### PR TITLE
SSE parser double-prefixes `data:` causing JSON parse failures with custom OpenAI-compatible gateways.

### DIFF
--- a/src/agents/provider-transport-fetch.test.ts
+++ b/src/agents/provider-transport-fetch.test.ts
@@ -1193,6 +1193,40 @@ describe("buildGuardedModelFetch", () => {
     expect(items).toEqual([{ ok: true }]);
   });
 
+  it("passes through already-SSE-formatted bodies returned with application/json content-type", async () => {
+    // Regression: some OpenAI-compatible gateways return application/json content-type
+    // with SSE-formatted body (data: {...}\n\n). The JSON synthesis path must not
+    // double-wrap the data: prefix. (#96497)
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response('data: {"ok": true}\n\n', {
+        headers: { "content-type": "application/json; charset=utf-8" },
+      }),
+      finalUrl: "https://custom-gateway.example.com/v1/chat/completions",
+      release: vi.fn(async () => undefined),
+    });
+    const model = {
+      id: "minimax-m3",
+      provider: "hetu",
+      api: "openai-completions",
+      baseUrl: "https://custom-gateway.example.com/v1",
+    } as unknown as Model<"openai-completions">;
+
+    const response = await buildGuardedModelFetch(model)(
+      "https://custom-gateway.example.com/v1/chat/completions",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ model: "minimax-m3", stream: true }),
+      },
+    );
+    const items = [];
+    for await (const item of Stream.fromSSEResponse(response, new AbortController())) {
+      items.push(item);
+    }
+
+    expect(items).toEqual([{ ok: true }]);
+  });
+
   it("does not clone Request bodies while checking for streaming JSON fallbacks", async () => {
     const cloneSpy = vi.spyOn(Request.prototype, "clone");
     fetchWithSsrFGuardMock.mockResolvedValue({

--- a/src/agents/provider-transport-fetch.ts
+++ b/src/agents/provider-transport-fetch.ts
@@ -126,7 +126,15 @@ function sanitizeOpenAISdkSseResponse(
               buffer += decoder.decode();
               const data = buffer.trim();
               if (data) {
-                controller.enqueue(encoder.encode(`data: ${data}\n\n`));
+                // Guard against double-wrapping: some OpenAI-compatible gateways
+                // return application/json content-type with SSE-formatted body
+                // (data: {...}\n\n). If the body already starts with an SSE field,
+                // pass it through as-is instead of prefixing another data: wrapper.
+                if (/^(?::|(?:data|event|id|retry)(?::|[\r\n]))/mu.test(data)) {
+                  controller.enqueue(encoder.encode(`${data}\n\n`));
+                } else {
+                  controller.enqueue(encoder.encode(`data: ${data}\n\n`));
+                }
               }
               controller.enqueue(encoder.encode("data: [DONE]\n\n"));
               controller.close();


### PR DESCRIPTION
**## Summary

Fixes #96497 — SSE parser double-prefixes `data:` causing JSON parse failures with custom OpenAI-compatible gateways.

## Root cause

Some OpenAI-compatible gateways return `application/json` content-type with SSE-formatted body content (`data: {...}\n\n`). The `sanitizeOpenAISdkSseResponse` JSON-to-SSE synthesis path unconditionally wrapped the body in a `data:` prefix before passing it to the OpenAI SDK's SSEDecoder.

For a response body like:
```
data: {"id":"123","choices":[...]}
```

The synthesis would produce:
```
data: data: {"id":"123","choices":[...]}
```

The SDK's SSEDecoder partitions on the first `:`, treating `data` as fieldname and ` data: {"id":"123",...}` as value. After stripping the leading space, `sse.data` becomes `data: {"id":"123",...}`, which `JSON.parse` rejects with:

```
Unexpected token 'd', "data: {"id"... is not valid JSON
```

This is a **regression** — the same setup works in OpenClaw 2026.5.4 and earlier.

## Fix

In the JSON synthesis path of `sanitizeOpenAISdkSseResponse`, detect whether the response body already starts with an SSE field (`data`, `event`, `id`, `retry`, or `:`) using the same regex used by `classifyOpenAISdkStreamBodyPrefix`. If the body is already SSE-formatted, pass it through as-is instead of double-wrapping it.

### Before
```ts
buffer += decoder.decode();
const data = buffer.trim();
if (data) {
  controller.enqueue(encoder.encode(`data: ${data}\n\n`));
}
```

### After
```ts
buffer += decoder.decode();
const data = buffer.trim();
if (data) {
  // Guard against double-wrapping: some gateways return
  // application/json content-type with SSE-formatted body.
  if (/^(?::|(?:data|event|id|retry)(?::|[\r\n]))/mu.test(data)) {
    controller.enqueue(encoder.encode(`${data}\n\n`));
  } else {
    controller.enqueue(encoder.encode(`data: ${data}\n\n`));
  }
}
```

## Testing

- **New regression test**: `passes through already-SSE-formatted bodies returned with application/json content-type` — reproduces the exact error pattern from #96497 (`Could not parse message into JSON: data: {...}`, `From chunk: ['data: data: {...}']`) and verifies the fix.
- **154/154** tests in `provider-transport-fetch.test.ts` pass
- **560/560** tests in `openai-transport-stream.test.ts` pass

## Affected versions

- **Broken**: OpenClaw 2026.6.x
- **Works**: OpenClaw 2026.5.4 and earlier

## Impact

All users with custom/self-hosted OpenAI-compatible gateways using `openai-completions` API whose gateway returns `application/json` content-type (or missing content-type that gets sniffed as JSON) for streaming responses. The agent run fails **before producing any reply** (`isError=true`).
**
