### PR TITLE
fix(control-ui): WebSocket connects to wrong gateway when two share an origin

### DIFF
--- a/ui/src/app/settings.node.test.ts
+++ b/ui/src/app/settings.node.test.ts
@@ -3,10 +3,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createImportedCustomThemeFixture } from "../test-helpers/custom-theme.ts";
 import { createStorageMock } from "../test-helpers/storage.ts";
 import {
+  loadGatewaySessionSelection,
   loadLocalUserIdentity,
   loadSettings,
   saveLocalUserIdentity,
   saveSettings,
+  type UiSettings,
 } from "./settings.ts";
 
 function setTestLocation(params: { protocol: string; host: string; pathname: string }) {
@@ -43,6 +45,26 @@ function setControlUiBasePath(value: string | undefined) {
 function expectedGatewayUrl(basePath: string): string {
   const proto = location.protocol === "https:" ? "wss" : "ws";
   return `${proto}://${location.host}${basePath}`;
+}
+
+function makeSettings(gatewayUrl: string, overrides: Partial<UiSettings> = {}): UiSettings {
+  return {
+    gatewayUrl,
+    token: "",
+    sessionKey: "main",
+    lastActiveSessionKey: "main",
+    theme: "claw",
+    themeMode: "system",
+    chatShowThinking: true,
+    chatShowToolCalls: true,
+    splitRatio: 0.6,
+    navCollapsed: false,
+    navWidth: 220,
+    sidebarPinnedRoutes: ["overview"],
+    sidebarMoreExpanded: false,
+    borderRadius: 50,
+    ...overrides,
+  };
 }
 
 describe("loadSettings default gateway URL derivation", () => {
@@ -698,6 +720,100 @@ describe("loadSettings default gateway URL derivation", () => {
       "wss://stale-10.example:8443",
       "wss://gateway.example:8443",
     ]);
+  });
+
+  it("does not let a saved sibling base path override the current page gateway", () => {
+    setTestLocation({ protocol: "https:", host: "multi.example:8443", pathname: "/gateway-a/" });
+    setControlUiBasePath("/gateway-a");
+    saveSettings(makeSettings(expectedGatewayUrl("/gateway-a")));
+
+    setTestLocation({ protocol: "https:", host: "multi.example:8443", pathname: "/gateway-b/" });
+    setControlUiBasePath("/gateway-b");
+
+    expect(loadSettings().gatewayUrl).toBe(expectedGatewayUrl("/gateway-b"));
+    expect(localStorage.getItem("openclaw.control.settings.v1")).toBeNull();
+  });
+
+  it("leaves an ambiguous same-origin legacy sibling for its owning page", () => {
+    setTestLocation({ protocol: "https:", host: "multi.example:8443", pathname: "/gateway-b/" });
+    setControlUiBasePath("/gateway-b");
+    localStorage.setItem(
+      "openclaw.control.settings.v1",
+      JSON.stringify({
+        gatewayUrl: "wss://multi.example:8443/gateway-a",
+        sessionKey: "agent:a:main",
+      }),
+    );
+
+    expect(loadSettings().gatewayUrl).toBe(expectedGatewayUrl("/gateway-b"));
+    expect(loadGatewaySessionSelection(expectedGatewayUrl("/gateway-b"))).toEqual({
+      sessionKey: "main",
+      lastActiveSessionKey: "main",
+    });
+    expect(localStorage.getItem("openclaw.control.settings.v1")).not.toBeNull();
+  });
+
+  it("migrates a legacy record that matches the current page", () => {
+    setTestLocation({ protocol: "https:", host: "multi.example:8443", pathname: "/gateway-b/" });
+    setControlUiBasePath("/gateway-b");
+    const gatewayUrl = expectedGatewayUrl("/gateway-b");
+    localStorage.setItem(
+      "openclaw.control.settings.v1",
+      JSON.stringify({
+        gatewayUrl,
+        sessionKey: "agent:b:main",
+        lastActiveSessionKey: "agent:b:main",
+      }),
+    );
+
+    expect(loadSettings()).toMatchObject({ gatewayUrl, sessionKey: "agent:b:main" });
+    expect(
+      localStorage.getItem("openclaw.control.currentGateway.v1:wss://multi.example:8443/gateway-b"),
+    ).toBe(gatewayUrl);
+    expect(localStorage.getItem(`openclaw.control.settings.v1:${gatewayUrl}`)).not.toBeNull();
+    expect(localStorage.getItem("openclaw.control.settings.v1")).toBeNull();
+  });
+
+  it("migrates a legacy custom gateway on a different host", () => {
+    setTestLocation({ protocol: "https:", host: "control.example:8443", pathname: "/openclaw/" });
+    setControlUiBasePath("/openclaw");
+    const remoteUrl = "wss://remote-gateway.example.com";
+    localStorage.setItem(
+      "openclaw.control.settings.v1",
+      JSON.stringify({ gatewayUrl: remoteUrl, sessionKey: "remote-session" }),
+    );
+
+    expect(loadSettings()).toMatchObject({ gatewayUrl: remoteUrl, sessionKey: "remote-session" });
+    expect(
+      localStorage.getItem(
+        "openclaw.control.currentGateway.v1:wss://control.example:8443/openclaw",
+      ),
+    ).toBe(remoteUrl);
+    expect(localStorage.getItem("openclaw.control.settings.v1")).toBeNull();
+  });
+
+  it("keeps custom gateway selections isolated per Control UI base path", () => {
+    setTestLocation({ protocol: "https:", host: "multi.example:8443", pathname: "/gateway-a/" });
+    setControlUiBasePath("/gateway-a");
+    saveSettings(makeSettings("wss://remote-a.example.com", { sessionKey: "agent:a:main" }));
+
+    setTestLocation({ protocol: "https:", host: "multi.example:8443", pathname: "/gateway-b/" });
+    setControlUiBasePath("/gateway-b");
+    saveSettings(makeSettings("wss://remote-b.example.com", { sessionKey: "agent:b:main" }));
+
+    setTestLocation({ protocol: "https:", host: "multi.example:8443", pathname: "/gateway-a/" });
+    setControlUiBasePath("/gateway-a");
+    expect(loadSettings()).toMatchObject({
+      gatewayUrl: "wss://remote-a.example.com",
+      sessionKey: "agent:a:main",
+    });
+
+    setTestLocation({ protocol: "https:", host: "multi.example:8443", pathname: "/gateway-b/" });
+    setControlUiBasePath("/gateway-b");
+    expect(loadSettings()).toMatchObject({
+      gatewayUrl: "wss://remote-b.example.com",
+      sessionKey: "agent:b:main",
+    });
   });
 
   it("persists local user identity separately from gateway settings", () => {

--- a/ui/src/app/settings.ts
+++ b/ui/src/app/settings.ts
@@ -1,6 +1,7 @@
 // Control UI module implements storage behavior.
 const SETTINGS_KEY_PREFIX = "openclaw.control.settings.v1:";
 const LEGACY_SETTINGS_KEY = "openclaw.control.settings.v1";
+const CURRENT_GATEWAY_SELECTION_KEY_PREFIX = "openclaw.control.currentGateway.v1:";
 const LOCAL_USER_IDENTITY_KEY = "openclaw.control.user.v1";
 const LEGACY_TOKEN_SESSION_KEY = "openclaw.control.token.v1";
 const TOKEN_SESSION_KEY_PREFIX = "openclaw.control.token.v1:";
@@ -13,6 +14,10 @@ type WindowWithControlUiBasePath = Window &
 
 function settingsKeyForGateway(gatewayUrl: string): string {
   return `${SETTINGS_KEY_PREFIX}${normalizeGatewayTokenScope(gatewayUrl)}`;
+}
+
+function currentGatewaySelectionKeyForPage(pageUrl: string): string {
+  return `${CURRENT_GATEWAY_SELECTION_KEY_PREFIX}${normalizeGatewayTokenScope(pageUrl)}`;
 }
 
 type ScopedSessionSelection = {
@@ -364,6 +369,95 @@ function normalizeGatewayTokenScope(gatewayUrl: string): string {
   }
 }
 
+type PersistedSettingsSource = {
+  gatewayUrl: string;
+  legacy: boolean;
+  parsed: PersistedUiSettings;
+};
+
+function parsePersistedSettings(raw: string | null): PersistedUiSettings | null {
+  if (!raw) {
+    return null;
+  }
+  try {
+    return JSON.parse(raw) as PersistedUiSettings;
+  } catch {
+    return null;
+  }
+}
+
+function settingsMatchGatewayTarget(
+  parsed: PersistedUiSettings,
+  targetUrl: string,
+  aliases: readonly string[] = [],
+): boolean {
+  const storedUrl = normalizeOptionalString(parsed.gatewayUrl);
+  if (!storedUrl) {
+    return false;
+  }
+  const storedScope = normalizeGatewayTokenScope(storedUrl);
+  return [targetUrl, ...aliases].some(
+    (candidate) => normalizeGatewayTokenScope(candidate) === storedScope,
+  );
+}
+
+function isClaimableLegacyGateway(storedUrl: string | undefined, pageUrl: string): boolean {
+  if (!storedUrl) {
+    return false;
+  }
+  try {
+    const stored = new URL(normalizeGatewayTokenScope(storedUrl));
+    const page = new URL(normalizeGatewayTokenScope(pageUrl));
+    return stored.host !== page.host || page.pathname === "/";
+  } catch {
+    return false;
+  }
+}
+
+function readSettingsForGateway(
+  storage: Storage | null,
+  targetUrl: string,
+  options: {
+    includeLegacy?: boolean;
+    legacyAliases?: readonly string[];
+    remoteLegacyPageUrl?: string;
+  } = {},
+): PersistedSettingsSource | null {
+  const scoped = parsePersistedSettings(storage?.getItem(settingsKeyForGateway(targetUrl)) ?? null);
+  if (
+    scoped &&
+    (!normalizeOptionalString(scoped.gatewayUrl) || settingsMatchGatewayTarget(scoped, targetUrl))
+  ) {
+    return {
+      gatewayUrl: normalizeOptionalString(scoped.gatewayUrl) ?? targetUrl,
+      legacy: false,
+      parsed: scoped,
+    };
+  }
+  if (!options.includeLegacy) {
+    return null;
+  }
+  for (const key of [`${SETTINGS_KEY_PREFIX}default`, LEGACY_SETTINGS_KEY]) {
+    const parsed = parsePersistedSettings(storage?.getItem(key) ?? null);
+    if (!parsed) {
+      continue;
+    }
+    const storedUrl = normalizeOptionalString(parsed.gatewayUrl);
+    const matchesTarget = settingsMatchGatewayTarget(parsed, targetUrl, options.legacyAliases);
+    const isRemote = options.remoteLegacyPageUrl
+      ? isClaimableLegacyGateway(storedUrl, options.remoteLegacyPageUrl)
+      : false;
+    if (matchesTarget || isRemote) {
+      return {
+        gatewayUrl: storedUrl ?? targetUrl,
+        legacy: true,
+        parsed,
+      };
+    }
+  }
+  return null;
+}
+
 function tokenSessionKeyForGateway(gatewayUrl: string): string {
   return `${TOKEN_SESSION_KEY_PREFIX}${normalizeGatewayTokenScope(gatewayUrl)}`;
 }
@@ -400,11 +494,8 @@ export function loadGatewaySessionSelection(gatewayUrl: string): ScopedSessionSe
   const fallback = { sessionKey: "main", lastActiveSessionKey: "main" };
   try {
     const storage = getSafeLocalStorage();
-    const raw =
-      storage?.getItem(settingsKeyForGateway(gatewayUrl)) ?? storage?.getItem(LEGACY_SETTINGS_KEY);
-    return raw
-      ? resolveScopedSessionSelection(gatewayUrl, JSON.parse(raw) as PersistedUiSettings, fallback)
-      : fallback;
+    const source = readSettingsForGateway(storage, gatewayUrl, { includeLegacy: true });
+    return source ? resolveScopedSessionSelection(gatewayUrl, source.parsed, fallback) : fallback;
   } catch {
     return fallback;
   }
@@ -484,17 +575,25 @@ export function loadSettings(): UiSettings {
   };
 
   try {
-    // First check for legacy key (no scope), then check for scoped key
-    const scopedKey = settingsKeyForGateway(defaults.gatewayUrl);
-    const raw =
-      storage?.getItem(scopedKey) ??
-      storage?.getItem(SETTINGS_KEY_PREFIX + "default") ??
-      storage?.getItem(LEGACY_SETTINGS_KEY);
-    if (!raw) {
+    const selectedGatewayUrl = normalizeOptionalString(
+      storage?.getItem(currentGatewaySelectionKeyForPage(pageDerivedUrl)),
+    );
+    const selected = selectedGatewayUrl
+      ? readSettingsForGateway(storage, selectedGatewayUrl)
+      : null;
+    // Legacy state has no page owner. Only the current page target or a deliberate
+    // cross-origin remote can claim it; ambiguous same-origin sibling paths cannot.
+    const defaultSource = readSettingsForGateway(storage, defaultUrl, {
+      includeLegacy: true,
+      legacyAliases: [pageDerivedUrl],
+      remoteLegacyPageUrl: pageDerivedUrl,
+    });
+    const source = selected ?? defaultSource;
+    if (!source) {
       return defaults;
     }
-    const parsed = JSON.parse(raw) as PersistedUiSettings;
-    const parsedGatewayUrl = normalizeOptionalString(parsed.gatewayUrl) ?? defaults.gatewayUrl;
+    const parsed = source.parsed;
+    const parsedGatewayUrl = source.gatewayUrl;
     const gatewayUrl = parsedGatewayUrl === pageDerivedUrl ? defaultUrl : parsedGatewayUrl;
     const scopedSessionSelection = resolveScopedSessionSelection(gatewayUrl, parsed, defaults);
     const customTheme = parseImportedCustomTheme((parsed as { customTheme?: unknown }).customTheme);
@@ -553,8 +652,8 @@ export function loadSettings(): UiSettings {
       customTheme: customTheme ?? undefined,
       locale: isSupportedLocale(parsed.locale) ? parsed.locale : undefined,
     };
-    if ("token" in parsed) {
-      persistSettings(settings);
+    if (source.legacy || "token" in parsed) {
+      persistSettings(settings, { selectGateway: true });
     }
     return settings;
   } catch {
@@ -568,7 +667,7 @@ export function saveSettings(next: UiSettings) {
 
 export function patchSettings(patch: Partial<UiSettings>): UiSettings {
   const next = { ...loadSettings(), ...patch };
-  persistSettings(next);
+  persistSettings(next, { selectGateway: patch.gatewayUrl !== undefined });
   return next;
 }
 
@@ -600,20 +699,16 @@ export function saveLocalUserIdentity(next: LocalUserIdentity) {
   }
 }
 
-function persistSettings(next: UiSettings) {
+function persistSettings(next: UiSettings, options: { selectGateway?: boolean } = {}) {
   persistSessionToken(next.gatewayUrl, next.token);
   const storage = getSafeLocalStorage();
   const scope = normalizeGatewayTokenScope(next.gatewayUrl);
   const scopedKey = settingsKeyForGateway(next.gatewayUrl);
   let existingSessionsByGateway: Record<string, ScopedSessionSelection> = {};
   try {
-    // Try to migrate from legacy key or other scopes
-    const raw =
-      storage?.getItem(scopedKey) ??
-      storage?.getItem(SETTINGS_KEY_PREFIX + "default") ??
-      storage?.getItem("openclaw.control.settings.v1");
-    if (raw) {
-      const parsed = JSON.parse(raw) as PersistedUiSettings;
+    const source = readSettingsForGateway(storage, next.gatewayUrl, { includeLegacy: true });
+    if (source) {
+      const parsed = source.parsed;
       if (parsed.sessionsByGateway && typeof parsed.sessionsByGateway === "object") {
         existingSessionsByGateway = parsed.sessionsByGateway;
       }
@@ -658,8 +753,13 @@ function persistSettings(next: UiSettings) {
   };
   const serialized = JSON.stringify(persisted);
   try {
+    const { pageUrl } = deriveDefaultGatewayUrl();
+    const selectionKey = currentGatewaySelectionKeyForPage(pageUrl);
     storage?.setItem(scopedKey, serialized);
-    storage?.setItem(LEGACY_SETTINGS_KEY, serialized);
+    if (options.selectGateway || storage?.getItem(selectionKey) == null) {
+      storage?.setItem(selectionKey, next.gatewayUrl);
+    }
+    storage?.removeItem(LEGACY_SETTINGS_KEY);
   } catch {
     // best-effort — quota exceeded or security restrictions should not
     // prevent in-memory settings and visual updates from being applied


### PR DESCRIPTION
Fixes #97636.

## What Problem This Solves

Two Control UIs served from different base paths on one origin shared one legacy settings record. Visiting the second UI could restore the first UI's Gateway URL, so its WebSocket connected to the wrong Gateway.

## Why This Change Was Made

The original PR added path heuristics and several new storage layers. This maintainer rewrite keeps one canonical payload per Gateway URL and adds only a page-scoped pointer to the selected Gateway.

Loading now:

- resolves a page's selected Gateway from its own base-path scope;
- validates that a scoped payload belongs to its key;
- rejects ambiguous same-origin legacy settings from sibling base paths;
- still migrates matching legacy settings and deliberate cross-origin custom Gateways;
- preserves custom Gateway selections and session state independently per base path.

Saving writes the canonical scoped payload, initializes or explicitly updates the page pointer, and removes the unscoped legacy record.

## User Impact

Multiple Gateways can safely share one browser origin under distinct paths. Existing matching or remote custom settings migrate automatically; sibling settings no longer redirect a page to the wrong WebSocket.

## Evidence

- 35 focused settings/Gateway-store tests passed.
- Full `pnpm build` passed.
- `pnpm check:changed` passed for both touched files.
- Blacksmith Testbox lease: `tbx_01kww1cytcgctj7rzjm3g6rczw`.
- Live Chromium E2E ran two real Gateways behind nginx on one origin. `/gateway-a` and `/gateway-b` each sent a real `connect` frame to its own WebSocket; Gateway B kept its own settings despite an injected Gateway A legacy record.
- Fresh autoreview reported no actionable findings.
