### PR TITLE
fix(sessions): avoid cross-cwd recent resumes

### DIFF
--- a/src/agents/sessions/session-manager.test.ts
+++ b/src/agents/sessions/session-manager.test.ts
@@ -153,6 +153,36 @@ describe("SessionManager.open", () => {
     expect(SessionManager.continueRecent(longCwd, dir).getSessionFile()).toBe(sessionFile);
   });
 
+  it("does not continue a different cwd from a colliding session directory", async () => {
+    const dir = await makeTempDir();
+    const cwdA = "/home/alice/dev/client/app";
+    const cwdB = "/home/alice/dev/client-app";
+    const sessionA = path.join(dir, "session-a.jsonl");
+    const sessionB = path.join(dir, "session-b.jsonl");
+    const headerA = buildSessionHeader(cwdA, "session-a");
+    const headerB = buildSessionHeader(cwdB, "session-b");
+
+    await fs.writeFile(sessionA, `${JSON.stringify(headerA)}\n`, "utf8");
+    await fs.writeFile(sessionB, `${JSON.stringify(headerB)}\n`, "utf8");
+    await fs.utimes(
+      sessionA,
+      new Date("2026-06-18T00:00:00.000Z"),
+      new Date("2026-06-18T00:00:00.000Z"),
+    );
+    await fs.utimes(
+      sessionB,
+      new Date("2026-06-18T00:00:01.000Z"),
+      new Date("2026-06-18T00:00:01.000Z"),
+    );
+
+    expect(findMostRecentSession(dir)).toBe(sessionB);
+    expect(findMostRecentSession(dir, cwdA)).toBe(sessionA);
+    expect(SessionManager.continueRecent(cwdA, dir).getSessionFile()).toBe(sessionA);
+    await expect(SessionManager.list(cwdA, dir)).resolves.toEqual([
+      expect.objectContaining({ path: sessionA, cwd: cwdA }),
+    ]);
+  });
+
   it("skips oversized recent session headers instead of hiding valid sessions", async () => {
     const dir = await makeTempDir();
     const validSessionFile = path.join(dir, "valid-session.jsonl");

--- a/src/agents/sessions/session-manager.ts
+++ b/src/agents/sessions/session-manager.ts
@@ -1171,27 +1171,34 @@ function readFirstSessionFileLine(filePath: string): string | undefined {
   }
 }
 
-function isValidSessionFile(filePath: string): boolean {
+function readSessionHeaderFromFile(filePath: string): SessionHeader | undefined {
   try {
     const firstLine = readFirstSessionFileLine(filePath);
     if (!firstLine) {
-      return false;
+      return undefined;
     }
     const header = JSON.parse(firstLine);
-    return header.type === "session" && typeof header.id === "string";
+    if (header.type !== "session" || typeof header.id !== "string") {
+      return undefined;
+    }
+    return header as SessionHeader;
   } catch {
-    return false;
+    return undefined;
   }
 }
 
 /** Exported for testing */
-export function findMostRecentSession(sessionDir: string): string | null {
+export function findMostRecentSession(sessionDir: string, cwd?: string): string | null {
   try {
     const files = readdirSync(sessionDir)
       .filter((f) => f.endsWith(".jsonl"))
       .map((f) => join(sessionDir, f))
-      .filter(isValidSessionFile)
-      .map((path) => ({ path, mtime: statSync(path).mtime }))
+      .map((path) => ({ path, header: readSessionHeaderFromFile(path) }))
+      .filter(
+        (candidate): candidate is { path: string; header: SessionHeader } =>
+          candidate.header !== undefined && (cwd === undefined || candidate.header.cwd === cwd),
+      )
+      .map((candidate) => ({ path: candidate.path, mtime: statSync(candidate.path).mtime }))
       .toSorted((a, b) => b.mtime.getTime() - a.mtime.getTime());
 
     return files[0]?.path || null;
@@ -1348,6 +1355,10 @@ async function buildSessionInfo(filePath: string): Promise<SessionInfo | null> {
   }
 }
 
+function sessionInfoMatchesCwd(info: SessionInfo, cwd: string | undefined): boolean {
+  return cwd === undefined || info.cwd === cwd;
+}
+
 export type SessionListProgress = (loaded: number, total: number) => void;
 
 const MAX_CONCURRENT_SESSION_INFO_LOADS = 10;
@@ -1397,6 +1408,7 @@ async function listSessionsFromDir(
   onProgress?: SessionListProgress,
   progressOffset = 0,
   progressTotal?: number,
+  cwd?: string,
 ): Promise<SessionInfo[]> {
   const sessions: SessionInfo[] = [];
   if (!existsSync(dir)) {
@@ -1414,7 +1426,7 @@ async function listSessionsFromDir(
       onProgress?.(progressOffset + loaded, total);
     });
     for (const info of results) {
-      if (info) {
+      if (info && sessionInfoMatchesCwd(info, cwd)) {
         sessions.push(info);
       }
     }
@@ -2921,7 +2933,7 @@ export class SessionManager {
    */
   static continueRecent(cwd: string, sessionDir?: string): SessionManager {
     const dir = sessionDir ?? getDefaultSessionDir(cwd);
-    const mostRecent = findMostRecentSession(dir);
+    const mostRecent = findMostRecentSession(dir, cwd);
     if (mostRecent) {
       return new SessionManager(cwd, dir, mostRecent, true);
     }
@@ -2995,7 +3007,7 @@ export class SessionManager {
     onProgress?: SessionListProgress,
   ): Promise<SessionInfo[]> {
     const dir = sessionDir ?? getDefaultSessionDir(cwd);
-    const sessions = await listSessionsFromDir(dir, onProgress);
+    const sessions = await listSessionsFromDir(dir, onProgress, 0, undefined, cwd);
     sessions.sort((a, b) => b.modified.getTime() - a.modified.getTime());
     return sessions;
   }


### PR DESCRIPTION
Closes #96542

## What Problem This Solves

Fixes an issue where users resuming a recent session from one project could silently load another project's transcript when the two project paths encode to the same default session directory, such as `/home/alice/dev/client/app` and `/home/alice/dev/client-app`.

## Why This Change Was Made

The fix keeps the existing shipped session-directory encoding intact and makes recent-session selection cwd-aware instead. `continueRecent` now only resumes JSONL files whose persisted session header `cwd` matches the requested cwd, and the normal per-project session list uses the same header-cwd filter. `listAll` remains unchanged because it is intentionally cross-project.

This avoids orphaning existing session directories while preventing a colliding directory from adopting the newest transcript for a different project.

## User Impact

Continuing a session from a project now resumes only that project's transcript, or starts fresh when no matching session exists. Users no longer get another project's conversation history mixed into the current cwd when path separators and literal hyphens collide in the encoded session directory.

## Evidence

- Duplicate PR gate:
  - `gh search prs --repo openclaw/openclaw --state open --match title,body --limit 50 --json number,title,url,updatedAt,body -- "96542 OR \"project cwds differing\" OR \"getDefaultSessionDir\" OR \"client-app\""` -> `[]`
- Real on-disk resume-path proof for the CLI/gateway session-manager boundary:
  - Command: `node --import tsx --input-type=module` from this branch, using the production `getDefaultSessionDir`, `findMostRecentSession`, `SessionManager.continueRecent`, and `SessionManager.list` exports against two real JSONL session headers in one isolated temp agent dir.
  - Observed terminal output, redacted only for the temp root:

```text
OpenClaw cwd-collision resume proof
agent dir: <tmp>/agent
cwd A: /home/alice/dev/client/app
cwd B: /home/alice/dev/client-app
default dirs collide: true
session A file: <tmp>/agent/sessions/--home-alice-dev-client-app--/2026-06-18T00-00-00-000Z_session-a.jsonl
session B file: <tmp>/agent/sessions/--home-alice-dev-client-app--/2026-06-18T00-00-01-000Z_session-b.jsonl
unfiltered newest file: <tmp>/agent/sessions/--home-alice-dev-client-app--/2026-06-18T00-00-01-000Z_session-b.jsonl
cwd-filtered newest for cwd A: <tmp>/agent/sessions/--home-alice-dev-client-app--/2026-06-18T00-00-00-000Z_session-a.jsonl
continueRecent(cwd A) file: <tmp>/agent/sessions/--home-alice-dev-client-app--/2026-06-18T00-00-00-000Z_session-a.jsonl
continueRecent(cwd A) header cwd: /home/alice/dev/client/app
continueRecent(cwd A) crossed cwd: false
SessionManager.list(cwd A) files: <tmp>/agent/sessions/--home-alice-dev-client-app--/2026-06-18T00-00-00-000Z_session-a.jsonl
SessionManager.list(cwd A) cwds: /home/alice/dev/client/app
```

  - Claim proved: the two example cwds still collide under the shipped directory encoding, but the fixed real resume selector does not adopt the newer JSONL file from the other cwd; `continueRecent(cwd A)` resumes only the session whose header `cwd` is `cwd A`, and `SessionManager.list(cwd A)` filters out the other cwd.
- Focused regression test:
  - `node scripts/run-vitest.mjs src/agents/sessions/session-manager.test.ts`
  - Result: 1 file passed, 48 tests passed.
- Touched-file formatting/lint:
  - `node_modules\.bin\oxfmt.CMD --check src/agents/sessions/session-manager.ts src/agents/sessions/session-manager.test.ts` -> all matched files use the correct format.
  - `node_modules\.bin\oxlint.CMD src/agents/sessions/session-manager.ts src/agents/sessions/session-manager.test.ts` -> exit 0.
- Patch hygiene:
  - `git diff --check` -> clean.
  - `git diff --cached --check` -> clean before commit.
- Autoreview:
  - `python .agents\skills\autoreview\scripts\autoreview --mode local` -> `autoreview clean: no accepted/actionable findings reported`.

Not tested / proof gaps:

- I did not run a provider-backed LLM turn or full gateway RPC end to end. The live terminal proof above drives the production session-manager resume/list boundary that the CLI/gateway resume-most-recent path depends on, with real on-disk JSONL session files and the colliding default session directory.

AI-assisted: yes. No agent transcript is included because explicit transcript approval was not requested during this fast contributor workflow.