### PR TITLE
fix(google): bound embedding-batch JSON response reads

### DIFF
--- a/extensions/google/embedding-batch.test.ts
+++ b/extensions/google/embedding-batch.test.ts
@@ -1,0 +1,228 @@
+// Google tests cover embedding batch bounded JSON response reads.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { runGeminiEmbeddingBatches } from "./embedding-batch.js";
+
+// Pass-through so onResponse receives real Response objects (required by
+// readProviderJsonResponse which needs a real .body ReadableStream).
+vi.mock("openclaw/plugin-sdk/memory-core-host-engine-embeddings", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("openclaw/plugin-sdk/memory-core-host-engine-embeddings")>();
+  return {
+    ...actual,
+    withRemoteHttpResponse: async <T>(params: {
+      url: string;
+      ssrfPolicy?: unknown;
+      init?: RequestInit;
+      onResponse: (response: Response) => Promise<T>;
+    }): Promise<T> => {
+      const response = await fetch(params.url, params.init);
+      return await params.onResponse(response);
+    },
+  };
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+function fetchInputUrl(input: RequestInfo | URL): string {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.href;
+  return input.url;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function makeGeminiClient() {
+  return {
+    baseUrl: "https://gemini-compatible.example/v1beta",
+    modelPath: "models/text-embedding-004",
+    headers: { "x-goog-api-key": "test-key" },
+    ssrfPolicy: undefined,
+  };
+}
+
+type GeminiBatchRequest = Parameters<typeof runGeminiEmbeddingBatches>[0]["requests"][number];
+
+function singleRequest(): GeminiBatchRequest[] {
+  return [
+    {
+      custom_id: "r0",
+      request: {
+        model: "models/text-embedding-004",
+        content: { parts: [{ text: "hello" }] },
+      },
+    },
+  ];
+}
+
+function makeOversizedResponse(): {
+  response: Response;
+  getReadCount: () => number;
+  wasCanceled: () => boolean;
+} {
+  const chunkSize = 1024 * 1024;
+  const chunkCount = 20; // 20 MiB — over 16 MiB cap
+  let readCount = 0;
+  let canceled = false;
+  return {
+    response: new Response(
+      new ReadableStream<Uint8Array>({
+        pull(controller) {
+          if (readCount >= chunkCount) {
+            controller.close();
+            return;
+          }
+          readCount += 1;
+          controller.enqueue(new Uint8Array(chunkSize));
+        },
+        cancel() {
+          canceled = true;
+        },
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    ),
+    getReadCount: () => readCount,
+    wasCanceled: () => canceled,
+  };
+}
+
+describe("Google embedding-batch bounded JSON reads", () => {
+  it("bounds oversized file-upload JSON response and cancels the stream", async () => {
+    const streamed = makeOversizedResponse();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        if (fetchInputUrl(input).includes("/upload/")) return streamed.response;
+        return new Response("unexpected", { status: 500 });
+      }),
+    );
+
+    await expect(
+      runGeminiEmbeddingBatches({
+        gemini: makeGeminiClient(),
+        agentId: "main",
+        requests: singleRequest(),
+        wait: true,
+        concurrency: 1,
+        pollIntervalMs: 50,
+        timeoutMs: 5_000,
+      }),
+    ).rejects.toThrow(/gemini\.batch-file-upload/);
+
+    expect(streamed.wasCanceled()).toBe(true);
+    expect(streamed.getReadCount()).toBeLessThan(20);
+  });
+
+  it("bounds oversized batch-create JSON response and cancels the stream", async () => {
+    const streamed = makeOversizedResponse();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = fetchInputUrl(input);
+        if (url.includes("/upload/")) return jsonResponse({ name: "files/f-ok" });
+        if (url.includes(":asyncBatchEmbedContent")) return streamed.response;
+        return new Response("unexpected", { status: 500 });
+      }),
+    );
+
+    await expect(
+      runGeminiEmbeddingBatches({
+        gemini: makeGeminiClient(),
+        agentId: "main",
+        requests: singleRequest(),
+        wait: true,
+        concurrency: 1,
+        pollIntervalMs: 50,
+        timeoutMs: 5_000,
+      }),
+    ).rejects.toThrow(/gemini\.batch-create/);
+
+    expect(streamed.wasCanceled()).toBe(true);
+    expect(streamed.getReadCount()).toBeLessThan(20);
+  });
+
+  it("bounds oversized batch-status poll JSON response and cancels the stream", async () => {
+    const streamed = makeOversizedResponse();
+    let statusCalled = false;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = fetchInputUrl(input);
+        if (url.includes("/upload/")) return jsonResponse({ name: "files/f-ok" });
+        if (url.includes(":asyncBatchEmbedContent")) {
+          return jsonResponse({ name: "batches/b-0", state: "PENDING" });
+        }
+        if (url.includes("/batches/") && !statusCalled) {
+          statusCalled = true;
+          return streamed.response;
+        }
+        return new Response("unexpected", { status: 500 });
+      }),
+    );
+
+    await expect(
+      runGeminiEmbeddingBatches({
+        gemini: makeGeminiClient(),
+        agentId: "main",
+        requests: singleRequest(),
+        wait: true,
+        concurrency: 1,
+        pollIntervalMs: 50,
+        timeoutMs: 5_000,
+      }),
+    ).rejects.toThrow(/gemini\.batch-status/);
+
+    expect(streamed.wasCanceled()).toBe(true);
+    expect(streamed.getReadCount()).toBeLessThan(20);
+  });
+
+  it("parses small responses on all three JSON paths correctly", async () => {
+    // Use a unit-length vector so sanitizeAndNormalizeEmbedding preserves values.
+    const outputLine = JSON.stringify({
+      key: "r0",
+      embedding: { values: [1, 0, 0] },
+    });
+    let statusCalled = false;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = fetchInputUrl(input);
+        if (url.includes("/upload/")) return jsonResponse({ name: "files/f-ok" });
+        if (url.includes(":asyncBatchEmbedContent")) {
+          return jsonResponse({ name: "batches/b-0", state: "PENDING" });
+        }
+        if (url.includes("/batches/") && !statusCalled) {
+          statusCalled = true;
+          return jsonResponse({
+            name: "batches/b-0",
+            state: "SUCCEEDED",
+            outputConfig: { file: "files/out-0" },
+          });
+        }
+        if (url.includes(":download")) {
+          return new Response(outputLine, { status: 200 });
+        }
+        return new Response("unexpected", { status: 500 });
+      }),
+    );
+
+    const result = await runGeminiEmbeddingBatches({
+      gemini: makeGeminiClient(),
+      agentId: "main",
+      requests: singleRequest(),
+      wait: true,
+      concurrency: 1,
+      pollIntervalMs: 50,
+      timeoutMs: 5_000,
+    });
+
+    expect(result.get("r0")).toEqual([1, 0, 0]);
+  });
+});

--- a/extensions/google/embedding-batch.test.ts
+++ b/extensions/google/embedding-batch.test.ts
@@ -1,6 +1,7 @@
 // Google tests cover embedding batch bounded JSON response reads.
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { runGeminiEmbeddingBatches } from "./embedding-batch.js";
+import type { GeminiEmbeddingClient } from "./embedding-provider.js";
 
 // Pass-through so onResponse receives real Response objects (required by
 // readProviderJsonResponse which needs a real .body ReadableStream).
@@ -27,8 +28,12 @@ afterEach(() => {
 });
 
 function fetchInputUrl(input: RequestInfo | URL): string {
-  if (typeof input === "string") return input;
-  if (input instanceof URL) return input.href;
+  if (typeof input === "string") {
+    return input;
+  }
+  if (input instanceof URL) {
+    return input.href;
+  }
   return input.url;
 }
 
@@ -39,11 +44,13 @@ function jsonResponse(body: unknown, status = 200): Response {
   });
 }
 
-function makeGeminiClient() {
+function makeGeminiClient(): GeminiEmbeddingClient {
   return {
     baseUrl: "https://gemini-compatible.example/v1beta",
+    model: "text-embedding-004",
     modelPath: "models/text-embedding-004",
     headers: { "x-goog-api-key": "test-key" },
+    apiKeys: ["test-key"],
     ssrfPolicy: undefined,
   };
 }
@@ -57,6 +64,7 @@ function singleRequest(): GeminiBatchRequest[] {
       request: {
         model: "models/text-embedding-004",
         content: { parts: [{ text: "hello" }] },
+        taskType: "RETRIEVAL_DOCUMENT",
       },
     },
   ];
@@ -99,7 +107,9 @@ describe("Google embedding-batch bounded JSON reads", () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(async (input: RequestInfo | URL) => {
-        if (fetchInputUrl(input).includes("/upload/")) return streamed.response;
+        if (fetchInputUrl(input).includes("/upload/")) {
+          return streamed.response;
+        }
         return new Response("unexpected", { status: 500 });
       }),
     );
@@ -126,8 +136,12 @@ describe("Google embedding-batch bounded JSON reads", () => {
       "fetch",
       vi.fn(async (input: RequestInfo | URL) => {
         const url = fetchInputUrl(input);
-        if (url.includes("/upload/")) return jsonResponse({ name: "files/f-ok" });
-        if (url.includes(":asyncBatchEmbedContent")) return streamed.response;
+        if (url.includes("/upload/")) {
+          return jsonResponse({ name: "files/f-ok" });
+        }
+        if (url.includes(":asyncBatchEmbedContent")) {
+          return streamed.response;
+        }
         return new Response("unexpected", { status: 500 });
       }),
     );
@@ -155,7 +169,9 @@ describe("Google embedding-batch bounded JSON reads", () => {
       "fetch",
       vi.fn(async (input: RequestInfo | URL) => {
         const url = fetchInputUrl(input);
-        if (url.includes("/upload/")) return jsonResponse({ name: "files/f-ok" });
+        if (url.includes("/upload/")) {
+          return jsonResponse({ name: "files/f-ok" });
+        }
         if (url.includes(":asyncBatchEmbedContent")) {
           return jsonResponse({ name: "batches/b-0", state: "PENDING" });
         }
@@ -194,7 +210,9 @@ describe("Google embedding-batch bounded JSON reads", () => {
       "fetch",
       vi.fn(async (input: RequestInfo | URL) => {
         const url = fetchInputUrl(input);
-        if (url.includes("/upload/")) return jsonResponse({ name: "files/f-ok" });
+        if (url.includes("/upload/")) {
+          return jsonResponse({ name: "files/f-ok" });
+        }
         if (url.includes(":asyncBatchEmbedContent")) {
           return jsonResponse({ name: "batches/b-0", state: "PENDING" });
         }

--- a/extensions/google/embedding-batch.ts
+++ b/extensions/google/embedding-batch.ts
@@ -9,7 +9,10 @@ import {
   sanitizeAndNormalizeEmbedding,
   withRemoteHttpResponse,
 } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
-import { createProviderHttpError } from "openclaw/plugin-sdk/provider-http";
+import {
+  createProviderHttpError,
+  readProviderJsonResponse,
+} from "openclaw/plugin-sdk/provider-http";
 import { normalizeStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { GeminiEmbeddingClient, GeminiTextEmbeddingRequest } from "./embedding-provider.js";
 
@@ -126,7 +129,10 @@ async function submitGeminiBatch(params: {
         const text = await fileRes.text();
         throw new Error(`gemini batch file upload failed: ${fileRes.status} ${text}`);
       }
-      return (await fileRes.json()) as { name?: string; file?: { name?: string } };
+      return readProviderJsonResponse<{ name?: string; file?: { name?: string } }>(
+        fileRes,
+        "gemini.batch-file-upload",
+      );
     },
   });
   const fileId = filePayload.name ?? filePayload.file?.name;
@@ -158,7 +164,7 @@ async function submitGeminiBatch(params: {
     },
     onResponse: async (batchRes) => {
       if (batchRes.ok) {
-        return (await batchRes.json()) as GeminiBatchStatus;
+        return readProviderJsonResponse<GeminiBatchStatus>(batchRes, "gemini.batch-create");
       }
       const text = await batchRes.text();
       if (batchRes.status === 404) {
@@ -191,7 +197,7 @@ async function fetchGeminiBatchStatus(params: {
       if (!res.ok) {
         throw await createProviderHttpError(res, "gemini batch status failed");
       }
-      return (await res.json()) as GeminiBatchStatus;
+      return readProviderJsonResponse<GeminiBatchStatus>(res, "gemini.batch-status");
     },
   });
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where three success-path JSON reads in `extensions/google/embedding-batch.ts` are unbounded, allowing a misbehaving or hostile Gemini endpoint to stream an arbitrarily large response body and cause memory pressure or OOM.

The three affected surfaces are:

1. **`submitGeminiBatch` — file-upload response** (`/upload/v1beta/files?uploadType=multipart`): returns `{ name?, file? }` identifying the uploaded batch file. Error path uses `fileRes.text()` (bounded via `readResponseTextLimited` elsewhere in the project), success path had no cap.

2. **`submitGeminiBatch` — batch-create response** (`:asyncBatchEmbedContent`): returns the initial `GeminiBatchStatus` after batch submission. Error path uses `batchRes.text()` (bounded), success path had no cap.

3. **`fetchGeminiBatchStatus` — batch-status poll response**: called in a polling loop to track batch progress. Error path already used `createProviderHttpError` (bounded), success path had no cap. This is the hottest path of the three — it is called once per poll interval for the lifetime of every running batch.

This asymmetric pattern (error bounded, success unbounded) is the same gap fixed for sibling surfaces in #95418, #95420 (OpenRouter model catalog), #96027 (Ollama discovery), and #96868 (OpenAI-compatible embeddings).

The Gemini client accepts a configurable `baseUrl` — when an operator or memory plugin is misconfigured against a hostile endpoint, all three paths are reachable with no cap.

## Why This Change Was Made

`readProviderJsonResponse` from `openclaw/plugin-sdk/provider-http` applies the standard 16 MiB cap, cancels the `ReadableStream` on overflow, and surfaces `"<label>: JSON response exceeds N bytes"` — a single-call replacement for each bare `await response.json()`. Net change is +1 LOC on the import and 0 on the production logic per call site.

## User Impact

No change for well-behaved Gemini endpoints. Memory embedding batch jobs running against a self-hosted, misconfigured, or compromised `baseUrl` that returns an oversized success payload will now see a bounded error and early stream cancellation instead of unbounded heap growth.

## Evidence

**Proof script** (`node scripts/proof-google-embedding-batch-bound.mjs`, Node v22.22.0):

```text
[case 1] gemini.batch-file-upload oversized, ReadableStream, cap=1 MiB
  ok: rejected on oversized file-upload body — true
  ok: bounded error message present (got: Content too large: 2097152 bytes (limit: 1048576 bytes)) — true
  ok: stream cancelled before all 20 chunks (readCount=2) — true
  ok: cancel() was called — true

[case 2] gemini.batch-create oversized, ReadableStream, cap=1 MiB
  ok: rejected on oversized batch-create body — true
  ok: stream cancelled — true
  ok: readCount < 20 — true

[case 3] gemini.batch-status oversized, node:http, bytes-on-wire
  ok: rejected on oversized batch-status body — true
  ok: bounded error message present (got: Content too large: 1071896 bytes (limit: 1048576 bytes)) — true

[case 4] negative control — raw response.json() does NOT cancel
  ok: unbounded .json() drained all 20 chunks (readCount=20) — true
  ok: stream NOT cancelled — drained to EOF — true

[case 5] small upload/batch/status bodies parse cleanly
  ok: file-upload small body parsed — true
  ok: batch-create/status small body parsed — true

ALL PROOF ASSERTIONS PASSED
```

**Local test suite** (`node scripts/run-vitest.mjs run extensions/google/embedding-batch.test.ts`, Vitest v4.1.8, Node v22.22.0):

```text
 ✓ bounds oversized file-upload JSON response and cancels the stream
 ✓ bounds oversized batch-create JSON response and cancels the stream
 ✓ bounds oversized batch-status poll JSON response and cancels the stream
 ✓ parses small responses on all three JSON paths correctly

 Test Files  1 passed (1)
      Tests  4 passed (4)
   Duration  2.07s
```

What was not tested: live Gemini API calls.

_AI-assisted._
