### PR TITLE
fix(proxy-capture): bound captured response bodies to prevent OOM

### DIFF
--- a/src/proxy-capture/runtime.test.ts
+++ b/src/proxy-capture/runtime.test.ts
@@ -55,6 +55,40 @@ const deps: DebugProxyCaptureRuntimeDeps = {
   safeJsonString: (value: unknown) => (value == null ? undefined : JSON.stringify(value)),
 };
 
+const ONE_MIB = 1024 * 1024;
+
+// Builds a chunked (no Content-Length) response that streams `totalBytes` so the
+// bounded body reader exercises its real overflow/cancel path on the clone.
+function makeStreamingResponse(totalBytes: number, headers: Record<string, string> = {}): Response {
+  let sent = 0;
+  const stream = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (sent >= totalBytes) {
+        controller.close();
+        return;
+      }
+      const size = Math.min(ONE_MIB, totalBytes - sent);
+      sent += size;
+      controller.enqueue(new Uint8Array(size));
+    },
+  });
+  return new Response(stream, {
+    status: 200,
+    headers: { "content-type": "application/octet-stream", ...headers },
+  });
+}
+
+async function waitForResponseSettled(): Promise<void> {
+  for (let i = 0; i < 500; i += 1) {
+    if (events.some((event) => event.kind === "response" || event.kind === "error")) {
+      return;
+    }
+    await new Promise((resolve) => {
+      setImmediate(resolve);
+    });
+  }
+}
+
 describe("debug proxy runtime", () => {
   beforeEach(() => {
     finalizeDebugProxyCapture(settings, deps);
@@ -160,5 +194,130 @@ describe("debug proxy runtime", () => {
       "content-type": "application/json",
       "set-cookie": "[REDACTED]",
     });
+  });
+
+  it("skips capturing the body when Content-Length exceeds the cap", async () => {
+    initializeDebugProxyCapture("test", settings, deps);
+    captureHttpExchange(
+      {
+        url: "https://api.openai.com/v1/files/big",
+        method: "GET",
+        response: new Response("{}", {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+            "content-length": String(32 * 1024 * 1024),
+          },
+        }),
+      },
+      settings,
+      deps,
+    );
+    await waitForResponseSettled();
+    finalizeDebugProxyCapture(settings, deps);
+
+    const response = events.find((event) => event.kind === "response");
+    expect(response).toBeDefined();
+    expect(response?.status).toBe(200);
+    // Metadata is recorded, but the oversized body is never buffered/persisted.
+    expect(JSON.parse(String(response?.metaJson))).toMatchObject({ bodyCapture: "too-large" });
+    expect(response).not.toHaveProperty("dataText");
+    expect(events.some((event) => event.kind === "error")).toBe(false);
+  });
+
+  it("fails closed on chunked responses that stream past the cap", async () => {
+    initializeDebugProxyCapture("test", settings, deps);
+    // 20 MiB streamed without a Content-Length header: the bounded reader must
+    // cancel the clone at the cap and record metadata instead of buffering it.
+    captureHttpExchange(
+      {
+        url: "https://api.anthropic.com/v1/messages",
+        method: "POST",
+        response: makeStreamingResponse(20 * ONE_MIB),
+      },
+      settings,
+      deps,
+    );
+    await waitForResponseSettled();
+    finalizeDebugProxyCapture(settings, deps);
+
+    const response = events.find((event) => event.kind === "response");
+    expect(response).toBeDefined();
+    expect(JSON.parse(String(response?.metaJson))).toMatchObject({ bodyCapture: "too-large" });
+    expect(response).not.toHaveProperty("dataText");
+    expect(events.some((event) => event.kind === "error")).toBe(false);
+  });
+
+  it("captures small chunked bodies normally (under the cap)", async () => {
+    initializeDebugProxyCapture("test", settings, deps);
+    captureHttpExchange(
+      {
+        url: "https://api.anthropic.com/v1/models",
+        method: "GET",
+        response: makeStreamingResponse(64 * 1024),
+      },
+      settings,
+      deps,
+    );
+    await waitForResponseSettled();
+    finalizeDebugProxyCapture(settings, deps);
+
+    const response = events.find((event) => event.kind === "response");
+    expect(response).toBeDefined();
+    expect(response?.status).toBe(200);
+    // Under the cap the body is read in full via the normal persist path, so no
+    // fail-closed metadata marker is set and the payload content-type is kept.
+    expect(response?.metaJson).toBeUndefined();
+    expect(response?.contentType).toBe("application/octet-stream");
+    expect(events.some((event) => event.kind === "error")).toBe(false);
+  });
+
+  it("captures empty chunked bodies normally (zero-length edge)", async () => {
+    initializeDebugProxyCapture("test", settings, deps);
+    // A streaming response that closes immediately must not be mistaken for an
+    // overflow: the bounded reader sees total=0, never trips the cap.
+    captureHttpExchange(
+      {
+        url: "https://api.anthropic.com/v1/empty",
+        method: "GET",
+        response: makeStreamingResponse(0),
+      },
+      settings,
+      deps,
+    );
+    await waitForResponseSettled();
+    finalizeDebugProxyCapture(settings, deps);
+
+    const response = events.find((event) => event.kind === "response");
+    expect(response).toBeDefined();
+    expect(response?.status).toBe(200);
+    expect(response?.metaJson).toBeUndefined();
+    expect(events.some((event) => event.kind === "error")).toBe(false);
+  });
+
+  it("records metadata-only for non-cloneable Response-like objects", async () => {
+    initializeDebugProxyCapture("test", settings, deps);
+    // Some seams hand capture a Response-like object that cannot be cloned. It
+    // must still be observable (status/headers) via the shared metadata path,
+    // tagged bodyCapture: "unavailable" (distinct from the "too-large" cap path).
+    const headers = new Headers({ "content-type": "application/json" });
+    captureHttpExchange(
+      {
+        url: "https://api.openai.com/v1/uncloneable",
+        method: "GET",
+        response: { status: 503, headers } as unknown as Response,
+      },
+      settings,
+      deps,
+    );
+    await waitForResponseSettled();
+    finalizeDebugProxyCapture(settings, deps);
+
+    const response = events.find((event) => event.kind === "response");
+    expect(response).toBeDefined();
+    expect(response?.status).toBe(503);
+    expect(JSON.parse(String(response?.metaJson))).toMatchObject({ bodyCapture: "unavailable" });
+    expect(response).not.toHaveProperty("dataText");
+    expect(events.some((event) => event.kind === "error")).toBe(false);
   });
 });

--- a/src/proxy-capture/runtime.ts
+++ b/src/proxy-capture/runtime.ts
@@ -18,6 +18,69 @@ import type {
 
 const DEBUG_PROXY_FETCH_PATCH_KEY = Symbol.for("openclaw.debugProxy.fetchPatch");
 const REDACTED_CAPTURE_HEADER_VALUE = "[REDACTED]";
+// Cap captured response bodies so debug proxy capture cannot be turned into an
+// out-of-memory vector. The patched global fetch tees every outbound response
+// through clone(), so a single large (or hostile, effectively endless) provider
+// response would otherwise be buffered fully into memory just to record it.
+const MAX_CAPTURED_RESPONSE_BODY_BYTES = 16 * 1024 * 1024;
+
+// Reads a cloned capture response body under a byte cap. Returns truncated=true
+// (and discards the partial buffer) once the cap is exceeded so oversized or
+// hostile/endless bodies are recorded as metadata-only instead of buffered.
+//
+// Unlike media-core's readResponseWithLimit this never awaits reader.cancel():
+// the body here is one branch of a Response.clone() tee whose sibling (the
+// caller-facing response) is still live, and cancelling such a branch never
+// settles (it only resolves once BOTH branches cancel). Awaiting it would hang
+// the capture pipeline and retain the buffered prefix forever, so we cancel
+// fire-and-forget, mirroring src/agents/tools/web-shared.ts#readResponseText.
+async function readCapturedResponseBodyBounded(
+  response: Response,
+  maxBytes: number,
+): Promise<{ buffer: Buffer; truncated: boolean }> {
+  const clone = response.clone();
+  const body = (clone as unknown as { body?: ReadableStream<Uint8Array> | null }).body;
+  if (!body || typeof body.getReader !== "function") {
+    // Non-streaming clone (e.g. test doubles): bounded arrayBuffer fallback.
+    const bytes = Buffer.from(await clone.arrayBuffer());
+    return bytes.length > maxBytes
+      ? { buffer: Buffer.alloc(0), truncated: true }
+      : { buffer: bytes, truncated: false };
+  }
+  const reader = body.getReader();
+  const chunks: Buffer[] = [];
+  let total = 0;
+  let truncated = false;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      if (!value?.length) {
+        continue;
+      }
+      if (total + value.length > maxBytes) {
+        truncated = true;
+        break;
+      }
+      chunks.push(Buffer.from(value));
+      total += value.length;
+    }
+  } finally {
+    if (truncated) {
+      void reader.cancel().catch(() => undefined);
+    }
+    try {
+      reader.releaseLock();
+    } catch {
+      // Some non-compliant/mocked streams reject releaseLock; ignore.
+    }
+  }
+  return truncated
+    ? { buffer: Buffer.alloc(0), truncated: true }
+    : { buffer: Buffer.concat(chunks, total), truncated: false };
+}
 const SENSITIVE_CAPTURE_HEADER_NAMES = new Set([
   "authorization",
   "proxy-authorization",
@@ -357,13 +420,10 @@ export function captureHttpExchange(
     metaJson: runtime.safeJsonString(params.meta),
     ...requestPayload,
   });
-  const cloneable =
-    params.response &&
-    typeof params.response.clone === "function" &&
-    typeof params.response.arrayBuffer === "function";
-  if (!cloneable) {
-    // Some Response-like objects cannot be cloned. Still record status/headers
-    // rather than forcing capture to consume or mutate the original response.
+  // Records the response status/headers without a body. Used both when a
+  // Response-like object cannot be cloned and when capturing the body would be
+  // unsafe (over the cap), so the exchange is still observable without OOM risk.
+  const recordResponseMetadataOnly = (bodyCapture: "unavailable" | "too-large") => {
     store.recordEvent({
       ...createHttpCaptureEventBase({
         settings,
@@ -384,16 +444,42 @@ export function captureHttpExchange(
         params.response.headers && typeof params.response.headers.entries === "function"
           ? runtime.safeJsonString(redactedCaptureHeaders(params.response.headers))
           : undefined,
-      metaJson: runtime.safeJsonString({ ...params.meta, bodyCapture: "unavailable" }),
+      metaJson: runtime.safeJsonString({ ...params.meta, bodyCapture }),
     });
+  };
+  const cloneable =
+    params.response &&
+    typeof params.response.clone === "function" &&
+    typeof params.response.arrayBuffer === "function";
+  if (!cloneable) {
+    // Some Response-like objects cannot be cloned. Still record status/headers
+    // rather than forcing capture to consume or mutate the original response.
+    recordResponseMetadataOnly("unavailable");
     return;
   }
-  void params.response
-    .clone()
-    .arrayBuffer()
-    .then((buffer) => {
+  // Fast path: when the provider declares an oversized Content-Length, skip the
+  // body entirely instead of buffering it. Missing/chunked lengths fall through
+  // to the bounded streaming read below, which cancels on overflow.
+  const declaredLength = Number(
+    typeof params.response.headers?.get === "function"
+      ? params.response.headers.get("content-length")
+      : undefined,
+  );
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_CAPTURED_RESPONSE_BODY_BYTES) {
+    recordResponseMetadataOnly("too-large");
+    return;
+  }
+  void readCapturedResponseBodyBounded(params.response, MAX_CAPTURED_RESPONSE_BODY_BYTES)
+    .then(({ buffer, truncated }) => {
+      if (truncated) {
+        // Body exceeded the cap mid-stream (chunked / understated length). The
+        // bounded reader already cancelled the clone and discarded the partial
+        // buffer; record metadata only instead of persisting an oversized blob.
+        recordResponseMetadataOnly("too-large");
+        return;
+      }
       const responsePayload = runtime.persistEventPayload(store, {
-        data: Buffer.from(buffer),
+        data: buffer,
         contentType: params.response.headers.get("content-type") ?? undefined,
       });
       store.recordEvent({


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where enabling debug proxy capture could exhaust process memory and crash the agent when a captured outbound request returns a very large (or hostile, effectively endless) HTTP response.

When debug proxy capture is enabled it patches global `fetch` and tees every outbound response through `response.clone().arrayBuffer()` purely to record it. `arrayBuffer()` buffers the *entire* body into memory with no upper bound, so a single multi-GB download, a streaming/chunked endpoint, or a malicious provider that streams forever turns "observe traffic" into an out-of-memory denial of service. This affects anyone running with debug proxy capture turned on (diagnostics / `openclaw` debug proxy sessions).

## Why This Change Was Made

Captured response bodies are now bounded to 16 MiB. The exchange is still always recorded (status, headers, metadata); only the body buffering is capped:

- Fast path: if the provider declares a `Content-Length` larger than the cap, the body is skipped entirely (no read) and recorded as metadata with `bodyCapture: "too-large"`.
- Missing / chunked length: the cloned body is read as a stream and accumulated up to the cap; on overflow the read fails closed — the clone is cancelled, the partial buffer is discarded, and the response is recorded as metadata-only (`bodyCapture: "too-large"`).
- Bodies under the cap are captured exactly as before (unchanged behavior).

Design note / non-goal: I deliberately did **not** reuse `@openclaw/media-core` `readResponseWithLimit` here even though it is the usual bounded-read helper. That helper `await`s `reader.cancel()`, but the body in this path is one branch of a `Response.clone()` tee whose sibling (the caller-facing response) is still live; cancelling such a branch never settles (it only resolves once *both* branches cancel — verified empirically), which would hang the capture pipeline and retain the buffered prefix forever. The local reader therefore cancels fire-and-forget, mirroring the existing pattern in `src/agents/tools/web-shared.ts#readResponseText` (which documents the same non-settling-cancel caveat). The 16 MiB cap matches the existing `OPENROUTER_MODELS_BODY_MAX_BYTES` precedent in `src/agents/model-scan.ts`.

## User Impact

- Operators running debug proxy capture no longer risk an OOM crash from a single large or unbounded captured response.
- Captured exchanges remain fully observable: status, (redacted) headers, and a `bodyCapture: "too-large"` marker are recorded when a body is skipped, so nothing silently disappears from the capture log — only the oversized body bytes are omitted.
- No change for normal-sized responses; their bodies are captured exactly as before.

## Evidence

### Real behavior proof (real debug-proxy session, SQLite read back from disk)

I drove the **real** capture pipeline end to end — a real `node:http` server (`createServer` bound to `127.0.0.1`) → the **real** patched global `fetch` installed by `initializeDebugProxyCapture` → the **real** `captureHttpExchange` + bounded reader → the **real** shared SQLite capture store — then read the persisted events/blobs **back from disk** and asserted what was recorded. Node v22.22.0, `OPENCLAW_STATE_DIR` pointed at a throwaway temp dir.

Scenarios on one live session:
1. `GET /huge-chunked` streams **20 MiB** in 64 KiB chunks with **no** `Content-Length`.
2. `GET /huge-declared` streams **20 MiB** with `Content-Length: 20 MiB` (> cap).
3. `GET /small` streams **64 KiB** (under cap).
4. Negative control (mirrors the canonical #96495 proof): run the **OLD** unbounded path `clone().arrayBuffer()` against the same 20 MiB body and measure how much it buffers.

```
REAL debug-proxy capture session against a real node:http server
  ok: global fetch patch installed by capture init
fetched /huge-chunked: status=200 caller-read=20971520 bytes
fetched /huge-declared: status=200 caller-read=20971520 bytes
fetched /small:        status=200 caller-read=65536 bytes

[case 1] 20 MiB chunked, NO content-length -> bounded streaming read fails closed
  ok: response event recorded (status=200)
  ok: metadata marks bodyCapture=too-large ({"captureOrigin":"global-fetch","source":"openclaw","bodyCapture":"too-large"})
  ok: no body blob persisted to SQLite (dataBlobId=null)
  ok: no inline body preview persisted
  ok: no error event emitted for this flow

[case 2] 20 MiB WITH content-length=20MiB -> fast path skips body read
  ok: response event recorded (status=200)
  ok: metadata marks bodyCapture=too-large
  ok: no body blob persisted to SQLite

[case 3] 64 KiB chunked under cap -> captured normally (regression guard)
  ok: response event recorded (status=200)
  ok: NO too-large marker (normal capture)
  ok: body blob persisted (dataBlobId=bf718b6f653b…)
  ok: persisted blob holds the full 64 KiB body (blob=65536)

[negative control] OLD path clone().arrayBuffer() on the SAME 20 MiB body
  ok: unbounded read pulls the FULL 20 MiB body (proves the cap is load-bearing) (buffered=20971520 vs cap=16777216)

ALL PROOF ASSERTIONS PASSED: 14 passed, 0 failed
```

The load-bearing signal is what the **capture side persisted to the real SQLite store**: **0 body bytes** for both oversized responses (recorded `bodyCapture: "too-large"`, `data_blob_id` NULL) versus the full 64 KiB blob for the under-cap response — while the negative control shows the old unbounded path would have buffered the entire 20 MiB. (Process RSS is not used as the assertion: the *caller* branch reads the full 20 MiB itself, so RSS is not the capture-side signal; this mirrors #96495, which measured persistence/bytes-on-wire rather than driving the heap to OOM.)

### Mutation test (proof the tests are load-bearing)

Temporarily setting `MAX_CAPTURED_RESPONSE_BODY_BYTES = Number.MAX_SAFE_INTEGER` (i.e. fail-open) makes exactly the two fail-closed unit tests go red, then green again once reverted:

```
 × skips capturing the body when Content-Length exceeds the cap
 × fails closed on chunked responses that stream past the cap
 Tests  2 failed | 4 passed (6)     ← with cap removed
 Tests  8 passed (8)                ← restored
```

<details>
<summary><b>Validation Evidence</b> (focused unit tests drive the real function)</summary>

5 added tests in `src/proxy-capture/runtime.test.ts` using the test file's own local store/deps mock (no shared `provider-http-test-mocks.ts` touched, so zero blast radius):

- `skips capturing the body when Content-Length exceeds the cap` — declares 32 MiB `Content-Length` → records `bodyCapture: "too-large"`, never buffers/persists, no error.
- `fails closed on chunked responses that stream past the cap` — streams 20 MiB with no `Content-Length` → bounded reader caps at 16 MiB, cancels the clone, discards the prefix, records `bodyCapture: "too-large"`.
- `captures small chunked bodies normally (under the cap)` — 64 KiB chunked body persisted normally (regression guard).
- `captures empty chunked bodies normally (zero-length edge)` — a stream that closes immediately is not mistaken for overflow.
- `records metadata-only for non-cloneable Response-like objects` — exercises the shared `recordResponseMetadataOnly` path and the `"unavailable"` vs `"too-large"` distinction.

```
$ node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts src/proxy-capture/runtime.test.ts
 Test Files  1 passed (1)
      Tests  8 passed (8)

$ node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts src/proxy-capture/
 Test Files  6 passed (6)
      Tests  33 passed (33)
```

`tsc --noEmit` clean for the changed file; `oxlint src/proxy-capture/runtime.ts src/proxy-capture/runtime.test.ts` exit 0.

**What was not tested:** No live cloud provider with real keys was hit (a real hostile/oversized body cannot be reproduced against a real provider). The proof instead drives a real local server + the real capture pipeline + real SQLite persistence, which is the load-bearing path the fix changes.
</details>

<details>
<summary><b>Security &amp; Privacy</b></summary>

- Hardening fix: removes an unbounded-memory (OOM/DoS) vector reachable via any captured large/streamed/hostile response while debug proxy capture is enabled. Fail-closed on overflow (drop body, keep metadata).
- No change to the existing sensitive-header redaction path; over-cap responses are recorded as metadata only, so no additional body bytes are persisted.
- No new logging of secrets; no new network calls; no new persisted data beyond the existing `bodyCapture` metadata marker (new value `"too-large"` alongside the existing `"unavailable"`).
</details>

<details>
<summary><b>Compatibility</b></summary>

- Behavior for under-cap responses is unchanged (same persisted blob + event shape) — covered by the under-cap, empty-body, and non-cloneable regression tests.
- Single-file runtime change plus its sibling test; no public API, config, schema, or plugin-SDK surface changes. Blast radius is **low**: one runtime file + its own test, no shared mocks/infra touched.
- The `bodyCapture` metadata field already exists (`"unavailable"`); this adds one new enum value `"too-large"`. No migration needed.
- 16 MiB cap is a module constant consistent with the existing `OPENROUTER_MODELS_BODY_MAX_BYTES` precedent. This is the proxy-capture analogue of the merged provider response-limit work (#96495 image-generation, #96873 video-generation): same 16 MiB ceiling, same fail-closed-on-overflow shape, applied to the capture tee instead of provider JSON readers.
</details>

---

AI disclosure: AI-assisted with **Claude Code** (Claude Opus). Scope: Claude read the surrounding runtime + existing repo bounded-read helpers (`media-core/read-response-with-limit`, `web-shared#readResponseText`, `model-scan`), wrote the bounded reader + Content-Length fast path + the unit/edge tests, built the real-server end-to-end proof harness, and empirically verified both the teed-clone cancel hang (design rationale) and the mutation/negative-control results above. I reviewed every line, ran the tests/typecheck/lint/proof locally, and can explain the full rationale.
