### PR TITLE
fix(matrix): dedupe poll answers before applying max_selections

### DIFF
--- a/extensions/matrix/src/matrix/poll-types.test.ts
+++ b/extensions/matrix/src/matrix/poll-types.test.ts
@@ -183,6 +183,48 @@ describe("buildPollResultsSummary", () => {
     expect(summary?.totalVotes).toBe(1);
   });
 
+  it("dedupes duplicate answer ids before applying max_selections", () => {
+    const summary = buildPollResultsSummary({
+      pollEventId: "$p",
+      roomId: "!r",
+      sender: "@host:x",
+      senderName: "H",
+      content: {
+        "m.poll.start": {
+          question: { "m.text": "Q" },
+          kind: "m.poll.disclosed",
+          max_selections: 2,
+          answers: [
+            { id: "a1", "m.text": "A1" },
+            { id: "a2", "m.text": "A2" },
+            { id: "a3", "m.text": "A3" },
+          ],
+        },
+      },
+      relationEvents: [
+        {
+          event_id: "$v1",
+          sender: "@bob:x",
+          type: "m.poll.response",
+          origin_server_ts: 1,
+          content: {
+            "m.poll.response": { answers: ["a1", "a1", "a2"] },
+            "m.relates_to": { rel_type: "m.reference", event_id: "$p" },
+          },
+        },
+      ],
+    });
+
+    // Duplicate "a1" must not consume a selection slot: both distinct
+    // selections (within max_selections=2) should be counted.
+    expect(summary?.entries).toEqual([
+      { id: "a1", text: "A1", votes: 1 },
+      { id: "a2", text: "A2", votes: 1 },
+      { id: "a3", text: "A3", votes: 0 },
+    ]);
+    expect(summary?.totalVotes).toBe(1);
+  });
+
   it("formats disclosed poll results with vote totals", () => {
     const text = formatPollResultsAsText({
       eventId: "$poll",

--- a/extensions/matrix/src/matrix/poll-types.ts
+++ b/extensions/matrix/src/matrix/poll-types.ts
@@ -308,10 +308,9 @@ export function buildPollResultsSummary(params: {
       new Set(
         rawAnswers
           .map((answerId) => normalizeOptionalString(answerId) ?? "")
-          .filter((answerId) => answerIds.has(answerId))
-          .slice(0, parsed.maxSelections),
+          .filter((answerId) => answerIds.has(answerId)),
       ),
-    );
+    ).slice(0, parsed.maxSelections);
     latestVoteBySender.set(senderId, {
       ts: eventTs,
       eventId: typeof event.event_id === "string" ? event.event_id : "",


### PR DESCRIPTION
## What Problem This Solves

Matrix poll submissions currently enforce max_selections before removing duplicate answer IDs. A repeated valid ID can consume the selection budget and drop a later distinct answer.

## Why This Change Was Made

The Matrix poll response contract should treat duplicate selections as one answer while preserving first-seen order. This keeps the existing unknown-answer filtering behavior and applies max_selections to the distinct answers the user selected.

## User Impact

Users who accidentally submit the same Matrix poll option more than once no longer lose a separate valid selection because of the duplicate entry.

## Evidence

- git diff --check origin/main...HEAD
- node scripts/run-vitest.mjs extensions/matrix/src/matrix/poll-types.test.ts
- .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
