### PR TITLE
docs(telegram): correct errorPolicy values and defaults to match actu…

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -952,12 +952,12 @@ openclaw message poll --channel telegram --target -1001234567890:topic:42 \
 
 ## Error reply controls
 
-When the agent encounters a delivery or provider error, Telegram can either reply with the error text or suppress it. Two config keys control this behavior:
+When the agent encounters a delivery or provider error, the error policy controls whether error messages are sent to the Telegram chat:
 
-| Key                                 | Values            | Default | Description                                                                                     |
-| ----------------------------------- | ----------------- | ------- | ----------------------------------------------------------------------------------------------- |
-| `channels.telegram.errorPolicy`     | `reply`, `silent` | `reply` | `reply` sends a friendly error message to the chat. `silent` suppresses error replies entirely. |
-| `channels.telegram.errorCooldownMs` | number (ms)       | `60000` | Minimum time between error replies to the same chat. Prevents error spam during outages.        |
+| Key                                 | Values                     | Default         | Description                                                                                                                                                                                               |
+| ----------------------------------- | -------------------------- | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `channels.telegram.errorPolicy`     | `always`, `once`, `silent` | `always`        | `always` — send every error message to the chat. `once` — send each unique error message once per cooldown window (suppress repeated identical errors). `silent` — never send error messages to the chat. |
+| `channels.telegram.errorCooldownMs` | number (ms)                | `14400000` (4h) | Cooldown window for the `once` policy. After an error is sent, the same error message is suppressed until this interval elapses. Prevents error spam during outages.                                      |
 
 Per-account, per-group, and per-topic overrides are supported (same inheritance as other Telegram config keys).
 
@@ -965,7 +965,7 @@ Per-account, per-group, and per-topic overrides are supported (same inheritance 
 {
   channels: {
     telegram: {
-      errorPolicy: "reply",
+      errorPolicy: "always",
       errorCooldownMs: 120000,
       groups: {
         "-1001234567890": {


### PR DESCRIPTION
## What Problem This Solves

The `errorPolicy` documented values and defaults in `docs/channels/telegram.md` do not match the actual Zod schema. Users who copy the documented value `errorPolicy: "reply"` will hit a schema validation failure at runtime.

## Evidence

The actual schema, runtime default, and consumer behavior all define exactly three values — `always`, `once`, `silent` — with `always` as the default.

### Schema definition

`src/config/zod-schema.providers-core.ts:150`

```ts
const TelegramErrorPolicySchema = z.enum(["always", "once", "silent"]).optional();
```

The doc previously listed `reply`, `silent` — `reply` is not a valid enum member.

### Runtime type and default

`extensions/telegram/src/error-policy.ts:14,23,46`

```ts
type TelegramErrorPolicy = "always" | "once" | "silent";

const DEFAULT_ERROR_COOLDOWN_MS = 14400000;

let policy: TelegramErrorPolicy = "always";
let cooldownMs = DEFAULT_ERROR_COOLDOWN_MS;
```

Default is `always`, not `reply`. Cooldown default is 4 hours (`14400000`), not 1 minute (`60000`).

### Runtime consumer — each value has distinct behavior

`extensions/telegram/src/bot-message-dispatch.ts:2300-2324`

```ts
onError: (err, info) => {
  const errorPolicy = resolveTelegramErrorPolicy({
    accountConfig: telegramCfg,
    groupConfig,
    topicConfig,
  });
  // "silent" → return immediately, never send
  if (isSilentErrorPolicy(errorPolicy.policy)) {
    return;
  }
  // "once" → suppress repeated identical errors within cooldown
  if (
    errorPolicy.policy === "once" &&
    shouldSuppressTelegramError({
      scopeKey: buildTelegramErrorScopeKey({ ... }),
      cooldownMs: errorPolicy.cooldownMs,
      errorMessage: String(err),
    })
  ) {
    return;
  }
  // "always" (and first occurrence for "once") → log & surface
  deliveryState.markNonSilentFailure();
  runtime.error?.(danger(`telegram ${info.kind} reply failed: ${String(err)}`));
},
```

### Unit tests confirm three-value contract

`extensions/telegram/src/error-policy.test.ts:25-34`

```ts
it("resolves policy and cooldown from the most specific config", () => {
  expect(
    resolveTelegramErrorPolicy({
      accountConfig: { errorPolicy: "once", errorCooldownMs: 1000 },
      groupConfig: { errorCooldownMs: 2000 },
      topicConfig: { errorPolicy: "silent" },
    }),
  ).toEqual({
    policy: "silent",
    cooldownMs: 2000,
  });
});
```

### Corrected doc values

| Value | Behavior |
|-------|----------|
| `always` | Send every error message to the chat (default). No suppression. |
| `once` | Send each unique error message once per cooldown window. Repeated identical errors within the window are suppressed; different errors are still sent. |
| `silent` | Never send error messages to the chat. |

## User Impact

Users who configured `errorPolicy: "reply"` based on the old docs would encounter a schema validation failure. After this fix, the documented values match the schema exactly.
