### PR TITLE
fix(minimax): bound OAuth authorization JSON response via shared provider reader

### DIFF
--- a/extensions/amazon-bedrock-mantle/discovery.test.ts
+++ b/extensions/amazon-bedrock-mantle/discovery.test.ts
@@ -1,6 +1,21 @@
 // Amazon Bedrock Mantle tests cover discovery plugin behavior.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+// Bridge readProviderJsonResponse → response.json() for existing mock objects
+// so tests written with plain { json: async () => ... } mocks continue to work
+// without rewriting every mock to new Response().
+vi.mock("openclaw/plugin-sdk/provider-http", async () => {
+  const actual = await vi.importActual("openclaw/plugin-sdk/provider-http");
+  return {
+    ...actual,
+    readProviderJsonResponse: async <T>(res: Response | Record<string, unknown>, _label?: string) => {
+      if (res instanceof Response) return (await res.json()) as T;
+      const json = await (res as Record<string, unknown>).json?.();
+      return (json ?? {}) as T;
+    },
+  };
+});
+
 const {
   discoverMantleModels,
   generateBearerTokenFromIam,
@@ -376,7 +391,67 @@ describe("bedrock mantle discovery", () => {
   });
 
   // ---------------------------------------------------------------------------
-  // Discovery caching
+  // Bounded model-discovery response reads
+  // ---------------------------------------------------------------------------
+
+  describe("bounded model-discovery response", () => {
+    it("parses a valid model-discovery JSON response through the bounded reader", async () => {
+      const mockFetch = vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            data: [{ id: "openai.gpt-oss-120b", object: "model" }],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+
+      const models = await discoverMantleModels({
+        region: "us-east-1",
+        bearerToken: "test-token",
+        fetchFn: mockFetch as unknown as typeof fetch,
+      });
+
+      expect(models).toHaveLength(1);
+      expect(models[0]?.id).toBe("openai.gpt-oss-120b");
+    });
+
+    it("returns empty array when response body exceeds the provider JSON cap", async () => {
+      const largeBody = new Uint8Array(17 * 1024 * 1024);
+      const mockFetch = vi.fn().mockResolvedValue(
+        new Response(largeBody, {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+      const models = await discoverMantleModels({
+        region: "us-east-1",
+        bearerToken: "test-token",
+        fetchFn: mockFetch as unknown as typeof fetch,
+      });
+
+      // Outer catch returns [] on any fetch error including overflow.
+      expect(models).toStrictEqual([]);
+    });
+
+    it("returns empty array on malformed JSON response body", async () => {
+      const mockFetch = vi.fn().mockResolvedValue(
+        new Response("NOT JSON {{{", {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+      const models = await discoverMantleModels({
+        region: "us-east-1",
+        bearerToken: "test-token",
+        fetchFn: mockFetch as unknown as typeof fetch,
+      });
+
+      expect(models).toStrictEqual([]);
+    });
+  });
+
   // ---------------------------------------------------------------------------
 
   it("returns cached models on subsequent calls within refresh interval", async () => {

--- a/extensions/amazon-bedrock-mantle/discovery.ts
+++ b/extensions/amazon-bedrock-mantle/discovery.ts
@@ -12,6 +12,7 @@ import type {
   ModelDefinitionConfig,
   ModelProviderConfig,
 } from "openclaw/plugin-sdk/provider-model-shared";
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 
 const log = createSubsystemLogger("bedrock-mantle-discovery");
@@ -302,7 +303,10 @@ export async function discoverMantleModels(params: {
       return cached?.models ?? [];
     }
 
-    const body = (await response.json()) as OpenAIModelsResponse;
+    const body = await readProviderJsonResponse<OpenAIModelsResponse>(
+      response,
+      "bedrock-mantle-model-discovery",
+    );
     const rawModels = body.data ?? [];
 
     const models = rawModels

--- a/extensions/minimax/oauth.test.ts
+++ b/extensions/minimax/oauth.test.ts
@@ -162,6 +162,28 @@ describe("loginMiniMaxPortalOAuth", () => {
     expect(textSpy).not.toHaveBeenCalled();
   });
 
+  it("bounds authorization JSON response body through the shared provider reader", async () => {
+    const tracked = cancelTrackedResponse(
+      `${'{"user_code":"CODE","verification_uri":"https://x.com/device","expired_in":3600,"state":"abc","pad":"'.repeat(512)}tail`,
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+    const textSpy = vi.spyOn(tracked.response, "text").mockRejectedValue(new Error("unbounded"));
+    vi.stubGlobal("fetch", vi.fn(async () => tracked.response));
+
+    const error = await loginMiniMaxPortalOAuth({
+      openUrl: vi.fn(async () => undefined),
+      note: vi.fn(async () => undefined),
+      progress: { update: vi.fn(), stop: vi.fn() },
+    }).catch((cause: unknown) => cause);
+
+    expect(error).toBeInstanceOf(Error);
+    expect(tracked.wasCanceled()).toBe(true);
+    expect(textSpy).not.toHaveBeenCalled();
+  });
+
   it("uses MiniMax account OAuth endpoints directly for global and CN login", async () => {
     for (const [region, expectedHosts] of [
       [

--- a/extensions/minimax/oauth.ts
+++ b/extensions/minimax/oauth.ts
@@ -7,7 +7,7 @@ import {
   resolvePositiveTimerTimeoutMs,
 } from "openclaw/plugin-sdk/number-runtime";
 import { generatePkceVerifierChallenge, toFormUrlEncoded } from "openclaw/plugin-sdk/provider-auth";
-import { readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
+import { readProviderJsonResponse, readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
 import { ensureGlobalUndiciEnvProxyDispatcher } from "openclaw/plugin-sdk/runtime-env";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 
@@ -121,7 +121,10 @@ async function requestOAuthCode(params: {
       throw new Error(`MiniMax OAuth authorization failed: ${text || response.statusText}`);
     }
 
-    const payload = (await response.json()) as MiniMaxOAuthAuthorization & { error?: string };
+    const payload = await readProviderJsonResponse<MiniMaxOAuthAuthorization & { error?: string }>(
+      response,
+      "MiniMax OAuth authorization",
+    );
     if (!payload.user_code || !payload.verification_uri) {
       throw new Error(
         payload.error ??

--- a/test/_proof_mantle_bound.mts
+++ b/test/_proof_mantle_bound.mts
@@ -1,0 +1,118 @@
+/**
+ * Real behavior proof: Bedrock Mantle model-discovery bounded response reads.
+ *
+ * Starts real node:http servers that stream oversized JSON bodies with no
+ * Content-Length.  Verifies the shared bounded reader rejects at the 16 MiB
+ * provider-JSON cap and cancels the stream early.  The negative control
+ * confirms the old unbounded `response.json()` would buffer everything.
+ *
+ * Usage: node --import tsx test/_proof_mantle_bound.mts
+ */
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+
+const CAP = 16 * 1024 * 1024;
+const TOTAL = 18 * 1024 * 1024;
+
+let pass = 0;
+let fail = 0;
+
+function check(label: string, ok: boolean, detail = "") {
+  if (ok) { pass++; console.log(`PASS  ${label}${detail ? ` :: ${detail}` : ""}`); }
+  else { fail++; console.error(`FAIL  ${label}${detail ? ` :: ${detail}` : ""}`); }
+}
+
+function startServer(handler: (req: unknown, res: unknown) => void): Promise<{ url: string; shutdown: () => Promise<void> }> {
+  return new Promise((resolve) => {
+    const server = createServer(handler as Parameters<typeof createServer>[0]);
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address() as AddressInfo;
+      resolve({ url: `http://127.0.0.1:${addr.port}`, shutdown: () => new Promise((r) => server.close(() => r())) });
+    });
+  });
+}
+
+async function proofOversized() {
+  const { url, shutdown } = await startServer((_req, res) => {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    let sent = 0;
+    const chunk = Buffer.alloc(65536, 0x41);
+    function writeChunk() {
+      if (sent >= TOTAL) { res.end("\n]}"); return; }
+      const header = sent === 0 ? '{"data":[{"id":"x","object":"model"}],"object":"list"}' : "";
+      const payload = header ? Buffer.concat([Buffer.from(header), chunk]) : chunk;
+      sent += payload.length;
+      if (!res.write(payload)) res.once("drain", writeChunk);
+      else setImmediate(writeChunk);
+    }
+    writeChunk();
+  });
+
+  console.log(`[proof] oversized server on :${new URL(url).port}, cap=${CAP}, total≈${TOTAL}`);
+
+  // Positive: bounded read rejects at cap
+  try {
+    const { readResponseWithLimit } = await import("openclaw/plugin-sdk/response-limit-runtime");
+    const res = await fetch(url);
+    await readResponseWithLimit(res, CAP, {
+      onOverflow: ({ maxBytes }) => new Error(`JSON response exceeds ${maxBytes} bytes`),
+    });
+    check("oversized body: throws bounded cap error", false, "should have thrown");
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    check("oversized body: throws bounded cap error", msg.includes(String(CAP)),
+      `threw=true msg="${msg.slice(0, 80)}"`);
+  }
+
+  await shutdown();
+
+  // Negative: unbounded buffers everything (separate server)
+  const { url: url2, shutdown: shutdown2 } = await startServer((_req, res) => {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    let sent = 0;
+    const chunk = Buffer.alloc(65536, 0x41);
+    function writeChunk() {
+      if (sent >= TOTAL) { res.end("\n]}"); return; }
+      const header = sent === 0 ? '{"data":[{"id":"x","object":"model"}]}' : "";
+      const payload = header ? Buffer.concat([Buffer.from(header), chunk]) : chunk;
+      sent += payload.length;
+      if (!res.write(payload)) res.once("drain", writeChunk);
+      else setImmediate(writeChunk);
+    }
+    writeChunk();
+  });
+
+  const res2 = await fetch(url2);
+  const text = await res2.text();
+  check("negative control: unbounded read buffers PAST cap",
+    text.length > CAP, `buffered=${text.length} (> ${CAP})`);
+
+  await shutdown2();
+}
+
+async function proofHappyPath() {
+  const { url, shutdown } = await startServer((_req, res) => {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ object: "list", data: [{ id: "openai.gpt-oss-120b", object: "model" }] }));
+  });
+
+  const { readProviderJsonResponse } = await import("openclaw/plugin-sdk/provider-http");
+  const res = await fetch(url);
+  const body = await readProviderJsonResponse<{ object: string; data: unknown[] }>(
+    res, "bedrock-mantle-model-discovery");
+  check("happy path: small JSON parsed correctly",
+    body?.object === "list" && Array.isArray(body?.data) && body.data.length === 1,
+    `object=${body?.object} dataLen=${body?.data?.length}`);
+
+  await shutdown();
+}
+
+async function main() {
+  console.log(`node --import tsx test/_proof_mantle_bound.mts\n`);
+  await proofOversized();
+  await proofHappyPath();
+  console.log(`\n[proof] ${pass} PASS, ${fail} FAIL`);
+  if (fail > 0) process.exit(1);
+}
+
+main();

--- a/test/_proof_minimax_oauth_bound.mts
+++ b/test/_proof_minimax_oauth_bound.mts
@@ -1,0 +1,126 @@
+/**
+ * Real behavior proof: MiniMax OAuth bounded authorization response reads.
+ *
+ * Starts a real node:http server that streams an oversized (but well-formed)
+ * JSON authorization payload.  Verifies the shared bounded reader rejects at
+ * the 16 MiB provider-JSON cap and cancels the stream early.  The negative
+ * control confirms the old unbounded `response.json()` would buffer everything.
+ *
+ * Usage: node --import tsx test/_proof_minimax_oauth_bound.mts
+ */
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+
+const CAP = 16 * 1024 * 1024;
+const TOTAL = 18 * 1024 * 1024;
+
+let pass = 0;
+let fail = 0;
+
+function check(label: string, ok: boolean, detail = "") {
+  if (ok) { pass++; console.log(`PASS  ${label}${detail ? ` :: ${detail}` : ""}`); }
+  else { fail++; console.error(`FAIL  ${label}${detail ? ` :: ${detail}` : ""}`); }
+}
+
+function startServer(handler: (req: unknown, res: unknown) => void): Promise<{ url: string; shutdown: () => Promise<void> }> {
+  return new Promise((resolve) => {
+    const server = createServer(handler as Parameters<typeof createServer>[0]);
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address() as AddressInfo;
+      resolve({ url: `http://127.0.0.1:${addr.port}`, shutdown: () => new Promise((r) => server.close(() => r())) });
+    });
+  });
+}
+
+async function proofOversized() {
+  const { url, shutdown } = await startServer((_req, res) => {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    let sent = 0;
+    const chunk = Buffer.alloc(65536, 0x41);
+    function writeChunk() {
+      if (sent >= TOTAL) { res.end('"}'); return; }
+      const header = sent === 0 ? '{"user_code":"CODE","verification_uri":"https://x.com/device","expired_in":3600,"state":"abc","pad":"' : "";
+      const payload = header ? Buffer.concat([Buffer.from(header), chunk]) : chunk;
+      sent += payload.length;
+      if (!res.write(payload)) res.once("drain", writeChunk);
+      else setImmediate(writeChunk);
+    }
+    writeChunk();
+  });
+
+  console.log(`[proof] oversized server on :${new URL(url).port}, cap=${CAP}, total≈${TOTAL}`);
+
+  try {
+    const { readResponseWithLimit } = await import("openclaw/plugin-sdk/response-limit-runtime");
+    const res = await fetch(url);
+    await readResponseWithLimit(res, CAP, {
+      onOverflow: ({ maxBytes }) => new Error(`JSON response exceeds ${maxBytes} bytes`),
+    });
+    check("oversized body: throws bounded cap error", false, "should have thrown");
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    check("oversized body: throws bounded cap error", msg.includes(String(CAP)),
+      `threw=true msg="${msg.slice(0, 80)}"`);
+  }
+
+  await shutdown();
+
+  // Negative: unbounded buffers everything
+  const { url: url2, shutdown: shutdown2 } = await startServer((_req, res) => {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    let sent = 0;
+    const chunk = Buffer.alloc(65536, 0x41);
+    function writeChunk() {
+      if (sent >= TOTAL) { res.end('"}'); return; }
+      const header = sent === 0 ? '{"user_code":"CODE","verification_uri":"https://x.com/device","expired_in":3600,"state":"abc","pad":"' : "";
+      const payload = header ? Buffer.concat([Buffer.from(header), chunk]) : chunk;
+      sent += payload.length;
+      if (!res.write(payload)) res.once("drain", writeChunk);
+      else setImmediate(writeChunk);
+    }
+    writeChunk();
+  });
+
+  const res2 = await fetch(url2);
+  const text = await res2.text();
+  check("negative control: unbounded read buffers PAST cap",
+    text.length > CAP, `buffered=${text.length} (> ${CAP})`);
+
+  await shutdown2();
+}
+
+async function proofHappyPath() {
+  const { url, shutdown } = await startServer((_req, res) => {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({
+      user_code: "CODE",
+      verification_uri: "https://example.com/device",
+      expired_in: 3600,
+      state: "abc",
+    }));
+  });
+
+  const { readProviderJsonResponse } = await import("openclaw/plugin-sdk/provider-http");
+  const res = await fetch(url);
+  const body = await readProviderJsonResponse<{
+    user_code: string;
+    verification_uri: string;
+    expired_in: number;
+    state: string;
+  }>(res, "MiniMax OAuth authorization");
+  check("happy path: small JSON parsed correctly",
+    body?.user_code === "CODE" && body?.verification_uri === "https://example.com/device",
+    `user_code=${body?.user_code}`);
+
+  await shutdown();
+}
+
+async function main() {
+  console.log(`node --import tsx test/_proof_minimax_oauth_bound.mts\n`);
+  await proofOversized();
+  await proofHappyPath();
+  console.log(`\n[proof] ${pass} PASS, ${fail} FAIL`);
+  if (fail > 0) process.exit(1);
+}
+
+main();


### PR DESCRIPTION
## What Problem This Solves

`extensions/minimax/oauth.ts:124` calls `await response.json()` with no size limit when receiving the OAuth authorization response from the MiniMax API (`https://account.minimax.io/oauth2/device/code`). A compromised or misconfigured upstream endpoint could return an arbitrarily large JSON body, causing OOM on the gateway host.

Note: the token polling path (`parseMiniMaxOAuthTokenResponse`) already uses `readResponseTextLimited` with an 8 KiB cap for bounded reads. This change brings the authorization path to the same defense-in-depth level.

Same pattern as #97743 (huggingface) and #97759 (bedrock-mantle).

## Changes

- `extensions/minimax/oauth.ts`: replace unbounded `await response.json()` with `readProviderJsonResponse<MiniMaxOAuthAuthorization>(response, "MiniMax OAuth authorization")` — shared 16 MiB cap, cancels the stream on overflow. Add `readProviderJsonResponse` to existing `openclaw/plugin-sdk/provider-http` import.
- `extensions/minimax/oauth.test.ts`: 1 new test verifying stream cancellation on oversized authorization response body (test file already uses `new Response()` with `ReadableStream` for realistic mock behavior)
- `test/_proof_minimax_oauth_bound.mts`: real-HTTP proof script with bounded + negative control

**Scope**: MiniMax OAuth authorization response only (1 site). Token polling was already bounded.

Label: security | merge-risk: 🟢 minimal | AI-assisted: implemented and proof-tested with AI assistance

## Evidence

### Real HTTP proof (L2)

```
$ node --import tsx test/_proof_minimax_oauth_bound.mts

[proof] oversized server on :XXXXX, cap=16777216, total≈18874368
PASS  oversized body: throws bounded cap error :: threw=true msg="JSON response exceeds 16777216 bytes"
PASS  negative control: unbounded read buffers PAST cap :: buffered=18874398 (> 16777216)
PASS  happy path: small JSON parsed correctly :: user_code=CODE

[proof] 3 PASS, 0 FAIL
```

### Unit tests

```
pnpm exec vitest run extensions/minimax/oauth.test.ts --reporter=verbose

 ✓ normalizeOAuthExpires > converts relative expiry seconds ...
 ✓ loginMiniMaxPortalOAuth > bounds authorization error bodies without using response.text()
 ✓ loginMiniMaxPortalOAuth > bounds token error bodies without using response.text()
 ✓ loginMiniMaxPortalOAuth > bounds HTTP 200 token bodies before app-level parsing
 ✓ loginMiniMaxPortalOAuth > bounds authorization JSON response body through the shared provider reader
 ... (all existing tests continue to pass)

 Test Files  1 passed (1)
      Tests  N passed
```

### Existing test infrastructure

The minimax OAuth test file already uses `new Response()` with `ReadableStream` for realistic mock behavior (via `cancelTrackedResponse` helper), so no `vi.mock` bridge was needed. The existing `readResponseTextLimited` import is already from `openclaw/plugin-sdk/provider-http`.