### PR TITLE
fix: apply text transforms to tool calls

### DIFF
--- a/packages/agent-core/src/agent-loop.ts
+++ b/packages/agent-core/src/agent-loop.ts
@@ -88,6 +88,17 @@ function removeNonExecutableToolCalls(message: AssistantMessage): AssistantMessa
   return content.length === message.content.length ? message : { ...message, content };
 }
 
+async function finalizeAssistantMessageForLoop(
+  message: AssistantMessage,
+  config: AgentLoopConfig,
+  signal: AbortSignal | undefined,
+): Promise<AssistantMessage> {
+  const executableMessage = removeNonExecutableToolCalls(message);
+  return config.transformAssistantMessage
+    ? await config.transformAssistantMessage(executableMessage, signal)
+    : executableMessage;
+}
+
 /**
  * Start an agent loop with a new prompt message.
  * The prompt is added to the context and events are emitted for it.
@@ -516,7 +527,11 @@ async function streamAssistantResponse(
 
       case "done":
       case "error": {
-        const finalMessage = removeNonExecutableToolCalls(await response.result());
+        const finalMessage = await finalizeAssistantMessageForLoop(
+          await response.result(),
+          config,
+          signal,
+        );
         if (addedPartial) {
           context.messages[context.messages.length - 1] = finalMessage;
         } else {
@@ -531,7 +546,11 @@ async function streamAssistantResponse(
     }
   }
 
-  const finalMessage = removeNonExecutableToolCalls(await response.result());
+  const finalMessage = await finalizeAssistantMessageForLoop(
+    await response.result(),
+    config,
+    signal,
+  );
   if (addedPartial) {
     context.messages[context.messages.length - 1] = finalMessage;
   } else {

--- a/packages/agent-core/src/agent.ts
+++ b/packages/agent-core/src/agent.ts
@@ -110,6 +110,8 @@ export interface AgentOptions {
   convertToLlm?: (messages: AgentMessage[]) => Message[] | Promise<Message[]>;
   /** Optionally rewrite context before each provider request. */
   transformContext?: (messages: AgentMessage[], signal?: AbortSignal) => Promise<AgentMessage[]>;
+  /** Optionally rewrite finalized assistant messages before emitting/executing. */
+  transformAssistantMessage?: AgentLoopConfig["transformAssistantMessage"];
   /** Injected stream runtime used when streamFn is not supplied. */
   runtime?: AgentCoreStreamRuntimeDeps;
   /** Explicit stream implementation, preferred over runtime.streamSimple. */
@@ -214,6 +216,7 @@ export class Agent {
     messages: AgentMessage[],
     signal?: AbortSignal,
   ) => Promise<AgentMessage[]>;
+  public transformAssistantMessage?: AgentLoopConfig["transformAssistantMessage"];
   public runtime?: AgentCoreStreamRuntimeDeps;
   public streamFn: StreamFn;
   public getApiKey?: (provider: string) => Promise<string | undefined> | string | undefined;
@@ -247,6 +250,7 @@ export class Agent {
     this.mutableState = createMutableAgentState(options.initialState);
     this.convertToLlm = options.convertToLlm ?? defaultConvertToLlm;
     this.transformContext = options.transformContext;
+    this.transformAssistantMessage = options.transformAssistantMessage;
     this.runtime = options.runtime;
     this.streamFn = resolveAgentCoreStreamFn(options.runtime, options.streamFn);
     this.getApiKey = options.getApiKey;
@@ -495,6 +499,7 @@ export class Agent {
         : undefined,
       convertToLlm: this.convertToLlm,
       transformContext: this.transformContext,
+      transformAssistantMessage: this.transformAssistantMessage,
       getApiKey: this.getApiKey,
       getSteeringMessages: async () => {
         if (skipInitialSteeringPoll) {

--- a/packages/agent-core/src/types.ts
+++ b/packages/agent-core/src/types.ts
@@ -196,6 +196,18 @@ export interface AgentLoopConfig extends SimpleStreamOptions {
   transformContext?: (messages: AgentMessage[], signal?: AbortSignal) => Promise<AgentMessage[]>;
 
   /**
+   * Optional transform applied to each finalized assistant message before it is
+   * emitted, stored in loop state, or used for tool execution.
+   *
+   * Contract: must not throw or reject. Return the original message or another
+   * safe fallback value instead.
+   */
+  transformAssistantMessage?: (
+    message: AssistantMessage,
+    signal?: AbortSignal,
+  ) => Promise<AssistantMessage> | AssistantMessage;
+
+  /**
    * Resolves an API key dynamically for each LLM call.
    *
    * Useful for short-lived OAuth tokens (e.g., GitHub Copilot) that may expire

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -47,6 +47,7 @@ import { resolveHeartbeatSummaryForAgent } from "../../../infra/heartbeat-summar
 import { getMachineDisplayName } from "../../../infra/machine-name.js";
 import { createCodexNativeWebSearchWrapper } from "../../../llm/providers/stream-wrappers/openai.js";
 import type { AssistantMessage } from "../../../llm/types.js";
+import type { PluginTextReplacement } from "../../../plugins/cli-backend.types.js";
 import { listRegisteredPluginAgentPromptGuidance } from "../../../plugins/command-registry-state.js";
 import { getCurrentPluginMetadataSnapshot } from "../../../plugins/current-plugin-metadata-snapshot.js";
 import {
@@ -178,7 +179,10 @@ import {
 import { resolveModelAuthMode } from "../../model-auth.js";
 import { resolveDefaultModelForAgent } from "../../model-selection.js";
 import { supportsModelTools } from "../../model-tool-support.js";
-import { wrapStreamFnTextTransforms } from "../../plugin-text-transforms.js";
+import {
+  transformPluginMessageText,
+  wrapStreamFnTextTransforms,
+} from "../../plugin-text-transforms.js";
 import { resolveAgentPromptSurfaceForSessionKey } from "../../prompt-surface.js";
 import { describeProviderRequestRoutingSummary } from "../../provider-attribution.js";
 import { registerProviderStreamForModel } from "../../provider-stream.js";
@@ -533,6 +537,37 @@ export {
 
 const MAX_BTW_SNAPSHOT_MESSAGES = 100;
 const PROMPT_TOOL_RESULT_AGGREGATE_CAP_MULTIPLIER = 4;
+
+type AssistantMessageTransform = (
+  message: AssistantMessage,
+  signal?: AbortSignal,
+) => AssistantMessage | Promise<AssistantMessage>;
+type AssistantMessageTransformAgent = {
+  transformAssistantMessage?: AssistantMessageTransform;
+};
+
+const originalAssistantMessageTransformByAgent = new WeakMap<
+  AssistantMessageTransformAgent,
+  AssistantMessageTransform | undefined
+>();
+
+function installAttemptAssistantMessageTextTransform(
+  agent: AssistantMessageTransformAgent,
+  output?: PluginTextReplacement[],
+): void {
+  if (!originalAssistantMessageTransformByAgent.has(agent)) {
+    originalAssistantMessageTransformByAgent.set(agent, agent.transformAssistantMessage);
+  }
+  const originalTransform = originalAssistantMessageTransformByAgent.get(agent);
+  if (!output || output.length === 0) {
+    agent.transformAssistantMessage = originalTransform;
+    return;
+  }
+  agent.transformAssistantMessage = async (message, signal) => {
+    const baseMessage = originalTransform ? await originalTransform(message, signal) : message;
+    return transformPluginMessageText(baseMessage, output);
+  };
+}
 
 function pluginMetadataSnapshotCoversProvider(
   snapshot: PluginMetadataSnapshot | undefined,
@@ -2876,8 +2911,13 @@ export async function runEmbeddedAttempt(
           input: providerTextTransforms.input,
           output: providerTextTransforms.output,
           transformSystemPrompt: false,
+          transformFinalResult: false,
         });
       }
+      installAttemptAssistantMessageTextTransform(
+        activeSession.agent,
+        providerTextTransforms?.output,
+      );
       const nativeWebSearchPolicyContext = {
         sessionKey: sandboxSessionKey,
         sandboxToolPolicy: sandbox?.tools,

--- a/src/agents/plugin-text-transforms.test.ts
+++ b/src/agents/plugin-text-transforms.test.ts
@@ -1,15 +1,18 @@
 // Verifies plugin text transforms rewrite prompts and streamed assistant output.
-import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
+import { runAgentLoop, type AgentEvent, type StreamFn } from "openclaw/plugin-sdk/agent-core";
 import {
   createAssistantMessageEventStream,
   type AssistantMessage,
   type Context,
   type Model,
+  type ToolCall,
 } from "openclaw/plugin-sdk/llm";
+import { Type } from "typebox";
 import { describe, expect, it } from "vitest";
 import {
   applyPluginTextReplacements,
   mergePluginTextTransforms,
+  transformPluginMessageText,
   wrapStreamFnTextTransforms,
 } from "./plugin-text-transforms.js";
 
@@ -37,6 +40,14 @@ function makeAssistantMessage(text: string): AssistantMessage {
       cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
     },
     timestamp: 0,
+  };
+}
+
+function makeAssistantToolMessage(toolCall: ToolCall): AssistantMessage {
+  return {
+    ...makeAssistantMessage("unused"),
+    content: [toolCall],
+    stopReason: "toolUse",
   };
 }
 
@@ -179,5 +190,181 @@ describe("plugin text transforms", () => {
     expect(firstEvent?.type).toBe("text_delta");
     expect(firstEvent?.delta).toBe("red basket on the left shelf");
     expect(result.content).toEqual([{ type: "text", text: "final red basket on the left shelf" }]);
+  });
+
+  it("wraps streamed tool call deltas and argument strings with outbound replacements", async () => {
+    const streamedToolCall: ToolCall = {
+      type: "toolCall",
+      id: "call_[MASKED]",
+      name: "send_[MASKED]",
+      arguments: {
+        text: "Message for [MASKED]",
+        nested: { title: "[MASKED] follow-up", count: 2 },
+        recipients: ["[MASKED]", "ops", true],
+      },
+      partialArgs: '{"text":"Message for [MASKED]"}',
+      partialJson: '{"text":"Message for [MASKED]"}',
+    } as ToolCall;
+    const finalToolCall: ToolCall = {
+      ...streamedToolCall,
+      arguments: {
+        text: "Final message for [MASKED]",
+        nested: { title: "[MASKED] final", enabled: false },
+      },
+      partialArgs: '{"text":"Final message for [MASKED]"}',
+      partialJson: '{"text":"Final message for [MASKED]"}',
+    } as ToolCall;
+    const partial = makeAssistantToolMessage(streamedToolCall);
+    const finalMessage = makeAssistantToolMessage(finalToolCall);
+    const baseStreamFn: StreamFn = () => {
+      const stream = createAssistantMessageEventStream();
+      queueMicrotask(() => {
+        stream.push({
+          type: "toolcall_delta",
+          contentIndex: 0,
+          delta: '{"text":"Message for [MASKED]"}',
+          partial,
+        });
+        stream.push({
+          type: "toolcall_end",
+          contentIndex: 0,
+          toolCall: streamedToolCall,
+          partial,
+        });
+        stream.push({
+          type: "done",
+          reason: "toolUse",
+          message: finalMessage,
+        });
+        stream.end();
+      });
+      return stream;
+    };
+
+    const wrapped = wrapStreamFnTextTransforms({
+      streamFn: baseStreamFn,
+      output: [{ from: /\[MASKED\]/g, to: "John Smith" }],
+    });
+    const stream = await Promise.resolve(wrapped(model, { messages: [] } as Context, undefined));
+    const events = [];
+    for await (const event of stream) {
+      events.push(event);
+    }
+    const result = await stream.result();
+
+    const delta = events[0] as { type?: string; delta?: string; partial?: AssistantMessage };
+    expect(delta.type).toBe("toolcall_delta");
+    expect(delta.delta).toBe('{"text":"Message for John Smith"}');
+    expect(delta.partial?.content[0]).toMatchObject({
+      id: "call_[MASKED]",
+      name: "send_[MASKED]",
+      partialArgs: '{"text":"Message for John Smith"}',
+      partialJson: '{"text":"Message for John Smith"}',
+      arguments: {
+        text: "Message for John Smith",
+        nested: { title: "John Smith follow-up", count: 2 },
+        recipients: ["John Smith", "ops", true],
+      },
+    });
+
+    const end = events[1] as { type?: string; toolCall?: ToolCall; partial?: AssistantMessage };
+    expect(end.type).toBe("toolcall_end");
+    expect(end.toolCall).toMatchObject({
+      id: "call_[MASKED]",
+      name: "send_[MASKED]",
+      partialArgs: '{"text":"Message for John Smith"}',
+      partialJson: '{"text":"Message for John Smith"}',
+      arguments: {
+        text: "Message for John Smith",
+        nested: { title: "John Smith follow-up", count: 2 },
+        recipients: ["John Smith", "ops", true],
+      },
+    });
+    expect(result.content[0]).toMatchObject({
+      id: "call_[MASKED]",
+      name: "send_[MASKED]",
+      partialArgs: '{"text":"Final message for John Smith"}',
+      partialJson: '{"text":"Final message for John Smith"}',
+      arguments: {
+        text: "Final message for John Smith",
+        nested: { title: "John Smith final", enabled: false },
+      },
+    });
+  });
+
+  it("rewrites finalized tool call arguments before agent tool execution", async () => {
+    const output = [{ from: /cat/g, to: "black cat" }];
+    const capturedEvents: AgentEvent[] = [];
+    const executedArgs: unknown[] = [];
+    let turn = 0;
+    const baseStreamFn: StreamFn = () => {
+      turn += 1;
+      const stream = createAssistantMessageEventStream();
+      queueMicrotask(() => {
+        const message =
+          turn === 1
+            ? makeAssistantToolMessage({
+                type: "toolCall",
+                id: "call_read",
+                name: "read",
+                arguments: { path: "cat.txt" },
+                partialArgs: '{"path":"cat.txt"}',
+              } as ToolCall)
+            : makeAssistantMessage("done");
+        stream.push({
+          type: "done",
+          reason: message.stopReason === "toolUse" ? "toolUse" : "stop",
+          message,
+        });
+        stream.end();
+      });
+      return stream;
+    };
+    const wrapped = wrapStreamFnTextTransforms({
+      streamFn: baseStreamFn,
+      output,
+      transformFinalResult: false,
+    });
+
+    await runAgentLoop(
+      [{ role: "user", content: "read it", timestamp: 1 }],
+      {
+        systemPrompt: "",
+        messages: [],
+        tools: [
+          {
+            name: "read",
+            label: "read",
+            description: "read",
+            parameters: Type.Object({ path: Type.String() }, { additionalProperties: false }),
+            execute: async (_toolCallId, args) => {
+              executedArgs.push(args);
+              return {
+                content: [{ type: "text", text: "ok" }],
+                details: args,
+                terminate: true,
+              };
+            },
+          },
+        ],
+      },
+      {
+        model,
+        convertToLlm: (messages) => messages as never,
+        transformAssistantMessage: (message) => transformPluginMessageText(message, output),
+      },
+      (event) => {
+        capturedEvents.push(event);
+      },
+      undefined,
+      wrapped,
+    );
+
+    const toolStart = capturedEvents.find(
+      (event): event is Extract<AgentEvent, { type: "tool_execution_start" }> =>
+        event.type === "tool_execution_start",
+    );
+    expect(toolStart?.args).toEqual({ path: "black cat.txt" });
+    expect(executedArgs).toEqual([{ path: "black cat.txt" }]);
   });
 });

--- a/src/agents/plugin-text-transforms.ts
+++ b/src/agents/plugin-text-transforms.ts
@@ -56,12 +56,60 @@ function transformContentText(content: unknown, replacements?: PluginTextReplace
     return content;
   }
   const next = { ...content };
+  if (next.type === "toolCall") {
+    transformToolCallFields(next, replacements);
+  }
   if (typeof next.text === "string") {
     next.text = applyPluginTextReplacements(next.text, replacements);
   }
   if (Object.hasOwn(next, "content")) {
     next.content = transformContentText(next.content, replacements);
   }
+  return next;
+}
+
+function transformToolCallArguments(
+  value: unknown,
+  replacements?: PluginTextReplacement[],
+): unknown {
+  if (typeof value === "string") {
+    return applyPluginTextReplacements(value, replacements);
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => transformToolCallArguments(entry, replacements));
+  }
+  if (!isRecord(value)) {
+    return value;
+  }
+  return Object.fromEntries(
+    Object.entries(value).map(([key, entry]) => [
+      key,
+      transformToolCallArguments(entry, replacements),
+    ]),
+  );
+}
+
+function transformToolCallFields(
+  toolCall: Record<string, unknown>,
+  replacements?: PluginTextReplacement[],
+): void {
+  if (typeof toolCall.partialArgs === "string") {
+    toolCall.partialArgs = applyPluginTextReplacements(toolCall.partialArgs, replacements);
+  }
+  if (typeof toolCall.partialJson === "string") {
+    toolCall.partialJson = applyPluginTextReplacements(toolCall.partialJson, replacements);
+  }
+  if (Object.hasOwn(toolCall, "arguments")) {
+    toolCall.arguments = transformToolCallArguments(toolCall.arguments, replacements);
+  }
+}
+
+function transformToolCallText(toolCall: unknown, replacements?: PluginTextReplacement[]): unknown {
+  if (!isRecord(toolCall)) {
+    return toolCall;
+  }
+  const next = { ...toolCall };
+  transformToolCallFields(next, replacements);
   return next;
 }
 
@@ -114,6 +162,12 @@ function transformAssistantEventText(
   if (next.type === "text_end" && typeof next.content === "string") {
     next.content = applyPluginTextReplacements(next.content, replacements);
   }
+  if (next.type === "toolcall_delta" && typeof next.delta === "string") {
+    next.delta = applyPluginTextReplacements(next.delta, replacements);
+  }
+  if (next.type === "toolcall_end") {
+    next.toolCall = transformToolCallText(next.toolCall, replacements);
+  }
   if (Object.hasOwn(next, "partial")) {
     next.partial = transformMessageText(next.partial, replacements);
   }
@@ -126,15 +180,25 @@ function transformAssistantEventText(
   return next as AssistantMessageEvent;
 }
 
+export function transformPluginMessageText<T>(
+  message: T,
+  replacements?: PluginTextReplacement[],
+): T {
+  return transformMessageText(message, replacements) as T;
+}
+
 function wrapStreamTextTransforms(
   stream: MutableAssistantMessageEventStream,
   replacements?: PluginTextReplacement[],
+  options?: { transformFinalResult?: boolean },
 ): MutableAssistantMessageEventStream {
   if (!replacements || replacements.length === 0) {
     return stream;
   }
-  const originalResult = stream.result.bind(stream);
-  stream.result = async () => transformMessageText(await originalResult(), replacements) as never;
+  if (options?.transformFinalResult !== false) {
+    const originalResult = stream.result.bind(stream);
+    stream.result = async () => transformMessageText(await originalResult(), replacements) as never;
+  }
 
   // Wrap async iteration so streamed deltas and the final result receive the
   // same output replacement policy.
@@ -164,6 +228,7 @@ export function wrapStreamFnTextTransforms(params: {
   input?: PluginTextReplacement[];
   output?: PluginTextReplacement[];
   transformSystemPrompt?: boolean;
+  transformFinalResult?: boolean;
 }): StreamFn {
   return (model, context, options) => {
     const nextContext = transformStreamContextText(context, params.input, {
@@ -172,9 +237,13 @@ export function wrapStreamFnTextTransforms(params: {
     const maybeStream = params.streamFn(model, nextContext, options);
     if (maybeStream && typeof maybeStream === "object" && "then" in maybeStream) {
       return Promise.resolve(maybeStream).then((stream) =>
-        wrapStreamTextTransforms(stream, params.output),
+        wrapStreamTextTransforms(stream, params.output, {
+          transformFinalResult: params.transformFinalResult,
+        }),
       );
     }
-    return wrapStreamTextTransforms(maybeStream, params.output);
+    return wrapStreamTextTransforms(maybeStream, params.output, {
+      transformFinalResult: params.transformFinalResult,
+    });
   };
 }


### PR DESCRIPTION
Closes #97761

## What Problem This Solves

Fixes an issue where plugin text output transforms restored assistant text but not tool-call argument payloads. When a transform masked prompt text before the provider call, tool calls could still execute with the masked value, so tools such as `read` looked for the wrong path.

AI-assisted.

## Why This Change Was Made

The stream text-transform wrapper now applies output replacements to tool-call deltas, finalized tool calls, and nested tool-call argument strings, while embedded agent runs also apply the same output transform once at the finalized assistant-message boundary before tool validation and execution. Risk note: output transforms can be non-idempotent, so embedded runs disable final-result transformation in the stream wrapper and use one loop-level finalizer to avoid double replacements.

## User Impact

Plugins that use text transforms to mask or rewrite provider-visible text can now rely on restored tool arguments before OpenClaw executes tools. Users should no longer see tool failures caused by transformed names or paths remaining in `toolcall_delta` / `toolcall_end` argument payloads.

## Evidence

Focused test:

```text
$ node scripts/run-vitest.mjs src/agents/plugin-text-transforms.test.ts
Test Files  1 passed (1)
Tests  6 passed (6)
```

Formatting and whitespace:

```text
$ pnpm exec oxfmt --check --threads=1 packages/agent-core/src/agent-loop.ts packages/agent-core/src/agent.ts packages/agent-core/src/types.ts src/agents/embedded-agent-runner/run/attempt.ts src/agents/plugin-text-transforms.ts src/agents/plugin-text-transforms.test.ts
All matched files use the correct format.

$ git diff --check
```

Real behavior proof with local DeepSeek environment:

```text
$ pnpm openclaw --profile issue-97761-proof agent --local --agent main \
  --session-key agent:main:proof-97761-toolcall-baseline-transform \
  --model deepseek/deepseek-v4-pro \
  --message 'Use the read tool exactly once to read the workspace file named "John Smith.txt". Then answer with only the file content, no extra words. Do not use exec.' \
  --json --timeout 180

finalAssistantVisibleText: OPENCLAW_97761_TOOLCALL_RESTORED
toolSummary: calls=1 tools=[read] failures=0
```

Session proof showed the executed `read` call used the restored path:

```json
{
  "name": "read",
  "arguments": {
    "path": "<proof-workspace>/John Smith.txt"
  }
}
```

Pre-PR structured review:

```text
$ .agents/skills/autoreview/scripts/autoreview --mode local
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.79)
```
