### PR TITLE
fix(models): sort alias versions numerically

### DIFF
--- a/src/agents/sessions/model-resolver.test.ts
+++ b/src/agents/sessions/model-resolver.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest";
 import type { Model } from "../../llm/types.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../defaults.js";
 import type { ModelRegistry } from "./model-registry.js";
-import { findInitialModel, restoreModelFromSession } from "./model-resolver.js";
+import { findInitialModel, parseModelPattern, restoreModelFromSession } from "./model-resolver.js";
 
 function model(provider: string, id: string): Model {
   return {
@@ -31,6 +31,15 @@ function registry(models: Model[]): ModelRegistry {
 }
 
 describe("model resolver fallback selection", () => {
+  it("selects the numerically newest alias match across double-digit versions", () => {
+    const result = parseModelPattern("opus", [
+      model("anthropic", "claude-opus-4-9"),
+      model("anthropic", "claude-opus-4-10"),
+    ]);
+
+    expect(result.model?.id).toBe("claude-opus-4-10");
+  });
+
   it("prefers the product default when no configured or scoped model is selected", async () => {
     const productDefault = model(DEFAULT_PROVIDER, DEFAULT_MODEL);
     const result = await findInitialModel({

--- a/src/agents/sessions/model-resolver.ts
+++ b/src/agents/sessions/model-resolver.ts
@@ -12,6 +12,7 @@ import { DEFAULT_THINKING_LEVEL } from "./defaults.js";
 import type { ModelRegistry } from "./model-registry.js";
 
 const VALID_THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh", "max"] as const;
+const MODEL_ID_COLLATOR = new Intl.Collator(undefined, { numeric: true });
 
 function isValidThinkingLevel(level: string): level is ThinkingLevel {
   return VALID_THINKING_LEVELS.includes(level as ThinkingLevel);
@@ -36,6 +37,10 @@ function isAlias(id: string): boolean {
   // Check if ID ends with a date pattern (-YYYYMMDD)
   const datePattern = /-\d{8}$/;
   return !datePattern.test(id);
+}
+
+function compareModelIdsDescending(a: Model, b: Model): number {
+  return MODEL_ID_COLLATOR.compare(b.id, a.id);
 }
 
 /**
@@ -116,11 +121,11 @@ function tryMatchModel(modelPattern: string, availableModels: Model[]): Model | 
 
   if (aliases.length > 0) {
     // Prefer alias - if multiple aliases, pick the one that sorts highest
-    aliases.sort((a, b) => b.id.localeCompare(a.id));
+    aliases.sort(compareModelIdsDescending);
     return aliases[0];
   }
   // No alias found, pick latest dated version
-  datedVersions.sort((a, b) => b.id.localeCompare(a.id));
+  datedVersions.sort(compareModelIdsDescending);
   return datedVersions[0];
 }
 


### PR DESCRIPTION
Closes #96588

## What Problem This Solves

Fixes an issue where users select a model by alias or partial model name and OpenClaw can choose an older model when a version family reaches double-digit minor versions.

For example, resolving `opus` against `claude-opus-4-9` and `claude-opus-4-10` should pick `4-10`, but lexicographic ordering ranks `4-9` higher.

## Why This Change Was Made

The resolver now uses numeric-aware model-id collation at the existing fallback ordering point for alias and dated-version candidates. Exact model references, provider scoping, configured auth, and fallback behavior are unchanged.

## User Impact

Model aliases continue to work the same way, but when matching versioned model IDs with numeric components, OpenClaw now selects the numerically newest match instead of the lexicographically highest older version.

## Evidence

- Claim proved: alias resolution picks the numerically newest matching version for the double-digit rollover case in #96588.
- Commands / artifacts:
  - `node scripts/run-vitest.mjs src/agents/sessions/model-resolver.test.ts`
  - `.\\node_modules\\.bin\\oxfmt.CMD --check --threads=1 src/agents/sessions/model-resolver.ts src/agents/sessions/model-resolver.test.ts`
  - `git diff --check`
  - `python .agents\\skills\\autoreview\\scripts\\autoreview --mode local`
- Observed result:
  - Vitest passed: 1 file, 3 tests.
  - oxfmt passed: both touched files use the correct format.
  - `git diff --check` produced no output.
  - Autoreview passed clean with no accepted/actionable findings.
- Not tested / proof gaps:
  - No live provider catalog currently exposes this exact double-digit rollover pair; the proof uses the real resolver with a synthetic `claude-opus-4-9` / `claude-opus-4-10` model list matching the reported future-facing bug.

AI-assisted: yes. I understand the change and verified the scoped behavior above.
