### PR TITLE
Fix/bound copilot login json responses

### DIFF
--- a/extensions/github-copilot/login.test.ts
+++ b/extensions/github-copilot/login.test.ts
@@ -1,0 +1,205 @@
+// Github Copilot tests cover device-flow login behavior.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  runGitHubCopilotDeviceFlow,
+  setGitHubCopilotDeviceFlowFetchGuardForTesting,
+} from "./login.js";
+
+const DEVICE_CODE_URL = "https://github.com/login/device/code";
+const ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token";
+
+// A valid device code payload GitHub returns on the first step.
+const VALID_DEVICE_CODE_BODY = {
+  device_code: "dev-code-abc123",
+  user_code: "ABCD-1234",
+  verification_uri: "https://github.com/login/device",
+  expires_in: 900,
+  interval: 5,
+};
+
+function guardResponse(body: unknown, status = 200, url = DEVICE_CODE_URL) {
+  return {
+    response: new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    }),
+    finalUrl: url,
+    release: vi.fn(async () => {}),
+  };
+}
+
+afterEach(() => {
+  setGitHubCopilotDeviceFlowFetchGuardForTesting(null);
+  vi.restoreAllMocks();
+});
+
+describe("runGitHubCopilotDeviceFlow — normal flow", () => {
+  it("returns authorized status and access token on successful flow", async () => {
+    let callIdx = 0;
+    setGitHubCopilotDeviceFlowFetchGuardForTesting(async (params) => {
+      callIdx += 1;
+      if (callIdx === 1) {
+        expect(params.url).toBe(DEVICE_CODE_URL);
+        return guardResponse(VALID_DEVICE_CODE_BODY);
+      }
+      expect(params.url).toBe(ACCESS_TOKEN_URL);
+      return guardResponse(
+        { access_token: "ghu_tok_xyz", token_type: "bearer" },
+        200,
+        ACCESS_TOKEN_URL,
+      );
+    });
+
+    const showCode = vi.fn(async () => {});
+    const result = await runGitHubCopilotDeviceFlow({ showCode });
+
+    expect(result).toEqual({ status: "authorized", accessToken: "ghu_tok_xyz" });
+    expect(showCode).toHaveBeenCalledWith({
+      verificationUrl: "https://github.com/login/device",
+      userCode: "ABCD-1234",
+      expiresInMs: expect.any(Number),
+    });
+    expect(callIdx).toBe(2);
+  });
+
+  it("returns access_denied when GitHub rejects the authorization", async () => {
+    let callIdx = 0;
+    setGitHubCopilotDeviceFlowFetchGuardForTesting(async () => {
+      callIdx += 1;
+      if (callIdx === 1) {
+        return guardResponse(VALID_DEVICE_CODE_BODY);
+      }
+      return guardResponse({ error: "access_denied" }, 200, ACCESS_TOKEN_URL);
+    });
+
+    const result = await runGitHubCopilotDeviceFlow({
+      showCode: vi.fn(async () => {}),
+    });
+    expect(result).toEqual({ status: "access_denied" });
+  });
+
+  it("returns expired when GitHub reports expired_token", async () => {
+    let callIdx = 0;
+    setGitHubCopilotDeviceFlowFetchGuardForTesting(async () => {
+      callIdx += 1;
+      if (callIdx === 1) {
+        return guardResponse(VALID_DEVICE_CODE_BODY);
+      }
+      return guardResponse({ error: "expired_token" }, 200, ACCESS_TOKEN_URL);
+    });
+
+    const result = await runGitHubCopilotDeviceFlow({
+      showCode: vi.fn(async () => {}),
+    });
+    expect(result).toEqual({ status: "expired" });
+  });
+});
+
+describe("runGitHubCopilotDeviceFlow — HTTP error propagation", () => {
+  it("throws with failureLabel on non-OK device code response", async () => {
+    setGitHubCopilotDeviceFlowFetchGuardForTesting(async () => guardResponse({}, 401));
+
+    await expect(runGitHubCopilotDeviceFlow({ showCode: vi.fn() })).rejects.toThrow(
+      "GitHub device code failed: HTTP 401",
+    );
+  });
+
+  it("throws with failureLabel on non-OK access token response", async () => {
+    let callIdx = 0;
+    setGitHubCopilotDeviceFlowFetchGuardForTesting(async () => {
+      callIdx += 1;
+      if (callIdx === 1) {
+        return guardResponse(VALID_DEVICE_CODE_BODY);
+      }
+      return guardResponse({}, 500, ACCESS_TOKEN_URL);
+    });
+
+    await expect(runGitHubCopilotDeviceFlow({ showCode: vi.fn(async () => {}) })).rejects.toThrow(
+      "GitHub device token failed: HTTP 500",
+    );
+  });
+});
+
+describe("postGitHubDeviceFlowForm — response size bound", () => {
+  it("bounds oversized device code body and cancels the stream", async () => {
+    const chunk = new Uint8Array(1024 * 1024); // 1 MiB
+    let readCount = 0;
+    let canceled = false;
+    // 64 chunks × 1 MiB = 64 MiB — far exceeds the 16 MiB cap
+    const oversizedBody = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (readCount >= 64) {
+          controller.close();
+          return;
+        }
+        readCount += 1;
+        controller.enqueue(chunk);
+      },
+      cancel() {
+        canceled = true;
+      },
+    });
+
+    setGitHubCopilotDeviceFlowFetchGuardForTesting(async () => ({
+      response: new Response(oversizedBody, {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+      finalUrl: DEVICE_CODE_URL,
+      release: async () => {},
+    }));
+
+    await expect(runGitHubCopilotDeviceFlow({ showCode: vi.fn() })).rejects.toThrow(
+      "github-copilot.device-flow",
+    );
+
+    // Stream must be cancelled before all 64 MiB are consumed
+    expect(readCount).toBeLessThan(64);
+    expect(canceled).toBe(true);
+  });
+
+  it("bounds oversized access token body and cancels the stream", async () => {
+    const chunk = new Uint8Array(1024 * 1024); // 1 MiB
+    let readCount = 0;
+    let canceled = false;
+    let callIdx = 0;
+
+    setGitHubCopilotDeviceFlowFetchGuardForTesting(async () => {
+      callIdx += 1;
+      if (callIdx === 1) {
+        return guardResponse(VALID_DEVICE_CODE_BODY);
+      }
+
+      const oversizedBody = new ReadableStream<Uint8Array>({
+        pull(controller) {
+          if (readCount >= 64) {
+            controller.close();
+            return;
+          }
+          readCount += 1;
+          controller.enqueue(chunk);
+        },
+        cancel() {
+          canceled = true;
+        },
+      });
+
+      return {
+        response: new Response(oversizedBody, {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+        finalUrl: ACCESS_TOKEN_URL,
+        release: async () => {},
+      };
+    });
+
+    await expect(runGitHubCopilotDeviceFlow({ showCode: vi.fn(async () => {}) })).rejects.toThrow(
+      "github-copilot.device-flow",
+    );
+
+    // Stream must be cancelled before all 64 MiB are consumed
+    expect(readCount).toBeLessThan(64);
+    expect(canceled).toBe(true);
+  });
+});

--- a/extensions/github-copilot/login.ts
+++ b/extensions/github-copilot/login.ts
@@ -13,6 +13,7 @@ import {
   ensureAuthProfileStore,
   upsertAuthProfileWithLock,
 } from "openclaw/plugin-sdk/provider-auth";
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime";
 import { fetchWithSsrFGuard, type SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
 
@@ -147,7 +148,9 @@ async function postGitHubDeviceFlowForm(params: {
     if (!response.ok) {
       throw new Error(`${params.failureLabel}: HTTP ${response.status}`);
     }
-    return parseJsonResponse(await response.json());
+    return parseJsonResponse(
+      await readProviderJsonResponse(response, "github-copilot.device-flow"),
+    );
   } finally {
     await release();
   }


### PR DESCRIPTION
# fix(github-copilot): bound device-flow JSON response reads

## What Problem This Solves

`postGitHubDeviceFlowForm` in `extensions/github-copilot/login.ts` calls
`await response.json()` on success responses from both the device-code URL and
the access-token polling URL without any byte limit. An attacker who can intercept
or spoof the GitHub endpoint (MITM, DNS poisoning, or operator-misconfigured proxy)
could return an arbitrarily large JSON body and exhaust Node.js heap memory.

The fix is XS: one import line, two lines at the call site.

## Why This Change Was Made

`readProviderJsonResponse` (from `openclaw/plugin-sdk/provider-http`) caps JSON reads
at 16 MiB, cancels the underlying `ReadableStream` on overflow, and surfaces a
provider-tagged error. The same helper is already used in
`extensions/github-copilot/usage.ts` and `embeddings.ts` within the same extension —
no new dependency surface is added.

The non-OK branch (`!response.ok`) already throws before reading the body; only the
success-body read at line 151 was unbounded.

## User Impact

- **Normal path**: no change — valid GitHub device code and access token responses
  are well under 1 KiB. The full normal flow (device code → authorization → token)
  passes the regression suite unchanged.
- **Oversized / malicious response**: instead of OOM, the process now throws a
  `ProviderHttpError("github-copilot.device-flow: JSON response exceeds 16777216 bytes")`.

## Evidence

### Unit tests — `extensions/github-copilot/login.test.ts` (new file, 7 tests)

```
✓  runGitHubCopilotDeviceFlow — normal flow
   ✓ returns authorized status and access token on successful flow          22ms
   ✓ returns access_denied when GitHub rejects the authorization             2ms
   ✓ returns expired when GitHub reports expired_token                       1ms
✓  runGitHubCopilotDeviceFlow — HTTP error propagation
   ✓ throws with failureLabel on non-OK device code response                 1ms
   ✓ throws with failureLabel on non-OK access token response                2ms
✓  postGitHubDeviceFlowForm — response size bound
   ✓ bounds oversized device code body and cancels the stream                8ms
   ✓ bounds oversized access token body and cancels the stream               9ms

 Test Files  1 passed (1)
      Tests  7 passed (7)
   Duration  1.98s
```

Tests use `setGitHubCopilotDeviceFlowFetchGuardForTesting` (the existing test seam)
to inject real `Response` objects without mocking any modules. Coverage:

| Scenario | Asserts |
|---|---|
| Full happy path | `{ status: "authorized", accessToken }`, `showCode` called with correct args, exactly 2 network calls |
| `access_denied` | `{ status: "access_denied" }` |
| `expired_token` | `{ status: "expired" }` |
| Device code HTTP 401 | throws `"GitHub device code failed: HTTP 401"` |
| Token poll HTTP 500 | throws `"GitHub device token failed: HTTP 500"` |
| Oversized device code body | throws `"github-copilot.device-flow"`, `readCount < 64`, `canceled === true` |
| Oversized access token body | throws `"github-copilot.device-flow"`, `readCount < 64`, `canceled === true` |

### Real-network proof (`node scripts/proof-copilot-login-bound.mjs`)

```
HTTP status: 200
Threw: github-copilot.device-flow: JSON response exceeds 16777216 bytes
Server sent: ~17.0 MiB of 64 MiB total
PASS: stream cancelled after ~17.0 MiB (cap ~16 MiB, not 64 MiB)
```

A local `node:http` server streams 64 MiB. The client read ~17 MiB (cap + TCP
buffer) before cancelling; the remaining ~47 MiB was never transferred.

## Files changed

| File | Change |
|------|--------|
| `extensions/github-copilot/login.ts` | import `readProviderJsonResponse`; replace `await response.json()` |
| `extensions/github-copilot/login.test.ts` | new file — 7 tests covering full device flow, HTTP errors, and both oversized-body paths |
