### PR TITLE
fix(llm): pass through SSE bodies mislabeled as application/json

### DIFF
--- a/src/agents/provider-transport-fetch.test.ts
+++ b/src/agents/provider-transport-fetch.test.ts
@@ -1193,6 +1193,48 @@ describe("buildGuardedModelFetch", () => {
     expect(items).toEqual([{ ok: true }]);
   });
 
+  it("passes through already-SSE bodies mislabeled as application/json without double-prefixing data:", async () => {
+    // Regression: OpenAI-compatible gateways that return standard SSE
+    // (`data: {...}\n\n`) with an `application/json` content-type caused
+    // `data: data: {...}` after JSON-to-SSE synthesis, which the OpenAI SDK
+    // could not JSON.parse. Verify the sanitizer detects already-SSE bodies
+    // and passes them through verbatim.
+    const events = [
+      `data: ${JSON.stringify({ ok: true })}`,
+      `data: ${JSON.stringify({ ok: false })}`,
+      "data: [DONE]",
+    ].join("\n\n");
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response(events, {
+        headers: { "content-type": "application/json; charset=utf-8" },
+      }),
+      finalUrl: "https://openrouter.ai/api/v1/chat/completions",
+      release: vi.fn(async () => undefined),
+    });
+    const model = {
+      id: "moonshotai/kimi-k2.6",
+      provider: "openrouter",
+      api: "openai-completions",
+      baseUrl: "https://openrouter.ai/api/v1",
+    } as unknown as Model<"openai-completions">;
+
+    const response = await buildGuardedModelFetch(model)(
+      "https://openrouter.ai/api/v1/chat/completions",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ model: "moonshotai/kimi-k2.6", stream: true }),
+      },
+    );
+    const items = [];
+    for await (const item of Stream.fromSSEResponse(response, new AbortController())) {
+      items.push(item);
+    }
+
+    expect(response.headers.get("content-type")).toContain("text/event-stream");
+    expect(items).toEqual([{ ok: true }, { ok: false }]);
+  });
+
   it("does not clone Request bodies while checking for streaming JSON fallbacks", async () => {
     const cloneSpy = vi.spyOn(Request.prototype, "clone");
     fetchWithSsrFGuardMock.mockResolvedValue({

--- a/src/agents/provider-transport-fetch.ts
+++ b/src/agents/provider-transport-fetch.ts
@@ -56,6 +56,11 @@ const SSE_SYNTHESIZE_JSON_MAX_BYTES = 16 * 1024 * 1024;
  *  almost certainly hostile or broken — cap the buffer rather than let it grow. */
 const SSE_SANITIZE_BUFFER_MAX_BYTES = 64 * 1024;
 
+/** Matches an SSE `data:` line prefix. Used to detect upstream bodies that are
+ *  already SSE but mislabeled as `application/json` so we do not double-wrap
+ *  them into `data: data: {...}` and break the OpenAI SDK JSON parser. */
+const SSE_DATA_LINE_PREFIX_RE = /^data[ \t]*:[ \t]?/;
+
 const BLOCKED_EXACT_ORIGIN_TRUST_HOSTNAME_LABELS = new Set(["instance-data"]);
 const PLAIN_DECIMAL_NUMBER_RE = /^\d+(?:\.\d+)?$/;
 const RETRY_AFTER_HTTP_DATE_RE =
@@ -156,7 +161,16 @@ function sanitizeOpenAISdkSseResponse(
               buffer += decoder.decode();
               const data = buffer.trim();
               if (data) {
-                controller.enqueue(encoder.encode(`data: ${data}\n\n`));
+                // Some OpenAI-compatible gateways return standard SSE
+                // (`data: {...}\n\n`) but mislabel the body as
+                // `application/json`. Re-wrapping would produce
+                // `data: data: {...}` and the OpenAI SDK fails JSON parsing.
+                // Detect already-SSE bodies and pass them through verbatim.
+                if (SSE_DATA_LINE_PREFIX_RE.test(data)) {
+                  controller.enqueue(encoder.encode(`${data}\n\n`));
+                } else {
+                  controller.enqueue(encoder.encode(`data: ${data}\n\n`));
+                }
               }
               controller.enqueue(encoder.encode("data: [DONE]\n\n"));
               controller.close();


### PR DESCRIPTION
## What Problem This Solves

Custom OpenAI-compatible streaming gateways (vLLM, Ollama, proxies) that return standard SSE frames (`data: {...}\n\n`) with an `application/json` content-type cause OpenClaw 2026.6.x to double-wrap the prefix, producing `data: data: {...}`. The OpenAI SDK strips one `data:` prefix and then `JSON.parse`s the remainder, which fails with `Unexpected token 'd', "data: {\"id\"..." is not valid JSON`. The agent run errors before any reply is produced.

This is a regression from 2026.5.4 — the JSON-to-SSE synthesis path was added to handle upstream bodies returned with a JSON content-type, but did not distinguish a true JSON body from an already-SSE body mislabeled as JSON.

Fixes #96497.

## Why This Change Was Made

- The sanitizer at `src/agents/provider-transport-fetch.ts:sanitizeOpenAISdkSseResponse` synthesizes SSE frames for any successful streaming response labeled `application/json`, prepending `data: ` to the body.
- When the body is already SSE (`data: {...}\n\n`), this prepends a second `data: ` and breaks the OpenAI SDK stream parser.
- JSON grammar cannot start with `data:` (objects start with `{`, arrays with `[`, etc.), so a leading `data:` line marker is an unambiguous signal that the body is already SSE.

## User Impact

- Users on custom/self-hosted OpenAI-compatible gateways using `openai-completions` no longer get pre-reply crashes when the gateway labels SSE as JSON.
- True JSON bodies continue to be synthesized into SSE as before — no behavior change for gateways that actually return JSON.
- Native `api.openai.com` responses are unaffected (the sanitizer only runs for non-native OpenAI-compatible providers).

## Evidence

- Added regression test `passes through already-SSE bodies mislabeled as application/json without double-prefixing data:` feeds a multi-event SSE body labeled `application/json; charset=utf-8` through `buildGuardedModelFetch` and asserts the OpenAI SDK stream yields both events without double-prefixing.
- Full file: `node scripts/run-vitest.mjs src/agents/provider-transport-fetch.test.ts` — 79/79 passing.
- Typecheck: `tsgo --project tsconfig.json --declaration false --checkers 4` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)