### PR TITLE
fix(agents): retry compaction on provider-side AbortErrors

### DIFF
--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -1864,6 +1864,107 @@ describe("compaction-safeguard recent-turn preservation", () => {
     expect(JSON.stringify(messages[0])).toContain("Old duplicated section");
   });
 
+  it("falls back to LLM when provider throws a provider-side AbortError with signal not aborted", async () => {
+    // Reproduce the undici AbortError("This operation was aborted") shape that
+    // arrives when the compaction provider's HTTP connection drops mid-stream while
+    // the caller has NOT yet fired their abort signal. Before the fix,
+    // isAbortError() matched this shape so tryProviderSummarize rethrew and the
+    // extension runner swallowed the error — the LLM fallback path was skipped.
+    mockSummarizeInStages.mockReset();
+    mockSummarizeInStages.mockResolvedValue("llm fallback summary");
+
+    const providerAbortErr = Object.assign(new Error("This operation was aborted"), {
+      name: "AbortError",
+    });
+    const failingProviderSummarize = vi.fn().mockRejectedValue(providerAbortErr);
+    registerCompactionProvider({
+      id: "disconnecting-provider",
+      label: "Disconnecting Provider",
+      summarize: failingProviderSummarize,
+    });
+
+    const sessionManager = stubSessionManager();
+    const model = createAnthropicModelFixture();
+    setCompactionSafeguardRuntime(sessionManager, {
+      provider: "disconnecting-provider",
+      model,
+      recentTurnsPreserve: 0,
+    });
+
+    const event = {
+      preparation: {
+        messagesToSummarize: [
+          { role: "user", content: "older context", timestamp: 1 },
+          { role: "assistant", content: "older reply", timestamp: 2 } as unknown as AgentMessage,
+        ],
+        turnPrefixMessages: [] as AgentMessage[],
+        firstKeptEntryId: "entry-1",
+        tokensBefore: 1_500,
+        fileOps: {
+          read: [],
+          edited: [],
+          written: [],
+        },
+        settings: { reserveTokens: 4_000 },
+      },
+      customInstructions: "",
+      signal: new AbortController().signal, // not aborted
+    };
+    const { result } = await runCompactionScenario({ sessionManager, event, apiKey: "key" });
+
+    // Provider failure → LLM fallback ran, not { cancel: true }.
+    expect(result.cancel).not.toBe(true);
+    expect(mockSummarizeInStages).toHaveBeenCalled();
+  });
+
+  it("propagates provider AbortError and cancels when caller signal is already aborted", async () => {
+    mockSummarizeInStages.mockReset();
+
+    const providerAbortErr = Object.assign(new Error("This operation was aborted"), {
+      name: "AbortError",
+    });
+    const failingProviderSummarize = vi.fn().mockRejectedValue(providerAbortErr);
+    registerCompactionProvider({
+      id: "aborted-provider",
+      label: "Aborted Provider",
+      summarize: failingProviderSummarize,
+    });
+
+    const controller = new AbortController();
+    controller.abort();
+
+    const sessionManager = stubSessionManager();
+    setCompactionSafeguardRuntime(sessionManager, {
+      provider: "aborted-provider",
+    });
+
+    const event = {
+      preparation: {
+        messagesToSummarize: [
+          { role: "user", content: "older context", timestamp: 1 },
+        ] as AgentMessage[],
+        turnPrefixMessages: [] as AgentMessage[],
+        firstKeptEntryId: "entry-1",
+        tokensBefore: 1_500,
+        fileOps: {
+          read: [],
+          edited: [],
+          written: [],
+        },
+        settings: { reserveTokens: 4_000 },
+      },
+      customInstructions: "",
+      signal: controller.signal, // already aborted
+    };
+
+    await expect(
+      runCompactionScenario({ sessionManager, event, apiKey: "key" }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+
+    // Caller abort is terminal — LLM fallback should not have run.
+    expect(mockSummarizeInStages).not.toHaveBeenCalled();
+  });
+
   it("passes compaction instructions to providers and preserves suffix context", async () => {
     mockSummarizeInStages.mockReset();
     const providerSummarize = vi.fn().mockResolvedValue("provider summary body");

--- a/src/agents/agent-hooks/compaction-safeguard.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.ts
@@ -207,8 +207,13 @@ async function tryProviderSummarize(
     log.warn(`Compaction provider "${provider.id}" returned empty result, falling back to LLM.`);
     return undefined;
   } catch (err) {
-    // Abort/timeout errors must propagate — the caller requested cancellation.
-    if (isAbortError(err) || isTimeoutError(err)) {
+    // Propagate only when the caller explicitly cancelled. Provider-side
+    // AbortErrors (signal not aborted) fall through to LLM summarization.
+    if (params.signal?.aborted) {
+      throw err;
+    }
+    // Real non-abort transport timeouts (e.g. ETIMEDOUT) still propagate.
+    if (!isAbortError(err) && isTimeoutError(err)) {
       throw err;
     }
     log.warn(
@@ -1009,9 +1014,12 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
           // Provider returned empty — fall through to LLM path.
           log.info("Compaction provider did not produce a result; falling back to LLM path.");
         } catch (err) {
-          // tryProviderSummarize rethrows abort/timeout — if we reach here it is
-          // an unexpected error from the assembly step. Fall through to LLM path.
-          if (isAbortError(err) || isTimeoutError(err)) {
+          // tryProviderSummarize rethrows on caller cancellation; reaching here
+          // means an unexpected error in the assembly step. Fall through to LLM.
+          if (signal?.aborted) {
+            throw err;
+          }
+          if (!isAbortError(err) && isTimeoutError(err)) {
             throw err;
           }
           log.warn(

--- a/src/agents/compaction-partial-summary.test.ts
+++ b/src/agents/compaction-partial-summary.test.ts
@@ -116,7 +116,7 @@ describe("summarizeChunks partial summary preservation (#82952)", () => {
     );
   });
 
-  it("re-throws abort errors instead of returning partial summary", async () => {
+  it("re-throws abort errors when the caller signal is already aborted", async () => {
     const abortErr = new Error("aborted");
     abortErr.name = "AbortError";
 
@@ -124,15 +124,46 @@ describe("summarizeChunks partial summary preservation (#82952)", () => {
       .mockResolvedValueOnce("Summary of chunk 1")
       .mockRejectedValue(abortErr);
 
-    const result = await callSummarize();
+    const controller = new AbortController();
+    controller.abort();
 
-    // Abort errors represent caller intent, so partial recovery must not mask
-    // cancellation as successful summarization.
-    expect(result).not.toBe("Summary of chunk 1");
-    expect(result).toContain("Context contained");
+    await expect(
+      summarizeWithFallback({
+        messages: twoChunkMessages,
+        model: testModel,
+        apiKey: "test-key", // pragma: allowlist secret
+        signal: controller.signal,
+        reserveTokens: 1000,
+        maxChunkTokens: 150,
+        contextWindow: 200_000,
+      }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+
+    // Caller abort is terminal — partial recovery must not mask cancellation.
     expect(compactionMocks.logWarn).not.toHaveBeenCalledWith(
       "chunk summarization failed after retries; partial summary available",
       expect.anything(),
+    );
+  });
+
+  it("returns partial summary when a later chunk fails with a provider-side AbortError", async () => {
+    const providerAbortErr = Object.assign(new Error("This operation was aborted"), {
+      name: "AbortError",
+    });
+
+    compactionMocks.generateSummary
+      .mockResolvedValueOnce("Summary of chunk 1")
+      .mockRejectedValue(providerAbortErr);
+
+    const result = await callSummarize();
+
+    // Provider-side disconnects are not caller cancellation; preserve completed work.
+    expect(result).toContain("Summary of chunk 1");
+    expect(result).toContain("[Partial summary:");
+    expect(result).toMatch(/chunks 1-1 of 2 were summarized/);
+    expect(compactionMocks.logWarn).toHaveBeenCalledWith(
+      "chunk summarization failed after retries; partial summary available",
+      expect.objectContaining({ err: providerAbortErr }),
     );
   });
 

--- a/src/agents/compaction.summarize-fallback.test.ts
+++ b/src/agents/compaction.summarize-fallback.test.ts
@@ -73,6 +73,71 @@ describe("summarizeWithFallback", () => {
     expect(agentSessionMocks.generateSummary).toHaveBeenCalledTimes(1);
   });
 
+  it("retries provider-side AbortError and returns a real summary when caller signal is not aborted", async () => {
+    // Reproduce the undici AbortError("This operation was aborted") shape thrown
+    // when the LLM API closes the connection mid-stream without the caller signal
+    // being fired. Before the fix, isAbortError() + isTimeoutError() both matched
+    // this error shape, so shouldRetry returned false and no retry was attempted —
+    // the compaction fell back to the "Summary unavailable" placeholder instead.
+    const providerAbortErr = Object.assign(new Error("This operation was aborted"), {
+      name: "AbortError",
+    });
+    agentSessionMocks.generateSummary
+      .mockRejectedValueOnce(providerAbortErr)
+      .mockResolvedValueOnce("recovered summary after provider disconnect");
+
+    const result = await summarizeWithFallback({
+      messages: [
+        {
+          role: "user",
+          content: "hello",
+          timestamp: 1,
+        } satisfies UserMessage,
+      ],
+      model: testModel,
+      apiKey: "test-key", // pragma: allowlist secret
+      signal: new AbortController().signal, // not aborted
+      reserveTokens: 1000,
+      maxChunkTokens: 50_000,
+      contextWindow: 200_000,
+    });
+
+    expect(result).toBe("recovered summary after provider disconnect");
+    // Two calls: first fails with provider-side AbortError, second succeeds.
+    expect(agentSessionMocks.generateSummary).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry and propagates AbortError immediately when caller signal is already aborted", async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    const providerAbortErr = Object.assign(new Error("This operation was aborted"), {
+      name: "AbortError",
+    });
+    agentSessionMocks.generateSummary.mockRejectedValueOnce(providerAbortErr);
+
+    await expect(
+      summarizeWithFallback({
+        messages: [
+          {
+            role: "user",
+            content: "hello",
+            timestamp: 1,
+          } satisfies UserMessage,
+        ],
+        model: testModel,
+        apiKey: "test-key", // pragma: allowlist secret
+        signal: controller.signal, // already aborted
+        reserveTokens: 1000,
+        maxChunkTokens: 50_000,
+        contextWindow: 200_000,
+      }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+
+    // Caller abort is terminal — no retry, no fallback to placeholder.
+    expect(agentSessionMocks.generateSummary).toHaveBeenCalledTimes(1);
+  });
+
   it("still attempts partial summarization when oversized messages were excluded", async () => {
     // Oversized-message fallback tries the safe subset so a huge attachment or
     // tool output does not prevent summarizing the rest of the transcript.

--- a/src/agents/compaction.ts
+++ b/src/agents/compaction.ts
@@ -175,13 +175,31 @@ async function summarizeChunks(params: {
           maxDelayMs: 5000,
           jitter: 0.2,
           label: "compaction/generateSummary",
-          shouldRetry: (err) => !isAbortError(err) && !isTimeoutError(err),
+          shouldRetry: (err) => {
+            // Stop retrying when the caller explicitly cancelled.
+            if (params.signal.aborted) {
+              return false;
+            }
+            // Preserve existing non-retry policy for real network/transport
+            // timeouts (e.g. "fetch failed", ETIMEDOUT) that are not AbortErrors.
+            if (!isAbortError(err) && isTimeoutError(err)) {
+              return false;
+            }
+            // Provider-side AbortErrors with signal not yet aborted are
+            // transient disconnects — retrying is correct.
+            return true;
+          },
         },
       );
       hasGeneratedChunk = true;
     } catch (err) {
-      // Abort and timeout errors always propagate immediately.
-      if (isAbortError(err) || isTimeoutError(err)) {
+      // Propagate only when the caller explicitly cancelled. Provider-side
+      // AbortErrors (signal not aborted) fall through to partial/fallback paths.
+      if (params.signal.aborted) {
+        throw err;
+      }
+      // Real non-abort transport timeouts still propagate immediately.
+      if (!isAbortError(err) && isTimeoutError(err)) {
         throw err;
       }
       // No chunk has succeeded yet — rethrow so summarizeWithFallback
@@ -270,6 +288,9 @@ export async function summarizeWithFallback(params: {
   try {
     return await summarizeChunks(params);
   } catch (fullError) {
+    if (params.signal.aborted) {
+      throw fullError;
+    }
     log.warn(`Full summarization failed: ${formatErrorMessage(fullError)}`);
     partialSummaryFallback = (fullError as PartialSummaryError).partialSummary;
   }
@@ -292,6 +313,9 @@ export async function summarizeWithFallback(params: {
       const notes = oversizedNotes.length > 0 ? `\n\n${oversizedNotes.join("\n")}` : "";
       return partialSummary + notes;
     } catch (partialError) {
+      if (params.signal.aborted) {
+        throw partialError;
+      }
       log.warn(`Partial summarization also failed: ${formatErrorMessage(partialError)}`);
       // Prefer the oversized retry's partial summary over the full attempt's,
       // since it covers the non-oversized transcript. Append oversized notes


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where long-running agent sessions would silently lose conversation context during compaction when the LLM API closed a connection mid-stream without the user cancelling the run.

PR #90908 fixed this classification for the outer `model-fallback` layer, but the inner compaction retry path still treated provider-side `AbortError`s (for example undici's `"This operation was aborted"`) as terminal user cancellations. That suppressed retries in `summarizeChunks` and skipped the LLM fallback in `compaction-safeguard` when a configured compaction provider disconnected the same way.

The user-visible symptom: compaction appeared to succeed (`compacted: true`) but the stored summary was a degraded placeholder such as `"Summary unavailable due to size limits"`, erasing useful history without an obvious error.

## Why This Change Was Made

The fix aligns inner compaction error handling with the #90908 pattern: only treat an error as a caller-initiated cancellation when `AbortSignal.aborted` is true. Provider-side `AbortError`s with an unaborted signal are retried (LLM path) or fall back to built-in LLM summarization (provider path). Real non-abort transport timeouts such as `"fetch failed"` / `ETIMEDOUT` keep the existing no-retry behavior.

`summarizeWithFallback` now rethrows on caller abort instead of swallowing the error into the placeholder fallback path.

## User Impact

- Default LLM compaction: transient provider disconnects during summarization are retried instead of producing placeholder summaries.
- Configured compaction provider: provider disconnects fall back to LLM summarization instead of aborting the safeguard path.
- Explicit user/system cancellation (`signal.aborted`) still stops immediately with no retry.

## Evidence

**Behavior or issue addressed:** Provider-side `AbortError` during compaction no longer suppresses retries or LLM fallback when the caller has not cancelled.

**Real environment tested:** macOS, Node 22, local OpenClaw source checkout on branch `fix/compaction-provider-abort-retry`, production modules `src/agents/compaction.ts` and `src/agents/agent-hooks/compaction-safeguard.ts`.

**Exact steps or command run after this patch:**

```bash
pnpm build
pnpm test src/agents/compaction.summarize-fallback.test.ts src/agents/agent-hooks/compaction-safeguard.test.ts src/agents/compaction.retry.test.ts
node scripts/proof-compaction-provider-abort-retry.mjs
```

**Evidence after fix:**

```text
$ pnpm test src/agents/compaction.summarize-fallback.test.ts src/agents/agent-hooks/compaction-safeguard.test.ts src/agents/compaction.retry.test.ts
 Test Files  3 passed (3)
      Tests  106 passed (106)

$ node scripts/proof-compaction-provider-abort-retry.mjs
PASS compaction.ts retries undici AbortError when signal is not aborted (exit=0)
PASS compaction.ts stops immediately when caller signal is already aborted (exit=0)
PASS compaction-safeguard falls back to LLM after provider AbortError (exit=0)
PASS compaction-safeguard propagates AbortError when caller signal is aborted (exit=0)

=== summary ===
ALL PASS
```

Proof script exercises the real production call chains:

- `summarizeWithFallback` → `summarizeChunks` → `retryAsync` (compaction.ts)
- `session_before_compact` → `tryProviderSummarize` → LLM fallback via `summarizeInStages` (compaction-safeguard.ts)

Regression tests mock only the external LLM API boundary (`generateSummary` / provider `summarize`); all classification and retry/fallback orchestration runs through production code.

**Observed result after fix:** Provider-side `AbortError` with unaborted signal triggers a second `generateSummary` call and returns `"recovered summary after provider disconnect"`; safeguard provider failure invokes `summarizeInStages` instead of `{ cancel: true }`. Caller-aborted signal still throws immediately with a single attempt.

**What was not tested:** Live gateway compaction against a real provider that disconnects mid-stream; Crabbox `pnpm check:changed` (local Crabbox unavailable).

**Proof limitations or environment constraints:** Proof uses production compaction modules with mocked LLM/provider network boundaries. No live network disconnect was injected during proof.

## Tests and validation

- `pnpm build` — pass
- `pnpm test src/agents/compaction.summarize-fallback.test.ts src/agents/agent-hooks/compaction-safeguard.test.ts src/agents/compaction.retry.test.ts` — 106 passed
- `node scripts/run-oxlint.mjs --tsconfig tsconfig.json src/agents/compaction.ts src/agents/agent-hooks/compaction-safeguard.ts` — pass
- Regression tests added in `src/agents/compaction.summarize-fallback.test.ts` and `src/agents/agent-hooks/compaction-safeguard.test.ts`

## Risk checklist

- Did user-visible behavior change? **Yes** — compaction now retries/fallbacks on provider disconnects instead of silently degrading summaries.
- Did config, environment, or migration behavior change? **No**
- Did security, auth, secrets, network, or tool execution behavior change? **No**
- Highest-risk area: compaction retry loop could retry provider-side aborts up to 3 times before falling back.
- Mitigation: retries are bounded (3 attempts, existing backoff); caller abort remains terminal; non-abort timeouts unchanged.

## Current review state

- Next action: awaiting maintainer review
- Bot comments addressed: none yet

Related: #90908 (outer model-fallback fix; this PR completes the inner compaction layers)

_AI-assisted._
