### PR TITLE
fix(slack): truncate text on code-point boundaries

### DIFF
--- a/extensions/slack/src/truncate.test.ts
+++ b/extensions/slack/src/truncate.test.ts
@@ -1,0 +1,27 @@
+// Slack tests cover truncate plugin behavior.
+import { describe, expect, it } from "vitest";
+import { truncateSlackText } from "./truncate.js";
+
+describe("truncateSlackText", () => {
+  it("drops a surrogate-pair emoji whole when it straddles the limit", () => {
+    // "abc😀def": 😀 (U+1F600) sits at the cut point. Slicing by UTF-16 code unit
+    // would keep only its high surrogate — a lone \uD83D — before the ellipsis,
+    // which serializes to an invalid character in the Slack payload.
+    const out = truncateSlackText("abc😀def", 5);
+    expect(out).toBe("abc…");
+    // No dangling high surrogate (a high surrogate not followed by a low one).
+    expect(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/.test(out)).toBe(false);
+  });
+
+  it("truncates plain BMP text unchanged", () => {
+    expect(truncateSlackText("hello world", 5)).toBe("hell…");
+  });
+
+  it("keeps an emoji that fits before the cut", () => {
+    expect(truncateSlackText("😀abcdef", 5)).toBe("😀ab…");
+  });
+
+  it("returns the trimmed input unchanged when it fits", () => {
+    expect(truncateSlackText("ab😀cd", 10)).toBe("ab😀cd");
+  });
+});

--- a/extensions/slack/src/truncate.ts
+++ b/extensions/slack/src/truncate.ts
@@ -1,11 +1,16 @@
 // Slack plugin module implements truncate behavior.
+import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+
 export function truncateSlackText(value: string, max: number): string {
   const trimmed = value.trim();
   if (trimmed.length <= max) {
     return trimmed;
   }
+  // Slice on a code-point boundary so a surrogate pair (emoji / astral char)
+  // straddling the limit is dropped whole, instead of leaving a lone surrogate
+  // half that serializes to an invalid `\uD83D` in the Slack payload.
   if (max <= 1) {
-    return trimmed.slice(0, max);
+    return sliceUtf16Safe(trimmed, 0, max);
   }
-  return `${trimmed.slice(0, max - 1)}…`;
+  return `${sliceUtf16Safe(trimmed, 0, max - 1)}…`;
 }


### PR DESCRIPTION
## What Problem This Solves

Slack text truncation used raw UTF-16 slicing. If an emoji or other astral character straddled the Slack limit, the payload could contain a dangling surrogate half before the ellipsis.

## Why This Change Was Made

The Slack truncation helper now uses the existing plugin SDK `sliceUtf16Safe` helper, matching the surrogate-safe truncation invariant already used elsewhere while preserving plain BMP truncation behavior.

## User Impact

Long Slack messages containing emoji no longer produce malformed replacement characters at truncation boundaries.

## Evidence

- git diff --check origin/main...HEAD
- node scripts/run-vitest.mjs extensions/slack/src/truncate.test.ts
- .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main

Autoreview result: clean; no accepted/actionable findings.

## After-fix Proof

Boundary probe on this PR branch:

```json
{
  "usesSafeSlice": true,
  "output": "abc…",
  "outputLength": 4,
  "hasLoneSurrogate": false
}
```

The input was `abc😀def` with limit `5`, so the emoji straddles the truncation boundary. The after-fix output drops the emoji whole and leaves no lone UTF-16 surrogate.
