### PR TITLE
fix(discord): bound PluralKit and voice-message JSON response reads to prevent OOM

### DIFF
--- a/extensions/discord/src/pluralkit.test.ts
+++ b/extensions/discord/src/pluralkit.test.ts
@@ -7,6 +7,8 @@ type MockResponse = {
   ok: boolean;
   text: () => Promise<string>;
   json: () => Promise<unknown>;
+  body: null;
+  arrayBuffer: () => Promise<Buffer>;
 };
 
 const buildResponse = (params: { status: number; body?: unknown }): MockResponse => {
@@ -17,6 +19,8 @@ const buildResponse = (params: { status: number; body?: unknown }): MockResponse
     ok: params.status >= 200 && params.status < 300,
     text: async () => textPayload,
     json: async () => body ?? {},
+    body: null,
+    arrayBuffer: async () => Buffer.from(textPayload),
   };
 };
 

--- a/extensions/discord/src/pluralkit.ts
+++ b/extensions/discord/src/pluralkit.ts
@@ -1,6 +1,6 @@
 // Discord plugin module implements pluralkit behavior.
 import { resolveFetch } from "openclaw/plugin-sdk/fetch-runtime";
-import { readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
+import { readProviderJsonResponse, readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
 
 const PLURALKIT_API_BASE = "https://api.pluralkit.me/v2";
 const PLURALKIT_ERROR_BODY_LIMIT_BYTES = 8 * 1024;
@@ -59,5 +59,5 @@ export async function fetchPluralKitMessageInfo(params: {
     const detail = text.trim() ? `: ${text.trim()}` : "";
     throw new Error(`PluralKit API failed (${res.status})${detail}`);
   }
-  return (await res.json()) as PluralKitMessageInfo;
+  return await readProviderJsonResponse<PluralKitMessageInfo>(res, "PluralKit message");
 }

--- a/extensions/discord/src/voice-message.ts
+++ b/extensions/discord/src/voice-message.ts
@@ -22,7 +22,7 @@ import {
 import { MEDIA_FFMPEG_MAX_AUDIO_DURATION_SECS } from "openclaw/plugin-sdk/media-runtime";
 import { unlinkIfExists } from "openclaw/plugin-sdk/media-runtime";
 import { parseStrictFiniteNumber } from "openclaw/plugin-sdk/number-runtime";
-import { readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
+import { readProviderJsonResponse, readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
 import type { RetryRunner } from "openclaw/plugin-sdk/retry-runtime";
 import { writeExternalFileWithinRoot } from "openclaw/plugin-sdk/security-runtime";
 import { fetchWithSsrFGuard, type SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
@@ -351,7 +351,7 @@ async function requestVoiceUploadUrl(params: {
     if (!res.ok) {
       throw await createVoiceRequestError(res, "Upload URL request failed");
     }
-    return (await res.json()) as UploadUrlResponse;
+    return await readProviderJsonResponse<UploadUrlResponse>(res, "discord.voice.upload-url");
   } finally {
     await release();
   }


### PR DESCRIPTION
## Summary

Replace unbounded `res.json()` with `readProviderJsonResponse` (16 MiB cap) in Discord PluralKit message lookup and voice-message upload URL fetch. Both already use `readResponseTextLimited` for error bodies — this extends bounding to the success path.

## Real behavior proof (required for external PRs)

**Behavior addressed**: Unbounded `res.json()` replaced with `readProviderJsonResponse` (16 MiB cap) in two Discord paths.

**Real environment tested**: Linux, Node 22, OpenClaw main @ 87db23e543

**Exact steps or command run after fix**:

```bash
node --import tsx proof-discord.mts
```

**Evidence after fix**:

```
=== PluralKit message ===
  chunks: 17, cancelled: true
  PASS
=== Voice upload URL ===
  chunks: 17, cancelled: true
  PASS

PASS: both Discord read paths bounded at 16 MiB
```

**All existing tests pass**: 4/4 pluralkit, 7/7 voice-message.

**What was not tested**: Live PluralKit API or Discord voice upload endpoint calls.

## Risk

Low. Both files already import from `openclaw/plugin-sdk/provider-http` and use `readResponseTextLimited` for error paths. The 16 MiB cap is the convention across the codebase.
