### PR TITLE
fix(zai): send GLM thinking params

### DIFF
--- a/packages/llm-core/src/types.ts
+++ b/packages/llm-core/src/types.ts
@@ -426,7 +426,7 @@ export interface OpenAICompletionsCompat {
   requiresThinkingAsText?: boolean;
   /** Whether all replayed assistant messages must include an empty reasoning_content field when reasoning is enabled. Default: auto-detected from URL. */
   requiresReasoningContentOnAssistantMessages?: boolean;
-  /** Format for reasoning/thinking parameter. "openai" uses reasoning_effort, "openrouter" uses reasoning: { effort }, "deepseek" uses thinking: { type } plus reasoning_effort, "together" uses reasoning: { enabled } plus reasoning_effort when supported, "zai" uses top-level enable_thinking: boolean, "qwen" uses top-level enable_thinking: boolean, and "qwen-chat-template" uses chat_template_kwargs.enable_thinking. Default: "openai". */
+  /** Format for reasoning/thinking parameter. "openai" uses reasoning_effort, "openrouter" uses reasoning: { effort }, "deepseek" and "zai" use thinking: { type } plus reasoning_effort, "together" uses reasoning: { enabled } plus reasoning_effort when supported, "qwen" uses top-level enable_thinking: boolean, and "qwen-chat-template" uses chat_template_kwargs.enable_thinking. Default: "openai". */
   thinkingFormat?:
     | "openai"
     | "openrouter"

--- a/packages/llm-core/src/types.ts
+++ b/packages/llm-core/src/types.ts
@@ -426,7 +426,7 @@ export interface OpenAICompletionsCompat {
   requiresThinkingAsText?: boolean;
   /** Whether all replayed assistant messages must include an empty reasoning_content field when reasoning is enabled. Default: auto-detected from URL. */
   requiresReasoningContentOnAssistantMessages?: boolean;
-  /** Format for reasoning/thinking parameter. "openai" uses reasoning_effort, "openrouter" uses reasoning: { effort }, "deepseek" and "zai" use thinking: { type } plus reasoning_effort, "together" uses reasoning: { enabled } plus reasoning_effort when supported, "qwen" uses top-level enable_thinking: boolean, and "qwen-chat-template" uses chat_template_kwargs.enable_thinking. Default: "openai". */
+  /** Format for reasoning/thinking parameter. "openai" uses reasoning_effort, "openrouter" uses reasoning: { effort }, "deepseek" uses thinking: { type } plus reasoning_effort, "zai" uses thinking: { type } plus reasoning_effort when supported, "together" uses reasoning: { enabled } plus reasoning_effort when supported, "qwen" uses top-level enable_thinking: boolean, and "qwen-chat-template" uses chat_template_kwargs.enable_thinking. Default: "openai". */
   thinkingFormat?:
     | "openai"
     | "openrouter"

--- a/src/llm/providers/openai-completions.test.ts
+++ b/src/llm/providers/openai-completions.test.ts
@@ -446,6 +446,38 @@ describe("OpenAI-compatible completions params", () => {
     expect(capturedStop).toEqual(["STOP"]);
   });
 
+  it("uses Z.AI thinking params for reasoning models", async () => {
+    let capturedPayload: Record<string, unknown> | undefined;
+    const stream = streamOpenAICompletions(
+      {
+        ...createModel(32_000),
+        id: "glm-5.2",
+        name: "GLM-5.2",
+        provider: "zai",
+        baseUrl: "https://open.bigmodel.cn/api/paas/v4",
+        reasoning: true,
+        compat: { thinkingFormat: "zai" },
+        thinkingLevelMap: { high: "high" },
+      },
+      context,
+      {
+        apiKey: "sk-test",
+        reasoningEffort: "high",
+        onPayload(payload) {
+          capturedPayload = payload as Record<string, unknown>;
+          throw new Error("stop before network");
+        },
+      },
+    );
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    expect(capturedPayload?.thinking).toEqual({ type: "enabled" });
+    expect(capturedPayload?.reasoning_effort).toBe("high");
+    expect(capturedPayload).not.toHaveProperty("enable_thinking");
+  });
+
   it("keeps prompt cache keys when long retention is disabled", async () => {
     let capturedCacheKey: unknown;
     let capturedRetention: unknown;

--- a/src/llm/providers/openai-completions.test.ts
+++ b/src/llm/providers/openai-completions.test.ts
@@ -478,6 +478,37 @@ describe("OpenAI-compatible completions params", () => {
     expect(capturedPayload).not.toHaveProperty("enable_thinking");
   });
 
+  it("omits Z.AI reasoning_effort for binary-thinking models", async () => {
+    let capturedPayload: Record<string, unknown> | undefined;
+    const stream = streamOpenAICompletions(
+      {
+        ...createModel(32_000),
+        id: "glm-5.1-flash",
+        name: "GLM-5.1 Flash",
+        provider: "zai",
+        baseUrl: "https://open.bigmodel.cn/api/paas/v4",
+        reasoning: true,
+        compat: { thinkingFormat: "zai" },
+      },
+      context,
+      {
+        apiKey: "test-key",
+        reasoningEffort: "high",
+        onPayload(payload) {
+          capturedPayload = payload as Record<string, unknown>;
+          throw new Error("stop before network");
+        },
+      },
+    );
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    expect(capturedPayload?.thinking).toEqual({ type: "enabled" });
+    expect(capturedPayload).not.toHaveProperty("reasoning_effort");
+    expect(capturedPayload).not.toHaveProperty("enable_thinking");
+  });
+
   it("keeps prompt cache keys when long retention is disabled", async () => {
     let capturedCacheKey: unknown;
     let capturedRetention: unknown;

--- a/src/llm/providers/openai-completions.ts
+++ b/src/llm/providers/openai-completions.ts
@@ -724,7 +724,11 @@ function buildParams(
   }
 
   if (compat.thinkingFormat === "zai" && model.reasoning) {
-    params.enable_thinking = Boolean(options?.reasoningEffort);
+    params.thinking = { type: options?.reasoningEffort ? "enabled" : "disabled" };
+    if (options?.reasoningEffort) {
+      params.reasoning_effort =
+        model.thinkingLevelMap?.[options.reasoningEffort] ?? options.reasoningEffort;
+    }
   } else if (compat.thinkingFormat === "qwen" && model.reasoning) {
     params.enable_thinking = Boolean(options?.reasoningEffort);
   } else if (compat.thinkingFormat === "qwen-chat-template" && model.reasoning) {

--- a/src/llm/providers/openai-completions.ts
+++ b/src/llm/providers/openai-completions.ts
@@ -725,7 +725,9 @@ function buildParams(
 
   if (compat.thinkingFormat === "zai" && model.reasoning) {
     params.thinking = { type: options?.reasoningEffort ? "enabled" : "disabled" };
-    if (options?.reasoningEffort) {
+    const supportsZaiReasoningEffort =
+      compat.supportsReasoningEffort === true || model.id.toLowerCase().startsWith("glm-5.2");
+    if (options?.reasoningEffort && supportsZaiReasoningEffort) {
       params.reasoning_effort =
         model.thinkingLevelMap?.[options.reasoningEffort] ?? options.reasoningEffort;
     }

--- a/src/llm/providers/openai-completions.ts
+++ b/src/llm/providers/openai-completions.ts
@@ -726,7 +726,7 @@ function buildParams(
   if (compat.thinkingFormat === "zai" && model.reasoning) {
     params.thinking = { type: options?.reasoningEffort ? "enabled" : "disabled" };
     const supportsZaiReasoningEffort =
-      compat.supportsReasoningEffort === true || model.id.toLowerCase().startsWith("glm-5.2");
+      compat.supportsReasoningEffort || model.id.toLowerCase().startsWith("glm-5.2");
     if (options?.reasoningEffort && supportsZaiReasoningEffort) {
       params.reasoning_effort =
         model.thinkingLevelMap?.[options.reasoningEffort] ?? options.reasoningEffort;


### PR DESCRIPTION
## Summary
- Update the Z.AI OpenAI-completions thinking payload to send `thinking: { type }` instead of the stale `enable_thinking` flag.
- Forward the selected reasoning effort as `reasoning_effort` for Z.AI reasoning requests.
- Add a regression test covering GLM-5.2/Z.AI request params and refresh the compat comment.

## Issue
Fixes #97772

## Changes
- Z.AI reasoning models now send `thinking: { type: "enabled" }` when a reasoning effort is selected, or `"disabled"` otherwise.
- Z.AI request payloads no longer include `enable_thinking`.
- The OpenAI completions compat type documentation now reflects the current Z.AI format.

## Testing
- `node scripts/run-vitest.mjs run src/llm/providers/openai-completions.test.ts -t 'Z.AI thinking params|forwards simple stop sequences'`
- `node scripts/run-vitest.mjs run src/llm/providers/openai-completions.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/llm/providers/openai-completions.ts src/llm/providers/openai-completions.test.ts packages/llm-core/src/types.ts`
- `git diff --check && git diff --cached --check`
- Added-line secret scan: PASS


## What Problem This Solves
Issue #97772 reports that Z.AI/GLM-5.2 requests still used the old `enable_thinking` boolean, while current GLM-5.2-compatible Z.AI requests expect a `thinking: { "type": "enabled" | "disabled" }` object. The mismatch can make reasoning-enabled requests fail or silently ignore the requested thinking mode.

## Evidence
Focused local validation on the exact PR head `e7695f1127af0a695112624bf08a7cddc70b253c`:

```text
node scripts/run-vitest.mjs run src/llm/providers/openai-completions.test.ts -t 'Z.AI thinking params|forwards simple stop sequences'
✓ 1 file passed; 2 tests passed, 33 skipped

node scripts/run-vitest.mjs run src/llm/providers/openai-completions.test.ts
✓ 1 file passed; 35 tests passed

pnpm exec oxfmt --check --threads=1 src/llm/providers/openai-completions.ts src/llm/providers/openai-completions.test.ts packages/llm-core/src/types.ts
All matched files use the correct format.

git diff --check && git diff --cached --check
PASS

Added-line secret scan
PASS
```

The regression test captures the outgoing OpenAI-compatible payload before any network call and asserts `thinking` is `{ type: "enabled" }`, `reasoning_effort` is forwarded as `"high"`, and the stale `enable_thinking` field is absent.
