### PR TITLE
fix(infra): recompute cost when transport records $0 against non-zero tokens for priced models

### DIFF
--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -300,6 +300,68 @@ describe("session cost usage", () => {
     });
   });
 
+  it("recomputes cost when a priced model's transport records $0 against non-zero tokens", async () => {
+    // DeepSeek V4 (and similar) returns `usage.cost.total: 0` even for billable
+    // turns. Pricing is known, so the prior all-zero/unknown-pricing branch does
+    // not fire, and the recorded 0 must not be accepted as a confident $0.
+    const root = await makeSessionCostRoot("cost-priced-zero-transport");
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+
+    const entry = {
+      type: "message",
+      timestamp: new Date().toISOString(),
+      message: {
+        role: "assistant",
+        provider: "deepseek",
+        model: "deepseek-v4-flash",
+        usage: {
+          input: 10_000,
+          output: 5_000,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 15_000,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+      },
+    };
+
+    await fs.writeFile(
+      path.join(sessionsDir, "sess-1.jsonl"),
+      transcriptText("sess-1", entry),
+      "utf-8",
+    );
+
+    // Real per-token rates — pricing IS known, so the all-zero branch must not
+    // mark this as missing. The transport-recorded $0 must be replaced by an
+    // estimate derived from these rates.
+    const config = {
+      models: {
+        providers: {
+          deepseek: {
+            models: [
+              {
+                id: "deepseek-v4-flash",
+                // $/million tokens: input ¥14, output ¥28 (issue reports
+                // ¥0.14/10K input and ¥0.28/10K output for v4-flash).
+                cost: { input: 14, output: 28, cacheRead: 0, cacheWrite: 0 },
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    clearGatewayModelPricingCacheState();
+    await withStateDir(root, async () => {
+      const summary = await loadCostUsageSummary({ days: 30, config });
+      expect(summary.totals.totalTokens).toBe(15_000);
+      // 10_000 * 14 / 1_000_000 + 5_000 * 28 / 1_000_000 = 0.14 + 0.14 = 0.28
+      expect(summary.totals.totalCost).toBeCloseTo(0.28, 6);
+      expect(summary.totals.missingCostEntries).toBe(0);
+    });
+  });
+
   it("treats a pre-upgrade (older-version) durable cache as stale so unpriced usage is rebuilt", async () => {
     const root = await makeSessionCostRoot("cost-cache-upgrade");
     const sessionsDir = path.join(root, "agents", "main", "sessions");

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -1165,9 +1165,16 @@ async function scanTranscriptFile(params: {
         // above.
         entry.costTotal = undefined;
         entry.costBreakdown = undefined;
-      } else if (entry.costTotal === undefined) {
-        // Fill in missing cost estimates.
+      } else if (
+        entry.costTotal === undefined ||
+        (entry.costTotal === 0 && computeUsageTokenTotals(entry.usage).totalTokens > 0)
+      ) {
+        // Fill in missing cost estimates, and recompute when the transport recorded a
+        // misleading $0 against non-zero token usage on a model whose per-token rates
+        // are known (e.g., DeepSeek V4 returns `usage.cost.total: 0` even for billable
+        // turns). A genuine $0 with zero tokens stays a $0.
         entry.costTotal = estimateUsageCost({ usage: entry.usage, cost });
+        entry.costBreakdown = undefined;
       }
     }
 


### PR DESCRIPTION
## What Problem This Solves

`loadCostUsageSummary` accepts the transport-recorded `usage.cost.total` as-is. Some providers — DeepSeek V4 in particular — return `usage.cost.total: 0` even for billable turns. When the model's per-token rates are known, session cost accounting silently records $0 against non-zero token usage, undercounting spend in the per-agent totals.

## Why This Change Was Made

`scanTranscriptFile` already had a branch that filled in `costTotal` when it was `undefined`. Extend the trigger so it also fires when:

- `costTotal === 0`, **and**
- `totalTokens > 0` (i.e., this is a real billable turn, not a free/cache-only record).

A genuine $0 with zero tokens stays a $0 — only the misleading-zero case is recomputed. After recompute, `costBreakdown` is cleared so the new `costTotal` is not paired with stale per-field numbers from the transport.

The DeepSeek V4 test pins the behavior: 10K input + 5K output tokens at ¥14/M input and ¥28/M output produces `totalCost ≈ 0.28`, and `missingCostEntries` stays at 0.

## User Impact

Status/dashboards that derive totals from `loadCostUsageSummary` now reflect real spend on affected providers instead of an artificial $0. No behavior change for transports that already report non-zero costs or for genuinely-free turns.

## Evidence

- Local: `pnpm test src/infra/session-cost-usage.test.ts`
- Touched files: `src/infra/session-cost-usage.ts`, `src/infra/session-cost-usage.test.ts`
- Branch: `fix/deepseek-v4-zero-cost-97047`
