### PR TITLE
fix: recognize Claude CLI apiKeyHelper auth

### DIFF
--- a/extensions/anthropic/cli-constants.ts
+++ b/extensions/anthropic/cli-constants.ts
@@ -4,6 +4,8 @@
  */
 /** Synthetic provider/backend id for Claude Code CLI-backed Anthropic models. */
 export const CLAUDE_CLI_BACKEND_ID = "claude-cli";
+/** Non-secret marker proving Claude CLI will resolve auth through settings apiKeyHelper at spawn time. */
+export const CLAUDE_CLI_API_KEY_HELPER_AUTH_MARKER = "claude-cli-api-key-helper";
 /** Default Claude CLI model ref for agent defaults and live tests. */
 export const CLAUDE_CLI_DEFAULT_MODEL_REF = `${CLAUDE_CLI_BACKEND_ID}/claude-opus-4-8`;
 /** Default Claude CLI models allowed when setup seeds the model allowlist. */

--- a/extensions/anthropic/cli-migration.test.ts
+++ b/extensions/anthropic/cli-migration.test.ts
@@ -442,6 +442,21 @@ describe("anthropic cli migration", () => {
     ]);
   });
 
+  it("does not persist a claude-cli auth profile for settings apiKeyHelper auth", () => {
+    const result = buildAnthropicCliMigrationResult(
+      {},
+      {
+        type: "api-key-helper",
+        provider: "anthropic",
+      },
+    );
+
+    expect(result.profiles).toEqual([]);
+    expect(result.configPatch.agents?.defaults?.models?.["anthropic/claude-opus-4-8"]).toEqual({
+      agentRuntime: { id: "claude-cli" },
+    });
+  });
+
   it("registered non-interactive cli auth keeps anthropic fallbacks and selects claude-cli runtime", async () => {
     readClaudeCliCredentialsForSetupNonInteractive.mockReturnValue({
       type: "oauth",

--- a/extensions/anthropic/cli-migration.ts
+++ b/extensions/anthropic/cli-migration.ts
@@ -175,6 +175,9 @@ function buildClaudeCliAuthProfiles(
   if (!credential) {
     return [];
   }
+  if (credential.type === "api-key-helper") {
+    return [];
+  }
   if (credential.type === "oauth") {
     return [
       {

--- a/extensions/anthropic/cli-shared.ts
+++ b/extensions/anthropic/cli-shared.ts
@@ -10,6 +10,7 @@ import type {
 import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { CLAUDE_CLI_BACKEND_ID } from "./cli-constants.js";
 export {
+  CLAUDE_CLI_API_KEY_HELPER_AUTH_MARKER,
   CLAUDE_CLI_BACKEND_ID,
   CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS,
   CLAUDE_CLI_DEFAULT_MODEL_REF,

--- a/extensions/anthropic/index.test.ts
+++ b/extensions/anthropic/index.test.ts
@@ -993,6 +993,27 @@ describe("anthropic provider replay hooks", () => {
     });
   });
 
+  it("resolves claude-cli synthetic auth when Claude settings use apiKeyHelper", async () => {
+    readClaudeCliCredentialsForRuntimeMock.mockReset();
+    readClaudeCliCredentialsForRuntimeMock.mockReturnValue({
+      type: "api-key-helper",
+      provider: "anthropic",
+    });
+
+    const provider = await registerSingleProviderPlugin(anthropicPlugin);
+
+    expect(
+      provider.resolveSyntheticAuth?.({
+        provider: "claude-cli",
+      } as never),
+    ).toEqual({
+      apiKey: "claude-cli-api-key-helper",
+      source: "Claude CLI apiKeyHelper auth",
+      mode: "api-key",
+    });
+    expect(readClaudeCliCredentialsForRuntimeMock).toHaveBeenCalledTimes(1);
+  });
+
   it("stores a claude-cli auth profile during anthropic cli migration", async () => {
     readClaudeCliCredentialsForSetupMock.mockReset();
     readClaudeCliCredentialsForSetupMock.mockReturnValue({

--- a/extensions/anthropic/openclaw.plugin.json
+++ b/extensions/anthropic/openclaw.plugin.json
@@ -191,6 +191,7 @@
       }
     }
   },
+  "nonSecretAuthMarkers": ["claude-cli-api-key-helper"],
   "cliBackends": ["claude-cli"],
   "syntheticAuthRefs": ["claude-cli"],
   "setup": {

--- a/extensions/anthropic/provider-discovery.ts
+++ b/extensions/anthropic/provider-discovery.ts
@@ -4,13 +4,19 @@
  */
 import type { ProviderPlugin } from "openclaw/plugin-sdk/provider-model-shared";
 import { readClaudeCliCredentialsForRuntime } from "./cli-auth-seam.js";
-
-const CLAUDE_CLI_BACKEND_ID = "claude-cli";
+import { CLAUDE_CLI_API_KEY_HELPER_AUTH_MARKER, CLAUDE_CLI_BACKEND_ID } from "./cli-constants.js";
 
 function resolveClaudeCliSyntheticAuth() {
   const credential = readClaudeCliCredentialsForRuntime();
   if (!credential) {
     return undefined;
+  }
+  if (credential.type === "api-key-helper") {
+    return {
+      apiKey: CLAUDE_CLI_API_KEY_HELPER_AUTH_MARKER,
+      source: "Claude CLI apiKeyHelper auth",
+      mode: "api-key" as const,
+    };
   }
   return credential.type === "oauth"
     ? {

--- a/extensions/anthropic/register.runtime.ts
+++ b/extensions/anthropic/register.runtime.ts
@@ -44,6 +44,7 @@ import { buildAnthropicCliBackend } from "./cli-backend.js";
 import { buildClaudeCliCatalogEntries } from "./cli-catalog.js";
 import { buildAnthropicCliMigrationResult } from "./cli-migration.js";
 import {
+  CLAUDE_CLI_API_KEY_HELPER_AUTH_MARKER,
   CLAUDE_CLI_BACKEND_ID,
   CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS,
   CLAUDE_CLI_DEFAULT_MODEL_REF,
@@ -638,6 +639,13 @@ function resolveClaudeCliSyntheticAuth() {
   const credential = claudeCliAuth.readClaudeCliCredentialsForRuntime();
   if (!credential) {
     return undefined;
+  }
+  if (credential.type === "api-key-helper") {
+    return {
+      apiKey: CLAUDE_CLI_API_KEY_HELPER_AUTH_MARKER,
+      source: "Claude CLI apiKeyHelper auth",
+      mode: "api-key" as const,
+    };
   }
   return credential.type === "oauth"
     ? {

--- a/src/agents/cli-credentials.test.ts
+++ b/src/agents/cli-credentials.test.ts
@@ -187,6 +187,29 @@ describe("cli credentials", () => {
     expect(execSyncMock).toHaveBeenCalledTimes(1);
   });
 
+  it("treats Claude settings apiKeyHelper as runtime-managed auth without executing it", () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-claude-helper-"));
+    fs.mkdirSync(path.join(tempDir, ".claude"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tempDir, ".claude", "settings.json"),
+      JSON.stringify({ apiKeyHelper: "printf should-not-run" }),
+    );
+
+    const credential = readClaudeCliCredentialsCached({
+      allowKeychainPrompt: false,
+      ttlMs: CLI_CREDENTIALS_CACHE_TTL_MS,
+      platform: "linux",
+      homeDir: tempDir,
+      execSync: execSyncMock,
+    });
+
+    expectFields(credential, {
+      type: "api-key-helper",
+      provider: "anthropic",
+    });
+    expect(execSyncMock).not.toHaveBeenCalled();
+  });
+
   it("reads Codex credentials from keychain when available", () => {
     const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-codex-"));
     process.env.CODEX_HOME = tempHome;

--- a/src/agents/cli-credentials.ts
+++ b/src/agents/cli-credentials.ts
@@ -19,6 +19,7 @@ import type { OAuthProvider } from "./auth-profiles/types.js";
 const log = createSubsystemLogger("agents/auth-profiles");
 
 const CLAUDE_CLI_CREDENTIALS_RELATIVE_PATH = ".claude/.credentials.json";
+const CLAUDE_CLI_SETTINGS_RELATIVE_PATH = ".claude/settings.json";
 const CODEX_CLI_AUTH_FILENAME = "auth.json";
 const MINIMAX_CLI_CREDENTIALS_RELATIVE_PATH = ".minimax/oauth_creds.json";
 const GEMINI_CLI_CREDENTIALS_RELATIVE_PATH = ".gemini/oauth_creds.json";
@@ -59,6 +60,10 @@ export type ClaudeCliCredential =
       provider: "anthropic";
       token: string;
       expires: number;
+    }
+  | {
+      type: "api-key-helper";
+      provider: "anthropic";
     };
 
 /** Credential shape parsed from Codex CLI storage. */
@@ -99,6 +104,11 @@ function resolveClaudeCliCredentialsPath(homeDir?: string) {
   return path.join(baseDir, CLAUDE_CLI_CREDENTIALS_RELATIVE_PATH);
 }
 
+function resolveClaudeCliSettingsPath(homeDir?: string) {
+  const baseDir = homeDir ?? resolveUserPath("~");
+  return path.join(baseDir, CLAUDE_CLI_SETTINGS_RELATIVE_PATH);
+}
+
 function parseClaudeCliOauthCredential(claudeOauth: unknown): ClaudeCliCredential | null {
   if (!claudeOauth || typeof claudeOauth !== "object") {
     return null;
@@ -127,6 +137,21 @@ function parseClaudeCliOauthCredential(claudeOauth: unknown): ClaudeCliCredentia
     provider: "anthropic",
     token: accessToken,
     expires: expiresAt,
+  };
+}
+
+function readClaudeCliApiKeyHelperCredential(homeDir?: string): ClaudeCliCredential | null {
+  const raw = loadJsonFile(resolveClaudeCliSettingsPath(homeDir));
+  if (!raw || typeof raw !== "object") {
+    return null;
+  }
+  const apiKeyHelper = (raw as Record<string, unknown>).apiKeyHelper;
+  if (typeof apiKeyHelper !== "string" || !apiKeyHelper.trim()) {
+    return null;
+  }
+  return {
+    type: "api-key-helper",
+    provider: "anthropic",
   };
 }
 
@@ -432,7 +457,7 @@ function readClaudeCliKeychainCredentials(
   }
 }
 
-/** Reads Claude CLI credentials from macOS Keychain or the CLI credential file. */
+/** Reads Claude CLI credentials from macOS Keychain, the CLI credential file, or settings-managed auth. */
 export function readClaudeCliCredentials(options?: {
   allowKeychainPrompt?: boolean;
   platform?: NodeJS.Platform;
@@ -452,12 +477,15 @@ export function readClaudeCliCredentials(options?: {
 
   const credPath = resolveClaudeCliCredentialsPath(options?.homeDir);
   const raw = loadJsonFile(credPath);
-  if (!raw || typeof raw !== "object") {
-    return null;
+  if (raw && typeof raw === "object") {
+    const data = raw as Record<string, unknown>;
+    const credential = parseClaudeCliOauthCredential(data.claudeAiOauth);
+    if (credential) {
+      return credential;
+    }
   }
 
-  const data = raw as Record<string, unknown>;
-  return parseClaudeCliOauthCredential(data.claudeAiOauth);
+  return readClaudeCliApiKeyHelperCredential(options?.homeDir);
 }
 
 /** @deprecated Anthropic provider-owned CLI credential helper; do not use from third-party plugins. */
@@ -471,12 +499,13 @@ export function readClaudeCliCredentialsCached(options?: {
   const platform = options?.platform ?? process.platform;
   const ttlMs = options?.ttlMs ?? 0;
   const credentialsPath = resolveClaudeCliCredentialsPath(options?.homeDir);
+  const settingsPath = resolveClaudeCliSettingsPath(options?.homeDir);
   const keychainIntent =
     platform === "darwin" && options?.allowKeychainPrompt !== false ? "keychain" : "file";
   return readCachedCliCredential({
     ttlMs,
     cache: claudeCliCache,
-    cacheKey: `${credentialsPath}:${keychainIntent}`,
+    cacheKey: `${credentialsPath}:${settingsPath}:${keychainIntent}`,
     read: () =>
       readClaudeCliCredentials({
         allowKeychainPrompt: options?.allowKeychainPrompt,
@@ -487,6 +516,8 @@ export function readClaudeCliCredentialsCached(options?: {
     setCache: (next) => {
       claudeCliCache = next;
     },
+    readSourceFingerprint: () =>
+      `${readFileMtimeMs(credentialsPath) ?? "missing"}:${readFileMtimeMs(settingsPath) ?? "missing"}`,
   });
 }
 

--- a/src/commands/doctor-claude-cli.test.ts
+++ b/src/commands/doctor-claude-cli.test.ts
@@ -236,6 +236,45 @@ describe("noteClaudeCliHealth", () => {
     });
   });
 
+  it("accepts settings apiKeyHelper auth without requiring a stored claude-cli profile", async () => {
+    await withTempHome(({ homeDir, workspaceDir }) => {
+      const noteFn = vi.fn();
+      noteClaudeCliHealth(
+        {
+          agents: {
+            defaults: {
+              model: { primary: "claude-cli/claude-sonnet-4-6" },
+            },
+          },
+        },
+        {
+          homeDir,
+          workspaceDir,
+          noteFn,
+          store: createStore(),
+          readClaudeCliCredentials: () => ({
+            type: "api-key-helper",
+            provider: "anthropic",
+          }),
+          resolveCommandPath: () => "/opt/homebrew/bin/claude",
+        },
+      );
+
+      const body = noteBody(noteFn);
+      expect(body).toContain("Headless Claude auth: OK (apiKeyHelper).");
+      expect(body).toContain(
+        "OpenClaw auth profile: not required; Claude settings manage apiKeyHelper auth.",
+      );
+      expect(body).not.toContain(`OpenClaw auth profile: missing (${CLAUDE_CLI_PROFILE_ID})`);
+      expect(body).not.toContain(
+        `OpenClaw auth profile: ${CLAUDE_CLI_PROFILE_ID} (provider claude-cli).`,
+      );
+      expect(body).not.toContain(
+        "openclaw models auth login --provider anthropic --method cli --set-default",
+      );
+    });
+  });
+
   it("warns when Claude auth is not readable headlessly", async () => {
     await withTempHome(({ homeDir, workspaceDir }) => {
       const noteFn = vi.fn();

--- a/src/commands/doctor-claude-cli.ts
+++ b/src/commands/doctor-claude-cli.ts
@@ -31,7 +31,8 @@ const CLAUDE_CLI_PROVIDER = "claude-cli";
 
 type ClaudeCliReadableCredential =
   | Pick<OAuthCredential, "type" | "expires">
-  | Pick<TokenCredential, "type" | "expires">;
+  | Pick<TokenCredential, "type" | "expires">
+  | { type: "api-key-helper"; provider: "anthropic" };
 
 type ClaudeCliDirHealth = "present" | "missing" | "not_directory" | "unreadable" | "readonly";
 
@@ -86,6 +87,9 @@ function probeDirectoryHealth(dirPath: string): ClaudeCliDirHealth {
 function formatCredentialLabel(credential: ClaudeCliReadableCredential): string {
   if (credential.type === "oauth" || credential.type === "token") {
     return credential.type;
+  }
+  if (credential.type === "api-key-helper") {
+    return "apiKeyHelper";
   }
   return "unknown";
 }
@@ -262,14 +266,16 @@ export function noteClaudeCliHealth(
     );
   }
 
-  if (!storedProfile) {
+  if (!storedProfile && credential?.type === "api-key-helper") {
+    lines.push("- OpenClaw auth profile: not required; Claude settings manage apiKeyHelper auth.");
+  } else if (!storedProfile) {
     lines.push(`- OpenClaw auth profile: missing (${CLAUDE_CLI_PROFILE_ID}) in ${authStorePath}.`);
     fixHints.push(
       `- Fix: run ${formatCliCommand(
         "openclaw models auth login --provider anthropic --method cli --set-default",
       )}.`,
     );
-  } else if (storedProfile.provider !== CLAUDE_CLI_PROVIDER) {
+  } else if (storedProfile && storedProfile.provider !== CLAUDE_CLI_PROVIDER) {
     lines.push(
       `- OpenClaw auth profile: ${CLAUDE_CLI_PROFILE_ID} is wired to provider "${storedProfile.provider}" instead of "${CLAUDE_CLI_PROVIDER}".`,
     );


### PR DESCRIPTION
Closes #97489

## What Problem This Solves

Fixes an issue where users who rely on Claude CLI `apiKeyHelper` auth in `.claude/settings.json` would hit `missing-provider-auth` before the Claude CLI session could start.

## Why This Change Was Made

OpenClaw now treats Claude settings `apiKeyHelper` as a supported headless Claude CLI credential source without executing the helper. The Anthropic plugin maps that settings-managed auth to a non-secret synthetic marker, avoids persisting fake token profiles during CLI migration, and reports the setup accurately in doctor output.

## User Impact

Users can run Claude CLI-backed Anthropic models with `apiKeyHelper` configured in Claude settings even when `.claude/.credentials.json` is absent. Doctor no longer asks those users to create an unnecessary OpenClaw auth profile for the settings-managed helper path.

## Evidence

- Added regression coverage for reading `.claude/settings.json` `apiKeyHelper` without executing it.
- Added Anthropic synthetic auth coverage for the non-secret apiKeyHelper marker.
- Added migration coverage to ensure apiKeyHelper does not create a fake persisted token profile.
- Added doctor coverage for settings-managed apiKeyHelper auth without a stored profile.
- `node scripts/run-vitest.mjs src/commands/doctor-claude-cli.test.ts extensions/anthropic/cli-migration.test.ts src/agents/cli-credentials.test.ts extensions/anthropic/index.test.ts src/agents/model-auth.profiles.test.ts src/plugins/bundled-plugin-metadata.test.ts src/plugins/manifest-registry.test.ts src/plugins/contracts/shape.contract.test.ts`
- `pnpm build`
- `.agents/skills/autoreview/scripts/autoreview --mode local` clean after fixing its doctor-output finding.
- `git diff --check`
- Direct touched-file oxlint:
  - `pnpm exec oxlint --tsconfig config/tsconfig/oxlint.core.json src/agents/cli-credentials.test.ts src/agents/cli-credentials.ts src/commands/doctor-claude-cli.test.ts src/commands/doctor-claude-cli.ts`
  - `pnpm exec oxlint --tsconfig config/tsconfig/oxlint.extensions.json extensions/anthropic/cli-constants.ts extensions/anthropic/cli-migration.test.ts extensions/anthropic/cli-migration.ts extensions/anthropic/cli-shared.ts extensions/anthropic/index.test.ts extensions/anthropic/provider-discovery.ts extensions/anthropic/register.runtime.ts`

Known broad-gate gaps from this checkout:

- `pnpm test` failed 19 unrelated shards across gateway/provider/proxy/env/pid/plugin-status surfaces.
- `pnpm check` failed before linting this patch because Slack boundary dts currently imports missing `createPluginRuntimeMock` from `openclaw/plugin-sdk/plugin-test-runtime` in `extensions/slack/src/monitor/message-handler/prepare.test-helpers.ts`.
- `pnpm check:changed -- <touched files>` could not delegate to Blacksmith Testbox because the local crabbox binary failed basic sanity checks.
