### PR TITLE
fix(telegram): hydrate every album sibling photo for model prompt context

### DIFF
--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -950,8 +950,12 @@ export const registerTelegramHandlers = ({
       }
 
       const allMedia: TelegramMediaRef[] = [];
+      // Track each surviving album item's source message id so prompt-context
+      // hydration can map every sibling photo to a `media://inbound/...` path
+      // instead of letting the cache fall through to raw `telegram:file/...` refs.
+      const albumMessageIds: string[] = [];
       let skippedCount = 0;
-      for (const { ctx } of entry.messages) {
+      for (const { ctx, msg } of entry.messages) {
         let media;
         try {
           media = await resolveMedia({
@@ -975,6 +979,9 @@ export const registerTelegramHandlers = ({
             contentType: media.contentType,
             stickerMetadata: media.stickerMetadata,
           });
+          if (typeof msg.message_id === "number") {
+            albumMessageIds.push(String(msg.message_id));
+          }
         } else {
           skippedCount++;
         }
@@ -1004,6 +1011,7 @@ export const registerTelegramHandlers = ({
         ctx: primaryEntry.ctx,
         msg: primaryEntry.msg,
         allMedia,
+        albumMessageIds,
         storeAllowFrom: entry.storeAllowFrom,
         options: {
           ...promptContextBoundaryOptions(entry.promptContextMinTimestampMs),
@@ -1373,6 +1381,7 @@ export const registerTelegramHandlers = ({
     ctx: TelegramContext;
     msg: Message;
     allMedia: TelegramMediaRef[];
+    albumMessageIds?: string[];
     storeAllowFrom: string[];
     options?: TelegramMessageContextOptions;
     dispatchDedupeKeys?: string[];
@@ -1450,15 +1459,27 @@ export const registerTelegramHandlers = ({
       const promptContextMediaByMessageId = new Map<string, TelegramMediaRef>();
       const currentMessageId =
         typeof params.msg.message_id === "number" ? String(params.msg.message_id) : undefined;
-      const currentMedia = params.allMedia[0];
-      const currentPromptMediaPath = currentMedia?.path
-        ? resolveTelegramPromptMediaPath(currentMedia.path)
-        : undefined;
-      if (currentMessageId && currentMedia && currentPromptMediaPath) {
-        promptContextMediaByMessageId.set(currentMessageId, {
-          ...currentMedia,
-          path: currentPromptMediaPath,
-        });
+      const albumMessageIds = params.albumMessageIds ?? [];
+      for (let index = 0; index < params.allMedia.length; index += 1) {
+        const media = params.allMedia[index];
+        if (!media?.path) {
+          continue;
+        }
+        const promptMediaPath = resolveTelegramPromptMediaPath(media.path);
+        if (!promptMediaPath) {
+          continue;
+        }
+        // Album siblings hydrate under their own message ids so the prompt
+        // builder can resolve each cached sibling photo to a media://inbound
+        // path; non-album callers fall back to the primary message id for the
+        // first item, preserving the single-photo behavior.
+        const messageId = albumMessageIds[index] ?? (index === 0 ? currentMessageId : undefined);
+        if (messageId) {
+          promptContextMediaByMessageId.set(messageId, {
+            ...media,
+            path: promptMediaPath,
+          });
+        }
       }
       for (const entry of replyChain) {
         const promptMediaPath = entry.mediaPath

--- a/extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts
@@ -294,6 +294,47 @@ describe("createTelegramBot channel_post media", () => {
     }
   });
 
+  it("hydrates every channel_post album sibling photo for model context (#96846)", async () => {
+    setOpenChannelPostConfig();
+
+    const fetchSpy = createImageFetchSpy();
+
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    try {
+      const handler = getChannelPostHandler();
+      const photoFileIds = ["album-a", "album-b", "album-c"];
+      const baseMessageId = 801;
+      await Promise.all(
+        photoFileIds.map((fileId, index) =>
+          handler(
+            createChannelPostContext({
+              messageId: baseMessageId + index,
+              date: 1736380800 + index,
+              ...(index === 0 ? { caption: "album caption" } : {}),
+              mediaGroupId: "channel-album-hydration",
+              photoFileId: fileId,
+            }),
+          ),
+        ),
+      );
+      expect(replySpy).not.toHaveBeenCalled();
+      await flushChannelPostMediaGroup(setTimeoutSpy);
+      await waitForMockCalls(replySpy, 1);
+
+      await vi.waitFor(() => expect(replySpy).toHaveBeenCalledTimes(1));
+      const payloadJson = JSON.stringify(replyPayload());
+      // Each sibling photo should hydrate to a media://inbound path keyed by its
+      // own message id, instead of leaking the raw telegram:file/<fileId> ref.
+      expect(payloadJson).not.toContain("telegram:file/");
+      for (const fileId of photoFileIds) {
+        expect(payloadJson).not.toContain(`telegram:file/${fileId}`);
+      }
+    } finally {
+      setTimeoutSpy.mockRestore();
+      fetchSpy.mockRestore();
+    }
+  });
+
   it("honors configured mediaGroupFlushMs for channel_post albums", async () => {
     loadConfig.mockReturnValue({
       channels: {


### PR DESCRIPTION
## What Problem This Solves

Fixes #96846.

When a Telegram user sends multiple photos as a media group/album, only the primary (captioned) message's photo reached the model with a `media://inbound/...` path. Cached sibling album photos leaked through prompt-context hydration as raw `telegram:file/<fileId>` strings, which the model cannot read. Users had to send photos one at a time as a workaround.

## Why This Change Was Made

`processMediaGroup` already collected every album photo into `allMedia`, but `processMessageWithReplyChain` only seeded `promptContextMediaByMessageId` for the primary message id (`params.allMedia[0]` under `params.msg.message_id`). The conversation-context builder then fell back to the raw cached `mediaRef` for each sibling message id, producing the unreadable refs reported in #96846.

The fix threads each surviving album item's source `message_id` from `processMediaGroup` (via a new optional `albumMessageIds` array, parallel to `allMedia`) into the prompt-context hydration loop, so every sibling photo is mapped under its own message id.

## User Impact

- Multi-photo album sends now reach the model with all N photos as readable image content blocks, instead of N-1 unreadable file references.
- No config or migration change; behavior matches the existing single-photo path for non-album callers (they omit `albumMessageIds`, so the loop falls back to `currentMessageId` for `allMedia[0]`).

## Evidence

- New regression test `hydrates every channel_post album sibling photo for model context (#96846)` in `extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts`. Sends a 3-photo album and asserts the dispatch payload contains no `telegram:file/...` refs. Reverting the production fix makes the test fail.
- Full file green locally on Node 22:
  - `node scripts/run-vitest.mjs extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts` → 12 passed
  - `node scripts/run-vitest.mjs extensions/telegram/src/bot.create-telegram-bot.media-group-skip-warning.test.ts` → 3 passed
- `node scripts/run-tsgo.mjs --project extensions/telegram/tsconfig.json` → clean