### PR TITLE
fix: archive role-ordering reset transcripts

### DIFF
--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -1414,7 +1414,8 @@ describe("session accessor file-backed seam", () => {
       .readdirSync(tempDir)
       .filter((file) => file.startsWith("previous-session.jsonl.reset."));
     expect(archivedPreviousTranscripts).toHaveLength(1);
-    const archivedPreviousTranscript = path.join(tempDir, archivedPreviousTranscripts[0]!);
+    const [archivedPreviousTranscriptName] = archivedPreviousTranscripts;
+    const archivedPreviousTranscript = path.join(tempDir, archivedPreviousTranscriptName);
     expect(fs.readFileSync(archivedPreviousTranscript, "utf-8")).toContain(
       '"id":"previous-session"',
     );

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -1358,7 +1358,7 @@ describe("session accessor file-backed seam", () => {
     ).toHaveLength(1);
   });
 
-  it("persists reset lifecycle entry changes with transcript replay and cleanup", async () => {
+  it("persists reset lifecycle entry changes with transcript replay and archive", async () => {
     const now = Date.now();
     const sessionKey = "agent:main:main";
     const previousTranscript = path.join(tempDir, "previous-session.jsonl");
@@ -1410,6 +1410,15 @@ describe("session accessor file-backed seam", () => {
     expect(result.replayedMessages).toBe(2);
     expect(loadSessionEntry({ sessionKey, storePath })).toMatchObject(nextEntry);
     expect(fs.existsSync(previousTranscript)).toBe(false);
+    const archivedPreviousTranscripts = fs
+      .readdirSync(tempDir)
+      .filter((file) => file.startsWith("previous-session.jsonl.reset."));
+    expect(archivedPreviousTranscripts).toHaveLength(1);
+    const archivedPreviousTranscript = path.join(tempDir, archivedPreviousTranscripts[0]!);
+    expect(fs.readFileSync(archivedPreviousTranscript, "utf-8")).toContain(
+      '"id":"previous-session"',
+    );
+    expect(fs.readFileSync(archivedPreviousTranscript, "utf-8")).toContain('"content":"hi"');
     expect(fs.readFileSync(nextTranscript, "utf-8")).toContain('"content":"hello"');
   });
 

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -1632,10 +1632,12 @@ export async function persistSessionResetLifecycle(params: {
   });
 
   if (params.cleanupPreviousTranscript && params.previousSessionId) {
-    cleanupPreviousResetTranscripts({
+    await archivePreviousSessionTranscript({
       agentId: params.agentId ?? resolveAgentIdFromSessionKey(params.sessionKey),
-      previousEntry: params.previousEntry,
-      previousSessionId: params.previousSessionId,
+      previousEntry:
+        params.previousEntry.sessionId === params.previousSessionId
+          ? params.previousEntry
+          : { ...params.previousEntry, sessionId: params.previousSessionId },
       storePath: params.storePath,
     });
   }
@@ -2706,34 +2708,6 @@ async function restoreTemporarySessionMapping(
     return undefined;
   } catch (err) {
     return formatErrorMessage(err);
-  }
-}
-
-function cleanupPreviousResetTranscripts(params: {
-  agentId: string;
-  previousEntry: SessionEntry;
-  previousSessionId: string;
-  storePath: string;
-}): void {
-  const transcriptCandidates = new Set<string>();
-  const resolved = resolveSessionFilePath(
-    params.previousSessionId,
-    params.previousEntry,
-    resolveSessionFilePathOptions({
-      agentId: params.agentId,
-      storePath: params.storePath,
-    }),
-  );
-  if (resolved) {
-    transcriptCandidates.add(resolved);
-  }
-  transcriptCandidates.add(resolveSessionTranscriptPath(params.previousSessionId, params.agentId));
-  for (const candidate of transcriptCandidates) {
-    try {
-      fs.unlinkSync(candidate);
-    } catch {
-      // Best-effort cleanup.
-    }
   }
 }
 


### PR DESCRIPTION
Closes #97529

AI-assisted by Codex.

## What Problem This Solves

Fixes an issue where users whose sessions hit an automatic role-ordering-conflict reset would silently lose the previous session transcript. The reset replayed only a bounded message tail into the new session, then hard-deleted the full previous transcript instead of preserving it as a reset archive.

## Why This Change Was Made

The role-ordering reset lifecycle now uses the existing reset transcript archive path instead of the unlink-only cleanup path. This keeps the behavior aligned with adjacent reset and rollover lifecycle flows while preserving the bounded replay into the new session.

## User Impact

Users retain a recoverable `.jsonl.reset.<timestamp>` archive for the full pre-reset transcript, so long conversations are not silently reduced to the replayed tail after this automatic recovery path runs.

## Evidence

- `node scripts/run-vitest.mjs src/config/sessions/session-accessor.test.ts`
  - Passed: 1 test file, 58 tests.
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/config/sessions/session-accessor.test.ts src/config/sessions/session-accessor.ts`
  - Passed with no output.
- `git diff --check`
  - Passed with no output.
- `git diff --numstat origin/main...HEAD`
  - `src/config/sessions/session-accessor.test.ts`: `11  1`
  - `src/config/sessions/session-accessor.ts`: `5  31`
- Branch-level real behavior proof on the fixed branch, driving the real exported `persistSessionResetLifecycle` from `src/config/sessions/session-accessor.ts` against an actual file-backed `agents/main/sessions/` layout:

```text
PR #97544 behavior proof: role-ordering reset archive path
workdir: /private/tmp/openclaw-97529-session-reset
tempRoot: /var/folders/ms/9qxgldzs4dd9f7hv74vrgxfh0000gn/T/openclaw-pr-97544-proof-TnZ4Gg
previous file exists after reset: false
reset archive files: 1 ["aaaaaaaa-1111-2222-3333-prevprevprev.jsonl.reset.2026-06-28T18-07-17.495Z"]
archive preserved previous session header: true
archive preserved user messages: 25
new transcript exists: true
replayed records returned: 6
new transcript replayed user messages: 3
new transcript includes newest user tail: true
```

- `.agents/skills/autoreview/scripts/autoreview --mode local --prompt 'Review the fix for GitHub issue #97529. Scope: preserve previous session transcript during role-ordering-conflict reset by archiving instead of unlinking, with focused session-accessor regression test. Focus on data-loss/session lifecycle regressions and whether proof covers the touched surface.'`
  - Clean: no accepted/actionable findings reported.

No live provider reproduction was run. The real behavior proof drives the fixed file-backed session lifecycle directly: it writes a 25-turn previous transcript in the real sessions directory shape, runs the reset lifecycle with cleanup enabled, verifies the previous transcript is preserved as exactly one `.jsonl.reset.<timestamp>` archive, and verifies the replayed tail still lands in the new transcript.
