### PR TITLE
perf(memory-wiki): count imported source results in one pass

### DIFF
--- a/extensions/memory-wiki/src/bridge.ts
+++ b/extensions/memory-wiki/src/bridge.ts
@@ -16,7 +16,11 @@ import {
   renderWikiMarkdown,
   slugifyWikiSegment,
 } from "./markdown.js";
-import { writeImportedSourcePage } from "./source-page-shared.js";
+import {
+  countImportedSourceWriteResults,
+  writeImportedSourcePage,
+  type ImportedSourceWriteResult,
+} from "./source-page-shared.js";
 import { resolveArtifactKey } from "./source-path-shared.js";
 import {
   assertMemoryWikiSourceSyncStateCapacity,
@@ -238,7 +242,7 @@ export async function syncMemoryWikiBridgeSources(params: {
   }
 
   const publicArtifacts = await listActiveMemoryPublicArtifacts({ cfg: params.appConfig });
-  const results: Array<{ pagePath: string; changed: boolean; created: boolean }> = [];
+  const results: ImportedSourceWriteResult[] = [];
   const activeKeys = new Set<string>();
   const artifacts = await collectBridgeArtifacts(
     params.config.bridge,
@@ -284,9 +288,7 @@ export async function syncMemoryWikiBridgeSources(params: {
       })
     : 0;
   await writeMemoryWikiSourceSyncState(params.config.vault.path, state);
-  const importedCount = results.filter((result) => result.changed && result.created).length;
-  const updatedCount = results.filter((result) => result.changed && !result.created).length;
-  const skippedCount = results.filter((result) => !result.changed).length;
+  const { importedCount, updatedCount, skippedCount } = countImportedSourceWriteResults(results);
   const pagePaths = results
     .map((result) => result.pagePath)
     .toSorted((left, right) => left.localeCompare(right));

--- a/extensions/memory-wiki/src/source-page-shared.ts
+++ b/extensions/memory-wiki/src/source-page-shared.ts
@@ -12,6 +12,32 @@ import { writeGuardedVaultPage } from "./vault-page-write.js";
 
 type ImportedSourceState = Parameters<typeof shouldSkipImportedSourceWrite>[0]["state"];
 
+export type ImportedSourceWriteResult = {
+  pagePath: string;
+  changed: boolean;
+  created: boolean;
+};
+
+export function countImportedSourceWriteResults(results: ImportedSourceWriteResult[]): {
+  importedCount: number;
+  updatedCount: number;
+  skippedCount: number;
+} {
+  let importedCount = 0;
+  let updatedCount = 0;
+  let skippedCount = 0;
+  for (const result of results) {
+    if (!result.changed) {
+      skippedCount += 1;
+    } else if (result.created) {
+      importedCount += 1;
+    } else {
+      updatedCount += 1;
+    }
+  }
+  return { importedCount, updatedCount, skippedCount };
+}
+
 export async function writeImportedSourcePage(params: {
   vaultRoot: string;
   syncKey: string;
@@ -23,7 +49,7 @@ export async function writeImportedSourcePage(params: {
   group: MemoryWikiImportedSourceGroup;
   state: ImportedSourceState;
   buildRendered: (raw: string, updatedAt: string) => string;
-}): Promise<{ pagePath: string; changed: boolean; created: boolean }> {
+}): Promise<ImportedSourceWriteResult> {
   const vault = await fsRoot(params.vaultRoot);
   const pageStat = await vault.stat(params.pagePath).catch((error: unknown) => {
     if (

--- a/extensions/memory-wiki/src/unsafe-local.ts
+++ b/extensions/memory-wiki/src/unsafe-local.ts
@@ -12,7 +12,7 @@ import {
   renderWikiMarkdown,
   slugifyWikiSegment,
 } from "./markdown.js";
-import { writeImportedSourcePage } from "./source-page-shared.js";
+import { countImportedSourceWriteResults, writeImportedSourcePage } from "./source-page-shared.js";
 import { resolveArtifactKey } from "./source-path-shared.js";
 import {
   assertMemoryWikiSourceSyncStateCapacity,
@@ -243,9 +243,7 @@ export async function syncMemoryWikiUnsafeLocalSources(
     state,
   });
   await writeMemoryWikiSourceSyncState(config.vault.path, state);
-  const importedCount = results.filter((result) => result.changed && result.created).length;
-  const updatedCount = results.filter((result) => result.changed && !result.created).length;
-  const skippedCount = results.filter((result) => !result.changed).length;
+  const { importedCount, updatedCount, skippedCount } = countImportedSourceWriteResults(results);
   const pagePaths = results
     .map((result) => result.pagePath)
     .toSorted((left, right) => left.localeCompare(right));


### PR DESCRIPTION
## What Problem This Solves

The current implementation uses multiple `.filter(...).length` passes (or similar repeated iterations) to compute summary counts. Each pass walks the full collection, so producing N counts costs N full traversals.

## Why This Change Was Made

`perf(memory-wiki): count imported source results in one pass` collects all the relevant counts in a single pass over the data. The aggregated shape stays identical, so callers and tests are unchanged; only the internal iteration count drops from O(N×M) to O(N).

## User Impact

No user-visible output change. Status/report generation avoids redundant aggregation work, which matters where the underlying collections are large (long migration plans, large QA suite reports, sizeable memory-wiki imports, etc.).

## Evidence

- Local: `node scripts/test-projects.mjs` on the touched test file(s)
- Touched files: extensions/memory-wiki/src/bridge.ts,extensions/memory-wiki/src/source-page-shared.ts,extensions/memory-wiki/src/unsafe-local.ts
- Branch: codex/high-quality-algo-42
