### PR TITLE
fix(whatsapp): emit sent hooks for native replies

### DIFF
--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.message-sent.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.message-sent.test.ts
@@ -1,0 +1,203 @@
+// WhatsApp tests prove native reply receipts reach the canonical sent-message observers.
+import {
+  dispatchChannelInboundReply,
+  type ChannelInboundTurnPlan,
+} from "openclaw/plugin-sdk/channel-inbound";
+import {
+  createMessageReceiptFromOutboundResults,
+  type MessageReceiptSourceResult,
+} from "openclaw/plugin-sdk/channel-outbound";
+import {
+  addTestHook,
+  createEmptyPluginRegistry,
+  initializeGlobalHookRunner,
+  resetGlobalHookRunner,
+  type PluginHookRegistration,
+} from "openclaw/plugin-sdk/channel-test-helpers";
+import { clearInternalHooks, registerInternalHook } from "openclaw/plugin-sdk/hook-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createTestWebInboundMessage } from "../../inbound/test-message.test-helper.js";
+import { createWhatsAppReplyPlan } from "./inbound-dispatch.js";
+
+const sessionKey = "agent:main:whatsapp:direct:+1000";
+type InternalHookEvent = Parameters<Parameters<typeof registerInternalHook>[1]>[0];
+
+function createReceipt(results: MessageReceiptSourceResult[]) {
+  return createMessageReceiptFromOutboundResults({
+    kind: "unknown",
+    results,
+  });
+}
+
+function createPlan(deliverReply: Parameters<typeof createWhatsAppReplyPlan>[0]["deliverReply"]) {
+  const msg = createTestWebInboundMessage({
+    event: { id: "wa-inbound-1" },
+    payload: { body: "show me the result" },
+    platform: {
+      chatJid: "1000@s.whatsapp.net",
+      recipientJid: "+2000",
+      senderJid: "1000@s.whatsapp.net",
+    },
+    admission: {
+      accountId: "default",
+      conversation: { kind: "direct", id: "+1000" },
+      sender: { id: "1000@s.whatsapp.net" },
+    },
+  });
+  const context = {
+    Body: "show me the result",
+    BodyForAgent: "show me the result",
+    RawBody: "show me the result",
+    CommandBody: "show me the result",
+    From: "+1000",
+    To: "+2000",
+    SessionKey: sessionKey,
+    Provider: "whatsapp",
+    Surface: "whatsapp",
+    OriginatingChannel: "whatsapp",
+    OriginatingTo: "+1000",
+    AccountId: "default",
+    ChatType: "direct",
+    CommandAuthorized: false,
+  };
+  const plan = createWhatsAppReplyPlan({
+    cfg: { channels: { whatsapp: {} } } as never,
+    connectionId: "conn-1",
+    context,
+    deliverReply,
+    groupHistories: new Map(),
+    groupHistoryKey: sessionKey,
+    maxMediaBytes: 1024,
+    msg,
+    rememberSentText: vi.fn(),
+    replyLogger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    } as never,
+    replyPipeline: {},
+    replyResolver: (async () => undefined) as never,
+    route: {
+      agentId: "main",
+      channel: "whatsapp",
+      accountId: "default",
+      sessionKey,
+      mainSessionKey: sessionKey,
+      lastRoutePolicy: "main",
+      matchedBy: "default",
+    },
+    shouldClearGroupHistory: false,
+  });
+  return { context, plan };
+}
+
+afterEach(() => {
+  clearInternalHooks();
+  resetGlobalHookRunner();
+});
+
+describe("WhatsApp canonical message_sent delivery", () => {
+  it("emits one receipt-backed event with session and run correlation for multipart media", async () => {
+    const pluginHook = vi.fn();
+    const internalHook = vi.fn();
+    const registry = createEmptyPluginRegistry();
+    addTestHook({
+      registry,
+      pluginId: "whatsapp-message-sent-test",
+      hookName: "message_sent",
+      handler: pluginHook as PluginHookRegistration["handler"],
+    });
+    initializeGlobalHookRunner(registry);
+    registerInternalHook("message:sent", internalHook);
+
+    const receipt = createReceipt([
+      { channel: "whatsapp", messageId: "wa-media-1" },
+      { channel: "whatsapp", messageId: "wa-caption-2" },
+    ]);
+    const { context, plan } = createPlan(async () => ({
+      results: [],
+      receipt,
+      providerAccepted: true,
+    }));
+    const dispatchReplyWithBufferedBlockDispatcher = vi.fn(async (params) => {
+      params.replyOptions?.onAgentRunStart?.("run-wa-1");
+      await params.dispatcherOptions.deliver(
+        {
+          text: "generated image",
+          mediaUrls: ["/tmp/generated.jpg", "/tmp/details.pdf"],
+        },
+        { kind: "final" },
+      );
+      return { queuedFinal: true, counts: { tool: 0, block: 0, final: 1 } };
+    });
+
+    await dispatchChannelInboundReply({
+      cfg: { channels: { whatsapp: {} } } as never,
+      channel: "whatsapp",
+      accountId: "default",
+      agentId: "main",
+      routeSessionKey: sessionKey,
+      storePath: "/tmp/whatsapp-message-sent-test.json",
+      ctxPayload: context,
+      recordInboundSession: async () => undefined,
+      dispatchReplyWithBufferedBlockDispatcher,
+      dispatcherOptions: plan.dispatcherOptions,
+      delivery: plan.delivery,
+      replyOptions: plan.replyOptions,
+      replyResolver: plan.replyResolver,
+    });
+
+    await vi.waitFor(() => {
+      expect(pluginHook).toHaveBeenCalledOnce();
+      expect(internalHook).toHaveBeenCalledOnce();
+    });
+    expect(pluginHook).toHaveBeenCalledWith(
+      {
+        to: "+1000",
+        content: "generated image",
+        success: true,
+        messageId: "wa-media-1",
+        sessionKey,
+        runId: "run-wa-1",
+      },
+      {
+        channelId: "whatsapp",
+        accountId: "default",
+        conversationId: "+1000",
+        sessionKey,
+        runId: "run-wa-1",
+        messageId: "wa-media-1",
+      },
+    );
+    const internalEvent = internalHook.mock.calls[0]?.[0] as InternalHookEvent;
+    expect(internalEvent).toMatchObject({
+      type: "message",
+      action: "sent",
+      sessionKey,
+      context: {
+        to: "+1000",
+        content: "generated image",
+        success: true,
+        channelId: "whatsapp",
+        accountId: "default",
+        conversationId: "+1000",
+        messageId: "wa-media-1",
+      },
+    });
+  });
+
+  it("keeps durable text on the core-owned path without native fallback", async () => {
+    const deliverReply = vi.fn();
+    const { plan } = createPlan(deliverReply);
+    const delivery = plan.delivery as ChannelInboundTurnPlan["delivery"];
+
+    expect(delivery.observeMessageSent).toBe(true);
+    expect(
+      typeof delivery.durable === "function"
+        ? await delivery.durable({ text: "durable text" }, { kind: "final" })
+        : delivery.durable,
+    ).toMatchObject({ to: "+1000" });
+    expect(deliverReply).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts
@@ -877,6 +877,7 @@ describe("whatsapp inbound dispatch", () => {
     });
     const deliverReply = vi.fn().mockRejectedValueOnce(error);
     let deferredFinalization: Promise<unknown> | undefined;
+    let replacementFailure: unknown;
     dispatchReplyWithBufferedBlockDispatcherMock.mockImplementationOnce(
       async (params: CapturedDispatchParams) => {
         capturedDispatchParams = params;
@@ -892,12 +893,14 @@ describe("whatsapp inbound dispatch", () => {
           "deferred media result",
         );
         deferredFinalization = deferred.finalization as Promise<unknown>;
-        await expect(
-          deliver(
+        try {
+          await deliver(
             { text: "captioned replacement", mediaUrls: ["/tmp/generated.jpg"] },
             { kind: "block" },
-          ),
-        ).rejects.toBe(error);
+          );
+        } catch (deliveryError: unknown) {
+          replacementFailure = deliveryError;
+        }
         await params.dispatcherOptions?.onSettled?.();
         return { queuedFinal: false, counts: { tool: 1, block: 1, final: 0 } };
       },
@@ -907,6 +910,16 @@ describe("whatsapp inbound dispatch", () => {
 
     await expect(deferredFinalization).resolves.toEqual({ visibleReplySent: false });
     expect(deliverReply).toHaveBeenCalledTimes(1);
+    expect(replacementFailure).toMatchObject({
+      code: "CHANNEL_PARTIAL_DELIVERY",
+      deliveryResult: {
+        content: "captioned replacement",
+        visibleReplySent: true,
+      },
+      sentBeforeError: true,
+      visibleReplySent: true,
+    });
+    expect((replacementFailure as Error).cause).toBe(error);
   });
 
   it("drops deferred media when replacement bookkeeping fails after provider acceptance", async () => {
@@ -916,6 +929,7 @@ describe("whatsapp inbound dispatch", () => {
       throw error;
     });
     let deferredFinalization: Promise<unknown> | undefined;
+    let replacementFailure: unknown;
     dispatchReplyWithBufferedBlockDispatcherMock.mockImplementationOnce(
       async (params: CapturedDispatchParams) => {
         capturedDispatchParams = params;
@@ -931,15 +945,14 @@ describe("whatsapp inbound dispatch", () => {
           "deferred media result",
         );
         deferredFinalization = deferred.finalization as Promise<unknown>;
-        await expect(
-          deliver(
+        try {
+          await deliver(
             { text: "captioned replacement", mediaUrls: ["/tmp/generated.jpg"] },
             { kind: "block" },
-          ),
-        ).rejects.toMatchObject({
-          sentBeforeError: true,
-          visibleReplySent: true,
-        });
+          );
+        } catch (deliveryError: unknown) {
+          replacementFailure = deliveryError;
+        }
         await params.dispatcherOptions?.onSettled?.();
         return { queuedFinal: false, counts: { tool: 1, block: 1, final: 0 } };
       },
@@ -949,7 +962,32 @@ describe("whatsapp inbound dispatch", () => {
 
     await expect(deferredFinalization).resolves.toEqual({ visibleReplySent: false });
     expect(deliverReply).toHaveBeenCalledTimes(1);
-    expect(error).toMatchObject({ sentBeforeError: true, visibleReplySent: true });
+    expect(replacementFailure).toMatchObject({
+      code: "CHANNEL_PARTIAL_DELIVERY",
+      deliveryResult: {
+        content: "captioned replacement",
+        messageIds: ["wa-sent-1"],
+        receipt: testReceipt(["wa-sent-1"]),
+        visibleReplySent: true,
+      },
+      sentBeforeError: true,
+      visibleReplySent: true,
+    });
+    expect((replacementFailure as Error).cause).toBe(error);
+  });
+
+  it("returns receipt-backed delivery facts for native text fallback", async () => {
+    const deliverReply = vi.fn(async () => acceptedDeliveryResult());
+
+    await dispatchBufferedReply({ deliverReply });
+
+    const deliver = getCapturedDeliver();
+    await expect(deliver?.({ text: "fallback text" }, { kind: "final" })).resolves.toMatchObject({
+      content: "fallback text",
+      messageIds: ["wa-sent-1"],
+      receipt: testReceipt(["wa-sent-1"]),
+      visibleReplySent: true,
+    });
   });
 
   it.each([
@@ -1160,7 +1198,12 @@ describe("whatsapp inbound dispatch", () => {
     await expect(deliver?.({ text: "cancelled final" }, { kind: "final" })).resolves.toMatchObject({
       visibleReplySent: false,
     });
-    await expect(deferred.finalization).resolves.toMatchObject({ visibleReplySent: true });
+    await expect(deferred.finalization).resolves.toMatchObject({
+      visibleReplySent: true,
+      messageIds: ["wa-sent-1"],
+      content: "",
+      receipt: testReceipt(["wa-sent-1"]),
+    });
     expect(deliverReply).toHaveBeenCalledTimes(1);
   });
 

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
@@ -2,6 +2,7 @@
 import type { StatusReactionController } from "openclaw/plugin-sdk/channel-feedback";
 import {
   buildChannelInboundEventContext,
+  createChannelPartialDeliveryError,
   isChannelPartialDeliveryError,
   type CommandFacts,
   type ChannelInboundTurnPlan,
@@ -10,6 +11,7 @@ import {
 import { hasVisibleInboundReplyDispatch } from "openclaw/plugin-sdk/channel-inbound";
 import {
   bindIngressLifecycleToReplyOptions,
+  listMessageReceiptPlatformIds,
   resolveChannelStreamingBlockEnabled,
 } from "openclaw/plugin-sdk/channel-outbound";
 import { buildInboundHistoryFromEntries } from "openclaw/plugin-sdk/reply-history";
@@ -101,12 +103,28 @@ function normalizeErrForLog(err: unknown): unknown {
 
 type WhatsAppReplyDeliveryVisibility = {
   visibleReplySent: boolean;
+  receipt?: WhatsAppReplyDeliveryResult["receipt"];
+  messageIds?: string[];
+  content?: string;
 };
 
 function whatsAppReplyDeliveryVisibility(
   visibleReplySent: boolean,
 ): WhatsAppReplyDeliveryVisibility {
   return { visibleReplySent };
+}
+
+function createWhatsAppChannelDeliveryResult(params: {
+  content: string;
+  delivery: WhatsAppReplyDeliveryResult;
+}): WhatsAppReplyDeliveryVisibility {
+  const messageIds = listMessageReceiptPlatformIds(params.delivery.receipt);
+  return {
+    receipt: params.delivery.receipt,
+    ...(messageIds.length > 0 ? { messageIds } : {}),
+    content: params.content,
+    visibleReplySent: params.delivery.providerAccepted,
+  };
 }
 
 function isWhatsAppVisibleDeliveryError(error: unknown): boolean {
@@ -643,20 +661,35 @@ export function createWhatsAppReplyPlan(params: {
     if (!reply.hasMedia && !reply.text.trim()) {
       return whatsAppReplyDeliveryVisibility(false);
     }
-    const delivery = await params.deliverReply({
-      replyResult: normalizedDeliveryPayload,
-      normalizedReplyResult: normalizedDeliveryPayload,
-      msg: params.msg,
-      mediaLocalRoots,
-      maxMediaBytes: params.maxMediaBytes,
-      textLimit,
-      chunkMode,
-      replyLogger: params.replyLogger,
-      connectionId: params.connectionId,
-      skipLog: false,
-      tableMode,
+    let delivery: WhatsAppReplyDeliveryResult;
+    try {
+      delivery = await params.deliverReply({
+        replyResult: normalizedDeliveryPayload,
+        normalizedReplyResult: normalizedDeliveryPayload,
+        msg: params.msg,
+        mediaLocalRoots,
+        maxMediaBytes: params.maxMediaBytes,
+        textLimit,
+        chunkMode,
+        replyLogger: params.replyLogger,
+        connectionId: params.connectionId,
+        skipLog: false,
+        tableMode,
+      });
+    } catch (error: unknown) {
+      if (isWhatsAppVisibleDeliveryError(error) && !isChannelPartialDeliveryError(error)) {
+        throw createChannelPartialDeliveryError(error, {
+          content: reply.text,
+          visibleReplySent: true,
+        });
+      }
+      throw error;
+    }
+    const result = createWhatsAppChannelDeliveryResult({
+      content: reply.text,
+      delivery,
     });
-    if (!delivery.providerAccepted) {
+    if (!result.visibleReplySent) {
       params.replyLogger.warn(
         {
           correlationId: params.msg.event.id ?? null,
@@ -669,17 +702,19 @@ export function createWhatsAppReplyPlan(params: {
         },
         "auto-reply was not accepted by WhatsApp provider",
       );
-      return whatsAppReplyDeliveryVisibility(false);
+      return result;
     }
     if (options?.recordDelivery !== false) {
       try {
         recordDeliveredPayload(normalizedDeliveryPayload);
       } catch (error: unknown) {
-        // Native delivery is already accepted; bookkeeping failure must retain visibility.
-        throw markWhatsAppVisibleDeliveryError(error);
+        throw createChannelPartialDeliveryError(error, {
+          ...result,
+          visibleReplySent: true,
+        });
       }
     }
-    return whatsAppReplyDeliveryVisibility(true);
+    return result;
   };
 
   const mediaOnlyCoalescer = createWhatsAppMediaOnlyReplyCoalescer({
@@ -704,6 +739,7 @@ export function createWhatsAppReplyPlan(params: {
     onReplyStart: params.msg.platform.sendComposing,
   };
   const delivery: ChannelInboundTurnPlan["delivery"] = {
+    observeMessageSent: true,
     preparePayload: async (payload: ReplyPayload, info: { kind: ReplyLifecycleKind }) => {
       const deliveryPayload = resolveWhatsAppDeliverablePayload(payload, info);
       if (!deliveryPayload) {


### PR DESCRIPTION
Closes #97726

## What Problem This Solves

Fixes an issue where WhatsApp native auto-replies could be accepted by the provider without producing the canonical `message_sent` observation. Hook consumers therefore missed successful replies sent through the WhatsApp inbound turn path.

## Why This Change Was Made

The rewrite keeps ownership at the existing channel-turn boundary. WhatsApp now returns its existing provider receipt, message IDs, visible content, and partial-delivery state through `ChannelDeliveryResult`, and opts into the core-owned `message_sent` observation.

This intentionally removes the original generic SDK emitter, TTL deduplication cache, and second emission path. Durable outbound delivery remains owned by the existing durable pipeline and is not observed twice.

## User Impact

`message_sent` hooks now observe provider-accepted WhatsApp native auto-replies with their canonical receipt and message IDs. Suppressed, rejected, deferred, and partially delivered replies preserve their existing behavior.

No config, environment variable, protocol, persistence, or public plugin SDK surface is added.

## Evidence

Exact maintainer rewrite head: `a6d06a783072a236b762b45ffcc783ab9ddf244a`

- 63 focused WhatsApp inbound-dispatch tests passed after rebasing onto current `main`.
- The broader rewrite proof passed 156 tests covering native fallback, multipart replies, deferred media, partial failure, and durable-delivery non-duplication.
- Fresh branch autoreview found no actionable findings and rated the owner-boundary rewrite correct.
- Targeted typecheck, lint, format, and diff checks passed before the final rebase; hosted exact-head CI is the final gate.

Live pairing with a real WhatsApp account was not used because no disposable account was available. The tests exercise the production channel-turn and delivery-receipt composition rather than a new reporting shim.
