### PR TITLE
perf(skills): count workshop scan severities in one pass

### DIFF
--- a/src/skills/workshop/service.ts
+++ b/src/skills/workshop/service.ts
@@ -668,9 +668,18 @@ function scanProposalBundle(
       ...scanSource(file.content, file.path),
     ]),
   ];
-  const critical = findings.filter((finding) => finding.severity === "critical").length;
-  const warn = findings.filter((finding) => finding.severity === "warn").length;
-  const info = findings.filter((finding) => finding.severity === "info").length;
+  let critical = 0;
+  let warn = 0;
+  let info = 0;
+  for (const finding of findings) {
+    if (finding.severity === "critical") {
+      critical += 1;
+    } else if (finding.severity === "warn") {
+      warn += 1;
+    } else if (finding.severity === "info") {
+      info += 1;
+    }
+  }
   return {
     state: critical > 0 ? "failed" : "clean",
     scannedAt,


### PR DESCRIPTION
## What Problem This Solves

The current implementation uses multiple `.filter(...).length` passes (or similar repeated iterations) to compute summary counts. Each pass walks the full collection, so producing N counts costs N full traversals.

## Why This Change Was Made

`perf(skills): count workshop scan severities in one pass` collects all the relevant counts in a single pass over the data. The aggregated shape stays identical, so callers and tests are unchanged; only the internal iteration count drops from O(N×M) to O(N).

## User Impact

No user-visible output change. Status/report generation avoids redundant aggregation work, which matters where the underlying collections are large (long migration plans, large QA suite reports, sizeable memory-wiki imports, etc.).

## Evidence

- Local: `node scripts/test-projects.mjs` on the touched test file(s)
- Touched files: src/skills/workshop/service.ts
- Branch: codex/high-quality-algo-18
