### PR TITLE
test(code-mode): fix cross-platform worker URL test

### DIFF
--- a/src/agents/code-mode.test.ts
+++ b/src/agents/code-mode.test.ts
@@ -240,12 +240,20 @@ describe("Code Mode", () => {
   });
 
   it("resolves the packaged worker URL from stable and hashed dist modules", () => {
-    expect(testing.resolveCodeModeWorkerUrl("file:///repo/dist/agents/code-mode.js").pathname).toBe(
-      "/repo/dist/agents/code-mode.worker.js",
-    );
-    expect(testing.resolveCodeModeWorkerUrl("file:///repo/dist/selection-abc123.js").pathname).toBe(
-      "/repo/dist/agents/code-mode.worker.js",
-    );
+    // Use pathToFileURL so the test is correct on Windows (drive-letter paths)
+    // as well as POSIX systems, rather than hardcoding file:///repo/...
+    const { pathToFileURL } = require("node:url");
+    const path = require("node:path");
+
+    const distDir = path.join(path.sep, "repo", "dist");
+    const agentsDir = path.join(distDir, "agents");
+    const workerPath = pathToFileURL(path.join(agentsDir, "code-mode.worker.js")).pathname;
+
+    const stableUrl = pathToFileURL(path.join(agentsDir, "code-mode.js")).href;
+    const hashedUrl = pathToFileURL(path.join(distDir, "selection-abc123.js")).href;
+
+    expect(testing.resolveCodeModeWorkerUrl(stableUrl).pathname).toBe(workerPath);
+    expect(testing.resolveCodeModeWorkerUrl(hashedUrl).pathname).toBe(workerPath);
   });
 
   it("hides all normal tools behind exec and wait", () => {

--- a/src/agents/code-mode.test.ts
+++ b/src/agents/code-mode.test.ts
@@ -1,4 +1,6 @@
 /** Tests Code Mode tool registration, namespace filtering, and run lifecycle. */
+import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { isRecord } from "../../packages/normalization-core/src/record-coerce.js";
 import { setPluginToolMeta } from "../plugins/tools.js";
@@ -240,20 +242,39 @@ describe("Code Mode", () => {
   });
 
   it("resolves the packaged worker URL from stable and hashed dist modules", () => {
-    // Use pathToFileURL so the test is correct on Windows (drive-letter paths)
-    // as well as POSIX systems, rather than hardcoding file:///repo/...
-    const { pathToFileURL } = require("node:url");
-    const path = require("node:path");
+    // The original test hardcoded POSIX file:// URLs and compared against a
+    // hardcoded POSIX pathname. resolveCodeModeWorkerUrl() internally calls
+    // fileURLToPath() and uses path.sep to locate the "/dist/" segment, so
+    // its behavior is platform-dependent — but pathToFileURL() in Node.js
+    // always uses the *current* process's platform semantics and cannot be
+    // forced to emit a Windows-style file:///C:/... URL from a POSIX (e.g.
+    // Linux CI) process, or vice versa. That means this test cannot fully
+    // simulate Windows behavior on a Linux runner regardless of how the
+    // fixture is built.
+    //
+    // What we *can* assert platform-independently is the actual contract of
+    // resolveCodeModeWorkerUrl: given a module URL whose path contains a
+    // "dist" segment, it returns a URL pointing at
+    // "<distRoot>/agents/code-mode.worker.js", and a hashed selection-*.js
+    // module resolves to the same destination as the stable code-mode.js
+    // module. We verify this using the current process's own
+    // pathToFileURL/path.join (so the assertion is internally consistent
+    // regardless of which platform CI runs on), rather than a hardcoded
+    // POSIX string that happened to only ever match Linux.
+    const distRoot = path.join(process.cwd(), "dist-test-fixture", "dist");
+    const agentsDir = path.join(distRoot, "agents");
+    const workerUrl = pathToFileURL(path.join(distRoot, "agents", "code-mode.worker.js"));
 
-    const distDir = path.join(path.sep, "repo", "dist");
-    const agentsDir = path.join(distDir, "agents");
-    const workerPath = pathToFileURL(path.join(agentsDir, "code-mode.worker.js")).pathname;
+    const stableModuleUrl = pathToFileURL(path.join(agentsDir, "code-mode.js")).href;
+    const hashedModuleUrl = pathToFileURL(path.join(distRoot, "selection-abc123.js")).href;
 
-    const stableUrl = pathToFileURL(path.join(agentsDir, "code-mode.js")).href;
-    const hashedUrl = pathToFileURL(path.join(distDir, "selection-abc123.js")).href;
+    const stableResolved = testing.resolveCodeModeWorkerUrl(stableModuleUrl);
+    const hashedResolved = testing.resolveCodeModeWorkerUrl(hashedModuleUrl);
 
-    expect(testing.resolveCodeModeWorkerUrl(stableUrl).pathname).toBe(workerPath);
-    expect(testing.resolveCodeModeWorkerUrl(hashedUrl).pathname).toBe(workerPath);
+    expect(stableResolved.href).toBe(workerUrl.href);
+    expect(hashedResolved.href).toBe(workerUrl.href);
+    // Both inputs resolve to the exact same destination, regardless of platform.
+    expect(stableResolved.href).toBe(hashedResolved.href);
   });
 
   it("hides all normal tools behind exec and wait", () => {


### PR DESCRIPTION
## Summary

Fixes the `resolveCodeModeWorkerUrl` test to assert a platform-independent contract instead of comparing against hardcoded paths.

## Why the previous fix in this PR was still wrong (per ClawSweeper review)

ClawSweeper correctly flagged that my first attempt still didn't prove cross-platform correctness. The previous version built the test fixture with `path.join(path.sep, "repo", "dist", ...)`, but on Linux CI `path.sep` is `/`, so it still produced the exact same `file:///repo/...` shape as the original hardcoded string. It proved nothing new.

**The deeper issue:** `pathToFileURL()` in Node.js always uses the *current process's* platform semantics. It cannot be forced to emit a Windows-style `file:///C:/...` URL while running on a POSIX process (or vice versa). Since `resolveCodeModeWorkerUrl()` itself is platform-dependent internally (`fileURLToPath()` + `path.sep`), **no single-platform CI run can fully simulate a different platform's path semantics for this function** — that limitation is real and I cannot test around it without an actual Windows runner.

## What this version actually verifies

Instead of asserting against a hardcoded string, the test now asserts the *contract* of `resolveCodeModeWorkerUrl()`:

1. A module URL whose path contains a `dist` segment resolves to `<distRoot>/agents/code-mode.worker.js`
2. A hashed `selection-*.js` module resolves to the **same destination** as the stable `code-mode.js` module

Both assertions are built using the *current process's own* `pathToFileURL`/`path.join`, so the test is internally consistent on whichever platform CI actually runs (Linux today, and correctly so if this ever runs on a Windows runner) — rather than a string that only ever incidentally matched Linux.

## Behavioral proof

Verified the new fixture against a standalone reimplementation of `resolveCodeModeWorkerUrl`'s exact `distMarker` lookup logic (copied directly from `code-mode.ts`):

```
$ node -e "... (full distMarker/path.join logic from code-mode.ts) ..."
workerUrl:      file:///cwd/dist-test-fixture/dist/agents/code-mode.worker.js
stableResolved: file:///cwd/dist-test-fixture/dist/agents/code-mode.worker.js
hashedResolved: file:///cwd/dist-test-fixture/dist/agents/code-mode.worker.js
stable match: true
hashed match: true
```

I was not able to run the full `vitest` suite in my sandbox — `vitest.config.ts` requires the complete monorepo dependency graph, which isn't installed in this environment — but the logic verified above is the exact `distMarker`/`path.join` algorithm from `resolveCodeModeWorkerUrl` in `code-mode.ts`, not an approximation.

## Honest limitation

This test cannot prove the function behaves correctly *specifically on Windows* — that would require an actual Windows CI runner or a maintainer with Windows access to confirm. What it does prove is that the test itself no longer silently passes by coincidence on Linux while claiming a cross-platform guarantee it can't back up.

## Changes

```
src/agents/code-mode.test.ts — 1 file, test-only
```