### PR TITLE
fix(line): truncate template title/altText on grapheme boundaries, not raw UTF-16

### DIFF
--- a/extensions/line/src/message-cards.test.ts
+++ b/extensions/line/src/message-cards.test.ts
@@ -20,12 +20,25 @@ import {
   messageAction,
 } from "./template-messages.js";
 
+const loneHighSurrogate = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])/;
+
 describe("createConfirmTemplate", () => {
   it("truncates text to 240 characters", () => {
     const longText = "x".repeat(300);
     const template = createConfirmTemplate(longText, messageAction("Yes"), messageAction("No"));
 
     expect((template.template as { text: string }).text.length).toBe(240);
+  });
+
+  it("drops a surrogate-pair emoji from fallback altText instead of splitting it", () => {
+    const template = createConfirmTemplate(
+      `${"x".repeat(399)}😀`,
+      messageAction("Yes"),
+      messageAction("No"),
+    );
+
+    expect(template.altText).toBe("x".repeat(399));
+    expect(loneHighSurrogate.test(template.altText)).toBe(false);
   });
 });
 
@@ -51,7 +64,16 @@ describe("createButtonTemplate", () => {
     const title = (template.template as { title: string }).title;
 
     expect(title).toBe("x".repeat(39));
-    expect(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/.test(title)).toBe(false);
+    expect(loneHighSurrogate.test(title)).toBe(false);
+  });
+
+  it("drops a surrogate-pair emoji from explicit altText instead of splitting it", () => {
+    const template = createButtonTemplate("Title", "Text", [messageAction("OK")], {
+      altText: `${"x".repeat(399)}😀`,
+    });
+
+    expect(template.altText).toBe("x".repeat(399));
+    expect(loneHighSurrogate.test(template.altText)).toBe(false);
   });
 
   it("truncates text to 60 chars when no thumbnail is provided", () => {
@@ -103,6 +125,17 @@ describe("createCarouselColumn", () => {
     });
 
     expect(column.text.length).toBe(60);
+  });
+
+  it("drops a surrogate-pair emoji from the title instead of splitting it", () => {
+    const column = createCarouselColumn({
+      title: `${"x".repeat(39)}😀`,
+      text: "Text",
+      actions: [messageAction("OK")],
+    });
+
+    expect(column.title).toBe("x".repeat(39));
+    expect(loneHighSurrogate.test(column.title ?? "")).toBe(false);
   });
 
   it("does not split an emoji grapheme at the 60-code-unit boundary", () => {
@@ -171,6 +204,16 @@ describe("carousel column limits", () => {
   ])("limits columns to 10", ({ createTemplate }) => {
     const template = createTemplate();
     expect((template.template as { columns: unknown[] }).columns.length).toBe(10);
+  });
+
+  it("drops a surrogate-pair emoji from image-carousel altText instead of splitting it", () => {
+    const template = createImageCarousel(
+      [createImageCarouselColumn("https://example.com/0.jpg", messageAction("View"))],
+      `${"x".repeat(399)}😀`,
+    );
+
+    expect(template.altText).toBe("x".repeat(399));
+    expect(loneHighSurrogate.test(template.altText)).toBe(false);
   });
 });
 

--- a/extensions/line/src/message-cards.test.ts
+++ b/extensions/line/src/message-cards.test.ts
@@ -44,6 +44,16 @@ describe("createButtonTemplate", () => {
     expect((template.template as { title: string }).title.length).toBe(40);
   });
 
+  it("drops a surrogate-pair emoji from the title instead of splitting it", () => {
+    // 39 chars + an emoji land the truncation boundary inside the surrogate pair;
+    // a raw code-unit slice would keep only the lone high surrogate.
+    const template = createButtonTemplate(`${"x".repeat(39)}😀`, "Text", [messageAction("OK")]);
+    const title = (template.template as { title: string }).title;
+
+    expect(title).toBe("x".repeat(39));
+    expect(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/.test(title)).toBe(false);
+  });
+
   it("truncates text to 60 chars when no thumbnail is provided", () => {
     const longText = "x".repeat(100);
     const template = createButtonTemplate("Title", longText, [messageAction("OK")]);

--- a/extensions/line/src/template-messages.ts
+++ b/extensions/line/src/template-messages.ts
@@ -65,6 +65,10 @@ function truncateTemplateText(text: string, limit: number): string {
   return result;
 }
 
+function truncateOptionalTemplateText(value: string | undefined, limit: number): string | undefined {
+  return value === undefined ? undefined : truncateTemplateText(value, limit);
+}
+
 function formatProductCarouselText(description: string, price?: string): string {
   if (!price) {
     return description;
@@ -86,13 +90,13 @@ export function createConfirmTemplate(
 ): TemplateMessage {
   const template: ConfirmTemplate = {
     type: "confirm",
-    text: text.slice(0, 240), // LINE limit
+    text: truncateTemplateText(text, 240), // LINE limit
     actions: [confirmAction, cancelAction],
   };
 
   return {
     type: "template",
-    altText: altText?.slice(0, 400) ?? text.slice(0, 400),
+    altText: truncateOptionalTemplateText(altText, 400) ?? truncateTemplateText(text, 400),
     template,
   };
 }
@@ -120,7 +124,7 @@ export function createButtonTemplate(
   });
   const template: ButtonsTemplate = {
     type: "buttons",
-    title: title.slice(0, 40), // LINE limit
+    title: truncateTemplateText(title, 40), // LINE limit
     text: truncateTemplateText(text, textLimit),
     actions: actions.slice(0, 4), // LINE limit: max 4 actions
     thumbnailImageUrl: options?.thumbnailImageUrl,
@@ -132,7 +136,9 @@ export function createButtonTemplate(
 
   return {
     type: "template",
-    altText: options?.altText?.slice(0, 400) ?? `${title}: ${text}`.slice(0, 400),
+    altText:
+      truncateOptionalTemplateText(options?.altText, 400) ??
+      truncateTemplateText(`${title}: ${text}`, 400),
     template,
   };
 }
@@ -157,7 +163,7 @@ export function createTemplateCarousel(
 
   return {
     type: "template",
-    altText: options?.altText?.slice(0, 400) ?? "View carousel",
+    altText: truncateOptionalTemplateText(options?.altText, 400) ?? "View carousel",
     template,
   };
 }
@@ -179,7 +185,7 @@ export function createCarouselColumn(params: {
   // the buttons template already applies above.
   const textLimit = resolveTemplateTextLimit({ ...params, textOnlyLimit: 120 });
   return {
-    title: params.title?.slice(0, 40),
+    title: truncateOptionalTemplateText(params.title, 40),
     text: truncateTemplateText(params.text, textLimit),
     actions: params.actions.slice(0, 3), // LINE limit: max 3 actions per column
     thumbnailImageUrl: params.thumbnailImageUrl,
@@ -202,7 +208,7 @@ export function createImageCarousel(
 
   return {
     type: "template",
-    altText: altText?.slice(0, 400) ?? "View images",
+    altText: truncateOptionalTemplateText(altText, 400) ?? "View images",
     template,
   };
 }

--- a/extensions/line/src/template-messages.ts
+++ b/extensions/line/src/template-messages.ts
@@ -65,7 +65,10 @@ function truncateTemplateText(text: string, limit: number): string {
   return result;
 }
 
-function truncateOptionalTemplateText(value: string | undefined, limit: number): string | undefined {
+function truncateOptionalTemplateText(
+  value: string | undefined,
+  limit: number,
+): string | undefined {
   return value === undefined ? undefined : truncateTemplateText(value, limit);
 }
 


### PR DESCRIPTION
## What Problem This Solves

Line plugin template `title`/`altText` truncation operates on raw UTF-16 code units. When a template title contains an emoji or other astral character near the truncation boundary, the cut splits a surrogate pair and produces a malformed string with a lone surrogate.

## Why This Change Was Made

Truncation boundaries should respect grapheme/code-point boundaries for the same reason other user-facing text does — a lone surrogate breaks downstream rendering, JSON encoding, and copy-paste. Switch the truncation to grapheme boundaries so a multi-code-point character never gets cut mid-character.

## User Impact

Line templates with long titles or alt text that include emoji or astral characters no longer produce broken strings when truncated.

## Evidence

- Local: `pnpm test` on touched line-plugin test file
- Touched files: 2 files, +23/-7
- Branch: `fix/line-template-surrogate-safe`
