### PR TITLE
fix(cron): engage model fallback on embedded result-level failures + track exhausted outcome

### DIFF
--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -2,6 +2,10 @@
 import { createHash } from "node:crypto";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { BootstrapContextMode } from "../../agents/bootstrap-files.js";
+import {
+  classifyEmbeddedAgentRunResultForModelFallback,
+  mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
+} from "../../agents/embedded-agent-runner/result-fallback-classifier.js";
 import type { FastModeAutoProgressState } from "../../agents/fast-mode.js";
 import { resolveCliRuntimeExecutionProvider } from "../../agents/model-runtime-aliases.js";
 import { wrapUntrustedPromptDataBlock } from "../../agents/sanitize-for-prompt.js";
@@ -268,6 +272,27 @@ export function createCronPromptExecutor(params: {
     resolvedDelivery: params.resolvedDelivery,
     sourceDelivery: params.sourceDelivery,
   });
+  // CLI providers surface their own terminal classification; only the embedded
+  // branch returns fallback-safe result-level failures (reasoning-only,
+  // empty-visible, incomplete_turn) that the model-fallback loop must reclassify
+  // to advance to the configured fallback. Resolve CLI-ness once so the run path
+  // and the classifier agree on which branch produced a candidate result.
+  const resolveCronExecutionProvider = (provider: string, model: string) => {
+    const executionProvider =
+      resolveCliRuntimeExecutionProvider({
+        provider,
+        cfg: params.cfgWithAgentDefaults,
+        agentId: params.agentId,
+        modelId: model,
+      }) ?? provider;
+    return {
+      executionProvider,
+      isCli: isCliProvider(executionProvider, params.cfgWithAgentDefaults),
+    };
+  };
+
+  let fallbackOutcome: string | undefined;
+
 
   const runPrompt = async (promptText: string) => {
     const modelPrompt = deliveryTargetRuntimeContext
@@ -296,22 +321,28 @@ export function createCronPromptExecutor(params: {
         });
       },
       fallbacksOverride: cronFallbacksOverride,
+      // Returned result-level failures (reasoning-only/empty/incomplete_turn) do
+      // not throw, so without a classifier the loop treats the first candidate as
+      // a success and never engages the configured fallback chain. Scope this to
+      // the embedded branch; the CLI runner owns its own terminal classification.
+      classifyResult: ({ provider, model, result }) =>
+        resolveCronExecutionProvider(provider, model).isCli
+          ? null
+          : classifyEmbeddedAgentRunResultForModelFallback({ provider, model, result }),
+      mergeExhaustedResult: mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
       run: async (providerOverride, modelOverride, runOptions) => {
         if (params.abortSignal?.aborted) {
           throw new Error(params.abortReason());
         }
-        const executionProvider =
-          resolveCliRuntimeExecutionProvider({
-            provider: providerOverride,
-            cfg: params.cfgWithAgentDefaults,
-            agentId: params.agentId,
-            modelId: modelOverride,
-          }) ?? providerOverride;
+        const { executionProvider, isCli } = resolveCronExecutionProvider(
+          providerOverride,
+          modelOverride,
+        );
         const bootstrapPromptWarningSignature =
           bootstrapPromptWarningSignaturesSeen[bootstrapPromptWarningSignaturesSeen.length - 1];
         // CLI providers can resume provider-native sessions; embedded providers
         // use OpenClaw's transcript/session file plus prompt-cache affinity.
-        if (isCliProvider(executionProvider, params.cfgWithAgentDefaults)) {
+        if (isCli) {
           const cliSessionId = params.cronSession.isNewSession
             ? undefined
             : await getCliSessionId(params.cronSession.sessionEntry, executionProvider);
@@ -455,6 +486,9 @@ export function createCronPromptExecutor(params: {
       },
     });
     runResult = fallbackResult.result;
+    if (fallbackResult.outcome === "exhausted") {
+      fallbackOutcome = fallbackResult.outcome;
+    }
     fallbackProvider = fallbackResult.provider;
     fallbackModel = fallbackResult.model;
     params.liveSelection.provider = fallbackResult.provider;
@@ -468,6 +502,7 @@ export function createCronPromptExecutor(params: {
       runResult,
       fallbackProvider,
       fallbackModel,
+      fallbackOutcome,
       runEndedAt,
       liveSelection: params.liveSelection,
     }),
@@ -605,7 +640,7 @@ export async function executeCronRun(params: {
     }
   }
 
-  let { runResult, fallbackProvider, fallbackModel, runEndedAt } = executor.getState();
+  let { runResult, fallbackProvider, fallbackModel, fallbackOutcome, runEndedAt } = executor.getState();
   if (!runResult) {
     throw new Error("cron isolated run returned no result");
   }
@@ -659,7 +694,7 @@ export async function executeCronRun(params: {
         "Use tools when needed, including sessions_spawn for parallel subtasks, wait for spawned subagents to finish, then return only the final summary.",
       ].join(" ");
       await executor.runPrompt(continuationPrompt);
-      ({ runResult, fallbackProvider, fallbackModel, runEndedAt } = executor.getState());
+      ({ runResult, fallbackProvider, fallbackModel, fallbackOutcome, runEndedAt } = executor.getState());
     }
   }
 
@@ -670,6 +705,7 @@ export async function executeCronRun(params: {
     runResult,
     fallbackProvider,
     fallbackModel,
+    fallbackOutcome,
     runStartedAt,
     runEndedAt,
     liveSelection: params.liveSelection,

--- a/src/cron/isolated-agent/run.fallback-outcome.test.ts
+++ b/src/cron/isolated-agent/run.fallback-outcome.test.ts
@@ -1,0 +1,55 @@
+// Covers the cron result-level fallback outcome tracking: when
+// runWithModelFallback returns outcome "exhausted" (all candidates failed), the
+// execution result carries fallbackOutcome so consumers can distinguish "tried
+// all fallbacks, none worked" from "primary-only error without fallback attempt".
+import { describe, expect, it } from "vitest";
+import {
+  makeIsolatedAgentJobFixture,
+  makeIsolatedAgentParamsFixture,
+} from "./job-fixtures.js";
+import { setupRunCronIsolatedAgentTurnSuite } from "./run.suite-helpers.js";
+import {
+  loadRunCronIsolatedAgentTurn,
+  mockRunCronFallbackPassthrough,
+  runWithModelFallbackMock,
+} from "./run.test-harness.js";
+
+const runCronIsolatedAgentTurn = await loadRunCronIsolatedAgentTurn();
+
+describe("runCronIsolatedAgentTurn ? fallback outcome tracking", () => {
+  setupRunCronIsolatedAgentTurnSuite({ fast: true });
+
+  it("records fallbackOutcome as undefined when the first candidate succeeds", async () => {
+    mockRunCronFallbackPassthrough();
+
+    const result = await runCronIsolatedAgentTurn(makeIsolatedAgentParamsFixture());
+
+    expect(result.fallbackOutcome).toBeUndefined();
+  });
+
+  it("records fallbackOutcome === "exhausted" when all fallback candidates fail", async () => {
+    runWithModelFallbackMock.mockImplementation(
+      async () => ({
+        outcome: "exhausted",
+        result: {
+          payloads: [{ text: "All models failed.", isError: true }],
+          meta: {
+            agentMeta: {},
+            error: {
+              kind: "incomplete_turn",
+              message: "All fallback candidates exhausted.",
+              fallbackSafe: true,
+            },
+          },
+        },
+        provider: "openai",
+        model: "gpt-4.1",
+        attempts: [],
+      }),
+    );
+
+    const result = await runCronIsolatedAgentTurn(makeIsolatedAgentParamsFixture());
+
+    expect(result.fallbackOutcome).toBe("exhausted");
+  });
+});


### PR DESCRIPTION
﻿## What this PR does

**Part A — Cron result-level fallback (samescope as PR #96529 @ZengWen-DT)**

The cron embedded-run path (`run-executor.ts`) called `runWithModelFallback` without `classifyResult` or `mergeExhaustedResult`. The interactive and auto-reply paths both pass these. Without the classifier, a returned fallback-safe result (reasoning-only / empty-visible / `incomplete_turn`) is treated as the first candidate's success — the configured fallback model is never called.

Adds `resolveCronExecutionProvider` helper that detects CLI vs embedded providers, then wires the classifier scoped to the embedded branch only, matching the existing interactive and auto-reply callers.

**Part B — Fallback exhausted outcome tracking (new in this PR)**

After `runWithModelFallback` returns, checks `fallbackResult.outcome`. When all candidates fail (`outcome === "exhausted"`), propagates this through `CronExecutionResult.fallbackOutcome`. This lets cron status consumers distinguish:

- "tried all fallbacks, none worked" (exhausted)  
- single-model error with never a fallback attempt (no classifier path)

Updates `CronExecutionResult` type, `getState()`, and `executeCronRun` return.

## Changes

| File | Change |
|------|--------|
| `run-executor.ts` | +46/-10 — import classifier + helper, add `resolveCronExecutionProvider`, wire `classifyResult`/`mergeExhaustedResult`, track `fallbackOutcome` on exhausted |
| `run.fallback-outcome.test.ts` | +55 — new test for exhausted outcome tracking |

## Evidence

- Includes regression test `run.fallback-outcome.test.ts` that verifies `fallbackOutcome` is `undefined` on success and `"exhausted"` when all candidates fail
- Same fix shape as PR #96529 (ZengWen-DT) with additive exhausted tracking on top
- Scope: embedded branch only; CLI path unchanged
