### PR TITLE
fix(agents): bound WHAM usage probe JSON response reads to prevent OOM

### DIFF
--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -14,6 +14,7 @@ import {
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { resolveProviderRequestHeaders } from "../provider-request-config.js";
+import { readProviderJsonResponse } from "../provider-http-errors.js";
 import { notifyAuthProfileFailureHook, setAuthProfileFailureHook } from "./failure-hook.js";
 import { logAuthProfileFailureStateChange } from "./state-observation.js";
 
@@ -265,7 +266,7 @@ async function probeWhamForCooldown(
       return { cooldownMs: WHAM_HTTP_ERROR_COOLDOWN_MS, reason: "wham_http_error" };
     }
 
-    const data = (await res.json()) as WhamUsageResponse;
+    const data = await readProviderJsonResponse<WhamUsageResponse>(res, "WHAM usage probe");
     if (!data.rate_limit) {
       return { cooldownMs: WHAM_PROBE_FAILURE_COOLDOWN_MS, reason: "wham_probe_failed" };
     }


### PR DESCRIPTION
## Summary

Replace unbounded `res.json()` with `readProviderJsonResponse` in the WHAM usage probe to cap OpenAI OAuth rate-limit API response bodies at 16 MiB.

## Real behavior proof (required for external PRs)

**Behavior addressed**: Unbounded `res.json()` replaced with `readProviderJsonResponse` (16 MiB cap).

**Real environment tested**: Linux, Node 22, OpenClaw main @ 87db23e543

**Exact steps or command run after fix**:

```bash
node --import tsx proof-wham-usage.mts
```

**Evidence after fix**:

```
cap: 16777216 bytes (16 MiB)
chunks enqueued: 17
stream cancelled: true
error: WHAM usage probe: JSON response exceeds 16777216 bytes
PASS: bounded at 17.0 MiB
```

**Observed result after fix**: `readProviderJsonResponse` caps WHAM usage probe responses at 16 MiB. Streaming bodies are cancelled at the cap.

**All existing tests pass**: 74 tests in `auth-profiles/usage.test.ts`.

**What was not tested**: A live WHAM usage API call was not tested.

## Risk

Low. The 16 MiB cap matches the convention in `provider-http-errors.ts`. The WHAM probe runs only for OpenAI OAuth profiles during auth profile usage checks.
