### PR TITLE
fix(infra): re-estimate cost from tokens when known-pricing API returns $0

### DIFF
--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -304,6 +304,64 @@ describe("session cost usage", () => {
     });
   });
 
+  it("re-estimates cost from tokens when pricing is known but API returned $0 with non-zero tokens (DeepSeek V4)", async () => {
+    const root = await makeSessionCostRoot("cost-deepseek-v4-zero");
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+
+    // DeepSeek V4 API returns usage.cost.total: 0 in every completion response.
+    // The operator has configured positive per-token pricing for the model.
+    const entry = {
+      type: "message",
+      timestamp: new Date().toISOString(),
+      message: {
+        role: "assistant",
+        provider: "deepseek",
+        model: "deepseek-v4-flash",
+        usage: {
+          input: 881,
+          output: 6,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 887,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+      },
+    };
+
+    await fs.writeFile(
+      path.join(sessionsDir, "sess-1.jsonl"),
+      transcriptText("sess-1", entry),
+      "utf-8",
+    );
+
+    // deepseek-v4-flash: input ¥0.14/10K tokens → input: 14 per M, output ¥0.28/10K → output: 28 per M
+    const config = {
+      models: {
+        providers: {
+          deepseek: {
+            models: [
+              {
+                id: "deepseek-v4-flash",
+                cost: { input: 14, output: 28, cacheRead: 0, cacheWrite: 0 },
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    clearGatewayModelPricingCacheState();
+    await withStateDir(root, async () => {
+      const summary = await loadCostUsageSummary({ days: 30, config });
+      expect(summary.totals.totalTokens).toBe(887);
+      // Cost should be estimated from tokens (881 * 14 + 6 * 28) / 1_000_000 = 0.012502
+      expect(summary.totals.totalCost).toBeCloseTo(0.012502, 6);
+      // Pricing is known, so it should NOT be marked as a missing-cost entry
+      expect(summary.totals.missingCostEntries).toBe(0);
+    });
+  });
+
   it("treats a pre-upgrade (older-version) durable cache as stale so unpriced usage is rebuilt", async () => {
     const root = await makeSessionCostRoot("cost-cache-upgrade");
     const sessionsDir = path.join(root, "agents", "main", "sessions");

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -1272,6 +1272,18 @@ async function scanTranscriptFile(params: {
         // above.
         entry.costTotal = undefined;
         entry.costBreakdown = undefined;
+      } else if (
+        isModelPricingKnown(cost) &&
+        entry.costTotal === 0 &&
+        computeUsageTokenTotals(entry.usage).totalTokens > 0
+      ) {
+        // Pricing is known (positive per-token rates configured), but the API or
+        // transport recorded $0 cost despite burning tokens. This is not trustworthy
+        // — for example, DeepSeek V4 returns usage.cost.total: 0 in every completion
+        // response. Re-estimate from token counts so budget and spike safeguards
+        // that read totalCost are not left blind to real spend.
+        entry.costTotal = estimateUsageCost({ usage: entry.usage, cost });
+        entry.costBreakdown = undefined;
       } else if (entry.costTotal === undefined) {
         // Fill in missing cost estimates.
         entry.costTotal = estimateUsageCost({ usage: entry.usage, cost });


### PR DESCRIPTION
## Summary

DeepSeek V4 API returns `usage.cost.total: 0` in every completion response. When the operator has configured positive per-token pricing for the model, `scanTranscriptFile()` now detects that a recorded $0 cost is not trustworthy when tokens are non-zero and re-estimates from token counts instead. This prevents Control UI Spend from showing ¥0.00 for all DeepSeek V4 model usage.

## Root cause

`scanTranscriptFile()` in `src/infra/session-cost-usage.ts` had three cost-resolution branches:
1. Tiered pricing → always re-estimate (correct)
2. Unknown pricing + (costTotal is 0/undefined) + non-zero tokens → mark as missing (correct)
3. costTotal is undefined → estimate from tokens (correct)

When `isModelPricingKnown(cost)` returned `true` (DeepSeek has positive per-token rates configured) but the API returned `cost.total: 0`, all three branches were skipped: branch 2 required `!isModelPricingKnown(cost)`, and branch 3 required `costTotal === undefined`. The `0` was accepted as a valid zero-cost entry.

## Fix

Added a new branch between 2 and 3 that handles known pricing + `costTotal === 0` + non-zero tokens by re-estimating from token counts. The new branch correctly routes DeepSeek V4 turns to token-based estimation.

## Changes

- `src/infra/session-cost-usage.ts`: Add `isModelPricingKnown(cost) && costTotal === 0 && tokens > 0` guard in `scanTranscriptFile()` that re-estimates cost instead of trusting the API-returned $0
- `src/infra/session-cost-usage.test.ts`: Add test case "re-estimates cost from tokens when pricing is known but API returned $0 with non-zero tokens (DeepSeek V4)"

## Real behavior proof

**Behavior addressed**: DeepSeek V4 cost showing ¥0.00 in Control UI Spend when positive per-token pricing is configured.

**Real environment tested**: Ubuntu, Node 22, OpenClaw test framework.

**Exact steps or command run after this patch**:
```
pnpm test src/infra/session-cost-usage.test.ts --run
```

**Evidence after fix**:
```
✓ re-estimates cost from tokens when pricing is known but API returned $0 with non-zero tokens (DeepSeek V4) (17ms)
59 tests: 58 passed, 1 failed (pre-existing DST timezone failure unrelated to this change)
```

**Observed result after fix**: With configured pricing `{input: 14, output: 28}` (¥0.14/10K in → ¥14/M, ¥0.28/10K out → ¥28/M) and usage `{input: 881, output: 6}`:
- **BEFORE**: totalCost = 0, missingCostEntries = 0 (confident but wrong $0)
- **AFTER**: totalCost ≈ 0.012502, missingCostEntries = 0 (estimated correctly from tokens)

**What was not tested**: End-to-end through a live DeepSeek provider connection. The proof drives the real cost-resolution and aggregation functions directly with transcript input.

## Verification
- 58/59 tests pass (1 pre-existing DST timezone failure)
- `npx oxlint` reports 0 warnings, 0 errors on changed files