### PR TITLE
fix(line): truncate action fields on code-point boundaries

### DIFF
--- a/extensions/line/src/actions.ts
+++ b/extensions/line/src/actions.ts
@@ -3,6 +3,16 @@ import type { messagingApi } from "@line/bot-sdk";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 
 export type Action = messagingApi.Action;
+export const LINE_ACTION_LABEL_LIMIT = 20;
+export const LINE_ACTION_DATA_LIMIT = 300;
+
+export function truncateLineActionLabel(label: string, limit = LINE_ACTION_LABEL_LIMIT): string {
+  return truncateUtf16Safe(label, limit);
+}
+
+export function truncateLineActionData(data: string): string {
+  return truncateUtf16Safe(data, LINE_ACTION_DATA_LIMIT);
+}
 
 /**
  * Create a message action (sends text when tapped)
@@ -10,7 +20,7 @@ export type Action = messagingApi.Action;
 export function messageAction(label: string, text?: string): Action {
   return {
     type: "message",
-    label: truncateUtf16Safe(label, 20),
+    label: truncateLineActionLabel(label),
     text: text ?? label,
   };
 }
@@ -21,7 +31,7 @@ export function messageAction(label: string, text?: string): Action {
 export function uriAction(label: string, uri: string): Action {
   return {
     type: "uri",
-    label: truncateUtf16Safe(label, 20),
+    label: truncateLineActionLabel(label),
     uri,
   };
 }
@@ -32,9 +42,9 @@ export function uriAction(label: string, uri: string): Action {
 export function postbackAction(label: string, data: string, displayText?: string): Action {
   return {
     type: "postback",
-    label: truncateUtf16Safe(label, 20),
-    data: truncateUtf16Safe(data, 300),
-    displayText: displayText === undefined ? undefined : truncateUtf16Safe(displayText, 300),
+    label: truncateLineActionLabel(label),
+    data: truncateLineActionData(data),
+    displayText: displayText === undefined ? undefined : truncateLineActionData(displayText),
   };
 }
 
@@ -53,8 +63,8 @@ export function datetimePickerAction(
 ): Action {
   return {
     type: "datetimepicker",
-    label: truncateUtf16Safe(label, 20),
-    data: truncateUtf16Safe(data, 300),
+    label: truncateLineActionLabel(label),
+    data: truncateLineActionData(data),
     mode,
     initial: options?.initial,
     max: options?.max,

--- a/extensions/line/src/actions.ts
+++ b/extensions/line/src/actions.ts
@@ -1,5 +1,6 @@
 // Line plugin module implements actions behavior.
 import type { messagingApi } from "@line/bot-sdk";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 
 export type Action = messagingApi.Action;
 
@@ -9,7 +10,7 @@ export type Action = messagingApi.Action;
 export function messageAction(label: string, text?: string): Action {
   return {
     type: "message",
-    label: label.slice(0, 20),
+    label: truncateUtf16Safe(label, 20),
     text: text ?? label,
   };
 }
@@ -20,7 +21,7 @@ export function messageAction(label: string, text?: string): Action {
 export function uriAction(label: string, uri: string): Action {
   return {
     type: "uri",
-    label: label.slice(0, 20),
+    label: truncateUtf16Safe(label, 20),
     uri,
   };
 }
@@ -31,9 +32,9 @@ export function uriAction(label: string, uri: string): Action {
 export function postbackAction(label: string, data: string, displayText?: string): Action {
   return {
     type: "postback",
-    label: label.slice(0, 20),
-    data: data.slice(0, 300),
-    displayText: displayText?.slice(0, 300),
+    label: truncateUtf16Safe(label, 20),
+    data: truncateUtf16Safe(data, 300),
+    displayText: displayText === undefined ? undefined : truncateUtf16Safe(displayText, 300),
   };
 }
 
@@ -52,8 +53,8 @@ export function datetimePickerAction(
 ): Action {
   return {
     type: "datetimepicker",
-    label: label.slice(0, 20),
-    data: data.slice(0, 300),
+    label: truncateUtf16Safe(label, 20),
+    data: truncateUtf16Safe(data, 300),
     mode,
     initial: options?.initial,
     max: options?.max,

--- a/extensions/line/src/card-command.ts
+++ b/extensions/line/src/card-command.ts
@@ -2,6 +2,7 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { messageAction, postbackAction, uriAction } from "./actions.js";
 import {
   createActionCard,
   createImageCard,
@@ -62,22 +63,17 @@ function parseActions(actionsStr: string | undefined): CardAction[] {
     if (actionData.startsWith("http://") || actionData.startsWith("https://")) {
       results.push({
         label,
-        action: { type: "uri", label: label.slice(0, 20), uri: actionData },
+        action: uriAction(label, actionData),
       });
     } else if (actionData.includes("=")) {
       results.push({
         label,
-        action: {
-          type: "postback",
-          label: label.slice(0, 20),
-          data: actionData.slice(0, 300),
-          displayText: label,
-        },
+        action: postbackAction(label, actionData, label),
       });
     } else {
       results.push({
         label,
-        action: { type: "message", label: label.slice(0, 20), text: actionData },
+        action: messageAction(label, actionData),
       });
     }
   }

--- a/extensions/line/src/flex-templates/media-control-cards.ts
+++ b/extensions/line/src/flex-templates/media-control-cards.ts
@@ -1,4 +1,5 @@
 // Line plugin module implements media control cards behavior.
+import { truncateLineActionLabel } from "../actions.js";
 import type {
   FlexBox,
   FlexBubble,
@@ -233,7 +234,7 @@ export function createMediaPlayerCard(params: {
               type: "button",
               action: {
                 type: "postback",
-                label: action.label.slice(0, 15),
+                label: truncateLineActionLabel(action.label, 15),
                 data: action.data,
               },
               style: "secondary",
@@ -518,7 +519,7 @@ export function createDeviceControlCard(params: {
           type: "button",
           action: {
             type: "postback",
-            label: buttonLabel.slice(0, 18),
+            label: truncateLineActionLabel(buttonLabel, 18),
             data: ctrl.data,
           },
           style: ctrl.style ?? "secondary",

--- a/extensions/line/src/markdown-to-line.test.ts
+++ b/extensions/line/src/markdown-to-line.test.ts
@@ -8,6 +8,7 @@ import {
   processLineMessage,
   convertTableToFlexBubble,
   convertCodeBlockToFlexBubble,
+  convertLinksToFlexBubble,
   hasMarkdownToConvert,
 } from "./markdown-to-line.js";
 
@@ -129,6 +130,18 @@ describe("extractLinks", () => {
     expect(links[0]).toEqual({ text: "Google", url: "https://google.com" });
     expect(links[1]).toEqual({ text: "GitHub", url: "https://github.com" });
     expect(textWithLinks).toBe("Check out Google and GitHub.");
+  });
+});
+
+describe("convertLinksToFlexBubble", () => {
+  it("truncates link button labels without leaving lone surrogates", () => {
+    const bubble = convertLinksToFlexBubble([
+      { text: "1234567890123456789😀", url: "https://example.com" },
+    ]);
+    const footer = bubble.footer as { contents: Array<{ action: { label: string } }> };
+
+    expect(footer.contents[0].action.label).toBe("1234567890123456789");
+    expect(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/.test(footer.contents[0].action.label)).toBe(false);
   });
 });
 

--- a/extensions/line/src/markdown-to-line.ts
+++ b/extensions/line/src/markdown-to-line.ts
@@ -1,6 +1,7 @@
 // Line plugin module implements markdown to line behavior.
 import type { messagingApi } from "@line/bot-sdk";
 import { stripMarkdown } from "openclaw/plugin-sdk/text-chunking";
+import { uriAction } from "./actions.js";
 import { createReceiptCard, toFlexMessage, type FlexBubble } from "./flex-templates.js";
 export { stripMarkdown } from "openclaw/plugin-sdk/text-chunking";
 
@@ -305,11 +306,7 @@ export interface MarkdownLink {
 export function convertLinksToFlexBubble(links: MarkdownLink[]): FlexBubble {
   const buttons: FlexComponent[] = links.slice(0, 4).map((link, index) => ({
     type: "button",
-    action: {
-      type: "uri",
-      label: link.text.slice(0, 20), // LINE button label limit
-      uri: link.url,
-    },
+    action: uriAction(link.text, link.url),
     style: index === 0 ? "primary" : "secondary",
     margin: index > 0 ? "sm" : undefined,
   }));

--- a/extensions/line/src/message-cards.test.ts
+++ b/extensions/line/src/message-cards.test.ts
@@ -1,6 +1,7 @@
 // Line tests cover message cards plugin behavior.
 import { describe, expect, it } from "vitest";
 import { datetimePickerAction, postbackAction, uriAction } from "./actions.js";
+import { registerLineCardCommand } from "./card-command.js";
 import {
   createActionCard,
   createCarousel,
@@ -9,6 +10,7 @@ import {
   createImageCard,
   createInfoCard,
   createListCard,
+  createMediaPlayerCard,
 } from "./flex-templates.js";
 import {
   createConfirmTemplate,
@@ -338,4 +340,62 @@ describe("action label/data surrogate-safe truncation", () => {
     expect(action.data).toBe("d".repeat(299));
     expect(loneHighSurrogate.test(action.data)).toBe(false);
   });
+
+  it("/card action command uses surrogate-safe labels and postback data", async () => {
+    const registerCommand = (command: unknown) => {
+      const { handler } = command as {
+        handler: (ctx: { args: string; channel: string }) => Promise<unknown>;
+      };
+      return handler({
+        channel: "line",
+        args: `action "Menu" "Body" --actions "${labelWithEmoji}|k=${"d".repeat(297)}😀"`,
+      });
+    };
+    const result = (await registerCommandWithHandler(registerCommand)) as {
+      channelData: {
+        line: {
+          flexMessage: {
+            contents: { footer: { contents: Array<{ action: { label: string; data: string } }> } };
+          };
+        };
+      };
+    };
+    const action = result.channelData.line.flexMessage.contents.footer.contents[0].action;
+
+    expect(action.label).toBe("1234567890123456789");
+    expect(loneHighSurrogate.test(action.label)).toBe(false);
+    expect(action.data).toBe(`k=${"d".repeat(297)}`);
+    expect(loneHighSurrogate.test(action.data)).toBe(false);
+  });
+
+  it("media control postback labels truncate on surrogate boundaries", () => {
+    const card = createMediaPlayerCard({
+      title: "Track",
+      controls: {
+        play: { data: "play" },
+      },
+      extraActions: [{ label: `${"x".repeat(14)}😀`, data: "extra" }],
+    });
+    const footer = card.footer as {
+      contents: Array<{ contents?: Array<{ action?: { data?: string; label: string } }> }>;
+    };
+    const extraAction = footer.contents
+      .flatMap((content) => content.contents ?? [])
+      .find((button) => button.action?.data === "extra")?.action;
+
+    expect(extraAction?.label).toBe("x".repeat(14));
+    expect(loneHighSurrogate.test(extraAction?.label ?? "")).toBe(false);
+  });
 });
+
+async function registerCommandWithHandler(
+  runHandler: (command: unknown) => Promise<unknown>,
+): Promise<unknown> {
+  let result: unknown;
+  registerLineCardCommand({
+    registerCommand(command: unknown) {
+      result = runHandler(command);
+    },
+  } as never);
+  return result;
+}

--- a/extensions/line/src/message-cards.test.ts
+++ b/extensions/line/src/message-cards.test.ts
@@ -278,10 +278,10 @@ describe("action label/data surrogate-safe truncation", () => {
   const loneHighSurrogate = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])/;
   // 19 ASCII chars + 😀 (U+1F600, two UTF-16 code units) = 21 code units; a raw
   // .slice(0, 20) would keep the first 19 chars plus the lone high surrogate.
-  const labelWithEmoji = `${"1234567890123456789"}😀`;
+  const labelWithEmoji = "1234567890123456789😀";
 
   it("messageAction drops a half emoji instead of leaving a lone surrogate", () => {
-    const action = messageAction(labelWithEmoji);
+    const action = messageAction(labelWithEmoji) as { label: string };
 
     expect(action.label).toBe("1234567890123456789");
     expect(loneHighSurrogate.test(action.label)).toBe(false);
@@ -294,7 +294,7 @@ describe("action label/data surrogate-safe truncation", () => {
   });
 
   it("uriAction drops a half emoji instead of leaving a lone surrogate", () => {
-    const action = uriAction(labelWithEmoji, "https://example.com");
+    const action = uriAction(labelWithEmoji, "https://example.com") as { label: string };
 
     expect(action.label).toBe("1234567890123456789");
     expect(loneHighSurrogate.test(action.label)).toBe(false);

--- a/extensions/line/src/message-cards.test.ts
+++ b/extensions/line/src/message-cards.test.ts
@@ -1,5 +1,6 @@
 // Line tests cover message cards plugin behavior.
 import { describe, expect, it } from "vitest";
+import { datetimePickerAction, postbackAction, uriAction } from "./actions.js";
 import {
   createActionCard,
   createCarousel,
@@ -270,5 +271,71 @@ describe("flex cards", () => {
     expect(card.size).toBe("mega");
     const body = card.body as { contents: Array<{ type: string }> };
     expect(body.contents).toHaveLength(3);
+  });
+});
+
+describe("action label/data surrogate-safe truncation", () => {
+  const loneHighSurrogate = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])/;
+  // 19 ASCII chars + 😀 (U+1F600, two UTF-16 code units) = 21 code units; a raw
+  // .slice(0, 20) would keep the first 19 chars plus the lone high surrogate.
+  const labelWithEmoji = `${"1234567890123456789"}😀`;
+
+  it("messageAction drops a half emoji instead of leaving a lone surrogate", () => {
+    const action = messageAction(labelWithEmoji);
+
+    expect(action.label).toBe("1234567890123456789");
+    expect(loneHighSurrogate.test(action.label)).toBe(false);
+  });
+
+  it("messageAction leaves a short ASCII label unchanged", () => {
+    const action = messageAction("Yes");
+
+    expect(action.label).toBe("Yes");
+  });
+
+  it("uriAction drops a half emoji instead of leaving a lone surrogate", () => {
+    const action = uriAction(labelWithEmoji, "https://example.com");
+
+    expect(action.label).toBe("1234567890123456789");
+    expect(loneHighSurrogate.test(action.label)).toBe(false);
+  });
+
+  it("postbackAction truncates label and data on surrogate boundaries", () => {
+    // 299 ASCII chars + 😀 = 301 code units; the 300-unit slice cuts the emoji.
+    const data = `${"d".repeat(299)}😀`;
+    const action = postbackAction(labelWithEmoji, data) as {
+      label: string;
+      data: string;
+    };
+
+    expect(action.label).toBe("1234567890123456789");
+    expect(loneHighSurrogate.test(action.label)).toBe(false);
+    expect(action.data).toBe("d".repeat(299));
+    expect(loneHighSurrogate.test(action.data)).toBe(false);
+  });
+
+  it("postbackAction truncates displayText on surrogate boundaries but keeps undefined", () => {
+    const displayText = `${"t".repeat(299)}😀`;
+    const withDisplay = postbackAction("Label", "data", displayText) as {
+      displayText?: string;
+    };
+    const withoutDisplay = postbackAction("Label", "data") as { displayText?: string };
+
+    expect(withDisplay.displayText).toBe("t".repeat(299));
+    expect(loneHighSurrogate.test(withDisplay.displayText ?? "")).toBe(false);
+    expect(withoutDisplay.displayText).toBeUndefined();
+  });
+
+  it("datetimePickerAction truncates label and data on surrogate boundaries", () => {
+    const data = `${"d".repeat(299)}😀`;
+    const action = datetimePickerAction(labelWithEmoji, data, "datetime") as {
+      label: string;
+      data: string;
+    };
+
+    expect(action.label).toBe("1234567890123456789");
+    expect(loneHighSurrogate.test(action.label)).toBe(false);
+    expect(action.data).toBe("d".repeat(299));
+    expect(loneHighSurrogate.test(action.data)).toBe(false);
   });
 });

--- a/extensions/line/src/send.test.ts
+++ b/extensions/line/src/send.test.ts
@@ -156,6 +156,16 @@ describe("LINE send helpers", () => {
     expect(quickReply.items).toHaveLength(13);
   });
 
+  it("truncates quick reply labels without leaving lone surrogates", () => {
+    const label = "1234567890123456789😀";
+    const quickReply = sendModule.createQuickReplyItems([label]);
+    const item = quickReply.items?.[0] as { action: { label: string; text: string } } | undefined;
+
+    expect(item?.action.label).toBe("1234567890123456789");
+    expect(item?.action.text).toBe(label);
+    expect(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/.test(item?.action.label ?? "")).toBe(false);
+  });
+
   it("pushes images via normalized LINE target", async () => {
     const result = await sendModule.pushImageMessage(
       "line:user:U123",

--- a/extensions/line/src/send.ts
+++ b/extensions/line/src/send.ts
@@ -5,6 +5,7 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { requireRuntimeConfig } from "openclaw/plugin-sdk/plugin-config-runtime";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { resolveLineAccount } from "./accounts.js";
+import { messageAction } from "./actions.js";
 import { resolveLineChannelAccessToken } from "./channel-access-token.js";
 import { validateLineMediaUrl } from "./outbound-media.js";
 import { createLineSendReceipt } from "./send-receipt.js";
@@ -454,11 +455,7 @@ export async function pushTextMessageWithQuickReplies(
 export function createQuickReplyItems(labels: string[]): QuickReply {
   const items: QuickReplyItem[] = labels.slice(0, 13).map((label) => ({
     type: "action",
-    action: {
-      type: "message",
-      label: label.slice(0, 20),
-      text: label,
-    },
+    action: messageAction(label, label),
   }));
   return { items };
 }


### PR DESCRIPTION
## What Problem This Solves

LINE action labels/data used raw UTF-16 slicing. When an emoji or other astral character landed on the LINE field limit boundary, the outgoing action payload could contain a dangling surrogate half.

## Why This Change Was Made

The LINE action builders now use the existing plugin SDK `truncateUtf16Safe` helper for label/data/displayText fields while preserving the existing 20 and 300 code-unit limits.

## User Impact

LINE actions with long labels or postback data containing emoji no longer produce malformed text at truncation boundaries.

## Evidence

- git diff --check origin/main...HEAD
- node scripts/run-vitest.mjs extensions/line/src/message-cards.test.ts
- .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main

Autoreview result: clean; no accepted/actionable findings.

## After-fix Proof

Boundary probe on this PR branch:

```json
{
  "usesSafeTruncate": true,
  "label": "1234567890123456789",
  "dataLength": 299,
  "labelHasLoneSurrogate": false,
  "dataHasLoneSurrogate": false
}
```

The probe places an emoji across the 20-unit LINE label limit and 300-unit postback data limit. Both are truncated without leaving a lone UTF-16 surrogate.
