### PR TITLE
fix(openai): bound embedding-batch and realtime session JSON respons

### DIFF
--- a/extensions/openai/embedding-batch.test.ts
+++ b/extensions/openai/embedding-batch.test.ts
@@ -266,6 +266,70 @@ describe("OpenAI embedding batch output", () => {
     ]);
   });
 
+  it("bounds batch status success body via readProviderJsonResponse", async () => {
+    const chunkSize = 1024 * 1024;
+    const chunkCount = 20; // 20 MiB, well over 16 MiB cap
+    let readCount = 0;
+    let canceled = false;
+    const oversizedStatus = new Response(
+      new ReadableStream<Uint8Array>({
+        pull(controller) {
+          if (readCount >= chunkCount) {
+            controller.close();
+            return;
+          }
+          readCount += 1;
+          controller.enqueue(new Uint8Array(chunkSize));
+        },
+        cancel() {
+          canceled = true;
+        },
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+    let batchStatusCalled = false;
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = fetchInputUrl(input);
+      if (url.endsWith("/files") && init?.method === "POST") {
+        return jsonResponse({ id: "file-0" });
+      }
+      if (url.endsWith("/batches") && init?.method === "POST") {
+        return jsonResponse({ id: "batch-0", status: "in_progress" });
+      }
+      if (url.endsWith("/batches/batch-0") && !batchStatusCalled) {
+        batchStatusCalled = true;
+        return oversizedStatus;
+      }
+      return new Response("unexpected request", { status: 500 });
+    });
+
+    await expect(
+      runOpenAiEmbeddingBatches({
+        openAi: {
+          baseUrl: "https://openai-compatible.example/v1",
+          headers: { Authorization: "Bearer test" },
+          model: "text-embedding-3-small",
+          fetchImpl,
+        },
+        agentId: "main",
+        requests: [
+          {
+            custom_id: "0",
+            method: "POST",
+            url: "/v1/embeddings",
+            body: { model: "text-embedding-3-small", input: "payload" },
+          },
+        ],
+        wait: true,
+        concurrency: 1,
+        pollIntervalMs: 1000,
+        timeoutMs: 60_000,
+      }),
+    ).rejects.toThrow(/openai\.batch-status/);
+    expect(canceled).toBe(true);
+    expect(readCount).toBeLessThan(chunkCount);
+  });
+
   it("bounds batch resource error bodies without using response.text()", async () => {
     const tracked = cancelTrackedResponse(`${"batch status unavailable ".repeat(1024)}tail`, {
       status: 400,

--- a/extensions/openai/embedding-batch.ts
+++ b/extensions/openai/embedding-batch.ts
@@ -18,7 +18,10 @@ import {
   uploadBatchJsonlFile,
   withRemoteHttpResponse,
 } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
-import { readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
+import {
+  readProviderJsonResponse,
+  readResponseTextLimited,
+} from "openclaw/plugin-sdk/provider-http";
 import { normalizeStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { OpenAiEmbeddingClient } from "./embedding-provider.js";
 
@@ -96,7 +99,7 @@ async function fetchOpenAiBatchStatus(params: {
     openAi: params.openAi,
     path: `/batches/${params.batchId}`,
     errorPrefix: "openai batch status",
-    parse: async (res) => (await res.json()) as OpenAiBatchStatus,
+    parse: async (res) => readProviderJsonResponse<OpenAiBatchStatus>(res, "openai.batch-status"),
   });
 }
 

--- a/extensions/openai/realtime-provider-shared.test.ts
+++ b/extensions/openai/realtime-provider-shared.test.ts
@@ -1,0 +1,100 @@
+// Openai tests cover realtime session secret creation behavior.
+import { describe, expect, it, vi } from "vitest";
+import {
+  createOpenAIRealtimeClientSecret,
+  createOpenAIRealtimeTranscriptionClientSecret,
+} from "./realtime-provider-shared.js";
+
+const { fetchWithSsrFGuardMock } = vi.hoisted(() => ({
+  fetchWithSsrFGuardMock: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
+  fetchWithSsrFGuard: fetchWithSsrFGuardMock,
+}));
+
+function makeStreamingResponse(params: { chunkCount: number; chunkSize: number }): {
+  response: Response;
+  getReadCount: () => number;
+  wasCanceled: () => boolean;
+} {
+  let readCount = 0;
+  let canceled = false;
+  const chunk = new Uint8Array(params.chunkSize);
+  const response = new Response(
+    new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (readCount >= params.chunkCount) {
+          controller.close();
+          return;
+        }
+        readCount += 1;
+        controller.enqueue(chunk);
+      },
+      cancel() {
+        canceled = true;
+      },
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } },
+  );
+  return { response, getReadCount: () => readCount, wasCanceled: () => canceled };
+}
+
+function guardedFetch(response: Response): void {
+  fetchWithSsrFGuardMock.mockResolvedValue({ response, release: vi.fn() });
+}
+
+describe("createOpenAIRealtimeClientSecret", () => {
+  it("returns client secret from a well-formed response", async () => {
+    guardedFetch(
+      new Response(
+        JSON.stringify({
+          client_secret: { value: "eph-secret-abc" },
+          expires_at: Math.floor(Date.now() / 1000) + 60,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    const result = await createOpenAIRealtimeClientSecret({
+      authToken: "sk-test",
+      auditContext: "test",
+      session: { model: "gpt-4o-realtime-preview" },
+    });
+
+    expect(result.value).toBe("eph-secret-abc");
+    expect(typeof result.expiresAt).toBe("number");
+  });
+
+  it("bounds oversized success response and cancels the stream", async () => {
+    // 20 MiB in 1 MiB chunks — well over the 16 MiB cap
+    const streamed = makeStreamingResponse({ chunkCount: 20, chunkSize: 1024 * 1024 });
+    guardedFetch(streamed.response);
+
+    await expect(
+      createOpenAIRealtimeClientSecret({
+        authToken: "sk-test",
+        auditContext: "test",
+        session: { model: "gpt-4o-realtime-preview" },
+      }),
+    ).rejects.toThrow(/openai\.realtime-session/);
+
+    expect(streamed.wasCanceled()).toBe(true);
+    expect(streamed.getReadCount()).toBeLessThan(20);
+  });
+
+  it("throws the provider error label on oversized body", async () => {
+    const streamed = makeStreamingResponse({ chunkCount: 20, chunkSize: 1024 * 1024 });
+    guardedFetch(streamed.response);
+
+    await expect(
+      createOpenAIRealtimeTranscriptionClientSecret({
+        authToken: "sk-test",
+        auditContext: "test",
+        session: { model: "gpt-4o-transcribe" },
+      }),
+    ).rejects.toThrow(/openai\.realtime-session/);
+
+    expect(streamed.wasCanceled()).toBe(true);
+  });
+});

--- a/extensions/openai/realtime-provider-shared.ts
+++ b/extensions/openai/realtime-provider-shared.ts
@@ -2,6 +2,7 @@
 import { resolveExpiresAtMsFromEpochSeconds } from "openclaw/plugin-sdk/number-runtime";
 import {
   createProviderHttpError,
+  readProviderJsonResponse,
   resolveProviderRequestHeaders,
 } from "openclaw/plugin-sdk/provider-http";
 import { captureWsEvent } from "openclaw/plugin-sdk/proxy-capture";
@@ -110,7 +111,7 @@ async function createOpenAIRealtimeSecret(
       if (!response.ok) {
         throw await createProviderHttpError(response, params.errorMessage);
       }
-      return (await response.json()) as unknown;
+      return await readProviderJsonResponse<unknown>(response, "openai.realtime-session");
     } finally {
       await release();
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where two OpenAI success-path JSON reads are unbounded, allowing a misbehaving or hostile endpoint to stream an arbitrarily large response body and cause memory pressure or OOM:

1. **`extensions/openai/embedding-batch.ts` — `fetchOpenAiBatchStatus`** polls `/batches/:id` to track embedding batch progress. The error path was already bounded via `readResponseTextLimited`, but the success-path `parse` callback used a raw `await res.json()` with no size cap. This is the same asymmetric gap fixed for sibling batch surfaces in #96868 (OpenAI-compatible embeddings) and #96608 (GitHub Copilot usage).

2. **`extensions/openai/realtime-provider-shared.ts` — `createOpenAIRealtimeSecret`** fetches ephemeral session tokens for Realtime voice and transcription. The error path used `createProviderHttpError` (bounded), while the success path fell back to a raw `await response.json()`. This shared helper is called by both `createOpenAIRealtimeClientSecret` and `createOpenAIRealtimeTranscriptionClientSecret`, so both Realtime entry points were affected.

## Why This Change Was Made

`readProviderJsonResponse` from `openclaw/plugin-sdk/provider-http` wraps `readResponseWithLimit` with the standard 16 MiB cap and stream cancellation. It is a one-call replacement that makes the success path symmetric with the existing error-path bounds, with no behavior change for well-formed endpoints.

## User Impact

No change for normal OpenAI endpoints. Users running memory embedding batches or Realtime voice/transcription against a self-hosted, misconfigured, or compromised `baseUrl` that returns an oversized success payload will now see a bounded error (`Content too large: N bytes (limit: 16777216 bytes)`) and early stream cancellation instead of unbounded heap growth.

## Evidence

**Proof script** (`node scripts/proof-openai-bound-batch-realtime.mjs`, Node v22.22.0):

```text
[case 1] openai.batch-status oversized, ReadableStream, cap=1 MiB
  ok: readResponseWithLimit rejected on oversized batch-status body — true
  ok: bounded error message present (got: Content too large: 2097152 bytes (limit: 1048576 bytes)) — true
  ok: stream was cancelled before all 20 chunks were read (readCount=2) — true
  ok: stream cancel() was called — true

[case 2] negative control — raw response.json() does NOT cancel
  ok: unbounded .json() drained all 20 chunks (readCount=20) — true
  ok: stream NOT cancelled via .cancel() — drained to EOF — true

[case 3] small batch-status body parses cleanly
  ok: small batch-status body parsed into result — true
  ok: result content intact (status=completed present) — true

[case 4] openai.realtime-session oversized, node:http, bytes-on-wire
  ok: readResponseWithLimit rejected realtime-session oversized body — true
  ok: bounded error message present (got: Content too large: 1112544 bytes (limit: 1048576 bytes)) — true

[case 5] small realtime-session body parses cleanly
  ok: small realtime-session body parsed into result — true
  ok: result content intact (batch-ok present) — true

ALL PROOF ASSERTIONS PASSED
```

**Local test suite** (`node scripts/run-vitest.mjs run extensions/openai/embedding-batch.test.ts extensions/openai/realtime-provider-shared.test.ts`, Vitest v4.1.8, Node v22.22.0):

```text
 ✓ extensions/openai/realtime-provider-shared.test.ts > createOpenAIRealtimeClientSecret > returns client secret from a well-formed response
 ✓ extensions/openai/realtime-provider-shared.test.ts > createOpenAIRealtimeClientSecret > bounds oversized success response and cancels the stream
 ✓ extensions/openai/realtime-provider-shared.test.ts > createOpenAIRealtimeClientSecret > throws the provider error label on oversized body
 ✓ extensions/openai/embedding-batch.test.ts > OpenAI embedding batch output > wraps malformed JSONL output
 ✓ extensions/openai/embedding-batch.test.ts > OpenAI embedding batch output > splits provider uploads by serialized JSONL byte cap
 ✓ extensions/openai/embedding-batch.test.ts > OpenAI embedding batch output > adapts OpenAI-compatible upload groups after payload-size rejection
 ✓ extensions/openai/embedding-batch.test.ts > OpenAI embedding batch output > bounds batch status success body via readProviderJsonResponse
 ✓ extensions/openai/embedding-batch.test.ts > OpenAI embedding batch output > bounds batch resource error bodies without using response.text()

 Test Files  2 passed (2)
      Tests  8 passed (8)
   Duration  16.97s
```

What was not tested: live OpenAI embedding batch API or Realtime API calls.

_AI-assisted._
