### PR TITLE
fix(browser): use public ssrf runtime import in CDP proxy bypass

### DIFF
--- a/extensions/browser/src/browser/cdp-proxy-bypass.test.ts
+++ b/extensions/browser/src/browser/cdp-proxy-bypass.test.ts
@@ -26,7 +26,7 @@ function createDeferred<T = void>(): {
   return { promise, resolve, reject };
 }
 
-vi.mock("openclaw/plugin-sdk/ssrf-runtime-internal", () => ({
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
   registerManagedProxyBrowserCdpBypass: registerManagedProxyBrowserCdpBypassMock,
 }));
 

--- a/extensions/browser/src/browser/cdp-proxy-bypass.ts
+++ b/extensions/browser/src/browser/cdp-proxy-bypass.ts
@@ -9,7 +9,7 @@
  */
 import http from "node:http";
 import https from "node:https";
-import { registerManagedProxyBrowserCdpBypass } from "openclaw/plugin-sdk/ssrf-runtime-internal";
+import { registerManagedProxyBrowserCdpBypass } from "openclaw/plugin-sdk/ssrf-runtime";
 import { isLoopbackHost } from "../gateway/net.js";
 import { hasProxyEnvConfigured } from "../infra/net/proxy-env.js";
 


### PR DESCRIPTION
## Summary
- switch the browser CDP proxy bypass helper to import `registerManagedProxyBrowserCdpBypass` from the exported `openclaw/plugin-sdk/ssrf-runtime` subpath
- update the focused browser test to mock the public subpath used at runtime

## Testing
- `pnpm exec vitest run extensions/browser/src/browser/cdp-proxy-bypass.test.ts`
- `node scripts/check-extension-plugin-sdk-boundary.mjs --mode=plugin-sdk-internal extensions/browser/src/browser/cdp-proxy-bypass.ts`

Closes #96639