### PR TITLE
fix(discord): bound requestDiscord happy-path response reads to prevent OOM

### DIFF
--- a/extensions/discord/src/api.test.ts
+++ b/extensions/discord/src/api.test.ts
@@ -272,4 +272,58 @@ describe("fetchDiscord", () => {
     expect(timeoutSpy).toHaveBeenCalledWith(MAX_TIMER_TIMEOUT_MS);
     expect(request?.signal).toBe(timeoutController.signal);
   });
+
+  it("reads happy-path response body without calling response.text()", async () => {
+    // mutation control: if code falls back to res.text(), the spy would intercept
+    // the catch(() => "") branch returns "" which makes requestDiscord return undefined,
+    // so the assertion on result also catches the regression.
+    const payload = { id: "channel-42", type: 0 };
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(JSON.stringify(payload)));
+        controller.close();
+      },
+    });
+    const response = new Response(stream, {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+    const textSpy = vi
+      .spyOn(response, "text")
+      .mockRejectedValue(new Error("response.text() must not be called on happy-path"));
+    const fetcher = withFetchPreconnect(async () => response);
+
+    const result = await requestDiscord<typeof payload>("/channels/channel-42", "test", {
+      fetcher,
+      retry: { attempts: 1 },
+    });
+
+    expect(result).toEqual(payload);
+    expect(textSpy).not.toHaveBeenCalled();
+  });
+
+  it("truncates oversized Discord API success responses to prevent unbounded memory growth", async () => {
+    // over-cap: a response larger than DISCORD_API_RESPONSE_BODY_LIMIT_BYTES (4 MiB)
+    // readResponseTextLimited cancels the reader after the cap and returns a truncated string.
+    // JSON.parse on a truncated JSON document throws SyntaxError, which surfaces to the caller.
+    let canceled = false;
+    const chunk = new Uint8Array(4 * 1024 * 1024 + 64).fill(0x78); // 'x' * (4MiB + 64)
+    const prefix = new TextEncoder().encode('{"items":[');
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(prefix);
+        controller.enqueue(chunk);
+      },
+      cancel() {
+        canceled = true;
+      },
+    });
+    const fetcher = withFetchPreconnect(async () => new Response(stream, { status: 200 }));
+
+    await expect(
+      requestDiscord("/channels/123/messages", "test", { fetcher, retry: { attempts: 1 } }),
+    ).rejects.toThrow(SyntaxError);
+
+    expect(canceled).toBe(true);
+  });
 });

--- a/extensions/discord/src/api.test.ts
+++ b/extensions/discord/src/api.test.ts
@@ -1,9 +1,13 @@
 // Discord tests cover api plugin behavior.
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { withFetchPreconnect } from "openclaw/plugin-sdk/test-env";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { DiscordApiError, fetchDiscord, requestDiscord } from "./api.js";
 import { jsonResponse } from "./test-http-helpers.js";
+
+const DISCORD_SUCCESS_RESPONSE_LIMIT_BYTES = 4 * 1024 * 1024;
 
 function cancelTrackedResponse(
   text: string,
@@ -27,9 +31,54 @@ function cancelTrackedResponse(
   };
 }
 
+async function listenLoopbackServer(server: Server): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("expected loopback TCP address"));
+        return;
+      }
+      resolve((address as AddressInfo).port);
+    });
+  });
+}
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve) => {
+    server.close(() => resolve());
+  });
+}
+
+function stubDiscordFetchToLoopback(
+  baseUrl: string,
+  onResponse?: (response: Response) => void,
+): void {
+  const realFetch = globalThis.fetch.bind(globalThis);
+  vi.stubGlobal(
+    "fetch",
+    withFetchPreconnect(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const originalUrl = new URL(input instanceof Request ? input.url : String(input));
+      expect(originalUrl.origin).toBe("https://discord.com");
+      expect(originalUrl.pathname).toMatch(/^\/api\/v10\//);
+      const loopbackUrl = new URL(`${originalUrl.pathname}${originalUrl.search}`, baseUrl);
+      const response = await realFetch(loopbackUrl, init);
+      onResponse?.(response);
+      return response;
+    }),
+  );
+}
+
 describe("fetchDiscord", () => {
   beforeEach(() => {
     vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   it("formats rate limit payloads without raw JSON", async () => {
@@ -273,57 +322,95 @@ describe("fetchDiscord", () => {
     expect(request?.signal).toBe(timeoutController.signal);
   });
 
-  it("reads happy-path response body without calling response.text()", async () => {
-    // mutation control: if code falls back to res.text(), the spy would intercept
-    // the catch(() => "") branch returns "" which makes requestDiscord return undefined,
-    // so the assertion on result also catches the regression.
-    const payload = { id: "channel-42", type: 0 };
-    const stream = new ReadableStream<Uint8Array>({
-      start(controller) {
-        controller.enqueue(new TextEncoder().encode(JSON.stringify(payload)));
-        controller.close();
-      },
+  it("returns under-cap requestDiscord responses from a real loopback HTTP server", async () => {
+    const payload = { id: "channel-42", name: "loopback", type: 0 };
+    let contentLength: string | null | undefined;
+    let requestUrl: string | undefined;
+    let authorization: string | undefined;
+    const server = createServer((req, res) => {
+      requestUrl = req.url;
+      authorization = req.headers.authorization;
+      const body = JSON.stringify(payload);
+      res.writeHead(200, { "content-type": "application/json" });
+      res.write(body.slice(0, 12));
+      res.end(body.slice(12));
     });
-    const response = new Response(stream, {
-      status: 200,
-      headers: { "content-type": "application/json" },
-    });
-    const textSpy = vi
-      .spyOn(response, "text")
-      .mockRejectedValue(new Error("response.text() must not be called on happy-path"));
-    const fetcher = withFetchPreconnect(async () => response);
+    const port = await listenLoopbackServer(server);
 
-    const result = await requestDiscord<typeof payload>("/channels/channel-42", "test", {
-      fetcher,
-      retry: { attempts: 1 },
-    });
+    try {
+      stubDiscordFetchToLoopback(`http://127.0.0.1:${port}`, (response) => {
+        contentLength = response.headers.get("content-length");
+      });
 
-    expect(result).toEqual(payload);
-    expect(textSpy).not.toHaveBeenCalled();
+      const result = await requestDiscord<typeof payload>("/channels/channel-42", "test-token", {
+        retry: { attempts: 1 },
+      });
+
+      expect(result).toEqual(payload);
+      expect(requestUrl).toBe("/api/v10/channels/channel-42");
+      expect(authorization).toBe("Bot test-token");
+      expect(contentLength).toBeNull();
+      console.log(
+        `[discord requestDiscord loopback proof] normal path: returned=${JSON.stringify(result)} content_length=${contentLength ?? "none"}`,
+      );
+    } finally {
+      await closeServer(server);
+    }
   });
 
-  it("truncates oversized Discord API success responses to prevent unbounded memory growth", async () => {
-    // over-cap: a response larger than DISCORD_API_RESPONSE_BODY_LIMIT_BYTES (4 MiB)
-    // readResponseTextLimited cancels the reader after the cap and returns a truncated string.
-    // JSON.parse on a truncated JSON document throws SyntaxError, which surfaces to the caller.
-    let canceled = false;
-    const chunk = new Uint8Array(4 * 1024 * 1024 + 64).fill(0x78); // 'x' * (4MiB + 64)
-    const prefix = new TextEncoder().encode('{"items":[');
-    const stream = new ReadableStream<Uint8Array>({
-      start(controller) {
-        controller.enqueue(prefix);
-        controller.enqueue(chunk);
-      },
-      cancel() {
-        canceled = true;
-      },
+  it("rejects oversized valid JSON requestDiscord responses from a real loopback HTTP server", async () => {
+    const oversizedPayloadBytes = DISCORD_SUCCESS_RESPONSE_LIMIT_BYTES + 256 * 1024;
+    let contentLength: string | null | undefined;
+    let requestUrl: string | undefined;
+    let streamedBytes = 0;
+    const server = createServer((req, res) => {
+      requestUrl = req.url;
+      const chunk = Buffer.alloc(64 * 1024, 0x78);
+      res.writeHead(200, { "content-type": "application/json" });
+      res.write('{"id":"');
+
+      const writeMore = () => {
+        while (streamedBytes < oversizedPayloadBytes) {
+          if (res.destroyed) {
+            return;
+          }
+          streamedBytes += chunk.byteLength;
+          if (!res.write(chunk)) {
+            res.once("drain", writeMore);
+            return;
+          }
+        }
+        res.end('"}');
+      };
+
+      writeMore();
     });
-    const fetcher = withFetchPreconnect(async () => new Response(stream, { status: 200 }));
+    const port = await listenLoopbackServer(server);
 
-    await expect(
-      requestDiscord("/channels/123/messages", "test", { fetcher, retry: { attempts: 1 } }),
-    ).rejects.toThrow(SyntaxError);
+    try {
+      stubDiscordFetchToLoopback(`http://127.0.0.1:${port}`, (response) => {
+        contentLength = response.headers.get("content-length");
+      });
 
-    expect(canceled).toBe(true);
+      let error: unknown;
+      try {
+        await requestDiscord("/channels/123/messages", "test-token", {
+          retry: { attempts: 1 },
+        });
+      } catch (err) {
+        error = err;
+      }
+
+      expect(error).toBeInstanceOf(Error);
+      expect(String(error)).toContain("Discord API /channels/123/messages response body too large");
+      expect(String(error)).toContain(`limit: ${DISCORD_SUCCESS_RESPONSE_LIMIT_BYTES} bytes`);
+      expect(requestUrl).toBe("/api/v10/channels/123/messages");
+      expect(contentLength).toBeNull();
+      console.log(
+        `[discord requestDiscord loopback proof] oversized path: cap=${DISCORD_SUCCESS_RESPONSE_LIMIT_BYTES} streamed>=${streamedBytes} content_length=${contentLength ?? "none"} rejected=${String(error)}`,
+      );
+    } finally {
+      await closeServer(server);
+    }
   });
 });

--- a/extensions/discord/src/api.test.ts
+++ b/extensions/discord/src/api.test.ts
@@ -1,6 +1,5 @@
 // Discord tests cover api plugin behavior.
 import { createServer, type Server } from "node:http";
-import type { AddressInfo } from "node:net";
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { withFetchPreconnect } from "openclaw/plugin-sdk/test-env";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -41,7 +40,7 @@ async function listenLoopbackServer(server: Server): Promise<number> {
         reject(new Error("expected loopback TCP address"));
         return;
       }
-      resolve((address as AddressInfo).port);
+      resolve(address.port);
     });
   });
 }

--- a/extensions/discord/src/api.ts
+++ b/extensions/discord/src/api.ts
@@ -2,6 +2,7 @@
 import { resolveFetch } from "openclaw/plugin-sdk/fetch-runtime";
 import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 import { readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
+import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import {
   resolveRetryConfig,
   retryAsync,
@@ -192,9 +193,13 @@ export async function requestDiscord<T>(
           retryAfter,
         );
       }
-      const text = await readResponseTextLimited(res, DISCORD_API_RESPONSE_BODY_LIMIT_BYTES).catch(
-        () => "",
-      );
+      const responseBody = await readResponseWithLimit(res, DISCORD_API_RESPONSE_BODY_LIMIT_BYTES, {
+        onOverflow: ({ size, maxBytes }) =>
+          new Error(
+            `Discord API ${path} response body too large: ${size} bytes (limit: ${maxBytes} bytes)`,
+          ),
+      });
+      const text = new TextDecoder().decode(responseBody);
       if (!text.trim()) {
         return undefined as T;
       }

--- a/extensions/discord/src/api.ts
+++ b/extensions/discord/src/api.ts
@@ -19,6 +19,7 @@ const DISCORD_API_RETRY_DEFAULTS = {
 };
 const DISCORD_API_429_FALLBACK_RETRY_AFTER_SECONDS = 60;
 const DISCORD_API_ERROR_BODY_LIMIT_BYTES = 8 * 1024;
+const DISCORD_API_RESPONSE_BODY_LIMIT_BYTES = 4 * 1024 * 1024;
 
 type DiscordApiErrorPayload = {
   message?: string;
@@ -191,7 +192,9 @@ export async function requestDiscord<T>(
           retryAfter,
         );
       }
-      const text = await res.text().catch(() => "");
+      const text = await readResponseTextLimited(res, DISCORD_API_RESPONSE_BODY_LIMIT_BYTES).catch(
+        () => "",
+      );
       if (!text.trim()) {
         return undefined as T;
       }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Discord channels under high message volume could cause unbounded memory growth: `requestDiscord` read success responses without a hard byte cap. Discord channel message lists, thread histories, and attachment manifests can reach significant sizes; without a cap the gateway process risks OOM.

## Why This Change Was Made

The error path in `requestDiscord` already used a bounded reader for failure bodies. This PR now reads success bodies with `readResponseWithLimit` using a separate 4 MiB `DISCORD_API_RESPONSE_BODY_LIMIT_BYTES` cap, and oversized success responses reject with a clear Discord API response-size error instead of being buffered or silently truncated.

The proof was upgraded from mock-only `ReadableStream` responses to real `node:http` loopback servers on `127.0.0.1` with random ports. The tests route real `requestDiscord` calls through `globalThis.fetch` to the loopback server, with chunked bodies and no `Content-Length` header.

## User Impact

Operators running busy Discord integrations no longer risk gateway OOM from unexpectedly large API responses. Normal Discord API payloads under the 4 MiB cap still parse and return normally.

## Evidence

Focused validation with real loopback HTTP server proof:

```text
[test] starting test/vitest/vitest.extension-discord.config.ts

 RUN  v4.1.8 /media/vdc/0668001470/workSpace/claw-campaign/openclaw

 ✓ |extension-discord| extensions/discord/src/api.test.ts > fetchDiscord > formats rate limit payloads without raw JSON 57ms
 ✓ |extension-discord| extensions/discord/src/api.test.ts > fetchDiscord > preserves non-JSON error text 6ms
 ✓ |extension-discord| extensions/discord/src/api.test.ts > fetchDiscord > bounds Discord API error bodies without using response.text() 6ms
 ✓ |extension-discord| extensions/discord/src/api.test.ts > fetchDiscord > sanitizes Cloudflare HTML rate limits and applies a fallback cooldown 2ms
 ✓ |extension-discord| extensions/discord/src/api.test.ts > fetchDiscord > honors Retry-After for Cloudflare HTML application lookup rate limits 2ms
 ✓ |extension-discord| extensions/discord/src/api.test.ts > fetchDiscord > rejects invalid Retry-After header values: hex 2ms
 ✓ |extension-discord| extensions/discord/src/api.test.ts > fetchDiscord > rejects invalid Retry-After header values: fractional 1ms
 ✓ |extension-discord| extensions/discord/src/api.test.ts > fetchDiscord > rejects invalid Retry-After header values: unsafe-ms 1ms
 ✓ |extension-discord| extensions/discord/src/api.test.ts > fetchDiscord > rejects invalid Retry-After header values: unsafe-integer 2ms
 ✓ |extension-discord| extensions/discord/src/api.test.ts > fetchDiscord > rejects invalid Retry-After header values: overflow 2ms
 ✓ |extension-discord| extensions/discord/src/api.test.ts > fetchDiscord > ignores unsafe retry_after body values and falls back to Retry-After 1ms
 ✓ |extension-discord| extensions/discord/src/api.test.ts > fetchDiscord > retries rate limits before succeeding 3ms
 ✓ |extension-discord| extensions/discord/src/api.test.ts > fetchDiscord > sends JSON request bodies through the shared retry helper 2ms
 ✓ |extension-discord| extensions/discord/src/api.test.ts > fetchDiscord > caps oversized request timeouts before creating abort signals 2ms
stdout | extensions/discord/src/api.test.ts > fetchDiscord > returns under-cap requestDiscord responses from a real loopback HTTP server
[discord requestDiscord loopback proof] normal path: returned={"id":"channel-42","name":"loopback","type":0} content_length=none

stdout | extensions/discord/src/api.test.ts > fetchDiscord > rejects oversized valid JSON requestDiscord responses from a real loopback HTTP server
[discord requestDiscord loopback proof] oversized path: cap=4194304 streamed>=4456448 content_length=none rejected=Error: Discord API /channels/123/messages response body too large: 4242180 bytes (limit: 4194304 bytes)

 ✓ |extension-discord| extensions/discord/src/api.test.ts > fetchDiscord > returns under-cap requestDiscord responses from a real loopback HTTP server 45ms
 ✓ |extension-discord| extensions/discord/src/api.test.ts > fetchDiscord > rejects oversized valid JSON requestDiscord responses from a real loopback HTTP server 58ms

 Test Files  1 passed (1)
      Tests  16 passed (16)
   Start at  16:19:31
   Duration  7.06s (transform 3.66s, setup 558ms, import 6.00s, tests 199ms, environment 0ms)

[test] passed 1 Vitest shard in 18.97s
```

Exact requested validation command:

```text
$ node scripts/run-vitest.mjs run extensions/discord/src/api.test.ts 2>&1 | tail -20
[test] starting test/vitest/vitest.extension-discord.config.ts

 RUN  v4.1.8 /media/vdc/0668001470/workSpace/claw-campaign/openclaw


 Test Files  1 passed (1)
      Tests  16 passed (16)
   Start at  16:19:50
   Duration  6.83s (transform 3.35s, setup 485ms, import 5.79s, tests 174ms, environment 0ms)

[test] passed 1 Vitest shard in 19.11s
```

Mutation check: temporarily reverting the success path back to `res.text()` made the oversized valid-JSON loopback test fail because the >4 MiB response no longer rejected:

```text
× |extension-discord| extensions/discord/src/api.test.ts > fetchDiscord > rejects oversized valid JSON requestDiscord responses from a real loopback HTTP server 67ms
  → expected undefined to be an instance of Error
```
