### PR TITLE
fix: allow model_not_found to trigger model fallback at retry limit

### DIFF
--- a/src/agents/embedded-agent-runner/run/failover-policy.ts
+++ b/src/agents/embedded-agent-runner/run/failover-policy.ts
@@ -77,11 +77,7 @@ type RunFailoverDecisionParams =
 
 function shouldEscalateRetryLimit(reason: FailoverReason | null): boolean {
   return Boolean(
-    reason &&
-    reason !== "timeout" &&
-    reason !== "model_not_found" &&
-    reason !== "format" &&
-    reason !== "session_expired",
+    reason && reason !== "timeout" && reason !== "format" && reason !== "session_expired",
   );
 }
 


### PR DESCRIPTION
## What Problem This Solves

When a configured primary model is decommissioned/removed by a provider, the provider returns a `model_not_found` error. OpenClaw's retry-limit failover policy explicitly excluded `model_not_found` from escalation, so the configured `model.fallbacks` chain never engaged. The user got a hard error instead of transparent fallback to the next configured model.

Fixes #97564.

## Why This Change Was Made

In `src/agents/embedded-agent-runner/run/failover-policy.ts`, `shouldEscalateRetryLimit` excluded four reasons from triggering fallback at the retry limit:

- `timeout` — retry same model
- `format` — retry same model
- `session_expired` — session is gone, no point
- `model_not_found` — the model doesn't exist **→ should try fallback!**

The exclusion meant that when `resolveRunFailoverDecision` was called with `stage: "retry_limit"` and `failoverReason: "model_not_found"`, it returned `return_error_payload` (terminal) instead of `fallback_model`. `handleRetryLimitExhaustion` then returned a terminal error result rather than throwing a `FailoverError`, so the outer `runWithModelFallback` loop never advanced to the next candidate.

The fix removes `model_not_found` from the exclusion list. All other excluded reasons (`timeout`, `format`, `session_expired`) remain unchanged because they represent transient or terminal states where fallback is inappropriate.

The `model-fallback.ts` outer loop already handles `model_not_found` correctly when it receives a `FailoverError` — it logs the warning and advances to the next candidate. The inner runner just wasn't throwing one.

## Evidence

### Existing tests pass

```
$ npx vitest run src/agents/failover-policy.test.ts --no-coverage
 Test Files  1 passed (1)
      Tests  1 passed (1)

$ npx vitest run src/agents/model-fallback.test.ts --no-coverage
 Test Files  2 passed (2)
      Tests  178 passed (178)
```

The model-fallback test suite already includes tests for `model_not_found` fallback behavior ("warns when falling back due to model_not_found", "sanitizes model identifiers in model_not_found warnings"), confirming this is the expected behavior. The inner retry-limit gate just wasn't wired to propagate it.

### Not tested

- End-to-end test with a real decommissioned model (requires a provider that has actually removed a model)
- The change is mechanically correct: it removes one exclusion that prevented the already-existing fallback machinery from engaging

## Merge Risk

Low. The change:
- Removes one line (`reason !== "model_not_found" &&`)
- Only affects the retry-limit exhaustion path, not the assistant-stage or prompt-stage failover paths
- The outer `runWithModelFallback` loop already handles `model_not_found` FailoverErrors correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)