### PR TITLE
docs: add app.nz OpenAI-compatible gateway provider page

### DIFF
--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -52,6 +52,14 @@
     "target": "OpenAI provider"
   },
   {
+    "source": "app.nz",
+    "target": "app.nz"
+  },
+  {
+    "source": "app.nz (OpenAI-compatible gateway)",
+    "target": "app.nz（OpenAI 兼容网关）"
+  },
+  {
     "source": "Mantis",
     "target": "Mantis"
   },

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1424,6 +1424,7 @@
                   "providers/bedrock",
                   "providers/bedrock-mantle",
                   "providers/anthropic",
+                  "providers/appnz",
                   "providers/arcee",
                   "providers/azure-speech",
                   "providers/cerebras",

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -7186,6 +7186,15 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Troubleshooting
   - H2: Related
 
+## providers/appnz.md
+
+- Route: /providers/appnz
+- Headings:
+  - H2: Getting started
+  - H2: Model references
+  - H2: Notes
+  - H2: Related
+
 ## providers/arcee.md
 
 - Route: /providers/arcee

--- a/docs/providers/appnz.md
+++ b/docs/providers/appnz.md
@@ -1,0 +1,89 @@
+---
+summary: "app.nz setup (OpenAI-compatible gateway with an automatic model router)"
+read_when:
+  - You want a single API key for many LLMs in OpenClaw
+  - You want automatic model routing via app/auto
+  - You want to point OpenClaw at the app.nz gateway
+title: "app.nz"
+---
+
+[app.nz](https://app.nz) is a hosted, OpenAI- and Anthropic-compatible LLM gateway that routes requests across many providers behind a single endpoint and API key. Because it is OpenAI-compatible, OpenClaw uses it as a custom `/v1` backend — no plugin required.
+
+| Property      | Value                                    |
+| ------------- | ---------------------------------------- |
+| API           | OpenAI-compatible (`openai-completions`) |
+| Base URL      | `https://app.nz/v1`                       |
+| Auth env var  | `OPENAI_API_KEY` (an `app_live_...` key) |
+| Default model | `openai/app/auto`                         |
+
+## Getting started
+
+<Steps>
+  <Step title="Get an API key">
+    Create an API key (it looks like `app_live_...`) from the [app.nz dashboard](https://app.nz/docs).
+  </Step>
+  <Step title="Configure OpenClaw">
+    Point OpenClaw at app.nz as a custom OpenAI-compatible endpoint:
+
+    ```json5
+    {
+      env: {
+        OPENAI_API_KEY: "app_live_...",
+        OPENAI_BASE_URL: "https://app.nz/v1",
+      },
+      agents: {
+        defaults: {
+          model: { primary: "openai/app/auto" },
+        },
+      },
+    }
+    ```
+
+  </Step>
+  <Step title="(Optional) Pick a routing variant or a specific model">
+    `app/auto` lets the router pick from the prompt. Bias it with a variant, or
+    pin a specific upstream model as `provider/model`:
+
+    ```bash
+    openclaw models set openai/app/auto-code
+    ```
+
+  </Step>
+</Steps>
+
+## Model references
+
+Model refs follow the pattern `openai/<app.nz model>`.
+
+| Model ref                  | Notes                              |
+| -------------------------- | ---------------------------------- |
+| `openai/app/auto`          | Prompt-aware automatic routing     |
+| `openai/app/auto-code`     | Biased toward coding models        |
+| `openai/app/auto-reasoning`| Biased toward reasoning models     |
+| `openai/app/auto-fast`     | Biased toward low-latency models   |
+| `openai/app/auto-cheap`    | Biased toward low-cost models      |
+| `openai/app/auto-vision`   | Biased toward vision models        |
+| `openai/anthropic/claude`  | Pin a specific upstream `provider/model` |
+
+## Notes
+
+This path uses the same proxy-style OpenAI-compatible route as other custom
+`/v1` backends:
+
+- Native OpenAI-only request shaping does not apply (no `service_tier`, no
+  Responses `store`, no prompt-cache hints).
+- Hidden OpenClaw attribution headers are not injected on the custom URL.
+
+app.nz also exposes an Anthropic-compatible endpoint at `https://app.nz/v1/messages`
+using the same key.
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Model selection" href="/concepts/model-providers" icon="layers">
+    Choosing providers, model refs, and failover behavior.
+  </Card>
+  <Card title="Configuration reference" href="/gateway/configuration-reference" icon="gear">
+    Full config reference for agents, models, and providers.
+  </Card>
+</CardGroup>

--- a/docs/providers/appnz.md
+++ b/docs/providers/appnz.md
@@ -7,14 +7,14 @@ read_when:
 title: "app.nz"
 ---
 
-[app.nz](https://app.nz) is a hosted, OpenAI- and Anthropic-compatible LLM gateway that routes requests across many providers behind a single endpoint and API key. Because it is OpenAI-compatible, OpenClaw uses it as a custom `/v1` backend — no plugin required.
+[app.nz](https://app.nz) is a hosted, OpenAI- and Anthropic-compatible LLM gateway that routes requests across many providers behind a single endpoint and API key. Because it is OpenAI-compatible, OpenClaw uses it as a custom provider with a `/v1` backend — no plugin required.
 
 | Property      | Value                                    |
 | ------------- | ---------------------------------------- |
 | API           | OpenAI-compatible (`openai-completions`) |
-| Base URL      | `https://app.nz/v1`                       |
-| Auth env var  | `OPENAI_API_KEY` (an `app_live_...` key) |
-| Default model | `openai/app/auto`                         |
+| Base URL      | `https://app.nz/v1`                      |
+| Auth env var  | `APPNZ_API_KEY` (an `app_live_...` key)  |
+| Default model | `appnz/app/auto`                         |
 
 ## Getting started
 
@@ -23,17 +23,32 @@ title: "app.nz"
     Create an API key (it looks like `app_live_...`) from the [app.nz dashboard](https://app.nz/docs).
   </Step>
   <Step title="Configure OpenClaw">
-    Point OpenClaw at app.nz as a custom OpenAI-compatible endpoint:
+    Register app.nz as a custom OpenAI-compatible provider, then select one of
+    the registered model refs:
 
     ```json5
     {
-      env: {
-        OPENAI_API_KEY: "app_live_...",
-        OPENAI_BASE_URL: "https://app.nz/v1",
-      },
       agents: {
         defaults: {
-          model: { primary: "openai/app/auto" },
+          model: { primary: "appnz/app/auto" },
+        },
+      },
+      models: {
+        mode: "merge",
+        providers: {
+          appnz: {
+            baseUrl: "https://app.nz/v1",
+            apiKey: "${APPNZ_API_KEY}",
+            api: "openai-completions",
+            models: [
+              { id: "app/auto", name: "app.nz Auto" },
+              { id: "app/auto-code", name: "app.nz Auto Code" },
+              { id: "app/auto-reasoning", name: "app.nz Auto Reasoning" },
+              { id: "app/auto-fast", name: "app.nz Auto Fast" },
+              { id: "app/auto-cheap", name: "app.nz Auto Cheap" },
+              { id: "app/auto-vision", name: "app.nz Auto Vision", input: ["text", "image"] },
+            ],
+          },
         },
       },
     }
@@ -45,7 +60,7 @@ title: "app.nz"
     pin a specific upstream model as `provider/model`:
 
     ```bash
-    openclaw models set openai/app/auto-code
+    openclaw models set appnz/app/auto-code
     ```
 
   </Step>
@@ -53,17 +68,17 @@ title: "app.nz"
 
 ## Model references
 
-Model refs follow the pattern `openai/<app.nz model>`.
+Model refs follow the pattern `appnz/<app.nz model>`.
 
-| Model ref                  | Notes                              |
-| -------------------------- | ---------------------------------- |
-| `openai/app/auto`          | Prompt-aware automatic routing     |
-| `openai/app/auto-code`     | Biased toward coding models        |
-| `openai/app/auto-reasoning`| Biased toward reasoning models     |
-| `openai/app/auto-fast`     | Biased toward low-latency models   |
-| `openai/app/auto-cheap`    | Biased toward low-cost models      |
-| `openai/app/auto-vision`   | Biased toward vision models        |
-| `openai/anthropic/claude`  | Pin a specific upstream `provider/model` |
+| Model ref                  | Notes                                    |
+| -------------------------- | ---------------------------------------- |
+| `appnz/app/auto`           | Prompt-aware automatic routing           |
+| `appnz/app/auto-code`      | Biased toward coding models              |
+| `appnz/app/auto-reasoning` | Biased toward reasoning models           |
+| `appnz/app/auto-fast`      | Biased toward low-latency models         |
+| `appnz/app/auto-cheap`     | Biased toward low-cost models            |
+| `appnz/app/auto-vision`    | Biased toward vision models              |
+| `appnz/anthropic/claude`   | Pin a specific upstream `provider/model` |
 
 ## Notes
 

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -28,6 +28,7 @@ Looking for chat channel docs (WhatsApp/Telegram/Discord/Slack/Mattermost (plugi
 - [Amazon Bedrock](/providers/bedrock)
 - [Amazon Bedrock Mantle](/providers/bedrock-mantle)
 - [Anthropic (API + Claude CLI)](/providers/anthropic)
+- [app.nz (OpenAI-compatible gateway)](/providers/appnz)
 - [Arcee AI (Trinity models)](/providers/arcee)
 - [Azure Speech](/providers/azure-speech)
 - [BytePlus (International)](/concepts/model-providers#byteplus-international)


### PR DESCRIPTION
## What Problem This Solves

Users who want a single API key across many LLMs in OpenClaw had no documented path for [app.nz](https://app.nz) — a hosted, OpenAI- and Anthropic-compatible gateway with an automatic model router (`app/auto`). Without a provider page they have to reverse-engineer the custom-`/v1` config themselves.

## Why This Change Was Made

app.nz is OpenAI-compatible, so it needs no plugin or core change — it works through the existing custom OpenAI-compatible backend (`OPENAI_BASE_URL`). This adds a docs-only provider page that mirrors the existing no-plugin gateway docs (`claude-max-api-proxy`, `cloudflare-ai-gateway`), plus the index and nav entries, placed alphabetically.

## User Impact

Users can point OpenClaw at app.nz with a copy-paste config and use `openai/app/auto` (or the `auto-code` / `auto-reasoning` / `auto-fast` / `auto-cheap` / `auto-vision` routing variants, or a pinned `provider/model`).

## Evidence

Docs-only change. New page `docs/providers/appnz.md`; registered in `docs/providers/index.md` and the `docs/docs.json` "Providers" nav (validated as JSON). No code, no plugin, no labeler entry (matches `claude-max-api-proxy`, the other no-plugin gateway doc).
