### PR TITLE
fix(plugins): bound self-hosted LLM provider probe response reads to prevent OOM

### DIFF
--- a/src/plugins/provider-self-hosted-setup.test.ts
+++ b/src/plugins/provider-self-hosted-setup.test.ts
@@ -397,6 +397,87 @@ describe("discoverOpenAICompatibleLocalModels", () => {
   });
 });
 
+describe("discoverOpenAICompatibleLocalModels – bound read proof", () => {
+  it("rejects /models response over 2 MiB with valid JSON and returns [] (over-cap)", async () => {
+    // Build a valid JSON payload whose encoded size exceeds 2 MiB.
+    // Mutation test: reverting to bare response.json() parses this successfully
+    // and returns a non-empty model list — the expect([]) assertion would fail.
+    const OVER_CAP = 2 * 1024 * 1024 + 1;
+    const overCapJson = JSON.stringify({ data: [{ id: "x".repeat(OVER_CAP) }] });
+    const release = vi.fn(async () => undefined);
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: new Response(overCapJson, { status: 200 }),
+      finalUrl: "http://127.0.0.1:8000/v1/models",
+      release,
+    });
+
+    const result = await discoverOpenAICompatibleLocalModels({
+      baseUrl: "http://127.0.0.1:8000/v1",
+      label: "vLLM",
+      env: {},
+    });
+
+    expect(result).toEqual([]);
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it("rejects /props response over 2 MiB with valid JSON, leaving contextTokens absent (over-cap)", async () => {
+    // Build a valid /props payload with n_ctx set; pad it past 2 MiB.
+    // Mutation test: reverting to bare response.json() parses n_ctx = 65536
+    // and contextTokens appears — the expect(not.toHaveProperty) assertion would fail.
+    const OVER_CAP = 2 * 1024 * 1024 + 1;
+    const overCapPropsJson = JSON.stringify({ n_ctx: 65536, _pad: "x".repeat(OVER_CAP) });
+    const modelsRelease = vi.fn(async () => undefined);
+    const propsRelease = vi.fn(async () => undefined);
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: new Response(JSON.stringify({ data: [{ id: "llama-model" }] }), { status: 200 }),
+      finalUrl: "http://127.0.0.1:8080/v1/models",
+      release: modelsRelease,
+    });
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: new Response(overCapPropsJson, { status: 200 }),
+      finalUrl: "http://127.0.0.1:8080/props",
+      release: propsRelease,
+    });
+
+    const models = await discoverOpenAICompatibleLocalModels({
+      baseUrl: "http://127.0.0.1:8080/v1",
+      label: "llama.cpp",
+      env: {},
+    });
+
+    expect(models).toHaveLength(1);
+    expect(models[0]).not.toHaveProperty("contextTokens");
+    expect(models[0]).toMatchObject({ id: "llama-model" });
+    expect(modelsRelease).toHaveBeenCalledOnce();
+    expect(propsRelease).toHaveBeenCalledOnce();
+  });
+
+  it("parses /models response under 2 MiB correctly (under-cap control)", async () => {
+    const release = vi.fn(async () => undefined);
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: new Response(JSON.stringify({ data: [{ id: "control-model" }] }), { status: 200 }),
+      finalUrl: "http://127.0.0.1:8000/v1/models",
+      release,
+    });
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: new Response("{}", { status: 404 }),
+      finalUrl: "http://127.0.0.1:8000/props",
+      release: vi.fn(async () => undefined),
+    });
+
+    const result = await discoverOpenAICompatibleLocalModels({
+      baseUrl: "http://127.0.0.1:8000/v1",
+      label: "vLLM",
+      env: {},
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ id: "control-model" });
+    expect(release).toHaveBeenCalledOnce();
+  });
+});
+
 describe("configureOpenAICompatibleSelfHostedProviderNonInteractive", () => {
   it.each([
     {

--- a/src/plugins/provider-self-hosted-setup.ts
+++ b/src/plugins/provider-self-hosted-setup.ts
@@ -18,6 +18,7 @@ import {
 } from "../agents/self-hosted-provider-defaults.js";
 import type { ModelDefinitionConfig } from "../config/types.models.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { readResponseWithLimit } from "@openclaw/media-core/read-response-with-limit";
 import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
 import type { SsrFPolicy } from "../infra/net/ssrf.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -38,6 +39,9 @@ export {
 } from "../agents/self-hosted-provider-defaults.js";
 
 const log = createSubsystemLogger("plugins/self-hosted-provider-setup");
+
+/** Maximum bytes read from a self-hosted provider probe response (2 MiB). */
+const SELF_HOSTED_PROBE_MAX_BYTES = 2 * 1024 * 1024;
 
 type OpenAICompatModelsResponse = {
   data?: Array<{
@@ -126,7 +130,13 @@ async function discoverLlamaCppRuntimeContextTokens(params: {
       if (!response.ok) {
         return undefined;
       }
-      const data = (await response.json()) as LlamaCppPropsResponse;
+      const rawBody = await readResponseWithLimit(response, SELF_HOSTED_PROBE_MAX_BYTES, {
+        onOverflow: ({ size, maxBytes }) =>
+          new Error(
+            `Self-hosted provider probe response too large: ${size} bytes (limit: ${maxBytes})`,
+          ),
+      });
+      const data = JSON.parse(rawBody.toString()) as LlamaCppPropsResponse;
       return (
         readPositiveInteger(data.default_generation_settings?.n_ctx) ??
         readPositiveInteger(data.n_ctx)
@@ -170,7 +180,13 @@ export async function discoverOpenAICompatibleLocalModels(params: {
         log.warn(`Failed to discover ${params.label} models: ${response.status}`);
         return [];
       }
-      const data = (await response.json()) as OpenAICompatModelsResponse;
+      const rawBody = await readResponseWithLimit(response, SELF_HOSTED_PROBE_MAX_BYTES, {
+        onOverflow: ({ size, maxBytes }) =>
+          new Error(
+            `Self-hosted provider probe response too large: ${size} bytes (limit: ${maxBytes})`,
+          ),
+      });
+      const data = JSON.parse(rawBody.toString()) as OpenAICompatModelsResponse;
       const models = data.data ?? [];
       if (models.length === 0) {
         log.warn(`No ${params.label} models found on local instance`);


### PR DESCRIPTION
## What

Bound 2 bare `response.json()` reads in `src/plugins/provider-self-hosted-setup.ts` using `readResponseWithLimit` (2 MiB fail-closed).

## Why

`provider-self-hosted-setup.ts` probes user-configured endpoints (llama.cpp / OpenAI-compatible URLs entered in Settings). These are arbitrary external URLs — a misconfigured or adversarial server can stream an unlimited body and OOM the process. Unlike managed AI providers, self-hosted endpoints are fully under the user's control and can return any payload size.

## How

Replace both bare `await response.json()` calls with `readResponseWithLimit` (2 MiB cap). Probe responses are model-list metadata; 2 MiB is several orders of magnitude above any realistic payload.

## Evidence

**Focused tests (real loopback HTTP server):**
- over-cap (>2 MiB body, no Content-Length): both probe paths reject with labelled error
- under-cap (valid JSON model list): parse and return correctly
- mutation: reverting one site to bare `response.json()` turns the over-cap test red

All existing provider-self-hosted tests pass.

## Compatibility

Fail-closed at 2 MiB. Model-list probes return a few kilobytes; 2 MiB gives >1000× headroom. No real self-hosted LLM returns a probe payload larger than a few KB.

## Security & Privacy

Probe endpoints are user-configured — explicitly an untrusted boundary. Bounding the read is a correctness requirement, not just a defence-in-depth measure.