### PR TITLE
fix(ollama): keep tool_calls.function.arguments as JSON string on outbound OpenAI-compat

### DIFF
--- a/extensions/ollama/index.test.ts
+++ b/extensions/ollama/index.test.ts
@@ -1552,6 +1552,71 @@ describe("ollama plugin", () => {
     expect((payloadSeen?.options as Record<string, unknown> | undefined)?.num_ctx).toBe(202752);
   });
 
+  it("keeps tool_calls.function.arguments as a JSON string on outbound OpenAI-compat payloads", () => {
+    const provider = registerProvider();
+    let payloadSeen: Record<string, unknown> | undefined;
+    const baseStreamFn = vi.fn((_model, _context, options) => {
+      // OpenAI-completions already emits arguments as a JSON string (per OpenAI spec).
+      const payload: Record<string, unknown> = {
+        options: { temperature: 0.1 },
+        messages: [
+          {
+            role: "assistant",
+            tool_calls: [
+              {
+                id: "call_1",
+                type: "function",
+                function: {
+                  name: "config_get",
+                  arguments: '{"action":"config.get","path":"gateway.port"}',
+                },
+              },
+            ],
+          },
+        ],
+      };
+      options?.onPayload?.(payload, _model);
+      payloadSeen = payload;
+      return {} as never;
+    });
+
+    const wrapped = provider.wrapStreamFn?.({
+      config: {
+        models: {
+          providers: {
+            ollama: {
+              api: "openai-completions",
+              baseUrl: "http://127.0.0.1:11434/v1",
+              models: [],
+            },
+          },
+        },
+      },
+      provider: "ollama",
+      modelId: "glm-5.2:cloud",
+      model: {
+        api: "openai-completions",
+        provider: "ollama",
+        id: "glm-5.2:cloud",
+        baseUrl: "http://127.0.0.1:11434/v1",
+        contextWindow: 128_000,
+      },
+      streamFn: baseStreamFn,
+    });
+
+    if (!wrapped) {
+      throw new Error("expected Ollama OpenAI-compatible stream wrapper");
+    }
+    void wrapped({} as never, {} as never, {});
+
+    const messages = payloadSeen?.messages as
+      | Array<{ tool_calls: Array<{ function: { arguments: unknown } }> }>
+      | undefined;
+    const args = messages?.[0]?.tool_calls?.[0]?.function.arguments;
+    expect(typeof args).toBe("string");
+    expect(args).toBe('{"action":"config.get","path":"gateway.port"}');
+  });
+
   it("owns replay policy for OpenAI-compatible and native Ollama routes", () => {
     const provider = registerProvider();
 

--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -247,7 +247,6 @@ export function wrapOllamaCompatNumCtx(baseFn: StreamFn | undefined, numCtx: num
         payloadRecord.options = {};
       }
       (payloadRecord.options as Record<string, unknown>).num_ctx = numCtx;
-      normalizeOllamaCompatMessageToolArgs(payloadRecord);
     });
 }
 
@@ -739,46 +738,6 @@ function ensureArgsObject(value: unknown): Record<string, unknown> {
 
 function normalizeOllamaToolCallArguments(value: unknown): Record<string, unknown> {
   return ensureArgsObject(value);
-}
-
-function normalizeOllamaCompatMessageToolArgs(payloadRecord: Record<string, unknown>): void {
-  const messages = payloadRecord.messages;
-  if (!Array.isArray(messages)) {
-    return;
-  }
-
-  for (const message of messages) {
-    if (!message || typeof message !== "object" || Array.isArray(message)) {
-      continue;
-    }
-    const messageRecord = message as Record<string, unknown>;
-
-    const functionCall = messageRecord.function_call;
-    if (functionCall && typeof functionCall === "object" && !Array.isArray(functionCall)) {
-      const functionCallRecord = functionCall as Record<string, unknown>;
-      if (Object.hasOwn(functionCallRecord, "arguments")) {
-        functionCallRecord.arguments = ensureArgsObject(functionCallRecord.arguments);
-      }
-    }
-
-    const toolCalls = messageRecord.tool_calls;
-    if (!Array.isArray(toolCalls)) {
-      continue;
-    }
-    for (const toolCall of toolCalls) {
-      if (!toolCall || typeof toolCall !== "object" || Array.isArray(toolCall)) {
-        continue;
-      }
-      const functionSpec = (toolCall as Record<string, unknown>).function;
-      if (!functionSpec || typeof functionSpec !== "object" || Array.isArray(functionSpec)) {
-        continue;
-      }
-      const functionRecord = functionSpec as Record<string, unknown>;
-      if (Object.hasOwn(functionRecord, "arguments")) {
-        functionRecord.arguments = ensureArgsObject(functionRecord.arguments);
-      }
-    }
-  }
 }
 
 function inferOllamaSchemaType(schema: Record<string, unknown>): string | undefined {


### PR DESCRIPTION
## What Problem This Solves

Fixes #96441 — Ollama Cloud tool calls fail on the 2nd agent turn with `400 json: cannot unmarshal object into Go struct field .messages.tool_calls.function.arguments of type string`.

Working in 2026.6.8, broken from 2026.6.9 onwards. Root cause was a regression where the outbound OpenAI-compat payload wrapper mutated `tool_calls[].function.arguments` from the spec-required JSON string into a JSON object. Ollama's cloud Go server enforces the OpenAI spec strictly and rejects the object form, while most other providers accept both forms.

## Why This Change Was Made

`wrapOllamaCompatNumCtx` is an outbound stream wrapper that adds `num_ctx` to Ollama OpenAI-compat request payloads. It also called `normalizeOllamaCompatMessageToolArgs(payloadRecord)`, which walked `messages[]` and rewrote every `tool_calls[].function.arguments` (and legacy `function_call.arguments`) from string to object via `ensureArgsObject`.

The normalization was wrong for the outbound direction: `src/llm/providers/openai-completions.ts:1084` already produces `arguments: JSON.stringify(tc.arguments)` per the OpenAI Chat Completions API contract. Converting it to an object on the way out breaks strict-spec consumers.

The fix removes the outbound call and the now-dead helper. Inbound response parsing still uses `ensureArgsObject` (lines 907, 916, 1070 in `extensions/ollama/src/stream.ts`) because Ollama can legitimately return `arguments` as either a string or an object on the response side.

## User Impact

- Ollama Cloud models (e.g. `ollama/glm-5.2:cloud`, `ollama/glm-5.1:cloud`, `ollama/minimax-m3:cloud`) work again on multi-turn tool-calling conversations.
- Direct non-Ollama providers were unaffected because they accept both forms.
- No new config surface, no behavior change for the inbound parsing path.

## Evidence

**Regression test** (`extensions/ollama/index.test.ts`):

```
✓ |ollama| ollama plugin > keeps tool_calls.function.arguments as a JSON string on outbound OpenAI-compat payloads
```

Test sets up the OpenAI-compat stream wrapper, captures the patched outbound payload, and asserts `typeof args === "string"` and that the string matches the original JSON encoding. Pre-fix this test fails because the wrapper rewrites arguments to an object.

**Full ollama suite**:
```
Test Files  1 passed (1)
     Tests  57 passed (57)
```

No existing test depended on the broken outbound mutation.

## Notes

- Branch HEAD: `ca543c1f`
- Source change: 1 line removed from `wrapOllamaCompatNumCtx`, plus 40 lines of dead helper code deleted.
- Test change: +60 lines (one regression test).