### PR TITLE
fix(status): warm gateway context cache in background

### DIFF
--- a/src/agents/context.lookup.test.ts
+++ b/src/agents/context.lookup.test.ts
@@ -344,6 +344,50 @@ describe("lookupContextTokens", () => {
     expect(lookupContextTokens("anthropic/claude-opus-4.7-20260219")).toBe(1_048_576);
   });
 
+  it("uses caller config when gateway startup starts cache warming", async () => {
+    const config = createContextOverrideConfig("anthropic", "claude-opus-4.7-20260219", 200_000);
+    mockDiscoveryDeps([
+      {
+        id: "anthropic/claude-opus-4.7-20260219",
+        provider: "anthropic",
+        contextWindow: 200_000,
+      },
+    ]);
+
+    const { ensureContextWindowCacheLoaded, lookupContextTokens } = await importContextModule();
+    await ensureContextWindowCacheLoaded(config);
+
+    expect(contextTestState.loadModelCatalog).toHaveBeenCalledWith({
+      config,
+      readOnly: true,
+    });
+    expect(
+      lookupContextTokens("anthropic/claude-opus-4.7-20260219", { allowAsyncLoad: false }),
+    ).toBe(1_048_576);
+  });
+
+  it("status waits for pending context warmup but releases on timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      contextTestState.loadModelCatalog.mockImplementationOnce(
+        () => new Promise<DiscoveredModel[]>(() => {}),
+      );
+
+      const { ensureContextWindowCacheLoaded, waitForContextWindowCacheLoad } =
+        await importContextModule();
+      void ensureContextWindowCacheLoaded(
+        createContextOverrideConfig("anthropic", "claude", 200_000),
+      );
+
+      const waitResult = waitForContextWindowCacheLoad({ timeoutMs: 5 });
+      await vi.advanceTimersByTimeAsync(5);
+
+      await expect(waitResult).resolves.toBe("timeout");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("warms context metadata from bundled provider static catalogs", async () => {
     contextTestState.staticCatalogModels = [
       {

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -184,7 +184,7 @@ function primeConfiguredContextWindows(): OpenClawConfig | undefined {
   }
 }
 
-export function ensureContextWindowCacheLoaded(): Promise<void> {
+export function ensureContextWindowCacheLoaded(cfgOverride?: OpenClawConfig): Promise<void> {
   const generation = CONTEXT_WINDOW_RUNTIME_STATE.generation;
   if (
     CONTEXT_WINDOW_RUNTIME_STATE.loadPromise &&
@@ -193,7 +193,9 @@ export function ensureContextWindowCacheLoaded(): Promise<void> {
     return CONTEXT_WINDOW_RUNTIME_STATE.loadPromise;
   }
 
-  const cfg = primeConfiguredContextWindows();
+  const cfg = cfgOverride
+    ? primeConfiguredContextWindowsFromConfig(cfgOverride)
+    : primeConfiguredContextWindows();
   if (!cfg) {
     return Promise.resolve();
   }
@@ -240,6 +242,38 @@ export function ensureContextWindowCacheLoaded(): Promise<void> {
     });
   CONTEXT_WINDOW_RUNTIME_STATE.loadGeneration = generation;
   return CONTEXT_WINDOW_RUNTIME_STATE.loadPromise;
+}
+
+export async function waitForContextWindowCacheLoad(options?: {
+  timeoutMs?: number;
+}): Promise<"idle" | "loaded" | "timeout"> {
+  const promise = CONTEXT_WINDOW_RUNTIME_STATE.loadPromise;
+  if (
+    !promise ||
+    CONTEXT_WINDOW_RUNTIME_STATE.loadGeneration !== CONTEXT_WINDOW_RUNTIME_STATE.generation
+  ) {
+    return "idle";
+  }
+
+  const timeoutMs = Math.max(0, Math.trunc(options?.timeoutMs ?? 250));
+  if (timeoutMs === 0) {
+    return "timeout";
+  }
+
+  let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+  try {
+    return await Promise.race([
+      promise.then(() => "loaded" as const),
+      new Promise<"timeout">((resolve) => {
+        timeoutHandle = setTimeout(() => resolve("timeout"), timeoutMs);
+        (timeoutHandle as ReturnType<typeof setTimeout> & { unref?: () => void }).unref?.();
+      }),
+    ]);
+  } finally {
+    if (timeoutHandle) {
+      clearTimeout(timeoutHandle);
+    }
+  }
 }
 
 /** Replace cached model context metadata for the active runtime configuration. */

--- a/src/commands/status.summary.runtime.ts
+++ b/src/commands/status.summary.runtime.ts
@@ -10,6 +10,7 @@ import { readAcpSessionMeta } from "../acp/runtime/session-meta.js";
 import { resolveModelAgentRuntimeMetadata } from "../agents/agent-runtime-metadata.js";
 import { resolveConfiguredProviderFallback } from "../agents/configured-provider-fallback.js";
 import { resolveContextTokensForModelFromCache as resolveContextTokensForModel } from "../agents/context-resolution.js";
+import { waitForContextWindowCacheLoad } from "../agents/context.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { parseModelRef, resolvePersistedSelectedModelRef } from "../agents/model-selection.js";
 import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
@@ -161,6 +162,7 @@ function resolveSessionRuntimeLabel(params: {
 }
 
 export const statusSummaryRuntime = {
+  waitForContextWindowCacheLoad,
   resolveContextTokensForModel,
   classifySessionKey: classifySessionKind,
   resolveSessionModelRef,

--- a/src/commands/status.summary.test.ts
+++ b/src/commands/status.summary.test.ts
@@ -81,6 +81,7 @@ vi.mock("./status.summary.runtime.js", () => ({
     })),
     resolveSessionRuntimeLabel: vi.fn(() => "OpenClaw Default"),
     resolveContextTokensForModel: vi.fn(() => 200_000),
+    waitForContextWindowCacheLoad: vi.fn(async () => "idle" as const),
   },
 }));
 
@@ -359,6 +360,7 @@ describe("getStatusSummary", () => {
   it("does not trigger async context warmup while building status summaries", async () => {
     await getStatusSummary();
 
+    expect(statusSummaryRuntime.waitForContextWindowCacheLoad).toHaveBeenCalledTimes(1);
     const contextCall = vi.mocked(statusSummaryRuntime.resolveContextTokensForModel).mock
       .calls[0]?.[0];
     expect(contextCall?.allowAsyncLoad).toBe(false);

--- a/src/commands/status.summary.ts
+++ b/src/commands/status.summary.ts
@@ -254,8 +254,10 @@ export async function getStatusSummary(
     resolveContextTokensForModel,
     resolveSessionRuntimeLabel,
     resolveSessionModelRef,
+    waitForContextWindowCacheLoad,
   } = await loadStatusSummaryRuntimeModule();
   const cfg = options.config ?? getRuntimeConfig();
+  await waitForContextWindowCacheLoad();
   const contextSourceConfig =
     options.sourceConfig !== undefined
       ? options.sourceConfig

--- a/src/gateway/server-startup-early.test.ts
+++ b/src/gateway/server-startup-early.test.ts
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   refreshRemoteBinsForConnectedNodes: vi.fn(),
   registerSkillsChangeListener: vi.fn(),
   skillsChangeUnsub: vi.fn(),
+  ensureContextWindowCacheLoaded: vi.fn(),
   configureTaskRegistryMaintenance: vi.fn(),
   startTaskRegistryMaintenance: vi.fn(),
   getInspectableActiveTaskRestartBlockers: vi.fn(),
@@ -35,6 +36,10 @@ vi.mock("../skills/runtime/remote.js", () => ({
 
 vi.mock("../skills/runtime/refresh.js", () => ({
   registerSkillsChangeListener: mocks.registerSkillsChangeListener,
+}));
+
+vi.mock("../agents/context.js", () => ({
+  ensureContextWindowCacheLoaded: mocks.ensureContextWindowCacheLoaded,
 }));
 
 vi.mock("../tasks/task-registry.maintenance.js", () => ({
@@ -90,6 +95,8 @@ describe("startGatewayEarlyRuntime", () => {
     mocks.registerSkillsChangeListener.mockReset();
     mocks.registerSkillsChangeListener.mockReturnValue(mocks.skillsChangeUnsub);
     mocks.skillsChangeUnsub.mockReset();
+    mocks.ensureContextWindowCacheLoaded.mockReset();
+    mocks.ensureContextWindowCacheLoaded.mockResolvedValue(undefined);
     mocks.configureTaskRegistryMaintenance.mockReset();
     mocks.startTaskRegistryMaintenance.mockReset();
     mocks.getInspectableActiveTaskRestartBlockers.mockReset();
@@ -114,6 +121,8 @@ describe("startGatewayEarlyRuntime", () => {
     );
 
     expect(mocks.setSkillsRemoteRegistry).toHaveBeenCalledWith(nodeRegistry);
+    await Promise.resolve();
+    expect(mocks.ensureContextWindowCacheLoaded).toHaveBeenCalledWith({});
     expect(mocks.primeRemoteSkillsCache).toHaveBeenCalledTimes(1);
     expect(mocks.configureTaskRegistryMaintenance).toHaveBeenCalledTimes(1);
     expect(mocks.startTaskRegistryMaintenance).toHaveBeenCalledTimes(1);
@@ -122,6 +131,22 @@ describe("startGatewayEarlyRuntime", () => {
 
     earlyRuntime.skillsChangeUnsub();
     expect(mocks.skillsChangeUnsub).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not block gateway early runtime on context-window cache warmup", async () => {
+    const pendingWarmup = new Promise<void>(() => {});
+    mocks.ensureContextWindowCacheLoaded.mockReturnValueOnce(pendingWarmup);
+
+    const earlyRuntime = await startGatewayEarlyRuntime(
+      earlyRuntimeInput({
+        minimalTestGateway: false,
+        cfgAtStart: { agents: { defaults: { model: "openai/gpt-5.5" } } } as never,
+      }),
+    );
+
+    await Promise.resolve();
+    expect(mocks.ensureContextWindowCacheLoaded).toHaveBeenCalledTimes(1);
+    expect(earlyRuntime).toHaveProperty("startMaintenance");
   });
 
   it("starts discovery with the current plugin registry services", async () => {

--- a/src/gateway/server-startup-early.ts
+++ b/src/gateway/server-startup-early.ts
@@ -116,6 +116,14 @@ export async function startGatewayEarlyRuntime(params: {
   let getActiveTaskCount = () => 0;
 
   if (!params.minimalTestGateway) {
+    void import("../agents/context.js")
+      .then(({ ensureContextWindowCacheLoaded }) =>
+        ensureContextWindowCacheLoaded(params.cfgAtStart),
+      )
+      .catch((err: unknown) => {
+        params.log.warn(`Context-window cache warmup failed to start: ${String(err)}`);
+      });
+
     const [{ primeRemoteSkillsCache, setSkillsRemoteRegistry }, taskRegistryMaintenance] =
       await measureStartup(params.startupTrace, "runtime.early.lazy-runtime-imports", () =>
         Promise.all([

--- a/src/status/status-text.ts
+++ b/src/status/status-text.ts
@@ -10,7 +10,7 @@ import {
   resolveAgentModelFallbacksOverride,
 } from "../agents/agent-scope.js";
 import { ensureAuthProfileStore } from "../agents/auth-profiles/store.js";
-import { resolveContextTokensForModel } from "../agents/context.js";
+import { resolveContextTokensForModel, waitForContextWindowCacheLoad } from "../agents/context.js";
 import { resolveFastModeState } from "../agents/fast-mode.js";
 import { resolveModelAuthLabel } from "../agents/model-auth-label.js";
 import {
@@ -48,11 +48,11 @@ import {
   formatTaskStatusDetail,
   formatTaskStatusTitle,
 } from "../tasks/task-status.js";
-import { resolveActiveFallbackState } from "./fallback-notice-state.js";
 import {
   buildCodexSyntheticUsageAuth,
   shouldUseCodexSyntheticUsageForRuntime,
 } from "./codex-synthetic-usage.js";
+import { resolveActiveFallbackState } from "./fallback-notice-state.js";
 import { formatCompactPluginHealthLine } from "./status-plugin-health.js";
 import type { BuildStatusTextParams } from "./status-text.types.js";
 
@@ -584,6 +584,7 @@ export async function buildStatusText(params: BuildStatusTextParams): Promise<st
     sessionEntry,
   });
   const { buildStatusMessage } = await loadStatusMessageRuntime();
+  await waitForContextWindowCacheLoad();
   const explicitThinkingDefault =
     (agentConfig?.thinkingDefault as ThinkLevel | undefined) ??
     (agentDefaults.thinkingDefault as ThinkLevel | undefined);


### PR DESCRIPTION
Closes #92967.

## What Problem This Solves

Fixes an issue where cold Gateway status paths could report fallback context-window values before startup-time model metadata discovery had a chance to populate the cache.

## Why This Change Was Made

Gateway startup now begins context-window cache warmup in the background from the startup config, and status briefly waits only for an already pending warmup before using the existing synchronous cache read. Startup readiness remains independent from catalog warmup completion.

## User Impact

Status output can show discovered context-window metadata earlier after Gateway startup without delaying Gateway readiness or crossing the lazy catalog import boundary.

## Evidence

Live cold Gateway proof from a disposable local setup:

```text
first_rpc=callGateway(status) with operator.admin scope
config_model=opencode-go/deepseek-v4-pro
explicit_context_window_in_config=false
sessions.defaults.model=deepseek-v4-pro
sessions.defaults.contextTokens=1000000
[gateway] agent model: opencode-go/deepseek-v4-pro (thinking=medium, fast=off)
[gateway] http server listening ...
[gateway] ready
```

Focused coverage passed for context warmup, status summary, status text, and Gateway early-startup behavior. The tests verify that Gateway early runtime returns while mocked warmup stays pending, status waits on pending warmup with a timeout, and startup config-based warmup populates discovered 1M context metadata. The production build also completed from this branch.

## Real behavior proof

Behavior addressed: Cold Gateway status paths can read discovered context-window metadata instead of falling back to 200K after startup warmup begins.
Real environment tested: macOS, disposable local Gateway from this branch with isolated OPENCLAW_HOME/OPENCLAW_CONFIG_PATH and channels skipped.
Exact steps or command run after this patch: Started a fresh local Gateway with opencode-go/deepseek-v4-pro configured and no explicit contextWindow, waited for [gateway] ready, then made the first status RPC against that process with operator.admin scope via the repo callGateway runtime.
Evidence after fix: First status returned sessions.defaults.model=deepseek-v4-pro and sessions.defaults.contextTokens=1000000; Gateway logs showed the configured model and readiness before the status call.
Observed result after fix: The first cold status read from the disposable Gateway reported the warmed 1M context-window metadata instead of the 200K fallback.
What was not tested: A long-lived installed daemon using the user's real provider credentials.
