### PR TITLE
docs(feishu): remove nonexistent disabled value from dmPolicy options

### DIFF
--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -44,7 +44,6 @@ Configure `dmPolicy` to control who can DM the bot:
 - `"pairing"` - unknown users receive a pairing code; approve via CLI
 - `"allowlist"` - only users listed in `allowFrom` can chat
 - `"open"` - allow public DMs only when `allowFrom` includes `"*"`; with restrictive entries, only matching users can chat
-- `"disabled"` - disable all DMs
 
 **Approve a pairing request:**
 


### PR DESCRIPTION
## What Problem This Solves

`docs/channels/feishu.md` line 47 lists `"disabled"` as a valid `dmPolicy` value, but the Zod schema only accepts `open`, `pairing`, `allowlist`. Users who configure `dmPolicy: "disabled"` will hit a schema validation failure at runtime.

## Evidence

### Schema — `disabled` is not a valid `dmPolicy` value

`extensions/feishu/src/config-schema.ts:14`

```ts
const DmPolicySchema = z.enum(["open", "pairing", "allowlist"]);
```

Only three values are valid for `dmPolicy`. `"disabled"` is not in the enum.

### Schema distinguishes DM policy from group policy

`extensions/feishu/src/config-schema.ts:14-18`

```ts
const DmPolicySchema = z.enum(["open", "pairing", "allowlist"]);
const GroupPolicySchema = z.union([
  z.enum(["open", "allowlist", "disabled"]),
  z.literal("allowall").transform(() => "open" as const),
]);
```

`groupPolicy` supports `disabled`; `dmPolicy` does not. The doc incorrectly applied the group-policy value set to the DM-policy field.

### Runtime uses `dmPolicy: "disabled"` only as an internal routing sentinel

`extensions/feishu/src/policy.ts:182,212`

```ts
// Group message ingress routing — internal sentinel, not user-configurable
dmPolicy: "disabled",
groupPolicy,
```

The literal `"disabled"` is hardcoded internally to prevent group messages from falling through to DM routing. It is never read from user config.

### Validated config reference — `dmPolicy` has no `disabled` entry

The config schema validation at `extensions/feishu/src/config-schema.ts:326` only handles `dmPolicy === "open"` for the wildcard check; validation passes through silently for `pairing` and `allowlist`:

```ts
if (value.dmPolicy === "open") {
  // checks allowFrom includes "*"
}
```

There is no validation branch for `disabled` because the schema rejects it before this code runs.

## User Impact

Users who configured `channels.feishu.dmPolicy: "disabled"` based on the old docs would encounter a schema validation failure. To disable DMs, use `dmPolicy: "allowlist"` with an empty `allowFrom` array.
