### PR TITLE
fix(tui): normalize WSL Ubuntu DEL backspace to ASCII BS

### DIFF
--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -241,9 +241,7 @@ describe("resolveTuiShutdownHardExitMs", () => {
 
   it("clamps oversized local run shutdown grace values", () => {
     withEnv({ OPENCLAW_TUI_LOCAL_RUN_SHUTDOWN_GRACE_MS: String(Number.MAX_SAFE_INTEGER) }, () => {
-      expect(resolveTuiShutdownHardExitMs({ localMode: true })).toBe(
-        MAX_TIMER_TIMEOUT_MS + 2000,
-      );
+      expect(resolveTuiShutdownHardExitMs({ localMode: true })).toBe(MAX_TIMER_TIMEOUT_MS + 2000);
     });
   });
 });
@@ -379,7 +377,7 @@ describe("createBackspaceDeduper", () => {
   it("suppresses duplicate backspace events within the dedupe window", () => {
     const { dedupe, advance } = createTimedDedupe();
 
-    expect(dedupe("\x7f")).toBe("\x7f");
+    expect(dedupe("\x7f")).toBe("\x08");
     advance(1);
     expect(dedupe("\x08")).toBe("");
   });
@@ -387,9 +385,9 @@ describe("createBackspaceDeduper", () => {
   it("preserves backspace events outside the dedupe window", () => {
     const { dedupe, advance } = createTimedDedupe();
 
-    expect(dedupe("\x7f")).toBe("\x7f");
+    expect(dedupe("\x7f")).toBe("\x08");
     advance(10);
-    expect(dedupe("\x7f")).toBe("\x7f");
+    expect(dedupe("\x7f")).toBe("\x08");
   });
 
   it("treats ASCII BS as backspace when it is the first event", () => {
@@ -398,6 +396,12 @@ describe("createBackspaceDeduper", () => {
     expect(dedupe("\x08")).toBe("\x08");
     advance(1);
     expect(dedupe("\x7f")).toBe("");
+  });
+
+  it("normalizes WSL Ubuntu DEL (0x7f) to canonical ASCII BS (0x08)", () => {
+    const dedupe = createBackspaceDeduper();
+
+    expect(dedupe("\x7f")).toBe("\x08");
   });
 
   it("never suppresses non-backspace keys", () => {

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -258,7 +258,11 @@ export function createBackspaceDeduper(params?: { dedupeWindowMs?: number; now?:
       return "";
     }
     lastBackspaceAt = ts;
-    return data;
+    // Normalize DEL (0x7f), Kitty CSI-u backspace sequences, and any other
+    // backspace representation to canonical ASCII BS (0x08). Some terminals
+    // (e.g. WSL Ubuntu) send DEL, and downstream keybinding handling is
+    // simplest when there is one canonical backspace byte.
+    return "\x08";
   };
 }
 


### PR DESCRIPTION
Fixes #92777

## What Problem This Solves

On WSL2 Ubuntu, the terminal sends DEL (0x7f) for the Backspace key. After an agent response renders and the TUI re-enters raw mode, that DEL byte was not handled consistently, so Backspace stopped working until the TUI was restarted. Ctrl+H (which sends ASCII BS 0x08) continued to work as a workaround.

## Why This Change Was Made

OpenClaw's TUI input deduper already recognized both DEL and ASCII BS as backspace events for deduplication, but it forwarded the raw byte unchanged to the editor. Normalizing every recognized backspace representation to canonical ASCII BS keeps downstream keybinding handling simple and makes Backspace reliable across terminals.

## User Impact

Users running the OpenClaw TUI on WSL2 Ubuntu (and any other terminal that sends DEL for Backspace) can now use Backspace consistently before, during, and after agent responses.

## Evidence

- Added a regression test in src/tui/tui.test.ts that asserts DEL (0x7f) is normalized to ASCII BS (0x08).
- Updated existing createBackspaceDeduper tests to expect the normalized output.
- Ran pnpm test src/tui/tui.test.ts: 64 tests pass.
- Ran node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts (fast fake-backend PTY lane): 13 tests pass.
- Ran pnpm exec oxlint --tsconfig config/tsconfig/oxlint.core.json src/tui/tui.ts src/tui/tui.test.ts: 0 warnings, 0 errors.
- Ran pnpm exec oxfmt --check src/tui/tui.ts src/tui/tui.test.ts: clean.