### PR TITLE
fix(matrix): truncate reply context on code-point boundaries

### DIFF
--- a/extensions/matrix/src/matrix/monitor/reply-context.test.ts
+++ b/extensions/matrix/src/matrix/monitor/reply-context.test.ts
@@ -39,6 +39,30 @@ describe("matrix reply context", () => {
     expect(result.endsWith("...")).toBe(true);
   });
 
+  it("truncates on a code-point boundary without orphaning a surrogate half", () => {
+    // Body is 496 'a' + 😀 (U+1F600, a surrogate pair at UTF-16 indices 496-497)
+    // + "bcd". Raw `.slice(0, 497)` would split the emoji and leave a lone high
+    // surrogate (\uD83D) before the ellipsis. The fix must drop the half emoji.
+    const body = `${"a".repeat(496)}😀bcd`;
+    expect(body.length).toBe(501);
+    const result = summarizeMatrixReplyEvent({
+      event_id: "$original",
+      sender: "@alice:example.org",
+      type: "m.room.message",
+      origin_server_ts: Date.now(),
+      content: {
+        msgtype: "m.text",
+        body,
+      },
+    } as MatrixRawEvent);
+    if (result === undefined) {
+      throw new Error("expected truncated reply context");
+    }
+    expect(result).toBe(`${"a".repeat(496)}...`);
+    // No dangling high surrogate should survive the truncation.
+    expect(result.includes("\uD83D")).toBe(false);
+  });
+
   it("handles media-only reply events", () => {
     expect(
       summarizeMatrixReplyEvent({

--- a/extensions/matrix/src/matrix/monitor/reply-context.ts
+++ b/extensions/matrix/src/matrix/monitor/reply-context.ts
@@ -1,4 +1,5 @@
 // Matrix plugin module implements reply context behavior.
+import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { MatrixClient } from "../sdk.js";
 import { summarizeMatrixMessageContextEvent, trimMatrixMaybeString } from "./context-summary.js";
 import type { MatrixRawEvent } from "./types.js";
@@ -16,7 +17,7 @@ function truncateReplyBody(value: string): string {
   if (value.length <= MAX_REPLY_BODY_LENGTH) {
     return value;
   }
-  return `${value.slice(0, MAX_REPLY_BODY_LENGTH - 3)}...`;
+  return `${sliceUtf16Safe(value, 0, MAX_REPLY_BODY_LENGTH - 3)}...`;
 }
 
 export function summarizeMatrixReplyEvent(event: MatrixRawEvent): string | undefined {


### PR DESCRIPTION
## What Problem This Solves

Matrix reply context truncation used raw UTF-16 slicing. If an emoji or other astral character straddled the reply-context limit, the quoted context could contain a dangling surrogate half before the ellipsis.

## Why This Change Was Made

The Matrix reply-context truncation now uses the existing plugin SDK `sliceUtf16Safe` helper, preserving the existing 500-code-unit cap while avoiding malformed text at the truncation boundary.

## User Impact

Matrix reply context shown to agents no longer includes replacement characters or malformed text when long messages with emoji are truncated.

## Evidence

- git diff --check origin/main...HEAD
- node scripts/run-vitest.mjs extensions/matrix/src/matrix/monitor/reply-context.test.ts
- .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main

Autoreview result: clean; no accepted/actionable findings.

## After-fix Proof

Boundary probe on this PR branch:

```json
{
  "usesSafeSlice": true,
  "inputLength": 501,
  "outputLength": 499,
  "hasLoneSurrogate": false,
  "outputTail": "aaa..."
}
```

The probe places an emoji across the 497-code-unit slice boundary before the ellipsis. The after-fix output drops the emoji whole and leaves no lone UTF-16 surrogate.
