### PR TITLE
test: make workspace-load symlink tests compatible with Windows

### DIFF
--- a/src/skills/loading/workspace-load.test.ts
+++ b/src/skills/loading/workspace-load.test.ts
@@ -1,4 +1,51 @@
 // Workspace load tests cover loading skills from workspace directories and manifests.
+
+import _fsSync from "node:fs";
+import _os from "node:os";
+import _path from "node:path";
+
+const directorySymlinkType = process.platform === "win32" ? "junction" : "dir";
+
+const canCreateDirectorySymlinks = (() => {
+  let probeDir;
+  try {
+    probeDir = _fsSync.mkdtempSync(_path.join(_os.tmpdir(), "openclaw-dir-symlink-probe-"));
+    const targetDir = _path.join(probeDir, "target");
+    const linkDir = _path.join(probeDir, "link");
+    _fsSync.mkdirSync(targetDir);
+    _fsSync.symlinkSync(targetDir, linkDir, directorySymlinkType);
+    return true;
+  } catch {
+    return false;
+  } finally {
+    if (probeDir) {
+      try {
+        _fsSync.rmSync(probeDir, { recursive: true, force: true });
+      } catch {}
+    }
+  }
+})();
+
+const canCreateFileSymlinks = (() => {
+  let probeDir;
+  try {
+    probeDir = _fsSync.mkdtempSync(_path.join(_os.tmpdir(), "openclaw-file-symlink-probe-"));
+    const targetFile = _path.join(probeDir, "target.txt");
+    const linkFile = _path.join(probeDir, "link.txt");
+    _fsSync.writeFileSync(targetFile, "content");
+    _fsSync.symlinkSync(targetFile, linkFile);
+    return true;
+  } catch {
+    return false;
+  } finally {
+    if (probeDir) {
+      try {
+        _fsSync.rmSync(probeDir, { recursive: true, force: true });
+      } catch {}
+    }
+  }
+})();
+
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
@@ -272,7 +319,7 @@ async function createEscapedBundledSkillFixture(params?: {
   });
   await fs.mkdir(bundledDir, { recursive: true });
   const requestedPath = path.join(bundledDir, "escaped-bundled-skill");
-  await fs.symlink(escapedSkillDir, requestedPath, "dir");
+  await fs.symlink(escapedSkillDir, requestedPath, directorySymlinkType);
   return { workspaceDir, outsideDir, bundledDir, escapedSkillDir, requestedPath };
 }
 
@@ -489,7 +536,7 @@ describe("loadWorkspaceSkillEntries", () => {
     expect(entries.map((entry) => entry.skill.name)).toEqual(["local-only"]);
   });
 
-  it.runIf(process.platform !== "win32")(
+  it.skipIf(!canCreateDirectorySymlinks || !canCreateFileSymlinks)(
     "skips workspace skill paths that resolve outside the workspace root",
     async () => {
       const workspaceDir = await createTempWorkspaceDir();
@@ -502,7 +549,7 @@ describe("loadWorkspaceSkillEntries", () => {
       });
       await fs.mkdir(path.join(workspaceDir, "skills"), { recursive: true });
       const requestedPath = path.join(workspaceDir, "skills", "escaped-skill");
-      await fs.symlink(escapedSkillDir, requestedPath, "dir");
+      await fs.symlink(escapedSkillDir, requestedPath, directorySymlinkType);
       const fileLinkSkillDir = path.join(workspaceDir, "skills", "escaped-file");
       await fs.mkdir(fileLinkSkillDir, { recursive: true });
       await fs.symlink(path.join(outsideDir, "SKILL.md"), path.join(fileLinkSkillDir, "SKILL.md"));
@@ -532,7 +579,7 @@ describe("loadWorkspaceSkillEntries", () => {
     },
   );
 
-  it.runIf(process.platform !== "win32")(
+  it.skipIf(!canCreateDirectorySymlinks)(
     "allows configured skill symlink targets outside their source root",
     async () => {
       const workspaceDir = await createTempWorkspaceDir();
@@ -547,7 +594,7 @@ describe("loadWorkspaceSkillEntries", () => {
       const workspaceSkillsDir = path.join(workspaceDir, "skills");
       await fs.mkdir(workspaceSkillsDir, { recursive: true });
       const symlinkPath = path.join(workspaceSkillsDir, skillName);
-      await fs.symlink(targetSkillDir, symlinkPath, "dir");
+      await fs.symlink(targetSkillDir, symlinkPath, directorySymlinkType);
       const warn = captureWarningLogger();
 
       try {
@@ -569,7 +616,7 @@ describe("loadWorkspaceSkillEntries", () => {
     },
   );
 
-  it.runIf(process.platform !== "win32")(
+  it.skipIf(!canCreateDirectorySymlinks)(
     "loads managed skill directory symlinks outside the managed root",
     async () => {
       const workspaceDir = await createTempWorkspaceDir();
@@ -583,7 +630,7 @@ describe("loadWorkspaceSkillEntries", () => {
       });
       await fs.mkdir(managedDir, { recursive: true });
       const symlinkPath = path.join(managedDir, skillName);
-      await fs.symlink(targetSkillDir, symlinkPath, "dir");
+      await fs.symlink(targetSkillDir, symlinkPath, directorySymlinkType);
       const warn = captureWarningLogger();
 
       try {
@@ -599,7 +646,7 @@ describe("loadWorkspaceSkillEntries", () => {
     },
   );
 
-  it.runIf(process.platform !== "win32")(
+  it.skipIf(!canCreateDirectorySymlinks || !canCreateFileSymlinks)(
     "keeps SKILL.md containment for managed symlinked skill directories",
     async () => {
       const workspaceDir = await createTempWorkspaceDir();
@@ -617,7 +664,7 @@ describe("loadWorkspaceSkillEntries", () => {
       await fs.symlink(path.join(outsideDir, "SKILL.md"), path.join(targetSkillDir, "SKILL.md"));
       await fs.mkdir(managedDir, { recursive: true });
       const symlinkPath = path.join(managedDir, skillName);
-      await fs.symlink(targetSkillDir, symlinkPath, "dir");
+      await fs.symlink(targetSkillDir, symlinkPath, directorySymlinkType);
       const warn = captureWarningLogger();
 
       try {
@@ -636,7 +683,7 @@ describe("loadWorkspaceSkillEntries", () => {
     },
   );
 
-  it.runIf(process.platform !== "win32")(
+  it.skipIf(!canCreateDirectorySymlinks)(
     "calls out bundled symlink escapes with compact home-relative paths",
     async () => {
       const { workspaceDir, bundledDir, requestedPath } = await createEscapedBundledSkillFixture();
@@ -657,7 +704,7 @@ describe("loadWorkspaceSkillEntries", () => {
     },
   );
 
-  it.runIf(process.platform !== "win32")(
+  it.skipIf(!canCreateDirectorySymlinks)(
     "uses compact home-relative paths in escaped skill console warnings",
     async () => {
       const { workspaceDir, bundledDir } = await createEscapedBundledSkillFixture({
@@ -677,7 +724,7 @@ describe("loadWorkspaceSkillEntries", () => {
     },
   );
 
-  it.runIf(process.platform !== "win32")(
+  it.skipIf(!canCreateDirectorySymlinks)(
     "reads skill frontmatter when the allowed root is the filesystem root",
     async () => {
       const workspaceDir = await createTempWorkspaceDir();
@@ -961,7 +1008,7 @@ describe("loadWorkspaceSkillEntries", () => {
       expect(names).not.toContain("outside-child");
     });
 
-    it.runIf(process.platform !== "win32")(
+    it.skipIf(!canCreateDirectorySymlinks)(
       "does not follow outside symlink dirs during repo-root detection",
       async () => {
         const workspaceDir = await createTempWorkspaceDir();
@@ -993,7 +1040,7 @@ describe("loadWorkspaceSkillEntries", () => {
       },
     );
 
-    it.runIf(process.platform !== "win32")(
+    it.skipIf(!canCreateDirectorySymlinks)(
       "keeps configured roots with possible symlink skills outside nested skills",
       async () => {
         const workspaceDir = await createTempWorkspaceDir();

--- a/src/skills/loading/workspace-load.test.ts
+++ b/src/skills/loading/workspace-load.test.ts
@@ -1020,7 +1020,7 @@ describe("loadWorkspaceSkillEntries", () => {
           description: "Outside linked skill",
         });
         await fs.mkdir(path.join(repoDir, "examples"), { recursive: true });
-        await fs.symlink(outsideDir, path.join(repoDir, "examples", "linked"), "dir");
+        await fs.symlink(outsideDir, path.join(repoDir, "examples", "linked"), directorySymlinkType);
         await writeSkill({
           dir: path.join(repoDir, "skills", "group", "valid"),
           name: "repo-nested-skill",
@@ -1053,7 +1053,7 @@ describe("loadWorkspaceSkillEntries", () => {
           description: "Allowed linked skill",
         });
         await fs.mkdir(path.join(repoDir, "group"), { recursive: true });
-        await fs.symlink(targetSkillDir, path.join(repoDir, "group", "linked-skill"), "dir");
+        await fs.symlink(targetSkillDir, path.join(repoDir, "group", "linked-skill"), directorySymlinkType);
         await writeSkill({
           dir: path.join(repoDir, "skills", "group", "valid"),
           name: "repo-nested-skill",


### PR DESCRIPTION
﻿Related: #97437

### What Problem This Solves

Fixes an issue where several workspace-load symlink boundary tests were unconditionally skipped on Windows environments, even if the environment supports creating file and directory symlinks (like with Developer Mode enabled).

### Why This Change Was Made

Replaces the hardcoded `process.platform !== "win32"` skips with dynamic capability checks (`canCreateDirectorySymlinks` and `canCreateFileSymlinks`). If file and directory symlinks are supported by the environment, the tests execute. Otherwise, they skip gracefully while keeping coverage active on capable hosts. Additionally, replaces literal "dir" arguments in symlink calls with the OS-appropriate directorySymlinkType to ensure tests run properly on Windows.

### User Impact

No user-visible product impact. This improves test portability and preserves regression coverage on capable Windows environments.

### Evidence

Tests run successfully on Windows when directory junctions are supported.
Test output from a Windows environment:
``
 ✓ src/skills/loading/workspace-load.test.ts (29)
   ✓ loadWorkspaceSkillEntries (29)
     ✓ loads direct skills under skills directory (skills/skill.md)
     ✓ keeps loading direct skills (skills/skill/SKILL.md) unchanged
...
 Test Files  1 passed (1)
      Tests  29 passed (29)
   Start at  08:04:21
   Duration  2.41s
``
Code conforms to existing symlink capability patterns by using directorySymlinkType.
