### PR TITLE
fix: prevent stale skill snapshots blocking Discord replies

### DIFF
--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SessionManager } from "../../agents/sessions/session-manager.js";
 import { onSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
+import { createCanonicalFixtureSkill } from "../../skills/test-support/test-helpers.js";
 import type { OpenClawConfig } from "../types.openclaw.js";
 import {
   applyRestartRecoveryLifecycle,
@@ -531,6 +532,60 @@ describe("session accessor file-backed seam", () => {
     expect(loadSessionEntry({ sessionKey, storePath })).toMatchObject({
       sessionId: "second-session",
     });
+  });
+
+  it("commits reply session initialization despite runtime-only skill snapshot cache", async () => {
+    const sessionKey = "agent:main:main";
+    await upsertSessionEntry(
+      { sessionKey, storePath },
+      {
+        sessionId: "first-session",
+        skillsSnapshot: {
+          prompt: `<available_skills>${"x".repeat(600)}</available_skills>`,
+          skills: [{ name: "skill-0" }],
+          version: 1,
+        },
+        updatedAt: 10,
+      },
+    );
+
+    const snapshot = loadReplySessionInitializationSnapshot({ sessionKey, storePath });
+    const cachedStore = loadSessionStore(storePath, { clone: false });
+    const cachedEntry = cachedStore[sessionKey];
+    if (!cachedEntry?.skillsSnapshot) {
+      throw new Error("expected cached skills snapshot");
+    }
+    cachedEntry.skillsSnapshot = {
+      ...cachedEntry.skillsSnapshot,
+      resolvedSkills: [
+        createCanonicalFixtureSkill({
+          baseDir: "/skills/skill-0",
+          description: "skill-0 description",
+          filePath: "/skills/skill-0/SKILL.md",
+          name: "skill-0",
+          source: `# skill-0\n\n${"x".repeat(3000)}`,
+        }),
+      ],
+    };
+
+    const committed = await commitReplySessionInitialization({
+      activeSessionKey: sessionKey,
+      agentId: "main",
+      expectedRevision: snapshot.revision,
+      previousEntry: snapshot.currentEntry,
+      sessionEntry: {
+        sessionId: "next-session",
+        updatedAt: 20,
+      },
+      sessionKey,
+      storePath,
+    });
+
+    expect(committed.ok).toBe(true);
+    if (!committed.ok) {
+      throw new Error("expected reply session initialization to commit");
+    }
+    expect(committed.sessionEntry.sessionId).toBe("next-session");
   });
 
   it("can borrow cached entry objects for read-only hot paths", async () => {

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -52,6 +52,7 @@ import {
   patchSessionEntry as patchFileSessionEntry,
   patchSessionEntryWithKey as patchFileSessionEntryWithKey,
   purgeDeletedAgentSessionEntries as purgeFileDeletedAgentSessionEntries,
+  projectSessionEntryForPersistenceRevision,
   readSessionUpdatedAt as readFileSessionUpdatedAt,
   resolveSessionStoreEntry,
   resetSessionEntryLifecycle as resetFileSessionEntryLifecycle,
@@ -1155,8 +1156,17 @@ function cloneSessionEntries(store: Record<string, SessionEntry>): Record<string
   );
 }
 
-function createReplySessionInitializationRevision(entry: SessionEntry | undefined): string {
-  return JSON.stringify(entry ?? null);
+function createReplySessionInitializationRevision(params: {
+  entry: SessionEntry | undefined;
+  storePath: string;
+}): string {
+  const { entry, storePath } = params;
+  // Snapshot reads may see promptRef-only disk entries while commit reads can
+  // see hydrated prompt text and runtime-only resolvedSkills cache entries.
+  // Compare the canonical persisted shape so cache hydration is not a conflict.
+  return JSON.stringify(
+    entry ? projectSessionEntryForPersistenceRevision({ storePath, entry }) : null,
+  );
 }
 
 function resolveInitializedReplySessionEntry(params: {
@@ -1711,7 +1721,10 @@ export function loadReplySessionInitializationSnapshot(params: {
       const entry = resolveSessionStoreEntry({ store: entries, sessionKey }).existing;
       return entry ? { ...entry } : undefined;
     },
-    revision: createReplySessionInitializationRevision(currentEntry),
+    revision: createReplySessionInitializationRevision({
+      entry: currentEntry,
+      storePath: params.storePath,
+    }),
   };
 }
 
@@ -1742,7 +1755,10 @@ export async function commitReplySessionInitialization(params: {
     async (store): Promise<ReplySessionInitializationCommitResult> => {
       const resolved = resolveSessionStoreEntry({ store, sessionKey: params.sessionKey });
       const currentEntry = resolved.existing ? { ...resolved.existing } : undefined;
-      const revision = createReplySessionInitializationRevision(currentEntry);
+      const revision = createReplySessionInitializationRevision({
+        entry: currentEntry,
+        storePath: params.storePath,
+      });
       if (revision !== params.expectedRevision) {
         return {
           ok: false,

--- a/src/config/sessions/store-load.ts
+++ b/src/config/sessions/store-load.ts
@@ -339,7 +339,7 @@ function normalizeSessionEntryDelivery(entry: SessionEntry): SessionEntry {
 // sessions.json by orders of magnitude when many sessions are active. Strip
 // it from every entry that flows through normalize, so neither the in-memory
 // store reloaded from disk nor the JSON serialized back to disk carries it.
-function stripPersistedSkillsCache(entry: SessionEntry): SessionEntry {
+export function stripPersistedSkillsCache(entry: SessionEntry): SessionEntry {
   const snapshot = entry.skillsSnapshot;
   if (!snapshot || snapshot.resolvedSkills === undefined) {
     return entry;

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -57,6 +57,7 @@ import {
   normalizeSessionStore,
   readSessionEntries,
   readSessionEntry,
+  stripPersistedSkillsCache,
 } from "./store-load.js";
 import {
   applyFileBackedSessionStoreMaintenance,
@@ -345,6 +346,18 @@ export type DeletedAgentSessionEntryPurgeParams = {
 
 function cloneSessionEntry(entry: SessionEntry): SessionEntry {
   return cloneSessionStoreRecord({ entry }).entry;
+}
+
+export function projectSessionEntryForPersistenceRevision(params: {
+  storePath: string;
+  entry: SessionEntry;
+}): SessionEntry {
+  const stripped = stripPersistedSkillsCache(params.entry);
+  const projected = projectSessionStoreForPersistence({
+    storePath: params.storePath,
+    store: { entry: stripped },
+  });
+  return projected.store.entry ?? stripped;
 }
 
 function resolveSessionWorkflowStorePath(


### PR DESCRIPTION
Closes #96698

## What Problem This Solves

Fixes an issue where users sending a second Discord message in the same session could receive no reply when the first turn persisted a large skills snapshot as a prompt blob.

## Why This Change Was Made

The reply-session initialization guard now compares the canonical persisted session-entry shape instead of the live hydrated runtime object. That keeps real stale-session protection intact while ignoring equivalent representation differences such as hydrated `skillsSnapshot.prompt` text and runtime-only `resolvedSkills` cache entries.

This change stays in the shared session file-backend boundary rather than adding Discord-specific handling, because the false conflict is caused by session snapshot revision comparison.

## User Impact

Discord users can continue an existing agent conversation after a skills snapshot is persisted as a prompt blob. Other channel/session users benefit from the same shared guard behavior, and true concurrent durable session changes still reject as stale.

AI-assisted change.

## Evidence

- Autoreview: `.agents/skills/autoreview/scripts/autoreview --mode local` completed cleanly with no accepted/actionable findings before commit.
- Focused test after rebase: `node scripts/run-vitest.mjs src/config/sessions/session-accessor.test.ts` passed: 1 file, 59 tests.
- Fix proof, live Discord via Crabbox Azure: lease `cbx_11c087803ec6`, run `run_f4d2ea8c6456`.
  - `OPENCLAW_TEST_FAST_CHILD=0`
  - first Discord reply succeeded
  - session persisted `skillsSnapshot.promptRef`
  - second Discord reply succeeded
  - `FIX_RESULT=passed-promptRef-present-second-replied`
- Regression repro, same live Discord scenario with the fix hunk reverted via Crabbox Azure: lease `cbx_c94f033b0224`, run `run_ff0d0c251602`.
  - `OPENCLAW_TEST_FAST_CHILD=0`
  - first Discord reply succeeded
  - session persisted `skillsSnapshot.promptRef`
  - second Discord reply was missing with stale-snapshot conflict
  - `REPRO_RESULT=reproduced-promptRef-present-second-missing`

Note: an initial focused test command with `--runInBand` failed before tests ran because that Vitest option is unsupported by the repo wrapper; it was rerun with the supported command above and passed.
