### PR TITLE
feat(durable): add workflow kernel primitives

### DIFF
--- a/docs/specs/durable-coordination-bridge-plan.md
+++ b/docs/specs/durable-coordination-bridge-plan.md
@@ -1,0 +1,319 @@
+---
+summary: "Plan for connecting Durable Core with Background Tasks, Task Flow, and Workboard"
+read_when:
+  - You are wiring native durable workflow state into OpenClaw task surfaces
+  - You need an upstream-friendly contract between Durable Core and Workboard
+  - You are debugging silent long-running agent coordination, fan-in, or gateway restart recovery
+title: "Durable Coordination Bridge Plan"
+---
+
+# Durable Coordination Bridge Plan
+
+This plan connects the native Durable Core with three existing OpenClaw surfaces:
+
+- Background Tasks: the operator ledger for detached work.
+- Task Flow: the multi-step orchestration view above tasks.
+- Workboard: the optional plugin control board for agent-owned work.
+
+The bridge must stay upstream-friendly. Durable Core must not import or require
+the Workboard plugin. Workboard should consume a generic durable projection when
+the plugin is enabled.
+
+## Architecture decision
+
+Durable Core is the source of truth for workflow identity, run state, step
+ordering, child links, retry, recovery, signals, timers, and event history.
+
+Background Tasks, Task Flow, and Workboard are projections and control surfaces:
+
+- Background Tasks show individual detached runtime work.
+- Task Flow shows human-readable multi-step progress.
+- Workboard shows operational cards, claims, dispatch, proof, diagnostics, and
+  recovery actions.
+
+The bridge is intentionally metadata-first at the beginning. Existing task and
+flow schemas already have `runId`, `parentFlowId`, `stateJson`, `waitJson`, and
+Workboard metadata. The first upstream-friendly PRs should avoid schema churn
+unless typed durable IDs become widely used.
+
+## Shared durable projection contract
+
+Durable Core exposes a small coordination projection:
+
+```ts
+type DurableCoordinationProjection = {
+  workflowRunId: string;
+  workflowId: string;
+  workflowVersion: string;
+  status: string;
+  recoveryState: string;
+  sourceType?: string;
+  sourceRef?: string;
+  parentWorkflowRunId?: string;
+  parentStepId?: string;
+  currentStepId?: string;
+  waitingReason?: "signal" | "timer" | "child" | "retry" | "worker" | "unknown";
+  heartbeatAt?: number;
+  updatedAt: number;
+  completedAt?: number;
+  refs: {
+    inputRef?: string;
+    checkpointRef?: string;
+    outputRefs: string[];
+    errorRefs: string[];
+    artifactRefs: string[];
+  };
+  external: {
+    taskId?: string;
+    taskFlowId?: string;
+    workboardCardId?: string;
+    sessionKey?: string;
+    runId?: string;
+    agentId?: string;
+    requesterAgentId?: string;
+  };
+  children: {
+    total: number;
+    pending: number;
+    running: number;
+    succeeded: number;
+    failed: number;
+    cancelled: number;
+    lost: number;
+    terminal: number;
+    open: number;
+  };
+  controls: {
+    canCancel: boolean;
+    canRetry: boolean;
+    canResume: boolean;
+    canSignal: boolean;
+    canOpenTimeline: boolean;
+  };
+};
+```
+
+This contract is stable enough for CLI, Gateway RPC, TaskFlow projections, and
+Workboard without making those systems depend on durable table internals.
+
+## Background Task bridge
+
+### Goals
+
+- Every subagent or detached agent task should be discoverable from its durable
+  workflow run.
+- A durable child workflow should preserve `taskId`, `parentFlowId`, `runId`,
+  `childSessionKey`, `agentId`, and `requesterAgentId`.
+- Task audit should be able to ask Durable Core whether a stale runtime is
+  truly lost, retryable, waiting for child, or unknown after side effect.
+
+### Initial implementation
+
+When a subagent run is registered:
+
+1. Create or update the Background Task record as today.
+2. Capture the returned `taskId` and one-task `parentFlowId`.
+3. Mirror those IDs into the durable child run metadata.
+4. Mirror the same IDs into the parent durable child link metadata.
+5. Preserve the IDs when the durable child reaches terminal state.
+
+### Later implementation
+
+- Add task audit reconciliation that checks durable state before marking a task
+  lost.
+- Add task CLI fields:
+  - `durable.workflowRunId`
+  - `durable.status`
+  - `durable.recoveryState`
+  - `durable.waitingReason`
+- Add a task cancel path that records a durable cancel signal before cancelling
+  backing runtime handles.
+
+## Task Flow bridge
+
+### Goals
+
+- Task Flow remains the human-readable orchestration surface.
+- Durable Core owns fan-in/fan-out, retries, timers, and recovery.
+- A TaskFlow can be managed by Durable Core without rewriting TaskFlow storage.
+
+### Metadata convention
+
+TaskFlow `stateJson` may include:
+
+```json
+{
+  "durable": {
+    "workflowRunId": "wfr_...",
+    "workflowId": "openclaw.agent.turn",
+    "status": "waiting_child",
+    "recoveryState": "waiting_child",
+    "currentStepId": "subagents",
+    "waitingReason": "child",
+    "children": {
+      "total": 3,
+      "running": 1,
+      "succeeded": 1,
+      "failed": 1,
+      "open": 1
+    },
+    "updatedAt": 1234567890
+  }
+}
+```
+
+TaskFlow `waitJson` may include:
+
+```json
+{
+  "durable": {
+    "waitingReason": "child",
+    "workflowRunId": "wfr_...",
+    "stepId": "subagents"
+  }
+}
+```
+
+### Initial implementation
+
+- Add a pure Durable Core projection builder that can produce TaskFlow-safe JSON.
+- Keep TaskFlow writes out of Durable Core in the first bridge PR.
+- Let TaskFlow runtime or gateway later opt into writing the projection.
+
+### Later implementation
+
+- Add a TaskFlow sync job:
+  - finds flows with durable bindings;
+  - reads durable projection;
+  - updates `status/currentStep/stateJson/waitJson`;
+  - never blocks live agent execution.
+- Add a managed TaskFlow mode where Durable Core advances steps and TaskFlow is
+  the operator view.
+
+## Workboard bridge
+
+### Goals
+
+- Workboard remains optional and plugin-owned.
+- Workboard can show durable state, child counts, retry state, waiting reason,
+  and timeline links.
+- Workboard dispatch can start durable workflows when Durable Core is enabled,
+  with existing subagent dispatch as fallback.
+
+### Metadata convention
+
+Workboard card metadata may include:
+
+```json
+{
+  "durable": {
+    "workflowRunId": "wfr_...",
+    "workflowId": "openclaw.subagent.run",
+    "status": "running",
+    "recoveryState": "running",
+    "waitingReason": null,
+    "taskId": "task_...",
+    "taskFlowId": "flow_...",
+    "sessionKey": "agent:bo:subagent:workboard-default-card",
+    "runId": "run_...",
+    "children": {
+      "total": 0,
+      "open": 0,
+      "failed": 0
+    },
+    "timelineCommand": "openclaw durable timeline wfr_..."
+  }
+}
+```
+
+### Initial implementation
+
+- Add a durable projection helper that emits Workboard-safe metadata.
+- Do not import Workboard types from Durable Core.
+- Let Workboard adapter merge `metadata.durable` into cards later.
+
+### Later implementation
+
+- Add Workboard plugin adapter:
+  - maps durable projection to card execution status;
+  - maps durable stale/lost/retry/wait states to diagnostics;
+  - links card to durable timeline;
+  - writes only summaries, never full durable events.
+- Update Workboard dispatch:
+  - start Durable Core workflow when enabled;
+  - fallback to direct `subagent.run` when not enabled;
+  - reuse card `idempotencyKey`.
+
+## PR stack
+
+This bridge PR stack is the integration subset of the broader upstream stack in
+[`durable-workflow-core-upstream-pr-stack.md`](./durable-workflow-core-upstream-pr-stack.md).
+The upstream stack should remain split so reviewers can accept durable store,
+gateway inspection, subagent fan-in, TaskFlow binding, and Workboard projection
+independently.
+
+1. Durable coordination projection contract.
+   - Add pure projection module.
+   - Add CLI `openclaw durable coordination <workflowRunId>`.
+   - Add tests for child counts, waiting reason, and metadata patch output.
+   - Status: implemented.
+
+2. Background Task durable binding.
+   - Pass `taskId` and `parentFlowId` from subagent task creation into durable
+     subagent metadata.
+   - Preserve bindings through terminal updates.
+   - Add tests around metadata preservation.
+   - Status: implemented for subagent runs.
+
+3. TaskFlow projection writer.
+   - Add optional helper that writes projection into `stateJson/waitJson`.
+   - Add maintenance sync for flows with durable bindings.
+   - Status: implemented as a best-effort helper and tests. Runtime wiring is
+     intentionally left for a separate adapter PR so Durable Core does not
+     depend directly on TaskFlow.
+
+4. Workboard projection adapter.
+   - Add plugin-side adapter that reads durable projection.
+   - Store compact `metadata.durable`.
+   - Show status, waiting reason, child counts, and timeline command.
+   - Status: implemented as plugin-side projection-to-card-patch adapter plus
+     typed `metadata.durable` persistence and
+     `workboard.cards.applyDurableProjection` gateway method. UI rendering is
+     still pending.
+
+5. Durable dispatch path.
+   - Let Workboard dispatch start durable workflows when enabled.
+   - Keep direct subagent dispatch fallback.
+   - Status: pending.
+
+6. Recovery integration.
+   - Task audit asks Durable Core before marking task lost.
+   - Workboard diagnostics consume durable stale/lost/retry findings.
+   - Status: partial. Core recovery now reconciles retry timers and pending
+     signals back to runnable run/step state. Task audit, TaskFlow projection
+     refresh, and Workboard diagnostics are pending adapter work.
+
+7. Gateway read API.
+   - Expose durable coordination projection to UI/plugin/operator clients.
+   - Status: implemented as `durable.coordination.get` with `operator.read`
+     scope.
+
+## Anti-goals
+
+- Do not make Workboard a required dependency of Durable Core.
+- Do not duplicate the full durable event timeline into task, flow, or card
+  records.
+- Do not hard-code AICOS terms into upstream OpenClaw core.
+- Do not convert TaskFlow into a second event journal.
+- Do not block agent execution if a projection write fails.
+
+## Acceptance criteria
+
+- A subagent background task has a durable child workflow run.
+- The durable child run metadata contains task and flow identity when available.
+- A durable parent link preserves the same child task identity.
+- A CLI/user can inspect a durable coordination projection without direct SQLite
+  queries.
+- A Gateway client can read a durable coordination projection through
+  `durable.coordination.get`.
+- Workboard can consume the projection later without core importing Workboard.

--- a/docs/specs/durable-workflow-core-full-engine-plan.md
+++ b/docs/specs/durable-workflow-core-full-engine-plan.md
@@ -1,0 +1,331 @@
+# Durable Workflow Core Full Engine Plan
+
+Status: implementation plan for moving from durable coordination slice to a
+full native durable workflow engine.
+
+Date: 2026-06-28
+
+## Definition
+
+A full native durable workflow engine for OpenClaw is a local-first runtime
+control plane that can accept agent work, persist its state, coordinate
+multi-step and multi-agent execution, recover after process restart, resume safe
+steps, expose waits and failures, and keep parent/child branch ownership clear.
+
+It is not a clone of Temporal, Restate, Hatchet, or LangGraph. OpenClaw's engine
+should be optimized for agent coordination:
+
+- non-deterministic LLM calls;
+- tools with external side effects;
+- subagent fan-out/fan-in;
+- human approval and resume;
+- workspace artifacts;
+- background task, TaskFlow, and Workboard surfaces;
+- local-first operation with optional server-grade storage later.
+
+## Current State
+
+The current branch provides a native durable coordination slice:
+
+- durable store primitives;
+- run, event, step, ref, link, timer, and signal records;
+- agent turn lifecycle recording;
+- subagent child links;
+- fan-in reconciliation;
+- recovery worker;
+- TaskFlow projection;
+- Workboard projection metadata;
+- gateway read API.
+
+This already addresses part of OpenClaw's silent/stuck problem because accepted
+work no longer exists only in gateway memory. However, it is not yet a full
+engine because there is no generic executor that claims runnable steps and
+resumes safe work.
+
+## Required Full Engine Components
+
+### 1. Storage Contract
+
+Required:
+
+- stable `DurableWorkflowStore` interface;
+- SQLite implementation as default;
+- Postgres-compatible implementation later;
+- schema versioning and migrations;
+- transactional run/step/event updates;
+- step-level claims, not only run-level claims;
+- claim expiry and heartbeat fields;
+- compact refs for input, output, error, checkpoint, and artifacts.
+
+Initial implementation:
+
+- keep SQLite store;
+- add step-level claim/release API;
+- treat the existing store interface as the storage boundary.
+
+Later:
+
+- add `DurableWorkflowStoreFactory`;
+- add Postgres driver;
+- add migration version table;
+- add lease contention tests across multiple workers.
+
+### 2. Workflow Registry
+
+Required:
+
+- workflow definitions by `workflowId` and version;
+- step handlers by `stepType`;
+- compatibility metadata for future visual workflow designer;
+- explicit side-effect policy per handler.
+
+Initial implementation:
+
+- add an in-process registry;
+- allow registering step handlers;
+- keep definitions optional so existing agent-turn/subagent flows keep working.
+
+Later:
+
+- add declarative workflow definitions;
+- add workflow version routing;
+- add compatibility checks for saved designer graphs.
+
+### 3. Durable Executor
+
+Required:
+
+- claim one runnable step;
+- mark step/run running;
+- execute registered handler;
+- heartbeat while running;
+- write output/error refs;
+- transition to terminal, waiting, retry, or unknown-after-side-effect;
+- release claims;
+- append timeline events.
+
+Initial implementation:
+
+- add `runDurableExecutorOnce`;
+- support one-step execution;
+- support success, failed, retry, waiting-signal, waiting-timer, and
+  unknown-after-side-effect outcomes.
+
+Later:
+
+- add long-running worker loop;
+- add max concurrency;
+- add workflow-level scheduling;
+- add metrics and backpressure.
+
+### 4. Retry and Timer Semantics
+
+Required:
+
+- retry policy per step;
+- retry timer creation;
+- retry due reconciliation;
+- attempt increments;
+- clear terminal behavior when attempts are exhausted.
+
+Initial implementation:
+
+- executor schedules retry timers from handler output;
+- recovery worker already moves due retry timers back to runnable state.
+
+Later:
+
+- add exponential backoff policies;
+- add jitter;
+- add max elapsed time;
+- add retry policy in workflow definitions.
+
+### 5. Human Signal Semantics
+
+Required:
+
+- explicit waiting state;
+- signal persistence;
+- idempotent signal consumption;
+- resume from signal.
+
+Initial implementation:
+
+- executor can move a step/run to `waiting_signal`;
+- existing CLI/recovery signal handling can requeue runs.
+
+Later:
+
+- route signals to specific waiting steps;
+- add typed approval/rejection contracts;
+- add external callback correlation.
+
+### 6. Side-Effect Uncertainty
+
+Required:
+
+- do not replay unsafe side effects blindly;
+- mark uncertain steps/runs;
+- expose diagnostics to operators.
+
+Initial implementation:
+
+- executor supports `unknown_after_side_effect`;
+- CLI already has `mark-unknown`.
+
+Later:
+
+- annotate handler side-effect policy;
+- add reconciliation hooks for idempotent external operations;
+- add Workboard/operator diagnostics.
+
+### 7. Parent/Child Coordination Kernel
+
+Required:
+
+- durable subagent child runs;
+- durable parent links;
+- fan-in step;
+- policy-driven continuation;
+- child failure isolation.
+
+Initial implementation:
+
+- current branch already has subagent durable child links and fan-in policy.
+
+Later:
+
+- connect generic executor to fan-in continuation;
+- let parent workflow become runnable when fan-in is satisfied;
+- add partial-result aggregation refs.
+
+### 8. Frontdoor Integration
+
+Required:
+
+- every accepted message/task has durable identity;
+- restart-safe gateway intake;
+- external channels use the same durable run identity;
+- request and channel ids are metadata, not engine-specific semantics.
+
+Initial implementation:
+
+- gateway agent turns are recorded durably.
+
+Later:
+
+- add durable dispatch path for Workboard;
+- add Slack/Discord/API frontdoor bindings through the same intake contract;
+- expose durable ids in operator output.
+
+### 9. Observability
+
+Required:
+
+- timeline;
+- current step;
+- waiting reason;
+- heartbeat;
+- child counts;
+- error refs;
+- retry timers;
+- signal state.
+
+Initial implementation:
+
+- CLI and gateway projection exist.
+
+Later:
+
+- add structured diagnostics endpoint;
+- add Workboard UI rendering;
+- add replay/debug view.
+
+### 10. Designer Compatibility
+
+Required:
+
+- stable workflow id/version;
+- stable step id;
+- typed step inputs/outputs;
+- explicit edges and wait conditions;
+- no dependency on prompt memory for graph state.
+
+Initial implementation:
+
+- preserve stable ids in store and projection.
+
+Later:
+
+- add workflow definition schema;
+- add graph validation;
+- add import/export format.
+
+## Implementation Phases
+
+### Phase A: Engine Kernel
+
+- Add step-level claims.
+- Add registry.
+- Add one-shot executor.
+- Add tests for success, retry, wait, and unknown outcomes.
+
+### Phase B: Worker Loop
+
+- Add durable worker loop.
+- Add interval/concurrency controls.
+- Add feature flag.
+- Add graceful shutdown.
+
+### Phase C: Workflow Definitions
+
+- Add workflow registry definitions.
+- Add built-in agent-turn workflow definition.
+- Add version compatibility.
+
+### Phase D: Frontdoor Dispatch
+
+- Make Workboard dispatch durable when enabled.
+- Keep direct dispatch fallback.
+- Add external frontdoor intake contract.
+
+### Phase E: Storage Expansion
+
+- Add storage factory.
+- Keep SQLite default.
+- Add Postgres implementation.
+- Add migration versioning.
+
+### Phase F: Operational UX
+
+- Add diagnostics endpoint.
+- Add Workboard UI badges/timeline.
+- Add task audit durable recovery checks.
+
+## Acceptance Criteria For "Full Engine"
+
+OpenClaw can call the durable core a full native durable workflow engine when:
+
+- every accepted request can have a durable run id;
+- runnable steps can be claimed and executed by a worker;
+- safe steps can resume after restart;
+- unsafe side-effect uncertainty is explicit;
+- subagent branches cannot mix parent/reporting channels;
+- parent fan-in is driven by durable child terminal state;
+- failed child branches do not block parent unless policy requires it;
+- timers, retries, cancellation, and signals are durable;
+- SQLite works locally;
+- storage contract can support Postgres without changing public identifiers;
+- operators can answer why work is quiet without internal log digging.
+
+## Current Code Milestone
+
+This pass implements Phase A:
+
+- step-level claim/release;
+- in-process registry;
+- one-shot executor;
+- tests for core transitions.
+
+It intentionally does not wire a long-running executor into gateway startup yet.
+That should be a separate PR after the kernel API is reviewed.

--- a/docs/specs/durable-workflow-core-next-plan.md
+++ b/docs/specs/durable-workflow-core-next-plan.md
@@ -1,0 +1,1099 @@
+# Native Durable Workflow Core Next Plan
+
+Status: planning document for the next implementation stack.
+
+This document defines the core pieces OpenClaw needs to grow the current durable
+workflow prototype into a real native durable workflow core. The scope is limited
+to durable workflow primitives and runtime behavior. It intentionally avoids
+OpenClaw profile semantics, AICOS domain concepts, dashboards, visual workflow
+designer UI, and external engine adapters.
+
+For upstream contribution planning, see
+[`durable-workflow-core-upstream-pr-stack.md`](./durable-workflow-core-upstream-pr-stack.md).
+That document splits the current branch into small reviewable PRs and marks the
+line between the implemented durable coordination slice and a complete durable
+workflow runtime.
+
+For the full-engine expansion plan, see
+[`durable-workflow-core-full-engine-plan.md`](./durable-workflow-core-full-engine-plan.md).
+
+## Durable Core Definition
+
+For this plan, "durable core" means a native OpenClaw coordination kernel that
+lets agents run long, multi-step, branching, multi-subagent work without losing
+state, mixing branches, or going silent when something finishes, fails, times
+out, overflows, or restarts.
+
+It is not only a DB-backed event log. It must eventually answer and control:
+
+- which accepted request created this work;
+- which workflow run owns it;
+- which step is currently active;
+- which subagents were spawned;
+- which child branches have completed;
+- which child branches failed, timed out, overflowed, were cancelled, or were
+  lost;
+- why the parent is waiting;
+- whether the parent should continue, retry, wait for human input, or fail;
+- what can be safely resumed;
+- what is unsafe to replay because a side effect may already have happened;
+- why the system is quiet right now.
+
+The practical OpenClaw value is:
+
+- long-running agent work remains visible instead of looking hung;
+- parent agents do not depend on prompt memory to fan-in child results;
+- subagent completion can unblock the parent durably;
+- one failed child does not lock the parent when policy allows continuation;
+- gateway restart does not erase the control-plane truth;
+- operators can inspect status and timeline without reading internal logs or
+  SQLite manually;
+- future workflow designer/runtime features have stable contracts for steps,
+  links, signals, timers, and fan-in.
+
+The durable core should stay small and upstream-friendly: it owns identity,
+ordering, step state, waits, signals, child results, retries, recovery, and
+audit. It does not own persona, prompt style, skills, memory content, workspace
+files, or channel-specific UX.
+
+## Current Maturity Level
+
+Current maturity: native durable coordination slice with an initial executor
+kernel.
+
+This branch is already more than documentation: it adds a native OpenClaw
+control plane for agent turn state, subagent child links, fan-in policy,
+recovery state, TaskFlow projection, Workboard projection metadata, and gateway
+read APIs. It now also includes step-level claims, an in-process workflow
+registry, and a one-shot durable executor for safe built-in step handlers.
+
+It should not yet be described as a complete durable workflow engine because it
+does not yet include a long-running worker loop, durable dispatch from all
+frontdoors, pluggable storage interface, schema migration policy, workflow SDK,
+or mature multi-worker lease behavior.
+
+The next architecture milestone is wiring the executor behind a feature flag as
+a controlled worker loop. That is the point where the module starts moving from
+durable inspection plus one-shot execution into a true durable runtime.
+
+## Current Baseline
+
+The prototype already provides:
+
+- `openclaw.gateway.startup` durable startup records.
+- `openclaw.agent.turn` run records.
+- agent turn lifecycle events:
+  - `agent.turn.received`
+  - `agent.turn.running`
+  - `agent.turn.succeeded`
+  - `agent.turn.failed`
+  - `agent.turn.cancelled`
+  - `agent.turn.lost`
+- SQLite local-first store.
+- idempotency key uniqueness per workflow.
+- prompt hash and metadata without raw prompt persistence.
+- startup reconciliation of in-flight agent turns from a previous gateway
+  lifecycle.
+- gateway-local stale-run recovery worker.
+- durable core primitive tables and APIs for:
+  - steps;
+  - refs;
+  - parent/child links;
+  - timers;
+  - signals;
+  - run claims;
+  - fan-in reconciliation.
+- agent turn lifecycle now creates a durable input ref and agent step.
+
+This is enough to make lost work visible, but it is not enough to resume,
+retry, or fully coordinate multi-agent workflows safely. The new fan-in helper
+provides the core parent/child policy primitive, but it is not yet wired into
+all session/subagent runtime paths.
+
+The current prototype partially addresses OpenClaw's "silent/stuck" failure
+mode:
+
+- gateway-restart loss is no longer invisible for gateway agent turns;
+- timeout/abort/lost terminal states are written durably;
+- each new gateway agent turn now has an `agent_invocation` step and input/output
+  refs;
+- stale agent turns can be marked `lost`;
+- core fan-in policy can unblock a parent in tests.
+
+It does not yet fully solve silence for long-running or branched work because
+runtime subagent spawning, parent fan-in, heartbeat/progress events, query UI/CLI,
+and actual claim/resume execution are still pending.
+
+## Immediate Execution Checklist
+
+The next implementation pass should close the following eight missing runtime
+authority gaps in order. Each item must remain feature-flagged and must be safe
+when durable workflows are disabled.
+
+1. Runtime subagent wiring:
+   - real subagent/session spawn creates durable child links;
+   - child terminal state updates the durable child link;
+   - child overflow, timeout, cancelled, lost, and announce-failed outcomes are
+     represented as terminal child link states or error refs.
+
+2. Parent resume/unblock:
+   - parent creates or reuses a `fan_in` step before spawning children;
+   - child terminal events call fan-in reconciliation;
+   - satisfied fan-in moves parent from `waiting_child` to `queued/runnable`;
+   - continue policies allow parent to resume with partial results.
+
+3. Heartbeat/progress:
+   - long-running agent, tool, and child steps emit heartbeat/progress events;
+   - active run/step `heartbeat_at` is updated;
+   - stale heartbeat detection reports stuck work separately from quiet work.
+
+4. Durable query/status API:
+   - CLI/internal APIs list runs, inspect a run, show timeline, steps, children,
+     timers, and signals;
+   - status output includes current step, waiting reason, last heartbeat, child
+     counts, and terminal/lost reason.
+
+5. Claim/resume execution loop:
+   - worker claims runnable runs/steps;
+   - loads input/checkpoint refs;
+   - executes or resumes safe steps;
+   - releases claim on terminal or waiting states.
+
+6. Retry and cancellation:
+   - retry policy/backoff uses timers;
+   - failed retryable steps schedule retry timers;
+   - cancellation requests are durable and observed by active/waiting steps.
+
+7. Human signal resume:
+   - waiting signal state is represented durably;
+   - human/external signal is persisted and consumed idempotently;
+   - consumed signal moves run/step back to queued/runnable or terminal.
+
+8. Side-effect uncertainty:
+   - tool/model/message delivery operations that may have completed before
+     crash are marked `unknown_after_side_effect`;
+   - recovery reports these as requiring inspection or idempotent reconciliation
+     before automatic replay.
+
+## Design Goal
+
+The durable core should provide a small native control plane for:
+
+- request identity;
+- step ordering;
+- idempotency;
+- retries;
+- timers;
+- recovery;
+- cancellation;
+- parent/child workflow linkage;
+- fan-out/fan-in;
+- human input signals;
+- audit and timeline query.
+
+It should remain:
+
+- local-first;
+- SQLite by default;
+- optional Postgres-compatible later;
+- feature-flagged while maturing;
+- upstream-friendly;
+- independent from AICOS-specific domain objects.
+
+## Non-goals
+
+- Do not implement a general-purpose Temporal clone.
+- Do not require Postgres for local OpenClaw.
+- Do not store raw prompts in event payloads by default.
+- Do not make profiles, skills, or memory part of workflow state.
+- Do not hard-code AICOS, AICOS-X, AICOS-R, Discord, Slack, or dashboard terms.
+- Do not require a visual workflow designer before runtime primitives are stable.
+
+## Required Core Pieces
+
+### 1. Durable Identity Model
+
+OpenClaw needs stable identity across user messages, gateway requests, agent
+turns, child workflows, steps, retries, and emitted events.
+
+Required identifiers:
+
+- `workflow_id`
+- `workflow_run_id`
+- `message_id`
+- `turn_id`
+- `agent_invocation_id`
+- `step_id`
+- `event_id`
+- `event_seq`
+- `idempotency_key`
+- `parent_workflow_run_id`
+- `parent_step_id`
+- `child_workflow_run_id`
+- `checkpoint_ref`
+- `input_ref`
+- `output_ref`
+- `error_ref`
+
+Current coverage:
+
+- `workflow_run_id`
+- `workflow_id`
+- `event_id`
+- `event_seq`
+- `idempotency_key`
+- `agent_invocation_id`
+- `input_ref`
+
+Missing coverage:
+
+- explicit message and turn identifiers;
+- formal parent/child links;
+- step-level input, output, and error references;
+- checkpoint references tied to step transitions.
+
+### 2. Durable Input/Output Store
+
+The event journal should stay compact. Raw or large data should be stored behind
+references.
+
+Add store concepts:
+
+- `durable_workflow_inputs`
+- `durable_workflow_outputs`
+- `durable_workflow_errors`
+- `durable_artifact_refs`
+
+Required behavior:
+
+- store input bodies by ref only when durable retry/resume requires it;
+- store payload hash for integrity;
+- support redaction/encryption policy later;
+- avoid raw prompt text in event payloads;
+- allow outputs to reference files, artifacts, tool results, or summarized text;
+- keep event log readable without embedding huge blobs.
+
+Minimal input record:
+
+```text
+input_ref
+workflow_run_id
+step_id
+media_type
+hash
+storage_kind
+storage_uri
+created_at
+metadata_json
+```
+
+Minimal output record:
+
+```text
+output_ref
+workflow_run_id
+step_id
+media_type
+hash
+storage_kind
+storage_uri
+created_at
+metadata_json
+```
+
+### 3. Formal Run State Machine
+
+Status strings need transition rules. Without a state machine, multi-step and
+multi-agent runs can mix states or leave parent runs blocked forever.
+
+Recommended run statuses:
+
+```text
+received
+queued
+running
+waiting_signal
+waiting_timer
+waiting_child
+retry_scheduled
+succeeded
+failed
+cancelled
+lost
+```
+
+Recommended recovery states:
+
+```text
+runnable
+claimed
+running
+waiting_signal
+waiting_timer
+waiting_child
+retry_scheduled
+reconciling
+unknown_after_side_effect
+lost
+terminal
+```
+
+Valid transition examples:
+
+```text
+received -> queued
+queued -> running
+running -> waiting_child
+waiting_child -> queued
+running -> waiting_signal
+waiting_signal -> queued
+running -> waiting_timer
+waiting_timer -> queued
+running -> retry_scheduled
+retry_scheduled -> queued
+running -> succeeded
+running -> failed
+running -> cancelled
+running -> lost
+```
+
+Transition guard requirements:
+
+- terminal states cannot become non-terminal without an explicit retry run;
+- stale recovery cannot mark `waiting_signal` or `waiting_child` lost without a
+  timeout policy;
+- only the claiming worker can move a claimed run into running or terminal;
+- idempotent duplicate requests must return the existing run, not create a
+  second run.
+
+### 4. Durable Step Model
+
+An agent turn is not enough. A real workflow needs durable steps.
+
+Add table:
+
+```text
+durable_workflow_steps
+```
+
+Minimal fields:
+
+```text
+workflow_run_id
+step_id
+parent_step_id
+step_type
+status
+recovery_state
+attempt
+max_attempts
+idempotency_key
+input_ref
+output_ref
+error_ref
+checkpoint_ref
+created_at
+started_at
+updated_at
+completed_at
+metadata_json
+```
+
+Step types:
+
+```text
+agent
+tool
+timer
+signal
+child_workflow
+checkpoint
+fan_in
+```
+
+Step statuses:
+
+```text
+pending
+queued
+running
+waiting
+retry_scheduled
+succeeded
+failed
+cancelled
+lost
+skipped
+```
+
+Why this matters:
+
+- retries should happen per step;
+- child agent failure should not automatically block the parent;
+- a parent can wait on a durable `fan_in` step instead of remembering children
+  in prompt context;
+- recovery can reason about the last incomplete step.
+
+### 5. Parent/Child Workflow and Fan-in Contract
+
+This is the most important missing piece for reliable multi-agent coordination.
+
+Add durable relation:
+
+```text
+durable_workflow_links
+```
+
+Minimal fields:
+
+```text
+parent_workflow_run_id
+parent_step_id
+child_workflow_run_id
+link_type
+status
+created_at
+updated_at
+metadata_json
+```
+
+Link types:
+
+```text
+child_workflow
+handoff
+subagent
+evidence
+artifact
+```
+
+Fan-in primitive:
+
+```text
+fan_in_id
+parent_workflow_run_id
+parent_step_id
+expected_child_count
+completed_child_count
+failed_child_count
+policy
+status
+```
+
+Fan-in policies:
+
+```text
+all_succeeded
+all_terminal
+quorum
+first_success
+manual_review
+continue_on_child_failure
+fail_parent_on_child_failure
+```
+
+Required events:
+
+```text
+child.workflow.spawned
+child.workflow.running
+child.workflow.succeeded
+child.workflow.failed
+child.workflow.cancelled
+child.workflow.lost
+fan_in.waiting
+fan_in.partial
+fan_in.ready
+fan_in.failed
+```
+
+Core rule:
+
+A parent run must not depend on prompt memory to notice child completion. Child
+terminal events should update the parent fan-in step durably. If one child
+overflows, times out, or fails, the configured fan-in policy decides whether the
+parent continues, retries, waits for human input, or fails.
+
+### 6. Recovery Worker With Claiming
+
+The current worker can mark stale runs lost. The real worker must claim and
+advance work.
+
+Add claim fields to runs and steps:
+
+```text
+claimed_by
+claim_expires_at
+heartbeat_at
+worker_id
+```
+
+Worker loop:
+
+```text
+scan runnable runs
+claim one run or step
+load input_ref/checkpoint_ref
+execute or resume the next step
+append events
+update step state
+update run state
+release claim or renew heartbeat
+```
+
+SQLite local-first claim strategy:
+
+- use transaction;
+- select due runnable item;
+- update `claimed_by`, `claim_expires_at`, `heartbeat_at`;
+- only proceed if update succeeds;
+- release claim on terminal or waiting state.
+
+Future Postgres strategy:
+
+- same interface;
+- use `FOR UPDATE SKIP LOCKED`;
+- keep state machine identical.
+
+Recovery cases:
+
+- gateway restart while run is accepted but not started;
+- gateway restart while model call is in progress;
+- tool call completed but result not recorded;
+- child workflow completed but parent fan-in not updated;
+- worker claim expired;
+- retry timer due;
+- human signal arrived.
+
+### 7. Retry, Timer, Deadline, and Cancellation Core
+
+Retry and timer primitives should be part of durable core, not agent profile
+logic.
+
+Add retry fields:
+
+```text
+retry_policy_json
+attempt
+max_attempts
+next_attempt_at
+last_error_ref
+```
+
+Retry policy:
+
+```text
+max_attempts
+initial_delay_ms
+max_delay_ms
+backoff_multiplier
+jitter
+retry_on
+do_not_retry_on
+```
+
+Add timers:
+
+```text
+durable_workflow_timers
+```
+
+Timer fields:
+
+```text
+timer_id
+workflow_run_id
+step_id
+timer_type
+due_at
+status
+created_at
+fired_at
+cancelled_at
+metadata_json
+```
+
+Timer types:
+
+```text
+retry
+deadline
+sleep
+human_timeout
+child_timeout
+scheduled_start
+```
+
+Cancellation fields:
+
+```text
+cancel_requested_at
+cancel_reason
+cancelled_by
+```
+
+Cancellation behavior:
+
+- cancellation request is durable;
+- active worker observes cancellation;
+- waiting timers/signals/children can be cancelled;
+- terminal event records who/what cancelled the run.
+
+### 8. Signal and Human-in-the-loop Core
+
+Human input should be a durable signal, not just another chat message.
+
+Add table:
+
+```text
+durable_workflow_signals
+```
+
+Minimal fields:
+
+```text
+signal_id
+workflow_run_id
+step_id
+signal_type
+idempotency_key
+payload_ref
+correlation_id
+received_at
+consumed_at
+metadata_json
+```
+
+Signal types:
+
+```text
+human_input
+approval
+rejection
+external_callback
+child_completed
+child_failed
+cancel
+resume
+```
+
+Behavior:
+
+- waiting workflow records `waiting_signal`;
+- incoming signal is persisted first;
+- worker consumes signal idempotently;
+- run moves back to `queued` or terminal depending on signal.
+
+This enables approvals from Discord, Slack, dashboard, CLI, API, or future
+workflow designer without changing the core runtime.
+
+### 9. Query and Control API
+
+The core needs a small API so UI, CLI, and external frontdoors can inspect and
+operate on durable runs.
+
+Required read APIs:
+
+```text
+listWorkflowRuns(filter)
+getWorkflowRun(workflow_run_id)
+getWorkflowTimeline(workflow_run_id)
+getWorkflowSteps(workflow_run_id)
+getWorkflowChildren(workflow_run_id)
+getWorkflowSignals(workflow_run_id)
+```
+
+Required control APIs:
+
+```text
+startWorkflow(input_ref)
+sendSignal(workflow_run_id, signal)
+cancelWorkflow(workflow_run_id, reason)
+retryWorkflow(workflow_run_id)
+retryStep(workflow_run_id, step_id)
+```
+
+For upstream acceptance, start with CLI/internal API only. UI can come later.
+
+### 10. Observability and Debug Timeline
+
+Minimum observability:
+
+- run status;
+- current step;
+- active claim owner;
+- last event;
+- last error;
+- retry schedule;
+- parent/child graph;
+- waiting reason;
+- signal/timer due status.
+
+Timeline should be enough to answer:
+
+- what request created this run?
+- which agent was invoked?
+- which step is currently blocking?
+- did any child finish?
+- why is parent waiting?
+- did gateway restart mark this lost?
+- is this retryable?
+
+### 11. Silence and Stuck Work Closure
+
+The main user-visible failure to close is: OpenClaw appears silent or stuck while
+coordinating long work, multi-step work, multiple agents, or branched subagent
+work.
+
+There are five distinct causes, and each needs a different core capability.
+
+#### A. Gateway Restart or Process Loss
+
+Current status:
+
+- agent turns are recorded before execution;
+- startup recovery marks old in-flight gateway agent turns as `lost`;
+- stale recovery worker can mark long-stale turns as `lost`.
+
+Remaining work:
+
+- retry or resume from durable `input_ref`/`checkpoint_ref`;
+- record side-effect uncertainty as `unknown_after_side_effect` when a tool/model
+  call may have completed but terminal state was not recorded;
+- expose the `lost` state through CLI/API instead of requiring SQLite inspection.
+
+#### B. Long-running Step With No Progress
+
+Current status:
+
+- a run can show `running`;
+- an agent step can show `running`.
+
+Remaining work:
+
+- emit periodic heartbeat/progress events for long-running steps;
+- store `heartbeat_at` updates for active run/step claims;
+- add stuck-step detection that distinguishes "alive but quiet" from "dead";
+- surface last heartbeat, current step, and elapsed time in status/timeline.
+
+Required events:
+
+```text
+step.heartbeat
+step.progress
+agent.turn.heartbeat
+tool.invocation.heartbeat
+```
+
+#### C. Parent Waiting for Subagents
+
+Current status:
+
+- link table and fan-in helper exist;
+- policies can continue parent despite child failure in tests.
+
+Remaining work:
+
+- wire real subagent/session spawn paths to create `child_workflow` links;
+- create a parent `fan_in` step when parent spawns children;
+- update child link status when child reaches terminal state;
+- call fan-in reconciliation on child terminal event;
+- move parent from `waiting_child` back to `queued/runnable` when policy is
+  satisfied;
+- add parent waiting reason and child counts to timeline/status.
+
+Required events:
+
+```text
+child.workflow.spawned
+child.workflow.terminal
+fan_in.waiting
+fan_in.partial
+fan_in.ready
+fan_in.failed
+parent.workflow.unblocked
+```
+
+#### D. One Child Fails or Overflows
+
+Current status:
+
+- fan-in helper supports `continue_on_child_failure` and
+  `fail_parent_on_child_failure`.
+
+Remaining work:
+
+- define default fan-in policy for OpenClaw subagents;
+- record child failure reason as `error_ref`;
+- prevent child failure from holding parent claim forever;
+- support child retry policy independent of parent retry policy;
+- support parent continuation with partial child outputs.
+
+#### E. No Human-readable Status Surface
+
+Current status:
+
+- durable data exists in SQLite.
+
+Remaining work:
+
+- add CLI/internal API:
+  - `durable runs list`
+  - `durable run get <workflow_run_id>`
+  - `durable timeline <workflow_run_id>`
+  - `durable steps <workflow_run_id>`
+  - `durable children <workflow_run_id>`
+- include session key, agent id, current step, waiting reason, last heartbeat,
+  child counts, and terminal/lost reason;
+- keep this API usable without dashboard changes.
+
+## Storage Plan
+
+Keep SQLite as default.
+
+Recommended table stack:
+
+```text
+durable_workflow_runs
+durable_workflow_events
+durable_workflow_steps
+durable_workflow_links
+durable_workflow_inputs
+durable_workflow_outputs
+durable_workflow_errors
+durable_workflow_timers
+durable_workflow_signals
+```
+
+Storage interfaces should stay independent from SQLite details so Postgres can
+be added later.
+
+Do not make Postgres mandatory.
+
+## Execution Model
+
+Recommended model:
+
+```text
+event journal + resumable state machine + checkpoint/input refs
+```
+
+Avoid requiring deterministic workflow replay in the first native core. Agent
+workflows are usually side-effect-heavy, tool-heavy, and human-interactive. A
+resumable state machine with explicit step boundaries is a better fit for
+OpenClaw's local-first agent runtime.
+
+Use deterministic replay only later for narrowly scoped pure workflow logic, if
+needed.
+
+## PR Stack
+
+### PR 1: Durable Step Store
+
+- add `durable_workflow_steps`;
+- add step CRUD/list APIs;
+- add transition helpers;
+- add tests for step status transitions.
+
+Current status: implemented as core store API. Transition helpers remain
+minimal and should be hardened before upstream submission.
+
+### PR 2: Durable Input/Output Refs
+
+- add input/output/error ref tables;
+- write agent turn input refs;
+- keep event payloads compact;
+- add hash validation tests.
+
+Current status: implemented as a compact `durable_workflow_refs` table with
+`ref_kind` for input, output, error, and artifact refs. Agent turns write input
+refs and terminal output/error refs. Raw prompt text is still not stored in the
+journal.
+
+### PR 3: Parent/Child Links and Fan-in
+
+- add workflow link table;
+- add child spawn event contract;
+- add fan-in step type;
+- update parent state on child terminal events;
+- test child success/failure isolation.
+
+Current status: implemented store links and a reusable fan-in reconciliation
+helper. The helper supports `continue_on_child_failure` and
+`fail_parent_on_child_failure` behavior in tests. Runtime session/subagent spawn
+paths still need to call it.
+
+### PR 4: Recovery Claim Loop
+
+- add claim fields;
+- add worker claim/release/heartbeat;
+- scan runnable and retry-due steps;
+- keep SQLite local-first;
+- test claim expiry and stuck-run recovery.
+
+Current status: run claim/release primitives are implemented. The existing
+recovery worker now reconciles stale agent turns, due retry timers, and pending
+cancel/resume/human signals. It still performs visibility/state reconciliation
+rather than executing a full claim/resume loop.
+
+### PR 5: Retry and Timer Core
+
+- add timer table;
+- add retry policy;
+- add due timer scan;
+- add cancellation request fields;
+- test backoff, retry exhaustion, and cancellation.
+
+Current status: timer table, due timer listing, retry scheduling via the
+`durable retry` CLI, and recovery-worker retry due reconciliation are
+implemented. Retry policy inheritance/exhaustion and cancellation propagation
+into live agent processes are still pending.
+
+### PR 6: Signal and Human Input
+
+- add signal table;
+- add send/consume signal APIs;
+- support waiting_signal -> queued transition;
+- test human approval/rejection and idempotency.
+
+Current status: signal table, idempotent signal creation, consume, list APIs,
+`durable signal`, and recovery-worker waiting_signal/resume/cancel transitions
+are implemented. Runtime tool/UI surfaces for human approval are still pending.
+
+### PR 7: Query and Control API
+
+- add timeline query;
+- add run/step/child listing;
+- add retry/cancel commands;
+- expose enough for CLI and future UI.
+
+Current status: implemented as the first operator-facing CLI slice:
+`openclaw durable stats|runs|show|timeline|steps|children|parents|signals|refs|timers`
+plus conservative `cancel|retry|resume|signal|mark-unknown` control commands.
+This replaces direct SQLite inspection for the current prototype state.
+
+### PR 8: Runtime Subagent/Fan-in Wiring
+
+- identify every real subagent/session spawn path;
+- create parent fan-in step before spawning children;
+- create child workflow runs and durable links;
+- write child terminal events;
+- reconcile parent fan-in on child terminal state;
+- test one child success + one child failure under continue policy;
+- test child overflow/lost does not lock the parent.
+
+Current status: partially implemented. Core tables and fan-in helper exist, and
+the subagent registry run manager now mirrors subagent registration and terminal
+outcomes into durable child runs/links. Child terminal outcomes reconcile the
+parent fan-in step with `continue_on_child_failure`. More spawn paths and
+focused overflow/announce-failure tests are still required before this should
+be considered authoritative.
+
+### PR 9: Heartbeat and Progress Events
+
+- add heartbeat/progress helper for long-running run and step execution;
+- update `heartbeat_at` for active run/step claims;
+- emit `step.heartbeat` and `step.progress` events;
+- add stale heartbeat detection;
+- expose last heartbeat in status/timeline.
+
+Current status: implemented for gateway agent turns. Active agent turns update
+run/step `heartbeat_at` and emit `agent.turn.heartbeat` events. Generic
+step/tool/subagent progress events and stale-heartbeat findings are still
+pending.
+
+### PR 10: Claim/Resume Execution Loop
+
+- turn recovery worker from visibility reconciler into executor/reconciler;
+- claim runnable runs/steps;
+- load `input_ref` and last checkpoint;
+- resume or retry safe steps;
+- preserve `unknown_after_side_effect` for unsafe replay;
+- release claim on waiting/terminal state.
+
+Current status: pending. Claim primitives exist, and recovery can move timer or
+signal waits back to runnable state, but the worker does not yet execute or
+resume steps.
+
+### Implementation Checkpoint 2026-06-27
+
+The current implementation now covers the first runtime-authority slice:
+
+- durable query/status CLI and timeline output;
+- agent-turn heartbeat and visible `heartbeat_at`;
+- retry timer scheduling and due reconciliation;
+- durable signal/cancel/resume control-plane transitions;
+- side-effect uncertainty marker via `durable mark-unknown`;
+- subagent registry mirroring into child workflow runs and parent durable links;
+- fan-in reconciliation on subagent terminal outcomes with a continue-on-child-failure policy;
+- build and OpenClaw A smoke validation after gateway restart.
+
+### Implementation Checkpoint 2026-06-28
+
+The durable coordination bridge plan is now captured in
+[`durable-coordination-bridge-plan.md`](./durable-coordination-bridge-plan.md).
+That plan defines how Durable Core connects to Background Tasks, Task Flow, and
+Workboard without making the optional Workboard plugin a hard dependency.
+
+Implemented in the first bridge slice:
+
+- durable coordination projection helper for task, TaskFlow, and Workboard
+  consumers;
+- `openclaw durable coordination <workflowRunId>` CLI projection output;
+- `durable.coordination.get` Gateway read method for UI/plugin/operator clients;
+- subagent durable child metadata now preserves Background Task `taskId` and
+  one-task TaskFlow `parentFlowId` when available;
+- terminal subagent durable updates preserve existing task/flow bindings instead
+  of replacing the metadata;
+- TaskFlow projection writer can update `stateJson.durable`, `waitJson.durable`,
+  `currentStep`, and lifecycle status from durable state when an adapter calls it;
+- Workboard now has typed `metadata.durable` persistence and a plugin-side
+  projection-to-card-patch adapter plus `workboard.cards.applyDurableProjection`;
+- tests for projection shape, subagent task/flow binding preservation, TaskFlow
+  sync, Gateway projection reads, and Workboard durable metadata persistence.
+
+Still not complete:
+
+- no long-running claim/resume worker loop yet;
+- no Postgres backend yet;
+- no full human approval UI/tool flow yet;
+- no message delivery side-effect dedupe beyond marking uncertainty;
+- no TaskFlow maintenance sweep for all durable-bound flows yet;
+- no Workboard UI rendering or diagnostics integration yet;
+- no Workboard durable dispatch path yet;
+- subagent overflow/announce-failure and branch route isolation need focused
+  runtime tests;
+- parent agent resume still depends on existing OpenClaw runtime behavior until
+  durable control mode is explicitly introduced.
+
+## Acceptance Criteria
+
+The native durable core is minimally real when OpenClaw can:
+
+- persist every accepted agent request before execution;
+- recover or explicitly mark incomplete runs after gateway restart;
+- retry a failed step without duplicating completed steps;
+- spawn child agent workflows with durable parent links;
+- fan-in child completion without relying on prompt memory;
+- keep parent workflows unblocked when a child fails under a continue policy;
+- report long-running step heartbeat/progress so quiet work is distinguishable
+  from stuck work;
+- show current durable state through CLI/API without direct SQLite queries;
+- wait for human input as a durable signal;
+- resume from input/checkpoint refs;
+- explain run state through a timeline API.
+
+## Most Important Next Step
+
+Wire real runtime subagent/session spawn paths into durable parent/child links
+and fan-in reconciliation, then add heartbeat/progress and query APIs.
+
+Reason:
+
+The largest current operational failure mode is not just losing a single chat
+turn. It is losing coordination across long, branched agent work: parent agents
+cannot reliably fan-in when subagents finish, and one child failure can make the
+parent appear stuck. Step state and parent/child fan-in are the core primitives
+that directly address that failure mode. The primitives now exist; the next
+critical work is wiring them into the real runtime paths and making their state
+visible to users/operators.

--- a/docs/specs/durable-workflow-core-prototype.md
+++ b/docs/specs/durable-workflow-core-prototype.md
@@ -1,0 +1,125 @@
+# Durable Workflow Core Prototype
+
+Status: prototype slice, disabled by default.
+
+## Goal
+
+OpenClaw needs a small native durable control plane for agent turns before it can
+reliably support long-running, multi-step, and multi-agent work. The first slice
+does not try to replace Temporal, Restate, Hatchet, or LangGraph. It records
+workflow identity, agent-turn lifecycle events, and restart recovery state so the
+gateway can explain where a request went instead of silently losing in-flight
+work.
+
+## Current Slice
+
+The prototype is enabled with `OPENCLAW_DURABLE_WORKFLOWS=1`.
+
+- SQLite-backed store at `${OPENCLAW_STATE_DIR}/durable/workflows.sqlite`.
+- Tables:
+  - `durable_workflow_runs`
+  - `durable_workflow_events`
+- Gateway startup run: `openclaw.gateway.startup`.
+- Agent turn run: `openclaw.agent.turn`.
+- Gateway-local recovery worker:
+  - `OPENCLAW_DURABLE_RECOVERY_INTERVAL_MS`, default `60000`
+  - `OPENCLAW_DURABLE_STALE_AGENT_TURN_AFTER_MS`, default `21600000`
+- Agent turn events:
+  - `agent.turn.received`
+  - `agent.turn.running`
+  - `agent.turn.succeeded`
+  - `agent.turn.failed`
+  - `agent.turn.cancelled`
+  - `agent.turn.lost`
+
+Agent turn metadata stores routing and audit fields such as agent id, session
+key, channel, transport, message length, and message hash. It intentionally does
+not store the raw user prompt body.
+
+## Gateway Placement
+
+The durable lifecycle is recorded server-side in the gateway agent handler, not
+in the CLI client. This keeps Discord, webchat, CLI, API, and future channel
+frontdoors on the same source of truth.
+
+The lifecycle boundary is:
+
+1. Record `received` after session/channel resolution.
+2. Record `running` when the run is accepted and registered.
+3. Record terminal state from the actual agent runner callback.
+4. On gateway startup, reconcile stale non-terminal agent turns from previous
+   gateway lifecycles to `lost`.
+5. While the gateway is running, periodically reconcile very old `received` or
+   `running` agent turns to `lost`.
+
+## Restart Semantics
+
+This slice does not resume an in-flight model/tool call after process death. It
+does make the failure explicit:
+
+- A run accepted by the old gateway is recorded before dispatch.
+- If the gateway restarts before terminal completion, startup reconciliation
+  appends `agent.turn.lost`.
+- If an agent turn remains `received` or `running` past the stale threshold,
+  the local recovery worker appends `agent.turn.lost`.
+- `waiting` runs are not marked lost by this worker so future human-in-the-loop
+  gates can survive restarts and long pauses.
+- The user or a future reconciler can retry from the stored idempotency key,
+  input reference, session key, and event timeline.
+
+## Validation
+
+Manual validation against OpenClaw A:
+
+- Short agent message: `succeeded`, three events.
+- Longer multi-step prompt: `succeeded`, three events.
+- Parallel branches: one branch `succeeded` while another timed out as
+  `cancelled`; states did not mix.
+- Gateway restart during an in-flight run: old gateway run became `lost` with
+  `agent.turn.lost`; a new post-restart message succeeded.
+- Recovery worker smoke after restart: new agent turn succeeded while the worker
+  was active.
+
+Automated checks run:
+
+- `npm test -- --run src/durable src/gateway/server-methods/agent.test.ts`
+- `npm test -- --run src/durable src/cli/program/register.agent.test.ts src/commands/agent-via-gateway.test.ts`
+- `npm run tsgo:core`
+- `npm run build`
+
+## Proposed PR Stack
+
+1. Durable store foundations:
+   - shared durable workflow types
+   - SQLite store
+   - feature flag and state-dir path resolution
+   - store tests
+
+2. Gateway lifecycle hook:
+   - record gateway startup
+   - add startup reconciliation for stale open agent turns
+   - start/stop a gateway-local stale-run recovery worker
+   - keep recovery best-effort and non-blocking for user traffic
+
+3. Agent turn lifecycle:
+   - server-side gateway agent turn recording
+   - received/running/terminal event timeline
+   - prompt hash and metadata, not raw prompt storage
+
+4. Follow-up recovery API:
+   - query run timeline
+   - retry/cancel by workflow run id
+   - reconcile `lost` runs into explicit retry proposals
+
+5. Follow-up multi-agent contract:
+   - parent/child run links
+   - fan-out/fan-in step ids
+   - child failure isolation and parent continuation policy
+
+## Anti-goals
+
+- No deterministic replay runtime in this slice.
+- No embedded Temporal/Restate/Hatchet/LangGraph implementation.
+- No AICOS-specific concepts in OpenClaw core.
+- No raw prompt persistence in the durable journal.
+- No dashboard changes.

--- a/docs/specs/durable-workflow-core-upstream-pr-stack.md
+++ b/docs/specs/durable-workflow-core-upstream-pr-stack.md
@@ -1,0 +1,504 @@
+# Durable Workflow Core Upstream PR Stack
+
+Status: preparation document for splitting the OpenClaw-X durable core work into
+small upstream-friendly pull requests.
+
+Date: 2026-06-28
+
+## Executive Assessment
+
+The current branch contains a real native durable coordination slice, but it is
+not yet a complete durable workflow engine.
+
+It is native because the control plane is implemented inside OpenClaw rather
+than delegated entirely to Temporal, Restate, Hatchet, LangGraph, or an
+AICOS-specific bridge. It records workflow runs, events, steps, refs, timers,
+signals, parent/child links, agent turns, subagent child runs, recovery state,
+and coordination projections in OpenClaw's runtime state.
+
+It is durable because accepted agent work can survive gateway process restarts
+as inspectable state. Lost, failed, cancelled, waiting, retry, and child terminal
+states are explicit records instead of only transient process memory.
+
+It is still a slice because it does not yet provide a long-running worker loop,
+storage abstraction beyond SQLite, schema migration policy, deterministic
+replay, or a full workflow SDK. The branch now includes an initial in-process
+registry and one-shot executor kernel, but those pieces are not wired as a
+production worker yet.
+
+The right upstream message is:
+
+> Add a local-first durable coordination core for agent runs and subagent
+> fan-in, starting with inspectable runtime state and recovery primitives.
+
+Avoid claiming:
+
+> Add a Temporal-compatible workflow engine.
+
+## What Exists Now
+
+Current implemented capabilities:
+
+- SQLite-backed local-first durable store.
+- Workflow run, event, step, ref, link, timer, and signal primitives.
+- Durable startup lifecycle records.
+- Durable gateway agent turn records.
+- Durable input refs for agent turns without storing raw prompts by default.
+- Gateway startup reconciliation for previously in-flight agent turns.
+- Recovery worker that marks stale agent turns lost and processes durable
+  recovery transitions.
+- Subagent child workflow records and parent/child links.
+- Fan-in policy helper that can continue parents when children fail, depending
+  on policy.
+- Best-effort TaskFlow projection writer.
+- Durable coordination projection API.
+- Gateway method `durable.coordination.get`.
+- Workboard-side projection adapter and typed `metadata.durable` persistence.
+- Workboard gateway method `workboard.cards.applyDurableProjection`.
+- Step-level claim/release.
+- In-process workflow registry.
+- One-shot durable executor for safe registered step handlers.
+
+The design remains upstream-friendly because core durable code does not import
+Workboard plugin code, does not hard-code AICOS names, and keeps projection
+writes best-effort.
+
+## What Is Still Missing
+
+Required before calling this a full core module:
+
+- Long-running worker loop that claims runnable steps and resumes safe work.
+- Durable dispatch path from Workboard and other frontdoors.
+- Storage interface with SQLite default and Postgres-compatible implementation.
+- Schema migration/versioning policy for the durable store.
+- Durable task audit integration before task cleanup marks work lost.
+- Workboard UI rendering for durable state, not only metadata persistence.
+- Explicit side-effect uncertainty handling for model, tool, and message-send
+  operations that may have completed before a crash.
+- Durable workflow versioning policy.
+- Operator-facing timeline and diagnostics polished enough for support.
+- Multi-worker leasing and claim-expiry behavior tested under contention.
+
+## Scalability Direction
+
+The durable core should scale by contract, not by making the first PR large.
+
+Keep the first implementation local-first:
+
+- SQLite is the default runtime store.
+- Postgres support comes through the same storage interface later.
+- Runtime semantics are at-least-once with idempotent steps.
+- Exactly-once should not be promised across external side effects.
+- Event history is used for audit and recovery decisions.
+- Checkpoint/resume state machines are preferred over Temporal-style
+  deterministic replay for the initial agent kernel.
+
+This model fits OpenClaw because agent work often includes non-deterministic LLM
+calls, tools, workspace mutations, and human input. The durable core should make
+state, ownership, waits, retries, and fan-in explicit; it should not require all
+agent code to be deterministic workflow code.
+
+## PR Stack
+
+Do not upstream this branch as one pull request. Split it into reviewable layers.
+
+### PR 1: Durable Store Primitives
+
+Goal:
+
+- Introduce durable workflow control-plane types and SQLite store primitives.
+
+Scope:
+
+- `src/durable/types.ts`
+- `src/durable/sqlite-store.ts`
+- `src/durable/config.ts`
+- low-level store tests
+
+Public surface:
+
+- runs;
+- events;
+- steps;
+- refs;
+- parent/child links;
+- timers;
+- signals;
+- run claims.
+
+Acceptance criteria:
+
+- Store creates schema in OpenClaw state dir.
+- Idempotency key uniqueness is enforced per workflow.
+- Event sequence is monotonic per run.
+- Tests cover create/update/list/read paths.
+
+Review risk:
+
+- Medium. This adds schema and runtime persistence, but no behavior changes if
+  not wired into gateway execution.
+
+Rollback:
+
+- Remove durable module and command registration from later PRs.
+
+### PR 2: Durable CLI and Operator Inspection
+
+Goal:
+
+- Let maintainers inspect durable state without reading SQLite manually.
+
+Scope:
+
+- `src/commands/durable.ts`
+- `src/cli/program/register.durable.ts`
+- CLI command descriptors
+- docs for `openclaw durable`
+
+Commands:
+
+- list runs;
+- show run;
+- timeline;
+- steps;
+- refs;
+- timers;
+- signals;
+- coordination projection if PR 5 has landed.
+
+Acceptance criteria:
+
+- CLI is read-only by default.
+- JSON output is available for tooling.
+- No gateway behavior changes.
+
+Review risk:
+
+- Low. Mostly operator tooling.
+
+### PR 3: Gateway Agent Turn Lifecycle
+
+Goal:
+
+- Record every accepted gateway agent turn as a durable workflow run.
+
+Scope:
+
+- `src/gateway/server-methods/agent.ts`
+- gateway run-loop startup hook
+- durable startup helper
+- agent turn tests
+
+Behavior:
+
+- create durable input ref;
+- create agent invocation step;
+- record received/running/succeeded/failed/cancelled/lost events;
+- avoid raw prompt persistence by default;
+- support opt-out or feature flag while maturing.
+
+Acceptance criteria:
+
+- Normal chat still works when durable core is disabled.
+- Accepted messages have durable run ids when enabled.
+- Gateway restart can show previously running work as lost or recoverable.
+
+Review risk:
+
+- High compared with earlier PRs because it touches request handling.
+
+Mitigation:
+
+- Keep the durable write path best-effort or feature-gated initially.
+- Never block normal message handling because durable inspection metadata failed.
+
+### PR 4: Recovery Worker, Timers, Signals, and Cancellation
+
+Goal:
+
+- Make silence diagnosable and make waits explicit.
+
+Scope:
+
+- `src/durable/recovery.ts`
+- startup recovery registration
+- timer/signal/cancellation tests
+
+Behavior:
+
+- mark stale in-flight runs as lost;
+- process retry timers;
+- process pending cancellation/resume signals;
+- update heartbeat and recovery state;
+- report `unknown_after_side_effect` instead of blindly replaying unsafe work.
+
+Acceptance criteria:
+
+- Gateway restart does not erase accepted work state.
+- Stale work is visible as stale/lost, not silent.
+- Retry/cancel/signal state can be inspected through CLI.
+
+Review risk:
+
+- Medium. This improves visibility first; automatic re-execution should remain
+  conservative until the executor PR.
+
+### PR 5: Subagent Links and Fan-In Policy
+
+Goal:
+
+- Prevent parent agents from silently blocking when subagents complete, fail,
+  overflow, or are cancelled.
+
+Scope:
+
+- `src/durable/fan-in.ts`
+- `src/durable/subagent.ts`
+- `src/agents/subagent-registry-run-manager.ts`
+- fan-in and subagent tests
+
+Behavior:
+
+- create child workflow run for subagent work;
+- link child run to parent run/step;
+- update child link terminal state;
+- reconcile parent fan-in step;
+- allow policy-driven continuation with partial results.
+
+Acceptance criteria:
+
+- Child success unblocks parent fan-in.
+- Child failure does not block parent when policy allows continuation.
+- Lost/cancelled/overflow outcomes become durable terminal child states.
+- Parent and child runs are never mixed across branches.
+
+Review risk:
+
+- High. This is the first PR directly addressing multi-agent coordination.
+
+Mitigation:
+
+- Keep the policy small and explicit.
+- Avoid changing prompt/persona/profile behavior.
+
+### PR 6: Durable Coordination Projection and Gateway Read API
+
+Goal:
+
+- Provide a stable read model for UI, plugins, frontdoors, and operators.
+
+Scope:
+
+- `src/durable/coordination-projection.ts`
+- `src/gateway/server-methods/durable.ts`
+- gateway method descriptors and tests
+- `docs/gateway/protocol.md`
+
+API:
+
+- `durable.coordination.get`
+
+Acceptance criteria:
+
+- Requires `operator.read`.
+- Returns current run status, waiting reason, child counts, terminal reason, and
+  timeline command.
+- Does not expose raw prompts or full event payloads by default.
+
+Review risk:
+
+- Medium. New gateway API, but read-only.
+
+### PR 7: Background Task and TaskFlow Binding
+
+Goal:
+
+- Connect durable coordination state to existing OpenClaw task surfaces without
+  making those surfaces the source of truth.
+
+Scope:
+
+- subagent task metadata binding;
+- `src/durable/taskflow-bridge.ts`;
+- TaskFlow projection tests.
+
+Behavior:
+
+- pass `taskId` and `taskFlowId` into durable run metadata when available;
+- provide a best-effort helper that can sync compact durable projection into
+  TaskFlow state/wait JSON when an adapter calls it;
+- keep projection writes best-effort.
+
+Acceptance criteria:
+
+- Durable run remains the source of truth.
+- TaskFlow can show durable wait/lost/retry state.
+- Projection failure never blocks agent execution.
+
+Review risk:
+
+- Medium. This touches existing task surfaces.
+
+Mitigation:
+
+- Keep all bindings optional.
+- Preserve existing TaskFlow fields.
+
+### PR 8: Workboard Projection Adapter
+
+Goal:
+
+- Let Workboard consume durable coordination state without making Workboard a
+  core dependency.
+
+Scope:
+
+- `extensions/workboard/src/durable-adapter.ts`
+- `extensions/workboard/src/types.ts`
+- `extensions/workboard/src/store.ts`
+- `extensions/workboard/src/gateway.ts`
+- Workboard tests
+
+API:
+
+- `workboard.cards.applyDurableProjection`
+
+Behavior:
+
+- store compact `metadata.durable`;
+- map durable status into Workboard card status;
+- preserve previous durable metadata when partial card updates occur.
+
+Acceptance criteria:
+
+- Workboard can accept a durable projection.
+- Core durable module imports no Workboard code.
+- Card status mapping is deterministic and tested.
+
+Review risk:
+
+- Medium. Plugin-only, but reviewers may ask to split type/store/gateway pieces.
+
+### PR 9: Documentation and Architecture Notes
+
+Goal:
+
+- Explain the durable core boundaries before expanding runtime behavior.
+
+Scope:
+
+- durable core definition;
+- architecture sketch;
+- gateway protocol docs;
+- recovery semantics;
+- anti-goals;
+- future storage and executor plans.
+
+Acceptance criteria:
+
+- Docs explain what is and is not durable.
+- Docs avoid AICOS-specific terms.
+- Docs make clear that this is a native coordination core, not a Temporal clone.
+
+Review risk:
+
+- Low. Should accompany earlier PRs, but can be a separate docs PR if needed.
+
+### PR 10: Executor Kernel Prototype
+
+Goal:
+
+- Add the minimal runtime kernel needed to move from durable inspection to
+  durable execution.
+
+Scope:
+
+- step-level claim/release in `DurableWorkflowStore`;
+- SQLite implementation of step claims;
+- in-process workflow registry;
+- one-shot durable executor;
+- executor tests.
+
+Behavior:
+
+- claim one runnable step;
+- mark run/step running;
+- call a registered step handler;
+- persist heartbeat, output, error, retry timer, wait state, or
+  unknown-after-side-effect;
+- release claim on terminal/waiting/retry outcomes.
+
+Acceptance criteria:
+
+- Success writes output ref and can complete the run.
+- Retryable failure writes error ref and retry timer.
+- Missing handlers become `unknown_after_side_effect`, not blind replay.
+- Existing agent/subagent paths are not automatically executed by the generic
+  executor until a later feature-flagged worker-loop PR.
+
+Review risk:
+
+- Medium. This is core runtime behavior, but it is isolated and not wired into
+  gateway startup.
+
+## Later PRs Not Ready Yet
+
+These should not be bundled into the first upstream stack:
+
+1. Long-running worker loop for the executor kernel.
+2. Workflow SDK and declarative workflow definitions.
+3. Pluggable storage interface and Postgres implementation.
+4. Durable Workboard dispatch path.
+5. Workboard UI timeline/status rendering.
+6. Task audit durable recovery integration.
+7. Multi-worker claim/lease contention tests.
+8. Durable workflow versioning and migration policy.
+9. External adapters for Restate, Temporal, Hatchet, or LangGraph.
+
+## Upstream-Friendly Rules
+
+- Keep the durable core optional while it matures.
+- Do not hard-code AICOS, Discord, Slack, dashboard, or enterprise terms.
+- Keep profile, memory, skill, and prompt semantics outside durable workflow
+  state.
+- Never make Workboard a required dependency of core durable code.
+- Prefer compact projections over duplicating the event journal into every
+  surface.
+- Do not promise exactly-once external side effects.
+- Make side-effect uncertainty visible instead of hiding it.
+- Keep SQLite first; add Postgres through an interface later.
+- Add tests with every behavioral PR.
+
+## Native Core Readiness Checklist
+
+Before calling this "OpenClaw Durable Core" instead of "durable coordination
+slice", the branch should satisfy:
+
+- every accepted frontdoor message gets a durable identity;
+- every long-running step updates heartbeat/progress;
+- every parent wait has an explicit durable reason;
+- every spawned subagent has a durable child run or explicit non-durable reason;
+- child terminal states reconcile parent fan-in;
+- failed child branches do not block the parent unless policy says they should;
+- gateway restart leaves accepted work inspectable and recoverable;
+- operator CLI and gateway API can explain why work is quiet;
+- retry/cancel/human-signal transitions are durable and idempotent;
+- unsafe replay after side effects is marked explicitly;
+- storage schema can evolve safely;
+- future Postgres/multi-worker support does not require changing public durable
+  identifiers.
+
+## Recommended Next Engineering Step
+
+The next code milestone after the current executor kernel should be a
+feature-flagged worker loop that can:
+
+1. poll for runnable durable steps;
+2. enforce max concurrency;
+3. run registered safe handlers;
+4. stop cleanly on gateway shutdown;
+5. leave unsafe side-effect steps in inspectable waiting state;
+6. expose worker health through CLI/gateway diagnostics.
+
+That milestone is the line between one-shot durable execution and an always-on
+native durable workflow runtime.

--- a/scripts/check-kysely-guardrails.mjs
+++ b/scripts/check-kysely-guardrails.mjs
@@ -52,7 +52,10 @@ const rawSqliteAllowPathGroups = {
     "src/infra/state-migrations.ts",
     "src/infra/state-migrations.debug-proxy.ts",
   ],
-  "shared database stores with direct DatabaseSync access": ["src/proxy-capture/store.sqlite.ts"],
+  "shared database stores with direct DatabaseSync access": [
+    "src/durable/sqlite-store.ts",
+    "src/proxy-capture/store.sqlite.ts",
+  ],
   "Kysely-backed stores that own a DatabaseSync boundary": [
     "src/acp/event-ledger.ts",
     "src/agents/subagent-registry.store.ts",

--- a/src/durable/config.ts
+++ b/src/durable/config.ts
@@ -1,0 +1,17 @@
+// Durable workflow feature flag and path resolution.
+import path from "node:path";
+import { resolveStateDir } from "../config/paths.js";
+
+const ENABLED_VALUES = new Set(["1", "true", "yes", "on"]);
+
+export function isDurableWorkflowsEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return ENABLED_VALUES.has((env.OPENCLAW_DURABLE_WORKFLOWS ?? "").trim().toLowerCase());
+}
+
+export function resolveDurableWorkflowSqlitePath(env: NodeJS.ProcessEnv = process.env): string {
+  const override = env.OPENCLAW_DURABLE_WORKFLOWS_DB_PATH?.trim();
+  if (override) {
+    return path.resolve(override);
+  }
+  return path.join(resolveStateDir(env), "durable", "workflows.sqlite");
+}

--- a/src/durable/executor.test.ts
+++ b/src/durable/executor.test.ts
@@ -1,0 +1,196 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { runDurableExecutorOnce } from "./executor.js";
+import { createDurableWorkflowRegistry } from "./registry.js";
+import { openDurableWorkflowSqliteStore } from "./sqlite-store.js";
+
+function tempStore() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-durable-executor-"));
+  const store = openDurableWorkflowSqliteStore({
+    path: path.join(dir, "workflows.sqlite"),
+  });
+  return {
+    store,
+    cleanup: () => {
+      store.close();
+      fs.rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+describe("durable workflow executor", () => {
+  it("claims a runnable step, runs a handler, records heartbeat, and completes the run", async () => {
+    const { store, cleanup } = tempStore();
+    try {
+      const registry = createDurableWorkflowRegistry();
+      registry.registerStepHandler("tool", (context) => {
+        context.heartbeat({ phase: "testing" });
+        return {
+          kind: "succeeded",
+          output: { ok: true },
+          completeRun: true,
+        };
+      });
+      const run = store.createRun({
+        workflowId: "test.workflow",
+        status: "queued",
+        recoveryState: "runnable",
+        now: 100,
+      });
+      const step = store.createStep({
+        workflowRunId: run.workflowRunId,
+        stepType: "tool",
+        status: "queued",
+        recoveryState: "runnable",
+        now: 110,
+      });
+      let clock = 120;
+
+      const result = await runDurableExecutorOnce({
+        store,
+        registry,
+        workerId: "worker-1",
+        workflowId: "test.workflow",
+        now: () => {
+          clock += 10;
+          return clock;
+        },
+      });
+
+      expect(result).toEqual({
+        claimed: true,
+        workflowRunId: run.workflowRunId,
+        stepId: step.stepId,
+        outcome: "succeeded",
+      });
+      expect(store.getRun(run.workflowRunId)).toMatchObject({
+        status: "succeeded",
+        recoveryState: "terminal",
+      });
+      expect(store.listSteps(run.workflowRunId)).toMatchObject([
+        {
+          stepId: step.stepId,
+          status: "succeeded",
+          recoveryState: "terminal",
+          outputRef: expect.any(String),
+        },
+      ]);
+      expect(store.getTimeline(run.workflowRunId).map((event) => event.eventType)).toEqual([
+        "workflow.step.running",
+        "workflow.step.heartbeat",
+        "workflow.step.succeeded",
+      ]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("schedules retry timers for retryable handler failures", async () => {
+    const { store, cleanup } = tempStore();
+    try {
+      const registry = createDurableWorkflowRegistry();
+      registry.registerStepHandler("tool", () => ({
+        kind: "failed",
+        error: { code: "temporary" },
+        retryAfterMs: 500,
+      }));
+      const run = store.createRun({
+        workflowId: "test.workflow",
+        status: "queued",
+        recoveryState: "runnable",
+        now: 100,
+      });
+      const step = store.createStep({
+        workflowRunId: run.workflowRunId,
+        stepType: "tool",
+        status: "queued",
+        recoveryState: "runnable",
+        maxAttempts: 3,
+        now: 110,
+      });
+
+      const result = await runDurableExecutorOnce({
+        store,
+        registry,
+        workerId: "worker-1",
+        workflowId: "test.workflow",
+        now: () => 200,
+      });
+
+      expect(result).toMatchObject({ claimed: true, outcome: "failed" });
+      expect(store.getRun(run.workflowRunId)).toMatchObject({
+        status: "retry_scheduled",
+        recoveryState: "retry_scheduled",
+      });
+      expect(store.listSteps(run.workflowRunId)).toMatchObject([
+        {
+          stepId: step.stepId,
+          status: "retry_scheduled",
+          recoveryState: "retry_scheduled",
+          attempt: 2,
+          errorRef: expect.any(String),
+        },
+      ]);
+      expect(store.listTimers(run.workflowRunId)).toMatchObject([
+        {
+          timerType: "retry",
+          dueAt: 700,
+          status: "pending",
+          stepId: step.stepId,
+        },
+      ]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("marks unhandled step types as unknown instead of replaying blindly", async () => {
+    const { store, cleanup } = tempStore();
+    try {
+      const registry = createDurableWorkflowRegistry();
+      const run = store.createRun({
+        workflowId: "test.workflow",
+        status: "queued",
+        recoveryState: "runnable",
+        now: 100,
+      });
+      const step = store.createStep({
+        workflowRunId: run.workflowRunId,
+        stepType: "agent",
+        status: "queued",
+        recoveryState: "runnable",
+        now: 110,
+      });
+
+      const result = await runDurableExecutorOnce({
+        store,
+        registry,
+        workerId: "worker-1",
+        workflowId: "test.workflow",
+        now: () => 200,
+      });
+
+      expect(result).toEqual({
+        claimed: true,
+        workflowRunId: run.workflowRunId,
+        stepId: step.stepId,
+        outcome: "no_handler",
+      });
+      expect(store.getRun(run.workflowRunId)).toMatchObject({
+        status: "waiting",
+        recoveryState: "unknown_after_side_effect",
+      });
+      expect(store.listSteps(run.workflowRunId)).toMatchObject([
+        {
+          stepId: step.stepId,
+          status: "waiting",
+          recoveryState: "unknown_after_side_effect",
+        },
+      ]);
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/src/durable/executor.ts
+++ b/src/durable/executor.ts
@@ -1,0 +1,548 @@
+import type { DurableWorkflowRegistry, DurableWorkflowStepHandlerResult } from "./registry.js";
+import type {
+  DurableWorkflowRef,
+  DurableWorkflowRun,
+  DurableWorkflowStep,
+  DurableWorkflowStepType,
+  DurableWorkflowStore,
+} from "./types.js";
+
+export type DurableExecutorRunOnceOptions = {
+  store: DurableWorkflowStore;
+  registry: DurableWorkflowRegistry;
+  workerId: string;
+  claimTtlMs?: number;
+  workflowId?: string;
+  stepType?: DurableWorkflowStepType;
+  now?: () => number;
+};
+
+export type DurableExecutorRunOnceResult =
+  | {
+      claimed: false;
+      reason: "no_runnable_step";
+    }
+  | {
+      claimed: true;
+      workflowRunId: string;
+      stepId: string;
+      outcome: DurableWorkflowStepHandlerResult["kind"] | "no_handler" | "handler_exception";
+    };
+
+const DEFAULT_CLAIM_TTL_MS = 5 * 60 * 1000;
+
+function terminalRunStatus(run: DurableWorkflowRun): boolean {
+  return (
+    run.status === "succeeded" ||
+    run.status === "failed" ||
+    run.status === "cancelled" ||
+    run.status === "lost"
+  );
+}
+
+function createJsonRef(params: {
+  store: DurableWorkflowStore;
+  run: DurableWorkflowRun;
+  step: DurableWorkflowStep;
+  refKind: DurableWorkflowRef["refKind"];
+  metadata: Record<string, unknown>;
+  label: string;
+  now: number;
+}): DurableWorkflowRef {
+  return params.store.createRef({
+    workflowRunId: params.run.workflowRunId,
+    stepId: params.step.stepId,
+    refKind: params.refKind,
+    mediaType: "application/json",
+    storageKind: "inline",
+    storageUri: `inline:durable-step:${params.step.stepId}:${params.label}`,
+    metadata: params.metadata,
+    now: params.now,
+  });
+}
+
+function clearStepClaimFields(workerId: string): {
+  claimedBy: null;
+  claimExpiresAt: null;
+  heartbeatAt: null;
+} {
+  void workerId;
+  return {
+    claimedBy: null,
+    claimExpiresAt: null,
+    heartbeatAt: null,
+  };
+}
+
+function markNoHandler(params: {
+  store: DurableWorkflowStore;
+  run: DurableWorkflowRun;
+  step: DurableWorkflowStep;
+  workerId: string;
+  now: number;
+}): DurableExecutorRunOnceResult {
+  params.store.updateStep({
+    workflowRunId: params.step.workflowRunId,
+    stepId: params.step.stepId,
+    status: "waiting",
+    recoveryState: "unknown_after_side_effect",
+    ...clearStepClaimFields(params.workerId),
+    now: params.now,
+  });
+  params.store.updateRun({
+    workflowRunId: params.run.workflowRunId,
+    status: "waiting",
+    recoveryState: "unknown_after_side_effect",
+    heartbeatAt: null,
+    now: params.now,
+  });
+  params.store.appendEvent({
+    workflowRunId: params.run.workflowRunId,
+    eventType: "workflow.step.no_handler",
+    eventTime: params.now,
+    stepId: params.step.stepId,
+    payload: {
+      stepType: params.step.stepType,
+      workerId: params.workerId,
+    },
+  });
+  return {
+    claimed: true,
+    workflowRunId: params.run.workflowRunId,
+    stepId: params.step.stepId,
+    outcome: "no_handler",
+  };
+}
+
+function markHandlerException(params: {
+  store: DurableWorkflowStore;
+  run: DurableWorkflowRun;
+  step: DurableWorkflowStep;
+  workerId: string;
+  now: number;
+  err: unknown;
+}): DurableExecutorRunOnceResult {
+  const errorRef = createJsonRef({
+    store: params.store,
+    run: params.run,
+    step: params.step,
+    refKind: "error",
+    label: "handler-exception",
+    metadata: { message: String(params.err) },
+    now: params.now,
+  });
+  params.store.updateStep({
+    workflowRunId: params.step.workflowRunId,
+    stepId: params.step.stepId,
+    status: "failed",
+    recoveryState: "terminal",
+    errorRef: errorRef.refId,
+    completedAt: params.now,
+    ...clearStepClaimFields(params.workerId),
+    now: params.now,
+  });
+  params.store.updateRun({
+    workflowRunId: params.run.workflowRunId,
+    status: "failed",
+    recoveryState: "terminal",
+    completedAt: params.now,
+    heartbeatAt: null,
+    now: params.now,
+  });
+  params.store.appendEvent({
+    workflowRunId: params.run.workflowRunId,
+    eventType: "workflow.step.handler_exception",
+    eventTime: params.now,
+    stepId: params.step.stepId,
+    payload: {
+      errorRef: errorRef.refId,
+      workerId: params.workerId,
+    },
+  });
+  return {
+    claimed: true,
+    workflowRunId: params.run.workflowRunId,
+    stepId: params.step.stepId,
+    outcome: "handler_exception",
+  };
+}
+
+function applyStepResult(params: {
+  store: DurableWorkflowStore;
+  run: DurableWorkflowRun;
+  step: DurableWorkflowStep;
+  workerId: string;
+  now: number;
+  result: DurableWorkflowStepHandlerResult;
+}): DurableExecutorRunOnceResult {
+  const { store, run, step, workerId, now, result } = params;
+
+  if (result.kind === "succeeded") {
+    const outputRef =
+      result.outputRef ??
+      (result.output
+        ? createJsonRef({
+            store,
+            run,
+            step,
+            refKind: "output",
+            label: "output",
+            metadata: result.output,
+            now,
+          }).refId
+        : undefined);
+    store.updateStep({
+      workflowRunId: step.workflowRunId,
+      stepId: step.stepId,
+      status: "succeeded",
+      recoveryState: "terminal",
+      outputRef,
+      checkpointRef: result.checkpointRef ?? null,
+      completedAt: now,
+      ...clearStepClaimFields(workerId),
+      now,
+    });
+    store.appendEvent({
+      workflowRunId: run.workflowRunId,
+      eventType: "workflow.step.succeeded",
+      eventTime: now,
+      stepId: step.stepId,
+      payload: { outputRef, workerId },
+    });
+    store.updateRun(
+      result.completeRun
+        ? {
+            workflowRunId: run.workflowRunId,
+            status: "succeeded",
+            recoveryState: "terminal",
+            checkpointRef: result.checkpointRef ?? null,
+            completedAt: now,
+            heartbeatAt: null,
+            now,
+          }
+        : {
+            workflowRunId: run.workflowRunId,
+            status: "queued",
+            recoveryState: "runnable",
+            checkpointRef: result.checkpointRef ?? undefined,
+            heartbeatAt: null,
+            now,
+          },
+    );
+    return {
+      claimed: true,
+      workflowRunId: run.workflowRunId,
+      stepId: step.stepId,
+      outcome: result.kind,
+    };
+  }
+
+  if (result.kind === "failed") {
+    const errorRef = createJsonRef({
+      store,
+      run,
+      step,
+      refKind: "error",
+      label: "error",
+      metadata: result.error ?? { message: "durable step failed" },
+      now,
+    });
+    const retryAllowed = Boolean(
+      result.retryAfterMs && (!step.maxAttempts || step.attempt < step.maxAttempts),
+    );
+    if (retryAllowed) {
+      const timer = store.createTimer({
+        workflowRunId: run.workflowRunId,
+        stepId: step.stepId,
+        timerType: "retry",
+        dueAt: now + Math.max(0, Math.trunc(result.retryAfterMs ?? 0)),
+        metadata: { errorRef: errorRef.refId },
+        now,
+      });
+      store.updateStep({
+        workflowRunId: step.workflowRunId,
+        stepId: step.stepId,
+        status: "retry_scheduled",
+        recoveryState: "retry_scheduled",
+        attempt: step.attempt + 1,
+        errorRef: errorRef.refId,
+        checkpointRef: result.checkpointRef ?? null,
+        ...clearStepClaimFields(workerId),
+        now,
+      });
+      store.updateRun({
+        workflowRunId: run.workflowRunId,
+        status: "retry_scheduled",
+        recoveryState: "retry_scheduled",
+        checkpointRef: result.checkpointRef ?? undefined,
+        heartbeatAt: null,
+        now,
+      });
+      store.appendEvent({
+        workflowRunId: run.workflowRunId,
+        eventType: "workflow.step.retry_scheduled",
+        eventTime: now,
+        stepId: step.stepId,
+        payload: { errorRef: errorRef.refId, timerId: timer.timerId, workerId },
+      });
+      return {
+        claimed: true,
+        workflowRunId: run.workflowRunId,
+        stepId: step.stepId,
+        outcome: result.kind,
+      };
+    }
+    store.updateStep({
+      workflowRunId: step.workflowRunId,
+      stepId: step.stepId,
+      status: "failed",
+      recoveryState: "terminal",
+      errorRef: errorRef.refId,
+      checkpointRef: result.checkpointRef ?? null,
+      completedAt: now,
+      ...clearStepClaimFields(workerId),
+      now,
+    });
+    if (result.completeRun !== false) {
+      store.updateRun({
+        workflowRunId: run.workflowRunId,
+        status: "failed",
+        recoveryState: "terminal",
+        checkpointRef: result.checkpointRef ?? null,
+        completedAt: now,
+        heartbeatAt: null,
+        now,
+      });
+    }
+    store.appendEvent({
+      workflowRunId: run.workflowRunId,
+      eventType: "workflow.step.failed",
+      eventTime: now,
+      stepId: step.stepId,
+      payload: { errorRef: errorRef.refId, workerId },
+    });
+    return {
+      claimed: true,
+      workflowRunId: run.workflowRunId,
+      stepId: step.stepId,
+      outcome: result.kind,
+    };
+  }
+
+  if (result.kind === "waiting_signal") {
+    store.updateStep({
+      workflowRunId: step.workflowRunId,
+      stepId: step.stepId,
+      status: "waiting",
+      recoveryState: "waiting_signal",
+      checkpointRef: result.checkpointRef ?? null,
+      ...clearStepClaimFields(workerId),
+      now,
+    });
+    store.updateRun({
+      workflowRunId: run.workflowRunId,
+      status: "waiting_signal",
+      recoveryState: "waiting_signal",
+      checkpointRef: result.checkpointRef ?? undefined,
+      heartbeatAt: null,
+      now,
+    });
+    store.appendEvent({
+      workflowRunId: run.workflowRunId,
+      eventType: "workflow.step.waiting_signal",
+      eventTime: now,
+      stepId: step.stepId,
+      payload: { reason: result.reason, workerId },
+    });
+    return {
+      claimed: true,
+      workflowRunId: run.workflowRunId,
+      stepId: step.stepId,
+      outcome: result.kind,
+    };
+  }
+
+  if (result.kind === "waiting_timer") {
+    const timer = store.createTimer({
+      workflowRunId: run.workflowRunId,
+      stepId: step.stepId,
+      timerType: result.timerType ?? "sleep",
+      dueAt: result.dueAt,
+      metadata: { reason: result.reason },
+      now,
+    });
+    store.updateStep({
+      workflowRunId: step.workflowRunId,
+      stepId: step.stepId,
+      status: "waiting",
+      recoveryState: "waiting_timer",
+      checkpointRef: result.checkpointRef ?? null,
+      ...clearStepClaimFields(workerId),
+      now,
+    });
+    store.updateRun({
+      workflowRunId: run.workflowRunId,
+      status: "waiting_timer",
+      recoveryState: "waiting_timer",
+      checkpointRef: result.checkpointRef ?? undefined,
+      heartbeatAt: null,
+      now,
+    });
+    store.appendEvent({
+      workflowRunId: run.workflowRunId,
+      eventType: "workflow.step.waiting_timer",
+      eventTime: now,
+      stepId: step.stepId,
+      payload: { timerId: timer.timerId, reason: result.reason, workerId },
+    });
+    return {
+      claimed: true,
+      workflowRunId: run.workflowRunId,
+      stepId: step.stepId,
+      outcome: result.kind,
+    };
+  }
+
+  store.updateStep({
+    workflowRunId: step.workflowRunId,
+    stepId: step.stepId,
+    status: "waiting",
+    recoveryState: "unknown_after_side_effect",
+    checkpointRef: result.checkpointRef ?? null,
+    ...clearStepClaimFields(workerId),
+    now,
+  });
+  store.updateRun({
+    workflowRunId: run.workflowRunId,
+    status: "waiting",
+    recoveryState: "unknown_after_side_effect",
+    checkpointRef: result.checkpointRef ?? undefined,
+    heartbeatAt: null,
+    now,
+  });
+  store.appendEvent({
+    workflowRunId: run.workflowRunId,
+    eventType: "workflow.step.side_effect_uncertain",
+    eventTime: now,
+    stepId: step.stepId,
+    payload: { reason: result.reason, workerId },
+  });
+  return {
+    claimed: true,
+    workflowRunId: run.workflowRunId,
+    stepId: step.stepId,
+    outcome: result.kind,
+  };
+}
+
+export async function runDurableExecutorOnce(
+  options: DurableExecutorRunOnceOptions,
+): Promise<DurableExecutorRunOnceResult> {
+  const now = options.now ?? (() => Date.now());
+  const claimTime = now();
+  const step = options.store.claimNextRunnableStep({
+    workflowId: options.workflowId,
+    stepType: options.stepType,
+    workerId: options.workerId,
+    claimTtlMs: options.claimTtlMs ?? DEFAULT_CLAIM_TTL_MS,
+    now: claimTime,
+  });
+  if (!step) {
+    return { claimed: false, reason: "no_runnable_step" };
+  }
+  const run = options.store.getRun(step.workflowRunId);
+  if (!run || terminalRunStatus(run)) {
+    options.store.releaseStepClaim({
+      workflowRunId: step.workflowRunId,
+      stepId: step.stepId,
+      workerId: options.workerId,
+      now: now(),
+    });
+    return { claimed: false, reason: "no_runnable_step" };
+  }
+  const handler = options.registry.getStepHandler(step.stepType);
+  const startTime = now();
+  options.store.updateStep({
+    workflowRunId: step.workflowRunId,
+    stepId: step.stepId,
+    status: "running",
+    recoveryState: "running",
+    startedAt: step.startedAt ?? startTime,
+    heartbeatAt: startTime,
+    now: startTime,
+  });
+  options.store.updateRun({
+    workflowRunId: run.workflowRunId,
+    status: "running",
+    recoveryState: "running",
+    heartbeatAt: startTime,
+    now: startTime,
+  });
+  options.store.appendEvent({
+    workflowRunId: run.workflowRunId,
+    eventType: "workflow.step.running",
+    eventTime: startTime,
+    stepId: step.stepId,
+    payload: {
+      stepType: step.stepType,
+      workerId: options.workerId,
+    },
+  });
+  if (!handler) {
+    return markNoHandler({
+      store: options.store,
+      run,
+      step,
+      workerId: options.workerId,
+      now: now(),
+    });
+  }
+
+  try {
+    const result = await handler({
+      store: options.store,
+      run,
+      step,
+      workerId: options.workerId,
+      now,
+      heartbeat: (payload?: Record<string, unknown>) => {
+        const heartbeatAt = now();
+        options.store.updateStep({
+          workflowRunId: step.workflowRunId,
+          stepId: step.stepId,
+          heartbeatAt,
+          now: heartbeatAt,
+        });
+        options.store.updateRun({
+          workflowRunId: run.workflowRunId,
+          heartbeatAt,
+          now: heartbeatAt,
+        });
+        options.store.appendEvent({
+          workflowRunId: run.workflowRunId,
+          eventType: "workflow.step.heartbeat",
+          eventTime: heartbeatAt,
+          stepId: step.stepId,
+          payload: { ...payload, workerId: options.workerId },
+        });
+      },
+    });
+    return applyStepResult({
+      store: options.store,
+      run,
+      step,
+      workerId: options.workerId,
+      now: now(),
+      result,
+    });
+  } catch (err) {
+    return markHandlerException({
+      store: options.store,
+      run,
+      step,
+      workerId: options.workerId,
+      now: now(),
+      err,
+    });
+  }
+}

--- a/src/durable/fan-in.test.ts
+++ b/src/durable/fan-in.test.ts
@@ -1,0 +1,167 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { reconcileDurableFanIn } from "./fan-in.js";
+import { openDurableWorkflowSqliteStore } from "./sqlite-store.js";
+
+describe("durable workflow fan-in", () => {
+  it("unblocks the parent when all children are terminal under continue policy", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-durable-fanin-"));
+    const store = openDurableWorkflowSqliteStore({
+      path: path.join(dir, "workflows.sqlite"),
+    });
+    try {
+      const parent = store.createRun({
+        workflowId: "test.parent",
+        status: "waiting_child",
+        recoveryState: "waiting_child",
+        now: 100,
+      });
+      const fanInStep = store.createStep({
+        workflowRunId: parent.workflowRunId,
+        stepId: "fan_in_children",
+        stepType: "fan_in",
+        status: "waiting",
+        recoveryState: "waiting_child",
+        now: 100,
+      });
+      const childA = store.createRun({
+        workflowId: "test.child",
+        parentWorkflowRunId: parent.workflowRunId,
+        parentStepId: fanInStep.stepId,
+        status: "succeeded",
+        recoveryState: "terminal",
+        completedAt: 120,
+        now: 120,
+      });
+      const childB = store.createRun({
+        workflowId: "test.child",
+        parentWorkflowRunId: parent.workflowRunId,
+        parentStepId: fanInStep.stepId,
+        status: "failed",
+        recoveryState: "terminal",
+        completedAt: 130,
+        now: 130,
+      });
+      store.createLink({
+        parentWorkflowRunId: parent.workflowRunId,
+        parentStepId: fanInStep.stepId,
+        childWorkflowRunId: childA.workflowRunId,
+        linkType: "child_workflow",
+        status: "succeeded",
+        now: 121,
+      });
+      store.createLink({
+        parentWorkflowRunId: parent.workflowRunId,
+        parentStepId: fanInStep.stepId,
+        childWorkflowRunId: childB.workflowRunId,
+        linkType: "child_workflow",
+        status: "failed",
+        now: 131,
+      });
+
+      const result = reconcileDurableFanIn({
+        store,
+        parentWorkflowRunId: parent.workflowRunId,
+        parentStepId: fanInStep.stepId,
+        policy: "continue_on_child_failure",
+        now: 140,
+      });
+
+      expect(result).toEqual({
+        status: "succeeded",
+        total: 2,
+        succeeded: 1,
+        failed: 1,
+        terminal: 2,
+        ready: true,
+      });
+      expect(store.listSteps(parent.workflowRunId)).toMatchObject([
+        {
+          stepId: fanInStep.stepId,
+          status: "succeeded",
+          recoveryState: "terminal",
+          completedAt: 140,
+        },
+      ]);
+      expect(store.listOpenRuns({ workflowId: "test.parent" })).toMatchObject([
+        {
+          workflowRunId: parent.workflowRunId,
+          status: "queued",
+          recoveryState: "runnable",
+        },
+      ]);
+      expect(store.getTimeline(parent.workflowRunId).at(-1)).toMatchObject({
+        eventType: "fan_in.ready",
+      });
+    } finally {
+      store.close();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("fails the parent when fail-parent policy sees a failed child", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-durable-fanin-"));
+    const store = openDurableWorkflowSqliteStore({
+      path: path.join(dir, "workflows.sqlite"),
+    });
+    try {
+      const parent = store.createRun({
+        workflowId: "test.parent",
+        status: "waiting_child",
+        recoveryState: "waiting_child",
+        now: 100,
+      });
+      const fanInStep = store.createStep({
+        workflowRunId: parent.workflowRunId,
+        stepId: "fan_in_children",
+        stepType: "fan_in",
+        status: "waiting",
+        recoveryState: "waiting_child",
+        now: 100,
+      });
+      const child = store.createRun({
+        workflowId: "test.child",
+        status: "failed",
+        recoveryState: "terminal",
+        completedAt: 120,
+        now: 120,
+      });
+      store.createLink({
+        parentWorkflowRunId: parent.workflowRunId,
+        parentStepId: fanInStep.stepId,
+        childWorkflowRunId: child.workflowRunId,
+        linkType: "child_workflow",
+        status: "failed",
+        now: 121,
+      });
+
+      const result = reconcileDurableFanIn({
+        store,
+        parentWorkflowRunId: parent.workflowRunId,
+        parentStepId: fanInStep.stepId,
+        policy: "fail_parent_on_child_failure",
+        now: 130,
+      });
+
+      expect(result.status).toBe("failed");
+      expect(store.listRuns({ limit: 10 })).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            workflowRunId: parent.workflowRunId,
+            status: "failed",
+            recoveryState: "terminal",
+            completedAt: 130,
+          }),
+        ]),
+      );
+      expect(store.getTimeline(parent.workflowRunId).at(-1)).toMatchObject({
+        eventType: "fan_in.failed",
+      });
+    } finally {
+      store.close();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/durable/fan-in.ts
+++ b/src/durable/fan-in.ts
@@ -1,0 +1,163 @@
+// Durable parent/child fan-in policy helpers.
+import type {
+  DurableWorkflowLinkStatus,
+  DurableWorkflowStepStatus,
+  DurableWorkflowStore,
+} from "./types.js";
+
+export type DurableFanInPolicy =
+  | "all_succeeded"
+  | "all_terminal"
+  | "first_success"
+  | "continue_on_child_failure"
+  | "fail_parent_on_child_failure";
+
+export type DurableFanInResult = {
+  status: DurableWorkflowStepStatus;
+  total: number;
+  succeeded: number;
+  failed: number;
+  terminal: number;
+  ready: boolean;
+};
+
+function isTerminalLinkStatus(status: DurableWorkflowLinkStatus): boolean {
+  return (
+    status === "succeeded" || status === "failed" || status === "cancelled" || status === "lost"
+  );
+}
+
+function computeFanInResult(params: {
+  statuses: DurableWorkflowLinkStatus[];
+  policy: DurableFanInPolicy;
+}): DurableFanInResult {
+  const total = params.statuses.length;
+  const succeeded = params.statuses.filter((status) => status === "succeeded").length;
+  const failed = params.statuses.filter(
+    (status) => status === "failed" || status === "cancelled" || status === "lost",
+  ).length;
+  const terminal = params.statuses.filter(isTerminalLinkStatus).length;
+
+  if (total === 0) {
+    return { status: "waiting", total, succeeded, failed, terminal, ready: false };
+  }
+
+  switch (params.policy) {
+    case "all_succeeded":
+      if (failed > 0) {
+        return { status: "failed", total, succeeded, failed, terminal, ready: true };
+      }
+      return {
+        status: succeeded === total ? "succeeded" : "waiting",
+        total,
+        succeeded,
+        failed,
+        terminal,
+        ready: succeeded === total,
+      };
+    case "all_terminal":
+    case "continue_on_child_failure":
+      return {
+        status: terminal === total ? "succeeded" : "waiting",
+        total,
+        succeeded,
+        failed,
+        terminal,
+        ready: terminal === total,
+      };
+    case "first_success":
+      if (succeeded > 0) {
+        return { status: "succeeded", total, succeeded, failed, terminal, ready: true };
+      }
+      return {
+        status: terminal === total ? "failed" : "waiting",
+        total,
+        succeeded,
+        failed,
+        terminal,
+        ready: terminal === total,
+      };
+    case "fail_parent_on_child_failure":
+      if (failed > 0) {
+        return { status: "failed", total, succeeded, failed, terminal, ready: true };
+      }
+      return {
+        status: succeeded === total ? "succeeded" : "waiting",
+        total,
+        succeeded,
+        failed,
+        terminal,
+        ready: succeeded === total,
+      };
+  }
+}
+
+export function reconcileDurableFanIn(params: {
+  store: DurableWorkflowStore;
+  parentWorkflowRunId: string;
+  parentStepId: string;
+  policy: DurableFanInPolicy;
+  now?: number;
+}): DurableFanInResult {
+  const now = params.now ?? Date.now();
+  const childLinks = params.store
+    .listChildLinks(params.parentWorkflowRunId)
+    .filter((link) => link.parentStepId === params.parentStepId);
+  const result = computeFanInResult({
+    statuses: childLinks.map((link) => link.status),
+    policy: params.policy,
+  });
+
+  params.store.updateStep({
+    workflowRunId: params.parentWorkflowRunId,
+    stepId: params.parentStepId,
+    status: result.status,
+    recoveryState: result.status === "waiting" ? "waiting_child" : "terminal",
+    ...(result.ready ? { completedAt: now } : {}),
+    metadata: {
+      policy: params.policy,
+      total: result.total,
+      succeeded: result.succeeded,
+      failed: result.failed,
+      terminal: result.terminal,
+    },
+    now,
+  });
+
+  params.store.appendEvent({
+    workflowRunId: params.parentWorkflowRunId,
+    eventType: result.ready
+      ? result.status === "succeeded"
+        ? "fan_in.ready"
+        : "fan_in.failed"
+      : "fan_in.partial",
+    eventTime: now,
+    stepId: params.parentStepId,
+    payload: {
+      policy: params.policy,
+      total: result.total,
+      succeeded: result.succeeded,
+      failed: result.failed,
+      terminal: result.terminal,
+    },
+  });
+
+  if (result.status === "succeeded") {
+    params.store.updateRun({
+      workflowRunId: params.parentWorkflowRunId,
+      status: "queued",
+      recoveryState: "runnable",
+      now,
+    });
+  } else if (result.status === "failed" && params.policy === "fail_parent_on_child_failure") {
+    params.store.updateRun({
+      workflowRunId: params.parentWorkflowRunId,
+      status: "failed",
+      recoveryState: "terminal",
+      completedAt: now,
+      now,
+    });
+  }
+
+  return result;
+}

--- a/src/durable/recovery.test.ts
+++ b/src/durable/recovery.test.ts
@@ -1,0 +1,265 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  reconcileDueDurableTimers,
+  reconcileDurableAgentTurnsOnGatewayStartup,
+  reconcilePendingDurableSignals,
+  reconcileStaleDurableAgentTurns,
+} from "./recovery.js";
+import { openDurableWorkflowSqliteStore } from "./sqlite-store.js";
+import { DURABLE_AGENT_TURN_WORKFLOW_ID } from "./workflow-ids.js";
+
+describe("durable workflow recovery", () => {
+  it("marks running agent turns lost on gateway startup without touching waiting turns", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-durable-recovery-"));
+    const store = openDurableWorkflowSqliteStore({
+      path: path.join(dir, "workflows.sqlite"),
+    });
+    try {
+      const running = store.createRun({
+        workflowId: DURABLE_AGENT_TURN_WORKFLOW_ID,
+        idempotencyKey: "run-running",
+        status: "running",
+        recoveryState: "running",
+        metadata: { sessionKey: "agent:test:running" },
+        now: 100,
+      });
+      const runningStep = store.createStep({
+        workflowRunId: running.workflowRunId,
+        stepId: "agent_invocation",
+        stepType: "agent",
+        status: "running",
+        recoveryState: "running",
+        now: 100,
+      });
+      const waiting = store.createRun({
+        workflowId: DURABLE_AGENT_TURN_WORKFLOW_ID,
+        idempotencyKey: "run-waiting",
+        status: "waiting",
+        recoveryState: "waiting_signal",
+        metadata: { sessionKey: "agent:test:waiting" },
+        now: 100,
+      });
+
+      const result = reconcileDurableAgentTurnsOnGatewayStartup({
+        store,
+        processInstanceId: "process-1",
+        now: 200,
+      });
+
+      expect(result).toEqual({ scanned: 2, markedLost: 1 });
+      expect(store.listRuns({ limit: 10 })).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            workflowRunId: running.workflowRunId,
+            status: "lost",
+            recoveryState: "lost",
+            completedAt: 200,
+          }),
+          expect.objectContaining({
+            workflowRunId: waiting.workflowRunId,
+            status: "waiting",
+            recoveryState: "waiting_signal",
+          }),
+        ]),
+      );
+      expect(store.getTimeline(running.workflowRunId).map((event) => event.eventType)).toEqual([
+        "agent.turn.lost",
+      ]);
+      expect(store.listSteps(running.workflowRunId)).toMatchObject([
+        {
+          stepId: runningStep.stepId,
+          status: "lost",
+          recoveryState: "lost",
+          completedAt: 200,
+        },
+      ]);
+    } finally {
+      store.close();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("marks only stale running agent turns lost during periodic recovery", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-durable-recovery-"));
+    const store = openDurableWorkflowSqliteStore({
+      path: path.join(dir, "workflows.sqlite"),
+    });
+    try {
+      const stale = store.createRun({
+        workflowId: DURABLE_AGENT_TURN_WORKFLOW_ID,
+        idempotencyKey: "run-stale",
+        status: "running",
+        recoveryState: "running",
+        metadata: { sessionKey: "agent:test:stale" },
+        now: 100,
+      });
+      const fresh = store.createRun({
+        workflowId: DURABLE_AGENT_TURN_WORKFLOW_ID,
+        idempotencyKey: "run-fresh",
+        status: "running",
+        recoveryState: "running",
+        metadata: { sessionKey: "agent:test:fresh" },
+        now: 1_900,
+      });
+
+      const result = reconcileStaleDurableAgentTurns({
+        store,
+        processInstanceId: "process-1",
+        now: 2_000,
+        staleAfterMs: 1_000,
+      });
+
+      expect(result).toEqual({ scanned: 2, markedLost: 1 });
+      expect(store.listRuns({ limit: 10 })).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            workflowRunId: stale.workflowRunId,
+            status: "lost",
+            recoveryState: "lost",
+            completedAt: 2_000,
+          }),
+          expect.objectContaining({
+            workflowRunId: fresh.workflowRunId,
+            status: "running",
+            recoveryState: "running",
+          }),
+        ]),
+      );
+      expect(store.getTimeline(stale.workflowRunId).at(-1)).toMatchObject({
+        eventType: "agent.turn.lost",
+        payload: expect.objectContaining({
+          reason: "stale_agent_turn_reconciliation",
+        }),
+      });
+    } finally {
+      store.close();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("queues retry-scheduled run and step only when retry timer is due", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-durable-recovery-"));
+    const store = openDurableWorkflowSqliteStore({
+      path: path.join(dir, "workflows.sqlite"),
+    });
+    try {
+      const run = store.createRun({
+        workflowId: "test.workflow",
+        idempotencyKey: "run-retry",
+        status: "retry_scheduled",
+        recoveryState: "retry_scheduled",
+        now: 100,
+      });
+      const step = store.createStep({
+        workflowRunId: run.workflowRunId,
+        stepId: "tool_step",
+        stepType: "tool",
+        status: "retry_scheduled",
+        recoveryState: "retry_scheduled",
+        now: 100,
+      });
+      store.createTimer({
+        workflowRunId: run.workflowRunId,
+        stepId: step.stepId,
+        timerType: "retry",
+        dueAt: 1_000,
+        now: 100,
+      });
+
+      expect(
+        reconcileDueDurableTimers({
+          store,
+          processInstanceId: "process-1",
+          now: 999,
+        }),
+      ).toEqual({ scanned: 0, markedLost: 0, firedTimers: 0, queuedRuns: 0 });
+      expect(store.getRun(run.workflowRunId)).toMatchObject({
+        status: "retry_scheduled",
+        recoveryState: "retry_scheduled",
+      });
+
+      expect(
+        reconcileDueDurableTimers({
+          store,
+          processInstanceId: "process-1",
+          now: 1_000,
+        }),
+      ).toEqual({ scanned: 1, markedLost: 0, firedTimers: 1, queuedRuns: 1 });
+      expect(store.getRun(run.workflowRunId)).toMatchObject({
+        status: "queued",
+        recoveryState: "runnable",
+      });
+      expect(store.listSteps(run.workflowRunId)).toMatchObject([
+        {
+          stepId: step.stepId,
+          status: "queued",
+          recoveryState: "runnable",
+        },
+      ]);
+      expect(store.getTimeline(run.workflowRunId).map((event) => event.eventType)).toEqual([
+        "workflow.timer.fired",
+        "workflow.retry_due",
+      ]);
+    } finally {
+      store.close();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("queues waiting signal step when a resume signal is consumed", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-durable-recovery-"));
+    const store = openDurableWorkflowSqliteStore({
+      path: path.join(dir, "workflows.sqlite"),
+    });
+    try {
+      const run = store.createRun({
+        workflowId: "test.workflow",
+        idempotencyKey: "run-signal",
+        status: "waiting_signal",
+        recoveryState: "waiting_signal",
+        now: 100,
+      });
+      const step = store.createStep({
+        workflowRunId: run.workflowRunId,
+        stepId: "approval",
+        stepType: "signal",
+        status: "waiting",
+        recoveryState: "waiting_signal",
+        now: 100,
+      });
+      store.createSignal({
+        workflowRunId: run.workflowRunId,
+        stepId: step.stepId,
+        signalType: "resume",
+        idempotencyKey: "resume-1",
+        now: 200,
+      });
+
+      expect(
+        reconcilePendingDurableSignals({
+          store,
+          processInstanceId: "process-1",
+          now: 300,
+        }),
+      ).toEqual({ scanned: 1, markedLost: 0, consumedSignals: 1, queuedRuns: 1 });
+      expect(store.getRun(run.workflowRunId)).toMatchObject({
+        status: "queued",
+        recoveryState: "runnable",
+      });
+      expect(store.listSteps(run.workflowRunId)).toMatchObject([
+        {
+          stepId: step.stepId,
+          status: "queued",
+          recoveryState: "runnable",
+        },
+      ]);
+      expect(store.listPendingSignals()).toEqual([]);
+    } finally {
+      store.close();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/durable/recovery.ts
+++ b/src/durable/recovery.ts
@@ -1,0 +1,480 @@
+import { createSubsystemLogger } from "../logging/subsystem.js";
+// Recovery reconciliation for durable workflow runs.
+import { isDurableWorkflowsEnabled } from "./config.js";
+import { openDurableWorkflowSqliteStore } from "./sqlite-store.js";
+import type { DurableWorkflowRun, DurableWorkflowStep, DurableWorkflowStore } from "./types.js";
+import { DURABLE_AGENT_TURN_WORKFLOW_ID } from "./workflow-ids.js";
+
+const log = createSubsystemLogger("durable/recovery");
+
+const DEFAULT_RECOVERY_INTERVAL_MS = 60_000;
+const DEFAULT_STALE_AGENT_TURN_AFTER_MS = 6 * 60 * 60 * 1000;
+
+export type DurableRecoveryResult = {
+  scanned: number;
+  markedLost: number;
+  firedTimers?: number;
+  consumedSignals?: number;
+  queuedRuns?: number;
+};
+
+function parsePositiveInteger(value: string | undefined): number | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const parsed = Number(trimmed);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+export function resolveDurableRecoveryIntervalMs(env: NodeJS.ProcessEnv = process.env): number {
+  return (
+    parsePositiveInteger(env.OPENCLAW_DURABLE_RECOVERY_INTERVAL_MS) ?? DEFAULT_RECOVERY_INTERVAL_MS
+  );
+}
+
+export function resolveDurableStaleAgentTurnAfterMs(env: NodeJS.ProcessEnv = process.env): number {
+  return (
+    parsePositiveInteger(env.OPENCLAW_DURABLE_STALE_AGENT_TURN_AFTER_MS) ??
+    DEFAULT_STALE_AGENT_TURN_AFTER_MS
+  );
+}
+
+function shouldMarkAgentTurnLost(run: DurableWorkflowRun): boolean {
+  if (run.workflowId !== DURABLE_AGENT_TURN_WORKFLOW_ID) {
+    return false;
+  }
+  return run.status === "received" || run.status === "running";
+}
+
+function correlationIdForRun(run: DurableWorkflowRun): string | undefined {
+  return run.metadata?.sessionKey ? String(run.metadata.sessionKey) : run.sourceRef;
+}
+
+function markAgentTurnLost(params: {
+  store: DurableWorkflowStore;
+  run: DurableWorkflowRun;
+  now: number;
+  reason: string;
+  processInstanceId: string;
+}): boolean {
+  if (!shouldMarkAgentTurnLost(params.run)) {
+    return false;
+  }
+  params.store.updateRun({
+    workflowRunId: params.run.workflowRunId,
+    status: "lost",
+    recoveryState: "lost",
+    completedAt: params.now,
+    now: params.now,
+  });
+  for (const step of params.store.listSteps(params.run.workflowRunId)) {
+    if (
+      step.status === "succeeded" ||
+      step.status === "failed" ||
+      step.status === "cancelled" ||
+      step.status === "lost" ||
+      step.status === "skipped"
+    ) {
+      continue;
+    }
+    params.store.updateStep({
+      workflowRunId: params.run.workflowRunId,
+      stepId: step.stepId,
+      status: "lost",
+      recoveryState: "lost",
+      completedAt: params.now,
+      now: params.now,
+    });
+  }
+  params.store.appendEvent({
+    workflowRunId: params.run.workflowRunId,
+    eventType: "agent.turn.lost",
+    eventTime: params.now,
+    stepId: "recovery",
+    agentInvocationId: params.run.idempotencyKey,
+    idempotencyKey: params.run.idempotencyKey,
+    correlationId: correlationIdForRun(params.run),
+    payload: {
+      reason: params.reason,
+      processInstanceId: params.processInstanceId,
+      previousStatus: params.run.status,
+      previousRecoveryState: params.run.recoveryState,
+    },
+  });
+  return true;
+}
+
+export function reconcileDurableAgentTurnsOnGatewayStartup(params: {
+  store: DurableWorkflowStore;
+  processInstanceId: string;
+  now: number;
+  limit?: number;
+}): DurableRecoveryResult {
+  const openRuns = params.store.listOpenRuns({
+    workflowId: DURABLE_AGENT_TURN_WORKFLOW_ID,
+    limit: params.limit ?? 5000,
+  });
+  let markedLost = 0;
+  for (const run of openRuns) {
+    if (
+      markAgentTurnLost({
+        store: params.store,
+        run,
+        now: params.now,
+        reason: "gateway_startup_reconciliation",
+        processInstanceId: params.processInstanceId,
+      })
+    ) {
+      markedLost += 1;
+    }
+  }
+  return { scanned: openRuns.length, markedLost };
+}
+
+export function reconcileStaleDurableAgentTurns(params: {
+  store: DurableWorkflowStore;
+  processInstanceId: string;
+  now: number;
+  staleAfterMs: number;
+  limit?: number;
+}): DurableRecoveryResult {
+  const cutoff = params.now - params.staleAfterMs;
+  const openRuns = params.store.listOpenRuns({
+    workflowId: DURABLE_AGENT_TURN_WORKFLOW_ID,
+    limit: params.limit ?? 5000,
+  });
+  let markedLost = 0;
+  for (const run of openRuns) {
+    if (run.updatedAt > cutoff) {
+      continue;
+    }
+    if (
+      markAgentTurnLost({
+        store: params.store,
+        run,
+        now: params.now,
+        reason: "stale_agent_turn_reconciliation",
+        processInstanceId: params.processInstanceId,
+      })
+    ) {
+      markedLost += 1;
+    }
+  }
+  return { scanned: openRuns.length, markedLost };
+}
+
+function isTerminalRun(run: DurableWorkflowRun): boolean {
+  return (
+    run.status === "succeeded" ||
+    run.status === "failed" ||
+    run.status === "cancelled" ||
+    run.status === "lost"
+  );
+}
+
+function isTerminalStep(step: DurableWorkflowStep): boolean {
+  return (
+    step.status === "succeeded" ||
+    step.status === "failed" ||
+    step.status === "cancelled" ||
+    step.status === "lost" ||
+    step.status === "skipped"
+  );
+}
+
+function markOpenStepsTerminal(params: {
+  store: DurableWorkflowStore;
+  workflowRunId: string;
+  status: "cancelled" | "lost";
+  now: number;
+}): void {
+  for (const step of params.store.listSteps(params.workflowRunId)) {
+    if (isTerminalStep(step)) {
+      continue;
+    }
+    params.store.updateStep({
+      workflowRunId: params.workflowRunId,
+      stepId: step.stepId,
+      status: params.status,
+      recoveryState: params.status === "lost" ? "lost" : "terminal",
+      claimedBy: null,
+      claimExpiresAt: null,
+      heartbeatAt: null,
+      completedAt: params.now,
+      now: params.now,
+    });
+  }
+}
+
+function queueStepForRecovery(params: {
+  store: DurableWorkflowStore;
+  workflowRunId: string;
+  stepId?: string;
+  recoveryState?: "waiting_signal" | "waiting_timer" | "retry_scheduled";
+  now: number;
+}): number {
+  let queued = 0;
+  for (const step of params.store.listSteps(params.workflowRunId)) {
+    if (isTerminalStep(step)) {
+      continue;
+    }
+    if (params.stepId && step.stepId !== params.stepId) {
+      continue;
+    }
+    if (!params.stepId && params.recoveryState && step.recoveryState !== params.recoveryState) {
+      continue;
+    }
+    params.store.updateStep({
+      workflowRunId: params.workflowRunId,
+      stepId: step.stepId,
+      status: "queued",
+      recoveryState: "runnable",
+      claimedBy: null,
+      claimExpiresAt: null,
+      heartbeatAt: null,
+      now: params.now,
+    });
+    queued += 1;
+  }
+  return queued;
+}
+
+export function reconcileDueDurableTimers(params: {
+  store: DurableWorkflowStore;
+  processInstanceId: string;
+  now: number;
+  limit?: number;
+}): DurableRecoveryResult {
+  const timers = params.store.listDueTimers(params.now, { limit: params.limit ?? 500 });
+  let firedTimers = 0;
+  let queuedRuns = 0;
+  for (const timer of timers) {
+    const run = params.store.getRun(timer.workflowRunId);
+    params.store.updateTimer({ timerId: timer.timerId, status: "fired", now: params.now });
+    firedTimers += 1;
+    params.store.appendEvent({
+      workflowRunId: timer.workflowRunId,
+      eventType: "workflow.timer.fired",
+      eventTime: params.now,
+      stepId: timer.stepId,
+      payload: {
+        timerId: timer.timerId,
+        timerType: timer.timerType,
+        processInstanceId: params.processInstanceId,
+      },
+    });
+    if (!run || isTerminalRun(run)) {
+      continue;
+    }
+    if (timer.timerType === "retry") {
+      queueStepForRecovery({
+        store: params.store,
+        workflowRunId: timer.workflowRunId,
+        stepId: timer.stepId,
+        recoveryState: "retry_scheduled",
+        now: params.now,
+      });
+      params.store.updateRun({
+        workflowRunId: timer.workflowRunId,
+        status: "queued",
+        recoveryState: "runnable",
+        now: params.now,
+      });
+      queuedRuns += 1;
+      params.store.appendEvent({
+        workflowRunId: timer.workflowRunId,
+        eventType: "workflow.retry_due",
+        eventTime: params.now,
+        stepId: timer.stepId,
+        payload: {
+          timerId: timer.timerId,
+          processInstanceId: params.processInstanceId,
+        },
+      });
+      continue;
+    }
+    if (run.status === "waiting_timer" || run.recoveryState === "waiting_timer") {
+      queueStepForRecovery({
+        store: params.store,
+        workflowRunId: timer.workflowRunId,
+        stepId: timer.stepId,
+        recoveryState: "waiting_timer",
+        now: params.now,
+      });
+      params.store.updateRun({
+        workflowRunId: timer.workflowRunId,
+        status: "queued",
+        recoveryState: "runnable",
+        now: params.now,
+      });
+      queuedRuns += 1;
+      params.store.appendEvent({
+        workflowRunId: timer.workflowRunId,
+        eventType: "workflow.timer.resume_queued",
+        eventTime: params.now,
+        stepId: timer.stepId,
+        payload: {
+          timerId: timer.timerId,
+          timerType: timer.timerType,
+          processInstanceId: params.processInstanceId,
+        },
+      });
+    }
+  }
+  return { scanned: timers.length, markedLost: 0, firedTimers, queuedRuns };
+}
+
+export function reconcilePendingDurableSignals(params: {
+  store: DurableWorkflowStore;
+  processInstanceId: string;
+  now: number;
+  limit?: number;
+}): DurableRecoveryResult {
+  const signals = params.store.listPendingSignals({ limit: params.limit ?? 5000 });
+  let consumedSignals = 0;
+  let queuedRuns = 0;
+  for (const signal of signals) {
+    const run = params.store.getRun(signal.workflowRunId);
+    if (!run || isTerminalRun(run)) {
+      params.store.consumeSignal({ signalId: signal.signalId, now: params.now });
+      consumedSignals += 1;
+      continue;
+    }
+    if (signal.signalType === "cancel") {
+      params.store.consumeSignal({ signalId: signal.signalId, now: params.now });
+      markOpenStepsTerminal({
+        store: params.store,
+        workflowRunId: run.workflowRunId,
+        status: "cancelled",
+        now: params.now,
+      });
+      params.store.updateRun({
+        workflowRunId: run.workflowRunId,
+        status: "cancelled",
+        recoveryState: "terminal",
+        completedAt: params.now,
+        now: params.now,
+      });
+      params.store.appendEvent({
+        workflowRunId: run.workflowRunId,
+        eventType: "workflow.signal.cancelled",
+        eventTime: params.now,
+        correlationId: signal.correlationId,
+        payload: {
+          signalId: signal.signalId,
+          processInstanceId: params.processInstanceId,
+        },
+      });
+      consumedSignals += 1;
+      continue;
+    }
+    if (
+      signal.signalType === "resume" ||
+      run.recoveryState === "waiting_signal" ||
+      run.status === "waiting_signal"
+    ) {
+      params.store.consumeSignal({ signalId: signal.signalId, now: params.now });
+      queueStepForRecovery({
+        store: params.store,
+        workflowRunId: run.workflowRunId,
+        stepId: signal.stepId,
+        recoveryState: "waiting_signal",
+        now: params.now,
+      });
+      params.store.updateRun({
+        workflowRunId: run.workflowRunId,
+        status: "queued",
+        recoveryState: "runnable",
+        now: params.now,
+      });
+      params.store.appendEvent({
+        workflowRunId: run.workflowRunId,
+        eventType: "workflow.signal.resume_queued",
+        eventTime: params.now,
+        correlationId: signal.correlationId,
+        payload: {
+          signalId: signal.signalId,
+          signalType: signal.signalType,
+          processInstanceId: params.processInstanceId,
+        },
+      });
+      consumedSignals += 1;
+      queuedRuns += 1;
+    }
+  }
+  return { scanned: signals.length, markedLost: 0, consumedSignals, queuedRuns };
+}
+
+export function startDurableRecoveryWorker(params: {
+  processInstanceId: string;
+  env?: NodeJS.ProcessEnv;
+}): () => void {
+  const env = params.env ?? process.env;
+  if (!isDurableWorkflowsEnabled(env)) {
+    return () => {};
+  }
+  const intervalMs = resolveDurableRecoveryIntervalMs(env);
+  const staleAfterMs = resolveDurableStaleAgentTurnAfterMs(env);
+  let running = false;
+  let stopped = false;
+
+  const reconcileOnce = () => {
+    if (running || stopped) {
+      return;
+    }
+    running = true;
+    let store: DurableWorkflowStore | null = null;
+    try {
+      store = openDurableWorkflowSqliteStore({ env });
+      const result = reconcileStaleDurableAgentTurns({
+        store,
+        processInstanceId: params.processInstanceId,
+        now: Date.now(),
+        staleAfterMs,
+      });
+      const timerResult = reconcileDueDurableTimers({
+        store,
+        processInstanceId: params.processInstanceId,
+        now: Date.now(),
+      });
+      const signalResult = reconcilePendingDurableSignals({
+        store,
+        processInstanceId: params.processInstanceId,
+        now: Date.now(),
+      });
+      if (
+        result.markedLost > 0 ||
+        (timerResult.firedTimers ?? 0) > 0 ||
+        (signalResult.consumedSignals ?? 0) > 0
+      ) {
+        log.warn("reconciled durable workflow state", {
+          staleScanned: result.scanned,
+          markedLost: result.markedLost,
+          firedTimers: timerResult.firedTimers ?? 0,
+          consumedSignals: signalResult.consumedSignals ?? 0,
+          queuedRuns: (timerResult.queuedRuns ?? 0) + (signalResult.queuedRuns ?? 0),
+          staleAfterMs,
+        });
+      }
+    } catch (err) {
+      log.warn(`durable recovery worker failed: ${String(err)}`);
+    } finally {
+      store?.close();
+      running = false;
+    }
+  };
+
+  const timer = setInterval(reconcileOnce, intervalMs);
+  timer.unref?.();
+  log.info("started durable recovery worker", {
+    intervalMs,
+    staleAfterMs,
+    processInstanceId: params.processInstanceId,
+  });
+
+  return () => {
+    stopped = true;
+    clearInterval(timer);
+  };
+}

--- a/src/durable/registry.ts
+++ b/src/durable/registry.ts
@@ -1,0 +1,103 @@
+import type {
+  DurableWorkflowRun,
+  DurableWorkflowStep,
+  DurableWorkflowStepType,
+  DurableWorkflowStore,
+  DurableWorkflowTimer,
+} from "./types.js";
+
+export type DurableWorkflowDefinition = {
+  workflowId: string;
+  version: string;
+  description?: string;
+  stepTypes?: DurableWorkflowStepType[];
+  metadata?: Record<string, unknown>;
+};
+
+export type DurableWorkflowStepHandlerContext = {
+  store: DurableWorkflowStore;
+  run: DurableWorkflowRun;
+  step: DurableWorkflowStep;
+  workerId: string;
+  now(): number;
+  heartbeat(payload?: Record<string, unknown>): void;
+};
+
+export type DurableWorkflowStepHandlerResult =
+  | {
+      kind: "succeeded";
+      output?: Record<string, unknown>;
+      outputRef?: string;
+      checkpointRef?: string;
+      completeRun?: boolean;
+    }
+  | {
+      kind: "failed";
+      error?: Record<string, unknown>;
+      retryAfterMs?: number;
+      checkpointRef?: string;
+      completeRun?: boolean;
+    }
+  | {
+      kind: "waiting_signal";
+      reason?: string;
+      checkpointRef?: string;
+    }
+  | {
+      kind: "waiting_timer";
+      dueAt: number;
+      timerType?: DurableWorkflowTimer["timerType"];
+      reason?: string;
+      checkpointRef?: string;
+    }
+  | {
+      kind: "unknown_after_side_effect";
+      reason?: string;
+      checkpointRef?: string;
+    };
+
+export type DurableWorkflowStepHandler = (
+  context: DurableWorkflowStepHandlerContext,
+) => DurableWorkflowStepHandlerResult | Promise<DurableWorkflowStepHandlerResult>;
+
+export type DurableWorkflowRegistry = {
+  registerWorkflow(definition: DurableWorkflowDefinition): void;
+  getWorkflow(workflowId: string, version?: string): DurableWorkflowDefinition | undefined;
+  listWorkflows(): DurableWorkflowDefinition[];
+  registerStepHandler(stepType: DurableWorkflowStepType, handler: DurableWorkflowStepHandler): void;
+  getStepHandler(stepType: DurableWorkflowStepType): DurableWorkflowStepHandler | undefined;
+};
+
+function workflowKey(workflowId: string, version: string): string {
+  return `${workflowId}@${version}`;
+}
+
+export function createDurableWorkflowRegistry(): DurableWorkflowRegistry {
+  const workflows = new Map<string, DurableWorkflowDefinition>();
+  const handlers = new Map<DurableWorkflowStepType, DurableWorkflowStepHandler>();
+
+  return {
+    registerWorkflow(definition: DurableWorkflowDefinition): void {
+      workflows.set(workflowKey(definition.workflowId, definition.version), { ...definition });
+    },
+
+    getWorkflow(workflowId: string, version = "1"): DurableWorkflowDefinition | undefined {
+      return workflows.get(workflowKey(workflowId, version));
+    },
+
+    listWorkflows(): DurableWorkflowDefinition[] {
+      return [...workflows.values()].map((definition) => ({ ...definition }));
+    },
+
+    registerStepHandler(
+      stepType: DurableWorkflowStepType,
+      handler: DurableWorkflowStepHandler,
+    ): void {
+      handlers.set(stepType, handler);
+    },
+
+    getStepHandler(stepType: DurableWorkflowStepType): DurableWorkflowStepHandler | undefined {
+      return handlers.get(stepType);
+    },
+  };
+}

--- a/src/durable/sqlite-store.test.ts
+++ b/src/durable/sqlite-store.test.ts
@@ -1,0 +1,306 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { openDurableWorkflowSqliteStore } from "./sqlite-store.js";
+
+describe("durable workflow sqlite store", () => {
+  it("creates runs, dedupes idempotency keys, and appends ordered events", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-durable-store-"));
+    const store = openDurableWorkflowSqliteStore({
+      path: path.join(dir, "workflows.sqlite"),
+    });
+    try {
+      const first = store.createRun({
+        workflowId: "test.workflow",
+        idempotencyKey: "request-1",
+        requestHash: "hash-1",
+        metadata: { surface: "test" },
+        now: 100,
+      });
+      const duplicate = store.createRun({
+        workflowId: "test.workflow",
+        idempotencyKey: "request-1",
+        requestHash: "hash-1",
+        now: 200,
+      });
+      expect(duplicate.workflowRunId).toBe(first.workflowRunId);
+
+      const started = store.appendEvent({
+        workflowRunId: first.workflowRunId,
+        eventType: "workflow.started",
+        payload: { ok: true },
+      });
+      const completed = store.appendEvent({
+        workflowRunId: first.workflowRunId,
+        eventType: "workflow.completed",
+      });
+      expect(store.listOpenRuns({ workflowId: "test.workflow" })).toMatchObject([
+        {
+          workflowRunId: first.workflowRunId,
+          workflowId: "test.workflow",
+          status: "received",
+        },
+      ]);
+      const terminal = store.updateRun({
+        workflowRunId: first.workflowRunId,
+        status: "succeeded",
+        recoveryState: "terminal",
+        completedAt: 300,
+        now: 300,
+      });
+
+      expect(started.eventSeq).toBe(1);
+      expect(completed.eventSeq).toBe(2);
+      expect(terminal).toMatchObject({
+        workflowRunId: first.workflowRunId,
+        status: "succeeded",
+        recoveryState: "terminal",
+        completedAt: 300,
+      });
+      expect(store.getTimeline(first.workflowRunId).map((event) => event.eventType)).toEqual([
+        "workflow.started",
+        "workflow.completed",
+      ]);
+      expect(store.listOpenRuns({ workflowId: "test.workflow" })).toEqual([]);
+      expect(store.getStats()).toMatchObject({ runs: 1, events: 2, steps: 0, openRuns: 0 });
+    } finally {
+      store.close();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("stores core workflow primitives for steps, refs, links, timers, signals, and claims", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-durable-store-"));
+    const store = openDurableWorkflowSqliteStore({
+      path: path.join(dir, "workflows.sqlite"),
+    });
+    try {
+      const parent = store.createRun({
+        workflowId: "test.workflow",
+        status: "queued",
+        recoveryState: "runnable",
+        idempotencyKey: "parent",
+        now: 100,
+      });
+      const child = store.createRun({
+        workflowId: "test.workflow",
+        status: "queued",
+        recoveryState: "runnable",
+        idempotencyKey: "child",
+        parentWorkflowRunId: parent.workflowRunId,
+        now: 110,
+      });
+      const claimed = store.claimNextRunnableRun({
+        workflowId: "test.workflow",
+        workerId: "worker-1",
+        claimTtlMs: 1_000,
+        now: 120,
+      });
+      expect(claimed).toMatchObject({
+        workflowRunId: parent.workflowRunId,
+        claimedBy: "worker-1",
+        recoveryState: "claimed",
+        claimExpiresAt: 1_120,
+      });
+      const released = store.releaseRunClaim({
+        workflowRunId: parent.workflowRunId,
+        workerId: "worker-1",
+        now: 130,
+      });
+      expect(released).toMatchObject({
+        workflowRunId: parent.workflowRunId,
+        recoveryState: "runnable",
+      });
+
+      const inputRef = store.createRef({
+        workflowRunId: parent.workflowRunId,
+        refKind: "input",
+        mediaType: "application/json",
+        hash: "input-hash",
+        storageKind: "inline",
+        storageUri: "inline:test",
+        now: 140,
+      });
+      expect(store.getRef(inputRef.refId)).toMatchObject({
+        refKind: "input",
+        storageKind: "inline",
+        hash: "input-hash",
+      });
+
+      const step = store.createStep({
+        workflowRunId: parent.workflowRunId,
+        stepType: "fan_in",
+        status: "waiting",
+        recoveryState: "waiting_child",
+        inputRef: inputRef.refId,
+        idempotencyKey: "fan-in-1",
+        metadata: { policy: "all_terminal" },
+        now: 150,
+      });
+      const duplicateStep = store.createStep({
+        workflowRunId: parent.workflowRunId,
+        stepType: "fan_in",
+        idempotencyKey: "fan-in-1",
+        now: 160,
+      });
+      expect(duplicateStep.stepId).toBe(step.stepId);
+
+      const updatedStep = store.updateStep({
+        workflowRunId: parent.workflowRunId,
+        stepId: step.stepId,
+        status: "succeeded",
+        recoveryState: "terminal",
+        outputRef: "output-ref",
+        completedAt: 170,
+        now: 170,
+      });
+      expect(updatedStep).toMatchObject({
+        stepId: step.stepId,
+        status: "succeeded",
+        outputRef: "output-ref",
+        completedAt: 170,
+      });
+      expect(store.listSteps(parent.workflowRunId)).toHaveLength(1);
+
+      const executableStep = store.createStep({
+        workflowRunId: parent.workflowRunId,
+        stepType: "tool",
+        status: "queued",
+        recoveryState: "runnable",
+        idempotencyKey: "tool-1",
+        now: 175,
+      });
+      const claimedStep = store.claimNextRunnableStep({
+        workflowId: "test.workflow",
+        stepType: "tool",
+        workerId: "worker-1",
+        claimTtlMs: 1_000,
+        now: 176,
+      });
+      expect(claimedStep).toMatchObject({
+        workflowRunId: parent.workflowRunId,
+        stepId: executableStep.stepId,
+        status: "queued",
+        recoveryState: "claimed",
+        claimedBy: "worker-1",
+        claimExpiresAt: 1_176,
+      });
+      expect(
+        store.releaseStepClaim({
+          workflowRunId: parent.workflowRunId,
+          stepId: executableStep.stepId,
+          workerId: "worker-1",
+          now: 177,
+        }),
+      ).toMatchObject({
+        stepId: executableStep.stepId,
+        recoveryState: "runnable",
+      });
+
+      const link = store.createLink({
+        parentWorkflowRunId: parent.workflowRunId,
+        parentStepId: step.stepId,
+        childWorkflowRunId: child.workflowRunId,
+        linkType: "child_workflow",
+        status: "running",
+        now: 180,
+      });
+      expect(link.status).toBe("running");
+      expect(
+        store.updateLink({
+          parentWorkflowRunId: parent.workflowRunId,
+          parentStepId: step.stepId,
+          childWorkflowRunId: child.workflowRunId,
+          status: "succeeded",
+          now: 190,
+        }),
+      ).toMatchObject({ status: "succeeded" });
+      expect(store.listChildLinks(parent.workflowRunId)).toHaveLength(1);
+
+      const timer = store.createTimer({
+        workflowRunId: parent.workflowRunId,
+        stepId: step.stepId,
+        timerType: "retry",
+        dueAt: 200,
+        now: 195,
+      });
+      expect(store.listDueTimers(199)).toEqual([]);
+      expect(store.listDueTimers(200)).toMatchObject([{ timerId: timer.timerId }]);
+      expect(
+        store.updateTimer({ timerId: timer.timerId, status: "fired", now: 201 }),
+      ).toMatchObject({
+        status: "fired",
+        firedAt: 201,
+      });
+
+      const signal = store.createSignal({
+        workflowRunId: parent.workflowRunId,
+        stepId: step.stepId,
+        signalType: "human_input",
+        idempotencyKey: "signal-1",
+        payloadRef: inputRef.refId,
+        now: 210,
+      });
+      const duplicateSignal = store.createSignal({
+        workflowRunId: parent.workflowRunId,
+        signalType: "human_input",
+        idempotencyKey: "signal-1",
+        now: 211,
+      });
+      expect(duplicateSignal.signalId).toBe(signal.signalId);
+      expect(store.consumeSignal({ signalId: signal.signalId, now: 220 })).toMatchObject({
+        signalId: signal.signalId,
+        consumedAt: 220,
+      });
+      expect(store.listSignals(parent.workflowRunId)).toHaveLength(1);
+      expect(store.listPendingSignals()).toEqual([]);
+      expect(store.getStats()).toMatchObject({ runs: 2, steps: 2 });
+    } finally {
+      store.close();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not claim retry-scheduled runs or steps before recovery queues them", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-durable-store-"));
+    const store = openDurableWorkflowSqliteStore({
+      path: path.join(dir, "workflows.sqlite"),
+    });
+    try {
+      const run = store.createRun({
+        workflowId: "test.workflow",
+        status: "retry_scheduled",
+        recoveryState: "retry_scheduled",
+        now: 100,
+      });
+      store.createStep({
+        workflowRunId: run.workflowRunId,
+        stepType: "tool",
+        status: "retry_scheduled",
+        recoveryState: "retry_scheduled",
+        now: 110,
+      });
+
+      expect(
+        store.claimNextRunnableRun({
+          workflowId: "test.workflow",
+          workerId: "worker-1",
+          claimTtlMs: 1_000,
+          now: 120,
+        }),
+      ).toBeUndefined();
+      expect(
+        store.claimNextRunnableStep({
+          workflowId: "test.workflow",
+          workerId: "worker-1",
+          claimTtlMs: 1_000,
+          now: 120,
+        }),
+      ).toBeUndefined();
+    } finally {
+      store.close();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/durable/sqlite-store.ts
+++ b/src/durable/sqlite-store.ts
@@ -1,0 +1,1406 @@
+// SQLite-backed durable workflow store for the native control-plane prototype.
+import { randomUUID } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import type { DatabaseSync, SQLInputValue } from "node:sqlite";
+import { requireNodeSqlite } from "../infra/node-sqlite.js";
+import { runSqliteImmediateTransactionSync } from "../infra/sqlite-transaction.js";
+import { configureSqliteConnectionPragmas } from "../infra/sqlite-wal.js";
+import { resolveDurableWorkflowSqlitePath } from "./config.js";
+import type {
+  AppendDurableWorkflowEventInput,
+  ClaimDurableWorkflowRunInput,
+  ClaimDurableWorkflowStepInput,
+  CreateDurableWorkflowLinkInput,
+  CreateDurableWorkflowRefInput,
+  CreateDurableWorkflowRunInput,
+  CreateDurableWorkflowSignalInput,
+  CreateDurableWorkflowStepInput,
+  CreateDurableWorkflowTimerInput,
+  DurableWorkflowLink,
+  DurableWorkflowLinkStatus,
+  DurableWorkflowLinkType,
+  DurableRecoveryState,
+  DurableWorkflowEvent,
+  DurableWorkflowRef,
+  DurableWorkflowRefKind,
+  DurableWorkflowRun,
+  DurableWorkflowRunStatus,
+  DurableWorkflowSignal,
+  DurableWorkflowStep,
+  DurableWorkflowStepStatus,
+  DurableWorkflowStepType,
+  DurableWorkflowStore,
+  DurableWorkflowStoreStats,
+  DurableWorkflowTimer,
+  DurableWorkflowTimerStatus,
+  UpdateDurableWorkflowRunInput,
+  UpdateDurableWorkflowLinkInput,
+  UpdateDurableWorkflowStepInput,
+  UpdateDurableWorkflowTimerInput,
+} from "./types.js";
+
+type DurableWorkflowRunRow = {
+  workflow_run_id: string;
+  workflow_id: string;
+  workflow_version: string;
+  idempotency_key: string | null;
+  request_hash: string | null;
+  status: DurableWorkflowRunStatus;
+  source_type: string | null;
+  source_ref: string | null;
+  input_ref: string | null;
+  created_at: number;
+  updated_at: number;
+  completed_at: number | null;
+  recovery_state: DurableRecoveryState;
+  checkpoint_ref: string | null;
+  parent_workflow_run_id: string | null;
+  parent_step_id: string | null;
+  message_id: string | null;
+  turn_id: string | null;
+  claimed_by: string | null;
+  claim_expires_at: number | null;
+  heartbeat_at: number | null;
+  metadata_json: string | null;
+};
+
+type DurableWorkflowEventRow = {
+  event_id: string;
+  workflow_run_id: string;
+  event_seq: number;
+  event_type: string;
+  event_time: number;
+  step_id: string | null;
+  agent_invocation_id: string | null;
+  tool_invocation_id: string | null;
+  idempotency_key: string | null;
+  payload_json: string | null;
+  payload_hash: string | null;
+  checkpoint_ref: string | null;
+  causation_event_id: string | null;
+  correlation_id: string | null;
+  recorded_at: number;
+};
+
+type DurableWorkflowStepRow = {
+  workflow_run_id: string;
+  step_id: string;
+  parent_step_id: string | null;
+  step_type: DurableWorkflowStepType;
+  status: DurableWorkflowStepStatus;
+  recovery_state: DurableRecoveryState;
+  attempt: number;
+  max_attempts: number | null;
+  idempotency_key: string | null;
+  input_ref: string | null;
+  output_ref: string | null;
+  error_ref: string | null;
+  checkpoint_ref: string | null;
+  claimed_by: string | null;
+  claim_expires_at: number | null;
+  heartbeat_at: number | null;
+  created_at: number;
+  started_at: number | null;
+  updated_at: number;
+  completed_at: number | null;
+  metadata_json: string | null;
+};
+
+type DurableWorkflowRefRow = {
+  ref_id: string;
+  workflow_run_id: string;
+  step_id: string | null;
+  ref_kind: DurableWorkflowRefKind;
+  media_type: string | null;
+  hash: string | null;
+  storage_kind: "inline" | "file" | "external";
+  storage_uri: string | null;
+  created_at: number;
+  metadata_json: string | null;
+};
+
+type DurableWorkflowLinkRow = {
+  parent_workflow_run_id: string;
+  parent_step_id: string;
+  child_workflow_run_id: string;
+  link_type: DurableWorkflowLinkType;
+  status: DurableWorkflowLinkStatus;
+  created_at: number;
+  updated_at: number;
+  metadata_json: string | null;
+};
+
+type DurableWorkflowTimerRow = {
+  timer_id: string;
+  workflow_run_id: string;
+  step_id: string | null;
+  timer_type: DurableWorkflowTimer["timerType"];
+  due_at: number;
+  status: DurableWorkflowTimerStatus;
+  created_at: number;
+  fired_at: number | null;
+  cancelled_at: number | null;
+  metadata_json: string | null;
+};
+
+type DurableWorkflowSignalRow = {
+  signal_id: string;
+  workflow_run_id: string;
+  step_id: string | null;
+  signal_type: DurableWorkflowSignal["signalType"];
+  idempotency_key: string | null;
+  payload_ref: string | null;
+  correlation_id: string | null;
+  received_at: number;
+  consumed_at: number | null;
+  metadata_json: string | null;
+};
+
+type CountRow = { count: number | bigint };
+
+const DURABLE_WORKFLOW_SQLITE_BUSY_TIMEOUT_MS = 30_000;
+
+function optionalText(value: string | undefined): string | null {
+  return value && value.trim() ? value : null;
+}
+
+function serializeJson(value: Record<string, unknown> | undefined): string | null {
+  return value === undefined ? null : JSON.stringify(value);
+}
+
+function parseJsonRecord(value: string | null): Record<string, unknown> | undefined {
+  if (!value) {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function rowToRun(row: DurableWorkflowRunRow): DurableWorkflowRun {
+  return {
+    workflowRunId: row.workflow_run_id,
+    workflowId: row.workflow_id,
+    workflowVersion: row.workflow_version,
+    status: row.status,
+    recoveryState: row.recovery_state,
+    ...(row.idempotency_key ? { idempotencyKey: row.idempotency_key } : {}),
+    ...(row.request_hash ? { requestHash: row.request_hash } : {}),
+    ...(row.source_type ? { sourceType: row.source_type } : {}),
+    ...(row.source_ref ? { sourceRef: row.source_ref } : {}),
+    ...(row.input_ref ? { inputRef: row.input_ref } : {}),
+    ...(row.checkpoint_ref ? { checkpointRef: row.checkpoint_ref } : {}),
+    ...(row.parent_workflow_run_id ? { parentWorkflowRunId: row.parent_workflow_run_id } : {}),
+    ...(row.parent_step_id ? { parentStepId: row.parent_step_id } : {}),
+    ...(row.message_id ? { messageId: row.message_id } : {}),
+    ...(row.turn_id ? { turnId: row.turn_id } : {}),
+    ...(row.claimed_by ? { claimedBy: row.claimed_by } : {}),
+    ...(row.claim_expires_at == null ? {} : { claimExpiresAt: Number(row.claim_expires_at) }),
+    ...(row.heartbeat_at == null ? {} : { heartbeatAt: Number(row.heartbeat_at) }),
+    ...(row.metadata_json ? { metadata: parseJsonRecord(row.metadata_json) } : {}),
+    createdAt: Number(row.created_at),
+    updatedAt: Number(row.updated_at),
+    ...(row.completed_at == null ? {} : { completedAt: Number(row.completed_at) }),
+  };
+}
+
+function rowToEvent(row: DurableWorkflowEventRow): DurableWorkflowEvent {
+  return {
+    eventId: row.event_id,
+    workflowRunId: row.workflow_run_id,
+    eventSeq: Number(row.event_seq),
+    eventType: row.event_type,
+    eventTime: Number(row.event_time),
+    ...(row.step_id ? { stepId: row.step_id } : {}),
+    ...(row.agent_invocation_id ? { agentInvocationId: row.agent_invocation_id } : {}),
+    ...(row.tool_invocation_id ? { toolInvocationId: row.tool_invocation_id } : {}),
+    ...(row.idempotency_key ? { idempotencyKey: row.idempotency_key } : {}),
+    ...(row.payload_json ? { payload: parseJsonRecord(row.payload_json) } : {}),
+    ...(row.payload_hash ? { payloadHash: row.payload_hash } : {}),
+    ...(row.checkpoint_ref ? { checkpointRef: row.checkpoint_ref } : {}),
+    ...(row.causation_event_id ? { causationEventId: row.causation_event_id } : {}),
+    ...(row.correlation_id ? { correlationId: row.correlation_id } : {}),
+    recordedAt: Number(row.recorded_at),
+  };
+}
+
+function rowToStep(row: DurableWorkflowStepRow): DurableWorkflowStep {
+  return {
+    workflowRunId: row.workflow_run_id,
+    stepId: row.step_id,
+    ...(row.parent_step_id ? { parentStepId: row.parent_step_id } : {}),
+    stepType: row.step_type,
+    status: row.status,
+    recoveryState: row.recovery_state,
+    attempt: Number(row.attempt),
+    ...(row.max_attempts == null ? {} : { maxAttempts: Number(row.max_attempts) }),
+    ...(row.idempotency_key ? { idempotencyKey: row.idempotency_key } : {}),
+    ...(row.input_ref ? { inputRef: row.input_ref } : {}),
+    ...(row.output_ref ? { outputRef: row.output_ref } : {}),
+    ...(row.error_ref ? { errorRef: row.error_ref } : {}),
+    ...(row.checkpoint_ref ? { checkpointRef: row.checkpoint_ref } : {}),
+    ...(row.claimed_by ? { claimedBy: row.claimed_by } : {}),
+    ...(row.claim_expires_at == null ? {} : { claimExpiresAt: Number(row.claim_expires_at) }),
+    ...(row.heartbeat_at == null ? {} : { heartbeatAt: Number(row.heartbeat_at) }),
+    ...(row.metadata_json ? { metadata: parseJsonRecord(row.metadata_json) } : {}),
+    createdAt: Number(row.created_at),
+    ...(row.started_at == null ? {} : { startedAt: Number(row.started_at) }),
+    updatedAt: Number(row.updated_at),
+    ...(row.completed_at == null ? {} : { completedAt: Number(row.completed_at) }),
+  };
+}
+
+function rowToRef(row: DurableWorkflowRefRow): DurableWorkflowRef {
+  return {
+    refId: row.ref_id,
+    workflowRunId: row.workflow_run_id,
+    ...(row.step_id ? { stepId: row.step_id } : {}),
+    refKind: row.ref_kind,
+    ...(row.media_type ? { mediaType: row.media_type } : {}),
+    ...(row.hash ? { hash: row.hash } : {}),
+    storageKind: row.storage_kind,
+    ...(row.storage_uri ? { storageUri: row.storage_uri } : {}),
+    ...(row.metadata_json ? { metadata: parseJsonRecord(row.metadata_json) } : {}),
+    createdAt: Number(row.created_at),
+  };
+}
+
+function rowToLink(row: DurableWorkflowLinkRow): DurableWorkflowLink {
+  return {
+    parentWorkflowRunId: row.parent_workflow_run_id,
+    parentStepId: row.parent_step_id,
+    childWorkflowRunId: row.child_workflow_run_id,
+    linkType: row.link_type,
+    status: row.status,
+    ...(row.metadata_json ? { metadata: parseJsonRecord(row.metadata_json) } : {}),
+    createdAt: Number(row.created_at),
+    updatedAt: Number(row.updated_at),
+  };
+}
+
+function rowToTimer(row: DurableWorkflowTimerRow): DurableWorkflowTimer {
+  return {
+    timerId: row.timer_id,
+    workflowRunId: row.workflow_run_id,
+    ...(row.step_id ? { stepId: row.step_id } : {}),
+    timerType: row.timer_type,
+    dueAt: Number(row.due_at),
+    status: row.status,
+    ...(row.metadata_json ? { metadata: parseJsonRecord(row.metadata_json) } : {}),
+    createdAt: Number(row.created_at),
+    ...(row.fired_at == null ? {} : { firedAt: Number(row.fired_at) }),
+    ...(row.cancelled_at == null ? {} : { cancelledAt: Number(row.cancelled_at) }),
+  };
+}
+
+function rowToSignal(row: DurableWorkflowSignalRow): DurableWorkflowSignal {
+  return {
+    signalId: row.signal_id,
+    workflowRunId: row.workflow_run_id,
+    ...(row.step_id ? { stepId: row.step_id } : {}),
+    signalType: row.signal_type,
+    ...(row.idempotency_key ? { idempotencyKey: row.idempotency_key } : {}),
+    ...(row.payload_ref ? { payloadRef: row.payload_ref } : {}),
+    ...(row.correlation_id ? { correlationId: row.correlation_id } : {}),
+    ...(row.metadata_json ? { metadata: parseJsonRecord(row.metadata_json) } : {}),
+    receivedAt: Number(row.received_at),
+    ...(row.consumed_at == null ? {} : { consumedAt: Number(row.consumed_at) }),
+  };
+}
+
+function ensureColumn(db: DatabaseSync, tableName: string, columnDefinition: string): void {
+  try {
+    db.exec(`ALTER TABLE ${tableName} ADD COLUMN ${columnDefinition}`);
+  } catch (err) {
+    if (!String(err).includes("duplicate column name")) {
+      throw err;
+    }
+  }
+}
+
+function ensureDurableWorkflowSchema(db: DatabaseSync): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS durable_workflow_runs (
+      workflow_run_id TEXT NOT NULL PRIMARY KEY,
+      workflow_id TEXT NOT NULL,
+      workflow_version TEXT NOT NULL DEFAULT '1',
+      idempotency_key TEXT,
+      request_hash TEXT,
+      status TEXT NOT NULL,
+      source_type TEXT,
+      source_ref TEXT,
+      input_ref TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      completed_at INTEGER,
+      recovery_state TEXT NOT NULL DEFAULT 'runnable',
+      checkpoint_ref TEXT,
+      parent_workflow_run_id TEXT,
+      parent_step_id TEXT,
+      message_id TEXT,
+      turn_id TEXT,
+      claimed_by TEXT,
+      claim_expires_at INTEGER,
+      heartbeat_at INTEGER,
+      metadata_json TEXT
+    );
+
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_durable_workflow_runs_idempotency
+      ON durable_workflow_runs(workflow_id, idempotency_key)
+      WHERE idempotency_key IS NOT NULL;
+
+    CREATE INDEX IF NOT EXISTS idx_durable_workflow_runs_status
+      ON durable_workflow_runs(status, updated_at, workflow_run_id);
+
+    CREATE TABLE IF NOT EXISTS durable_workflow_events (
+      event_id TEXT NOT NULL UNIQUE,
+      workflow_run_id TEXT NOT NULL,
+      event_seq INTEGER NOT NULL,
+      event_type TEXT NOT NULL,
+      event_time INTEGER NOT NULL,
+      step_id TEXT,
+      agent_invocation_id TEXT,
+      tool_invocation_id TEXT,
+      idempotency_key TEXT,
+      payload_json TEXT,
+      payload_hash TEXT,
+      checkpoint_ref TEXT,
+      causation_event_id TEXT,
+      correlation_id TEXT,
+      recorded_at INTEGER NOT NULL,
+      PRIMARY KEY (workflow_run_id, event_seq),
+      FOREIGN KEY (workflow_run_id) REFERENCES durable_workflow_runs(workflow_run_id)
+        ON DELETE CASCADE
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_durable_workflow_events_type
+      ON durable_workflow_events(event_type, event_time, workflow_run_id);
+
+    CREATE TABLE IF NOT EXISTS durable_workflow_steps (
+      workflow_run_id TEXT NOT NULL,
+      step_id TEXT NOT NULL,
+      parent_step_id TEXT,
+      step_type TEXT NOT NULL,
+      status TEXT NOT NULL,
+      recovery_state TEXT NOT NULL,
+      attempt INTEGER NOT NULL DEFAULT 1,
+      max_attempts INTEGER,
+      idempotency_key TEXT,
+      input_ref TEXT,
+      output_ref TEXT,
+      error_ref TEXT,
+      checkpoint_ref TEXT,
+      claimed_by TEXT,
+      claim_expires_at INTEGER,
+      heartbeat_at INTEGER,
+      created_at INTEGER NOT NULL,
+      started_at INTEGER,
+      updated_at INTEGER NOT NULL,
+      completed_at INTEGER,
+      metadata_json TEXT,
+      PRIMARY KEY (workflow_run_id, step_id),
+      FOREIGN KEY (workflow_run_id) REFERENCES durable_workflow_runs(workflow_run_id)
+        ON DELETE CASCADE
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_durable_workflow_steps_status
+      ON durable_workflow_steps(status, updated_at, workflow_run_id, step_id);
+
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_durable_workflow_steps_idempotency
+      ON durable_workflow_steps(workflow_run_id, idempotency_key)
+      WHERE idempotency_key IS NOT NULL;
+
+    CREATE TABLE IF NOT EXISTS durable_workflow_refs (
+      ref_id TEXT NOT NULL PRIMARY KEY,
+      workflow_run_id TEXT NOT NULL,
+      step_id TEXT,
+      ref_kind TEXT NOT NULL,
+      media_type TEXT,
+      hash TEXT,
+      storage_kind TEXT NOT NULL,
+      storage_uri TEXT,
+      created_at INTEGER NOT NULL,
+      metadata_json TEXT,
+      FOREIGN KEY (workflow_run_id) REFERENCES durable_workflow_runs(workflow_run_id)
+        ON DELETE CASCADE
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_durable_workflow_refs_run
+      ON durable_workflow_refs(workflow_run_id, ref_kind, created_at);
+
+    CREATE TABLE IF NOT EXISTS durable_workflow_links (
+      parent_workflow_run_id TEXT NOT NULL,
+      parent_step_id TEXT NOT NULL,
+      child_workflow_run_id TEXT NOT NULL,
+      link_type TEXT NOT NULL,
+      status TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      metadata_json TEXT,
+      PRIMARY KEY (parent_workflow_run_id, parent_step_id, child_workflow_run_id),
+      FOREIGN KEY (parent_workflow_run_id) REFERENCES durable_workflow_runs(workflow_run_id)
+        ON DELETE CASCADE,
+      FOREIGN KEY (child_workflow_run_id) REFERENCES durable_workflow_runs(workflow_run_id)
+        ON DELETE CASCADE
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_durable_workflow_links_child
+      ON durable_workflow_links(child_workflow_run_id, status);
+
+    CREATE TABLE IF NOT EXISTS durable_workflow_timers (
+      timer_id TEXT NOT NULL PRIMARY KEY,
+      workflow_run_id TEXT NOT NULL,
+      step_id TEXT,
+      timer_type TEXT NOT NULL,
+      due_at INTEGER NOT NULL,
+      status TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      fired_at INTEGER,
+      cancelled_at INTEGER,
+      metadata_json TEXT,
+      FOREIGN KEY (workflow_run_id) REFERENCES durable_workflow_runs(workflow_run_id)
+        ON DELETE CASCADE
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_durable_workflow_timers_due
+      ON durable_workflow_timers(status, due_at, timer_id);
+
+    CREATE TABLE IF NOT EXISTS durable_workflow_signals (
+      signal_id TEXT NOT NULL PRIMARY KEY,
+      workflow_run_id TEXT NOT NULL,
+      step_id TEXT,
+      signal_type TEXT NOT NULL,
+      idempotency_key TEXT,
+      payload_ref TEXT,
+      correlation_id TEXT,
+      received_at INTEGER NOT NULL,
+      consumed_at INTEGER,
+      metadata_json TEXT,
+      FOREIGN KEY (workflow_run_id) REFERENCES durable_workflow_runs(workflow_run_id)
+        ON DELETE CASCADE
+    );
+
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_durable_workflow_signals_idempotency
+      ON durable_workflow_signals(workflow_run_id, idempotency_key)
+      WHERE idempotency_key IS NOT NULL;
+
+    CREATE INDEX IF NOT EXISTS idx_durable_workflow_signals_pending
+      ON durable_workflow_signals(consumed_at, received_at, signal_id);
+  `);
+  for (const column of [
+    "parent_workflow_run_id TEXT",
+    "parent_step_id TEXT",
+    "message_id TEXT",
+    "turn_id TEXT",
+    "claimed_by TEXT",
+    "claim_expires_at INTEGER",
+    "heartbeat_at INTEGER",
+  ]) {
+    ensureColumn(db, "durable_workflow_runs", column);
+  }
+  for (const column of ["claimed_by TEXT", "claim_expires_at INTEGER", "heartbeat_at INTEGER"]) {
+    ensureColumn(db, "durable_workflow_steps", column);
+  }
+}
+
+function count(db: DatabaseSync, sql: string, values: SQLInputValue[] = []): number {
+  const row = db.prepare(sql).get(...values) as CountRow | undefined;
+  return Number(row?.count ?? 0);
+}
+
+export function openDurableWorkflowSqliteStore(options?: {
+  path?: string;
+  env?: NodeJS.ProcessEnv;
+}): DurableWorkflowStore {
+  const pathname = path.resolve(options?.path ?? resolveDurableWorkflowSqlitePath(options?.env));
+  fs.mkdirSync(path.dirname(pathname), { recursive: true, mode: 0o700 });
+  const sqlite = requireNodeSqlite();
+  const db = new sqlite.DatabaseSync(pathname);
+  const walMaintenance = configureSqliteConnectionPragmas(db, {
+    busyTimeoutMs: DURABLE_WORKFLOW_SQLITE_BUSY_TIMEOUT_MS,
+    databaseLabel: "openclaw-durable-workflows",
+    databasePath: pathname,
+    foreignKeys: true,
+    synchronous: "NORMAL",
+  });
+  ensureDurableWorkflowSchema(db);
+
+  return {
+    createRun(input: CreateDurableWorkflowRunInput): DurableWorkflowRun {
+      const now = input.now ?? Date.now();
+      const workflowRunId = input.workflowRunId ?? `wfr_${randomUUID()}`;
+      const workflowVersion = input.workflowVersion ?? "1";
+      const status = input.status ?? "received";
+      const recoveryState = input.recoveryState ?? "runnable";
+      return runSqliteImmediateTransactionSync(db, () => {
+        const existing =
+          input.idempotencyKey &&
+          (db
+            .prepare(
+              `SELECT *
+                 FROM durable_workflow_runs
+                WHERE workflow_id = ?
+                  AND idempotency_key = ?`,
+            )
+            .get(input.workflowId, input.idempotencyKey) as DurableWorkflowRunRow | undefined);
+        if (existing) {
+          if (
+            input.requestHash &&
+            existing.request_hash &&
+            existing.request_hash !== input.requestHash
+          ) {
+            throw new Error(
+              `Durable workflow idempotency key conflict for ${input.workflowId}:${input.idempotencyKey}`,
+            );
+          }
+          return rowToRun(existing);
+        }
+        db.prepare(
+          `INSERT INTO durable_workflow_runs (
+             workflow_run_id, workflow_id, workflow_version, idempotency_key, request_hash,
+             status, source_type, source_ref, input_ref, created_at, updated_at, completed_at,
+             recovery_state, checkpoint_ref, parent_workflow_run_id, parent_step_id, message_id,
+             turn_id, claimed_by, claim_expires_at, heartbeat_at, metadata_json
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        ).run(
+          workflowRunId,
+          input.workflowId,
+          workflowVersion,
+          optionalText(input.idempotencyKey),
+          optionalText(input.requestHash),
+          status,
+          optionalText(input.sourceType),
+          optionalText(input.sourceRef),
+          optionalText(input.inputRef),
+          now,
+          now,
+          null,
+          recoveryState,
+          optionalText(input.checkpointRef),
+          optionalText(input.parentWorkflowRunId),
+          optionalText(input.parentStepId),
+          optionalText(input.messageId),
+          optionalText(input.turnId),
+          null,
+          null,
+          null,
+          serializeJson(input.metadata),
+        );
+        const row = db
+          .prepare("SELECT * FROM durable_workflow_runs WHERE workflow_run_id = ?")
+          .get(workflowRunId) as DurableWorkflowRunRow;
+        return rowToRun(row);
+      });
+    },
+
+    getRun(workflowRunId: string): DurableWorkflowRun | undefined {
+      const row = db
+        .prepare("SELECT * FROM durable_workflow_runs WHERE workflow_run_id = ?")
+        .get(workflowRunId) as DurableWorkflowRunRow | undefined;
+      return row ? rowToRun(row) : undefined;
+    },
+
+    updateRun(input: UpdateDurableWorkflowRunInput): DurableWorkflowRun | undefined {
+      const now = input.now ?? Date.now();
+      return runSqliteImmediateTransactionSync(db, () => {
+        const current = db
+          .prepare("SELECT * FROM durable_workflow_runs WHERE workflow_run_id = ?")
+          .get(input.workflowRunId) as DurableWorkflowRunRow | undefined;
+        if (!current) {
+          return undefined;
+        }
+        const completedAt =
+          input.completedAt === undefined
+            ? current.completed_at
+            : input.completedAt === null
+              ? null
+              : input.completedAt;
+        db.prepare(
+          `UPDATE durable_workflow_runs
+              SET status = ?,
+                  recovery_state = ?,
+                  updated_at = ?,
+                  completed_at = ?,
+                  checkpoint_ref = ?,
+                  claimed_by = ?,
+                  claim_expires_at = ?,
+                  heartbeat_at = ?,
+                  metadata_json = ?
+            WHERE workflow_run_id = ?`,
+        ).run(
+          input.status ?? current.status,
+          input.recoveryState ?? current.recovery_state,
+          now,
+          completedAt,
+          input.checkpointRef === undefined
+            ? current.checkpoint_ref
+            : optionalText(input.checkpointRef ?? undefined),
+          input.claimedBy === undefined
+            ? current.claimed_by
+            : optionalText(input.claimedBy ?? undefined),
+          input.claimExpiresAt === undefined ? current.claim_expires_at : input.claimExpiresAt,
+          input.heartbeatAt === undefined ? current.heartbeat_at : input.heartbeatAt,
+          input.metadata === undefined ? current.metadata_json : serializeJson(input.metadata),
+          input.workflowRunId,
+        );
+        const row = db
+          .prepare("SELECT * FROM durable_workflow_runs WHERE workflow_run_id = ?")
+          .get(input.workflowRunId) as DurableWorkflowRunRow;
+        return rowToRun(row);
+      });
+    },
+
+    appendEvent(input: AppendDurableWorkflowEventInput): DurableWorkflowEvent {
+      const now = input.eventTime ?? Date.now();
+      const recordedAt = Date.now();
+      const eventId = input.eventId ?? `wfe_${randomUUID()}`;
+      return runSqliteImmediateTransactionSync(db, () => {
+        const nextSeq = count(
+          db,
+          "SELECT COALESCE(MAX(event_seq), 0) + 1 AS count FROM durable_workflow_events WHERE workflow_run_id = ?",
+          [input.workflowRunId],
+        );
+        db.prepare(
+          `INSERT INTO durable_workflow_events (
+             event_id, workflow_run_id, event_seq, event_type, event_time, step_id,
+             agent_invocation_id, tool_invocation_id, idempotency_key, payload_json,
+             payload_hash, checkpoint_ref, causation_event_id, correlation_id, recorded_at
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        ).run(
+          eventId,
+          input.workflowRunId,
+          nextSeq,
+          input.eventType,
+          now,
+          optionalText(input.stepId),
+          optionalText(input.agentInvocationId),
+          optionalText(input.toolInvocationId),
+          optionalText(input.idempotencyKey),
+          serializeJson(input.payload),
+          optionalText(input.payloadHash),
+          optionalText(input.checkpointRef),
+          optionalText(input.causationEventId),
+          optionalText(input.correlationId),
+          recordedAt,
+        );
+        db.prepare(
+          `UPDATE durable_workflow_runs
+              SET updated_at = ?
+            WHERE workflow_run_id = ?`,
+        ).run(recordedAt, input.workflowRunId);
+        const row = db
+          .prepare(
+            `SELECT *
+               FROM durable_workflow_events
+              WHERE workflow_run_id = ?
+                AND event_seq = ?`,
+          )
+          .get(input.workflowRunId, nextSeq) as DurableWorkflowEventRow;
+        return rowToEvent(row);
+      });
+    },
+
+    listRuns(options?: { limit?: number }): DurableWorkflowRun[] {
+      const limit = Math.max(1, Math.min(500, Math.trunc(options?.limit ?? 50)));
+      const rows = db
+        .prepare(
+          `SELECT *
+             FROM durable_workflow_runs
+            ORDER BY updated_at DESC, workflow_run_id DESC
+            LIMIT ?`,
+        )
+        .all(limit) as DurableWorkflowRunRow[];
+      return rows.map(rowToRun);
+    },
+
+    listOpenRuns(options?: { workflowId?: string; limit?: number }): DurableWorkflowRun[] {
+      const limit = Math.max(1, Math.min(5000, Math.trunc(options?.limit ?? 500)));
+      const workflowId = optionalText(options?.workflowId);
+      const rows = workflowId
+        ? (db
+            .prepare(
+              `SELECT *
+                 FROM durable_workflow_runs
+                WHERE workflow_id = ?
+                  AND status NOT IN ('succeeded', 'failed', 'cancelled', 'lost')
+                ORDER BY updated_at ASC, workflow_run_id ASC
+                LIMIT ?`,
+            )
+            .all(workflowId, limit) as DurableWorkflowRunRow[])
+        : (db
+            .prepare(
+              `SELECT *
+                 FROM durable_workflow_runs
+                WHERE status NOT IN ('succeeded', 'failed', 'cancelled', 'lost')
+                ORDER BY updated_at ASC, workflow_run_id ASC
+                LIMIT ?`,
+            )
+            .all(limit) as DurableWorkflowRunRow[]);
+      return rows.map(rowToRun);
+    },
+
+    claimNextRunnableRun(input: ClaimDurableWorkflowRunInput): DurableWorkflowRun | undefined {
+      const now = input.now ?? Date.now();
+      const claimExpiresAt = now + input.claimTtlMs;
+      return runSqliteImmediateTransactionSync(db, () => {
+        const workflowId = optionalText(input.workflowId);
+        const row = workflowId
+          ? (db
+              .prepare(
+                `SELECT *
+                   FROM durable_workflow_runs
+                  WHERE workflow_id = ?
+                    AND status IN ('received', 'queued')
+                    AND recovery_state = 'runnable'
+                    AND (claimed_by IS NULL OR claim_expires_at IS NULL OR claim_expires_at <= ?)
+                  ORDER BY updated_at ASC, workflow_run_id ASC
+                  LIMIT 1`,
+              )
+              .get(workflowId, now) as DurableWorkflowRunRow | undefined)
+          : (db
+              .prepare(
+                `SELECT *
+                   FROM durable_workflow_runs
+                  WHERE status IN ('received', 'queued')
+                    AND recovery_state = 'runnable'
+                    AND (claimed_by IS NULL OR claim_expires_at IS NULL OR claim_expires_at <= ?)
+                  ORDER BY updated_at ASC, workflow_run_id ASC
+                  LIMIT 1`,
+              )
+              .get(now) as DurableWorkflowRunRow | undefined);
+        if (!row) {
+          return undefined;
+        }
+        db.prepare(
+          `UPDATE durable_workflow_runs
+              SET status = 'queued',
+                  recovery_state = 'claimed',
+                  claimed_by = ?,
+                  claim_expires_at = ?,
+                  heartbeat_at = ?,
+                  updated_at = ?
+            WHERE workflow_run_id = ?`,
+        ).run(input.workerId, claimExpiresAt, now, now, row.workflow_run_id);
+        const claimed = db
+          .prepare("SELECT * FROM durable_workflow_runs WHERE workflow_run_id = ?")
+          .get(row.workflow_run_id) as DurableWorkflowRunRow;
+        return rowToRun(claimed);
+      });
+    },
+
+    releaseRunClaim(input: {
+      workflowRunId: string;
+      workerId: string;
+      now?: number;
+    }): DurableWorkflowRun | undefined {
+      const now = input.now ?? Date.now();
+      return runSqliteImmediateTransactionSync(db, () => {
+        db.prepare(
+          `UPDATE durable_workflow_runs
+              SET recovery_state = 'runnable',
+                  claimed_by = NULL,
+                  claim_expires_at = NULL,
+                  heartbeat_at = NULL,
+                  updated_at = ?
+            WHERE workflow_run_id = ?
+              AND claimed_by = ?`,
+        ).run(now, input.workflowRunId, input.workerId);
+        const row = db
+          .prepare("SELECT * FROM durable_workflow_runs WHERE workflow_run_id = ?")
+          .get(input.workflowRunId) as DurableWorkflowRunRow | undefined;
+        return row ? rowToRun(row) : undefined;
+      });
+    },
+
+    createStep(input: CreateDurableWorkflowStepInput): DurableWorkflowStep {
+      const now = input.now ?? Date.now();
+      const stepId = input.stepId ?? `step_${randomUUID()}`;
+      const status = input.status ?? "pending";
+      const recoveryState = input.recoveryState ?? "runnable";
+      const attempt = input.attempt ?? 1;
+      return runSqliteImmediateTransactionSync(db, () => {
+        const existing =
+          input.idempotencyKey &&
+          (db
+            .prepare(
+              `SELECT *
+                 FROM durable_workflow_steps
+                WHERE workflow_run_id = ?
+                  AND idempotency_key = ?`,
+            )
+            .get(input.workflowRunId, input.idempotencyKey) as DurableWorkflowStepRow | undefined);
+        if (existing) {
+          return rowToStep(existing);
+        }
+        db.prepare(
+          `INSERT INTO durable_workflow_steps (
+             workflow_run_id, step_id, parent_step_id, step_type, status, recovery_state,
+             attempt, max_attempts, idempotency_key, input_ref, output_ref, error_ref,
+             checkpoint_ref, claimed_by, claim_expires_at, heartbeat_at, created_at,
+             started_at, updated_at, completed_at, metadata_json
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        ).run(
+          input.workflowRunId,
+          stepId,
+          optionalText(input.parentStepId),
+          input.stepType,
+          status,
+          recoveryState,
+          attempt,
+          input.maxAttempts ?? null,
+          optionalText(input.idempotencyKey),
+          optionalText(input.inputRef),
+          optionalText(input.outputRef),
+          optionalText(input.errorRef),
+          optionalText(input.checkpointRef),
+          null,
+          null,
+          null,
+          now,
+          status === "running" ? now : null,
+          now,
+          null,
+          serializeJson(input.metadata),
+        );
+        const row = db
+          .prepare("SELECT * FROM durable_workflow_steps WHERE workflow_run_id = ? AND step_id = ?")
+          .get(input.workflowRunId, stepId) as DurableWorkflowStepRow;
+        return rowToStep(row);
+      });
+    },
+
+    updateStep(input: UpdateDurableWorkflowStepInput): DurableWorkflowStep | undefined {
+      const now = input.now ?? Date.now();
+      return runSqliteImmediateTransactionSync(db, () => {
+        const current = db
+          .prepare("SELECT * FROM durable_workflow_steps WHERE workflow_run_id = ? AND step_id = ?")
+          .get(input.workflowRunId, input.stepId) as DurableWorkflowStepRow | undefined;
+        if (!current) {
+          return undefined;
+        }
+        db.prepare(
+          `UPDATE durable_workflow_steps
+              SET status = ?,
+                  recovery_state = ?,
+                  attempt = ?,
+                  max_attempts = ?,
+                  input_ref = ?,
+                  output_ref = ?,
+                  error_ref = ?,
+                  checkpoint_ref = ?,
+                  claimed_by = ?,
+                  claim_expires_at = ?,
+                  heartbeat_at = ?,
+                  started_at = ?,
+                  completed_at = ?,
+                  updated_at = ?,
+                  metadata_json = ?
+            WHERE workflow_run_id = ?
+              AND step_id = ?`,
+        ).run(
+          input.status ?? current.status,
+          input.recoveryState ?? current.recovery_state,
+          input.attempt ?? current.attempt,
+          input.maxAttempts === undefined ? current.max_attempts : input.maxAttempts,
+          input.inputRef === undefined
+            ? current.input_ref
+            : optionalText(input.inputRef ?? undefined),
+          input.outputRef === undefined
+            ? current.output_ref
+            : optionalText(input.outputRef ?? undefined),
+          input.errorRef === undefined
+            ? current.error_ref
+            : optionalText(input.errorRef ?? undefined),
+          input.checkpointRef === undefined
+            ? current.checkpoint_ref
+            : optionalText(input.checkpointRef ?? undefined),
+          input.claimedBy === undefined
+            ? current.claimed_by
+            : optionalText(input.claimedBy ?? undefined),
+          input.claimExpiresAt === undefined ? current.claim_expires_at : input.claimExpiresAt,
+          input.heartbeatAt === undefined ? current.heartbeat_at : input.heartbeatAt,
+          input.startedAt === undefined
+            ? current.started_at
+            : input.startedAt === null
+              ? null
+              : input.startedAt,
+          input.completedAt === undefined
+            ? current.completed_at
+            : input.completedAt === null
+              ? null
+              : input.completedAt,
+          now,
+          input.metadata === undefined ? current.metadata_json : serializeJson(input.metadata),
+          input.workflowRunId,
+          input.stepId,
+        );
+        const row = db
+          .prepare("SELECT * FROM durable_workflow_steps WHERE workflow_run_id = ? AND step_id = ?")
+          .get(input.workflowRunId, input.stepId) as DurableWorkflowStepRow;
+        return rowToStep(row);
+      });
+    },
+
+    claimNextRunnableStep(input: ClaimDurableWorkflowStepInput): DurableWorkflowStep | undefined {
+      const now = input.now ?? Date.now();
+      const claimExpiresAt = now + input.claimTtlMs;
+      return runSqliteImmediateTransactionSync(db, () => {
+        const filters: string[] = [
+          "s.status IN ('pending', 'queued')",
+          "s.recovery_state = 'runnable'",
+          "(s.claimed_by IS NULL OR s.claim_expires_at IS NULL OR s.claim_expires_at <= ?)",
+          "r.status NOT IN ('succeeded', 'failed', 'cancelled', 'lost')",
+        ];
+        const values: SQLInputValue[] = [now];
+        const workflowId = optionalText(input.workflowId);
+        if (workflowId) {
+          filters.push("r.workflow_id = ?");
+          values.push(workflowId);
+        }
+        if (input.stepType) {
+          filters.push("s.step_type = ?");
+          values.push(input.stepType);
+        }
+        const row = db
+          .prepare(
+            `SELECT s.*
+               FROM durable_workflow_steps s
+               JOIN durable_workflow_runs r
+                 ON r.workflow_run_id = s.workflow_run_id
+              WHERE ${filters.join(" AND ")}
+              ORDER BY s.updated_at ASC, s.workflow_run_id ASC, s.step_id ASC
+              LIMIT 1`,
+          )
+          .get(...values) as DurableWorkflowStepRow | undefined;
+        if (!row) {
+          return undefined;
+        }
+        db.prepare(
+          `UPDATE durable_workflow_steps
+              SET status = 'queued',
+                  recovery_state = 'claimed',
+                  claimed_by = ?,
+                  claim_expires_at = ?,
+                  heartbeat_at = ?,
+                  updated_at = ?
+            WHERE workflow_run_id = ?
+              AND step_id = ?`,
+        ).run(input.workerId, claimExpiresAt, now, now, row.workflow_run_id, row.step_id);
+        const claimed = db
+          .prepare("SELECT * FROM durable_workflow_steps WHERE workflow_run_id = ? AND step_id = ?")
+          .get(row.workflow_run_id, row.step_id) as DurableWorkflowStepRow;
+        return rowToStep(claimed);
+      });
+    },
+
+    releaseStepClaim(input: {
+      workflowRunId: string;
+      stepId: string;
+      workerId: string;
+      now?: number;
+    }): DurableWorkflowStep | undefined {
+      const now = input.now ?? Date.now();
+      return runSqliteImmediateTransactionSync(db, () => {
+        db.prepare(
+          `UPDATE durable_workflow_steps
+              SET status = CASE WHEN status = 'running' THEN 'queued' ELSE status END,
+                  recovery_state = 'runnable',
+                  claimed_by = NULL,
+                  claim_expires_at = NULL,
+                  heartbeat_at = NULL,
+                  updated_at = ?
+            WHERE workflow_run_id = ?
+              AND step_id = ?
+              AND claimed_by = ?`,
+        ).run(now, input.workflowRunId, input.stepId, input.workerId);
+        const row = db
+          .prepare("SELECT * FROM durable_workflow_steps WHERE workflow_run_id = ? AND step_id = ?")
+          .get(input.workflowRunId, input.stepId) as DurableWorkflowStepRow | undefined;
+        return row ? rowToStep(row) : undefined;
+      });
+    },
+
+    listSteps(workflowRunId: string): DurableWorkflowStep[] {
+      const rows = db
+        .prepare(
+          `SELECT *
+             FROM durable_workflow_steps
+            WHERE workflow_run_id = ?
+            ORDER BY created_at ASC, step_id ASC`,
+        )
+        .all(workflowRunId) as DurableWorkflowStepRow[];
+      return rows.map(rowToStep);
+    },
+
+    createRef(input: CreateDurableWorkflowRefInput): DurableWorkflowRef {
+      const now = input.now ?? Date.now();
+      const refId = input.refId ?? `ref_${randomUUID()}`;
+      db.prepare(
+        `INSERT INTO durable_workflow_refs (
+           ref_id, workflow_run_id, step_id, ref_kind, media_type, hash, storage_kind,
+           storage_uri, created_at, metadata_json
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ).run(
+        refId,
+        input.workflowRunId,
+        optionalText(input.stepId),
+        input.refKind,
+        optionalText(input.mediaType),
+        optionalText(input.hash),
+        input.storageKind ?? "external",
+        optionalText(input.storageUri),
+        now,
+        serializeJson(input.metadata),
+      );
+      const row = db
+        .prepare("SELECT * FROM durable_workflow_refs WHERE ref_id = ?")
+        .get(refId) as DurableWorkflowRefRow;
+      return rowToRef(row);
+    },
+
+    getRef(refId: string): DurableWorkflowRef | undefined {
+      const row = db.prepare("SELECT * FROM durable_workflow_refs WHERE ref_id = ?").get(refId) as
+        | DurableWorkflowRefRow
+        | undefined;
+      return row ? rowToRef(row) : undefined;
+    },
+
+    listRefs(workflowRunId: string): DurableWorkflowRef[] {
+      const rows = db
+        .prepare(
+          `SELECT *
+             FROM durable_workflow_refs
+            WHERE workflow_run_id = ?
+            ORDER BY created_at ASC, ref_id ASC`,
+        )
+        .all(workflowRunId) as DurableWorkflowRefRow[];
+      return rows.map(rowToRef);
+    },
+
+    createLink(input: CreateDurableWorkflowLinkInput): DurableWorkflowLink {
+      const now = input.now ?? Date.now();
+      db.prepare(
+        `INSERT INTO durable_workflow_links (
+           parent_workflow_run_id, parent_step_id, child_workflow_run_id, link_type,
+           status, created_at, updated_at, metadata_json
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      ).run(
+        input.parentWorkflowRunId,
+        input.parentStepId,
+        input.childWorkflowRunId,
+        input.linkType,
+        input.status ?? "pending",
+        now,
+        now,
+        serializeJson(input.metadata),
+      );
+      const row = db
+        .prepare(
+          `SELECT *
+             FROM durable_workflow_links
+            WHERE parent_workflow_run_id = ?
+              AND parent_step_id = ?
+              AND child_workflow_run_id = ?`,
+        )
+        .get(
+          input.parentWorkflowRunId,
+          input.parentStepId,
+          input.childWorkflowRunId,
+        ) as DurableWorkflowLinkRow;
+      return rowToLink(row);
+    },
+
+    updateLink(input: UpdateDurableWorkflowLinkInput): DurableWorkflowLink | undefined {
+      const now = input.now ?? Date.now();
+      return runSqliteImmediateTransactionSync(db, () => {
+        const current = db
+          .prepare(
+            `SELECT *
+               FROM durable_workflow_links
+              WHERE parent_workflow_run_id = ?
+                AND parent_step_id = ?
+                AND child_workflow_run_id = ?`,
+          )
+          .get(input.parentWorkflowRunId, input.parentStepId, input.childWorkflowRunId) as
+          | DurableWorkflowLinkRow
+          | undefined;
+        if (!current) {
+          return undefined;
+        }
+        db.prepare(
+          `UPDATE durable_workflow_links
+              SET status = ?,
+                  updated_at = ?,
+                  metadata_json = ?
+            WHERE parent_workflow_run_id = ?
+              AND parent_step_id = ?
+              AND child_workflow_run_id = ?`,
+        ).run(
+          input.status ?? current.status,
+          now,
+          input.metadata === undefined ? current.metadata_json : serializeJson(input.metadata),
+          input.parentWorkflowRunId,
+          input.parentStepId,
+          input.childWorkflowRunId,
+        );
+        const row = db
+          .prepare(
+            `SELECT *
+               FROM durable_workflow_links
+              WHERE parent_workflow_run_id = ?
+                AND parent_step_id = ?
+                AND child_workflow_run_id = ?`,
+          )
+          .get(
+            input.parentWorkflowRunId,
+            input.parentStepId,
+            input.childWorkflowRunId,
+          ) as DurableWorkflowLinkRow;
+        return rowToLink(row);
+      });
+    },
+
+    listChildLinks(parentWorkflowRunId: string): DurableWorkflowLink[] {
+      const rows = db
+        .prepare(
+          `SELECT *
+             FROM durable_workflow_links
+            WHERE parent_workflow_run_id = ?
+            ORDER BY created_at ASC, child_workflow_run_id ASC`,
+        )
+        .all(parentWorkflowRunId) as DurableWorkflowLinkRow[];
+      return rows.map(rowToLink);
+    },
+
+    listParentLinks(childWorkflowRunId: string): DurableWorkflowLink[] {
+      const rows = db
+        .prepare(
+          `SELECT *
+             FROM durable_workflow_links
+            WHERE child_workflow_run_id = ?
+            ORDER BY created_at ASC, parent_workflow_run_id ASC, parent_step_id ASC`,
+        )
+        .all(childWorkflowRunId) as DurableWorkflowLinkRow[];
+      return rows.map(rowToLink);
+    },
+
+    createTimer(input: CreateDurableWorkflowTimerInput): DurableWorkflowTimer {
+      const now = input.now ?? Date.now();
+      const timerId = input.timerId ?? `timer_${randomUUID()}`;
+      db.prepare(
+        `INSERT INTO durable_workflow_timers (
+           timer_id, workflow_run_id, step_id, timer_type, due_at, status, created_at,
+           fired_at, cancelled_at, metadata_json
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ).run(
+        timerId,
+        input.workflowRunId,
+        optionalText(input.stepId),
+        input.timerType,
+        input.dueAt,
+        "pending",
+        now,
+        null,
+        null,
+        serializeJson(input.metadata),
+      );
+      const row = db
+        .prepare("SELECT * FROM durable_workflow_timers WHERE timer_id = ?")
+        .get(timerId) as DurableWorkflowTimerRow;
+      return rowToTimer(row);
+    },
+
+    updateTimer(input: UpdateDurableWorkflowTimerInput): DurableWorkflowTimer | undefined {
+      const now = input.now ?? Date.now();
+      return runSqliteImmediateTransactionSync(db, () => {
+        const current = db
+          .prepare("SELECT * FROM durable_workflow_timers WHERE timer_id = ?")
+          .get(input.timerId) as DurableWorkflowTimerRow | undefined;
+        if (!current) {
+          return undefined;
+        }
+        db.prepare(
+          `UPDATE durable_workflow_timers
+              SET status = ?,
+                  fired_at = ?,
+                  cancelled_at = ?
+            WHERE timer_id = ?`,
+        ).run(
+          input.status,
+          input.firedAt === undefined
+            ? input.status === "fired"
+              ? now
+              : current.fired_at
+            : input.firedAt,
+          input.cancelledAt === undefined
+            ? input.status === "cancelled"
+              ? now
+              : current.cancelled_at
+            : input.cancelledAt,
+          input.timerId,
+        );
+        const row = db
+          .prepare("SELECT * FROM durable_workflow_timers WHERE timer_id = ?")
+          .get(input.timerId) as DurableWorkflowTimerRow;
+        return rowToTimer(row);
+      });
+    },
+
+    listTimers(workflowRunId?: string): DurableWorkflowTimer[] {
+      const rows = workflowRunId
+        ? (db
+            .prepare(
+              `SELECT *
+                 FROM durable_workflow_timers
+                WHERE workflow_run_id = ?
+                ORDER BY due_at ASC, timer_id ASC`,
+            )
+            .all(workflowRunId) as DurableWorkflowTimerRow[])
+        : (db
+            .prepare(
+              `SELECT *
+                 FROM durable_workflow_timers
+                ORDER BY due_at ASC, timer_id ASC`,
+            )
+            .all() as DurableWorkflowTimerRow[]);
+      return rows.map(rowToTimer);
+    },
+
+    listDueTimers(now: number, options?: { limit?: number }): DurableWorkflowTimer[] {
+      const limit = Math.max(1, Math.min(5000, Math.trunc(options?.limit ?? 500)));
+      const rows = db
+        .prepare(
+          `SELECT *
+             FROM durable_workflow_timers
+            WHERE status = 'pending'
+              AND due_at <= ?
+            ORDER BY due_at ASC, timer_id ASC
+            LIMIT ?`,
+        )
+        .all(now, limit) as DurableWorkflowTimerRow[];
+      return rows.map(rowToTimer);
+    },
+
+    createSignal(input: CreateDurableWorkflowSignalInput): DurableWorkflowSignal {
+      const now = input.now ?? Date.now();
+      return runSqliteImmediateTransactionSync(db, () => {
+        const existing =
+          input.idempotencyKey &&
+          (db
+            .prepare(
+              `SELECT *
+                 FROM durable_workflow_signals
+                WHERE workflow_run_id = ?
+                  AND idempotency_key = ?`,
+            )
+            .get(input.workflowRunId, input.idempotencyKey) as
+            | DurableWorkflowSignalRow
+            | undefined);
+        if (existing) {
+          return rowToSignal(existing);
+        }
+        const signalId = input.signalId ?? `sig_${randomUUID()}`;
+        db.prepare(
+          `INSERT INTO durable_workflow_signals (
+             signal_id, workflow_run_id, step_id, signal_type, idempotency_key, payload_ref,
+             correlation_id, received_at, consumed_at, metadata_json
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        ).run(
+          signalId,
+          input.workflowRunId,
+          optionalText(input.stepId),
+          input.signalType,
+          optionalText(input.idempotencyKey),
+          optionalText(input.payloadRef),
+          optionalText(input.correlationId),
+          now,
+          null,
+          serializeJson(input.metadata),
+        );
+        const row = db
+          .prepare("SELECT * FROM durable_workflow_signals WHERE signal_id = ?")
+          .get(signalId) as DurableWorkflowSignalRow;
+        return rowToSignal(row);
+      });
+    },
+
+    consumeSignal(input: { signalId: string; now?: number }): DurableWorkflowSignal | undefined {
+      const now = input.now ?? Date.now();
+      return runSqliteImmediateTransactionSync(db, () => {
+        db.prepare(
+          `UPDATE durable_workflow_signals
+              SET consumed_at = COALESCE(consumed_at, ?)
+            WHERE signal_id = ?`,
+        ).run(now, input.signalId);
+        const row = db
+          .prepare("SELECT * FROM durable_workflow_signals WHERE signal_id = ?")
+          .get(input.signalId) as DurableWorkflowSignalRow | undefined;
+        return row ? rowToSignal(row) : undefined;
+      });
+    },
+
+    listPendingSignals(options?: { limit?: number }): DurableWorkflowSignal[] {
+      const limit = Math.max(1, Math.min(5000, Math.trunc(options?.limit ?? 500)));
+      const rows = db
+        .prepare(
+          `SELECT *
+             FROM durable_workflow_signals
+            WHERE consumed_at IS NULL
+            ORDER BY received_at ASC, signal_id ASC
+            LIMIT ?`,
+        )
+        .all(limit) as DurableWorkflowSignalRow[];
+      return rows.map(rowToSignal);
+    },
+
+    listSignals(workflowRunId: string): DurableWorkflowSignal[] {
+      const rows = db
+        .prepare(
+          `SELECT *
+             FROM durable_workflow_signals
+            WHERE workflow_run_id = ?
+            ORDER BY received_at ASC, signal_id ASC`,
+        )
+        .all(workflowRunId) as DurableWorkflowSignalRow[];
+      return rows.map(rowToSignal);
+    },
+
+    getTimeline(workflowRunId: string): DurableWorkflowEvent[] {
+      const rows = db
+        .prepare(
+          `SELECT *
+             FROM durable_workflow_events
+            WHERE workflow_run_id = ?
+            ORDER BY event_seq ASC`,
+        )
+        .all(workflowRunId) as DurableWorkflowEventRow[];
+      return rows.map(rowToEvent);
+    },
+
+    getStats(): DurableWorkflowStoreStats {
+      return {
+        path: pathname,
+        runs: count(db, "SELECT COUNT(*) AS count FROM durable_workflow_runs"),
+        events: count(db, "SELECT COUNT(*) AS count FROM durable_workflow_events"),
+        steps: count(db, "SELECT COUNT(*) AS count FROM durable_workflow_steps"),
+        openRuns: count(
+          db,
+          "SELECT COUNT(*) AS count FROM durable_workflow_runs WHERE status NOT IN ('succeeded', 'failed', 'cancelled', 'lost')",
+        ),
+      };
+    },
+
+    close(): void {
+      walMaintenance.close();
+      if (db.isOpen) {
+        db.close();
+      }
+    },
+  };
+}

--- a/src/durable/types.ts
+++ b/src/durable/types.ts
@@ -1,0 +1,408 @@
+// Shared durable workflow control-plane types.
+export type DurableWorkflowRunStatus =
+  | "received"
+  | "queued"
+  | "running"
+  | "waiting"
+  | "waiting_signal"
+  | "waiting_timer"
+  | "waiting_child"
+  | "retry_scheduled"
+  | "succeeded"
+  | "failed"
+  | "cancelled"
+  | "lost";
+
+export type DurableRecoveryState =
+  | "runnable"
+  | "claimed"
+  | "running"
+  | "waiting_signal"
+  | "waiting_timer"
+  | "waiting_child"
+  | "retry_scheduled"
+  | "reconciling"
+  | "unknown_after_side_effect"
+  | "lost"
+  | "terminal";
+
+export type DurableWorkflowStepType =
+  | "agent"
+  | "tool"
+  | "timer"
+  | "signal"
+  | "child_workflow"
+  | "checkpoint"
+  | "fan_in";
+
+export type DurableWorkflowStepStatus =
+  | "pending"
+  | "queued"
+  | "running"
+  | "waiting"
+  | "retry_scheduled"
+  | "succeeded"
+  | "failed"
+  | "cancelled"
+  | "lost"
+  | "skipped";
+
+export type DurableWorkflowRefKind = "input" | "output" | "error" | "artifact";
+
+export type DurableWorkflowLinkType =
+  | "child_workflow"
+  | "handoff"
+  | "subagent"
+  | "evidence"
+  | "artifact";
+
+export type DurableWorkflowLinkStatus =
+  | "pending"
+  | "running"
+  | "succeeded"
+  | "failed"
+  | "cancelled"
+  | "lost";
+
+export type DurableWorkflowTimerStatus = "pending" | "fired" | "cancelled";
+export type DurableWorkflowSignalStatus = "pending" | "consumed";
+
+export type DurableWorkflowRun = {
+  workflowRunId: string;
+  workflowId: string;
+  workflowVersion: string;
+  status: DurableWorkflowRunStatus;
+  recoveryState: DurableRecoveryState;
+  idempotencyKey?: string;
+  requestHash?: string;
+  sourceType?: string;
+  sourceRef?: string;
+  inputRef?: string;
+  checkpointRef?: string;
+  parentWorkflowRunId?: string;
+  parentStepId?: string;
+  messageId?: string;
+  turnId?: string;
+  claimedBy?: string;
+  claimExpiresAt?: number;
+  heartbeatAt?: number;
+  metadata?: Record<string, unknown>;
+  createdAt: number;
+  updatedAt: number;
+  completedAt?: number;
+};
+
+export type DurableWorkflowStep = {
+  workflowRunId: string;
+  stepId: string;
+  parentStepId?: string;
+  stepType: DurableWorkflowStepType;
+  status: DurableWorkflowStepStatus;
+  recoveryState: DurableRecoveryState;
+  attempt: number;
+  maxAttempts?: number;
+  idempotencyKey?: string;
+  inputRef?: string;
+  outputRef?: string;
+  errorRef?: string;
+  checkpointRef?: string;
+  claimedBy?: string;
+  claimExpiresAt?: number;
+  heartbeatAt?: number;
+  metadata?: Record<string, unknown>;
+  createdAt: number;
+  startedAt?: number;
+  updatedAt: number;
+  completedAt?: number;
+};
+
+export type DurableWorkflowRef = {
+  refId: string;
+  workflowRunId: string;
+  stepId?: string;
+  refKind: DurableWorkflowRefKind;
+  mediaType?: string;
+  hash?: string;
+  storageKind: "inline" | "file" | "external";
+  storageUri?: string;
+  metadata?: Record<string, unknown>;
+  createdAt: number;
+};
+
+export type DurableWorkflowLink = {
+  parentWorkflowRunId: string;
+  parentStepId: string;
+  childWorkflowRunId: string;
+  linkType: DurableWorkflowLinkType;
+  status: DurableWorkflowLinkStatus;
+  metadata?: Record<string, unknown>;
+  createdAt: number;
+  updatedAt: number;
+};
+
+export type DurableWorkflowTimer = {
+  timerId: string;
+  workflowRunId: string;
+  stepId?: string;
+  timerType: "retry" | "deadline" | "sleep" | "human_timeout" | "child_timeout" | "scheduled_start";
+  dueAt: number;
+  status: DurableWorkflowTimerStatus;
+  metadata?: Record<string, unknown>;
+  createdAt: number;
+  firedAt?: number;
+  cancelledAt?: number;
+};
+
+export type DurableWorkflowSignal = {
+  signalId: string;
+  workflowRunId: string;
+  stepId?: string;
+  signalType:
+    | "human_input"
+    | "approval"
+    | "rejection"
+    | "external_callback"
+    | "child_completed"
+    | "child_failed"
+    | "cancel"
+    | "resume";
+  idempotencyKey?: string;
+  payloadRef?: string;
+  correlationId?: string;
+  metadata?: Record<string, unknown>;
+  receivedAt: number;
+  consumedAt?: number;
+};
+
+export type DurableWorkflowEvent = {
+  eventId: string;
+  workflowRunId: string;
+  eventSeq: number;
+  eventType: string;
+  eventTime: number;
+  stepId?: string;
+  agentInvocationId?: string;
+  toolInvocationId?: string;
+  idempotencyKey?: string;
+  payload?: Record<string, unknown>;
+  payloadHash?: string;
+  checkpointRef?: string;
+  causationEventId?: string;
+  correlationId?: string;
+  recordedAt: number;
+};
+
+export type CreateDurableWorkflowRunInput = {
+  workflowRunId?: string;
+  workflowId: string;
+  workflowVersion?: string;
+  status?: DurableWorkflowRunStatus;
+  recoveryState?: DurableRecoveryState;
+  idempotencyKey?: string;
+  requestHash?: string;
+  sourceType?: string;
+  sourceRef?: string;
+  inputRef?: string;
+  checkpointRef?: string;
+  parentWorkflowRunId?: string;
+  parentStepId?: string;
+  messageId?: string;
+  turnId?: string;
+  metadata?: Record<string, unknown>;
+  now?: number;
+};
+
+export type AppendDurableWorkflowEventInput = {
+  workflowRunId: string;
+  eventId?: string;
+  eventType: string;
+  eventTime?: number;
+  stepId?: string;
+  agentInvocationId?: string;
+  toolInvocationId?: string;
+  idempotencyKey?: string;
+  payload?: Record<string, unknown>;
+  payloadHash?: string;
+  checkpointRef?: string;
+  causationEventId?: string;
+  correlationId?: string;
+};
+
+export type UpdateDurableWorkflowRunInput = {
+  workflowRunId: string;
+  status?: DurableWorkflowRunStatus;
+  recoveryState?: DurableRecoveryState;
+  completedAt?: number | null;
+  checkpointRef?: string | null;
+  claimedBy?: string | null;
+  claimExpiresAt?: number | null;
+  heartbeatAt?: number | null;
+  metadata?: Record<string, unknown>;
+  now?: number;
+};
+
+export type CreateDurableWorkflowStepInput = {
+  workflowRunId: string;
+  stepId?: string;
+  parentStepId?: string;
+  stepType: DurableWorkflowStepType;
+  status?: DurableWorkflowStepStatus;
+  recoveryState?: DurableRecoveryState;
+  attempt?: number;
+  maxAttempts?: number;
+  idempotencyKey?: string;
+  inputRef?: string;
+  outputRef?: string;
+  errorRef?: string;
+  checkpointRef?: string;
+  metadata?: Record<string, unknown>;
+  now?: number;
+};
+
+export type UpdateDurableWorkflowStepInput = {
+  workflowRunId: string;
+  stepId: string;
+  status?: DurableWorkflowStepStatus;
+  recoveryState?: DurableRecoveryState;
+  attempt?: number;
+  maxAttempts?: number | null;
+  inputRef?: string | null;
+  outputRef?: string | null;
+  errorRef?: string | null;
+  checkpointRef?: string | null;
+  claimedBy?: string | null;
+  claimExpiresAt?: number | null;
+  heartbeatAt?: number | null;
+  startedAt?: number | null;
+  completedAt?: number | null;
+  metadata?: Record<string, unknown>;
+  now?: number;
+};
+
+export type CreateDurableWorkflowRefInput = {
+  refId?: string;
+  workflowRunId: string;
+  stepId?: string;
+  refKind: DurableWorkflowRefKind;
+  mediaType?: string;
+  hash?: string;
+  storageKind?: "inline" | "file" | "external";
+  storageUri?: string;
+  metadata?: Record<string, unknown>;
+  now?: number;
+};
+
+export type CreateDurableWorkflowLinkInput = {
+  parentWorkflowRunId: string;
+  parentStepId: string;
+  childWorkflowRunId: string;
+  linkType: DurableWorkflowLinkType;
+  status?: DurableWorkflowLinkStatus;
+  metadata?: Record<string, unknown>;
+  now?: number;
+};
+
+export type UpdateDurableWorkflowLinkInput = {
+  parentWorkflowRunId: string;
+  parentStepId: string;
+  childWorkflowRunId: string;
+  status?: DurableWorkflowLinkStatus;
+  metadata?: Record<string, unknown>;
+  now?: number;
+};
+
+export type CreateDurableWorkflowTimerInput = {
+  timerId?: string;
+  workflowRunId: string;
+  stepId?: string;
+  timerType: DurableWorkflowTimer["timerType"];
+  dueAt: number;
+  metadata?: Record<string, unknown>;
+  now?: number;
+};
+
+export type UpdateDurableWorkflowTimerInput = {
+  timerId: string;
+  status: DurableWorkflowTimerStatus;
+  firedAt?: number | null;
+  cancelledAt?: number | null;
+  now?: number;
+};
+
+export type CreateDurableWorkflowSignalInput = {
+  signalId?: string;
+  workflowRunId: string;
+  stepId?: string;
+  signalType: DurableWorkflowSignal["signalType"];
+  idempotencyKey?: string;
+  payloadRef?: string;
+  correlationId?: string;
+  metadata?: Record<string, unknown>;
+  now?: number;
+};
+
+export type ClaimDurableWorkflowRunInput = {
+  workflowId?: string;
+  workerId: string;
+  claimTtlMs: number;
+  now?: number;
+};
+
+export type ClaimDurableWorkflowStepInput = {
+  workflowId?: string;
+  stepType?: DurableWorkflowStepType;
+  workerId: string;
+  claimTtlMs: number;
+  now?: number;
+};
+
+export type DurableWorkflowStoreStats = {
+  path: string;
+  runs: number;
+  events: number;
+  steps: number;
+  openRuns: number;
+};
+
+export type DurableWorkflowStore = {
+  createRun(input: CreateDurableWorkflowRunInput): DurableWorkflowRun;
+  getRun(workflowRunId: string): DurableWorkflowRun | undefined;
+  updateRun(input: UpdateDurableWorkflowRunInput): DurableWorkflowRun | undefined;
+  appendEvent(input: AppendDurableWorkflowEventInput): DurableWorkflowEvent;
+  listRuns(options?: { limit?: number }): DurableWorkflowRun[];
+  listOpenRuns(options?: { workflowId?: string; limit?: number }): DurableWorkflowRun[];
+  claimNextRunnableRun(input: ClaimDurableWorkflowRunInput): DurableWorkflowRun | undefined;
+  releaseRunClaim(input: {
+    workflowRunId: string;
+    workerId: string;
+    now?: number;
+  }): DurableWorkflowRun | undefined;
+  createStep(input: CreateDurableWorkflowStepInput): DurableWorkflowStep;
+  updateStep(input: UpdateDurableWorkflowStepInput): DurableWorkflowStep | undefined;
+  claimNextRunnableStep(input: ClaimDurableWorkflowStepInput): DurableWorkflowStep | undefined;
+  releaseStepClaim(input: {
+    workflowRunId: string;
+    stepId: string;
+    workerId: string;
+    now?: number;
+  }): DurableWorkflowStep | undefined;
+  listSteps(workflowRunId: string): DurableWorkflowStep[];
+  createRef(input: CreateDurableWorkflowRefInput): DurableWorkflowRef;
+  getRef(refId: string): DurableWorkflowRef | undefined;
+  listRefs(workflowRunId: string): DurableWorkflowRef[];
+  createLink(input: CreateDurableWorkflowLinkInput): DurableWorkflowLink;
+  updateLink(input: UpdateDurableWorkflowLinkInput): DurableWorkflowLink | undefined;
+  listChildLinks(parentWorkflowRunId: string): DurableWorkflowLink[];
+  listParentLinks(childWorkflowRunId: string): DurableWorkflowLink[];
+  createTimer(input: CreateDurableWorkflowTimerInput): DurableWorkflowTimer;
+  updateTimer(input: UpdateDurableWorkflowTimerInput): DurableWorkflowTimer | undefined;
+  listTimers(workflowRunId?: string): DurableWorkflowTimer[];
+  listDueTimers(now: number, options?: { limit?: number }): DurableWorkflowTimer[];
+  createSignal(input: CreateDurableWorkflowSignalInput): DurableWorkflowSignal;
+  consumeSignal(input: { signalId: string; now?: number }): DurableWorkflowSignal | undefined;
+  listPendingSignals(options?: { limit?: number }): DurableWorkflowSignal[];
+  listSignals(workflowRunId: string): DurableWorkflowSignal[];
+  getTimeline(workflowRunId: string): DurableWorkflowEvent[];
+  getStats(): DurableWorkflowStoreStats;
+  close(): void;
+};

--- a/src/durable/workflow-ids.ts
+++ b/src/durable/workflow-ids.ts
@@ -1,0 +1,2 @@
+export const DURABLE_AGENT_TURN_WORKFLOW_ID = "openclaw.agent.turn";
+export const DURABLE_SUBAGENT_RUN_WORKFLOW_ID = "openclaw.subagent.run";


### PR DESCRIPTION
## Summary

This PR adds the native durable workflow kernel primitives.

It introduces:

- durable workflow run, step, event, ref, link, timer, and signal types;
- SQLite local-first store;
- run and step claims;
- timer and signal recovery primitives;
- fan-in helper;
- in-process workflow registry;
- one-shot durable executor for registered safe step handlers.

## Why

This creates the minimal native kernel needed before OpenClaw can make long-running agent work restart-visible, retryable, and resumable.

## Stack Note

This is PR 2 in the durable core stack and should be reviewed after PR 1.

GitHub may show cumulative diff until PR 1 is merged because the branch is pushed from a fork and the upstream repository does not allow branch bases for this stack.

Incremental branch:

- `mjnkao:codex/openclaw-x-durable-pr2-core-kernel`

## Validation

- `npm test -- --run src/durable src/gateway/server-methods/durable.test.ts extensions/workboard/src/gateway.test.ts extensions/workboard/src/store.test.ts`
- `npm run tsgo:core`
- `npm run build`
