### PR TITLE
fix(failover): allow model_not_found to trigger fallback chain when configured (fixes #97564)

### DIFF
--- a/src/agents/embedded-agent-runner/run/failover-policy.test.ts
+++ b/src/agents/embedded-agent-runner/run/failover-policy.test.ts
@@ -20,12 +20,39 @@ describe("resolveRunFailoverDecision", () => {
     });
   });
 
+  it("escalates retry-limit for model_not_found when fallback is configured", () => {
+    // model_not_found should trigger fallback to configured alternatives
+    // when the primary model is decommissioned by the provider.
+    expect(
+      resolveRunFailoverDecision({
+        stage: "retry_limit",
+        fallbackConfigured: true,
+        failoverReason: "model_not_found",
+      }),
+    ).toEqual({
+      action: "fallback_model",
+      reason: "model_not_found",
+    });
+  });
+
   it("keeps retry-limit as a local error for non-escalating reasons", () => {
     expect(
       resolveRunFailoverDecision({
         stage: "retry_limit",
         fallbackConfigured: true,
         failoverReason: "timeout",
+      }),
+    ).toEqual({
+      action: "return_error_payload",
+    });
+  });
+
+  it("returns error payload for model_not_found when no fallback is configured", () => {
+    expect(
+      resolveRunFailoverDecision({
+        stage: "retry_limit",
+        fallbackConfigured: false,
+        failoverReason: "model_not_found",
       }),
     ).toEqual({
       action: "return_error_payload",

--- a/src/agents/embedded-agent-runner/run/failover-policy.ts
+++ b/src/agents/embedded-agent-runner/run/failover-policy.ts
@@ -77,11 +77,7 @@ type RunFailoverDecisionParams =
 
 function shouldEscalateRetryLimit(reason: FailoverReason | null): boolean {
   return Boolean(
-    reason &&
-    reason !== "timeout" &&
-    reason !== "model_not_found" &&
-    reason !== "format" &&
-    reason !== "session_expired",
+    reason && reason !== "timeout" && reason !== "format" && reason !== "session_expired",
   );
 }
 


### PR DESCRIPTION
## What Problem This Solves

When a configured primary model is decommissioned by the provider (returns `model_not_found`), OpenClaw's failover policy treats this as a terminal error and never attempts the configured fallback chain. Users who set up `model.fallbacks` specifically for resilience against model decommission silently lose that protection.

## Why This Change Was Made

The `shouldEscalateRetryLimit` function in `failover-policy.ts` explicitly excluded `model_not_found` from failover escalation. This was defensible for typos (a misconfigured model should surface loudly), but it conflated two distinct cases:

1. **Typo / never-existed model** — surfacing the error is correct.
2. **Previously-valid model decommissioned mid-life** — the fallback chain is the intended remedy.

Since there's no reliable way to distinguish these at runtime, the fix removes the exclusion so `model_not_found` behaves like other availability-class reasons: attempt fallback when configured, surface error when the chain is exhausted.

## User Impact

- Agents with configured `model.fallbacks` will now correctly cascade to fallback models when the primary model returns `model_not_found`.
- Single-model configs with no fallback configured still surface the error immediately (no behavior change).
- Other excluded reasons (`timeout`, `format`, `session_expired`) are unaffected.

## Evidence

- **Behavior addressed:** model_not_found failover escalation when fallback chain is configured
- **Environment tested:** macOS, Node 22, OpenClaw 2026.5.28, commit 9bb00435
- **Steps run after the patch:** Call `resolveRunFailoverDecision` with `failoverReason: "model_not_found"` and `fallbackConfigured: true` via the production failover-policy module
- **Evidence after fix:**

```
$ npx tsx -e "
import { resolveRunFailoverDecision } from './src/agents/embedded-agent-runner/run/failover-policy.ts';
const r = resolveRunFailoverDecision({ stage: 'retry_limit', fallbackConfigured: true, failoverReason: 'model_not_found' });
console.log(JSON.stringify(r));
"
{"action":"fallback_model","reason":"model_not_found"}
```

- **Observed result after fix:** `model_not_found` with `fallbackConfigured: true` returns `{ action: "fallback_model", reason: "model_not_found" }` — fallback chain engages.
- **What was not tested:** Live provider interaction with a decommissioned model (no provider API key configured for test scenario). The fix is a single-line removal in a pure policy function, validated by the same production code path used by the embedded agent runner.

## Real behavior proof

- **Behavior addressed:** model_not_found failover escalation when fallback chain is configured
- **Environment tested:** macOS, Node 22, OpenClaw 2026.5.28, commit 9bb00435
- **Steps run after the patch:** Call `resolveRunFailoverDecision` with `failoverReason: "model_not_found"` and `fallbackConfigured: true` via the production failover-policy module
- **Evidence after fix:**

```
$ npx tsx -e "
import { resolveRunFailoverDecision } from './src/agents/embedded-agent-runner/run/failover-policy.ts';
const r = resolveRunFailoverDecision({ stage: 'retry_limit', fallbackConfigured: true, failoverReason: 'model_not_found' });
console.log(JSON.stringify(r));
"
{"action":"fallback_model","reason":"model_not_found"}
```

- **Observed result after fix:** `model_not_found` with `fallbackConfigured: true` returns `{ action: "fallback_model", reason: "model_not_found" }` — fallback chain engages. With `fallbackConfigured: false`, returns `{ action: "return_error_payload" }` — error surfaces when no fallback available.
- **What was not tested:** Live provider interaction with a decommissioned model. The fix is validated through the production failover policy function used by the embedded agent runner.

- [x] AI-assisted (Hermes Agent)
