### PR TITLE
test(config): add unit tests for sensitive config path classification

### DIFF
--- a/src/config/sensitive-paths.test.ts
+++ b/src/config/sensitive-paths.test.ts
@@ -1,0 +1,157 @@
+// Covers config path sensitivity classification -- pattern matching, whitelist
+// exemption, and local-service env override.
+import { describe, expect, it } from "vitest";
+import { isSensitiveConfigPath } from "./sensitive-paths.js";
+
+describe("isSensitiveConfigPath", () => {
+  // -- Sensitive pattern matching ---------------------------------------
+
+  describe("matches sensitive patterns", () => {
+    it("matches paths ending with token", () => {
+      expect(isSensitiveConfigPath("myToken")).toBe(true);
+      expect(isSensitiveConfigPath("auth_token")).toBe(true);
+      expect(isSensitiveConfigPath("api.bot.token")).toBe(true);
+    });
+
+    it("matches paths containing password", () => {
+      expect(isSensitiveConfigPath("password")).toBe(true);
+      expect(isSensitiveConfigPath("dbPassword")).toBe(true);
+      expect(isSensitiveConfigPath("some.password.field")).toBe(true);
+    });
+
+    it("matches paths containing secret", () => {
+      expect(isSensitiveConfigPath("clientSecret")).toBe(true);
+      expect(isSensitiveConfigPath("my_secret_key")).toBe(true);
+    });
+
+    it("matches paths matching api.?key", () => {
+      expect(isSensitiveConfigPath("apiKey")).toBe(true);
+      expect(isSensitiveConfigPath("apikey")).toBe(true);
+      expect(isSensitiveConfigPath("api_key")).toBe(true);
+      expect(isSensitiveConfigPath("openai_api_key")).toBe(true);
+    });
+
+    it("matches paths matching encrypt.?key", () => {
+      expect(isSensitiveConfigPath("encryptKey")).toBe(true);
+      expect(isSensitiveConfigPath("encrypt_key")).toBe(true);
+    });
+
+    it("matches paths matching private.?key", () => {
+      expect(isSensitiveConfigPath("privateKey")).toBe(true);
+      expect(isSensitiveConfigPath("private_key")).toBe(true);
+    });
+
+    it("matches paths ending with serviceaccount or serviceaccountref", () => {
+      expect(isSensitiveConfigPath("serviceAccount")).toBe(true);
+      expect(isSensitiveConfigPath("gcpServiceAccountRef")).toBe(true);
+      expect(isSensitiveConfigPath("azure.serviceaccount")).toBe(true);
+    });
+
+    it("is case-insensitive across all patterns", () => {
+      expect(isSensitiveConfigPath("APITOKEN")).toBe(true);
+      expect(isSensitiveConfigPath("PASSWORD")).toBe(true);
+      expect(isSensitiveConfigPath("SECRET")).toBe(true);
+      expect(isSensitiveConfigPath("APIKEY")).toBe(true);
+      expect(isSensitiveConfigPath("PRIVATEKEY")).toBe(true);
+    });
+
+    it("matches fully qualified path segments", () => {
+      expect(isSensitiveConfigPath("providers.openai.apiKey")).toBe(true);
+      expect(isSensitiveConfigPath("channels.discord.botToken")).toBe(true);
+      expect(isSensitiveConfigPath("plugins.myapp.clientSecret")).toBe(true);
+    });
+  });
+
+  // -- Whitelist exemption ----------------------------------------------
+
+  describe("whitelisted suffixes are not sensitive", () => {
+    it.each([
+      "maxTokens",
+      "maxOutputTokens",
+      "maxInputTokens",
+      "maxCompletionTokens",
+      "contextTokens",
+      "totalTokens",
+      "tokenCount",
+      "tokenLimit",
+      "tokenBudget",
+    ])("exempts token-related whitelist suffix: %s", (path) => {
+      expect(isSensitiveConfigPath(path)).toBe(false);
+    });
+
+    it("exempts passwordFile suffix", () => {
+      // passwordFile is whitelisted -- even though it contains "password"
+      expect(isSensitiveConfigPath("passwordFile")).toBe(false);
+      expect(isSensitiveConfigPath("sshPasswordFile")).toBe(false);
+    });
+
+    it("exempts whitelist suffixes case-insensitively", () => {
+      expect(isSensitiveConfigPath("MAXTOKENS")).toBe(false);
+      expect(isSensitiveConfigPath("PASSWORDFILE")).toBe(false);
+      expect(isSensitiveConfigPath("MaxTokens")).toBe(false);
+      expect(isSensitiveConfigPath("PasswordFile")).toBe(false);
+    });
+
+    it("whitelist does not leak to shorter suffixes", () => {
+      // "maxtokens" is whitelisted; bare "token" is not.
+      expect(isSensitiveConfigPath("token")).toBe(true);
+      // "passwordfile" is whitelisted; bare "password" is not.
+      expect(isSensitiveConfigPath("password")).toBe(true);
+    });
+
+    it("whitelist only applies at exact suffix match", () => {
+      // "maxtokens" is whitelisted when at path end; embedded does not exempt.
+      expect(isSensitiveConfigPath("maxToken")).toBe(true);
+    });
+  });
+
+  // -- Local service env ------------------------------------------------
+
+  describe("local service env values are always sensitive", () => {
+    it("flags localservice.env paths", () => {
+      expect(isSensitiveConfigPath("localservice.env.MY_VAR")).toBe(true);
+      expect(isSensitiveConfigPath("plugins.myapp.localservice.env.API_KEY")).toBe(true);
+    });
+
+    it("is case-insensitive for localservice.env", () => {
+      expect(isSensitiveConfigPath("LocalService.ENV.myvar")).toBe(true);
+      expect(isSensitiveConfigPath("LOCALSERVICE.ENV.TOKEN")).toBe(true);
+    });
+
+    it("takes priority over whitelist exemption", () => {
+      // Even if the variable name is a whitelisted suffix, local service env wins.
+      expect(isSensitiveConfigPath("localservice.env.maxTokens")).toBe(true);
+    });
+  });
+
+  // -- Non-sensitive paths ----------------------------------------------
+
+  describe("returns false for non-sensitive paths", () => {
+    it.each([
+      ["model", "plain model name"],
+      ["temperature", "model parameter"],
+      ["systemPrompt", "prompt text"],
+      ["plugins.myapp.enabled", "plugin toggle"],
+      ["channels.discord.guildId", "channel identifier"],
+      ["agents.defaults.maxConcurrent", "numeric limit"],
+      ["", "empty string"],
+    ])("rejects %s (%s)", (path) => {
+      expect(isSensitiveConfigPath(path)).toBe(false);
+    });
+  });
+
+  // -- Composite path ---------------------------------------------------
+
+  describe("composite config paths", () => {
+    it("correctly classifies deeply nested paths", () => {
+      // Sensitive: has apiKey in the path
+      expect(isSensitiveConfigPath("plugins.myapp.auth.apiKey")).toBe(true);
+      // Not sensitive: no sensitive pattern
+      expect(isSensitiveConfigPath("plugins.myapp.auth.method")).toBe(false);
+      // Whitelisted: ends with tokenLimit
+      expect(isSensitiveConfigPath("plugins.myapp.auth.tokenLimit")).toBe(false);
+      // Local service env overrides everything
+      expect(isSensitiveConfigPath("plugins.myapp.localservice.env.tokenLimit")).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

The `sensitive-paths.ts` module classifies config paths whose values should be redacted from UI/API output. It uses pattern matching against common secret patterns (`token`, `password`, `secret`, `api.*key`, etc.), a whitelist for known non-sensitive suffixes that happen to match (`maxTokens`, `tokenLimit`, `passwordFile`), and a local service env override that is always treated as sensitive. Despite being a core path for config redaction, this function had no direct unit tests.

## Why This Change Was Made

Add focused unit tests for `isSensitiveConfigPath` to verify:
- All 7 sensitive regex patterns match correctly (case-insensitive, fully qualified paths)
- Whitelist exemptions apply correctly for all 10 suffixes (case-insensitive, no suffix leak)
- Local service env paths are always sensitive and take priority over whitelist
- Non-sensitive paths (model, temperature, etc.) are correctly rejected
- Composite/nested config paths are correctly classified

This improves test coverage and prevents regressions when patterns or whitelist are modified.

## User Impact

Config path sensitivity classification now has 33 dedicated unit tests covering the main branching paths, reducing the risk of regressions.

## Evidence

Redacted real config path proof via production `redactConfigObject` pipeline:

```
$ node --import tsx -e "... redactConfigObject() ..."

=== Input config (with secrets) ===
{
  "providers": {
    "openai": { "apiKey": "sk-abc123", "model": "gpt-4" },
    "anthropic": { "apiKey": "sk-ant-xyz789" }
  },
  "plugins": {
    "myapp": {
      "clientSecret": "s3cr3t!",
      "passwordFile": "/etc/passwd",
      "maxTokens": 8192,
      "enabled": true
    }
  },
  "channels": {
    "discord": { "token": "discord-token-xxx", "guildId": "12345" }
  }
}

=== After redactConfigObject() ===
{
  "providers": {
    "openai": { "apiKey": "__OPENCLAW_REDACTED__", "model": "gpt-4" },
    "anthropic": { "apiKey": "__OPENCLAW_REDACTED__" }
  },
  "plugins": {
    "myapp": {
      "clientSecret": "__OPENCLAW_REDACTED__",
      "passwordFile": "/etc/passwd",
      "maxTokens": 8192,
      "enabled": true
    }
  },
  "channels": {
    "discord": { "token": "__OPENCLAW_REDACTED__", "guildId": "12345" }
  }
}

=== Redaction summary ===
🔴 REDACTED   providers.openai.apiKey
🟢 KEPT       providers.openai.model                             "gpt-4"
🔴 REDACTED   providers.anthropic.apiKey
🔴 REDACTED   plugins.myapp.clientSecret
🟢 KEPT       plugins.myapp.passwordFile                         "/etc/passwd"
🟢 KEPT       plugins.myapp.maxTokens                            8192
🟢 KEPT       plugins.myapp.enabled                              true
🔴 REDACTED   channels.discord.token
🟢 KEPT       channels.discord.guildId                           "12345"
```

- `apiKey` → redacted, `model` → preserved (no pattern match)
- `clientSecret` → redacted, `passwordFile` → preserved (whitelisted suffix)
- `maxTokens` → preserved (whitelisted suffix), `token` → redacted
- `guildId` → preserved (no pattern match)

Direct helper probe:

```
$ node --import tsx -e "import('./src/config/sensitive-paths.js').then(({ isSensitiveConfigPath }) => console.log(JSON.stringify([...], null, 2)))"
[
  { "desc": "apiKey → sensitive", "result": true },
  { "desc": "botToken → sensitive", "result": true },
  { "desc": "password → sensitive", "result": true },
  { "desc": "maxTokens → not sensitive", "result": false },
  { "desc": "passwordFile → not sensitive", "result": false },
  { "desc": "localservice.env.X → sensitive", "result": true },
  { "desc": "model → not sensitive", "result": false }
]
```

Targeted test:

```
$ pnpm test src/config/sensitive-paths.test.ts

 RUN  v4.1.8

 Test Files  1 passed (1)
      Tests  33 passed (33)
   Start at  21:12:17
   Duration  407ms

[test] passed 1 Vitest shard in 12.75s
```

Formatting:

```
$ oxfmt --check src/config/sensitive-paths.test.ts
```

Whitespace:

```
$ git diff --check
```