### PR TITLE
fix(google): bound OAuth project and token JSON response reads

### DIFF
--- a/extensions/google/oauth.project.ts
+++ b/extensions/google/oauth.project.ts
@@ -1,4 +1,5 @@
 // Google plugin module implements oauth.project behavior.
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import { fetchWithTimeout } from "./oauth.http.js";
 import {
   CODE_ASSIST_ENDPOINT_PROD,
@@ -21,7 +22,7 @@ async function getUserEmail(accessToken: string): Promise<string | undefined> {
       headers: { Authorization: `Bearer ${accessToken}` },
     });
     if (response.ok) {
-      const data = (await response.json()) as { email?: string };
+      const data = await readProviderJsonResponse<{ email?: string }>(response, "google.userinfo");
       return data.email;
     }
   } catch {
@@ -74,10 +75,10 @@ async function pollOperation(
     if (!response.ok) {
       continue;
     }
-    const data = (await response.json()) as {
+    const data = await readProviderJsonResponse<{
       done?: boolean;
       response?: { cloudaicompanionProject?: { id?: string } };
-    };
+    }>(response, "google.poll-operation");
     if (data.done) {
       return data;
     }
@@ -135,7 +136,10 @@ async function discoverProject(accessToken: string): Promise<string> {
       });
 
       if (!response.ok) {
-        const errorPayload = await response.json().catch(() => null);
+        const errorPayload = await readProviderJsonResponse(
+          response,
+          "google.load-code-assist",
+        ).catch(() => null);
         if (isVpcScAffected(errorPayload)) {
           data = { currentTier: { id: TIER_STANDARD } };
           activeEndpoint = endpoint;
@@ -146,7 +150,7 @@ async function discoverProject(accessToken: string): Promise<string> {
         continue;
       }
 
-      data = (await response.json()) as typeof data;
+      data = await readProviderJsonResponse<typeof data>(response, "google.load-code-assist");
       activeEndpoint = endpoint;
       loadError = undefined;
       break;
@@ -211,11 +215,11 @@ async function discoverProject(accessToken: string): Promise<string> {
     throw new Error(`onboardUser failed: ${onboardResponse.status} ${onboardResponse.statusText}`);
   }
 
-  let lro = (await onboardResponse.json()) as {
+  let lro = await readProviderJsonResponse<{
     done?: boolean;
     name?: string;
     response?: { cloudaicompanionProject?: { id?: string } };
-  };
+  }>(onboardResponse, "google.onboard-user");
 
   if (!lro.done && lro.name) {
     lro = await pollOperation(activeEndpoint, lro.name, headers);

--- a/extensions/google/oauth.test.ts
+++ b/extensions/google/oauth.test.ts
@@ -649,6 +649,7 @@ describe("loginGeminiCliOAuth", () => {
     platform: "PLATFORM_UNSPECIFIED",
     pluginType: "GEMINI",
   } as const;
+  const OVERSIZED_OAUTH_RESPONSE_BYTES = 17 * 1024 * 1024;
 
   function getRequestUrl(input: string | URL | Request): string {
     if (typeof input === "string") {
@@ -678,6 +679,40 @@ describe("loginGeminiCliOAuth", () => {
       status,
       headers: { "Content-Type": "application/json" },
     });
+  }
+
+  function oversizedJsonStringFieldResponse(params: {
+    prefix: string;
+    suffix: string;
+    targetBytes?: number;
+  }): Response {
+    const encoder = new TextEncoder();
+    const prefix = encoder.encode(params.prefix);
+    const suffix = encoder.encode(params.suffix);
+    const chunk = new Uint8Array(64 * 1024).fill(0x61);
+    const targetBytes = params.targetBytes ?? OVERSIZED_OAUTH_RESPONSE_BYTES;
+    let sentBytes = 0;
+    return new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(prefix);
+          sentBytes += prefix.byteLength;
+        },
+        pull(controller) {
+          if (sentBytes >= targetBytes) {
+            controller.enqueue(suffix);
+            controller.close();
+            return;
+          }
+          controller.enqueue(chunk);
+          sentBytes += chunk.byteLength;
+        },
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
   }
 
   function responseTextBodyWithTextTrap(body: string, status = 500) {
@@ -837,6 +872,7 @@ describe("loginGeminiCliOAuth", () => {
       }
     }
     setOAuthSettingsFsForTest();
+    vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
 
@@ -1116,5 +1152,103 @@ describe("loginGeminiCliOAuth", () => {
 
     expect(Number.isSafeInteger(result.expires)).toBe(true);
     expect(result.expires).toBeLessThanOrEqual(beforeRefresh);
+  });
+
+  it("rejects an oversized token exchange response body", async () => {
+    // End-to-end OAuth path: oversized upstream bodies fail closed before auth
+    // completes. After #97628 the shared fetchWithTimeout cap fires first;
+    // readProviderJsonResponse remains the labeled parse boundary afterward.
+    installGeminiOAuthFetchMock(() => undefined, {
+      tokenResponse: () =>
+        oversizedJsonStringFieldResponse({
+          prefix: '{"access_token":"',
+          suffix: '","refresh_token":"r","expires_in":3600}',
+        }),
+    });
+
+    const { exchangeCodeForTokens } = await import("./oauth.token.js");
+    await expect(exchangeCodeForTokens("oauth-code", "pkce-verifier")).rejects.toThrow(
+      /google HTTP fetch: body exceeds|google\.token.*exceeds|Content too large/,
+    );
+  });
+
+  it("rejects an oversized token body at the JSON parse boundary", async () => {
+    // Defense-in-depth: if fetchWithTimeout already returned a buffered Response,
+    // readProviderJsonResponse still caps JSON.parse on the OAuth token path.
+    vi.resetModules();
+    const oauthHttp = await import("./oauth.http.js");
+    const originalFetchWithTimeout = oauthHttp.fetchWithTimeout;
+    vi.spyOn(oauthHttp, "fetchWithTimeout").mockImplementation(async (url, init, timeoutMs) => {
+      if (url === TOKEN_URL) {
+        return oversizedJsonStringFieldResponse({
+          prefix: '{"access_token":"',
+          suffix: '","refresh_token":"r","expires_in":3600}',
+        });
+      }
+      return originalFetchWithTimeout(url, init, timeoutMs);
+    });
+    installGeminiOAuthFetchMock(() => undefined);
+
+    const { exchangeCodeForTokens } = await import("./oauth.token.js");
+    await expect(exchangeCodeForTokens("oauth-code", "pkce-verifier")).rejects.toThrow(
+      /google\.token.*exceeds|Content too large/,
+    );
+  });
+
+  it("rejects an oversized loadCodeAssist success response body", async () => {
+    // discoverProject loops over all 3 LOAD endpoints; each must return the
+    // oversized body so that bound errors propagate for the whole loop.
+    const oversizedResponse = () =>
+      oversizedJsonStringFieldResponse({
+        prefix: '{"currentTier":{"id":"standard-tier"},"cloudaicompanionProject":{"id":"',
+        suffix: '"}}',
+      });
+    installGeminiOAuthFetchMock(({ url }) => {
+      if (url === LOAD_PROD || url === LOAD_DAILY || url === LOAD_AUTOPUSH) {
+        return oversizedResponse();
+      }
+      return undefined;
+    });
+
+    const { resolveGoogleOAuthIdentity } = await import("./oauth.project.js");
+    await expect(resolveGoogleOAuthIdentity("access-token")).rejects.toThrow(
+      /google HTTP fetch: body exceeds|google\.load-code-assist.*exceeds|Content too large/,
+    );
+  });
+
+  it("swallows bound error on oversized userinfo body and returns undefined email", async () => {
+    // getUserEmail catches all errors; an oversized userinfo body should not
+    // propagate but email must be undefined. After #97628 the fetch cap may
+    // truncate the upstream body before parse, so the swallowed error can be
+    // either a labeled size cap or malformed JSON — either proves the bound fired.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request, _init?: RequestInit) => {
+        const url =
+          typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+        if (url === USERINFO_URL) {
+          return oversizedJsonStringFieldResponse({
+            prefix: '{"email":"',
+            suffix: '"}',
+          });
+        }
+        if (url === LOAD_PROD) {
+          return new Response(
+            JSON.stringify({
+              currentTier: { id: "standard-tier" },
+              cloudaicompanionProject: { id: "proj-bound-test" },
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          );
+        }
+        return new Response(JSON.stringify({ error: "not found" }), { status: 503 });
+      }),
+    );
+
+    const { resolveGoogleOAuthIdentity } = await import("./oauth.project.js");
+    const result = await resolveGoogleOAuthIdentity("access-token");
+    expect(result.projectId).toBe("proj-bound-test");
+    // email is undefined: the bound error was thrown and swallowed by getUserEmail
+    expect(result.email).toBeUndefined();
   });
 });

--- a/extensions/google/oauth.token.ts
+++ b/extensions/google/oauth.token.ts
@@ -3,7 +3,10 @@ import {
   asDateTimestampMs,
   resolveExpiresAtMsFromDurationSeconds,
 } from "openclaw/plugin-sdk/number-runtime";
-import { readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
+import {
+  readProviderJsonResponse,
+  readResponseTextLimited,
+} from "openclaw/plugin-sdk/provider-http";
 import { resolveOAuthClientConfig } from "./oauth.credentials.js";
 import { fetchWithTimeout } from "./oauth.http.js";
 import { resolveGoogleOAuthIdentity, resolveGooglePersonalOAuthIdentity } from "./oauth.project.js";
@@ -36,11 +39,11 @@ async function requestTokenGrant(body: URLSearchParams): Promise<{
     throw new Error(`Token exchange failed: ${errorText}`);
   }
 
-  return (await response.json()) as {
+  return readProviderJsonResponse<{
     access_token?: string;
     refresh_token?: string;
     expires_in?: unknown;
-  };
+  }>(response, "google.token");
 }
 
 function resolveExpiredTokenTimestampMs(nowMs: number): number {


### PR DESCRIPTION
## What Problem This Solves

`extensions/google/oauth.project.ts` and `extensions/google/oauth.token.ts` contained six
unbounded `await response.json()` calls on the Gemini CLI OAuth onboarding and token-exchange
paths (`getUserEmail`, `pollOperation`, `loadCodeAssist` success + error, `onboardUser`,
`requestTokenGrant`).

After `fetchWithTimeout` materialises the response body, `response.json()` can trigger a
second large allocation during `JSON.parse`. Replacing these calls with
`readProviderJsonResponse` caps the JSON parse step at 16 MiB with labeled errors at each
OAuth call site.

This complements the shared fetch boundary landed in **#97628**
(`readResponseWithLimit` inside `fetchWithTimeout`). Together the two layers give defense in
depth:

1. **Fetch boundary (#97628 on main):** bounds upstream stream reads before buffering.
2. **Parse boundary (this PR):** bounds `JSON.parse` on the buffered `Response` objects that
   OAuth call sites consume.

## Changes

* `extensions/google/oauth.project.ts`:
  - imports `readProviderJsonResponse` from `openclaw/plugin-sdk/provider-http`
  - replaces six `response.json()` reads with labeled `readProviderJsonResponse(...)` calls
    (`google.userinfo`, `google.poll-operation`, `google.load-code-assist`,
    `google.onboard-user`)

* `extensions/google/oauth.token.ts`:
  - imports `readProviderJsonResponse` from `openclaw/plugin-sdk/provider-http`
  - replaces `await response.json()` → `readProviderJsonResponse(response, "google.token")`
    in `requestTokenGrant`

* `extensions/google/oauth.test.ts`:
  - adds four regression tests:
    - `rejects an oversized token exchange response body` (end-to-end via
      `exchangeCodeForTokens`; fetch cap fires first after #97628)
    - `rejects an oversized token body at the JSON parse boundary` (defense-in-depth when
      `fetchWithTimeout` already returned a buffered oversized body)
    - `rejects an oversized loadCodeAssist success response body` (via
      `resolveGoogleOAuthIdentity`)
    - `swallows bound error on oversized userinfo body and returns undefined email`

Rebased onto current `main`; the stale plugin SDK surface budget commit was dropped because
#97628 and other main commits already carry those values.

## Real behavior proof

**Behavior addressed:** Oversized or hostile Google OAuth JSON responses fail closed instead
of triggering unbounded `JSON.parse` allocation on buffered bodies returned by
`fetchWithTimeout`.

**Real environment tested:** Node v22, macOS 24.3.0, `node:http` streaming server on
`127.0.0.1`, built helpers from `dist/plugin-sdk/provider-http.js` and
`dist/plugin-sdk/response-limit-runtime.js`.

**Exact steps:**
1. Stream an ~18 MiB OAuth token JSON body from a local HTTP server (no `Content-Length`).
2. Drive `readResponseWithLimit` at the fetch boundary → assert labeled overflow error.
3. Drive `readProviderJsonResponse` on the same streamed body → assert labeled parse cap.
4. Negative control: unbounded `response.body` reader consumes the full ~18 MiB stream.
5. Verify post-`fetchWithTimeout` buffered `Response` shape rejects at parse boundary.
6. Verify normal token / userinfo / loadCodeAssist bodies still parse.
7. Verify VPC-SC error-path `.catch(() => null)` swallows oversized error bodies.
8. Run OAuth module regression tests through `exchangeCodeForTokens` and
   `resolveGoogleOAuthIdentity`.

**Observed result:**
- Fetch boundary: `google HTTP fetch: body exceeds 16777216 bytes (got 16817603)`
- Parse boundary (stream): `google.token: JSON response exceeds 16777216 bytes`
- Negative control: unbounded reader consumed 18 874 405 bytes (~18 MiB)
- Buffered oversized body (16 778 297 bytes) rejected before `JSON.parse`
- Normal token / userinfo / loadCodeAssist responses parse correctly
- VPC-SC error-path `.catch(() => null)` returns `null` on oversized body
- `ALL PROOF ASSERTIONS PASSED`

**What was not tested:** live Google OAuth API calls.

## Evidence

```
=== Google OAuth response bound proof (path-level) ===
Layers: (1) fetchWithTimeout readResponseWithLimit [#97628 on main]
        (2) readProviderJsonResponse on OAuth call sites [#97587]

--- Case 1: oversized streamed token body (fetch boundary) ---
  ok: readResponseWithLimit rejects oversized streamed OAuth body
  ok: fetch-boundary error is labeled (got: google HTTP fetch: body exceeds 16777216 bytes (got 16817603))
  ok: negative control: unbounded reader consumed full ~18 MiB stream (18874405 bytes)

--- Case 2: oversized streamed body rejected at JSON parse boundary ---
  ok: readProviderJsonResponse rejects oversized streamed body
  ok: parse-boundary label present (got: google.token: JSON response exceeds 16777216 bytes)

--- Case 3: oversized buffered OAuth token body (post-fetch shape) ---
  ok: buffered oversized body rejected before JSON.parse
  ok: body size 16778297 bytes exceeds 16777216 cap

--- Case 4: normal OAuth JSON responses still parse ---
  ok: token body parses
  ok: userinfo body parses
  ok: loadCodeAssist body parses

--- Case 5: loadCodeAssist error path .catch(() => null) ---
  ok: oversized VPC-SC probe body returns null via .catch

--- Case 6: OAuth module path-level regression tests ---
  Tests  4 passed | 27 skipped (31)
  ok: vitest OAuth bound regression tests passed

ALL PROOF ASSERTIONS PASSED
```

```
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/google/oauth.test.ts \
  -t "rejects an oversized|swallows bound"
# Tests  4 passed | 27 skipped (31)
```

New bound regression tests (4 added):
- `loginGeminiCliOAuth > rejects an oversized token exchange response body` ✓
- `loginGeminiCliOAuth > rejects an oversized token body at the JSON parse boundary` ✓
- `loginGeminiCliOAuth > rejects an oversized loadCodeAssist success response body` ✓
- `loginGeminiCliOAuth > swallows bound error on oversized userinfo body and returns undefined email` ✓
