### PR TITLE
fix(memory-wiki): skip prune when configured path is transiently unavailable (#97523)

### DIFF
--- a/extensions/memory-wiki/src/unsafe-local.test.ts
+++ b/extensions/memory-wiki/src/unsafe-local.test.ts
@@ -135,4 +135,49 @@ describe("syncMemoryWikiUnsafeLocalSources", () => {
       "# very private",
     );
   });
+
+  it("preserves imported pages when configured path becomes transiently unavailable", async () => {
+    // Use a nested path where the parent becomes empty after removal,
+    // simulating a NAS mount point or removable drive being undocked.
+    const mountPoint = nextCaseRoot("nas-mount");
+    await fs.mkdir(mountPoint, { recursive: true });
+    const sourceDir = path.join(mountPoint, "source");
+    await fs.mkdir(sourceDir, { recursive: true });
+    const filePath = path.join(sourceDir, "notes.md");
+    await fs.writeFile(filePath, "# my notes\n", "utf8");
+
+    const { rootDir: vaultDir, config } = await createVault({
+      rootDir: nextCaseRoot("transient-vault"),
+      config: {
+        vaultMode: "unsafe-local",
+        unsafeLocal: {
+          allowPrivateMemoryCoreAccess: true,
+          paths: [sourceDir],
+        },
+      },
+    });
+
+    const first = await syncMemoryWikiUnsafeLocalSources(config);
+    expect(first.importedCount).toBe(1);
+    expect(first.removedCount).toBe(0);
+    const firstPagePath = first.pagePaths[0] ?? "";
+
+    // Simulate the path becoming transiently unavailable (drive undocked, NAS
+    // rebooting). Remove both sourceDir and mountPoint so the parent of the
+    // configured path is inaccessible.
+    await fs.rm(mountPoint, { recursive: true, force: true });
+    const second = await syncMemoryWikiUnsafeLocalSources(config);
+    expect(second.artifactCount).toBe(0);
+    expect(second.removedCount).toBe(0);
+    await expect(fs.readFile(path.join(vaultDir, firstPagePath), "utf8")).resolves.toContain(
+      "# my notes",
+    );
+
+    // Restore the path — next sync should re-reconcile cleanly.
+    await fs.mkdir(mountPoint, { recursive: true });
+    await fs.mkdir(sourceDir, { recursive: true });
+    await fs.writeFile(filePath, "# my notes\n", "utf8");
+    const third = await syncMemoryWikiUnsafeLocalSources(config);
+    expect(third.removedCount).toBe(0);
+  });
 });

--- a/extensions/memory-wiki/src/unsafe-local.ts
+++ b/extensions/memory-wiki/src/unsafe-local.ts
@@ -64,6 +64,15 @@ async function listAllowedFilesRecursive(rootDir: string): Promise<string[]> {
   return files.toSorted((left, right) => left.localeCompare(right));
 }
 
+async function isParentAccessible(configuredPath: string): Promise<boolean> {
+  try {
+    await fs.access(path.dirname(path.resolve(configuredPath)));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 async function collectUnsafeLocalArtifacts(
   configuredPaths: string[],
 ): Promise<UnsafeLocalArtifact[]> {
@@ -236,12 +245,25 @@ export async function syncMemoryWikiUnsafeLocalSources(
     }),
   );
 
-  const removedCount = await pruneImportedSourceEntries({
-    vaultRoot: config.vault.path,
-    group: "unsafe-local",
-    activeKeys,
-    state,
-  });
+  // Skip pruning when zero artifacts were collected AND at least one configured
+  // path has an inaccessible parent directory (transiently unavailable —
+  // undocked drive, NAS rebooting, cloud folder not mounted yet). In that
+  // state, zero artifacts is indistinguishable from "all sources deleted."
+  // Pruning would irreversibly delete imported pages and user-authored
+  // human-notes blocks. When the parent IS accessible but yields no artifacts,
+  // the user intentionally removed the source files, so pruning proceeds
+  // normally. See #97523.
+  const hasInaccessiblePath =
+    artifacts.length === 0 &&
+    !(await Promise.all(config.unsafeLocal.paths.map(isParentAccessible))).every(Boolean);
+  const removedCount = hasInaccessiblePath
+    ? 0
+    : await pruneImportedSourceEntries({
+        vaultRoot: config.vault.path,
+        group: "unsafe-local",
+        activeKeys,
+        state,
+      });
   await writeMemoryWikiSourceSyncState(config.vault.path, state);
   const importedCount = results.filter((result) => result.changed && result.created).length;
   const updatedCount = results.filter((result) => result.changed && !result.created).length;


### PR DESCRIPTION
## What Problem This Solves

In memory-wiki `vaultMode: "unsafe-local"`, a transiently unavailable configured source path (undocked external drive, NAS rebooting, cloud-synced folder not mounted yet) causes the next wiki sync to delete every imported page for that path AND destroy the user-authored human-notes block inside each page. The loss is permanent: on the next successful sync the page is recreated empty, with no prior content to restore the notes from.

## Why This Change Was Made

`collectUnsafeLocalArtifacts` treats a missing path as "zero artifacts collected" (indistinguishable from "all sources deleted"). The sync function then calls `pruneImportedSourceEntries` unconditionally, which hard-deletes every state entry whose `syncKey` is not in `activeKeys` — wiping all imported pages.

The fix adds a guard: when zero artifacts are collected AND at least one configured path's parent directory is inaccessible, skip the prune entirely. This preserves imported pages and user-authored human-notes blocks during transient outages. When the parent directory IS accessible (user intentionally removed source files), pruning proceeds normally.

## User Impact

Users with `unsafe-local` vault mode on removable/network/cloud-synced storage no longer lose imported pages and hand-written notes when the storage is temporarily unavailable.

## Evidence

- **Behavior addressed:** memory-wiki unsafe-local sync prunes imported pages when a configured path is transiently unavailable
- **Environment tested:** macOS, Node 22, OpenClaw 2026.5.28
- **Steps run after the patch:** Ran `pnpm test:extension memory-wiki` which exercises `syncMemoryWikiUnsafeLocalSources` with both transient unavailability (new test) and intentional file deletion (existing test)
- **Evidence after fix:**
```
 Test Files  31 passed (31)
      Tests  187 passed (187)
   Start at  00:17:37
   Duration  17.89s
```
- **Observed result after fix:** All 187 tests pass including the new transient-unavailability test and the existing prune-on-delete test. The guard correctly distinguishes between "parent directory inaccessible" (skip prune) and "file removed from accessible directory" (proceed with prune).
- **What was not tested:** Live NAS/removable-drive unavailability scenario (requires physical hardware). The test simulates this by removing both the source directory and its parent mount point.

## Real behavior proof

- **Behavior addressed:** memory-wiki unsafe-local sync prunes imported pages when a configured path is transiently unavailable
- **Environment tested:** macOS, Node 22, OpenClaw 2026.5.28
- **Steps run after the patch:** Ran `pnpm test:extension memory-wiki` which exercises `syncMemoryWikiUnsafeLocalSources` with both transient unavailability (new test) and intentional file deletion (existing test)
- **Evidence after fix:**
```
 Test Files  31 passed (31)
      Tests  187 passed (187)
   Start at  00:17:37
   Duration  17.89s
```
- **Observed result after fix:** All 187 tests pass including the new transient-unavailability test and the existing prune-on-delete test. The guard correctly distinguishes between "parent directory inaccessible" (skip prune) and "file removed from accessible directory" (proceed with prune).
- **What was not tested:** Live NAS/removable-drive unavailability scenario (requires physical hardware). The test simulates this by removing both the source directory and its parent mount point.

- [x] AI-assisted (Hermes Agent)
