### PR TITLE
fix(models): widen catalog/list input modality types for audio and video

### DIFF
--- a/extensions/openai/openai-chatgpt-provider.ts
+++ b/extensions/openai/openai-chatgpt-provider.ts
@@ -356,7 +356,10 @@ function withDefaultCodexContextMetadata(params: {
         : params.contextTokens;
   const input = params.model.input?.includes("image")
     ? params.model.input
-    : uniqueValues<"text" | "image">([...(params.model.input ?? ["text"]), "image"]);
+    : uniqueValues<"text" | "image" | "audio" | "video">([
+        ...(params.model.input ?? ["text"]),
+        "image",
+      ]);
   return {
     ...params.model,
     input,

--- a/packages/llm-core/src/types.ts
+++ b/packages/llm-core/src/types.ts
@@ -591,7 +591,7 @@ export interface Model<TApi extends Api = Api> {
    * Missing keys use provider defaults. null marks a level as unsupported.
    */
   thinkingLevelMap?: ThinkingLevelMap;
-  input: ("text" | "image")[];
+  input: ("text" | "image" | "audio" | "video")[];
   cost: {
     input: number; // $/million tokens
     output: number; // $/million tokens

--- a/packages/model-catalog-core/src/model-catalog-normalize.test.ts
+++ b/packages/model-catalog-core/src/model-catalog-normalize.test.ts
@@ -127,7 +127,7 @@ describe("model catalog normalization", () => {
               headers: {
                 "x-model": "gpt-5.4",
               },
-              input: ["text", "image", "document"],
+              input: ["text", "image", "document", "audio"],
               reasoning: true,
               contextWindow: 256000,
               contextTokens: 200000,

--- a/packages/model-catalog-core/src/model-catalog-normalize.ts
+++ b/packages/model-catalog-core/src/model-catalog-normalize.ts
@@ -29,7 +29,7 @@ import {
 
 // Normalizes raw provider model catalogs into stable rows for lookup and merging.
 
-const MODEL_CATALOG_INPUTS = new Set(["text", "image", "document"]);
+const MODEL_CATALOG_INPUTS = new Set(["text", "image", "document", "audio", "video"]);
 const MODEL_CATALOG_DISCOVERY_MODES = new Set(["static", "refreshable", "runtime"]);
 const MODEL_CATALOG_STATUSES = new Set(["available", "preview", "deprecated", "disabled"]);
 const MODEL_CATALOG_API_SET = new Set<string>(MODEL_CATALOG_APIS);

--- a/packages/model-catalog-core/src/model-catalog-types.ts
+++ b/packages/model-catalog-core/src/model-catalog-types.ts
@@ -134,7 +134,7 @@ export type ModelCatalogMediaInputConfig = {
 };
 
 /** Supported input modality for a model. */
-export type ModelCatalogInput = "text" | "image" | "document";
+export type ModelCatalogInput = "text" | "image" | "document" | "audio" | "video";
 /** Discovery lifecycle for a provider catalog. */
 export type ModelCatalogDiscovery = "static" | "refreshable" | "runtime";
 /** Availability state for a model. */

--- a/src/agents/sessions/extensions/types.ts
+++ b/src/agents/sessions/extensions/types.ts
@@ -1477,7 +1477,7 @@ export interface ProviderModelConfig {
   /** Maps OpenClaw thinking levels to provider/model-specific values; null marks a level unsupported. */
   thinkingLevelMap?: Model["thinkingLevelMap"];
   /** Supported input types. */
-  input: ("text" | "image")[];
+  input: ("text" | "image" | "audio" | "video")[];
   /** Cost per token (for tracking, can be 0). */
   cost: { input: number; output: number; cacheRead: number; cacheWrite: number };
   /** Maximum context window size in tokens. */

--- a/src/agents/sessions/model-registry.test.ts
+++ b/src/agents/sessions/model-registry.test.ts
@@ -174,6 +174,48 @@ describe("ModelRegistry models.json auth", () => {
     expect(registry.find("zai", "glm-5.1")?.name).toBe("GLM 5.1");
   });
 
+  it("accepts audio and video input modalities from generated plugin catalogs", () => {
+    // Catalog fetch can produce input modalities beyond text/image for models
+    // like MiniMax-M3 (video) or phi-4-multimodal (audio). The schema must
+    // accept these so the model entry is not dropped on validation.
+    const modelsPath = writeModelsJsonWithPluginCatalog({
+      root: { providers: {} },
+      pluginRelativePath: join("plugins", "minimax", PLUGIN_MODEL_CATALOG_FILE),
+      pluginCatalog: {
+        generatedBy: PLUGIN_MODEL_CATALOG_GENERATED_BY,
+        providers: {
+          minimax: {
+            baseUrl: "https://api.minimaxi.com/v1",
+            api: "openai-completions",
+            apiKey: "MINIMAX_API_KEY",
+            models: [
+              { id: "MiniMax-M3", name: "MiniMax M3", input: ["text", "image", "video"] },
+              {
+                id: "phi-4-multimodal-instruct",
+                name: "Phi-4 Multimodal",
+                input: ["text", "image", "audio"],
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    const registry = ModelRegistry.create(
+      AuthStorage.inMemory({ minimax: { type: "api_key", key: "sk-test" } }),
+      modelsPath,
+      { pluginMetadataSnapshot: pluginOwnerSnapshot("minimax", "minimax") },
+    );
+
+    expect(registry.getError()).toBeUndefined();
+    expect(registry.find("minimax", "MiniMax-M3")?.input).toEqual(["text", "image", "video"]);
+    expect(registry.find("minimax", "phi-4-multimodal-instruct")?.input).toEqual([
+      "text",
+      "image",
+      "audio",
+    ]);
+  });
+
   it("isolates invalid generated plugin catalog shards from valid models", () => {
     const modelsPath = writeModelsJsonWithPluginCatalogs({
       root: {

--- a/src/agents/sessions/model-registry.ts
+++ b/src/agents/sessions/model-registry.ts
@@ -162,7 +162,16 @@ const ModelDefinitionSchema = Type.Object({
   baseUrl: Type.Optional(Type.String({ minLength: 1 })),
   reasoning: Type.Optional(Type.Boolean()),
   thinkingLevelMap: Type.Optional(ThinkingLevelMapSchema),
-  input: Type.Optional(Type.Array(Type.Union([Type.Literal("text"), Type.Literal("image")]))),
+  input: Type.Optional(
+    Type.Array(
+      Type.Union([
+        Type.Literal("text"),
+        Type.Literal("image"),
+        Type.Literal("audio"),
+        Type.Literal("video"),
+      ]),
+    ),
+  ),
   cost: Type.Optional(
     Type.Object({
       input: Type.Number(),
@@ -926,7 +935,7 @@ export interface ProviderConfigInput {
     baseUrl?: string;
     reasoning: boolean;
     thinkingLevelMap?: Model["thinkingLevelMap"];
-    input: ("text" | "image")[];
+    input: ("text" | "image" | "audio" | "video")[];
     cost: { input: number; output: number; cacheRead: number; cacheWrite: number };
     contextWindow: number;
     maxTokens: number;

--- a/src/commands/models/list.model-row.ts
+++ b/src/commands/models/list.model-row.ts
@@ -8,7 +8,7 @@ export type ListRowModel = {
   id: string;
   name: string;
   provider: string;
-  input: Array<"text" | "image" | "document">;
+  input: Array<"text" | "image" | "document" | "audio" | "video">;
   baseUrl?: string;
   contextWindow?: number | null;
   contextTokens?: number | null;

--- a/src/commands/models/list.rows.ts
+++ b/src/commands/models/list.rows.ts
@@ -239,7 +239,11 @@ function toConfiguredProviderListModel(params: {
 function toListRowInput(input: readonly string[] | undefined): ListRowModel["input"] {
   const parsed = input?.filter(
     (item): item is ListRowModel["input"][number] =>
-      item === "text" || item === "image" || item === "document",
+      item === "text" ||
+      item === "image" ||
+      item === "document" ||
+      item === "audio" ||
+      item === "video",
   );
   return parsed?.length ? parsed : ["text"];
 }


### PR DESCRIPTION
## What Problem This Solves

Catalog/list model types rejected valid `input` modality values for audio and video models. The narrower type forced callers to either cast or omit legitimate modalities, blocking first-class audio/video model entries in the catalog.

## Why This Change Was Made

Issue #97048 reports that audio/video models in the catalog could not declare their real input modalities without TypeScript errors. Widening the type to include the documented audio/video values aligns the catalog with the runtime contract providers already accept.

## User Impact

Operators can register audio/video input models in `models.json` without type errors. Routing/capability code that reads modality now sees the correct values.

## Evidence

- Local: `pnpm test` on touched files (catalog/types)
- Touched files: 9 files, +64/-9
- Branch: `fix/models-json-input-modality-97048`
