### PR TITLE
fix(msteams): bound attachment JSON response reads to prevent OOM

### DIFF
--- a/extensions/msteams/src/attachments.graph.test.ts
+++ b/extensions/msteams/src/attachments.graph.test.ts
@@ -412,4 +412,111 @@ describe("msteams graph attachments", () => {
       bufferFromSpy.mockRestore();
     }
   });
+
+  it("bounds Graph main message JSON read and cancels the stream on overflow", async () => {
+    const ONE_MIB = 1024 * 1024;
+    let canceled = false;
+
+    const makeOversizedBody = (): ReadableStream<Uint8Array> => {
+      let pulled = 0;
+      return new ReadableStream<Uint8Array>({
+        pull(controller) {
+          if (pulled >= 32) {
+            controller.close();
+            return;
+          }
+          pulled += 1;
+          controller.enqueue(new Uint8Array(ONE_MIB));
+        },
+        cancel() {
+          canceled = true;
+        },
+      });
+    };
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = resolveRequestUrl(input);
+      if (url === DEFAULT_MESSAGE_URL) {
+        return new Response(makeOversizedBody(), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (url.endsWith("/hostedContents") || url.endsWith("/attachments")) {
+        return createGraphCollectionResponse([]);
+      }
+      return createNotFoundResponse();
+    });
+
+    const warn = vi.fn();
+    const media = await downloadMSTeamsGraphMedia({
+      messageUrl: DEFAULT_MESSAGE_URL,
+      tokenProvider: createTokenProvider(),
+      maxBytes: DEFAULT_MAX_BYTES,
+      fetchFn: asFetchFn(fetchMock),
+      resolveFn: resolvePublicHost,
+      logger: { warn },
+    });
+
+    expect(canceled).toBe(true);
+    expect(media.media).toStrictEqual([]);
+    expect(warn).toHaveBeenCalledWith(
+      "msteams graph message parse failed",
+      expect.objectContaining({
+        error: expect.stringContaining("exceeds") as unknown,
+        messageUrl: DEFAULT_MESSAGE_URL,
+      }),
+    );
+  });
+
+  it("bounds Graph hostedContents collection JSON read and handles overflow gracefully", async () => {
+    const ONE_MIB = 1024 * 1024;
+    let canceled = false;
+
+    const makeOversizedBody = (): ReadableStream<Uint8Array> => {
+      let pulled = 0;
+      return new ReadableStream<Uint8Array>({
+        pull(controller) {
+          if (pulled >= 32) {
+            controller.close();
+            return;
+          }
+          pulled += 1;
+          controller.enqueue(new Uint8Array(ONE_MIB));
+        },
+        cancel() {
+          canceled = true;
+        },
+      });
+    };
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = resolveRequestUrl(input);
+      if (url === DEFAULT_MESSAGE_URL) {
+        return createJsonResponse({ attachments: [] });
+      }
+      if (url.endsWith("/hostedContents")) {
+        return new Response(makeOversizedBody(), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (url.endsWith("/attachments")) {
+        return createGraphCollectionResponse([]);
+      }
+      return createNotFoundResponse();
+    });
+
+    const media = await downloadMSTeamsGraphMedia({
+      messageUrl: DEFAULT_MESSAGE_URL,
+      tokenProvider: createTokenProvider(),
+      maxBytes: DEFAULT_MAX_BYTES,
+      fetchFn: asFetchFn(fetchMock),
+      resolveFn: resolvePublicHost,
+    });
+
+    expect(canceled).toBe(true);
+    expect(media.hostedCount).toBe(0);
+    expect(media.media).toStrictEqual([]);
+  });
 });

--- a/extensions/msteams/src/attachments/bot-framework.test.ts
+++ b/extensions/msteams/src/attachments/bot-framework.test.ts
@@ -514,6 +514,57 @@ describe("downloadMSTeamsBotFrameworkAttachment", () => {
         { status: 500 },
       ]);
     });
+
+    it("bounds attachmentInfo JSON read and cancels the stream on overflow", async () => {
+      const ONE_MIB = 1024 * 1024;
+      let canceled = false;
+
+      const makeOversizedBody = (): ReadableStream<Uint8Array> => {
+        let pulled = 0;
+        return new ReadableStream<Uint8Array>({
+          pull(controller) {
+            if (pulled >= 32) {
+              controller.close();
+              return;
+            }
+            pulled += 1;
+            controller.enqueue(new Uint8Array(ONE_MIB));
+          },
+          cancel() {
+            canceled = true;
+          },
+        });
+      };
+
+      const warn = vi.fn();
+      const logger = { warn };
+      const fetchFn = createMockFetch([
+        {
+          match: /\/v3\/attachments\/att-oversized$/,
+          response: new Response(makeOversizedBody(), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+        },
+      ]);
+
+      const media = await downloadMSTeamsBotFrameworkAttachment({
+        serviceUrl: "https://smba.trafficmanager.net/amer",
+        attachmentId: "att-oversized",
+        tokenProvider: buildTokenProvider(),
+        maxBytes: 10_000_000,
+        fetchFn,
+        resolveFn: resolvePublicHost,
+        logger,
+      });
+
+      expect(canceled).toBe(true);
+      expect(media).toBeUndefined();
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(firstMockCall(warn, "logger.warn")[0]).toBe(
+        "msteams botFramework attachmentInfo parse failed",
+      );
+    });
   });
 });
 

--- a/extensions/msteams/src/attachments/bot-framework.ts
+++ b/extensions/msteams/src/attachments/bot-framework.ts
@@ -1,5 +1,6 @@
 // Msteams plugin module implements bot framework behavior.
 import { parseMediaContentLength } from "openclaw/plugin-sdk/media-runtime";
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import { getMSTeamsRuntime } from "../runtime.js";
 import { ensureUserAgentHeader } from "../user-agent.js";
 import {
@@ -112,7 +113,10 @@ async function fetchBotFrameworkAttachmentInfo(params: {
     return undefined;
   }
   try {
-    return (await response.json()) as BotFrameworkAttachmentInfo;
+    return await readProviderJsonResponse<BotFrameworkAttachmentInfo>(
+      response,
+      "msteams.botFramework.attachmentInfo",
+    );
   } catch (err) {
     params.logger?.warn?.("msteams botFramework attachmentInfo parse failed", {
       error: err instanceof Error ? err.message : String(err),

--- a/extensions/msteams/src/attachments/graph.ts
+++ b/extensions/msteams/src/attachments/graph.ts
@@ -1,4 +1,5 @@
 // Msteams plugin module implements graph behavior.
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import { fetchWithSsrFGuard, type SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
 import {
   normalizeLowercaseStringOrEmpty,
@@ -143,7 +144,10 @@ async function fetchGraphCollection(params: {
       return { status, items: [] };
     }
     try {
-      const data = (await response.json()) as { value?: unknown[] };
+      const data = await readProviderJsonResponse<{ value?: unknown[] }>(
+        response,
+        "msteams.graph.collection",
+      );
       return { status, items: Array.isArray(data.value) ? data.value : [] };
     } catch {
       return { status, items: [] };
@@ -345,7 +349,10 @@ export async function downloadMSTeamsGraphMedia(params: {
           attachments?: GraphAttachment[];
         };
         try {
-          msgData = (await msgRes.json()) as typeof msgData;
+          msgData = await readProviderJsonResponse<typeof msgData>(
+            msgRes,
+            "msteams.graph.message",
+          );
         } catch (err) {
           debugLog?.debug?.("graph media message parse failed", {
             messageUrl,


### PR DESCRIPTION
## Summary

Replace unbounded `response.json()` with `readProviderJsonResponse` (16 MiB cap) in MSTeams Bot Framework attachment info fetch and Graph collection fetch. Both already have try-catch error handling — this adds size bounding to the JSON parse path.

## Real behavior proof (required for external PRs)

**Behavior addressed**: Unbounded `response.json()` replaced with `readProviderJsonResponse` (16 MiB cap) in two MSTeams attachment paths.

**Real environment tested**: Linux, Node 22, OpenClaw main @ 87db23e543

**Exact steps or command run after fix**:

```bash
node --import tsx proof-msteams.mts
```

**Evidence after fix**:

```
=== Bot Framework attachmentInfo ===
  chunks: 17, cancelled: true
  PASS
=== Graph collection ===
  chunks: 17, cancelled: true
  PASS

PASS: both MSTeams read paths bounded at 16 MiB
```

**All existing tests pass**: 31/31 tests (bot-framework + graph).

**What was not tested**: Live Bot Framework v3 attachments API or Microsoft Graph API calls.

## Risk

Low. Both functions already have try-catch that returns `undefined` or `{ status, items: [] }` on errors. The overflow error from `readProviderJsonResponse` is caught by the existing catch blocks, preserving the same graceful degradation.
