### PR TITLE
fix(security): align browser audit with plugin policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Security audit browser posture:** derive Browser control and small-model exposure reporting from canonical plugin activation policy, so restrictive allowlists and explicit deny/disable settings no longer report the Browser plugin as exposed while explicit Browser config retains startup intent. (#97732) Thanks @amtellezfernandez.
+- **Security audit browser posture:** derive Browser control and small-model exposure reporting from canonical plugin activation policy, so restrictive allowlists and explicit deny/disable settings no longer report the Browser plugin as exposed and Browser config cannot bypass global plugin policy. (#97732) Thanks @amtellezfernandez.
 - **Codex yielded native subagents:** keep the parent app-server subscription and shared client alive until yielded native subagent completion delivery settles, preventing lost wakeups and leaked one-shot cleanup.
 - **Discord streamed finals:** send completion replies as fresh messages so inactive channels become unread, while preserving targeted mentions without escalating `@everyone` or `@here`. (#99711, #99662) Thanks @davelutztx.
 - **OpenAI-compatible SSE parsing:** recognize event streams mislabeled as JSON without prepending a second `data:` prefix, preserving valid streamed responses from non-conforming providers. (#96503) Thanks @ZengWen-DT.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Security audit browser posture:** derive Browser control and small-model exposure reporting from canonical plugin activation policy, so restrictive allowlists and explicit deny/disable settings no longer report the Browser plugin as exposed and Browser config cannot bypass global plugin policy. (#97732) Thanks @amtellezfernandez.
 - **Codex yielded native subagents:** keep the parent app-server subscription and shared client alive until yielded native subagent completion delivery settles, preventing lost wakeups and leaked one-shot cleanup.
 - **Discord streamed finals:** send completion replies as fresh messages so inactive channels become unread, while preserving targeted mentions without escalating `@everyone` or `@here`. (#99711, #99662) Thanks @davelutztx.
 - **OpenAI-compatible SSE parsing:** recognize event streams mislabeled as JSON without prepending a second `data:` prefix, preserving valid streamed responses from non-conforming providers. (#96503) Thanks @ZengWen-DT.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Security audit browser posture:** derive Browser control and small-model exposure reporting from canonical plugin activation policy, so restrictive allowlists and explicit deny/disable settings no longer report the Browser plugin as exposed while explicit Browser config retains startup intent. (#97732) Thanks @amtellezfernandez.
 - **Codex yielded native subagents:** keep the parent app-server subscription and shared client alive until yielded native subagent completion delivery settles, preventing lost wakeups and leaked one-shot cleanup.
 - **Discord streamed finals:** send completion replies as fresh messages so inactive channels become unread, while preserving targeted mentions without escalating `@everyone` or `@here`. (#99711, #99662) Thanks @davelutztx.
 - **OpenAI-compatible SSE parsing:** recognize event streams mislabeled as JSON without prepending a second `data:` prefix, preserving valid streamed responses from non-conforming providers. (#96503) Thanks @ZengWen-DT.

--- a/src/security/audit-extra.summary.ts
+++ b/src/security/audit-extra.summary.ts
@@ -117,13 +117,43 @@ function isBrowserEnabled(cfg: OpenClawConfig): boolean {
   return cfg.browser?.enabled !== false;
 }
 
+function listIncludesPluginId(list: readonly string[] | undefined, pluginId: string): boolean {
+  const normalizedPluginId = pluginId.trim().toLowerCase();
+  return list?.some((entry) => entry.trim().toLowerCase() === normalizedPluginId) ?? false;
+}
+
+function hasBrowserStartupIntent(cfg: OpenClawConfig): boolean {
+  return cfg.browser !== undefined && cfg.browser.enabled !== false;
+}
+
+function isBrowserControlSummaryEnabled(cfg: OpenClawConfig): boolean {
+  if (cfg.browser?.enabled === false || cfg.plugins?.enabled === false) {
+    return false;
+  }
+  if (
+    cfg.plugins?.entries?.browser?.enabled === false ||
+    listIncludesPluginId(cfg.plugins?.deny, "browser")
+  ) {
+    return false;
+  }
+  if (
+    Array.isArray(cfg.plugins?.allow) &&
+    cfg.plugins.allow.length > 0 &&
+    !listIncludesPluginId(cfg.plugins.allow, "browser") &&
+    !hasBrowserStartupIntent(cfg)
+  ) {
+    return false;
+  }
+  return true;
+}
+
 /** Produce a concise inventory of major security-relevant surfaces. */
 export function collectAttackSurfaceSummaryFindings(cfg: OpenClawConfig): SecurityAuditFinding[] {
   const group = summarizeGroupPolicy(cfg);
   const elevated = cfg.tools?.elevated?.enabled !== false;
   const webhooksEnabled = cfg.hooks?.enabled === true;
   const internalHooksEnabled = hasConfiguredInternalHooks(cfg);
-  const browserEnabled = cfg.browser?.enabled ?? true;
+  const browserEnabled = isBrowserControlSummaryEnabled(cfg);
 
   const detail =
     `groups: open=${group.open}, allowlist=${group.allowlist}` +

--- a/src/security/audit-extra.summary.ts
+++ b/src/security/audit-extra.summary.ts
@@ -1,3 +1,4 @@
+import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 // Summarizes extra security audit findings for user-facing output.
 import {
   resolveConfiguredToolPolicies,
@@ -10,6 +11,8 @@ import { isToolAllowedByPolicies } from "../agents/tool-policy-match.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { AgentToolsConfig } from "../config/types.tools.js";
 import { hasConfiguredInternalHooks } from "../hooks/configured.js";
+import { normalizePluginsConfigWithResolver } from "../plugins/config-normalization-shared.js";
+import { passesManifestOwnerBasePolicy } from "../plugins/manifest-owner-policy.js";
 import { hasConfiguredWebSearchCredential } from "../plugins/web-search-credential-presence.js";
 import { inferParamBFromIdOrName } from "../shared/model-param-b.js";
 import { collectAuditModelRefs } from "./audit-model-refs.js";
@@ -114,37 +117,19 @@ function isWebFetchEnabled(cfg: OpenClawConfig): boolean {
 }
 
 function isBrowserEnabled(cfg: OpenClawConfig): boolean {
-  return cfg.browser?.enabled !== false;
-}
-
-function listIncludesPluginId(list: readonly string[] | undefined, pluginId: string): boolean {
-  const normalizedPluginId = pluginId.trim().toLowerCase();
-  return list?.some((entry) => entry.trim().toLowerCase() === normalizedPluginId) ?? false;
-}
-
-function hasBrowserStartupIntent(cfg: OpenClawConfig): boolean {
-  return cfg.browser !== undefined && cfg.browser.enabled !== false;
-}
-
-function isBrowserControlSummaryEnabled(cfg: OpenClawConfig): boolean {
-  if (cfg.browser?.enabled === false || cfg.plugins?.enabled === false) {
+  if (cfg.browser?.enabled === false) {
     return false;
   }
-  if (
-    cfg.plugins?.entries?.browser?.enabled === false ||
-    listIncludesPluginId(cfg.plugins?.deny, "browser")
-  ) {
-    return false;
-  }
-  if (
-    Array.isArray(cfg.plugins?.allow) &&
-    cfg.plugins.allow.length > 0 &&
-    !listIncludesPluginId(cfg.plugins.allow, "browser") &&
-    !hasBrowserStartupIntent(cfg)
-  ) {
-    return false;
-  }
-  return true;
+  return passesManifestOwnerBasePolicy({
+    plugin: { id: "browser" },
+    normalizedConfig: normalizePluginsConfigWithResolver(
+      cfg.plugins,
+      (pluginId) => normalizeOptionalLowercaseString(pluginId) ?? "",
+    ),
+    // Explicit browser config is a manifest-owned startup path and therefore
+    // bypasses only the restrictive allowlist, never deny or disable policy.
+    allowRestrictiveAllowlistBypass: cfg.browser !== undefined,
+  });
 }
 
 /** Produce a concise inventory of major security-relevant surfaces. */
@@ -153,7 +138,7 @@ export function collectAttackSurfaceSummaryFindings(cfg: OpenClawConfig): Securi
   const elevated = cfg.tools?.elevated?.enabled !== false;
   const webhooksEnabled = cfg.hooks?.enabled === true;
   const internalHooksEnabled = hasConfiguredInternalHooks(cfg);
-  const browserEnabled = isBrowserControlSummaryEnabled(cfg);
+  const browserEnabled = isBrowserEnabled(cfg);
 
   const detail =
     `groups: open=${group.open}, allowlist=${group.allowlist}` +

--- a/src/security/audit-extra.summary.ts
+++ b/src/security/audit-extra.summary.ts
@@ -126,9 +126,7 @@ function isBrowserEnabled(cfg: OpenClawConfig): boolean {
       cfg.plugins,
       (pluginId) => normalizeOptionalLowercaseString(pluginId) ?? "",
     ),
-    // Explicit browser config is a manifest-owned startup path and therefore
-    // bypasses only the restrictive allowlist, never deny or disable policy.
-    allowRestrictiveAllowlistBypass: cfg.browser !== undefined,
+    // Browser config selects behavior; it must not weaken global plugin policy.
   });
 }
 

--- a/src/security/audit-extra.sync.test.ts
+++ b/src/security/audit-extra.sync.test.ts
@@ -68,6 +68,10 @@ describe("collectSmallModelRiskFindings", () => {
     agents: { defaults: { model: { primary: "ollama/mistral-8b" } } },
     tools: { web: { fetch: { enabled: false } } },
   } satisfies OpenClawConfig;
+  const browserBlockedByPluginPolicyCfg = {
+    ...browserDefaultCfg,
+    plugins: { allow: ["openai"] },
+  } satisfies OpenClawConfig;
 
   it.each([
     {
@@ -85,6 +89,14 @@ describe("collectSmallModelRiskFindings", () => {
       expectedSeverity: "critical",
       detailIncludes: ["web=[browser]"],
       detailExcludes: ["No web/browser tools detected"],
+    },
+    {
+      name: "treats browser as disabled when restrictive plugin policy excludes it",
+      cfg: browserBlockedByPluginPolicyCfg,
+      env: {},
+      expectedSeverity: "info",
+      detailIncludes: ["web=[off]", "No web/browser tools detected"],
+      detailExcludes: ["web=[browser]"],
     },
   ])("$name", ({ cfg, env, expectedSeverity, detailIncludes, detailExcludes }) => {
     const finding = requireFirstFinding(

--- a/src/security/audit-extra.sync.test.ts
+++ b/src/security/audit-extra.sync.test.ts
@@ -72,6 +72,10 @@ describe("collectSmallModelRiskFindings", () => {
     ...browserDefaultCfg,
     plugins: { allow: ["openai"] },
   } satisfies OpenClawConfig;
+  const configuredBrowserBlockedByPluginPolicyCfg = {
+    ...browserBlockedByPluginPolicyCfg,
+    browser: { enabled: true },
+  } satisfies OpenClawConfig;
 
   it.each([
     {
@@ -93,6 +97,14 @@ describe("collectSmallModelRiskFindings", () => {
     {
       name: "treats browser as disabled when restrictive plugin policy excludes it",
       cfg: browserBlockedByPluginPolicyCfg,
+      env: {},
+      expectedSeverity: "info",
+      detailIncludes: ["web=[off]", "No web/browser tools detected"],
+      detailExcludes: ["web=[browser]"],
+    },
+    {
+      name: "does not let browser config bypass restrictive plugin policy",
+      cfg: configuredBrowserBlockedByPluginPolicyCfg,
       env: {},
       expectedSeverity: "info",
       detailIncludes: ["web=[off]", "No web/browser tools detected"],

--- a/src/security/audit-summary.test.ts
+++ b/src/security/audit-summary.test.ts
@@ -38,4 +38,50 @@ describe("security audit attack surface summary", () => {
       ].join("\n"),
     );
   });
+
+  it.each([
+    {
+      name: "restrictive plugin allowlist excludes browser and no browser config is present",
+      cfg: {
+        plugins: { allow: ["openai"] },
+      } satisfies OpenClawConfig,
+      expected: "browser control: disabled",
+    },
+    {
+      name: "explicit browser config is startup intent even when browser is absent from allowlist",
+      cfg: {
+        browser: { enabled: true },
+        plugins: { allow: ["openai"] },
+      } satisfies OpenClawConfig,
+      expected: "browser control: enabled",
+    },
+    {
+      name: "plugin deny policy wins over explicit browser config",
+      cfg: {
+        browser: { enabled: true },
+        plugins: { allow: ["browser"], deny: ["browser"] },
+      } satisfies OpenClawConfig,
+      expected: "browser control: disabled",
+    },
+    {
+      name: "disabled browser plugin entry wins over explicit browser config",
+      cfg: {
+        browser: { enabled: true },
+        plugins: { allow: ["browser"], entries: { browser: { enabled: false } } },
+      } satisfies OpenClawConfig,
+      expected: "browser control: disabled",
+    },
+    {
+      name: "browser.enabled=false disables browser control",
+      cfg: {
+        browser: { enabled: false },
+        plugins: { allow: ["browser"] },
+      } satisfies OpenClawConfig,
+      expected: "browser control: disabled",
+    },
+  ])("reports browser control from effective plugin policy: $name", ({ cfg, expected }) => {
+    const summary = requireAttackSurfaceSummary(collectAttackSurfaceSummaryFindings(cfg));
+
+    expect(summary.detail).toContain(expected);
+  });
 });

--- a/src/security/audit-summary.test.ts
+++ b/src/security/audit-summary.test.ts
@@ -56,6 +56,13 @@ describe("security audit attack surface summary", () => {
       expected: "browser control: enabled",
     },
     {
+      name: "plugin ids use the same case-insensitive canonical form as startup",
+      cfg: {
+        plugins: { allow: ["Browser"] },
+      } satisfies OpenClawConfig,
+      expected: "browser control: enabled",
+    },
+    {
       name: "plugin deny policy wins over explicit browser config",
       cfg: {
         browser: { enabled: true },
@@ -76,6 +83,13 @@ describe("security audit attack surface summary", () => {
       cfg: {
         browser: { enabled: false },
         plugins: { allow: ["browser"] },
+      } satisfies OpenClawConfig,
+      expected: "browser control: disabled",
+    },
+    {
+      name: "case-normalized plugin deny policy disables browser control",
+      cfg: {
+        plugins: { deny: ["BROWSER"] },
       } satisfies OpenClawConfig,
       expected: "browser control: disabled",
     },

--- a/src/security/audit-summary.test.ts
+++ b/src/security/audit-summary.test.ts
@@ -48,12 +48,12 @@ describe("security audit attack surface summary", () => {
       expected: "browser control: disabled",
     },
     {
-      name: "explicit browser config is startup intent even when browser is absent from allowlist",
+      name: "explicit browser config does not bypass a restrictive plugin allowlist",
       cfg: {
         browser: { enabled: true },
         plugins: { allow: ["openai"] },
       } satisfies OpenClawConfig,
-      expected: "browser control: enabled",
+      expected: "browser control: disabled",
     },
     {
       name: "plugin ids use the same case-insensitive canonical form as startup",


### PR DESCRIPTION
## What Problem This Solves

`openclaw security audit` could report `browser control: enabled` and flag Browser exposure for small-model agents even when global plugin policy prevented the bundled Browser plugin from running. The summary treated omitted Browser config as enabled without applying `plugins.enabled`, `plugins.allow`, `plugins.deny`, or `plugins.entries.browser.enabled`.

## Why This Change Was Made

The rewritten change uses the existing canonical manifest-owner base policy instead of duplicating plugin-policy rules in security code. Browser plugin ids are normalized case-insensitively, matching startup behavior, and one shared predicate now drives both:

- `summary.attack_surface` Browser-control reporting
- `models.small_params` Browser-tool exposure reporting

Global plugin policy remains authoritative. Explicit `browser` config selects Browser behavior but does not bypass a restrictive plugin allowlist; operators who use `plugins.allow` must include `browser` to expose Browser control.

This does not change the per-agent trust boundary. The small-model check still evaluates each agent's sandbox and tool policy independently after global Browser availability is established.

## User Impact

- Restrictive plugin configurations no longer receive a false Browser-enabled summary.
- Small agents no longer receive a false `web=[browser]` risk classification when Browser is globally unavailable.
- Mixed-case `Browser`/`BROWSER` policy entries are interpreted the same way as Gateway startup.
- Explicitly allowed Browser configurations keep full Browser functionality.
- No config, schema, migration, protocol, or runtime enablement behavior changes.

## Evidence

Final PR head: `a2ad2c8e12e2e5f95bc1dafaa689f1342c222596`

- Focused remote suite: `pnpm test src/security/audit-summary.test.ts src/security/audit-extra.sync.test.ts` — 16/16 passed.
- Sanitized direct-AWS run `run_3fb78ed75c91` on fresh public-network lease `cbx_58fe8eb9e642` (`brisk-krill`, `c7a.8xlarge`) exercised the exact pre-rebase head `c98ea86a471667056ad20e8c5e88462243376b59`.
- The live-proven pre-rebase head and final head have the identical `src/security/**` stable patch id `d87df79373b19924dc57e146d0f084e0dbb3a9c9`; later changes only rebased onto current `main` and removed the release-owned root changelog line required by native prepare policy.
- Restrictive state (`plugins.allow=["openai"]`): audit reported `browser control: disabled`, the small agent reported `web=[off]`, Browser inventory was disabled, a real Gateway started, and an `openai/gpt-5.4` agent returned `SECURITY_POLICY_OK`.
- Explicitly allowed state (`plugins.allow=["openai","browser"]`, `browser.enabled=true`): audit reported `browser control: enabled`, the small agent reported `web=[browser]`, a real Gateway and managed Chrome started, and an `openai/gpt-5.4` agent used the Browser tool against the live page and returned `SECURITY_BROWSER_OK`.
- Fresh final-head autoreview against `origin/main`: no accepted/actionable findings, confidence 0.86.
- [Exact-head hosted CI](https://github.com/openclaw/openclaw/actions/runs/28834540783): all selected checks passed on `a2ad2c8e12e2e5f95bc1dafaa689f1342c222596`.

## Scope

This is an audit-reporting correction. It does not change plugin activation, Browser startup, Browser authorization, per-agent tool policy, or Gateway behavior.
