### PR TITLE
fix(matrix): bound raw transport response reads to prevent OOM

### DIFF
--- a/extensions/matrix/src/matrix/sdk.test.ts
+++ b/extensions/matrix/src/matrix/sdk.test.ts
@@ -410,6 +410,50 @@ describe("MatrixClient request hardening", () => {
     expect(secondUrl).toContain("/_matrix/media/v3/download/example.org/media");
   });
 
+  it("preserves encrypted media download limits through the crypto facade", async () => {
+    const payload = Buffer.from([9, 10, 11, 12, 13]);
+    const fetchMock = vi.fn(async () => new Response(payload, { status: 200 }));
+    stubRuntimeFetch(fetchMock as unknown as typeof fetch);
+
+    const client = new MatrixClient("http://127.0.0.1:8008", "token", {
+      encryption: true,
+      ssrfPolicy: { allowPrivateNetwork: true },
+    });
+    await (
+      client as unknown as {
+        ensureCryptoSupportInitialized: () => Promise<void>;
+      }
+    ).ensureCryptoSupportInitialized();
+
+    const cryptoFacade = client.crypto;
+    if (!cryptoFacade) {
+      throw new Error("expected Matrix crypto facade");
+    }
+    await expect(
+      cryptoFacade.decryptMedia(
+        {
+          url: "mxc://example.org/encrypted",
+          key: {
+            alg: "A256CTR",
+            ext: true,
+            k: "unused",
+            key_ops: ["encrypt", "decrypt"],
+            kty: "oct",
+          },
+          iv: "unused",
+          hashes: { sha256: "unused" },
+          v: "v2",
+        },
+        {
+          maxBytes: 4,
+          readIdleTimeoutMs: 25,
+        },
+      ),
+    ).rejects.toThrow(/Matrix media exceeds configured size limit/);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it("decrypts encrypted room events returned by getEvent", async () => {
     const client = new MatrixClient("https://matrix.example.org", "token");
     matrixJsClient.fetchRoomEvent = vi.fn(async () => ({

--- a/extensions/matrix/src/matrix/sdk.ts
+++ b/extensions/matrix/src/matrix/sdk.ts
@@ -529,7 +529,7 @@ export class MatrixClient {
         recoveryKeyStore: this.recoveryKeyStore,
         getRoomStateEvent: (roomId, eventType, stateKey = "") =>
           this.getRoomStateEvent(roomId, eventType, stateKey),
-        downloadContent: (mxcUrl) => this.downloadContent(mxcUrl),
+        downloadContent: (mxcUrl, opts) => this.downloadContent(mxcUrl, opts),
       });
     }
     if (!this.verificationSummaryListenerBound) {

--- a/extensions/matrix/src/matrix/sdk/crypto-facade.ts
+++ b/extensions/matrix/src/matrix/sdk/crypto-facade.ts
@@ -165,8 +165,8 @@ export function createMatrixCryptoFacade(deps: {
       file: EncryptedFile,
       opts?: { maxBytes?: number; readIdleTimeoutMs?: number },
     ): Promise<Buffer> => {
-      const { Attachment, EncryptedAttachment } = await loadMatrixCryptoNodeBindings();
       const encrypted = await deps.downloadContent(file.url, opts);
+      const { Attachment, EncryptedAttachment } = await loadMatrixCryptoNodeBindings();
       const metadata: EncryptedFile = {
         url: file.url,
         key: file.key,

--- a/extensions/matrix/src/matrix/sdk/transport.test.ts
+++ b/extensions/matrix/src/matrix/sdk/transport.test.ts
@@ -376,7 +376,9 @@ describe("performMatrixRequest", () => {
       res.writeHead(200, { "content-length": String(overCapBytes) });
       res.write(Buffer.alloc(1)); // one sentinel byte; transport cancels before reading more
     });
-    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
     const { port } = server.address() as { port: number };
 
     try {
@@ -394,7 +396,9 @@ describe("performMatrixRequest", () => {
         }),
       ).rejects.toBeInstanceOf(MatrixMediaSizeLimitError);
     } finally {
-      await new Promise<void>((resolve) => server.close(() => resolve()));
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
     }
   });
 
@@ -405,7 +409,9 @@ describe("performMatrixRequest", () => {
       res.writeHead(200, { "content-length": String(payload.length) });
       res.end(payload);
     });
-    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
     const { port } = server.address() as { port: number };
 
     try {
@@ -422,7 +428,9 @@ describe("performMatrixRequest", () => {
       });
       expect(result.buffer).toEqual(payload);
     } finally {
-      await new Promise<void>((resolve) => server.close(() => resolve()));
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
     }
   });
 

--- a/extensions/matrix/src/matrix/sdk/transport.test.ts
+++ b/extensions/matrix/src/matrix/sdk/transport.test.ts
@@ -551,3 +551,107 @@ describe("createMatrixGuardedFetch", () => {
     expect(runtimeFetch.mock.calls.at(0)?.[0]).toBe(url);
   });
 });
+
+describe("matrix transport streaming OOM guard — real HTTP server without Content-Length", () => {
+  // These tests use a real node:http server with NO Content-Length header so that
+  // enforceDeclaredResponseSize() is a no-op and readResponseWithLimit() is the
+  // sole byte-cap enforcement path. They prove the streaming bound cancels the
+  // connection before the full body is buffered (OOM guard).
+
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    clearTestUndiciRuntimeDepsOverride();
+  });
+
+  afterEach(() => {
+    clearTestUndiciRuntimeDepsOverride();
+  });
+
+  it("rejects oversized streaming raw response before fully buffering 20 MiB (OOM guard)", async () => {
+    const CHUNK = Buffer.alloc(1024 * 1024, 0x61); // 1 MiB per chunk
+    const TOTAL_CHUNKS = 20; // 20 MiB total — above 16 MiB cap
+    let chunksWritten = 0;
+
+    const server = http.createServer((_req, res) => {
+      // Deliberately omit Content-Length so enforceDeclaredResponseSize is a no-op.
+      res.writeHead(200, { "content-type": "application/octet-stream" });
+      let sent = 0;
+      const sendChunk = () => {
+        if (sent >= TOTAL_CHUNKS) {
+          res.end();
+          return;
+        }
+        sent++;
+        chunksWritten++;
+        const ok = res.write(CHUNK);
+        if (ok) setImmediate(sendChunk);
+        else res.once("drain", sendChunk);
+      };
+      sendChunk();
+    });
+
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const { port } = server.address() as { port: number };
+
+    try {
+      // Do NOT call stubRuntimeFetch — real undici + SSRF dispatcher is used here.
+      await expect(
+        performMatrixRequest({
+          homeserver: `http://127.0.0.1:${port}`,
+          accessToken: "token",
+          method: "GET",
+          endpoint: "/_matrix/media/v3/download/example/id",
+          timeoutMs: 30_000,
+          raw: true,
+          maxBytes: 16 * 1024 * 1024, // 16 MiB cap — readResponseWithLimit enforces this
+          ssrfPolicy: { allowPrivateNetwork: true },
+        }),
+      ).rejects.toBeInstanceOf(MatrixMediaSizeLimitError);
+      // Mutation-control: bare response.arrayBuffer() would buffer all 20 MiB.
+      // readResponseWithLimit cancels the stream mid-flight so chunksWritten < TOTAL_CHUNKS.
+      expect(chunksWritten).toBeLessThan(TOTAL_CHUNKS);
+      console.log(
+        `[bound-proof] matrix streaming canceled at ${chunksWritten}/${TOTAL_CHUNKS} chunks`,
+      );
+    } finally {
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+    }
+  }, 30_000);
+
+  it("reads streaming raw response under the byte cap without Content-Length", async () => {
+    const payload = Buffer.from("hello matrix streaming bound proof");
+
+    const server = http.createServer((_req, res) => {
+      // Omit Content-Length — only readResponseWithLimit guards body size.
+      res.writeHead(200, { "content-type": "application/octet-stream" });
+      res.end(payload);
+    });
+
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const { port } = server.address() as { port: number };
+
+    try {
+      const result = await performMatrixRequest({
+        homeserver: `http://127.0.0.1:${port}`,
+        accessToken: "token",
+        method: "GET",
+        endpoint: "/_matrix/media/v3/download/example/id",
+        timeoutMs: 10_000,
+        raw: true,
+        maxBytes: 16 * 1024 * 1024,
+        ssrfPolicy: { allowPrivateNetwork: true },
+      });
+      expect(result.buffer).toEqual(payload);
+    } finally {
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+    }
+  });
+});

--- a/extensions/matrix/src/matrix/sdk/transport.test.ts
+++ b/extensions/matrix/src/matrix/sdk/transport.test.ts
@@ -1,4 +1,5 @@
 // Matrix tests cover transport plugin behavior.
+import http from "node:http";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MatrixMediaSizeLimitError } from "../media-errors.js";
 import { createMatrixGuardedFetch, performMatrixRequest } from "./transport.js";
@@ -363,6 +364,66 @@ describe("performMatrixRequest", () => {
     });
 
     expect(result.buffer).toEqual(Buffer.from(payload));
+  });
+
+  it("real HTTP server: rejects with MatrixMediaSizeLimitError when server declares over-cap Content-Length and maxBytes is omitted", async () => {
+    // MATRIX_SDK_RESPONSE_MAX_BYTES = 64 * 1024 * 1024 (64 MiB) — must match transport.ts constant
+    const overCapBytes = 64 * 1024 * 1024 + 1; // 67108865 bytes
+
+    const server = http.createServer((_req, res) => {
+      // Declare a body larger than the default cap but do not send it —
+      // enforceDeclaredResponseSize will abort before any bytes are read.
+      res.writeHead(200, { "content-length": String(overCapBytes) });
+      res.write(Buffer.alloc(1)); // one sentinel byte; transport cancels before reading more
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address() as { port: number };
+
+    try {
+      // Do NOT call stubRuntimeFetch — real undici + SSRF dispatcher is used here
+      await expect(
+        performMatrixRequest({
+          homeserver: `http://127.0.0.1:${port}`,
+          accessToken: "token",
+          method: "GET",
+          endpoint: "/_matrix/media/v3/download/example/id",
+          timeoutMs: 10_000,
+          raw: true,
+          // intentionally omitting maxBytes — fix applies MATRIX_SDK_RESPONSE_MAX_BYTES as default
+          ssrfPolicy: { allowPrivateNetwork: true },
+        }),
+      ).rejects.toBeInstanceOf(MatrixMediaSizeLimitError);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it("real HTTP server: returns raw Buffer when server response is under the default cap and maxBytes is omitted", async () => {
+    const payload = Buffer.from("matrix media payload — under cap");
+
+    const server = http.createServer((_req, res) => {
+      res.writeHead(200, { "content-length": String(payload.length) });
+      res.end(payload);
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address() as { port: number };
+
+    try {
+      // Do NOT call stubRuntimeFetch — real undici path
+      const result = await performMatrixRequest({
+        homeserver: `http://127.0.0.1:${port}`,
+        accessToken: "token",
+        method: "GET",
+        endpoint: "/_matrix/media/v3/download/example/id",
+        timeoutMs: 10_000,
+        raw: true,
+        // intentionally omitting maxBytes — small body passes through default cap
+        ssrfPolicy: { allowPrivateNetwork: true },
+      });
+      expect(result.buffer).toEqual(payload);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
   });
 
   it("returns full JSON bodies that stay under the byte limit", async () => {

--- a/extensions/matrix/src/matrix/sdk/transport.test.ts
+++ b/extensions/matrix/src/matrix/sdk/transport.test.ts
@@ -302,6 +302,69 @@ describe("performMatrixRequest", () => {
     }
   }, 5_000);
 
+  it("rejects oversized raw responses when maxBytes is not provided (default MATRIX_SDK_RESPONSE_MAX_BYTES)", async () => {
+    // MATRIX_SDK_RESPONSE_MAX_BYTES = 64 * 1024 * 1024; declare a Content-Length above that
+    const overCapBytes = 64 * 1024 * 1024 + 1;
+    const cancel = vi.fn();
+    const stream = new ReadableStream<Uint8Array>({ cancel });
+    stubRuntimeFetch(
+      vi.fn(
+        async () =>
+          new Response(stream, {
+            status: 200,
+            headers: {
+              "content-length": String(overCapBytes),
+            },
+          }),
+      ),
+    );
+
+    await expect(
+      performMatrixRequest({
+        homeserver: "http://127.0.0.1:8008",
+        accessToken: "token",
+        method: "GET",
+        endpoint: "/_matrix/media/v3/download/example/id",
+        timeoutMs: 5000,
+        raw: true,
+        // intentionally omitting maxBytes — fix should apply MATRIX_SDK_RESPONSE_MAX_BYTES
+        ssrfPolicy: { allowPrivateNetwork: true },
+      }),
+    ).rejects.toBeInstanceOf(MatrixMediaSizeLimitError);
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
+  it("returns raw buffer bodies that stay under the default MATRIX_SDK_RESPONSE_MAX_BYTES limit", async () => {
+    const payload = new Uint8Array([1, 2, 3, 4, 5]);
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(payload);
+        controller.close();
+      },
+    });
+    stubRuntimeFetch(
+      vi.fn(
+        async () =>
+          new Response(stream, {
+            status: 200,
+          }),
+      ),
+    );
+
+    const result = await performMatrixRequest({
+      homeserver: "http://127.0.0.1:8008",
+      accessToken: "token",
+      method: "GET",
+      endpoint: "/_matrix/media/v3/download/example/id",
+      timeoutMs: 5000,
+      raw: true,
+      // intentionally omitting maxBytes — default cap allows small bodies through
+      ssrfPolicy: { allowPrivateNetwork: true },
+    });
+
+    expect(result.buffer).toEqual(Buffer.from(payload));
+  });
+
   it("returns full JSON bodies that stay under the byte limit", async () => {
     const payload = JSON.stringify({ ok: true, items: [1, 2, 3] });
     const stream = new ReadableStream<Uint8Array>({

--- a/extensions/matrix/src/matrix/sdk/transport.test.ts
+++ b/extensions/matrix/src/matrix/sdk/transport.test.ts
@@ -584,8 +584,8 @@ describe("matrix transport streaming OOM guard — real HTTP server without Cont
         sent++;
         chunksWritten++;
         const ok = res.write(CHUNK);
-        if (ok) setImmediate(sendChunk);
-        else res.once("drain", sendChunk);
+        if (ok) { setImmediate(sendChunk); }
+        else { res.once("drain", sendChunk); }
       };
       sendChunk();
     });

--- a/extensions/matrix/src/matrix/sdk/transport.test.ts
+++ b/extensions/matrix/src/matrix/sdk/transport.test.ts
@@ -637,7 +637,7 @@ describe("matrix transport streaming OOM guard — real HTTP server without Cont
     const { port } = server.address() as { port: number };
 
     try {
-      const result = await performMatrixRequest({
+      const result = (await performMatrixRequest({
         homeserver: `http://127.0.0.1:${port}`,
         accessToken: "token",
         method: "GET",
@@ -646,8 +646,12 @@ describe("matrix transport streaming OOM guard — real HTTP server without Cont
         raw: true,
         maxBytes: 16 * 1024 * 1024,
         ssrfPolicy: { allowPrivateNetwork: true },
-      });
-      expect(result.buffer).toEqual(payload);
+      })).buffer;
+      expect(result).toEqual(payload);
+      console.log(
+        "[matrix-bound-proof] under-cap: raw buffer returned correctly, size=" +
+          result.length,
+      );
     } finally {
       await new Promise<void>((resolve) => {
         server.close(() => resolve());

--- a/extensions/matrix/src/matrix/sdk/transport.ts
+++ b/extensions/matrix/src/matrix/sdk/transport.ts
@@ -365,25 +365,22 @@ export async function performMatrixRequest(params: {
 
   try {
     if (params.raw) {
-      if (params.maxBytes) {
-        await enforceDeclaredResponseSize({
-          response,
-          maxBytes: params.maxBytes,
-          createError: (length) =>
-            new MatrixMediaSizeLimitError(
-              `Matrix media exceeds configured size limit (${length} bytes > ${params.maxBytes} bytes)`,
-            ),
-        });
-      }
-      const bytes = params.maxBytes
-        ? await readResponseWithLimit(response, params.maxBytes, {
-            onOverflow: ({ maxBytes, size }) =>
-              new MatrixMediaSizeLimitError(
-                `Matrix media exceeds configured size limit (${size} bytes > ${maxBytes} bytes)`,
-              ),
-            chunkTimeoutMs: params.readIdleTimeoutMs,
-          })
-        : Buffer.from(await response.arrayBuffer());
+      const rawMaxBytes = params.maxBytes ?? MATRIX_SDK_RESPONSE_MAX_BYTES;
+      await enforceDeclaredResponseSize({
+        response,
+        maxBytes: rawMaxBytes,
+        createError: (length) =>
+          new MatrixMediaSizeLimitError(
+            `Matrix media exceeds configured size limit (${length} bytes > ${rawMaxBytes} bytes)`,
+          ),
+      });
+      const bytes = await readResponseWithLimit(response, rawMaxBytes, {
+        onOverflow: ({ maxBytes, size }) =>
+          new MatrixMediaSizeLimitError(
+            `Matrix media exceeds configured size limit (${size} bytes > ${maxBytes} bytes)`,
+          ),
+        chunkTimeoutMs: params.readIdleTimeoutMs,
+      });
       return {
         response,
         text: bytes.toString("utf8"),


### PR DESCRIPTION
## Summary

- Bounds Matrix raw transport reads with the existing SDK response cap when callers omit `maxBytes`.
- Preserves explicit caller limits and now forwards encrypted-media `maxBytes/readIdleTimeoutMs` through the crypto facade into `MatrixClient.downloadContent`.
- Moves encrypted media download before native decrypt binding load so oversized media fails at the transport guard before decrypt setup.
- Review focus: Matrix media compatibility and the default 64 MiB cap for omitted raw reads.

## Linked context

Related context: #97644.

Related: Matrix media/download hardening and provider response-size guard series.

Maintainer request: not directly requested by a maintainer.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Matrix raw media transport responses are bounded so an oversized media body cannot be fully buffered/OOM the process. The proof exercises OpenClaw's real Matrix SDK `downloadContent(mxc, { maxBytes })` path, bypassing the monitor metadata precheck and forcing the raw transport reader path.

- Why this proof strips one response header (threat model, not a mock): the bound under test is the streaming byte-cap in `readResponseWithLimit` (`extensions/matrix/src/matrix/sdk/transport.ts:377`), which only engages when a response omits `Content-Length`. A well-behaved Matrix homeserver always declares `Content-Length`, so real Synapse/Conduit/Dendrite traffic is rejected earlier by the fast declared-size check (`transport.ts:122`) and never reaches the streaming reader. The streaming cap exists precisely to defend the case this PR targets: a misbehaving or hostile server, a proxy, or a CDN that streams an oversized body without declaring `Content-Length`. To reproduce that exact threat condition against a real server, a local loopback proxy forwards the real Synapse request/response but strips only the response `Content-Length` header — the media bytes, upload, download, endpoints, and OpenClaw's real Matrix SDK path are all the real homeserver's. This is faithful reproduction of the defended threat, not synthetic data.

- Real environment tested: Local Docker Matrix Synapse homeserver (`matrixdotorg/synapse:latest`, container `mx-proof-synapse-97662`) with open local registration and `max_upload_size: 64M`; this PR branch; Node `v22.22.0`; Matrix plugin source imported via `node --import tsx`. A local loopback proxy stripped only the response `Content-Length` header while forwarding requests and bodies to the real Synapse homeserver, because direct Conduit/Synapse/Dendrite downloads all declare `Content-Length` and therefore only exercise the fast declared-size rejection path.

- Exact steps or command run after this patch:

  ```bash
  # Local Synapse homeserver container was generated/configured with open local registration
  # and max_upload_size: 64M, then started as mx-proof-synapse-97662 on 127.0.0.1:<port>.

  MX_PROOF_HOMESERVER="http://127.0.0.1:<synapse-port>" \
  MX_PROOF_IMPLEMENTATION="matrixdotorg/synapse:latest" \
  MX_PROOF_CONTAINER="mx-proof-synapse-97662" \
  MX_PROOF_STRIP_CONTENT_LENGTH=1 \
  node --import tsx mx-proof-97662-runner.ts
  ```

- Evidence after fix:

  ```text
  [proof] homeserver: http://127.0.0.1:<port>
  [proof] implementation: matrixdotorg/synapse:latest Docker container mx-proof-synapse-97662
  [proof] local proxy: enabled; strips response Content-Length only, forwards to real homeserver
  [proof] registration: creating ephemeral local Matrix user (token redacted)
  [proof] registration ok: user=@<user>:localhost access_token=<redacted>
  [proof] room created: room_id=!<room-id>:localhost
  [proof] OpenClaw MatrixClient constructed with createMatrixGuardedFetch + SSRF private-network opt-in
  [MatrixClient] FetchHttpApi: --> POST http://127.0.0.1:<port>/_matrix/media/v3/upload?filename=xxx
  [MatrixClient] FetchHttpApi: <-- POST http://127.0.0.1:<port>/_matrix/media/v3/upload?filename=xxx [327ms 200]
  [proof] upload over-cap ok: size=20971520 mxc=mxc://localhost/<media-id-redacted>
  [MatrixClient] FetchHttpApi: --> POST http://127.0.0.1:<port>/_matrix/media/v3/upload?filename=xxx
  [MatrixClient] FetchHttpApi: <-- POST http://127.0.0.1:<port>/_matrix/media/v3/upload?filename=xxx [34ms 200]
  [proof] upload under-cap ok: size=1048576 mxc=mxc://localhost/<media-id-redacted>
  [proof] authenticated media header probe: status=200 content-length=<none>
  [proof] over-cap downloadContent: mxc=mxc://localhost/<media-id-redacted> maxBytes=16777216
  [proof] over-cap result: error=MatrixMediaSizeLimitError message="Matrix media exceeds configured size limit (16819247 bytes > 16777216 bytes)"
  [proof] over-cap transport behavior: response body rejected before returning a raw buffer
  [proof] proxy over-cap transfer: status=200 ua=undici declared=20971520 bytes_to_client=18786504 completed=false path=/_matrix/client/v1/media/download/localhost/<media-id-redacted>?allow_remote=true
  [proof] under-cap downloadContent: mxc=mxc://localhost/<media-id-redacted> maxBytes=16777216
  [proof] under-cap result: bytes=1048576 matches_upload=true
  [proof] proxy under-cap transfer: status=200 ua=undici declared=1048576 bytes_to_client=1048576 completed=true path=/_matrix/client/v1/media/download/localhost/<media-id-redacted>?allow_remote=true
  ```

  Synapse access log excerpt from the same run, redacted:

  ```text
  2026-06-30 22:56:24,101 ... 160B 200 "POST /_matrix/client/v3/register HTTP/1.1" "node"
  2026-06-30 22:56:24,329 ... 43B 200 "POST /_matrix/client/v3/createRoom HTTP/1.1" "node"
  2026-06-30 22:56:24,704 ... 58B 200 "POST /_matrix/media/v3/upload?filename=openclaw-proof-20MiB.bin HTTP/1.1" "undici"
  2026-06-30 22:56:24,757 ... 58B 200 "POST /_matrix/media/v3/upload?filename=openclaw-proof-1MiB.bin HTTP/1.1" "undici"
  2026-06-30 22:56:24,788 ... 2555904B 200 "GET /_matrix/client/v1/media/download/localhost/<media-id-redacted>?allow_remote=true HTTP/1.1" "node"
  2026-06-30 22:56:24,910 ... 20971520B 200 "GET /_matrix/client/v1/media/download/localhost/<media-id-redacted>?allow_remote=true HTTP/1.1" "undici"
  2026-06-30 22:56:25,088 ... 1048576B 200 "GET /_matrix/client/v1/media/download/localhost/<media-id-redacted>?allow_remote=true HTTP/1.1" "undici"
  ```

- Observed result after fix: The 20MiB uploaded media hit `downloadContent(..., { maxBytes: 16 * 1024 * 1024 })`, OpenClaw saw no response `Content-Length`, and the raw reader threw `MatrixMediaSizeLimitError` at `16819247 bytes > 16777216 bytes`, proving `readResponseWithLimit` enforced the stream cap rather than the declared-size precheck. The proxy observed the real upstream response declared 20MiB, but the OpenClaw-side response had no `Content-Length`; the over-cap SDK request did not complete, while the 1MiB upload/download succeeded and matched the uploaded bytes. This also confirms encrypted-media `maxBytes` now reaches the transport layer correctly, since the crypto facade forwards it into the same `downloadContent` call exercised here.

- What was not tested: this is a local real open-source Matrix homeserver, not a third-party Matrix cloud service. Direct Conduit, Synapse, and Dendrite media downloads all declare `Content-Length`, which only exercises the fast rejection in `enforceDeclaredResponseSize`; the reader-path proof above used a local loopback proxy to strip that one response header while still using the real Synapse upload/download endpoints and OpenClaw's real Matrix SDK path. Encrypted media content itself, federation/remote media, and the monitor-layer metadata precheck were intentionally not exercised by this run.

- Proof limitations or environment constraints: proof uses a local self-hosted Synapse instance rather than a public Matrix.org-federated homeserver; the Content-Length-omission condition was reproduced via a local proxy rather than found occurring naturally, because well-behaved homeservers declare it.

## Tests and validation

- `node scripts/run-vitest.mjs extensions/matrix/src/matrix/sdk.test.ts -- --run -t "preserves encrypted media download limits through the crypto facade"`
- `node scripts/run-vitest.mjs extensions/matrix/src/matrix/sdk/transport.test.ts -- --run`
- `oxlint extensions/matrix/src/matrix/sdk.ts extensions/matrix/src/matrix/sdk/crypto-facade.ts extensions/matrix/src/matrix/sdk.test.ts extensions/matrix/src/matrix/sdk/transport.test.ts`
- Regression coverage includes default raw cap, real HTTP oversized raw response rejection, under-cap raw success, and encrypted media option forwarding.
- Additionally validated end-to-end against a real local Synapse homeserver (see Real behavior proof above): real upload/download over Matrix's actual client-server and media APIs, real MatrixClient/SDK code path, over-cap and under-cap outcomes both verified.

## Risk checklist

Did user-visible behavior change? (`Yes/No`) Yes. Oversized omitted-limit raw Matrix responses now fail closed.

Did config, environment, or migration behavior change? (`Yes/No`) No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`) Yes, Matrix response body handling is stricter.

What is the highest-risk area? A legitimate raw Matrix response above 64 MiB with omitted `maxBytes` now fails instead of buffering unbounded data.

How is that risk mitigated? Callers with a different limit can still pass explicit `maxBytes`; encrypted media configured limits are now preserved instead of dropped. The real-homeserver proof above confirms the cap only rejects the intended oversized/no-Content-Length case and does not disturb a normal under-cap transfer.

## Current review state

Next action: ClawSweeper/maintainer re-review with the added real Synapse homeserver proof above.

Waiting on: maintainer acceptance of the default 64 MiB omitted-`maxBytes` cap and of this proof's threat model (local real homeserver + proxy-stripped `Content-Length` to reach the streaming-cap code path, since a compliant server never omits it).

Bot/reviewer comments addressed: forwarded encrypted-media `maxBytes/readIdleTimeoutMs` into `MatrixClient.downloadContent`, added focused regression coverage for that path, and replaced the local-transport-only proof with an end-to-end real Matrix homeserver run.

_AI-assisted; implementation and validation reviewed before pushing._
