### PR TITLE
harden WhatsApp WebSocket URL override

### DIFF
--- a/extensions/whatsapp/src/session.test.ts
+++ b/extensions/whatsapp/src/session.test.ts
@@ -449,6 +449,25 @@ describe("web session", () => {
     expect(readLastSocketOptions().waWebSocketUrl).toBeUndefined();
   });
 
+  it("rejects invalid OPENCLAW_WHATSAPP_WEB_SOCKET_URL values", async () => {
+    vi.stubEnv(OPENCLAW_WHATSAPP_WEB_SOCKET_URL_ENV, "http://127.0.0.1:14567/ws");
+
+    await expect(createWaSocket(false, false)).rejects.toThrow(
+      "OPENCLAW_WHATSAPP_WEB_SOCKET_URL must use ws:// or wss://.",
+    );
+    expect(baileys.makeWASocket).not.toHaveBeenCalled();
+  });
+
+  it("preserves explicit Baileys WebSocket URL options over invalid environment", async () => {
+    vi.stubEnv(OPENCLAW_WHATSAPP_WEB_SOCKET_URL_ENV, "http://127.0.0.1:49153/ws/chat");
+
+    await createWaSocket(false, false, {
+      waWebSocketUrl: "ws://127.0.0.1:49154/ws/chat",
+    });
+
+    expect(readLastSocketOptions().waWebSocketUrl).toBe("ws://127.0.0.1:49154/ws/chat");
+  });
+
   it("uses ambient env proxy agent when HTTPS_PROXY is configured", async () => {
     vi.stubEnv("HTTPS_PROXY", "http://proxy.test:8080");
 

--- a/extensions/whatsapp/src/session.ts
+++ b/extensions/whatsapp/src/session.ts
@@ -133,6 +133,23 @@ function resolveWaWebSocketUrl(value: string | URL | undefined): string | URL | 
   return value.trim() || undefined;
 }
 
+function resolveEnvWaWebSocketUrl(): string | undefined {
+  const value = resolveWaWebSocketUrl(process.env[OPENCLAW_WHATSAPP_WEB_SOCKET_URL_ENV]);
+  if (!value) {
+    return undefined;
+  }
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error(`${OPENCLAW_WHATSAPP_WEB_SOCKET_URL_ENV} must be a valid URL.`);
+  }
+  if (url.protocol !== "ws:" && url.protocol !== "wss:") {
+    throw new Error(`${OPENCLAW_WHATSAPP_WEB_SOCKET_URL_ENV} must use ws:// or wss://.`);
+  }
+  return url.toString();
+}
+
 /**
  * Create a Baileys socket backed by the multi-file auth store we keep on disk.
  * Consumers can opt into QR printing for interactive login flows.
@@ -172,6 +189,7 @@ export async function createWaSocket(
     await writeCredsJsonAtomically(authDir, state.creds);
   };
   const { version } = await fetchLatestBaileysVersion();
+  const waWebSocketUrl = resolveWaWebSocketUrl(opts.waWebSocketUrl) ?? resolveEnvWaWebSocketUrl();
   const agent = await resolveEnvProxyAgent(sessionLogger);
   const fetchAgent = await resolveEnvFetchDispatcher(sessionLogger, agent);
   const socketTiming = {
@@ -181,9 +199,6 @@ export async function createWaSocket(
     defaultQueryTimeoutMs:
       opts.defaultQueryTimeoutMs ?? DEFAULT_WHATSAPP_SOCKET_TIMING.defaultQueryTimeoutMs,
   };
-  const waWebSocketUrl =
-    resolveWaWebSocketUrl(opts.waWebSocketUrl) ??
-    resolveWaWebSocketUrl(process.env[OPENCLAW_WHATSAPP_WEB_SOCKET_URL_ENV]);
   const sock = makeWASocket({
     auth: {
       creds: state.creds,


### PR DESCRIPTION
## Summary

- Rebased this PR onto `main` after #97155 merged the canonical WhatsApp Baileys `waWebSocketUrl` override.
- Trimmed the diff so this PR now only adds validation for the trusted `OPENCLAW_WHATSAPP_WEB_SOCKET_URL` env fallback.
- Rejects invalid env fallback values before Baileys socket creation while preserving explicit `waWebSocketUrl` call options over environment.

## Verification

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-whatsapp.config.ts whatsapp/src/session.test.ts`
- `pnpm exec oxfmt --check extensions/whatsapp/src/session.ts extensions/whatsapp/src/session.test.ts`
- `pnpm install` after one `pnpm exec oxlint` attempt hit dependency materialization `ENOENT`; install reported already up to date.
- `pnpm exec oxlint --deny-warnings --tsconfig config/tsconfig/oxlint.extensions.json extensions/whatsapp/src/session.ts extensions/whatsapp/src/session.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
