### PR TITLE
fix(msteams): bound Microsoft Graph API response reads in graph-upload to prevent OOM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Microsoft Teams Graph response bounds:** cap successful file-upload and chat JSON reads so oversized Microsoft Graph responses cannot be buffered without limit. (#97784) Thanks @Alix-007.
 - **Packaged speech runtime:** stop treating package-backed `speech-core` as a bundled plugin sidecar, restoring TTS startup in npm installs while release checks keep true activation-bypassing facades package-complete. (#89899, #89425) Thanks @zhangguiping-xydt.
 - **Codex app-server protocol:** require app-server 0.142 or newer, remove pre-0.142 wire-shape compatibility, and teach Codex to retrieve deferred native `spawn_agent` through `tool_search` so native subagent task mirroring works on search-capable models. (#101221)
 - **Android hardware keyboard chat:** send with unmodified Enter on physical keyboards while preserving Shift+Enter and other modified Enter combinations for multiline input. (#101239) Thanks @3ninyt3nin-creator.

--- a/extensions/msteams/src/graph-upload.test.ts
+++ b/extensions/msteams/src/graph-upload.test.ts
@@ -1,6 +1,5 @@
 // Msteams tests cover graph upload plugin behavior.
 import { createServer, type Server } from "node:http";
-import type { AddressInfo } from "node:net";
 import { withFetchPreconnect } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildTeamsFileInfoCard } from "./graph-chat.js";
@@ -265,7 +264,7 @@ async function listenLoopbackServer(server: Server): Promise<number> {
         reject(new Error("expected loopback TCP address"));
         return;
       }
-      resolve((address as AddressInfo).port);
+      resolve(address.port);
     });
   });
 }
@@ -410,6 +409,52 @@ describe("graph-upload readProviderJsonResponse loopback proof", () => {
       expect(String(error)).toContain("malformed JSON response");
       console.log(
         `[msteams graph-upload loopback proof] malformed JSON labelled: ${String(error)}`,
+      );
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it("uploadToOneDrive rejects an oversized success JSON body from a real loopback HTTP server", async () => {
+    const server = createServer((_req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      const chunk = Buffer.alloc(64 * 1024, 0x20);
+      let remaining = 257; // >16 MiB when combined with the JSON prefix.
+      res.write('{"id":"item-big","webUrl":"https://example.com/big","name":"big.txt","padding":"');
+      const writeNext = () => {
+        if (remaining <= 0) {
+          res.end('"}');
+          return;
+        }
+        remaining -= 1;
+        if (res.write(chunk)) {
+          setImmediate(writeNext);
+        } else {
+          res.once("drain", writeNext);
+        }
+      };
+      writeNext();
+    });
+    const port = await listenLoopbackServer(server);
+
+    try {
+      const realFetch = globalThis.fetch.bind(globalThis);
+      vi.stubGlobal(
+        "fetch",
+        withFetchPreconnect(async (input: RequestInfo | URL, init?: RequestInit) => {
+          const url = new URL(input instanceof Request ? input.url : String(input));
+          const loopback = new URL(`${url.pathname}${url.search}`, `http://127.0.0.1:${port}`);
+          return realFetch(loopback, init);
+        }),
+      );
+
+      await expect(
+        uploadToOneDrive({ buffer: Buffer.from("x"), filename: "big.txt", tokenProvider }),
+      ).rejects.toThrow(
+        "msteams.graph-upload.uploadOneDriveFile: JSON response exceeds 16777216 bytes",
+      );
+      console.log(
+        "[msteams graph-upload loopback proof] oversized JSON rejected by bounded reader",
       );
     } finally {
       await closeServer(server);

--- a/extensions/msteams/src/graph-upload.test.ts
+++ b/extensions/msteams/src/graph-upload.test.ts
@@ -1,6 +1,5 @@
 // Msteams tests cover graph upload plugin behavior.
-import { createServer, type Server } from "node:http";
-import { withFetchPreconnect } from "openclaw/plugin-sdk/test-env";
+import { withFetchPreconnect, withServer } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildTeamsFileInfoCard } from "./graph-chat.js";
 import { resolveGraphChatId, uploadToOneDrive, uploadToSharePoint } from "./graph-upload.js";
@@ -250,36 +249,7 @@ describe("resolveGraphChatId", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// Loopback server helpers
-// ---------------------------------------------------------------------------
-
-async function listenLoopbackServer(server: Server): Promise<number> {
-  return await new Promise((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(0, "127.0.0.1", () => {
-      server.off("error", reject);
-      const address = server.address();
-      if (!address || typeof address === "string") {
-        reject(new Error("expected loopback TCP address"));
-        return;
-      }
-      resolve(address.port);
-    });
-  });
-}
-
-async function closeServer(server: Server): Promise<void> {
-  await new Promise<void>((resolve) => {
-    server.close(() => resolve());
-  });
-}
-
-// ---------------------------------------------------------------------------
-// Loopback proof: readProviderJsonResponse replaces bare res.json() calls
-// ---------------------------------------------------------------------------
-
-describe("graph-upload readProviderJsonResponse loopback proof", () => {
+describe("graph upload response limits", () => {
   const tokenProvider = {
     getAccessToken: vi.fn(async () => "graph-token"),
   };
@@ -289,176 +259,47 @@ describe("graph-upload readProviderJsonResponse loopback proof", () => {
     vi.unstubAllGlobals();
   });
 
-  it("uploadToOneDrive parses normal JSON response from a real loopback HTTP server", async () => {
-    const payload = { id: "item-lp", webUrl: "https://example.com/lp", name: "lp.txt" };
-    let receivedMethod: string | undefined;
-    let receivedAuth: string | undefined;
-    let contentLength: string | null | undefined;
-    const server = createServer((req, res) => {
-      receivedMethod = req.method;
-      receivedAuth = req.headers.authorization;
-      const body = JSON.stringify(payload);
-      res.writeHead(200, { "content-type": "application/json" });
-      res.write(body.slice(0, 10));
-      res.end(body.slice(10));
-    });
-    const port = await listenLoopbackServer(server);
+  it("rejects an oversized upload response from a real loopback server", async () => {
+    await withServer(
+      (_req, res) => {
+        res.writeHead(200, { "content-type": "application/json" });
+        const chunk = Buffer.alloc(64 * 1024, 0x20);
+        let remaining = 257; // >16 MiB when combined with the JSON prefix.
+        res.write(
+          '{"id":"item-big","webUrl":"https://example.com/big","name":"big.txt","padding":"',
+        );
+        const writeNext = () => {
+          if (remaining <= 0) {
+            res.end('"}');
+            return;
+          }
+          remaining -= 1;
+          if (res.write(chunk)) {
+            setImmediate(writeNext);
+          } else {
+            res.once("drain", writeNext);
+          }
+        };
+        writeNext();
+      },
+      async (baseUrl) => {
+        const realFetch = globalThis.fetch.bind(globalThis);
+        vi.stubGlobal(
+          "fetch",
+          withFetchPreconnect(async (input: RequestInfo | URL, init?: RequestInit) => {
+            const url = new URL(input instanceof Request ? input.url : String(input));
+            const loopback = new URL(`${url.pathname}${url.search}`, baseUrl);
+            return realFetch(loopback, init);
+          }),
+        );
 
-    try {
-      const realFetch = globalThis.fetch.bind(globalThis);
-      vi.stubGlobal(
-        "fetch",
-        withFetchPreconnect(async (input: RequestInfo | URL, init?: RequestInit) => {
-          const url = new URL(input instanceof Request ? input.url : String(input));
-          const loopback = new URL(`${url.pathname}${url.search}`, `http://127.0.0.1:${port}`);
-          const response = await realFetch(loopback, init);
-          contentLength = response.headers.get("content-length");
-          return response;
-        }),
-      );
-
-      const result = await uploadToOneDrive({
-        buffer: Buffer.from("hello"),
-        filename: "lp.txt",
-        tokenProvider,
-      });
-
-      expect(result).toEqual(payload);
-      expect(receivedMethod).toBe("PUT");
-      expect(receivedAuth).toBe("Bearer graph-token");
-      expect(contentLength).toBeNull();
-      console.log(
-        `[msteams graph-upload loopback proof] uploadToOneDrive: returned=${JSON.stringify(result)} auth_ok=${receivedAuth === "Bearer graph-token"} content_length=${contentLength ?? "none"}`,
-      );
-    } finally {
-      await closeServer(server);
-    }
-  });
-
-  it("uploadToSharePoint parses normal JSON response from a real loopback HTTP server", async () => {
-    const payload = { id: "sp-lp", webUrl: "https://sp.example.com/lp", name: "sp-lp.txt" };
-    let receivedMethod: string | undefined;
-    let contentLength: string | null | undefined;
-    const server = createServer((req, res) => {
-      receivedMethod = req.method;
-      const body = JSON.stringify(payload);
-      res.writeHead(200, { "content-type": "application/json" });
-      res.write(body.slice(0, 15));
-      res.end(body.slice(15));
-    });
-    const port = await listenLoopbackServer(server);
-
-    try {
-      const realFetch = globalThis.fetch.bind(globalThis);
-      vi.stubGlobal(
-        "fetch",
-        withFetchPreconnect(async (input: RequestInfo | URL, init?: RequestInit) => {
-          const url = new URL(input instanceof Request ? input.url : String(input));
-          const loopback = new URL(`${url.pathname}${url.search}`, `http://127.0.0.1:${port}`);
-          const response = await realFetch(loopback, init);
-          contentLength = response.headers.get("content-length");
-          return response;
-        }),
-      );
-
-      const result = await uploadToSharePoint({
-        buffer: Buffer.from("world"),
-        filename: "sp-lp.txt",
-        siteId: "site-123",
-        tokenProvider,
-      });
-
-      expect(result).toEqual(payload);
-      expect(receivedMethod).toBe("PUT");
-      expect(contentLength).toBeNull();
-      console.log(
-        `[msteams graph-upload loopback proof] uploadToSharePoint: returned=${JSON.stringify(result)} content_length=${contentLength ?? "none"}`,
-      );
-    } finally {
-      await closeServer(server);
-    }
-  });
-
-  it("uploadToOneDrive surfaces a labelled error on malformed JSON from a real loopback HTTP server", async () => {
-    const server = createServer((_req, res) => {
-      res.writeHead(200, { "content-type": "application/json" });
-      res.end("{not-valid-json");
-    });
-    const port = await listenLoopbackServer(server);
-
-    try {
-      const realFetch = globalThis.fetch.bind(globalThis);
-      vi.stubGlobal(
-        "fetch",
-        withFetchPreconnect(async (input: RequestInfo | URL, init?: RequestInit) => {
-          const url = new URL(input instanceof Request ? input.url : String(input));
-          const loopback = new URL(`${url.pathname}${url.search}`, `http://127.0.0.1:${port}`);
-          return realFetch(loopback, init);
-        }),
-      );
-
-      let error: unknown;
-      try {
-        await uploadToOneDrive({ buffer: Buffer.from("x"), filename: "bad.txt", tokenProvider });
-      } catch (err) {
-        error = err;
-      }
-
-      expect(error).toBeInstanceOf(Error);
-      expect(String(error)).toContain("msteams.graph-upload.uploadOneDriveFile");
-      expect(String(error)).toContain("malformed JSON response");
-      console.log(
-        `[msteams graph-upload loopback proof] malformed JSON labelled: ${String(error)}`,
-      );
-    } finally {
-      await closeServer(server);
-    }
-  });
-
-  it("uploadToOneDrive rejects an oversized success JSON body from a real loopback HTTP server", async () => {
-    const server = createServer((_req, res) => {
-      res.writeHead(200, { "content-type": "application/json" });
-      const chunk = Buffer.alloc(64 * 1024, 0x20);
-      let remaining = 257; // >16 MiB when combined with the JSON prefix.
-      res.write('{"id":"item-big","webUrl":"https://example.com/big","name":"big.txt","padding":"');
-      const writeNext = () => {
-        if (remaining <= 0) {
-          res.end('"}');
-          return;
-        }
-        remaining -= 1;
-        if (res.write(chunk)) {
-          setImmediate(writeNext);
-        } else {
-          res.once("drain", writeNext);
-        }
-      };
-      writeNext();
-    });
-    const port = await listenLoopbackServer(server);
-
-    try {
-      const realFetch = globalThis.fetch.bind(globalThis);
-      vi.stubGlobal(
-        "fetch",
-        withFetchPreconnect(async (input: RequestInfo | URL, init?: RequestInit) => {
-          const url = new URL(input instanceof Request ? input.url : String(input));
-          const loopback = new URL(`${url.pathname}${url.search}`, `http://127.0.0.1:${port}`);
-          return realFetch(loopback, init);
-        }),
-      );
-
-      await expect(
-        uploadToOneDrive({ buffer: Buffer.from("x"), filename: "big.txt", tokenProvider }),
-      ).rejects.toThrow(
-        "msteams.graph-upload.uploadOneDriveFile: JSON response exceeds 16777216 bytes",
-      );
-      console.log(
-        "[msteams graph-upload loopback proof] oversized JSON rejected by bounded reader",
-      );
-    } finally {
-      await closeServer(server);
-    }
+        await expect(
+          uploadToOneDrive({ buffer: Buffer.from("x"), filename: "big.txt", tokenProvider }),
+        ).rejects.toThrow(
+          "msteams.graph-upload.uploadOneDriveFile: JSON response exceeds 16777216 bytes",
+        );
+      },
+    );
   });
 });
 

--- a/extensions/msteams/src/graph-upload.test.ts
+++ b/extensions/msteams/src/graph-upload.test.ts
@@ -1,6 +1,8 @@
 // Msteams tests cover graph upload plugin behavior.
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
 import { withFetchPreconnect } from "openclaw/plugin-sdk/test-env";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildTeamsFileInfoCard } from "./graph-chat.js";
 import { resolveGraphChatId, uploadToOneDrive, uploadToSharePoint } from "./graph-upload.js";
 
@@ -246,6 +248,172 @@ describe("resolveGraphChatId", () => {
     });
 
     expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Loopback server helpers
+// ---------------------------------------------------------------------------
+
+async function listenLoopbackServer(server: Server): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("expected loopback TCP address"));
+        return;
+      }
+      resolve((address as AddressInfo).port);
+    });
+  });
+}
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve) => {
+    server.close(() => resolve());
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Loopback proof: readProviderJsonResponse replaces bare res.json() calls
+// ---------------------------------------------------------------------------
+
+describe("graph-upload readProviderJsonResponse loopback proof", () => {
+  const tokenProvider = {
+    getAccessToken: vi.fn(async () => "graph-token"),
+  };
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("uploadToOneDrive parses normal JSON response from a real loopback HTTP server", async () => {
+    const payload = { id: "item-lp", webUrl: "https://example.com/lp", name: "lp.txt" };
+    let receivedMethod: string | undefined;
+    let receivedAuth: string | undefined;
+    let contentLength: string | null | undefined;
+    const server = createServer((req, res) => {
+      receivedMethod = req.method;
+      receivedAuth = req.headers.authorization;
+      const body = JSON.stringify(payload);
+      res.writeHead(200, { "content-type": "application/json" });
+      res.write(body.slice(0, 10));
+      res.end(body.slice(10));
+    });
+    const port = await listenLoopbackServer(server);
+
+    try {
+      const realFetch = globalThis.fetch.bind(globalThis);
+      vi.stubGlobal(
+        "fetch",
+        withFetchPreconnect(async (input: RequestInfo | URL, init?: RequestInit) => {
+          const url = new URL(input instanceof Request ? input.url : String(input));
+          const loopback = new URL(`${url.pathname}${url.search}`, `http://127.0.0.1:${port}`);
+          const response = await realFetch(loopback, init);
+          contentLength = response.headers.get("content-length");
+          return response;
+        }),
+      );
+
+      const result = await uploadToOneDrive({
+        buffer: Buffer.from("hello"),
+        filename: "lp.txt",
+        tokenProvider,
+      });
+
+      expect(result).toEqual(payload);
+      expect(receivedMethod).toBe("PUT");
+      expect(receivedAuth).toBe("Bearer graph-token");
+      expect(contentLength).toBeNull();
+      console.log(
+        `[msteams graph-upload loopback proof] uploadToOneDrive: returned=${JSON.stringify(result)} auth_ok=${receivedAuth === "Bearer graph-token"} content_length=${contentLength ?? "none"}`,
+      );
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it("uploadToSharePoint parses normal JSON response from a real loopback HTTP server", async () => {
+    const payload = { id: "sp-lp", webUrl: "https://sp.example.com/lp", name: "sp-lp.txt" };
+    let receivedMethod: string | undefined;
+    let contentLength: string | null | undefined;
+    const server = createServer((req, res) => {
+      receivedMethod = req.method;
+      const body = JSON.stringify(payload);
+      res.writeHead(200, { "content-type": "application/json" });
+      res.write(body.slice(0, 15));
+      res.end(body.slice(15));
+    });
+    const port = await listenLoopbackServer(server);
+
+    try {
+      const realFetch = globalThis.fetch.bind(globalThis);
+      vi.stubGlobal(
+        "fetch",
+        withFetchPreconnect(async (input: RequestInfo | URL, init?: RequestInit) => {
+          const url = new URL(input instanceof Request ? input.url : String(input));
+          const loopback = new URL(`${url.pathname}${url.search}`, `http://127.0.0.1:${port}`);
+          const response = await realFetch(loopback, init);
+          contentLength = response.headers.get("content-length");
+          return response;
+        }),
+      );
+
+      const result = await uploadToSharePoint({
+        buffer: Buffer.from("world"),
+        filename: "sp-lp.txt",
+        siteId: "site-123",
+        tokenProvider,
+      });
+
+      expect(result).toEqual(payload);
+      expect(receivedMethod).toBe("PUT");
+      expect(contentLength).toBeNull();
+      console.log(
+        `[msteams graph-upload loopback proof] uploadToSharePoint: returned=${JSON.stringify(result)} content_length=${contentLength ?? "none"}`,
+      );
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it("uploadToOneDrive surfaces a labelled error on malformed JSON from a real loopback HTTP server", async () => {
+    const server = createServer((_req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end("{not-valid-json");
+    });
+    const port = await listenLoopbackServer(server);
+
+    try {
+      const realFetch = globalThis.fetch.bind(globalThis);
+      vi.stubGlobal(
+        "fetch",
+        withFetchPreconnect(async (input: RequestInfo | URL, init?: RequestInit) => {
+          const url = new URL(input instanceof Request ? input.url : String(input));
+          const loopback = new URL(`${url.pathname}${url.search}`, `http://127.0.0.1:${port}`);
+          return realFetch(loopback, init);
+        }),
+      );
+
+      let error: unknown;
+      try {
+        await uploadToOneDrive({ buffer: Buffer.from("x"), filename: "bad.txt", tokenProvider });
+      } catch (err) {
+        error = err;
+      }
+
+      expect(error).toBeInstanceOf(Error);
+      expect(String(error)).toContain("msteams.graph-upload.uploadOneDriveFile");
+      expect(String(error)).toContain("malformed JSON response");
+      console.log(
+        `[msteams graph-upload loopback proof] malformed JSON labelled: ${String(error)}`,
+      );
+    } finally {
+      await closeServer(server);
+    }
   });
 });
 

--- a/extensions/msteams/src/graph-upload.ts
+++ b/extensions/msteams/src/graph-upload.ts
@@ -9,6 +9,7 @@
  * - Getting chat members for per-user sharing
  */
 
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import type { MSTeamsAccessTokenProvider } from "./attachments/types.js";
 import { createMSTeamsHttpError } from "./http-error.js";
 import { buildUserAgent } from "./user-agent.js";
@@ -54,11 +55,11 @@ export async function uploadToOneDrive(params: {
     throw await createMSTeamsHttpError(res, "OneDrive upload failed");
   }
 
-  const data = (await res.json()) as {
+  const data = await readProviderJsonResponse<{
     id?: string;
     webUrl?: string;
     name?: string;
-  };
+  }>(res, "msteams.graph-upload.uploadOneDriveFile");
 
   if (!data.id || !data.webUrl || !data.name) {
     throw new Error("OneDrive upload response missing required fields");
@@ -106,9 +107,9 @@ async function createSharingLink(params: {
     throw await createMSTeamsHttpError(res, "Create sharing link failed");
   }
 
-  const data = (await res.json()) as {
+  const data = await readProviderJsonResponse<{
     link?: { webUrl?: string };
-  };
+  }>(res, "msteams.graph-upload.createOneDriveSharingLink");
 
   if (!data.link?.webUrl) {
     throw new Error("Create sharing link response missing webUrl");
@@ -200,11 +201,11 @@ export async function uploadToSharePoint(params: {
     throw await createMSTeamsHttpError(res, "SharePoint upload failed");
   }
 
-  const data = (await res.json()) as {
+  const data = await readProviderJsonResponse<{
     id?: string;
     webUrl?: string;
     name?: string;
-  };
+  }>(res, "msteams.graph-upload.uploadSharePointFile");
 
   if (!data.id || !data.webUrl || !data.name) {
     throw new Error("SharePoint upload response missing required fields");
@@ -260,11 +261,11 @@ export async function getDriveItemProperties(params: {
     throw await createMSTeamsHttpError(res, "Get driveItem properties failed");
   }
 
-  const data = (await res.json()) as {
+  const data = await readProviderJsonResponse<{
     eTag?: string;
     webDavUrl?: string;
     name?: string;
-  };
+  }>(res, "msteams.graph-upload.getDriveItemProperties");
 
   if (!data.eTag || !data.webDavUrl || !data.name) {
     throw new Error("DriveItem response missing required properties (eTag, webDavUrl, or name)");
@@ -331,9 +332,9 @@ export async function resolveGraphChatId(params: {
     return null;
   }
 
-  const data = (await res.json()) as {
+  const data = await readProviderJsonResponse<{
     value?: Array<{ id?: string }>;
-  };
+  }>(res, "msteams.graph-upload.getOneOnOneChatId");
 
   const chats = data.value ?? [];
 
@@ -371,12 +372,12 @@ async function getChatMembers(params: {
     throw await createMSTeamsHttpError(res, "Get chat members failed");
   }
 
-  const data = (await res.json()) as {
+  const data = await readProviderJsonResponse<{
     value?: Array<{
       userId?: string;
       displayName?: string;
     }>;
-  };
+  }>(res, "msteams.graph-upload.getChatMembers");
 
   return (data.value ?? [])
     .map((m) => ({
@@ -435,9 +436,9 @@ async function createSharePointSharingLink(params: {
     throw await createMSTeamsHttpError(res, "Create SharePoint sharing link failed");
   }
 
-  const data = (await res.json()) as {
+  const data = await readProviderJsonResponse<{
     link?: { webUrl?: string };
-  };
+  }>(res, "msteams.graph-upload.createSharePointSharingLink");
 
   if (!data.link?.webUrl) {
     throw new Error("Create SharePoint sharing link response missing webUrl");


### PR DESCRIPTION
## Summary

- Replaces the 7 bare successful-response `res.json()` calls in `extensions/msteams/src/graph-upload.ts` with the shared bounded provider JSON reader.
- Covers OneDrive uploads, SharePoint uploads, sharing links, driveItem properties, chat list resolution, and chat member enumeration.
- Rebased onto latest `upstream/main`, where `readProviderJsonResponse` reads JSON through `readResponseWithLimit` with the shared 16 MiB cap.
- Adds real `node:http` loopback proof for normal chunked JSON, malformed JSON labelling, and oversized success JSON rejection.

## Linked context

No linked issue; this is a narrow follow-up to the bounded-response-read hardening series.

Related #97711 (same file family, but this PR includes loopback proof and complete PR context).

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed:** 7 unbounded successful Microsoft Graph API JSON reads in `graph-upload.ts` (`uploadToOneDrive`, `createSharingLink`, `uploadToSharePoint`, `getDriveItemProperties`, `resolveGraphChatId`, `getChatMembers`, `createSharePointSharingLink`).
- **Real environment tested:** Linux x86-64, Node 22/24 compatible repo environment, latest `upstream/main` after rebase on 2026-06-29.
- **Exact steps or command run after this patch:**
  ```bash
  PNPM_CONFIG_MODULES_DIR=/media/vdc/0668001470/workSpace/claw-campaign/openclaw/node_modules \
    node scripts/run-vitest.mjs extensions/msteams/src/graph-upload.test.ts -- --run
  PNPM_CONFIG_MODULES_DIR=/media/vdc/0668001470/workSpace/claw-campaign/openclaw/node_modules \
    /media/vdc/0668001470/workSpace/claw-campaign/openclaw/node_modules/.bin/oxlint \
    extensions/msteams/src/graph-upload.ts extensions/msteams/src/graph-upload.test.ts
  ```
- **Evidence after fix:**
  ```text
  [msteams graph-upload loopback proof] uploadToOneDrive: returned={"id":"item-lp","webUrl":"https://example.com/lp","name":"lp.txt"} auth_ok=true content_length=none
  [msteams graph-upload loopback proof] uploadToSharePoint: returned={"id":"sp-lp","webUrl":"https://sp.example.com/lp","name":"sp-lp.txt"} content_length=none
  [msteams graph-upload loopback proof] malformed JSON labelled: Error: msteams.graph-upload.uploadOneDriveFile: malformed JSON response
  [msteams graph-upload loopback proof] oversized JSON rejected by bounded reader
  Test Files  1 passed (1)
  Tests  15 passed (15)
  ```
- **Observed result after fix:** Chunked success JSON still parses, malformed JSON is labelled with the Graph upload call site, and an oversized successful JSON response now fails closed with `msteams.graph-upload.uploadOneDriveFile: JSON response exceeds 16777216 bytes` before buffering the whole body.
- **What was not tested:** Live Microsoft Graph API calls against a real Microsoft 365 tenant; no tenant credentials are available in this environment.
- **Proof limitations or environment constraints:** Loopback proof uses the real OS TCP stack and Node's real fetch/Response path, while redirecting the hardcoded Graph URL to localhost inside the test seam.
- **Before evidence:** The previous PR version had 14 tests and no direct oversized success-body assertion in this file. Current main had raw `res.json()` call sites in graph-upload before this branch.

## Tests and validation

- `node scripts/run-vitest.mjs extensions/msteams/src/graph-upload.test.ts -- --run` — 15 tests passed.
- `oxlint extensions/msteams/src/graph-upload.ts extensions/msteams/src/graph-upload.test.ts` — 0 problems.
- Addressed ClawSweeper review feedback by removing the redundant `AddressInfo` assertion that failed `check-lint` / `check-additional-extension-bundled`.

## Risk checklist

- Did user-visible behavior change? **Only for oversized successful Microsoft Graph JSON responses**: they now fail closed at the shared 16 MiB JSON cap instead of being read unbounded.
- Did config, environment, or migration behavior change? **No**
- Did security, auth, secrets, network, or tool execution behavior change? **No** — the same Graph endpoints and auth headers are used.
- What is the highest-risk area? `resolveGraphChatId` still returns `null` on Graph lookup failures; bounded JSON errors still flow through the existing outer failure path.
- How is that risk mitigated? Existing null-return tests still pass, and the new loopback tests cover the changed success-path reader behavior.

## Current review state

- **Next action:** ClawSweeper re-review, then maintainer review if CI stays green.
- **Waiting on:** CI after rebase/push.
- **Bot/reviewer comments addressed:** Removed redundant address assertion; added direct oversized success JSON proof; rebased onto latest main so the shared helper is the bounded implementation.
