### PR TITLE
fix(agents): preserve compactionSummary in limitHistoryTurns (fixes #97590) (AI-assisted)

### DIFF
--- a/src/agents/embedded-agent-runner.limithistoryturns.test.ts
+++ b/src/agents/embedded-agent-runner.limithistoryturns.test.ts
@@ -118,6 +118,50 @@ describe("limitHistoryTurns", () => {
     expect(limited[1].role).toBe("assistant");
   });
 
+  it("preserves leading compactionSummary when limiting", () => {
+    const compactionSummary: AgentMessage = {
+      role: "compactionSummary",
+      summary: "Previous conversation about topic X",
+      tokensBefore: 5000,
+      tokensAfter: 2000,
+      timestamp: Date.now(),
+    } as AgentMessage;
+    const messages = [
+      compactionSummary,
+      ...makeMessages(["user", "assistant", "user", "assistant"]),
+    ];
+    const limited = limitHistoryTurns(messages, 1);
+    // compactionSummary is preserved, last 1 user turn + assistant kept
+    expect(limited.length).toBe(3);
+    expect(limited[0].role).toBe("compactionSummary");
+    expect(firstText(limited[1])).toBe("message 2");
+  });
+
+  it("preserves leading branchSummary when limiting", () => {
+    const branchSummary: AgentMessage = {
+      role: "branchSummary",
+      summary: "Branch context",
+      fromId: "abc",
+      timestamp: Date.now(),
+    } as AgentMessage;
+    const messages = [branchSummary, ...makeMessages(["user", "assistant", "user", "assistant"])];
+    const limited = limitHistoryTurns(messages, 1);
+    expect(limited.length).toBe(3);
+    expect(limited[0].role).toBe("branchSummary");
+  });
+
+  it("returns all when only non-conversation messages exist", () => {
+    const compactionSummary: AgentMessage = {
+      role: "compactionSummary",
+      summary: "Summary only",
+      tokensBefore: 1000,
+      timestamp: Date.now(),
+    } as AgentMessage;
+    const limited = limitHistoryTurns([compactionSummary], 2);
+    expect(limited).toHaveLength(1);
+    expect(limited[0].role).toBe("compactionSummary");
+  });
+
   it("preserves message content integrity", () => {
     // Limiting should slice whole turns, not mutate tool calls or message bodies.
     const messages: AgentMessage[] = [

--- a/src/agents/embedded-agent-runner/history.ts
+++ b/src/agents/embedded-agent-runner/history.ts
@@ -16,6 +16,10 @@ function stripThreadSuffix(value: string): string {
 /**
  * Limits conversation history to the last N user turns (and their associated
  * assistant responses). This reduces token usage for long-running DM sessions.
+ *
+ * Leading non-conversation messages (e.g. compactionSummary, branchSummary)
+ * placed at index 0 by buildSessionContext are always preserved, since they
+ * carry summarized pre-compaction context that history limiting must not drop.
  */
 export function limitHistoryTurns(
   messages: AgentMessage[],
@@ -25,14 +29,28 @@ export function limitHistoryTurns(
     return messages;
   }
 
-  let userCount = 0;
-  let lastUserIndex = messages.length;
+  // Preserve leading non-conversation messages (compactionSummary, branchSummary, etc.)
+  // that buildSessionContext places at index 0 to carry pre-compaction context.
+  let conversationStart = 0;
+  while (conversationStart < messages.length) {
+    const role = messages[conversationStart].role;
+    if (role === "user" || role === "assistant") break;
+    conversationStart++;
+  }
 
-  for (let i = messages.length - 1; i >= 0; i--) {
-    if (messages[i].role === "user") {
+  const tail = messages.slice(conversationStart);
+  if (tail.length === 0) {
+    return messages;
+  }
+
+  let userCount = 0;
+  let lastUserIndex = tail.length;
+
+  for (let i = tail.length - 1; i >= 0; i--) {
+    if (tail[i].role === "user") {
       userCount++;
       if (userCount > limit) {
-        return messages.slice(lastUserIndex);
+        return [...messages.slice(0, conversationStart), ...tail.slice(lastUserIndex)];
       }
       lastUserIndex = i;
     }

--- a/src/agents/embedded-agent-runner/history.ts
+++ b/src/agents/embedded-agent-runner/history.ts
@@ -34,7 +34,9 @@ export function limitHistoryTurns(
   let conversationStart = 0;
   while (conversationStart < messages.length) {
     const role = messages[conversationStart].role;
-    if (role === "user" || role === "assistant") break;
+    if (role === "user" || role === "assistant") {
+      break;
+    }
     conversationStart++;
   }
 


### PR DESCRIPTION
## What Problem This Solves

When a session has a configured `historyLimit` (or `dmHistoryLimit`) and has auto-compacted, `limitHistoryTurns` silently drops the leading `compactionSummary` message from the model context. The assistant loses all pre-compaction conversation context on every subsequent turn, even though compaction explicitly preserved a summary for that purpose.

## Why This Change Was Made

`limitHistoryTurns` counts `role === "user"` messages from the end and slices to the last N turns. When the retained tail exceeds the limit, the slice starts at a user message index > 0, discarding everything before it — including the `compactionSummary` at index 0 that `buildSessionContext` places there.

The fix: skip leading non-conversation messages (roles other than `"user"` / `"assistant"`, such as `compactionSummary` and `branchSummary`) before counting user turns, then prepend them back to the result.

## User Impact

Users with `historyLimit` or `dmHistoryLimit` configured will no longer lose summarized pre-compaction context. The assistant retains conversation continuity across compaction boundaries.

## Changes Made

- `src/agents/embedded-agent-runner/history.ts`: `limitHistoryTurns` now preserves leading non-conversation messages (compactionSummary, branchSummary, etc.) when slicing by user turn count.
- `src/agents/embedded-agent-runner.limithistoryturns.test.ts`: Added 3 test cases covering compactionSummary preservation, branchSummary preservation, and non-conversation-only message arrays.

- [x] AI-assisted (Hermes Agent)

## Evidence

- **Behavior addressed:** `limitHistoryTurns` drops the leading `compactionSummary` from model context when the session has a configured history limit and more user turns than the limit after compaction.
- **Environment tested:** macOS, Node v22.22.3, OpenClaw 2026.5.28, commit 19cac35a (upstream/main).
- **Steps run after the patch:** Invoked the production `limitHistoryTurns` function with a realistic post-compaction message array (compactionSummary + 3 user/assistant turn pairs) using `limit=2`.
- **Evidence after fix:**

```
$ npx tsx -e 'import { limitHistoryTurns } from "./src/agents/embedded-agent-runner/history.ts"; ...'
Input: 7 messages, roles: ['compactionSummary','user','assistant','user','assistant','user','assistant']
After limit=2: 5 messages, roles: ['compactionSummary','user','assistant','user','assistant']
compactionSummary preserved: YES
User turns kept: 2
```

- **Observed result after fix:** The `compactionSummary` is preserved at index 0, the last 2 user turns and their assistant responses are retained, total 5 messages (was 4 before fix — summary was dropped).
- **What was not tested:** End-to-end session with real LLM provider (function is internal to embedded agent runner, not directly observable via CLI). The fix is verified through production function invocation and 12 unit tests (9 existing + 3 new) all passing.

## Real behavior proof

- **Behavior addressed:** `limitHistoryTurns` drops the leading `compactionSummary` from model context when the session has a configured history limit and more user turns than the limit after compaction.
- **Environment tested:** macOS, Node v22.22.3, OpenClaw 2026.5.28, commit 19cac35a (upstream/main).
- **Steps run after the patch:** Invoked the production `limitHistoryTurns` function with a realistic post-compaction message array (compactionSummary + 3 user/assistant turn pairs) using `limit=2`.
- **Evidence after fix:**

```
$ npx tsx -e 'import { limitHistoryTurns } from "./src/agents/embedded-agent-runner/history.ts"; ...'
Input: 7 messages, roles: ['compactionSummary','user','assistant','user','assistant','user','assistant']
After limit=2: 5 messages, roles: ['compactionSummary','user','assistant','user','assistant']
compactionSummary preserved: YES
User turns kept: 2
```

- **Observed result after fix:** The `compactionSummary` is preserved at index 0, the last 2 user turns and their assistant responses are retained, total 5 messages (was 4 before fix — summary was dropped).
- **What was not tested:** End-to-end session with real LLM provider (function is internal to embedded agent runner, not directly observable via CLI). The fix is verified through production function invocation and 12 unit tests (9 existing + 3 new) all passing.
