### PR TITLE
fix(agents): escalate retry-limit model_not_found to configured fallbacks

### DIFF
--- a/src/agents/embedded-agent-runner/run/failover-policy.test.ts
+++ b/src/agents/embedded-agent-runner/run/failover-policy.test.ts
@@ -32,6 +32,38 @@ describe("resolveRunFailoverDecision", () => {
     });
   });
 
+  it("escalates retry-limit model_not_found to model fallback when fallbacks are configured (#97564)", () => {
+    // A previously-valid primary model that the provider decommissioned mid-life
+    // should engage the configured fallback chain instead of returning a hard
+    // error. The fallback chain itself filters same-model candidates, so this
+    // policy only needs to allow the escalation.
+    expect(
+      resolveRunFailoverDecision({
+        stage: "retry_limit",
+        fallbackConfigured: true,
+        failoverReason: "model_not_found",
+      }),
+    ).toEqual({
+      action: "fallback_model",
+      reason: "model_not_found",
+    });
+  });
+
+  it("surfaces retry-limit model_not_found as a local error when no fallback is configured (#97564)", () => {
+    // Single-model configs (or chains with no remaining distinct candidate)
+    // must still fail loudly so a pure typo surfaces instead of silently
+    // resolving to nothing.
+    expect(
+      resolveRunFailoverDecision({
+        stage: "retry_limit",
+        fallbackConfigured: false,
+        failoverReason: "model_not_found",
+      }),
+    ).toEqual({
+      action: "return_error_payload",
+    });
+  });
+
   it("prefers prompt-side profile rotation before fallback", () => {
     // Prompt construction can fail before any model output exists, so rotate
     // the current provider profile before spending the configured fallback.

--- a/src/agents/embedded-agent-runner/run/failover-policy.ts
+++ b/src/agents/embedded-agent-runner/run/failover-policy.ts
@@ -76,12 +76,15 @@ type RunFailoverDecisionParams =
   | AssistantDecisionParams;
 
 function shouldEscalateRetryLimit(reason: FailoverReason | null): boolean {
+  // model_not_found is intentionally allowed to escalate to the configured
+  // fallback chain: a primary model that was previously valid but has been
+  // decommissioned by the provider is exactly the case configured fallbacks
+  // exist for. Pure-typo single-model configs still fail loudly because
+  // retry-limit only escalates when fallbackConfigured is true at the call
+  // site, and the fallback chain itself filters out same-model candidates so
+  // an exhausted/no-distinct-fallback chain still surfaces the error.
   return Boolean(
-    reason &&
-    reason !== "timeout" &&
-    reason !== "model_not_found" &&
-    reason !== "format" &&
-    reason !== "session_expired",
+    reason && reason !== "timeout" && reason !== "format" && reason !== "session_expired",
   );
 }
 


### PR DESCRIPTION
Fixes #97564

## What Problem This Solves

Fixes an issue where users who configured `model.fallbacks` against a primary that the provider has decommissioned would see a hard "request failed after repeated internal retries" error in the chat session instead of OpenClaw advancing onto the configured fallback chain. The user-visible symptom is a silent loss of the resilience the fallback config was set up for: the session that should have rolled over to the next configured model on a `model_not_found`-class provider response just dies on the primary.

Reproduced in the embedded run decision table (`failover-policy.ts`): retry-limit exhaustion classifies the carried failover reason as `model_not_found`, and `shouldEscalateRetryLimit` previously excluded `model_not_found` from the escalation set, so the policy returned `return_error_payload` even when `fallbackConfigured` was true. The fallback chain in `model-fallback.ts` already handles `model_not_found` for first-attempt classifications (see the `notFoundAttempt` warning around line 1682), so the only gap was the retry-limit path on the embedded run side.

## Why This Change Was Made

Remove `model_not_found` from the retry-limit exclusion set in `shouldEscalateRetryLimit`. With this change, retry-limit exhaustion with reason `model_not_found` returns `{ action: "fallback_model", reason: "model_not_found" }` when `fallbackConfigured` is true, matching the existing behavior for `rate_limit`, `overloaded`, `billing`, `auth`, and `server_error`. The other terminal reasons (`timeout`, `format`, `session_expired`) stay excluded.

Pure-typo single-model configs still fail loudly because the retry-limit branch only escalates when `fallbackConfigured` is true at the call site, and the fallback chain itself filters out same-model candidates so an exhausted or no-distinct-fallback chain still surfaces the original error. The provider-side classifier and the per-attempt model-fallback loop are unchanged; the fix is contained to the policy decision for the retry-limit stage.

## User Impact

Users who configure `agents.defaults.model.fallbacks` (or per-agent `fallbacks`) for resilience now actually get that resilience when the primary model is removed by the provider. A run that hits retry-limit with a `model_not_found`-class response rolls onto the next configured fallback candidate the same way it already does for rate-limit, overload, and billing exhaustion. Users with no configured fallbacks see exactly the same hard error as before.

## Evidence

Added two focused regression tests in `failover-policy.test.ts`:

- `escalates retry-limit model_not_found to model fallback when fallbacks are configured (#97564)` covers the new behavior.
- `surfaces retry-limit model_not_found as a local error when no fallback is configured (#97564)` pins the typo-still-fails-loudly guarantee so a future refactor cannot silently swallow single-model `model_not_found` failures.

Verified the new escalation test FAILS on the base file and PASSES with the fix, and that the no-fallback-configured guard test passes in both states. Full `failover-policy.test.ts` suite (36 tests including the existing decision-table coverage) is green with the fix; `model-fallback.test.ts` (89 tests) remains green. One pre-existing `model-fallback.run-embedded.e2e.test.ts` failure (`rethrows AbortError during overload backoff…`) reproduces on unmodified `main` and is unrelated to this change, so it is left for the maintainer team per `CONTRIBUTING.md`.

```
src/agents/embedded-agent-runner/run/failover-policy.test.ts  | 32 ++++++++++++++++++++++
src/agents/embedded-agent-runner/run/failover-policy.ts       | 13 +++++----
2 files changed, 40 insertions(+), 5 deletions(-)
```

## AI disclosure

This change was written with the assistance of Claude. I have reviewed the diff and the regression tests and take responsibility for the code.
