### PR TITLE
fix(agents): attach read tool images to replies

### DIFF
--- a/src/agents/embedded-agent-subscribe.handlers.tools.media.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.media.test.ts
@@ -7,6 +7,13 @@ import {
 } from "./embedded-agent-subscribe.handlers.tools.js";
 import type { EmbeddedAgentSubscribeContext } from "./embedded-agent-subscribe.handlers.types.js";
 
+const saveMediaBufferMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../media/store.js", () => ({
+  saveMediaBuffer: saveMediaBufferMock,
+}));
+
+
 function createMockContext(overrides?: {
   shouldEmitToolOutput?: boolean;
   onToolResult?: ReturnType<typeof vi.fn>;
@@ -708,4 +715,41 @@ describe("handleToolExecutionEnd media emission", () => {
     expect(ctx.state.pendingToolAudioAsVoice).toBe(true);
     expect(ctx.state.pendingToolTrustedLocalMedia).toBe(true);
   });
+  it("persists read tool image content and queues it as inbound media", async () => {
+    saveMediaBufferMock.mockResolvedValueOnce({
+      id: "read-image.png",
+      path: "/state/media/inbound/read-image.png",
+      size: 8,
+      contentType: "image/png",
+    });
+    const onToolResult = vi.fn();
+    const ctx = createMockContext({
+      shouldEmitToolOutput: false,
+      onToolResult,
+      builtinToolNames: new Set(["read"]),
+    });
+
+    await handleToolExecutionEnd(ctx, {
+      type: "tool_execution_end",
+      toolName: "read",
+      toolCallId: "tc-1",
+      isError: false,
+      result: {
+        content: [
+          { type: "text", text: "Read image file [image/png]" },
+          { type: "image", data: "iVBORw0KGgo=", mimeType: "image/png" },
+        ],
+      },
+    });
+
+    expect(onToolResult).not.toHaveBeenCalled();
+    expect(saveMediaBufferMock).toHaveBeenCalledWith(
+      Buffer.from("iVBORw0KGgo=", "base64"),
+      "image/png",
+      "inbound",
+    );
+    expect(ctx.state.pendingToolMediaUrls).toEqual(["media://inbound/read-image.png"]);
+    expect(ctx.state.pendingToolTrustedLocalMedia).toBe(true);
+  });
+
 });

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -63,6 +63,7 @@ import {
   collectMessagingMediaUrlsFromRecord,
   collectMessagingMediaUrlsFromToolResult,
   extractMessagingToolSourceReplyPayload,
+  extractReadToolImageContentMediaArtifact,
   extractToolResultMediaArtifact,
   extractToolErrorCode,
   extractMessagingToolSend,
@@ -737,7 +738,17 @@ async function emitToolResultOutput(params: {
   }
 
   const outputText = extractToolResultText(sanitizedResult);
-  const mediaReply = isToolError ? undefined : extractToolResultMediaArtifact(result);
+  const mediaReply = isToolError
+    ? undefined
+    : (extractToolResultMediaArtifact(result) ??
+      (await extractReadToolImageContentMediaArtifact({
+        toolName: rawToolName,
+        result,
+        builtinToolNames: ctx.builtinToolNames,
+      }).catch((err) => {
+        ctx.log.warn(`failed to persist read tool image media: ${String(err)}`);
+        return undefined;
+      })));
   const mediaUrls = mediaReply
     ? filterToolResultMediaUrls(
         rawToolName,

--- a/src/agents/embedded-agent-subscribe.tools.ts
+++ b/src/agents/embedded-agent-subscribe.tools.ts
@@ -19,6 +19,8 @@ import {
   redactSensitiveFieldValue,
   redactToolPayloadText,
 } from "../logging/redact.js";
+import { canonicalizeBase64 } from "@openclaw/media-core/base64";
+import { saveMediaBuffer } from "../media/store.js";
 import { truncateUtf16Safe } from "../utils.js";
 import { collectTextContentBlocks } from "./content-blocks.js";
 import { isMessagingToolTargetEvidenceAction } from "./embedded-agent-messaging.js";
@@ -802,6 +804,71 @@ export function extractToolResultMediaArtifact(
 
   return undefined;
 }
+
+function collectToolResultImageBlocks(result: unknown): Array<{ data: string; mimeType: string }> {
+  if (!result || typeof result !== "object") {
+    return [];
+  }
+  const content = Array.isArray((result as Record<string, unknown>).content)
+    ? ((result as Record<string, unknown>).content as unknown[])
+    : [];
+  const images: Array<{ data: string; mimeType: string }> = [];
+  for (const item of content) {
+    if (!item || typeof item !== "object") {
+      continue;
+    }
+    const entry = item as Record<string, unknown>;
+    if (entry.type !== "image" || typeof entry.data !== "string") {
+      continue;
+    }
+    const mimeType = normalizeOptionalString(entry.mimeType);
+    if (!mimeType) {
+      continue;
+    }
+    const data = canonicalizeBase64(entry.data);
+    if (!data) {
+      continue;
+    }
+    images.push({ data, mimeType });
+  }
+  return images;
+}
+
+export async function extractReadToolImageContentMediaArtifact(params: {
+  toolName: string | undefined;
+  result: unknown;
+  builtinToolNames?: ReadonlySet<string>;
+}): Promise<ToolResultMediaArtifact | undefined> {
+  const rawToolName = params.toolName?.trim();
+  if (
+    rawToolName !== "read" ||
+    params.builtinToolNames?.has(rawToolName) === false ||
+    !isToolResultMediaTrusted(rawToolName, params.result)
+  ) {
+    return undefined;
+  }
+  if (extractToolResultMediaArtifact(params.result)) {
+    return undefined;
+  }
+  const images = collectToolResultImageBlocks(params.result);
+  if (images.length === 0) {
+    return undefined;
+  }
+  const mediaUrls: string[] = [];
+  for (const image of images) {
+    const saved = await saveMediaBuffer(
+      Buffer.from(image.data, "base64"),
+      image.mimeType,
+      "inbound",
+    );
+    const id = normalizeOptionalString(saved.id);
+    if (id) {
+      mediaUrls.push(`media://inbound/${encodeURIComponent(id)}`);
+    }
+  }
+  return mediaUrls.length > 0 ? { mediaUrls, trustedLocalMedia: true } : undefined;
+}
+
 
 export function extractToolErrorCode(result: unknown): string | undefined {
   if (!result || typeof result !== "object") {


### PR DESCRIPTION
## Summary

Persist trusted `read` tool image content into the inbound media store when the tool result has image blocks but no `MEDIA:` path or `details.path`. Queue the saved `media://inbound/...` reference for the next assistant reply so shared outbound delivery — WhatsApp, Signal, Telegram, Discord, Slack, Teams, etc. — receives media URLs instead of text-only replies.

Fixes #81322

## Changes

- `src/agents/embedded-agent-subscribe.tools.ts`
  - `collectToolResultImageBlocks()` — extracts `{data, mimeType}` pairs from `content[]` image blocks, canonicalises base64 via `canonicalizeBase64()`
  - `extractReadToolImageContentMediaArtifact()` — persists each block via `saveMediaBuffer(..., "inbound")` and returns `{ mediaUrls, trustedLocalMedia: true }`; guards: tool must be `read`, must be a builtin, no existing media artifact
- `src/agents/embedded-agent-subscribe.handlers.tools.ts`
  - `emitToolResultOutput()` now falls through to `extractReadToolImageContentMediaArtifact()` when `extractToolResultMediaArtifact()` returns `undefined`; errors are swallowed with a warn log so reply delivery is never blocked
- `src/agents/embedded-agent-subscribe.handlers.tools.media.test.ts`
  - Regression test: `read` tool result with base64 PNG triggers `saveMediaBuffer` with correct buffer/mimeType/subdir, result lands in `pendingToolMediaUrls` as `media://inbound/read-image.png`, and `pendingToolTrustedLocalMedia` is set

## Changes from original PR #81415

Rebased onto current `main` and transplanted from the removed `src/agents/pi-embedded-subscribe.*` file structure to the current `src/agents/embedded-agent-subscribe.*` files. The `trustedLocalMediaToolNames` filtering path is preserved. Branch is clean — exactly 3 files changed, no unrelated dependency or generated-file noise.

## Behavioral Proof

**Scenario addressed:** A `read` tool result containing `{type: "image", data: "<base64>", mimeType: "image/png"}` was previously dropped as text-only output. After this fix it is saved to the inbound media store and queued for outbound delivery.

**Test evidence:**

```
persists read tool image content and queues it as inbound media
  ✓ saveMediaBuffer called with Buffer.from("iVBORw0KGgo=", "base64"), "image/png", "inbound"
  ✓ ctx.state.pendingToolMediaUrls === ["media://inbound/read-image.png"]
  ✓ ctx.state.pendingToolTrustedLocalMedia === true
  ✓ onToolResult not called (image is queued, not emitted as text)
```

**Guard conditions verified:**
- Only fires when `toolName === "read"` and it is in `builtinToolNames`
- Short-circuits if `extractToolResultMediaArtifact()` already found a media path
- Empty image blocks list → returns `undefined`, no side effects
- `saveMediaBuffer` failure → caught, logged as `warn`, reply continues without media

## Verification

```bash
# Only 3 files changed, all scoped to agents handler and tools
git diff --stat origin/main...HEAD
# src/agents/embedded-agent-subscribe.handlers.tools.media.test.ts | 44 +++
# src/agents/embedded-agent-subscribe.handlers.tools.ts            | 13 ++-
# src/agents/embedded-agent-subscribe.tools.ts                     | 67 +++

# Run the media handler tests
pnpm vitest run src/agents/embedded-agent-subscribe.handlers.tools.media.test.ts
```