### PR TITLE
fix(matrix): truncate thread starter body on UTF-16 boundary

### DIFF
--- a/extensions/matrix/src/matrix/monitor/thread-context.ts
+++ b/extensions/matrix/src/matrix/monitor/thread-context.ts
@@ -1,4 +1,5 @@
 // Matrix plugin module implements thread context behavior.
+import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { MatrixClient } from "../sdk.js";
 import { summarizeMatrixMessageContextEvent, trimMatrixMaybeString } from "./context-summary.js";
 import type { MatrixRawEvent } from "./types.js";
@@ -17,7 +18,7 @@ function truncateThreadStarterBody(value: string): string {
   if (value.length <= MAX_THREAD_STARTER_BODY_LENGTH) {
     return value;
   }
-  return `${value.slice(0, MAX_THREAD_STARTER_BODY_LENGTH - 3)}...`;
+  return `${sliceUtf16Safe(value, 0, MAX_THREAD_STARTER_BODY_LENGTH - 3)}...`;
 }
 
 export function summarizeMatrixThreadStarterEvent(event: MatrixRawEvent): string | undefined {


### PR DESCRIPTION
**Summary:** The Matrix thread-context tracker truncated thread starter bodies with raw `.slice()`, so an emoji at the 500-character body limit was torn into a lone high surrogate before the trailing ellipsis — malformed text in the Matrix room context sent to the agent.

## What Problem This Solves

`truncateThreadStarterBody` in `extensions/matrix/src/matrix/monitor/thread-context.ts` caps the stored thread starter body at `MAX_THREAD_STARTER_BODY_LENGTH` (500 code units). The old `value.slice(0, MAX_THREAD_STARTER_BODY_LENGTH - 3)` cut on raw UTF-16 indices. A Matrix message whose emoji landed at positions 497–499 was split mid-surrogate-pair, emitting a lone high surrogate in the context that is later sent to the agent.

## Fix

Replace the raw `.slice()` with `sliceUtf16Safe(value, 0, MAX_THREAD_STARTER_BODY_LENGTH - 3)` from `openclaw/plugin-sdk/text-utility-runtime`. The helper steps back over a trailing high surrogate so the body always ends on a code-point boundary. The 500-unit cap and the `...` suffix are unchanged.

## Evidence

Real `truncateThreadStarterBody` (via `summarizeMatrixThreadStarterEvent`) invoked on the PR branch:

```text
input: "x".repeat(497) + "😀" + "rest"  (emoji straddles limit)

BEFORE .slice(0, 497):
  tail units: 0078 0078 d83d  ← lone ? high surrogate
  lone-surrogate: true

AFTER sliceUtf16Safe(value, 0, 497):
  result: "xxx...xxx..."  (497 × x then "...", emoji dropped whole)
  lone-surrogate: false
```

## Tests

`extensions/matrix/src/matrix/monitor/thread-context.test.ts` covers `summarizeMatrixThreadStarterEvent`; the lone-surrogate assertion is red before the fix and green after.