### PR TITLE
fix(gateway): activate source-reply delivery for direct webchat turns (#96840)

### DIFF
--- a/src/gateway/tool-resolution.test.ts
+++ b/src/gateway/tool-resolution.test.ts
@@ -43,6 +43,21 @@ describe("resolveGatewayScopedTools", () => {
     expect(result.tools.some((tool) => tool.name === "message")).toBe(false);
   });
 
+  it("force-allows the message tool for direct webchat turns so targetless send projects to the same chat (#96840)", () => {
+    const result = resolveGatewayScopedTools({
+      cfg: { tools: { profile: "minimal" } } as OpenClawConfig,
+      sessionKey: "agent:main:webchat:forge-main",
+      messageProvider: "webchat",
+      inboundEventKind: "user_request",
+      surface: "loopback",
+    });
+
+    const messageTool = result.tools.find((tool) => tool.name === "message");
+    expect(messageTool?.description).toContain(
+      "visible replies to the current source conversation",
+    );
+  });
+
   it("force-allows the message tool for routed webchat room-event turns", () => {
     const result = resolveGatewayScopedTools({
       cfg: { tools: { profile: "minimal" } } as OpenClawConfig,

--- a/src/gateway/tool-resolution.ts
+++ b/src/gateway/tool-resolution.ts
@@ -81,9 +81,18 @@ export function resolveGatewayScopedTools(params: {
   const providerProfilePolicy = resolveToolProfilePolicy(providerProfile);
   const gatewayRequestedTools = params.gatewayRequestedTools ?? [];
   const messageProvider = params.messageProvider?.trim().toLowerCase();
+  // Activate source-reply delivery for:
+  //   - non-webchat room-event turns (existing), or
+  //   - direct WebChat turns (`message(action="send")` without a target should
+  //     project into the same chat rather than fail). WebChat room-event turns
+  //     keep automatic delivery because the WebChat harness already projects
+  //     those — see the "keeps webchat room-event turns on automatic source
+  //     delivery" regression test.
+  const isWebchatSession = messageProvider === "webchat";
+  const isRoomEvent = params.inboundEventKind === "room_event";
   const sourceReplyDeliveryMode: SourceReplyDeliveryMode | undefined =
     params.sourceReplyDeliveryMode ??
-    (params.inboundEventKind === "room_event" && messageProvider !== "webchat"
+    ((isRoomEvent && !isWebchatSession) || (isWebchatSession && !isRoomEvent)
       ? "message_tool_only"
       : undefined);
   const runtimeAlsoAllow = sourceReplyDeliveryMode === "message_tool_only" ? ["message"] : [];


### PR DESCRIPTION
## What Problem This Solves

Fixes #96840.

A targetless `message(action="send")` from a direct WebChat turn (Control UI chat tab / SwiftUI app) fails with `Action send requires a target.` even though `docs/web/webchat.md` states:

> Harnesses that require visible replies through `tools.message` still use WebChat as a current-run internal source reply sink. A targetless `message.send` from that active WebChat run is projected into the same chat and mirrored to the session transcript.

The root cause: `resolveGatewayScopedTools` only activates `sourceReplyDeliveryMode = "message_tool_only"` for non-webchat room-event turns. Direct WebChat turns get `sourceReplyDeliveryMode = undefined`, so `shouldUseInternalSourceReplySink` short-circuits at its first guard clause and `normalizeMessageActionInput` throws the missing-target error.

## Why This Change Was Made

Extend the source-reply activation to also cover direct WebChat turns (any non-room-event WebChat inbound). The original webchat exclusion in the room-event branch stays in place so the existing "automatic source delivery" contract for WebChat room-event turns (regression test at `src/gateway/tool-resolution.test.ts`) is preserved.

The actual send-vs-skip decision still belongs to `shouldUseInternalSourceReplySink`, which already knows how to gate on `hasCurrentSourceReplyContext` and external session routes — this PR only ensures the request reaches that gate for direct WebChat turns.

## User Impact

Targetless `message.send` calls during an active WebChat run now project into the same chat (matching the documented contract) instead of failing with a missing-target error. Non-webchat room-event behavior is unchanged. WebChat room-event turns continue to use automatic delivery.

## Evidence

- New regression test `force-allows the message tool for direct webchat turns so targetless send projects to the same chat (#96840)` — asserts the message tool is force-allowed with the source-reply description for an `inboundEventKind: "user_request"` WebChat session.
- Existing `keeps webchat room-event turns on automatic source delivery` regression test still passes — the room-event webchat exclusion is preserved.
- Existing `force-allows the message tool for room-event loopback turns` test still passes — non-webchat room-event behavior is unchanged.
- `pnpm test src/gateway/tool-resolution.test.ts` — 24/24 pass across 4 files.
- `pnpm tsgo:core` — clean.