### PR TITLE
fix(agents): use numeric-aware collation for alias model resolution (#96588)

### DIFF
--- a/src/agents/sessions/model-resolver.test.ts
+++ b/src/agents/sessions/model-resolver.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest";
 import type { Model } from "../../llm/types.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../defaults.js";
 import type { ModelRegistry } from "./model-registry.js";
-import { findInitialModel, restoreModelFromSession } from "./model-resolver.js";
+import { findInitialModel, parseModelPattern, restoreModelFromSession } from "./model-resolver.js";
 
 function model(provider: string, id: string): Model {
   return {
@@ -55,5 +55,38 @@ describe("model resolver fallback selection", () => {
     );
 
     expect(result.model).toBe(firstAvailable);
+  });
+});
+
+describe("parseModelPattern alias ordering", () => {
+  it("picks the numerically newest version when an alias hits double-digit minors (#96588)", () => {
+    // Plain localeCompare would order `4-9` above `4-10` because the digit
+    // `9` ranks above `1` lexicographically. Numeric-aware collation keeps
+    // the numerically newer version on top.
+    const v9 = model("anthropic", "claude-opus-4-9");
+    const v10 = model("anthropic", "claude-opus-4-10");
+    const result = parseModelPattern("opus", [v9, v10]);
+
+    expect(result.model).toBe(v10);
+  });
+
+  it("picks the numerically newest version regardless of input order", () => {
+    // Test lists in both orderings to prove the comparator (not list order)
+    // is responsible for the result.
+    const v9 = model("anthropic", "claude-opus-4-9");
+    const v10 = model("anthropic", "claude-opus-4-10");
+    const reversed = parseModelPattern("opus", [v10, v9]);
+
+    expect(reversed.model).toBe(v10);
+  });
+
+  it("keeps single-digit behavior unchanged (regression guard)", () => {
+    // Today's shipped catalogs use single-digit minors where text and numeric
+    // order agree; the fix must not change the existing selection.
+    const v7 = model("anthropic", "claude-opus-4-7");
+    const v8 = model("anthropic", "claude-opus-4-8");
+    const result = parseModelPattern("opus", [v7, v8]);
+
+    expect(result.model).toBe(v8);
   });
 });

--- a/src/agents/sessions/model-resolver.ts
+++ b/src/agents/sessions/model-resolver.ts
@@ -114,13 +114,21 @@ function tryMatchModel(modelPattern: string, availableModels: Model[]): Model | 
   const aliases = matches.filter((m) => isAlias(m.id));
   const datedVersions = matches.filter((m) => !isAlias(m.id));
 
+  // Numeric-aware collation so version-suffixed ids like `claude-opus-4-10`
+  // sort above `claude-opus-4-9`. Plain localeCompare treats digits as text,
+  // so `9` ranks above `10` once a family crosses into double-digit minors.
+  // Dated `-YYYYMMDD` suffixes are fixed-width so text and numeric order
+  // agree today, but using the same comparator keeps the contract consistent.
+  const numericSort = (a: Model, b: Model) =>
+    b.id.localeCompare(a.id, undefined, { numeric: true });
+
   if (aliases.length > 0) {
     // Prefer alias - if multiple aliases, pick the one that sorts highest
-    aliases.sort((a, b) => b.id.localeCompare(a.id));
+    aliases.sort(numericSort);
     return aliases[0];
   }
   // No alias found, pick latest dated version
-  datedVersions.sort((a, b) => b.id.localeCompare(a.id));
+  datedVersions.sort(numericSort);
   return datedVersions[0];
 }
 


### PR DESCRIPTION
## What Problem This Solves

Closes #96588.

`tryMatchModel` in `src/agents/sessions/model-resolver.ts` orders alias-candidate model ids with plain `b.id.localeCompare(a.id)`. Plain `localeCompare` compares digit runs as text, so `9` ranks above `10`. Once a model family crosses into double-digit minor versions, the alias resolver silently selects the older version:

```
parseModelPattern(\"opus\", [claude-opus-4-9, claude-opus-4-10])
  → claude-opus-4-9   (expected: claude-opus-4-10)
```

This is latent today (no shipped family has double-digit minor versions yet) but will silently mis-resolve the moment one ships.

## Why This Change Was Made

Pass `{ numeric: true }` to `localeCompare` so digit runs in the id sort by numeric value. This is the narrowest fix — no config surface, no provider policy, no catalog changes. The fix applies to both comparators in `tryMatchModel`:

- Alias bucket (the live risk): version-suffixed ids like `claude-opus-4-10` land here because `isAlias` only treats 8-digit `-YYYYMMDD` suffixes as dated.
- Dated-version bucket: fixed-width `-YYYYMMDD` suffixes where text and numeric order already coincide today, but using the same comparator keeps the contract consistent.

`grep` for `localeCompare` on model ids returns only these two lines, so the fix is complete.

## User Impact

- `/model opus`, scope patterns, and CLI `--model opus` keep working exactly as today for single-digit families.
- The first time a family ships a double-digit minor (e.g. a hypothetical `claude-opus-4-10` next to `claude-opus-4-9`), the alias resolver picks the newer version instead of silently sticking with the older one.
- No behavior change for dated `-YYYYMMDD` suffixes — fixed-width text and numeric order agree.

## Evidence

```
$ node scripts/run-vitest.mjs src/agents/sessions/model-resolver.test.ts
Test Files  1 passed (1)
     Tests  5 passed (5)
```

Regression coverage added in `model-resolver.test.ts::parseModelPattern alias ordering`:

- `picks the numerically newest version when an alias hits double-digit minors (#96588)` — `parseModelPattern(\"opus\", [v4-9, v4-10])` resolves to `v4-10`
- `picks the numerically newest version regardless of input order` — same result with reversed input list, proving the comparator (not list order) drives selection
- `keeps single-digit behavior unchanged (regression guard)` — `parseModelPattern(\"opus\", [v4-7, v4-8])` still resolves to `v4-8`

### Real-behavior proof

Driving the real exported `parseModelPattern` against a synthetic two-version list mirrors the first double-digit rollover. Pre-fix (`origin/main`), `claude-opus-4-9` is selected; post-fix, `claude-opus-4-10` is selected.

The issue body notes no shipped model family currently exposes a double-digit minor; the bug is forward-looking and was reproduced only against the real resolver with a synthetic list, not against a live provider catalog.

### Touched surface

- `src/agents/sessions/model-resolver.ts` — `tryMatchModel` comparators (lines 119 and 123 in the original source) gain `{ numeric: true }`.
- `src/agents/sessions/model-resolver.test.ts` — new `parseModelPattern alias ordering` describe block with three focused regression tests.