### PR TITLE
Bound Anthropic Messages transport SSE success stream buffering

### DIFF
--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -675,6 +675,38 @@ describe("anthropic transport stream", () => {
     expect(result.errorMessage).toBe("OpenClaw transport error: malformed_streaming_fragment");
   });
 
+  it("caps unterminated Anthropic SSE success body bytes", async () => {
+    const timedOut = Symbol("timed out");
+    let cancelReason: unknown;
+    guardedFetchMock.mockResolvedValueOnce(
+      createOpenRawSseResponse({
+        body: `data: ${"x".repeat(17 * 1024 * 1024)}`,
+        onCancel: (reason) => {
+          cancelReason = reason;
+        },
+      }),
+    );
+
+    const result = await Promise.race([
+      runTransportStream(
+        makeAnthropicTransportModel(),
+        {
+          messages: [{ role: "user", content: "hello" }],
+        } as AnthropicStreamContext,
+        {
+          apiKey: "sk-ant-api",
+        } as AnthropicStreamOptions,
+      ),
+      delay(100, timedOut),
+    ]);
+
+    expect(result).toMatchObject({
+      stopReason: "error",
+      errorMessage: "Anthropic Messages SSE stream exceeded 16777216 bytes",
+    });
+    expect(cancelReason).toBeInstanceOf(Error);
+  });
+
   it.each(["anthropic", "anthropic-vertex"])(
     "surfaces structured Anthropic streaming refusals for %s",
     async (provider) => {

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -53,6 +53,7 @@ import { parseJsonObjectPreservingUnsafeIntegers } from "./json-unsafe-integers.
 import { resolveProviderEndpoint } from "./provider-attribution.js";
 import { buildGuardedModelFetch } from "./provider-transport-fetch.js";
 import type { StreamFn } from "./runtime/index.js";
+import { createSseByteGuard, type SseByteGuard } from "./streaming-byte-guard.js";
 import { transformTransportMessages } from "./transport-message-transform.js";
 import {
   coerceTransportToolCallArguments,
@@ -69,6 +70,7 @@ const CLAUDE_CODE_VERSION = "2.1.75";
 const ANTHROPIC_MESSAGES_ERROR_BODY_MAX_BYTES = 8 * 1024;
 const ANTHROPIC_MESSAGES_ERROR_BODY_MAX_CHARS = 400;
 const ANTHROPIC_MESSAGES_ERROR_BODY_READ_IDLE_TIMEOUT_MS = 10_000;
+const ANTHROPIC_MESSAGES_SSE_STREAM_MAX_BYTES = 16 * 1024 * 1024;
 const CLAUDE_CODE_TOOLS = [
   "Read",
   "Write",
@@ -613,7 +615,7 @@ function createAbortError(signal: AbortSignal): Error {
 }
 
 function readAnthropicSseChunk(
-  reader: ReadableStreamDefaultReader<Uint8Array>,
+  reader: Pick<SseByteGuard, "read" | "cancel">,
   signal?: AbortSignal,
 ): Promise<ReadableStreamReadResult<Uint8Array>> {
   if (!signal) {
@@ -675,12 +677,17 @@ async function* parseAnthropicSseBody(
   signal?: AbortSignal,
 ): AsyncIterable<Record<string, unknown>> {
   const reader = body.getReader();
+  const sseReader = createSseByteGuard(reader, {
+    maxBytes: ANTHROPIC_MESSAGES_SSE_STREAM_MAX_BYTES,
+    onOverflow: ({ maxBytes }) =>
+      new Error(`Anthropic Messages SSE stream exceeded ${maxBytes} bytes`),
+  });
   const decoder = new TextDecoder();
   let buffer = "";
   let completed = false;
   try {
     while (true) {
-      const { done, value } = await readAnthropicSseChunk(reader, signal);
+      const { done, value } = await readAnthropicSseChunk(sseReader, signal);
       if (done) {
         completed = true;
         break;


### PR DESCRIPTION
## Summary

What problem does this PR solve?

Fixes an issue where OpenClaw-managed Anthropic Messages streaming transport could keep reading an overlarge successful SSE response body without a transport-level byte ceiling. If a provider kept sending a very large successful SSE stream, the parser could continue consuming bytes until a later boundary or runtime timeout instead of failing at a bounded size.

Why does this matter now?

This transport path consumes untrusted provider response bytes. A deterministic cap prevents pathological memory growth and gives operators a clear bounded failure when an Anthropic-compatible provider emits an oversized successful SSE response.

What is the intended outcome?

Successful Anthropic Messages SSE responses are capped at 16 MiB on the parser's raw-byte reader, and overflow raises `Anthropic Messages SSE stream exceeded 16777216 bytes` while cancelling the underlying reader.

What is intentionally out of scope?

No changes to proxy SSE parsing, non-2xx Anthropic error body handling, provider selection, model catalog behavior, request payload shaping, gateway lifecycle, global sanitizer limits, or normal Anthropic Messages streaming semantics.

- **Fix classification:** Root-cause fix for the Anthropic Messages successful SSE parser read boundary.
- **Maintainer-ready confidence:** High — the patch reuses the existing streaming byte guard pattern, keeps the limit scoped to Anthropic Messages successful SSE reads, and has both regression coverage and CLI live proof.
- **Root cause:** The Anthropic Messages success path parsed provider SSE events from the response body but did not wrap that body reader with the existing raw-byte guard. Error responses already had bounded snippet reads, but successful SSE reads could cross a large total-byte boundary before the parser produced a terminal error.
- **Why this is root-cause fix:** The guard is attached at the parser's source-of-truth byte reader, before decoded frames are appended or parsed. That means every successful Anthropic Messages SSE body is capped consistently regardless of how the provider chunks valid SSE frames.
- **Patch quality notes:** Small, localized change; no new public config, schema, model routing, API contract, or fallback behavior. The error message is explicit and the reader is cancelled through the existing guard path.
- **Why it matters / User impact:** Users and operators get a deterministic bounded failure instead of unbounded memory growth or a delayed timeout when an Anthropic-compatible provider emits an oversized successful SSE response.
- **What did NOT change:** This does not change proxy SSE parsing, non-2xx Anthropic error body handling, provider selection, model catalog behavior, request payload shaping, or normal Anthropic Messages streaming semantics.
- **Architecture / source-of-truth check:** The cap is enforced in the Anthropic Messages transport parser, which is the source-of-truth consumer for successful Anthropic SSE response bodies. It reuses the existing `createSseByteGuard` contract rather than adding an Anthropic-only buffering workaround.
- **Related open PR / same-contract scan:** ClawSweeper noted a canonical overlapping Anthropic Messages parser PR; this PR keeps the same scoped 16 MiB guard shape and adds live CLI proof for this branch's current head.
- **Out of scope:** No changes to global provider request policy, sanitizer limits, gateway lifecycle, or broader streaming contracts.

## Linked context

Which issue does this close?

No linked issue.

Which issues, PRs, or discussions are related?

ClawSweeper flagged this as overlapping with canonical PR #96701 and related parser-surface PRs #96723 and #96762. This PR now includes direct local TCP/CLI live proof for the current branch head so maintainers can compare proof quality without relying only on tests.

Was this requested by a maintainer or owner?

The PR has a ClawSweeper `status: needs proof` signal requesting real behavior proof. This update addresses that proof gap with a real CLI/provider-boundary run.

## Real behavior proof

- **Behavior or issue addressed:** Successful Anthropic Messages SSE response bodies are capped before an oversized provider stream can continue accumulating in the parser/runtime path.
- **Real environment tested:** Local OpenClaw CLI run through `node scripts/run-node.mjs agent --local --json` with a temporary `OPENCLAW_CONFIG_PATH`, an OpenClaw-managed `api=anthropic-messages` provider, provider `localService` health check, and a local TCP HTTP/SSE server responding to `/models` and `/v1/messages`.
- **Exact steps or command run after this patch:** Through the OpenClaw CLI surface, a temporary Anthropic Messages provider was configured with `api=anthropic-messages` and `localService`; `node scripts/run-node.mjs agent --local --json --agent proof --message "live proof: trigger Anthropic SSE parser guard" --model live-proof-anthropic/claude-live-proof --timeout 30` was run against a local TCP SSE server.
- **Evidence after fix:** Validation `anthropic-sse-live-proof` passed. The live server received `GET /models` and `POST /v1/messages`; OpenClaw logged `method=POST url=http://127.0.0.1:<port>/v1/messages ... contentType=text/event-stream`; the runtime surfaced `Anthropic Messages SSE stream exceeded 16777216 bytes`; the server wrote 35,656,398 SSE bytes and observed the client socket close.
- **Observed result after fix:** The real CLI path hit the OpenClaw-managed Anthropic Messages transport, read a successful SSE body from `/v1/messages`, raised the 16 MiB guard error, and closed the client connection instead of continuing to consume the oversized stream.
- **What was not tested:** No real Anthropic network call was made; the proof used a local Anthropic-compatible SSE server so the oversized response could be produced safely and deterministically. GUI surfaces and unrelated providers were not exercised.
- **Proof limitations or environment constraints:** The proof intentionally uses a local TCP server rather than a real third-party Anthropic endpoint to avoid unsafe oversized traffic against an external service; it still exercises the real OpenClaw CLI, provider routing, HTTP request, SSE response reader, overflow error, and connection close path.

## Tests and validation

Which commands did you run?

- `pnpm exec vitest run src/agents/anthropic-transport-stream.test.ts`
- `node scripts/run-node.mjs agent --local --json --agent proof --message "live proof: trigger Anthropic SSE parser guard" --model live-proof-anthropic/claude-live-proof --timeout 30` via daily-fix validation `anthropic-sse-live-proof`

What regression coverage was added or updated?

- **Target test file:** `src/agents/anthropic-transport-stream.test.ts`.
- **Scenario locked in:** A successful Anthropic Messages SSE body that exceeds 16 MiB triggers `Anthropic Messages SSE stream exceeded 16777216 bytes` and cancels the reader.
- **Why this is the smallest reliable guardrail:** The regression targets the transport parser boundary that owns successful Anthropic SSE response reads; the live proof then exercises the same behavior through the CLI/provider boundary instead of importing the parser directly.

What failed before this fix, if known?

Before the production fix, the focused regression timed out on an overlarge successful Anthropic SSE body because the successful stream parser did not produce a bounded failure at the intended 16 MiB limit.

If no test was added, why not?

Not applicable; a focused regression test was added and a separate CLI live proof was recorded.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Oversized successful Anthropic Messages SSE streams now fail predictably instead of continuing to read until later timeout or memory pressure.

Did config, environment, or migration behavior change? (`Yes/No`)

No. There is no config, environment, schema, migration, or model catalog change.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

Yes, narrowly in the defensive network-response handling sense: untrusted Anthropic Messages SSE response bytes now have a parser-level cap. No auth, secret, tool execution, or outbound request policy behavior changed.

What is the highest-risk area?

- **Risk labels considered:** `merge-risk: compatibility`, provider runtime, streaming parser behavior.
- **Risk explanation:** The main compatibility risk is rejecting previously accepted successful SSE streams larger than 16 MiB. That is intentional for a memory-safety guard and is scoped to Anthropic Messages successful SSE bodies.

How is that risk mitigated?

- **Why acceptable:** Oversized successful SSE streams are not a normal completion contract; bounding them prevents pathological memory growth while preserving ordinary framed SSE responses below the limit.

## Current review state

What is the next action?

ClawSweeper should re-evaluate the PR now that the PR body includes explicit local TCP/CLI live proof for the current branch head.

What is still waiting on author, maintainer, CI, or external proof?

Author-side proof has been supplied. CI is green, mergeability is clean, and the remaining visible item is the stale `status: needs proof`/duplicate advisory signal from the earlier ClawSweeper comment.

Which bot or reviewer comments were addressed?

Addressed the ClawSweeper request for stronger real behavior proof by adding a local TCP-server proof through the real OpenClaw CLI/provider path, including `/models`, `/v1/messages`, the 16 MiB overflow error, and observed client socket close.

## What Problem This Solves

Fixes an issue where OpenClaw-managed Anthropic Messages streaming transport could keep reading an overlarge successful SSE response body without a transport-level byte ceiling.

## Why This Change Was Made

The change wraps the successful Anthropic Messages SSE response reader with the existing raw-byte guard and sets a 16 MiB ceiling for that stream.

## User Impact

Anthropic-compatible providers that return oversized successful SSE streams now fail predictably with a bounded transport error and close the underlying client connection. Normal valid streams continue through the same parser and event handling path.

## Evidence

See `## Real behavior proof` above for the current CLI/local TCP proof and `## Tests and validation` for regression coverage.
