### PR TITLE
fix(failover): treat model_not_found as failover-eligible when fallback is configured

### DIFF
--- a/src/agents/embedded-agent-runner/run/failover-policy.test.ts
+++ b/src/agents/embedded-agent-runner/run/failover-policy.test.ts
@@ -20,6 +20,37 @@ describe("resolveRunFailoverDecision", () => {
     });
   });
 
+  it("escalates retry-limit exhaustion for model_not_found when fallback is configured", () => {
+    // model_not_found should cascade to configured fallbacks instead of
+    // returning a terminal error, so a decommissioned model is handled
+    // transparently via the fallback chain.
+    expect(
+      resolveRunFailoverDecision({
+        stage: "retry_limit",
+        fallbackConfigured: true,
+        failoverReason: "model_not_found",
+      }),
+    ).toEqual({
+      action: "fallback_model",
+      reason: "model_not_found",
+    });
+  });
+
+  it("surfaces model_not_found as terminal when no fallback is configured", () => {
+    // Without fallbacks, model_not_found stays terminal so a typo'd model id
+    // surfaces loudly — the fallbackConfigured guard handles this, not the
+    // shouldEscalateRetryLimit exclusion.
+    expect(
+      resolveRunFailoverDecision({
+        stage: "retry_limit",
+        fallbackConfigured: false,
+        failoverReason: "model_not_found",
+      }),
+    ).toEqual({
+      action: "return_error_payload",
+    });
+  });
+
   it("keeps retry-limit as a local error for non-escalating reasons", () => {
     expect(
       resolveRunFailoverDecision({

--- a/src/agents/embedded-agent-runner/run/failover-policy.ts
+++ b/src/agents/embedded-agent-runner/run/failover-policy.ts
@@ -77,11 +77,7 @@ type RunFailoverDecisionParams =
 
 function shouldEscalateRetryLimit(reason: FailoverReason | null): boolean {
   return Boolean(
-    reason &&
-    reason !== "timeout" &&
-    reason !== "model_not_found" &&
-    reason !== "format" &&
-    reason !== "session_expired",
+    reason && reason !== "timeout" && reason !== "format" && reason !== "session_expired",
   );
 }
 


### PR DESCRIPTION
## What Problem This Solves

When a configured primary model is decommissioned by the provider, `model_not_found` should cascade to the user's configured `model.fallbacks` chain instead of returning a terminal error.

Currently `shouldEscalateRetryLimit` explicitly excludes `model_not_found`, so the retry-limit stage short-circuits to `return_error_payload` even when valid fallbacks exist and are waiting to be tried.

## Why This Change Was Made

The exclusion was meant to surface model-not-found errors loudly for typos. But the `fallbackConfigured` guard at the caller site already handles this distinction: when no fallback is configured, `return_error_payload` is still the terminal outcome. With fallbacks present, the model should cascade.

The fix removes `model_not_found` from the `shouldEscalateRetryLimit` exclusion list. This is the same caller-guard pattern used by the prompt and assistant stages, which already allow `model_not_found` through their failover paths.

## User Impact

Users with `model.fallbacks` configured for their primary model will now automatically fall back to the next model in the chain when the provider decommissions the primary model. Previously the turn would hard-error without trying any fallback.

No impact for users without fallbacks configured — `model_not_found` still surfaces as a terminal error.

## Evidence

### Before/after behavior matrix

| Scenario | Before | After |
|-----------|--------|-------|
| model_not_found + fallback configured | `return_error_payload` | `fallback_model` ✅ |
| model_not_found + no fallback | `return_error_payload` | `return_error_payload` (unchanged) |
| model_not_found at prompt stage | `rotate_profile` then `fallback_model` | unchanged ✅ |
| model_not_found at assistant stage | `rotate_profile` then `fallback_model` | unchanged ✅ |
| timeout + fallback configured | `return_error_payload` | unchanged ✅ |
| rate_limit + fallback configured | `fallback_model` | unchanged ✅ |

### Test output (36 tests, all passing)

```
$ npx vitest run src/agents/embedded-agent-runner/run/failover-policy.test.ts

✓ resolveRunFailoverDecision > escalates retry-limit exhaustion for replay-safe failover reasons
✓ resolveRunFailoverDecision > escalates retry-limit exhaustion for model_not_found when fallback is configured
✓ resolveRunFailoverDecision > surfaces model_not_found as terminal when no fallback is configured
✓ resolveRunFailoverDecision > keeps retry-limit as a local error for non-escalating reasons
... (36 tests, all passed)
 Test Files  1 passed (1)
      Tests  36 passed (36)
```

### Regressions (452 tests across 5 files)

```
$ npx vitest run failover-policy.test.ts model-fallback.test.ts failover-error.test.ts ... 

 Test Files  5 passed (5)
      Tests  452 passed (452)
```

### Code-level proof

The entire source change is one line removed:

```diff
 function shouldEscalateRetryLimit(reason) {
   return Boolean(
     reason &&
     reason !== "timeout" &&
-    reason !== "model_not_found" &&
     reason !== "format" &&
     reason !== "session_expired",
   );
 }
``'

The `fallbackConfigured` guard at the caller ensures safety:

- fallbackConfigured=true, model_not_found → fallback_model (new)
- fallbackConfigured=false, model_not_found → return_error_payload (unchanged)

## AI Assistance
- **AI-assisted**: Yes
- **Co-Authored-By**: Claude <noreply@anthropic.com>
