### PR TITLE
fix(anthropic): accept Claude CLI apiKeyHelper auth

### DIFF
--- a/extensions/anthropic/cli-constants.ts
+++ b/extensions/anthropic/cli-constants.ts
@@ -4,6 +4,10 @@
  */
 /** Synthetic provider/backend id for Claude Code CLI-backed Anthropic models. */
 export const CLAUDE_CLI_BACKEND_ID = "claude-cli";
+/** Non-secret marker for Claude Code settings.json apiKeyHelper auth. */
+export const CLAUDE_CLI_API_KEY_HELPER_AUTH_MARKER = ["openclaw", "claude-cli-api-key-helper"].join(
+  ":",
+);
 /** Default Claude CLI model ref for agent defaults and live tests. */
 export const CLAUDE_CLI_DEFAULT_MODEL_REF = `${CLAUDE_CLI_BACKEND_ID}/claude-opus-4-8`;
 /** Provider-relative model id for Anthropic runtime-policy resolution. */

--- a/extensions/anthropic/cli-migration.test.ts
+++ b/extensions/anthropic/cli-migration.test.ts
@@ -445,6 +445,15 @@ describe("anthropic cli migration", () => {
     ]);
   });
 
+  it("does not persist a synthetic profile for Claude CLI apiKeyHelper auth", () => {
+    const result = buildAnthropicCliMigrationResult(
+      {},
+      { type: "api_key_helper", provider: "anthropic", helperHash: "helper-hash" },
+    );
+
+    expect(result.profiles).toEqual([]);
+  });
+
   it("registered non-interactive cli auth keeps anthropic fallbacks and selects claude-cli runtime", async () => {
     readClaudeCliCredentialsForSetupNonInteractive.mockReturnValue({
       type: "oauth",

--- a/extensions/anthropic/cli-migration.ts
+++ b/extensions/anthropic/cli-migration.ts
@@ -189,6 +189,9 @@ function buildClaudeCliAuthProfiles(
       },
     ];
   }
+  if (credential.type === "api_key_helper") {
+    return [];
+  }
   return [
     {
       profileId: CLAUDE_CLI_PROFILE_ID,

--- a/extensions/anthropic/index.test.ts
+++ b/extensions/anthropic/index.test.ts
@@ -25,7 +25,9 @@ vi.mock("./cli-auth-seam.js", () => {
 });
 
 import { buildClaudeCliCatalogEntries } from "./cli-catalog.js";
+import { CLAUDE_CLI_API_KEY_HELPER_AUTH_MARKER } from "./cli-constants.js";
 import anthropicPlugin from "./index.js";
+import anthropicProviderDiscovery from "./provider-discovery.js";
 
 beforeEach(() => {
   readClaudeCliCredentialsForSetupMock.mockReset();
@@ -1329,6 +1331,29 @@ describe("anthropic provider replay hooks", () => {
       mode: "token",
       expiresAt: 123,
     });
+  });
+
+  it("resolves claude-cli apiKeyHelper synthetic auth without exposing helper output", async () => {
+    readClaudeCliCredentialsForRuntimeMock.mockReset();
+    readClaudeCliCredentialsForRuntimeMock.mockReturnValue({
+      type: "api_key_helper",
+      provider: "anthropic",
+      helperHash: "helper-hash",
+    });
+
+    const provider = await registerSingleProviderPlugin(anthropicPlugin);
+
+    const runtimeAuth = provider.resolveSyntheticAuth?.({
+      provider: "claude-cli",
+    } as never);
+    const discoveryAuth = anthropicProviderDiscovery.resolveSyntheticAuth?.({
+      provider: "claude-cli",
+    } as never);
+    for (const auth of [runtimeAuth, discoveryAuth]) {
+      expect(auth?.apiKey).toBe(CLAUDE_CLI_API_KEY_HELPER_AUTH_MARKER);
+      expect(auth?.source).toBe("Claude CLI apiKeyHelper");
+      expect(auth?.mode).toBe("api-key");
+    }
   });
 
   it("stores a claude-cli auth profile during anthropic cli migration", async () => {

--- a/extensions/anthropic/openclaw.plugin.json
+++ b/extensions/anthropic/openclaw.plugin.json
@@ -247,6 +247,7 @@
   },
   "cliBackends": ["claude-cli"],
   "syntheticAuthRefs": ["claude-cli"],
+  "nonSecretAuthMarkers": ["openclaw:claude-cli-api-key-helper"],
   "setup": {
     "providers": [
       {

--- a/extensions/anthropic/provider-discovery.ts
+++ b/extensions/anthropic/provider-discovery.ts
@@ -37,6 +37,7 @@ export function resolveClaudeCliSyntheticAuth() {
       };
     }
   }
+  return undefined;
 }
 
 const anthropicProviderDiscovery: ProviderPlugin = {

--- a/extensions/anthropic/provider-discovery.ts
+++ b/extensions/anthropic/provider-discovery.ts
@@ -4,27 +4,39 @@
  */
 import type { ProviderPlugin } from "openclaw/plugin-sdk/provider-model-shared";
 import { readClaudeCliCredentialsForRuntime } from "./cli-auth-seam.js";
+import { CLAUDE_CLI_API_KEY_HELPER_AUTH_MARKER } from "./cli-constants.js";
 
 const CLAUDE_CLI_BACKEND_ID = "claude-cli";
 
-function resolveClaudeCliSyntheticAuth() {
+export function resolveClaudeCliSyntheticAuth() {
   const credential = readClaudeCliCredentialsForRuntime();
   if (!credential) {
     return undefined;
   }
-  return credential.type === "oauth"
-    ? {
+  switch (credential.type) {
+    case "oauth":
+      return {
         apiKey: credential.access,
         source: "Claude CLI native auth",
         mode: "oauth" as const,
         expiresAt: credential.expires,
-      }
-    : {
+      };
+    case "token":
+      return {
         apiKey: credential.token,
         source: "Claude CLI native auth",
         mode: "token" as const,
         expiresAt: credential.expires,
       };
+    case "api_key_helper": {
+      const marker = CLAUDE_CLI_API_KEY_HELPER_AUTH_MARKER;
+      return {
+        apiKey: marker,
+        source: "Claude CLI apiKeyHelper",
+        mode: "api-key" as const,
+      };
+    }
+  }
 }
 
 const anthropicProviderDiscovery: ProviderPlugin = {

--- a/extensions/anthropic/register.runtime.ts
+++ b/extensions/anthropic/register.runtime.ts
@@ -54,6 +54,7 @@ import {
   normalizeAnthropicProviderConfigForProvider,
 } from "./config-defaults.js";
 import { anthropicMediaUnderstandingProvider } from "./media-understanding-provider.js";
+import { resolveClaudeCliSyntheticAuth } from "./provider-discovery.js";
 import { createClaudeSessionNodeInvokePolicies } from "./session-catalog-node-commands.js";
 import { registerClaudeSessionDiscovery } from "./session-catalog-registration.js";
 import { wrapAnthropicProviderStream } from "./stream-wrappers.js";
@@ -712,26 +713,6 @@ function buildAnthropicAuthDoctorHint(params: {
     `- suggested profile: ${suggested}`,
     `Fix: run "${formatCliCommand("openclaw doctor --yes")}"`,
   ].join("\n");
-}
-
-function resolveClaudeCliSyntheticAuth() {
-  const credential = claudeCliAuth.readClaudeCliCredentialsForRuntime();
-  if (!credential) {
-    return undefined;
-  }
-  return credential.type === "oauth"
-    ? {
-        apiKey: credential.access,
-        source: "Claude CLI native auth",
-        mode: "oauth" as const,
-        expiresAt: credential.expires,
-      }
-    : {
-        apiKey: credential.token,
-        source: "Claude CLI native auth",
-        mode: "token" as const,
-        expiresAt: credential.expires,
-      };
 }
 
 async function runAnthropicCliMigration(ctx: ProviderAuthContext): Promise<ProviderAuthResult> {

--- a/src/agents/auth-profiles.external-cli-sync.test.ts
+++ b/src/agents/auth-profiles.external-cli-sync.test.ts
@@ -589,6 +589,22 @@ describe("external cli oauth resolution", () => {
     expect(profiles).toStrictEqual([]);
   });
 
+  it("ignores Claude CLI apiKeyHelper credentials for OAuth profile sync", () => {
+    mocks.readClaudeCliCredentialsCached.mockReturnValue({
+      type: "api_key_helper",
+      provider: "anthropic",
+      helperHash: "helper-hash",
+    });
+
+    const profiles = resolveExternalCliAuthProfiles(makeStore(), {
+      providerIds: ["claude-cli"],
+      allowKeychainPrompt: false,
+    });
+
+    expect(profiles).toStrictEqual([]);
+    expectReaderPolicyCall(mocks.readClaudeCliCredentialsCached);
+  });
+
   it("resolves fresher minimax external oauth profiles as runtime overlays", () => {
     mocks.readMiniMaxCliCredentialsCached.mockReturnValue(
       makeOAuthCredential({

--- a/src/agents/cli-auth-epoch.test.ts
+++ b/src/agents/cli-auth-epoch.test.ts
@@ -414,6 +414,25 @@ describe("resolveCliAuthEpoch", () => {
     expect(tokenEpoch).toBe(oauthEpoch);
   });
 
+  it("changes the Claude CLI auth epoch when apiKeyHelper configuration changes", async () => {
+    let helperHash = "helper-hash-a";
+    setCliAuthEpochTestDeps({
+      readClaudeCliCredentialsCached: () => ({
+        type: "api_key_helper",
+        provider: "anthropic",
+        helperHash,
+      }),
+    });
+
+    const first = await resolveCliAuthEpoch({ provider: "claude-cli" });
+    helperHash = "helper-hash-b";
+    const second = await resolveCliAuthEpoch({ provider: "claude-cli" });
+
+    expectCliAuthEpoch(first);
+    expectCliAuthEpoch(second);
+    expect(second).not.toBe(first);
+  });
+
   it("drops the claude cli epoch when the credential read is absent", async () => {
     setCliAuthEpochTestDeps({
       readClaudeCliCredentialsCached: () => ({

--- a/src/agents/cli-auth-epoch.ts
+++ b/src/agents/cli-auth-epoch.ts
@@ -47,7 +47,7 @@ const defaultCliAuthEpochDeps: CliAuthEpochDeps = {
 const cliAuthEpochDeps: CliAuthEpochDeps = { ...defaultCliAuthEpochDeps };
 
 /** Version salt for CLI auth epoch encoding semantics. */
-export const CLI_AUTH_EPOCH_VERSION = 6;
+export const CLI_AUTH_EPOCH_VERSION = 7;
 
 const GEMINI_CLI_PROVIDER_ID = "google-gemini-cli";
 
@@ -100,15 +100,18 @@ function encodeOAuthIdentity(credential: {
 }
 
 function encodeClaudeCredential(credential: ClaudeCliCredential): string {
-  // Identity-only hashing for both OAuth and token Claude CLI credentials.
+  if (credential.type === "api_key_helper") {
+    return JSON.stringify([credential.type, credential.provider, credential.helperHash]);
+  }
+  // Identity-only hashing for Claude CLI-managed credentials.
   // The Claude CLI keychain rewrite is not atomic: a token rotation can
   // briefly produce a partial read where `refreshToken` is missing, and the
   // parser falls back to a token-shaped credential. With the previous
   // token-inclusive hash, that transient race flipped the auth-epoch and
-  // forced a session reset on every rotation. Routing both branches through
-  // `encodeOAuthIdentity` collapses partial reads and rotations onto the
-  // same provider-keyed identity hash, while a real account switch would
-  // still surface as different identity fields. Fixes #74312.
+  // forced a session reset on every rotation. Routing these branches through
+  // `encodeOAuthIdentity` collapses partial reads and rotations onto the same
+  // provider-keyed identity hash. Helper auth stays distinct because changing
+  // its configured command can switch accounts. Fixes #74312.
   return encodeOAuthIdentity({
     type: "oauth",
     provider: credential.provider,
@@ -221,13 +224,15 @@ function getLocalCliCredentialFingerprint(provider: string): string | undefined 
 
 function getLocalCliCredential(provider: string): AuthProfileCredential | undefined {
   switch (provider) {
-    case "claude-cli":
-      return (
-        cliAuthEpochDeps.readClaudeCliCredentialsCached({
-          ttlMs: 0,
-          allowKeychainPrompt: false,
-        }) ?? undefined
-      );
+    case "claude-cli": {
+      const auth = cliAuthEpochDeps.readClaudeCliCredentialsCached({
+        ttlMs: 0,
+        allowKeychainPrompt: false,
+      });
+      // Helper auth has no persisted secret/profile shape; its opaque command
+      // fingerprint is already carried by getLocalCliCredentialFingerprint.
+      return auth?.type === "api_key_helper" ? undefined : (auth ?? undefined);
+    }
     case "codex-cli":
       return (
         cliAuthEpochDeps.readCodexCliCredentialsCached({

--- a/src/agents/cli-credentials.test.ts
+++ b/src/agents/cli-credentials.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 
 const execSyncMock = vi.fn();
 const CLI_CREDENTIALS_CACHE_TTL_MS = 15 * 60 * 1000;
@@ -12,6 +13,7 @@ let readGeminiCliCredentialsCached: typeof import("./cli-credentials.js").readGe
 let readMiniMaxCliCredentialsCached: typeof import("./cli-credentials.js").readMiniMaxCliCredentialsCached;
 let readCodexAuth: typeof import("./cli-auth.test-support.js").readCodexAuth;
 let resetCliAuthCaches: typeof import("./cli-auth.test-support.js").resetCliAuthCaches;
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 async function readCachedClaudeCliCredentials(allowKeychainPrompt: boolean) {
   return readClaudeCliCredentialsCached({
@@ -386,6 +388,71 @@ describe("cli credentials", () => {
     });
     expect(withoutPrompt).toBeNull();
     expect(execSyncMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("recognizes Claude Code user apiKeyHelper settings as CLI-managed auth", () => {
+    const tempDir = tempDirs.make("openclaw-claude-settings-");
+    const settingsDir = path.join(tempDir, ".claude");
+    fs.mkdirSync(settingsDir, { recursive: true });
+
+    const options = {
+      allowKeychainPrompt: false,
+      ttlMs: CLI_CREDENTIALS_CACHE_TTL_MS,
+      platform: "linux" as const,
+      homeDir: tempDir,
+      execSync: execSyncMock,
+    };
+    expect(readClaudeCliCredentialsCached(options)).toBeNull();
+
+    fs.writeFileSync(
+      path.join(settingsDir, "settings.json"),
+      JSON.stringify({ apiKeyHelper: "test-api-key-helper" }),
+    );
+
+    const result = readClaudeCliCredentialsCached(options);
+
+    expect(result).toEqual({
+      type: "api_key_helper",
+      provider: "anthropic",
+      helperHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+    });
+    expect(execSyncMock).not.toHaveBeenCalled();
+  });
+
+  it("prefers Claude Code user apiKeyHelper settings over stored Claude credentials", () => {
+    const tempDir = tempDirs.make("openclaw-claude-helper-first-");
+    const settingsDir = path.join(tempDir, ".claude");
+    fs.mkdirSync(settingsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(settingsDir, "settings.json"),
+      JSON.stringify({ apiKeyHelper: "test-api-key-helper" }),
+    );
+    fs.writeFileSync(
+      path.join(settingsDir, ".credentials.json"),
+      JSON.stringify({
+        claudeAiOauth: {
+          accessToken: "test-access-token",
+          refreshToken: "test-refresh-token",
+          expiresAt: Date.parse("2099-01-01T00:00:00Z"),
+        },
+      }),
+    );
+    mockClaudeCliCredentialRead();
+
+    const result = readClaudeCliCredentialsCached({
+      allowKeychainPrompt: true,
+      ttlMs: CLI_CREDENTIALS_CACHE_TTL_MS,
+      platform: "darwin",
+      homeDir: tempDir,
+      execSync: execSyncMock,
+    });
+
+    expect(result).toEqual({
+      type: "api_key_helper",
+      provider: "anthropic",
+      helperHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+    });
+    expect(execSyncMock).not.toHaveBeenCalled();
   });
 
   it("reads Codex credentials from keychain when available", () => {

--- a/src/agents/cli-credentials.ts
+++ b/src/agents/cli-credentials.ts
@@ -19,6 +19,7 @@ import type { OAuthProvider } from "./auth-profiles/types.js";
 const log = createSubsystemLogger("agents/auth-profiles");
 
 const CLAUDE_CLI_CREDENTIALS_RELATIVE_PATH = ".claude/.credentials.json";
+const CLAUDE_CLI_USER_SETTINGS_RELATIVE_PATH = ".claude/settings.json";
 const CODEX_CLI_AUTH_FILENAME = "auth.json";
 const MINIMAX_CLI_CREDENTIALS_RELATIVE_PATH = ".minimax/oauth_creds.json";
 const GEMINI_CLI_CREDENTIALS_RELATIVE_PATH = ".gemini/oauth_creds.json";
@@ -65,6 +66,11 @@ export type ClaudeCliCredential =
       subscriptionType?: string;
       rateLimitTier?: string;
       email?: string;
+    }
+  | {
+      type: "api_key_helper";
+      provider: "anthropic";
+      helperHash: string;
     };
 
 /** Credential shape parsed from Codex CLI storage. */
@@ -103,6 +109,13 @@ type ExecSyncFn = typeof execSync;
 function resolveClaudeCliCredentialsPath(homeDir?: string) {
   const baseDir = resolveOsHomeRelativePath(homeDir ?? "~");
   return path.join(baseDir, CLAUDE_CLI_CREDENTIALS_RELATIVE_PATH);
+}
+
+function resolveClaudeCliUserSettingsPath(homeDir?: string) {
+  // Managed Claude CLI launches clear CLAUDE_CONFIG_DIR, so auth discovery
+  // inspects the canonical user settings tree that the child will use.
+  const baseDir = resolveOsHomeRelativePath(homeDir ?? "~");
+  return path.join(baseDir, CLAUDE_CLI_USER_SETTINGS_RELATIVE_PATH);
 }
 
 function parseClaudeCliOauthCredential(claudeOauth: unknown): ClaudeCliCredential | null {
@@ -462,6 +475,21 @@ function readClaudeCliKeychainCredentials(
   }
 }
 
+function readClaudeCliUserApiKeyHelperCredential(homeDir?: string): ClaudeCliCredential | null {
+  const raw = loadJsonFile(resolveClaudeCliUserSettingsPath(homeDir));
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return null;
+  }
+  const helper = (raw as Record<string, unknown>).apiKeyHelper;
+  return typeof helper === "string" && helper.trim().length > 0
+    ? {
+        type: "api_key_helper",
+        provider: "anthropic",
+        helperHash: createHash("sha256").update(helper.trim()).digest("hex"),
+      }
+    : null;
+}
+
 // The CLI login flow writes the account identity to the config file next to
 // the credential store, so the pair describes one login. Capturing it here
 // keeps usage surfaces from re-reading ambient config at fetch time, where a
@@ -487,17 +515,25 @@ function withClaudeAccountEmail(
   if (!cliLogin) {
     return null;
   }
+  if (cliLogin.type === "api_key_helper") {
+    return cliLogin;
+  }
   const email = readClaudeCliAccountEmail(homeDir);
   return email ? { ...cliLogin, email } : cliLogin;
 }
 
-/** Reads Claude CLI credentials from macOS Keychain or the CLI credential file. */
+/** Reads Claude CLI credentials in Claude Code's credential precedence order. */
 function readClaudeCliCredentials(options?: {
   allowKeychainPrompt?: boolean;
   platform?: NodeJS.Platform;
   homeDir?: string;
   execSync?: ExecSyncFn;
 }): ClaudeCliCredential | null {
+  const helperAuth = readClaudeCliUserApiKeyHelperCredential(options?.homeDir);
+  if (helperAuth) {
+    return helperAuth;
+  }
+
   const platform = options?.platform ?? process.platform;
   if (platform === "darwin" && options?.allowKeychainPrompt !== false) {
     const keychainCreds = readClaudeCliKeychainCredentials(options?.execSync);
@@ -533,6 +569,7 @@ export function readClaudeCliCredentialsCached(options?: {
   const platform = options?.platform ?? process.platform;
   const ttlMs = options?.ttlMs ?? 0;
   const credentialsPath = resolveClaudeCliCredentialsPath(options?.homeDir);
+  const settingsPath = resolveClaudeCliUserSettingsPath(options?.homeDir);
   const keychainIntent =
     platform === "darwin" && options?.allowKeychainPrompt !== false ? "keychain" : "file";
   return readCachedCliCredential({
@@ -549,6 +586,8 @@ export function readClaudeCliCredentialsCached(options?: {
     setCache: (next) => {
       claudeCliCache = next;
     },
+    readSourceFingerprint: () =>
+      `${readFileMtimeMs(credentialsPath) ?? "missing"}:${readFileMtimeMs(settingsPath) ?? "missing"}`,
   });
 }
 

--- a/src/agents/model-auth-label.test.ts
+++ b/src/agents/model-auth-label.test.ts
@@ -251,6 +251,30 @@ describe("resolveModelAuthLabel", () => {
     });
   });
 
+  it("shows claude cli apiKeyHelper auth without calling it oauth", () => {
+    mocks.ensureAuthProfileStore.mockReturnValue({
+      version: 1,
+      profiles: {},
+    } as never);
+    mocks.resolveAuthProfileOrder.mockReturnValue([]);
+    mocks.readClaudeCliCredentialsCached.mockReturnValue({
+      type: "api_key_helper",
+      provider: "anthropic",
+      helperHash: "helper-hash",
+    });
+
+    const label = resolveModelAuthLabel({
+      provider: "claude-cli",
+      cfg: {},
+    });
+
+    expect(label).toBe("api-key-helper (claude-cli)");
+    expect(mocks.readClaudeCliCredentialsCached).toHaveBeenCalledWith({
+      ttlMs: 5_000,
+      allowKeychainPrompt: false,
+    });
+  });
+
   it("can skip external auth profile overlays for status labels", () => {
     mocks.loadAuthProfileStoreWithoutExternalProfiles.mockReturnValue({
       version: 1,

--- a/src/agents/model-auth-label.ts
+++ b/src/agents/model-auth-label.ts
@@ -148,11 +148,17 @@ export function resolveModelAuthLabel(params: {
   ) {
     return "oauth (codex-cli)";
   }
-  if (
-    providerKey === "claude-cli" &&
-    readClaudeCliCredentialsCached({ ttlMs: 5_000, allowKeychainPrompt: false })
-  ) {
-    return "oauth (claude-cli)";
+  if (providerKey === "claude-cli") {
+    const auth = readClaudeCliCredentialsCached({
+      ttlMs: 5_000,
+      allowKeychainPrompt: false,
+    });
+    if (auth?.type === "api_key_helper") {
+      return "api-key-helper (claude-cli)";
+    }
+    if (auth) {
+      return "oauth (claude-cli)";
+    }
   }
 
   const customKey = resolveUsableCustomProviderApiKey({

--- a/src/agents/model-auth-markers.test.ts
+++ b/src/agents/model-auth-markers.test.ts
@@ -84,6 +84,9 @@ describe("model auth markers", () => {
   it("reads bundled plugin-owned non-secret markers from manifests", () => {
     withEnv(cleanPluginManifestEnv(), () => {
       expect(isNonSecretApiKeyMarker("codex-app-server")).toBe(true);
+      expect(isNonSecretApiKeyMarker(["openclaw", "claude-cli-api-key-helper"].join(":"))).toBe(
+        true,
+      );
       expect(isNonSecretApiKeyMarker("gcp-vertex-credentials")).toBe(true);
       expect(isNonSecretApiKeyMarker("lmstudio-local")).toBe(true);
       expect(isNonSecretApiKeyMarker("minimax-oauth")).toBe(true);

--- a/src/commands/doctor-claude-cli.test.ts
+++ b/src/commands/doctor-claude-cli.test.ts
@@ -219,6 +219,33 @@ describe("noteClaudeCliHealth", () => {
     });
   });
 
+  it("accepts Claude CLI apiKeyHelper without a stored auth profile", async () => {
+    await withTempHome(({ homeDir, workspaceDir }) => {
+      const noteFn = vi.fn();
+      noteClaudeCliHealth(
+        {
+          agents: {
+            defaults: {
+              model: { primary: "claude-cli/claude-sonnet-4-6" },
+            },
+          },
+        },
+        {
+          homeDir,
+          workspaceDir,
+          noteFn,
+          store: createStore(),
+          readClaudeCliCredentials: () => ({
+            type: "api_key_helper",
+          }),
+          resolveCommandPath: () => "/opt/homebrew/bin/claude",
+        },
+      );
+
+      expect(noteFn).not.toHaveBeenCalled();
+    });
+  });
+
   it("warns when Claude auth is not readable headlessly", async () => {
     await withTempHome(({ homeDir, workspaceDir }) => {
       const noteFn = vi.fn();

--- a/src/commands/doctor-claude-cli.ts
+++ b/src/commands/doctor-claude-cli.ts
@@ -31,7 +31,8 @@ const CLAUDE_CLI_PROVIDER = "claude-cli";
 
 type ClaudeCliReadableCredential =
   | Pick<OAuthCredential, "type" | "expires">
-  | Pick<TokenCredential, "type" | "expires">;
+  | Pick<TokenCredential, "type" | "expires">
+  | { type: "api_key_helper" };
 
 type ClaudeCliDirHealth = "present" | "missing" | "not_directory" | "unreadable" | "readonly";
 
@@ -245,14 +246,14 @@ export function noteClaudeCliHealth(
     );
   }
 
-  if (!storedProfile) {
+  if (!storedProfile && credential?.type !== "api_key_helper") {
     lines.push(`- OpenClaw auth profile: missing (${CLAUDE_CLI_PROFILE_ID}) in ${authStorePath}.`);
     fixHints.push(
       `- Fix: run ${formatCliCommand(
         "openclaw models auth login --provider anthropic --method cli --set-default",
       )}.`,
     );
-  } else if (storedProfile.provider !== CLAUDE_CLI_PROVIDER) {
+  } else if (storedProfile && storedProfile.provider !== CLAUDE_CLI_PROVIDER) {
     lines.push(
       `- OpenClaw auth profile: ${CLAUDE_CLI_PROFILE_ID} is wired to provider "${storedProfile.provider}" instead of "${CLAUDE_CLI_PROVIDER}".`,
     );


### PR DESCRIPTION
Fixes #97489

## What Problem This Solves

Claude CLI turns could fail OpenClaw's pre-spawn auth gate with `missing-provider-auth` when Claude Code was authenticated by the user-level `~/.claude/settings.json` `apiKeyHelper` setting instead of Keychain or `~/.claude/.credentials.json`.

## Why This Change Was Made

Claude Code documents `apiKeyHelper` as a supported dynamic credential source. OpenClaw now recognizes a non-empty user-level helper setting as Claude CLI-managed auth evidence without executing the helper, reading its output, or persisting a fake auth profile.

The maintainer rewrite keeps the shared credential reader canonical across provider discovery, migration, status, doctor, profile synchronization, and auth-epoch invalidation. Helper configuration wins over stale stored Claude OAuth/token credentials, matching Claude Code credential precedence. The helper command is hashed into the auth epoch so changing the setting invalidates cached discovery without exposing the command.

## User Impact

Users with proxy, vault, or rotating-key Claude CLI setups can start OpenClaw turns through `agentRuntime.id: "claude-cli"` without creating dummy credentials. Status and doctor surfaces report helper-backed auth without presenting it as OAuth state.

## Evidence

- Dependency contract: Claude Code documents user settings and `apiKeyHelper`: https://code.claude.com/docs/en/settings and https://code.claude.com/docs/en/authentication
- Focused proof: `node scripts/run-vitest.mjs src/agents/cli-credentials.test.ts src/agents/cli-auth-epoch.test.ts extensions/anthropic/index.test.ts extensions/anthropic/cli-migration.test.ts src/agents/auth-profiles.external-cli-sync.test.ts src/agents/model-auth-label.test.ts src/agents/model-auth-markers.test.ts src/commands/doctor-claude-cli.test.ts` — 8 files, 163 tests passed on the rebased head.
- Fresh autoreview: clean; no accepted/actionable findings.
- Hosted changed gate: formatting, four typecheck lanes, core/extension lint, plugin boundaries, import cycles, and repository guards passed: https://github.com/openclaw/openclaw/actions/runs/29552636396
- The hosted test image did not contain the Claude CLI binary, so dependency behavior was verified against current official docs and the isolated shared-reader/provider seam rather than a packaged CLI spawn.

## Release Note

Fix Claude CLI `apiKeyHelper` authentication routing so helper-managed credentials satisfy OpenClaw's auth gate without persisting secrets.
