### PR TITLE
fix(anthropic): bound OAuth token response read in postJson to prevent OOM

### DIFF
--- a/src/llm/utils/oauth/anthropic.test.ts
+++ b/src/llm/utils/oauth/anthropic.test.ts
@@ -79,4 +79,38 @@ describe("Anthropic OAuth token responses", () => {
       "Anthropic token refresh returned invalid token fields.",
     );
   });
+
+  it("rejects oversized token refresh responses", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => makeOversizedOAuthJsonResponse()));
+
+    await expect(refreshAnthropicToken("old-refresh-token")).rejects.toThrow(
+      "Anthropic OAuth token response exceeds",
+    );
+  });
 });
+
+/**
+ * Builds a JSON response body larger than the 16 MiB OAuth cap so the bounded
+ * reader cancels the stream mid-flight; proves oversized token responses are
+ * rejected before full buffering.
+ */
+function makeOversizedOAuthJsonResponse(): Response {
+  const ONE_MIB = 1024 * 1024;
+  const TOTAL_CHUNKS = 18;
+  const chunk = new Uint8Array(ONE_MIB);
+  let pulled = 0;
+  const body = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (pulled >= TOTAL_CHUNKS) {
+        controller.close();
+        return;
+      }
+      pulled += 1;
+      controller.enqueue(chunk);
+    },
+  });
+  return new Response(body, {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/src/llm/utils/oauth/anthropic.ts
+++ b/src/llm/utils/oauth/anthropic.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Server } from "node:http";
+import { readResponseWithLimit } from "@openclaw/media-core/read-response-with-limit";
 import { toErrorObject } from "../../../infra/errors.js";
 import {
   generateOAuthState,
@@ -50,6 +51,7 @@ const CALLBACK_HOST = process.env.OPENCLAW_OAUTH_CALLBACK_HOST || "127.0.0.1";
 const CALLBACK_PORT = 53692;
 const CALLBACK_PATH = "/callback";
 const REDIRECT_URI = `http://localhost:${CALLBACK_PORT}${CALLBACK_PATH}`;
+const ANTHROPIC_OAUTH_RESPONSE_MAX_BYTES = 16 * 1024 * 1024;
 const SCOPES =
   "org:create_api_key user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload";
 async function getNodeApis(): Promise<NodeApis> {
@@ -233,7 +235,12 @@ async function postJson(
     signal: buildOAuthRequestSignal({ signal: options.signal, timeoutMs }),
   });
 
-  const responseBody = await response.text();
+  const responseBody = new TextDecoder().decode(
+    await readResponseWithLimit(response, ANTHROPIC_OAUTH_RESPONSE_MAX_BYTES, {
+      onOverflow: ({ maxBytes }) =>
+        new Error(`Anthropic OAuth token response exceeds ${maxBytes} bytes`),
+    }),
+  );
 
   if (!response.ok) {
     throw new Error(


### PR DESCRIPTION
## What Problem This Solves

The `postJson` function in the Anthropic OAuth flow uses `await response.text()` as the first body read on the Anthropic OAuth token endpoint. This is an unbounded read that can cause OOM on oversized responses. The function is called by both `exchangeAuthorizationCode` and `refreshAnthropicToken`.

This replaces `response.text()` with `readResponseWithLimit` (16 MiB cap), matching the codebase convention used in other OAuth paths.

## Evidence

**Real environment tested**: Linux, Node 22, OpenClaw main @ 0ce10d7793

**Existing tests**: 4/4 pass (cancel, setup, token leak prevention, lifetime validation unchanged).

**New regression test**: 1 oversized-response test passes:
- `rejects oversized token refresh responses` — verifies refresh path through `postJson` catches overflow from an 18 MiB response stream before full buffering

**Test approach**: Stubs global `fetch` with an 18 MiB ReadableStream response (cap is 16 MiB), verifies the bounded reader cancels the stream and the error propagates with `"Anthropic OAuth token response exceeds"`.

## Risk

Low. The 16 MiB cap matches the codebase convention. The `postJson` function already accepted that responses could throw (the `response.text()` call was not wrapped in try/catch), and callers already catch errors from `postJson`. The overflow error propagates through the same catch paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)