### PR TITLE
fix(launcher): stop respawned children after parent death on Unix

### DIFF
--- a/openclaw.mjs
+++ b/openclaw.mjs
@@ -114,11 +114,52 @@ const respawnSignals =
 const respawnSignalExitGraceMs = 1_000;
 const respawnSignalForceKillGraceMs = 1_000;
 const respawnSignalHardExitGraceMs = 1_000;
+const respawnParentPidEnv = "OPENCLAW_RESPAWN_PARENT_PID";
+const respawnParentDeathGuardIntervalMs = 250;
+
+const installRespawnParentDeathGuard = () => {
+  if (process.platform === "win32") {
+    return;
+  }
+  const parentPid = Number(process.env[respawnParentPidEnv]);
+  delete process.env[respawnParentPidEnv];
+  if (!Number.isSafeInteger(parentPid) || parentPid <= 0 || parentPid === process.pid) {
+    return;
+  }
+  let detached = false;
+  let timer = null;
+  const detach = () => {
+    detached = true;
+    if (timer) {
+      clearInterval(timer);
+      timer = null;
+    }
+  };
+  const terminateIfOrphaned = () => {
+    if (detached || process.ppid === parentPid) {
+      return;
+    }
+    detach();
+    process.exit(1);
+  };
+  timer = setInterval(terminateIfOrphaned, respawnParentDeathGuardIntervalMs);
+  timer.unref?.();
+  terminateIfOrphaned();
+};
+
+installRespawnParentDeathGuard();
 
 const runRespawnedChild = (command, args, env) => {
+  const childEnv =
+    process.platform === "win32"
+      ? env
+      : {
+          ...env,
+          [respawnParentPidEnv]: String(process.pid),
+        };
   const child = spawn(command, args, {
     stdio: "inherit",
-    env,
+    env: childEnv,
   });
   const listeners = new Map();
   // This intentionally overlaps with src/entry.compile-cache.ts; keep the

--- a/src/entry.compile-cache.test.ts
+++ b/src/entry.compile-cache.test.ts
@@ -14,6 +14,7 @@ import {
   runOpenClawCompileCacheRespawnPlan,
   shouldEnableOpenClawCompileCache,
 } from "./entry.compile-cache.js";
+import { OPENCLAW_RESPAWN_PARENT_PID } from "./process/child-process-bridge.js";
 
 function requireFirstMockCall(mock: { mock: { calls: unknown[][] } }, label: string): unknown[] {
   const [call] = mock.mock.calls;
@@ -235,9 +236,11 @@ describe("entry compile cache", () => {
       ["/repo/openclaw/dist/entry.js", "status"],
       {
         stdio: "inherit",
-        env: { NODE_DISABLE_COMPILE_CACHE: "1" },
-        detached:
-          process.platform !== "win32" && !(process.stdin.isTTY || process.stdout.isTTY),
+        env: {
+          NODE_DISABLE_COMPILE_CACHE: "1",
+          [OPENCLAW_RESPAWN_PARENT_PID]: String(process.pid),
+        },
+        detached: process.platform !== "win32" && !(process.stdin.isTTY || process.stdout.isTTY),
       },
     );
     const [bridgeChild, bridgeOptions] = requireFirstMockCall(

--- a/src/entry.respawn.test.ts
+++ b/src/entry.respawn.test.ts
@@ -3,6 +3,7 @@ import type { ChildProcess } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { describe, expect, it, vi } from "vitest";
 import { buildCliRespawnPlan, runCliRespawnPlan } from "./entry.respawn.js";
+import { OPENCLAW_RESPAWN_PARENT_PID } from "./process/child-process-bridge.js";
 
 const EXPERIMENTAL_WARNING_FLAG = "--disable-warning=ExperimentalWarning";
 const OPENCLAW_NODE_EXTRA_CA_CERTS_READY = "OPENCLAW_NODE_EXTRA_CA_CERTS_READY";
@@ -257,9 +258,11 @@ describe("runCliRespawnPlan", () => {
       ["/repo/openclaw/dist/entry.js", "status"],
       {
         stdio: "inherit",
-        env: { OPENCLAW_NODE_OPTIONS_READY: "1" },
-        detached:
-          process.platform !== "win32" && !(process.stdin.isTTY || process.stdout.isTTY),
+        env: {
+          OPENCLAW_NODE_OPTIONS_READY: "1",
+          [OPENCLAW_RESPAWN_PARENT_PID]: String(process.pid),
+        },
+        detached: process.platform !== "win32" && !(process.stdin.isTTY || process.stdout.isTTY),
       },
     );
     const [bridgeChild, bridgeOptions] = requireFirstMockCall(

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -24,6 +24,7 @@ import { normalizeEnv } from "./infra/env.js";
 import { isMainModule } from "./infra/is-main.js";
 import { ensureOpenClawExecMarkerOnProcess } from "./infra/openclaw-exec-env.js";
 import { installProcessWarningFilter } from "./infra/warning-filter.js";
+import { installChildProcessParentDeathGuard } from "./process/child-process-bridge.js";
 
 const ENTRY_WRAPPER_PAIRS = [
   { wrapperBasename: "openclaw.mjs", entryBasename: "entry.js" },
@@ -61,6 +62,7 @@ if (
 ) {
   // Imported as a dependency — skip all entry-point side effects.
 } else {
+  installChildProcessParentDeathGuard();
   const entryFile = fileURLToPath(import.meta.url);
   const installRoot = resolveEntryInstallRoot(entryFile);
   const waitingForCompileCacheRespawn = respawnWithoutOpenClawCompileCacheIfNeeded({

--- a/src/process/child-process-bridge.test.ts
+++ b/src/process/child-process-bridge.test.ts
@@ -1,0 +1,178 @@
+// Child process bridge tests cover signal forwarding and parent-death guard behavior.
+import { EventEmitter } from "node:events";
+import { describe, expect, it, vi } from "vitest";
+import {
+  attachChildProcessBridge,
+  installChildProcessParentDeathGuard,
+  OPENCLAW_RESPAWN_PARENT_PID,
+  withChildProcessParentGuardEnv,
+} from "./child-process-bridge.js";
+
+describe("attachChildProcessBridge", () => {
+  function createFakeChild() {
+    const emitter = new EventEmitter() as EventEmitter & import("node:child_process").ChildProcess;
+    const kill = vi.fn<(signal?: NodeJS.Signals) => boolean>(() => true);
+    emitter.kill = kill as import("node:child_process").ChildProcess["kill"];
+    return { child: emitter, kill };
+  }
+
+  it("forwards SIGTERM to the wrapped child and detaches on exit", () => {
+    const beforeSigterm = new Set(process.listeners("SIGTERM"));
+    const { child, kill } = createFakeChild();
+    const observedSignals: NodeJS.Signals[] = [];
+
+    const { detach } = attachChildProcessBridge(child, {
+      signals: ["SIGTERM"],
+      onSignal: (signal) => observedSignals.push(signal),
+    });
+
+    const afterSigterm = process.listeners("SIGTERM");
+    const addedSigterm = afterSigterm.find((listener) => !beforeSigterm.has(listener));
+
+    if (!addedSigterm) {
+      throw new Error("expected SIGTERM listener");
+    }
+
+    addedSigterm("SIGTERM");
+    expect(observedSignals).toEqual(["SIGTERM"]);
+    expect(kill).toHaveBeenCalledWith("SIGTERM");
+
+    child.emit("exit");
+    expect(process.listeners("SIGTERM")).toHaveLength(beforeSigterm.size);
+
+    detach();
+  });
+});
+
+describe("withChildProcessParentGuardEnv", () => {
+  it("adds the wrapper PID marker on Unix", () => {
+    expect(
+      withChildProcessParentGuardEnv({
+        env: { OPENCLAW_NODE_OPTIONS_READY: "1" },
+        parentPid: 12345,
+        platform: "linux",
+      }),
+    ).toEqual({
+      OPENCLAW_NODE_OPTIONS_READY: "1",
+      [OPENCLAW_RESPAWN_PARENT_PID]: "12345",
+    });
+  });
+
+  it("returns the env unchanged on Windows", () => {
+    expect(
+      withChildProcessParentGuardEnv({
+        env: { OPENCLAW_NODE_OPTIONS_READY: "1" },
+        parentPid: 12345,
+        platform: "win32",
+      }),
+    ).toEqual({ OPENCLAW_NODE_OPTIONS_READY: "1" });
+  });
+});
+
+describe("installChildProcessParentDeathGuard", () => {
+  it("returns null on Windows", () => {
+    expect(
+      installChildProcessParentDeathGuard({
+        runtime: {
+          env: { [OPENCLAW_RESPAWN_PARENT_PID]: "12345" },
+          platform: "win32",
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when the marker is missing or invalid", () => {
+    expect(
+      installChildProcessParentDeathGuard({
+        runtime: {
+          env: {},
+          platform: "linux",
+        },
+      }),
+    ).toBeNull();
+    expect(
+      installChildProcessParentDeathGuard({
+        runtime: {
+          env: { [OPENCLAW_RESPAWN_PARENT_PID]: "not-a-number" },
+          platform: "linux",
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it("exits when the guarded child is reparented", () => {
+    let ppid = 12345;
+    let intervalCallback: (() => void) | undefined;
+    const timer = { unref: vi.fn() } as unknown as ReturnType<typeof setInterval>;
+    const clearInterval = vi.fn();
+    const exit = vi.fn();
+    const env = { [OPENCLAW_RESPAWN_PARENT_PID]: "12345" };
+
+    const guard = installChildProcessParentDeathGuard({
+      intervalMs: 10,
+      runtime: {
+        env,
+        exit: exit as unknown as (code?: number) => never,
+        pid: 67890,
+        platform: "linux",
+        ppid: () => ppid,
+        setInterval: vi.fn((callback: () => void) => {
+          intervalCallback = callback;
+          return timer;
+        }) as unknown as typeof setInterval,
+        clearInterval,
+      },
+    });
+
+    expect(guard).not.toBeNull();
+    expect(env).toEqual({});
+    expect(exit).not.toHaveBeenCalled();
+
+    ppid = 1;
+    intervalCallback?.();
+
+    expect(clearInterval).toHaveBeenCalledWith(timer);
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  it("keeps the guard alive while the parent PID matches", () => {
+    const timer = { unref: vi.fn() } as unknown as ReturnType<typeof setInterval>;
+    const exit = vi.fn();
+
+    const guard = installChildProcessParentDeathGuard({
+      intervalMs: 10,
+      runtime: {
+        env: { [OPENCLAW_RESPAWN_PARENT_PID]: "12345" },
+        exit: exit as unknown as (code?: number) => never,
+        pid: 67890,
+        platform: "linux",
+        ppid: () => 12345,
+        setInterval: vi.fn(() => timer) as unknown as typeof setInterval,
+        clearInterval: vi.fn(),
+      },
+    });
+
+    expect(guard).not.toBeNull();
+    expect(exit).not.toHaveBeenCalled();
+  });
+
+  it("detaches the guard cleanly", () => {
+    const timer = { unref: vi.fn() } as unknown as ReturnType<typeof setInterval>;
+    const clearInterval = vi.fn();
+
+    const guard = installChildProcessParentDeathGuard({
+      runtime: {
+        env: { [OPENCLAW_RESPAWN_PARENT_PID]: "12345" },
+        exit: vi.fn() as unknown as (code?: number) => never,
+        pid: 67890,
+        platform: "linux",
+        ppid: () => 12345,
+        setInterval: vi.fn(() => timer) as unknown as typeof setInterval,
+        clearInterval,
+      },
+    });
+
+    guard?.detach();
+    expect(clearInterval).toHaveBeenCalledWith(timer);
+  });
+});

--- a/src/process/child-process-bridge.ts
+++ b/src/process/child-process-bridge.ts
@@ -8,10 +8,98 @@ export type ChildProcessBridgeOptions = {
   onSignal?: (signal: NodeJS.Signals) => void;
 };
 
+/** Internal env key marking the wrapper PID that spawned a respawn child. */
+export const OPENCLAW_RESPAWN_PARENT_PID = "OPENCLAW_RESPAWN_PARENT_PID";
+const DEFAULT_PARENT_DEATH_GUARD_INTERVAL_MS = 250;
+
+type ParentDeathGuardRuntime = {
+  env: NodeJS.ProcessEnv;
+  exit: (code?: number) => never;
+  pid: number;
+  platform: NodeJS.Platform;
+  ppid: () => number;
+  setInterval: typeof setInterval;
+  clearInterval: typeof clearInterval;
+};
+
 const defaultSignals: NodeJS.Signals[] =
   process.platform === "win32"
     ? ["SIGTERM", "SIGINT", "SIGBREAK"]
     : ["SIGTERM", "SIGINT", "SIGHUP", "SIGQUIT"];
+
+/** Adds the wrapper PID marker to a respawn child's env on Unix. */
+export function withChildProcessParentGuardEnv(params: {
+  env: NodeJS.ProcessEnv;
+  parentPid?: number;
+  platform?: NodeJS.Platform;
+}): NodeJS.ProcessEnv {
+  if ((params.platform ?? process.platform) === "win32") {
+    return params.env;
+  }
+  return {
+    ...params.env,
+    [OPENCLAW_RESPAWN_PARENT_PID]: String(params.parentPid ?? process.pid),
+  };
+}
+
+/**
+ * Starts a parent-death guard in a respawned child.
+ *
+ * If the env marker names the current wrapper PID, the child polls its ppid and
+ * exits when it is reparented (e.g. wrapper SIGKILL/crash). The marker is
+ * consumed so nested child commands cannot inherit a stale wrapper PID.
+ */
+export function installChildProcessParentDeathGuard(
+  params: {
+    intervalMs?: number;
+    runtime?: Partial<ParentDeathGuardRuntime>;
+  } = {},
+): { detach: () => void } | null {
+  const runtime: ParentDeathGuardRuntime = {
+    env: process.env,
+    exit: process.exit.bind(process) as (code?: number) => never,
+    pid: process.pid,
+    platform: process.platform,
+    ppid: () => process.ppid,
+    setInterval,
+    clearInterval,
+    ...params.runtime,
+  };
+  if (runtime.platform === "win32") {
+    return null;
+  }
+  const parentPid = Number(runtime.env[OPENCLAW_RESPAWN_PARENT_PID]);
+  delete runtime.env[OPENCLAW_RESPAWN_PARENT_PID];
+  if (!Number.isSafeInteger(parentPid) || parentPid <= 0 || parentPid === runtime.pid) {
+    return null;
+  }
+
+  let detached = false;
+  let timer: ReturnType<typeof setInterval> | undefined;
+  const detach = (): void => {
+    detached = true;
+    if (timer) {
+      runtime.clearInterval(timer);
+      timer = undefined;
+    }
+  };
+  const terminateIfOrphaned = (): void => {
+    if (detached || runtime.ppid() === parentPid) {
+      return;
+    }
+    detach();
+    runtime.exit(1);
+  };
+
+  timer = runtime.setInterval(
+    terminateIfOrphaned,
+    params.intervalMs ?? DEFAULT_PARENT_DEATH_GUARD_INTERVAL_MS,
+  );
+  timer.unref?.();
+  terminateIfOrphaned();
+
+  return { detach };
+}
 
 /** Forwards process termination signals to a child and detaches on child exit/error. */
 export function attachChildProcessBridge(

--- a/src/process/exec.test.ts
+++ b/src/process/exec.test.ts
@@ -11,7 +11,6 @@ const spawnMock = vi.hoisted(() => vi.fn());
 const execFileMock = vi.hoisted(() => vi.fn());
 const execFilePromiseMock = vi.hoisted(() => vi.fn());
 
-let attachChildProcessBridge: typeof import("./child-process-bridge.js").attachChildProcessBridge;
 let resolveCommandEnv: typeof import("./exec.js").resolveCommandEnv;
 let resolveProcessExitCode: typeof import("./exec.js").resolveProcessExitCode;
 let runExec: typeof import("./exec.js").runExec;
@@ -413,42 +412,5 @@ describe("runCommandWithTimeout", () => {
     );
 
     expect(result.preservedStdoutLines).toEqual(["x".repeat(22)]);
-  });
-});
-
-describe("attachChildProcessBridge", () => {
-  function createFakeChild() {
-    const emitter = new EventEmitter() as EventEmitter & ChildProcess;
-    const kill = vi.fn<(signal?: NodeJS.Signals) => boolean>(() => true);
-    emitter.kill = kill as ChildProcess["kill"];
-    return { child: emitter, kill };
-  }
-
-  it("forwards SIGTERM to the wrapped child and detaches on exit", () => {
-    const beforeSigterm = new Set(process.listeners("SIGTERM"));
-    const { child, kill } = createFakeChild();
-    const observedSignals: NodeJS.Signals[] = [];
-
-    const { detach } = attachChildProcessBridge(child, {
-      signals: ["SIGTERM"],
-      onSignal: (signal) => observedSignals.push(signal),
-    });
-
-    const afterSigterm = process.listeners("SIGTERM");
-    const addedSigterm = afterSigterm.find((listener) => !beforeSigterm.has(listener));
-
-    if (!addedSigterm) {
-      throw new Error("expected SIGTERM listener");
-    }
-
-    addedSigterm("SIGTERM");
-    expect(observedSignals).toEqual(["SIGTERM"]);
-    expect(kill).toHaveBeenCalledWith("SIGTERM");
-
-    child.emit("exit");
-    expect(process.listeners("SIGTERM")).toHaveLength(beforeSigterm.size);
-
-    // Detached already via exit; should remain a safe no-op.
-    detach();
   });
 });

--- a/src/process/respawn-child-runner.test.ts
+++ b/src/process/respawn-child-runner.test.ts
@@ -2,6 +2,7 @@
 import type { ChildProcess, spawn } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { OPENCLAW_RESPAWN_PARENT_PID } from "./child-process-bridge.js";
 
 const signalProcessTreeMock = vi.hoisted(() => vi.fn());
 
@@ -43,15 +44,17 @@ describe("runRespawnChildWithSignalBridge", () => {
       onError: vi.fn(),
     });
 
-    expect(spawnChild).toHaveBeenCalledWith(
-      "/usr/bin/node",
-      ["/repo/openclaw/dist/entry.js"],
-      {
-        stdio: "inherit",
-        env: { OPENCLAW_NODE_OPTIONS_READY: "1" },
-        detached: process.platform !== "win32",
-      },
-    );
+    expect(spawnChild).toHaveBeenCalledWith("/usr/bin/node", ["/repo/openclaw/dist/entry.js"], {
+      stdio: "inherit",
+      env:
+        process.platform === "win32"
+          ? { OPENCLAW_NODE_OPTIONS_READY: "1" }
+          : {
+              OPENCLAW_NODE_OPTIONS_READY: "1",
+              [OPENCLAW_RESPAWN_PARENT_PID]: String(process.pid),
+            },
+      detached: process.platform !== "win32",
+    });
   });
 
   it("signals detached respawn process groups after forwarded signal grace", () => {
@@ -172,7 +175,10 @@ describe("runRespawnChildWithSignalBridge", () => {
       ["/repo/openclaw/dist/entry.js", "configure"],
       {
         stdio: "inherit",
-        env: {},
+        env:
+          process.platform === "win32"
+            ? {}
+            : { [OPENCLAW_RESPAWN_PARENT_PID]: String(process.pid) },
         detached: false,
       },
     );

--- a/src/process/respawn-child-runner.ts
+++ b/src/process/respawn-child-runner.ts
@@ -1,6 +1,7 @@
 // Respawn child runner restarts child processes after configured exits.
 import type { ChildProcess, spawn } from "node:child_process";
 import type { attachChildProcessBridge } from "./child-process-bridge.js";
+import { withChildProcessParentGuardEnv } from "./child-process-bridge.js";
 import { signalProcessTree } from "./kill-tree.js";
 
 const RESPAWN_SIGNAL_EXIT_GRACE_MS = 1_000;
@@ -28,7 +29,7 @@ export function runRespawnChildWithSignalBridge(params: {
     params.detachForProcessTree === true && process.platform !== "win32" && !stdioIsTerminal;
   const child = runtime.spawn(command, args, {
     stdio: "inherit",
-    env,
+    env: withChildProcessParentGuardEnv({ env }),
     detached: detachForProcessTree,
   });
 

--- a/test/openclaw-launcher.e2e.test.ts
+++ b/test/openclaw-launcher.e2e.test.ts
@@ -128,6 +128,19 @@ function isProcessAlive(pid: number | undefined): boolean {
   }
 }
 
+async function waitUntil(predicate: () => boolean, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() <= deadline) {
+    if (predicate()) {
+      return;
+    }
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 25);
+    });
+  }
+  throw new Error("timed out waiting for condition");
+}
+
 function launcherEnv(extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
   const env = { ...process.env, ...extra };
   delete env.OPENCLAW_BUNDLED_PLUGINS_DIR;
@@ -893,6 +906,59 @@ describe("openclaw launcher", () => {
           code: 1,
           signal: null,
         });
+        expect(isProcessAlive(launcher.pid)).toBe(false);
+        expect(isProcessAlive(respawnChildPid)).toBe(false);
+      } finally {
+        if (isProcessAlive(respawnChildPid)) {
+          process.kill(respawnChildPid!, "SIGKILL");
+        }
+        if (isProcessAlive(launcher.pid)) {
+          process.kill(launcher.pid!, "SIGKILL");
+        }
+      }
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "terminates source-checkout compile-cache respawn children after parent SIGKILL",
+    async () => {
+      const fixtureRoot = await makeLauncherFixture(fixtureRoots);
+      await addGitMarker(fixtureRoot);
+      const childInfoPath = path.join(fixtureRoot, "child-info.json");
+      await fs.writeFile(
+        path.join(fixtureRoot, "dist", "entry.js"),
+        [
+          'import { writeFileSync } from "node:fs";',
+          `writeFileSync(${JSON.stringify(
+            childInfoPath,
+          )}, JSON.stringify({ pid: process.pid, ppid: process.ppid }) + "\\n");`,
+          'process.title = "openclaw-launcher-parent-death-test-child";',
+          "setInterval(() => {}, 1000);",
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+
+      const launcher = spawn(process.execPath, [path.join(fixtureRoot, "openclaw.mjs")], {
+        cwd: fixtureRoot,
+        env: launcherEnv({
+          NODE_COMPILE_CACHE: path.join(fixtureRoot, ".node-compile-cache"),
+        }),
+        stdio: "ignore",
+      });
+      let respawnChildPid: number | undefined;
+
+      try {
+        const childInfo = await waitForJsonFile<{ pid: number; ppid: number }>(childInfoPath, 5000);
+        respawnChildPid = childInfo.pid;
+        expect(childInfo.ppid).toBe(launcher.pid);
+
+        launcher.kill("SIGKILL");
+
+        await waitUntil(
+          () => !isProcessAlive(launcher.pid) && !isProcessAlive(respawnChildPid),
+          5000,
+        );
         expect(isProcessAlive(launcher.pid)).toBe(false);
         expect(isProcessAlive(respawnChildPid)).toBe(false);
       } finally {


### PR DESCRIPTION
## What Problem This Solves

Fixes #79534. When `openclaw.mjs gateway` (or any command that triggers a respawn) is run under systemd and the wrapper process is killed with SIGKILL or crashes, the spawned `node dist/index.js ...` child can survive and become an orphan reparented to PID 1. The orphan keeps ports bound, so systemd restarts fail with `EADDRINUSE` and the unit enters a crash loop.

## Why This Change Was Made

The launcher already forwards catchable signals (SIGTERM/SIGINT/SIGHUP/SIGQUIT) to respawn children, but SIGKILL and wrapper crashes cannot run that forwarding path. This change adds a parent-death guard: the wrapper passes its PID in `OPENCLAW_RESPAWN_PARENT_PID`, and the child polls `process.ppid` on Unix; if the child is reparented, it exits immediately.

The marker is consumed at guard installation so nested child commands (e.g. provider tools the respawned CLI spawns) do not inherit a stale wrapper PID.

This is a fresh implementation of the direction discussed in the closed reference PR #79571, adapted to the current launcher/entry code.

## User Impact

- Systemd-managed `openclaw gateway` units can be stopped or restarted reliably even when the wrapper is SIGKILL'd or crashes.
- No behavior change on Windows (parent-PID polling is Unix-only).
- No change for normal interactive use where the wrapper exits cleanly.

## Evidence

Local verification commands:

```text
pnpm build
pnpm test src/process/child-process-bridge.test.ts src/process/respawn-child-runner.test.ts src/process/exec.test.ts src/entry.respawn.test.ts src/entry.compile-cache.test.ts test/openclaw-launcher.e2e.test.ts
pnpm exec oxfmt --check --threads=1 openclaw.mjs src/entry.ts src/process/child-process-bridge.ts src/process/respawn-child-runner.ts src/process/exec.test.ts test/openclaw-launcher.e2e.test.ts src/entry.respawn.test.ts src/entry.compile-cache.test.ts src/process/child-process-bridge.test.ts src/process/respawn-child-runner.test.ts
git diff --check
```

Results:

- `pnpm build`: passed
- Tests: 103 passed / 2 skipped across 3 Vitest shards
- Format/whitespace checks: passed

Closes #79534