### PR TITLE
[codex] fix native subagent completion retry cap

### DIFF
--- a/extensions/codex/src/app-server/native-subagent-monitor.test.ts
+++ b/extensions/codex/src/app-server/native-subagent-monitor.test.ts
@@ -1286,6 +1286,128 @@ describe("CodexNativeSubagentMonitor", () => {
     }
   });
 
+  it("uses every configured completion retry delay before a durable parent handoff", async () => {
+    vi.useFakeTimers();
+    try {
+      const client = createClient();
+      const runtime = createRuntime();
+      runtime.deliverAgentHarnessTaskCompletion
+        .mockResolvedValueOnce({
+          delivered: false,
+          path: "direct" as const,
+          error: "completion handoff is still pending",
+        })
+        .mockResolvedValueOnce({
+          delivered: false,
+          path: "direct" as const,
+          error: "completion handoff is still pending",
+        })
+        .mockResolvedValueOnce({
+          delivered: true,
+          path: "direct" as const,
+          phases: [{ phase: "direct-primary" as const, delivered: true, path: "direct" as const }],
+        });
+      const monitor = new CodexNativeSubagentMonitor(client, runtime, {
+        completionDeliveryRetryDelaysMs: [10, 20],
+      });
+      monitor.registerParent({
+        parentThreadId: "parent-thread",
+        requesterSessionKey: "agent:main:discord:channel:C123",
+        taskRuntimeScope: createTaskScope(),
+        agentId: "main",
+      });
+
+      await notifyChildStarted(client);
+      await client.notify(
+        nativeCompletionNotification({
+          agentPath: "child-thread",
+          statusLabel: "completed",
+          result: "child final result",
+        }),
+      );
+
+      expect(runtime.deliverAgentHarnessTaskCompletion).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(10);
+      expect(runtime.deliverAgentHarnessTaskCompletion).toHaveBeenCalledTimes(2);
+
+      await vi.advanceTimersByTimeAsync(20);
+      expect(runtime.deliverAgentHarnessTaskCompletion).toHaveBeenCalledTimes(3);
+      expect(runtime.setDetachedTaskDeliveryStatusByRunId).toHaveBeenCalledWith(
+        expect.objectContaining({
+          runId: "codex-thread:child-thread",
+          deliveryStatus: "delivered",
+        }),
+      );
+      expect(runtime.setDetachedTaskDeliveryStatusByRunId).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          runId: "codex-thread:child-thread",
+          deliveryStatus: "failed",
+        }),
+      );
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(runtime.deliverAgentHarnessTaskCompletion).toHaveBeenCalledTimes(3);
+
+      client.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("fails completion delivery after exhausting retries on permanently non-durable handoff", async () => {
+    vi.useFakeTimers();
+    try {
+      const client = createClient();
+      const runtime = createRuntime();
+      runtime.deliverAgentHarnessTaskCompletion.mockResolvedValue({
+        delivered: false,
+        path: "direct" as const,
+        error: "completion delivery did not produce a parent response",
+      });
+      const monitor = new CodexNativeSubagentMonitor(client, runtime, {
+        completionDeliveryRetryDelaysMs: [10, 20],
+      });
+      monitor.registerParent({
+        parentThreadId: "parent-thread",
+        requesterSessionKey: "agent:main:discord:channel:C123",
+        taskRuntimeScope: createTaskScope(),
+        agentId: "main",
+      });
+
+      await notifyChildStarted(client);
+      await client.notify(
+        nativeCompletionNotification({
+          agentPath: "child-thread",
+          statusLabel: "completed",
+          result: "child final result",
+        }),
+      );
+
+      expect(runtime.deliverAgentHarnessTaskCompletion).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(10);
+      expect(runtime.deliverAgentHarnessTaskCompletion).toHaveBeenCalledTimes(2);
+
+      await vi.advanceTimersByTimeAsync(20);
+      expect(runtime.deliverAgentHarnessTaskCompletion).toHaveBeenCalledTimes(3);
+      expect(runtime.setDetachedTaskDeliveryStatusByRunId).toHaveBeenCalledWith(
+        expect.objectContaining({
+          runId: "codex-thread:child-thread",
+          deliveryStatus: "failed",
+          error: expect.stringContaining("retry schedule exhausted"),
+        }),
+      );
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(runtime.deliverAgentHarnessTaskCompletion).toHaveBeenCalledTimes(3);
+
+      client.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("reconciles completed native subagents from child rollout transcripts", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-subagent-"));
     const codexHome = path.join(tempDir, "codex-home");

--- a/extensions/codex/src/app-server/native-subagent-monitor.ts
+++ b/extensions/codex/src/app-server/native-subagent-monitor.ts
@@ -614,15 +614,47 @@ export class CodexNativeSubagentMonitor {
     });
   }
 
+  private markCompletionDeliveryFailed(
+    completion: CodexNativeSubagentCompletion,
+    error: string,
+  ): void {
+    const taskRuntime = this.getTaskRuntimeForChild(completion.childThreadId);
+    if (!taskRuntime) {
+      return;
+    }
+    taskRuntime.setDetachedTaskDeliveryStatusByRunId({
+      runId: codexNativeSubagentRunId(completion.childThreadId),
+      deliveryStatus: "failed",
+      error,
+    });
+  }
+
   private scheduleCompletionDeliveryRetry(childState: ChildState): void {
     if (!childState.pendingCompletion || childState.completionDeliveryTimer) {
       return;
     }
     const attempt = childState.completionDeliveryAttempt;
-    const delayMs =
-      this.completionDeliveryRetryDelaysMs[
-        Math.min(attempt, this.completionDeliveryRetryDelaysMs.length - 1)
-      ];
+    const delayMs = this.completionDeliveryRetryDelaysMs[attempt];
+    // completionDeliveryAttempt tracks scheduled retries. Once every configured
+    // delay has been consumed, settle the handoff instead of clamping forever.
+    if (delayMs === undefined) {
+      const completion = childState.pendingCompletion;
+      const deliveryAttempts = childState.completionDeliveryAttempt + 1;
+      const error =
+        `completion delivery abandoned after ${deliveryAttempts} failed attempts; ` +
+        "retry schedule exhausted";
+      childState.pendingCompletion = undefined;
+      childState.pendingCompletionEventAt = undefined;
+      childState.completionDeliveryAttempt = 0;
+      this.markCompletionDeliveryFailed(completion, error);
+      embeddedAgentLog.warn("Codex native subagent completion delivery abandoned", {
+        parentThreadId: childState.parentThreadId,
+        childThreadId: completion.childThreadId,
+        attempts: deliveryAttempts,
+        error,
+      });
+      return;
+    }
     childState.completionDeliveryAttempt += 1;
     childState.completionDeliveryTimer = setTimeout(() => {
       childState.completionDeliveryTimer = undefined;


### PR DESCRIPTION
## What Problem This Solves

Fixes #97593.

Codex native subagent completion delivery could retry forever when the parent handoff was permanently non-durable. The monitor marked the completion pending, called `deliverAgentHarnessTaskCompletion`, and on every non-durable result scheduled another retry. The retry counter only selected a delay with a clamped array index, so once it reached the final configured delay it re-fired every 300 seconds indefinitely, waking and re-running the parent agent forever.

## Why This Change Was Made

The fix keeps ownership inside the Codex plugin monitor and does not add public config or SDK surface. `completionDeliveryRetryDelaysMs` remains the single retry policy: each configured delay is consumed exactly once, and once the schedule is exhausted the pending completion is cleared and its task delivery status is marked `failed` with a diagnostic error.

This intentionally avoids the two sharp edges from the open candidate PRs:

- It does not add a separate max-attempt option for a plugin-local scheduler.
- It does not skip the final configured retry delay; the default six-delay schedule still uses the 300 second final delay before giving up.

The failed terminal state mirrors the existing task delivery vocabulary and gives maintainers/logs a visible end state instead of leaving the child completion pending forever.

## User Impact

Users running Codex native multi-agent sessions will no longer get an unbounded parent wake/re-run loop when a subagent completion cannot durably reach the parent. Transient failures still retry through the configured schedule and can still become delivered. Permanently non-durable failures settle as failed after the schedule is exhausted, preventing repeated parent reruns every five minutes.

## Evidence

Commands run on this branch:

```text
pnpm -s exec oxfmt --check extensions/codex/src/app-server/native-subagent-monitor.ts extensions/codex/src/app-server/native-subagent-monitor.test.ts
git diff --check
pnpm changed:lanes --json
node scripts/run-vitest.mjs extensions/codex/src/app-server/native-subagent-monitor.test.ts
node scripts/run-vitest.mjs src/plugin-sdk/agent-harness-task-runtime.test.ts
pnpm test:changed
.agents/skills/autoreview/scripts/autoreview --mode local
```

Observed results:

```text
native-subagent-monitor.test.ts: 35 tests passed
agent-harness-task-runtime.test.ts: 6 tests passed
pnpm test:changed: 35 tests passed
changed lanes: extensions=true, extensionTests=true, all other lanes false
autoreview clean: no accepted/actionable findings reported
```

Regression coverage added:

- Durable-on-final-retry path: a handoff that is non-durable twice and durable on the second configured retry is delivered, and is not marked failed.
- Permanent non-durable path: a handoff with a two-delay schedule attempts initial + two retries, marks delivery `failed` with a retry-schedule-exhausted error, and does not invoke the parent delivery again after more timer advancement.

Dependency/Codex contract checked:

- `src/plugin-sdk/agent-harness-task-runtime.ts` durable-delivery predicate returns false for `delivered: false` and true only for durable direct/steered delivery.
- Sibling Codex source confirms native subagent activity/completion signals are upstream protocol/runtime events, while OpenClaw owns the monitor retry and parent-handoff policy: `../codex/codex-rs/app-server-protocol/schema/typescript/v2/ThreadItem.ts`, `../codex/codex-rs/protocol/src/protocol.rs`, `../codex/codex-rs/core/src/tools/handlers/multi_agents_v2/spawn.rs`.

**Screenshot evidence**: The attached terminal screenshot shows `node scripts/run-vitest.mjs extensions/codex/src/app-server/native-subagent-monitor.test.ts --reporter=verbose` passing with the new retry-exhaustion and final-retry delivery regressions included in the 35-test Codex native subagent monitor suite.
<img width="1367" height="720" alt="image" src="https://github.com/user-attachments/assets/6d9b3189-4cb5-42f6-8374-b01d21d19d00" />

Screenshot evidence shows a real OpenClaw Gateway + Codex app-server run on d31cb1ba using the local Codex OAuth bootstrap: an aborted-parent Codex native subagent completion stayed pending through the configured retry schedule and then reached deliveryStatus: failed with retry schedule exhausted, rather than retrying indefinitely.
<img width="1600" height="5694" alt="image" src="https://github.com/user-attachments/assets/5676da4f-44df-45bc-bd07-098eae522ee1" />

