### PR TITLE
fix(plugins): apply output text transforms to toolcall_delta and toolcall_end events

### DIFF
--- a/docs/gateway/cli-backends.md
+++ b/docs/gateway/cli-backends.md
@@ -382,8 +382,11 @@ api.registerTextTransforms({
 ```
 
 `input` rewrites the system prompt and user prompt passed to the CLI. `output`
-rewrites streamed assistant deltas and parsed final text before OpenClaw handles
-its own control markers and channel delivery.
+rewrites streamed assistant text and parsed final text before OpenClaw handles
+its own control markers and channel delivery. For provider-backed model calls,
+`output` also restores string values inside structured tool-call arguments after
+stream repair and before tool execution. Raw provider JSON fragments remain
+unchanged; consumers should use the structured partial, end, or result payload.
 
 For CLIs that emit provider-specific JSONL events, set `jsonlDialect` on that
 backend's config. Supported dialects are `claude-stream-json` for Claude

--- a/src/agents/embedded-agent-runner/run/attempt.tool-call-argument-repair.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.tool-call-argument-repair.test.ts
@@ -1,5 +1,6 @@
 // Coverage for repairing malformed streamed tool-call arguments.
 import { describe, expect, it } from "vitest";
+import { wrapStreamFnTextTransforms } from "../../plugin-text-transforms.js";
 import {
   shouldRepairMalformedToolCallArguments,
   wrapStreamFnRepairMalformedToolCallArguments,
@@ -213,6 +214,61 @@ describe("shouldRepairMalformedToolCallArguments", () => {
 });
 
 describe("openai-completions malformed tool-call argument repair", () => {
+  it("restores split replacement tokens after argument repair", async () => {
+    const partialToolCall = { type: "toolCall", name: "send", arguments: {} };
+    const streamedToolCall = { type: "toolCall", name: "send", arguments: {} };
+    const finalToolCall = { type: "toolCall", name: "send", arguments: {} };
+    const partialMessage = { role: "assistant", content: [partialToolCall] };
+    const finalMessage = { role: "assistant", content: [finalToolCall] };
+    const baseFn: FakeStreamFn = () =>
+      createFakeStream({
+        events: [
+          {
+            type: "toolcall_delta",
+            contentIndex: 0,
+            delta: '{"text":"[MAS',
+            partial: partialMessage,
+          },
+          {
+            type: "toolcall_delta",
+            contentIndex: 0,
+            delta: 'KED]"}',
+            partial: partialMessage,
+          },
+          {
+            type: "toolcall_end",
+            contentIndex: 0,
+            toolCall: streamedToolCall,
+            partial: partialMessage,
+          },
+        ],
+        resultMessage: finalMessage,
+      });
+    const repairedFn = wrapStreamFnRepairMalformedToolCallArguments(baseFn as never);
+    const transformedFn = wrapStreamFnTextTransforms({
+      streamFn: repairedFn,
+      output: [{ from: /\[MASKED\]/g, to: "John Smith" }],
+    }) as FakeStreamFn;
+    const stream = await Promise.resolve(transformedFn({} as never, {} as never, {} as never));
+    const events = [];
+    for await (const event of stream) {
+      events.push(event);
+    }
+
+    expect(
+      events
+        .filter((event) => (event as { type?: string }).type === "toolcall_delta")
+        .map((event) => (event as { delta?: string }).delta),
+    ).toEqual(['{"text":"[MAS', 'KED]"}']);
+    const endEvent = events.find(
+      (event) => (event as { type?: string }).type === "toolcall_end",
+    ) as { toolCall?: { arguments?: unknown } } | undefined;
+    expect(endEvent?.toolCall?.arguments).toEqual({ text: "John Smith" });
+    await expect(stream.result()).resolves.toMatchObject({
+      content: [{ arguments: { text: "John Smith" } }],
+    });
+  });
+
   it.each([
     ["openai-completions", "sglang"],
     ["openai-chatgpt-responses", "openai"],

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -2872,11 +2872,10 @@ export async function runEmbeddedAttempt(
         workspaceDir: effectiveWorkspace,
         runtimeHandle: getProviderRuntimeHandle(),
       });
-      if (providerTextTransforms) {
+      if (providerTextTransforms?.input?.length) {
         activeSession.agent.streamFn = wrapStreamFnTextTransforms({
           streamFn: activeSession.agent.streamFn,
           input: providerTextTransforms.input,
-          output: providerTextTransforms.output,
           transformSystemPrompt: false,
         });
       }
@@ -3099,6 +3098,15 @@ export async function runEmbeddedAttempt(
         activeSession.agent.streamFn = wrapStreamFnDecodeXaiToolCallArguments(
           activeSession.agent.streamFn,
         );
+      }
+
+      // Tool-call repair can replace structured arguments from fragmented deltas.
+      // Restore provider-masked text afterward so executable args stay canonical.
+      if (providerTextTransforms?.output?.length) {
+        activeSession.agent.streamFn = wrapStreamFnTextTransforms({
+          streamFn: activeSession.agent.streamFn,
+          output: providerTextTransforms.output,
+        });
       }
 
       if (anthropicPayloadLogger) {

--- a/src/agents/plugin-text-transforms.test.ts
+++ b/src/agents/plugin-text-transforms.test.ts
@@ -180,4 +180,46 @@ describe("plugin text transforms", () => {
     expect(firstEvent?.delta).toBe("red basket on the left shelf");
     expect(result.content).toEqual([{ type: "text", text: "final red basket on the left shelf" }]);
   });
+
+  it("applies output replacements to toolcall_delta and toolcall_end events", async () => {
+    const baseStreamFn: StreamFn = (_model, _context) => {
+      const stream = createAssistantMessageEventStream();
+      queueMicrotask(() => {
+        stream.push({
+          type: "toolcall_delta",
+          contentIndex: 0,
+          delta: '{"name":"[MASKED]","id":"123"}',
+          partial: { name: "[MASKED]", id: "123" },
+        } as never);
+        stream.push({
+          type: "toolcall_end",
+          contentIndex: 0,
+          toolCall: { type: "toolCall", id: "call-1", name: "[MASKED]_greet" },
+        } as never);
+        stream.push({ type: "done", reason: "stop" } as never);
+        stream.end();
+      });
+      return stream;
+    };
+
+    const wrapped = wrapStreamFnTextTransforms({
+      streamFn: baseStreamFn,
+      output: [{ from: /\[MASKED\]/g, to: "John" }],
+    });
+    const stream = await Promise.resolve(wrapped(model, {} as Context, undefined));
+    const events = [];
+    for await (const event of stream) {
+      events.push(event);
+    }
+
+    const deltaEvent = events.find((e) => e?.type === "toolcall_delta") as
+      | { delta?: string }
+      | undefined;
+    expect(deltaEvent?.delta).toBe('{"name":"John","id":"123"}');
+
+    const endEvent = events.find((e) => e?.type === "toolcall_end") as
+      | { toolCall?: { name?: string } }
+      | undefined;
+    expect(endEvent?.toolCall?.name).toBe("John_greet");
+  });
 });

--- a/src/agents/plugin-text-transforms.test.ts
+++ b/src/agents/plugin-text-transforms.test.ts
@@ -5,6 +5,7 @@ import {
   type AssistantMessage,
   type Context,
   type Model,
+  type ToolCall,
 } from "openclaw/plugin-sdk/llm";
 import { describe, expect, it } from "vitest";
 import {
@@ -37,6 +38,14 @@ function makeAssistantMessage(text: string): AssistantMessage {
       cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
     },
     timestamp: 0,
+  };
+}
+
+function makeAssistantToolMessage(toolCall: ToolCall): AssistantMessage {
+  return {
+    ...makeAssistantMessage(""),
+    content: [toolCall],
+    stopReason: "toolUse",
   };
 }
 
@@ -181,45 +190,44 @@ describe("plugin text transforms", () => {
     expect(result.content).toEqual([{ type: "text", text: "final red basket on the left shelf" }]);
   });
 
-  it("applies output replacements to toolcall_delta and toolcall_end events", async () => {
+  it("applies output replacements to structured tool-call arguments", async () => {
+    const partialToolCall: ToolCall = {
+      type: "toolCall",
+      id: "call-1",
+      name: "search",
+      arguments: {
+        query: "[MASKED]",
+        nested: { note: "ask [MASKED] again" },
+        entries: ["[MASKED]", 7],
+      },
+    };
+    const finalToolCall: ToolCall = {
+      type: "toolCall",
+      id: "call-2",
+      name: "send_msg",
+      arguments: { text: "[MASKED]" },
+    };
+    const partial = makeAssistantToolMessage(partialToolCall);
     const baseStreamFn: StreamFn = (_model, _context) => {
       const stream = createAssistantMessageEventStream();
       queueMicrotask(() => {
         stream.push({
           type: "toolcall_delta",
           contentIndex: 0,
-          delta: '{"name":"[MASKED]","id":"123"}',
-          partial: { name: "[MASKED]", id: "123" },
-        } as never);
+          delta: '{"query":"[MASKED]"}',
+          partial,
+        });
         stream.push({
           type: "toolcall_end",
           contentIndex: 0,
-          toolCall: {
-            type: "toolCall",
-            id: "call-1",
-            name: "search",
-            arguments: {
-              query: "[MASKED]",
-              nested: { note: "ask [MASKED] again" },
-              entries: ["[MASKED]", 7],
-            },
-          },
-        } as never);
+          toolCall: partialToolCall,
+          partial,
+        });
         stream.push({
           type: "done",
-          reason: "stop",
-          message: {
-            role: "assistant",
-            content: [
-              { type: "text", text: "done." },
-              {
-                type: "toolCall",
-                name: "send_msg",
-                arguments: { text: "[MASKED]" },
-              },
-            ],
-          },
-        } as never);
+          reason: "toolUse",
+          message: makeAssistantToolMessage(finalToolCall),
+        });
         stream.end();
       });
       return stream;
@@ -235,12 +243,22 @@ describe("plugin text transforms", () => {
       events.push(event);
     }
 
-    const deltaEvent = events.find((e) => e?.type === "toolcall_delta") as
-      | { delta?: string }
+    const deltaEvent = events.find((event) => event.type === "toolcall_delta") as
+      | { delta?: string; partial?: AssistantMessage }
       | undefined;
-    expect(deltaEvent?.delta).toBe('{"name":"John","id":"123"}');
+    // Raw JSON fragments are provider bytes and may split a replacement token.
+    // Structured arguments are the safe, canonical transform surface.
+    expect(deltaEvent?.delta).toBe('{"query":"[MASKED]"}');
+    expect(deltaEvent?.partial?.content[0]).toMatchObject({
+      name: "search",
+      arguments: {
+        query: "John",
+        nested: { note: "ask John again" },
+        entries: ["John", 7],
+      },
+    });
 
-    const endEvent = events.find((e) => e?.type === "toolcall_end") as
+    const endEvent = events.find((event) => event.type === "toolcall_end") as
       | { toolCall?: { name?: string; arguments?: Record<string, unknown> } }
       | undefined;
     // Tool name is preserved — only arguments are transformed to avoid
@@ -252,11 +270,10 @@ describe("plugin text transforms", () => {
       entries: ["John", 7],
     });
 
-    // stream.result() tool-call blocks must also be transformed (#97761).
     const result = await stream.result();
-    const toolCallBlock = (
-      result.content as unknown as Array<Record<string, unknown>> | undefined
-    )?.find((b) => b?.type === "toolCall");
-    expect(toolCallBlock?.arguments).toEqual({ text: "John" });
+    expect(result.content[0]).toMatchObject({
+      name: "send_msg",
+      arguments: { text: "John" },
+    });
   });
 });

--- a/src/agents/plugin-text-transforms.test.ts
+++ b/src/agents/plugin-text-transforms.test.ts
@@ -241,5 +241,12 @@ describe("plugin text transforms", () => {
       nested: { note: "ask John again" },
       entries: ["John", 7],
     });
+
+    // stream.result() tool-call blocks must also be transformed (#97761).
+    const result = await stream.result();
+    const toolCallBlock = (result.content as Array<Record<string, unknown>> | undefined)?.find(
+      (b) => b?.type === "toolCall",
+    );
+    expect(toolCallBlock?.arguments).toEqual({ text: "John" });
   });
 });

--- a/src/agents/plugin-text-transforms.test.ts
+++ b/src/agents/plugin-text-transforms.test.ts
@@ -197,7 +197,7 @@ describe("plugin text transforms", () => {
           toolCall: {
             type: "toolCall",
             id: "call-1",
-            name: "[MASKED]_greet",
+            name: "search",
             arguments: {
               query: "[MASKED]",
               nested: { note: "ask [MASKED] again" },
@@ -205,7 +205,11 @@ describe("plugin text transforms", () => {
             },
           },
         } as never);
-        stream.push({ type: "done", reason: "stop" } as never);
+        stream.push({
+          type: "done",
+          reason: "stop",
+          message: makeAssistantMessage("final"),
+        } as never);
         stream.end();
       });
       return stream;
@@ -229,7 +233,9 @@ describe("plugin text transforms", () => {
     const endEvent = events.find((e) => e?.type === "toolcall_end") as
       | { toolCall?: { name?: string; arguments?: Record<string, unknown> } }
       | undefined;
-    expect(endEvent?.toolCall?.name).toBe("John_greet");
+    // Tool name is preserved — only arguments are transformed to avoid
+    // breaking tool routing by renaming a registered tool identifier.
+    expect(endEvent?.toolCall?.name).toBe("search");
     expect(endEvent?.toolCall?.arguments).toEqual({
       query: "John",
       nested: { note: "ask John again" },

--- a/src/agents/plugin-text-transforms.test.ts
+++ b/src/agents/plugin-text-transforms.test.ts
@@ -254,9 +254,9 @@ describe("plugin text transforms", () => {
 
     // stream.result() tool-call blocks must also be transformed (#97761).
     const result = await stream.result();
-    const toolCallBlock = (result.content as Array<Record<string, unknown>> | undefined)?.find(
-      (b) => b?.type === "toolCall",
-    );
+    const toolCallBlock = (
+      result.content as unknown as Array<Record<string, unknown>> | undefined
+    )?.find((b) => b?.type === "toolCall");
     expect(toolCallBlock?.arguments).toEqual({ text: "John" });
   });
 });

--- a/src/agents/plugin-text-transforms.test.ts
+++ b/src/agents/plugin-text-transforms.test.ts
@@ -194,7 +194,16 @@ describe("plugin text transforms", () => {
         stream.push({
           type: "toolcall_end",
           contentIndex: 0,
-          toolCall: { type: "toolCall", id: "call-1", name: "[MASKED]_greet" },
+          toolCall: {
+            type: "toolCall",
+            id: "call-1",
+            name: "[MASKED]_greet",
+            arguments: {
+              query: "[MASKED]",
+              nested: { note: "ask [MASKED] again" },
+              entries: ["[MASKED]", 7],
+            },
+          },
         } as never);
         stream.push({ type: "done", reason: "stop" } as never);
         stream.end();
@@ -218,8 +227,13 @@ describe("plugin text transforms", () => {
     expect(deltaEvent?.delta).toBe('{"name":"John","id":"123"}');
 
     const endEvent = events.find((e) => e?.type === "toolcall_end") as
-      | { toolCall?: { name?: string } }
+      | { toolCall?: { name?: string; arguments?: Record<string, unknown> } }
       | undefined;
     expect(endEvent?.toolCall?.name).toBe("John_greet");
+    expect(endEvent?.toolCall?.arguments).toEqual({
+      query: "John",
+      nested: { note: "ask John again" },
+      entries: ["John", 7],
+    });
   });
 });

--- a/src/agents/plugin-text-transforms.test.ts
+++ b/src/agents/plugin-text-transforms.test.ts
@@ -208,7 +208,17 @@ describe("plugin text transforms", () => {
         stream.push({
           type: "done",
           reason: "stop",
-          message: makeAssistantMessage("final"),
+          message: {
+            role: "assistant",
+            content: [
+              { type: "text", text: "done." },
+              {
+                type: "toolCall",
+                name: "send_msg",
+                arguments: { text: "[MASKED]" },
+              },
+            ],
+          },
         } as never);
         stream.end();
       });

--- a/src/agents/plugin-text-transforms.ts
+++ b/src/agents/plugin-text-transforms.ts
@@ -147,10 +147,7 @@ function transformAssistantEventText(
     return event as AssistantMessageEvent;
   }
   const next = { ...event };
-  if (
-    (next.type === "text_delta" || next.type === "toolcall_delta") &&
-    typeof next.delta === "string"
-  ) {
+  if (next.type === "text_delta" && typeof next.delta === "string") {
     next.delta = applyPluginTextReplacements(next.delta, replacements);
   }
   if (next.type === "text_end" && typeof next.content === "string") {

--- a/src/agents/plugin-text-transforms.ts
+++ b/src/agents/plugin-text-transforms.ts
@@ -79,6 +79,20 @@ function transformMessageText(message: unknown, replacements?: PluginTextReplace
   return next;
 }
 
+function transformToolCallText(
+  toolCall: Record<string, unknown>,
+  replacements?: PluginTextReplacement[],
+): Record<string, unknown> {
+  if (!replacements || replacements.length === 0) {
+    return toolCall;
+  }
+  const next = { ...toolCall };
+  if (typeof next.name === "string") {
+    next.name = applyPluginTextReplacements(next.name, replacements);
+  }
+  return next;
+}
+
 /** Apply input text replacements to a stream context. */
 function transformStreamContextText(
   context: Parameters<StreamFn>[1],
@@ -108,11 +122,17 @@ function transformAssistantEventText(
     return event as AssistantMessageEvent;
   }
   const next = { ...event };
-  if (next.type === "text_delta" && typeof next.delta === "string") {
+  if (
+    (next.type === "text_delta" || next.type === "toolcall_delta") &&
+    typeof next.delta === "string"
+  ) {
     next.delta = applyPluginTextReplacements(next.delta, replacements);
   }
   if (next.type === "text_end" && typeof next.content === "string") {
     next.content = applyPluginTextReplacements(next.content, replacements);
+  }
+  if (next.type === "toolcall_end" && isRecord(next.toolCall)) {
+    next.toolCall = transformToolCallText(next.toolCall, replacements);
   }
   if (Object.hasOwn(next, "partial")) {
     next.partial = transformMessageText(next.partial, replacements);

--- a/src/agents/plugin-text-transforms.ts
+++ b/src/agents/plugin-text-transforms.ts
@@ -79,6 +79,26 @@ function transformMessageText(message: unknown, replacements?: PluginTextReplace
   return next;
 }
 
+function transformToolCallArgumentText(
+  value: unknown,
+  replacements?: PluginTextReplacement[],
+): unknown {
+  if (typeof value === "string") {
+    return applyPluginTextReplacements(value, replacements);
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => transformToolCallArgumentText(entry, replacements));
+  }
+  if (!isRecord(value)) {
+    return value;
+  }
+  const next: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    next[key] = transformToolCallArgumentText(entry, replacements);
+  }
+  return next;
+}
+
 function transformToolCallText(
   toolCall: Record<string, unknown>,
   replacements?: PluginTextReplacement[],
@@ -89,6 +109,9 @@ function transformToolCallText(
   const next = { ...toolCall };
   if (typeof next.name === "string") {
     next.name = applyPluginTextReplacements(next.name, replacements);
+  }
+  if (Object.hasOwn(next, "arguments")) {
+    next.arguments = transformToolCallArgumentText(next.arguments, replacements);
   }
   return next;
 }

--- a/src/agents/plugin-text-transforms.ts
+++ b/src/agents/plugin-text-transforms.ts
@@ -95,27 +95,12 @@ function transformToolCallArgumentText(
   if (!isRecord(value)) {
     return value;
   }
-  const next: Record<string, unknown> = {};
-  for (const [key, entry] of Object.entries(value)) {
-    next[key] = transformToolCallArgumentText(entry, replacements);
-  }
-  return next;
-}
-
-function transformToolCallText(
-  toolCall: Record<string, unknown>,
-  replacements?: PluginTextReplacement[],
-): Record<string, unknown> {
-  if (!replacements || replacements.length === 0) {
-    return toolCall;
-  }
-  const next = { ...toolCall };
-  // Only transform arguments, not the tool name — renaming a tool can
-  // break execution by routing to an unknown or unintended tool.
-  if (Object.hasOwn(next, "arguments")) {
-    next.arguments = transformToolCallArgumentText(next.arguments, replacements);
-  }
-  return next;
+  return Object.fromEntries(
+    Object.entries(value).map(([key, entry]) => [
+      key,
+      transformToolCallArgumentText(entry, replacements),
+    ]),
+  );
 }
 
 /** Apply input text replacements to a stream context. */
@@ -153,8 +138,16 @@ function transformAssistantEventText(
   if (next.type === "text_end" && typeof next.content === "string") {
     next.content = applyPluginTextReplacements(next.content, replacements);
   }
-  if (next.type === "toolcall_end" && isRecord(next.toolCall)) {
-    next.toolCall = transformToolCallText(next.toolCall, replacements);
+  if (
+    next.type === "toolcall_end" &&
+    isRecord(next.toolCall) &&
+    Object.hasOwn(next.toolCall, "arguments")
+  ) {
+    // Tool names are routing identifiers; only argument values are text.
+    next.toolCall = {
+      ...next.toolCall,
+      arguments: transformToolCallArgumentText(next.toolCall.arguments, replacements),
+    };
   }
   if (Object.hasOwn(next, "partial")) {
     next.partial = transformMessageText(next.partial, replacements);

--- a/src/agents/plugin-text-transforms.ts
+++ b/src/agents/plugin-text-transforms.ts
@@ -62,7 +62,7 @@ function transformContentText(content: unknown, replacements?: PluginTextReplace
   if (Object.hasOwn(next, "content")) {
     next.content = transformContentText(next.content, replacements);
   }
-  if (Object.hasOwn(next, "arguments")) {
+  if (next.type === "toolCall" && Object.hasOwn(next, "arguments")) {
     next.arguments = transformToolCallArgumentText(next.arguments, replacements);
   }
   return next;

--- a/src/agents/plugin-text-transforms.ts
+++ b/src/agents/plugin-text-transforms.ts
@@ -62,6 +62,9 @@ function transformContentText(content: unknown, replacements?: PluginTextReplace
   if (Object.hasOwn(next, "content")) {
     next.content = transformContentText(next.content, replacements);
   }
+  if (Object.hasOwn(next, "arguments")) {
+    next.arguments = transformToolCallArgumentText(next.arguments, replacements);
+  }
   return next;
 }
 
@@ -107,9 +110,8 @@ function transformToolCallText(
     return toolCall;
   }
   const next = { ...toolCall };
-  if (typeof next.name === "string") {
-    next.name = applyPluginTextReplacements(next.name, replacements);
-  }
+  // Only transform arguments, not the tool name — renaming a tool can
+  // break execution by routing to an unknown or unintended tool.
   if (Object.hasOwn(next, "arguments")) {
     next.arguments = transformToolCallArgumentText(next.arguments, replacements);
   }


### PR DESCRIPTION
Closes #97761

## What Problem This Solves

Plugin `textTransforms.output` restored normal assistant text but skipped structured tool-call arguments. A model could therefore return a masked placeholder in a tool call and OpenClaw would execute or deliver that placeholder through Slack, Google Chat, email, or another external tool.

## Why This Change Was Made

The existing provider stream text-transform wrapper is the narrow owner boundary. This change:

- recursively restores string values inside structured `ToolCall.arguments`;
- preserves tool names, ids, numeric values, and other non-text metadata;
- leaves raw provider JSON delta fragments unchanged because replacement tokens can span chunks;
- keeps input transforms at the provider boundary, then applies output transforms after malformed-argument repair and HTML-entity decoding so later wrappers cannot restore masked arguments.

This avoids the broader alternative of adding a new agent-loop finalizer API.

## User Impact

Plugins that mask or rewrite provider-visible text can now rely on restored tool arguments before OpenClaw executes tools. Placeholder tokens should no longer leak into Slack messages, file paths, or other external tool inputs.

## Evidence

Focused tests:

```text
$ node scripts/run-vitest.mjs src/agents/plugin-text-transforms.test.ts src/agents/embedded-agent-runner/run/attempt.tool-call-argument-repair.test.ts
Test Files  2 passed (2)
Tests       32 passed (32)
```

The regression covers a placeholder split across two `toolcall_delta` chunks, reconstructed by the malformed-argument repair wrapper, and restored in the structured end/result arguments.

Documentation and formatting:

```text
$ node scripts/check-docs-mdx.mjs docs/gateway/cli-backends.md
Docs MDX check passed (1 files)

$ node_modules/.bin/oxfmt --check src/agents/plugin-text-transforms.ts src/agents/plugin-text-transforms.test.ts src/agents/embedded-agent-runner/run/attempt.ts src/agents/embedded-agent-runner/run/attempt.tool-call-argument-repair.test.ts docs/gateway/cli-backends.md
All matched files use the correct format.

$ git diff --check origin/main...HEAD
(clean)
```

Fresh repository autoreview after the maintainer repair:

```text
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.95)
```

Contributor live proof used DeepSeek V4 Pro with `"John Smith"` masked to `[MASKED]`; the model returned a masked `read` tool call, the output transform restored `John Smith.txt`, and the file read succeeded.

## Security Impact

- New permissions: no
- Secret handling changes: no
- New network calls: no
