### PR TITLE
fix(provider-usage): bound usage JSON response reads to prevent OOM

### DIFF
--- a/src/infra/provider-usage.fetch.shared.ts
+++ b/src/infra/provider-usage.fetch.shared.ts
@@ -1,5 +1,6 @@
 // Shared fetch and parsing helpers for provider usage endpoints.
 import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
+import { readProviderJsonResponse } from "../agents/provider-http-errors.js";
 import { parseFiniteNumber as parseFiniteNumberish } from "./parse-finite-number.js";
 import { PROVIDER_LABELS } from "./provider-usage.shared.js";
 import type { ProviderUsageSnapshot, UsageProviderId } from "./provider-usage.types.js";
@@ -67,7 +68,8 @@ export async function readUsageJson(
   response: Response,
 ): Promise<{ ok: true; data: unknown } | { ok: false; snapshot: ProviderUsageSnapshot }> {
   try {
-    return { ok: true, data: await response.json() };
+    const data = await readProviderJsonResponse<unknown>(response, `${provider} usage`);
+    return { ok: true, data };
   } catch {
     return {
       ok: false,


### PR DESCRIPTION
## Summary

Replace unbounded `response.json()` with `readProviderJsonResponse` in the `readUsageJson` shared helper to cap provider usage API response bodies at 16 MiB. This prevents unbounded buffering of responses from all seven providers that call this helper: Claude, Gemini, Codex, Z.AI, DeepSeek, MiniMax, and OpenAI-compatible embeddings.

## Real behavior proof (required for external PRs)

**Behavior addressed**: Unbounded `response.json()` replaced with `readProviderJsonResponse` (16 MiB cap).

**Real environment tested**: Linux, Node 22, OpenClaw main @ 87db23e543

**Exact steps or command run after fix**:

```bash
node --import tsx proof-readUsageJson.mts
```

**Proof harness**:

```ts
// Creates a streaming 64 MiB body with 1 MiB chunks.
// The bounded reader must stop at the 16 MiB cap, cancel
// the stream, and return { ok: false, snapshot }.
const { response, state } = makeOversizedStream();
const result = await readUsageJson("anthropic", response);
```

**Evidence after fix**:

```
cap: 16777216 bytes (16 MiB)
chunk: 1 MiB, total stream: 64 MiB
chunks enqueued: 17
stream cancelled: true
result.ok: false
snapshot.error: Malformed usage response
bytes buffered: 17825792 (17.0 MiB)
PASS: reader stopped at 17.0 MiB, stream cancelled before full 64 MiB buffering
```

The harness creates a streaming 64 MiB body with 1 MiB chunks. The bounded reader pulls only 17 chunks (stopping at the 16 MiB cap), cancels the stream, and returns the error snapshot. Before the fix, `response.json()` would have buffered the entire 64 MiB before parsing.

**Observed result after fix**: `readProviderJsonResponse` caps provider usage API responses at 16 MiB. Streaming bodies are cancelled at the cap instead of being fully buffered. The existing `{ ok: false, snapshot }` error contract is preserved for both overflow and malformed-JSON errors.

**All existing tests pass**: 51 tests across 5 caller test files (claude, codex, deepseek, gemini, zai) plus the shared helpers test file.

**What was not tested**: Live provider usage API calls against Anthropic, Gemini, Codex, Z.AI, DeepSeek, or MiniMax usage endpoints were not tested.

## Risk

Low. The 16 MiB cap matches the convention in `provider-http-errors.ts`. The existing try-catch in `readUsageJson` preserves the `{ ok: false, snapshot }` contract — overflow and JSON parse errors both return "Malformed usage response", matching the existing behavior for malformed-JSON responses.
