### PR TITLE
fix: make tool loop circuit breaker session-global

### DIFF
--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -568,6 +568,78 @@ describe("tool-loop-detection", () => {
       }
     });
 
+    it("blocks a session-wide no-progress streak across different tools and args", () => {
+      const state = createState();
+      const result = {
+        content: [{ type: "text", text: "same no-progress outcome" }],
+        details: { ok: true, unchanged: true },
+      };
+      const config: ToolLoopDetectionConfig = {
+        enabled: true,
+        warningThreshold: 2,
+        criticalThreshold: 3,
+        globalCircuitBreakerThreshold: 4,
+        detectors: { genericRepeat: false, knownPollNoProgress: false, pingPong: false },
+      };
+
+      recordSuccessfulCall(state, "read", { path: "/a.txt" }, result, 0);
+      recordSuccessfulCall(state, "list", { path: "/tmp" }, result, 1);
+      recordSuccessfulCall(state, "search", { query: "needle" }, result, 2);
+      recordSuccessfulCall(state, "inspect", { id: "different-args" }, result, 3);
+
+      const loopResult = detectToolCallLoop(state, "write", { path: "/next.txt" }, config);
+      expect(loopResult.stuck).toBe(true);
+      if (loopResult.stuck) {
+        expect(loopResult.level).toBe("critical");
+        expect(loopResult.detector).toBe("global_circuit_breaker");
+        expect(loopResult.count).toBe(4);
+        expect(loopResult.warningKey).toContain("global:session:");
+      }
+    });
+
+    it("does not count session-wide no-progress streak across different outcomes", () => {
+      const state = createState();
+      const config: ToolLoopDetectionConfig = {
+        enabled: true,
+        warningThreshold: 2,
+        criticalThreshold: 3,
+        globalCircuitBreakerThreshold: 4,
+        detectors: { genericRepeat: false, knownPollNoProgress: false, pingPong: false },
+      };
+
+      recordSuccessfulCall(
+        state,
+        "read",
+        { path: "/a.txt" },
+        { content: [{ type: "text", text: "same" }], details: { ok: true } },
+        0,
+      );
+      recordSuccessfulCall(
+        state,
+        "list",
+        { path: "/tmp" },
+        { content: [{ type: "text", text: "same" }], details: { ok: true } },
+        1,
+      );
+      recordSuccessfulCall(
+        state,
+        "search",
+        { query: "needle" },
+        { content: [{ type: "text", text: "progress" }], details: { ok: true } },
+        2,
+      );
+      recordSuccessfulCall(
+        state,
+        "inspect",
+        { id: "different-args" },
+        { content: [{ type: "text", text: "same" }], details: { ok: true } },
+        3,
+      );
+
+      const loopResult = detectToolCallLoop(state, "write", { path: "/next.txt" }, config);
+      expect(loopResult.stuck).toBe(false);
+    });
+
     it("blocks repeated completed exec calls despite volatile runtime details", () => {
       const state = createState();
       const params = { command: "grafana-api.sh datasources" };
@@ -1264,5 +1336,4 @@ describe("tool-loop-detection", () => {
       expect(loopResult.stuck && loopResult.level).not.toBe("critical");
     });
   });
-
 });

--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -568,36 +568,7 @@ describe("tool-loop-detection", () => {
       }
     });
 
-    it("blocks a session-wide no-progress streak across different tools and args", () => {
-      const state = createState();
-      const result = {
-        content: [{ type: "text", text: "same no-progress outcome" }],
-        details: { ok: true, unchanged: true },
-      };
-      const config: ToolLoopDetectionConfig = {
-        enabled: true,
-        warningThreshold: 2,
-        criticalThreshold: 3,
-        globalCircuitBreakerThreshold: 4,
-        detectors: { genericRepeat: false, knownPollNoProgress: false, pingPong: false },
-      };
-
-      recordSuccessfulCall(state, "read", { path: "/a.txt" }, result, 0);
-      recordSuccessfulCall(state, "list", { path: "/tmp" }, result, 1);
-      recordSuccessfulCall(state, "search", { query: "needle" }, result, 2);
-      recordSuccessfulCall(state, "inspect", { id: "different-args" }, result, 3);
-
-      const loopResult = detectToolCallLoop(state, "write", { path: "/next.txt" }, config);
-      expect(loopResult.stuck).toBe(true);
-      if (loopResult.stuck) {
-        expect(loopResult.level).toBe("critical");
-        expect(loopResult.detector).toBe("global_circuit_breaker");
-        expect(loopResult.count).toBe(4);
-        expect(loopResult.warningKey).toContain("global:session:");
-      }
-    });
-
-    it("does not count session-wide no-progress streak across different outcomes", () => {
+    it("blocks a session-wide no-progress streak across stable tool patterns", () => {
       const state = createState();
       const config: ToolLoopDetectionConfig = {
         enabled: true,
@@ -611,33 +582,229 @@ describe("tool-loop-detection", () => {
         state,
         "read",
         { path: "/a.txt" },
-        { content: [{ type: "text", text: "same" }], details: { ok: true } },
+        { content: [{ type: "text", text: "file unchanged" }], details: { ok: true } },
         0,
       );
       recordSuccessfulCall(
         state,
         "list",
         { path: "/tmp" },
-        { content: [{ type: "text", text: "same" }], details: { ok: true } },
+        { content: [{ type: "text", text: "same listing" }], details: { ok: true } },
+        1,
+      );
+      recordSuccessfulCall(
+        state,
+        "read",
+        { path: "/a.txt" },
+        { content: [{ type: "text", text: "file unchanged" }], details: { ok: true } },
+        2,
+      );
+      recordSuccessfulCall(
+        state,
+        "list",
+        { path: "/tmp" },
+        { content: [{ type: "text", text: "same listing" }], details: { ok: true } },
+        3,
+      );
+
+      const loopResult = detectToolCallLoop(state, "write", { path: "/next.txt" }, config);
+      expect(loopResult.stuck).toBe(true);
+      if (loopResult.stuck) {
+        expect(loopResult.level).toBe("critical");
+        expect(loopResult.detector).toBe("global_circuit_breaker");
+        expect(loopResult.count).toBe(4);
+        expect(loopResult.warningKey).toContain("global:session:");
+      }
+    });
+
+    it("ignores a session tail made only of unique progress outcomes", () => {
+      const state = createState();
+      const config: ToolLoopDetectionConfig = {
+        enabled: true,
+        warningThreshold: 2,
+        criticalThreshold: 3,
+        globalCircuitBreakerThreshold: 4,
+        detectors: { genericRepeat: false, knownPollNoProgress: false, pingPong: false },
+      };
+
+      recordSuccessfulCall(
+        state,
+        "read",
+        { path: "/a.txt" },
+        { content: [{ type: "text", text: "old file" }], details: { ok: true } },
+        0,
+      );
+      recordSuccessfulCall(
+        state,
+        "list",
+        { path: "/tmp" },
+        { content: [{ type: "text", text: "tmp listing" }], details: { ok: true } },
         1,
       );
       recordSuccessfulCall(
         state,
         "search",
         { query: "needle" },
-        { content: [{ type: "text", text: "progress" }], details: { ok: true } },
+        { content: [{ type: "text", text: "match found" }], details: { ok: true } },
         2,
       );
       recordSuccessfulCall(
         state,
         "inspect",
         { id: "different-args" },
-        { content: [{ type: "text", text: "same" }], details: { ok: true } },
+        { content: [{ type: "text", text: "object changed" }], details: { ok: true } },
         3,
       );
 
       const loopResult = detectToolCallLoop(state, "write", { path: "/next.txt" }, config);
       expect(loopResult.stuck).toBe(false);
+    });
+
+    it("stops the session-wide no-progress streak when a repeated tool pattern changes output", () => {
+      const state = createState();
+      const config: ToolLoopDetectionConfig = {
+        enabled: true,
+        warningThreshold: 2,
+        criticalThreshold: 3,
+        globalCircuitBreakerThreshold: 4,
+        detectors: { genericRepeat: false, knownPollNoProgress: false, pingPong: false },
+      };
+
+      recordSuccessfulCall(
+        state,
+        "read",
+        { path: "/a.txt" },
+        { content: [{ type: "text", text: "old file" }], details: { ok: true } },
+        0,
+      );
+      recordSuccessfulCall(
+        state,
+        "list",
+        { path: "/tmp" },
+        { content: [{ type: "text", text: "same listing" }], details: { ok: true } },
+        1,
+      );
+      recordSuccessfulCall(
+        state,
+        "read",
+        { path: "/a.txt" },
+        { content: [{ type: "text", text: "new file" }], details: { ok: true } },
+        2,
+      );
+      recordSuccessfulCall(
+        state,
+        "list",
+        { path: "/tmp" },
+        { content: [{ type: "text", text: "same listing" }], details: { ok: true } },
+        3,
+      );
+
+      const loopResult = detectToolCallLoop(state, "write", { path: "/next.txt" }, config);
+      expect(loopResult.stuck).toBe(false);
+    });
+
+    it("resets the session-wide no-progress streak after unique progress", () => {
+      const state = createState();
+      const config: ToolLoopDetectionConfig = {
+        enabled: true,
+        warningThreshold: 2,
+        criticalThreshold: 3,
+        globalCircuitBreakerThreshold: 4,
+        detectors: { genericRepeat: false, knownPollNoProgress: false, pingPong: false },
+      };
+
+      recordSuccessfulCall(
+        state,
+        "read",
+        { path: "/a.txt" },
+        { content: [{ type: "text", text: "file unchanged" }], details: { ok: true } },
+        0,
+      );
+      recordSuccessfulCall(
+        state,
+        "list",
+        { path: "/tmp" },
+        { content: [{ type: "text", text: "same listing" }], details: { ok: true } },
+        1,
+      );
+      recordSuccessfulCall(
+        state,
+        "read",
+        { path: "/a.txt" },
+        { content: [{ type: "text", text: "file unchanged" }], details: { ok: true } },
+        2,
+      );
+      recordSuccessfulCall(
+        state,
+        "list",
+        { path: "/tmp" },
+        { content: [{ type: "text", text: "same listing" }], details: { ok: true } },
+        3,
+      );
+      recordSuccessfulCall(
+        state,
+        "search",
+        { query: "needle" },
+        { content: [{ type: "text", text: "new result" }], details: { ok: true } },
+        4,
+      );
+
+      const loopResult = detectToolCallLoop(state, "write", { path: "/next.txt" }, config);
+      expect(loopResult.stuck).toBe(false);
+    });
+
+    it("counts a stable per-pattern tail after earlier unique progress", () => {
+      const state = createState();
+      const config: ToolLoopDetectionConfig = {
+        enabled: true,
+        warningThreshold: 2,
+        criticalThreshold: 3,
+        globalCircuitBreakerThreshold: 4,
+        detectors: { genericRepeat: false, knownPollNoProgress: false, pingPong: false },
+      };
+
+      recordSuccessfulCall(
+        state,
+        "search",
+        { query: "needle" },
+        { content: [{ type: "text", text: "new result" }], details: { ok: true } },
+        0,
+      );
+      recordSuccessfulCall(
+        state,
+        "read",
+        { path: "/a.txt" },
+        { content: [{ type: "text", text: "file unchanged" }], details: { ok: true } },
+        1,
+      );
+      recordSuccessfulCall(
+        state,
+        "list",
+        { path: "/tmp" },
+        { content: [{ type: "text", text: "same listing" }], details: { ok: true } },
+        2,
+      );
+      recordSuccessfulCall(
+        state,
+        "read",
+        { path: "/a.txt" },
+        { content: [{ type: "text", text: "file unchanged" }], details: { ok: true } },
+        3,
+      );
+      recordSuccessfulCall(
+        state,
+        "list",
+        { path: "/tmp" },
+        { content: [{ type: "text", text: "same listing" }], details: { ok: true } },
+        4,
+      );
+
+      const loopResult = detectToolCallLoop(state, "write", { path: "/next.txt" }, config);
+      expect(loopResult.stuck).toBe(true);
+      if (loopResult.stuck) {
+        expect(loopResult.detector).toBe("global_circuit_breaker");
+        expect(loopResult.count).toBe(4);
+      }
     });
 
     it("blocks repeated completed exec calls despite volatile runtime details", () => {

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -482,7 +482,7 @@ function getSessionNoProgressStreak(
       bestCount = stableEntries.reduce((total, [, value]) => total + value.count, 0);
       bestEvidenceKey = stableEntries
         .map(([stableSignature, value]) => `${stableSignature}:${value.resultHash}`)
-        .sort()
+        .toSorted()
         .join("|");
     }
   }

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -449,6 +449,32 @@ function getNoProgressStreak(
   return { count: streak, latestResultHash };
 }
 
+function getSessionNoProgressStreak(history: Array<{ resultHash?: string }>): {
+  count: number;
+  latestResultHash?: string;
+} {
+  let streak = 0;
+  let latestResultHash: string | undefined;
+
+  for (let i = history.length - 1; i >= 0; i -= 1) {
+    const record = history[i];
+    if (typeof record?.resultHash !== "string" || !record.resultHash) {
+      break;
+    }
+    if (!latestResultHash) {
+      latestResultHash = record.resultHash;
+      streak = 1;
+      continue;
+    }
+    if (record.resultHash !== latestResultHash) {
+      break;
+    }
+    streak += 1;
+  }
+
+  return { count: streak, latestResultHash };
+}
+
 function getPingPongStreak(
   history: Array<{ toolName: string; argsHash: string; resultHash?: string }>,
   currentSignature: string,
@@ -575,6 +601,8 @@ export function detectToolCallLoop(
   const unknownToolStreak = getUnknownToolRepeatStreak(history, toolName);
   const noProgress = getNoProgressStreak(history, toolName, currentHash);
   const noProgressStreak = noProgress.count;
+  const sessionNoProgress = getSessionNoProgressStreak(history);
+  const sessionNoProgressStreak = sessionNoProgress.count;
   const knownPollTool = isKnownPollToolCall(toolName, params);
   const pingPong = getPingPongStreak(history, currentHash);
 
@@ -589,17 +617,17 @@ export function detectToolCallLoop(
     };
   }
 
-  if (noProgressStreak >= resolvedConfig.globalCircuitBreakerThreshold) {
+  if (sessionNoProgressStreak >= resolvedConfig.globalCircuitBreakerThreshold) {
     log.error(
-      `Global circuit breaker triggered: ${toolName} repeated ${noProgressStreak} times with no progress`,
+      `Global circuit breaker triggered: session recorded ${sessionNoProgressStreak} consecutive no-progress outcomes`,
     );
     return {
       stuck: true,
       level: "critical",
       detector: "global_circuit_breaker",
-      count: noProgressStreak,
-      message: `CRITICAL: ${toolName} has repeated identical no-progress outcomes ${noProgressStreak} times. Session execution blocked by global circuit breaker to prevent runaway loops.`,
-      warningKey: `global:${toolName}:${currentHash}:${noProgress.latestResultHash ?? "none"}`,
+      count: sessionNoProgressStreak,
+      message: `CRITICAL: Session has repeated identical no-progress outcomes ${sessionNoProgressStreak} times across recent tool calls. Session execution blocked by global circuit breaker to prevent runaway loops.`,
+      warningKey: `global:session:${sessionNoProgress.latestResultHash ?? "none"}`,
     };
   }
 

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -449,30 +449,45 @@ function getNoProgressStreak(
   return { count: streak, latestResultHash };
 }
 
-function getSessionNoProgressStreak(history: Array<{ resultHash?: string }>): {
+function getSessionNoProgressStreak(
+  history: Array<{ toolName: string; argsHash: string; resultHash?: string }>,
+): {
   count: number;
-  latestResultHash?: string;
+  evidenceKey?: string;
 } {
-  let streak = 0;
-  let latestResultHash: string | undefined;
+  const stableResultsBySignature = new Map<string, { resultHash: string; count: number }>();
+  let bestCount = 0;
+  let bestEvidenceKey: string | undefined;
 
   for (let i = history.length - 1; i >= 0; i -= 1) {
     const record = history[i];
     if (typeof record?.resultHash !== "string" || !record.resultHash) {
       break;
     }
-    if (!latestResultHash) {
-      latestResultHash = record.resultHash;
-      streak = 1;
-      continue;
+
+    const signature = `${record.toolName}:${record.argsHash}`;
+    const prior = stableResultsBySignature.get(signature);
+    if (prior) {
+      if (prior.resultHash !== record.resultHash) {
+        break;
+      }
+      prior.count += 1;
+    } else {
+      stableResultsBySignature.set(signature, { resultHash: record.resultHash, count: 1 });
     }
-    if (record.resultHash !== latestResultHash) {
-      break;
+
+    const stableEntries = [...stableResultsBySignature];
+    const hasOnlyRepeatedStablePatterns = stableEntries.every(([, value]) => value.count > 1);
+    if (hasOnlyRepeatedStablePatterns) {
+      bestCount = stableEntries.reduce((total, [, value]) => total + value.count, 0);
+      bestEvidenceKey = stableEntries
+        .map(([stableSignature, value]) => `${stableSignature}:${value.resultHash}`)
+        .sort()
+        .join("|");
     }
-    streak += 1;
   }
 
-  return { count: streak, latestResultHash };
+  return { count: bestCount, evidenceKey: bestEvidenceKey };
 }
 
 function getPingPongStreak(
@@ -627,7 +642,7 @@ export function detectToolCallLoop(
       detector: "global_circuit_breaker",
       count: sessionNoProgressStreak,
       message: `CRITICAL: Session has repeated identical no-progress outcomes ${sessionNoProgressStreak} times across recent tool calls. Session execution blocked by global circuit breaker to prevent runaway loops.`,
-      warningKey: `global:session:${sessionNoProgress.latestResultHash ?? "none"}`,
+      warningKey: `global:session:${sessionNoProgress.evidenceKey || "none"}`,
     };
   }
 


### PR DESCRIPTION
## Summary

Fixes the global tool loop circuit breaker so it tracks a session-wide consecutive no-progress streak instead of only repeated calls to the same tool+args pair.

Fixes #79252

## What Problem This Solves

`globalCircuitBreakerThreshold` is documented as the final global no-progress breaker, but current main derives it from `getNoProgressStreak(history, toolName, currentHash)`. That means a runaway session can avoid the global breaker by alternating tools or arguments while receiving the same no-progress outcome each time. Each per-tool/per-args streak stays below the threshold even though the session as a whole is stuck.

## Issue / Motivation

Issue #79252 reports a real incident where a session cycled through multiple tools after each individual tool was blocked, consuming many model calls and tokens before manual intervention. The intended behavior is for the global breaker to count consecutive no-progress outcomes across the scoped session, independent of the specific tool signature.

## Changes

- Add a session-wide no-progress streak helper over the latest consecutive result hashes in scoped tool history.
- Wire `globalCircuitBreakerThreshold` to that session-wide streak and use a session-level warning key/message.
- Keep generic repeat, known poll no-progress, and ping-pong detectors on their existing per-tool/per-pattern logic.
- Add regression coverage for cross-tool/cross-args identical no-progress outcomes and for different outcomes breaking the session streak.

## Evidence

The regression test now records four consecutive successful calls using different tools and different args (`read`, `list`, `search`, `inspect`) with the same no-progress result, then verifies that the next tool call is blocked by `global_circuit_breaker` with count `4`. A paired negative test records a different result in the middle and verifies the session-global breaker does not fire.

Local validation completed on this branch:

```text
$ node scripts/run-vitest.mjs src/agents/tool-loop-detection.test.ts
[test] starting test/vitest/vitest.agents.config.ts
✓ agents  src/agents/tool-loop-detection.test.ts (58 tests) 146ms
Test Files  1 passed (1)
Tests  58 passed (58)
[test] passed 1 Vitest shard in 7.99s

$ pnpm -s exec oxfmt --check --threads=1 src/agents/tool-loop-detection.ts src/agents/tool-loop-detection.test.ts
Checking formatting...
All matched files use the correct format.
Finished in 20ms on 2 files using 1 threads.

$ git diff --check
(no output)

$ git diff origin/main...HEAD | added-line secret scan
secret_scan_ok
```

The previous Real behavior proof failures were PR-body metadata failures only: the workflow required authored `What Problem This Solves` and `Evidence` sections. This update adds those sections without changing code.

## Testing

- `node scripts/run-vitest.mjs src/agents/tool-loop-detection.test.ts`
- `pnpm -s exec oxfmt --check --threads=1 src/agents/tool-loop-detection.ts src/agents/tool-loop-detection.test.ts`
- `git diff --check`
- Added-line secret scan over `git diff origin/main...HEAD`



## Follow-up validation (2026-06-29)

Addressed ClawSweeper feedback by aggregating stable no-progress outcomes per tool/args pattern across the session tail instead of requiring every adjacent call to share one result hash. Added coverage for stable read/list tails, unique progress-only tails, changed repeated-pattern output, progress after a stable tail, and earlier unique progress before a stable tail.

Commands run on commit `74ebbadb507a6ff93a69ec4b0bd99a33c88012e1`:
- `node scripts/run-vitest.mjs src/agents/tool-loop-detection.test.ts -- --run` — 1 shard passed; 61 tests passed
- `pnpm -s exec oxfmt --check --threads=1 src/agents/tool-loop-detection.ts src/agents/tool-loop-detection.test.ts` — passed
- `git diff --check` and `git diff --cached --check` — passed
- added-line secret scan over `git diff origin/main...HEAD` — clean
