### PR TITLE
fix(agents): add diagnostic comments to empty catch blocks in streaming/proxy paths

### DIFF
--- a/src/agents/minimax-vlm.ts
+++ b/src/agents/minimax-vlm.ts
@@ -54,7 +54,9 @@ function coerceApiHost(params: {
   try {
     const url = new URL(raw);
     return url.origin;
-  } catch {}
+  } catch {
+    // URL parse failed; fall through to retry with https:// prefix or default host.
+  }
 
   if (/^[a-z][a-z\d+.-]*:\/\//i.test(raw)) {
     return defaultHost;

--- a/src/agents/runtime/proxy.ts
+++ b/src/agents/runtime/proxy.ts
@@ -409,7 +409,9 @@ export function streamProxy(
     } finally {
       try {
         reader?.releaseLock();
-      } catch {}
+      } catch {
+        // Best-effort: reader may already be released or stream closed.
+      }
       if (options.signal) {
         options.signal.removeEventListener("abort", abortHandler);
       }

--- a/src/agents/tools/web-shared.ts
+++ b/src/agents/tools/web-shared.ts
@@ -287,7 +287,9 @@ export async function readResponseText(
       }
       try {
         reader.releaseLock();
-      } catch {}
+      } catch {
+        // Best-effort: reader may already be released or stream closed.
+      }
     }
 
     const bytes = concatBytes(parts, bytesRead);


### PR DESCRIPTION
## Summary

**Problem**: Three empty `catch {}` blocks in streaming and proxy hot paths (web-shared.ts, proxy.ts, minimax-vlm.ts) silently swallow errors that could indicate real I/O failures, stream corruption, or URL parsing errors. These are distinct from the catches fixed in #63423 (config/pairing/infra paths) — these are in the agent inference hot path where swallowed errors hinder troubleshooting of stream truncation, proxy failures, and Minimax VLM misconfiguration.

**Solution**: Add explicit intent comments to all three empty catch blocks, following the same convention established in #63423. No behavior change — strictly documentation/diagnostics improvement. The comments make it clear to future maintainers that these catches are intentional best-effort cleanup or fallback, not oversight.

**What changed**: Three empty `catch {}` blocks replaced with `catch { /* comment */ }` blocks containing concise explanations of why the error is intentionally ignored.

**What did NOT change**: No behavior change. No logging added (per ClawSweeper guidance: logging cleanup errors from stream `releaseLock()` must not replace computed results or turn best-effort cleanup into user-visible failures). No Minimax VLM routing semantics changed — the malformed-host fallback behavior (tested in minimax-vlm.normalizes-api-key.test.ts) is preserved exactly.

Fixes #97691

---

## What Problem This Solves

**Problem**: When troubleshooting truncated web fetches, proxy stream failures, or misconfigured Minimax VLM endpoints, maintainers encounter empty `catch {}` blocks with no indication whether the suppression is intentional or an oversight. This requires reading surrounding context or git history to understand the design intent, slowing down debugging.

**Why This Change Was Made**: The #63423 fix established a convention of documenting empty catches with comments or debug logging for the config/pairing/infra paths. These three sites in the agent inference hot path were missed. Adding comments is the narrowest fix that provides clarity without risking behavior changes or log spam in hot paths.

**User Impact**: Zero behavioral impact. Users see identical behavior. The benefit is purely for maintainers and contributors debugging stream/proxy/URL issues — the comments eliminate the "is this a bug?" question when encountering these catch blocks.

---

## Root Cause

**Trigger condition**: Source inspection of three files on current main reveals empty catch blocks with no comment documenting intent. These catches are reached when:
1. `reader.releaseLock()` throws (stream already released/closed) during web fetch cleanup
2. `reader?.releaseLock()` throws during proxy SSE stream cleanup
3. `new URL(raw)` fails for a malformed Minimax VLM endpoint URL

**Root cause analysis**:
| Level | Question | Answer |
|-------|----------|--------|
| Why 1 | Why are errors silently swallowed? | Empty `catch {}` blocks suppress all errors without logging or comment |
| Why 2 | Why were empty catches used? | These are best-effort cleanup/fallback operations where errors are non-actionable |
| Why 3 | Why weren't comments added? | The code predates or was missed by the #63423 empty-catch documentation convention |
| Why 4 | Why did #63423 miss these sites? | #63423 targeted config/pairing/infra paths; these are in agent inference hot paths |
| Why 5 | Root cause | Three catch sites in streaming/proxy paths predate or were missed by the #63423 empty-catch documentation convention |

**Affected scope**:
- `src/agents/tools/web-shared.ts:290` — `readResponseText()` cleanup
- `src/agents/runtime/proxy.ts:412` — `streamProxy()` cleanup
- `src/agents/minimax-vlm.ts:57` — `coerceApiHost()` fallback
- Affected versions: all versions containing these catch sites (includes v2026.6.5 through latest)
- Not affected: normal operation paths — errors are correctly suppressed; only observability is missing

---

## Linked context

- **Issue**: #97691
- **Related PRs**: #63423 (prior empty-catch fix for config/pairing/infra paths — established the comment/doc pattern)
- **In scope**: Add intent comments to three empty catch blocks in web-shared.ts, proxy.ts, minimax-vlm.ts
- **Out of scope**: Adding logging (could interfere with hot-path performance or turn cleanup errors into user-visible failures), changing Minimax VLM fallback behavior (tested and intentional), broad lint churn across the codebase
- **Design doc**: [issue-97691-04-design.md](docs/.local/issue-97691-04-design.md)

---

## Real behavior proof

**Behavior addressed**: Three empty catch blocks in streaming/proxy/Minimax paths lacked comments documenting why error suppression is intentional, hindering maintainer troubleshooting.

**Real environment tested**: Linux 4.19.112-2.el8.x86_64, Node v26.2.0, pnpm 11.5.1, OpenClaw main @ 5327340a09

**Exact steps or command run after this patch**:

1. Source inspection confirms all three empty catches are now documented
```bash
cd /home/0668001050/workspace/openclaw
rg -A2 'catch \{' src/agents/tools/web-shared.ts src/agents/runtime/proxy.ts src/agents/minimax-vlm.ts
```

2. Run all affected tests
```bash
node scripts/run-vitest.mjs src/agents/tools/web-shared.test.ts src/agents/runtime/proxy.test.ts src/agents/minimax-vlm.normalizes-api-key.test.ts
```

3. Verify whitespace and diff
```bash
git diff --check
git diff --stat
```

**After-fix evidence**:

git diff --stat:
```
src/agents/minimax-vlm.ts      | 4 +++-
src/agents/runtime/proxy.ts    | 4 +++-
src/agents/tools/web-shared.ts | 4 +++-
3 files changed, 9 insertions(+), 3 deletions(-)
```

git diff (changes in all three files):
```
@@ src/agents/minimax-vlm.ts @@
-  } catch {}
+  } catch {
+    // URL parse failed; fall through to retry with https:// prefix or default host.
+  }

@@ src/agents/runtime/proxy.ts @@
-      } catch {}
+      } catch {
+        // Best-effort: reader may already be released or stream closed.
+      }

@@ src/agents/tools/web-shared.ts @@
-      } catch {}
+      } catch {
+        // Best-effort: reader may already be released or stream closed.
+      }
```

Test results:
```
Test Files  3 passed (3)
     Tests  32 passed (32)
  Duration  2.83s
```

**Observed result after the fix**: All three empty `catch {}` blocks now contain explicit intent comments. All 32 existing tests pass with zero behavior change. The `git diff --check` confirms no whitespace issues. The Minimax VLM malformed-host fallback behavior (tested in minimax-vlm.normalizes-api-key.test.ts:109) is preserved.

**What was not tested**: No new tests added — this is a comment-only change with zero behavior impact. Existing test coverage for the affected functions (readResponseText, streamProxy, coerceApiHost) is sufficient to confirm no regression. Runtime scenarios where `releaseLock()` actually throws (concurrent cancel, GC timing) are not reproducible in unit tests and are inherently best-effort.

---

## Tests and validation

### Unit tests

```
node scripts/run-vitest.mjs src/agents/tools/web-shared.test.ts src/agents/runtime/proxy.test.ts src/agents/minimax-vlm.normalizes-api-key.test.ts

RUN  v4.1.8

 Test Files  3 passed (3)
      Tests  32 passed (32)
   Start at  15:10:40
   Duration  2.83s
```

### Integration / E2E

N/A — comment-only change with zero behavioral impact. No integration or E2E paths are affected.

---

## Risk checklist

- [x] This change is backwards compatible — comment-only, zero behavior impact
- [x] This change has been tested with existing configurations — all 32 existing tests pass
- [x] I have updated relevant documentation — no API/config/CLI changes; docs/.local/ analysis/design docs created
- [x] Breaking changes (if any) are documented in Summary — N/A, no breaking changes

- Compatibility risk: None. Comments-only change, no code paths altered.
- Merge-risk explanation: Minimal risk. Three single-line changes in three files, each replacing `catch {}` with `catch { /* comment */ }`. No logic, no control flow, no type changes. Can be merged without concern.

---

## Current review state

- [x] Self-review completed
- [ ] At least one maintainer review
- [ ] All CI checks passed
