### PR TITLE
perf(plugin-sdk): summarize migration items in one pass

### DIFF
--- a/src/plugin-sdk/migration-runtime.test.ts
+++ b/src/plugin-sdk/migration-runtime.test.ts
@@ -10,7 +10,7 @@ import {
   withCachedMigrationConfigRuntime,
   writeMigrationReport,
 } from "./migration-runtime.js";
-import { createMigrationItem } from "./migration.js";
+import { createMigrationItem, summarizeMigrationItems } from "./migration.js";
 import type { MigrationProviderContext } from "./plugin-entry.js";
 
 async function writeFile(filePath: string, contents: string): Promise<void> {
@@ -154,6 +154,60 @@ describe("copyMigrationFileItem", () => {
     expect(firstBackup).not.toBe(secondBackup);
     await expect(fs.readFile(firstBackup, "utf8")).resolves.toBe("old one");
     await expect(fs.readFile(secondBackup, "utf8")).resolves.toBe("old two");
+  });
+});
+
+describe("summarizeMigrationItems", () => {
+  it("counts statuses and sensitive items in one summary", () => {
+    const items = [
+      createMigrationItem({
+        id: "planned",
+        kind: "file",
+        action: "copy",
+        source: "/source/planned",
+        target: "/target/planned",
+      }),
+      createMigrationItem({
+        id: "migrated-sensitive",
+        kind: "config",
+        action: "merge",
+        status: "migrated",
+        sensitive: true,
+      }),
+      createMigrationItem({
+        id: "skipped",
+        kind: "file",
+        action: "copy",
+        source: "/source/skipped",
+        target: "/target/skipped",
+        status: "skipped",
+      }),
+      createMigrationItem({
+        id: "conflict-sensitive",
+        kind: "config",
+        action: "merge",
+        status: "conflict",
+        sensitive: true,
+      }),
+      createMigrationItem({
+        id: "error",
+        kind: "file",
+        action: "copy",
+        source: "/source/error",
+        target: "/target/error",
+        status: "error",
+      }),
+    ];
+
+    expect(summarizeMigrationItems(items)).toEqual({
+      total: 5,
+      planned: 1,
+      migrated: 1,
+      skipped: 1,
+      conflicts: 1,
+      errors: 1,
+      sensitive: 2,
+    });
   });
 });
 

--- a/src/plugin-sdk/migration.ts
+++ b/src/plugin-sdk/migration.ts
@@ -51,15 +51,34 @@ export function markMigrationItemSkipped(item: MigrationItem, reason: string): M
 
 /** Counts migration item statuses for provider plans, apply results, and CLI reports. */
 export function summarizeMigrationItems(items: readonly MigrationItem[]): MigrationSummary {
-  return {
+  const summary: MigrationSummary = {
     total: items.length,
-    planned: items.filter((item) => item.status === "planned").length,
-    migrated: items.filter((item) => item.status === "migrated").length,
-    skipped: items.filter((item) => item.status === "skipped").length,
-    conflicts: items.filter((item) => item.status === "conflict").length,
-    errors: items.filter((item) => item.status === "error").length,
-    sensitive: items.filter((item) => item.sensitive).length,
+    planned: 0,
+    migrated: 0,
+    skipped: 0,
+    conflicts: 0,
+    errors: 0,
+    sensitive: 0,
   };
+
+  for (const item of items) {
+    if (item.status === "planned") {
+      summary.planned += 1;
+    } else if (item.status === "migrated") {
+      summary.migrated += 1;
+    } else if (item.status === "skipped") {
+      summary.skipped += 1;
+    } else if (item.status === "conflict") {
+      summary.conflicts += 1;
+    } else if (item.status === "error") {
+      summary.errors += 1;
+    }
+    if (item.sensitive) {
+      summary.sensitive += 1;
+    }
+  }
+
+  return summary;
 }
 
 const REDACTED_MIGRATION_VALUE = "[redacted]";


### PR DESCRIPTION
## What Problem This Solves

The current implementation uses multiple `.filter(...).length` passes (or similar repeated iterations) to compute summary counts. Each pass walks the full collection, so producing N counts costs N full traversals.

## Why This Change Was Made

`perf(plugin-sdk): summarize migration items in one pass` collects all the relevant counts in a single pass over the data. The aggregated shape stays identical, so callers and tests are unchanged; only the internal iteration count drops from O(N×M) to O(N).

## User Impact

No user-visible output change. Status/report generation avoids redundant aggregation work, which matters where the underlying collections are large (long migration plans, large QA suite reports, sizeable memory-wiki imports, etc.).

## Evidence

- Local: `node scripts/test-projects.mjs` on the touched test file(s)
- Touched files: src/plugin-sdk/migration-runtime.test.ts,src/plugin-sdk/migration.ts
- Branch: codex/high-quality-algo-16
