### PR TITLE
fix(agents): escalate model_not_found to fallback when fallbacks are configured

### DIFF
--- a/src/agents/embedded-agent-runner/run/failover-policy.test.ts
+++ b/src/agents/embedded-agent-runner/run/failover-policy.test.ts
@@ -49,6 +49,20 @@ describe("resolveRunFailoverDecision", () => {
     });
   });
 
+  it("returns error payload for model_not_found when no fallback is configured", () => {
+    // Without configured fallbacks a typo'd model should still surface
+    // loudly as a terminal error rather than silently swallowing it.
+    expect(
+      resolveRunFailoverDecision({
+        stage: "retry_limit",
+        fallbackConfigured: false,
+        failoverReason: "model_not_found",
+      }),
+    ).toEqual({
+      action: "return_error_payload",
+    });
+  });
+
   it("prefers prompt-side profile rotation before fallback", () => {
     // Prompt construction can fail before any model output exists, so rotate
     // the current provider profile before spending the configured fallback.

--- a/src/agents/embedded-agent-runner/run/failover-policy.test.ts
+++ b/src/agents/embedded-agent-runner/run/failover-policy.test.ts
@@ -32,6 +32,23 @@ describe("resolveRunFailoverDecision", () => {
     });
   });
 
+  it("escalates retry-limit model_not_found to fallback when fallbacks are configured", () => {
+    // model_not_found used to be excluded from retry-limit escalation, which
+    // silently defeated configured fallbacks when a primary model was
+    // decommissioned mid-life. A decommissioned model with a configured
+    // fallback chain should cascade to the next model.
+    expect(
+      resolveRunFailoverDecision({
+        stage: "retry_limit",
+        fallbackConfigured: true,
+        failoverReason: "model_not_found",
+      }),
+    ).toEqual({
+      action: "fallback_model",
+      reason: "model_not_found",
+    });
+  });
+
   it("prefers prompt-side profile rotation before fallback", () => {
     // Prompt construction can fail before any model output exists, so rotate
     // the current provider profile before spending the configured fallback.

--- a/src/agents/embedded-agent-runner/run/failover-policy.ts
+++ b/src/agents/embedded-agent-runner/run/failover-policy.ts
@@ -77,11 +77,7 @@ type RunFailoverDecisionParams =
 
 function shouldEscalateRetryLimit(reason: FailoverReason | null): boolean {
   return Boolean(
-    reason &&
-    reason !== "timeout" &&
-    reason !== "model_not_found" &&
-    reason !== "format" &&
-    reason !== "session_expired",
+    reason && reason !== "timeout" && reason !== "format" && reason !== "session_expired",
   );
 }
 


### PR DESCRIPTION
## Summary

When a configured primary model is decommissioned by the provider, `shouldEscalateRetryLimit` excluded `model_not_found` from failover escalation, causing configured `fallbacks` to never be engaged. The user-visible result was a hard error on a config that was specifically set up with fallbacks for exactly this scenario.

## Root cause

`shouldEscalateRetryLimit()` in `src/agents/embedded-agent-runner/run/failover-policy.ts:78` explicitly excluded `model_not_found` from escalation alongside `timeout`, `format`, and `session_expired`:

```ts
function shouldEscalateRetryLimit(reason) {
  return Boolean(
    reason &&
    reason !== "timeout" &&
    reason !== "model_not_found" &&
    reason !== "format" &&
    reason !== "session_expired"
  );
}
```

The exclusion conflated two distinct causes:
1. Typo / never-existed model — surfacing the error is correct.
2. Previously-valid model decommissioned mid-life — the fallbacks chain is the intended remedy.

## Fix

Remove `model_not_found` from the exclusion list. `shouldEscalateRetryLimit` is only called when `fallbackConfigured` is true (line 163), so:
- `model_not_found` + fallbacks configured → cascade to fallback model
- `model_not_found` + no fallbacks → still returns terminal error (the function is never called, the retry_limit path falls through to `return_error_payload`)

## Changes

- `src/agents/embedded-agent-runner/run/failover-policy.ts`: Remove `model_not_found` from `shouldEscalateRetryLimit` exclusion list
- `src/agents/embedded-agent-runner/run/failover-policy.test.ts`: Add test case verifying `model_not_found` with `fallbackConfigured: true` returns `fallback_model`

## Real behavior proof

**Behavior addressed**: `model_not_found` now cascades to configured fallbacks instead of returning a terminal error.

**Real environment tested**: Ubuntu, Node 22, OpenClaw test framework.

**Exact steps or command run after this patch**:
```
pnpm test src/agents/embedded-agent-runner/run/failover-policy.test.ts --run
```

**Evidence after fix**:
```
✓ keeps retry-limit as a local error for non-escalating reasons (1ms)
✓ escalates retry-limit model_not_found to fallback when fallbacks are configured (1ms)
35 tests passed
```

**Observed result after fix**: With `fallbackConfigured: true` and `failoverReason: "model_not_found"`:
- **BEFORE**: `action: "return_error_payload"` (terminal error, fallback never tried)
- **AFTER**: `action: "fallback_model"`, `reason: "model_not_found"` (cascades to next fallback)

**What was not tested**: End-to-end through a live provider. The proof drives the real decision function with the exact params that match the reported bug scenario.

## Verification
- 35/35 tests pass
- Test file: `src/agents/embedded-agent-runner/run/failover-policy.test.ts`