### PR TITLE
fix: Discord follow-up replies avoid false stale snapshots

### DIFF
--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -40,7 +40,12 @@ import {
   upsertSessionEntry,
 } from "./session-accessor.js";
 import * as sessionStore from "./store.js";
-import { loadSessionStore, saveSessionStore, updateSessionStoreEntry } from "./store.js";
+import {
+  clearSessionStoreCacheForTest,
+  loadSessionStore,
+  saveSessionStore,
+  updateSessionStoreEntry,
+} from "./store.js";
 import { withOwnedSessionTranscriptWrites } from "./transcript-write-context.js";
 import type { SessionEntry } from "./types.js";
 
@@ -457,6 +462,70 @@ describe("session accessor file-backed seam", () => {
     });
     expect(committed.previousSessionTranscript.transcriptArchived).toBe(true);
     expect(fs.existsSync(previousTranscript)).toBe(false);
+  });
+
+  it("does not treat skillsSnapshot promptRef hydration as a stale reply initialization", async () => {
+    const previousCacheTtl = process.env.OPENCLAW_SESSION_CACHE_TTL_MS;
+    process.env.OPENCLAW_SESSION_CACHE_TTL_MS = "45000";
+    clearSessionStoreCacheForTest();
+    const sessionKey = "agent:main:discord:channel:123";
+    const prompt = `<available_skills>\n${"reply initialization skill prompt\n".repeat(
+      200,
+    )}</available_skills>`;
+    await saveSessionStore(
+      storePath,
+      {
+        [sessionKey]: {
+          sessionId: "previous-discord-session",
+          skillsSnapshot: {
+            prompt,
+            skills: [{ name: "reply-skill" }],
+            version: 1,
+          },
+          updatedAt: 10,
+        },
+      },
+      { skipMaintenance: true },
+    );
+    const persistedStore = JSON.parse(fs.readFileSync(storePath, "utf8")) as Record<
+      string,
+      SessionEntry
+    >;
+    expect(persistedStore[sessionKey]?.skillsSnapshot?.prompt).toBeUndefined();
+    expect(persistedStore[sessionKey]?.skillsSnapshot?.promptRef?.hash).toMatch(/^[a-f0-9]{64}$/);
+
+    clearSessionStoreCacheForTest();
+    await saveSessionStore(storePath, persistedStore, { skipMaintenance: true });
+    const snapshot = loadReplySessionInitializationSnapshot({ sessionKey, storePath });
+
+    try {
+      expect(snapshot.currentEntry?.skillsSnapshot?.prompt).toBe(prompt);
+      const committed = await commitReplySessionInitialization({
+        activeSessionKey: sessionKey,
+        agentId: "main",
+        expectedRevision: snapshot.revision,
+        previousEntry: snapshot.currentEntry,
+        sessionEntry: {
+          sessionId: "next-discord-session",
+          updatedAt: 20,
+        },
+        sessionKey,
+        storePath,
+      });
+
+      if (!committed.ok) {
+        throw new Error(`expected reply session initialization to commit, got ${committed.reason}`);
+      }
+      expect(committed.ok).toBe(true);
+      expect(committed.sessionEntry.sessionId).toBe("next-discord-session");
+    } finally {
+      if (previousCacheTtl === undefined) {
+        delete process.env.OPENCLAW_SESSION_CACHE_TTL_MS;
+      } else {
+        process.env.OPENCLAW_SESSION_CACHE_TTL_MS = previousCacheTtl;
+      }
+      clearSessionStoreCacheForTest();
+    }
   });
 
   it("does not reuse the previous transcript file when initialization rotates session ids", async () => {

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -500,7 +500,14 @@ describe("session accessor file-backed seam", () => {
       const snapshot = loadReplySessionInitializationSnapshot({ sessionKey, storePath });
 
       expect(snapshot.currentEntry?.skillsSnapshot?.prompt).toBe(prompt);
-      snapshot.currentEntry!.skillsSnapshot!.resolvedSkills = [
+      clearSessionStoreCacheForTest();
+      const writerStore = loadSessionStore(storePath, { clone: false });
+      const writerEntry = writerStore[sessionKey];
+      if (!writerEntry?.skillsSnapshot) {
+        throw new Error("expected hydrated writer skills snapshot");
+      }
+      expect(writerEntry.skillsSnapshot.prompt).toBe(prompt);
+      writerEntry.skillsSnapshot.resolvedSkills = [
         {
           name: "reply-skill",
           description: "runtime-only resolved skill body",

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -500,6 +500,23 @@ describe("session accessor file-backed seam", () => {
       const snapshot = loadReplySessionInitializationSnapshot({ sessionKey, storePath });
 
       expect(snapshot.currentEntry?.skillsSnapshot?.prompt).toBe(prompt);
+      snapshot.currentEntry!.skillsSnapshot!.resolvedSkills = [
+        {
+          name: "reply-skill",
+          description: "runtime-only resolved skill body",
+          filePath: "/tmp/reply-skill/SKILL.md",
+          baseDir: "/tmp/reply-skill",
+          source: "test",
+          sourceInfo: {
+            path: "/tmp/reply-skill/SKILL.md",
+            source: "test",
+            scope: "temporary",
+            origin: "top-level",
+            baseDir: "/tmp/reply-skill",
+          },
+          disableModelInvocation: false,
+        },
+      ];
       const committed = await commitReplySessionInitialization({
         activeSessionKey: sessionKey,
         agentId: "main",

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -468,37 +468,37 @@ describe("session accessor file-backed seam", () => {
     const previousCacheTtl = process.env.OPENCLAW_SESSION_CACHE_TTL_MS;
     process.env.OPENCLAW_SESSION_CACHE_TTL_MS = "45000";
     clearSessionStoreCacheForTest();
-    const sessionKey = "agent:main:discord:channel:123";
-    const prompt = `<available_skills>\n${"reply initialization skill prompt\n".repeat(
-      200,
-    )}</available_skills>`;
-    await saveSessionStore(
-      storePath,
-      {
-        [sessionKey]: {
-          sessionId: "previous-discord-session",
-          skillsSnapshot: {
-            prompt,
-            skills: [{ name: "reply-skill" }],
-            version: 1,
-          },
-          updatedAt: 10,
-        },
-      },
-      { skipMaintenance: true },
-    );
-    const persistedStore = JSON.parse(fs.readFileSync(storePath, "utf8")) as Record<
-      string,
-      SessionEntry
-    >;
-    expect(persistedStore[sessionKey]?.skillsSnapshot?.prompt).toBeUndefined();
-    expect(persistedStore[sessionKey]?.skillsSnapshot?.promptRef?.hash).toMatch(/^[a-f0-9]{64}$/);
-
-    clearSessionStoreCacheForTest();
-    await saveSessionStore(storePath, persistedStore, { skipMaintenance: true });
-    const snapshot = loadReplySessionInitializationSnapshot({ sessionKey, storePath });
-
     try {
+      const sessionKey = "agent:main:discord:channel:123";
+      const prompt = `<available_skills>\n${"reply initialization skill prompt\n".repeat(
+        200,
+      )}</available_skills>`;
+      await saveSessionStore(
+        storePath,
+        {
+          [sessionKey]: {
+            sessionId: "previous-discord-session",
+            skillsSnapshot: {
+              prompt,
+              skills: [{ name: "reply-skill" }],
+              version: 1,
+            },
+            updatedAt: 10,
+          },
+        },
+        { skipMaintenance: true },
+      );
+      const persistedStore = JSON.parse(fs.readFileSync(storePath, "utf8")) as Record<
+        string,
+        SessionEntry
+      >;
+      expect(persistedStore[sessionKey]?.skillsSnapshot?.prompt).toBeUndefined();
+      expect(persistedStore[sessionKey]?.skillsSnapshot?.promptRef?.hash).toMatch(/^[a-f0-9]{64}$/);
+
+      clearSessionStoreCacheForTest();
+      await saveSessionStore(storePath, persistedStore, { skipMaintenance: true });
+      const snapshot = loadReplySessionInitializationSnapshot({ sessionKey, storePath });
+
       expect(snapshot.currentEntry?.skillsSnapshot?.prompt).toBe(prompt);
       const committed = await commitReplySessionInitialization({
         activeSessionKey: sessionKey,

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -37,6 +37,7 @@ import {
   type PluginHostSessionCleanupStoreParams,
 } from "./plugin-host-cleanup.js";
 import { resolveAndPersistSessionFile } from "./session-file.js";
+import { projectSessionStoreForPersistence } from "./skill-prompt-blobs.js";
 import type {
   ResolvedSessionMaintenanceConfig,
   SessionMaintenanceWarning,
@@ -1155,8 +1156,24 @@ function cloneSessionEntries(store: Record<string, SessionEntry>): Record<string
   );
 }
 
-function createReplySessionInitializationRevision(entry: SessionEntry | undefined): string {
-  return JSON.stringify(entry ?? null);
+const REPLY_SESSION_INITIALIZATION_REVISION_KEY = "__replySessionInitializationRevision";
+
+function createReplySessionInitializationRevision(params: {
+  entry: SessionEntry | undefined;
+  storePath: string;
+}): string {
+  if (!params.entry) {
+    return "null";
+  }
+  // Reply-init guards compare the durable JSON shape. Skills promptRef hydration
+  // can turn the same persisted snapshot into a runtime-only prompt string.
+  const projected = projectSessionStoreForPersistence({
+    storePath: params.storePath,
+    store: {
+      [REPLY_SESSION_INITIALIZATION_REVISION_KEY]: params.entry,
+    },
+  });
+  return JSON.stringify(projected.store[REPLY_SESSION_INITIALIZATION_REVISION_KEY] ?? null);
 }
 
 function resolveInitializedReplySessionEntry(params: {
@@ -1711,7 +1728,10 @@ export function loadReplySessionInitializationSnapshot(params: {
       const entry = resolveSessionStoreEntry({ store: entries, sessionKey }).existing;
       return entry ? { ...entry } : undefined;
     },
-    revision: createReplySessionInitializationRevision(currentEntry),
+    revision: createReplySessionInitializationRevision({
+      entry: currentEntry,
+      storePath: params.storePath,
+    }),
   };
 }
 
@@ -1742,7 +1762,10 @@ export async function commitReplySessionInitialization(params: {
     async (store): Promise<ReplySessionInitializationCommitResult> => {
       const resolved = resolveSessionStoreEntry({ store, sessionKey: params.sessionKey });
       const currentEntry = resolved.existing ? { ...resolved.existing } : undefined;
-      const revision = createReplySessionInitializationRevision(currentEntry);
+      const revision = createReplySessionInitializationRevision({
+        entry: currentEntry,
+        storePath: params.storePath,
+      });
       if (revision !== params.expectedRevision) {
         return {
           ok: false,

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -38,6 +38,7 @@ import {
 } from "./plugin-host-cleanup.js";
 import { resolveAndPersistSessionFile } from "./session-file.js";
 import { projectSessionStoreForPersistence } from "./skill-prompt-blobs.js";
+import { normalizeSessionStore } from "./store-load.js";
 import type {
   ResolvedSessionMaintenanceConfig,
   SessionMaintenanceWarning,
@@ -1166,12 +1167,16 @@ function createReplySessionInitializationRevision(params: {
     return "null";
   }
   // Reply-init guards compare the durable JSON shape. Skills promptRef hydration
-  // can turn the same persisted snapshot into a runtime-only prompt string.
+  // can turn the same persisted snapshot into a runtime-only prompt string, and
+  // writer caches may carry runtime-only fields such as resolvedSkills. Project
+  // through the full persisted-entry normalization before deriving the revision.
+  const normalizedStore = {
+    [REPLY_SESSION_INITIALIZATION_REVISION_KEY]: params.entry,
+  };
+  normalizeSessionStore(normalizedStore);
   const projected = projectSessionStoreForPersistence({
     storePath: params.storePath,
-    store: {
-      [REPLY_SESSION_INITIALIZATION_REVISION_KEY]: params.entry,
-    },
+    store: normalizedStore,
   });
   return JSON.stringify(projected.store[REPLY_SESSION_INITIALIZATION_REVISION_KEY] ?? null);
 }


### PR DESCRIPTION
## Summary

Fix false `stale-snapshot` conflicts during reply-session initialization when a persisted `skillsSnapshot.promptRef` is hydrated into runtime `skillsSnapshot.prompt`.

Fixes openclaw/openclaw#96698.
Related to openclaw/openclaw#96699.

## What Problem This Solves

Discord/channel follow-up messages can fail with:

```text
reply session initialization conflicted for agent:main:discord:channel:<channelId>
```

The reply-session initialization guard computes a revision by serializing the session entry. But session-store reads can represent the same logical entry in multiple shapes:

- persisted/durable shape: `skillsSnapshot: { skills, promptRef }`
- hydrated runtime shape: `skillsSnapshot: { skills, prompt }`
- writer-cache shape: runtime-only fields such as `skillsSnapshot.resolvedSkills`

That means the optimistic guard can compare two equivalent session entries and falsely conclude that the entry changed concurrently.

## Fix

Build reply-init revisions from the normalized persisted session-entry shape before comparing. This makes hydrated `prompt`, durable `promptRef`, and runtime-only `resolvedSkills` caches compare equivalently while keeping the optimistic guard intact for real concurrent entry mutations.

## Evidence

The regression test recreates the exact mismatch:

1. Save a session entry with a large `skillsSnapshot.prompt`.
2. Verify it persists as `skillsSnapshot.promptRef`.
3. Reload through the reply-init snapshot path, which hydrates the prompt.
4. Add runtime-only `skillsSnapshot.resolvedSkills` to the hydrated writer entry.
5. Attempt `commitReplySessionInitialization`.
6. Before the fix: commit returns `stale-snapshot`.
7. After the fix: commit succeeds.

Focused proof:

```bash
node scripts/run-vitest.mjs run src/config/sessions/session-accessor.test.ts -t 'skillsSnapshot'
```

Supplemental live output from Ronan after the rescue frond-build shows consecutive Discord `message.action` successes and zero reply-init conflict/stale-snapshot lines in the same copied journal window:

```text
2026-06-28T21:21:32-07:00 ... [ws] ⇄ res ✓ message.action 346ms channel=discord ...
2026-06-28T21:21:39-07:00 ... [ws] ⇄ res ✓ message.action 208ms channel=discord ...
...
reply-init conflict/stale-snapshot count in window: 0
```

PR-scoped proof corpus:

- INDEX: https://github.com/karmaterminal/karmaterminal-openclaw-docs/blob/main/PR-1130/PROOFS/reply-init-skills-snapshot-live/INDEX.json
- manifest: https://github.com/karmaterminal/karmaterminal-openclaw-docs/blob/main/PR-1130/PROOFS/reply-init-skills-snapshot-live/manifest.json
- evidence summary: https://github.com/karmaterminal/karmaterminal-openclaw-docs/blob/main/PR-1130/PROOFS/reply-init-skills-snapshot-live/frond-scribe/EVIDENCE.md
- copied live output: https://github.com/karmaterminal/karmaterminal-openclaw-docs/blob/main/PR-1130/PROOFS/reply-init-skills-snapshot-live/frond-scribe/after/ronan-post-p2-two-message-live-output.log

## Validation

```bash
node scripts/run-vitest.mjs run src/config/sessions/session-accessor.test.ts -t 'skillsSnapshot'
node scripts/run-vitest.mjs run src/config/sessions/session-accessor.test.ts
node scripts/run-vitest.mjs run src/config/sessions/store.skills-stripping.test.ts
node scripts/run-vitest.mjs run src/auto-reply/reply/session.test.ts
CI=true pnpm tsgo:core:test
node scripts/run-oxlint-shards.mjs --only=core --split-core
```

Full `node scripts/test-projects.mjs` was also run. It failed unrelated baseline/environment/catalog shards outside this session-store change; targeted session-store/reply-session coverage passed.
