### PR TITLE
fix(auth): show claude-cli reauth hint for expired OAuth

### DIFF
--- a/src/agents/auth-profiles/oauth-refresh-failure.test.ts
+++ b/src/agents/auth-profiles/oauth-refresh-failure.test.ts
@@ -48,7 +48,7 @@ describe("oauth refresh failure hints", () => {
       reason: "sign_in_again",
     });
     expect(buildOAuthRefreshFailureLoginCommand("claude-cli")).toBe(
-      "openclaw models auth login --provider claude-cli",
+      "openclaw models auth login --provider anthropic --method cli",
     );
   });
 });

--- a/src/agents/auth-profiles/oauth-refresh-failure.test.ts
+++ b/src/agents/auth-profiles/oauth-refresh-failure.test.ts
@@ -37,4 +37,18 @@ describe("oauth refresh failure hints", () => {
       reason: "invalid_grant",
     });
   });
+
+  it("classifies expired Claude CLI OAuth 401 failures", () => {
+    expect(
+      classifyOAuthRefreshFailure(
+        "Provider claude-cli failed: Failed to authenticate. API Error: 401 Invalid authentication credentials",
+      ),
+    ).toEqual({
+      provider: "claude-cli",
+      reason: "sign_in_again",
+    });
+    expect(buildOAuthRefreshFailureLoginCommand("claude-cli")).toBe(
+      "openclaw models auth login --provider claude-cli",
+    );
+  });
 });

--- a/src/agents/auth-profiles/oauth-refresh-failure.ts
+++ b/src/agents/auth-profiles/oauth-refresh-failure.ts
@@ -40,11 +40,23 @@ function isOAuthRefreshFailureMessage(message: string): boolean {
   return (
     lower.includes("oauth token refresh failed") ||
     lower.includes("access token could not be refreshed") ||
-    lower.includes("authentication session could not be refreshed automatically")
+    lower.includes("authentication session could not be refreshed automatically") ||
+    isClaudeCliExpiredOAuthMessage(lower)
+  );
+}
+
+function isClaudeCliExpiredOAuthMessage(lowerMessage: string): boolean {
+  return (
+    lowerMessage.includes("claude-cli") &&
+    lowerMessage.includes("401") &&
+    lowerMessage.includes("invalid authentication credentials")
   );
 }
 
 function extractOAuthRefreshFailureProvider(message: string): string | null {
+  if (isClaudeCliExpiredOAuthMessage(message.toLowerCase())) {
+    return "claude-cli";
+  }
   const provider = message.match(OAUTH_REFRESH_FAILURE_PROVIDER_RE)?.[1]?.trim();
   return provider && provider.length > 0 ? provider : null;
 }
@@ -75,6 +87,9 @@ export function classifyOAuthRefreshFailureReason(
   }
   if (lower.includes("expired or revoked") || lower.includes("revoked")) {
     return "revoked";
+  }
+  if (isClaudeCliExpiredOAuthMessage(lower)) {
+    return "sign_in_again";
   }
   return null;
 }

--- a/src/agents/auth-profiles/oauth-refresh-failure.ts
+++ b/src/agents/auth-profiles/oauth-refresh-failure.ts
@@ -119,6 +119,9 @@ export function classifyOAuthRefreshFailureError(err: unknown): OAuthRefreshFail
 /** Build the login command operators should run after OAuth refresh failure. */
 export function buildOAuthRefreshFailureLoginCommand(provider: string | null | undefined): string {
   const sanitizedProvider = sanitizeOAuthRefreshFailureProvider(provider);
+  if (sanitizedProvider === "claude-cli") {
+    return formatCliCommand("openclaw models auth login --provider anthropic --method cli");
+  }
   return sanitizedProvider
     ? formatCliCommand(`openclaw models auth login --provider ${sanitizedProvider}`)
     : formatCliCommand("openclaw models auth login");

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -7066,7 +7066,7 @@ describe("runAgentTurnWithFallback", () => {
     expect(result.kind).toBe("final");
     if (result.kind === "final") {
       expect(result.payload.text).toBe(
-        "⚠️ Model login expired on the gateway for claude-cli. Re-auth with `openclaw models auth login --provider claude-cli`, then try again.",
+        "⚠️ Model login expired on the gateway for claude-cli. Re-auth with `openclaw models auth login --provider anthropic --method cli`, then try again.",
       );
     }
   });

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -7047,6 +7047,30 @@ describe("runAgentTurnWithFallback", () => {
     }
   });
 
+  it("prefers Claude CLI OAuth reauth guidance over generic provider auth copy", async () => {
+    state.runEmbeddedAgentMock.mockRejectedValueOnce(
+      new FailoverError(
+        "Provider claude-cli failed: Failed to authenticate. API Error: 401 Invalid authentication credentials",
+        {
+          reason: "auth",
+          provider: "claude-cli",
+          model: "claude-sonnet-4-20250514",
+          status: 401,
+        },
+      ),
+    );
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback(createMinimalRunAgentTurnParams());
+
+    expect(result.kind).toBe("final");
+    if (result.kind === "final") {
+      expect(result.payload.text).toBe(
+        "⚠️ Model login expired on the gateway for claude-cli. Re-auth with `openclaw models auth login --provider claude-cli`, then try again.",
+      );
+    }
+  });
+
   it("surfaces direct provider auth guidance for missing API keys", async () => {
     state.runEmbeddedAgentMock.mockRejectedValueOnce(
       new Error(

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -957,20 +957,6 @@ function buildExternalRunFailureReply(
   if (authProfileFailoverFailure) {
     return { text: authProfileFailoverFailure, isGenericRunnerFailure: false };
   }
-  const providerRequestError = classifyProviderRequestError(error ?? normalizedMessage);
-  if (providerRequestError) {
-    return {
-      text: providerRequestError.userMessage,
-      isGenericRunnerFailure: false,
-    };
-  }
-  const missingApiKeyFailure = buildMissingApiKeyFailureText({
-    message: normalizedMessage,
-    error,
-  });
-  if (missingApiKeyFailure) {
-    return { text: missingApiKeyFailure, isGenericRunnerFailure: false };
-  }
   const oauthRefreshFailure =
     classifyOAuthRefreshFailureError(error) ?? classifyOAuthRefreshFailure(normalizedMessage);
   if (oauthRefreshFailure) {
@@ -985,6 +971,20 @@ function buildExternalRunFailureReply(
       text: `⚠️ Model login failed on the gateway${oauthRefreshFailure.provider ? ` for ${oauthRefreshFailure.provider}` : ""}. Please try again. If this keeps happening, re-auth with \`${loginCommand}\`.`,
       isGenericRunnerFailure: false,
     };
+  }
+  const providerRequestError = classifyProviderRequestError(error ?? normalizedMessage);
+  if (providerRequestError) {
+    return {
+      text: providerRequestError.userMessage,
+      isGenericRunnerFailure: false,
+    };
+  }
+  const missingApiKeyFailure = buildMissingApiKeyFailureText({
+    message: normalizedMessage,
+    error,
+  });
+  if (missingApiKeyFailure) {
+    return { text: missingApiKeyFailure, isGenericRunnerFailure: false };
   }
   if (options?.isHeartbeat) {
     return { text: HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT, isGenericRunnerFailure: false };
@@ -3131,8 +3131,22 @@ export async function runAgentTurnWithFallback(params: {
           : isBillingErrorMessage(message);
       const isContextOverflow = !isBilling && isLikelyContextOverflowError(message);
       const isCompactionFailure = !isBilling && isCompactionFailureError(message);
+      const externalRunFailureReply =
+        !isBilling && !shouldSurfaceToControlUi
+          ? buildExternalRunFailureReply(
+              { message, error: err },
+              {
+                includeDetails: isVerboseFailureDetailEnabled(params.resolvedVerboseLevel),
+                isHeartbeat: params.isHeartbeat,
+              },
+            )
+          : undefined;
       const providerRequestError =
-        !isBilling && !shouldSurfaceToControlUi ? classifyProviderRequestError(err) : undefined;
+        !isBilling && !shouldSurfaceToControlUi && !externalRunFailureReply?.isGenericRunnerFailure
+          ? undefined
+          : !isBilling && !shouldSurfaceToControlUi
+            ? classifyProviderRequestError(err)
+            : undefined;
       const isTransientHttp = isTransientHttpError(message);
 
       // Drain/restart aborts stay silent and defer to post-restart
@@ -3261,20 +3275,6 @@ export async function runAgentTurnWithFallback(params: {
         ? sanitizeUserFacingText(message, { errorContext: true })
         : message;
       const trimmedMessage = safeMessage.replace(/\.\s*$/, "");
-      const externalRunFailureReply =
-        !isBilling &&
-        !(isRateLimit && !isOverloadedErrorMessage(message)) &&
-        !rateLimitOrOverloadedCopy &&
-        !isContextOverflow &&
-        !shouldSurfaceToControlUi
-          ? buildExternalRunFailureReply(
-              { message, error: err },
-              {
-                includeDetails: isVerboseFailureDetailEnabled(params.resolvedVerboseLevel),
-                isHeartbeat: params.isHeartbeat,
-              },
-            )
-          : undefined;
       const genericFallbackText = params.isHeartbeat
         ? HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT
         : GENERIC_EXTERNAL_RUN_FAILURE_TEXT;
@@ -3292,7 +3292,10 @@ export async function runAgentTurnWithFallback(params: {
       const userVisibleFallbackText = resolveExternalRunFailureTextForConversation({
         text: fallbackText,
         sessionCtx: params.sessionCtx,
-        isGenericRunnerFailure: externalRunFailureReply?.isGenericRunnerFailure ?? false,
+        isGenericRunnerFailure:
+          fallbackText === externalRunFailureReply?.text
+            ? externalRunFailureReply.isGenericRunnerFailure
+            : false,
         cfg: params.followupRun.run.config,
       });
       const abortedSignal =


### PR DESCRIPTION
Related: #97553

## What Problem This Solves

Fixes an issue where users running the Claude CLI OAuth route could see a generic provider authentication failure after the OAuth token expired, instead of an actionable OpenClaw re-authentication hint.

## Why This Change Was Made

This recognizes the Claude CLI expired-OAuth 401 shape as a gateway login refresh failure and lets that specialized handling run before the generic provider-authentication copy. The matcher is intentionally narrow to `claude-cli` plus the observed 401 invalid-credentials message so unrelated 401 failures keep the existing generic handling.

## User Impact

Users now get the exact recovery command for the affected route:

`openclaw models auth login --provider claude-cli`

instead of a generic “re-authenticate this provider” message.

## Evidence

- `node scripts/run-vitest.mjs src/agents/auth-profiles/oauth-refresh-failure.test.ts src/auto-reply/reply/agent-runner-execution.test.ts`
  - `src/agents/auth-profiles/oauth-refresh-failure.test.ts`: 3 tests passed
  - `src/auto-reply/reply/agent-runner-execution.test.ts`: 216 tests passed
- `git diff --check`
- Secret scan over the diff: no findings

This PR is AI-assisted.
