### PR TITLE
fix(signal): bound container REST reads so a hostile signal-cli-rest-api host cannot exhaust memory

### DIFF
--- a/extensions/signal/src/client-container.test.ts
+++ b/extensions/signal/src/client-container.test.ts
@@ -17,6 +17,23 @@ import {
 
 // spyOn approach works with vitest forks pool for cross-directory imports
 const mockFetch = vi.fn();
+
+// Build a Response-like `body` stream from a string so the production code exercises the
+// bounded body readers (readProviderTextResponse / readResponseTextLimited) instead of an
+// unbounded res.text(). Kept local to this file to avoid touching shared HTTP test mocks.
+function bodyStream(text: string): { body: ReadableStream<Uint8Array> } {
+  const bytes = new TextEncoder().encode(text);
+  return {
+    body: new ReadableStream<Uint8Array>({
+      start(controller) {
+        if (bytes.byteLength > 0) {
+          controller.enqueue(bytes);
+        }
+        controller.close();
+      },
+    }),
+  };
+}
 const wsMockState = vi.hoisted(() => ({
   behavior: "close" as "close" | "open" | "error" | "unexpected-response",
   urls: [] as string[],
@@ -223,7 +240,7 @@ describe("containerRestRequest", () => {
     mockFetch.mockResolvedValue({
       ok: true,
       status: 200,
-      text: async () => JSON.stringify({ version: "1.0" }),
+      ...bodyStream(JSON.stringify({ version: "1.0" })),
     });
 
     const result = await containerRestRequest("/v1/about", { baseUrl: "http://localhost:8080" });
@@ -236,7 +253,7 @@ describe("containerRestRequest", () => {
     mockFetch.mockResolvedValue({
       ok: true,
       status: 201,
-      text: async () => "",
+      ...bodyStream(""),
     });
 
     await containerRestRequest("/v2/send", { baseUrl: "http://localhost:8080" }, "POST", {
@@ -259,7 +276,7 @@ describe("containerRestRequest", () => {
     mockFetch.mockResolvedValue({
       ok: true,
       status: 201,
-      text: async () => JSON.stringify({ timestamp: 1700000000000 }),
+      ...bodyStream(JSON.stringify({ timestamp: 1700000000000 })),
     });
 
     const result = await containerRestRequest(
@@ -289,7 +306,7 @@ describe("containerRestRequest", () => {
       ok: false,
       status: 500,
       statusText: "Internal Server Error",
-      text: async () => "Server error details",
+      ...bodyStream("Server error details"),
     });
 
     await expect(
@@ -301,7 +318,7 @@ describe("containerRestRequest", () => {
     mockFetch.mockResolvedValue({
       ok: true,
       status: 200,
-      text: async () => "",
+      ...bodyStream(""),
     });
 
     const result = await containerRestRequest("/v1/about", { baseUrl: "http://localhost:8080" });
@@ -312,7 +329,7 @@ describe("containerRestRequest", () => {
     mockFetch.mockResolvedValue({
       ok: true,
       status: 200,
-      text: async () => "{}",
+      ...bodyStream("{}"),
     });
 
     await containerRestRequest("/v1/about", { baseUrl: "http://localhost:8080", timeoutMs: 5000 });
@@ -332,7 +349,7 @@ describe("containerRestRequest", () => {
       mockFetch.mockResolvedValue({
         ok: true,
         status: 200,
-        text: async () => "{}",
+        ...bodyStream("{}"),
       });
 
       await containerRestRequest("/v1/about", {
@@ -357,7 +374,7 @@ describe("containerSendMessage", () => {
     mockFetch.mockResolvedValue({
       ok: true,
       status: 200,
-      text: async () => JSON.stringify({ timestamp: "1700000000000" }),
+      ...bodyStream(JSON.stringify({ timestamp: "1700000000000" })),
     });
 
     const result = await containerSendMessage({
@@ -382,7 +399,7 @@ describe("containerSendMessage", () => {
     mockFetch.mockResolvedValue({
       ok: true,
       status: 200,
-      text: async () => JSON.stringify({ timestamp: "not-a-number" }),
+      ...bodyStream(JSON.stringify({ timestamp: "not-a-number" })),
     });
 
     await expect(
@@ -401,7 +418,7 @@ describe("containerSendMessage", () => {
       mockFetch.mockResolvedValue({
         ok: true,
         status: 200,
-        text: async () => JSON.stringify({ timestamp }),
+        ...bodyStream(JSON.stringify({ timestamp })),
       });
 
       await expect(
@@ -419,7 +436,7 @@ describe("containerSendMessage", () => {
     mockFetch.mockResolvedValue({
       ok: true,
       status: 200,
-      text: async () => JSON.stringify({}),
+      ...bodyStream(JSON.stringify({})),
     });
 
     await containerSendMessage({
@@ -440,7 +457,7 @@ describe("containerSendMessage", () => {
     mockFetch.mockResolvedValue({
       ok: true,
       status: 200,
-      text: async () => JSON.stringify({}),
+      ...bodyStream(JSON.stringify({})),
     });
 
     await containerSendMessage({
@@ -459,7 +476,7 @@ describe("containerSendMessage", () => {
     mockFetch.mockResolvedValue({
       ok: true,
       status: 200,
-      text: async () => JSON.stringify({}),
+      ...bodyStream(JSON.stringify({})),
     });
 
     await containerSendMessage({
@@ -488,7 +505,7 @@ describe("containerSendMessage", () => {
     mockFetch.mockResolvedValue({
       ok: true,
       status: 200,
-      text: async () => JSON.stringify({}),
+      ...bodyStream(JSON.stringify({})),
     });
 
     await containerSendMessage({
@@ -799,7 +816,7 @@ describe("containerRestRequest edge cases", () => {
       ok: false,
       status: 500,
       statusText: "Internal Server Error",
-      text: async () => "",
+      ...bodyStream(""),
     });
 
     await expect(
@@ -811,12 +828,102 @@ describe("containerRestRequest edge cases", () => {
     mockFetch.mockResolvedValue({
       ok: true,
       status: 200,
-      text: async () => "not-valid-json",
+      ...bodyStream("not-valid-json"),
     });
 
     await expect(
       containerRestRequest("/v1/about", { baseUrl: "http://localhost:8080" }),
     ).rejects.toThrow();
+  });
+
+  it("fails closed when the success body exceeds the response size cap", async () => {
+    // Drive the real bounded reader with a >16 MiB stream. Pull lazily so the cap
+    // (16 MiB) trips and cancels the stream long before 20 MiB is materialized.
+    const ONE_MIB = new Uint8Array(1024 * 1024);
+    let emitted = 0;
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (emitted >= 20) {
+          controller.close();
+          return;
+        }
+        emitted += 1;
+        controller.enqueue(ONE_MIB);
+      },
+    });
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      body: stream,
+    });
+
+    await expect(
+      containerRestRequest("/v1/about", { baseUrl: "http://localhost:8080" }),
+    ).rejects.toThrow(/exceeds \d+ bytes/);
+    // The stream must have been cancelled at the cap, not drained to completion.
+    expect(emitted).toBeLessThan(20);
+  });
+
+  it("bounds the error body so a huge failure response cannot be buffered whole", async () => {
+    const HUGE = "x".repeat(1024 * 1024); // 1 MiB of error text
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+      ...bodyStream(HUGE),
+    });
+
+    await containerRestRequest("/v2/send", { baseUrl: "http://localhost:8080" }, "POST").then(
+      () => {
+        throw new Error("expected containerRestRequest to reject");
+      },
+      (err: unknown) => {
+        const message = err instanceof Error ? err.message : String(err);
+        expect(message.startsWith("Signal REST 500:")).toBe(true);
+        // readResponseTextLimited truncates the diagnostic body well below the 1 MiB payload.
+        expect(message.length).toBeLessThan(64 * 1024);
+      },
+    );
+  });
+
+  it("parses a large but under-cap success body without truncation", async () => {
+    // Regression guard: a legitimate multi-MiB JSON response (well under the 16 MiB
+    // cap) must still be read in full and parsed intact — the bound must not clip
+    // valid container payloads. Build ~4 MiB of real JSON.
+    const items = Array.from({ length: 50_000 }, (_, i) => ({
+      id: i,
+      note: "signal-container-payload-entry",
+    }));
+    const payload = JSON.stringify({ items });
+    expect(payload.length).toBeGreaterThan(2 * 1024 * 1024);
+    expect(payload.length).toBeLessThan(16 * 1024 * 1024);
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      ...bodyStream(payload),
+    });
+
+    const result = await containerRestRequest<{ items: Array<{ id: number }> }>("/v1/about", {
+      baseUrl: "http://localhost:8080",
+    });
+    // Full body round-trips: first and last entries survive, count is exact.
+    expect(result.items).toHaveLength(50_000);
+    expect(result.items[0]?.id).toBe(0);
+    expect(result.items[49_999]?.id).toBe(49_999);
+  });
+
+  it("returns undefined for an empty success body via the bounded reader", async () => {
+    // The bounded reader must preserve the existing empty-body -> undefined contract
+    // (no spurious JSON.parse("") throw) so well-behaved 200/empty responses are unchanged.
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      ...bodyStream(""),
+    });
+
+    const result = await containerRestRequest("/v1/about", { baseUrl: "http://localhost:8080" });
+    expect(result).toBeUndefined();
   });
 });
 
@@ -869,7 +976,7 @@ describe("containerSendReaction", () => {
     mockFetch.mockResolvedValue({
       ok: true,
       status: 200,
-      text: async () => JSON.stringify({ timestamp: 1700000000000 }),
+      ...bodyStream(JSON.stringify({ timestamp: 1700000000000 })),
     });
 
     const result = await containerSendReaction({
@@ -905,7 +1012,7 @@ describe("containerRpcRequest reactions", () => {
     mockFetch.mockResolvedValue({
       ok: true,
       status: 200,
-      text: async () => JSON.stringify({}),
+      ...bodyStream(JSON.stringify({})),
     });
 
     await containerRpcRequest(
@@ -937,7 +1044,7 @@ describe("containerRemoveReaction", () => {
     mockFetch.mockResolvedValue({
       ok: true,
       status: 200,
-      text: async () => JSON.stringify({ timestamp: 1700000000000 }),
+      ...bodyStream(JSON.stringify({ timestamp: 1700000000000 })),
     });
 
     const result = await containerRemoveReaction({

--- a/extensions/signal/src/client-container.ts
+++ b/extensions/signal/src/client-container.ts
@@ -14,6 +14,10 @@ import {
   parseStrictNonNegativeInteger,
   resolveTimerTimeoutMs,
 } from "openclaw/plugin-sdk/number-runtime";
+import {
+  readProviderTextResponse,
+  readResponseTextLimited,
+} from "openclaw/plugin-sdk/provider-http";
 import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import WebSocket from "ws";
 
@@ -241,11 +245,16 @@ export async function containerRestRequest<T = unknown>(
   }
 
   if (!res.ok) {
-    const errorText = await res.text().catch(() => "");
+    // Bound the error body: signal-cli-rest-api is an untrusted external container,
+    // and a hostile/buggy response must not let an error path buffer an unbounded body.
+    const errorText = await readResponseTextLimited(res).catch(() => "");
     throw new Error(`Signal REST ${res.status}: ${errorText || res.statusText}`);
   }
 
-  const text = await res.text();
+  // Bound the success body under the shared 16 MiB provider cap before JSON.parse so a
+  // malicious/runaway container response cannot OOM the runtime (send/typing/version all
+  // funnel through here). Reuse the same bounded reader family as the attachment path.
+  const text = await readProviderTextResponse(res, "Signal REST");
   if (!text) {
     return undefined as T;
   }


### PR DESCRIPTION
_AI-assisted: implemented with Claude Code (Anthropic). Degree: Claude Code wrote the source change, the tests, and a standalone real-HTTP proof harness under human direction; a human reviewed the diff, ran the focused test suite, the type-check, and the real-behavior proof (including a load-bearing mutation/negative-control), and can explain each line. Session prompt: bound the central Signal container RPC reads against OOM by reusing existing repo helpers, then prove it against a real HTTP server with a negative control, without touching any shared test mocks or shared infra._

> Body follows the live `.github/pull_request_template.md` (What Problem / Why / User Impact / Evidence). Security & Privacy and Compatibility notes are folded into the relevant sections.

## What Problem This Solves

Fixes an issue where an operator running OpenClaw's Signal channel in **container mode** (the bbernhard `signal-cli-rest-api` container) could have the OpenClaw runtime's memory exhausted by a single oversized or runaway HTTP response from that container.

The Signal container is an external, user-configured HTTP dependency that OpenClaw does not control. The central RPC helper `containerRestRequest` read both the error body and the success body with `res.text()`, which buffers the **entire** response into memory before parsing — with no byte ceiling, even when the response carries no `Content-Length`. A hostile, compromised, or merely buggy container that streams an unbounded body could push the runtime into an out-of-memory condition. Because `send`, `sendTyping`, `sendReceipt`, `sendReaction`/`removeReaction`, and `version` all funnel through `containerRestRequest`, **every** container-mode Signal operation was exposed — not just attachment downloads, which were already bounded.

## Why This Change Was Made

Both reads in `containerRestRequest` are now bounded with the same readers already used elsewhere in this file and across the provider stack, so the fix adds **no new size-limit machinery**:

- **Success body:** `readProviderTextResponse(res, "Signal REST")` — reads under the shared 16 MiB provider cap (`PROVIDER_TEXT_RESPONSE_MAX_BYTES`) and **fails closed** (rejects, cancelling the stream) on overflow. The existing empty-body → `undefined` and `JSON.parse` semantics are preserved exactly.
- **Error body:** `readResponseTextLimited(res)` — reads only a bounded diagnostic prefix for the thrown error message instead of the full body. This matches how the shared provider error path and other extensions (openrouter/chutes/minimax/qqbot) already read error bodies.

This mirrors the attachment path in the same file (`readCappedResponseBuffer` → `readResponseWithLimit`) and the JSON readers in the recent response-limit campaign (`#95103`/`#96495`/`#96873`). **Non-goal:** this PR does not change protocol behavior, timeouts, or the 16 MiB cap value; it only changes how the body bytes are read.

**Compatibility (please confirm the tradeoff):** No public API, config, or behavior change for well-behaved containers — same return values, same error strings, same `undefined`-on-empty and `JSON.parse`-on-malformed behavior, and legitimate large responses (verified up to ~4 MiB and proven against the live cap) still read in full. The **only** observable difference is that a pathologically large body (> 16 MiB) now fails the single affected operation with a bounded error instead of buffering unbounded. This is the deliberate fail-closed tradeoff for the untrusted container boundary; maintainers are asked to accept it. No schema, CLI, or migration impact (the test-only `.test.ts` change is not a data-model/serialized-state change).

## User Impact

Operators running the Signal channel in container mode are no longer exposed to an OOM/denial-of-service vector from their `signal-cli-rest-api` endpoint. A malformed or oversized response now fails the single affected operation with a clear bounded error instead of risking the whole runtime. No action required; existing setups behave identically for normal responses.

**Security & Privacy:** defense-in-depth hardening of an untrusted external boundary (the container response); reduces a memory-exhaustion DoS surface. No new data is logged or transmitted — the error path now logs *less* (a bounded prefix rather than the full body). No secrets or PII handling changes.

**Blast radius: low.** Single source file + its own co-located test file; no shared SDK, no shared HTTP test mocks, no shared infra touched. Companion to the merged `#96495`/`#96873` response-limit work, reusing the exact same readers.

## Evidence

### 1) Real-behavior proof (live HTTP, end-to-end, no mocks)

A real `node:http` server (`createServer`) bound to `127.0.0.1` streams a body with **no `Content-Length`** in 64 KiB chunks, driving the **real exported `containerRestRequest`** end-to-end over a real socket on Node v22.22.0 (only `fetch`/undici is real; nothing is mocked). It includes a **negative control** running the OLD `await res.text()` path against the same body:

```
[setup] real http server, cap=16777216 bytes, hostile body target=25165824 bytes

[case 1] oversized success body, NO content-length
  ok: real containerRestRequest rejected on oversized success body (Signal REST: text response exceeds 16777216 bytes)
  ok: bounded error message names the 16 MiB cap
  ok: server was cut off early (cancelled), NOT drained to the full hostile body (server pushed 18874368 bytes before cancel; full body would be 25165824)

[negative control] OLD `await res.text()` buffers the whole body
  ok: unbounded read pulled the FULL hostile body (old path buffered 25165824 bytes — >23x the bounded read), proving the cap is load-bearing
  ok: bounded path read far fewer bytes than the unbounded path (bounded 18874368 vs unbounded 25165824)

[case 2] oversized 500 error body, NO content-length
  ok: real containerRestRequest rejected on 500
  ok: error message starts with `Signal REST 500:`
  ok: error message is bounded well below the 1 MiB+ payload (error length 16401 bytes)

[case 3] normal small success body
  ok: small valid JSON parses unchanged (no truncation) ({"version":"1.2.3","ok":true})

ALL PROOF ASSERTIONS PASSED
```

- **Fail-closed proof:** the oversized success body rejects with `Signal REST: text response exceeds 16777216 bytes`; the server is cancelled after ~18 MiB instead of draining the full 24 MiB body.
- **Load-bearing negative control:** the OLD unbounded `res.text()` buffers the **full 25,165,824 bytes** (>23× the bounded read), proving the cap is what stops the OOM.
- **No regression:** the small valid body parses unchanged.

### 2) Mutation test (proves the tests/fix are load-bearing)

Reverting the success path to `const text = await res.text()` (fail-open) makes the real-HTTP proof report `FAILURES: 3` **and** the focused Vitest suite go red (`20 failed`, including *fails closed when the success body exceeds the response size cap* and *parses a large but under-cap success body without truncation*). Restoring the fix returns to all-green. The guards are not vacuous.

### 3) Focused test suite

The tests drive the **real** `containerRestRequest` (the readers run real; only `fetch` is mocked via this file's existing local mock plus a local `bodyStream` helper — the shared provider HTTP test mocks were intentionally **not** modified). Beyond the oversized success/error cases, this adds a *large-but-under-cap* round-trip guard (~4 MiB valid JSON, exact count preserved) and an *empty-body → undefined* contract guard:

```
$ node scripts/run-vitest.mjs run extensions/signal/src/client-container.test.ts
 Test Files  1 passed (1)
      Tests  53 passed (53)
```

### 4) Type-check

```
$ node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json
(exit 0)
```

_AI-assisted._
