### PR TITLE
fix: parse provider rate-limit reset timestamps for smarter cooldowns

### DIFF
--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -13,8 +13,12 @@ import {
 } from "@openclaw/normalization-core/number-coercion";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
-import { resolveProviderRequestHeaders } from "../provider-request-config.js";
+import {
+  parseRateLimitResetTimestamp,
+  isPeriodicQuotaError,
+} from "../embedded-agent-helpers/rate-limit-reset-parser.js";
 import { readProviderJsonResponse } from "../provider-http-errors.js";
+import { resolveProviderRequestHeaders } from "../provider-request-config.js";
 import { notifyAuthProfileFailureHook, setAuthProfileFailureHook } from "./failure-hook.js";
 import { logAuthProfileFailureStateChange } from "./state-observation.js";
 
@@ -595,6 +599,7 @@ function computeNextProfileUsageStats(params: {
   reason: AuthProfileFailureReason;
   cfgResolved: ResolvedAuthCooldownConfig;
   modelId?: string;
+  rawError?: string;
 }): ProfileUsageStats {
   const windowMs = params.cfgResolved.failureWindowMs;
   const windowExpired =
@@ -643,7 +648,15 @@ function computeNextProfileUsageStats(params: {
     });
     updatedStats.disabledReason = disabledFailureReason;
   } else {
-    const backoffMs = calculateAuthProfileCooldownMs(nextErrorCount);
+    // If the provider included an explicit reset timestamp in the error
+    // message (e.g. "Your limit will reset at 2026-07-02 17:39:49"), use
+    // that instead of exponential backoff. This avoids wasteful retry
+    // cycles when a weekly/monthly quota is exhausted. (#97764)
+    const parsedResetMs = parseRateLimitResetTimestamp(params.rawError, params.now);
+    const backoffMs =
+      parsedResetMs !== null && parsedResetMs > calculateAuthProfileCooldownMs(nextErrorCount)
+        ? parsedResetMs
+        : calculateAuthProfileCooldownMs(nextErrorCount);
     // Keep active cooldown windows immutable so retries within the window
     // cannot push recovery further out.
     updatedStats.cooldownUntil = keepActiveWindowOrRecompute({
@@ -709,8 +722,9 @@ export async function markAuthProfileFailure(params: {
   agentDir?: string;
   runId?: string;
   modelId?: string;
+  rawError?: string;
 }): Promise<void> {
-  const { store, profileId, reason, agentDir, cfg, runId, modelId } = params;
+  const { store, profileId, reason, agentDir, cfg, runId, modelId, rawError } = params;
   const profile = store.profiles[profileId];
   if (!profile || isAuthCooldownBypassedForProvider(profile.provider)) {
     return;
@@ -745,6 +759,7 @@ export async function markAuthProfileFailure(params: {
         reason,
         cfgResolved,
         modelId,
+        rawError,
       });
       nextStats =
         whamResult && shouldProbeWhamForFailure(profileValue.provider, reason)
@@ -802,6 +817,7 @@ export async function markAuthProfileFailure(params: {
     reason,
     cfgResolved,
     modelId,
+    rawError,
   });
   nextStats =
     whamResult && shouldProbeWhamForFailure(store.profiles[profileId]?.provider, reason)

--- a/src/agents/embedded-agent-helpers/rate-limit-reset-parser.test.ts
+++ b/src/agents/embedded-agent-helpers/rate-limit-reset-parser.test.ts
@@ -1,0 +1,78 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import { parseRateLimitResetTimestamp, isPeriodicQuotaError } from "./rate-limit-reset-parser.js";
+
+const NOW = new Date("2026-06-29T12:00:00Z").getTime();
+
+test("parses 'reset at YYYY-MM-DD HH:MM:SS' format (ZAI/ZhipuAI)", () => {
+  const raw = "429 Weekly/Monthly Limit Exhausted. Your limit will reset at 2026-07-02 17:39:49";
+  const result = parseRateLimitResetTimestamp(raw, NOW);
+  assert.notEqual(result, null);
+  assert.ok(result! > 2 * 24 * 60 * 60 * 1000); // > 2 days
+  assert.ok(result! < 4 * 24 * 60 * 60 * 1000); // < 4 days
+});
+
+test("parses ISO 8601 'reset at' format with Z suffix", () => {
+  const raw = "Rate limit exceeded. Resets at 2026-07-02T17:39:49Z";
+  const result = parseRateLimitResetTimestamp(raw, NOW);
+  assert.notEqual(result, null);
+  assert.ok(result! > 2 * 24 * 60 * 60 * 1000);
+});
+
+test("parses 'retry after N seconds' format", () => {
+  const raw = "Rate limited. Retry after 3600 seconds.";
+  const result = parseRateLimitResetTimestamp(raw, NOW);
+  assert.notEqual(result, null);
+  assert.ok(Math.abs(result! - 3600_000) < 1000);
+});
+
+test("parses 'Retry-After: 60' header-style text", () => {
+  const raw = "Retry-After: 120";
+  const result = parseRateLimitResetTimestamp(raw, NOW);
+  assert.notEqual(result, null);
+  assert.ok(Math.abs(result! - 120_000) < 1000);
+});
+
+test("returns null for errors without reset info", () => {
+  assert.equal(parseRateLimitResetTimestamp("Too many requests", NOW), null);
+  assert.equal(parseRateLimitResetTimestamp("429 Service temporarily overloaded", NOW), null);
+  assert.equal(parseRateLimitResetTimestamp("", NOW), null);
+  assert.equal(parseRateLimitResetTimestamp(undefined, NOW), null);
+});
+
+test("returns null for very short durations (< 30s)", () => {
+  const raw = "Retry-After: 10";
+  assert.equal(parseRateLimitResetTimestamp(raw, NOW), null);
+});
+
+test("clamps to 7 days max", () => {
+  const raw = "Your limit will reset at 2027-01-01 00:00:00";
+  const result = parseRateLimitResetTimestamp(raw, NOW);
+  assert.notEqual(result, null);
+  assert.ok(result! <= 7 * 24 * 60 * 60 * 1000);
+});
+
+test("isPeriodicQuotaError detects weekly limits", () => {
+  assert.equal(
+    isPeriodicQuotaError("Weekly/Monthly Limit Exhausted. Your limit will reset at 2026-07-02"),
+    true,
+  );
+  assert.equal(isPeriodicQuotaError("Daily limit reached"), true);
+  assert.equal(isPeriodicQuotaError("Monthly usage limit exceeded"), true);
+  assert.equal(isPeriodicQuotaError("Too many requests"), false);
+  assert.equal(isPeriodicQuotaError("Service temporarily overloaded"), false);
+});
+
+test("handles JSON reset_after_seconds field", () => {
+  const raw = '{"error":{"reset_after_seconds":3600}}';
+  const result = parseRateLimitResetTimestamp(raw, NOW);
+  assert.notEqual(result, null);
+  assert.ok(Math.abs(result! - 3600_000) < 1000);
+});
+
+test("handles JSON reset_at ISO field", () => {
+  const raw = '{"error":{"reset_at":"2026-07-02T17:39:49Z"}}';
+  const result = parseRateLimitResetTimestamp(raw, NOW);
+  assert.notEqual(result, null);
+  assert.ok(result! > 2 * 24 * 60 * 60 * 1000);
+});

--- a/src/agents/embedded-agent-helpers/rate-limit-reset-parser.ts
+++ b/src/agents/embedded-agent-helpers/rate-limit-reset-parser.ts
@@ -1,0 +1,149 @@
+/**
+ * Parser for provider rate-limit reset timestamps.
+ *
+ * When a provider returns a rate-limit error containing an explicit reset
+ * timestamp (e.g. "Your limit will reset at 2026-07-02 17:39:49"), this
+ * module extracts that timestamp so the cooldown system can use it instead
+ * of generic exponential backoff.
+ *
+ * See: https://github.com/openclaw/openclaw/issues/97764
+ */
+
+/** Max cooldown we'll set from a parsed reset timestamp (7 days). */
+const MAX_RESET_COOLDOWN_MS = 7 * 24 * 60 * 60 * 1000;
+/** Minimum cooldown for a parsed reset to be meaningful (30s). Below this, backoff is better. */
+const MIN_RESET_COOLDOWN_MS = 30_000;
+
+/**
+ * Regex patterns for extracting reset timestamps from provider error messages.
+ * Matches common formats across ZAI/ZhipuAI, OpenAI, Anthropic, and others.
+ */
+// "reset at YYYY-MM-DD HH:MM:SS" or "resets at YYYY-MM-DD HH:MM:SS"
+// "reset at YYYY-MM-DDTHH:MM:SSZ" (ISO 8601)
+const RESET_AT_DATETIME_RE =
+  /(?:reset(?:s)?(?:\s+will)?\s+(?:at|on)|expires?\s+(?:at|on))\s+(\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?)/i;
+
+// "Retry-After: N" or "retry after N seconds"
+const RETRY_AFTER_SECONDS_RE =
+  /(?:retry[ -]after(?:\s+seconds?)?\s*[:=]?\s*)(\d{1,8})\s*(?:seconds?|s)?\b/i;
+
+// "reset_after_seconds": N (JSON field)
+const RESET_AFTER_SECONDS_JSON_RE = /["']?reset_after_seconds["']?\s*[:=]\s*(\d{1,8})/i;
+
+// "reset_at": "YYYY-MM-DDTHH:MM:SSZ" (JSON field)
+const RESET_AT_JSON_RE =
+  /["']?reset_at["']?\s*[:=]\s*["'](\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?)["']/i;
+
+/**
+ * Detects whether an error message indicates a periodic (daily/weekly/monthly)
+ * quota exhaustion rather than a transient rate limit.
+ *
+ * Periodic quota errors typically include an explicit reset timestamp and
+ * should be treated differently from transient server overload.
+ */
+export function isPeriodicQuotaError(rawMessage: string | undefined): boolean {
+  if (!rawMessage) {
+    return false;
+  }
+  return /\b(?:daily|weekly|monthly)(?:\/(?:daily|weekly|monthly))*\s+(?:usage\s+)?limit(?:s)?(?:\s+(?:exhausted|reached|exceeded))?\b/i.test(
+    rawMessage,
+  );
+}
+
+/**
+ * Parse a reset timestamp from a provider rate-limit error message.
+ *
+ * Returns the cooldown duration in milliseconds (relative to `now`), or `null`
+ * if no reset timestamp could be parsed.
+ *
+ * The returned duration is clamped to [MIN_RESET_COOLDOWN_MS, MAX_RESET_COOLDOWN_MS].
+ * Durations below MIN_RESET_COOLDOWN_MS are treated as noise — exponential
+ * backoff is more appropriate for short windows.
+ *
+ * @param rawMessage - The raw error text from the provider response
+ * @param now - Current timestamp (ms epoch). Defaults to Date.now()
+ */
+export function parseRateLimitResetTimestamp(
+  rawMessage: string | undefined | null,
+  now: number = Date.now(),
+): number | null {
+  if (!rawMessage || typeof rawMessage !== "string") {
+    return null;
+  }
+
+  // Try datetime patterns first (most precise)
+  const cooldownMs = tryParseDatetime(rawMessage, now) ?? tryParseSeconds(rawMessage, now);
+  if (cooldownMs === null) {
+    return null;
+  }
+
+  // Clamp to reasonable bounds
+  if (cooldownMs < MIN_RESET_COOLDOWN_MS) {
+    return null;
+  }
+  return Math.min(cooldownMs, MAX_RESET_COOLDOWN_MS);
+}
+
+function tryParseDatetime(raw: string, now: number): number | null {
+  // Try "reset(s) at YYYY-MM-DD..." format
+  const match1 = raw.match(RESET_AT_DATETIME_RE);
+  if (match1) {
+    const parsed = parseTimestamp(match1[1]);
+    if (parsed !== null) {
+      return Math.max(0, parsed - now);
+    }
+  }
+
+  // Try JSON "reset_at" field
+  const match2 = raw.match(RESET_AT_JSON_RE);
+  if (match2) {
+    const parsed = parseTimestamp(match2[1]);
+    if (parsed !== null) {
+      return Math.max(0, parsed - now);
+    }
+  }
+
+  return null;
+}
+
+function tryParseSeconds(raw: string, now: number): number | null {
+  // Try "Retry-After: N" / "retry after N seconds"
+  const match1 = raw.match(RETRY_AFTER_SECONDS_RE);
+  if (match1) {
+    const seconds = parseInt(match1[1], 10);
+    if (Number.isFinite(seconds) && seconds > 0) {
+      return seconds * 1000;
+    }
+  }
+
+  // Try JSON "reset_after_seconds" field
+  const match2 = raw.match(RESET_AFTER_SECONDS_JSON_RE);
+  if (match2) {
+    const seconds = parseInt(match2[1], 10);
+    if (Number.isFinite(seconds) && seconds > 0) {
+      return seconds * 1000;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Parse a timestamp string into epoch milliseconds.
+ * Handles both "YYYY-MM-DD HH:MM:SS" (space separator) and ISO 8601 formats.
+ */
+function parseTimestamp(value: string): number | null {
+  // Normalize space separator to "T" for ISO parsing
+  const normalized = value.includes("T") ? value : value.replace(" ", "T");
+
+  // If no timezone suffix, assume the provider's local time matches the runtime timezone.
+  // This is imperfect but covers the common case where the server and client share a TZ.
+  const hasTz = /(?:Z|[+-]\d{2}:?\d{2})$/.test(normalized);
+
+  const date = new Date(hasTz ? normalized : normalized + "Z");
+  const ms = date.getTime();
+  if (!Number.isFinite(ms)) {
+    return null;
+  }
+  return ms;
+}

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -1716,6 +1716,7 @@ async function runEmbeddedAgentInternal(
         config?: RunEmbeddedAgentParams["config"];
         agentDir?: RunEmbeddedAgentParams["agentDir"];
         modelId?: string;
+        rawError?: string;
       }) => {
         const { profileId, reason } = failure;
         if (!profileId || !reason) {
@@ -1734,6 +1735,7 @@ async function runEmbeddedAgentInternal(
           agentDir,
           runId: params.runId,
           modelId: failure.modelId,
+          rawError: failure.rawError,
         });
       };
       const markAuthProfileSuccessAfterRun = () => {
@@ -3210,6 +3212,7 @@ async function runEmbeddedAgentInternal(
                   profileId: failedPromptProfileId,
                   reason: promptProfileFailureReason,
                   modelId,
+                  rawError: errorText,
                 }).catch((err: unknown) => {
                   log.warn(`prompt profile failure mark failed: ${String(err)}`);
                 });
@@ -3248,6 +3251,7 @@ async function runEmbeddedAgentInternal(
                   profileId: failedPromptProfileId,
                   reason: promptProfileFailureReason,
                   modelId,
+                  rawError: errorText,
                 });
               } catch (err) {
                 log.warn(`prompt profile failure mark failed: ${String(err)}`);
@@ -3919,6 +3923,7 @@ async function runEmbeddedAgentInternal(
                 profileId: lastProfileId,
                 reason: assistantProfileFailureReason,
                 modelId,
+                rawError: assistantForFailover?.errorMessage,
               });
             }
             return {
@@ -4007,6 +4012,7 @@ async function runEmbeddedAgentInternal(
                 profileId: lastProfileId,
                 reason: assistantProfileFailureReason,
                 modelId,
+                rawError: assistantForFailover?.errorMessage,
               });
             }
 


### PR DESCRIPTION
# Fix: Parse provider rate-limit reset timestamps for smarter cooldowns

## Summary

When a provider returns a rate-limit error containing an explicit reset
timestamp (e.g. `"Weekly/Monthly Limit Exhausted. Your limit will reset at
2026-07-02 17:39:49"`), OpenClaw now parses that timestamp and sets the
auth-profile cooldown to the exact reset time instead of using generic
exponential backoff (30s → 60s → 5min cap).

This eliminates wasteful retry cycles where a weekly-quota-exhausted key is
probed every few minutes for 3+ days, each probe wasting an API call and
adding latency before falling back to the next profile or model.

Fixes #97764.

## Problem

With two ZAI API keys configured via `auth.order.zai`, when the primary key
hits a weekly/monthly quota limit:

1. Primary key → 429 `"Your limit will reset at 2026-07-02 17:39:49"`
2. OpenClaw gives it a 30-second cooldown (exponential backoff step 1)
3. After 30s, primary is probed again → same 429 → 60s cooldown
4. After 60s, probed again → same 429 → 5min cooldown
5. Repeat every 5 minutes for 3 days until the quota actually resets

Each probe wastes an API call, adds ~3-5s latency, and triggers an
unnecessary profile rotation on every turn.

## Solution

### New module: `rate-limit-reset-parser.ts`

A pure parser that extracts reset timestamps from provider error messages
in these formats:

- `reset(s) at YYYY-MM-DD HH:MM:SS` (ZAI/ZhipuAI)
- `reset(s) at YYYY-MM-DDTHH:MM:SSZ` (ISO 8601)
- `Retry-After: N` / `retry after N seconds`
- JSON fields: `reset_at`, `reset_after_seconds`

The returned duration (ms relative to now) is clamped to
`[30s, 7 days]`. Durations below 30s are ignored — exponential backoff
is more appropriate for short windows.

### `usage.ts` — `computeNextProfileUsageStats`

When `rawError` is provided and a reset timestamp is parsed, the cooldown
is set to `max(parsed_reset, exponential_backoff)`. This ensures we never
shorten a backoff window, only extend it when the provider tells us the
exact reset time.

### `run.ts` — Propagate `rawError`

The `maybeMarkAuthProfileFailure` helper now accepts and forwards
`rawError` (the provider error text) to `markAuthProfileFailure`. This
is wired up at all four call sites where profile failures are recorded.

## Testing

10 unit tests covering:
- ZAI/ZhipuAI datetime format
- ISO 8601 with timezone
- `Retry-After: N` header-style
- JSON `reset_after_seconds` and `reset_at` fields
- Negative cases (no reset info, empty input, short durations)
- 7-day max clamp
- `isPeriodicQuotaError` classifier

All tests pass:
```
ℹ tests 10
ℹ pass 10
ℹ fail 0
```

## Limitations / Future work

- The parser treats datetimes without an explicit timezone as UTC. This is
  imperfect if the provider's server timezone differs, but covers the common
  case where the API returns UTC or the server/client share a timezone.
- `rateLimitedProfileRotations` is still error-class-unaware. A future
  enhancement could give transient overload errors more rotations than
  quota-exhaustion errors. This PR focuses on the cooldown-duration fix,
  which provides the most immediate value.
