### PR TITLE
fix(pdf): bound AI provider response reads in PDF text extraction

### DIFF
--- a/src/agents/tools/pdf-native-providers.test.ts
+++ b/src/agents/tools/pdf-native-providers.test.ts
@@ -1,5 +1,8 @@
 // Native PDF provider tests cover direct Anthropic and Gemini request shapes,
-// base URL handling, and bounded API error reporting.
+// base URL handling, bounded API error reporting, and the 16 MiB response-size
+// guard added to prevent OOM on oversized AI provider responses.
+import { createServer } from "node:http";
+import type { IncomingMessage, ServerResponse } from "node:http";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import * as pdfNativeProviders from "./pdf-native-providers.js";
 
@@ -70,12 +73,12 @@ describe("native PDF provider API calls", () => {
   });
 
   it("anthropicAnalyzePdf sends correct request shape", async () => {
-    const fetchMock = mockFetchResponse({
-      ok: true,
-      json: async () => ({
-        content: [{ type: "text", text: "Analysis of PDF" }],
+    const fetchMock = mockFetchResponse(
+      new Response(JSON.stringify({ content: [{ type: "text", text: "Analysis of PDF" }] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
       }),
-    });
+    );
 
     const result = await pdfNativeProviders.anthropicAnalyzePdf(
       makeAnthropicAnalyzeParams({
@@ -104,12 +107,12 @@ describe("native PDF provider API calls", () => {
 
   it("anthropicAnalyzePdf honors ANTHROPIC_BASE_URL when no base URL is configured", async () => {
     vi.stubEnv("ANTHROPIC_BASE_URL", "https://anthropic-pdf-proxy.example/v1");
-    const fetchMock = mockFetchResponse({
-      ok: true,
-      json: async () => ({
-        content: [{ type: "text", text: "Analysis of PDF" }],
+    const fetchMock = mockFetchResponse(
+      new Response(JSON.stringify({ content: [{ type: "text", text: "Analysis of PDF" }] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
       }),
-    });
+    );
 
     await pdfNativeProviders.anthropicAnalyzePdf(makeAnthropicAnalyzeParams());
 
@@ -196,12 +199,12 @@ describe("native PDF provider API calls", () => {
   });
 
   it("anthropicAnalyzePdf throws when response has no text", async () => {
-    mockFetchResponse({
-      ok: true,
-      json: async () => ({
-        content: [{ type: "text", text: "   " }],
+    mockFetchResponse(
+      new Response(JSON.stringify({ content: [{ type: "text", text: "   " }] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
       }),
-    });
+    );
 
     await expect(
       pdfNativeProviders.anthropicAnalyzePdf(makeAnthropicAnalyzeParams()),
@@ -211,12 +214,12 @@ describe("native PDF provider API calls", () => {
   it("geminiAnalyzePdf sends correct request shape", async () => {
     // Gemini API keys belong in headers here, not query strings that are more
     // likely to leak through logs and URL diagnostics.
-    const fetchMock = mockFetchResponse({
-      ok: true,
-      json: async () => ({
-        candidates: [{ content: { parts: [{ text: "Gemini PDF analysis" }] } }],
-      }),
-    });
+    const fetchMock = mockFetchResponse(
+      new Response(
+        JSON.stringify({ candidates: [{ content: { parts: [{ text: "Gemini PDF analysis" }] } }] }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
 
     const result = await pdfNativeProviders.geminiAnalyzePdf(
       makeGeminiAnalyzeParams({
@@ -257,10 +260,12 @@ describe("native PDF provider API calls", () => {
   });
 
   it("geminiAnalyzePdf throws when no candidates returned", async () => {
-    mockFetchResponse({
-      ok: true,
-      json: async () => ({ candidates: [] }),
-    });
+    mockFetchResponse(
+      new Response(JSON.stringify({ candidates: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
 
     await expect(pdfNativeProviders.geminiAnalyzePdf(makeGeminiAnalyzeParams())).rejects.toThrow(
       "Gemini PDF returned no candidates",
@@ -268,12 +273,12 @@ describe("native PDF provider API calls", () => {
   });
 
   it("anthropicAnalyzePdf supports multiple PDFs", async () => {
-    const fetchMock = mockFetchResponse({
-      ok: true,
-      json: async () => ({
-        content: [{ type: "text", text: "Multi-doc analysis" }],
+    const fetchMock = mockFetchResponse(
+      new Response(JSON.stringify({ content: [{ type: "text", text: "Multi-doc analysis" }] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
       }),
-    });
+    );
 
     await pdfNativeProviders.anthropicAnalyzePdf(
       makeAnthropicAnalyzeParams({
@@ -295,12 +300,12 @@ describe("native PDF provider API calls", () => {
   });
 
   it("anthropicAnalyzePdf uses custom base URL", async () => {
-    const fetchMock = mockFetchResponse({
-      ok: true,
-      json: async () => ({
-        content: [{ type: "text", text: "ok" }],
+    const fetchMock = mockFetchResponse(
+      new Response(JSON.stringify({ content: [{ type: "text", text: "ok" }] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
       }),
-    });
+    );
 
     await pdfNativeProviders.anthropicAnalyzePdf(
       makeAnthropicAnalyzeParams({ baseUrl: "https://custom.example.com" }),
@@ -322,12 +327,12 @@ describe("native PDF provider API calls", () => {
   });
 
   it("geminiAnalyzePdf does not duplicate /v1beta when baseUrl already includes it", async () => {
-    const fetchMock = mockFetchResponse({
-      ok: true,
-      json: async () => ({
-        candidates: [{ content: { parts: [{ text: "ok" }] } }],
-      }),
-    });
+    const fetchMock = mockFetchResponse(
+      new Response(
+        JSON.stringify({ candidates: [{ content: { parts: [{ text: "ok" }] } }] }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
 
     await pdfNativeProviders.geminiAnalyzePdf(
       makeGeminiAnalyzeParams({
@@ -341,12 +346,12 @@ describe("native PDF provider API calls", () => {
   });
 
   it("geminiAnalyzePdf normalizes bare Google API hosts to a single /v1beta root", async () => {
-    const fetchMock = mockFetchResponse({
-      ok: true,
-      json: async () => ({
-        candidates: [{ content: { parts: [{ text: "ok" }] } }],
-      }),
-    });
+    const fetchMock = mockFetchResponse(
+      new Response(
+        JSON.stringify({ candidates: [{ content: { parts: [{ text: "ok" }] } }] }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
 
     await pdfNativeProviders.geminiAnalyzePdf(
       makeGeminiAnalyzeParams({
@@ -357,5 +362,183 @@ describe("native PDF provider API calls", () => {
     const [url] = firstFetchCall(fetchMock);
     expect(url).toContain("https://generativelanguage.googleapis.com/v1beta/models/");
     expect(url).not.toContain("/v1beta/v1beta");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 16 MiB response-size guard — real node:http server (no fetch mock)
+// Drives the exported functions end-to-end to prove readProviderJsonResponse
+// caps oversized bodies before OOM can occur.
+// ---------------------------------------------------------------------------
+
+type ServerHandle = { port: number; stop: () => Promise<void> };
+
+function startTestServer(
+  handler: (req: IncomingMessage, res: ServerResponse) => void,
+): Promise<ServerHandle> {
+  return new Promise((resolve, reject) => {
+    const server = createServer(handler);
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address() as { port: number };
+      resolve({
+        port: addr.port,
+        stop: () =>
+          new Promise<void>((res, rej) =>
+            server.close((err) => (err ? rej(err) : res())),
+          ),
+      });
+    });
+  });
+}
+
+/**
+ * Returns an HTTP handler that streams 20 MiB of content in 1 MiB chunks.
+ * The caller-supplied callback fires once per chunk so tests can confirm the
+ * cap fires before all chunks are consumed.
+ */
+function makeOversizedStreamHandler(
+  onChunkWritten: () => void,
+): (req: IncomingMessage, res: ServerResponse) => void {
+  const CHUNK_SIZE = 1024 * 1024; // 1 MiB
+  const TOTAL_CHUNKS = 20; // 20 MiB total — well above the 16 MiB default cap
+  const CHUNK = Buffer.alloc(CHUNK_SIZE, 0x61); // fill with 'a'
+
+  return (_req, res) => {
+    res.writeHead(200, { "content-type": "application/json" });
+    let written = 0;
+
+    function writeNext() {
+      if (written >= TOTAL_CHUNKS) {
+        res.end();
+        return;
+      }
+      written++;
+      onChunkWritten();
+      const ok = res.write(CHUNK);
+      if (ok) {
+        writeNext();
+      } else {
+        res.once("drain", writeNext);
+      }
+    }
+
+    writeNext();
+  };
+}
+
+describe("anthropicAnalyzePdf — 16 MiB response-size guard (real HTTP server)", () => {
+  it("returns extracted text for a well-formed response under the cap", async () => {
+    const responseBody = JSON.stringify({
+      content: [{ type: "text", text: "Summary of the PDF document." }],
+    });
+
+    const srv = await startTestServer((_req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(responseBody);
+    });
+
+    try {
+      const result = await pdfNativeProviders.anthropicAnalyzePdf({
+        apiKey: "sk-test-placeholder",
+        modelId: "claude-3-5-sonnet-20241022",
+        prompt: "Summarize",
+        pdfs: [{ base64: "dGVzdA==" }],
+        baseUrl: `http://127.0.0.1:${srv.port}`,
+      });
+      expect(result).toBe("Summary of the PDF document.");
+    } finally {
+      await srv.stop();
+    }
+  });
+
+  it("rejects oversized AI responses before buffering all 20 MiB (OOM guard)", async () => {
+    let chunksWritten = 0;
+    const TOTAL_CHUNKS = 20;
+
+    const srv = await startTestServer(
+      makeOversizedStreamHandler(() => {
+        chunksWritten++;
+      }),
+    );
+
+    try {
+      // Mutation-control: bare `res.json()` would buffer all 20 MiB and then
+      // throw a JSON parse error. readProviderJsonResponse throws with this
+      // specific message once the 16 MiB cap is crossed.
+      await expect(
+        pdfNativeProviders.anthropicAnalyzePdf({
+          apiKey: "sk-test-placeholder",
+          modelId: "claude-3-5-sonnet-20241022",
+          prompt: "Summarize",
+          pdfs: [{ base64: "dGVzdA==" }],
+          baseUrl: `http://127.0.0.1:${srv.port}`,
+        }),
+      ).rejects.toThrow(/JSON response exceeds/);
+
+      // Negative-control: the cap fires well before the server finishes
+      // streaming, proving the body was NOT fully buffered.
+      expect(chunksWritten).toBeLessThan(TOTAL_CHUNKS);
+    } finally {
+      await srv.stop();
+    }
+  });
+});
+
+describe("geminiAnalyzePdf — 16 MiB response-size guard (real HTTP server)", () => {
+  it("returns extracted text for a well-formed response under the cap", async () => {
+    const responseBody = JSON.stringify({
+      candidates: [{ content: { parts: [{ text: "Extracted Gemini PDF text." }] } }],
+    });
+
+    const srv = await startTestServer((_req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(responseBody);
+    });
+
+    try {
+      const result = await pdfNativeProviders.geminiAnalyzePdf({
+        apiKey: "gai-test-placeholder",
+        modelId: "gemini-2.0-flash",
+        prompt: "Summarize",
+        pdfs: [{ base64: "dGVzdA==" }],
+        baseUrl: `http://127.0.0.1:${srv.port}`,
+      });
+      expect(result).toBe("Extracted Gemini PDF text.");
+    } finally {
+      await srv.stop();
+    }
+  });
+
+  it("rejects oversized AI responses before buffering all 20 MiB (OOM guard)", async () => {
+    let chunksWritten = 0;
+    const TOTAL_CHUNKS = 20;
+
+    const srv = await startTestServer(
+      makeOversizedStreamHandler(() => {
+        chunksWritten++;
+      }),
+    );
+
+    try {
+      // Mutation-control: bare `res.json()` would buffer all 20 MiB and then
+      // throw a JSON parse error. readProviderJsonResponse throws with this
+      // specific message once the 16 MiB cap is crossed.
+      await expect(
+        pdfNativeProviders.geminiAnalyzePdf({
+          apiKey: "gai-test-placeholder",
+          modelId: "gemini-2.0-flash",
+          prompt: "Summarize",
+          pdfs: [{ base64: "dGVzdA==" }],
+          baseUrl: `http://127.0.0.1:${srv.port}`,
+        }),
+      ).rejects.toThrow(/JSON response exceeds/);
+
+      // Negative-control: the cap fires well before the server finishes
+      // streaming, proving the body was NOT fully buffered.
+      expect(chunksWritten).toBeLessThan(TOTAL_CHUNKS);
+    } finally {
+      await srv.stop();
+    }
   });
 });

--- a/src/agents/tools/pdf-native-providers.test.ts
+++ b/src/agents/tools/pdf-native-providers.test.ts
@@ -67,6 +67,27 @@ describe("native PDF provider API calls", () => {
     return call;
   };
 
+  const withTimeout = async <T>(
+    promise: Promise<T>,
+    timeoutMs: number,
+    message: string,
+  ): Promise<T> => {
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    const timeoutPromise = new Promise<never>((_resolve, reject) => {
+      timeout = setTimeout(() => {
+        reject(new Error(message));
+      }, timeoutMs);
+    });
+
+    try {
+      return await Promise.race([promise, timeoutPromise]);
+    } finally {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+    }
+  };
+
   afterEach(() => {
     global.fetch = priorFetch;
     vi.unstubAllEnvs();
@@ -182,14 +203,13 @@ describe("native PDF provider API calls", () => {
       }),
     );
 
-    const error = await Promise.race([
+    const error = await withTimeout(
       pdfNativeProviders
         .anthropicAnalyzePdf(makeAnthropicAnalyzeParams())
         .catch((caught: unknown) => caught),
-      new Promise<Error>((_resolve, reject) => {
-        setTimeout(() => reject(new Error("timed out waiting for bounded error body")), 500);
-      }),
-    ]);
+      2_000,
+      "timed out waiting for bounded error body",
+    );
 
     if (!(error instanceof Error)) {
       throw new Error("expected Anthropic PDF request to throw an Error");
@@ -384,9 +404,15 @@ function startTestServer(
       resolve({
         port: addr.port,
         stop: () =>
-          new Promise<void>((res, rej) =>
-            server.close((err) => (err ? rej(err) : res())),
-          ),
+          new Promise<void>((res, rej) => {
+            server.close((err) => {
+              if (err) {
+                rej(err);
+                return;
+              }
+              res();
+            });
+          }),
       });
     });
   });
@@ -407,8 +433,28 @@ function makeOversizedStreamHandler(
   return (_req, res) => {
     res.writeHead(200, { "content-type": "application/json" });
     let written = 0;
+    let closed = false;
+    let pendingWrite: ReturnType<typeof setTimeout> | undefined;
+
+    const clearPendingWrite = () => {
+      if (pendingWrite) {
+        clearTimeout(pendingWrite);
+        pendingWrite = undefined;
+      }
+    };
+
+    const scheduleNext = () => {
+      if (closed || pendingWrite) {
+        return;
+      }
+      pendingWrite = setTimeout(writeNext, 5);
+    };
 
     function writeNext() {
+      pendingWrite = undefined;
+      if (closed) {
+        return;
+      }
       if (written >= TOTAL_CHUNKS) {
         res.end();
         return;
@@ -416,14 +462,23 @@ function makeOversizedStreamHandler(
       written++;
       onChunkWritten();
       const ok = res.write(CHUNK);
-      if (ok) {
-        writeNext();
-      } else {
-        res.once("drain", writeNext);
+      if (closed) {
+        return;
       }
+      if (!ok) {
+        res.once("drain", scheduleNext);
+        return;
+      }
+      scheduleNext();
     }
 
-    writeNext();
+    res.on("close", () => {
+      closed = true;
+      clearPendingWrite();
+      res.off("drain", scheduleNext);
+    });
+
+    scheduleNext();
   };
 }
 

--- a/src/agents/tools/pdf-native-providers.ts
+++ b/src/agents/tools/pdf-native-providers.ts
@@ -8,6 +8,7 @@ import { normalizeProviderTransportWithPlugin } from "../../plugins/provider-run
 import { isRecord } from "../../utils.js";
 import { normalizeSecretInput } from "../../utils/normalize-secret-input.js";
 import { resolveAnthropicMessagesUrl } from "../anthropic-transport-stream.js";
+import { readProviderJsonResponse } from "../provider-http-errors.js";
 
 type PdfInput = {
   base64: string;
@@ -92,7 +93,7 @@ export async function anthropicAnalyzePdf(params: {
     );
   }
 
-  const json = (await res.json().catch(() => null)) as unknown;
+  const json = await readProviderJsonResponse<unknown>(res, "Anthropic PDF");
   if (!isRecord(json)) {
     throw new Error("Anthropic PDF response was not JSON.");
   }
@@ -180,7 +181,7 @@ export async function geminiAnalyzePdf(params: {
     );
   }
 
-  const json = (await res.json().catch(() => null)) as unknown;
+  const json = await readProviderJsonResponse<unknown>(res, "Gemini PDF");
   if (!isRecord(json)) {
     throw new Error("Gemini PDF response was not JSON.");
   }


### PR DESCRIPTION
## Summary

- Bounds native PDF provider success JSON reads for Anthropic and Gemini with the shared provider JSON response limit instead of bare `res.json()`.
- Prevents a misbehaving or proxying AI provider endpoint from making PDF extraction buffer an arbitrarily large success body before parsing.
- Intentionally out of scope: changing provider output semantics, adding live Anthropic/Gemini credentials, or redesigning large-PDF extraction streaming.
- Review focus: the 16 MiB fail-closed compatibility tradeoff for native PDF success responses.

## Linked context

Related context: #97688.

Related: existing provider response hardening series that routes success/control-plane provider reads through bounded helpers.

Maintainer request: not directly requested by a maintainer.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: native PDF provider success responses were read with unbounded `res.json()` in `anthropicAnalyzePdf` and `geminiAnalyzePdf`.
- Real environment tested: local OpenClaw checkout on Node 22 using the actual exported native PDF provider functions and a real `node:http` server bound to `127.0.0.1`; no fetch mock on these proof cases.
- Exact steps or command run after this patch: `PNPM_CONFIG_MODULES_DIR=/media/vdc/0668001470/workSpace/claw-campaign/openclaw/node_modules node scripts/run-vitest.mjs src/agents/tools/pdf-native-providers.test.ts -- --run -t "response-size guard"`
- Evidence after fix: Live test output from real node:http loopback server (no fetch mock), Linux x86-64, Node v22:

```text
✓ anthropicAnalyzePdf — 16 MiB response-size guard (real HTTP server) > returns extracted text for a well-formed response under the cap   44ms
✓ anthropicAnalyzePdf — 16 MiB response-size guard (real HTTP server) > rejects oversized AI responses before buffering all 20 MiB (OOM guard)   177ms
✓ geminiAnalyzePdf — 16 MiB response-size guard (real HTTP server) > returns extracted text for a well-formed response under the cap   7ms
✓ geminiAnalyzePdf — 16 MiB response-size guard (real HTTP server) > rejects oversized AI responses before buffering all 20 MiB (OOM guard)   177ms
```

Both providers reject oversized (20 MiB) AI responses before full buffering; under-cap responses parse and return extracted text correctly. Real node:http loopback — no fetch mock.

- Observed result after fix: under-cap local Anthropic/Gemini JSON responses parse and return extracted text; oversized 20 MiB success responses reject with `JSON response exceeds` before the server finishes streaming all chunks.
- What was not tested: live Anthropic or live Gemini API calls with real provider credentials; no private provider token is available in this environment.
- Proof limitations or environment constraints: this is a real local HTTP transport proof through the production provider functions, not a live third-party API proof. Maintainers still need to accept the 16 MiB success-response cap or request a native-PDF-specific cap.
- Before evidence: source on `main` used bare `res.json()` for both native PDF success paths, which buffers the response body to completion before JSON parsing.

## Tests and validation

- `PNPM_CONFIG_MODULES_DIR=/media/vdc/0668001470/workSpace/claw-campaign/openclaw/node_modules node scripts/run-vitest.mjs src/agents/tools/pdf-native-providers.test.ts -- --run -t "response-size guard"`
- Regression coverage added for Anthropic and Gemini under-cap success bodies plus oversized streaming success bodies from a real local HTTP server.
- Existing request-shape/error tests remain in `src/agents/tools/pdf-native-providers.test.ts`.

## Risk checklist

Did user-visible behavior change? (`Yes/No`) Yes. Success responses above the shared JSON cap now fail closed instead of buffering unbounded data.

Did config, environment, or migration behavior change? (`Yes/No`) No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`) Yes, network response body handling is stricter for two AI provider calls.

What is the highest-risk area? Legitimate native PDF outputs above 16 MiB would now fail.

How is that risk mitigated? Native PDF extraction defaults to `max_tokens` around normal text output sizes, and the failure mode is explicit instead of process OOM. The PR calls out the cap for maintainer decision.

## Current review state

Next action: ClawSweeper/maintainer re-review after the PR body proof refresh.

Waiting on: maintainer acceptance of the 16 MiB native PDF success-response cap or a requested cap adjustment.

Bot/reviewer comments addressed: the PR body now uses the full template and explicitly separates real local HTTP proof from the missing live provider proof.

_AI-assisted; implementation and validation reviewed before pushing._

