### PR TITLE
fix: bound APNs relay response body so an oversized relay reply can't exhaust gateway memory

### DIFF
--- a/src/infra/push-apns.relay.test.ts
+++ b/src/infra/push-apns.relay.test.ts
@@ -343,6 +343,24 @@ describe("push-apns.relay", () => {
       });
     });
 
+    it("honors BOM-prefixed relay failure JSON", async () => {
+      const body = `\uFEFF${JSON.stringify({ ok: false, status: 410 })}`;
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValue(
+          new Response(body, { status: 202, headers: { "content-type": "application/json" } }),
+        );
+      vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+      await expect(sendApnsRelayPush(createRelayPushParams())).resolves.toEqual({
+        ok: false,
+        status: 410,
+        apnsId: undefined,
+        reason: undefined,
+        tokenSuffix: undefined,
+      });
+    });
+
     it("normalizes sandbox relay response metadata", async () => {
       const fetchMock = vi.fn().mockResolvedValue(
         new Response(

--- a/src/infra/push-apns.relay.test.ts
+++ b/src/infra/push-apns.relay.test.ts
@@ -291,11 +291,23 @@ describe("push-apns.relay", () => {
     });
 
     it("falls back to fetch status when the relay body is not JSON", async () => {
-      const fetchMock = vi.fn().mockResolvedValue({
+      // Real Response body so the bounded reader runs end-to-end; non-JSON parse stays a soft null.
+      const fetchMock = vi.fn().mockResolvedValue(new Response("not-json-at-all", { status: 202 }));
+      vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+      await expect(sendApnsRelayPush(createRelayPushParams())).resolves.toEqual({
         ok: true,
         status: 202,
-        json: vi.fn().mockRejectedValue(new Error("bad json")),
+        apnsId: undefined,
+        reason: undefined,
+        tokenSuffix: undefined,
       });
+    });
+
+    it("treats an empty relay body as absent and derives status from the HTTP response", async () => {
+      // Empty body: JSON.parse("") throws -> soft null fallback (not an overflow), same as the
+      // prior response.json() behaviour. Confirms the new try/catch does not regress empty bodies.
+      const fetchMock = vi.fn().mockResolvedValue(new Response("", { status: 202 }));
       vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
 
       await expect(sendApnsRelayPush(createRelayPushParams())).resolves.toEqual({
@@ -308,17 +320,18 @@ describe("push-apns.relay", () => {
     });
 
     it("normalizes relay JSON response fields", async () => {
-      const fetchMock = vi.fn().mockResolvedValue({
-        ok: true,
-        status: 202,
-        json: vi.fn().mockResolvedValue({
-          ok: false,
-          status: 410,
-          apnsId: " relay-apns-id ",
-          reason: " Unregistered ",
-          tokenSuffix: " abcd1234 ",
-        }),
-      });
+      const fetchMock = vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            ok: false,
+            status: 410,
+            apnsId: " relay-apns-id ",
+            reason: " Unregistered ",
+            tokenSuffix: " abcd1234 ",
+          }),
+          { status: 202, headers: { "content-type": "application/json" } },
+        ),
+      );
       vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
 
       await expect(sendApnsRelayPush(createRelayPushParams())).resolves.toEqual({
@@ -331,16 +344,17 @@ describe("push-apns.relay", () => {
     });
 
     it("normalizes sandbox relay response metadata", async () => {
-      const fetchMock = vi.fn().mockResolvedValue({
-        ok: true,
-        status: 200,
-        json: vi.fn().mockResolvedValue({
-          ok: true,
-          status: 200,
-          environment: "sandbox",
-          tokenSuffix: " abcd1234 ",
-        }),
-      });
+      const fetchMock = vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            ok: true,
+            status: 200,
+            environment: "sandbox",
+            tokenSuffix: " abcd1234 ",
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      );
       vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
 
       await expect(sendApnsRelayPush(createRelayPushParams())).resolves.toEqual({
@@ -351,6 +365,61 @@ describe("push-apns.relay", () => {
         environment: "sandbox",
         tokenSuffix: "abcd1234",
       });
+    });
+
+    it("parses a large under-cap relay body unchanged (boundary just below the 16 MiB cap)", async () => {
+      // A valid, large-but-bounded JSON body (~8 MiB payload, comfortably under the 16 MiB cap)
+      // must still parse normally: the cap only rejects overflow, it must not truncate or reject
+      // legitimate large success responses.
+      const padding = "x".repeat(8 * 1024 * 1024);
+      const fetchMock = vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            ok: true,
+            status: 200,
+            apnsId: "big-but-valid",
+            note: padding,
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      );
+      vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+      await expect(sendApnsRelayPush(createRelayPushParams())).resolves.toEqual({
+        ok: true,
+        status: 200,
+        apnsId: "big-but-valid",
+        reason: undefined,
+        tokenSuffix: undefined,
+      });
+    });
+
+    it("fails closed when the relay response body exceeds the size cap", async () => {
+      // Drive the real send path with an over-cap (>16 MiB) body: the bounded reader must
+      // cancel the stream and the request must fail closed rather than report a delivered push.
+      const oversized = "a".repeat(16 * 1024 * 1024 + 1024);
+      const fetchMock = vi.fn().mockResolvedValue(new Response(oversized, { status: 200 }));
+      vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+      await expect(sendApnsRelayPush(createRelayPushParams())).resolves.toEqual({
+        ok: false,
+        status: 200,
+        reason: "RelayResponseTooLarge",
+      });
+    });
+
+    it("fails closed on an oversized body even when the HTTP status would imply success", async () => {
+      // Regression guard for the core design decision: a 2xx relay response with an oversized
+      // body must NOT be folded into the malformed-JSON (treat-as-empty -> HTTP-derived ok)
+      // fallback. Overflow always wins and the push is reported failed, never silently delivered.
+      const oversized = "b".repeat(16 * 1024 * 1024 + 4096);
+      const fetchMock = vi.fn().mockResolvedValue(new Response(oversized, { status: 202 }));
+      vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+      const result = await sendApnsRelayPush(createRelayPushParams());
+      expect(result.ok).toBe(false);
+      expect(result.reason).toBe("RelayResponseTooLarge");
+      expect(result.status).toBe(202);
     });
   });
 });

--- a/src/infra/push-apns.relay.ts
+++ b/src/infra/push-apns.relay.ts
@@ -1,5 +1,6 @@
 // Sends APNs notifications through the configured relay endpoint.
 import { URL } from "node:url";
+import { readResponseWithLimit } from "@openclaw/media-core/read-response-with-limit";
 import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 import {
   normalizeLowercaseStringOrEmpty,
@@ -59,6 +60,10 @@ export type ApnsRelayRequestSender = (params: {
 export const DEFAULT_APNS_RELAY_BASE_URL = "https://ios-push-relay.openclaw.ai";
 export const DEFAULT_APNS_SANDBOX_RELAY_BASE_URL = "https://ios-push-relay-sandbox.openclaw.ai";
 const DEFAULT_APNS_RELAY_TIMEOUT_MS = 10_000;
+// Hard cap on the relay response body. The hosted relay reply is a tiny JSON status object;
+// without a cap a buggy/hostile/compromised relay could stream an unbounded body and exhaust
+// gateway memory (the existing AbortSignal.timeout only bounds connection latency, not body size).
+const APNS_RELAY_MAX_RESPONSE_BYTES = 16 * 1024 * 1024;
 const GATEWAY_DEVICE_ID_HEADER = "x-openclaw-gateway-device-id";
 const GATEWAY_SIGNATURE_HEADER = "x-openclaw-gateway-signature";
 const GATEWAY_SIGNED_AT_HEADER = "x-openclaw-gateway-signed-at-ms";
@@ -226,6 +231,19 @@ export function resolveApnsRelayConfigFromEnv(
   };
 }
 
+// Sentinel marking an over-cap relay body. Carried as a distinct type so the response-read
+// catch path can fail closed on overflow instead of swallowing it into the malformed-JSON
+// (treat-as-empty-body) fallback that would otherwise report a successful send.
+class ApnsRelayResponseTooLargeError extends Error {
+  constructor(
+    readonly size: number,
+    readonly maxBytes: number,
+  ) {
+    super(`APNs relay response exceeded ${maxBytes} bytes (${size} bytes received)`);
+    this.name = "ApnsRelayResponseTooLargeError";
+  }
+}
+
 async function sendApnsRelayRequest(params: {
   relayConfig: ApnsRelayConfig;
   sendGrant: string;
@@ -262,8 +280,22 @@ async function sendApnsRelayRequest(params: {
 
   let json: unknown;
   try {
-    json = (await response.json()) as unknown;
-  } catch {
+    // Bound the relay body before buffering it; cancel the stream past the cap.
+    const buffer = await readResponseWithLimit(response, APNS_RELAY_MAX_RESPONSE_BYTES, {
+      onOverflow: ({ size, maxBytes }) => new ApnsRelayResponseTooLargeError(size, maxBytes),
+    });
+    json = JSON.parse(buffer.toString("utf8")) as unknown;
+  } catch (err) {
+    if (err instanceof ApnsRelayResponseTooLargeError) {
+      // Fail closed: an oversized relay body must never be reported as a delivered push.
+      return {
+        ok: false,
+        status: response.status,
+        reason: "RelayResponseTooLarge",
+      };
+    }
+    // Malformed/empty JSON (or a non-overflow body read error) keeps the prior behaviour:
+    // treat the body as absent and derive status/ok from the HTTP response.
     json = null;
   }
   const body =

--- a/src/infra/push-apns.relay.ts
+++ b/src/infra/push-apns.relay.ts
@@ -284,7 +284,7 @@ async function sendApnsRelayRequest(params: {
     const buffer = await readResponseWithLimit(response, APNS_RELAY_MAX_RESPONSE_BYTES, {
       onOverflow: ({ size, maxBytes }) => new ApnsRelayResponseTooLargeError(size, maxBytes),
     });
-    json = JSON.parse(buffer.toString("utf8")) as unknown;
+    json = JSON.parse(new TextDecoder("utf-8").decode(buffer)) as unknown;
   } catch (err) {
     if (err instanceof ApnsRelayResponseTooLargeError) {
       // Fail closed: an oversized relay body must never be reported as a delivered push.


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a gateway sending iOS push notifications through the hosted APNs relay could exhaust its own memory when the relay returns an abnormally large HTTP response body. `sendApnsRelayRequest` (`src/infra/push-apns.relay.ts`) buffered the relay reply with `await response.json()`, which has no size limit. The relay reply is supposed to be a tiny JSON status object, but a buggy, misconfigured, hostile, or compromised relay endpoint (including a self-hosted/loopback `baseUrl` override) can stream an unbounded body. The existing `AbortSignal.timeout` only bounds connection latency, not response body size, so nothing stops the gateway from buffering an arbitrarily large body into memory.

The affected surface is the gateway-originated APNs push path.

## Why This Change Was Made

Read the relay response through the shared `readResponseWithLimit` helper (`@openclaw/media-core/read-response-with-limit`) under a 16 MiB cap, then `JSON.parse` the resulting buffer. This mirrors the existing bounded-read precedent already used for ClawHub JSON in `src/infra/clawhub.ts` (same 16 MiB cap as `CLAWHUB_JSON_MAX_BYTES`), reusing the repo's established helper rather than introducing a new mechanism.

Key design decision (fail-closed): the prior code wrapped the body read in a `try/catch` that swallowed any failure into `json = null`, which then derived a *successful* `ok` from the HTTP status. Simply moving the bounded read inside that same catch would silently turn an overflow into a reported-as-delivered push. Instead, overflow is raised as a dedicated `ApnsRelayResponseTooLargeError` and the request fails closed (`ok:false`, `reason:"RelayResponseTooLarge"`). Genuine JSON-parse errors, empty bodies, and other non-overflow read errors keep the prior treat-as-empty-body behaviour, so this is not a behaviour change for normal/malformed-but-small responses — only oversized bodies change outcome.

Non-goal: this does not change the relay protocol, the success-path response shape, or any normal-size response handling.

## User Impact

Operators running a gateway with APNs relay push enabled are protected from an out-of-memory crash triggered by an oversized relay response. On overflow the push is reported as failed (`ok:false`, `RelayResponseTooLarge`) instead of being silently treated as delivered, so failures are now visible and accurate rather than masked. There is no user-visible change for normal relay traffic.

## Evidence

### Real behavior proof

- **Behavior addressed**: an untrusted relay success response with no `Content-Length` and an oversized/never-ending body must not be buffered whole; the read must stop at the cap, cancel the stream, and fail the push closed — while valid small responses still parse unchanged.
- **Real environment tested**: a real `node:http` server (`createServer`) bound to `127.0.0.1`, streaming a JSON body in 64 KiB chunks with **no `Content-Length`** header, driving the **real** `sendApnsRelayPush` → `sendApnsRelayRequest` → real `fetch` → real `Response` stream → real `readResponseWithLimit` path (no stubbed `fetch`). Node v22.22.0.
- **Exact steps**:
  1. Boot the server; `/huge` streams an unbounded JSON object (~24 MiB) with no `Content-Length`; `/small` returns one valid status object.
  2. Drive the real `sendApnsRelayPush` against `/huge` and assert it returns `ok:false, RelayResponseTooLarge` and the server stopped well short of 24 MiB (stream cancelled).
  3. Drive it against `/small` and assert the success path is unchanged.
  4. **Negative control**: run the OLD unbounded read against the same `/huge` body and measure how many bytes the server pushed.
- **Evidence after fix**:

```
[case 1] oversized -> result: {"ok":false,"status":200,"reason":"RelayResponseTooLarge"}
[case 1] cap=16777216 bytes; server pushed ~18284552 bytes before the client cancelled the stream
[case 2] small -> result: {"ok":true,"status":200,"apnsId":"real-relay-ok"}
[negative control] unbounded read pulled the FULL body: 25165833 bytes (>= 24 MiB), proving the cap is load-bearing
```

  The bounded path cancels the stream at ~18 MiB (near the 16 MiB cap, not the full 24 MiB body); the unbounded control pulls the full ~24 MiB, proving the cap is load-bearing.

- **What was not tested**: live hosted relay endpoints were not hit (would not reproduce a hostile oversized body). The proof measures bytes-on-wire + early stream cancel and the fail-closed outcome, which is the load-bearing signal.

### Mutation check (tests are load-bearing)

Temporarily changing the fix to *fail open* (swallow overflow into the `json = null` fallback) makes the fail-closed test fail as expected:

```
× fails closed when the relay response body exceeds the size cap
  AssertionError: expected { ok: true, status: 200, …(3) } to deeply equal { ok: false, status: 200, …(1) }
  -   "reason": "RelayResponseTooLarge",
```

Restoring the fix returns the suite to green.

### Focused tests

```
node scripts/run-vitest.mjs run --config test/vitest/vitest.infra.config.ts src/infra/push-apns.relay.test.ts

 Test Files  1 passed (1)
      Tests  20 passed (20)
```

Focused tests drive the **real** `sendApnsRelayRequest` path via `sendApnsRelayPush` (no injected `requestSender`), stubbing `global.fetch` to return real `Response` objects with actual body streams. The tests use only this file's local mocks; the shared `provider-http-test-mocks.ts` is intentionally not touched.

<details>
<summary>Validation Evidence</summary>

- New test `fails closed when the relay response body exceeds the size cap`: real >16 MiB body → bounded reader cancels stream → `ok:false, RelayResponseTooLarge`.
- New test `fails closed on an oversized body even when the HTTP status would imply success`: 2xx + oversized body must still fail closed (regression guard for the core design decision; overflow never folds into the treat-as-empty fallback).
- New test `parses a large under-cap relay body unchanged`: ~8 MiB valid JSON still parses normally — the cap rejects overflow only, never truncates legitimate large success responses.
- New test `treats an empty relay body as absent`: empty body keeps the soft-null fallback (no regression for empty/`204`-style bodies).
- Existing tests retained and converted to real `Response` bodies so the bounded reader runs end-to-end.
- Real `node:http` loopback proof + mutation check above.
- `oxlint` clean (no findings) and `oxfmt --check` reports correct formatting on both changed files.
- All 20 tests in the file pass.

</details>

<details>
<summary>Security &amp; Privacy</summary>

- Hardening fix: removes an unbounded-memory read of an external (relay) response, closing a DoS/OOM vector reachable by a malicious or compromised relay.
- Fail-closed semantics: an oversized body is never reported as a delivered push, preventing silent success masking.
- No new secrets, logging of payloads, or PII handling; no change to signatures, grants, or the relay origin/redirect protections.
- No new dependency — reuses the existing `@openclaw/media-core/read-response-with-limit` helper.

</details>

<details>
<summary>Compatibility</summary>

- Backwards compatible for all normal-size responses: success-path response shape and field normalization are unchanged; malformed/empty small JSON keeps the existing treat-as-empty-body fallback.
- Only oversized (>16 MiB) responses change outcome (now fail closed). 16 MiB matches the existing repo precedent (`CLAWHUB_JSON_MAX_BYTES`). Custom relay operators returning bodies over 16 MiB would see those pushes report failure after upgrade — intentional, since the previous success-derived outcome was unsafe.
- No API, config, or schema changes. Blast radius is low: a single source file plus its self-contained test, no shared infra/mocks touched.

</details>

---

_AI-assisted (Claude Code)._ Implementation and tests were authored with Claude Code (Anthropic). Degree of assistance: the helper-reuse pattern, the fail-closed overflow design, the focused tests, and the real `node:http` loopback proof + mutation check were drafted by Claude Code, then reviewed and validated locally by the author (focused vitest run + real-server proof + oxlint/oxfmt). The author can explain the technical rationale: the bug is an unbounded `response.json()` buffer; the fix swaps in the shared bounded reader and distinguishes overflow (fail-closed) from JSON-parse/empty errors (null fallback) so an oversized body can never be reported as a delivered push.
