### PR TITLE
fix: Codex plugin updates fail before reply on Windows

### DIFF
--- a/src/plugins/install-paths.test.ts
+++ b/src/plugins/install-paths.test.ts
@@ -1,0 +1,60 @@
+// Covers managed plugin install path generation.
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  resolvePluginNpmGenerationProjectDir,
+  resolvePluginNpmGenerationProjectDirPrefix,
+} from "./install-paths.js";
+
+describe("managed npm plugin install paths", () => {
+  it("keeps generation project names compact for nested Windows runtime binaries", () => {
+    const packageName = "@openclaw/codex";
+    const generationKey = [
+      packageName,
+      "2026.6.10",
+      `${packageName}@2026.6.10`,
+      "sha512-test-integrity",
+      "codexshasum",
+    ].join("\n");
+    const projectDir = resolvePluginNpmGenerationProjectDir({
+      npmDir: String.raw`C:\Users\Administrator\.openclaw\npm`,
+      packageName,
+      generationKey,
+    });
+    const projectName = path.basename(projectDir);
+
+    expect(projectName).toMatch(
+      /^openclaw-codex-[a-f0-9]{10}__openclaw-generation__g-[a-f0-9]{16}$/u,
+    );
+    expect(projectName.length).toBeLessThanOrEqual(66);
+
+    const nestedCodexBinaryPath = path.win32.join(
+      String.raw`C:\Users\Administrator\.openclaw\npm\projects`,
+      projectName,
+      "node_modules",
+      "@openclaw",
+      "codex",
+      "node_modules",
+      "@openai",
+      "codex-win32-x64",
+      "vendor",
+      "x86_64-pc-windows-msvc",
+      "bin",
+      "codex.exe",
+    );
+    expect(nestedCodexBinaryPath.length).toBeLessThan(260);
+  });
+
+  it("keeps generation project names under the recoverable package prefix", () => {
+    const packageName = "@openclaw/codex";
+    const projectDir = resolvePluginNpmGenerationProjectDir({
+      npmDir: "/tmp/openclaw/npm",
+      packageName,
+      generationKey: "codex-v2",
+    });
+
+    expect(path.basename(projectDir)).toMatch(
+      new RegExp(`^${resolvePluginNpmGenerationProjectDirPrefix(packageName)}`, "u"),
+    );
+  });
+});

--- a/src/plugins/install-paths.ts
+++ b/src/plugins/install-paths.ts
@@ -1,4 +1,5 @@
 // Resolves plugin install paths for local and package sources.
+import { createHash } from "node:crypto";
 import path from "node:path";
 import {
   resolveSafeInstallDir,
@@ -121,10 +122,17 @@ export function resolvePluginNpmProjectDir(params: {
 }
 
 const PLUGIN_NPM_GENERATION_PROJECT_SEPARATOR = "__openclaw-generation__";
+const PLUGIN_NPM_GENERATION_KEY_HASH_CHARS = 16;
 
 /** Resolves the managed npm artifact-generation project directory prefix for a package. */
 export function resolvePluginNpmGenerationProjectDirPrefix(packageName: string): string {
   return `${encodePluginNpmProjectDirName(packageName)}${PLUGIN_NPM_GENERATION_PROJECT_SEPARATOR}`;
+}
+
+/** Encodes a package generation fingerprint into a compact project directory suffix. */
+export function encodePluginNpmGenerationKeyDirName(generationKey: string): string {
+  const digest = createHash("sha256").update(generationKey).digest("hex");
+  return `g-${digest.slice(0, PLUGIN_NPM_GENERATION_KEY_HASH_CHARS)}`;
 }
 
 /** Resolves an artifact-generation-specific managed npm project directory. */
@@ -135,7 +143,7 @@ export function resolvePluginNpmGenerationProjectDir(params: {
 }): string {
   return path.join(
     resolvePluginNpmProjectsDir(params.npmDir),
-    `${resolvePluginNpmGenerationProjectDirPrefix(params.packageName)}${safePathSegmentHashed(
+    `${resolvePluginNpmGenerationProjectDirPrefix(params.packageName)}${encodePluginNpmGenerationKeyDirName(
       params.generationKey,
     )}`,
   );


### PR DESCRIPTION
Fixes #97487
Related: #85844

## What Problem This Solves

Fixes an issue where Windows users updating the Codex plugin could have Codex-backed agents fail before reply when the managed npm generation path pushes Codex's native `codex.exe` beyond the legacy 260-character Windows path boundary.

In the observed `2026.6.11-beta.1` upgrade, the gateway, Telegram channel, and plugin registry were healthy, but Codex app-server startup failed with `spawn ...\@openai\codex-win32-x64\vendor\...\codex.exe ENOENT`. The binary was present; the generated managed npm path was too long for the Windows spawn path that Codex CLI uses internally.

## Why This Change Was Made

Managed npm generation project names now keep the existing package-derived prefix used by recovery and retention scans, but encode the artifact generation fingerprint as a compact deterministic hash suffix. This preserves prefix-based generation discovery while keeping new generation project roots short enough for nested Windows runtime binaries.

This PR intentionally does not change plugin install policy, package trust, Codex CLI package layout, channel routing, or the broader running-gateway module lifecycle tracked by #85844.

## User Impact

Windows operators can update official npm-backed plugins such as `@openclaw/codex` without creating new generation roots that make nested native binaries unspawnable. Codex-backed agents should no longer fail before reply solely because a managed npm generation directory name made the runtime path too long.

Existing generation directories remain discoverable because the package prefix shape is unchanged.

## Evidence

Real before evidence from a Windows `2026.6.11-beta.1` upgrade:

```text
Agent failed before reply: codex app-server exited: code=1 signal=null
Error: spawn <state>\npm\projects\openclaw-codex-...__openclaw-generation__...\node_modules\@openclaw\codex\node_modules\@openai\codex-win32-x64\vendor\x86_64-pc-windows-msvc\bin\codex.exe ENOENT
```

Path diagnostics from the same install, redacted to the relevant lengths:

```text
generationProjectNameLength=109
pluginPackageRootLength=184
longExeLength=265
longExeTestPath=False
```

Copying the same `@openclaw/codex@2026.6.10` package tree to a short local path proved the package contents were valid:

```text
shortExeLength=109
shortExeExists=True
codex-cli 0.139.0
```

Operational recovery proof after applying a local short-path workaround on that machine:

```text
openclaw agent --agent youyou-cli --session-key agent:youyou-cli:upgrade-611-beta1-shortpath-smoke2 ...
status=ok
finalAssistantVisibleText="OpenClaw 2026.6.11-beta.1 (c862a64)"
toolSummary.calls=1
toolSummary.failures=0
```

Patched Windows proof using this branch's generation-name resolver:

```text
projectName=openclaw-codex-8902d781d4__openclaw-generation__g-95c48d287a5038dc
projectNameLength=66
defaultWindowsNestedCodexExeLength=222
underMaxPath=True
defaultWindowsNestedCodexExe=C:\Users\Administrator\.openclaw\npm\projects\openclaw-codex-8902d781d4__openclaw-generation__g-95c48d287a5038dc\node_modules\@openclaw\codex\node_modules\@openai\codex-win32-x64\vendor\x86_64-pc-windows-msvc\bin\codex.exe
```

The same verified `@openclaw/codex@2026.6.10` package tree was copied under that patched generated project name on Windows, and the Codex app-server command was pointed at that generated package root:

```text
packageRootLength=141
shimLength=169
nestedExeLength=222
shimExists=True
nestedExeExists=True
codex-cli 0.139.0
```

Codex-backed agent smoke through that patched generated package root:

```text
openclaw agent --agent youyou-cli --session-key agent:youyou-cli:patched-generation-path-proof ...
agentSmoke.status=ok
agentSmoke.finalAssistantVisibleText=OpenClaw 2026.6.11-beta.1 (c862a64)
agentSmoke.agentHarnessId=codex
agentSmoke.toolCalls=1
agentSmoke.toolFailures=0
```

Post-proof local health checks:

```text
openclaw plugins doctor
# No plugin issues detected.

openclaw channels status --channel telegram
# Telegram default: enabled, configured, running, connected, transport:just now, mode:polling
```

Regression coverage added in this PR:

- `src/plugins/install-paths.test.ts` asserts the `@openclaw/codex` generation project name is compact.
- The test models the default Windows state root plus nested `@openai/codex-win32-x64\vendor\...\codex.exe` path and verifies it stays below 260 characters.
- The test also asserts new generation names remain under the existing recoverable package prefix.

Focused local validation:

```text
pnpm install --frozen-lockfile

node scripts/run-vitest.mjs src/plugins/install-paths.test.ts --testNamePattern="managed npm plugin install paths"
# 1 file passed, 2 tests passed

node scripts/run-vitest.mjs src/plugins/install.npm-spec.test.ts --testNamePattern="keeps lazy imports from a loaded old npm generation available across updates"
# 1 file passed, 1 test passed

node scripts/run-vitest.mjs src/plugins/install.test.ts --testNamePattern="reports update mode to policy when npm update installs a new artifact generation"
# 1 file passed, 1 test passed

pnpm exec oxlint src/plugins/install-paths.ts src/plugins/install-paths.test.ts
# exited 0

pnpm exec oxfmt --check --threads=1 src/plugins/install-paths.ts src/plugins/install-paths.test.ts
# all matched files use the correct format

git diff --check
# passed

$env:PYTHONUTF8='1'; python .agents\skills\autoreview\scripts\autoreview --mode local
# autoreview clean: no accepted/actionable findings reported
```

What was not tested: a full published-package Windows upgrade after this source patch. GitHub CI should remain the authority for the full matrix; the local proof covers the real failure shape, the package-content control, and the source-level path generation fix.
