### PR TITLE
fix(agents): transform tool call output text

### DIFF
--- a/src/agents/plugin-text-transforms.test.ts
+++ b/src/agents/plugin-text-transforms.test.ts
@@ -139,6 +139,27 @@ describe("plugin text transforms", () => {
           partial,
         });
         stream.push({
+          type: "toolcall_delta",
+          contentIndex: 1,
+          delta: '{"query":"blue basket on the right shelf"}',
+          partial,
+        });
+        stream.push({
+          type: "toolcall_end",
+          contentIndex: 1,
+          toolCall: {
+            type: "toolCall",
+            id: "tool-1",
+            name: "search",
+            arguments: {
+              query: "blue basket on the right shelf",
+              nested: { note: "blue basket" },
+              entries: ["right shelf", 7],
+            },
+          },
+          partial,
+        });
+        stream.push({
           type: "done",
           reason: "stop",
           message: makeAssistantMessage("final blue basket on the right shelf"),
@@ -178,6 +199,22 @@ describe("plugin text transforms", () => {
     const firstEvent = events[0] as { type?: string; delta?: string } | undefined;
     expect(firstEvent?.type).toBe("text_delta");
     expect(firstEvent?.delta).toBe("red basket on the left shelf");
+    const toolDeltaEvent = events[1] as { type?: string; delta?: string } | undefined;
+    expect(toolDeltaEvent?.type).toBe("toolcall_delta");
+    expect(toolDeltaEvent?.delta).toBe('{"query":"red basket on the left shelf"}');
+    const toolEndEvent = events[2] as
+      | {
+          type?: string;
+          toolCall?: { name?: string; arguments?: Record<string, unknown> };
+        }
+      | undefined;
+    expect(toolEndEvent?.type).toBe("toolcall_end");
+    expect(toolEndEvent?.toolCall?.name).toBe("search");
+    expect(toolEndEvent?.toolCall?.arguments).toEqual({
+      query: "red basket on the left shelf",
+      nested: { note: "red basket" },
+      entries: ["left shelf", 7],
+    });
     expect(result.content).toEqual([{ type: "text", text: "final red basket on the left shelf" }]);
   });
 });

--- a/src/agents/plugin-text-transforms.ts
+++ b/src/agents/plugin-text-transforms.ts
@@ -79,6 +79,38 @@ function transformMessageText(message: unknown, replacements?: PluginTextReplace
   return next;
 }
 
+function transformToolCallArgumentText(
+  value: unknown,
+  replacements?: PluginTextReplacement[],
+): unknown {
+  if (typeof value === "string") {
+    return applyPluginTextReplacements(value, replacements);
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => transformToolCallArgumentText(entry, replacements));
+  }
+  if (!isRecord(value)) {
+    return value;
+  }
+  return Object.fromEntries(
+    Object.entries(value).map(([key, entry]) => [
+      key,
+      transformToolCallArgumentText(entry, replacements),
+    ]),
+  );
+}
+
+function transformToolCallText(toolCall: unknown, replacements?: PluginTextReplacement[]): unknown {
+  if (!isRecord(toolCall)) {
+    return toolCall;
+  }
+  const next = { ...toolCall };
+  if (Object.hasOwn(next, "arguments")) {
+    next.arguments = transformToolCallArgumentText(next.arguments, replacements);
+  }
+  return next;
+}
+
 /** Apply input text replacements to a stream context. */
 function transformStreamContextText(
   context: Parameters<StreamFn>[1],
@@ -113,6 +145,12 @@ function transformAssistantEventText(
   }
   if (next.type === "text_end" && typeof next.content === "string") {
     next.content = applyPluginTextReplacements(next.content, replacements);
+  }
+  if (next.type === "toolcall_delta" && typeof next.delta === "string") {
+    next.delta = applyPluginTextReplacements(next.delta, replacements);
+  }
+  if (next.type === "toolcall_end" && Object.hasOwn(next, "toolCall")) {
+    next.toolCall = transformToolCallText(next.toolCall, replacements);
   }
   if (Object.hasOwn(next, "partial")) {
     next.partial = transformMessageText(next.partial, replacements);


### PR DESCRIPTION
## What Problem This Solves

Fixes #97761.

Plugin `textTransforms.output` currently rewrites streamed assistant text and final messages, but skips structured tool-call output boundaries. Providers that emit masked or placeholder strings through `toolcall_delta` or parsed `toolCall.arguments` can therefore pass stale values into later tool execution even though normal text output is transformed.

## Why This Change Was Made

The stream wrapper already owns output replacement at the provider boundary. This change extends that same boundary to tool-call deltas and the string leaves inside tool-call argument objects, while leaving tool names, ids, numeric values, and other metadata untouched.

## User Impact

Users relying on plugin output replacements get consistent behavior for tool-call payloads as well as regular assistant text, reducing the chance that masked placeholders reach external tools.

## Evidence

- `node scripts/run-vitest.mjs src/agents/plugin-text-transforms.test.ts`
- `pnpm format:check src/agents/plugin-text-transforms.ts src/agents/plugin-text-transforms.test.ts`
- `git diff --check`
- Secret scan over diff: no matches for common token/private-key patterns

Refs/Fixes: #97761
