### PR TITLE
fix(feishu): truncate streaming-card summary on code-point boundaries

### DIFF
--- a/extensions/feishu/src/streaming-card.test.ts
+++ b/extensions/feishu/src/streaming-card.test.ts
@@ -341,6 +341,72 @@ describe("FeishuStreamingSession", () => {
     });
   });
 
+  it("drops a surrogate pair whole when truncating the closeout summary", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(4_200);
+    // 46 'a' + 😀 (U+1F600, UTF-16 indices 46-47) + 20 'b' = 68-char string.
+    // truncateSummary's default max is 50, so it slices at max-3 = 47, which
+    // lands between the high and low surrogate halves of the emoji.
+    const finalText = `${"a".repeat(46)}\u{1F600}${"b".repeat(20)}`;
+    const settingsBodies: string[] = [];
+    const release = vi.fn(async () => {});
+    fetchWithSsrFGuardMock.mockImplementation(
+      async ({ url, init }: { url: string; init?: { body?: string } }) => {
+        if (url.includes("/auth/")) {
+          return {
+            response: {
+              ok: true,
+              json: async () => ({
+                code: 0,
+                msg: "ok",
+                tenant_access_token: "token",
+                expire: 7200,
+              }),
+            },
+            release,
+          };
+        }
+        if (url.includes("/settings")) {
+          settingsBodies.push(init?.body ?? "");
+        }
+        return {
+          response: { ok: true, status: 200, json: async () => ({ code: 0, msg: "ok" }) },
+          release,
+        };
+      },
+    );
+
+    const session = new FeishuStreamingSession({} as never, {
+      appId: "app_summary_surrogate",
+      appSecret: "secret",
+    });
+    setStreamingSessionInternals(session, {
+      state: {
+        cardId: "card_surrogate",
+        messageId: "om_surrogate",
+        sequence: 1,
+        currentText: "",
+        sentText: "",
+        hasNote: false,
+      },
+      lastUpdateTime: 3_000,
+    });
+
+    await session.close(finalText);
+
+    expect(settingsBodies).toHaveLength(1);
+    const settingsPayload = JSON.parse(settingsBodies[0] ?? "{}") as { settings?: string };
+    const settings = JSON.parse(settingsPayload.settings ?? "{}") as {
+      config?: { summary?: { content?: string } };
+    };
+    const summary = settings.config?.summary?.content ?? "";
+    // The half-emoji must be dropped whole: 46 a's + "...", and the summary
+    // must NOT end with a lone high surrogate (which Feishu renders as �).
+    expect(summary).toBe(`${"a".repeat(46)}...`);
+    expect(summary).not.toContain("\uD83D");
+    expect(summary.charCodeAt(summary.length - 4)).not.toBe(0xd83d);
+  });
+
   it("logs a final replacement failure when CardKit returns non-OK", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(4_500);

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -9,6 +9,7 @@ import {
   resolveExpiresAtMsFromDurationSeconds,
 } from "openclaw/plugin-sdk/number-runtime";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
+import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { getFeishuUserAgent } from "./client.js";
 import { requestFeishuApi } from "./comment-shared.js";
 import { resolveFeishuCardTemplate, type CardHeaderConfig } from "./send.js";
@@ -138,7 +139,10 @@ function truncateSummary(text: string, max = 50): string {
     return "";
   }
   const clean = text.replace(/\n/g, " ").trim();
-  return clean.length <= max ? clean : clean.slice(0, max - 3) + "...";
+  // Slice on a code-point boundary so a surrogate pair (emoji / astral char)
+  // straddling the limit is dropped whole, instead of leaving a lone surrogate
+  // half that Feishu renders as the replacement char.
+  return clean.length <= max ? clean : sliceUtf16Safe(clean, 0, max - 3) + "...";
 }
 
 function hasNaturalStreamingBoundary(text: string): boolean {


### PR DESCRIPTION
## What Problem This Solves

Feishu streaming-card summary truncation could slice directly through a UTF-16 surrogate pair when a long summary placed an emoji at the boundary.

## Why This Change Was Made

The streaming-card summary now uses the shared surrogate-safe truncation helper so Feishu receives valid text while the existing summary limit and fallback behavior stay unchanged.

## User Impact

Long Feishu streaming-card summaries containing emoji or other astral characters no longer render replacement characters or malformed text at the truncation boundary.

## Evidence

- git diff --check origin/main...HEAD
- node scripts/run-vitest.mjs extensions/feishu/src/streaming-card.test.ts
- .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main


## After-fix Proof

Ran on the PR branch:

```text
node scripts/run-vitest.mjs extensions/feishu/src/streaming-card.test.ts --reporter=verbose
# exit 0
```

Additional boundary probe against the PR branch source:

```json
{
  "usesSafeSlice": true,
  "inputLength": 68,
  "outputLength": 49,
  "hasLoneSurrogate": false,
  "outputTailCodeUnits": [
    "61",
    "61",
    "61",
    "2e",
    "2e",
    "2e"
  ]
}
```

The probe uses the same 50-code-unit summary limit and an emoji at the truncation boundary. `hasLoneSurrogate: false` confirms the after-fix summary no longer leaves a dangling UTF-16 surrogate before the ellipsis.
