### PR TITLE
fix(litellm): pass Anthropic cache control

### DIFF
--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -98,7 +98,7 @@ Official provider plugins publish their own model catalog rows. These providers 
 - `/fast` and `params.fastMode` map direct `openai/*` Responses requests to `service_tier=priority` on `api.openai.com`
 - Use `params.serviceTier` when you want an explicit tier instead of the shared `/fast` toggle
 - Hidden OpenClaw attribution headers (`originator`, `version`, `User-Agent`) apply only on native OpenAI traffic to `api.openai.com`, not generic OpenAI-compatible proxies
-- Native OpenAI routes also keep Responses `store`, prompt-cache hints, and OpenAI reasoning-compat payload shaping; proxy routes do not
+- Native OpenAI routes also keep Responses `store`, prompt-cache hints, and OpenAI reasoning-compat payload shaping; proxy routes do not, except LiteLLM Anthropic refs can send Anthropic `cache_control` markers when `cacheRetention` is explicitly `short` or `long`
 - `openai/gpt-5.3-codex-spark` is available through ChatGPT/Codex OAuth subscription auth when your signed-in account exposes it; OpenClaw still suppresses direct OpenAI API-key and Azure API-key routes for this model because those transports reject it
 
 ```json5
@@ -667,7 +667,8 @@ Example (OpenAI-compatible):
   </Accordion>
   <Accordion title="Proxy-route shaping rules">
     - For `api: "openai-completions"` on non-native endpoints (any non-empty `baseUrl` whose host is not `api.openai.com`), OpenClaw forces `compat.supportsDeveloperRole: false` to avoid provider 400 errors for unsupported `developer` roles.
-    - Proxy-style OpenAI-compatible routes also skip native OpenAI-only request shaping: no `service_tier`, no Responses `store`, no Completions `store`, no prompt-cache hints, no OpenAI reasoning-compat payload shaping, and no hidden OpenClaw attribution headers.
+    - Proxy-style OpenAI-compatible routes also skip native OpenAI-only request shaping: no `service_tier`, no Responses `store`, no Completions `store`, no prompt-cache hints by default, no OpenAI reasoning-compat payload shaping, and no hidden OpenClaw attribution headers.
+    - LiteLLM Anthropic refs are the prompt-cache exception for proxy routes: when `cacheRetention` is explicitly `short` or `long`, OpenClaw sends Anthropic `cache_control` markers through the OpenAI-compatible payload.
     - For OpenAI-compatible Completions proxies that need vendor-specific fields, set `agents.defaults.models["provider/model"].params.extra_body` (or `extraBody`) to merge extra JSON into the outbound request body.
     - For vLLM chat-template controls, set `agents.defaults.models["provider/model"].params.chat_template_kwargs`. The bundled vLLM plugin automatically sends `enable_thinking: false` and `force_nonempty_content: true` for `vllm/nemotron-3-*` when the session thinking level is off.
     - For slow local models or remote LAN/tailnet hosts, set `models.providers.<id>.timeoutSeconds`. This extends provider model HTTP request handling, including connect, headers, body streaming, and the total guarded-fetch abort, without increasing the whole agent runtime timeout. If `agents.defaults.timeoutSeconds` or a run-specific timeout is lower, raise that ceiling too; provider timeouts cannot extend the whole run.

--- a/docs/gateway/local-models.md
+++ b/docs/gateway/local-models.md
@@ -211,7 +211,10 @@ Behavior note for local/proxied `/v1` backends:
   OpenAI endpoints
 - native OpenAI-only request shaping does not apply here: no
   `service_tier`, no Responses `store`, no OpenAI reasoning-compat payload
-  shaping, and no prompt-cache hints
+  shaping, and no prompt-cache hints by default. LiteLLM Anthropic model refs
+  are the exception: explicit `cacheRetention: "short"` or
+  `cacheRetention: "long"` sends Anthropic `cache_control` markers through the
+  proxy.
 - hidden OpenClaw attribution headers (`originator`, `version`, `User-Agent`)
   are not injected on these custom proxy URLs
 

--- a/docs/providers/litellm.md
+++ b/docs/providers/litellm.md
@@ -205,8 +205,12 @@ will be sent to the configured proxy host.
     - OpenClaw connects through LiteLLM's proxy-style OpenAI-compatible `/v1`
       endpoint
     - Native OpenAI-only request shaping does not apply through LiteLLM:
-      no `service_tier`, no Responses `store`, no prompt-cache hints, and no
-      OpenAI reasoning-compat payload shaping
+      no `service_tier`, no Responses `store`, and no OpenAI reasoning-compat
+      payload shaping
+    - LiteLLM Anthropic model refs such as `litellm/claude-opus-4-6` or
+      `litellm/anthropic/claude-opus-4-6` do receive Anthropic `cache_control`
+      prompt-cache markers when `cacheRetention` is explicitly set to `short`
+      or `long`
     - Hidden OpenClaw attribution headers (`originator`, `version`, `User-Agent`)
       are not injected on custom LiteLLM base URLs
   </Accordion>

--- a/docs/reference/prompt-caching.md
+++ b/docs/reference/prompt-caching.md
@@ -144,6 +144,15 @@ as the cache-hit signal.
 If you repoint the model at an arbitrary OpenAI-compatible proxy URL, OpenClaw
 stops injecting those OpenRouter-specific Anthropic cache markers.
 
+### LiteLLM Anthropic routes
+
+For `litellm/claude-*`, `litellm/anthropic/*`, and
+`litellm/anthropic.claude*` model refs, explicit `cacheRetention: "short"` or
+`cacheRetention: "long"` makes OpenClaw inject Anthropic `cache_control` markers
+into the OpenAI-compatible chat payload so LiteLLM can pass them through to
+Anthropic. Non-Anthropic LiteLLM models do not receive those Anthropic markers,
+and `cacheRetention: "none"` suppresses them.
+
 ### Other providers
 
 If the provider does not support this cache mode, `cacheRetention` has no effect.

--- a/src/agents/embedded-agent-runner/prompt-cache-retention.test.ts
+++ b/src/agents/embedded-agent-runner/prompt-cache-retention.test.ts
@@ -121,6 +121,53 @@ describe("prompt cache retention", () => {
     ).toBeUndefined();
   });
 
+  it("passes explicit cacheRetention through for LiteLLM Anthropic openai-completions models", () => {
+    expect(
+      resolveCacheRetention(
+        { cacheRetention: "long" },
+        "litellm",
+        "openai-completions",
+        "claude-opus-4-6",
+      ),
+    ).toBe("long");
+    expect(
+      resolveCacheRetention(
+        { cacheRetention: "short" },
+        "litellm",
+        "openai-completions",
+        "anthropic/claude-sonnet-4.6",
+      ),
+    ).toBe("short");
+    expect(
+      resolveCacheRetention(
+        { cacheRetention: "none" },
+        "litellm",
+        "openai-completions",
+        "anthropic.claude-sonnet-4-6",
+      ),
+    ).toBe("none");
+  });
+
+  it("does not default cacheRetention for LiteLLM Anthropic openai-completions models", () => {
+    expect(
+      resolveCacheRetention(undefined, "litellm", "openai-completions", "claude-opus-4-6"),
+    ).toBeUndefined();
+    expect(
+      resolveCacheRetention({}, "litellm", "openai-completions", "claude-opus-4-6"),
+    ).toBeUndefined();
+  });
+
+  it("does not honor explicit cacheRetention for non-Anthropic LiteLLM openai-completions models", () => {
+    expect(
+      resolveCacheRetention(
+        { cacheRetention: "long" },
+        "litellm",
+        "openai-completions",
+        "openai/gpt-5.5",
+      ),
+    ).toBeUndefined();
+  });
+
   it("identifies supported direct Google cache families", () => {
     expect(
       isGooglePromptCacheEligible({

--- a/src/agents/embedded-agent-runner/prompt-cache-retention.ts
+++ b/src/agents/embedded-agent-runner/prompt-cache-retention.ts
@@ -2,7 +2,10 @@
  * Resolves provider/model prompt-cache retention behavior.
  */
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
-import { resolveAnthropicCacheRetentionFamily } from "../../llm/providers/stream-wrappers/anthropic-family-cache-semantics.js";
+import {
+  isLiteLLMAnthropicModelRef,
+  resolveAnthropicCacheRetentionFamily,
+} from "../../llm/providers/stream-wrappers/anthropic-family-cache-semantics.js";
 
 type CacheRetention = "none" | "short" | "long";
 
@@ -41,8 +44,14 @@ export function resolveCacheRetention(
   // openai-completions wire (amazon-bedrock + amazon.* nova models) leave
   // the flag unset, so the existing family gate still applies to them.
   const cacheKeyEligible = supportsPromptCacheKey === true;
+  const liteLLMAnthropicEligible =
+    normalizeLowercaseStringOrEmpty(provider) === "litellm" &&
+    modelApi === "openai-completions" &&
+    hasExplicitCacheConfig &&
+    typeof modelId === "string" &&
+    isLiteLLMAnthropicModelRef(modelId);
 
-  if (!family && !googleEligible && !cacheKeyEligible) {
+  if (!family && !googleEligible && !cacheKeyEligible && !liteLLMAnthropicEligible) {
     return undefined;
   }
 

--- a/src/llm/providers/openai-completions.test.ts
+++ b/src/llm/providers/openai-completions.test.ts
@@ -590,6 +590,147 @@ describe("OpenAI-compatible completions params", () => {
     });
   });
 
+  it("splits the cache boundary before applying Anthropic cache control for LiteLLM Anthropic models", async () => {
+    let capturedMessages: unknown;
+    const stream = streamOpenAICompletions(
+      {
+        ...createModel(32_000),
+        id: "claude-opus-4-6",
+        provider: "litellm",
+        baseUrl: "https://litellm.example.test/v1",
+      },
+      {
+        systemPrompt: `Stable prefix${SYSTEM_PROMPT_CACHE_BOUNDARY}Dynamic suffix`,
+        messages: [{ role: "user", content: "hi", timestamp: 1 }],
+      },
+      {
+        apiKey: "sk-test",
+        cacheRetention: "long",
+        onPayload(payload) {
+          capturedMessages = (payload as { messages?: unknown }).messages;
+          throw new Error("stop before network");
+        },
+      },
+    );
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    const messages = capturedMessages as Array<{ role: string; content: unknown }>;
+    expect(messages[0]).toEqual({
+      role: "system",
+      content: [
+        {
+          type: "text",
+          text: "Stable prefix",
+          cache_control: { type: "ephemeral", ttl: "1h" },
+        },
+        {
+          type: "text",
+          text: "Dynamic suffix",
+        },
+      ],
+    });
+  });
+
+  it("does not default Anthropic cache control for LiteLLM Anthropic models", async () => {
+    let capturedMessages: unknown;
+    const stream = streamOpenAICompletions(
+      {
+        ...createModel(32_000),
+        id: "claude-opus-4-6",
+        provider: "litellm",
+        baseUrl: "https://litellm.example.test/v1",
+      },
+      {
+        systemPrompt: `Stable prefix${SYSTEM_PROMPT_CACHE_BOUNDARY}Dynamic suffix`,
+        messages: [{ role: "user", content: "hi", timestamp: 1 }],
+      },
+      {
+        apiKey: "sk-test",
+        onPayload(payload) {
+          capturedMessages = (payload as { messages?: unknown }).messages;
+          throw new Error("stop before network");
+        },
+      },
+    );
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    const messages = capturedMessages as Array<{ role: string; content: unknown }>;
+    expect(messages[0]).toEqual({
+      role: "system",
+      content: "Stable prefix\nDynamic suffix",
+    });
+  });
+
+  it("does not apply Anthropic cache control for LiteLLM Anthropic models when cacheRetention is none", async () => {
+    let capturedMessages: unknown;
+    const stream = streamOpenAICompletions(
+      {
+        ...createModel(32_000),
+        id: "claude-opus-4-6",
+        provider: "litellm",
+        baseUrl: "https://litellm.example.test/v1",
+      },
+      {
+        systemPrompt: `Stable prefix${SYSTEM_PROMPT_CACHE_BOUNDARY}Dynamic suffix`,
+        messages: [{ role: "user", content: "hi", timestamp: 1 }],
+      },
+      {
+        apiKey: "sk-test",
+        cacheRetention: "none",
+        onPayload(payload) {
+          capturedMessages = (payload as { messages?: unknown }).messages;
+          throw new Error("stop before network");
+        },
+      },
+    );
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    const messages = capturedMessages as Array<{ role: string; content: unknown }>;
+    expect(messages[0]).toEqual({
+      role: "system",
+      content: "Stable prefix\nDynamic suffix",
+    });
+  });
+
+  it("does not apply Anthropic cache control for non-Anthropic LiteLLM models", async () => {
+    let capturedMessages: unknown;
+    const stream = streamOpenAICompletions(
+      {
+        ...createModel(32_000),
+        id: "openai/gpt-5.5",
+        provider: "litellm",
+        baseUrl: "https://litellm.example.test/v1",
+      },
+      {
+        systemPrompt: `Stable prefix${SYSTEM_PROMPT_CACHE_BOUNDARY}Dynamic suffix`,
+        messages: [{ role: "user", content: "hi", timestamp: 1 }],
+      },
+      {
+        apiKey: "sk-test",
+        cacheRetention: "long",
+        onPayload(payload) {
+          capturedMessages = (payload as { messages?: unknown }).messages;
+          throw new Error("stop before network");
+        },
+      },
+    );
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    const messages = capturedMessages as Array<{ role: string; content: unknown }>;
+    expect(messages[0]).toEqual({
+      role: "system",
+      content: "Stable prefix\nDynamic suffix",
+    });
+  });
+
   it("adds reasoning_content replay fields for Xiaomi MiMo assistant tool history", async () => {
     let capturedMessages: unknown;
     const stream = streamOpenAICompletions(

--- a/src/llm/providers/openai-completions.ts
+++ b/src/llm/providers/openai-completions.ts
@@ -52,6 +52,10 @@ import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copi
 import { clampOpenAIPromptCacheKey } from "./openai-prompt-cache.js";
 import { mapOpenAIStopReason } from "./openai-stop-reason.js";
 import { buildBaseOptions } from "./simple-options.js";
+import {
+  isAnthropicModelRef,
+  isLiteLLMAnthropicModelRef,
+} from "./stream-wrappers/anthropic-family-cache-semantics.js";
 import { transformMessages } from "./transform-messages.js";
 
 /**
@@ -628,7 +632,10 @@ function buildParams(
   compat: ResolvedOpenAICompletionsCompat = getCompat(model),
   cacheRetention: CacheRetention = resolveCacheRetention(options?.cacheRetention),
 ) {
-  const cacheControl = getCompatCacheControl(compat, cacheRetention);
+  const cacheControl =
+    model.provider === "litellm" && options?.cacheRetention === undefined
+      ? undefined
+      : getCompatCacheControl(compat, cacheRetention);
   const messages = convertMessages(model, context, compat, {
     preserveSystemPromptCacheBoundary: cacheControl !== undefined,
   });
@@ -1309,8 +1316,10 @@ function detectCompat(model: Model<"openai-completions">): ResolvedOpenAIComplet
   const isGrok = provider === "xai" || baseUrl.includes("api.x.ai");
   const isDeepSeek = provider === "deepseek" || baseUrl.includes("deepseek.com");
   const isXiaomi = provider === "xiaomi" || baseUrl.includes("xiaomimimo.com");
-  const cacheControlFormat =
-    provider === "openrouter" && model.id.startsWith("anthropic/") ? "anthropic" : undefined;
+  const usesAnthropicCacheControl =
+    (provider === "openrouter" && isAnthropicModelRef(model.id)) ||
+    (provider === "litellm" && isLiteLLMAnthropicModelRef(model.id));
+  const cacheControlFormat = usesAnthropicCacheControl ? "anthropic" : undefined;
 
   return {
     supportsStore: !isNonStandard,

--- a/src/llm/providers/stream-wrappers/anthropic-family-cache-semantics.ts
+++ b/src/llm/providers/stream-wrappers/anthropic-family-cache-semantics.ts
@@ -13,6 +13,15 @@ export function isAnthropicModelRef(modelId: string): boolean {
   return normalizeLowercaseStringOrEmpty(modelId).startsWith("anthropic/");
 }
 
+export function isLiteLLMAnthropicModelRef(modelId: string): boolean {
+  const normalized = normalizeLowercaseStringOrEmpty(modelId);
+  return (
+    isAnthropicModelRef(normalized) ||
+    normalized.startsWith("anthropic.claude") ||
+    normalized.startsWith("claude-")
+  );
+}
+
 /** Matches Application Inference Profile ARNs across all AWS partitions with Bedrock. */
 const BEDROCK_APP_INFERENCE_PROFILE_ARN_RE = /^arn:aws(-cn|-us-gov)?:bedrock:/;
 


### PR DESCRIPTION
﻿Closes #37966

## What Problem This Solves

Fixes an issue where users routing Claude through LiteLLM would not get Anthropic prompt-cache markers when they explicitly configured `cacheRetention`, causing repeated prompts to miss Anthropic cache creation/read behavior behind the proxy.

## Why This Change Was Made

OpenClaw already has Anthropic `cache_control` payload shaping for OpenAI-compatible Anthropic routes. This change extends that compatibility detection to LiteLLM Anthropic route names (`claude-*`, `anthropic/*`, and `anthropic.claude*`) while leaving non-Anthropic LiteLLM models, no explicit LiteLLM cache config, and `cacheRetention: "none"` unmarked.

The embedded runner retention resolver now has the same LiteLLM Anthropic gate as the OpenAI-compatible transport, so configured `short`, `long`, and `none` values survive the wrapper path instead of being dropped before payload construction.

The provider docs, local model guide, model-provider concept page, and prompt-caching reference now call out the LiteLLM Anthropic exception instead of saying proxy routes never receive prompt-cache hints.

## User Impact

Users can set `cacheRetention: "short"` or `cacheRetention: "long"` for LiteLLM-routed Claude models and have OpenClaw send Anthropic `cache_control` markers through the OpenAI-compatible payload. Non-Anthropic LiteLLM routes and LiteLLM Claude routes without explicit cache retention keep their existing payload shape.

## Evidence

- RED check: with the implementation temporarily removed, `node scripts/run-vitest.mjs src/llm/providers/openai-completions.test.ts` failed only the new LiteLLM Anthropic cache-control assertion because the system prompt stayed a plain string without `cache_control`.
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/prompt-cache-retention.test.ts src/llm/providers/openai-completions.test.ts`
- `pnpm --config.verify-deps-before-run=false docs:list`
- `pnpm --config.verify-deps-before-run=false exec oxfmt --check --threads=1 docs/gateway/local-models.md docs/concepts/model-providers.md docs/providers/litellm.md docs/reference/prompt-caching.md src/agents/embedded-agent-runner/prompt-cache-retention.ts src/agents/embedded-agent-runner/prompt-cache-retention.test.ts src/llm/providers/openai-completions.ts src/llm/providers/openai-completions.test.ts src/llm/providers/stream-wrappers/anthropic-family-cache-semantics.ts`
- `git diff --check`

## Not Tested

- Live LiteLLM-to-Anthropic cache creation/read proof was not run in this Windows worktree because `ANTHROPIC_API_KEY`, `LITELLM_API_KEY`, and `OPENAI_API_KEY` were not present in the local environment. The mocked payload tests do verify the exact outbound `cache_control` payload shape before the network call.
