### PR TITLE
fix(msteams): handle message card submit values

### DIFF
--- a/extensions/msteams/src/adaptive-card-submit.ts
+++ b/extensions/msteams/src/adaptive-card-submit.ts
@@ -1,0 +1,52 @@
+// Msteams helper module supports Adaptive Card submit payload behavior.
+import {
+  isRecord,
+  normalizeOptionalLowercaseString,
+  normalizeOptionalString,
+} from "openclaw/plugin-sdk/string-coerce-runtime";
+
+function extractAdaptiveCardSubmittedData(value: unknown): unknown {
+  if (!isRecord(value)) {
+    return value;
+  }
+  const action = isRecord(value.action) ? value.action : undefined;
+  if (
+    action &&
+    normalizeOptionalLowercaseString(action.type) === "action.submit" &&
+    "data" in action
+  ) {
+    return action.data;
+  }
+  return value;
+}
+
+function readMSTeamsImBackValue(value: unknown): string | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+  const msteams = isRecord(value.msteams) ? value.msteams : undefined;
+  if (!msteams || normalizeOptionalLowercaseString(msteams.type) !== "imback") {
+    return null;
+  }
+  return normalizeOptionalString(msteams.value) ?? null;
+}
+
+export function serializeMSTeamsAdaptiveCardActionValue(value: unknown): string | null {
+  const submittedValue = extractAdaptiveCardSubmittedData(value);
+  if (typeof submittedValue === "string") {
+    const trimmed = submittedValue.trim();
+    return trimmed ? trimmed : null;
+  }
+  const imBackValue = readMSTeamsImBackValue(submittedValue);
+  if (imBackValue) {
+    return imBackValue;
+  }
+  if (submittedValue == null) {
+    return null;
+  }
+  try {
+    return JSON.stringify(submittedValue);
+  } catch {
+    return null;
+  }
+}

--- a/extensions/msteams/src/monitor-handler.adaptive-card.test.ts
+++ b/extensions/msteams/src/monitor-handler.adaptive-card.test.ts
@@ -105,6 +105,56 @@ async function runAdaptiveCardInvoke(
   } as unknown as MSTeamsTurnContext);
 }
 
+async function runMessageActivity(params: {
+  value?: unknown;
+  text?: string;
+  deps?: MSTeamsMessageHandlerDeps;
+}) {
+  const deps = params.deps ?? createDeps();
+  let messageHandler: ((context: unknown, next: () => Promise<void>) => Promise<void>) | undefined;
+  const handler: MSTeamsActivityHandler = {
+    onMessage: (callback) => {
+      messageHandler = callback;
+      return handler;
+    },
+    onMembersAdded: () => handler,
+    onReactionsAdded: () => handler,
+    onReactionsRemoved: () => handler,
+    run: vi.fn(async () => undefined),
+  };
+  registerMSTeamsHandlers(handler, deps);
+  await messageHandler?.(
+    {
+      activity: {
+        id: "message-1",
+        type: "message",
+        text: params.text ?? "",
+        channelId: "msteams",
+        serviceUrl: "https://service.example.test",
+        from: {
+          id: "user-bf",
+          aadObjectId: "user-aad",
+          name: "User",
+        },
+        recipient: {
+          id: "bot-id",
+          name: "Bot",
+        },
+        conversation: {
+          id: "19:personal-chat",
+          conversationType: "personal",
+        },
+        channelData: {},
+        attachments: [],
+        value: params.value,
+      },
+      sendActivity: vi.fn(async () => ({ id: "activity-id" })),
+      sendActivities: async () => [],
+    } as unknown as MSTeamsTurnContext,
+    vi.fn(async () => undefined),
+  );
+}
+
 function lastDispatchedCtxPayload(): Record<string, unknown> {
   const dispatched = runtimeApiMockState.dispatchReplyFromConfigWithSettledDispatcher.mock.calls.at(
     -1,
@@ -250,5 +300,28 @@ describe("msteams adaptive card action invoke", () => {
     const ctxPayload = lastDispatchedCtxPayload();
     expect(ctxPayload.BodyForAgent).toBe(JSON.stringify(payload));
     expect(ctxPayload.CommandBody).toBe(JSON.stringify(payload));
+  });
+
+  it("routes message activities with submitted card values as message text", async () => {
+    const data = { value: "button-submit-value", label: "Submit action" };
+
+    await runMessageActivity({ value: data });
+
+    const ctxPayload = lastDispatchedCtxPayload();
+    expect(ctxPayload.BodyForAgent).toBe(JSON.stringify(data));
+    expect(ctxPayload.CommandBody).toBe(JSON.stringify(data));
+    expect(ctxPayload.SessionKey).toBe("msteams:direct:user-aad");
+    expect(ctxPayload.SenderId).toBe("user-aad");
+  });
+
+  it("keeps activity text ahead of submitted card values on normal messages", async () => {
+    await runMessageActivity({
+      text: "typed text",
+      value: { value: "card-value", label: "Card value" },
+    });
+
+    const ctxPayload = lastDispatchedCtxPayload();
+    expect(ctxPayload.BodyForAgent).toBe("typed text");
+    expect(ctxPayload.CommandBody).toBe("typed text");
   });
 });

--- a/extensions/msteams/src/monitor-handler.ts
+++ b/extensions/msteams/src/monitor-handler.ts
@@ -1,9 +1,6 @@
 // Msteams plugin module implements monitor handler behavior.
-import {
-  isRecord,
-  normalizeOptionalLowercaseString,
-  normalizeOptionalString,
-} from "openclaw/plugin-sdk/string-coerce-runtime";
+import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { serializeMSTeamsAdaptiveCardActionValue } from "./adaptive-card-submit.js";
 import { formatUnknownError } from "./errors.js";
 import { resolveMSTeamsSenderAccess } from "./monitor-handler/access.js";
 import { createMSTeamsMessageHandler } from "./monitor-handler/message-handler.js";
@@ -28,48 +25,6 @@ export type MSTeamsActivityHandler = {
   ) => MSTeamsActivityHandler;
   run?: (context: unknown) => Promise<void>;
 };
-
-function extractAdaptiveCardSubmittedData(value: unknown): unknown {
-  if (!isRecord(value)) {
-    return value;
-  }
-  const action = isRecord(value.action) ? value.action : undefined;
-  if (action && normalizeOptionalLowercaseString(action.type) === "action.submit" && "data" in action) {
-    return action.data;
-  }
-  return value;
-}
-
-function readMSTeamsImBackValue(value: unknown): string | null {
-  if (!isRecord(value)) {
-    return null;
-  }
-  const msteams = isRecord(value.msteams) ? value.msteams : undefined;
-  if (!msteams || normalizeOptionalLowercaseString(msteams.type) !== "imback") {
-    return null;
-  }
-  return normalizeOptionalString(msteams.value) ?? null;
-}
-
-function serializeAdaptiveCardActionValue(value: unknown): string | null {
-  const submittedValue = extractAdaptiveCardSubmittedData(value);
-  if (typeof submittedValue === "string") {
-    const trimmed = submittedValue.trim();
-    return trimmed ? trimmed : null;
-  }
-  const imBackValue = readMSTeamsImBackValue(submittedValue);
-  if (imBackValue) {
-    return imBackValue;
-  }
-  if (submittedValue == null) {
-    return null;
-  }
-  try {
-    return JSON.stringify(submittedValue);
-  } catch {
-    return null;
-  }
-}
 
 async function isInvokeAuthorized(params: {
   context: MSTeamsTurnContext;
@@ -191,7 +146,7 @@ export function registerMSTeamsHandlers<T extends MSTeamsActivityHandler>(
       // agent can react. Poll votes are intercepted in monitor.ts's
       // app.on("card.action") handler which returns the InvokeResponse to Teams.
       if (ctx.activity?.type === "invoke" && ctx.activity?.name === "adaptiveCard/action") {
-        const text = serializeAdaptiveCardActionValue(ctx.activity?.value);
+        const text = serializeMSTeamsAdaptiveCardActionValue(ctx.activity?.value);
         if (text) {
           await handleTeamsMessage({
             ...ctx,

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -20,6 +20,7 @@ import {
   createChannelHistoryWindow,
   type HistoryEntry,
 } from "openclaw/plugin-sdk/reply-history";
+import { serializeMSTeamsAdaptiveCardActionValue } from "../adaptive-card-submit.js";
 import {
   buildMSTeamsAttachmentPlaceholder,
   buildMSTeamsMediaPayload,
@@ -1012,7 +1013,9 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
       : [];
     const rawText = activity.text?.trim() ?? "";
     const htmlText = extractTextFromHtmlAttachments(attachments);
-    const text = stripMSTeamsMentionTags(rawText || htmlText);
+    const valueText =
+      rawText || htmlText ? "" : serializeMSTeamsAdaptiveCardActionValue(activity.value);
+    const text = stripMSTeamsMentionTags(rawText || htmlText || valueText || "");
     const wasMentioned = wasMSTeamsBotMentioned(activity);
     const conversationId = normalizeMSTeamsConversationId(activity.conversation?.id ?? "");
     const replyToId = activity.replyToId ?? undefined;


### PR DESCRIPTION
## What Problem This Solves

Microsoft Teams can deliver Adaptive Card submit clicks as normal `message` activities with empty `text` and submitted data in `activity.value`. The existing Teams handler already serialized the canonical `adaptiveCard/action` invoke path, but this observed fallback shape could reach the agent as an empty or no-op message.

This PR reuses the existing Adaptive Card submit serialization for that normal-message fallback path, while preserving existing precedence so real typed message text and extracted HTML text still win over `activity.value`.

## Summary

- Problem: Microsoft Teams Adaptive Card submit clicks can arrive as a normal `message` activity with empty text and the submit payload in `activity.value`, not only as the canonical Adaptive Card invoke shape.
- What changed: shared Teams Adaptive Card submit serialization between the canonical invoke handler and the normal message handler fallback.
- Why it matters: Teams button clicks that would otherwise look like empty inbound messages now reach the agent as meaningful user input.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes: N/A
- Related: live Teams payload capture
- [x] This PR fixes a bug or regression

## Root Cause / Regression History

- Root cause: the Teams monitor handler only converted Adaptive Card submit payloads to text on the canonical `adaptiveCard/action` invoke path. Live Teams testing showed that submit data can also arrive on a normal `message` activity as `activity.value`, with no useful `activity.text`.
- Missing detection / guardrail: existing tests covered the canonical invoke path, but not a normal `message` activity whose useful content is only in `activity.value`.
- Prior context: Teams button submit handling already existed for invoke activities; this patch reuses the same serializer for the observed fallback shape.
- Why this surfaced now: live payload capture of Teams Adaptive Card actions found a delivery shape that the existing code did not explicitly handle.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `extensions/msteams/src/monitor-handler.adaptive-card.test.ts`
- Scenario the test locks in:
  - A Teams `message` activity with empty `text` and submit data in `activity.value` is delivered to the agent as serialized submit text.
  - Existing real message text still wins over `activity.value`, so normal messages are not overwritten by incidental structured values.
- Why this is the smallest reliable guardrail: the bug is inside Teams inbound message normalization; a focused monitor-handler regression catches the observed payload shape without widening the PR into broader Teams interactivity work.

## User-visible / Behavior Changes

- Teams Adaptive Card button clicks delivered through the normal message fallback path now produce agent-visible input.
- Existing canonical Adaptive Card invoke behavior is preserved.
- Plain Teams message text continues to take precedence over `activity.value`.

## Evidence

- [x] Failing/passing regression behavior covered by test
- [x] Screenshot from live Microsoft Teams tenant
- [x] Anonymized raw activity excerpt

Live Teams proof, sanitized:

- A Teams Adaptive Card rendered with a `Send fallback value` button.
- After pressing the button, Teams showed `Your response was sent to the app`.
- The test bot received the fallback payload and replied with:
  - `<submitted-button-value>`
  - button label `"Send fallback value"`

Anonymized raw activity excerpt from the payload capture:

```json
{
  "type": "message",
  "text": "",
  "hasReplyToId": true,
  "value": {
    "value": "<submitted-button-value>",
    "label": "Send fallback value"
  },
  "channelId": "msteams",
  "conversationType": "personal"
}
```

Screenshot evidence:

- Sanitized screenshot attached to the PR comment/body after upload.
<img width="1700" height="760" alt="openclaw-teams-adaptive-fallback-evidence" src="https://github.com/user-attachments/assets/30f34d5f-13f4-417e-9c16-f7626a9839e9" />

## Validation

Passed:

```bash
pnpm test -- extensions/msteams/src/monitor-handler.adaptive-card.test.ts
```

Result:

```text
Test Files  1 passed (1)
Tests       8 passed (8)
```

Live smoke:

- Deployed this branch's `@openclaw/msteams` extension to a private test gateway for a single-account Teams test.
- Sent a clean Adaptive Card to Teams.
- Clicked `Send fallback value`.
- Verified the test bot received and replied with the submitted fallback payload.
- Restored the test gateway back to its prior multi-account Teams setup after screenshot capture.

Rollback verification after smoke:

- `Microsoft Teams default: enabled, configured, running, works`
- `Microsoft Teams secondary: enabled, configured, running, works`
- Both local Teams listener ports were active
- Public unsigned probes for both Teams routes returned `401 Unauthorized`, not `502`

Known validation limitation:

```bash
pnpm --filter @openclaw/msteams exec tsc -p tsconfig.json --noEmit
```

currently fails on latest `upstream/main` in pre-existing Teams SDK drift areas unrelated to this change, including:

- `doctor-contract-api.ts`
- `src/graph-thread.ts`
- `src/presentation.ts`
- `src/probe.ts`
- `src/thread-parent-context.ts`
- `src/token.ts`

The new/changed files for this PR are not among the reported typecheck failures.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

This is intentionally independent of the larger Teams multi-account PR. If that PR lands first, this branch should be rebased and the same fallback behavior carried into the refactored account-aware Teams monitor handler. The expected overlap is limited to the Teams monitor-handler files; the behavior remains the same.

## Implementation Alignment

- Reuses the existing Teams Adaptive Card submit serialization behavior instead of introducing a second parser for the message fallback path.
- Keeps the fallback inside the existing Teams message normalization flow, next to `activity.text`, HTML attachment text extraction, and mention stripping.
- Uses existing OpenClaw runtime helpers (`isRecord`, `normalizeOptionalLowercaseString`, `normalizeOptionalString`) for unknown payload coercion.
- Preserves existing precedence: typed message text and extracted HTML text win over `activity.value`.
- Adds focused coverage in the existing Teams Adaptive Card monitor-handler test file.

## Risk and Mitigation

- Risk: serializing `activity.value` too eagerly could turn unrelated structured message values into user text.
  - Mitigation: the fallback only runs when both extracted message text and HTML text are empty, and existing message text continues to win.
- Risk: Teams has multiple Adaptive Card submit shapes.
  - Mitigation: the serializer is shared with the existing canonical invoke path and handles string, object, and Teams `msteams.imBack` submit payloads.

## AI Assistance

This PR was prepared with AI assistance. The implementation, tests, live Teams validation, and anonymized evidence were reviewed by the contributor before submission.