### PR TITLE
fix(shared): use UTF-16 safe truncation in subagent line display

### DIFF
--- a/src/shared/subagents-format.test.ts
+++ b/src/shared/subagents-format.test.ts
@@ -40,6 +40,25 @@ describe("shared/subagents-format", () => {
     expect(truncateLine("trim me   ", 7)).toBe("trim me...");
   });
 
+  it("truncates without breaking surrogate pairs", () => {
+    // Emoji at the cut point: the surrogate pair must not be split.
+    expect(truncateLine("AB🤖CD", 3)).toBe("AB...");
+    // Cut point in the middle of a 3-emoji string.
+    expect(truncateLine("🤖🤖🤖", 5)).toBe("🤖🤖...");
+    // CJK Extension B (surrogate pair) at boundary: character stays intact.
+    expect(truncateLine("AB𠮷CD", 5)).toBe("AB𠮷C...");
+    // No broken surrogates in output.
+    for (const result of [
+      truncateLine("AB🤖CD", 3),
+      truncateLine("🤖🤖🤖", 5),
+      truncateLine("AB𠮷CD", 5),
+    ]) {
+      expect(result).not.toMatch(
+        /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/,
+      );
+    }
+  });
+
   it("resolves token totals and io breakdowns from valid numeric fields only", () => {
     expect(resolveTotalTokens()).toBeUndefined();
     expect(resolveTotalTokens({ totalTokens: 42 })).toBe(42);

--- a/src/shared/subagents-format.ts
+++ b/src/shared/subagents-format.ts
@@ -1,6 +1,6 @@
 // Subagent formatting helpers expose compact durations and status text.
-export { formatDurationCompact } from "../infra/format-time/format-duration.ts";
 import { truncateUtf16Safe } from "./utf16-slice.js";
+export { formatDurationCompact } from "../infra/format-time/format-duration.ts";
 
 /** Formats token counts using compact k/m suffixes for subagent summaries. */
 export function formatTokenShort(value?: number) {

--- a/src/shared/subagents-format.ts
+++ b/src/shared/subagents-format.ts
@@ -1,5 +1,6 @@
 // Subagent formatting helpers expose compact durations and status text.
 export { formatDurationCompact } from "../infra/format-time/format-duration.ts";
+import { truncateUtf16Safe } from "./utf16-slice.js";
 
 /** Formats token counts using compact k/m suffixes for subagent summaries. */
 export function formatTokenShort(value?: number) {
@@ -29,7 +30,7 @@ export function truncateLine(value: string, maxLength: number) {
   if (value.length <= maxLength) {
     return value;
   }
-  return `${value.slice(0, maxLength).trimEnd()}...`;
+  return `${truncateUtf16Safe(value, maxLength).trimEnd()}...`;
 }
 
 type TokenUsageLike = {


### PR DESCRIPTION
## Summary
Replace bare `value.slice(0, maxLength)` in `truncateLine` with the existing `truncateUtf16Safe` utility to prevent surrogate-pair splitting when emoji or CJK Extension B characters land at the truncation boundary.

## What Problem This Solves
The `truncateLine` helper in `src/shared/subagents-format.ts` truncates subagent name labels (48 chars) and task descriptions (72 chars) for display in `/subagents list` output. It used `value.slice(0, maxLength)` which counts UTF-16 code units, not characters. When an emoji (like 🤖) or a CJK Extension B character (like 𠮷) straddles the cut point, the surrogate pair is split in half, producing a broken unpaired surrogate that renders as `�` (U+FFFD replacement character).

**Code evidence**: In `src/shared/subagents-format.ts:32`, the original code:
```ts
return `${value.slice(0, maxLength).trimEnd()}...`;
```
`String.prototype.slice` operates on UTF-16 code units and has no awareness of surrogate pairs.

## Root Cause
- **Introduced by**: commit `bdc3e447e9` (2026-02-15) — initial extraction of formatting helpers
- **Violated invariant**: `String.prototype.slice(start, end)` preserves individual code units but does not guarantee surrogate-pair integrity. Any truncation point that falls between a high surrogate (0xD800–0xDBFF) and its paired low surrogate (0xDC00–0xDFFF) produces an invalid code point.
- **Trigger**: A subagent label or task description containing an emoji/CJK-ExtB character whose surrogate pair crosses the `maxLength` boundary (48 or 72).

## Why This Fix
The fix imports `truncateUtf16Safe` from `./utf16-slice.js` (already in the same directory) and uses it in place of `value.slice(0, maxLength)`. This utility checks both ends of the slice for dangling surrogates and adjusts the cut point to keep pairs intact.

- **Chosen approach**: Use existing `truncateUtf16Safe` utility, which is already employed by 40+ callers across the codebase (`agents/`, `auto-reply/`, `cron/`, `gateway/`, `plugin-sdk/`).
- **Alternative considered**: `Array.from(value).slice(0, maxLength).join('')` — correct but allocates an intermediate array and is inconsistent with the rest of the codebase which standardised on `truncateUtf16Safe`.

## User Impact
- **Affected operation**: `/subagents list` command output when subagent names or task descriptions contain emoji / CJK Extension B characters exceeding 48 or 72 code units.
- **Before**: Emoji cut in half → `�` replacement character in terminal/Gateway UI.
- **After**: Emoji preserved intact, truncation occurs at the nearest safe character boundary.

## Evidence
- **Before**: `truncateLine("AB🤖CD", 3)` → `"AB�..."` (broken surrogate at position 2-3)
- **After**: `truncateLine("AB🤖CD", 3)` → `"AB..."` (surrogate pair preserved, safe truncation)

## Real Behavior Proof

### Before (on main)
```bash
$ git checkout main && node --import tsx proof-truncateline.mjs
=== UTF-16 Safe Truncation Proof ===

--- Test 1: Emoji at boundary (maxLength=3) ---
Input string: "AB🤖CD" (length=6, chars=5)
After truncateLine(input, 3): "AB�..."
FAIL: Output contains broken unpaired surrogate (emoji cut in half)!

--- Test 3: Multiple emoji, cut point in middle emoji (maxLength=5) ---
Input string: "🤖🤖🤖" (length=6, chars=3)
After truncateLine(input, 5): "🤖🤖�..."
FAIL: Output contains broken unpaired surrogate!
```

### After (with fix)
```bash
$ git checkout fix/utf16-safe-truncateline-subagents && node --import tsx proof-truncateline.mjs
=== UTF-16 Safe Truncation Proof ===

--- Test 1: Emoji at boundary (maxLength=3) ---
Input string: "AB🤖CD" (length=6, chars=5)
After truncateLine(input, 3): "AB..."
PASS: No broken surrogate pairs in output

--- Test 3: Multiple emoji, cut point in middle emoji (maxLength=5) ---
Input string: "🤖🤖🤖" (length=6, chars=3)
After truncateLine(input, 5): "🤖🤖..."
PASS: No broken surrogate pairs in output
Result has 2 visible characters (expect >= 2 complete emojis)
PASS: Two complete emojis preserved, third correctly dropped
```

## Tests and Validation
- `pnpm check` passed
- `vitest run src/shared/subagents-format.test.ts` — **6/6 tests passed** (5 existing + 1 new UTF-16 safety test)
- New test `"truncates without breaking surrogate pairs"` covers: emoji at boundary, 3-emoji middle cut, CJK Extension B at boundary, and a regex assertion that output never contains unpaired surrogates
