### PR TITLE
fix(agent-core): avoid splitting surrogate pairs in grep line truncation

### DIFF
--- a/packages/agent-core/src/harness/utils/truncate.test.ts
+++ b/packages/agent-core/src/harness/utils/truncate.test.ts
@@ -1,6 +1,6 @@
 // Agent Core tests cover truncate behavior.
 import { describe, expect, it } from "vitest";
-import { truncateHead, truncateTail } from "./truncate.js";
+import { truncateHead, truncateLine, truncateTail } from "./truncate.js";
 
 describe("truncate utilities", () => {
   it("does not count a trailing newline as an extra display line", () => {
@@ -19,5 +19,45 @@ describe("truncate utilities", () => {
     expect(result.content).toBe("🙂");
     expect(result.lastLinePartial).toBe(true);
     expect(result.outputBytes).toBe(4);
+  });
+
+  describe("truncateLine", () => {
+    it("returns text unchanged when within limit", () => {
+      expect(truncateLine("short", 10)).toEqual({ text: "short", wasTruncated: false });
+    });
+
+    it("truncates and appends suffix when over limit", () => {
+      const result = truncateLine("this is a very long line", 10);
+      expect(result.wasTruncated).toBe(true);
+      expect(result.text).toBe("this is a ... [truncated]");
+    });
+
+    it("uses GREP_MAX_LINE_LENGTH as the default limit", () => {
+      const result = truncateLine("x");
+      expect(result.wasTruncated).toBe(false);
+      expect(result.text).toBe("x");
+    });
+
+    it("does not split a surrogate pair at the cut point", () => {
+      // Emoji at boundary: "AB" + 🤖(surrogate pair) + "CD" — cut at 3 splits the emoji.
+      expect(truncateLine("AB🤖CD", 3).text).toBe("AB... [truncated]");
+      // Three emoji, cut in the middle of the second emoji.
+      expect(truncateLine("🤖🤖🤖", 5).text).toBe("🤖🤖... [truncated]");
+      // CJK Extension B (surrogate pair) at boundary stays intact.
+      expect(truncateLine("AB𠮷CD", 5).text).toBe("AB𠮷C... [truncated]");
+    });
+
+    it("never produces unpaired surrogates in output", () => {
+      const results = [
+        truncateLine("AB🤖CD", 3).text,
+        truncateLine("🤖🤖🤖", 5).text,
+        truncateLine("AB𠮷CD", 5).text,
+      ];
+      for (const text of results) {
+        expect(text).not.toMatch(
+          /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/,
+        );
+      }
+    });
   });
 });

--- a/packages/agent-core/src/harness/utils/truncate.ts
+++ b/packages/agent-core/src/harness/utils/truncate.ts
@@ -359,6 +359,10 @@ function truncateStringToBytesFromEnd(str: string, maxBytes: number): string {
 
 /**
  * Trim a single display line and mark it with the grep-style truncation suffix.
+ *
+ * The cut point is backed off by one code unit when it would otherwise split a
+ * surrogate pair, so emoji / CJK Extension B characters crossing the boundary
+ * stay intact instead of rendering as replacement characters.
  */
 export function truncateLine(
   line: string,
@@ -367,5 +371,16 @@ export function truncateLine(
   if (line.length <= maxChars) {
     return { text: line, wasTruncated: false };
   }
-  return { text: `${line.slice(0, maxChars)}... [truncated]`, wasTruncated: true };
+  let cut = maxChars;
+  // Avoid splitting a surrogate pair at the truncation boundary.
+  if (cut < line.length) {
+    const lastCode = line.charCodeAt(cut - 1);
+    if (lastCode >= 0xd800 && lastCode <= 0xdbff) {
+      const nextCode = line.charCodeAt(cut);
+      if (nextCode >= 0xdc00 && nextCode <= 0xdfff) {
+        cut -= 1;
+      }
+    }
+  }
+  return { text: `${line.slice(0, cut)}... [truncated]`, wasTruncated: true };
 }


### PR DESCRIPTION
## Summary
Guard `truncateLine` in agent-core against splitting surrogate pairs when the truncation boundary lands between a high surrogate and its paired low surrogate, preventing broken replacement characters in grep tool output.

## What Problem This Solves
The `truncateLine` utility in `packages/agent-core/src/harness/utils/truncate.ts` truncates grep match lines to `GREP_MAX_LINE_LENGTH` (500 code units) with a `... [truncated]` suffix. It used `line.slice(0, maxChars)` which operates on UTF-16 code units. When an emoji (like 🤖) or a CJK Extension B character (like 𠮷) straddles the cut point, the surrogate pair is split in half, producing a broken unpaired surrogate that renders as `�`.

**Code evidence**: In `packages/agent-core/src/harness/utils/truncate.ts:370`, the original code:
```ts
return { text: `${line.slice(0, maxChars)}... [truncated]`, wasTruncated: true };
```
No surrogate-pair boundary check was performed before slicing.

## Root Cause
- **Violated invariant**: `String.prototype.slice` preserves individual code units but has no awareness of surrogate pairs. A cut between a high surrogate (U+D800–U+DBFF) and low surrogate (U+DC00–U+DFFF) corrupts the character.
- **Trigger**: A file containing emoji/CJK-ExtB where a character's surrogate pair crosses the 500-code-unit line boundary during grep output.

## Why This Fix
Adds a lightweight inline surrogate-pair check before the slice: if `line.charCodeAt(cut - 1)` is a high surrogate and `line.charCodeAt(cut)` is a low surrogate, the cut point is pulled back by one code unit to keep the pair intact.

- **Chosen approach**: Inline check — self-contained, no new imports. The file already has a similar `replaceUnpairedSurrogates` helper and the surrogate-range constants (0xD800–0xDFFF) are already used in `utf8ByteLength` in the same file.
- **Alternative considered**: Import `truncateUtf16Safe` from `src/shared/utf16-slice.js` — rejected because agent-core is a standalone package and this avoids a cross-package dependency.

## User Impact
- **Affected operation**: Agent grep tool output where a matched line containing emoji/CJK-ExtB crosses the 500-char truncation boundary.
- **Before**: Garbled `�` in truncated grep results.
- **After**: Complete emoji/CJK characters preserved, truncation at the nearest safe boundary.

## Evidence
- **Before**: `truncateLine("AB🤖CD", 3).text` → `"AB�... [truncated]"` (broken surrogate)
- **After**: `truncateLine("AB🤖CD", 3).text` → `"AB... [truncated]"` (safe truncation)

## Real Behavior Proof

### Before (on main)
```bash
$ node --import tsx proof-truncateline-grep.mjs
=== UTF-16 Safe Grep Truncation Proof ===

--- Test 1: Emoji at boundary (maxChars=3) ---
Input: "AB🤖CD" (length=6, chars=5)
Output: "AB�... [truncated]"
FAIL: Output contains broken unpaired surrogate (emoji cut in half)!

--- Test 2: Multiple emoji, cut in middle (maxChars=5) ---
Input: "🤖🤖🤖" (length=6, chars=3)
Output: "🤖🤖�... [truncated]"
FAIL: Output contains broken unpaired surrogate!
```

### After (with fix)
```bash
$ node --import tsx proof-truncateline-grep.mjs
=== UTF-16 Safe Grep Truncation Proof ===

--- Test 1: Emoji at boundary (maxChars=3) ---
Input: "AB🤖CD" (length=6, chars=5)
Output: "AB... [truncated]"
PASS: No broken surrogate pairs in output

--- Test 2: Multiple emoji, cut in middle (maxChars=5) ---
Input: "🤖🤖🤖" (length=6, chars=3)
Output: "🤖🤖... [truncated]"
PASS: No broken surrogate pairs in output
PASS: Two complete emojis preserved, third correctly dropped
```

## Tests and Validation
- 8 tests in `packages/agent-core/src/harness/utils/truncate.test.ts` (3 existing + 5 new for truncateLine)
- New tests cover: within-limit passthrough, truncation suffix, default maxChars, surrogate-pair safety at boundary, unpaired-surrogate regex assertion
