### PR TITLE
fix(qqbot): treat escaped pipes as literal content when splitting table cells

### DIFF
--- a/extensions/qqbot/src/engine/messaging/markdown-table-chunking.test.ts
+++ b/extensions/qqbot/src/engine/messaging/markdown-table-chunking.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   chunkQQBotMarkdownText,
   createQQBotMarkdownChunker,
+  testing,
   type QQBotBaseMarkdownChunker,
 } from "./markdown-table-chunking.js";
 
@@ -259,5 +260,26 @@ describe("chunkQQBotMarkdownText", () => {
       ["| Id | Value |", "|---:|---|", "| 1 | alpha |", "| 2 | beta |"].join("\n"),
       "后置说明第一段，表格结束后继续普通文字。\n后置说明第二段。",
     ]);
+  });
+});
+
+describe("table-cell splitting", () => {
+  it("treats a backslash-escaped pipe as literal cell content, not a delimiter", () => {
+    // GFM: `\|` inside a cell is a literal "|", so this row has two cells, not
+    // three. Splitting on every "|" previously mis-counted columns, so the
+    // oversized-row fallback rendered the trailing content under the wrong header.
+    expect(testing.splitTableCells("| a \\| b | c |")).toEqual(["a | b", "c"]);
+  });
+
+  it("leaves ordinary rows unchanged", () => {
+    expect(testing.splitTableCells("| a | b |")).toEqual(["a", "b"]);
+  });
+
+  it("unescapes a literal backslash and still splits on the following pipe", () => {
+    expect(testing.splitTableCells("| a \\\\ | b |")).toEqual(["a \\", "b"]);
+  });
+
+  it("handles escaped pipes in partial (unterminated) rows", () => {
+    expect(testing.splitPartialTableCells("| a \\| b")).toEqual(["a | b"]);
   });
 });

--- a/extensions/qqbot/src/engine/messaging/markdown-table-chunking.ts
+++ b/extensions/qqbot/src/engine/messaging/markdown-table-chunking.ts
@@ -439,19 +439,40 @@ function isTableSeparatorLine(line: string): boolean {
   return cells.length > 0 && cells.every((cell) => /^:?-+:?$/.test(cell.trim()));
 }
 
+// Split a markdown table row's inner text on its column delimiters. A
+// backslash-escaped pipe (`\|`) is literal cell content per GFM, not a column
+// delimiter, so it must not start a new cell; it is unescaped to a bare `|`.
+// (`\\` is likewise unescaped to a single backslash so a following `|` still
+// delimits.) Splitting on every `|` previously mis-counted columns whenever a
+// cell contained an escaped pipe.
+function splitTableRowCells(inner: string): string[] {
+  const cells: string[] = [];
+  let current = "";
+  for (let i = 0; i < inner.length; i++) {
+    const char = inner[i];
+    if (char === "\\" && i + 1 < inner.length) {
+      const next = inner[i + 1];
+      current += next === "|" || next === "\\" ? next : `\\${next}`;
+      i++;
+      continue;
+    }
+    if (char === "|") {
+      cells.push(current);
+      current = "";
+      continue;
+    }
+    current += char;
+  }
+  cells.push(current);
+  return cells;
+}
+
 function splitTableCells(line: string): string[] {
-  const trimmed = line.trim();
-  return trimmed
-    .slice(1, -1)
-    .split("|")
-    .map((cell) => cell.trim());
+  return splitTableRowCells(line.trim().slice(1, -1)).map((cell) => cell.trim());
 }
 
 function splitPartialTableCells(line: string): string[] {
-  const trimmed = line.trim();
-  return trimmed
-    .replace(/^\|/, "")
-    .split("|")
+  return splitTableRowCells(line.trim().replace(/^\|/, ""))
     .map((cell) => cell.trim())
     .filter((cell) => cell.length > 0);
 }
@@ -595,3 +616,6 @@ function isClosingFenceLine(line: string, fence: ActiveFence): boolean {
     match?.[2] && match[2][0] === markerChar && match[2].length >= fence.marker.length,
   );
 }
+
+// Exposed for unit testing of the table-cell splitting logic only.
+export const testing = { splitTableCells, splitPartialTableCells };


### PR DESCRIPTION
## What Problem This Solves

QQBot table-cell splitting treats every `|` as a column separator, including `\|` escapes. Markdown spec says `\|` is a literal pipe inside a table cell. The current splitter drops the escape and breaks cells on the escaped pipe, corrupting table content that legitimately contains pipe characters.

## Why This Change Was Made

`\|` is a documented Markdown escape for a literal pipe in table cells. Treating it as a separator causes data loss whenever cell content contains a pipe (very common in command examples, paths, and code snippets). The fix recognizes `\|` as literal content and only splits on unescaped `|`.

## User Impact

QQBot users sending tables with pipe-containing cells (commands, paths, OR-expressions) see the table render correctly instead of being split mid-content.

## Evidence

- Local: `pnpm test` on touched qqbot test file
- Touched files: 2 files, +55/-9
- Branch: `fix/qqbot-table-escaped-pipe`
