### PR TITLE
Doctor: expose tool result cap findings

### DIFF
--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -1260,6 +1260,56 @@ describe("doctor health contributions", () => {
     });
   });
 
+  it("reports agent findings for inherited default tool result caps", async () => {
+    const contributionChecks = await resolveDoctorContributionHealthChecks();
+    const toolResultCapCheck = contributionChecks.find(
+      (check) => check.id === "core/doctor/tool-result-cap",
+    );
+    expect(toolResultCapCheck).toBeDefined();
+
+    mocks.resolveAgentContextLimits.mockImplementation(
+      (cfg: { agents?: { defaults?: { contextLimits?: unknown } } }) =>
+        cfg.agents?.defaults?.contextLimits ?? {},
+    );
+    mocks.resolveDefaultModelForAgent.mockImplementation((...args: unknown[]) => {
+      const params = args[0] as { agentId?: string };
+      return params.agentId === "writer"
+        ? { provider: "openai", model: "gpt-5.5" }
+        : { provider: "local", model: "tiny" };
+    });
+    mocks.findModelCatalogEntry.mockImplementation((...args: unknown[]) => {
+      const params = args[1] as { modelId?: string };
+      return params.modelId === "gpt-5.5" ? { contextTokens: 200_000 } : { contextTokens: 8_000 };
+    });
+
+    const ctx = {
+      cfg: {
+        agents: {
+          defaults: { contextLimits: { toolResultMaxChars: 16_000 } },
+          list: [{ id: "writer" }],
+        },
+      },
+      mode: "lint" as const,
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+    };
+
+    await expect(
+      runDoctorLintChecks(ctx, {
+        checks: [toolResultCapCheck!],
+        onlyIds: ["core/doctor/tool-result-cap"],
+      }),
+    ).resolves.toMatchObject({
+      checksRun: 1,
+      findings: expect.arrayContaining([
+        expect.objectContaining({
+          checkId: "core/doctor/tool-result-cap",
+          path: "agents.defaults.contextLimits.toolResultMaxChars",
+          target: "agents.writer",
+        }),
+      ]),
+    });
+  });
+
   it("keeps state integrity opt-in for default lint selection", async () => {
     const contributionChecks = await resolveDoctorContributionHealthChecks();
     const stateIntegrityCheck = contributionChecks.find(

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -61,11 +61,18 @@ const mocks = vi.hoisted(() => ({
   maybeArchiveLegacyClawdBrowserProfileResidue: vi.fn(),
   resolveAgentWorkspaceDir: vi.fn(() => "/tmp/openclaw-workspace"),
   resolveDefaultAgentId: vi.fn(() => "default"),
+  resolveAgentContextLimits: vi.fn(
+    (cfg: { agents?: { defaults?: { contextLimits?: unknown } } }) =>
+      cfg.agents?.defaults?.contextLimits ?? {},
+  ),
   note: vi.fn(),
   loadModelCatalog: vi.fn(async () => []),
+  findModelCatalogEntry: vi.fn(() => ({ contextTokens: 200_000 })),
   getModelRefStatus: vi.fn(() => ({ allowed: true, inCatalog: true, key: "openai/gpt-5.5" })),
   resolveConfiguredModelRef: vi.fn(() => ({ provider: "openai", model: "gpt-5.5" })),
+  resolveDefaultModelForAgent: vi.fn(() => ({ provider: "openai", model: "gpt-5.5" })),
   resolveHooksGmailModel: vi.fn(() => ({ provider: "openai", model: "gpt-5.5" })),
+  modelKey: vi.fn((provider: string, model: string) => `${provider}/${model}`),
   replaceConfigFile: vi.fn().mockResolvedValue(undefined),
   readConfigFileSnapshot: vi.fn().mockResolvedValue({
     exists: true,
@@ -243,6 +250,7 @@ vi.mock("../commands/doctor-browser.js", () => ({
 vi.mock("../agents/agent-scope.js", () => ({
   resolveAgentWorkspaceDir: mocks.resolveAgentWorkspaceDir,
   resolveDefaultAgentId: mocks.resolveDefaultAgentId,
+  resolveAgentContextLimits: mocks.resolveAgentContextLimits,
 }));
 
 vi.mock("../../packages/terminal-core/src/note.js", () => ({
@@ -251,12 +259,15 @@ vi.mock("../../packages/terminal-core/src/note.js", () => ({
 
 vi.mock("../agents/model-catalog.js", () => ({
   loadModelCatalog: mocks.loadModelCatalog,
+  findModelCatalogEntry: mocks.findModelCatalogEntry,
 }));
 
 vi.mock("../agents/model-selection.js", () => ({
   getModelRefStatus: mocks.getModelRefStatus,
   resolveConfiguredModelRef: mocks.resolveConfiguredModelRef,
+  resolveDefaultModelForAgent: mocks.resolveDefaultModelForAgent,
   resolveHooksGmailModel: mocks.resolveHooksGmailModel,
+  modelKey: mocks.modelKey,
 }));
 
 vi.mock("../version.js", async () => ({
@@ -441,9 +452,16 @@ describe("doctor health contributions", () => {
     mocks.resolveAgentWorkspaceDir.mockReturnValue("/tmp/openclaw-workspace");
     mocks.resolveDefaultAgentId.mockReset();
     mocks.resolveDefaultAgentId.mockReturnValue("default");
+    mocks.resolveAgentContextLimits.mockReset();
+    mocks.resolveAgentContextLimits.mockImplementation(
+      (cfg: { agents?: { defaults?: { contextLimits?: unknown } } }) =>
+        cfg.agents?.defaults?.contextLimits ?? {},
+    );
     mocks.note.mockReset();
     mocks.loadModelCatalog.mockReset();
     mocks.loadModelCatalog.mockResolvedValue([]);
+    mocks.findModelCatalogEntry.mockReset();
+    mocks.findModelCatalogEntry.mockReturnValue({ contextTokens: 200_000 });
     mocks.getModelRefStatus.mockReset();
     mocks.getModelRefStatus.mockReturnValue({
       allowed: true,
@@ -452,8 +470,12 @@ describe("doctor health contributions", () => {
     });
     mocks.resolveConfiguredModelRef.mockReset();
     mocks.resolveConfiguredModelRef.mockReturnValue({ provider: "openai", model: "gpt-5.5" });
+    mocks.resolveDefaultModelForAgent.mockReset();
+    mocks.resolveDefaultModelForAgent.mockReturnValue({ provider: "openai", model: "gpt-5.5" });
     mocks.resolveHooksGmailModel.mockReset();
     mocks.resolveHooksGmailModel.mockReturnValue({ provider: "openai", model: "gpt-5.5" });
+    mocks.modelKey.mockReset();
+    mocks.modelKey.mockImplementation((provider: string, model: string) => `${provider}/${model}`);
     mocks.readConfigFileSnapshot.mockReset();
     mocks.readConfigFileSnapshot.mockResolvedValue({
       exists: true,
@@ -1191,7 +1213,51 @@ describe("doctor health contributions", () => {
     expect(contributionIds).toContain("core/doctor/configured-plugin-installs");
     expect(contributionIds).toContain("core/doctor/device-pairing");
     expect(contributionIds).toContain("core/doctor/channel-plugin-blockers");
+    expect(contributionIds).toContain("core/doctor/tool-result-cap");
     expect(contributionChecks.map((check) => check.id)).toEqual(contributionIds);
+  });
+
+  it("keeps tool result cap opt-in for default lint selection", async () => {
+    const contributionChecks = await resolveDoctorContributionHealthChecks();
+    const toolResultCapCheck = contributionChecks.find(
+      (check) => check.id === "core/doctor/tool-result-cap",
+    );
+    expect(toolResultCapCheck).toMatchObject({ defaultEnabled: false });
+    expect(toolResultCapCheck).toBeDefined();
+
+    const ctx = {
+      cfg: {
+        agents: {
+          defaults: { contextLimits: { toolResultMaxChars: 16_000 } },
+        },
+      },
+      mode: "lint",
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+    } as const;
+    const checks = [toolResultCapCheck!];
+
+    await expect(runDoctorLintChecks(ctx, { checks })).resolves.toMatchObject({
+      checksRun: 0,
+      checksSkipped: 1,
+    });
+    await expect(
+      runDoctorLintChecks(ctx, { checks, includeAllChecks: true }),
+    ).resolves.toMatchObject({
+      checksRun: 1,
+      checksSkipped: 0,
+      findings: [
+        expect.objectContaining({
+          checkId: "core/doctor/tool-result-cap",
+          path: "agents.defaults.contextLimits.toolResultMaxChars",
+        }),
+      ],
+    });
+    await expect(
+      runDoctorLintChecks(ctx, { checks, onlyIds: ["core/doctor/tool-result-cap"] }),
+    ).resolves.toMatchObject({
+      checksRun: 1,
+      checksSkipped: 0,
+    });
   });
 
   it("keeps state integrity opt-in for default lint selection", async () => {

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -1304,7 +1304,7 @@ describe("doctor health contributions", () => {
         expect.objectContaining({
           checkId: "core/doctor/tool-result-cap",
           path: "agents.defaults.contextLimits.toolResultMaxChars",
-          target: "agents.writer",
+          target: "agents.list.writer",
         }),
       ]),
     });

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -786,14 +786,115 @@ async function runHooksModelHealth(ctx: DoctorHealthFlowContext): Promise<void> 
   }
 }
 
+type ToolResultCapTarget = {
+  agentId?: string;
+  configuredCap?: number;
+  path?: string;
+  scopeLabel: string;
+  target?: string;
+};
+
+async function collectToolResultCapFindings(
+  cfg: OpenClawConfig,
+): Promise<readonly HealthFinding[]> {
+  const { normalizeAgentId } = await import("../routing/session-key.js");
+  const targets: ToolResultCapTarget[] = [];
+  const defaultsConfiguredCap = cfg.agents?.defaults?.contextLimits?.toolResultMaxChars;
+  if (defaultsConfiguredCap !== undefined) {
+    targets.push({
+      configuredCap: defaultsConfiguredCap,
+      path: "agents.defaults.contextLimits.toolResultMaxChars",
+      scopeLabel: "defaults",
+      target: "agents.defaults",
+    });
+  }
+  for (const entry of cfg.agents?.list ?? []) {
+    const normalizedAgentId = normalizeAgentId(entry.id);
+    if (!normalizedAgentId || entry.contextLimits?.toolResultMaxChars === undefined) {
+      continue;
+    }
+    targets.push({
+      agentId: normalizedAgentId,
+      configuredCap: entry.contextLimits.toolResultMaxChars,
+      path: `agents.${normalizedAgentId}.contextLimits.toolResultMaxChars`,
+      scopeLabel: `agent "${normalizedAgentId}"`,
+      target: `agents.${normalizedAgentId}`,
+    });
+  }
+  if (targets.length === 0) {
+    return [];
+  }
+
+  const { collectToolResultCapDoctorIssues, toolResultCapDoctorIssueToHealthFinding } =
+    await import("./doctor-tool-result-cap-advice.js");
+
+  return collectToolResultCapTargetAdvice({
+    cfg,
+    readOnlyCatalog: true,
+    targets,
+  }).then((entries) =>
+    entries.flatMap((entry) =>
+      collectToolResultCapDoctorIssues(entry).map(toolResultCapDoctorIssueToHealthFinding),
+    ),
+  );
+}
+
+async function collectToolResultCapTargetAdvice(params: {
+  cfg: OpenClawConfig;
+  readOnlyCatalog?: boolean;
+  targets: readonly ToolResultCapTarget[];
+}): Promise<
+  Array<{
+    contextWindowTokens: number;
+    modelKey: string;
+    configuredCap?: number;
+    deep?: boolean;
+    path?: string;
+    scopeLabel?: string;
+    target?: string;
+  }>
+> {
+  const { DEFAULT_CONTEXT_TOKENS } = await loadAgentDefaultsModule();
+  const { loadModelCatalog, findModelCatalogEntry } = await loadModelCatalogModule();
+  const { resolveContextWindowInfo } = await import("../agents/context-window-guard.js");
+  const { resolveDefaultModelForAgent, modelKey } = await loadModelSelectionModule();
+  const catalog = await loadModelCatalog({
+    config: params.cfg,
+    ...(params.readOnlyCatalog ? { readOnly: true } : {}),
+  });
+
+  return params.targets.map((target) => {
+    const modelRef = resolveDefaultModelForAgent({
+      cfg: params.cfg,
+      agentId: target.agentId,
+    });
+    const entry = findModelCatalogEntry(catalog, {
+      provider: modelRef.provider,
+      modelId: modelRef.model,
+    });
+    const contextWindow = resolveContextWindowInfo({
+      cfg: params.cfg,
+      provider: modelRef.provider,
+      modelId: modelRef.model,
+      modelContextTokens: entry?.contextTokens,
+      modelContextWindow: entry?.contextWindow,
+      defaultTokens: DEFAULT_CONTEXT_TOKENS,
+    });
+    return {
+      contextWindowTokens: contextWindow.tokens,
+      modelKey: modelKey(modelRef.provider, modelRef.model),
+      configuredCap: target.configuredCap,
+      path: target.path,
+      scopeLabel: target.scopeLabel,
+      target: target.target,
+    };
+  });
+}
+
 async function runToolResultCapHealth(ctx: DoctorHealthFlowContext): Promise<void> {
   const { resolveAgentContextLimits } = await loadAgentScopeModule();
   const { normalizeAgentId } = await import("../routing/session-key.js");
-  const targets: Array<{
-    agentId?: string;
-    configuredCap?: number;
-    scopeLabel: string;
-  }> = [];
+  const targets: ToolResultCapTarget[] = [];
   const defaultsConfiguredCap = ctx.cfg.agents?.defaults?.contextLimits?.toolResultMaxChars;
   if (ctx.options.deep === true || defaultsConfiguredCap !== undefined) {
     targets.push({
@@ -821,39 +922,18 @@ async function runToolResultCapHealth(ctx: DoctorHealthFlowContext): Promise<voi
     return;
   }
 
-  const { DEFAULT_CONTEXT_TOKENS } = await loadAgentDefaultsModule();
-  const { loadModelCatalog, findModelCatalogEntry } = await loadModelCatalogModule();
-  const { resolveContextWindowInfo } = await import("../agents/context-window-guard.js");
-  const { resolveDefaultModelForAgent, modelKey } = await loadModelSelectionModule();
   const { buildToolResultCapDoctorAdvice } = await import("./doctor-tool-result-cap-advice.js");
   const { note } = await loadNoteModule();
-
-  const catalog = await loadModelCatalog({ config: ctx.cfg });
-  const lines = targets.flatMap((target) => {
-    const modelRef = resolveDefaultModelForAgent({
-      cfg: ctx.cfg,
-      agentId: target.agentId,
-    });
-    const entry = findModelCatalogEntry(catalog, {
-      provider: modelRef.provider,
-      modelId: modelRef.model,
-    });
-    const contextWindow = resolveContextWindowInfo({
-      cfg: ctx.cfg,
-      provider: modelRef.provider,
-      modelId: modelRef.model,
-      modelContextTokens: entry?.contextTokens,
-      modelContextWindow: entry?.contextWindow,
-      defaultTokens: DEFAULT_CONTEXT_TOKENS,
-    });
-    return buildToolResultCapDoctorAdvice({
-      contextWindowTokens: contextWindow.tokens,
-      modelKey: modelKey(modelRef.provider, modelRef.model),
-      configuredCap: target.configuredCap,
-      deep: ctx.options.deep === true,
-      scopeLabel: target.scopeLabel,
-    });
+  const entries = await collectToolResultCapTargetAdvice({
+    cfg: ctx.cfg,
+    targets,
   });
+  const lines = entries.flatMap((entry) =>
+    buildToolResultCapDoctorAdvice({
+      ...entry,
+      deep: ctx.options.deep === true,
+    }),
+  );
   if (lines.length > 0) {
     note(lines.join("\n"), "Tool result cap");
   }
@@ -1679,6 +1759,13 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
     createDoctorHealthContribution({
       id: "doctor:tool-result-cap",
       label: "Tool result cap",
+      healthChecks: {
+        id: "core/doctor/tool-result-cap",
+        description:
+          "Detect explicit toolResultMaxChars settings that fight model-window defaults.",
+        defaultEnabled: false,
+        detect: async (ctx) => collectToolResultCapFindings(ctx.cfg),
+      },
       run: runToolResultCapHealth,
     }),
     createDoctorHealthContribution({

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -823,9 +823,9 @@ async function collectToolResultCapFindings(
       path:
         entry.contextLimits?.toolResultMaxChars === undefined
           ? "agents.defaults.contextLimits.toolResultMaxChars"
-          : `agents.${normalizedAgentId}.contextLimits.toolResultMaxChars`,
+          : `agents.list.${normalizedAgentId}.contextLimits.toolResultMaxChars`,
       scopeLabel: `agent "${normalizedAgentId}"`,
-      target: `agents.${normalizedAgentId}`,
+      target: `agents.list.${normalizedAgentId}`,
     });
   }
   if (targets.length === 0) {

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -797,6 +797,7 @@ type ToolResultCapTarget = {
 async function collectToolResultCapFindings(
   cfg: OpenClawConfig,
 ): Promise<readonly HealthFinding[]> {
+  const { resolveAgentContextLimits } = await loadAgentScopeModule();
   const { normalizeAgentId } = await import("../routing/session-key.js");
   const targets: ToolResultCapTarget[] = [];
   const defaultsConfiguredCap = cfg.agents?.defaults?.contextLimits?.toolResultMaxChars;
@@ -810,13 +811,19 @@ async function collectToolResultCapFindings(
   }
   for (const entry of cfg.agents?.list ?? []) {
     const normalizedAgentId = normalizeAgentId(entry.id);
-    if (!normalizedAgentId || entry.contextLimits?.toolResultMaxChars === undefined) {
+    if (
+      !normalizedAgentId ||
+      (defaultsConfiguredCap === undefined && entry.contextLimits?.toolResultMaxChars === undefined)
+    ) {
       continue;
     }
     targets.push({
       agentId: normalizedAgentId,
-      configuredCap: entry.contextLimits.toolResultMaxChars,
-      path: `agents.${normalizedAgentId}.contextLimits.toolResultMaxChars`,
+      configuredCap: resolveAgentContextLimits(cfg, normalizedAgentId)?.toolResultMaxChars,
+      path:
+        entry.contextLimits?.toolResultMaxChars === undefined
+          ? "agents.defaults.contextLimits.toolResultMaxChars"
+          : `agents.${normalizedAgentId}.contextLimits.toolResultMaxChars`,
       scopeLabel: `agent "${normalizedAgentId}"`,
       target: `agents.${normalizedAgentId}`,
     });

--- a/src/flows/doctor-tool-result-cap-advice.test.ts
+++ b/src/flows/doctor-tool-result-cap-advice.test.ts
@@ -1,6 +1,10 @@
 // Tool result cap advice tests cover doctor guidance for capped tool output.
 import { describe, expect, it } from "vitest";
-import { buildToolResultCapDoctorAdvice } from "./doctor-tool-result-cap-advice.js";
+import {
+  buildToolResultCapDoctorAdvice,
+  collectToolResultCapDoctorIssues,
+  toolResultCapDoctorIssueToHealthFinding,
+} from "./doctor-tool-result-cap-advice.js";
 
 describe("buildToolResultCapDoctorAdvice", () => {
   it("stays quiet for unset config outside deep doctor output", () => {
@@ -47,5 +51,27 @@ describe("buildToolResultCapDoctorAdvice", () => {
     ).toEqual([
       "- configured toolResultMaxChars is 20,000 chars, but this model can use at most 9,600 chars per live tool result; lower it or unset it.",
     ]);
+  });
+
+  it("maps cap advice issues to structured health findings", () => {
+    const [issue] = collectToolResultCapDoctorIssues({
+      contextWindowTokens: 200_000,
+      modelKey: "openai/gpt-5.5",
+      configuredCap: 16_000,
+      path: "agents.writer.contextLimits.toolResultMaxChars",
+      scopeLabel: 'agent "writer"',
+      target: "agents.writer",
+    });
+
+    expect(toolResultCapDoctorIssueToHealthFinding(issue)).toEqual({
+      checkId: "core/doctor/tool-result-cap",
+      severity: "warning",
+      message:
+        'agent "writer": configured toolResultMaxChars is 16,000 chars; unset it to use the 64,000 char auto cap for "openai/gpt-5.5".',
+      path: "agents.writer.contextLimits.toolResultMaxChars",
+      target: "agents.writer",
+      requirement: "configured-below-auto-cap",
+      fixHint: "Lower or unset agents.writer.contextLimits.toolResultMaxChars.",
+    });
   });
 });

--- a/src/flows/doctor-tool-result-cap-advice.ts
+++ b/src/flows/doctor-tool-result-cap-advice.ts
@@ -3,6 +3,21 @@ import {
   calculateMaxToolResultCharsWithCap,
   resolveAutoLiveToolResultMaxChars,
 } from "../agents/embedded-agent-runner/tool-result-truncation.js";
+import type { HealthFinding } from "./health-checks.js";
+
+export const TOOL_RESULT_CAP_CHECK_ID = "core/doctor/tool-result-cap";
+
+export type ToolResultCapDoctorIssue = {
+  kind: "configured-above-runtime-ceiling" | "configured-below-auto-cap";
+  contextWindowTokens: number;
+  modelKey: string;
+  configuredCap: number;
+  runtimeCeiling?: number;
+  autoEffectiveCap?: number;
+  path?: string;
+  scopeLabel?: string;
+  target?: string;
+};
 
 // Doctor advice for explicit live tool-result caps that fight model-window defaults.
 export type ToolResultCapDoctorAdviceParams = {
@@ -10,11 +25,102 @@ export type ToolResultCapDoctorAdviceParams = {
   modelKey: string;
   configuredCap?: number;
   deep?: boolean;
+  path?: string;
   scopeLabel?: string;
+  target?: string;
 };
 
 function formatNumber(value: number): string {
   return String(Math.max(0, Math.floor(value))).replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+}
+
+function formatIssueMessage(issue: ToolResultCapDoctorIssue): string {
+  const prefix = issue.scopeLabel ? `${issue.scopeLabel}: ` : "";
+  if (issue.kind === "configured-above-runtime-ceiling") {
+    return `${prefix}configured toolResultMaxChars is ${formatNumber(
+      issue.configuredCap,
+    )} chars, but this model can use at most ${formatNumber(
+      issue.runtimeCeiling ?? 0,
+    )} chars per live tool result; lower it or unset it.`;
+  }
+  return `${prefix}configured toolResultMaxChars is ${formatNumber(
+    issue.configuredCap,
+  )} chars; unset it to use the ${formatNumber(issue.autoEffectiveCap ?? 0)} char auto cap for "${
+    issue.modelKey
+  }".`;
+}
+
+export function collectToolResultCapDoctorIssues(
+  params: ToolResultCapDoctorAdviceParams,
+): ToolResultCapDoctorIssue[] {
+  if (!Number.isFinite(params.contextWindowTokens) || params.contextWindowTokens <= 0) {
+    return [];
+  }
+
+  const configuredCap =
+    typeof params.configuredCap === "number" && Number.isFinite(params.configuredCap)
+      ? Math.floor(params.configuredCap)
+      : undefined;
+  if (configuredCap === undefined) {
+    return [];
+  }
+
+  const autoCap = resolveAutoLiveToolResultMaxChars(params.contextWindowTokens);
+  const runtimeCeiling = calculateMaxToolResultCharsWithCap(
+    params.contextWindowTokens,
+    Number.MAX_SAFE_INTEGER,
+  );
+  const effectiveCap = calculateMaxToolResultCharsWithCap(
+    params.contextWindowTokens,
+    configuredCap,
+  );
+  const autoEffectiveCap = calculateMaxToolResultCharsWithCap(params.contextWindowTokens, autoCap);
+
+  if (configuredCap > runtimeCeiling) {
+    return [
+      {
+        kind: "configured-above-runtime-ceiling",
+        contextWindowTokens: params.contextWindowTokens,
+        modelKey: params.modelKey,
+        configuredCap,
+        runtimeCeiling,
+        path: params.path,
+        scopeLabel: params.scopeLabel,
+        target: params.target,
+      },
+    ];
+  }
+
+  if (effectiveCap < autoEffectiveCap) {
+    return [
+      {
+        kind: "configured-below-auto-cap",
+        contextWindowTokens: params.contextWindowTokens,
+        modelKey: params.modelKey,
+        configuredCap,
+        autoEffectiveCap,
+        path: params.path,
+        scopeLabel: params.scopeLabel,
+        target: params.target,
+      },
+    ];
+  }
+
+  return [];
+}
+
+export function toolResultCapDoctorIssueToHealthFinding(
+  issue: ToolResultCapDoctorIssue,
+): HealthFinding {
+  return {
+    checkId: TOOL_RESULT_CAP_CHECK_ID,
+    severity: "warning",
+    message: formatIssueMessage(issue),
+    ...(issue.path ? { path: issue.path } : {}),
+    ...(issue.target ? { target: issue.target } : {}),
+    requirement: issue.kind,
+    fixHint: issue.path ? `Lower or unset ${issue.path}.` : "Lower or unset toolResultMaxChars.",
+  };
 }
 
 /** Builds human-readable doctor lines for stale or ineffective toolResultMaxChars settings. */
@@ -24,10 +130,6 @@ export function buildToolResultCapDoctorAdvice(params: ToolResultCapDoctorAdvice
   }
 
   const autoCap = resolveAutoLiveToolResultMaxChars(params.contextWindowTokens);
-  const runtimeCeiling = calculateMaxToolResultCharsWithCap(
-    params.contextWindowTokens,
-    Number.MAX_SAFE_INTEGER,
-  );
   const configuredCap =
     typeof params.configuredCap === "number" && Number.isFinite(params.configuredCap)
       ? Math.floor(params.configuredCap)
@@ -35,8 +137,6 @@ export function buildToolResultCapDoctorAdvice(params: ToolResultCapDoctorAdvice
   const configuredSource = configuredCap !== undefined;
   const requestedCap = configuredCap ?? autoCap;
   const effectiveCap = calculateMaxToolResultCharsWithCap(params.contextWindowTokens, requestedCap);
-  const autoEffectiveCap = calculateMaxToolResultCharsWithCap(params.contextWindowTokens, autoCap);
-
   const lines: string[] = [];
   const prefix = params.scopeLabel ? `${params.scopeLabel}: ` : "";
   // Deep mode always shows the effective cap, even when no warning is needed.
@@ -54,26 +154,9 @@ export function buildToolResultCapDoctorAdvice(params: ToolResultCapDoctorAdvice
     return lines;
   }
 
-  if (configuredCap > runtimeCeiling) {
-    lines.push(
-      `- ${prefix}configured toolResultMaxChars is ${formatNumber(
-        configuredCap,
-      )} chars, but this model can use at most ${formatNumber(
-        runtimeCeiling,
-      )} chars per live tool result; lower it or unset it.`,
-    );
-    return lines;
-  }
-
-  if (effectiveCap < autoEffectiveCap) {
-    lines.push(
-      `- ${prefix}configured toolResultMaxChars is ${formatNumber(
-        configuredCap,
-      )} chars; unset it to use the ${formatNumber(
-        autoEffectiveCap,
-      )} char auto cap for "${params.modelKey}".`,
-    );
-  }
+  lines.push(
+    ...collectToolResultCapDoctorIssues(params).map((issue) => `- ${formatIssueMessage(issue)}`),
+  );
 
   return lines;
 }


### PR DESCRIPTION
## Summary
- add default-disabled structured lint findings for `core/doctor/tool-result-cap`
- map existing `toolResultMaxChars` advice into warning findings with stable path/target/fixHint metadata
- keep legacy `openclaw doctor` note output as the authority for normal Doctor runs

## Public contract
- No public SDK, plugin manifest, config schema, or persisted data-model contract changes.
- The structured check is opt-in via `defaultEnabled: false`; default `doctor --lint` skips it while `--all` and `--only core/doctor/tool-result-cap` include it.
- No repair path is added.

## Real behavior proof
Source CLI proof with isolated `OPENCLAW_CONFIG_PATH` containing `agents.defaults.contextLimits.toolResultMaxChars = 16000`:
- default `pnpm --silent openclaw doctor --lint --json`: `checksRun: 25`, `checksSkipped: 8`, `toolResultCapFindings: 0`
- explicit `pnpm --silent openclaw doctor --lint --json --only core/doctor/tool-result-cap`: `checksRun: 1`, `checksSkipped: 32`, finding path `agents.defaults.contextLimits.toolResultMaxChars`, target `agents.defaults`, severity `warning`

## Review updates
- Addressed ClawSweeper's inherited-default target enumeration P2: inherited defaults now produce per-agent findings where appropriate.
- Addressed ClawSweeper's per-agent path-shape P2: explicit per-agent findings use `agents.list.<id>.contextLimits.toolResultMaxChars` and `target: agents.list.<id>`; inherited-default findings remain anchored to `agents.defaults.contextLimits.toolResultMaxChars` with per-agent targets.
- Galin reviewed the PR and found no blocking findings.
- ClawSweeper rated the prior head diamond lobster with proof sufficient / ready for maintainer look; re-review requested for the refreshed head.

## Rebase refresh - 2026-07-01 after #97496
Rebased onto current `origin/main` after #97496 merged and refreshed the PR head to `a9d3dfd9f58d087abb8bc13414ecd44534a1516e`.

Fresh validation after rebase:
- `./node_modules/.bin/oxfmt --check src/flows/doctor-health-contributions.ts src/flows/doctor-health-contributions.test.ts src/flows/doctor-tool-result-cap-advice.ts src/flows/doctor-tool-result-cap-advice.test.ts`
- `./node_modules/.bin/oxlint src/flows/doctor-health-contributions.ts src/flows/doctor-health-contributions.test.ts src/flows/doctor-tool-result-cap-advice.ts src/flows/doctor-tool-result-cap-advice.test.ts`
- `node scripts/run-vitest.mjs src/flows/doctor-tool-result-cap-advice.test.ts src/flows/doctor-health-contributions.test.ts` (63 tests)
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo`
- `node scripts/plugin-sdk-surface-report.mjs --check`
- `node scripts/sync-plugin-sdk-exports.mjs --check`
- `git diff --check`

## Notes
`pnpm check:changed` first tried to delegate to Blacksmith Testbox and was blocked by the local Crabbox binary version (`0.15.0`, requires `>=0.22.0`), so the prior validation used the documented local child path directly with `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1`.
