### PR TITLE
fix(provider-usage): bound Anthropic usage error response reads to prevent OOM

### DIFF
--- a/src/infra/provider-usage.fetch.claude.ts
+++ b/src/infra/provider-usage.fetch.claude.ts
@@ -7,6 +7,7 @@ import {
 } from "./provider-usage.fetch.shared.js";
 import { clampPercent, PROVIDER_LABELS } from "./provider-usage.shared.js";
 import type { ProviderUsageSnapshot, UsageWindow } from "./provider-usage.types.js";
+import { readProviderJsonResponse } from "../agents/provider-http-errors.js";
 
 type ClaudeUsageResponse = {
   five_hour?: { utilization?: number; resets_at?: string };
@@ -151,9 +152,9 @@ export async function fetchClaudeUsage(
   if (!res.ok) {
     let message: string | undefined;
     try {
-      const data = (await res.json()) as {
+      const data = await readProviderJsonResponse<{
         error?: { message?: unknown } | null;
-      };
+      }>(res, "Anthropic usage error");
       const raw = data?.error?.message;
       if (typeof raw === "string" && raw.trim()) {
         message = raw.trim();


### PR DESCRIPTION
## Summary

Replace unbounded `res.json()` with `readProviderJsonResponse` in the `fetchClaudeUsage` error handler. This caps Anthropic usage API error response bodies at 16 MiB, preventing unbounded buffering when the API returns a large error body (CDN error pages, WAF blocks, misconfigured proxies, etc.).

## Real behavior proof (required for external PRs)

**Behavior addressed**: Unbounded `res.json()` replaced with `readProviderJsonResponse` (16 MiB cap) in the error handler path.

**Real environment tested**: Linux, Node 22, OpenClaw main @ 87db23e543

**Exact steps or command run after fix**:

```bash
node --import tsx proof-claude-usage-error.mts
```

**Evidence after fix**:

```
cap: 16777216 bytes (16 MiB)
chunks enqueued: 17
stream cancelled: true
error: Anthropic usage error: JSON response exceeds 16777216 bytes
data: null
PASS: reader stopped at 17.0 MiB, stream cancelled before full 64 MiB buffering
```

The harness creates a streaming 64 MiB error body with 1 MiB chunks. The bounded reader pulls only 17 chunks (stopping at the 16 MiB cap), cancels the stream, and throws. The existing catch block catches this and returns the error snapshot. Before the fix, `res.json()` would have buffered the entire 64 MiB before parsing.

**Observed result after fix**: `readProviderJsonResponse` caps Anthropic usage error bodies at 16 MiB. Streaming error bodies are cancelled at the cap. The existing catch block ("ignore parse errors") now also handles overflow errors, preserving the existing fallback behavior (scope-check → web fallback → HTTP error snapshot).

**All existing tests pass**: 14 tests in `provider-usage.fetch.claude.test.ts`.

**What was not tested**: A live Anthropic usage API call returning a large error body was not tested.

## Risk

Low. The 16 MiB cap matches the convention in `provider-http-errors.ts`. The existing catch block gracefully handles both parse errors (existing) and overflow errors (new), preserving the same fallback behavior.
