### PR TITLE
fix(deepinfra): bound video generation JSON response reads

### DIFF
--- a/extensions/deepinfra/video-generation-provider.ts
+++ b/extensions/deepinfra/video-generation-provider.ts
@@ -6,6 +6,7 @@ import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runt
 import {
   assertOkOrThrowHttpError,
   postJsonRequest,
+  readProviderJsonResponse,
   resolveProviderHttpRequestConfig,
 } from "openclaw/plugin-sdk/provider-http";
 import {
@@ -270,12 +271,10 @@ export function buildDeepInfraVideoGenerationProvider(options?: {
       });
       try {
         await assertOkOrThrowHttpError(response, "DeepInfra video generation failed");
-        let payload: DeepInfraVideoResponse;
-        try {
-          payload = (await response.json()) as DeepInfraVideoResponse;
-        } catch (cause) {
-          throw new Error("DeepInfra video generation failed: malformed JSON response", { cause });
-        }
+        const payload = await readProviderJsonResponse<DeepInfraVideoResponse>(
+          response,
+          "DeepInfra video generation failed",
+        );
         const failed = failureMessage(payload);
         if (failed) {
           throw new Error(failed);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the DeepInfra video generation success response was read
with an unbounded `await response.json()`, meaning a misbehaving or hostile
DeepInfra endpoint (including a self-hosted `baseUrl` override accepted by
`normalizeDeepInfraBaseUrl`) could stream an arbitrarily large JSON body into
the Node.js heap before parsing began — causing memory pressure or OOM on the
video generation path.

The error body on the same path was already bounded via
`assertOkOrThrowHttpError`, but the success JSON path was missed in the
response-limit campaign that fixed xAI, Runway, Together, Pixverse, and others.

Related: the existing `try/catch` block around `response.json()` duplicated
malformed-JSON wrapping already provided by `readProviderJsonResponse`, so this
change also removes that duplication.

## Why This Change Was Made

`readProviderJsonResponse` (from `openclaw/plugin-sdk/provider-http`) wraps
`readResponseWithLimit` with a 16 MiB cap, cancels the ReadableStream on
overflow, and surfaces a consistent `"<label>: malformed JSON response"` error
on bad JSON — replacing the previous manual `try/catch` with a single call and
net -1 LOC on the production path. Error message format is unchanged.

## User Impact

No user-visible behavior change for well-behaved endpoints. Operators running
DeepInfra video generation against a self-hosted or compromised `baseUrl` that
returns an oversized JSON payload will now see a bounded error
(`Content too large: N bytes (limit: 16777216 bytes)`) instead of unbounded
heap growth.

## Evidence

**Diff** — `extensions/deepinfra/video-generation-provider.ts` (net -1 LOC):

```diff
-        let payload: DeepInfraVideoResponse;
-        try {
-          payload = (await response.json()) as DeepInfraVideoResponse;
-        } catch (cause) {
-          throw new Error("DeepInfra video generation failed: malformed JSON response", { cause });
-        }
+        const payload = await readProviderJsonResponse<DeepInfraVideoResponse>(
+          response,
+          "DeepInfra video generation failed",
+        );
```

**Proof script** (`node scripts/proof-deepinfra-bound.mjs`, Node v22.22.0):

```
[case 1] oversized DeepInfra video JSON, cap=1024 KiB, ReadableStream
  ok: readResponseWithLimit rejected on oversized body — true
  ok: bounded error message present (got: Content too large: 2097152 bytes (limit: 1048576 bytes)) — true
  ok: stream was cancelled before all 64 chunks were read (readCount=2) — true
  ok: stream cancel() was called — true

[negative control] OLD unbounded await response.json() — no cancellation
  ok: unbounded .json() consumed all chunks before failing (readCount=64) — true
  ok: stream NOT cancelled via .cancel() — drained to EOF instead — true

[case 3] normal small DeepInfra video JSON — parses unchanged
  ok: small body parsed into result — true
  ok: result content intact (req_proof_ok present) — true

ALL PROOF ASSERTIONS PASSED
```

**Local test suite** (`pnpm test extensions/deepinfra`, Vitest v4.1.8, Node v22.22.0):

```
Test Files  12 passed (12)
     Tests  73 passed (73)
  Duration  23.76s
```

AI-assisted.
