### PR TITLE
fix(msteams): bound graph-upload JSON response reads to prevent OOM

### DIFF
--- a/extensions/msteams/src/graph-upload.test.ts
+++ b/extensions/msteams/src/graph-upload.test.ts
@@ -247,6 +247,37 @@ describe("resolveGraphChatId", () => {
 
     expect(result).toBeNull();
   });
+
+  it("rejects oversized OneDrive upload responses and cancels the stream", async () => {
+    const cancel = vi.fn();
+    const stream = new ReadableStream<Uint8Array>({
+      cancel,
+      start(controller) {
+        const ONE_MIB = 1024 * 1024;
+        for (let i = 0; i < 18; i++) {
+          controller.enqueue(new Uint8Array(ONE_MIB));
+        }
+        controller.close();
+      },
+    });
+    const fetchFn = vi.fn(
+      async () =>
+        new Response(stream, {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+
+    await expect(
+      uploadToOneDrive({
+        buffer: Buffer.from("x"),
+        filename: "a.txt",
+        tokenProvider,
+        fetchFn,
+      }),
+    ).rejects.toThrow("msteams.graph.oneDriveUpload: JSON response exceeds");
+    expect(cancel).toHaveBeenCalledOnce();
+  });
 });
 
 describe("buildTeamsFileInfoCard", () => {
@@ -285,4 +316,5 @@ describe("buildTeamsFileInfoCard", () => {
       },
     });
   });
+
 });

--- a/extensions/msteams/src/graph-upload.ts
+++ b/extensions/msteams/src/graph-upload.ts
@@ -11,6 +11,7 @@
 
 import type { MSTeamsAccessTokenProvider } from "./attachments/types.js";
 import { createMSTeamsHttpError } from "./http-error.js";
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import { buildUserAgent } from "./user-agent.js";
 
 const GRAPH_ROOT = "https://graph.microsoft.com/v1.0";
@@ -54,11 +55,11 @@ export async function uploadToOneDrive(params: {
     throw await createMSTeamsHttpError(res, "OneDrive upload failed");
   }
 
-  const data = (await res.json()) as {
+  const data = await readProviderJsonResponse<{
     id?: string;
     webUrl?: string;
     name?: string;
-  };
+  }>(res, "msteams.graph.oneDriveUpload");
 
   if (!data.id || !data.webUrl || !data.name) {
     throw new Error("OneDrive upload response missing required fields");
@@ -106,9 +107,9 @@ async function createSharingLink(params: {
     throw await createMSTeamsHttpError(res, "Create sharing link failed");
   }
 
-  const data = (await res.json()) as {
+  const data = await readProviderJsonResponse<{
     link?: { webUrl?: string };
-  };
+  }>(res, "msteams.graph.createSharingLink");
 
   if (!data.link?.webUrl) {
     throw new Error("Create sharing link response missing webUrl");
@@ -200,11 +201,11 @@ export async function uploadToSharePoint(params: {
     throw await createMSTeamsHttpError(res, "SharePoint upload failed");
   }
 
-  const data = (await res.json()) as {
+  const data = await readProviderJsonResponse<{
     id?: string;
     webUrl?: string;
     name?: string;
-  };
+  }>(res, "msteams.graph.sharePointUpload");
 
   if (!data.id || !data.webUrl || !data.name) {
     throw new Error("SharePoint upload response missing required fields");
@@ -260,11 +261,11 @@ export async function getDriveItemProperties(params: {
     throw await createMSTeamsHttpError(res, "Get driveItem properties failed");
   }
 
-  const data = (await res.json()) as {
+  const data = await readProviderJsonResponse<{
     eTag?: string;
     webDavUrl?: string;
     name?: string;
-  };
+  }>(res, "msteams.graph.getDriveItem");
 
   if (!data.eTag || !data.webDavUrl || !data.name) {
     throw new Error("DriveItem response missing required properties (eTag, webDavUrl, or name)");
@@ -331,9 +332,9 @@ export async function resolveGraphChatId(params: {
     return null;
   }
 
-  const data = (await res.json()) as {
+  const data = await readProviderJsonResponse<{
     value?: Array<{ id?: string }>;
-  };
+  }>(res, "msteams.graph.listChats");
 
   const chats = data.value ?? [];
 
@@ -371,12 +372,12 @@ async function getChatMembers(params: {
     throw await createMSTeamsHttpError(res, "Get chat members failed");
   }
 
-  const data = (await res.json()) as {
+  const data = await readProviderJsonResponse<{
     value?: Array<{
       userId?: string;
       displayName?: string;
     }>;
-  };
+  }>(res, "msteams.graph.getChatMembers");
 
   return (data.value ?? [])
     .map((m) => ({
@@ -435,9 +436,9 @@ async function createSharePointSharingLink(params: {
     throw await createMSTeamsHttpError(res, "Create SharePoint sharing link failed");
   }
 
-  const data = (await res.json()) as {
+  const data = await readProviderJsonResponse<{
     link?: { webUrl?: string };
-  };
+  }>(res, "msteams.graph.createSharePointSharingLink");
 
   if (!data.link?.webUrl) {
     throw new Error("Create SharePoint sharing link response missing webUrl");


### PR DESCRIPTION
## What Problem This Solves

Replace 7 unbounded `res.json()` calls with `readProviderJsonResponse` (16 MiB cap) in MSTeams OneDrive/SharePoint upload, sharing link, driveItem properties, chat listing, and chat member fetch paths. Without a bound, an oversized or malicious JSON response can OOM the process.

## Why This Change Was Made

All JSON response reads from external HTTP endpoints should use `readProviderJsonResponse` or `readResponseWithLimit` to prevent unbounded memory consumption. This is the same pattern already used in `bot-framework.ts` and `graph.ts`.

## User Impact

MS Teams file upload, SharePoint sharing, chat resolution, and member fetching are now protected against oversized JSON responses. No functional change for normal-sized responses.

## Evidence

**Environment**: Linux, Node 22, OpenClaw main

**All existing tests pass** (12/12 in graph-upload.test.ts):
```
 ✓ graph upload helpers > uploads to OneDrive with the personal drive path
 ✓ graph upload helpers > uploads to SharePoint with the site drive path
 ✓ graph upload helpers > rejects upload responses missing required fields
 ✓ graph upload helpers > bounds upload error bodies without requiring response.text()
 ✓ resolveGraphChatId > returns the ID directly when it already starts with 19:
 ✓ resolveGraphChatId > resolves personal DM chat ID via Graph API using user AAD object ID
 ✓ resolveGraphChatId > resolves personal DM chat ID without user AAD object ID (lists all 1:1 chats)
 ✓ resolveGraphChatId > returns null when Graph API returns no chats
 ✓ resolveGraphChatId > returns null when Graph API call fails
 ✓ resolveGraphChatId > rejects oversized OneDrive upload responses and cancels the stream
 ✓ buildTeamsFileInfoCard > extracts a unique id from quoted etags and lowercases file extensions
 ✓ buildTeamsFileInfoCard > keeps the raw etag when no version suffix exists and handles extensionless files
```

**Oversized response test** proves stream cancellation on 18 MiB payload:
```ts
const stream = new ReadableStream<Uint8Array>({ cancel, start(controller) {
  for (let i = 0; i < 18; i++) controller.enqueue(new Uint8Array(ONE_MIB));
}});
// bounded reader throws "JSON response exceeds 16 MiB", stream is cancelled
```

**Bundle lint**: clean.

## Risk

Low. Same `readProviderJsonResponse` helper already used in `bot-framework.ts` and `graph.ts`. Pure replacement with 16 MiB cap matching codebase convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)