### PR TITLE
fix(model-registry): accept video and audio input modalities in schema validation (fixes #97048)

### DIFF
--- a/src/agents/sessions/model-registry.test.ts
+++ b/src/agents/sessions/model-registry.test.ts
@@ -345,4 +345,77 @@ describe("ModelRegistry models.json auth", () => {
     expect(registry.getError()).toBeUndefined();
     expect(registry.find("zai", "glm-5.1")).toBeUndefined();
   });
+
+  it("accepts video and audio input modalities from plugin catalog shards", () => {
+    // Providers like MiniMax and NVIDIA NIM declare video/audio input
+    // modalities in their fetched catalogs. The schema must accept these
+    // to avoid silently dropping models on gateway start.
+    const modelsPath = writeModelsJsonWithPluginCatalog({
+      root: { providers: {} },
+      pluginRelativePath: join("plugins", "minimax", PLUGIN_MODEL_CATALOG_FILE),
+      pluginCatalog: {
+        generatedBy: PLUGIN_MODEL_CATALOG_GENERATED_BY,
+        providers: {
+          minimax: {
+            baseUrl: "https://api.minimax.chat/v1",
+            api: "openai-completions",
+            apiKey: "MINIMAX_API_KEY",
+            models: [
+              {
+                id: "MiniMax-M3",
+                name: "MiniMax M3",
+                input: ["text", "image", "video"],
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    const registry = ModelRegistry.create(
+      AuthStorage.inMemory({ minimax: { type: "api_key", key: "sk-test" } }),
+      modelsPath,
+      { pluginMetadataSnapshot: pluginOwnerSnapshot("minimax", "minimax") },
+    );
+
+    expect(registry.getError()).toBeUndefined();
+    const model = registry.find("minimax", "MiniMax-M3");
+    expect(model).toBeDefined();
+    expect(model?.input).toEqual(["text", "image", "video"]);
+  });
+
+  it("accepts audio input modality from plugin catalog shards", () => {
+    const modelsPath = writeModelsJsonWithPluginCatalog({
+      root: { providers: {} },
+      pluginRelativePath: join("plugins", "nvidia", PLUGIN_MODEL_CATALOG_FILE),
+      pluginCatalog: {
+        generatedBy: PLUGIN_MODEL_CATALOG_GENERATED_BY,
+        providers: {
+          nvidia: {
+            baseUrl: "https://integrate.api.nvidia.com/v1",
+            api: "openai-completions",
+            apiKey: "NVIDIA_API_KEY",
+            models: [
+              {
+                id: "microsoft/phi-4-multimodal",
+                name: "Phi-4 Multimodal",
+                input: ["text", "image", "audio"],
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    const registry = ModelRegistry.create(
+      AuthStorage.inMemory({ nvidia: { type: "api_key", key: "sk-test" } }),
+      modelsPath,
+      { pluginMetadataSnapshot: pluginOwnerSnapshot("nvidia", "nvidia") },
+    );
+
+    expect(registry.getError()).toBeUndefined();
+    const model = registry.find("nvidia", "microsoft/phi-4-multimodal");
+    expect(model).toBeDefined();
+    expect(model?.input).toEqual(["text", "image", "audio"]);
+  });
 });

--- a/src/agents/sessions/model-registry.ts
+++ b/src/agents/sessions/model-registry.ts
@@ -162,7 +162,16 @@ const ModelDefinitionSchema = Type.Object({
   baseUrl: Type.Optional(Type.String({ minLength: 1 })),
   reasoning: Type.Optional(Type.Boolean()),
   thinkingLevelMap: Type.Optional(ThinkingLevelMapSchema),
-  input: Type.Optional(Type.Array(Type.Union([Type.Literal("text"), Type.Literal("image")]))),
+  input: Type.Optional(
+    Type.Array(
+      Type.Union([
+        Type.Literal("text"),
+        Type.Literal("image"),
+        Type.Literal("video"),
+        Type.Literal("audio"),
+      ]),
+    ),
+  ),
   cost: Type.Optional(
     Type.Object({
       input: Type.Number(),


### PR DESCRIPTION
## What Problem This Solves

When gateway starts, the model registry validates plugin catalog entries against a TypeBox schema. The schema's `input` field only accepted `"text"` and `"image"` modalities, but providers like MiniMax (`MiniMax-M3`) and NVIDIA NIM (`phi-4-multimodal`) declare `"video"` and `"audio"` in their fetched catalogs. This causes valid models to be silently dropped on gateway start, with the only signal being a `model catalog load issue: Invalid models.json schema` log entry.

The TypeScript type definition at `src/config/types.models.ts:164` already includes `video` and `audio`:
```typescript
input: Array<"text" | "image" | "video" | "audio">;
```

But the TypeBox validation schema at `src/agents/sessions/model-registry.ts:165` only had:
```typescript
Type.Union([Type.Literal("text"), Type.Literal("image")])
```

## Why This Change Was Made

The type/schema mismatch means any provider catalog declaring video or audio modalities fails validation. The model entry is dropped, and agents configured with those models silently fall back to defaults. This is a data-loss-adjacent behavior — the operator configured a specific model, but the runtime ignores it without actionable feedback.

## User Impact

- Models from MiniMax, NVIDIA NIM, and any future provider declaring video/audio input modalities now load correctly
- No config changes required — existing `models.json` and plugin catalogs work as-is
- Eliminates the silent model drop on gateway start for multimodal providers

## Evidence

## Real behavior proof

- **Behavior addressed:** Model catalog schema validation now accepts `video` and `audio` input modalities alongside `text` and `image`
- **Environment tested:** macOS, Node 22.22.3, OpenClaw worktree at `db2488b6e`
- **Steps run after the patch:**
  1. Built the project: `pnpm build` — succeeded
  2. Ran `node --import tsx` script that creates a temp `models.json` with models declaring `input: ["text", "image", "video"]`, `input: ["text", "image", "audio"]`, and `input: ["text", "image", "video", "audio"]`
  3. Instantiated `ModelRegistry.create()` with the fixture file
  4. Verified `registry.getError()` is `undefined` and all 3 models load correctly
- **Evidence after fix:**

```
✅ ModelRegistry accepts video/audio input modalities
  video-model.input: ["text","image","video"]
  audio-model.input: ["text","image","audio"]
  full-model.input: ["text","image","video","audio"]
  Total models loaded: 3
```

- **Observed result after fix:** All multimodal models load without schema validation errors. `registry.find()` returns the expected model entries with correct `input` arrays.
- **What was not tested:** Live gateway startup with a real MiniMax/NVIDIA plugin catalog (requires full gateway setup and API keys). The fix is a schema literal expansion — the behavior is deterministic from the TypeBox validation alone.

- [x] AI-assisted (Hermes Agent)
