### PR TITLE
test: refresh plugin SDK surface budgets

### DIFF
--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -131,7 +131,7 @@ const defaultPublicDeprecatedExportsByEntrypointBudget = Object.freeze({
   "ssrf-policy": 1,
   "ssrf-runtime": 1,
   "media-runtime": 2,
-  "text-runtime": 189,
+  "text-runtime": 191,
   "agent-runtime": 7,
   "plugin-runtime": 13,
   "channel-secret-runtime": 23,
@@ -202,11 +202,11 @@ let publicDeprecatedExportsByEntrypointBudget;
 try {
   budgets = {
     publicEntrypoints: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_ENTRYPOINTS", 322),
-    publicExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS", 10396),
-    publicFunctionExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_FUNCTION_EXPORTS", 5218),
+    publicExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS", 10398),
+    publicFunctionExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_FUNCTION_EXPORTS", 5219),
     publicDeprecatedExports: readBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_DEPRECATED_EXPORTS",
-      3253,
+      3255,
     ),
     publicWildcardReexports: readBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_WILDCARD_REEXPORTS",


### PR DESCRIPTION
## What Problem This Solves

Current `main` CI fails in `test/scripts/plugin-sdk-surface-report.test.ts` because the plugin SDK public surface budget constants no longer match the current source counts.

## Why This Change Was Made

Refreshes only the pinned public/deprecated SDK surface budgets reported by `scripts/plugin-sdk-surface-report.mjs --check`.

## User Impact

No runtime behavior change. This restores the CI guard to the current intended baseline so future SDK surface growth still fails explicitly.

## Evidence

- `node scripts/plugin-sdk-surface-report.mjs --check`
- `node scripts/run-vitest.mjs run test/scripts/plugin-sdk-surface-report.test.ts --reporter=verbose`
- `git diff --check`
