### PR TITLE
[codex] fix(telegram): add rich paragraph spacing

### DIFF
--- a/extensions/telegram/src/format.test.ts
+++ b/extensions/telegram/src/format.test.ts
@@ -144,6 +144,29 @@ describe("markdownToTelegramHtml", () => {
     );
   });
 
+  it("does not restore user placeholder-looking text outside raw code HTML", () => {
+    const placeholderText = "TG_RICH_RAW_LITERAL_HTML_BLOCK_0_TOKEN";
+    const preHtml = markdownToTelegramRichHtml(
+      [
+        `Literal ${placeholderText} stays visible.`,
+        "<pre><code>",
+        "- First item",
+        "- Second item",
+        "</code></pre>",
+      ].join("\n"),
+    );
+
+    expect(preHtml).toBe(
+      [
+        `Literal ${placeholderText} stays visible.`,
+        "<pre><code>",
+        "- First item",
+        "- Second item",
+        "</code></pre>",
+      ].join("\n"),
+    );
+  });
+
   it("materializes inline and paragraph newlines as <br> for rich messages", () => {
     // The exact reported symptom: literal "• " bullets (not Markdown list markers)
     // joined by soft breaks, which Bot API 10.1 rich messages collapse without <br>.

--- a/extensions/telegram/src/format.test.ts
+++ b/extensions/telegram/src/format.test.ts
@@ -89,6 +89,30 @@ describe("markdownToTelegramHtml", () => {
     expect(markdownToTelegramRichHtml("<sup>1</sup>")).toBe("<sup>1</sup>");
   });
 
+  it("adds rich paragraph spacing between Markdown list items", () => {
+    const html = markdownToTelegramRichHtml("- First item\n- Second item\n- Third item");
+
+    expect(html).toBe("• First item\n\n• Second item\n\n• Third item");
+    expect(materializeTelegramRichHtmlLineBreaks(html)).toBe(
+      "• First item<br><br>• Second item<br><br>• Third item",
+    );
+    expect(markdownToTelegramHtml("- First item\n- Second item\n- Third item")).toBe(
+      "• First item\n• Second item\n• Third item",
+    );
+  });
+
+  it("adds rich paragraph spacing before bold section headers", () => {
+    const html = markdownToTelegramRichHtml("Intro line\n**Section:**\nDetail line");
+
+    expect(html).toBe("Intro line\n\n<b>Section:</b>\nDetail line");
+    expect(materializeTelegramRichHtmlLineBreaks(html)).toBe(
+      "Intro line<br><br><b>Section:</b><br>Detail line",
+    );
+    expect(markdownToTelegramHtml("Intro line\n**Section:**\nDetail line")).toBe(
+      "Intro line\n<b>Section:</b>\nDetail line",
+    );
+  });
+
   it("materializes inline and paragraph newlines as <br> for rich messages", () => {
     // The exact reported symptom: literal "• " bullets (not Markdown list markers)
     // joined by soft breaks, which Bot API 10.1 rich messages collapse without <br>.

--- a/extensions/telegram/src/format.test.ts
+++ b/extensions/telegram/src/format.test.ts
@@ -113,6 +113,37 @@ describe("markdownToTelegramHtml", () => {
     );
   });
 
+  it("does not add rich paragraph spacing inside raw code HTML", () => {
+    const preHtml = markdownToTelegramRichHtml(
+      [
+        "<pre><code>",
+        "- First item",
+        "- Second item",
+        "**Details:**",
+        "Stay literal.",
+        "</code></pre>",
+        "After raw code",
+        "**Visible:**",
+        "Detail line",
+      ].join("\n"),
+    );
+
+    expect(preHtml).toBe(
+      [
+        "<pre><code>",
+        "- First item",
+        "- Second item",
+        "**Details:**",
+        "Stay literal.",
+        "</code></pre>",
+        "After raw code",
+        "",
+        "<b>Visible:</b>",
+        "Detail line",
+      ].join("\n"),
+    );
+  });
+
   it("materializes inline and paragraph newlines as <br> for rich messages", () => {
     // The exact reported symptom: literal "• " bullets (not Markdown list markers)
     // joined by soft breaks, which Bot API 10.1 rich messages collapse without <br>.

--- a/extensions/telegram/src/format.ts
+++ b/extensions/telegram/src/format.ts
@@ -115,8 +115,20 @@ function isTelegramBulletLine(line: string): boolean {
   return /^[ \t]*(?:[•*+-])[ \t]+\S/.test(line);
 }
 
+function isTelegramOrderedListLine(line: string): boolean {
+  return /^[ \t]*\d+\.[ \t]+\S/.test(line);
+}
+
+function isTelegramMarkdownListItemLine(line: string): boolean {
+  return isTelegramBulletLine(line) || isTelegramOrderedListLine(line);
+}
+
+function isTelegramBoldSectionHeaderLine(line: string): boolean {
+  return /^[ \t]*\*\*[^*\n]+:\*\*(?:[ \t]*$|[ \t]+\S)/.test(line);
+}
+
 function isTelegramListBoundaryLine(line: string): boolean {
-  return /^[ \t]*(?:\d+\.|#{1,6})[ \t]+\S/.test(line);
+  return isTelegramOrderedListLine(line) || /^[ \t]*#{1,6}[ \t]+\S/.test(line);
 }
 
 function isMarkdownIndentedCodeLine(line: string): boolean {
@@ -133,7 +145,27 @@ function shouldPreserveTelegramListBoundarySpacing(previous: string, next: strin
   );
 }
 
-function preserveTelegramListBoundarySpacing(markdown: string): string {
+function shouldPreserveTelegramRichStructuredSpacing(previous: string, next: string): boolean {
+  if (
+    isMarkdownIndentedCodeLine(previous) ||
+    isMarkdownIndentedCodeLine(next) ||
+    !previous.trim()
+  ) {
+    return false;
+  }
+  if (isTelegramMarkdownListItemLine(previous) && isTelegramMarkdownListItemLine(next)) {
+    return leadingWhitespaceLength(next) <= leadingWhitespaceLength(previous);
+  }
+  return (
+    isTelegramBoldSectionHeaderLine(next) &&
+    leadingWhitespaceLength(next) <= leadingWhitespaceLength(previous)
+  );
+}
+
+function preserveTelegramListBoundarySpacing(
+  markdown: string,
+  options: { richStructuredSpacing?: boolean } = {},
+): string {
   const lines = markdown.split("\n");
   const out: string[] = [];
   let inFence = false;
@@ -142,7 +174,12 @@ function preserveTelegramListBoundarySpacing(markdown: string): string {
   for (const line of lines) {
     const normalizedLine = line.replace(/\r$/, "");
     const isFenceLine = /^[ \t]*(?:```|~~~)/.test(normalizedLine);
-    if (!inFence && shouldPreserveTelegramListBoundarySpacing(previousLine, normalizedLine)) {
+    if (
+      !inFence &&
+      (shouldPreserveTelegramListBoundarySpacing(previousLine, normalizedLine) ||
+        (options.richStructuredSpacing === true &&
+          shouldPreserveTelegramRichStructuredSpacing(previousLine, normalizedLine)))
+    ) {
       out.push("");
     }
     out.push(line);
@@ -1127,7 +1164,7 @@ export function markdownToTelegramRichHtml(
   const tableMode = options.tableMode ?? "block";
   const normalized = normalizeTelegramRichMarkdownMedia(markdown ?? "");
   const { ir, tables } = markdownToIRWithMeta(
-    preserveTelegramListBoundarySpacing(normalized.markdown),
+    preserveTelegramListBoundarySpacing(normalized.markdown, { richStructuredSpacing: true }),
     {
       linkify: options.skipEntityDetection !== true,
       enableSpoilers: true,

--- a/extensions/telegram/src/format.ts
+++ b/extensions/telegram/src/format.ts
@@ -135,6 +135,22 @@ function isMarkdownIndentedCodeLine(line: string): boolean {
   return /^(?: {4}|\t)/.test(line);
 }
 
+const TELEGRAM_RAW_LITERAL_HTML_TAG_PATTERN = /<\/?\s*(code|pre)\b[^>]*?>/gi;
+
+function nextTelegramRawLiteralHtmlDepth(line: string, depth: number): number {
+  let nextDepth = depth;
+  TELEGRAM_RAW_LITERAL_HTML_TAG_PATTERN.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = TELEGRAM_RAW_LITERAL_HTML_TAG_PATTERN.exec(line)) !== null) {
+    const rawTag = match[0];
+    if (rawTag.trimEnd().endsWith("/>")) {
+      continue;
+    }
+    nextDepth = /^<\s*\//.test(rawTag) ? Math.max(0, nextDepth - 1) : nextDepth + 1;
+  }
+  return nextDepth;
+}
+
 function shouldPreserveTelegramListBoundarySpacing(previous: string, next: string): boolean {
   return (
     !isMarkdownIndentedCodeLine(previous) &&
@@ -170,12 +186,17 @@ function preserveTelegramListBoundarySpacing(
   const out: string[] = [];
   let inFence = false;
   let previousLine = "";
+  let previousLineWasRawLiteralHtml = false;
+  let rawLiteralHtmlDepth = 0;
 
   for (const line of lines) {
     const normalizedLine = line.replace(/\r$/, "");
     const isFenceLine = /^[ \t]*(?:```|~~~)/.test(normalizedLine);
+    const isRawLiteralHtmlLine = rawLiteralHtmlDepth > 0;
     if (
       !inFence &&
+      !previousLineWasRawLiteralHtml &&
+      !isRawLiteralHtmlLine &&
       (shouldPreserveTelegramListBoundarySpacing(previousLine, normalizedLine) ||
         (options.richStructuredSpacing === true &&
           shouldPreserveTelegramRichStructuredSpacing(previousLine, normalizedLine)))
@@ -186,6 +207,8 @@ function preserveTelegramListBoundarySpacing(
     if (isFenceLine) {
       inFence = !inFence;
     }
+    rawLiteralHtmlDepth = nextTelegramRawLiteralHtmlDepth(normalizedLine, rawLiteralHtmlDepth);
+    previousLineWasRawLiteralHtml = isRawLiteralHtmlLine || rawLiteralHtmlDepth > 0;
     previousLine = normalizedLine;
   }
 
@@ -393,6 +416,10 @@ const TELEGRAM_LEGACY_HTML_TAG_SUPPORT: TelegramHtmlTagSupport = {
 const TELEGRAM_RICH_HTML_TAG_SUPPORT: TelegramHtmlTagSupport = {
   simpleTags: TELEGRAM_RICH_SIMPLE_HTML_TAGS,
   attrPatterns: TELEGRAM_RICH_ATTR_HTML_TAG_PATTERNS,
+};
+const TELEGRAM_NO_HTML_TAG_SUPPORT: TelegramHtmlTagSupport = {
+  simpleTags: new Set(),
+  attrPatterns: new Map(),
 };
 
 function popLastTagName(tags: string[], name: string): boolean {
@@ -642,6 +669,106 @@ function preserveSupportedTelegramHtmlTags(
     codeDepth > 0 || preDepth > 0
       ? remainingText
       : promoteEscapedSupportedTelegramTags(remainingText, openEscapedTags, support);
+  return result;
+}
+
+type TelegramRawLiteralHtmlExtraction = {
+  markdown: string;
+  blocks: string[];
+};
+
+const TELEGRAM_RAW_LITERAL_HTML_PLACEHOLDER_PREFIX = "TG_RICH_RAW_LITERAL_HTML_BLOCK_";
+const TELEGRAM_RAW_LITERAL_HTML_PLACEHOLDER_SUFFIX = "_TOKEN";
+
+function buildTelegramRawLiteralHtmlPlaceholder(index: number): string {
+  return `${TELEGRAM_RAW_LITERAL_HTML_PLACEHOLDER_PREFIX}${index}${TELEGRAM_RAW_LITERAL_HTML_PLACEHOLDER_SUFFIX}`;
+}
+
+function preserveTelegramRawLiteralHtmlBlock(block: string): string {
+  let result = "";
+  let lastIndex = 0;
+  const openTags: string[] = [];
+
+  HTML_TAG_PATTERN.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = HTML_TAG_PATTERN.exec(block)) !== null) {
+    const tagStart = match.index;
+    const tagEnd = HTML_TAG_PATTERN.lastIndex;
+    const rawTag = match[0];
+    const tagName = normalizeLowercaseStringOrEmpty(match[2]);
+
+    result += escapeUnsupportedTelegramHtml(
+      block.slice(lastIndex, tagStart),
+      TELEGRAM_NO_HTML_TAG_SUPPORT,
+    );
+    result +=
+      tagName === "code" || tagName === "pre"
+        ? preserveTelegramHtmlTag(rawTag, openTags, escapeHtml, TELEGRAM_RICH_HTML_TAG_SUPPORT)
+        : escapeHtml(rawTag);
+    lastIndex = tagEnd;
+  }
+
+  result += escapeUnsupportedTelegramHtml(block.slice(lastIndex), TELEGRAM_NO_HTML_TAG_SUPPORT);
+  return result;
+}
+
+function extractTelegramRawLiteralHtmlBlocks(markdown: string): TelegramRawLiteralHtmlExtraction {
+  const ranges: Array<{ start: number; end: number }> = [];
+  let blockStart = -1;
+  let depth = 0;
+
+  HTML_TAG_PATTERN.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = HTML_TAG_PATTERN.exec(markdown)) !== null) {
+    const rawTag = match[0];
+    const tagName = normalizeLowercaseStringOrEmpty(match[2]);
+    if (tagName !== "code" && tagName !== "pre") {
+      continue;
+    }
+    if (rawTag.trimEnd().endsWith("/>")) {
+      continue;
+    }
+    const isClosing = match[1] === "</";
+    if (!isClosing) {
+      if (depth === 0) {
+        blockStart = match.index;
+      }
+      depth++;
+      continue;
+    }
+    if (depth === 0) {
+      continue;
+    }
+    depth--;
+    if (depth === 0 && blockStart >= 0) {
+      ranges.push({ start: blockStart, end: HTML_TAG_PATTERN.lastIndex });
+      blockStart = -1;
+    }
+  }
+
+  if (!ranges.length) {
+    return { markdown, blocks: [] };
+  }
+
+  let out = "";
+  let lastIndex = 0;
+  const blocks: string[] = [];
+  for (const range of ranges) {
+    out += markdown.slice(lastIndex, range.start);
+    const placeholder = buildTelegramRawLiteralHtmlPlaceholder(blocks.length);
+    blocks.push(preserveTelegramRawLiteralHtmlBlock(markdown.slice(range.start, range.end)));
+    out += placeholder;
+    lastIndex = range.end;
+  }
+  out += markdown.slice(lastIndex);
+  return { markdown: out, blocks };
+}
+
+function restoreTelegramRawLiteralHtmlBlocks(html: string, blocks: readonly string[]): string {
+  let result = html;
+  for (const [index, block] of blocks.entries()) {
+    result = result.replaceAll(buildTelegramRawLiteralHtmlPlaceholder(index), block);
+  }
   return result;
 }
 
@@ -1162,7 +1289,8 @@ export function markdownToTelegramRichHtml(
   options: { tableMode?: MarkdownTableMode; skipEntityDetection?: boolean } = {},
 ): string {
   const tableMode = options.tableMode ?? "block";
-  const normalized = normalizeTelegramRichMarkdownMedia(markdown ?? "");
+  const rawLiteralHtml = extractTelegramRawLiteralHtmlBlocks(markdown ?? "");
+  const normalized = normalizeTelegramRichMarkdownMedia(rawLiteralHtml.markdown);
   const { ir, tables } = markdownToIRWithMeta(
     preserveTelegramListBoundarySpacing(normalized.markdown, { richStructuredSpacing: true }),
     {
@@ -1173,11 +1301,12 @@ export function markdownToTelegramRichHtml(
       tableMode,
     },
   );
+  const html = replaceTelegramRichMarkdownMediaPlaceholders(
+    renderTelegramRichHtmlDocument(ir, tables),
+    normalized.mediaBlocks,
+  );
   return isolateTelegramRichMediaBlocks(
-    replaceTelegramRichMarkdownMediaPlaceholders(
-      renderTelegramRichHtmlDocument(ir, tables),
-      normalized.mediaBlocks,
-    ),
+    restoreTelegramRawLiteralHtmlBlocks(html, rawLiteralHtml.blocks),
   );
 }
 

--- a/extensions/telegram/src/format.ts
+++ b/extensions/telegram/src/format.ts
@@ -674,14 +674,30 @@ function preserveSupportedTelegramHtmlTags(
 
 type TelegramRawLiteralHtmlExtraction = {
   markdown: string;
-  blocks: string[];
+  blocks: TelegramRawLiteralHtmlBlock[];
 };
 
-const TELEGRAM_RAW_LITERAL_HTML_PLACEHOLDER_PREFIX = "TG_RICH_RAW_LITERAL_HTML_BLOCK_";
-const TELEGRAM_RAW_LITERAL_HTML_PLACEHOLDER_SUFFIX = "_TOKEN";
+type TelegramRawLiteralHtmlBlock = {
+  placeholder: string;
+  html: string;
+};
 
-function buildTelegramRawLiteralHtmlPlaceholder(index: number): string {
-  return `${TELEGRAM_RAW_LITERAL_HTML_PLACEHOLDER_PREFIX}${index}${TELEGRAM_RAW_LITERAL_HTML_PLACEHOLDER_SUFFIX}`;
+const TELEGRAM_RAW_LITERAL_HTML_PLACEHOLDER_PREFIX = "\u{e000}TG_RICH_RAW_LITERAL_HTML_BLOCK_";
+const TELEGRAM_RAW_LITERAL_HTML_PLACEHOLDER_SUFFIX = "_TOKEN\u{e001}";
+
+function buildTelegramRawLiteralHtmlPlaceholder(index: number, attempt: number): string {
+  return `${TELEGRAM_RAW_LITERAL_HTML_PLACEHOLDER_PREFIX}${index}_${attempt}${TELEGRAM_RAW_LITERAL_HTML_PLACEHOLDER_SUFFIX}`;
+}
+
+function buildUnusedTelegramRawLiteralHtmlPlaceholder(markdown: string, index: number): string {
+  let attempt = 0;
+  while (true) {
+    const placeholder = buildTelegramRawLiteralHtmlPlaceholder(index, attempt);
+    if (!markdown.includes(placeholder)) {
+      return placeholder;
+    }
+    attempt++;
+  }
 }
 
 function preserveTelegramRawLiteralHtmlBlock(block: string): string {
@@ -752,11 +768,14 @@ function extractTelegramRawLiteralHtmlBlocks(markdown: string): TelegramRawLiter
 
   let out = "";
   let lastIndex = 0;
-  const blocks: string[] = [];
+  const blocks: TelegramRawLiteralHtmlBlock[] = [];
   for (const range of ranges) {
     out += markdown.slice(lastIndex, range.start);
-    const placeholder = buildTelegramRawLiteralHtmlPlaceholder(blocks.length);
-    blocks.push(preserveTelegramRawLiteralHtmlBlock(markdown.slice(range.start, range.end)));
+    const placeholder = buildUnusedTelegramRawLiteralHtmlPlaceholder(markdown, blocks.length);
+    blocks.push({
+      placeholder,
+      html: preserveTelegramRawLiteralHtmlBlock(markdown.slice(range.start, range.end)),
+    });
     out += placeholder;
     lastIndex = range.end;
   }
@@ -764,10 +783,13 @@ function extractTelegramRawLiteralHtmlBlocks(markdown: string): TelegramRawLiter
   return { markdown: out, blocks };
 }
 
-function restoreTelegramRawLiteralHtmlBlocks(html: string, blocks: readonly string[]): string {
+function restoreTelegramRawLiteralHtmlBlocks(
+  html: string,
+  blocks: readonly TelegramRawLiteralHtmlBlock[],
+): string {
   let result = html;
-  for (const [index, block] of blocks.entries()) {
-    result = result.replaceAll(buildTelegramRawLiteralHtmlPlaceholder(index), block);
+  for (const block of blocks) {
+    result = result.replace(block.placeholder, block.html);
   }
   return result;
 }

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -1056,7 +1056,7 @@ describe("sendMessageTelegram", () => {
     expect(richHtml).toContain("nested<br>line");
   });
 
-  it("materializes bullet and paragraph line breaks in rich Markdown sends", async () => {
+  it("materializes bullet paragraph spacing in rich Markdown sends", async () => {
     botApi.sendMessage.mockResolvedValue({ message_id: 60, chat: { id: "123" } });
 
     await sendMessageTelegram(
@@ -1067,7 +1067,7 @@ describe("sendMessageTelegram", () => {
 
     expect(botRawApi.sendRichMessage).toHaveBeenCalledTimes(1);
     expect(botRawApi.sendRichMessage.mock.calls[0]?.[0]?.rich_message.html).toBe(
-      "Start here:<br><br>• Florist - Red Bird<br>• Tomberlin - Seventeen",
+      "Start here:<br><br>• Florist - Red Bird<br><br>• Tomberlin - Seventeen",
     );
   });
 


### PR DESCRIPTION
Closes #97568

## What Problem This Solves

Fixes an issue where users with `channels.telegram.richMessages: true` would see Telegram Markdown list items and bold section headers render too tightly because rich messages only preserved single line breaks for those structured Markdown lines.

AI-assisted with Codex.

## Why This Change Was Made

The Telegram Markdown formatter now enables extra paragraph spacing only on the rich-message path before consecutive list items and before bold section-header lines. The legacy Telegram HTML/Markdown path keeps its existing single-line list behavior, so this stays scoped to Bot API rich-message rendering.

Follow-ups for ClawSweeper review: raw rich HTML `<pre>`/`<code>` literal regions are extracted before rich Markdown media normalization and spacing promotion, then restored after rich rendering. The extraction now uses per-block placeholders that are absent from the original markdown and restores each inserted placeholder once, so user-visible placeholder-looking text outside raw code cannot be replaced with an extracted raw block.

## User Impact

Telegram rich-message replies, slash-command output, and other Markdown sends with lists or bold section headers are easier to scan, while users who disable rich messages keep the previous rendering behavior. Raw Telegram rich code blocks keep their literal contents.

## Evidence

- `node scripts/run-vitest.mjs extensions/telegram/src/format.test.ts` — 1 file, 63 tests passed.
- `node scripts/run-vitest.mjs extensions/telegram/src/format.test.ts extensions/telegram/src/send.test.ts` — 2 files, 198 tests passed.
- `./node_modules/.bin/oxfmt --check --threads=1 extensions/telegram/src/format.ts extensions/telegram/src/format.test.ts extensions/telegram/src/send.test.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/telegram/src/format.ts extensions/telegram/src/format.test.ts extensions/telegram/src/send.test.ts`
- `node scripts/run-tsgo.mjs -p extensions/telegram/tsconfig.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/telegram.tsbuildinfo`
- `git diff --check`

Known proof gap: I do not have live Telegram Bot API/Desktop proof from this local environment, so this PR is intentionally draft. The hosted Mantis Telegram Desktop proof run also did not produce usable proof because the proof session rendered replies with rich messages disabled.

Blocked broader type check:

- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo` currently fails on unrelated current-main extension errors in `extensions/acpx` and missing `@openclaw/crabline` declarations in `extensions/qa-lab`.
