### PR TITLE
fix(google): bound OAuth token response reads to prevent OOM

### DIFF
--- a/extensions/google/oauth.token.ts
+++ b/extensions/google/oauth.token.ts
@@ -3,6 +3,8 @@ import {
   asDateTimestampMs,
   resolveExpiresAtMsFromDurationSeconds,
 } from "openclaw/plugin-sdk/number-runtime";
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
+import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import { resolveOAuthClientConfig } from "./oauth.credentials.js";
 import { fetchWithTimeout } from "./oauth.http.js";
 import { resolveGoogleOAuthIdentity, resolveGooglePersonalOAuthIdentity } from "./oauth.project.js";
@@ -10,6 +12,7 @@ import { isGeminiCliPersonalOAuth } from "./oauth.settings.js";
 import { REDIRECT_URI, TOKEN_URL, type GeminiCliOAuthCredentials } from "./oauth.shared.js";
 
 const TOKEN_EXPIRY_BUFFER_MS = 5 * 60 * 1000;
+const GOOGLE_OAUTH_RESPONSE_MAX_BYTES = 16 * 1024 * 1024;
 
 async function requestTokenGrant(body: URLSearchParams): Promise<{
   access_token?: string;
@@ -27,15 +30,18 @@ async function requestTokenGrant(body: URLSearchParams): Promise<{
   });
 
   if (!response.ok) {
-    const errorText = await response.text();
-    throw new Error(`Token exchange failed: ${errorText}`);
+    const errorBuffer = await readResponseWithLimit(response, GOOGLE_OAUTH_RESPONSE_MAX_BYTES, {
+      onOverflow: ({ maxBytes }) =>
+        new Error(`Google OAuth token response exceeds ${maxBytes} bytes`),
+    });
+    throw new Error(`Token exchange failed: ${new TextDecoder().decode(errorBuffer)}`);
   }
 
-  return (await response.json()) as {
+  return await readProviderJsonResponse<{
     access_token?: string;
     refresh_token?: string;
     expires_in?: unknown;
-  };
+  }>(response, "Google OAuth token");
 }
 
 function resolveExpiredTokenTimestampMs(nowMs: number): number {


### PR DESCRIPTION
## Summary

Replace unbounded `response.text()` in the error path and unbounded `response.json()` in the success path of the Google OAuth token exchange with `readResponseWithLimit` and `readProviderJsonResponse` (16 MiB cap). This prevents unbounded buffering of OAuth token endpoint responses.

## Real behavior proof (required for external PRs)

**Behavior addressed**: Two unbounded response reads replaced in `requestTokenGrant` — `response.text()` (error path) and `response.json()` (success path).

**Real environment tested**: Linux, Node 22, OpenClaw main @ 87db23e543

**Exact steps or command run after fix**:

```bash
node --import tsx proof-google-oauth.mts
```

**Evidence after fix**:

```
=== Test 1: error path (readResponseWithLimit) ===
  chunks: 17, cancelled: true
  PASS

=== Test 2: success path (readProviderJsonResponse) ===
  chunks: 17, cancelled: true
  PASS

PASS: both Google OAuth read paths bounded at 16 MiB
```

**Observed result after fix**: Both the error path (text read with `readResponseWithLimit`) and the success path (JSON read with `readProviderJsonResponse`) cap Google OAuth token responses at 16 MiB and cancel streaming bodies at the cap.

**All existing tests pass**: 32 tests across `oauth.test.ts` and `oauth-token-shared.test.ts`.

**What was not tested**: Live Google OAuth token exchange endpoints were not tested.

## Risk

Low. The 16 MiB cap is consistent with the existing Google extension pattern (`embedding-batch.ts`, `speech-provider.ts`, etc. already use `readProviderJsonResponse`). The same `readResponseWithLimit` helper is already used in `extensions/google/video-generation-provider.ts`.
