### PR TITLE
fix(tlon): truncate approval message preview on UTF-16 boundary

### DIFF
--- a/extensions/tlon/src/monitor/approval.test.ts
+++ b/extensions/tlon/src/monitor/approval.test.ts
@@ -10,9 +10,12 @@ vi.mock("node:crypto", () => ({
 }));
 
 let generateApprovalId: typeof import("./approval.js").generateApprovalId;
+let createPendingApproval: typeof import("./approval.js").createPendingApproval;
+let formatApprovalRequest: typeof import("./approval.js").formatApprovalRequest;
 
 beforeAll(async () => {
-  ({ generateApprovalId } = await import("./approval.js"));
+  ({ generateApprovalId, createPendingApproval, formatApprovalRequest } =
+    await import("./approval.js"));
 });
 
 beforeEach(() => {
@@ -27,6 +30,64 @@ describe("generateApprovalId", () => {
     try {
       expect(generateApprovalId("dm")).toBe("dm-1717171717171-a1b2c3");
       expect(cryptoMocks.randomBytes).toHaveBeenCalledWith(3);
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+});
+
+describe("approval preview UTF-16 boundary safety", () => {
+  const LONE_SURROGATE = /[\uD800-\uDFFF]/;
+
+  // Emoji 😀 = U+1F600, two UTF-16 code units: 😀.
+  // Place it so the high surrogate lands exactly at the 100-unit cap.
+  // "a".repeat(99) = 99 units, then \uD83D at index 99 → cap splits the pair.
+  const textWithEmojiAtBoundary = "a".repeat(99) + "😀" + "tail";
+
+  it("DM path: messagePreview stored in PendingApproval is free of lone surrogates", () => {
+    cryptoMocks.randomBytes.mockReturnValue(Buffer.from("aabbcc", "hex"));
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_000_000_000_000);
+    try {
+      const approval = createPendingApproval({
+        type: "dm",
+        requestingShip: "~sampel-palnet",
+        messagePreview: textWithEmojiAtBoundary,
+      });
+      expect(LONE_SURROGATE.test(approval.messagePreview ?? "")).toBe(false);
+      expect(approval.messagePreview).not.toContain("\uD83D");
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it("channel path: messagePreview stored in PendingApproval is free of lone surrogates", () => {
+    cryptoMocks.randomBytes.mockReturnValue(Buffer.from("aabbcc", "hex"));
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_000_000_000_000);
+    try {
+      const approval = createPendingApproval({
+        type: "channel",
+        requestingShip: "~sampel-palnet",
+        channelNest: "chat/~sampel/test",
+        messagePreview: textWithEmojiAtBoundary,
+      });
+      expect(LONE_SURROGATE.test(approval.messagePreview ?? "")).toBe(false);
+      expect(approval.messagePreview).not.toContain("\uD83D");
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it("formatApprovalRequest renders well-formed UTF-16 in the owner notification", () => {
+    cryptoMocks.randomBytes.mockReturnValue(Buffer.from("aabbcc", "hex"));
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_000_000_000_000);
+    try {
+      const approval = createPendingApproval({
+        type: "dm",
+        requestingShip: "~sampel-palnet",
+        messagePreview: textWithEmojiAtBoundary,
+      });
+      const rendered = formatApprovalRequest(approval);
+      expect(LONE_SURROGATE.test(rendered)).toBe(false);
     } finally {
       nowSpy.mockRestore();
     }

--- a/extensions/tlon/src/monitor/approval.test.ts
+++ b/extensions/tlon/src/monitor/approval.test.ts
@@ -39,10 +39,10 @@ describe("generateApprovalId", () => {
 describe("approval preview UTF-16 boundary safety", () => {
   const LONE_SURROGATE = /[\uD800-\uDFFF]/;
 
-  // Emoji 😀 = U+1F600, two UTF-16 code units: 😀.
+  // U+1F600 is two UTF-16 code units.
   // Place it so the high surrogate lands exactly at the 100-unit cap.
-  // "a".repeat(99) = 99 units, then \uD83D at index 99 → cap splits the pair.
-  const textWithEmojiAtBoundary = "a".repeat(99) + "😀" + "tail";
+  // "a".repeat(99) = 99 units, then \uD83D at index 99 splits the pair.
+  const textWithEmojiAtBoundary = "a".repeat(99) + "\uD83D\uDE00" + "tail";
 
   it("DM path: messagePreview stored in PendingApproval is free of lone surrogates", () => {
     cryptoMocks.randomBytes.mockReturnValue(Buffer.from("aabbcc", "hex"));

--- a/extensions/tlon/src/monitor/approval.test.ts
+++ b/extensions/tlon/src/monitor/approval.test.ts
@@ -42,7 +42,7 @@ describe("approval preview UTF-16 boundary safety", () => {
   // U+1F600 is two UTF-16 code units.
   // Place it so the high surrogate lands exactly at the 100-unit cap.
   // "a".repeat(99) = 99 units, then \uD83D at index 99 splits the pair.
-  const textWithEmojiAtBoundary = "a".repeat(99) + "\uD83D\uDE00" + "tail";
+  const textWithEmojiAtBoundary = "a".repeat(99) + "\uD83D\uDE00tail";
 
   it("DM path: messagePreview stored in PendingApproval is free of lone surrogates", () => {
     cryptoMocks.randomBytes.mockReturnValue(Buffer.from("aabbcc", "hex"));

--- a/extensions/tlon/src/monitor/approval.ts
+++ b/extensions/tlon/src/monitor/approval.ts
@@ -8,6 +8,7 @@
 // Extensions cannot import core internals directly, so use node:crypto here.
 import { randomBytes } from "node:crypto";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { PendingApproval } from "../settings.js";
 
 export type { PendingApproval };
@@ -62,7 +63,7 @@ function truncate(text: string, maxLength: number): string {
   if (text.length <= maxLength) {
     return text;
   }
-  return text.slice(0, maxLength - 3) + "...";
+  return sliceUtf16Safe(text, 0, maxLength - 3) + "...";
 }
 
 /**

--- a/extensions/tlon/src/monitor/approval.ts
+++ b/extensions/tlon/src/monitor/approval.ts
@@ -50,7 +50,8 @@ export function createPendingApproval(params: CreateApprovalParams): PendingAppr
     requestingShip: params.requestingShip,
     channelNest: params.channelNest,
     groupFlag: params.groupFlag,
-    messagePreview: params.messagePreview,
+    messagePreview:
+      params.messagePreview != null ? sliceUtf16Safe(params.messagePreview, 0, 100) : undefined,
     originalMessage: params.originalMessage,
     timestamp: Date.now(),
   };

--- a/extensions/tlon/src/monitor/index.ts
+++ b/extensions/tlon/src/monitor/index.ts
@@ -2,6 +2,7 @@
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime";
 import { asFiniteNumber } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { OpenClawConfig } from "../../runtime-api.js";
 import { createLoggerBackedRuntime } from "../../runtime-api.js";
 import { getTlonRuntime } from "../runtime.js";
@@ -852,7 +853,7 @@ export async function monitorTlonProvider(opts: MonitorTlonOpts = {}): Promise<v
                     type: "channel",
                     requestingShip: senderShip,
                     channelNest: nest,
-                    messagePreview: rawText.slice(0, 100),
+                    messagePreview: sliceUtf16Safe(rawText, 0, 100),
                     originalMessage: {
                       messageId: messageId ?? "",
                       messageText: rawText,
@@ -1056,7 +1057,7 @@ export async function monitorTlonProvider(opts: MonitorTlonOpts = {}): Promise<v
               const approval = createPendingApproval({
                 type: "dm",
                 requestingShip: senderShip,
-                messagePreview: messageText.slice(0, 100),
+                messagePreview: sliceUtf16Safe(messageText, 0, 100),
                 originalMessage: {
                   messageId: messageId ?? "",
                   messageText,


### PR DESCRIPTION
**Summary:** Three UTF-16 truncation sites in the Tlon approval flow were slicing emoji at a surrogate-pair boundary. The root-cause sites are in `monitor/index.ts` where `PendingApproval.messagePreview` is stored; a third defensive guard was added in `createPendingApproval()` itself.

## What Problem This Solves

When a Tlon ship sends a DM or channel mention whose text places an emoji exactly at the 100-code-unit preview cap, the old `rawText.slice(0, 100)` / `messageText.slice(0, 100)` cuts landed mid-surrogate-pair. The stored `messagePreview` contained a lone `\uD83D` high surrogate — malformed UTF-16 that the owner's notification formatter then embedded verbatim in the approval request DM.

Three sites required fixing:

1. **`monitor/index.ts` L855** (channel mention path): `messagePreview: rawText.slice(0, 100)` → `sliceUtf16Safe(rawText, 0, 100)`
2. **`monitor/index.ts` L1059** (DM path): `messagePreview: messageText.slice(0, 100)` → `sliceUtf16Safe(messageText, 0, 100)`
3. **`monitor/approval.ts` `createPendingApproval()`**: added `sliceUtf16Safe` guard in the constructor so any future caller that passes an untruncated preview is automatically safe
4. **`monitor/approval.ts` `truncate()`**: `text.slice(0, maxLength - 3)` → `sliceUtf16Safe(text, 0, maxLength - 3)` (display-layer defense)

## Evidence

Real `createPendingApproval` + `formatApprovalRequest` functions driven via `node --import tsx` on the PR branch:

```text
input length: 105 code units
unit at 99: U+D83D (high surrogate of 😀)

BEFORE .slice(0,100):
  lone-surrogate=true  tail=[0061 d83d]   ← broken

AFTER DM createPendingApproval:
  preview length: 99  lone-surrogate: false
  tail: [0061 0061]   ← clean, emoji dropped whole
  rendered lone-surrogate: false

AFTER channel createPendingApproval:
  preview length: 99  lone-surrogate: false

✅ All paths produce well-formed UTF-16.
```

## Tests

Three regression tests added to `extensions/tlon/src/monitor/approval.test.ts`, driving the full production chain (`createPendingApproval → messagePreview → formatApprovalRequest`) with an emoji placed exactly at the 100-unit boundary:

- **DM path**: lone-surrogate detector is red before the fix, green after
- **channel path**: same
- **rendered notification**: `formatApprovalRequest` output contains no lone surrogates