### PR TITLE
perf(qa-matrix): count contract statuses in one pass

### DIFF
--- a/extensions/qa-matrix/src/runners/contract/runtime.ts
+++ b/extensions/qa-matrix/src/runners/contract/runtime.ts
@@ -18,6 +18,7 @@ import {
   type QaReportCheck,
 } from "openclaw/plugin-sdk/qa-runtime";
 import { normalizeQaProviderMode, type QaProviderModeInput } from "../../run-config.js";
+import { createLiveTransportQaRunId } from "../../shared/live-transport-artifacts.js";
 import { buildMatrixQaObservedEventsArtifact } from "../../substrate/artifacts.js";
 import { provisionMatrixQaRoom, type MatrixQaProvisionResult } from "../../substrate/client.js";
 import {
@@ -29,7 +30,6 @@ import {
 } from "../../substrate/config.js";
 import type { MatrixQaObservedEvent } from "../../substrate/events.js";
 import { startMatrixQaHarness } from "../../substrate/harness.runtime.js";
-import { createLiveTransportQaRunId } from "../../shared/live-transport-artifacts.js";
 import { resolveMatrixQaModels, type ResolvedMatrixQaModels } from "./model-selection.js";
 import type { MatrixQaSyncStreams } from "./scenario-runtime-shared.js";
 import {
@@ -325,10 +325,16 @@ async function cleanupMatrixQaResource(params: {
 }
 
 function countMatrixQaStatuses(entries: Array<{ status: "fail" | "pass" | "skip" }>) {
-  return {
-    failed: entries.filter((entry) => entry.status === "fail").length,
-    passed: entries.filter((entry) => entry.status === "pass").length,
-  };
+  let failed = 0;
+  let passed = 0;
+  for (const entry of entries) {
+    if (entry.status === "fail") {
+      failed += 1;
+    } else if (entry.status === "pass") {
+      passed += 1;
+    }
+  }
+  return { failed, passed };
 }
 
 function formatMatrixQaScenarioDetails(params: { details: string; configSummary?: string }) {


### PR DESCRIPTION
## What Problem This Solves

The current implementation uses multiple `.filter(...).length` passes (or similar repeated iterations) to compute summary counts. Each pass walks the full collection, so producing N counts costs N full traversals.

## Why This Change Was Made

`perf(qa-matrix): count contract statuses in one pass` collects all the relevant counts in a single pass over the data. The aggregated shape stays identical, so callers and tests are unchanged; only the internal iteration count drops from O(N×M) to O(N).

## User Impact

No user-visible output change. Status/report generation avoids redundant aggregation work, which matters where the underlying collections are large (long migration plans, large QA suite reports, sizeable memory-wiki imports, etc.).

## Evidence

- Local: `node scripts/test-projects.mjs` on the touched test file(s)
- Touched files: extensions/qa-matrix/src/runners/contract/runtime.ts
- Branch: codex/high-quality-algo-43
