### PR TITLE
fix(xai): bound OAuth response reads to prevent OOM

### DIFF
--- a/extensions/xai/xai-oauth.ts
+++ b/extensions/xai/xai-oauth.ts
@@ -5,6 +5,7 @@ import {
   resolveExpiresAtMsFromDurationSeconds,
   resolveExpiresAtMsFromEpochSeconds,
 } from "openclaw/plugin-sdk/number-runtime";
+import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import type { ProviderAuthContext, ProviderAuthMethod } from "openclaw/plugin-sdk/plugin-entry";
 import {
   buildOauthProviderAuthResult,
@@ -28,6 +29,7 @@ const XAI_LEGACY_OAUTH_TOKEN_ENDPOINT = `${XAI_OAUTH_ISSUER}/oauth/token`;
 
 const XAI_OAUTH_TIMEOUT_MS = 5 * 60 * 1000;
 const XAI_OAUTH_FETCH_TIMEOUT_MS = 30 * 1000;
+const XAI_OAUTH_RESPONSE_MAX_BYTES = 16 * 1024 * 1024;
 const XAI_OAUTH_REFRESH_MAX_ATTEMPTS = 3;
 const XAI_OAUTH_REFRESH_RETRY_DELAY_MS = 250;
 const XAI_DEVICE_CODE_DEFAULT_INTERVAL_MS = 5 * 1000;
@@ -111,7 +113,10 @@ function readStringRecord(value: unknown): Record<string, unknown> {
 }
 
 async function readResponseBody(response: Response): Promise<XaiOAuthResponseBody> {
-  const text = await response.text();
+  const buffer = await readResponseWithLimit(response, XAI_OAUTH_RESPONSE_MAX_BYTES, {
+    onOverflow: ({ maxBytes }) => new Error(`xAI OAuth response exceeds ${maxBytes} bytes`),
+  });
+  const text = new TextDecoder().decode(buffer);
   let json: unknown;
   try {
     json = JSON.parse(text);
@@ -449,7 +454,11 @@ async function pollXaiDeviceCodeToken(
     );
     let body: unknown;
     try {
-      body = await response.json();
+      const buffer = await readResponseWithLimit(response, XAI_OAUTH_RESPONSE_MAX_BYTES, {
+        onOverflow: ({ maxBytes }) =>
+          new Error(`xAI device code response exceeds ${maxBytes} bytes`),
+      });
+      body = JSON.parse(new TextDecoder().decode(buffer));
     } catch {
       body = null;
     }


### PR DESCRIPTION
## Summary

Replace unbounded `response.text()` in `readResponseBody` and unbounded `response.json()` in the device-code polling loop with `readResponseWithLimit` (16 MiB cap). This prevents unbounded buffering of xAI OAuth discovery document, token exchange, and device-code polling responses.

## Real behavior proof (required for external PRs)

**Behavior addressed**: Two unbounded response reads replaced with `readResponseWithLimit` (16 MiB cap).

**Real environment tested**: Linux, Node 22, OpenClaw main @ 87db23e543

**Exact steps or command run after fix**:

```bash
node --import tsx proof-xai-oauth.mts
```

**Evidence after fix**:

```
=== Test 1: readResponseBody (response.text() replacement) ===
  chunks enqueued: 17
  stream cancelled: true
  error: xAI OAuth response exceeds 16777216 bytes
  PASS

=== Test 2: device-code polling (response.json() replacement) ===
  chunks enqueued: 17
  stream cancelled: true
  body: null (bounded)
  PASS

PASS: both xAI OAuth read paths bounded at 16 MiB, streams cancelled
```

**Observed result after fix**: `readResponseWithLimit` caps xAI OAuth response bodies at 16 MiB. Both the OAuth discovery/token path and the polling path cancel streaming bodies at the cap. The existing catch blocks preserve the same fallback behavior (error message extraction for the OAuth path, `body = null` for the polling retry path).

**What was not tested**: Live xAI OAuth discovery, token exchange, or device-code polling endpoints were not tested.

## Risk

Low. The 16 MiB cap is generous for OAuth responses (typically under 10 KB). The same `readResponseWithLimit` helper is already used in `extensions/xai/tts.ts` and `extensions/xai/video-generation-provider.ts`.
