### PR TITLE
fix(feishu): bound Feishu API JSON response reads to prevent OOM

### DIFF
--- a/extensions/feishu/src/app-registration.test.ts
+++ b/extensions/feishu/src/app-registration.test.ts
@@ -2,6 +2,7 @@
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { beginAppRegistration, pollAppRegistration, printQrCode } from "./app-registration.js";
+import { FEISHU_JSON_MAX_BYTES } from "./json-response.js";
 
 const { fetchWithSsrFGuardMock, renderQrTerminalMock } = vi.hoisted(() => ({
   fetchWithSsrFGuardMock: vi.fn(),
@@ -21,6 +22,33 @@ function mockFeishuJson(payload: unknown) {
     response: new Response(JSON.stringify(payload), { status: 200 }),
     release: async () => {},
   });
+}
+
+/** Builds a ReadableStream that streams `totalBytes` of zero bytes and tracks cancellation. */
+function makeOversizedStream(totalBytes: number): {
+  stream: ReadableStream<Uint8Array>;
+  state: { bytesPulled: number; canceled: boolean };
+} {
+  const state = { bytesPulled: 0, canceled: false };
+  const CHUNK = 1024 * 1024; // 1 MiB per chunk
+  let pulled = 0;
+  const stream = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (pulled >= totalBytes) {
+        controller.close();
+        return;
+      }
+      const remaining = totalBytes - pulled;
+      const size = Math.min(CHUNK, remaining);
+      pulled += size;
+      state.bytesPulled += size;
+      controller.enqueue(new Uint8Array(size));
+    },
+    cancel() {
+      state.canceled = true;
+    },
+  });
+  return { stream, state };
 }
 
 describe("Feishu app registration", () => {
@@ -76,5 +104,86 @@ describe("Feishu app registration", () => {
       { small: true },
     );
     expect(writeSpy).toHaveBeenCalledWith("terminal-qr\n");
+  });
+
+  // over-cap: body > 16 MiB, no Content-Length — bounded reader cancels stream and rejects.
+  // mutation control: reverting readResponseWithLimit to bare response.json() turns this test red
+  // because json() buffers the entire stream instead of cancelling at 16 MiB.
+  it("rejects Feishu API responses that exceed the 16 MiB JSON body cap", async () => {
+    const { stream, state } = makeOversizedStream(FEISHU_JSON_MAX_BYTES * 2); // 32 MiB
+    const release = vi.fn(async () => {});
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: new Response(stream, {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        // No Content-Length — tests the streaming path
+      }),
+      release,
+    });
+
+    await expect(beginAppRegistration()).rejects.toThrow(
+      /feishu\.api: JSON response exceeds \d+ bytes/,
+    );
+    // Confirm the stream was cancelled — not fully buffered.
+    expect(state.canceled).toBe(true);
+    expect(state.bytesPulled).toBeLessThan(FEISHU_JSON_MAX_BYTES * 2);
+    // release() must be called even when the body overflows.
+    expect(release).toHaveBeenCalledOnce();
+    console.log(
+      `[feishu fetchFeishuJson bound proof] over-cap: bytes_pulled=${state.bytesPulled} cap=${FEISHU_JSON_MAX_BYTES} canceled=${state.canceled}`,
+    );
+  });
+
+  // under-cap: a normal-sized valid JSON response is parsed and returned correctly.
+  it("parses under-cap Feishu API JSON responses and returns the typed payload", async () => {
+    const payload = {
+      device_code: "dev-code-123",
+      verification_uri_complete: "https://accounts.feishu.cn/verify?x=1",
+      user_code: "UC-456",
+      interval: 5,
+      expire_in: 300,
+    };
+    // Serve via ReadableStream (no Content-Length) to exercise the streaming path.
+    const body = JSON.stringify(payload);
+    const encoded = new TextEncoder().encode(body);
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoded.slice(0, Math.floor(encoded.length / 2)));
+        controller.enqueue(encoded.slice(Math.floor(encoded.length / 2)));
+        controller.close();
+      },
+    });
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: new Response(stream, {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+      release: async () => {},
+    });
+
+    const result = await beginAppRegistration();
+    expect(result).toMatchObject({
+      deviceCode: "dev-code-123",
+      userCode: "UC-456",
+      interval: 5,
+      expireIn: 300,
+    });
+    console.log(
+      `[feishu fetchFeishuJson bound proof] under-cap: returned=${JSON.stringify(result)}`,
+    );
+  });
+
+  it("wraps malformed Feishu API JSON with a feishu.api labelled error", async () => {
+    const release = vi.fn(async () => {});
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: new Response("not-valid-json{{", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+      release,
+    });
+
+    await expect(beginAppRegistration()).rejects.toThrow(/feishu\.api: malformed JSON response/);
+    expect(release).toHaveBeenCalledOnce();
   });
 });

--- a/extensions/feishu/src/app-registration.test.ts
+++ b/extensions/feishu/src/app-registration.test.ts
@@ -34,10 +34,10 @@ type RegistrationFetchOptions = {
 
 const HERMETIC_PUBLIC_LOOKUP_ADDRESS = "93.184.216.34";
 
-const hermeticPublicLookup: LookupFn = async () => ({
+const hermeticPublicLookup: LookupFn = (async (_hostname: string, _options?: unknown) => ({
   address: HERMETIC_PUBLIC_LOOKUP_ADDRESS,
   family: 4,
-});
+})) as LookupFn;
 
 async function startLocalServer(
   handler: (req: IncomingMessage, res: ServerResponse) => void,

--- a/extensions/feishu/src/app-registration.test.ts
+++ b/extensions/feishu/src/app-registration.test.ts
@@ -1,92 +1,237 @@
 // Feishu tests cover app registration plugin behavior.
-import { createServer } from "node:http";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
+import type { LookupFn } from "openclaw/plugin-sdk/ssrf-runtime";
+import { withFetchPreconnect } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { beginAppRegistration, pollAppRegistration, printQrCode } from "./app-registration.js";
+import {
+  beginAppRegistration,
+  type FeishuAppRegistrationFetch,
+  pollAppRegistration,
+  printQrCode,
+} from "./app-registration.js";
 import { FEISHU_JSON_MAX_BYTES } from "./json-response.js";
 
-const { fetchWithSsrFGuardMock, renderQrTerminalMock } = vi.hoisted(() => ({
-  fetchWithSsrFGuardMock: vi.fn(),
+const { renderQrTerminalMock } = vi.hoisted(() => ({
   renderQrTerminalMock: vi.fn(async () => "terminal-qr"),
-}));
-
-vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
-  fetchWithSsrFGuard: fetchWithSsrFGuardMock,
 }));
 
 vi.mock("./qr-terminal.js", () => ({
   renderQrTerminal: renderQrTerminalMock,
 }));
 
-function mockFeishuJson(payload: unknown) {
-  fetchWithSsrFGuardMock.mockResolvedValueOnce({
-    response: new Response(JSON.stringify(payload), { status: 200 }),
-    release: async () => {},
+type LocalServer = {
+  port: number;
+  stop: () => Promise<void>;
+};
+
+type DispatcherInit = RequestInit & { dispatcher?: unknown };
+type RegistrationFetchOptions = {
+  fetchImpl: FeishuAppRegistrationFetch;
+  lookupFn: LookupFn;
+};
+
+const HERMETIC_PUBLIC_LOOKUP_ADDRESS = "93.184.216.34";
+
+const hermeticPublicLookup: LookupFn = async () => ({
+  address: HERMETIC_PUBLIC_LOOKUP_ADDRESS,
+  family: 4,
+});
+
+async function startLocalServer(
+  handler: (req: IncomingMessage, res: ServerResponse) => void,
+): Promise<LocalServer> {
+  return await new Promise<LocalServer>((resolve, reject) => {
+    const server = createServer(handler);
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      if (!addr || typeof addr === "string") {
+        reject(new Error("local test server did not expose a TCP port"));
+        return;
+      }
+      resolve({
+        port: addr.port,
+        stop: async () =>
+          await new Promise<void>((innerResolve, innerReject) => {
+            server.close((err) => (err ? innerReject(err) : innerResolve()));
+          }),
+      });
+    });
   });
 }
 
-/** Builds a ReadableStream that streams `totalBytes` of zero bytes and tracks cancellation. */
-function makeOversizedStream(totalBytes: number): {
-  stream: ReadableStream<Uint8Array>;
-  state: { bytesPulled: number; canceled: boolean };
-} {
-  const state = { bytesPulled: 0, canceled: false };
-  const CHUNK = 1024 * 1024; // 1 MiB per chunk
-  let pulled = 0;
-  const stream = new ReadableStream<Uint8Array>({
-    pull(controller) {
-      if (pulled >= totalBytes) {
-        controller.close();
+function stripDispatcher(init: RequestInit | undefined): RequestInit | undefined {
+  if (!init || !("dispatcher" in init)) {
+    return init;
+  }
+  const { dispatcher: _dispatcher, ...rest } = init as DispatcherInit;
+  return rest;
+}
+
+function createLocalRedirectFetch(port: number): FeishuAppRegistrationFetch {
+  const realFetch = globalThis.fetch.bind(globalThis);
+  return withFetchPreconnect(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = new URL(input instanceof Request ? input.url : input.toString());
+    if (url.hostname === "accounts.feishu.cn" || url.hostname === "accounts.larksuite.com") {
+      const loopback = new URL(`${url.pathname}${url.search}`, `http://127.0.0.1:${port}`);
+      return await realFetch(loopback, stripDispatcher(init));
+    }
+    return await realFetch(input, init);
+  });
+}
+
+async function withRegistrationServer<T>(
+  handler: (req: IncomingMessage, res: ServerResponse) => void,
+  run: (options: RegistrationFetchOptions) => Promise<T>,
+): Promise<T> {
+  const server = await startLocalServer(handler);
+  try {
+    return await run({
+      fetchImpl: createLocalRedirectFetch(server.port),
+      lookupFn: hermeticPublicLookup,
+    });
+  } finally {
+    await server.stop();
+  }
+}
+
+function writeJson(res: ServerResponse, payload: unknown): void {
+  res.writeHead(200, { "content-type": "application/json" });
+  res.end(JSON.stringify(payload));
+}
+
+function writeOversizedJson(
+  res: ServerResponse,
+  totalBytes: number,
+): { bytesPulled: () => number; canceled: () => boolean } {
+  const chunk = Buffer.alloc(1024 * 1024, 0x20);
+  let bytesPulled = 0;
+  let canceled = false;
+  let ended = false;
+  res.writeHead(200, { "content-type": "application/json" });
+  res.on("close", () => {
+    if (!ended && bytesPulled < totalBytes) {
+      canceled = true;
+    }
+  });
+  const prefix = Buffer.from('{"device_code":"dev","padding":"');
+  bytesPulled += prefix.byteLength;
+  res.write(prefix);
+  const sendChunk = () => {
+    if (bytesPulled >= totalBytes) {
+      if (!res.destroyed) {
+        ended = true;
+        res.end('"}');
+      }
+      return;
+    }
+    const remaining = totalBytes - bytesPulled;
+    const size = Math.min(chunk.byteLength, remaining);
+    bytesPulled += size;
+    const ok = res.write(chunk.subarray(0, size));
+    if (ok) {
+      setImmediate(sendChunk);
+      return;
+    }
+    res.once("drain", sendChunk);
+  };
+  setImmediate(sendChunk);
+  return {
+    bytesPulled: () => bytesPulled,
+    canceled: () => canceled || (!ended && bytesPulled < totalBytes),
+  };
+}
+
+async function readRequestBody(req: IncomingMessage): Promise<string> {
+  let body = "";
+  for await (const chunk of req) {
+    body += String(chunk);
+  }
+  return body;
+}
+
+async function readRegistrationAction(req: IncomingMessage): Promise<string> {
+  const body = await readRequestBody(req);
+  return new URLSearchParams(body).get("action") ?? "";
+}
+
+function beginRegistrationPayload(
+  overrides?: Partial<Record<string, unknown>>,
+): Record<string, unknown> {
+  return {
+    device_code: "device-code",
+    verification_uri_complete: "https://accounts.feishu.cn/verify?x=1",
+    user_code: "user-code",
+    interval: 5,
+    expire_in: 300,
+    ...overrides,
+  };
+}
+
+function beginRegistrationWithServer<T>(
+  handler: (req: IncomingMessage, res: ServerResponse) => void,
+  run: (options: RegistrationFetchOptions) => Promise<T>,
+): Promise<T> {
+  return withRegistrationServer(handler, run);
+}
+
+function beginRegistrationJson<T>(
+  payload: Record<string, unknown>,
+  run: (options: RegistrationFetchOptions) => Promise<T>,
+): Promise<T> {
+  return beginRegistrationWithServer((req, res) => {
+    void readRegistrationAction(req).then((action) => {
+      if (action !== "begin") {
+        res.writeHead(400);
+        res.end("unexpected action");
         return;
       }
-      const remaining = totalBytes - pulled;
-      const size = Math.min(CHUNK, remaining);
-      pulled += size;
-      state.bytesPulled += size;
-      controller.enqueue(new Uint8Array(size));
-    },
-    cancel() {
-      state.canceled = true;
-    },
-  });
-  return { stream, state };
+      writeJson(res, payload);
+    });
+  }, run);
 }
 
 describe("Feishu app registration", () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.restoreAllMocks();
-    fetchWithSsrFGuardMock.mockReset();
     renderQrTerminalMock.mockClear();
   });
 
   it("defaults unsafe begin polling lifetimes from provider responses", async () => {
-    mockFeishuJson({
-      device_code: "device-code",
-      verification_uri_complete: "https://accounts.feishu.cn/verify?x=1",
-      user_code: "user-code",
-      interval: Number.POSITIVE_INFINITY,
-      expire_in: Number.POSITIVE_INFINITY,
-    });
-
-    await expect(beginAppRegistration()).resolves.toMatchObject({
-      deviceCode: "device-code",
-      userCode: "user-code",
-      interval: 5,
-      expireIn: 600,
-    });
+    await beginRegistrationJson(
+      beginRegistrationPayload({
+        interval: Number.POSITIVE_INFINITY,
+        expire_in: Number.POSITIVE_INFINITY,
+      }),
+      async (options) => {
+        await expect(beginAppRegistration("feishu", options)).resolves.toMatchObject({
+          deviceCode: "device-code",
+          userCode: "user-code",
+          interval: 5,
+          expireIn: 600,
+        });
+      },
+    );
   });
 
   it("clamps unsafe poll sleeps from provider intervals", async () => {
     vi.useFakeTimers();
     const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
-    fetchWithSsrFGuardMock.mockRejectedValueOnce(new Error("transient"));
+    const fetchImpl = withFetchPreconnect(
+      vi.fn(async () => {
+        throw new Error("transient");
+      }),
+    ) as FeishuAppRegistrationFetch;
 
     const poll = pollAppRegistration({
       deviceCode: "device-code",
       interval: 10_000_000,
       expireIn: 10_000_000,
+      fetchImpl,
+      lookupFn: hermeticPublicLookup,
     });
     await vi.advanceTimersByTimeAsync(0);
 
@@ -108,31 +253,30 @@ describe("Feishu app registration", () => {
     expect(writeSpy).toHaveBeenCalledWith("terminal-qr\n");
   });
 
-  // over-cap: body > 16 MiB, no Content-Length — bounded reader cancels stream and rejects.
-  // mutation control: reverting readResponseWithLimit to bare response.json() turns this test red
-  // because json() buffers the entire stream instead of cancelling at 16 MiB.
+  // over-cap: body > 16 MiB, no Content-Length. The bounded reader cancels
+  // through the real SSRF guard and rejects before full buffering.
   it("rejects Feishu API responses that exceed the 16 MiB JSON body cap", async () => {
-    const { stream, state } = makeOversizedStream(FEISHU_JSON_MAX_BYTES * 2); // 32 MiB
-    const release = vi.fn(async () => {});
-    fetchWithSsrFGuardMock.mockResolvedValueOnce({
-      response: new Response(stream, {
-        status: 200,
-        headers: { "content-type": "application/json" },
-        // No Content-Length — tests the streaming path
-      }),
-      release,
-    });
-
-    await expect(beginAppRegistration()).rejects.toThrow(
-      /feishu\.api: JSON response exceeds \d+ bytes/,
+    let streamState:
+      | {
+          bytesPulled: () => number;
+          canceled: () => boolean;
+        }
+      | undefined;
+    await beginRegistrationWithServer(
+      (_req, res) => {
+        streamState = writeOversizedJson(res, FEISHU_JSON_MAX_BYTES * 2);
+      },
+      async (options) => {
+        await expect(beginAppRegistration("feishu", options)).rejects.toThrow(
+          /feishu\.api: JSON response exceeds \d+ bytes/,
+        );
+      },
     );
-    // Confirm the stream was cancelled — not fully buffered.
-    expect(state.canceled).toBe(true);
-    expect(state.bytesPulled).toBeLessThan(FEISHU_JSON_MAX_BYTES * 2);
-    // release() must be called even when the body overflows.
-    expect(release).toHaveBeenCalledOnce();
+
+    expect(streamState?.canceled()).toBe(true);
+    expect(streamState?.bytesPulled()).toBeLessThan(FEISHU_JSON_MAX_BYTES * 2);
     console.log(
-      `[feishu fetchFeishuJson bound proof] over-cap: bytes_pulled=${state.bytesPulled} cap=${FEISHU_JSON_MAX_BYTES} canceled=${state.canceled}`,
+      `[feishu fetchFeishuJson bound proof] over-cap: bytes_pulled=${streamState?.bytesPulled()} cap=${FEISHU_JSON_MAX_BYTES} canceled=${streamState?.canceled()}`,
     );
   });
 
@@ -145,83 +289,94 @@ describe("Feishu app registration", () => {
       interval: 5,
       expire_in: 300,
     };
-    // Serve via ReadableStream (no Content-Length) to exercise the streaming path.
-    const body = JSON.stringify(payload);
-    const encoded = new TextEncoder().encode(body);
-    const stream = new ReadableStream<Uint8Array>({
-      start(controller) {
-        controller.enqueue(encoded.slice(0, Math.floor(encoded.length / 2)));
-        controller.enqueue(encoded.slice(Math.floor(encoded.length / 2)));
-        controller.close();
-      },
+
+    await beginRegistrationJson(payload, async (options) => {
+      const result = await beginAppRegistration("feishu", options);
+      expect(result).toMatchObject({
+        deviceCode: "dev-code-123",
+        userCode: "UC-456",
+        interval: 5,
+        expireIn: 300,
+      });
+      console.log(
+        `[feishu fetchFeishuJson bound proof] under-cap: returned=${JSON.stringify(result)}`,
+      );
     });
-    fetchWithSsrFGuardMock.mockResolvedValueOnce({
-      response: new Response(stream, {
-        status: 200,
-        headers: { "content-type": "application/json" },
-      }),
-      release: async () => {},
+  });
+
+  it("sends bound reads through the real SSRF guard before local socket redirect", async () => {
+    const fetchCalls: string[] = [];
+    await beginRegistrationJson(beginRegistrationPayload(), async (options) => {
+      const recordingFetch: FeishuAppRegistrationFetch = withFetchPreconnect(
+        async (input, init) => {
+          fetchCalls.push(input instanceof Request ? input.url : input.toString());
+          return await options.fetchImpl(input, init);
+        },
+      );
+
+      await expect(
+        beginAppRegistration("feishu", { ...options, fetchImpl: recordingFetch }),
+      ).resolves.toMatchObject({
+        deviceCode: "device-code",
+        userCode: "user-code",
+      });
     });
 
-    const result = await beginAppRegistration();
-    expect(result).toMatchObject({
-      deviceCode: "dev-code-123",
-      userCode: "UC-456",
-      interval: 5,
-      expireIn: 300,
-    });
+    expect(fetchCalls).toEqual(["https://accounts.feishu.cn/oauth/v1/app/registration"]);
     console.log(
-      `[feishu fetchFeishuJson bound proof] under-cap: returned=${JSON.stringify(result)}`,
+      `[feishu fetchFeishuJson bound proof] real-ssrf-guard: guarded_url=${fetchCalls[0]} socket=127.0.0.1`,
     );
   });
 
   it("wraps malformed Feishu API JSON with a feishu.api labelled error", async () => {
-    const release = vi.fn(async () => {});
-    fetchWithSsrFGuardMock.mockResolvedValueOnce({
-      response: new Response("not-valid-json{{", {
-        status: 200,
-        headers: { "content-type": "application/json" },
-      }),
-      release,
-    });
-
-    await expect(beginAppRegistration()).rejects.toThrow(/feishu\.api: malformed JSON response/);
-    expect(release).toHaveBeenCalledOnce();
+    await beginRegistrationWithServer(
+      (_req, res) => {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end("not-valid-json{{");
+      },
+      async (options) => {
+        await expect(beginAppRegistration("feishu", options)).rejects.toThrow(
+          /feishu\.api: malformed JSON response/,
+        );
+      },
+    );
   });
 });
 
-describe("feishu bound reads — real HTTP server (no fetch mock)", () => {
-  it("rejects oversized response before fully buffering 20 MiB (OOM guard)", async () => {
-    const CHUNK = Buffer.alloc(1024 * 1024, 0x61);
-    const TOTAL_CHUNKS = 20;
+describe("feishu bound reads — local HTTP server", () => {
+  it("rejects oversized response before fully buffering the response (OOM guard)", async () => {
+    const chunk = Buffer.alloc(1024 * 1024, 0x61);
+    const totalChunks = 64;
     let chunksWritten = 0;
 
-    const srv = await new Promise<{ port: number; stop: () => Promise<void> }>((resolve, reject) => {
-      const server = createServer((_req, res) => {
-        res.writeHead(200, { "content-type": "application/json" });
-        let sent = 0;
-        const sendChunk = () => {
-          if (sent >= TOTAL_CHUNKS) { res.end(); return; }
-          sent++; chunksWritten++;
-          const ok = res.write(CHUNK);
-          if (ok) { setImmediate(sendChunk); }
-          else { res.once("drain", sendChunk); }
-        };
-        sendChunk();
-      });
-      server.on("error", reject);
-      server.listen(0, "127.0.0.1", () => {
-        const addr = server.address() as { port: number };
-        resolve({ port: addr.port, stop: () => new Promise<void>((r, e) => { server.close(err => (err ? e(err) : r())); }) });
-      });
+    const srv = await startLocalServer((_req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      let sent = 0;
+      const sendChunk = () => {
+        if (sent >= totalChunks) {
+          res.end();
+          return;
+        }
+        sent += 1;
+        chunksWritten += 1;
+        const ok = res.write(chunk);
+        if (ok) {
+          setImmediate(sendChunk);
+          return;
+        }
+        res.once("drain", sendChunk);
+      };
+      sendChunk();
     });
 
     try {
       const response = await fetch(`http://127.0.0.1:${srv.port}/`);
       // Mutation-control: bare `response.json()` would buffer all 20 MiB.
-      await expect(readProviderJsonResponse(response, "feishu.bound-proof")).rejects.toThrow(/JSON response exceeds/);
-      expect(chunksWritten).toBeLessThan(TOTAL_CHUNKS);
-      console.log(`[bound-proof] canceled at ${chunksWritten}/${TOTAL_CHUNKS} chunks`);
+      await expect(readProviderJsonResponse(response, "feishu.bound-proof")).rejects.toThrow(
+        /JSON response exceeds/,
+      );
+      expect(chunksWritten).toBeLessThan(totalChunks);
+      console.log(`[bound-proof] canceled at ${chunksWritten}/${totalChunks} chunks`);
     } finally {
       await srv.stop();
     }
@@ -229,16 +384,8 @@ describe("feishu bound reads — real HTTP server (no fetch mock)", () => {
 
   it("parses well-formed JSON response under the cap", async () => {
     const payload = { code: 0, data: { app_id: "cli_test" } };
-    const srv = await new Promise<{ port: number; stop: () => Promise<void> }>((resolve, reject) => {
-      const server = createServer((_req, res) => {
-        res.writeHead(200, { "content-type": "application/json" });
-        res.end(JSON.stringify(payload));
-      });
-      server.on("error", reject);
-      server.listen(0, "127.0.0.1", () => {
-        const addr = server.address() as { port: number };
-        resolve({ port: addr.port, stop: () => new Promise<void>((r, e) => { server.close(err => (err ? e(err) : r())); }) });
-      });
+    const srv = await startLocalServer((_req, res) => {
+      writeJson(res, payload);
     });
     try {
       const response = await fetch(`http://127.0.0.1:${srv.port}/`);

--- a/extensions/feishu/src/app-registration.test.ts
+++ b/extensions/feishu/src/app-registration.test.ts
@@ -204,15 +204,15 @@ describe("feishu bound reads — real HTTP server (no fetch mock)", () => {
           if (sent >= TOTAL_CHUNKS) { res.end(); return; }
           sent++; chunksWritten++;
           const ok = res.write(CHUNK);
-          if (ok) setImmediate(sendChunk);
-          else res.once("drain", sendChunk);
+          if (ok) { setImmediate(sendChunk); }
+          else { res.once("drain", sendChunk); }
         };
         sendChunk();
       });
       server.on("error", reject);
       server.listen(0, "127.0.0.1", () => {
         const addr = server.address() as { port: number };
-        resolve({ port: addr.port, stop: () => new Promise<void>((r, e) => server.close(err => err ? e(err) : r())) });
+        resolve({ port: addr.port, stop: () => new Promise<void>((r, e) => { server.close(err => (err ? e(err) : r())); }) });
       });
     });
 
@@ -237,7 +237,7 @@ describe("feishu bound reads — real HTTP server (no fetch mock)", () => {
       server.on("error", reject);
       server.listen(0, "127.0.0.1", () => {
         const addr = server.address() as { port: number };
-        resolve({ port: addr.port, stop: () => new Promise<void>((r, e) => server.close(err => err ? e(err) : r())) });
+        resolve({ port: addr.port, stop: () => new Promise<void>((r, e) => { server.close(err => (err ? e(err) : r())); }) });
       });
     });
     try {

--- a/extensions/feishu/src/app-registration.test.ts
+++ b/extensions/feishu/src/app-registration.test.ts
@@ -1,5 +1,7 @@
 // Feishu tests cover app registration plugin behavior.
+import { createServer } from "node:http";
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { beginAppRegistration, pollAppRegistration, printQrCode } from "./app-registration.js";
 import { FEISHU_JSON_MAX_BYTES } from "./json-response.js";
@@ -185,5 +187,65 @@ describe("Feishu app registration", () => {
 
     await expect(beginAppRegistration()).rejects.toThrow(/feishu\.api: malformed JSON response/);
     expect(release).toHaveBeenCalledOnce();
+  });
+});
+
+describe("feishu bound reads — real HTTP server (no fetch mock)", () => {
+  it("rejects oversized response before fully buffering 20 MiB (OOM guard)", async () => {
+    const CHUNK = Buffer.alloc(1024 * 1024, 0x61);
+    const TOTAL_CHUNKS = 20;
+    let chunksWritten = 0;
+
+    const srv = await new Promise<{ port: number; stop: () => Promise<void> }>((resolve, reject) => {
+      const server = createServer((_req, res) => {
+        res.writeHead(200, { "content-type": "application/json" });
+        let sent = 0;
+        const sendChunk = () => {
+          if (sent >= TOTAL_CHUNKS) { res.end(); return; }
+          sent++; chunksWritten++;
+          const ok = res.write(CHUNK);
+          if (ok) setImmediate(sendChunk);
+          else res.once("drain", sendChunk);
+        };
+        sendChunk();
+      });
+      server.on("error", reject);
+      server.listen(0, "127.0.0.1", () => {
+        const addr = server.address() as { port: number };
+        resolve({ port: addr.port, stop: () => new Promise<void>((r, e) => server.close(err => err ? e(err) : r())) });
+      });
+    });
+
+    try {
+      const response = await fetch(`http://127.0.0.1:${srv.port}/`);
+      // Mutation-control: bare `response.json()` would buffer all 20 MiB.
+      await expect(readProviderJsonResponse(response, "feishu.bound-proof")).rejects.toThrow(/JSON response exceeds/);
+      expect(chunksWritten).toBeLessThan(TOTAL_CHUNKS);
+      console.log(`[bound-proof] canceled at ${chunksWritten}/${TOTAL_CHUNKS} chunks`);
+    } finally {
+      await srv.stop();
+    }
+  });
+
+  it("parses well-formed JSON response under the cap", async () => {
+    const payload = { code: 0, data: { app_id: "cli_test" } };
+    const srv = await new Promise<{ port: number; stop: () => Promise<void> }>((resolve, reject) => {
+      const server = createServer((_req, res) => {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify(payload));
+      });
+      server.on("error", reject);
+      server.listen(0, "127.0.0.1", () => {
+        const addr = server.address() as { port: number };
+        resolve({ port: addr.port, stop: () => new Promise<void>((r, e) => server.close(err => err ? e(err) : r())) });
+      });
+    });
+    try {
+      const response = await fetch(`http://127.0.0.1:${srv.port}/`);
+      const result = await readProviderJsonResponse<typeof payload>(response, "feishu.bound-proof");
+      expect(result).toEqual(payload);
+    } finally {
+      await srv.stop();
+    }
   });
 });

--- a/extensions/feishu/src/app-registration.ts
+++ b/extensions/feishu/src/app-registration.ts
@@ -9,6 +9,7 @@ import { sleep } from "openclaw/plugin-sdk/runtime-env";
  * the openclaw WizardPrompter surface.
  */
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
+import { readFeishuJsonResponse } from "./json-response.js";
 import { renderQrTerminal } from "./qr-terminal.js";
 import type { FeishuDomain } from "./types.js";
 
@@ -110,7 +111,7 @@ async function fetchFeishuJson<T>(params: {
   });
   try {
     // Registration poll returns 4xx for pending/error states with a JSON body.
-    return (await response.json()) as T;
+    return await readFeishuJsonResponse<T>(response);
   } finally {
     await release();
   }

--- a/extensions/feishu/src/app-registration.ts
+++ b/extensions/feishu/src/app-registration.ts
@@ -8,7 +8,7 @@ import { sleep } from "openclaw/plugin-sdk/runtime-env";
  * Replaces axios with native fetch, removes inquirer/ora/chalk in favor of
  * the openclaw WizardPrompter surface.
  */
-import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
+import { fetchWithSsrFGuard, type LookupFn } from "openclaw/plugin-sdk/ssrf-runtime";
 import { readFeishuJsonResponse } from "./json-response.js";
 import { renderQrTerminal } from "./qr-terminal.js";
 import type { FeishuDomain } from "./types.js";
@@ -50,6 +50,15 @@ export interface BeginResult {
   expireIn: number;
 }
 
+export type FeishuAppRegistrationFetch = typeof fetch;
+
+export type FeishuAppRegistrationFetchOptions = {
+  /** Override fetch for tests while preserving the real SSRF guard path. */
+  fetchImpl?: FeishuAppRegistrationFetch;
+  /** Override hostname lookup for hermetic SSRF-guard tests. */
+  lookupFn?: LookupFn;
+};
+
 interface RawBeginResponse {
   device_code: string;
   verification_uri: string;
@@ -85,7 +94,11 @@ function accountsBaseUrl(domain: FeishuDomain): string {
   return domain === "lark" ? LARK_ACCOUNTS_URL : FEISHU_ACCOUNTS_URL;
 }
 
-async function postRegistration<T>(baseUrl: string, body: Record<string, string>): Promise<T> {
+async function postRegistration<T>(
+  baseUrl: string,
+  body: Record<string, string>,
+  options?: FeishuAppRegistrationFetchOptions,
+): Promise<T> {
   return await fetchFeishuJson<T>({
     url: `${baseUrl}${REGISTRATION_PATH}`,
     init: {
@@ -95,6 +108,8 @@ async function postRegistration<T>(baseUrl: string, body: Record<string, string>
       signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
     },
     auditContext: "feishu.app-registration.post",
+    fetchImpl: options?.fetchImpl,
+    lookupFn: options?.lookupFn,
   });
 }
 
@@ -102,10 +117,14 @@ async function fetchFeishuJson<T>(params: {
   url: string;
   init: RequestInit;
   auditContext: string;
+  fetchImpl?: FeishuAppRegistrationFetch;
+  lookupFn?: LookupFn;
 }): Promise<T> {
   const { response, release } = await fetchWithSsrFGuard({
     url: params.url,
     init: params.init,
+    fetchImpl: params.fetchImpl,
+    lookupFn: params.lookupFn,
     policy: { allowedHostnames: [new URL(params.url).hostname] },
     auditContext: params.auditContext,
   });
@@ -127,9 +146,12 @@ async function fetchFeishuJson<T>(params: {
  *
  * @throws If the environment does not support `client_secret`.
  */
-export async function initAppRegistration(domain: FeishuDomain = "feishu"): Promise<void> {
+export async function initAppRegistration(
+  domain: FeishuDomain = "feishu",
+  options?: FeishuAppRegistrationFetchOptions,
+): Promise<void> {
   const baseUrl = accountsBaseUrl(domain);
-  const res = await postRegistration<InitResponse>(baseUrl, { action: "init" });
+  const res = await postRegistration<InitResponse>(baseUrl, { action: "init" }, options);
 
   if (!res.supported_auth_methods?.includes("client_secret")) {
     throw new Error("Current environment does not support client_secret auth method");
@@ -140,14 +162,21 @@ export async function initAppRegistration(domain: FeishuDomain = "feishu"): Prom
  * Step 2: Begin the device-code flow. Returns a device code and a QR URL
  * that the user should scan with Feishu/Lark mobile app.
  */
-export async function beginAppRegistration(domain: FeishuDomain = "feishu"): Promise<BeginResult> {
+export async function beginAppRegistration(
+  domain: FeishuDomain = "feishu",
+  options?: FeishuAppRegistrationFetchOptions,
+): Promise<BeginResult> {
   const baseUrl = accountsBaseUrl(domain);
-  const res = await postRegistration<RawBeginResponse>(baseUrl, {
-    action: "begin",
-    archetype: "PersonalAgent",
-    auth_method: "client_secret",
-    request_user_info: "open_id",
-  });
+  const res = await postRegistration<RawBeginResponse>(
+    baseUrl,
+    {
+      action: "begin",
+      archetype: "PersonalAgent",
+      auth_method: "client_secret",
+      request_user_info: "open_id",
+    },
+    options,
+  );
 
   const qrUrl = new URL(res.verification_uri_complete);
   qrUrl.searchParams.set("from", "oc_onboard");
@@ -181,8 +210,18 @@ export async function pollAppRegistration(params: {
   abortSignal?: AbortSignal;
   /** Registration type parameter. The CLI bot QR flow uses "ob_cli_app". */
   tp?: string;
+  fetchImpl?: FeishuAppRegistrationFetch;
+  lookupFn?: LookupFn;
 }): Promise<PollOutcome> {
-  const { deviceCode, expireIn, initialDomain = "feishu", abortSignal, tp } = params;
+  const {
+    deviceCode,
+    expireIn,
+    initialDomain = "feishu",
+    abortSignal,
+    tp,
+    fetchImpl,
+    lookupFn,
+  } = params;
   let currentInterval = params.interval;
   let domain: FeishuDomain = initialDomain;
   let domainSwitched = false;
@@ -202,11 +241,15 @@ export async function pollAppRegistration(params: {
 
     let pollRes: PollResponse;
     try {
-      pollRes = await postRegistration<PollResponse>(baseUrl, {
-        action: "poll",
-        device_code: deviceCode,
-        ...(tp ? { tp } : {}),
-      });
+      pollRes = await postRegistration<PollResponse>(
+        baseUrl,
+        {
+          action: "poll",
+          device_code: deviceCode,
+          ...(tp ? { tp } : {}),
+        },
+        { fetchImpl, lookupFn },
+      );
     } catch {
       // Transient network error — keep polling.
       await sleepRegistrationPollInterval(currentInterval);
@@ -282,6 +325,8 @@ export async function getAppOwnerOpenId(params: {
   appId: string;
   appSecret: string;
   domain?: FeishuDomain;
+  fetchImpl?: FeishuAppRegistrationFetch;
+  lookupFn?: LookupFn;
 }): Promise<string | undefined> {
   const baseUrl =
     params.domain === "lark" ? "https://open.larksuite.com" : "https://open.feishu.cn";
@@ -300,6 +345,8 @@ export async function getAppOwnerOpenId(params: {
         signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
       },
       auditContext: "feishu.app-registration.owner-token",
+      fetchImpl: params.fetchImpl,
+      lookupFn: params.lookupFn,
     });
     if (!tokenData.tenant_access_token) {
       return undefined;
@@ -325,6 +372,8 @@ export async function getAppOwnerOpenId(params: {
         signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
       },
       auditContext: "feishu.app-registration.owner-app",
+      fetchImpl: params.fetchImpl,
+      lookupFn: params.lookupFn,
     });
     if (appData.code !== 0) {
       return undefined;

--- a/extensions/feishu/src/json-response.ts
+++ b/extensions/feishu/src/json-response.ts
@@ -1,5 +1,5 @@
 // Feishu JSON response helpers shared by credentialed API paths.
-import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 
 /** Feishu control-plane JSON responses are tiny; 16 MiB leaves ample headroom. */
 export const FEISHU_JSON_MAX_BYTES = 16 * 1024 * 1024;
@@ -8,13 +8,5 @@ export async function readFeishuJsonResponse<T>(
   response: Response,
   label = "feishu.api",
 ): Promise<T> {
-  const bytes = await readResponseWithLimit(response, FEISHU_JSON_MAX_BYTES, {
-    onOverflow: ({ size, maxBytes }) =>
-      new Error(`${label}: JSON response exceeds ${maxBytes} bytes (got ${size})`),
-  });
-  try {
-    return JSON.parse(new TextDecoder().decode(bytes)) as T;
-  } catch (cause) {
-    throw new Error(`${label}: malformed JSON response`, { cause });
-  }
+  return readProviderJsonResponse<T>(response, label, { maxBytes: FEISHU_JSON_MAX_BYTES });
 }

--- a/extensions/feishu/src/json-response.ts
+++ b/extensions/feishu/src/json-response.ts
@@ -1,0 +1,20 @@
+// Feishu JSON response helpers shared by credentialed API paths.
+import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
+
+/** Feishu control-plane JSON responses are tiny; 16 MiB leaves ample headroom. */
+export const FEISHU_JSON_MAX_BYTES = 16 * 1024 * 1024;
+
+export async function readFeishuJsonResponse<T>(
+  response: Response,
+  label = "feishu.api",
+): Promise<T> {
+  const bytes = await readResponseWithLimit(response, FEISHU_JSON_MAX_BYTES, {
+    onOverflow: ({ size, maxBytes }) =>
+      new Error(`${label}: JSON response exceeds ${maxBytes} bytes (got ${size})`),
+  });
+  try {
+    return JSON.parse(new TextDecoder().decode(bytes)) as T;
+  } catch (cause) {
+    throw new Error(`${label}: malformed JSON response`, { cause });
+  }
+}

--- a/extensions/feishu/src/streaming-card.test.ts
+++ b/extensions/feishu/src/streaming-card.test.ts
@@ -7,6 +7,7 @@ vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
   fetchWithSsrFGuard: fetchWithSsrFGuardMock,
 }));
 
+import { FEISHU_JSON_MAX_BYTES } from "./json-response.js";
 import {
   FeishuStreamingSession,
   mergeStreamingText,
@@ -21,6 +22,53 @@ type StreamingSessionState = {
   sentText: string;
   hasNote: boolean;
 };
+
+function jsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function oversizedJsonStream(totalBytes: number): {
+  response: Response;
+  state: { bytesPulled: number; canceled: boolean };
+} {
+  const state = { bytesPulled: 0, canceled: false };
+  const chunk = Buffer.alloc(1024 * 1024, 0x20);
+  let remaining = totalBytes;
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      const prefix = new TextEncoder().encode(
+        '{"code":0,"msg":"ok","tenant_access_token":"token","padding":"',
+      );
+      remaining -= prefix.byteLength;
+      state.bytesPulled += prefix.byteLength;
+      controller.enqueue(prefix);
+    },
+    pull(controller) {
+      if (remaining <= 0) {
+        controller.enqueue(new TextEncoder().encode('"}'));
+        controller.close();
+        return;
+      }
+      const size = Math.min(chunk.byteLength, remaining);
+      remaining -= size;
+      state.bytesPulled += size;
+      controller.enqueue(chunk.subarray(0, size));
+    },
+    cancel() {
+      state.canceled = true;
+    },
+  });
+  return {
+    response: new Response(stream, {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }),
+    state,
+  };
+}
 
 function setStreamingSessionInternals(
   session: FeishuStreamingSession,
@@ -65,19 +113,15 @@ describe("FeishuStreamingSession", () => {
     fetchWithSsrFGuardMock.mockImplementation(
       async ({ url, init }: { url: string; init?: { body?: string } }) => {
         const release = vi.fn(async () => {});
-        let ok = true;
         let status = 200;
         if (url.includes("/auth/")) {
           return {
-            response: {
-              ok: true,
-              json: async () => ({
-                code: 0,
-                msg: "ok",
-                tenant_access_token: "token",
-                expire: 7200,
-              }),
-            },
+            response: jsonResponse({
+              code: 0,
+              msg: "ok",
+              tenant_access_token: "token",
+              expire: 7200,
+            }),
             release,
           };
         }
@@ -89,7 +133,6 @@ describe("FeishuStreamingSession", () => {
           }
           const failedStatus = failedContentUpdateStatuses.get(updateIndex);
           if (failedStatus !== undefined) {
-            ok = false;
             status = failedStatus;
           }
         } else if (url.includes("/elements/content")) {
@@ -97,16 +140,11 @@ describe("FeishuStreamingSession", () => {
           replaceBodies.push(init?.body ?? "");
           const failedStatus = failedReplaceStatuses.get(replaceIndex);
           if (failedStatus !== undefined) {
-            ok = false;
             status = failedStatus;
           }
         }
         return {
-          response: {
-            ok,
-            status,
-            json: async () => ({ code: 0, msg: "ok" }),
-          },
+          response: jsonResponse({ code: 0, msg: "ok" }, status),
           release,
         };
       },
@@ -125,19 +163,16 @@ describe("FeishuStreamingSession", () => {
           const token = `token-${authTokens.length + 1}`;
           authTokens.push(token);
           return {
-            response: { ok: true, json: async () => resolveAuthJson(token) },
+            response: jsonResponse(resolveAuthJson(token)),
             release,
           };
         }
         return {
-          response: {
-            ok: true,
-            json: async () => ({
-              code: 0,
-              msg: "ok",
-              data: { card_id: `card-${authTokens.length}` },
-            }),
-          },
+          response: jsonResponse({
+            code: 0,
+            msg: "ok",
+            data: { card_id: `card-${authTokens.length}` },
+          }),
           release,
         };
       },
@@ -151,6 +186,69 @@ describe("FeishuStreamingSession", () => {
     } as unknown as ConstructorParameters<typeof FeishuStreamingSession>[0];
     return { authTokens, client };
   }
+
+  it("rejects oversized streaming tenant-token JSON before buffering the full body", async () => {
+    const { response, state } = oversizedJsonStream(FEISHU_JSON_MAX_BYTES * 2);
+    const release = vi.fn(async () => {});
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({ response, release });
+
+    const session = new FeishuStreamingSession({} as never, {
+      appId: "app_oversized_token",
+      appSecret: "secret",
+    });
+
+    await expect(session.start("chat_id", "open_id")).rejects.toThrow(
+      /feishu\.streaming-card\.token: JSON response exceeds \d+ bytes/,
+    );
+    expect(state.canceled).toBe(true);
+    expect(state.bytesPulled).toBeLessThan(FEISHU_JSON_MAX_BYTES * 2);
+    expect(release).toHaveBeenCalledOnce();
+    console.log(
+      `[feishu streaming-card bound proof] token over-cap: bytes_pulled=${state.bytesPulled} cap=${FEISHU_JSON_MAX_BYTES} canceled=${state.canceled}`,
+    );
+  });
+
+  it("rejects oversized streaming card-create JSON before buffering the full body", async () => {
+    const tokenRelease = vi.fn(async () => {});
+    const cardRelease = vi.fn(async () => {});
+    const { response: cardResponse, state } = oversizedJsonStream(FEISHU_JSON_MAX_BYTES * 2);
+    fetchWithSsrFGuardMock
+      .mockResolvedValueOnce({
+        response: jsonResponse({
+          code: 0,
+          msg: "ok",
+          tenant_access_token: "token",
+          expire: 7200,
+        }),
+        release: tokenRelease,
+      })
+      .mockResolvedValueOnce({ response: cardResponse, release: cardRelease });
+
+    const session = new FeishuStreamingSession(
+      {
+        im: {
+          message: {
+            create: vi.fn(),
+          },
+        },
+      } as unknown as ConstructorParameters<typeof FeishuStreamingSession>[0],
+      {
+        appId: "app_oversized_card_create",
+        appSecret: "secret",
+      },
+    );
+
+    await expect(session.start("chat_id", "open_id")).rejects.toThrow(
+      /feishu\.streaming-card\.create: JSON response exceeds \d+ bytes/,
+    );
+    expect(tokenRelease).toHaveBeenCalledOnce();
+    expect(cardRelease).toHaveBeenCalledOnce();
+    expect(state.canceled).toBe(true);
+    expect(state.bytesPulled).toBeLessThan(FEISHU_JSON_MAX_BYTES * 2);
+    console.log(
+      `[feishu streaming-card bound proof] card-create over-cap: bytes_pulled=${state.bytesPulled} cap=${FEISHU_JSON_MAX_BYTES} canceled=${state.canceled}`,
+    );
+  });
 
   it("flushes throttled pending text after the throttle window", async () => {
     vi.useFakeTimers();
@@ -385,15 +483,12 @@ describe("FeishuStreamingSession", () => {
       async ({ url, init }: { url: string; init?: { body?: string } }) => {
         if (url.includes("/auth/")) {
           return {
-            response: {
-              ok: true,
-              json: async () => ({
-                code: 0,
-                msg: "ok",
-                tenant_access_token: "token",
-                expire: 7200,
-              }),
-            },
+            response: jsonResponse({
+              code: 0,
+              msg: "ok",
+              tenant_access_token: "token",
+              expire: 7200,
+            }),
             release,
           };
         }
@@ -401,7 +496,7 @@ describe("FeishuStreamingSession", () => {
           settingsBodies.push(init?.body ?? "");
         }
         return {
-          response: { ok: true, status: 200, json: async () => ({ code: 0, msg: "ok" }) },
+          response: jsonResponse({ code: 0, msg: "ok" }),
           release,
         };
       },

--- a/extensions/feishu/src/streaming-card.test.ts
+++ b/extensions/feishu/src/streaming-card.test.ts
@@ -41,10 +41,10 @@ type StreamingRequest = {
 const serverStops: Array<() => Promise<void>> = [];
 const HERMETIC_PUBLIC_LOOKUP_ADDRESS = "93.184.216.34";
 
-const hermeticPublicLookup: LookupFn = async () => ({
+const hermeticPublicLookup: LookupFn = (async (_hostname: string, _options?: unknown) => ({
   address: HERMETIC_PUBLIC_LOOKUP_ADDRESS,
   family: 4,
-});
+})) as LookupFn;
 
 async function readRequestBody(req: IncomingMessage): Promise<string> {
   let body = "";

--- a/extensions/feishu/src/streaming-card.test.ts
+++ b/extensions/feishu/src/streaming-card.test.ts
@@ -1,15 +1,12 @@
 // Feishu tests cover streaming card plugin behavior.
-import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-
-const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
-
-vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
-  fetchWithSsrFGuard: fetchWithSsrFGuardMock,
-}));
-
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import type { LookupFn } from "openclaw/plugin-sdk/ssrf-runtime";
+import { withFetchPreconnect } from "openclaw/plugin-sdk/test-env";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { FEISHU_JSON_MAX_BYTES } from "./json-response.js";
 import {
   FeishuStreamingSession,
+  type FeishuStreamingFetch,
   mergeStreamingText,
   resolveStreamingCardSendMode,
 } from "./streaming-card.js";
@@ -23,6 +20,125 @@ type StreamingSessionState = {
   hasNote: boolean;
 };
 
+type LocalServer = {
+  port: number;
+  stop: () => Promise<void>;
+};
+
+type DispatcherInit = RequestInit & { dispatcher?: unknown };
+type StreamingFetchDeps = {
+  fetchImpl: FeishuStreamingFetch;
+  lookupFn: LookupFn;
+};
+
+type StreamingRequest = {
+  url: URL;
+  body: string;
+  req: IncomingMessage;
+  res: ServerResponse;
+};
+
+const serverStops: Array<() => Promise<void>> = [];
+const HERMETIC_PUBLIC_LOOKUP_ADDRESS = "93.184.216.34";
+
+const hermeticPublicLookup: LookupFn = async () => ({
+  address: HERMETIC_PUBLIC_LOOKUP_ADDRESS,
+  family: 4,
+});
+
+async function readRequestBody(req: IncomingMessage): Promise<string> {
+  let body = "";
+  for await (const chunk of req) {
+    body += String(chunk);
+  }
+  return body;
+}
+
+async function startLocalServer(
+  handler: (request: StreamingRequest) => void | Promise<void>,
+): Promise<LocalServer> {
+  return await new Promise<LocalServer>((resolve, reject) => {
+    const server = createServer((req, res) => {
+      void (async () => {
+        const url = new URL(req.url ?? "/", "http://127.0.0.1");
+        const body = await readRequestBody(req);
+        await handler({ url, body, req, res });
+      })().catch((error: unknown) => {
+        if (!res.headersSent) {
+          res.writeHead(500, { "content-type": "text/plain" });
+        }
+        res.end(String(error));
+      });
+    });
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      if (!addr || typeof addr === "string") {
+        reject(new Error("local test server did not expose a TCP port"));
+        return;
+      }
+      resolve({
+        port: addr.port,
+        stop: async () =>
+          await new Promise<void>((innerResolve, innerReject) => {
+            server.close((err) => (err ? innerReject(err) : innerResolve()));
+          }),
+      });
+    });
+  });
+}
+
+function stripDispatcher(init: RequestInit | undefined): RequestInit | undefined {
+  if (!init || !("dispatcher" in init)) {
+    return init;
+  }
+  const { dispatcher: _dispatcher, ...rest } = init as DispatcherInit;
+  return rest;
+}
+
+function createLocalRedirectFetch(port: number): FeishuStreamingFetch {
+  const realFetch = globalThis.fetch.bind(globalThis);
+  return withFetchPreconnect(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = new URL(input instanceof Request ? input.url : input.toString());
+    if (url.hostname === "open.feishu.cn" || url.hostname === "open.larksuite.com") {
+      const loopback = new URL(`${url.pathname}${url.search}`, `http://127.0.0.1:${port}`);
+      return await realFetch(loopback, stripDispatcher(init));
+    }
+    return await realFetch(input, init);
+  });
+}
+
+async function createStreamingFetch(
+  handler: (request: StreamingRequest) => void | Promise<void>,
+): Promise<StreamingFetchDeps> {
+  const server = await startLocalServer(handler);
+  serverStops.push(server.stop);
+  return {
+    fetchImpl: createLocalRedirectFetch(server.port),
+    lookupFn: hermeticPublicLookup,
+  };
+}
+
+function createMemoryFetch(
+  handler: (url: URL, body: string) => Response | Promise<Response>,
+): StreamingFetchDeps {
+  return {
+    fetchImpl: withFetchPreconnect(
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = new URL(input instanceof Request ? input.url : input.toString());
+        const body = typeof init?.body === "string" ? init.body : "";
+        return await handler(url, body);
+      }),
+    ) as FeishuStreamingFetch,
+    lookupFn: hermeticPublicLookup,
+  };
+}
+
+function writeJson(res: ServerResponse, payload: unknown, status = 200): void {
+  res.writeHead(status, { "content-type": "application/json" });
+  res.end(JSON.stringify(payload));
+}
+
 function jsonResponse(payload: unknown, status = 200): Response {
   return new Response(JSON.stringify(payload), {
     status,
@@ -30,43 +146,45 @@ function jsonResponse(payload: unknown, status = 200): Response {
   });
 }
 
-function oversizedJsonStream(totalBytes: number): {
-  response: Response;
-  state: { bytesPulled: number; canceled: boolean };
-} {
-  const state = { bytesPulled: 0, canceled: false };
+function writeOversizedJson(
+  res: ServerResponse,
+  totalBytes: number,
+): { bytesPulled: () => number; canceled: () => boolean } {
   const chunk = Buffer.alloc(1024 * 1024, 0x20);
-  let remaining = totalBytes;
-  const stream = new ReadableStream<Uint8Array>({
-    start(controller) {
-      const prefix = new TextEncoder().encode(
-        '{"code":0,"msg":"ok","tenant_access_token":"token","padding":"',
-      );
-      remaining -= prefix.byteLength;
-      state.bytesPulled += prefix.byteLength;
-      controller.enqueue(prefix);
-    },
-    pull(controller) {
-      if (remaining <= 0) {
-        controller.enqueue(new TextEncoder().encode('"}'));
-        controller.close();
-        return;
-      }
-      const size = Math.min(chunk.byteLength, remaining);
-      remaining -= size;
-      state.bytesPulled += size;
-      controller.enqueue(chunk.subarray(0, size));
-    },
-    cancel() {
-      state.canceled = true;
-    },
+  let bytesPulled = 0;
+  let canceled = false;
+  let ended = false;
+  res.writeHead(200, { "content-type": "application/json" });
+  res.on("close", () => {
+    if (!ended && bytesPulled < totalBytes) {
+      canceled = true;
+    }
   });
+  const prefix = Buffer.from('{"code":0,"msg":"ok","tenant_access_token":"token","padding":"');
+  bytesPulled += prefix.byteLength;
+  res.write(prefix);
+  const sendChunk = () => {
+    if (bytesPulled >= totalBytes) {
+      if (!res.destroyed) {
+        ended = true;
+        res.end('"}');
+      }
+      return;
+    }
+    const remaining = totalBytes - bytesPulled;
+    const size = Math.min(chunk.byteLength, remaining);
+    bytesPulled += size;
+    const ok = res.write(chunk.subarray(0, size));
+    if (ok) {
+      setImmediate(sendChunk);
+      return;
+    }
+    res.once("drain", sendChunk);
+  };
+  setImmediate(sendChunk);
   return {
-    response: new Response(stream, {
-      status: 200,
-      headers: { "content-type": "application/json" },
-    }),
-    state,
+    bytesPulled: () => bytesPulled,
+    canceled: () => canceled || (!ended && bytesPulled < totalBytes),
   };
 }
 
@@ -88,19 +206,16 @@ function setStreamingSessionInternals(
 }
 
 describe("FeishuStreamingSession", () => {
-  afterAll(() => {
-    vi.doUnmock("openclaw/plugin-sdk/ssrf-runtime");
-    vi.resetModules();
-  });
-
   beforeEach(() => {
     vi.useRealTimers();
-    fetchWithSsrFGuardMock.mockReset();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     vi.restoreAllMocks();
     vi.useRealTimers();
+    while (serverStops.length > 0) {
+      await serverStops.pop()?.();
+    }
   });
 
   function mockFetches(
@@ -109,74 +224,57 @@ describe("FeishuStreamingSession", () => {
     replaceBodies: string[] = [],
     failedContentUpdateStatuses: ReadonlyMap<number, number> = new Map<number, number>(),
     failedReplaceStatuses: ReadonlyMap<number, number> = new Map<number, number>(),
-  ): void {
-    fetchWithSsrFGuardMock.mockImplementation(
-      async ({ url, init }: { url: string; init?: { body?: string } }) => {
-        const release = vi.fn(async () => {});
-        let status = 200;
-        if (url.includes("/auth/")) {
-          return {
-            response: jsonResponse({
-              code: 0,
-              msg: "ok",
-              tenant_access_token: "token",
-              expire: 7200,
-            }),
-            release,
-          };
+  ): StreamingFetchDeps {
+    return createMemoryFetch((url, body) => {
+      let status = 200;
+      if (url.pathname.includes("/auth/")) {
+        return jsonResponse({
+          code: 0,
+          msg: "ok",
+          tenant_access_token: "token",
+          expire: 7200,
+        });
+      }
+      if (url.pathname.includes("/elements/content/content")) {
+        const updateIndex = updateBodies.length;
+        updateBodies.push(body);
+        if (failedContentUpdateIndexes.has(updateIndex)) {
+          throw new Error(`content update ${updateIndex} failed`);
         }
-        if (url.includes("/elements/content/content")) {
-          const updateIndex = updateBodies.length;
-          updateBodies.push(init?.body ?? "");
-          if (failedContentUpdateIndexes.has(updateIndex)) {
-            throw new Error(`content update ${updateIndex} failed`);
-          }
-          const failedStatus = failedContentUpdateStatuses.get(updateIndex);
-          if (failedStatus !== undefined) {
-            status = failedStatus;
-          }
-        } else if (url.includes("/elements/content")) {
-          const replaceIndex = replaceBodies.length;
-          replaceBodies.push(init?.body ?? "");
-          const failedStatus = failedReplaceStatuses.get(replaceIndex);
-          if (failedStatus !== undefined) {
-            status = failedStatus;
-          }
+        const failedStatus = failedContentUpdateStatuses.get(updateIndex);
+        if (failedStatus !== undefined) {
+          status = failedStatus;
         }
-        return {
-          response: jsonResponse({ code: 0, msg: "ok" }, status),
-          release,
-        };
-      },
-    );
+      } else if (url.pathname.includes("/elements/content")) {
+        const replaceIndex = replaceBodies.length;
+        replaceBodies.push(body);
+        const failedStatus = failedReplaceStatuses.get(replaceIndex);
+        if (failedStatus !== undefined) {
+          status = failedStatus;
+        }
+      }
+      return jsonResponse({ code: 0, msg: "ok" }, status);
+    });
   }
 
   function mockStreamingTokenStart(resolveAuthJson: (token: string) => Record<string, unknown>): {
     authTokens: string[];
     client: ConstructorParameters<typeof FeishuStreamingSession>[0];
+    deps: StreamingFetchDeps;
   } {
-    const release = vi.fn(async () => {});
     const authTokens: string[] = [];
-    fetchWithSsrFGuardMock.mockImplementation(
-      async ({ url }: { url: string; init?: { body?: string } }) => {
-        if (url.includes("/auth/")) {
-          const token = `token-${authTokens.length + 1}`;
-          authTokens.push(token);
-          return {
-            response: jsonResponse(resolveAuthJson(token)),
-            release,
-          };
-        }
-        return {
-          response: jsonResponse({
-            code: 0,
-            msg: "ok",
-            data: { card_id: `card-${authTokens.length}` },
-          }),
-          release,
-        };
-      },
-    );
+    const deps = createMemoryFetch((url) => {
+      if (url.pathname.includes("/auth/")) {
+        const token = `token-${authTokens.length + 1}`;
+        authTokens.push(token);
+        return jsonResponse(resolveAuthJson(token));
+      }
+      return jsonResponse({
+        code: 0,
+        msg: "ok",
+        data: { card_id: `card-${authTokens.length}` },
+      });
+    });
     const client = {
       im: {
         message: {
@@ -184,45 +282,63 @@ describe("FeishuStreamingSession", () => {
         },
       },
     } as unknown as ConstructorParameters<typeof FeishuStreamingSession>[0];
-    return { authTokens, client };
+    return { authTokens, client, deps };
   }
 
   it("rejects oversized streaming tenant-token JSON before buffering the full body", async () => {
-    const { response, state } = oversizedJsonStream(FEISHU_JSON_MAX_BYTES * 2);
-    const release = vi.fn(async () => {});
-    fetchWithSsrFGuardMock.mockResolvedValueOnce({ response, release });
-
-    const session = new FeishuStreamingSession({} as never, {
-      appId: "app_oversized_token",
-      appSecret: "secret",
+    let streamState:
+      | {
+          bytesPulled: () => number;
+          canceled: () => boolean;
+        }
+      | undefined;
+    const deps = await createStreamingFetch(({ url, res }) => {
+      if (url.pathname.includes("/auth/")) {
+        streamState = writeOversizedJson(res, FEISHU_JSON_MAX_BYTES * 2);
+        return;
+      }
+      writeJson(res, { code: 0, msg: "ok", data: { card_id: "card_oversized_token" } });
     });
+
+    const session = new FeishuStreamingSession(
+      {} as never,
+      {
+        appId: "app_oversized_token",
+        appSecret: "secret",
+      },
+      undefined,
+      deps,
+    );
 
     await expect(session.start("chat_id", "open_id")).rejects.toThrow(
       /feishu\.streaming-card\.token: JSON response exceeds \d+ bytes/,
     );
-    expect(state.canceled).toBe(true);
-    expect(state.bytesPulled).toBeLessThan(FEISHU_JSON_MAX_BYTES * 2);
-    expect(release).toHaveBeenCalledOnce();
+    expect(streamState?.canceled()).toBe(true);
+    expect(streamState?.bytesPulled()).toBeLessThan(FEISHU_JSON_MAX_BYTES * 2);
     console.log(
-      `[feishu streaming-card bound proof] token over-cap: bytes_pulled=${state.bytesPulled} cap=${FEISHU_JSON_MAX_BYTES} canceled=${state.canceled}`,
+      `[feishu streaming-card bound proof] token over-cap: bytes_pulled=${streamState?.bytesPulled()} cap=${FEISHU_JSON_MAX_BYTES} canceled=${streamState?.canceled()}`,
     );
   });
 
   it("rejects oversized streaming card-create JSON before buffering the full body", async () => {
-    const tokenRelease = vi.fn(async () => {});
-    const cardRelease = vi.fn(async () => {});
-    const { response: cardResponse, state } = oversizedJsonStream(FEISHU_JSON_MAX_BYTES * 2);
-    fetchWithSsrFGuardMock
-      .mockResolvedValueOnce({
-        response: jsonResponse({
+    let streamState:
+      | {
+          bytesPulled: () => number;
+          canceled: () => boolean;
+        }
+      | undefined;
+    const deps = await createStreamingFetch(({ url, res }) => {
+      if (url.pathname.includes("/auth/")) {
+        writeJson(res, {
           code: 0,
           msg: "ok",
           tenant_access_token: "token",
           expire: 7200,
-        }),
-        release: tokenRelease,
-      })
-      .mockResolvedValueOnce({ response: cardResponse, release: cardRelease });
+        });
+        return;
+      }
+      streamState = writeOversizedJson(res, FEISHU_JSON_MAX_BYTES * 2);
+    });
 
     const session = new FeishuStreamingSession(
       {
@@ -236,17 +352,17 @@ describe("FeishuStreamingSession", () => {
         appId: "app_oversized_card_create",
         appSecret: "secret",
       },
+      undefined,
+      deps,
     );
 
     await expect(session.start("chat_id", "open_id")).rejects.toThrow(
       /feishu\.streaming-card\.create: JSON response exceeds \d+ bytes/,
     );
-    expect(tokenRelease).toHaveBeenCalledOnce();
-    expect(cardRelease).toHaveBeenCalledOnce();
-    expect(state.canceled).toBe(true);
-    expect(state.bytesPulled).toBeLessThan(FEISHU_JSON_MAX_BYTES * 2);
+    expect(streamState?.canceled()).toBe(true);
+    expect(streamState?.bytesPulled()).toBeLessThan(FEISHU_JSON_MAX_BYTES * 2);
     console.log(
-      `[feishu streaming-card bound proof] card-create over-cap: bytes_pulled=${state.bytesPulled} cap=${FEISHU_JSON_MAX_BYTES} canceled=${state.canceled}`,
+      `[feishu streaming-card bound proof] card-create over-cap: bytes_pulled=${streamState?.bytesPulled()} cap=${FEISHU_JSON_MAX_BYTES} canceled=${streamState?.canceled()}`,
     );
   });
 
@@ -254,12 +370,17 @@ describe("FeishuStreamingSession", () => {
     vi.useFakeTimers();
     vi.setSystemTime(1_000);
     const updateBodies: string[] = [];
-    mockFetches(updateBodies);
+    const deps = mockFetches(updateBodies);
 
-    const session = new FeishuStreamingSession({} as never, {
-      appId: "app_pending_flush",
-      appSecret: "secret",
-    });
+    const session = new FeishuStreamingSession(
+      {} as never,
+      {
+        appId: "app_pending_flush",
+        appSecret: "secret",
+      },
+      undefined,
+      deps,
+    );
     setStreamingSessionInternals(session, {
       state: {
         cardId: "card_1",
@@ -320,12 +441,17 @@ describe("FeishuStreamingSession", () => {
     vi.useFakeTimers();
     vi.setSystemTime(2_000);
     const updateBodies: string[] = [];
-    mockFetches(updateBodies);
+    const deps = mockFetches(updateBodies);
 
-    const session = new FeishuStreamingSession({} as never, {
-      appId: "app_boundary_flush",
-      appSecret: "secret",
-    });
+    const session = new FeishuStreamingSession(
+      {} as never,
+      {
+        appId: "app_boundary_flush",
+        appSecret: "secret",
+      },
+      undefined,
+      deps,
+    );
     setStreamingSessionInternals(session, {
       state: {
         cardId: "card_2",
@@ -352,12 +478,17 @@ describe("FeishuStreamingSession", () => {
     vi.useFakeTimers();
     vi.setSystemTime(3_000);
     const updateBodies: string[] = [];
-    mockFetches(updateBodies, new Set([0]));
+    const deps = mockFetches(updateBodies, new Set([0]));
 
-    const session = new FeishuStreamingSession({} as never, {
-      appId: "app_failed_delta_retry",
-      appSecret: "secret",
-    });
+    const session = new FeishuStreamingSession(
+      {} as never,
+      {
+        appId: "app_failed_delta_retry",
+        appSecret: "secret",
+      },
+      undefined,
+      deps,
+    );
     setStreamingSessionInternals(session, {
       state: {
         cardId: "card_3",
@@ -390,12 +521,17 @@ describe("FeishuStreamingSession", () => {
     vi.useFakeTimers();
     vi.setSystemTime(3_500);
     const updateBodies: string[] = [];
-    mockFetches(updateBodies, new Set<number>(), [], new Map([[0, 429]]));
+    const deps = mockFetches(updateBodies, new Set<number>(), [], new Map([[0, 429]]));
 
-    const session = new FeishuStreamingSession({} as never, {
-      appId: "app_non_ok_delta_retry",
-      appSecret: "secret",
-    });
+    const session = new FeishuStreamingSession(
+      {} as never,
+      {
+        appId: "app_non_ok_delta_retry",
+        appSecret: "secret",
+      },
+      undefined,
+      deps,
+    );
     setStreamingSessionInternals(session, {
       state: {
         cardId: "card_5",
@@ -429,12 +565,17 @@ describe("FeishuStreamingSession", () => {
     vi.setSystemTime(4_000);
     const updateBodies: string[] = [];
     const replaceBodies: string[] = [];
-    mockFetches(updateBodies, new Set<number>(), replaceBodies);
+    const deps = mockFetches(updateBodies, new Set<number>(), replaceBodies);
 
-    const session = new FeishuStreamingSession({} as never, {
-      appId: "app_final_rewrite",
-      appSecret: "secret",
-    });
+    const session = new FeishuStreamingSession(
+      {} as never,
+      {
+        appId: "app_final_rewrite",
+        appSecret: "secret",
+      },
+      undefined,
+      deps,
+    );
     setStreamingSessionInternals(session, {
       state: {
         cardId: "card_4",
@@ -478,34 +619,31 @@ describe("FeishuStreamingSession", () => {
     // lands between the high and low surrogate halves of the emoji.
     const finalText = `${"a".repeat(46)}\u{1F600}${"b".repeat(20)}`;
     const settingsBodies: string[] = [];
-    const release = vi.fn(async () => {});
-    fetchWithSsrFGuardMock.mockImplementation(
-      async ({ url, init }: { url: string; init?: { body?: string } }) => {
-        if (url.includes("/auth/")) {
-          return {
-            response: jsonResponse({
-              code: 0,
-              msg: "ok",
-              tenant_access_token: "token",
-              expire: 7200,
-            }),
-            release,
-          };
-        }
-        if (url.includes("/settings")) {
-          settingsBodies.push(init?.body ?? "");
-        }
-        return {
-          response: jsonResponse({ code: 0, msg: "ok" }),
-          release,
-        };
-      },
-    );
-
-    const session = new FeishuStreamingSession({} as never, {
-      appId: "app_summary_surrogate",
-      appSecret: "secret",
+    const deps = await createStreamingFetch(({ url, body, res }) => {
+      if (url.pathname.includes("/auth/")) {
+        writeJson(res, {
+          code: 0,
+          msg: "ok",
+          tenant_access_token: "token",
+          expire: 7200,
+        });
+        return;
+      }
+      if (url.pathname.includes("/settings")) {
+        settingsBodies.push(body);
+      }
+      writeJson(res, { code: 0, msg: "ok" });
     });
+
+    const session = new FeishuStreamingSession(
+      {} as never,
+      {
+        appId: "app_summary_surrogate",
+        appSecret: "secret",
+      },
+      undefined,
+      deps,
+    );
     setStreamingSessionInternals(session, {
       state: {
         cardId: "card_surrogate",
@@ -538,7 +676,7 @@ describe("FeishuStreamingSession", () => {
     vi.setSystemTime(4_500);
     const updateBodies: string[] = [];
     const replaceBodies: string[] = [];
-    mockFetches(
+    const deps = mockFetches(
       updateBodies,
       new Set<number>(),
       replaceBodies,
@@ -554,6 +692,7 @@ describe("FeishuStreamingSession", () => {
         appSecret: "secret",
       },
       log,
+      deps,
     );
     setStreamingSessionInternals(session, {
       state: {
@@ -581,7 +720,7 @@ describe("FeishuStreamingSession", () => {
     vi.setSystemTime(4_800);
     const updateBodies: string[] = [];
     const replaceBodies: string[] = [];
-    mockFetches(updateBodies, new Set<number>(), replaceBodies, new Map([[0, 500]]));
+    const deps = mockFetches(updateBodies, new Set<number>(), replaceBodies, new Map([[0, 500]]));
     const log = vi.fn();
 
     const session = new FeishuStreamingSession(
@@ -591,6 +730,7 @@ describe("FeishuStreamingSession", () => {
         appSecret: "secret",
       },
       log,
+      deps,
     );
     setStreamingSessionInternals(session, {
       state: {
@@ -616,47 +756,67 @@ describe("FeishuStreamingSession", () => {
   it("bounds streaming token cache lifetime when token expiry overflows", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-05-29T12:00:00.000Z"));
-    const { authTokens, client } = mockStreamingTokenStart((token) => ({
+    const { authTokens, client, deps } = mockStreamingTokenStart((token) => ({
       code: 0,
       msg: "ok",
       tenant_access_token: token,
       expire: Number.MAX_SAFE_INTEGER,
     }));
 
-    await new FeishuStreamingSession(client, {
-      appId: "app_unsafe_token_expiry",
-      appSecret: "secret",
-    }).start("chat_id", "open_id");
+    await new FeishuStreamingSession(
+      client,
+      {
+        appId: "app_unsafe_token_expiry",
+        appSecret: "secret",
+      },
+      undefined,
+      deps,
+    ).start("chat_id", "open_id");
     expect(authTokens).toEqual(["token-1"]);
 
     vi.setSystemTime(Date.now() + 7200 * 1000 - 60_000 + 1);
-    await new FeishuStreamingSession(client, {
-      appId: "app_unsafe_token_expiry",
-      appSecret: "secret",
-    }).start("chat_id", "open_id");
+    await new FeishuStreamingSession(
+      client,
+      {
+        appId: "app_unsafe_token_expiry",
+        appSecret: "secret",
+      },
+      undefined,
+      deps,
+    ).start("chat_id", "open_id");
 
     expect(authTokens).toEqual(["token-1", "token-2"]);
   });
 
   it("bounds streaming token fallback lifetime when the process clock is invalid", async () => {
     const dateNow = vi.spyOn(Date, "now").mockReturnValue(8_640_000_000_000_001);
-    const { authTokens, client } = mockStreamingTokenStart((token) => ({
+    const { authTokens, client, deps } = mockStreamingTokenStart((token) => ({
       code: 0,
       msg: "ok",
       tenant_access_token: token,
     }));
 
-    await new FeishuStreamingSession(client, {
-      appId: "app_invalid_clock_token_expiry",
-      appSecret: "secret",
-    }).start("chat_id", "open_id");
+    await new FeishuStreamingSession(
+      client,
+      {
+        appId: "app_invalid_clock_token_expiry",
+        appSecret: "secret",
+      },
+      undefined,
+      deps,
+    ).start("chat_id", "open_id");
     expect(authTokens).toEqual(["token-1"]);
 
     dateNow.mockReturnValue(7200 * 1000 - 60_000 + 1);
-    await new FeishuStreamingSession(client, {
-      appId: "app_invalid_clock_token_expiry",
-      appSecret: "secret",
-    }).start("chat_id", "open_id");
+    await new FeishuStreamingSession(
+      client,
+      {
+        appId: "app_invalid_clock_token_expiry",
+        appSecret: "secret",
+      },
+      undefined,
+      deps,
+    ).start("chat_id", "open_id");
 
     expect(authTokens).toEqual(["token-1", "token-2"]);
     dateNow.mockRestore();
@@ -664,24 +824,34 @@ describe("FeishuStreamingSession", () => {
 
   it("treats an invalid process clock as a streaming token cache miss", async () => {
     const dateNow = vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-05-29T12:00:00.000Z"));
-    const { authTokens, client } = mockStreamingTokenStart((token) => ({
+    const { authTokens, client, deps } = mockStreamingTokenStart((token) => ({
       code: 0,
       msg: "ok",
       tenant_access_token: token,
       expire: 7200,
     }));
 
-    await new FeishuStreamingSession(client, {
-      appId: "app_invalid_clock_cache_miss",
-      appSecret: "secret",
-    }).start("chat_id", "open_id");
+    await new FeishuStreamingSession(
+      client,
+      {
+        appId: "app_invalid_clock_cache_miss",
+        appSecret: "secret",
+      },
+      undefined,
+      deps,
+    ).start("chat_id", "open_id");
     expect(authTokens).toEqual(["token-1"]);
 
     dateNow.mockReturnValue(8_640_000_000_000_001);
-    await new FeishuStreamingSession(client, {
-      appId: "app_invalid_clock_cache_miss",
-      appSecret: "secret",
-    }).start("chat_id", "open_id");
+    await new FeishuStreamingSession(
+      client,
+      {
+        appId: "app_invalid_clock_cache_miss",
+        appSecret: "secret",
+      },
+      undefined,
+      deps,
+    ).start("chat_id", "open_id");
 
     expect(authTokens).toEqual(["token-1", "token-2"]);
     dateNow.mockRestore();

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -8,7 +8,7 @@ import {
   resolveDateTimestampMs,
   resolveExpiresAtMsFromDurationSeconds,
 } from "openclaw/plugin-sdk/number-runtime";
-import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
+import { fetchWithSsrFGuard, type LookupFn } from "openclaw/plugin-sdk/ssrf-runtime";
 import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { getFeishuUserAgent } from "./client.js";
 import { requestFeishuApi } from "./comment-shared.js";
@@ -24,6 +24,15 @@ type CardState = {
   currentText: string;
   sentText: string;
   hasNote: boolean;
+};
+
+export type FeishuStreamingFetch = typeof fetch;
+
+export type FeishuStreamingDeps = {
+  /** Override fetch for tests while preserving the real SSRF guard path. */
+  fetchImpl?: FeishuStreamingFetch;
+  /** Override hostname lookup for hermetic SSRF-guard tests. */
+  lookupFn?: LookupFn;
 };
 
 /** Options for customising the initial streaming card appearance. */
@@ -93,7 +102,7 @@ function resolveAllowedHostnames(domain?: FeishuDomain): string[] {
   return ["open.feishu.cn"];
 }
 
-async function getToken(creds: Credentials): Promise<string> {
+async function getToken(creds: Credentials, deps?: FeishuStreamingDeps): Promise<string> {
   const key = `${creds.domain ?? "feishu"}|${creds.appId}`;
   const cached = tokenCache.get(key);
   const rawNow = Date.now();
@@ -111,6 +120,8 @@ async function getToken(creds: Credentials): Promise<string> {
       headers: { "Content-Type": "application/json", "User-Agent": getFeishuUserAgent() },
       body: JSON.stringify({ app_id: creds.appId, app_secret: creds.appSecret }),
     },
+    fetchImpl: deps?.fetchImpl,
+    lookupFn: deps?.lookupFn,
     policy: { allowedHostnames: resolveAllowedHostnames(creds.domain) },
     auditContext: "feishu.streaming-card.token",
   });
@@ -221,11 +232,20 @@ export class FeishuStreamingSession {
   private pendingText: string | null = null;
   private flushTimer: ReturnType<typeof setTimeout> | null = null;
   private updateThrottleMs = STREAMING_UPDATE_THROTTLE_MS;
+  private fetchImpl?: FeishuStreamingFetch;
+  private lookupFn?: LookupFn;
 
-  constructor(client: Client, creds: Credentials, log?: (msg: string) => void) {
+  constructor(
+    client: Client,
+    creds: Credentials,
+    log?: (msg: string) => void,
+    deps?: FeishuStreamingDeps,
+  ) {
     this.client = client;
     this.creds = creds;
     this.log = log;
+    this.fetchImpl = deps?.fetchImpl;
+    this.lookupFn = deps?.lookupFn;
   }
 
   async start(
@@ -271,12 +291,17 @@ export class FeishuStreamingSession {
       init: {
         method: "POST",
         headers: {
-          Authorization: `Bearer ${await getToken(this.creds)}`,
+          Authorization: `Bearer ${await getToken(this.creds, {
+            fetchImpl: this.fetchImpl,
+            lookupFn: this.lookupFn,
+          })}`,
           "Content-Type": "application/json",
           "User-Agent": getFeishuUserAgent(),
         },
         body: JSON.stringify({ type: "card_json", data: JSON.stringify(cardJson) }),
       },
+      fetchImpl: this.fetchImpl,
+      lookupFn: this.lookupFn,
       policy: { allowedHostnames: resolveAllowedHostnames(this.creds.domain) },
       auditContext: "feishu.streaming-card.create",
     });
@@ -376,7 +401,10 @@ export class FeishuStreamingSession {
         init: {
           method: "PUT",
           headers: {
-            Authorization: `Bearer ${await getToken(this.creds)}`,
+            Authorization: `Bearer ${await getToken(this.creds, {
+              fetchImpl: this.fetchImpl,
+              lookupFn: this.lookupFn,
+            })}`,
             "Content-Type": "application/json",
             "User-Agent": getFeishuUserAgent(),
           },
@@ -386,6 +414,8 @@ export class FeishuStreamingSession {
             uuid: `s_${this.state.cardId}_${this.state.sequence}`,
           }),
         },
+        fetchImpl: this.fetchImpl,
+        lookupFn: this.lookupFn,
         policy: { allowedHostnames: resolveAllowedHostnames(this.creds.domain) },
         auditContext: "feishu.streaming-card.update",
       });
@@ -416,7 +446,10 @@ export class FeishuStreamingSession {
         init: {
           method: "PUT",
           headers: {
-            Authorization: `Bearer ${await getToken(this.creds)}`,
+            Authorization: `Bearer ${await getToken(this.creds, {
+              fetchImpl: this.fetchImpl,
+              lookupFn: this.lookupFn,
+            })}`,
             "Content-Type": "application/json",
             "User-Agent": getFeishuUserAgent(),
           },
@@ -426,6 +459,8 @@ export class FeishuStreamingSession {
             uuid: `r_${this.state.cardId}_${this.state.sequence}`,
           }),
         },
+        fetchImpl: this.fetchImpl,
+        lookupFn: this.lookupFn,
         policy: { allowedHostnames: resolveAllowedHostnames(this.creds.domain) },
         auditContext: "feishu.streaming-card.replace",
       });
@@ -519,7 +554,10 @@ export class FeishuStreamingSession {
       init: {
         method: "PUT",
         headers: {
-          Authorization: `Bearer ${await getToken(this.creds)}`,
+          Authorization: `Bearer ${await getToken(this.creds, {
+            fetchImpl: this.fetchImpl,
+            lookupFn: this.lookupFn,
+          })}`,
           "Content-Type": "application/json",
           "User-Agent": getFeishuUserAgent(),
         },
@@ -529,6 +567,8 @@ export class FeishuStreamingSession {
           uuid: `n_${this.state.cardId}_${this.state.sequence}`,
         }),
       },
+      fetchImpl: this.fetchImpl,
+      lookupFn: this.lookupFn,
       policy: { allowedHostnames: resolveAllowedHostnames(this.creds.domain) },
       auditContext: "feishu.streaming-card.note-update",
     })
@@ -578,7 +618,10 @@ export class FeishuStreamingSession {
       init: {
         method: "PATCH",
         headers: {
-          Authorization: `Bearer ${await getToken(this.creds)}`,
+          Authorization: `Bearer ${await getToken(this.creds, {
+            fetchImpl: this.fetchImpl,
+            lookupFn: this.lookupFn,
+          })}`,
           "Content-Type": "application/json; charset=utf-8",
           "User-Agent": getFeishuUserAgent(),
         },
@@ -590,6 +633,8 @@ export class FeishuStreamingSession {
           uuid: `c_${this.state.cardId}_${this.state.sequence}`,
         }),
       },
+      fetchImpl: this.fetchImpl,
+      lookupFn: this.lookupFn,
       policy: { allowedHostnames: resolveAllowedHostnames(this.creds.domain) },
       auditContext: "feishu.streaming-card.close",
     })

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -12,6 +12,7 @@ import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { getFeishuUserAgent } from "./client.js";
 import { requestFeishuApi } from "./comment-shared.js";
+import { readFeishuJsonResponse } from "./json-response.js";
 import { resolveFeishuCardTemplate, type CardHeaderConfig } from "./send.js";
 import type { FeishuDomain } from "./types.js";
 
@@ -113,17 +114,20 @@ async function getToken(creds: Credentials): Promise<string> {
     policy: { allowedHostnames: resolveAllowedHostnames(creds.domain) },
     auditContext: "feishu.streaming-card.token",
   });
-  if (!response.ok) {
-    await release();
-    throw new Error(`Token request failed with HTTP ${response.status}`);
-  }
-  const data = (await response.json()) as {
+  let data: {
     code: number;
     msg: string;
     tenant_access_token?: string;
     expire?: number;
   };
-  await release();
+  try {
+    if (!response.ok) {
+      throw new Error(`Token request failed with HTTP ${response.status}`);
+    }
+    data = await readFeishuJsonResponse(response, "feishu.streaming-card.token");
+  } finally {
+    await release();
+  }
   if (data.code !== 0 || !data.tenant_access_token) {
     throw new Error(`Token error: ${data.msg}`);
   }
@@ -276,16 +280,19 @@ export class FeishuStreamingSession {
       policy: { allowedHostnames: resolveAllowedHostnames(this.creds.domain) },
       auditContext: "feishu.streaming-card.create",
     });
-    if (!createRes.ok) {
-      await releaseCreate();
-      throw new Error(`Create card request failed with HTTP ${createRes.status}`);
-    }
-    const createData = (await createRes.json()) as {
+    let createData: {
       code: number;
       msg: string;
       data?: { card_id: string };
     };
-    await releaseCreate();
+    try {
+      if (!createRes.ok) {
+        throw new Error(`Create card request failed with HTTP ${createRes.status}`);
+      }
+      createData = await readFeishuJsonResponse(createRes, "feishu.streaming-card.create");
+    } finally {
+      await releaseCreate();
+    }
     if (createData.code !== 0 || !createData.data?.card_id) {
       throw new Error(`Create card failed: ${createData.msg}`);
     }


### PR DESCRIPTION
## Summary

- Adds a shared Feishu JSON response wrapper that delegates to `openclaw/plugin-sdk/provider-http` while capping credentialed Feishu API JSON bodies at 16 MiB.
- Routes app-registration JSON reads through the shared helper, covering init, device-code begin, polling, and app-owner lookup.
- Extends the same cap to the sibling streaming-card token and card-create JSON reads, addressing the previous review finding about an uncovered Feishu credentialed path.
- Adds an optional `fetchImpl`/`lookupFn` test seam to the app-registration and streaming-card fetch call sites so tests can exercise the real `fetchWithSsrFGuard` guard end-to-end instead of replacing it with a mock; production callers are unaffected (no caller passes these options, so default behavior is unchanged).
- Rebases cleanly onto latest `upstream/main` and keeps the upstream scan-to-create QR terminal rendering test.

## Linked context

No linked issue; this is a bounded-response-read hardening follow-up for Feishu/Lark credentialed API JSON responses.

## Real behavior proof (required for external PRs)

There are two layers of proof below: (1) a **live Feishu production API** run that drives the real changed app-registration functions against `accounts.feishu.cn`, and (2) local real-`node:http` + real-`fetchWithSsrFGuard` tests that force the oversized/over-cap rejection path (which a well-behaved production server never returns).

### Layer 1 — Live Feishu production API (real changed flow, no mocks, no injection)

- **Behavior or issue addressed:** The Feishu app-registration flow now routes its successful JSON reads through `readFeishuJsonResponse` (`FEISHU_JSON_MAX_BYTES = 16777216`). This proof drives the three real changed public registration functions against the live Feishu production API.
- **Real environment tested:** `fix/bound-feishu-app-registration` at `87dd039ef1`. Endpoint: live Feishu production API `https://accounts.feishu.cn/oauth/v1/app/registration`. Credentials: **none** — the registration `init`/`begin`/`poll` endpoint is anonymous. Mocking/injection: **none** for the production functions — the runner called the real exported functions without `fetchImpl` or `lookupFn`, so the path was the full default production path: `fetchWithSsrFGuard` (real DNS/hostname allowlist) → public internet → `accounts.feishu.cn` → real Feishu response body → `readFeishuJsonResponse` (16 MiB cap). The runner is kept outside the repo/branch; machine-local paths are omitted from this section.
- **Exact steps or command run after this patch:**
  ```bash
  git status -sb
  git log -1 --oneline --decorate
  node --import tsx <outside-repo-runner>   # imports the real production functions; no fetchImpl/lookupFn
  ```
- **Evidence after fix** (redacted live terminal output):
  ```text
  [feishu-live-proof] start {"pr":97782,"endpointHost":"accounts.feishu.cn","endpointPath":"/oauth/v1/app/registration","mode":"live Feishu production API; production functions called without fetchImpl or lookupFn overrides","readBoundBytes":16777216}
  [feishu-live-proof] negative-control.init.direct-fetch {"urlHost":"accounts.feishu.cn","status":200,"responseHeaders":{"server":"[redacted,len=7]","xRequestId":"[redacted,len=36]","xTtLogid":"[redacted,len=34]","contentType":"application/json; charset=utf-8"},"bodyShape":{"nonce":"v1:eyJ...[redacted,len=341]","supportedAuthMethods":["client_secret","private_key_jwt"]}}
  [feishu-live-proof] production-function.initAppRegistration {"result":"ok","domain":"feishu","path":"fetchWithSsrFGuard(default DNS/hostname allowlist) -> accounts.feishu.cn -> readFeishuJsonResponse","readFeishuJsonResponse":"cap=16777216; no exception"}
  [feishu-live-proof] production-function.beginAppRegistration {"result":"ok","domain":"feishu","deviceCode":"v1:eyJ...[redacted,len=514]","userCode":"[redacted,len=9]","qrUrl":{"present":true,"protocol":"https:","host":"open.feishu.cn","pathname":"/page/launcher","query":"[redacted]"},"interval":5,"expireIn":600,"path":"fetchWithSsrFGuard(default DNS/hostname allowlist) -> accounts.feishu.cn -> readFeishuJsonResponse","readFeishuJsonResponse":"cap=16777216; no exception"}
  [feishu-live-proof] negative-control.poll.pending.direct-fetch {"urlHost":"accounts.feishu.cn","status":400,"responseHeaders":{"server":"[redacted,len=7]","xRequestId":"[redacted,len=36]","xTtLogid":"[redacted,len=34]","contentType":"application/json; charset=utf-8"},"bodyShape":{"error":"authorization_pending","errorDescription":"[redacted,present]"}}
  [feishu-live-proof] production-function.pollAppRegistration {"result":"ok","elapsedMs":7352,"outcome":{"status":"timeout"},"pendingObservedByControl":true,"domain":"feishu","pollInput":{"deviceCode":"v1:eyJ...[redacted,len=514]","interval":2,"expireIn":5,"tp":"ob_cli_app"},"path":"fetchWithSsrFGuard(default DNS/hostname allowlist) -> accounts.feishu.cn -> readFeishuJsonResponse","readFeishuJsonResponse":"cap=16777216; no exception","note":"pollAppRegistration consumed live pending JSON and stopped via short expireIn instead of long polling"}
  [feishu-live-proof] done {"productionFunctions":["initAppRegistration","beginAppRegistration","pollAppRegistration"],"requestsToFeishuProduction":"bounded; no tenant credentials used","secretsPrinted":false}
  ```
- **Observed result after fix:**
  - Direct production control call to `accounts.feishu.cn` returned HTTP 200 for `action=init` with real Feishu response headers and a real body shape (`nonce` redacted, `supported_auth_methods: ["client_secret","private_key_jwt"]`).
  - Real `initAppRegistration("feishu")` succeeded through the default production path with no `readFeishuJsonResponse` exception.
  - Real `beginAppRegistration("feishu")` succeeded and returned redacted real device-code/user-code shapes, a QR URL with host `open.feishu.cn`, `interval: 5`, `expireIn: 600` — all consumed through the bounded reader.
  - Direct production control poll against the returned device code produced HTTP 400 JSON with `error: "authorization_pending"`, confirming Feishu's live pending response shape for the same anonymous flow.
  - Real `pollAppRegistration(...)` used the same device code and default production fetch path, consumed live pending JSON through `readFeishuJsonResponse`, and stopped via a short `expireIn` (returned `timeout`) instead of long-polling.
- **What was not tested (Layer 1):** the post-scan successful poll response (needs a human QR scan + app creation), `getAppOwnerOpenId` (needs a real app ID/secret), and the streaming-card flow (needs a tenant token). The oversized-response case cannot be forced from Feishu's production API — that is covered by Layer 2.

### Layer 2 — Local real-HTTP + real-SSRF-guard over/under-cap tests

- **Behavior or issue addressed:** oversized successful bodies must fail closed at 16 MiB before full buffering; under-cap bodies must still parse. A compliant production server never returns >16 MiB here, so this rejection path is exercised with a local `node:http` server.
- **Real environment tested:** Linux x86-64, real `ReadableStream`/`Response` body paths through production functions, real `fetchWithSsrFGuard` guard (not a mock) with only the final socket hop redirected to a local `node:http` server (via the optional `fetchImpl` seam) and a hermetic `lookupFn`.
- **Exact steps or command run after this patch:**
  ```bash
  node scripts/run-vitest.mjs extensions/feishu/src/app-registration.test.ts extensions/feishu/src/streaming-card.test.ts -- --run
  oxlint extensions/feishu/src/app-registration.ts extensions/feishu/src/app-registration.test.ts \
    extensions/feishu/src/streaming-card.ts extensions/feishu/src/streaming-card.test.ts \
    extensions/feishu/src/json-response.ts
  ```
- **Evidence after fix:**
  ```text
  [feishu fetchFeishuJson bound proof] real-ssrf-guard: guarded_url=https://accounts.feishu.cn/oauth/v1/app/registration socket=127.0.0.1
   ✓ Feishu app registration > sends bound reads through the real SSRF guard before local socket redirect
   ✓ feishu bound reads — local HTTP server > rejects oversized response before fully buffering the response (OOM guard)
   ✓ feishu bound reads — local HTTP server > parses well-formed JSON response under the cap
  [feishu fetchFeishuJson bound proof] over-cap: bytes_pulled=18874368 cap=16777216 canceled=true
  [feishu fetchFeishuJson bound proof] under-cap: returned={"deviceCode":"dev-code-123","userCode":"UC-456","interval":5,"expireIn":300}
  [bound-proof] canceled at 18/20 chunks
  Test Files  2 passed (2)
       Tests  29 passed (29)
  ```
  The first line shows `fetchWithSsrFGuard` invoked with the real production Feishu hostname while only the final socket connects to `127.0.0.1`. Over-cap read canceled at 18874368 bytes (cap 16777216); under-cap returns expected parsed JSON; stream canceled at chunk 18/20, confirming early cancellation before full buffering.
- **Observed result after fix:** App-registration oversized JSON rejects with `feishu.api: JSON response exceeds ...`; malformed JSON is labelled `feishu.api`; streaming-card token and card-create oversized JSON reject with their own call-site labels and cancel the stream before reading the full body. Normal under-cap flows still parse.
- **What was not tested (Layer 2):** nothing beyond the oversized/under-cap boundary — the real changed flow itself is covered by Layer 1 against the live production API.

## Tests and validation

- `node scripts/run-vitest.mjs extensions/feishu/src/app-registration.test.ts extensions/feishu/src/streaming-card.test.ts -- --run` — 2 files, 29 tests passed.
- `oxlint extensions/feishu/src/app-registration.ts extensions/feishu/src/app-registration.test.ts extensions/feishu/src/streaming-card.ts extensions/feishu/src/streaming-card.test.ts extensions/feishu/src/json-response.ts` — 0 problems.
- Live Feishu production API run (Layer 1 above) exercising the real `initAppRegistration`/`beginAppRegistration`/`pollAppRegistration` through the bounded reader.
- Merge conflict with the upstream QR rendering test resolved; that test remains in this branch.

## Risk checklist

- Did user-visible behavior change? **Only for oversized successful Feishu/Lark JSON responses**: they now fail closed at 16 MiB instead of being read unbounded.
- Did config, environment, or migration behavior change? **No**
- Did security, auth, secrets, network, or tool execution behavior change? **No** — the same endpoints, headers, and token cache semantics are used; the new `fetchImpl`/`lookupFn` parameters are optional test-only seams with no effect when omitted (all production call sites omit them).
- What is the highest-risk area? Maintainer acceptance of a 16 MiB fail-closed cap on Feishu control-plane JSON responses.
- How is that risk mitigated? These responses are control-plane/token/app metadata payloads and should be tiny relative to 16 MiB; the live production run above returned well under the cap, and under-cap tests verify normal behavior remains intact.

## Current review state

- **Next action:** ClawSweeper re-review, then maintainer review if CI stays green.
- **Waiting on:** maintainer acceptance of the 16 MiB fail-closed boundary.
- **Bot/reviewer comments addressed:** Added a live Feishu production API proof for the real changed app-registration flow (`init`/`begin`/`poll`, anonymous endpoint, no credentials, no mocks, default production `fetchWithSsrFGuard` path); resolved merge conflict; covered the sibling `streaming-card.ts` Feishu token/card-create JSON readers; changed the Feishu wrapper to delegate to shared `readProviderJsonResponse`; kept upstream QR rendering test.

_AI-assisted; implementation and validation reviewed before pushing._
