### PR TITLE
fix: document stream cleanup fallback intent

### DIFF
--- a/src/agents/minimax-vlm.ts
+++ b/src/agents/minimax-vlm.ts
@@ -54,7 +54,10 @@ function coerceApiHost(params: {
   try {
     const url = new URL(raw);
     return url.origin;
-  } catch {}
+  } catch {
+    // Bare hosts are retried with https:// below; malformed absolute URLs fall
+    // back to provider defaults instead of sending requests to invalid endpoints.
+  }
 
   if (/^[a-z][a-z\d+.-]*:\/\//i.test(raw)) {
     return defaultHost;

--- a/src/agents/provider-http-errors.ts
+++ b/src/agents/provider-http-errors.ts
@@ -81,7 +81,10 @@ export async function readResponseTextLimited(
     }
     try {
       reader.releaseLock();
-    } catch {}
+    } catch {
+      // Error-body reads are diagnostic best effort; release failures must not
+      // hide the bounded provider error text already captured.
+    }
   }
 
   return text;

--- a/src/agents/runtime/proxy.ts
+++ b/src/agents/runtime/proxy.ts
@@ -409,7 +409,10 @@ export function streamProxy(
     } finally {
       try {
         reader?.releaseLock();
-      } catch {}
+      } catch {
+        // Stream handling above already pushed the terminal proxy event;
+        // cleanup failures must not replace it with a secondary release error.
+      }
       if (options.signal) {
         options.signal.removeEventListener("abort", abortHandler);
       }

--- a/src/agents/tools/web-shared.ts
+++ b/src/agents/tools/web-shared.ts
@@ -287,7 +287,10 @@ export async function readResponseText(
       }
       try {
         reader.releaseLock();
-      } catch {}
+      } catch {
+        // The read/cancel path already produced the best-effort body result;
+        // lock-release failures must not replace that outcome.
+      }
     }
 
     const bytes = concatBytes(parts, bytesRead);


### PR DESCRIPTION
Closes #97691

## What Problem This Solves

Fixes an issue where operators troubleshooting web response reads, proxy SSE streams, or MiniMax VLM host selection would find empty `catch {}` blocks with no indication whether cleanup and URL parse errors were intentionally ignored.

## Why This Change Was Made

The catch sites now document the existing best-effort cleanup and fallback contracts in place, including the sibling provider error-body reader cleanup path that shares the same `releaseLock()` invariant. This preserves current stream handling and MiniMax malformed-host fallback behavior; it does not add logging, change provider routing, or turn cleanup failures into user-visible errors.

## User Impact

Operators and maintainers can now tell why these errors are swallowed when reading the hot paths, while users keep the same runtime behavior for bounded web reads, proxy streams, provider error snippets, and MiniMax VLM endpoint fallback.

AI-assisted.

## Evidence

Source precheck on current `upstream/main` showed the reported empty catches still present in `src/agents/tools/web-shared.ts`, `src/agents/runtime/proxy.ts`, and `src/agents/minimax-vlm.ts`; the sibling `src/agents/provider-http-errors.ts` cleanup catch used the same best-effort `releaseLock()` pattern. Existing MiniMax tests already cover malformed CN host fallback, so this patch keeps that behavior unchanged.

Focused tests:

```text
node scripts/run-vitest.mjs src/agents/tools/web-shared.test.ts src/agents/runtime/proxy.test.ts src/agents/minimax-vlm.normalizes-api-key.test.ts src/agents/provider-http-errors.test.ts
[test] passed 1 Vitest shard in 4.55s
Test Files  4 passed (4)
Tests       45 passed (45)
```

Formatting and patch checks:

```text
node_modules/.bin/oxfmt --check src/agents/tools/web-shared.ts src/agents/runtime/proxy.ts src/agents/minimax-vlm.ts src/agents/provider-http-errors.ts
All matched files use the correct format.

git diff --check
# no output
```

Build/CLI and live model proof:

```text
pnpm openclaw --version
OpenClaw 2026.6.10 (b01e612)

pnpm openclaw agent --local --model deepseek/deepseek-v4-pro --session-key agent:default:issue-97691-proof --message "Reply exactly with: openclaw-proof-ok" --json --timeout 180
[provider-transport-fetch] response provider=deepseek api=openai-completions model=deepseek-v4-pro status=200
finalAssistantVisibleText: openclaw-proof-ok
stopReason: stop
```

Review:

```text
.agents/skills/autoreview/scripts/autoreview --mode local
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.92)
```
