### PR TITLE
fix(gateway): report dropped message count in enforceChatHistoryFinalBudget placeholderCount

### DIFF
--- a/src/gateway/server-methods/chat-history-budget.test.ts
+++ b/src/gateway/server-methods/chat-history-budget.test.ts
@@ -36,6 +36,19 @@ describe("enforceChatHistoryFinalBudget", () => {
     // originals were omitted by identity.
     expect(result.messages).toEqual([last]);
     expect(result.messages[0]).toBe(last);
+    // 1 earlier message was dropped; placeholderCount must reflect that (#96783).
+    expect(result.placeholderCount).toBe(1);
+  });
+
+  it("reports the correct dropped-message count when multiple messages are truncated", () => {
+    const m1 = { role: "user", content: [{ type: "text", text: "a".repeat(2000) }] };
+    const m2 = { role: "assistant", content: [{ type: "text", text: "b".repeat(2000) }] };
+    const m3 = { role: "user", content: [{ type: "text", text: "c".repeat(2000) }] };
+    const last = { role: "assistant", content: [{ type: "text", text: "ok" }] };
+    const result = enforceChatHistoryFinalBudget({ messages: [m1, m2, m3, last], maxBytes: 3_000 });
+    expect(result.messages).toEqual([last]);
+    // 3 earlier messages were silently dropped; placeholderCount must reflect that.
+    expect(result.placeholderCount).toBe(3);
   });
 
   it("falls back to a small placeholder when even the last message is too large", () => {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1673,11 +1673,11 @@ export function replaceOversizedChatHistoryMessages(params: {
 }
 
 // Enforces the final byte budget for chat.history. Returns only the surviving
-// messages; how many original messages were omitted is measured end-to-end by
-// reportOmittedChatHistory, which alone sees the full replace/cap/final pipeline
-// and so can count unique omitted originals without double-counting.
+// messages. When the final-byte cap keeps only the last message, report the
+// dropped prefix count so callers can include that loss in end-to-end metrics.
 export function enforceChatHistoryFinalBudget(params: { messages: unknown[]; maxBytes: number }): {
   messages: unknown[];
+  placeholderCount?: number;
 } {
   const { messages, maxBytes } = params;
   if (messages.length === 0) {
@@ -1688,7 +1688,9 @@ export function enforceChatHistoryFinalBudget(params: { messages: unknown[]; max
   }
   const last = messages.at(-1);
   if (last && jsonUtf8Bytes([last]) <= maxBytes) {
-    return { messages: [last] };
+    // messages.length - 1 earlier messages were dropped; report them so the
+    // caller's truncation log and metrics stay accurate (#96783).
+    return { messages: [last], placeholderCount: messages.length - 1 };
   }
   const placeholder = buildOversizedHistoryPlaceholder(last);
   if (jsonUtf8Bytes([placeholder]) <= maxBytes) {


### PR DESCRIPTION
## What Problem This Solves

`enforceChatHistoryFinalBudget` drops messages when the budget is exceeded but does not surface how many were dropped. The placeholder count stays at zero even when real messages were trimmed, so callers cannot tell whether a budget was hit.

## Why This Change Was Made

Dropped-message counts are operationally important: they tell operators and tests that a chat history budget is binding. Reporting `placeholderCount` accurately (reflecting dropped messages) keeps the budget-enforcement contract observable.

## User Impact

Status/dashboards/tests that read `placeholderCount` after budget enforcement now see the dropped-message count. No behavior change to the trimming logic itself.

## Evidence

- Local: `pnpm test` on touched gateway chat-history test file
- Touched files: 2 files, +19/-4
- Branch: `fix/chat-history-budget-placeholder-count`
