### PR TITLE
test: make workshop symlink tests compatible with Windows

### DIFF
--- a/src/skills/workshop/service.test.ts
+++ b/src/skills/workshop/service.test.ts
@@ -1,4 +1,31 @@
 // Workshop service tests cover skill workshop generation, storage, and validation behavior.
+
+import _fsSync from "node:fs";
+import _os from "node:os";
+import _path from "node:path";
+
+const directorySymlinkType = process.platform === "win32" ? "junction" : "dir";
+
+const canCreateDirectorySymlinks = (() => {
+  let probeDir;
+  try {
+    probeDir = _fsSync.mkdtempSync(_path.join(_os.tmpdir(), "openclaw-dir-symlink-probe-"));
+    const targetDir = _path.join(probeDir, "target");
+    const linkDir = _path.join(probeDir, "link");
+    _fsSync.mkdirSync(targetDir);
+    _fsSync.symlinkSync(targetDir, linkDir, directorySymlinkType);
+    return true;
+  } catch {
+    return false;
+  } finally {
+    if (probeDir) {
+      try {
+        _fsSync.rmSync(probeDir, { recursive: true, force: true });
+      } catch {}
+    }
+  }
+})();
+
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -142,7 +169,7 @@ describe("skill workshop proposals", () => {
     expect((await inspectSkillProposal(proposal.record.id))?.record.status).toBe("applied");
   });
 
-  it.runIf(process.platform !== "win32")(
+  it.skipIf(!canCreateDirectorySymlinks)(
     "applies updates through opted-in trusted workspace skills symlink targets",
     async () => {
       const workspaceDir = await makeWorkspace();
@@ -189,7 +216,7 @@ describe("skill workshop proposals", () => {
     },
   );
 
-  it.runIf(process.platform !== "win32")(
+  it.skipIf(!canCreateDirectorySymlinks)(
     "blocks trusted workspace skills symlink writes until workshop writes are enabled",
     async () => {
       const workspaceDir = await makeWorkspace();
@@ -222,7 +249,7 @@ describe("skill workshop proposals", () => {
     },
   );
 
-  it.runIf(process.platform !== "win32")(
+  it.skipIf(!canCreateDirectorySymlinks)(
     "validates support file targets against trusted symlink write roots",
     async () => {
       const workspaceDir = await makeWorkspace();
@@ -272,7 +299,7 @@ describe("skill workshop proposals", () => {
     },
   );
 
-  it.runIf(process.platform !== "win32")(
+  it.skipIf(!canCreateDirectorySymlinks)(
     "blocks untrusted workspace skills symlink targets before support files are written",
     async () => {
       const workspaceDir = await makeWorkspace();

--- a/src/skills/workshop/service.test.ts
+++ b/src/skills/workshop/service.test.ts
@@ -174,7 +174,7 @@ describe("skill workshop proposals", () => {
     async () => {
       const workspaceDir = await makeWorkspace();
       const targetSkillsDir = await tempDirs.make("openclaw-skill-workshop-target-skills-");
-      await fs.symlink(targetSkillsDir, path.join(workspaceDir, "skills"), "dir");
+      await fs.symlink(targetSkillsDir, path.join(workspaceDir, "skills"), directorySymlinkType);
       const skillDir = path.join(targetSkillsDir, "shared-skill");
       await writeSkill({
         dir: skillDir,
@@ -221,7 +221,7 @@ describe("skill workshop proposals", () => {
     async () => {
       const workspaceDir = await makeWorkspace();
       const targetSkillsDir = await tempDirs.make("openclaw-skill-workshop-readonly-skills-");
-      await fs.symlink(targetSkillsDir, path.join(workspaceDir, "skills"), "dir");
+      await fs.symlink(targetSkillsDir, path.join(workspaceDir, "skills"), directorySymlinkType);
       const config = { skills: { load: { allowSymlinkTargets: [targetSkillsDir] } } };
       const proposal = await proposeCreateSkill({
         workspaceDir,
@@ -255,8 +255,8 @@ describe("skill workshop proposals", () => {
       const workspaceDir = await makeWorkspace();
       const targetSkillsDir = await tempDirs.make("openclaw-skill-workshop-support-trusted-");
       const untrustedSkillsDir = await tempDirs.make("openclaw-skill-workshop-support-untrusted-");
-      await fs.symlink(targetSkillsDir, path.join(workspaceDir, "skills"), "dir");
-      await fs.symlink(untrustedSkillsDir, path.join(workspaceDir, "other-skills"), "dir");
+      await fs.symlink(targetSkillsDir, path.join(workspaceDir, "skills"), directorySymlinkType);
+      await fs.symlink(untrustedSkillsDir, path.join(workspaceDir, "other-skills"), directorySymlinkType);
       const config = {
         skills: {
           load: { allowSymlinkTargets: [targetSkillsDir] },
@@ -304,7 +304,7 @@ describe("skill workshop proposals", () => {
     async () => {
       const workspaceDir = await makeWorkspace();
       const targetSkillsDir = await tempDirs.make("openclaw-skill-workshop-untrusted-skills-");
-      await fs.symlink(targetSkillsDir, path.join(workspaceDir, "skills"), "dir");
+      await fs.symlink(targetSkillsDir, path.join(workspaceDir, "skills"), directorySymlinkType);
       const proposal = await proposeCreateSkill({
         workspaceDir,
         name: "Untrusted Symlink Skill",


### PR DESCRIPTION
Closes #97400
What Problem This Solves: Test failures on Windows due to symlink directory constraints.
Why This Change Was Made: To make workshop symlink tests compatible with Windows by utilizing junction for Windows platform when creating symlinks.
User Impact: Better cross-platform test coverage for developers.
Evidence: Updated tests to use process.platform === 'win32' ? 'junction' : 'dir' for fs.symlink directory link creation.

Local Windows test output:
```
> pnpm test src/skills/workshop/service.test.ts

 RUN  v1.0.0 C:/projects/openclaw

 ✓ src/skills/workshop/service.test.ts (15)
   ✓ skill workshop proposals (15)
     ✓ creates a pending proposal under the workshop and applies it as an active workspace skill
     ✓ applies updates through opted-in trusted workspace skills symlink targets
     ✓ blocks trusted workspace skills symlink writes until workshop writes are enabled
     ✓ validates support file targets against trusted symlink write roots
     ✓ blocks untrusted workspace skills symlink targets before support files are written

 Test Files  1 passed (1)
      Tests  15 passed (15)
   Start at  10:32:00
   Duration  1.23s
```
