### PR TITLE
perf(memory-wiki): count page kinds in one pass

### DIFF
--- a/extensions/memory-wiki/src/compile.ts
+++ b/extensions/memory-wiki/src/compile.ts
@@ -404,13 +404,17 @@ async function readPageSummaries(rootDir: string): Promise<WikiPageSummary[]> {
 }
 
 function buildPageCounts(pages: WikiPageSummary[]): Record<WikiPageKind, number> {
-  return {
-    entity: pages.filter((page) => page.kind === "entity").length,
-    concept: pages.filter((page) => page.kind === "concept").length,
-    source: pages.filter((page) => page.kind === "source").length,
-    synthesis: pages.filter((page) => page.kind === "synthesis").length,
-    report: pages.filter((page) => page.kind === "report").length,
+  const counts: Record<WikiPageKind, number> = {
+    entity: 0,
+    concept: 0,
+    source: 0,
+    synthesis: 0,
+    report: 0,
   };
+  for (const page of pages) {
+    counts[page.kind] += 1;
+  }
+  return counts;
 }
 
 function formatPageLink(


### PR DESCRIPTION
## What Problem This Solves

The current implementation uses multiple `.filter(...).length` passes (or similar repeated iterations) to compute summary counts. Each pass walks the full collection, so producing N counts costs N full traversals.

## Why This Change Was Made

`perf(memory-wiki): count page kinds in one pass` collects all the relevant counts in a single pass over the data. The aggregated shape stays identical, so callers and tests are unchanged; only the internal iteration count drops from O(N×M) to O(N).

## User Impact

No user-visible output change. Status/report generation avoids redundant aggregation work, which matters where the underlying collections are large (long migration plans, large QA suite reports, sizeable memory-wiki imports, etc.).

## Evidence

- Local: `node scripts/test-projects.mjs` on the touched test file(s)
- Touched files: extensions/memory-wiki/src/compile.ts
- Branch: codex/high-quality-algo-21
