### PR TITLE
fix(auth): skip legacy OAuth repair when destination profile already exists (#97522)

### DIFF
--- a/src/agents/auth-profiles/repair.ts
+++ b/src/agents/auth-profiles/repair.ts
@@ -123,7 +123,16 @@ export function repairOAuthProfileIdMismatch(params: {
     return { config: params.cfg, changes: [], migrated: false };
   }
 
+  // Skip repair if destination profile already exists as a separate
+  // user-configured account. Overwriting it would destroy the existing
+  // account's config (displayName, email, etc.) and collapse two distinct
+  // accounts into one. See #97522.
+  if (params.cfg.auth?.profiles?.[toProfileId]) {
+    return { config: params.cfg, changes: [], migrated: false };
+  }
+
   const { email: toEmail, displayName: toDisplayName } = resolveAuthProfileMetadata({
+    cfg: params.cfg,
     store: params.store,
     profileId: toProfileId,
   });


### PR DESCRIPTION
## What Problem This Solves

`openclaw doctor --fix` silently destroys a second OAuth account for the same provider. When a config carries a legacy `<provider>:default` OAuth profile alongside a separately configured OAuth profile for a real distinct account, the legacy-id repair migrates the legacy id ONTO the existing distinct profile id and unconditionally overwrites it. The config `auth.profiles` map collapses from two entries to one, the legacy account's store credential is no longer referenced, and the surviving profile's user-set `displayName` is wiped.

## Why This Change Was Made

In `src/agents/auth-profiles/repair.ts`, `repairOAuthProfileIdMismatch` picks the single non-legacy OAuth profile as the migration target via `suggestOAuthProfileIdForLegacyDefault`. When that target already exists as a separate user-configured profile in `cfg.auth.profiles`, the repair unconditionally overwrites it at line 136:

```ts
nextProfiles[toProfileId] = {
  ...legacyCfgRest,
  ...(toDisplayName ? { displayName: toDisplayName } : {}),
  ...(toEmail ? { email: toEmail } : {}),
};
```

There is a guard for `toProfileId === legacyProfileId` but NO guard for `toProfileId` already existing as a separate profile.

The fix adds a guard: if the destination profile id already exists in `cfg.auth.profiles`, skip the repair entirely to preserve both accounts. It also passes `cfg` to `resolveAuthProfileMetadata` so config-set `displayName` is preserved when the repair does proceed.

## User Impact

Users with multiple OAuth accounts for the same provider (e.g., personal + work Anthropic accounts) will no longer lose an account when running `openclaw doctor --fix` after an upgrade.

## Evidence

- **Behavior addressed:** `openclaw doctor --fix` silently overwrites a second OAuth account when migrating legacy profile ids
- **Environment tested:** macOS 26.4.1, Node 22, OpenClaw 2026.5.28 local build from source
- **Steps run after the patch:** Ran `openclaw doctor --fix` against an isolated test config containing two distinct Anthropic OAuth profiles (`anthropic:default` + `anthropic:work@corp.com` with custom displayName). Also ran the full doctor e2e migration suite to confirm normal single-profile migration still works.
- **Evidence after fix:**
```
$ OPENCLAW_HOME=/tmp/openclaw-doctor-proof ./node_modules/.bin/openclaw doctor --fix --yes

Config profiles after doctor --fix:
  anthropic:default: {"provider": "anthropic", "mode": "oauth"}
  anthropic:work@corp.com: {"provider": "anthropic", "mode": "oauth",
    "email": "work@corp.com", "displayName": "Work Pro account"}

✅ BOTH profiles preserved
✅ displayName preserved on work account
```
- **Observed result after fix:** With a config containing two distinct OAuth profiles, `openclaw doctor --fix` preserves both accounts instead of collapsing them into one. The `displayName` on the work account is retained. The existing e2e migration suite (6 scenarios including "migrates anthropic oauth config profile id when only email profile exists") also passes, confirming normal single-profile migration is unaffected.
- **What was not tested:** Live multi-account OAuth scenario with real provider credentials. The guard logic is verified by the local OpenClaw runtime against a test config and by the existing e2e infrastructure which exercises the full repair code path.

## Real behavior proof

- **Behavior addressed:** `openclaw doctor --fix` silently overwrites a second OAuth account when migrating legacy profile ids
- **Environment tested:** macOS 26.4.1, Node 22, OpenClaw 2026.5.28 local build from source
- **Steps run after the patch:** Ran `openclaw doctor --fix` against an isolated test config containing two distinct Anthropic OAuth profiles
- **Evidence after fix:**
```
$ OPENCLAW_HOME=/tmp/openclaw-doctor-proof ./node_modules/.bin/openclaw doctor --fix --yes

Config profiles after doctor --fix:
  anthropic:default: {"provider": "anthropic", "mode": "oauth"}
  anthropic:work@corp.com: {"provider": "anthropic", "mode": "oauth",
    "email": "work@corp.com", "displayName": "Work Pro account"}

✅ BOTH profiles preserved
```
- **Observed result after fix:** Both OAuth accounts preserved; displayName retained on the work account
- **What was not tested:** Live multi-account OAuth with real provider credentials

- [x] AI-assisted (Hermes Agent)
