### PR TITLE
fix(control-ui): resolve Personal card avatar 401 via data URI

### DIFF
--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -153,6 +153,7 @@ import {
   migrateAndPruneGatewaySessionStoreKey,
   resolveGatewaySessionStoreTarget,
   resolveGatewayModelSupportsImages,
+  resolveIdentityAvatarUrl,
   resolveSessionStoreKey,
   resolveSessionModelRef,
 } from "../session-utils.js";
@@ -2847,7 +2848,11 @@ export const agentHandlers: GatewayRequestHandlers = {
     }
     const cfg = context.getRuntimeConfig();
     const identity = resolveAssistantIdentity({ cfg, agentId });
+    // Try resolving workspace-relative avatars to data URIs (consistent with agents.list).
+    // Falls back to the gateway-served /avatar/<agentId> route for other avatar types.
+    const dataUriAvatar = resolveIdentityAvatarUrl(cfg, agentId, identity.avatar);
     const avatarValue =
+      dataUriAvatar ??
       resolveAssistantAvatarUrl({
         avatar: identity.avatar,
         agentId: identity.agentId,

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -164,7 +164,7 @@ function tryResolveExistingPath(value: string): string | null {
   }
 }
 
-function resolveIdentityAvatarUrl(
+export function resolveIdentityAvatarUrl(
   cfg: OpenClawConfig,
   agentId: string,
   avatar: string | undefined,

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1442,10 +1442,8 @@ export function renderApp(state: AppViewState) {
       : state.assistantAvatar);
   const configAssistantAvatarUrl =
     localAssistantAvatarOverride ??
-    (configAssistantAvatarStatus === "local" && state.assistantAgentId
-      ? buildAssistantAvatarRoute(state.basePath, state.assistantAgentId)
-      : (state.chatAvatarUrl ??
-        (configAssistantAvatarMissing ? null : (assistantAvatarUrl ?? null))));
+    (state.chatAvatarUrl ??
+      (configAssistantAvatarMissing ? null : (assistantAvatarUrl ?? null)));
   const configValue =
     state.configForm ?? (state.configSnapshot?.config as Record<string, unknown> | null);
   const configuredDreaming = resolveConfiguredDreaming(configValue);


### PR DESCRIPTION
## Problem

Fixes #97602

The Personal card in Control UI shows a broken avatar image (401) because `agent.identity.get` returns `/avatar/<agentId>` — a path requiring Bearer auth — while `agents.list` correctly resolves workspace-relative avatars to base64 data URIs. Since `<img>` tags cannot carry Authorization headers, the Personal card always fails.

## Root Cause

Two RPC handlers resolve agent avatars differently:

| RPC | Avatar resolution | Result |
|-----|-------------------|--------|
| `agents.list` | `resolveIdentityAvatarUrl()` reads file → base64 data URI | ✅ Works |
| `agent.identity.get` | `resolveAssistantAvatarUrl()` → `/avatar/<agentId>` path | ❌ 401 |

Additionally, the frontend (`app-render.ts`) explicitly constructs `/avatar/<agentId>` via `buildAssistantAvatarRoute()` when `avatarStatus === "local"`, bypassing any data URI the backend might return.

## Changes

### 1. `src/gateway/session-utils.ts`
- Export `resolveIdentityAvatarUrl` (was private)

### 2. `src/gateway/server-methods/agent.ts`
- Import `resolveIdentityAvatarUrl`
- In `agent.identity.get` handler, try `resolveIdentityAvatarUrl()` first (returns data URI for workspace-relative paths), falling back to `resolveAssistantAvatarUrl()` for other avatar types

### 3. `ui/src/ui/app-render.ts`
- Remove `buildAssistantAvatarRoute()` call for local avatars in Personal card config
- Use the data URI returned by the RPC (via `assistantAvatarUrl`) instead of constructing an unauthenticated URL path

## Testing

Verified on OpenClaw 2026.6.10 (aa69b12): patched dist files locally, restarted gateway, hard-refreshed Control UI. Personal card avatar displays correctly — no more 401 on `/avatar/<agentId>`.