### PR TITLE
fix(apps): reconcile slow Apple chat replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Apple chat slow replies:** keep iOS and macOS chat runs pending through slow first replies and reconnect/history gaps by separating request deadlines from Gateway run policy and reconciling terminal state from canonical history. (#97722) Thanks @zhangguiping-xydt.
 - **Gateway service audit:** treat POSIX shell `-c` wrappers as opaque for the gateway-subcommand check, avoiding false missing-command warnings for shell-wrapped macOS LaunchAgents without parsing inner commands or ports. Fixes #81751. (#81778) Thanks @liaoandi.
 - **Memory filename search:** index paths separately from chunk bodies so exact full-path, basename, and stem queries rank the intended memory file first without changing body BM25 scores, snippets, or embeddings. (#96052, #94102) Thanks @Pick-cat.
 - **Outbound channel bootstrap:** suppress repeated failed plugin activation for the same channel, config, and registry generation while retrying after config or registry reloads. (#100377) Thanks @xialonglee.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Apple chat slow replies:** keep iOS and macOS chat runs pending through slow first replies and reconnect/history gaps by separating request deadlines from Gateway run policy and reconciling terminal state from canonical history. (#97722) Thanks @zhangguiping-xydt.
 - **Gateway service audit:** treat POSIX shell `-c` wrappers as opaque for the gateway-subcommand check, avoiding false missing-command warnings for shell-wrapped macOS LaunchAgents without parsing inner commands or ports. Fixes #81751. (#81778) Thanks @liaoandi.
 - **Memory filename search:** index paths separately from chunk bodies so exact full-path, basename, and stem queries rank the intended memory file first without changing body BM25 scores, snippets, or embeddings. (#96052, #94102) Thanks @Pick-cat.
 - **Outbound channel bootstrap:** suppress repeated failed plugin activation for the same channel, config, and registry generation while retrying after config or registry reloads. (#100377) Thanks @xialonglee.

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -6755,7 +6755,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 350,
+      "line": 356,
       "path": "apps/ios/Sources/Chat/AppleReviewDemoChatTransport.swift",
       "source": "\\\"\\(trimmed)\\\"",
       "surface": "apple",
@@ -6763,7 +6763,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 350,
+      "line": 356,
       "path": "apps/ios/Sources/Chat/AppleReviewDemoChatTransport.swift",
       "source": "that request",
       "surface": "apple",
@@ -23507,7 +23507,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 673,
+      "line": 671,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Sending.swift",
       "source": "delivery unconfirmed",
       "surface": "apple",
@@ -23515,7 +23515,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 673,
+      "line": 671,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Sending.swift",
       "source": "queued after route change",
       "surface": "apple",
@@ -23523,7 +23523,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1176,
+      "line": 1181,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift",
       "source": "Remove attachments or wait for delivery to resolve before switching chats.",
       "surface": "apple",
@@ -23531,7 +23531,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1232,
+      "line": 1237,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift",
       "source": "Remove attachments or wait for delivery to resolve before starting a new chat.",
       "surface": "apple",

--- a/apps/ios/Sources/Chat/AppleReviewDemoChatTransport.swift
+++ b/apps/ios/Sources/Chat/AppleReviewDemoChatTransport.swift
@@ -197,8 +197,11 @@ struct LocalFixtureChatTransport: OpenClawChatTransport {
         true
     }
 
-    func waitForRunCompletion(runId _: String, timeoutMs _: Int) async -> Bool {
-        true
+    func waitForRunCompletion(
+        runId _: String,
+        timeoutMs _: Int) async -> OpenClawChatRunObservation
+    {
+        .terminal(.completed)
     }
 
     func events() -> AsyncStream<OpenClawChatTransportEvent> {
@@ -291,7 +294,10 @@ struct AppleReviewDemoChatTransport: OpenClawChatTransport {
         try await self.transport.requestHealth(timeoutMs: timeoutMs)
     }
 
-    func waitForRunCompletion(runId: String, timeoutMs: Int) async -> Bool {
+    func waitForRunCompletion(
+        runId: String,
+        timeoutMs: Int) async -> OpenClawChatRunObservation
+    {
         await self.transport.waitForRunCompletion(runId: runId, timeoutMs: timeoutMs)
     }
 

--- a/apps/ios/Sources/Chat/IOSGatewayChatTransport.swift
+++ b/apps/ios/Sources/Chat/IOSGatewayChatTransport.swift
@@ -6,7 +6,7 @@ import OSLog
 
 struct IOSGatewayChatTransport: OpenClawChatTransport {
     static let logger = Logger(subsystem: "ai.openclawfoundation.app", category: "ios.chat.transport")
-    static let defaultChatSendTimeoutMs = 30000
+    static let chatSendRequestTimeoutSeconds = 30
     static let compactionRequestTimeoutSeconds = 0
     private let gateway: GatewayNodeSession
     private let globalAgentId: String?
@@ -98,7 +98,7 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
         var message: String
         var thinking: String
         var attachments: [OpenClawChatAttachmentPayload]?
-        var timeoutMs: Int
+        var timeoutMs: Int?
         var idempotencyKey: String
     }
 
@@ -116,22 +116,16 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
     private struct AgentWaitResponse: Codable {
         var runId: String?
         var status: String?
+        var startedAt: Double?
+        var endedAt: Double?
         var error: String?
-    }
-
-    struct AgentWaitCompletion: Equatable {
-        var runId: String
-        var status: String
-        var completed: Bool
-    }
-
-    static func isAgentWaitCompletionStatus(_ status: String) -> Bool {
-        switch status.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
-        case "ok", "completed", "success", "succeeded":
-            true
-        default:
-            false
-        }
+        var stopReason: String?
+        var livenessState: String?
+        var yielded: Bool?
+        var pendingError: Bool?
+        var timeoutPhase: String?
+        var providerStarted: Bool?
+        var aborted: Bool?
     }
 
     init(
@@ -265,7 +259,7 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
             message: message,
             thinking: thinking,
             attachments: attachments.isEmpty ? nil : attachments,
-            timeoutMs: self.defaultChatSendTimeoutMs,
+            timeoutMs: nil,
             idempotencyKey: idempotencyKey)
         return try self.encodeParams(params)
     }
@@ -289,13 +283,19 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
         return agentID.isEmpty ? nil : agentID
     }
 
-    static func decodeAgentWaitCompletion(_ data: Data, fallbackRunId: String) throws -> AgentWaitCompletion {
+    static func decodeAgentWaitObservation(_ data: Data) throws -> OpenClawChatRunObservation {
         let decoded = try JSONDecoder().decode(AgentWaitResponse.self, from: data)
-        let status = (decoded.status ?? "unknown").lowercased()
-        return AgentWaitCompletion(
-            runId: decoded.runId ?? fallbackRunId,
-            status: status,
-            completed: self.isAgentWaitCompletionStatus(status))
+        return OpenClawChatRunObservation.fromWaitResponse(
+            status: decoded.status,
+            endedAt: decoded.endedAt,
+            error: decoded.error,
+            stopReason: decoded.stopReason,
+            livenessState: decoded.livenessState,
+            yielded: decoded.yielded,
+            pendingError: decoded.pendingError,
+            timeoutPhase: decoded.timeoutPhase,
+            providerStarted: decoded.providerStarted,
+            aborted: decoded.aborted)
     }
 
     static func decodeModelChoices(_ data: Data) throws -> [OpenClawChatModelChoice] {
@@ -696,7 +696,7 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
             let res = try await gateway.request(
                 method: "chat.send",
                 paramsJSON: json,
-                timeoutSeconds: 35,
+                timeoutSeconds: Self.chatSendRequestTimeoutSeconds,
                 ifCurrentRoute: expectedRoute,
                 distinguishPreDispatchRouteChange: distinguishPreDispatchRouteChange)
             let decoded = try JSONDecoder().decode(OpenClawChatSendResponse.self, from: res)
@@ -745,20 +745,24 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
             acceptsArgs: entry.acceptsargs)
     }
 
-    func waitForRunCompletion(runId rawRunId: String, timeoutMs: Int) async -> Bool {
-        await self.waitForRunCompletion(
+    func waitForRunCompletion(
+        runId rawRunId: String,
+        timeoutMs: Int) async -> OpenClawChatRunObservation
+    {
+        let route = await self.gateway.currentRoute()
+        return await self.waitForRunCompletion(
             runId: rawRunId,
             timeoutMs: timeoutMs,
-            ifCurrentRoute: nil)
+            ifCurrentRoute: route)
     }
 
     func waitForRunCompletion(
         runId rawRunId: String,
         timeoutMs: Int,
-        ifCurrentRoute expectedRoute: GatewayNodeSessionRoute?) async -> Bool
+        ifCurrentRoute expectedRoute: GatewayNodeSessionRoute?) async -> OpenClawChatRunObservation
     {
         let runId = rawRunId.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !runId.isEmpty else { return false }
+        guard !runId.isEmpty, let expectedRoute else { return .unavailable }
 
         do {
             let json = try Self.makeAgentWaitParamsJSON(runId: runId, timeoutMs: timeoutMs)
@@ -769,17 +773,13 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
                 paramsJSON: json,
                 timeoutSeconds: requestTimeoutSeconds,
                 ifCurrentRoute: expectedRoute)
-            let completion = try Self.decodeAgentWaitCompletion(res, fallbackRunId: runId)
-            GatewayDiagnostics.log("agent.wait completed runId=\(completion.runId) status=\(completion.status)")
-            if !completion.completed {
-                Self.logger.warning(
-                    "agent.wait status \(completion.status, privacy: .public) runId=\(runId, privacy: .public)")
-            }
-            return completion.completed
+            let observation = try Self.decodeAgentWaitObservation(res)
+            GatewayDiagnostics.log("agent.wait completed runId=\(runId) observation=\(observation)")
+            return observation
         } catch {
             Self.logger.warning("agent.wait failed \(error.localizedDescription, privacy: .public)")
             GatewayDiagnostics.log("agent.wait failed runId=\(runId) error=\(error.localizedDescription)")
-            return false
+            return .unavailable
         }
     }
 

--- a/apps/ios/Tests/IOSGatewayChatTransportTests.swift
+++ b/apps/ios/Tests/IOSGatewayChatTransportTests.swift
@@ -34,15 +34,6 @@ struct IOSGatewayChatTransportTests {
         return try #require(value as? [String: Any])
     }
 
-    @Test func `agent wait treats success as completion`() {
-        #expect(IOSGatewayChatTransport.isAgentWaitCompletionStatus("success"))
-        #expect(IOSGatewayChatTransport.isAgentWaitCompletionStatus(" ok "))
-        #expect(IOSGatewayChatTransport.isAgentWaitCompletionStatus("completed"))
-        #expect(IOSGatewayChatTransport.isAgentWaitCompletionStatus("succeeded"))
-        #expect(!IOSGatewayChatTransport.isAgentWaitCompletionStatus("timeout"))
-        #expect(!IOSGatewayChatTransport.isAgentWaitCompletionStatus("failed"))
-    }
-
     @Test func `agent wait timeout adds gateway margin`() {
         #expect(IOSGatewayChatTransport.agentWaitRequestTimeoutSeconds(timeoutMs: 1) == 6)
         #expect(IOSGatewayChatTransport.agentWaitRequestTimeoutSeconds(timeoutMs: 1000) == 6)
@@ -53,12 +44,26 @@ struct IOSGatewayChatTransportTests {
         #expect(IOSGatewayChatTransport.compactionRequestTimeoutSeconds == 0)
     }
 
-    @Test func `agent wait completion decodes fallback run id`() throws {
+    @Test func `agent wait distinguishes terminal and retryable timeouts`() throws {
         let data = Data(#"{"status":"completed"}"#.utf8)
-        let completion = try IOSGatewayChatTransport.decodeAgentWaitCompletion(data, fallbackRunId: "run-local")
-        #expect(completion.runId == "run-local")
-        #expect(completion.status == "completed")
-        #expect(completion.completed)
+        #expect(try IOSGatewayChatTransport.decodeAgentWaitObservation(data) == .terminal(.completed))
+
+        let pending = Data(#"{"status":"pending"}"#.utf8)
+        #expect(try IOSGatewayChatTransport.decodeAgentWaitObservation(pending) == .checkAgain)
+
+        let queued = Data(#"{"status":"timeout","timeoutPhase":"queue","providerStarted":false}"#.utf8)
+        #expect(try IOSGatewayChatTransport.decodeAgentWaitObservation(queued) == .checkAgain)
+
+        let providerTimeout = Data(
+            #"{"status":"timeout","timeoutPhase":"provider","providerStarted":true}"#.utf8)
+        #expect(
+            try IOSGatewayChatTransport.decodeAgentWaitObservation(providerTimeout) ==
+                .terminal(.failed(message: "Run timed out")))
+
+        let stopped = Data(#"{"status":"timeout","stopReason":"stop"}"#.utf8)
+        #expect(
+            try IOSGatewayChatTransport.decodeAgentWaitObservation(stopped) ==
+                .terminal(.failed(message: "Run cancelled")))
     }
 
     @Test func `model patch result decodes authoritative Luna thinking state`() throws {
@@ -254,7 +259,7 @@ struct IOSGatewayChatTransportTests {
         #expect(params["message"] as? String == "hello")
         #expect(params["thinking"] as? String == "low")
         #expect(params["idempotencyKey"] as? String == "send-1")
-        #expect(params["timeoutMs"] as? Int == IOSGatewayChatTransport.defaultChatSendTimeoutMs)
+        #expect(params["timeoutMs"] == nil)
         #expect(params["attachments"] == nil)
     }
 

--- a/apps/macos/Sources/OpenClaw/GatewayConnection.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnection.swift
@@ -1493,7 +1493,8 @@ extension GatewayConnection {
         thinking: String?,
         idempotencyKey: String,
         attachments: [OpenClawChatAttachmentPayload],
-        timeoutMs: Int = 30000,
+        runTimeoutMs: Int? = nil,
+        requestTimeoutMs: Int = 30000,
         ifCurrentRoute route: Route? = nil,
         distinguishPreDispatchRouteChange: Bool = false) async throws -> OpenClawChatSendResponse
     {
@@ -1502,8 +1503,10 @@ extension GatewayConnection {
             "sessionKey": AnyCodable(resolvedKey),
             "message": AnyCodable(message),
             "idempotencyKey": AnyCodable(idempotencyKey),
-            "timeoutMs": AnyCodable(timeoutMs),
         ]
+        if let runTimeoutMs {
+            params["timeoutMs"] = AnyCodable(runTimeoutMs)
+        }
         if let agentID = agentID?.trimmingCharacters(in: .whitespacesAndNewlines), !agentID.isEmpty {
             params["agentId"] = AnyCodable(agentID)
         }
@@ -1535,12 +1538,15 @@ extension GatewayConnection {
             let data = try await request(
                 method: Method.chatSend.rawValue,
                 params: params,
-                timeoutMs: Double(timeoutMs),
+                timeoutMs: Double(requestTimeoutMs),
                 ifCurrentRoute: route,
                 distinguishPreDispatchRouteChange: distinguishPreDispatchRouteChange)
             return try self.decoder.decode(OpenClawChatSendResponse.self, from: data)
         }
-        return try await self.requestDecoded(method: .chatSend, params: params, timeoutMs: Double(timeoutMs))
+        return try await self.requestDecoded(
+            method: .chatSend,
+            params: params,
+            timeoutMs: Double(requestTimeoutMs))
     }
 
     func chatAbort(sessionKey: String, runId: String) async throws -> Bool {

--- a/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
+++ b/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
@@ -19,6 +19,19 @@ private enum WebChatSwiftUILayout {
 }
 
 struct MacGatewayChatTransport: OpenClawChatTransport {
+    private struct AgentWaitResponse: Decodable {
+        var status: String?
+        var endedAt: Double?
+        var error: String?
+        var stopReason: String?
+        var livenessState: String?
+        var yielded: Bool?
+        var pendingError: Bool?
+        var timeoutPhase: String?
+        var providerStarted: Bool?
+        var aborted: Bool?
+    }
+
     /// Shared across transport value copies so the live view model and its
     /// snapshot observer cannot diverge on the owner of the bare global alias.
     private final class RoutingIdentity: @unchecked Sendable {
@@ -392,6 +405,42 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
 
     func requestHealth(timeoutMs: Int) async throws -> Bool {
         try await GatewayConnection.shared.healthOK(timeoutMs: timeoutMs)
+    }
+
+    func waitForRunCompletion(
+        runId rawRunId: String,
+        timeoutMs: Int) async -> OpenClawChatRunObservation
+    {
+        let runId = rawRunId.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !runId.isEmpty,
+              let route = await GatewayConnection.shared.captureRoute()
+        else { return .unavailable }
+        do {
+            let data = try await GatewayConnection.shared.request(
+                method: "agent.wait",
+                params: [
+                    "runId": AnyCodable(runId),
+                    "timeoutMs": AnyCodable(timeoutMs),
+                ],
+                timeoutMs: Double(timeoutMs + 5000),
+                ifCurrentRoute: route)
+            let decoded = try JSONDecoder().decode(AgentWaitResponse.self, from: data)
+            return OpenClawChatRunObservation.fromWaitResponse(
+                status: decoded.status,
+                endedAt: decoded.endedAt,
+                error: decoded.error,
+                stopReason: decoded.stopReason,
+                livenessState: decoded.livenessState,
+                yielded: decoded.yielded,
+                pendingError: decoded.pendingError,
+                timeoutPhase: decoded.timeoutPhase,
+                providerStarted: decoded.providerStarted,
+                aborted: decoded.aborted)
+        } catch {
+            webChatSwiftLogger.warning(
+                "agent.wait failed runId=\(runId, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
+            return .unavailable
+        }
     }
 
     func resetSession(sessionKey: String) async throws {

--- a/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
+++ b/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
@@ -438,7 +438,8 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
                 aborted: decoded.aborted)
         } catch {
             webChatSwiftLogger.warning(
-                "agent.wait failed runId=\(runId, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
+                "agent.wait failed runId=\(runId, privacy: .public) "
+                    + "error=\(error.localizedDescription, privacy: .public)")
             return .unavailable
         }
     }

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayConnectionControlTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayConnectionControlTests.swift
@@ -680,6 +680,7 @@ private func makeTestGatewayConnection() -> (GatewayConnection, FakeWebSocketSes
         let params = json?["params"] as? [String: Any]
         #expect(params?["thinking"] == nil)
         #expect(params?["expectedSessionRoutingContract"] as? String == "per-sender|main|main")
+        #expect(params?["timeoutMs"] == nil)
     }
 
     @Test func `routing identity decodes agent and contract from one response`() throws {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTransport.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTransport.swift
@@ -113,6 +113,98 @@ public enum OpenClawChatTransportUpgradeMessage {
         "Update the gateway before sending queued messages. This version requires safe delivery routing."
 }
 
+public enum OpenClawChatRunTerminalState: Sendable, Equatable {
+    case completed
+    case failed(message: String)
+}
+
+public enum OpenClawChatRunObservation: Sendable, Equatable {
+    case terminal(OpenClawChatRunTerminalState)
+    case checkAgain
+    case unavailable
+
+    public static func fromWaitResponse(
+        status: String?,
+        endedAt: Double? = nil,
+        error: String? = nil,
+        stopReason: String? = nil,
+        livenessState: String? = nil,
+        yielded: Bool? = nil,
+        pendingError: Bool? = nil,
+        timeoutPhase: String? = nil,
+        providerStarted: Bool? = nil,
+        aborted: Bool? = nil) -> Self
+    {
+        let status = Self.normalized(status)
+        if status == "pending" {
+            return .checkAgain
+        }
+        if ["ok", "completed", "success", "succeeded"].contains(status) {
+            return .terminal(.completed)
+        }
+        if [
+            "error", "failed", "aborted", "cancelled", "canceled", "killed", "timed_out",
+        ].contains(status) {
+            return .terminal(.failed(message: Self.failureMessage(
+                status: status,
+                error: error,
+                stopReason: stopReason,
+                aborted: aborted)))
+        }
+        guard status == "timeout" else { return .unavailable }
+        guard pendingError != true else { return .checkAgain }
+
+        let timeoutPhase = Self.normalized(timeoutPhase)
+        let stopReason = Self.normalized(stopReason)
+        let terminalTimeout = ["preflight", "provider", "post_turn"].contains(timeoutPhase) ||
+            ["timeout", "timed_out"].contains(stopReason) ||
+            endedAt != nil ||
+            !Self.normalized(error).isEmpty ||
+            !stopReason.isEmpty ||
+            !Self.normalized(livenessState).isEmpty ||
+            yielded == true ||
+            aborted == true ||
+            (providerStarted == true && timeoutPhase != "queue" && timeoutPhase != "gateway_draining")
+        return terminalTimeout
+            ? .terminal(.failed(message: Self.failureMessage(
+                status: status,
+                error: error,
+                stopReason: stopReason,
+                aborted: aborted)))
+            : .checkAgain
+    }
+
+    private static func normalized(_ value: String?) -> String {
+        (value ?? "").trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+
+    private static func failureMessage(
+        status: String,
+        error: String?,
+        stopReason: String?,
+        aborted: Bool?) -> String
+    {
+        if let error = error?.trimmingCharacters(in: .whitespacesAndNewlines), !error.isEmpty {
+            return error
+        }
+        let stopReason = Self.normalized(stopReason)
+        if aborted == true || status == "aborted" || stopReason == "aborted" {
+            return "Run aborted"
+        }
+        if ["cancelled", "canceled", "killed"].contains(status) ||
+            ["cancelled", "canceled", "killed", "restart", "rpc", "stop", "user"].contains(stopReason)
+        {
+            return "Run cancelled"
+        }
+        if status == "timeout" || status == "timed_out" ||
+            stopReason == "timeout" || stopReason == "timed_out"
+        {
+            return "Run timed out"
+        }
+        return "Chat failed"
+    }
+}
+
 public protocol OpenClawChatTransport: Sendable {
     func createSession(
         key: String,
@@ -166,7 +258,7 @@ public protocol OpenClawChatTransport: Sendable {
     func setSessionThinking(sessionKey: String, thinkingLevel: String) async throws
 
     func requestHealth(timeoutMs: Int) async throws -> Bool
-    func waitForRunCompletion(runId: String, timeoutMs: Int) async -> Bool
+    func waitForRunCompletion(runId: String, timeoutMs: Int) async -> OpenClawChatRunObservation
     func events() -> AsyncStream<OpenClawChatTransportEvent>
 
     func setActiveSessionKey(_ sessionKey: String) async throws
@@ -226,8 +318,8 @@ extension OpenClawChatTransport {
 
     public func setActiveSessionKey(_: String) async throws {}
 
-    public func waitForRunCompletion(runId _: String, timeoutMs _: Int) async -> Bool {
-        false
+    public func waitForRunCompletion(runId _: String, timeoutMs _: Int) async -> OpenClawChatRunObservation {
+        .unavailable
     }
 
     public func resetSession(sessionKey _: String) async throws {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Sending.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Sending.swift
@@ -470,7 +470,6 @@ extension OpenClawChatViewModel {
         let runId = UUID().uuidString
         let storedThinkingLevel = self.preferredThinkingLevel
         self.pendingRuns.insert(runId)
-        self.armPendingRunTimeout(runId: runId)
         self.logDiagnostic(
             "chat.ui send queued sessionKey=\(draft.session.key) "
                 + "localRunId=\(runId) pending=\(self.pendingRunCount)")
@@ -618,11 +617,7 @@ extension OpenClawChatViewModel {
                 runId: response.runId,
                 after: attempt.userMessageTimestamp)
         {
-            self.armPostSendRefreshFallback(
-                runId: response.runId,
-                sessionSnapshot: attempt.draft.session,
-                userMessageTimestamp: attempt.userMessageTimestamp)
-            self.armRunCompletionRefresh(
+            self.armPendingRunOwner(
                 runId: response.runId,
                 sessionSnapshot: attempt.draft.session,
                 userMessageTimestamp: attempt.userMessageTimestamp)
@@ -650,7 +645,10 @@ extension OpenClawChatViewModel {
             self.pendingToolCallsById = [:]
             self.updateStreamingAssistantText(nil)
         } else {
-            self.armPendingRunTimeout(runId: remoteRunId)
+            self.armPendingRunOwner(
+                runId: remoteRunId,
+                sessionSnapshot: remoteRunScope.session,
+                userMessageTimestamp: remoteRunScope.latestUserTurn?.timestamp)
         }
         return reusedRunAlreadyFinal
     }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+TransportEvents.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+TransportEvents.swift
@@ -729,7 +729,7 @@ extension OpenClawChatViewModel {
         }
     }
 
-    nonisolated private static func runPendingRunOwner(
+    private nonisolated static func runPendingRunOwner(
         owner: PendingRunOwnerReference,
         runId: String,
         sessionSnapshot: SessionSnapshot,
@@ -760,7 +760,7 @@ extension OpenClawChatViewModel {
         }
     }
 
-    nonisolated private static func observePendingRunCompletion(
+    private nonisolated static func observePendingRunCompletion(
         owner: PendingRunOwnerReference,
         runId: String,
         sessionSnapshot: SessionSnapshot,
@@ -865,7 +865,7 @@ extension OpenClawChatViewModel {
         }
     }
 
-    nonisolated private static func pollPendingRunHistory(
+    private nonisolated static func pollPendingRunHistory(
         owner: PendingRunOwnerReference,
         runId: String,
         sessionSnapshot: SessionSnapshot,

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+TransportEvents.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+TransportEvents.swift
@@ -4,6 +4,15 @@ import OSLog
 
 private let transportEventsLogger = Logger(subsystem: "ai.openclaw", category: "OpenClawChatUI")
 
+@MainActor
+private final class PendingRunOwnerReference {
+    weak var value: OpenClawChatViewModel?
+
+    init(_ value: OpenClawChatViewModel) {
+        self.value = value
+    }
+}
+
 extension OpenClawChatViewModel {
     func handleTransportEvent(_ evt: OpenClawChatTransportEvent) {
         switch evt {
@@ -376,63 +385,43 @@ extension OpenClawChatViewModel {
         self.pendingLocalUserEchoMessageIDsByRunID[runId] = nil
     }
 
-    func armPostSendRefreshFallback(
-        runId: String,
-        sessionSnapshot: SessionSnapshot,
-        userMessageTimestamp: Double)
-    {
-        Task { [weak self] in
-            for delayMs in Self.postSendRefreshDelaysMs {
-                try? await Task.sleep(nanoseconds: delayMs * 1_000_000)
-                let shouldContinue = await self?.refreshIfPending(
-                    runId: runId,
-                    sessionSnapshot: sessionSnapshot,
-                    after: userMessageTimestamp,
-                    diagnostic: "chat.ui refresh fallback sessionKey=\(sessionSnapshot.key) "
-                        + "runId=\(runId) delayMs=\(delayMs)")
-                guard shouldContinue == true else {
-                    return
-                }
-            }
-        }
-    }
-
-    func armRunCompletionRefresh(
-        runId: String,
-        sessionSnapshot: SessionSnapshot,
-        userMessageTimestamp: Double)
-    {
-        let timeoutMs = Int(pendingRunTimeoutMs)
-        let transport = self.transport
-        Task { [weak self, transport] in
-            let observedCompletion = await transport.waitForRunCompletion(runId: runId, timeoutMs: timeoutMs)
-            guard observedCompletion else { return }
-            _ = await self?.refreshIfPending(
-                runId: runId,
-                sessionSnapshot: sessionSnapshot,
-                after: userMessageTimestamp,
-                diagnostic: "chat.ui run completion refresh sessionKey=\(sessionSnapshot.key) "
-                    + "runId=\(runId)")
-        }
-    }
-
     private func refreshIfPending(
         runId: String,
         sessionSnapshot: SessionSnapshot,
-        after timestamp: Double,
+        armID: UInt64? = nil,
+        after timestamp: Double?,
+        terminalState: OpenClawChatRunTerminalState? = nil,
+        allowNoOutputCompletion: Bool = false,
         diagnostic: String) async -> Bool
     {
-        guard self.isCurrentSession(sessionSnapshot),
-              self.pendingRuns.contains(runId)
+        guard self.isCurrentPendingRunOwner(
+            runId: runId,
+            sessionSnapshot: sessionSnapshot,
+            armID: armID)
         else {
             return false
         }
         self.logDiagnostic(diagnostic)
         let historyContext = self.beginHistoryRequest(for: sessionSnapshot)
         let refresh = await refreshHistoryAfterRun(historyRequest: historyContext)
-        guard self.isCurrentSession(sessionSnapshot),
-              self.pendingRuns.contains(runId)
+        guard self.isCurrentPendingRunOwner(
+            runId: runId,
+            sessionSnapshot: sessionSnapshot,
+            armID: armID)
         else { return false }
+        if case let .failed(message)? = terminalState {
+            if refresh.applied,
+               let timestamp,
+               self.clearPendingRunIfAssistantMessagePresent(runId: runId, after: timestamp)
+            {
+                return false
+            }
+            self.errorText = message
+            self.clearPendingRun(runId, hapticEvent: .runFailed)
+            self.pendingToolCallsById = [:]
+            self.updateStreamingAssistantText(nil)
+            return false
+        }
         if refresh.applied, refresh.runSnapshotApplied, refresh.supportsInFlightRunState {
             if refresh.hasInFlightRun {
                 return true
@@ -446,12 +435,52 @@ extension OpenClawChatViewModel {
                 self.updateStreamingAssistantText(nil)
                 return true
             }
-            self.clearPendingRun(runId)
-            self.pendingToolCallsById = [:]
-            self.updateStreamingAssistantText(nil)
+            if let timestamp,
+               self.clearPendingRunIfAssistantMessagePresent(runId: runId, after: timestamp)
+            {
+                return false
+            }
+            if terminalState == .completed, allowNoOutputCompletion {
+                self.finishPendingRun(runId: runId, terminalState: .completed)
+                return false
+            }
+            return true
+        }
+        if refresh.applied, terminalState == .completed, allowNoOutputCompletion {
+            if let timestamp,
+               self.clearPendingRunIfAssistantMessagePresent(runId: runId, after: timestamp)
+            {
+                return false
+            }
+            self.finishPendingRun(runId: runId, terminalState: .completed)
             return false
         }
+        guard let timestamp else { return true }
         return !self.clearPendingRunIfAssistantMessagePresent(runId: runId, after: timestamp)
+    }
+
+    private func finishPendingRun(runId: String, terminalState: OpenClawChatRunTerminalState) {
+        let hapticEvent: OpenClawChatHaptics.Event
+        switch terminalState {
+        case .completed:
+            hapticEvent = .runCompleted
+        case let .failed(message):
+            self.errorText = message
+            hapticEvent = .runFailed
+        }
+        self.clearPendingRun(runId, hapticEvent: hapticEvent)
+        self.pendingToolCallsById = [:]
+        self.updateStreamingAssistantText(nil)
+    }
+
+    private func isCurrentPendingRunOwner(
+        runId: String,
+        sessionSnapshot: SessionSnapshot,
+        armID: UInt64?) -> Bool
+    {
+        self.isCurrentSession(sessionSnapshot) &&
+            self.pendingRuns.contains(runId) &&
+            (armID == nil || self.pendingRunOwnerArmIDs[runId] == armID)
     }
 
     @discardableResult
@@ -673,32 +702,235 @@ extension OpenClawChatViewModel {
         }
     }
 
-    func armPendingRunTimeout(runId: String) {
-        self.pendingRunTimeoutTasks[runId]?.cancel()
-        self.nextPendingRunTimeoutArmID &+= 1
-        let armID = self.nextPendingRunTimeoutArmID
-        self.pendingRunTimeoutArmIDs[runId] = armID
-        self.pendingRunTimeoutTasks[runId] = Task { [weak self] in
-            let timeoutMs = await MainActor.run { self?.pendingRunTimeoutMs ?? 0 }
+    func armPendingRunOwner(
+        runId: String,
+        sessionSnapshot: SessionSnapshot? = nil,
+        userMessageTimestamp: Double? = nil)
+    {
+        self.pendingRunOwnerTasks[runId]?.cancel()
+        self.nextPendingRunOwnerArmID &+= 1
+        let armID = self.nextPendingRunOwnerArmID
+        let scope = self.runMessageScopesByRunID[runId]
+        let session = sessionSnapshot ?? scope?.session ?? self.currentSessionSnapshot()
+        let timestamp = userMessageTimestamp ?? scope?.latestUserTurn?.timestamp
+        self.pendingRunOwnerArmIDs[runId] = armID
+        // One arm owns both completion waits and history polling. Rearms cancel
+        // every child so stale route/session results cannot retire a successor run.
+        let owner = PendingRunOwnerReference(self)
+        let transport = self.transport
+        self.pendingRunOwnerTasks[runId] = Task {
+            await Self.runPendingRunOwner(
+                owner: owner,
+                runId: runId,
+                sessionSnapshot: session,
+                userMessageTimestamp: timestamp,
+                armID: armID,
+                transport: transport)
+        }
+    }
+
+    nonisolated private static func runPendingRunOwner(
+        owner: PendingRunOwnerReference,
+        runId: String,
+        sessionSnapshot: SessionSnapshot,
+        userMessageTimestamp: Double?,
+        armID: UInt64,
+        transport: any OpenClawChatTransport) async
+    {
+        await withTaskGroup(of: Void.self) { group in
+            group.addTask {
+                await Self.observePendingRunCompletion(
+                    owner: owner,
+                    runId: runId,
+                    sessionSnapshot: sessionSnapshot,
+                    userMessageTimestamp: userMessageTimestamp,
+                    armID: armID,
+                    transport: transport)
+            }
+            group.addTask {
+                await Self.pollPendingRunHistory(
+                    owner: owner,
+                    runId: runId,
+                    sessionSnapshot: sessionSnapshot,
+                    userMessageTimestamp: userMessageTimestamp,
+                    armID: armID)
+            }
+            _ = await group.next()
+            group.cancelAll()
+        }
+    }
+
+    nonisolated private static func observePendingRunCompletion(
+        owner: PendingRunOwnerReference,
+        runId: String,
+        sessionSnapshot: SessionSnapshot,
+        userMessageTimestamp: Double?,
+        armID: UInt64,
+        transport: any OpenClawChatTransport) async
+    {
+        var terminalState: OpenClawChatRunTerminalState?
+        var completedObservedAtMs: Double?
+        while let timeoutMs = await Self.pendingRunWaitTimeout(
+            owner: owner,
+            runId: runId,
+            sessionSnapshot: sessionSnapshot,
+            armID: armID)
+        {
+            let observation = await transport.waitForRunCompletion(
+                runId: runId,
+                timeoutMs: timeoutMs)
+            if case let .terminal(observedTerminalState) = observation {
+                terminalState = observedTerminalState
+                if observedTerminalState == .completed, completedObservedAtMs == nil {
+                    completedObservedAtMs = Date().timeIntervalSince1970 * 1000
+                }
+            }
+            let effectiveObservation = terminalState.map(OpenClawChatRunObservation.terminal) ?? observation
+            guard let retryDelayMs = await Self.processPendingRunObservation(
+                owner: owner,
+                runId: runId,
+                sessionSnapshot: sessionSnapshot,
+                userMessageTimestamp: userMessageTimestamp,
+                armID: armID,
+                observation: effectiveObservation,
+                completedObservedAtMs: completedObservedAtMs)
+            else { return }
             do {
-                try await Task.sleep(nanoseconds: timeoutMs * 1_000_000)
+                try await Task.sleep(nanoseconds: retryDelayMs * 1_000_000)
             } catch {
-                // Rearming or completing a run cancels this task. Never let the
-                // retired timeout clear the still-active replacement owner.
                 return
             }
-            guard !Task.isCancelled else { return }
-            await MainActor.run { [weak self] in
-                guard let self else { return }
-                guard self.pendingRunTimeoutArmIDs[runId] == armID else { return }
-                guard self.pendingRuns.contains(runId) else { return }
-                self.logDiagnostic(
-                    "chat.ui pending timeout sessionKey=\(self.sessionKey) "
-                        + "runId=\(runId)")
-                self.errorText = "Timed out waiting for a reply; try again or refresh."
-                self.clearPendingRun(runId, hapticEvent: .runFailed)
-            }
         }
+    }
+
+    private static func pendingRunWaitTimeout(
+        owner: PendingRunOwnerReference,
+        runId: String,
+        sessionSnapshot: SessionSnapshot,
+        armID: UInt64) -> Int?
+    {
+        guard let model = owner.value,
+              model.isCurrentPendingRunOwner(
+                  runId: runId,
+                  sessionSnapshot: sessionSnapshot,
+                  armID: armID)
+        else { return nil }
+        return Int(model.pendingRunWaitTimeoutMs)
+    }
+
+    private static func processPendingRunObservation(
+        owner: PendingRunOwnerReference,
+        runId: String,
+        sessionSnapshot: SessionSnapshot,
+        userMessageTimestamp: Double?,
+        armID: UInt64,
+        observation: OpenClawChatRunObservation,
+        completedObservedAtMs: Double?) async -> UInt64?
+    {
+        guard let model = owner.value,
+              model.isCurrentPendingRunOwner(
+                  runId: runId,
+                  sessionSnapshot: sessionSnapshot,
+                  armID: armID)
+        else { return nil }
+        switch observation {
+        case let .terminal(terminalState):
+            let terminalAgeMs = completedObservedAtMs.map {
+                (Date().timeIntervalSince1970 * 1000) - $0
+            }
+            let allowNoOutputCompletion = terminalAgeMs.map {
+                $0 >= Double(model.pendingRunTerminalHistoryGraceMs)
+            } ?? false
+            let shouldContinue = await model.refreshIfPending(
+                runId: runId,
+                sessionSnapshot: sessionSnapshot,
+                armID: armID,
+                after: userMessageTimestamp,
+                terminalState: terminalState,
+                allowNoOutputCompletion: allowNoOutputCompletion,
+                diagnostic: "chat.ui run observation sessionKey=\(sessionSnapshot.key) "
+                    + "runId=\(runId) observation=\(observation)")
+            return shouldContinue ? model.pendingRunTerminalRetryMs : nil
+        case .checkAgain:
+            let shouldContinue = await model.refreshIfPending(
+                runId: runId,
+                sessionSnapshot: sessionSnapshot,
+                armID: armID,
+                after: userMessageTimestamp,
+                diagnostic: "chat.ui run observation sessionKey=\(sessionSnapshot.key) "
+                    + "runId=\(runId) observation=\(observation)")
+            return shouldContinue ? model.pendingRunTerminalRetryMs : nil
+        case .unavailable:
+            return model.pendingRunUnavailableRetryMs
+        }
+    }
+
+    nonisolated private static func pollPendingRunHistory(
+        owner: PendingRunOwnerReference,
+        runId: String,
+        sessionSnapshot: SessionSnapshot,
+        userMessageTimestamp: Double?,
+        armID: UInt64) async
+    {
+        var delayIndex = 0
+        while let delayMs = await Self.pendingRunRefreshDelay(
+            owner: owner,
+            runId: runId,
+            sessionSnapshot: sessionSnapshot,
+            armID: armID,
+            delayIndex: delayIndex)
+        {
+            delayIndex += 1
+            do {
+                try await Task.sleep(nanoseconds: delayMs * 1_000_000)
+            } catch {
+                return
+            }
+            let shouldContinue = await Self.refreshPendingRunOwner(
+                owner: owner,
+                runId: runId,
+                sessionSnapshot: sessionSnapshot,
+                armID: armID,
+                after: userMessageTimestamp,
+                diagnostic: "chat.ui pending refresh sessionKey=\(sessionSnapshot.key) "
+                    + "runId=\(runId) delayMs=\(delayMs)")
+            guard shouldContinue else { return }
+        }
+    }
+
+    private static func pendingRunRefreshDelay(
+        owner: PendingRunOwnerReference,
+        runId: String,
+        sessionSnapshot: SessionSnapshot,
+        armID: UInt64,
+        delayIndex: Int) -> UInt64?
+    {
+        guard let model = owner.value,
+              model.isCurrentPendingRunOwner(
+                  runId: runId,
+                  sessionSnapshot: sessionSnapshot,
+                  armID: armID)
+        else { return nil }
+        return delayIndex < model.pendingRunRefreshDelaysMs.count
+            ? model.pendingRunRefreshDelaysMs[delayIndex]
+            : model.pendingRunSteadyRefreshDelayMs
+    }
+
+    private static func refreshPendingRunOwner(
+        owner: PendingRunOwnerReference,
+        runId: String,
+        sessionSnapshot: SessionSnapshot,
+        armID: UInt64,
+        after timestamp: Double?,
+        diagnostic: String) async -> Bool
+    {
+        guard let model = owner.value else { return false }
+        return await model.refreshIfPending(
+            runId: runId,
+            sessionSnapshot: sessionSnapshot,
+            armID: armID,
+            after: timestamp,
+            diagnostic: diagnostic)
     }
 
     func clearPendingRun(
@@ -708,9 +940,9 @@ extension OpenClawChatViewModel {
         let wasPending = self.pendingRuns.contains(runId)
         self.pendingRuns.remove(runId)
         self.pendingLocalUserEchoMessageIDsByRunID[runId] = nil
-        self.pendingRunTimeoutTasks[runId]?.cancel()
-        self.pendingRunTimeoutTasks[runId] = nil
-        self.pendingRunTimeoutArmIDs[runId] = nil
+        self.pendingRunOwnerTasks[runId]?.cancel()
+        self.pendingRunOwnerTasks[runId] = nil
+        self.pendingRunOwnerArmIDs[runId] = nil
         if wasPending {
             self.logDiagnostic(
                 "chat.ui pending cleared sessionKey=\(self.sessionKey) "
@@ -727,10 +959,10 @@ extension OpenClawChatViewModel {
     {
         let runIds = Array(pendingRuns)
         for runId in self.pendingRuns {
-            self.pendingRunTimeoutTasks[runId]?.cancel()
+            self.pendingRunOwnerTasks[runId]?.cancel()
         }
-        self.pendingRunTimeoutTasks.removeAll()
-        self.pendingRunTimeoutArmIDs.removeAll()
+        self.pendingRunOwnerTasks.removeAll()
+        self.pendingRunOwnerArmIDs.removeAll()
         self.pendingRuns.removeAll()
         self.pendingLocalUserEchoMessageIDsByRunID.removeAll()
         if !runIds.isEmpty, let hapticEvent {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
@@ -185,20 +185,23 @@ public final class OpenClawChatViewModel {
     var readySessionMetadataGeneration: UInt64?
 
     @ObservationIgnored
-    nonisolated(unsafe) var pendingRunTimeoutTasks: [String: Task<Void, Never>] = [:]
-    var nextPendingRunTimeoutArmID: UInt64 = 0
-    var pendingRunTimeoutArmIDs: [String: UInt64] = [:]
+    nonisolated(unsafe) var pendingRunOwnerTasks: [String: Task<Void, Never>] = [:]
+    var nextPendingRunOwnerArmID: UInt64 = 0
+    var pendingRunOwnerArmIDs: [String: UInt64] = [:]
     @ObservationIgnored
     private nonisolated(unsafe) var activeSessionRunIndicatorTimeoutTask: Task<Void, Never>?
-    let pendingRunTimeoutMs: UInt64 = 120_000
-    static let postSendRefreshDelaysMs: [UInt64] = [
+    var pendingRunWaitTimeoutMs: UInt64 = 120_000
+    var pendingRunUnavailableRetryMs: UInt64 = 30000
+    var pendingRunTerminalRetryMs: UInt64 = 2000
+    var pendingRunTerminalHistoryGraceMs: UInt64 = 10000
+    var pendingRunRefreshDelaysMs: [UInt64] = [
         1500,
         4000,
         9000,
         20000,
         45000,
-        90000,
     ]
+    var pendingRunSteadyRefreshDelayMs: UInt64 = 60000
     // Session switches can overlap in-flight picker patches, so stale completions
     // must compare against the latest request and latest desired value for that session.
     private var nextModelSelectionRequestID: UInt64 = 0
@@ -377,7 +380,7 @@ public final class OpenClawChatViewModel {
         self.outboxRetryTask?.cancel()
         self.outboxChangesTask?.cancel()
         self.activeSessionRunIndicatorTimeoutTask?.cancel()
-        for (_, task) in self.pendingRunTimeoutTasks {
+        for (_, task) in self.pendingRunOwnerTasks {
             task.cancel()
         }
     }
@@ -693,7 +696,7 @@ extension OpenClawChatViewModel {
 
     private func armActiveSessionRunIndicatorTimeout() {
         self.activeSessionRunIndicatorTimeoutTask?.cancel()
-        let timeoutMs = self.pendingRunTimeoutMs
+        let timeoutMs = self.pendingRunWaitTimeoutMs
         self.activeSessionRunIndicatorTimeoutTask = Task { [weak self] in
             do {
                 try await Task.sleep(nanoseconds: timeoutMs * 1_000_000)
@@ -928,7 +931,9 @@ extension OpenClawChatViewModel {
         if self.runMessageScopesByRunID[runId] == nil {
             self.runMessageScopesByRunID[runId] = currentRunMessageScope()
         }
-        self.armPendingRunTimeout(runId: runId)
+        if self.pendingRunOwnerArmIDs[runId] == nil {
+            self.armPendingRunOwner(runId: runId)
+        }
         if !bufferedText.isEmpty {
             self.updateStreamingAssistantText(bufferedText)
         }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
@@ -242,7 +242,7 @@ private func makeViewModel(
         @Sendable (TestSessionListQuery) async throws -> OpenClawChatSessionsListResponse?)? = nil,
     sendMessageHook: (@Sendable (String) async throws -> OpenClawChatSendResponse)? = nil,
     sendMessageStatus: String = "ok",
-    waitForRunCompletionHook: (@Sendable (String, Int) async -> Bool)? = nil,
+    waitForRunCompletionHook: (@Sendable (String, Int) async -> OpenClawChatRunObservation)? = nil,
     healthResponses: [Bool] = [true],
     initialThinkingLevel: String? = nil,
     modelPickerStore: ChatModelPickerStore? = nil,
@@ -545,7 +545,8 @@ private final class TestChatTransport: @unchecked Sendable, OpenClawChatTranspor
         (@Sendable (TestSessionListQuery) async throws -> OpenClawChatSessionsListResponse?)?
     private let sendMessageHook: (@Sendable (String) async throws -> OpenClawChatSendResponse)?
     private let sendMessageStatus: String
-    private let waitForRunCompletionHook: (@Sendable (String, Int) async -> Bool)?
+    private let waitForRunCompletionHook:
+        (@Sendable (String, Int) async -> OpenClawChatRunObservation)?
     private let healthResponses: [Bool]
 
     private let stream: AsyncStream<OpenClawChatTransportEvent>
@@ -572,7 +573,7 @@ private final class TestChatTransport: @unchecked Sendable, OpenClawChatTranspor
             @Sendable (TestSessionListQuery) async throws -> OpenClawChatSessionsListResponse?)? = nil,
         sendMessageHook: (@Sendable (String) async throws -> OpenClawChatSendResponse)? = nil,
         sendMessageStatus: String = "ok",
-        waitForRunCompletionHook: (@Sendable (String, Int) async -> Bool)? = nil,
+        waitForRunCompletionHook: (@Sendable (String, Int) async -> OpenClawChatRunObservation)? = nil,
         healthResponses: [Bool] = [true])
     {
         self.historyResponses = historyResponses
@@ -815,9 +816,12 @@ private final class TestChatTransport: @unchecked Sendable, OpenClawChatTranspor
         return self.healthResponses.last ?? true
     }
 
-    func waitForRunCompletion(runId: String, timeoutMs: Int) async -> Bool {
+    func waitForRunCompletion(
+        runId: String,
+        timeoutMs: Int) async -> OpenClawChatRunObservation
+    {
         await self.state.waitCompletionRunIdsAppend(runId)
-        return await self.waitForRunCompletionHook?(runId, timeoutMs) ?? false
+        return await self.waitForRunCompletionHook?(runId, timeoutMs) ?? .unavailable
     }
 
     func emit(_ evt: OpenClawChatTransportEvent) {
@@ -2633,7 +2637,7 @@ struct ChatViewModelTests {
         let (transport, vm) = await makeViewModel(
             historyResponses: [history1, history2, history3],
             sendMessageStatus: "pending",
-            waitForRunCompletionHook: { _, _ in true })
+            waitForRunCompletionHook: { _, _ in .terminal(.completed) })
         try await loadAndWaitBootstrap(vm: vm, sessionId: sessionId)
 
         await sendUserMessage(vm, text: "hello")
@@ -2650,6 +2654,102 @@ struct ChatViewModelTests {
                         message.role == "assistant" &&
                             message.content.contains { $0.text == "completed after wait" }
                     }
+            }
+        }
+    }
+
+    @Test func `terminal wait keeps ownership until history becomes available`() async throws {
+        let historyCalls = AsyncCounter()
+        let waitCalls = AsyncCounter()
+        let sessionId = "sess-main"
+        let now = (Date().timeIntervalSince1970 * 1000) + 10000
+        let empty = historyPayload(sessionId: sessionId)
+        let completed = historyPayload(
+            sessionId: sessionId,
+            messages: [
+                chatTextMessage(
+                    role: "assistant",
+                    text: "recovered after history failure",
+                    timestamp: now + 1),
+            ])
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [empty, empty, empty, completed],
+            requestHistoryHook: { _ in
+                let count = await historyCalls.increment()
+                if count == 3 {
+                    throw NSError(domain: "ChatViewModelTests", code: 1)
+                }
+            },
+            sendMessageStatus: "pending",
+            waitForRunCompletionHook: { _, _ in
+                await waitCalls.increment() == 1 ? .terminal(.completed) : .unavailable
+            })
+        await MainActor.run {
+            vm.pendingRunTerminalRetryMs = 10
+            vm.pendingRunRefreshDelaysMs = [60000]
+        }
+        try await loadAndWaitBootstrap(vm: vm, sessionId: sessionId)
+
+        await sendUserMessage(vm, text: "hello")
+        try await waitUntil("terminal observation retries failed history") {
+            let waits = await transport.waitCompletionRunIds()
+            return await MainActor.run {
+                waits.count >= 2 &&
+                    vm.pendingRunCount == 0 &&
+                    vm.messages.contains { message in
+                        message.content.contains { $0.text == "recovered after history failure" }
+                    }
+            }
+        }
+        #expect(await MainActor.run { vm.errorText == nil })
+    }
+
+    @Test func `terminal wait surfaces a missed lifecycle failure`() async throws {
+        let historyCalls = AsyncCounter()
+        let sessionId = "sess-main"
+        let empty = historyPayload(sessionId: sessionId)
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [empty, empty, empty],
+            requestHistoryHook: { _ in
+                if await historyCalls.increment() >= 3 {
+                    throw NSError(domain: "ChatViewModelTests", code: 2)
+                }
+            },
+            sendMessageStatus: "pending",
+            waitForRunCompletionHook: { _, _ in
+                .terminal(.failed(message: "Provider rejected the request"))
+            })
+        try await loadAndWaitBootstrap(vm: vm, sessionId: sessionId)
+
+        await sendUserMessage(vm, text: "hello")
+        try await waitUntil("terminal failure clears pending run") {
+            await MainActor.run {
+                vm.pendingRunCount == 0 &&
+                    vm.errorText == "Provider rejected the request"
+            }
+        }
+        #expect(await !(transport.waitCompletionRunIds()).isEmpty)
+    }
+
+    @Test func `terminal wait retires a confirmed no-output completion`() async throws {
+        let sessionId = "sess-main"
+        let empty = historyPayload(sessionId: sessionId)
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [empty, empty, empty, empty],
+            sendMessageStatus: "pending",
+            waitForRunCompletionHook: { _, _ in .terminal(.completed) })
+        await MainActor.run {
+            vm.pendingRunTerminalRetryMs = 10
+            vm.pendingRunTerminalHistoryGraceMs = 10
+            vm.pendingRunRefreshDelaysMs = [60000]
+        }
+        try await loadAndWaitBootstrap(vm: vm, sessionId: sessionId)
+
+        await sendUserMessage(vm, text: "hello")
+        try await waitUntil("confirmed no-output completion clears pending run") {
+            let waits = await transport.waitCompletionRunIds()
+            return await MainActor.run {
+                waits.count >= 2 && vm.pendingRunCount == 0 && vm.errorText == nil
             }
         }
     }


### PR DESCRIPTION
## What Problem This Solves

iOS and macOS chat treated a 30-second RPC deadline as the Gateway run deadline, while shared Apple chat also retired pending runs after a local 120-second timer. Slow first replies or reconnect/history gaps could therefore show a false timeout, clear the run owner early, or hide a later canonical reply.

## Why This Change Was Made

Ordinary Apple chat sends now omit `chat.send.timeoutMs`, leaving run lifetime with Gateway policy while retaining bounded request/ACK deadlines.

Shared Apple chat uses one arm-scoped owner per pending run. It combines route-bound `agent.wait` observations with bounded canonical-history polling, preserves terminal failures and Gateway error text, caches terminal state through reconnects, and keeps a short post-terminal history grace window before accepting a valid no-output completion. The owner holds the view model weakly and cancels both child paths together.

The rewrite intentionally does not change Android, Gateway schema, protocol version, configuration, provider routing, authentication, or persistence.

## User Impact

Slow accepted Apple chat replies stay pending until Gateway terminal state and canonical history reconcile. Missed lifecycle failures remain visible, reconnects cannot silently lose a known terminal result, and legitimate no-output completions still unblock sending.

## Evidence

- Exact rewritten head: `ddace4e9d2e60346edaaf8aed2019bba9f90f140`.
- Fresh autoreview completed clean after every actionable finding was fixed.
- Fresh Testbox `pnpm check:changed` passed: https://github.com/openclaw/openclaw/actions/runs/29172114245.
- Focused Swift syntax parsing and `git diff --check` passed.
- Regression coverage includes delayed terminal history, history failure followed by unavailable waits, missed lifecycle failures, retry backoff, valid no-output completion, and separation of request vs run deadlines.
- Local `swift test` was blocked before the changed files compiled because the installed Command Line Tools lacked `SwiftUIMacros`; hosted iOS/macOS CI on the exact PR head is the authoritative Apple compile/test gate.
