### PR TITLE
perf(gateway): classify status warning probes in one pass

### DIFF
--- a/src/commands/gateway-status/output.ts
+++ b/src/commands/gateway-status/output.ts
@@ -90,13 +90,20 @@ export function buildGatewayStatusWarnings(params: {
   localTlsLoadError?: string | null;
   discoveryCount?: number;
 }): GatewayStatusWarning[] {
-  const reachable = params.probed.filter((entry) => isProbeReachable(entry.probe));
-  const degradedScopeLimited = params.probed.filter((entry) =>
-    isScopeLimitedProbeFailure(entry.probe),
-  );
-  const degradedDetailFailed = params.probed.filter(
-    (entry) => isPostConnectProbeFailure(entry.probe) && !isScopeLimitedProbeFailure(entry.probe),
-  );
+  const reachable: GatewayStatusProbedTarget[] = [];
+  const degradedScopeLimited: GatewayStatusProbedTarget[] = [];
+  const degradedDetailFailed: GatewayStatusProbedTarget[] = [];
+  for (const entry of params.probed) {
+    if (isProbeReachable(entry.probe)) {
+      reachable.push(entry);
+    }
+    const scopeLimited = isScopeLimitedProbeFailure(entry.probe);
+    if (scopeLimited) {
+      degradedScopeLimited.push(entry);
+    } else if (isPostConnectProbeFailure(entry.probe)) {
+      degradedDetailFailed.push(entry);
+    }
+  }
   const warnings: GatewayStatusWarning[] = [];
   if (params.sshTarget && !params.sshTunnelStarted) {
     warnings.push({


### PR DESCRIPTION
## What Problem This Solves

Gateway status warning generation classified probed targets with several independent filter passes. That repeated the same probe classification work when status output includes multiple probed endpoints.

## Why This Change Was Made

This preserves the warning buckets and ordering while classifying reachable, scope-limited, and detail-failed probes in a single pass. The change is limited to gateway status output formatting.

## User Impact

Users get the same gateway status warnings with less repeated work when multiple endpoints are probed.

## Evidence

- `git diff --check origin/main...HEAD`
- `node scripts/run-vitest.mjs src/commands/gateway-status/output.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` clean, no accepted/actionable findings
