### PR TITLE
perf(qa-lab): build token aggregate in one pass

### DIFF
--- a/extensions/qa-lab/src/token-efficiency-report.ts
+++ b/extensions/qa-lab/src/token-efficiency-report.ts
@@ -147,10 +147,26 @@ function buildRow(params: {
 }
 
 function buildAggregate(rows: readonly TokenEfficiencyRow[]): TokenEfficiencyReport["aggregate"] {
-  const openclawTotals = rows.map((row) => row.openclaw.totalTokens);
-  const codexTotals = rows.map((row) => row.codex.totalTokens);
-  const openclawTotalTokens = openclawTotals.reduce((sum, value) => sum + value, 0);
-  const codexTotalTokens = codexTotals.reduce((sum, value) => sum + value, 0);
+  const openclawTotals: number[] = [];
+  const codexTotals: number[] = [];
+  const flaggedScenarios: string[] = [];
+  const savingsScenarios: string[] = [];
+  let openclawTotalTokens = 0;
+  let codexTotalTokens = 0;
+  for (const row of rows) {
+    const openclawTokens = row.openclaw.totalTokens;
+    const codexTokens = row.codex.totalTokens;
+    openclawTotals.push(openclawTokens);
+    codexTotals.push(codexTokens);
+    openclawTotalTokens += openclawTokens;
+    codexTotalTokens += codexTokens;
+    if (row.flagged) {
+      flaggedScenarios.push(row.scenarioId);
+    }
+    if (row.classification === "savings") {
+      savingsScenarios.push(row.scenarioId);
+    }
+  }
   return {
     openclaw: {
       totalTokens: openclawTotalTokens,
@@ -163,10 +179,8 @@ function buildAggregate(rows: readonly TokenEfficiencyRow[]): TokenEfficiencyRep
       p90PerScenario: percentile(codexTotals, 90),
     },
     deltaPercent: deltaPercent(openclawTotalTokens, codexTotalTokens),
-    flaggedScenarios: rows.filter((row) => row.flagged).map((row) => row.scenarioId),
-    savingsScenarios: rows
-      .filter((row) => row.classification === "savings")
-      .map((row) => row.scenarioId),
+    flaggedScenarios,
+    savingsScenarios,
   };
 }
 


### PR DESCRIPTION
## What Problem This Solves

The current implementation uses multiple `.filter(...).length` passes (or similar repeated iterations) to compute summary counts. Each pass walks the full collection, so producing N counts costs N full traversals.

## Why This Change Was Made

`perf(qa-lab): build token aggregate in one pass` collects all the relevant counts in a single pass over the data. The aggregated shape stays identical, so callers and tests are unchanged; only the internal iteration count drops from O(N×M) to O(N).

## User Impact

No user-visible output change. Status/report generation avoids redundant aggregation work, which matters where the underlying collections are large (long migration plans, large QA suite reports, sizeable memory-wiki imports, etc.).

## Evidence

- Local: `node scripts/test-projects.mjs` on the touched test file(s)
- Touched files: extensions/qa-lab/src/token-efficiency-report.ts
- Branch: codex/high-quality-algo-51
