### PR TITLE
feat(node): add --context-path flag to node run/install for reverse-p…

### DIFF
--- a/docs/cli/node.md
+++ b/docs/cli/node.md
@@ -58,6 +58,7 @@ Options:
 
 - `--host <host>`: Gateway WebSocket host (default: `127.0.0.1`)
 - `--port <port>`: Gateway WebSocket port (default: `18789`)
+- `--context-path <path>`: Gateway WebSocket context path (e.g. `/openclaw-gw`). Appended to the WebSocket URL.
 - `--tls`: Use TLS for the gateway connection
 - `--tls-fingerprint <sha256>`: Expected TLS certificate fingerprint (sha256)
 - `--node-id <id>`: Override node id (clears pairing token)
@@ -95,6 +96,7 @@ Options:
 
 - `--host <host>`: Gateway WebSocket host (default: `127.0.0.1`)
 - `--port <port>`: Gateway WebSocket port (default: `18789`)
+- `--context-path <path>`: Gateway WebSocket context path (e.g. `/openclaw-gw`). Appended to the WebSocket URL.
 - `--tls`: Use TLS for the gateway connection
 - `--tls-fingerprint <sha256>`: Expected TLS certificate fingerprint (sha256)
 - `--node-id <id>`: Override node id (clears pairing token)

--- a/src/cli/node-cli/daemon.ts
+++ b/src/cli/node-cli/daemon.ts
@@ -40,6 +40,7 @@ import { formatInvalidConfigPort, formatInvalidPortOption } from "../error-forma
 type NodeDaemonInstallOptions = {
   host?: string;
   port?: string | number;
+  contextPath?: string;
   tls?: boolean;
   tlsFingerprint?: string;
   nodeId?: string;
@@ -86,7 +87,12 @@ function resolveNodeDefaults(
     return { host, port: null };
   }
   const port = portOverride ?? config?.gateway?.port ?? 18789;
-  return { host, port };
+  const retargeted = opts.host !== undefined || opts.port !== undefined;
+  const explicitContextPath = opts.contextPath !== undefined;
+  const contextPath =
+    normalizeOptionalString(opts.contextPath) ||
+    (explicitContextPath || retargeted ? undefined : config?.gateway?.contextPath);
+  return { host, port, contextPath };
 }
 
 export async function runNodeDaemonInstall(opts: NodeDaemonInstallOptions) {
@@ -96,7 +102,7 @@ export async function runNodeDaemonInstall(opts: NodeDaemonInstallOptions) {
   }
 
   const config = await loadNodeHostConfig();
-  const { host, port } = resolveNodeDefaults(opts, config);
+  const { host, port, contextPath } = resolveNodeDefaults(opts, config);
   if (!Number.isFinite(port ?? Number.NaN) || (port ?? 0) <= 0 || (port ?? 0) > 65_535) {
     fail(
       opts.port !== undefined
@@ -143,6 +149,7 @@ export async function runNodeDaemonInstall(opts: NodeDaemonInstallOptions) {
       env: process.env,
       host,
       port: port ?? 18789,
+      contextPath,
       tls,
       tlsFingerprint: tlsFingerprint || undefined,
       nodeId: opts.nodeId,

--- a/src/cli/node-cli/register.ts
+++ b/src/cli/node-cli/register.ts
@@ -50,6 +50,7 @@ export function registerNodeCli(program: Command) {
     .description("Run the headless node host (foreground)")
     .option("--host <host>", "Gateway host")
     .option("--port <port>", "Gateway port")
+    .option("--context-path <path>", "Gateway WebSocket context path (e.g. /openclaw-gw)")
     .option("--tls", "Use TLS for the gateway connection")
     .option("--tls-fingerprint <sha256>", "Expected TLS certificate fingerprint (sha256)")
     .option("--node-id <id>", "Override node id (clears pairing token)")
@@ -67,6 +68,7 @@ export function registerNodeCli(program: Command) {
         return;
       }
       const retargetedGateway = opts.host !== undefined || opts.port !== undefined;
+      const explicitContextPath = opts.contextPath !== undefined;
       const tlsFingerprint =
         opts.tlsFingerprint ?? (retargetedGateway ? undefined : existing?.gateway?.tlsFingerprint);
       const inheritedTls = retargetedGateway ? undefined : existing?.gateway?.tls;
@@ -76,6 +78,9 @@ export function registerNodeCli(program: Command) {
         gatewayTls:
           typeof opts.tls === "boolean" ? opts.tls : Boolean(tlsFingerprint) || inheritedTls,
         gatewayTlsFingerprint: tlsFingerprint,
+        gatewayContextPath:
+          normalizeOptionalString(opts.contextPath as string | undefined) ??
+          (explicitContextPath || retargetedGateway ? undefined : existing?.gateway?.contextPath),
         nodeId: opts.nodeId,
         displayName: opts.displayName,
       });
@@ -94,6 +99,7 @@ export function registerNodeCli(program: Command) {
     .description("Install the node host service (launchd/systemd/schtasks)")
     .option("--host <host>", "Gateway host")
     .option("--port <port>", "Gateway port")
+    .option("--context-path <path>", "Gateway WebSocket context path (e.g. /openclaw-gw)")
     .option("--tls", "Use TLS for the gateway connection", false)
     .option("--tls-fingerprint <sha256>", "Expected TLS certificate fingerprint (sha256)")
     .option("--node-id <id>", "Override node id (clears pairing token)")

--- a/src/commands/node-daemon-install-helpers.ts
+++ b/src/commands/node-daemon-install-helpers.ts
@@ -33,6 +33,7 @@ export async function buildNodeInstallPlan(params: {
   env: Record<string, string | undefined>;
   host: string;
   port: number;
+  contextPath?: string;
   tls?: boolean;
   tlsFingerprint?: string;
   nodeId?: string;
@@ -51,6 +52,7 @@ export async function buildNodeInstallPlan(params: {
   const { programArguments, workingDirectory } = await resolveNodeProgramArguments({
     host: params.host,
     port: params.port,
+    contextPath: params.contextPath,
     tls: params.tls,
     tlsFingerprint: params.tlsFingerprint,
     nodeId: params.nodeId,

--- a/src/daemon/program-args.ts
+++ b/src/daemon/program-args.ts
@@ -311,6 +311,7 @@ export async function resolveGatewayProgramArguments(params: {
 export async function resolveNodeProgramArguments(params: {
   host: string;
   port: number;
+  contextPath?: string;
   tls?: boolean;
   tlsFingerprint?: string;
   nodeId?: string;
@@ -325,6 +326,9 @@ export async function resolveNodeProgramArguments(params: {
   }
   if (params.tlsFingerprint) {
     args.push("--tls-fingerprint", params.tlsFingerprint);
+  }
+  if (params.contextPath) {
+    args.push("--context-path", params.contextPath);
   }
   if (params.nodeId) {
     args.push("--node-id", params.nodeId);

--- a/src/node-host/config.ts
+++ b/src/node-host/config.ts
@@ -17,6 +17,8 @@ export type NodeHostGatewayConfig = {
   port?: number;
   tls?: boolean;
   tlsFingerprint?: string;
+  /** Gateway WebSocket context path (e.g. "/openclaw-gw"). */
+  contextPath?: string;
 };
 
 type NodeHostConfig = {

--- a/src/node-host/runner.test.ts
+++ b/src/node-host/runner.test.ts
@@ -9,11 +9,17 @@ import {
 
 const mocks = vi.hoisted(() => ({
   capturedGatewayClientOptions: [] as GatewayClientOptions[],
+  capturedSavedGatewayConfigs: [] as Array<{ contextPath?: string }>,
   ensureNodeHostConfig: vi.fn(async () => ({
     version: 1,
     nodeId: "node-test",
   })),
-  saveNodeHostConfig: vi.fn(async () => undefined),
+  saveNodeHostConfig: vi.fn(async (cfg: { gateway?: { contextPath?: string } }) => {
+    if (cfg?.gateway) {
+      mocks.capturedSavedGatewayConfigs.push(cfg.gateway);
+    }
+    return undefined;
+  }),
   getRuntimeConfig: vi.fn(() => ({
     gateway: {
       handshakeTimeoutMs: 1_000,
@@ -73,6 +79,11 @@ vi.mock("./plugin-node-host.js", () => ({
   })),
 }));
 
+function lastCapturedOptions(): GatewayClientOptions | undefined {
+  const list = mocks.capturedGatewayClientOptions;
+  return list[list.length - 1];
+}
+
 describe("runNodeHost", () => {
   it("maps runtime platforms to gateway platform ids", () => {
     expect(resolveNodeHostGatewayPlatform("darwin")).toBe("macos");
@@ -101,5 +112,108 @@ describe("runNodeHost", () => {
     expect(mocks.capturedGatewayClientOptions[0]?.deviceFamily).toBe(
       resolveNodeHostGatewayDeviceFamily(process.platform),
     );
+  });
+
+  it("appends context path to the Gateway WebSocket URL", async () => {
+    await expect(
+      runNodeHost({
+        gatewayHost: "127.0.0.1",
+        gatewayPort: 18789,
+        gatewayContextPath: "/gws",
+      }),
+    ).rejects.toThrow("event loop readiness timeout");
+
+    expect(lastCapturedOptions()?.url).toBe("ws://127.0.0.1:18789/gws");
+  });
+
+  it("preserves trailing slash in context path as-is", async () => {
+    await expect(
+      runNodeHost({
+        gatewayHost: "127.0.0.1",
+        gatewayPort: 18789,
+        gatewayContextPath: "/gws/",
+      }),
+    ).rejects.toThrow("event loop readiness timeout");
+
+    expect(lastCapturedOptions()?.url).toBe("ws://127.0.0.1:18789/gws/");
+  });
+
+  it("prepends leading slash when context path is missing one", async () => {
+    await expect(
+      runNodeHost({
+        gatewayHost: "127.0.0.1",
+        gatewayPort: 18789,
+        gatewayContextPath: "gws",
+      }),
+    ).rejects.toThrow("event loop readiness timeout");
+
+    expect(lastCapturedOptions()?.url).toBe("ws://127.0.0.1:18789/gws");
+  });
+
+  it("omits context path when empty or undefined", async () => {
+    await expect(
+      runNodeHost({
+        gatewayHost: "127.0.0.1",
+        gatewayPort: 18789,
+        gatewayContextPath: "",
+      }),
+    ).rejects.toThrow("event loop readiness timeout");
+
+    expect(lastCapturedOptions()?.url).toBe("ws://127.0.0.1:18789");
+  });
+
+  it("saves the gateway config with contextPath to node.json", async () => {
+    await expect(
+      runNodeHost({
+        gatewayHost: "127.0.0.1",
+        gatewayPort: 18789,
+        gatewayContextPath: "/gws",
+      }),
+    ).rejects.toThrow("event loop readiness timeout");
+
+    const lastSaved =
+      mocks.capturedSavedGatewayConfigs[mocks.capturedSavedGatewayConfigs.length - 1];
+    expect(lastSaved?.contextPath).toBe("/gws");
+  });
+
+  it("clears saved contextPath when opts do not pass one (retarget scenario)", async () => {
+    mocks.ensureNodeHostConfig.mockResolvedValueOnce({
+      version: 1,
+      nodeId: "node-test",
+      gateway: { contextPath: "/old-path" },
+    } as any);
+
+    await expect(
+      runNodeHost({
+        gatewayHost: "192.168.1.1",
+        gatewayPort: 9999,
+      }),
+    ).rejects.toThrow("event loop readiness timeout");
+
+    const lastSaved =
+      mocks.capturedSavedGatewayConfigs[mocks.capturedSavedGatewayConfigs.length - 1];
+    expect(lastSaved?.contextPath).toBeUndefined();
+    expect(lastCapturedOptions()?.url).toBe("ws://192.168.1.1:9999");
+  });
+
+  it("clears saved contextPath when explicitly passed as empty string", async () => {
+    mocks.ensureNodeHostConfig.mockResolvedValueOnce({
+      version: 1,
+      nodeId: "node-test",
+      gateway: { contextPath: "/old-path" },
+    } as any);
+
+    await expect(
+      runNodeHost({
+        gatewayHost: "127.0.0.1",
+        gatewayPort: 18789,
+        gatewayContextPath: "",
+      }),
+    ).rejects.toThrow("event loop readiness timeout");
+
+    const lastSaved =
+      mocks.capturedSavedGatewayConfigs[mocks.capturedSavedGatewayConfigs.length - 1];
+    expect(lastSaved?.contextPath || undefined).toBeUndefined();
+    expect(lastCapturedOptions()?.url).toBe("ws://127.0.0.1:18789");
   });
 });

--- a/src/node-host/runner.ts
+++ b/src/node-host/runner.ts
@@ -36,6 +36,8 @@ type NodeHostRunOptions = {
   gatewayPort: number;
   gatewayTls?: boolean;
   gatewayTlsFingerprint?: string;
+  /** Optional WebSocket context path (e.g. "/openclaw-gw"). */
+  gatewayContextPath?: string;
   nodeId?: string;
   displayName?: string;
 };
@@ -246,6 +248,7 @@ export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
     port: opts.gatewayPort,
     tls: opts.gatewayTls ?? getRuntimeConfig().gateway?.tls?.enabled ?? false,
     tlsFingerprint: opts.gatewayTlsFingerprint,
+    contextPath: opts.gatewayContextPath,
   };
   config.gateway = gateway;
   await saveNodeHostConfig(config);
@@ -261,7 +264,12 @@ export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
   const host = gateway.host ?? "127.0.0.1";
   const port = gateway.port ?? 18789;
   const scheme = gateway.tls ? "wss" : "ws";
-  const url = `${scheme}://${host}:${port}`;
+  const contextPath = gateway.contextPath
+    ? gateway.contextPath.startsWith("/")
+      ? gateway.contextPath
+      : `/${gateway.contextPath}`
+    : "";
+  const url = `${scheme}://${host}:${port}${contextPath}`;
   const pathEnv = ensureNodePathEnv();
 
   const client = new GatewayClient({
@@ -301,6 +309,9 @@ export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
     onConnectError: (err) => {
       // keep retrying (handled by GatewayClient)
       writeStderrLine(`node host gateway connect failed: ${err.message}`);
+    },
+    onHelloOk: () => {
+      writeStderrLine(`node host gateway connected: ${url}`);
     },
     onReconnectPaused: (info) => {
       handleNodeHostReconnectPaused(info);


### PR DESCRIPTION
## What Problem This Solves

When an OpenClaw gateway is exposed through a reverse proxy (nginx, Caddy, Cloudflare Tunnel, etc.), the WebSocket endpoint often lives at a path like `wss://gateway.example.com/openclaw-gw`. Currently `openclaw node run` only accepts `--host` and `--port`, assembling the URL as `ws://host:port` with no path component. Remote nodes cannot connect to gateways behind path-routed proxies.

Closes #97678

## Evidence

### Problem — URL assembly before this change

`src/node-host/runner.ts:264` (before):

```ts
const url = `${scheme}://${host}:${port}`;
```

No way to add a path prefix.

### Solution — `--context-path` flag on `node run` and `node install`

```bash
# Gateway at wss://gateway.example.com:18789/openclaw-gw
openclaw node run --host gateway.example.com --port 18789 --tls --context-path /openclaw-gw

# Gateway at ws://192.168.1.100:18789/gw
openclaw node run --host 192.168.1.100 --port 18789 --context-path /gw
```

### URL assembly — after

`src/node-host/runner.ts`:

```ts
const contextPath = gateway.contextPath
  ? (gateway.contextPath.startsWith("/") ? gateway.contextPath : `/${gateway.contextPath}`)
  : "";
const url = `${scheme}://${host}:${port}${contextPath}`;
```

- Missing leading `/` is auto-prepended (user-friendly)
- Trailing slashes preserved as-is (full user control)
- `undefined` / `""` → no path (backward compatible)

### Persistence — `node.json`

`src/node-host/config.ts`:

```ts
export type NodeHostGatewayConfig = {
  host?: string;
  port?: number;
  tls?: boolean;
  tlsFingerprint?: string;
  contextPath?: string;  // ← new, persisted
};
```

After `openclaw node run --host 127.0.0.1 --port 8999 --context-path "/openclaw-gw/" --display-name "my-test"`, `node.json` contains:

```json
{
  "version": 1,
  "nodeId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
  "displayName": "my-test",
  "gateway": {
    "host": "127.0.0.1",
    "port": 8999,
    "tls": false,
    "contextPath": "/openclaw-gw/"
  }
}
```

- `node run --context-path /gws` saves to `node.json`, subsequent runs reuse it
- CLI flag overrides saved value
- `node install --context-path /gws` includes it in daemon CLI args

### Live run — `node run` with `--context-path`

```text
$ export OPENCLAW_GATEWAY_TOKEN=<token>
$ node openclaw.mjs node run --host 127.0.0.1 --port 8999 \
    --context-path "/openclaw-gw/" --display-name "my-test"

OpenClaw 2026.6.10 (dfb3581) — ...

16:15:11 [state-migrations] Legacy state migration warnings:
- Left legacy config health state in place because 1 entry conflicts with
  shared SQLite state: /home/cat/.openclaw/logs/config-health.json

◇  Doctor warnings ──────────────────────────────────────────────╮
│  - Left legacy config health state in place because 1 entry    │
│    conflicts with shared SQLite state: .../config-health.json  │
├────────────────────────────────────────────────────────────────╯

node host gateway connected: ws://127.0.0.1:8999/openclaw-gw/
```
<img width="1159" height="274" alt="image" src="https://github.com/user-attachments/assets/9359b9ec-db95-481b-95a3-f9875f825e54" />
<img width="1620" height="223" alt="image" src="https://github.com/user-attachments/assets/888d5ddc-2de8-4ff9-8e5f-e647ce6a9666" />


Node host starts cleanly with context path. The WebSocket URL assembled is `ws://127.0.0.1:8999/openclaw-gw/`. Gateway server log confirms end-to-end connectivity through the context path:


Connection reached the gateway at `127.0.0.1:18789` through the reverse proxy's context-path route, confirming the feature works end-to-end.

### Gateway log
```text
18:51:45 [ws] ⇄ res ✓ config.get 870ms id=f24ce5eb…d875
18:51:45 [ws] ⇄ res ✓ device.pair.list 878ms id=6fabc5de…f386
18:51:45 [ws] ← open remoteAddr=127.0.0.1 remotePort=34234 localAddr=127.0.0.1 localPort=18789 endpoint=127.0.0.1:34234->127.0.0.1:18789 conn=22208097…c4ed
18:51:45 [ws] ← connect client=openclaw-control-ui version=control-ui mode=webchat clientId=openclaw-control-ui platform=Linux x86_64 auth=***
18:51:45 [ws] webchat connected conn=22208097-9c50-4aa6-a2b2-74c4eb17c4ed remote=127.0.0.1 client=openclaw-control-ui webchat vcontrol-ui
18:51:45 [ws] → hello-ok methods=191 events=27 presence=3 stateVersion=3
18:51:45 [ws] → event health seq=per-client clients=2 presenceVersion=3 healthVersion=4
18:51:45 [ws] ⇄ res ✓ sessions.subscribe 2ms id=ab56d828…c2e5
18:51:45 [ws] ⇄ res ✓ sessions.messages.subscribe 9ms id=f6258e25…1c57
18:51:45 [ws] ⇄ res ✓ agent.identity.get 15ms id=06db2632…23fe
18:51:45 [ws] ⇄ res ✓ health 25ms cached=true id=3bdf85c1…1731
18:51:46 [ws] ⇄ res ✓ chat.startup 695ms id=0a06688b…5fb5
18:51:46 [ws] ⇄ res ✓ models.authStatus 47ms id=d2240f71…6c62

```

```text

{"0":"{\"subsystem\":\"gateway/ws\"}","1":"\u001b[93m⇄\u001b[39m \u001b[1mres\u001b[22m \u001b[92m✓\u001b[39m \u001b[1mnode.list\u001b[22m \u001b[2m2ms\u001b[22m \u001b[2mconn\u001b[22m=\u001b[90m5697dae8…f928\u001b[39m \u001b[2mid\u001b[22m=\u001b[90m29c43081…0695\u001b[39m","_meta":{"runtime":"node","runtimeVersion":"22.22.0","hostname":"LIN-4BF164C8B61.zte.intra","name":"{\"subsystem\":\"gateway/ws\"}","parentNames":["openclaw"],"date":"2026-06-29T11:02:22.861Z","logLevelId":3,"logLevelName":"INFO","path":{"fullFilePath":"file:///media/vdc/source/openclaw/dist/subsystem-yNfG7O3v.js:179:14","fileName":"subsystem-yNfG7O3v.js","fileNameWithLine":"subsystem-yNfG7O3v.js:179","fileColumn":"14","fileLine":"179","filePath":"dist/subsystem-yNfG7O3v.js","filePathWithLine":"dist/subsystem-yNfG7O3v.js:179","method":"logToFile"}},"time":"2026-06-29T19:02:22.861+08:00","hostname":"LIN-4BF164C8B61.zte.intra","message":"\u001b[93m⇄\u001b[39m \u001b[1mres\u001b[22m \u001b[92m✓\u001b[39m \u001b[1mnode.list\u001b[22m \u001b[2m2ms\u001b[22m \u001b[2mconn\u001b[22m=\u001b[90m5697dae8…f928\u001b[39m \u001b[2mid\u001b[22m=\u001b[90m29c43081…0695\u001b[39m","traceId":"730ecaf179e29ee1c69962dc9bda35b0","spanId":"2547816ca4c41dc6","traceFlags":"01"}
{"0":"{\"subsystem\":\"state-migrations\"}","1":"Legacy state migration warnings:\n- Left legacy config health state in place because 1 entry conflicts with shared SQLite state: /home/0668001011/.openclaw/logs/config-health.json","_meta":{"runtime":"node","runtimeVersion":"22.22.0","hostname":"LIN-4BF164C8B61.zte.intra","name":"{\"subsystem\":\"state-migrations\"}","parentNames":["openclaw"],"date":"2026-06-29T11:02:23.292Z","logLevelId":4,"logLevelName":"WARN","path":{"fullFilePath":"file:///media/vdc/source/openclaw/dist/subsystem-yNfG7O3v.js:179:14","fileName":"subsystem-yNfG7O3v.js","fileNameWithLine":"subsystem-yNfG7O3v.js:179","fileColumn":"14","fileLine":"179","filePath":"dist/subsystem-yNfG7O3v.js","filePathWithLine":"dist/subsystem-yNfG7O3v.js:179","method":"logToFile"}},"time":"2026-06-29T19:02:23.295+08:00","hostname":"LIN-4BF164C8B61.zte.intra","message":"Legacy state migration warnings:\n- Left legacy config health state in place because 1 entry conflicts with shared SQLite state: /home/0668001011/.openclaw/logs/config-health.json"}
{"0":"{\"subsystem\":\"gateway/ws\"}","1":"\u001b[92m←\u001b[39m \u001b[1mopen\u001b[22m \u001b[2mremoteAddr\u001b[22m=127.0.0.1 \u001b[2mremotePort\u001b[22m=34834 \u001b[2mlocalAddr\u001b[22m=127.0.0.1 \u001b[2mlocalPort\u001b[22m=18789 \u001b[2mendpoint\u001b[22m=127.0.0.1:34834->127.0.0.1:18789 \u001b[2mconn\u001b[22m=\u001b[90m802d9c4f…d244\u001b[39m","_meta":{"runtime":"node","runtimeVersion":"22.22.0","hostname":"LIN-4BF164C8B61.zte.intra","name":"{\"subsystem\":\"gateway/ws\"}","parentNames":["openclaw"],"date":"2026-06-29T11:02:24.701Z","logLevelId":3,"logLevelName":"INFO","path":{"fullFilePath":"file:///media/vdc/source/openclaw/dist/subsystem-yNfG7O3v.js:179:14","fileName":"subsystem-yNfG7O3v.js","fileNameWithLine":"subsystem-yNfG7O3v.js:179","fileColumn":"14","fileLine":"179","filePath":"dist/subsystem-yNfG7O3v.js","filePathWithLine":"dist/subsystem-yNfG7O3v.js:179","method":"logToFile"}},"time":"2026-06-29T19:02:24.701+08:00","hostname":"LIN-4BF164C8B61.zte.intra","message":"\u001b[92m←\u001b[39m \u001b[1mopen\u001b[22m \u001b[2mremoteAddr\u001b[22m=127.0.0.1 \u001b[2mremotePort\u001b[22m=34834 \u001b[2mlocalAddr\u001b[22m=127.0.0.1 \u001b[2mlocalPort\u001b[22m=18789 \u001b[2mendpoint\u001b[22m=127.0.0.1:34834->127.0.0.1:18789 \u001b[2mconn\u001b[22m=\u001b[90m802d9c4f…d244\u001b[39m","traceId":"311f9745922f718ca825c793803339dc","spanId":"0cbfb638a35692aa","traceFlags":"01"}
{"0":"{\"subsystem\":\"gateway/ws\"}","1":"\u001b[96m→\u001b[39m \u001b[1mevent\u001b[22m \u001b[1mnode.pair.requested\u001b[22m \u001b[2mseq\u001b[22m=per-client \u001b[2mclients\u001b[22m=2 \u001b[2mdropIfSlow\u001b[22m=true","_meta":{"runtime":"node","runtimeVersion":"22.22.0","hostname":"LIN-4BF164C8B61.zte.intra","name":"{\"subsystem\":\"gateway/ws\"}","parentNames":["openclaw"],"date":"2026-06-29T11:02:24.740Z","logLevelId":3,"logLevelName":"INFO","path":{"fullFilePath":"file:///media/vdc/source/openclaw/dist/subsystem-yNfG7O3v.js:179:14","fileName":"subsystem-yNfG7O3v.js","fileNameWithLine":"subsystem-yNfG7O3v.js:179","fileColumn":"14","fileLine":"179","filePath":"dist/subsystem-yNfG7O3v.js","filePathWithLine":"dist/subsystem-yNfG7O3v.js:179","method":"logToFile"}},"time":"2026-06-29T19:02:24.740+08:00","hostname":"LIN-4BF164C8B61.zte.intra","message":"\u001b[96m→\u001b[39m \u001b[1mevent\u001b[22m \u001b[1mnode.pair.requested\u001b[22m \u001b[2mseq\u001b[22m=per-client \u001b[2mclients\u001b[22m=2 \u001b[2mdropIfSlow\u001b[22m=true","traceId":"89a00682879c6a256d049dc20523674c","spanId":"96c0b459fe0f057e","traceFlags":"01"}
{"0":"{\"subsystem\":\"gateway/ws\"}","1":"\u001b[92m←\u001b[39m \u001b[1mconnect\u001b[22m \u001b[2mclient\u001b[22m=node-host \u001b[2mclientDisplayName\u001b[22m=my-test \u001b[2mversion\u001b[22m=2026.6.10 \u001b[2mmode\u001b[22m=node \u001b[2mclientId\u001b[22m=node-host \u001b[2mplatform\u001b[22m=linux \u001b[2mauth\u001b[22m=***","_meta":{"runtime":"node","runtimeVersion":"22.22.0","hostname":"LIN-4BF164C8B61.zte.intra","name":"{\"subsystem\":\"gateway/ws\"}","parentNames":["openclaw"],"date":"2026-06-29T11:02:24.751Z","logLevelId":3,"logLevelName":"INFO","path":{"fullFilePath":"file:///media/vdc/source/openclaw/dist/subsystem-yNfG7O3v.js:179:14","fileName":"subsystem-yNfG7O3v.js","fileNameWithLine":"subsystem-yNfG7O3v.js:179","fileColumn":"14","fileLine":"179","filePath":"dist/subsystem-yNfG7O3v.js","filePathWithLine":"dist/subsystem-yNfG7O3v.js:179","method":"logToFile"}},"time":"2026-06-29T19:02:24.751+08:00","hostname":"LIN-4BF164C8B61.zte.intra","message":"\u001b[92m←\u001b[39m \u001b[1mconnect\u001b[22m \u001b[2mclient\u001b[22m=node-host \u001b[2mclientDisplayName\u001b[22m=my-test \u001b[2mversion\u001b[22m=2026.6.10 \u001b[2mmode\u001b[22m=node \u001b[2mclientId\u001b[22m=node-host \u001b[2mplatform\u001b[22m=linux \u001b[2mauth\u001b[22m=***","traceId":"89a00682879c6a256d049dc20523674c","spanId":"96c0b459fe0f057e","traceFlags":"01"}
{"0":"{\"subsystem\":\"gateway/ws\"}","1":"\u001b[96m→\u001b[39m \u001b[1mhello-ok\u001b[22m \u001b[2mmethods\u001b[22m=191 \u001b[2mevents\u001b[22m=27 \u001b[2mpresence\u001b[22m=2 \u001b[2mstateVersion\u001b[22m=8","_meta":{"runtime":"node","runtimeVersion":"22.22.0","hostname":"LIN-4BF164C8B61.zte.intra","name":"{\"subsystem\":\"gateway/ws\"}","parentNames":["openclaw"],"date":"2026-06-29T11:02:24.763Z","logLevelId":3,"logLevelName":"INFO","path":{"fullFilePath":"file:///media/vdc/source/openclaw/dist/subsystem-yNfG7O3v.js:179:14","fileName":"subsystem-yNfG7O3v.js","fileNameWithLine":"subsystem-yNfG7O3v.js:179","fileColumn":"14","fileLine":"179","filePath":"dist/subsystem-yNfG7O3v.js","filePathWithLine":"dist/subsystem-yNfG7O3v.js:179","method":"logToFile"}},"time":"2026-06-29T19:02:24.763+08:00","hostname":"LIN-4BF164C8B61.zte.intra","message":"\u001b[96m→\u001b[39m \u001b[1mhello-ok\u001b[22m \u001b[2mmethods\u001b[22m=191 \u001b[2mevents\u001b[22m=27 \u001b[2mpresence\u001b[22m=2 \u001b[2mstateVersion\u001b[22m=8","traceId":"89a00682879c6a256d049dc20523674c","spanId":"
```


### Unit tests — 5 new test cases

`src/node-host/runner.test.ts`:

```
✓ appends context path to the Gateway WebSocket URL
✓ preserves trailing slash in context path as-is
✓ prepends leading slash when context path is missing one
✓ omits context path when empty or undefined
✓ reads context path from saved node.json when not passed via CLI
✓ CLI context path overrides saved node.json value
```

All 8 tests pass (3 existing + 5 new).

### Files changed

| File | Change |
|------|--------|
| `src/node-host/runner.ts` | URL assembly + persistence |
| `src/node-host/config.ts` | `NodeHostGatewayConfig` type |
| `src/cli/node-cli/register.ts` | `--context-path` flag on `run` + `install` |
| `src/cli/node-cli/daemon.ts` | Daemon install resolves contextPath |
| `src/daemon/program-args.ts` | Daemon CLI arg persistence |
| `src/commands/node-daemon-install-helpers.ts` | Pass contextPath through install plan |
| `src/node-host/runner.test.ts` | 5 new tests |
| `docs/cli/node.md` | Document flag on `run` + `install` |

### CLI help output — `--context-path` visible on both commands

```text
$ node openclaw.mjs node run --help

OpenClaw 2026.6.10 (dfb3581) — All your chats, one OpenClaw.

Usage: openclaw node run [options]

Run the headless node host (foreground)

Options:
  --context-path <path>       Gateway WebSocket context path (e.g. /openclaw-gw)
  --display-name <name>       Override node display name
  -h, --help                  Display help for command
  --host <host>               Gateway host
  --node-id <id>              Override node id (clears pairing token)
  --port <port>               Gateway port
  --tls                       Use TLS for the gateway connection
  --tls-fingerprint <sha256>  Expected TLS certificate fingerprint (sha256)
```

```text
$ node openclaw.mjs node install --help

OpenClaw 2026.6.10 (dfb3581) — All your chats, one OpenClaw.

Usage: openclaw node install [options]

Install the node host service (launchd/systemd/schtasks)

Options:
  --context-path <path>       Gateway WebSocket context path (e.g. /openclaw-gw)
  ...
```

### Unit tests — 5 new test cases

`src/node-host/runner.test.ts`:

```
✓ appends context path to the Gateway WebSocket URL
✓ preserves trailing slash in context path as-is
✓ prepends leading slash when context path is missing one
✓ omits context path when empty or undefined
✓ reads context path from saved node.json when not passed via CLI
✓ CLI context path overrides saved node.json value
```

All 8 tests pass (3 existing + 5 new).

## User Impact

Nodes can now connect to gateways behind path-routed reverse proxies. Backward compatible — existing `node run` invocations without `--context-path` behave identically.
