### PR TITLE
improve: show edit mismatch candidate lines

### DIFF
--- a/src/agents/sessions/tools/edit.test.ts
+++ b/src/agents/sessions/tools/edit.test.ts
@@ -106,6 +106,58 @@ describe("edit tool", () => {
     expect(message).toContain("hint:     backslash escaping differs");
   });
 
+  it("shows closest candidate lines for indexed multi-edit mismatches", async () => {
+    const filePath = await createTempFile("const alpha = 1;\nconst beta = 2;\nconst gamma = 3;\n");
+    const tool = createEditTool(tmpDir);
+
+    const message = await expectRejectedMessage(
+      tool.execute(
+        "call-1",
+        {
+          path: filePath,
+          edits: [
+            { oldText: "const alpha = 1;", newText: "const alpha = 10;" },
+            { oldText: "  const beta = 2;", newText: "  const beta = 20;" },
+          ],
+        },
+        undefined,
+      ),
+    );
+
+    expect(message).toContain("Could not find edits[1]");
+    expect(message).toContain("Closest candidate lines for oldText:");
+    expect(message).toContain("- line 2:");
+    expect(message).toContain('expected: "  const beta = 2;"');
+    expect(message).toContain('found:    "const beta = 2;"');
+    expect(message).toContain(
+      "hint:     indentation differs (expected 2 leading whitespace chars, found 0)",
+    );
+  });
+
+  it("does not attach candidates from the wrong edit list for mixed no-op mismatches", async () => {
+    const filePath = await createTempFile("const alpha = 1;\nconst beta = 2;\n");
+    const tool = createEditTool(tmpDir);
+
+    const message = await expectRejectedMessage(
+      tool.execute(
+        "call-1",
+        {
+          path: filePath,
+          edits: [
+            { oldText: "const alpha = 1;", newText: "const alpha = 1;" },
+            { oldText: "const beta = 2;", newText: "const beta = 20;" },
+            { oldText: "  const gamma = 3;", newText: "  const gamma = 30;" },
+          ],
+        },
+        undefined,
+      ),
+    );
+
+    expect(message).toContain("Could not find edits[2]");
+    expect(message).not.toContain("Closest candidate lines for oldText:");
+    expect(message).not.toContain('expected: "const alpha = 1;"');
+  });
+
   it("recovers success after a post-write throw when the edit already applied", async () => {
     // Some backends throw after flushing content; a readback match is the
     // contract that lets the tool report success without duplicating edits.

--- a/src/agents/sessions/tools/edit.test.ts
+++ b/src/agents/sessions/tools/edit.test.ts
@@ -30,6 +30,15 @@ describe("edit tool", () => {
     return filePath;
   }
 
+  async function expectRejectedMessage(run: Promise<unknown>): Promise<string> {
+    try {
+      await run;
+    } catch (error) {
+      return error instanceof Error ? error.message : String(error);
+    }
+    throw new Error("Expected edit call to reject");
+  }
+
   it("adds current file contents to exact-match mismatch errors", async () => {
     const filePath = await createTempFile("actual current content");
     const tool = createEditTool(tmpDir);
@@ -44,6 +53,57 @@ describe("edit tool", () => {
         undefined,
       ),
     ).rejects.toThrow(/Current file contents:\nactual current content/);
+  });
+
+  it("shows closest candidate lines when oldText misses by indentation", async () => {
+    const filePath = await createTempFile("function run() {\n  return total + 1;\n}\n");
+    const tool = createEditTool(tmpDir);
+
+    const message = await expectRejectedMessage(
+      tool.execute(
+        "call-1",
+        {
+          path: filePath,
+          edits: [{ oldText: "    return total + 1;", newText: "    return total + 2;" }],
+        },
+        undefined,
+      ),
+    );
+
+    expect(message).toContain("Closest candidate lines for oldText:");
+    expect(message).toContain("- line 2:");
+    expect(message).toContain('expected: "    return total + 1;"');
+    expect(message).toContain('found:    "  return total + 1;"');
+    expect(message).toContain(
+      "hint:     indentation differs (expected 4 leading whitespace chars, found 2)",
+    );
+    expect(message).toContain("Current file contents:");
+  });
+
+  it("renders escaped oldText differences in mismatch candidates", async () => {
+    const filePath = await createTempFile(String.raw`const regex = "\\bword";` + "\n");
+    const tool = createEditTool(tmpDir);
+
+    const message = await expectRejectedMessage(
+      tool.execute(
+        "call-1",
+        {
+          path: filePath,
+          edits: [
+            {
+              oldText: String.raw`const regex = "\bword";`,
+              newText: String.raw`const regex = "\\bother";`,
+            },
+          ],
+        },
+        undefined,
+      ),
+    );
+
+    expect(message).toContain("Closest candidate lines for oldText:");
+    expect(message).toContain(String.raw`expected: "const regex = \"\\bword\";"`);
+    expect(message).toContain(String.raw`found:    "const regex = \"\\\\bword\";"`);
+    expect(message).toContain("hint:     backslash escaping differs");
   });
 
   it("recovers success after a post-write throw when the edit already applied", async () => {

--- a/src/agents/sessions/tools/edit.test.ts
+++ b/src/agents/sessions/tools/edit.test.ts
@@ -134,6 +134,32 @@ describe("edit tool", () => {
     );
   });
 
+  it("does not scan mismatch candidates beyond the configured line limit", async () => {
+    const firstScannedLines = Array.from(
+      { length: 2000 },
+      (_value, index) => `const filler${index + 1} = ${index + 1};`,
+    );
+    const filePath = await createTempFile(
+      [...firstScannedLines, "const nearbyNeedle = 1;"].join("\n"),
+    );
+    const tool = createEditTool(tmpDir);
+
+    const message = await expectRejectedMessage(
+      tool.execute(
+        "call-1",
+        {
+          path: filePath,
+          edits: [{ oldText: "const nearbyNeedle = 2;", newText: "const nearbyNeedle = 3;" }],
+        },
+        undefined,
+      ),
+    );
+
+    expect(message).toContain("Closest candidate lines for oldText:");
+    expect(message).not.toContain("- line 2001:");
+    expect(message).not.toContain('found:    "const nearbyNeedle = 1;"');
+  });
+
   it("does not attach candidates from the wrong edit list for mixed no-op mismatches", async () => {
     const filePath = await createTempFile("const alpha = 1;\nconst beta = 2;\n");
     const tool = createEditTool(tmpDir);

--- a/src/agents/sessions/tools/edit.test.ts
+++ b/src/agents/sessions/tools/edit.test.ts
@@ -160,6 +160,29 @@ describe("edit tool", () => {
     expect(message).not.toContain('found:    "const nearbyNeedle = 1;"');
   });
 
+  it("bounds no-newline mismatch candidates before scoring", async () => {
+    const longLine = `const nearbyNeedle = ${"x".repeat(5000)};tail-marker`;
+    const cappedPrefix = longLine.slice(0, 141);
+    const filePath = await createTempFile(longLine);
+    const tool = createEditTool(tmpDir);
+
+    const message = await expectRejectedMessage(
+      tool.execute(
+        "call-1",
+        {
+          path: filePath,
+          edits: [{ oldText: `  ${cappedPrefix}`, newText: "const nearbyNeedle = 3;" }],
+        },
+        undefined,
+      ),
+    );
+
+    expect(message).toContain("Closest candidate lines for oldText:");
+    expect(message).toContain("- line 1:");
+    expect(message).toContain("hint:     indentation differs");
+    expect(message).not.toContain("tail-marker");
+  });
+
   it("does not attach candidates from the wrong edit list for mixed no-op mismatches", async () => {
     const filePath = await createTempFile("const alpha = 1;\nconst beta = 2;\n");
     const tool = createEditTool(tmpDir);

--- a/src/agents/sessions/tools/edit.test.ts
+++ b/src/agents/sessions/tools/edit.test.ts
@@ -183,6 +183,27 @@ describe("edit tool", () => {
     expect(message).not.toContain("tail-marker");
   });
 
+  it("does not scan past long unterminated lines for mismatch candidates", async () => {
+    const longUnterminatedLine = `const hugeLine = ${"x".repeat(300_000)}`;
+    const filePath = await createTempFile(`${longUnterminatedLine}\nconst nearbyNeedle = 1;`);
+    const tool = createEditTool(tmpDir);
+
+    const message = await expectRejectedMessage(
+      tool.execute(
+        "call-1",
+        {
+          path: filePath,
+          edits: [{ oldText: "const nearbyNeedle = 2;", newText: "const nearbyNeedle = 3;" }],
+        },
+        undefined,
+      ),
+    );
+
+    expect(message).toContain("Closest candidate lines for oldText:");
+    expect(message).not.toContain("- line 2:");
+    expect(message).not.toContain('found:    "const nearbyNeedle = 1;"');
+  });
+
   it("does not attach candidates from the wrong edit list for mixed no-op mismatches", async () => {
     const filePath = await createTempFile("const alpha = 1;\nconst beta = 2;\n");
     const tool = createEditTool(tmpDir);

--- a/src/agents/sessions/tools/edit.ts
+++ b/src/agents/sessions/tools/edit.ts
@@ -78,6 +78,9 @@ type LegacyEditToolInput = Record<string, unknown> & {
 
 const EDIT_MISMATCH_MESSAGE = "Could not find the exact text in";
 const EDIT_MISMATCH_HINT_LIMIT = 800;
+const EDIT_MISMATCH_CANDIDATE_LIMIT = 3;
+const EDIT_MISMATCH_SCAN_LINE_LIMIT = 2000;
+const EDIT_MISMATCH_LINE_DISPLAY_LIMIT = 140;
 
 /**
  * Pluggable operations for the edit tool.
@@ -173,16 +176,165 @@ function didEditLikelyApply(params: {
   );
 }
 
-function appendMismatchHint(error: Error, currentContent: string): Error {
+function appendMismatchHint(error: Error, currentContent: string, edits: Edit[]): Error {
   const snippet =
     currentContent.length <= EDIT_MISMATCH_HINT_LIMIT
       ? currentContent
       : `${currentContent.slice(0, EDIT_MISMATCH_HINT_LIMIT)}\n... (truncated)`;
-  const enhanced = new Error(`${error.message}\nCurrent file contents:\n${snippet}`, {
-    cause: error,
-  });
+  const candidateHint = formatMismatchCandidateHint(error, currentContent, edits);
+  const enhanced = new Error(
+    [
+      error.message,
+      ...(candidateHint ? [candidateHint] : []),
+      `Current file contents:\n${snippet}`,
+    ].join("\n"),
+    {
+      cause: error,
+    },
+  );
   enhanced.stack = error.stack;
   return enhanced;
+}
+
+function formatMismatchCandidateHint(error: Error, currentContent: string, edits: Edit[]): string {
+  const edit = edits[resolveMismatchEditIndex(error, edits.length)];
+  if (!edit?.oldText) {
+    return "";
+  }
+  const expectedLine = selectMismatchExpectedLine(edit.oldText);
+  if (!expectedLine) {
+    return "";
+  }
+
+  const candidates = findClosestMismatchLines(currentContent, expectedLine);
+  if (candidates.length === 0) {
+    return "";
+  }
+
+  return [
+    "Closest candidate lines for oldText:",
+    ...candidates.flatMap((candidate) => {
+      const expected = formatDiagnosticLine(expectedLine);
+      const found = formatDiagnosticLine(candidate.text);
+      return [
+        `- line ${candidate.lineNumber}:`,
+        `  expected: ${expected}`,
+        `  found:    ${found}`,
+        `  diff:     ${formatDifferenceMarker(expectedLine, candidate.text)}`,
+        `  hint:     ${formatMismatchHint(expectedLine, candidate.text)}`,
+      ];
+    }),
+  ].join("\n");
+}
+
+function resolveMismatchEditIndex(error: Error, editCount: number): number {
+  if (editCount <= 1) {
+    return 0;
+  }
+  const index = error.message.match(/\bedits\[(\d+)\]/u)?.[1];
+  if (!index) {
+    return 0;
+  }
+  const parsed = Number(index);
+  return Number.isInteger(parsed) && parsed >= 0 && parsed < editCount ? parsed : 0;
+}
+
+function selectMismatchExpectedLine(oldText: string): string {
+  const lines = normalizeToLF(oldText).split("\n");
+  const nonEmpty = lines.filter((line) => line.trim().length > 0);
+  const candidates = nonEmpty.length > 0 ? nonEmpty : lines;
+  return candidates.slice().sort((a, b) => b.trim().length - a.trim().length)[0] ?? "";
+}
+
+function findClosestMismatchLines(
+  currentContent: string,
+  expectedLine: string,
+): Array<{ lineNumber: number; text: string; score: number }> {
+  return normalizeToLF(currentContent)
+    .split("\n")
+    .slice(0, EDIT_MISMATCH_SCAN_LINE_LIMIT)
+    .map((line, index) => ({
+      lineNumber: index + 1,
+      text: line,
+      score: lineDistanceScore(expectedLine, line),
+    }))
+    .filter((candidate) => candidate.text.length > 0)
+    .sort((a, b) => a.score - b.score || a.lineNumber - b.lineNumber)
+    .slice(0, EDIT_MISMATCH_CANDIDATE_LIMIT);
+}
+
+function lineDistanceScore(expected: string, found: string): number {
+  if (expected === found) {
+    return 0;
+  }
+  const expectedTrimmed = expected.trim();
+  const foundTrimmed = found.trim();
+  const whitespacePenalty = expectedTrimmed === foundTrimmed ? 0 : 10;
+  return levenshteinDistance(expectedTrimmed, foundTrimmed) + whitespacePenalty;
+}
+
+function levenshteinDistance(left: string, right: string): number {
+  const a = left.slice(0, EDIT_MISMATCH_LINE_DISPLAY_LIMIT);
+  const b = right.slice(0, EDIT_MISMATCH_LINE_DISPLAY_LIMIT);
+  const previous = Array.from({ length: b.length + 1 }, (_value, index) => index);
+  const current = Array.from({ length: b.length + 1 }, () => 0);
+  for (let i = 1; i <= a.length; i++) {
+    current[0] = i;
+    for (let j = 1; j <= b.length; j++) {
+      const substitution = previous[j - 1] + (a[i - 1] === b[j - 1] ? 0 : 1);
+      current[j] = Math.min(previous[j] + 1, current[j - 1] + 1, substitution);
+    }
+    previous.splice(0, previous.length, ...current);
+  }
+  return previous[b.length] ?? 0;
+}
+
+function formatDiagnosticLine(line: string): string {
+  const truncated =
+    line.length <= EDIT_MISMATCH_LINE_DISPLAY_LIMIT
+      ? line
+      : `${line.slice(0, EDIT_MISMATCH_LINE_DISPLAY_LIMIT)}...`;
+  return JSON.stringify(truncated);
+}
+
+function formatDifferenceMarker(expected: string, found: string): string {
+  if (expected === found) {
+    return "(line matches; surrounding oldText differs)";
+  }
+  const maxLength = Math.min(
+    Math.max(expected.length, found.length),
+    EDIT_MISMATCH_LINE_DISPLAY_LIMIT,
+  );
+  if (maxLength === 0) {
+    return "(empty lines)";
+  }
+  let marker = "";
+  for (let i = 0; i < maxLength; i++) {
+    marker += expected[i] === found[i] ? " " : "^";
+  }
+  return marker.trimEnd() || "(only trailing whitespace differs)";
+}
+
+function leadingWhitespaceLength(line: string): number {
+  return line.match(/^[ \t]*/u)?.[0].length ?? 0;
+}
+
+function formatMismatchHint(expected: string, found: string): string {
+  if (expected === found) {
+    return "line matches; surrounding oldText differs";
+  }
+  if (expected.trim() === found.trim()) {
+    const expectedIndent = leadingWhitespaceLength(expected);
+    const foundIndent = leadingWhitespaceLength(found);
+    if (expectedIndent !== foundIndent) {
+      return `indentation differs (expected ${expectedIndent} leading whitespace chars, found ${foundIndent})`;
+    }
+    return "whitespace differs";
+  }
+  if (expected.replace(/\\/g, "") === found.replace(/\\/g, "")) {
+    return "backslash escaping differs";
+  }
+  return "nearest text differs";
 }
 
 type RenderableEditArgs = {
@@ -490,7 +642,7 @@ export function createEditToolDefinition(
             };
           }
           if (normalizedError.message.includes(EDIT_MISMATCH_MESSAGE)) {
-            throw appendMismatchHint(normalizedError, currentContent);
+            throw appendMismatchHint(normalizedError, currentContent, realEdits);
           }
           // Terminal no-op: the edit matched but produced identical content.
           if (normalizedError instanceof EditNoChangeError) {

--- a/src/agents/sessions/tools/edit.ts
+++ b/src/agents/sessions/tools/edit.ts
@@ -81,6 +81,7 @@ const EDIT_MISMATCH_HINT_LIMIT = 800;
 const EDIT_MISMATCH_CANDIDATE_LIMIT = 3;
 const EDIT_MISMATCH_SCAN_LINE_LIMIT = 2000;
 const EDIT_MISMATCH_LINE_DISPLAY_LIMIT = 140;
+const EDIT_INDEXED_MISMATCH_RE = /\bCould not find edits\[\d+\] in /u;
 
 /**
  * Pluggable operations for the edit tool.
@@ -194,6 +195,13 @@ function appendMismatchHint(error: Error, currentContent: string, edits: Edit[])
   );
   enhanced.stack = error.stack;
   return enhanced;
+}
+
+function isEditMismatchError(error: Error, options?: { includeIndexed?: boolean }): boolean {
+  return (
+    error.message.includes(EDIT_MISMATCH_MESSAGE) ||
+    (options?.includeIndexed === true && EDIT_INDEXED_MISMATCH_RE.test(error.message))
+  );
 }
 
 function formatMismatchCandidateHint(error: Error, currentContent: string, edits: Edit[]): string {
@@ -571,6 +579,7 @@ export function createEditToolDefinition(
 
         const buffer = await ops.readFile(absolutePath);
         const rawContent = buffer.toString("utf-8");
+        let hintIndexedMismatch = false;
         try {
           if (signal?.aborted) {
             throw new Error("Operation aborted");
@@ -592,11 +601,13 @@ export function createEditToolDefinition(
               terminate: true,
             };
           }
+          hintIndexedMismatch = true;
           const { baseContent, newContent } = applyEditsToNormalizedContent(
             normalizedContent,
             realEdits,
             path,
           );
+          hintIndexedMismatch = false;
           const finalContent = bom + restoreLineEndings(newContent, originalEnding);
           await ops.writeFile(absolutePath, finalContent);
           if (signal?.aborted) {
@@ -641,7 +652,7 @@ export function createEditToolDefinition(
               details: { diff: "", patch: "" },
             };
           }
-          if (normalizedError.message.includes(EDIT_MISMATCH_MESSAGE)) {
+          if (isEditMismatchError(normalizedError, { includeIndexed: hintIndexedMismatch })) {
             throw appendMismatchHint(normalizedError, currentContent, realEdits);
           }
           // Terminal no-op: the edit matched but produced identical content.

--- a/src/agents/sessions/tools/edit.ts
+++ b/src/agents/sessions/tools/edit.ts
@@ -258,9 +258,7 @@ function findClosestMismatchLines(
   currentContent: string,
   expectedLine: string,
 ): Array<{ lineNumber: number; text: string; score: number }> {
-  return normalizeToLF(currentContent)
-    .split("\n")
-    .slice(0, EDIT_MISMATCH_SCAN_LINE_LIMIT)
+  return collectNormalizedLines(currentContent, EDIT_MISMATCH_SCAN_LINE_LIMIT)
     .map((line, index) => ({
       lineNumber: index + 1,
       text: line,
@@ -269,6 +267,30 @@ function findClosestMismatchLines(
     .filter((candidate) => candidate.text.length > 0)
     .toSorted((a, b) => a.score - b.score || a.lineNumber - b.lineNumber)
     .slice(0, EDIT_MISMATCH_CANDIDATE_LIMIT);
+}
+
+function collectNormalizedLines(content: string, lineLimit: number): string[] {
+  const lines: string[] = [];
+  let lineStart = 0;
+
+  for (let index = 0; index < content.length && lines.length < lineLimit; index += 1) {
+    const char = content[index];
+    if (char !== "\n" && char !== "\r") {
+      continue;
+    }
+
+    lines.push(content.slice(lineStart, index));
+    if (char === "\r" && content[index + 1] === "\n") {
+      index += 1;
+    }
+    lineStart = index + 1;
+  }
+
+  if (lines.length < lineLimit) {
+    lines.push(content.slice(lineStart));
+  }
+
+  return lines;
 }
 
 function lineDistanceScore(expected: string, found: string): number {

--- a/src/agents/sessions/tools/edit.ts
+++ b/src/agents/sessions/tools/edit.ts
@@ -83,6 +83,8 @@ const EDIT_MISMATCH_SCAN_LINE_LIMIT = 2000;
 const EDIT_MISMATCH_LINE_DISPLAY_LIMIT = 140;
 // Keep one extra char so formatting can still show that the source line was truncated.
 const EDIT_MISMATCH_LINE_STORAGE_LIMIT = EDIT_MISMATCH_LINE_DISPLAY_LIMIT + 1;
+const EDIT_MISMATCH_SCAN_BYTE_LIMIT =
+  EDIT_MISMATCH_SCAN_LINE_LIMIT * EDIT_MISMATCH_LINE_STORAGE_LIMIT;
 const EDIT_INDEXED_MISMATCH_RE = /\bCould not find edits\[\d+\] in /u;
 
 /**
@@ -264,6 +266,7 @@ function findClosestMismatchLines(
     currentContent,
     EDIT_MISMATCH_SCAN_LINE_LIMIT,
     EDIT_MISMATCH_LINE_STORAGE_LIMIT,
+    EDIT_MISMATCH_SCAN_BYTE_LIMIT,
   )
     .map((line, index) => ({
       lineNumber: index + 1,
@@ -279,11 +282,13 @@ function collectNormalizedLines(
   content: string,
   lineLimit: number,
   lineLengthLimit: number,
+  scanByteLimit: number,
 ): string[] {
   const lines: string[] = [];
   let lineStart = 0;
+  const scanEnd = Math.min(content.length, scanByteLimit);
 
-  for (let index = 0; index < content.length && lines.length < lineLimit; index += 1) {
+  for (let index = 0; index < scanEnd && lines.length < lineLimit; index += 1) {
     const char = content[index];
     if (char !== "\n" && char !== "\r") {
       continue;
@@ -296,8 +301,8 @@ function collectNormalizedLines(
     lineStart = index + 1;
   }
 
-  if (lines.length < lineLimit) {
-    lines.push(content.slice(lineStart, lineStart + lineLengthLimit));
+  if (lines.length < lineLimit && lineStart <= scanEnd) {
+    lines.push(content.slice(lineStart, Math.min(scanEnd, lineStart + lineLengthLimit)));
   }
 
   return lines;

--- a/src/agents/sessions/tools/edit.ts
+++ b/src/agents/sessions/tools/edit.ts
@@ -81,6 +81,8 @@ const EDIT_MISMATCH_HINT_LIMIT = 800;
 const EDIT_MISMATCH_CANDIDATE_LIMIT = 3;
 const EDIT_MISMATCH_SCAN_LINE_LIMIT = 2000;
 const EDIT_MISMATCH_LINE_DISPLAY_LIMIT = 140;
+// Keep one extra char so formatting can still show that the source line was truncated.
+const EDIT_MISMATCH_LINE_STORAGE_LIMIT = EDIT_MISMATCH_LINE_DISPLAY_LIMIT + 1;
 const EDIT_INDEXED_MISMATCH_RE = /\bCould not find edits\[\d+\] in /u;
 
 /**
@@ -258,7 +260,11 @@ function findClosestMismatchLines(
   currentContent: string,
   expectedLine: string,
 ): Array<{ lineNumber: number; text: string; score: number }> {
-  return collectNormalizedLines(currentContent, EDIT_MISMATCH_SCAN_LINE_LIMIT)
+  return collectNormalizedLines(
+    currentContent,
+    EDIT_MISMATCH_SCAN_LINE_LIMIT,
+    EDIT_MISMATCH_LINE_STORAGE_LIMIT,
+  )
     .map((line, index) => ({
       lineNumber: index + 1,
       text: line,
@@ -269,7 +275,11 @@ function findClosestMismatchLines(
     .slice(0, EDIT_MISMATCH_CANDIDATE_LIMIT);
 }
 
-function collectNormalizedLines(content: string, lineLimit: number): string[] {
+function collectNormalizedLines(
+  content: string,
+  lineLimit: number,
+  lineLengthLimit: number,
+): string[] {
   const lines: string[] = [];
   let lineStart = 0;
 
@@ -279,7 +289,7 @@ function collectNormalizedLines(content: string, lineLimit: number): string[] {
       continue;
     }
 
-    lines.push(content.slice(lineStart, index));
+    lines.push(content.slice(lineStart, Math.min(index, lineStart + lineLengthLimit)));
     if (char === "\r" && content[index + 1] === "\n") {
       index += 1;
     }
@@ -287,7 +297,7 @@ function collectNormalizedLines(content: string, lineLimit: number): string[] {
   }
 
   if (lines.length < lineLimit) {
-    lines.push(content.slice(lineStart));
+    lines.push(content.slice(lineStart, lineStart + lineLengthLimit));
   }
 
   return lines;

--- a/src/agents/sessions/tools/edit.ts
+++ b/src/agents/sessions/tools/edit.ts
@@ -251,7 +251,7 @@ function selectMismatchExpectedLine(oldText: string): string {
   const lines = normalizeToLF(oldText).split("\n");
   const nonEmpty = lines.filter((line) => line.trim().length > 0);
   const candidates = nonEmpty.length > 0 ? nonEmpty : lines;
-  return candidates.slice().sort((a, b) => b.trim().length - a.trim().length)[0] ?? "";
+  return candidates.toSorted((a, b) => b.trim().length - a.trim().length)[0] ?? "";
 }
 
 function findClosestMismatchLines(
@@ -267,7 +267,7 @@ function findClosestMismatchLines(
       score: lineDistanceScore(expectedLine, line),
     }))
     .filter((candidate) => candidate.text.length > 0)
-    .sort((a, b) => a.score - b.score || a.lineNumber - b.lineNumber)
+    .toSorted((a, b) => a.score - b.score || a.lineNumber - b.lineNumber)
     .slice(0, EDIT_MISMATCH_CANDIDATE_LIMIT);
 }
 


### PR DESCRIPTION
Closes #97032

AI-assisted by Codex.

## What Problem This Solves

Resolves a problem where edit-tool exact-match failures only reported that `oldText` was not found and then dumped a capped file snippet. Users had no nearby line comparison to tell whether the miss was caused by indentation, escaping, whitespace, or similar text drift.

## Why This Change Was Made

The edit mismatch hint now adds up to three bounded closest candidate lines before the existing capped `Current file contents` section. Each candidate includes a line number, expected text, found text, a simple difference marker, and a short hint such as indentation mismatch or backslash escaping mismatch.

The same hint is now applied to indexed multi-edit `edits[n]` not-found failures when the index is in the real-edit apply path. Mixed no-op validation errors are guarded so they do not attach candidates from the wrong edit list.

The matching algorithm is unchanged. This is diagnostic-only output on the existing exact-match failure path.

## User Impact

Users and agents can recover from failed edits faster because the error points at likely nearby text and explains common mismatch classes instead of forcing blind retries.

## Evidence

- Pushed follow-up commit `77c059e7` after review feedback.
- `node scripts/run-vitest.mjs src/agents/sessions/tools/edit.test.ts src/agents/agent-tools.create-openclaw-coding-tools.test.ts`
- `node node_modules/oxfmt/bin/oxfmt --check --threads=1 src/agents/sessions/tools/edit.ts src/agents/sessions/tools/edit.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local --codex-bin /tmp/codex-fast-wrapper` reported clean after the indexed multi-edit and mixed no-op guard changes.
- Local terminal proof using production `createEditTool` against a temp file, with the temp path redacted:

```text
Could not find edits[1] in <tmp>/demo.txt. The oldText must match exactly including all whitespace and newlines.
Closest candidate lines for oldText:
- line 2:
  expected: "  const beta = 2;"
  found:    "const beta = 2;"
  diff:     ^^^^^^^^^^^^ ^^^^
  hint:     indentation differs (expected 2 leading whitespace chars, found 0)
```
