### PR TITLE
perf(doctor): count session lock states in one pass

### DIFF
--- a/src/commands/doctor-session-locks.ts
+++ b/src/commands/doctor-session-locks.ts
@@ -139,8 +139,16 @@ export async function noteSessionLockHealth(params?: {
     return;
   }
 
-  const staleCount = allLocks.filter((lock) => lock.stale).length;
-  const removedCount = allLocks.filter((lock) => lock.removed).length;
+  let staleCount = 0;
+  let removedCount = 0;
+  for (const lock of allLocks) {
+    if (lock.stale) {
+      staleCount += 1;
+    }
+    if (lock.removed) {
+      removedCount += 1;
+    }
+  }
   const lines: string[] = [
     `- Found ${allLocks.length} session lock file${allLocks.length === 1 ? "" : "s"}.`,
     ...allLocks.toSorted((a, b) => a.lockPath.localeCompare(b.lockPath)).map(formatLockLine),


### PR DESCRIPTION
## What Problem This Solves

Doctor session lock health reporting counted stale and removed lock states with separate full-array scans. On large workspaces with many session locks, that adds avoidable repeated traversal in a diagnostic path operators use when troubleshooting lock cleanup.

## Why This Change Was Made

This keeps the existing report semantics and sorted output intact while collecting stale and removed counts in the same pass over inspected locks. The change stays inside the doctor session-lock reporting boundary.

## User Impact

Operators get the same doctor output with less unnecessary work when many session lock files are present.

## Evidence

- `git diff --check origin/main...HEAD`
- `node scripts/run-vitest.mjs src/commands/doctor-session-locks.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` clean, no accepted/actionable findings
