### PR TITLE
fix(code-mode): handle QuickJS interrupted error on VM dispose

### DIFF
--- a/src/agents/code-mode.test.ts
+++ b/src/agents/code-mode.test.ts
@@ -1,4 +1,6 @@
 /** Tests Code Mode tool registration, namespace filtering, and run lifecycle. */
+import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { isRecord } from "../../packages/normalization-core/src/record-coerce.js";
 import { setPluginToolMeta } from "../plugins/tools.js";
@@ -240,12 +242,17 @@ describe("Code Mode", () => {
   });
 
   it("resolves the packaged worker URL from stable and hashed dist modules", () => {
-    expect(testing.resolveCodeModeWorkerUrl("file:///repo/dist/agents/code-mode.js").pathname).toBe(
-      "/repo/dist/agents/code-mode.worker.js",
-    );
-    expect(testing.resolveCodeModeWorkerUrl("file:///repo/dist/selection-abc123.js").pathname).toBe(
-      "/repo/dist/agents/code-mode.worker.js",
-    );
+    const repoRoot = path.join(process.cwd(), "repo");
+    const stableModuleUrl = pathToFileURL(
+      path.join(repoRoot, "dist", "agents", "code-mode.js"),
+    ).href;
+    const hashedModuleUrl = pathToFileURL(path.join(repoRoot, "dist", "selection-abc123.js")).href;
+    const workerPath = pathToFileURL(
+      path.join(repoRoot, "dist", "agents", "code-mode.worker.js"),
+    ).pathname;
+
+    expect(testing.resolveCodeModeWorkerUrl(stableModuleUrl).pathname).toBe(workerPath);
+    expect(testing.resolveCodeModeWorkerUrl(hashedModuleUrl).pathname).toBe(workerPath);
   });
 
   it("hides all normal tools behind exec and wait", () => {

--- a/src/agents/code-mode.worker.ts
+++ b/src/agents/code-mode.worker.ts
@@ -555,6 +555,16 @@ function throwWorkerFailureWithOutput(params: {
   throw params.error;
 }
 
+function disposeVmAfterRun(vm: QuickJS): void {
+  try {
+    vm.dispose();
+  } catch (error) {
+    if (!isQuickJsInterruptedError(error)) {
+      throw error;
+    }
+  }
+}
+
 function drainPendingJobs(vm: QuickJS): void {
   for (let index = 0; index < 1000; index += 1) {
     if (vm.executePendingJobs() === 0) {
@@ -648,7 +658,7 @@ async function runVmExecution(params: {
       vm: params.vm,
     });
   } finally {
-    params.vm.dispose();
+    disposeVmAfterRun(params.vm);
   }
 }
 


### PR DESCRIPTION
## Summary

Two fixes in `code-mode`:

### 1. Handle QuickJS interrupted errors on VM dispose

**File:** `src/agents/code-mode.worker.ts`

`vm.dispose()` can throw `isQuickJsInterruptedError` when the VM was forcefully interrupted. Previously this was called directly in the `finally` block of `runVmExecution`, causing unhandled exceptions.

**Fix:** Extract `disposeVmAfterRun()` that catches and swallows `isQuickJsInterruptedError`, re-throwing only unexpected errors.

### 2. Cross-platform path handling in test

**File:** `src/agents/code-mode.test.ts`

Tests used hardcoded `file:///repo/...` paths that fail on Windows. Replaced with `pathToFileURL` from `node:url` for cross-platform compatibility.