### PR TITLE
fix(media-understanding): use aws-sdk credentials for bedrock image models

### DIFF
--- a/src/media-understanding/image.test.ts
+++ b/src/media-understanding/image.test.ts
@@ -248,6 +248,60 @@ describe("describeImageWithModel", () => {
     expect(completeMock).not.toHaveBeenCalled();
   });
 
+  it("lets amazon-bedrock image models use aws-sdk credentials without an API key", async () => {
+    // Regression: bedrock uses aws-sdk auth, so the resolved apiKey is
+    // legitimately empty (credentials come from the AWS SDK chain / instance
+    // role). The image path must not require an API key for aws-sdk mode, or
+    // image analysis fails with "No API key resolved ... (auth mode: aws-sdk)".
+    const bedrockModel = {
+      provider: "amazon-bedrock",
+      id: "global.anthropic.claude-opus-4-8",
+      input: ["text", "image"],
+      api: "bedrock-converse-stream",
+      maxTokens: 4096,
+    };
+    discoverModelsMock.mockReturnValue({
+      find: vi.fn(() => bedrockModel),
+    });
+    getApiKeyForModelMock.mockResolvedValueOnce({
+      apiKey: undefined,
+      source: "aws-sdk default chain",
+      mode: "aws-sdk",
+    });
+    completeMock.mockResolvedValue({
+      role: "assistant",
+      api: "bedrock-converse-stream",
+      provider: "amazon-bedrock",
+      model: "global.anthropic.claude-opus-4-8",
+      stopReason: "stop",
+      timestamp: Date.now(),
+      content: [{ type: "text", text: "bedrock ok" }],
+    });
+
+    const result = await describeImageWithModel({
+      cfg: {},
+      agentDir: "/tmp/openclaw-agent",
+      provider: "amazon-bedrock",
+      model: "global.anthropic.claude-opus-4-8",
+      buffer: Buffer.from("png-bytes"),
+      fileName: "image.png",
+      mime: "image/png",
+      prompt: "Describe the image.",
+      timeoutMs: 1000,
+    });
+
+    expect(result).toEqual({
+      text: "bedrock ok",
+      model: "global.anthropic.claude-opus-4-8",
+    });
+    // aws-sdk mode must bypass the API-key requirement entirely.
+    expect(requireApiKeyMock).not.toHaveBeenCalled();
+    expect(setRuntimeApiKeyMock).toHaveBeenCalledWith("amazon-bedrock", "");
+    expect(completeMock).toHaveBeenCalledOnce();
+    const [, , completeOptions] = requireFirstMockCall(completeMock, "complete");
+    expect(requireRecord(completeOptions, "complete options").apiKey).toBe("");
+  });
+
   it("uses generic completion for non-canonical minimax-portal image models", async () => {
     discoverModelsMock.mockReturnValue({
       find: vi.fn(() => ({

--- a/src/media-understanding/image.ts
+++ b/src/media-understanding/image.ts
@@ -238,7 +238,18 @@ async function prepareResolvedImageRuntime(
     preferredProfile: params.preferredProfile,
     store: params.authStore,
   });
-  let apiKey = requireApiKey(apiKeyInfo, model.provider);
+  // aws-sdk auth resolves credentials lazily through the AWS SDK credential
+  // chain (env vars / shared ~/.aws files / EC2 instance-role IMDS / ECS
+  // container role), so the resolved apiKey is legitimately empty. The
+  // bedrock-converse provider stream signs requests with those SDK credentials
+  // and never consumes this apiKey — mirroring the main chat path, which never
+  // calls requireApiKey for aws-sdk. Requiring a key here wrongly failed image
+  // analysis for amazon-bedrock models with "No API key resolved ... (auth
+  // mode: aws-sdk ...)". Other auth modes still require a usable key.
+  let apiKey =
+    apiKeyInfo.mode === "aws-sdk"
+      ? (apiKeyInfo.apiKey ?? "")
+      : requireApiKey(apiKeyInfo, model.provider);
   // Image tool bypasses prepareRuntimeAuth — exchange OAuth token for
   // a short-lived Copilot API token so the integrator scope (vscode-chat)
   // matches what runtime chat requests send.


### PR DESCRIPTION
## What Problem This Solves

When `agents.defaults.imageModel` points at an `amazon-bedrock` model and the provider uses `auth: "aws-sdk"`, the image-understanding tool fails with:

```
No API key resolved for provider "amazon-bedrock" (auth mode: aws-sdk, checked: aws-sdk default chain).
```

…even though the same bedrock model works fine for normal chat.

`aws-sdk` auth resolves credentials lazily through the AWS SDK credential chain (env vars, shared `~/.aws` files, EC2 instance-role IMDS, ECS container role), so the resolved API key is legitimately empty. The bedrock-converse provider stream signs requests with those SDK credentials and never consumes an API key, and the main chat path never calls `requireApiKey` for `aws-sdk`.

The image path in `src/media-understanding/image.ts` (`prepareResolvedImageRuntime`) unconditionally called `requireApiKey(...)`, which throws `MissingProviderAuthError` whenever the key is empty. This wrongly blocked image analysis for every bedrock deployment that relies on instance-role / default-profile / SSO credentials (no static key in env) — chat worked, the image tool did not.

## Evidence

**Repro before the fix** (EC2 host, bedrock credentials via instance role; chat works, image tool fails):
- Config: `imageModel = amazon-bedrock/global.anthropic.claude-opus-4-8`, provider `auth: "aws-sdk"`.
- Image tool result: `All image models failed (2): amazon-bedrock/global.anthropic.claude-opus-4-8: No API key resolved for provider "amazon-bedrock" (auth mode: aws-sdk, checked: aws-sdk default chain). | amazon-bedrock/global.anthropic.claude-opus-4-7: No API key resolved ...`

**Fix** (`src/media-understanding/image.ts`) — branch on auth mode so `aws-sdk` keeps an empty key and defers to the SDK chain, while all other modes still require a usable key:

```ts
let apiKey =
  apiKeyInfo.mode === "aws-sdk"
    ? (apiKeyInfo.apiKey ?? "")
    : requireApiKey(apiKeyInfo, model.provider);
```

**Regression test** added in `src/media-understanding/image.test.ts` — "lets amazon-bedrock image models use aws-sdk credentials without an API key" — asserts that for an `aws-sdk` bedrock model the path (1) never calls `requireApiKey`, (2) stores an empty runtime key (`setRuntimeApiKey("amazon-bedrock", "")`), and (3) reaches the provider completion with `apiKey: ""`.

**Local test run** (added test + existing suite, on the EC2 host above):
```
$ node node_modules/.bin/vitest run --config test/vitest/vitest.media-understanding.config.ts src/media-understanding/image.test.ts
 ✓ media-understanding  src/media-understanding/image.test.ts (30 tests) 2475ms
 Test Files  1 passed (1)
      Tests  30 passed (30)
```
