### PR TITLE
fix(google): rotate GEMINI_API_KEY on rate-limit errors in LLM streaming path

### DIFF
--- a/src/llm/providers/google-shared.ts
+++ b/src/llm/providers/google-shared.ts
@@ -465,6 +465,10 @@ export async function runGoogleGenerateContentLifecycle<T extends GoogleApiType>
       nextToolCallId: params.nextToolCallId,
     });
   } catch (error) {
+    // Re-throw rate-limit errors so callers can rotate API keys (e.g. GEMINI_API_KEY_1/2/3).
+    if ((error as { status?: number }).status === 429) {
+      throw error;
+    }
     for (const block of output.content) {
       if ("index" in block) {
         delete (block as { index?: number }).index;

--- a/src/llm/providers/google.ts
+++ b/src/llm/providers/google.ts
@@ -1,5 +1,11 @@
 // Google provider adapts Gemini streams and tools to the agent runtime.
 import { type GenerateContentParameters, GoogleGenAI } from "@google/genai";
+import {
+  collectProviderApiKeysForExecution,
+  executeWithApiKeyRotation,
+} from "../../agents/api-key-rotation.js";
+import { isApiKeyRateLimitError } from "../../agents/live-auth-keys.js";
+import { formatErrorMessage } from "../../infra/errors.js";
 import { getEnvApiKey } from "../env-api-keys.js";
 import type { Context, Model, SimpleStreamOptions, StreamFunction } from "../types.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
@@ -26,17 +32,41 @@ export const streamGoogle: StreamFunction<"google-generative-ai", GoogleOptions>
   const stream = new AssistantMessageEventStream();
   const output = createGoogleAssistantOutput(model, "google-generative-ai");
 
-  void runGoogleGenerateContentLifecycle({
-    stream,
-    model,
-    output,
-    options,
-    createClient: () => {
-      const apiKey = options?.apiKey || getEnvApiKey(model.provider) || "";
-      return createClient(model, apiKey, options?.headers);
+  const primaryApiKey = options?.apiKey || getEnvApiKey(model.provider) || "";
+  const apiKeys = collectProviderApiKeysForExecution({
+    provider: model.provider,
+    primaryApiKey,
+  });
+
+  void executeWithApiKeyRotation({
+    provider: model.provider,
+    apiKeys,
+    execute: async (apiKey) => {
+      await runGoogleGenerateContentLifecycle({
+        stream,
+        model,
+        output,
+        options,
+        createClient: () => createClient(model, apiKey, options?.headers),
+        buildParams: () => buildParams(model, context, options),
+        nextToolCallId: (name) => `${name}_${Date.now()}_${++toolCallCounter}`,
+      });
     },
-    buildParams: () => buildParams(model, context, options),
-    nextToolCallId: (name) => `${name}_${Date.now()}_${++toolCallCounter}`,
+    shouldRetry: ({ message }) => isApiKeyRateLimitError(message),
+  }).catch((err) => {
+    // All API keys exhausted — push final error to stream.
+    const errorMessage = formatErrorMessage(err);
+    for (const block of output.content) {
+      if ("index" in block) {
+        delete (block as { index?: number }).index;
+      }
+    }
+    if (!output.stopReason) {
+      output.stopReason = "error";
+      output.errorMessage = errorMessage;
+      stream.push({ type: "error", reason: "error", error: output });
+      stream.end();
+    }
   });
 
   return stream;


### PR DESCRIPTION
## What Problem This Solves

When multiple Gemini API keys are configured via `GEMINI_API_KEY_1`/`GEMINI_API_KEY_2`/`GEMINI_API_KEY_3` or `GEMINI_API_KEYS`, the LLM streaming path only used the first key (`GEMINI_API_KEY`) and never rotated on 429 rate-limit errors. The embedding path correctly called `executeWithApiKeyRotation` but the LLM streaming path did not, causing permanent failures once the first key hit its rate limit.

Fixes #97314

## Why This Change Was Made

**Root cause**: The LLM streaming path in `streamGoogle` (google.ts) called `getEnvApiKey(model.provider)` which returns only the first key. The Google SDK errors on 429 were caught generically inside `runGoogleGenerateContentLifecycle` (google-shared.ts), pushing an error event to the stream without giving callers a chance to rotate keys.

**Fix (two files):**

1. **`google-shared.ts`**: Added a re-throw guard for Google API errors with `status === 429` in `runGoogleGenerateContentLifecycle`. Rate-limit errors now propagate to the caller so key rotation can occur. Other errors continue to be handled with the existing stream-error path.

2. **`google.ts`**: Replaced the direct `getEnvApiKey` call with `collectProviderApiKeysForExecution` (which collects from `GEMINI_API_KEY`, `GEMINI_API_KEY_1/2/3`, `GEMINI_API_KEYS`, and `GOOGLE_API_KEY`), then wrapped the lifecycle call in `executeWithApiKeyRotation` with `shouldRetry` checking `isApiKeyRateLimitError`. If all keys are exhausted, a final error is pushed to the stream.

## Evidence

### Test Results
```
✓ src/llm/providers/google-shared.test.ts        5 passed
✓ src/agents/api-key-rotation.test.ts           38 passed (2 files)
✓ src/llm/providers/stream-wrappers/google.test.ts  11 passed
```

### How Key Rotation Works After Fix
1. `streamGoogle` collects all configured Gemini API keys
2. First key is tried → if Google returns 429, the error re-throws (not pushed to stream)
3. `executeWithApiKeyRotation` rotates to the next key and retries
4. If all keys fail, a final error is pushed to the stream
5. Non-rate-limit errors continue to use the existing error handling (pushed to stream immediately)

## Merge Risk

Low. The google-shared.ts change only re-throws 429 errors — all other error handling is unchanged. The google.ts change uses the same key-rotation pattern already present in the embedding path (`media-understanding/runner.entries.ts`). Both the google-generative-ai and google-vertex providers call `runGoogleGenerateContentLifecycle`, and the re-throw guard only fires on `status === 429` (a Google SDK-specific `ApiError` property), so google-vertex (which uses ADC, not API keys) is unaffected.