### PR TITLE
fix(mattermost): truncate draft previews on code-point boundaries

### DIFF
--- a/extensions/mattermost/src/mattermost/draft-stream.test.ts
+++ b/extensions/mattermost/src/mattermost/draft-stream.test.ts
@@ -205,6 +205,31 @@ describe("createMattermostDraftStream", () => {
     expect(stream.postId()).toBeUndefined();
   });
 
+  it("truncates on a code-point boundary so a straddling emoji is dropped whole", async () => {
+    const { client, calls } = createMockClient();
+    // maxChars=12 => cut point is maxChars-3=9. The emoji 😀 occupies UTF-16
+    // indices 8-9, so a raw slice(0,9) would keep the lone high surrogate at
+    // index 8 and drop its low surrogate at index 9, leaking a dangling half.
+    const stream = createMattermostDraftStream({
+      client,
+      channelId: "channel-1",
+      throttleMs: 0,
+      maxChars: 12,
+    });
+
+    const input = `${"a".repeat(8)}\u{1F600}${"b".repeat(5)}`;
+    stream.update(input);
+    await stream.flush();
+
+    expect(calls).toHaveLength(1);
+    const message = parseRequestJson(calls[0]?.init).message;
+    expect(typeof message).toBe("string");
+    const sent = message as string;
+    // The straddling emoji must be dropped whole, leaving no dangling surrogate half.
+    expect(/[\uD800-\uDFFF]/u.test(sent)).toBe(false);
+    expect(sent).toBe("aaaaaaaa...");
+  });
+
   it("does not resend after an update failure followed by stop", async () => {
     const warn = vi.fn();
     const calls: RequestRecord[] = [];

--- a/extensions/mattermost/src/mattermost/draft-stream.test.ts
+++ b/extensions/mattermost/src/mattermost/draft-stream.test.ts
@@ -227,6 +227,7 @@ describe("createMattermostDraftStream", () => {
     const sent = message as string;
     // The straddling emoji must be dropped whole, leaving no dangling surrogate half.
     expect(/[\uD800-\uDFFF]/u.test(sent)).toBe(false);
+    expect(sent.length).toBeLessThanOrEqual(12);
     expect(sent).toBe("aaaaaaaa...");
   });
 

--- a/extensions/mattermost/src/mattermost/draft-stream.ts
+++ b/extensions/mattermost/src/mattermost/draft-stream.ts
@@ -1,5 +1,6 @@
 // Mattermost plugin module implements draft stream behavior.
 import { createFinalizableDraftLifecycle } from "openclaw/plugin-sdk/channel-outbound";
+import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import {
   createMattermostPost,
   deleteMattermostPost,
@@ -29,7 +30,7 @@ function normalizeMattermostDraftText(text: string, maxChars: number): string {
   if (trimmed.length <= maxChars) {
     return trimmed;
   }
-  return `${trimmed.slice(0, Math.max(0, maxChars - 3)).trimEnd()}...`;
+  return `${sliceUtf16Safe(trimmed, 0, Math.max(0, maxChars - 3)).trimEnd()}...`;
 }
 
 export function createMattermostDraftStream(params: {


### PR DESCRIPTION
## What Problem This Solves

Mattermost draft preview truncation used raw UTF-16 slicing. If an emoji or other astral character straddled the draft preview limit, the draft update could contain a dangling surrogate half before the ellipsis.

## Why This Change Was Made

The Mattermost draft text normalizer now uses the existing plugin SDK `sliceUtf16Safe` helper while preserving the existing max-character cap and trailing ellipsis behavior.

## User Impact

Long Mattermost draft updates containing emoji no longer produce malformed replacement characters at truncation boundaries.

## Evidence

- git diff --check origin/main...HEAD
- node scripts/run-vitest.mjs extensions/mattermost/src/mattermost/draft-stream.test.ts
- .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main

Autoreview result: clean; no accepted/actionable findings.

## After-fix Proof

Boundary probe on this PR branch:

```json
{
  "usesSafeSlice": true,
  "output": "aaaaaaaa...",
  "outputLength": 11,
  "hasLoneSurrogate": false
}
```

The probe places an emoji across the `maxChars - 3` slice boundary. The after-fix output drops the emoji whole and leaves no lone UTF-16 surrogate.
