### PR TITLE
fix(config): prune orphan model refs when provider is missing

### DIFF
--- a/packages/model-catalog-core/src/configured-model-refs.test.ts
+++ b/packages/model-catalog-core/src/configured-model-refs.test.ts
@@ -4,6 +4,8 @@ import {
   collectConfiguredModelRefs,
   collectConfiguredModelRefValues,
   listModelRefsFromConfigValue,
+  extractProviderFromModelRef,
+  pruneOrphanModelRefs,
 } from "./configured-model-refs.js";
 
 describe("configured model refs", () => {
@@ -114,5 +116,274 @@ describe("configured model refs", () => {
         },
       }),
     ).toEqual([]);
+  });
+});
+
+describe("pruneOrphanModelRefs", () => {
+  it("removes allowlist map entries for missing providers", () => {
+    const result = pruneOrphanModelRefs(
+      {
+        agents: {
+          defaults: {
+            models: {
+              "openai/gpt-5.5": {},
+              "ghostprovider/model-a": { alias: "ghost-a" },
+              "anthropic/claude-sonnet-4-6": {},
+            },
+          },
+        },
+      },
+      new Set(["openai", "anthropic"]),
+    );
+    expect(result.config).toEqual({
+      agents: {
+        defaults: {
+          models: {
+            "openai/gpt-5.5": {},
+            "anthropic/claude-sonnet-4-6": {},
+          },
+        },
+      },
+    });
+    expect(result.pruned).toEqual([
+      {
+        path: "agents.defaults.models.ghostprovider/model-a",
+        value: "ghostprovider/model-a",
+        reason: "missing-provider",
+      },
+    ]);
+  });
+
+  it("removes fallback array entries for missing providers", () => {
+    const result = pruneOrphanModelRefs(
+      {
+        agents: {
+          defaults: {
+            model: {
+              primary: "openai/gpt-5.5",
+              fallbacks: ["anthropic/claude-sonnet-4-6", "ghostprovider/foo", "openai/gpt-5.4"],
+            },
+          },
+        },
+      },
+      new Set(["openai", "anthropic"]),
+    );
+    expect(result.config).toEqual({
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-5.5",
+            fallbacks: ["anthropic/claude-sonnet-4-6", "openai/gpt-5.4"],
+          },
+        },
+      },
+    });
+    expect(result.pruned).toEqual([
+      {
+        path: "agents.defaults.model.fallbacks.1",
+        value: "ghostprovider/foo",
+        reason: "missing-provider",
+      },
+    ]);
+  });
+
+  it("rewrites primary refs using agents.defaults.model.primary as fallback", () => {
+    const result = pruneOrphanModelRefs(
+      {
+        agents: {
+          defaults: {
+            model: { primary: "openai/gpt-5.5" },
+          },
+          list: [{ id: "agent-a", model: { primary: "ghostprovider/model-x" } }],
+        },
+      },
+      new Set(["openai"]),
+    );
+    expect(result.config).toEqual({
+      agents: {
+        defaults: {
+          model: { primary: "openai/gpt-5.5" },
+        },
+        list: [{ id: "agent-a", model: { primary: "openai/gpt-5.5" } }],
+      },
+    });
+    expect(result.pruned).toEqual([
+      {
+        path: "agents.list.0.model.primary",
+        value: "ghostprovider/model-x",
+        reason: "rewritten",
+      },
+    ]);
+  });
+
+  it("rewrites primary refs to first provider when defaults.model.primary is also orphan", () => {
+    const result = pruneOrphanModelRefs(
+      {
+        agents: {
+          defaults: {
+            model: { primary: "ghostprovider/model-y" },
+          },
+          list: [{ id: "agent-a", model: { primary: "ghostprovider/model-x" } }],
+        },
+      },
+      new Set(["openai", "anthropic"]),
+    );
+    const config = result.config as any;
+    expect(config.agents.defaults.model.primary).toMatch(/^(openai|anthropic)\/default$/);
+    expect(config.agents.list[0].model.primary).toMatch(/^(openai|anthropic)\/default$/);
+    expect(result.pruned).toHaveLength(2);
+    expect(result.pruned.every((p) => p.reason === "rewritten")).toBe(true);
+  });
+
+  it("prunes from agents.list entries", () => {
+    const result = pruneOrphanModelRefs(
+      {
+        agents: {
+          defaults: {
+            model: "openai/gpt-5.5",
+          },
+          list: [
+            { id: "agent-a", model: { fallbacks: ["ghostprovider/a", "openai/gpt-5.5"] } },
+            { id: "agent-b", models: { "ghostprovider/b": {}, "openai/gpt-5.5": {} } },
+          ],
+        },
+      },
+      new Set(["openai"]),
+    );
+    expect(result.config).toEqual({
+      agents: {
+        defaults: {
+          model: "openai/gpt-5.5",
+        },
+        list: [
+          { id: "agent-a", model: { fallbacks: ["openai/gpt-5.5"] } },
+          { id: "agent-b", models: { "openai/gpt-5.5": {} } },
+        ],
+      },
+    });
+    expect(result.pruned).toHaveLength(2);
+  });
+
+  it("ignores refs without provider prefix", () => {
+    const result = pruneOrphanModelRefs(
+      {
+        agents: {
+          defaults: {
+            model: "gpt-5.5",
+            models: { "gpt-5.5": {} },
+          },
+        },
+      },
+      new Set(["openai"]),
+    );
+    expect(result.config).toEqual({
+      agents: {
+        defaults: {
+          model: "gpt-5.5",
+          models: { "gpt-5.5": {} },
+        },
+      },
+    });
+    expect(result.pruned).toEqual([]);
+  });
+
+  it("preserves models when provider exists", () => {
+    const result = pruneOrphanModelRefs(
+      {
+        agents: {
+          defaults: {
+            models: { "openai/gpt-5.5": {}, "anthropic/claude-sonnet-4-6": {} },
+          },
+        },
+      },
+      new Set(["openai", "anthropic"]),
+    );
+    expect(result.config).toEqual({
+      agents: {
+        defaults: {
+          models: { "openai/gpt-5.5": {}, "anthropic/claude-sonnet-4-6": {} },
+        },
+      },
+    });
+    expect(result.pruned).toEqual([]);
+  });
+
+  it("handles compaction.model and subagents.model rewriting", () => {
+    const result = pruneOrphanModelRefs(
+      {
+        agents: {
+          defaults: {
+            model: "openai/gpt-5.5",
+            compaction: { model: "ghostprovider/a", memoryFlush: { model: "ghostprovider/b" } },
+            subagents: { model: { primary: "ghostprovider/c", fallbacks: ["ghostprovider/d"] } },
+          },
+        },
+      },
+      new Set(["openai"]),
+    );
+    const config = result.config as any;
+    expect(config.agents.defaults.compaction.model).toBe("openai/gpt-5.5");
+    expect(config.agents.defaults.compaction.memoryFlush.model).toBe("openai/gpt-5.5");
+    expect(config.agents.defaults.subagents.model.primary).toBe("openai/gpt-5.5");
+    expect(config.agents.defaults.subagents.model.fallbacks).toEqual([]);
+    expect(result.pruned).toHaveLength(4);
+  });
+
+  it("prunes hooks.mappings and hooks.gmail model refs", () => {
+    const result = pruneOrphanModelRefs(
+      {
+        agents: { defaults: { model: "openai/gpt-5.5" } },
+        hooks: {
+          mappings: [{ model: "ghostprovider/hook-a" }],
+          gmail: { model: "ghostprovider/hook-b" },
+        },
+      },
+      new Set(["openai"]),
+    );
+    const config = result.config as any;
+    expect(config.hooks.mappings[0].model).toBe("openai/gpt-5.5");
+    expect(config.hooks.gmail.model).toBe("openai/gpt-5.5");
+    expect(result.pruned).toHaveLength(2);
+    expect(result.pruned.every((p) => p.reason === "rewritten")).toBe(true);
+  });
+
+  it("prunes messages.tts.summaryModel", () => {
+    const result = pruneOrphanModelRefs(
+      {
+        agents: { defaults: { model: "anthropic/claude-sonnet-4-6" } },
+        messages: { tts: { summaryModel: "ghostprovider/tts-model" } },
+      },
+      new Set(["anthropic"]),
+    );
+    const config = result.config as any;
+    expect(config.messages.tts.summaryModel).toBe("anthropic/claude-sonnet-4-6");
+    expect(result.pruned).toEqual([
+      {
+        path: "messages.tts.summaryModel",
+        value: "ghostprovider/tts-model",
+        reason: "rewritten",
+      },
+    ]);
+  });
+
+  it("prunes channels.modelByChannel and channels.discord.voice.model", () => {
+    const result = pruneOrphanModelRefs(
+      {
+        agents: { defaults: { model: "openai/gpt-5.5" } },
+        channels: {
+          modelByChannel: {
+            discord: { guild: "ghostprovider/discord-a" },
+            telegram: { chat: "openai/gpt-5.4" },
+          },
+          discord: { voice: { model: "ghostprovider/voice-model" } },
+        },
+      },
+      new Set(["openai"]),
+    );
+    const config = result.config as any;
+    expect(config.channels.modelByChannel.discord.guild).toBe("openai/gpt-5.5");
+    expect(config.channels.modelByChannel.telegram.chat).toBe("openai/gpt-5.4");
+    expect(config.channels.discord.voice.model).toBe("openai/gpt-5.5");
+    expect(result.pruned).toHaveLength(2);
   });
 });

--- a/packages/model-catalog-core/src/configured-model-refs.test.ts
+++ b/packages/model-catalog-core/src/configured-model-refs.test.ts
@@ -120,6 +120,21 @@ describe("configured model refs", () => {
 });
 
 describe("pruneOrphanModelRefs", () => {
+  const catalogOptions = (modelRefs: readonly string[], fallbackModelRef?: string) => {
+    const knownProviderIds = new Set<string>();
+    for (const modelRef of modelRefs) {
+      const provider = extractProviderFromModelRef(modelRef);
+      if (provider) {
+        knownProviderIds.add(provider);
+      }
+    }
+    return {
+      knownProviderIds,
+      knownModelRefs: new Set(modelRefs),
+      ...(fallbackModelRef ? { fallbackModelRef } : {}),
+    };
+  };
+
   it("removes allowlist map entries for missing providers", () => {
     const result = pruneOrphanModelRefs(
       {
@@ -133,7 +148,7 @@ describe("pruneOrphanModelRefs", () => {
           },
         },
       },
-      new Set(["openai", "anthropic"]),
+      catalogOptions(["openai/gpt-5.5", "anthropic/claude-sonnet-4-6"]),
     );
     expect(result.config).toEqual({
       agents: {
@@ -166,7 +181,7 @@ describe("pruneOrphanModelRefs", () => {
           },
         },
       },
-      new Set(["openai", "anthropic"]),
+      catalogOptions(["openai/gpt-5.5", "openai/gpt-5.4", "anthropic/claude-sonnet-4-6"]),
     );
     expect(result.config).toEqual({
       agents: {
@@ -197,7 +212,7 @@ describe("pruneOrphanModelRefs", () => {
           list: [{ id: "agent-a", model: { primary: "ghostprovider/model-x" } }],
         },
       },
-      new Set(["openai"]),
+      catalogOptions(["openai/gpt-5.5"]),
     );
     expect(result.config).toEqual({
       agents: {
@@ -211,12 +226,13 @@ describe("pruneOrphanModelRefs", () => {
       {
         path: "agents.list.0.model.primary",
         value: "ghostprovider/model-x",
-        reason: "rewritten",
+        reason: "missing-provider",
+        replacement: "openai/gpt-5.5",
       },
     ]);
   });
 
-  it("rewrites primary refs to first provider when defaults.model.primary is also orphan", () => {
+  it("rewrites primary refs to a concrete configured fallback when defaults.model.primary is also orphan", () => {
     const result = pruneOrphanModelRefs(
       {
         agents: {
@@ -226,13 +242,65 @@ describe("pruneOrphanModelRefs", () => {
           list: [{ id: "agent-a", model: { primary: "ghostprovider/model-x" } }],
         },
       },
-      new Set(["openai", "anthropic"]),
+      catalogOptions(
+        ["openai/gpt-5.5", "anthropic/claude-sonnet-4-6"],
+        "anthropic/claude-sonnet-4-6",
+      ),
     );
-    const config = result.config as any;
-    expect(config.agents.defaults.model.primary).toMatch(/^(openai|anthropic)\/default$/);
-    expect(config.agents.list[0].model.primary).toMatch(/^(openai|anthropic)\/default$/);
-    expect(result.pruned).toHaveLength(2);
-    expect(result.pruned.every((p) => p.reason === "rewritten")).toBe(true);
+    expect(result.config).toEqual({
+      agents: {
+        defaults: { model: { primary: "anthropic/claude-sonnet-4-6" } },
+        list: [{ id: "agent-a", model: { primary: "anthropic/claude-sonnet-4-6" } }],
+      },
+    });
+    expect(result.pruned).toEqual([
+      {
+        path: "agents.defaults.model.primary",
+        value: "ghostprovider/model-y",
+        reason: "missing-provider",
+        replacement: "anthropic/claude-sonnet-4-6",
+      },
+      {
+        path: "agents.list.0.model.primary",
+        value: "ghostprovider/model-x",
+        reason: "missing-provider",
+        replacement: "anthropic/claude-sonnet-4-6",
+      },
+    ]);
+  });
+
+  it("deletes stale scalar refs instead of inventing provider/default fallbacks", () => {
+    const result = pruneOrphanModelRefs(
+      {
+        agents: {
+          defaults: {
+            model: { primary: "ghostprovider/model-y" },
+          },
+          list: [{ id: "agent-a", model: "ghostprovider/model-x" }],
+        },
+      },
+      catalogOptions(["openai/gpt-5.5", "anthropic/claude-sonnet-4-6"]),
+    );
+    expect(result.config).toEqual({
+      agents: {
+        defaults: {
+          model: {},
+        },
+        list: [{ id: "agent-a" }],
+      },
+    });
+    expect(result.pruned).toEqual([
+      {
+        path: "agents.defaults.model.primary",
+        value: "ghostprovider/model-y",
+        reason: "missing-provider",
+      },
+      {
+        path: "agents.list.0.model",
+        value: "ghostprovider/model-x",
+        reason: "missing-provider",
+      },
+    ]);
   });
 
   it("prunes from agents.list entries", () => {
@@ -248,7 +316,7 @@ describe("pruneOrphanModelRefs", () => {
           ],
         },
       },
-      new Set(["openai"]),
+      catalogOptions(["openai/gpt-5.5"]),
     );
     expect(result.config).toEqual({
       agents: {
@@ -274,7 +342,7 @@ describe("pruneOrphanModelRefs", () => {
           },
         },
       },
-      new Set(["openai"]),
+      catalogOptions(["openai/gpt-5.5"]),
     );
     expect(result.config).toEqual({
       agents: {
@@ -296,7 +364,7 @@ describe("pruneOrphanModelRefs", () => {
           },
         },
       },
-      new Set(["openai", "anthropic"]),
+      catalogOptions(["openai/gpt-5.5", "anthropic/claude-sonnet-4-6"]),
     );
     expect(result.config).toEqual({
       agents: {
@@ -306,6 +374,60 @@ describe("pruneOrphanModelRefs", () => {
       },
     });
     expect(result.pruned).toEqual([]);
+  });
+
+  it("removes allowlist map entries for provider refs missing from the runtime catalog", () => {
+    const result = pruneOrphanModelRefs(
+      {
+        agents: {
+          defaults: {
+            models: { "openai/gpt-5.5": {}, "openai/retired-model": {} },
+          },
+        },
+      },
+      catalogOptions(["openai/gpt-5.5"]),
+    );
+    expect(result.config).toEqual({
+      agents: {
+        defaults: {
+          models: { "openai/gpt-5.5": {} },
+        },
+      },
+    });
+    expect(result.pruned).toEqual([
+      {
+        path: "agents.defaults.models.openai/retired-model",
+        value: "openai/retired-model",
+        reason: "missing-model",
+      },
+    ]);
+  });
+
+  it("preserves provider wildcard allowlist entries for known runtime catalog providers", () => {
+    const result = pruneOrphanModelRefs(
+      {
+        agents: {
+          defaults: {
+            models: { "openai/*": {}, "ghostprovider/*": {} },
+          },
+        },
+      },
+      catalogOptions(["openai/gpt-5.5"]),
+    );
+    expect(result.config).toEqual({
+      agents: {
+        defaults: {
+          models: { "openai/*": {} },
+        },
+      },
+    });
+    expect(result.pruned).toEqual([
+      {
+        path: "agents.defaults.models.ghostprovider/*",
+        value: "ghostprovider/*",
+        reason: "missing-provider",
+      },
+    ]);
   });
 
   it("handles compaction.model and subagents.model rewriting", () => {
@@ -319,14 +441,89 @@ describe("pruneOrphanModelRefs", () => {
           },
         },
       },
-      new Set(["openai"]),
+      catalogOptions(["openai/gpt-5.5"]),
     );
-    const config = result.config as any;
-    expect(config.agents.defaults.compaction.model).toBe("openai/gpt-5.5");
-    expect(config.agents.defaults.compaction.memoryFlush.model).toBe("openai/gpt-5.5");
-    expect(config.agents.defaults.subagents.model.primary).toBe("openai/gpt-5.5");
-    expect(config.agents.defaults.subagents.model.fallbacks).toEqual([]);
-    expect(result.pruned).toHaveLength(4);
+    expect(result.config).toEqual({
+      agents: {
+        defaults: {
+          model: "openai/gpt-5.5",
+          compaction: {
+            model: "openai/gpt-5.5",
+            memoryFlush: { model: "openai/gpt-5.5" },
+          },
+          subagents: { model: { primary: "openai/gpt-5.5", fallbacks: [] } },
+        },
+      },
+    });
+    expect(result.pruned).toEqual([
+      {
+        path: "agents.defaults.subagents.model.primary",
+        value: "ghostprovider/c",
+        reason: "missing-provider",
+        replacement: "openai/gpt-5.5",
+      },
+      {
+        path: "agents.defaults.subagents.model.fallbacks.0",
+        value: "ghostprovider/d",
+        reason: "missing-provider",
+      },
+      {
+        path: "agents.defaults.compaction.model",
+        value: "ghostprovider/a",
+        reason: "missing-provider",
+        replacement: "openai/gpt-5.5",
+      },
+      {
+        path: "agents.defaults.compaction.memoryFlush.model",
+        value: "ghostprovider/b",
+        reason: "missing-provider",
+        replacement: "openai/gpt-5.5",
+      },
+    ]);
+  });
+
+  it("prunes keyed agent entries and media model selectors", () => {
+    const result = pruneOrphanModelRefs(
+      {
+        agents: {
+          defaults: { model: "openai/gpt-5.5" },
+          entries: {
+            ops: {
+              utilityModel: "ghostprovider/utility",
+              mediaModels: {
+                image: "ghostprovider/image",
+                video: {
+                  primary: "openai/gpt-5.5",
+                  fallbacks: ["ghostprovider/video"],
+                },
+              },
+            },
+          },
+          list: [{ id: "shadowed", model: "ghostprovider/legacy" }],
+        },
+      },
+      catalogOptions(["openai/gpt-5.5"]),
+    );
+    expect(result.config).toEqual({
+      agents: {
+        defaults: { model: "openai/gpt-5.5" },
+        entries: {
+          ops: {
+            utilityModel: "openai/gpt-5.5",
+            mediaModels: {
+              image: "openai/gpt-5.5",
+              video: { primary: "openai/gpt-5.5", fallbacks: [] },
+            },
+          },
+        },
+        list: [{ id: "shadowed", model: "ghostprovider/legacy" }],
+      },
+    });
+    expect(result.pruned.map((ref) => ref.path)).toEqual([
+      "agents.entries.ops.utilityModel",
+      "agents.entries.ops.mediaModels.image",
+      "agents.entries.ops.mediaModels.video.fallbacks.0",
+    ]);
   });
 
   it("prunes hooks.mappings and hooks.gmail model refs", () => {
@@ -338,30 +535,36 @@ describe("pruneOrphanModelRefs", () => {
           gmail: { model: "ghostprovider/hook-b" },
         },
       },
-      new Set(["openai"]),
+      catalogOptions(["openai/gpt-5.5"]),
     );
-    const config = result.config as any;
-    expect(config.hooks.mappings[0].model).toBe("openai/gpt-5.5");
-    expect(config.hooks.gmail.model).toBe("openai/gpt-5.5");
-    expect(result.pruned).toHaveLength(2);
-    expect(result.pruned.every((p) => p.reason === "rewritten")).toBe(true);
+    expect(result.config).toEqual({
+      agents: { defaults: { model: "openai/gpt-5.5" } },
+      hooks: {
+        mappings: [{ model: "openai/gpt-5.5" }],
+        gmail: { model: "openai/gpt-5.5" },
+      },
+    });
+    expect(result.pruned.every((p) => p.replacement === "openai/gpt-5.5")).toBe(true);
   });
 
-  it("prunes messages.tts.summaryModel", () => {
+  it("prunes tts.summaryModel", () => {
     const result = pruneOrphanModelRefs(
       {
         agents: { defaults: { model: "anthropic/claude-sonnet-4-6" } },
-        messages: { tts: { summaryModel: "ghostprovider/tts-model" } },
+        tts: { summaryModel: "ghostprovider/tts-model" },
       },
-      new Set(["anthropic"]),
+      catalogOptions(["anthropic/claude-sonnet-4-6"]),
     );
-    const config = result.config as any;
-    expect(config.messages.tts.summaryModel).toBe("anthropic/claude-sonnet-4-6");
+    expect(result.config).toEqual({
+      agents: { defaults: { model: "anthropic/claude-sonnet-4-6" } },
+      tts: { summaryModel: "anthropic/claude-sonnet-4-6" },
+    });
     expect(result.pruned).toEqual([
       {
-        path: "messages.tts.summaryModel",
+        path: "tts.summaryModel",
         value: "ghostprovider/tts-model",
-        reason: "rewritten",
+        reason: "missing-provider",
+        replacement: "anthropic/claude-sonnet-4-6",
       },
     ]);
   });
@@ -378,12 +581,18 @@ describe("pruneOrphanModelRefs", () => {
           discord: { voice: { model: "ghostprovider/voice-model" } },
         },
       },
-      new Set(["openai"]),
+      catalogOptions(["openai/gpt-5.5", "openai/gpt-5.4"]),
     );
-    const config = result.config as any;
-    expect(config.channels.modelByChannel.discord.guild).toBe("openai/gpt-5.5");
-    expect(config.channels.modelByChannel.telegram.chat).toBe("openai/gpt-5.4");
-    expect(config.channels.discord.voice.model).toBe("openai/gpt-5.5");
+    expect(result.config).toEqual({
+      agents: { defaults: { model: "openai/gpt-5.5" } },
+      channels: {
+        modelByChannel: {
+          discord: { guild: "openai/gpt-5.5" },
+          telegram: { chat: "openai/gpt-5.4" },
+        },
+        discord: { voice: { model: "openai/gpt-5.5" } },
+      },
+    });
     expect(result.pruned).toHaveLength(2);
   });
 });

--- a/packages/model-catalog-core/src/configured-model-refs.ts
+++ b/packages/model-catalog-core/src/configured-model-refs.ts
@@ -1,5 +1,6 @@
+import { normalizeLowercaseStringOrEmpty, normalizeProviderId } from "./provider-id.js";
+
 // Collects configured model references from OpenClaw config-shaped objects.
-import { normalizeProviderId } from "./provider-id.js";
 
 /** Narrow unknown values to plain records. */
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -152,6 +153,7 @@ export function collectConfiguredModelRefValues(
 ): string[] {
   return collectConfiguredModelRefs(config, options).map((ref) => ref.value);
 }
+
 /** Extract a normalized provider id from a provider/model reference. */
 export function extractProviderFromModelRef(value: string): string | null {
   const trimmed = value.trim();
@@ -166,24 +168,113 @@ export function extractProviderFromModelRef(value: string): string | null {
 export type PrunedModelRef = {
   path: string;
   value: string;
-  reason: "missing-provider" | "rewritten";
+  reason: "missing-provider" | "missing-model";
+  replacement?: string;
 };
 
-/** Prune orphan model refs whose provider is not in the known provider set. Returns immutable config clone. */
+export type PruneOrphanModelRefsOptions = {
+  knownProviderIds: ReadonlySet<string>;
+  knownModelRefs?: ReadonlySet<string>;
+  fallbackModelRef?: string | null;
+};
+
+const DELETE_FIELD = Symbol("delete-field");
+
+function extractModelFromModelRef(value: string): string | null {
+  const trimmed = value.trim();
+  const slash = trimmed.indexOf("/");
+  if (slash <= 0 || slash === trimmed.length - 1) {
+    return null;
+  }
+  return trimmed.slice(slash + 1).trim() || null;
+}
+
+function normalizeModelRefForLookup(value: string): string | null {
+  const provider = extractProviderFromModelRef(value);
+  const model = extractModelFromModelRef(value);
+  if (provider === null || model === null) {
+    return null;
+  }
+  return `${provider}/${normalizeLowercaseStringOrEmpty(model)}`;
+}
+
+function normalizeKnownProviderIds(providerIds: ReadonlySet<string>): Set<string> {
+  const normalized = new Set<string>();
+  for (const providerId of providerIds) {
+    const provider = normalizeProviderId(providerId);
+    if (provider) {
+      normalized.add(provider);
+    }
+  }
+  return normalized;
+}
+
+function normalizeKnownModelRefs(modelRefs: ReadonlySet<string> | undefined): Set<string> | null {
+  if (!modelRefs) {
+    return null;
+  }
+  const normalized = new Set<string>();
+  for (const modelRef of modelRefs) {
+    const lookup = normalizeModelRefForLookup(modelRef);
+    if (lookup) {
+      normalized.add(lookup);
+    }
+  }
+  return normalized.size > 0 ? normalized : null;
+}
+
+/** Prune configured model refs that are absent from the runtime provider/model catalog. */
 export function pruneOrphanModelRefs(
   config: unknown,
-  knownProviderIds: ReadonlySet<string>,
+  options: PruneOrphanModelRefsOptions,
 ): { config: unknown; pruned: PrunedModelRef[] } {
   const pruned: PrunedModelRef[] = [];
+  const knownProviderIds = normalizeKnownProviderIds(options.knownProviderIds);
+  const knownModelRefs = normalizeKnownModelRefs(options.knownModelRefs);
   const root = isRecord(config) ? { ...config } : {};
-  const agents = isRecord(root.agents) ? { ...root.agents } : {};
+  const sourceAgents = isRecord(root.agents) ? root.agents : null;
+  const agents: Record<string, unknown> = sourceAgents ? { ...sourceAgents } : {};
 
-  const shouldPruneRef = (ref: string): boolean => {
+  const refIssue = (ref: string): PrunedModelRef["reason"] | null => {
     const provider = extractProviderFromModelRef(ref);
-    return provider !== null && !knownProviderIds.has(provider);
+    if (provider === null) {
+      return null;
+    }
+    if (!knownProviderIds.has(provider)) {
+      return "missing-provider";
+    }
+    const model = extractModelFromModelRef(ref);
+    if (model === "*") {
+      return null;
+    }
+    const lookup = normalizeModelRefForLookup(ref);
+    if (knownModelRefs && lookup && !knownModelRefs.has(lookup)) {
+      return "missing-model";
+    }
+    return null;
   };
 
-  // Compute fallback primary ref: agents.defaults.model.primary or first available provider
+  const validRef = (ref: string): string | null => {
+    const trimmed = ref.trim();
+    return trimmed && refIssue(trimmed) === null ? trimmed : null;
+  };
+
+  const configuredFallbackModelRef =
+    typeof options.fallbackModelRef === "string" ? validRef(options.fallbackModelRef) : null;
+
+  const recordPruned = (path: string, value: string, replacement?: string): void => {
+    const reason = refIssue(value);
+    if (!reason) {
+      return;
+    }
+    pruned.push({
+      path,
+      value,
+      reason,
+      ...(replacement ? { replacement } : {}),
+    });
+  };
+
   const computeFallbackPrimary = (): string | null => {
     const defaultsModel = isRecord(agents.defaults) ? agents.defaults.model : undefined;
     const defaultPrimary =
@@ -192,20 +283,22 @@ export function pruneOrphanModelRefs(
         : isRecord(defaultsModel)
           ? defaultsModel.primary
           : undefined;
-    if (typeof defaultPrimary === "string" && !shouldPruneRef(defaultPrimary)) {
-      return defaultPrimary;
+    if (typeof defaultPrimary === "string") {
+      const validDefault = validRef(defaultPrimary);
+      if (validDefault) {
+        return validDefault;
+      }
     }
-    const firstProvider = Array.from(knownProviderIds)[0];
-    return firstProvider ? `${firstProvider}/default` : null;
+    return configuredFallbackModelRef;
   };
 
   const fallbackPrimary = computeFallbackPrimary();
 
   const pruneModelConfig = (path: string, value: unknown): unknown => {
     if (typeof value === "string") {
-      if (shouldPruneRef(value)) {
-        pruned.push({ path, value, reason: "missing-provider" });
-        return fallbackPrimary ?? value;
+      if (refIssue(value)) {
+        recordPruned(path, value, fallbackPrimary ?? undefined);
+        return fallbackPrimary ?? DELETE_FIELD;
       }
       return value;
     }
@@ -213,18 +306,18 @@ export function pruneOrphanModelRefs(
       return value;
     }
     const next: Record<string, unknown> = { ...value };
-    if (typeof value.primary === "string" && shouldPruneRef(value.primary)) {
-      pruned.push({ path: `${path}.primary`, value: value.primary, reason: "rewritten" });
-      next.primary = fallbackPrimary ?? value.primary;
+    if (typeof value.primary === "string" && refIssue(value.primary)) {
+      recordPruned(`${path}.primary`, value.primary, fallbackPrimary ?? undefined);
+      if (fallbackPrimary) {
+        next.primary = fallbackPrimary;
+      } else {
+        delete next.primary;
+      }
     }
     if (Array.isArray(value.fallbacks)) {
       next.fallbacks = value.fallbacks.filter((entry, index) => {
-        if (typeof entry === "string" && shouldPruneRef(entry)) {
-          pruned.push({
-            path: `${path}.fallbacks.${index}`,
-            value: entry,
-            reason: "missing-provider",
-          });
+        if (typeof entry === "string" && refIssue(entry)) {
+          recordPruned(`${path}.fallbacks.${index}`, entry);
           return false;
         }
         return true;
@@ -240,69 +333,100 @@ export function pruneOrphanModelRefs(
     const next: Record<string, unknown> = { ...agent };
     for (const key of AGENT_MODEL_CONFIG_KEYS) {
       if (agent[key] !== undefined) {
-        next[key] = pruneModelConfig(`${path}.${key}`, agent[key]);
+        const prunedValue = pruneModelConfig(`${path}.${key}`, agent[key]);
+        if (prunedValue === DELETE_FIELD) {
+          delete next[key];
+        } else {
+          next[key] = prunedValue;
+        }
       }
     }
+    if (isRecord(agent.mediaModels)) {
+      const mediaModels: Record<string, unknown> = { ...agent.mediaModels };
+      for (const capability of ["image", "video", "music"] as const) {
+        if (agent.mediaModels[capability] === undefined) {
+          continue;
+        }
+        const prunedValue = pruneModelConfig(
+          `${path}.mediaModels.${capability}`,
+          agent.mediaModels[capability],
+        );
+        if (prunedValue === DELETE_FIELD) {
+          delete mediaModels[capability];
+        } else {
+          mediaModels[capability] = prunedValue;
+        }
+      }
+      next.mediaModels = mediaModels;
+    }
     if (isRecord(agent.heartbeat) && typeof agent.heartbeat.model === "string") {
-      if (shouldPruneRef(agent.heartbeat.model)) {
-        pruned.push({
-          path: `${path}.heartbeat.model`,
-          value: agent.heartbeat.model,
-          reason: "rewritten",
-        });
-        const heartbeat: Record<string, unknown> = {
-          ...agent.heartbeat,
-          model: fallbackPrimary ?? agent.heartbeat.model,
-        };
+      if (refIssue(agent.heartbeat.model)) {
+        recordPruned(
+          `${path}.heartbeat.model`,
+          agent.heartbeat.model,
+          fallbackPrimary ?? undefined,
+        );
+        const heartbeat: Record<string, unknown> = { ...agent.heartbeat };
+        if (fallbackPrimary) {
+          heartbeat.model = fallbackPrimary;
+        } else {
+          delete heartbeat.model;
+        }
         next.heartbeat = heartbeat;
       }
     }
-    if (agent.subagents !== undefined) {
-      const subagents = isRecord(agent.subagents) ? agent.subagents : {};
-      next.subagents = { ...subagents };
-      if (isRecord(next.subagents)) {
-        next.subagents.model = pruneModelConfig(`${path}.subagents.model`, subagents.model);
+    if (isRecord(agent.subagents)) {
+      const subagents: Record<string, unknown> = { ...agent.subagents };
+      const prunedValue = pruneModelConfig(`${path}.subagents.model`, agent.subagents.model);
+      if (prunedValue === DELETE_FIELD) {
+        delete subagents.model;
+      } else {
+        subagents.model = prunedValue;
       }
+      next.subagents = subagents;
     }
     if (isRecord(agent.compaction)) {
       const compaction: Record<string, unknown> = { ...agent.compaction };
       next.compaction = compaction;
-      if (typeof agent.compaction.model === "string" && shouldPruneRef(agent.compaction.model)) {
-        pruned.push({
-          path: `${path}.compaction.model`,
-          value: agent.compaction.model,
-          reason: "rewritten",
-        });
-        compaction.model = fallbackPrimary ?? agent.compaction.model;
+      if (typeof agent.compaction.model === "string" && refIssue(agent.compaction.model)) {
+        recordPruned(
+          `${path}.compaction.model`,
+          agent.compaction.model,
+          fallbackPrimary ?? undefined,
+        );
+        if (fallbackPrimary) {
+          compaction.model = fallbackPrimary;
+        } else {
+          delete compaction.model;
+        }
       }
       if (
         isRecord(agent.compaction.memoryFlush) &&
         typeof agent.compaction.memoryFlush.model === "string"
       ) {
-        if (shouldPruneRef(agent.compaction.memoryFlush.model)) {
-          pruned.push({
-            path: `${path}.compaction.memoryFlush.model`,
-            value: agent.compaction.memoryFlush.model,
-            reason: "rewritten",
-          });
-          compaction.memoryFlush = {
-            ...agent.compaction.memoryFlush,
-            model: fallbackPrimary ?? agent.compaction.memoryFlush.model,
-          };
+        if (refIssue(agent.compaction.memoryFlush.model)) {
+          recordPruned(
+            `${path}.compaction.memoryFlush.model`,
+            agent.compaction.memoryFlush.model,
+            fallbackPrimary ?? undefined,
+          );
+          const memoryFlush: Record<string, unknown> = { ...agent.compaction.memoryFlush };
+          if (fallbackPrimary) {
+            memoryFlush.model = fallbackPrimary;
+          } else {
+            delete memoryFlush.model;
+          }
+          compaction.memoryFlush = memoryFlush;
         }
       }
     }
     if (isRecord(agent.models)) {
       const nextModels: Record<string, unknown> = {};
       for (const [modelRef, entry] of Object.entries(agent.models)) {
-        if (!shouldPruneRef(modelRef)) {
+        if (!refIssue(modelRef)) {
           nextModels[modelRef] = entry;
         } else {
-          pruned.push({
-            path: `${path}.models.${modelRef}`,
-            value: modelRef,
-            reason: "missing-provider",
-          });
+          recordPruned(`${path}.models.${modelRef}`, modelRef);
         }
       }
       next.models = nextModels;
@@ -311,58 +435,69 @@ export function pruneOrphanModelRefs(
   };
 
   agents.defaults = pruneFromAgent("agents.defaults", agents.defaults);
-  if (Array.isArray(agents.list)) {
+  if (isRecord(agents.entries)) {
+    const entries: Record<string, unknown> = {};
+    for (const [agentId, entry] of Object.entries(agents.entries)) {
+      entries[agentId] = pruneFromAgent(`agents.entries.${agentId}`, entry);
+    }
+    agents.entries = entries;
+  } else if (Array.isArray(agents.list)) {
     agents.list = agents.list.map((entry, index) => pruneFromAgent(`agents.list.${index}`, entry));
   }
 
-  root.agents = agents;
+  if (sourceAgents) {
+    root.agents = agents;
+  }
 
   // Prune hooks
   if (isRecord(root.hooks)) {
     const hooks: Record<string, unknown> = { ...root.hooks };
     if (Array.isArray(hooks.mappings)) {
       hooks.mappings = hooks.mappings.map((mapping, index) => {
-        if (
-          isRecord(mapping) &&
-          typeof mapping.model === "string" &&
-          shouldPruneRef(mapping.model)
-        ) {
-          pruned.push({
-            path: `hooks.mappings.${index}.model`,
-            value: mapping.model,
-            reason: "rewritten",
-          });
-          return { ...mapping, model: fallbackPrimary ?? mapping.model };
+        if (isRecord(mapping) && typeof mapping.model === "string" && refIssue(mapping.model)) {
+          recordPruned(
+            `hooks.mappings.${index}.model`,
+            mapping.model,
+            fallbackPrimary ?? undefined,
+          );
+          const nextMapping = { ...mapping };
+          if (fallbackPrimary) {
+            nextMapping.model = fallbackPrimary;
+          } else {
+            delete nextMapping.model;
+          }
+          return nextMapping;
         }
         return mapping;
       });
     }
     if (isRecord(hooks.gmail) && typeof hooks.gmail.model === "string") {
-      if (shouldPruneRef(hooks.gmail.model)) {
-        pruned.push({ path: "hooks.gmail.model", value: hooks.gmail.model, reason: "rewritten" });
-        hooks.gmail = { ...hooks.gmail, model: fallbackPrimary ?? hooks.gmail.model };
+      if (refIssue(hooks.gmail.model)) {
+        recordPruned("hooks.gmail.model", hooks.gmail.model, fallbackPrimary ?? undefined);
+        const gmail = { ...hooks.gmail };
+        if (fallbackPrimary) {
+          gmail.model = fallbackPrimary;
+        } else {
+          delete gmail.model;
+        }
+        hooks.gmail = gmail;
       }
     }
     root.hooks = hooks;
   }
 
-  // Prune messages
-  if (isRecord(root.messages)) {
-    const messages: Record<string, unknown> = { ...root.messages };
-    if (isRecord(messages.tts) && typeof messages.tts.summaryModel === "string") {
-      if (shouldPruneRef(messages.tts.summaryModel)) {
-        pruned.push({
-          path: "messages.tts.summaryModel",
-          value: messages.tts.summaryModel,
-          reason: "rewritten",
-        });
-        messages.tts = {
-          ...messages.tts,
-          summaryModel: fallbackPrimary ?? messages.tts.summaryModel,
-        };
+  // Prune TTS summary model.
+  if (isRecord(root.tts) && typeof root.tts.summaryModel === "string") {
+    if (refIssue(root.tts.summaryModel)) {
+      recordPruned("tts.summaryModel", root.tts.summaryModel, fallbackPrimary ?? undefined);
+      const tts = { ...root.tts };
+      if (fallbackPrimary) {
+        tts.summaryModel = fallbackPrimary;
+      } else {
+        delete tts.summaryModel;
       }
+      root.tts = tts;
     }
-    root.messages = messages;
   }
 
   // Prune channels
@@ -377,13 +512,15 @@ export function pruneOrphanModelRefs(
         }
         const nextChannelMap: Record<string, unknown> = {};
         for (const [targetId, modelRef] of Object.entries(channelMap)) {
-          if (typeof modelRef === "string" && shouldPruneRef(modelRef)) {
-            pruned.push({
-              path: `channels.modelByChannel.${channelId}.${targetId}`,
-              value: modelRef,
-              reason: "rewritten",
-            });
-            nextChannelMap[targetId] = fallbackPrimary ?? modelRef;
+          if (typeof modelRef === "string" && refIssue(modelRef)) {
+            recordPruned(
+              `channels.modelByChannel.${channelId}.${targetId}`,
+              modelRef,
+              fallbackPrimary ?? undefined,
+            );
+            if (fallbackPrimary) {
+              nextChannelMap[targetId] = fallbackPrimary;
+            }
           } else {
             nextChannelMap[targetId] = modelRef;
           }
@@ -397,18 +534,21 @@ export function pruneOrphanModelRefs(
       isRecord(channels.discord.voice) &&
       typeof channels.discord.voice.model === "string"
     ) {
-      if (shouldPruneRef(channels.discord.voice.model)) {
-        pruned.push({
-          path: "channels.discord.voice.model",
-          value: channels.discord.voice.model,
-          reason: "rewritten",
-        });
+      if (refIssue(channels.discord.voice.model)) {
+        recordPruned(
+          "channels.discord.voice.model",
+          channels.discord.voice.model,
+          fallbackPrimary ?? undefined,
+        );
+        const voice = { ...channels.discord.voice };
+        if (fallbackPrimary) {
+          voice.model = fallbackPrimary;
+        } else {
+          delete voice.model;
+        }
         channels.discord = {
           ...channels.discord,
-          voice: {
-            ...channels.discord.voice,
-            model: fallbackPrimary ?? channels.discord.voice.model,
-          },
+          voice,
         };
       }
     }

--- a/packages/model-catalog-core/src/configured-model-refs.ts
+++ b/packages/model-catalog-core/src/configured-model-refs.ts
@@ -1,4 +1,5 @@
 // Collects configured model references from OpenClaw config-shaped objects.
+import { normalizeProviderId } from "./provider-id.js";
 
 /** Narrow unknown values to plain records. */
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -150,4 +151,269 @@ export function collectConfiguredModelRefValues(
   options?: { includeChannelModelOverrides?: boolean },
 ): string[] {
   return collectConfiguredModelRefs(config, options).map((ref) => ref.value);
+}
+/** Extract a normalized provider id from a provider/model reference. */
+export function extractProviderFromModelRef(value: string): string | null {
+  const trimmed = value.trim();
+  const slash = trimmed.indexOf("/");
+  if (slash <= 0) {
+    return null;
+  }
+  return normalizeProviderId(trimmed.slice(0, slash));
+}
+
+/** One pruned model reference plus its config path and prune reason. */
+export type PrunedModelRef = {
+  path: string;
+  value: string;
+  reason: "missing-provider" | "rewritten";
+};
+
+/** Prune orphan model refs whose provider is not in the known provider set. Returns immutable config clone. */
+export function pruneOrphanModelRefs(
+  config: unknown,
+  knownProviderIds: ReadonlySet<string>,
+): { config: unknown; pruned: PrunedModelRef[] } {
+  const pruned: PrunedModelRef[] = [];
+  const root = isRecord(config) ? { ...config } : {};
+  const agents = isRecord(root.agents) ? { ...root.agents } : {};
+
+  const shouldPruneRef = (ref: string): boolean => {
+    const provider = extractProviderFromModelRef(ref);
+    return provider !== null && !knownProviderIds.has(provider);
+  };
+
+  // Compute fallback primary ref: agents.defaults.model.primary or first available provider
+  const computeFallbackPrimary = (): string | null => {
+    const defaultsModel = isRecord(agents.defaults) ? agents.defaults.model : undefined;
+    const defaultPrimary =
+      typeof defaultsModel === "string"
+        ? defaultsModel
+        : isRecord(defaultsModel)
+          ? defaultsModel.primary
+          : undefined;
+    if (typeof defaultPrimary === "string" && !shouldPruneRef(defaultPrimary)) {
+      return defaultPrimary;
+    }
+    const firstProvider = Array.from(knownProviderIds)[0];
+    return firstProvider ? `${firstProvider}/default` : null;
+  };
+
+  const fallbackPrimary = computeFallbackPrimary();
+
+  const pruneModelConfig = (path: string, value: unknown): unknown => {
+    if (typeof value === "string") {
+      if (shouldPruneRef(value)) {
+        pruned.push({ path, value, reason: "missing-provider" });
+        return fallbackPrimary ?? value;
+      }
+      return value;
+    }
+    if (!isRecord(value)) {
+      return value;
+    }
+    const next: Record<string, unknown> = { ...value };
+    if (typeof value.primary === "string" && shouldPruneRef(value.primary)) {
+      pruned.push({ path: `${path}.primary`, value: value.primary, reason: "rewritten" });
+      next.primary = fallbackPrimary ?? value.primary;
+    }
+    if (Array.isArray(value.fallbacks)) {
+      next.fallbacks = value.fallbacks.filter((entry, index) => {
+        if (typeof entry === "string" && shouldPruneRef(entry)) {
+          pruned.push({
+            path: `${path}.fallbacks.${index}`,
+            value: entry,
+            reason: "missing-provider",
+          });
+          return false;
+        }
+        return true;
+      });
+    }
+    return next;
+  };
+
+  const pruneFromAgent = (path: string, agent: unknown): unknown => {
+    if (!isRecord(agent)) {
+      return agent;
+    }
+    const next: Record<string, unknown> = { ...agent };
+    for (const key of AGENT_MODEL_CONFIG_KEYS) {
+      if (agent[key] !== undefined) {
+        next[key] = pruneModelConfig(`${path}.${key}`, agent[key]);
+      }
+    }
+    if (isRecord(agent.heartbeat) && typeof agent.heartbeat.model === "string") {
+      if (shouldPruneRef(agent.heartbeat.model)) {
+        pruned.push({
+          path: `${path}.heartbeat.model`,
+          value: agent.heartbeat.model,
+          reason: "rewritten",
+        });
+        const heartbeat: Record<string, unknown> = {
+          ...agent.heartbeat,
+          model: fallbackPrimary ?? agent.heartbeat.model,
+        };
+        next.heartbeat = heartbeat;
+      }
+    }
+    if (agent.subagents !== undefined) {
+      const subagents = isRecord(agent.subagents) ? agent.subagents : {};
+      next.subagents = { ...subagents };
+      if (isRecord(next.subagents)) {
+        next.subagents.model = pruneModelConfig(`${path}.subagents.model`, subagents.model);
+      }
+    }
+    if (isRecord(agent.compaction)) {
+      const compaction: Record<string, unknown> = { ...agent.compaction };
+      next.compaction = compaction;
+      if (typeof agent.compaction.model === "string" && shouldPruneRef(agent.compaction.model)) {
+        pruned.push({
+          path: `${path}.compaction.model`,
+          value: agent.compaction.model,
+          reason: "rewritten",
+        });
+        compaction.model = fallbackPrimary ?? agent.compaction.model;
+      }
+      if (
+        isRecord(agent.compaction.memoryFlush) &&
+        typeof agent.compaction.memoryFlush.model === "string"
+      ) {
+        if (shouldPruneRef(agent.compaction.memoryFlush.model)) {
+          pruned.push({
+            path: `${path}.compaction.memoryFlush.model`,
+            value: agent.compaction.memoryFlush.model,
+            reason: "rewritten",
+          });
+          compaction.memoryFlush = {
+            ...agent.compaction.memoryFlush,
+            model: fallbackPrimary ?? agent.compaction.memoryFlush.model,
+          };
+        }
+      }
+    }
+    if (isRecord(agent.models)) {
+      const nextModels: Record<string, unknown> = {};
+      for (const [modelRef, entry] of Object.entries(agent.models)) {
+        if (!shouldPruneRef(modelRef)) {
+          nextModels[modelRef] = entry;
+        } else {
+          pruned.push({
+            path: `${path}.models.${modelRef}`,
+            value: modelRef,
+            reason: "missing-provider",
+          });
+        }
+      }
+      next.models = nextModels;
+    }
+    return next;
+  };
+
+  agents.defaults = pruneFromAgent("agents.defaults", agents.defaults);
+  if (Array.isArray(agents.list)) {
+    agents.list = agents.list.map((entry, index) => pruneFromAgent(`agents.list.${index}`, entry));
+  }
+
+  root.agents = agents;
+
+  // Prune hooks
+  if (isRecord(root.hooks)) {
+    const hooks: Record<string, unknown> = { ...root.hooks };
+    if (Array.isArray(hooks.mappings)) {
+      hooks.mappings = hooks.mappings.map((mapping, index) => {
+        if (
+          isRecord(mapping) &&
+          typeof mapping.model === "string" &&
+          shouldPruneRef(mapping.model)
+        ) {
+          pruned.push({
+            path: `hooks.mappings.${index}.model`,
+            value: mapping.model,
+            reason: "rewritten",
+          });
+          return { ...mapping, model: fallbackPrimary ?? mapping.model };
+        }
+        return mapping;
+      });
+    }
+    if (isRecord(hooks.gmail) && typeof hooks.gmail.model === "string") {
+      if (shouldPruneRef(hooks.gmail.model)) {
+        pruned.push({ path: "hooks.gmail.model", value: hooks.gmail.model, reason: "rewritten" });
+        hooks.gmail = { ...hooks.gmail, model: fallbackPrimary ?? hooks.gmail.model };
+      }
+    }
+    root.hooks = hooks;
+  }
+
+  // Prune messages
+  if (isRecord(root.messages)) {
+    const messages: Record<string, unknown> = { ...root.messages };
+    if (isRecord(messages.tts) && typeof messages.tts.summaryModel === "string") {
+      if (shouldPruneRef(messages.tts.summaryModel)) {
+        pruned.push({
+          path: "messages.tts.summaryModel",
+          value: messages.tts.summaryModel,
+          reason: "rewritten",
+        });
+        messages.tts = {
+          ...messages.tts,
+          summaryModel: fallbackPrimary ?? messages.tts.summaryModel,
+        };
+      }
+    }
+    root.messages = messages;
+  }
+
+  // Prune channels
+  if (isRecord(root.channels)) {
+    const channels: Record<string, unknown> = { ...root.channels };
+    if (isRecord(channels.modelByChannel)) {
+      const modelByChannel: Record<string, unknown> = {};
+      for (const [channelId, channelMap] of Object.entries(channels.modelByChannel)) {
+        if (!isRecord(channelMap)) {
+          modelByChannel[channelId] = channelMap;
+          continue;
+        }
+        const nextChannelMap: Record<string, unknown> = {};
+        for (const [targetId, modelRef] of Object.entries(channelMap)) {
+          if (typeof modelRef === "string" && shouldPruneRef(modelRef)) {
+            pruned.push({
+              path: `channels.modelByChannel.${channelId}.${targetId}`,
+              value: modelRef,
+              reason: "rewritten",
+            });
+            nextChannelMap[targetId] = fallbackPrimary ?? modelRef;
+          } else {
+            nextChannelMap[targetId] = modelRef;
+          }
+        }
+        modelByChannel[channelId] = nextChannelMap;
+      }
+      channels.modelByChannel = modelByChannel;
+    }
+    if (
+      isRecord(channels.discord) &&
+      isRecord(channels.discord.voice) &&
+      typeof channels.discord.voice.model === "string"
+    ) {
+      if (shouldPruneRef(channels.discord.voice.model)) {
+        pruned.push({
+          path: "channels.discord.voice.model",
+          value: channels.discord.voice.model,
+          reason: "rewritten",
+        });
+        channels.discord = {
+          ...channels.discord,
+          voice: {
+            ...channels.discord.voice,
+            model: fallbackPrimary ?? channels.discord.voice.model,
+          },
+        };
+      }
+    }
+    root.channels = channels;
+  }
+
+  return { config: root, pruned };
 }

--- a/src/flows/doctor-core-checks.orphan-model-refs.test.ts
+++ b/src/flows/doctor-core-checks.orphan-model-refs.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ModelCatalogEntry } from "../agents/model-catalog.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { orphanModelRefsCheck } from "./doctor-core-checks.js";
+
+const mocks = vi.hoisted(() => ({
+  loadModelCatalog: vi.fn(async (): Promise<ModelCatalogEntry[]> => []),
+}));
+
+vi.mock("../agents/prepared-model-catalog.js", () => ({
+  loadPreparedModelCatalog: mocks.loadModelCatalog,
+}));
+
+const runtime = { log() {}, error() {}, exit() {} };
+
+describe("core/doctor/orphan-model-refs", () => {
+  beforeEach(() => {
+    mocks.loadModelCatalog.mockReset();
+    mocks.loadModelCatalog.mockResolvedValue([]);
+  });
+
+  it("does not report runtime catalog model refs just because models.providers is empty", async () => {
+    mocks.loadModelCatalog.mockResolvedValueOnce([
+      { provider: "openai", id: "gpt-5.5", name: "GPT-5.5" },
+    ]);
+    const cfg: OpenClawConfig = {
+      agents: { defaults: { model: "openai/gpt-5.5" } },
+    };
+
+    await expect(orphanModelRefsCheck.detect({ mode: "doctor", runtime, cfg })).resolves.toEqual(
+      [],
+    );
+  });
+
+  it("reports and repairs stale model refs through the runtime catalog", async () => {
+    mocks.loadModelCatalog.mockResolvedValue([
+      { provider: "openai", id: "gpt-5.5", name: "GPT-5.5" },
+    ]);
+    if (typeof orphanModelRefsCheck.repair !== "function") {
+      throw new Error("expected orphan model ref check repair");
+    }
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-5.5",
+            fallbacks: ["ghostprovider/foo", "openai/gpt-5.5"],
+          },
+          models: {
+            "ghostprovider/foo": {},
+            "openai/gpt-5.5": {},
+          },
+        },
+      },
+    };
+
+    const findings = await orphanModelRefsCheck.detect({ mode: "doctor", runtime, cfg });
+    expect(findings).toEqual([
+      expect.objectContaining({
+        checkId: "core/doctor/orphan-model-refs",
+        severity: "warning",
+        path: "agents.defaults.model.fallbacks.0",
+      }),
+      expect.objectContaining({
+        checkId: "core/doctor/orphan-model-refs",
+        severity: "warning",
+        path: "agents.defaults.models.ghostprovider/foo",
+      }),
+    ]);
+
+    await expect(orphanModelRefsCheck.repair({ mode: "fix", runtime, cfg })).resolves.toEqual(
+      expect.objectContaining({
+        config: {
+          agents: {
+            defaults: {
+              model: {
+                primary: "openai/gpt-5.5",
+                fallbacks: ["openai/gpt-5.5"],
+              },
+              models: { "openai/gpt-5.5": {} },
+            },
+          },
+        },
+        changes: [
+          "Removed stale model reference ghostprovider/foo at agents.defaults.model.fallbacks.0.",
+          "Removed stale model reference ghostprovider/foo at agents.defaults.models.ghostprovider/foo.",
+        ],
+      }),
+    );
+  });
+});

--- a/src/flows/doctor-core-checks.test.ts
+++ b/src/flows/doctor-core-checks.test.ts
@@ -3,6 +3,7 @@ import { promises as fs } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ModelCatalogEntry } from "../agents/model-catalog.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { withSecureTestNodeCommand } from "../secrets/test-node-command.test-support.js";
 import type { SkillStatusEntry } from "../skills/discovery/status.js";
@@ -16,7 +17,7 @@ import { clearHealthChecksForTest } from "./health-check-registry.js";
 import type { HealthCheck, HealthFinding, HealthRepairEffect } from "./health-checks.js";
 
 const mocks = vi.hoisted(() => ({
-  loadModelCatalog: vi.fn(async () => []),
+  loadModelCatalog: vi.fn(async (): Promise<ModelCatalogEntry[]> => []),
   detectExtraGatewayServiceIssues: vi.fn(async (): Promise<readonly { label: string }[]> => []),
   extraGatewayServiceToHealthFinding: vi.fn(
     (service: { label: string }): HealthFinding => ({

--- a/src/flows/doctor-core-checks.ts
+++ b/src/flows/doctor-core-checks.ts
@@ -1049,6 +1049,47 @@ function createSkillsReadinessCheck(
   };
 }
 
+const orphanModelRefsCheck: HealthCheck = {
+  id: "core/doctor/orphan-model-refs",
+  kind: "core",
+  description: "Agent model references point to providers that exist in models.providers.",
+  source: "doctor",
+  async detect(ctx) {
+    const { pruneOrphanModelRefs } =
+      await import("@openclaw/model-catalog-core/configured-model-refs");
+    const knownProviders = new Set(Object.keys(ctx.cfg.models?.providers ?? {}));
+    const { pruned } = pruneOrphanModelRefs(ctx.cfg, knownProviders);
+    return pruned.map(
+      (ref): HealthFinding => ({
+        checkId: "core/doctor/orphan-model-refs",
+        severity: "warning",
+        message: `Model reference "${ref.value}" points to provider "${ref.value.split("/")[0]}" which is not in models.providers.`,
+        path: ref.path,
+        fixHint: "Run `openclaw doctor --fix` to remove orphan model references from config.",
+      }),
+    );
+  },
+  async repair(ctx) {
+    const { pruneOrphanModelRefs } =
+      await import("@openclaw/model-catalog-core/configured-model-refs");
+    const knownProviders = new Set(Object.keys(ctx.cfg.models?.providers ?? {}));
+    const { config: nextConfig, pruned } = pruneOrphanModelRefs(ctx.cfg, knownProviders);
+    if (pruned.length === 0) {
+      return { changes: [] };
+    }
+    return {
+      config: nextConfig as OpenClawConfig,
+      changes: pruned.map((ref) => `Removed orphan model reference ${ref.value} at ${ref.path}.`),
+      effects: pruned.map((ref) => ({
+        kind: "config" as const,
+        action: ctx.dryRun === true ? "would-remove-orphan-model-ref" : "remove-orphan-model-ref",
+        target: ref.path,
+        dryRunSafe: true,
+      })),
+    };
+  },
+};
+
 function unavailableSkillToFinding(skill: SkillStatusEntry): HealthFinding {
   return {
     checkId: "core/doctor/skills-readiness",
@@ -1323,6 +1364,7 @@ export function createCoreHealthChecks(
     ...createConvertedWorkflowChecks(deps),
     commandOwnerCheck,
     createSkillsReadinessCheck(deps),
+    orphanModelRefsCheck,
     browserClawdProfileResidueCheck,
     finalConfigValidationCheck,
   ];

--- a/src/flows/doctor-core-checks.ts
+++ b/src/flows/doctor-core-checks.ts
@@ -1049,46 +1049,89 @@ function createSkillsReadinessCheck(
   };
 }
 
-const orphanModelRefsCheck: HealthCheck = {
+async function buildOrphanModelRefPruneOptions(ctx: HealthCheckContext) {
+  const { pruneOrphanModelRefs } =
+    await import("@openclaw/model-catalog-core/configured-model-refs");
+  const { loadPreparedModelCatalog } = await import("../agents/prepared-model-catalog.js");
+  const { modelKey } = await import("../agents/model-ref-shared.js");
+  const catalog = await loadPreparedModelCatalog({ config: ctx.cfg, readOnly: true });
+  if (catalog.length === 0) {
+    return { pruneOrphanModelRefs, options: null };
+  }
+  const knownProviderIds = new Set<string>();
+  const knownModelRefs = new Set<string>();
+  for (const entry of catalog) {
+    knownProviderIds.add(entry.provider);
+    knownModelRefs.add(modelKey(entry.provider, entry.id));
+  }
+  const fallbackEntry =
+    catalog.find((entry) => !entry.input || entry.input.includes("text")) ?? catalog[0];
+  return {
+    pruneOrphanModelRefs,
+    options: {
+      knownProviderIds,
+      knownModelRefs,
+      fallbackModelRef: fallbackEntry ? modelKey(fallbackEntry.provider, fallbackEntry.id) : null,
+    },
+  };
+}
+
+export const orphanModelRefsCheck = {
   id: "core/doctor/orphan-model-refs",
   kind: "core",
-  description: "Agent model references point to providers that exist in models.providers.",
+  description: "Configured model references point to runtime catalog provider/model rows.",
   source: "doctor",
   async detect(ctx) {
-    const { pruneOrphanModelRefs } =
-      await import("@openclaw/model-catalog-core/configured-model-refs");
-    const knownProviders = new Set(Object.keys(ctx.cfg.models?.providers ?? {}));
-    const { pruned } = pruneOrphanModelRefs(ctx.cfg, knownProviders);
+    const { pruneOrphanModelRefs, options } = await buildOrphanModelRefPruneOptions(ctx);
+    if (!options) {
+      return [];
+    }
+    const { pruned } = pruneOrphanModelRefs(ctx.cfg, options);
     return pruned.map(
       (ref): HealthFinding => ({
         checkId: "core/doctor/orphan-model-refs",
         severity: "warning",
-        message: `Model reference "${ref.value}" points to provider "${ref.value.split("/")[0]}" which is not in models.providers.`,
+        message:
+          ref.reason === "missing-provider"
+            ? `Model reference "${ref.value}" points to provider "${ref.value.split("/")[0]}" which is not in the runtime model catalog.`
+            : `Model reference "${ref.value}" is not present in the runtime model catalog.`,
         path: ref.path,
-        fixHint: "Run `openclaw doctor --fix` to remove orphan model references from config.",
+        fixHint: "Run `openclaw doctor --fix` to remove or rewrite stale model references.",
       }),
     );
   },
   async repair(ctx) {
-    const { pruneOrphanModelRefs } =
-      await import("@openclaw/model-catalog-core/configured-model-refs");
-    const knownProviders = new Set(Object.keys(ctx.cfg.models?.providers ?? {}));
-    const { config: nextConfig, pruned } = pruneOrphanModelRefs(ctx.cfg, knownProviders);
+    const { pruneOrphanModelRefs, options } = await buildOrphanModelRefPruneOptions(ctx);
+    if (!options) {
+      return { changes: [] };
+    }
+    const { config: nextConfig, pruned } = pruneOrphanModelRefs(ctx.cfg, options);
     if (pruned.length === 0) {
       return { changes: [] };
     }
     return {
       config: nextConfig as OpenClawConfig,
-      changes: pruned.map((ref) => `Removed orphan model reference ${ref.value} at ${ref.path}.`),
+      changes: pruned.map((ref) =>
+        ref.replacement
+          ? `Replaced stale model reference ${ref.value} at ${ref.path} with ${ref.replacement}.`
+          : `Removed stale model reference ${ref.value} at ${ref.path}.`,
+      ),
       effects: pruned.map((ref) => ({
         kind: "config" as const,
-        action: ctx.dryRun === true ? "would-remove-orphan-model-ref" : "remove-orphan-model-ref",
+        action:
+          ctx.dryRun === true
+            ? ref.replacement
+              ? "would-replace-stale-model-ref"
+              : "would-remove-stale-model-ref"
+            : ref.replacement
+              ? "replace-stale-model-ref"
+              : "remove-stale-model-ref",
         target: ref.path,
         dryRunSafe: true,
       })),
     };
   },
-};
+} satisfies HealthCheck;
 
 function unavailableSkillToFinding(skill: SkillStatusEntry): HealthFinding {
   return {

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -2796,6 +2796,37 @@ describe("doctor health contributions", () => {
     );
   });
 
+  it("runs orphan model refs through structured health during normal doctor runs", async () => {
+    const contribution = requireDoctorContribution("doctor:orphan-model-refs");
+    const ctx = {
+      cfg: {},
+      cfgForPersistence: {},
+      configResult: { cfg: {} },
+      sourceConfigValid: true,
+      prompter: buildDoctorPrompter(false),
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      options: {},
+      configPath: "/tmp/fake-openclaw.json",
+    } as unknown as Parameters<(typeof contribution)["run"]>[0];
+
+    await contribution.run(ctx);
+
+    expect(contribution.healthCheckIds).toEqual(["core/doctor/orphan-model-refs"]);
+    expect(contribution.healthChecks).toHaveLength(1);
+    expect(mocks.runDoctorHealthRepairs).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cfg: {},
+        cwd: "/tmp/openclaw-workspace",
+        configPath: "/tmp/fake-openclaw.json",
+        dryRun: true,
+      }),
+      {
+        checks: contribution.healthChecks,
+        dryRun: true,
+      },
+    );
+  });
+
   it("requires explicit health check ids for multi-check contributions", () => {
     expect(() =>
       createDoctorHealthContribution({

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -1,6 +1,7 @@
 // Doctor health contributions preserve the ordered interactive doctor flow while
 // exposing the same checks to structured lint and repair commands.
 import fs from "node:fs";
+import { orphanModelRefsCheck } from "./doctor-core-checks.js";
 import { hasActiveGatewayExecCredential } from "./doctor-gateway-exec-credential.js";
 import {
   runCoreContributionHealth,
@@ -377,6 +378,11 @@ function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
       runAuthProfileHealth,
       runGatewayAuthHealth,
       runLegacyStateHealth,
+    }),
+    createDoctorHealthContribution({
+      id: "doctor:orphan-model-refs",
+      label: "Orphan model refs",
+      healthChecks: orphanModelRefsCheck,
     }),
     ...resolveFinalDoctorHealthContributions({
       runSystemdLingerHealth,


### PR DESCRIPTION
## What Problem This Solves

When external tools like `cc-switch` remove a provider from `models.providers`, they leave orphan model references in:
- `agents.defaults.models` allowlist (map keys like `mycodex/gpt-5.5`)
- `agents.defaults.model.fallbacks` and per-agent fallback arrays
- `hooks.mappings[].model`, `hooks.gmail.model`
- `messages.tts.summaryModel`
- `channels.modelByChannel` and `channels.discord.voice.model`

This causes "ghost entries" that point to non-existent providers, visible in Gateway UI and model selection.

## Why This Change Was Made

`cc-switch` is an external Rust binary that directly edits `openclaw.json` without openclaw's mutation helpers. Per CLAUDE.md design:

> "Runtime reads canonical config only. If a config change invalidates existing files, add a matching \`openclaw doctor --fix\` migration."

The robust fix is **defensive self-healing in openclaw** via doctor check, not patching external tools.

## Solution

### Core cleanup function (`pruneOrphanModelRefs`)
- **Deletes** orphan entries from `agents.defaults.models` allowlist map
- **Filters** orphan entries from `fallbacks` arrays
- **Rewrites** orphan primary refs to `agents.defaults.model.primary`
- **Fallbacks** to first available provider if defaults is also orphan
- **Extends** to hooks, messages, and channels config

### Doctor integration
- `openclaw doctor` detects and lists all orphan refs
- `openclaw doctor --fix` automatically repairs config
- Follows existing doctor check patterns (detect + repair)

## User Impact

After this change:
- Users who remove providers via `cc-switch` or manual editing won't see ghost model refs
- `openclaw doctor` warns about orphaned refs with fix hints
- `openclaw doctor --fix` cleans up:
  - ✅ Allowlist map entries (deleted)
  - ✅ Fallback array entries (filtered out)
  - ✅ Primary refs (rewritten to valid provider)
  - ✅ Hooks/messages/channels refs (rewritten)

No runtime performance impact — repair is explicit via doctor command.

## Evidence

- **Unit tests**: 15 passed covering all cleanup scenarios
- **Type check**: `pnpm build:plugin-sdk:dts` passed
- **Test coverage**:
  - Allowlist pruning
  - Fallback filtering
  - Primary ref rewriting with fallback logic
  - agents.list handling
  - hooks/messages/channels cleaning

Fixes the "幽灵条目" (ghost entries) issue.