### PR TITLE
fix(memory): stop light dreaming from restaging stale summaries

### DIFF
--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -3029,6 +3029,7 @@ describe("memory-core dreaming phases", () => {
     });
     expect(after1).toHaveLength(1);
     expect(after1[0]?.dailyCount).toBe(1);
+    expect(after1[0]?.lastRecalledAt).toBe("2026-04-05T10:00:00.000Z");
 
     const day2Ms = Date.parse("2026-04-06T10:00:00.000Z");
     const { beforeAgentReply: reply2 } = createHarness(configForTest, workspaceDir);
@@ -3049,6 +3050,7 @@ describe("memory-core dreaming phases", () => {
     });
     expect(after2).toHaveLength(1);
     expect(after2[0]?.dailyCount).toBe(2);
+    expect(after2[0]?.lastRecalledAt).toBe("2026-04-05T10:00:00.000Z");
   });
 });
 

--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -469,8 +469,75 @@ describe("memory-core dreaming phases", () => {
         "utf-8",
       );
       expect(dailyContent).toContain("## Light Sleep");
-      expect(dailyContent.match(/^- Candidate:/gm)).toHaveLength(1);
+      expect(dailyContent).toContain("- No notable updates.");
+      expect(dailyContent.match(/^- Candidate:/gm) ?? []).toHaveLength(0);
       expect(dailyContent).not.toContain("Light Sleep: Candidate:");
+    });
+  });
+
+  it("does not restage unchanged light candidates in later cycles", async () => {
+    const workspaceDir = await createDreamingWorkspace();
+    await withDreamingTestClock(async () => {
+      await writeDailyNote(workspaceDir, [
+        `# ${DREAMING_TEST_DAY}`,
+        "",
+        "- Added primary issue extraction for pain notifications.",
+        "- Updated signals cron notification style.",
+      ]);
+
+      const { beforeAgentReply } = createLightDreamingHarness(workspaceDir);
+      await triggerLightDreaming(beforeAgentReply, workspaceDir, 1);
+
+      const firstCycle = await fs.readFile(
+        path.join(workspaceDir, "memory", `${DREAMING_TEST_DAY}.md`),
+        "utf-8",
+      );
+      expect(firstCycle).toContain(
+        "Added primary issue extraction for pain notifications.; Updated signals cron notification style.",
+      );
+
+      await triggerLightDreaming(beforeAgentReply, workspaceDir, 61);
+
+      const secondCycle = await fs.readFile(
+        path.join(workspaceDir, "memory", `${DREAMING_TEST_DAY}.md`),
+        "utf-8",
+      );
+      expect(secondCycle).toContain("- No notable updates.");
+      expect(secondCycle).not.toContain(
+        "Added primary issue extraction for pain notifications.; Updated signals cron notification style.",
+      );
+    });
+  });
+
+  it("restages same-day light candidates after daily note content changes", async () => {
+    const workspaceDir = await createDreamingWorkspace();
+    await withDreamingTestClock(async () => {
+      await writeDailyNote(workspaceDir, [
+        `# ${DREAMING_TEST_DAY}`,
+        "",
+        "- Added primary issue extraction for pain notifications.",
+        "- Updated signals cron notification style.",
+      ]);
+
+      const { beforeAgentReply } = createLightDreamingHarness(workspaceDir);
+      await triggerLightDreaming(beforeAgentReply, workspaceDir, 1);
+
+      await writeDailyNote(workspaceDir, [
+        `# ${DREAMING_TEST_DAY}`,
+        "",
+        "- Added primary issue extraction for pain notifications.",
+        "- Updated signals cron notification style.",
+        "- Documented the shared pain notification issue.",
+      ]);
+      await triggerLightDreaming(beforeAgentReply, workspaceDir, 61);
+
+      const secondCycle = await fs.readFile(
+        path.join(workspaceDir, "memory", `${DREAMING_TEST_DAY}.md`),
+        "utf-8",
+      );
+      expect(secondCycle).toContain(
+        "Added primary issue extraction for pain notifications.; Updated signals cron notification style.; Documented the shared pain notification issue.",
+      );
     });
   });
 

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -39,6 +39,7 @@ import {
 import { textSimilarity as snippetSimilarity } from "./memory/tokenize.js";
 import {
   filterLiveShortTermRecallEntries,
+  filterFreshLightDreamingEntries,
   readLightStagedKeys,
   readShortTermRecallEntries,
   recordDreamingPhaseSignals,
@@ -1689,10 +1690,14 @@ async function runLightDreaming(params: {
   });
   const recentEntries = await filterLiveShortTermRecallEntries({
     workspaceDir: params.workspaceDir,
-    entries: filterRecallEntriesWithinLookback({
-      entries: await readShortTermRecallEntries({ workspaceDir: params.workspaceDir, nowMs }),
+    entries: await filterFreshLightDreamingEntries({
+      workspaceDir: params.workspaceDir,
       nowMs,
-      lookbackDays: params.config.lookbackDays,
+      entries: filterRecallEntriesWithinLookback({
+        entries: await readShortTermRecallEntries({ workspaceDir: params.workspaceDir, nowMs }),
+        nowMs,
+        lookbackDays: params.config.lookbackDays,
+      }),
     }),
   });
   const rankedEntries = dedupeEntries(

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -110,6 +110,7 @@ describe("short-term promotion", () => {
         claimHash?: unknown;
         firstRecalledAt?: unknown;
         lastRecalledAt?: unknown;
+        dailyCount?: unknown;
         recallCount?: unknown;
         snippet?: unknown;
         totalScore?: unknown;

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -580,6 +580,51 @@ describe("short-term promotion", () => {
     });
   });
 
+  it("keeps duplicate daily signals from refreshing recall freshness", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      await recordShortTermRecalls({
+        workspaceDir,
+        query: "__dreaming_daily__:2026-04-03",
+        signalType: "daily",
+        dedupeByQueryPerDay: true,
+        dayBucket: "2026-04-05",
+        nowMs: Date.parse("2026-04-05T10:00:00.000Z"),
+        results: [
+          {
+            path: "memory/2026-04-03.md",
+            startLine: 1,
+            endLine: 1,
+            score: 0.62,
+            snippet: "Added primary issue extraction for pain notifications.",
+            source: "memory",
+          },
+        ],
+      });
+      await recordShortTermRecalls({
+        workspaceDir,
+        query: "__dreaming_daily__:2026-04-03",
+        signalType: "daily",
+        dedupeByQueryPerDay: true,
+        dayBucket: "2026-04-05",
+        nowMs: Date.parse("2026-04-05T11:00:00.000Z"),
+        results: [
+          {
+            path: "memory/2026-04-03.md",
+            startLine: 1,
+            endLine: 1,
+            score: 0.62,
+            snippet: "Added primary issue extraction for pain notifications.",
+            source: "memory",
+          },
+        ],
+      });
+
+      const [entry] = Object.values(await readRecallStoreEntries(workspaceDir));
+      expect(entry?.dailyCount).toBe(1);
+      expect(entry?.lastRecalledAt).toBe("2026-04-05T10:00:00.000Z");
+    });
+  });
+
   it("uses default thresholds for promotion", async () => {
     await withTempWorkspace(async (workspaceDir) => {
       await recordShortTermRecalls({

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -1457,6 +1457,9 @@ export async function recordShortTermRecalls(params: {
       const recallDays = mergeRecentDistinct(recallDaysBase, todayBucket, MAX_RECALL_DAYS);
       const conceptTags = deriveConceptTags({ path: normalizedPath, snippet });
 
+      const unchangedDedupeSignal = dedupeSignal && existing?.snippet === snippet;
+      const lastRecalledAt = unchangedDedupeSignal ? (existing?.lastRecalledAt ?? nowIso) : nowIso;
+
       store.entries[key] = {
         key,
         path: normalizedPath,
@@ -1470,7 +1473,7 @@ export async function recordShortTermRecalls(params: {
         totalScore,
         maxScore,
         firstRecalledAt: existing?.firstRecalledAt ?? nowIso,
-        lastRecalledAt: nowIso,
+        lastRecalledAt,
         queryHashes,
         recallDays,
         conceptTags: conceptTags.length > 0 ? conceptTags : (existing?.conceptTags ?? []),
@@ -1606,6 +1609,9 @@ export async function recordGroundedShortTermCandidates(params: {
       const recallDays = mergeRecentDistinct(recallDaysBase, dayBucket, MAX_RECALL_DAYS);
       const conceptTags = deriveConceptTags({ path: item.path, snippet: item.snippet });
 
+      const unchangedDedupeSignal = dedupeSignal && existing?.snippet === item.snippet;
+      const lastRecalledAt = unchangedDedupeSignal ? (existing?.lastRecalledAt ?? nowIso) : nowIso;
+
       store.entries[key] = {
         key,
         path: item.path,
@@ -1619,7 +1625,7 @@ export async function recordGroundedShortTermCandidates(params: {
         totalScore,
         maxScore,
         firstRecalledAt: existing?.firstRecalledAt ?? nowIso,
-        lastRecalledAt: nowIso,
+        lastRecalledAt,
         queryHashes,
         recallDays,
         conceptTags: conceptTags.length > 0 ? conceptTags : (existing?.conceptTags ?? []),
@@ -1765,6 +1771,32 @@ export async function readLightStagedKeys(params: {
     }
   }
   return keys;
+}
+
+export async function filterFreshLightDreamingEntries(params: {
+  workspaceDir: string;
+  entries: readonly ShortTermRecallEntry[];
+  nowMs?: number;
+}): Promise<ShortTermRecallEntry[]> {
+  const workspaceDir = params.workspaceDir.trim();
+  if (!workspaceDir || params.entries.length === 0) {
+    return [];
+  }
+  const nowMs = resolveMemoryCoreNowMs(params.nowMs);
+  const nowIso = resolveMemoryCoreTimestamp(nowMs);
+  const phaseSignals = await readPhaseSignalStore(workspaceDir, nowIso);
+  return params.entries.filter((entry) => {
+    const phaseSignal = phaseSignals.entries[entry.key];
+    if (!phaseSignal || phaseSignal.lightHits <= 0) {
+      return true;
+    }
+    const lastLightMs = parseStoreTimestampMs(phaseSignal.lastLightAt);
+    if (!Number.isFinite(lastLightMs)) {
+      return true;
+    }
+    const lastRecalledAtMs = parseStoreTimestampMs(entry.lastRecalledAt);
+    return Number.isFinite(lastRecalledAtMs) && lastRecalledAtMs > lastLightMs;
+  });
 }
 
 export async function rankShortTermPromotionCandidates(

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -1457,8 +1457,13 @@ export async function recordShortTermRecalls(params: {
       const recallDays = mergeRecentDistinct(recallDaysBase, todayBucket, MAX_RECALL_DAYS);
       const conceptTags = deriveConceptTags({ path: normalizedPath, snippet });
 
-      const unchangedDedupeSignal = dedupeSignal && existing?.snippet === snippet;
-      const lastRecalledAt = unchangedDedupeSignal ? (existing?.lastRecalledAt ?? nowIso) : nowIso;
+      const unchangedRepeatedSignal =
+        Boolean(params.dedupeByQueryPerDay) &&
+        queryHashesBase.includes(queryHash) &&
+        existing?.snippet === snippet;
+      const lastRecalledAt = unchangedRepeatedSignal
+        ? (existing?.lastRecalledAt ?? nowIso)
+        : nowIso;
 
       store.entries[key] = {
         key,
@@ -1609,8 +1614,13 @@ export async function recordGroundedShortTermCandidates(params: {
       const recallDays = mergeRecentDistinct(recallDaysBase, dayBucket, MAX_RECALL_DAYS);
       const conceptTags = deriveConceptTags({ path: item.path, snippet: item.snippet });
 
-      const unchangedDedupeSignal = dedupeSignal && existing?.snippet === item.snippet;
-      const lastRecalledAt = unchangedDedupeSignal ? (existing?.lastRecalledAt ?? nowIso) : nowIso;
+      const unchangedRepeatedSignal =
+        Boolean(params.dedupeByQueryPerDay) &&
+        queryHashesBase.includes(queryHash) &&
+        existing?.snippet === item.snippet;
+      const lastRecalledAt = unchangedRepeatedSignal
+        ? (existing?.lastRecalledAt ?? nowIso)
+        : nowIso;
 
       store.entries[key] = {
         key,


### PR DESCRIPTION
Closes #72096

## What Problem This Solves

Fixes an issue where users running memory-core dreaming would see the same light-phase work summary staged again in later cycles when the underlying daily memory content had not changed.

## Why This Change Was Made

Light dreaming now filters already-emitted recall entries unless the recall freshness moved past the last light emission. Repeated same-query daily signals keep their original freshness when the stored snippet is unchanged, including cross-day re-ingestion, so unchanged daily ingestion no longer makes stale content look new while real same-day note edits can still be staged.

## User Impact

DREAMS.md light-phase sections stop repeating unchanged work-summary blocks across hourly or cross-night cycles, reducing duplicate memory noise without hiding newly edited daily-note content from later light dreaming cycles.

## Evidence

- Claim proved: unchanged light dreaming candidates are not restaged in a later cycle, cross-day unchanged daily re-ingestion increments `dailyCount` without refreshing `lastRecalledAt`, and same-day daily-note content changes are still restaged.
- Duplicate PR checks: `gh search prs --repo openclaw/openclaw --state open --match title,body -- "72096"`, `"Dreaming light-phase work summary repeats"`, and `"light dreaming lastLightAt"` returned no open PR coverage before opening this PR.
- Real behavior proof: ran `runDreamingSweepPhases` from `extensions/memory-core/src/dreaming-phases.ts` against a temporary memory workspace and temporary SQLite-backed memory-core state store on PR head `5c3f7ed6f3ce3ea4566f29e7402792d6a3af729a`. This exercised the real light-dreaming runtime write path into `memory/2026-04-05.md` with inline dreaming output; no private local OpenClaw home, credentials, or user memory were used.

  Redacted terminal output from the repeated light-dreaming cycle:

  ```json
  {
    "proof": "PR #97446 real light-dreaming repeated-cycle proof",
    "head": "5c3f7ed6f3ce3ea4566f29e7402792d6a3af729a",
    "workspace": "<temp-workspace>",
    "stateDir": "<temp-state>",
    "cycles": [
      {
        "label": "cycle 1: initial daily note",
        "now": "2026-04-05T10:01:00.000Z",
        "candidateCount": 1,
        "noNotableUpdates": false,
        "lightBlock": "- Candidate: Added primary issue extraction for pain notifications.; Updated signals cron notification style.\n  - confidence: 0.62\n  - evidence: memory/2026-04-05.md:3-4\n  - recalls: 0\n  - status: staged",
        "logs": [
          "[info] memory-core: light dreaming staged 1 candidate(s) [workspace=<temp-workspace>]."
        ]
      },
      {
        "label": "cycle 2: unchanged note",
        "now": "2026-04-05T11:01:00.000Z",
        "candidateCount": 0,
        "noNotableUpdates": true,
        "lightBlock": "- No notable updates.",
        "logs": []
      },
      {
        "label": "cycle 3: edited note",
        "now": "2026-04-05T12:01:00.000Z",
        "candidateCount": 1,
        "noNotableUpdates": false,
        "lightBlock": "- Candidate: Added primary issue extraction for pain notifications.; Updated signals cron notification style.; Documented the shared pain notification issue.\n  - confidence: 0.62\n  - evidence: memory/2026-04-05.md:3-5\n  - recalls: 0\n  - status: staged",
        "logs": [
          "[info] memory-core: light dreaming staged 1 candidate(s) [workspace=<temp-workspace>]."
        ]
      }
    ]
  }
  ```

  Observed result: the first cycle staged one light candidate, the second unchanged cycle wrote `- No notable updates.` with `candidateCount: 0`, and the third cycle after editing the daily note staged the updated candidate again.

- Commands / artifacts:
  - `git diff --check` passed.
  - `node scripts/run-vitest.mjs extensions/memory-core/src/dreaming-phases.test.ts extensions/memory-core/src/short-term-promotion.test.ts` passed: 2 files, 130 tests.
  - `corepack pnpm exec oxfmt --check --threads=1 extensions/memory-core/src/dreaming-phases.ts extensions/memory-core/src/dreaming-phases.test.ts extensions/memory-core/src/short-term-promotion.ts extensions/memory-core/src/short-term-promotion.test.ts` passed.
  - `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo` passed, matching the previous failing CI `check-test-types` extension-test lane.
  - `python .agents\skills\autoreview\scripts\autoreview --mode local` passed with `autoreview clean: no accepted/actionable findings reported` after the cross-day freshness fix.
- Not tested / proof gaps: did not run an overnight wall-clock dreaming cycle or broad local repo checks. The added real behavior proof uses a temporary workspace and calls the shipped memory-core light-dreaming runtime entry directly to exercise the repeated-cycle write path without exposing private local memory.