### PR TITLE
fix(anthropic): strip type:custom from custom tool definitions to prevent Messages API rejection

### DIFF
--- a/src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.test.ts
+++ b/src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.test.ts
@@ -259,7 +259,7 @@ describe("createOpenAIAnthropicToolPayloadCompatibilityWrapper", () => {
     });
   });
 
-  it("preserves custom tools and named custom choices", () => {
+  it("converts custom tools to Anthropic format and preserves named custom choices", () => {
     const payload = runWrapper({
       tools: [
         {
@@ -279,11 +279,9 @@ describe("createOpenAIAnthropicToolPayloadCompatibilityWrapper", () => {
     expect(payload).toEqual({
       tools: [
         {
-          type: "custom",
-          custom: {
-            name: "shell",
-            description: "Run a shell command.",
-          },
+          name: "shell",
+          description: "Run a shell command.",
+          input_schema: { type: "object", properties: {} },
         },
       ],
       tool_choice: {

--- a/src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.ts
+++ b/src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.ts
@@ -237,7 +237,21 @@ function normalizeOpenAiFunctionAnthropicToolDefinition(
     }
     if (snapshot.type === "custom" && isRecord(snapshot.custom)) {
       const name = normalizeOptionalString(snapshot.custom.name) ?? undefined;
-      return name ? { kind: "custom", name, tool: snapshot } : undefined;
+      if (name) {
+        // Anthropic Messages API rejects type: "custom" for tool definitions.
+        // Convert custom tools to standard Anthropic tool format (name, description, input_schema).
+        const description = normalizeOptionalString(snapshot.custom.description) ?? undefined;
+        return {
+          kind: "custom",
+          name,
+          tool: {
+            name,
+            ...(description ? { description } : {}),
+            input_schema: { type: "object", properties: {} },
+          },
+        };
+      }
+      return undefined;
     }
     return { tool: snapshot };
   }


### PR DESCRIPTION
## What Problem This Solves

Gateway agent calls using the OpenAI-compatible Anthropic-family wrapper can fail when custom tools reach the Anthropic Messages API with the unsupported `type: "custom"` field. The `normalizeOpenAiFunctionAnthropicToolDefinition` function in `anthropic-family-tool-payload-compat.ts` preserves the original custom tool snapshot (which includes `type: "custom"`) in the projected tool output.

## Why This Change Was Made

The `anthropic-family-tool-payload-compat.ts` wrapper is used for OpenAI-compatible Anthropic-family endpoints (e.g., Amazon Bedrock, Vertex AI Anthropic). Custom tools with `type: "custom"` must be converted to standard Anthropic tool format `{ name, description, input_schema }` before reaching the API.

## Changes

- **`anthropic-family-tool-payload-compat.ts`**: Custom tools with `type: "custom"` are now converted to `{ name, description?, input_schema: { type: "object", properties: {} } }` instead of preserving the original snapshot with the rejected `type: "custom"`
- **`anthropic-family-tool-payload-compat.test.ts`**: Updated test expectation to verify the new Anthropic format output

## Related Issues

- Issue #85009 was closed as misattributed after investigation found the direct Anthropic transport was already correct. However, the OpenAI-compatible Anthropic-family wrapper (`anthropic-family-tool-payload-compat.ts`) addressed by this PR still has the bug as confirmed against current `main`. This is the path identified by @steipete as having "explicit compatibility shaping for OpenAI-compatible Anthropic-family endpoints."
- PR #85044 was a previous attempt to address this from a different angle (stream routing) that was closed without merging.

## User Impact

Gateway agent calls routed through the OpenAI-compatible Anthropic-family wrapper with custom tools (e.g., Codex shell tool, skill bundles) no longer risk Anthropic API validation errors.

## Evidence

- All 16 unit tests pass
- `main` branch confirmed to still have the bug (`tool: snapshot` preserves `type: "custom"`)
- Custom tools are now correctly output as valid Anthropic tool format
- Custom tool name tracking (`customNames` set) remains intact for `tool_choice` validation

## Verification

```
pnpm test src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.test.ts --run
# Result: 1 passed (1), 16 tests, 16 passed
```