### PR TITLE
fix: preserve cron sessions with stale transcript metadata

### DIFF
--- a/src/commands/sessions-cleanup.test.ts
+++ b/src/commands/sessions-cleanup.test.ts
@@ -122,6 +122,7 @@ describe("sessionsCleanupCommand", () => {
     mocks.resolveSessionCleanupAction.mockImplementation(
       (params: {
         key: string;
+        repairedKeys?: Set<string>;
         missingKeys: Set<string>;
         staleKeys: Set<string>;
         cappedKeys: Set<string>;
@@ -143,6 +144,9 @@ describe("sessionsCleanupCommand", () => {
         }
         if (params.budgetEvictedKeys.has(params.key)) {
           return "evict-budget";
+        }
+        if (params.repairedKeys?.has(params.key)) {
+          return "repair-session-file";
         }
         return "keep";
       },
@@ -453,6 +457,127 @@ describe("sessionsCleanupCommand", () => {
       diskBudget: null,
       wouldMutate: true,
     });
+  });
+
+  it("reports repaired sessionFile metadata in dry-run JSON and action table", async () => {
+    mocks.enforceSessionDiskBudget.mockResolvedValue(null);
+    mocks.runSessionsCleanup.mockResolvedValue({
+      mode: "enforce",
+      previewResults: [
+        {
+          summary: {
+            agentId: "main",
+            storePath: "/resolved/sessions.json",
+            mode: "enforce",
+            dryRun: true,
+            beforeCount: 1,
+            afterCount: 1,
+            repaired: 1,
+            missing: 0,
+            dmScopeRetired: 0,
+            modelRunPruned: 0,
+            pruned: 0,
+            capped: 0,
+            diskBudget: null,
+            wouldMutate: true,
+          },
+          beforeStore: {
+            repaired: { sessionId: "session-id", updatedAt: 1, model: "test:opus" },
+          },
+          repairedKeys: new Set(["repaired"]),
+          missingKeys: new Set<string>(),
+          staleKeys: new Set<string>(),
+          cappedKeys: new Set<string>(),
+          budgetEvictedKeys: new Set<string>(),
+          dmScopeRetiredKeys: new Set<string>(),
+          modelRunPrunedKeys: new Set<string>(),
+        },
+      ],
+      appliedSummaries: [],
+    });
+
+    const jsonRun = makeRuntime();
+    await sessionsCleanupCommand(
+      {
+        json: true,
+        dryRun: true,
+        enforce: true,
+        fixMissing: true,
+      },
+      jsonRun.runtime,
+    );
+
+    expect(JSON.parse(jsonRun.logs[0] ?? "{}")).toMatchObject({
+      repaired: 1,
+      missing: 0,
+      wouldMutate: true,
+    });
+
+    const tableRun = makeRuntime();
+    await sessionsCleanupCommand(
+      {
+        dryRun: true,
+        enforce: true,
+        fixMissing: true,
+      },
+      tableRun.runtime,
+    );
+
+    expectLogsToInclude(tableRun.logs, "Would repair sessionFile metadata: 1");
+    expectLogsToInclude(tableRun.logs, "repair-session-file");
+  });
+
+  it("lets destructive cleanup actions override repair action rows", async () => {
+    mocks.enforceSessionDiskBudget.mockResolvedValue(null);
+    mocks.runSessionsCleanup.mockResolvedValue({
+      mode: "enforce",
+      previewResults: [
+        {
+          summary: {
+            agentId: "main",
+            storePath: "/resolved/sessions.json",
+            mode: "enforce",
+            dryRun: true,
+            beforeCount: 1,
+            afterCount: 0,
+            repaired: 0,
+            missing: 0,
+            dmScopeRetired: 0,
+            modelRunPruned: 0,
+            pruned: 1,
+            capped: 0,
+            diskBudget: null,
+            wouldMutate: true,
+          },
+          beforeStore: {
+            repairedThenStale: { sessionId: "session-id", updatedAt: 1, model: "test:opus" },
+          },
+          repairedKeys: new Set(["repairedThenStale"]),
+          missingKeys: new Set<string>(),
+          staleKeys: new Set(["repairedThenStale"]),
+          cappedKeys: new Set<string>(),
+          budgetEvictedKeys: new Set<string>(),
+          dmScopeRetiredKeys: new Set<string>(),
+          modelRunPrunedKeys: new Set<string>(),
+        },
+      ],
+      appliedSummaries: [],
+    });
+
+    const { runtime, logs } = makeRuntime();
+    await sessionsCleanupCommand(
+      {
+        dryRun: true,
+        enforce: true,
+        fixMissing: true,
+      },
+      runtime,
+    );
+
+    const row = logs.find((line) => line.includes("repairedThenStale")) ?? "";
+    expect(row).toContain("prune-stale");
+    expect(row).not.toContain("repair-session-file");
+    expectLogsToInclude(logs, "Would repair sessionFile metadata: 0");
   });
 
   it("renders a dry-run action table with keep/prune actions", async () => {

--- a/src/commands/sessions-cleanup.ts
+++ b/src/commands/sessions-cleanup.ts
@@ -32,7 +32,7 @@ import {
   toSessionDisplayRows,
 } from "./sessions-table.js";
 
-const ACTION_PAD = 16;
+const ACTION_PAD = "repair-session-file".length;
 
 type SessionCleanupActionRow = ReturnType<typeof toSessionDisplayRows>[number] & {
   action: ReturnType<typeof resolveSessionCleanupAction>;
@@ -56,6 +56,9 @@ function formatCleanupActionCell(
   if (action === "keep") {
     return theme.muted(label);
   }
+  if (action === "repair-session-file") {
+    return theme.accentBright(label);
+  }
   if (action === "prune-missing") {
     return theme.error(label);
   }
@@ -76,6 +79,7 @@ function formatCleanupActionCell(
 
 function buildActionRows(params: {
   beforeStore: Parameters<typeof toSessionDisplayRows>[0];
+  repairedKeys?: Set<string>;
   missingKeys: Set<string>;
   modelRunPrunedKeys: Set<string>;
   staleKeys: Set<string>;
@@ -90,6 +94,7 @@ function buildActionRows(params: {
       label: params.beforeStore[row.key]?.label,
       action: resolveSessionCleanupAction({
         key: row.key,
+        repairedKeys: params.repairedKeys ?? new Set<string>(),
         missingKeys: params.missingKeys,
         modelRunPrunedKeys: params.modelRunPrunedKeys,
         staleKeys: params.staleKeys,
@@ -111,7 +116,7 @@ function buildLabelSummaries(actionRows: SessionCleanupActionRow[]): SessionClea
       summary = { label, kept: 0, pruned: 0 };
       summaryByLabel.set(label, summary);
     }
-    if (actionRow.action === "keep") {
+    if (actionRow.action === "keep" || actionRow.action === "repair-session-file") {
       summary.kept += 1;
     } else {
       summary.pruned += 1;
@@ -157,6 +162,7 @@ function renderStoreDryRunPlan(params: {
   params.runtime.log(
     `Entries: ${params.summary.beforeCount} -> ${params.summary.afterCount} (remove ${params.summary.beforeCount - params.summary.afterCount})`,
   );
+  params.runtime.log(`Would repair sessionFile metadata: ${params.summary.repaired}`);
   params.runtime.log(`Would prune missing transcripts: ${params.summary.missing}`);
   params.runtime.log(`Would retire stale direct DM sessions: ${params.summary.dmScopeRetired}`);
   params.runtime.log(`Would prune stale model-run probes: ${params.summary.modelRunPruned}`);

--- a/src/config/sessions/cleanup-service.ts
+++ b/src/config/sessions/cleanup-service.ts
@@ -55,6 +55,7 @@ export type SessionsCleanupOptions = SessionStoreSelectionOptions & {
 
 export type SessionCleanupAction =
   | "keep"
+  | "repair-session-file"
   | "prune-missing"
   | "prune-model-run"
   | "prune-stale"
@@ -69,6 +70,7 @@ export type SessionCleanupSummary = {
   dryRun: boolean;
   beforeCount: number;
   afterCount: number;
+  repaired: number;
   missing: number;
   dmScopeRetired: number;
   modelRunPruned: number;
@@ -95,6 +97,7 @@ export type SessionsCleanupRunResult = {
   previewResults: Array<{
     summary: SessionCleanupSummary;
     beforeStore: Record<string, SessionEntry>;
+    repairedKeys: Set<string>;
     missingKeys: Set<string>;
     modelRunPrunedKeys: Set<string>;
     staleKeys: Set<string>;
@@ -191,6 +194,7 @@ function isStaleGeneratedBaseTranscript(params: {
 /** Resolves the action label for one session key from cleanup key sets. */
 export function resolveSessionCleanupAction(params: {
   key: string;
+  repairedKeys: Set<string>;
   missingKeys: Set<string>;
   modelRunPrunedKeys: Set<string>;
   staleKeys: Set<string>;
@@ -215,6 +219,9 @@ export function resolveSessionCleanupAction(params: {
   }
   if (params.budgetEvictedKeys.has(params.key)) {
     return "evict-budget";
+  }
+  if (params.repairedKeys.has(params.key)) {
+    return "repair-session-file";
   }
   return "keep";
 }
@@ -400,6 +407,7 @@ async function previewStoreCleanup(params: {
   const staleKeys = new Set<string>();
   const cappedKeys = new Set<string>();
   const missingKeys = new Set<string>();
+  const repairedKeys = new Set<string>();
   const modelRunPrunedKeys = new Set<string>();
   const dmScopeRetiredKeys = new Set<string>();
   const missingResult =
@@ -409,6 +417,9 @@ async function previewStoreCleanup(params: {
           storePath: params.target.storePath,
           onPruned: (key) => {
             missingKeys.add(key);
+          },
+          onRepaired: (key) => {
+            repairedKeys.add(key);
           },
         })
       : { removed: 0, repaired: 0 };
@@ -508,11 +519,22 @@ async function previewStoreCleanup(params: {
       budgetEvictedKeys.add(key);
     }
   }
+  for (const removedKey of [
+    ...missingKeys,
+    ...modelRunPrunedKeys,
+    ...staleKeys,
+    ...cappedKeys,
+    ...budgetEvictedKeys,
+    ...dmScopeRetiredKeys,
+  ]) {
+    repairedKeys.delete(removedKey);
+  }
+  const repaired = repairedKeys.size;
   const beforeCount = Object.keys(beforeStore).length;
   const afterPreviewCount = Object.keys(previewStore).length;
   const wouldMutate =
     missing > 0 ||
-    missingResult.repaired > 0 ||
+    repaired > 0 ||
     dmScopeRetired > 0 ||
     modelRunPruned > 0 ||
     pruned > 0 ||
@@ -528,6 +550,7 @@ async function previewStoreCleanup(params: {
     dryRun: params.dryRun,
     beforeCount,
     afterCount: afterPreviewCount,
+    repaired,
     missing,
     dmScopeRetired,
     modelRunPruned,
@@ -541,6 +564,7 @@ async function previewStoreCleanup(params: {
   return {
     summary,
     beforeStore,
+    repairedKeys,
     missingKeys,
     modelRunPrunedKeys,
     staleKeys,
@@ -587,6 +611,7 @@ export async function runSessionsCleanup(params: {
     for (const target of targets) {
       const applyStore = loadSessionStore(target.storePath, { skipCache: true });
       const missingRemovals: SessionEntryLifecycleRemoval[] = [];
+      const missingRepairPlans: Array<{ sessionKey: string; sessionFile: string }> = [];
       const missingRepairs: SessionEntryLifecycleUpsert[] = [];
       const dmScopeRetiredRemovals: SessionEntryLifecycleRemoval[] = [];
       if (opts.fixMissing) {
@@ -601,6 +626,7 @@ export async function runSessionsCleanup(params: {
           },
           onRepaired: (sessionKey, entry, sessionFile, previousSessionFile) => {
             const expectedSessionId = entry.sessionId;
+            missingRepairPlans.push({ sessionKey, sessionFile });
             missingRepairs.push({
               sessionKey,
               buildEntry: ({ currentEntry }) => {
@@ -655,6 +681,13 @@ export async function runSessionsCleanup(params: {
               },
       });
       const removedSessionKeys = new Set(lifecycleResult.removedSessionKeys);
+      const postApplyStore: Record<string, SessionEntry> =
+        missingRepairPlans.length > 0
+          ? loadSessionStore(target.storePath, { skipCache: true })
+          : {};
+      const repairedApplied = missingRepairPlans.filter(
+        ({ sessionKey, sessionFile }) => postApplyStore[sessionKey]?.sessionFile === sessionFile,
+      ).length;
       const missingApplied = missingRemovals.filter(({ sessionKey }) =>
         removedSessionKeys.has(sessionKey),
       ).length;
@@ -689,6 +722,7 @@ export async function runSessionsCleanup(params: {
                 dryRun: false,
                 beforeCount: 0,
                 afterCount: 0,
+                repaired: 0,
                 missing: 0,
                 dmScopeRetired: 0,
                 modelRunPruned: 0,
@@ -702,6 +736,7 @@ export async function runSessionsCleanup(params: {
               unreferencedArtifacts,
               wouldMutate:
                 (preview?.summary.wouldMutate ?? false) || unreferencedArtifacts.removedFiles > 0,
+              repaired: repairedApplied,
               applied: true,
               appliedCount: lifecycleResult.afterCount,
             }
@@ -712,6 +747,7 @@ export async function runSessionsCleanup(params: {
               dryRun: false,
               beforeCount: appliedReport.beforeCount,
               afterCount: appliedReport.afterCount,
+              repaired: repairedApplied,
               missing: missingApplied,
               dmScopeRetired: dmScopeRetiredApplied,
               modelRunPruned: appliedReport.modelRunPruned,
@@ -721,7 +757,7 @@ export async function runSessionsCleanup(params: {
               diskBudget: appliedReport.diskBudget,
               wouldMutate:
                 missingApplied > 0 ||
-                missingRepairs.length > 0 ||
+                repairedApplied > 0 ||
                 dmScopeRetiredApplied > 0 ||
                 appliedReport.modelRunPruned > 0 ||
                 appliedReport.pruned > 0 ||

--- a/src/config/sessions/cleanup-service.ts
+++ b/src/config/sessions/cleanup-service.ts
@@ -13,15 +13,18 @@ import {
   resolveSessionArtifactCanonicalPathsForEntry,
   type SessionUnreferencedArtifactSweepResult,
 } from "./disk-budget.js";
+import { extractGeneratedTranscriptSessionId } from "./generated-transcript-session-id.js";
 import {
   resolveSessionFilePath,
   resolveSessionFilePathOptions,
+  resolveSessionTranscriptPathInDir,
   resolveStorePath,
 } from "./paths.js";
 import {
   applySessionEntryLifecycleMutation,
   purgeDeletedAgentSessionEntries,
   type SessionEntryLifecycleRemoval,
+  type SessionEntryLifecycleUpsert,
 } from "./session-accessor.js";
 import { cloneSessionStoreRecord } from "./store-cache.js";
 import { collectSessionMaintenancePreserveKeys } from "./store-maintenance-preserve.js";
@@ -170,6 +173,21 @@ function transcriptHasNoMessageRecords(transcriptPath: string): boolean {
   return true;
 }
 
+function transcriptExistsWithMessages(transcriptPath: string): boolean {
+  return fs.existsSync(transcriptPath) && !transcriptHasNoMessageRecords(transcriptPath);
+}
+
+function isStaleGeneratedBaseTranscript(params: {
+  sessionId: string;
+  sessionFile?: string;
+}): boolean {
+  const generatedSessionId = extractGeneratedTranscriptSessionId(params.sessionFile);
+  if (!generatedSessionId || generatedSessionId === params.sessionId) {
+    return false;
+  }
+  return path.basename(params.sessionFile?.trim() ?? "") === `${generatedSessionId}.jsonl`;
+}
+
 /** Resolves the action label for one session key from cleanup key sets. */
 export function resolveSessionCleanupAction(params: {
   key: string;
@@ -278,11 +296,19 @@ function pruneMissingTranscriptEntries(params: {
   store: Record<string, SessionEntry>;
   storePath: string;
   onPruned?: (key: string, entry: SessionEntry) => void;
-}): number {
+  onRepaired?: (
+    key: string,
+    entry: SessionEntry,
+    sessionFile: string,
+    previousSessionFile: string | undefined,
+  ) => void;
+}): { removed: number; repaired: number } {
   const sessionPathOpts = resolveSessionFilePathOptions({
     storePath: params.storePath,
   });
+  const sessionsDir = path.dirname(params.storePath);
   let removed = 0;
+  let repaired = 0;
   for (const [key, entry] of Object.entries(params.store)) {
     if (!entry?.sessionId) {
       if (parseAgentSessionKey(key)) {
@@ -294,11 +320,35 @@ function pruneMissingTranscriptEntries(params: {
       params.onPruned?.(key, entry);
       continue;
     }
+    let canonicalTranscriptPath: string | undefined;
+    try {
+      canonicalTranscriptPath = resolveSessionTranscriptPathInDir(entry.sessionId, sessionsDir);
+    } catch {
+      // Malformed legacy rows cannot resolve a transcript path; --fix-missing prunes them.
+    }
     let transcriptPath: string | undefined;
     try {
       transcriptPath = resolveSessionFilePath(entry.sessionId, entry, sessionPathOpts);
     } catch {
-      // Malformed legacy rows cannot resolve a transcript path; --fix-missing prunes them.
+      // Malformed sessionFile metadata can still be repaired via the canonical path below.
+    }
+    if (
+      isStaleGeneratedBaseTranscript({
+        sessionId: entry.sessionId,
+        sessionFile: entry.sessionFile,
+      }) &&
+      canonicalTranscriptPath &&
+      canonicalTranscriptPath !== transcriptPath &&
+      transcriptExistsWithMessages(canonicalTranscriptPath)
+    ) {
+      const previousSessionFile = entry.sessionFile;
+      entry.sessionFile = canonicalTranscriptPath;
+      repaired += 1;
+      params.onRepaired?.(key, entry, canonicalTranscriptPath, previousSessionFile);
+      continue;
+    }
+    if (transcriptPath && transcriptExistsWithMessages(transcriptPath)) {
+      continue;
     }
     if (
       !transcriptPath ||
@@ -310,7 +360,7 @@ function pruneMissingTranscriptEntries(params: {
       params.onPruned?.(key, entry);
     }
   }
-  return removed;
+  return { removed, repaired };
 }
 
 function addEntryArtifactPathsToSet(params: {
@@ -352,7 +402,7 @@ async function previewStoreCleanup(params: {
   const missingKeys = new Set<string>();
   const modelRunPrunedKeys = new Set<string>();
   const dmScopeRetiredKeys = new Set<string>();
-  const missing =
+  const missingResult =
     params.fixMissing === true
       ? pruneMissingTranscriptEntries({
           store: previewStore,
@@ -361,7 +411,8 @@ async function previewStoreCleanup(params: {
             missingKeys.add(key);
           },
         })
-      : 0;
+      : { removed: 0, repaired: 0 };
+  const missing = missingResult.removed;
   const dmScopeRetired =
     params.fixDmScope === true
       ? retireMainScopeDirectSessionEntries({
@@ -461,6 +512,7 @@ async function previewStoreCleanup(params: {
   const afterPreviewCount = Object.keys(previewStore).length;
   const wouldMutate =
     missing > 0 ||
+    missingResult.repaired > 0 ||
     dmScopeRetired > 0 ||
     modelRunPruned > 0 ||
     pruned > 0 ||
@@ -535,6 +587,7 @@ export async function runSessionsCleanup(params: {
     for (const target of targets) {
       const applyStore = loadSessionStore(target.storePath, { skipCache: true });
       const missingRemovals: SessionEntryLifecycleRemoval[] = [];
+      const missingRepairs: SessionEntryLifecycleUpsert[] = [];
       const dmScopeRetiredRemovals: SessionEntryLifecycleRemoval[] = [];
       if (opts.fixMissing) {
         pruneMissingTranscriptEntries({
@@ -544,6 +597,23 @@ export async function runSessionsCleanup(params: {
             missingRemovals.push({
               sessionKey,
               expectedEntry: cloneSessionStoreRecord({ entry }).entry,
+            });
+          },
+          onRepaired: (sessionKey, entry, sessionFile, previousSessionFile) => {
+            const expectedSessionId = entry.sessionId;
+            missingRepairs.push({
+              sessionKey,
+              buildEntry: ({ currentEntry }) => {
+                if (
+                  !currentEntry ||
+                  currentEntry.sessionId !== expectedSessionId ||
+                  currentEntry.sessionFile !== previousSessionFile ||
+                  !transcriptExistsWithMessages(sessionFile)
+                ) {
+                  return undefined;
+                }
+                return { ...currentEntry, sessionFile };
+              },
             });
           },
         });
@@ -570,6 +640,7 @@ export async function runSessionsCleanup(params: {
       const lifecycleResult = await applySessionEntryLifecycleMutation({
         storePath: target.storePath,
         removals,
+        upserts: missingRepairs,
         activeSessionKey: opts.activeKey,
         maintenanceOverride: {
           mode,
@@ -650,6 +721,7 @@ export async function runSessionsCleanup(params: {
               diskBudget: appliedReport.diskBudget,
               wouldMutate:
                 missingApplied > 0 ||
+                missingRepairs.length > 0 ||
                 dmScopeRetiredApplied > 0 ||
                 appliedReport.modelRunPruned > 0 ||
                 appliedReport.pruned > 0 ||

--- a/src/config/sessions/store.pruning.integration.test.ts
+++ b/src/config/sessions/store.pruning.integration.test.ts
@@ -613,10 +613,12 @@ describe("Integration: saveSessionStore with pruning", () => {
     });
 
     const preview = dryRun.previewResults[0];
+    expect(preview?.summary.repaired).toBe(1);
     expect(preview?.summary.missing).toBe(0);
     expect(preview?.summary.beforeCount).toBe(1);
     expect(preview?.summary.afterCount).toBe(1);
     expect(preview?.summary.wouldMutate).toBe(true);
+    expect(preview?.repairedKeys.has("agent:main:cron:job:run:fresh")).toBe(true);
     expect(preview?.missingKeys.size).toBe(0);
     expect(
       loadSessionStore(storePath, { skipCache: true })["agent:main:cron:job:run:fresh"]
@@ -629,6 +631,7 @@ describe("Integration: saveSessionStore with pruning", () => {
       targets: [{ agentId: "main", storePath }],
     });
 
+    expect(applied.appliedSummaries[0]?.repaired).toBe(1);
     expect(applied.appliedSummaries[0]?.missing).toBe(0);
     expect(applied.appliedSummaries[0]?.afterCount).toBe(1);
     expect(applied.appliedSummaries[0]?.wouldMutate).toBe(true);
@@ -680,6 +683,7 @@ describe("Integration: saveSessionStore with pruning", () => {
       targets: [{ agentId: "main", storePath }],
     });
 
+    expect(applied.appliedSummaries[0]?.repaired).toBe(1);
     expect(applied.appliedSummaries[0]?.missing).toBe(0);
     const persisted = loadSessionStore(storePath, { skipCache: true });
     expect(persisted[sessionKey]?.sessionFile).toBe(canonicalTranscript);
@@ -741,6 +745,7 @@ describe("Integration: saveSessionStore with pruning", () => {
       targets: [{ agentId: "main", storePath }],
     });
 
+    expect(applied.appliedSummaries[0]?.repaired).toBe(0);
     expect(applied.appliedSummaries[0]?.missing).toBe(0);
     const persisted = loadSessionStore(storePath, { skipCache: true });
     expect(persisted[sessionKey]?.sessionFile).toBe(concurrentTranscript);

--- a/src/config/sessions/store.pruning.integration.test.ts
+++ b/src/config/sessions/store.pruning.integration.test.ts
@@ -578,6 +578,217 @@ describe("Integration: saveSessionStore with pruning", () => {
     await expectPathExists(userOnlyPresentTranscript);
   });
 
+  it("sessions cleanup repairs stale generated sessionFile metadata before pruning", async () => {
+    applyEnforcedMaintenanceConfig(mockLoadConfig);
+
+    const now = Date.now();
+    const sessionId = "11111111-1111-4111-8111-111111111111";
+    const staleTranscript = path.join(testDir, "22222222-2222-4222-8222-222222222222.jsonl");
+    const canonicalTranscript = path.join(testDir, `${sessionId}.jsonl`);
+    await fs.writeFile(
+      storePath,
+      JSON.stringify(
+        {
+          "agent:main:cron:job:run:fresh": {
+            sessionId,
+            updatedAt: now,
+            sessionFile: staleTranscript,
+          },
+        } satisfies Record<string, SessionEntry>,
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+    await fs.writeFile(
+      canonicalTranscript,
+      '{"type":"session","id":"11111111-1111-4111-8111-111111111111","cwd":"/tmp"}\n{"type":"message","message":{"role":"user","content":"still valid"}}\n',
+      "utf-8",
+    );
+
+    const dryRun = await runSessionsCleanup({
+      cfg: {},
+      opts: { store: storePath, dryRun: true, enforce: true, fixMissing: true },
+      targets: [{ agentId: "main", storePath }],
+    });
+
+    const preview = dryRun.previewResults[0];
+    expect(preview?.summary.missing).toBe(0);
+    expect(preview?.summary.beforeCount).toBe(1);
+    expect(preview?.summary.afterCount).toBe(1);
+    expect(preview?.summary.wouldMutate).toBe(true);
+    expect(preview?.missingKeys.size).toBe(0);
+    expect(
+      loadSessionStore(storePath, { skipCache: true })["agent:main:cron:job:run:fresh"]
+        ?.sessionFile,
+    ).toBe(staleTranscript);
+
+    const applied = await runSessionsCleanup({
+      cfg: {},
+      opts: { store: storePath, enforce: true, fixMissing: true },
+      targets: [{ agentId: "main", storePath }],
+    });
+
+    expect(applied.appliedSummaries[0]?.missing).toBe(0);
+    expect(applied.appliedSummaries[0]?.afterCount).toBe(1);
+    expect(applied.appliedSummaries[0]?.wouldMutate).toBe(true);
+    const persisted = loadSessionStore(storePath, { skipCache: true });
+    expect(persisted["agent:main:cron:job:run:fresh"]?.sessionFile).toBe(canonicalTranscript);
+    await expectPathExists(canonicalTranscript);
+  });
+
+  it("sessions cleanup repairs stale generated metadata even when the stale transcript exists", async () => {
+    applyEnforcedMaintenanceConfig(mockLoadConfig);
+
+    const now = Date.now();
+    const oldDate = new Date(now - 10 * DAY_MS);
+    const sessionKey = "agent:main:cron:job:run:fresh";
+    const sessionId = "55555555-5555-4555-8555-555555555555";
+    const staleTranscript = path.join(testDir, "66666666-6666-4666-8666-666666666666.jsonl");
+    const canonicalTranscript = path.join(testDir, `${sessionId}.jsonl`);
+    await fs.writeFile(
+      storePath,
+      JSON.stringify(
+        {
+          [sessionKey]: {
+            sessionId,
+            updatedAt: now,
+            sessionFile: staleTranscript,
+          },
+        } satisfies Record<string, SessionEntry>,
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+    await fs.writeFile(
+      staleTranscript,
+      '{"type":"session","id":"66666666-6666-4666-8666-666666666666","cwd":"/tmp"}\n{"type":"message","message":{"role":"user","content":"old transcript"}}\n',
+      "utf-8",
+    );
+    await fs.writeFile(
+      canonicalTranscript,
+      '{"type":"session","id":"55555555-5555-4555-8555-555555555555","cwd":"/tmp"}\n{"type":"message","message":{"role":"user","content":"current transcript"}}\n',
+      "utf-8",
+    );
+    await fs.utimes(staleTranscript, oldDate, oldDate);
+    await fs.utimes(canonicalTranscript, oldDate, oldDate);
+
+    const applied = await runSessionsCleanup({
+      cfg: {},
+      opts: { store: storePath, enforce: true, fixMissing: true },
+      targets: [{ agentId: "main", storePath }],
+    });
+
+    expect(applied.appliedSummaries[0]?.missing).toBe(0);
+    const persisted = loadSessionStore(storePath, { skipCache: true });
+    expect(persisted[sessionKey]?.sessionFile).toBe(canonicalTranscript);
+    await expectPathExists(canonicalTranscript);
+  });
+
+  it("sessions cleanup does not clobber concurrent sessionFile updates while repairing", async () => {
+    applyEnforcedMaintenanceConfig(mockLoadConfig);
+
+    const now = Date.now();
+    const sessionKey = "agent:main:cron:job:run:fresh";
+    const sessionId = "33333333-3333-4333-8333-333333333333";
+    const staleTranscript = path.join(testDir, "44444444-4444-4444-8444-444444444444.jsonl");
+    const canonicalTranscript = path.join(testDir, `${sessionId}.jsonl`);
+    const concurrentTranscript = path.join(testDir, "concurrent-cron-session.jsonl");
+    await fs.writeFile(
+      storePath,
+      JSON.stringify(
+        {
+          [sessionKey]: {
+            sessionId,
+            updatedAt: now,
+            sessionFile: staleTranscript,
+          },
+        } satisfies Record<string, SessionEntry>,
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+    await fs.writeFile(
+      canonicalTranscript,
+      '{"type":"session","id":"33333333-3333-4333-8333-333333333333","cwd":"/tmp"}\n{"type":"message","message":{"role":"user","content":"still valid"}}\n',
+      "utf-8",
+    );
+    await fs.writeFile(
+      concurrentTranscript,
+      '{"type":"session","id":"33333333-3333-4333-8333-333333333333","cwd":"/tmp"}\n{"type":"message","message":{"role":"assistant","content":"newer write"}}\n',
+      "utf-8",
+    );
+
+    const staleEntry = loadSessionStore(storePath, { skipCache: true })[sessionKey];
+    expect(staleEntry?.sessionFile).toBe(staleTranscript);
+    await updateSessionStore(storePath, (store) => {
+      const current = store[sessionKey];
+      if (!current) {
+        throw new Error("expected session entry");
+      }
+      store[sessionKey] = {
+        ...current,
+        sessionFile: concurrentTranscript,
+        updatedAt: now + 1,
+      };
+    });
+
+    const applied = await runSessionsCleanup({
+      cfg: {},
+      opts: { store: storePath, enforce: true, fixMissing: true },
+      targets: [{ agentId: "main", storePath }],
+    });
+
+    expect(applied.appliedSummaries[0]?.missing).toBe(0);
+    const persisted = loadSessionStore(storePath, { skipCache: true });
+    expect(persisted[sessionKey]?.sessionFile).toBe(concurrentTranscript);
+    expect(persisted[sessionKey]?.updatedAt).toBe(now + 1);
+  });
+
+  it("sessions cleanup does not repair missing topic transcripts to the base transcript", async () => {
+    applyEnforcedMaintenanceConfig(mockLoadConfig);
+
+    const now = Date.now();
+    const sessionKey = "agent:main:telegram:thread:topic";
+    const sessionId = "aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa";
+    const missingTopicTranscript = path.join(testDir, `${sessionId}-topic-456.jsonl`);
+    const baseTranscript = path.join(testDir, `${sessionId}.jsonl`);
+    await fs.writeFile(
+      storePath,
+      JSON.stringify(
+        {
+          [sessionKey]: {
+            sessionId,
+            updatedAt: now,
+            sessionFile: missingTopicTranscript,
+          },
+        } satisfies Record<string, SessionEntry>,
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+    await fs.writeFile(
+      baseTranscript,
+      '{"type":"session","id":"aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa","cwd":"/tmp"}\n{"type":"message","message":{"role":"user","content":"base conversation"}}\n',
+      "utf-8",
+    );
+
+    const applied = await runSessionsCleanup({
+      cfg: {},
+      opts: { store: storePath, enforce: true, fixMissing: true },
+      targets: [{ agentId: "main", storePath }],
+    });
+
+    expect(applied.appliedSummaries[0]?.missing).toBe(1);
+    expect(applied.appliedSummaries[0]?.afterCount).toBe(0);
+    const persisted = loadSessionStore(storePath, { skipCache: true });
+    expect(persisted[sessionKey]).toBeUndefined();
+    await expectPathExists(baseTranscript);
+  });
+
   it("sessions cleanup previews stale direct DM rows after dmScope returns to main", async () => {
     applyEnforcedMaintenanceConfig(mockLoadConfig);
 


### PR DESCRIPTION
Closes #50248

## What Problem This Solves

Fixes an issue where users running `openclaw sessions cleanup --fix-missing` could lose a fresh cron session when the session row still pointed at a stale transcript path even though the canonical transcript for the same session id existed.

## Why This Change Was Made

The cleanup flow now treats stale `sessionFile` metadata as repairable state instead of missing-session evidence: it reports repairs in dry-run output, persists the canonical transcript path during apply, and lets destructive cleanup decisions take precedence when a row is also stale, capped, or genuinely missing.

## User Impact

Fresh cron sessions with valid transcripts are preserved and repaired instead of being pruned because of stale metadata. Operators also get explicit JSON and table output showing `repair-session-file` / `repaired` counts before applying cleanup.

## Evidence

- Real CLI dry-run JSON proof against an isolated scratch store with one fresh cron session whose `sessionFile` pointed at a stale transcript while the canonical transcript existed: `node --import tsx src/entry.ts sessions cleanup --store <scratch>/sessions.json --dry-run --enforce --fix-missing --json` returned `beforeCount: 1`, `afterCount: 1`, `repaired: 1`, `missing: 0`, `pruned: 0`, `capped: 0`, and `wouldMutate: true`.
- Real CLI dry-run terminal proof for the same store: `node --import tsx src/entry.ts sessions cleanup --store <scratch>/sessions.json --dry-run --enforce --fix-missing` printed `Would repair sessionFile metadata: 1`, table action `repair-session-file`, and label summary `Cron: proof job  1 kept, 0 pruned`.
- Real CLI apply proof for the same store: `node --import tsx src/entry.ts sessions cleanup --store <scratch>/sessions.json --enforce --fix-missing --json` returned `repaired: 1`, `missing: 0`, `afterCount: 1`, `applied: true`, and `appliedCount: 1`; a follow-up store read showed persisted `sessionFile` changed to the canonical `11111111-1111-4111-8111-111111111111.jsonl` transcript path.
- Focused regression tests: `OPENCLAW_VITEST_MAX_WORKERS=1` with an isolated `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH`, then `node scripts/run-vitest.mjs src/commands/sessions-cleanup.test.ts src/config/sessions/store.pruning.integration.test.ts --reporter dot` passed with `Test Files 2 passed (2)` and `Tests 45 passed (45)`.
- Focused checks passed: `node_modules/.bin/oxfmt.cmd --check --threads=1 src/config/sessions/cleanup-service.ts src/config/sessions/store.pruning.integration.test.ts src/commands/sessions-cleanup.ts src/commands/sessions-cleanup.test.ts`; `node scripts/run-oxlint.mjs src/config/sessions/cleanup-service.ts src/config/sessions/store.pruning.integration.test.ts src/commands/sessions-cleanup.ts src/commands/sessions-cleanup.test.ts`; `git diff --check`.
- Local autoreview after the repair-action precedence fix reported: `autoreview clean: no accepted/actionable findings reported`.
- Not tested: broad local `pnpm check`, full typecheck, live cron scheduling, or fleet-wide cleanup apply. The proof is scoped to the changed sessions cleanup command/store behavior.