### PR TITLE
fix(discord): truncate forum thread names on a surrogate boundary

### DIFF
--- a/extensions/discord/src/send.outbound.thread-name.test.ts
+++ b/extensions/discord/src/send.outbound.thread-name.test.ts
@@ -1,0 +1,39 @@
+// Discord plugin tests cover forum/media thread-name derivation.
+import { describe, expect, it } from "vitest";
+import { deriveForumThreadName } from "./send.outbound.js";
+
+const DISCORD_THREAD_NAME_LIMIT = 100;
+
+// Matches a high surrogate not followed by a low surrogate, or a low surrogate
+// not preceded by a high one — i.e. a split surrogate pair.
+const LONE_SURROGATE = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/;
+
+describe("deriveForumThreadName", () => {
+  it("uses the first non-empty line and caps it at the Discord limit", () => {
+    const name = deriveForumThreadName(`\n  \n${"a".repeat(150)}`);
+    expect(name).toBe("a".repeat(DISCORD_THREAD_NAME_LIMIT));
+  });
+
+  it("does not split a surrogate pair at the length boundary", () => {
+    // 99 ASCII chars then an emoji whose surrogate pair straddles index 100.
+    const text = `${"x".repeat(DISCORD_THREAD_NAME_LIMIT - 1)}😀 rest of the line`;
+    const name = deriveForumThreadName(text);
+    expect(name.length).toBeLessThanOrEqual(DISCORD_THREAD_NAME_LIMIT);
+    expect(LONE_SURROGATE.test(name)).toBe(false);
+    // The incomplete emoji is dropped rather than left as a dangling half.
+    expect(name).toBe("x".repeat(DISCORD_THREAD_NAME_LIMIT - 1));
+    // Guard: the previous raw slice produced a lone surrogate here.
+    expect(LONE_SURROGATE.test(text.slice(0, DISCORD_THREAD_NAME_LIMIT))).toBe(true);
+  });
+
+  it("keeps a complete emoji that fits within the limit", () => {
+    const name = deriveForumThreadName("hi 😀");
+    expect(name).toBe("hi 😀");
+    expect(LONE_SURROGATE.test(name)).toBe(false);
+  });
+
+  it("falls back to a timestamp when there is no usable line", () => {
+    const name = deriveForumThreadName("\n   \n");
+    expect(name).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/);
+  });
+});

--- a/extensions/discord/src/send.outbound.ts
+++ b/extensions/discord/src/send.outbound.ts
@@ -9,6 +9,7 @@ import { resolveChunkMode, type ChunkMode } from "openclaw/plugin-sdk/reply-chun
 import type { RetryConfig } from "openclaw/plugin-sdk/retry-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { convertMarkdownTables } from "openclaw/plugin-sdk/text-chunking";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { resolveDiscordAccount } from "./accounts.js";
 import { createChannelMessage, createThread, type RequestClient } from "./internal/discord.js";
 import { rewriteDiscordKnownMentions } from "./mentions.js";
@@ -101,10 +102,15 @@ function resolveDiscordSuppressEmbeds(params: {
 const DISCORD_THREAD_NAME_LIMIT = 100;
 
 /** Derive a thread title from the first non-empty line of the message text. */
-function deriveForumThreadName(text: string): string {
+export function deriveForumThreadName(text: string): string {
   const firstLine =
     normalizeOptionalString(text.split("\n").find((line) => normalizeOptionalString(line))) ?? "";
-  return firstLine.slice(0, DISCORD_THREAD_NAME_LIMIT) || new Date().toISOString().slice(0, 16);
+  // Surrogate-safe cap so an emoji straddling the 100-char Discord limit is not
+  // split into a dangling half (broken glyph / rejected name). Matches the
+  // sibling thread-name path in monitor/threading.starter.ts.
+  return (
+    truncateUtf16Safe(firstLine, DISCORD_THREAD_NAME_LIMIT) || new Date().toISOString().slice(0, 16)
+  );
 }
 
 /** Forum/Media channels cannot receive regular messages; detect them here. */


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Discord forum/media channel **thread names can come out with a broken character** (a `�` or mangled emoji) when the derived name hits Discord's 100-character limit. `deriveForumThreadName` capped the name with a raw `firstLine.slice(0, 100)`, so when an emoji or other non-BMP character straddles index 100 the slice cuts a UTF-16 surrogate pair in half, leaving a dangling surrogate in the thread title (and Discord can reject the name outright).

## Why This Change Was Made

The cap now goes through `truncateUtf16Safe(firstLine, 100)` instead of a raw `.slice`, which drops an incomplete trailing code unit rather than splitting a surrogate pair. This is the same helper the **sibling** thread-name path already uses for the identical 100-char Discord limit — `extensions/discord/src/monitor/threading.starter.ts:263` (`sanitizeDiscordThreadName`) — so this just brings the forum/media path in line with the regular thread path; no other behavior changes.

## User Impact

Discord users whose message first line contains an emoji near the 100-character mark get a clean, valid forum/media thread name instead of a broken glyph or a failed thread creation. No configuration changes.

## Evidence

### Real terminal proof (standalone, non-test)

Drove the real `deriveForumThreadName` from a standalone script against the failing input — a first line of 99 ASCII chars followed by `😀` (its surrogate pair straddles index 100). Inspecting the trailing UTF-16 code units shows the old raw slice leaves a dangling surrogate, while the fix produces a clean, in-limit title:

```
input first line length (UTF-16 units): 143

BEFORE  (raw .slice(0, 100) — current main):
  length:            100
  tail code units:   0x0078 0xd83d
  ends with 0xd83d (lone emoji half): true
  contains lone surrogate (broken glyph): true

AFTER   (truncateUtf16Safe — this PR):
  length:            99
  tail code units:   0x0078 0x0078
  value tail:        "xxxxxx"
  contains lone surrogate (broken glyph): false

RESULT: PASS — raw slice was broken; fixed title is valid and within limit
```

`0xd83d` is the high-surrogate half of `😀` (`U+1F600`); on `main` it is left dangling at the end of the thread name (rendered as a broken glyph and rejectable by Discord). With the fix the incomplete emoji is dropped and the name ends on a complete character.

### Unit tests

Added `extensions/discord/src/send.outbound.thread-name.test.ts` (4 cases) — `pnpm test extensions/discord/src/send.outbound.thread-name.test.ts`:

```
 ✓ uses the first non-empty line and caps it at the Discord limit
 ✓ does not split a surrogate pair at the length boundary
 ✓ keeps a complete emoji that fits within the limit
 ✓ falls back to a timestamp when there is no usable line

 Test Files  1 passed (1)
      Tests  4 passed (4)
```

The surrogate-boundary test also asserts (as a guard) that the previous raw `slice(0, 100)` produced a lone surrogate on the same input, so the test fails on the unpatched code and passes with the fix.

oxlint and `oxfmt --check` are clean on both changed files.

AI-assisted (Claude Code); change reviewed and understood by the author.
