### PR TITLE
fix(acp): resolve delivery threadId from session deliveryContext for ACP sessions

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1444,9 +1444,12 @@ export async function dispatchReplyFromConfig(
   // Do not read thread ids from the normalised session store here: `origin.threadId` can be
   // folded back into lastThreadId/deliveryContext during store normalisation and resurrect a
   // stale route after thread delivery was intentionally cleared.
+  // deliveryContext.threadId set during ACP spawn (via requestDeliveryHint) is authoritative
+  // and safe — it is written once at session creation, not during normalization.
   const routeThreadId = resolveRoutedDeliveryThreadId({
     ctx,
     sessionKey: acpDispatchSessionKey,
+    deliveryThreadId: sessionStoreEntry.entry?.deliveryContext?.threadId,
   });
   // Inherited sessions_send routes carry thread ids only when the stored route
   // proves the thread came from an explicit target, not session normalization.

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1444,12 +1444,17 @@ export async function dispatchReplyFromConfig(
   // Do not read thread ids from the normalised session store here: `origin.threadId` can be
   // folded back into lastThreadId/deliveryContext during store normalisation and resurrect a
   // stale route after thread delivery was intentionally cleared.
-  // deliveryContext.threadId set during ACP spawn (via requestDeliveryHint) is authoritative
-  // and safe — it is written once at session creation, not during normalization.
+  // deliveryContext.threadId set during ACP spawn (via requestDeliveryHint) is
+  // authoritative and safe — it is written once at session creation, not during
+  // normalization.  Only trust it when the session key has the `:acp:` segment;
+  // otherwise deliveryContext can carry stale normalized threadId values that
+  // would resurrect an intentionally cleared route.
+  const isAcpSession =
+    typeof acpDispatchSessionKey === "string" && acpDispatchSessionKey.includes(":acp:");
   const routeThreadId = resolveRoutedDeliveryThreadId({
     ctx,
     sessionKey: acpDispatchSessionKey,
-    deliveryThreadId: sessionStoreEntry.entry?.deliveryContext?.threadId,
+    deliveryThreadId: isAcpSession ? sessionStoreEntry.entry?.deliveryContext?.threadId : undefined,
   });
   // Inherited sessions_send routes carry thread ids only when the stored route
   // proves the thread came from an explicit target, not session normalization.

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -1333,10 +1333,17 @@ export async function runPreparedReply(
   const runHasAutoFallbackProvenance =
     runHasSessionModelOverride &&
     hasSessionAutoModelFallbackProvenance(preparedSessionState.sessionEntry);
+  // deliveryContext.threadId is only authoritative for ACP sessions where
+  // it is set once during spawn (via requestDeliveryHint).  Non-ACP sessions
+  // can have stale normalized threadId values in deliveryContext that would
+  // resurrect an intentionally cleared route.
+  const isAcpSession = typeof sessionKey === "string" && sessionKey.includes(":acp:");
   const originatingThreadId = resolveRoutedDeliveryThreadId({
     ctx,
     sessionKey,
-    deliveryThreadId: preparedSessionState.sessionEntry?.deliveryContext?.threadId,
+    deliveryThreadId: isAcpSession
+      ? preparedSessionState.sessionEntry?.deliveryContext?.threadId
+      : undefined,
   });
   const currentTurnImages = await traceRunPhase("reply.resolve_current_turn_images", () =>
     resolveCurrentTurnImages({

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -1336,6 +1336,7 @@ export async function runPreparedReply(
   const originatingThreadId = resolveRoutedDeliveryThreadId({
     ctx,
     sessionKey,
+    deliveryThreadId: preparedSessionState.sessionEntry?.deliveryContext?.threadId,
   });
   const currentTurnImages = await traceRunPhase("reply.resolve_current_turn_images", () =>
     resolveCurrentTurnImages({

--- a/src/auto-reply/reply/routed-delivery-thread.test.ts
+++ b/src/auto-reply/reply/routed-delivery-thread.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import type { MsgContext } from "../templating.js";
+import { resolveRoutedDeliveryThreadId } from "./routed-delivery-thread.js";
+
+function makeCtx(overrides: Partial<MsgContext> = {}): MsgContext {
+  return {
+    MessageThreadId: undefined,
+    TransportThreadId: undefined,
+    ...overrides,
+  } as MsgContext;
+}
+
+describe("resolveRoutedDeliveryThreadId", () => {
+  // ── Priority 1: MessageThreadId ──
+  it("returns MessageThreadId when present", () => {
+    const ctx = makeCtx({ MessageThreadId: "msg-thread-1" });
+    expect(resolveRoutedDeliveryThreadId({ ctx })).toBe("msg-thread-1");
+  });
+
+  it("returns MessageThreadId even when deliveryThreadId is also provided", () => {
+    const ctx = makeCtx({ MessageThreadId: 42 });
+    expect(resolveRoutedDeliveryThreadId({ ctx, deliveryThreadId: "delivery-thread" })).toBe(42);
+  });
+
+  // ── Priority 2: TransportThreadId ──
+  it("returns TransportThreadId when MessageThreadId is absent", () => {
+    const ctx = makeCtx({ TransportThreadId: "transport-thread-2" });
+    expect(resolveRoutedDeliveryThreadId({ ctx })).toBe("transport-thread-2");
+  });
+
+  it("returns TransportThreadId over deliveryThreadId", () => {
+    const ctx = makeCtx({ TransportThreadId: "transport-thread" });
+    expect(resolveRoutedDeliveryThreadId({ ctx, deliveryThreadId: "delivery-thread" })).toBe(
+      "transport-thread",
+    );
+  });
+
+  // ── Priority 3: deliveryThreadId (NEW, #97633) ──
+  it("falls back to deliveryThreadId when MessageThreadId and TransportThreadId are absent (string)", () => {
+    const ctx = makeCtx();
+    expect(resolveRoutedDeliveryThreadId({ ctx, deliveryThreadId: "delivery-thread-3" })).toBe(
+      "delivery-thread-3",
+    );
+  });
+
+  it("falls back to deliveryThreadId when MessageThreadId and TransportThreadId are absent (number)", () => {
+    const ctx = makeCtx();
+    expect(resolveRoutedDeliveryThreadId({ ctx, deliveryThreadId: 12345 })).toBe(12345);
+  });
+
+  it("deliveryThreadId with value 0 is treated as present (number 0 is valid)", () => {
+    const ctx = makeCtx();
+    // Thread id 0 is valid in some systems
+    expect(resolveRoutedDeliveryThreadId({ ctx, deliveryThreadId: 0 })).toBe(0);
+  });
+
+  // ── Priority 4: session key parse ──
+  it("parses thread id from session key when deliveryThreadId is absent", () => {
+    const ctx = makeCtx();
+    const result = resolveRoutedDeliveryThreadId({
+      ctx,
+      sessionKey: "agent:user:thread:789",
+    });
+    expect(result).toBe("789");
+  });
+
+  it("parses thread id from ACP-style session key (no :thread: suffix)", () => {
+    const ctx = makeCtx();
+    // ACP session keys use agent:<id>:acp:<uuid> — no :thread: suffix,
+    // so parseSessionThreadInfoFast can't find a threadId.
+    const result = resolveRoutedDeliveryThreadId({
+      ctx,
+      sessionKey: "agent:42:acp:abc-123",
+    });
+    // Without deliveryThreadId, ACP keys return undefined from parse
+    expect(result).toBeUndefined();
+  });
+
+  it("deliveryThreadId bridges ACP key gap", () => {
+    const ctx = makeCtx();
+    // This is the exact scenario #97633 fixes:
+    // ACP session key has no :thread: suffix, but deliveryContext.threadId is set.
+    const result = resolveRoutedDeliveryThreadId({
+      ctx,
+      sessionKey: "agent:42:acp:abc-123",
+      deliveryThreadId: "acp-thread-999",
+    });
+    expect(result).toBe("acp-thread-999");
+  });
+
+  // ── Edge cases ──
+  it("returns undefined when all sources are absent", () => {
+    const ctx = makeCtx();
+    expect(resolveRoutedDeliveryThreadId({ ctx, sessionKey: "agent:42:main" })).toBeUndefined();
+  });
+
+  it("deliveryThreadId is skipped when null", () => {
+    const ctx = makeCtx();
+    const result = resolveRoutedDeliveryThreadId({
+      ctx,
+      sessionKey: "agent:user:thread:555",
+      deliveryThreadId: null as unknown as undefined,
+    });
+    // null is not != null, so falls through to parseSessionThreadInfoFast
+    expect(result).toBe("555");
+  });
+});

--- a/src/auto-reply/reply/routed-delivery-thread.ts
+++ b/src/auto-reply/reply/routed-delivery-thread.ts
@@ -2,16 +2,31 @@
 import { parseSessionThreadInfoFast } from "../../config/sessions/thread-info.js";
 import type { MsgContext } from "../templating.js";
 
-/** Prefers current inbound thread ids, falling back to persisted session thread metadata. */
+/**
+ * Resolves the best thread id for routed delivery, using these fallbacks in order:
+ * 1. Inbound message thread id (ctx.MessageThreadId)
+ * 2. Transport-level thread id (ctx.TransportThreadId)
+ * 3. Explicit delivery thread id from the session delivery context
+ * 4. Thread id parsed from the session key suffix
+ *
+ * ACP sessions store their thread id in deliveryContext (set during spawn), but
+ * their session keys use an `agent:<id>:acp:<uuid>` format without a `:thread:`
+ * suffix, so the session-key parse never finds it.  Passing `deliveryThreadId`
+ * from the session entry's `deliveryContext.threadId` fills that gap.
+ */
 export function resolveRoutedDeliveryThreadId(params: {
   ctx: MsgContext;
   sessionKey?: string;
+  deliveryThreadId?: string | number;
 }): string | number | undefined {
   if (params.ctx.MessageThreadId != null) {
     return params.ctx.MessageThreadId;
   }
   if (params.ctx.TransportThreadId != null) {
     return params.ctx.TransportThreadId;
+  }
+  if (params.deliveryThreadId != null) {
+    return params.deliveryThreadId;
   }
   return parseSessionThreadInfoFast(params.sessionKey).threadId;
 }


### PR DESCRIPTION
## What Problem This Solves

ACP sessions (e.g. Discord delivery via ACP) fail to route replies to the correct thread because `resolveRoutedDeliveryThreadId` cannot extract a `threadId` from ACP session keys. The function's three-tier fallback chain — `MessageThreadId` → `TransportThreadId` → `parseSessionThreadInfoFast` — all return nothing because:

1. `MessageThreadId` and `TransportThreadId` are null when delivering through the ACP coordinator
2. `parseSessionThreadInfoFast` parses thread info from `:thread:` suffix, but ACP session keys use `agent:<id>:acp:<uuid>` format

However, the session entry's `deliveryContext.threadId` IS already set during ACP spawn (`src/gateway/server-methods/agent.ts` adds it via `requestDeliveryHint`), and is available at the call site. The data was there — it just wasn't being used.

## Why This Change Was Made

The fix adds a `deliveryThreadId` parameter to `resolveRoutedDeliveryThreadId` that slots between the inbound thread id checks and the session-key parse:

```
MessageThreadId → TransportThreadId → deliveryThreadId (NEW) → parseSessionThreadInfoFast
```

**ACP-only guard**: The `deliveryContext.threadId` is only trusted when the session key contains `:acp:`. Non-ACP sessions can carry stale normalized `threadId` values in `deliveryContext` that would resurrect an intentionally cleared route. The `:acp:` guard preserves the existing cleared-route protection while allowing ACP sessions to use their authoritative spawn-time thread binding.

## Evidence

### New test file: `routed-delivery-thread.test.ts` (12 tests)

All 12 tests pass on the fix branch, covering the complete fallback chain:
- MessageThreadId priority (existing behavior)
- TransportThreadId priority (existing behavior)
- deliveryThreadId fallback for ACP sessions (NEW — the gap being fixed)
- deliveryThreadId with string, number, and 0 values
- Session key `:thread:` suffix parse (existing behavior)
- ACP key gap: `agent:<id>:acp:<uuid>` keys now get threadId from deliveryContext
- Edge cases: null deliveryThreadId, all sources absent

```
$ npx vitest run src/auto-reply/reply/routed-delivery-thread.test.ts --no-coverage --pool forks

 Test Files  1 passed (1)
      Tests  12 passed (12)
```

### Existing tests unchanged — 31/31 pass

```
$ npx vitest run src/auto-reply/reply/dispatch-acp-delivery.test.ts --no-coverage --pool forks

 Test Files  1 passed (1)
      Tests  31 passed (31)
```

### Stale-route regression test still passes

The existing test at `dispatch-from-config.test.ts:2400` (where `deliveryContext.threadId` and `lastThreadId` contain stale origin metadata) continues to pass because the `:acp:` guard prevents non-ACP sessions from reading the stored threadId.

### Not tested

- End-to-end ACP Discord delivery with a real Discord channel (requires live Discord + agent infrastructure)

## Merge Risk

**Low**. The change:
- Adds one optional parameter (no existing callers broken — the two call sites are the only callers)
- Guards deliveryContext read with `isAcpSession` check at both call sites
- Uses the same `string | number` type already supported by the function
- 12 new unit tests + 31 existing tests all pass