### PR TITLE
fix(provider-transport): pass SSE-shaped bodies through under JSON content-type (#96497)

### DIFF
--- a/src/agents/provider-transport-fetch.test.ts
+++ b/src/agents/provider-transport-fetch.test.ts
@@ -1193,6 +1193,50 @@ describe("buildGuardedModelFetch", () => {
     expect(items).toEqual([{ ok: true }]);
   });
 
+  it("passes SSE-shaped bodies through unchanged under JSON content-type (#96497)", async () => {
+    // A misconfigured OpenAI-compatible gateway can return a standard SSE body
+    // (`data: {...}\n\n`) under a `application/json` content-type. Wrapping that
+    // body as a single `data:` frame would yield `data: data: {...}` and break
+    // the OpenAI SDK stream parser. Pass SSE-shaped buffers through unchanged.
+    const sseBody =
+      `data: ${JSON.stringify({ choices: [{ delta: { content: "hi" } }] })}\n\n` +
+      `data: ${JSON.stringify({ choices: [{ delta: { content: " there" } }] })}\n\n`;
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response(sseBody, {
+        headers: { "content-type": "application/json; charset=utf-8" },
+      }),
+      finalUrl: "https://openrouter.ai/api/v1/chat/completions",
+      release: vi.fn(async () => undefined),
+    });
+    const model = {
+      id: "moonshotai/kimi-k2.6",
+      provider: "openrouter",
+      api: "openai-completions",
+      baseUrl: "https://openrouter.ai/api/v1",
+    } as unknown as Model<"openai-completions">;
+
+    const response = await buildGuardedModelFetch(model)(
+      "https://openrouter.ai/api/v1/chat/completions",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ model: "moonshotai/kimi-k2.6", stream: true }),
+      },
+    );
+    const items: unknown[] = [];
+    for await (const item of Stream.fromSSEResponse(response, new AbortController())) {
+      items.push(item);
+    }
+
+    expect(response.headers.get("content-type")).toContain("text/event-stream");
+    // The two original SSE frames should be parsed back as two distinct items,
+    // not collapsed into a single broken `data: data: {...}` frame.
+    expect(items).toEqual([
+      { choices: [{ delta: { content: "hi" } }] },
+      { choices: [{ delta: { content: " there" } }] },
+    ]);
+  });
+
   it("does not clone Request bodies while checking for streaming JSON fallbacks", async () => {
     const cloneSpy = vi.spyOn(Request.prototype, "clone");
     fetchWithSsrFGuardMock.mockResolvedValue({

--- a/src/agents/provider-transport-fetch.ts
+++ b/src/agents/provider-transport-fetch.ts
@@ -126,7 +126,16 @@ function sanitizeOpenAISdkSseResponse(
               buffer += decoder.decode();
               const data = buffer.trim();
               if (data) {
-                controller.enqueue(encoder.encode(`data: ${data}\n\n`));
+                // Some OpenAI-compatible gateways return SSE-formatted bodies
+                // under a non-SSE content-type (e.g. `application/json`).
+                // Wrapping such bodies as a single `data:` frame produces
+                // `data: data: {...}` and breaks the OpenAI SDK stream parser.
+                // Pass SSE-shaped bodies through with their original framing.
+                if (classifyOpenAISdkStreamBodyPrefix(data) === "sse") {
+                  controller.enqueue(encoder.encode(`${data}\n\n`));
+                } else {
+                  controller.enqueue(encoder.encode(`data: ${data}\n\n`));
+                }
               }
               controller.enqueue(encoder.encode("data: [DONE]\n\n"));
               controller.close();


### PR DESCRIPTION
## What Problem This Solves

Fixes #96497.

Custom OpenAI-compatible gateways that return a standard SSE body (`data: {...}\n\n`) under a `Content-Type: application/json` header (or any `+json` variant) trigger OpenClaw's JSON-to-SSE synthesis path, which wraps the entire body as a single `data:` frame. The OpenAI SDK stream parser then sees `data: data: {...}` and fails with `Unexpected token 'd', \"data: {\"id\"... is not valid JSON`, breaking the agent run before any reply is produced. The issue reports this as a 2026.6.x regression — the synthesis path exists to recover streaming when an upstream drops the content-type, but it currently assumes any JSON-typed body is a single JSON object.

## Why This Change Was Made

The synthesis path runs whenever a streaming request (`stream: true`) gets a JSON-typed response. Before wrapping the body as `data: ${body}\n\n`, check whether the body is already SSE-shaped using the existing `classifyOpenAISdkStreamBodyPrefix` helper. If the body classifies as SSE, emit it verbatim (plus the `data: [DONE]\n\n` terminator the OpenAI SDK expects). Otherwise, retain the current single-frame wrap for genuine JSON bodies.

This reuses an existing classifier (no new heuristic), keeps the happy-path JSON synthesis behavior intact, and only loosens the wrap for bodies that already carry SSE framing.

## User Impact

Streaming against OpenAI-compatible gateways that mislabel SSE as JSON (vLLM and Ollama proxies have been reported in the wild) now works without a JSON parse failure. Users on compliant gateways see no behavior change — the synthesis path is unchanged for bodies that classify as JSON.

## Evidence

- New regression test `passes SSE-shaped bodies through unchanged under JSON content-type (#96497)` constructs a two-frame SSE body under `application/json; charset=utf-8`, runs it through `buildGuardedModelFetch`, and asserts the two original frames parse back as two distinct items (not one collapsed `data: data: {...}` frame).
- Existing happy-path tests still pass:
  - `synthesizes SSE frames for JSON bodies returned to streaming OpenAI SDK requests` — JSON body still wraps as `data: {...}\n\n`.
  - `continues reading split JSON bodies before synthesizing streaming SSE frames` — chunked JSON accumulation still works.
- `pnpm test src/agents/provider-transport-fetch.test.ts` — 77/77 pass.
- `pnpm tsgo:core` — clean.