### PR TITLE
fix(cron): suppress stream-error placeholder echo in fallback delivery

### DIFF
--- a/src/agents/stream-message-shared.test.ts
+++ b/src/agents/stream-message-shared.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import {
   STREAM_ERROR_FALLBACK_TEXT,
   buildStreamErrorAssistantMessage,
+  isStreamErrorPlaceholderOnlyText,
 } from "./stream-message-shared.js";
 
 const model = {
@@ -41,5 +42,48 @@ describe("buildStreamErrorAssistantMessage", () => {
     expect(message.content).toEqual([{ type: "text", text: STREAM_ERROR_FALLBACK_TEXT }]);
     // Original errorMessage is preserved verbatim for clients that surface it.
     expect(message.errorMessage).toBe("   ");
+  });
+});
+
+describe("isStreamErrorPlaceholderOnlyText", () => {
+  it("matches a single placeholder occurrence", () => {
+    expect(isStreamErrorPlaceholderOnlyText(STREAM_ERROR_FALLBACK_TEXT)).toBe(true);
+  });
+
+  it("matches a single placeholder with surrounding whitespace", () => {
+    expect(isStreamErrorPlaceholderOnlyText(`   ${STREAM_ERROR_FALLBACK_TEXT}\n`)).toBe(true);
+  });
+
+  it("matches many placeholder repetitions separated by newlines", () => {
+    // Mirrors the #97357 repro: fallback model echoed the sentinel 43 times.
+    const repeated = Array.from({ length: 43 }, () => STREAM_ERROR_FALLBACK_TEXT).join("\n");
+    expect(isStreamErrorPlaceholderOnlyText(repeated)).toBe(true);
+  });
+
+  it("matches placeholder repetitions separated by mixed whitespace", () => {
+    const repeated = `${STREAM_ERROR_FALLBACK_TEXT} \n  ${STREAM_ERROR_FALLBACK_TEXT}\t${STREAM_ERROR_FALLBACK_TEXT}`;
+    expect(isStreamErrorPlaceholderOnlyText(repeated)).toBe(true);
+  });
+
+  it("rejects undefined, empty, and whitespace-only text", () => {
+    expect(isStreamErrorPlaceholderOnlyText(undefined)).toBe(false);
+    expect(isStreamErrorPlaceholderOnlyText("")).toBe(false);
+    expect(isStreamErrorPlaceholderOnlyText("   \n\t")).toBe(false);
+  });
+
+  it("rejects text that merely mentions the placeholder", () => {
+    expect(isStreamErrorPlaceholderOnlyText(`I got: ${STREAM_ERROR_FALLBACK_TEXT}`)).toBe(false);
+  });
+
+  it("rejects text that mixes the placeholder with other content", () => {
+    // Even when the placeholder dominates, any non-placeholder content
+    // disqualifies the text — we never suppress a real recovery by mistake.
+    const mixed = `${STREAM_ERROR_FALLBACK_TEXT}\nSorry, let me try again.${STREAM_ERROR_FALLBACK_TEXT}`;
+    expect(isStreamErrorPlaceholderOnlyText(mixed)).toBe(false);
+  });
+
+  it("rejects unrelated text", () => {
+    expect(isStreamErrorPlaceholderOnlyText("HEARTBEAT_OK")).toBe(false);
+    expect(isStreamErrorPlaceholderOnlyText("[assistant turn failed]")).toBe(false);
   });
 });

--- a/src/agents/stream-message-shared.ts
+++ b/src/agents/stream-message-shared.ts
@@ -94,6 +94,51 @@ export function buildAssistantMessageWithZeroUsage(params: {
 // to a live stream-error turn (and the repair pass remains idempotent).
 export const STREAM_ERROR_FALLBACK_TEXT = "[assistant turn failed before producing content]";
 
+// Whitespace is the only plausible separator between repeated placeholder
+// occurrences. The placeholder itself contains internal spaces, so we compare
+// a whitespace-stripped copy of the input against a whitespace-stripped copy
+// of the constant — that turns "N copies with arbitrary whitespace between
+// them" into a clean integer-multiple check.
+const STREAM_ERROR_PLACEHOLDER_COMPACT = STREAM_ERROR_FALLBACK_TEXT.replace(/\s+/g, "");
+
+/**
+ * Detect text made up entirely of stream-error placeholder repetitions.
+ *
+ * When a primary model fails mid-stream the runtime records an assistant turn
+ * with the canonical sentinel as content. If a fallback model then runs in the
+ * same session, it can echo that sentinel back as its "completed" final reply
+ * — sometimes a single occurrence, sometimes dozens concatenated with
+ * whitespace. Because that fallback turn carries `stopReason: "stop"`, it is
+ * treated as a normal user-visible response and reaches durable delivery
+ * unless the dispatcher strips it. Exact-equality checks elsewhere (chat
+ * display, replay history, agent prompt builder) only catch the single-copy
+ * case; this helper also catches pure repetition so the fallback echo cannot
+ * leak to channels as visible chat.
+ *
+ * The matcher is deliberately conservative: text that mixes the placeholder
+ * with any other content (an apology, a partial recovery, a single literal
+ * mention) is left alone. Suppressing that would risk dropping real replies
+ * that happen to quote the sentinel.
+ */
+export function isStreamErrorPlaceholderOnlyText(text: string | undefined | null): boolean {
+  if (!text) {
+    return false;
+  }
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return false;
+  }
+  if (trimmed === STREAM_ERROR_FALLBACK_TEXT) {
+    return true;
+  }
+  const compact = trimmed.replace(/\s+/g, "");
+  const placeholder = STREAM_ERROR_PLACEHOLDER_COMPACT;
+  if (compact.length < placeholder.length || compact.length % placeholder.length !== 0) {
+    return false;
+  }
+  return compact === placeholder.repeat(compact.length / placeholder.length);
+}
+
 export function buildStreamErrorAssistantMessage(params: {
   model: StreamModelDescriptor;
   errorMessage: string;

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -1,6 +1,7 @@
 /** Dispatches isolated cron output to direct delivery, mirrors, and follow-up queues. */
 import { isAudioFileName } from "@openclaw/media-core/mime";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { isStreamErrorPlaceholderOnlyText } from "../../agents/stream-message-shared.js";
 import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
 import {
   isSilentReplyText,
@@ -67,6 +68,14 @@ function normalizeSilentReplyText(text: string | undefined): NormalizedSilentRep
     return { text, strippedTrailingSilentToken: false };
   }
   if (isSuppressedControlReplyText(text)) {
+    return { text: undefined, strippedTrailingSilentToken: false };
+  }
+  // A fallback model can echo the stream-error sentinel back as its "completed"
+  // reply (single copy or many). When that happens the fallback turn carries
+  // stopReason="stop" and would otherwise reach durable channel delivery as
+  // visible chat. Treat placeholder-only text the same as a control token and
+  // suppress it before outbound dispatch. See #97357.
+  if (isStreamErrorPlaceholderOnlyText(text)) {
     return { text: undefined, strippedTrailingSilentToken: false };
   }
 


### PR DESCRIPTION
## What Problem This Solves

When a primary model errors mid-stream and a fallback model is selected for the same heartbeat poll, the fallback can echo the internal stream-error sentinel (`[assistant turn failed before producing content]`) back as its "completed" reply. Because that fallback turn carries `stopReason: "stop"`, the sentinel is treated as a normal user-visible response and reaches durable channel delivery. In the reported case the fallback produced 43 concatenated copies of the sentinel as the final reply, which was delivered as a visible Feishu DM blast.

The existing exact-equality guards (`agent-prompt.ts`, `chat-display-projection.ts`, `replay-history.ts`) only catch a single literal occurrence of the sentinel. They were never updated to handle the case where a fallback model echoes the sentinel N times as ordinary text.

Closes #97357.

## Why This Change Was Made

The sentinel is a runtime-internal marker for "this assistant turn failed before producing content." It must never become user-visible chat, regardless of how many times a confused fallback model echoes it. Treating placeholder-only text (single copy or pure repetition) as equivalent to a control token restores that invariant at the cron delivery boundary, which is the choke point for heartbeat / scheduled-reply delivery.

The matcher is deliberately conservative:

- **Matches**: exact sentinel, sentinel with surrounding whitespace, N copies of the sentinel with any whitespace between them.
- **Does not match**: text that merely mentions the sentinel (`I got: [assistant turn failed...]`), text that mixes the sentinel with any other content (an apology, a partial recovery), unrelated text.

That way the suppression never risks dropping a real recovery that happens to quote the sentinel.

## User Impact

- Heartbeat polls that previously produced visible Feishu / channel DMs filled with the internal sentinel text will now suppress the placeholder reply the same way they suppress `SILENT_REPLY_TOKEN` / `ANNOUNCE_SKIP` / `REPLY_SKIP`.
- Heartbeat delivery remains `ok` from the runtime's perspective (no behavioral change to status reporting), but the noisy channel DM is no longer emitted.
- Real heartbeat output (HEARTBEAT_OK, actual alerts) is unaffected — only placeholder-only text is suppressed.

## Evidence

- Local unit tests cover the matcher (11 tests, all passing):
  - single placeholder match
  - placeholder with surrounding whitespace
  - 43 repetitions joined by `\n` (mirrors the issue repro)
  - mixed-whitespace repetitions
  - undefined / empty / whitespace-only rejected
  - text that merely mentions the placeholder rejected
  - text that mixes placeholder with other content rejected
  - unrelated text rejected
- Existing delivery-dispatch regression tests (94 tests) continue to pass — the wire-up does not change behavior for any non-placeholder text.

```
npx vitest run src/agents/stream-message-shared.test.ts \
  src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts \
  src/cron/isolated-agent/delivery-dispatch.named-agent.test.ts
# Test Files  3 passed (3)
#      Tests  105 passed (105)
```

The helper lives next to `STREAM_ERROR_FALLBACK_TEXT` in `src/agents/stream-message-shared.ts` so the constant and its repetition-aware matcher stay co-located. The wire-up is a single 4-line addition to `normalizeSilentReplyText` in `src/cron/isolated-agent/delivery-dispatch.ts`, sitting alongside the existing `isSuppressedControlReplyText` check.
