### PR TITLE
fix(plugin-sdk): bound Copilot token exchange JSON response reads

### DIFF
--- a/src/plugin-sdk/provider-auth.test.ts
+++ b/src/plugin-sdk/provider-auth.test.ts
@@ -406,6 +406,125 @@ describe("provider auth profile helpers", () => {
     expect(canceled).toBe(true);
   });
 
+  it("bounds oversized Copilot token success body over HTTP transport", async () => {
+    vi.resetModules();
+
+    const http = await import("node:http");
+    const { once } = await import("node:events");
+    const MiB = 1024 * 1024;
+    let bytesWritten = 0;
+
+    const server = http.createServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      const chunk = Buffer.alloc(MiB, 120);
+      const header = Buffer.from('{"token":"');
+      res.write(header);
+      bytesWritten += header.length;
+      let chunksSent = 0;
+      const writeNext = () => {
+        if (chunksSent >= 18) {
+          const tail = Buffer.from('","expires_at":9999999999}');
+          res.write(tail);
+          bytesWritten += tail.length;
+          res.end();
+          return;
+        }
+        const ok = res.write(chunk);
+        bytesWritten += chunk.length;
+        chunksSent += 1;
+        if (ok) {
+          setImmediate(writeNext);
+        } else {
+          res.once("drain", writeNext);
+        }
+      };
+      writeNext();
+    });
+
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("expected server address");
+    }
+
+    try {
+      const fetchImpl = vi.fn(async (_url: string, init?: RequestInit) =>
+        fetch(`http://127.0.0.1:${address.port}/token`, init),
+      );
+      const { resolveCopilotApiToken } = await import("./provider-auth.js");
+
+      await expect(
+        resolveCopilotApiToken({
+          githubToken: "github-token",
+          fetchImpl,
+          cachePath: "/tmp/copilot-token-http-proof.json",
+          loadJsonFileImpl: () => undefined,
+          saveJsonFileImpl: () => {
+            throw new Error("should not save oversized token");
+          },
+        }),
+      ).rejects.toThrow("github-copilot.token");
+
+      expect(bytesWritten).toBeGreaterThan(17 * MiB);
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+
+  it("accepts a normal Copilot token success body over HTTP transport", async () => {
+    vi.resetModules();
+
+    const http = await import("node:http");
+    const { once } = await import("node:events");
+    const body = JSON.stringify({
+      token: "gho_abc;proxy-ep=proxy.individual.githubcopilot.com",
+      expires_at: "+2000000000",
+    });
+
+    const server = http.createServer((_req, res) => {
+      res.writeHead(200, {
+        "Content-Type": "application/json",
+        "Content-Length": String(Buffer.byteLength(body)),
+      });
+      res.end(body);
+    });
+
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("expected server address");
+    }
+
+    try {
+      const saved: unknown[] = [];
+      const fetchImpl = vi.fn(async (_url: string, init?: RequestInit) =>
+        fetch(`http://127.0.0.1:${address.port}/token`, init),
+      );
+      const { resolveCopilotApiToken } = await import("./provider-auth.js");
+
+      const result = await resolveCopilotApiToken({
+        githubToken: "github-token",
+        fetchImpl,
+        cachePath: "/tmp/copilot-token-http-happy.json",
+        loadJsonFileImpl: () => undefined,
+        saveJsonFileImpl: (path, value) => {
+          saved.push({ path, value });
+        },
+      });
+
+      expect(result.token).toContain("proxy-ep=proxy.individual.githubcopilot.com");
+      expect(saved).toHaveLength(1);
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+
   it("refreshes cached Copilot tokens with out-of-range expiry values", async () => {
     vi.resetModules();
 

--- a/src/plugin-sdk/provider-auth.test.ts
+++ b/src/plugin-sdk/provider-auth.test.ts
@@ -457,7 +457,7 @@ describe("provider auth profile helpers", () => {
       await expect(
         resolveCopilotApiToken({
           githubToken: "github-token",
-          fetchImpl,
+          fetchImpl: fetchImpl as typeof fetch,
           cachePath: "/tmp/copilot-token-http-proof.json",
           loadJsonFileImpl: () => undefined,
           saveJsonFileImpl: () => {
@@ -508,7 +508,7 @@ describe("provider auth profile helpers", () => {
 
       const result = await resolveCopilotApiToken({
         githubToken: "github-token",
-        fetchImpl,
+        fetchImpl: fetchImpl as typeof fetch,
         cachePath: "/tmp/copilot-token-http-happy.json",
         loadJsonFileImpl: () => undefined,
         saveJsonFileImpl: (path, value) => {

--- a/src/plugin-sdk/provider-auth.test.ts
+++ b/src/plugin-sdk/provider-auth.test.ts
@@ -361,6 +361,51 @@ describe("provider auth profile helpers", () => {
     expect(cancel).toHaveBeenCalledOnce();
   });
 
+  it("bounds oversized Copilot token success body and cancels the stream", async () => {
+    vi.resetModules();
+
+    const chunk = new Uint8Array(1024 * 1024); // 1 MiB chunk
+    let readCount = 0;
+    let canceled = false;
+    // 64 chunks × 1 MiB = 64 MiB — far exceeds the 16 MiB cap
+    const oversizedBody = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (readCount >= 64) {
+          controller.close();
+          return;
+        }
+        readCount += 1;
+        controller.enqueue(chunk);
+      },
+      cancel() {
+        canceled = true;
+      },
+    });
+    const response = new Response(oversizedBody, {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+    const fetchImpl = vi.fn(async () => response);
+
+    const { resolveCopilotApiToken } = await import("./provider-auth.js");
+
+    await expect(
+      resolveCopilotApiToken({
+        githubToken: "github-token",
+        fetchImpl,
+        cachePath: "/tmp/copilot-token.json",
+        loadJsonFileImpl: () => undefined,
+        saveJsonFileImpl: () => {
+          throw new Error("should not save oversized token");
+        },
+      }),
+    ).rejects.toThrow("github-copilot.token");
+
+    // Stream must be cancelled before all 64 chunks are consumed
+    expect(readCount).toBeLessThan(64);
+    expect(canceled).toBe(true);
+  });
+
   it("refreshes cached Copilot tokens with out-of-range expiry values", async () => {
     vi.resetModules();
 

--- a/src/plugin-sdk/provider-auth.ts
+++ b/src/plugin-sdk/provider-auth.ts
@@ -23,6 +23,7 @@ import {
   buildCopilotIdeHeaders,
 } from "../agents/copilot-dynamic-headers.js";
 import { resolveEnvApiKey } from "../agents/model-auth-env.js";
+import { readProviderJsonResponse } from "../agents/provider-http-errors.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";
 import { loadJsonFile, saveJsonFile } from "../infra/json-file.js";
@@ -310,7 +311,9 @@ export async function resolveCopilotApiToken(params: {
     throw new Error(`Copilot token exchange failed: HTTP ${res.status}`);
   }
 
-  const json = parseCopilotTokenResponse(await res.json());
+  const json = parseCopilotTokenResponse(
+    await readProviderJsonResponse(res, "github-copilot.token"),
+  );
   const payload: CachedCopilotToken = {
     token: json.token,
     expiresAt: json.expiresAt,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the GitHub Copilot API token exchange success response
was read with an unbounded `await res.json()`, meaning a misbehaving,
compromised, or proxied Copilot token endpoint could stream an arbitrarily
large JSON body into the Node.js heap before parsing began — causing memory
pressure or OOM during `openclaw onboard` and every Copilot auth refresh.

The failure path at `provider-auth.ts:309` already calls
`cancelUnreadResponseBody(res)` to release the stream, but the success path
immediately below had no size cap — a clear asymmetric gap.

This is a **SDK-level** path (`src/plugin-sdk/`): every consumer of
`resolveCopilotApiToken` (agent startup, onboarding, live Copilot inference
sessions) is affected. Sibling paths in the same campaign that have already
been fixed include `github-copilot/usage.ts` and `github-copilot/embeddings.ts`
(merged #96607), and `github-copilot/login.ts` device-flow exchange (merged
#97583).

## Why This Change Was Made

`readProviderJsonResponse` (from `../agents/provider-http-errors.js`, the same
module re-exported via `openclaw/plugin-sdk/provider-http`) wraps
`readResponseWithLimit` with a 16 MiB cap, cancels the ReadableStream on
overflow, and wraps JSON parse errors in a consistent
`"<label>: malformed JSON response"` message.

```typescript
// Before
const json = parseCopilotTokenResponse(await res.json());

// After
const json = parseCopilotTokenResponse(
  await readProviderJsonResponse(res, "github-copilot.token"),
);
```

The `parseCopilotTokenResponse` wrapper is unchanged — it still validates the
`token` and `expires_at` fields after the bounded read. Net diff: **+1 import,
+2 production lines** (wrapping the existing single-line call).

## User Impact

No user-visible behavior change for well-behaved GitHub Copilot endpoints.
Operators or users whose Copilot token endpoint returns an oversized JSON
payload (e.g., a misconfigured proxy, a MITM relay, or a future protocol
change) will now see a bounded error
(`github-copilot.token: JSON response exceeds 16777216 bytes`) instead of
unbounded heap growth.

## Changes

* `src/plugin-sdk/provider-auth.ts`:
  - imports `readProviderJsonResponse` from `../agents/provider-http-errors.js`
  - replaces unbounded `await res.json()` with
    `readProviderJsonResponse(res, "github-copilot.token")` on the Copilot token
    exchange success path

* `src/plugin-sdk/provider-auth.test.ts`:
  - adds `bounds oversized Copilot token success body and cancels the stream`
    (injected `ReadableStream` regression)
  - adds `bounds oversized Copilot token success body over HTTP transport`
    (`node:http` server + real `fetch`/`undici` through `resolveCopilotApiToken`)
  - adds `accepts a normal Copilot token success body over HTTP transport`
    (happy-path HTTP proof)

Rebased onto current `main`.

## Real behavior proof

**Behavior addressed:** Prevents unbounded JSON parse allocation on the Copilot
token exchange success path. Oversized streamed bodies fail closed with a
labeled error before `JSON.parse` runs.

**Real environment tested:** Node v22, macOS 24.3.0, `node:http` streaming
server on `127.0.0.1`, built `resolveCopilotApiToken` from
`dist/plugin-sdk/provider-auth.js`, real `fetch`/undici transport (not injected
`Response` objects for path-level cases).

**Exact steps:**
1. Stream an ~18 MiB Copilot token JSON body from a local HTTP server (no
   `Content-Length`).
2. Drive `resolveCopilotApiToken` with `fetchImpl` pointing at the local server
   → assert labeled rejection.
3. Serve a normal Copilot token JSON body over HTTP → assert exchange + cache
   write succeeds.
4. Drive `readProviderJsonResponse` on the same streamed HTTP body → assert
   parse cap fires.
5. Negative control: unbounded `response.json()` drains 64 MiB without
   cancelling the stream.
6. Bounded helper cancels injected stream after ~17 MiB read.
7. Run `provider-auth` HTTP transport regression tests.

**Observed result:**
- Path-level HTTP: `github-copilot.token: JSON response exceeds 16777216 bytes`
- Normal HTTP token body parses; `proxy-ep=` metadata intact; cache write once
- Negative control: unbounded `.json()` read all 64 chunks; no `cancel()`
- Bounded helper: `readCount=17`, `cancel()` invoked
- `ALL PROOF ASSERTIONS PASSED`

**What was not tested:** live `api.github.com/copilot_internal/v2/token` calls.

## Evidence

```
=== Copilot token exchange bound proof (path-level) ===
--- Case 1: oversized streamed body through resolveCopilotApiToken + fetch ---
  ok: resolveCopilotApiToken rejects oversized HTTP token body
  ok: labeled parse cap error (got: github-copilot.token: JSON response exceeds 16777216 bytes)

--- Case 2: normal Copilot token body over HTTP transport ---
  ok: normal HTTP token body parses
  ok: proxy-ep metadata intact
  ok: token cached once

--- Case 3: oversized streamed HTTP body rejected at JSON parse helper ---
  ok: readProviderJsonResponse rejects oversized streamed body
  ok: helper label present (got: github-copilot.token: JSON response exceeds 16777216 bytes)

--- Case 4: negative control — unbounded response.json() ---
  ok: unbounded .json() consumed all 64 chunks (readCount=64)
  ok: stream NOT cancelled via .cancel()

--- Case 5: bounded helper cancels oversized injected stream ---
  ok: readProviderJsonResponse rejected oversized injected stream
  ok: stream read stopped early (readCount=17)
  ok: stream cancel() was invoked

ALL PROOF ASSERTIONS PASSED
```

```
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/plugin-sdk/provider-auth.test.ts \
  -t "HTTP transport|bounds oversized Copilot token success body"
# Tests  3 passed | 8 skipped (11)
```

New bound regression tests (3 added):
- `bounds oversized Copilot token success body and cancels the stream` ✓
- `bounds oversized Copilot token success body over HTTP transport` ✓
- `accepts a normal Copilot token success body over HTTP transport` ✓
