### PR TITLE
fix(embedded-agent): allow re-entrant session write lock during compaction

### DIFF
--- a/src/agents/embedded-agent-runner/compact.hooks.harness.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.harness.ts
@@ -99,6 +99,11 @@ function createDefaultSessionMessages(): unknown[] {
 }
 export const sessionMessages: unknown[] = createDefaultSessionMessages();
 export const sessionAbortCompactionMock: Mock<(reason?: unknown) => void> = vi.fn();
+export const acquireSessionWriteLockMock: Mock<
+  (params?: { sessionFile?: string; allowReentrant?: boolean; timeoutMs?: number }) => Promise<{
+    release: Mock<() => Promise<void>>;
+  }>
+> = vi.fn(async () => ({ release: vi.fn(async () => {}) }));
 function createMockCompactionSession() {
   const session = {
     sessionId: "session-1",
@@ -398,6 +403,8 @@ export function resetCompactHooksHarnessMocks(): void {
   });
 
   triggerInternalHook.mockReset();
+  acquireSessionWriteLockMock.mockReset();
+  acquireSessionWriteLockMock.mockResolvedValue({ release: vi.fn(async () => {}) });
   resetCompactSessionStateMocks();
   createOpenClawCodingToolsMock.mockReset();
   createOpenClawCodingToolsMock.mockReturnValue([]);
@@ -560,7 +567,7 @@ export async function loadCompactHooksHarness(): Promise<{
   }));
 
   vi.doMock("../session-write-lock.js", () => ({
-    acquireSessionWriteLock: vi.fn(async () => ({ release: vi.fn(async () => {}) })),
+    acquireSessionWriteLock: acquireSessionWriteLockMock,
     resolveSessionLockMaxHoldFromTimeout: vi.fn(() => 0),
     resolveSessionWriteLockAcquireTimeoutMs: vi.fn(() => 60_000),
     resolveSessionWriteLockOptions: vi.fn(() => ({

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -3,6 +3,7 @@ import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
 import { beforeAll, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import {
   applyExtraParamsToAgentMock,
+  acquireSessionWriteLockMock,
   applyAgentCompactionSettingsFromConfigMock,
   buildEmbeddedSystemPromptMock,
   contextEngineCompactMock,
@@ -272,6 +273,22 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       sessionKey: "agent:main:telegram:default:direct:12345",
       workspaceDir: "/tmp/workspace",
     });
+  });
+
+  it("acquires the session write lock with allowReentrant for nested compaction", async () => {
+    await compactEmbeddedAgentSessionDirect({
+      sessionId: "session-1",
+      sessionKey: "agent:main:main",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp/workspace",
+    });
+
+    expect(acquireSessionWriteLockMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionFile: "/tmp/session.jsonl",
+        allowReentrant: true,
+      }),
+    );
   });
 
   it("uses subagent prompt surface and guidance for compacted subagent prompt rebuilds", async () => {

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -1180,6 +1180,11 @@ async function compactEmbeddedAgentSessionDirectOnce(
     const compactionTimeoutMs = resolveCompactionTimeoutMs(params.config);
     const sessionLock = await acquireSessionWriteLock({
       sessionFile: params.sessionFile,
+      // Compaction can be invoked from within an embedded attempt that already
+      // holds this session's write lock (e.g. overflow-recovery auto-compaction).
+      // Treat the nested acquire as re-entrant so it returns immediately instead
+      // of deadlocking against the outer lock.
+      allowReentrant: true,
       ...resolveSessionWriteLockOptions(params.config, {
         maxHoldMsFallback: resolveSessionLockMaxHoldFromTimeout({
           timeoutMs: compactionTimeoutMs,


### PR DESCRIPTION
Fixes #97747

## What Problem This Solves

When an embedded agent attempt triggers overflow-recovery auto-compaction, the compaction path (`compactContextEngineWithSafetyTimeout` → `contextEngine.compact()` → `compactEmbeddedAgentSessionDirect` → `acquireSessionWriteLock`) tries to acquire the same session write lock that the attempt already holds. Because `acquireSessionWriteLock` defaults to `allowReentrant: false`, the nested acquire blocks for 60s and then fails with `SessionWriteLockTimeoutError: pid=<self> alive=true`. Each fallback model repeats the same deadlock, producing the 18-minute recovery window reported in the issue.

## Why This Change Was Made

`compactEmbeddedAgentSessionDirect` can legitimately be invoked while the same process already owns the session write lock. Passing `allowReentrant: true` makes the nested acquire return immediately with a bumped reference count, matching the plugin-sdk `acquireFileLock` path and preventing self-deadlock during overflow recovery.

## User Impact

Long-running webchat sessions that hit context overflow no longer stall for minutes with "session file locked" errors while auto-compaction retries across the fallback chain.

## Evidence

- Added a regression test in `src/agents/embedded-agent-runner/compact.hooks.test.ts` that asserts `compactEmbeddedAgentSessionDirect` calls `acquireSessionWriteLock` with `allowReentrant: true`.
- Existing `src/agents/session-write-lock.test.ts` already covers that `allowReentrant: true` permits nested acquisition and only releases the lock after the final release.
- Ran `pnpm test src/agents/embedded-agent-runner/compact.hooks.test.ts`: 70 tests pass.
- Ran `pnpm test src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts`: 63 tests pass.
- Ran `oxlint` on changed files: 0 warnings, 0 errors.
- Ran `oxfmt --check` on changed files: clean.
