### PR TITLE
fix(cron): warn when web_search allowlist has no provider

### DIFF
--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -82,6 +82,7 @@ export const callGatewayMock = createMock();
 export const ensureRuntimePluginsLoadedMock = createMock();
 export const listWebSearchProvidersMock = createMock();
 export const resolveWebSearchProviderIdMock = createMock();
+export const resolveCodexNativeSearchActivationMock = createMock();
 
 const resolveBootstrapWarningSignaturesSeenMock = createMock();
 const resolveCronStyleNowMock = createMock();
@@ -166,6 +167,10 @@ vi.mock("../../plugins/runtime-plugins.runtime.js", () => ({
 vi.mock("../../web-search/runtime.js", () => ({
   listWebSearchProviders: listWebSearchProvidersMock,
   resolveWebSearchProviderId: resolveWebSearchProviderIdMock,
+}));
+
+vi.mock("../../agents/codex-native-web-search-core.js", () => ({
+  resolveCodexNativeSearchActivation: resolveCodexNativeSearchActivationMock,
 }));
 
 vi.mock("../../skills/runtime/cron-snapshot.runtime.js", () => ({
@@ -503,6 +508,7 @@ function resetRunConfigMocks(): void {
   getRemoteSkillEligibilityMock.mockResolvedValue({ remoteSkillsEnabled: false });
   listWebSearchProvidersMock.mockReturnValue([]);
   resolveWebSearchProviderIdMock.mockReturnValue("");
+  resolveCodexNativeSearchActivationMock.mockReturnValue({ state: "managed_only" });
 }
 
 function resetRunExecutionMocks(): void {

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -80,6 +80,8 @@ export const getChannelPluginMock = createMock();
 export const retireSessionMcpRuntimeMock = createMock();
 export const callGatewayMock = createMock();
 export const ensureRuntimePluginsLoadedMock = createMock();
+export const listWebSearchProvidersMock = createMock();
+export const resolveWebSearchProviderIdMock = createMock();
 
 const resolveBootstrapWarningSignaturesSeenMock = createMock();
 const resolveCronStyleNowMock = createMock();
@@ -159,6 +161,11 @@ vi.mock("./run-model-catalog.runtime.js", () => ({
 
 vi.mock("../../plugins/runtime-plugins.runtime.js", () => ({
   ensureRuntimePluginsLoaded: ensureRuntimePluginsLoadedMock,
+}));
+
+vi.mock("../../web-search/runtime.js", () => ({
+  listWebSearchProviders: listWebSearchProvidersMock,
+  resolveWebSearchProviderId: resolveWebSearchProviderIdMock,
 }));
 
 vi.mock("../../skills/runtime/cron-snapshot.runtime.js", () => ({
@@ -494,6 +501,8 @@ function resetRunConfigMocks(): void {
   getSkillsSnapshotVersionMock.mockReturnValue(42);
   loadModelCatalogMock.mockResolvedValue([]);
   getRemoteSkillEligibilityMock.mockResolvedValue({ remoteSkillsEnabled: false });
+  listWebSearchProvidersMock.mockReturnValue([]);
+  resolveWebSearchProviderIdMock.mockReturnValue("");
 }
 
 function resetRunExecutionMocks(): void {

--- a/src/cron/isolated-agent/run.tools-allow.test.ts
+++ b/src/cron/isolated-agent/run.tools-allow.test.ts
@@ -5,6 +5,7 @@ import {
   listWebSearchProvidersMock,
   loadRunCronIsolatedAgentTurn,
   resetRunCronIsolatedAgentTurnHarness,
+  resolveCodexNativeSearchActivationMock,
   resolveDeliveryTargetMock,
   resolveWebSearchProviderIdMock,
   runEmbeddedAgentMock,
@@ -201,6 +202,21 @@ describe("runCronIsolatedAgentTurn toolsAllow passthrough", () => {
     async () => {
       listWebSearchProvidersMock.mockReturnValue([{ id: "duckduckgo" }]);
       resolveWebSearchProviderIdMock.mockReturnValue("duckduckgo");
+
+      const result = await runCronIsolatedAgentTurn(makeParamsWithToolsAllow(["web_search"]));
+
+      expect(result.status).toBe("ok");
+      expect(result.diagnostics).toBeUndefined();
+    },
+  );
+
+  it(
+    "does not warn when native OpenAI/Codex hosted web_search is active for the resolved model",
+    { timeout: RUN_TOOLS_ALLOW_TIMEOUT_MS },
+    async () => {
+      listWebSearchProvidersMock.mockReturnValue([]);
+      resolveWebSearchProviderIdMock.mockReturnValue("");
+      resolveCodexNativeSearchActivationMock.mockReturnValue({ state: "native_active" });
 
       const result = await runCronIsolatedAgentTurn(makeParamsWithToolsAllow(["web_search"]));
 

--- a/src/cron/isolated-agent/run.tools-allow.test.ts
+++ b/src/cron/isolated-agent/run.tools-allow.test.ts
@@ -2,9 +2,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import "../../agents/test-helpers/fast-coding-tools.js";
 import {
+  listWebSearchProvidersMock,
   loadRunCronIsolatedAgentTurn,
   resetRunCronIsolatedAgentTurnHarness,
   resolveDeliveryTargetMock,
+  resolveWebSearchProviderIdMock,
   runEmbeddedAgentMock,
   runWithModelFallbackMock,
 } from "./run.test-harness.js";
@@ -125,6 +127,85 @@ describe("runCronIsolatedAgentTurn toolsAllow passthrough", () => {
       expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
       const call = requireEmbeddedAgentCall();
       expect(call.toolsAllow).toEqual(["maniple__check_idle_workers"]);
+    },
+  );
+
+  it(
+    "adds a warning diagnostic when web_search is allowed but no provider is enabled",
+    { timeout: RUN_TOOLS_ALLOW_TIMEOUT_MS },
+    async () => {
+      listWebSearchProvidersMock.mockReturnValue([]);
+
+      const result = await runCronIsolatedAgentTurn(makeParamsWithToolsAllow(["web_search"]));
+
+      expect(result.status).toBe("ok");
+      expect(resolveWebSearchProviderIdMock).toHaveBeenCalledWith({
+        config: expect.any(Object),
+        agentDir: "/tmp/agent-dir",
+        providers: [],
+      });
+      expect(result.diagnostics?.summary).toContain(
+        "web_search is in toolsAllow but no web search provider is selected or available",
+      );
+      expect(result.diagnostics?.entries).toContainEqual({
+        ts: expect.any(Number),
+        source: "cron-preflight",
+        severity: "warn",
+        message:
+          "web_search is in toolsAllow but no web search provider is selected or available. Enable or configure one with: openclaw plugins enable duckduckgo",
+        toolName: "web_search",
+      });
+    },
+  );
+
+  it(
+    "adds a warning diagnostic when web_search has providers but no selected provider",
+    { timeout: RUN_TOOLS_ALLOW_TIMEOUT_MS },
+    async () => {
+      listWebSearchProvidersMock.mockReturnValue([{ id: "duckduckgo" }]);
+      resolveWebSearchProviderIdMock.mockReturnValue("");
+
+      const result = await runCronIsolatedAgentTurn(makeParamsWithToolsAllow(["web_search"]));
+
+      expect(result.status).toBe("ok");
+      expect(result.diagnostics?.summary).toContain(
+        "web_search is in toolsAllow but no web search provider is selected or available",
+      );
+    },
+  );
+
+  it(
+    "keeps cron execution non-fatal when web_search availability diagnostics fail",
+    { timeout: RUN_TOOLS_ALLOW_TIMEOUT_MS },
+    async () => {
+      listWebSearchProvidersMock.mockImplementation(() => {
+        throw new Error("provider registry unavailable");
+      });
+
+      const result = await runCronIsolatedAgentTurn(makeParamsWithToolsAllow(["web_search"]));
+
+      expect(result.status).toBe("ok");
+      expect(result.diagnostics?.entries).toContainEqual({
+        ts: expect.any(Number),
+        source: "cron-preflight",
+        severity: "warn",
+        message: "provider registry unavailable",
+        toolName: "web_search",
+      });
+    },
+  );
+
+  it(
+    "does not warn when web_search has a selected provider",
+    { timeout: RUN_TOOLS_ALLOW_TIMEOUT_MS },
+    async () => {
+      listWebSearchProvidersMock.mockReturnValue([{ id: "duckduckgo" }]);
+      resolveWebSearchProviderIdMock.mockReturnValue("duckduckgo");
+
+      const result = await runCronIsolatedAgentTurn(makeParamsWithToolsAllow(["web_search"]));
+
+      expect(result.status).toBe("ok");
+      expect(result.diagnostics).toBeUndefined();
     },
   );
 });

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -130,6 +130,9 @@ const cronModelPreflightRuntimeLoader = createLazyImportLoader(
   () => import("./model-preflight.runtime.js"),
 );
 const webSearchRuntimeLoader = createLazyImportLoader(() => import("../../web-search/runtime.js"));
+const nativeWebSearchRuntimeLoader = createLazyImportLoader(
+  () => import("../../agents/codex-native-web-search-core.js"),
+);
 const runtimePluginsLoader = createLazyImportLoader(
   () => import("../../plugins/runtime-plugins.runtime.js"),
 );
@@ -170,6 +173,10 @@ async function loadCronModelPreflightRuntime() {
 
 async function loadWebSearchRuntime() {
   return await webSearchRuntimeLoader.load();
+}
+
+async function loadNativeWebSearchRuntime() {
+  return await nativeWebSearchRuntimeLoader.load();
 }
 
 async function loadRuntimePlugins() {
@@ -336,15 +343,20 @@ function canPromptForMessageTool(params: {
 async function createCronToolsAllowWebSearchDiagnostics(params: {
   cfg: OpenClawConfig;
   agentDir: string;
+  agentId?: string;
+  agentSessionKey?: string;
+  modelProvider?: string;
+  modelApi?: string;
+  modelId?: string;
   toolsAllow?: string[];
 }) {
   if (!params.toolsAllow || params.toolsAllow.length === 0) {
     return undefined;
   }
-  const normalizedAllow = expandToolGroups(params.toolsAllow).map((toolName) =>
-    normalizeToolName(toolName),
+  const normalizedAllow = new Set(
+    expandToolGroups(params.toolsAllow).map((toolName) => normalizeToolName(toolName)),
   );
-  if (!normalizedAllow.includes("web_search") || normalizedAllow.includes("*")) {
+  if (!normalizedAllow.has("web_search") || normalizedAllow.has("*")) {
     return undefined;
   }
   try {
@@ -357,6 +369,28 @@ async function createCronToolsAllowWebSearchDiagnostics(params: {
         providers,
       })
     ) {
+      return undefined;
+    }
+    // Native OpenAI/Codex hosted web_search bypasses managed provider selection;
+    // skip the warning when it would handle the resolved model so operators on
+    // direct OpenAI Responses/Codex traffic do not see a misleading diagnostic.
+    const configuredProvider = params.modelProvider
+      ? params.cfg.models?.providers?.[params.modelProvider]
+      : undefined;
+    const configuredModelApi = params.modelId
+      ? configuredProvider?.models?.find((candidate) => candidate.id === params.modelId)?.api
+      : undefined;
+    const { resolveCodexNativeSearchActivation } = await loadNativeWebSearchRuntime();
+    const nativeActivation = resolveCodexNativeSearchActivation({
+      config: params.cfg,
+      modelProvider: params.modelProvider,
+      modelApi: params.modelApi ?? configuredModelApi ?? configuredProvider?.api,
+      modelId: params.modelId,
+      agentId: params.agentId,
+      sessionKey: params.agentSessionKey,
+      agentDir: params.agentDir,
+    });
+    if (nativeActivation.state === "native_active") {
       return undefined;
     }
   } catch (error) {
@@ -1454,14 +1488,16 @@ export async function runCronIsolatedAgentTurn(params: {
   let outcome: "completed" | "error" = "completed";
   let outcomeError: string | undefined;
   let cronRunSessionCleanupAttempted = false;
-  let preflightDiagnostics: Awaited<
-    ReturnType<typeof createCronToolsAllowWebSearchDiagnostics>
-  >;
+  let preflightDiagnostics: Awaited<ReturnType<typeof createCronToolsAllowWebSearchDiagnostics>>;
   try {
     assertAgentRunLifecycleGenerationCurrent(runLifecycleGeneration);
     preflightDiagnostics = await createCronToolsAllowWebSearchDiagnostics({
       cfg: prepared.context.cfgWithAgentDefaults,
       agentDir: prepared.context.agentDir,
+      agentId: prepared.context.agentId,
+      agentSessionKey: prepared.context.agentSessionKey,
+      modelProvider: prepared.context.liveSelection?.provider,
+      modelId: prepared.context.liveSelection?.model,
       toolsAllow: prepared.context.agentPayload?.toolsAllow,
     });
     const existingRunContext = getAgentRunContext(initialSessionId);

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -129,9 +129,12 @@ const cronDeliveryRuntimeLoader = createLazyImportLoader(() => import("./run-del
 const cronModelPreflightRuntimeLoader = createLazyImportLoader(
   () => import("./model-preflight.runtime.js"),
 );
+const webSearchRuntimeLoader = createLazyImportLoader(() => import("../../web-search/runtime.js"));
 const runtimePluginsLoader = createLazyImportLoader(
   () => import("../../plugins/runtime-plugins.runtime.js"),
 );
+const WEB_SEARCH_TOOLS_ALLOW_NO_PROVIDER_MESSAGE =
+  "web_search is in toolsAllow but no web search provider is selected or available. Enable or configure one with: openclaw plugins enable duckduckgo";
 
 async function loadSessionStoreRuntime() {
   return await sessionStoreRuntimeLoader.load();
@@ -163,6 +166,10 @@ async function loadCronDeliveryRuntime() {
 
 async function loadCronModelPreflightRuntime() {
   return await cronModelPreflightRuntimeLoader.load();
+}
+
+async function loadWebSearchRuntime() {
+  return await webSearchRuntimeLoader.load();
 }
 
 async function loadRuntimePlugins() {
@@ -323,6 +330,48 @@ function canPromptForMessageTool(params: {
     params.toolsAllow === undefined ||
     normalizedToolsAllow?.includes("*") === true ||
     normalizedToolsAllow?.includes("message") === true
+  );
+}
+
+async function createCronToolsAllowWebSearchDiagnostics(params: {
+  cfg: OpenClawConfig;
+  agentDir: string;
+  toolsAllow?: string[];
+}) {
+  if (!params.toolsAllow || params.toolsAllow.length === 0) {
+    return undefined;
+  }
+  const normalizedAllow = expandToolGroups(params.toolsAllow).map((toolName) =>
+    normalizeToolName(toolName),
+  );
+  if (!normalizedAllow.includes("web_search") || normalizedAllow.includes("*")) {
+    return undefined;
+  }
+  try {
+    const { listWebSearchProviders, resolveWebSearchProviderId } = await loadWebSearchRuntime();
+    const providers = listWebSearchProviders({ config: params.cfg });
+    if (
+      resolveWebSearchProviderId({
+        config: params.cfg,
+        agentDir: params.agentDir,
+        providers,
+      })
+    ) {
+      return undefined;
+    }
+  } catch (error) {
+    return createCronRunDiagnosticsFromError("cron-preflight", error, {
+      severity: "warn",
+      toolName: "web_search",
+    });
+  }
+  return createCronRunDiagnosticsFromError(
+    "cron-preflight",
+    WEB_SEARCH_TOOLS_ALLOW_NO_PROVIDER_MESSAGE,
+    {
+      severity: "warn",
+      toolName: "web_search",
+    },
   );
 }
 
@@ -915,6 +964,7 @@ async function prepareCronRunContext(params: {
 async function finalizeCronRun(params: {
   prepared: PreparedCronRunContext;
   execution: CronExecutionResult;
+  preflightDiagnostics: Awaited<ReturnType<typeof createCronToolsAllowWebSearchDiagnostics>>;
   abortReason: () => string;
   isAborted: () => boolean;
   markCronRunSessionCleanupAttempted: () => void;
@@ -922,6 +972,9 @@ async function finalizeCronRun(params: {
   const { prepared, execution } = params;
   const finalRunResult = execution.runResult;
   const payloads = finalRunResult.payloads ?? [];
+  const mergeWithPreflightDiagnostics = (
+    ...diagnostics: Parameters<typeof mergeCronRunDiagnostics>
+  ) => mergeCronRunDiagnostics(params.preflightDiagnostics, ...diagnostics);
   let telemetry: CronRunTelemetry | undefined;
 
   // Late aborted results may still contain billable usage. Recheck before each
@@ -1088,7 +1141,7 @@ async function finalizeCronRun(params: {
     return prepared.withRunSession({
       status: "error",
       error: params.abortReason(),
-      diagnostics: mergeCronRunDiagnostics(
+      diagnostics: mergeWithPreflightDiagnostics(
         createCronRunDiagnosticsFromAgentResult(finalRunResult, { finalStatus: "error" }),
         createCronRunDiagnosticsFromError("cron-setup", params.abortReason()),
       ),
@@ -1120,7 +1173,7 @@ async function finalizeCronRun(params: {
     return prepared.withRunSession({
       status: "error",
       error,
-      diagnostics: mergeCronRunDiagnostics(
+      diagnostics: mergeWithPreflightDiagnostics(
         createCronRunDiagnosticsFromAgentResult(finalRunResult, { finalStatus: "error" }),
         createCronRunDiagnosticsFromError("agent-run", error),
       ),
@@ -1154,14 +1207,14 @@ async function finalizeCronRun(params: {
       deliveryAttempted: result?.deliveryAttempted,
       delivery: result?.delivery,
       diagnostics: hasFatalErrorPayload
-        ? mergeCronRunDiagnostics(
+        ? mergeWithPreflightDiagnostics(
             agentDiagnostics,
             createCronRunDiagnosticsFromError(
               "agent-run",
               embeddedRunError ?? "cron isolated run returned an error payload",
             ),
           )
-        : agentDiagnostics,
+        : mergeWithPreflightDiagnostics(agentDiagnostics),
       ...telemetry,
     });
   const failPendingPresentationWarningUnlessDelivered = (delivered?: boolean) => {
@@ -1264,7 +1317,7 @@ async function finalizeCronRun(params: {
       deliveryAttempted:
         deliveryResult.result.deliveryAttempted ?? deliveryResult.deliveryAttempted,
       delivery: deliveryTrace,
-      diagnostics: mergeCronRunDiagnostics(
+      diagnostics: mergeWithPreflightDiagnostics(
         agentDiagnostics,
         deliveryResult.result.diagnostics,
         deliveryResult.result.status === "error" && deliveryResult.result.error
@@ -1401,8 +1454,16 @@ export async function runCronIsolatedAgentTurn(params: {
   let outcome: "completed" | "error" = "completed";
   let outcomeError: string | undefined;
   let cronRunSessionCleanupAttempted = false;
+  let preflightDiagnostics: Awaited<
+    ReturnType<typeof createCronToolsAllowWebSearchDiagnostics>
+  >;
   try {
     assertAgentRunLifecycleGenerationCurrent(runLifecycleGeneration);
+    preflightDiagnostics = await createCronToolsAllowWebSearchDiagnostics({
+      cfg: prepared.context.cfgWithAgentDefaults,
+      agentDir: prepared.context.agentDir,
+      toolsAllow: prepared.context.agentPayload?.toolsAllow,
+    });
     const existingRunContext = getAgentRunContext(initialSessionId);
     runContextOwnerToken = claimAgentRunContext(
       initialSessionId,
@@ -1465,6 +1526,7 @@ export async function runCronIsolatedAgentTurn(params: {
     const finalized = await finalizeCronRun({
       prepared: prepared.context,
       execution,
+      preflightDiagnostics,
       abortReason,
       isAborted,
       markCronRunSessionCleanupAttempted: () => {
@@ -1484,9 +1546,12 @@ export async function runCronIsolatedAgentTurn(params: {
     return prepared.context.withRunSession({
       status: "error",
       error,
-      diagnostics: createCronRunDiagnosticsFromError(
-        isCronLaneTimeout ? "cron-setup" : "agent-run",
-        isCronLaneTimeout ? error : err,
+      diagnostics: mergeCronRunDiagnostics(
+        preflightDiagnostics,
+        createCronRunDiagnosticsFromError(
+          isCronLaneTimeout ? "cron-setup" : "agent-run",
+          isCronLaneTimeout ? error : err,
+        ),
       ),
     });
   } finally {


### PR DESCRIPTION
Closes #97654

AI-assisted change authored in Codex.

## What Problem This Solves

Cron `agentTurn` jobs can explicitly set `toolsAllow: ["web_search"]` while no usable web search provider is selected or available. Before this change, the run could still finish as `ok` with a model apology and no persisted cron diagnostic, leaving operators without an actionable signal.

## Why This Change Was Made

This adds a narrow, non-fatal cron preflight diagnostic for the explicit `web_search` allowlist case. The diagnostic uses the same provider-selection path as the web_search runtime (`listWebSearchProviders` plus `resolveWebSearchProviderId`) and passes the cron agent directory so auth-profile-backed provider auto-detection matches the actual tool runtime.

The warning is merged into normal cron run diagnostics, delivery diagnostics, and error results. If the diagnostic availability check itself fails, the cron run remains non-fatal and records that failure as a warning instead of bypassing cron cleanup.

Refinement (re-review): the predicate also checks `resolveCodexNativeSearchActivation` against the resolved live model. When native OpenAI/Codex hosted `web_search` would handle the request (`state === "native_active"`), the warning is suppressed so operators on direct OpenAI Responses/Codex traffic do not see a misleading diagnostic. This covers the CS finding that the original predicate could warn even when native hosted search was active.

## User Impact

Operators get a persisted warning such as:

`web_search is in toolsAllow but no web search provider is selected or available. Enable or configure one with: openclaw plugins enable duckduckgo`

Healthy runs with a selected provider are unchanged. Operators using native OpenAI/Codex hosted `web_search` no longer see a false positive. Wildcard/default tool access is not newly warned.

## Evidence

- `node scripts/run-vitest.mjs run src/cron/isolated-agent/run.tools-allow.test.ts src/cron/run-diagnostics.test.ts --maxWorkers=1` -> 18/18 pass (8 tools-allow incl. new native_active no-warning case + 10 run-diagnostics).
- `node scripts/run-vitest.mjs run src/agents/tools/web-tools.enabled-defaults.test.ts src/agents/tool-allowlist-guard.test.ts --maxWorkers=1` -> 12/12 pass (7 web-tools enabled-defaults + 5 tool-allowlist-guard).
- `node scripts/run-oxlint.mjs --tsconfig tsconfig.json src/cron/isolated-agent/run.ts` -> clean.
- `git diff --check origin/main...HEAD`.

New regression test `does not warn when native OpenAI/Codex hosted web_search is active for the resolved model` mocks `resolveCodexNativeSearchActivation` to return `native_active` and asserts no diagnostic fires. The existing `adds a warning diagnostic when web_search is allowed but no provider is enabled` test continues to verify the warning path when native search is `managed_only`.

Autoreview history:
- Fixed accepted finding: provider presence was not enough; now requires `resolveWebSearchProviderId` to select a provider.
- Fixed accepted finding: provider selection now receives the cron `agentDir` for agent-scoped auth-profile detection.
- Fixed accepted finding: diagnostic generation now runs inside the protected cron path and degrades diagnostic failures to warning diagnostics.
- CS re-review refinement: added native hosted search activation check to suppress false positives; normalized `toolsAllow` check to `Set` to satisfy `unicorn(prefer-set-has)`.
