### PR TITLE
feat(venice): sync model catalog + add image generation provider

### DIFF
--- a/docs/providers/venice.md
+++ b/docs/providers/venice.md
@@ -89,7 +89,7 @@ Anonymized models are **not** fully private. Venice strips metadata before forwa
 After setup, OpenClaw shows all available Venice models. Pick based on your needs:
 
 - **Default model**: `venice/kimi-k2-5` for strong private reasoning plus vision.
-- **High-capability option**: `venice/claude-opus-4-6` for the strongest anonymized Venice path.
+- **High-capability option**: `venice/claude-opus-4-8` for the strongest anonymized Venice path.
 - **Privacy**: Choose "private" models for fully private inference.
 - **Capability**: Choose "anonymized" models to access Claude, GPT, Gemini via Venice's proxy.
 
@@ -97,7 +97,7 @@ Change your default model anytime:
 
 ```bash
 openclaw models set venice/kimi-k2-5
-openclaw models set venice/claude-opus-4-6
+openclaw models set venice/claude-opus-4-8
 ```
 
 List all available models:
@@ -111,15 +111,15 @@ You can also run `openclaw configure`, select **Model/auth**, and choose **Venic
 <Tip>
 Use the table below to pick the right model for your use case.
 
-| Use Case                   | Recommended Model                | Why                                          |
-| -------------------------- | -------------------------------- | -------------------------------------------- |
-| **General chat (default)** | `kimi-k2-5`                      | Strong private reasoning plus vision         |
-| **Best overall quality**   | `claude-opus-4-6`                | Strongest anonymized Venice option           |
-| **Privacy + coding**       | `qwen3-coder-480b-a35b-instruct` | Private coding model with large context      |
-| **Private vision**         | `kimi-k2-5`                      | Vision support without leaving private mode  |
-| **Fast + cheap**           | `qwen3-4b`                       | Lightweight reasoning model                  |
-| **Complex private tasks**  | `deepseek-v3.2`                  | Strong reasoning, but no Venice tool support |
-| **Uncensored**             | `venice-uncensored`              | No content restrictions                      |
+| Use Case                   | Recommended Model                      | Why                                          |
+| -------------------------- | -------------------------------------- | -------------------------------------------- |
+| **General chat (default)** | `kimi-k2-5`                            | Strong private reasoning plus vision         |
+| **Best overall quality**   | `claude-opus-4-8`                      | Strongest anonymized Venice option           |
+| **Privacy + coding**       | `qwen3-coder-480b-a35b-instruct-turbo` | Private coding model with large context      |
+| **Private vision**         | `kimi-k2-5`                            | Vision support without leaving private mode  |
+| **Fast + cheap**           | `qwen3-5-9b`                           | Lightweight reasoning model                  |
+| **Complex private tasks**  | `deepseek-v3.2`                        | Strong reasoning, but no Venice tool support |
+| **Uncensored**             | `venice-uncensored-1-2`                | No content restrictions                      |
 
 </Tip>
 
@@ -132,55 +132,119 @@ omits it. Venice rejects DeepSeek's native top-level `thinking` control, so
 OpenClaw keeps that provider-specific replay fix separate from the native
 DeepSeek provider's thinking controls.
 
-## Built-in catalog (41 total)
+## Image generation
+
+Venice image models are available through the `image_generate` tool — the same
+tool used for every other image provider. Once `VENICE_API_KEY` is set, OpenClaw
+registers Venice as an image-generation provider automatically; no extra
+configuration is needed.
+
+- **Default model**: `venice-sd35`. Override with any Venice image model, for
+  example `flux-2-pro`, `seedream-v5-lite`, `nano-banana-pro`, or the uncensored
+  `lustify-v8`.
+- **Geometry**: pass `size` (width/height up to 1280px), `aspectRatio`, or
+  `resolution` (`1K`/`2K`/`4K`) — Venice applies each model's own defaults for
+  anything you omit.
+- **Uncensored by default**: Venice's `safe_mode` is disabled for this provider
+  so uncensored image models behave as intended.
+- **Text-to-image only**: image editing is not wired through this provider.
+
+List the registered image providers and models at runtime with the tool's
+`list` action:
+
+```text
+/tool image_generate action=list
+```
+
+See [Image generation](/tools/image-generation) for the full tool reference.
+
+## Built-in catalog (76 total)
 
 <AccordionGroup>
-  <Accordion title="Private models (26) — fully private, no logging">
-    | Model ID                               | Name                                | Context | Features                   |
-    | -------------------------------------- | ----------------------------------- | ------- | -------------------------- |
-    | `kimi-k2-5`                            | Kimi K2.5                           | 256k    | Default, reasoning, vision |
-    | `kimi-k2-thinking`                     | Kimi K2 Thinking                    | 256k    | Reasoning                  |
-    | `llama-3.3-70b`                        | Llama 3.3 70B                       | 128k    | General                    |
-    | `llama-3.2-3b`                         | Llama 3.2 3B                        | 128k    | General                    |
-    | `hermes-3-llama-3.1-405b`              | Hermes 3 Llama 3.1 405B            | 128k    | General, tools disabled    |
-    | `qwen3-235b-a22b-thinking-2507`        | Qwen3 235B Thinking                | 128k    | Reasoning                  |
-    | `qwen3-235b-a22b-instruct-2507`        | Qwen3 235B Instruct                | 128k    | General                    |
-    | `qwen3-coder-480b-a35b-instruct`       | Qwen3 Coder 480B                   | 256k    | Coding                     |
-    | `qwen3-coder-480b-a35b-instruct-turbo` | Qwen3 Coder 480B Turbo             | 256k    | Coding                     |
-    | `qwen3-5-35b-a3b`                      | Qwen3.5 35B A3B                    | 256k    | Reasoning, vision          |
-    | `qwen3-next-80b`                       | Qwen3 Next 80B                     | 256k    | General                    |
-    | `qwen3-vl-235b-a22b`                   | Qwen3 VL 235B (Vision)             | 256k    | Vision                     |
-    | `qwen3-4b`                             | Venice Small (Qwen3 4B)            | 32k     | Fast, reasoning            |
-    | `deepseek-v3.2`                        | DeepSeek V3.2                      | 160k    | Reasoning, tools disabled  |
-    | `venice-uncensored`                    | Venice Uncensored (Dolphin-Mistral) | 32k     | Uncensored, tools disabled |
-    | `mistral-31-24b`                       | Venice Medium (Mistral)            | 128k    | Vision                     |
-    | `google-gemma-3-27b-it`                | Google Gemma 3 27B Instruct        | 198k    | Vision                     |
-    | `openai-gpt-oss-120b`                  | OpenAI GPT OSS 120B               | 128k    | General                    |
-    | `nvidia-nemotron-3-nano-30b-a3b`       | NVIDIA Nemotron 3 Nano 30B         | 128k    | General                    |
-    | `olafangensan-glm-4.7-flash-heretic`   | GLM 4.7 Flash Heretic              | 128k    | Reasoning                  |
-    | `zai-org-glm-4.6`                      | GLM 4.6                            | 198k    | General                    |
-    | `zai-org-glm-4.7`                      | GLM 4.7                            | 198k    | Reasoning                  |
-    | `zai-org-glm-4.7-flash`                | GLM 4.7 Flash                      | 128k    | Reasoning                  |
-    | `zai-org-glm-5`                        | GLM 5                              | 198k    | Reasoning                  |
-    | `minimax-m21`                          | MiniMax M2.1                       | 198k    | Reasoning                  |
-    | `minimax-m25`                          | MiniMax M2.5                       | 198k    | Reasoning                  |
+  <Accordion title="Private models (43) - fully private, no logging">
+    | Model ID | Name | Context | Features |
+    | --- | --- | --- | --- |
+    | `zai-org-glm-5-2` | GLM 5.2 | 1M | Reasoning |
+    | `zai-org-glm-5-1` | GLM 5.1 | 200k | Reasoning |
+    | `zai-org-glm-5` | GLM 5 | 198k | Reasoning |
+    | `olafangensan-glm-4.7-flash-heretic` | GLM 4.7 Flash Heretic | 128k | Reasoning, uncensored |
+    | `zai-org-glm-4.7-flash` | GLM 4.7 Flash | 128k | Reasoning |
+    | `zai-org-glm-4.6` | GLM 4.6 | 198k | General |
+    | `zai-org-glm-4.7` | GLM 4.7 | 198k | Reasoning |
+    | `venice-uncensored-1-2` | Venice Uncensored 1.2 | 128k | Vision, uncensored |
+    | `venice-uncensored-role-play` | Venice Role Play Uncensored | 128k | Vision, uncensored |
+    | `qwen3-6-27b` | Qwen 3.6 27B | 256k | Reasoning, vision |
+    | `qwen3-5-9b` | Qwen 3.5 9B | 256k | Reasoning, vision |
+    | `qwen3-5-35b-a3b` | Qwen3.5 35B A3B | 256k | Reasoning, vision |
+    | `qwen3-235b-a22b-thinking-2507` | Qwen3 235B Thinking | 128k | Reasoning |
+    | `qwen3-235b-a22b-instruct-2507` | Qwen3 235B Instruct | 128k | General |
+    | `qwen3-next-80b` | Qwen3 Next 80B | 256k | General |
+    | `qwen3-vl-235b-a22b` | Qwen3 VL 235B (Vision) | 256k | Vision |
+    | `qwen3-coder-480b-a35b-instruct-turbo` | Qwen3 Coder 480B Turbo | 256k | Coding |
+    | `google-gemma-4-26b-a4b-it` | Google Gemma 4 26B A4B Instruct | 256k | Reasoning, vision |
+    | `google-gemma-4-31b-it` | Google Gemma 4 31B Instruct | 256k | Reasoning, vision |
+    | `gemma-4-uncensored` | Gemma 4 Uncensored | 256k | Vision, uncensored |
+    | `google-gemma-3-27b-it` | Google Gemma 3 27B Instruct | 198k | Vision |
+    | `arcee-trinity-large-thinking` | Trinity Large Thinking | 256k | Reasoning |
+    | `grok-4-3` | Grok 4.3 | 1M | Reasoning, vision |
+    | `grok-4-20` | Grok 4.20 | 2M | Reasoning, vision |
+    | `grok-4-20-multi-agent` | Grok 4.20 Multi-Agent | 2M | Reasoning, vision, tools disabled |
+    | `grok-build-0-1` | Grok Build 0.1 | 256k | Reasoning, vision |
+    | `mistral-small-3-2-24b-instruct` | Mistral Small 3.2 24B Instruct | 256k | General |
+    | `mistral-small-2603` | Mistral Small 4 | 256k | Reasoning, vision |
+    | `hermes-3-llama-3.1-405b` | Hermes 3 Llama 3.1 405B | 128k | Tools disabled |
+    | `openai-gpt-oss-120b` | OpenAI GPT OSS 120B | 128k | General |
+    | `kimi-k2-6` | Kimi K2.6 | 256k | Reasoning, vision |
+    | `kimi-k2-7-code` | Kimi K2.7 Code | 256k | Reasoning, vision, coding |
+    | `kimi-k2-5` | Kimi K2.5 | 256k | Default, reasoning, vision |
+    | `xiaomi-mimo-v2-5` | MiMo-V2.5 | 1M | Reasoning, vision |
+    | `deepseek-v3.2` | DeepSeek V3.2 | 160k | Reasoning, tools disabled |
+    | `llama-3.2-3b` | Llama 3.2 3B | 128k | General |
+    | `llama-3.3-70b` | Llama 3.3 70B | 128k | General |
+    | `minimax-m3-preview` | MiniMax M3 Preview | 524k | Reasoning |
+    | `minimax-m25` | MiniMax M2.5 | 198k | Reasoning |
+    | `minimax-m27` | MiniMax M2.7 | 198k | Reasoning |
+    | `nvidia-nemotron-3-nano-30b-a3b` | NVIDIA Nemotron 3 Nano 30B | 128k | General |
+    | `nvidia-nemotron-3-ultra-550b-a55b` | NVIDIA Nemotron 3 Ultra | 256k | Reasoning |
+    | `nvidia-nemotron-cascade-2-30b-a3b` | Nemotron Cascade 2 30B A3B | 256k | Reasoning |
   </Accordion>
 
-  <Accordion title="Anonymized models (12) — via Venice proxy">
-    | Model ID                        | Name                           | Context | Features                  |
-    | ------------------------------- | ------------------------------ | ------- | ------------------------- |
-    | `claude-opus-4-6`               | Claude Opus 4.6 (via Venice)   | 1M      | Reasoning, vision         |
-    | `claude-sonnet-4-6`             | Claude Sonnet 4.6 (via Venice) | 1M      | Reasoning, vision         |
-    | `openai-gpt-54`                 | GPT-5.4 (via Venice)           | 1M      | Reasoning, vision         |
-    | `openai-gpt-53-codex`           | GPT-5.3 Codex (via Venice)     | 400k    | Reasoning, vision, coding |
-    | `openai-gpt-52`                 | GPT-5.2 (via Venice)           | 256k    | Reasoning                 |
-    | `openai-gpt-52-codex`           | GPT-5.2 Codex (via Venice)     | 256k    | Reasoning, vision, coding |
-    | `openai-gpt-4o-2024-11-20`      | GPT-4o (via Venice)            | 128k    | Vision                    |
-    | `openai-gpt-4o-mini-2024-07-18` | GPT-4o Mini (via Venice)       | 128k    | Vision                    |
-    | `gemini-3-1-pro-preview`        | Gemini 3.1 Pro (via Venice)    | 1M      | Reasoning, vision         |
-    | `gemini-3-pro-preview`          | Gemini 3 Pro (via Venice)      | 198k    | Reasoning, vision         |
-    | `gemini-3-flash-preview`        | Gemini 3 Flash (via Venice)    | 256k    | Reasoning, vision         |
-    | `grok-41-fast`                  | Grok 4.1 Fast (via Venice)     | 1M      | Reasoning, vision         |
+  <Accordion title="Anonymized models (33) - via Venice proxy">
+    | Model ID | Name | Context | Features |
+    | --- | --- | --- | --- |
+    | `z-ai-glm-5-turbo` | GLM 5 Turbo | 200k | Reasoning |
+    | `z-ai-glm-5v-turbo` | GLM 5V Turbo | 200k | Reasoning, vision |
+    | `qwen-3-7-max` | Qwen 3.7 Max | 1M | Reasoning, vision |
+    | `qwen-3-7-plus` | Qwen 3.7 Plus | 1M | Reasoning, vision |
+    | `qwen-3-6-plus` | Qwen 3.6 Plus Uncensored | 1M | Reasoning, vision, uncensored |
+    | `qwen3-5-397b-a17b` | Qwen 3.5 397B | 128k | Reasoning, vision |
+    | `gemini-3-1-pro-preview` | Gemini 3.1 Pro (via Venice) | 1M | Reasoning, vision |
+    | `gemini-3-5-flash` | Gemini 3.5 Flash | 1M | Reasoning, vision |
+    | `gemini-3-flash-preview` | Gemini 3 Flash (via Venice) | 256k | Reasoning, vision |
+    | `claude-fable-5` | Claude Fable 5 | 1M | Reasoning, vision |
+    | `claude-opus-4-8` | Claude Opus 4.8 | 1M | Reasoning, vision |
+    | `claude-opus-4-8-fast` | Claude Opus 4.8 Fast | 1M | Reasoning, vision |
+    | `claude-opus-4-7` | Claude Opus 4.7 | 1M | Reasoning, vision |
+    | `claude-opus-4-7-fast` | Claude Opus 4.7 Fast | 1M | Reasoning, vision |
+    | `claude-opus-4-8` | Claude Opus 4.6 (via Venice) | 1M | Reasoning, vision |
+    | `claude-opus-4-6-fast` | Claude Opus 4.6 Fast | 1M | Reasoning, vision |
+    | `claude-opus-4-5` | Claude Opus 4.5 | 198k | Reasoning, vision |
+    | `claude-sonnet-4-6` | Claude Sonnet 4.6 (via Venice) | 1M | Reasoning, vision |
+    | `claude-sonnet-4-5` | Claude Sonnet 4.5 | 198k | Reasoning, vision |
+    | `deepseek-v4-pro` | DeepSeek V4 Pro | 1M | Reasoning |
+    | `deepseek-v4-flash` | DeepSeek V4 Flash | 1M | Reasoning |
+    | `aion-labs-aion-2-0` | Aion 2.0 | 128k | Reasoning, tools disabled |
+    | `openai-gpt-52` | GPT-5.2 (via Venice) | 256k | Reasoning |
+    | `openai-gpt-52-codex` | GPT-5.2 Codex (via Venice) | 256k | Reasoning, vision, coding |
+    | `openai-gpt-53-codex` | GPT-5.3 Codex (via Venice) | 400k | Reasoning, vision, coding |
+    | `openai-gpt-54` | GPT-5.4 (via Venice) | 1M | Reasoning, vision |
+    | `openai-gpt-54-pro` | GPT-5.4 Pro | 1M | Reasoning, vision |
+    | `openai-gpt-54-mini` | GPT-5.4 Mini | 400k | Reasoning, vision |
+    | `openai-gpt-55` | GPT-5.5 | 1M | Reasoning, vision |
+    | `openai-gpt-55-pro` | GPT-5.5 Pro | 1M | Reasoning, vision |
+    | `openai-gpt-4o-2024-11-20` | GPT-4o (via Venice) | 128k | Vision |
+    | `openai-gpt-4o-mini-2024-07-18` | GPT-4o Mini (via Venice) | 128k | Vision |
+    | `mercury-2` | Mercury 2 | 128k | Reasoning |
   </Accordion>
 </AccordionGroup>
 
@@ -222,16 +286,16 @@ Venice uses a credit-based system. Check [venice.ai/pricing](https://venice.ai/p
 openclaw agent --model venice/kimi-k2-5 --message "Quick health check"
 
 # Use Claude Opus via Venice (anonymized)
-openclaw agent --model venice/claude-opus-4-6 --message "Summarize this task"
+openclaw agent --model venice/claude-opus-4-8 --message "Summarize this task"
 
 # Use uncensored model
-openclaw agent --model venice/venice-uncensored --message "Draft options"
+openclaw agent --model venice/venice-uncensored-1-2 --message "Draft options"
 
 # Use vision model with image
 openclaw agent --model venice/qwen3-vl-235b-a22b --message "Review attached image"
 
 # Use coding model
-openclaw agent --model venice/qwen3-coder-480b-a35b-instruct --message "Refactor this function"
+openclaw agent --model venice/qwen3-coder-480b-a35b-instruct-turbo --message "Refactor this function"
 ```
 
 ## Troubleshooting

--- a/docs/tools/image-generation.md
+++ b/docs/tools/image-generation.md
@@ -1,5 +1,5 @@
 ---
-summary: "Generate and edit images via image_generate across OpenAI, Google, fal, MiniMax, ComfyUI, DeepInfra, OpenRouter, LiteLLM, xAI, Vydra"
+summary: "Generate and edit images via image_generate across OpenAI, Google, fal, MiniMax, ComfyUI, DeepInfra, OpenRouter, LiteLLM, Venice, xAI, Vydra"
 read_when:
   - Generating or editing images via the agent
   - Configuring image-generation providers and models
@@ -103,6 +103,7 @@ backend emits it.
 | MiniMax    | `image-01`                              | Yes (subject reference)            | `MINIMAX_API_KEY` or MiniMax OAuth (`minimax-portal`) |
 | OpenAI     | `gpt-image-2`                           | Yes (up to 4 images)               | `OPENAI_API_KEY` or OpenAI Codex OAuth                |
 | OpenRouter | `google/gemini-3.1-flash-image-preview` | Yes (up to 5 input images)         | `OPENROUTER_API_KEY`                                  |
+| Venice     | `venice-sd35`                           | No                                 | `VENICE_API_KEY`                                      |
 | Vydra      | `grok-imagine`                          | No                                 | `VYDRA_API_KEY`                                       |
 | xAI        | `grok-imagine-image`                    | Yes (up to 5 images)               | `XAI_API_KEY`                                         |
 
@@ -121,13 +122,13 @@ current session:
 
 ## Provider capabilities
 
-| Capability            | ComfyUI            | DeepInfra | fal                       | Google         | MiniMax               | OpenAI         | Vydra | xAI            |
-| --------------------- | ------------------ | --------- | ------------------------- | -------------- | --------------------- | -------------- | ----- | -------------- |
-| Generate (max count)  | Workflow-defined   | 4         | 4                         | 4              | 9                     | 4              | 1     | 4              |
-| Edit / reference      | 1 image (workflow) | 1 image   | Flux: 1; GPT: 10; NB2: 14 | Up to 5 images | 1 image (subject ref) | Up to 5 images | -     | Up to 5 images |
-| Size control          | -                  | ✓         | ✓                         | ✓              | -                     | Up to 4K       | -     | -              |
-| Aspect ratio          | -                  | -         | ✓                         | ✓              | ✓                     | -              | -     | ✓              |
-| Resolution (1K/2K/4K) | -                  | -         | ✓                         | ✓              | -                     | -              | -     | 1K, 2K         |
+| Capability            | ComfyUI            | DeepInfra | fal                       | Google         | MiniMax               | OpenAI         | Venice       | Vydra | xAI            |
+| --------------------- | ------------------ | --------- | ------------------------- | -------------- | --------------------- | -------------- | ------------ | ----- | -------------- |
+| Generate (max count)  | Workflow-defined   | 4         | 4                         | 4              | 9                     | 4              | 4            | 1     | 4              |
+| Edit / reference      | 1 image (workflow) | 1 image   | Flux: 1; GPT: 10; NB2: 14 | Up to 5 images | 1 image (subject ref) | Up to 5 images | -            | -     | Up to 5 images |
+| Size control          | -                  | ✓         | ✓                         | ✓              | -                     | Up to 4K       | Up to 1280px | -     | -              |
+| Aspect ratio          | -                  | -         | ✓                         | ✓              | ✓                     | -              | ✓            | -     | ✓              |
+| Resolution (1K/2K/4K) | -                  | -         | ✓                         | ✓              | -                     | -              | 1K, 2K, 4K   | -     | 1K, 2K         |
 
 ## Tool parameters
 

--- a/extensions/venice/image-generation-provider.test.ts
+++ b/extensions/venice/image-generation-provider.test.ts
@@ -1,0 +1,123 @@
+import * as providerAuth from "openclaw/plugin-sdk/provider-auth-runtime";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fetchWithSsrFGuardMock } = vi.hoisted(() => ({
+  fetchWithSsrFGuardMock: vi.fn(),
+}));
+
+import {
+  buildVeniceImageGenerationProvider,
+  setVeniceImageFetchGuardForTesting,
+} from "./image-generation-provider.js";
+
+// 1x1 transparent PNG.
+const PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
+
+function lastRequest() {
+  const request = fetchWithSsrFGuardMock.mock.calls.at(-1)?.[0];
+  if (!request) {
+    throw new Error("expected a venice fetch request");
+  }
+  return request;
+}
+
+describe("venice image-generation provider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
+      apiKey: "venice-test-key",
+      source: "env",
+      mode: "api-key",
+    });
+    setVeniceImageFetchGuardForTesting(fetchWithSsrFGuardMock);
+  });
+
+  afterEach(() => {
+    setVeniceImageFetchGuardForTesting(null);
+    vi.restoreAllMocks();
+  });
+
+  function mockImageResponse(): void {
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: new Response(JSON.stringify({ id: "img-1", images: [PNG_BASE64] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+      release: vi.fn(async () => {}),
+    });
+  }
+
+  it("posts to the venice image endpoint and decodes base64 images", async () => {
+    mockImageResponse();
+    const provider = buildVeniceImageGenerationProvider();
+    const result = await provider.generateImage({
+      provider: "venice",
+      model: "lustify-v8",
+      prompt: "a serene mountain lake",
+      cfg: {} as never,
+      aspectRatio: "16:9",
+      count: 2,
+    });
+
+    const request = lastRequest();
+    expect(request.url).toBe("https://api.venice.ai/api/v1/image/generate");
+    expect(request.auditContext).toBe("venice-image-generate");
+    expect(request.policy).toEqual({ allowedHostnames: ["api.venice.ai"] });
+    expect(request.init?.method).toBe("POST");
+    expect(new Headers(request.init?.headers).get("authorization")).toBe("Bearer venice-test-key");
+
+    const body = JSON.parse(String(request.init?.body));
+    expect(body).toMatchObject({
+      model: "lustify-v8",
+      prompt: "a serene mountain lake",
+      aspect_ratio: "16:9",
+      variants: 2,
+      return_binary: false,
+      // Uncensored-by-default: the Venice plugin disables safe_mode.
+      safe_mode: false,
+    });
+    expect(body.width).toBeUndefined();
+
+    expect(result.model).toBe("lustify-v8");
+    expect(result.images).toHaveLength(1);
+    expect(result.images[0]?.mimeType).toBe("image/png");
+    expect(result.images[0]?.buffer.length).toBeGreaterThan(0);
+  });
+
+  it("maps an explicit size to clamped width/height and defaults the model", async () => {
+    mockImageResponse();
+    const provider = buildVeniceImageGenerationProvider();
+    await provider.generateImage({
+      provider: "venice",
+      prompt: "test",
+      cfg: {} as never,
+      size: "2048x768",
+    });
+
+    const body = JSON.parse(String(lastRequest().init?.body));
+    expect(body.model).toBe(provider.defaultModel);
+    expect(body.width).toBe(1280); // clamped to Venice max edge
+    expect(body.height).toBe(768);
+    expect(body.aspect_ratio).toBeUndefined();
+    expect(body.variants).toBe(1);
+  });
+
+  it("throws on a malformed response", async () => {
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: new Response(JSON.stringify({ images: "nope" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+      release: vi.fn(async () => {}),
+    });
+    const provider = buildVeniceImageGenerationProvider();
+    await expect(
+      provider.generateImage({
+        provider: "venice",
+        prompt: "test",
+        cfg: {} as never,
+      }),
+    ).rejects.toThrow(/malformed/);
+  });
+});

--- a/extensions/venice/image-generation-provider.ts
+++ b/extensions/venice/image-generation-provider.ts
@@ -1,0 +1,186 @@
+import type {
+  GeneratedImageAsset,
+  ImageGenerationOutputFormat,
+  ImageGenerationProvider,
+} from "openclaw/plugin-sdk/image-generation";
+import { generatedImageAssetFromBase64 } from "openclaw/plugin-sdk/image-generation";
+import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
+import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
+import { assertOkOrThrowHttpError } from "openclaw/plugin-sdk/provider-http";
+import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
+import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { VENICE_BASE_URL } from "./models.js";
+
+const PROVIDER_ID = "venice";
+// Venice's native default text-to-image model (model_spec trait "eliza-default").
+const DEFAULT_VENICE_IMAGE_MODEL = "venice-sd35";
+const DEFAULT_OUTPUT_FORMAT: ImageGenerationOutputFormat = "png";
+// Venice caps pixel-addressed models at 1280px per edge.
+const VENICE_MAX_EDGE = 1280;
+const VENICE_IMAGE_ALLOWED_HOSTNAMES = ["api.venice.ai"];
+const VENICE_IMAGE_MALFORMED_RESPONSE = "venice image generation response malformed";
+
+// Advisory hint list for callers; any Venice image model id is accepted.
+const VENICE_IMAGE_MODELS = [
+  "venice-sd35",
+  "flux-2-pro",
+  "flux-2-max",
+  "seedream-v5-lite",
+  "nano-banana-pro",
+  "qwen-image-2",
+  "hunyuan-image-v3",
+  "lustify-v8",
+  "lustify-sdxl",
+];
+const VENICE_SUPPORTED_SIZES = ["1024x1024", "1280x720", "720x1280", "1280x768", "768x1280"];
+const VENICE_SUPPORTED_ASPECT_RATIOS = ["1:1", "3:2", "2:3", "16:9", "9:16", "21:9", "3:4", "4:5"];
+const VENICE_OUTPUT_FORMATS: ImageGenerationOutputFormat[] = ["png", "jpeg", "webp"];
+
+let veniceImageFetchGuard = fetchWithSsrFGuard;
+
+export function setVeniceImageFetchGuardForTesting(impl: typeof fetchWithSsrFGuard | null): void {
+  veniceImageFetchGuard = impl ?? fetchWithSsrFGuard;
+}
+
+function clampEdge(value: number): number {
+  return Math.max(1, Math.min(VENICE_MAX_EDGE, Math.floor(value)));
+}
+
+function parseSize(raw: string | undefined): { width: number; height: number } | null {
+  const match = /^(\d{2,5})x(\d{2,5})$/iu.exec(raw?.trim() ?? "");
+  if (!match) {
+    return null;
+  }
+  const width = Number.parseInt(match[1] ?? "", 10);
+  const height = Number.parseInt(match[2] ?? "", 10);
+  if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+    return null;
+  }
+  return { width: clampEdge(width), height: clampEdge(height) };
+}
+
+// Venice models accept either width/height (pixel models) OR aspect_ratio,
+// optionally with a resolution tier. Send the most specific signal the caller
+// gave and let Venice apply each model's own defaults for the rest.
+function applyGeometry(
+  body: Record<string, unknown>,
+  req: { size?: string; aspectRatio?: string; resolution?: string },
+): void {
+  const size = parseSize(req.size);
+  if (size) {
+    body.width = size.width;
+    body.height = size.height;
+    return;
+  }
+  if (req.aspectRatio?.trim()) {
+    body.aspect_ratio = req.aspectRatio.trim();
+  }
+  if (req.resolution) {
+    body.resolution = req.resolution;
+  }
+}
+
+function parseVeniceImageResponse(payload: unknown): string[] {
+  if (!isRecord(payload) || !Array.isArray(payload.images)) {
+    throw new Error(VENICE_IMAGE_MALFORMED_RESPONSE);
+  }
+  const images: string[] = [];
+  for (const entry of payload.images) {
+    if (typeof entry !== "string" || entry.length === 0) {
+      throw new Error(VENICE_IMAGE_MALFORMED_RESPONSE);
+    }
+    images.push(entry);
+  }
+  return images;
+}
+
+export function buildVeniceImageGenerationProvider(): ImageGenerationProvider {
+  return {
+    id: PROVIDER_ID,
+    label: "Venice",
+    defaultModel: DEFAULT_VENICE_IMAGE_MODEL,
+    models: VENICE_IMAGE_MODELS,
+    isConfigured: ({ agentDir }) => isProviderApiKeyConfigured({ provider: PROVIDER_ID, agentDir }),
+    capabilities: {
+      generate: {
+        maxCount: 4,
+        supportsSize: true,
+        supportsAspectRatio: true,
+        supportsResolution: true,
+      },
+      // Venice /image/generate is text-to-image only; edit/inpaint is a separate
+      // endpoint not wired here.
+      edit: { enabled: false },
+      geometry: {
+        sizes: [...VENICE_SUPPORTED_SIZES],
+        aspectRatios: [...VENICE_SUPPORTED_ASPECT_RATIOS],
+        resolutions: ["1K", "2K", "4K"],
+      },
+      output: {
+        formats: [...VENICE_OUTPUT_FORMATS],
+      },
+    },
+    async generateImage(req) {
+      const auth = await resolveApiKeyForProvider({
+        provider: PROVIDER_ID,
+        cfg: req.cfg,
+        agentDir: req.agentDir,
+        store: req.authStore,
+      });
+      if (!auth.apiKey) {
+        throw new Error("venice API key missing");
+      }
+
+      const model = req.model?.trim() || DEFAULT_VENICE_IMAGE_MODEL;
+      const format = req.outputFormat ?? DEFAULT_OUTPUT_FORMAT;
+      const requestBody: Record<string, unknown> = {
+        model,
+        prompt: req.prompt,
+        format,
+        return_binary: false,
+        // The Venice plugin exists to serve uncensored models; Venice's own
+        // safe_mode default (true) would filter exactly those outputs.
+        safe_mode: false,
+        variants: Math.max(1, Math.min(4, req.count ?? 1)),
+      };
+      applyGeometry(requestBody, req);
+
+      const { response, release } = await veniceImageFetchGuard({
+        url: `${VENICE_BASE_URL}/image/generate`,
+        init: {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${auth.apiKey}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(requestBody),
+        },
+        timeoutMs: req.timeoutMs,
+        policy: { allowedHostnames: VENICE_IMAGE_ALLOWED_HOSTNAMES },
+        auditContext: "venice-image-generate",
+      });
+      try {
+        await assertOkOrThrowHttpError(response, "venice image generation failed");
+        const base64Images = parseVeniceImageResponse(await response.json());
+        const images: GeneratedImageAsset[] = [];
+        base64Images.forEach((base64, index) => {
+          const asset = generatedImageAssetFromBase64({
+            base64,
+            index,
+            defaultMimeType: `image/${format === "jpeg" ? "jpeg" : format}`,
+            sniffMimeType: true,
+          });
+          if (asset) {
+            images.push(asset);
+          }
+        });
+        if (images.length === 0) {
+          throw new Error("venice image generation response missing image data");
+        }
+        return { images, model };
+      } finally {
+        await release();
+      }
+    },
+  };
+}

--- a/extensions/venice/index.ts
+++ b/extensions/venice/index.ts
@@ -4,6 +4,7 @@ import {
   type ModelCompatConfig,
 } from "openclaw/plugin-sdk/provider-model-shared";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { buildVeniceImageGenerationProvider } from "./image-generation-provider.js";
 import { applyVeniceConfig, VENICE_DEFAULT_MODEL_REF } from "./onboard.js";
 import { buildVeniceProvider } from "./provider-catalog.js";
 import { createVeniceDeepSeekV4Wrapper } from "./stream.js";
@@ -66,5 +67,8 @@ export default defineSingleProviderPluginEntry({
     normalizeResolvedModel: ({ modelId, model }) =>
       isXaiBackedVeniceModel(modelId) ? applyXaiModelCompat(model) : undefined,
     wrapStreamFn: (ctx) => createVeniceDeepSeekV4Wrapper(ctx.streamFn, ctx.thinkingLevel),
+  },
+  register(api) {
+    api.registerImageGenerationProvider(buildVeniceImageGenerationProvider());
   },
 });

--- a/extensions/venice/openclaw.plugin.json
+++ b/extensions/venice/openclaw.plugin.json
@@ -40,6 +40,11 @@
       }
     ]
   },
+  "contracts": {
+    "imageGenerationProviders": [
+      "venice"
+    ]
+  },
   "modelCatalog": {
     "providers": {
       "venice": {

--- a/extensions/venice/openclaw.plugin.json
+++ b/extensions/venice/openclaw.plugin.json
@@ -4,7 +4,9 @@
     "onStartup": false
   },
   "enabledByDefault": true,
-  "providers": ["venice"],
+  "providers": [
+    "venice"
+  ],
   "providerAuthChoices": [
     {
       "provider": "venice",
@@ -29,8 +31,12 @@
     "providers": [
       {
         "id": "venice",
-        "authMethods": ["api-key"],
-        "envVars": ["VENICE_API_KEY"]
+        "authMethods": [
+          "api-key"
+        ],
+        "envVars": [
+          "VENICE_API_KEY"
+        ]
       }
     ]
   },
@@ -41,191 +47,56 @@
         "api": "openai-completions",
         "models": [
           {
-            "id": "llama-3.3-70b",
-            "name": "Llama 3.3 70B",
-            "reasoning": false,
-            "input": ["text"],
-            "contextWindow": 128000,
-            "maxTokens": 4096,
-            "compat": {
-              "supportsUsageInStreaming": false
-            }
-          },
-          {
-            "id": "llama-3.2-3b",
-            "name": "Llama 3.2 3B",
-            "reasoning": false,
-            "input": ["text"],
-            "contextWindow": 128000,
-            "maxTokens": 4096,
-            "compat": {
-              "supportsUsageInStreaming": false
-            }
-          },
-          {
-            "id": "hermes-3-llama-3.1-405b",
-            "name": "Hermes 3 Llama 3.1 405B",
-            "reasoning": false,
-            "input": ["text"],
-            "contextWindow": 128000,
-            "maxTokens": 16384,
-            "compat": {
-              "supportsUsageInStreaming": false,
-              "supportsTools": false
-            }
-          },
-          {
-            "id": "qwen3-235b-a22b-thinking-2507",
-            "name": "Qwen3 235B Thinking",
+            "id": "zai-org-glm-5-2",
+            "name": "GLM 5.2",
             "reasoning": true,
             "input": ["text"],
-            "contextWindow": 128000,
-            "maxTokens": 16384,
+            "contextWindow": 1000000,
+            "maxTokens": 131072,
             "compat": {
               "supportsUsageInStreaming": false
             }
           },
           {
-            "id": "qwen3-235b-a22b-instruct-2507",
-            "name": "Qwen3 235B Instruct",
-            "reasoning": false,
-            "input": ["text"],
-            "contextWindow": 128000,
-            "maxTokens": 16384,
-            "compat": {
-              "supportsUsageInStreaming": false
-            }
-          },
-          {
-            "id": "qwen3-coder-480b-a35b-instruct",
-            "name": "Qwen3 Coder 480B",
-            "reasoning": false,
-            "input": ["text"],
-            "contextWindow": 256000,
-            "maxTokens": 65536,
-            "compat": {
-              "supportsUsageInStreaming": false
-            }
-          },
-          {
-            "id": "qwen3-coder-480b-a35b-instruct-turbo",
-            "name": "Qwen3 Coder 480B Turbo",
-            "reasoning": false,
-            "input": ["text"],
-            "contextWindow": 256000,
-            "maxTokens": 65536,
-            "compat": {
-              "supportsUsageInStreaming": false
-            }
-          },
-          {
-            "id": "qwen3-5-35b-a3b",
-            "name": "Qwen3.5 35B A3B",
-            "reasoning": true,
-            "input": ["text", "image"],
-            "contextWindow": 256000,
-            "maxTokens": 65536,
-            "compat": {
-              "supportsUsageInStreaming": false
-            }
-          },
-          {
-            "id": "qwen3-next-80b",
-            "name": "Qwen3 Next 80B",
-            "reasoning": false,
-            "input": ["text"],
-            "contextWindow": 256000,
-            "maxTokens": 16384,
-            "compat": {
-              "supportsUsageInStreaming": false
-            }
-          },
-          {
-            "id": "qwen3-vl-235b-a22b",
-            "name": "Qwen3 VL 235B (Vision)",
-            "reasoning": false,
-            "input": ["text", "image"],
-            "contextWindow": 256000,
-            "maxTokens": 16384,
-            "compat": {
-              "supportsUsageInStreaming": false
-            }
-          },
-          {
-            "id": "qwen3-4b",
-            "name": "Venice Small (Qwen3 4B)",
+            "id": "zai-org-glm-5-1",
+            "name": "GLM 5.1",
             "reasoning": true,
             "input": ["text"],
-            "contextWindow": 32000,
-            "maxTokens": 4096,
+            "contextWindow": 200000,
+            "maxTokens": 24000,
             "compat": {
               "supportsUsageInStreaming": false
             }
           },
           {
-            "id": "deepseek-v3.2",
-            "name": "DeepSeek V3.2",
+            "id": "zai-org-glm-5",
+            "name": "GLM 5",
             "reasoning": true,
             "input": ["text"],
-            "contextWindow": 160000,
+            "contextWindow": 198000,
+            "maxTokens": 32000,
+            "compat": {
+              "supportsUsageInStreaming": false
+            }
+          },
+          {
+            "id": "z-ai-glm-5-turbo",
+            "name": "GLM 5 Turbo",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 200000,
             "maxTokens": 32768,
             "compat": {
-              "supportsUsageInStreaming": false,
-              "supportsTools": false
+              "supportsUsageInStreaming": false
             }
           },
           {
-            "id": "venice-uncensored",
-            "name": "Venice Uncensored (Dolphin-Mistral)",
-            "reasoning": false,
-            "input": ["text"],
-            "contextWindow": 32000,
-            "maxTokens": 4096,
-            "compat": {
-              "supportsUsageInStreaming": false,
-              "supportsTools": false
-            }
-          },
-          {
-            "id": "mistral-31-24b",
-            "name": "Venice Medium (Mistral)",
-            "reasoning": false,
+            "id": "z-ai-glm-5v-turbo",
+            "name": "GLM 5V Turbo",
+            "reasoning": true,
             "input": ["text", "image"],
-            "contextWindow": 128000,
-            "maxTokens": 4096,
-            "compat": {
-              "supportsUsageInStreaming": false
-            }
-          },
-          {
-            "id": "google-gemma-3-27b-it",
-            "name": "Google Gemma 3 27B Instruct",
-            "reasoning": false,
-            "input": ["text", "image"],
-            "contextWindow": 198000,
-            "maxTokens": 16384,
-            "compat": {
-              "supportsUsageInStreaming": false
-            }
-          },
-          {
-            "id": "openai-gpt-oss-120b",
-            "name": "OpenAI GPT OSS 120B",
-            "reasoning": false,
-            "input": ["text"],
-            "contextWindow": 128000,
-            "maxTokens": 16384,
-            "compat": {
-              "supportsUsageInStreaming": false
-            }
-          },
-          {
-            "id": "nvidia-nemotron-3-nano-30b-a3b",
-            "name": "NVIDIA Nemotron 3 Nano 30B",
-            "reasoning": false,
-            "input": ["text"],
-            "contextWindow": 128000,
-            "maxTokens": 16384,
+            "contextWindow": 200000,
+            "maxTokens": 32768,
             "compat": {
               "supportsUsageInStreaming": false
             }
@@ -237,6 +108,17 @@
             "input": ["text"],
             "contextWindow": 128000,
             "maxTokens": 24000,
+            "compat": {
+              "supportsUsageInStreaming": false
+            }
+          },
+          {
+            "id": "zai-org-glm-4.7-flash",
+            "name": "GLM 4.7 Flash",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 128000,
+            "maxTokens": 16384,
             "compat": {
               "supportsUsageInStreaming": false
             }
@@ -264,30 +146,63 @@
             }
           },
           {
-            "id": "zai-org-glm-4.7-flash",
-            "name": "GLM 4.7 Flash",
-            "reasoning": true,
-            "input": ["text"],
+            "id": "venice-uncensored-1-2",
+            "name": "Venice Uncensored 1.2",
+            "reasoning": false,
+            "input": ["text", "image"],
             "contextWindow": 128000,
-            "maxTokens": 16384,
+            "maxTokens": 8192,
             "compat": {
               "supportsUsageInStreaming": false
             }
           },
           {
-            "id": "zai-org-glm-5",
-            "name": "GLM 5",
+            "id": "venice-uncensored-role-play",
+            "name": "Venice Role Play Uncensored",
+            "reasoning": false,
+            "input": ["text", "image"],
+            "contextWindow": 128000,
+            "maxTokens": 4096,
+            "compat": {
+              "supportsUsageInStreaming": false
+            }
+          },
+          {
+            "id": "qwen-3-7-max",
+            "name": "Qwen 3.7 Max",
             "reasoning": true,
-            "input": ["text"],
-            "contextWindow": 198000,
-            "maxTokens": 32000,
+            "input": ["text", "image"],
+            "contextWindow": 1000000,
+            "maxTokens": 65536,
             "compat": {
               "supportsUsageInStreaming": false
             }
           },
           {
-            "id": "kimi-k2-5",
-            "name": "Kimi K2.5",
+            "id": "qwen-3-7-plus",
+            "name": "Qwen 3.7 Plus",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 1000000,
+            "maxTokens": 65536,
+            "compat": {
+              "supportsUsageInStreaming": false
+            }
+          },
+          {
+            "id": "qwen-3-6-plus",
+            "name": "Qwen 3.6 Plus Uncensored",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 1000000,
+            "maxTokens": 65536,
+            "compat": {
+              "supportsUsageInStreaming": false
+            }
+          },
+          {
+            "id": "qwen3-6-27b",
+            "name": "Qwen 3.6 27B",
             "reasoning": true,
             "input": ["text", "image"],
             "contextWindow": 256000,
@@ -297,8 +212,140 @@
             }
           },
           {
-            "id": "kimi-k2-thinking",
-            "name": "Kimi K2 Thinking",
+            "id": "qwen3-5-9b",
+            "name": "Qwen 3.5 9B",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 256000,
+            "maxTokens": 32768,
+            "compat": {
+              "supportsUsageInStreaming": false
+            }
+          },
+          {
+            "id": "qwen3-5-397b-a17b",
+            "name": "Qwen 3.5 397B",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 128000,
+            "maxTokens": 32768,
+            "compat": {
+              "supportsUsageInStreaming": false
+            }
+          },
+          {
+            "id": "qwen3-5-35b-a3b",
+            "name": "Qwen3.5 35B A3B",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 256000,
+            "maxTokens": 65536,
+            "compat": {
+              "supportsUsageInStreaming": false
+            }
+          },
+          {
+            "id": "qwen3-235b-a22b-thinking-2507",
+            "name": "Qwen3 235B Thinking",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 128000,
+            "maxTokens": 16384,
+            "compat": {
+              "supportsUsageInStreaming": false
+            }
+          },
+          {
+            "id": "qwen3-235b-a22b-instruct-2507",
+            "name": "Qwen3 235B Instruct",
+            "reasoning": false,
+            "input": ["text"],
+            "contextWindow": 128000,
+            "maxTokens": 16384,
+            "compat": {
+              "supportsUsageInStreaming": false
+            }
+          },
+          {
+            "id": "qwen3-next-80b",
+            "name": "Qwen3 Next 80B",
+            "reasoning": false,
+            "input": ["text"],
+            "contextWindow": 256000,
+            "maxTokens": 16384,
+            "compat": {
+              "supportsUsageInStreaming": false
+            }
+          },
+          {
+            "id": "qwen3-vl-235b-a22b",
+            "name": "Qwen3 VL 235B (Vision)",
+            "reasoning": false,
+            "input": ["text", "image"],
+            "contextWindow": 256000,
+            "maxTokens": 16384,
+            "compat": {
+              "supportsUsageInStreaming": false
+            }
+          },
+          {
+            "id": "qwen3-coder-480b-a35b-instruct-turbo",
+            "name": "Qwen3 Coder 480B Turbo",
+            "reasoning": false,
+            "input": ["text"],
+            "contextWindow": 256000,
+            "maxTokens": 65536,
+            "compat": {
+              "supportsUsageInStreaming": false
+            }
+          },
+          {
+            "id": "google-gemma-4-26b-a4b-it",
+            "name": "Google Gemma 4 26B A4B Instruct",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 256000,
+            "maxTokens": 8192,
+            "compat": {
+              "supportsUsageInStreaming": false
+            }
+          },
+          {
+            "id": "google-gemma-4-31b-it",
+            "name": "Google Gemma 4 31B Instruct",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 256000,
+            "maxTokens": 8192,
+            "compat": {
+              "supportsUsageInStreaming": false
+            }
+          },
+          {
+            "id": "gemma-4-uncensored",
+            "name": "Gemma 4 Uncensored",
+            "reasoning": false,
+            "input": ["text", "image"],
+            "contextWindow": 256000,
+            "maxTokens": 8192,
+            "compat": {
+              "supportsUsageInStreaming": false
+            }
+          },
+          {
+            "id": "google-gemma-3-27b-it",
+            "name": "Google Gemma 3 27B Instruct",
+            "reasoning": false,
+            "input": ["text", "image"],
+            "contextWindow": 198000,
+            "maxTokens": 16384,
+            "compat": {
+              "supportsUsageInStreaming": false
+            }
+          },
+          {
+            "id": "arcee-trinity-large-thinking",
+            "name": "Trinity Large Thinking",
             "reasoning": true,
             "input": ["text"],
             "contextWindow": 256000,
@@ -308,23 +355,168 @@
             }
           },
           {
-            "id": "minimax-m21",
-            "name": "MiniMax M2.1",
+            "id": "grok-4-3",
+            "name": "Grok 4.3",
             "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 1000000,
+            "maxTokens": 32000,
+            "compat": {
+              "supportsUsageInStreaming": false
+            }
+          },
+          {
+            "id": "grok-4-20",
+            "name": "Grok 4.20",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 2000000,
+            "maxTokens": 128000,
+            "compat": {
+              "supportsUsageInStreaming": false
+            }
+          },
+          {
+            "id": "grok-4-20-multi-agent",
+            "name": "Grok 4.20 Multi-Agent",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 2000000,
+            "maxTokens": 128000,
+            "compat": {
+              "supportsUsageInStreaming": false,
+              "supportsTools": false
+            }
+          },
+          {
+            "id": "grok-build-0-1",
+            "name": "Grok Build 0.1",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 256000,
+            "maxTokens": 65536,
+            "compat": {
+              "supportsUsageInStreaming": false
+            }
+          },
+          {
+            "id": "mistral-small-3-2-24b-instruct",
+            "name": "Mistral Small 3.2 24B Instruct",
+            "reasoning": false,
             "input": ["text"],
-            "contextWindow": 198000,
+            "contextWindow": 256000,
+            "maxTokens": 16384,
+            "compat": {
+              "supportsUsageInStreaming": false
+            }
+          },
+          {
+            "id": "mistral-small-2603",
+            "name": "Mistral Small 4",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 256000,
+            "maxTokens": 65536,
+            "compat": {
+              "supportsUsageInStreaming": false
+            }
+          },
+          {
+            "id": "hermes-3-llama-3.1-405b",
+            "name": "Hermes 3 Llama 3.1 405B",
+            "reasoning": false,
+            "input": ["text"],
+            "contextWindow": 128000,
+            "maxTokens": 16384,
+            "compat": {
+              "supportsUsageInStreaming": false,
+              "supportsTools": false
+            }
+          },
+          {
+            "id": "gemini-3-1-pro-preview",
+            "name": "Gemini 3.1 Pro (via Venice)",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 1000000,
             "maxTokens": 32768,
             "compat": {
               "supportsUsageInStreaming": false
             }
           },
           {
-            "id": "minimax-m25",
-            "name": "MiniMax M2.5",
+            "id": "gemini-3-5-flash",
+            "name": "Gemini 3.5 Flash",
             "reasoning": true,
-            "input": ["text"],
-            "contextWindow": 198000,
-            "maxTokens": 32768,
+            "input": ["text", "image"],
+            "contextWindow": 1000000,
+            "maxTokens": 65536,
+            "compat": {
+              "supportsUsageInStreaming": false
+            }
+          },
+          {
+            "id": "gemini-3-flash-preview",
+            "name": "Gemini 3 Flash (via Venice)",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 256000,
+            "maxTokens": 65536,
+            "compat": {
+              "supportsUsageInStreaming": false
+            }
+          },
+          {
+            "id": "claude-fable-5",
+            "name": "Claude Fable 5",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 1000000,
+            "maxTokens": 128000,
+            "compat": {
+              "supportsUsageInStreaming": false
+            }
+          },
+          {
+            "id": "claude-opus-4-8",
+            "name": "Claude Opus 4.8",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 1000000,
+            "maxTokens": 128000,
+            "compat": {
+              "supportsUsageInStreaming": false
+            }
+          },
+          {
+            "id": "claude-opus-4-8-fast",
+            "name": "Claude Opus 4.8 Fast",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 1000000,
+            "maxTokens": 128000,
+            "compat": {
+              "supportsUsageInStreaming": false
+            }
+          },
+          {
+            "id": "claude-opus-4-7",
+            "name": "Claude Opus 4.7",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 1000000,
+            "maxTokens": 128000,
+            "compat": {
+              "supportsUsageInStreaming": false
+            }
+          },
+          {
+            "id": "claude-opus-4-7-fast",
+            "name": "Claude Opus 4.7 Fast",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 1000000,
+            "maxTokens": 128000,
             "compat": {
               "supportsUsageInStreaming": false
             }
@@ -341,12 +533,168 @@
             }
           },
           {
+            "id": "claude-opus-4-6-fast",
+            "name": "Claude Opus 4.6 Fast",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 1000000,
+            "maxTokens": 128000,
+            "compat": {
+              "supportsUsageInStreaming": false
+            }
+          },
+          {
+            "id": "claude-opus-4-5",
+            "name": "Claude Opus 4.5",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 198000,
+            "maxTokens": 32768,
+            "compat": {
+              "supportsUsageInStreaming": false
+            }
+          },
+          {
             "id": "claude-sonnet-4-6",
             "name": "Claude Sonnet 4.6 (via Venice)",
             "reasoning": true,
             "input": ["text", "image"],
             "contextWindow": 1000000,
             "maxTokens": 64000,
+            "compat": {
+              "supportsUsageInStreaming": false
+            }
+          },
+          {
+            "id": "claude-sonnet-4-5",
+            "name": "Claude Sonnet 4.5",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 198000,
+            "maxTokens": 64000,
+            "compat": {
+              "supportsUsageInStreaming": false
+            }
+          },
+          {
+            "id": "openai-gpt-oss-120b",
+            "name": "OpenAI GPT OSS 120B",
+            "reasoning": false,
+            "input": ["text"],
+            "contextWindow": 128000,
+            "maxTokens": 16384,
+            "compat": {
+              "supportsUsageInStreaming": false
+            }
+          },
+          {
+            "id": "kimi-k2-6",
+            "name": "Kimi K2.6",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 256000,
+            "maxTokens": 65536,
+            "compat": {
+              "supportsUsageInStreaming": false
+            }
+          },
+          {
+            "id": "kimi-k2-7-code",
+            "name": "Kimi K2.7 Code",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 256000,
+            "maxTokens": 65536,
+            "compat": {
+              "supportsUsageInStreaming": false
+            }
+          },
+          {
+            "id": "kimi-k2-5",
+            "name": "Kimi K2.5",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 256000,
+            "maxTokens": 65536,
+            "compat": {
+              "supportsUsageInStreaming": false
+            }
+          },
+          {
+            "id": "xiaomi-mimo-v2-5",
+            "name": "MiMo-V2.5",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 1000000,
+            "maxTokens": 65536,
+            "compat": {
+              "supportsUsageInStreaming": false
+            }
+          },
+          {
+            "id": "deepseek-v4-pro",
+            "name": "DeepSeek V4 Pro",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 1000000,
+            "maxTokens": 32768,
+            "compat": {
+              "supportsUsageInStreaming": false
+            }
+          },
+          {
+            "id": "deepseek-v4-flash",
+            "name": "DeepSeek V4 Flash",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 1000000,
+            "maxTokens": 32768,
+            "compat": {
+              "supportsUsageInStreaming": false
+            }
+          },
+          {
+            "id": "deepseek-v3.2",
+            "name": "DeepSeek V3.2",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 160000,
+            "maxTokens": 32768,
+            "compat": {
+              "supportsUsageInStreaming": false,
+              "supportsTools": false
+            }
+          },
+          {
+            "id": "aion-labs-aion-2-0",
+            "name": "Aion 2.0",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 128000,
+            "maxTokens": 32768,
+            "compat": {
+              "supportsUsageInStreaming": false,
+              "supportsTools": false
+            }
+          },
+          {
+            "id": "llama-3.2-3b",
+            "name": "Llama 3.2 3B",
+            "reasoning": false,
+            "input": ["text"],
+            "contextWindow": 128000,
+            "maxTokens": 4096,
+            "compat": {
+              "supportsUsageInStreaming": false
+            }
+          },
+          {
+            "id": "llama-3.3-70b",
+            "name": "Llama 3.3 70B",
+            "reasoning": false,
+            "input": ["text"],
+            "contextWindow": 128000,
+            "maxTokens": 4096,
             "compat": {
               "supportsUsageInStreaming": false
             }
@@ -396,6 +744,50 @@
             }
           },
           {
+            "id": "openai-gpt-54-pro",
+            "name": "GPT-5.4 Pro",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 1000000,
+            "maxTokens": 128000,
+            "compat": {
+              "supportsUsageInStreaming": false
+            }
+          },
+          {
+            "id": "openai-gpt-54-mini",
+            "name": "GPT-5.4 Mini",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 400000,
+            "maxTokens": 128000,
+            "compat": {
+              "supportsUsageInStreaming": false
+            }
+          },
+          {
+            "id": "openai-gpt-55",
+            "name": "GPT-5.5",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 1000000,
+            "maxTokens": 131072,
+            "compat": {
+              "supportsUsageInStreaming": false
+            }
+          },
+          {
+            "id": "openai-gpt-55-pro",
+            "name": "GPT-5.5 Pro",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 1000000,
+            "maxTokens": 128000,
+            "compat": {
+              "supportsUsageInStreaming": false
+            }
+          },
+          {
             "id": "openai-gpt-4o-2024-11-20",
             "name": "GPT-4o (via Venice)",
             "reasoning": false,
@@ -418,10 +810,21 @@
             }
           },
           {
-            "id": "gemini-3-pro-preview",
-            "name": "Gemini 3 Pro (via Venice)",
+            "id": "minimax-m3-preview",
+            "name": "MiniMax M3 Preview",
             "reasoning": true,
-            "input": ["text", "image"],
+            "input": ["text"],
+            "contextWindow": 524288,
+            "maxTokens": 65536,
+            "compat": {
+              "supportsUsageInStreaming": false
+            }
+          },
+          {
+            "id": "minimax-m25",
+            "name": "MiniMax M2.5",
+            "reasoning": true,
+            "input": ["text"],
             "contextWindow": 198000,
             "maxTokens": 32768,
             "compat": {
@@ -429,34 +832,56 @@
             }
           },
           {
-            "id": "gemini-3-1-pro-preview",
-            "name": "Gemini 3.1 Pro (via Venice)",
+            "id": "minimax-m27",
+            "name": "MiniMax M2.7",
             "reasoning": true,
-            "input": ["text", "image"],
-            "contextWindow": 1000000,
+            "input": ["text"],
+            "contextWindow": 198000,
             "maxTokens": 32768,
             "compat": {
               "supportsUsageInStreaming": false
             }
           },
           {
-            "id": "gemini-3-flash-preview",
-            "name": "Gemini 3 Flash (via Venice)",
+            "id": "mercury-2",
+            "name": "Mercury 2",
             "reasoning": true,
-            "input": ["text", "image"],
-            "contextWindow": 256000,
-            "maxTokens": 65536,
+            "input": ["text"],
+            "contextWindow": 128000,
+            "maxTokens": 50000,
             "compat": {
               "supportsUsageInStreaming": false
             }
           },
           {
-            "id": "grok-41-fast",
-            "name": "Grok 4.1 Fast (via Venice)",
+            "id": "nvidia-nemotron-3-nano-30b-a3b",
+            "name": "NVIDIA Nemotron 3 Nano 30B",
+            "reasoning": false,
+            "input": ["text"],
+            "contextWindow": 128000,
+            "maxTokens": 16384,
+            "compat": {
+              "supportsUsageInStreaming": false
+            }
+          },
+          {
+            "id": "nvidia-nemotron-3-ultra-550b-a55b",
+            "name": "NVIDIA Nemotron 3 Ultra",
             "reasoning": true,
-            "input": ["text", "image"],
-            "contextWindow": 1000000,
-            "maxTokens": 30000,
+            "input": ["text"],
+            "contextWindow": 256000,
+            "maxTokens": 32768,
+            "compat": {
+              "supportsUsageInStreaming": false
+            }
+          },
+          {
+            "id": "nvidia-nemotron-cascade-2-30b-a3b",
+            "name": "Nemotron Cascade 2 30B A3B",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 256000,
+            "maxTokens": 32768,
             "compat": {
               "supportsUsageInStreaming": false
             }


### PR DESCRIPTION
## Summary

Two related changes to the bundled Venice provider:

1. **Sync the text model catalog** (`extensions/venice/openclaw.plugin.json`) with Venice's live API: 40 → 76 models. Adds 44 current text models (incl. `venice-uncensored-1-2`, `venice-uncensored-role-play`, latest Claude/GPT/Kimi/DeepSeek/GLM/Grok via Venice), drops 8 entries retired upstream (incl. the old `venice-uncensored` Dolphin-Mistral), and excludes `e2ee-*` private-tier mirrors. Entries mirror `models.ts` discovery so the static fallback matches live behavior.

2. **Add a Venice image-generation provider** so the `image_generate` tool can reach Venice's image models (Flux, Seedream, Nano Banana, the uncensored Lustify line, etc.). The provider posts to Venice's native `POST /image/generate`, decodes the base64 `images`, and maps `size`/`aspectRatio`/`resolution`. `safe_mode` is disabled so the uncensored models the plugin exists to serve behave as intended. Text-to-image only; edit is not wired. Registered via the plugin entry `register()` hook and declared in the manifest `contracts.imageGenerationProviders`.

Docs: refreshes the Venice provider doc catalog to match the synced 76-model list and documents the new image-generation support; adds Venice rows/column to the `image_generate` tool reference.

## Verification

- `pnpm test extensions/venice` → all green (incl. new image-provider unit tests)
- `src/image-generation/provider-registry.test.ts` + `src/plugins/contracts/registry.contract.test.ts` → green (capability inventory picks up the new manifest contract)
- `tsgo -p extensions/venice/tsconfig.json` → clean
- `pnpm build` → exit 0, no `INEFFECTIVE_DYNAMIC_IMPORT`
- oxfmt / oxlint (direct on changed files) / format-docs → clean

## Real behavior proof

- Behavior addressed: Venice image models were unreachable (no registered image-generation provider); Venice text catalog was stale.
- Real environment tested: live calls to `https://api.venice.ai/api/v1/image/generate` exercising the new provider code (auth key stubbed, real network).
- Exact steps or command run after this patch: ran the provider's `generateImage` against `venice-sd35` and the uncensored `lustify-v8` (with `safe_mode: false`).
- Evidence after fix: both returned valid PNGs (1024x1024, ~1 MB; and 1536x1536, ~5 MB) decoded from the base64 response.
- Observed result after fix: standard and uncensored image paths both produce images end-to-end.
- What was not tested: in-gateway `image_generate` tool round-trip (gateway not restarted); image edit (intentionally unsupported).
