### PR TITLE
fix(signal): bound GitHub release info JSON response with readProviderJsonResponse

### DIFF
--- a/extensions/signal/src/install-signal-cli.test.ts
+++ b/extensions/signal/src/install-signal-cli.test.ts
@@ -314,6 +314,38 @@ describe("installSignalCliFromRelease", () => {
     expect(fetchResult.release).toHaveBeenCalledTimes(1);
   });
 
+  it("bounds oversized GitHub release metadata and cancels the stream", async () => {
+    const chunkSize = 1024 * 1024;
+    const chunkCount = 20; // 20 MiB — over the 16 MiB cap
+    let readCount = 0;
+    let canceled = false;
+    const oversized = new Response(
+      new ReadableStream<Uint8Array>({
+        pull(controller) {
+          if (readCount >= chunkCount) {
+            controller.close();
+            return;
+          }
+          readCount += 1;
+          controller.enqueue(new Uint8Array(chunkSize));
+        },
+        cancel() {
+          canceled = true;
+        },
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+    const releaseMock = vi.fn().mockResolvedValue(undefined);
+    fetchWithSsrFGuardMock.mockResolvedValue({ response: oversized, release: releaseMock });
+
+    const result = await installSignalCliFromRelease({ log: vi.fn() } as unknown as RuntimeEnv);
+
+    expect(result).toEqual({ ok: false, error: "Failed to parse signal-cli release info." });
+    expect(canceled).toBe(true);
+    expect(readCount).toBeLessThan(chunkCount);
+    expect(releaseMock).toHaveBeenCalledTimes(1);
+  });
+
   it("bounds the release metadata request with an explicit timeout", async () => {
     const fetchResult = okDownloadResponse(JSON.stringify({ tag_name: "v0.14.3", assets: [] }), {
       headers: { "content-type": "application/json" },

--- a/extensions/signal/src/install-signal-cli.ts
+++ b/extensions/signal/src/install-signal-cli.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { Readable, Transform } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import { runPluginCommandWithTimeout } from "openclaw/plugin-sdk/run-command";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { CONFIG_DIR, extractArchive, resolveBrewExecutable } from "openclaw/plugin-sdk/setup-tools";
@@ -303,7 +304,7 @@ export async function installSignalCliFromRelease(
       };
     }
     try {
-      payload = (await response.json()) as ReleaseResponse;
+      payload = await readProviderJsonResponse<ReleaseResponse>(response, "signal.release-info");
     } catch {
       return {
         ok: false,


### PR DESCRIPTION
## What Problem This Solves

`installSignalCliFromRelease` fetches
`https://api.github.com/repos/AsamK/signal-cli/releases/latest` and reads the
response with an unbounded `await response.json()` call. GitHub release objects
include a `body` field containing the full changelog text plus an `assets[]`
array; a misbehaving or slow endpoint can return an arbitrarily large payload
that is buffered entirely into memory.

The error path already guarded against a bad HTTP status (`!response.ok`), but
the success path had no size limit — a textbook asymmetric-bounding gap.

## Why This Change Was Made

Replace the bare `response.json()` with `readProviderJsonResponse`, which
enforces a 16 MiB cap, cancels the underlying stream on overflow, and surfaces a
consistent labelled error (`signal.release-info: …`). The existing inner
`try/catch` continues to convert any parse or overflow error into the friendly
`{ ok: false, error: "Failed to parse signal-cli release info." }` result,
preserving the caller's graceful-degradation path.

## User Impact

An operator cannot cause the Signal plugin setup to OOM the process by returning
an oversized release-info JSON body (whether from a misconfigured proxy or a
slow/malformed GitHub response).

## Evidence

**Proof script** (`scripts/proof-signal-release-info-bound.mjs`) — 4 assertions:

```
[case 1] signal.release-info oversized, ReadableStream, cap=1 MiB
  ok: rejected on oversized release-info body — true
  ok: bounded error message present (got: Content too large: 2097152 bytes (limit: 1048576 bytes)) — true
  ok: stream cancelled before all 20 chunks (readCount=2) — true
  ok: cancel() was called — true

[case 2] negative control — raw response.json() does NOT cancel
  ok: unbounded .json() drained all 20 chunks (readCount=20) — true
  ok: stream NOT cancelled — drained to EOF — true

[case 3] signal.release-info oversized, node:http, bytes-on-wire
  ok: rejected on oversized release-info body (node:http) — true
  ok: bounded error message present (got: Content too large: 1113792 bytes (limit: 1048576 bytes)) — true

[case 4] small GitHub release JSON parses cleanly
  ok: small release JSON parsed into result — true
  ok: tag_name intact in parsed result — true

ALL PROOF ASSERTIONS PASSED
```

**Unit tests** (`extensions/signal/src/install-signal-cli.test.ts`) — 29/29
pass, including new regression:

```
✓ installSignalCliFromRelease > bounds oversized GitHub release metadata and cancels the stream
✓ installSignalCliFromRelease > returns an installer error when GitHub release metadata is malformed JSON
✓ installSignalCliFromRelease > bounds the release metadata request with an explicit timeout
```
