### PR TITLE
fix(qqbot): stop splitting short replies on every markdown table

### DIFF
--- a/extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts
+++ b/extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts
@@ -678,12 +678,16 @@ describe("dispatchOutbound", () => {
       account,
     });
 
-    expect(sendTextMock).toHaveBeenCalledTimes(2);
+    // Under the lazy-flush chunker contract, consecutive block deliveries under
+    // the byte limit are merged into one chunk (joined with a blank line). The
+    // invariant is that each table remains self-contained: the continuation
+    // table is re-prefixed with the active header so it renders on its own.
+    expect(sendTextMock).toHaveBeenCalledTimes(1);
     expect(sendTextMock.mock.calls[0]?.[1]).toBe(
-      ["| Id | Value |", "|---:|---|", "| 1 | alpha |"].join("\n"),
-    );
-    expect(sendTextMock.mock.calls[1]?.[1]).toBe(
-      ["| Id | Value |", "|---:|---|", "| 2 | beta |", "| 3 | gamma |"].join("\n"),
+      [
+        ["| Id | Value |", "|---:|---|", "| 1 | alpha |"].join("\n"),
+        ["| Id | Value |", "|---:|---|", "| 2 | beta |", "| 3 | gamma |"].join("\n"),
+      ].join("\n\n"),
     );
   });
 
@@ -725,9 +729,15 @@ describe("dispatchOutbound", () => {
       account,
     });
 
+    // Under the lazy-flush chunker contract, the complete table and the
+    // following unfinished row fragment are merged into one chunk. The
+    // invariant is that the unfinished fragment is still rendered as plain
+    // "Field: value" fields rather than a malformed pipe row.
     expect(sendTextMock.mock.calls.map((call) => call[1])).toEqual([
-      ["| Id | Function | Status |", "|---:|---|---|", "| 1 | auth | ok |"].join("\n"),
-      ["Id: 10", "Function: analyzeerror_patterns", "Status: 无需重试"].join("\n"),
+      [
+        ["| Id | Function | Status |", "|---:|---|---|", "| 1 | auth | ok |"].join("\n"),
+        ["Id: 10", "Function: analyzeerror_patterns", "Status: 无需重试"].join("\n"),
+      ].join("\n\n"),
     ]);
   });
 
@@ -755,13 +765,21 @@ describe("dispatchOutbound", () => {
       account,
     });
 
+    // Under the lazy-flush chunker contract, the two block deliveries are
+    // merged into one chunk. The invariant is that the short row fragment
+    // ("| 17 | 100ms |") is held until the following block completes its
+    // columns, then emitted as a full row re-prefixed with the active header.
     expect(sendTextMock.mock.calls.map((call) => call[1])).toEqual([
-      ["| Id | Time | Owner | Note |", "|---:|---|---|---|", "| 16 | 40ms | He | ok |"].join("\n"),
       [
-        "| Id | Time | Owner | Note |",
-        "|---:|---|---|---|",
-        "| 17 | 100ms | Lin | daily cap |",
-      ].join("\n"),
+        ["| Id | Time | Owner | Note |", "|---:|---|---|---|", "| 16 | 40ms | He | ok |"].join(
+          "\n",
+        ),
+        [
+          "| Id | Time | Owner | Note |",
+          "|---:|---|---|---|",
+          "| 17 | 100ms | Lin | daily cap |",
+        ].join("\n"),
+      ].join("\n\n"),
     ]);
   });
 });

--- a/extensions/qqbot/src/engine/gateway/outbound-dispatch.ts
+++ b/extensions/qqbot/src/engine/gateway/outbound-dispatch.ts
@@ -293,15 +293,15 @@ export async function dispatchOutbound(
     },
     chunkText: (text, limit) => markdownChunker.chunkText(text, limit),
   };
+  const passthroughDeps: DeliverDeps = {
+    ...deliverDeps,
+    chunkText: (text) => [text],
+  };
   const flushPendingMarkdownText = async (): Promise<void> => {
     const pendingChunks = markdownChunker.flushPendingText(TEXT_CHUNK_LIMIT);
     if (pendingChunks.length === 0) {
       return;
     }
-    const passthroughDeps: DeliverDeps = {
-      ...deliverDeps,
-      chunkText: (text) => [text],
-    };
     for (const chunk of pendingChunks) {
       await sendTextOnlyReply(
         chunk,
@@ -358,7 +358,7 @@ export async function dispatchOutbound(
           { account, qualifiedTarget, log },
           sendWithRetry,
           () => undefined,
-          deliverDeps,
+          passthroughDeps,
         );
       }
     }
@@ -473,7 +473,7 @@ export async function dispatchOutbound(
                       { account, qualifiedTarget, log },
                       sendWithRetry,
                       () => undefined,
-                      deliverDeps,
+                      passthroughDeps,
                     );
                     recordOutbound();
                     return;

--- a/extensions/qqbot/src/engine/messaging/markdown-table-chunking.test.ts
+++ b/extensions/qqbot/src/engine/messaging/markdown-table-chunking.test.ts
@@ -20,11 +20,12 @@ describe("chunkQQBotMarkdownText", () => {
       "| 3 | gamma |",
     ].join("\n");
 
-    expect(chunkQQBotMarkdownText(text, 45, baseChunker)).toEqual([
-      ["| Id | Value |", "|---:|---|", "| 1 | alpha |"].join("\n"),
-      ["| Id | Value |", "|---:|---|", "| 2 | beta |"].join("\n"),
-      ["| Id | Value |", "|---:|---|", "| 3 | gamma |"].join("\n"),
-    ]);
+    const chunks = chunkQQBotMarkdownText(text, 45, baseChunker);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.startsWith("| Id | Value |")).toBe(true);
+      expect(Buffer.byteLength(chunk, "utf8")).toBeLessThanOrEqual(45);
+    }
   });
 
   it("keeps table state across streaming block flushes", () => {
@@ -32,9 +33,13 @@ describe("chunkQQBotMarkdownText", () => {
 
     expect(
       chunker.chunkText(["| Id | Value |", "|---:|---|", "| 1 | alpha |"].join("\n"), 120),
-    ).toEqual([["| Id | Value |", "|---:|---|", "| 1 | alpha |"].join("\n")]);
-    expect(chunker.chunkText(["| 2 | beta |", "| 3 | gamma |"].join("\n"), 120)).toEqual([
-      ["| Id | Value |", "|---:|---|", "| 2 | beta |", "| 3 | gamma |"].join("\n"),
+    ).toEqual([]);
+    expect(chunker.chunkText(["| 2 | beta |", "| 3 | gamma |"].join("\n"), 120)).toEqual([]);
+    expect(chunker.flushPendingText(120)).toEqual([
+      [
+        ["| Id | Value |", "|---:|---|", "| 1 | alpha |"].join("\n"),
+        ["| Id | Value |", "|---:|---|", "| 2 | beta |", "| 3 | gamma |"].join("\n"),
+      ].join("\n\n"),
     ]);
   });
 
@@ -44,7 +49,10 @@ describe("chunkQQBotMarkdownText", () => {
     expect(chunker.chunkText("| Id | Value |", 120)).toEqual([]);
     expect(
       chunker.chunkText(["|---:|---|", "| 1 | alpha |", "| 2 | beta |"].join("\n"), 120),
-    ).toEqual([["| Id | Value |", "|---:|---|", "| 1 | alpha |", "| 2 | beta |"].join("\n")]);
+    ).toEqual([]);
+    expect(chunker.flushPendingText(120)).toEqual([
+      ["| Id | Value |", "|---:|---|", "| 1 | alpha |", "| 2 | beta |"].join("\n"),
+    ]);
   });
 
   it("confirms a table when the separator uses one or two dashes, not only three", () => {
@@ -60,7 +68,8 @@ describe("chunkQQBotMarkdownText", () => {
     const chunker = createQQBotMarkdownChunker((text) => [text]);
 
     expect(chunker.chunkText("| maybe | header |", 120)).toEqual([]);
-    expect(chunker.chunkText("plain continuation", 120)).toEqual([
+    expect(chunker.chunkText("plain continuation", 120)).toEqual([]);
+    expect(chunker.flushPendingText(120)).toEqual([
       ["| maybe | header |", "plain continuation"].join("\n"),
     ]);
   });
@@ -69,6 +78,7 @@ describe("chunkQQBotMarkdownText", () => {
     const chunker = createQQBotMarkdownChunker((text) => [text]);
 
     chunker.chunkText(["| Id | Value |", "|---:|---|", "| 1 | alpha |"].join("\n") + "\n\n", 120);
+    chunker.flushPendingText(120);
 
     expect(chunker.chunkText("| not | a continuation |", 120)).toEqual([]);
     expect(chunker.flushPendingText(120)).toEqual(["| not | a continuation |"]);
@@ -100,15 +110,19 @@ describe("chunkQQBotMarkdownText", () => {
         ["| Id | Function | Status |", "|---:|---|---|", "| 1 | auth | ok |"].join("\n"),
         160,
       ),
-    ).toEqual([["| Id | Function | Status |", "|---:|---|---|", "| 1 | auth | ok |"].join("\n")]);
+    ).toEqual([]);
 
     expect(chunker.chunkText("| 5 | generatemonthly_sales", 160)).toEqual([]);
-    expect(chunker.chunkText("_by_region | ok |", 160)).toEqual([
+    expect(chunker.chunkText("_by_region | ok |", 160)).toEqual([]);
+    expect(chunker.flushPendingText(160)).toEqual([
       [
-        "| Id | Function | Status |",
-        "|---:|---|---|",
-        "| 5 | generatemonthly_sales_by_region | ok |",
-      ].join("\n"),
+        ["| Id | Function | Status |", "|---:|---|---|", "| 1 | auth | ok |"].join("\n"),
+        [
+          "| Id | Function | Status |",
+          "|---:|---|---|",
+          "| 5 | generatemonthly_sales_by_region | ok |",
+        ].join("\n"),
+      ].join("\n\n"),
     ]);
   });
 
@@ -122,17 +136,21 @@ describe("chunkQQBotMarkdownText", () => {
         ),
         200,
       ),
-    ).toEqual([
-      ["| Id | Time | Owner | Note |", "|---:|---|---|---|", "| 16 | 40ms | He | ok |"].join("\n"),
-    ]);
+    ).toEqual([]);
 
     expect(chunker.chunkText("| 17 | 100ms |", 200)).toEqual([]);
-    expect(chunker.chunkText("Lin | daily cap |", 200)).toEqual([
+    expect(chunker.chunkText("Lin | daily cap |", 200)).toEqual([]);
+    expect(chunker.flushPendingText(200)).toEqual([
       [
-        "| Id | Time | Owner | Note |",
-        "|---:|---|---|---|",
-        "| 17 | 100ms | Lin | daily cap |",
-      ].join("\n"),
+        ["| Id | Time | Owner | Note |", "|---:|---|---|---|", "| 16 | 40ms | He | ok |"].join(
+          "\n",
+        ),
+        [
+          "| Id | Time | Owner | Note |",
+          "|---:|---|---|---|",
+          "| 17 | 100ms | Lin | daily cap |",
+        ].join("\n"),
+      ].join("\n\n"),
     ]);
   });
 
@@ -143,6 +161,7 @@ describe("chunkQQBotMarkdownText", () => {
       ["| Id | Function | Status |", "|---:|---|---|", "| 1 | auth | ok |"].join("\n"),
       160,
     );
+    chunker.flushPendingText(160);
     expect(chunker.chunkText("| 10 | analyzeerror_patterns | 无需重试", 160)).toEqual([]);
 
     expect(chunker.flushPendingText(160)).toEqual([
@@ -161,7 +180,8 @@ describe("chunkQQBotMarkdownText", () => {
     const chunker = createQQBotMarkdownChunker((text) => [text]);
 
     expect(chunker.chunkText(["```ts", "const a = 1;"].join("\n"), 200)).toEqual([]);
-    expect(chunker.chunkText(["const b = 2;", "```"].join("\n"), 200)).toEqual([
+    expect(chunker.chunkText(["const b = 2;", "```"].join("\n"), 200)).toEqual([]);
+    expect(chunker.flushPendingText(200)).toEqual([
       ["```ts", "const a = 1;", "const b = 2;", "```"].join("\n"),
     ]);
   });
@@ -174,7 +194,8 @@ describe("chunkQQBotMarkdownText", () => {
     ).toEqual([]);
     expect(
       chunker.chunkText(["0", "    def get_dsn(self) -> str:", "```"].join("\n"), 200),
-    ).toEqual([
+    ).toEqual([]);
+    expect(chunker.flushPendingText(200)).toEqual([
       ["```python", "    pool_timeout: float = 30.0", "    def get_dsn(self) -> str:", "```"].join(
         "\n",
       ),
@@ -218,7 +239,8 @@ describe("chunkQQBotMarkdownText", () => {
     const chunker = createQQBotMarkdownChunker((text) => [text]);
 
     expect(chunker.chunkText(["```math", "E = mc^2"].join("\n"), 200)).toEqual([]);
-    expect(chunker.chunkText(["a^2 + b^2 = c^2", "```"].join("\n"), 200)).toEqual([
+    expect(chunker.chunkText(["a^2 + b^2 = c^2", "```"].join("\n"), 200)).toEqual([]);
+    expect(chunker.flushPendingText(200)).toEqual([
       ["```math", "E = mc^2", "a^2 + b^2 = c^2", "```"].join("\n"),
     ]);
   });
@@ -243,7 +265,7 @@ describe("chunkQQBotMarkdownText", () => {
     }
   });
 
-  it("handles prose before and after a table split at row boundaries", () => {
+  it("merges prose before and after a small table into one chunk when under limit", () => {
     const text = [
       "前置说明第一段，长度足够触发普通文本先发送。",
       "前置说明第二段继续解释。",
@@ -255,11 +277,32 @@ describe("chunkQQBotMarkdownText", () => {
       "后置说明第二段。",
     ].join("\n");
 
-    expect(chunkQQBotMarkdownText(text, 180, baseChunker)).toEqual([
-      "前置说明第一段，长度足够触发普通文本先发送。\n前置说明第二段继续解释。",
-      ["| Id | Value |", "|---:|---|", "| 1 | alpha |", "| 2 | beta |"].join("\n"),
-      "后置说明第一段，表格结束后继续普通文字。\n后置说明第二段。",
+    expect(chunkQQBotMarkdownText(text, 5000, baseChunker)).toEqual([
+      [
+        "前置说明第一段，长度足够触发普通文本先发送。\n前置说明第二段继续解释。",
+        ["| Id | Value |", "|---:|---|", "| 1 | alpha |", "| 2 | beta |"].join("\n"),
+        "后置说明第一段，表格结束后继续普通文字。\n后置说明第二段。",
+      ].join("\n\n"),
     ]);
+  });
+
+  it("still splits prose before and after a table when content exceeds limit", () => {
+    const text = [
+      "前置说明第一段，长度足够触发普通文本先发送。",
+      "前置说明第二段继续解释。",
+      "| Id | Value |",
+      "|---:|---|",
+      "| 1 | alpha |",
+      "| 2 | beta |",
+      "后置说明第一段，表格结束后继续普通文字。",
+      "后置说明第二段。",
+    ].join("\n");
+
+    const chunks = chunkQQBotMarkdownText(text, 80, baseChunker);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(Buffer.byteLength(chunk, "utf8")).toBeLessThanOrEqual(80);
+    }
   });
 });
 

--- a/extensions/qqbot/src/engine/messaging/markdown-table-chunking.test.ts
+++ b/extensions/qqbot/src/engine/messaging/markdown-table-chunking.test.ts
@@ -374,6 +374,44 @@ describe("chunkQQBotMarkdownText", () => {
     expect(chunks).toHaveLength(1);
     expect(Buffer.byteLength(chunks[0], "utf8")).toBeLessThan(3600);
   });
+
+  it("splits oversized paragraph via baseChunker", () => {
+    const hugePara = "x".repeat(4000);
+    const chunks = chunkQQBotMarkdownText(hugePara, 5000, baseChunker);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(Buffer.byteLength(chunk, "utf8")).toBeLessThanOrEqual(3600);
+    }
+  });
+
+  it("handles empty text without errors", () => {
+    expect(chunkQQBotMarkdownText("", 5000, baseChunker)).toEqual([]);
+  });
+
+  it("coalesces multiple small paragraphs into one chunk at flushPendingText", () => {
+    const chunker = createQQBotMarkdownChunker((text) => [text]);
+    chunker.chunkText("段落一。", 5000);
+    chunker.chunkText("段落二。", 5000);
+    chunker.chunkText("段落三。", 5000);
+    const chunks = chunker.flushPendingText(5000);
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toBe("段落一。\n\n段落二。\n\n段落三。");
+  });
+
+  it("drains oversized unit from emit buffer without infinite loop", () => {
+    const huge = "y".repeat(5000);
+    const chunker = createQQBotMarkdownChunker((text) =>
+      text.length <= 3600 ? [text] : [text.slice(0, 3600), text.slice(3600)],
+    );
+    // Streaming drain path: chunkText drains the oversized unit via maybeFlushEmitBuffer
+    // (and forceFlushEmitBuffer at end-of-stream); a regression that re-enqueues instead
+    // of draining would hang here. Combined output must be multi-chunk and within budget.
+    const chunks = [...chunker.chunkText(huge, 5000), ...chunker.flushPendingText(5000)];
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(Buffer.byteLength(chunk, "utf8")).toBeLessThanOrEqual(3600);
+    }
+  });
 });
 
 describe("table-cell splitting", () => {

--- a/extensions/qqbot/src/engine/messaging/markdown-table-chunking.test.ts
+++ b/extensions/qqbot/src/engine/messaging/markdown-table-chunking.test.ts
@@ -304,6 +304,76 @@ describe("chunkQQBotMarkdownText", () => {
       expect(Buffer.byteLength(chunk, "utf8")).toBeLessThanOrEqual(80);
     }
   });
+
+  it("merges prose-table-prose into one chunk when under limit", () => {
+    const text = [
+      "前置段落第一句，描述上下文。",
+      "前置段落第二句，继续说明。",
+      "| 类型 | 用途 |",
+      "|---|---|",
+      "| 截图 | 页面快照 |",
+      "| 文本 | 留底 |",
+      "后置段落，表格结束后的总结。",
+    ].join("\n");
+    const chunks = chunkQQBotMarkdownText(text, 5000, baseChunker);
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toContain("前置段落第一句");
+    expect(chunks[0]).toContain("| 截图 | 页面快照 |");
+    expect(chunks[0]).toContain("后置段落");
+    expect(chunks[0]).toMatch(/继续说明。\n\n\| 类型/);
+    expect(chunks[0]).toMatch(/\| 文本 \| 留底 \|\n\n后置段落/);
+  });
+
+  it("merges adjacent small tables into one chunk when under limit", () => {
+    const text = [
+      "| A | B |",
+      "|---|---|",
+      "| 1 | 2 |",
+      "",
+      "| C | D |",
+      "|---|---|",
+      "| 3 | 4 |",
+    ].join("\n");
+    expect(chunkQQBotMarkdownText(text, 5000, baseChunker)).toHaveLength(1);
+  });
+
+  it("merges prose-fence-prose into one chunk when under limit", () => {
+    const text = ["前一段落。", "```ts", "const x = 1;", "```", "后一段落。"].join("\n");
+    const chunks = chunkQQBotMarkdownText(text, 5000, baseChunker);
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toContain("```ts\nconst x = 1;\n```");
+  });
+
+  it("still splits correctly when content exceeds limit", () => {
+    const longPara = "前置长段落。".repeat(500);
+    const text = [longPara, "| A | B |", "|---|---|", "| 1 | 2 |"].join("\n");
+    const chunks = chunkQQBotMarkdownText(text, 5000, baseChunker);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(Buffer.byteLength(chunk, "utf8")).toBeLessThanOrEqual(3600);
+    }
+  });
+
+  it("regression: 400-byte reply with two small tables is one chunk", () => {
+    const text = [
+      '明白 —— 你要的不是"任务完成"那行短消息，是 OpenCode 任务产出的全部对话/输出文本，要完整留底。',
+      "",
+      '修改现有的 cron job，把"完成后动作"扩成三件套：截图 + 完整文本落盘 + 一起发 QQ。',
+      "",
+      "| 类型 | 路径 | 用途 |",
+      "|---|---|---|",
+      "| 截图 | tmp/one.jpg | 页面快照 |",
+      "| 文本 | tmp/two.md | 留底 |",
+      "| 推送 | 截图+md | 一起发 |",
+      "",
+      "抓取策略：主用 evaluate innerText 抓主对话区，长内容兜底用 scrollTo 顶部+底部各抓一次合并去重，5MB 截断保 QQ 附件安全。",
+      "",
+      "任务一完成，截图和 md 一起弹到你 QQ。",
+    ].join("\n");
+    const chunks = chunkQQBotMarkdownText(text, 5000, baseChunker);
+    expect(chunks).toHaveLength(1);
+    expect(Buffer.byteLength(chunks[0], "utf8")).toBeLessThan(3600);
+  });
 });
 
 describe("table-cell splitting", () => {

--- a/extensions/qqbot/src/engine/messaging/markdown-table-chunking.ts
+++ b/extensions/qqbot/src/engine/messaging/markdown-table-chunking.ts
@@ -397,6 +397,44 @@ class QQBotMarkdownChunkingState {
     return out;
   }
 
+  private forceFlushEmitBuffer(chunkLimit: number): void {
+    if (this.pendingEmitBuffer.length > 1) {
+      const joined = this.renderEmitBufferAsString();
+      if (utf8ByteLength(joined) <= chunkLimit) {
+        this.chunks.push(joined);
+        this.pendingEmitBuffer = [];
+        this.pendingEmitBytes = 0;
+        return;
+      }
+    }
+    let current = "";
+    let currentBytes = 0;
+    while (this.pendingEmitBuffer.length > 0) {
+      const unit = this.pendingEmitBuffer.shift()!;
+      this.pendingEmitBytes -= unit.bytes;
+      const sep = current ? 2 : 0;
+      if (currentBytes + sep + unit.bytes <= chunkLimit) {
+        current = current ? `${current}\n\n${unit.content}` : unit.content;
+        currentBytes += sep + unit.bytes;
+        continue;
+      }
+      if (current) {
+        this.chunks.push(current);
+        current = "";
+        currentBytes = 0;
+      }
+      if (unit.bytes <= chunkLimit) {
+        current = unit.content;
+        currentBytes = unit.bytes;
+      } else {
+        pushBaseChunks(this.chunks, unit.content, chunkLimit, this.baseChunker);
+      }
+    }
+    if (current) {
+      this.chunks.push(current);
+    }
+  }
+
   private endTable(chunks: string[]): void {
     this.flushTable(chunks);
     this.activeTable = null;

--- a/extensions/qqbot/src/engine/messaging/markdown-table-chunking.ts
+++ b/extensions/qqbot/src/engine/messaging/markdown-table-chunking.ts
@@ -350,7 +350,7 @@ class QQBotMarkdownChunkingState {
     if (this.tableLines.length === 0) {
       return;
     }
-    chunks.push(this.tableLines.join("\n"));
+    this.enqueuePending(this.tableLines.join("\n"), "table", QQBOT_MARKDOWN_SAFE_CHUNK_BYTE_LIMIT);
     this.tableLines = [];
   }
 

--- a/extensions/qqbot/src/engine/messaging/markdown-table-chunking.ts
+++ b/extensions/qqbot/src/engine/messaging/markdown-table-chunking.ts
@@ -259,7 +259,7 @@ class QQBotMarkdownChunkingState {
     if (!text) {
       return;
     }
-    pushBaseChunks(chunks, text, limit, this.baseChunker);
+    this.enqueuePending(text, "text", limit);
   }
 
   private flushFenceText(chunks: string[], limit: number): boolean {

--- a/extensions/qqbot/src/engine/messaging/markdown-table-chunking.ts
+++ b/extensions/qqbot/src/engine/messaging/markdown-table-chunking.ts
@@ -281,7 +281,7 @@ class QQBotMarkdownChunkingState {
     }
 
     pushFenceLineChunks({
-      chunks,
+      enqueue: (content, kind, chunkLimit) => this.enqueuePending(content, kind, chunkLimit),
       openLine: fence.openLine,
       closeLine: fence.closeLine,
       bodyLines,
@@ -640,21 +640,21 @@ function renderTableRowAsFields(headers: string[], cells: string[]): string {
 }
 
 function pushFenceLineChunks(params: {
-  chunks: string[];
+  enqueue: (content: string, kind: EmitUnitKind, chunkLimit: number) => void;
   openLine: string;
   closeLine: string;
   bodyLines: string[];
   limit: number;
   baseChunker: QQBotBaseMarkdownChunker;
 }): void {
-  const { chunks, openLine, closeLine, bodyLines, limit, baseChunker } = params;
+  const { enqueue, openLine, closeLine, bodyLines, limit, baseChunker } = params;
   let currentLines: string[] = [];
   const render = (lines: string[]) => [openLine, ...lines, closeLine].join("\n");
   const flushCurrent = (): void => {
     if (currentLines.length === 0) {
       return;
     }
-    chunks.push(render(currentLines));
+    enqueue(render(currentLines), "fence", limit);
     currentLines = [];
   };
 
@@ -670,11 +670,13 @@ function pushFenceLineChunks(params: {
       currentLines = [line];
       continue;
     }
-    pushBaseChunks(chunks, singleLineChunk, limit, baseChunker);
+    for (const piece of baseChunker(singleLineChunk, limit)) {
+      if (piece) enqueue(piece, "fence", limit);
+    }
   }
 
   if (currentLines.length > 0 || bodyLines.length === 0) {
-    chunks.push(render(currentLines));
+    enqueue(render(currentLines), "fence", limit);
   }
 }
 

--- a/extensions/qqbot/src/engine/messaging/markdown-table-chunking.ts
+++ b/extensions/qqbot/src/engine/messaging/markdown-table-chunking.ts
@@ -21,6 +21,14 @@ export type QQBotMarkdownChunker = {
   flushPendingText: (limit: number) => string[];
 };
 
+type EmitUnitKind = "text" | "table" | "fence";
+
+interface EmitUnit {
+  content: string;
+  kind: EmitUnitKind;
+  bytes: number;
+}
+
 export function chunkQQBotMarkdownText(
   text: string,
   limit: number,
@@ -50,6 +58,9 @@ class QQBotMarkdownChunkingState {
   private activeFence: ActiveFence | null = null;
   private pendingTextFenceOpenLine: string | null = null;
   private pendingFenceLineFragment: string | null = null;
+  private pendingEmitBuffer: EmitUnit[] = [];
+  private pendingEmitBytes = 0;
+  private chunks: string[] = [];
 
   constructor(private readonly baseChunker: QQBotBaseMarkdownChunker) {}
 

--- a/extensions/qqbot/src/engine/messaging/markdown-table-chunking.ts
+++ b/extensions/qqbot/src/engine/messaging/markdown-table-chunking.ts
@@ -365,6 +365,38 @@ class QQBotMarkdownChunkingState {
     }
   }
 
+  private enqueuePending(content: string, kind: EmitUnitKind, chunkLimit: number): void {
+    const trimmed = content.trim();
+    if (!trimmed) return;
+    this.pendingEmitBuffer.push({
+      content: trimmed,
+      kind,
+      bytes: utf8ByteLength(trimmed),
+    });
+    this.pendingEmitBytes += utf8ByteLength(trimmed);
+    this.maybeFlushEmitBuffer(chunkLimit);
+  }
+
+  private maybeFlushEmitBuffer(chunkLimit: number): void {
+    while (this.pendingEmitBuffer.length > 0 && this.pendingEmitBytes > chunkLimit) {
+      const head = this.pendingEmitBuffer.shift()!;
+      this.pendingEmitBytes -= head.bytes;
+      if (head.bytes <= chunkLimit) {
+        this.chunks.push(head.content);
+        continue;
+      }
+      pushBaseChunks(this.chunks, head.content, chunkLimit, this.baseChunker);
+    }
+  }
+
+  private renderEmitBufferAsString(): string {
+    let out = "";
+    for (const unit of this.pendingEmitBuffer) {
+      out = out ? `${out}\n\n${unit.content}` : unit.content;
+    }
+    return out;
+  }
+
   private endTable(chunks: string[]): void {
     this.flushTable(chunks);
     this.activeTable = null;

--- a/extensions/qqbot/src/engine/messaging/markdown-table-chunking.ts
+++ b/extensions/qqbot/src/engine/messaging/markdown-table-chunking.ts
@@ -228,9 +228,11 @@ class QQBotMarkdownChunkingState {
     this.tableLines.push(line);
   }
 
-  private pushOversizedTableRow(line: string, limit: number, chunks: string[]): void {
+  private pushOversizedTableRow(line: string, limit: number, _chunks: string[]): void {
     const text = renderTableRowAsFields(this.activeTable!.cells, splitTableCells(line));
-    pushBaseChunks(chunks, text, limit, this.baseChunker);
+    for (const piece of this.baseChunker(text, limit)) {
+      if (piece) this.enqueuePending(piece, "text", limit);
+    }
   }
 
   private ensureTableHeader(): void {
@@ -343,7 +345,9 @@ class QQBotMarkdownChunkingState {
     const text = this.activeTable
       ? renderTableRowAsFields(this.activeTable.cells, splitPartialTableCells(fragment))
       : renderMalformedPipeLineAsText(fragment);
-    pushBaseChunks(chunks, text, limit, this.baseChunker);
+    for (const piece of this.baseChunker(text, limit)) {
+      if (piece) this.enqueuePending(piece, "text", limit);
+    }
   }
 
   private flushTable(chunks: string[]): void {

--- a/extensions/qqbot/src/engine/messaging/markdown-table-chunking.ts
+++ b/extensions/qqbot/src/engine/messaging/markdown-table-chunking.ts
@@ -73,7 +73,7 @@ class QQBotMarkdownChunkingState {
     }
     const chunkLimit = resolveQQBotMarkdownChunkLimit(limit);
 
-    const chunks: string[] = [];
+    this.chunks = [];
     const textWithPendingRow = this.consumePendingRowPrefix(text);
     const textWithPendingFenceLine = this.consumePendingFenceLinePrefix(textWithPendingRow);
     const hasTrailingNewline = textWithPendingFenceLine.endsWith("\n");
@@ -82,26 +82,27 @@ class QQBotMarkdownChunkingState {
       const isTrailingSplitLine = index === lines.length - 1 && line === "";
       this.consumeLine(line, {
         limit: chunkLimit,
-        chunks,
+        chunks: this.chunks,
         hasTrailingNewline,
         isTrailingSplitLine,
         isLastLine: index === lines.length - 1,
       });
     }
-    this.flushText(chunks, chunkLimit);
-    this.flushTable(chunks);
-    return chunks;
+    this.flushText(this.chunks, chunkLimit);
+    this.flushTable(this.chunks);
+    return this.chunks;
   }
 
   flushPendingText(limit: number): string[] {
     const chunkLimit = resolveQQBotMarkdownChunkLimit(limit);
-    const chunks: string[] = [];
-    this.flushPendingRowFragment(chunks, chunkLimit);
+    this.chunks = [];
+    this.flushPendingRowFragment(this.chunks, chunkLimit);
     this.flushPendingFenceLineFragment();
     this.flushPendingHeaderAsText();
-    this.flushText(chunks, chunkLimit);
-    this.flushTable(chunks);
-    return chunks;
+    this.flushText(this.chunks, chunkLimit);
+    this.flushTable(this.chunks);
+    this.forceFlushEmitBuffer(chunkLimit);
+    return this.chunks;
   }
 
   private consumeLine(

--- a/extensions/qqbot/src/engine/messaging/markdown-table-chunking.ts
+++ b/extensions/qqbot/src/engine/messaging/markdown-table-chunking.ts
@@ -232,7 +232,9 @@ class QQBotMarkdownChunkingState {
   private pushOversizedTableRow(line: string, limit: number, _chunks: string[]): void {
     const text = renderTableRowAsFields(this.activeTable!.cells, splitTableCells(line));
     for (const piece of this.baseChunker(text, limit)) {
-      if (piece) this.enqueuePending(piece, "text", limit);
+      if (piece) {
+        this.enqueuePending(piece, "text", limit);
+      }
     }
   }
 
@@ -347,11 +349,13 @@ class QQBotMarkdownChunkingState {
       ? renderTableRowAsFields(this.activeTable.cells, splitPartialTableCells(fragment))
       : renderMalformedPipeLineAsText(fragment);
     for (const piece of this.baseChunker(text, limit)) {
-      if (piece) this.enqueuePending(piece, "text", limit);
+      if (piece) {
+        this.enqueuePending(piece, "text", limit);
+      }
     }
   }
 
-  private flushTable(chunks: string[]): void {
+  private flushTable(_chunks: string[]): void {
     if (this.tableLines.length === 0) {
       return;
     }
@@ -372,7 +376,9 @@ class QQBotMarkdownChunkingState {
 
   private enqueuePending(content: string, kind: EmitUnitKind, chunkLimit: number): void {
     const trimmed = content.trim();
-    if (!trimmed) return;
+    if (!trimmed) {
+      return;
+    }
     this.pendingEmitBuffer.push({
       content: trimmed,
       kind,
@@ -676,7 +682,9 @@ function pushFenceLineChunks(params: {
       continue;
     }
     for (const piece of baseChunker(singleLineChunk, limit)) {
-      if (piece) enqueue(piece, "fence", limit);
+      if (piece) {
+        enqueue(piece, "fence", limit);
+      }
     }
   }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users sending short requests to a QQ Bot bot would receive a single reply fragmented into 5 or more separate messages whenever the model output contained two or more markdown tables (or a table plus adjacent prose), even when the entire reply was only a few hundred characters and well under QQ Bot's per-message limit. Users see what looks like a broken/spammy reply: a paragraph, then a tiny table, then another paragraph, then another tiny table, each arriving as its own message, instead of one coherent reply.

## Why This Change Was Made

The QQ Bot chunker's custom markdown state machine was flushing accumulated prose unconditionally whenever it encountered a table header, closed a table, or closed a fenced code block. This made any structural boundary — including a single small table in an otherwise short reply — a hard message boundary.

We introduced a deferred emit buffer (`pendingEmitBuffer`) in `QQBotMarkdownChunkingState`. Closed structural units (paragraph, table, fence) are now enqueued into the buffer instead of being pushed to the output array. The buffer is drained by `maybeFlushEmitBuffer` only when accumulated bytes exceed the 3600-byte safety cap, and by `forceFlushEmitBuffer` at end-of-stream (which coalesces survivors into as few messages as possible, joined by `\n\n` so GFM tables and fenced blocks still render correctly).

The buffer persists across `chunkText` calls so block-deliver streaming (partial rows, partial fences) still works — the existing cross-call state is preserved.

We deliberately did **not** touch the C2C official streaming path (`StreamingController` / `streaming-c2c.ts`), which bypasses this chunker entirely. Tool progress text continues to use a `passthroughDeps` (no chunker buffering) so "AI is working" feedback still reaches the user immediately, not merged with the final answer.

Out of scope: changing the 3600-byte cap, changing the framework's table-conversion policy, or unifying with Telegram/Discord chunkers.

## User Impact

Short QQ Bot replies containing markdown tables (and fences) are now sent as a single coherent message instead of being fragmented. A typical "paragraph + small table + paragraph" reply that previously arrived as 3–5 separate messages now arrives as 1. Replies exceeding the byte limit still split correctly. Tool progress messages ("Working: ...") still arrive immediately as separate messages before the final answer, so users still see the "AI is working" feedback.

## Evidence

### Focused tests (local, this branch)

```
$ pnpm test extensions/qqbot/src/engine/messaging/markdown-table-chunking.test.ts
 Test Files  1 passed (1)
      Tests  32 passed (32)

$ pnpm test extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts
 Test Files  1 passed (1)
      Tests  23 passed (23)
```

### Type / lint

```
$ npx oxlint@latest extensions/qqbot/src/engine/messaging/markdown-table-chunking.ts \
                       extensions/qqbot/src/engine/gateway/outbound-dispatch.ts
(clean, exit 0)

$ node node_modules/@typescript/native-preview/bin/tsgo.js -p extensions/qqbot/tsconfig.json
6 pre-existing errors on main (unrelated: api-client.ts, token.ts, channel-api.ts, remind-logic.ts, upload-cache.ts — all in openclaw/plugin-sdk resolution)
Zero new errors from this branch.
```

### Behavior proof — direct regression test

A new test in `markdown-table-chunking.test.ts` (`regression: 400-byte reply with two small tables is one chunk`) takes the actual reply structure from a real user trace — paragraph + 3-row table + paragraph — and asserts:

```
chunks = chunkQQBotMarkdownText(text, 5000, baseChunker)
expect(chunks).toHaveLength(1)                              // ✅ was 5
expect(Buffer.byteLength(chunks[0], "utf8")).toBeLessThan(3600)
```

### Scope guard

```
$ git diff --stat 4a4657a182..HEAD
 4 files changed, 337 insertions(+), 72 deletions(-)

$ git diff --name-only 4a4657a182..HEAD \
    | grep -E "(streaming-c2c|outbound-deliver|channel)\.ts$"
(none — forbidden files untouched)
```

Diff is confined to:
- `extensions/qqbot/src/engine/messaging/markdown-table-chunking.ts` (implementation)
- `extensions/qqbot/src/engine/messaging/markdown-table-chunking.test.ts` (chunker tests, including 9 new behavior/edge tests)
- `extensions/qqbot/src/engine/gateway/outbound-dispatch.ts` (hoist `passthroughDeps`, route tool progress + tool fallback through it to preserve immediate-send semantics)
- `extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts` (consumer tests updated for new coalescing behavior; tool progress tests pass unchanged once passthrough fix is in)