### PR TITLE
test(infra): add unit tests for numeric CLI and config option helpers

### DIFF
--- a/src/infra/numeric-options.test.ts
+++ b/src/infra/numeric-options.test.ts
@@ -16,7 +16,7 @@ describe("resolveNonNegativeIntegerOption", () => {
   });
 
   it("returns fallback when value is NaN", () => {
-    expect(resolveNonNegativeIntegerOption(NaN, 10)).toBe(10);
+    expect(resolveNonNegativeIntegerOption(Number.NaN, 10)).toBe(10);
   });
 
   it("returns fallback when value is Infinity", () => {
@@ -42,7 +42,7 @@ describe("resolveIntegerOption", () => {
   });
 
   it("returns fallback when value is NaN", () => {
-    expect(resolveIntegerOption(NaN, 10, { min: 1 })).toBe(10);
+    expect(resolveIntegerOption(Number.NaN, 10, { min: 1 })).toBe(10);
   });
 
   it("returns fallback when value is Infinity", () => {

--- a/src/infra/numeric-options.test.ts
+++ b/src/infra/numeric-options.test.ts
@@ -20,7 +20,7 @@ describe("resolveNonNegativeIntegerOption", () => {
   });
 
   it("returns fallback when value is Infinity", () => {
-    expect(resolveNonNegativeIntegerOption(Infinity, 10)).toBe(10);
+    expect(resolveNonNegativeIntegerOption(Number.POSITIVE_INFINITY, 10)).toBe(10);
   });
 
   it("floors decimal values", () => {
@@ -46,7 +46,7 @@ describe("resolveIntegerOption", () => {
   });
 
   it("returns fallback when value is Infinity", () => {
-    expect(resolveIntegerOption(Infinity, 10, { min: 1 })).toBe(10);
+    expect(resolveIntegerOption(Number.POSITIVE_INFINITY, 10, { min: 1 })).toBe(10);
   });
 
   it("floors decimal values", () => {

--- a/src/infra/numeric-options.test.ts
+++ b/src/infra/numeric-options.test.ts
@@ -1,0 +1,59 @@
+// Tests for numeric CLI and config option helpers.
+import { describe, expect, it } from "vitest";
+import { resolveNonNegativeIntegerOption, resolveIntegerOption } from "./numeric-options.js";
+
+describe("resolveNonNegativeIntegerOption", () => {
+  it("returns value when non-negative", () => {
+    expect(resolveNonNegativeIntegerOption(5, 10)).toBe(5);
+  });
+
+  it("clamps negative value to zero", () => {
+    expect(resolveNonNegativeIntegerOption(-1, 10)).toBe(0);
+  });
+
+  it("returns zero when value is zero", () => {
+    expect(resolveNonNegativeIntegerOption(0, 10)).toBe(0);
+  });
+
+  it("returns fallback when value is NaN", () => {
+    expect(resolveNonNegativeIntegerOption(NaN, 10)).toBe(10);
+  });
+
+  it("returns fallback when value is Infinity", () => {
+    expect(resolveNonNegativeIntegerOption(Infinity, 10)).toBe(10);
+  });
+
+  it("floors decimal values", () => {
+    expect(resolveNonNegativeIntegerOption(5.7, 10)).toBe(5);
+  });
+});
+
+describe("resolveIntegerOption", () => {
+  it("returns value when above minimum", () => {
+    expect(resolveIntegerOption(5, 10, { min: 1 })).toBe(5);
+  });
+
+  it("clamps value to minimum", () => {
+    expect(resolveIntegerOption(0, 10, { min: 1 })).toBe(1);
+  });
+
+  it("returns value when at minimum", () => {
+    expect(resolveIntegerOption(1, 10, { min: 1 })).toBe(1);
+  });
+
+  it("returns fallback when value is NaN", () => {
+    expect(resolveIntegerOption(NaN, 10, { min: 1 })).toBe(10);
+  });
+
+  it("returns fallback when value is Infinity", () => {
+    expect(resolveIntegerOption(Infinity, 10, { min: 1 })).toBe(10);
+  });
+
+  it("floors decimal values", () => {
+    expect(resolveIntegerOption(5.7, 10, { min: 1 })).toBe(5);
+  });
+
+  it("handles negative minimum", () => {
+    expect(resolveIntegerOption(-5, 10, { min: -10 })).toBe(-5);
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

The `numeric-options.ts` module provides numeric CLI and config option helpers with shared bounds. However, this module lacked unit tests to verify the numeric option parsing behavior, which could lead to regressions when the function is modified.

## Why This Change Was Made

Add unit tests for `resolveNonNegativeIntegerOption` and `resolveIntegerOption` functions to verify numeric option parsing behavior. This improves test coverage and prevents regressions.

Focused tests cover non-negative integer resolution, integer resolution with minimum bounds, fallback behavior, and edge cases like NaN and Infinity.

## User Impact

Numeric CLI and config option helpers now have comprehensive test coverage, reducing the risk of regressions when the function is modified.

## Evidence

Reproducibility: not applicable. This PR adds direct coverage for existing helper behavior rather than reporting a user-visible runtime bug. Source inspection confirms the helper behavior the tests target.

Direct behavior probe:

```text
$ node --import tsx -e "import('./src/infra/numeric-options.js').then(({ resolveNonNegativeIntegerOption, resolveIntegerOption }) => console.log(JSON.stringify([{ desc: 'resolveNonNegativeIntegerOption returns value when non-negative', value: 5, fallback: 10, result: resolveNonNegativeIntegerOption(5, 10), expected: 5 }, { desc: 'resolveNonNegativeIntegerOption clamps negative value to zero', value: -1, fallback: 10, result: resolveNonNegativeIntegerOption(-1, 10), expected: 0 }, { desc: 'resolveIntegerOption returns value when above minimum', value: 5, fallback: 10, min: 1, result: resolveIntegerOption(5, 10, { min: 1 }), expected: 5 }, { desc: 'resolveIntegerOption clamps value to minimum', value: 0, fallback: 10, min: 1, result: resolveIntegerOption(0, 10, { min: 1 }), expected: 1 }], null, 2)))"
[
  {
    "desc": "resolveNonNegativeIntegerOption returns value when non-negative",
    "value": 5,
    "fallback": 10,
    "result": 5,
    "expected": 5
  },
  {
    "desc": "resolveNonNegativeIntegerOption clamps negative value to zero",
    "value": -1,
    "fallback": 10,
    "result": 0,
    "expected": 0
  },
  {
    "desc": "resolveIntegerOption returns value when above minimum",
    "value": 5,
    "fallback": 10,
    "min": 1,
    "result": 5,
    "expected": 5
  },
  {
    "desc": "resolveIntegerOption clamps value to minimum",
    "value": 0,
    "fallback": 10,
    "min": 1,
    "result": 1,
    "expected": 1
  }
]
```

Targeted test:

```text
$ node scripts/run-vitest.mjs run src/infra/numeric-options.test.ts

 RUN  v4.1.8 /home/0668001110/ZTEProject/openclaw-worktrees/pr-94335

 Test Files  1 passed (1)
      Tests  13 passed (13)
   Start at  22:00:15
   Duration  465ms (transform 75ms, setup 0ms, import 117ms, tests 9ms)

[test] passed 1 Vitest shard in 11.00s
```

Formatting:

```text
$ npx oxfmt --check src/infra/numeric-options.ts src/infra/numeric-options.test.ts
Checking formatting...

All matched files use the correct format.
Finished in 86ms on 2 files using 8 threads.
```

Whitespace:

```text
$ git diff --check
```

## AI-assisted

Prepared with Codex. I reviewed the change, understand the touched code path, and kept the PR focused on the bug described above.
