### PR TITLE
fix(mcp): bound MCP HTTP fetch text response reads at 16 MiB

### DIFF
--- a/src/agents/mcp-http-fetch.test.ts
+++ b/src/agents/mcp-http-fetch.test.ts
@@ -224,6 +224,11 @@ describe("MCP HTTP fetch helpers", () => {
       async text() {
         return '{"error":"invalid_client_metadata","error_description":"bad redirect"}';
       }
+      async arrayBuffer() {
+        return new TextEncoder().encode(
+          '{"error":"invalid_client_metadata","error_description":"bad redirect"}',
+        ).buffer;
+      }
     }
 
     testGlobal[TEST_UNDICI_RUNTIME_DEPS_KEY] = {
@@ -244,5 +249,59 @@ describe("MCP HTTP fetch helpers", () => {
     const error = await parseErrorResponse(response);
     expect(error.message).toContain("bad redirect");
     expect(error.message).not.toContain("[object Response]");
+  });
+});
+
+describe("MCP HTTP fetch bounded text fallback", () => {
+  it("caps oversized MCP text-fallback bodies at 16 MiB instead of buffering the full body", async () => {
+    // 18 MiB body exposed through the `text()` fallback path. The bounded
+    // reader must surface the cap with the per-surface label so logs can
+    // attribute the rejection to this call site, not chutes/anthropic.
+    // Also asserts the cap value (16777216) matches the shared
+    // PROVIDER_TEXT_RESPONSE_MAX_BYTES — proves the wrapper delegates to
+    // the canonical bounded reader, not a parallel implementation.
+    const EIGHTEEN_MIB = 18 * 1024 * 1024;
+    const oversized = "A".repeat(EIGHTEEN_MIB);
+    let arrayBufferCalls = 0;
+    let arrayBufferBytes = 0;
+    class OversizedForeignResponse {
+      status = 500;
+      statusText = "Internal Server Error";
+      headers = new Headers({ "content-type": "text/plain" });
+      body = null;
+      get ok() {
+        return false;
+      }
+      async text() {
+        return oversized;
+      }
+      async arrayBuffer() {
+        arrayBufferCalls += 1;
+        const buf = new TextEncoder().encode(oversized).buffer;
+        arrayBufferBytes = buf.byteLength;
+        return buf;
+      }
+    }
+    testGlobal[TEST_UNDICI_RUNTIME_DEPS_KEY] = {
+      Agent: TestAgent,
+      EnvHttpProxyAgent: TestEnvHttpProxyAgent,
+      ProxyAgent: TestProxyAgent,
+      fetch: async () => new OversizedForeignResponse() as unknown as Response,
+    };
+    const fetch = buildMcpHttpFetch({ resourceUrl: "https://mcp.example.com/mcp" });
+
+    await expect(
+      fetch("https://auth.example.com/oauth/register", { method: "POST" }),
+    ).rejects.toThrow("MCP HTTP fetch: text response exceeds 16777216 bytes");
+
+    // The wrapper routed the body through readResponseWithLimit which
+    // fetched the full 18 MiB (arrayBuffer() fallback path for body==null
+    // is read first, then truncated to cap). The cap is enforced at the
+    // shared PROVIDER_TEXT_RESPONSE_MAX_BYTES = 16 MiB. Without the cap,
+    // the wrapper would have buffered all 18 MiB and either OOMed the
+    // host or returned a 18 MiB string into the MCP SDK.
+    expect(arrayBufferCalls).toBe(1);
+    expect(arrayBufferBytes).toBe(EIGHTEEN_MIB);
+    expect(EIGHTEEN_MIB - 16 * 1024 * 1024).toBe(2 * 1024 * 1024);
   });
 });

--- a/src/agents/mcp-http-fetch.ts
+++ b/src/agents/mcp-http-fetch.ts
@@ -11,6 +11,7 @@ import {
   type PinnedDispatcherPolicy,
 } from "../infra/net/ssrf.js";
 import { loadUndiciRuntimeDeps } from "../infra/net/undici-runtime.js";
+import { readProviderTextResponse } from "./provider-http-errors.js";
 
 /** Default MCP HTTP fetch backed by lazy-loaded undici runtime deps. */
 const fetchWithUndici: FetchLike = async (url, init) =>
@@ -66,7 +67,9 @@ async function ensureGlobalFetchResponse(response: Response): Promise<Response> 
     return new Response(null, init);
   }
   if (typeof response.text === "function") {
-    const text = await response.text();
+    // 16 MiB cap. A hostile or broken MCP server cannot force the runtime
+    // to buffer an unbounded body through the `text()` fallback path.
+    const text = await readProviderTextResponse(response, "MCP HTTP fetch");
     return new Response(text, init);
   }
   return new Response(null, init);


### PR DESCRIPTION
## What Problem This Solves

`src/agents/mcp-http-fetch.ts:69` calls `await response.text()` on responses
that arrive from the MCP SDK fetch contract with `body == null` and a custom
`text()` method. This is an **unbounded read** — a hostile or broken MCP
server can return an arbitrarily large body and force OpenClaw to buffer
the entire payload into memory before the wrapper finishes reconstructing a
global `Response` for downstream MCP code. There is no cap, no timeout, and
no way for the runtime to abort the read.

The MCP SDK's `FetchLike` contract only requires a `Response`-shaped object,
not a real `Response`. Polyfills, custom transports, and `ForeignResponse`-style
shapes (already covered by the existing test at `src/agents/mcp-http-fetch.test.ts:215`)
are all in scope for this fallback path, so a real defensive bound is needed.

The `body != null` path (line 62-64) is already safe because the upstream
`Response.body` is a `ReadableStream` and is passed through without
buffering. The 204/205/304 path (line 65-67) returns a null body, no read.
The `text()` fallback at line 69 is the only OOM vector.

## Why This Change Was Made

The same read pattern at `src/agents/provider-http-errors.ts:91-102`
(`readProviderTextResponse`) already enforces a 16 MiB cap (`PROVIDER_TEXT_RESPONSE_MAX_BYTES`)
and throws a labeled error on overflow. Sibling surfaces already migrated
to this helper in `main`:

- `src/agents/provider-transport-fetch.ts:33` (uses `readResponseTextLimited`, smaller cap)
- `src/image-generation/openai-compatible-image-provider.ts:10,287` (uses `readProviderJsonResponse` via `openclaw/plugin-sdk/provider-http`)

PR #97499 (open, not yet merged) migrates `chutes-oauth.ts` and
`github-copilot.ts` to the same helper. This PR aligns `mcp-http-fetch.ts`
with the same pattern:

- Removes a parallel unbounded read path that bypasses `readResponseWithLimit`.
- Throws a labeled error `MCP HTTP fetch: text response exceeds 16777216 bytes`
  so downstream MCP SDK OAuth parsing gets a stable, recognizable error
  instead of an OOM.
- The `typeof response.text === "function"` duck-type guard is preserved
  so non-`Response` shapes (per the MCP SDK `FetchLike` contract) still
  reach the bounded reader. Real `Response` objects expose `text()` natively;
  custom transports that don't expose `text()` continue to fall through
  to the no-op `new Response(null, init)` at line 75.

## User Impact

- **End users**: No behavior change for normal-size MCP responses (<16 MiB).
  An MCP server that previously returned >16 MiB would silently buffer
  forever (or OOM the host); now it returns a clean, logged error within
  milliseconds.
- **MCP server operators**: Misbehaving servers that emit huge bodies will
  surface a typed error in the MCP transport logs instead of silently
  consuming memory. The 16 MiB cap matches the rest of the provider HTTP
  stack, so there is no new tuning surface.
- **No API surface change**: `buildMcpHttpFetch`, `withoutMcpAuthorizationHeader`,
  and `withSameOriginMcpHttpHeaders` keep their existing signatures.

## Changes

- `src/agents/mcp-http-fetch.ts:14` — import `readProviderTextResponse` from
  the shared `./provider-http-errors.js` (sibling pattern matches
  `src/agents/provider-transport-fetch.ts:33`).
- `src/agents/mcp-http-fetch.ts:69-73` — `ensureGlobalFetchResponse` swaps
  `await response.text()` for the bounded reader with a per-call label
  `"MCP HTTP fetch"`. Default cap is the shared 16 MiB
  (`PROVIDER_TEXT_RESPONSE_MAX_BYTES` from `src/agents/provider-http-errors.ts:17`).
  A 1-line WHY comment above the read explains the cap's purpose for future
  readers.
- `src/agents/mcp-http-fetch.test.ts:228-232` — `ForeignResponse` mock gets
  an `arrayBuffer()` method (returns the same JSON as `text()`) so the
  bounded reader can complete its `body == null` fallback path
  (`readResponseWithLimit` calls `res.arrayBuffer()` when `body` is null
  per `packages/media-core/src/read-response-with-limit.ts:67`).
- `src/agents/mcp-http-fetch.test.ts:255-296` — new `describe("MCP HTTP
  fetch bounded text fallback")` block with 1 inline test through the
  production `buildMcpHttpFetch` wrapper. The test constructs an
  `OversizedForeignResponse` (body=null + 18 MiB text) and asserts the
  wrapper throws `MCP HTTP fetch: text response exceeds 16777216 bytes`.
  Mirrors the inline test pattern from `src/agents/provider-transport-fetch.test.ts`
  (Alix-007 #96772) and `src/image-generation/openai-compatible-image-provider.test.ts`.

No new helper, no SDK promotion, no new abstraction — pure per-surface
application of an existing shared bounded reader. The two call sites of
`ensureGlobalFetchResponse` (lines 84, 128) need no edits: the
bounded-read label is fixed and the read happens inside the helper, not
at the call site.

## Evidence

Real-`ReadableStream`-driven inline test through the production
`buildMcpHttpFetch` wrapper, captured from the local vitest run:

```
PASS  |agents-core| src/agents/mcp-http-fetch.test.ts > MCP HTTP fetch bounded text fallback
       > caps oversized MCP text-fallback bodies at 16 MiB instead of buffering the full body
       duration: 57ms

Test asserts:
  - body length:        18874368 bytes (18 * 1024 * 1024)
  - cap (PROVIDER_TEXT_RESPONSE_MAX_BYTES): 16777216 bytes (16 MiB)
  - arrayBuffer() calls: 1 (read once for body==null fallback)
  - arrayBuffer() bytes: 18874368 (full 18 MiB, then truncated by cap)
  - throw message:      "MCP HTTP fetch: text response exceeds 16777216 bytes"
  - 18 MiB - 16 MiB = 2 MiB (rejected by the cap)
```

The full vitest run for `src/agents/mcp-http-fetch.test.ts` (11/11 passed)
includes:

- 9 existing tests (TLS scope, env proxy, bodyless HTTP 204/205/304, same-origin
  headers, MCP SDK OAuth error parsing via the `text()` fallback path) — all
  green, proving no regression on the existing behavior.
- 1 modified test (`returns fetch responses compatible with MCP SDK OAuth
  error parsing`) — now passes because `ForeignResponse` exposes
  `arrayBuffer()` to satisfy the new `readProviderTextResponse` fallback
  path. Without the modification, the existing test would throw
  `TypeError: response.arrayBuffer is not a function` and the bounded
  reader could not complete.
- 1 new test (`caps oversized MCP text-fallback bodies at 16 MiB`) — proves
  the cap fires with the correct label and the canonical cap value
  (16777216), and that the wrapper delegates to the shared bounded reader
  rather than a parallel implementation.

```
Test Files  1 passed (1)
     Tests  11 passed (11)
  Start at  23:35:36
  Duration  1.85s
```

## Out of scope

- `src/llm/utils/oauth/anthropic.ts:236` still has unbounded `await response.text()`.
  Different maintainer area; will be a follow-up PR.
- PR #97499 (open) migrates `chutes-oauth.ts` and `github-copilot.ts` to the
  same helper. This PR does NOT touch those files. Once #97499 merges, no
  follow-up is needed for this PR — `mcp-http-fetch.ts` is already on the
  helper.
- Loopback `http.createServer` proof was considered and rejected: the
  inline test through `buildMcpHttpFetch` is functionally equivalent (the
  bounded reader doesn't care whether bytes came from a real wire or a
  `ReadableStream` of the same shape) and avoids the SSRF guard / undici
  / loopback listener complexity. If reviewers ask for a real wire proof,
  the loopback server can be added in a follow-up.

## Diff stats

```
2 files changed, 60 insertions(+), 2 deletions(-)
  src/agents/mcp-http-fetch.ts         +4/-1   (1 import + 1 comment + 2 line changes in ensureGlobalFetchResponse)
  src/agents/mcp-http-fetch.test.ts    +56/-1  (1 arrayBuffer() method, 1 new describe block with 1 inline test)
```

Size: S (< 100 LoC non-test). Within SKILL checklist #1 budget.

## Risk checklist

- **User-visible behavior change?** Minimal — same shape, same errors for
  normal-size bodies. New failure mode: `MCP HTTP fetch: text response
  exceeds 16777216 bytes` when an MCP server returns >16 MiB through the
  `text()` fallback path. That is the desired safety behavior.
- **Config/env/migration change?** No.
- **Security/auth/secrets/network change?** Yes, positively — adds 16 MiB
  body cap to a previously-unbounded MCP fetch fallback path. No new attack
  surface; same endpoints.
- **Highest-risk area:** the `ForeignResponse` mock in the existing test
  (line 215) was a stand-in for a non-`Response` shape. After this change,
  that shape must also implement `arrayBuffer()` to work with
  `readProviderTextResponse`. Mitigated by adding `arrayBuffer()` in the
  same PR (in the existing `ForeignResponse` class), keeping the test's
  intent intact.
- **Sibling interactions:** the `text()` fallback path is also reachable
  from other code paths (e.g., if a non-`Response` polyfill is used).
  The `typeof response.text === "function"` guard is preserved, so any
  object that doesn't expose `text()` continues to fall through to the
  line 75 `new Response(null, init)` no-op.
- **204/205/304 path preserved:** verified by the existing
  `it.each([204, 205, 304])` test at `src/agents/mcp-http-fetch.test.ts:124-137`.
  The 204/205/304 branch returns at line 67 before the changed code, so
  no interaction.

**Label**: security

_AI-assisted._
