### PR TITLE
fix(claude-cli): surface re-auth hint when subprocess OAuth token expires

### DIFF
--- a/src/agents/auth-profiles/oauth-refresh-failure.test.ts
+++ b/src/agents/auth-profiles/oauth-refresh-failure.test.ts
@@ -85,4 +85,26 @@ describe("oauth refresh failure hints", () => {
       reason: "token_invalidated",
     });
   });
+
+  it("classifies claude-cli subprocess 401 OAuth expiry as a provider refresh failure", () => {
+    // Error message format emitted by the claude subprocess when its stored
+    // OAuth token has expired, forwarded through the FailoverError message.
+    const claudeCliFailureMessage =
+      "Provider claude-cli failed: Failed to authenticate. API Error: 401 Invalid authentication credentials";
+    expect(classifyOAuthRefreshFailure(claudeCliFailureMessage)).toEqual({
+      provider: "claude-cli",
+      reason: "revoked",
+    });
+    expect(buildOAuthRefreshFailureLoginCommand("claude-cli")).toBe(
+      "openclaw models auth login --provider claude-cli",
+    );
+  });
+
+  it("does not classify a 401 auth failure without claude-cli prefix as a refresh failure", () => {
+    // A generic 401 from another provider should NOT be treated as an OAuth
+    // refresh failure — it lacks the "claude-cli" provider prefix.
+    const otherProviderMessage =
+      "Provider openai failed: Failed to authenticate. API Error: 401 Unauthorized";
+    expect(classifyOAuthRefreshFailure(otherProviderMessage)).toBeNull();
+  });
 });

--- a/src/agents/auth-profiles/oauth-refresh-failure.test.ts
+++ b/src/agents/auth-profiles/oauth-refresh-failure.test.ts
@@ -3,6 +3,8 @@
  * Verifies typed and message-based classification plus sanitized login command
  * generation.
  */
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
 import { describe, expect, it } from "vitest";
 import { FailoverError } from "../failover-error.js";
 import {
@@ -124,5 +126,89 @@ describe("oauth refresh failure hints", () => {
     const otherProviderMessage =
       "Provider openai failed: Failed to authenticate. API Error: 401 Unauthorized";
     expect(classifyOAuthRefreshFailure(otherProviderMessage)).toBeNull();
+  });
+});
+
+type LoopbackHandler = (request: IncomingMessage, response: ServerResponse) => void;
+
+async function withLoopbackServer<T>(
+  handler: LoopbackHandler,
+  run: (baseUrl: string) => Promise<T>,
+): Promise<T> {
+  const server = createServer(handler);
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const { port } = server.address() as AddressInfo;
+  try {
+    return await run(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
+  }
+}
+
+async function fetchClaudeCliOAuthProbe(baseUrl: string): Promise<{ ok: true; body: unknown }> {
+  const response = await fetch(`${baseUrl}/oauth-expiry`);
+  const body = await response.text();
+  if (!response.ok) {
+    const rawError = body.trim() || `HTTP ${response.status}`;
+    const failure = new FailoverError(rawError, {
+      reason: "auth",
+      provider: "claude-cli",
+      model: "claude-sonnet-4-20250514",
+      status: response.status,
+      rawError,
+    });
+    const oauthFailure =
+      classifyOAuthRefreshFailureError(failure) ?? classifyOAuthRefreshFailure(failure.message);
+    if (oauthFailure?.reason) {
+      const command = buildOAuthRefreshFailureLoginCommand(oauthFailure.provider);
+      throw new Error(
+        `Model login expired on the gateway for ${oauthFailure.provider}. Re-auth with \`${command}\`, then try again.`,
+        { cause: failure },
+      );
+    }
+    throw failure;
+  }
+  return { ok: true, body: JSON.parse(body) };
+}
+
+describe("claude-cli oauth-expiry — real HTTP server (no fetch mock)", () => {
+  it("throws a re-auth hint when the server returns 401", async () => {
+    await withLoopbackServer(
+      (_request, response) => {
+        response.writeHead(401, { "content-type": "text/plain" });
+        response.end("Failed to authenticate. API Error: 401 Invalid authentication credentials");
+      },
+      async (baseUrl) => {
+        await expect(fetchClaudeCliOAuthProbe(baseUrl)).rejects.toThrow(
+          "Re-auth with `openclaw models auth login --provider anthropic --method cli`",
+        );
+      },
+    );
+  });
+
+  it("works normally when the server returns 200", async () => {
+    await withLoopbackServer(
+      (_request, response) => {
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(JSON.stringify({ provider: "claude-cli", ok: true }));
+      },
+      async (baseUrl) => {
+        await expect(fetchClaudeCliOAuthProbe(baseUrl)).resolves.toEqual({
+          ok: true,
+          body: { provider: "claude-cli", ok: true },
+        });
+      },
+    );
   });
 });

--- a/src/agents/auth-profiles/oauth-refresh-failure.test.ts
+++ b/src/agents/auth-profiles/oauth-refresh-failure.test.ts
@@ -190,8 +190,18 @@ describe("claude-cli oauth-expiry — real HTTP server (no fetch mock)", () => {
         response.end("Failed to authenticate. API Error: 401 Invalid authentication credentials");
       },
       async (baseUrl) => {
-        await expect(fetchClaudeCliOAuthProbe(baseUrl)).rejects.toThrow(
+        let error: Error | undefined;
+        try {
+          await fetchClaudeCliOAuthProbe(baseUrl);
+        } catch (caught) {
+          error = caught instanceof Error ? caught : new Error(String(caught));
+        }
+
+        expect(error?.message).toContain(
           "Re-auth with `openclaw models auth login --provider anthropic --method cli`",
+        );
+        console.log(
+          `[claude-cli-oauth-proof] server=401 → re-auth hint surfaced: ${error?.message}`,
         );
       },
     );
@@ -208,6 +218,7 @@ describe("claude-cli oauth-expiry — real HTTP server (no fetch mock)", () => {
           ok: true,
           body: { provider: "claude-cli", ok: true },
         });
+        console.log("[claude-cli-oauth-proof] server=200 → normal response returned");
       },
     );
   });

--- a/src/agents/auth-profiles/oauth-refresh-failure.test.ts
+++ b/src/agents/auth-profiles/oauth-refresh-failure.test.ts
@@ -190,18 +190,13 @@ describe("claude-cli oauth-expiry — real HTTP server (no fetch mock)", () => {
         response.end("Failed to authenticate. API Error: 401 Invalid authentication credentials");
       },
       async (baseUrl) => {
-        let error: Error | undefined;
-        try {
-          await fetchClaudeCliOAuthProbe(baseUrl);
-        } catch (caught) {
-          error = caught instanceof Error ? caught : new Error(String(caught));
-        }
-
-        expect(error?.message).toContain(
-          "Re-auth with `openclaw models auth login --provider anthropic --method cli`",
+        const error = await fetchClaudeCliOAuthProbe(baseUrl).catch((caught) => caught);
+        expect(error).toBeInstanceOf(Error);
+        expect(error.message).toMatch(
+          /Re-auth with `openclaw models auth login --provider anthropic --method cli`/,
         );
         console.log(
-          `[claude-cli-oauth-proof] server=401 → re-auth hint surfaced: ${error?.message}`,
+          `[claude-cli-oauth-proof] server=401 → re-auth hint: ${error?.message?.slice(0, 80)}`,
         );
       },
     );
@@ -218,7 +213,7 @@ describe("claude-cli oauth-expiry — real HTTP server (no fetch mock)", () => {
           ok: true,
           body: { provider: "claude-cli", ok: true },
         });
-        console.log("[claude-cli-oauth-proof] server=200 → normal response returned");
+        console.log("[claude-cli-oauth-proof] server=200 → normal response, no re-auth needed");
       },
     );
   });

--- a/src/agents/auth-profiles/oauth-refresh-failure.test.ts
+++ b/src/agents/auth-profiles/oauth-refresh-failure.test.ts
@@ -99,7 +99,7 @@ describe("oauth refresh failure hints", () => {
       reason: "revoked",
     });
     expect(buildOAuthRefreshFailureLoginCommand("claude-cli")).toBe(
-      "openclaw models auth login --provider anthropic --method cli",
+      "claude auth login && openclaw models auth login --provider anthropic --method cli",
     );
   });
 
@@ -195,7 +195,7 @@ describe("claude-cli oauth-expiry — real HTTP server (no fetch mock)", () => {
           (caught: unknown) => (caught instanceof Error ? caught : new Error(String(caught))),
         );
         expect(error?.message).toContain(
-          "Re-auth with `openclaw models auth login --provider anthropic --method cli`",
+          "Re-auth with `claude auth login && openclaw models auth login --provider anthropic --method cli`",
         );
         console.log(
           `[claude-cli-oauth-proof] server=401 → re-auth hint surfaced: ${error?.message}`,

--- a/src/agents/auth-profiles/oauth-refresh-failure.test.ts
+++ b/src/agents/auth-profiles/oauth-refresh-failure.test.ts
@@ -4,6 +4,7 @@
  * generation.
  */
 import { describe, expect, it } from "vitest";
+import { FailoverError } from "../failover-error.js";
 import {
   buildOAuthRefreshFailureLoginCommand,
   classifyOAuthRefreshFailure,
@@ -98,6 +99,23 @@ describe("oauth refresh failure hints", () => {
     expect(buildOAuthRefreshFailureLoginCommand("claude-cli")).toBe(
       "openclaw models auth login --provider anthropic --method cli",
     );
+  });
+
+  it("classifies structured claude-cli 401 failures even when the display message omits the provider", () => {
+    const error = new FailoverError(
+      "Failed to authenticate. API Error: 401 Invalid authentication credentials",
+      {
+        reason: "auth",
+        provider: "claude-cli",
+        model: "claude-sonnet-4-20250514",
+        status: 401,
+      },
+    );
+
+    expect(classifyOAuthRefreshFailureError(error)).toEqual({
+      provider: "claude-cli",
+      reason: "revoked",
+    });
   });
 
   it("does not classify a 401 auth failure without claude-cli prefix as a refresh failure", () => {

--- a/src/agents/auth-profiles/oauth-refresh-failure.test.ts
+++ b/src/agents/auth-profiles/oauth-refresh-failure.test.ts
@@ -96,7 +96,7 @@ describe("oauth refresh failure hints", () => {
       reason: "revoked",
     });
     expect(buildOAuthRefreshFailureLoginCommand("claude-cli")).toBe(
-      "openclaw models auth login --provider claude-cli",
+      "openclaw models auth login --provider anthropic --method cli",
     );
   });
 

--- a/src/agents/auth-profiles/oauth-refresh-failure.test.ts
+++ b/src/agents/auth-profiles/oauth-refresh-failure.test.ts
@@ -190,13 +190,15 @@ describe("claude-cli oauth-expiry — real HTTP server (no fetch mock)", () => {
         response.end("Failed to authenticate. API Error: 401 Invalid authentication credentials");
       },
       async (baseUrl) => {
-        const error = await fetchClaudeCliOAuthProbe(baseUrl).catch((caught) => caught);
-        expect(error).toBeInstanceOf(Error);
-        expect(error.message).toMatch(
-          /Re-auth with `openclaw models auth login --provider anthropic --method cli`/,
+        const error = await fetchClaudeCliOAuthProbe(baseUrl).then(
+          () => undefined,
+          (caught: unknown) => (caught instanceof Error ? caught : new Error(String(caught))),
+        );
+        expect(error?.message).toContain(
+          "Re-auth with `openclaw models auth login --provider anthropic --method cli`",
         );
         console.log(
-          `[claude-cli-oauth-proof] server=401 → re-auth hint: ${error?.message?.slice(0, 80)}`,
+          `[claude-cli-oauth-proof] server=401 → re-auth hint surfaced: ${error?.message}`,
         );
       },
     );
@@ -213,7 +215,7 @@ describe("claude-cli oauth-expiry — real HTTP server (no fetch mock)", () => {
           ok: true,
           body: { provider: "claude-cli", ok: true },
         });
-        console.log("[claude-cli-oauth-proof] server=200 → normal response, no re-auth needed");
+        console.log("[claude-cli-oauth-proof] server=200 → normal response returned");
       },
     );
   });

--- a/src/agents/auth-profiles/oauth-refresh-failure.ts
+++ b/src/agents/auth-profiles/oauth-refresh-failure.ts
@@ -22,6 +22,13 @@ type OAuthRefreshFailure = {
   reason: OAuthRefreshFailureReason | null;
 };
 
+type StructuredClaudeCliAuthFailure = {
+  provider?: unknown;
+  rawError?: unknown;
+  reason?: unknown;
+  status?: unknown;
+};
+
 /** Error type that carries provider and classified OAuth refresh failure reason. */
 export class OAuthRefreshFailureError extends Error {
   readonly provider: string;
@@ -50,6 +57,36 @@ const CLAUDE_CLI_AUTH_FAILURE_RE =
 
 function isClaudeCliExpiredOAuthMessage(message: string): boolean {
   return CLAUDE_CLI_AUTH_FAILURE_RE.test(message);
+}
+
+function readStructuredClaudeCliAuthFailure(err: unknown): StructuredClaudeCliAuthFailure | null {
+  if (!err || typeof err !== "object") {
+    return null;
+  }
+  const candidate = err as StructuredClaudeCliAuthFailure & { name?: unknown };
+  if (
+    candidate.name !== "FailoverError" ||
+    candidate.provider !== "claude-cli" ||
+    candidate.reason !== "auth" ||
+    candidate.status !== 401
+  ) {
+    return null;
+  }
+  return candidate;
+}
+
+function isStructuredClaudeCliExpiredOAuthFailure(err: unknown): boolean {
+  const failure = readStructuredClaudeCliAuthFailure(err);
+  if (!failure) {
+    return false;
+  }
+  const rawError = typeof failure.rawError === "string" ? failure.rawError : "";
+  const message = err instanceof Error ? err.message : "";
+  const combined = `${message}\n${rawError}`;
+  const lower = combined.toLowerCase();
+  return (
+    lower.includes("failed to authenticate") || lower.includes("invalid authentication credentials")
+  );
 }
 
 function isOAuthRefreshFailureMessage(message: string): boolean {
@@ -144,6 +181,12 @@ export function classifyOAuthRefreshFailureError(err: unknown): OAuthRefreshFail
   const seen = new Set<object>();
   let candidate = err;
   while (candidate && typeof candidate === "object") {
+    if (isStructuredClaudeCliExpiredOAuthFailure(candidate)) {
+      return {
+        provider: "claude-cli",
+        reason: "revoked",
+      };
+    }
     if (candidate instanceof OAuthRefreshFailureError) {
       const profileId = sanitizeOAuthRefreshFailureProfileId(candidate.profileId);
       return {

--- a/src/agents/auth-profiles/oauth-refresh-failure.ts
+++ b/src/agents/auth-profiles/oauth-refresh-failure.ts
@@ -39,17 +39,35 @@ export class OAuthRefreshFailureError extends Error {
 
 const OAUTH_REFRESH_FAILURE_PROVIDER_RE = /OAuth token refresh failed for ([^:]+):/i;
 const SAFE_PROVIDER_ID_RE = /^[a-z0-9][a-z0-9._-]*$/;
+// Matches the error surfaced via FailoverError when the `claude` subprocess
+// has an expired/invalid OAuth token.  The message always includes the
+// "claude-cli" provider prefix (injected by the failover layer) and the
+// literal 401 status plus Anthropic's "Invalid authentication credentials"
+// phrase, so the pattern is narrow enough to avoid false-positives from
+// unrelated provider 401 failures.
+const CLAUDE_CLI_AUTH_FAILURE_RE =
+  /\bclaude-cli\b.+?\b(failed to authenticate|401\s+invalid authentication credentials)\b/is;
+
+function isClaudeCliExpiredOAuthMessage(message: string): boolean {
+  return CLAUDE_CLI_AUTH_FAILURE_RE.test(message);
+}
 
 function isOAuthRefreshFailureMessage(message: string): boolean {
   const lower = message.toLowerCase();
   return (
     lower.includes("oauth token refresh failed") ||
     lower.includes("access token could not be refreshed") ||
-    lower.includes("authentication session could not be refreshed automatically")
+    lower.includes("authentication session could not be refreshed automatically") ||
+    isClaudeCliExpiredOAuthMessage(message)
   );
 }
 
 function extractOAuthRefreshFailureProvider(message: string): string | null {
+  if (isClaudeCliExpiredOAuthMessage(message)) {
+    // The message was produced by the claude-cli subprocess; the provider is
+    // statically known — no need to parse it from the error text.
+    return "claude-cli";
+  }
   const provider = message.match(OAUTH_REFRESH_FAILURE_PROVIDER_RE)?.[1]?.trim();
   return provider && provider.length > 0 ? provider : null;
 }
@@ -98,6 +116,13 @@ export function classifyOAuthRefreshFailureReason(
     return "invalid_refresh_token";
   }
   if (lower.includes("expired or revoked") || lower.includes("revoked")) {
+    return "revoked";
+  }
+  if (isClaudeCliExpiredOAuthMessage(message)) {
+    // The claude subprocess emits "401 Invalid authentication credentials"
+    // when its stored OAuth token has expired.  Map this to "revoked" so the
+    // caller surfaces the targeted re-auth hint rather than the generic login
+    // failure copy.
     return "revoked";
   }
   return null;

--- a/src/agents/auth-profiles/oauth-refresh-failure.ts
+++ b/src/agents/auth-profiles/oauth-refresh-failure.ts
@@ -168,6 +168,16 @@ export function buildOAuthRefreshFailureLoginCommand(
 ): string {
   const sanitizedProvider = sanitizeOAuthRefreshFailureProvider(provider);
   const sanitizedProfileId = sanitizeOAuthRefreshFailureProfileId(options?.profileId);
+  if (sanitizedProvider === "claude-cli") {
+    // claude-cli is not a standalone provider id; it is the Anthropic provider
+    // accessed via the CLI auth method.  The correct re-auth command must
+    // specify both --provider and --method flags.
+    return formatCliCommand(
+      sanitizedProfileId
+        ? `openclaw models auth login --provider anthropic --method cli --profile-id ${quoteShellArg(sanitizedProfileId)}`
+        : "openclaw models auth login --provider anthropic --method cli",
+    );
+  }
   return sanitizedProvider
     ? formatCliCommand(
         sanitizedProfileId

--- a/src/agents/auth-profiles/oauth-refresh-failure.ts
+++ b/src/agents/auth-profiles/oauth-refresh-failure.ts
@@ -213,13 +213,15 @@ export function buildOAuthRefreshFailureLoginCommand(
   const sanitizedProfileId = sanitizeOAuthRefreshFailureProfileId(options?.profileId);
   if (sanitizedProvider === "claude-cli") {
     // claude-cli is not a standalone provider id; it is the Anthropic provider
-    // accessed via the CLI auth method.  The correct re-auth command must
-    // specify both --provider and --method flags.
-    return formatCliCommand(
+    // accessed via the CLI auth method. Refresh the local Claude CLI session
+    // first, then re-register that auth method with OpenClaw.
+    const claudeLoginCommand = formatCliCommand("claude auth login");
+    const openclawLoginCommand = formatCliCommand(
       sanitizedProfileId
         ? `openclaw models auth login --provider anthropic --method cli --profile-id ${quoteShellArg(sanitizedProfileId)}`
         : "openclaw models auth login --provider anthropic --method cli",
     );
+    return `${claudeLoginCommand} && ${openclawLoginCommand}`;
   }
   return sanitizedProvider
     ? formatCliCommand(

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -7714,7 +7714,7 @@ describe("runAgentTurnWithFallback", () => {
     expect(result.kind).toBe("final");
     if (result.kind === "final") {
       expect(result.payload.text).toBe(
-        "⚠️ Model login expired on the gateway for claude-cli. Re-auth with `openclaw models auth login --provider anthropic --method cli`, then try again.",
+        "⚠️ Model login expired on the gateway for claude-cli. Re-auth with `claude auth login && openclaw models auth login --provider anthropic --method cli`, then try again.",
       );
     }
   });
@@ -7738,7 +7738,7 @@ describe("runAgentTurnWithFallback", () => {
     expect(result.kind).toBe("final");
     if (result.kind === "final") {
       expect(result.payload.text).toBe(
-        "⚠️ Model login expired on the gateway for claude-cli. Re-auth with `openclaw models auth login --provider anthropic --method cli`, then try again.",
+        "⚠️ Model login expired on the gateway for claude-cli. Re-auth with `claude auth login && openclaw models auth login --provider anthropic --method cli`, then try again.",
       );
     }
   });

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -7714,7 +7714,7 @@ describe("runAgentTurnWithFallback", () => {
     expect(result.kind).toBe("final");
     if (result.kind === "final") {
       expect(result.payload.text).toBe(
-        "⚠️ Model login expired on the gateway for claude-cli. Re-auth with `openclaw models auth login --provider claude-cli`, then try again.",
+        "⚠️ Model login expired on the gateway for claude-cli. Re-auth with `openclaw models auth login --provider anthropic --method cli`, then try again.",
       );
     }
   });

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -7719,6 +7719,30 @@ describe("runAgentTurnWithFallback", () => {
     }
   });
 
+  it("surfaces claude-cli re-auth hint from structured provider metadata when the message omits claude-cli", async () => {
+    state.runEmbeddedAgentMock.mockRejectedValueOnce(
+      new FailoverError(
+        "Failed to authenticate. API Error: 401 Invalid authentication credentials",
+        {
+          reason: "auth",
+          provider: "claude-cli",
+          model: "claude-sonnet-4-20250514",
+          status: 401,
+        },
+      ),
+    );
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback(createMinimalRunAgentTurnParams());
+
+    expect(result.kind).toBe("final");
+    if (result.kind === "final") {
+      expect(result.payload.text).toBe(
+        "⚠️ Model login expired on the gateway for claude-cli. Re-auth with `openclaw models auth login --provider anthropic --method cli`, then try again.",
+      );
+    }
+  });
+
   it("surfaces direct provider auth guidance for missing API keys", async () => {
     state.runEmbeddedAgentMock.mockRejectedValueOnce(
       new Error(

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -7714,7 +7714,7 @@ describe("runAgentTurnWithFallback", () => {
     expect(result.kind).toBe("final");
     if (result.kind === "final") {
       expect(result.payload.text).toBe(
-        "⚠️ Model login expired on the gateway for claude-cli. Re-auth with `claude auth login && openclaw models auth login --provider anthropic --method cli`, then try again.",
+        "⚠️ Model login expired on the gateway for claude-cli. Re-auth with `claude auth login && openclaw models auth login --provider anthropic --method cli` in a terminal, then try again.",
       );
     }
   });
@@ -7738,7 +7738,7 @@ describe("runAgentTurnWithFallback", () => {
     expect(result.kind).toBe("final");
     if (result.kind === "final") {
       expect(result.payload.text).toBe(
-        "⚠️ Model login expired on the gateway for claude-cli. Re-auth with `claude auth login && openclaw models auth login --provider anthropic --method cli`, then try again.",
+        "⚠️ Model login expired on the gateway for claude-cli. Re-auth with `claude auth login && openclaw models auth login --provider anthropic --method cli` in a terminal, then try again.",
       );
     }
   });

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -7689,6 +7689,36 @@ describe("runAgentTurnWithFallback", () => {
     }
   });
 
+  it("surfaces claude-cli re-auth hint over generic provider auth copy for 401 OAuth expiry", async () => {
+    // When the claude subprocess emits a 401 "Failed to authenticate" because
+    // its OAuth token has expired, the error is wrapped as a FailoverError with
+    // reason:"auth" and status:401.  Without the ordering fix, this would be
+    // caught by classifyProviderRequestError before reaching classifyOAuthRefreshFailure,
+    // producing the generic "re-authenticate this provider" copy instead of the
+    // targeted claude-cli re-auth command.
+    state.runEmbeddedAgentMock.mockRejectedValueOnce(
+      new FailoverError(
+        "Provider claude-cli failed: Failed to authenticate. API Error: 401 Invalid authentication credentials",
+        {
+          reason: "auth",
+          provider: "claude-cli",
+          model: "claude-sonnet-4-20250514",
+          status: 401,
+        },
+      ),
+    );
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback(createMinimalRunAgentTurnParams());
+
+    expect(result.kind).toBe("final");
+    if (result.kind === "final") {
+      expect(result.payload.text).toBe(
+        "⚠️ Model login expired on the gateway for claude-cli. Re-auth with `openclaw models auth login --provider claude-cli`, then try again.",
+      );
+    }
+  });
+
   it("surfaces direct provider auth guidance for missing API keys", async () => {
     state.runEmbeddedAgentMock.mockRejectedValueOnce(
       new Error(

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -981,6 +981,11 @@ function buildExternalRunFailureReply(
   const message = typeof input === "string" ? input : input.message;
   const error = typeof input === "string" ? undefined : input.error;
   const normalizedMessage = collapseRepeatedFailureDetail(message);
+  // OAuth refresh failure is classified before the generic provider-auth check:
+  // a FailoverError with reason:"auth" and status:401 (e.g. from the claude-cli
+  // subprocess when its stored OAuth token has expired) would otherwise match
+  // classifyProviderRequestError and surface the generic provider-auth copy
+  // instead of the targeted re-auth command for the affected provider.
   const oauthRefreshFailure =
     classifyOAuthRefreshFailureError(error) ?? classifyOAuthRefreshFailure(normalizedMessage);
   if (oauthRefreshFailure) {
@@ -3306,6 +3311,9 @@ async function runAgentTurnWithFallbackInternal(
           : isBillingErrorMessage(message);
       const isContextOverflow = !isBilling && isLikelyContextOverflowError(message);
       const isCompactionFailure = !isBilling && isCompactionFailureError(message);
+      // OAuth/auth-profile failures must reach buildExternalRunFailureReply so
+      // the targeted re-auth/failover copy is surfaced instead of the generic
+      // provider-auth message.
       const oauthRefreshFailure =
         classifyOAuthRefreshFailureError(err) ?? classifyOAuthRefreshFailure(message);
       const hasAuthProfileFailoverFailure = buildAuthProfileFailoverFailureText(err) !== null;


### PR DESCRIPTION
## Summary

- Surfaces a targeted Claude CLI re-auth hint when the subprocess OAuth token expires and returns a 401 authentication failure.
- Handles both message-based failures and structured `FailoverError` metadata where `provider: "claude-cli"` is not embedded in the display message.
- Emits the correct recovery command: `claude auth login && openclaw models auth login --provider anthropic --method cli`.
- Review focus: the narrowness of the Claude CLI classification and precedence over generic provider-auth copy.

## Linked context

Fixes #97553.

Related: #97561 overlaps the same root cause; this branch now covers the structured `FailoverError` path called out by ClawSweeper.

Maintainer request: not directly requested by a maintainer.

## Real behavior proof (required for external PRs)

Behavior addressed: After PR #97669, a real Claude Code CLI auth/OAuth 401 envelope is classified through OpenClaw's `claude-cli` structured OAuth failure path, and the reply path surfaces the targeted re-auth hint: `claude auth login && openclaw models auth login --provider anthropic --method cli`.

Real environment tested: OpenClaw PR branch `fix/claude-cli-oauth-expiry-detection` at `775e22e9da`; local `claude` binary `2.1.196 (Claude Code)`; Linux shell; isolated temporary `HOME`, `XDG_CONFIG_HOME`, `XDG_CACHE_HOME`, and `XDG_STATE_HOME`. The Claude CLI subprocess used an invalid non-secret OAuth bearer value only to force a real Anthropic API 401. No real user `~/.claude`, Claude login state, API key, or OAuth secret was read, modified, or deleted.

Exact steps or command run after this patch:

```sh
git -C <repo> log --oneline -1
# 775e22e9da test(claude-cli): expect full cli reauth command

command -v claude
claude --version
# <npm-global>/bin/claude
# 2.1.196 (Claude Code)

tmp=$(mktemp -d "$TMPDIR/claude-proof.XXXXXX")
env -i \
  HOME="$tmp" \
  XDG_CONFIG_HOME="$tmp/.config" \
  XDG_CACHE_HOME="$tmp/.cache" \
  XDG_STATE_HOME="$tmp/.local/state" \
  PATH="$PATH" \
  TERM=dumb \
  NO_COLOR=1 \
  CI=1 \
  CLAUDE_CODE_OAUTH_TOKEN="<invalid non-secret OAuth bearer>" \
  claude -p --output-format stream-json --include-partial-messages --verbose \
    --setting-sources user --model claude-sonnet-4-6 \
    <<< 'Reply with one word: ok' \
    > "$tmp/stdout.txt" 2> "$tmp/stderr.txt"

node --import tsx - <<'NODE'
import fs from 'node:fs';
import { extractCliErrorMessage } from './src/agents/cli-output.ts';
import { classifyFailoverReason } from './src/agents/embedded-agent-helpers.ts';
import { FailoverError, resolveFailoverStatus } from './src/agents/failover-error.ts';
import {
  buildOAuthRefreshFailureLoginCommand,
  classifyOAuthRefreshFailure,
  classifyOAuthRefreshFailureError,
} from './src/agents/auth-profiles/oauth-refresh-failure.ts';
import { buildKnownAgentRunFailureReplyPayload } from './src/auto-reply/reply/agent-runner-execution.ts';

const stdout = fs.readFileSync('<tmp-home>/stdout.txt', 'utf8');
const message = extractCliErrorMessage(stdout) ?? '';
const reason = classifyFailoverReason(message, { provider: 'claude-cli' }) ?? 'unknown';
const status = resolveFailoverStatus(reason);
const err = new FailoverError(message, {
  reason,
  provider: 'claude-cli',
  model: 'claude-sonnet-4-6',
  status,
});
const oauthFromMessage = classifyOAuthRefreshFailure(message);
const oauthFromError = classifyOAuthRefreshFailureError(err);
const payload = buildKnownAgentRunFailureReplyPayload({
  err,
  sessionCtx: { Provider: 'proof' },
  resolvedVerboseLevel: 'off',
});
console.log(JSON.stringify({
  extractedMessage: message,
  failoverReason: reason,
  failoverStatus: status,
  oauthFromMessage,
  oauthFromError,
  loginCommand: buildOAuthRefreshFailureLoginCommand(oauthFromError?.provider),
  replyText: payload?.text,
  replyIsError: payload?.isError,
}, null, 2));
NODE
```

Evidence after fix:

The real `claude` subprocess returned exit status `1`, empty stderr, and stdout JSONL containing real 401/authentication failure records:

```jsonl
{"type":"system","subtype":"init","cwd":"<repo>","session_id":"<session-id>","model":"claude-sonnet-4-6","apiKeySource":"none","claude_code_version":"2.1.196","memory_paths":{"auto":"<tmp-home>/.claude/projects/<repo-slug>/memory/"}}
{"type":"system","subtype":"status","status":"requesting","session_id":"<session-id>"}
{"type":"system","subtype":"api_retry","attempt":1,"max_retries":10,"retry_delay_ms":"<redacted>","error_status":401,"error":"authentication_failed","session_id":"<session-id>"}
{"type":"system","subtype":"api_retry","attempt":2,"max_retries":10,"retry_delay_ms":"<redacted>","error_status":401,"error":"authentication_failed","session_id":"<session-id>"}
{"type":"assistant","message":{"model":"<synthetic>","role":"assistant","content":[{"type":"text","text":"Failed to authenticate. API Error: 401 Invalid bearer token"}]},"session_id":"<session-id>","error":"authentication_failed","request_id":"<request-id>"}
{"type":"result","subtype":"success","is_error":true,"api_error_status":401,"num_turns":1,"result":"Failed to authenticate. API Error: 401 Invalid bearer token","session_id":"<session-id>","total_cost_usd":0}
```

OpenClaw's real exported functions then produced:

```json
{
  "extractedMessage": "Failed to authenticate. API Error: 401 Invalid bearer token",
  "failoverReason": "auth",
  "failoverStatus": 401,
  "oauthFromMessage": null,
  "oauthFromError": {
    "provider": "claude-cli",
    "reason": "revoked"
  },
  "loginCommand": "claude auth login && openclaw models auth login --provider anthropic --method cli",
  "replyText": "⚠️ Model login expired on the gateway for claude-cli. Re-auth with `claude auth login && openclaw models auth login --provider anthropic --method cli`, then try again.",
  "replyIsError": true
}
```

Observed result after fix: The real Claude Code 401 stdout envelope is reduced to `Failed to authenticate. API Error: 401 Invalid bearer token`; OpenClaw classifies it as `FailoverError(provider=claude-cli, reason=auth, status=401)`, maps it to OAuth failure `{ provider: "claude-cli", reason: "revoked" }`, builds the full CLI re-auth command, and emits the targeted reply text instead of the generic provider-auth copy.

What was not tested: I did not use or mutate a real user's stored Claude login, and I did not produce a naturally expired stored Claude OAuth session. A fabricated `<tmp-home>/.claude/.credentials.json` was not accepted as logged in by Claude Code `2.1.196`, and OpenClaw-managed Claude CLI runs intentionally scrub `CLAUDE_CODE_OAUTH_TOKEN`/`CLAUDE_CONFIG_DIR` before spawn, so this proof uses the accepted fallback shape: real Claude CLI 401 stdout bytes from an isolated environment, fed through OpenClaw's real classifier, command builder, and reply assembly functions. No PR body update, PR comment, review, push, or global auth mutation was performed.

## Redacted raw terminal output

Redaction legend: `<tmp-home>` is the isolated temporary HOME; `<repo>` is the PR worktree; `<session-id>`, `<uuid>`, `<request-id>`, and retry delay values are redacted runtime identifiers; `<invalid non-secret OAuth bearer>` is not a real secret.

```text
$ git -C <repo> status -sb
## fix/claude-cli-oauth-expiry-detection...fork/fix/claude-cli-oauth-expiry-detection

$ git -C <repo> log --oneline -1
775e22e9da test(claude-cli): expect full cli reauth command

$ command -v claude && claude --version
<npm-global>/bin/claude
2.1.196 (Claude Code)

$ tmp=$(mktemp -d "$TMPDIR/claude-proof.XXXXXX")
$ env -i HOME="$tmp" XDG_CONFIG_HOME="$tmp/.config" XDG_CACHE_HOME="$tmp/.cache" XDG_STATE_HOME="$tmp/.local/state" PATH="$PATH" TERM=dumb NO_COLOR=1 CI=1 CLAUDE_CODE_OAUTH_TOKEN="<invalid non-secret OAuth bearer>" claude -p --output-format stream-json --include-partial-messages --verbose --setting-sources user --model claude-sonnet-4-6 <<< 'Reply with one word: ok' > "$tmp/stdout.txt" 2> "$tmp/stderr.txt"
exit status: 1

$ sed -n '1,120p' "$tmp/stdout.txt"
{"type":"system","subtype":"init","cwd":"<repo>","session_id":"<session-id>","tools":"<elided>","mcp_servers":"<elided>","model":"claude-sonnet-4-6","permissionMode":"default","slash_commands":"<elided>","apiKeySource":"none","claude_code_version":"2.1.196","output_style":"default","agents":"<elided>","skills":"<elided>","plugins":"<elided>","analytics_disabled":false,"product_feedback_disabled":true,"uuid":"<uuid>","memory_paths":{"auto":"<tmp-home>/.claude/projects/<repo-slug>/memory/"},"fast_mode_state":"off"}
{"type":"system","subtype":"status","status":"requesting","uuid":"<uuid>","session_id":"<session-id>"}
{"type":"system","subtype":"api_retry","attempt":1,"max_retries":10,"retry_delay_ms":"<redacted>","error_status":401,"error":"authentication_failed","session_id":"<session-id>","uuid":"<uuid>"}
{"type":"system","subtype":"api_retry","attempt":2,"max_retries":10,"retry_delay_ms":"<redacted>","error_status":401,"error":"authentication_failed","session_id":"<session-id>","uuid":"<uuid>"}
{"type":"assistant","message":{"id":"<uuid>","container":null,"model":"<synthetic>","role":"assistant","stop_details":null,"stop_reason":"stop_sequence","stop_sequence":"","type":"message","usage":{"input_tokens":0,"output_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"server_tool_use":{"web_search_requests":0,"web_fetch_requests":0},"service_tier":null,"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},"inference_geo":null,"iterations":null,"speed":null},"content":[{"type":"text","text":"Failed to authenticate. API Error: 401 Invalid bearer token"}],"context_management":null},"parent_tool_use_id":null,"session_id":"<session-id>","uuid":"<uuid>","error":"authentication_failed","request_id":"<request-id>"}
{"type":"result","subtype":"success","is_error":true,"api_error_status":401,"duration_ms":3530,"duration_api_ms":0,"num_turns":1,"result":"Failed to authenticate. API Error: 401 Invalid bearer token","stop_reason":"stop_sequence","session_id":"<session-id>","total_cost_usd":0,"usage":{"input_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":0,"server_tool_use":{"web_search_requests":0,"web_fetch_requests":0},"service_tier":"standard","cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},"inference_geo":"","iterations":[],"speed":"standard"},"modelUsage":{},"permission_denials":[],"terminal_reason":"completed","fast_mode_state":"off","uuid":"<uuid>"}

$ wc -c "$tmp/stderr.txt"
0 <tmp-home>/stderr.txt

$ find "$tmp" -maxdepth 3 -type f | sed "s#$tmp#<tmp-home>#"
<tmp-home>/.claude.json
<tmp-home>/.claude/backups/.claude.json.backup.<timestamp>
<tmp-home>/stdout.txt
<tmp-home>/stderr.txt

$ node - <<'NODE'
const fs = require('fs');
const text = fs.readFileSync('<tmp-home>/stdout.txt', 'utf8');
for (const [i,line] of text.trim().split(/\n/).entries()) {
  const obj = JSON.parse(line);
  console.log('LINE', i + 1, obj.type, obj.subtype || '', JSON.stringify({
    status: obj.status,
    error_status: obj.error_status,
    error: obj.error,
    is_error: obj.is_error,
    api_error_status: obj.api_error_status,
    result: obj.result,
    message: obj.message?.content?.[0]?.text,
    apiKeySource: obj.apiKeySource,
    claude_code_version: obj.claude_code_version,
    authMethod: obj.authMethod,
  }));
}
NODE
LINE 1 system init {"apiKeySource":"none","claude_code_version":"2.1.196"}
LINE 2 system status {"status":"requesting"}
LINE 3 system api_retry {"error_status":401,"error":"authentication_failed"}
LINE 4 system api_retry {"error_status":401,"error":"authentication_failed"}
LINE 5 assistant  {"error":"authentication_failed","message":"Failed to authenticate. API Error: 401 Invalid bearer token"}
LINE 6 result success {"is_error":true,"api_error_status":401,"result":"Failed to authenticate. API Error: 401 Invalid bearer token"}

$ node --import tsx - <<'NODE'
import fs from 'node:fs';
import { extractCliErrorMessage } from './src/agents/cli-output.ts';
import { classifyFailoverReason } from './src/agents/embedded-agent-helpers.ts';
import { FailoverError, resolveFailoverStatus } from './src/agents/failover-error.ts';
import {
  buildOAuthRefreshFailureLoginCommand,
  classifyOAuthRefreshFailure,
  classifyOAuthRefreshFailureError,
} from './src/agents/auth-profiles/oauth-refresh-failure.ts';
import { buildKnownAgentRunFailureReplyPayload } from './src/auto-reply/reply/agent-runner-execution.ts';

const stdout = fs.readFileSync('<tmp-home>/stdout.txt', 'utf8');
const message = extractCliErrorMessage(stdout) ?? '';
const reason = classifyFailoverReason(message, { provider: 'claude-cli' }) ?? 'unknown';
const status = resolveFailoverStatus(reason);
const err = new FailoverError(message, {
  reason,
  provider: 'claude-cli',
  model: 'claude-sonnet-4-6',
  status,
});
const oauthFromMessage = classifyOAuthRefreshFailure(message);
const oauthFromError = classifyOAuthRefreshFailureError(err);
const payload = buildKnownAgentRunFailureReplyPayload({
  err,
  sessionCtx: { Provider: 'proof' },
  resolvedVerboseLevel: 'off',
});
console.log(JSON.stringify({
  stdoutPath: '<tmp-home>/stdout.txt',
  extractedMessage: message,
  failoverReason: reason,
  failoverStatus: status,
  oauthFromMessage,
  oauthFromError,
  loginCommand: buildOAuthRefreshFailureLoginCommand(oauthFromError?.provider),
  replyText: payload?.text,
  replyIsError: payload?.isError,
}, null, 2));
NODE
{
  "stdoutPath": "<tmp-home>/stdout.txt",
  "extractedMessage": "Failed to authenticate. API Error: 401 Invalid bearer token",
  "failoverReason": "auth",
  "failoverStatus": 401,
  "oauthFromMessage": null,
  "oauthFromError": {
    "provider": "claude-cli",
    "reason": "revoked"
  },
  "loginCommand": "claude auth login && openclaw models auth login --provider anthropic --method cli",
  "replyText": "⚠️ Model login expired on the gateway for claude-cli. Re-auth with `claude auth login && openclaw models auth login --provider anthropic --method cli`, then try again.",
  "replyIsError": true
}
```

## Tests and validation

- `node scripts/run-vitest.mjs src/agents/auth-profiles/oauth-refresh-failure.test.ts src/auto-reply/reply/agent-runner-execution.test.ts -- --run -t "claude-cli"`
- `node_modules/.bin/oxlint src/agents/auth-profiles/oauth-refresh-failure.ts src/agents/auth-profiles/oauth-refresh-failure.test.ts src/auto-reply/reply/agent-runner-execution.test.ts`
- New regression coverage includes the structured provider metadata path requested by ClawSweeper.

## Risk checklist

Did user-visible behavior change? (`Yes/No`) Yes. A specific Claude CLI 401 now gets a targeted re-auth hint.

Did config, environment, or migration behavior change? (`Yes/No`) No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`) Yes, auth failure classification and recovery guidance changed.

What is the highest-risk area? Misclassifying unrelated provider 401 failures as Claude CLI OAuth expiry.

How is that risk mitigated? Structured classification requires `FailoverError`, `provider: "claude-cli"`, `reason: "auth"`, `status: 401`, plus the Claude authentication failure wording in the message or raw error.

## Current review state

Next action: ClawSweeper/maintainer re-review after the structured metadata fix.

Waiting on: maintainer decision on overlap with #97561; this branch now addresses the gap noted by ClawSweeper.

Bot/reviewer comments addressed: handled the raw structured `claude-cli` `FailoverError` path where provider is not embedded in message text.

_AI-assisted; implementation and validation reviewed before pushing._
