### PR TITLE
test: update plugin SDK surface budget

### DIFF
--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -131,7 +131,7 @@ const defaultPublicDeprecatedExportsByEntrypointBudget = Object.freeze({
   "ssrf-policy": 1,
   "ssrf-runtime": 1,
   "media-runtime": 2,
-  "text-runtime": 189,
+  "text-runtime": 191,
   "agent-runtime": 7,
   "plugin-runtime": 13,
   "channel-secret-runtime": 23,
@@ -202,11 +202,11 @@ let publicDeprecatedExportsByEntrypointBudget;
 try {
   budgets = {
     publicEntrypoints: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_ENTRYPOINTS", 322),
-    publicExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS", 10396),
-    publicFunctionExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_FUNCTION_EXPORTS", 5218),
+    publicExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS", 10398),
+    publicFunctionExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_FUNCTION_EXPORTS", 5219),
     publicDeprecatedExports: readBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_DEPRECATED_EXPORTS",
-      3253,
+      3255,
     ),
     publicWildcardReexports: readBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_WILDCARD_REEXPORTS",


### PR DESCRIPTION
## What Problem This Solves

Current `main` fails the plugin SDK surface budget check because the pinned budgets lag the generated SDK surface counts.

## Why This Change Was Made

Refreshes the pinned public export, callable export, deprecated export, and `text-runtime` deprecated export budgets to match the current source surface.

## User Impact

Unblocks PR validation that is failing on the stale budget gate rather than on PR-specific behavior.

## Evidence

- `node scripts/plugin-sdk-surface-report.mjs --check`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.tooling.config.ts test/scripts/plugin-sdk-surface-report.test.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.scripts.json scripts/plugin-sdk-surface-report.mjs`
- `git diff --check`
- `node scripts/check-changed.mjs -- scripts/plugin-sdk-surface-report.mjs` could not complete locally because pnpm aborted dependency-status install/purge in this linked worktree before Testbox dispatch.
