### PR TITLE
fix(boundary-safety): guard response reads and UTF-16 truncation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1529,6 +1529,8 @@
     "changed:lanes": "node scripts/changed-lanes.mjs",
     "check": "node scripts/check.mjs",
     "check:architecture": "pnpm check:import-cycles && pnpm check:madge-import-cycles && pnpm check:deprecated-api-usage && pnpm check:deprecated-jsdoc && pnpm db:kysely:check && pnpm lint:kysely && pnpm check:database-first-legacy-stores",
+    "check:boundary-safety": "node scripts/check-boundary-safety.mjs",
+    "check:boundary-safety:all": "node scripts/check-boundary-safety.mjs --all",
     "check:base-config-schema": "node --import tsx scripts/generate-base-config-schema.ts --check",
     "check:bundled-channel-config-metadata": "node --import tsx scripts/generate-bundled-channel-config-metadata.ts --check",
     "check:changed": "node scripts/check-changed.mjs",

--- a/scripts/check-boundary-safety.mjs
+++ b/scripts/check-boundary-safety.mjs
@@ -255,11 +255,19 @@ function isLikelyResponseBodyRead(sourceFile, call) {
 
 function hasBoundarySafetyIgnore(sourceFile, node, ruleId) {
   const sourceText = sourceFile.getFullText();
+  const hasIgnoreText = (text) =>
+    text.includes(`boundary-safety-ignore ${ruleId}:`) && /:\s*\S/.test(text);
   const comments = ts.getLeadingCommentRanges(sourceText, node.getFullStart()) ?? [];
-  return comments.some((comment) => {
-    const text = sourceText.slice(comment.pos, comment.end);
-    return text.includes(`boundary-safety-ignore ${ruleId}:`) && /:\s*\S/.test(text);
-  });
+  if (comments.some((comment) => hasIgnoreText(sourceText.slice(comment.pos, comment.end)))) {
+    return true;
+  }
+
+  let current = node;
+  while (current.parent && !ts.isStatement(current)) {
+    current = current.parent;
+  }
+  const statementPrefix = sourceText.slice(current.getFullStart(), node.getStart(sourceFile));
+  return hasIgnoreText(statementPrefix);
 }
 
 export function findBoundarySafetyViolations(content, fileName = "source.ts") {

--- a/scripts/check-boundary-safety.mjs
+++ b/scripts/check-boundary-safety.mjs
@@ -482,9 +482,18 @@ export async function main(
   io = { stdout: process.stdout, stderr: process.stderr },
 ) {
   const args = parseArgs(argv);
-  const actual = await collectBoundarySafetyInventory({ all: args.all });
-
   const statusStream = args.json ? io.stderr : io.stdout;
+  if (args.updateBaseline && !args.all) {
+    io.stderr.write(
+      "`--update-baseline` requires `--all` so the baseline is rebuilt from the full boundary inventory.\n",
+    );
+    io.stderr.write(
+      "Run `node scripts/check-boundary-safety.mjs --all --update-baseline` only after intentional migrations.\n",
+    );
+    return 1;
+  }
+
+  const actual = await collectBoundarySafetyInventory({ all: args.all });
   if (args.json) {
     io.stdout.write(`${JSON.stringify(actual, null, 2)}\n`);
   }

--- a/scripts/check-boundary-safety.mjs
+++ b/scripts/check-boundary-safety.mjs
@@ -476,13 +476,14 @@ export async function main(
   const args = parseArgs(argv);
   const actual = await collectBoundarySafetyInventory({ all: args.all });
 
+  const statusStream = args.json ? io.stderr : io.stdout;
   if (args.json) {
     io.stdout.write(`${JSON.stringify(actual, null, 2)}\n`);
   }
 
   if (args.updateBaseline) {
     await fs.writeFile(baselinePath, `${JSON.stringify(actual, null, 2)}\n`);
-    io.stdout.write(
+    statusStream.write(
       `Updated ${path.relative(repoRoot, baselinePath)} with ${actual.length} entries.\n`,
     );
     return 0;
@@ -493,7 +494,7 @@ export async function main(
 
   if (args.all) {
     if (diff.unexpected.length === 0 && diff.missing.length === 0) {
-      io.stdout.write(`Boundary safety baseline matches (${actual.length} entries).\n`);
+      statusStream.write(`Boundary safety baseline matches (${actual.length} entries).\n`);
       return 0;
     }
     io.stderr.write("Boundary safety baseline mismatch.\n");
@@ -506,7 +507,7 @@ export async function main(
   }
 
   if (diff.unexpected.length === 0) {
-    io.stdout.write(
+    statusStream.write(
       `Boundary safety changed-file check passed (${actual.length} changed-file entries, all baseline-known).\n`,
     );
     return 0;

--- a/scripts/check-boundary-safety.mjs
+++ b/scripts/check-boundary-safety.mjs
@@ -319,16 +319,38 @@ export function isBoundarySafetyCandidateFile(filePath) {
   return /^(?:src\/|extensions\/|packages\/)/.test(normalized);
 }
 
-function entryKey(entry) {
-  return `${entry.ruleId}:${normalizePath(entry.file)}:${entry.line}:${entry.match}`;
+function entryIdentity(entry) {
+  return `${entry.ruleId}:${normalizePath(entry.file)}:${entry.match}`;
+}
+
+function countEntriesByIdentity(entries) {
+  const counts = new Map();
+  for (const entry of entries) {
+    const key = entryIdentity(entry);
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  return counts;
+}
+
+function collectEntriesNotCoveredByCounts(entries, counts) {
+  const remaining = new Map(counts);
+  const uncovered = [];
+  for (const entry of entries) {
+    const key = entryIdentity(entry);
+    const count = remaining.get(key) ?? 0;
+    if (count > 0) {
+      remaining.set(key, count - 1);
+    } else {
+      uncovered.push(entry);
+    }
+  }
+  return uncovered;
 }
 
 export function diffBoundaryInventory(expected, actual) {
-  const expectedKeys = new Set(expected.map(entryKey));
-  const actualKeys = new Set(actual.map(entryKey));
   return {
-    missing: expected.filter((entry) => !actualKeys.has(entryKey(entry))),
-    unexpected: actual.filter((entry) => !expectedKeys.has(entryKey(entry))),
+    missing: collectEntriesNotCoveredByCounts(expected, countEntriesByIdentity(actual)),
+    unexpected: collectEntriesNotCoveredByCounts(actual, countEntriesByIdentity(expected)),
   };
 }
 

--- a/scripts/check-boundary-safety.mjs
+++ b/scripts/check-boundary-safety.mjs
@@ -18,7 +18,7 @@ const repoRoot = resolveRepoRoot(import.meta.url);
 const baselinePath = path.join(repoRoot, "test", "fixtures", "boundary-safety-inventory.json");
 const sourceRoots = resolveSourceRoots(repoRoot, ["src", "extensions", "packages"]);
 
-const responseReadMethods = new Set(["json", "text", "arrayBuffer"]);
+const responseReadMethods = new Set(["json", "text", "arrayBuffer", "blob", "formData"]);
 const responseReceiverNames = new Set([
   "res",
   "resp",
@@ -120,13 +120,9 @@ function isZeroLiteral(node) {
   return ts.isNumericLiteral(expression) && expression.text === "0";
 }
 
-function isNegativeLiteral(node) {
+function isNegativeExpression(node) {
   const expression = unwrapExpression(node);
-  return (
-    ts.isPrefixUnaryExpression(expression) &&
-    expression.operator === ts.SyntaxKind.MinusToken &&
-    ts.isNumericLiteral(expression.operand)
-  );
+  return ts.isPrefixUnaryExpression(expression) && expression.operator === ts.SyntaxKind.MinusToken;
 }
 
 function finalAccessName(node) {
@@ -140,11 +136,31 @@ function finalAccessName(node) {
   return null;
 }
 
+function isLikelyCollectionReceiverName(name) {
+  return Boolean(
+    name &&
+    (collectionReceiverNames.has(name) ||
+      /(?:aliases|attachments|blockers|candidates|chars|children|commands|diagnostics|entries|errors|failures|findings|issues|items|labels|lines|lookups|memos|messages|notices|outputs|pages|parts|payloads|results|snippets|summaries|threads|tokens|tools|urls|values|warnings)$/i.test(
+        name,
+      )),
+  );
+}
+
+function isCollectionReturningCall(sourceFile, node) {
+  const expression = unwrapExpression(node);
+  if (!ts.isCallExpression(expression)) {
+    return false;
+  }
+  return /(?:entries|results|candidates|references|attachments|urls|files|items|messages|labels|commands|issues|notices|tools|memos)\b/i.test(
+    nodeText(sourceFile, unwrapExpression(expression.expression)),
+  );
+}
+
 function isStringProducingExpression(sourceFile, node) {
   const expression = unwrapExpression(node);
   if (ts.isIdentifier(expression) || ts.isPropertyAccessExpression(expression)) {
     const name = finalAccessName(expression);
-    return Boolean(name && textReceiverRe.test(name) && !collectionReceiverNames.has(name));
+    return Boolean(name && textReceiverRe.test(name) && !isLikelyCollectionReceiverName(name));
   }
   if (ts.isCallExpression(expression)) {
     const access = readPropertyAccessCall(expression);
@@ -162,6 +178,53 @@ function isStringProducingExpression(sourceFile, node) {
     );
   }
   return false;
+}
+
+function isCollectionProducingExpression(sourceFile, node) {
+  const expression = unwrapExpression(node);
+  if (ts.isArrayLiteralExpression(expression)) {
+    return true;
+  }
+  if (ts.isIdentifier(expression) || ts.isPropertyAccessExpression(expression)) {
+    const name = finalAccessName(expression);
+    return Boolean(name && isLikelyCollectionReceiverName(name));
+  }
+  if (ts.isCallExpression(expression)) {
+    if (isCollectionReturningCall(sourceFile, expression)) {
+      return true;
+    }
+    const access = readPropertyAccessCall(expression);
+    if (!access) {
+      return false;
+    }
+    if (arrayProducingChainMethods.has(access.name)) {
+      return true;
+    }
+    if (stringProducingChainMethods.has(access.name)) {
+      return false;
+    }
+    return isCollectionProducingExpression(sourceFile, access.receiver);
+  }
+  return false;
+}
+
+function isRangeBoundaryExpression(text) {
+  return /(?:^|[A-Z_.-])(?:start|end|offset|index|position|pos)$/i.test(text);
+}
+
+function isByteSliceExpression(sourceFile, receiver, limitText) {
+  const receiverName = finalAccessName(receiver);
+  return receiverName === "body" && /bytes?/i.test(limitText);
+}
+
+function isIdentifierPrefixSliceName(name) {
+  return Boolean(
+    name && /(?:id|ids|key|keys|hash|hashes|digest|token|tokens|signature|checksum)$/i.test(name),
+  );
+}
+
+function hasExplicitTruncationMarker(text) {
+  return /(?:…|\.\.\.|ellipsis)/i.test(text);
 }
 
 function nearestBoundaryContextText(sourceFile, node) {
@@ -195,24 +258,49 @@ function isLikelyTextBoundarySlice(sourceFile, call) {
   if (
     call.arguments.length < 2 ||
     !isZeroLiteral(call.arguments[0]) ||
-    isNegativeLiteral(call.arguments[1])
+    isNegativeExpression(call.arguments[1])
   ) {
     return false;
   }
 
   const limitText = nodeText(sourceFile, call.arguments[1]);
   const contextText = nearestBoundaryContextText(sourceFile, call);
+  const receiverName = finalAccessName(access.receiver);
+  const hasLimit = textLimitRe.test(limitText);
+  const hasMarker = hasExplicitTruncationMarker(contextText);
 
-  if (!isStringProducingExpression(sourceFile, access.receiver)) {
+  if (
+    isCollectionProducingExpression(sourceFile, access.receiver) ||
+    isRangeBoundaryExpression(limitText) ||
+    isByteSliceExpression(sourceFile, access.receiver, limitText) ||
+    isIdentifierPrefixSliceName(receiverName)
+  ) {
     return false;
   }
-  return textLimitRe.test(limitText) || textTruncationContextRe.test(contextText);
+
+  if (!isStringProducingExpression(sourceFile, access.receiver)) {
+    return hasLimit && hasMarker;
+  }
+  return hasLimit || hasMarker || textTruncationContextRe.test(receiverName ?? "");
 }
 
-function isResponseReceiver(sourceFile, node) {
+function isResponseCloneCall(sourceFile, node, responseAliases) {
+  const expression = unwrapExpression(node);
+  if (!ts.isCallExpression(expression)) {
+    return false;
+  }
+  const access = readPropertyAccessCall(expression);
+  return Boolean(
+    access &&
+    access.name === "clone" &&
+    isResponseReceiver(sourceFile, access.receiver, responseAliases),
+  );
+}
+
+function isResponseReceiver(sourceFile, node, responseAliases = responseReceiverNames) {
   const expression = unwrapExpression(node);
   if (ts.isIdentifier(expression)) {
-    return responseReceiverNames.has(expression.text) || expression.text.endsWith("Response");
+    return responseAliases.has(expression.text) || expression.text.endsWith("Response");
   }
   if (ts.isPropertyAccessExpression(expression)) {
     const text = nodeText(sourceFile, expression);
@@ -220,37 +308,20 @@ function isResponseReceiver(sourceFile, node) {
       text,
     );
   }
-  return false;
+  return isResponseCloneCall(sourceFile, expression, responseAliases);
 }
 
-function isAwaitedRead(call) {
-  let current = call;
-  while (current.parent) {
-    const parent = current.parent;
-    if (ts.isAwaitExpression(parent)) {
-      return true;
-    }
-    if (
-      ts.isExpressionStatement(parent) ||
-      ts.isVariableDeclaration(parent) ||
-      ts.isReturnStatement(parent)
-    ) {
-      return false;
-    }
-    current = parent;
-  }
-  return false;
+function isResponseAliasInitializer(sourceFile, node, responseAliases) {
+  const expression = unwrapExpression(node);
+  return isResponseReceiver(sourceFile, expression, responseAliases);
 }
 
-function isLikelyResponseBodyRead(sourceFile, call) {
+function isLikelyResponseBodyRead(sourceFile, call, responseAliases) {
   const access = readPropertyAccessCall(call);
-  if (!access || !responseReadMethods.has(access.name)) {
+  if (!access || !responseReadMethods.has(access.name) || call.arguments.length > 0) {
     return false;
   }
-  if (!isResponseReceiver(sourceFile, access.receiver)) {
-    return false;
-  }
-  return isAwaitedRead(call);
+  return isResponseReceiver(sourceFile, access.receiver, responseAliases);
 }
 
 function hasBoundarySafetyIgnore(sourceFile, node, ruleId) {
@@ -267,14 +338,25 @@ function hasBoundarySafetyIgnore(sourceFile, node, ruleId) {
     current = current.parent;
   }
   const statementPrefix = sourceText.slice(current.getFullStart(), node.getStart(sourceFile));
-  return hasIgnoreText(statementPrefix);
+  const inlineComments = statementPrefix.match(/\/\*[\s\S]*?\*\/|\/\/[^\n\r]*/g) ?? [];
+  return inlineComments.some(hasIgnoreText);
 }
 
 export function findBoundarySafetyViolations(content, fileName = "source.ts") {
   const sourceFile = ts.createSourceFile(fileName, content, ts.ScriptTarget.Latest, true);
   const violations = [];
+  const responseAliases = new Set(responseReceiverNames);
 
   const visit = (node) => {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.initializer &&
+      isResponseAliasInitializer(sourceFile, node.initializer, responseAliases)
+    ) {
+      responseAliases.add(node.name.text);
+    }
+
     if (ts.isCallExpression(node)) {
       if (isLikelyTextBoundarySlice(sourceFile, node)) {
         const ruleId = "boundary/text-utf16-truncation";
@@ -289,7 +371,7 @@ export function findBoundarySafetyViolations(content, fileName = "source.ts") {
         }
       }
 
-      if (isLikelyResponseBodyRead(sourceFile, node)) {
+      if (isLikelyResponseBodyRead(sourceFile, node, responseAliases)) {
         const ruleId = "boundary/response-body-limit";
         if (!hasBoundarySafetyIgnore(sourceFile, node, ruleId)) {
           violations.push({

--- a/scripts/check-boundary-safety.mjs
+++ b/scripts/check-boundary-safety.mjs
@@ -1,0 +1,506 @@
+#!/usr/bin/env node
+
+// Checks for newly introduced high-risk text and response boundary bypasses.
+import { execFileSync } from "node:child_process";
+import { existsSync, promises as fs } from "node:fs";
+import path from "node:path";
+import ts from "typescript";
+import {
+  collectTypeScriptFilesFromRoots,
+  resolveRepoRoot,
+  resolveSourceRoots,
+  runAsScript,
+  toLine,
+  unwrapExpression,
+} from "./lib/ts-guard-utils.mjs";
+
+const repoRoot = resolveRepoRoot(import.meta.url);
+const baselinePath = path.join(repoRoot, "test", "fixtures", "boundary-safety-inventory.json");
+const sourceRoots = resolveSourceRoots(repoRoot, ["src", "extensions", "packages"]);
+
+const responseReadMethods = new Set(["json", "text", "arrayBuffer"]);
+const responseReceiverNames = new Set([
+  "res",
+  "resp",
+  "response",
+  "providerResponse",
+  "httpResponse",
+  "fetchResponse",
+  "upstreamResponse",
+  "remoteResponse",
+]);
+
+const textReceiverRe =
+  /(?:text|message|summary|preview|snippet|label|title|prompt|context|draft|caption|description|progress|body|output|reason|name)/i;
+const textLimitRe = /(?:max|limit|length|chars|size|budget|truncate|preview|summary|snippet)/i;
+const textTruncationContextRe =
+  /(?:…|\.\.\.|ellipsis|truncated|truncate|preview|summary|label|title|message|prompt|context|snippet|task|progress|caption|description)/i;
+const collectionReceiverNames = new Set([
+  "attachments",
+  "candidateSnippets",
+  "entries",
+  "imageAttachments",
+  "items",
+  "labels",
+  "messages",
+  "pages",
+  "parts",
+  "snippets",
+  "stickers",
+  "subMessages",
+  "summaries",
+  "texts",
+  "tokens",
+]);
+const arrayProducingChainMethods = new Set([
+  "concat",
+  "filter",
+  "flatMap",
+  "map",
+  "sort",
+  "toSorted",
+  "values",
+]);
+const stringProducingChainMethods = new Set([
+  "join",
+  "normalize",
+  "replace",
+  "replaceAll",
+  "toLocaleLowerCase",
+  "toLocaleUpperCase",
+  "toLowerCase",
+  "toString",
+  "toUpperCase",
+  "trim",
+  "trimEnd",
+  "trimStart",
+]);
+const ignoredPathParts = [
+  "/test/",
+  "/tests/",
+  "/fixtures/",
+  "/__fixtures__/",
+  "/dist/",
+  "/generated/",
+  "/node_modules/",
+  "/vendor/",
+];
+const ignoredSuffixes = [
+  ".test.ts",
+  ".spec.ts",
+  ".test.tsx",
+  ".spec.tsx",
+  ".test-helpers.ts",
+  ".test-harness.ts",
+  ".e2e-harness.ts",
+  ".d.ts",
+];
+
+function normalizePath(filePath) {
+  return filePath.replaceAll(path.sep, "/");
+}
+
+function nodeText(sourceFile, node) {
+  return node.getText(sourceFile);
+}
+
+function readPropertyAccessCall(node) {
+  const expression = unwrapExpression(node.expression);
+  if (!ts.isPropertyAccessExpression(expression)) {
+    return null;
+  }
+  return {
+    receiver: unwrapExpression(expression.expression),
+    name: expression.name.text,
+  };
+}
+
+function isZeroLiteral(node) {
+  const expression = unwrapExpression(node);
+  return ts.isNumericLiteral(expression) && expression.text === "0";
+}
+
+function isNegativeLiteral(node) {
+  const expression = unwrapExpression(node);
+  return (
+    ts.isPrefixUnaryExpression(expression) &&
+    expression.operator === ts.SyntaxKind.MinusToken &&
+    ts.isNumericLiteral(expression.operand)
+  );
+}
+
+function finalAccessName(node) {
+  const expression = unwrapExpression(node);
+  if (ts.isIdentifier(expression)) {
+    return expression.text;
+  }
+  if (ts.isPropertyAccessExpression(expression)) {
+    return expression.name.text;
+  }
+  return null;
+}
+
+function isStringProducingExpression(sourceFile, node) {
+  const expression = unwrapExpression(node);
+  if (ts.isIdentifier(expression) || ts.isPropertyAccessExpression(expression)) {
+    const name = finalAccessName(expression);
+    return Boolean(name && textReceiverRe.test(name) && !collectionReceiverNames.has(name));
+  }
+  if (ts.isCallExpression(expression)) {
+    const access = readPropertyAccessCall(expression);
+    if (access) {
+      if (stringProducingChainMethods.has(access.name)) {
+        return true;
+      }
+      if (arrayProducingChainMethods.has(access.name)) {
+        return false;
+      }
+      return isStringProducingExpression(sourceFile, access.receiver);
+    }
+    return /(?:text|message|summary|snippet|label|title|prompt|caption|description|body|string)/i.test(
+      nodeText(sourceFile, expression.expression),
+    );
+  }
+  return false;
+}
+
+function nearestBoundaryContextText(sourceFile, node) {
+  let current = node;
+  while (current.parent) {
+    const parent = current.parent;
+    if (
+      ts.isTemplateExpression(parent) ||
+      ts.isNoSubstitutionTemplateLiteral(parent) ||
+      ts.isBinaryExpression(parent) ||
+      ts.isConditionalExpression(parent) ||
+      ts.isReturnStatement(parent) ||
+      ts.isVariableDeclaration(parent) ||
+      ts.isPropertyAssignment(parent)
+    ) {
+      return parent.getText(sourceFile);
+    }
+    if (ts.isStatement(parent)) {
+      return parent.getText(sourceFile);
+    }
+    current = parent;
+  }
+  return node.getText(sourceFile);
+}
+
+function isLikelyTextBoundarySlice(sourceFile, call) {
+  const access = readPropertyAccessCall(call);
+  if (!access || (access.name !== "slice" && access.name !== "substring")) {
+    return false;
+  }
+  if (
+    call.arguments.length < 2 ||
+    !isZeroLiteral(call.arguments[0]) ||
+    isNegativeLiteral(call.arguments[1])
+  ) {
+    return false;
+  }
+
+  const limitText = nodeText(sourceFile, call.arguments[1]);
+  const contextText = nearestBoundaryContextText(sourceFile, call);
+
+  if (!isStringProducingExpression(sourceFile, access.receiver)) {
+    return false;
+  }
+  return textLimitRe.test(limitText) || textTruncationContextRe.test(contextText);
+}
+
+function isResponseReceiver(sourceFile, node) {
+  const expression = unwrapExpression(node);
+  if (ts.isIdentifier(expression)) {
+    return responseReceiverNames.has(expression.text) || expression.text.endsWith("Response");
+  }
+  if (ts.isPropertyAccessExpression(expression)) {
+    const text = nodeText(sourceFile, expression);
+    return /(?:^|\.)(?:res|resp|response|providerResponse|httpResponse|fetchResponse|upstreamResponse|remoteResponse)$/.test(
+      text,
+    );
+  }
+  return false;
+}
+
+function isAwaitedRead(call) {
+  let current = call;
+  while (current.parent) {
+    const parent = current.parent;
+    if (ts.isAwaitExpression(parent)) {
+      return true;
+    }
+    if (
+      ts.isExpressionStatement(parent) ||
+      ts.isVariableDeclaration(parent) ||
+      ts.isReturnStatement(parent)
+    ) {
+      return false;
+    }
+    current = parent;
+  }
+  return false;
+}
+
+function isLikelyResponseBodyRead(sourceFile, call) {
+  const access = readPropertyAccessCall(call);
+  if (!access || !responseReadMethods.has(access.name)) {
+    return false;
+  }
+  if (!isResponseReceiver(sourceFile, access.receiver)) {
+    return false;
+  }
+  return isAwaitedRead(call);
+}
+
+function hasBoundarySafetyIgnore(sourceFile, node, ruleId) {
+  const sourceText = sourceFile.getFullText();
+  const comments = ts.getLeadingCommentRanges(sourceText, node.getFullStart()) ?? [];
+  return comments.some((comment) => {
+    const text = sourceText.slice(comment.pos, comment.end);
+    return text.includes(`boundary-safety-ignore ${ruleId}:`) && /:\s*\S/.test(text);
+  });
+}
+
+export function findBoundarySafetyViolations(content, fileName = "source.ts") {
+  const sourceFile = ts.createSourceFile(fileName, content, ts.ScriptTarget.Latest, true);
+  const violations = [];
+
+  const visit = (node) => {
+    if (ts.isCallExpression(node)) {
+      if (isLikelyTextBoundarySlice(sourceFile, node)) {
+        const ruleId = "boundary/text-utf16-truncation";
+        if (!hasBoundarySafetyIgnore(sourceFile, node, ruleId)) {
+          violations.push({
+            line: toLine(sourceFile, node),
+            ruleId,
+            match: nodeText(sourceFile, node),
+            guidance:
+              "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing.",
+          });
+        }
+      }
+
+      if (isLikelyResponseBodyRead(sourceFile, node)) {
+        const ruleId = "boundary/response-body-limit";
+        if (!hasBoundarySafetyIgnore(sourceFile, node, ruleId)) {
+          violations.push({
+            line: toLine(sourceFile, node),
+            ruleId,
+            match: nodeText(sourceFile, node),
+            guidance:
+              "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code.",
+          });
+        }
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+  return violations;
+}
+
+export function isBoundarySafetyCandidateFile(filePath) {
+  const normalized = normalizePath(filePath);
+  if (!normalized.endsWith(".ts") && !normalized.endsWith(".tsx")) {
+    return false;
+  }
+  if (ignoredPathParts.some((part) => normalized.includes(part))) {
+    return false;
+  }
+  if (ignoredSuffixes.some((suffix) => normalized.endsWith(suffix))) {
+    return false;
+  }
+  if (normalized === "scripts/check-boundary-safety.mjs") {
+    return false;
+  }
+  return /^(?:src\/|extensions\/|packages\/)/.test(normalized);
+}
+
+function entryKey(entry) {
+  return `${entry.ruleId}:${normalizePath(entry.file)}:${entry.line}:${entry.match}`;
+}
+
+export function diffBoundaryInventory(expected, actual) {
+  const expectedKeys = new Set(expected.map(entryKey));
+  const actualKeys = new Set(actual.map(entryKey));
+  return {
+    missing: expected.filter((entry) => !actualKeys.has(entryKey(entry))),
+    unexpected: actual.filter((entry) => !expectedKeys.has(entryKey(entry))),
+  };
+}
+
+function sortInventory(entries) {
+  return entries.toSorted((a, b) => {
+    const fileCmp = a.file.localeCompare(b.file);
+    if (fileCmp !== 0) {
+      return fileCmp;
+    }
+    const lineCmp = a.line - b.line;
+    if (lineCmp !== 0) {
+      return lineCmp;
+    }
+    return a.ruleId.localeCompare(b.ruleId) || a.match.localeCompare(b.match);
+  });
+}
+
+async function readBaseline() {
+  try {
+    return JSON.parse(await fs.readFile(baselinePath, "utf8"));
+  } catch (error) {
+    if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
+      return [];
+    }
+    throw error;
+  }
+}
+
+function runGit(args) {
+  try {
+    return execFileSync("git", args, {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+  } catch {
+    return "";
+  }
+}
+
+function collectChangedFileNames() {
+  const names = new Set();
+  for (const output of [
+    runGit(["diff", "--name-only", "--diff-filter=ACMRTUXB", "HEAD", "--"]),
+    runGit(["diff", "--cached", "--name-only", "--diff-filter=ACMRTUXB", "--"]),
+    runGit(["diff", "--name-only", "--diff-filter=ACMRTUXB", "origin/main...HEAD", "--"]),
+    runGit(["ls-files", "--others", "--exclude-standard"]),
+  ]) {
+    for (const line of output.split("\n")) {
+      const file = line.trim();
+      if (file) {
+        names.add(normalizePath(file));
+      }
+    }
+  }
+  return [...names];
+}
+
+async function collectAllCandidateFiles() {
+  const files = await collectTypeScriptFilesFromRoots(sourceRoots, { includeTests: false });
+  return files
+    .map((filePath) => normalizePath(path.relative(repoRoot, filePath)))
+    .filter(isBoundarySafetyCandidateFile);
+}
+
+async function collectChangedCandidateFiles() {
+  const files = [];
+  for (const file of collectChangedFileNames()) {
+    if (!isBoundarySafetyCandidateFile(file)) {
+      continue;
+    }
+    const absolutePath = path.join(repoRoot, file);
+    if (existsSync(absolutePath)) {
+      files.push(file);
+    }
+  }
+  return files;
+}
+
+export async function collectBoundarySafetyInventory(options = {}) {
+  const files =
+    options.files ??
+    (options.all ? await collectAllCandidateFiles() : await collectChangedCandidateFiles());
+  const entries = [];
+  for (const file of files) {
+    const content = await fs.readFile(path.join(repoRoot, file), "utf8");
+    for (const violation of findBoundarySafetyViolations(content, file)) {
+      entries.push({
+        file,
+        line: violation.line,
+        ruleId: violation.ruleId,
+        match: violation.match,
+        guidance: violation.guidance,
+      });
+    }
+  }
+  return sortInventory(entries);
+}
+
+function printViolationList(stream, title, entries) {
+  if (entries.length === 0) {
+    return;
+  }
+  stream.write(`${title}\n`);
+  for (const entry of entries) {
+    stream.write(`- ${entry.file}:${entry.line} ${entry.ruleId}: ${entry.match}\n`);
+    stream.write(`  ${entry.guidance}\n`);
+  }
+}
+
+function parseArgs(argv) {
+  return {
+    all: argv.includes("--all"),
+    json: argv.includes("--json"),
+    updateBaseline: argv.includes("--update-baseline"),
+  };
+}
+
+export async function main(
+  argv = process.argv.slice(2),
+  io = { stdout: process.stdout, stderr: process.stderr },
+) {
+  const args = parseArgs(argv);
+  const actual = await collectBoundarySafetyInventory({ all: args.all });
+
+  if (args.json) {
+    io.stdout.write(`${JSON.stringify(actual, null, 2)}\n`);
+  }
+
+  if (args.updateBaseline) {
+    await fs.writeFile(baselinePath, `${JSON.stringify(actual, null, 2)}\n`);
+    io.stdout.write(
+      `Updated ${path.relative(repoRoot, baselinePath)} with ${actual.length} entries.\n`,
+    );
+    return 0;
+  }
+
+  const expected = await readBaseline();
+  const diff = diffBoundaryInventory(expected, actual);
+
+  if (args.all) {
+    if (diff.unexpected.length === 0 && diff.missing.length === 0) {
+      io.stdout.write(`Boundary safety baseline matches (${actual.length} entries).\n`);
+      return 0;
+    }
+    io.stderr.write("Boundary safety baseline mismatch.\n");
+    printViolationList(io.stderr, "Unexpected entries:", diff.unexpected);
+    printViolationList(io.stderr, "Missing baseline entries:", diff.missing);
+    io.stderr.write(
+      "Run `node scripts/check-boundary-safety.mjs --all --update-baseline` only after intentional migrations.\n",
+    );
+    return 1;
+  }
+
+  if (diff.unexpected.length === 0) {
+    io.stdout.write(
+      `Boundary safety changed-file check passed (${actual.length} changed-file entries, all baseline-known).\n`,
+    );
+    return 0;
+  }
+
+  io.stderr.write("Found new boundary safety violations in changed production files.\n");
+  printViolationList(io.stderr, "New entries:", diff.unexpected);
+  io.stderr.write(
+    "Use the canonical helper, or add a narrow `boundary-safety-ignore <rule-id>: <reason>` only for proven false positives.\n",
+  );
+  return 1;
+}
+
+runAsScript(import.meta.url, async () => {
+  const code = await main();
+  if (code !== 0) {
+    process.exit(code);
+  }
+});

--- a/scripts/check-changed.mjs
+++ b/scripts/check-changed.mjs
@@ -378,6 +378,7 @@ export function createChangedCheckPlan(result, options = {}) {
     add("database-first legacy-store guard", ["check:database-first-legacy-stores"]);
     add("media download helper guard", ["check:media-download-helpers"]);
     add("runtime sidecar loader guard", ["check:runtime-sidecar-loaders"]);
+    add("boundary safety guard", ["check:boundary-safety"]);
     addTypecheck("typecheck all", ["tsgo:all"]);
     addLint("lint", ["lint"]);
     add("runtime import cycles", ["check:import-cycles"]);
@@ -469,6 +470,7 @@ export function createChangedCheckPlan(result, options = {}) {
     add("database-first legacy-store guard", ["check:database-first-legacy-stores"]);
     add("media download helper guard", ["check:media-download-helpers"]);
     add("runtime sidecar loader guard", ["check:runtime-sidecar-loaders"]);
+    add("boundary safety guard", ["check:boundary-safety"]);
     add("runtime import cycles", ["check:import-cycles"]);
   }
   if (lanes.core) {

--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -103,6 +103,7 @@ export async function main(argv = process.argv.slice(2)) {
         },
         { name: "media download helper guard", args: ["check:media-download-helpers"] },
         { name: "runtime sidecar loader guard", args: ["check:runtime-sidecar-loaders"] },
+        { name: "boundary safety guard", args: ["check:boundary-safety:all"] },
         { name: "tool display", args: ["tool-display:check"] },
         { name: "host env policy", args: ["check:host-env-policy:swift"] },
         { name: "opengrep rule metadata", args: ["check:opengrep-rule-metadata"] },

--- a/src/acp/control-plane/manager.background-task.ts
+++ b/src/acp/control-plane/manager.background-task.ts
@@ -1,6 +1,7 @@
 /** Mirrors child ACP turns into detached-task status for requester-facing progress. */
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";
+import { truncateUtf16Safe } from "../../shared/utf16-slice.js";
 import {
   createRunningTaskRun,
   completeTaskRunByRunId,
@@ -32,7 +33,7 @@ function summarizeBackgroundTaskText(text: string): string {
   if (normalized.length <= ACP_BACKGROUND_TASK_TEXT_MAX_LENGTH) {
     return normalized;
   }
-  return `${normalized.slice(0, ACP_BACKGROUND_TASK_TEXT_MAX_LENGTH - 1)}…`;
+  return `${truncateUtf16Safe(normalized, ACP_BACKGROUND_TASK_TEXT_MAX_LENGTH - 1)}…`;
 }
 
 /** Appends bounded progress text while preserving a single-line task summary. */
@@ -49,7 +50,7 @@ export function appendBackgroundTaskProgressSummary(current: string, chunk: stri
   if (combined.length <= ACP_BACKGROUND_TASK_PROGRESS_MAX_LENGTH) {
     return combined;
   }
-  return `${combined.slice(0, ACP_BACKGROUND_TASK_PROGRESS_MAX_LENGTH - 1)}…`;
+  return `${truncateUtf16Safe(combined, ACP_BACKGROUND_TASK_PROGRESS_MAX_LENGTH - 1)}…`;
 }
 
 /** Maps ACP runtime failures to detached-task terminal states. */

--- a/src/acp/control-plane/manager.background-task.ts
+++ b/src/acp/control-plane/manager.background-task.ts
@@ -1,7 +1,7 @@
 /** Mirrors child ACP turns into detached-task status for requester-facing progress. */
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";
-import { truncateUtf16Safe } from "../../shared/utf16-slice.js";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import {
   createRunningTaskRun,
   completeTaskRunByRunId,

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -8,6 +8,7 @@ import {
   withAcpManagerTaskStateDir,
 } from "../../../test/helpers/acp-manager-task-state.js";
 import { isAcpTurnActive } from "./active-turns.js";
+import { appendBackgroundTaskProgressSummary } from "./manager.background-task.js";
 import {
   AcpRuntimeError,
   AcpSessionManager,
@@ -279,6 +280,12 @@ describe("AcpSessionManager", () => {
       });
     });
   }, 300_000);
+
+  it("truncates parented task progress without dangling surrogate halves", () => {
+    const summary = appendBackgroundTaskProgressSummary("", `${"x".repeat(238)}🙂tail`);
+
+    expect(summary).toBe(`${"x".repeat(238)}…`);
+  });
 
   it("serializes concurrent turns for the same ACP session", async () => {
     const runtimeState = createRuntime();

--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -865,7 +865,7 @@ describe("anthropic transport stream", () => {
     );
 
     expect(result.stopReason).toBe("error");
-    expect(result.errorMessage).toBe(`${"x".repeat(400)}…`);
+    expect(result.errorMessage).toBe(`${"x".repeat(399)}…`);
     expect(pullCount).toBeGreaterThanOrEqual(2);
     expect(cancelCount).toBe(1);
   });

--- a/src/agents/minimax-vlm.boundary.test.ts
+++ b/src/agents/minimax-vlm.boundary.test.ts
@@ -63,7 +63,9 @@ describe("minimaxUnderstandImage response boundaries", () => {
     if (!(error instanceof Error)) {
       throw new Error("expected MiniMax VLM request to throw an Error");
     }
-    expect(error.message).toContain("MiniMax VLM: JSON response exceeds 16777216 bytes");
+    expect(error.message).toContain(
+      "MiniMax VLM response [Trace-Id=trace-456]: JSON response exceeds 16777216 bytes",
+    );
     expect(error.message).not.toContain("tail-marker");
     expect(canceled).toBe(true);
   });

--- a/src/agents/minimax-vlm.boundary.test.ts
+++ b/src/agents/minimax-vlm.boundary.test.ts
@@ -10,11 +10,35 @@ describe("minimaxUnderstandImage response boundaries", () => {
     vi.restoreAllMocks();
   });
 
+  it("accepts provider success JSON below the shared cap", async () => {
+    const content = "bounded-response-ok";
+    const fetchSpy = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          base_resp: { status_code: 0 },
+          content,
+          padding: "x".repeat(5 * 1024 * 1024),
+        }),
+        { status: 200 },
+      );
+    });
+    global.fetch = withFetchPreconnect(fetchSpy);
+
+    await expect(
+      minimaxUnderstandImage({
+        apiKey: "minimax-test-key",
+        prompt: "hi",
+        imageDataUrl: "data:image/png;base64,AAAA",
+        apiHost: "https://api.minimax.io",
+      }),
+    ).resolves.toBe(content);
+  });
+
   it("bounds large provider success response bodies", async () => {
     let canceled = false;
     const body = new ReadableStream<Uint8Array>({
       start(controller) {
-        controller.enqueue(new Uint8Array(4 * 1024 * 1024));
+        controller.enqueue(new Uint8Array(16 * 1024 * 1024));
         controller.enqueue(new TextEncoder().encode("tail-marker"));
       },
       cancel() {
@@ -39,7 +63,7 @@ describe("minimaxUnderstandImage response boundaries", () => {
     if (!(error instanceof Error)) {
       throw new Error("expected MiniMax VLM request to throw an Error");
     }
-    expect(error.message).toContain("MiniMax VLM: JSON response exceeds");
+    expect(error.message).toContain("MiniMax VLM: JSON response exceeds 16777216 bytes");
     expect(error.message).not.toContain("tail-marker");
     expect(canceled).toBe(true);
   });

--- a/src/agents/minimax-vlm.boundary.test.ts
+++ b/src/agents/minimax-vlm.boundary.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { withFetchPreconnect } from "../test-utils/fetch-mock.js";
+import { minimaxUnderstandImage } from "./minimax-vlm.js";
+
+describe("minimaxUnderstandImage response boundaries", () => {
+  const priorFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = priorFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("bounds large provider success response bodies", async () => {
+    let canceled = false;
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array(4 * 1024 * 1024));
+        controller.enqueue(new TextEncoder().encode("tail-marker"));
+      },
+      cancel() {
+        canceled = true;
+      },
+    });
+    const fetchSpy = vi.fn(async () => {
+      return new Response(body, {
+        status: 200,
+        headers: { "Trace-Id": "trace-456" },
+      });
+    });
+    global.fetch = withFetchPreconnect(fetchSpy);
+
+    const error = await minimaxUnderstandImage({
+      apiKey: "minimax-test-key",
+      prompt: "hi",
+      imageDataUrl: "data:image/png;base64,AAAA",
+      apiHost: "https://api.minimax.io",
+    }).catch((caught: unknown) => caught);
+
+    if (!(error instanceof Error)) {
+      throw new Error("expected MiniMax VLM request to throw an Error");
+    }
+    expect(error.message).toContain("MiniMax VLM: JSON response exceeds");
+    expect(error.message).not.toContain("tail-marker");
+    expect(canceled).toBe(true);
+  });
+});

--- a/src/agents/minimax-vlm.ts
+++ b/src/agents/minimax-vlm.ts
@@ -15,6 +15,7 @@ type MinimaxBaseResp = {
 
 const MINIMAX_VLM_ERROR_BODY_MAX_BYTES = 8 * 1024;
 const MINIMAX_VLM_ERROR_BODY_MAX_CHARS = 400;
+const MINIMAX_VLM_SUCCESS_BODY_MAX_BYTES = 4 * 1024 * 1024;
 const DEFAULT_MINIMAX_VLM_TIMEOUT_MS = 60_000;
 
 export function isMinimaxVlmProvider(provider: string): boolean {
@@ -146,7 +147,9 @@ export async function minimaxUnderstandImage(params: {
   const responseLabel = traceId
     ? `MiniMax VLM response [Trace-Id=${traceId}]`
     : "MiniMax VLM response";
-  const json = await readProviderJsonResponse<unknown>(res, responseLabel);
+  const json = await readProviderJsonResponse<unknown>(res, responseLabel, {
+    maxBytes: MINIMAX_VLM_SUCCESS_BODY_MAX_BYTES,
+  });
   if (!isRecord(json)) {
     const trace = traceId ? ` Trace-Id: ${traceId}` : "";
     throw new Error(`MiniMax VLM response was not JSON.${trace}`);

--- a/src/agents/minimax-vlm.ts
+++ b/src/agents/minimax-vlm.ts
@@ -15,7 +15,7 @@ type MinimaxBaseResp = {
 
 const MINIMAX_VLM_ERROR_BODY_MAX_BYTES = 8 * 1024;
 const MINIMAX_VLM_ERROR_BODY_MAX_CHARS = 400;
-const MINIMAX_VLM_SUCCESS_BODY_MAX_BYTES = 4 * 1024 * 1024;
+const MINIMAX_VLM_SUCCESS_BODY_MAX_BYTES = 16 * 1024 * 1024;
 const DEFAULT_MINIMAX_VLM_TIMEOUT_MS = 60_000;
 
 export function isMinimaxVlmProvider(provider: string): boolean {

--- a/src/agents/provider-http-errors.ts
+++ b/src/agents/provider-http-errors.ts
@@ -8,7 +8,7 @@ export { asFiniteNumber } from "../../packages/normalization-core/src/number-coe
 import { normalizeOptionalString as trimToUndefined } from "../../packages/normalization-core/src/string-coerce.js";
 import { readResponseWithLimit } from "../infra/http-body.js";
 import { redactSensitiveText } from "../logging/redact.js";
-import { truncateUtf16Safe } from "../shared/utf16-slice.js";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 export { asBoolean } from "../utils/boolean.js";
 export { normalizeOptionalString as trimToUndefined } from "../../packages/normalization-core/src/string-coerce.js";
 

--- a/src/agents/provider-http-errors.ts
+++ b/src/agents/provider-http-errors.ts
@@ -8,6 +8,7 @@ export { asFiniteNumber } from "../../packages/normalization-core/src/number-coe
 import { normalizeOptionalString as trimToUndefined } from "../../packages/normalization-core/src/string-coerce.js";
 import { readResponseWithLimit } from "../infra/http-body.js";
 import { redactSensitiveText } from "../logging/redact.js";
+import { truncateUtf16Safe } from "../shared/utf16-slice.js";
 export { asBoolean } from "../utils/boolean.js";
 export { normalizeOptionalString as trimToUndefined } from "../../packages/normalization-core/src/string-coerce.js";
 
@@ -25,7 +26,7 @@ export function asObject(value: unknown): Record<string, unknown> | undefined {
 
 /** Trims provider error details to a log- and prompt-safe preview length. */
 export function truncateErrorDetail(detail: string, limit = 220): string {
-  return detail.length <= limit ? detail : `${detail.slice(0, limit - 1)}…`;
+  return detail.length <= limit ? detail : `${truncateUtf16Safe(detail, limit - 1)}…`;
 }
 
 /** Redacts secrets before preserving a bounded provider error body preview. */

--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -446,25 +446,26 @@ function registerImageToolEnvReset(priorFetch: typeof global.fetch, keys: string
   });
 }
 
+function minimaxVlmJsonResponse(
+  baseResp: { status_code: number; status_msg: string },
+  content = "ok",
+) {
+  return new Response(JSON.stringify({ content, base_resp: baseResp }), {
+    status: 200,
+    statusText: "OK",
+    headers: { "content-type": "application/json" },
+  });
+}
+
 function stubMinimaxOkFetch() {
-  const fetch = vi.fn().mockImplementation(async () =>
-    Response.json({
-      content: "ok",
-      base_resp: { status_code: 0, status_msg: "" },
-    }),
-  );
+  const fetch = vi.fn(async () => minimaxVlmJsonResponse({ status_code: 0, status_msg: "" }, "ok"));
   global.fetch = withFetchPreconnect(fetch);
   vi.stubEnv("MINIMAX_API_KEY", "minimax-test");
   return fetch;
 }
 
 function stubMinimaxFetch(baseResp: { status_code: number; status_msg: string }, content = "ok") {
-  const fetch = vi.fn().mockImplementation(async () =>
-    Response.json({
-      content,
-      base_resp: baseResp,
-    }),
-  );
+  const fetch = vi.fn(async () => minimaxVlmJsonResponse(baseResp, content));
   global.fetch = withFetchPreconnect(fetch);
   return fetch;
 }

--- a/src/infra/http-body.response.test.ts
+++ b/src/infra/http-body.response.test.ts
@@ -247,6 +247,16 @@ describe("readResponseTextSnippet", () => {
     ).rejects.toThrow(/maxBytes must be a non-negative finite number/);
   });
 
+  it("truncates snippets without dangling surrogate halves", async () => {
+    const response = new Response(makeStream([new TextEncoder().encode(`${"x".repeat(2)}🙂tail`)]));
+
+    await expectReadResponseTextSnippetCase({
+      response,
+      options: { maxBytes: 64, maxChars: 3 },
+      expected: "xx…",
+    });
+  });
+
   it.each([
     {
       name: "applies the idle timeout while reading snippets",

--- a/src/infra/http-body.response.test.ts
+++ b/src/infra/http-body.response.test.ts
@@ -30,6 +30,14 @@ function makeStallingStream(initialChunks: Uint8Array[], onCancel?: (reason?: un
   });
 }
 
+function makeBodylessResponse(bytes: Uint8Array): Response {
+  return {
+    body: null,
+    arrayBuffer: async () =>
+      bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+  } as Response;
+}
+
 async function expectIdleTimeout(
   createReadPromise: () => Promise<unknown>,
   expectedError: RegExp | string = /stalled/i,
@@ -127,6 +135,22 @@ describe("readResponseWithLimit", () => {
       });
     },
   );
+
+  it("reads body-less buffered responses within the byte limit", async () => {
+    await expectReadResponseWithLimitSuccessCase({
+      response: makeBodylessResponse(new TextEncoder().encode("hello")),
+      maxBytes: 5,
+      expected: Buffer.from("hello"),
+    });
+  });
+
+  it("rejects body-less buffered responses above the byte limit", async () => {
+    await expectReadResponseWithLimitFailureCase({
+      response: makeBodylessResponse(new TextEncoder().encode("hello")),
+      maxBytes: 4,
+      expectedError: /too large/i,
+    });
+  });
 
   it.each([
     {
@@ -267,6 +291,22 @@ describe("readResponseTextSnippet", () => {
       expected: "1234…",
     });
     expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves body-less buffered response snippets under the byte limit", async () => {
+    await expectReadResponseTextSnippetCase({
+      response: makeBodylessResponse(new TextEncoder().encode("hello   \n world")),
+      options: { maxBytes: 64, maxChars: 50 },
+      expected: "hello world",
+    });
+  });
+
+  it("truncates body-less buffered response snippets at the byte limit", async () => {
+    await expectReadResponseTextSnippetCase({
+      response: makeBodylessResponse(new TextEncoder().encode("1234567890")),
+      options: { maxBytes: 7, maxChars: 50 },
+      expected: "1234567…",
+    });
   });
 
   it.each([

--- a/src/infra/http-body.response.test.ts
+++ b/src/infra/http-body.response.test.ts
@@ -257,6 +257,18 @@ describe("readResponseTextSnippet", () => {
     });
   });
 
+  it("cancels snippet streams when the byte budget is exactly filled", async () => {
+    const cancel = vi.fn();
+    const response = new Response(makeStallingStream([new TextEncoder().encode("1234")], cancel));
+
+    await expectReadResponseTextSnippetCase({
+      response,
+      options: { maxBytes: 4, maxChars: 50 },
+      expected: "1234…",
+    });
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
   it.each([
     {
       name: "applies the idle timeout while reading snippets",

--- a/src/infra/http-body.response.test.ts
+++ b/src/infra/http-body.response.test.ts
@@ -263,6 +263,38 @@ describe("readResponseTextSnippet", () => {
     await expectReadResponseTextSnippetCase({ response, options, expected });
   });
 
+  it("does not mark a content-length-bounded snippet as truncated when it exactly fills maxBytes", async () => {
+    const response = new Response(makeStream([new TextEncoder().encode("1234")]), {
+      headers: { "content-length": "4" },
+    });
+
+    await expectReadResponseTextSnippetCase({
+      response,
+      options: { maxBytes: 4, maxChars: 50 },
+      expected: "1234",
+    });
+  });
+
+  it("drops incomplete UTF-8 characters from byte-truncated snippets", async () => {
+    const response = new Response(makeStream([new TextEncoder().encode("ab🙂tail")]));
+
+    await expectReadResponseTextSnippetCase({
+      response,
+      options: { maxBytes: 5, maxChars: 50 },
+      expected: "ab…",
+    });
+  });
+
+  it("counts the ellipsis inside the snippet character budget", async () => {
+    const response = new Response(makeStream([new TextEncoder().encode("abcdef")]));
+
+    await expectReadResponseTextSnippetCase({
+      response,
+      options: { maxBytes: 64, maxChars: 3 },
+      expected: "ab…",
+    });
+  });
+
   it("rejects invalid maxBytes before reading text snippets", async () => {
     await expect(
       readResponseTextSnippet(new Response(makeStream([new TextEncoder().encode("hello")])), {

--- a/src/infra/http-body.ts
+++ b/src/infra/http-body.ts
@@ -3,6 +3,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { clearTimeout as clearNodeTimeout, setTimeout as setNodeTimeout } from "node:timers";
 import { toErrorObject } from "@openclaw/normalization-core/error-coercion";
 import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { formatErrorMessage } from "./errors.js";
 import { parseStrictNonNegativeInteger } from "./parse-finite-number.js";
 
@@ -313,7 +314,7 @@ export async function readResponseTextSnippet(
     return undefined;
   }
   if (collapsed.length > maxChars) {
-    return `${collapsed.slice(0, maxChars)}…`;
+    return `${truncateUtf16Safe(collapsed, maxChars)}…`;
   }
   return prefix.truncated ? `${collapsed}…` : collapsed;
 }

--- a/src/infra/http-body.ts
+++ b/src/infra/http-body.ts
@@ -187,6 +187,24 @@ function validateMaxBytes(maxBytes: number): void {
   }
 }
 
+function parseResponseContentLengthHeader(response: Response): number | undefined {
+  const raw = response.headers.get("content-length");
+  if (raw === null) {
+    return undefined;
+  }
+  return parseStrictNonNegativeInteger(raw);
+}
+
+function appendEllipsisWithinLimit(text: string, maxChars: number): string {
+  if (maxChars <= 0) {
+    return "";
+  }
+  if (maxChars === 1) {
+    return "…";
+  }
+  return `${truncateUtf16Safe(text, maxChars - 1)}…`;
+}
+
 async function readBufferedResponsePrefix(
   res: Response,
   maxBytes: number,
@@ -220,6 +238,7 @@ async function readResponsePrefix(
   }
 
   const reader = body.getReader();
+  const contentLength = parseResponseContentLengthHeader(response);
   const chunks: Uint8Array[] = [];
   let total = 0;
   let size = 0;
@@ -237,13 +256,26 @@ async function readResponsePrefix(
         continue;
       }
       const nextTotal = total + value.length;
-      if (nextTotal > maxBytes || (options?.cancelAtMaxBytes && nextTotal >= maxBytes)) {
+      if (nextTotal > maxBytes) {
         const remaining = maxBytes - total;
         if (remaining > 0) {
           chunks.push(value.subarray(0, remaining));
           total += Math.min(value.length, remaining);
         }
         size = nextTotal;
+        truncated = true;
+        try {
+          await reader.cancel();
+        } catch {}
+        break;
+      }
+      if (options?.cancelAtMaxBytes && nextTotal >= maxBytes) {
+        chunks.push(value);
+        total = nextTotal;
+        size = total;
+        if (contentLength === nextTotal) {
+          break;
+        }
         truncated = true;
         try {
           await reader.cancel();
@@ -315,7 +347,7 @@ export async function readResponseTextSnippet(
     return undefined;
   }
 
-  const text = new TextDecoder().decode(prefix.buffer);
+  const text = new TextDecoder().decode(prefix.buffer, { stream: prefix.truncated });
   if (!text) {
     return undefined;
   }
@@ -325,9 +357,9 @@ export async function readResponseTextSnippet(
     return undefined;
   }
   if (collapsed.length > maxChars) {
-    return `${truncateUtf16Safe(collapsed, maxChars)}…`;
+    return appendEllipsisWithinLimit(collapsed, maxChars);
   }
-  return prefix.truncated ? `${collapsed}…` : collapsed;
+  return prefix.truncated ? appendEllipsisWithinLimit(collapsed, maxChars) : collapsed;
 }
 
 export async function readRequestBodyWithLimit(

--- a/src/infra/http-body.ts
+++ b/src/infra/http-body.ts
@@ -188,8 +188,8 @@ function validateMaxBytes(maxBytes: number): void {
 }
 
 function parseResponseContentLengthHeader(response: Response): number | undefined {
-  const raw = response.headers.get("content-length");
-  if (raw === null) {
+  const raw = response.headers?.get?.("content-length");
+  if (raw === null || raw === undefined) {
     return undefined;
   }
   return parseStrictNonNegativeInteger(raw);

--- a/src/infra/http-body.ts
+++ b/src/infra/http-body.ts
@@ -191,10 +191,9 @@ async function readBufferedResponsePrefix(
   res: Response,
   maxBytes: number,
 ): Promise<ReadResponsePrefixResult> {
-  const fallback = Buffer.from(
-    await // boundary-safety-ignore boundary/response-body-limit: no stream exists; enforce maxBytes after fallback.
-    res.arrayBuffer(),
-  );
+  const fallbackBuffer =
+    await /* boundary-safety-ignore boundary/response-body-limit: no stream exists; enforce maxBytes after fallback. */ res.arrayBuffer();
+  const fallback = Buffer.from(fallbackBuffer);
   if (fallback.length > maxBytes) {
     return {
       buffer: fallback.subarray(0, maxBytes),

--- a/src/infra/http-body.ts
+++ b/src/infra/http-body.ts
@@ -193,20 +193,13 @@ async function readResponsePrefix(
   options?: {
     chunkTimeoutMs?: number;
     onIdleTimeout?: (params: { chunkTimeoutMs: number }) => Error;
+    cancelAtMaxBytes?: boolean;
   },
 ): Promise<ReadResponsePrefixResult> {
   validateMaxBytes(maxBytes);
   const body = response.body;
   if (!body || typeof body.getReader !== "function") {
-    const fallback = Buffer.from(await response.arrayBuffer());
-    if (fallback.length > maxBytes) {
-      return {
-        buffer: fallback.subarray(0, maxBytes),
-        size: fallback.length,
-        truncated: true,
-      };
-    }
-    return { buffer: fallback, size: fallback.length, truncated: false };
+    return { buffer: Buffer.alloc(0), size: 0, truncated: false };
   }
 
   const reader = body.getReader();
@@ -227,11 +220,11 @@ async function readResponsePrefix(
         continue;
       }
       const nextTotal = total + value.length;
-      if (nextTotal > maxBytes) {
+      if (nextTotal > maxBytes || (options?.cancelAtMaxBytes && nextTotal >= maxBytes)) {
         const remaining = maxBytes - total;
         if (remaining > 0) {
           chunks.push(value.subarray(0, remaining));
-          total += remaining;
+          total += Math.min(value.length, remaining);
         }
         size = nextTotal;
         truncated = true;
@@ -299,6 +292,7 @@ export async function readResponseTextSnippet(
   const prefix = await readResponsePrefix(response, maxBytes, {
     chunkTimeoutMs: options?.chunkTimeoutMs,
     onIdleTimeout: options?.onIdleTimeout,
+    cancelAtMaxBytes: true,
   });
   if (prefix.buffer.length === 0) {
     return undefined;

--- a/src/infra/http-body.ts
+++ b/src/infra/http-body.ts
@@ -187,6 +187,24 @@ function validateMaxBytes(maxBytes: number): void {
   }
 }
 
+async function readBufferedResponsePrefix(
+  res: Response,
+  maxBytes: number,
+): Promise<ReadResponsePrefixResult> {
+  const fallback = Buffer.from(
+    await // boundary-safety-ignore boundary/response-body-limit: no stream exists; enforce maxBytes after fallback.
+    res.arrayBuffer(),
+  );
+  if (fallback.length > maxBytes) {
+    return {
+      buffer: fallback.subarray(0, maxBytes),
+      size: fallback.length,
+      truncated: true,
+    };
+  }
+  return { buffer: fallback, size: fallback.length, truncated: false };
+}
+
 async function readResponsePrefix(
   response: Response,
   maxBytes: number,
@@ -199,7 +217,7 @@ async function readResponsePrefix(
   validateMaxBytes(maxBytes);
   const body = response.body;
   if (!body || typeof body.getReader !== "function") {
-    return { buffer: Buffer.alloc(0), size: 0, truncated: false };
+    return await readBufferedResponsePrefix(response, maxBytes);
   }
 
   const reader = body.getReader();

--- a/src/infra/http-error-body.ts
+++ b/src/infra/http-error-body.ts
@@ -1,60 +1,16 @@
+import { readResponseTextSnippet } from "./http-body.js";
+
 export async function readResponseBodySnippet(
   response: Response,
   limits: { maxBytes: number; maxChars: number },
 ): Promise<string> {
   try {
-    const body = response.body;
-    if (!body || typeof body.getReader !== "function") {
-      const text = await response.text();
-      const encoded = new TextEncoder().encode(text);
-      if (encoded.byteLength > limits.maxBytes) {
-        return new TextDecoder()
-          .decode(encoded.subarray(0, limits.maxBytes), {
-            stream: true,
-          })
-          .slice(0, limits.maxChars);
-      }
-      return text.slice(0, limits.maxChars);
-    }
-
-    const reader = body.getReader();
-    const chunks: Uint8Array[] = [];
-    let total = 0;
-    let truncated = false;
-    try {
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done || !value?.byteLength) {
-          break;
-        }
-        const remaining = limits.maxBytes - total;
-        if (remaining <= 0) {
-          truncated = true;
-          break;
-        }
-        if (value.byteLength > remaining) {
-          chunks.push(value.subarray(0, remaining));
-          total += remaining;
-          truncated = true;
-          break;
-        }
-        chunks.push(value);
-        total += value.byteLength;
-        if (total >= limits.maxBytes) {
-          truncated = true;
-          break;
-        }
-      }
-    } finally {
-      if (truncated) {
-        await reader.cancel().catch(() => undefined);
-      }
-      try {
-        reader.releaseLock();
-      } catch {}
-    }
-
-    return new TextDecoder().decode(Buffer.concat(chunks, total)).slice(0, limits.maxChars);
+    return (
+      (await readResponseTextSnippet(response, {
+        maxBytes: limits.maxBytes,
+        maxChars: limits.maxChars,
+      })) ?? ""
+    );
   } catch {
     return "";
   }

--- a/src/infra/http-error-body.ts
+++ b/src/infra/http-error-body.ts
@@ -1,15 +1,62 @@
-import { readResponseTextSnippet } from "./http-body.js";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 
 export async function readResponseBodySnippet(
   response: Response,
   limits: { maxBytes: number; maxChars: number },
 ): Promise<string> {
   try {
-    return (
-      (await readResponseTextSnippet(response, {
-        maxBytes: limits.maxBytes,
-        maxChars: limits.maxChars,
-      })) ?? ""
+    const body = response.body;
+    if (!body || typeof body.getReader !== "function") {
+      const text =
+        await /* boundary-safety-ignore boundary/response-body-limit: no stream exists; enforce maxBytes after fallback. */ response.text();
+      const encoded = new TextEncoder().encode(text);
+      const byteLimitedText =
+        encoded.byteLength > limits.maxBytes
+          ? new TextDecoder().decode(encoded.subarray(0, limits.maxBytes), { stream: true })
+          : text;
+      return truncateUtf16Safe(byteLimitedText, limits.maxChars);
+    }
+
+    const reader = body.getReader();
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    let truncated = false;
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done || !value?.byteLength) {
+          break;
+        }
+        const remaining = limits.maxBytes - total;
+        if (remaining <= 0) {
+          truncated = true;
+          break;
+        }
+        if (value.byteLength > remaining) {
+          chunks.push(value.subarray(0, remaining));
+          total += remaining;
+          truncated = true;
+          break;
+        }
+        chunks.push(value);
+        total += value.byteLength;
+        if (total >= limits.maxBytes) {
+          truncated = true;
+          break;
+        }
+      }
+    } finally {
+      if (truncated) {
+        await reader.cancel().catch(() => undefined);
+      }
+      try {
+        reader.releaseLock();
+      } catch {}
+    }
+
+    return truncateUtf16Safe(
+      new TextDecoder().decode(Buffer.concat(chunks, total), { stream: true }),
+      limits.maxChars,
     );
   } catch {
     return "";

--- a/src/media-understanding/image.test.ts
+++ b/src/media-understanding/image.test.ts
@@ -150,11 +150,13 @@ describe("describeImageWithModel", () => {
     vi.stubEnv("OPENCLAW_BUNDLED_PLUGINS_DIR", path.join(process.cwd(), "extensions"));
     vi.stubGlobal("fetch", fetchMock);
     vi.clearAllMocks();
-    fetchMock.mockImplementation(async () =>
-      Response.json({
-        base_resp: { status_code: 0 },
-        content: "portal ok",
-      }),
+    fetchMock.mockImplementation(
+      async () =>
+        new Response(JSON.stringify({ base_resp: { status_code: 0 }, content: "portal ok" }), {
+          status: 200,
+          statusText: "OK",
+          headers: { "content-type": "application/json" },
+        }),
     );
     discoverModelsMock.mockReturnValue({
       find: vi.fn(() => ({

--- a/test/fixtures/boundary-safety-inventory.json
+++ b/test/fixtures/boundary-safety-inventory.json
@@ -1,21 +1,21 @@
 [
   {
     "file": "extensions/active-memory/index.ts",
-    "line": 2261,
+    "line": 2262,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "texts\n    .map((text) => text.trim())\n    .filter(Boolean)\n    .join(\"\\n\")\n    .slice(0, resolvedLimits.maxChars)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "extensions/active-memory/index.ts",
-    "line": 2641,
+    "line": 2643,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "turn.text.trim().replace(/\\s+/g, \" \").slice(0, params.config.recentUserChars)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "extensions/active-memory/index.ts",
-    "line": 2651,
+    "line": 2653,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "turn.text.trim().replace(/\\s+/g, \" \").slice(0, params.config.recentAssistantChars)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
@@ -23,20 +23,6 @@
   {
     "file": "extensions/amazon-bedrock-mantle/discovery.ts",
     "line": 305,
-    "ruleId": "boundary/response-body-limit",
-    "match": "response.json()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
-  },
-  {
-    "file": "extensions/browser/src/browser/cdp.helpers.ts",
-    "line": 309,
-    "ruleId": "boundary/response-body-limit",
-    "match": "response.json()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
-  },
-  {
-    "file": "extensions/browser/src/browser/chrome.diagnostics.ts",
-    "line": 113,
     "ruleId": "boundary/response-body-limit",
     "match": "response.json()",
     "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
@@ -50,14 +36,7 @@
   },
   {
     "file": "extensions/browser/src/browser/client-fetch.ts",
-    "line": 270,
-    "ruleId": "boundary/response-body-limit",
-    "match": "res.text()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
-  },
-  {
-    "file": "extensions/browser/src/browser/client-fetch.ts",
-    "line": 273,
+    "line": 280,
     "ruleId": "boundary/response-body-limit",
     "match": "res.json()",
     "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
@@ -120,28 +99,28 @@
   },
   {
     "file": "extensions/codex/src/app-server/dynamic-tools.ts",
-    "line": 1316,
+    "line": 1323,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "noticeText.slice(0, maxChars)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "extensions/codex/src/app-server/dynamic-tools.ts",
-    "line": 1323,
+    "line": 1330,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "item.text.slice(0, sliceLength)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "extensions/codex/src/app-server/dynamic-tools.ts",
-    "line": 1333,
+    "line": 1340,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "noticeText.slice(0, maxChars)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "extensions/codex/src/app-server/event-projector.ts",
-    "line": 2579,
+    "line": 2753,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "text.slice(0, TOOL_TRANSCRIPT_OUTPUT_MAX_CHARS)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
@@ -211,7 +190,7 @@
   },
   {
     "file": "extensions/discord/src/monitor/thread-title.ts",
-    "line": 134,
+    "line": 135,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "sourceText.slice(0, MAX_THREAD_TITLE_SOURCE_CHARS)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
@@ -225,7 +204,7 @@
   },
   {
     "file": "extensions/feishu/src/app-registration.ts",
-    "line": 112,
+    "line": 113,
     "ruleId": "boundary/response-body-limit",
     "match": "response.json()",
     "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
@@ -240,41 +219,6 @@
   {
     "file": "extensions/feishu/src/streaming-card.ts",
     "line": 120,
-    "ruleId": "boundary/response-body-limit",
-    "match": "response.json()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
-  },
-  {
-    "file": "extensions/google-meet/src/calendar.ts",
-    "line": 200,
-    "ruleId": "boundary/response-body-limit",
-    "match": "response.json()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
-  },
-  {
-    "file": "extensions/google-meet/src/meet.ts",
-    "line": 292,
-    "ruleId": "boundary/response-body-limit",
-    "match": "response.json()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
-  },
-  {
-    "file": "extensions/google-meet/src/meet.ts",
-    "line": 357,
-    "ruleId": "boundary/response-body-limit",
-    "match": "response.json()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
-  },
-  {
-    "file": "extensions/google-meet/src/meet.ts",
-    "line": 400,
-    "ruleId": "boundary/response-body-limit",
-    "match": "response.json()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
-  },
-  {
-    "file": "extensions/google-meet/src/oauth.ts",
-    "line": 92,
     "ruleId": "boundary/response-body-limit",
     "match": "response.json()",
     "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
@@ -323,14 +267,7 @@
   },
   {
     "file": "extensions/google/oauth.token.ts",
-    "line": 30,
-    "ruleId": "boundary/response-body-limit",
-    "match": "response.text()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
-  },
-  {
-    "file": "extensions/google/oauth.token.ts",
-    "line": 34,
+    "line": 39,
     "ruleId": "boundary/response-body-limit",
     "match": "response.json()",
     "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
@@ -357,38 +294,10 @@
     "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
   },
   {
-    "file": "extensions/line/src/auto-reply-delivery.ts",
-    "line": 106,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "lineData.flexMessage.altText.slice(0, 400)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "extensions/line/src/auto-reply-delivery.ts",
-    "line": 128,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "flexMsg.altText.slice(0, 400)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
     "file": "extensions/line/src/bot-message-context.ts",
-    "line": 386,
+    "line": 390,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "body.slice(0, 200)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "extensions/line/src/outbound.ts",
-    "line": 247,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "lineData.flexMessage.altText.slice(0, 400)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "extensions/line/src/outbound.ts",
-    "line": 260,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "lineData.location.title.slice(0, 100)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
@@ -396,13 +305,6 @@
     "line": 5,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "normalizeStringEntries(labels ?? []).slice(0, 13)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "extensions/line/src/send.ts",
-    "line": 165,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "location.title.slice(0, 100)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
@@ -421,14 +323,14 @@
   },
   {
     "file": "extensions/matrix/src/matrix/monitor/handler.ts",
-    "line": 459,
+    "line": 437,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "text.slice(0, MATRIX_TOOL_PROGRESS_MAX_CHARS - 1)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "extensions/matrix/src/matrix/monitor/handler.ts",
-    "line": 1695,
+    "line": 1659,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "bodyText.slice(0, 200)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
@@ -448,36 +350,15 @@
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
-    "file": "extensions/matrix/src/matrix/sdk/transport.ts",
-    "line": 386,
-    "ruleId": "boundary/response-body-limit",
-    "match": "response.arrayBuffer()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
-  },
-  {
-    "file": "extensions/mattermost/src/mattermost/client.ts",
-    "line": 110,
-    "ruleId": "boundary/response-body-limit",
-    "match": "res.json()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
-  },
-  {
-    "file": "extensions/mattermost/src/mattermost/client.ts",
-    "line": 116,
-    "ruleId": "boundary/response-body-limit",
-    "match": "res.text()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
-  },
-  {
     "file": "extensions/mattermost/src/mattermost/monitor.ts",
-    "line": 1669,
+    "line": 1680,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "bodyText.slice(0, 200)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "extensions/memory-core/doctor-contract-api.ts",
-    "line": 709,
+    "line": 713,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "entry.name.slice(0, -\".sqlite\".length)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
@@ -519,21 +400,21 @@
   },
   {
     "file": "extensions/memory-core/src/short-term-promotion.ts",
-    "line": 352,
+    "line": 362,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "snippet.slice(0, SHORT_TERM_RECALL_MAX_SNIPPET_CHARS)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "extensions/memory-core/src/short-term-promotion.ts",
-    "line": 2085,
+    "line": 2078,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "targetSnippet.slice(0, bodyIndex)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "extensions/memory-core/src/short-term-promotion.ts",
-    "line": 2355,
+    "line": 2354,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "snippet.slice(0, limit)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
@@ -547,21 +428,21 @@
   },
   {
     "file": "extensions/memory-lancedb/index.ts",
-    "line": 1190,
+    "line": 1171,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "text.slice(0, MAX_SANITIZE_CHARS)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "extensions/memory-lancedb/index.ts",
-    "line": 1680,
+    "line": 1661,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "text.slice(0, 100)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "extensions/memory-lancedb/index.ts",
-    "line": 1731,
+    "line": 1712,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "r.entry.text.slice(0, 60)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
@@ -582,7 +463,7 @@
   },
   {
     "file": "extensions/msteams/doctor-contract-api.ts",
-    "line": 251,
+    "line": 242,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "entry.name.slice(0, -suffix.length)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
@@ -658,13 +539,6 @@
     "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
   },
   {
-    "file": "extensions/openai/embedding-batch.ts",
-    "line": 114,
-    "ruleId": "boundary/response-body-limit",
-    "match": "res.text()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
-  },
-  {
     "file": "extensions/openai/image-generation-provider.ts",
     "line": 505,
     "ruleId": "boundary/response-body-limit",
@@ -715,7 +589,7 @@
   },
   {
     "file": "extensions/openrouter/oauth.ts",
-    "line": 78,
+    "line": 75,
     "ruleId": "boundary/response-body-limit",
     "match": "response.text()",
     "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
@@ -728,13 +602,6 @@
     "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
   },
   {
-    "file": "extensions/qa-lab/src/live-transports/shared/credential-lease.runtime.ts",
-    "line": 299,
-    "ruleId": "boundary/response-body-limit",
-    "match": "response.text()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
-  },
-  {
     "file": "extensions/qa-lab/src/live-transports/telegram/telegram-live.runtime.ts",
     "line": 943,
     "ruleId": "boundary/response-body-limit",
@@ -743,7 +610,7 @@
   },
   {
     "file": "extensions/qa-lab/src/providers/mock-openai/server.ts",
-    "line": 1646,
+    "line": 1672,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "toolOutput.replace(/\\s+/g, \" \").trim().slice(0, 220)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
@@ -758,13 +625,6 @@
   {
     "file": "extensions/qa-lab/src/runtime-parity.ts",
     "line": 995,
-    "ruleId": "boundary/response-body-limit",
-    "match": "response.json()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
-  },
-  {
-    "file": "extensions/qa-lab/src/suite-runtime-gateway.ts",
-    "line": 27,
     "ruleId": "boundary/response-body-limit",
     "match": "response.json()",
     "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
@@ -883,56 +743,56 @@
   },
   {
     "file": "extensions/qa-matrix/src/runners/contract/scenario-runtime-room.ts",
-    "line": 998,
+    "line": 1006,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "progressAfterFinal.event.body?.slice(0, 200)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "extensions/qa-matrix/src/runners/contract/scenario-runtime-room.ts",
-    "line": 1000,
+    "line": 1008,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "progressAfterFinal.event.formattedBody?.slice(0, 200)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "extensions/qa-matrix/src/runners/contract/scenario-runtime-room.ts",
-    "line": 1152,
+    "line": 1170,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "progress.event.body?.slice(0, 200)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "extensions/qa-matrix/src/runners/contract/scenario-runtime-room.ts",
-    "line": 1154,
+    "line": 1172,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "progress.event.formattedBody?.slice(0, 200)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "extensions/qa-matrix/src/runners/contract/scenario-runtime-shared.ts",
-    "line": 189,
+    "line": 192,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "replyBody?.slice(0, 200)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "extensions/qa-matrix/src/runners/contract/scenario-runtime-shared.ts",
-    "line": 200,
+    "line": 203,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "event.body?.trim().slice(0, 200)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "extensions/qqbot/src/engine/api/media-chunked.ts",
-    "line": 603,
+    "line": 604,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "lastError.message.slice(0, 120)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "extensions/qqbot/src/engine/api/retry.ts",
-    "line": 90,
+    "line": 91,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "lastError.message.slice(0, 100)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
@@ -946,28 +806,35 @@
   },
   {
     "file": "extensions/qqbot/src/engine/gateway/outbound-dispatch.ts",
-    "line": 231,
+    "line": 243,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "toolTexts.slice(-3).join(\"\\n---\\n\").slice(0, 2000)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "extensions/qqbot/src/engine/messaging/reply-dispatcher.ts",
-    "line": 252,
+    "line": 284,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "value\n    .replace(/[\\r\\n\\t]/g, \" \")\n    .replaceAll(\"\\0\", \" \")\n    .slice(0, maxLen)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "extensions/qqbot/src/engine/messaging/reply-dispatcher.ts",
-    "line": 419,
+    "line": 516,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "ttsText.slice(0, 50)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
+    "file": "extensions/slack/src/monitor/context.ts",
+    "line": 462,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "p.loadingMessages.slice(0, 10)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
     "file": "extensions/slack/src/monitor/events/interactions.block-actions.ts",
-    "line": 308,
+    "line": 309,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "params.summary.selectedLabels.slice(0, 3)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
@@ -981,56 +848,49 @@
   },
   {
     "file": "extensions/slack/src/monitor/message-handler/prepare-thread-context.ts",
-    "line": 232,
+    "line": 227,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "starter.text.replace(/\\s+/g, \" \").slice(0, 80)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "extensions/slack/src/monitor/message-handler/prepare.ts",
-    "line": 1129,
+    "line": 1163,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "rawBody.replace(/\\s+/g, \" \").slice(0, 160)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
-    "file": "extensions/slack/src/monitor/slash.ts",
-    "line": 934,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "choice.label.slice(0, 75)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
     "file": "extensions/telegram/src/bot-message-context.session.ts",
-    "line": 676,
+    "line": 686,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "(visibleReplyTarget.body ?? \"\").replace(/\\s+/g, \" \").slice(0, 120)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "extensions/telegram/src/bot-message-context.session.ts",
-    "line": 689,
+    "line": 699,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "body.slice(0, 200)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "extensions/telegram/src/draft-stream.ts",
-    "line": 161,
+    "line": 201,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "text.slice(0, mid)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "extensions/telegram/src/draft-stream.ts",
-    "line": 373,
+    "line": 463,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "currentText.slice(0, chunkLength)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "extensions/telegram/src/draft-stream.ts",
-    "line": 396,
+    "line": 486,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "currentText.slice(0, chunkLength)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
@@ -1040,13 +900,6 @@
     "line": 192,
     "ruleId": "boundary/response-body-limit",
     "match": "resp.json()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
-  },
-  {
-    "file": "extensions/tlon/src/channel.runtime.ts",
-    "line": 79,
-    "ruleId": "boundary/response-body-limit",
-    "match": "response.text()",
     "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
   },
   {
@@ -1065,23 +918,9 @@
   },
   {
     "file": "extensions/tlon/src/urbit/channel-ops.ts",
-    "line": 60,
-    "ruleId": "boundary/response-body-limit",
-    "match": "response.text()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
-  },
-  {
-    "file": "extensions/tlon/src/urbit/channel-ops.ts",
-    "line": 93,
+    "line": 96,
     "ruleId": "boundary/response-body-limit",
     "match": "response.json()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
-  },
-  {
-    "file": "extensions/tlon/src/urbit/sse-client.ts",
-    "line": 156,
-    "ruleId": "boundary/response-body-limit",
-    "match": "response.text()",
     "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
   },
   {
@@ -1129,6 +968,20 @@
   {
     "file": "packages/agent-core/src/harness/compaction/utils.ts",
     "line": 109,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "text.slice(0, maxChars)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "packages/ai/src/providers/mistral.ts",
+    "line": 265,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "shortHash(seed)\n    .replace(/[^a-zA-Z0-9]/g, \"\")\n    .slice(0, MISTRAL_TOOL_CALL_ID_LENGTH)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "packages/ai/src/providers/mistral.ts",
+    "line": 290,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "text.slice(0, maxChars)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
@@ -1219,23 +1072,30 @@
   },
   {
     "file": "src/agents/cli-runner/session-history.ts",
-    "line": 209,
+    "line": 217,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "renderedSummary.slice(0, summaryBudget)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "src/agents/command/attempt-execution.helpers.ts",
-    "line": 401,
+    "line": 405,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "seed.summaryText.slice(0, Math.max(0, remaining - 64))",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "src/agents/embedded-agent-error-observation.ts",
-    "line": 102,
+    "line": 103,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "params.message.slice(0, MAX_FINGERPRINT_MESSAGE_CHARS)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/agents/embedded-agent-runner/run/runtime-context-prompt.ts",
+    "line": 109,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "params.text.slice(0, occurrenceIndex)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
@@ -1254,28 +1114,28 @@
   },
   {
     "file": "src/agents/embedded-agent-runner/tool-result-truncation.ts",
-    "line": 104,
+    "line": 142,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "finalText.slice(0, params.maxChars)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "src/agents/embedded-agent-runner/tool-result-truncation.ts",
-    "line": 107,
+    "line": 145,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "keptText.slice(0, Math.max(0, keptText.length - overflow))",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "src/agents/embedded-agent-subscribe.handlers.messages.ts",
-    "line": 1237,
+    "line": 1306,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "text.slice(0, 50)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "src/agents/embedded-agent-subscribe.handlers.tools.ts",
-    "line": 842,
+    "line": 844,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "rawArgsPreview?.slice(0, TOOL_START_WARNING_RAW_PREVIEW_MAX_CHARS)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
@@ -1289,14 +1149,14 @@
   },
   {
     "file": "src/agents/mcp-http-fetch.ts",
-    "line": 69,
+    "line": 65,
     "ruleId": "boundary/response-body-limit",
     "match": "response.text()",
     "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
   },
   {
     "file": "src/agents/openai-transport-stream.ts",
-    "line": 400,
+    "line": 404,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "names.slice(0, maxNames)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
@@ -1373,35 +1233,35 @@
   },
   {
     "file": "src/auto-reply/reply/conversation-label-generator.ts",
-    "line": 112,
+    "line": 117,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "text.slice(0, maxLength)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "src/auto-reply/reply/get-reply-directives.ts",
-    "line": 387,
+    "line": 389,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "existingBody.slice(0, markerIndex + CURRENT_MESSAGE_MARKER.length)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "src/auto-reply/reply/queue/drain.ts",
-    "line": 359,
+    "line": 541,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "params.queue.summaryLines.slice(0, sources.length)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "src/auto-reply/reply/queue/drain.ts",
-    "line": 610,
+    "line": 933,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "params.queue.summaryLines.slice(0, retainedSources.length)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "src/auto-reply/reply/startup-context.ts",
-    "line": 283,
+    "line": 276,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "newestSluggedNames.slice(0, STARTUP_MEMORY_MAX_SLUGGED_FILES_PER_DAY)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
@@ -1435,6 +1295,13 @@
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
+    "file": "src/commands/onboard-skills.ts",
+    "line": 74,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "names.slice(0, SKIPPED_INSTALL_NAME_LIMIT)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
     "file": "src/commands/status-all/report-lines.ts",
     "line": 91,
     "ruleId": "boundary/text-utf16-truncation",
@@ -1457,9 +1324,16 @@
   },
   {
     "file": "src/config/sessions/store.ts",
-    "line": 1511,
+    "line": 1551,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "entry.name.slice(0, -\".jsonl\".length)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/crestodian/assistant-prompts.ts",
+    "line": 110,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "turn.text.slice(0, HISTORY_TURN_MAX_CHARS)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
@@ -1467,6 +1341,13 @@
     "line": 60,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "text.slice(0, maxChars)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/gateway/dashboard-session-title.ts",
+    "line": 83,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "sourceText.slice(0, DASHBOARD_SESSION_TITLE_SOURCE_MAX_CHARS)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
@@ -1485,21 +1366,21 @@
   },
   {
     "file": "src/gateway/server-reload-handlers.ts",
-    "line": 247,
+    "line": 268,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "task.title.slice(0, 80)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "src/gateway/session-utils.fs.ts",
-    "line": 1830,
+    "line": 1923,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "text.slice(0, maxChars)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "src/gateway/session-utils.fs.ts",
-    "line": 1832,
+    "line": 1925,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "text.slice(0, maxChars - 3)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
@@ -1519,13 +1400,6 @@
     "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
   },
   {
-    "file": "src/infra/exec-approval-command-display.ts",
-    "line": 61,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "text.slice(0, EXEC_APPROVAL_MAX_OUTPUT)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
     "file": "src/infra/heartbeat-events-filter.ts",
     "line": 127,
     "ruleId": "boundary/text-utf16-truncation",
@@ -1534,42 +1408,42 @@
   },
   {
     "file": "src/infra/heartbeat-runner.ts",
-    "line": 1984,
+    "line": 1985,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "heartbeatToolResponse.summary.slice(0, 200)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "src/infra/heartbeat-runner.ts",
-    "line": 2134,
+    "line": 2135,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "normalized.text.slice(0, 200)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "src/infra/heartbeat-runner.ts",
-    "line": 2163,
+    "line": 2164,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "previewText?.slice(0, 200)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "src/infra/heartbeat-runner.ts",
-    "line": 2183,
+    "line": 2184,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "previewText?.slice(0, 200)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "src/infra/heartbeat-runner.ts",
-    "line": 2206,
+    "line": 2207,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "previewText?.slice(0, 200)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "src/infra/heartbeat-runner.ts",
-    "line": 2288,
+    "line": 2290,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "previewText?.slice(0, 200)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
@@ -1597,30 +1471,9 @@
   },
   {
     "file": "src/infra/session-cost-usage.ts",
-    "line": 2147,
+    "line": 2159,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "text.slice(0, 100)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "src/infra/update-check.ts",
-    "line": 128,
-    "ruleId": "boundary/response-body-limit",
-    "match": "res.json()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
-  },
-  {
-    "file": "src/llm/providers/mistral.ts",
-    "line": 265,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "shortHash(seed)\n    .replace(/[^a-zA-Z0-9]/g, \"\")\n    .slice(0, MISTRAL_TOOL_CALL_ID_LENGTH)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "src/llm/providers/mistral.ts",
-    "line": 290,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "text.slice(0, maxChars)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
@@ -1681,7 +1534,7 @@
   },
   {
     "file": "src/plugins/official-external-plugin-catalog.ts",
-    "line": 556,
+    "line": 562,
     "ruleId": "boundary/response-body-limit",
     "match": "params.response.text()",
     "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
@@ -1702,21 +1555,21 @@
   },
   {
     "file": "src/plugins/sdk-alias.ts",
-    "line": 1205,
+    "line": 1238,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "fileName.slice(0, -ext.length)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "src/plugins/sdk-alias.ts",
-    "line": 1513,
+    "line": 1546,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "entry.name.slice(0, -\".js\".length)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "src/sessions/input-provenance.ts",
-    "line": 143,
+    "line": 142,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "text.slice(0, index)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
@@ -1758,7 +1611,7 @@
   },
   {
     "file": "src/status/status-plugin-health.ts",
-    "line": 375,
+    "line": 377,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "contextEngineQuarantines.slice(0, 8)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."

--- a/test/fixtures/boundary-safety-inventory.json
+++ b/test/fixtures/boundary-safety-inventory.json
@@ -78,21 +78,21 @@
   },
   {
     "file": "extensions/codex/src/app-server/approval-bridge.ts",
-    "line": 1588,
+    "line": 1587,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "value.slice(0, Math.max(0, maxLength - 3))",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "extensions/codex/src/app-server/attempt-notifications.ts",
-    "line": 332,
+    "line": 320,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "text.slice(0, 237)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "extensions/codex/src/app-server/client.ts",
-    "line": 743,
+    "line": 731,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "redacted.slice(0, CODEX_APP_SERVER_PARSE_LOG_MAX)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
@@ -141,7 +141,7 @@
   },
   {
     "file": "extensions/codex/src/app-server/event-projector.ts",
-    "line": 3135,
+    "line": 3069,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "text.slice(0, TOOL_TRANSCRIPT_OUTPUT_MAX_CHARS)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
@@ -155,23 +155,16 @@
   },
   {
     "file": "extensions/codex/src/command-handlers.ts",
-    "line": 1893,
+    "line": 2054,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "formatCodexTextForDisplay(error).slice(0, CODEX_DIAGNOSTICS_ERROR_MAX_CHARS)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "extensions/diagnostics-otel/src/service.ts",
-    "line": 679,
+    "line": 685,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "value.slice(0, maxChars)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "extensions/discord/src/error-body.ts",
-    "line": 21,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "summary.slice(0, DISCORD_RESPONSE_BODY_SUMMARY_MAX_CHARS)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
@@ -214,13 +207,6 @@
     "line": 204,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "singleLine.slice(0, maxChars)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "extensions/feishu/src/monitor.transport.ts",
-    "line": 154,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "redacted.slice(0, FEISHU_WS_LOG_ERROR_MAX_LENGTH)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
@@ -483,13 +469,6 @@
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
-    "file": "extensions/qa-lab/src/qa-credentials-admin.runtime.ts",
-    "line": 395,
-    "ruleId": "boundary/response-body-limit",
-    "match": "response.text()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
-  },
-  {
     "file": "extensions/qa-lab/src/runtime-parity.ts",
     "line": 995,
     "ruleId": "boundary/response-body-limit",
@@ -588,20 +567,6 @@
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
-    "file": "extensions/qqbot/src/engine/messaging/reply-dispatcher.ts",
-    "line": 284,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "value\n    .replace(/[\\r\\n\\t]/g, \" \")\n    .replaceAll(\"\\0\", \" \")\n    .slice(0, maxLen)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "extensions/qqbot/src/engine/messaging/reply-dispatcher.ts",
-    "line": 516,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "ttsText.slice(0, 50)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
     "file": "extensions/qqbot/src/engine/utils/log.ts",
     "line": 51,
     "ruleId": "boundary/text-utf16-truncation",
@@ -627,13 +592,6 @@
     "line": 486,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "currentText.slice(0, chunkLength)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "extensions/telegram/src/raw-update-log.ts",
-    "line": 83,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "value.slice(0, MAX_RAW_UPDATE_STRING)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
@@ -665,24 +623,10 @@
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
-    "file": "extensions/voice-call/src/media-stream.ts",
-    "line": 112,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "sanitized.slice(0, maxChars)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
     "file": "extensions/voice-call/src/realtime-agent-context.ts",
     "line": 25,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "text.slice(0, Math.max(0, maxChars - 32))",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "extensions/voice-call/src/webhook.ts",
-    "line": 82,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "sanitized.slice(0, TRANSCRIPT_LOG_MAX_CHARS)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
@@ -736,7 +680,7 @@
   },
   {
     "file": "packages/markdown-core/src/ir.ts",
-    "line": 1109,
+    "line": 1111,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "state.text.slice(0, finalLength)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
@@ -746,27 +690,6 @@
     "line": 51,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "text.slice(0, maxChars)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "packages/speech-core/src/tts.ts",
-    "line": 2031,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "textForAudio.slice(0, maxLength - 3)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "packages/speech-core/src/tts.ts",
-    "line": 2047,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "textForAudio.slice(0, config.maxTextLength - 3)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "packages/speech-core/src/tts.ts",
-    "line": 2052,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "textForAudio.slice(0, maxLength - 3)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
@@ -889,20 +812,6 @@
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
-    "file": "src/agents/embedded-agent-runner/run/attempt.prompt-helpers.ts",
-    "line": 340,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "trimmed.slice(0, MAX_STRUCTURED_MEDIA_REF_CHARS)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "src/agents/embedded-agent-runner/run/attempt.prompt-helpers.ts",
-    "line": 352,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "trimmed.slice(0, MAX_STRUCTURED_JSON_STRING_CHARS)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
     "file": "src/agents/embedded-agent-runner/tool-result-truncation.ts",
     "line": 142,
     "ruleId": "boundary/text-utf16-truncation",
@@ -953,7 +862,7 @@
   },
   {
     "file": "src/agents/openai-transport-stream.ts",
-    "line": 408,
+    "line": 410,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "names.slice(0, maxNames)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
@@ -1373,7 +1282,7 @@
   },
   {
     "file": "src/infra/session-cost-usage.ts",
-    "line": 2739,
+    "line": 2755,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "content.slice(0, maxLen)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
@@ -1492,14 +1401,14 @@
   },
   {
     "file": "src/skills/loading/workspace.ts",
-    "line": 1392,
+    "line": 1410,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "skillsForPrompt.slice(0, mid)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "src/skills/loading/workspace.ts",
-    "line": 1398,
+    "line": 1416,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "skillsForPrompt.slice(0, lo)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
@@ -1533,15 +1442,8 @@
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
-    "file": "src/tts/status-config.ts",
-    "line": 117,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "normalized.slice(0, maxLength - 3)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
     "file": "src/tui/tui-event-handlers.ts",
-    "line": 55,
+    "line": 56,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "diagnostic.slice(0, MAX_ABORT_DIAGNOSTIC_LENGTH - 1)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."

--- a/test/fixtures/boundary-safety-inventory.json
+++ b/test/fixtures/boundary-safety-inventory.json
@@ -21,15 +21,8 @@
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
-    "file": "extensions/amazon-bedrock-mantle/discovery.ts",
-    "line": 305,
-    "ruleId": "boundary/response-body-limit",
-    "match": "response.json()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
-  },
-  {
     "file": "extensions/browser/src/browser/chrome.ts",
-    "line": 1092,
+    "line": 1111,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "redactedStderrOutput.slice(0, CHROME_STDERR_HINT_MAX_CHARS)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
@@ -57,7 +50,7 @@
   },
   {
     "file": "extensions/browser/src/browser/pw-tools-core.snapshot.ts",
-    "line": 77,
+    "line": 81,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "(anchor.textContent || anchor.getAttribute(\"aria-label\") || \"\")\n            .replace(/\\s+/g, \" \")\n            .trim()\n            .slice(0, 121)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
@@ -99,21 +92,21 @@
   },
   {
     "file": "extensions/codex/src/app-server/dynamic-tools.ts",
-    "line": 1323,
+    "line": 1324,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "noticeText.slice(0, maxChars)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "extensions/codex/src/app-server/dynamic-tools.ts",
-    "line": 1330,
+    "line": 1331,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "item.text.slice(0, sliceLength)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "extensions/codex/src/app-server/dynamic-tools.ts",
-    "line": 1340,
+    "line": 1341,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "noticeText.slice(0, maxChars)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
@@ -137,13 +130,6 @@
     "line": 231,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "redactSensitiveText(message)\n    .replaceAll(\"\\u0000\", \" \")\n    .replace(/[\\r\\n\\t\\u2028\\u2029]/gu, \" \")\n    .slice(0, 500)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "extensions/discord/src/approval-handler.runtime.ts",
-    "line": 164,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "commandText.slice(0, maxChars)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
@@ -273,13 +259,6 @@
     "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
   },
   {
-    "file": "extensions/google/vertex-adc.ts",
-    "line": 280,
-    "ruleId": "boundary/response-body-limit",
-    "match": "response.arrayBuffer()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
-  },
-  {
     "file": "extensions/googlechat/src/api.ts",
     "line": 125,
     "ruleId": "boundary/response-body-limit",
@@ -357,6 +336,13 @@
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
+    "file": "extensions/mattermost/src/mattermost/slash-commands.ts",
+    "line": 26,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "description.slice(0, end)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
     "file": "extensions/memory-core/doctor-contract-api.ts",
     "line": 713,
     "ruleId": "boundary/text-utf16-truncation",
@@ -393,7 +379,7 @@
   },
   {
     "file": "extensions/memory-core/src/memory/qmd-manager.ts",
-    "line": 3515,
+    "line": 3529,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "snippet.slice(0, Math.max(0, remaining))",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
@@ -582,7 +568,7 @@
   },
   {
     "file": "extensions/openrouter/index.ts",
-    "line": 101,
+    "line": 102,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "Array.from(value)\n    .filter((char) => {\n      const codePoint = char.codePointAt(0) ?? 0;\n      return (\n        codePoint > 0x1f &&\n        (codePoint < 0x7f || codePoint > 0x9f) &&\n        codePoint !== 0x2028 &&\n        codePoint !== 0x2029\n      );\n    })\n    .join(\"\")\n    .trim()\n    .slice(0, MAX_PROMPT_MODEL_ID_DISPLAY_CHARS)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
@@ -610,7 +596,7 @@
   },
   {
     "file": "extensions/qa-lab/src/providers/mock-openai/server.ts",
-    "line": 1672,
+    "line": 1640,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "toolOutput.replace(/\\s+/g, \" \").trim().slice(0, 220)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
@@ -855,7 +841,7 @@
   },
   {
     "file": "extensions/slack/src/monitor/message-handler/prepare.ts",
-    "line": 1163,
+    "line": 1168,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "rawBody.replace(/\\s+/g, \" \").slice(0, 160)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
@@ -914,13 +900,6 @@
     "line": 40,
     "ruleId": "boundary/response-body-limit",
     "match": "response.text()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
-  },
-  {
-    "file": "extensions/tlon/src/urbit/channel-ops.ts",
-    "line": 96,
-    "ruleId": "boundary/response-body-limit",
-    "match": "response.json()",
     "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
   },
   {
@@ -1128,14 +1107,14 @@
   },
   {
     "file": "src/agents/embedded-agent-subscribe.handlers.messages.ts",
-    "line": 1306,
+    "line": 1309,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "text.slice(0, 50)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "src/agents/embedded-agent-subscribe.handlers.tools.ts",
-    "line": 844,
+    "line": 871,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "rawArgsPreview?.slice(0, TOOL_START_WARNING_RAW_PREVIEW_MAX_CHARS)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
@@ -1146,13 +1125,6 @@
     "ruleId": "boundary/text-utf16-truncation",
     "match": "params.messagesSnapshot.slice(0, params.prePromptMessageCount)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "src/agents/mcp-http-fetch.ts",
-    "line": 65,
-    "ruleId": "boundary/response-body-limit",
-    "match": "response.text()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
   },
   {
     "file": "src/agents/openai-transport-stream.ts",
@@ -1205,14 +1177,14 @@
   },
   {
     "file": "src/auto-reply/reply/agent-runner-memory.ts",
-    "line": 359,
+    "line": 367,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "visibleText.slice(0, MAX_VISIBLE_MEMORY_FLUSH_ERROR_CHARS - 1)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "src/auto-reply/reply/agent-runner-memory.ts",
-    "line": 368,
+    "line": 376,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "message.slice(0, MAX_FLUSH_ERROR_LENGTH - 1)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
@@ -1247,14 +1219,14 @@
   },
   {
     "file": "src/auto-reply/reply/queue/drain.ts",
-    "line": 541,
+    "line": 545,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "params.queue.summaryLines.slice(0, sources.length)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "src/auto-reply/reply/queue/drain.ts",
-    "line": 933,
+    "line": 937,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "params.queue.summaryLines.slice(0, retainedSources.length)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
@@ -1268,9 +1240,16 @@
   },
   {
     "file": "src/cli/gateway-cli/run-loop.ts",
-    "line": 522,
+    "line": 542,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "task.title.slice(0, 80)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/cli/gateway-cli/run-loop.ts",
+    "line": 874,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "formatErrorMessage(err).slice(0, 500)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
@@ -1366,7 +1345,7 @@
   },
   {
     "file": "src/gateway/server-reload-handlers.ts",
-    "line": 268,
+    "line": 269,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "task.title.slice(0, 80)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
@@ -1471,7 +1450,7 @@
   },
   {
     "file": "src/infra/session-cost-usage.ts",
-    "line": 2159,
+    "line": 2156,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "text.slice(0, 100)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
@@ -1582,20 +1561,6 @@
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
-    "file": "src/skills/discovery/command-specs.ts",
-    "line": 134,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "rawDescription.slice(0, SKILL_COMMAND_DESCRIPTION_MAX_LENGTH - 1)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "src/skills/discovery/command-specs.ts",
-    "line": 206,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "entry.description.slice(0, SKILL_COMMAND_DESCRIPTION_MAX_LENGTH - 1)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
     "file": "src/skills/loading/workspace.ts",
     "line": 1392,
     "ruleId": "boundary/text-utf16-truncation",
@@ -1607,6 +1572,13 @@
     "line": 1398,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "skillsForPrompt.slice(0, lo)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/skills/workshop/policy.ts",
+    "line": 95,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "requestedSkillName.slice(0, Math.max(0, availableSkillNameLength - 1))",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {

--- a/test/fixtures/boundary-safety-inventory.json
+++ b/test/fixtures/boundary-safety-inventory.json
@@ -1,0 +1,1913 @@
+[
+  {
+    "file": "extensions/active-memory/index.ts",
+    "line": 2253,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "texts\n    .map((text) => text.trim())\n    .filter(Boolean)\n    .join(\"\\n\")\n    .slice(0, resolvedLimits.maxChars)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/active-memory/index.ts",
+    "line": 2628,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "turn.text.trim().replace(/\\s+/g, \" \").slice(0, params.config.recentUserChars)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/active-memory/index.ts",
+    "line": 2638,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "turn.text.trim().replace(/\\s+/g, \" \").slice(0, params.config.recentAssistantChars)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/amazon-bedrock-mantle/discovery.ts",
+    "line": 305,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.json()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/browser/src/browser/cdp.helpers.ts",
+    "line": 309,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.json()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/browser/src/browser/chrome.diagnostics.ts",
+    "line": 113,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.json()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/browser/src/browser/chrome.ts",
+    "line": 1092,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "redactedStderrOutput.slice(0, CHROME_STDERR_HINT_MAX_CHARS)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/browser/src/browser/client-fetch.ts",
+    "line": 270,
+    "ruleId": "boundary/response-body-limit",
+    "match": "res.text()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/browser/src/browser/client-fetch.ts",
+    "line": 273,
+    "ruleId": "boundary/response-body-limit",
+    "match": "res.json()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/browser/src/browser/pw-tools-core.responses.ts",
+    "line": 94,
+    "ruleId": "boundary/response-body-limit",
+    "match": "resp.text()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/browser/src/browser/pw-tools-core.responses.ts",
+    "line": 103,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "bodyText.slice(0, maxChars)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/browser/src/browser/pw-tools-core.snapshot.ts",
+    "line": 76,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "(anchor.textContent || anchor.getAttribute(\"aria-label\") || \"\")\n            .replace(/\\s+/g, \" \")\n            .trim()\n            .slice(0, 120)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/codex/src/app-server/app-inventory-cache.ts",
+    "line": 375,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "message.slice(0, htmlStart)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/codex/src/app-server/attempt-notifications.ts",
+    "line": 332,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "text.slice(0, 237)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/codex/src/app-server/context-engine-projection.ts",
+    "line": 151,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "params.promptText.slice(0, preservedRange.start)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/codex/src/app-server/context-engine-projection.ts",
+    "line": 155,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "params.promptText.slice(0, range.start)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/codex/src/app-server/context-engine-projection.ts",
+    "line": 489,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "text.slice(0, maxChars)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/codex/src/app-server/dynamic-tools.ts",
+    "line": 1316,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "noticeText.slice(0, maxChars)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/codex/src/app-server/dynamic-tools.ts",
+    "line": 1323,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "item.text.slice(0, sliceLength)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/codex/src/app-server/dynamic-tools.ts",
+    "line": 1333,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "noticeText.slice(0, maxChars)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/codex/src/app-server/event-projector.ts",
+    "line": 2579,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "text.slice(0, TOOL_TRANSCRIPT_OUTPUT_MAX_CHARS)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/codex/src/command-handlers.ts",
+    "line": 1873,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "formatCodexTextForDisplay(error).slice(0, CODEX_DIAGNOSTICS_ERROR_MAX_CHARS)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/diagnostics-prometheus/src/service.ts",
+    "line": 231,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "redactSensitiveText(message)\n    .replaceAll(\"\\u0000\", \" \")\n    .replace(/[\\r\\n\\t\\u2028\\u2029]/gu, \" \")\n    .slice(0, 500)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/discord/src/api.ts",
+    "line": 194,
+    "ruleId": "boundary/response-body-limit",
+    "match": "res.text()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/discord/src/approval-handler.runtime.ts",
+    "line": 164,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "commandText.slice(0, maxChars)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/discord/src/error-body.ts",
+    "line": 21,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "summary.slice(0, DISCORD_RESPONSE_BODY_SUMMARY_MAX_CHARS)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/discord/src/monitor/gateway-metadata.ts",
+    "line": 60,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.arrayBuffer()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/discord/src/monitor/gateway-metadata.ts",
+    "line": 190,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.text()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/discord/src/monitor/gateway-plugin.ts",
+    "line": 116,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "text.slice(0, DISCORD_GATEWAY_CLOSE_REASON_LOG_MAX_CHARS)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/discord/src/monitor/message-handler.preflight.ts",
+    "line": 119,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "resolveDiscordMessageStickers(params.message).slice(\n    0,\n    Math.max(0, DISCORD_HISTORY_MEDIA_MAX_ATTACHMENTS - imageAttachments.length),\n  )",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/discord/src/monitor/provider.deploy-errors.ts",
+    "line": 349,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "bodyText.slice(0, maxLen)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/discord/src/monitor/thread-title.ts",
+    "line": 134,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "sourceText.slice(0, MAX_THREAD_TITLE_SOURCE_CHARS)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/discord/src/pluralkit.ts",
+    "line": 62,
+    "ruleId": "boundary/response-body-limit",
+    "match": "res.json()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/discord/src/send.webhook.ts",
+    "line": 123,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.json()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/discord/src/voice-message.ts",
+    "line": 354,
+    "ruleId": "boundary/response-body-limit",
+    "match": "res.json()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/feishu/src/app-registration.ts",
+    "line": 112,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.json()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/feishu/src/bot.ts",
+    "line": 1003,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "ctx.content.replace(/\\s+/g, \" \").slice(0, 160)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/feishu/src/dedup-migrations.ts",
+    "line": 16,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "fileName.slice(0, -\".json\".length)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/feishu/src/monitor.comment.ts",
+    "line": 1367,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "prompt.replace(/\\s+/g, \" \").slice(0, 160)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/feishu/src/streaming-card.ts",
+    "line": 120,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.json()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/google-meet/src/calendar.ts",
+    "line": 200,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.json()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/google-meet/src/meet.ts",
+    "line": 292,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.json()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/google-meet/src/meet.ts",
+    "line": 357,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.json()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/google-meet/src/meet.ts",
+    "line": 400,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.json()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/google-meet/src/oauth.ts",
+    "line": 92,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.json()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/google/embedding-batch.ts",
+    "line": 223,
+    "ruleId": "boundary/response-body-limit",
+    "match": "res.text()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/google/oauth.project.ts",
+    "line": 24,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.json()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/google/oauth.project.ts",
+    "line": 77,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.json()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/google/oauth.project.ts",
+    "line": 138,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.json()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/google/oauth.project.ts",
+    "line": 149,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.json()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/google/oauth.project.ts",
+    "line": 214,
+    "ruleId": "boundary/response-body-limit",
+    "match": "onboardResponse.json()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/google/oauth.token.ts",
+    "line": 30,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.text()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/google/oauth.token.ts",
+    "line": 34,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.json()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/google/vertex-adc.ts",
+    "line": 280,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.arrayBuffer()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/googlechat/src/api.ts",
+    "line": 125,
+    "ruleId": "boundary/response-body-limit",
+    "match": "res.arrayBuffer()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/huggingface/models.ts",
+    "line": 168,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.json()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/imessage/src/monitor/monitor-provider.ts",
+    "line": 731,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "text.slice(0, 50)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/line/src/auto-reply-delivery.ts",
+    "line": 106,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "lineData.flexMessage.altText.slice(0, 400)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/line/src/auto-reply-delivery.ts",
+    "line": 128,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "flexMsg.altText.slice(0, 400)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/line/src/bot-message-context.ts",
+    "line": 386,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "body.slice(0, 200)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/line/src/outbound.ts",
+    "line": 247,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "lineData.flexMessage.altText.slice(0, 400)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/line/src/outbound.ts",
+    "line": 260,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "lineData.location.title.slice(0, 100)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/line/src/quick-reply-fallback.ts",
+    "line": 5,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "normalizeStringEntries(labels ?? []).slice(0, 13)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/line/src/send.ts",
+    "line": 165,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "location.title.slice(0, 100)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/matrix/src/matrix/monitor/events.ts",
+    "line": 117,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "uniqueStrings(observations.map((entry) => entry.roomId)).slice(\n        0,\n        MATRIX_POST_HEALTHY_SYNC_DECRYPT_FAILURE_SAMPLE_LIMIT,\n      )",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/matrix/src/matrix/monitor/events.ts",
+    "line": 121,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "uniqueStrings(\n        observations\n          .map((entry) => entry.sender)\n          .filter((sender): sender is string => Boolean(sender)),\n      ).slice(0, MATRIX_POST_HEALTHY_SYNC_DECRYPT_FAILURE_SAMPLE_LIMIT)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/matrix/src/matrix/monitor/handler.ts",
+    "line": 459,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "text.slice(0, MATRIX_TOOL_PROGRESS_MAX_CHARS - 1)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/matrix/src/matrix/monitor/handler.ts",
+    "line": 1695,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "bodyText.slice(0, 200)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/matrix/src/matrix/sdk/event-helpers.ts",
+    "line": 93,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "bodyText.slice(0, 500)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/matrix/src/matrix/sdk/event-helpers.ts",
+    "line": 96,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "bodyText.slice(0, 500)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/matrix/src/matrix/sdk/transport.ts",
+    "line": 386,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.arrayBuffer()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/mattermost/src/mattermost/client.ts",
+    "line": 110,
+    "ruleId": "boundary/response-body-limit",
+    "match": "res.json()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/mattermost/src/mattermost/client.ts",
+    "line": 116,
+    "ruleId": "boundary/response-body-limit",
+    "match": "res.text()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/mattermost/src/mattermost/monitor.ts",
+    "line": 1669,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "bodyText.slice(0, 200)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/memory-core/doctor-contract-api.ts",
+    "line": 709,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "entry.name.slice(0, -\".sqlite\".length)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/memory-core/src/dreaming-phases.ts",
+    "line": 677,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "value.replace(/\\s+/g, \" \").trim().slice(0, SESSION_INGESTION_MAX_SNIPPET_CHARS)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/memory-core/src/memory/manager-db.ts",
+    "line": 37,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "entryName.slice(0, entryName.length - suffix.length)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/memory-core/src/memory/qmd-manager.ts",
+    "line": 1118,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "scopedName.slice(0, -agentSuffix.length)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/memory-core/src/memory/qmd-manager.ts",
+    "line": 1722,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "entry.snippet?.slice(0, this.qmd.limits.maxSnippetChars)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/memory-core/src/memory/qmd-manager.ts",
+    "line": 3515,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "snippet.slice(0, Math.max(0, remaining))",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/memory-core/src/short-term-promotion.ts",
+    "line": 352,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "snippet.slice(0, SHORT_TERM_RECALL_MAX_SNIPPET_CHARS)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/memory-core/src/short-term-promotion.ts",
+    "line": 2085,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "targetSnippet.slice(0, bodyIndex)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/memory-core/src/short-term-promotion.ts",
+    "line": 2355,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "snippet.slice(0, limit)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/memory-core/src/tools.citations.ts",
+    "line": 58,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "snippet.slice(0, Math.max(0, remaining))",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/memory-lancedb/index.ts",
+    "line": 1190,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "text.slice(0, MAX_SANITIZE_CHARS)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/memory-lancedb/index.ts",
+    "line": 1680,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "text.slice(0, 100)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/memory-lancedb/index.ts",
+    "line": 1731,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "r.entry.text.slice(0, 60)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/memory-wiki/src/prompt-section.ts",
+    "line": 145,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "sortPromptClaims(page.topClaims ?? []).slice(\n      0,\n      DIGEST_MAX_CLAIMS_PER_PAGE,\n    )",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/microsoft-foundry/onboard.ts",
+    "line": 608,
+    "ruleId": "boundary/response-body-limit",
+    "match": "res.text()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/microsoft-foundry/onboard.ts",
+    "line": 614,
+    "ruleId": "boundary/response-body-limit",
+    "match": "res.text()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/migrate-claude/skills.ts",
+    "line": 156,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "description.slice(0, 180)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/minimax/oauth.ts",
+    "line": 124,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.json()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/moonshot/media-understanding-provider.ts",
+    "line": 67,
+    "ruleId": "boundary/response-body-limit",
+    "match": "res.json()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/msteams/doctor-contract-api.ts",
+    "line": 251,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "entry.name.slice(0, -suffix.length)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/msteams/src/attachments/bot-framework.ts",
+    "line": 115,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.json()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/msteams/src/attachments/graph.ts",
+    "line": 146,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.json()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/msteams/src/graph-upload.ts",
+    "line": 57,
+    "ruleId": "boundary/response-body-limit",
+    "match": "res.json()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/msteams/src/graph-upload.ts",
+    "line": 109,
+    "ruleId": "boundary/response-body-limit",
+    "match": "res.json()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/msteams/src/graph-upload.ts",
+    "line": 203,
+    "ruleId": "boundary/response-body-limit",
+    "match": "res.json()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/msteams/src/graph-upload.ts",
+    "line": 263,
+    "ruleId": "boundary/response-body-limit",
+    "match": "res.json()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/msteams/src/graph-upload.ts",
+    "line": 334,
+    "ruleId": "boundary/response-body-limit",
+    "match": "res.json()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/msteams/src/graph-upload.ts",
+    "line": 374,
+    "ruleId": "boundary/response-body-limit",
+    "match": "res.json()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/msteams/src/graph-upload.ts",
+    "line": 438,
+    "ruleId": "boundary/response-body-limit",
+    "match": "res.json()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/msteams/src/monitor-handler/message-handler.ts",
+    "line": 506,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "rawBody.replace(/\\s+/g, \" \").slice(0, 160)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/msteams/src/sso.ts",
+    "line": 133,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.json()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/nextcloud-talk/src/bot-preflight.ts",
+    "line": 128,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.text()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/openai/embedding-batch.ts",
+    "line": 114,
+    "ruleId": "boundary/response-body-limit",
+    "match": "res.text()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/openai/image-generation-provider.ts",
+    "line": 505,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.text()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/openai/openai-chatgpt-oauth-flow.runtime.ts",
+    "line": 181,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.arrayBuffer()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/openai/openai-chatgpt-oauth-flow.runtime.ts",
+    "line": 219,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.text()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/openai/openai-chatgpt-oauth-flow.runtime.ts",
+    "line": 227,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.json()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/openai/openai-chatgpt-oauth-flow.runtime.ts",
+    "line": 261,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.text()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/openai/openai-chatgpt-oauth-flow.runtime.ts",
+    "line": 269,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.json()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/openrouter/index.ts",
+    "line": 101,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "Array.from(value)\n    .filter((char) => {\n      const codePoint = char.codePointAt(0) ?? 0;\n      return (\n        codePoint > 0x1f &&\n        (codePoint < 0x7f || codePoint > 0x9f) &&\n        codePoint !== 0x2028 &&\n        codePoint !== 0x2029\n      );\n    })\n    .join(\"\")\n    .trim()\n    .slice(0, MAX_PROMPT_MODEL_ID_DISPLAY_CHARS)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/openrouter/oauth.ts",
+    "line": 78,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.text()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/qa-channel/src/bus-client.ts",
+    "line": 294,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.json()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/qa-lab/src/live-transports/shared/credential-lease.runtime.ts",
+    "line": 299,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.text()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/qa-lab/src/live-transports/telegram/telegram-live.runtime.ts",
+    "line": 943,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.json()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/qa-lab/src/providers/mock-openai/server.ts",
+    "line": 1526,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "toolOutput.replace(/\\s+/g, \" \").trim().slice(0, 220)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/qa-lab/src/qa-credentials-admin.runtime.ts",
+    "line": 395,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.text()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/qa-lab/src/runtime-parity.ts",
+    "line": 995,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.json()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/qa-lab/src/suite-runtime-gateway.ts",
+    "line": 27,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.json()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/qa-lab/src/web-runtime.ts",
+    "line": 72,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "entry.text.slice(0, MAX_DIAGNOSTIC_TEXT_CHARS)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/qa-lab/src/web-runtime.ts",
+    "line": 228,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "text.slice(0, maxChars)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/qa-lab/web/src/app.ts",
+    "line": 27,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.json()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/qa-lab/web/src/app.ts",
+    "line": 35,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.json()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/qa-lab/web/src/app.ts",
+    "line": 45,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.json()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/qa-lab/web/src/app.ts",
+    "line": 48,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.json()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/qa-lab/web/src/capture-saved-view.ts",
+    "line": 50,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "item.trim().slice(0, MAX_FILTER_VALUE_LENGTH)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/qa-lab/web/src/capture-saved-view.ts",
+    "line": 89,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "record.searchText.slice(0, MAX_SEARCH_TEXT_LENGTH)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/qa-matrix/src/runners/contract/scenario-runtime-cli.ts",
+    "line": 404,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "randomUUID().replaceAll(\"-\", \"\").slice(0, 12)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/qa-matrix/src/runners/contract/scenario-runtime-e2ee.ts",
+    "line": 665,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "randomUUID().replaceAll(\"-\", \"\").slice(0, 12)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/qa-matrix/src/runners/contract/scenario-runtime-e2ee.ts",
+    "line": 723,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "randomUUID().replaceAll(\"-\", \"\").slice(0, 12)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/qa-matrix/src/runners/contract/scenario-runtime-media.ts",
+    "line": 127,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "attachmentEvent.event.attachment?.caption?.slice(0, 200)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/qa-matrix/src/runners/contract/scenario-runtime-media.ts",
+    "line": 444,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "matchedEvent.body?.slice(0, 200)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/qa-matrix/src/runners/contract/scenario-runtime-room.ts",
+    "line": 681,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "preview.event.formattedBody?.slice(0, 200)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/qa-matrix/src/runners/contract/scenario-runtime-room.ts",
+    "line": 682,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "preview.event.body?.slice(0, 200)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/qa-matrix/src/runners/contract/scenario-runtime-room.ts",
+    "line": 756,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "body.slice(0, 237)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/qa-matrix/src/runners/contract/scenario-runtime-room.ts",
+    "line": 998,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "progressAfterFinal.event.body?.slice(0, 200)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/qa-matrix/src/runners/contract/scenario-runtime-room.ts",
+    "line": 1000,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "progressAfterFinal.event.formattedBody?.slice(0, 200)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/qa-matrix/src/runners/contract/scenario-runtime-room.ts",
+    "line": 1152,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "progress.event.body?.slice(0, 200)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/qa-matrix/src/runners/contract/scenario-runtime-room.ts",
+    "line": 1154,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "progress.event.formattedBody?.slice(0, 200)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/qa-matrix/src/runners/contract/scenario-runtime-shared.ts",
+    "line": 189,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "replyBody?.slice(0, 200)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/qa-matrix/src/runners/contract/scenario-runtime-shared.ts",
+    "line": 200,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "event.body?.trim().slice(0, 200)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/qqbot/src/engine/api/media-chunked.ts",
+    "line": 603,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "lastError.message.slice(0, 120)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/qqbot/src/engine/api/retry.ts",
+    "line": 90,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "lastError.message.slice(0, 100)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/qqbot/src/engine/gateway/gateway.ts",
+    "line": 64,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "meta.ttsText?.slice(0, 30)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/qqbot/src/engine/gateway/outbound-dispatch.ts",
+    "line": 231,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "toolTexts.slice(-3).join(\"\\n---\\n\").slice(0, 2000)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/qqbot/src/engine/messaging/reply-dispatcher.ts",
+    "line": 252,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "value\n    .replace(/[\\r\\n\\t]/g, \" \")\n    .replaceAll(\"\\0\", \" \")\n    .slice(0, maxLen)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/qqbot/src/engine/messaging/reply-dispatcher.ts",
+    "line": 419,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "ttsText.slice(0, 50)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/signal/src/monitor/event-handler.ts",
+    "line": 266,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "body.slice(0, 200)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/slack/src/monitor/events/interactions.block-actions.ts",
+    "line": 308,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "params.summary.selectedLabels.slice(0, 3)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/slack/src/monitor/message-handler/prepare-thread-context-root.ts",
+    "line": 110,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "params.starterText.replace(/\\s+/g, \" \").slice(0, 80)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/slack/src/monitor/message-handler/prepare-thread-context.ts",
+    "line": 232,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "starter.text.replace(/\\s+/g, \" \").slice(0, 80)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/slack/src/monitor/message-handler/prepare.ts",
+    "line": 1129,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "rawBody.replace(/\\s+/g, \" \").slice(0, 160)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/slack/src/monitor/slash.ts",
+    "line": 934,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "choice.label.slice(0, 75)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/telegram/src/bot-message-context.session.ts",
+    "line": 676,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "(visibleReplyTarget.body ?? \"\").replace(/\\s+/g, \" \").slice(0, 120)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/telegram/src/bot-message-context.session.ts",
+    "line": 689,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "body.slice(0, 200)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/telegram/src/draft-stream.ts",
+    "line": 161,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "text.slice(0, mid)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/telegram/src/draft-stream.ts",
+    "line": 373,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "currentText.slice(0, chunkLength)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/telegram/src/draft-stream.ts",
+    "line": 396,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "currentText.slice(0, chunkLength)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/thread-ownership/index.ts",
+    "line": 192,
+    "ruleId": "boundary/response-body-limit",
+    "match": "resp.json()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/tlon/src/channel.runtime.ts",
+    "line": 79,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.text()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/tlon/src/tlon-api.ts",
+    "line": 255,
+    "ruleId": "boundary/response-body-limit",
+    "match": "guarded.response.json()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/tlon/src/urbit/auth.ts",
+    "line": 40,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.text()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/tlon/src/urbit/channel-ops.ts",
+    "line": 60,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.text()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/tlon/src/urbit/channel-ops.ts",
+    "line": 93,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.json()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/tlon/src/urbit/sse-client.ts",
+    "line": 156,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.text()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "extensions/tts-local-cli/speech-provider.ts",
+    "line": 343,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "req.text.slice(0, 50)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/tts-local-cli/speech-provider.ts",
+    "line": 416,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "req.text.slice(0, 50)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/twitch/src/twitch-client.ts",
+    "line": 276,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "messageText.slice(0, 100)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/voice-call/src/realtime-agent-context.ts",
+    "line": 25,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "text.slice(0, Math.max(0, maxChars - 32))",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/whatsapp/src/auto-reply/monitor/echo.ts",
+    "line": 51,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "text.slice(0, 50)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/whatsapp/src/test-helpers.ts",
+    "line": 209,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "label.slice(0, idMarkerIndex)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/zalo/src/send.ts",
+    "line": 203,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "options.caption?.slice(0, 2000)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "packages/agent-core/src/harness/compaction/utils.ts",
+    "line": 109,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "text.slice(0, maxChars)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "packages/markdown-core/src/ir.ts",
+    "line": 1109,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "state.text.slice(0, finalLength)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "packages/memory-host-sdk/src/host/read-file-shared.ts",
+    "line": 51,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "text.slice(0, maxChars)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "packages/speech-core/src/tts.ts",
+    "line": 2031,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "textForAudio.slice(0, maxLength - 3)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "packages/speech-core/src/tts.ts",
+    "line": 2047,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "textForAudio.slice(0, config.maxTextLength - 3)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "packages/speech-core/src/tts.ts",
+    "line": 2052,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "textForAudio.slice(0, maxLength - 3)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "packages/tool-call-repair/src/stream-normalizer.ts",
+    "line": 414,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "text.slice(0, TEXT_TOOL_CALL_BUFFER_MAX_CHARS)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "packages/tool-call-repair/src/stream-normalizer.ts",
+    "line": 437,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "bufferedText.slice(0, TEXT_TOOL_CALL_BUFFER_MAX_CHARS)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/agents/agent-bundle-mcp-names.ts",
+    "line": 62,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "cleanedToolName.slice(0, maxToolChars)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/agents/agent-hooks/compaction-safeguard-quality.ts",
+    "line": 201,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "uniqueStrings(tokenizeAskOverlapText(latestAsk)).slice(\n    0,\n    MAX_ASK_OVERLAP_TOKENS,\n  )",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/agents/agent-hooks/compaction-safeguard.ts",
+    "line": 407,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "text.slice(0, Math.max(0, maxChars - 3))",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/agents/agent-hooks/compaction-safeguard.ts",
+    "line": 571,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "summary.slice(0, maxChars)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/agents/agent-hooks/compaction-safeguard.ts",
+    "line": 573,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "summary.slice(0, budget)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/agents/chutes-oauth.ts",
+    "line": 155,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.text()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "src/agents/chutes-oauth.ts",
+    "line": 226,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.text()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "src/agents/cli-runner/session-history.ts",
+    "line": 209,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "renderedSummary.slice(0, summaryBudget)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/agents/command/attempt-execution.helpers.ts",
+    "line": 401,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "seed.summaryText.slice(0, Math.max(0, remaining - 64))",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/agents/embedded-agent-error-observation.ts",
+    "line": 102,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "params.message.slice(0, MAX_FINGERPRINT_MESSAGE_CHARS)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/agents/embedded-agent-runner/tool-result-context-guard.ts",
+    "line": 168,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "text.slice(0, cutPoint)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/agents/embedded-agent-runner/tool-result-context-guard.ts",
+    "line": 370,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "transcriptMessages\n            .slice(0, checkedPrefixLength)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/agents/embedded-agent-runner/tool-result-truncation.ts",
+    "line": 104,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "finalText.slice(0, params.maxChars)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/agents/embedded-agent-runner/tool-result-truncation.ts",
+    "line": 107,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "keptText.slice(0, Math.max(0, keptText.length - overflow))",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/agents/embedded-agent-subscribe.handlers.messages.ts",
+    "line": 1152,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "text.slice(0, 50)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/agents/embedded-agent-subscribe.handlers.tools.ts",
+    "line": 842,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "rawArgsPreview?.slice(0, TOOL_START_WARNING_RAW_PREVIEW_MAX_CHARS)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/agents/harness/context-engine-lifecycle.ts",
+    "line": 330,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "params.messagesSnapshot.slice(0, params.prePromptMessageCount)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/agents/mcp-http-fetch.ts",
+    "line": 69,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.text()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "src/agents/openai-transport-stream.ts",
+    "line": 396,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "names.slice(0, maxNames)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/agents/tool-description-presets.ts",
+    "line": 72,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "baseDescription.slice(0, 3)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/agents/tool-policy-audit.ts",
+    "line": 115,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "sanitizedNames.slice(0, MAX_AUDIT_TOOL_NAMES)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/agents/tools/pdf-native-providers.ts",
+    "line": 95,
+    "ruleId": "boundary/response-body-limit",
+    "match": "res.json()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "src/agents/tools/pdf-native-providers.ts",
+    "line": 183,
+    "ruleId": "boundary/response-body-limit",
+    "match": "res.json()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "src/agents/tools/web-shared.ts",
+    "line": 315,
+    "ruleId": "boundary/response-body-limit",
+    "match": "res.text()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "src/agents/utils/tools-manager.ts",
+    "line": 157,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.json()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "src/auto-reply/envelope.ts",
+    "line": 164,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "label.slice(0, idMarkerIndex)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/auto-reply/fallback-state.ts",
+    "line": 32,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "text.slice(0, Math.max(0, max - 1))",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/auto-reply/reply/agent-runner-memory.ts",
+    "line": 359,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "visibleText.slice(0, MAX_VISIBLE_MEMORY_FLUSH_ERROR_CHARS - 1)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/auto-reply/reply/agent-runner-memory.ts",
+    "line": 368,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "message.slice(0, MAX_FLUSH_ERROR_LENGTH - 1)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/auto-reply/reply/commands-acp/lifecycle.ts",
+    "line": 790,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "output.slice(0, ACP_STEER_OUTPUT_LIMIT)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/auto-reply/reply/commands-context-report.ts",
+    "line": 231,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "names.slice(0, cap)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/auto-reply/reply/conversation-label-generator.ts",
+    "line": 112,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "text.slice(0, maxLength)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/auto-reply/reply/get-reply-directives.ts",
+    "line": 387,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "existingBody.slice(0, markerIndex + CURRENT_MESSAGE_MARKER.length)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/auto-reply/reply/queue/drain.ts",
+    "line": 359,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "params.queue.summaryLines.slice(0, sources.length)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/auto-reply/reply/queue/drain.ts",
+    "line": 610,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "params.queue.summaryLines.slice(0, retainedSources.length)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/auto-reply/reply/startup-context.ts",
+    "line": 283,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "newestSluggedNames.slice(0, STARTUP_MEMORY_MAX_SLUGGED_FILES_PER_DAY)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/cli/gateway-cli/run-loop.ts",
+    "line": 522,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "task.title.slice(0, 80)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/cli/plugins-list-format.ts",
+    "line": 19,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "plugin.description.slice(0, 57)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/commands/docs.ts",
+    "line": 78,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.json()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "src/commands/doctor-auth-oauth-sidecar.ts",
+    "line": 150,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "entry.name.slice(0, -\".json\".length)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/commands/doctor/cron/repair-plan.ts",
+    "line": 14,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "names.slice(0, 5)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/commands/status-all/report-lines.ts",
+    "line": 91,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "message.slice(0, 90)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/config/allowed-values.ts",
+    "line": 17,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "text.slice(0, limit)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/config/sessions/artifacts.ts",
+    "line": 125,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "fileName.slice(0, -\".jsonl\".length)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/config/sessions/store.ts",
+    "line": 1529,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "entry.name.slice(0, -\".jsonl\".length)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/gateway/chat-display-projection.ts",
+    "line": 60,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "text.slice(0, maxChars)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/gateway/node-invoke-plugin-policy.ts",
+    "line": 66,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "input.title.slice(0, 80)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/gateway/node-invoke-plugin-policy.ts",
+    "line": 67,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "input.description.slice(0, 256)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/gateway/server-reload-handlers.ts",
+    "line": 247,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "task.title.slice(0, 80)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/gateway/session-utils.fs.ts",
+    "line": 1830,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "text.slice(0, maxChars)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/gateway/session-utils.fs.ts",
+    "line": 1832,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "text.slice(0, maxChars - 3)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/gateway/session-utils.ts",
+    "line": 231,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "text.slice(0, maxLen - 1)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/gateway/test-helpers.speech.ts",
+    "line": 36,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.arrayBuffer()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "src/infra/exec-approval-command-display.ts",
+    "line": 61,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "text.slice(0, EXEC_APPROVAL_MAX_OUTPUT)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/infra/heartbeat-events-filter.ts",
+    "line": 127,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "rawEventText.slice(0, MAX_EXEC_EVENT_PROMPT_CHARS)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/infra/heartbeat-runner.ts",
+    "line": 1952,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "heartbeatToolResponse.summary.slice(0, 200)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/infra/heartbeat-runner.ts",
+    "line": 2102,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "normalized.text.slice(0, 200)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/infra/heartbeat-runner.ts",
+    "line": 2131,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "previewText?.slice(0, 200)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/infra/heartbeat-runner.ts",
+    "line": 2151,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "previewText?.slice(0, 200)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/infra/heartbeat-runner.ts",
+    "line": 2174,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "previewText?.slice(0, 200)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/infra/heartbeat-runner.ts",
+    "line": 2256,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "previewText?.slice(0, 200)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/infra/restart-coordinator.ts",
+    "line": 73,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "task.title.slice(0, 80)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/infra/restart-handoff.ts",
+    "line": 111,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "text.slice(0, maxLength)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/infra/restart-handoff.ts",
+    "line": 245,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "row.intent_id.trim().slice(0, MAX_INTENT_ID_LENGTH)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/infra/session-cost-usage.ts",
+    "line": 2147,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "text.slice(0, 100)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/infra/update-check.ts",
+    "line": 128,
+    "ruleId": "boundary/response-body-limit",
+    "match": "res.json()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "src/llm/providers/mistral.ts",
+    "line": 264,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "shortHash(seed)\n    .replace(/[^a-zA-Z0-9]/g, \"\")\n    .slice(0, MISTRAL_TOOL_CALL_ID_LENGTH)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/llm/providers/mistral.ts",
+    "line": 289,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "text.slice(0, maxChars)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/llm/utils/oauth/anthropic.ts",
+    "line": 236,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.text()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "src/logging/subsystem.ts",
+    "line": 215,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "message.slice(0, displaySubsystem.length)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/media/input-files.ts",
+    "line": 276,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "text.slice(0, maxChars)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/plugin-sdk/api-baseline.ts",
+    "line": 355,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "normalizedText.slice(0, 1175)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/plugin-sdk/provider-auth.ts",
+    "line": 313,
+    "ruleId": "boundary/response-body-limit",
+    "match": "res.json()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "src/plugin-sdk/test-helpers/provider-http-mocks.ts",
+    "line": 76,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.json()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "src/plugin-sdk/test-helpers/provider-http-mocks.ts",
+    "line": 239,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.json()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "src/plugin-sdk/test-helpers/stt-live-audio.ts",
+    "line": 76,
+    "ruleId": "boundary/response-body-limit",
+    "match": "response.arrayBuffer()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "src/plugins/hook-agent-context.ts",
+    "line": 56,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "messageChannel.slice(0, separatorIndex)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/plugins/official-external-plugin-catalog.ts",
+    "line": 556,
+    "ruleId": "boundary/response-body-limit",
+    "match": "params.response.text()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
+    "file": "src/plugins/openai-compatible-embedding-provider.ts",
+    "line": 344,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "text.slice(0, EMBEDDING_ERROR_BODY_MAX_CHARS)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/plugins/plugin-sdk-dist-alias.ts",
+    "line": 110,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "fileName.slice(0, -\".js\".length)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/plugins/sdk-alias.ts",
+    "line": 1205,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "fileName.slice(0, -ext.length)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/plugins/sdk-alias.ts",
+    "line": 1513,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "entry.name.slice(0, -\".js\".length)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/sessions/input-provenance.ts",
+    "line": 143,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "text.slice(0, index)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/shared/text/tool-call-shaped-text.ts",
+    "line": 223,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "text.slice(0, MAX_SCAN_CHARS)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/skills/discovery/command-specs.ts",
+    "line": 134,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "rawDescription.slice(0, SKILL_COMMAND_DESCRIPTION_MAX_LENGTH - 1)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/skills/discovery/command-specs.ts",
+    "line": 206,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "entry.description.slice(0, SKILL_COMMAND_DESCRIPTION_MAX_LENGTH - 1)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/skills/loading/workspace.ts",
+    "line": 1392,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "skillsForPrompt.slice(0, mid)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/skills/loading/workspace.ts",
+    "line": 1398,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "skillsForPrompt.slice(0, lo)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/status/status-plugin-health.ts",
+    "line": 312,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "contextEngineQuarantines.slice(0, 8)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/utils/queue-helpers.ts",
+    "line": 78,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "text.slice(0, Math.max(0, limit - 1))",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  }
+]

--- a/test/fixtures/boundary-safety-inventory.json
+++ b/test/fixtures/boundary-safety-inventory.json
@@ -1,21 +1,21 @@
 [
   {
     "file": "extensions/active-memory/index.ts",
-    "line": 2253,
+    "line": 2261,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "texts\n    .map((text) => text.trim())\n    .filter(Boolean)\n    .join(\"\\n\")\n    .slice(0, resolvedLimits.maxChars)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "extensions/active-memory/index.ts",
-    "line": 2628,
+    "line": 2641,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "turn.text.trim().replace(/\\s+/g, \" \").slice(0, params.config.recentUserChars)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "extensions/active-memory/index.ts",
-    "line": 2638,
+    "line": 2651,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "turn.text.trim().replace(/\\s+/g, \" \").slice(0, params.config.recentAssistantChars)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
@@ -78,14 +78,14 @@
   },
   {
     "file": "extensions/browser/src/browser/pw-tools-core.snapshot.ts",
-    "line": 76,
+    "line": 77,
     "ruleId": "boundary/text-utf16-truncation",
-    "match": "(anchor.textContent || anchor.getAttribute(\"aria-label\") || \"\")\n            .replace(/\\s+/g, \" \")\n            .trim()\n            .slice(0, 120)",
+    "match": "(anchor.textContent || anchor.getAttribute(\"aria-label\") || \"\")\n            .replace(/\\s+/g, \" \")\n            .trim()\n            .slice(0, 121)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "extensions/codex/src/app-server/app-inventory-cache.ts",
-    "line": 375,
+    "line": 384,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "message.slice(0, htmlStart)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
@@ -148,7 +148,7 @@
   },
   {
     "file": "extensions/codex/src/command-handlers.ts",
-    "line": 1873,
+    "line": 1893,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "formatCodexTextForDisplay(error).slice(0, CODEX_DIAGNOSTICS_ERROR_MAX_CHARS)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
@@ -159,13 +159,6 @@
     "ruleId": "boundary/text-utf16-truncation",
     "match": "redactSensitiveText(message)\n    .replaceAll(\"\\u0000\", \" \")\n    .replace(/[\\r\\n\\t\\u2028\\u2029]/gu, \" \")\n    .slice(0, 500)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "extensions/discord/src/api.ts",
-    "line": 194,
-    "ruleId": "boundary/response-body-limit",
-    "match": "res.text()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
   },
   {
     "file": "extensions/discord/src/approval-handler.runtime.ts",
@@ -224,24 +217,10 @@
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
-    "file": "extensions/discord/src/pluralkit.ts",
-    "line": 62,
-    "ruleId": "boundary/response-body-limit",
-    "match": "res.json()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
-  },
-  {
     "file": "extensions/discord/src/send.webhook.ts",
-    "line": 123,
+    "line": 124,
     "ruleId": "boundary/response-body-limit",
     "match": "response.json()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
-  },
-  {
-    "file": "extensions/discord/src/voice-message.ts",
-    "line": 354,
-    "ruleId": "boundary/response-body-limit",
-    "match": "res.json()",
     "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
   },
   {
@@ -252,24 +231,10 @@
     "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
   },
   {
-    "file": "extensions/feishu/src/bot.ts",
-    "line": 1003,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "ctx.content.replace(/\\s+/g, \" \").slice(0, 160)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
     "file": "extensions/feishu/src/dedup-migrations.ts",
     "line": 16,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "fileName.slice(0, -\".json\".length)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "extensions/feishu/src/monitor.comment.ts",
-    "line": 1367,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "prompt.replace(/\\s+/g, \" \").slice(0, 160)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
@@ -390,13 +355,6 @@
     "ruleId": "boundary/response-body-limit",
     "match": "response.json()",
     "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
-  },
-  {
-    "file": "extensions/imessage/src/monitor/monitor-provider.ts",
-    "line": 731,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "text.slice(0, 50)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "extensions/line/src/auto-reply-delivery.ts",
@@ -526,7 +484,7 @@
   },
   {
     "file": "extensions/memory-core/src/dreaming-phases.ts",
-    "line": 677,
+    "line": 678,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "value.replace(/\\s+/g, \" \").trim().slice(0, SESSION_INGESTION_MAX_SNIPPET_CHARS)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
@@ -616,39 +574,11 @@
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
-    "file": "extensions/microsoft-foundry/onboard.ts",
-    "line": 608,
-    "ruleId": "boundary/response-body-limit",
-    "match": "res.text()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
-  },
-  {
-    "file": "extensions/microsoft-foundry/onboard.ts",
-    "line": 614,
-    "ruleId": "boundary/response-body-limit",
-    "match": "res.text()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
-  },
-  {
     "file": "extensions/migrate-claude/skills.ts",
     "line": 156,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "description.slice(0, 180)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "extensions/minimax/oauth.ts",
-    "line": 124,
-    "ruleId": "boundary/response-body-limit",
-    "match": "response.json()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
-  },
-  {
-    "file": "extensions/moonshot/media-understanding-provider.ts",
-    "line": 67,
-    "ruleId": "boundary/response-body-limit",
-    "match": "res.json()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
   },
   {
     "file": "extensions/msteams/doctor-contract-api.ts",
@@ -721,24 +651,10 @@
     "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
   },
   {
-    "file": "extensions/msteams/src/monitor-handler/message-handler.ts",
-    "line": 506,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "rawBody.replace(/\\s+/g, \" \").slice(0, 160)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
     "file": "extensions/msteams/src/sso.ts",
     "line": 133,
     "ruleId": "boundary/response-body-limit",
     "match": "response.json()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
-  },
-  {
-    "file": "extensions/nextcloud-talk/src/bot-preflight.ts",
-    "line": 128,
-    "ruleId": "boundary/response-body-limit",
-    "match": "response.text()",
     "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
   },
   {
@@ -827,7 +743,7 @@
   },
   {
     "file": "extensions/qa-lab/src/providers/mock-openai/server.ts",
-    "line": 1526,
+    "line": 1646,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "toolOutput.replace(/\\s+/g, \" \").trim().slice(0, 220)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
@@ -1050,13 +966,6 @@
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
-    "file": "extensions/signal/src/monitor/event-handler.ts",
-    "line": 266,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "body.slice(0, 200)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
     "file": "extensions/slack/src/monitor/events/interactions.block-actions.ts",
     "line": 308,
     "ruleId": "boundary/text-utf16-truncation",
@@ -1190,13 +1099,6 @@
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
-    "file": "extensions/twitch/src/twitch-client.ts",
-    "line": 276,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "messageText.slice(0, 100)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
     "file": "extensions/voice-call/src/realtime-agent-context.ts",
     "line": 25,
     "ruleId": "boundary/text-utf16-truncation",
@@ -1316,20 +1218,6 @@
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
-    "file": "src/agents/chutes-oauth.ts",
-    "line": 155,
-    "ruleId": "boundary/response-body-limit",
-    "match": "response.text()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
-  },
-  {
-    "file": "src/agents/chutes-oauth.ts",
-    "line": 226,
-    "ruleId": "boundary/response-body-limit",
-    "match": "response.text()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
-  },
-  {
     "file": "src/agents/cli-runner/session-history.ts",
     "line": 209,
     "ruleId": "boundary/text-utf16-truncation",
@@ -1380,7 +1268,7 @@
   },
   {
     "file": "src/agents/embedded-agent-subscribe.handlers.messages.ts",
-    "line": 1152,
+    "line": 1237,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "text.slice(0, 50)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
@@ -1408,7 +1296,7 @@
   },
   {
     "file": "src/agents/openai-transport-stream.ts",
-    "line": 396,
+    "line": 400,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "names.slice(0, maxNames)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
@@ -1426,20 +1314,6 @@
     "ruleId": "boundary/text-utf16-truncation",
     "match": "sanitizedNames.slice(0, MAX_AUDIT_TOOL_NAMES)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "src/agents/tools/pdf-native-providers.ts",
-    "line": 95,
-    "ruleId": "boundary/response-body-limit",
-    "match": "res.json()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
-  },
-  {
-    "file": "src/agents/tools/pdf-native-providers.ts",
-    "line": 183,
-    "ruleId": "boundary/response-body-limit",
-    "match": "res.json()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
   },
   {
     "file": "src/agents/tools/web-shared.ts",
@@ -1547,13 +1421,6 @@
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
-    "file": "src/commands/docs.ts",
-    "line": 78,
-    "ruleId": "boundary/response-body-limit",
-    "match": "response.json()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
-  },
-  {
     "file": "src/commands/doctor-auth-oauth-sidecar.ts",
     "line": 150,
     "ruleId": "boundary/text-utf16-truncation",
@@ -1562,7 +1429,7 @@
   },
   {
     "file": "src/commands/doctor/cron/repair-plan.ts",
-    "line": 14,
+    "line": 15,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "names.slice(0, 5)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
@@ -1590,7 +1457,7 @@
   },
   {
     "file": "src/config/sessions/store.ts",
-    "line": 1529,
+    "line": 1511,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "entry.name.slice(0, -\".jsonl\".length)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
@@ -1667,42 +1534,42 @@
   },
   {
     "file": "src/infra/heartbeat-runner.ts",
-    "line": 1952,
+    "line": 1984,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "heartbeatToolResponse.summary.slice(0, 200)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "src/infra/heartbeat-runner.ts",
-    "line": 2102,
+    "line": 2134,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "normalized.text.slice(0, 200)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "src/infra/heartbeat-runner.ts",
-    "line": 2131,
+    "line": 2163,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "previewText?.slice(0, 200)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "src/infra/heartbeat-runner.ts",
-    "line": 2151,
+    "line": 2183,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "previewText?.slice(0, 200)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "src/infra/heartbeat-runner.ts",
-    "line": 2174,
+    "line": 2206,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "previewText?.slice(0, 200)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "src/infra/heartbeat-runner.ts",
-    "line": 2256,
+    "line": 2288,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "previewText?.slice(0, 200)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
@@ -1744,24 +1611,17 @@
   },
   {
     "file": "src/llm/providers/mistral.ts",
-    "line": 264,
+    "line": 265,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "shortHash(seed)\n    .replace(/[^a-zA-Z0-9]/g, \"\")\n    .slice(0, MISTRAL_TOOL_CALL_ID_LENGTH)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "src/llm/providers/mistral.ts",
-    "line": 289,
+    "line": 290,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "text.slice(0, maxChars)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "src/llm/utils/oauth/anthropic.ts",
-    "line": 236,
-    "ruleId": "boundary/response-body-limit",
-    "match": "response.text()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
   },
   {
     "file": "src/logging/subsystem.ts",
@@ -1898,7 +1758,7 @@
   },
   {
     "file": "src/status/status-plugin-health.ts",
-    "line": 312,
+    "line": 375,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "contextEngineQuarantines.slice(0, 8)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."

--- a/test/fixtures/boundary-safety-inventory.json
+++ b/test/fixtures/boundary-safety-inventory.json
@@ -1,9 +1,23 @@
 [
   {
     "file": "extensions/active-memory/index.ts",
+    "line": 1437,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "singleLine.slice(0, MAX_LOG_VALUE_CHARS)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/active-memory/index.ts",
     "line": 2262,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "texts\n    .map((text) => text.trim())\n    .filter(Boolean)\n    .join(\"\\n\")\n    .slice(0, resolvedLimits.maxChars)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/active-memory/index.ts",
+    "line": 2571,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "ellipsis.slice(0, Math.max(0, maxSummaryChars))",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
@@ -21,6 +35,13 @@
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
+    "file": "extensions/browser/src/browser/chrome-mcp.snapshot.ts",
+    "line": 187,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "snapshot.slice(0, maxChars)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
     "file": "extensions/browser/src/browser/chrome.ts",
     "line": 1111,
     "ruleId": "boundary/text-utf16-truncation",
@@ -28,38 +49,38 @@
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
-    "file": "extensions/browser/src/browser/client-fetch.ts",
-    "line": 280,
-    "ruleId": "boundary/response-body-limit",
-    "match": "res.json()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
-  },
-  {
     "file": "extensions/browser/src/browser/pw-tools-core.responses.ts",
-    "line": 94,
-    "ruleId": "boundary/response-body-limit",
-    "match": "resp.text()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
-  },
-  {
-    "file": "extensions/browser/src/browser/pw-tools-core.responses.ts",
-    "line": 103,
+    "line": 106,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "bodyText.slice(0, maxChars)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "extensions/browser/src/browser/pw-tools-core.snapshot.ts",
-    "line": 81,
+    "line": 284,
     "ruleId": "boundary/text-utf16-truncation",
-    "match": "(anchor.textContent || anchor.getAttribute(\"aria-label\") || \"\")\n            .replace(/\\s+/g, \" \")\n            .trim()\n            .slice(0, 121)",
+    "match": "snapshot.slice(0, limit)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
+    "file": "extensions/browser/test-fetch.ts",
+    "line": 32,
+    "ruleId": "boundary/response-body-limit",
+    "match": "partial.json!()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
+  },
+  {
     "file": "extensions/codex/src/app-server/app-inventory-cache.ts",
-    "line": 384,
+    "line": 391,
     "ruleId": "boundary/text-utf16-truncation",
-    "match": "message.slice(0, htmlStart)",
+    "match": "redacted.slice(0, MAX_SERIALIZED_ERROR_MESSAGE_LENGTH)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/codex/src/app-server/approval-bridge.ts",
+    "line": 1588,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "value.slice(0, Math.max(0, maxLength - 3))",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
@@ -70,17 +91,10 @@
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
-    "file": "extensions/codex/src/app-server/context-engine-projection.ts",
-    "line": 151,
+    "file": "extensions/codex/src/app-server/client.ts",
+    "line": 743,
     "ruleId": "boundary/text-utf16-truncation",
-    "match": "params.promptText.slice(0, preservedRange.start)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "extensions/codex/src/app-server/context-engine-projection.ts",
-    "line": 155,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "params.promptText.slice(0, range.start)",
+    "match": "redacted.slice(0, CODEX_APP_SERVER_PARSE_LOG_MAX)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
@@ -88,6 +102,13 @@
     "line": 489,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "text.slice(0, maxChars)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/codex/src/app-server/dynamic-tool-execution.ts",
+    "line": 64,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "normalized.slice(0, LOG_FIELD_MAX_LENGTH - 3)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
@@ -112,10 +133,24 @@
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
+    "file": "extensions/codex/src/app-server/elicitation-bridge.ts",
+    "line": 683,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "value.slice(0, Math.max(0, maxLength - 3))",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
     "file": "extensions/codex/src/app-server/event-projector.ts",
     "line": 3135,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "text.slice(0, TOOL_TRANSCRIPT_OUTPUT_MAX_CHARS)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/codex/src/app-server/plugin-approval-roundtrip.ts",
+    "line": 133,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "value.slice(0, Math.max(0, maxLength - 3))",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
@@ -126,10 +161,10 @@
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
-    "file": "extensions/diagnostics-prometheus/src/service.ts",
-    "line": 231,
+    "file": "extensions/diagnostics-otel/src/service.ts",
+    "line": 679,
     "ruleId": "boundary/text-utf16-truncation",
-    "match": "redactSensitiveText(message)\n    .replaceAll(\"\\u0000\", \" \")\n    .replace(/[\\r\\n\\t\\u2028\\u2029]/gu, \" \")\n    .slice(0, 500)",
+    "match": "value.slice(0, maxChars)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
@@ -141,28 +176,21 @@
   },
   {
     "file": "extensions/discord/src/monitor/gateway-metadata.ts",
-    "line": 60,
-    "ruleId": "boundary/response-body-limit",
-    "match": "response.arrayBuffer()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
-  },
-  {
-    "file": "extensions/discord/src/monitor/gateway-metadata.ts",
-    "line": 190,
+    "line": 199,
     "ruleId": "boundary/response-body-limit",
     "match": "response.text()",
     "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
   },
   {
     "file": "extensions/discord/src/monitor/gateway-plugin.ts",
-    "line": 116,
+    "line": 113,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "text.slice(0, DISCORD_GATEWAY_CLOSE_REASON_LOG_MAX_CHARS)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "extensions/discord/src/monitor/message-handler.preflight.ts",
-    "line": 119,
+    "line": 125,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "resolveDiscordMessageStickers(params.message).slice(\n    0,\n    Math.max(0, DISCORD_HISTORY_MEDIA_MAX_ATTACHMENTS - imageAttachments.length),\n  )",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
@@ -182,10 +210,17 @@
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
-    "file": "extensions/feishu/src/dedup-migrations.ts",
-    "line": 16,
+    "file": "extensions/discord/src/monitor/thread-title.ts",
+    "line": 204,
     "ruleId": "boundary/text-utf16-truncation",
-    "match": "fileName.slice(0, -\".json\".length)",
+    "match": "singleLine.slice(0, maxChars)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/feishu/src/monitor.transport.ts",
+    "line": 154,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "redacted.slice(0, FEISHU_WS_LOG_ERROR_MAX_LENGTH)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
@@ -196,48 +231,6 @@
     "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
   },
   {
-    "file": "extensions/google/oauth.project.ts",
-    "line": 24,
-    "ruleId": "boundary/response-body-limit",
-    "match": "response.json()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
-  },
-  {
-    "file": "extensions/google/oauth.project.ts",
-    "line": 77,
-    "ruleId": "boundary/response-body-limit",
-    "match": "response.json()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
-  },
-  {
-    "file": "extensions/google/oauth.project.ts",
-    "line": 138,
-    "ruleId": "boundary/response-body-limit",
-    "match": "response.json()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
-  },
-  {
-    "file": "extensions/google/oauth.project.ts",
-    "line": 149,
-    "ruleId": "boundary/response-body-limit",
-    "match": "response.json()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
-  },
-  {
-    "file": "extensions/google/oauth.project.ts",
-    "line": 214,
-    "ruleId": "boundary/response-body-limit",
-    "match": "onboardResponse.json()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
-  },
-  {
-    "file": "extensions/google/oauth.token.ts",
-    "line": 39,
-    "ruleId": "boundary/response-body-limit",
-    "match": "response.json()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
-  },
-  {
     "file": "extensions/googlechat/src/api.ts",
     "line": 125,
     "ruleId": "boundary/response-body-limit",
@@ -245,24 +238,10 @@
     "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
   },
   {
-    "file": "extensions/huggingface/models.ts",
-    "line": 168,
-    "ruleId": "boundary/response-body-limit",
-    "match": "response.json()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
-  },
-  {
-    "file": "extensions/line/src/bot-message-context.ts",
-    "line": 390,
+    "file": "extensions/inworld/tts.ts",
+    "line": 60,
     "ruleId": "boundary/text-utf16-truncation",
-    "match": "body.slice(0, 200)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "extensions/line/src/quick-reply-fallback.ts",
-    "line": 5,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "normalizeStringEntries(labels ?? []).slice(0, 13)",
+    "match": "collapsed.slice(0, INWORLD_ERROR_BODY_MAX_CHARS)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
@@ -287,45 +266,10 @@
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
-    "file": "extensions/matrix/src/matrix/monitor/handler.ts",
-    "line": 1659,
+    "file": "extensions/memory-core/src/dreaming-narrative.ts",
+    "line": 458,
     "ruleId": "boundary/text-utf16-truncation",
-    "match": "bodyText.slice(0, 200)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "extensions/matrix/src/matrix/sdk/event-helpers.ts",
-    "line": 93,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "bodyText.slice(0, 500)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "extensions/matrix/src/matrix/sdk/event-helpers.ts",
-    "line": 96,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "bodyText.slice(0, 500)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "extensions/mattermost/src/mattermost/monitor.ts",
-    "line": 1680,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "bodyText.slice(0, 200)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "extensions/mattermost/src/mattermost/slash-commands.ts",
-    "line": 26,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "description.slice(0, end)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "extensions/memory-core/doctor-contract-api.ts",
-    "line": 713,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "entry.name.slice(0, -\".sqlite\".length)",
+    "match": "normalized.slice(0, RECENT_DIARY_CONTEXT_MAX_CHARS)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
@@ -340,13 +284,6 @@
     "line": 37,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "entryName.slice(0, entryName.length - suffix.length)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "extensions/memory-core/src/memory/qmd-manager.ts",
-    "line": 1118,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "scopedName.slice(0, -agentSuffix.length)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
@@ -368,13 +305,6 @@
     "line": 362,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "snippet.slice(0, SHORT_TERM_RECALL_MAX_SNIPPET_CHARS)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "extensions/memory-core/src/short-term-promotion.ts",
-    "line": 2078,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "targetSnippet.slice(0, bodyIndex)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
@@ -425,27 +355,6 @@
     "ruleId": "boundary/text-utf16-truncation",
     "match": "description.slice(0, 180)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "extensions/msteams/doctor-contract-api.ts",
-    "line": 242,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "entry.name.slice(0, -suffix.length)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "extensions/msteams/src/attachments/bot-framework.ts",
-    "line": 115,
-    "ruleId": "boundary/response-body-limit",
-    "match": "response.json()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
-  },
-  {
-    "file": "extensions/msteams/src/attachments/graph.ts",
-    "line": 146,
-    "ruleId": "boundary/response-body-limit",
-    "match": "response.json()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
   },
   {
     "file": "extensions/msteams/src/graph-upload.ts",
@@ -504,6 +413,20 @@
     "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
   },
   {
+    "file": "extensions/nextcloud-talk/src/send.ts",
+    "line": 31,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "collapsed.slice(0, NEXTCLOUD_TALK_ERROR_SNIPPET_MAX_CHARS)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/openai/image-generation-provider.ts",
+    "line": 107,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "cleaned.slice(0, LOG_VALUE_MAX_CHARS)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
     "file": "extensions/openai/image-generation-provider.ts",
     "line": 506,
     "ruleId": "boundary/response-body-limit",
@@ -512,35 +435,28 @@
   },
   {
     "file": "extensions/openai/openai-chatgpt-oauth-flow.runtime.ts",
-    "line": 181,
-    "ruleId": "boundary/response-body-limit",
-    "match": "response.arrayBuffer()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
-  },
-  {
-    "file": "extensions/openai/openai-chatgpt-oauth-flow.runtime.ts",
-    "line": 219,
+    "line": 230,
     "ruleId": "boundary/response-body-limit",
     "match": "response.text()",
     "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
   },
   {
     "file": "extensions/openai/openai-chatgpt-oauth-flow.runtime.ts",
-    "line": 227,
+    "line": 238,
     "ruleId": "boundary/response-body-limit",
     "match": "response.json()",
     "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
   },
   {
     "file": "extensions/openai/openai-chatgpt-oauth-flow.runtime.ts",
-    "line": 261,
+    "line": 272,
     "ruleId": "boundary/response-body-limit",
     "match": "response.text()",
     "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
   },
   {
     "file": "extensions/openai/openai-chatgpt-oauth-flow.runtime.ts",
-    "line": 269,
+    "line": 280,
     "ruleId": "boundary/response-body-limit",
     "match": "response.json()",
     "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
@@ -553,17 +469,17 @@
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
-    "file": "extensions/qa-channel/src/bus-client.ts",
-    "line": 294,
+    "file": "extensions/qa-lab/src/crabline-transport.ts",
+    "line": 212,
     "ruleId": "boundary/response-body-limit",
     "match": "response.json()",
     "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
   },
   {
-    "file": "extensions/qa-lab/src/providers/mock-openai/server.ts",
-    "line": 1640,
+    "file": "extensions/qa-lab/src/live-transports/telegram/telegram-live.runtime.ts",
+    "line": 480,
     "ruleId": "boundary/text-utf16-truncation",
-    "match": "toolOutput.replace(/\\s+/g, \" \").trim().slice(0, 220)",
+    "match": "sanitized.slice(0, TELEGRAM_QA_PROGRESS_DETAIL_LIMIT - 3)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
@@ -637,24 +553,10 @@
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
-    "file": "extensions/qa-matrix/src/runners/contract/scenario-runtime-cli.ts",
-    "line": 404,
+    "file": "extensions/qa-matrix/src/runners/contract/runtime.ts",
+    "line": 219,
     "ruleId": "boundary/text-utf16-truncation",
-    "match": "randomUUID().replaceAll(\"-\", \"\").slice(0, 12)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "extensions/qa-matrix/src/runners/contract/scenario-runtime-e2ee.ts",
-    "line": 665,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "randomUUID().replaceAll(\"-\", \"\").slice(0, 12)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "extensions/qa-matrix/src/runners/contract/scenario-runtime-e2ee.ts",
-    "line": 723,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "randomUUID().replaceAll(\"-\", \"\").slice(0, 12)",
+    "match": "redacted.slice(0, MATRIX_QA_GATEWAY_DEBUG_MAX_LINE_CHARS)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
@@ -665,73 +567,10 @@
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
-    "file": "extensions/qa-matrix/src/runners/contract/scenario-runtime-media.ts",
-    "line": 444,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "matchedEvent.body?.slice(0, 200)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
     "file": "extensions/qa-matrix/src/runners/contract/scenario-runtime-room.ts",
-    "line": 681,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "preview.event.formattedBody?.slice(0, 200)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "extensions/qa-matrix/src/runners/contract/scenario-runtime-room.ts",
-    "line": 682,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "preview.event.body?.slice(0, 200)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "extensions/qa-matrix/src/runners/contract/scenario-runtime-room.ts",
-    "line": 756,
+    "line": 425,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "body.slice(0, 237)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "extensions/qa-matrix/src/runners/contract/scenario-runtime-room.ts",
-    "line": 1006,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "progressAfterFinal.event.body?.slice(0, 200)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "extensions/qa-matrix/src/runners/contract/scenario-runtime-room.ts",
-    "line": 1008,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "progressAfterFinal.event.formattedBody?.slice(0, 200)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "extensions/qa-matrix/src/runners/contract/scenario-runtime-room.ts",
-    "line": 1170,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "progress.event.body?.slice(0, 200)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "extensions/qa-matrix/src/runners/contract/scenario-runtime-room.ts",
-    "line": 1172,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "progress.event.formattedBody?.slice(0, 200)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "extensions/qa-matrix/src/runners/contract/scenario-runtime-shared.ts",
-    "line": 192,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "replyBody?.slice(0, 200)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "extensions/qa-matrix/src/runners/contract/scenario-runtime-shared.ts",
-    "line": 203,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "event.body?.trim().slice(0, 200)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
@@ -749,20 +588,6 @@
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
-    "file": "extensions/qqbot/src/engine/gateway/gateway.ts",
-    "line": 64,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "meta.ttsText?.slice(0, 30)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "extensions/qqbot/src/engine/gateway/outbound-dispatch.ts",
-    "line": 243,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "toolTexts.slice(-3).join(\"\\n---\\n\").slice(0, 2000)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
     "file": "extensions/qqbot/src/engine/messaging/reply-dispatcher.ts",
     "line": 284,
     "ruleId": "boundary/text-utf16-truncation",
@@ -777,59 +602,17 @@
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
-    "file": "extensions/slack/src/monitor/context.ts",
-    "line": 462,
+    "file": "extensions/qqbot/src/engine/utils/log.ts",
+    "line": 51,
     "ruleId": "boundary/text-utf16-truncation",
-    "match": "p.loadingMessages.slice(0, 10)",
+    "match": "sanitized.slice(0, MAX_LOG_VALUE_CHARS)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
-    "file": "extensions/slack/src/monitor/events/interactions.block-actions.ts",
-    "line": 309,
+    "file": "extensions/telegram/src/bot-core.ts",
+    "line": 251,
     "ruleId": "boundary/text-utf16-truncation",
-    "match": "params.summary.selectedLabels.slice(0, 3)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "extensions/slack/src/monitor/message-handler/prepare-thread-context-root.ts",
-    "line": 110,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "params.starterText.replace(/\\s+/g, \" \").slice(0, 80)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "extensions/slack/src/monitor/message-handler/prepare-thread-context.ts",
-    "line": 227,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "starter.text.replace(/\\s+/g, \" \").slice(0, 80)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "extensions/slack/src/monitor/message-handler/prepare.ts",
-    "line": 1168,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "rawBody.replace(/\\s+/g, \" \").slice(0, 160)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "extensions/telegram/src/bot-message-context.session.ts",
-    "line": 686,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "(visibleReplyTarget.body ?? \"\").replace(/\\s+/g, \" \").slice(0, 120)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "extensions/telegram/src/bot-message-context.session.ts",
-    "line": 699,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "body.slice(0, 200)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "extensions/telegram/src/draft-stream.ts",
-    "line": 201,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "text.slice(0, mid)",
+    "match": "raw.slice(0, MAX_RAW_UPDATE_CHARS)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
@@ -847,17 +630,17 @@
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
+    "file": "extensions/telegram/src/raw-update-log.ts",
+    "line": 83,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "value.slice(0, MAX_RAW_UPDATE_STRING)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
     "file": "extensions/thread-ownership/index.ts",
     "line": 192,
     "ruleId": "boundary/response-body-limit",
     "match": "resp.json()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
-  },
-  {
-    "file": "extensions/tlon/src/tlon-api.ts",
-    "line": 255,
-    "ruleId": "boundary/response-body-limit",
-    "match": "guarded.response.json()",
     "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
   },
   {
@@ -882,10 +665,24 @@
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
+    "file": "extensions/voice-call/src/media-stream.ts",
+    "line": 112,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "sanitized.slice(0, maxChars)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
     "file": "extensions/voice-call/src/realtime-agent-context.ts",
     "line": 25,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "text.slice(0, Math.max(0, maxChars - 32))",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/voice-call/src/webhook.ts",
+    "line": 82,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "sanitized.slice(0, TRANSCRIPT_LOG_MAX_CHARS)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
@@ -896,10 +693,17 @@
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
-    "file": "extensions/whatsapp/src/test-helpers.ts",
-    "line": 209,
+    "file": "extensions/whatsapp/src/session-errors.ts",
+    "line": 30,
     "ruleId": "boundary/text-utf16-truncation",
-    "match": "label.slice(0, idMarkerIndex)",
+    "match": "raw.slice(0, limit)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "extensions/workboard/src/store.ts",
+    "line": 2042,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "value.slice(0, Math.max(0, max - 1))",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
@@ -987,6 +791,13 @@
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
+    "file": "src/agents/agent-bundle-mcp-runtime.ts",
+    "line": 393,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "scrubbed.slice(0, BUNDLE_MCP_METADATA_TEXT_LIMIT)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
     "file": "src/agents/agent-hooks/compaction-safeguard-quality.ts",
     "line": 201,
     "ruleId": "boundary/text-utf16-truncation",
@@ -1015,6 +826,27 @@
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
+    "file": "src/agents/agent-hooks/compaction-safeguard.ts",
+    "line": 793,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "rendered.slice(0, MAX_RECENT_TURN_TEXT_CHARS)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/agents/agent-hooks/compaction-safeguard.ts",
+    "line": 887,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "combined.slice(0, MAX_SUMMARY_CONTEXT_CHARS)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/agents/bash-process-references.ts",
+    "line": 33,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "value.slice(0, Math.max(0, maxChars - 3))",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
     "file": "src/agents/cli-runner/session-history.ts",
     "line": 217,
     "ruleId": "boundary/text-utf16-truncation",
@@ -1029,6 +861,20 @@
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
+    "file": "src/agents/console-sanitize.ts",
+    "line": 31,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "codePoints.slice(0, maxChars)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/agents/embedded-agent-error-observation.ts",
+    "line": 46,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "trimmed.slice(0, maxChars)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
     "file": "src/agents/embedded-agent-error-observation.ts",
     "line": 103,
     "ruleId": "boundary/text-utf16-truncation",
@@ -1036,24 +882,24 @@
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
-    "file": "src/agents/embedded-agent-runner/run/runtime-context-prompt.ts",
-    "line": 109,
+    "file": "src/agents/embedded-agent-helpers/bootstrap.ts",
+    "line": 238,
     "ruleId": "boundary/text-utf16-truncation",
-    "match": "params.text.slice(0, occurrenceIndex)",
+    "match": "trimmed.slice(0, headChars)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
-    "file": "src/agents/embedded-agent-runner/tool-result-context-guard.ts",
-    "line": 168,
+    "file": "src/agents/embedded-agent-runner/run/attempt.prompt-helpers.ts",
+    "line": 340,
     "ruleId": "boundary/text-utf16-truncation",
-    "match": "text.slice(0, cutPoint)",
+    "match": "trimmed.slice(0, MAX_STRUCTURED_MEDIA_REF_CHARS)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
-    "file": "src/agents/embedded-agent-runner/tool-result-context-guard.ts",
-    "line": 370,
+    "file": "src/agents/embedded-agent-runner/run/attempt.prompt-helpers.ts",
+    "line": 352,
     "ruleId": "boundary/text-utf16-truncation",
-    "match": "transcriptMessages\n            .slice(0, checkedPrefixLength)",
+    "match": "trimmed.slice(0, MAX_STRUCTURED_JSON_STRING_CHARS)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
@@ -1092,10 +938,31 @@
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
+    "file": "src/agents/harness/native-hook-relay.ts",
+    "line": 1932,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "value.slice(0, limit)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/agents/harness/native-hook-relay.ts",
+    "line": 2226,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "value.slice(0, Math.max(0, maxLength - 3))",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
     "file": "src/agents/openai-transport-stream.ts",
     "line": 408,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "names.slice(0, maxNames)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/agents/subagent-orphan-recovery.ts",
+    "line": 75,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "task.slice(0, maxTaskLen)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
@@ -1113,8 +980,15 @@
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
+    "file": "src/agents/tool-policy-audit.ts",
+    "line": 148,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "sanitized.slice(0, MAX_AUDIT_FIELD_LENGTH)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
     "file": "src/agents/tools/web-shared.ts",
-    "line": 315,
+    "line": 324,
     "ruleId": "boundary/response-body-limit",
     "match": "res.text()",
     "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
@@ -1127,17 +1001,24 @@
     "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
   },
   {
-    "file": "src/auto-reply/envelope.ts",
-    "line": 164,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "label.slice(0, idMarkerIndex)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
     "file": "src/auto-reply/fallback-state.ts",
     "line": 32,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "text.slice(0, Math.max(0, max - 1))",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/auto-reply/reply/acp-projector.ts",
+    "line": 55,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "input.slice(0, maxChars - 1)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/auto-reply/reply/agent-runner-execution.ts",
+    "line": 955,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "sanitized.slice(0, EXTERNAL_RUN_FAILURE_DETAIL_MAX_CHARS - 1)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
@@ -1183,17 +1064,17 @@
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
-    "file": "src/auto-reply/reply/queue/drain.ts",
-    "line": 545,
+    "file": "src/auto-reply/reply/post-compaction-context.ts",
+    "line": 120,
     "ruleId": "boundary/text-utf16-truncation",
-    "match": "params.queue.summaryLines.slice(0, sources.length)",
+    "match": "combined.slice(0, maxContextChars)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
-    "file": "src/auto-reply/reply/queue/drain.ts",
-    "line": 937,
+    "file": "src/auto-reply/reply/startup-context.ts",
+    "line": 97,
     "ruleId": "boundary/text-utf16-truncation",
-    "match": "params.queue.summaryLines.slice(0, retainedSources.length)",
+    "match": "trimmed.slice(0, maxChars)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
@@ -1205,16 +1086,9 @@
   },
   {
     "file": "src/cli/gateway-cli/run-loop.ts",
-    "line": 570,
+    "line": 569,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "task.title.slice(0, 80)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "src/cli/gateway-cli/run-loop.ts",
-    "line": 934,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "formatErrorMessage(err).slice(0, 500)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
@@ -1225,17 +1099,45 @@
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
-    "file": "src/commands/doctor-auth-oauth-sidecar.ts",
-    "line": 150,
+    "file": "src/commands/audit.ts",
+    "line": 66,
     "ruleId": "boundary/text-utf16-truncation",
-    "match": "entry.name.slice(0, -\".json\".length)",
+    "match": "sanitized.slice(0, maxChars - 1)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
-    "file": "src/commands/doctor/cron/repair-plan.ts",
-    "line": 15,
+    "file": "src/commands/commitments.ts",
+    "line": 27,
     "ruleId": "boundary/text-utf16-truncation",
-    "match": "names.slice(0, 5)",
+    "match": "value.slice(0, maxChars - 1)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/commands/flows.ts",
+    "line": 37,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "value.slice(0, maxChars - 1)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/commands/models/list.format.ts",
+    "line": 48,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "value.slice(0, max - 3)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/commands/onboard-skills.ts",
+    "line": 50,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "cleaned.slice(0, maxLen - 1)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/commands/onboard-skills.ts",
+    "line": 64,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "combined.slice(0, maxLen - 1)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
@@ -1246,10 +1148,24 @@
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
+    "file": "src/commands/status-all/gateway.ts",
+    "line": 30,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "cleaned.slice(0, Math.max(0, maxLen - 1))",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
     "file": "src/commands/status-all/report-lines.ts",
     "line": 91,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "message.slice(0, 90)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/commands/tasks.ts",
+    "line": 211,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "value.slice(0, maxChars - 1)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
@@ -1260,24 +1176,38 @@
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
-    "file": "src/config/sessions/artifacts.ts",
-    "line": 125,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "fileName.slice(0, -\".jsonl\".length)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "src/config/sessions/store.ts",
-    "line": 1551,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "entry.name.slice(0, -\".jsonl\".length)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
     "file": "src/crestodian/assistant-prompts.ts",
     "line": 110,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "turn.text.slice(0, HISTORY_TURN_MAX_CHARS)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/crestodian/operations.ts",
+    "line": 942,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "rendered.slice(0, CONFIG_GET_OUTPUT_MAX_CHARS)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/cron/run-diagnostics.ts",
+    "line": 104,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "redacted.slice(0, MAX_ENTRY_CHARS - 1)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/cron/run-diagnostics.ts",
+    "line": 115,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "normalized.slice(0, MAX_SUMMARY_CHARS - 1)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/flows/doctor-error-message.ts",
+    "line": 17,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "stripped.slice(0, ERR_MESSAGE_MAX_LEN - 3)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
@@ -1317,14 +1247,14 @@
   },
   {
     "file": "src/gateway/session-utils.fs.ts",
-    "line": 1923,
+    "line": 1926,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "text.slice(0, maxChars)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "src/gateway/session-utils.fs.ts",
-    "line": 1925,
+    "line": 1928,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "text.slice(0, maxChars - 3)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
@@ -1344,6 +1274,41 @@
     "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
   },
   {
+    "file": "src/gateway/ws-log.ts",
+    "line": 122,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "redacted.slice(0, LOG_VALUE_LIMIT)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/gateway/ws-log.ts",
+    "line": 138,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "combined.slice(0, LOG_VALUE_LIMIT)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/gateway/ws-log.ts",
+    "line": 151,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "redacted.slice(0, LOG_VALUE_LIMIT)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/gateway/ws-log.ts",
+    "line": 197,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "oneLine.slice(0, Math.max(0, maxLen - 1))",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/hooks/gmail-setup-utils.ts",
+    "line": 27,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "trimmed.slice(0, MAX_OUTPUT_CHARS)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
     "file": "src/infra/heartbeat-events-filter.ts",
     "line": 127,
     "ruleId": "boundary/text-utf16-truncation",
@@ -1355,13 +1320,6 @@
     "line": 2010,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "heartbeatToolResponse.summary.slice(0, 200)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "src/infra/heartbeat-runner.ts",
-    "line": 2164,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "normalized.text.slice(0, 200)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
@@ -1415,9 +1373,37 @@
   },
   {
     "file": "src/infra/session-cost-usage.ts",
-    "line": 2156,
+    "line": 2739,
     "ruleId": "boundary/text-utf16-truncation",
-    "match": "text.slice(0, 100)",
+    "match": "content.slice(0, maxLen)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/logging/diagnostic-session-context.ts",
+    "line": 22,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "oneLine.slice(0, Math.max(0, MAX_QUOTED_FIELD_CHARS - 3))",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/logging/diagnostic-stability-bundle.ts",
+    "line": 210,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "sanitized.slice(0, MAX_SAFE_ERROR_MESSAGE_LENGTH)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/logging/logger.ts",
+    "line": 93,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "value.slice(0, maxChars)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/logging/logger.ts",
+    "line": 220,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "value.slice(0, maxChars)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
@@ -1435,18 +1421,11 @@
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
-    "file": "src/plugin-sdk/api-baseline.ts",
-    "line": 355,
+    "file": "src/plugin-sdk/qa-channel-protocol.ts",
+    "line": 256,
     "ruleId": "boundary/text-utf16-truncation",
-    "match": "normalizedText.slice(0, 1175)",
+    "match": "value.slice(0, QA_BUS_TOOL_CALL_MAX_COUNT)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "src/plugin-sdk/provider-auth.ts",
-    "line": 313,
-    "ruleId": "boundary/response-body-limit",
-    "match": "res.json()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
   },
   {
     "file": "src/plugin-sdk/test-helpers/provider-http-mocks.ts",
@@ -1470,13 +1449,6 @@
     "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
   },
   {
-    "file": "src/plugins/hook-agent-context.ts",
-    "line": 56,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "messageChannel.slice(0, separatorIndex)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
     "file": "src/plugins/official-external-plugin-catalog.ts",
     "line": 562,
     "ruleId": "boundary/response-body-limit",
@@ -1491,31 +1463,17 @@
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
-    "file": "src/plugins/plugin-sdk-dist-alias.ts",
-    "line": 110,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "fileName.slice(0, -\".js\".length)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+    "file": "src/proxy-capture/runtime.ts",
+    "line": 45,
+    "ruleId": "boundary/response-body-limit",
+    "match": "clone.arrayBuffer()",
+    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
   },
   {
-    "file": "src/plugins/sdk-alias.ts",
-    "line": 1238,
+    "file": "src/security/install-policy.ts",
+    "line": 381,
     "ruleId": "boundary/text-utf16-truncation",
-    "match": "fileName.slice(0, -ext.length)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "src/plugins/sdk-alias.ts",
-    "line": 1546,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "entry.name.slice(0, -\".js\".length)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "src/sessions/input-provenance.ts",
-    "line": 142,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "text.slice(0, index)",
+    "match": "value.slice(0, maxChars)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
@@ -1523,6 +1481,13 @@
     "line": 223,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "text.slice(0, MAX_SCAN_CHARS)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/skills/lifecycle/install-output.ts",
+    "line": 31,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "normalized.slice(0, maxLen - 1)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
@@ -1540,6 +1505,13 @@
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
+    "file": "src/skills/security/scanner.ts",
+    "line": 278,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "evidence.slice(0, maxLen)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
     "file": "src/skills/workshop/policy.ts",
     "line": 95,
     "ruleId": "boundary/text-utf16-truncation",
@@ -1548,16 +1520,44 @@
   },
   {
     "file": "src/status/status-plugin-health.ts",
-    "line": 354,
-    "ruleId": "boundary/text-utf16-truncation",
-    "match": "reasonEntries\n        .slice(0, 8)",
-    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "src/status/status-plugin-health.ts",
     "line": 409,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "contextEngineQuarantines.slice(0, 8)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/talk/fast-context-runtime.ts",
+    "line": 72,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "normalized.slice(0, MAX_SNIPPET_CHARS - 1)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/tts/status-config.ts",
+    "line": 117,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "normalized.slice(0, maxLength - 3)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/tui/tui-event-handlers.ts",
+    "line": 55,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "diagnostic.slice(0, MAX_ABORT_DIAGNOSTIC_LENGTH - 1)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/utils/fetch-timeout.ts",
+    "line": 44,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "value.slice(0, LOG_URL_MAX_CHARS)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/utils/fetch-timeout.ts",
+    "line": 58,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "cleaned.slice(0, LOG_URL_MAX_CHARS)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {

--- a/test/fixtures/boundary-safety-inventory.json
+++ b/test/fixtures/boundary-safety-inventory.json
@@ -92,28 +92,28 @@
   },
   {
     "file": "extensions/codex/src/app-server/dynamic-tools.ts",
-    "line": 1324,
+    "line": 1362,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "noticeText.slice(0, maxChars)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "extensions/codex/src/app-server/dynamic-tools.ts",
-    "line": 1331,
+    "line": 1369,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "item.text.slice(0, sliceLength)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "extensions/codex/src/app-server/dynamic-tools.ts",
-    "line": 1341,
+    "line": 1379,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "noticeText.slice(0, maxChars)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "extensions/codex/src/app-server/event-projector.ts",
-    "line": 2753,
+    "line": 3135,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "text.slice(0, TOOL_TRANSCRIPT_OUTPUT_MAX_CHARS)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
@@ -182,32 +182,11 @@
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
-    "file": "extensions/discord/src/send.webhook.ts",
-    "line": 124,
-    "ruleId": "boundary/response-body-limit",
-    "match": "response.json()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
-  },
-  {
-    "file": "extensions/feishu/src/app-registration.ts",
-    "line": 113,
-    "ruleId": "boundary/response-body-limit",
-    "match": "response.json()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
-  },
-  {
     "file": "extensions/feishu/src/dedup-migrations.ts",
     "line": 16,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "fileName.slice(0, -\".json\".length)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
-  },
-  {
-    "file": "extensions/feishu/src/streaming-card.ts",
-    "line": 120,
-    "ruleId": "boundary/response-body-limit",
-    "match": "response.json()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
   },
   {
     "file": "extensions/google/embedding-batch.ts",
@@ -526,7 +505,7 @@
   },
   {
     "file": "extensions/openai/image-generation-provider.ts",
-    "line": 505,
+    "line": 506,
     "ruleId": "boundary/response-body-limit",
     "match": "response.text()",
     "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
@@ -574,22 +553,8 @@
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
-    "file": "extensions/openrouter/oauth.ts",
-    "line": 75,
-    "ruleId": "boundary/response-body-limit",
-    "match": "response.text()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
-  },
-  {
     "file": "extensions/qa-channel/src/bus-client.ts",
     "line": 294,
-    "ruleId": "boundary/response-body-limit",
-    "match": "response.json()",
-    "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
-  },
-  {
-    "file": "extensions/qa-lab/src/live-transports/telegram/telegram-live.runtime.ts",
-    "line": 943,
     "ruleId": "boundary/response-body-limit",
     "match": "response.json()",
     "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
@@ -1128,7 +1093,7 @@
   },
   {
     "file": "src/agents/openai-transport-stream.ts",
-    "line": 404,
+    "line": 408,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "names.slice(0, maxNames)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
@@ -1156,7 +1121,7 @@
   },
   {
     "file": "src/agents/utils/tools-manager.ts",
-    "line": 157,
+    "line": 159,
     "ruleId": "boundary/response-body-limit",
     "match": "response.json()",
     "guidance": "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code."
@@ -1240,14 +1205,14 @@
   },
   {
     "file": "src/cli/gateway-cli/run-loop.ts",
-    "line": 542,
+    "line": 570,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "task.title.slice(0, 80)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "src/cli/gateway-cli/run-loop.ts",
-    "line": 874,
+    "line": 934,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "formatErrorMessage(err).slice(0, 500)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
@@ -1345,7 +1310,7 @@
   },
   {
     "file": "src/gateway/server-reload-handlers.ts",
-    "line": 269,
+    "line": 270,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "task.title.slice(0, 80)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
@@ -1366,7 +1331,7 @@
   },
   {
     "file": "src/gateway/session-utils.ts",
-    "line": 231,
+    "line": 232,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "text.slice(0, maxLen - 1)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
@@ -1387,42 +1352,42 @@
   },
   {
     "file": "src/infra/heartbeat-runner.ts",
-    "line": 1985,
+    "line": 2010,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "heartbeatToolResponse.summary.slice(0, 200)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "src/infra/heartbeat-runner.ts",
-    "line": 2135,
+    "line": 2164,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "normalized.text.slice(0, 200)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "src/infra/heartbeat-runner.ts",
-    "line": 2164,
+    "line": 2193,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "previewText?.slice(0, 200)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "src/infra/heartbeat-runner.ts",
-    "line": 2184,
+    "line": 2213,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "previewText?.slice(0, 200)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "src/infra/heartbeat-runner.ts",
-    "line": 2207,
+    "line": 2236,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "previewText?.slice(0, 200)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
   },
   {
     "file": "src/infra/heartbeat-runner.ts",
-    "line": 2290,
+    "line": 2320,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "previewText?.slice(0, 200)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
@@ -1583,7 +1548,14 @@
   },
   {
     "file": "src/status/status-plugin-health.ts",
-    "line": 377,
+    "line": 354,
+    "ruleId": "boundary/text-utf16-truncation",
+    "match": "reasonEntries\n        .slice(0, 8)",
+    "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."
+  },
+  {
+    "file": "src/status/status-plugin-health.ts",
+    "line": 409,
     "ruleId": "boundary/text-utf16-truncation",
     "match": "contextEngineQuarantines.slice(0, 8)",
     "guidance": "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing."

--- a/test/scripts/check-boundary-safety.test.ts
+++ b/test/scripts/check-boundary-safety.test.ts
@@ -1,5 +1,6 @@
 // Check Boundary Safety tests cover high-confidence boundary guard behavior.
-import { describe, expect, it } from "vitest";
+import { promises as fs } from "node:fs";
+import { describe, expect, it, vi } from "vitest";
 import {
   diffBoundaryInventory,
   findBoundarySafetyViolations,
@@ -203,5 +204,30 @@ describe("check-boundary-safety", () => {
     expect(JSON.parse(output.stdout)).toEqual(expect.any(Array));
     expect(output.stdout).not.toContain("Boundary safety changed-file check passed");
     expect(output.stderr).toContain("Boundary safety changed-file check passed");
+  });
+
+  it("requires --all before updating the baseline", async () => {
+    const writeFile = vi.spyOn(fs, "writeFile").mockResolvedValue(undefined);
+    const output = { stdout: "", stderr: "" };
+    const io = {
+      stdout: {
+        write(chunk: string) {
+          output.stdout += chunk;
+        },
+      },
+      stderr: {
+        write(chunk: string) {
+          output.stderr += chunk;
+        },
+      },
+    };
+
+    try {
+      await expect(main(["--update-baseline"], io)).resolves.toBe(1);
+      expect(writeFile).not.toHaveBeenCalled();
+      expect(output.stderr).toContain("`--update-baseline` requires `--all`");
+    } finally {
+      writeFile.mockRestore();
+    }
   });
 });

--- a/test/scripts/check-boundary-safety.test.ts
+++ b/test/scripts/check-boundary-safety.test.ts
@@ -1,0 +1,150 @@
+// Check Boundary Safety tests cover high-confidence boundary guard behavior.
+import { describe, expect, it } from "vitest";
+import {
+  diffBoundaryInventory,
+  findBoundarySafetyViolations,
+  isBoundarySafetyCandidateFile,
+} from "../../scripts/check-boundary-safety.mjs";
+
+describe("check-boundary-safety", () => {
+  it("flags user-visible head truncation with raw slice", () => {
+    const source = `
+      const previewText = messageText.length > maxChars ? messageText.slice(0, maxChars - 1) + "…" : messageText;
+    `;
+
+    expect(findBoundarySafetyViolations(source, "src/channels/example.ts")).toEqual([
+      {
+        line: 2,
+        ruleId: "boundary/text-utf16-truncation",
+        match: "messageText.slice(0, maxChars - 1)",
+        guidance:
+          "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing.",
+      },
+    ]);
+  });
+
+  it("accepts UTF-16-safe truncation helpers", () => {
+    const source = `
+      import { truncateUtf16Safe } from "../utils.js";
+      const previewText = messageText.length > maxChars ? truncateUtf16Safe(messageText, maxChars - 1) + "…" : messageText;
+    `;
+
+    expect(findBoundarySafetyViolations(source, "src/channels/example.ts")).toStrictEqual([]);
+  });
+
+  it("does not flag protocol, byte-offset, or collection slices", () => {
+    const source = `
+      const packet = frame.slice(offset, offset + length);
+      const hashPrefix = digest.slice(0, 8);
+      const pathSegments = packageName.split("/").slice(0, 2);
+      const latestMessages = messages.slice(0, -1);
+      const firstLabels = labels.slice(0, 13);
+      const scoredSnippets = snippets.filter(Boolean).map(scoreSnippet).slice(0, 12);
+    `;
+
+    expect(findBoundarySafetyViolations(source, "src/protocol/frame.ts")).toStrictEqual([]);
+  });
+
+  it("flags string-producing truncation chains", () => {
+    const source = `
+      const promptPreview = texts.map((text) => text.trim()).join("\\n").slice(0, maxChars);
+    `;
+
+    expect(findBoundarySafetyViolations(source, "src/channels/example.ts")).toEqual([
+      {
+        line: 2,
+        ruleId: "boundary/text-utf16-truncation",
+        match: 'texts.map((text) => text.trim()).join("\\n").slice(0, maxChars)',
+        guidance:
+          "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing.",
+      },
+    ]);
+  });
+
+  it("flags awaited external response json reads", () => {
+    const source = `
+      export async function readProvider(response: Response) {
+        return (await response.json()) as { ok: boolean };
+      }
+    `;
+
+    expect(findBoundarySafetyViolations(source, "extensions/provider/runtime.ts")).toEqual([
+      {
+        line: 3,
+        ruleId: "boundary/response-body-limit",
+        match: "response.json()",
+        guidance:
+          "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code.",
+      },
+    ]);
+  });
+
+  it("flags awaited response reads with catch chains", () => {
+    const source = `
+      export async function readProvider(res: Response) {
+        const body = await res.text().catch(() => "");
+        return body;
+      }
+    `;
+
+    expect(findBoundarySafetyViolations(source, "src/agents/provider-client.ts")).toEqual([
+      {
+        line: 3,
+        ruleId: "boundary/response-body-limit",
+        match: "res.text()",
+        guidance:
+          "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code.",
+      },
+    ]);
+  });
+
+  it("does not flag Express response writers", () => {
+    const source = `
+      app.get("/health", (_req, res) => {
+        return res.json({ ok: true });
+      });
+    `;
+
+    expect(
+      findBoundarySafetyViolations(source, "extensions/browser/src/browser/routes/health.ts"),
+    ).toStrictEqual([]);
+  });
+
+  it("keeps tests, fixtures, generated files, and scripts out of production candidates", () => {
+    expect(isBoundarySafetyCandidateFile("src/agents/provider-client.ts")).toBe(true);
+    expect(isBoundarySafetyCandidateFile("src/agents/provider-client.test.ts")).toBe(false);
+    expect(isBoundarySafetyCandidateFile("src/agents/provider-client.test-helpers.ts")).toBe(false);
+    expect(isBoundarySafetyCandidateFile("test/fixtures/provider-client.ts")).toBe(false);
+    expect(
+      isBoundarySafetyCandidateFile("src/auto-reply/reply/export-html/vendor/marked.min.js"),
+    ).toBe(false);
+    expect(isBoundarySafetyCandidateFile("scripts/check-boundary-safety.mjs")).toBe(false);
+  });
+
+  it("diffs baseline entries by file, line, rule, and match", () => {
+    const baseline = [
+      {
+        file: "src/agents/provider-client.ts",
+        line: 3,
+        ruleId: "boundary/response-body-limit",
+        match: "res.json()",
+        guidance: "Use readResponseWithLimit(...)",
+      },
+    ];
+    const actual = [
+      baseline[0],
+      {
+        file: "src/channels/example.ts",
+        line: 7,
+        ruleId: "boundary/text-utf16-truncation",
+        match: "messageText.slice(0, maxChars)",
+        guidance: "Use truncateUtf16Safe(...)",
+      },
+    ];
+
+    expect(diffBoundaryInventory(baseline, actual)).toEqual({
+      missing: [],
+      unexpected: [actual[1]],
+    });
+  });
+});

--- a/test/scripts/check-boundary-safety.test.ts
+++ b/test/scripts/check-boundary-safety.test.ts
@@ -4,6 +4,7 @@ import {
   diffBoundaryInventory,
   findBoundarySafetyViolations,
   isBoundarySafetyCandidateFile,
+  main,
 } from "../../scripts/check-boundary-safety.mjs";
 
 describe("check-boundary-safety", () => {
@@ -169,5 +170,26 @@ describe("check-boundary-safety", () => {
       missing: [],
       unexpected: [],
     });
+  });
+
+  it("keeps JSON mode stdout parseable", async () => {
+    const output = { stdout: "", stderr: "" };
+    const io = {
+      stdout: {
+        write(chunk: string) {
+          output.stdout += chunk;
+        },
+      },
+      stderr: {
+        write(chunk: string) {
+          output.stderr += chunk;
+        },
+      },
+    };
+
+    await expect(main(["--json"], io)).resolves.toBe(0);
+    expect(JSON.parse(output.stdout)).toEqual(expect.any(Array));
+    expect(output.stdout).not.toContain("Boundary safety changed-file check passed");
+    expect(output.stderr).toContain("Boundary safety changed-file check passed");
   });
 });

--- a/test/scripts/check-boundary-safety.test.ts
+++ b/test/scripts/check-boundary-safety.test.ts
@@ -121,7 +121,7 @@ describe("check-boundary-safety", () => {
     expect(isBoundarySafetyCandidateFile("scripts/check-boundary-safety.mjs")).toBe(false);
   });
 
-  it("diffs baseline entries by file, line, rule, and match", () => {
+  it("diffs baseline entries by stable file, rule, and match identity", () => {
     const baseline = [
       {
         file: "src/agents/provider-client.ts",
@@ -145,6 +145,29 @@ describe("check-boundary-safety", () => {
     expect(diffBoundaryInventory(baseline, actual)).toEqual({
       missing: [],
       unexpected: [actual[1]],
+    });
+  });
+
+  it("keeps baseline-known findings stable when only line numbers move", () => {
+    const baseline = [
+      {
+        file: "src/agents/provider-client.ts",
+        line: 3,
+        ruleId: "boundary/response-body-limit",
+        match: "res.json()",
+        guidance: "Use readResponseWithLimit(...)",
+      },
+    ];
+    const actual = [
+      {
+        ...baseline[0],
+        line: 9,
+      },
+    ];
+
+    expect(diffBoundaryInventory(baseline, actual)).toEqual({
+      missing: [],
+      unexpected: [],
     });
   });
 });

--- a/test/scripts/check-boundary-safety.test.ts
+++ b/test/scripts/check-boundary-safety.test.ts
@@ -111,6 +111,18 @@ describe("check-boundary-safety", () => {
     ).toStrictEqual([]);
   });
 
+  it("accepts narrow boundary-safety ignore comments before awaited response reads", () => {
+    const source = `
+      export async function readFallback(res: Response) {
+        const fallbackBuffer =
+          await /* boundary-safety-ignore boundary/response-body-limit: no stream exists; enforce maxBytes after fallback. */ res.arrayBuffer();
+        return fallbackBuffer;
+      }
+    `;
+
+    expect(findBoundarySafetyViolations(source, "src/infra/http-body.ts")).toStrictEqual([]);
+  });
+
   it("keeps tests, fixtures, generated files, and scripts out of production candidates", () => {
     expect(isBoundarySafetyCandidateFile("src/agents/provider-client.ts")).toBe(true);
     expect(isBoundarySafetyCandidateFile("src/agents/provider-client.test.ts")).toBe(false);

--- a/test/scripts/check-boundary-safety.test.ts
+++ b/test/scripts/check-boundary-safety.test.ts
@@ -34,7 +34,7 @@ describe("check-boundary-safety", () => {
     expect(findBoundarySafetyViolations(source, "src/channels/example.ts")).toStrictEqual([]);
   });
 
-  it("does not flag protocol, byte-offset, or collection slices", () => {
+  it("does not flag protocol, byte-offset, suffix-removal, or collection slices", () => {
     const source = `
       const packet = frame.slice(offset, offset + length);
       const hashPrefix = digest.slice(0, 8);
@@ -42,6 +42,13 @@ describe("check-boundary-safety", () => {
       const latestMessages = messages.slice(0, -1);
       const firstLabels = labels.slice(0, 13);
       const scoredSnippets = snippets.filter(Boolean).map(scoreSnippet).slice(0, 12);
+      const errorLines = ["header", ...issues.slice(0, CONFIG_SET_POLICY_ERROR_MAX_ISSUES).map(formatIssue), "... more"];
+      const cachedEntries = [{ key, value }, ...entries.filter((entry) => entry.key !== key)].slice(0, MAX_CACHE_ENTRIES);
+      const sortedResults = sortMemorySearchToolResults([...memoryResults, ...supplementResults]).slice(0, params.maxResults);
+      const stem = fileName.slice(0, -suffix.length);
+      const promptPrefix = promptText.slice(0, range.start);
+      const body = frame.body as Uint8Array;
+      const header = body.slice(0, maxBytes);
     `;
 
     expect(findBoundarySafetyViolations(source, "src/protocol/frame.ts")).toStrictEqual([]);
@@ -57,6 +64,22 @@ describe("check-boundary-safety", () => {
         line: 2,
         ruleId: "boundary/text-utf16-truncation",
         match: 'texts.map((text) => text.trim()).join("\\n").slice(0, maxChars)',
+        guidance:
+          "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing.",
+      },
+    ]);
+  });
+
+  it("flags display truncation from generic string values", () => {
+    const source = `
+      const preview = normalized.length > maxLen ? normalized.slice(0, maxLen - 1) + "…" : normalized;
+    `;
+
+    expect(findBoundarySafetyViolations(source, "src/channels/example.ts")).toEqual([
+      {
+        line: 2,
+        ruleId: "boundary/text-utf16-truncation",
+        match: "normalized.slice(0, maxLen - 1)",
         guidance:
           "Use truncateUtf16Safe(...) for head truncation or sliceUtf16Safe(...) for non-head slicing.",
       },
@@ -100,6 +123,85 @@ describe("check-boundary-safety", () => {
     ]);
   });
 
+  it("flags returned and deferred response body reads", () => {
+    const source = `
+      export async function readProvider(response: Response) {
+        return response.json();
+      }
+      export const readText = (res: Response) => res.text().catch(() => "");
+    `;
+
+    expect(findBoundarySafetyViolations(source, "src/agents/provider-client.ts")).toEqual([
+      {
+        line: 3,
+        ruleId: "boundary/response-body-limit",
+        match: "response.json()",
+        guidance:
+          "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code.",
+      },
+      {
+        line: 5,
+        ruleId: "boundary/response-body-limit",
+        match: "res.text()",
+        guidance:
+          "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code.",
+      },
+    ]);
+  });
+
+  it("flags cloned response body reads", () => {
+    const source = `
+      export async function readProvider(response: Response) {
+        await response.clone().text();
+        const clone = response.clone();
+        return await clone.arrayBuffer();
+      }
+    `;
+
+    expect(findBoundarySafetyViolations(source, "src/agents/provider-client.ts")).toEqual([
+      {
+        line: 3,
+        ruleId: "boundary/response-body-limit",
+        match: "response.clone().text()",
+        guidance:
+          "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code.",
+      },
+      {
+        line: 5,
+        ruleId: "boundary/response-body-limit",
+        match: "clone.arrayBuffer()",
+        guidance:
+          "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code.",
+      },
+    ]);
+  });
+
+  it("flags all full-buffer response readers", () => {
+    const source = `
+      export async function readProvider(response: Response) {
+        await response.blob();
+        return await response.formData();
+      }
+    `;
+
+    expect(findBoundarySafetyViolations(source, "src/agents/provider-client.ts")).toEqual([
+      {
+        line: 3,
+        ruleId: "boundary/response-body-limit",
+        match: "response.blob()",
+        guidance:
+          "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code.",
+      },
+      {
+        line: 4,
+        ruleId: "boundary/response-body-limit",
+        match: "response.formData()",
+        guidance:
+          "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code.",
+      },
+    ]);
+  });
+
   it("does not flag Express response writers", () => {
     const source = `
       app.get("/health", (_req, res) => {
@@ -122,6 +224,25 @@ describe("check-boundary-safety", () => {
     `;
 
     expect(findBoundarySafetyViolations(source, "src/infra/http-body.ts")).toStrictEqual([]);
+  });
+
+  it("does not treat ordinary string literals as boundary-safety ignores", () => {
+    const source = `
+      export async function readFallback(response: Response) {
+        const body = logger.debug("boundary-safety-ignore boundary/response-body-limit: no stream exists") || await response.text();
+        return body;
+      }
+    `;
+
+    expect(findBoundarySafetyViolations(source, "src/agents/provider-client.ts")).toEqual([
+      {
+        line: 3,
+        ruleId: "boundary/response-body-limit",
+        match: "response.text()",
+        guidance:
+          "Use readResponseWithLimit(...), readProviderJsonResponse(...), readResponseTextSnippet(...), or openclaw/plugin-sdk/response-limit-runtime from plugin code.",
+      },
+    ]);
   });
 
   it("keeps tests, fixtures, generated files, and scripts out of production candidates", () => {

--- a/test/vitest/vitest.unit-fast-paths.mjs
+++ b/test/vitest/vitest.unit-fast-paths.mjs
@@ -207,6 +207,7 @@ export const forcedUnitFastTestFiles = [
   "src/test-utils/openclaw-test-state.test.ts",
   "src/test-utils/temp-home.test.ts",
   "src/utils.test.ts",
+  "test/scripts/check-boundary-safety.test.ts",
   "src/version.test.ts",
   "src/video-generation/provider-registry.test.ts",
 ];


### PR DESCRIPTION
## Summary

- Tighten the boundary-safety guard so changed production files catch returned/deferred `Response` body reads, cloned/aliased responses, and full-buffer `blob()` / `formData()` reads.
- Reduce UTF-16 truncation noise by excluding collection, range, suffix-removal, byte-prefix, and identifier-prefix slices, while accepting only actual `boundary-safety-ignore` comments with reasons.
- Fix the shared bounded `Response` read and `readResponseTextSnippet(...)` contracts for exact byte budgets, headerless/minimal `Response` objects, byte-truncated UTF-8, and `maxChars` ellipsis budgeting, with the full boundary inventory stable at 210 known entries.

## What Problem This Solves

OpenClaw already had canonical helpers for UTF-16-safe text truncation and bounded response reads, but the repository invariant was incomplete: new production code could still add raw head truncation or direct unbounded `Response` body reads in source shapes the original guard missed.

This update keeps the guardrail value while lowering reviewer noise. It catches the high-risk response read patterns, removes common false-positive text-slice shapes, and leaves legacy debt tracked in the 210-entry baseline instead of expanding the remediation scope.

## User Impact

Future runtime/channel/model-adjacent changes are less likely to reintroduce corrupted surrogate-pair snippets or unbounded `Response` body buffering. Diagnostic snippets are also more accurate: exact `Content-Length` bodies at the byte cap no longer get a false ellipsis, headerless/minimal `Response` objects still enforce overflow handling, byte-truncated UTF-8 no longer emits `�`, and the ellipsis stays inside the configured character budget.

## Origin / follow-up

Follow-up to #97620. That merged change fixed one bounded-read path; this PR keeps the broader source invariant that catches the same boundary regression classes when future production files change.

## Competition / linked PR analysis

This is an update to the existing #97774 branch, not a replacement PR. The related merged work considered in this repair flow includes #97620 and #99340. Those merged fixes reduce focused runtime boundary gaps, but they do not add a changed-file guard for new raw UTF-16 truncation or unbounded `Response` body reads, and they do not supersede this repository-wide guard/baseline proposal. No public API, user configuration, schema, protocol, data format, default-value, or migration contract is being introduced here; the contract surface is the repository validator plus the shared `Response` snippet helper.

## Maintainer-ready notes

- **Behavior or issue addressed:** The repaired branch catches newly introduced high-confidence unbounded `Response` body reads and raw UTF-16 text truncation while reducing known false-positive classes. The bounded `Response` helpers now preserve exact byte-budget snippets without a false ellipsis, keep headerless/minimal `Response` objects on the overflow-enforced path, drop incomplete UTF-8 tails instead of emitting `�`, and count the ellipsis within `maxChars`.
- **Why it matters / User impact:** The guard turns repeated boundary review findings into a source-of-truth validation invariant for changed production files, while the runtime fix prevents malformed or misleading diagnostic snippets from the shared `Response` helper.
- **Fix classification:** Root cause fix
- **Maintainer-ready confidence:** High for the local guard behavior and shared `Response` snippet semantics covered by focused tests, prior `check:changed`, and latest diff hygiene. A later full local `check:changed` rerun after the expectation-only CI fix reached typecheck, then failed in `lint core` because `tsgolint` was SIGTERM'd without a code diagnostic; the remaining review question is maintainer policy acceptance for a baseline-backed changed-file gate.
- **Root cause:** The root cause was a missing source invariant: OpenClaw had canonical UTF-16 and bounded-response helpers, but no changed-file validator contract preventing new production files from bypassing those helpers. The initial guard also over- and under-matched important parser shapes, which caused review noise and missed returned/cloned `Response` reads.
- **Why this is root-cause fix:** `scripts/check-boundary-safety.mjs` is now the validation source of truth for this invariant, so new raw text truncation and unbounded `Response` reads fail changed-file validation before they reach runtime code. `src/infra/http-body.ts` fixes the canonical snippet contract itself rather than patching individual call sites.
- **What did NOT change:** The patch only changes the boundary-safety guard, its baseline/tests, and the shared `Response` snippet semantics. It does not change credentials, user configuration, browser UI, public APIs, schema/protocol formats, migrations, or attempt full legacy remediation for all 210 baseline-known entries.
- **Architecture / source-of-truth check:** `scripts/check-boundary-safety.mjs` is the validator and `test/fixtures/boundary-safety-inventory.json` is the baseline contract. `src/infra/http-body.ts` owns bounded response/snippet reads, and `@openclaw/normalization-core/utf16-slice` remains the canonical UTF-16-safe text owner.
- **Patch quality notes:** The large fixture diff is the explicit 210-entry baseline contract, not unrelated cleanup. The parser guard uses explicit false returns for non-candidate AST shapes, and the body-less `Response` path keeps a narrow comment-only ignore because maxBytes enforcement happens immediately after the only available read path.
- **Target test file:** `test/scripts/check-boundary-safety.test.ts`; `src/infra/http-body.response.test.ts`; `src/agents/runtime/proxy.test.ts`; `src/agents/anthropic-transport-stream.test.ts`.
- **Scenario locked in:** Returned, deferred, cloned, and full-buffer `Response` reads are flagged; collection/range/suffix/byte slices are not treated as user-visible text truncation; spoofed ignore strings do not suppress violations; bounded response reads handle headerless/minimal `Response` objects; snippet output handles exact byte caps plus UTF-8/max-char boundaries correctly.
- **Why this is the smallest reliable guardrail:** A baseline-backed changed-file guard prevents new regressions without forcing broad legacy remediation in the same PR. The runtime hunk is limited to the shared helper semantics that the guard points callers toward.

## Real behavior proof

- **Behavior or issue addressed:** The repaired branch catches newly introduced high-confidence unbounded `Response` body reads and raw UTF-16 text truncation while reducing known false-positive classes. The bounded `Response` helpers now preserve exact byte-budget snippets without a false ellipsis, keep headerless/minimal `Response` objects on the overflow-enforced path, drop incomplete UTF-8 tails instead of emitting `�`, and count the ellipsis within `maxChars`.
- **Canonical reachability path:** Developer changes production TypeScript source → `pnpm check:changed` / `node scripts/check-boundary-safety.mjs` derives the changed-file set from git → `scripts/check-boundary-safety.mjs` parses those source files with TypeScript AST rules → new raw head UTF-16 slices or full `Response` body reads are compared against `test/fixtures/boundary-safety-inventory.json` → changed-file validation fails with guidance before the code can merge. Runtime snippet reachability is HTTP/provider/channel response handling → shared `src/infra/http-body.ts` bounded reader → diagnostic/error snippet text returned to callers.
- **Boundary crossed:** Repository validation crosses the source-to-CI boundary for changed production files, and the runtime proof crosses real local WHATWG `Response` stream boundaries, including unknown/headerless responses, exact `Content-Length`, clone/alias response reads, byte-truncated UTF-8, and stalled/overflowing body streams.
- **Shared helper / provider constraint check:** The validator points new code to existing shared helpers (`truncateUtf16Safe`, `sliceUtf16Safe`, `readResponseWithLimit`, `readResponseTextSnippet`, and `readProviderJsonResponse`) instead of adding provider-specific policy. No provider credentials, routing, schema, model selection, or channel protocol constraint changed.
- **Real environment tested:** Local Linux OpenClaw repair worktree at `/media/vdb/code/ai/aispace/openclaw-worktrees/pr-97774`, branch `repair/pr-97774`, after `daily_fix.sh sync-main` onto current `origin/main`. The exercised behavior is repository guard execution plus real local WHATWG `Response` stream handling in Vitest.
- **Exact steps or command run after this patch:**

```bash
cd /media/vdb/code/ai/aispace/openclaw-worktrees/pr-97774 && node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts test/scripts/check-boundary-safety.test.ts
```

```bash
cd /media/vdb/code/ai/aispace/openclaw-worktrees/pr-97774 && node scripts/run-vitest.mjs run src/infra/http-body.response.test.ts
```

```bash
cd /media/vdb/code/ai/aispace/openclaw-worktrees/pr-97774 && node scripts/run-vitest.mjs run src/agents/runtime/proxy.test.ts -t "bounds non-2xx proxy JSON error reads"
```

```bash
cd /media/vdb/code/ai/aispace/openclaw-worktrees/pr-97774 && node scripts/run-vitest.mjs run src/agents/anthropic-transport-stream.test.ts -t "bounds streamed Anthropic error responses without content-length"
```

```bash
cd /media/vdb/code/ai/aispace/openclaw-worktrees/pr-97774 && node scripts/run-vitest.mjs run src/agents/tool-search.test.ts -t "aborts already-started bridged calls when code mode times out"
```

```bash
cd /media/vdb/code/ai/aispace/openclaw-worktrees/pr-97774 && pnpm test src/acp/control-plane/manager.cancel-session.test.ts src/acp/control-plane/manager.turn-results.test.ts
```

```bash
cd /media/vdb/code/ai/aispace/openclaw-worktrees/pr-97774 && node scripts/check-boundary-safety.mjs --all && node scripts/check-boundary-safety.mjs
```

```bash
gh pr checks 97774 --repo openclaw/openclaw --watch
```

```bash
cd /media/vdb/code/ai/aispace/openclaw-worktrees/pr-97774 && CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm check:changed
```

- **Evidence after fix:**

```text
node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts test/scripts/check-boundary-safety.test.ts
Test Files  1 passed (1)
Tests  18 passed (18)
```

```text
node scripts/run-vitest.mjs run src/infra/http-body.response.test.ts
Test Files  1 passed (1)
Tests  24 passed (24)
```

```text
node scripts/run-vitest.mjs run src/agents/runtime/proxy.test.ts -t "bounds non-2xx proxy JSON error reads"
Test Files  2 passed (2)
Tests  2 passed | 22 skipped (24)
```

```text
node scripts/run-vitest.mjs run src/agents/anthropic-transport-stream.test.ts -t "bounds streamed Anthropic error responses without content-length"
Test Files  2 passed (2)
Tests  2 passed | 198 skipped (200)
```

```text
node scripts/run-vitest.mjs run src/agents/tool-search.test.ts -t "aborts already-started bridged calls when code mode times out"
Test Files  2 passed (2)
Tests  2 passed | 96 skipped (98)
```

```text
pnpm test src/acp/control-plane/manager.cancel-session.test.ts src/acp/control-plane/manager.turn-results.test.ts
Test Files  1 passed (1)
Tests  18 passed (18)
Test Files  1 passed (1)
Tests  1 passed (1)
[test] passed 2 Vitest shards in 43.14s
```

```text
gh pr checks 97774 --repo openclaw/openclaw --watch
checks-node-compact-large-2 pass
check-lint pass
check-guards pass
check-prod-types pass
check-test-types pass
Real behavior proof pass
Security High (process-exec-boundary) pass
Critical Quality (agent-runtime-boundary) pass
exit code 0
```

```text
node scripts/check-boundary-safety.mjs --all
Boundary safety baseline matches (210 entries).

node scripts/check-boundary-safety.mjs
Boundary safety changed-file check passed (0 changed-file entries, all baseline-known).
```

```text
CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm check:changed
[check:changed] lanes=core, coreTests, tooling
Boundary safety changed-file check passed (0 changed-file entries, all baseline-known).
Import cycle check: 0 runtime value cycle(s).
exit code 0
```

- **Observed result after fix:** Focused guard tests pass with coverage for returned/deferred `Response` reads, response clones/aliases, `blob()` / `formData()`, generic display truncation, comment-only ignores, and false-positive boundaries. Focused response-body tests pass with exact `Content-Length` byte-budget, headerless/minimal `Response` overflow handling, byte-truncated UTF-8, and max-char ellipsis semantics. The proxy non-2xx oversized-body regression now reports `Proxy error body exceeded 16777216 bytes`. The Anthropic streamed error response test now expects the ellipsis inside the 400-character budget and passes. The ACP cancellation tests requested by ClawSweeper pass. After syncing main, the full boundary inventory is refreshed to 210 entries, changed-file enforcement reports 0 new entries, and the exact-head hosted checks completed without failures.
- **What was not tested:** No browser UI or hosted CI success is claimed from local proof. The remote `tool-search` abort-signal failure was checked with its targeted local test and passed locally; this PR does not claim that local result as a hosted CI pass. Network integrations were not exercised because this patch changes the repository guard and shared `Response` stream helper, not an integration-specific transport path.
- **Fix classification:** Root cause fix

## Review findings addressed

- **RF-001 — waiting-on-author label:** Addressed by pushing the repair commits and re-running exact-head checks. Label clearing is left to ClawSweeper/maintainer automation; no direct label mutation was made.
- **RF-002 — refresh exact-head CI:** Addressed. After the latest head was pushed, `gh pr checks 97774 --repo openclaw/openclaw --watch` exited 0; key checks including `checks-node-compact-large-2`, `check-lint`, `check-guards`, `check-prod-types`, `check-test-types`, `Real behavior proof`, `Security High (process-exec-boundary)`, and `Critical Quality (agent-runtime-boundary)` passed.
- **RF-003 — ACP `cancelled` compatibility:** Addressed by preserving the ACP `cancelled` terminal status compatibility in the repaired branch and verifying the relevant ACP manager tests.
- **RF-004 — baseline-backed guard policy:** Disclosed as maintainer policy territory. The full inventory is now 210 entries after main sync, changed-file enforcement reports 0 new entries, and the PR body calls out maintainer acceptance of the baseline-backed gate as the remaining non-code decision.
- **RF-005 — branch behind / exact merge result:** Addressed with `daily_fix.sh sync-main`, which rebased the repair branch onto current `origin/main`; the baseline was refreshed after sync and exact-head checks were re-run.
- **RF-006 — narrow ACP repair versus guard policy:** Addressed by keeping the ACP compatibility repair separate from the guard-policy decision in this explanation: ACP cancellation compatibility is verified, while guard adoption remains an explicit maintainer review item.
- **RF-007 — restore cancelled ACP task status:** Addressed in `src/acp/control-plane/manager.background-task.ts` by retaining the `cancelled` terminal status path expected by current main.
- **RF-008 — requested ACP tests:** Addressed. `pnpm test src/acp/control-plane/manager.cancel-session.test.ts src/acp/control-plane/manager.turn-results.test.ts` passed after sync.
- **RF-009 — `pnpm check:changed`:** Addressed through prior local `check:changed` success, post-sync targeted validation, and exact-head hosted checks. A local post-expectation rerun hit a `tsgolint` SIGTERM without a code diagnostic, but hosted `check-lint`, `check-guards`, type/test checks, compact test shards, and security checks passed on the pushed head.
- **ClawSweeper — latest CI attribution:** Addressed. The contributor-fixable failure in `src/agents/anthropic-transport-stream.test.ts` was a stale expectation after ellipsis budgeting changed; the test now matches the shared helper contract and `checks-node-compact-large-2` passes remotely.
- **ClawSweeper — superseded-by-runtime-fix concern:** Addressed in scope notes. #99340 covers the body-less HTTP error snippet path; it does not replace this PR's changed-file validator, 210-entry baseline, response-read detector, or UTF-16 guardrail.
- **ClawSweeper — stored data model signal:** Treated as a false-positive policy signal from test fixtures/baseline metadata. This PR does not add or migrate production persisted state, serialized user data, vector metadata, schema, or upgrade format.

## Regression Test Plan

- **Target test file:** `test/scripts/check-boundary-safety.test.ts`; `src/infra/http-body.response.test.ts`; `src/agents/runtime/proxy.test.ts`; `src/agents/anthropic-transport-stream.test.ts`.
- **Scenario locked in:** Guard tests lock returned/deferred/cloned/full-buffer `Response` reads, generic display truncation, actual-comment ignores, spoofed ignore strings, and collection/range/suffix/byte false-positive boundaries. Response tests lock exact byte-budget snippets, headerless/minimal `Response` overflow handling, byte-truncated UTF-8 behavior, max-char ellipsis budgeting, stalling-stream cancellation, and body-less handling.
- **Why this is the smallest reliable guardrail:** These regression tests cover the source invariant and shared helper contract directly, so the PR does not need broad legacy migrations or integration-specific fixtures to prove the repaired behavior.
- `test/fixtures/boundary-safety-inventory.json` is the current full inventory contract: 210 baseline-known entries after the refactor.
- `pnpm check:changed` covers conflict markers, package guardrails, typecheck, lint, boundary-safety guard, import cycles, and related repository guards for this changed-file set.

## Merge risk

- **Risk labels considered:** CI/tooling, security-boundary, compatibility, message-delivery text boundaries, auth-adjacent response reads, session-state text previews, and availability of the changed-file check path.
- **Risk explanation:** The PR adds a baseline-backed guard that can fail future changed-file checks when production code introduces high-confidence raw UTF-16 truncation or unbounded `Response` body reads. The runtime snippet helper also changes how diagnostics mark exact byte budgets and truncated UTF-8. The remaining non-code risk is maintainer acceptance of the guard/baseline policy, not an unresolved contributor proof gap.
- **Why acceptable:** The guard fails with actionable guidance to use `truncateUtf16Safe`, `sliceUtf16Safe`, `readResponseWithLimit`, `readResponseTextSnippet`, `readProviderJsonResponse`, or a narrow comment-only ignore with a reason. Existing debt remains baseline-known at 210 entries, changed-file enforcement reports 0 new entries, the runtime behavior is covered by focused `Response` stream tests, and ClawSweeper's stored-data signal maps to test fixtures rather than a production migration.

## Risk / Compatibility

- **Guard adoption risk:** The PR adds a validation gate that can block future source changes introducing high-confidence raw UTF-16 truncation or unbounded `Response` reads. This is intentionally maintainer-policy territory because it changes future review/CI behavior.
- **False-positive/noise boundary:** The guard is high-confidence rather than exhaustive. Existing debt stays visible in the 210-entry baseline, while changed-file enforcement stays focused on new violations.
- **Runtime compatibility:** `readResponseTextSnippet(...)` still cancels stalling exact-budget streams when size is not proven. It only avoids the truncation ellipsis when `Content-Length` proves the exact byte budget was also EOF, and all ellipsis output now stays inside `maxChars`.
- **Stored data model boundary:** The changed serialized-looking content is test/baseline material only. No production persisted state, migration, vector metadata contract, schema, or user-data upgrade path changes in this PR.
- **Public contract boundary:** No user-facing API, config, schema, protocol, default, or migration contract is changed. The contract being clarified is internal validation ownership for boundary safety and the shared helper's diagnostic snippet semantics.

## What was not changed

- No public APIs, credential/configuration behavior, browser UI, schema/protocol formats, migrations, or integration-specific runtime behavior were changed.
- The PR does not attempt full legacy remediation for all 210 baseline-known entries.
- The PR does not replace maintainer policy judgment about whether OpenClaw should adopt this guard now.
- No `CHANGELOG.md` changes were made.

## Root Cause

- **Root cause:** The root cause was a missing repository-level source invariant for boundary code: new production files could still introduce raw UTF-16 code-unit truncation or direct unbounded `Response` body reads even though canonical helpers existed. The first guard version also had parser-rule gaps that missed returned/cloned reads and produced noisy matches for collection/range/suffix/byte slices.
- **Why this is root-cause fix:** This refactor puts the invariant in `scripts/check-boundary-safety.mjs`, keeps its full baseline in `test/fixtures/boundary-safety-inventory.json`, and fixes `src/infra/http-body.ts` where the shared snippet contract is owned. That prevents new violations at validation time and repairs the canonical runtime helper instead of masking individual call sites.
