### PR TITLE
fix(slack): include attachment text in thread context

### DIFF
--- a/extensions/slack/src/monitor/block-text.ts
+++ b/extensions/slack/src/monitor/block-text.ts
@@ -1,0 +1,190 @@
+import {
+  normalizeOptionalString,
+  readStringValue as readString,
+} from "openclaw/plugin-sdk/string-coerce-runtime";
+
+type SlackTextObject = {
+  text?: unknown;
+};
+
+type SlackRichTextElement = {
+  type?: unknown;
+  text?: unknown;
+  url?: unknown;
+  user_id?: unknown;
+  channel_id?: unknown;
+  usergroup_id?: unknown;
+  name?: unknown;
+  range?: unknown;
+  elements?: unknown;
+};
+
+type SlackBlockLike = {
+  type?: unknown;
+  text?: unknown;
+  elements?: unknown;
+  fields?: unknown;
+  alt_text?: unknown;
+  title?: unknown;
+};
+
+type SlackBlocksText = {
+  text: string;
+  hasRichText: boolean;
+};
+
+function readTextObject(value: unknown): string | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  return normalizeOptionalString(readString((value as SlackTextObject).text));
+}
+
+function renderSlackRichTextLeaf(element: SlackRichTextElement): string {
+  switch (element.type) {
+    case "text":
+      return readString(element.text) ?? "";
+    case "link":
+      return readString(element.text) ?? readString(element.url) ?? "";
+    case "user": {
+      const userId = readString(element.user_id);
+      return userId ? `<@${userId}>` : "";
+    }
+    case "channel": {
+      const channelId = readString(element.channel_id);
+      return channelId ? `<#${channelId}>` : "";
+    }
+    case "usergroup": {
+      const usergroupId = readString(element.usergroup_id);
+      return usergroupId ? `<!subteam^${usergroupId}>` : "";
+    }
+    case "broadcast": {
+      const range = readString(element.range);
+      return range ? `<!${range}>` : "";
+    }
+    case "emoji": {
+      const name = readString(element.name);
+      return name ? `:${name}:` : "";
+    }
+    default:
+      return "";
+  }
+}
+
+function renderSlackRichTextElements(elements: unknown): string {
+  if (!Array.isArray(elements)) {
+    return "";
+  }
+  const parts: string[] = [];
+  for (const rawElement of elements) {
+    if (!rawElement || typeof rawElement !== "object") {
+      continue;
+    }
+    const element = rawElement as SlackRichTextElement;
+    switch (element.type) {
+      case "rich_text_section":
+      case "rich_text_preformatted":
+      case "rich_text_quote":
+        parts.push(renderSlackRichTextElements(element.elements));
+        break;
+      case "rich_text_list": {
+        const listParts: string[] = [];
+        if (Array.isArray(element.elements)) {
+          for (const child of element.elements) {
+            if (!child || typeof child !== "object") {
+              continue;
+            }
+            const rendered = renderSlackRichTextElements((child as SlackRichTextElement).elements);
+            if (rendered) {
+              listParts.push(rendered);
+            }
+          }
+        }
+        parts.push(listParts.join("\n"));
+        break;
+      }
+      default:
+        parts.push(renderSlackRichTextLeaf(element));
+        break;
+    }
+  }
+  return parts.join("");
+}
+
+function readSlackBlockText(block: unknown): string | undefined {
+  if (!block || typeof block !== "object") {
+    return undefined;
+  }
+  const blockLike = block as SlackBlockLike;
+  switch (blockLike.type) {
+    case "rich_text":
+      return normalizeOptionalString(renderSlackRichTextElements(blockLike.elements));
+    case "section": {
+      const text = readTextObject(blockLike.text);
+      if (text) {
+        return text;
+      }
+      if (!Array.isArray(blockLike.fields)) {
+        return undefined;
+      }
+      const fields = blockLike.fields.flatMap((field) => readTextObject(field) ?? []);
+      return fields.length > 0 ? fields.join("\n") : undefined;
+    }
+    case "header":
+      return readTextObject(blockLike.text);
+    case "context": {
+      if (!Array.isArray(blockLike.elements)) {
+        return undefined;
+      }
+      const parts = blockLike.elements.flatMap((element) => readTextObject(element) ?? []);
+      return parts.length > 0 ? parts.join(" ") : undefined;
+    }
+    case "image":
+      return (
+        normalizeOptionalString(readString(blockLike.alt_text)) ?? readTextObject(blockLike.title)
+      );
+    case "video":
+      return (
+        readTextObject(blockLike.title) ?? normalizeOptionalString(readString(blockLike.alt_text))
+      );
+    default:
+      return undefined;
+  }
+}
+
+export function resolveSlackBlocksText(blocks: unknown[] | undefined): SlackBlocksText | undefined {
+  if (!blocks?.length) {
+    return undefined;
+  }
+  const parts: string[] = [];
+  let hasRichText = false;
+  for (const block of blocks) {
+    if (block && typeof block === "object" && (block as SlackBlockLike).type === "rich_text") {
+      hasRichText = true;
+    }
+    const text = readSlackBlockText(block);
+    if (text) {
+      parts.push(text);
+    }
+  }
+  return parts.length > 0 ? { text: parts.join("\n"), hasRichText } : undefined;
+}
+
+export function chooseSlackPrimaryText(params: {
+  messageText: string | undefined;
+  blocksText: SlackBlocksText | undefined;
+}): string | undefined {
+  const { messageText, blocksText } = params;
+  if (!blocksText) {
+    return messageText;
+  }
+  if (!messageText) {
+    return blocksText.text;
+  }
+  if (blocksText.hasRichText && blocksText.text.length > messageText.length) {
+    return blocksText.text;
+  }
+  return blocksText.text.length > messageText.length && blocksText.text.startsWith(messageText)
+    ? blocksText.text
+    : messageText;
+}

--- a/extensions/slack/src/monitor/media.test.ts
+++ b/extensions/slack/src/monitor/media.test.ts
@@ -1022,7 +1022,7 @@ describe("resolveSlackThreadHistory", () => {
     expect(result[1]?.text).toBe("hello");
   });
 
-  it("includes bot messages whose text is only in Slack attachments", async () => {
+  it("extracts thread text from Slack attachment and block surfaces", async () => {
     const replies = vi.fn().mockResolvedValueOnce({
       messages: [
         {
@@ -1033,106 +1033,20 @@ describe("resolveSlackThreadHistory", () => {
             {
               title: "Filesystem on /dev/sda1 has only 14.93% available space left.",
               fallback: "Alert: filesystem space is low",
+              fields: [{ title: "Host", value: "dc2.ipa.mgt" }],
             },
           ],
         },
-      ],
-      response_metadata: { next_cursor: "" },
-    });
-    const client = {
-      conversations: { replies },
-    } as unknown as Parameters<typeof resolveSlackThreadHistory>[0]["client"];
-
-    const result = await resolveSlackThreadHistory({
-      channelId: "C1",
-      threadTs: "1.000",
-      client,
-      limit: 10,
-    });
-
-    expect(result).toEqual([
-      {
-        text: "Filesystem on /dev/sda1 has only 14.93% available space left.\nAlert: filesystem space is low",
-        userId: undefined,
-        botId: "BMONITOR",
-        ts: "1.000",
-        files: undefined,
-      },
-    ]);
-  });
-
-  it("includes bot messages whose text is only in Slack blocks", async () => {
-    const replies = vi.fn().mockResolvedValueOnce({
-      messages: [
         {
           text: "  ",
           bot_id: "BMONITOR",
-          ts: "1.000",
+          ts: "2.000",
           blocks: [{ type: "section", text: { type: "mrkdwn", text: "Pod restart rate is high" } }],
         },
-      ],
-      response_metadata: { next_cursor: "" },
-    });
-    const client = {
-      conversations: { replies },
-    } as unknown as Parameters<typeof resolveSlackThreadHistory>[0]["client"];
-
-    const result = await resolveSlackThreadHistory({
-      channelId: "C1",
-      threadTs: "1.000",
-      client,
-      limit: 10,
-    });
-
-    expect(result).toHaveLength(1);
-    expect(result[0]?.text).toBe("Pod restart rate is high");
-    expect(result[0]?.botId).toBe("BMONITOR");
-  });
-
-  it("includes bot messages whose text is only in standard attachment blocks", async () => {
-    const replies = vi.fn().mockResolvedValueOnce({
-      messages: [
         {
           text: "  ",
           bot_id: "BMONITOR",
-          ts: "1.000",
-          attachments: [
-            {
-              blocks: [
-                {
-                  type: "section",
-                  text: { type: "mrkdwn", text: "High error rate on checkout" },
-                },
-              ],
-            },
-          ],
-        },
-      ],
-      response_metadata: { next_cursor: "" },
-    });
-    const client = {
-      conversations: { replies },
-    } as unknown as Parameters<typeof resolveSlackThreadHistory>[0]["client"];
-
-    const result = await resolveSlackThreadHistory({
-      channelId: "C1",
-      threadTs: "1.000",
-      client,
-      limit: 10,
-    });
-
-    expect(result).toHaveLength(1);
-    expect(result[0]?.text).toBe("High error rate on checkout");
-    expect(result[0]?.botId).toBe("BMONITOR");
-  });
-
-  it("collects all readable text from attachment blocks and section fields", async () => {
-    const replies = vi.fn().mockResolvedValueOnce({
-      messages: [
-        {
-          text: "  ",
-          bot_id: "BMONITOR",
-          ts: "1.000",
+          ts: "3.000",
           attachments: [
             {
               blocks: [
@@ -1152,32 +1066,9 @@ describe("resolveSlackThreadHistory", () => {
             },
           ],
         },
-      ],
-      response_metadata: { next_cursor: "" },
-    });
-    const client = {
-      conversations: { replies },
-    } as unknown as Parameters<typeof resolveSlackThreadHistory>[0]["client"];
-
-    const result = await resolveSlackThreadHistory({
-      channelId: "C1",
-      threadTs: "1.000",
-      client,
-      limit: 10,
-    });
-
-    expect(result).toHaveLength(1);
-    expect(result[0]?.text).toBe(
-      "Alert firing\n*host:* dc2.ipa.mgt\n*device:* /dev/sda1\nFree space below threshold",
-    );
-  });
-
-  it("preserves formatting in primary Slack text", async () => {
-    const replies = vi.fn().mockResolvedValueOnce({
-      messages: [
         {
           text: "  line one\nline two  ",
-          ts: "1.000",
+          ts: "4.000",
         },
       ],
       response_metadata: { next_cursor: "" },
@@ -1193,7 +1084,18 @@ describe("resolveSlackThreadHistory", () => {
       limit: 10,
     });
 
-    expect(result[0]?.text).toBe("line one\nline two");
+    expect(result.map((entry) => entry.text)).toEqual([
+      "Filesystem on /dev/sda1 has only 14.93% available space left.\nAlert: filesystem space is low\nHost\ndc2.ipa.mgt",
+      "Pod restart rate is high",
+      "Alert firing\n*host:* dc2.ipa.mgt\n*device:* /dev/sda1\nFree space below threshold",
+      "line one\nline two",
+    ]);
+    expect(result.map((entry) => entry.botId)).toEqual([
+      "BMONITOR",
+      "BMONITOR",
+      "BMONITOR",
+      undefined,
+    ]);
   });
 
   it("returns empty when limit is zero without calling Slack API", async () => {

--- a/extensions/slack/src/monitor/media.test.ts
+++ b/extensions/slack/src/monitor/media.test.ts
@@ -1089,6 +1089,67 @@ describe("resolveSlackThreadHistory", () => {
     expect(result[0]?.botId).toBe("BMONITOR");
   });
 
+  it("includes bot messages whose text is only in standard attachment blocks", async () => {
+    const replies = vi.fn().mockResolvedValueOnce({
+      messages: [
+        {
+          text: "  ",
+          bot_id: "BMONITOR",
+          ts: "1.000",
+          attachments: [
+            {
+              blocks: [
+                {
+                  type: "section",
+                  text: { type: "mrkdwn", text: "High error rate on checkout" },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      response_metadata: { next_cursor: "" },
+    });
+    const client = {
+      conversations: { replies },
+    } as unknown as Parameters<typeof resolveSlackThreadHistory>[0]["client"];
+
+    const result = await resolveSlackThreadHistory({
+      channelId: "C1",
+      threadTs: "1.000",
+      client,
+      limit: 10,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.text).toBe("High error rate on checkout");
+    expect(result[0]?.botId).toBe("BMONITOR");
+  });
+
+  it("preserves formatting in primary Slack text", async () => {
+    const replies = vi.fn().mockResolvedValueOnce({
+      messages: [
+        {
+          text: "  line one\nline two  ",
+          ts: "1.000",
+        },
+      ],
+      response_metadata: { next_cursor: "" },
+    });
+    const client = {
+      conversations: { replies },
+    } as unknown as Parameters<typeof resolveSlackThreadHistory>[0]["client"];
+
+    const result = await resolveSlackThreadHistory({
+      channelId: "C1",
+      threadTs: "1.000",
+      client,
+      limit: 10,
+    });
+
+    expect(result[0]?.text).toBe("line one\nline two");
+  });
+
   it("returns empty when limit is zero without calling Slack API", async () => {
     const replies = vi.fn();
     const client = {

--- a/extensions/slack/src/monitor/media.test.ts
+++ b/extensions/slack/src/monitor/media.test.ts
@@ -1126,6 +1126,52 @@ describe("resolveSlackThreadHistory", () => {
     expect(result[0]?.botId).toBe("BMONITOR");
   });
 
+  it("collects all readable text from attachment blocks and section fields", async () => {
+    const replies = vi.fn().mockResolvedValueOnce({
+      messages: [
+        {
+          text: "  ",
+          bot_id: "BMONITOR",
+          ts: "1.000",
+          attachments: [
+            {
+              blocks: [
+                { type: "header", text: { type: "plain_text", text: "Alert firing" } },
+                {
+                  type: "section",
+                  fields: [
+                    { type: "mrkdwn", text: "*host:* dc2.ipa.mgt" },
+                    { type: "mrkdwn", text: "*device:* /dev/sda1" },
+                  ],
+                },
+                {
+                  type: "section",
+                  text: { type: "mrkdwn", text: "Free space below threshold" },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      response_metadata: { next_cursor: "" },
+    });
+    const client = {
+      conversations: { replies },
+    } as unknown as Parameters<typeof resolveSlackThreadHistory>[0]["client"];
+
+    const result = await resolveSlackThreadHistory({
+      channelId: "C1",
+      threadTs: "1.000",
+      client,
+      limit: 10,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.text).toBe(
+      "Alert firing\n*host:* dc2.ipa.mgt\n*device:* /dev/sda1\nFree space below threshold",
+    );
+  });
+
   it("preserves formatting in primary Slack text", async () => {
     const replies = vi.fn().mockResolvedValueOnce({
       messages: [

--- a/extensions/slack/src/monitor/media.test.ts
+++ b/extensions/slack/src/monitor/media.test.ts
@@ -1022,6 +1022,73 @@ describe("resolveSlackThreadHistory", () => {
     expect(result[1]?.text).toBe("hello");
   });
 
+  it("includes bot messages whose text is only in Slack attachments", async () => {
+    const replies = vi.fn().mockResolvedValueOnce({
+      messages: [
+        {
+          text: "  ",
+          bot_id: "BMONITOR",
+          ts: "1.000",
+          attachments: [
+            {
+              title: "Filesystem on /dev/sda1 has only 14.93% available space left.",
+              fallback: "Alert: filesystem space is low",
+            },
+          ],
+        },
+      ],
+      response_metadata: { next_cursor: "" },
+    });
+    const client = {
+      conversations: { replies },
+    } as unknown as Parameters<typeof resolveSlackThreadHistory>[0]["client"];
+
+    const result = await resolveSlackThreadHistory({
+      channelId: "C1",
+      threadTs: "1.000",
+      client,
+      limit: 10,
+    });
+
+    expect(result).toEqual([
+      {
+        text: "Filesystem on /dev/sda1 has only 14.93% available space left.\nAlert: filesystem space is low",
+        userId: undefined,
+        botId: "BMONITOR",
+        ts: "1.000",
+        files: undefined,
+      },
+    ]);
+  });
+
+  it("includes bot messages whose text is only in Slack blocks", async () => {
+    const replies = vi.fn().mockResolvedValueOnce({
+      messages: [
+        {
+          text: "  ",
+          bot_id: "BMONITOR",
+          ts: "1.000",
+          blocks: [{ type: "section", text: { type: "mrkdwn", text: "Pod restart rate is high" } }],
+        },
+      ],
+      response_metadata: { next_cursor: "" },
+    });
+    const client = {
+      conversations: { replies },
+    } as unknown as Parameters<typeof resolveSlackThreadHistory>[0]["client"];
+
+    const result = await resolveSlackThreadHistory({
+      channelId: "C1",
+      threadTs: "1.000",
+      client,
+      limit: 10,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.text).toBe("Pod restart rate is high");
+    expect(result[0]?.botId).toBe("BMONITOR");
+  });
+
   it("returns empty when limit is zero without calling Slack API", async () => {
     const replies = vi.fn();
     const client = {
@@ -1103,6 +1170,43 @@ describe("resolveSlackThreadStarter", () => {
     });
 
     expect(result).toBeNull();
+    expect(vi.mocked(logVerbose)).not.toHaveBeenCalled();
+  });
+
+  it("returns the starter text from Slack attachments when bot message text is empty", async () => {
+    const replies = vi.fn().mockResolvedValueOnce({
+      messages: [
+        {
+          text: "   ",
+          bot_id: "BMONITOR",
+          ts: "1.000",
+          attachments: [
+            {
+              pretext: "[FIRING:1] HostFilesystemSpaceLow",
+              title: "Filesystem on /dev/sda1 has only 14.93% available space left.",
+              fallback: "dc2.ipa.mgt /dev/sda1 low free space",
+            },
+          ],
+        },
+      ],
+    });
+    const client = {
+      conversations: { replies },
+    } as unknown as Parameters<typeof resolveSlackThreadStarter>[0]["client"];
+
+    const result = await resolveSlackThreadStarter({
+      channelId: "C1",
+      threadTs: "1.000",
+      client,
+    });
+
+    expect(result).toEqual({
+      text: "[FIRING:1] HostFilesystemSpaceLow\nFilesystem on /dev/sda1 has only 14.93% available space left.\ndc2.ipa.mgt /dev/sda1 low free space",
+      userId: undefined,
+      botId: "BMONITOR",
+      ts: "1.000",
+      files: undefined,
+    });
     expect(vi.mocked(logVerbose)).not.toHaveBeenCalled();
   });
 

--- a/extensions/slack/src/monitor/message-handler/prepare-content.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-content.ts
@@ -3,12 +3,10 @@ import type { WebClient as SlackWebClient } from "@slack/web-api";
 import { runTasksWithConcurrency } from "openclaw/plugin-sdk/concurrency-runtime";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
-import {
-  normalizeOptionalString,
-  readStringValue as readString,
-} from "openclaw/plugin-sdk/string-coerce-runtime";
+import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { formatSlackFileReference } from "../../file-reference.js";
 import type { SlackFile, SlackMessageEvent } from "../../types.js";
+import { chooseSlackPrimaryText, resolveSlackBlocksText } from "../block-text.js";
 import { MAX_SLACK_MEDIA_FILES, type SlackMediaResult } from "../media-types.js";
 import type { SlackThreadStarter } from "../thread.js";
 
@@ -20,36 +18,6 @@ type SlackResolvedMessageContent = {
 const SLACK_MENTION_RESOLUTION_CONCURRENCY = 4;
 const SLACK_MENTION_RESOLUTION_MAX_LOOKUPS_PER_MESSAGE = 20;
 const SLACK_USER_MENTION_RE = /<@([A-Z0-9]+)(?:\|[^>]+)?>/gi;
-
-type SlackTextObject = {
-  text?: unknown;
-};
-
-type SlackRichTextElement = {
-  type?: unknown;
-  text?: unknown;
-  url?: unknown;
-  user_id?: unknown;
-  channel_id?: unknown;
-  usergroup_id?: unknown;
-  name?: unknown;
-  range?: unknown;
-  elements?: unknown;
-};
-
-type SlackBlockLike = {
-  type?: unknown;
-  text?: unknown;
-  elements?: unknown;
-  fields?: unknown;
-  alt_text?: unknown;
-  title?: unknown;
-};
-
-type SlackBlocksText = {
-  text: string;
-  hasRichText: boolean;
-};
 
 const loadSlackMediaModule = createLazyRuntimeModule(() => import("../media.js"));
 
@@ -85,176 +53,6 @@ function renderSlackUserMentions(
     const rendered = renderedMentions.get(userId);
     return rendered ?? full;
   });
-}
-
-function readTextObject(value: unknown): string | undefined {
-  if (!value || typeof value !== "object") {
-    return undefined;
-  }
-  return normalizeOptionalString(readString((value as SlackTextObject).text));
-}
-
-function renderSlackRichTextLeaf(element: SlackRichTextElement): string {
-  switch (element.type) {
-    case "text":
-      return readString(element.text) ?? "";
-    case "link":
-      return readString(element.text) ?? readString(element.url) ?? "";
-    case "user": {
-      const userId = readString(element.user_id);
-      return userId ? `<@${userId}>` : "";
-    }
-    case "channel": {
-      const channelId = readString(element.channel_id);
-      return channelId ? `<#${channelId}>` : "";
-    }
-    case "usergroup": {
-      const usergroupId = readString(element.usergroup_id);
-      return usergroupId ? `<!subteam^${usergroupId}>` : "";
-    }
-    case "broadcast": {
-      const range = readString(element.range);
-      return range ? `<!${range}>` : "";
-    }
-    case "emoji": {
-      const name = readString(element.name);
-      return name ? `:${name}:` : "";
-    }
-    default:
-      return "";
-  }
-}
-
-function renderSlackRichTextElements(elements: unknown): string {
-  if (!Array.isArray(elements)) {
-    return "";
-  }
-  const parts: string[] = [];
-  for (const rawElement of elements) {
-    if (!rawElement || typeof rawElement !== "object") {
-      continue;
-    }
-    const element = rawElement as SlackRichTextElement;
-    switch (element.type) {
-      case "rich_text_section":
-      case "rich_text_preformatted":
-      case "rich_text_quote": {
-        parts.push(renderSlackRichTextElements(element.elements));
-        break;
-      }
-      case "rich_text_list": {
-        const listParts: string[] = [];
-        if (Array.isArray(element.elements)) {
-          for (const child of element.elements) {
-            if (!child || typeof child !== "object") {
-              continue;
-            }
-            const rendered = renderSlackRichTextElements((child as SlackRichTextElement).elements);
-            if (rendered) {
-              listParts.push(rendered);
-            }
-          }
-        }
-        const listText = listParts.join("\n");
-        parts.push(listText);
-        break;
-      }
-      default:
-        parts.push(renderSlackRichTextLeaf(element));
-        break;
-    }
-  }
-  return parts.join("");
-}
-
-function readSlackBlockText(block: unknown): string | undefined {
-  if (!block || typeof block !== "object") {
-    return undefined;
-  }
-  const blockLike = block as SlackBlockLike;
-  switch (blockLike.type) {
-    case "rich_text":
-      return normalizeOptionalString(renderSlackRichTextElements(blockLike.elements));
-    case "section": {
-      const text = readTextObject(blockLike.text);
-      if (text) {
-        return text;
-      }
-      if (Array.isArray(blockLike.fields)) {
-        const fields: string[] = [];
-        for (const field of blockLike.fields) {
-          const fieldText = readTextObject(field);
-          if (fieldText) {
-            fields.push(fieldText);
-          }
-        }
-        return fields.length > 0 ? fields.join("\n") : undefined;
-      }
-      return undefined;
-    }
-    case "header":
-      return readTextObject(blockLike.text);
-    case "context": {
-      if (!Array.isArray(blockLike.elements)) {
-        return undefined;
-      }
-      const parts: string[] = [];
-      for (const element of blockLike.elements) {
-        const text = readTextObject(element);
-        if (text) {
-          parts.push(text);
-        }
-      }
-      return parts.length > 0 ? parts.join(" ") : undefined;
-    }
-    case "image":
-      return (
-        normalizeOptionalString(readString(blockLike.alt_text)) ?? readTextObject(blockLike.title)
-      );
-    case "video":
-      return (
-        readTextObject(blockLike.title) ?? normalizeOptionalString(readString(blockLike.alt_text))
-      );
-    default:
-      return undefined;
-  }
-}
-
-function resolveSlackBlocksText(blocks: unknown[] | undefined): SlackBlocksText | undefined {
-  if (!blocks?.length) {
-    return undefined;
-  }
-  const parts: string[] = [];
-  let hasRichText = false;
-  for (const block of blocks) {
-    if (block && typeof block === "object" && (block as SlackBlockLike).type === "rich_text") {
-      hasRichText = true;
-    }
-    const text = readSlackBlockText(block);
-    if (text) {
-      parts.push(text);
-    }
-  }
-  return parts.length > 0 ? { text: parts.join("\n"), hasRichText } : undefined;
-}
-
-function chooseSlackPrimaryText(params: {
-  messageText: string | undefined;
-  blocksText: SlackBlocksText | undefined;
-}): string | undefined {
-  const { messageText, blocksText } = params;
-  if (!blocksText) {
-    return messageText;
-  }
-  if (!messageText) {
-    return blocksText.text;
-  }
-  if (blocksText.hasRichText && blocksText.text.length > messageText.length) {
-    return blocksText.text;
-  }
-  return blocksText.text.length > messageText.length && blocksText.text.startsWith(messageText)
-    ? blocksText.text
-    : messageText;
 }
 
 function filterInheritedParentFiles(params: {

--- a/extensions/slack/src/monitor/thread.ts
+++ b/extensions/slack/src/monitor/thread.ts
@@ -1,13 +1,14 @@
 // Slack plugin module implements thread behavior.
-import type { WebClient as SlackWebClient } from "@slack/web-api";
+import type { Block, KnownBlock, WebClient as SlackWebClient } from "@slack/web-api";
 import { pruneMapToMaxSize } from "openclaw/plugin-sdk/collection-runtime";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import {
   asDateTimestampMs,
   resolveExpiresAtMsFromDurationMs,
 } from "openclaw/plugin-sdk/number-runtime";
+import { buildSlackBlocksFallbackText } from "../blocks-fallback.js";
 import { formatSlackFileReferenceList } from "../file-reference.js";
-import type { SlackFile } from "../types.js";
+import type { SlackAttachment, SlackFile } from "../types.js";
 import { logVerbose } from "./thread.runtime.js";
 
 export type SlackThreadStarter = {
@@ -45,6 +46,56 @@ function formatSlackFilePlaceholder(files: SlackFile[] | undefined): string {
   return `[attached: ${formatSlackFileReferenceList(files)}]`;
 }
 
+function cleanSlackTextCandidate(value: string | undefined): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const normalized = value.replace(/\s+/g, " ").trim();
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function pushUniqueText(parts: string[], value: string | undefined): void {
+  const text = cleanSlackTextCandidate(value);
+  if (text && !parts.includes(text)) {
+    parts.push(text);
+  }
+}
+
+function resolveSlackBlocksFallbackText(blocks: unknown[] | undefined): string | undefined {
+  if (!Array.isArray(blocks) || blocks.length === 0) {
+    return undefined;
+  }
+  return cleanSlackTextCandidate(buildSlackBlocksFallbackText(blocks as (Block | KnownBlock)[]));
+}
+
+function resolveSlackAttachmentFallbackText(attachments: SlackAttachment[] | undefined): string | undefined {
+  if (!Array.isArray(attachments) || attachments.length === 0) {
+    return undefined;
+  }
+
+  const parts: string[] = [];
+  for (const attachment of attachments) {
+    pushUniqueText(parts, attachment.pretext);
+    pushUniqueText(parts, attachment.title);
+    pushUniqueText(parts, attachment.text);
+    pushUniqueText(parts, attachment.fallback);
+    pushUniqueText(parts, resolveSlackBlocksFallbackText(attachment.message_blocks));
+  }
+  return parts.length > 0 ? parts.join("\n") : undefined;
+}
+
+function resolveSlackMessageText(message: {
+  text?: string;
+  blocks?: unknown[];
+  attachments?: SlackAttachment[];
+}): string | undefined {
+  return (
+    cleanSlackTextCandidate(message.text) ??
+    resolveSlackAttachmentFallbackText(message.attachments) ??
+    resolveSlackBlocksFallbackText(message.blocks)
+  );
+}
+
 export async function resolveSlackThreadStarter(params: {
   channelId: string;
   threadTs: string;
@@ -73,10 +124,12 @@ export async function resolveSlackThreadStarter(params: {
         bot_id?: string;
         ts?: string;
         files?: SlackFile[];
+        blocks?: unknown[];
+        attachments?: SlackAttachment[];
       }>;
     };
     const message = response?.messages?.[0];
-    const text = (message?.text ?? "").trim();
+    const text = message ? resolveSlackMessageText(message) : undefined;
     const files = message?.files?.length ? message.files : undefined;
     if (!message || (!text && !files)) {
       return null;
@@ -126,6 +179,8 @@ type SlackRepliesPageMessage = {
   bot_id?: string;
   ts?: string;
   files?: SlackFile[];
+  blocks?: unknown[];
+  attachments?: SlackAttachment[];
 };
 
 type SlackRepliesPage = {
@@ -168,8 +223,9 @@ export async function resolveSlackThreadHistory(params: {
       })) as SlackRepliesPage;
 
       for (const msg of response.messages ?? []) {
-        // Keep messages with text OR file attachments.
-        if (!msg.text?.trim() && !msg.files?.length) {
+        const text = resolveSlackMessageText(msg);
+        // Keep messages with text, Slack attachment/block fallback text, or file attachments.
+        if (!text && !msg.files?.length) {
           continue;
         }
         if (params.currentMessageTs && msg.ts === params.currentMessageTs) {
@@ -187,7 +243,7 @@ export async function resolveSlackThreadHistory(params: {
 
     return retained.map((msg) => ({
       // For file-only messages, create a placeholder showing attached filenames.
-      text: msg.text?.trim() ? msg.text : formatSlackFilePlaceholder(msg.files),
+      text: resolveSlackMessageText(msg) ?? formatSlackFilePlaceholder(msg.files),
       userId: msg.user,
       botId: msg.bot_id,
       ts: msg.ts,

--- a/extensions/slack/src/monitor/thread.ts
+++ b/extensions/slack/src/monitor/thread.ts
@@ -54,6 +54,14 @@ function cleanSlackTextCandidate(value: string | undefined): string | undefined 
   return normalized.length > 0 ? normalized : undefined;
 }
 
+function readPrimarySlackText(value: string | undefined): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
 function pushUniqueText(parts: string[], value: string | undefined): void {
   const text = cleanSlackTextCandidate(value);
   if (text && !parts.includes(text)) {
@@ -79,6 +87,7 @@ function resolveSlackAttachmentFallbackText(attachments: SlackAttachment[] | und
     pushUniqueText(parts, attachment.title);
     pushUniqueText(parts, attachment.text);
     pushUniqueText(parts, attachment.fallback);
+    pushUniqueText(parts, resolveSlackBlocksFallbackText(attachment.blocks));
     pushUniqueText(parts, resolveSlackBlocksFallbackText(attachment.message_blocks));
   }
   return parts.length > 0 ? parts.join("\n") : undefined;
@@ -90,7 +99,7 @@ function resolveSlackMessageText(message: {
   attachments?: SlackAttachment[];
 }): string | undefined {
   return (
-    cleanSlackTextCandidate(message.text) ??
+    readPrimarySlackText(message.text) ??
     resolveSlackAttachmentFallbackText(message.attachments) ??
     resolveSlackBlocksFallbackText(message.blocks)
   );

--- a/extensions/slack/src/monitor/thread.ts
+++ b/extensions/slack/src/monitor/thread.ts
@@ -1,15 +1,43 @@
 // Slack plugin module implements thread behavior.
-import type { Block, KnownBlock, WebClient as SlackWebClient } from "@slack/web-api";
+import type { WebClient as SlackWebClient } from "@slack/web-api";
 import { pruneMapToMaxSize } from "openclaw/plugin-sdk/collection-runtime";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import {
   asDateTimestampMs,
   resolveExpiresAtMsFromDurationMs,
 } from "openclaw/plugin-sdk/number-runtime";
-import { buildSlackBlocksFallbackText } from "../blocks-fallback.js";
+import {
+  normalizeOptionalString,
+  readStringValue as readString,
+} from "openclaw/plugin-sdk/string-coerce-runtime";
 import { formatSlackFileReferenceList } from "../file-reference.js";
 import type { SlackAttachment, SlackFile } from "../types.js";
 import { logVerbose } from "./thread.runtime.js";
+
+type SlackTextObject = {
+  text?: unknown;
+};
+
+type SlackRichTextElement = {
+  type?: unknown;
+  text?: unknown;
+  url?: unknown;
+  user_id?: unknown;
+  channel_id?: unknown;
+  usergroup_id?: unknown;
+  name?: unknown;
+  range?: unknown;
+  elements?: unknown;
+};
+
+type SlackBlockLike = {
+  type?: unknown;
+  text?: unknown;
+  elements?: unknown;
+  fields?: unknown;
+  alt_text?: unknown;
+  title?: unknown;
+};
 
 export type SlackThreadStarter = {
   text: string;
@@ -69,11 +97,153 @@ function pushUniqueText(parts: string[], value: string | undefined): void {
   }
 }
 
+function pushUniqueFormattedText(parts: string[], value: string | undefined): void {
+  const text = readPrimarySlackText(value);
+  if (text && !parts.includes(text)) {
+    parts.push(text);
+  }
+}
+
+function readTextObject(value: unknown): string | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  return normalizeOptionalString(readString((value as SlackTextObject).text));
+}
+
+function renderSlackRichTextLeaf(element: SlackRichTextElement): string {
+  switch (element.type) {
+    case "text":
+      return readString(element.text) ?? "";
+    case "link":
+      return readString(element.text) ?? readString(element.url) ?? "";
+    case "user": {
+      const userId = readString(element.user_id);
+      return userId ? `<@${userId}>` : "";
+    }
+    case "channel": {
+      const channelId = readString(element.channel_id);
+      return channelId ? `<#${channelId}>` : "";
+    }
+    case "usergroup": {
+      const usergroupId = readString(element.usergroup_id);
+      return usergroupId ? `<!subteam^${usergroupId}>` : "";
+    }
+    case "broadcast": {
+      const range = readString(element.range);
+      return range ? `<!${range}>` : "";
+    }
+    case "emoji": {
+      const name = readString(element.name);
+      return name ? `:${name}:` : "";
+    }
+    default:
+      return "";
+  }
+}
+
+function renderSlackRichTextElements(elements: unknown): string {
+  if (!Array.isArray(elements)) {
+    return "";
+  }
+  const parts: string[] = [];
+  for (const rawElement of elements) {
+    if (!rawElement || typeof rawElement !== "object") {
+      continue;
+    }
+    const element = rawElement as SlackRichTextElement;
+    switch (element.type) {
+      case "rich_text_section":
+      case "rich_text_preformatted":
+      case "rich_text_quote": {
+        parts.push(renderSlackRichTextElements(element.elements));
+        break;
+      }
+      case "rich_text_list": {
+        const listParts: string[] = [];
+        if (Array.isArray(element.elements)) {
+          for (const child of element.elements) {
+            if (!child || typeof child !== "object") {
+              continue;
+            }
+            const rendered = renderSlackRichTextElements((child as SlackRichTextElement).elements);
+            if (rendered) {
+              listParts.push(rendered);
+            }
+          }
+        }
+        parts.push(listParts.join("\n"));
+        break;
+      }
+      default:
+        parts.push(renderSlackRichTextLeaf(element));
+        break;
+    }
+  }
+  return parts.join("");
+}
+
+function readSlackBlockText(block: unknown): string | undefined {
+  if (!block || typeof block !== "object") {
+    return undefined;
+  }
+  const blockLike = block as SlackBlockLike;
+  switch (blockLike.type) {
+    case "rich_text":
+      return normalizeOptionalString(renderSlackRichTextElements(blockLike.elements));
+    case "section": {
+      const text = readTextObject(blockLike.text);
+      if (text) {
+        return text;
+      }
+      if (!Array.isArray(blockLike.fields)) {
+        return undefined;
+      }
+      const fields: string[] = [];
+      for (const field of blockLike.fields) {
+        const fieldText = readTextObject(field);
+        if (fieldText) {
+          fields.push(fieldText);
+        }
+      }
+      return fields.length > 0 ? fields.join("\n") : undefined;
+    }
+    case "header":
+      return readTextObject(blockLike.text);
+    case "context": {
+      if (!Array.isArray(blockLike.elements)) {
+        return undefined;
+      }
+      const parts: string[] = [];
+      for (const element of blockLike.elements) {
+        const text = readTextObject(element);
+        if (text) {
+          parts.push(text);
+        }
+      }
+      return parts.length > 0 ? parts.join(" ") : undefined;
+    }
+    case "image":
+      return normalizeOptionalString(readString(blockLike.alt_text)) ?? readTextObject(blockLike.title);
+    case "video":
+      return readTextObject(blockLike.title) ?? normalizeOptionalString(readString(blockLike.alt_text));
+    default:
+      return undefined;
+  }
+}
+
 function resolveSlackBlocksFallbackText(blocks: unknown[] | undefined): string | undefined {
   if (!Array.isArray(blocks) || blocks.length === 0) {
     return undefined;
   }
-  return cleanSlackTextCandidate(buildSlackBlocksFallbackText(blocks as (Block | KnownBlock)[]));
+  const parts: string[] = [];
+  for (const block of blocks) {
+    const text = readSlackBlockText(block);
+    if (text) {
+      parts.push(text);
+    }
+  }
+  return parts.length > 0 ? parts.join("\n") : undefined;
 }
 
 function resolveSlackAttachmentFallbackText(attachments: SlackAttachment[] | undefined): string | undefined {
@@ -87,8 +257,8 @@ function resolveSlackAttachmentFallbackText(attachments: SlackAttachment[] | und
     pushUniqueText(parts, attachment.title);
     pushUniqueText(parts, attachment.text);
     pushUniqueText(parts, attachment.fallback);
-    pushUniqueText(parts, resolveSlackBlocksFallbackText(attachment.blocks));
-    pushUniqueText(parts, resolveSlackBlocksFallbackText(attachment.message_blocks));
+    pushUniqueFormattedText(parts, resolveSlackBlocksFallbackText(attachment.blocks));
+    pushUniqueFormattedText(parts, resolveSlackBlocksFallbackText(attachment.message_blocks));
   }
   return parts.length > 0 ? parts.join("\n") : undefined;
 }

--- a/extensions/slack/src/monitor/thread.ts
+++ b/extensions/slack/src/monitor/thread.ts
@@ -6,38 +6,11 @@ import {
   asDateTimestampMs,
   resolveExpiresAtMsFromDurationMs,
 } from "openclaw/plugin-sdk/number-runtime";
-import {
-  normalizeOptionalString,
-  readStringValue as readString,
-} from "openclaw/plugin-sdk/string-coerce-runtime";
+import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { formatSlackFileReferenceList } from "../file-reference.js";
 import type { SlackAttachment, SlackFile } from "../types.js";
+import { resolveSlackBlocksText } from "./block-text.js";
 import { logVerbose } from "./thread.runtime.js";
-
-type SlackTextObject = {
-  text?: unknown;
-};
-
-type SlackRichTextElement = {
-  type?: unknown;
-  text?: unknown;
-  url?: unknown;
-  user_id?: unknown;
-  channel_id?: unknown;
-  usergroup_id?: unknown;
-  name?: unknown;
-  range?: unknown;
-  elements?: unknown;
-};
-
-type SlackBlockLike = {
-  type?: unknown;
-  text?: unknown;
-  elements?: unknown;
-  fields?: unknown;
-  alt_text?: unknown;
-  title?: unknown;
-};
 
 export type SlackThreadStarter = {
   text: string;
@@ -74,179 +47,20 @@ function formatSlackFilePlaceholder(files: SlackFile[] | undefined): string {
   return `[attached: ${formatSlackFileReferenceList(files)}]`;
 }
 
-function cleanSlackTextCandidate(value: string | undefined): string | undefined {
-  if (typeof value !== "string") {
-    return undefined;
-  }
-  const normalized = value.replace(/\s+/g, " ").trim();
-  return normalized.length > 0 ? normalized : undefined;
-}
-
-function readPrimarySlackText(value: string | undefined): string | undefined {
-  if (typeof value !== "string") {
-    return undefined;
-  }
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : undefined;
-}
-
 function pushUniqueText(parts: string[], value: string | undefined): void {
-  const text = cleanSlackTextCandidate(value);
+  const text = normalizeOptionalString(value);
   if (text && !parts.includes(text)) {
     parts.push(text);
-  }
-}
-
-function pushUniqueFormattedText(parts: string[], value: string | undefined): void {
-  const text = readPrimarySlackText(value);
-  if (text && !parts.includes(text)) {
-    parts.push(text);
-  }
-}
-
-function readTextObject(value: unknown): string | undefined {
-  if (!value || typeof value !== "object") {
-    return undefined;
-  }
-  return normalizeOptionalString(readString((value as SlackTextObject).text));
-}
-
-function renderSlackRichTextLeaf(element: SlackRichTextElement): string {
-  switch (element.type) {
-    case "text":
-      return readString(element.text) ?? "";
-    case "link":
-      return readString(element.text) ?? readString(element.url) ?? "";
-    case "user": {
-      const userId = readString(element.user_id);
-      return userId ? `<@${userId}>` : "";
-    }
-    case "channel": {
-      const channelId = readString(element.channel_id);
-      return channelId ? `<#${channelId}>` : "";
-    }
-    case "usergroup": {
-      const usergroupId = readString(element.usergroup_id);
-      return usergroupId ? `<!subteam^${usergroupId}>` : "";
-    }
-    case "broadcast": {
-      const range = readString(element.range);
-      return range ? `<!${range}>` : "";
-    }
-    case "emoji": {
-      const name = readString(element.name);
-      return name ? `:${name}:` : "";
-    }
-    default:
-      return "";
-  }
-}
-
-function renderSlackRichTextElements(elements: unknown): string {
-  if (!Array.isArray(elements)) {
-    return "";
-  }
-  const parts: string[] = [];
-  for (const rawElement of elements) {
-    if (!rawElement || typeof rawElement !== "object") {
-      continue;
-    }
-    const element = rawElement as SlackRichTextElement;
-    switch (element.type) {
-      case "rich_text_section":
-      case "rich_text_preformatted":
-      case "rich_text_quote": {
-        parts.push(renderSlackRichTextElements(element.elements));
-        break;
-      }
-      case "rich_text_list": {
-        const listParts: string[] = [];
-        if (Array.isArray(element.elements)) {
-          for (const child of element.elements) {
-            if (!child || typeof child !== "object") {
-              continue;
-            }
-            const rendered = renderSlackRichTextElements((child as SlackRichTextElement).elements);
-            if (rendered) {
-              listParts.push(rendered);
-            }
-          }
-        }
-        parts.push(listParts.join("\n"));
-        break;
-      }
-      default:
-        parts.push(renderSlackRichTextLeaf(element));
-        break;
-    }
-  }
-  return parts.join("");
-}
-
-function readSlackBlockText(block: unknown): string | undefined {
-  if (!block || typeof block !== "object") {
-    return undefined;
-  }
-  const blockLike = block as SlackBlockLike;
-  switch (blockLike.type) {
-    case "rich_text":
-      return normalizeOptionalString(renderSlackRichTextElements(blockLike.elements));
-    case "section": {
-      const text = readTextObject(blockLike.text);
-      if (text) {
-        return text;
-      }
-      if (!Array.isArray(blockLike.fields)) {
-        return undefined;
-      }
-      const fields: string[] = [];
-      for (const field of blockLike.fields) {
-        const fieldText = readTextObject(field);
-        if (fieldText) {
-          fields.push(fieldText);
-        }
-      }
-      return fields.length > 0 ? fields.join("\n") : undefined;
-    }
-    case "header":
-      return readTextObject(blockLike.text);
-    case "context": {
-      if (!Array.isArray(blockLike.elements)) {
-        return undefined;
-      }
-      const parts: string[] = [];
-      for (const element of blockLike.elements) {
-        const text = readTextObject(element);
-        if (text) {
-          parts.push(text);
-        }
-      }
-      return parts.length > 0 ? parts.join(" ") : undefined;
-    }
-    case "image":
-      return normalizeOptionalString(readString(blockLike.alt_text)) ?? readTextObject(blockLike.title);
-    case "video":
-      return readTextObject(blockLike.title) ?? normalizeOptionalString(readString(blockLike.alt_text));
-    default:
-      return undefined;
   }
 }
 
 function resolveSlackBlocksFallbackText(blocks: unknown[] | undefined): string | undefined {
-  if (!Array.isArray(blocks) || blocks.length === 0) {
-    return undefined;
-  }
-  const parts: string[] = [];
-  for (const block of blocks) {
-    const text = readSlackBlockText(block);
-    if (text) {
-      parts.push(text);
-    }
-  }
-  return parts.length > 0 ? parts.join("\n") : undefined;
+  return resolveSlackBlocksText(blocks)?.text;
 }
 
-function resolveSlackAttachmentFallbackText(attachments: SlackAttachment[] | undefined): string | undefined {
+function resolveSlackAttachmentFallbackText(
+  attachments: SlackAttachment[] | undefined,
+): string | undefined {
   if (!Array.isArray(attachments) || attachments.length === 0) {
     return undefined;
   }
@@ -257,8 +71,12 @@ function resolveSlackAttachmentFallbackText(attachments: SlackAttachment[] | und
     pushUniqueText(parts, attachment.title);
     pushUniqueText(parts, attachment.text);
     pushUniqueText(parts, attachment.fallback);
-    pushUniqueFormattedText(parts, resolveSlackBlocksFallbackText(attachment.blocks));
-    pushUniqueFormattedText(parts, resolveSlackBlocksFallbackText(attachment.message_blocks));
+    for (const field of attachment.fields ?? []) {
+      pushUniqueText(parts, field.title);
+      pushUniqueText(parts, field.value);
+    }
+    pushUniqueText(parts, resolveSlackBlocksFallbackText(attachment.blocks));
+    pushUniqueText(parts, resolveSlackBlocksFallbackText(attachment.message_blocks));
   }
   return parts.length > 0 ? parts.join("\n") : undefined;
 }
@@ -269,7 +87,7 @@ function resolveSlackMessageText(message: {
   attachments?: SlackAttachment[];
 }): string | undefined {
   return (
-    readPrimarySlackText(message.text) ??
+    normalizeOptionalString(message.text) ??
     resolveSlackAttachmentFallbackText(message.attachments) ??
     resolveSlackBlocksFallbackText(message.blocks)
   );

--- a/extensions/slack/src/types.ts
+++ b/extensions/slack/src/types.ts
@@ -11,6 +11,7 @@ export type SlackFile = {
 
 export type SlackAttachment = {
   fallback?: string;
+  title?: string;
   text?: string;
   pretext?: string;
   author_name?: string;

--- a/extensions/slack/src/types.ts
+++ b/extensions/slack/src/types.ts
@@ -27,6 +27,7 @@ export type SlackAttachment = {
   image_height?: number;
   thumb_url?: string;
   files?: SlackFile[];
+  blocks?: unknown[];
   message_blocks?: unknown[];
 };
 

--- a/extensions/slack/src/types.ts
+++ b/extensions/slack/src/types.ts
@@ -27,6 +27,7 @@ export type SlackAttachment = {
   image_height?: number;
   thumb_url?: string;
   files?: SlackFile[];
+  fields?: Array<{ title?: string; value?: string }>;
   blocks?: unknown[];
   message_blocks?: unknown[];
 };


### PR DESCRIPTION
## What Problem This Solves

Slack monitoring messages can have an empty top-level `message.text` while their visible alert content lives in secondary attachments or Block Kit blocks. OpenClaw previously discarded those messages from thread starter/history context, leaving the agent unable to see the alert it was asked to triage.

Slack documents secondary attachments as a message text surface and returns thread messages through `conversations.replies`:

- https://docs.slack.dev/messaging/formatting-message-text/#attachments
- https://docs.slack.dev/reference/methods/conversations.replies/
- https://docs.slack.dev/reference/block-kit/blocks/

## Why This Change Was Made

The Slack plugin now uses one shared Block Kit text extractor for normal inbound messages and thread context. Thread starter/history fallback reads:

- attachment `pretext`, `title`, `text`, `fallback`, and legacy fields
- standard attachment `blocks` and Slack `message_blocks`
- top-level message blocks, including all readable sections and section fields

The shared extractor replaces the PR's duplicated parser, so inbound and thread paths cannot drift independently.

## User Impact

Agents can see and triage attachment-only or block-only Slack alert roots and prior thread messages. Existing non-empty top-level message text and file-only placeholders keep their prior behavior.

## Evidence

- Focused local proof: `node scripts/run-vitest.mjs extensions/slack/src/monitor/media.test.ts extensions/slack/src/monitor/message-handler/prepare.test.ts` — 129 tests passed.
- Formatting and whitespace: Oxfmt check and `git diff --check` passed.
- Fresh autoreview: clean, no actionable findings, correctness confidence 0.94.
- Final-rebase Testbox changed gate: `tbx_01kwq6zftt1s99cdk3wc6ae6cy` — extension typechecks, test types, lint, guards, runtime-sidecar checks, and import-cycle checks passed. Run: https://github.com/openclaw/openclaw/actions/runs/28715983396
- Exact-head hosted gates on `ca15bc0064c`: [CI](https://github.com/openclaw/openclaw/actions/runs/28715971791), [CodeQL Critical Quality](https://github.com/openclaw/openclaw/actions/runs/28715971807), and [Workflow Sanity](https://github.com/openclaw/openclaw/actions/runs/28715971790) passed with no failures.
- Live native Slack proof on exact head `ca15bc0064c`: posted one attachment-only root and one block-only root with whitespace/empty stored top-level text; the production `resolveSlackThreadStarter` and `resolveSlackThreadHistory` paths recovered every unique title, fallback, legacy-field, header, and section-field marker for both messages. Both synthetic messages were deleted and the pooled credential lease was released. No workspace IDs, message content, or credentials were retained or published.
