### PR TITLE
test: make marketplace symlink tests compatible with Windows

### DIFF
--- a/src/plugins/marketplace.test.ts
+++ b/src/plugins/marketplace.test.ts
@@ -1,4 +1,31 @@
 // Covers plugin marketplace catalog loading and validation.
+
+import _fsSync from "node:fs";
+import _os from "node:os";
+import _path from "node:path";
+
+const directorySymlinkType = process.platform === "win32" ? "junction" : "dir";
+
+const canCreateDirectorySymlinks = (() => {
+  let probeDir;
+  try {
+    probeDir = _fsSync.mkdtempSync(_path.join(_os.tmpdir(), "openclaw-dir-symlink-probe-"));
+    const targetDir = _path.join(probeDir, "target");
+    const linkDir = _path.join(probeDir, "link");
+    _fsSync.mkdirSync(targetDir);
+    _fsSync.symlinkSync(targetDir, linkDir, directorySymlinkType);
+    return true;
+  } catch {
+    return false;
+  } finally {
+    if (probeDir) {
+      try {
+        _fsSync.rmSync(probeDir, { recursive: true, force: true });
+      } catch {}
+    }
+  }
+})();
+
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -653,7 +680,7 @@ describe("marketplace plugins", () => {
     });
   });
 
-  it.runIf(process.platform !== "win32")(
+  it.skipIf(!canCreateDirectorySymlinks)(
     "rejects remote marketplace plugin paths that resolve through symlinks outside the cloned repo",
     async () => {
       mockRemoteMarketplaceCloneWithOutsideSymlink({
@@ -1269,7 +1296,7 @@ describe("marketplace plugins", () => {
     await expectRemoteMarketplaceError({ manifest, expectedError });
   });
 
-  it.runIf(process.platform !== "win32")(
+  it.skipIf(!canCreateDirectorySymlinks)(
     "rejects remote marketplace symlink plugin paths during manifest validation",
     async () => {
       mockRemoteMarketplaceCloneWithOutsideSymlink({

--- a/src/plugins/marketplace.test.ts
+++ b/src/plugins/marketplace.test.ts
@@ -165,7 +165,7 @@ function mockRemoteMarketplaceCloneWithOutsideSymlink(params: {
     await fs.mkdir(path.dirname(path.join(repoDir as string, params.symlinkPath)), {
       recursive: true,
     });
-    await fs.symlink(outsideDir, path.join(repoDir as string, params.symlinkPath));
+    await fs.symlink(outsideDir, path.join(repoDir as string, params.symlinkPath), directorySymlinkType);
     return { code: 0, stdout: "", stderr: "", killed: false };
   });
 }


### PR DESCRIPTION
��Closes #95534

## What Problem This Solves

Fixes an issue where several marketplace plugin symlink boundary tests were unconditionally skipped on Windows environments, even if the environment supports creating directory symlinks (like with Developer Mode enabled).

## Why This Change Was Made

Replaces the hardcoded Windows skips with a dynamic capability check (canCreateDirectorySymlinks) and explicitly passes directorySymlinkType to s.symlink when creating the test fixture, so that it creates a junction on Windows and matches the canCreateDirectorySymlinks probe logic.

## User Impact

No user-visible product impact. This improves test portability and preserves regression coverage on capable Windows environments.

## Evidence

- Fixed the mockRemoteMarketplaceCloneWithOutsideSymlink test fixture to use directorySymlinkType matching the probe.
- Ran 
ode scripts/run-vitest.mjs src/plugins/marketplace.test.ts locally and it exited successfully without errors.
- Pushed the commit so that CI will provide remote test evidence as required.

@clawsweeper re-review
