### PR TITLE
fix(agents): load generated Bedrock catalogs without snapshots

### DIFF
--- a/src/agents/plugin-model-catalog.ts
+++ b/src/agents/plugin-model-catalog.ts
@@ -144,12 +144,20 @@ export function filterGeneratedPluginModelCatalogProviders<T>(params: {
   pluginMetadataSnapshot?: PluginModelCatalogMetadataSnapshot;
   providers: Record<string, T>;
 }): Record<string, T> {
+  if (!params.catalogPluginId) {
+    return {};
+  }
   if (
-    !params.catalogPluginId ||
-    !params.pluginMetadataSnapshot ||
-    (params.parsedCatalog !== undefined && !isGeneratedPluginModelCatalog(params.parsedCatalog))
+    params.parsedCatalog !== undefined &&
+    !isGeneratedPluginModelCatalog(params.parsedCatalog)
   ) {
     return {};
+  }
+  if (!params.pluginMetadataSnapshot) {
+    // Runtime model resolution can outlive the process snapshot that originally
+    // wrote a generated sidecar. When metadata is temporarily unavailable, fall
+    // back to the generated catalog path as the remaining ownership signal.
+    return params.parsedCatalog === undefined ? {} : params.providers;
   }
   return Object.fromEntries(
     Object.entries(params.providers).filter(([providerId]) => {

--- a/src/agents/sessions/model-registry.test.ts
+++ b/src/agents/sessions/model-registry.test.ts
@@ -265,6 +265,36 @@ describe("ModelRegistry models.json auth", () => {
     });
   });
 
+  it("loads generated Bedrock plugin catalog shards without a metadata snapshot", () => {
+    const modelsPath = writeModelsJsonWithPluginCatalog({
+      root: { providers: {} },
+      pluginRelativePath: join("plugins", "amazon-bedrock", PLUGIN_MODEL_CATALOG_FILE),
+      pluginCatalog: {
+        generatedBy: PLUGIN_MODEL_CATALOG_GENERATED_BY,
+        providers: {
+          "amazon-bedrock": {
+            baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+            api: "bedrock-converse-stream",
+            auth: "aws-sdk",
+            models: [
+              {
+                id: "anthropic.claude-sonnet-4-6",
+                name: "Claude Sonnet 4.6",
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    const registry = ModelRegistry.create(AuthStorage.inMemory(), modelsPath);
+
+    expect(registry.getError()).toBeUndefined();
+    expect(registry.find("amazon-bedrock", "anthropic.claude-sonnet-4-6")?.name).toBe(
+      "Claude Sonnet 4.6",
+    );
+  });
+
   it("ignores non-generated plugin catalog files", () => {
     // Plugin catalog shards are codegen artifacts; hand-written lookalikes must
     // not extend the provider registry.


### PR DESCRIPTION
## Summary

Fixes #97241.

Generated plugin model catalogs were being dropped whenever `ModelRegistry` could not resolve a plugin metadata snapshot at runtime. That meant Bedrock models could appear in `openclaw models list` from provider discovery, but the chat runtime still failed with `Unknown model` because the generated `agents/<agent>/plugins/amazon-bedrock/catalog.json` sidecar was ignored.

## What Problem This Solves

Bedrock agents can generate canonical plugin catalog sidecars before the plugin metadata snapshot is available. Without a trusted fallback for those generated sidecars, the runtime rejects models that discovery already exposed, leaving users unable to start chats with valid Bedrock model IDs.

## What changed

- Keep rejecting non-generated plugin catalog files.
- When a catalog is confirmed as OpenClaw-generated and it is being loaded from the canonical plugin sidecar path, fall back to trusting that sidecar if the metadata snapshot is temporarily unavailable.
- Add a Bedrock regression test that exercises generated catalog loading without a metadata snapshot.

## Why this is safe

The fallback only applies to generated sidecars under `plugins/<plugin>/catalog.json`; handwritten lookalikes are still ignored. When a metadata snapshot is available, ownership filtering remains unchanged.

## Evidence

- `node scripts/run-vitest.mjs src/agents/sessions/model-registry.test.ts`
- `pnpm install --frozen-lockfile --fetch-timeout=600000 --fetch-retries=5 --network-concurrency=1`
- `pnpm_config_verify_deps_before_run=false pnpm build`
