### PR TITLE
perf(qa-lab): count confidence lane statuses in one pass

### DIFF
--- a/extensions/qa-lab/src/confidence-report.ts
+++ b/extensions/qa-lab/src/confidence-report.ts
@@ -389,8 +389,7 @@ function evaluateQaSuiteSummary(payload: unknown): QaConfidenceLaneEvaluation {
   const failedCount = readCount(counts?.failed);
   const explicitSkippedCount = readCount(counts?.skipped);
   if (totalCount !== undefined) {
-    const providedCountSum =
-      (passedCount ?? 0) + (failedCount ?? 0) + (explicitSkippedCount ?? 0);
+    const providedCountSum = (passedCount ?? 0) + (failedCount ?? 0) + (explicitSkippedCount ?? 0);
     if (totalCount < providedCountSum) {
       return {
         passed: false,
@@ -878,14 +877,29 @@ function applySkipBackfillState(
 }
 
 function countLaneResults(lanes: readonly QaConfidenceLaneResult[]): QaConfidenceReport["counts"] {
-  return {
+  const counts: QaConfidenceReport["counts"] = {
     total: lanes.length,
-    passed: lanes.filter((lane) => lane.status === "pass").length,
-    failed: lanes.filter((lane) => lane.status === "fail").length,
-    blocked: lanes.filter((lane) => lane.status === "blocked").length,
-    missing: lanes.filter((lane) => lane.status === "missing").length,
-    unknown: lanes.filter((lane) => lane.status === "unknown" || lane.status === "missing").length,
+    passed: 0,
+    failed: 0,
+    blocked: 0,
+    missing: 0,
+    unknown: 0,
   };
+  for (const lane of lanes) {
+    if (lane.status === "pass") {
+      counts.passed += 1;
+    } else if (lane.status === "fail") {
+      counts.failed += 1;
+    } else if (lane.status === "blocked") {
+      counts.blocked += 1;
+    } else if (lane.status === "missing") {
+      counts.missing += 1;
+      counts.unknown += 1;
+    } else if (lane.status === "unknown") {
+      counts.unknown += 1;
+    }
+  }
+  return counts;
 }
 
 function failuresForLaneResults(lanes: readonly QaConfidenceLaneResult[]): string[] {


### PR DESCRIPTION
## What Problem This Solves

The current implementation uses multiple `.filter(...).length` passes (or similar repeated iterations) to compute summary counts. Each pass walks the full collection, so producing N counts costs N full traversals.

## Why This Change Was Made

`perf(qa-lab): count confidence lane statuses in one pass` collects all the relevant counts in a single pass over the data. The aggregated shape stays identical, so callers and tests are unchanged; only the internal iteration count drops from O(N×M) to O(N).

## User Impact

No user-visible output change. Status/report generation avoids redundant aggregation work, which matters where the underlying collections are large (long migration plans, large QA suite reports, sizeable memory-wiki imports, etc.).

## Evidence

- Local: `node scripts/test-projects.mjs` on the touched test file(s)
- Touched files: extensions/qa-lab/src/confidence-report.ts
- Branch: codex/high-quality-algo-47
