### PR TITLE
fix(telegram): recover stalled ingress spool claims

### DIFF
--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -72,6 +72,7 @@ let isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess: typeof import("./telegr
 let listTelegramSpooledUpdateClaims: typeof import("./telegram-ingress-spool.js").listTelegramSpooledUpdateClaims;
 let listTelegramSpooledUpdates: typeof import("./telegram-ingress-spool.js").listTelegramSpooledUpdates;
 let recoverStaleTelegramSpooledUpdateClaims: typeof import("./telegram-ingress-spool.js").recoverStaleTelegramSpooledUpdateClaims;
+let telegramSpooledUpdateClaimLeaseMs: typeof import("./telegram-ingress-spool.js").TELEGRAM_SPOOLED_UPDATE_CLAIM_LEASE_MS;
 let writeTelegramSpooledUpdate: typeof import("./telegram-ingress-spool.js").writeTelegramSpooledUpdate;
 let createTelegramSpooledReplayDeferredParticipant: typeof import("./bot-processing-outcome.js").createTelegramSpooledReplayDeferredParticipant;
 let TelegramMessageDispatchReplayForgetError: typeof import("./message-dispatch-dedupe.js").TelegramMessageDispatchReplayForgetError;
@@ -476,6 +477,49 @@ async function pendingUpdateIds(spoolDir: string, limit: number | "all" = 100): 
   return (await listTelegramSpooledUpdates({ spoolDir, limit })).map((update) => update.updateId);
 }
 
+async function claimedAtForUpdate(spoolDir: string, updateId: number): Promise<number> {
+  const claim = (await listTelegramSpooledUpdateClaims({ spoolDir })).find(
+    (entry) => entry.updateId === updateId,
+  );
+  if (!claim?.claim) {
+    throw new Error(`Expected claimed spooled update ${updateId}`);
+  }
+  return claim.claim.claimedAt;
+}
+
+function installSpooledClaimRefreshHarness(): {
+  restore: () => void;
+  triggerRefresh: () => void;
+} {
+  let refresh: (() => void) | undefined;
+  const realSetInterval = globalThis.setInterval.bind(globalThis);
+  const setIntervalSpy = vi.spyOn(globalThis, "setInterval").mockImplementation(((
+    handler: Parameters<typeof setInterval>[0],
+    timeout?: number,
+  ) => {
+    if (timeout === pollingSessionTesting.spooledClaimRefreshIntervalMs) {
+      refresh = () => {
+        if (typeof handler === "function") {
+          handler();
+        }
+      };
+      const timer = realSetInterval(() => undefined, 2_147_483_647);
+      timer.unref?.();
+      return timer;
+    }
+    return realSetInterval(handler, timeout);
+  }) as typeof setInterval);
+  return {
+    restore: () => setIntervalSpy.mockRestore(),
+    triggerRefresh: () => {
+      if (!refresh) {
+        throw new Error("Expected spooled claim refresh interval to be registered");
+      }
+      refresh();
+    },
+  };
+}
+
 function normalizeTelegramTestAccountId(spoolDir: string): string {
   const trimmed = path.basename(spoolDir).trim();
   return trimmed ? trimmed.replace(/[^a-z0-9._-]+/gi, "_") : "default";
@@ -632,6 +676,7 @@ describe("TelegramPollingSession", () => {
       listTelegramSpooledUpdateClaims,
       listTelegramSpooledUpdates,
       recoverStaleTelegramSpooledUpdateClaims,
+      TELEGRAM_SPOOLED_UPDATE_CLAIM_LEASE_MS: telegramSpooledUpdateClaimLeaseMs,
       writeTelegramSpooledUpdate,
     } = await import("./telegram-ingress-spool.js"));
     ({ createTelegramSpooledReplayDeferredParticipant } =
@@ -1014,13 +1059,13 @@ describe("TelegramPollingSession", () => {
           const queue = createChannelIngressQueue({ ...options, channelId: "telegram" });
           return {
             ...queue,
-            claim: async (...args: Parameters<typeof queue.claim>) => {
-              if (args[0] === "0000000000000001" && !blockedFirstClaim) {
+            claimNext: async (...args: Parameters<typeof queue.claimNext>) => {
+              if (!blockedFirstClaim) {
                 blockedFirstClaim = true;
                 firstClaimStarted?.();
                 await firstClaimGate;
               }
-              return queue.claim(...args);
+              return queue.claimNext(...args);
             },
           };
         },
@@ -1565,6 +1610,132 @@ describe("TelegramPollingSession", () => {
     });
   });
 
+  it("refreshes active spooled claims while the handler is still running", async () => {
+    const refreshHarness = installSpooledClaimRefreshHarness();
+    await withTempSpool(async (tempDir) => {
+      const abort = new AbortController();
+      const events: string[] = [];
+      let releaseHandler: (() => void) | undefined;
+      const handlerDone = new Promise<void>((resolve) => {
+        releaseHandler = resolve;
+      });
+      await writeSpooledTestUpdates(tempDir, [topicUpdate(42, 10, "long topic 10 turn")]);
+
+      const { runPromise, stopWorker } = startIsolatedIngressSession({
+        abort,
+        spoolDir: tempDir,
+        handleUpdate: async (update) => {
+          events.push(`topic10:${update.update_id}`);
+          await handlerDone;
+        },
+      });
+
+      try {
+        await vi.waitFor(() => expect(events).toEqual(["topic10:42"]));
+        const before = await claimedAtForUpdate(tempDir, 42);
+
+        await new Promise((resolve) => {
+          setTimeout(resolve, 2);
+        });
+        refreshHarness.triggerRefresh();
+        await vi.waitFor(async () =>
+          expect(await claimedAtForUpdate(tempDir, 42)).toBeGreaterThan(before),
+        );
+
+        releaseHandler?.();
+        await vi.waitFor(async () =>
+          expect(await listTelegramSpooledUpdateClaims({ spoolDir: tempDir })).toEqual([]),
+        );
+      } finally {
+        releaseHandler?.();
+        abort.abort();
+        stopWorker();
+        refreshHarness.restore();
+        await runPromise;
+      }
+    });
+  });
+
+  it("stops refreshing a claim when the drain loop is stalled", async () => {
+    vi.useFakeTimers({ now: 1_000 });
+    const refreshHarness = installSpooledClaimRefreshHarness();
+    await withTempSpool(async (tempDir) => {
+      let blockedSecondClaim = false;
+      let releaseSecondClaim: (() => void) | undefined;
+      const secondClaimStarted = new Promise<void>((resolve) => {
+        const gate = new Promise<void>((release) => {
+          releaseSecondClaim = release;
+        });
+        setTelegramRuntime({
+          state: {
+            resolveStateDir: () => tempDir,
+            openChannelIngressQueue: (
+              options?: Omit<Parameters<typeof createChannelIngressQueue>[0], "channelId">,
+            ) => {
+              const queue = createChannelIngressQueue({ ...options, channelId: "telegram" });
+              return {
+                ...queue,
+                claimNext: async (...args: Parameters<typeof queue.claimNext>) => {
+                  const claimOptions = args[0];
+                  const blockedLaneKeys = claimOptions?.blockedLaneKeys
+                    ? Array.from(claimOptions.blockedLaneKeys)
+                    : [];
+                  const candidateIds = claimOptions?.candidateIds
+                    ? Array.from(claimOptions.candidateIds)
+                    : [];
+                  if (
+                    candidateIds.includes("0000000000000043") &&
+                    blockedLaneKeys.length > 0 &&
+                    !blockedSecondClaim
+                  ) {
+                    blockedSecondClaim = true;
+                    resolve();
+                    await gate;
+                  }
+                  return queue.claimNext(...args);
+                },
+              };
+            },
+          },
+        } as TelegramRuntime);
+      });
+      const abort = new AbortController();
+      let releaseHandler: (() => void) | undefined;
+      const handlerDone = new Promise<void>((resolve) => {
+        releaseHandler = resolve;
+      });
+      await writeSpooledTestUpdates(tempDir, [
+        topicUpdate(42, 10, "first topic 10 turn"),
+        topicUpdate(43, 11, "blocked topic 11 turn"),
+      ]);
+
+      const { runPromise, stopWorker } = startIsolatedIngressSession({
+        abort,
+        spoolDir: tempDir,
+        handleUpdate: async () => {
+          await handlerDone;
+        },
+      });
+
+      try {
+        await secondClaimStarted;
+        const before = await claimedAtForUpdate(tempDir, 42);
+        vi.setSystemTime(1_000 + pollingSessionTesting.spooledClaimRefreshIntervalMs * 2 + 1);
+        refreshHarness.triggerRefresh();
+        await Promise.resolve();
+        expect(await claimedAtForUpdate(tempDir, 42)).toBe(before);
+      } finally {
+        releaseSecondClaim?.();
+        releaseHandler?.();
+        abort.abort();
+        stopWorker();
+        refreshHarness.restore();
+        vi.useRealTimers();
+        await runPromise;
+      }
+    });
+  });
+
   it("holds buffered spooled claims until deferred processing settles without blocking same-lane buffering", async () => {
     await withTempSpool(async (tempDir) => {
       const abort = new AbortController();
@@ -1953,10 +2124,11 @@ describe("TelegramPollingSession", () => {
       if (!claimed) {
         throw new Error("Expected claimed update");
       }
+      const liveOwnerPid = process.ppid > 0 ? process.ppid : 1;
       await adoptClaimOwner({
         spoolDir: tempDir,
         updateId: 42,
-        ownerId: `${process.pid}:other-process`,
+        ownerId: `${liveOwnerPid}:other-process`,
         claimedAt: Date.now(),
       });
 
@@ -1976,10 +2148,9 @@ describe("TelegramPollingSession", () => {
     });
   });
 
-  it("fails timed-out current-process claims before draining later same-lane updates", async () => {
+  it("releases pid-reused claims before draining later same-lane updates", async () => {
     await withTempSpool(async (tempDir) => {
       const abort = new AbortController();
-      const log = vi.fn();
       const events: string[] = [];
       await writeSpooledTestUpdates(tempDir, [
         topicUpdate(42, 10, "wedged topic 10 turn"),
@@ -2005,7 +2176,6 @@ describe("TelegramPollingSession", () => {
       const { runPromise, stopWorker } = startIsolatedIngressSession({
         abort,
         spoolDir: tempDir,
-        log,
         spooledUpdateHandlerTimeoutMs: 100,
         handleUpdate: async (update) => {
           events.push(`handled:${update.update_id}`);
@@ -2013,18 +2183,55 @@ describe("TelegramPollingSession", () => {
         },
       });
 
-      await vi.waitFor(() => expect(events).toEqual(["handled:43"]));
+      await vi.waitFor(() => expect(events).toEqual(["handled:42"]));
       await runPromise;
-      expect(await failedUpdateReasons(tempDir)).toEqual([
-        { id: 42, reason: "lane-released-on-stuck" },
-      ]);
-      expect(await pendingUpdateIds(tempDir, "all")).toEqual([]);
+      expect(await failedUpdateReasons(tempDir)).toEqual([]);
+      expect(await pendingUpdateIds(tempDir, "all")).toEqual([43]);
       expect(await listTelegramSpooledUpdateClaims({ spoolDir: tempDir })).toEqual([]);
-      expectLogIncludes(
-        log,
-        "spooled update 42 Telegram spooled update claim owned by this process",
-      );
       stopWorker();
+    });
+  });
+
+  it("reclaims an expired foreign claim so the lane can drain", async () => {
+    await withTempSpool(async (tempDir) => {
+      const abort = new AbortController();
+      const events: number[] = [];
+      await writeSpooledTestUpdates(tempDir, [
+        topicUpdate(42, 10, "expired foreign claim"),
+        topicUpdate(43, 10, "later topic 10 turn"),
+      ]);
+      const interrupted = (await listTelegramSpooledUpdates({ spoolDir: tempDir })).find(
+        (update) => update.updateId === 42,
+      );
+      if (!interrupted) {
+        throw new Error("Expected interrupted update");
+      }
+      const claimed = await claimTelegramSpooledUpdate(interrupted);
+      if (!claimed) {
+        throw new Error("Expected claimed update");
+      }
+      await adoptClaimOwner({
+        spoolDir: tempDir,
+        updateId: 42,
+        ownerId: "1:other-process",
+        claimedAt: Date.now() - telegramSpooledUpdateClaimLeaseMs - 1,
+      });
+
+      const { runPromise, stopWorker } = startIsolatedIngressSession({
+        abort,
+        spoolDir: tempDir,
+        spooledUpdateHandlerTimeoutMs: 100,
+        handleUpdate: async (update) => {
+          events.push(update.update_id ?? -1);
+          if (events.length === 2) {
+            abort.abort();
+          }
+        },
+      });
+
+      await vi.waitFor(() => expect(events).toEqual([42, 43]));
+      stopWorker();
+      await runPromise;
     });
   });
 

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -34,15 +34,17 @@ import { TelegramPollingTransportState } from "./polling-transport-state.js";
 import { TELEGRAM_GET_UPDATES_REQUEST_TIMEOUT_MS } from "./request-timeouts.js";
 import { getTelegramSequentialKey } from "./sequential-key.js";
 import {
-  claimTelegramSpooledUpdate,
+  claimNextTelegramSpooledUpdate,
   deleteTelegramSpooledUpdate,
   failTelegramSpooledUpdateClaim,
   isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess,
   listTelegramSpooledUpdateClaims,
   listTelegramSpooledUpdates,
   recoverStaleTelegramSpooledUpdateClaims,
+  refreshTelegramSpooledUpdateClaim,
   releaseTelegramSpooledUpdateClaim,
   resolveTelegramIngressSpoolDir,
+  TELEGRAM_SPOOLED_UPDATE_CLAIM_LEASE_MS,
   writeTelegramSpooledUpdate,
   type ClaimedTelegramSpooledUpdate,
   type TelegramSpooledUpdate,
@@ -131,11 +133,16 @@ const TELEGRAM_SPOOLED_HANDLER_ABORT_GRACE_MS = 5_000;
 const TELEGRAM_SPOOLED_HANDLER_TIMEOUT_ENV = "OPENCLAW_TELEGRAM_SPOOLED_HANDLER_TIMEOUT_MS";
 const TELEGRAM_SPOOLED_DRAIN_START_LIMIT = 100;
 const TELEGRAM_SPOOLED_DRAIN_SCAN_LIMIT = TELEGRAM_SPOOLED_DRAIN_START_LIMIT * 10;
+const TELEGRAM_SPOOLED_CLAIM_REFRESH_INTERVAL_MS = 5 * 60 * 1000;
+const TELEGRAM_SPOOLED_CLAIM_HEALTH_GRACE_MS = 2 * TELEGRAM_SPOOLED_CLAIM_REFRESH_INTERVAL_MS;
+const TELEGRAM_SPOOLED_SESSION_INIT_CONFLICT_RETRY_BASE_MS = 5_000;
+const TELEGRAM_SPOOLED_SESSION_INIT_CONFLICT_RETRY_MAX_MS = 60_000;
 const TELEGRAM_POLLING_CLIENT_TIMEOUT_FLOOR_SECONDS = Math.ceil(
   TELEGRAM_GET_UPDATES_REQUEST_TIMEOUT_MS / 1000,
 );
 const MISSING_AGENT_HARNESS_ERROR_NAME = "MissingAgentHarnessError";
 const MISSING_AGENT_HARNESS_MESSAGE_RE = /Requested agent harness "[^"]+" is not registered\./u;
+const REPLY_SESSION_INIT_CONFLICT_MESSAGE_RE = /reply session initialization conflicted for \S+/u;
 
 function normalizeTelegramAccountId(accountId?: string | null): string {
   return accountId?.trim() || "default";
@@ -167,6 +174,24 @@ function resolveNonRetryableSpooledUpdateFailure(
     }
   }
   return null;
+}
+
+function resolveSpooledUpdateRetryDelayMs(update: TelegramSpooledUpdate, now = Date.now()): number {
+  const attempts = update.attempts ?? 0;
+  if (
+    !update.lastError ||
+    !REPLY_SESSION_INIT_CONFLICT_MESSAGE_RE.test(update.lastError) ||
+    update.lastAttemptAt === undefined ||
+    attempts <= 0
+  ) {
+    return 0;
+  }
+  const exponent = Math.min(attempts - 1, 8);
+  const delayMs = Math.min(
+    TELEGRAM_SPOOLED_SESSION_INIT_CONFLICT_RETRY_MAX_MS,
+    TELEGRAM_SPOOLED_SESSION_INIT_CONFLICT_RETRY_BASE_MS * 2 ** exponent,
+  );
+  return Math.max(0, update.lastAttemptAt + delayMs - now);
 }
 
 type TelegramBot = ReturnType<typeof createTelegramBot>;
@@ -270,6 +295,8 @@ type SpooledUpdateHandlerState = {
   update: ClaimedTelegramSpooledUpdate;
   updateId: number;
   startedAt: number;
+  stopClaimRefresh: () => void;
+  backlogStatusMessage?: string;
   timedOutAt?: number;
   timeoutMessage?: string;
 };
@@ -282,6 +309,7 @@ type DeferredSpooledUpdateClaimState = {
   timedOutMessage?: string;
   update: ClaimedTelegramSpooledUpdate;
   updateId: number;
+  stopClaimRefresh: () => void;
 };
 
 const deferredSpooledUpdateClaimsByKey = new Map<string, DeferredSpooledUpdateClaimState>();
@@ -298,6 +326,21 @@ type SpooledUpdateDrainResult = {
 // Account health restarts create a new session in the same process while an old
 // spooled handler may still be running after shutdown grace.
 const activeSpooledUpdateHandlersByLane = new Map<string, SpooledUpdateHandlerState>();
+type SpooledUpdateDrainHealth = {
+  lastCompletedAt: number;
+};
+
+const spooledUpdateDrainHealthBySpool = new Map<string, SpooledUpdateDrainHealth>();
+
+function getSpooledUpdateDrainHealth(spoolDir: string): SpooledUpdateDrainHealth {
+  const existing = spooledUpdateDrainHealthBySpool.get(spoolDir);
+  if (existing) {
+    return existing;
+  }
+  const created = { lastCompletedAt: Date.now() };
+  spooledUpdateDrainHealthBySpool.set(spoolDir, created);
+  return created;
+}
 
 function resolveSpooledUpdateHandlerTimeoutMs(params: {
   configured?: number;
@@ -538,21 +581,83 @@ export class TelegramPollingSession {
     }
   }
 
-  async #claimSpooledUpdate(
-    update: TelegramSpooledUpdate,
-  ): Promise<ClaimedTelegramSpooledUpdate | null> {
+  async #claimNextSpooledUpdate(params: {
+    blockedLaneKeys: Set<string>;
+    candidateUpdateIds: readonly number[];
+    spoolDir: string;
+  }): Promise<ClaimedTelegramSpooledUpdate | null> {
     try {
-      return await claimTelegramSpooledUpdate(update);
+      return await claimNextTelegramSpooledUpdate({
+        spoolDir: params.spoolDir,
+        blockedLaneKeys: params.blockedLaneKeys,
+        botInfo: this.opts.botInfo,
+        candidateUpdateIds: params.candidateUpdateIds,
+        scanLimit: TELEGRAM_SPOOLED_DRAIN_SCAN_LIMIT,
+      });
     } catch (err) {
       this.opts.log(
-        `[telegram][diag] spooled update ${update.updateId} claim failed; keeping for retry: ${formatErrorMessage(err)}`,
+        `[telegram][diag] spooled update claim failed; keeping pending updates for retry: ${formatErrorMessage(err)}`,
       );
       return null;
     }
   }
 
+  #startSpooledUpdateClaimRefresh(
+    update: ClaimedTelegramSpooledUpdate,
+    isDrainHealthy: () => boolean,
+    onDrainUnhealthy: () => void,
+  ): () => void {
+    // Refresh only while this process owns useful work and its drain loop is making progress.
+    // Stopping the lease on a stalled drain lets another process recover the lane.
+    let stopped = false;
+    let refreshing = false;
+    const refresh = async (): Promise<void> => {
+      if (stopped || refreshing) {
+        return;
+      }
+      if (!isDrainHealthy()) {
+        onDrainUnhealthy();
+        stopped = true;
+        clearInterval(timer);
+        return;
+      }
+      refreshing = true;
+      try {
+        const refreshed = await refreshTelegramSpooledUpdateClaim(update);
+        if (!refreshed && !stopped) {
+          onDrainUnhealthy();
+          stopped = true;
+          clearInterval(timer);
+        }
+      } catch (err) {
+        this.opts.log(
+          `[telegram][diag] spooled update ${update.updateId} claim refresh failed: ${formatErrorMessage(err)}`,
+        );
+        if (!stopped) {
+          onDrainUnhealthy();
+          stopped = true;
+          clearInterval(timer);
+        }
+      } finally {
+        refreshing = false;
+      }
+    };
+    const timer = setInterval(() => {
+      void refresh();
+    }, TELEGRAM_SPOOLED_CLAIM_REFRESH_INTERVAL_MS);
+    timer.unref?.();
+    return () => {
+      if (stopped) {
+        return;
+      }
+      stopped = true;
+      clearInterval(timer);
+    };
+  }
+
   async #handleClaimedSpooledUpdate(params: {
     bot: TelegramBot;
+    stopClaimRefresh: () => void;
     update: ClaimedTelegramSpooledUpdate;
   }): Promise<boolean> {
     let replay: { deferredWork?: TelegramSpooledReplayDeferredParticipant };
@@ -562,6 +667,7 @@ export class TelegramPollingSession {
         await params.bot.handleUpdate(update);
       });
     } catch (err) {
+      params.stopClaimRefresh();
       await this.#releaseFailedSpooledUpdate({
         err,
         update: params.update,
@@ -572,11 +678,13 @@ export class TelegramPollingSession {
       this.#registerDeferredSpooledUpdate({
         deferredWork: replay.deferredWork,
         laneKey: this.#spooledUpdateLaneKey(params.update),
+        stopClaimRefresh: params.stopClaimRefresh,
         update: params.update,
       });
       return true;
     }
     try {
+      params.stopClaimRefresh();
       await deleteTelegramSpooledUpdate(params.update);
       return true;
     } catch (err) {
@@ -590,6 +698,7 @@ export class TelegramPollingSession {
   #registerDeferredSpooledUpdate(params: {
     deferredWork: TelegramSpooledReplayDeferredParticipant;
     laneKey: string;
+    stopClaimRefresh: () => void;
     update: ClaimedTelegramSpooledUpdate;
   }): void {
     const claimKey = buildDeferredSpooledUpdateClaimKey(params.update);
@@ -598,6 +707,7 @@ export class TelegramPollingSession {
       if (previous.timer) {
         clearTimeout(previous.timer);
       }
+      previous.stopClaimRefresh();
       deferredSpooledUpdateClaimsByKey.delete(claimKey);
     }
     let settled = false;
@@ -609,6 +719,7 @@ export class TelegramPollingSession {
       if (state.timer) {
         clearTimeout(state.timer);
       }
+      state.stopClaimRefresh();
       if (deferredSpooledUpdateClaimsByKey.get(claimKey) === state) {
         deferredSpooledUpdateClaimsByKey.delete(claimKey);
       }
@@ -640,10 +751,12 @@ export class TelegramPollingSession {
       }),
       update: params.update,
       updateId: params.update.updateId,
+      stopClaimRefresh: params.stopClaimRefresh,
     };
     state.timer = setTimeout(() => {
       const age = formatDurationPrecise(this.#spooledUpdateHandlerTimeoutMs);
       state.timedOutMessage = `Telegram isolated polling spool buffered processing timed out behind update ${params.update.updateId} on lane ${params.laneKey} after ${age}; marking the update failed, aborting active reply work, and keeping the claim out of retry while the buffered task settles.`;
+      state.stopClaimRefresh();
       params.deferredWork.settle({
         kind: "failed-retryable",
         error: new Error(state.timedOutMessage),
@@ -656,58 +769,6 @@ export class TelegramPollingSession {
 
   #isDeferredSpooledUpdateClaim(update: ClaimedTelegramSpooledUpdate): boolean {
     return deferredSpooledUpdateClaimsByKey.has(buildDeferredSpooledUpdateClaimKey(update));
-  }
-
-  async #failTimedOutCurrentProcessSpooledUpdateClaims(params: {
-    activeLaneKeys: Set<string>;
-    spoolDir: string;
-  }): Promise<void> {
-    const claims = await listTelegramSpooledUpdateClaims({ spoolDir: params.spoolDir });
-    const now = Date.now();
-    for (const claim of claims) {
-      const claimOwner = claim.claim;
-      if (!claimOwner) {
-        continue;
-      }
-      if (this.#isDeferredSpooledUpdateClaim(claim)) {
-        continue;
-      }
-      if (params.activeLaneKeys.has(this.#spooledUpdateLaneKey(claim))) {
-        continue;
-      }
-      if (now - claimOwner.claimedAt < this.#spooledUpdateHandlerTimeoutMs) {
-        continue;
-      }
-      if (!isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess(claim)) {
-        continue;
-      }
-      // Same PID with a stale owner id means this process orphaned a previous
-      // local handler state; different live PIDs may still be processing.
-      if (claimOwner.processPid !== process.pid) {
-        continue;
-      }
-      const claimedForMs = now - claimOwner.claimedAt;
-      const message = `Telegram spooled update claim owned by this process for ${formatDurationPrecise(claimedForMs)} without active handler state; marking failed so the lane can continue.`;
-      try {
-        const failed = await failTelegramSpooledUpdateClaim({
-          update: claim,
-          reason: "lane-released-on-stuck",
-          message,
-        });
-        if (!failed) {
-          this.opts.log(
-            `[telegram][diag] spooled update ${claim.updateId} current-process claim no longer had a processing marker to fail.`,
-          );
-          continue;
-        }
-      } catch (err) {
-        this.opts.log(
-          `[telegram][diag] spooled update ${claim.updateId} current-process claim could not be marked failed: ${formatErrorMessage(err)}`,
-        );
-        continue;
-      }
-      this.opts.log(`[telegram][diag] spooled update ${claim.updateId} ${message}`);
-    }
   }
 
   async #failTimedOutDeferredSpooledUpdate(state: DeferredSpooledUpdateClaimState): Promise<void> {
@@ -777,7 +838,9 @@ export class TelegramPollingSession {
       }
     }
     try {
-      await releaseTelegramSpooledUpdateClaim(params.update);
+      await releaseTelegramSpooledUpdateClaim(params.update, {
+        lastError: formatErrorMessage(params.err),
+      });
     } catch (releaseErr) {
       this.opts.log(
         `[telegram][diag] spooled update ${params.update.updateId} failed and could not be requeued: ${formatErrorMessage(releaseErr)}`,
@@ -801,8 +864,12 @@ export class TelegramPollingSession {
   }
 
   #spooledUpdateLaneKey(update: TelegramSpooledUpdate): string {
+    return this.#rawSpooledUpdateLaneKey(update.update);
+  }
+
+  #rawSpooledUpdateLaneKey(update: unknown): string {
     return getTelegramSequentialKey({
-      update: update.update as Parameters<typeof getTelegramSequentialKey>[0]["update"],
+      update: update as Parameters<typeof getTelegramSequentialKey>[0]["update"],
       ...(this.opts.botInfo ? { me: this.opts.botInfo } : {}),
     });
   }
@@ -830,20 +897,19 @@ export class TelegramPollingSession {
 
   async #drainSpooledUpdates(params: {
     bot: TelegramBot;
+    isDrainHealthy: () => boolean;
     spoolDir: string;
   }): Promise<SpooledUpdateDrainResult> {
     const activeLaneKeys = this.#activeSpooledUpdateLaneKeysForSpool(params.spoolDir);
-    await this.#failTimedOutCurrentProcessSpooledUpdateClaims({
-      activeLaneKeys,
-      spoolDir: params.spoolDir,
-    });
     await recoverStaleTelegramSpooledUpdateClaims({
       spoolDir: params.spoolDir,
       staleMs: 0,
       shouldRecover: (claim) =>
         !this.#isDeferredSpooledUpdateClaim(claim) &&
         !activeLaneKeys.has(this.#spooledUpdateLaneKey(claim)) &&
-        !isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess(claim),
+        !isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess(claim, {
+          maxAgeMs: TELEGRAM_SPOOLED_UPDATE_CLAIM_LEASE_MS,
+        }),
     });
     const claimedLaneKeys = new Set(
       (
@@ -858,8 +924,9 @@ export class TelegramPollingSession {
       spoolDir: params.spoolDir,
       limit: TELEGRAM_SPOOLED_DRAIN_SCAN_LIMIT,
     });
+    const candidateUpdateIds = updates.map((update) => update.updateId);
     const blockedByLane = new Set<string>();
-    let started = 0;
+    const retryDelayedLaneKeys = new Set<string>();
     for (const update of updates) {
       const laneKey = this.#spooledUpdateLaneKey(update);
       if (this.opts.abortSignal?.aborted) {
@@ -868,18 +935,58 @@ export class TelegramPollingSession {
       const handlerKey = buildSpooledUpdateHandlerKey({ spoolDir: params.spoolDir, laneKey });
       if (activeSpooledUpdateHandlersByLane.has(handlerKey)) {
         blockedByLane.add(handlerKey);
-        continue;
       }
-      if (claimedLaneKeys.has(laneKey)) {
-        continue;
+      if (resolveSpooledUpdateRetryDelayMs(update) > 0) {
+        retryDelayedLaneKeys.add(laneKey);
       }
-      const claimedUpdate = await this.#claimSpooledUpdate(update);
+    }
+    const blockedLaneKeys = new Set([
+      ...activeLaneKeys,
+      ...claimedLaneKeys,
+      ...retryDelayedLaneKeys,
+    ]);
+    let started = 0;
+    while (started < TELEGRAM_SPOOLED_DRAIN_START_LIMIT) {
+      if (this.opts.abortSignal?.aborted) {
+        break;
+      }
+      const claimedUpdate = await this.#claimNextSpooledUpdate({
+        blockedLaneKeys,
+        candidateUpdateIds,
+        spoolDir: params.spoolDir,
+      });
       if (!claimedUpdate) {
-        claimedLaneKeys.add(laneKey);
+        break;
+      }
+      const laneKey = this.#spooledUpdateLaneKey(claimedUpdate);
+      const handlerKey = buildSpooledUpdateHandlerKey({ spoolDir: params.spoolDir, laneKey });
+      if (activeSpooledUpdateHandlersByLane.has(handlerKey)) {
+        blockedByLane.add(handlerKey);
+        await releaseTelegramSpooledUpdateClaim(claimedUpdate, {
+          lastError: "active Telegram spool handler already owns this lane",
+        });
+        blockedLaneKeys.add(laneKey);
         continue;
       }
+      const stopClaimRefresh = this.#startSpooledUpdateClaimRefresh(
+        claimedUpdate,
+        params.isDrainHealthy,
+        () => {
+          const scopedReplyFenceLaneKey = buildTelegramReplyFenceLaneKey({
+            accountId: this.opts.accountId,
+            sequentialKey: laneKey,
+          });
+          const abortedReplyWork = supersedeTelegramReplyFenceLane(scopedReplyFenceLaneKey);
+          if (!abortedReplyWork) {
+            this.opts.log(
+              `[telegram][diag] spooled update ${claimedUpdate.updateId} drain heartbeat expired without an active reply fence on lane ${laneKey}; stopping claim refresh.`,
+            );
+          }
+        },
+      );
       const handler = this.#handleClaimedSpooledUpdate({
         bot: params.bot,
+        stopClaimRefresh,
         update: claimedUpdate,
       });
       const state: SpooledUpdateHandlerState = {
@@ -887,22 +994,25 @@ export class TelegramPollingSession {
         laneKey,
         task: handler,
         update: claimedUpdate,
-        updateId: update.updateId,
+        updateId: claimedUpdate.updateId,
         startedAt: Date.now(),
+        stopClaimRefresh,
       };
       activeSpooledUpdateHandlersByLane.set(handlerKey, state);
       this.#spooledUpdateHandlerKeys.add(handlerKey);
-      claimedLaneKeys.add(laneKey);
+      blockedLaneKeys.add(laneKey);
       void handler.finally(() => {
+        if (
+          !deferredSpooledUpdateClaimsByKey.has(buildDeferredSpooledUpdateClaimKey(claimedUpdate))
+        ) {
+          state.stopClaimRefresh();
+        }
         if (activeSpooledUpdateHandlersByLane.get(handlerKey) === state) {
           activeSpooledUpdateHandlersByLane.delete(handlerKey);
         }
         this.#spooledUpdateHandlerKeys.delete(handlerKey);
       });
       started += 1;
-      if (started >= TELEGRAM_SPOOLED_DRAIN_START_LIMIT) {
-        break;
-      }
     }
     return { blockedByLane, started };
   }
@@ -1108,6 +1218,7 @@ export class TelegramPollingSession {
         void writeTelegramSpooledUpdate({
           spoolDir,
           update: message.update,
+          laneKey: this.#rawSpooledUpdateLaneKey(message.update),
         }).then(
           (updateId) => {
             ackSpooledUpdate(message.requestId, { ok: true, updateId });
@@ -1133,6 +1244,11 @@ export class TelegramPollingSession {
     this.opts.abortSignal?.addEventListener("abort", stopOnAbort, { once: true });
     const drainIntervalMs = Math.max(100, Math.floor(ingress.drainIntervalMs ?? 500));
     let drainActive = false;
+    const drainHealth = getSpooledUpdateDrainHealth(spoolDir);
+    // Fail closed when the spool stops making progress: keeping any claim live would
+    // prevent a healthy process from recovering a wedged drain.
+    const isDrainHealthy = () =>
+      Date.now() - drainHealth.lastCompletedAt <= TELEGRAM_SPOOLED_CLAIM_HEALTH_GRACE_MS;
     const stopBot = () => {
       return Promise.resolve(bot.stop())
         .then(() => undefined)
@@ -1174,8 +1290,13 @@ export class TelegramPollingSession {
       }
       drainActive = true;
       drainRequested = false;
+      let drainCompleted = false;
       try {
-        const drain = await this.#drainSpooledUpdates({ bot, spoolDir });
+        const drain = await this.#drainSpooledUpdates({
+          bot,
+          isDrainHealthy,
+          spoolDir,
+        });
         consecutiveDrainFailures = 0;
         for (const handlerKey of stalledBacklogKeys) {
           if (
@@ -1209,12 +1330,16 @@ export class TelegramPollingSession {
         } else if (timedOutRecovery) {
           stalledBacklogKeys.add(timedOutRecovery.handlerKey);
         }
+        drainCompleted = true;
       } catch (err) {
         consecutiveDrainFailures += 1;
         this.opts.log(
           `[telegram][diag] isolated polling spool drain failed (${consecutiveDrainFailures}): ${formatErrorMessage(err)}`,
         );
       } finally {
+        if (drainCompleted) {
+          drainHealth.lastCompletedAt = Date.now();
+        }
         drainActive = false;
         if (drainRequested && !restartRequested && !this.opts.abortSignal?.aborted) {
           drainRequested = false;
@@ -1529,10 +1654,12 @@ const isGetUpdatesConflict = (err: unknown) => {
 export const testing = {
   resetActiveSpooledUpdateHandlersForTests: (): void => {
     activeSpooledUpdateHandlersByLane.clear();
+    spooledUpdateDrainHealthBySpool.clear();
   },
   createTelegramRestartBackoffState,
   resetTelegramRestartBackoffState,
   resolveTelegramRestartDelayMs,
   resolveSpooledUpdateHandlerAbortGraceMs: (valueMs: unknown): number =>
     resolvePositiveTimerTimeoutMs(valueMs, TELEGRAM_SPOOLED_HANDLER_ABORT_GRACE_MS),
+  spooledClaimRefreshIntervalMs: TELEGRAM_SPOOLED_CLAIM_REFRESH_INTERVAL_MS,
 };

--- a/extensions/telegram/src/telegram-ingress-spool.test.ts
+++ b/extensions/telegram/src/telegram-ingress-spool.test.ts
@@ -10,6 +10,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { clearTelegramRuntime, setTelegramRuntime } from "./runtime.js";
 import type { TelegramRuntime } from "./runtime.types.js";
 import {
+  claimNextTelegramSpooledUpdate,
   claimTelegramSpooledUpdate,
   deleteTelegramSpooledUpdate,
   failTelegramSpooledUpdateClaim,
@@ -114,6 +115,120 @@ describe("Telegram ingress spool", () => {
       }
       await deleteTelegramSpooledUpdate(claimed);
       expect(await listTelegramSpooledUpdateClaims({ spoolDir })).toEqual([]);
+    });
+  });
+
+  it("claims next update through the native ingress queue in update id order", async () => {
+    await withTempSpool(async (spoolDir) => {
+      await writeTelegramSpooledUpdate({
+        spoolDir,
+        update: { update_id: 101, message: { chat: { id: 1 }, message_id: 1, text: "second" } },
+        now: 1,
+      });
+      await writeTelegramSpooledUpdate({
+        spoolDir,
+        update: { update_id: 100, message: { chat: { id: 1 }, message_id: 2, text: "first" } },
+        now: 2,
+      });
+
+      const claimed = await claimNextTelegramSpooledUpdate({ spoolDir });
+
+      expect(claimed?.updateId).toBe(100);
+      expect(await listTelegramSpooledUpdates({ spoolDir })).toHaveLength(1);
+      expect(
+        (await listTelegramSpooledUpdateClaims({ spoolDir })).map((claim) => claim.updateId),
+      ).toEqual([100]);
+    });
+  });
+
+  it("derives lane keys while claiming legacy rows without stored lane keys", async () => {
+    await withTempSpool(async (spoolDir) => {
+      const stateDir = path.dirname(path.dirname(spoolDir));
+      const queue = createChannelIngressQueue<{
+        version: 1;
+        updateId: number;
+        receivedAt: number;
+        update: unknown;
+      }>({
+        channelId: "telegram",
+        accountId: "test",
+        stateDir,
+      });
+      await queue.enqueue(
+        "0000000000000042",
+        {
+          version: 1,
+          updateId: 42,
+          receivedAt: 1,
+          update: {
+            update_id: 42,
+            message: {
+              chat: { id: 100, type: "supergroup", is_forum: true },
+              is_topic_message: true,
+              message_id: 1,
+              message_thread_id: 10,
+              text: "blocked topic",
+            },
+          },
+        },
+        { receivedAt: 1 },
+      );
+      await queue.enqueue(
+        "0000000000000043",
+        {
+          version: 1,
+          updateId: 43,
+          receivedAt: 2,
+          update: {
+            update_id: 43,
+            message: {
+              chat: { id: 100, type: "supergroup", is_forum: true },
+              is_topic_message: true,
+              message_id: 2,
+              message_thread_id: 11,
+              text: "open topic",
+            },
+          },
+        },
+        { receivedAt: 2 },
+      );
+
+      const claimed = await claimNextTelegramSpooledUpdate({
+        spoolDir,
+        blockedLaneKeys: ["telegram:100:topic:10"],
+      });
+
+      expect(claimed?.updateId).toBe(43);
+      expect(claimed?.claim?.claimToken).toEqual(expect.any(String));
+      expect(
+        (await listTelegramSpooledUpdates({ spoolDir })).map((update) => update.updateId),
+      ).toEqual([42]);
+    });
+  });
+
+  it("does not claim outside the provided candidate update ids", async () => {
+    await withTempSpool(async (spoolDir) => {
+      await writeTelegramSpooledUpdate({
+        spoolDir,
+        update: { update_id: 200, message: { chat: { id: 1 }, message_id: 1, text: "first" } },
+        now: 1,
+      });
+      await writeTelegramSpooledUpdate({
+        spoolDir,
+        update: { update_id: 201, message: { chat: { id: 2 }, message_id: 1, text: "later" } },
+        now: 2,
+      });
+
+      const claimed = await claimNextTelegramSpooledUpdate({
+        spoolDir,
+        blockedLaneKeys: ["telegram:1"],
+        candidateUpdateIds: [200],
+      });
+
+      expect(claimed).toBeNull();
+      expect(
+        (await listTelegramSpooledUpdates({ spoolDir })).map((update) => update.updateId),
+      ).toEqual([200, 201]);
     });
   });
 
@@ -276,7 +391,7 @@ describe("Telegram ingress spool", () => {
     ).toBe(false);
   });
 
-  it("treats fresh claims with reused pids and different owner ids as live-owned", () => {
+  it("does not treat fresh claims with the current pid and a different owner id as foreign", () => {
     const now = Date.now();
     expect(
       isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess({
@@ -288,6 +403,25 @@ describe("Telegram ingress spool", () => {
         claim: {
           processId: "other-process",
           processPid: process.pid,
+          claimedAt: now,
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("treats fresh claims with other live pids as live-owned", () => {
+    const now = Date.now();
+    const liveOwnerPid = process.ppid > 0 ? process.ppid : 1;
+    expect(
+      isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess({
+        updateId: 51,
+        path: path.join(os.tmpdir(), "51.json.processing"),
+        pendingPath: path.join(os.tmpdir(), "51.json"),
+        update: { update_id: 51 },
+        receivedAt: now,
+        claim: {
+          processId: "other-process",
+          processPid: liveOwnerPid,
           claimedAt: now,
         },
       }),

--- a/extensions/telegram/src/telegram-ingress-spool.ts
+++ b/extensions/telegram/src/telegram-ingress-spool.ts
@@ -9,12 +9,15 @@ import type {
   ChannelIngressQueueRecord,
 } from "openclaw/plugin-sdk/channel-outbound";
 import { resolveStateDir } from "openclaw/plugin-sdk/state-paths";
+import type { TelegramBotInfo } from "./bot-info.js";
 import { getTelegramRuntime } from "./runtime.js";
+import { getTelegramSequentialKey } from "./sequential-key.js";
 import { normalizeTelegramStateAccountId } from "./state-account-id.js";
 
 const SPOOL_VERSION = 1;
 const TELEGRAM_INGRESS_SPOOL_PREFIX = "ingress-spool-";
 export const TELEGRAM_SPOOLED_UPDATE_PROCESSING_STALE_MS = 6 * 60 * 60 * 1000;
+export const TELEGRAM_SPOOLED_UPDATE_CLAIM_LEASE_MS = 30 * 60 * 1000;
 const TELEGRAM_SPOOLED_UPDATE_FAILED_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 const TELEGRAM_SPOOLED_UPDATE_FAILED_MAX_ENTRIES = 1000;
 const TELEGRAM_SPOOLED_UPDATE_PROCESS_ID = `${process.pid}:${randomUUID()}`;
@@ -38,6 +41,9 @@ export type TelegramSpooledUpdate = {
   path: string;
   update: unknown;
   receivedAt: number;
+  attempts?: number;
+  lastAttemptAt?: number;
+  lastError?: string;
   claim?: TelegramSpooledUpdateClaimOwner;
 };
 
@@ -149,8 +155,13 @@ function processExists(pid: number): boolean {
   }
 }
 
-function isFreshClaimOwner(claim: TelegramSpooledUpdateClaimOwner): boolean {
-  return Date.now() - claim.claimedAt < TELEGRAM_SPOOLED_UPDATE_PROCESSING_STALE_MS;
+function isFreshClaimOwner(
+  claim: TelegramSpooledUpdateClaimOwner,
+  options?: { maxAgeMs?: number; now?: number },
+): boolean {
+  const now = options?.now ?? Date.now();
+  const maxAgeMs = options?.maxAgeMs ?? TELEGRAM_SPOOLED_UPDATE_PROCESSING_STALE_MS;
+  return now - claim.claimedAt < maxAgeMs;
 }
 
 function parseQueueRecord(
@@ -166,6 +177,9 @@ function parseQueueRecord(
     path: pendingPath(spoolDir, payload.updateId),
     update: payload.update,
     receivedAt: payload.receivedAt,
+    attempts: record.attempts,
+    ...(record.lastAttemptAt === undefined ? {} : { lastAttemptAt: record.lastAttemptAt }),
+    ...(record.lastError === undefined ? {} : { lastError: record.lastError }),
   };
 }
 
@@ -190,6 +204,13 @@ function parseQueueClaim(
   };
 }
 
+function spooledUpdateLaneKey(update: unknown, botInfo?: TelegramBotInfo): string {
+  return getTelegramSequentialKey({
+    update: update as Parameters<typeof getTelegramSequentialKey>[0]["update"],
+    ...(botInfo ? { me: botInfo } : {}),
+  });
+}
+
 function sortTelegramUpdates<T extends TelegramSpooledUpdate>(updates: T[]): T[] {
   return updates.toSorted((a, b) => a.updateId - b.updateId);
 }
@@ -201,18 +222,27 @@ function queueMutationTarget(update: TelegramSpooledUpdate): string | ChannelIng
 
 export function isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess(
   claim: ClaimedTelegramSpooledUpdate,
+  options?: { maxAgeMs?: number; now?: number },
 ): boolean {
   return Boolean(
     claim.claim &&
     claim.claim.processId !== TELEGRAM_SPOOLED_UPDATE_PROCESS_ID &&
-    isFreshClaimOwner(claim.claim) &&
+    claim.claim.processPid !== process.pid &&
+    isFreshClaimOwner(claim.claim, options) &&
     processExists(claim.claim.processPid),
   );
+}
+
+export function isTelegramSpooledUpdateClaimOwnedByCurrentProcess(
+  claim: ClaimedTelegramSpooledUpdate,
+): boolean {
+  return claim.claim?.processId === TELEGRAM_SPOOLED_UPDATE_PROCESS_ID;
 }
 
 export async function writeTelegramSpooledUpdate(params: {
   spoolDir: string;
   update: unknown;
+  laneKey?: string;
   now?: number;
 }): Promise<number> {
   const updateId = resolveTelegramUpdateId(params.update);
@@ -230,7 +260,10 @@ export async function writeTelegramSpooledUpdate(params: {
       receivedAt,
       update: params.update,
     },
-    { receivedAt },
+    {
+      receivedAt,
+      laneKey: params.laneKey ?? spooledUpdateLaneKey(params.update),
+    },
   );
   return updateId;
 }
@@ -265,11 +298,62 @@ export async function claimTelegramSpooledUpdate(
   return claimed ? parseQueueClaim(spoolDir, claimed) : null;
 }
 
+export async function claimNextTelegramSpooledUpdate(params: {
+  spoolDir: string;
+  blockedLaneKeys?: Iterable<string>;
+  botInfo?: TelegramBotInfo;
+  candidateUpdateIds?: Iterable<number>;
+  scanLimit?: number;
+}): Promise<ClaimedTelegramSpooledUpdate | null> {
+  const queue = createTelegramIngressQueue(params.spoolDir);
+  const claimed = await queue.claimNext({
+    ownerId: TELEGRAM_SPOOLED_UPDATE_PROCESS_ID,
+    blockedLaneKeys: params.blockedLaneKeys,
+    ...(params.candidateUpdateIds === undefined
+      ? {}
+      : { candidateIds: [...params.candidateUpdateIds].map(queueEventId) }),
+    orderBy: "id",
+    scanLimit: params.scanLimit,
+    deriveLaneKey: (record) => spooledUpdateLaneKey(record.payload.update, params.botInfo),
+  });
+  if (!claimed) {
+    return null;
+  }
+  const update = parseQueueClaim(params.spoolDir, claimed);
+  if (update) {
+    return update;
+  }
+  await queue.fail(claimed, {
+    reason: "invalid-spooled-update",
+    message: "Telegram spooled update payload was invalid.",
+  });
+  return null;
+}
+
 export async function releaseTelegramSpooledUpdateClaim(
   update: ClaimedTelegramSpooledUpdate,
+  options?: { lastError?: string; releasedAt?: number },
 ): Promise<void> {
   await createTelegramIngressQueue(path.dirname(update.pendingPath)).release(
     queueMutationTarget(update),
+    options,
+  );
+}
+
+export async function refreshTelegramSpooledUpdateClaim(
+  update: ClaimedTelegramSpooledUpdate,
+  options?: { refreshedAt?: number },
+): Promise<boolean> {
+  const claimToken = update.claim?.claimToken;
+  if (!claimToken) {
+    return false;
+  }
+  const queue = createTelegramIngressQueue(path.dirname(update.pendingPath));
+  return (
+    (await queue.refreshClaim?.(
+      { id: queueEventId(update.updateId), claim: { token: claimToken } },
+      options,
+    )) ?? false
   );
 }
 

--- a/src/channels/message/ingress-queue.test.ts
+++ b/src/channels/message/ingress-queue.test.ts
@@ -251,6 +251,107 @@ describe("channel ingress queue", () => {
     });
   });
 
+  it("claims next pending row by id when requested", async () => {
+    await withTempState(async (stateDir) => {
+      let clock = 1;
+      const queue = createChannelIngressQueue<{ text: string }>({
+        channelId: "test",
+        accountId: "account",
+        stateDir,
+        now: () => clock++,
+      });
+
+      await queue.enqueue("0002", { text: "second" }, { receivedAt: 1 });
+      await queue.enqueue("0001", { text: "first" }, { receivedAt: 2 });
+
+      const claimed = await queue.claimNext({
+        ownerId: "worker",
+        orderBy: "id",
+      });
+
+      expect(claimed?.id).toBe("0001");
+    });
+  });
+
+  it("claims next only from candidate ids when provided", async () => {
+    await withTempState(async (stateDir) => {
+      let clock = 1;
+      const queue = createChannelIngressQueue<{ text: string }>({
+        channelId: "test",
+        accountId: "account",
+        stateDir,
+        now: () => clock++,
+      });
+
+      await queue.enqueue("a", { text: "outside snapshot" }, { receivedAt: 1 });
+      await queue.enqueue("b", { text: "inside snapshot" }, { receivedAt: 2 });
+
+      expect(
+        await queue.claimNext({
+          ownerId: "worker",
+          candidateIds: ["b"],
+        }),
+      ).toMatchObject({ id: "b" });
+      expect(await queue.claimNext({ candidateIds: [] })).toBeNull();
+    });
+  });
+
+  it("derives missing lane keys before claiming next", async () => {
+    await withTempState(async (stateDir) => {
+      let clock = 1;
+      const queue = createChannelIngressQueue<{ lane: string }>({
+        channelId: "test",
+        accountId: "account",
+        stateDir,
+        now: () => clock++,
+      });
+
+      await queue.enqueue("a", { lane: "blocked" }, { receivedAt: 1 });
+      await queue.enqueue("b", { lane: "open" }, { receivedAt: 2 });
+
+      const claimed = await queue.claimNext({
+        ownerId: "worker",
+        blockedLaneKeys: ["blocked"],
+        deriveLaneKey: (record) => record.payload.lane,
+      });
+
+      expect(claimed?.id).toBe("b");
+      expect(claimed?.laneKey).toBe("open");
+      expect(
+        (await queue.listPending()).find((record) => record.id === "a")?.laneKey,
+      ).toBeUndefined();
+    });
+  });
+
+  it("blocks lanes claimed by candidate rows before claiming later candidates", async () => {
+    await withTempState(async (stateDir) => {
+      let clock = 1;
+      const queue = createChannelIngressQueue<{ lane: string }>({
+        channelId: "test",
+        accountId: "account",
+        stateDir,
+        now: () => clock++,
+      });
+
+      await queue.enqueue("a", { lane: "chat-1" }, { receivedAt: 1 });
+      await queue.enqueue("b", { lane: "chat-1" }, { receivedAt: 2 });
+      await queue.enqueue("c", { lane: "chat-2" }, { receivedAt: 3 });
+      await queue.claim("a", { ownerId: "sibling-worker" });
+
+      const claimed = await queue.claimNext({
+        ownerId: "worker",
+        candidateIds: ["a", "b", "c"],
+        orderBy: "id",
+        deriveLaneKey: (record) => record.payload.lane,
+      });
+
+      expect(claimed?.id).toBe("c");
+      expect(claimed?.laneKey).toBe("chat-2");
+      const sameLanePending = (await queue.listPending()).find((record) => record.id === "b");
+      expect(sameLanePending?.laneKey).toBeUndefined();
+    });
+  });
+
   it("requires claim tokens before mutating claimed rows", async () => {
     await withTempState(async (stateDir) => {
       const queue = createChannelIngressQueue<{ text: string }>({
@@ -274,6 +375,105 @@ describe("channel ingress queue", () => {
       expect(await queue.complete(claimed, { completedAt: 20 })).toBe(true);
       const duplicate = await queue.enqueue("event-1", { text: "duplicate" });
       expect(duplicate.kind).toBe("completed");
+    });
+  });
+
+  it("refreshes claimed rows only with the active claim token", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createChannelIngressQueue<{ text: string }>({
+        channelId: "test",
+        accountId: "account",
+        stateDir,
+        now: () => 10,
+      });
+
+      await queue.enqueue("event-1", { text: "claimed" });
+      const claimed = await queue.claim("event-1", { ownerId: "worker" });
+      if (!claimed) {
+        throw new Error("Expected a claimed ingress event");
+      }
+
+      expect(await queue.refreshClaim?.(claimed, { refreshedAt: 20 })).toBe(true);
+      expect(
+        (await queue.listClaims()).map((claim) => ({
+          id: claim.id,
+          claimedAt: claim.claim.claimedAt,
+          updatedAt: claim.updatedAt,
+        })),
+      ).toEqual([{ id: "event-1", claimedAt: 20, updatedAt: 20 }]);
+
+      expect(
+        await queue.refreshClaim?.(
+          { id: "event-1", claim: { token: "wrong" } },
+          {
+            refreshedAt: 30,
+          },
+        ),
+      ).toBe(false);
+      expect((await queue.listClaims())[0]?.claim.claimedAt).toBe(20);
+    });
+  });
+
+  it("does not let old claim tokens refresh recovered and reclaimed rows", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createChannelIngressQueue<{ text: string }>({
+        channelId: "test",
+        accountId: "account",
+        stateDir,
+        now: () => 10,
+      });
+
+      await queue.enqueue("event-1", { text: "claimed" });
+      const oldClaim = await queue.claim("event-1", { ownerId: "worker-1" });
+      if (!oldClaim) {
+        throw new Error("Expected a claimed ingress event");
+      }
+      expect(await queue.recoverStaleClaims({ staleMs: 5, now: 20 })).toBe(1);
+      const newClaim = await queue.claim("event-1", { ownerId: "worker-2" });
+      if (!newClaim) {
+        throw new Error("Expected reclaimed ingress event");
+      }
+
+      expect(await queue.refreshClaim?.(oldClaim, { refreshedAt: 30 })).toBe(false);
+      expect(await queue.refreshClaim?.(newClaim, { refreshedAt: 40 })).toBe(true);
+      expect((await queue.listClaims())[0]?.claim).toMatchObject({
+        ownerId: "worker-2",
+        claimedAt: 40,
+      });
+    });
+  });
+
+  it("does not recover a claim refreshed after stale recovery snapshots it", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createChannelIngressQueue<{ text: string }>({
+        channelId: "test",
+        accountId: "account",
+        stateDir,
+        now: () => 10,
+      });
+
+      await queue.enqueue("event-1", { text: "claimed" });
+      const claimed = await queue.claim("event-1", { ownerId: "worker" });
+      if (!claimed) {
+        throw new Error("Expected a claimed ingress event");
+      }
+
+      expect(
+        await queue.recoverStaleClaims({
+          staleMs: 5,
+          now: 20,
+          shouldRecover: async (claim) => {
+            expect(claim.id).toBe("event-1");
+            expect(await queue.refreshClaim?.(claim, { refreshedAt: 20 })).toBe(true);
+            return true;
+          },
+        }),
+      ).toBe(0);
+      expect((await queue.listPending()).map((record) => record.id)).toEqual([]);
+      expect((await queue.listClaims())[0]?.claim).toMatchObject({
+        ownerId: "worker",
+        claimedAt: 20,
+      });
     });
   });
 

--- a/src/channels/message/ingress-queue.ts
+++ b/src/channels/message/ingress-queue.ts
@@ -137,11 +137,19 @@ export type ChannelIngressQueue<TPayload, TMetadata = unknown, TCompletedMetadat
     ownerId?: string;
     blockedLaneKeys?: Iterable<string>;
     staleMs?: number;
+    orderBy?: "received" | "id";
+    scanLimit?: number;
+    candidateIds?: Iterable<string>;
+    deriveLaneKey?: (record: ChannelIngressQueueRecord<TPayload, TMetadata>) => string | undefined;
   }): Promise<ChannelIngressQueueClaim<TPayload, TMetadata> | null>;
   claim(
     id: string,
     options?: { ownerId?: string },
   ): Promise<ChannelIngressQueueClaim<TPayload, TMetadata> | null>;
+  refreshClaim?(
+    claim: ChannelIngressQueueClaimRef,
+    options?: { refreshedAt?: number },
+  ): Promise<boolean>;
   complete(
     idOrClaim: string | ChannelIngressQueueClaimRef,
     options?: { metadata?: TCompletedMetadata; completedAt?: number },
@@ -318,12 +326,20 @@ function normalizeLimit(limit: number | "all" | undefined): number {
   return limit === "all" ? Number.MAX_SAFE_INTEGER : Math.max(1, Math.floor(limit ?? 100));
 }
 
+function normalizeScanLimit(limit: number | undefined): number {
+  return Math.max(1, Math.floor(limit ?? 100));
+}
+
 function normalizeMaxEntries(value: number | undefined): number | null {
   return value === undefined ? null : Math.max(0, Math.floor(value));
 }
 
 function normalizedProtectedIds(ids: Iterable<string> | undefined): string[] {
   return [...(ids ?? [])].map((id) => id.trim()).filter(Boolean);
+}
+
+function normalizedCandidateIds(ids: Iterable<string> | undefined): string[] | undefined {
+  return ids === undefined ? undefined : [...ids].map((id) => id.trim()).filter(Boolean);
 }
 
 function queueNameForParts(channelId: string, accountId: string): string {
@@ -445,15 +461,16 @@ export function createChannelIngressQueue<
     TMetadata,
     TCompletedMetadata
   >["recoverStaleClaims"] = async (recoverOptions) => {
+    const current = recoverOptions?.now ?? now();
     const staleMs = Math.max(0, Math.floor(recoverOptions?.staleMs ?? 0));
-    const cutoff = (recoverOptions?.now ?? now()) - staleMs;
+    const cutoff = current - staleMs;
     const claims = (await listClaims()).filter((claim) => claim.claim.claimedAt <= cutoff);
     let recovered = 0;
     for (const claim of claims) {
       if (recoverOptions?.shouldRecover && !(await recoverOptions.shouldRecover(claim))) {
         continue;
       }
-      if (await release(claim, { releasedAt: recoverOptions?.now ?? now() })) {
+      if (await releaseClaimIfStillStale(claim, { cutoff, releasedAt: current })) {
         recovered += 1;
       }
     }
@@ -471,28 +488,66 @@ export function createChannelIngressQueue<
     const blocked = new Set(
       [...(claimOptions?.blockedLaneKeys ?? [])].map((key) => key.trim()).filter(Boolean),
     );
+    const candidateIds = normalizedCandidateIds(claimOptions?.candidateIds);
+    if (candidateIds?.length === 0) {
+      return null;
+    }
     const database = openStateDatabase(options.stateDir);
     return runOpenClawStateWriteTransaction(
       (tx) => {
         const kysely = getChannelIngressKysely(tx.db);
+        let effectiveBlocked = blocked;
+        if (candidateIds && candidateIds.length > 0) {
+          // Candidate snapshots can race a sibling drainer. If an earlier
+          // candidate is now claimed, its lane must block later same-lane rows.
+          const claimedCandidateRows = executeSqliteQuerySync(
+            tx.db,
+            kysely
+              .selectFrom("channel_ingress_events")
+              .selectAll()
+              .where("queue_name", "=", queueName)
+              .where("status", "=", "claimed")
+              .where("event_id", "in", candidateIds),
+          ).rows;
+          const claimedCandidateLaneKeys = claimedCandidateRows
+            .map((row) => row.lane_key ?? claimOptions?.deriveLaneKey?.(baseRecord(row)))
+            .filter((laneKey): laneKey is string => Boolean(laneKey));
+          if (claimedCandidateLaneKeys.length > 0) {
+            effectiveBlocked = new Set([...blocked, ...claimedCandidateLaneKeys]);
+          }
+        }
         const baseSelect = kysely
           .selectFrom("channel_ingress_events")
-          .select(["event_id", "lane_key"])
+          .selectAll()
           .where("queue_name", "=", queueName)
           .where("status", "=", "pending");
-        const select =
-          blocked.size === 0
-            ? baseSelect
-            : baseSelect.where((eb) =>
-                eb.or([eb("lane_key", "is", null), eb("lane_key", "not in", [...blocked])]),
-              );
-        const selected = executeSqliteQueryTakeFirstSync(
-          tx.db,
-          select.orderBy("received_at", "asc").orderBy("event_id", "asc").limit(1),
-        );
+        let select = baseSelect;
+        if (candidateIds) {
+          select = select.where("event_id", "in", candidateIds);
+        }
+        if (effectiveBlocked.size > 0 && !claimOptions?.deriveLaneKey) {
+          select = select.where((eb) =>
+            eb.or([eb("lane_key", "is", null), eb("lane_key", "not in", [...effectiveBlocked])]),
+          );
+        }
+        let orderedSelect =
+          claimOptions?.orderBy === "id"
+            ? select.orderBy("event_id", "asc")
+            : select.orderBy("received_at", "asc").orderBy("event_id", "asc");
+        orderedSelect =
+          claimOptions?.deriveLaneKey === undefined
+            ? orderedSelect.limit(1)
+            : orderedSelect.limit(normalizeScanLimit(claimOptions.scanLimit));
+        const rows = executeSqliteQuerySync(tx.db, orderedSelect).rows;
+        const selected = rows.find((row) => {
+          const laneKey = row.lane_key ?? claimOptions?.deriveLaneKey?.(baseRecord(row));
+          return !laneKey || !effectiveBlocked.has(laneKey);
+        });
         if (!selected) {
           return null;
         }
+        const derivedLaneKey =
+          selected.lane_key ?? claimOptions?.deriveLaneKey?.(baseRecord(selected));
         const token = randomUUID();
         const claimedAt = now();
         const ownerId = normalizePart(claimOptions?.ownerId, `${process.pid}`);
@@ -505,6 +560,7 @@ export function createChannelIngressQueue<
               claim_token: token,
               claim_owner: ownerId,
               claimed_at: claimedAt,
+              ...(derivedLaneKey ? { lane_key: derivedLaneKey } : {}),
               updated_at: claimedAt,
             })
             .where("queue_name", "=", queueName)
@@ -556,6 +612,68 @@ export function createChannelIngressQueue<
         }
         const row = selectRow(tx.db, queueName, eventId);
         return row ? claimedRecord<TPayload, TMetadata>(row) : null;
+      },
+      { path: database.path },
+    );
+  };
+
+  const refreshClaim: NonNullable<
+    ChannelIngressQueue<TPayload, TMetadata, TCompletedMetadata>["refreshClaim"]
+  > = async (claimRef, refreshOptions) => {
+    const eventId = idFrom(claimRef);
+    const refreshedAt = refreshOptions?.refreshedAt ?? now();
+    const database = openStateDatabase(options.stateDir);
+    return runOpenClawStateWriteTransaction(
+      (tx) => {
+        const kysely = getChannelIngressKysely(tx.db);
+        const result = executeSqliteQuerySync(
+          tx.db,
+          kysely
+            .updateTable("channel_ingress_events")
+            .set({
+              claimed_at: refreshedAt,
+              updated_at: refreshedAt,
+            })
+            .where("queue_name", "=", queueName)
+            .where("event_id", "=", eventId)
+            .where("status", "=", "claimed")
+            .where("claim_token", "=", claimRef.claim.token),
+        );
+        return affectedRows(result) > 0;
+      },
+      { path: database.path },
+    );
+  };
+
+  const releaseClaimIfStillStale = async (
+    claimRef: ChannelIngressQueueClaimRef,
+    releaseOptions: { cutoff: number; releasedAt: number },
+  ): Promise<boolean> => {
+    const eventId = idFrom(claimRef);
+    const database = openStateDatabase(options.stateDir);
+    return runOpenClawStateWriteTransaction(
+      (tx) => {
+        const kysely = getChannelIngressKysely(tx.db);
+        const result = executeSqliteQuerySync(
+          tx.db,
+          kysely
+            .updateTable("channel_ingress_events")
+            .set((eb) => ({
+              status: "pending",
+              claim_token: null,
+              claim_owner: null,
+              claimed_at: null,
+              attempts: eb("attempts", "+", 1),
+              last_attempt_at: releaseOptions.releasedAt,
+              updated_at: releaseOptions.releasedAt,
+            }))
+            .where("queue_name", "=", queueName)
+            .where("event_id", "=", eventId)
+            .where("status", "=", "claimed")
+            .where("claim_token", "=", claimRef.claim.token)
+            .where("claimed_at", "<=", releaseOptions.cutoff),
+        );
+        return affectedRows(result) > 0;
       },
       { path: database.path },
     );
@@ -845,6 +963,7 @@ export function createChannelIngressQueue<
     listClaims,
     claimNext,
     claim,
+    refreshClaim,
     complete,
     release,
     fail,


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/97118

## What Problem This Solves

Fixes an issue where Telegram channel updates could remain claimed in the ingress spool and stop draining on release/2026.6.11. When a handler ran long enough or a claim got stranded, messages could sit pending or claimed instead of being processed.

## Why This Change Was Made

This backports the merged main fix from https://github.com/openclaw/openclaw/pull/97118, including token-guarded ingress claim refresh, safer stale-claim recovery, Telegram drain lane blocking, retry backoff metadata, and regression coverage. The release branch needed small conflict-resolution wiring because its Telegram spool adapter and channel queue primitives were behind main.

## User Impact

Telegram users should see queued updates drain again instead of getting stuck in the OpenClaw ingress spool. Operators also get safer recovery for stale claims without stealing claims that an active handler has refreshed.

## Evidence

- Main fix landed on main as https://github.com/openclaw/openclaw/commit/b8e3de11608d12354b17cadd3703b3823b055a24.
- Backport branch head: 769a9938b3c008aa0d6ae34b08b8b0af3f027589.
- Focused tests: `node scripts/run-vitest.mjs extensions/telegram/src/telegram-ingress-spool.test.ts extensions/telegram/src/polling-session.test.ts src/channels/message/ingress-queue.test.ts` passed, 94 tests.
- Format/lint: `oxfmt --check` on touched files passed; `node scripts/run-oxlint.mjs` on touched files passed.
- Autoreview: `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/release/2026.6.11` clean, no accepted/actionable findings.
- Testbox-through-Crabbox: `tbx_01kw7mnx5nc924cshgkxzchs5d`, Actions run https://github.com/openclaw/openclaw/actions/runs/28330370613, `check:changed --base origin/release/2026.6.11 --head HEAD` passed with lanes `core, coreTests, extensions, extensionTests`.
