### PR TITLE
fix(cli): skip gateway secrets.resolve for exec-backed command targets (#96653)

### DIFF
--- a/src/cli/command-secret-gateway.test.ts
+++ b/src/cli/command-secret-gateway.test.ts
@@ -623,7 +623,6 @@ describe("resolveCommandSecretRefsViaGateway", () => {
 
   it("keeps local exec SecretRef fallback enabled by default", async () => {
     const { config, markerPath } = await createExecProviderConfig("talk/providers/api-key");
-    callGateway.mockRejectedValueOnce(new Error("gateway closed"));
 
     const result = await resolveCommandSecretRefsViaGateway({
       config,
@@ -632,15 +631,23 @@ describe("resolveCommandSecretRefsViaGateway", () => {
       mode: "read_only_status",
     });
 
+    // The gateway RPC cannot resolve exec-backed targets from the active
+    // snapshot, so we skip the round-trip and resolve locally.
+    expect(callGateway).not.toHaveBeenCalled();
     expect(await markerExists(markerPath)).toBe(true);
     expect(readTalkProviderApiKey(result.resolvedConfig)).toBe("exec-local-key");
     expect(result.targetStatesByPath[TALK_TEST_PROVIDER_API_KEY_PATH]).toBe("resolved_local");
-    expectGatewayUnavailableLocalFallbackDiagnostics(result);
+    expect(
+      result.diagnostics.some((entry) =>
+        entry.includes(
+          "memory status: skipped gateway secrets.resolve because command targets use exec SecretRefs at talk.providers.acme-speech.apiKey",
+        ),
+      ),
+    ).toBe(true);
   });
 
   it("skips local exec SecretRef fallback when the caller disallows exec providers", async () => {
     const { config, markerPath } = await createExecProviderConfig("talk/providers/api-key");
-    callGateway.mockRejectedValueOnce(new Error("gateway closed"));
 
     const result = await resolveCommandSecretRefsViaGateway({
       config,
@@ -650,6 +657,7 @@ describe("resolveCommandSecretRefsViaGateway", () => {
       allowLocalExecSecretRefs: false,
     });
 
+    expect(callGateway).not.toHaveBeenCalled();
     expect(await markerExists(markerPath)).toBe(false);
     expect(readTalkProviderApiKey(result.resolvedConfig)).toBeUndefined();
     expect(result.targetStatesByPath[TALK_TEST_PROVIDER_API_KEY_PATH]).toBe("unresolved");
@@ -663,16 +671,10 @@ describe("resolveCommandSecretRefsViaGateway", () => {
         ),
       ),
     ).toBe(true);
-    expect(
-      result.diagnostics.some((entry) =>
-        entry.includes("attempted local command-secret resolution"),
-      ),
-    ).toBe(true);
   });
 
   it("can preserve unresolved SecretRefs when local exec fallback is disabled", async () => {
     const { config, markerPath } = await createExecProviderConfig("talk/providers/api-key");
-    callGateway.mockRejectedValueOnce(new Error("gateway closed"));
 
     const result = await resolveCommandSecretRefsViaGateway({
       config,
@@ -683,6 +685,7 @@ describe("resolveCommandSecretRefsViaGateway", () => {
       scrubUnresolvedSecretRefs: false,
     });
 
+    expect(callGateway).not.toHaveBeenCalled();
     expect(await markerExists(markerPath)).toBe(false);
     expect(readTalkProviderApiKey(result.resolvedConfig)).toEqual({
       source: "exec",
@@ -746,6 +749,67 @@ describe("resolveCommandSecretRefsViaGateway", () => {
         ).toBe(true);
       },
     );
+  });
+
+  it("skips gateway resolution when agent-runtime targets use exec SecretRefs (#96653)", async () => {
+    const restoreDeps = setSingleSecretTargetDeps({
+      path: "models.providers.anthropic.apiKey",
+      pathSegments: ["models", "providers", "anthropic", "apiKey"],
+    });
+    try {
+      await withEnvAsync(
+        {
+          ANTHROPIC_API_KEY_LOCAL: "exec-local-key",
+        },
+        async () => {
+          const result = await resolveCommandSecretRefsViaGateway({
+            config: {
+              models: {
+                providers: {
+                  anthropic: {
+                    apiKey: { source: "exec", provider: "vault", id: "anthropic/api-key" },
+                  },
+                },
+              },
+              secrets: {
+                providers: {
+                  vault: {
+                    source: "exec",
+                    command: process.execPath,
+                    args: [
+                      "-e",
+                      "process.stdout.write(JSON.stringify({protocolVersion:1,values:{'anthropic/api-key':'exec-local-key'}}))",
+                    ],
+                    allowInsecurePath: true,
+                    allowSymlinkCommand: true,
+                    jsonOnly: true,
+                  },
+                },
+              },
+            } as unknown as OpenClawConfig,
+            commandName: "reply",
+            targetIds: new Set(["models.providers.*.apiKey"]),
+          });
+
+          // The gateway RPC would only return UNAVAILABLE for exec-backed
+          // targets and force a local fallback; skip the noisy round-trip.
+          expect(callGateway).not.toHaveBeenCalled();
+          expect(result.resolvedConfig.models?.providers?.anthropic?.apiKey).toBe("exec-local-key");
+          expect(result.targetStatesByPath["models.providers.anthropic.apiKey"]).toBe(
+            "resolved_local",
+          );
+          expect(
+            result.diagnostics.some((entry) =>
+              entry.includes(
+                "reply: skipped gateway secrets.resolve because command targets use exec SecretRefs at models.providers.anthropic.apiKey",
+              ),
+            ),
+          ).toBe(true);
+        },
+      );
+    } finally {
+      restoreDeps();
+    }
   });
 
   it("falls back to local resolution for web search SecretRefs when gateway is unavailable", async () => {

--- a/src/cli/command-secret-gateway.ts
+++ b/src/cli/command-secret-gateway.ts
@@ -6,7 +6,7 @@ import {
 } from "../../packages/gateway-protocol/src/client-info.js";
 import { validateSecretsResolveResult } from "../../packages/gateway-protocol/src/index.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { resolveSecretInputRef } from "../config/types.secrets.js";
+import { resolveSecretInputRef, type SecretRef } from "../config/types.secrets.js";
 import { callGateway } from "../gateway/call.js";
 import { gatewaySecretInputPathCanWin } from "../gateway/credentials-secret-inputs.js";
 import {
@@ -328,9 +328,13 @@ function collectConfiguredTargetRefPaths(params: {
   config: OpenClawConfig;
   targetIds: Set<string>;
   allowedPaths?: ReadonlySet<string>;
-}): Set<string> {
+}): {
+  paths: Set<string>;
+  refsByPath: Map<string, SecretRef>;
+} {
   const defaults = params.config.secrets?.defaults;
   const configuredTargetRefPaths = new Set<string>();
+  const refsByPath = new Map<string, SecretRef>();
   for (const target of commandSecretGatewayDeps.discoverConfigSecretTargetsByIds(
     params.config,
     params.targetIds,
@@ -345,25 +349,29 @@ function collectConfiguredTargetRefPaths(params: {
     });
     if (ref) {
       configuredTargetRefPaths.add(target.path);
+      refsByPath.set(target.path, ref);
     }
   }
-  return configuredTargetRefPaths;
+  return { paths: configuredTargetRefPaths, refsByPath };
 }
 
 function classifyConfiguredTargetRefs(params: {
   config: OpenClawConfig;
   configuredTargetRefPaths: Set<string>;
+  refsByPath?: Map<string, SecretRef>;
   forcedActivePaths?: ReadonlySet<string>;
   optionalActivePaths?: ReadonlySet<string>;
 }): {
   hasActiveConfiguredRef: boolean;
   hasUnknownConfiguredRef: boolean;
+  activeExecBackedPaths: string[];
   diagnostics: string[];
 } {
   if (params.configuredTargetRefPaths.size === 0) {
     return {
       hasActiveConfiguredRef: false,
       hasUnknownConfiguredRef: false,
+      activeExecBackedPaths: [],
       diagnostics: [],
     };
   }
@@ -388,6 +396,7 @@ function classifyConfiguredTargetRefs(params: {
   const diagnostics = new Set<string>();
   let hasActiveConfiguredRef = false;
   let hasUnknownConfiguredRef = false;
+  const activeExecBackedPaths: string[] = [];
 
   for (const path of params.configuredTargetRefPaths) {
     if (
@@ -396,6 +405,13 @@ function classifyConfiguredTargetRefs(params: {
       params.optionalActivePaths?.has(path)
     ) {
       hasActiveConfiguredRef = true;
+      // The gateway's command-path resolver only reads pre-resolved values
+      // from the active snapshot; it cannot execute exec providers itself.
+      // Track exec-backed active targets so the caller can skip the round-trip
+      // and resolve them locally instead of producing a noisy UNAVAILABLE log.
+      if (params.refsByPath?.get(path)?.source === "exec") {
+        activeExecBackedPaths.push(path);
+      }
       continue;
     }
     const inactiveWarning = inactiveWarningsByPath.get(path);
@@ -409,6 +425,7 @@ function classifyConfiguredTargetRefs(params: {
   return {
     hasActiveConfiguredRef,
     hasUnknownConfiguredRef,
+    activeExecBackedPaths,
     diagnostics: [...diagnostics],
   };
 }
@@ -908,7 +925,7 @@ export async function resolveCommandSecretRefsViaGateway(params: {
     allowLocalExecSecretRefs: params.allowLocalExecSecretRefs,
     scrubUnresolvedSecretRefs: params.scrubUnresolvedSecretRefs,
   });
-  const configuredTargetRefPaths = collectConfiguredTargetRefPaths({
+  const { paths: configuredTargetRefPaths, refsByPath } = collectConfiguredTargetRefPaths({
     config: params.config,
     targetIds: params.targetIds,
     allowedPaths: params.allowedPaths,
@@ -924,6 +941,7 @@ export async function resolveCommandSecretRefsViaGateway(params: {
   const preflight = classifyConfiguredTargetRefs({
     config: params.config,
     configuredTargetRefPaths,
+    refsByPath,
     forcedActivePaths: params.forcedActivePaths,
     optionalActivePaths: params.optionalActivePaths,
   });
@@ -950,6 +968,24 @@ export async function resolveCommandSecretRefsViaGateway(params: {
       optionalActivePaths: params.optionalActivePaths,
       resolutionPolicy,
       reasonDiagnostic: `${params.commandName}: skipped gateway secrets.resolve because gateway credentials use exec SecretRefs at ${gatewayExecSecretRefCredentialPaths.join(", ")}; rerun with --allow-exec to execute configured exec providers.`,
+    });
+  }
+  if (preflight.activeExecBackedPaths.length > 0) {
+    // Command-path resolution on the gateway only reads pre-resolved values
+    // from the active snapshot; exec-backed refs the snapshot has not yet
+    // resolved will surface as a per-turn UNAVAILABLE failure even though
+    // local fallback succeeds. Skip the round-trip and resolve locally.
+    return await resolveCommandSecretRefsWithoutGateway({
+      config: params.config,
+      commandName: params.commandName,
+      targetIds: params.targetIds,
+      preflightDiagnostics: preflight.diagnostics,
+      mode,
+      allowedPaths: params.allowedPaths,
+      forcedActivePaths: params.forcedActivePaths,
+      optionalActivePaths: params.optionalActivePaths,
+      resolutionPolicy,
+      reasonDiagnostic: `${params.commandName}: skipped gateway secrets.resolve because command targets use exec SecretRefs at ${preflight.activeExecBackedPaths.join(", ")} that the gateway cannot resolve from the active snapshot; resolving locally.`,
     });
   }
 


### PR DESCRIPTION
## What Problem This Solves

On every agent **reply** turn, the gateway logs a noisy failure for `secrets.resolve` when a model-provider credential is an `exec` SecretRef, even though the gateway resolved that same secret fine at startup and the turn proceeds normally via local fallback (~1 line/turn; thousands over time):

```
[ws] ⇄ res ✗ secrets.resolve 6ms errorCode=UNAVAILABLE errorMessage=secrets.resolve failed conn=… id=…
```

Closes #96653.

## Why This Change Was Made

The gateway's command-path resolver only reads pre-resolved values from the active snapshot; it cannot execute exec providers itself. For exec-backed agent-runtime/model-provider SecretRefs (e.g. `models.providers.<name>.apiKey`), the per-turn `secrets.resolve` RPC is therefore guaranteed to fail with `UNAVAILABLE`, after which the client falls back to local resolution and succeeds. The round-trip is pure overhead + noise, and the misleading `⚠️ UNAVAILABLE` line drowns out real failures during debugging.

The existing skip in `resolveCommandSecretRefsViaGateway` only covers gateway-credential exec refs (`gateway.auth.*`/`gateway.remote.*`) because those would prevent gateway authentication. The agent-runtime/model-provider case has the same futility but was not covered.

## User Impact

- Operators using exec-backed model-provider credentials (e.g. `models.providers.<name>.apiKey = { source: "exec", ... }`) no longer get a misleading per-turn `secrets.resolve UNAVAILABLE` log entry on reply turns.
- Reply-path secret resolution behavior is otherwise unchanged: the secret still resolves locally and the turn proceeds normally.
- Diagnostics now include a single `reply: skipped gateway secrets.resolve because command targets use exec SecretRefs at <paths> that the gateway cannot resolve from the active snapshot; resolving locally.` line that makes the intent clear.

## Evidence

- `pnpm test src/cli/command-secret-gateway.test.ts` — 35/35 pass on local run (Node 22).
- New regression test `skips gateway resolution when agent-runtime targets use exec SecretRefs (#96653)` asserts `callGateway` is NOT called, the exec provider resolves locally (`exec-local-key`), and the new skip diagnostic is emitted.
- Updated `keeps local exec SecretRef fallback enabled by default`, `skips local exec SecretRef fallback when the caller disallows exec providers`, and `can preserve unresolved SecretRefs when local exec fallback is disabled` to reflect that the gateway RPC is now skipped; their core assertions (exec marker present/absent, resolved/unresolved state, local exec skip diagnostic) are preserved.
- `git diff --numstat`: 40/-4 in `command-secret-gateway.ts`, 75/-9 in `command-secret-gateway.test.ts`. Non-test LOC growth ~36 from a new helper return field, a new skip branch, and inline comments explaining the gateway-snapshot invariant.