### PR TITLE
fix(ui): ignore sibling base-path legacy gateway url

### DIFF
--- a/ui/src/ui/storage.node.test.ts
+++ b/ui/src/ui/storage.node.test.ts
@@ -99,23 +99,17 @@ describe("loadSettings default gateway URL derivation", () => {
     });
     setControlUiBasePath("/gateway-a");
     const gatewayAUrl = expectedGatewayUrl("/gateway-a");
-    saveSettings({
-      gatewayUrl: gatewayAUrl,
-      token: "",
-      sessionKey: "agent:gateway-a:main",
-      lastActiveSessionKey: "agent:gateway-a:main",
-      theme: "dash",
-      themeMode: "dark",
-      chatShowThinking: true,
-      chatShowToolCalls: true,
-      chatAutoScroll: "near-bottom",
-      splitRatio: 0.6,
-      navCollapsed: true,
-      navWidth: 260,
-      navGroupsCollapsed: {},
-      borderRadius: 50,
-      textScale: 100,
-    });
+    localStorage.setItem(
+      "openclaw.control.settings.v1",
+      JSON.stringify({
+        gatewayUrl: gatewayAUrl,
+        theme: "dash",
+        themeMode: "dark",
+        navCollapsed: true,
+        sessionKey: "agent:gateway-a:main",
+        lastActiveSessionKey: "agent:gateway-a:main",
+      }),
+    );
 
     setTestLocation({
       protocol: "https:",
@@ -126,9 +120,10 @@ describe("loadSettings default gateway URL derivation", () => {
 
     const settings = loadSettings();
     expect(settings.gatewayUrl).toBe(expectedGatewayUrl("/gateway-b"));
-    expect(settings.theme).toBe("dash");
-    expect(settings.themeMode).toBe("dark");
+    expect(settings.theme).toBe("claw");
+    expect(settings.themeMode).toBe("system");
     expect(settings.sessionKey).toBe("main");
+    expect(localStorage.getItem("openclaw.control.settings.v1")).toBeNull();
   });
 
   it("keeps a legacy cross-origin custom gateway URL", () => {
@@ -149,6 +144,90 @@ describe("loadSettings default gateway URL derivation", () => {
     const settings = loadSettings();
     expect(settings.gatewayUrl).toBe("wss://custom-gateway.example/control");
     expect(settings.theme).toBe("dash");
+  });
+
+  it("keeps a legacy same-origin relative custom gateway URL", () => {
+    setTestLocation({
+      protocol: "https:",
+      host: "example.com",
+      pathname: "/openclaw/chat",
+    });
+    setControlUiBasePath("/openclaw");
+    localStorage.setItem(
+      "openclaw.control.settings.v1",
+      JSON.stringify({
+        gatewayUrl: "/ws",
+        theme: "dash",
+        themeMode: "dark",
+        sessionKey: "custom-ws-session",
+        lastActiveSessionKey: "custom-ws-session",
+      }),
+    );
+
+    const settings = loadSettings();
+    expect(settings.gatewayUrl).toBe("/ws");
+    expect(settings.theme).toBe("dash");
+    expect(settings.themeMode).toBe("dark");
+    expect(settings.sessionKey).toBe("custom-ws-session");
+    const pageScopedKey = "openclaw.control.settings.v1:wss://example.com/openclaw";
+    expect(JSON.parse(localStorage.getItem(pageScopedKey) ?? "{}")).toMatchObject({
+      gatewayUrl: "/ws",
+      theme: "dash",
+      themeMode: "dark",
+    });
+    expect(localStorage.getItem("openclaw.control.settings.v1")).toBeNull();
+  });
+
+  it("keeps a legacy same-origin absolute WebSocket endpoint URL", () => {
+    setTestLocation({
+      protocol: "https:",
+      host: "example.com",
+      pathname: "/openclaw/chat",
+    });
+    setControlUiBasePath("/openclaw");
+    localStorage.setItem(
+      "openclaw.control.settings.v1",
+      JSON.stringify({
+        gatewayUrl: "wss://example.com/ws",
+        theme: "dash",
+      }),
+    );
+
+    const settings = loadSettings();
+    expect(settings.gatewayUrl).toBe("wss://example.com/ws");
+    expect(settings.theme).toBe("dash");
+  });
+
+  it("persists a same-origin custom gateway URL under the current page scope", () => {
+    setTestLocation({
+      protocol: "https:",
+      host: "example.com",
+      pathname: "/openclaw/chat",
+    });
+    setControlUiBasePath("/openclaw");
+    saveSettings({
+      gatewayUrl: "/ws",
+      token: "",
+      sessionKey: "custom-ws-session",
+      lastActiveSessionKey: "custom-ws-session",
+      theme: "dash",
+      themeMode: "dark",
+      chatShowThinking: true,
+      chatShowToolCalls: true,
+      chatAutoScroll: "near-bottom",
+      splitRatio: 0.6,
+      navCollapsed: false,
+      navWidth: 220,
+      navGroupsCollapsed: {},
+      borderRadius: 50,
+      textScale: 100,
+    });
+
+    const settings = loadSettings();
+    expect(settings.gatewayUrl).toBe("/ws");
+    expect(settings.theme).toBe("dash");
+    expect(settings.sessionKey).toBe("custom-ws-session");
+    expect(localStorage.getItem("openclaw.control.settings.v1")).toBeNull();
   });
 
   it("skips node sessionStorage accessors that warn without a storage file", () => {
@@ -293,8 +372,8 @@ describe("loadSettings default gateway URL derivation", () => {
     });
 
     const settings = loadSettings();
-    expect(settings.gatewayUrl).toBe(gwUrl);
-    expect(settings.token).toBe("gateway-a-token");
+    expect(settings.gatewayUrl).toBe(otherUrl);
+    expect(settings.token).toBe("");
   });
 
   it("does not persist gateway tokens when saving settings", () => {

--- a/ui/src/ui/storage.node.test.ts
+++ b/ui/src/ui/storage.node.test.ts
@@ -91,6 +91,66 @@ describe("loadSettings default gateway URL derivation", () => {
     expect(loadSettings().gatewayUrl).toBe(expectedGatewayUrl("/apps/openclaw"));
   });
 
+  it("does not let a legacy sibling base-path setting override the current page gateway", () => {
+    setTestLocation({
+      protocol: "https:",
+      host: "example.com",
+      pathname: "/gateway-a/chat",
+    });
+    setControlUiBasePath("/gateway-a");
+    const gatewayAUrl = expectedGatewayUrl("/gateway-a");
+    saveSettings({
+      gatewayUrl: gatewayAUrl,
+      token: "",
+      sessionKey: "agent:gateway-a:main",
+      lastActiveSessionKey: "agent:gateway-a:main",
+      theme: "dash",
+      themeMode: "dark",
+      chatShowThinking: true,
+      chatShowToolCalls: true,
+      chatAutoScroll: "near-bottom",
+      splitRatio: 0.6,
+      navCollapsed: true,
+      navWidth: 260,
+      navGroupsCollapsed: {},
+      borderRadius: 50,
+      textScale: 100,
+    });
+
+    setTestLocation({
+      protocol: "https:",
+      host: "example.com",
+      pathname: "/gateway-b/chat",
+    });
+    setControlUiBasePath("/gateway-b");
+
+    const settings = loadSettings();
+    expect(settings.gatewayUrl).toBe(expectedGatewayUrl("/gateway-b"));
+    expect(settings.theme).toBe("dash");
+    expect(settings.themeMode).toBe("dark");
+    expect(settings.sessionKey).toBe("main");
+  });
+
+  it("keeps a legacy cross-origin custom gateway URL", () => {
+    setTestLocation({
+      protocol: "https:",
+      host: "example.com",
+      pathname: "/gateway-b/chat",
+    });
+    setControlUiBasePath("/gateway-b");
+    localStorage.setItem(
+      "openclaw.control.settings.v1",
+      JSON.stringify({
+        gatewayUrl: "wss://custom-gateway.example/control",
+        theme: "dash",
+      }),
+    );
+
+    const settings = loadSettings();
+    expect(settings.gatewayUrl).toBe("wss://custom-gateway.example/control");
+    expect(settings.theme).toBe("dash");
+  });
+
   it("skips node sessionStorage accessors that warn without a storage file", () => {
     vi.unstubAllGlobals();
     vi.stubGlobal("localStorage", createStorageMock());

--- a/ui/src/ui/storage.node.test.ts
+++ b/ui/src/ui/storage.node.test.ts
@@ -198,6 +198,34 @@ describe("loadSettings default gateway URL derivation", () => {
     expect(settings.theme).toBe("dash");
   });
 
+  it("does not keep legacy sibling base-path WebSocket endpoint URLs", () => {
+    for (const legacyGatewayUrl of ["/gateway-a/ws", "wss://example.com/gateway-a/ws"]) {
+      localStorage.clear();
+      sessionStorage.clear();
+      setTestLocation({
+        protocol: "https:",
+        host: "example.com",
+        pathname: "/gateway-b/chat",
+      });
+      setControlUiBasePath("/gateway-b");
+      localStorage.setItem(
+        "openclaw.control.settings.v1",
+        JSON.stringify({
+          gatewayUrl: legacyGatewayUrl,
+          theme: "dash",
+          sessionKey: "agent:gateway-a:main",
+          lastActiveSessionKey: "agent:gateway-a:main",
+        }),
+      );
+
+      const settings = loadSettings();
+      expect(settings.gatewayUrl).toBe(expectedGatewayUrl("/gateway-b"));
+      expect(settings.theme).toBe("claw");
+      expect(settings.sessionKey).toBe("main");
+      expect(localStorage.getItem("openclaw.control.settings.v1")).toBeNull();
+    }
+  });
+
   it("persists a same-origin custom gateway URL under the current page scope", () => {
     setTestLocation({
       protocol: "https:",

--- a/ui/src/ui/storage.ts
+++ b/ui/src/ui/storage.ts
@@ -138,7 +138,7 @@ function getSessionStorage(): Storage | null {
 
 function parseGatewayScopeParts(
   gatewayUrl: string,
-): { scope: string; origin: string; pathname: string } | null {
+): { scope: string; origin: string; host: string; pathname: string } | null {
   try {
     const base =
       typeof location !== "undefined"
@@ -148,7 +148,7 @@ function parseGatewayScopeParts(
     const pathname =
       parsed.pathname === "/" ? "" : parsed.pathname.replace(/\/+$/, "") || parsed.pathname;
     const origin = `${parsed.protocol}//${parsed.host}`;
-    return { scope: `${origin}${pathname}`, origin, pathname };
+    return { scope: `${origin}${pathname}`, origin, host: parsed.host, pathname };
   } catch {
     return null;
   }
@@ -173,20 +173,8 @@ function resolvePersistedGatewayUrl(params: {
   return params.parsedGatewayUrl;
 }
 
-function isRootRelativeGatewayUrl(gatewayUrl: string): boolean {
-  const trimmed = gatewayUrl.trim();
-  return trimmed.startsWith("/") && !trimmed.startsWith("//");
-}
-
-function isWebSocketEndpointPath(pathname: string): boolean {
-  const segments = pathname.split("/");
-  for (let index = segments.length - 1; index >= 0; index -= 1) {
-    const segment = segments[index];
-    if (segment) {
-      return segment.toLowerCase() === "ws";
-    }
-  }
-  return false;
+function isRootWebSocketEndpointPath(pathname: string): boolean {
+  return pathname.toLowerCase() === "/ws";
 }
 
 function shouldIgnoreLegacySettingsForPage(params: {
@@ -199,16 +187,13 @@ function shouldIgnoreLegacySettingsForPage(params: {
   }
   const parsed = parseGatewayScopeParts(params.parsedGatewayUrl);
   const page = parseGatewayScopeParts(params.pageDerivedUrl);
-  if (!parsed || !page || !page.pathname || parsed.origin !== page.origin) {
+  if (!parsed || !page || !page.pathname || parsed.host !== page.host) {
     return false;
   }
   if (parsed.pathname === page.pathname) {
     return false;
   }
-  if (
-    isRootRelativeGatewayUrl(params.parsedGatewayUrl) ||
-    isWebSocketEndpointPath(parsed.pathname)
-  ) {
+  if (isRootWebSocketEndpointPath(parsed.pathname)) {
     return false;
   }
   return true;

--- a/ui/src/ui/storage.ts
+++ b/ui/src/ui/storage.ts
@@ -163,7 +163,6 @@ function normalizeGatewayTokenScope(gatewayUrl: string): string {
 }
 
 function resolvePersistedGatewayUrl(params: {
-  source: LoadedSettingsSource;
   parsedGatewayUrl: string;
   pageDerivedUrl: string;
   defaultUrl: string;
@@ -171,21 +170,48 @@ function resolvePersistedGatewayUrl(params: {
   if (params.parsedGatewayUrl === params.pageDerivedUrl) {
     return params.defaultUrl;
   }
+  return params.parsedGatewayUrl;
+}
+
+function isRootRelativeGatewayUrl(gatewayUrl: string): boolean {
+  const trimmed = gatewayUrl.trim();
+  return trimmed.startsWith("/") && !trimmed.startsWith("//");
+}
+
+function isWebSocketEndpointPath(pathname: string): boolean {
+  const segments = pathname.split("/");
+  for (let index = segments.length - 1; index >= 0; index -= 1) {
+    const segment = segments[index];
+    if (segment) {
+      return segment.toLowerCase() === "ws";
+    }
+  }
+  return false;
+}
+
+function shouldIgnoreLegacySettingsForPage(params: {
+  source: LoadedSettingsSource;
+  parsedGatewayUrl: string;
+  pageDerivedUrl: string;
+}): boolean {
   if (params.source !== "legacy") {
-    return params.parsedGatewayUrl;
+    return false;
   }
   const parsed = parseGatewayScopeParts(params.parsedGatewayUrl);
   const page = parseGatewayScopeParts(params.pageDerivedUrl);
-  if (
-    parsed &&
-    page &&
-    page.pathname &&
-    parsed.origin === page.origin &&
-    parsed.pathname !== page.pathname
-  ) {
-    return params.defaultUrl;
+  if (!parsed || !page || !page.pathname || parsed.origin !== page.origin) {
+    return false;
   }
-  return params.parsedGatewayUrl;
+  if (parsed.pathname === page.pathname) {
+    return false;
+  }
+  if (
+    isRootRelativeGatewayUrl(params.parsedGatewayUrl) ||
+    isWebSocketEndpointPath(parsed.pathname)
+  ) {
+    return false;
+  }
+  return true;
 }
 
 function tokenSessionKeyForGateway(gatewayUrl: string): string {
@@ -294,24 +320,37 @@ export function loadSettings(): UiSettings {
   try {
     // Prefer the current scoped record; legacy global settings are a fallback for older installs.
     const scopedKey = settingsKeyForGateway(defaults.gatewayUrl);
+    const pageScopedKey = settingsKeyForGateway(pageDerivedUrl);
     const scopedRaw = storage?.getItem(scopedKey);
+    const pageScopedRaw = pageScopedKey === scopedKey ? null : storage?.getItem(pageScopedKey);
     const defaultRaw = storage?.getItem(SETTINGS_KEY_PREFIX + "default");
     const legacyRaw = storage?.getItem(LEGACY_SETTINGS_KEY);
     const loaded =
       scopedRaw != null
         ? { raw: scopedRaw, source: "scoped" as const }
-        : defaultRaw != null
-          ? { raw: defaultRaw, source: "default" as const }
-          : legacyRaw != null
-            ? { raw: legacyRaw, source: "legacy" as const }
-            : null;
+        : pageScopedRaw != null
+          ? { raw: pageScopedRaw, source: "scoped" as const }
+          : defaultRaw != null
+            ? { raw: defaultRaw, source: "default" as const }
+            : legacyRaw != null
+              ? { raw: legacyRaw, source: "legacy" as const }
+              : null;
     if (!loaded?.raw) {
       return defaults;
     }
     const parsed = JSON.parse(loaded.raw) as PersistedUiSettings;
     const parsedGatewayUrl = normalizeOptionalString(parsed.gatewayUrl) ?? defaults.gatewayUrl;
+    if (
+      shouldIgnoreLegacySettingsForPage({
+        source: loaded.source,
+        parsedGatewayUrl,
+        pageDerivedUrl,
+      })
+    ) {
+      persistSettings(defaults);
+      return defaults;
+    }
     const gatewayUrl = resolvePersistedGatewayUrl({
-      source: loaded.source,
       parsedGatewayUrl,
       pageDerivedUrl,
       defaultUrl,
@@ -369,7 +408,7 @@ export function loadSettings(): UiSettings {
       customTheme: customTheme ?? undefined,
       locale: isSupportedLocale(parsed.locale) ? parsed.locale : undefined,
     };
-    if ("token" in parsed) {
+    if (loaded.source === "legacy" || "token" in parsed) {
       persistSettings(settings);
     }
     return settings;
@@ -552,7 +591,12 @@ function persistSettings(next: UiSettings) {
   const serialized = JSON.stringify(persisted);
   try {
     storage?.setItem(scopedKey, serialized);
-    storage?.setItem(LEGACY_SETTINGS_KEY, serialized);
+    const { pageUrl: pageDerivedUrl } = deriveDefaultGatewayUrl();
+    const pageScopedKey = settingsKeyForGateway(pageDerivedUrl);
+    if (pageScopedKey !== scopedKey) {
+      storage?.setItem(pageScopedKey, serialized);
+    }
+    storage?.removeItem(LEGACY_SETTINGS_KEY);
   } catch {
     // best-effort — quota exceeded or security restrictions should not
     // prevent in-memory settings and visual updates from being applied

--- a/ui/src/ui/storage.ts
+++ b/ui/src/ui/storage.ts
@@ -23,6 +23,8 @@ type PersistedUiSettings = Omit<UiSettings, "token" | "sessionKey" | "lastActive
   sessionsByGateway?: Record<string, ScopedSessionSelection>;
 };
 
+type LoadedSettingsSource = "scoped" | "default" | "legacy";
+
 import { isSupportedLocale } from "../i18n/index.ts";
 import { getSafeLocalStorage, getSafeSessionStorage } from "../local-storage.ts";
 import { parseImportedCustomTheme, type ImportedCustomTheme } from "./custom-theme.ts";
@@ -134,23 +136,56 @@ function getSessionStorage(): Storage | null {
   return getSafeSessionStorage();
 }
 
-function normalizeGatewayTokenScope(gatewayUrl: string): string {
-  const trimmed = normalizeOptionalString(gatewayUrl) ?? "";
-  if (!trimmed) {
-    return "default";
-  }
+function parseGatewayScopeParts(
+  gatewayUrl: string,
+): { scope: string; origin: string; pathname: string } | null {
   try {
     const base =
       typeof location !== "undefined"
         ? `${location.protocol}//${location.host}${location.pathname || "/"}`
         : undefined;
-    const parsed = base ? new URL(trimmed, base) : new URL(trimmed);
+    const parsed = base ? new URL(gatewayUrl, base) : new URL(gatewayUrl);
     const pathname =
       parsed.pathname === "/" ? "" : parsed.pathname.replace(/\/+$/, "") || parsed.pathname;
-    return `${parsed.protocol}//${parsed.host}${pathname}`;
+    const origin = `${parsed.protocol}//${parsed.host}`;
+    return { scope: `${origin}${pathname}`, origin, pathname };
   } catch {
-    return trimmed;
+    return null;
   }
+}
+
+function normalizeGatewayTokenScope(gatewayUrl: string): string {
+  const trimmed = normalizeOptionalString(gatewayUrl) ?? "";
+  if (!trimmed) {
+    return "default";
+  }
+  return parseGatewayScopeParts(trimmed)?.scope ?? trimmed;
+}
+
+function resolvePersistedGatewayUrl(params: {
+  source: LoadedSettingsSource;
+  parsedGatewayUrl: string;
+  pageDerivedUrl: string;
+  defaultUrl: string;
+}): string {
+  if (params.parsedGatewayUrl === params.pageDerivedUrl) {
+    return params.defaultUrl;
+  }
+  if (params.source !== "legacy") {
+    return params.parsedGatewayUrl;
+  }
+  const parsed = parseGatewayScopeParts(params.parsedGatewayUrl);
+  const page = parseGatewayScopeParts(params.pageDerivedUrl);
+  if (
+    parsed &&
+    page &&
+    page.pathname &&
+    parsed.origin === page.origin &&
+    parsed.pathname !== page.pathname
+  ) {
+    return params.defaultUrl;
+  }
+  return params.parsedGatewayUrl;
 }
 
 function tokenSessionKeyForGateway(gatewayUrl: string): string {
@@ -257,18 +292,30 @@ export function loadSettings(): UiSettings {
   };
 
   try {
-    // First check for legacy key (no scope), then check for scoped key
+    // Prefer the current scoped record; legacy global settings are a fallback for older installs.
     const scopedKey = settingsKeyForGateway(defaults.gatewayUrl);
-    const raw =
-      storage?.getItem(scopedKey) ??
-      storage?.getItem(SETTINGS_KEY_PREFIX + "default") ??
-      storage?.getItem(LEGACY_SETTINGS_KEY);
-    if (!raw) {
+    const scopedRaw = storage?.getItem(scopedKey);
+    const defaultRaw = storage?.getItem(SETTINGS_KEY_PREFIX + "default");
+    const legacyRaw = storage?.getItem(LEGACY_SETTINGS_KEY);
+    const loaded =
+      scopedRaw != null
+        ? { raw: scopedRaw, source: "scoped" as const }
+        : defaultRaw != null
+          ? { raw: defaultRaw, source: "default" as const }
+          : legacyRaw != null
+            ? { raw: legacyRaw, source: "legacy" as const }
+            : null;
+    if (!loaded?.raw) {
       return defaults;
     }
-    const parsed = JSON.parse(raw) as PersistedUiSettings;
+    const parsed = JSON.parse(loaded.raw) as PersistedUiSettings;
     const parsedGatewayUrl = normalizeOptionalString(parsed.gatewayUrl) ?? defaults.gatewayUrl;
-    const gatewayUrl = parsedGatewayUrl === pageDerivedUrl ? defaultUrl : parsedGatewayUrl;
+    const gatewayUrl = resolvePersistedGatewayUrl({
+      source: loaded.source,
+      parsedGatewayUrl,
+      pageDerivedUrl,
+      defaultUrl,
+    });
     const scopedSessionSelection = resolveScopedSessionSelection(gatewayUrl, parsed, defaults);
     const customTheme = parseImportedCustomTheme((parsed as { customTheme?: unknown }).customTheme);
     const { theme, mode } = parseThemeSelection(


### PR DESCRIPTION
## What Problem This Solves

- When two Control UI deployments share one browser origin but use different base paths, a page with no current scoped settings could fall back to the legacy global settings entry from another base path.
- That stale legacy entry could carry another Gateway's `gatewayUrl`, so the page loaded from `/gateway-b/` could open its WebSocket against `/gateway-a/`.
- The review feedback also identified an upgrade-compatibility gap: intentional same-origin custom endpoints such as `/ws` must not be reset while fixing sibling base-path pollution.

## Why This Change Was Made

- `loadSettings()` now rejects a stale legacy sibling record as a whole when its absolute same-origin path differs from the current page-derived Gateway path.
- Root-relative legacy Gateway URLs and same-origin `/ws` endpoint paths remain migratable, preserving existing custom endpoint setups.
- `persistSettings()` now writes settings under both the Gateway scope and the current page-derived scope, then removes the shared legacy key so new saves do not keep refreshing the cross-base-path pollution source.
- Current scoped settings still take precedence, and legacy global settings remain an upgrade source only when they are compatible with the current page.

## User Impact

- Users opening a second Control UI base path on the same origin connect to the Gateway implied by that page URL, not a stale sibling Gateway URL.
- Existing browser profiles that intentionally saved same-origin `/ws` custom Gateway endpoints keep that endpoint on first load after upgrade.
- New custom Gateway URL saves survive page reload through the page-scoped settings key without relying on the shared legacy key.

## Evidence

```text
node scripts/run-vitest.mjs ui/src/ui/storage.node.test.ts
[test] starting test/vitest/vitest.ui.config.ts
[test] passed 1 Vitest shard in 1.14s
```

```text
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.json ui/src/ui/storage.ts ui/src/ui/storage.node.test.ts
[plugin-sdk boundary dts] fresh; skipping
[plugin-sdk package boundary dts] fresh; skipping
[qa-channel boundary dts] fresh; skipping
[discord boundary dts] fresh; skipping
[slack boundary dts] fresh; skipping
[whatsapp boundary dts] fresh; skipping
[plugin-sdk boundary root shims] fresh; skipping
```

```text
node_modules/.bin/oxfmt --check --threads=1 ui/src/ui/storage.ts ui/src/ui/storage.node.test.ts
Checking formatting...

All matched files use the correct format.
Finished in 21ms on 2 files using 1 threads.
```

```text
git diff --check
```

## Real behavior proof

**Behavior addressed:** Two same-origin Control UI base paths no longer share stale legacy Gateway URLs, including sibling WebSocket endpoint paths, while root `/ws` custom endpoints are still migrated.
**Environment tested:** Linux, Node with `tsx`, local OpenClaw source checkout on branch `fix/97636-control-ui-basepath-settings`.
**Steps run after the patch:** Called the actual `saveSettings()` and `loadSettings()` functions from source, then started the actual `GatewayBrowserClient` with a WebSocket target recorder to capture the URL it would open for each loaded settings object.
**Evidence after fix:**

```text
two base path WebSocket targets:
  /gateway-a -> wss://example.com/gateway-a
  /gateway-b -> wss://example.com/gateway-b
  shared legacy key present: false
legacy sibling migration for wss://example.com/gateway-a:
  loaded gatewayUrl: wss://example.com/gateway-b
  websocket target: wss://example.com/gateway-b
  sessionKey: main
  shared legacy key present: false
legacy sibling migration for /gateway-a/ws:
  loaded gatewayUrl: wss://example.com/gateway-b
  websocket target: wss://example.com/gateway-b
  sessionKey: main
  shared legacy key present: false
legacy sibling migration for wss://example.com/gateway-a/ws:
  loaded gatewayUrl: wss://example.com/gateway-b
  websocket target: wss://example.com/gateway-b
  sessionKey: main
  shared legacy key present: false
same-origin custom endpoint migration for /ws:
  loaded gatewayUrl: /ws
  websocket target: /ws
  sessionKey: custom-ws-session
  page scoped key present: true
  shared legacy key present: false
same-origin custom endpoint migration for wss://example.com/ws:
  loaded gatewayUrl: wss://example.com/ws
  websocket target: wss://example.com/ws
  sessionKey: custom-ws-session
  page scoped key present: true
  shared legacy key present: false
```

**Observed result:** New saves for `/gateway-a` and `/gateway-b` produce separate WebSocket targets; legacy `/gateway-a`, `/gateway-a/ws`, and `wss://example.com/gateway-a/ws` sibling records loaded on `/gateway-b` resolve to `/gateway-b`; root `/ws` and `wss://example.com/ws` custom endpoints remain unchanged while migrating to the page-scoped key.
**Not tested:** A live Kubernetes or reverse-proxy deployment with two running Gateways was not exercised; the proof records the actual Control UI settings loader and GatewayBrowserClient WebSocket target locally.

## Impact Assessment

- Scope: Control UI browser settings load/persist behavior and storage regression tests.
- Downstream: `connectGateway()` continues to pass `host.settings.gatewayUrl` into `GatewayBrowserClient`; this patch changes which settings object reaches that call for legacy fallback data.
- Edge cases: current scoped settings, page-scoped custom Gateway settings, default scoped settings, legacy same-origin sibling paths, legacy sibling WebSocket endpoint paths, legacy cross-origin custom URLs, legacy root-relative `/ws`, and legacy absolute same-origin `/ws` are covered.
- Hard-coded values: no deployment-specific host or base path is hard-coded; the stale sibling check derives origin and normalized path from the current page and persisted URL. The `/ws` endpoint exception preserves an existing same-origin custom Gateway URL shape used by the UI.
- Existing fixes: related open PRs #97643 and #97665 were checked; this branch keeps legacy migration while adding same-origin custom endpoint coverage requested on this PR.

Closes #97636
