### PR TITLE
fix(plugins): bound OpenAI-compatible embedding provider response reads to prevent OOM

### DIFF
--- a/src/plugins/openai-compatible-embedding-provider.test.ts
+++ b/src/plugins/openai-compatible-embedding-provider.test.ts
@@ -678,4 +678,85 @@ describe("openai-compatible generic embedding provider", () => {
       "openai-compatible embeddings failed: malformed JSON response",
     );
   });
+
+  describe("response size bound (readResponseWithLimit)", () => {
+    async function startOversizedServer(): Promise<{ baseUrl: string }> {
+      const SIXTEEN_MIB = 16 * 1024 * 1024;
+      const server = createServer((_req: IncomingMessage, res: ServerResponse) => {
+        // Stream >16 MiB of JSON-like data without Content-Length to exercise
+        // the streaming code path in readResponseWithLimit.
+        res.writeHead(200, {
+          "content-type": "application/json",
+          // Deliberately omit content-length so the reader must stream.
+        });
+        // Write a valid JSON prefix, then flood with filler to exceed the cap.
+        res.write('{"object":"list","data":[{"embedding":[');
+        const chunk = Buffer.alloc(64 * 1024, "1.0,".charCodeAt(0)); // 64 KiB
+        const iterations = Math.ceil((SIXTEEN_MIB + 64 * 1024) / chunk.length);
+        let written = 0;
+        const writeNext = () => {
+          while (written < iterations) {
+            const ok = res.write(chunk);
+            written++;
+            if (!ok) {
+              res.once("drain", writeNext);
+              return;
+            }
+          }
+          res.end("]}]}");
+        };
+        writeNext();
+      });
+
+      await new Promise<void>((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(0, "127.0.0.1", () => {
+          server.off("error", reject);
+          resolve();
+        });
+      });
+
+      servers.push({
+        close: () =>
+          new Promise<void>((resolve, reject) => {
+            server.close((error) => (error ? reject(error) : resolve()));
+          }),
+      });
+
+      const address = server.address() as AddressInfo;
+      return { baseUrl: `http://127.0.0.1:${address.port}/v1` };
+    }
+
+    it("rejects embedding responses larger than 16 MiB with a labelled error", async () => {
+      const server = await startOversizedServer();
+      const { provider } = await createOpenAICompatibleEmbeddingProvider(
+        createOptions({
+          model: "text-embedding-bge-m3",
+          remote: { baseUrl: server.baseUrl },
+        }),
+      );
+
+      await expect(provider.embed("hello")).rejects.toThrow(
+        "OpenAI-compatible embedding response too large",
+      );
+    });
+
+    it("accepts valid embedding responses that fit within the 16 MiB limit", async () => {
+      const validServer = await startEmbeddingServer({
+        respond: () => ({
+          object: "list",
+          data: [{ object: "embedding", embedding: [0.1, 0.2, 0.3], index: 0 }],
+          model: "text-embedding-bge-m3",
+        }),
+      });
+      const { provider } = await createOpenAICompatibleEmbeddingProvider(
+        createOptions({
+          model: "text-embedding-bge-m3",
+          remote: { baseUrl: validServer.baseUrl },
+        }),
+      );
+
+      await expect(provider.embed("hello")).resolves.toEqual([0.1, 0.2, 0.3]);
+    });
+  });
 });

--- a/src/plugins/openai-compatible-embedding-provider.ts
+++ b/src/plugins/openai-compatible-embedding-provider.ts
@@ -1,4 +1,5 @@
 // Builds OpenAI-compatible embedding provider entries for plugins.
+import { readResponseWithLimit } from "@openclaw/media-core/read-response-with-limit";
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { normalizeSecretInputString } from "../config/types.secrets.js";
 import { resolveConfiguredSecretInputString } from "../gateway/resolve-configured-secret-input-string.js";
@@ -14,6 +15,8 @@ import type {
 
 /** Provider id for OpenAI-compatible remote embedding servers. */
 export const OPENAI_COMPATIBLE_EMBEDDING_PROVIDER_ID = "openai-compatible";
+
+const EMBEDDING_RESPONSE_MAX_BYTES = 16 * 1024 * 1024; // 16 MiB
 const OPENAI_COMPATIBLE_MODEL_APIS = new Set(["openai-completions", "openai-responses"]);
 
 /** Normalized OpenAI-compatible embedding client configuration. */
@@ -282,8 +285,14 @@ function readEmbeddingVectors(
 }
 
 async function readJsonResponse(response: Response): Promise<unknown> {
+  const rawBody = await readResponseWithLimit(response, EMBEDDING_RESPONSE_MAX_BYTES, {
+    onOverflow: ({ size, maxBytes }) =>
+      new Error(
+        `OpenAI-compatible embedding response too large: ${size} bytes (limit: ${maxBytes})`,
+      ),
+  });
   try {
-    return await response.json();
+    return JSON.parse(new TextDecoder().decode(rawBody));
   } catch (cause) {
     throw new Error("openai-compatible embeddings failed: malformed JSON response", { cause });
   }


### PR DESCRIPTION
## What

Bound the bare `response.json()` read in `src/plugins/openai-compatible-embedding-provider.ts` using `readResponseWithLimit` (16 MiB fail-closed).

## Why

The OpenAI-compatible embedding provider reads batch embedding responses with an unbounded `await response.json()`. A batch of many documents can produce a large response (each embedding vector is 1536–3072 floats); more critically, a user-configured self-hosted endpoint is an untrusted boundary and could return an arbitrarily large body.

## How

Replace the bare read with `readResponseWithLimit` (16 MiB cap, fail-closed). Parse the bounded buffer with `JSON.parse(new TextDecoder().decode(body))`.

## Evidence

**Focused tests (real loopback HTTP server):**
- over-cap (>16 MiB body, no Content-Length): rejects with labelled error
- under-cap (valid JSON embedding response): parses and returns correctly
- mutation: reverting to bare `response.json()` turns the over-cap test red

All 24 existing embedding provider tests pass (26 total including the 2 new bound tests).

## Compatibility

Fail-closed at 16 MiB. A batch of 2048 documents with 3072-float embeddings is ~25 MB — for extreme batches consider increasing this limit, but the existing batch size cap makes this scenario unlikely in practice. Normal usage remains unaffected.

## Security & Privacy

Self-hosted OpenAI-compatible endpoints are user-configured untrusted sources. Bounding the read reduces OOM exposure from misconfigured or adversarial endpoints. No user data is logged or exposed.