### PR TITLE
docs(onboard): document 11 missing non-interactive CLI flags

### DIFF
--- a/docs/cli/onboard.md
+++ b/docs/cli/onboard.md
@@ -208,6 +208,34 @@ openclaw onboard --non-interactive \
   --mistral-api-key "$MISTRAL_API_KEY"
 ```
 
+## Additional non-interactive flags
+
+Token-based model auth (non-interactive; used with `--auth-choice token`):
+
+- `--token-provider <id>` — Token provider id. Identifies which provider issues the token.
+- `--token <token>` — Token value for model authentication.
+- `--token-profile-id <id>` — Auth profile id (default: `<provider>:manual`).
+- `--token-expires-in <duration>` — Optional token expiry duration (e.g. `365d`, `12h`).
+
+Cloudflare AI Gateway (non-interactive):
+
+- `--cloudflare-ai-gateway-account-id <id>` — Cloudflare Account ID for routing through Cloudflare AI Gateway.
+- `--cloudflare-ai-gateway-gateway-id <id>` — Cloudflare AI Gateway ID.
+
+Daemon install control:
+
+- `--no-install-daemon` — Explicitly skip gateway service installation.
+- `--skip-daemon` — Alias for `--no-install-daemon`.
+
+UI and hook setup control:
+
+- `--skip-ui` — Skip Control UI / TUI prompts during onboarding.
+- `--skip-hooks` — Skip webhook / hook setup prompts during onboarding.
+
+Output suppression:
+
+- `--suppress-gateway-token-output` — Suppress token-bearing Gateway/UI output (token hints, auto-login URL with embedded token, and automatic Control UI launch). Useful in shared terminal and CI environments.
+
 ## Flow notes
 
 <AccordionGroup>

--- a/docs/cli/onboard.md
+++ b/docs/cli/onboard.md
@@ -214,7 +214,7 @@ Token-based model auth (non-interactive; used with `--auth-choice token`):
 
 - `--token-provider <id>` — Token provider id. Identifies which provider issues the token.
 - `--token <token>` — Token value for model authentication.
-- `--token-profile-id <id>` — Auth profile id (default: `<provider>:manual`).
+- `--token-profile-id <id>` — Auth profile id. Generic token storage defaults to `<provider>:manual`; provider-owned setup flows may use their own default, such as `anthropic:default`.
 - `--token-expires-in <duration>` — Optional token expiry duration (e.g. `365d`, `12h`).
 
 Cloudflare AI Gateway (non-interactive):

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -1707,6 +1707,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Examples
   - H2: Locale
   - H3: Non-interactive Z.AI endpoint choices
+  - H2: Additional non-interactive flags
   - H2: Flow notes
   - H2: Common follow-up commands
 


### PR DESCRIPTION
## What Problem This Solves

`docs/cli/onboard.md` was missing documentation for 11 CLI flags that exist in `src/cli/program/register.onboard.ts`. Users scripting non-interactive onboarding had to guess these flags or read source code.

## Why This Change Was Made

The following flags exist in the code (`src/cli/program/register.onboard.ts`) but had no documentation entry:

| Flag | Code line | Purpose |
|------|-----------|---------|
| `--token-provider <id>` | 119 | Token provider id for `--auth-choice token` |
| `--token <token>` | 122 | Token value for model authentication |
| `--token-profile-id <id>` | 124 | Auth profile id (default: `<provider>:manual`) |
| `--token-expires-in <duration>` | 127 | Token expiry duration (e.g. `365d`, `12h`) |
| `--cloudflare-ai-gateway-account-id <id>` | 132 | Cloudflare Account ID |
| `--cloudflare-ai-gateway-gateway-id <id>` | 133 | Cloudflare AI Gateway ID |
| `--no-install-daemon` | 164 | Skip gateway service installation |
| `--skip-daemon` | 165 | Alias for `--no-install-daemon` |
| `--skip-ui` | 172 | Skip Control UI / TUI prompts |
| `--suppress-gateway-token-output` | 173 | Suppress token-bearing output |
| `--skip-hooks` | 174 | Skip webhook/hook setup |

## Evidence

### Code — flag registrations in `src/cli/program/register.onboard.ts`

**Token auth flags (lines 118-127)**:
```ts
.option(
  "--token-provider <id>",
  "Token provider id (non-interactive; used with --auth-choice token)",
)
.option("--token <token>", "Token value (non-interactive; used with --auth-choice token)")
.option(
  "--token-profile-id <id>",
  "Auth profile id (non-interactive; default: <provider>:manual)",
)
.option("--token-expires-in <duration>", "Optional token expiry duration (e.g. 365d, 12h)")
```

**Cloudflare AI Gateway flags (lines 132-133)**:
```ts
.option("--cloudflare-ai-gateway-account-id <id>", "Cloudflare Account ID")
.option("--cloudflare-ai-gateway-gateway-id <id>", "Cloudflare AI Gateway ID")
```

**Daemon install control (lines 164-165)**:
```ts
.option("--no-install-daemon", "Skip gateway service install")
.option("--skip-daemon", "Skip gateway service install")
```

**UI / Hooks / Output control (lines 172-174)**:
```ts
.option("--skip-ui", "Skip Control UI/TUI prompts")
.option("--suppress-gateway-token-output", "Suppress token-bearing Gateway/UI output")
.option("--skip-hooks", "Skip hook setup")
```

### CLI help output confirms all 11 flags exist

```text
$ node openclaw.mjs onboard --help

--token-provider <id>                     Token provider id (non-interactive; used with --auth-choice token)
--token <token>                           Token value (non-interactive; used with --auth-choice token)
--token-profile-id <id>                   Auth profile id (non-interactive; default: <provider>:manual)
--token-expires-in <duration>             Optional token expiry duration (e.g. 365d, 12h)
--cloudflare-ai-gateway-account-id <id>   Cloudflare Account ID
--cloudflare-ai-gateway-gateway-id <id>   Cloudflare AI Gateway ID
--no-install-daemon                       Skip gateway service install
--skip-daemon                             Skip gateway service install
--skip-ui                                 Skip Control UI/TUI prompts
--skip-hooks                              Skip hook setup
--suppress-gateway-token-output           Suppress token-bearing Gateway/UI output
```

All 11 flags verified present in the CLI and now documented.

## User Impact

Users scripting non-interactive onboarding now have complete flag documentation. Editorial-only change — no code behavior affected.
