### PR TITLE
fix: allow model_not_found fallback

### DIFF
--- a/src/agents/embedded-agent-runner/run/failover-policy.test.ts
+++ b/src/agents/embedded-agent-runner/run/failover-policy.test.ts
@@ -32,6 +32,19 @@ describe("resolveRunFailoverDecision", () => {
     });
   });
 
+  it("falls back from retry-limit exhaustion when the reason is model_not_found", () => {
+    expect(
+      resolveRunFailoverDecision({
+        stage: "retry_limit",
+        fallbackConfigured: true,
+        failoverReason: "model_not_found",
+      }),
+    ).toEqual({
+      action: "fallback_model",
+      reason: "model_not_found",
+    });
+  });
+
   it("prefers prompt-side profile rotation before fallback", () => {
     // Prompt construction can fail before any model output exists, so rotate
     // the current provider profile before spending the configured fallback.

--- a/src/agents/embedded-agent-runner/run/failover-policy.ts
+++ b/src/agents/embedded-agent-runner/run/failover-policy.ts
@@ -77,11 +77,7 @@ type RunFailoverDecisionParams =
 
 function shouldEscalateRetryLimit(reason: FailoverReason | null): boolean {
   return Boolean(
-    reason &&
-    reason !== "timeout" &&
-    reason !== "model_not_found" &&
-    reason !== "format" &&
-    reason !== "session_expired",
+    reason && reason !== "timeout" && reason !== "format" && reason !== "session_expired",
   );
 }
 
@@ -160,6 +156,9 @@ export function resolveRunFailoverDecision(
  */
 export function resolveRunFailoverDecision(params: RunFailoverDecisionParams): RunFailoverDecision {
   if (params.stage === "retry_limit") {
+    // Retry-limit exhaustion stays terminal for clearly non-replayable reasons,
+    // but configured model fallbacks should still catch model_not_found so a
+    // decommissioned primary can advance to the next candidate.
     if (params.fallbackConfigured && shouldEscalateRetryLimit(params.failoverReason)) {
       const fallbackReason = params.failoverReason ?? "unknown";
       return {


### PR DESCRIPTION
What Problem This Solves
The embedded runner treated `model_not_found` as terminal during retry-limit exhaustion, so a decommissioned primary model could stop a run even when configured fallbacks were available.

Why This Change Was Made
`resolveRunFailoverDecision` now lets `model_not_found` advance to configured model fallbacks when `fallbackConfigured` is true. This keeps the retry-limit path aligned with existing model-fallback behavior without adding any new config or policy surface.

User Impact
Runs that lose a primary model to provider decommission can continue onto the next configured fallback instead of failing immediately at retry-limit exhaustion.

Evidence
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/failover-policy.test.ts`
- `pnpm build`
- `pnpm check`

Issue
Fixes #97564

AI-assisted implementation note
This change was produced with AI assistance and reviewed through focused tests and build/check verification.
