### PR TITLE
fix: report pending memory close errors

### DIFF
--- a/extensions/memory-core/src/memory/manager-async-state.ts
+++ b/extensions/memory-core/src/memory/manager-async-state.ts
@@ -19,15 +19,20 @@ export async function startAsyncSearchSync(params: {
 export async function awaitPendingManagerWork(params: {
   pendingSync?: Promise<void> | null;
   pendingProviderInit?: Promise<void> | null;
+  onError?: (err: unknown, kind: "sync" | "provider-init") => void;
 }): Promise<void> {
   if (params.pendingSync) {
     try {
       await params.pendingSync;
-    } catch {}
+    } catch (err: unknown) {
+      params.onError?.(err, "sync");
+    }
   }
   if (params.pendingProviderInit) {
     try {
       await params.pendingProviderInit;
-    } catch {}
+    } catch (err: unknown) {
+      params.onError?.(err, "provider-init");
+    }
   }
 }

--- a/extensions/memory-core/src/memory/manager.async-search.test.ts
+++ b/extensions/memory-core/src/memory/manager.async-search.test.ts
@@ -72,6 +72,30 @@ describe("memory search async sync", () => {
     await closePromise;
   });
 
+  it("reports rejected pending sync work during close wait", async () => {
+    const err = new Error("sync failed");
+    const onError = vi.fn();
+
+    await awaitPendingManagerWork({
+      pendingSync: Promise.reject(err),
+      onError,
+    });
+
+    expect(onError).toHaveBeenCalledWith(err, "sync");
+  });
+
+  it("reports rejected pending provider init work during close wait", async () => {
+    const err = new Error("provider failed");
+    const onError = vi.fn();
+
+    await awaitPendingManagerWork({
+      pendingProviderInit: Promise.reject(err),
+      onError,
+    });
+
+    expect(onError).toHaveBeenCalledWith(err, "provider-init");
+  });
+
   it("skips background search sync when search-triggered sync is disabled", async () => {
     const syncMock = vi.fn(async () => {});
     await startAsyncSearchSync({

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -1356,9 +1356,19 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       if (!pendingSync) {
         return;
       }
-      await awaitPendingManagerWork({ pendingSync });
+      await awaitPendingManagerWork({
+        pendingSync,
+        onError: (err) => {
+          log.warn(`memory sync failed (close): ${String(err)}`);
+        },
+      });
     };
-    await awaitPendingManagerWork({ pendingProviderInit });
+    await awaitPendingManagerWork({
+      pendingProviderInit,
+      onError: (err) => {
+        log.warn(`memory provider init failed (close): ${String(err)}`);
+      },
+    });
     rememberCurrentProvider();
     try {
       await awaitCurrentSync();


### PR DESCRIPTION
Closes #96766

## What Problem This Solves

Fixes an issue where memory close could silently swallow failures from pending sync or provider initialization work, leaving shutdown-time memory/index problems invisible.

## Why This Change Was Made

`awaitPendingManagerWork` now accepts an error-reporting callback while preserving the existing close behavior of waiting without throwing those pending-work failures. `MemoryIndexManager.close()` wires that callback into the existing memory logger with close-specific messages for pending sync and provider init failures.

## User Impact

Operators now get diagnostics when close-time memory sync or provider initialization work fails. Shutdown behavior remains compatible: close still drains pending work and continues provider/database teardown instead of turning these background failures into new thrown close errors.

## Evidence

- `node scripts/run-vitest.mjs extensions/memory-core/src/memory/manager.async-search.test.ts -- --reporter=dot` (5 tests passed)
- `node scripts/run-vitest.mjs extensions/memory-core/src/memory/index.test.ts -- --reporter=dot` (54 tests passed)
- `pnpm exec oxfmt --check extensions/memory-core/src/memory/manager-async-state.ts extensions/memory-core/src/memory/manager.ts extensions/memory-core/src/memory/manager.async-search.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --codex-bin .artifacts/codex-flex` (clean, confidence 0.86)

Known proof gap: I did not run a live shutdown scenario forcing a real SQLite lock, disk-full, or provider-init failure; the defect and fix are source-level and regression-test covered.
