### PR TITLE
fix(google-meet): bound Calendar and Meet API response reads to prevent OOM

### DIFF
--- a/extensions/google-meet/src/api-fetch-guard.test.ts
+++ b/extensions/google-meet/src/api-fetch-guard.test.ts
@@ -52,6 +52,16 @@ function requestHeader(init: RequestInit | undefined, name: string): string | nu
   return new Headers(init?.headers).get(name);
 }
 
+function requestUrl(input: RequestInfo | URL): string {
+  if (typeof input === "string") {
+    return input;
+  }
+  if (input instanceof URL) {
+    return input.toString();
+  }
+  return input.url;
+}
+
 describe("Google Meet API bounded reads through the real fetch guard", () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -59,7 +69,7 @@ describe("Google Meet API bounded reads through the real fetch guard", () => {
 
   it("lists Calendar events through fetchWithSsrFGuard and parses under-cap JSON", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
-      const url = String(input);
+      const url = requestUrl(input);
       expect(url).toMatch(
         /^https:\/\/www\.googleapis\.com\/calendar\/v3\/calendars\/primary\/events\?/,
       );
@@ -94,7 +104,7 @@ describe("Google Meet API bounded reads through the real fetch guard", () => {
     const overCap = 17 * 1024 * 1024;
     const { response, state } = oversizedJsonResponse(overCap);
     const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
-      expect(String(input)).toBe("https://meet.googleapis.com/v2/spaces/abc123");
+      expect(requestUrl(input)).toBe("https://meet.googleapis.com/v2/spaces/abc123");
       expect(requestHeader(init, "authorization")).toBe("Bearer tok-meet");
       return response;
     });

--- a/extensions/google-meet/src/api-fetch-guard.test.ts
+++ b/extensions/google-meet/src/api-fetch-guard.test.ts
@@ -1,57 +1,40 @@
 // Google Meet tests prove bounded reads through the real SSRF fetch guard.
-import { createServer } from "node:http";
-import { afterEach, describe, expect, it, vi } from "vitest";
-import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
+import { createServer, type IncomingHttpHeaders, type IncomingMessage, type ServerResponse } from "node:http";
+import { describe, expect, it } from "vitest";
+import type { LookupFn } from "openclaw/plugin-sdk/ssrf-runtime";
 import { listGoogleMeetCalendarEvents } from "./calendar.js";
 import { fetchGoogleMeetSpace } from "./meet.js";
 
-function streamedJsonResponse(payload: unknown): Response {
-  const encoded = new TextEncoder().encode(JSON.stringify(payload));
-  const midpoint = Math.floor(encoded.length / 2);
-  return new Response(
-    new ReadableStream<Uint8Array>({
-      start(controller) {
-        controller.enqueue(encoded.slice(0, midpoint));
-        controller.enqueue(encoded.slice(midpoint));
-        controller.close();
-      },
-    }),
-    { status: 200, headers: { "content-type": "application/json" } },
-  );
-}
+type RecordedRequest = {
+  method: string;
+  url: string;
+  headers: IncomingHttpHeaders;
+};
 
-function oversizedJsonResponse(totalBytes: number): {
-  response: Response;
-  state: { bytesPulled: number; canceled: boolean };
-} {
-  const chunk = new Uint8Array(64 * 1024).fill(0x78);
-  const state = { bytesPulled: 0, canceled: false };
-  let sent = 0;
-  return {
-    response: new Response(
-      new ReadableStream<Uint8Array>({
-        pull(controller) {
-          if (sent >= totalBytes) {
-            controller.close();
-            return;
-          }
-          const size = Math.min(chunk.byteLength, totalBytes - sent);
-          sent += size;
-          state.bytesPulled += size;
-          controller.enqueue(chunk.subarray(0, size));
-        },
-        cancel() {
-          state.canceled = true;
-        },
-      }),
-      { status: 200, headers: { "content-type": "application/json" } },
-    ),
-    state,
-  };
-}
+type LocalServer = {
+  baseUrl: string;
+  requests: RecordedRequest[];
+  stop: () => Promise<void>;
+};
 
-function requestHeader(init: RequestInit | undefined, name: string): string | null {
-  return new Headers(init?.headers).get(name);
+type GoogleApiFetch = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+type DispatcherAwareRequestInit = RequestInit & { dispatcher?: unknown };
+
+type OversizedWriteState = { bytesWritten: number; closed: boolean };
+
+type LocalGuardFetchDeps = {
+  fetchImpl: GoogleApiFetch;
+  lookupFn: LookupFn;
+};
+
+async function waitForServerClose(state: OversizedWriteState): Promise<void> {
+  const deadline = Date.now() + 1_000;
+  while (!state.closed && Date.now() < deadline) {
+    await new Promise((resolve) => {
+      setTimeout(resolve, 10);
+    });
+  }
 }
 
 function requestUrl(input: RequestInfo | URL): string {
@@ -64,20 +47,125 @@ function requestUrl(input: RequestInfo | URL): string {
   return input.url;
 }
 
-describe("Google Meet API bounded reads through the real fetch guard", () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
+function withoutDispatcher(init: RequestInit | undefined): RequestInit | undefined {
+  if (!init) {
+    return undefined;
+  }
+  const { dispatcher: _dispatcher, ...standardInit } = init as DispatcherAwareRequestInit;
+  return standardInit;
+}
 
+async function startLocalServer(
+  handler: (req: IncomingMessage, res: ServerResponse) => void,
+): Promise<LocalServer> {
+  const requests: RecordedRequest[] = [];
+  const server = createServer((req, res) => {
+    requests.push({
+      method: req.method ?? "GET",
+      url: req.url ?? "/",
+      headers: req.headers,
+    });
+    handler(req, res);
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Local test server did not bind to a TCP port");
+  }
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    requests,
+    stop: async () => {
+      server.closeAllConnections();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      });
+    },
+  };
+}
+
+const TEST_PUBLIC_DNS_ADDRESS = "93.184.216.34";
+
+const testLookupFn = (async (_hostname: string, options?: { all?: boolean }) =>
+  options?.all
+    ? [{ address: TEST_PUBLIC_DNS_ADDRESS, family: 4 }]
+    : { address: TEST_PUBLIC_DNS_ADDRESS, family: 4 }) as LookupFn;
+
+function createLocalGuardFetchDeps(params: {
+  localBaseUrl: string;
+  allowedHostnames: string[];
+}): LocalGuardFetchDeps {
+  const realFetch = globalThis.fetch.bind(globalThis);
+  const allowedHostnames = new Set(params.allowedHostnames);
+  return {
+    fetchImpl: async (input, init) => {
+      const url = new URL(requestUrl(input));
+      if (!allowedHostnames.has(url.hostname)) {
+        return await realFetch(input, init);
+      }
+      const loopback = new URL(`${url.pathname}${url.search}`, params.localBaseUrl);
+      return await realFetch(loopback, withoutDispatcher(init));
+    },
+    lookupFn: testLookupFn,
+  };
+}
+
+function writeJson(res: ServerResponse, payload: unknown): void {
+  res.writeHead(200, { "content-type": "application/json" });
+  res.end(JSON.stringify(payload));
+}
+
+function writeOversizedJson(
+  res: ServerResponse,
+  params: {
+    totalBytes: number;
+    state: OversizedWriteState;
+  },
+): void {
+  const chunk = Buffer.alloc(64 * 1024, 0x78);
+  let sent = 0;
+  res.on("close", () => {
+    params.state.closed = true;
+  });
+  res.writeHead(200, { "content-type": "application/json" });
+
+  const writeNext = () => {
+    if (res.destroyed || sent >= params.totalBytes) {
+      if (!res.destroyed) {
+        res.end();
+      }
+      return;
+    }
+    const size = Math.min(chunk.byteLength, params.totalBytes - sent);
+    sent += size;
+    params.state.bytesWritten += size;
+    const canContinue = res.write(chunk.subarray(0, size));
+    if (canContinue) {
+      setTimeout(writeNext, 1);
+      return;
+    }
+    res.once("drain", () => setTimeout(writeNext, 1));
+  };
+
+  writeNext();
+}
+
+describe("Google Meet API bounded reads through the real fetch guard", () => {
   it("lists Calendar events through fetchWithSsrFGuard and parses under-cap JSON", async () => {
-    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
-      const url = requestUrl(input);
-      expect(url).toMatch(
-        /^https:\/\/www\.googleapis\.com\/calendar\/v3\/calendars\/primary\/events\?/,
-      );
-      expect(requestHeader(init, "authorization")).toBe("Bearer tok-calendar");
-      expect(requestHeader(init, "accept")).toBe("application/json");
-      return streamedJsonResponse({
+    const server = await startLocalServer((_req, res) => {
+      writeJson(res, {
         items: [
           {
             id: "event-real-guard",
@@ -90,113 +178,120 @@ describe("Google Meet API bounded reads through the real fetch guard", () => {
       });
     });
 
-    const result = await listGoogleMeetCalendarEvents({
-      accessToken: "tok-calendar",
-      calendarId: "primary",
-    });
+    try {
+      const fetchDeps = createLocalGuardFetchDeps({
+        localBaseUrl: server.baseUrl,
+        allowedHostnames: ["www.googleapis.com"],
+      });
+      const result = await listGoogleMeetCalendarEvents({
+        accessToken: "tok-calendar",
+        calendarId: "primary",
+        ...fetchDeps,
+      });
 
-    expect(fetchMock).toHaveBeenCalledOnce();
-    expect(result.events[0]?.meetingUri).toBe("https://meet.google.com/abc-def-ghi");
-    console.log(
-      `[google-meet fetch-guard proof] calendar events via real fetch guard: count=${result.events.length}`,
-    );
+      expect(server.requests).toHaveLength(1);
+      const request = server.requests[0];
+      expect(request?.method).toBe("GET");
+      expect(request?.url).toMatch(/^\/calendar\/v3\/calendars\/primary\/events\?/);
+      expect(request?.headers.authorization).toBe("Bearer tok-calendar");
+      expect(request?.headers.accept).toBe("application/json");
+      expect(result.events[0]?.meetingUri).toBe("https://meet.google.com/abc-def-ghi");
+      console.log(
+        `[google-meet fetch-guard proof] calendar events via real fetch guard: count=${result.events.length}`,
+      );
+    } finally {
+      await server.stop();
+    }
   });
 
   it("rejects oversized Meet space JSON through fetchWithSsrFGuard before full buffering", async () => {
     const overCap = 17 * 1024 * 1024;
-    const { response, state } = oversizedJsonResponse(overCap);
-    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
-      expect(requestUrl(input)).toBe("https://meet.googleapis.com/v2/spaces/abc123");
-      expect(requestHeader(init, "authorization")).toBe("Bearer tok-meet");
-      return response;
-    });
-
-    await expect(
-      fetchGoogleMeetSpace({ accessToken: "tok-meet", meeting: "spaces/abc123" }),
-    ).rejects.toThrow(/google-meet\.spaces\.get: JSON response exceeds \d+ bytes/);
-
-    expect(fetchMock).toHaveBeenCalledOnce();
-    expect(state.canceled).toBe(true);
-    expect(state.bytesPulled).toBeLessThan(overCap);
-    console.log(
-      `[google-meet fetch-guard proof] Meet spaces oversized JSON canceled at ${state.bytesPulled}/${overCap} bytes`,
-    );
-  });
-});
-
-describe("google-meet bound reads — real HTTP server (no fetch mock)", () => {
-  it("rejects oversized response before fully buffering 20 MiB (OOM guard)", async () => {
-    const CHUNK = Buffer.alloc(1024 * 1024, 0x61); // 1 MiB, all 'a'
-    const TOTAL_CHUNKS = 20; // 20 MiB total, well above 16 MiB cap
-    let chunksWritten = 0;
-
-    const srv = await new Promise<{ port: number; stop: () => Promise<void> }>((resolve, reject) => {
-      const server = createServer((_req, res) => {
-        res.writeHead(200, { "content-type": "application/json" });
-        let sent = 0;
-        const sendChunk = () => {
-          if (sent >= TOTAL_CHUNKS) {
-            res.end();
-            return;
-          }
-          sent++;
-          chunksWritten++;
-          const ok = res.write(CHUNK);
-          if (ok) { setImmediate(sendChunk); }
-          else { res.once("drain", sendChunk); }
-        };
-        sendChunk();
-      });
-      server.on("error", reject);
-      server.listen(0, "127.0.0.1", () => {
-        const addr = server.address() as { port: number };
-        resolve({
-          port: addr.port,
-          stop: () => new Promise<void>((r, e) => { server.close(err => (err ? e(err) : r())); }),
-        });
-      });
+    const state: OversizedWriteState = { bytesWritten: 0, closed: false };
+    const server = await startLocalServer((_req, res) => {
+      writeOversizedJson(res, { totalBytes: overCap, state });
     });
 
     try {
-      const response = await fetch(`http://127.0.0.1:${srv.port}/`);
-      // Mutation-control: bare `response.json()` would buffer all 20 MiB before throwing.
-      // readProviderJsonResponse aborts the stream at 16 MiB.
+      const fetchDeps = createLocalGuardFetchDeps({
+        localBaseUrl: server.baseUrl,
+        allowedHostnames: ["meet.googleapis.com"],
+      });
       await expect(
-        readProviderJsonResponse(response, "google-meet.bound-proof"),
-      ).rejects.toThrow(/JSON response exceeds/);
-      // Proves the body was NOT fully consumed before the cap fired.
-      expect(chunksWritten).toBeLessThan(TOTAL_CHUNKS);
-      console.log(`[bound-proof] canceled at ${chunksWritten}/${TOTAL_CHUNKS} chunks`);
+        fetchGoogleMeetSpace({
+          accessToken: "tok-meet",
+          meeting: "spaces/abc123",
+          ...fetchDeps,
+        }),
+      ).rejects.toThrow(/google-meet\.spaces\.get: JSON response exceeds \d+ bytes/);
+
+      expect(server.requests).toHaveLength(1);
+      const request = server.requests[0];
+      expect(request?.method).toBe("GET");
+      expect(request?.url).toBe("/v2/spaces/abc123");
+      expect(request?.headers.authorization).toBe("Bearer tok-meet");
+      await waitForServerClose(state);
+      expect(state.closed).toBe(true);
+      expect(state.bytesWritten).toBeLessThan(overCap);
+      console.log(
+        `[google-meet fetch-guard proof] Meet spaces oversized JSON canceled at ${state.bytesWritten}/${overCap} bytes`,
+      );
     } finally {
-      await srv.stop();
+      await server.stop();
+    }
+  });
+});
+
+describe("google-meet bound reads with a real HTTP server through the SSRF guard", () => {
+  it("rejects oversized response before fully buffering 20 MiB (OOM guard)", async () => {
+    const totalBytes = 20 * 1024 * 1024;
+    const state: OversizedWriteState = { bytesWritten: 0, closed: false };
+    const server = await startLocalServer((_req, res) => {
+      writeOversizedJson(res, { totalBytes, state });
+    });
+
+    try {
+      const fetchDeps = createLocalGuardFetchDeps({
+        localBaseUrl: server.baseUrl,
+        allowedHostnames: ["meet.googleapis.com"],
+      });
+      await expect(
+        fetchGoogleMeetSpace({
+          accessToken: "tok-meet",
+          meeting: "spaces/abc123",
+          ...fetchDeps,
+        }),
+      ).rejects.toThrow(/JSON response exceeds/);
+
+      expect(server.requests).toHaveLength(1);
+      await waitForServerClose(state);
+      expect(state.closed).toBe(true);
+      expect(state.bytesWritten).toBeLessThan(totalBytes);
+      console.log(`[bound-proof] canceled at ${state.bytesWritten}/${totalBytes} bytes`);
+    } finally {
+      await server.stop();
     }
   });
 
   it("parses well-formed JSON response under the 16 MiB cap", async () => {
-    const payload = { kind: "calendar#events", items: [] };
-    const srv = await new Promise<{ port: number; stop: () => Promise<void> }>((resolve, reject) => {
-      const server = createServer((_req, res) => {
-        res.writeHead(200, { "content-type": "application/json" });
-        res.end(JSON.stringify(payload));
-      });
-      server.on("error", reject);
-      server.listen(0, "127.0.0.1", () => {
-        const addr = server.address() as { port: number };
-        resolve({
-          port: addr.port,
-          stop: () => new Promise<void>((r, e) => { server.close(err => (err ? e(err) : r())); }),
-        });
-      });
+    const server = await startLocalServer((_req, res) => {
+      writeJson(res, { kind: "calendar#events", items: [] });
     });
+
     try {
-      const response = await fetch(`http://127.0.0.1:${srv.port}/`);
-      const result = await readProviderJsonResponse<typeof payload>(
-        response,
-        "google-meet.bound-proof",
-      );
-      expect(result).toEqual(payload);
+      const fetchDeps = createLocalGuardFetchDeps({
+        localBaseUrl: server.baseUrl,
+        allowedHostnames: ["www.googleapis.com"],
+      });
+      const result = await listGoogleMeetCalendarEvents({
+        accessToken: "tok-calendar",
+        calendarId: "primary",
+        ...fetchDeps,
+      });
+
+      expect(server.requests).toHaveLength(1);
+      expect(result).toEqual({ calendarId: "primary", events: [] });
     } finally {
-      await srv.stop();
+      await server.stop();
     }
   });
 });

--- a/extensions/google-meet/src/api-fetch-guard.test.ts
+++ b/extensions/google-meet/src/api-fetch-guard.test.ts
@@ -142,8 +142,8 @@ describe("google-meet bound reads — real HTTP server (no fetch mock)", () => {
           sent++;
           chunksWritten++;
           const ok = res.write(CHUNK);
-          if (ok) setImmediate(sendChunk);
-          else res.once("drain", sendChunk);
+          if (ok) { setImmediate(sendChunk); }
+          else { res.once("drain", sendChunk); }
         };
         sendChunk();
       });
@@ -152,7 +152,7 @@ describe("google-meet bound reads — real HTTP server (no fetch mock)", () => {
         const addr = server.address() as { port: number };
         resolve({
           port: addr.port,
-          stop: () => new Promise<void>((r, e) => server.close(err => (err ? e(err) : r()))),
+          stop: () => new Promise<void>((r, e) => { server.close(err => (err ? e(err) : r())); }),
         });
       });
     });
@@ -184,7 +184,7 @@ describe("google-meet bound reads — real HTTP server (no fetch mock)", () => {
         const addr = server.address() as { port: number };
         resolve({
           port: addr.port,
-          stop: () => new Promise<void>((r, e) => server.close(err => (err ? e(err) : r()))),
+          stop: () => new Promise<void>((r, e) => { server.close(err => (err ? e(err) : r())); }),
         });
       });
     });

--- a/extensions/google-meet/src/api-fetch-guard.test.ts
+++ b/extensions/google-meet/src/api-fetch-guard.test.ts
@@ -1,0 +1,113 @@
+// Google Meet tests prove bounded reads through the real SSRF fetch guard.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { listGoogleMeetCalendarEvents } from "./calendar.js";
+import { fetchGoogleMeetSpace } from "./meet.js";
+
+function streamedJsonResponse(payload: unknown): Response {
+  const encoded = new TextEncoder().encode(JSON.stringify(payload));
+  const midpoint = Math.floor(encoded.length / 2);
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoded.slice(0, midpoint));
+        controller.enqueue(encoded.slice(midpoint));
+        controller.close();
+      },
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
+function oversizedJsonResponse(totalBytes: number): {
+  response: Response;
+  state: { bytesPulled: number; canceled: boolean };
+} {
+  const chunk = new Uint8Array(64 * 1024).fill(0x78);
+  const state = { bytesPulled: 0, canceled: false };
+  let sent = 0;
+  return {
+    response: new Response(
+      new ReadableStream<Uint8Array>({
+        pull(controller) {
+          if (sent >= totalBytes) {
+            controller.close();
+            return;
+          }
+          const size = Math.min(chunk.byteLength, totalBytes - sent);
+          sent += size;
+          state.bytesPulled += size;
+          controller.enqueue(chunk.subarray(0, size));
+        },
+        cancel() {
+          state.canceled = true;
+        },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    ),
+    state,
+  };
+}
+
+function requestHeader(init: RequestInit | undefined, name: string): string | null {
+  return new Headers(init?.headers).get(name);
+}
+
+describe("Google Meet API bounded reads through the real fetch guard", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("lists Calendar events through fetchWithSsrFGuard and parses under-cap JSON", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const url = String(input);
+      expect(url).toMatch(
+        /^https:\/\/www\.googleapis\.com\/calendar\/v3\/calendars\/primary\/events\?/,
+      );
+      expect(requestHeader(init, "authorization")).toBe("Bearer tok-calendar");
+      expect(requestHeader(init, "accept")).toBe("application/json");
+      return streamedJsonResponse({
+        items: [
+          {
+            id: "event-real-guard",
+            summary: "Real guard proof",
+            hangoutLink: "https://meet.google.com/abc-def-ghi",
+            start: { dateTime: new Date(Date.now() + 60_000).toISOString() },
+            end: { dateTime: new Date(Date.now() + 3_660_000).toISOString() },
+          },
+        ],
+      });
+    });
+
+    const result = await listGoogleMeetCalendarEvents({
+      accessToken: "tok-calendar",
+      calendarId: "primary",
+    });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(result.events[0]?.meetingUri).toBe("https://meet.google.com/abc-def-ghi");
+    console.log(
+      `[google-meet fetch-guard proof] calendar events via real fetch guard: count=${result.events.length}`,
+    );
+  });
+
+  it("rejects oversized Meet space JSON through fetchWithSsrFGuard before full buffering", async () => {
+    const overCap = 17 * 1024 * 1024;
+    const { response, state } = oversizedJsonResponse(overCap);
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      expect(String(input)).toBe("https://meet.googleapis.com/v2/spaces/abc123");
+      expect(requestHeader(init, "authorization")).toBe("Bearer tok-meet");
+      return response;
+    });
+
+    await expect(
+      fetchGoogleMeetSpace({ accessToken: "tok-meet", meeting: "spaces/abc123" }),
+    ).rejects.toThrow(/google-meet\.spaces\.get: JSON response exceeds \d+ bytes/);
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(state.canceled).toBe(true);
+    expect(state.bytesPulled).toBeLessThan(overCap);
+    console.log(
+      `[google-meet fetch-guard proof] Meet spaces oversized JSON canceled at ${state.bytesPulled}/${overCap} bytes`,
+    );
+  });
+});

--- a/extensions/google-meet/src/api-fetch-guard.test.ts
+++ b/extensions/google-meet/src/api-fetch-guard.test.ts
@@ -1,5 +1,7 @@
 // Google Meet tests prove bounded reads through the real SSRF fetch guard.
+import { createServer } from "node:http";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import { listGoogleMeetCalendarEvents } from "./calendar.js";
 import { fetchGoogleMeetSpace } from "./meet.js";
 
@@ -119,5 +121,82 @@ describe("Google Meet API bounded reads through the real fetch guard", () => {
     console.log(
       `[google-meet fetch-guard proof] Meet spaces oversized JSON canceled at ${state.bytesPulled}/${overCap} bytes`,
     );
+  });
+});
+
+describe("google-meet bound reads — real HTTP server (no fetch mock)", () => {
+  it("rejects oversized response before fully buffering 20 MiB (OOM guard)", async () => {
+    const CHUNK = Buffer.alloc(1024 * 1024, 0x61); // 1 MiB, all 'a'
+    const TOTAL_CHUNKS = 20; // 20 MiB total, well above 16 MiB cap
+    let chunksWritten = 0;
+
+    const srv = await new Promise<{ port: number; stop: () => Promise<void> }>((resolve, reject) => {
+      const server = createServer((_req, res) => {
+        res.writeHead(200, { "content-type": "application/json" });
+        let sent = 0;
+        const sendChunk = () => {
+          if (sent >= TOTAL_CHUNKS) {
+            res.end();
+            return;
+          }
+          sent++;
+          chunksWritten++;
+          const ok = res.write(CHUNK);
+          if (ok) setImmediate(sendChunk);
+          else res.once("drain", sendChunk);
+        };
+        sendChunk();
+      });
+      server.on("error", reject);
+      server.listen(0, "127.0.0.1", () => {
+        const addr = server.address() as { port: number };
+        resolve({
+          port: addr.port,
+          stop: () => new Promise<void>((r, e) => server.close(err => (err ? e(err) : r()))),
+        });
+      });
+    });
+
+    try {
+      const response = await fetch(`http://127.0.0.1:${srv.port}/`);
+      // Mutation-control: bare `response.json()` would buffer all 20 MiB before throwing.
+      // readProviderJsonResponse aborts the stream at 16 MiB.
+      await expect(
+        readProviderJsonResponse(response, "google-meet.bound-proof"),
+      ).rejects.toThrow(/JSON response exceeds/);
+      // Proves the body was NOT fully consumed before the cap fired.
+      expect(chunksWritten).toBeLessThan(TOTAL_CHUNKS);
+      console.log(`[bound-proof] canceled at ${chunksWritten}/${TOTAL_CHUNKS} chunks`);
+    } finally {
+      await srv.stop();
+    }
+  });
+
+  it("parses well-formed JSON response under the 16 MiB cap", async () => {
+    const payload = { kind: "calendar#events", items: [] };
+    const srv = await new Promise<{ port: number; stop: () => Promise<void> }>((resolve, reject) => {
+      const server = createServer((_req, res) => {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify(payload));
+      });
+      server.on("error", reject);
+      server.listen(0, "127.0.0.1", () => {
+        const addr = server.address() as { port: number };
+        resolve({
+          port: addr.port,
+          stop: () => new Promise<void>((r, e) => server.close(err => (err ? e(err) : r()))),
+        });
+      });
+    });
+    try {
+      const response = await fetch(`http://127.0.0.1:${srv.port}/`);
+      const result = await readProviderJsonResponse<typeof payload>(
+        response,
+        "google-meet.bound-proof",
+      );
+      expect(result).toEqual(payload);
+    } finally {
+      await srv.stop();
+    }
   });
 });

--- a/extensions/google-meet/src/calendar.test.ts
+++ b/extensions/google-meet/src/calendar.test.ts
@@ -1,61 +1,147 @@
-// Google Meet tests cover bounded Calendar API response reads (listGoogleMeetCalendarEvents).
-//
-// readProviderJsonResponse is NOT mocked — it runs from real source so the byte-bounded
-// reader actually enforces the 16 MiB cap. Only fetchWithSsrFGuard is mocked so tests
-// can inject controlled Response bodies without network I/O.
-import { describe, expect, it, vi } from "vitest";
+// Google Meet tests cover bounded Calendar API response reads through the real SSRF guard.
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { describe, expect, it } from "vitest";
+import type { LookupFn } from "openclaw/plugin-sdk/ssrf-runtime";
 import { listGoogleMeetCalendarEvents } from "./calendar.js";
 
-vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
-  fetchWithSsrFGuard: vi.fn(),
-}));
+type LocalServer = {
+  baseUrl: string;
+  stop: () => Promise<void>;
+};
 
-import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
+type DispatcherAwareRequestInit = RequestInit & { dispatcher?: unknown };
 
-const mockFetch = vi.mocked(fetchWithSsrFGuard);
+type OversizedWriteState = { bytesWritten: number; closed: boolean };
 
-function streamedJsonResponse(payload: unknown, status = 200): Response {
-  const encoded = new TextEncoder().encode(JSON.stringify(payload));
-  const stream = new ReadableStream<Uint8Array>({
-    start(controller) {
-      controller.enqueue(encoded);
-      controller.close();
-    },
-  });
-  return new Response(stream, {
-    status,
-    headers: { "content-type": "application/json" },
-  });
+type GoogleMeetCalendarFetch = (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+) => Promise<Response>;
+
+type LocalGuardFetchDeps = {
+  fetchImpl: GoogleMeetCalendarFetch;
+  lookupFn: LookupFn;
+};
+
+async function waitForServerClose(state: OversizedWriteState): Promise<void> {
+  const deadline = Date.now() + 1_000;
+  while (!state.closed && Date.now() < deadline) {
+    await new Promise((resolve) => {
+      setTimeout(resolve, 10);
+    });
+  }
 }
 
-function makeOversizedJsonResponse(sizeBytes: number): {
-  response: Response;
-  state: { bytesPulled: number; canceled: boolean };
-} {
-  const CHUNK = 65536;
-  const chunk = new Uint8Array(CHUNK).fill(0x78);
-  const state = { bytesPulled: 0, canceled: false };
-  let sent = 0;
-  const body = new ReadableStream<Uint8Array>({
-    pull(controller) {
-      if (sent >= sizeBytes) {
-        controller.close();
-        return;
+function requestUrl(input: RequestInfo | URL): string {
+  if (typeof input === "string") {
+    return input;
+  }
+  if (input instanceof URL) {
+    return input.toString();
+  }
+  return input.url;
+}
+
+function withoutDispatcher(init: RequestInit | undefined): RequestInit | undefined {
+  if (!init) {
+    return undefined;
+  }
+  const { dispatcher: _dispatcher, ...standardInit } = init as DispatcherAwareRequestInit;
+  return standardInit;
+}
+
+async function startLocalServer(
+  handler: (req: IncomingMessage, res: ServerResponse) => void,
+): Promise<LocalServer> {
+  const server = createServer(handler);
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Local test server did not bind to a TCP port");
+  }
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    stop: async () => {
+      server.closeAllConnections();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      });
+    },
+  };
+}
+
+const TEST_PUBLIC_DNS_ADDRESS = "93.184.216.34";
+
+const testLookupFn = (async (_hostname: string, options?: { all?: boolean }) =>
+  options?.all
+    ? [{ address: TEST_PUBLIC_DNS_ADDRESS, family: 4 }]
+    : { address: TEST_PUBLIC_DNS_ADDRESS, family: 4 }) as LookupFn;
+
+function createCalendarFetchDeps(localBaseUrl: string): LocalGuardFetchDeps {
+  const realFetch = globalThis.fetch.bind(globalThis);
+  return {
+    fetchImpl: async (input, init) => {
+      const url = new URL(requestUrl(input));
+      if (url.hostname !== "www.googleapis.com") {
+        return await realFetch(input, init);
       }
-      const toSend = Math.min(CHUNK, sizeBytes - sent);
-      controller.enqueue(chunk.subarray(0, toSend));
-      sent += toSend;
-      state.bytesPulled += toSend;
+      const loopback = new URL(`${url.pathname}${url.search}`, localBaseUrl);
+      return await realFetch(loopback, withoutDispatcher(init));
     },
-    cancel() {
-      state.canceled = true;
-    },
+    lookupFn: testLookupFn,
+  };
+}
+
+function writeJson(res: ServerResponse, payload: unknown): void {
+  res.writeHead(200, { "content-type": "application/json" });
+  res.end(JSON.stringify(payload));
+}
+
+function writeOversizedJson(
+  res: ServerResponse,
+  params: {
+    sizeBytes: number;
+    state: OversizedWriteState;
+  },
+): void {
+  const chunk = Buffer.alloc(64 * 1024, 0x78);
+  let sent = 0;
+  res.on("close", () => {
+    params.state.closed = true;
   });
-  const response = new Response(body, {
-    status: 200,
-    headers: { "content-type": "application/json" },
-  });
-  return { response, state };
+  res.writeHead(200, { "content-type": "application/json" });
+
+  const writeNext = () => {
+    if (res.destroyed || sent >= params.sizeBytes) {
+      if (!res.destroyed) {
+        res.end();
+      }
+      return;
+    }
+    const size = Math.min(chunk.byteLength, params.sizeBytes - sent);
+    sent += size;
+    params.state.bytesWritten += size;
+    const canContinue = res.write(chunk.subarray(0, size));
+    if (canContinue) {
+      setTimeout(writeNext, 1);
+      return;
+    }
+    res.once("drain", () => setTimeout(writeNext, 1));
+  };
+
+  writeNext();
 }
 
 describe("listGoogleMeetCalendarEvents — bounded Calendar API read", () => {
@@ -71,41 +157,47 @@ describe("listGoogleMeetCalendarEvents — bounded Calendar API read", () => {
         },
       ],
     };
-    const release = vi.fn(async () => undefined);
-    mockFetch.mockResolvedValueOnce({
-      response: streamedJsonResponse(eventsPayload),
-      finalUrl:
-        "https://www.googleapis.com/calendar/v3/calendars/primary/events",
-      release,
+    const server = await startLocalServer((_req, res) => {
+      writeJson(res, eventsPayload);
     });
 
-    const result = await listGoogleMeetCalendarEvents({
-      accessToken: "tok",
-      calendarId: "primary",
-    });
+    try {
+      const fetchDeps = createCalendarFetchDeps(server.baseUrl);
+      const result = await listGoogleMeetCalendarEvents({
+        accessToken: "tok",
+        calendarId: "primary",
+        ...fetchDeps,
+      });
 
-    expect(result.events.length).toBeGreaterThan(0);
-    expect(result.events[0]?.meetingUri).toBe("https://meet.google.com/abc-def-ghi");
-    expect(release).toHaveBeenCalledTimes(1);
+      expect(result.events.length).toBeGreaterThan(0);
+      expect(result.events[0]?.meetingUri).toBe("https://meet.google.com/abc-def-ghi");
+    } finally {
+      await server.stop();
+    }
   });
 
   it("rejects with a size error when Calendar response body exceeds 16 MiB (fail-closed)", async () => {
-    const OVER_CAP = 17 * 1024 * 1024;
-    const { response, state } = makeOversizedJsonResponse(OVER_CAP);
-    const release = vi.fn(async () => undefined);
-    mockFetch.mockResolvedValueOnce({
-      response,
-      finalUrl:
-        "https://www.googleapis.com/calendar/v3/calendars/primary/events",
-      release,
+    const overCap = 17 * 1024 * 1024;
+    const state: OversizedWriteState = { bytesWritten: 0, closed: false };
+    const server = await startLocalServer((_req, res) => {
+      writeOversizedJson(res, { sizeBytes: overCap, state });
     });
 
-    await expect(
-      listGoogleMeetCalendarEvents({ accessToken: "tok", calendarId: "primary" }),
-    ).rejects.toThrow(/exceeds/i);
+    try {
+      const fetchDeps = createCalendarFetchDeps(server.baseUrl);
+      await expect(
+        listGoogleMeetCalendarEvents({
+          accessToken: "tok",
+          calendarId: "primary",
+          ...fetchDeps,
+        }),
+      ).rejects.toThrow(/exceeds/i);
 
-    expect(state.canceled).toBe(true);
-    expect(state.bytesPulled).toBeLessThan(OVER_CAP);
-    expect(release).toHaveBeenCalledTimes(1);
+      await waitForServerClose(state);
+      expect(state.closed).toBe(true);
+      expect(state.bytesWritten).toBeLessThan(overCap);
+    } finally {
+      await server.stop();
+    }
   });
 });

--- a/extensions/google-meet/src/calendar.test.ts
+++ b/extensions/google-meet/src/calendar.test.ts
@@ -1,0 +1,111 @@
+// Google Meet tests cover bounded Calendar API response reads (listGoogleMeetCalendarEvents).
+//
+// readProviderJsonResponse is NOT mocked — it runs from real source so the byte-bounded
+// reader actually enforces the 16 MiB cap. Only fetchWithSsrFGuard is mocked so tests
+// can inject controlled Response bodies without network I/O.
+import { describe, expect, it, vi } from "vitest";
+import { listGoogleMeetCalendarEvents } from "./calendar.js";
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
+  fetchWithSsrFGuard: vi.fn(),
+}));
+
+import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
+
+const mockFetch = vi.mocked(fetchWithSsrFGuard);
+
+function streamedJsonResponse(payload: unknown, status = 200): Response {
+  const encoded = new TextEncoder().encode(JSON.stringify(payload));
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoded);
+      controller.close();
+    },
+  });
+  return new Response(stream, {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function makeOversizedJsonResponse(sizeBytes: number): {
+  response: Response;
+  state: { bytesPulled: number; canceled: boolean };
+} {
+  const CHUNK = 65536;
+  const chunk = new Uint8Array(CHUNK).fill(0x78);
+  const state = { bytesPulled: 0, canceled: false };
+  let sent = 0;
+  const body = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (sent >= sizeBytes) {
+        controller.close();
+        return;
+      }
+      const toSend = Math.min(CHUNK, sizeBytes - sent);
+      controller.enqueue(chunk.subarray(0, toSend));
+      sent += toSend;
+      state.bytesPulled += toSend;
+    },
+    cancel() {
+      state.canceled = true;
+    },
+  });
+  const response = new Response(body, {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+  return { response, state };
+}
+
+describe("listGoogleMeetCalendarEvents — bounded Calendar API read", () => {
+  it("returns events when the Calendar response is within the 16 MiB cap", async () => {
+    const eventsPayload = {
+      items: [
+        {
+          id: "event1",
+          summary: "Weekly Sync",
+          hangoutLink: "https://meet.google.com/abc-def-ghi",
+          start: { dateTime: new Date(Date.now() + 60_000).toISOString() },
+          end: { dateTime: new Date(Date.now() + 3_660_000).toISOString() },
+        },
+      ],
+    };
+    const release = vi.fn(async () => undefined);
+    mockFetch.mockResolvedValueOnce({
+      response: streamedJsonResponse(eventsPayload),
+      finalUrl:
+        "https://www.googleapis.com/calendar/v3/calendars/primary/events",
+      release,
+    });
+
+    const result = await listGoogleMeetCalendarEvents({
+      accessToken: "tok",
+      calendarId: "primary",
+    });
+
+    expect(result.events.length).toBeGreaterThan(0);
+    expect(result.events[0]?.meetingUri).toBe("https://meet.google.com/abc-def-ghi");
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects with a size error when Calendar response body exceeds 16 MiB (fail-closed)", async () => {
+    const OVER_CAP = 17 * 1024 * 1024;
+    const { response, state } = makeOversizedJsonResponse(OVER_CAP);
+    const release = vi.fn(async () => undefined);
+    mockFetch.mockResolvedValueOnce({
+      response,
+      finalUrl:
+        "https://www.googleapis.com/calendar/v3/calendars/primary/events",
+      release,
+    });
+
+    await expect(
+      listGoogleMeetCalendarEvents({ accessToken: "tok", calendarId: "primary" }),
+    ).rejects.toThrow(/exceeds/i);
+
+    expect(state.canceled).toBe(true);
+    expect(state.bytesPulled).toBeLessThan(OVER_CAP);
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/google-meet/src/calendar.ts
+++ b/extensions/google-meet/src/calendar.ts
@@ -1,5 +1,5 @@
 // Google Meet plugin module implements calendar behavior.
-import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
+import { fetchWithSsrFGuard, type LookupFn } from "openclaw/plugin-sdk/ssrf-runtime";
 import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import { googleApiError } from "./google-api-errors.js";
 
@@ -7,6 +7,14 @@ const GOOGLE_CALENDAR_API_BASE_URL = "https://www.googleapis.com/calendar/v3";
 const GOOGLE_CALENDAR_API_HOST = "www.googleapis.com";
 const GOOGLE_MEET_URL_HOST = "meet.google.com";
 const GOOGLE_CALENDAR_EVENTS_SCOPE = "https://www.googleapis.com/auth/calendar.events.readonly";
+
+type GoogleMeetCalendarFetch = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+type GoogleMeetCalendarFetchDeps = {
+  /** Override `fetch` for tests that exercise the real SSRF guard. */
+  fetchImpl?: GoogleMeetCalendarFetch;
+  lookupFn?: LookupFn;
+};
 
 type GoogleCalendarEventDate = {
   date?: string;
@@ -163,7 +171,11 @@ async function fetchGoogleCalendarEvents(params: {
   timeMax?: string;
   maxResults?: number;
   now?: Date;
-}): Promise<{ calendarId: string; events: GoogleMeetCalendarEvent[]; now: Date }> {
+} & GoogleMeetCalendarFetchDeps): Promise<{
+  calendarId: string;
+  events: GoogleMeetCalendarEvent[];
+  now: Date;
+}> {
   const calendarId = params.calendarId?.trim() || "primary";
   const now = params.now ?? new Date();
   const defaultTimeMax = new Date(now);
@@ -189,6 +201,8 @@ async function fetchGoogleCalendarEvents(params: {
     },
     policy: { allowedHostnames: [GOOGLE_CALENDAR_API_HOST] },
     auditContext: "google-meet.calendar.events.list",
+    fetchImpl: params.fetchImpl,
+    lookupFn: params.lookupFn,
   });
   try {
     if (!response.ok) {
@@ -216,7 +230,7 @@ export async function listGoogleMeetCalendarEvents(params: {
   timeMax?: string;
   maxResults?: number;
   now?: Date;
-}): Promise<GoogleMeetCalendarEventsResult> {
+} & GoogleMeetCalendarFetchDeps): Promise<GoogleMeetCalendarEventsResult> {
   const { calendarId, events, now } = await fetchGoogleCalendarEvents(params);
   const best = chooseBestMeetCalendarEvent(events, now);
   return {
@@ -238,7 +252,7 @@ export async function findGoogleMeetCalendarEvent(params: {
   timeMax?: string;
   maxResults?: number;
   now?: Date;
-}): Promise<GoogleMeetCalendarLookupResult> {
+} & GoogleMeetCalendarFetchDeps): Promise<GoogleMeetCalendarLookupResult> {
   const result = await listGoogleMeetCalendarEvents(params);
   const selected = result.events.find((event) => event.selected) ?? result.events[0];
   if (!selected) {

--- a/extensions/google-meet/src/calendar.ts
+++ b/extensions/google-meet/src/calendar.ts
@@ -1,5 +1,6 @@
 // Google Meet plugin module implements calendar behavior.
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import { googleApiError } from "./google-api-errors.js";
 
 const GOOGLE_CALENDAR_API_BASE_URL = "https://www.googleapis.com/calendar/v3";
@@ -197,7 +198,7 @@ async function fetchGoogleCalendarEvents(params: {
         scopes: [GOOGLE_CALENDAR_EVENTS_SCOPE],
       });
     }
-    const payload = (await response.json()) as { items?: unknown };
+    const payload = await readProviderJsonResponse<{ items?: unknown }>(response, "google-meet.calendar.events.list");
     if (payload.items !== undefined && !Array.isArray(payload.items)) {
       throw new Error("Google Calendar events.list response had non-array items");
     }

--- a/extensions/google-meet/src/meet.test.ts
+++ b/extensions/google-meet/src/meet.test.ts
@@ -1,68 +1,144 @@
-// Google Meet tests cover bounded Meet API response reads (fetchGoogleMeetJson helper
-// and fetchGoogleMeetSpace / createGoogleMeetSpace direct callers).
-//
-// readProviderJsonResponse is NOT mocked — it runs from real source so the byte-bounded
-// reader actually enforces the 16 MiB cap under test. Only fetchWithSsrFGuard is mocked
-// so tests can inject controlled Response bodies without network I/O.
-import { describe, expect, it, vi } from "vitest";
+// Google Meet tests cover bounded Meet API response reads through the real SSRF guard.
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { describe, expect, it } from "vitest";
+import type { LookupFn } from "openclaw/plugin-sdk/ssrf-runtime";
 import { createGoogleMeetSpace, fetchGoogleMeetSpace } from "./meet.js";
 
-vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
-  fetchWithSsrFGuard: vi.fn(),
-}));
+type LocalServer = {
+  baseUrl: string;
+  stop: () => Promise<void>;
+};
 
-import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
+type DispatcherAwareRequestInit = RequestInit & { dispatcher?: unknown };
 
-const mockFetch = vi.mocked(fetchWithSsrFGuard);
+type OversizedWriteState = { bytesWritten: number; closed: boolean };
 
-/** Streams a JSON payload as a Response body (no Content-Length). */
-function streamedJsonResponse(payload: unknown, status = 200): Response {
-  const encoded = new TextEncoder().encode(JSON.stringify(payload));
-  const stream = new ReadableStream<Uint8Array>({
-    start(controller) {
-      controller.enqueue(encoded);
-      controller.close();
-    },
-  });
-  return new Response(stream, {
-    status,
-    headers: { "content-type": "application/json" },
-  });
+type GoogleMeetApiFetch = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+type LocalGuardFetchDeps = {
+  fetchImpl: GoogleMeetApiFetch;
+  lookupFn: LookupFn;
+};
+
+async function waitForServerClose(state: OversizedWriteState): Promise<void> {
+  const deadline = Date.now() + 1_000;
+  while (!state.closed && Date.now() < deadline) {
+    await new Promise((resolve) => {
+      setTimeout(resolve, 10);
+    });
+  }
 }
 
-/**
- * Builds a Response whose body is larger than the 16 MiB cap.
- * Tracks whether the underlying stream was cancelled mid-flight (proving the
- * bounded reader aborted rather than buffering the full body).
- */
-function makeOversizedJsonResponse(sizeBytes: number): {
-  response: Response;
-  state: { bytesPulled: number; canceled: boolean };
-} {
-  const CHUNK = 65536;
-  const chunk = new Uint8Array(CHUNK).fill(0x78); // 'x' bytes — invalid JSON filler
-  const state = { bytesPulled: 0, canceled: false };
-  let sent = 0;
-  const body = new ReadableStream<Uint8Array>({
-    pull(controller) {
-      if (sent >= sizeBytes) {
-        controller.close();
-        return;
+function requestUrl(input: RequestInfo | URL): string {
+  if (typeof input === "string") {
+    return input;
+  }
+  if (input instanceof URL) {
+    return input.toString();
+  }
+  return input.url;
+}
+
+function withoutDispatcher(init: RequestInit | undefined): RequestInit | undefined {
+  if (!init) {
+    return undefined;
+  }
+  const { dispatcher: _dispatcher, ...standardInit } = init as DispatcherAwareRequestInit;
+  return standardInit;
+}
+
+async function startLocalServer(
+  handler: (req: IncomingMessage, res: ServerResponse) => void,
+): Promise<LocalServer> {
+  const server = createServer(handler);
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Local test server did not bind to a TCP port");
+  }
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    stop: async () => {
+      server.closeAllConnections();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      });
+    },
+  };
+}
+
+const TEST_PUBLIC_DNS_ADDRESS = "93.184.216.34";
+
+const testLookupFn = (async (_hostname: string, options?: { all?: boolean }) =>
+  options?.all
+    ? [{ address: TEST_PUBLIC_DNS_ADDRESS, family: 4 }]
+    : { address: TEST_PUBLIC_DNS_ADDRESS, family: 4 }) as LookupFn;
+
+function createMeetFetchDeps(localBaseUrl: string): LocalGuardFetchDeps {
+  const realFetch = globalThis.fetch.bind(globalThis);
+  return {
+    fetchImpl: async (input, init) => {
+      const url = new URL(requestUrl(input));
+      if (url.hostname !== "meet.googleapis.com") {
+        return await realFetch(input, init);
       }
-      const toSend = Math.min(CHUNK, sizeBytes - sent);
-      controller.enqueue(chunk.subarray(0, toSend));
-      sent += toSend;
-      state.bytesPulled += toSend;
+      const loopback = new URL(`${url.pathname}${url.search}`, localBaseUrl);
+      return await realFetch(loopback, withoutDispatcher(init));
     },
-    cancel() {
-      state.canceled = true;
-    },
+    lookupFn: testLookupFn,
+  };
+}
+
+function writeJson(res: ServerResponse, payload: unknown): void {
+  res.writeHead(200, { "content-type": "application/json" });
+  res.end(JSON.stringify(payload));
+}
+
+function writeOversizedJson(
+  res: ServerResponse,
+  params: {
+    sizeBytes: number;
+    state: OversizedWriteState;
+  },
+): void {
+  const chunk = Buffer.alloc(64 * 1024, 0x78);
+  let sent = 0;
+  res.on("close", () => {
+    params.state.closed = true;
   });
-  const response = new Response(body, {
-    status: 200,
-    headers: { "content-type": "application/json" },
-  });
-  return { response, state };
+  res.writeHead(200, { "content-type": "application/json" });
+
+  const writeNext = () => {
+    if (res.destroyed || sent >= params.sizeBytes) {
+      if (!res.destroyed) {
+        res.end();
+      }
+      return;
+    }
+    const size = Math.min(chunk.byteLength, params.sizeBytes - sent);
+    sent += size;
+    params.state.bytesWritten += size;
+    const canContinue = res.write(chunk.subarray(0, size));
+    if (canContinue) {
+      setTimeout(writeNext, 1);
+      return;
+    }
+    res.once("drain", () => setTimeout(writeNext, 1));
+  };
+
+  writeNext();
 }
 
 // ---------------------------------------------------------------------------
@@ -78,46 +154,58 @@ describe("fetchGoogleMeetSpace — bounded read", () => {
       meetingCode: "abc-def-ghi",
       meetingUri: "https://meet.google.com/abc-def-ghi",
     };
-    const release = vi.fn(async () => undefined);
-    mockFetch.mockResolvedValueOnce({
-      response: streamedJsonResponse(spacePayload),
-      finalUrl: "https://meet.googleapis.com/v2/spaces/abc123",
-      release,
+    const server = await startLocalServer((_req, res) => {
+      writeJson(res, spacePayload);
     });
 
-    const result = await fetchGoogleMeetSpace({ accessToken: "tok", meeting: "spaces/abc123" });
+    try {
+      const fetchDeps = createMeetFetchDeps(server.baseUrl);
+      const result = await fetchGoogleMeetSpace({
+        accessToken: "tok",
+        meeting: "spaces/abc123",
+        ...fetchDeps,
+      });
 
-    expect(result.name).toBe("spaces/abc123");
-    expect(result.meetingUri).toBe("https://meet.google.com/abc-def-ghi");
-    expect(release).toHaveBeenCalledTimes(1);
+      expect(result.name).toBe("spaces/abc123");
+      expect(result.meetingUri).toBe("https://meet.google.com/abc-def-ghi");
+    } finally {
+      await server.stop();
+    }
   });
 
   it("rejects with a labelled size error when response body exceeds 16 MiB (fail-closed)", async () => {
-    const OVER_CAP = 17 * 1024 * 1024; // 17 MiB — above the 16 MiB cap
-    const { response, state } = makeOversizedJsonResponse(OVER_CAP);
-    const release = vi.fn(async () => undefined);
-    mockFetch.mockResolvedValueOnce({
-      response,
-      finalUrl: "https://meet.googleapis.com/v2/spaces/abc123",
-      release,
+    const overCap = 17 * 1024 * 1024;
+    const state: OversizedWriteState = { bytesWritten: 0, closed: false };
+    const server = await startLocalServer((_req, res) => {
+      writeOversizedJson(res, { sizeBytes: overCap, state });
     });
 
-    await expect(
-      fetchGoogleMeetSpace({ accessToken: "tok", meeting: "spaces/abc123" }),
-    ).rejects.toThrow(/exceeds/i);
+    try {
+      const fetchDeps = createMeetFetchDeps(server.baseUrl);
+      await expect(
+        fetchGoogleMeetSpace({
+          accessToken: "tok",
+          meeting: "spaces/abc123",
+          ...fetchDeps,
+        }),
+      ).rejects.toThrow(/exceeds/i);
 
-    // The bounded reader must have cancelled the stream before reading all bytes.
-    expect(state.canceled).toBe(true);
-    expect(state.bytesPulled).toBeLessThan(OVER_CAP);
-    expect(release).toHaveBeenCalledTimes(1);
+      // The bounded reader must have cancelled the stream before reading all bytes.
+      await waitForServerClose(state);
+      expect(state.closed).toBe(true);
+      expect(state.bytesWritten).toBeLessThan(overCap);
+    } finally {
+      await server.stop();
+    }
   });
 
-  it("mutation: bare response.json() buffers the full oversized body without throwing", async () => {
+  it("mutation: bare response.arrayBuffer() buffers the full oversized body without throwing", async () => {
     // Negative-control: proves that reverting fetchGoogleMeetSpace to a bare
-    // response.json() call would silently buffer the entire oversized body.
-    const OVER_CAP = 17 * 1024 * 1024;
-    const { response } = makeOversizedJsonResponse(OVER_CAP);
-    // Calling response.json() directly buffers everything — no error is thrown.
+    // response body read would silently buffer the entire oversized body.
+    const overCap = 17 * 1024 * 1024;
+    const response = new Response(Buffer.alloc(overCap, 0x78), {
+      headers: { "content-type": "application/json" },
+    });
     const buffer = await response.arrayBuffer();
     expect(buffer.byteLength).toBeGreaterThan(16 * 1024 * 1024);
   });
@@ -134,33 +222,45 @@ describe("createGoogleMeetSpace — bounded read", () => {
       meetingCode: "new-space-code",
       meetingUri: "https://meet.google.com/new-space-code",
     };
-    const release = vi.fn(async () => undefined);
-    mockFetch.mockResolvedValueOnce({
-      response: streamedJsonResponse(spacePayload),
-      finalUrl: "https://meet.googleapis.com/v2/spaces",
-      release,
+    const server = await startLocalServer((_req, res) => {
+      writeJson(res, spacePayload);
     });
 
-    const result = await createGoogleMeetSpace({ accessToken: "tok" });
+    try {
+      const fetchDeps = createMeetFetchDeps(server.baseUrl);
+      const result = await createGoogleMeetSpace({
+        accessToken: "tok",
+        ...fetchDeps,
+      });
 
-    expect(result.space.name).toBe("spaces/newSpace");
-    expect(result.meetingUri).toBe("https://meet.google.com/new-space-code");
-    expect(release).toHaveBeenCalledTimes(1);
+      expect(result.space.name).toBe("spaces/newSpace");
+      expect(result.meetingUri).toBe("https://meet.google.com/new-space-code");
+    } finally {
+      await server.stop();
+    }
   });
 
   it("rejects with a labelled size error when create-space response body exceeds 16 MiB", async () => {
-    const OVER_CAP = 17 * 1024 * 1024;
-    const { response, state } = makeOversizedJsonResponse(OVER_CAP);
-    const release = vi.fn(async () => undefined);
-    mockFetch.mockResolvedValueOnce({
-      response,
-      finalUrl: "https://meet.googleapis.com/v2/spaces",
-      release,
+    const overCap = 17 * 1024 * 1024;
+    const state: OversizedWriteState = { bytesWritten: 0, closed: false };
+    const server = await startLocalServer((_req, res) => {
+      writeOversizedJson(res, { sizeBytes: overCap, state });
     });
 
-    await expect(createGoogleMeetSpace({ accessToken: "tok" })).rejects.toThrow(/exceeds/i);
+    try {
+      const fetchDeps = createMeetFetchDeps(server.baseUrl);
+      await expect(
+        createGoogleMeetSpace({
+          accessToken: "tok",
+          ...fetchDeps,
+        }),
+      ).rejects.toThrow(/exceeds/i);
 
-    expect(state.canceled).toBe(true);
-    expect(release).toHaveBeenCalledTimes(1);
+      await waitForServerClose(state);
+      expect(state.closed).toBe(true);
+      expect(state.bytesWritten).toBeLessThan(overCap);
+    } finally {
+      await server.stop();
+    }
   });
 });

--- a/extensions/google-meet/src/meet.test.ts
+++ b/extensions/google-meet/src/meet.test.ts
@@ -1,0 +1,166 @@
+// Google Meet tests cover bounded Meet API response reads (fetchGoogleMeetJson helper
+// and fetchGoogleMeetSpace / createGoogleMeetSpace direct callers).
+//
+// readProviderJsonResponse is NOT mocked — it runs from real source so the byte-bounded
+// reader actually enforces the 16 MiB cap under test. Only fetchWithSsrFGuard is mocked
+// so tests can inject controlled Response bodies without network I/O.
+import { describe, expect, it, vi } from "vitest";
+import { createGoogleMeetSpace, fetchGoogleMeetSpace } from "./meet.js";
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
+  fetchWithSsrFGuard: vi.fn(),
+}));
+
+import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
+
+const mockFetch = vi.mocked(fetchWithSsrFGuard);
+
+/** Streams a JSON payload as a Response body (no Content-Length). */
+function streamedJsonResponse(payload: unknown, status = 200): Response {
+  const encoded = new TextEncoder().encode(JSON.stringify(payload));
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoded);
+      controller.close();
+    },
+  });
+  return new Response(stream, {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+/**
+ * Builds a Response whose body is larger than the 16 MiB cap.
+ * Tracks whether the underlying stream was cancelled mid-flight (proving the
+ * bounded reader aborted rather than buffering the full body).
+ */
+function makeOversizedJsonResponse(sizeBytes: number): {
+  response: Response;
+  state: { bytesPulled: number; canceled: boolean };
+} {
+  const CHUNK = 65536;
+  const chunk = new Uint8Array(CHUNK).fill(0x78); // 'x' bytes — invalid JSON filler
+  const state = { bytesPulled: 0, canceled: false };
+  let sent = 0;
+  const body = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (sent >= sizeBytes) {
+        controller.close();
+        return;
+      }
+      const toSend = Math.min(CHUNK, sizeBytes - sent);
+      controller.enqueue(chunk.subarray(0, toSend));
+      sent += toSend;
+      state.bytesPulled += toSend;
+    },
+    cancel() {
+      state.canceled = true;
+    },
+  });
+  const response = new Response(body, {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+  return { response, state };
+}
+
+// ---------------------------------------------------------------------------
+// fetchGoogleMeetSpace — exercising the readProviderJsonResponse guard
+// (fetchGoogleMeetSpace has its own fetchWithSsrFGuard call; guarding it also
+// covers the fetchGoogleMeetJson shared helper which wraps the same pattern)
+// ---------------------------------------------------------------------------
+
+describe("fetchGoogleMeetSpace — bounded read", () => {
+  it("parses a well-formed space response within the 16 MiB cap", async () => {
+    const spacePayload = {
+      name: "spaces/abc123",
+      meetingCode: "abc-def-ghi",
+      meetingUri: "https://meet.google.com/abc-def-ghi",
+    };
+    const release = vi.fn(async () => undefined);
+    mockFetch.mockResolvedValueOnce({
+      response: streamedJsonResponse(spacePayload),
+      finalUrl: "https://meet.googleapis.com/v2/spaces/abc123",
+      release,
+    });
+
+    const result = await fetchGoogleMeetSpace({ accessToken: "tok", meeting: "spaces/abc123" });
+
+    expect(result.name).toBe("spaces/abc123");
+    expect(result.meetingUri).toBe("https://meet.google.com/abc-def-ghi");
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects with a labelled size error when response body exceeds 16 MiB (fail-closed)", async () => {
+    const OVER_CAP = 17 * 1024 * 1024; // 17 MiB — above the 16 MiB cap
+    const { response, state } = makeOversizedJsonResponse(OVER_CAP);
+    const release = vi.fn(async () => undefined);
+    mockFetch.mockResolvedValueOnce({
+      response,
+      finalUrl: "https://meet.googleapis.com/v2/spaces/abc123",
+      release,
+    });
+
+    await expect(
+      fetchGoogleMeetSpace({ accessToken: "tok", meeting: "spaces/abc123" }),
+    ).rejects.toThrow(/exceeds/i);
+
+    // The bounded reader must have cancelled the stream before reading all bytes.
+    expect(state.canceled).toBe(true);
+    expect(state.bytesPulled).toBeLessThan(OVER_CAP);
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it("mutation: bare response.json() buffers the full oversized body without throwing", async () => {
+    // Negative-control: proves that reverting fetchGoogleMeetSpace to a bare
+    // response.json() call would silently buffer the entire oversized body.
+    const OVER_CAP = 17 * 1024 * 1024;
+    const { response } = makeOversizedJsonResponse(OVER_CAP);
+    // Calling response.json() directly buffers everything — no error is thrown.
+    const buffer = await response.arrayBuffer();
+    expect(buffer.byteLength).toBeGreaterThan(16 * 1024 * 1024);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createGoogleMeetSpace — independent fetchWithSsrFGuard caller
+// ---------------------------------------------------------------------------
+
+describe("createGoogleMeetSpace — bounded read", () => {
+  it("parses a well-formed create-space response within the 16 MiB cap", async () => {
+    const spacePayload = {
+      name: "spaces/newSpace",
+      meetingCode: "new-space-code",
+      meetingUri: "https://meet.google.com/new-space-code",
+    };
+    const release = vi.fn(async () => undefined);
+    mockFetch.mockResolvedValueOnce({
+      response: streamedJsonResponse(spacePayload),
+      finalUrl: "https://meet.googleapis.com/v2/spaces",
+      release,
+    });
+
+    const result = await createGoogleMeetSpace({ accessToken: "tok" });
+
+    expect(result.space.name).toBe("spaces/newSpace");
+    expect(result.meetingUri).toBe("https://meet.google.com/new-space-code");
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects with a labelled size error when create-space response body exceeds 16 MiB", async () => {
+    const OVER_CAP = 17 * 1024 * 1024;
+    const { response, state } = makeOversizedJsonResponse(OVER_CAP);
+    const release = vi.fn(async () => undefined);
+    mockFetch.mockResolvedValueOnce({
+      response,
+      finalUrl: "https://meet.googleapis.com/v2/spaces",
+      release,
+    });
+
+    await expect(createGoogleMeetSpace({ accessToken: "tok" })).rejects.toThrow(/exceeds/i);
+
+    expect(state.canceled).toBe(true);
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/google-meet/src/meet.ts
+++ b/extensions/google-meet/src/meet.ts
@@ -1,5 +1,5 @@
 // Google Meet plugin module implements meet behavior.
-import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
+import { fetchWithSsrFGuard, type LookupFn } from "openclaw/plugin-sdk/ssrf-runtime";
 import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import { uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { exportGoogleDriveDocumentText, extractGoogleDriveDocumentId } from "./drive.js";
@@ -14,6 +14,14 @@ const GOOGLE_MEET_MEDIA_SCOPE =
 const GOOGLE_MEET_SPACE_SCOPE = "https://www.googleapis.com/auth/meetings.space.readonly";
 const GOOGLE_MEET_SPACE_CREATED_SCOPE = "https://www.googleapis.com/auth/meetings.space.created";
 const GOOGLE_MEET_SPACE_SETTINGS_SCOPE = "https://www.googleapis.com/auth/meetings.space.settings";
+
+type GoogleMeetApiFetch = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+type GoogleMeetApiFetchDeps = {
+  /** Override `fetch` for tests that exercise the real SSRF guard. */
+  fetchImpl?: GoogleMeetApiFetch;
+  lookupFn?: LookupFn;
+};
 
 export type GoogleMeetAccessType = "OPEN" | "TRUSTED" | "RESTRICTED";
 export type GoogleMeetEntryPointAccess = "ALL" | "CREATOR_APP_ONLY";
@@ -270,7 +278,7 @@ async function fetchGoogleMeetJson<T>(params: {
   query?: Record<string, string | number | boolean | undefined>;
   auditContext: string;
   errorPrefix: string;
-}): Promise<T> {
+} & GoogleMeetApiFetchDeps): Promise<T> {
   const { response, release } = await fetchWithSsrFGuard({
     url: appendQuery(`${GOOGLE_MEET_API_BASE_URL}/${params.path}`, params.query),
     init: {
@@ -281,6 +289,8 @@ async function fetchGoogleMeetJson<T>(params: {
     },
     policy: { allowedHostnames: [GOOGLE_MEET_API_HOST] },
     auditContext: params.auditContext,
+    fetchImpl: params.fetchImpl,
+    lookupFn: params.lookupFn,
   });
   try {
     if (!response.ok) {
@@ -304,7 +314,7 @@ async function listGoogleMeetCollection<T extends { name?: string }>(params: {
   maxItems?: number;
   auditContext: string;
   errorPrefix: string;
-}): Promise<T[]> {
+} & GoogleMeetApiFetchDeps): Promise<T[]> {
   const items: T[] = [];
   let pageToken: string | undefined;
   do {
@@ -314,6 +324,8 @@ async function listGoogleMeetCollection<T extends { name?: string }>(params: {
       query: { ...params.query, pageToken },
       auditContext: params.auditContext,
       errorPrefix: params.errorPrefix,
+      fetchImpl: params.fetchImpl,
+      lookupFn: params.lookupFn,
     });
     const pageItems = assertResourceArray<T>(
       payload[params.collectionKey],
@@ -334,7 +346,7 @@ async function listGoogleMeetCollection<T extends { name?: string }>(params: {
 export async function fetchGoogleMeetSpace(params: {
   accessToken: string;
   meeting: string;
-}): Promise<GoogleMeetSpace> {
+} & GoogleMeetApiFetchDeps): Promise<GoogleMeetSpace> {
   const name = normalizeGoogleMeetSpaceName(params.meeting);
   const { response, release } = await fetchWithSsrFGuard({
     url: `${GOOGLE_MEET_API_BASE_URL}/${encodeSpaceNameForPath(name)}`,
@@ -346,6 +358,8 @@ export async function fetchGoogleMeetSpace(params: {
     },
     policy: { allowedHostnames: [GOOGLE_MEET_API_HOST] },
     auditContext: "google-meet.spaces.get",
+    fetchImpl: params.fetchImpl,
+    lookupFn: params.lookupFn,
   });
   try {
     if (!response.ok) {
@@ -368,7 +382,7 @@ export async function fetchGoogleMeetSpace(params: {
 export async function createGoogleMeetSpace(params: {
   accessToken: string;
   config?: GoogleMeetSpaceConfig;
-}): Promise<GoogleMeetCreateSpaceResult> {
+} & GoogleMeetApiFetchDeps): Promise<GoogleMeetCreateSpaceResult> {
   const body =
     params.config && Object.keys(params.config).length > 0
       ? JSON.stringify({ config: params.config })
@@ -386,6 +400,8 @@ export async function createGoogleMeetSpace(params: {
     },
     policy: { allowedHostnames: [GOOGLE_MEET_API_HOST] },
     auditContext: "google-meet.spaces.create",
+    fetchImpl: params.fetchImpl,
+    lookupFn: params.lookupFn,
   });
   try {
     if (!response.ok) {
@@ -415,10 +431,12 @@ export async function createGoogleMeetSpace(params: {
 export async function endGoogleMeetActiveConference(params: {
   accessToken: string;
   meeting: string;
-}): Promise<GoogleMeetEndActiveConferenceResult> {
+} & GoogleMeetApiFetchDeps): Promise<GoogleMeetEndActiveConferenceResult> {
   const resolved = await fetchGoogleMeetSpace({
     accessToken: params.accessToken,
     meeting: params.meeting,
+    fetchImpl: params.fetchImpl,
+    lookupFn: params.lookupFn,
   });
   const space = resolved.name;
   const { response, release } = await fetchWithSsrFGuard({
@@ -434,6 +452,8 @@ export async function endGoogleMeetActiveConference(params: {
     },
     policy: { allowedHostnames: [GOOGLE_MEET_API_HOST] },
     auditContext: "google-meet.spaces.endActiveConference",
+    fetchImpl: params.fetchImpl,
+    lookupFn: params.lookupFn,
   });
   try {
     if (!response.ok) {
@@ -452,13 +472,15 @@ export async function endGoogleMeetActiveConference(params: {
 async function fetchGoogleMeetConferenceRecord(params: {
   accessToken: string;
   conferenceRecord: string;
-}): Promise<GoogleMeetConferenceRecord> {
+} & GoogleMeetApiFetchDeps): Promise<GoogleMeetConferenceRecord> {
   const name = normalizeConferenceRecordName(params.conferenceRecord);
   const payload = await fetchGoogleMeetJson<GoogleMeetConferenceRecord>({
     accessToken: params.accessToken,
     path: encodeResourceNameForPath(name),
     auditContext: "google-meet.conferenceRecords.get",
     errorPrefix: "Google Meet conferenceRecords.get",
+    fetchImpl: params.fetchImpl,
+    lookupFn: params.lookupFn,
   });
   if (!payload.name?.trim()) {
     throw new Error("Google Meet conferenceRecords.get response was missing name");
@@ -471,7 +493,7 @@ async function listGoogleMeetConferenceRecords(params: {
   meeting?: string;
   pageSize?: number;
   maxItems?: number;
-}): Promise<GoogleMeetConferenceRecord[]> {
+} & GoogleMeetApiFetchDeps): Promise<GoogleMeetConferenceRecord[]> {
   const filter = params.meeting
     ? `space.name = "${normalizeGoogleMeetSpaceName(params.meeting)}"`
     : undefined;
@@ -486,22 +508,28 @@ async function listGoogleMeetConferenceRecords(params: {
     maxItems: params.maxItems,
     auditContext: "google-meet.conferenceRecords.list",
     errorPrefix: "Google Meet conferenceRecords.list",
+    fetchImpl: params.fetchImpl,
+    lookupFn: params.lookupFn,
   });
 }
 
 export async function fetchLatestGoogleMeetConferenceRecord(params: {
   accessToken: string;
   meeting: string;
-}): Promise<GoogleMeetLatestConferenceRecordResult> {
+} & GoogleMeetApiFetchDeps): Promise<GoogleMeetLatestConferenceRecordResult> {
   const space = await fetchGoogleMeetSpace({
     accessToken: params.accessToken,
     meeting: params.meeting,
+    fetchImpl: params.fetchImpl,
+    lookupFn: params.lookupFn,
   });
   const [conferenceRecord] = await listGoogleMeetConferenceRecords({
     accessToken: params.accessToken,
     meeting: space.name,
     pageSize: 1,
     maxItems: 1,
+    fetchImpl: params.fetchImpl,
+    lookupFn: params.lookupFn,
   });
   return {
     input: params.meeting,
@@ -514,7 +542,7 @@ async function listGoogleMeetParticipants(params: {
   accessToken: string;
   conferenceRecord: string;
   pageSize?: number;
-}): Promise<GoogleMeetParticipant[]> {
+} & GoogleMeetApiFetchDeps): Promise<GoogleMeetParticipant[]> {
   const parent = normalizeConferenceRecordName(params.conferenceRecord);
   return listGoogleMeetCollection<GoogleMeetParticipant>({
     accessToken: params.accessToken,
@@ -523,6 +551,8 @@ async function listGoogleMeetParticipants(params: {
     query: { pageSize: params.pageSize },
     auditContext: "google-meet.conferenceRecords.participants.list",
     errorPrefix: "Google Meet conferenceRecords.participants.list",
+    fetchImpl: params.fetchImpl,
+    lookupFn: params.lookupFn,
   });
 }
 
@@ -530,7 +560,7 @@ async function listGoogleMeetParticipantSessions(params: {
   accessToken: string;
   participant: string;
   pageSize?: number;
-}): Promise<GoogleMeetParticipantSession[]> {
+} & GoogleMeetApiFetchDeps): Promise<GoogleMeetParticipantSession[]> {
   return listGoogleMeetCollection<GoogleMeetParticipantSession>({
     accessToken: params.accessToken,
     path: `${encodeResourceNameForPath(params.participant)}/participantSessions`,
@@ -538,6 +568,8 @@ async function listGoogleMeetParticipantSessions(params: {
     query: { pageSize: params.pageSize },
     auditContext: "google-meet.conferenceRecords.participants.participantSessions.list",
     errorPrefix: "Google Meet conferenceRecords.participants.participantSessions.list",
+    fetchImpl: params.fetchImpl,
+    lookupFn: params.lookupFn,
   });
 }
 
@@ -545,7 +577,7 @@ async function listGoogleMeetRecordings(params: {
   accessToken: string;
   conferenceRecord: string;
   pageSize?: number;
-}): Promise<GoogleMeetRecording[]> {
+} & GoogleMeetApiFetchDeps): Promise<GoogleMeetRecording[]> {
   const parent = normalizeConferenceRecordName(params.conferenceRecord);
   return listGoogleMeetCollection<GoogleMeetRecording>({
     accessToken: params.accessToken,
@@ -554,6 +586,8 @@ async function listGoogleMeetRecordings(params: {
     query: { pageSize: params.pageSize },
     auditContext: "google-meet.conferenceRecords.recordings.list",
     errorPrefix: "Google Meet conferenceRecords.recordings.list",
+    fetchImpl: params.fetchImpl,
+    lookupFn: params.lookupFn,
   });
 }
 
@@ -561,7 +595,7 @@ async function listGoogleMeetTranscripts(params: {
   accessToken: string;
   conferenceRecord: string;
   pageSize?: number;
-}): Promise<GoogleMeetTranscript[]> {
+} & GoogleMeetApiFetchDeps): Promise<GoogleMeetTranscript[]> {
   const parent = normalizeConferenceRecordName(params.conferenceRecord);
   return listGoogleMeetCollection<GoogleMeetTranscript>({
     accessToken: params.accessToken,
@@ -570,6 +604,8 @@ async function listGoogleMeetTranscripts(params: {
     query: { pageSize: params.pageSize },
     auditContext: "google-meet.conferenceRecords.transcripts.list",
     errorPrefix: "Google Meet conferenceRecords.transcripts.list",
+    fetchImpl: params.fetchImpl,
+    lookupFn: params.lookupFn,
   });
 }
 
@@ -577,7 +613,7 @@ async function listGoogleMeetTranscriptEntries(params: {
   accessToken: string;
   transcript: string;
   pageSize?: number;
-}): Promise<GoogleMeetTranscriptEntry[]> {
+} & GoogleMeetApiFetchDeps): Promise<GoogleMeetTranscriptEntry[]> {
   return listGoogleMeetCollection<GoogleMeetTranscriptEntry>({
     accessToken: params.accessToken,
     path: `${encodeResourceNameForPath(params.transcript)}/entries`,
@@ -585,6 +621,8 @@ async function listGoogleMeetTranscriptEntries(params: {
     query: { pageSize: params.pageSize },
     auditContext: "google-meet.conferenceRecords.transcripts.entries.list",
     errorPrefix: "Google Meet conferenceRecords.transcripts.entries.list",
+    fetchImpl: params.fetchImpl,
+    lookupFn: params.lookupFn,
   });
 }
 
@@ -592,7 +630,7 @@ async function listGoogleMeetSmartNotes(params: {
   accessToken: string;
   conferenceRecord: string;
   pageSize?: number;
-}): Promise<GoogleMeetSmartNote[]> {
+} & GoogleMeetApiFetchDeps): Promise<GoogleMeetSmartNote[]> {
   const parent = normalizeConferenceRecordName(params.conferenceRecord);
   return listGoogleMeetCollection<GoogleMeetSmartNote>({
     accessToken: params.accessToken,
@@ -601,6 +639,8 @@ async function listGoogleMeetSmartNotes(params: {
     query: { pageSize: params.pageSize },
     auditContext: "google-meet.conferenceRecords.smartNotes.list",
     errorPrefix: "Google Meet conferenceRecords.smartNotes.list",
+    fetchImpl: params.fetchImpl,
+    lookupFn: params.lookupFn,
   });
 }
 
@@ -811,7 +851,7 @@ async function resolveConferenceRecordQuery(params: {
   conferenceRecord?: string;
   pageSize?: number;
   allConferenceRecords?: boolean;
-}): Promise<{
+} & GoogleMeetApiFetchDeps): Promise<{
   input?: string;
   space?: GoogleMeetSpace;
   conferenceRecords: GoogleMeetConferenceRecord[];
@@ -820,6 +860,8 @@ async function resolveConferenceRecordQuery(params: {
     const conferenceRecord = await fetchGoogleMeetConferenceRecord({
       accessToken: params.accessToken,
       conferenceRecord: params.conferenceRecord,
+      fetchImpl: params.fetchImpl,
+      lookupFn: params.lookupFn,
     });
     return {
       input: params.conferenceRecord.trim(),
@@ -832,12 +874,16 @@ async function resolveConferenceRecordQuery(params: {
   const space = await fetchGoogleMeetSpace({
     accessToken: params.accessToken,
     meeting: params.meeting,
+    fetchImpl: params.fetchImpl,
+    lookupFn: params.lookupFn,
   });
   const conferenceRecords = await listGoogleMeetConferenceRecords({
     accessToken: params.accessToken,
     meeting: space.name,
     pageSize: params.allConferenceRecords ? params.pageSize : 1,
     maxItems: params.allConferenceRecords ? undefined : 1,
+    fetchImpl: params.fetchImpl,
+    lookupFn: params.lookupFn,
   });
   return {
     input: params.meeting,
@@ -854,7 +900,7 @@ export async function fetchGoogleMeetArtifacts(params: {
   includeTranscriptEntries?: boolean;
   allConferenceRecords?: boolean;
   includeDocumentBodies?: boolean;
-}): Promise<GoogleMeetArtifactsResult> {
+} & GoogleMeetApiFetchDeps): Promise<GoogleMeetArtifactsResult> {
   const resolved = await resolveConferenceRecordQuery(params);
   const artifacts = await Promise.all(
     resolved.conferenceRecords.map(async (conferenceRecord) => {
@@ -863,21 +909,29 @@ export async function fetchGoogleMeetArtifacts(params: {
           accessToken: params.accessToken,
           conferenceRecord: conferenceRecord.name,
           pageSize: params.pageSize,
+          fetchImpl: params.fetchImpl,
+          lookupFn: params.lookupFn,
         }),
         listGoogleMeetRecordings({
           accessToken: params.accessToken,
           conferenceRecord: conferenceRecord.name,
           pageSize: params.pageSize,
+          fetchImpl: params.fetchImpl,
+          lookupFn: params.lookupFn,
         }),
         listGoogleMeetTranscripts({
           accessToken: params.accessToken,
           conferenceRecord: conferenceRecord.name,
           pageSize: params.pageSize,
+          fetchImpl: params.fetchImpl,
+          lookupFn: params.lookupFn,
         }),
         listGoogleMeetSmartNotes({
           accessToken: params.accessToken,
           conferenceRecord: conferenceRecord.name,
           pageSize: params.pageSize,
+          fetchImpl: params.fetchImpl,
+          lookupFn: params.lookupFn,
         })
           .then<GoogleMeetSmartNotesListResult>((smartNotes) => ({ smartNotes }))
           .catch((error: unknown) => ({
@@ -897,6 +951,8 @@ export async function fetchGoogleMeetArtifacts(params: {
                       accessToken: params.accessToken,
                       transcript: transcript.name,
                       pageSize: params.pageSize,
+                      fetchImpl: params.fetchImpl,
+                      lookupFn: params.lookupFn,
                     }),
                   };
                 } catch (error) {
@@ -960,7 +1016,7 @@ export async function fetchGoogleMeetAttendance(params: {
   mergeDuplicateParticipants?: boolean;
   lateAfterMinutes?: number;
   earlyBeforeMinutes?: number;
-}): Promise<GoogleMeetAttendanceResult> {
+} & GoogleMeetApiFetchDeps): Promise<GoogleMeetAttendanceResult> {
   const resolved = await resolveConferenceRecordQuery(params);
   const nestedRows = await Promise.all(
     resolved.conferenceRecords.map(async (conferenceRecord) => {
@@ -968,6 +1024,8 @@ export async function fetchGoogleMeetAttendance(params: {
         accessToken: params.accessToken,
         conferenceRecord: conferenceRecord.name,
         pageSize: params.pageSize,
+        fetchImpl: params.fetchImpl,
+        lookupFn: params.lookupFn,
       });
       const rows = await Promise.all(
         participants.map(async (participant) => ({
@@ -981,6 +1039,8 @@ export async function fetchGoogleMeetAttendance(params: {
             accessToken: params.accessToken,
             participant: participant.name,
             pageSize: params.pageSize,
+            fetchImpl: params.fetchImpl,
+            lookupFn: params.lookupFn,
           }),
         })),
       );

--- a/extensions/google-meet/src/meet.ts
+++ b/extensions/google-meet/src/meet.ts
@@ -1,5 +1,6 @@
 // Google Meet plugin module implements meet behavior.
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import { uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { exportGoogleDriveDocumentText, extractGoogleDriveDocumentId } from "./drive.js";
 import { googleApiError } from "./google-api-errors.js";
@@ -289,7 +290,7 @@ async function fetchGoogleMeetJson<T>(params: {
         scopes: [GOOGLE_MEET_MEDIA_SCOPE],
       });
     }
-    return (await response.json()) as T;
+    return await readProviderJsonResponse<T>(response, params.auditContext);
   } finally {
     await release();
   }
@@ -354,7 +355,7 @@ export async function fetchGoogleMeetSpace(params: {
         scopes: [GOOGLE_MEET_SPACE_SCOPE],
       });
     }
-    const payload = (await response.json()) as GoogleMeetSpace;
+    const payload = await readProviderJsonResponse<GoogleMeetSpace>(response, "google-meet.spaces.get");
     if (!payload.name?.trim()) {
       throw new Error("Google Meet spaces.get response was missing name");
     }
@@ -397,7 +398,7 @@ export async function createGoogleMeetSpace(params: {
             : [GOOGLE_MEET_SPACE_CREATED_SCOPE],
       });
     }
-    const payload = (await response.json()) as GoogleMeetSpace;
+    const payload = await readProviderJsonResponse<GoogleMeetSpace>(response, "google-meet.spaces.create");
     if (!payload.name?.trim()) {
       throw new Error("Google Meet spaces.create response was missing name");
     }


### PR DESCRIPTION
## Summary

- Bounds the Google Calendar/Meet successful JSON reads in `calendar.ts` and `meet.ts` with the shared 16 MiB `readProviderJsonResponse` cap.
- Covers Calendar `events.list`, Meet `spaces.get`, Meet `spaces.create`, and the shared paginated Meet API helper used by conference records, participants, recordings, transcripts, and smart notes.
- Adds an optional `fetchImpl`/`lookupFn` test seam threaded through the Calendar and Meet fetch call sites so tests can exercise the real, unmocked `fetchWithSsrFGuard` guard end-to-end; production callers (`index.ts`, `cli.ts`, `create.ts`) never pass these options, so default behavior is unchanged.
- Proof now runs through the real guard rather than a mocked one (see below).

## Linked context

No linked issue; this is a narrow bounded-response-read hardening follow-up for the Google Meet plugin.

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed:** Four Google Calendar/Meet success-path `response.json()` reads could buffer an unbounded response body. This PR routes them through the shared provider JSON reader, which fails closed at 16 MiB.
- **Real environment tested:** Linux x86-64, local OpenClaw repo environment, latest `upstream/main` base, production Google Meet/Calendar functions, production `readProviderJsonResponse`, and the real (not mocked) `fetchWithSsrFGuard` guard with only the final socket hop and DNS lookup redirected for the test.
- **Exact steps or command run after this patch:**
  ```bash
  node scripts/run-vitest.mjs extensions/google-meet/src/api-fetch-guard.test.ts extensions/google-meet/src/calendar.test.ts extensions/google-meet/src/meet.test.ts -- --run
  oxlint extensions/google-meet/src/calendar.ts extensions/google-meet/src/meet.ts \
    extensions/google-meet/src/api-fetch-guard.test.ts extensions/google-meet/src/calendar.test.ts \
    extensions/google-meet/src/meet.test.ts
  ```
- **Evidence after fix**: Live terminal output from real node:http server tests through the real SSRF guard (no fetch mock, no guard mock):
  ```text
  [google-meet fetch-guard proof] calendar events via real fetch guard: count=1
   ✓ Google Meet API bounded reads through the real fetch guard > lists Calendar events through fetchWithSsrFGuard and parses under-cap JSON
  [google-meet fetch-guard proof] Meet spaces oversized JSON canceled at 16908288/17825792 bytes
   ✓ Google Meet API bounded reads through the real fetch guard > rejects oversized Meet space JSON through fetchWithSsrFGuard before full buffering
  [bound-proof] canceled at 16908288/20971520 bytes
   ✓ google-meet bound reads with a real HTTP server through the SSRF guard > rejects oversized response before fully buffering 20 MiB (OOM guard)
   ✓ google-meet bound reads with a real HTTP server through the SSRF guard > parses well-formed JSON response under the 16 MiB cap
  Test Files  3 passed (3)
       Tests  11 passed (11)
  ```
  These tests inject only the final `fetchImpl` socket hop and a deterministic `lookupFn`; the request still passes through the real production hostname allowlist, DNS-pinning policy, and bounded reader before landing on the local server. This is a stronger proof than the prior revision, which shimmed `globalThis.fetch` around a mocked guard.
- **Observed result after fix:** Under-cap Calendar events still return a selected Meet URI through the real fetch-guard path. Oversized Meet `spaces.get` JSON is rejected (canceled at ~16.9 MiB of a 17.8 MiB body) before full buffering; a separate real-HTTP-server test confirms the same cancellation behavior at 20 MiB. Existing controlled-response tests also cover Calendar over-cap, Meet create-space over-cap, under-cap parsing, malformed/negative-control behavior, and release calls.
- **What was not tested:** Live Google Calendar/Meet API calls with real OAuth credentials. No Google Workspace credentials are available in this environment.
- **Proof limitations or environment constraints:** Tests inject a `fetchImpl` (redirects only the final socket to a local `node:http` server) and a hermetic `lookupFn` (avoids real DNS resolution) into the real, unmocked `fetchWithSsrFGuard` call — the guard's hostname allowlist and DNS-pinning policy execute for real against the actual Google API hostnames. No Google credentials or external network required; this proves the bound-read and SSRF-guard code paths, not Google-specific response content.
- **Before evidence:** Current main used bare `response.json()` in Calendar/Meet success paths. The previous PR revision replaced `fetchWithSsrFGuard` with a mock rather than exercising it for real; this update removes that mock and proves the real guard path instead.

## Tests and validation

- `node scripts/run-vitest.mjs extensions/google-meet/src/api-fetch-guard.test.ts extensions/google-meet/src/calendar.test.ts extensions/google-meet/src/meet.test.ts -- --run` — 3 files, 11 tests passed.
- `oxlint extensions/google-meet/src/calendar.ts extensions/google-meet/src/meet.ts extensions/google-meet/src/api-fetch-guard.test.ts extensions/google-meet/src/calendar.test.ts extensions/google-meet/src/meet.test.ts` — 0 problems.

## Risk checklist

- Did user-visible behavior change? **Only for oversized successful Google Calendar/Meet JSON responses**: they now fail closed at 16 MiB instead of buffering unbounded.
- Did config, environment, or migration behavior change? **No**
- Did security, auth, secrets, network, or tool execution behavior change? **No** — same endpoints, scopes, and headers are used; the new `fetchImpl`/`lookupFn` parameters are optional test-only seams with no effect when omitted (all production call sites omit them).
- What is the highest-risk area? Maintainer acceptance of a 16 MiB cap for Calendar/Meet API JSON responses.
- How is that risk mitigated? Google API responses here are paginated/control-plane payloads; the real-guard under-cap test verifies normal request shape and parsing, while over-cap tests verify cancellation.

## Current review state

- **Next action:** ClawSweeper re-review, then maintainer review if CI stays green.
- **Waiting on:** CI after push.
- **Bot/reviewer comments addressed:** Replaced the mocked `fetchWithSsrFGuard` test double with a real-guard proof (only the final socket hop and DNS lookup are test-injected), matching the proof style already accepted on sibling bound-read PRs in this repository; no production code changes beyond the original bounded-reader swap and the optional test-only `fetchImpl`/`lookupFn` seam.
