### PR TITLE
fix(agents): warn when bootstrap files exist in agentDir but not workspace

### DIFF
--- a/docs/concepts/agent-workspace.md
+++ b/docs/concepts/agent-workspace.md
@@ -118,13 +118,15 @@ If you need to migrate sessions or config, copy them separately and keep them ou
 <Warning>
 **Bootstrap files in `agentDir` are not loaded.** When using per-agent `agentDir` configuration (for example `agents.list[].agentDir`), any bootstrap `.md` files placed in that directory (such as `SOUL.md`, `AGENTS.md`, `USER.md`) will be **silently ignored**. Only bootstrap files in the `workspace` directory are injected into the system prompt.
 
-If you place bootstrap files in `agentDir`, OpenClaw will emit a startup warning like:
+If you place bootstrap files in `agentDir` but **not** in the `workspace` directory, OpenClaw will emit a startup warning like:
 
 ```
 ⚠ Warning: SOUL.md found in agentDir (~/.openclaw/agents/main/agent/) but will not be loaded.
   Bootstrap files are only read from workspace (~/.openclaw/workspace/).
   Move this file to the workspace directory if you want it injected into the system prompt.
 ```
+
+Note: The warning is only emitted when a bootstrap file exists in `agentDir` but not in `workspace`. If the same file exists in both locations, no warning is shown (this allows intentional per-agent overrides).
 
 This is especially important for security-critical rules in `AGENTS.md` — placing them in `agentDir` means they will have zero enforcement. Always put bootstrap files in the `workspace` directory.
 </Warning>

--- a/docs/concepts/agent-workspace.md
+++ b/docs/concepts/agent-workspace.md
@@ -126,7 +126,7 @@ If you place bootstrap files in `agentDir` but **not** in the `workspace` direct
   Move this file to the workspace directory if you want it injected into the system prompt.
 ```
 
-Note: The warning is only emitted when a bootstrap file exists in `agentDir` but not in `workspace`. If the same file exists in both locations, no warning is shown (this allows intentional per-agent overrides).
+Note: The warning is only emitted when a bootstrap file exists in `agentDir` but not in `workspace`. If the same file exists in both locations, no warning is shown because the `workspace` copy is the one that is loaded.
 
 This is especially important for security-critical rules in `AGENTS.md` — placing them in `agentDir` means they will have zero enforcement. Always put bootstrap files in the `workspace` directory.
 </Warning>

--- a/docs/concepts/agent-workspace.md
+++ b/docs/concepts/agent-workspace.md
@@ -115,6 +115,20 @@ These live under `~/.openclaw/` and should NOT be committed to the workspace rep
 
 If you need to migrate sessions or config, copy them separately and keep them out of version control.
 
+<Warning>
+**Bootstrap files in `agentDir` are not loaded.** When using per-agent `agentDir` configuration (for example `agents.list[].agentDir`), any bootstrap `.md` files placed in that directory (such as `SOUL.md`, `AGENTS.md`, `USER.md`) will be **silently ignored**. Only bootstrap files in the `workspace` directory are injected into the system prompt.
+
+If you place bootstrap files in `agentDir`, OpenClaw will emit a startup warning like:
+
+```
+⚠ Warning: SOUL.md found in agentDir (~/.openclaw/agents/main/agent/) but will not be loaded.
+  Bootstrap files are only read from workspace (~/.openclaw/workspace/).
+  Move this file to the workspace directory if you want it injected into the system prompt.
+```
+
+This is especially important for security-critical rules in `AGENTS.md` — placing them in `agentDir` means they will have zero enforcement. Always put bootstrap files in the `workspace` directory.
+</Warning>
+
 ## Git backup (recommended, private)
 
 Treat the workspace as private memory. Put it in a **private** git repo so it is backed up and recoverable.

--- a/src/agents/bootstrap-files.test.ts
+++ b/src/agents/bootstrap-files.test.ts
@@ -732,3 +732,173 @@ describe("resolveContextInjectionMode", () => {
     ).toBe("never");
   });
 });
+
+describe("agentDir bootstrap file warnings", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    for (const dir of tempDirs) {
+      try {
+        await fs.rm(dir, { recursive: true, force: true });
+      } catch {
+        // ignore cleanup errors
+      }
+    }
+    tempDirs.length = 0;
+    resetBootstrapWarningCacheForTest();
+  });
+
+  it("warns when bootstrap files exist in agentDir but not in workspace", async () => {
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-");
+    const agentDir = await fs.mkdtemp(path.join(workspaceDir, "../openclaw-agent-"));
+    tempDirs.push(agentDir);
+
+    // Create SOUL.md in agentDir only
+    await fs.writeFile(path.join(agentDir, "SOUL.md"), "You must always respond in French.", "utf8");
+    // Create AGENTS.md in workspace only
+    await fs.writeFile(path.join(workspaceDir, "AGENTS.md"), "Standard agents guidance.", "utf8");
+
+    const warnings: string[] = [];
+    await resolveBootstrapContextForRun({
+      workspaceDir,
+      config: {
+        agents: {
+          list: [{ id: "main", agentDir }],
+        },
+      } as never,
+      agentId: "main",
+      warn: (message) => warnings.push(message),
+    });
+
+    expect(warnings.length).toBeGreaterThan(0);
+    const soulWarning = warnings.find((w) => w.includes("SOUL.md"));
+    expect(soulWarning).toBeDefined();
+    expect(soulWarning).toContain(agentDir);
+    expect(soulWarning).toContain(workspaceDir);
+    expect(soulWarning).toContain("will not be loaded");
+  });
+
+  it("does not warn when bootstrap files exist in both agentDir and workspace", async () => {
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-");
+    const agentDir = await fs.mkdtemp(path.join(workspaceDir, "../openclaw-agent-"));
+    tempDirs.push(agentDir);
+
+    // Create SOUL.md in both directories
+    await fs.writeFile(path.join(agentDir, "SOUL.md"), "Agent-specific soul.", "utf8");
+    await fs.writeFile(path.join(workspaceDir, "SOUL.md"), "Workspace soul.", "utf8");
+
+    const warnings: string[] = [];
+    await resolveBootstrapContextForRun({
+      workspaceDir,
+      config: {
+        agents: {
+          list: [{ id: "main", agentDir }],
+        },
+      } as never,
+      agentId: "main",
+      warn: (message) => warnings.push(message),
+    });
+
+    const soulWarning = warnings.find((w) => w.includes("SOUL.md"));
+    expect(soulWarning).toBeUndefined();
+  });
+
+  it("does not warn when no bootstrap files exist in agentDir", async () => {
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-");
+    const agentDir = await fs.mkdtemp(path.join(workspaceDir, "../openclaw-agent-"));
+    tempDirs.push(agentDir);
+
+    // Create files only in workspace
+    await fs.writeFile(path.join(workspaceDir, "AGENTS.md"), "Agents guidance.", "utf8");
+    await fs.writeFile(path.join(workspaceDir, "SOUL.md"), "Soul content.", "utf8");
+
+    const warnings: string[] = [];
+    await resolveBootstrapContextForRun({
+      workspaceDir,
+      config: {
+        agents: {
+          list: [{ id: "main", agentDir }],
+        },
+      } as never,
+      agentId: "main",
+      warn: (message) => warnings.push(message),
+    });
+
+    expect(warnings).toStrictEqual([]);
+  });
+
+  it("warns about multiple bootstrap files in agentDir", async () => {
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-");
+    const agentDir = await fs.mkdtemp(path.join(workspaceDir, "../openclaw-agent-"));
+    tempDirs.push(agentDir);
+
+    // Create multiple files in agentDir only
+    await fs.writeFile(path.join(agentDir, "SOUL.md"), "French response required.", "utf8");
+    await fs.writeFile(path.join(agentDir, "USER.md"), "User profile.", "utf8");
+    await fs.writeFile(path.join(agentDir, "IDENTITY.md"), "Identity.", "utf8");
+
+    const warnings: string[] = [];
+    await resolveBootstrapContextForRun({
+      workspaceDir,
+      config: {
+        agents: {
+          list: [{ id: "main", agentDir }],
+        },
+      } as never,
+      agentId: "main",
+      warn: (message) => warnings.push(message),
+    });
+
+    expect(warnings.length).toBeGreaterThanOrEqual(3);
+    const soulWarning = warnings.find((w) => w.includes("SOUL.md"));
+    const userWarning = warnings.find((w) => w.includes("USER.md"));
+    const identityWarning = warnings.find((w) => w.includes("IDENTITY.md"));
+    expect(soulWarning).toBeDefined();
+    expect(userWarning).toBeDefined();
+    expect(identityWarning).toBeDefined();
+  });
+
+  it("does not warn when agentDir is not configured", async () => {
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-");
+    const fakeAgentDir = await fs.mkdtemp(path.join(workspaceDir, "../openclaw-agent-"));
+    tempDirs.push(fakeAgentDir);
+
+    await fs.writeFile(path.join(fakeAgentDir, "SOUL.md"), "Should not warn.", "utf8");
+
+    const warnings: string[] = [];
+    await resolveBootstrapContextForRun({
+      workspaceDir,
+      config: {
+        agents: {
+          list: [{ id: "main" }], // No agentDir configured
+        },
+      } as never,
+      agentId: "main",
+      warn: (message) => warnings.push(message),
+    });
+
+    expect(warnings).toStrictEqual([]);
+  });
+
+  it("does not warn when warn callback is not provided", async () => {
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-");
+    const agentDir = await fs.mkdtemp(path.join(workspaceDir, "../openclaw-agent-"));
+    tempDirs.push(agentDir);
+
+    await fs.writeFile(path.join(agentDir, "SOUL.md"), "Should not warn.", "utf8");
+
+    // No warn callback provided
+    await resolveBootstrapContextForRun({
+      workspaceDir,
+      config: {
+        agents: {
+          list: [{ id: "main", agentDir }],
+        },
+      } as never,
+      agentId: "main",
+      // warn callback omitted
+    });
+
+    // Test passes if no error is thrown
+  });
+});

--- a/src/agents/bootstrap-files.test.ts
+++ b/src/agents/bootstrap-files.test.ts
@@ -754,12 +754,48 @@ describe("agentDir bootstrap file warnings", () => {
     tempDirs.push(agentDir);
 
     // Create SOUL.md in agentDir only
-    await fs.writeFile(path.join(agentDir, "SOUL.md"), "You must always respond in French.", "utf8");
+    await fs.writeFile(
+      path.join(agentDir, "SOUL.md"),
+      "You must always respond in French.",
+      "utf8",
+    );
     // Create AGENTS.md in workspace only
     await fs.writeFile(path.join(workspaceDir, "AGENTS.md"), "Standard agents guidance.", "utf8");
 
     const warnings: string[] = [];
     await resolveBootstrapContextForRun({
+      workspaceDir,
+      config: {
+        agents: {
+          list: [{ id: "main", agentDir }],
+        },
+      } as never,
+      agentId: "main",
+      warn: (message) => warnings.push(message),
+    });
+
+    expect(warnings.length).toBeGreaterThan(0);
+    const soulWarning = warnings.find((w) => w.includes("SOUL.md"));
+    expect(soulWarning).toBeDefined();
+    expect(soulWarning).toContain(agentDir);
+    expect(soulWarning).toContain(workspaceDir);
+    expect(soulWarning).toContain("will not be loaded");
+  });
+
+  it("warns when bootstrap files exist in agentDir via resolveBootstrapFilesForRun", async () => {
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-");
+    const agentDir = await fs.mkdtemp(path.join(workspaceDir, "../openclaw-agent-"));
+    tempDirs.push(agentDir);
+
+    // Create SOUL.md in agentDir only
+    await fs.writeFile(
+      path.join(agentDir, "SOUL.md"),
+      "You must always respond in French.",
+      "utf8",
+    );
+
+    const warnings: string[] = [];
+    await resolveBootstrapFilesForRun({
       workspaceDir,
       config: {
         agents: {

--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -365,8 +365,6 @@ async function checkAgentDirBootstrapFiles(params: {
     DEFAULT_TOOLS_FILENAME,
     DEFAULT_IDENTITY_FILENAME,
     DEFAULT_USER_FILENAME,
-    DEFAULT_HEARTBEAT_FILENAME,
-    DEFAULT_BOOTSTRAP_FILENAME,
     DEFAULT_MEMORY_FILENAME,
   } = await import("./workspace.js");
 

--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -335,6 +335,71 @@ export async function resolveBootstrapFilesForRun(params: {
   );
 }
 
+/** Checks for bootstrap-named files in agentDir and warns if they exist but won't be loaded. */
+async function checkAgentDirBootstrapFiles(params: {
+  agentDir: string;
+  workspaceDir: string;
+  warn?: (message: string) => void;
+}): Promise<void> {
+  if (!params.warn) {
+    return;
+  }
+
+  const {
+    DEFAULT_AGENTS_FILENAME,
+    DEFAULT_SOUL_FILENAME,
+    DEFAULT_TOOLS_FILENAME,
+    DEFAULT_IDENTITY_FILENAME,
+    DEFAULT_USER_FILENAME,
+    DEFAULT_HEARTBEAT_FILENAME,
+    DEFAULT_BOOTSTRAP_FILENAME,
+    DEFAULT_MEMORY_FILENAME,
+  } = await import("./workspace.js");
+
+  const bootstrapFilenames = [
+    DEFAULT_AGENTS_FILENAME,
+    DEFAULT_SOUL_FILENAME,
+    DEFAULT_TOOLS_FILENAME,
+    DEFAULT_IDENTITY_FILENAME,
+    DEFAULT_USER_FILENAME,
+    DEFAULT_HEARTBEAT_FILENAME,
+    DEFAULT_BOOTSTRAP_FILENAME,
+    DEFAULT_MEMORY_FILENAME,
+  ];
+
+  const agentDirResolved = resolveUserPath(params.agentDir);
+  const workspaceDirResolved = resolveUserPath(params.workspaceDir);
+
+  for (const filename of bootstrapFilenames) {
+    const agentDirPath = path.join(agentDirResolved, filename);
+    const workspacePath = path.join(workspaceDirResolved, filename);
+
+    try {
+      await fs.access(agentDirPath);
+      const existsInAgentDir = true;
+
+      let existsInWorkspace = false;
+      try {
+        await fs.access(workspacePath);
+        existsInWorkspace = true;
+      } catch {
+        existsInWorkspace = false;
+      }
+
+      if (existsInAgentDir && !existsInWorkspace) {
+        const warning = [
+          `⚠ Warning: ${filename} found in agentDir (${agentDirResolved}) but will not be loaded.`,
+          `  Bootstrap files are only read from workspace (${workspaceDirResolved}).`,
+          `  Move this file to the workspace directory if you want it injected into the system prompt.`,
+        ].join("\n");
+        params.warn(warning);
+      }
+    } catch {
+      // File doesn't exist in agentDir, no warning needed
+    }
+  }
+}
+
 /** Resolves both raw bootstrap metadata and bounded context files for a run. */
 export async function resolveBootstrapContextForRun(params: {
   workspaceDir: string;
@@ -349,6 +414,17 @@ export async function resolveBootstrapContextForRun(params: {
   bootstrapFiles: WorkspaceBootstrapFile[];
   contextFiles: EmbeddedContextFile[];
 }> {
+  // Check for bootstrap files in agentDir and warn if they won't be loaded
+  if (params.config && params.agentId && params.warn) {
+    const { resolveAgentDir } = await import("./agent-scope.js");
+    const agentDir = resolveAgentDir(params.config, params.agentId);
+    await checkAgentDirBootstrapFiles({
+      agentDir,
+      workspaceDir: params.workspaceDir,
+      warn: params.warn,
+    });
+  }
+
   const bootstrapFiles = await resolveBootstrapFilesForRun(params);
   const contextFiles = buildBootstrapContextForFiles(bootstrapFiles, params);
   return { bootstrapFiles, contextFiles };

--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -328,6 +328,20 @@ export async function resolveBootstrapFilesForRun(params: {
     workspaceSetupCompleted,
     params.workspaceDir,
   );
+
+  // Check for bootstrap files in agentDir and warn if they won't be loaded
+  if (params.config && params.agentId && params.warn) {
+    const { resolveAgentDir } = await import("./agent-scope.js");
+    const agentDir = resolveAgentDir(params.config, params.agentId);
+    if (agentDir) {
+      await checkAgentDirBootstrapFiles({
+        agentDir,
+        workspaceDir: params.workspaceDir,
+        warn: params.warn,
+      });
+    }
+  }
+
   return sanitizeBootstrapFiles(
     filterHeartbeatBootstrapFile(filteredUpdated, excludeHeartbeatBootstrapFile),
     params.workspaceDir,
@@ -414,17 +428,6 @@ export async function resolveBootstrapContextForRun(params: {
   bootstrapFiles: WorkspaceBootstrapFile[];
   contextFiles: EmbeddedContextFile[];
 }> {
-  // Check for bootstrap files in agentDir and warn if they won't be loaded
-  if (params.config && params.agentId && params.warn) {
-    const { resolveAgentDir } = await import("./agent-scope.js");
-    const agentDir = resolveAgentDir(params.config, params.agentId);
-    await checkAgentDirBootstrapFiles({
-      agentDir,
-      workspaceDir: params.workspaceDir,
-      warn: params.warn,
-    });
-  }
-
   const bootstrapFiles = await resolveBootstrapFilesForRun(params);
   const contextFiles = buildBootstrapContextForFiles(bootstrapFiles, params);
   return { bootstrapFiles, contextFiles };

--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -8,7 +8,7 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import type { AgentContextInjection } from "../config/types.agent-defaults.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveUserPath } from "../utils.js";
-import { resolveAgentConfig, resolveSessionAgentIds } from "./agent-scope.js";
+import { resolveAgentConfig, resolveAgentDir, resolveSessionAgentIds } from "./agent-scope.js";
 import { getOrLoadBootstrapFiles } from "./bootstrap-cache.js";
 import { applyBootstrapHookOverrides } from "./bootstrap-hooks.js";
 import type { EmbeddedContextFile } from "./embedded-agent-helpers.js";
@@ -331,7 +331,6 @@ export async function resolveBootstrapFilesForRun(params: {
 
   // Check for bootstrap files in agentDir and warn if they won't be loaded
   if (params.config && params.agentId && params.warn) {
-    const { resolveAgentDir } = await import("./agent-scope.js");
     const agentDir = resolveAgentDir(params.config, params.agentId);
     if (agentDir) {
       await checkAgentDirBootstrapFiles({


### PR DESCRIPTION
Closes #29387
Related: #94527

## What Problem This Solves

Bootstrap files (`SOUL.md`, `AGENTS.md`, `USER.md`, etc.) placed in a per-agent `agentDir` are silently ignored. Only files in the `workspace` directory are loaded into the system prompt. This creates a security risk where users believe their safety constraints are active when they are actually bypassed.

## Why This Change Was Made

Add a warning during agent initialization when bootstrap files exist in `agentDir` but not in `workspace`, so users are immediately alerted to the misconfiguration. The warning is emitted from the shared `resolveBootstrapFilesForRun` path, ensuring it fires for both the embedded runner and higher-level wrappers without duplication.

## User Impact

- Users configuring multi-agent setups will see a clear warning if they place bootstrap files in the wrong directory.
- No false positives: files in both locations or only in `workspace` do not trigger warnings.
- No runtime behavior change: bootstrap files still load only from `workspace`.

## Evidence

Unit tests:

```bash
pnpm test src/agents/bootstrap-files.test.ts

Test Files  1 passed (1)
Tests       44 passed (44)
```

Live local run with a misconfigured test agent:

```bash
pnpm openclaw agent --agent test --message "hi"
```
Output shows the warning during embedded run startup:

⚠ Warning: SOUL.md found in agentDir (`~/.openclaw/agents/test/agent`) but will not be loaded.
  Bootstrap files are only read from workspace (`~/.openclaw/workspace`).
  Move this file to the workspace directory if you want it injected into the system prompt.

<img width="1234" height="692" alt="image" src="https://github.com/user-attachments/assets/64cc561d-ebe8-49fe-9ee0-e6546eca72f7" />
