### PR TITLE
fix(openai): bound OAuth token response read at first body read in postTokenForm to prevent OOM

### DIFF
--- a/extensions/openai/openai-chatgpt-oauth-flow.runtime.test.ts
+++ b/extensions/openai/openai-chatgpt-oauth-flow.runtime.test.ts
@@ -174,4 +174,63 @@ describe("OpenAI Codex OAuth flow", () => {
       message: "OpenAI Codex token refresh response missing fields: expires_in",
     });
   });
+
+  it("rejects oversized token exchange responses", async () => {
+    ssrfMocks.fetchWithSsrFGuard.mockResolvedValueOnce({
+      response: makeOversizedOAuthJsonResponse(),
+      release: vi.fn(async () => undefined),
+    });
+
+    const result = await testing.exchangeAuthorizationCode(
+      "code",
+      "verifier",
+      testing.resolveRedirectUri("localhost"),
+      { timeoutMs: 5_000 },
+    );
+
+    expect(result).toMatchObject({
+      type: "failed",
+      message: expect.stringContaining("OpenAI Codex token exchange error"),
+    });
+  });
+
+  it("rejects oversized token refresh responses", async () => {
+    ssrfMocks.fetchWithSsrFGuard.mockResolvedValueOnce({
+      response: makeOversizedOAuthJsonResponse(),
+      release: vi.fn(async () => undefined),
+    });
+
+    const result = await testing.refreshAccessToken("old-refresh-token", { timeoutMs: 5_000 });
+
+    expect(result).toMatchObject({
+      type: "failed",
+      message: expect.stringContaining("OpenAI Codex token refresh error"),
+    });
+  });
 });
+
+/**
+ * Builds a JSON response body larger than the 16 MiB OAuth cap so the bounded
+ * reader cancels the stream mid-flight; proves oversized token responses are
+ * rejected before full buffering.
+ */
+function makeOversizedOAuthJsonResponse(): Response {
+  const ONE_MIB = 1024 * 1024;
+  const TOTAL_CHUNKS = 18;
+  const chunk = new Uint8Array(ONE_MIB);
+  let pulled = 0;
+  const body = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (pulled >= TOTAL_CHUNKS) {
+        controller.close();
+        return;
+      }
+      pulled += 1;
+      controller.enqueue(chunk);
+    },
+  });
+  return new Response(body, {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/extensions/openai/openai-chatgpt-oauth-flow.runtime.ts
+++ b/extensions/openai/openai-chatgpt-oauth-flow.runtime.ts
@@ -10,6 +10,8 @@ import {
   resolveOAuthTokenExpiresAt,
   resolveOAuthTokenLifetimeMs,
 } from "openclaw/plugin-sdk/provider-oauth-runtime";
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
+import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { resolveCodexAuthIdentity } from "./openai-chatgpt-auth-identity.js";
 import {
@@ -36,6 +38,7 @@ const LOOPBACK_CALLBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1"]);
 const CALLBACK_HOST = resolveCallbackHost();
 const REDIRECT_URI = resolveRedirectUri(CALLBACK_HOST);
 const MANUAL_PROMPT_FALLBACK_MS = 15_000;
+const OPENAI_OAUTH_RESPONSE_MAX_BYTES = 16 * 1024 * 1024;
 const TOKEN_REQUEST_TIMEOUT_MS = 30_000;
 const SCOPE = "openid profile email offline_access";
 
@@ -178,8 +181,12 @@ async function postTokenForm(
     auditContext: "openai-chatgpt-oauth-token",
   });
   try {
-    const responseBody = await response.arrayBuffer();
-    return new Response(responseBody, {
+    const responseBody = await readResponseWithLimit(response, OPENAI_OAUTH_RESPONSE_MAX_BYTES, {
+      onOverflow: ({ maxBytes }) =>
+        new Error(`OpenAI OAuth token response exceeds ${maxBytes} bytes`),
+    });
+    const bodyBuffer = new Uint8Array(responseBody);
+    return new Response(bodyBuffer, {
       status: response.status,
       statusText: response.statusText,
       headers: response.headers,
@@ -216,7 +223,12 @@ async function exchangeAuthorizationCode(
   }
 
   if (!response.ok) {
-    const text = await response.text().catch(() => "");
+    const text = await readResponseWithLimit(response, OPENAI_OAUTH_RESPONSE_MAX_BYTES, {
+      onOverflow: ({ maxBytes }) =>
+        new Error(`OpenAI OAuth token response exceeds ${maxBytes} bytes`),
+    })
+      .then((buf) => new TextDecoder().decode(buf))
+      .catch(() => "");
     return {
       type: "failed",
       status: response.status,
@@ -224,7 +236,10 @@ async function exchangeAuthorizationCode(
     };
   }
 
-  const json = (await response.json()) as TokenResponseJson;
+  const json = await readProviderJsonResponse<TokenResponseJson>(
+    response,
+    "OpenAI Codex token exchange",
+  );
 
   const expires = resolveOAuthTokenExpiresAt(json.expires_in);
   if (!json.access_token || !json.refresh_token || expires === undefined) {
@@ -258,7 +273,12 @@ async function refreshAccessToken(
     );
 
     if (!response.ok) {
-      const text = await response.text().catch(() => "");
+      const text = await readResponseWithLimit(response, OPENAI_OAUTH_RESPONSE_MAX_BYTES, {
+        onOverflow: ({ maxBytes }) =>
+          new Error(`OpenAI OAuth token response exceeds ${maxBytes} bytes`),
+      })
+        .then((buf) => new TextDecoder().decode(buf))
+        .catch(() => "");
       return {
         type: "failed",
         status: response.status,
@@ -266,7 +286,10 @@ async function refreshAccessToken(
       };
     }
 
-    const json = (await response.json()) as TokenResponseJson;
+    const json = await readProviderJsonResponse<TokenResponseJson>(
+      response,
+      "OpenAI Codex token refresh",
+    );
 
     const expires = resolveOAuthTokenExpiresAt(json.expires_in);
     if (!json.access_token || !json.refresh_token || expires === undefined) {


### PR DESCRIPTION
## What Problem This Solves

The original fix (#97716) applied bounded response readers downstream in `exchangeAuthorizationCode` and `refreshAccessToken`, but those operate on a `Response` already re-wrapped after `postTokenForm` consumed the entire body with `await response.arrayBuffer()`. The actual OOM vector was the unbounded first read inside `postTokenForm`.

This PR moves the 16 MiB bounded read (`readResponseWithLimit`) into `postTokenForm` — before the body is buffered — so oversized OAuth token responses are cancelled mid-stream rather than fully buffered. Downstream bounded readers are retained for defense-in-depth.

## Evidence

**Environment**: Linux, Node 22, OpenClaw main @ 0ce10d7793

**Terminal output** — all 12 tests pass, including 2 oversized-response regression tests:

```
$ pnpm test extensions/openai/openai-chatgpt-oauth-flow.runtime.test.ts --run --reporter=verbose

 ✓ OpenAI Codex OAuth flow > cancels provider login before opening the OAuth flow 91ms
 ✓ OpenAI Codex OAuth flow > does not open the OAuth flow after cancellation during setup 41ms
 ✓ OpenAI Codex OAuth flow > waits for Node OAuth runtime before creating an authorization flow 5ms
 ✓ OpenAI Codex OAuth flow > builds callback redirect URIs from the configured loopback host 1ms
 ✓ OpenAI Codex OAuth flow > rejects non-loopback callback bind hosts 1ms
 ✓ OpenAI Codex OAuth flow > times out token exchange requests 5ms
 ✓ OpenAI Codex OAuth flow > cancels token exchange requests with the caller signal 1ms
 ✓ OpenAI Codex OAuth flow > rejects unsafe token exchange lifetimes 16ms
 ✓ OpenAI Codex OAuth flow > times out token refresh requests 1ms
 ✓ OpenAI Codex OAuth flow > rejects non-positive token refresh lifetimes 1ms
 ✓ OpenAI Codex OAuth flow > rejects oversized token exchange responses 37ms
 ✓ OpenAI Codex OAuth flow > rejects oversized token refresh responses 36ms

 Test Files  1 passed (1)
      Tests  12 passed (12)
```

The oversized tests create 18 MiB ReadableStream responses (cap is 16 MiB) and verify the bounded reader in `postTokenForm` cancels the stream and the error propagates through `exchangeAuthorizationCode` / `refreshAccessToken` as a formatted token failure.

## Risk

Low. The 16 MiB cap matches the codebase convention. The cap is applied at the first body read (inside `postTokenForm`), and downstream bounded readers provide defense-in-depth on the re-wrapped response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)