### PR TITLE
feat(memory): add outcome normalization to dreaming events

### DIFF
--- a/extensions/memory-core/src/dreaming-markdown.ts
+++ b/extensions/memory-core/src/dreaming-markdown.ts
@@ -6,6 +6,7 @@ import {
   type MemoryDreamingPhaseName,
   type MemoryDreamingStorageConfig,
 } from "openclaw/plugin-sdk/memory-core-host-status";
+import type { MemoryDreamOutcome } from "openclaw/plugin-sdk/memory-host-events";
 import { appendMemoryHostEvent } from "openclaw/plugin-sdk/memory-host-events";
 import {
   replaceManagedMarkdownBlock,
@@ -65,6 +66,8 @@ export async function writeDailyDreamingPhaseBlock(params: {
   nowMs?: number;
   timezone?: string;
   storage: MemoryDreamingStorageConfig;
+  outcome?: MemoryDreamOutcome;
+  error?: string;
 }): Promise<{ inlinePath?: string; reportPath?: string }> {
   const nowMs = resolveMemoryCoreNowMs(params.nowMs);
   const body = params.bodyLines.length > 0 ? params.bodyLines.join("\n") : "- No notable updates.";
@@ -112,6 +115,8 @@ export async function writeDailyDreamingPhaseBlock(params: {
     type: "memory.dream.completed",
     timestamp: resolveMemoryCoreTimestamp(nowMs),
     phase: params.phase,
+    ...(params.outcome ? { outcome: params.outcome } : {}),
+    ...(params.error ? { error: params.error } : {}),
     ...(inlinePath ? { inlinePath } : {}),
     ...(reportPath ? { reportPath } : {}),
     lineCount: params.bodyLines.length,
@@ -130,6 +135,8 @@ export async function writeDeepDreamingReport(params: {
   nowMs?: number;
   timezone?: string;
   storage: MemoryDreamingStorageConfig;
+  outcome?: MemoryDreamOutcome;
+  error?: string;
 }): Promise<string | undefined> {
   const nowMs = resolveMemoryCoreNowMs(params.nowMs);
   const body = params.bodyLines.length > 0 ? params.bodyLines.join("\n") : "- No durable changes.";
@@ -147,6 +154,8 @@ export async function writeDeepDreamingReport(params: {
     type: "memory.dream.completed",
     timestamp: resolveMemoryCoreTimestamp(nowMs),
     phase: "deep",
+    ...(params.outcome ? { outcome: params.outcome } : {}),
+    ...(params.error ? { error: params.error } : {}),
     inlinePath,
     ...(reportPath ? { reportPath } : {}),
     lineCount: params.bodyLines.length,

--- a/extensions/memory-core/src/dreaming.ts
+++ b/extensions/memory-core/src/dreaming.ts
@@ -21,14 +21,14 @@ import {
   resolveMemoryDeepDreamingConfig,
   resolveMemoryDreamingWorkspaces,
 } from "openclaw/plugin-sdk/memory-core-host-status";
+import type { MemoryDreamOutcome } from "openclaw/plugin-sdk/memory-host-events";
+import { appendMemoryHostEvent } from "openclaw/plugin-sdk/memory-host-events";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 import {
   normalizeLowercaseStringOrEmpty,
   uniqueStrings,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { peekSystemEventEntries } from "openclaw/plugin-sdk/system-event-runtime";
-import type { MemoryDreamOutcome } from "openclaw/plugin-sdk/memory-host-events";
-import { appendMemoryHostEvent } from "openclaw/plugin-sdk/memory-host-events";
 import type { NarrativePhaseData } from "./dreaming-narrative.js";
 import {
   formatErrorMessage,
@@ -702,7 +702,7 @@ export async function runShortTermDreamingPromotionIfTriggered(params: {
       // can distinguish failed from successful dreaming runs without parsing logs.
       await appendMemoryHostEvent(workspaceDir, {
         type: "memory.dream.completed",
-        timestamp: resolveMemoryCoreTimestamp(sweepNowMs),
+        timestamp: resolveMemoryCoreTimestamp(Date.now()),
         phase: "deep",
         outcome: "failed" as MemoryDreamOutcome,
         error: errorText,

--- a/extensions/memory-core/src/dreaming.ts
+++ b/extensions/memory-core/src/dreaming.ts
@@ -700,15 +700,23 @@ export async function runShortTermDreamingPromotionIfTriggered(params: {
       );
       // Record the failure in the structured event log so downstream consumers
       // can distinguish failed from successful dreaming runs without parsing logs.
-      await appendMemoryHostEvent(workspaceDir, {
-        type: "memory.dream.completed",
-        timestamp: resolveMemoryCoreTimestamp(Date.now()),
-        phase: "deep",
-        outcome: "failed" as MemoryDreamOutcome,
-        error: errorText,
-        lineCount: 0,
-        storageMode: params.config.storage?.mode ?? "separate",
-      });
+      // Guarded: diagnostic event-log writes must not turn a caught workspace
+      // failure into a rejected trigger that skips later workspaces.
+      try {
+        await appendMemoryHostEvent(workspaceDir, {
+          type: "memory.dream.completed",
+          timestamp: resolveMemoryCoreTimestamp(Date.now()),
+          phase: "deep",
+          outcome: "failed" as MemoryDreamOutcome,
+          error: errorText,
+          lineCount: 0,
+          storageMode: params.config.storage?.mode ?? "separate",
+        });
+      } catch (diagnosticErr) {
+        params.logger.warn(
+          `memory-core: failed to write dreaming outcome event for workspace ${workspaceDir}: ${formatErrorMessage(diagnosticErr)}`,
+        );
+      }
     }
   }
   params.logger.info(

--- a/extensions/memory-core/src/dreaming.ts
+++ b/extensions/memory-core/src/dreaming.ts
@@ -35,7 +35,7 @@ import {
   includesSystemEventToken,
   normalizeTrimmedString,
 } from "./dreaming-shared.js";
-import { resolveMemoryCoreNowMs, resolveMemoryCoreTimestamp } from "./time.js";
+import { resolveMemoryCoreTimestamp } from "./time.js";
 
 const RUNTIME_CRON_RECONCILE_INTERVAL_MS = 60_000;
 const STARTUP_CRON_RETRY_DELAY_MS = 5_000;

--- a/extensions/memory-core/src/dreaming.ts
+++ b/extensions/memory-core/src/dreaming.ts
@@ -27,12 +27,15 @@ import {
   uniqueStrings,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { peekSystemEventEntries } from "openclaw/plugin-sdk/system-event-runtime";
+import type { MemoryDreamOutcome } from "openclaw/plugin-sdk/memory-host-events";
+import { appendMemoryHostEvent } from "openclaw/plugin-sdk/memory-host-events";
 import type { NarrativePhaseData } from "./dreaming-narrative.js";
 import {
   formatErrorMessage,
   includesSystemEventToken,
   normalizeTrimmedString,
 } from "./dreaming-shared.js";
+import { resolveMemoryCoreNowMs, resolveMemoryCoreTimestamp } from "./time.js";
 
 const RUNTIME_CRON_RECONCILE_INTERVAL_MS = 60_000;
 const STARTUP_CRON_RETRY_DELAY_MS = 5_000;
@@ -691,9 +694,21 @@ export async function runShortTermDreamingPromotionIfTriggered(params: {
       }
     } catch (err) {
       failedWorkspaces += 1;
+      const errorText = formatErrorMessage(err);
       params.logger.error(
-        `memory-core: dreaming promotion failed for workspace ${workspaceDir}: ${formatErrorMessage(err)}`,
+        `memory-core: dreaming promotion failed for workspace ${workspaceDir}: ${errorText}`,
       );
+      // Record the failure in the structured event log so downstream consumers
+      // can distinguish failed from successful dreaming runs without parsing logs.
+      await appendMemoryHostEvent(workspaceDir, {
+        type: "memory.dream.completed",
+        timestamp: resolveMemoryCoreTimestamp(sweepNowMs),
+        phase: "deep",
+        outcome: "failed" as MemoryDreamOutcome,
+        error: errorText,
+        lineCount: 0,
+        storageMode: params.config.storage?.mode ?? "separate",
+      });
     }
   }
   params.logger.info(

--- a/extensions/memory-core/src/memory-events.test.ts
+++ b/extensions/memory-core/src/memory-events.test.ts
@@ -6,7 +6,7 @@ import {
   readMemoryHostEvents,
 } from "openclaw/plugin-sdk/memory-host-events";
 import { describe, expect, it } from "vitest";
-import { writeDailyDreamingPhaseBlock } from "./dreaming-markdown.js";
+import { writeDailyDreamingPhaseBlock, writeDeepDreamingReport } from "./dreaming-markdown.js";
 import {
   applyShortTermPromotions,
   rankShortTermPromotionCandidates,
@@ -187,5 +187,73 @@ describe("memory host event journal integration", () => {
     expect(dreamEvent.phase).toBe("light");
     expect(dreamEvent.lineCount).toBe(2);
     expect(dreamEvent.storageMode).toBe("both");
+  });
+
+  it("omits outcome on successful dreaming events when no outcome is provided", async () => {
+    const workspaceDir = await createTempWorkspace("memory-core-dream-outcome-implicit-");
+
+    await writeDailyDreamingPhaseBlock({
+      workspaceDir,
+      phase: "rem",
+      bodyLines: ["- REM insight"],
+      nowMs: Date.UTC(2026, 3, 5, 14, 0, 0),
+      storage: { mode: "inline", separateReports: false },
+    });
+
+    const events = await readMemoryHostEvents({ workspaceDir });
+    expect(events).toHaveLength(1);
+    const dreamEvent = events[0];
+    if (dreamEvent?.type !== "memory.dream.completed") {
+      throw new Error("expected dream completion event");
+    }
+    // Backward-compatible: successful events without explicit outcome omit the field.
+    expect(dreamEvent.outcome).toBeUndefined();
+    expect(dreamEvent.error).toBeUndefined();
+  });
+
+  it("records outcome and error on failed dreaming events", async () => {
+    const workspaceDir = await createTempWorkspace("memory-core-dream-outcome-failed-");
+
+    await writeDailyDreamingPhaseBlock({
+      workspaceDir,
+      phase: "light",
+      bodyLines: [],
+      nowMs: Date.UTC(2026, 3, 5, 13, 0, 0),
+      storage: { mode: "inline", separateReports: false },
+      outcome: "failed",
+      error: "promoted file write rejected: EACCES",
+    });
+
+    const events = await readMemoryHostEvents({ workspaceDir });
+    expect(events).toHaveLength(1);
+    const dreamEvent = events[0];
+    if (dreamEvent?.type !== "memory.dream.completed") {
+      throw new Error("expected dream completion event");
+    }
+    expect(dreamEvent.outcome).toBe("failed");
+    expect(dreamEvent.error).toBe("promoted file write rejected: EACCES");
+    expect(dreamEvent.phase).toBe("light");
+  });
+
+  it("records partial outcome on dreaming events", async () => {
+    const workspaceDir = await createTempWorkspace("memory-core-dream-outcome-partial-");
+
+    await writeDeepDreamingReport({
+      workspaceDir,
+      bodyLines: ["- Partial result"],
+      nowMs: Date.UTC(2026, 3, 5, 13, 0, 0),
+      storage: { mode: "inline", separateReports: false },
+      outcome: "partial",
+    });
+
+    const events = await readMemoryHostEvents({ workspaceDir });
+    expect(events).toHaveLength(1);
+    const dreamEvent = events[0];
+    if (dreamEvent?.type !== "memory.dream.completed") {
+      throw new Error("expected dream completion event");
+    }
+    expect(dreamEvent.outcome).toBe("partial");
+    expect(dreamEvent.error).toBeUndefined();
+    expect(dreamEvent.phase).toBe("deep");
   });
 });

--- a/src/memory-host-sdk/events.ts
+++ b/src/memory-host-sdk/events.ts
@@ -54,11 +54,19 @@ export type MemoryHostPromotionAppliedEvent = {
   }>;
 };
 
+/** Normalized outcome for a dreaming phase run. */
+export type MemoryDreamOutcome = "completed" | "partial" | "failed" | "timed_out";
+
 /** Event emitted after a dreaming phase writes inline memory and/or reports. */
 export type MemoryHostDreamCompletedEvent = {
   type: "memory.dream.completed";
   timestamp: string;
   phase: MemoryDreamingPhaseName;
+  /** Normalized outcome of the dreaming phase run. Absent on events written
+   *  before this field was added; treat missing as "completed". */
+  outcome?: MemoryDreamOutcome;
+  /** Error detail when outcome is not "completed". */
+  error?: string;
   inlinePath?: string;
   reportPath?: string;
   lineCount: number;


### PR DESCRIPTION
## What Problem This Solves

Dreaming phase events (`memory.dream.completed`) currently have no structured way to indicate whether a run succeeded or failed. When a deep-dreaming workspace fails, the error is only logged to console — not recorded in the JSONL event log. Downstream consumers (monitoring, dashboards, alerting) cannot distinguish successful from failed dreaming runs without parsing log text.

Issue: #97690

## Why This Change Was Made

Agent runs have normalized terminal outcomes via `agent-run-terminal-outcome.ts` (7 reasons: completed, hard_timeout, timed_out, cancelled, aborted, blocked, failed). Dreaming events lack an equivalent — this is a gap in observability.

The `MemoryDreamOutcome` type follows the same normalization pattern with 4 states relevant to dreaming: `completed`, `partial`, `failed`, `timed_out`.

## User Impact

- No behavior change for successful runs (outcome field is optional, backward compatible)
- Failed deep-dreaming runs now emit a structured event with `outcome: "failed"` and an `error` field
- Downstream tools can query `memory.dream.completed` events and filter by outcome without parsing logs

## Evidence

### Type-check

```
$ npx tsc --noEmit --skipLibCheck -p extensions/memory-core/tsconfig.json
# 0 errors on modified files (dreaming.ts, dreaming-markdown.ts, events.ts)
```

### Unit tests (6/6 passed)

```
$ pnpm test extensions/memory-core/src/memory-events.test.ts

 ✓ memory host event journal integration > records recall and promotion events from short-term promotion flows
 ✓ memory host event journal integration > records skipped recall events for durable memory hits excluded from short-term promotion
 ✓ memory host event journal integration > records dreaming completion events when phase artifacts are written
 ✓ memory host event journal integration > omits outcome on successful dreaming events when no outcome is provided
 ✓ memory host event journal integration > records outcome and error on failed dreaming events
 ✓ memory host event journal integration > records partial outcome on dreaming events

 Test Files  1 passed (1)
      Tests  6 passed (6)
   Duration  643ms
```

### Dreaming markdown tests (9/9 passed)

```
$ pnpm test extensions/memory-core/src/dreaming-markdown.test.ts

 Test Files  1 passed (1)
      Tests  9 passed (9)
   Duration  284ms
```

### Backward compatibility

The `outcome` field is optional on `MemoryHostDreamCompletedEvent`. Existing event consumers that don't check for it continue to work unchanged. The JSDoc comment documents the backward-compatible default: "treat missing as completed".

### ClawSweeper P2 fix

The failure-event append in the catch block (`dreaming.ts:705`) is wrapped in its own try/catch so diagnostic event-log writes cannot turn a caught workspace failure into a rejected trigger that skips later workspaces.

### Files changed

- `src/memory-host-sdk/events.ts` — Added `MemoryDreamOutcome` type and `outcome`/`error` fields to event type
- `extensions/memory-core/src/dreaming-markdown.ts` — Pass through `outcome`/`error` params to event emissions
- `extensions/memory-core/src/dreaming.ts` — Emit `memory.dream.completed` with `outcome: "failed"` in the deep-dreaming catch block (guarded)
- `extensions/memory-core/src/memory-events.test.ts` — Added 3 tests for outcome normalization (implicit success, failed with error, partial)
