### PR TITLE
Fix iOS chat Dynamic Type text

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
@@ -55,6 +55,7 @@ struct OpenClawChatComposer: View {
     #else
     @State private var shouldFocusTextView = false
     #endif
+    @ScaledMetric(relativeTo: .body) private var scaledBodyLineHeight: CGFloat = 22
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -337,7 +338,7 @@ struct OpenClawChatComposer: View {
 
                 HStack(alignment: .center, spacing: 8) {
                     self.editorOverlay
-                        .frame(minHeight: self.cleanControlHeight)
+                        .frame(minHeight: self.cleanEditorMinHeight)
 
                     if let talkControl {
                         self.compactTalkButton(talkControl)
@@ -345,7 +346,7 @@ struct OpenClawChatComposer: View {
                 }
                 .padding(.leading, 14)
                 .padding(.trailing, 6)
-                .frame(height: self.cleanControlHeight)
+                .frame(minHeight: self.cleanEditorMinHeight)
                 .background(
                     Capsule(style: .continuous)
                         .fill(OpenClawChatTheme.composerField)
@@ -356,7 +357,7 @@ struct OpenClawChatComposer: View {
                 self.sendButton
                     .frame(width: self.cleanControlHeight, height: self.cleanControlHeight)
             }
-            .frame(height: self.cleanControlHeight)
+            .frame(minHeight: self.cleanEditorMinHeight)
 
             if self.showsConnectionPill {
                 self.connectionPill
@@ -488,6 +489,7 @@ struct OpenClawChatComposer: View {
         ZStack(alignment: self.editorOverlayAlignment) {
             if self.viewModel.input.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                 Text(self.placeholderText)
+                    .font(.body)
                     .foregroundStyle(.tertiary)
                     .padding(.horizontal, self.cleanFieldTextInset)
                     .padding(.vertical, self.composerChrome == .clean ? 0 : 4)
@@ -513,7 +515,7 @@ struct OpenClawChatComposer: View {
                 "",
                 text: self.$viewModel.input,
                 axis: .vertical)
-                .font(.system(size: 15))
+                .font(.body)
                 .lineLimit(1...4)
                 .submitLabel(.send)
                 .onSubmit {
@@ -614,13 +616,25 @@ struct OpenClawChatComposer: View {
     }
 
     private var textMinHeight: CGFloat {
-        if self.style == .onboarding { return 24 }
-        return self.composerChrome == .clean ? 24 : 28
+        let base: CGFloat = if self.style == .onboarding {
+            24
+        } else {
+            self.composerChrome == .clean ? 24 : 28
+        }
+        return max(base, self.scaledBodyLineHeight)
     }
 
     private var textMaxHeight: CGFloat {
-        if self.style == .onboarding { return 52 }
-        return self.composerChrome == .clean ? 48 : 64
+        let base: CGFloat = if self.style == .onboarding {
+            52
+        } else {
+            self.composerChrome == .clean ? 48 : 64
+        }
+        return max(base, self.scaledBodyLineHeight * 4)
+    }
+
+    private var cleanEditorMinHeight: CGFloat {
+        max(self.cleanControlHeight, self.textMinHeight)
     }
 
     private var sendButtonSize: CGFloat {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift
@@ -274,7 +274,7 @@ private struct ChatMessageBody: View {
                     text: text,
                     context: .user,
                     variant: self.markdownVariant,
-                    font: .system(size: 14),
+                    font: .body,
                     textColor: textColor)
             } else {
                 ChatAssistantTextBody(
@@ -747,7 +747,7 @@ private struct ChatAssistantTextBody: View {
         let segments = AssistantTextParser.segments(from: self.text, includeThinking: self.includesThinking)
         VStack(alignment: .leading, spacing: 10) {
             ForEach(segments) { segment in
-                let font = segment.kind == .thinking ? Font.system(size: 14).italic() : Font.system(size: 14)
+                let font = segment.kind == .thinking ? Font.callout.italic() : Font.body
                 ChatMarkdownRenderer(
                     text: segment.text,
                     context: .assistant,

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
@@ -649,7 +649,7 @@ private struct ChatAssistantIntroCard: View {
 
     var body: some View {
         Text(self.text)
-            .font(.system(size: 15))
+            .font(.body)
             .lineSpacing(4)
             .foregroundStyle(OpenClawChatTheme.assistantText)
             .multilineTextAlignment(.leading)

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatDynamicTypeSourceGuardTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatDynamicTypeSourceGuardTests.swift
@@ -1,0 +1,38 @@
+import Foundation
+import Testing
+
+struct ChatDynamicTypeSourceGuardTests {
+    @Test func `chat text avoids fixed point fonts`() throws {
+        let sources = try Self.scopedChatTextSources()
+
+        #expect(!sources.messageViews.contains("font: .system(size: 14)"))
+        #expect(!sources.messageViews.contains("Font.system(size: 14)"))
+        #expect(!sources.chatView.contains(".font(.system(size: 15))"))
+        #expect(!sources.composer.contains(".font(.system(size: 15))"))
+        #expect(!sources.composer.contains(".frame(height: self.cleanControlHeight)"))
+        #expect(!sources.composer.contains("return self.composerChrome == .clean ? 48 : 64"))
+        #expect(sources.composer.contains("@ScaledMetric(relativeTo: .body)"))
+    }
+
+    private static func scopedChatTextSources() throws -> (
+        messageViews: String,
+        chatView: String,
+        composer: String)
+    {
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+
+        return try (
+            messageViews: String(
+                contentsOf: root.appendingPathComponent("Sources/OpenClawChatUI/ChatMessageViews.swift"),
+                encoding: .utf8),
+            chatView: String(
+                contentsOf: root.appendingPathComponent("Sources/OpenClawChatUI/ChatView.swift"),
+                encoding: .utf8),
+            composer: String(
+                contentsOf: root.appendingPathComponent("Sources/OpenClawChatUI/ChatComposer.swift"),
+                encoding: .utf8))
+    }
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes openclaw/openclaw#97534. The native iOS Chat surface used fixed point fonts for scoped chat text paths, so users who increase iOS text size could still see small message, intro, and composer text in OpenClaw Chat.

## Why This Change Was Made

The scoped chat text call sites now use Dynamic Type-aware SwiftUI text styles:

- User message markdown: `.body`
- Assistant message markdown: `.body`
- Assistant thinking segments: `.callout.italic()`
- Empty chat intro text: `.body`
- iOS composer text and placeholder: `.body`

The iOS clean composer row also now uses Dynamic Type-scaled text min/max heights and a minimum row height instead of forcing the editor capsule into a fixed 40-point row, avoiding clipping at accessibility text sizes.

## User Impact

Users who rely on iOS Larger Text should see Chat message text and composer text scale with their system setting. This is intentionally limited to chat transcript/intro/composer text and does not change Control, Settings, app tabs, gateway setup, or other app shell surfaces.

## Evidence

- `swiftformat --lint --config config/swiftformat apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatDynamicTypeSourceGuardTests.swift` passed.
- `swift test --package-path apps/shared/OpenClawKit --filter ChatDynamicTypeSourceGuardTests` passed.
- `pnpm ios:gen` passed.
- XcodeBuildMCP simulator run succeeded for screenshot fixture mode after bypassing only the local generated SwiftLint phase; the normal generated-project build remains blocked on this host by `/usr/local/bin/swiftlint` failing to load `sourcekitdInProc.framework`.
- Autoreview initially found composer clipping risk; fixed by scaling composer text heights and removing the fixed clean-row height clamp.
- Autoreview rerun passed: `autoreview clean: no accepted/actionable findings reported`.

Screenshot proof from the current branch build, captured with the existing iOS `--openclaw-screenshot-mode` fixture:

Normal text size:

![OpenClaw iOS Chat normal text size](https://github.com/jmcte/openclaw/releases/download/proof-ios-chat-dynamic-type-97552/chat-current-normal.jpg)

Max accessibility text size:

![OpenClaw iOS Chat max accessibility text size](https://github.com/jmcte/openclaw/releases/download/proof-ios-chat-dynamic-type-97552/chat-current-accessibility-max.jpg)

Screenshot asset host: https://github.com/jmcte/openclaw/releases/tag/proof-ios-chat-dynamic-type-97552

Full app screenshots are intentionally not used as acceptance proof because iOS Dynamic Type is a global setting and existing non-chat surfaces may already respond independently of this patch.

Known unrelated validation failures:

- Full `swift test --package-path apps/shared/OpenClawKit` still fails in existing `TalkConfigContractTests.selectionFixtures` and several async `ChatViewModelTests` timeout/dedupe expectations.
- `xcodebuild`/XcodeBuildMCP generated-project build still fails before compilation in the SwiftLint phase with `SourceKittenFramework/library_wrapper.swift:58: Fatal error: Loading sourcekitdInProc.framework/Versions/A/sourcekitdInProc failed`.
