### PR TITLE
fix: clarify exec tool failure warnings

### DIFF
--- a/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
@@ -787,6 +787,131 @@ describe("buildEmbeddedRunPayloads", () => {
     expect(payloads[0]?.text).not.toContain("`run python3");
   });
 
+  it("prefers raw exec metadata when tool progress detail includes it", () => {
+    const payloads = buildPayloads({
+      lastToolError: {
+        toolName: "exec",
+        meta: "run python3 /tmp/audit.py · `python3 /tmp/audit.py`",
+        error: "Command exited with code 1",
+        mutatingAction: true,
+      },
+      toolResultFormat: "markdown",
+    });
+
+    expectSinglePayloadSummary(payloads, {
+      text: "⚠️ 🛠️ Exec failed: `python3 /tmp/audit.py` (exit 1)",
+      isError: true,
+    });
+  });
+
+  it("strips literal synthetic run prefixes without stripping semantic run summaries", () => {
+    const genericPayloads = buildPayloads({
+      lastToolError: {
+        toolName: "exec",
+        meta: "run make build",
+        error: "Command failed with exit code 2",
+        mutatingAction: true,
+      },
+      toolResultFormat: "markdown",
+    });
+    const semanticPayloads = buildPayloads({
+      lastToolError: {
+        toolName: "exec",
+        meta: "run tests",
+        error: "Command failed with exit code 1",
+        mutatingAction: true,
+      },
+      toolResultFormat: "markdown",
+    });
+    const scriptPayloads = buildPayloads({
+      lastToolError: {
+        toolName: "exec",
+        meta: "run deploy",
+        error: "Command failed with exit code 1",
+        mutatingAction: true,
+      },
+      toolResultFormat: "markdown",
+    });
+    const compoundPayloads = buildPayloads({
+      lastToolError: {
+        toolName: "exec",
+        meta: "run tests → install dependencies",
+        error: "Command failed with exit code 1",
+        mutatingAction: true,
+      },
+      toolResultFormat: "markdown",
+    });
+    const inlineScriptPayloads = buildPayloads({
+      lastToolError: {
+        toolName: "exec",
+        meta: "run node inline script",
+        error: "Command failed with exit code 1",
+        mutatingAction: true,
+      },
+      toolResultFormat: "markdown",
+    });
+    const heredocPayloads = buildPayloads({
+      lastToolError: {
+        toolName: "exec",
+        meta: "run python3 inline script (heredoc)",
+        error: "Command failed with exit code 1",
+        mutatingAction: true,
+      },
+      toolResultFormat: "markdown",
+    });
+    const sedSummaryPayloads = buildPayloads({
+      lastToolError: {
+        toolName: "exec",
+        meta: "run sed on file",
+        error: "Command failed with exit code 1",
+        mutatingAction: true,
+      },
+      toolResultFormat: "markdown",
+    });
+    const pipelineSummaryPayloads = buildPayloads({
+      lastToolError: {
+        toolName: "exec",
+        meta: "run tests -> show first 3 lines",
+        error: "Command failed with exit code 1",
+        mutatingAction: true,
+      },
+      toolResultFormat: "markdown",
+    });
+
+    expectSinglePayloadSummary(genericPayloads, {
+      text: "⚠️ 🛠️ Exec failed: `make build` (exit 2)",
+      isError: true,
+    });
+    expectSinglePayloadSummary(semanticPayloads, {
+      text: "⚠️ 🛠️ Exec failed: `run tests` (exit 1)",
+      isError: true,
+    });
+    expectSinglePayloadSummary(scriptPayloads, {
+      text: "⚠️ 🛠️ Exec failed: `run deploy` (exit 1)",
+      isError: true,
+    });
+    expectSinglePayloadSummary(compoundPayloads, {
+      text: "⚠️ 🛠️ Exec failed: `run tests → install dependencies` (exit 1)",
+      isError: true,
+    });
+    expectSinglePayloadSummary(inlineScriptPayloads, {
+      text: "⚠️ 🛠️ Exec failed: `run node inline script` (exit 1)",
+      isError: true,
+    });
+    expectSinglePayloadSummary(heredocPayloads, {
+      text: "⚠️ 🛠️ Exec failed: `run python3 inline script (heredoc)` (exit 1)",
+      isError: true,
+    });
+    expectSinglePayloadSummary(sedSummaryPayloads, {
+      text: "⚠️ 🛠️ Exec failed: `run sed on file` (exit 1)",
+      isError: true,
+    });
+    expectSinglePayloadSummary(pipelineSummaryPayloads, {
+      text: "⚠️ 🛠️ Exec failed: `run tests -> show first 3 lines` (exit 1)",
+      isError: true,
+    });
+  });
+
   it("keeps arbitrary exec cwd suffixes inside markdown command text", () => {
     const payloads = buildPayloads({
       lastToolError: {

--- a/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
@@ -821,6 +821,49 @@ describe("buildEmbeddedRunPayloads", () => {
     });
   });
 
+  it("preserves raw exec cwd context before trailing raw command metadata", () => {
+    const cwdPayloads = buildPayloads({
+      lastToolError: {
+        toolName: "exec",
+        meta: "run python3 audit.py (in /tmp/build) · `python3 audit.py`",
+        error: "Command exited with code 1",
+        mutatingAction: true,
+      },
+      toolResultFormat: "markdown",
+    });
+    const workspaceNodePayloads = buildPayloads({
+      lastToolError: {
+        toolName: "exec",
+        meta: "run python3 audit.py (workspace), node: mac-1, `python3 audit.py`",
+        error: "Command exited with code 1",
+        mutatingAction: true,
+      },
+      toolResultFormat: "markdown",
+    });
+    const semanticCompactPayloads = buildPayloads({
+      lastToolError: {
+        toolName: "exec",
+        meta: "check git status (repo), `git status`",
+        error: "Command exited with code 1",
+        mutatingAction: true,
+      },
+      toolResultFormat: "markdown",
+    });
+
+    expectSinglePayloadSummary(cwdPayloads, {
+      text: "⚠️ 🛠️ Exec failed: `python3 audit.py (in /tmp/build)` (exit 1)",
+      isError: true,
+    });
+    expectSinglePayloadSummary(workspaceNodePayloads, {
+      text: "⚠️ 🛠️ Exec failed: `node: mac-1 · python3 audit.py (workspace)` (exit 1)",
+      isError: true,
+    });
+    expectSinglePayloadSummary(semanticCompactPayloads, {
+      text: "⚠️ 🛠️ Exec failed: `git status (repo)` (exit 1)",
+      isError: true,
+    });
+  });
+
   it("does not promote display-summary commas into raw exec context", () => {
     const payloads = buildPayloads({
       lastToolError: {
@@ -834,6 +877,40 @@ describe("buildEmbeddedRunPayloads", () => {
 
     expectSinglePayloadSummary(payloads, {
       text: '⚠️ 🛠️ Exec failed: `rg "foo,bar" src` (exit 1)',
+      isError: true,
+    });
+  });
+
+  it("does not treat parenthesized raw command arguments as cwd context", () => {
+    const payloads = buildPayloads({
+      lastToolError: {
+        toolName: "exec",
+        meta: 'list files in (in progress) · `ls "(in progress)"`',
+        error: "Command exited with code 1",
+        mutatingAction: true,
+      },
+      toolResultFormat: "markdown",
+    });
+
+    expectSinglePayloadSummary(payloads, {
+      text: '⚠️ 🛠️ Exec failed: `ls "(in progress)"` (exit 1)',
+      isError: true,
+    });
+  });
+
+  it("does not duplicate compact cwd labels already present in raw command arguments", () => {
+    const payloads = buildPayloads({
+      lastToolError: {
+        toolName: "exec",
+        meta: 'print text (repo) · `printf "%s" "(repo)"`',
+        error: "Command exited with code 1",
+        mutatingAction: true,
+      },
+      toolResultFormat: "markdown",
+    });
+
+    expectSinglePayloadSummary(payloads, {
+      text: '⚠️ 🛠️ Exec failed: `printf "%s" "(repo)"` (exit 1)',
       isError: true,
     });
   });

--- a/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
@@ -804,6 +804,23 @@ describe("buildEmbeddedRunPayloads", () => {
     });
   });
 
+  it("prefers raw exec metadata when the literal command contains backticks", () => {
+    const payloads = buildPayloads({
+      lastToolError: {
+        toolName: "exec",
+        meta: "run node inline script, `node -e 'console.log(1, `x`)'`",
+        error: "Command exited with code 1",
+        mutatingAction: true,
+      },
+      toolResultFormat: "markdown",
+    });
+
+    expectSinglePayloadSummary(payloads, {
+      text: "⚠️ 🛠️ Exec failed: ``node -e 'console.log(1, `x`)'`` (exit 1)",
+      isError: true,
+    });
+  });
+
   it("preserves raw exec context before trailing raw command metadata", () => {
     const payloads = buildPayloads({
       lastToolError: {

--- a/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
@@ -804,6 +804,40 @@ describe("buildEmbeddedRunPayloads", () => {
     });
   });
 
+  it("preserves raw exec context before trailing raw command metadata", () => {
+    const payloads = buildPayloads({
+      lastToolError: {
+        toolName: "exec",
+        meta: "run python3 /tmp/audit.py, node: mac-1, `python3 /tmp/audit.py`",
+        error: "Command exited with code 1",
+        mutatingAction: true,
+      },
+      toolResultFormat: "markdown",
+    });
+
+    expectSinglePayloadSummary(payloads, {
+      text: "⚠️ 🛠️ Exec failed: `node: mac-1 · python3 /tmp/audit.py` (exit 1)",
+      isError: true,
+    });
+  });
+
+  it("does not promote display-summary commas into raw exec context", () => {
+    const payloads = buildPayloads({
+      lastToolError: {
+        toolName: "exec",
+        meta: 'search "foo,bar" in src, `rg "foo,bar" src`',
+        error: "Command exited with code 1",
+        mutatingAction: true,
+      },
+      toolResultFormat: "markdown",
+    });
+
+    expectSinglePayloadSummary(payloads, {
+      text: '⚠️ 🛠️ Exec failed: `rg "foo,bar" src` (exit 1)',
+      isError: true,
+    });
+  });
+
   it("strips literal synthetic run prefixes without stripping semantic run summaries", () => {
     const genericPayloads = buildPayloads({
       lastToolError: {

--- a/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
@@ -769,6 +769,41 @@ describe("buildEmbeddedRunPayloads", () => {
     expectSinglePayloadSummary(payloads, { text: warningText ?? "" });
   });
 
+  it("keeps exec failure labels outside markdown command text", () => {
+    const payloads = buildPayloads({
+      lastToolError: {
+        toolName: "exec",
+        meta: "run python3 /path/to/daily-cost-audit.py",
+        error: "Command exited with code 1",
+        mutatingAction: true,
+      },
+      toolResultFormat: "markdown",
+    });
+
+    expectSinglePayloadSummary(payloads, {
+      text: "⚠️ 🛠️ Exec failed: `python3 /path/to/daily-cost-audit.py` (exit 1)",
+      isError: true,
+    });
+    expect(payloads[0]?.text).not.toContain("`run python3");
+  });
+
+  it("keeps arbitrary exec cwd suffixes inside markdown command text", () => {
+    const payloads = buildPayloads({
+      lastToolError: {
+        toolName: "exec",
+        meta: "run python3 /tmp/audit.py (in /tmp/build @everyone)",
+        error: "Command exited with code 1",
+        mutatingAction: true,
+      },
+      toolResultFormat: "markdown",
+    });
+
+    expectSinglePayloadSummary(payloads, {
+      text: "⚠️ 🛠️ Exec failed: `python3 /tmp/audit.py (in /tmp/build @everyone)` (exit 1)",
+      isError: true,
+    });
+  });
+
   it("wraps markdown-capable mutating tool warnings so mention-looking names stay inert", () => {
     const payloads = buildPayloads({
       lastToolError: {
@@ -781,7 +816,7 @@ describe("buildEmbeddedRunPayloads", () => {
     });
 
     expectSinglePayloadSummary(payloads, {
-      text: "⚠️ 🛠️ `show matrix-progress-@room-@alice:matrix-qa.test-!room:matrix-qa.test.txt (workspace)` failed",
+      text: "⚠️ 🛠️ Bash failed: `show matrix-progress-@room-@alice:matrix-qa.test-!room:matrix-qa.test.txt` (workspace)",
       isError: true,
     });
   });

--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -245,9 +245,9 @@ const LITERAL_RUN_SUMMARY_PREFIXES = new Set([
 ]);
 
 function extractLiteralExecCommand(body: string): string | undefined {
-  const inlineCode = body.match(/(?:^|,\s*| · )`([^`]+)`$/u)?.[1];
-  if (inlineCode) {
-    return inlineCode;
+  const rawCommand = extractRawExecCommand(body);
+  if (rawCommand) {
+    return rawCommand;
   }
 
   const nodeScript = body.match(/^run node script (.+)$/u);
@@ -261,6 +261,23 @@ function extractLiteralExecCommand(body: string): string | undefined {
   }
 
   return undefined;
+}
+
+function extractRawExecCommand(body: string): string | undefined {
+  const match = body.match(/^(?:(.*)(?:,\s*| · ))?`([^`]+)`$/u);
+  const inlineCode = match?.[2];
+  if (!inlineCode) {
+    return undefined;
+  }
+  const context = extractRawExecContext(match?.[1]);
+  return context ? `${context} · ${inlineCode}` : inlineCode;
+}
+
+function extractRawExecContext(prefix: string | undefined): string {
+  const contexts = [...(prefix ?? "").matchAll(/(?:^|,\s*| · )(node:\s*[^,·]+)(?=,\s*| · |$)/gu)]
+    .map((match) => match[1]?.trim())
+    .filter((part): part is string => Boolean(part));
+  return contexts.join(" · ");
 }
 
 function isKnownLiteralRunSummary(subject: string): boolean {

--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -219,17 +219,35 @@ function splitExecLikeFailureMeta(meta: string): { flags: string[]; body: string
   return { flags, body: bodyParts.join(" · ") };
 }
 
+const SEMANTIC_RUN_SUMMARIES = new Set(["tests", "build", "lint", "script", "command"]);
+const LITERAL_RUN_SUMMARY_PREFIXES = new Set([
+  "python",
+  "python3",
+  "ruby",
+  "php",
+  "git",
+  "npm",
+  "pnpm",
+  "yarn",
+  "bun",
+  "openclaw",
+  "make",
+  "cargo",
+  "go",
+  "docker",
+  "npx",
+  "uv",
+  "poetry",
+  "pytest",
+  "vitest",
+  "jest",
+  "deno",
+]);
+
 function extractLiteralExecCommand(body: string): string | undefined {
-  const inlineCode = body.match(/(?:^|,\s*)`([^`]+)`$/u)?.[1];
+  const inlineCode = body.match(/(?:^|,\s*| · )`([^`]+)`$/u)?.[1];
   if (inlineCode) {
     return inlineCode;
-  }
-
-  const directRun = body.match(
-    /^(?:run )((?:python3?|ruby|php|git|npm|pnpm|yarn|bun|openclaw) .+)$/u,
-  );
-  if (directRun?.[1]) {
-    return directRun[1];
   }
 
   const nodeScript = body.match(/^run node script (.+)$/u);
@@ -237,7 +255,30 @@ function extractLiteralExecCommand(body: string): string | undefined {
     return `node ${nodeScript[1]}`;
   }
 
+  const runSubject = body.match(/^run (.+)$/u)?.[1];
+  if (runSubject && isKnownLiteralRunSummary(runSubject)) {
+    return runSubject;
+  }
+
   return undefined;
+}
+
+function isKnownLiteralRunSummary(subject: string): boolean {
+  if (
+    SEMANTIC_RUN_SUMMARIES.has(subject) ||
+    subject.includes("→") ||
+    subject.includes("->") ||
+    /^(?:node|python3?|ruby|php) inline script(?: \(heredoc\))?$/u.test(subject)
+  ) {
+    return false;
+  }
+  const match = subject.match(/^(\S+)\s+(.+)$/u);
+  const command = match?.[1];
+  const remainder = match?.[2];
+  if (!command || !remainder || remainder === "command") {
+    return false;
+  }
+  return LITERAL_RUN_SUMMARY_PREFIXES.has(command);
 }
 
 function splitDisplayContextSuffix(value: string): { text: string; suffix: string } {

--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -269,14 +269,54 @@ type RawExecContext = {
 };
 
 function extractRawExecCommand(body: string): string | undefined {
-  const match = body.match(/^(?:(.*)(?:,\s*| · ))?`([^`]+)`$/u);
-  const inlineCode = match?.[2];
-  if (!inlineCode) {
+  const codeSpan = extractTrailingMarkdownCodeSpan(body);
+  if (!codeSpan) {
     return undefined;
   }
-  const context = extractRawExecContext(match?.[1], inlineCode);
-  const command = context.trailing.reduce((value, suffix) => `${value} ${suffix}`, inlineCode);
+  const context = extractRawExecContext(codeSpan.prefix, codeSpan.value);
+  const command = context.trailing.reduce((value, suffix) => `${value} ${suffix}`, codeSpan.value);
   return context.leading.length > 0 ? `${context.leading.join(" · ")} · ${command}` : command;
+}
+
+function extractTrailingMarkdownCodeSpan(
+  body: string,
+): { prefix: string | undefined; value: string } | undefined {
+  const trimmed = body.trimEnd();
+  if (!trimmed.endsWith("`")) {
+    return undefined;
+  }
+  let delimiterLength = 0;
+  for (let index = trimmed.length - 1; index >= 0 && trimmed[index] === "`"; index -= 1) {
+    delimiterLength += 1;
+  }
+  const delimiter = "`".repeat(delimiterLength);
+  const valueEnd = trimmed.length - delimiterLength;
+  let searchIndex = 0;
+  while (searchIndex < valueEnd) {
+    const openIndex = trimmed.indexOf(delimiter, searchIndex);
+    if (openIndex < 0 || openIndex >= valueEnd) {
+      return undefined;
+    }
+    const prefixMatch = trimmed.slice(0, openIndex).match(/^(?:(.*)(?:,\s*| · ))?$/u);
+    if (prefixMatch) {
+      return {
+        prefix: prefixMatch[1],
+        value: unwrapMarkdownInlineCodePadding(
+          trimmed.slice(openIndex + delimiterLength, valueEnd),
+        ),
+      };
+    }
+    searchIndex = openIndex + delimiterLength;
+  }
+  return undefined;
+}
+
+function unwrapMarkdownInlineCodePadding(value: string): string {
+  if (value.length < 2 || !value.startsWith(" ") || !value.endsWith(" ")) {
+    return value;
+  }
+  const unwrapped = value.slice(1, -1);
+  return /\S/u.test(unwrapped) ? unwrapped : value;
 }
 
 function extractRawExecContext(prefix: string | undefined, inlineCode: string): RawExecContext {

--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -263,21 +263,72 @@ function extractLiteralExecCommand(body: string): string | undefined {
   return undefined;
 }
 
+type RawExecContext = {
+  leading: string[];
+  trailing: string[];
+};
+
 function extractRawExecCommand(body: string): string | undefined {
   const match = body.match(/^(?:(.*)(?:,\s*| · ))?`([^`]+)`$/u);
   const inlineCode = match?.[2];
   if (!inlineCode) {
     return undefined;
   }
-  const context = extractRawExecContext(match?.[1]);
-  return context ? `${context} · ${inlineCode}` : inlineCode;
+  const context = extractRawExecContext(match?.[1], inlineCode);
+  const command = context.trailing.reduce((value, suffix) => `${value} ${suffix}`, inlineCode);
+  return context.leading.length > 0 ? `${context.leading.join(" · ")} · ${command}` : command;
 }
 
-function extractRawExecContext(prefix: string | undefined): string {
-  const contexts = [...(prefix ?? "").matchAll(/(?:^|,\s*| · )(node:\s*[^,·]+)(?=,\s*| · |$)/gu)]
+function extractRawExecContext(prefix: string | undefined, inlineCode: string): RawExecContext {
+  const value = prefix ?? "";
+  const leading = [...value.matchAll(/(?:^|,\s*| · )(node:\s*[^,·]+)(?=,\s*| · |$)/gu)]
     .map((match) => match[1]?.trim())
     .filter((part): part is string => Boolean(part));
-  return contexts.join(" · ");
+  const trailing = [
+    ...value.matchAll(
+      /(\((?:agent|repo|sandbox|workspace)\)|\(in [^)\r\n]+\))(?=\s*(?:,\s*| · |$))/gu,
+    ),
+  ]
+    .filter((match) => shouldKeepRawExecTrailingContext(value, match, inlineCode))
+    .map((match) => match[1]?.trim())
+    .filter((part): part is string => Boolean(part));
+  return { leading, trailing };
+}
+
+function shouldKeepRawExecTrailingContext(
+  prefix: string,
+  match: RegExpMatchArray,
+  inlineCode: string,
+): boolean {
+  const suffix = match[1]?.trim();
+  if (!suffix || inlineCode.includes(suffix)) {
+    return false;
+  }
+  const segment = prefix
+    .slice(0, match.index ?? 0)
+    .trimEnd()
+    .split(/,\s*| · /u)
+    .at(-1)
+    ?.trim();
+  const segmentCommand = segment ? extractLiteralExecCommand(segment) : undefined;
+  if (segmentCommand === inlineCode || segment === inlineCode) {
+    return true;
+  }
+  if (isCompactCwdSuffix(suffix)) {
+    return true;
+  }
+  return isPathLikeCwdSuffix(suffix);
+}
+
+function isCompactCwdSuffix(suffix: string): boolean {
+  return /^\((?:agent|repo|workspace)\)$/u.test(suffix);
+}
+
+function isPathLikeCwdSuffix(suffix: string): boolean {
+  const cwd = suffix.match(/^\(in ([^)\r\n]+)\)$/u)?.[1]?.trim();
+  return Boolean(
+    cwd && (/^(?:\/|~|\.{1,2}(?:\/|$)|[A-Za-z]:[\\/]|\\\\)/u.test(cwd) || cwd.includes("/")),
+  );
 }
 
 function isKnownLiteralRunSummary(subject: string): boolean {

--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -156,6 +156,129 @@ function shouldMarkNonTerminalToolErrorWarning(lastToolError: ToolErrorSummary):
   return lastToolError.middlewareError === true;
 }
 
+function formatToolErrorWarningText(params: {
+  lastToolError: ToolErrorSummary;
+  includeDetails: boolean;
+  useMarkdown: boolean;
+}): string {
+  if (isExecLikeToolName(params.lastToolError.toolName)) {
+    const toolLabel = formatToolAggregate(params.lastToolError.toolName, undefined, {
+      markdown: params.useMarkdown,
+    });
+    const subject = formatExecLikeFailureSubject(params.lastToolError.meta, params.useMarkdown);
+    const conciseExitSuffix = params.includeDetails
+      ? ""
+      : formatConciseExecExitSuffix(params.lastToolError.error);
+    const errorSuffix =
+      params.includeDetails && params.lastToolError.error ? `: ${params.lastToolError.error}` : "";
+    return subject
+      ? `⚠️ ${toolLabel} failed: ${subject}${conciseExitSuffix}${errorSuffix}`
+      : `⚠️ ${toolLabel} failed${conciseExitSuffix}${errorSuffix}`;
+  }
+
+  const toolSummary = formatToolAggregate(
+    params.lastToolError.toolName,
+    params.lastToolError.meta ? [params.lastToolError.meta] : undefined,
+    { markdown: params.useMarkdown },
+  );
+  const errorSuffix =
+    params.includeDetails && params.lastToolError.error ? `: ${params.lastToolError.error}` : "";
+  return `⚠️ ${toolSummary} failed${errorSuffix}`;
+}
+
+function formatExecLikeFailureSubject(meta: string | undefined, markdown: boolean): string {
+  const normalized = normalizeOptionalString(meta);
+  if (!normalized) {
+    return "";
+  }
+
+  const { flags, body } = splitExecLikeFailureMeta(normalized);
+  if (!body) {
+    return flags.join(" · ");
+  }
+
+  const { text, suffix } = splitDisplayContextSuffix(body);
+  const literalCommand = extractLiteralExecCommand(text);
+  const subject = `${maybeWrapInlineCode(literalCommand ?? text, markdown)}${suffix}`;
+  return flags.length > 0 ? `${flags.join(" · ")} · ${subject}` : subject;
+}
+
+function splitExecLikeFailureMeta(meta: string): { flags: string[]; body: string } {
+  const flags: string[] = [];
+  const bodyParts: string[] = [];
+  for (const part of meta
+    .split(" · ")
+    .map((candidate) => candidate.trim())
+    .filter(Boolean)) {
+    if (part === "elevated" || part === "pty") {
+      flags.push(part);
+      continue;
+    }
+    bodyParts.push(part);
+  }
+  return { flags, body: bodyParts.join(" · ") };
+}
+
+function extractLiteralExecCommand(body: string): string | undefined {
+  const inlineCode = body.match(/(?:^|,\s*)`([^`]+)`$/u)?.[1];
+  if (inlineCode) {
+    return inlineCode;
+  }
+
+  const directRun = body.match(
+    /^(?:run )((?:python3?|ruby|php|git|npm|pnpm|yarn|bun|openclaw) .+)$/u,
+  );
+  if (directRun?.[1]) {
+    return directRun[1];
+  }
+
+  const nodeScript = body.match(/^run node script (.+)$/u);
+  if (nodeScript?.[1]) {
+    return `node ${nodeScript[1]}`;
+  }
+
+  return undefined;
+}
+
+function splitDisplayContextSuffix(value: string): { text: string; suffix: string } {
+  const match = /^(.*?)( \((?:agent|repo|workspace|sandbox)\))$/u.exec(value);
+  if (!match) {
+    return { text: value, suffix: "" };
+  }
+  return { text: match[1] ?? value, suffix: match[2] ?? "" };
+}
+
+function formatConciseExecExitSuffix(error: string | undefined): string {
+  const normalized = normalizeOptionalString(error);
+  const code = normalized?.match(
+    /\b(?:command\s+)?(?:failed\s+with\s+exit\s+code|exited\s+with\s+code|exit(?:ed)?\s+code|exit\s+status)\s+(-?\d+)\b/iu,
+  )?.[1];
+  return code ? ` (exit ${code})` : "";
+}
+
+function maybeWrapInlineCode(value: string, markdown: boolean): string {
+  if (!markdown) {
+    return value;
+  }
+  const delimiter = "`".repeat(longestBacktickRun(value) + 1);
+  const padding = value.startsWith("`") || value.endsWith("`") || value.includes("\n") ? " " : "";
+  return `${delimiter}${padding}${value}${padding}${delimiter}`;
+}
+
+function longestBacktickRun(value: string): number {
+  let longest = 0;
+  let current = 0;
+  for (const char of value) {
+    if (char === "`") {
+      current += 1;
+      longest = Math.max(longest, current);
+      continue;
+    }
+    current = 0;
+  }
+  return longest;
+}
+
 /**
  * Chooses whether a tool failure needs a separate user-visible warning and
  * whether to include raw details. Mutating failures are stricter because a
@@ -550,16 +673,11 @@ export function buildEmbeddedRunPayloads(params: {
     // Surface mutating failures unless the assistant explicitly acknowledged the failed action.
     // Otherwise, keep the previous behavior and only surface non-recoverable failures when no reply exists.
     if (warningPolicy.showWarning) {
-      const toolSummary = formatToolAggregate(
-        params.lastToolError.toolName,
-        params.lastToolError.meta ? [params.lastToolError.meta] : undefined,
-        { markdown: useMarkdown },
-      );
-      const errorSuffix =
-        warningPolicy.includeDetails && params.lastToolError.error
-          ? `: ${params.lastToolError.error}`
-          : "";
-      const warningText = `⚠️ ${toolSummary} failed${errorSuffix}`;
+      const warningText = formatToolErrorWarningText({
+        lastToolError: params.lastToolError,
+        includeDetails: warningPolicy.includeDetails,
+        useMarkdown,
+      });
       const normalizedWarning = normalizeTextForComparison(warningText);
       const duplicateWarning = normalizedWarning
         ? replyItems.some((item) => {

--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -15,6 +15,7 @@ import {
   testing as beforeToolCallTesting,
 } from "./agent-tools.before-tool-call.js";
 import type { MessagingToolSend } from "./embedded-agent-messaging.types.js";
+import { buildEmbeddedRunPayloads } from "./embedded-agent-runner/run/payloads.js";
 import {
   handleToolExecutionEnd,
   handleToolExecutionStart,
@@ -1369,6 +1370,53 @@ describe("handleToolExecutionEnd timeout metadata", () => {
       toolName: "exec",
       timedOut: true,
     });
+  });
+
+  it("uses raw exec metadata for failed tool payload warnings", async () => {
+    const { ctx } = createTestContext();
+    ctx.params.toolProgressDetail = "raw";
+
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "exec",
+        toolCallId: "tool-exec-raw-command",
+        args: { command: "python3 /tmp/audit.py" },
+      } as never,
+    );
+
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "exec",
+        toolCallId: "tool-exec-raw-command",
+        isError: true,
+        result: {
+          error: "Command exited with code 1",
+          content: [{ type: "text", text: "Command exited with code 1" }],
+          details: { status: "failed", exitCode: 1 },
+        },
+      } as never,
+    );
+
+    expectRecordFields(ctx.state.lastToolError, "last tool error", {
+      toolName: "exec",
+      meta: "run python3 /tmp/audit.py, `python3 /tmp/audit.py`",
+    });
+
+    const payloads = buildEmbeddedRunPayloads({
+      assistantTexts: [],
+      toolMetas: ctx.state.toolMetas,
+      lastAssistant: undefined,
+      lastToolError: ctx.state.lastToolError,
+      sessionKey: "agent:unit-session",
+      toolResultFormat: "markdown",
+      inlineToolResultsAllowed: false,
+    });
+
+    expect(payloads[0]?.text).toBe("⚠️ 🛠️ Exec failed: `python3 /tmp/audit.py` (exit 1)");
   });
 
   it("records structured error codes for failed tool results", async () => {

--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -28,6 +28,7 @@ import type {
 
 type ToolExecutionStartEvent = Extract<AgentEvent, { type: "tool_execution_start" }>;
 type ToolExecutionEndEvent = Extract<AgentEvent, { type: "tool_execution_end" }>;
+type PayloadToolMetas = Parameters<typeof buildEmbeddedRunPayloads>[0]["toolMetas"];
 
 function createTestContext(): {
   ctx: ToolHandlerContext;
@@ -116,6 +117,19 @@ function requireEvent(
     throw new Error(`expected ${label} event`);
   }
   return event;
+}
+
+function requirePayloadToolMetas(
+  toolMetas: ToolHandlerContext["state"]["toolMetas"],
+): PayloadToolMetas {
+  return toolMetas.map((toolMeta) => {
+    if (!toolMeta.toolName) {
+      throw new Error("expected tool metadata to include toolName");
+    }
+    return toolMeta.meta === undefined
+      ? { toolName: toolMeta.toolName }
+      : { toolName: toolMeta.toolName, meta: toolMeta.meta };
+  });
 }
 
 function requireString(value: unknown, label: string): string {
@@ -1408,7 +1422,7 @@ describe("handleToolExecutionEnd timeout metadata", () => {
 
     const payloads = buildEmbeddedRunPayloads({
       assistantTexts: [],
-      toolMetas: ctx.state.toolMetas,
+      toolMetas: requirePayloadToolMetas(ctx.state.toolMetas),
       lastAssistant: undefined,
       lastToolError: ctx.state.lastToolError,
       sessionKey: "agent:unit-session",
@@ -1455,7 +1469,7 @@ describe("handleToolExecutionEnd timeout metadata", () => {
 
     const payloads = buildEmbeddedRunPayloads({
       assistantTexts: [],
-      toolMetas: ctx.state.toolMetas,
+      toolMetas: requirePayloadToolMetas(ctx.state.toolMetas),
       lastAssistant: undefined,
       lastToolError: ctx.state.lastToolError,
       sessionKey: "agent:unit-session",
@@ -1504,7 +1518,7 @@ describe("handleToolExecutionEnd timeout metadata", () => {
 
     const payloads = buildEmbeddedRunPayloads({
       assistantTexts: [],
-      toolMetas: ctx.state.toolMetas,
+      toolMetas: requirePayloadToolMetas(ctx.state.toolMetas),
       lastAssistant: undefined,
       lastToolError: ctx.state.lastToolError,
       sessionKey: "agent:unit-session",
@@ -1553,7 +1567,7 @@ describe("handleToolExecutionEnd timeout metadata", () => {
 
     const payloads = buildEmbeddedRunPayloads({
       assistantTexts: [],
-      toolMetas: ctx.state.toolMetas,
+      toolMetas: requirePayloadToolMetas(ctx.state.toolMetas),
       lastAssistant: undefined,
       lastToolError: ctx.state.lastToolError,
       sessionKey: "agent:unit-session",

--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -1419,6 +1419,55 @@ describe("handleToolExecutionEnd timeout metadata", () => {
     expect(payloads[0]?.text).toBe("⚠️ 🛠️ Exec failed: `python3 /tmp/audit.py` (exit 1)");
   });
 
+  it("preserves node context in raw exec metadata payload warnings", async () => {
+    const { ctx } = createTestContext();
+    ctx.params.toolProgressDetail = "raw";
+
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "exec",
+        toolCallId: "tool-exec-node-raw-command",
+        args: { command: "python3 /tmp/audit.py", host: "node", node: "mac-1" },
+      } as never,
+    );
+
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "exec",
+        toolCallId: "tool-exec-node-raw-command",
+        isError: true,
+        result: {
+          error: "Command exited with code 1",
+          content: [{ type: "text", text: "Command exited with code 1" }],
+          details: { status: "failed", exitCode: 1 },
+        },
+      } as never,
+    );
+
+    expectRecordFields(ctx.state.lastToolError, "last tool error", {
+      toolName: "exec",
+      meta: "run python3 /tmp/audit.py, node: mac-1, `python3 /tmp/audit.py`",
+    });
+
+    const payloads = buildEmbeddedRunPayloads({
+      assistantTexts: [],
+      toolMetas: ctx.state.toolMetas,
+      lastAssistant: undefined,
+      lastToolError: ctx.state.lastToolError,
+      sessionKey: "agent:unit-session",
+      toolResultFormat: "markdown",
+      inlineToolResultsAllowed: false,
+    });
+
+    expect(payloads[0]?.text).toBe(
+      "⚠️ 🛠️ Exec failed: `node: mac-1 · python3 /tmp/audit.py` (exit 1)",
+    );
+  });
+
   it("records structured error codes for failed tool results", async () => {
     const { ctx } = createTestContext();
 

--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -1468,6 +1468,102 @@ describe("handleToolExecutionEnd timeout metadata", () => {
     );
   });
 
+  it("preserves cwd context in raw exec metadata payload warnings", async () => {
+    const { ctx } = createTestContext();
+    ctx.params.toolProgressDetail = "raw";
+
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "exec",
+        toolCallId: "tool-exec-cwd-raw-command",
+        args: { command: "python3 audit.py", workdir: "/tmp/build" },
+      } as never,
+    );
+
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "exec",
+        toolCallId: "tool-exec-cwd-raw-command",
+        isError: true,
+        result: {
+          error: "Command exited with code 1",
+          content: [{ type: "text", text: "Command exited with code 1" }],
+          details: { status: "failed", exitCode: 1 },
+        },
+      } as never,
+    );
+
+    expectRecordFields(ctx.state.lastToolError, "last tool error", {
+      toolName: "exec",
+      meta: "run python3 audit.py (in /tmp/build), `python3 audit.py`",
+    });
+
+    const payloads = buildEmbeddedRunPayloads({
+      assistantTexts: [],
+      toolMetas: ctx.state.toolMetas,
+      lastAssistant: undefined,
+      lastToolError: ctx.state.lastToolError,
+      sessionKey: "agent:unit-session",
+      toolResultFormat: "markdown",
+      inlineToolResultsAllowed: false,
+    });
+
+    expect(payloads[0]?.text).toBe(
+      "⚠️ 🛠️ Exec failed: `python3 audit.py (in /tmp/build)` (exit 1)",
+    );
+  });
+
+  it("preserves compact cwd labels in semantic raw exec metadata payload warnings", async () => {
+    const { ctx } = createTestContext();
+    ctx.params.toolProgressDetail = "raw";
+
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "exec",
+        toolCallId: "tool-exec-repo-raw-command",
+        args: { command: "git status", workdir: "/Users/agent/Projects/OpenClaw" },
+      } as never,
+    );
+
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "exec",
+        toolCallId: "tool-exec-repo-raw-command",
+        isError: true,
+        result: {
+          error: "Command exited with code 1",
+          content: [{ type: "text", text: "Command exited with code 1" }],
+          details: { status: "failed", exitCode: 1 },
+        },
+      } as never,
+    );
+
+    expectRecordFields(ctx.state.lastToolError, "last tool error", {
+      toolName: "exec",
+      meta: "check git status (repo), `git status`",
+    });
+
+    const payloads = buildEmbeddedRunPayloads({
+      assistantTexts: [],
+      toolMetas: ctx.state.toolMetas,
+      lastAssistant: undefined,
+      lastToolError: ctx.state.lastToolError,
+      sessionKey: "agent:unit-session",
+      toolResultFormat: "markdown",
+      inlineToolResultsAllowed: false,
+    });
+
+    expect(payloads[0]?.text).toBe("⚠️ 🛠️ Exec failed: `git status (repo)` (exit 1)");
+  });
+
   it("records structured error codes for failed tool results", async () => {
     const { ctx } = createTestContext();
 

--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -1433,6 +1433,54 @@ describe("handleToolExecutionEnd timeout metadata", () => {
     expect(payloads[0]?.text).toBe("⚠️ 🛠️ Exec failed: `python3 /tmp/audit.py` (exit 1)");
   });
 
+  it("uses raw exec metadata for payload warnings when commands contain backticks", async () => {
+    const { ctx } = createTestContext();
+    const command = "node -e 'console.log(1, `x`)'";
+    ctx.params.toolProgressDetail = "raw";
+
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "exec",
+        toolCallId: "tool-exec-raw-command-backticks",
+        args: { command },
+      } as never,
+    );
+
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "exec",
+        toolCallId: "tool-exec-raw-command-backticks",
+        isError: true,
+        result: {
+          error: "Command exited with code 1",
+          content: [{ type: "text", text: "Command exited with code 1" }],
+          details: { status: "failed", exitCode: 1 },
+        },
+      } as never,
+    );
+
+    expectRecordFields(ctx.state.lastToolError, "last tool error", {
+      toolName: "exec",
+      meta: "run node inline script, ``node -e 'console.log(1, `x`)'``",
+    });
+
+    const payloads = buildEmbeddedRunPayloads({
+      assistantTexts: [],
+      toolMetas: requirePayloadToolMetas(ctx.state.toolMetas),
+      lastAssistant: undefined,
+      lastToolError: ctx.state.lastToolError,
+      sessionKey: "agent:unit-session",
+      toolResultFormat: "markdown",
+      inlineToolResultsAllowed: false,
+    });
+
+    expect(payloads[0]?.text).toBe("⚠️ 🛠️ Exec failed: ``node -e 'console.log(1, `x`)'`` (exit 1)");
+  });
+
   it("preserves node context in raw exec metadata payload warnings", async () => {
     const { ctx } = createTestContext();
     ctx.params.toolProgressDetail = "raw";

--- a/src/agents/tool-display-exec.ts
+++ b/src/agents/tool-display-exec.ts
@@ -446,6 +446,26 @@ function compactRawCommand(raw: string, maxLength = 120): string {
   return `${sliceUtf16Safe(oneLine, 0, half)}…${sliceUtf16Safe(oneLine, -(maxLength - 1 - half))}`;
 }
 
+function wrapRawExecCode(value: string): string {
+  const delimiter = "`".repeat(longestBacktickRun(value) + 1);
+  const padding = value.startsWith("`") || value.endsWith("`") || value.includes("\n") ? " " : "";
+  return `${delimiter}${padding}${value}${padding}${delimiter}`;
+}
+
+function longestBacktickRun(value: string): number {
+  let longest = 0;
+  let current = 0;
+  for (const char of value) {
+    if (char === "`") {
+      current += 1;
+      longest = Math.max(longest, current);
+      continue;
+    }
+    current = 0;
+  }
+  return longest;
+}
+
 export type ToolDetailMode = "explain" | "raw";
 
 export function resolveExecDetail(
@@ -495,7 +515,7 @@ export function resolveExecDetail(
     compact !== displaySummary &&
     compact !== summary
   ) {
-    return `${displaySummary}${nodeFragment} · \`${compact}\``;
+    return `${displaySummary}${nodeFragment} · ${wrapRawExecCode(compact)}`;
   }
 
   return `${displaySummary}${nodeFragment}`;


### PR DESCRIPTION
Closes #97319

AI-assisted by Codex.

## What Problem This Solves

Fixes an issue where users debugging failed exec/bash tool calls could see the framework-generated action summary rendered like a literal command, for example a Python script failure appearing as if the agent typed `run python3 ...`.

This affected chat/tool-failure cards and cron run diagnostics that reuse the embedded-runner payload warning text.

## Why This Change Was Made

Exec-like tool failures now render the tool label and failure state separately from the command subject, using forms like `Exec failed: <command>` instead of wrapping the whole summary before appending `failed`.

When the stored exec summary has a raw trailing inline command, the warning prefers that literal command. Known literal `run <tool> <arg>` summaries render without the framework `run` label, while semantic summaries such as package scripts, inline scripts, cwd/repo labels, node context, and pipeline summaries keep the useful display context. Non-verbose exec failures also include a concise `(exit N)` suffix when the error text exposes an exit code.

The raw metadata parser preserves explicit `node: <name>` context plus cwd labels such as `(in /tmp/build)` and `(repo)`, while avoiding duplicate/false cwd suffixes when the literal raw command itself contains parenthesized text.

## User Impact

Users get clearer failure messages when debugging failed scripts or shell commands, including which node and working directory context applied to a failed exec. The change is presentation-only; it does not change tool execution, retry policy, cron behavior, or verbose error-detail rules.

## Evidence

- Pushed follow-up commits `f89d605c`, `aed96cde`, and `9d955988` after review feedback.
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/payloads.errors.test.ts src/agents/embedded-agent-subscribe.handlers.tools.test.ts src/cron/run-diagnostics.test.ts src/cron/isolated-agent.helpers.test.ts src/agents/tool-display.test.ts ui/src/ui/chat/tool-cards.test.ts`
- `node node_modules/oxfmt/bin/oxfmt --check --threads=1 src/agents/embedded-agent-runner/run/payloads.ts src/agents/embedded-agent-runner/run/payloads.errors.test.ts src/agents/embedded-agent-subscribe.handlers.tools.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local --codex-bin /tmp/codex-fast-wrapper` reported clean after the raw-detail, semantic-summary, node-context, cwd-context, compact-label, and false-positive review findings were fixed.
- Focused handler tests cover production `handleToolExecutionStart` -> `handleToolExecutionEnd` -> `buildEmbeddedRunPayloads` for raw command, node context, path cwd context, and compact repo cwd context.
- Local terminal proof using production `buildEmbeddedRunPayloads` with static command metadata:

```text
local raw: ⚠️ 🛠️ Exec failed: `python3 /tmp/audit.py` (exit 1)
node raw: ⚠️ 🛠️ Exec failed: `node: mac-1 · python3 /tmp/audit.py` (exit 1)
cwd raw: ⚠️ 🛠️ Exec failed: `python3 audit.py (in /tmp/build)` (exit 1)
repo raw: ⚠️ 🛠️ Exec failed: `git status (repo)` (exit 1)
quoted arg: ⚠️ 🛠️ Exec failed: `ls "(in progress)"` (exit 1)
```
