### PR TITLE
fix(embedded-agent): acquire compaction session lock reentrantly

### DIFF
--- a/src/agents/embedded-agent-runner/compact.hooks.harness.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.harness.ts
@@ -99,6 +99,9 @@ function createDefaultSessionMessages(): unknown[] {
 }
 export const sessionMessages: unknown[] = createDefaultSessionMessages();
 export const sessionAbortCompactionMock: Mock<(reason?: unknown) => void> = vi.fn();
+export const acquireSessionWriteLockMock: Mock<
+  (params?: unknown) => Promise<{ release: () => Promise<void> }>
+> = vi.fn(async () => ({ release: vi.fn(async () => {}) }));
 function createMockCompactionSession() {
   const session = {
     sessionId: "session-1",
@@ -355,6 +358,8 @@ export function resetCompactSessionStateMocks(): void {
 
 export function resetCompactHooksHarnessMocks(): void {
   clearAgentHarnesses();
+  acquireSessionWriteLockMock.mockReset();
+  acquireSessionWriteLockMock.mockResolvedValue({ release: vi.fn(async () => {}) });
   hookRunner.hasHooks.mockReset();
   hookRunner.hasHooks.mockReturnValue(false);
   hookRunner.runBeforeCompaction.mockReset();
@@ -560,7 +565,7 @@ export async function loadCompactHooksHarness(): Promise<{
   }));
 
   vi.doMock("../session-write-lock.js", () => ({
-    acquireSessionWriteLock: vi.fn(async () => ({ release: vi.fn(async () => {}) })),
+    acquireSessionWriteLock: acquireSessionWriteLockMock,
     resolveSessionLockMaxHoldFromTimeout: vi.fn(() => 0),
     resolveSessionWriteLockAcquireTimeoutMs: vi.fn(() => 60_000),
     resolveSessionWriteLockOptions: vi.fn(() => ({

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -4,6 +4,7 @@ import { beforeAll, beforeEach, describe, expect, it, vi, type Mock } from "vite
 import {
   applyExtraParamsToAgentMock,
   applyAgentCompactionSettingsFromConfigMock,
+  acquireSessionWriteLockMock,
   buildEmbeddedSystemPromptMock,
   contextEngineCompactMock,
   createAgentSessionMock,
@@ -210,6 +211,22 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       details: { ok: true },
     });
     resetCompactSessionStateMocks();
+  });
+
+  it("acquires the session write lock reentrantly so overflow recovery does not self-deadlock", async () => {
+    // Regression for #97747: the embedded attempt already holds the session
+    // write lock when overflow recovery calls compactEmbeddedAgentSessionDirect.
+    // The nested acquire must pass allowReentrant:true so the lock manager
+    // bumps the refcount instead of blocking for the full 60s timeout.
+    await compactEmbeddedAgentSessionDirect({
+      sessionId: "session-1",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp/workspace",
+    });
+
+    expect(acquireSessionWriteLockMock).toHaveBeenCalledWith(
+      expect.objectContaining({ allowReentrant: true }),
+    );
   });
 
   it("bootstraps runtime plugins with the resolved workspace", async () => {

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -1185,6 +1185,15 @@ async function compactEmbeddedAgentSessionDirectOnce(
           timeoutMs: compactionTimeoutMs,
         }),
       }),
+      // Compaction runs inside the embedded attempt, which already holds the
+      // session write lock via createEmbeddedAttemptSessionLockController.
+      // Without reentrancy, the nested acquire blocks for the full timeout
+      // and then fails — extending overflow recovery across every fallback
+      // model and rejecting concurrent webchat messages with "session file
+      // locked". Match the reentrancy already used by transcript-append /
+      // session-accessor writes so the in-process nested acquire bumps the
+      // refcount instead. (#97747)
+      allowReentrant: true,
     });
     try {
       await repairSessionFileIfNeeded({


### PR DESCRIPTION
## What Problem This Solves

Fixes #97747.

When an embedded agent attempt triggers overflow-recovery auto-compaction, the compaction path re-acquires the same session's write lock inside the same process. `acquireSessionWriteLock` defaults `allowReentrant` to `false`, so the nested acquire blocks for 60s and then fails with `SessionWriteLockTimeoutError: pid=<self> alive=true`. Each model in the fallback chain repeats the same 180s timeout, producing an ~18-minute recovery window during which every new webchat message surfaces as `Embedded agent failed before reply: session file locked`. The overflow path's own compactions all fail — only a manual `/compact` ends the cycle.

## Why This Change Was Made

`createEmbeddedAttemptSessionLockController` (in `run/attempt.session-lock.ts:1158-1164`) acquires the session write lock at attempt start and holds it for the run's lifetime. The overflow recovery path in `run.ts:2707` invokes `compactContextEngineWithSafetyTimeout` → `compactEmbeddedAgentSessionDirect` → `compactEmbeddedAgentSessionDirectOnce` → `acquireSessionWriteLock` at `compact.ts:1180`, which did not pass `allowReentrant`. The underlying `@openclaw/fs-safe` lock manager supports in-process reentrancy when `allowReentrant: true` is passed (incrementing the refcount), and two sibling writers (`config/sessions/transcript-append.ts:619` and `config/sessions/session-accessor.ts:2327`) already use this exact pattern. The compaction path was simply missing the same flag.

## User Impact

- Long-running webchat sessions that hit context overflow on the primary model recover in seconds instead of stalling for ~18 minutes per overflow event.
- Concurrent messages during overflow recovery are processed normally instead of being rejected with `Embedded agent failed before reply: session file locked`.
- Affected deployments: anyone using a primary + fallback model chain where the primary drives the session into overflow (the repro uses `minimax/MiniMax-M3` with M2.7, GLM-5.1, Kimi-K2.5, Gemini-3.1 as fallbacks).

## Evidence

- Local tests: `node scripts/run-vitest.mjs run src/agents/embedded-agent-runner/compact.hooks.test.ts` → 70 passed (70), including the new `acquires the session write lock reentrantly so overflow recovery does not self-deadlock` regression.
- Local tests: `node scripts/run-vitest.mjs run src/agents/session-write-lock.test.ts` → 53 passed (53) — reentrancy contract for the underlying lock still holds.
- Typecheck: `pnpm check:test-types` (covers core + extensions test configs).
- Lint: `node scripts/run-oxlint.mjs` on the three touched files.
- Source proof: `acquireSessionWriteLock` at `src/agents/session-write-lock.ts:895` reads `params.allowReentrant ?? false`; the manager honors the flag (`allowReentrant` branch in `node_modules/@openclaw/fs-safe/dist/sidecar-lock.js:204` increments `held.count`). Sibling reentrant writers at `src/config/sessions/transcript-append.ts:619` and `src/config/sessions/session-accessor.ts:2327` confirm the pattern.
