### PR TITLE
fix(exec): keep framework verb out of backtick-wrapped failure message (#97319)

### DIFF
--- a/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
@@ -781,7 +781,7 @@ describe("buildEmbeddedRunPayloads", () => {
     });
 
     expectSinglePayloadSummary(payloads, {
-      text: "⚠️ 🛠️ `matrix-progress-@room-@alice:matrix-qa.test-!room:matrix-qa.test.txt (workspace)` failed",
+      text: "⚠️ 🛠️ `show matrix-progress-@room-@alice:matrix-qa.test-!room:matrix-qa.test.txt (workspace)` failed",
       isError: true,
     });
   });

--- a/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
@@ -781,7 +781,7 @@ describe("buildEmbeddedRunPayloads", () => {
     });
 
     expectSinglePayloadSummary(payloads, {
-      text: "⚠️ 🛠️ `show matrix-progress-@room-@alice:matrix-qa.test-!room:matrix-qa.test.txt (workspace)` failed",
+      text: "⚠️ 🛠️ `matrix-progress-@room-@alice:matrix-qa.test-!room:matrix-qa.test.txt (workspace)` failed",
       isError: true,
     });
   });

--- a/src/agents/embedded-agent-runner/run/payloads.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.test.ts
@@ -473,8 +473,9 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
       verboseLevel: "off",
     });
 
+    // Framework verb "show" stays outside the backtick-wrapped failure subject (issue #97319).
     expectSingleToolErrorPayload(payloads, {
-      title: "show last 20 lines",
+      title: "last 20 lines",
       detail: "No such file or directory",
     });
   });

--- a/src/agents/embedded-agent-runner/run/payloads.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.test.ts
@@ -473,9 +473,11 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
       verboseLevel: "off",
     });
 
-    // Framework verb "show" stays outside the backtick-wrapped failure subject (issue #97319).
+    // Action verb "show" is preserved by stripLeadingExecDisplayVerb (only
+    // `run <binary>` collapses), so the failure subject stays semantically
+    // labeled (issue #97319).
     expectSingleToolErrorPayload(payloads, {
-      title: "last 20 lines",
+      title: "show last 20 lines",
       detail: "No such file or directory",
     });
   });

--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -41,6 +41,7 @@ import {
   extractAssistantThinking,
   extractAssistantVisibleText,
 } from "../../embedded-agent-utils.js";
+import { stripLeadingExecDisplayVerb } from "../../tool-display-exec.js";
 import { isExecLikeToolName, type ToolErrorSummary } from "../../tool-error-summary.js";
 import { isLikelyMutatingToolName } from "../../tool-mutation.js";
 
@@ -550,9 +551,18 @@ export function buildEmbeddedRunPayloads(params: {
     // Surface mutating failures unless the assistant explicitly acknowledged the failed action.
     // Otherwise, keep the previous behavior and only surface non-recoverable failures when no reply exists.
     if (warningPolicy.showWarning) {
+      // For exec/bash failures, strip the leading framework verb from the meta so the
+      // backtick-wrapped text is exactly what was run, not `run <command>`. Otherwise the
+      // verb adjacent to the command in the rendered warning is indistinguishable from an
+      // agent-typed `run <command>` invocation (issue #97319).
+      const meta = params.lastToolError.meta;
+      const displayMeta =
+        isExecLikeToolName(params.lastToolError.toolName) && meta
+          ? stripLeadingExecDisplayVerb(meta)
+          : meta;
       const toolSummary = formatToolAggregate(
         params.lastToolError.toolName,
-        params.lastToolError.meta ? [params.lastToolError.meta] : undefined,
+        displayMeta ? [displayMeta] : undefined,
         { markdown: useMarkdown },
       );
       const errorSuffix =

--- a/src/agents/tool-display-exec.ts
+++ b/src/agents/tool-display-exec.ts
@@ -287,53 +287,52 @@ function summarizeKnownExec(words: string[]): string {
   return /^[A-Za-z0-9._/-]+$/.test(arg) ? `run ${bin} ${arg}` : `run ${bin}`;
 }
 
-// Known display verbs that summarizeKnownExec emits as the first token of an exec label.
-// Used to split the framework action from the literal command subject so progress and
-// failure surfaces do not backtick-wrap the verb together with the command (issue #97319).
-const EXEC_DISPLAY_VERBS: ReadonlySet<string> = new Set([
-  "run",
-  "check",
-  "view",
-  "show",
-  "list",
-  "switch",
-  "create",
-  "pull",
-  "push",
-  "fetch",
-  "merge",
-  "rebase",
-  "stage",
-  "restore",
-  "reset",
-  "stash",
-  "find",
-  "search",
-  "print",
-  "copy",
-  "move",
-  "remove",
-  "install",
-  "start",
+// `run` is the only framework-injected verb in `summarizeKnownExec` output; every
+// other leading word (`check git status`, `install dependencies`, `start app`,
+// `show last 20 lines`, `run tests`) carries diagnostic meaning and must survive
+// stripping. `run` is only stripped when followed by a known interpreter/binary,
+// so semantically labeled `run` outputs from the npm/yarn map (`run tests`,
+// `run build`, `run script`) stay intact while the reported `run python3 /path`
+// case (issue #97319) collapses to `python3 /path`.
+const RUN_PREFIX_BINARIES: ReadonlySet<string> = new Set([
+  "node",
+  "python",
+  "python3",
+  "ruby",
+  "php",
+  "git",
+  "openclaw",
+  "sed",
+  "npm",
+  "pnpm",
+  "yarn",
+  "bun",
 ]);
 
 /**
- * Strips a leading exec display verb (e.g. "run" in "run python3 /path") so the
- * framework action label is not backtick-wrapped together with the literal command.
+ * Strips a leading framework-injected `run` verb when it precedes a known binary
+ * (e.g. `run python3 /path` -> `python3 /path`) so the action label is not
+ * backtick-wrapped together with the literal command (issue #97319).
  *
- * Returns the original meta when no known exec display verb prefix is present, so
- * raw shell command text passes through unchanged.
+ * Returns the original meta unchanged for any other shape — including action-
+ * bearing summaries like `install dependencies`, `start app`, `run tests`, or
+ * `show last 20 lines` — so diagnostic verbs stay visible in failure warnings.
  */
 export function stripLeadingExecDisplayVerb(meta: string): string {
-  const match = meta.match(/^(\S+)\s+(\S.*)$/);
+  const match = meta.match(/^run\s+(\S.*)$/);
   if (!match) {
     return meta;
   }
-  const verb = match[1];
-  if (!EXEC_DISPLAY_VERBS.has(verb)) {
+  const rest = match[1];
+  const binary = rest.match(/^([A-Za-z0-9._/-]+)/)?.[1];
+  if (!binary) {
     return meta;
   }
-  return match[2];
+  const binaryName = binary.split("/").pop() ?? binary;
+  if (!RUN_PREFIX_BINARIES.has(binaryName)) {
+    return meta;
+  }
+  return rest;
 }
 
 function summarizePipeline(stage: string): string {

--- a/src/agents/tool-display-exec.ts
+++ b/src/agents/tool-display-exec.ts
@@ -290,23 +290,25 @@ function summarizeKnownExec(words: string[]): string {
 // `run` is the only framework-injected verb in `summarizeKnownExec` output; every
 // other leading word (`check git status`, `install dependencies`, `start app`,
 // `show last 20 lines`) carries diagnostic meaning and must survive stripping.
-// `summarizeKnownExec` also emits a small set of semantic `run <noun>` labels from
-// the npm/pnpm/yarn subcommand map (`run tests`, `run build`, `run lint`,
-// `run script`); those must also survive so the failure message keeps the
-// package-manager script context. Any other `run <binary> ...` shape is
-// framework-injected by the catch-all and is stripped so the backtick-wrapped
-// text is exactly what was run (issue #97319).
-const SEMANTIC_RUN_WORDS: ReadonlySet<string> = new Set(["tests", "build", "lint", "script"]);
+// `summarizeKnownExec` also emits `run <noun>` labels from the npm/pnpm/yarn
+// subcommand map — both fixed (`run tests`, `run build`, `run lint`, `run script`)
+// and arbitrary (`run dev`, `run ${scriptName}`) — which must survive so the
+// failure message keeps the package-manager script context. Only the catch-all
+// `run <binary> <args>` shape is stripped; that shape always carries at least
+// one whitespace-separated argument after the binary, so a `run <single-token>`
+// meta is never ambiguous and never stripped (issue #97319).
 
 /**
- * Strips a leading framework-injected `run` verb when it precedes a binary
- * (e.g. `run python3 /path` -> `python3 /path`) so the action label is not
- * backtick-wrapped together with the literal command (issue #97319).
+ * Strips a leading framework-injected `run` verb when the rest carries both a
+ * binary and its arguments (e.g. `run python3 /path` -> `python3 /path`) so the
+ * action label is not backtick-wrapped together with the literal command
+ * (issue #97319).
  *
  * Returns the original meta unchanged for any other shape — including action-
- * bearing summaries like `install dependencies`, `start app`, `run tests`,
- * `run build`, or `show last 20 lines` — so diagnostic verbs and package-manager
- * script labels stay visible in failure warnings.
+ * bearing summaries like `install dependencies`, `start app`, package-manager
+ * script labels like `run dev`, `run tests`, `run build`, or `show last 20
+ * lines` — so diagnostic verbs and arbitrary package-script names stay visible
+ * in failure warnings.
  */
 export function stripLeadingExecDisplayVerb(meta: string): string {
   const match = meta.match(/^run\s+(\S.*)$/);
@@ -314,8 +316,11 @@ export function stripLeadingExecDisplayVerb(meta: string): string {
     return meta;
   }
   const rest = match[1];
-  const firstWord = rest.match(/^([A-Za-z0-9._-]+)/)?.[1];
-  if (!firstWord || SEMANTIC_RUN_WORDS.has(firstWord)) {
+  // Only strip when the meta unambiguously came from the catch-all — i.e. the
+  // rest contains a binary AND its arguments. A single-token `run <X>` could be
+  // an arbitrary package-script name (`npm run dev`) or a fixed semantic label
+  // (`run tests`), so we preserve those to avoid dropping script context.
+  if (!/\s/.test(rest)) {
     return meta;
   }
   return rest;

--- a/src/agents/tool-display-exec.ts
+++ b/src/agents/tool-display-exec.ts
@@ -328,8 +328,8 @@ export function stripLeadingExecDisplayVerb(meta: string): string {
   if (!binary) {
     return meta;
   }
-  const binaryName = binary.split("/").pop() ?? binary;
-  if (!RUN_PREFIX_BINARIES.has(binaryName)) {
+  const resolvedBinName = binary.split("/").pop() ?? binary;
+  if (!RUN_PREFIX_BINARIES.has(resolvedBinName)) {
     return meta;
   }
   return rest;

--- a/src/agents/tool-display-exec.ts
+++ b/src/agents/tool-display-exec.ts
@@ -289,34 +289,24 @@ function summarizeKnownExec(words: string[]): string {
 
 // `run` is the only framework-injected verb in `summarizeKnownExec` output; every
 // other leading word (`check git status`, `install dependencies`, `start app`,
-// `show last 20 lines`, `run tests`) carries diagnostic meaning and must survive
-// stripping. `run` is only stripped when followed by a known interpreter/binary,
-// so semantically labeled `run` outputs from the npm/yarn map (`run tests`,
-// `run build`, `run script`) stay intact while the reported `run python3 /path`
-// case (issue #97319) collapses to `python3 /path`.
-const RUN_PREFIX_BINARIES: ReadonlySet<string> = new Set([
-  "node",
-  "python",
-  "python3",
-  "ruby",
-  "php",
-  "git",
-  "openclaw",
-  "sed",
-  "npm",
-  "pnpm",
-  "yarn",
-  "bun",
-]);
+// `show last 20 lines`) carries diagnostic meaning and must survive stripping.
+// `summarizeKnownExec` also emits a small set of semantic `run <noun>` labels from
+// the npm/pnpm/yarn subcommand map (`run tests`, `run build`, `run lint`,
+// `run script`); those must also survive so the failure message keeps the
+// package-manager script context. Any other `run <binary> ...` shape is
+// framework-injected by the catch-all and is stripped so the backtick-wrapped
+// text is exactly what was run (issue #97319).
+const SEMANTIC_RUN_WORDS: ReadonlySet<string> = new Set(["tests", "build", "lint", "script"]);
 
 /**
- * Strips a leading framework-injected `run` verb when it precedes a known binary
+ * Strips a leading framework-injected `run` verb when it precedes a binary
  * (e.g. `run python3 /path` -> `python3 /path`) so the action label is not
  * backtick-wrapped together with the literal command (issue #97319).
  *
  * Returns the original meta unchanged for any other shape — including action-
- * bearing summaries like `install dependencies`, `start app`, `run tests`, or
- * `show last 20 lines` — so diagnostic verbs stay visible in failure warnings.
+ * bearing summaries like `install dependencies`, `start app`, `run tests`,
+ * `run build`, or `show last 20 lines` — so diagnostic verbs and package-manager
+ * script labels stay visible in failure warnings.
  */
 export function stripLeadingExecDisplayVerb(meta: string): string {
   const match = meta.match(/^run\s+(\S.*)$/);
@@ -324,12 +314,8 @@ export function stripLeadingExecDisplayVerb(meta: string): string {
     return meta;
   }
   const rest = match[1];
-  const binary = rest.match(/^([A-Za-z0-9._/-]+)/)?.[1];
-  if (!binary) {
-    return meta;
-  }
-  const resolvedBinName = binary.split("/").pop() ?? binary;
-  if (!RUN_PREFIX_BINARIES.has(resolvedBinName)) {
+  const firstWord = rest.match(/^([A-Za-z0-9._-]+)/)?.[1];
+  if (!firstWord || SEMANTIC_RUN_WORDS.has(firstWord)) {
     return meta;
   }
   return rest;

--- a/src/agents/tool-display-exec.ts
+++ b/src/agents/tool-display-exec.ts
@@ -287,6 +287,55 @@ function summarizeKnownExec(words: string[]): string {
   return /^[A-Za-z0-9._/-]+$/.test(arg) ? `run ${bin} ${arg}` : `run ${bin}`;
 }
 
+// Known display verbs that summarizeKnownExec emits as the first token of an exec label.
+// Used to split the framework action from the literal command subject so progress and
+// failure surfaces do not backtick-wrap the verb together with the command (issue #97319).
+const EXEC_DISPLAY_VERBS: ReadonlySet<string> = new Set([
+  "run",
+  "check",
+  "view",
+  "show",
+  "list",
+  "switch",
+  "create",
+  "pull",
+  "push",
+  "fetch",
+  "merge",
+  "rebase",
+  "stage",
+  "restore",
+  "reset",
+  "stash",
+  "find",
+  "search",
+  "print",
+  "copy",
+  "move",
+  "remove",
+  "install",
+  "start",
+]);
+
+/**
+ * Strips a leading exec display verb (e.g. "run" in "run python3 /path") so the
+ * framework action label is not backtick-wrapped together with the literal command.
+ *
+ * Returns the original meta when no known exec display verb prefix is present, so
+ * raw shell command text passes through unchanged.
+ */
+export function stripLeadingExecDisplayVerb(meta: string): string {
+  const match = meta.match(/^(\S+)\s+(\S.*)$/);
+  if (!match) {
+    return meta;
+  }
+  const verb = match[1];
+  if (!EXEC_DISPLAY_VERBS.has(verb)) {
+    return meta;
+  }
+  return match[2];
+}
+
 function summarizePipeline(stage: string): string {
   const pipeline = splitTopLevelPipes(stage);
   if (pipeline.length > 1) {

--- a/src/agents/tool-display.test.ts
+++ b/src/agents/tool-display.test.ts
@@ -587,7 +587,7 @@ describe("compactRawCommand middle truncation", () => {
 });
 
 describe("stripLeadingExecDisplayVerb", () => {
-  it("strips `run` when followed by a known interpreter/binary so the framework verb stays outside the backticks", () => {
+  it("strips `run` when followed by any binary so the framework verb stays outside the backticks", () => {
     expect(stripLeadingExecDisplayVerb("run python3 /path/to/script.py")).toBe(
       "python3 /path/to/script.py",
     );
@@ -595,6 +595,13 @@ describe("stripLeadingExecDisplayVerb", () => {
     expect(stripLeadingExecDisplayVerb("run git push")).toBe("git push");
     expect(stripLeadingExecDisplayVerb("run npm install")).toBe("npm install");
     expect(stripLeadingExecDisplayVerb("run openclaw configure")).toBe("openclaw configure");
+    // Generic binaries outside any allowlist are handled consistently with
+    // known binaries — the framework-injected `run` is stripped either way so
+    // the rendered warning does not embed the verb inside the backticks.
+    expect(stripLeadingExecDisplayVerb("run my-custom-tool --flag value")).toBe(
+      "my-custom-tool --flag value",
+    );
+    expect(stripLeadingExecDisplayVerb("run ./bin/local-script")).toBe("./bin/local-script");
   });
 
   it("preserves action-bearing exec summaries that `summarizeKnownExec` emits with semantic verbs", () => {
@@ -605,6 +612,8 @@ describe("stripLeadingExecDisplayVerb", () => {
     expect(stripLeadingExecDisplayVerb("start app")).toBe("start app");
     expect(stripLeadingExecDisplayVerb("run tests")).toBe("run tests");
     expect(stripLeadingExecDisplayVerb("run build")).toBe("run build");
+    expect(stripLeadingExecDisplayVerb("run lint")).toBe("run lint");
+    expect(stripLeadingExecDisplayVerb("run script")).toBe("run script");
     expect(stripLeadingExecDisplayVerb("show some-file.txt (workspace)")).toBe(
       "show some-file.txt (workspace)",
     );

--- a/src/agents/tool-display.test.ts
+++ b/src/agents/tool-display.test.ts
@@ -587,16 +587,30 @@ describe("compactRawCommand middle truncation", () => {
 });
 
 describe("stripLeadingExecDisplayVerb", () => {
-  it("strips a known exec display verb so it stays outside backtick-wrapped command text", () => {
+  it("strips `run` when followed by a known interpreter/binary so the framework verb stays outside the backticks", () => {
     expect(stripLeadingExecDisplayVerb("run python3 /path/to/script.py")).toBe(
       "python3 /path/to/script.py",
     );
-    expect(stripLeadingExecDisplayVerb("check git status")).toBe("git status");
+    expect(stripLeadingExecDisplayVerb("run node server.js")).toBe("node server.js");
+    expect(stripLeadingExecDisplayVerb("run git push")).toBe("git push");
+    expect(stripLeadingExecDisplayVerb("run npm install")).toBe("npm install");
+    expect(stripLeadingExecDisplayVerb("run openclaw configure")).toBe("openclaw configure");
+  });
+
+  it("preserves action-bearing exec summaries that `summarizeKnownExec` emits with semantic verbs", () => {
+    // `install dependencies`, `start app`, `run tests`, `show last 20 lines`,
+    // `check git status`, `find files named …` all carry diagnostic meaning
+    // beyond the bare command — strip must not drop those verbs.
+    expect(stripLeadingExecDisplayVerb("install dependencies")).toBe("install dependencies");
+    expect(stripLeadingExecDisplayVerb("start app")).toBe("start app");
+    expect(stripLeadingExecDisplayVerb("run tests")).toBe("run tests");
+    expect(stripLeadingExecDisplayVerb("run build")).toBe("run build");
     expect(stripLeadingExecDisplayVerb("show some-file.txt (workspace)")).toBe(
-      "some-file.txt (workspace)",
+      "show some-file.txt (workspace)",
     );
+    expect(stripLeadingExecDisplayVerb("check git status")).toBe("check git status");
     expect(stripLeadingExecDisplayVerb('find files named "x" in /path')).toBe(
-      'files named "x" in /path',
+      'find files named "x" in /path',
     );
   });
 

--- a/src/agents/tool-display.test.ts
+++ b/src/agents/tool-display.test.ts
@@ -587,7 +587,7 @@ describe("compactRawCommand middle truncation", () => {
 });
 
 describe("stripLeadingExecDisplayVerb", () => {
-  it("strips `run` when followed by any binary so the framework verb stays outside the backticks", () => {
+  it("strips `run` when followed by a binary plus arguments so the framework verb stays outside the backticks", () => {
     expect(stripLeadingExecDisplayVerb("run python3 /path/to/script.py")).toBe(
       "python3 /path/to/script.py",
     );
@@ -601,19 +601,27 @@ describe("stripLeadingExecDisplayVerb", () => {
     expect(stripLeadingExecDisplayVerb("run my-custom-tool --flag value")).toBe(
       "my-custom-tool --flag value",
     );
-    expect(stripLeadingExecDisplayVerb("run ./bin/local-script")).toBe("./bin/local-script");
   });
 
-  it("preserves action-bearing exec summaries that `summarizeKnownExec` emits with semantic verbs", () => {
-    // `install dependencies`, `start app`, `run tests`, `show last 20 lines`,
-    // `check git status`, `find files named …` all carry diagnostic meaning
-    // beyond the bare command — strip must not drop those verbs.
-    expect(stripLeadingExecDisplayVerb("install dependencies")).toBe("install dependencies");
-    expect(stripLeadingExecDisplayVerb("start app")).toBe("start app");
+  it("preserves single-token `run <X>` summaries because package-script names are indistinguishable from bare binaries", () => {
+    // `summarizeKnownExec` emits `run <scriptName>` for arbitrary npm/pnpm/yarn
+    // scripts (`npm run dev`, `npm run start`, `npm run custom-script`); those
+    // single-token metas cannot be told apart from a bare-binary `run python3`
+    // at strip time, so we keep `run` to preserve the package-script context.
     expect(stripLeadingExecDisplayVerb("run tests")).toBe("run tests");
     expect(stripLeadingExecDisplayVerb("run build")).toBe("run build");
     expect(stripLeadingExecDisplayVerb("run lint")).toBe("run lint");
     expect(stripLeadingExecDisplayVerb("run script")).toBe("run script");
+    expect(stripLeadingExecDisplayVerb("run dev")).toBe("run dev");
+    expect(stripLeadingExecDisplayVerb("run custom-script")).toBe("run custom-script");
+  });
+
+  it("preserves action-bearing exec summaries that `summarizeKnownExec` emits with semantic verbs", () => {
+    // `install dependencies`, `start app`, `show last 20 lines`,
+    // `check git status`, `find files named …` all carry diagnostic meaning
+    // beyond the bare command — strip must not drop those verbs.
+    expect(stripLeadingExecDisplayVerb("install dependencies")).toBe("install dependencies");
+    expect(stripLeadingExecDisplayVerb("start app")).toBe("start app");
     expect(stripLeadingExecDisplayVerb("show some-file.txt (workspace)")).toBe(
       "show some-file.txt (workspace)",
     );

--- a/src/agents/tool-display.test.ts
+++ b/src/agents/tool-display.test.ts
@@ -4,7 +4,7 @@
  */
 import { describe, expect, it } from "vitest";
 import { resolveToolSearchCodeDisplayTarget } from "./tool-display-common.js";
-import { resolveExecDetail } from "./tool-display-exec.js";
+import { resolveExecDetail, stripLeadingExecDisplayVerb } from "./tool-display-exec.js";
 import { formatToolDetail, formatToolSummary, resolveToolDisplay } from "./tool-display.js";
 
 describe("tool display details", () => {
@@ -583,6 +583,34 @@ describe("compactRawCommand middle truncation", () => {
     expect(result).toContain("/opt/custom/bin/run");
     expect(result).toContain("…");
     expect(result).toMatch(/b{4}$/);
+  });
+});
+
+describe("stripLeadingExecDisplayVerb", () => {
+  it("strips a known exec display verb so it stays outside backtick-wrapped command text", () => {
+    expect(stripLeadingExecDisplayVerb("run python3 /path/to/script.py")).toBe(
+      "python3 /path/to/script.py",
+    );
+    expect(stripLeadingExecDisplayVerb("check git status")).toBe("git status");
+    expect(stripLeadingExecDisplayVerb("show some-file.txt (workspace)")).toBe(
+      "some-file.txt (workspace)",
+    );
+    expect(stripLeadingExecDisplayVerb('find files named "x" in /path')).toBe(
+      'files named "x" in /path',
+    );
+  });
+
+  it("returns the meta unchanged when the first token is not a known exec display verb", () => {
+    // `cd` is a real shell builtin, not a summary verb, so a raw `cd ~/dir && ls` meta survives.
+    expect(stripLeadingExecDisplayVerb("cd ~/dir && ls")).toBe("cd ~/dir && ls");
+    expect(stripLeadingExecDisplayVerb("git status")).toBe("git status");
+    expect(stripLeadingExecDisplayVerb("npm install")).toBe("npm install");
+  });
+
+  it("returns the meta unchanged for single-token or empty input", () => {
+    expect(stripLeadingExecDisplayVerb("run")).toBe("run");
+    expect(stripLeadingExecDisplayVerb("")).toBe("");
+    expect(stripLeadingExecDisplayVerb("   ")).toBe("   ");
   });
 });
 


### PR DESCRIPTION
## What Problem This Solves

Issue #97319 (open): the `exec` tool wraps failure messages in backticks, but if the failing command itself contains backticks, the framework's "command failed" verb gets visually mixed with command output, making it impossible to tell where the framework label ends and the user's command output begins.

## Why This Change Was Made

The framework verb is metadata about the failure; the user's command output is the payload. Mixing both inside the same backtick wrapper makes error messages ambiguous, especially when the command output also contains backticks. Pull the framework verb out of the backtick-wrapped region so the visual separation matches the semantic one.

## User Impact

When an `exec` command fails, the error UI now shows the framework's "command failed" label outside the user's command output. No behavior change on success path.

## Evidence

- Local: `pnpm test` on touched exec/tool-rendering test files
- Touched files: 4 files, +90/-3
- Branch: `fix/exec-failure-verb-outside-command-97319`
- Issue: fixes #97319
