### PR TITLE
fix: propagate subagent model overrides into child runs

### DIFF
--- a/src/agents/subagent-spawn.test.ts
+++ b/src/agents/subagent-spawn.test.ts
@@ -312,8 +312,11 @@ describe("spawnSubagentDirect seam flow", () => {
       operations.lastIndexOf("store:update"),
     );
     const agentRequest = gatewayRequest("agent");
+    expect(agentRequest.scopes).toEqual(["operator.admin"]);
     const agentParams = requireRecord(agentRequest.params);
     expect(agentParams.sessionKey).toBe(childSessionKey);
+    expect(agentParams.provider).toBe("openai");
+    expect(agentParams.model).toBe("gpt-5.4");
     expect(agentParams.cleanupBundleMcpOnRunEnd).toBe(true);
   });
 
@@ -925,11 +928,15 @@ describe("spawnSubagentDirect seam flow", () => {
   });
 
   it("pins admin-only methods to operator.admin and preserves least-privilege for others (#59428)", async () => {
-    const capturedCalls: Array<{ method?: string; scopes?: string[] }> = [];
+    const capturedCalls: Array<{ method?: string; scopes?: string[]; params?: unknown }> = [];
 
     hoisted.callGatewayMock.mockImplementation(
-      async (request: { method?: string; scopes?: string[] }) => {
-        capturedCalls.push({ method: request.method, scopes: request.scopes });
+      async (request: { method?: string; scopes?: string[]; params?: unknown }) => {
+        capturedCalls.push({
+          method: request.method,
+          scopes: request.scopes,
+          params: request.params,
+        });
         if (request.method === "agent") {
           return { runId: "run-1" };
         }
@@ -962,8 +969,15 @@ describe("spawnSubagentDirect seam flow", () => {
       if (call.method === "sessions.patch" || call.method === "sessions.delete") {
         // Admin-only methods must be pinned to operator.admin.
         expect(call.scopes).toEqual(["operator.admin"]);
+      } else if (call.method === "agent") {
+        const params = requireRecord(call.params);
+        if (params.provider || params.model) {
+          // Explicit per-run model override must be admin-scoped or Gateway rejects it.
+          expect(call.scopes).toEqual(["operator.admin"]);
+        } else {
+          expect(call.scopes).toBeUndefined();
+        }
       } else {
-        // Non-admin methods (e.g. "agent") must NOT be forced to admin scope.
         expect(call.scopes).toBeUndefined();
       }
     }

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -359,6 +359,33 @@ function buildDirectChildSessionPatch(patch: Record<string, unknown>): Partial<S
   return entry;
 }
 
+function shouldPersistSubagentModelOverride(patch: Record<string, unknown>): boolean {
+  if (patch.modelOverrideSource === "user") {
+    return true;
+  }
+  return Boolean(
+    normalizeOptionalString(patch.modelOverrideFallbackOriginProvider) &&
+    normalizeOptionalString(patch.modelOverrideFallbackOriginModel),
+  );
+}
+
+function buildSubagentRunModelOverride(params: {
+  resolvedModel?: string;
+  initialSessionPatch: Record<string, unknown>;
+}): { provider?: string; model: string } | undefined {
+  if (!shouldPersistSubagentModelOverride(params.initialSessionPatch)) {
+    return undefined;
+  }
+  const { provider, model } = splitModelRef(params.resolvedModel);
+  if (!model) {
+    return undefined;
+  }
+  return {
+    ...(provider ? { provider } : {}),
+    model,
+  };
+}
+
 function loadSubagentConfig() {
   return subagentSpawnDeps.getRuntimeConfig();
 }
@@ -367,6 +394,10 @@ async function persistInitialChildSessionRuntimeModel(params: {
   cfg: OpenClawConfig;
   childSessionKey: string;
   resolvedModel?: string;
+  persistOverride?: boolean;
+  modelOverrideSource?: unknown;
+  modelOverrideFallbackOriginProvider?: string;
+  modelOverrideFallbackOriginModel?: string;
 }): Promise<string | undefined> {
   const { provider, model } = splitModelRef(params.resolvedModel);
   if (!model) {
@@ -386,6 +417,20 @@ async function persistInitialChildSessionRuntimeModel(params: {
       store[target.canonicalKey] = mergeSessionEntry(store[target.canonicalKey], {
         model,
         ...(provider ? { modelProvider: provider } : {}),
+        ...(params.persistOverride
+          ? {
+              modelOverride: model,
+              modelOverrideSource: params.modelOverrideSource === "auto" ? "auto" : "user",
+              ...(provider ? { providerOverride: provider } : {}),
+              ...(params.modelOverrideFallbackOriginProvider &&
+              params.modelOverrideFallbackOriginModel
+                ? {
+                    modelOverrideFallbackOriginProvider: params.modelOverrideFallbackOriginProvider,
+                    modelOverrideFallbackOriginModel: params.modelOverrideFallbackOriginModel,
+                  }
+                : {}),
+            }
+          : {}),
       });
     });
     return undefined;
@@ -1366,6 +1411,14 @@ export async function spawnSubagentDirect(
       cfg,
       childSessionKey,
       resolvedModel,
+      persistOverride: shouldPersistSubagentModelOverride(initialChildSessionPatch),
+      modelOverrideSource: initialChildSessionPatch.modelOverrideSource,
+      modelOverrideFallbackOriginProvider: normalizeOptionalString(
+        initialChildSessionPatch.modelOverrideFallbackOriginProvider,
+      ),
+      modelOverrideFallbackOriginModel: normalizeOptionalString(
+        initialChildSessionPatch.modelOverrideFallbackOriginModel,
+      ),
     });
     if (runtimeModelPersistError) {
       try {
@@ -1543,6 +1596,10 @@ export async function spawnSubagentDirect(
   const shouldAnnounceCompletion = deliverInitialChildRunDirectly
     ? false
     : expectsCompletionMessage;
+  const runModelOverride = buildSubagentRunModelOverride({
+    resolvedModel,
+    initialSessionPatch: initialChildSessionPatch,
+  });
   try {
     const {
       spawnedBy: _spawnedBy,
@@ -1551,9 +1608,11 @@ export async function spawnSubagentDirect(
     } = spawnedMetadata;
     const response = await callSubagentGateway({
       method: "agent",
+      ...(runModelOverride ? { scopes: [ADMIN_SCOPE] } : {}),
       params: {
         message: childTaskMessage,
         sessionKey: childSessionKey,
+        ...(runModelOverride ?? {}),
         channel: childSessionOrigin?.channel,
         to: childSessionOrigin?.to ?? undefined,
         accountId: childSessionOrigin?.accountId ?? undefined,


### PR DESCRIPTION
## Summary

Fix native subagent model overrides so `sessions_spawn(..., model=...)` actually propagates the selected model into the child agent run instead of relying only on pre-populated session metadata.

## Problem

A regression allowed child subagent lanes to be labelled/configured with a requested model while the actual child run could fall back to the requester/default model. In this state `modelApplied` could be true even though the child `agent` gateway call did not carry an explicit `provider/model` override.

This is especially dangerous for multi-model review/panel workflows because they can silently appear to use different models while actual execution uses the default model.

## Fix

- Detect when the initial child session patch represents a real user/configured model override.
- Re-persist `modelOverride/providerOverride` after child session preparation, so bootstrap/store writes do not erase the override semantics.
- Pass explicit `provider/model` into the internal child `agent` call when a real subagent model override exists.
- Scope that internal `agent` call to `operator.admin` only when it carries the model override, because Gateway rejects provider/model overrides without admin scope.
- Keep default-only/inherited model paths least-privilege.

## Tests

Targeted test run on this branch:

```bash
pnpm exec vitest run src/agents/subagent-spawn.test.ts --config test/vitest/vitest.agents.config.ts
```

Result:

```text
✓ src/agents/subagent-spawn.test.ts (25 tests)
```

Also ran:

```bash
git diff --check
```

## Notes

This fix is paired with a local consult-panel guard that now fail-closes on actual provider/model mismatch, but the runtime fix is still needed for native `sessions_spawn(model=...)` users outside that runner.
