### PR TITLE
fix(docs): Fix formatting on permissions for Discord bot

### DIFF
--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -63,6 +63,7 @@ You will need to create a new application with a bot, add the bot to your server
 
     **General Permissions**
       - View Channels
+    
     **Text Permissions**
       - Send Messages
       - Read Message History

--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -63,7 +63,7 @@ You will need to create a new application with a bot, add the bot to your server
 
     **General Permissions**
       - View Channels
-    
+
     **Text Permissions**
       - Send Messages
       - Read Message History


### PR DESCRIPTION
Closes #97582 

## What Problem This Solves

Fixes an issue where users follow the documentation for Discord channel and would experience confusion when the "Text Permissions" heading is not on a separate line as the "General Permissions".

## Why This Change Was Made

While I was following the documentation, I got confused at the required permissions step for the Discord bot since the "Text Permissions" header was not its own list.

## User Impact

The documentation is clearly separated.

## Evidence

https://github.com/openclaw/openclaw/issues/97582#issuecomment-4827661064