### PR TITLE
test(plugin-sdk): cover origin trust SSRF edges

### DIFF
--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -240,14 +240,14 @@ usage endpoint failed or returned no usable usage data.
     | `plugin-sdk/webhook-request-guards` | Request body size/timeout helpers and `runDetachedWebhookWork` for tracked post-ack processing |
 
 Provider and web-fetch helpers that accept a configured `baseUrl` use exact
-HTTP origin trust for SSRF exemptions. The runtime normalizes the configured
+HTTP origin trust for SSRF exemptions. The runtime serializes the configured
 origin with the platform `URL.origin` rules: path and query are ignored, default
-ports are elided, userinfo is stripped, host case is folded, and trailing host
-dots are normalized before comparison. A matching origin may promote only the
-current request hostname for that request; redirects and sibling origins are
-re-evaluated independently, and metadata/link-local/private network blocking
-still runs in the resolver. Do not use origin trust as a wildcard for every host
-that shares a domain or provider plugin.
+ports are elided, userinfo is stripped, and host case is folded. OpenClaw's SSRF
+hostname comparison separately normalizes trailing host dots. A matching origin
+may promote only the current request hostname for that request; redirects and
+sibling origins are re-evaluated independently, and metadata/link-local/private
+network blocking still runs in the resolver. Do not use origin trust as a
+wildcard for every host that shares a domain or provider plugin.
 
   </Accordion>
 

--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -238,6 +238,17 @@ usage endpoint failed or returned no usable usage data.
     | `plugin-sdk/secret-input` | Secret input parsing helpers |
     | `plugin-sdk/webhook-ingress` | Webhook request/target helpers and raw websocket/body coercion |
     | `plugin-sdk/webhook-request-guards` | Request body size/timeout helpers and `runDetachedWebhookWork` for tracked post-ack processing |
+
+Provider and web-fetch helpers that accept a configured `baseUrl` use exact
+HTTP origin trust for SSRF exemptions. The runtime normalizes the configured
+origin with the platform `URL.origin` rules: path and query are ignored, default
+ports are elided, userinfo is stripped, host case is folded, and trailing host
+dots are normalized before comparison. A matching origin may promote only the
+current request hostname for that request; redirects and sibling origins are
+re-evaluated independently, and metadata/link-local/private network blocking
+still runs in the resolver. Do not use origin trust as a wildcard for every host
+that shares a domain or provider plugin.
+
   </Accordion>
 
   <Accordion title="Runtime and storage subpaths">

--- a/src/infra/net/ssrf.test.ts
+++ b/src/infra/net/ssrf.test.ts
@@ -161,6 +161,21 @@ describe("ssrfPolicyFromHttpBaseUrlAllowedOrigin", () => {
       allowedOrigins: ["https://api.example.com"],
     });
   });
+
+  // #81963: plugin-provider baseUrl trust is origin-scoped, not path-scoped.
+  // URL.origin intentionally drops path/query, strips userinfo, and elides
+  // default ports so equivalent configured baseUrls trust the same request
+  // origin without promoting sibling origins.
+  it.each([
+    ["https://api.example.com/v1/", "https://api.example.com"],
+    ["https://api.example.com:443/v1", "https://api.example.com"],
+    ["http://api.example.com:80/v1", "http://api.example.com"],
+    ["https://token@example.com/v1", "https://example.com"],
+  ])("normalizes plugin provider baseUrl origin %s", (baseUrl, origin) => {
+    expect(ssrfPolicyFromHttpBaseUrlAllowedOrigin(baseUrl)).toEqual({
+      allowedOrigins: [origin],
+    });
+  });
 });
 
 describe("resolveSsrFPolicyForUrl", () => {
@@ -243,6 +258,29 @@ describe("resolveSsrFPolicyForUrl", () => {
     ).toEqual({
       allowedOrigins: ["http://[fd00::1]:11434"],
     });
+  });
+
+  it("keeps concurrent private-origin trust isolated per configured baseUrl", async () => {
+    const agentA = { allowedOrigins: ["http://10.0.0.5:11434"] };
+    const agentB = { allowedOrigins: ["http://10.0.0.5:11435"] };
+
+    const [aPolicy, bPolicy, aAgainstBPort] = await Promise.all([
+      Promise.resolve(resolveSsrFPolicyForUrl(new URL("http://10.0.0.5:11434/v1/chat"), agentA)),
+      Promise.resolve(resolveSsrFPolicyForUrl(new URL("http://10.0.0.5:11435/v1/chat"), agentB)),
+      Promise.resolve(resolveSsrFPolicyForUrl(new URL("http://10.0.0.5:11435/v1/chat"), agentA)),
+    ]);
+
+    expect(aPolicy).toEqual({
+      allowedOrigins: ["http://10.0.0.5:11434"],
+      allowedHostnames: ["10.0.0.5"],
+    });
+    expect(bPolicy).toEqual({
+      allowedOrigins: ["http://10.0.0.5:11435"],
+      allowedHostnames: ["10.0.0.5"],
+    });
+    expect(aAgainstBPort).toEqual({ allowedOrigins: ["http://10.0.0.5:11434"] });
+    expect(agentA).toEqual({ allowedOrigins: ["http://10.0.0.5:11434"] });
+    expect(agentB).toEqual({ allowedOrigins: ["http://10.0.0.5:11435"] });
   });
 });
 

--- a/src/infra/net/ssrf.test.ts
+++ b/src/infra/net/ssrf.test.ts
@@ -181,7 +181,7 @@ describe("ssrfPolicyFromHttpBaseUrlAllowedOrigin", () => {
     const policy = ssrfPolicyFromHttpBaseUrlAllowedOrigin("http://example.com.:11434/v1");
 
     expect(resolveSsrFPolicyForUrl(new URL("http://example.com:11434/v1/chat"), policy)).toEqual({
-      allowedOrigins: ["http://example.com.:11434"],
+      allowedOrigins: ["http://example.com:11434"],
       allowedHostnames: ["example.com"],
     });
   });

--- a/src/infra/net/ssrf.test.ts
+++ b/src/infra/net/ssrf.test.ts
@@ -176,6 +176,15 @@ describe("ssrfPolicyFromHttpBaseUrlAllowedOrigin", () => {
       allowedOrigins: [origin],
     });
   });
+
+  it("matches a configured trailing-dot baseUrl to its dotless request origin", () => {
+    const policy = ssrfPolicyFromHttpBaseUrlAllowedOrigin("http://example.com.:11434/v1");
+
+    expect(resolveSsrFPolicyForUrl(new URL("http://example.com:11434/v1/chat"), policy)).toEqual({
+      allowedOrigins: ["http://example.com.:11434"],
+      allowedHostnames: ["example.com"],
+    });
+  });
 });
 
 describe("resolveSsrFPolicyForUrl", () => {


### PR DESCRIPTION
## Summary

Adds the remaining origin-trust SSRF edge coverage and plugin SDK docs requested by #81963.

## Issue / Motivation

Fixes #81963.

The core origin-scoped SSRF behavior already landed in #80751. The follow-up issue asks for narrow provider `baseUrl` normalization coverage plus documentation of the trust semantics for plugin authors, without changing runtime policy.

## Changes

- Add regression coverage for provider `baseUrl` origin normalization:
  - trailing slash/path ignored for origin trust
  - default HTTP/HTTPS ports elided
  - userinfo stripped by `URL.origin`
  - configured trailing-dot hosts match their dotless request origin
- Add a concurrent isolation test showing overlapping private origins with different ports do not leak trust between configured base URLs.
- Document exact-origin trust semantics in `docs/plugins/sdk-subpaths.md`, including redirect re-evaluation and continued metadata/link-local/private-network resolver blocking.

## Testing

- `pnpm exec vitest run src/infra/net/ssrf.test.ts`
  - 57 tests passed on the previous head; exact-head local rerun is unavailable in the low-disk worktree because workspace dependencies are not installed, so exact-head CI is the runtime-test authority
- `pnpm oxfmt --check src/infra/net/ssrf.test.ts docs/plugins/sdk-subpaths.md`
  - All matched files use the correct format.
- `git diff --check`
  - passed
- staged diff secret scan
  - no secret-like added lines

## What Problem This Solves

Plugin/provider authors need a precise contract for when configured `baseUrl` values may promote a private hostname through the SSRF guard. This PR pins the intended origin-normalization behavior in tests and documents that the trust is exact-origin, per-request, and does not bypass resolver-level metadata/link-local/private network protections.

## Evidence

Exact-head static validation passed: `npx --yes oxfmt@latest --check docs/plugins/sdk-subpaths.md src/infra/net/ssrf.test.ts`, `npx --yes oxlint@latest --tsconfig config/tsconfig/oxlint.core.json src/infra/net/ssrf.test.ts`, `node scripts/generate-docs-map.mjs --check`, `git diff --check`, and diff secret scan. The new regression directly covers the configured trailing-dot baseUrl contract identified in review. The PR intentionally contains tests/docs only and does not change production SSRF policy behavior.
