### PR TITLE
fix(reply): clear 'model unavailable' reply + correct operator hint for retired runtime models

### DIFF
--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -2832,6 +2832,29 @@ describe("resolveModel", () => {
     );
   });
 
+  it("points runtime-bound model entries at the runtime catalog instead of provider registration", async () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "openai/gpt-5.3-codex": {
+              agentRuntime: { id: "codex" },
+            },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = await resolveModelAsync("openai", "gpt-5.3-codex", "/tmp/agent", cfg, {
+      runtimeHooks: createRuntimeHooks(),
+      skipAgentDiscovery: true,
+    });
+
+    expect(result.error).toBe(
+      'Unknown model: openai/gpt-5.3-codex. Found agents.defaults.models["openai/gpt-5.3-codex"] bound to the "codex" agent runtime. Models served by an agent runtime come from that runtime and its linked account, not from models.providers["openai"].models[] — registering it there will not make it usable. Confirm "gpt-5.3-codex" is still offered by the "codex" runtime and switch agents.defaults.model.primary to a currently available model (run `openclaw models list --provider openai` to list them). See https://docs.openclaw.ai/concepts/model-providers.',
+    );
+  });
+
   it("repairs stale text-only Foundry fallback rows for GPT-family models", () => {
     const cfg = {
       models: {

--- a/src/agents/embedded-agent-runner/model.ts
+++ b/src/agents/embedded-agent-runner/model.ts
@@ -1913,11 +1913,21 @@ function buildMissingProviderModelRegistrationHint(params: {
     return undefined;
   }
   const agentModelKey = modelKey(params.provider, params.modelId);
-  if (
-    !configuredModels[agentModelKey] &&
-    !configuredModels[`${params.provider}/${params.modelId}`]
-  ) {
+  const configuredEntry =
+    configuredModels[agentModelKey] ?? configuredModels[`${params.provider}/${params.modelId}`];
+  if (!configuredEntry) {
     return undefined;
+  }
+  // Models bound to an agent runtime (e.g. "codex") draw their catalog from that
+  // runtime and its linked account, not from models.providers[].models[].
+  // Advising a models.providers[] registration here is actively misleading: it
+  // makes resolution "succeed" only for the request to be rejected later by the
+  // runtime/provider (e.g. OpenAI returns 400 "model is not supported when using
+  // Codex with a ChatGPT account" once a deprecated model id is no longer
+  // offered). Point the user at the runtime's live catalog instead.
+  const agentRuntimeId = configuredEntry.agentRuntime?.id;
+  if (agentRuntimeId) {
+    return `Found agents.defaults.models["${agentModelKey}"] bound to the "${agentRuntimeId}" agent runtime. Models served by an agent runtime come from that runtime and its linked account, not from models.providers["${params.provider}"].models[] — registering it there will not make it usable. Confirm "${params.modelId}" is still offered by the "${agentRuntimeId}" runtime and switch agents.defaults.model.primary to a currently available model (run \`openclaw models list --provider ${params.provider}\` to list them). See https://docs.openclaw.ai/concepts/model-providers.`;
   }
   const providerConfig = findNormalizedProviderValue(
     params.cfg?.models?.providers,

--- a/src/auto-reply/reply/provider-request-error-classifier.test.ts
+++ b/src/auto-reply/reply/provider-request-error-classifier.test.ts
@@ -6,6 +6,7 @@ import {
   PROVIDER_AUTHENTICATION_ERROR_USER_MESSAGE,
   PROVIDER_CONVERSATION_STATE_ERROR_USER_MESSAGE,
   PROVIDER_INTERNAL_ERROR_USER_MESSAGE,
+  PROVIDER_MODEL_UNAVAILABLE_USER_MESSAGE,
   PROVIDER_RATE_LIMIT_OR_QUOTA_ERROR_USER_MESSAGE,
 } from "./provider-request-error-classifier.js";
 
@@ -53,6 +54,41 @@ describe("provider request error classifier", () => {
         new Error("401 input item id does not belong to this conversation"),
       ),
     ).toBeUndefined();
+  });
+
+  it("classifies typed model_not_found failover errors as model unavailable", () => {
+    const error = new FailoverError(
+      'Unknown model: openai/gpt-5.3-codex. Found agents.defaults.models["openai/gpt-5.3-codex"] bound to the "codex" agent runtime.',
+      {
+        reason: "model_not_found",
+        provider: "openai",
+        model: "gpt-5.3-codex",
+      },
+    );
+
+    expect(classifyProviderRequestError(error)).toEqual({
+      code: "provider_model_unavailable",
+      userMessage: PROVIDER_MODEL_UNAVAILABLE_USER_MESSAGE,
+      technicalMessage: error.message,
+    });
+  });
+
+  it("does not classify model-not-found from raw provider text alone", () => {
+    // Detection is structural (typed failover reason), not text matching: a
+    // bare error string without the typed reason is left unclassified.
+    expect(
+      classifyProviderRequestError(new Error("Unknown model: openai/gpt-5.3-codex")),
+    ).toBeUndefined();
+  });
+
+  it("does not misclassify other typed failover reasons as model unavailable", () => {
+    const error = new FailoverError("Provider overloaded.", {
+      reason: "overloaded",
+      provider: "openai",
+      model: "gpt-5.5",
+    });
+
+    expect(classifyProviderRequestError(error)).toBeUndefined();
   });
 
   it.each([

--- a/src/auto-reply/reply/provider-request-error-classifier.ts
+++ b/src/auto-reply/reply/provider-request-error-classifier.ts
@@ -12,6 +12,7 @@ export type ProviderRequestErrorCode =
   | "provider_authentication_error"
   | "provider_conversation_state_error"
   | "provider_internal_error"
+  | "provider_model_unavailable"
   | "provider_rate_limit_or_quota_error";
 
 /** Structured provider error classification for reply failure handling. */
@@ -33,6 +34,14 @@ export const PROVIDER_INTERNAL_ERROR_USER_MESSAGE =
 
 export const PROVIDER_AUTHENTICATION_ERROR_USER_MESSAGE = `⚠️ ${AUTH_INVALID_TOKEN_USER_TEXT}`;
 
+/**
+ * User-facing copy for a configured model the provider no longer serves.
+ * Distinct from generic failures because retrying or starting a new session
+ * cannot help: the model id itself must be changed in config.
+ */
+export const PROVIDER_MODEL_UNAVAILABLE_USER_MESSAGE =
+  "⚠️ The configured model is unavailable from the provider — it may have been renamed, retired, or is not offered on this account. This needs a config update (agents.defaults.model); retrying or starting a new session won't fix it.";
+
 /** Classifies provider request failures that are actionable for users. */
 export function classifyProviderRequestError(
   err: unknown,
@@ -46,6 +55,17 @@ export function classifyProviderRequestError(
     return {
       code: "provider_authentication_error",
       userMessage: PROVIDER_AUTHENTICATION_ERROR_USER_MESSAGE,
+      technicalMessage,
+    };
+  }
+  // Detect retired/unavailable models structurally via the typed failover
+  // reason set at resolution time (run.ts), not by matching provider error
+  // text. Free-text provider rejections without a typed reason are left to the
+  // failover layer that owns error classification.
+  if (isFailoverError(err) && err.reason === "model_not_found") {
+    return {
+      code: "provider_model_unavailable",
+      userMessage: PROVIDER_MODEL_UNAVAILABLE_USER_MESSAGE,
       technicalMessage,
     };
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a chat user (e.g. on Telegram) gets **"⚠️ Something went
wrong while processing your request. Please try again, or use /new to start a
fresh session"** on *every* message — and `/new` doesn't help — when the agent's
configured model has been retired/renamed by the provider.

Concrete trigger: a config pinned to `openai/gpt-5.3-codex` via the `codex`
agent runtime (OpenAI ChatGPT account). After OpenAI stopped offering
`gpt-5.3-codex` to ChatGPT-account Codex, every turn failed. Two things made it
hard to recover:

1. **Chat user surface:** model resolution throws a typed `FailoverError` with
   reason `model_not_found`, but the reply classifier has no matching branch, so
   the reply falls back to the generic "try again / use /new" copy — which is
   actively wrong here, since retrying or starting a new session can never fix a
   bad model id.

2. **Operator surface:** the underlying "Unknown model" error appends a hint
   telling the operator to register the model in `models.providers[].models[]`.
   For a runtime-bound model that's misleading: runtime-owned models draw their
   catalog from the runtime/account, not config, so following the hint can't
   help (and can push the operator toward a config that the provider rejects
   downstream).

## Why This Change Was Made

Two small, layered changes, one per surface:

- **Chat reply (`provider-request-error-classifier.ts`):** add a
  `provider_model_unavailable` classification that returns a dedicated reply
  ("the model is unavailable; this needs a config change; retrying/`/new` won't
  help") instead of the generic copy. Detection is **structural and typed-only**
  — it keys off `isFailoverError(err) && err.reason === "model_not_found"` (the
  reason `run.ts` sets at resolution time). It does **not** match provider error
  text.

- **Operator hint (`embedded-agent-runner/model.ts`):** when the configured
  `agents.defaults.models` entry is bound to an `agentRuntime`, stop advising a
  `models.providers[]` registration and instead point at the runtime's live
  catalog (`openclaw models list --provider <id>`).

Non-runtime/plain-provider behavior is unchanged.

### Scope / non-goals

The chat classifier deliberately handles only the **typed** `model_not_found`
failover. It does **not** classify raw provider error strings or account-scoped
provider `400`s (e.g. OpenAI's "model is not supported when using Codex with a
ChatGPT account"). Those carry no structured signal, and string-matching error
classification belongs to the failover layer that already owns it — not to this
downstream reply classifier. In practice the typed path covers the real
recovery case, and the operator-hint change steers operators away from the
config state that produces such provider `400`s.

## User Impact

- **Chat users** now get an accurate, actionable reply instead of an endless
  generic "try again" loop, for any failure that surfaces as a typed
  `model_not_found`.
- **Operators** debugging via logs/CLI get a hint that leads to the real fix
  (switch to an available model) instead of a `models.providers[]` registration
  that can't help for runtime-bound models.

## Evidence

- New unit tests:
  - `provider-request-error-classifier.test.ts` — a typed
    `FailoverError(reason: "model_not_found")` classifies to
    `provider_model_unavailable`; a bare error string without the typed reason,
    and a different typed reason (`overloaded`), both stay unclassified
    (locks in structural-only detection).
  - `model.test.ts` — a runtime-bound entry gets the runtime-catalog hint; a
    plain-provider entry keeps the existing registration hint.
- Reproduced live on an affected install: the Codex app-server offered
  `gpt-5.5`/`gpt-5.4`/`gpt-5.4-mini` but not `gpt-5.3-codex`; the failing path
  threw exactly the typed `model_not_found` failover handled here, and switching
  the default to `openai/gpt-5.5` restored normal operation. (Live
  ChatGPT/Codex account path not re-run in CI.)

> AI-assisted: investigated and authored with Claude Code.