### PR TITLE
[codex] Add current OpenRouter image models

### DIFF
--- a/docs/providers/openrouter.md
+++ b/docs/providers/openrouter.md
@@ -110,6 +110,13 @@ OpenRouter can also back the `image_generate` tool. Use an OpenRouter image mode
 
 OpenClaw sends image requests to OpenRouter's chat completions image API with `modalities: ["image", "text"]`. Gemini image models receive supported `aspectRatio` and `resolution` hints through OpenRouter's `image_config`. Use `agents.defaults.imageGenerationModel.timeoutMs` for slower OpenRouter image models; the `image_generate` tool's per-call `timeoutMs` parameter still wins.
 
+The bundled OpenRouter image provider exposes a curated set of OpenRouter
+image-output models, including `google/gemini-3.1-flash-image`,
+`google/gemini-3-pro-image`, `google/gemini-2.5-flash-image`,
+`openai/gpt-5-image`, `openai/gpt-5-image-mini`, and
+`openai/gpt-5.4-image-2`. Existing preview model refs remain accepted when
+you have already configured them.
+
 ## Video generation
 
 OpenRouter can also back the `video_generate` tool through its asynchronous `/videos` API. Use an OpenRouter video model under `agents.defaults.videoGenerationModel`:

--- a/docs/providers/openrouter.md
+++ b/docs/providers/openrouter.md
@@ -116,6 +116,12 @@ receive supported `aspectRatio` and `resolution` hints through OpenRouter's
 OpenRouter image models; the `image_generate` tool's per-call `timeoutMs`
 parameter still wins.
 
+For `/images` models, OpenClaw honors model-specific OpenRouter limits before
+submission. Gemini and Microsoft image models request one output at a time,
+Microsoft receives only supported aspect-ratio/reference-image fields, and
+OpenAI image models do not receive unsupported Gemini-style
+`aspect_ratio`/`resolution` fields.
+
 The bundled OpenRouter image provider exposes a curated set of OpenRouter
 image-output models, including `google/gemini-3.1-flash-image`,
 `google/gemini-3-pro-image`, `google/gemini-2.5-flash-image`,

--- a/docs/providers/openrouter.md
+++ b/docs/providers/openrouter.md
@@ -108,14 +108,20 @@ OpenRouter can also back the `image_generate` tool. Use an OpenRouter image mode
 }
 ```
 
-OpenClaw sends image requests to OpenRouter's chat completions image API with `modalities: ["image", "text"]`. Gemini image models receive supported `aspectRatio` and `resolution` hints through OpenRouter's `image_config`. Use `agents.defaults.imageGenerationModel.timeoutMs` for slower OpenRouter image models; the `image_generate` tool's per-call `timeoutMs` parameter still wins.
+OpenClaw sends current OpenRouter image models through OpenRouter's dedicated
+`/images` API. Existing preview/default chat-image models continue to use chat
+completions with `modalities: ["image", "text"]`; Gemini chat-image models
+receive supported `aspectRatio` and `resolution` hints through OpenRouter's
+`image_config`. Use `agents.defaults.imageGenerationModel.timeoutMs` for slower
+OpenRouter image models; the `image_generate` tool's per-call `timeoutMs`
+parameter still wins.
 
 The bundled OpenRouter image provider exposes a curated set of OpenRouter
 image-output models, including `google/gemini-3.1-flash-image`,
 `google/gemini-3-pro-image`, `google/gemini-2.5-flash-image`,
 `openai/gpt-5-image`, `openai/gpt-5-image-mini`, and
-`openai/gpt-5.4-image-2`. Existing preview model refs remain accepted when
-you have already configured them.
+`microsoft/mai-image-2.5`. Existing preview model refs and
+`openai/gpt-5.4-image-2` remain accepted when you have already configured them.
 
 ## Video generation
 

--- a/docs/tools/image-generation.md
+++ b/docs/tools/image-generation.md
@@ -74,17 +74,17 @@ internal image endpoints remain blocked by default.
 
 ## Common routes
 
-| Goal                                                 | Model ref                                          | Auth                                   |
-| ---------------------------------------------------- | -------------------------------------------------- | -------------------------------------- |
-| OpenAI image generation with API billing             | `openai/gpt-image-2`                               | `OPENAI_API_KEY`                       |
-| OpenAI image generation with Codex subscription auth | `openai/gpt-image-2`                               | OpenAI ChatGPT/Codex OAuth             |
-| OpenAI transparent-background PNG/WebP               | `openai/gpt-image-1.5`                             | `OPENAI_API_KEY` or OpenAI Codex OAuth |
-| DeepInfra image generation                           | `deepinfra/black-forest-labs/FLUX-1-schnell`       | `DEEPINFRA_API_KEY`                    |
-| fal Krea 2 expressive/style-directed generation      | `fal/krea/v2/medium/text-to-image`                 | `FAL_KEY`                              |
-| OpenRouter image generation                          | `openrouter/google/gemini-3.1-flash-image-preview` | `OPENROUTER_API_KEY`                   |
-| LiteLLM image generation                             | `litellm/gpt-image-2`                              | `LITELLM_API_KEY`                      |
-| Microsoft Foundry MAI image generation               | `microsoft-foundry/<deployment-name>`              | `AZURE_OPENAI_API_KEY` or Entra ID     |
-| Google Gemini image generation                       | `google/gemini-3.1-flash-image-preview`            | `GEMINI_API_KEY` or `GOOGLE_API_KEY`   |
+| Goal                                                 | Model ref                                    | Auth                                   |
+| ---------------------------------------------------- | -------------------------------------------- | -------------------------------------- |
+| OpenAI image generation with API billing             | `openai/gpt-image-2`                         | `OPENAI_API_KEY`                       |
+| OpenAI image generation with Codex subscription auth | `openai/gpt-image-2`                         | OpenAI ChatGPT/Codex OAuth             |
+| OpenAI transparent-background PNG/WebP               | `openai/gpt-image-1.5`                       | `OPENAI_API_KEY` or OpenAI Codex OAuth |
+| DeepInfra image generation                           | `deepinfra/black-forest-labs/FLUX-1-schnell` | `DEEPINFRA_API_KEY`                    |
+| fal Krea 2 expressive/style-directed generation      | `fal/krea/v2/medium/text-to-image`           | `FAL_KEY`                              |
+| OpenRouter image generation                          | `openrouter/google/gemini-3.1-flash-image`   | `OPENROUTER_API_KEY`                   |
+| LiteLLM image generation                             | `litellm/gpt-image-2`                        | `LITELLM_API_KEY`                      |
+| Microsoft Foundry MAI image generation               | `microsoft-foundry/<deployment-name>`        | `AZURE_OPENAI_API_KEY` or Entra ID     |
+| Google Gemini image generation                       | `google/gemini-3.1-flash-image-preview`      | `GEMINI_API_KEY` or `GOOGLE_API_KEY`   |
 
 The same `image_generate` tool handles text-to-image and reference-image
 editing. Use `image` for one reference or `images` for multiple references.
@@ -108,7 +108,7 @@ backend emits it.
 | Microsoft Foundry | `<deployment-name>`                     | Yes (MAI-Image-2.5 models only)    | `AZURE_OPENAI_API_KEY` or Entra ID (`az login`)       |
 | MiniMax           | `image-01`                              | Yes (subject reference)            | `MINIMAX_API_KEY` or MiniMax OAuth (`minimax-portal`) |
 | OpenAI            | `gpt-image-2`                           | Yes (up to 4 images)               | `OPENAI_API_KEY` or OpenAI ChatGPT/Codex OAuth        |
-| OpenRouter        | `google/gemini-3.1-flash-image-preview` | Yes (up to 5 input images)         | `OPENROUTER_API_KEY`                                  |
+| OpenRouter        | `google/gemini-3.1-flash-image-preview` | Yes (model-specific limits)        | `OPENROUTER_API_KEY`                                  |
 | Vydra             | `grok-imagine`                          | No                                 | `VYDRA_API_KEY`                                       |
 | xAI               | `grok-imagine-image`                    | Yes (up to 5 images)               | `XAI_API_KEY`                                         |
 
@@ -273,10 +273,12 @@ a reference image path or URL:
 "Generate a watercolor version of this photo" + image: "/path/to/photo.jpg"
 ```
 
-OpenAI, OpenRouter, Google, and xAI support up to 5 reference images via the
-`images` parameter. fal supports 1 reference image for Flux image-to-image, up
-to 10 for GPT Image 2 edits, up to 10 style references for Krea 2, and up to
-14 for Nano Banana 2 edits. Microsoft Foundry, MiniMax, and ComfyUI support 1.
+OpenAI, Google, and xAI support up to 5 reference images via the `images`
+parameter. OpenRouter accepts up to 10 through the shared tool when the selected
+upstream model allows it, with smaller model-specific limits enforced before
+submission. fal supports 1 reference image for Flux image-to-image, up to 10
+for GPT Image 2 edits, up to 10 style references for Krea 2, and up to 14 for
+Nano Banana 2 edits. Microsoft Foundry, MiniMax, and ComfyUI support 1.
 
 ## Provider deep dives
 
@@ -381,8 +383,9 @@ to 10 for GPT Image 2 edits, up to 10 style references for Krea 2, and up to
   </Accordion>
   <Accordion title="OpenRouter image models">
     OpenRouter image generation uses the same `OPENROUTER_API_KEY` and
-    routes through OpenRouter's chat completions image API. Select
-    OpenRouter image models with the `openrouter/` prefix:
+    supports both OpenRouter's dedicated `/images` API and older chat-image
+    completions models. Select OpenRouter image models with the `openrouter/`
+    prefix:
 
     ```json5
     {
@@ -396,9 +399,19 @@ to 10 for GPT Image 2 edits, up to 10 style references for Krea 2, and up to
     }
     ```
 
-    OpenClaw forwards `prompt`, `count`, reference images, and
-    Gemini-compatible `aspectRatio` / `resolution` hints to OpenRouter.
+    Current OpenRouter image models use `/images`; existing preview/default
+    chat-image refs continue to use chat completions with
+    `modalities: ["image", "text"]`. OpenClaw applies model-specific OpenRouter
+    `/images` limits before submission: Gemini and Microsoft models request one
+    output at a time, Microsoft receives only supported aspect-ratio/reference
+    fields, and OpenAI image models do not receive unsupported Gemini-style
+    `aspect_ratio` or `resolution` fields.
+
     Current built-in OpenRouter image model shortcuts include
+    `google/gemini-3.1-flash-image`, `google/gemini-3-pro-image`,
+    `google/gemini-2.5-flash-image`, `openai/gpt-5-image`,
+    `openai/gpt-5-image-mini`, `microsoft/mai-image-2.5`, the legacy preview
+    refs
     `google/gemini-3.1-flash-image-preview`,
     `google/gemini-3-pro-image-preview`, and `openai/gpt-5.4-image-2`. Use
     `action: "list"` to see what your configured plugin exposes.

--- a/extensions/openrouter/image-generation-provider.test.ts
+++ b/extensions/openrouter/image-generation-provider.test.ts
@@ -110,8 +110,11 @@ describe("openrouter image generation provider", () => {
     expect(provider.models).toContain("microsoft/mai-image-2.5");
     expect(provider.capabilities.generate.maxCount).toBe(4);
     expect(provider.capabilities.generate.supportsAspectRatio).toBe(true);
+    expect(provider.capabilities.geometry?.aspectRatios).toContain("1:4");
+    expect(provider.capabilities.geometry?.aspectRatios).toContain("8:1");
     expect(provider.capabilities.edit.enabled).toBe(true);
-    expect(provider.capabilities.edit.maxInputImages).toBe(5);
+    expect(provider.capabilities.edit.maxInputImages).toBe(10);
+    expect(provider.capabilities.edit.supportsResolution).toBe(true);
   });
 
   it("sends current image models through OpenRouter images API", async () => {
@@ -131,8 +134,8 @@ describe("openrouter image generation provider", () => {
       model: "microsoft/mai-image-2.5",
       prompt: "draw a sticker",
       aspectRatio: "16:9",
-      resolution: "2K",
-      count: 2,
+      count: 1,
+      inputImages: [{ buffer: Buffer.from("source-one"), mimeType: "image/png" }],
       cfg: {},
     });
 
@@ -142,13 +145,144 @@ describe("openrouter image generation provider", () => {
       body: {
         model: "microsoft/mai-image-2.5",
         prompt: "draw a sticker",
-        n: 2,
+        n: 1,
         aspect_ratio: "16:9",
-        resolution: "2K",
+        input_references: [
+          {
+            type: "image_url",
+            image_url: {
+              url: `data:image/png;base64,${Buffer.from("source-one").toString("base64")}`,
+            },
+          },
+        ],
       },
     });
     expect(result.model).toBe("microsoft/mai-image-2.5");
     expect(requireGeneratedImage(result, 0).buffer.toString()).toBe("png-one");
+  });
+
+  it("rejects unsupported Images API count and reference image limits before request", async () => {
+    const provider = buildOpenRouterImageGenerationProvider();
+    await expect(
+      provider.generateImage({
+        provider: "openrouter",
+        model: "microsoft/mai-image-2.5",
+        prompt: "draw a sticker",
+        count: 2,
+        cfg: {},
+      }),
+    ).rejects.toThrow("supports at most 1 output image");
+
+    await expect(
+      provider.generateImage({
+        provider: "openrouter",
+        model: "microsoft/mai-image-2.5",
+        prompt: "draw a sticker",
+        inputImages: [
+          { buffer: Buffer.from("source-one"), mimeType: "image/png" },
+          { buffer: Buffer.from("source-two"), mimeType: "image/png" },
+        ],
+        cfg: {},
+      }),
+    ).rejects.toThrow("supports at most 1 reference image");
+
+    expect(postJsonRequestMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects unsupported Images API geometry before request", async () => {
+    const provider = buildOpenRouterImageGenerationProvider();
+    await expect(
+      provider.generateImage({
+        provider: "openrouter",
+        model: "microsoft/mai-image-2.5",
+        prompt: "draw a sticker",
+        resolution: "2K",
+        cfg: {},
+      }),
+    ).rejects.toThrow("does not support resolution=2K");
+
+    await expect(
+      provider.generateImage({
+        provider: "openrouter",
+        model: "openai/gpt-5-image",
+        prompt: "draw a sticker",
+        aspectRatio: "16:9",
+        cfg: {},
+      }),
+    ).rejects.toThrow("does not support aspectRatio=16:9");
+
+    expect(postJsonRequestMock).not.toHaveBeenCalled();
+  });
+
+  it("sends OpenAI image models through OpenRouter images API without geometry", async () => {
+    const release = vi.fn(async () => {});
+    postJsonRequestMock.mockResolvedValue({
+      response: {
+        json: async () => ({
+          data: [{ b64_json: Buffer.from("png-one").toString("base64") }],
+        }),
+      },
+      release,
+    });
+
+    const provider = buildOpenRouterImageGenerationProvider();
+    await provider.generateImage({
+      provider: "openrouter",
+      model: "openai/gpt-5-image",
+      prompt: "draw a sticker",
+      count: 4,
+      cfg: {},
+    });
+
+    expect(requireOpenRouterPostRequest()).toMatchObject({
+      url: "https://openrouter.ai/api/v1/images",
+      body: {
+        model: "openai/gpt-5-image",
+        prompt: "draw a sticker",
+        n: 4,
+      },
+    });
+    expect(requireOpenRouterPostRequest().body).not.toHaveProperty("aspect_ratio");
+    expect(requireOpenRouterPostRequest().body).not.toHaveProperty("resolution");
+  });
+
+  it("ignores unsupported inferred edit resolution for Images API models", async () => {
+    const release = vi.fn(async () => {});
+    postJsonRequestMock.mockResolvedValue({
+      response: {
+        json: async () => ({
+          data: [{ b64_json: Buffer.from("png-one").toString("base64") }],
+        }),
+      },
+      release,
+    });
+
+    const provider = buildOpenRouterImageGenerationProvider();
+    await provider.generateImage({
+      provider: "openrouter",
+      model: "openai/gpt-5-image",
+      prompt: "draw a sticker",
+      inputImages: [{ buffer: Buffer.from("source-one"), mimeType: "image/png" }],
+      resolution: "1K",
+      resolutionInferred: true,
+      cfg: {},
+    });
+
+    const body = requireOpenRouterPostRequest().body as Record<string, unknown>;
+    expect(body).toMatchObject({
+      model: "openai/gpt-5-image",
+      prompt: "draw a sticker",
+      n: 1,
+      input_references: [
+        {
+          type: "image_url",
+          image_url: {
+            url: `data:image/png;base64,${Buffer.from("source-one").toString("base64")}`,
+          },
+        },
+      ],
+    });
+    expect(body).not.toHaveProperty("resolution");
   });
 
   it("sends chat completion image requests with Gemini image config and count", async () => {
@@ -347,6 +481,24 @@ describe("openrouter image generation provider", () => {
     const image = requireGeneratedImage(result, 0);
     expect(image.buffer.toString()).toBe("webp-one");
     expect(image.mimeType).toBe("image/webp");
+  });
+
+  it("rejects too many legacy chat-image references before request", async () => {
+    const provider = buildOpenRouterImageGenerationProvider();
+    await expect(
+      provider.generateImage({
+        provider: "openrouter",
+        model: "google/gemini-3.1-flash-image-preview",
+        prompt: "turn these into watercolor",
+        inputImages: Array.from({ length: 6 }, (_, index) => ({
+          buffer: Buffer.from(`source-image-${index}`),
+          mimeType: "image/png",
+        })),
+        cfg: {},
+      }),
+    ).rejects.toThrow("supports at most 5 reference images");
+
+    expect(postJsonRequestMock).not.toHaveBeenCalled();
   });
 
   it("wraps wrong-shape successful OpenRouter image responses", async () => {

--- a/extensions/openrouter/image-generation-provider.test.ts
+++ b/extensions/openrouter/image-generation-provider.test.ts
@@ -100,7 +100,13 @@ describe("openrouter image generation provider", () => {
     expect(provider.id).toBe("openrouter");
     expect(provider.label).toBe("OpenRouter");
     expect(provider.defaultModel).toBe("google/gemini-3.1-flash-image-preview");
+    expect(provider.models).toContain("google/gemini-3.1-flash-image");
+    expect(provider.models).toContain("google/gemini-3-pro-image");
     expect(provider.models).toContain("google/gemini-3-pro-image-preview");
+    expect(provider.models).toContain("google/gemini-2.5-flash-image");
+    expect(provider.models).toContain("openai/gpt-5-image");
+    expect(provider.models).toContain("openai/gpt-5-image-mini");
+    expect(provider.models).toContain("openai/gpt-5.4-image-2");
     expect(provider.capabilities.generate.maxCount).toBe(4);
     expect(provider.capabilities.generate.supportsAspectRatio).toBe(true);
     expect(provider.capabilities.edit.enabled).toBe(true);

--- a/extensions/openrouter/image-generation-provider.test.ts
+++ b/extensions/openrouter/image-generation-provider.test.ts
@@ -107,10 +107,48 @@ describe("openrouter image generation provider", () => {
     expect(provider.models).toContain("openai/gpt-5-image");
     expect(provider.models).toContain("openai/gpt-5-image-mini");
     expect(provider.models).toContain("openai/gpt-5.4-image-2");
+    expect(provider.models).toContain("microsoft/mai-image-2.5");
     expect(provider.capabilities.generate.maxCount).toBe(4);
     expect(provider.capabilities.generate.supportsAspectRatio).toBe(true);
     expect(provider.capabilities.edit.enabled).toBe(true);
     expect(provider.capabilities.edit.maxInputImages).toBe(5);
+  });
+
+  it("sends current image models through OpenRouter images API", async () => {
+    const release = vi.fn(async () => {});
+    postJsonRequestMock.mockResolvedValue({
+      response: {
+        json: async () => ({
+          data: [{ b64_json: Buffer.from("png-one").toString("base64") }],
+        }),
+      },
+      release,
+    });
+
+    const provider = buildOpenRouterImageGenerationProvider();
+    const result = await provider.generateImage({
+      provider: "openrouter",
+      model: "microsoft/mai-image-2.5",
+      prompt: "draw a sticker",
+      aspectRatio: "16:9",
+      resolution: "2K",
+      count: 2,
+      cfg: {},
+    });
+
+    const request = requireOpenRouterPostRequest();
+    expect(request).toMatchObject({
+      url: "https://openrouter.ai/api/v1/images",
+      body: {
+        model: "microsoft/mai-image-2.5",
+        prompt: "draw a sticker",
+        n: 2,
+        aspect_ratio: "16:9",
+        resolution: "2K",
+      },
+    });
+    expect(result.model).toBe("microsoft/mai-image-2.5");
+    expect(requireGeneratedImage(result, 0).buffer.toString()).toBe("png-one");
   });
 
   it("sends chat completion image requests with Gemini image config and count", async () => {

--- a/extensions/openrouter/image-generation-provider.test.ts
+++ b/extensions/openrouter/image-generation-provider.test.ts
@@ -109,11 +109,17 @@ describe("openrouter image generation provider", () => {
     expect(provider.models).toContain("openai/gpt-5.4-image-2");
     expect(provider.models).toContain("microsoft/mai-image-2.5");
     expect(provider.capabilities.generate.maxCount).toBe(4);
+    expect(provider.capabilities.generate.maxCountByModel?.["microsoft/mai-image-2.5"]).toBe(1);
     expect(provider.capabilities.generate.supportsAspectRatio).toBe(true);
     expect(provider.capabilities.geometry?.aspectRatios).toContain("1:4");
     expect(provider.capabilities.geometry?.aspectRatios).toContain("8:1");
     expect(provider.capabilities.edit.enabled).toBe(true);
     expect(provider.capabilities.edit.maxInputImages).toBe(10);
+    expect(provider.capabilities.edit.maxInputImagesByModel?.[provider.defaultModel ?? ""]).toBe(5);
+    expect(
+      provider.capabilities.edit.maxInputImagesByModel?.["google/gemini-2.5-flash-image"],
+    ).toBe(3);
+    expect(provider.capabilities.edit.maxInputImagesByModel?.["microsoft/mai-image-2.5"]).toBe(1);
     expect(provider.capabilities.edit.supportsResolution).toBe(true);
   });
 

--- a/extensions/openrouter/image-generation-provider.ts
+++ b/extensions/openrouter/image-generation-provider.ts
@@ -25,6 +25,7 @@ import { OPENROUTER_BASE_URL } from "./provider-catalog.js";
 const DEFAULT_MODEL = "google/gemini-3.1-flash-image-preview";
 const DEFAULT_TIMEOUT_MS = 180_000;
 const MAX_IMAGE_RESULTS = 4;
+const MAX_CHAT_COMPLETIONS_INPUT_IMAGES = 5;
 const MB = 1024 * 1024;
 const SUPPORTED_MODELS = [
   DEFAULT_MODEL,
@@ -37,15 +38,30 @@ const SUPPORTED_MODELS = [
   "openai/gpt-5.4-image-2",
   "microsoft/mai-image-2.5",
 ] as const;
-const DEDICATED_IMAGE_API_MODELS = new Set<string>([
-  "google/gemini-3.1-flash-image",
-  "google/gemini-3-pro-image",
-  "google/gemini-2.5-flash-image",
-  "openai/gpt-5-image",
-  "openai/gpt-5-image-mini",
-  "microsoft/mai-image-2.5",
-]);
 const SUPPORTED_ASPECT_RATIOS = [
+  "1:1",
+  "1:4",
+  "1:8",
+  "2:3",
+  "3:2",
+  "3:4",
+  "4:1",
+  "4:3",
+  "4:5",
+  "5:4",
+  "8:1",
+  "9:16",
+  "16:9",
+  "21:9",
+] as const;
+const MAX_IMAGES_API_INPUT_REFERENCES = 10;
+type OpenRouterImagesApiModelCapabilities = {
+  maxCount: number;
+  maxInputImages: number;
+  aspectRatios?: readonly string[];
+  resolutions?: readonly string[];
+};
+const GEMINI_IMAGE_ASPECT_RATIOS = [
   "1:1",
   "2:3",
   "3:2",
@@ -57,6 +73,44 @@ const SUPPORTED_ASPECT_RATIOS = [
   "16:9",
   "21:9",
 ] as const;
+const OPENROUTER_IMAGES_API_MODEL_CAPABILITIES: Record<
+  string,
+  OpenRouterImagesApiModelCapabilities
+> = {
+  "google/gemini-3.1-flash-image": {
+    maxCount: 1,
+    maxInputImages: MAX_IMAGES_API_INPUT_REFERENCES,
+    aspectRatios: [...GEMINI_IMAGE_ASPECT_RATIOS, "1:4", "1:8", "4:1", "8:1"],
+    resolutions: ["1K", "2K", "4K"],
+  },
+  "google/gemini-3-pro-image": {
+    maxCount: 1,
+    maxInputImages: MAX_IMAGES_API_INPUT_REFERENCES,
+    aspectRatios: GEMINI_IMAGE_ASPECT_RATIOS,
+    resolutions: ["1K", "2K", "4K"],
+  },
+  "google/gemini-2.5-flash-image": {
+    maxCount: 1,
+    maxInputImages: 3,
+    aspectRatios: GEMINI_IMAGE_ASPECT_RATIOS,
+  },
+  "openai/gpt-5-image": {
+    maxCount: MAX_IMAGE_RESULTS,
+    maxInputImages: MAX_IMAGES_API_INPUT_REFERENCES,
+  },
+  "openai/gpt-5-image-mini": {
+    maxCount: MAX_IMAGE_RESULTS,
+    maxInputImages: MAX_IMAGES_API_INPUT_REFERENCES,
+  },
+  "microsoft/mai-image-2.5": {
+    maxCount: 1,
+    maxInputImages: 1,
+    aspectRatios: ["1:1", "4:3", "3:4", "16:9", "9:16", "3:2", "2:3"],
+  },
+};
+const DEDICATED_IMAGE_API_MODELS = new Set<string>(
+  Object.keys(OPENROUTER_IMAGES_API_MODEL_CAPABILITIES),
+);
 const OPENROUTER_IMAGE_MALFORMED_RESPONSE = "OpenRouter image generation response malformed";
 
 function throwMalformedOpenRouterImageResponse(message: string | undefined): never | undefined {
@@ -322,28 +376,102 @@ function shouldUseDedicatedImagesApi(model: string): boolean {
   return DEDICATED_IMAGE_API_MODELS.has(model);
 }
 
-function buildImagesApiBody(req: ImageGenerationRequest, model: string, count: number) {
+function resolveImagesApiModelCapabilities(model: string): OpenRouterImagesApiModelCapabilities {
+  return (
+    OPENROUTER_IMAGES_API_MODEL_CAPABILITIES[model] ?? {
+      maxCount: 1,
+      maxInputImages: 0,
+    }
+  );
+}
+
+function assertImagesApiModelCount(
+  model: string,
+  req: ImageGenerationRequest,
+  capabilities: OpenRouterImagesApiModelCapabilities,
+): number {
+  const count = resolveImageCount(req.count);
+  if (
+    typeof req.count === "number" &&
+    Number.isFinite(req.count) &&
+    count > capabilities.maxCount
+  ) {
+    throw new Error(
+      `OpenRouter image model ${model} supports at most ${capabilities.maxCount} output image${
+        capabilities.maxCount === 1 ? "" : "s"
+      }.`,
+    );
+  }
+  return count;
+}
+
+function assertImagesApiModelGeometry(
+  model: string,
+  req: ImageGenerationRequest,
+  capabilities: OpenRouterImagesApiModelCapabilities,
+): { aspectRatio?: string; resolution?: string } {
+  const aspectRatio = normalizeOptionalString(req.aspectRatio);
+  if (aspectRatio && !capabilities.aspectRatios?.includes(aspectRatio)) {
+    throw new Error(`OpenRouter image model ${model} does not support aspectRatio=${aspectRatio}.`);
+  }
+  const resolution = normalizeOptionalString(req.resolution);
+  if (resolution && !capabilities.resolutions?.includes(resolution)) {
+    if (req.resolutionInferred === true) {
+      return { aspectRatio };
+    }
+    throw new Error(`OpenRouter image model ${model} does not support resolution=${resolution}.`);
+  }
+  return { aspectRatio, resolution };
+}
+
+function assertImagesApiInputImages(
+  model: string,
+  req: ImageGenerationRequest,
+  capabilities: OpenRouterImagesApiModelCapabilities,
+) {
+  const inputImages = req.inputImages ?? [];
+  if (inputImages.length > capabilities.maxInputImages) {
+    throw new Error(
+      `OpenRouter image model ${model} supports at most ${
+        capabilities.maxInputImages
+      } reference image${capabilities.maxInputImages === 1 ? "" : "s"}.`,
+    );
+  }
+  return inputImages;
+}
+
+function buildImagesApiBody(req: ImageGenerationRequest, model: string) {
+  const capabilities = resolveImagesApiModelCapabilities(model);
+  const count = assertImagesApiModelCount(model, req, capabilities);
+  const { aspectRatio, resolution } = assertImagesApiModelGeometry(model, req, capabilities);
+  const inputImages = assertImagesApiInputImages(model, req, capabilities);
   const body: Record<string, unknown> = {
     model,
     prompt: req.prompt,
     n: count,
   };
-  const aspectRatio = normalizeOptionalString(req.aspectRatio);
   if (aspectRatio) {
     body.aspect_ratio = aspectRatio;
   }
-  const resolution = normalizeOptionalString(req.resolution);
   if (resolution) {
     body.resolution = resolution;
   }
-  const inputImages = req.inputImages ?? [];
   if (inputImages.length > 0) {
     body.input_references = inputImages.map((image) => ({
       type: "image_url",
       image_url: { url: toImageDataUrl(image) },
     }));
   }
-  return body;
+  return { body, count };
+}
+
+function assertChatCompletionsInputImages(model: string, req: ImageGenerationRequest): void {
+  const inputImages = req.inputImages ?? [];
+  if (inputImages.length > MAX_CHAT_COMPLETIONS_INPUT_IMAGES) {
+    throw new Error(
+      `OpenRouter image model ${model} supports at most ${MAX_CHAT_COMPLETIONS_INPUT_IMAGES} reference images.`,
+    );
+  }
 }
 
 export function buildOpenRouterImageGenerationProvider(): ImageGenerationProvider {
@@ -364,7 +492,7 @@ export function buildOpenRouterImageGenerationProvider(): ImageGenerationProvide
       edit: {
         enabled: true,
         maxCount: MAX_IMAGE_RESULTS,
-        maxInputImages: 5,
+        maxInputImages: MAX_IMAGES_API_INPUT_REFERENCES,
         supportsSize: false,
         supportsAspectRatio: true,
         supportsResolution: true,
@@ -402,13 +530,17 @@ export function buildOpenRouterImageGenerationProvider(): ImageGenerationProvide
           transport: "http",
         });
 
-      const count = resolveImageCount(req.count);
       const useImagesApi = shouldUseDedicatedImagesApi(model);
+      const imagesApiRequest = useImagesApi ? buildImagesApiBody(req, model) : undefined;
+      const count = imagesApiRequest?.count ?? resolveImageCount(req.count);
+      if (!useImagesApi) {
+        assertChatCompletionsInputImages(model, req);
+      }
       const { response, release } = await postJsonRequest({
         url: useImagesApi ? `${baseUrl}/images` : `${baseUrl}/chat/completions`,
         headers,
-        body: useImagesApi
-          ? buildImagesApiBody(req, model, count)
+        body: imagesApiRequest
+          ? imagesApiRequest.body
           : {
               model,
               messages: [{ role: "user", content: buildMessageContent(req) }],

--- a/extensions/openrouter/image-generation-provider.ts
+++ b/extensions/openrouter/image-generation-provider.ts
@@ -111,6 +111,19 @@ const OPENROUTER_IMAGES_API_MODEL_CAPABILITIES: Record<
 const DEDICATED_IMAGE_API_MODELS = new Set<string>(
   Object.keys(OPENROUTER_IMAGES_API_MODEL_CAPABILITIES),
 );
+const OPENROUTER_MAX_COUNTS_BY_MODEL = Object.fromEntries(
+  SUPPORTED_MODELS.map((model) => [
+    model,
+    OPENROUTER_IMAGES_API_MODEL_CAPABILITIES[model]?.maxCount ?? MAX_IMAGE_RESULTS,
+  ]),
+);
+const OPENROUTER_MAX_INPUT_IMAGES_BY_MODEL = Object.fromEntries(
+  SUPPORTED_MODELS.map((model) => [
+    model,
+    OPENROUTER_IMAGES_API_MODEL_CAPABILITIES[model]?.maxInputImages ??
+      MAX_CHAT_COMPLETIONS_INPUT_IMAGES,
+  ]),
+);
 const OPENROUTER_IMAGE_MALFORMED_RESPONSE = "OpenRouter image generation response malformed";
 
 function throwMalformedOpenRouterImageResponse(message: string | undefined): never | undefined {
@@ -485,6 +498,7 @@ export function buildOpenRouterImageGenerationProvider(): ImageGenerationProvide
     capabilities: {
       generate: {
         maxCount: MAX_IMAGE_RESULTS,
+        maxCountByModel: OPENROUTER_MAX_COUNTS_BY_MODEL,
         supportsSize: false,
         supportsAspectRatio: true,
         supportsResolution: true,
@@ -492,7 +506,9 @@ export function buildOpenRouterImageGenerationProvider(): ImageGenerationProvide
       edit: {
         enabled: true,
         maxCount: MAX_IMAGE_RESULTS,
+        maxCountByModel: OPENROUTER_MAX_COUNTS_BY_MODEL,
         maxInputImages: MAX_IMAGES_API_INPUT_REFERENCES,
+        maxInputImagesByModel: OPENROUTER_MAX_INPUT_IMAGES_BY_MODEL,
         supportsSize: false,
         supportsAspectRatio: true,
         supportsResolution: true,

--- a/extensions/openrouter/image-generation-provider.ts
+++ b/extensions/openrouter/image-generation-provider.ts
@@ -28,7 +28,12 @@ const MAX_IMAGE_RESULTS = 4;
 const MB = 1024 * 1024;
 const SUPPORTED_MODELS = [
   DEFAULT_MODEL,
+  "google/gemini-3.1-flash-image",
+  "google/gemini-3-pro-image",
   "google/gemini-3-pro-image-preview",
+  "google/gemini-2.5-flash-image",
+  "openai/gpt-5-image",
+  "openai/gpt-5-image-mini",
   "openai/gpt-5.4-image-2",
 ] as const;
 const SUPPORTED_ASPECT_RATIOS = [

--- a/extensions/openrouter/image-generation-provider.ts
+++ b/extensions/openrouter/image-generation-provider.ts
@@ -35,7 +35,16 @@ const SUPPORTED_MODELS = [
   "openai/gpt-5-image",
   "openai/gpt-5-image-mini",
   "openai/gpt-5.4-image-2",
+  "microsoft/mai-image-2.5",
 ] as const;
+const DEDICATED_IMAGE_API_MODELS = new Set<string>([
+  "google/gemini-3.1-flash-image",
+  "google/gemini-3-pro-image",
+  "google/gemini-2.5-flash-image",
+  "openai/gpt-5-image",
+  "openai/gpt-5-image-mini",
+  "microsoft/mai-image-2.5",
+]);
 const SUPPORTED_ASPECT_RATIOS = [
   "1:1",
   "2:3",
@@ -141,6 +150,42 @@ function extractImagesFromPart(
   throwMalformedOpenRouterImageResponse(malformedResponseError);
 }
 
+function extractImagesFromDataArray(
+  images: GeneratedImageAsset[],
+  data: unknown,
+  malformedResponseError?: string,
+): boolean {
+  if (data === undefined || data === null) {
+    return false;
+  }
+  if (!Array.isArray(data)) {
+    throwMalformedOpenRouterImageResponse(malformedResponseError);
+    return true;
+  }
+  for (const entry of data) {
+    if (!isRecord(entry)) {
+      throwMalformedOpenRouterImageResponse(malformedResponseError);
+      continue;
+    }
+    const rawBase64 = normalizeOptionalString(entry.b64_json);
+    if (!rawBase64) {
+      throwMalformedOpenRouterImageResponse(malformedResponseError);
+      continue;
+    }
+    const image = generatedImageAssetFromBase64({
+      base64: rawBase64,
+      index: images.length,
+      mimeType: normalizeOptionalString(entry.media_type),
+    });
+    if (!image) {
+      throwMalformedOpenRouterImageResponse(malformedResponseError);
+      continue;
+    }
+    images.push(image);
+  }
+  return true;
+}
+
 export function extractOpenRouterImagesFromResponse(
   body: unknown,
   options: { malformedResponseError?: string } = {},
@@ -148,6 +193,10 @@ export function extractOpenRouterImagesFromResponse(
   if (!isRecord(body)) {
     throwMalformedOpenRouterImageResponse(options.malformedResponseError);
     return [];
+  }
+  const images: GeneratedImageAsset[] = [];
+  if (extractImagesFromDataArray(images, body.data, options.malformedResponseError)) {
+    return images;
   }
   const choices = body.choices;
   if (choices === undefined || choices === null) {
@@ -158,7 +207,6 @@ export function extractOpenRouterImagesFromResponse(
     return [];
   }
 
-  const images: GeneratedImageAsset[] = [];
   for (const choice of choices) {
     if (!isRecord(choice)) {
       throwMalformedOpenRouterImageResponse(options.malformedResponseError);
@@ -270,6 +318,34 @@ function buildImageConfig(req: ImageGenerationRequest, model: string): Record<st
   return imageConfig;
 }
 
+function shouldUseDedicatedImagesApi(model: string): boolean {
+  return DEDICATED_IMAGE_API_MODELS.has(model);
+}
+
+function buildImagesApiBody(req: ImageGenerationRequest, model: string, count: number) {
+  const body: Record<string, unknown> = {
+    model,
+    prompt: req.prompt,
+    n: count,
+  };
+  const aspectRatio = normalizeOptionalString(req.aspectRatio);
+  if (aspectRatio) {
+    body.aspect_ratio = aspectRatio;
+  }
+  const resolution = normalizeOptionalString(req.resolution);
+  if (resolution) {
+    body.resolution = resolution;
+  }
+  const inputImages = req.inputImages ?? [];
+  if (inputImages.length > 0) {
+    body.input_references = inputImages.map((image) => ({
+      type: "image_url",
+      image_url: { url: toImageDataUrl(image) },
+    }));
+  }
+  return body;
+}
+
 export function buildOpenRouterImageGenerationProvider(): ImageGenerationProvider {
   return {
     id: "openrouter",
@@ -327,16 +403,19 @@ export function buildOpenRouterImageGenerationProvider(): ImageGenerationProvide
         });
 
       const count = resolveImageCount(req.count);
+      const useImagesApi = shouldUseDedicatedImagesApi(model);
       const { response, release } = await postJsonRequest({
-        url: `${baseUrl}/chat/completions`,
+        url: useImagesApi ? `${baseUrl}/images` : `${baseUrl}/chat/completions`,
         headers,
-        body: {
-          model,
-          messages: [{ role: "user", content: buildMessageContent(req) }],
-          modalities: ["image", "text"],
-          n: count,
-          ...(Object.keys(imageConfig).length > 0 ? { image_config: imageConfig } : {}),
-        },
+        body: useImagesApi
+          ? buildImagesApiBody(req, model, count)
+          : {
+              model,
+              messages: [{ role: "user", content: buildMessageContent(req) }],
+              modalities: ["image", "text"],
+              n: count,
+              ...(Object.keys(imageConfig).length > 0 ? { image_config: imageConfig } : {}),
+            },
         timeoutMs: req.timeoutMs ?? DEFAULT_TIMEOUT_MS,
         fetchFn: fetch,
         allowPrivateNetwork,

--- a/src/agents/tools/image-generate-tool.actions.ts
+++ b/src/agents/tools/image-generate-tool.actions.ts
@@ -50,7 +50,7 @@ function summarizeModelSpecificImageEditLimits(
   const entries = Object.entries(provider.capabilities.edit.maxInputImagesByModel ?? {})
     .filter(([, maxRefs]) => Number.isFinite(maxRefs))
     .filter(([, maxRefs]) => maxRefs !== provider.capabilities.edit.maxInputImages)
-    .sort(([left], [right]) => left.localeCompare(right));
+    .toSorted(([left], [right]) => left.localeCompare(right));
   if (entries.length === 0) {
     return undefined;
   }

--- a/src/agents/tools/image-generate-tool.actions.ts
+++ b/src/agents/tools/image-generate-tool.actions.ts
@@ -44,13 +44,31 @@ function listSupportedImageGenerationModes(provider: ImageGenerationProvider): s
   return ["generate", ...(provider.capabilities.edit.enabled ? ["edit"] : [])];
 }
 
+function summarizeModelSpecificImageEditLimits(
+  provider: ImageGenerationProvider,
+): string | undefined {
+  const entries = Object.entries(provider.capabilities.edit.maxInputImagesByModel ?? {})
+    .filter(([, maxRefs]) => Number.isFinite(maxRefs))
+    .filter(([, maxRefs]) => maxRefs !== provider.capabilities.edit.maxInputImages)
+    .sort(([left], [right]) => left.localeCompare(right));
+  if (entries.length === 0) {
+    return undefined;
+  }
+  return `model-specific refs ${entries
+    .map(([model, maxRefs]) => `${model}=${maxRefs}`)
+    .join(", ")}`;
+}
+
 /** Formats provider capability details for the image generation `list` action. */
 function summarizeImageGenerationCapabilities(provider: ImageGenerationProvider): string {
   const caps: string[] = [];
   if (provider.capabilities.edit.enabled) {
     const maxRefs = provider.capabilities.edit.maxInputImages;
+    const modelSpecificRefs = summarizeModelSpecificImageEditLimits(provider);
     caps.push(
-      `editing${typeof maxRefs === "number" ? ` up to ${maxRefs} ref${maxRefs === 1 ? "" : "s"}` : ""}`,
+      `editing${typeof maxRefs === "number" ? ` up to ${maxRefs} ref${maxRefs === 1 ? "" : "s"}` : ""}${
+        modelSpecificRefs ? ` (${modelSpecificRefs})` : ""
+      }`,
     );
   }
   if ((provider.capabilities.geometry?.resolutions?.length ?? 0) > 0) {

--- a/src/agents/tools/image-generate-tool.test.ts
+++ b/src/agents/tools/image-generate-tool.test.ts
@@ -88,7 +88,11 @@ function stubImageGenerationProviders() {
     {
       id: "google",
       defaultModel: "gemini-3.1-flash-image-preview",
-      models: ["gemini-3.1-flash-image-preview", "gemini-3-pro-image-preview"],
+      models: [
+        "gemini-3.1-flash-image-preview",
+        "gemini-3-pro-image-preview",
+        "gemini-2.5-flash-image",
+      ],
       isConfigured: () => hasStubbedImageProviderAuth("google"),
       capabilities: {
         generate: {
@@ -99,6 +103,9 @@ function stubImageGenerationProviders() {
         edit: {
           enabled: true,
           maxInputImages: 5,
+          maxInputImagesByModel: {
+            "gemini-2.5-flash-image": 3,
+          },
           supportsAspectRatio: true,
           supportsResolution: true,
         },
@@ -252,7 +259,9 @@ function stubEditedImageFlow(params?: { width?: number; height?: number }) {
 
 function createFalEditProvider(params?: {
   defaultModel?: string;
+  maxCountByModel?: Record<string, number>;
   maxInputImages?: number;
+  maxInputImagesByModel?: Record<string, number>;
   models?: string[];
   supportsAspectRatio?: boolean;
   aspectRatios?: string[];
@@ -264,6 +273,7 @@ function createFalEditProvider(params?: {
     capabilities: {
       generate: {
         maxCount: 4,
+        ...(params?.maxCountByModel ? { maxCountByModel: params.maxCountByModel } : {}),
         supportsSize: true,
         supportsAspectRatio: true,
         supportsResolution: true,
@@ -271,6 +281,10 @@ function createFalEditProvider(params?: {
       edit: {
         enabled: true,
         maxInputImages: params?.maxInputImages ?? 1,
+        ...(params?.maxCountByModel ? { maxCountByModel: params.maxCountByModel } : {}),
+        ...(params?.maxInputImagesByModel
+          ? { maxInputImagesByModel: params.maxInputImagesByModel }
+          : {}),
         supportsSize: true,
         supportsAspectRatio: params?.supportsAspectRatio ?? false,
         supportsResolution: true,
@@ -2250,7 +2264,7 @@ describe("createImageGenerateTool", () => {
     expect(text).toContain(
       "auth: set OPENAI_API_KEY or configure OpenAI Codex OAuth for openai/gpt-image-2",
     );
-    expect(text).toContain("editing up to 5 refs");
+    expect(text).toContain("editing up to 5 refs (model-specific refs gemini-2.5-flash-image=3)");
     expect(text).toContain("aspect ratios 1:1, 16:9");
     const details = resultDetails(result);
     const providers = details.providers as Array<Record<string, unknown>>;
@@ -2264,11 +2278,15 @@ describe("createImageGenerateTool", () => {
     expect(googleProvider.models).toEqual([
       "gemini-3.1-flash-image-preview",
       "gemini-3-pro-image-preview",
+      "gemini-2.5-flash-image",
     ]);
     const googleCapabilities = requireRecord(googleProvider.capabilities, "google capabilities");
     expect(googleCapabilities.edit).toEqual({
       enabled: true,
       maxInputImages: 5,
+      maxInputImagesByModel: {
+        "gemini-2.5-flash-image": 3,
+      },
       supportsAspectRatio: true,
       supportsResolution: true,
     });
@@ -2345,6 +2363,149 @@ describe("createImageGenerateTool", () => {
     ).rejects.toThrow("fal edit supports at most 1 reference image");
     expect(loadWebMedia).not.toHaveBeenCalled();
     expect(generateImage).not.toHaveBeenCalled();
+  });
+
+  it("rejects model-specific edit limits before loading references", async () => {
+    vi.spyOn(imageGenerationRuntime, "listRuntimeImageGenerationProviders").mockReturnValue([
+      createFalEditProvider({
+        maxInputImages: 10,
+        maxInputImagesByModel: {
+          "fal-ai/flux/dev": 1,
+        },
+      }),
+    ]);
+    const generateImage = vi.spyOn(imageGenerationRuntime, "generateImage");
+    const loadWebMedia = vi.spyOn(webMedia, "loadWebMedia").mockResolvedValue({
+      kind: "image",
+      buffer: Buffer.from("input-image"),
+      contentType: "image/png",
+    });
+
+    const tool = createToolWithPrimaryImageModel("fal/fal-ai/flux/dev", {
+      workspaceDir: process.cwd(),
+    });
+
+    await expect(
+      tool.execute("call-fal-model-edit-limit", {
+        prompt: "combine",
+        images: ["https://example.test/a.png", "https://example.test/b.png"],
+      }),
+    ).rejects.toThrow("fal edit supports at most 1 reference image");
+    expect(loadWebMedia).not.toHaveBeenCalled();
+    expect(generateImage).not.toHaveBeenCalled();
+  });
+
+  it("rejects model-specific output counts before runtime", async () => {
+    vi.spyOn(imageGenerationRuntime, "listRuntimeImageGenerationProviders").mockReturnValue([
+      createFalEditProvider({
+        maxInputImages: 10,
+        maxCountByModel: {
+          "fal-ai/flux/dev": 1,
+        },
+      }),
+    ]);
+    const generateImage = vi.spyOn(imageGenerationRuntime, "generateImage");
+
+    const tool = createToolWithPrimaryImageModel("fal/fal-ai/flux/dev");
+
+    await expect(
+      tool.execute("call-fal-model-count-limit", {
+        prompt: "draw several options",
+        count: 2,
+      }),
+    ).rejects.toThrow("fal generate supports at most 1 output image");
+    expect(generateImage).not.toHaveBeenCalled();
+  });
+
+  it("allows configured fallbacks to satisfy model-specific output counts", async () => {
+    vi.spyOn(imageGenerationRuntime, "listRuntimeImageGenerationProviders").mockReturnValue([
+      createFalEditProvider({
+        models: ["fal-ai/flux/dev", "fal-ai/flux/pro"],
+        maxInputImages: 10,
+        maxCountByModel: {
+          "fal-ai/flux/dev": 1,
+          "fal-ai/flux/pro": 4,
+        },
+      }),
+    ]);
+    const generateImage = vi.spyOn(imageGenerationRuntime, "generateImage").mockResolvedValue({
+      provider: "fal",
+      model: "fal-ai/flux/pro",
+      attempts: [{ provider: "fal", model: "fal-ai/flux/dev", error: "too many images" }],
+      ignoredOverrides: [],
+      images: [
+        {
+          buffer: Buffer.from("png-out"),
+          mimeType: "image/png",
+          fileName: "fallback.png",
+        },
+      ],
+    });
+    vi.spyOn(mediaStore, "saveMediaBuffer").mockResolvedValue({
+      path: "/tmp/fallback.png",
+      id: "fallback.png",
+      size: 7,
+      contentType: "image/png",
+    });
+    const tool = requireImageGenerateTool(
+      createImageGenerateTool({
+        config: {
+          agents: {
+            defaults: {
+              imageGenerationModel: {
+                primary: "fal/fal-ai/flux/dev",
+                fallbacks: ["fal/fal-ai/flux/pro"],
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    await tool.execute("call-fal-count-fallback", {
+      prompt: "draw several options",
+      count: 2,
+    });
+
+    expect(generateImage).toHaveBeenCalled();
+    expect(mockCallArg(generateImage, 0, "generateImage").count).toBe(2);
+  });
+
+  it("allows configured fallbacks to satisfy model-specific edit limits", async () => {
+    vi.spyOn(imageGenerationRuntime, "listRuntimeImageGenerationProviders").mockReturnValue([
+      createFalEditProvider({
+        models: ["fal-ai/flux/dev", "fal-ai/flux/pro"],
+        maxInputImages: 10,
+        maxInputImagesByModel: {
+          "fal-ai/flux/dev": 1,
+          "fal-ai/flux/pro": 10,
+        },
+      }),
+    ]);
+    const generateImage = stubEditedImageFlow();
+    const tool = requireImageGenerateTool(
+      createImageGenerateTool({
+        config: {
+          agents: {
+            defaults: {
+              imageGenerationModel: {
+                primary: "fal/fal-ai/flux/dev",
+                fallbacks: ["fal/fal-ai/flux/pro"],
+              },
+            },
+          },
+        },
+        workspaceDir: process.cwd(),
+      }),
+    );
+
+    await tool.execute("call-fal-edit-fallback", {
+      prompt: "combine",
+      images: ["https://example.test/a.png", "https://example.test/b.png"],
+    });
+
+    expect(generateImage).toHaveBeenCalled();
+    expect(mockCallArg(generateImage, 0, "generateImage").inputImages).toHaveLength(2);
   });
 
   it("uses registered provider metadata for slash-containing model overrides", async () => {

--- a/src/agents/tools/image-generate-tool.ts
+++ b/src/agents/tools/image-generate-tool.ts
@@ -6,6 +6,7 @@
 import { Type } from "typebox";
 import { getRuntimeConfig } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resolveImageGenerationModeCapabilities } from "../../image-generation/capabilities.js";
 import { parseImageGenerationModelRef } from "../../image-generation/model-ref.js";
 import {
   generateImage,
@@ -26,6 +27,7 @@ import type {
 } from "../../image-generation/types.js";
 import type { SsrFPolicy } from "../../infra/net/ssrf.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { resolveCapabilityModelCandidates } from "../../media-generation/runtime-shared.js";
 import {
   resolveConfiguredMediaMaxBytes,
   resolveGeneratedMediaMaxBytes,
@@ -116,6 +118,10 @@ const SUPPORTED_BACKGROUNDS = ["transparent", "opaque", "auto"] as const;
 const SUPPORTED_OPENAI_MODERATIONS = ["low", "auto"] as const;
 const SUPPORTED_FAL_CREATIVITY = ["raw", "low", "medium", "high"] as const;
 type FalCreativity = (typeof SUPPORTED_FAL_CREATIVITY)[number];
+type ImageGenerationCapabilityValidationTarget = {
+  provider: ImageGenerationProvider;
+  model?: string;
+};
 const SUPPORTED_ASPECT_RATIOS = new Set([
   "1:1",
   "2:3",
@@ -436,6 +442,32 @@ function resolveSelectedImageGenerationProvider(params: {
   });
 }
 
+function resolveImageGenerationCapabilityValidationTargets(params: {
+  config: OpenClawConfig;
+  imageGenerationModelConfig: ToolModelConfig;
+  modelOverride?: string;
+  agentDir?: string;
+  autoProviderFallback?: boolean;
+}): ImageGenerationCapabilityValidationTarget[] {
+  const providers = listRuntimeImageGenerationProviders({ config: params.config });
+  const findProvider = (providerId: string): ImageGenerationProvider | undefined =>
+    providers.find(
+      (provider) => provider.id === providerId || provider.aliases?.includes(providerId),
+    );
+  return resolveCapabilityModelCandidates({
+    cfg: params.config,
+    modelConfig: params.imageGenerationModelConfig,
+    modelOverride: params.modelOverride,
+    parseModelRef: parseImageGenerationModelRef,
+    agentDir: params.agentDir,
+    listProviders: () => providers,
+    autoProviderFallback: params.autoProviderFallback,
+  }).flatMap((candidate) => {
+    const provider = findProvider(candidate.provider);
+    return provider ? [{ provider, model: candidate.model }] : [];
+  });
+}
+
 function resolveSelectedImageGenerationModelId(params: {
   selectedProvider: ImageGenerationProvider | undefined;
   imageGenerationModelConfig: ToolModelConfig;
@@ -503,6 +535,8 @@ function isInlineDirectiveControlCharacter(char: string): boolean {
 
 function validateImageGenerationCapabilities(params: {
   provider: ImageGenerationProvider | undefined;
+  model?: string;
+  validationTargets?: ImageGenerationCapabilityValidationTarget[];
   count: number;
   inputImageCount: number;
   size?: string;
@@ -510,30 +544,66 @@ function validateImageGenerationCapabilities(params: {
   resolution?: ImageGenerationResolution;
   explicitResolution?: boolean;
 }) {
-  const provider = params.provider;
-  if (!provider) {
+  const validationTargets =
+    params.validationTargets && params.validationTargets.length > 0
+      ? params.validationTargets
+      : params.provider
+        ? [{ provider: params.provider, model: params.model }]
+        : [];
+  if (validationTargets.length === 0) {
     return;
   }
-  const isEdit = params.inputImageCount > 0;
-  const modeCaps = isEdit ? provider.capabilities.edit : provider.capabilities.generate;
-  const maxCount = modeCaps.maxCount ?? MAX_COUNT;
+  const errors: ToolInputError[] = [];
+  for (const target of validationTargets) {
+    const error = validateSingleImageGenerationCapabilityTarget({
+      provider: target.provider,
+      model: target.model,
+      count: params.count,
+      inputImageCount: params.inputImageCount,
+    });
+    if (!error) {
+      return;
+    }
+    errors.push(error);
+  }
+  throw errors[0];
+}
+
+function validateSingleImageGenerationCapabilityTarget(params: {
+  provider: ImageGenerationProvider;
+  model?: string;
+  count: number;
+  inputImageCount: number;
+}): ToolInputError | undefined {
+  const provider = params.provider;
+  const { mode, capabilities: modeCaps } = resolveImageGenerationModeCapabilities({
+    provider,
+    model: params.model,
+    inputImageCount: params.inputImageCount,
+  });
+  const isEdit = mode === "edit";
+  const maxCount = modeCaps?.maxCount ?? MAX_COUNT;
   if (params.count > maxCount) {
-    throw new ToolInputError(
+    return new ToolInputError(
       `${provider.id} ${isEdit ? "edit" : "generate"} supports at most ${maxCount} output image${maxCount === 1 ? "" : "s"}.`,
     );
   }
 
   if (isEdit) {
     if (!provider.capabilities.edit.enabled) {
-      throw new ToolInputError(`${provider.id} does not support reference-image edits.`);
+      return new ToolInputError(`${provider.id} does not support reference-image edits.`);
     }
-    const maxInputImages = provider.capabilities.edit.maxInputImages ?? MAX_INPUT_IMAGES;
+    const maxInputImages =
+      modeCaps && "maxInputImages" in modeCaps && typeof modeCaps.maxInputImages === "number"
+        ? modeCaps.maxInputImages
+        : MAX_INPUT_IMAGES;
     if (params.inputImageCount > maxInputImages) {
-      throw new ToolInputError(
+      return new ToolInputError(
         `${provider.id} edit supports at most ${maxInputImages} reference image${maxInputImages === 1 ? "" : "s"}.`,
       );
     }
   }
+  return undefined;
 }
 
 type ImageGenerateSandboxConfig = {
@@ -955,6 +1025,14 @@ export function createImageGenerateTool(options?: {
         explicitModelRef,
         primaryModelRef,
       });
+      const autoProviderFallback = explicitModelConfig ? false : undefined;
+      const capabilityValidationTargets = resolveImageGenerationCapabilityValidationTargets({
+        config: effectiveCfg,
+        imageGenerationModelConfig,
+        modelOverride: model,
+        agentDir: options?.agentDir,
+        autoProviderFallback,
+      });
       const count = resolveRequestedCount(params);
       const requestKey = buildMediaGenerationRequestKey({
         tool: "image_generate",
@@ -986,6 +1064,8 @@ export function createImageGenerateTool(options?: {
       }
       validateImageGenerationCapabilities({
         provider: selectedProvider,
+        model: selectedModelId,
+        validationTargets: capabilityValidationTargets,
         count,
         inputImageCount: imageInputs.length,
         size,
@@ -1019,6 +1099,8 @@ export function createImageGenerateTool(options?: {
             : undefined);
       validateImageGenerationCapabilities({
         provider: selectedProvider,
+        model: selectedModelId,
+        validationTargets: capabilityValidationTargets,
         count,
         inputImageCount: inputImages.length,
         size,
@@ -1077,7 +1159,7 @@ export function createImageGenerateTool(options?: {
               filename,
               loadedReferenceImages,
               taskHandle,
-              autoProviderFallback: explicitModelConfig ? false : undefined,
+              autoProviderFallback,
             }),
         });
 
@@ -1135,7 +1217,7 @@ export function createImageGenerateTool(options?: {
           filename,
           loadedReferenceImages,
           taskHandle,
-          autoProviderFallback: explicitModelConfig ? false : undefined,
+          autoProviderFallback,
         });
         completeImageGenerationTaskRun({
           handle: taskHandle,

--- a/src/agents/tools/image-generate-tool.ts
+++ b/src/agents/tools/image-generate-tool.ts
@@ -693,6 +693,7 @@ async function executeImageGenerationJob(params: {
   size?: string;
   aspectRatio?: string;
   resolution?: ImageGenerationResolution;
+  resolutionInferred?: boolean;
   quality?: ImageGenerationQuality;
   outputFormat?: ImageGenerationOutputFormat;
   background?: ImageGenerationBackground;
@@ -721,6 +722,7 @@ async function executeImageGenerationJob(params: {
     size: params.size,
     aspectRatio: params.aspectRatio,
     resolution: params.resolution,
+    resolutionInferred: params.resolutionInferred,
     quality: params.quality,
     outputFormat: params.outputFormat,
     background: params.background,
@@ -1063,6 +1065,7 @@ export function createImageGenerateTool(options?: {
               size,
               aspectRatio,
               resolution,
+              resolutionInferred: Boolean(resolution && !explicitResolution),
               quality,
               outputFormat,
               background,
@@ -1120,6 +1123,7 @@ export function createImageGenerateTool(options?: {
           size,
           aspectRatio,
           resolution,
+          resolutionInferred: Boolean(resolution && !explicitResolution),
           quality,
           outputFormat,
           background,

--- a/src/image-generation/capabilities.ts
+++ b/src/image-generation/capabilities.ts
@@ -1,0 +1,46 @@
+// Image generation capability helpers resolve the active mode and model limits.
+import type {
+  ImageGenerationEditCapabilities,
+  ImageGenerationMode,
+  ImageGenerationModeCapabilities,
+  ImageGenerationProvider,
+} from "./types.js";
+
+export function resolveImageGenerationMode(params: {
+  inputImageCount?: number;
+}): ImageGenerationMode {
+  return (params.inputImageCount ?? 0) > 0 ? "edit" : "generate";
+}
+
+export function resolveImageGenerationModeCapabilities(params: {
+  provider?: Pick<ImageGenerationProvider, "capabilities">;
+  model?: string;
+  inputImageCount?: number;
+}): {
+  mode: ImageGenerationMode;
+  capabilities: ImageGenerationModeCapabilities | ImageGenerationEditCapabilities | undefined;
+} {
+  const mode = resolveImageGenerationMode(params);
+  const caps =
+    mode === "edit" ? params.provider?.capabilities.edit : params.provider?.capabilities.generate;
+  const model = params.model?.trim();
+  if (!caps || !model) {
+    return { mode, capabilities: caps };
+  }
+  const maxCount = caps.maxCountByModel?.[model];
+  const maxInputImages =
+    mode === "edit"
+      ? (caps as ImageGenerationEditCapabilities).maxInputImagesByModel?.[model]
+      : undefined;
+  if (typeof maxCount !== "number" && typeof maxInputImages !== "number") {
+    return { mode, capabilities: caps };
+  }
+  return {
+    mode,
+    capabilities: {
+      ...caps,
+      ...(typeof maxCount === "number" ? { maxCount } : {}),
+      ...(typeof maxInputImages === "number" ? { maxInputImages } : {}),
+    },
+  };
+}

--- a/src/image-generation/runtime-types.ts
+++ b/src/image-generation/runtime-types.ts
@@ -26,6 +26,7 @@ export type GenerateImageParams = {
   size?: string;
   aspectRatio?: string;
   resolution?: ImageGenerationResolution;
+  resolutionInferred?: boolean;
   quality?: ImageGenerationQuality;
   outputFormat?: ImageGenerationOutputFormat;
   background?: ImageGenerationBackground;

--- a/src/image-generation/runtime.ts
+++ b/src/image-generation/runtime.ts
@@ -127,6 +127,8 @@ export async function generateImage(
         size: sanitized.size,
         aspectRatio: sanitized.aspectRatio,
         resolution: sanitized.resolution,
+        resolutionInferred:
+          params.resolutionInferred === true && sanitized.resolution !== undefined,
         quality: sanitized.quality,
         outputFormat: sanitized.outputFormat,
         background: sanitized.background,

--- a/src/image-generation/types.ts
+++ b/src/image-generation/types.ts
@@ -74,6 +74,7 @@ export type ImageGenerationRequest = {
   size?: string;
   aspectRatio?: string;
   resolution?: ImageGenerationResolution;
+  resolutionInferred?: boolean;
   quality?: ImageGenerationQuality;
   outputFormat?: ImageGenerationOutputFormat;
   background?: ImageGenerationBackground;

--- a/src/image-generation/types.ts
+++ b/src/image-generation/types.ts
@@ -89,16 +89,20 @@ export type ImageGenerationResult = {
   metadata?: Record<string, unknown>;
 };
 
-type ImageGenerationModeCapabilities = {
+export type ImageGenerationMode = "generate" | "edit";
+
+export type ImageGenerationModeCapabilities = {
   maxCount?: number;
+  maxCountByModel?: Readonly<Record<string, number>>;
   supportsSize?: boolean;
   supportsAspectRatio?: boolean;
   supportsResolution?: boolean;
 };
 
-type ImageGenerationEditCapabilities = ImageGenerationModeCapabilities & {
+export type ImageGenerationEditCapabilities = ImageGenerationModeCapabilities & {
   enabled: boolean;
   maxInputImages?: number;
+  maxInputImagesByModel?: Readonly<Record<string, number>>;
 };
 
 type ImageGenerationGeometryCapabilities = {


### PR DESCRIPTION
## What Problem This Solves

Related #91504.

OpenRouter image generation currently exposes only a small static shortcut list, so users asking for broader OpenRouter image model support do not see current image-output models in OpenClaw's provider metadata or generated model catalog. Current OpenRouter image models are also documented under OpenRouter's dedicated Images API, so exposing them through the old chat-completions path would advertise models that can fail at runtime.

## Why This Change Was Made

OpenRouter's public `https://openrouter.ai/api/v1/images/models` response currently advertises additional image models beyond the existing OpenClaw list, including:

- `google/gemini-3.1-flash-image`
- `google/gemini-3-pro-image`
- `google/gemini-2.5-flash-image`
- `openai/gpt-5-image`
- `openai/gpt-5-image-mini`
- `microsoft/mai-image-2.5`

This PR adds those current model ids to the curated OpenRouter image-generation provider list, routes them through OpenRouter's dedicated `/images` endpoint, and parses the Images API `data[].b64_json` response shape. Existing preview/default chat-image model refs remain accepted on the chat-completions path so already configured users are not migrated unexpectedly.

OpenRouter `/images` supported parameters are model-specific, so this PR also gates the new models before submission:

- Gemini and Microsoft `/images` models request one output at a time.
- Microsoft receives only supported aspect-ratio/reference-image fields and rejects unsupported resolution requests clearly.
- OpenAI image models reject explicit unsupported Gemini-style `aspectRatio`/`resolution` requests instead of silently dropping them.
- Tool-inferred edit resolution is marked as inferred so OpenRouter can ignore unsupported inferred hints without breaking OpenAI/Microsoft reference-image edits.
- Legacy/default chat-image models keep their previous 5-reference-image guard while current `/images` models can use the shared tool cap of 10 when supported.

This intentionally remains a curated-list update, not dynamic catalog discovery; the broader catalog policy can still be considered separately.

## User Impact

Users can now discover and configure more current OpenRouter image models for the `image_generate` tool without relying on undocumented override strings. The linked issue's `microsoft/mai-image-2.5` example is included. Unsupported model-specific count, geometry, or reference-image requests fail locally with clear errors instead of being sent to OpenRouter and rejected later.

Existing OpenRouter image configs continue to work because the previous preview ids remain in the list and the default is unchanged.

## Evidence

- OpenRouter docs: current image generation uses `POST /api/v1/images` and returns image data through `data[].b64_json`: https://openrouter.ai/docs/guides/overview/multimodal/image-generation
- Queried OpenRouter's live `https://openrouter.ai/api/v1/images/models` endpoint on 2026-06-28 and confirmed the six added ids are present. Live capability proof showed model-specific `n`, `aspect_ratio`, `resolution`, and `input_references` support, including Microsoft `n.max=1`, Microsoft no `resolution`, OpenAI no `aspect_ratio`/`resolution`, and Gemini/Microsoft/OpenAI different reference limits.
- Built the local CLI runtime with bundled Node: `/Users/AdityaWork/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node scripts/build-all.mjs cliStartup`.
- Runtime provider-list proof: `/Users/AdityaWork/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node openclaw.mjs capability image providers --json | jq '.[] | select(.id == "openrouter") | {id, defaultModel, models, generate: .capabilities.generate, edit: .capabilities.edit, geometry: .capabilities.geometry}'` showed OpenRouter exposing all six added ids, `defaultModel: google/gemini-3.1-flash-image-preview`, `generate.maxCount: 4`, `edit.maxInputImages: 10`, aspect ratios including `1:4`, `1:8`, `4:1`, `8:1`, and resolutions `1K`, `2K`, `4K`.
- Redacted no-paid runtime generation proof using the compiled OpenRouter provider and a local HTTP fixture with explicit test SSRF allowance: `provider.generateImage({ model: "google/gemini-3.1-flash-image", count: 1, aspectRatio: "1:4", resolution: "1K" })` posted to `/api/v1/images` with authorization redacted, body `{ model: "google/gemini-3.1-flash-image", n: 1, aspect_ratio: "1:4", resolution: "1K" }`, parsed an Images API-style `{ data: [{ b64_json, media_type: "image/png" }] }` response, and returned one `image/png` asset (`image-1.png`, 68 bytes). This exercises the compiled provider endpoint/body/response path without making a paid live OpenRouter generation request.
- `node scripts/run-vitest.mjs extensions/openrouter/image-generation-provider.test.ts src/image-generation/runtime.test.ts src/agents/tools/image-generate-tool.test.ts`
- `node node_modules/oxfmt/bin/oxfmt --check --threads=1 extensions/openrouter/image-generation-provider.ts extensions/openrouter/image-generation-provider.test.ts docs/providers/openrouter.md docs/tools/image-generation.md src/image-generation/types.ts src/image-generation/runtime-types.ts src/image-generation/runtime.ts src/agents/tools/image-generate-tool.ts`
- `git diff --check`
- `corepack pnpm docs:list`
- `.agents/skills/autoreview/scripts/autoreview --mode local --codex-bin /tmp/codex-fast-wrapper` -> clean, no accepted/actionable findings after per-model caps, docs alignment, runtime `resolutionInferred` plumbing, and legacy chat-image reference guard.
