### PR TITLE
fix: route targetless WebChat message sends

### DIFF
--- a/src/infra/outbound/internal-source-reply.ts
+++ b/src/infra/outbound/internal-source-reply.ts
@@ -83,9 +83,17 @@ export async function shouldUseInternalSourceReplySink(
   input: InternalSourceReplySinkInput,
   params: Record<string, unknown>,
 ): Promise<boolean> {
+  const sourceProvider = normalizeOptionalLowercaseString(
+    input.toolContext?.currentChannelProvider,
+  );
+  const sourceCanUseImplicitSink =
+    input.sourceReplyDeliveryMode === "message_tool_only" ||
+    (input.sourceReplyDeliveryMode === "automatic" &&
+      sourceProvider === INTERNAL_MESSAGE_CHANNEL &&
+      !hasExternalSessionDeliveryRoute(input.sessionKey));
   const hasImplicitCurrentSourceRoute =
     input.action === "send" &&
-    input.sourceReplyDeliveryMode === "message_tool_only" &&
+    sourceCanUseImplicitSink &&
     hasCurrentSourceReplyContext(input) &&
     Boolean(input.sessionKey?.trim()) &&
     !hasExplicitRouteParam(params);

--- a/src/infra/outbound/message-action-runner.send-validation.test.ts
+++ b/src/infra/outbound/message-action-runner.send-validation.test.ts
@@ -143,6 +143,52 @@ describe("runMessageAction send validation", () => {
     expect(JSON.stringify(result.toolResult?.content)).not.toContain("hello from codex");
   });
 
+  it("uses the current internal UI source as the automatic WebChat send sink", async () => {
+    const result = await runMessageAction({
+      cfg: emptyConfig,
+      action: "send",
+      params: {
+        message: "hello from webchat",
+      },
+      toolContext: {
+        currentChannelProvider: "webchat",
+      },
+      sessionKey: "agent:main",
+      sourceReplyDeliveryMode: "automatic",
+    });
+
+    expect(result).toMatchObject({
+      kind: "send",
+      channel: "webchat",
+      to: "current-run",
+      handledBy: "internal-source",
+      payload: {
+        status: "ok",
+        deliveryStatus: "sent",
+        sourceReplySink: "internal-ui",
+        sourceReply: {
+          text: "hello from webchat",
+        },
+      },
+    });
+  });
+
+  it("does not infer the automatic WebChat send sink when delivery mode is omitted", async () => {
+    await expect(
+      runMessageAction({
+        cfg: emptyConfig,
+        action: "send",
+        params: {
+          message: "hello from webchat",
+        },
+        toolContext: {
+          currentChannelProvider: "webchat",
+        },
+        sessionKey: "agent:main",
+      }),
+    ).rejects.toThrow(/requires a target/i);
+  });
+
   it.each(["agent:voice:agent:channel:room", "agent:main:telegram::group:room"])(
     "keeps malformed session route %s on the internal source sink",
     async (sessionKey) => {
@@ -237,18 +283,18 @@ describe("runMessageAction send validation", () => {
     expect(JSON.stringify(result.payload)).not.toContain("turn2view0");
   });
 
-  it("does not infer an internal UI sink outside message-tool-only source delivery", async () => {
+  it("does not infer a non-webchat source sink outside message-tool-only source delivery", async () => {
     await expect(
       runMessageAction({
         cfg: emptyConfig,
         action: "send",
         params: {
-          message: "hello from codex",
+          message: "telegram reply",
         },
         toolContext: {
-          currentChannelProvider: "webchat",
+          currentChannelProvider: "telegram",
         },
-        sessionKey: "agent:main",
+        sessionKey: "agent:main:telegram:direct:123456789",
         sourceReplyDeliveryMode: "automatic",
       }),
     ).rejects.toThrow(/requires a target/i);


### PR DESCRIPTION
Closes #96840

## What Problem This Solves

Fixes an issue where targetless `message(action="send")` calls from active WebChat runs could fail with "Action send requires a target" even though WebChat documents a current-run internal source-reply sink.

## Why This Change Was Made

The internal source-reply sink now accepts targetless sends from WebChat only when the run has explicit automatic source-reply delivery, the current source provider is WebChat, no external session route is encoded, and the call has no explicit target. The existing message-tool-only sink behavior remains unchanged, omitted delivery mode still rejects, and non-WebChat automatic source contexts still require a target.

## User Impact

WebChat-visible tools.message replies can be projected into the active WebChat conversation without asking the model for a reusable outbound target. Normal automatic final replies stay automatic, and external channels do not inherit WebChat as a fallback route.

## Evidence

- `node scripts/run-vitest.mjs src/infra/outbound/message-action-runner.send-validation.test.ts src/infra/outbound/message-action-runner.core-send.test.ts src/auto-reply/reply/source-reply-delivery-mode.test.ts -- --reporter=dot` — 3 files passed, 67 tests passed
- `pnpm exec oxfmt --check src/infra/outbound/internal-source-reply.ts src/infra/outbound/message-action-runner.send-validation.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --codex-bin .artifacts/codex-flex` — clean, patch correct (0.84)
