### PR TITLE
fix(heartbeat): rewrite stream-error placeholder leak replies before delivery (#97357)

### DIFF
--- a/src/auto-reply/reply/agent-runner-failure-copy.ts
+++ b/src/auto-reply/reply/agent-runner-failure-copy.ts
@@ -1,4 +1,6 @@
 // Centralizes user-facing failure copy for external agent runner errors.
+import { STREAM_ERROR_FALLBACK_TEXT } from "../../agents/stream-message-shared.js";
+
 export const GENERIC_EXTERNAL_RUN_FAILURE_TEXT =
   "⚠️ Something went wrong while processing your request. Please try again, or use /new to start a fresh session.";
 
@@ -10,12 +12,35 @@ function isGenericExternalRunFailureText(text: string | undefined): boolean {
   return text?.trim() === GENERIC_EXTERNAL_RUN_FAILURE_TEXT;
 }
 
+/**
+ * True when text consists only of stream-error placeholder repetitions and
+ * whitespace. A fallback model can echo `[assistant turn failed before
+ * producing content]` from prior transcript entries as a "successful" final
+ * reply (stopReason=stop); such text must never reach heartbeat delivery.
+ */
+function isStreamErrorPlaceholderOnlyText(text: string | undefined): boolean {
+  if (!text) {
+    return false;
+  }
+  const collapsed = text.replace(/\s+/g, " ").trim();
+  if (!collapsed) {
+    return false;
+  }
+  // The placeholder has no regex-special characters, so a direct split is safe.
+  const parts = collapsed.split(STREAM_ERROR_FALLBACK_TEXT);
+  return parts.every((part) => part.trim() === "");
+}
+
 /** Replaces trailing generic failure text with heartbeat-specific copy. */
 export function replaceGenericExternalRunFailureText(text: string): {
   text: string;
   replaced: boolean;
 } {
   if (isGenericExternalRunFailureText(text)) {
+    return { text: HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT, replaced: true };
+  }
+
+  if (isStreamErrorPlaceholderOnlyText(text)) {
     return { text: HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT, replaced: true };
   }
 

--- a/src/infra/heartbeat-runner.tool-response.test.ts
+++ b/src/infra/heartbeat-runner.tool-response.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { STREAM_ERROR_FALLBACK_TEXT } from "../agents/stream-message-shared.js";
 import {
   createHeartbeatToolResponsePayload,
   type HeartbeatToolResponse,
@@ -336,6 +337,46 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
         cfg,
       });
       expect(HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT).not.toContain("/new");
+      expect(getLastHeartbeatEvent()).toMatchObject({
+        status: "failed",
+        reason: "agent-runner-failure",
+        preview: HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT,
+        channel: "telegram",
+      });
+    });
+  });
+
+  it("rewrites stream-error placeholder leak replies before heartbeat delivery (#97357)", async () => {
+    await withTempTelegramHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const cfg = createConfig({ tmpDir, storePath });
+      await seedMainSessionStore(storePath, cfg, {
+        lastChannel: "telegram",
+        lastProvider: "telegram",
+        lastTo: TELEGRAM_GROUP,
+      });
+      // A fallback model can echo the internal stream-error placeholder from
+      // prior transcript entries as a "successful" final reply (stopReason=stop).
+      // Reproduce 43 placeholder repetitions, matching the field report in #97357.
+      const placeholderReply = Array.from({ length: 43 }, () => STREAM_ERROR_FALLBACK_TEXT).join(
+        "   ",
+      );
+      replySpy.mockResolvedValue(
+        markReplyPayloadForSourceSuppressionDelivery({
+          text: placeholderReply,
+        }),
+      );
+      const sendTelegram = vi.fn().mockResolvedValue({ messageId: "m1" });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        deps: createDeps({ sendTelegram, getReplyFromConfig: replySpy }),
+      });
+
+      expect(result.status).toBe("ran");
+      expectTelegramSend(sendTelegram, {
+        text: HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT,
+        cfg,
+      });
       expect(getLastHeartbeatEvent()).toMatchObject({
         status: "failed",
         reason: "agent-runner-failure",


### PR DESCRIPTION
## What Problem This Solves

Fixes #97357 — heartbeat fallback can deliver repeated internal stream-error placeholders as user-visible messages.

When the primary model fails before producing content (`stopReason=error`), the runtime records an internal placeholder:

```
[assistant turn failed before producing content]
```

If a fallback model is configured, it can echo that placeholder from prior transcript entries as a "successful" final reply (`stopReason=stop`). The heartbeat delivery path then treats it as a normal assistant message and ships it visibly — the field report shows 43 placeholder repetitions delivered to a Feishu DM.

## Why This Change Was Made

`replaceGenericExternalRunFailureText` is the existing heartbeat-specific rewrite gate, but it only matches the `GENERIC_EXTERNAL_RUN_FAILURE_TEXT` literal. The stream-error placeholder is a distinct internal string, so placeholder-only replies slipped through unchanged.

Heartbeat is a high-trust scheduled surface: it should either complete its check (`HEARTBEAT_OK`) or fail with the existing `HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT` copy. Internal diagnostic placeholders must never reach end users via this path.

## User Impact

- **Before:** A fallback model that echoes prior transcript placeholders causes the heartbeat to deliver 1–N repetitions of `[assistant turn failed before producing content]` to the configured channel (Feishu DM in the field report). User sees noise; heartbeat state is ambiguous (runtime says "completed", user sees garbage).
- **After:** Such replies are detected and rewritten to `HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT` before delivery, matching the existing behavior for generic external-run failure text.

## Evidence

### Reproduction matches the field report

Issue #97357 captured the exact shape: 43 repetitions of `STREAM_ERROR_FALLBACK_TEXT` joined by whitespace, returned by the fallback model with `stopReason=stop`. The regression test reproduces this verbatim.

### Local test run (Node 22.22.1)

\`\`\`
$ pnpm test src/infra/heartbeat-runner.tool-response.test.ts

 Test Files  1 passed (1)
      Tests  16 passed (16)
   Duration  27.39s
[test] passed 1 Vitest shard in 94.83s
\`\`\`

### Coverage

- **Placeholder-only rewrite** — 43 repetitions of `STREAM_ERROR_FALLBACK_TEXT` joined by spaces collapse to `HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT` before delivery.
- **Heartbeat event shape** — `getLastHeartbeatEvent()` reports `status: "failed"`, `reason: "agent-runner-failure"`, matching the existing failure-copy rewrite path so downstream dashboards/alerts see a consistent signal.
- **Existing generic-failure path unchanged** — original 15 tests still pass; the new branch runs before the generic-text scan and only matches placeholder-only input.

### Production code shape

- `isStreamErrorPlaceholderOnlyText` collapses whitespace, splits on the literal `STREAM_ERROR_FALLBACK_TEXT`, and returns true only when every split part trims to empty. The placeholder has no regex-special characters, so a direct `split` is safe (no regex escaping needed).
- The new check sits beside `isGenericExternalRunFailureText` in `replaceGenericExternalRunFailureText`, sharing the same rewrite target so callers see one consistent failure copy.