### PR TITLE
fix: handle JSON-labeled OpenAI SSE streams

### DIFF
--- a/src/agents/provider-transport-fetch.test.ts
+++ b/src/agents/provider-transport-fetch.test.ts
@@ -1193,6 +1193,38 @@ describe("buildGuardedModelFetch", () => {
     expect(items).toEqual([{ ok: true }]);
   });
 
+  it("passes through SSE bodies mislabeled as JSON for streaming OpenAI SDK requests", async () => {
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response('data: {"ok": true}\n\ndata: [DONE]\n\n', {
+        headers: { "content-type": "application/json; charset=utf-8" },
+      }),
+      finalUrl: "https://api.openai.com/v1/chat/completions",
+      release: vi.fn(async () => undefined),
+    });
+    const model = {
+      id: "moonshotai/kimi-k2.6",
+      provider: "openrouter",
+      api: "openai-completions",
+      baseUrl: "https://openrouter.ai/api/v1",
+    } as unknown as Model<"openai-completions">;
+
+    const response = await buildGuardedModelFetch(model)(
+      "https://openrouter.ai/api/v1/chat/completions",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ model: "moonshotai/kimi-k2.6", stream: true }),
+      },
+    );
+    const items = [];
+    for await (const item of Stream.fromSSEResponse(response, new AbortController())) {
+      items.push(item);
+    }
+
+    expect(response.headers.get("content-type")).toContain("text/event-stream");
+    expect(items).toEqual([{ ok: true }]);
+  });
+
   it("does not clone Request bodies while checking for streaming JSON fallbacks", async () => {
     const cloneSpy = vi.spyOn(Request.prototype, "clone");
     fetchWithSsrFGuardMock.mockResolvedValue({

--- a/src/agents/provider-transport-fetch.test.ts
+++ b/src/agents/provider-transport-fetch.test.ts
@@ -1225,6 +1225,36 @@ describe("buildGuardedModelFetch", () => {
     expect(items).toEqual([{ ok: true }]);
   });
 
+  it("does not apply the JSON synthesis byte cap after recognizing mislabeled SSE", async () => {
+    const oversizedSse = `data: {"ok": true}\n\n: ${"x".repeat(16 * 1024 * 1024 + 1)}\n\ndata: [DONE]\n\n`;
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response(oversizedSse, {
+        headers: { "content-type": "application/json; charset=utf-8" },
+      }),
+      finalUrl: "https://api.openai.com/v1/chat/completions",
+      release: vi.fn(async () => undefined),
+    });
+    const model = {
+      id: "moonshotai/kimi-k2.6",
+      provider: "openrouter",
+      api: "openai-completions",
+      baseUrl: "https://openrouter.ai/api/v1",
+    } as unknown as Model<"openai-completions">;
+
+    const response = await buildGuardedModelFetch(model)(
+      "https://openrouter.ai/api/v1/chat/completions",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ model: "moonshotai/kimi-k2.6", stream: true }),
+      },
+    );
+
+    const body = await response.text();
+
+    expect(body).toBe(oversizedSse);
+  });
+
   it("does not clone Request bodies while checking for streaming JSON fallbacks", async () => {
     const cloneSpy = vi.spyOn(Request.prototype, "clone");
     fetchWithSsrFGuardMock.mockResolvedValue({

--- a/src/agents/provider-transport-fetch.test.ts
+++ b/src/agents/provider-transport-fetch.test.ts
@@ -1195,7 +1195,7 @@ describe("buildGuardedModelFetch", () => {
 
   it("passes through SSE bodies mislabeled as JSON for streaming OpenAI SDK requests", async () => {
     fetchWithSsrFGuardMock.mockResolvedValue({
-      response: new Response('data: {"ok": true}\n\ndata: [DONE]\n\n', {
+      response: new Response('event: response.created\n\ndata: {"ok": true}\n\ndata: [DONE]\n\n', {
         headers: { "content-type": "application/json; charset=utf-8" },
       }),
       finalUrl: "https://api.openai.com/v1/chat/completions",
@@ -1226,7 +1226,7 @@ describe("buildGuardedModelFetch", () => {
   });
 
   it("does not apply the JSON synthesis byte cap after recognizing mislabeled SSE", async () => {
-    const oversizedSse = `data: {"ok": true}\n\n: ${"x".repeat(16 * 1024 * 1024 + 1)}\n\ndata: [DONE]\n\n`;
+    const oversizedSse = `data: {"padding":"${"x".repeat(16 * 1024 * 1024 + 1)}"}\n\ndata: [DONE]\n\n`;
     fetchWithSsrFGuardMock.mockResolvedValue({
       response: new Response(oversizedSse, {
         headers: { "content-type": "application/json; charset=utf-8" },

--- a/src/agents/provider-transport-fetch.ts
+++ b/src/agents/provider-transport-fetch.ts
@@ -50,6 +50,7 @@ const log = createSubsystemLogger("provider-transport-fetch");
  *  when a hostile streaming endpoint returns a never-ending JSON response
  *  without Content-Length. */
 const SSE_SYNTHESIZE_JSON_MAX_BYTES = 16 * 1024 * 1024;
+const JSON_LABELED_STREAM_KIND_SNIFF_CHARS = 256;
 
 /** Max bytes for the internal SSE sanitization buffer between event boundaries.
  *  A response that cannot find a \n\n boundary within this many characters is
@@ -197,20 +198,30 @@ function sanitizeOpenAISdkSseResponse(
               controller.enqueue(encoder.encode(text));
               return;
             }
-            buffer += text;
-            bodyKind = bodyKind ?? classifyJsonLabeledStreamingBody(buffer);
-            if (bodyKind === "sse") {
-              controller.enqueue(encoder.encode(buffer));
-              buffer = "";
-              return;
+            if (!bodyKind) {
+              const remainingSniffChars = Math.max(
+                0,
+                JSON_LABELED_STREAM_KIND_SNIFF_CHARS - buffer.length,
+              );
+              const classificationBuffer = `${buffer}${text.slice(0, remainingSniffChars)}`;
+              bodyKind = classifyJsonLabeledStreamingBody(classificationBuffer);
             }
             const nextTotalBytes = totalBytes + chunk.value.byteLength;
-            if (nextTotalBytes > SSE_SYNTHESIZE_JSON_MAX_BYTES) {
+            if (bodyKind !== "sse" && nextTotalBytes > SSE_SYNTHESIZE_JSON_MAX_BYTES) {
               throw new Error(
                 `Streaming JSON body exceeded ${SSE_SYNTHESIZE_JSON_MAX_BYTES} bytes while synthesizing SSE frames`,
               );
             }
+            if (bodyKind === "sse") {
+              if (buffer) {
+                controller.enqueue(encoder.encode(buffer));
+              }
+              controller.enqueue(encoder.encode(text));
+              buffer = "";
+              return;
+            }
             totalBytes = nextTotalBytes;
+            buffer += text;
           }
         } catch (error) {
           await reader?.cancel(error).catch(() => {});
@@ -223,11 +234,13 @@ function sanitizeOpenAISdkSseResponse(
     });
     const headers = new Headers(response.headers);
     headers.set("content-type", "text/event-stream; charset=utf-8");
-    return new Response(sseBody, {
-      status: response.status,
-      statusText: response.statusText,
-      headers,
-    });
+    return sanitizeOpenAISdkSseResponse(
+      new Response(sseBody, {
+        status: response.status,
+        statusText: response.statusText,
+        headers,
+      }),
+    );
   }
   if (!/\btext\/event-stream\b/i.test(contentType)) {
     return response;

--- a/src/agents/provider-transport-fetch.ts
+++ b/src/agents/provider-transport-fetch.ts
@@ -123,6 +123,25 @@ function capNonOkResponseBodyLazily(response: Response, maxBytes: number): Respo
   return new Response(capped, response);
 }
 
+function classifyJsonLabeledStreamingBody(buffer: string): "json" | "sse" | undefined {
+  const text = buffer.replace(/^\uFEFF/, "").trimStart();
+  if (!text) {
+    return undefined;
+  }
+  if (/^(?::|data:|event:|id:|retry:)/.test(text)) {
+    return "sse";
+  }
+  const first = text[0];
+  if (first && '{["-0123456789tfn'.includes(first)) {
+    return "json";
+  }
+  const firstLine = text.match(/^[^\r\n]*/)?.[0] ?? "";
+  if (["data", "event", "id", "retry"].some((field) => field.startsWith(firstLine))) {
+    return undefined;
+  }
+  return "json";
+}
+
 function sanitizeOpenAISdkSseResponse(
   response: Response,
   options?: { synthesizeJsonAsSse?: boolean },
@@ -144,6 +163,7 @@ function sanitizeOpenAISdkSseResponse(
     let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
     let buffer = "";
     let totalBytes = 0;
+    let bodyKind: "json" | "sse" | undefined;
     const sseBody = new ReadableStream<Uint8Array>({
       start() {
         reader = source.getReader();
@@ -154,6 +174,16 @@ function sanitizeOpenAISdkSseResponse(
             const chunk = await reader?.read();
             if (!chunk || chunk.done) {
               buffer += decoder.decode();
+              if (!bodyKind) {
+                bodyKind = classifyJsonLabeledStreamingBody(buffer) ?? "json";
+              }
+              if (bodyKind === "sse") {
+                if (buffer) {
+                  controller.enqueue(encoder.encode(buffer));
+                }
+                controller.close();
+                return;
+              }
               const data = buffer.trim();
               if (data) {
                 controller.enqueue(encoder.encode(`data: ${data}\n\n`));
@@ -169,7 +199,18 @@ function sanitizeOpenAISdkSseResponse(
               );
             }
             totalBytes = nextTotalBytes;
-            buffer += decoder.decode(chunk.value, { stream: true });
+            const text = decoder.decode(chunk.value, { stream: true });
+            if (bodyKind === "sse") {
+              controller.enqueue(encoder.encode(text));
+              return;
+            }
+            buffer += text;
+            bodyKind = bodyKind ?? classifyJsonLabeledStreamingBody(buffer);
+            if (bodyKind === "sse") {
+              controller.enqueue(encoder.encode(buffer));
+              buffer = "";
+              return;
+            }
           }
         } catch (error) {
           await reader?.cancel(error).catch(() => {});

--- a/src/agents/provider-transport-fetch.ts
+++ b/src/agents/provider-transport-fetch.ts
@@ -192,13 +192,6 @@ function sanitizeOpenAISdkSseResponse(
               controller.close();
               return;
             }
-            const nextTotalBytes = totalBytes + chunk.value.byteLength;
-            if (nextTotalBytes > SSE_SYNTHESIZE_JSON_MAX_BYTES) {
-              throw new Error(
-                `Streaming JSON body exceeded ${SSE_SYNTHESIZE_JSON_MAX_BYTES} bytes while synthesizing SSE frames`,
-              );
-            }
-            totalBytes = nextTotalBytes;
             const text = decoder.decode(chunk.value, { stream: true });
             if (bodyKind === "sse") {
               controller.enqueue(encoder.encode(text));
@@ -211,6 +204,13 @@ function sanitizeOpenAISdkSseResponse(
               buffer = "";
               return;
             }
+            const nextTotalBytes = totalBytes + chunk.value.byteLength;
+            if (nextTotalBytes > SSE_SYNTHESIZE_JSON_MAX_BYTES) {
+              throw new Error(
+                `Streaming JSON body exceeded ${SSE_SYNTHESIZE_JSON_MAX_BYTES} bytes while synthesizing SSE frames`,
+              );
+            }
+            totalBytes = nextTotalBytes;
           }
         } catch (error) {
           await reader?.cancel(error).catch(() => {});


### PR DESCRIPTION
Closes #96497

## What Problem This Solves

Fixes an issue where OpenAI-compatible streaming endpoints could fail before producing a reply when they returned valid SSE frames with an `application/json` content type. The OpenAI SDK strips one `data:` field before `JSON.parse`; OpenClaw was wrapping already-SSE text into another `data:` frame, producing `data: data: {...}` and a JSON parse error.

## Why This Change Was Made

The guarded OpenAI SDK transport now classifies JSON-labeled streaming bodies before synthesis. True JSON bodies still get converted into SSE frames, while JSON-labeled SSE bodies are routed through the existing SSE sanitizer instead of being wrapped or passed through raw.

This keeps the existing event-only frame filtering and unterminated-event cap for SSE, preserves the JSON synthesis byte cap for actual JSON bodies, and avoids adding a new config option for a provider response-shape bug.

## User Impact

Users of custom or self-hosted OpenAI-compatible gateways can stream through `openai-completions` even when the gateway incorrectly labels SSE as JSON. The normal JSON fallback still works for gateways that really return a JSON body to a streaming SDK request.

## Evidence

Dependency contract checked locally against `openai@6.39.1`: `node_modules/openai/src/core/streaming.ts` parses `sse.data` with `JSON.parse` after the SDK `SSEDecoder` strips exactly one `data:` prefix.

Focused validation:

- `node scripts/run-vitest.mjs src/agents/provider-transport-fetch.test.ts -- --reporter=dot` — 80 tests passed.
- `pnpm exec oxfmt --check src/agents/provider-transport-fetch.ts src/agents/provider-transport-fetch.test.ts` — passed.
- `git diff --check` — passed.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --codex-bin .artifacts/codex-flex` — clean, no accepted/actionable findings.
