### PR TITLE
improve(qa-lab): bound Discord API response reads in mantis smoke

### DIFF
--- a/extensions/qa-lab/src/mantis/discord-smoke.runtime.test.ts
+++ b/extensions/qa-lab/src/mantis/discord-smoke.runtime.test.ts
@@ -255,6 +255,122 @@ describe("mantis discord smoke runtime", () => {
     expect(fetchGuardCallsWithMethod("POST")).toHaveLength(0);
   });
 
+  it("fails closed when a Discord API response exceeds the byte cap", async () => {
+    const oversizedBody = "x".repeat(16 * 1024 * 1024 + 1);
+    const release = vi.fn();
+    fetchWithSsrFGuard.mockImplementation(async ({ url }: { url: string }) => {
+      const pathname = new URL(url).pathname;
+      if (pathname === "/api/v10/users/@me") {
+        return {
+          response: new Response(oversizedBody, {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+          release,
+        };
+      }
+      return {
+        response: jsonResponse({ message: `unexpected ${pathname}` }, 404),
+        release: vi.fn(),
+      };
+    });
+
+    const result = await runMantisDiscordSmoke({
+      repoRoot,
+      outputDir: ".artifacts/qa-e2e/mantis/oversized",
+      tokenFile,
+      env: {
+        OPENCLAW_QA_DISCORD_GUILD_ID: "1456350064065904867",
+        OPENCLAW_QA_DISCORD_CHANNEL_ID: "1456744319972282449",
+      },
+    });
+
+    expect(result.status).toBe("fail");
+    const errorText = await fs.readFile(path.join(result.outputDir, "error.txt"), "utf8");
+    expect(errorText).toContain("/users/@me response exceeds");
+    expect(errorText).toContain(`${16 * 1024 * 1024} bytes`);
+    // The byte cap trips on the first call, so the post step never runs.
+    expect(fetchGuardCallsWithMethod("POST")).toHaveLength(0);
+    // The connection is still released on the fail-closed path.
+    expect(release).toHaveBeenCalled();
+  });
+
+  it("parses a large-but-under-cap Discord response unchanged", async () => {
+    // A bot username padded out to ~1 MiB of valid JSON: streamed across many
+    // chunks but comfortably under the 16 MiB cap, so the smoke must still pass
+    // and never truncate the legitimate payload.
+    const paddedUsername = `Mantis${"_".repeat(1024 * 1024)}`;
+    const baseImpl = fetchWithSsrFGuard.getMockImplementation();
+    fetchWithSsrFGuard.mockImplementation(
+      async (request: { url: string; init?: RequestInit }) => {
+        const pathname = new URL(request.url).pathname;
+        if (pathname === "/api/v10/users/@me") {
+          return {
+            response: jsonResponse({ id: "1489650053747314748", username: paddedUsername }),
+            release: vi.fn(),
+          };
+        }
+        return baseImpl!(request);
+      },
+    );
+
+    const result = await runMantisDiscordSmoke({
+      repoRoot,
+      outputDir: ".artifacts/qa-e2e/mantis/under-cap",
+      tokenFile,
+      env: {
+        OPENCLAW_QA_DISCORD_GUILD_ID: "1456350064065904867",
+        OPENCLAW_QA_DISCORD_CHANNEL_ID: "1456744319972282449",
+      },
+    });
+
+    expect(result.status).toBe("pass");
+    const summary = JSON.parse(await fs.readFile(result.summaryPath, "utf8")) as {
+      bot?: { username?: string };
+      status: string;
+    };
+    expect(summary.status).toBe("pass");
+    // The full (un-truncated) padded username round-trips through the bounded read.
+    expect(summary.bot?.username).toBe(paddedUsername);
+    expect(fetchGuardCallsWithMethod("POST")).toHaveLength(1);
+  });
+
+  it("fails with a parse error when a Discord 200 body is not JSON (bounded read preserves malformed handling)", async () => {
+    const release = vi.fn();
+    fetchWithSsrFGuard.mockImplementation(async ({ url }: { url: string }) => {
+      const pathname = new URL(url).pathname;
+      if (pathname === "/api/v10/users/@me") {
+        return {
+          response: new Response("<!doctype html><html>not json</html>", {
+            status: 200,
+            headers: { "content-type": "text/html" },
+          }),
+          release,
+        };
+      }
+      return {
+        response: jsonResponse({ message: `unexpected ${pathname}` }, 404),
+        release: vi.fn(),
+      };
+    });
+
+    const result = await runMantisDiscordSmoke({
+      repoRoot,
+      outputDir: ".artifacts/qa-e2e/mantis/malformed",
+      tokenFile,
+      env: {
+        OPENCLAW_QA_DISCORD_GUILD_ID: "1456350064065904867",
+        OPENCLAW_QA_DISCORD_CHANNEL_ID: "1456744319972282449",
+      },
+    });
+
+    expect(result.status).toBe("fail");
+    // A non-JSON 200 still surfaces as a clean fail (JSON.parse throws on the
+    // under-cap body), and no post is attempted.
+    expect(fetchGuardCallsWithMethod("POST")).toHaveLength(0);
+    expect(release).toHaveBeenCalled();
+  });
+
   it("redacts response guild ids in mismatch failure artifacts", async () => {
     fetchWithSsrFGuard.mockImplementation(
       async ({ url, init }: { url: string; init?: RequestInit }) => {

--- a/extensions/qa-lab/src/mantis/discord-smoke.runtime.ts
+++ b/extensions/qa-lab/src/mantis/discord-smoke.runtime.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { ensureRepoBoundDirectory, resolveRepoRelativeOutputDir } from "../cli-paths.js";
 import { isTruthyOptIn, trimToValue } from "../mantis-options.runtime.js";
@@ -100,6 +101,7 @@ const DEFAULT_MANTIS_TOKEN_FILE_ENV = "OPENCLAW_QA_DISCORD_MANTIS_BOT_TOKEN_FILE
 const DEFAULT_GUILD_ID_ENV = "OPENCLAW_QA_DISCORD_GUILD_ID";
 const DEFAULT_CHANNEL_ID_ENV = "OPENCLAW_QA_DISCORD_CHANNEL_ID";
 const QA_REDACT_PUBLIC_METADATA_ENV = "OPENCLAW_QA_REDACT_PUBLIC_METADATA";
+const DISCORD_API_RESPONSE_MAX_BYTES = 16 * 1024 * 1024;
 
 function assertDiscordSnowflake(value: string, label: string) {
   if (!/^\d{17,20}$/u.test(value)) {
@@ -201,7 +203,11 @@ async function callDiscordApi<T>(params: {
     auditContext: "qa-lab-mantis-discord-smoke",
   });
   try {
-    const text = await response.text();
+    const buffer = await readResponseWithLimit(response, DISCORD_API_RESPONSE_MAX_BYTES, {
+      onOverflow: ({ maxBytes }) =>
+        new Error(`Discord API ${params.path} response exceeds ${maxBytes} bytes`),
+    });
+    const text = buffer.toString("utf8");
     const payload = text.trim() ? (JSON.parse(text) as unknown) : undefined;
     params.apiCalls.push({
       label: params.label,


### PR DESCRIPTION
## What Problem This Solves

The internal Mantis Discord smoke check (`qa-lab` extension) talks to `discord.com` and reads every API response body with an unbounded `await response.text()`. The request goes through `fetchWithSsrFGuard`, but that guard only vets the connection/host — it does **not** cap the response body. A hostile, compromised, or simply malfunctioning endpoint on the allowlisted host can therefore stream an arbitrarily large (or never-ending) payload, and the QA process buffers the whole thing into memory before `JSON.parse` ever runs. There is no known user-triggered crash today, but this was the one remaining unbounded external-body read in this file and could OOM the smoke run. It affects operators/developers running the Mantis Discord smoke diagnostic.

## Why This Change Was Made

Route every Discord response through the shared `readResponseWithLimit` helper (`openclaw/plugin-sdk/response-limit-runtime`, already used across ~20 providers and by the sibling Discord REST client `extensions/discord/src/internal/rest.ts`) with a 16 MiB cap — the same constant the qa-lab mock-openai server and several media providers use. The change is deliberately minimal: only the body read is replaced (`const buffer = await readResponseWithLimit(...)` then `buffer.toString("utf8")`); all downstream `JSON.parse`, ok/error handling, and `release()` cleanup are unchanged. The cap is fail-closed: on overflow the helper cancels the stream and throws, the existing `runMantisDiscordSmoke` try/catch turns that into `status=fail` + an `error.txt` artifact, so the check degrades gracefully and never posts to Discord. Non-goal: this does not touch the SSRF policy, the allowlist, or any legitimate (small JSON) Discord response behavior.

## User Impact

For operators/developers running the Mantis Discord smoke check: legitimate Discord JSON responses (well under 16 MiB) behave exactly as before. An abnormally large response now produces a clean `status=fail` with a descriptive `error.txt` ("Discord API <path> response exceeds 16777216 bytes") instead of risking an out-of-memory abort of the smoke run. No public API, CLI flag, or config surface changes. Blast radius is low: one source file plus its own test, reusing an established helper with no new dependency or API surface.

## Evidence

**Real behavior proof**

- **Behavior addressed**: an untrusted Discord response with no `Content-Length` and an oversized body must not be buffered whole — the read must stop at the cap, cancel the stream, and throw a bounded error, while valid small responses parse unchanged.
- **Real environment tested**: a real `node:http` server (`createServer`) bound to `127.0.0.1`, streaming a JSON body in 64 KiB chunks with **no** `Content-Length`, driving the **real exported** `readResponseWithLimit` helper (the exact helper `callDiscordApi` now wraps) on Node v22.22.0.
- **Exact steps**: (1) `GET /huge` streams a ~24 MiB JSON object with no `Content-Length`; drive `readResponseWithLimit(res, 16 MiB)` with the qa-lab `onOverflow` and assert it rejects + the stream is cancelled early. (2) **Negative control**: run the OLD path `await response.text()` against the same body and measure bytes pushed. (3) `GET /small` returns one valid result; assert it parses intact.
- **Evidence after fix**:

```
[case 1] oversized Discord body, cap=16777216 bytes, NO content-length
  ok: readResponseWithLimit rejected the oversized body (msg: Discord API /users/@me response exceeds 16777216 bytes)
  ok: fail-closed error matches the qa-lab onOverflow message
  ok: stream cancelled early: only 18284544 bytes reached the wire, not the full 25165824
[negative control] OLD unbounded await response.text() buffers everything
  ok: unbounded read pulled the FULL body (25165834 bytes >= 25165824), proving the cap is load-bearing
  ok: unbounded (25165834) read far more than bounded (18284544)
[case 3] normal small Discord JSON parses unchanged
  ok: small body parsed intact (username=Mantis)

ALL PROOF ASSERTIONS PASSED
```

- **Mutation check (the test is load-bearing)**: reverting `callDiscordApi` to the old `await response.text()` makes the new oversized test FAIL — it then surfaces a `JSON.parse` "Unexpected token 'x'" error because the full hostile body was buffered whole. Source restored afterward.
- **What was not tested**: live Discord endpoints were not hit (no keys; a hostile oversized body would not reproduce live). The proof measures bytes-on-wire + early stream cancellation, which is the load-bearing signal, rather than driving an actual OOM.

**Validation Evidence**

- Focused suite: `node scripts/run-vitest.mjs run extensions/qa-lab/src/mantis/discord-smoke.runtime.test.ts` → **9/9 passed** (6 pre-existing + 3 new).
- New tests: `fails closed when a Discord API response exceeds the byte cap` (16 MiB+1 body → `status=fail`, `error.txt` contains the bounded message, zero POSTs, `release()` invoked); `parses a large-but-under-cap Discord response unchanged` (~1 MiB padded username round-trips un-truncated across many chunks, smoke still passes and posts exactly once); `fails with a parse error when a Discord 200 body is not JSON` (regression — the bounded read still feeds `JSON.parse` and fails cleanly, releasing the connection).
- All tests use this file's OWN local `fetchWithSsrFGuard` mock; the shared `provider-http-test-mocks.ts` is intentionally NOT modified.
- `oxlint` clean on both changed files.

**Security & Privacy**

- Removes an unbounded external-body read on the `discord.com` path — memory-exhaustion / resource-abuse hardening. Fail-closed: overflow aborts the run rather than degrading silently.
- No tokens or target metadata are newly logged; the existing redaction path (`redactMantisDiscordMetadata`) still owns `error.txt` content. The overflow message contains only the request path and the byte limit, no response body.

**Compatibility**

- Backward compatible: identical behavior for all normal-sized Discord responses; `JSON.parse`, status/error handling and connection `release()` are unchanged (covered by the under-cap and malformed-body tests).
- Reuses the established `readResponseWithLimit` + `onOverflow` pattern (mirrors `extensions/discord/src/internal/rest.ts` and the image/video providers), so no new dependency or API surface.

Scope is one source file (`extensions/qa-lab/src/mantis/discord-smoke.runtime.ts`) plus its test. Rebuilt on latest `main` (behind 0). **Allow edits by maintainers** is enabled so maintainers can take it over if needed.

_AI-assisted: implemented with Claude Code under human direction. Claude wrote the bounded-read change, the three focused regression tests, and the standalone real-behavior + negative-control proof, ran the focused Vitest suite and the proof locally, and performed the mutation check; a human reviewed the diff and the proof before opening._
