### PR TITLE
fix(pdf): reject empty parsed page ranges before native analysis

### DIFF
--- a/src/agents/tools/pdf-tool.helpers.test.ts
+++ b/src/agents/tools/pdf-tool.helpers.test.ts
@@ -62,6 +62,10 @@ describe("parsePageRange", () => {
     expect(parsePageRange("1-100", 5)).toEqual([1, 2, 3, 4, 5]);
   });
 
+  it("throws when no requested pages are within maxPages", () => {
+    expect(() => parsePageRange("999", 20)).toThrow('No PDF pages matched requested range "999"');
+  });
+
   it("deduplicates and sorts", () => {
     expect(parsePageRange("5,3,1,3,5", 20)).toEqual([1, 3, 5]);
   });

--- a/src/agents/tools/pdf-tool.helpers.ts
+++ b/src/agents/tools/pdf-tool.helpers.ts
@@ -74,7 +74,11 @@ export function parsePageRange(range: string, maxPages: number): number[] {
       }
     }
   }
-  return Array.from(pages).toSorted((a, b) => a - b);
+  const parsedPages = Array.from(pages).toSorted((a, b) => a - b);
+  if (parsedPages.length === 0) {
+    throw new Error(`No PDF pages matched requested range "${range}"`);
+  }
+  return parsedPages;
 }
 
 /** Converts a provider assistant message into PDF text or throws a model-labelled failure. */

--- a/src/agents/tools/pdf-tool.test.ts
+++ b/src/agents/tools/pdf-tool.test.ts
@@ -548,6 +548,26 @@ describe("createPdfTool", () => {
     });
   });
 
+  it("rejects explicit page ranges that resolve to no pages before native PDF analysis", async () => {
+    await withTempPdfAgentDir(async (agentDir) => {
+      await stubPdfToolInfra(agentDir, { provider: "anthropic", input: ["text", "document"] });
+      const nativeSpy = vi
+        .spyOn(pdfNativeProviders, "anthropicAnalyzePdf")
+        .mockResolvedValue("native summary");
+      const cfg = withPdfModel(ANTHROPIC_PDF_MODEL);
+      const tool = requirePdfTool((await loadCreatePdfTool())({ config: cfg, agentDir }));
+
+      await expect(
+        tool.execute("t1", {
+          prompt: "summarize",
+          pdf: "/tmp/doc.pdf",
+          pages: "999",
+        }),
+      ).rejects.toThrow('No PDF pages matched requested range "999"');
+      expect(nativeSpy).not.toHaveBeenCalled();
+    });
+  });
+
   it("rejects password parameter for native PDF providers", async () => {
     await withTempPdfAgentDir(async (agentDir) => {
       await stubPdfToolInfra(agentDir, { provider: "anthropic", input: ["text", "document"] });


### PR DESCRIPTION
## Summary

What problem does this PR solve?

- Fix classification: Root-cause bug fix for PDF tool page-range input handling.
- Root cause: `parsePageRange()` returned an empty array when every explicitly requested page was outside `pdfMaxPages`; downstream PDF tool paths could then treat that empty selection like no effective page filter, allowing native PDF providers to analyze the full document.
- Why this is root-cause fix: The parser now rejects the empty explicit selection at the source-of-truth page-range boundary, before provider routing or document extraction can reinterpret it as an unrestricted PDF request.
- Patch quality notes: XS scoped change; one production helper changed, with helper-level and tool-level regression tests; no schema, config, provider catalog, or native provider contract changes.

Why does this matter now?

- Why it matters / User impact: A user-supplied `pages` argument is a privacy, cost, and intent boundary. If the range resolves to no pages, the safe behavior is a clear input error rather than silently sending the whole PDF to a native provider.

What is the intended outcome?

- Maintainer-ready confidence: High; the failing behavior is reproduced at the tool boundary, the fix is at the parser boundary, and focused PDF tool tests pass on the current commit.

What is intentionally out of scope?

- What did NOT change: Valid page range parsing still clamps to `pdfMaxPages`, sorts and de-duplicates pages, and rejects malformed page numbers/ranges as before.
- Out of scope: This PR does not add native-provider page filtering, change PDF extraction plugin behavior, alter `pdfMaxPages` defaults, or change password/native provider support rules.

What does success look like?

Users who pass an explicit page range that selects no pages get `No PDF pages matched requested range "..."`; native PDF analysis is not invoked for that request.

What should reviewers focus on?

- Architecture / source-of-truth check: `parsePageRange()` is the single PDF tool boundary that converts user `pages` text into the `pageNumbers` contract, so rejecting an empty explicit selection there protects both native provider routing and fallback extraction callers.
- Related open PR / same-contract scan: No linked issue or known competing same-contract PR; this is a problem-mode contributor PR for a narrow PDF tool input boundary.

## Linked context

Which issue does this close?

No linked issue; problem-mode PR.

Which issues, PRs, or discussions are related?

Related: none.

Was this requested by a maintainer or owner?

No direct maintainer request; contributor-identified privacy/cost boundary bug.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Explicit PDF page ranges that resolve to zero pages are rejected before native PDF analysis can receive the full PDF.
- Real environment tested: Local OpenClaw repository test environment in the PR worktree, running the real `createPdfTool().execute()` path against a local redacted PDF fixture with `anthropic/claude-opus-4-6` configured as the native PDF model.
- Exact steps or command run after this patch: `daily_fix.sh run-validation --name pdf-empty-pages-real-tool-proof -- pnpm -C <pr-worktree> exec tsx <evidence>/pdf-empty-pages-real-tool-proof.ts`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Validation `pdf-empty-pages-real-tool-proof` (pass, exit_code=0, 35635ms):

  ```text
  OpenClaw PDF tool live execution proof
  pdf: redacted-proof.pdf
  input pages: "999"
  configured pdfMaxPages: 20
  error: No PDF pages matched requested range "999"
  native provider reached: no
  ```

- Observed result after fix: The real PDF tool execution rejects `pages: "999"` with `No PDF pages matched requested range "999"` before native provider execution; the regression test also asserts `anthropicAnalyzePdf` is not called.
- What was not tested: No live external Anthropic or Google API request was made, because the intended behavior is to fail before sending the PDF to a native provider. The local proof runs the real OpenClaw PDF tool boundary and records that native provider execution was not reached.
- Proof limitations or environment constraints: The proof uses a local redacted PDF fixture and configured native provider model, but intentionally stops at the fail-fast boundary to avoid exposing document content externally.
- Before evidence (optional but encouraged): The added tool regression failed before the fix because the promise resolved with `{ native: true, text: "native summary" }` instead of rejecting.

## Tests and validation

Which commands did you run?

- Target test file: `src/agents/tools/pdf-tool.helpers.test.ts`, `src/agents/tools/pdf-tool.test.ts`

What regression coverage was added or updated?

- Scenario locked in: `parsePageRange("999", 20)` throws, and a PDF tool request with `pages: "999"` rejects before Anthropic native PDF analysis is called.

What failed before this fix, if known?

- Why this is the smallest reliable guardrail: The helper-level test locks the parser invariant, while the tool-level test locks the user-visible provider boundary; together they prevent both a helper regression and a future native-provider full-document leak for empty parsed selections.

If no test was added, why not?

Regression tests were added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Explicit page ranges that select no pages now fail fast instead of behaving like an unrestricted PDF request.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

Yes. The tool execution boundary is tightened so invalid explicit page selection does not proceed to native PDF provider execution.

What is the highest-risk area?

- Risk labels considered: privacy/cost boundary, tool execution boundary, PDF page-range compatibility.
- Risk explanation: The main compatibility risk is that a user who previously requested only out-of-range pages may have received a full-document answer; that behavior conflicts with the explicit `pages` intent and could expose more content than requested.

How is that risk mitigated?

- Why acceptable: Failing fast with a precise error is safer than silently broadening scope, and valid in-range or partially in-range page requests keep the existing clamping behavior.

## Current review state

What is the next action?

Ready for maintainer review after adding the requested real PDF tool behavior proof and rerunning local submit gates.

What is still waiting on author, maintainer, CI, or external proof?

Nothing known on the author side after this update. Maintainer acceptance is still needed for the intentional fail-closed compatibility change, and remote checks/re-review may still need to settle.

Which bot or reviewer comments were addressed?

- ClawSweeper RF-001/RF-002/RF-004: added redacted terminal output from a real OpenClaw PDF tool execution showing the out-of-range `pages` request fails before native provider execution.
- ClawSweeper RF-003: disclosed the user-visible fail-closed compatibility change in the risk checklist.
- ClawSweeper RF-005: no code repair was queued; the remaining items are contributor proof, now added here, and maintainer acceptance of the fail-closed behavior.
