### PR TITLE
fix(auth): recover from malformed API-key profiles

### DIFF
--- a/src/agents/auth-health.test.ts
+++ b/src/agents/auth-health.test.ts
@@ -311,6 +311,29 @@ describe("buildAuthHealthSummary", () => {
     expect(statuses["google:no-refresh"]).toBe("expired");
   });
 
+  it("reports command-shaped API-key profiles as missing malformed auth", () => {
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    const store = {
+      version: 1,
+      profiles: {
+        "zai:default": {
+          type: "api_key" as const,
+          provider: "zai",
+          key: "openclaw onboard --auth-choice zai-coding-global",
+        },
+      },
+    };
+
+    const summary = buildAuthHealthSummary({
+      store,
+      warnAfterMs: DEFAULT_OAUTH_WARN_MS,
+    });
+
+    expect(profileStatuses(summary)["zai:default"]).toBe("missing");
+    expect(profileReasonCodes(summary)["zai:default"]).toBe("malformed_api_key");
+    expect(summary.providers.find((entry) => entry.provider === "zai")?.status).toBe("missing");
+  });
+
   it("uses runtime provider credentials for profile health", () => {
     vi.spyOn(Date, "now").mockReturnValue(now);
     const store = {

--- a/src/agents/auth-health.ts
+++ b/src/agents/auth-health.ts
@@ -142,6 +142,21 @@ function buildProfileHealth(params: {
   const provider = normalizeProviderId(healthCredential.provider);
 
   if (healthCredential.type === "api_key") {
+    const eligibility = evaluateStoredCredentialEligibility({
+      credential: healthCredential,
+      now,
+    });
+    if (!eligibility.eligible) {
+      return {
+        profileId,
+        provider,
+        type: "api_key",
+        status: "missing",
+        reasonCode: eligibility.reasonCode,
+        source,
+        label,
+      };
+    }
     return {
       profileId,
       provider,
@@ -377,7 +392,11 @@ export function buildAuthHealthSummary(params: {
     let earliestExpiry: number | undefined;
     for (const profile of effectiveProfiles) {
       if (profile.type === "api_key") {
-        hasApiKeyProfile = true;
+        if (profile.status === "static") {
+          hasApiKeyProfile = true;
+        } else if (profile.status === "missing") {
+          hasMissing = true;
+        }
         continue;
       }
       if (profile.type !== "oauth" && profile.type !== "token") {
@@ -400,7 +419,7 @@ export function buildAuthHealthSummary(params: {
     }
 
     if (!hasExpirableProfile) {
-      provider.status = hasApiKeyProfile ? "static" : "missing";
+      provider.status = hasMissing ? "missing" : hasApiKeyProfile ? "static" : "missing";
       continue;
     }
 

--- a/src/agents/auth-profiles/credential-state.test.ts
+++ b/src/agents/auth-profiles/credential-state.test.ts
@@ -84,12 +84,17 @@ describe("evaluateStoredCredentialEligibility", () => {
     expect(result).toEqual({ eligible: true, reasonCode: "ok" });
   });
 
-  it("marks pasted OpenClaw onboarding commands as malformed api keys", () => {
+  it.each([
+    "openclaw onboard --auth-choice zai-coding-global",
+    "openclaw onboard --auth-choice=zai-coding-global",
+    "openclaw onboard --non-interactive --auth-choice zai-coding-global --zai-api-key $ZAI_API_KEY",
+    "openclaw onboard --non-interactive --auth-choice=zai-coding-global --zai-api-key $ZAI_API_KEY",
+  ])("marks pasted OpenClaw onboarding command %p as a malformed api key", (key) => {
     const result = evaluateStoredCredentialEligibility({
       credential: {
         type: "api_key",
         provider: "zai",
-        key: "openclaw onboard --auth-choice zai-coding-global",
+        key,
       },
       now,
     });

--- a/src/agents/auth-profiles/credential-state.test.ts
+++ b/src/agents/auth-profiles/credential-state.test.ts
@@ -84,6 +84,18 @@ describe("evaluateStoredCredentialEligibility", () => {
     expect(result).toEqual({ eligible: true, reasonCode: "ok" });
   });
 
+  it("marks pasted OpenClaw onboarding commands as malformed api keys", () => {
+    const result = evaluateStoredCredentialEligibility({
+      credential: {
+        type: "api_key",
+        provider: "zai",
+        key: "openclaw onboard --auth-choice zai-coding-global",
+      },
+      now,
+    });
+    expect(result).toEqual({ eligible: false, reasonCode: "malformed_api_key" });
+  });
+
   it("marks tokenRef with missing expires as eligible", () => {
     const result = evaluateStoredCredentialEligibility({
       credential: {

--- a/src/agents/auth-profiles/credential-state.ts
+++ b/src/agents/auth-profiles/credential-state.ts
@@ -13,7 +13,8 @@ export type AuthCredentialReasonCode =
   | "missing_credential"
   | "invalid_expires"
   | "expired"
-  | "unresolved_ref";
+  | "unresolved_ref"
+  | "malformed_api_key";
 
 /** Default OAuth access-token refresh margin before expiry. */
 export const DEFAULT_OAUTH_REFRESH_MARGIN_MS = 5 * 60 * 1000;
@@ -82,6 +83,13 @@ function hasConfiguredSecretString(value: unknown): boolean {
   return normalizeSecretInputString(value) !== undefined;
 }
 
+export function isMalformedApiKeyInput(value: unknown): boolean {
+  const normalized = normalizeSecretInputString(value);
+  return (
+    normalized !== undefined && /^openclaw\s+onboard\s+--auth-choice(?:\s|=|$)/i.test(normalized)
+  );
+}
+
 /** Classifies whether a stored credential is eligible for auth selection. */
 export function evaluateStoredCredentialEligibility(params: {
   credential: AuthProfileCredential;
@@ -93,6 +101,9 @@ export function evaluateStoredCredentialEligibility(params: {
   if (credential.type === "api_key") {
     const hasKey = hasConfiguredSecretString(credential.key);
     const hasKeyRef = hasConfiguredSecretRef(credential.keyRef);
+    if (isMalformedApiKeyInput(credential.key)) {
+      return { eligible: false, reasonCode: "malformed_api_key" };
+    }
     if (!hasKey && !hasKeyRef) {
       return { eligible: false, reasonCode: "missing_credential" };
     }

--- a/src/agents/auth-profiles/credential-state.ts
+++ b/src/agents/auth-profiles/credential-state.ts
@@ -86,7 +86,8 @@ function hasConfiguredSecretString(value: unknown): boolean {
 export function isMalformedApiKeyInput(value: unknown): boolean {
   const normalized = normalizeSecretInputString(value);
   return (
-    normalized !== undefined && /^openclaw\s+onboard\s+--auth-choice(?:\s|=|$)/i.test(normalized)
+    normalized !== undefined &&
+    /^openclaw\s+onboard(?:\s+.*)?\s+--auth-choice(?:\s|=|$)/i.test(normalized)
   );
 }
 

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -23,7 +23,10 @@ import { normalizeOptionalSecretInput } from "../../utils/normalize-secret-input
 import { refreshChutesTokens } from "../chutes-oauth.js";
 import { resolveProviderIdForAuth } from "../provider-auth-aliases.js";
 import { log } from "./constants.js";
-import { resolveTokenExpiryState } from "./credential-state.js";
+import {
+  evaluateStoredCredentialEligibility,
+  resolveTokenExpiryState,
+} from "./credential-state.js";
 import { formatAuthDoctorHint } from "./doctor.js";
 import {
   readExternalCliBootstrapCredential,
@@ -376,6 +379,9 @@ export async function resolveApiKeyForProfile(
   });
 
   if (cred.type === "api_key") {
+    if (!evaluateStoredCredentialEligibility({ credential: cred }).eligible) {
+      return null;
+    }
     const key = await resolveProfileSecretString({
       profileId,
       provider: cred.provider,

--- a/src/agents/model-auth.profiles.test.ts
+++ b/src/agents/model-auth.profiles.test.ts
@@ -733,6 +733,33 @@ describe("getApiKeyForModel", () => {
     );
   });
 
+  it("skips malformed stored ZAI command profiles and uses current env auth", async () => {
+    await withEnvAsync(
+      {
+        ZAI_API_KEY: "zai-current-key", // pragma: allowlist secret
+        Z_AI_API_KEY: undefined,
+      },
+      async () => {
+        const resolved = await resolveApiKeyForProvider({
+          provider: "zai",
+          store: {
+            version: 1,
+            profiles: {
+              "zai:default": {
+                type: "api_key",
+                provider: "zai",
+                key: "openclaw onboard --auth-choice zai-coding-global",
+              },
+            },
+          },
+        });
+        expect(resolved.apiKey).toBe("zai-current-key");
+        expect(resolved.source).toContain("ZAI_API_KEY");
+        expect(resolved.profileId).toBeUndefined();
+      },
+    );
+  });
+
   it("keeps stored provider auth ahead of env by default", async () => {
     await withEnvAsync({ OPENAI_API_KEY: "env-openai-key" }, async () => {
       const resolved = await resolveApiKeyForProvider({

--- a/src/commands/doctor-auth.profile-health.test.ts
+++ b/src/commands/doctor-auth.profile-health.test.ts
@@ -6,18 +6,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { DoctorPrompter } from "./doctor-prompter.js";
 
+type MockAuthProfileStore = {
+  version: number;
+  profiles: Record<
+    string,
+    | { type: "oauth"; provider: string; access: string; refresh: string; expires: number }
+    | { type: "api_key"; provider: string; key: string }
+  >;
+};
+
 const authProfileMocks = vi.hoisted(() => ({
   ensureAuthProfileStore: vi.fn<
-    (
-      agentDir?: string,
-      options?: { allowKeychainPrompt?: boolean },
-    ) => {
-      version: number;
-      profiles: Record<
-        string,
-        { type: "oauth"; provider: string; access: string; refresh: string; expires: number }
-      >;
-    }
+    (agentDir?: string, options?: { allowKeychainPrompt?: boolean }) => MockAuthProfileStore
   >(() => {
     throw new Error("unexpected auth profile load");
   }),
@@ -200,6 +200,46 @@ describe("noteAuthProfileHealth", () => {
     });
     expect(noteMock).toHaveBeenCalledWith(
       expect.stringContaining("openai-codex:main"),
+      "Model auth",
+    );
+  });
+
+  it("prints malformed API-key profile diagnostics", async () => {
+    const agentDir = path.join(tempDir, "main-agent");
+    writeAuthStore(agentDir);
+    authProfileMocks.hasAnyAuthProfileStoreSource.mockReturnValue(true);
+    authProfileMocks.ensureAuthProfileStore.mockImplementation(
+      (receivedAgentDir): MockAuthProfileStore => {
+        if (receivedAgentDir === agentDir) {
+          return {
+            version: 1,
+            profiles: {
+              "zai:default": {
+                type: "api_key",
+                provider: "zai",
+                key: "openclaw onboard --auth-choice zai-coding-global",
+              },
+            },
+          };
+        }
+        return { version: 1, profiles: {} };
+      },
+    );
+
+    await noteAuthProfileHealth({
+      cfg: {
+        agents: {
+          list: [{ id: "main", default: true, agentDir }],
+        },
+      } as OpenClawConfig,
+      prompter: {
+        confirmAutoFix: vi.fn(async () => false),
+      } as unknown as DoctorPrompter,
+      allowKeychainPrompt: false,
+    });
+
+    expect(noteMock).toHaveBeenCalledWith(
+      expect.stringContaining("zai:default: missing [malformed_api_key]"),
       "Model auth",
     );
   });

--- a/src/commands/doctor-auth.ts
+++ b/src/commands/doctor-auth.ts
@@ -234,6 +234,9 @@ async function resolveAuthIssueHint(
   if (issue.reasonCode === "invalid_expires") {
     return "Invalid token expires metadata. Set a future Unix ms timestamp or remove expires.";
   }
+  if (issue.reasonCode === "malformed_api_key") {
+    return "Paste the API key value, not an OpenClaw onboarding command.";
+  }
   const providerHint = await formatAuthDoctorHint({
     cfg,
     store,
@@ -307,29 +310,34 @@ async function noteAuthProfileHealthForTarget(params: {
   });
 
   const findIssues = () =>
-    summary.profiles.filter(
-      (profile) =>
+    summary.profiles.filter((profile) => {
+      if (profile.type === "api_key") {
+        return profile.status === "missing";
+      }
+      return (
         (profile.type === "oauth" || profile.type === "token") &&
         (profile.status === "expired" ||
           profile.status === "expiring" ||
-          profile.status === "missing"),
-    );
+          profile.status === "missing")
+      );
+    });
 
   let issues = findIssues();
   if (issues.length === 0) {
     return;
   }
 
-  const shouldRefresh = await params.prompter.confirmAutoFix({
-    message: "Refresh expiring OAuth tokens now? (static tokens need re-auth)",
-    initialValue: true,
-  });
+  const refreshTargets = issues.filter(
+    (issue) => issue.type === "oauth" && ["expired", "expiring", "missing"].includes(issue.status),
+  );
+  const shouldRefresh =
+    refreshTargets.length > 0 &&
+    (await params.prompter.confirmAutoFix({
+      message: "Refresh expiring OAuth tokens now? (static tokens need re-auth)",
+      initialValue: true,
+    }));
 
   if (shouldRefresh) {
-    const refreshTargets = issues.filter(
-      (issue) =>
-        issue.type === "oauth" && ["expired", "expiring", "missing"].includes(issue.status),
-    );
     const errors: string[] = [];
     for (const profile of refreshTargets) {
       try {

--- a/src/commands/onboard-non-interactive/api-keys.test.ts
+++ b/src/commands/onboard-non-interactive/api-keys.test.ts
@@ -61,6 +61,30 @@ describe("resolveNonInteractiveApiKey", () => {
     expect(runtime.exit).not.toHaveBeenCalled();
   });
 
+  it("rejects command-shaped flag keys before returning them", async () => {
+    const runtime = createRuntime();
+    resolveEnvApiKey.mockImplementation(() => {
+      throw new Error("env lookup should not run for a malformed explicit flag");
+    });
+
+    const result = await resolveNonInteractiveApiKey({
+      provider: "zai",
+      cfg: {},
+      flagValue:
+        "openclaw onboard --non-interactive --auth-choice=zai-coding-global --zai-api-key $ZAI_API_KEY",
+      flagName: "--zai-api-key",
+      envVar: "ZAI_API_KEY",
+      runtime: runtime as never,
+    });
+
+    expect(result).toBeNull();
+    expect(resolveEnvApiKey).not.toHaveBeenCalled();
+    expect(runtime.error).toHaveBeenCalledWith(
+      "Paste the API key value, not an OpenClaw onboarding command.",
+    );
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+  });
+
   it.each([
     {
       provider: "xai",

--- a/src/commands/onboard-non-interactive/api-keys.ts
+++ b/src/commands/onboard-non-interactive/api-keys.ts
@@ -9,6 +9,7 @@ import {
   resolveApiKeyForProfile,
   resolveAuthProfileOrder,
 } from "../../agents/auth-profiles.js";
+import { isMalformedApiKeyInput } from "../../agents/auth-profiles/credential-state.js";
 import { resolveEnvApiKey } from "../../agents/model-auth.js";
 import { formatCliCommand } from "../../cli/command-format.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -124,6 +125,11 @@ export async function resolveNonInteractiveApiKey(params: {
   }
 
   if (flagKey) {
+    if (isMalformedApiKeyInput(flagKey)) {
+      params.runtime.error("Paste the API key value, not an OpenClaw onboarding command.");
+      params.runtime.exit(1);
+      return null;
+    }
     return { key: flagKey, source: "flag" };
   }
 

--- a/src/plugins/provider-auth-input.test.ts
+++ b/src/plugins/provider-auth-input.test.ts
@@ -7,6 +7,7 @@ import {
   maybeApplyApiKeyFromOption,
   normalizeApiKeyInput,
   normalizeTokenProviderInput,
+  validateApiKeyInput,
 } from "./provider-auth-input.js";
 
 const acceptAnyApiKeyInput = () => undefined;
@@ -237,6 +238,14 @@ describe("normalizeApiKeyInput", () => {
 
   it("preserves ordinary interior spaces in bearer-style values", () => {
     expect(normalizeApiKeyInput('TOKEN="Bearer demo token"')).toBe("Bearer demo token");
+  });
+});
+
+describe("validateApiKeyInput", () => {
+  it("rejects pasted OpenClaw onboarding commands", () => {
+    expect(validateApiKeyInput("openclaw onboard --auth-choice zai-coding-global")).toBe(
+      "Paste the API key value, not an OpenClaw onboarding command.",
+    );
   });
 });
 

--- a/src/plugins/provider-auth-input.test.ts
+++ b/src/plugins/provider-auth-input.test.ts
@@ -242,8 +242,13 @@ describe("normalizeApiKeyInput", () => {
 });
 
 describe("validateApiKeyInput", () => {
-  it("rejects pasted OpenClaw onboarding commands", () => {
-    expect(validateApiKeyInput("openclaw onboard --auth-choice zai-coding-global")).toBe(
+  it.each([
+    "openclaw onboard --auth-choice zai-coding-global",
+    "openclaw onboard --auth-choice=zai-coding-global",
+    "openclaw onboard --non-interactive --auth-choice zai-coding-global --zai-api-key $ZAI_API_KEY",
+    "openclaw onboard --non-interactive --auth-choice=zai-coding-global --zai-api-key $ZAI_API_KEY",
+  ])("rejects pasted OpenClaw onboarding command %p", (value) => {
+    expect(validateApiKeyInput(value)).toBe(
       "Paste the API key value, not an OpenClaw onboarding command.",
     );
   });

--- a/src/plugins/provider-auth-input.test.ts
+++ b/src/plugins/provider-auth-input.test.ts
@@ -279,6 +279,23 @@ describe("maybeApplyApiKeyFromOption", () => {
     expect(result).toBeUndefined();
     expect(setCredential).not.toHaveBeenCalled();
   });
+
+  it("rejects malformed command-shaped option keys before storing them", async () => {
+    const setCredential = vi.fn(async () => undefined);
+
+    await expect(
+      maybeApplyApiKeyFromOption({
+        token:
+          "openclaw onboard --non-interactive --auth-choice=zai-coding-global --zai-api-key $ZAI_API_KEY",
+        tokenProvider: "zai",
+        expectedProviders: ["zai"],
+        normalize: normalizeApiKeyInput,
+        validate: validateApiKeyInput,
+        setCredential,
+      }),
+    ).rejects.toThrow("Paste the API key value, not an OpenClaw onboarding command.");
+    expect(setCredential).not.toHaveBeenCalled();
+  });
 });
 
 describe("ensureApiKeyFromEnvOrPrompt", () => {

--- a/src/plugins/provider-auth-input.ts
+++ b/src/plugins/provider-auth-input.ts
@@ -114,6 +114,7 @@ export async function maybeApplyApiKeyFromOption(params: {
   secretInputMode?: SecretInputMode;
   expectedProviders: string[];
   normalize: (value: string) => string;
+  validate?: (value: string) => string | undefined;
   setCredential: (apiKey: SecretInput, mode?: SecretInputMode) => Promise<void>;
 }): Promise<string | undefined> {
   const tokenProvider = normalizeTokenProviderInput(params.tokenProvider);
@@ -124,6 +125,10 @@ export async function maybeApplyApiKeyFromOption(params: {
     return undefined;
   }
   const apiKey = params.normalize(params.token);
+  const validationError = params.validate?.(apiKey);
+  if (validationError) {
+    throw new Error(validationError);
+  }
   await params.setCredential(apiKey, params.secretInputMode);
   return apiKey;
 }
@@ -152,6 +157,7 @@ export async function ensureApiKeyFromOptionEnvOrPrompt(params: {
     secretInputMode: params.secretInputMode,
     expectedProviders: params.expectedProviders,
     normalize: params.normalize,
+    validate: params.validate,
     setCredential: params.setCredential,
   });
   if (optionApiKey) {

--- a/src/plugins/provider-auth-input.ts
+++ b/src/plugins/provider-auth-input.ts
@@ -3,6 +3,7 @@ import {
   normalizeOptionalLowercaseString,
   normalizeStringifiedOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
+import { isMalformedApiKeyInput } from "../agents/auth-profiles/credential-state.js";
 import { resolveEnvApiKey } from "../agents/model-auth-env.js";
 import type { OpenClawConfig } from "../config/types.js";
 import type { SecretInput } from "../config/types.secrets.js";
@@ -55,8 +56,16 @@ export function normalizeApiKeyInput(raw: string): string {
 }
 
 /** Validates required API-key input for setup prompts. */
-export const validateApiKeyInput = (value: string) =>
-  normalizeApiKeyInput(value).length > 0 ? undefined : "Required";
+export const validateApiKeyInput = (value: string) => {
+  const normalized = normalizeApiKeyInput(value);
+  if (!normalized) {
+    return "Required";
+  }
+  if (isMalformedApiKeyInput(normalized)) {
+    return "Paste the API key value, not an OpenClaw onboarding command.";
+  }
+  return undefined;
+};
 
 /** Formats a redacted API-key preview for setup confirmation prompts. */
 export function formatApiKeyPreview(


### PR DESCRIPTION
Closes #97313

## Summary

Fixes an issue where Z.AI users could rotate credentials or run setup/doctor repair, but sub-agents and embedded model auth would still try a stale stored `zai:default` auth profile whose API-key value was accidentally saved as an `openclaw onboard ... --auth-choice ...` command. That made the bad profile look usable, so auth selection could prefer it over current env/config credentials and produce Z.AI 401s.

- Fix classification: root-cause auth-profile credential eligibility fix with input-boundary prevention.
- Maintainer-ready confidence: high; the patch covers the stored-profile consumer boundary, explicit profile lookup, doctor health reporting, interactive provider setup input, CLI provider option input, and non-interactive API-key flag input.
- Root cause: command text saved in an API-key credential was treated like a valid static API key because stored profile eligibility only checked whether a string existed.
- Why this is root-cause fix: the root invariant is that an auth profile is eligible only when its credential can actually be used by the provider resolver. This fix moves the malformed command check to that source eligibility predicate, so every downstream resolver/doctor consumer sees the same invalid state instead of each path masking a bad profile separately; setup/onboarding input validation reuses the same source classifier to prevent reintroducing the same malformed state.
- Patch quality notes: the new `return null` branches are explicit fail-closed paths for malformed explicit profile and non-interactive flag inputs after emitting a user-facing diagnostic, so the caller stops before using command text as provider auth. The `return undefined` branch in option handling preserves the existing “this option did not apply” contract for unmatched provider options and is not a fallback for malformed matching options. The test prompter cast stays local to the doctor-auth test fixture because the test only exercises the prompt methods used by that doctor path.

## Linked context

- Issue: #97313
- Related open PR / same-contract scan: this update is scoped to the current PR and the auth-profile/API-key contract for #97313; no public comparison with other PRs is included here.
- Out of scope: no schema migration, provider catalog change, OAuth/token credential behavior change, keyRef/SecretRef handling change, or broad command parser is added.

## What Problem This Solves

Fixes an issue where users who accidentally saved an OpenClaw onboarding command as a Z.AI API key could still see sub-agent or embedded model auth use that stale stored profile after credential rotation or setup/doctor repair. The expected recovery path is that current env/config credentials can take over and doctor points to the malformed stored profile instead of letting it masquerade as usable auth.

- Why it matters / User impact: users can recover from the malformed `zai:default` profile without deleting all auth state, and future setup/onboarding attempts reject the command text before it is stored or sent to provider endpoint detection.
- Behavior or issue addressed: command-shaped API-key profile values are treated as malformed, skipped for auth resolution, surfaced in doctor health, and rejected from provider setup/onboarding API-key input paths.

## Why This Change Was Made

This treats command-shaped API-key profile values as malformed at the shared auth-profile eligibility boundary. Stored malformed profiles are skipped during provider auth selection and explicit profile resolution, doctor surfaces them as `missing [malformed_api_key]`, and provider setup/onboarding input validation rejects pasted onboarding commands before they can be persisted or used.

- Architecture / source-of-truth check: the source of truth is stored credential eligibility, because the same saved profile is consumed by sub-agent auth selection, explicit profile resolution, and doctor health. Provider setup, CLI option, and non-interactive flag checks reuse that same detector so prevention and recovery classify the same malformed shape consistently.
- What did NOT change: ordinary API-key strings, token credentials, OAuth credentials, keyRef, SecretRef, env fallback, config fallback, and provider precedence for healthy stored profiles are unchanged. This is only a narrow malformed-command boundary and does not change schemas, migrations, provider catalogs, or unrelated auth flows.
- Risk labels considered: auth-provider, compatibility, session-state, and security-boundary.
- Risk explanation: the change tightens auth-provider/profile eligibility and setup input validation, but only for OpenClaw onboarding command text containing `--auth-choice`, including documented non-interactive forms with intervening flags.
- Why acceptable: a literal `openclaw onboard ... --auth-choice ...` command is not a valid provider API key, and leaving it eligible causes the reported Z.AI 401 recovery failure; the detector deliberately stays narrower than general shell-command detection to avoid rejecting normal secrets.

Compatibility/risk boundary: the new malformed check is intentionally narrow to OpenClaw onboarding command text containing `--auth-choice`, including documented non-interactive forms where other flags appear before `--auth-choice`. It does not change normal API-key, token, OAuth, keyRef, or SecretRef handling. This PR keeps the behavior in shared auth-profile eligibility because the poisoned value is consumed by multiple paths: sub-agent auth selection, explicit profile lookup, doctor health, and provider setup/onboarding input.

## User Impact

Users who accidentally persisted an onboarding command in `zai:default` can recover without manually deleting all auth state: current env/config Z.AI credentials are allowed to take over, and `openclaw doctor` now tells them exactly which profile is malformed and what to paste instead. Future setup/onboarding attempts reject command text at input time.

## Real behavior proof

- Exact steps or command run after this patch: a redacted local OpenClaw doctor/auth proof used an isolated temporary agent auth store, saved a fake malformed `zai:default` API-key profile through OpenClaw's auth-profile store helper, loaded the real doctor/auth modules, built the health summary, and ran `noteAuthProfileHealth` with keychain prompts disabled.
- Evidence after fix (redacted local OpenClaw doctor/auth path): Validation `real-doctor-auth-proof` (pass, exit_code=0):

  ```text
  OpenClaw doctor/auth proof: isolated temp auth store with malformed Z.AI profile
  Profile under test: zai:default
  Stored value shape: openclaw onboard --non-interactive --auth-choice=zai-coding-global --zai-api-key $ZAI_API_KEY
  Auth source detected: true
  Loaded profile type/provider: api_key/zai
  Health summary: zai:default: missing [malformed_api_key]
  Doctor note output:
  │
  ◇  Model auth ────────────────────────────────────────────────────────────╮
  │                                                                         │
  │  - zai:default: missing [malformed_api_key] — Paste the API key value,  │
  │    not an OpenClaw onboarding command.                                  │
  │                                                                         │
  ├─────────────────────────────────────────────────────────────────────────╯
  ```

- Observed result after fix: the malformed static Z.AI profile is loaded from the auth store, classified as `missing [malformed_api_key]`, and surfaced by the doctor auth output with the direct remediation hint instead of being treated as usable auth.
- What was not tested: no real Z.AI credential was used and no live provider request was sent; the proof intentionally uses a fake command-shaped value and isolated temp auth store to avoid exposing credentials or touching user auth state.

## Tests and validation

- Target test file: `src/agents/auth-profiles/credential-state.test.ts`, `src/plugins/provider-auth-input.test.ts`, `src/commands/onboard-non-interactive/api-keys.test.ts`, `src/agents/model-auth.profiles.test.ts`, `src/agents/auth-health.test.ts`, and `src/commands/doctor-auth.profile-health.test.ts`.
- Scenario locked in: documented `openclaw onboard --auth-choice ...` and `openclaw onboard --non-interactive ... --auth-choice=... --zai-api-key ...` command variants are rejected as malformed API keys; malformed stored Z.AI profiles are skipped in favor of current env auth; doctor prints `missing [malformed_api_key]`; CLI option and non-interactive flag inputs reject command-shaped values before storing or returning them.
- Why this is the smallest reliable guardrail: the tests pin both recovery and prevention boundaries without adding provider-specific branches beyond the shared malformed-command classifier.

- CLI API-key option and non-interactive flag regression tests: `node scripts/run-vitest.mjs src/plugins/provider-auth-input.test.ts src/commands/onboard-non-interactive/api-keys.test.ts --reporter=verbose`

  ```text
  [test] passed 2 Vitest shards in 27.37s
  src/commands/onboard-non-interactive/api-keys.test.ts: 7 tests passed
  src/plugins/provider-auth-input.test.ts: 20 tests passed
  ```

- Focused auth regression tests: `node scripts/run-vitest.mjs src/agents/auth-profiles/credential-state.test.ts src/plugins/provider-auth-input.test.ts src/commands/onboard-non-interactive/api-keys.test.ts src/agents/model-auth.profiles.test.ts src/agents/auth-health.test.ts src/commands/doctor-auth.profile-health.test.ts --reporter=verbose`

  ```text
  [test] passed 4 Vitest shards in 63.04s
  src/agents/auth-profiles/credential-state.test.ts: 15 tests passed
  src/commands/doctor-auth.profile-health.test.ts and src/commands/onboard-non-interactive/api-keys.test.ts: 13 tests passed
  src/agents/model-auth.profiles.test.ts and src/agents/auth-health.test.ts: 88 tests passed
  src/plugins/provider-auth-input.test.ts: 20 tests passed
  ```

- Format check: `pnpm exec oxfmt --check src/agents/auth-profiles/credential-state.ts src/agents/auth-profiles/credential-state.test.ts src/plugins/provider-auth-input.ts src/plugins/provider-auth-input.test.ts src/commands/onboard-non-interactive/api-keys.ts src/commands/onboard-non-interactive/api-keys.test.ts src/agents/auth-health.ts src/agents/auth-health.test.ts src/agents/auth-profiles/oauth.ts src/agents/model-auth.profiles.test.ts src/commands/doctor-auth.ts src/commands/doctor-auth.profile-health.test.ts`

  ```text
  All matched files use the correct format.
  Finished in 176ms on 12 files using 8 threads.
  ```

- Test typecheck: `pnpm check:test-types`

  ```text
  $ pnpm tsgo:test
  $ pnpm tsgo:core:test && pnpm tsgo:extensions:test
  ```

## Risk checklist

- Auth-provider risk: limited to static API-key values matching OpenClaw onboarding command text with `--auth-choice`; healthy stored profiles and env/config fallbacks are unchanged.
- Compatibility risk: a saved profile whose key is literally an OpenClaw onboarding command becomes ineligible and visible in doctor as malformed; that is the intended recovery behavior for #97313.
- Security-boundary risk: the PR avoids printing or persisting real credentials in proof, keeps malformed command text out of provider endpoint probing, and does not expand accepted secret formats.
- Session-state risk: no auth store schema or migration changes are introduced; only eligibility and health classification change for the malformed static API-key shape.
- Merge-risk explanation: the diff touches several auth files because the same malformed profile flows through selection, explicit resolution, doctor output, and setup input; the behavior is still one narrow invariant rather than separate feature work.

## Current review state

Which bot or reviewer comments were addressed?

- RF-001: fixed. Documented `openclaw onboard` command variants with intervening flags and `--auth-choice=` are covered by `credential-state.test.ts` and `provider-auth-input.test.ts`.
- RF-002: fixed. PR body now includes redacted local OpenClaw doctor/auth proof from the real auth-profile store and doctor health path.
- RF-003: fixed. The real behavior proof shows the malformed `zai:default` profile loading as `api_key/zai`, health classification as `missing [malformed_api_key]`, and doctor output with the remediation hint.
- RF-004: maintainer decision disclosed. Compatibility risk is limited to command-shaped API-key values containing `--auth-choice`; normal API-key, token, OAuth, keyRef, and SecretRef behavior is unchanged.
- RF-005: fixed. The detector now recognizes documented non-interactive onboard command variants where other flags appear before `--auth-choice`.
- RF-006: fixed. Redacted after-fix OpenClaw doctor/auth proof is included under Real behavior proof.
- RF-007: maintainer decision disclosed. The PR keeps the classifier in shared auth-profile eligibility because the poisoned value is consumed by auth selection, explicit profile lookup, doctor health, and setup/onboarding input.
- RF-008: fixed. `src/agents/auth-profiles/credential-state.ts` now covers documented onboard command variants, with regression tests for the missed forms.
- Additional ClawSweeper commit-review finding: fixed. CLI provider option and non-interactive API-key flag inputs now reject command-shaped values before storage or endpoint probing, with focused regression tests.
