### PR TITLE
fix(macos): open dashboard when Dock or Finder relaunches app

### DIFF
--- a/apps/macos/Sources/OpenClaw/DeepLinks.swift
+++ b/apps/macos/Sources/OpenClaw/DeepLinks.swift
@@ -74,7 +74,6 @@ final class DeepLinkHandler {
                 self.presentAlert(title: "OpenClaw is paused", message: "Unpause OpenClaw to run agent actions.")
                 return
             }
-            break
         }
     }
 

--- a/apps/macos/Sources/OpenClaw/DeepLinks.swift
+++ b/apps/macos/Sources/OpenClaw/DeepLinks.swift
@@ -59,6 +59,10 @@ final class DeepLinkHandler {
             deepLinkLogger.debug("ignored url \(url.absoluteString, privacy: .public)")
             return
         }
+        if case .dashboard = route {
+            await self.openDashboard()
+            return
+        }
         guard !AppStateStore.shared.isPaused else {
             self.presentAlert(title: "OpenClaw is paused", message: "Unpause OpenClaw to run agent actions.")
             return
@@ -70,7 +74,7 @@ final class DeepLinkHandler {
         case .gateway:
             break
         case .dashboard:
-            await self.openDashboard()
+            break
         }
     }
 

--- a/apps/macos/Sources/OpenClaw/DeepLinks.swift
+++ b/apps/macos/Sources/OpenClaw/DeepLinks.swift
@@ -59,21 +59,21 @@ final class DeepLinkHandler {
             deepLinkLogger.debug("ignored url \(url.absoluteString, privacy: .public)")
             return
         }
-        if case .dashboard = route {
+        switch route {
+        case .dashboard:
             await self.openDashboard()
             return
-        }
-        guard !AppStateStore.shared.isPaused else {
-            self.presentAlert(title: "OpenClaw is paused", message: "Unpause OpenClaw to run agent actions.")
-            return
-        }
-
-        switch route {
         case let .agent(link):
+            guard !AppStateStore.shared.isPaused else {
+                self.presentAlert(title: "OpenClaw is paused", message: "Unpause OpenClaw to run agent actions.")
+                return
+            }
             await self.handleAgent(link: link, originalURL: url)
         case .gateway:
-            break
-        case .dashboard:
+            guard !AppStateStore.shared.isPaused else {
+                self.presentAlert(title: "OpenClaw is paused", message: "Unpause OpenClaw to run agent actions.")
+                return
+            }
             break
         }
     }

--- a/apps/macos/Sources/OpenClaw/MenuBar.swift
+++ b/apps/macos/Sources/OpenClaw/MenuBar.swift
@@ -341,7 +341,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    func applicationShouldHandleReopen(_: NSApplication, hasVisibleWindows _: Bool) -> Bool {
+    func applicationShouldHandleReopen(_: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+        if flag {
+            return true
+        }
         self.openDashboardAction()
         return false
     }

--- a/apps/macos/Sources/OpenClaw/MenuBar.swift
+++ b/apps/macos/Sources/OpenClaw/MenuBar.swift
@@ -274,8 +274,10 @@ private struct SettingsWindowOpenRegistrar: View {
 
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
+    private static let dashboardURL = URL(string: "openclaw://dashboard")!
     private var state: AppState?
     private let webChatAutoLogger = Logger(subsystem: "ai.openclaw", category: "Chat")
+    var openDashboardAction: @MainActor () -> Void = { AppNavigationActions.openDashboard() }
     let updaterController: UpdaterProviding = makeUpdaterController()
 
     func applicationDockMenu(_: NSApplication) -> NSMenu? {
@@ -313,7 +315,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     @objc
     private func openDashboardFromDockMenu(_: Any?) {
-        AppNavigationActions.openDashboard()
+        self.openDashboardAction()
     }
 
     @objc
@@ -339,9 +341,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
+    func applicationShouldHandleReopen(_: NSApplication, hasVisibleWindows _: Bool) -> Bool {
+        self.openDashboardAction()
+        return false
+    }
+
     @MainActor
     func applicationDidFinishLaunching(_ notification: Notification) {
         if self.isDuplicateInstance() {
+            NSWorkspace.shared.open(Self.dashboardURL)
             NSApp.terminate(nil)
             return
         }

--- a/apps/macos/Tests/OpenClawIPCTests/MenuContentSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MenuContentSmokeTests.swift
@@ -50,4 +50,19 @@ struct MenuContentSmokeTests {
         #expect(titles.contains("Open Canvas") || titles.contains("Close Canvas"))
         #expect(titles.contains("Settings…"))
     }
+
+    @Test func `dock reopen opens dashboard and suppresses default handling`() {
+        let delegate = AppDelegate()
+        var didOpenDashboard = false
+        delegate.openDashboardAction = {
+            didOpenDashboard = true
+        }
+
+        let shouldUseDefaultHandling = delegate.applicationShouldHandleReopen(
+            NSApplication.shared,
+            hasVisibleWindows: false)
+
+        #expect(shouldUseDefaultHandling == false)
+        #expect(didOpenDashboard)
+    }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/MenuContentSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MenuContentSmokeTests.swift
@@ -65,4 +65,19 @@ struct MenuContentSmokeTests {
         #expect(shouldUseDefaultHandling == false)
         #expect(didOpenDashboard)
     }
+
+    @Test func `dock reopen keeps default handling when windows are visible`() {
+        let delegate = AppDelegate()
+        var didOpenDashboard = false
+        delegate.openDashboardAction = {
+            didOpenDashboard = true
+        }
+
+        let shouldUseDefaultHandling = delegate.applicationShouldHandleReopen(
+            NSApplication.shared,
+            hasVisibleWindows: true)
+
+        #expect(shouldUseDefaultHandling)
+        #expect(!didOpenDashboard)
+    }
 }


### PR DESCRIPTION
## What Problem This Solves

Clicking OpenClaw from Finder or the Dock could appear to do nothing when OpenClaw was already running as a menu-bar/background app. The duplicate LaunchServices process exited without asking the existing app instance to open the dashboard.

## Why This Change Was Made

This adds an AppKit reopen handler for the running app and forwards duplicate launches to the existing dashboard deep link before terminating the duplicate process.

Dashboard deep links now bypass the paused-agent guard so a paused OpenClaw app can still open its dashboard. Agent deep links remain paused-gated.

## User Impact

Users can click OpenClaw from Finder or the Dock and get the dashboard/failure window instead of a silent no-op, including when the menu-bar app is already running.

## Evidence

### Code and test proof

- `swift test --filter 'MenuContentSmokeTests|DeepLinkAgentPolicyTests'`
  - Passed 12 tests in 2 suites after the review-comment fixes, including both no-visible-window and visible-window Dock reopen cases.
  - Latest run on `201042575cc`: `Build complete! (8.81s)` and `Test run with 12 tests in 2 suites passed after 0.049 seconds.`
- `swiftformat --lint apps/macos/Sources/OpenClaw/DeepLinks.swift --config config/swiftformat`
  - Passed after `201042575cc`: `0/1 files require formatting.`
  - This fixes the previous `macos-swift` failure, which was formatting-only: SwiftFormat reported `redundantBreak` in `DeepLinks.swift`.
- `SKIP_TSC=1 scripts/package-mac-app.sh`
  - Re-run after review-comment code changes.
  - Built Control UI, OpenClaw macOS app, MLX helper, and signed `dist/OpenClaw.app`.
  - Key output: `Build of product 'OpenClaw' complete! (7.37s)`, `Build of product 'openclaw-mlx-tts' complete! (0.78s)`, `Codesign complete for dist/OpenClaw.app`, `✅ Bundle ready at dist/OpenClaw.app`.
- `.agents/skills/autoreview/scripts/autoreview --mode local`
  - Clean before PR creation; rerun clean after review-comment fixes on `ef26a758983`.
  - Latest review result: `autoreview clean: no accepted/actionable findings reported`, `overall: patch is correct (0.86)`.
- `git diff --check HEAD`
  - Passed after review-comment fixes; no output.

### Local macOS 27 visual smoke

Environment:

```text
ProductVersion: 27.0
BuildVersion: 26A5368g
Darwin 27.0.0 arm64
```

Flow:

1. Built and launched the patched debug bundle, `ai.openclaw.mac.debug`.
2. Set the app's Dock icon preference on for the debug bundle.
3. Recorded over a solid black privacy background, with other desktop/app content covered.
4. Clicked the OpenClaw Dock candidate via Accessibility.
5. Used a closed local gateway port for the patched app so the dashboard window could open without showing real local session data.
6. Redacted the local URL/token field before publishing the artifact.

Result: the patched app opens the dashboard window after the Dock click instead of doing nothing when no windows are visible. A follow-up regression test verifies visible windows keep AppKit default reopen behavior. The latest code-only formatting fix in `201042575cc` does not change the recorded behavior; it removes the redundant switch `break` that failed `macos-swift`. Because the proof intentionally used a closed local gateway port, the visible state is the expected `Dashboard unavailable` window.

![Redacted local macOS Dock click recording](https://raw.githubusercontent.com/Solvely-Colin/pr-proof-assets/main/openclaw-macos-dock-reopen-dashboard/openclaw-dock-click-clean-redacted.gif)

MP4 copy: https://raw.githubusercontent.com/Solvely-Colin/pr-proof-assets/main/openclaw-macos-dock-reopen-dashboard/openclaw-dock-click-clean-redacted.mp4

Earlier window-only screenshot proof is also available here:

![Redacted local macOS Dock smoke](https://raw.githubusercontent.com/Solvely-Colin/pr-proof-assets/main/openclaw-macos-dock-reopen-dashboard/openclaw-window-after-dock-click-redacted.png)

### What was not tested

- Remote Crabbox/Testbox proof was not used; this is a local macOS UI bug and the available local Crabbox setup did not provide a macOS desktop target.
- Full dashboard web UI rendering was not exercised in the visual smoke because the proof intentionally used a closed local gateway port to avoid exposing local dashboard/session state. The proof covers the repaired app-open/reopen behavior and visible dashboard-window creation.

