### PR TITLE
fix(openrouter): bound OAuth API key response read in readResponseBody to prevent OOM

### DIFF
--- a/extensions/openrouter/oauth.test.ts
+++ b/extensions/openrouter/oauth.test.ts
@@ -312,4 +312,42 @@ describe("OpenRouter OAuth", () => {
   it("exposes stable auth choice metadata", () => {
     expect(OPENROUTER_OAUTH_CHOICE_ID).toBe("openrouter-oauth");
   });
+
+  it("rejects oversized OpenRouter OAuth API key responses", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValueOnce(makeOversizedOAuthJsonResponse());
+
+    await expect(
+      exchangeOpenRouterOAuthCode({
+        code: "AUTHCODE",
+        codeVerifier: "verifier-1",
+        fetchImpl,
+      }),
+    ).rejects.toThrow("OpenRouter OAuth key response exceeds");
+  });
 });
+
+/**
+ * Builds a JSON response body larger than the 16 MiB OAuth cap so the bounded
+ * reader cancels the stream mid-flight; proves oversized API key responses are
+ * rejected before full buffering.
+ */
+function makeOversizedOAuthJsonResponse(): Response {
+  const ONE_MIB = 1024 * 1024;
+  const TOTAL_CHUNKS = 18;
+  const chunk = new Uint8Array(ONE_MIB);
+  let pulled = 0;
+  const body = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (pulled >= TOTAL_CHUNKS) {
+        controller.close();
+        return;
+      }
+      pulled += 1;
+      controller.enqueue(chunk);
+    },
+  });
+  return new Response(body, {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/extensions/openrouter/oauth.ts
+++ b/extensions/openrouter/oauth.ts
@@ -9,6 +9,7 @@ import {
 } from "openclaw/plugin-sdk/provider-auth";
 import { generateOAuthState } from "openclaw/plugin-sdk/provider-auth-runtime";
 import { readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
+import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import { applyOpenrouterConfig, OPENROUTER_DEFAULT_MODEL_REF } from "./onboard.js";
 
 const PROVIDER_ID = "openrouter";
@@ -25,6 +26,7 @@ export const OPENROUTER_OAUTH_CODE_CHALLENGE_METHOD = "S256";
 const OPENROUTER_OAUTH_TIMEOUT_MS = 5 * 60 * 1000;
 const OPENROUTER_OAUTH_FETCH_TIMEOUT_MS = 30 * 1000;
 const OPENROUTER_OAUTH_ERROR_BODY_LIMIT_BYTES = 8 * 1024;
+const OPENROUTER_OAUTH_RESPONSE_MAX_BYTES = 16 * 1024 * 1024;
 const OPENROUTER_OAUTH_PROFILE_ID = "openrouter:default";
 
 type OpenRouterOAuthCallbackResult = {
@@ -75,7 +77,12 @@ function extractOpenRouterError(value: unknown): string | undefined {
 
 async function readResponseBody(response: Response): Promise<unknown> {
   const text = response.ok
-    ? await response.text()
+    ? new TextDecoder().decode(
+        await readResponseWithLimit(response, OPENROUTER_OAUTH_RESPONSE_MAX_BYTES, {
+          onOverflow: ({ maxBytes }) =>
+            new Error(`OpenRouter OAuth key response exceeds ${maxBytes} bytes`),
+        }),
+      )
     : await readResponseTextLimited(response, OPENROUTER_OAUTH_ERROR_BODY_LIMIT_BYTES).catch(
         () => "",
       );


### PR DESCRIPTION
## What Problem This Solves

The `readResponseBody` function in the OpenRouter OAuth flow uses `await response.text()` on the success path — the first body read from the OpenRouter API key endpoint. This is unbounded and can cause OOM on oversized responses. The error path already uses `readResponseTextLimited` with an 8 KB cap, but the success path was unprotected.

This replaces the success path `response.text()` with `readResponseWithLimit` (16 MiB cap), matching the codebase convention.

## Evidence

**Environment**: Linux, Node 22, OpenClaw main @ 0ce10d7793

**Terminal output** — all 9 tests pass, including 1 oversized-response regression test:

```
$ pnpm test extensions/openrouter/oauth.test.ts --run --reporter=verbose

 ✓ OpenRouter OAuth > builds the documented PKCE authorize URL 22ms
 ✓ OpenRouter OAuth > parses state-bound OpenRouter redirect URLs and query strings 5ms
 ✓ OpenRouter OAuth > exchanges an authorization code for the issued OpenRouter API key 24ms
 ✓ OpenRouter OAuth > surfaces OpenRouter OAuth exchange errors without credential material 3ms
 ✓ OpenRouter OAuth > bounds OpenRouter OAuth exchange error bodies without requiring response.text() 3ms
 ✓ OpenRouter OAuth > stores a browser OAuth result as the default OpenRouter API-key profile 9ms
 ✓ OpenRouter OAuth > uses the local callback path before opening the browser locally 3ms
 ✓ OpenRouter OAuth > exposes stable auth choice metadata 1ms
 ✓ OpenRouter OAuth > rejects oversized OpenRouter OAuth API key responses 42ms

 Test Files  1 passed (1)
      Tests  9 passed (9)
```

The oversized test provides a `fetchImpl` mock returning an 18 MiB ReadableStream (cap is 16 MiB) and verifies the bounded reader cancels the stream and the error propagates through `exchangeOpenRouterOAuthCode` with `"OpenRouter OAuth key response exceeds"`.

## Risk

Low. The 16 MiB cap matches the codebase convention. The bounded read replaces the exact same `response.text()` call on the success path; the error path already uses `readResponseTextLimited` and is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)