### PR TITLE
fix(chutes): bound OAuth token error response reads

### DIFF
--- a/src/agents/chutes-oauth.flow.test.ts
+++ b/src/agents/chutes-oauth.flow.test.ts
@@ -27,6 +27,28 @@ function createStoredCredential(
   } as unknown as Parameters<typeof refreshChutesTokens>[0]["credential"];
 }
 
+function cancelTrackedResponse(
+  text: string,
+  init: ResponseInit,
+): {
+  response: Response;
+  wasCanceled: () => boolean;
+} {
+  let canceled = false;
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(text));
+    },
+    cancel() {
+      canceled = true;
+    },
+  });
+  return {
+    response: new Response(stream, init),
+    wasCanceled: () => canceled,
+  };
+}
+
 function expectRefreshedCredential(
   refreshed: Awaited<ReturnType<typeof refreshChutesTokens>>,
   now: number,
@@ -210,6 +232,62 @@ describe("chutes-oauth", () => {
     });
 
     expectRefreshedCredential(refreshed, now);
+  });
+
+  it("bounds token exchange error bodies without using response.text()", async () => {
+    const tracked = cancelTrackedResponse(`${"chutes exchange failure ".repeat(1024)}tail`, {
+      status: 401,
+      headers: { "content-type": "text/plain" },
+    });
+    const textSpy = vi.spyOn(tracked.response, "text").mockRejectedValue(new Error("unbounded"));
+    const fetchFn = withFetchPreconnect(async (input: RequestInfo | URL) => {
+      const url = urlToString(input);
+      if (url === CHUTES_TOKEN_ENDPOINT) {
+        return tracked.response;
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    await expect(
+      exchangeChutesCodeForTokens({
+        app: {
+          clientId: "cid_test",
+          redirectUri: "http://127.0.0.1:1456/oauth-callback",
+          scopes: ["openid"],
+        },
+        code: "code_401",
+        codeVerifier: "verifier_401",
+        fetchFn,
+        now: 1_000_000,
+      }),
+    ).rejects.toThrow("Chutes token exchange failed: chutes exchange failure");
+    expect(textSpy).not.toHaveBeenCalled();
+    expect(tracked.wasCanceled()).toBe(true);
+  });
+
+  it("bounds token refresh error bodies without using response.text()", async () => {
+    const tracked = cancelTrackedResponse(`${"chutes refresh failure ".repeat(1024)}tail`, {
+      status: 401,
+      headers: { "content-type": "text/plain" },
+    });
+    const textSpy = vi.spyOn(tracked.response, "text").mockRejectedValue(new Error("unbounded"));
+    const fetchFn = withFetchPreconnect(async (input: RequestInfo | URL) => {
+      const url = urlToString(input);
+      if (url === CHUTES_TOKEN_ENDPOINT) {
+        return tracked.response;
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    await expect(
+      refreshChutesTokens({
+        credential: createStoredCredential(5_000_000),
+        fetchFn,
+        now: 5_000_000,
+      }),
+    ).rejects.toThrow("Chutes token refresh failed: chutes refresh failure");
+    expect(textSpy).not.toHaveBeenCalled();
+    expect(tracked.wasCanceled()).toBe(true);
   });
 
   it("rejects unsafe refresh token lifetimes", async () => {

--- a/src/agents/chutes-oauth.ts
+++ b/src/agents/chutes-oauth.ts
@@ -6,7 +6,9 @@ import { createHash, randomBytes } from "node:crypto";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { resolveExpiresAtMsFromDurationSeconds } from "../infra/parse-finite-number.js";
 import type { OAuthCredentials } from "../llm/oauth.js";
-import { readProviderJsonResponse } from "./provider-http-errors.js";
+import { readProviderJsonResponse, readResponseTextLimited } from "./provider-http-errors.js";
+
+const CHUTES_OAUTH_ERROR_BODY_LIMIT_BYTES = 8 * 1024;
 
 const CHUTES_OAUTH_ISSUER = "https://api.chutes.ai";
 export const CHUTES_AUTHORIZE_ENDPOINT = `${CHUTES_OAUTH_ISSUER}/idp/authorize`;
@@ -152,7 +154,7 @@ export async function exchangeChutesCodeForTokens(params: {
     body,
   });
   if (!response.ok) {
-    const text = await response.text();
+    const text = await readResponseTextLimited(response, CHUTES_OAUTH_ERROR_BODY_LIMIT_BYTES);
     throw new Error(`Chutes token exchange failed: ${text}`);
   }
 
@@ -223,7 +225,7 @@ export async function refreshChutesTokens(params: {
     body,
   });
   if (!response.ok) {
-    const text = await response.text();
+    const text = await readResponseTextLimited(response, CHUTES_OAUTH_ERROR_BODY_LIMIT_BYTES);
     throw new Error(`Chutes token refresh failed: ${text}`);
   }
 


### PR DESCRIPTION
## What Problem This Solves

Chutes OAuth token **exchange** and **refresh** failures read the error body with an unbounded `await response.text()`. On a hostile or misconfigured token endpoint (`https://api.chutes.ai/idp/token`) that streams a large body with no `Content-Length`, the gateway buffers the **entire** payload into memory before surfacing the error — a memory-pressure / OOM vector during auth setup and token refresh.

Affected surface: `src/agents/chutes-oauth.ts` — `exchangeChutesCodeForTokens` and `refreshChutesTokens` error paths.

## Why This Change Was Made

Successful Chutes JSON token responses are already bounded via `readProviderJsonResponse`, but the two `!response.ok` branches still called `response.text()` directly. This change routes those reads through the existing shared bounded reader `readResponseTextLimited` with an 8 KiB cap (`CHUTES_OAUTH_ERROR_BODY_LIMIT_BYTES`), matching the MiniMax OAuth error-handling pattern. The reader stops pulling and cancels the upstream stream once the diagnostic budget is full, so the surfaced error snippet stays useful while the body can no longer grow without bound.

No new abstraction — reuses the existing `readResponseTextLimited` helper. One concern, two call sites; `chutes-oauth.ts` does not touch fs-safe or any other surface.

## User Impact

Operators configuring or refreshing Chutes OAuth credentials still get the same actionable error snippet on token failures, but the gateway can no longer be driven to buffer an arbitrarily large error body into memory by a hostile or broken token endpoint.

## Evidence

**1. Real-behavior proof with a negative control.** A harness drives the **real exported** `exchangeChutesCodeForTokens` / `refreshChutesTokens` against a real `node:http` server on `127.0.0.1` that streams a **25 MiB** error body in chunks with **no `Content-Length`**, and measures bytes actually flushed on the wire before the socket closes. The negative control runs the pre-fix `await response.text()` against the same server.

```
$ tsx chutes-proof.mts
CHUTES_TOKEN_ENDPOINT = https://api.chutes.ai/idp/token
Hostile error body = 25.00 MiB, streamed with NO Content-Length

[WITH FIX] exchangeChutesCodeForTokens
PASS: error surfaced — "Chutes token exchange failed: chutes error body chutes error..."
PASS: error snippet bounded — error message = 8222 bytes
PASS: upstream stopped early (cap load-bearing) — server flushed only 0.21 MiB before socket closed

[WITH FIX] refreshChutesTokens
PASS: error surfaced — "Chutes token refresh failed: chutes error body chutes error ..."
PASS: upstream stopped early (cap load-bearing) — server flushed only 0.21 MiB before socket closed

[NEGATIVE CONTROL] old `await response.text()` on same server
PASS: old path buffers entire body — response.text() returned 25.03 MiB (server sent 25.03 MiB)

ALL PROOF ASSERTIONS PASSED
```

Without the fix the error read returns the full **25.03 MiB** body; with the fix the surfaced snippet is capped at **8222 bytes** and the server flushes only **0.21 MiB** before the client cancels the stream and the socket closes — proving the cap is load-bearing, not incidental. The residual ~0.21 MiB is in-flight TCP/socket buffering, not buffered by the reader.

**2. Committed regression tests** (`src/agents/chutes-oauth.flow.test.ts`) cover both call sites: they stream an oversized error body through a tracked `ReadableStream`, spy on `response.text()` to assert it is never called, and assert the stream is canceled after the bounded read.

```
$ node scripts/run-vitest.mjs src/agents/chutes-oauth.flow.test.ts
 Test Files  1 passed (1)
      Tests  8 passed (8)
```

**3. Lint + types on the changed file:**

```
$ node scripts/run-oxlint.mjs src/agents/chutes-oauth.ts   # exit 0
$ pnpm tsgo                                                 # no chutes type errors
```

**What was NOT tested:** I did not hit the live Chutes endpoint and did not drive the process to an actual OOM. The cap is proven by bytes-on-wire + early socket close against a local server reproducing the unbounded-stream condition, plus the negative control showing the old path buffering the full body.

AI-assisted: implementation, tests, and the proof harness were drafted with agent assistance; all commands above were run locally.

Fixes the unbounded Chutes OAuth error-body read.
