### PR TITLE
fix(secrets): skip PLAINTEXT_FOUND for known non-secret apiKey markers

### DIFF
--- a/src/secrets/audit.test.ts
+++ b/src/secrets/audit.test.ts
@@ -771,4 +771,65 @@ describe("secrets audit", () => {
       ),
     ).toBe(true);
   });
+
+  it("does not flag openclaw.json model provider apiKey marker values as plaintext", async () => {
+    await writeJsonFile(fixture.configPath, {
+      models: {
+        providers: {
+          lmstudio: {
+            baseUrl: "http://127.0.0.1:1234/v1",
+            api: "openai-completions",
+            apiKey: "lmstudio-local",
+            models: [{ id: "lmstudio-local", name: "lmstudio-local" }],
+          },
+          ollama: {
+            baseUrl: "http://127.0.0.1:11434/v1",
+            api: "openai-completions",
+            apiKey: "ollama-local",
+            models: [{ id: "ollama-local", name: "ollama-local" }],
+          },
+          openai: {
+            baseUrl: "https://api.openai.com/v1",
+            api: "openai-completions",
+            apiKey: "sk-real-plaintext",
+            models: [{ id: "gpt-5", name: "gpt-5" }],
+          },
+        },
+      },
+    });
+    await writeJsonFile(fixture.authStorePath, {
+      version: 1,
+      profiles: {},
+    });
+    await fs.writeFile(fixture.envPath, "", "utf8");
+
+    const report = await runSecretsAudit({ env: fixture.env });
+    expect(
+      hasFinding(
+        report,
+        (entry) =>
+          entry.code === "PLAINTEXT_FOUND" &&
+          entry.file === fixture.configPath &&
+          entry.jsonPath === "models.providers.lmstudio.apiKey",
+      ),
+    ).toBe(false);
+    expect(
+      hasFinding(
+        report,
+        (entry) =>
+          entry.code === "PLAINTEXT_FOUND" &&
+          entry.file === fixture.configPath &&
+          entry.jsonPath === "models.providers.ollama.apiKey",
+      ),
+    ).toBe(false);
+    expect(
+      hasFinding(
+        report,
+        (entry) =>
+          entry.code === "PLAINTEXT_FOUND" &&
+          entry.file === fixture.configPath &&
+          entry.jsonPath === "models.providers.openai.apiKey",
+      ),
+    ).toBe(true);
+  });
 });

--- a/src/secrets/audit.ts
+++ b/src/secrets/audit.ts
@@ -221,6 +221,13 @@ function collectConfigSecrets(params: {
     ) {
       continue;
     }
+    if (
+      target.entry.id === "models.providers.*.apiKey" &&
+      typeof target.value === "string" &&
+      isNonSecretApiKeyMarker(target.value)
+    ) {
+      continue;
+    }
     if (!hasPlaintext) {
       continue;
     }


### PR DESCRIPTION
## What Problem This Solves

Fresh OpenClaw installs that enable the LM Studio provider ship with `models.providers.lmstudio.apiKey: "lmstudio-local"` as a placeholder. The local LM Studio server does not validate API keys, so this value is not a real secret, yet `openclaw security audit` (and `openclaw secrets audit`) emits a `PLAINTEXT_FOUND` warning for it. This trains users to ignore plaintext warnings, which can mask real credentials stored inline.

Closes #89233.

## Why This Change Was Made

The same `isNonSecretApiKeyMarker()` helper already skips these known local-provider markers when auditing `models.json` provider apiKeys (see `src/secrets/audit.ts:381`). However, the `openclaw.json` config audit path in `collectConfigSecrets()` only skipped non-sensitive request headers; it did not apply the marker check to `models.providers.*.apiKey`.

This change reuses the existing marker helper so that `lmstudio-local`, `ollama-local`, and other known non-secret apiKey markers are treated consistently across both `models.json` and `openclaw.json` audit paths.

## User Impact

- Operators with keyless LM Studio / Ollama providers no longer see a false-positive plaintext warning for the bundled placeholder apiKey.
- Real inline secrets (e.g., `sk-...`) continue to be flagged exactly as before.
- No config migration or user action is required.

## Evidence

Local validation run against this branch:

```bash
pnpm exec oxfmt src/secrets/audit.ts src/secrets/audit.test.ts
pnpm tsgo:core
pnpm exec vitest run src/secrets/audit.test.ts src/security/audit-config-basics.test.ts src/security/audit-model-hygiene.test.ts
```

Results:

```text
Test Files  3 passed (3)
     Tests  32 passed (32)
```

The new regression test (`src/secrets/audit.test.ts`) asserts that:
- `models.providers.lmstudio.apiKey = "lmstudio-local"` is **not** flagged.
- `models.providers.ollama.apiKey = "ollama-local"` is **not** flagged.
- `models.providers.openai.apiKey = "sk-real-plaintext"` **is** still flagged.

Files changed: `src/secrets/audit.ts`, `src/secrets/audit.test.ts`.
