### PR TITLE
perf(status): collect token summary accounts in one pass

### DIFF
--- a/src/commands/status-all/channels-token-summary.ts
+++ b/src/commands/status-all/channels-token-summary.ts
@@ -52,12 +52,19 @@ export function summarizeTokenConfig(params: {
   accounts: ChannelAccountTokenSummaryRow[];
   showSecrets: boolean;
 }): { state: "ok" | "setup" | "warn" | null; detail: string | null } {
-  const enabled = params.accounts.filter((a) => a.enabled);
+  const enabled: ChannelAccountTokenSummaryRow[] = [];
+  const accountRecs: Record<string, unknown>[] = [];
+  for (const account of params.accounts) {
+    if (!account.enabled) {
+      continue;
+    }
+    enabled.push(account);
+    accountRecs.push(asRecord(account.account));
+  }
   if (enabled.length === 0) {
     return { state: null, detail: null };
   }
 
-  const accountRecs = enabled.map((a) => asRecord(a.account));
   // Token field names are plugin-owned; infer the credential mode from the fields the plugin exposes.
   const hasBotTokenField = accountRecs.some((r) => "botToken" in r);
   const hasAppTokenField = accountRecs.some((r) => "appToken" in r);


### PR DESCRIPTION
## What Problem This Solves

`openclaw status --all` summarizes channel token configuration across enabled accounts. The token summary path built the enabled account list and then mapped it again to records, doing avoidable repeated traversal in a status command that may inspect many configured accounts.

## Why This Change Was Made

This keeps credential-source inference unchanged while collecting enabled rows and account records together in one pass. The change stays inside the status-all channel token summary helper and does not alter token display or secret redaction behavior.

## User Impact

Users and operators see the same status output with less unnecessary work when many channel accounts are configured.

## Evidence

- `git diff --check origin/main...HEAD`
- `node scripts/run-vitest.mjs src/commands/status-all/channels.mattermost-token-summary.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` clean, no accepted/actionable findings
