### PR TITLE
fix(memory-wiki): don't prune unsafe-local pages when a source path is   transiently unavailable

### DIFF
--- a/extensions/memory-wiki/src/unsafe-local.test.ts
+++ b/extensions/memory-wiki/src/unsafe-local.test.ts
@@ -190,6 +190,71 @@ describe("syncMemoryWikiUnsafeLocalSources", () => {
     }
   });
 
+  it("keeps the imported page when an explicit configured file is transiently unavailable", async () => {
+    const privateDir = await createPrivateDir("private-explicit");
+    const secretPath = path.join(privateDir, "secret.md");
+    await fs.writeFile(secretPath, "# private\n", "utf8");
+
+    const { rootDir: vaultDir, config } = await createVault({
+      rootDir: nextCaseRoot("explicit-vault"),
+      config: {
+        vaultMode: "unsafe-local",
+        unsafeLocal: {
+          allowPrivateMemoryCoreAccess: true,
+          paths: [secretPath],
+        },
+      },
+    });
+
+    const first = await syncMemoryWikiUnsafeLocalSources(config);
+    const pagePath = first.pagePaths[0] ?? "";
+    expect(first.importedCount).toBe(1);
+
+    // An explicit configured file that vanishes is indistinguishable from an
+    // unmounted one, so the conservative behavior keeps its page rather than
+    // destroying it.
+    await fs.rm(secretPath);
+    const second = await syncMemoryWikiUnsafeLocalSources(config);
+
+    expect(second.removedCount).toBe(0);
+    await expect(fs.readFile(path.join(vaultDir, pagePath), "utf8")).resolves.toContain(
+      "# private",
+    );
+  });
+
+  it("prunes a readable source even when another configured source is unreadable", async () => {
+    const readableDir = await createPrivateDir("multi-readable");
+    const keptPath = path.join(readableDir, "kept.md");
+    const removedPath = path.join(readableDir, "removed.md");
+    await fs.writeFile(keptPath, "# kept\n", "utf8");
+    await fs.writeFile(removedPath, "# removed\n", "utf8");
+
+    const offlineDir = await createPrivateDir("multi-offline");
+    await fs.writeFile(path.join(offlineDir, "notes.md"), "# notes\n", "utf8");
+
+    const { config } = await createVault({
+      rootDir: nextCaseRoot("multi-vault"),
+      config: {
+        vaultMode: "unsafe-local",
+        unsafeLocal: {
+          allowPrivateMemoryCoreAccess: true,
+          paths: [readableDir, offlineDir],
+        },
+      },
+    });
+
+    const first = await syncMemoryWikiUnsafeLocalSources(config);
+    expect(first.importedCount).toBe(3);
+
+    // One source goes offline while the other deletes a file. The healthy source
+    // must still prune its deletion; the offline source's page is preserved.
+    await fs.rm(removedPath);
+    await fs.rename(offlineDir, `${offlineDir}-gone`);
+    const second = await syncMemoryWikiUnsafeLocalSources(config);
+
+    expect(second.removedCount).toBe(1);
+  });
+
   it("caps composed unsafe-local filenames to the filesystem component limit", async () => {
     const privateDir = await createPrivateDir(`${"漢".repeat(50)}-private`);
     const nestedDir = path.join(privateDir, `${"語".repeat(50)}-nested`);

--- a/extensions/memory-wiki/src/unsafe-local.test.ts
+++ b/extensions/memory-wiki/src/unsafe-local.test.ts
@@ -152,6 +152,44 @@ describe("syncMemoryWikiUnsafeLocalSources", () => {
     await expect(fs.readFile(pageAbsPath, "utf8")).resolves.toContain("MY PERSONAL NOTE");
   });
 
+  it("does not prune when a nested subdirectory is transiently unreadable", async () => {
+    // Root bypasses permission bits, so the unreadable-directory simulation
+    // below would not actually fail; skip rather than assert a false pass.
+    if (process.getuid?.() === 0) {
+      return;
+    }
+
+    const privateDir = await createPrivateDir("private-nested");
+    const nestedDir = path.join(privateDir, "nested");
+    await fs.mkdir(nestedDir, { recursive: true });
+    await fs.writeFile(path.join(nestedDir, "deep.md"), "# deep\n", "utf8");
+    await fs.writeFile(path.join(privateDir, "top.md"), "# top\n", "utf8");
+
+    const { config } = await createVault({
+      rootDir: nextCaseRoot("nested-vault"),
+      config: {
+        vaultMode: "unsafe-local",
+        unsafeLocal: {
+          allowPrivateMemoryCoreAccess: true,
+          paths: [privateDir],
+        },
+      },
+    });
+
+    const first = await syncMemoryWikiUnsafeLocalSources(config);
+    expect(first.importedCount).toBe(2);
+
+    // Make the nested directory unreadable (mount not ready / permissions) while
+    // it still appears in the parent listing, then restore it afterward.
+    await fs.chmod(nestedDir, 0o000);
+    try {
+      const duringOutage = await syncMemoryWikiUnsafeLocalSources(config);
+      expect(duringOutage.removedCount).toBe(0);
+    } finally {
+      await fs.chmod(nestedDir, 0o755);
+    }
+  });
+
   it("caps composed unsafe-local filenames to the filesystem component limit", async () => {
     const privateDir = await createPrivateDir(`${"漢".repeat(50)}-private`);
     const nestedDir = path.join(privateDir, `${"語".repeat(50)}-nested`);

--- a/extensions/memory-wiki/src/unsafe-local.test.ts
+++ b/extensions/memory-wiki/src/unsafe-local.test.ts
@@ -190,6 +190,46 @@ describe("syncMemoryWikiUnsafeLocalSources", () => {
     }
   });
 
+  it("prunes a deleted readable sibling while a nested directory is unreadable", async () => {
+    // Root bypasses permission bits, so the unreadable-directory simulation
+    // below would not actually fail; skip rather than assert a false pass.
+    if (process.getuid?.() === 0) {
+      return;
+    }
+
+    const privateDir = await createPrivateDir("private-nested-sibling");
+    const nestedDir = path.join(privateDir, "nested");
+    await fs.mkdir(nestedDir, { recursive: true });
+    await fs.writeFile(path.join(nestedDir, "deep.md"), "# deep\n", "utf8");
+    const siblingPath = path.join(privateDir, "sibling.md");
+    await fs.writeFile(siblingPath, "# sibling\n", "utf8");
+
+    const { config } = await createVault({
+      rootDir: nextCaseRoot("nested-sibling-vault"),
+      config: {
+        vaultMode: "unsafe-local",
+        unsafeLocal: {
+          allowPrivateMemoryCoreAccess: true,
+          paths: [privateDir],
+        },
+      },
+    });
+
+    const first = await syncMemoryWikiUnsafeLocalSources(config);
+    expect(first.importedCount).toBe(2);
+
+    // The nested directory goes offline while a readable sibling file is deleted.
+    // Only the unavailable subtree is preserved; the sibling's stale page prunes.
+    await fs.rm(siblingPath);
+    await fs.chmod(nestedDir, 0o000);
+    try {
+      const second = await syncMemoryWikiUnsafeLocalSources(config);
+      expect(second.removedCount).toBe(1);
+    } finally {
+      await fs.chmod(nestedDir, 0o755);
+    }
+  });
+
   it("keeps the imported page when an explicit configured file is transiently unavailable", async () => {
     const privateDir = await createPrivateDir("private-explicit");
     const secretPath = path.join(privateDir, "secret.md");

--- a/extensions/memory-wiki/src/unsafe-local.test.ts
+++ b/extensions/memory-wiki/src/unsafe-local.test.ts
@@ -74,38 +74,82 @@ describe("syncMemoryWikiUnsafeLocalSources", () => {
     expect(second.removedCount).toBe(0);
   });
 
-  it("prunes stale unsafe-local pages when configured files disappear", async () => {
+  it("prunes stale unsafe-local pages when a file inside a readable directory is deleted", async () => {
     const privateDir = await createPrivateDir("private-prune");
 
-    const secretPath = path.join(privateDir, "secret.md");
-    await fs.writeFile(secretPath, "# private\n", "utf8");
+    const keptPath = path.join(privateDir, "kept.md");
+    const removedPath = path.join(privateDir, "removed.md");
+    await fs.writeFile(keptPath, "# kept\n", "utf8");
+    await fs.writeFile(removedPath, "# removed\n", "utf8");
 
-    const { rootDir: vaultDir, config } = await createVault({
+    const { config } = await createVault({
       rootDir: nextCaseRoot("prune-vault"),
       config: {
         vaultMode: "unsafe-local",
         unsafeLocal: {
           allowPrivateMemoryCoreAccess: true,
-          paths: [secretPath],
+          paths: [privateDir],
         },
       },
     });
 
     const first = await syncMemoryWikiUnsafeLocalSources(config);
-    const firstPagePath = first.pagePaths[0] ?? "";
-    await expect(fs.readFile(path.join(vaultDir, firstPagePath), "utf8")).resolves.toContain(
-      "# private",
-    );
+    expect(first.artifactCount).toBe(2);
+    expect(first.importedCount).toBe(2);
 
-    await fs.rm(secretPath);
+    // The configured directory stays readable, so removing one file in it is a
+    // genuine deletion and the matching page must be pruned.
+    await fs.rm(removedPath);
     const second = await syncMemoryWikiUnsafeLocalSources(config);
 
-    expect(second.artifactCount).toBe(0);
+    expect(second.artifactCount).toBe(1);
     expect(second.removedCount).toBe(1);
-    await expect(fs.stat(path.join(vaultDir, firstPagePath))).rejects.toHaveProperty(
-      "code",
-      "ENOENT",
+  });
+
+  it("keeps imported pages and human notes when a configured directory is transiently unreadable", async () => {
+    const privateDir = await createPrivateDir("private-transient");
+    await fs.writeFile(path.join(privateDir, "ideas.md"), "# ideas\n", "utf8");
+
+    const { rootDir: vaultDir, config } = await createVault({
+      rootDir: nextCaseRoot("transient-vault"),
+      config: {
+        vaultMode: "unsafe-local",
+        unsafeLocal: {
+          allowPrivateMemoryCoreAccess: true,
+          paths: [privateDir],
+        },
+      },
+    });
+
+    const first = await syncMemoryWikiUnsafeLocalSources(config);
+    const pagePath = first.pagePaths[0] ?? "";
+    expect(first.importedCount).toBe(1);
+
+    // Write a user note into the page's human-notes block, then take the source
+    // directory offline the way an undocked drive / unmounted NAS presents.
+    const pageAbsPath = path.join(vaultDir, pagePath);
+    const original = await fs.readFile(pageAbsPath, "utf8");
+    const noted = original.replace(
+      "<!-- openclaw:human:start -->\n<!-- openclaw:human:end -->",
+      "<!-- openclaw:human:start -->\nMY PERSONAL NOTE\n<!-- openclaw:human:end -->",
     );
+    expect(noted).not.toBe(original);
+    await fs.writeFile(pageAbsPath, noted, "utf8");
+
+    const offlinePath = `${privateDir}-offline`;
+    await fs.rename(privateDir, offlinePath);
+    const duringOutage = await syncMemoryWikiUnsafeLocalSources(config);
+
+    // A transient outage must not prune; the page and its human notes survive.
+    expect(duringOutage.artifactCount).toBe(0);
+    expect(duringOutage.removedCount).toBe(0);
+    await expect(fs.readFile(pageAbsPath, "utf8")).resolves.toContain("MY PERSONAL NOTE");
+
+    // Re-mount and re-sync: clean reconciliation, notes still intact.
+    await fs.rename(offlinePath, privateDir);
+    const afterRestore = await syncMemoryWikiUnsafeLocalSources(config);
+    expect(afterRestore.removedCount).toBe(0);
+    await expect(fs.readFile(pageAbsPath, "utf8")).resolves.toContain("MY PERSONAL NOTE");
   });
 
   it("caps composed unsafe-local filenames to the filesystem component limit", async () => {

--- a/extensions/memory-wiki/src/unsafe-local.ts
+++ b/extensions/memory-wiki/src/unsafe-local.ts
@@ -45,10 +45,10 @@ function detectFenceLanguage(filePath: string): string {
   return "markdown";
 }
 
-// `readable` is false only when this directory itself could not be read (an
-// unmounted/undocked volume), which is distinct from a readable-but-empty
-// directory. Callers use it to avoid treating a transient outage as deletion
-// (#97523). Nested read failures stay best-effort and contribute no files.
+// `readable` is false when this directory or any descendant could not be read
+// (an unmounted/undocked volume), which is distinct from a readable-but-empty
+// directory. It propagates up so a transiently-gone nested mount is not mistaken
+// for deletion; callers use it to skip pruning during an outage (#97523).
 async function listAllowedFilesRecursive(
   rootDir: string,
 ): Promise<{ files: string[]; readable: boolean }> {
@@ -57,10 +57,15 @@ async function listAllowedFilesRecursive(
     return { files: [], readable: false };
   }
   const files: string[] = [];
+  let readable = true;
   for (const entry of entries) {
     const fullPath = path.join(rootDir, entry.name);
     if (entry.isDirectory()) {
-      files.push(...(await listAllowedFilesRecursive(fullPath)).files);
+      const nested = await listAllowedFilesRecursive(fullPath);
+      files.push(...nested.files);
+      if (!nested.readable) {
+        readable = false;
+      }
       continue;
     }
     if (
@@ -70,7 +75,7 @@ async function listAllowedFilesRecursive(
       files.push(fullPath);
     }
   }
-  return { files: files.toSorted((left, right) => left.localeCompare(right)), readable: true };
+  return { files: files.toSorted((left, right) => left.localeCompare(right)), readable };
 }
 
 async function collectUnsafeLocalArtifacts(
@@ -90,9 +95,10 @@ async function collectUnsafeLocalArtifacts(
     }
     if (stat.isDirectory()) {
       const listing = await listAllowedFilesRecursive(absoluteConfiguredPath);
+      // A nested mount that is gone still imports the files we can read, but the
+      // outage must trip the prune guard so missing entries are not deleted.
       if (!listing.readable) {
         hadUnreadableSource = true;
-        continue;
       }
       for (const absolutePath of listing.files) {
         artifacts.push({

--- a/extensions/memory-wiki/src/unsafe-local.ts
+++ b/extensions/memory-wiki/src/unsafe-local.ts
@@ -80,25 +80,26 @@ async function listAllowedFilesRecursive(
 
 async function collectUnsafeLocalArtifacts(
   configuredPaths: string[],
-): Promise<{ artifacts: UnsafeLocalArtifact[]; hadUnreadableSource: boolean }> {
+): Promise<{ artifacts: UnsafeLocalArtifact[]; unreadableRoots: string[] }> {
   const artifacts: UnsafeLocalArtifact[] = [];
-  // A configured path that cannot be read (undocked drive, unmounted NAS,
-  // not-yet-mounted cloud folder) is transiently absent, not deleted. Track it
-  // so the caller skips pruning instead of destroying imported pages (#97523).
-  let hadUnreadableSource = false;
+  // Configured roots that could not be fully read (undocked drive, unmounted
+  // NAS, not-yet-mounted nested mount, or a missing explicit file) are
+  // transiently absent, not deleted. The caller preserves imported entries under
+  // these roots from pruning while still cleaning up readable roots (#97523).
+  const unreadableRoots: string[] = [];
   for (const configuredPath of configuredPaths) {
     const absoluteConfiguredPath = path.resolve(configuredPath);
     const stat = await fs.stat(absoluteConfiguredPath).catch(() => null);
     if (!stat) {
-      hadUnreadableSource = true;
+      unreadableRoots.push(absoluteConfiguredPath);
       continue;
     }
     if (stat.isDirectory()) {
       const listing = await listAllowedFilesRecursive(absoluteConfiguredPath);
       // A nested mount that is gone still imports the files we can read, but the
-      // outage must trip the prune guard so missing entries are not deleted.
+      // root is marked unreadable so its entries are not pruned during the outage.
       if (!listing.readable) {
-        hadUnreadableSource = true;
+        unreadableRoots.push(absoluteConfiguredPath);
       }
       for (const absolutePath of listing.files) {
         artifacts.push({
@@ -124,7 +125,36 @@ async function collectUnsafeLocalArtifacts(
   for (const artifact of artifacts) {
     deduped.set(artifact.syncKey, artifact);
   }
-  return { artifacts: [...deduped.values()], hadUnreadableSource };
+  return { artifacts: [...deduped.values()], unreadableRoots };
+}
+
+function isPathAtOrWithin(target: string, root: string): boolean {
+  if (target === root) {
+    return true;
+  }
+  const rootWithSep = root.endsWith(path.sep) ? root : `${root}${path.sep}`;
+  return target.startsWith(rootWithSep);
+}
+
+// Keep imported entries whose source lives under a transiently unreadable root
+// out of the prune by marking their keys active, so a temporary outage cannot
+// delete their pages or human-notes while readable roots still clean up (#97523).
+function preserveEntriesUnderUnreadableRoots(params: {
+  state: Awaited<ReturnType<typeof readMemoryWikiSourceSyncState>>;
+  unreadableRoots: string[];
+  activeKeys: Set<string>;
+}): void {
+  if (params.unreadableRoots.length === 0) {
+    return;
+  }
+  for (const [syncKey, entry] of Object.entries(params.state.entries)) {
+    if (entry.group !== "unsafe-local") {
+      continue;
+    }
+    if (params.unreadableRoots.some((root) => isPathAtOrWithin(entry.sourcePath, root))) {
+      params.activeKeys.add(syncKey);
+    }
+  }
 }
 
 function resolveUnsafeLocalPagePath(params: { configuredPath: string; absolutePath: string }): {
@@ -238,7 +268,7 @@ export async function syncMemoryWikiUnsafeLocalSources(
     };
   }
 
-  const { artifacts, hadUnreadableSource } = await collectUnsafeLocalArtifacts(
+  const { artifacts, unreadableRoots } = await collectUnsafeLocalArtifacts(
     config.unsafeLocal.paths,
   );
   const state = await readMemoryWikiSourceSyncState(config.vault.path);
@@ -262,20 +292,18 @@ export async function syncMemoryWikiUnsafeLocalSources(
     }),
   );
 
-  // When a configured source was transiently unreadable it collects zero
-  // artifacts the same way a real deletion does. Pruning here would hard-delete
-  // imported pages and the user's human-notes blocks for sources that are only
-  // temporarily gone, with no content left to restore on the next sync. Skip the
-  // prune until every configured source is readable again. Mirrors the
-  // capability-gated bridge-sync guard in bridge.ts (#68373). See #97523.
-  const removedCount = hadUnreadableSource
-    ? 0
-    : await pruneImportedSourceEntries({
-        vaultRoot: config.vault.path,
-        group: "unsafe-local",
-        activeKeys,
-        state,
-      });
+  // A transiently unreadable root collects zero artifacts the same way a real
+  // deletion does, so its entries would otherwise be pruned, hard-deleting their
+  // pages and human-notes blocks with nothing left to restore. Preserve those
+  // entries per-root, then prune normally so readable roots still clean up their
+  // genuinely deleted files. See #97523.
+  preserveEntriesUnderUnreadableRoots({ state, unreadableRoots, activeKeys });
+  const removedCount = await pruneImportedSourceEntries({
+    vaultRoot: config.vault.path,
+    group: "unsafe-local",
+    activeKeys,
+    state,
+  });
   await writeMemoryWikiSourceSyncState(config.vault.path, state);
   const importedCount = results.filter((result) => result.changed && result.created).length;
   const updatedCount = results.filter((result) => result.changed && !result.created).length;

--- a/extensions/memory-wiki/src/unsafe-local.ts
+++ b/extensions/memory-wiki/src/unsafe-local.ts
@@ -45,13 +45,22 @@ function detectFenceLanguage(filePath: string): string {
   return "markdown";
 }
 
-async function listAllowedFilesRecursive(rootDir: string): Promise<string[]> {
-  const entries = await fs.readdir(rootDir, { withFileTypes: true }).catch(() => []);
+// `readable` is false only when this directory itself could not be read (an
+// unmounted/undocked volume), which is distinct from a readable-but-empty
+// directory. Callers use it to avoid treating a transient outage as deletion
+// (#97523). Nested read failures stay best-effort and contribute no files.
+async function listAllowedFilesRecursive(
+  rootDir: string,
+): Promise<{ files: string[]; readable: boolean }> {
+  const entries = await fs.readdir(rootDir, { withFileTypes: true }).catch(() => null);
+  if (entries === null) {
+    return { files: [], readable: false };
+  }
   const files: string[] = [];
   for (const entry of entries) {
     const fullPath = path.join(rootDir, entry.name);
     if (entry.isDirectory()) {
-      files.push(...(await listAllowedFilesRecursive(fullPath)));
+      files.push(...(await listAllowedFilesRecursive(fullPath)).files);
       continue;
     }
     if (
@@ -61,22 +70,31 @@ async function listAllowedFilesRecursive(rootDir: string): Promise<string[]> {
       files.push(fullPath);
     }
   }
-  return files.toSorted((left, right) => left.localeCompare(right));
+  return { files: files.toSorted((left, right) => left.localeCompare(right)), readable: true };
 }
 
 async function collectUnsafeLocalArtifacts(
   configuredPaths: string[],
-): Promise<UnsafeLocalArtifact[]> {
+): Promise<{ artifacts: UnsafeLocalArtifact[]; hadUnreadableSource: boolean }> {
   const artifacts: UnsafeLocalArtifact[] = [];
+  // A configured path that cannot be read (undocked drive, unmounted NAS,
+  // not-yet-mounted cloud folder) is transiently absent, not deleted. Track it
+  // so the caller skips pruning instead of destroying imported pages (#97523).
+  let hadUnreadableSource = false;
   for (const configuredPath of configuredPaths) {
     const absoluteConfiguredPath = path.resolve(configuredPath);
     const stat = await fs.stat(absoluteConfiguredPath).catch(() => null);
     if (!stat) {
+      hadUnreadableSource = true;
       continue;
     }
     if (stat.isDirectory()) {
-      const files = await listAllowedFilesRecursive(absoluteConfiguredPath);
-      for (const absolutePath of files) {
+      const listing = await listAllowedFilesRecursive(absoluteConfiguredPath);
+      if (!listing.readable) {
+        hadUnreadableSource = true;
+        continue;
+      }
+      for (const absolutePath of listing.files) {
         artifacts.push({
           syncKey: await resolveArtifactKey(absolutePath),
           configuredPath: absoluteConfiguredPath,
@@ -100,7 +118,7 @@ async function collectUnsafeLocalArtifacts(
   for (const artifact of artifacts) {
     deduped.set(artifact.syncKey, artifact);
   }
-  return [...deduped.values()];
+  return { artifacts: [...deduped.values()], hadUnreadableSource };
 }
 
 function resolveUnsafeLocalPagePath(params: { configuredPath: string; absolutePath: string }): {
@@ -214,7 +232,9 @@ export async function syncMemoryWikiUnsafeLocalSources(
     };
   }
 
-  const artifacts = await collectUnsafeLocalArtifacts(config.unsafeLocal.paths);
+  const { artifacts, hadUnreadableSource } = await collectUnsafeLocalArtifacts(
+    config.unsafeLocal.paths,
+  );
   const state = await readMemoryWikiSourceSyncState(config.vault.path);
   assertMemoryWikiSourceSyncStateCapacity({
     state,
@@ -236,12 +256,20 @@ export async function syncMemoryWikiUnsafeLocalSources(
     }),
   );
 
-  const removedCount = await pruneImportedSourceEntries({
-    vaultRoot: config.vault.path,
-    group: "unsafe-local",
-    activeKeys,
-    state,
-  });
+  // When a configured source was transiently unreadable it collects zero
+  // artifacts the same way a real deletion does. Pruning here would hard-delete
+  // imported pages and the user's human-notes blocks for sources that are only
+  // temporarily gone, with no content left to restore on the next sync. Skip the
+  // prune until every configured source is readable again. Mirrors the
+  // capability-gated bridge-sync guard in bridge.ts (#68373). See #97523.
+  const removedCount = hadUnreadableSource
+    ? 0
+    : await pruneImportedSourceEntries({
+        vaultRoot: config.vault.path,
+        group: "unsafe-local",
+        activeKeys,
+        state,
+      });
   await writeMemoryWikiSourceSyncState(config.vault.path, state);
   const importedCount = results.filter((result) => result.changed && result.created).length;
   const updatedCount = results.filter((result) => result.changed && !result.created).length;

--- a/extensions/memory-wiki/src/unsafe-local.ts
+++ b/extensions/memory-wiki/src/unsafe-local.ts
@@ -45,27 +45,25 @@ function detectFenceLanguage(filePath: string): string {
   return "markdown";
 }
 
-// `readable` is false when this directory or any descendant could not be read
+// `unreadableDirs` lists the exact directories whose contents could not be read
 // (an unmounted/undocked volume), which is distinct from a readable-but-empty
-// directory. It propagates up so a transiently-gone nested mount is not mistaken
-// for deletion; callers use it to skip pruning during an outage (#97523).
+// directory. They bubble up so the caller preserves only the unavailable subtree
+// during an outage, while readable siblings still prune normally (#97523).
 async function listAllowedFilesRecursive(
   rootDir: string,
-): Promise<{ files: string[]; readable: boolean }> {
+): Promise<{ files: string[]; unreadableDirs: string[] }> {
   const entries = await fs.readdir(rootDir, { withFileTypes: true }).catch(() => null);
   if (entries === null) {
-    return { files: [], readable: false };
+    return { files: [], unreadableDirs: [rootDir] };
   }
   const files: string[] = [];
-  let readable = true;
+  const unreadableDirs: string[] = [];
   for (const entry of entries) {
     const fullPath = path.join(rootDir, entry.name);
     if (entry.isDirectory()) {
       const nested = await listAllowedFilesRecursive(fullPath);
       files.push(...nested.files);
-      if (!nested.readable) {
-        readable = false;
-      }
+      unreadableDirs.push(...nested.unreadableDirs);
       continue;
     }
     if (
@@ -75,32 +73,30 @@ async function listAllowedFilesRecursive(
       files.push(fullPath);
     }
   }
-  return { files: files.toSorted((left, right) => left.localeCompare(right)), readable };
+  return { files: files.toSorted((left, right) => left.localeCompare(right)), unreadableDirs };
 }
 
 async function collectUnsafeLocalArtifacts(
   configuredPaths: string[],
-): Promise<{ artifacts: UnsafeLocalArtifact[]; unreadableRoots: string[] }> {
+): Promise<{ artifacts: UnsafeLocalArtifact[]; unreadablePaths: string[] }> {
   const artifacts: UnsafeLocalArtifact[] = [];
-  // Configured roots that could not be fully read (undocked drive, unmounted
-  // NAS, not-yet-mounted nested mount, or a missing explicit file) are
-  // transiently absent, not deleted. The caller preserves imported entries under
-  // these roots from pruning while still cleaning up readable roots (#97523).
-  const unreadableRoots: string[] = [];
+  // Exact paths that could not be read (undocked drive, unmounted NAS,
+  // not-yet-mounted nested mount, or a missing explicit file) are transiently
+  // absent, not deleted. The caller preserves imported entries under these paths
+  // from pruning while readable siblings still clean up deletions (#97523).
+  const unreadablePaths: string[] = [];
   for (const configuredPath of configuredPaths) {
     const absoluteConfiguredPath = path.resolve(configuredPath);
     const stat = await fs.stat(absoluteConfiguredPath).catch(() => null);
     if (!stat) {
-      unreadableRoots.push(absoluteConfiguredPath);
+      unreadablePaths.push(absoluteConfiguredPath);
       continue;
     }
     if (stat.isDirectory()) {
       const listing = await listAllowedFilesRecursive(absoluteConfiguredPath);
-      // A nested mount that is gone still imports the files we can read, but the
-      // root is marked unreadable so its entries are not pruned during the outage.
-      if (!listing.readable) {
-        unreadableRoots.push(absoluteConfiguredPath);
-      }
+      // A gone nested mount still imports the files we can read; only the exact
+      // unreadable subtrees are preserved so readable siblings still prune.
+      unreadablePaths.push(...listing.unreadableDirs);
       for (const absolutePath of listing.files) {
         artifacts.push({
           syncKey: await resolveArtifactKey(absolutePath),
@@ -125,33 +121,34 @@ async function collectUnsafeLocalArtifacts(
   for (const artifact of artifacts) {
     deduped.set(artifact.syncKey, artifact);
   }
-  return { artifacts: [...deduped.values()], unreadableRoots };
+  return { artifacts: [...deduped.values()], unreadablePaths };
 }
 
-function isPathAtOrWithin(target: string, root: string): boolean {
-  if (target === root) {
+function isPathAtOrWithin(target: string, base: string): boolean {
+  if (target === base) {
     return true;
   }
-  const rootWithSep = root.endsWith(path.sep) ? root : `${root}${path.sep}`;
-  return target.startsWith(rootWithSep);
+  const baseWithSep = base.endsWith(path.sep) ? base : `${base}${path.sep}`;
+  return target.startsWith(baseWithSep);
 }
 
-// Keep imported entries whose source lives under a transiently unreadable root
+// Keep imported entries whose source lives under a transiently unreadable path
 // out of the prune by marking their keys active, so a temporary outage cannot
-// delete their pages or human-notes while readable roots still clean up (#97523).
-function preserveEntriesUnderUnreadableRoots(params: {
+// delete their pages or human-notes while readable siblings still clean up
+// genuinely deleted files (#97523).
+function preserveEntriesUnderUnreadablePaths(params: {
   state: Awaited<ReturnType<typeof readMemoryWikiSourceSyncState>>;
-  unreadableRoots: string[];
+  unreadablePaths: string[];
   activeKeys: Set<string>;
 }): void {
-  if (params.unreadableRoots.length === 0) {
+  if (params.unreadablePaths.length === 0) {
     return;
   }
   for (const [syncKey, entry] of Object.entries(params.state.entries)) {
     if (entry.group !== "unsafe-local") {
       continue;
     }
-    if (params.unreadableRoots.some((root) => isPathAtOrWithin(entry.sourcePath, root))) {
+    if (params.unreadablePaths.some((base) => isPathAtOrWithin(entry.sourcePath, base))) {
       params.activeKeys.add(syncKey);
     }
   }
@@ -268,7 +265,7 @@ export async function syncMemoryWikiUnsafeLocalSources(
     };
   }
 
-  const { artifacts, unreadableRoots } = await collectUnsafeLocalArtifacts(
+  const { artifacts, unreadablePaths } = await collectUnsafeLocalArtifacts(
     config.unsafeLocal.paths,
   );
   const state = await readMemoryWikiSourceSyncState(config.vault.path);
@@ -292,12 +289,12 @@ export async function syncMemoryWikiUnsafeLocalSources(
     }),
   );
 
-  // A transiently unreadable root collects zero artifacts the same way a real
+  // A transiently unreadable path collects zero artifacts the same way a real
   // deletion does, so its entries would otherwise be pruned, hard-deleting their
-  // pages and human-notes blocks with nothing left to restore. Preserve those
-  // entries per-root, then prune normally so readable roots still clean up their
-  // genuinely deleted files. See #97523.
-  preserveEntriesUnderUnreadableRoots({ state, unreadableRoots, activeKeys });
+  // pages and human-notes blocks with nothing left to restore. Preserve only the
+  // entries under the exact unreadable subtrees, then prune normally so readable
+  // siblings still clean up their genuinely deleted files. See #97523.
+  preserveEntriesUnderUnreadablePaths({ state, unreadablePaths, activeKeys });
   const removedCount = await pruneImportedSourceEntries({
     vaultRoot: config.vault.path,
     group: "unsafe-local",


### PR DESCRIPTION
Closes #97523

## What Problem This Solves

Fixes an issue where memory-wiki users running `vaultMode: "unsafe-local"` would permanently lose imported pages **and their hand-written human-notes blocks** when a configured source path became transiently unavailable (an undocked external drive, a rebooting NAS, or a cloud-synced folder that is not mounted yet). Any `wiki_*` tool that triggered a sync while the path was gone deleted every imported page for that path; when the path came back, pages were recreated empty and the user's notes were unrecoverable.

## Why This Change Was Made

A transiently unreadable source collects zero artifacts in exactly the same way a real deletion does, and the `unsafe-local` sync pruned unconditionally on that signal. The fix makes the prune aware of the **exact unreadable subtree**:

- `collectUnsafeLocalArtifacts` now records the precise paths that could not be read — `fs.stat` failing on a configured path, a missing explicit file, or `fs.readdir` failing on the configured directory or any nested subdirectory (each failing directory is reported individually).
- `syncMemoryWikiUnsafeLocalSources` preserves only the imported entries that live under those unreadable paths (keeps their keys active), then prunes normally. So a transient outage never deletes a page or its human-notes, while readable siblings — even a deleted file in a readable directory under the *same* configured root as an unreadable nested mount, or another configured source entirely — still get their stale pages cleaned up.

This is the narrowed, source-scope-aware behavior ClawSweeper recommended. An explicit configured file that vanishes is indistinguishable from an unmounted one, so its page is conservatively kept (data-safety first) until it returns.

## User Impact

Users with `unsafe-local` notes on removable, network, or cloud-synced storage no longer lose imported pages or their manually authored human-notes when a source path (or a nested mount inside it) is briefly offline. Healthy sources keep cleaning up deleted files normally. After the source returns, the next sync reconciles cleanly with notes intact. No config changes required.

## Evidence

### Real workflow run (standalone, non-test) — Node 24

Drove the real `syncMemoryWikiUnsafeLocalSources` from a standalone script (`node --import tsx`) against a real on-disk vault — not the test harness. The outage is a real directory `fs.rename` (ENOENT), the way an undocked drive / unmounted NAS presents. Steps per run: (1) sync imports the source page, (2) write a hand-written note into the page's human-notes block on disk, (3) take the source dir offline and sync, (4) remount and sync.

**BEFORE** — pristine base `7ac8b48a08` (current `main`):

```
[1] sync: imported=1 removed=0 page=sources/unsafe-local-notes-…-ideas-md-….md
[2] wrote user note into the page's human-notes block
[3] sync during outage: removed=1 pageStillOnDisk=false userNoteSurvived=false
[4] sync after remount: removed=0 userNoteSurvived=false

RESULT: FAIL — data was lost
```

**AFTER** — this branch, identical steps:

```
[1] sync: imported=1 removed=0 page=sources/unsafe-local-notes-…-ideas-md-….md
[2] wrote user note into the page's human-notes block
[3] sync during outage: removed=0 pageStillOnDisk=true userNoteSurvived=true
[4] sync after remount: removed=0 userNoteSurvived=true

RESULT: PASS — page + user note survived the transient outage
```

### Regression tests (real on-disk vault, pristine base vs this branch)

These drive the real `syncMemoryWikiUnsafeLocalSources` against a real on-disk vault, with the outage produced by a real `fs.rename` / `fs.chmod` on the source path (nothing in the collect/prune path is stubbed; only the plugin state store is the in-memory test store, which is incidental to the prune logic).

**BEFORE** — pristine base `7ac8b48a08`, same tests, the bug reproduces:

```
 ✓ prunes stale unsafe-local pages when a file inside a readable directory is deleted
 × keeps imported pages and human notes when a configured directory is transiently unreadable
 × does not prune when a nested subdirectory is transiently unreadable
 × prunes a deleted readable sibling while a nested directory is unreadable
 × keeps the imported page when an explicit configured file is transiently unavailable
 × prunes a readable source even when another configured source is unreadable

 Tests  5 failed | 3 passed (8)
```

**AFTER** — this branch, identical inputs:

```
 ✓ imports explicit private paths and preserves unsafe-local provenance
 ✓ prunes stale unsafe-local pages when a file inside a readable directory is deleted
 ✓ keeps imported pages and human notes when a configured directory is transiently unreadable
 ✓ does not prune when a nested subdirectory is transiently unreadable
 ✓ prunes a deleted readable sibling while a nested directory is unreadable
 ✓ keeps the imported page when an explicit configured file is transiently unavailable
 ✓ prunes a readable source even when another configured source is unreadable
 ✓ caps composed unsafe-local filenames to the filesystem component limit

 Tests  8 passed (8)
```

What the new/updated tests prove:

- `keeps imported pages and human notes when a configured directory is transiently unreadable` — imports a page, writes a real user note into its human-notes block, takes the source directory offline with a real `fs.rename` outage, syncs (asserts `removedCount` 0 and page + note survive), then re-mounts and syncs again (clean, note intact).
- `does not prune when a nested subdirectory is transiently unreadable` — a nested subdirectory made unreadable mid-sync no longer prunes its page (`removedCount` 0).
- `prunes a deleted readable sibling while a nested directory is unreadable` — proves the precise-subtree scope: only the unavailable subtree is preserved; a genuinely deleted readable sibling under the same configured root still prunes (`removedCount` 1).
- `keeps the imported page when an explicit configured file is transiently unavailable` — explicit-file (`unsafeLocal.paths` file shape) coverage: a vanished explicit file is preserved (`removedCount` 0, page still on disk).
- `prunes a readable source even when another configured source is unreadable` — one source offline, the other deletes a file → the healthy source still prunes (`removedCount` 1) while the offline source's page is preserved.

oxlint and `oxfmt --check` are clean on both changed files.

> Note: the local full extension lane shows 4 failures in `source-sync-state.test.ts` / `doctor-contract-api.test.ts` with `TypeError: statement.columns is not a function`. These reproduce identically on a clean checkout with my changes stashed; they are a `node:sqlite` incompatibility with local Node 23 (non-LTS) and are unrelated to this change. CI runs on Linux Node 24.

AI-assisted (Claude Code); change reviewed and understood by the author.
