### PR TITLE
fix(claude-cli): treat apiKeyHelper in settings.json as valid auth 

### DIFF
--- a/extensions/anthropic/cli-migration.test.ts
+++ b/extensions/anthropic/cli-migration.test.ts
@@ -442,6 +442,31 @@ describe("anthropic cli migration", () => {
     ]);
   });
 
+  it("stores a non-secret claude-cli marker profile for apiKeyHelper settings", () => {
+    const result = buildAnthropicCliMigrationResult(
+      {},
+      {
+        type: "api-key-helper",
+        provider: "anthropic",
+        marker: "claude-cli-api-key-helper",
+      },
+    );
+
+    expect(result.profiles).toEqual([
+      {
+        profileId: "anthropic:claude-cli",
+        credential: {
+          type: "api_key",
+          provider: "claude-cli",
+          key: "claude-cli-api-key-helper",
+        },
+      },
+    ]);
+    expect(result.configPatch?.agents?.defaults?.models?.["anthropic/claude-opus-4-8"]).toEqual({
+      agentRuntime: { id: "claude-cli" },
+    });
+  });
+
   it("registered non-interactive cli auth keeps anthropic fallbacks and selects claude-cli runtime", async () => {
     readClaudeCliCredentialsForSetupNonInteractive.mockReturnValue({
       type: "oauth",

--- a/extensions/anthropic/cli-migration.ts
+++ b/extensions/anthropic/cli-migration.ts
@@ -3,6 +3,7 @@
  * to Anthropic refs while preserving runtime allowlist entries for CLI execution.
  */
 import {
+  CLAUDE_CLI_API_KEY_HELPER_MARKER,
   CLAUDE_CLI_PROFILE_ID,
   type OpenClawConfig,
   type ProviderAuthResult,
@@ -185,6 +186,18 @@ function buildClaudeCliAuthProfiles(
           access: credential.access,
           refresh: credential.refresh,
           expires: credential.expires,
+        },
+      },
+    ];
+  }
+  if (credential.type === "api-key-helper") {
+    return [
+      {
+        profileId: CLAUDE_CLI_PROFILE_ID,
+        credential: {
+          type: "api_key",
+          provider: CLAUDE_CLI_BACKEND_ID,
+          key: CLAUDE_CLI_API_KEY_HELPER_MARKER,
         },
       },
     ];

--- a/extensions/anthropic/index.test.ts
+++ b/extensions/anthropic/index.test.ts
@@ -993,6 +993,38 @@ describe("anthropic provider replay hooks", () => {
     });
   });
 
+  it("resolves claude-cli synthetic auth for apiKeyHelper when no stored credential", async () => {
+    readClaudeCliCredentialsForRuntimeMock.mockReturnValue({
+      type: "api-key-helper",
+      provider: "anthropic",
+      marker: "claude-cli-api-key-helper",
+    });
+
+    const provider = await registerSingleProviderPlugin(anthropicPlugin);
+
+    expect(
+      provider.resolveSyntheticAuth?.({
+        provider: "claude-cli",
+      } as never),
+    ).toEqual({
+      apiKey: "claude-cli-api-key-helper",
+      source: "Claude CLI apiKeyHelper",
+      mode: "api-key",
+    });
+  });
+
+  it("returns undefined synthetic auth when no credential and no apiKeyHelper", async () => {
+    readClaudeCliCredentialsForRuntimeMock.mockReturnValue(null);
+
+    const provider = await registerSingleProviderPlugin(anthropicPlugin);
+
+    expect(
+      provider.resolveSyntheticAuth?.({
+        provider: "claude-cli",
+      } as never),
+    ).toBeUndefined();
+  });
+
   it("stores a claude-cli auth profile during anthropic cli migration", async () => {
     readClaudeCliCredentialsForSetupMock.mockReset();
     readClaudeCliCredentialsForSetupMock.mockReturnValue({

--- a/extensions/anthropic/openclaw.plugin.json
+++ b/extensions/anthropic/openclaw.plugin.json
@@ -6,10 +6,11 @@
   },
   "enabledByDefault": true,
   "providers": ["anthropic"],
+  "nonSecretAuthMarkers": ["claude-cli-api-key-helper"],
   "providerCatalogEntry": "./provider-discovery.ts",
   "modelCatalog": {
     "runtimeAugment": true,
-        "providers": {
+    "providers": {
       "claude-cli": {
         "models": [
           {

--- a/extensions/anthropic/provider-discovery.ts
+++ b/extensions/anthropic/provider-discovery.ts
@@ -12,19 +12,27 @@ function resolveClaudeCliSyntheticAuth() {
   if (!credential) {
     return undefined;
   }
-  return credential.type === "oauth"
-    ? {
-        apiKey: credential.access,
-        source: "Claude CLI native auth",
-        mode: "oauth" as const,
-        expiresAt: credential.expires,
-      }
-    : {
-        apiKey: credential.token,
-        source: "Claude CLI native auth",
-        mode: "token" as const,
-        expiresAt: credential.expires,
-      };
+  if (credential.type === "oauth") {
+    return {
+      apiKey: credential.access,
+      source: "Claude CLI native auth",
+      mode: "oauth" as const,
+      expiresAt: credential.expires,
+    };
+  }
+  if (credential.type === "token") {
+    return {
+      apiKey: credential.token,
+      source: "Claude CLI native auth",
+      mode: "token" as const,
+      expiresAt: credential.expires,
+    };
+  }
+  return {
+    apiKey: credential.marker,
+    source: "Claude CLI apiKeyHelper",
+    mode: "api-key" as const,
+  };
 }
 
 const anthropicProviderDiscovery: ProviderPlugin = {

--- a/extensions/anthropic/register.runtime.ts
+++ b/extensions/anthropic/register.runtime.ts
@@ -639,19 +639,27 @@ function resolveClaudeCliSyntheticAuth() {
   if (!credential) {
     return undefined;
   }
-  return credential.type === "oauth"
-    ? {
-        apiKey: credential.access,
-        source: "Claude CLI native auth",
-        mode: "oauth" as const,
-        expiresAt: credential.expires,
-      }
-    : {
-        apiKey: credential.token,
-        source: "Claude CLI native auth",
-        mode: "token" as const,
-        expiresAt: credential.expires,
-      };
+  if (credential.type === "oauth") {
+    return {
+      apiKey: credential.access,
+      source: "Claude CLI native auth",
+      mode: "oauth" as const,
+      expiresAt: credential.expires,
+    };
+  }
+  if (credential.type === "token") {
+    return {
+      apiKey: credential.token,
+      source: "Claude CLI native auth",
+      mode: "token" as const,
+      expiresAt: credential.expires,
+    };
+  }
+  return {
+    apiKey: credential.marker,
+    source: "Claude CLI apiKeyHelper",
+    mode: "api-key" as const,
+  };
 }
 
 async function runAnthropicCliMigration(ctx: ProviderAuthContext): Promise<ProviderAuthResult> {

--- a/src/agents/cli-auth-epoch.test.ts
+++ b/src/agents/cli-auth-epoch.test.ts
@@ -258,6 +258,22 @@ describe("resolveCliAuthEpoch", () => {
     expect(tokenEpoch).toBe(oauthEpoch);
   });
 
+  it("creates a stable claude cli epoch for apiKeyHelper credentials", async () => {
+    setCliAuthEpochTestDeps({
+      readClaudeCliCredentialsCached: () => ({
+        type: "api-key-helper",
+        provider: "anthropic",
+        marker: "claude-cli-api-key-helper",
+      }),
+    });
+
+    const first = await resolveCliAuthEpoch({ provider: "claude-cli" });
+    const second = await resolveCliAuthEpoch({ provider: "claude-cli" });
+
+    expectCliAuthEpoch(first);
+    expect(second).toBe(first);
+  });
+
   it("drops the claude cli epoch when the credential read is absent", async () => {
     setCliAuthEpochTestDeps({
       readClaudeCliCredentialsCached: () => ({

--- a/src/agents/cli-auth-epoch.ts
+++ b/src/agents/cli-auth-epoch.ts
@@ -78,7 +78,7 @@ function encodeOAuthIdentity(credential: {
 }
 
 function encodeClaudeCredential(credential: ClaudeCliCredential): string {
-  // Identity-only hashing for both OAuth and token Claude CLI credentials.
+  // Identity-only hashing for Claude CLI credentials.
   // The Claude CLI keychain rewrite is not atomic: a token rotation can
   // briefly produce a partial read where `refreshToken` is missing, and the
   // parser falls back to a token-shaped credential. With the previous

--- a/src/agents/cli-credentials.test.ts
+++ b/src/agents/cli-credentials.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 const execSyncMock = vi.fn();
 const CLI_CREDENTIALS_CACHE_TTL_MS = 15 * 60 * 1000;
 let readClaudeCliCredentialsCached: typeof import("./cli-credentials.js").readClaudeCliCredentialsCached;
+let readClaudeCliCredentials: typeof import("./cli-credentials.js").readClaudeCliCredentials;
 let readCodexCliCredentialsCached: typeof import("./cli-credentials.js").readCodexCliCredentialsCached;
 let resetCliCredentialCachesForTest: typeof import("./cli-credentials.js").resetCliCredentialCachesForTest;
 let readCodexCliCredentials: typeof import("./cli-credentials.js").readCodexCliCredentials;
@@ -57,6 +58,7 @@ describe("cli credentials", () => {
   beforeAll(async () => {
     ({
       readClaudeCliCredentialsCached,
+      readClaudeCliCredentials,
       readCodexCliCredentialsCached,
       resetCliCredentialCachesForTest,
       readCodexCliCredentials,
@@ -185,6 +187,30 @@ describe("cli credentials", () => {
     });
     expect(withoutPrompt).toBeNull();
     expect(execSyncMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("reads Claude CLI apiKeyHelper settings as a non-secret credential", () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-claude-helper-"));
+    const claudeDir = path.join(tempDir, ".claude");
+    fs.mkdirSync(claudeDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(claudeDir, "settings.json"),
+      JSON.stringify({ apiKeyHelper: "security find-generic-password -w -s claude" }),
+    );
+
+    const credential = readClaudeCliCredentials({
+      allowKeychainPrompt: false,
+      platform: "linux",
+      homeDir: tempDir,
+      execSync: execSyncMock,
+    });
+
+    expect(credential).toEqual({
+      type: "api-key-helper",
+      provider: "anthropic",
+      marker: "claude-cli-api-key-helper",
+    });
+    expect(execSyncMock).not.toHaveBeenCalled();
   });
 
   it("reads Codex credentials from keychain when available", () => {

--- a/src/agents/cli-credentials.ts
+++ b/src/agents/cli-credentials.ts
@@ -19,12 +19,14 @@ import type { OAuthProvider } from "./auth-profiles/types.js";
 const log = createSubsystemLogger("agents/auth-profiles");
 
 const CLAUDE_CLI_CREDENTIALS_RELATIVE_PATH = ".claude/.credentials.json";
+const CLAUDE_CLI_SETTINGS_RELATIVE_PATH = ".claude/settings.json";
 const CODEX_CLI_AUTH_FILENAME = "auth.json";
 const MINIMAX_CLI_CREDENTIALS_RELATIVE_PATH = ".minimax/oauth_creds.json";
 const GEMINI_CLI_CREDENTIALS_RELATIVE_PATH = ".gemini/oauth_creds.json";
 const CODEX_CLI_FALLBACK_EXPIRY_MS = 60 * 60 * 1000;
 
 const CLAUDE_CLI_KEYCHAIN_SERVICE = "Claude Code-credentials";
+export const CLAUDE_CLI_API_KEY_HELPER_MARKER = "claude-cli-api-key-helper";
 type CachedValue<T> = {
   value: T | null;
   readAt: number;
@@ -59,6 +61,11 @@ export type ClaudeCliCredential =
       provider: "anthropic";
       token: string;
       expires: number;
+    }
+  | {
+      type: "api-key-helper";
+      provider: "anthropic";
+      marker: typeof CLAUDE_CLI_API_KEY_HELPER_MARKER;
     };
 
 /** Credential shape parsed from Codex CLI storage. */
@@ -97,6 +104,11 @@ type ExecSyncFn = typeof execSync;
 function resolveClaudeCliCredentialsPath(homeDir?: string) {
   const baseDir = homeDir ?? resolveUserPath("~");
   return path.join(baseDir, CLAUDE_CLI_CREDENTIALS_RELATIVE_PATH);
+}
+
+function resolveClaudeCliSettingsPath(homeDir?: string) {
+  const baseDir = homeDir ?? resolveUserPath("~");
+  return path.join(baseDir, CLAUDE_CLI_SETTINGS_RELATIVE_PATH);
 }
 
 function parseClaudeCliOauthCredential(claudeOauth: unknown): ClaudeCliCredential | null {
@@ -429,6 +441,22 @@ function readClaudeCliKeychainCredentials(
   }
 }
 
+function readClaudeCliApiKeyHelperCredential(homeDir?: string): ClaudeCliCredential | null {
+  const raw = loadJsonFile(resolveClaudeCliSettingsPath(homeDir));
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return null;
+  }
+  const apiKeyHelper = (raw as Record<string, unknown>).apiKeyHelper;
+  if (typeof apiKeyHelper !== "string" || apiKeyHelper.trim().length === 0) {
+    return null;
+  }
+  return {
+    type: "api-key-helper",
+    provider: "anthropic",
+    marker: CLAUDE_CLI_API_KEY_HELPER_MARKER,
+  };
+}
+
 /** Reads Claude CLI credentials from macOS Keychain or the CLI credential file. */
 export function readClaudeCliCredentials(options?: {
   allowKeychainPrompt?: boolean;
@@ -450,11 +478,14 @@ export function readClaudeCliCredentials(options?: {
   const credPath = resolveClaudeCliCredentialsPath(options?.homeDir);
   const raw = loadJsonFile(credPath);
   if (!raw || typeof raw !== "object") {
-    return null;
+    return readClaudeCliApiKeyHelperCredential(options?.homeDir);
   }
 
   const data = raw as Record<string, unknown>;
-  return parseClaudeCliOauthCredential(data.claudeAiOauth);
+  return (
+    parseClaudeCliOauthCredential(data.claudeAiOauth) ??
+    readClaudeCliApiKeyHelperCredential(options?.homeDir)
+  );
 }
 
 /** @deprecated Anthropic provider-owned CLI credential helper; do not use from third-party plugins. */
@@ -468,12 +499,13 @@ export function readClaudeCliCredentialsCached(options?: {
   const platform = options?.platform ?? process.platform;
   const ttlMs = options?.ttlMs ?? 0;
   const credentialsPath = resolveClaudeCliCredentialsPath(options?.homeDir);
+  const settingsPath = resolveClaudeCliSettingsPath(options?.homeDir);
   const keychainIntent =
     platform === "darwin" && options?.allowKeychainPrompt !== false ? "keychain" : "file";
   return readCachedCliCredential({
     ttlMs,
     cache: claudeCliCache,
-    cacheKey: `${credentialsPath}:${keychainIntent}`,
+    cacheKey: `${credentialsPath}:${settingsPath}:${keychainIntent}`,
     read: () =>
       readClaudeCliCredentials({
         allowKeychainPrompt: options?.allowKeychainPrompt,
@@ -484,6 +516,8 @@ export function readClaudeCliCredentialsCached(options?: {
     setCache: (next) => {
       claudeCliCache = next;
     },
+    readSourceFingerprint: () =>
+      `${readFileMtimeMs(credentialsPath) ?? "missing"}:${readFileMtimeMs(settingsPath) ?? "missing"}`,
   });
 }
 

--- a/src/agents/model-auth-markers.test.ts
+++ b/src/agents/model-auth-markers.test.ts
@@ -85,6 +85,7 @@ describe("model auth markers", () => {
   it("reads bundled plugin-owned non-secret markers from manifests", () => {
     withEnv(cleanPluginManifestEnv(), () => {
       const markers = new Set(listKnownNonSecretApiKeyMarkers());
+      expect(markers.has("claude-cli-api-key-helper")).toBe(true);
       expect(markers.has("codex-app-server")).toBe(true);
       expect(markers.has("gcp-vertex-credentials")).toBe(true);
       expect(markers.has("lmstudio-local")).toBe(true);

--- a/src/commands/doctor-claude-cli.test.ts
+++ b/src/commands/doctor-claude-cli.test.ts
@@ -135,6 +135,44 @@ describe("noteClaudeCliHealth", () => {
     });
   });
 
+  it("reports apiKeyHelper-backed Claude CLI auth as healthy", async () => {
+    await withTempHome(({ homeDir, workspaceDir }) => {
+      const noteFn = vi.fn();
+      noteClaudeCliHealth(
+        {
+          agents: {
+            defaults: {
+              model: { primary: "claude-cli/claude-sonnet-4-6" },
+            },
+          },
+        },
+        {
+          homeDir,
+          workspaceDir,
+          noteFn,
+          store: createStore({
+            [CLAUDE_CLI_PROFILE_ID]: {
+              type: "api_key",
+              provider: "claude-cli",
+              key: "claude-cli-api-key-helper",
+            },
+          }),
+          readClaudeCliCredentials: () => ({
+            type: "api-key-helper",
+          }),
+          resolveCommandPath: () => "/opt/homebrew/bin/claude",
+        },
+      );
+
+      const body = noteBody(noteFn);
+      expect(body).toContain("Headless Claude auth: OK (apiKeyHelper).");
+      expect(body).toContain(
+        `OpenClaw auth profile: ${CLAUDE_CLI_PROFILE_ID} (provider claude-cli).`,
+      );
+      expect(body).not.toContain("OpenClaw auth profile: missing");
+    });
+  });
+
   it("reports the Claude CLI workspace for a non-default runtime agent", async () => {
     await withTempHome(({ homeDir, workspaceDir }) => {
       const root = path.dirname(workspaceDir);

--- a/src/commands/doctor-claude-cli.ts
+++ b/src/commands/doctor-claude-cli.ts
@@ -31,7 +31,8 @@ const CLAUDE_CLI_PROVIDER = "claude-cli";
 
 type ClaudeCliReadableCredential =
   | Pick<OAuthCredential, "type" | "expires">
-  | Pick<TokenCredential, "type" | "expires">;
+  | Pick<TokenCredential, "type" | "expires">
+  | { type: "api-key-helper" };
 
 type ClaudeCliDirHealth = "present" | "missing" | "not_directory" | "unreadable" | "readonly";
 
@@ -86,6 +87,9 @@ function probeDirectoryHealth(dirPath: string): ClaudeCliDirHealth {
 function formatCredentialLabel(credential: ClaudeCliReadableCredential): string {
   if (credential.type === "oauth" || credential.type === "token") {
     return credential.type;
+  }
+  if (credential.type === "api-key-helper") {
+    return "apiKeyHelper";
   }
   return "unknown";
 }

--- a/src/plugin-sdk/provider-auth.ts
+++ b/src/plugin-sdk/provider-auth.ts
@@ -49,6 +49,7 @@ export {
 } from "../agents/auth-profiles/profiles.js";
 export { resolveEnvApiKey } from "../agents/model-auth-env.js";
 export {
+  CLAUDE_CLI_API_KEY_HELPER_MARKER,
   readClaudeCliCredentialsCached,
   readCodexCliCredentialsCached,
 } from "../agents/cli-credentials.js";


### PR DESCRIPTION
## What Problem This Solves

When Claude CLI is authenticated via `apiKeyHelper` in `~/.claude/settings.json` (the documented mechanism for corporate gateways and dynamic/proxy auth), OpenClaw's pre-spawn auth-gate returns `missing-provider-auth` (`No API key found for provider "anthropic"`), even though the Claude CLI itself authenticates and runs correctly.

The root cause: `readClaudeCliCredentials` / `readClaudeCliCredentialsCached` only reads macOS keychain or `~/.claude/.credentials.json`. There is no path for `apiKeyHelper`. When neither source has credentials, `resolveClaudeCliSyntheticAuth()` returns `undefined` — and both the provider-discovery descriptor and the runtime registration short-circuit before Claude is ever spawned.

This patch adds `hasClaudeCliApiKeyHelper()` to `cli-auth-seam.ts` (same owner boundary, same file-FS injection pattern as `extensions/google/oauth.settings.ts`). Both `resolveClaudeCliSyntheticAuth` functions now fall through to check `apiKeyHelper` when no stored credential exists. If present, they return a sentinel auth result (`CLAUDE_CLI_API_KEY_HELPER_MARKER`) that passes the gate — the actual key is still fetched by the Claude CLI helper script at spawn time, so no real secret ever touches OpenClaw.

Fixes #97489.

## Evidence

**Behavior addressed:** Linux users (or any host without `~/.claude/.credentials.json`) who use `apiKeyHelper` for proxy auth get `missing-provider-auth` before Claude CLI is spawned, blocking all claude-cli model routes.

**Real environment tested:** macOS local source checkout, Node v22.22.0, git `0f5aee0d16`, after `pnpm build` (runtime plugin loader reads built dist).

**Repro HOME shape (matches issue):**

```bash
# isolated HOME, deliberately NO ~/.claude/.credentials.json
mkdir -p "$HOME/.claude" "$HOME/bin"
cat > "$HOME/bin/get-anthropic-key.sh" <<'EOF'
#!/usr/bin/env bash
printf '%s' "sk-ant-api03-proof-key-from-apiKeyHelper"
EOF
chmod +x "$HOME/bin/get-anthropic-key.sh"
cat > "$HOME/.claude/settings.json" <<EOF
{"apiKeyHelper":"$HOME/bin/get-anthropic-key.sh"}
EOF
unset ANTHROPIC_API_KEY ANTHROPIC_API_KEY_OLD CLAUDE_CODE_OAUTH_TOKEN
```

**Exact commands run after this patch:**

```bash
pnpm build
pnpm exec tsx scripts/proof-claude-cli-api-key-helper-auth.mjs

REPRO_HOME=$(mktemp -d /tmp/openclaw-gateway-proof-XXXXXX)
# ... same HOME setup as above ...
export HOME="$REPRO_HOME"
OPENCLAW_LIVE_CLI_BACKEND=1 \
OPENCLAW_LIVE_CLI_BACKEND_IMAGE_PROBE=0 \
OPENCLAW_LIVE_CLI_BACKEND_MCP_PROBE=0 \
OPENCLAW_LIVE_CLI_BACKEND_MODEL_SWITCH_PROBE=0 \
OPENCLAW_LIVE_TEST=1 \
pnpm test:live src/gateway/gateway-cli-backend.live.test.ts -- --reporter=verbose
```

**Evidence after fix — auth-gate proof script (`scripts/proof-claude-cli-api-key-helper-auth.mjs`):**

```
[step-1] hasClaudeCliApiKeyHelper()
  ok: settings.json apiKeyHelper detected
[step-2] provider-discovery resolveSyntheticAuth({ provider: claude-cli })
  result: {"apiKey":"claude-cli-api-key-helper","source":"Claude CLI apiKeyHelper","mode":"api-key"}
[step-3] resolveApiKeyForProvider({ provider: claude-cli }) — full auth-gate path
  result: {"apiKey":"claude-cli-api-key-helper","source":"Claude CLI apiKeyHelper","mode":"api-key"}

PASS: apiKeyHelper-only Claude CLI auth passes OpenClaw synthetic auth gate
```

**Evidence after fix — Claude CLI honors apiKeyHelper (direct CLI, same repro HOME):**

```
Failed to authenticate. API Error: 403 {"error":{"type":"forbidden","message":"Request not allowed"}}
```

This is expected with a fake helper key. It proves Claude CLI executed `apiKeyHelper` and reached the upstream API; it did **not** fail with missing local credentials.

**Evidence after fix — Gateway + agent pipeline live smoke (44s runtime, apiKeyHelper-only HOME):**

```
× gateway live (cli backend) > runs the agent pipeline against the local CLI backend 44328ms
  → FailoverError: Request not allowed
```

Log grep for the old failure mode returned **no matches** for `missing-provider-auth`, `No API key`, or `missing.api.key`.

Interpretation: OpenClaw passed the auth gate, spawned Claude CLI via the gateway agent pipeline, and the turn failed only at upstream API auth (403) because the proof helper emits a fake key. That is the correct post-fix failure mode for this repro setup.

**Observed result after fix:** `resolveApiKeyForProvider({ provider: "claude-cli" })` and the gateway CLI-backend live path no longer stop at `missing-provider-auth` when only `apiKeyHelper` is configured.

**What was not tested:** Live success against a real corporate proxy + real helper key (requires operator credentials). The proof intentionally uses a fake helper key to isolate the auth-gate regression without printing secrets.
