### PR TITLE
fix(memory-wiki): keep claim freshness tied to evidence timestamps

### DIFF
--- a/extensions/memory-wiki/src/claim-health.test.ts
+++ b/extensions/memory-wiki/src/claim-health.test.ts
@@ -116,4 +116,51 @@ describe("assessClaimFreshness", () => {
     expect(freshness.lastTouchedAt).toBe("2026-01-05T00:00:00.000Z");
     expect(freshness.daysSinceTouch).toBe(105);
   });
+
+  it("falls back to page freshness when claim and evidence timestamps are absent", () => {
+    const page = createPage({
+      relativePath: "entities/gamma.md",
+      title: "Gamma",
+      contradictions: [],
+    });
+    page.updatedAt = "2026-04-20T00:00:00.000Z";
+    const claim: WikiClaim = {
+      text: "Gamma was written through wiki_apply without per-claim timestamps.",
+      evidence: [{ kind: "session", sourceId: "session-1" }],
+    };
+
+    const freshness = assessClaimFreshness({
+      page,
+      claim,
+      now: new Date("2026-04-25T00:00:00.000Z"),
+    });
+
+    expect(freshness.level).toBe("fresh");
+    expect(freshness.lastTouchedAt).toBe("2026-04-20T00:00:00.000Z");
+    expect(freshness.daysSinceTouch).toBe(5);
+  });
+
+  it("keeps malformed claim timestamps unknown instead of using page freshness", () => {
+    const page = createPage({
+      relativePath: "entities/delta.md",
+      title: "Delta",
+      contradictions: [],
+    });
+    page.updatedAt = "2026-04-20T00:00:00.000Z";
+    const claim: WikiClaim = {
+      text: "Delta has malformed claim freshness metadata.",
+      updatedAt: "not-a-date",
+      evidence: [],
+    };
+
+    const freshness = assessClaimFreshness({
+      page,
+      claim,
+      now: new Date("2026-04-25T00:00:00.000Z"),
+    });
+
+    expect(freshness.level).toBe("unknown");
+    expect(freshness.lastTouchedAt).toBeUndefined();
+    expect(freshness.reason).toBe("missing updatedAt");
+  });
 });

--- a/extensions/memory-wiki/src/claim-health.test.ts
+++ b/extensions/memory-wiki/src/claim-health.test.ts
@@ -1,7 +1,7 @@
 // Memory Wiki tests cover claim health plugin behavior.
 import { describe, expect, it } from "vitest";
-import { buildPageContradictionClusters } from "./claim-health.js";
-import type { WikiPageSummary } from "./markdown.js";
+import { assessClaimFreshness, buildPageContradictionClusters } from "./claim-health.js";
+import type { WikiClaim, WikiPageSummary } from "./markdown.js";
 
 function createPage(params: {
   relativePath: string;
@@ -62,5 +62,58 @@ describe("buildPageContradictionClusters", () => {
     expect(clusters).toHaveLength(2);
     expect(clusters.map((cluster) => cluster.key).toSorted()).toEqual(["किताब", "कीताब"]);
     expect(clusters.every((cluster) => cluster.entries)).toBe(true);
+  });
+});
+
+describe("assessClaimFreshness", () => {
+  it("uses the latest claim evidence timestamp without relying on page freshness", () => {
+    const page = createPage({
+      relativePath: "entities/alpha.md",
+      title: "Alpha",
+      contradictions: [],
+    });
+    page.updatedAt = "2026-01-01T00:00:00.000Z";
+    const claim: WikiClaim = {
+      text: "Alpha prefers current evidence.",
+      updatedAt: "2026-01-05T00:00:00.000Z",
+      evidence: [
+        { updatedAt: "2026-01-03T00:00:00.000Z" },
+        { updatedAt: "2026-01-20T00:00:00.000Z" },
+      ],
+    };
+
+    const freshness = assessClaimFreshness({
+      page,
+      claim,
+      now: new Date("2026-01-25T00:00:00.000Z"),
+    });
+
+    expect(freshness.level).toBe("fresh");
+    expect(freshness.lastTouchedAt).toBe("2026-01-20T00:00:00.000Z");
+    expect(freshness.daysSinceTouch).toBe(5);
+  });
+
+  it("does not let a newer page timestamp make stale claim evidence fresh", () => {
+    const page = createPage({
+      relativePath: "entities/beta.md",
+      title: "Beta",
+      contradictions: [],
+    });
+    page.updatedAt = "2026-04-20T00:00:00.000Z";
+    const claim: WikiClaim = {
+      text: "Beta still needs old evidence checked.",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      evidence: [{ updatedAt: "2026-01-05T00:00:00.000Z" }],
+    };
+
+    const freshness = assessClaimFreshness({
+      page,
+      claim,
+      now: new Date("2026-04-20T00:00:00.000Z"),
+    });
+
+    expect(freshness.level).toBe("stale");
+    expect(freshness.lastTouchedAt).toBe("2026-01-05T00:00:00.000Z");
+    expect(freshness.daysSinceTouch).toBe(105);
   });
 });

--- a/extensions/memory-wiki/src/claim-health.ts
+++ b/extensions/memory-wiki/src/claim-health.ts
@@ -136,11 +136,16 @@ export function assessClaimFreshness(params: {
   claim: WikiClaim;
   now?: Date;
 }): WikiFreshness {
-  const latestTimestamp = resolveLatestTimestamp([
-    params.claim.updatedAt,
-    params.page.updatedAt,
-    ...params.claim.evidence.map((evidence) => evidence.updatedAt),
-  ]);
+  let latestTimestamp = resolveLatestTimestamp([params.claim.updatedAt]);
+  let latestMs = parseTimestamp(latestTimestamp) ?? -1;
+  for (const evidence of params.claim.evidence) {
+    const evidenceMs = parseTimestamp(evidence.updatedAt);
+    if (evidenceMs === null || !evidence.updatedAt || evidenceMs <= latestMs) {
+      continue;
+    }
+    latestMs = evidenceMs;
+    latestTimestamp = evidence.updatedAt;
+  }
   return buildFreshnessFromTimestamp({ timestamp: latestTimestamp, now: params.now });
 }
 

--- a/extensions/memory-wiki/src/claim-health.ts
+++ b/extensions/memory-wiki/src/claim-health.ts
@@ -136,9 +136,14 @@ export function assessClaimFreshness(params: {
   claim: WikiClaim;
   now?: Date;
 }): WikiFreshness {
+  let hasClaimTimestamp = typeof params.claim.updatedAt === "string" &&
+    params.claim.updatedAt.trim().length > 0;
   let latestTimestamp = resolveLatestTimestamp([params.claim.updatedAt]);
   let latestMs = parseTimestamp(latestTimestamp) ?? -1;
   for (const evidence of params.claim.evidence) {
+    if (typeof evidence.updatedAt === "string" && evidence.updatedAt.trim().length > 0) {
+      hasClaimTimestamp = true;
+    }
     const evidenceMs = parseTimestamp(evidence.updatedAt);
     if (evidenceMs === null || !evidence.updatedAt || evidenceMs <= latestMs) {
       continue;
@@ -146,7 +151,10 @@ export function assessClaimFreshness(params: {
     latestMs = evidenceMs;
     latestTimestamp = evidence.updatedAt;
   }
-  return buildFreshnessFromTimestamp({ timestamp: latestTimestamp, now: params.now });
+  return buildFreshnessFromTimestamp({
+    timestamp: latestTimestamp ?? (hasClaimTimestamp ? undefined : params.page.updatedAt),
+    now: params.now,
+  });
 }
 
 function buildWikiClaimHealth(params: {


### PR DESCRIPTION
## What Problem This Solves

Memory-wiki claim freshness should prefer explicit claim/evidence timestamps. The old path could fall back to page-level freshness even when a claim carried malformed timestamp data, which can hide bad claim metadata as a page-level stale/fresh result.

This replaces the earlier attempt in #97420, which was closed only by the author queue limit after review pressure, not because the patch was invalid.

## Why This Change Was Made

The fix keeps page `updatedAt` as a fallback only for claims with no explicit claim/evidence timestamp fields. If the claim provides timestamp metadata but it is malformed, the result stays `unknown` instead of silently using page freshness.

## User Impact

Memory-wiki health reports better distinguish untimestamped claims from claims with broken timestamp metadata. That makes freshness signals more trustworthy without changing the healthy explicit-timestamp path.

## Evidence

- git diff --check
- node scripts/run-vitest.mjs extensions/memory-wiki/src/claim-health.test.ts
- .agents/skills/autoreview/scripts/autoreview --mode local

Autoreview result: clean; no accepted/actionable findings. The reviewer confirmed explicit claim/evidence timestamps remain authoritative, malformed explicit timestamps stay unknown, and page freshness is only a fallback when timestamps are absent.


## After-fix Real Behavior Proof

Ran a real memory-wiki compile against a temporary vault on this PR branch. The vault had two claims on a page with fresh page-level `updatedAt`:

- `claim.malformed-explicit`: claim/evidence timestamp fields present but malformed.
- `claim.untimestamped`: no claim/evidence timestamp fields, so it should still use page freshness.

Command shape: `node --import tsx ... compileMemoryWikiVault(config)` with `render.createDashboards=true`, then read `reports/claim-health.md` and `.openclaw-wiki/cache/claims.jsonl` from the compiled vault.

Redacted terminal output:

```json
{
  "rootDir": "<redacted-temp-vault>",
  "compiledClaimCount": 2,
  "reportPath": "reports/claim-health.md",
  "reportClaimHealthLines": [
    "- Stale or unknown claims: 1",
    "- [Claim Freshness Proof](../entities/claims.md): `claim.malformed-explicit`: Malformed explicit timestamp should not inherit page freshness. (status supported, 1 evidence, missing updatedAt)"
  ]
}
```

This proves the generated claim-health report path now surfaces the malformed explicit timestamp as unknown while the untimestamped claim is not listed as stale/unknown and continues to inherit the fresh page timestamp.
