### PR TITLE
perf(memory-wiki): count import insight clusters in one pass

### DIFF
--- a/extensions/memory-wiki/src/import-insights.ts
+++ b/extensions/memory-wiki/src/import-insights.ts
@@ -326,8 +326,15 @@ export async function listMemoryWikiImportInsights(
         ? "withheld"
         : "available";
       const exposeImportContent = shouldExposeImportContent(digestStatus);
-      const userTurns = transcriptTurns.filter((turn) => turn.role === "user");
-      const assistantTurns = transcriptTurns.filter((turn) => turn.role === "assistant");
+      let userTurnCount = 0;
+      const assistantTurns: TranscriptTurn[] = [];
+      for (const turn of transcriptTurns) {
+        if (turn.role === "user") {
+          userTurnCount += 1;
+        } else if (turn.role === "assistant") {
+          assistantTurns.push(turn);
+        }
+      }
       const assistantOpener = exposeImportContent
         ? firstParagraph(assistantTurns[0]?.text ?? "")
         : undefined;
@@ -360,7 +367,7 @@ export async function listMemoryWikiImportInsights(
           activeBranchMessages: extractIntegerField(triageLines, "Active-branch messages"),
           userMessageCount: Math.max(
             extractIntegerField(digestLines, "User messages"),
-            userTurns.length,
+            userTurnCount,
           ),
           assistantMessageCount: Math.max(
             extractIntegerField(digestLines, "Assistant messages"),
@@ -401,20 +408,28 @@ export async function listMemoryWikiImportInsights(
   const clusters = [...clustersByKey.entries()]
     .map(([key, clusterItems]) => {
       const sortedItems = [...clusterItems].toSorted(compareItemsByUpdated);
-      const updatedAt = sortedItems
-        .map((item) => item.updatedAt ?? item.createdAt)
-        .find((value): value is string => typeof value === "string" && value.length > 0);
+      let updatedAt: string | undefined;
+      let highRiskCount = 0;
+      let withheldCount = 0;
+      let preferenceSignalCount = 0;
+      for (const item of sortedItems) {
+        updatedAt ??= item.updatedAt ?? item.createdAt;
+        if (item.riskLevel === "high") {
+          highRiskCount += 1;
+        }
+        if (item.digestStatus === "withheld") {
+          withheldCount += 1;
+        }
+        preferenceSignalCount += item.preferenceSignals.length;
+      }
       return Object.assign(
         {
           key,
           label: sortedItems[0]?.topicLabel ?? humanizeLabelSuffix(key),
           itemCount: sortedItems.length,
-          highRiskCount: sortedItems.filter((item) => item.riskLevel === `high`).length,
-          withheldCount: sortedItems.filter((item) => item.digestStatus === `withheld`).length,
-          preferenceSignalCount: sortedItems.reduce(
-            (sum, item) => sum + item.preferenceSignals.length,
-            0,
-          ),
+          highRiskCount,
+          withheldCount,
+          preferenceSignalCount,
         },
         updatedAt ? { updatedAt } : {},
         { items: sortedItems },


### PR DESCRIPTION
## What Problem This Solves

The current implementation uses multiple `.filter(...).length` passes (or similar repeated iterations) to compute summary counts. Each pass walks the full collection, so producing N counts costs N full traversals.

## Why This Change Was Made

`perf(memory-wiki): count import insight clusters in one pass` collects all the relevant counts in a single pass over the data. The aggregated shape stays identical, so callers and tests are unchanged; only the internal iteration count drops from O(N×M) to O(N).

## User Impact

No user-visible output change. Status/report generation avoids redundant aggregation work, which matters where the underlying collections are large (long migration plans, large QA suite reports, sizeable memory-wiki imports, etc.).

## Evidence

- Local: `node scripts/test-projects.mjs` on the touched test file(s)
- Touched files: extensions/memory-wiki/src/import-insights.ts
- Branch: codex/high-quality-algo-54
