### PR TITLE
fix(codex): cap native-subagent completion delivery retries (fixes #97593) (AI-assisted)

### DIFF
--- a/extensions/codex/src/app-server/native-subagent-monitor.test.ts
+++ b/extensions/codex/src/app-server/native-subagent-monitor.test.ts
@@ -793,6 +793,64 @@ describe("CodexNativeSubagentMonitor", () => {
     );
   });
 
+  it("abandons completion delivery after max retry attempts", async () => {
+    vi.useFakeTimers();
+    const client = createClient();
+    const runtime = createRuntime();
+    // Permanently non-durable delivery
+    runtime.deliverAgentHarnessTaskCompletion.mockResolvedValue({
+      delivered: false,
+      path: "none",
+      error: "parent response silent",
+    });
+    const maxAttempts = 3;
+    const monitor = new CodexNativeSubagentMonitor(client, runtime, {
+      completionDeliveryRetryDelaysMs: [100, 200, 300],
+      completionDeliveryMaxAttempts: maxAttempts,
+    });
+    monitor.registerParent({
+      parentThreadId: "parent-thread",
+      requesterSessionKey: "agent:main:discord:channel:C123",
+      taskRuntimeScope: createTaskScope(),
+      agentId: "main",
+    });
+
+    const completion = nativeCompletionNotification({
+      agentPath: "child-thread",
+      statusLabel: "completed",
+      result: "child final result",
+    });
+
+    await notifyChildStarted(client);
+    await client.notify(completion);
+
+    // First delivery attempt happens immediately
+    expect(runtime.deliverAgentHarnessTaskCompletion).toHaveBeenCalledTimes(1);
+
+    // Advance through all retry delays
+    for (let i = 0; i < maxAttempts + 2; i++) {
+      await vi.advanceTimersByTimeAsync(500);
+    }
+
+    // Should have attempted exactly maxAttempts times (1 initial + maxAttempts-1 retries)
+    expect(runtime.deliverAgentHarnessTaskCompletion).toHaveBeenCalledTimes(maxAttempts);
+
+    // Should have marked delivery as failed
+    expect(runtime.setDetachedTaskDeliveryStatusByRunId).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: "codex-thread:child-thread",
+        deliveryStatus: "failed",
+        error: expect.stringContaining("abandoned after"),
+      }),
+    );
+
+    // No more retries after give-up
+    await vi.advanceTimersByTimeAsync(1_000_000);
+    expect(runtime.deliverAgentHarnessTaskCompletion).toHaveBeenCalledTimes(maxAttempts);
+
+    vi.useRealTimers();
+  });
+
   it("reconciles transcript final text before delivering empty Codex completion notifications", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-subagent-"));
     const codexHome = path.join(tempDir, "codex-home");

--- a/extensions/codex/src/app-server/native-subagent-monitor.ts
+++ b/extensions/codex/src/app-server/native-subagent-monitor.ts
@@ -80,6 +80,7 @@ type MonitorOptions = {
   codexHome?: string;
   transcriptPollDelaysMs?: readonly number[];
   completionDeliveryRetryDelaysMs?: readonly number[];
+  completionDeliveryMaxAttempts?: number;
   taskRowReconcileIntervalMs?: number;
 };
 
@@ -89,6 +90,7 @@ const DEFAULT_TRANSCRIPT_POLL_DELAYS_MS = [
 const DEFAULT_COMPLETION_DELIVERY_RETRY_DELAYS_MS = [
   5_000, 15_000, 30_000, 60_000, 120_000, 300_000,
 ];
+const DEFAULT_MAX_COMPLETION_DELIVERY_ATTEMPTS = DEFAULT_COMPLETION_DELIVERY_RETRY_DELAYS_MS.length;
 const DEFAULT_TASK_ROW_RECONCILE_INTERVAL_MS = 10_000;
 const RECENT_TERMINAL_TASK_RECONCILE_GRACE_MS = 60_000;
 // Codex's recorder uses this filename contract; non-canonical names keep the
@@ -140,6 +142,7 @@ export class CodexNativeSubagentMonitor {
   private codexHome?: string;
   private transcriptPollDelaysMs: readonly number[];
   private completionDeliveryRetryDelaysMs: readonly number[];
+  private maxCompletionDeliveryAttempts: number;
   private taskRowReconcileTimer?: ReturnType<typeof setInterval>;
 
   constructor(
@@ -152,6 +155,8 @@ export class CodexNativeSubagentMonitor {
       options.transcriptPollDelaysMs ?? DEFAULT_TRANSCRIPT_POLL_DELAYS_MS;
     this.completionDeliveryRetryDelaysMs =
       options.completionDeliveryRetryDelaysMs ?? DEFAULT_COMPLETION_DELIVERY_RETRY_DELAYS_MS;
+    this.maxCompletionDeliveryAttempts =
+      options.completionDeliveryMaxAttempts ?? DEFAULT_MAX_COMPLETION_DELIVERY_ATTEMPTS;
     this.startTaskRowReconciler(
       options.taskRowReconcileIntervalMs ?? DEFAULT_TASK_ROW_RECONCILE_INTERVAL_MS,
     );
@@ -614,8 +619,39 @@ export class CodexNativeSubagentMonitor {
     });
   }
 
+  private markCompletionDeliveryFailed(
+    completion: CodexNativeSubagentCompletion,
+    error: string,
+  ): void {
+    const taskRuntime = this.getTaskRuntimeForChild(completion.childThreadId);
+    if (!taskRuntime) {
+      return;
+    }
+    taskRuntime.setDetachedTaskDeliveryStatusByRunId({
+      runId: codexNativeSubagentRunId(completion.childThreadId),
+      deliveryStatus: "failed",
+      error,
+    });
+  }
+
   private scheduleCompletionDeliveryRetry(childState: ChildState): void {
     if (!childState.pendingCompletion || childState.completionDeliveryTimer) {
+      return;
+    }
+    if (childState.completionDeliveryAttempt >= this.maxCompletionDeliveryAttempts - 1) {
+      const completion = childState.pendingCompletion;
+      childState.pendingCompletion = undefined;
+      childState.pendingCompletionEventAt = undefined;
+      childState.completionDeliveryAttempt = 0;
+      this.markCompletionDeliveryFailed(
+        completion,
+        `completion delivery abandoned after ${this.maxCompletionDeliveryAttempts} attempts`,
+      );
+      embeddedAgentLog.warn("Codex native subagent completion delivery abandoned", {
+        parentThreadId: childState.parentThreadId,
+        childThreadId: completion.childThreadId,
+        attempts: this.maxCompletionDeliveryAttempts,
+      });
       return;
     }
     const attempt = childState.completionDeliveryAttempt;


### PR DESCRIPTION
## What Problem This Solves

When a Codex native subagent (`spawn_agent`) completes, the `CodexNativeSubagentMonitor` delivers the completion to the parent agent via `runtime.deliverAgentHarnessTaskCompletion`. If that delivery is permanently non-durable (e.g. the parent's reply is silent for a subagent completion, or the external channel is down), the monitor reschedules the delivery with no maximum attempt count and no overall deadline. It re-fires forever — each retry re-invokes `deliverAgentHarnessTaskCompletion`, which wakes and re-runs the parent agent every 5 minutes indefinitely.

## Why This Change Was Made

The `scheduleCompletionDeliveryRetry` method clamps the delay using `Math.min(attempt, delays.length - 1)` but never compares the attempt count to a maximum. The `completionDeliveryAttempt` counter is incremented and used solely as a delay index, never as a termination condition.

The equivalent completion-delivery loop on the OpenClaw `sessions_spawn` announce path is bounded (#88523 added a retry cap, #90178 / #95080 added give-up / expiry). The Codex native-subagent monitor is a separate implementation (introduced via #83445) that lacked the same guard.

This change adds:
- `DEFAULT_MAX_COMPLETION_DELIVERY_ATTEMPTS` constant (6, matching the retry delay array length)
- `completionDeliveryMaxAttempts` option in `MonitorOptions` for test/custom configuration
- A max-attempts guard in `scheduleCompletionDeliveryRetry` that marks delivery as `"failed"` and clears pending state when the limit is reached

## User Impact

Users running Codex native multi-agent sessions will no longer see unbounded parent agent re-runs when a subagent completion delivery is permanently non-durable. The delivery is marked as failed after 6 attempts (~10.5 minutes total) instead of retrying forever.

## Evidence

- **Behavior addressed:** Codex native-subagent completion delivery retries with no attempt cap, re-running the parent agent forever on permanently non-durable delivery.
- **Environment tested:** `extensions/codex/src/app-server/native-subagent-monitor.ts` at commit `4c8470c0` (upstream/main), test suite via `node scripts/run-vitest.mjs run extensions/codex/src/app-server/native-subagent-monitor.test.ts`.
- **Steps run after the patch:** Ran the full native-subagent-monitor test suite (34 tests) including the new "abandons completion delivery after max retry attempts" test.
- **Evidence after fix:**
```
 ✓  extension-codex  extensions/codex/src/app-server/native-subagent-monitor.test.ts (34 tests) 85ms

 Test Files  1 passed (1)
      Tests  34 passed (34)
   Start at  08:23:00
   Duration  2.29s
```
- **Observed result after fix:** The new test verifies that with `completionDeliveryMaxAttempts: 3` and a permanently non-durable delivery mock, the monitor attempts exactly 3 times (1 initial + 2 retries), marks the delivery as `"failed"` with an "abandoned after" error, and makes no further retry attempts even after advancing time by 1,000,000ms.
- **What was not tested:** The live external-channel send-failure path against a real provider/channel was not exercised; the non-durable delivery was injected at the runtime seam rather than by knocking down a real channel. The default 6-attempt limit was verified via the constant definition rather than a real-time 10.5-minute test.

## Real behavior proof

- **Behavior addressed:** `scheduleCompletionDeliveryRetry` never bounds the attempt count, causing permanently non-durable deliveries to retry every 5 minutes forever.
- **Environment tested:** Real `CodexNativeSubagentMonitor` class from `extensions/codex/src/app-server/native-subagent-monitor.ts`, driven end-to-end with the production runtime seam (`deliverAgentHarnessTaskCompletion`) returning a permanently non-durable result (`delivered: false`).
- **Steps run after the patch:** Constructed monitor with `completionDeliveryMaxAttempts: 3`, registered parent, delivered a terminal native subagent completion, advanced fake timers across 1,000,500ms, and counted invocations and final delivery status.
- **Evidence after fix:**
```
✓ extension-codex  extensions/codex/src/app-server/native-subagent-monitor.test.ts (34 tests) 85ms
Test Files  1 passed (1) | Tests  34 passed (34)
```
- **Observed result after fix:** Delivery attempted exactly 3 times, then marked `"failed"` with error `"completion delivery abandoned after 3 attempts"`. No further retries after give-up.
- **What was not tested:** Live channel/provider failure paths. The fix was validated via the test suite with the runtime delivery seam stubbed.

- [x] AI-assisted (Hermes Agent)
