### PR TITLE
chore: fold release upgrade Docker lanes into QA

### DIFF
--- a/qa/scenarios/runtime/docker-release-upgrade-user-journey.yaml
+++ b/qa/scenarios/runtime/docker-release-upgrade-user-journey.yaml
@@ -1,0 +1,30 @@
+title: Docker release upgrade user journey
+
+scenario:
+  id: docker-release-upgrade-user-journey
+  surface: docker-podman-hosting
+  category: docker-podman-hosting.image-release-and-validation
+  coverage:
+    primary:
+      - docker.release-workflow
+      - docker.release-path-install
+  objective: Verify a published baseline can be configured, upgraded to the candidate tarball, and still complete the core release journey.
+  successCriteria:
+    - A published baseline installs and is configured with mock provider, plugin, and ClickClack channel state.
+    - The candidate package replaces the baseline package.
+    - The upgraded install still passes agent, plugin CLI, channel status, outbound message, Gateway, and inbound reply checks.
+  docsRefs:
+    - docs/help/testing.md
+    - docs/help/testing-updates-plugins.md
+    - docs/concepts/qa-e2e-automation.md
+  codeRefs:
+    - scripts/e2e/release-upgrade-user-journey-docker.sh
+    - scripts/e2e/lib/release-upgrade-user-journey/scenario.sh
+    - scripts/e2e/lib/release-user-journey/assertions.mjs
+  execution:
+    kind: script
+    path: scripts/qa/docker-e2e-lane.ts
+    summary: Runs the existing release-upgrade-user-journey Docker E2E lane and records QA Lab evidence for release-path upgrade coverage.
+    args:
+      - --lane
+      - release-upgrade-user-journey

--- a/qa/scenarios/runtime/docker-release-user-journey.yaml
+++ b/qa/scenarios/runtime/docker-release-user-journey.yaml
@@ -1,0 +1,29 @@
+title: Docker release user journey
+
+scenario:
+  id: docker-release-user-journey
+  surface: docker-podman-hosting
+  category: docker-podman-hosting.image-release-and-validation
+  coverage:
+    primary:
+      - docker.release-path-install
+  objective: Verify the package-installed Docker release journey from clean install through agent, plugin, channel, Gateway restart, and doctor checks.
+  successCriteria:
+    - The packed OpenClaw tarball installs globally in a clean Docker home.
+    - Non-interactive onboarding configures the loopback Gateway and mock model provider.
+    - A package-installed agent turn, external plugin install/uninstall, ClickClack outbound/inbound messaging, Gateway restart, and doctor repair all pass.
+  docsRefs:
+    - docs/help/testing.md
+    - docs/help/testing-updates-plugins.md
+    - docs/concepts/qa-e2e-automation.md
+  codeRefs:
+    - scripts/e2e/release-user-journey-docker.sh
+    - scripts/e2e/lib/release-user-journey/scenario.sh
+    - scripts/e2e/lib/release-user-journey/assertions.mjs
+  execution:
+    kind: script
+    path: scripts/qa/docker-e2e-lane.ts
+    summary: Runs the existing release-user-journey Docker E2E lane and records QA Lab evidence for release-path install coverage.
+    args:
+      - --lane
+      - release-user-journey

--- a/qa/scenarios/runtime/docker-update-channel-switch.yaml
+++ b/qa/scenarios/runtime/docker-update-channel-switch.yaml
@@ -1,0 +1,31 @@
+title: Docker update channel switch
+
+scenario:
+  id: docker-update-channel-switch
+  surface: cli-install-update-onboard-doctor
+  category: cli-install-update-onboard-doctor.updates-and-upgrades
+  coverage:
+    primary:
+      - cli.install-kind-switching
+      - cli.update-status-and-rpc
+    secondary:
+      - cli.update-channels
+  objective: Verify package-to-git and git-to-package update switching plus machine-readable update status in Docker.
+  successCriteria:
+    - The package install updates to a package-derived git dev fixture.
+    - The git install updates back to the package tarball.
+    - "`openclaw update status --json` reports the expected git and package status after each switch."
+  docsRefs:
+    - docs/cli/update.md
+    - docs/install/updating.md
+    - docs/help/testing-updates-plugins.md
+  codeRefs:
+    - scripts/e2e/update-channel-switch-docker.sh
+    - scripts/e2e/lib/update-channel-switch/assertions.mjs
+  execution:
+    kind: script
+    path: scripts/qa/docker-e2e-lane.ts
+    summary: Runs the existing update-channel-switch Docker E2E lane and records QA Lab evidence for install-kind switching and update status coverage.
+    args:
+      - --lane
+      - update-channel-switch

--- a/qa/scenarios/runtime/docker-update-migration.yaml
+++ b/qa/scenarios/runtime/docker-update-migration.yaml
@@ -1,0 +1,31 @@
+title: Docker update migration
+
+scenario:
+  id: docker-update-migration
+  surface: cli-install-update-onboard-doctor
+  category: cli-install-update-onboard-doctor.updates-and-upgrades
+  coverage:
+    primary:
+      - cli.plugin-convergence
+    secondary:
+      - cli.update-status-and-rpc
+  objective: Verify published baseline plugin dependency debris is cleaned by the candidate update and post-update doctor flow.
+  successCriteria:
+    - A published baseline is configured with the plugin-dependency cleanup scenario.
+    - Legacy plugin dependency debris is present before candidate repair.
+    - Candidate update plus doctor cleans the legacy dependency roots and the final Gateway/status probes pass.
+  docsRefs:
+    - docs/cli/update.md
+    - docs/help/testing-updates-plugins.md
+    - docs/reference/test.md
+  codeRefs:
+    - scripts/e2e/upgrade-survivor-docker.sh
+    - scripts/e2e/lib/upgrade-survivor/run.sh
+    - src/cli/update-cli/post-core-plugin-convergence.ts
+  execution:
+    kind: script
+    path: scripts/qa/docker-e2e-lane.ts
+    summary: Runs the existing update-migration Docker E2E lane and records QA Lab evidence for plugin convergence coverage.
+    args:
+      - --lane
+      - update-migration

--- a/qa/scenarios/runtime/docker-update-restart-auth.yaml
+++ b/qa/scenarios/runtime/docker-update-restart-auth.yaml
@@ -1,0 +1,31 @@
+title: Docker update managed restart auth
+
+scenario:
+  id: docker-update-restart-auth
+  surface: cli-install-update-onboard-doctor
+  category: cli-install-update-onboard-doctor.updates-and-upgrades
+  coverage:
+    primary:
+      - cli.managed-gateway-restart
+    secondary:
+      - cli.update-status-and-rpc
+  objective: Verify update-owned Gateway restart works when the caller lacks service-owned auth environment.
+  successCriteria:
+    - The lane starts a managed token-auth Gateway.
+    - "`openclaw update --yes --json` runs without inherited caller Gateway auth."
+    - The update command restarts the Gateway and the normal health, ready, and RPC status probes pass afterward.
+  docsRefs:
+    - docs/cli/update.md
+    - docs/install/updating.md
+    - docs/help/testing-updates-plugins.md
+  codeRefs:
+    - scripts/e2e/upgrade-survivor-docker.sh
+    - scripts/e2e/lib/upgrade-survivor/run.sh
+    - scripts/e2e/lib/upgrade-survivor/update-restart-auth.sh
+  execution:
+    kind: script
+    path: scripts/qa/docker-e2e-lane.ts
+    summary: Runs the existing update-restart-auth Docker E2E lane and records QA Lab evidence for managed Gateway restart coverage.
+    args:
+      - --lane
+      - update-restart-auth

--- a/qa/scenarios/runtime/docker-upgrade-survivor.yaml
+++ b/qa/scenarios/runtime/docker-upgrade-survivor.yaml
@@ -1,0 +1,31 @@
+title: Docker upgrade survivor
+
+scenario:
+  id: docker-upgrade-survivor
+  surface: cli-install-update-onboard-doctor
+  category: cli-install-update-onboard-doctor.updates-and-upgrades
+  coverage:
+    primary:
+      - cli.update-status-and-rpc
+    secondary:
+      - docker.release-path-install
+  objective: Verify dirty existing user state survives package update, doctor repair, Gateway startup, health probes, and RPC status in Docker.
+  successCriteria:
+    - The packed candidate installs over seeded existing-user state with agents, channels, plugin allowlists, workspaces, sessions, and stale dependency debris.
+    - Package update plus non-interactive doctor completes without live provider or channel keys.
+    - Gateway startup, `/healthz`, `/readyz`, and `gateway status --require-rpc --json` pass within survivor budgets.
+  docsRefs:
+    - docs/help/testing.md
+    - docs/help/testing-updates-plugins.md
+    - docs/reference/test.md
+  codeRefs:
+    - scripts/e2e/upgrade-survivor-docker.sh
+    - scripts/e2e/lib/upgrade-survivor/run.sh
+    - scripts/e2e/lib/upgrade-survivor/assertions.mjs
+  execution:
+    kind: script
+    path: scripts/qa/docker-e2e-lane.ts
+    summary: Runs the existing upgrade-survivor Docker E2E lane and records QA Lab evidence for update status/RPC survival coverage.
+    args:
+      - --lane
+      - upgrade-survivor

--- a/scripts/qa/docker-e2e-lane.ts
+++ b/scripts/qa/docker-e2e-lane.ts
@@ -1,0 +1,72 @@
+// Runs an existing Docker E2E lane through the QA Lab script scenario contract.
+import { spawnSync } from "node:child_process";
+
+type Lane = {
+  env?: Record<string, string>;
+  script: string;
+};
+
+const lanes: Record<string, Lane> = {
+  "release-upgrade-user-journey": {
+    script: "scripts/e2e/release-upgrade-user-journey-docker.sh",
+  },
+  "release-user-journey": {
+    script: "scripts/e2e/release-user-journey-docker.sh",
+  },
+  "update-channel-switch": {
+    script: "scripts/e2e/update-channel-switch-docker.sh",
+  },
+  "update-migration": {
+    env: {
+      OPENCLAW_UPGRADE_SURVIVOR_PUBLISHED_BASELINE: "1",
+      OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPEC:
+        process.env.OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPEC ?? "openclaw@2026.4.23",
+      OPENCLAW_UPGRADE_SURVIVOR_SCENARIO:
+        process.env.OPENCLAW_UPGRADE_SURVIVOR_SCENARIO ?? "plugin-deps-cleanup",
+    },
+    script: "scripts/e2e/upgrade-survivor-docker.sh",
+  },
+  "update-restart-auth": {
+    env: {
+      OPENCLAW_UPGRADE_SURVIVOR_UPDATE_RESTART_MODE: "auto-auth",
+      OPENCLAW_UPGRADE_SURVIVOR_DOCKER_RUN_TIMEOUT:
+        process.env.OPENCLAW_UPGRADE_SURVIVOR_DOCKER_RUN_TIMEOUT ?? "1500s",
+    },
+    script: "scripts/e2e/upgrade-survivor-docker.sh",
+  },
+  "upgrade-survivor": {
+    script: "scripts/e2e/upgrade-survivor-docker.sh",
+  },
+};
+
+function laneArg(argv: string[]) {
+  const index = argv.indexOf("--lane");
+  if (index === -1) {
+    throw new Error("--lane is required");
+  }
+  const lane = argv[index + 1];
+  if (!lane || lane.startsWith("-")) {
+    throw new Error("--lane requires a value");
+  }
+  return lane;
+}
+
+const laneName = laneArg(process.argv.slice(2));
+const lane = lanes[laneName];
+if (!lane) {
+  throw new Error(`unknown Docker E2E lane: ${laneName}`);
+}
+
+const result = spawnSync("bash", [lane.script], {
+  env: { ...process.env, ...lane.env },
+  stdio: "inherit",
+});
+
+if (result.error) {
+  console.error(result.error);
+  process.exit(1);
+}
+if (result.signal) {
+  process.kill(process.pid, result.signal);
+}
+process.exit(result.status ?? 1);


### PR DESCRIPTION
## What Problem This Solves

Release and update Docker E2E lanes already proved package install, release upgrade, update restart, update status, and plugin convergence behavior, but QA Lab could not select them as scenario evidence for the existing maturity coverage IDs.

## Why This Change Was Made

This adds QA scenario YAML wrappers for the existing Docker E2E lanes and one tiny `scripts/qa/docker-e2e-lane.ts` dispatcher that invokes those existing shell entrypoints. The Docker shell scripts stay authoritative for setup and assertions; this PR only makes them selectable through `pnpm openclaw qa suite --scenario ...` and visible in QA coverage inventory.

Primary coverage added:

- `docker-release-user-journey`: `docker.release-path-install` because it installs the packed tarball in Docker and verifies onboarding, agent turn, plugin install/uninstall, ClickClack messaging, Gateway restart, and doctor.
- `docker-release-upgrade-user-journey`: `docker.release-path-install`, `docker.release-workflow` because it installs a published baseline, upgrades to the candidate tarball, then reruns the release journey through agent/plugin/channel/Gateway assertions.
- `docker-update-channel-switch`: `cli.install-kind-switching`, `cli.update-status-and-rpc` because it switches package -> git -> package and asserts `openclaw update status --json` after each switch.
- `docker-update-restart-auth`: `cli.managed-gateway-restart` because it runs the update-restart-auth upgrade-survivor lane where update owns the managed Gateway restart without caller-owned Gateway auth env.
- `docker-upgrade-survivor`: `cli.update-status-and-rpc` because it runs update/doctor over dirty user state and asserts Gateway health, readiness, and `gateway status --require-rpc --json` after the update.
- `docker-update-migration`: `cli.plugin-convergence` because it runs the plugin-deps-cleanup upgrade-survivor variant and requires candidate update plus doctor to clean legacy plugin dependency roots before final probes pass.

## User Impact

Maintainers can now include these existing release/update Docker proofs in QA Lab evidence runs without duplicating the Docker tests or changing the taxonomy.

## Evidence

- `node scripts/run-vitest.mjs extensions/qa-lab/src/scenario-catalog.test.ts --reporter=verbose` passed: 30 tests.
- `node scripts/run-oxlint.mjs --tsconfig tsconfig.json scripts/qa/docker-e2e-lane.ts` passed.
- `node scripts/run-tsgo.mjs -p tsconfig.json --pretty false` passed.
- `git diff --check` passed.
- `pnpm openclaw qa coverage --match docker-release --json` showed `docker-release-user-journey` and `docker-release-upgrade-user-journey` with the expected coverage IDs.
- `pnpm openclaw qa coverage --match docker-update --json` showed update-channel-switch, update-restart-auth, and update-migration with the expected coverage IDs.
- `pnpm openclaw qa coverage --match docker-upgrade --json` showed upgrade-survivor with the expected coverage IDs.
- `.agents/skills/autoreview/scripts/autoreview --mode local` passed with no accepted/actionable findings.

Not run locally: the Docker lanes themselves. This PR does not change their Docker/runtime logic; it wires existing heavy lanes into QA Lab scenario metadata.
