### PR TITLE
perf(memory-wiki): count import run states in one pass

### DIFF
--- a/extensions/memory-wiki/src/import-runs.ts
+++ b/extensions/memory-wiki/src/import-runs.ts
@@ -111,11 +111,20 @@ export async function listMemoryWikiImportRuns(
     .map((record) => normalizeImportRunSummary(record))
     .filter((entry): entry is MemoryWikiImportRunSummary => entry !== null)
     .toSorted((left, right) => right.appliedAt.localeCompare(left.appliedAt));
+  let activeRuns = 0;
+  let rolledBackRuns = 0;
+  for (const run of runs) {
+    if (run.status === "applied") {
+      activeRuns += 1;
+    } else if (run.status === "rolled_back") {
+      rolledBackRuns += 1;
+    }
+  }
 
   return {
     runs: runs.slice(0, limit),
     totalRuns: runs.length,
-    activeRuns: runs.filter((entry) => entry.status === "applied").length,
-    rolledBackRuns: runs.filter((entry) => entry.status === "rolled_back").length,
+    activeRuns,
+    rolledBackRuns,
   };
 }


### PR DESCRIPTION
## What Problem This Solves

The current implementation uses multiple `.filter(...).length` passes (or similar repeated iterations) to compute summary counts. Each pass walks the full collection, so producing N counts costs N full traversals.

## Why This Change Was Made

`perf(memory-wiki): count import run states in one pass` collects all the relevant counts in a single pass over the data. The aggregated shape stays identical, so callers and tests are unchanged; only the internal iteration count drops from O(N×M) to O(N).

## User Impact

No user-visible output change. Status/report generation avoids redundant aggregation work, which matters where the underlying collections are large (long migration plans, large QA suite reports, sizeable memory-wiki imports, etc.).

## Evidence

- Local: `node scripts/test-projects.mjs` on the touched test file(s)
- Touched files: extensions/memory-wiki/src/import-runs.ts
- Branch: codex/high-quality-algo-22
