### PR TITLE
fix(zai): bound Z.AI endpoint-probe error body reads to prevent OOM

### DIFF
--- a/extensions/zai/detect.test.ts
+++ b/extensions/zai/detect.test.ts
@@ -1,9 +1,76 @@
 // Zai tests cover detect plugin behavior.
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
+import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { detectZaiEndpoint } from "./detect.js";
 
 type FetchResponse = { status: number; body?: unknown };
+
+const ZAI_DETECT_ERROR_BODY_MAX_BYTES = 16 * 1024 * 1024;
+
+/**
+ * Builds a streaming error Response whose body is far larger than the 16 MiB cap.
+ * Tracks how many bytes were actually pulled and whether the consumer cancelled
+ * the stream, so tests can prove the read is bounded (fail-closed) rather than
+ * draining the whole untrusted body into memory.
+ */
+function makeOversizedStreamFetch(params: {
+  url: string;
+  status: number;
+  chunkBytes?: number;
+  hardCeilingBytes?: number;
+}) {
+  const chunkBytes = params.chunkBytes ?? 1024 * 1024;
+  const hardCeilingBytes = params.hardCeilingBytes ?? 64 * 1024 * 1024;
+  const state = { enqueuedBytes: 0, cancelled: false };
+
+  const fetchFn = (async (url: string) => {
+    if (url !== params.url) {
+      throw new Error(`unexpected url: ${url}`);
+    }
+    const body = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (state.enqueuedBytes >= hardCeilingBytes) {
+          // Safety stop: with an unbounded reader this point would be reached
+          // (and the test would fail on the bounded-bytes assertion below).
+          controller.close();
+          return;
+        }
+        state.enqueuedBytes += chunkBytes;
+        controller.enqueue(new Uint8Array(chunkBytes));
+      },
+      cancel() {
+        state.cancelled = true;
+      },
+    });
+    return new Response(body, {
+      status: params.status,
+      headers: { "content-type": "application/json" },
+    });
+  }) as typeof fetch;
+
+  return { fetchFn, state };
+}
+
+/**
+ * Builds a fetch returning a single raw (possibly non-JSON) error body, keyed by
+ * `${url}::${model}`. Used to drive the new bounded decode path with small,
+ * well-formed, empty, and malformed sub-cap bodies that must behave exactly as
+ * the previous `res.json()` path did.
+ */
+function makeRawBodyFetch(map: Record<string, { status: number; raw: string }>) {
+  return (async (url: string, init?: RequestInit) => {
+    const rawBody = typeof init?.body === "string" ? JSON.parse(init.body) : null;
+    const entry = map[`${url}::${rawBody?.model ?? ""}`] ?? map[url];
+    if (!entry) {
+      throw new Error(`unexpected url: ${url} model=${String(rawBody?.model ?? "")}`);
+    }
+    return new Response(entry.raw, {
+      status: entry.status,
+      headers: { "content-type": "application/json" },
+    });
+  }) as typeof fetch;
+}
 
 function makeFetch(map: Record<string, FetchResponse>) {
   return (async (url: string, init?: RequestInit) => {
@@ -183,5 +250,89 @@ describe("detectZaiEndpoint", () => {
     });
 
     expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
+  });
+
+  it("still parses well-formed sub-cap error bodies to drive endpoint classification", async () => {
+    // Happy path: model-not-found errors must still be decoded from the bounded
+    // body so the probe classifies them as unsupported and walks to the GLM-4.7
+    // fallback. The error message that drives classification lives only inside
+    // the body, so a passing fallback proves the new bounded reader decoded it.
+    const codingGlobal = "https://api.z.ai/api/coding/paas/v4/chat/completions";
+    const detected = await detectZaiEndpoint({
+      apiKey: "sk-test", // pragma: allowlist secret
+      endpoint: "coding-global",
+      fetchFn: makeRawBodyFetch({
+        [`${codingGlobal}::glm-5.2`]: {
+          status: 400,
+          raw: JSON.stringify({ error: { message: "model not found for this plan" } }),
+        },
+        [`${codingGlobal}::glm-5.1`]: {
+          status: 400,
+          raw: JSON.stringify({ code: 1211, msg: "model does not exist" }),
+        },
+        [`${codingGlobal}::glm-4.7`]: { status: 200, raw: "{}" },
+      }),
+    });
+
+    expect(detected?.endpoint).toBe("coding-global");
+    expect(detected?.modelId).toBe("glm-4.7");
+  });
+
+  it("swallows malformed and empty sub-cap error bodies and falls back on status", async () => {
+    // Regression: a non-JSON or empty error body must not throw out of the
+    // probe. JSON.parse fails, the existing try/catch swallows it, and the
+    // probe degrades to status-only classification (404 => unsupported model),
+    // so the GLM-4.7 fallback still resolves exactly as before.
+    const codingGlobal = "https://api.z.ai/api/coding/paas/v4/chat/completions";
+    const detected = await detectZaiEndpoint({
+      apiKey: "sk-test", // pragma: allowlist secret
+      endpoint: "coding-global",
+      fetchFn: makeRawBodyFetch({
+        [`${codingGlobal}::glm-5.2`]: { status: 404, raw: "<html>gateway error</html>" },
+        [`${codingGlobal}::glm-5.1`]: { status: 404, raw: "" },
+        [`${codingGlobal}::glm-4.7`]: { status: 200, raw: "{}" },
+      }),
+    });
+
+    expect(detected?.endpoint).toBe("coding-global");
+    expect(detected?.modelId).toBe("glm-4.7");
+  });
+
+  it("fails closed on oversized probe error bodies without buffering unbounded", async () => {
+    const { fetchFn, state } = makeOversizedStreamFetch({
+      url: "https://api.z.ai/api/paas/v4/chat/completions",
+      status: 400,
+    });
+
+    const detected = await detectZaiEndpoint({
+      apiKey: "sk-test", // pragma: allowlist secret
+      endpoint: "global",
+      fetchFn,
+    });
+
+    // Probe swallows the bounded-read overflow and falls back to status-only,
+    // so the oversized error body cannot promote this endpoint.
+    expect(detected).toBeNull();
+    // The stream was cancelled (fail-closed) instead of being drained to the
+    // 64 MiB safety ceiling, proving the read stops near the 16 MiB cap.
+    expect(state.cancelled).toBe(true);
+    expect(state.enqueuedBytes).toBeLessThanOrEqual(
+      ZAI_DETECT_ERROR_BODY_MAX_BYTES + 2 * 1024 * 1024,
+    );
+  });
+
+  it("rejects oversized bodies via the shared bounded reader the probe uses", async () => {
+    const { fetchFn } = makeOversizedStreamFetch({
+      url: "https://api.z.ai/api/paas/v4/chat/completions",
+      status: 400,
+    });
+    const res = await fetchFn("https://api.z.ai/api/paas/v4/chat/completions");
+
+    await expect(
+      readResponseWithLimit(res, ZAI_DETECT_ERROR_BODY_MAX_BYTES, {
+        onOverflow: ({ maxBytes }) =>
+          new Error(`Z.AI probe error body exceeded size limit (${maxBytes} bytes)`),
+      }),
+    ).rejects.toThrow(/exceeded size limit/);
   });
 });

--- a/extensions/zai/detect.ts
+++ b/extensions/zai/detect.ts
@@ -1,5 +1,6 @@
 // Zai plugin module implements detect behavior.
 import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
+import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import {
   ZAI_CN_BASE_URL,
   ZAI_CODING_CN_BASE_URL,
@@ -35,6 +36,9 @@ type ProbeCandidate = ZaiDetectedEndpoint & {
 };
 
 const UNSUPPORTED_MODEL_ERROR_CODES = new Set(["1211", "1311"]);
+
+/** Cap for the Z.AI probe error body; bounds untrusted error responses to avoid unbounded buffering/OOM. */
+const ZAI_DETECT_ERROR_BODY_MAX_BYTES = 16 * 1024 * 1024;
 
 function isUnsupportedModelResult(result: ProbeResult): boolean {
   if (result.ok) {
@@ -106,7 +110,11 @@ async function probeZaiChatCompletions(params: {
     let errorCode: string | undefined;
     let errorMessage: string | undefined;
     try {
-      const json = (await res.json()) as {
+      const bytes = await readResponseWithLimit(res, ZAI_DETECT_ERROR_BODY_MAX_BYTES, {
+        onOverflow: ({ maxBytes }) =>
+          new Error(`Z.AI probe error body exceeded size limit (${maxBytes} bytes)`),
+      });
+      const json = JSON.parse(new TextDecoder().decode(bytes)) as {
         error?: { code?: unknown; message?: unknown };
         code?: unknown;
         msg?: unknown;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users configuring the Z.AI provider could exhaust host memory during endpoint auto-detection. When onboarding a Z.AI key, OpenClaw probes which Z.AI base URL and model the key can reach by POSTing to `/chat/completions` and reading the error body of any non-2xx response. A misbehaving, compromised, or hostile endpoint (including a self-hosted `baseUrl` override) can stream an arbitrarily large or never-ending error body, and the probe would buffer the **entire** body into memory before parsing — risking an out-of-memory crash of the OpenClaw host during a routine setup/detection step.

## Why This Change Was Made

The error path in `probeZaiChatCompletions` (`extensions/zai/detect.ts`) used an unbounded `await res.json()` to extract `error.code` / `error.message`. This change reads the body through the shared `readResponseWithLimit` helper (`openclaw/plugin-sdk/response-limit-runtime`) with a 16 MiB fail-closed cap, then `JSON.parse`s the decoded prefix. On overflow the helper cancels the stream and throws; the pre-existing `try/catch` ("ignore malformed error bodies") swallows it and the probe degrades to its existing status-only fallback. This reuses the same bounded-read pattern already merged across providers (image-generation #96495, openrouter video #96873, exa, qqbot media) rather than introducing a new mechanism. Non-goal: detection results and error classification for well-formed responses are unchanged.

## User Impact

Users running Z.AI provider detection/onboarding are protected from OOM caused by oversized error responses: the probe reads at most 16 MiB of an error body and fails closed (graceful status-only fallback) instead of buffering unbounded. For every normal/well-formed response, behavior is identical — same detected endpoint, model, and error-code classification. Blast radius is low: one provider file plus its self-contained test; no shared infra, mocks, config, schema, or public API touched.

## Real behavior proof

- **Behavior addressed**: an untrusted Z.AI probe error response with no `Content-Length` and an oversized/never-ending body must not be buffered whole; the read must stop near the cap, cancel the stream, and let the probe fall back — while valid small bodies still decode and classify unchanged.
- **Real environment tested**: a real `node:http` server (`createServer`) bound to `127.0.0.1`, streaming a 400 JSON body in 64 KiB chunks with **no Content-Length** up to a ~24 MiB ceiling, driving the **real exported** `detectZaiEndpoint` over a real socket (a URL-rewriting `fetchFn` points the probe at the local server) and the **real** `readResponseWithLimit` the probe wraps. Node v22.22.0.
- **Evidence after fix**:
  - Probe returns `null` (status-only fallback — the oversized body cannot promote the endpoint); the server observed the client **close the socket early** (stream cancelled); only **18,612,246 bytes** reached the wire vs the **25,165,824-byte** body — cancelled early, not drained.
  - `readResponseWithLimit(res, 16 MiB)` threw `Z.AI probe error body exceeded size limit (16777216 bytes)` and stopped at **18,481,174 bytes** (well below the full body).
  - **Negative control**: the OLD unbounded `await res.json()` against the same stream pulled the **full 25,165,846 bytes**, proving the cap is load-bearing.
  - Small well-formed bodies still decode: a `model not found` error drives the GLM-4.7 fallback (endpoint `coding-global`, model `glm-4.7`) — classification unchanged.

```
[case 1] REAL detectZaiEndpoint vs oversized streaming 400 (no Content-Length)
  ok: probe returns null (status-only fallback, body cannot promote) — detected=null
  ok: server saw client close the socket early (stream cancelled) — clientClosedEarly=true
  ok: bytes on wire stayed below the full ~24 MiB body (stream cancelled early) — bytesSent=18612246 (cap=16777216, ceiling=25165824)
[negative control] OLD `await res.json()` buffers the whole body
  ok: unbounded read pulled the FULL ~24 MiB body (proving the cap is load-bearing) — drained=25165846 >= ceiling=25165824
[case 2] REAL readResponseWithLimit(cap=16 MiB) rejects oversized body
  ok: readResponseWithLimit threw on overflow — message=Z.AI probe error body exceeded size limit (16777216 bytes)
  ok: stream cancelled early (below full body), not drained to ceiling — bytesSent=18481174 (ceiling=25165824)
[case 3] REAL detectZaiEndpoint classifies small well-formed error bodies
  ok: model-not-found errors decode + drive GLM-4.7 fallback (endpoint) — endpoint=coding-global
  ok: fallback model resolved from decoded body classification — modelId=glm-4.7

ALL PROOF ASSERTIONS PASSED
```

- **Mutation / load-bearing control**: temporarily reverting the fix to the old fail-open `await res.json()` makes the oversized test fail (`AssertionError: expected false to be true` — stream not cancelled, body drained to the 64 MiB ceiling); restoring the real fix returns all 6 green. The new test genuinely guards the bound.
- **What was not tested**: no live Z.AI endpoint was hit (no key would reproduce a hostile oversized body). The 64-bit OOM end-state was not driven to crash; the proof measures bytes-on-wire + early socket close + a negative control, which is the load-bearing signal.

## Evidence

Focused tests (local mocks only; the shared `provider-http-test-mocks.ts` is intentionally untouched to avoid cross-test blast radius):

```
$ node scripts/run-vitest.mjs run --reporter=verbose \
    --config test/vitest/vitest.extension-providers.config.ts \
    extensions/zai/detect.test.ts

 ✓ detectZaiEndpoint > resolves preferred/fallback endpoints and null when probes fail
 ✓ detectZaiEndpoint > caps oversized probe timeouts before scheduling
 ✓ detectZaiEndpoint > still parses well-formed sub-cap error bodies to drive endpoint classification
 ✓ detectZaiEndpoint > swallows malformed and empty sub-cap error bodies and falls back on status
 ✓ detectZaiEndpoint > fails closed on oversized probe error bodies without buffering unbounded
 ✓ detectZaiEndpoint > rejects oversized bodies via the shared bounded reader the probe uses

 Test Files  1 passed (1)
      Tests  6 passed (6)
```

The two oversized tests drive the **real** `detectZaiEndpoint` (and the real `readResponseWithLimit`) with a `ReadableStream` instrumented to record bytes pulled and stream cancellation; the happy-path and malformed/empty tests prove well-formed and small malformed bodies behave exactly as before. `oxfmt --check` clean and `oxlint` clean on both changed files.

**Label**: security

_AI-assisted:_ implemented with **Claude Code** (Anthropic). Scope of assistance: diagnosing the unbounded-read defect, locating the existing `readResponseWithLimit` convention, the code edit, authoring the focused tests + the oversized-stream mock, building the real `node:http` proof harness with negative + mutation controls, and running local validation (vitest + oxfmt + oxlint). All changes were reviewed by a human before submission.
