### PR TITLE
fix(memory-wiki): preserve unsafe-local notes during source outages

### DIFF
--- a/extensions/memory-wiki/src/unsafe-local.test.ts
+++ b/extensions/memory-wiki/src/unsafe-local.test.ts
@@ -77,7 +77,7 @@ describe("syncMemoryWikiUnsafeLocalSources", () => {
   it("prunes stale unsafe-local pages when configured files disappear", async () => {
     const privateDir = await createPrivateDir("private-prune");
 
-    const secretPath = path.join(privateDir, "secret.md");
+    const secretPath = path.join(privateDir, "..notes.md");
     await fs.writeFile(secretPath, "# private\n", "utf8");
 
     const { rootDir: vaultDir, config } = await createVault({
@@ -106,6 +106,48 @@ describe("syncMemoryWikiUnsafeLocalSources", () => {
       "code",
       "ENOENT",
     );
+  });
+
+  it("does not prune imported directory pages when a configured source root is unavailable", async () => {
+    const privateDir = await createPrivateDir("private-unavailable");
+
+    const secretPath = path.join(privateDir, "..notes.md");
+    await fs.writeFile(secretPath, "# private\n", "utf8");
+
+    const { rootDir: vaultDir, config } = await createVault({
+      rootDir: nextCaseRoot("unavailable-vault"),
+      config: {
+        vaultMode: "unsafe-local",
+        unsafeLocal: {
+          allowPrivateMemoryCoreAccess: true,
+          paths: [privateDir],
+        },
+      },
+    });
+
+    const first = await syncMemoryWikiUnsafeLocalSources(config);
+    const firstPagePath = first.pagePaths[0] ?? "";
+    const firstPageAbsPath = path.join(vaultDir, firstPagePath);
+    const userNote = "Keep this human note across transient source outages.";
+    const edited = (await fs.readFile(firstPageAbsPath, "utf8")).replace(
+      "<!-- openclaw:human:start -->\n<!-- openclaw:human:end -->",
+      `<!-- openclaw:human:start -->\n${userNote}\n<!-- openclaw:human:end -->`,
+    );
+    await fs.writeFile(firstPageAbsPath, edited, "utf8");
+
+    await fs.rename(privateDir, `${privateDir}.offline`);
+    const second = await syncMemoryWikiUnsafeLocalSources(config);
+
+    expect(second.artifactCount).toBe(0);
+    expect(second.removedCount).toBe(0);
+    await expect(fs.readFile(firstPageAbsPath, "utf8")).resolves.toContain(userNote);
+
+    await fs.rename(`${privateDir}.offline`, privateDir);
+    const third = await syncMemoryWikiUnsafeLocalSources(config);
+
+    expect(third.artifactCount).toBe(1);
+    expect(third.removedCount).toBe(0);
+    await expect(fs.readFile(firstPageAbsPath, "utf8")).resolves.toContain(userNote);
   });
 
   it("caps composed unsafe-local filenames to the filesystem component limit", async () => {

--- a/extensions/memory-wiki/src/unsafe-local.ts
+++ b/extensions/memory-wiki/src/unsafe-local.ts
@@ -18,6 +18,7 @@ import {
   assertMemoryWikiSourceSyncStateCapacity,
   pruneImportedSourceEntries,
   readMemoryWikiSourceSyncState,
+  type MemoryWikiImportedSourceState,
   writeMemoryWikiSourceSyncState,
 } from "./source-sync-state.js";
 import { initializeMemoryWikiVault } from "./vault.js";
@@ -27,6 +28,11 @@ type UnsafeLocalArtifact = {
   configuredPath: string;
   absolutePath: string;
   relativePath: string;
+};
+
+type UnsafeLocalArtifactCollection = {
+  artifacts: UnsafeLocalArtifact[];
+  pruneProtectedRoots: string[];
 };
 
 const DIRECTORY_TEXT_EXTENSIONS = new Set([".json", ".jsonl", ".md", ".txt", ".yaml", ".yml"]);
@@ -45,13 +51,58 @@ function detectFenceLanguage(filePath: string): string {
   return "markdown";
 }
 
-async function listAllowedFilesRecursive(rootDir: string): Promise<string[]> {
-  const entries = await fs.readdir(rootDir, { withFileTypes: true }).catch(() => []);
+function isPathInsideRoot(candidatePath: string, rootPath: string): boolean {
+  const relative = path.relative(path.resolve(rootPath), path.resolve(candidatePath));
+  return (
+    relative !== "" &&
+    relative !== ".." &&
+    !relative.startsWith(`..${path.sep}`) &&
+    !path.isAbsolute(relative)
+  );
+}
+
+function hasImportedUnsafeLocalDescendant(
+  state: MemoryWikiImportedSourceState,
+  configuredRoot: string,
+): boolean {
+  return Object.values(state.entries).some(
+    (entry) => entry.group === "unsafe-local" && isPathInsideRoot(entry.sourcePath, configuredRoot),
+  );
+}
+
+function addPruneProtectedKeys(params: {
+  activeKeys: Set<string>;
+  pruneProtectedRoots: string[];
+  state: MemoryWikiImportedSourceState;
+}): void {
+  if (params.pruneProtectedRoots.length === 0) {
+    return;
+  }
+  for (const [syncKey, entry] of Object.entries(params.state.entries)) {
+    if (
+      entry.group === "unsafe-local" &&
+      params.pruneProtectedRoots.some((root) => isPathInsideRoot(entry.sourcePath, root))
+    ) {
+      params.activeKeys.add(syncKey);
+    }
+  }
+}
+
+async function listAllowedFilesRecursive(
+  rootDir: string,
+): Promise<{ files: string[]; incomplete: boolean }> {
+  const entries = await fs.readdir(rootDir, { withFileTypes: true }).catch((): null => null);
+  if (entries === null) {
+    return { files: [], incomplete: true };
+  }
   const files: string[] = [];
+  let incomplete = false;
   for (const entry of entries) {
     const fullPath = path.join(rootDir, entry.name);
     if (entry.isDirectory()) {
-      files.push(...(await listAllowedFilesRecursive(fullPath)));
+      const nested = await listAllowedFilesRecursive(fullPath);
+      files.push(...nested.files);
+      incomplete ||= nested.incomplete;
       continue;
     }
     if (
@@ -61,21 +112,29 @@ async function listAllowedFilesRecursive(rootDir: string): Promise<string[]> {
       files.push(fullPath);
     }
   }
-  return files.toSorted((left, right) => left.localeCompare(right));
+  return { files: files.toSorted((left, right) => left.localeCompare(right)), incomplete };
 }
 
 async function collectUnsafeLocalArtifacts(
   configuredPaths: string[],
-): Promise<UnsafeLocalArtifact[]> {
+  state: MemoryWikiImportedSourceState,
+): Promise<UnsafeLocalArtifactCollection> {
   const artifacts: UnsafeLocalArtifact[] = [];
+  const pruneProtectedRoots: string[] = [];
   for (const configuredPath of configuredPaths) {
     const absoluteConfiguredPath = path.resolve(configuredPath);
     const stat = await fs.stat(absoluteConfiguredPath).catch(() => null);
     if (!stat) {
+      if (hasImportedUnsafeLocalDescendant(state, absoluteConfiguredPath)) {
+        pruneProtectedRoots.push(absoluteConfiguredPath);
+      }
       continue;
     }
     if (stat.isDirectory()) {
-      const files = await listAllowedFilesRecursive(absoluteConfiguredPath);
+      const { files, incomplete } = await listAllowedFilesRecursive(absoluteConfiguredPath);
+      if (incomplete) {
+        pruneProtectedRoots.push(absoluteConfiguredPath);
+      }
       for (const absolutePath of files) {
         artifacts.push({
           syncKey: await resolveArtifactKey(absolutePath),
@@ -100,7 +159,7 @@ async function collectUnsafeLocalArtifacts(
   for (const artifact of artifacts) {
     deduped.set(artifact.syncKey, artifact);
   }
-  return [...deduped.values()];
+  return { artifacts: [...deduped.values()], pruneProtectedRoots };
 }
 
 function resolveUnsafeLocalPagePath(params: { configuredPath: string; absolutePath: string }): {
@@ -214,18 +273,21 @@ export async function syncMemoryWikiUnsafeLocalSources(
     };
   }
 
-  const artifacts = await collectUnsafeLocalArtifacts(config.unsafeLocal.paths);
   const state = await readMemoryWikiSourceSyncState(config.vault.path);
+  const { artifacts, pruneProtectedRoots } = await collectUnsafeLocalArtifacts(
+    config.unsafeLocal.paths,
+    state,
+  );
+  const activeKeys = new Set(artifacts.map((artifact) => artifact.syncKey));
+  addPruneProtectedKeys({ activeKeys, pruneProtectedRoots, state });
   assertMemoryWikiSourceSyncStateCapacity({
     state,
     group: "unsafe-local",
-    incomingCount: artifacts.length,
+    incomingCount: activeKeys.size,
   });
-  const activeKeys = new Set<string>();
   const results = await Promise.all(
     artifacts.map(async (artifact) => {
       const stats = await fs.stat(artifact.absolutePath);
-      activeKeys.add(artifact.syncKey);
       return await writeUnsafeLocalSourcePage({
         config,
         artifact,


### PR DESCRIPTION
Closes #97523

AI-assisted: yes. I understand the change and validated the unsafe-local sync behavior with focused tests and autoreview.

## What Problem This Solves

Fixes an issue where users running memory-wiki in `unsafe-local` mode could lose imported pages and hand-written human notes when a configured source directory was temporarily unavailable, such as an unmounted drive, rebooting NAS, or cloud folder not mounted yet.

## Why This Change Was Made

The sync now distinguishes a configured file that disappeared from a previously imported directory root that is currently unreadable or missing. Imported descendants under unavailable roots are protected from destructive pruning for that sync, while explicitly deleted configured files still prune through the existing active-key flow. The capacity preflight uses the final protected active-key set before any page writes happen.

## User Impact

Users can keep unsafe-local source directories on removable, network, or cloud-synced storage without a transient outage deleting imported wiki pages or the preserved `openclaw:human` notes block. Intentional deletion of a configured file still removes its stale imported page.

## Evidence

- `node scripts/run-vitest.mjs extensions/memory-wiki/src/unsafe-local.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

The regression covers a temporarily unavailable configured directory containing a `..notes.md` imported file, verifies `removedCount` remains `0`, and verifies the human notes block survives both the outage sync and the later successful resync.
