### PR TITLE
fix(cron): warn when toolsAllow includes web_search but no search provider is enabled

### DIFF
--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -80,6 +80,7 @@ export const getChannelPluginMock = createMock();
 export const retireSessionMcpRuntimeMock = createMock();
 export const callGatewayMock = createMock();
 export const ensureRuntimePluginsLoadedMock = createMock();
+export const listWebSearchProvidersMock = createMock();
 
 const resolveBootstrapWarningSignaturesSeenMock = createMock();
 const resolveCronStyleNowMock = createMock();
@@ -159,6 +160,10 @@ vi.mock("./run-model-catalog.runtime.js", () => ({
 
 vi.mock("../../plugins/runtime-plugins.runtime.js", () => ({
   ensureRuntimePluginsLoaded: ensureRuntimePluginsLoadedMock,
+}));
+
+vi.mock("../../web-search/runtime.js", () => ({
+  listWebSearchProviders: listWebSearchProvidersMock,
 }));
 
 vi.mock("../../skills/runtime/cron-snapshot.runtime.js", () => ({
@@ -494,6 +499,8 @@ function resetRunConfigMocks(): void {
   getSkillsSnapshotVersionMock.mockReturnValue(42);
   loadModelCatalogMock.mockResolvedValue([]);
   getRemoteSkillEligibilityMock.mockResolvedValue({ remoteSkillsEnabled: false });
+  listWebSearchProvidersMock.mockReset();
+  listWebSearchProvidersMock.mockReturnValue([]);
 }
 
 function resetRunExecutionMocks(): void {

--- a/src/cron/isolated-agent/run.tools-allow.test.ts
+++ b/src/cron/isolated-agent/run.tools-allow.test.ts
@@ -127,4 +127,23 @@ describe("runCronIsolatedAgentTurn toolsAllow passthrough", () => {
       expect(call.toolsAllow).toEqual(["maniple__check_idle_workers"]);
     },
   );
+
+  it(
+    "warns when web_search is allowed but no provider is enabled",
+    { timeout: RUN_TOOLS_ALLOW_TIMEOUT_MS },
+    async () => {
+      const result = await runCronIsolatedAgentTurn(makeParamsWithToolsAllow(["web_search"]));
+
+      expect(result.diagnostics?.summary).toContain(
+        "web_search tool requested (toolsAllow) but no web search provider plugin is enabled",
+      );
+      expect(result.diagnostics?.entries[0]).toMatchObject({
+        source: "cron-preflight",
+        severity: "warn",
+      });
+      expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
+      const call = requireEmbeddedAgentCall();
+      expect(call.toolsAllow).toEqual(["web_search"]);
+    },
+  );
 });

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -50,6 +50,7 @@ import {
   createCronRunDiagnosticsFromAgentResult,
   createCronRunDiagnosticsFromError,
   mergeCronRunDiagnostics,
+  normalizeCronRunDiagnostics,
 } from "../run-diagnostics.js";
 import { resolveCronAbortReasonText } from "../service/execution-errors.js";
 import { resolveCronDeliverySessionKey } from "../session-target.js";
@@ -60,8 +61,10 @@ import type {
   CronDeliveryTraceMessageTarget,
   CronDeliveryTraceTarget,
   CronJob,
+  CronRunDiagnostics,
   CronRunTelemetry,
 } from "../types.js";
+import { listWebSearchProviders } from "../../web-search/runtime.js";
 import { resolveCronChannelOutputPolicy } from "./channel-output-policy.js";
 import {
   isHeartbeatOnlyResponse,
@@ -483,6 +486,12 @@ type PreparedCronRunContext = {
    * the LLM idle watchdog can honor the cron's per-run choice.
    */
   runTimeoutOverrideMs?: number;
+  /**
+   * Diagnostic warnings assembled during preflight (e.g. toolsAllow lists a
+   * tool that has no registered provider). Merged into the final run result so
+   * operators can see the misconfiguration even when the run status is "ok".
+   */
+  preflightDiagnostics?: CronRunDiagnostics;
 };
 
 type CronPreparationResult =
@@ -876,6 +885,38 @@ async function prepareCronRunContext(params: {
       : undefined,
   };
 
+  // Preflight: warn when toolsAllow requests web_search but no provider is enabled.
+  // This avoids silent failures where the model apologises instead of searching.
+  let preflightDiagnostics: CronRunDiagnostics | undefined;
+  const agentPayloadToolsAllow = agentPayload?.toolsAllow;
+  if (agentPayloadToolsAllow && agentPayloadToolsAllow.length > 0) {
+    const normalizedAllow = expandToolGroups(agentPayloadToolsAllow).map((t) =>
+      normalizeToolName(t),
+    );
+    const requestsWebSearch =
+      normalizedAllow.includes("*") || normalizedAllow.includes("web_search");
+    if (requestsWebSearch) {
+      const webSearchProviders = listWebSearchProviders({ config: cfgWithAgentDefaults });
+      if (webSearchProviders.length === 0) {
+        preflightDiagnostics = normalizeCronRunDiagnostics({
+          summary:
+            "web_search tool requested (toolsAllow) but no web search provider plugin is enabled. " +
+            "Enable one with: openclaw plugins enable duckduckgo",
+          entries: [
+            {
+              ts: Date.now(),
+              source: "cron-preflight",
+              severity: "warn",
+              message:
+                "web_search tool requested (toolsAllow) but no web search provider plugin is enabled. " +
+                "Enable one with: openclaw plugins enable duckduckgo",
+            },
+          ],
+        });
+      }
+    }
+  }
+
   return {
     ok: true,
     context: {
@@ -908,6 +949,7 @@ async function prepareCronRunContext(params: {
       thinkLevel,
       timeoutMs,
       runTimeoutOverrideMs,
+      preflightDiagnostics,
     },
   };
 }
@@ -1471,11 +1513,22 @@ export async function runCronIsolatedAgentTurn(params: {
         cronRunSessionCleanupAttempted = true;
       },
     });
-    if (finalized.status === "error") {
+    // Merge any preflight warnings (e.g. toolsAllow misconfiguration) so they
+    // appear in diagnostics_summary even when the run status is "ok".
+    const result = prepared.context.preflightDiagnostics
+      ? {
+          ...finalized,
+          diagnostics: mergeCronRunDiagnostics(
+            prepared.context.preflightDiagnostics,
+            finalized.diagnostics,
+          ),
+        }
+      : finalized;
+    if (result.status === "error") {
       outcome = "error";
-      outcomeError = finalized.error;
+      outcomeError = result.error;
     }
-    return finalized;
+    return result;
   } catch (err) {
     const isCronLaneTimeout = isAborted() || isCronNestedLaneTaskTimeoutError(err);
     const error = isCronLaneTimeout ? abortReason() : String(err);

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -41,6 +41,7 @@ import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { resolveNonNegativeNumber } from "../../shared/number-coercion.js";
 import { resolveCronSkillsSnapshot } from "../../skills/runtime/cron-snapshot.js";
 import type { SkillSnapshot } from "../../skills/types.js";
+import { listWebSearchProviders } from "../../web-search/runtime.js";
 import {
   hasExplicitCronDeliveryTarget,
   resolveCronDeliveryPlan,
@@ -64,7 +65,6 @@ import type {
   CronRunDiagnostics,
   CronRunTelemetry,
 } from "../types.js";
-import { listWebSearchProviders } from "../../web-search/runtime.js";
 import { resolveCronChannelOutputPolicy } from "./channel-output-policy.js";
 import {
   isHeartbeatOnlyResponse,
@@ -890,11 +890,10 @@ async function prepareCronRunContext(params: {
   let preflightDiagnostics: CronRunDiagnostics | undefined;
   const agentPayloadToolsAllow = agentPayload?.toolsAllow;
   if (agentPayloadToolsAllow && agentPayloadToolsAllow.length > 0) {
-    const normalizedAllow = expandToolGroups(agentPayloadToolsAllow).map((t) =>
-      normalizeToolName(t),
+    const normalizedAllow = new Set(
+      expandToolGroups(agentPayloadToolsAllow).map((t) => normalizeToolName(t)),
     );
-    const requestsWebSearch =
-      normalizedAllow.includes("*") || normalizedAllow.includes("web_search");
+    const requestsWebSearch = normalizedAllow.has("*") || normalizedAllow.has("web_search");
     if (requestsWebSearch) {
       const webSearchProviders = listWebSearchProviders({ config: cfgWithAgentDefaults });
       if (webSearchProviders.length === 0) {


### PR DESCRIPTION
## Summary

- Adds a cron preflight diagnostic when `toolsAllow` requests `web_search` but no web search provider plugin is enabled.
- Keeps execution behavior unchanged: the job still runs and delivery/status are not blocked.
- Makes the misconfiguration visible in diagnostics instead of leaving operators with a successful run that could not actually search.
- Review focus: diagnostic-only behavior and the plugin/provider availability check.

## Linked context

Closes #97654.

Related: cron isolated-agent diagnostics and tool availability handling.

Maintainer request: not directly requested by a maintainer.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: cron jobs could allow `web_search` while all search provider plugins were disabled, producing no operator-visible warning.
- Real environment tested: local OpenClaw cron isolated-agent test harness on Node 22 with web search providers mocked to an empty list.
- Exact steps or command run after this patch: `PNPM_CONFIG_MODULES_DIR=/media/vdc/0668001470/workSpace/claw-campaign/openclaw/node_modules node scripts/run-vitest.mjs src/cron/isolated-agent/run.tools-allow.test.ts -- --run -t "warns when web_search is allowed but no provider is enabled"`
- Evidence after fix:

```text
Test Files  1 passed (1)
     Tests  1 passed | 3 skipped (4)
[test] passed 1 Vitest shard
```

- Observed result after fix: cron diagnostics include a warn-severity message explaining that `web_search` was requested but no provider plugin is enabled, while the run status remains unchanged.
- What was not tested: a live scheduled cron run through a deployed gateway.
- Proof limitations or environment constraints: proof uses the cron isolated-agent harness with runtime provider list controlled to reproduce the misconfiguration deterministically.
- Before evidence: the same configuration completed without a diagnostics warning.

## Tests and validation

- `PNPM_CONFIG_MODULES_DIR=/media/vdc/0668001470/workSpace/claw-campaign/openclaw/node_modules node scripts/run-vitest.mjs src/cron/isolated-agent/run.tools-allow.test.ts -- --run -t "warns when web_search is allowed but no provider is enabled"`
- `/media/vdc/0668001470/workSpace/claw-campaign/openclaw/node_modules/.bin/oxlint src/cron/isolated-agent/run.ts src/cron/isolated-agent/run.tools-allow.test.ts src/cron/isolated-agent/run.test-harness.ts`
- Regression coverage verifies diagnostic text, severity, and that passthrough execution behavior remains intact.

## Risk checklist

Did user-visible behavior change? (`Yes/No`) Yes. Operators now see an additional warning diagnostic.

Did config, environment, or migration behavior change? (`Yes/No`) No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`) No execution behavior change; only preflight diagnostics change.

What is the highest-risk area? False-positive warning if provider availability is not loaded before the preflight.

How is that risk mitigated? The check runs after runtime plugins are loaded and uses the same provider listing path used by web search availability.

## Current review state

Next action: ClawSweeper/maintainer re-review after the previous infrastructure timeout.

Waiting on: ClawSweeper to complete a fresh review; the earlier review failed due infrastructure timeout, not patch quality.

Bot/reviewer comments addressed: lint issue fixed with `Set.has`, focused regression coverage added, and PR body now follows the full template.

_AI-assisted; implementation and validation reviewed before pushing._
