### PR TITLE
[codex] Defer quiet compaction accounting until after final reply

### DIFF
--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -91,6 +91,10 @@ const refreshQueuedFollowupSessionMock = vi.fn();
 const compactState = vi.hoisted(() => ({
   compactEmbeddedAgentSessionMock: vi.fn(),
 }));
+const sessionAccountingState = vi.hoisted(() => ({
+  incrementRunCompactionCountMock: vi.fn(),
+  incrementRunCompactionCountImpl: undefined as undefined | ((params: unknown) => Promise<unknown>),
+}));
 
 vi.mock("../../agents/model-fallback.js", () => ({
   runWithModelFallback: (params: {
@@ -161,6 +165,24 @@ vi.mock("./queue.js", () => {
     scheduleFollowupDrain: vi.fn(),
     clearSessionQueues: (...args: unknown[]) => clearSessionQueuesMock(...args),
     refreshQueuedFollowupSession: (...args: unknown[]) => refreshQueuedFollowupSessionMock(...args),
+  };
+});
+
+vi.mock("./session-run-accounting.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./session-run-accounting.js")>();
+  return {
+    ...actual,
+    incrementRunCompactionCount: async (
+      params: Parameters<typeof actual.incrementRunCompactionCount>[0],
+    ) => {
+      sessionAccountingState.incrementRunCompactionCountMock(params);
+      if (sessionAccountingState.incrementRunCompactionCountImpl) {
+        return (await sessionAccountingState.incrementRunCompactionCountImpl(params)) as
+          | number
+          | undefined;
+      }
+      return actual.incrementRunCompactionCount(params);
+    },
   };
 });
 
@@ -272,6 +294,8 @@ beforeEach(() => {
     compacted: false,
     reason: "test-preflight-disabled",
   });
+  sessionAccountingState.incrementRunCompactionCountMock.mockClear();
+  sessionAccountingState.incrementRunCompactionCountImpl = undefined;
   clearSessionQueuesMock.mockReset();
   clearSessionQueuesMock.mockReturnValue({ followupCleared: 0, laneCleared: 0, keys: [] });
   refreshQueuedFollowupSessionMock.mockReset();
@@ -538,6 +562,130 @@ describe("runReplyAgent auto-compaction token update", () => {
     expectReplyText(result, "ok");
     expect(scheduleFollowupDrain).toHaveBeenCalledTimes(1);
   });
+
+  it("returns quiet compaction replies before post-reply accounting finishes", async () => {
+    const sessionKey = "main";
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      sessionFile: "/tmp/session.jsonl",
+      updatedAt: Date.now(),
+      totalTokens: 50_000,
+    };
+    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
+    let releaseAccounting: (() => void) | undefined;
+    const accountingStarted = new Promise<void>((resolveStarted) => {
+      sessionAccountingState.incrementRunCompactionCountImpl = async (params) => {
+        resolveStarted();
+        await new Promise<void>((resolve) => {
+          releaseAccounting = resolve;
+        });
+        const accountingParams = params as {
+          amount?: number;
+          newSessionFile?: string;
+          newSessionId?: string;
+          sessionKey?: string;
+          sessionStore?: Record<string, SessionEntry>;
+        };
+        const key = accountingParams.sessionKey;
+        const entry = key ? accountingParams.sessionStore?.[key] : undefined;
+        if (key && entry && accountingParams.sessionStore) {
+          accountingParams.sessionStore[key] = {
+            ...entry,
+            compactionCount: (entry.compactionCount ?? 0) + (accountingParams.amount ?? 1),
+            sessionFile: accountingParams.newSessionFile ?? entry.sessionFile,
+            sessionId: accountingParams.newSessionId ?? entry.sessionId,
+          };
+        }
+        return 1;
+      };
+    });
+    runEmbeddedAgentMock.mockResolvedValue({
+      payloads: [{ text: "ok" }],
+      meta: {
+        agentMeta: {
+          compactionCount: 1,
+          lastCallUsage: { input: 10_000, output: 500, total: 10_500 },
+          sessionFile: "/tmp/session-rotated.jsonl",
+          sessionId: "session-rotated",
+        },
+      },
+    });
+
+    const { typing, sessionCtx, resolvedQueue, followupRun } = createBaseRun({
+      storePath: "",
+      sessionEntry,
+    });
+
+    const runPromise = runReplyAgent({
+      commandBody: "hello",
+      followupRun,
+      queueKey: sessionKey,
+      resolvedQueue,
+      shouldSteer: false,
+      shouldFollowup: false,
+      isActive: false,
+      isStreaming: false,
+      typing,
+      sessionCtx,
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      defaultModel: "anthropic/claude-opus-4-6",
+      agentCfgContextTokens: 200_000,
+      resolvedVerboseLevel: "off",
+      isNewSession: false,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      shouldInjectGroupIntro: false,
+      typingMode: "instant",
+    });
+
+    await accountingStarted;
+    try {
+      const resultRace = await Promise.race([
+        runPromise.then((value) => ({ kind: "result" as const, value })),
+        new Promise<{ kind: "timeout" }>((resolve) =>
+          setTimeout(() => resolve({ kind: "timeout" }), 1_000),
+        ),
+      ]);
+
+      expect(resultRace.kind).toBe("result");
+      if (resultRace.kind !== "result") {
+        throw new Error("quiet compaction reply did not return before accounting finished");
+      }
+      expectReplyText(resultRace.value, "ok");
+      expect(replyRunRegistry.get(sessionKey)).toBeUndefined();
+      expect(refreshQueuedFollowupSessionMock).not.toHaveBeenCalled();
+      expect(scheduleFollowupDrain).not.toHaveBeenCalled();
+      expect(() =>
+        createReplyOperation({
+          sessionKey,
+          sessionId: "session-rotated",
+          resetTriggered: false,
+          respectFollowupAdmissionBarrier: true,
+        }),
+      ).toThrow();
+
+      releaseAccounting?.();
+
+      await vi.waitFor(() => {
+        expect(refreshQueuedFollowupSessionMock).toHaveBeenCalledTimes(1);
+      });
+      await vi.waitFor(() => {
+        expect(scheduleFollowupDrain).toHaveBeenCalledTimes(1);
+      });
+      const nextOperation = createReplyOperation({
+        sessionKey,
+        sessionId: "session-rotated",
+        resetTriggered: false,
+        respectFollowupAdmissionBarrier: true,
+      });
+      nextOperation.complete();
+    } finally {
+      releaseAccounting?.();
+      await runPromise.catch(() => undefined);
+    }
+  }, 10_000);
 
   it("keeps a provided reply operation active until final delivery completes", async () => {
     const sessionKey = "main";

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1488,9 +1488,20 @@ export async function runReplyAgent(params: {
   }
   let runFollowupTurn = queuedRunFollowupTurn;
   let shouldDrainQueuedFollowupsAfterClear = false;
+  let postReplyCompletionBarrier: Promise<void> | undefined;
   const returnWithQueuedFollowupDrain = <T>(value: T): T => {
     shouldDrainQueuedFollowupsAfterClear = true;
     return value;
+  };
+  const completeOwnedReplyOperation = () => {
+    if (providedReplyOperation) {
+      return;
+    }
+    if (postReplyCompletionBarrier) {
+      replyOperation.completeWithAfterClearBarrier(postReplyCompletionBarrier);
+      return;
+    }
+    replyOperation.complete();
   };
   const restartRecoveryDeliveryRunId = crypto.randomUUID();
   let trackedRestartRecoveryDeliveryContext = false;
@@ -2268,7 +2279,11 @@ export async function runReplyAgent(params: {
       prefixNotices.push({ text: `🧭 New session: ${followupRun.run.sessionId}` });
     }
 
-    if (autoCompactionCount > 0) {
+    const traceAuthorized = followupRun.run.traceAuthorized === true;
+    const traceEnabledForSender =
+      traceAuthorized &&
+      (activeSessionEntry?.traceLevel === "on" || activeSessionEntry?.traceLevel === "raw");
+    const recordPostReplyCompactionAccounting = async (): Promise<number | undefined> => {
       const previousSessionId = activeSessionEntry?.sessionId ?? followupRun.run.sessionId;
       const count = await incrementRunCompactionCount({
         cfg,
@@ -2311,9 +2326,27 @@ export async function runReplyAgent(params: {
           });
       }
 
-      if (verboseEnabled) {
-        const suffix = typeof count === "number" ? ` (count ${count})` : "";
-        prefixNotices.push({ text: `🧹 Auto-compaction complete${suffix}.` });
+      return count;
+    };
+
+    if (autoCompactionCount > 0) {
+      if (!verboseEnabled && !providedReplyOperation && !traceEnabledForSender) {
+        postReplyCompletionBarrier = recordPostReplyCompactionAccounting()
+          .then(() => undefined)
+          .catch((error) => {
+            logVerbose(
+              `postReplyCompaction accounting failed for ${sessionKey ?? "unknown"}: ${String(
+                error,
+              )}`,
+            );
+          });
+      } else {
+        const count = await recordPostReplyCompactionAccounting();
+
+        if (verboseEnabled) {
+          const suffix = typeof count === "number" ? ` (count ${count})` : "";
+          prefixNotices.push({ text: `🧹 Auto-compaction complete${suffix}.` });
+        }
       }
     }
     const prefixPayloads = [...prefixNotices];
@@ -2328,7 +2361,6 @@ export async function runReplyAgent(params: {
     const rawAssistantText = isHookBlockedRun
       ? undefined
       : (runResult.meta?.finalAssistantRawText ?? runResult.meta?.finalAssistantVisibleText);
-    const traceAuthorized = followupRun.run.traceAuthorized === true;
     const executionTrace = mergeExecutionTrace({
       fallbackAttempts,
       executionTrace: runResult.meta?.executionTrace as TraceExecutionView | undefined,
@@ -2415,9 +2447,6 @@ export async function runReplyAgent(params: {
             sessionFile: followupRun.run.sessionFile,
           })
         : undefined;
-    const traceEnabledForSender =
-      traceAuthorized &&
-      (activeSessionEntry?.traceLevel === "on" || activeSessionEntry?.traceLevel === "raw");
     const shouldAppendTracePayload = verboseEnabled || traceEnabledForSender;
     let trailingPluginStatusPayload: ReplyPayload | undefined;
     if (shouldAppendTracePayload) {
@@ -2622,10 +2651,10 @@ export async function runReplyAgent(params: {
         runFollowup: runFollowupTurn,
       });
       if (!providedReplyOperation) {
-        replyOperation.complete();
+        completeOwnedReplyOperation();
       }
     } else if (!providedReplyOperation) {
-      replyOperation.complete();
+      completeOwnedReplyOperation();
     }
     blockReplyPipeline?.stop();
     typing.markRunComplete();


### PR DESCRIPTION
## What Problem This Solves
Quiet compaction accounting was happening too early relative to final reply cleanup. That can make the reply runner treat compaction bookkeeping and final-answer admission as overlapping concerns, increasing the chance of late-turn stalls or incorrect admission state around the response boundary.

## Summary
- Defer quiet compaction accounting until after the final reply path is cleared.
- Keep final-reply admission and compaction accounting from racing each other.
- Add regression coverage around quiet compaction behavior in the reply agent runner.

## Evidence
- Local core test typecheck pass: `pnpm tsgo:core:test`
- Local focused auto-reply test pass: `node scripts/test-projects.mjs src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts src/auto-reply/reply/reply-run-registry.test.ts src/auto-reply/reply/reply-turn-admission.test.ts`
- Focused auto-reply result: 3 test files passed, 76 tests passed.
- Draft PR check evidence before body update: code-adjacent checks passed; only `Real behavior proof` failed because this external PR body lacked the required authored sections.
