### PR TITLE
fix(telegram): consume trailing silent notify marker

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -130,6 +130,7 @@ import {
 } from "./rich-message.js";
 import { editMessageTelegram } from "./send.js";
 import { getTelegramSequentialKey } from "./sequential-key.js";
+import { consumeTelegramSilentNotificationMarker } from "./silent-marker.js";
 import { cacheSticker, describeStickerImage } from "./sticker-cache.js";
 import {
   beginTelegramReplyFence,
@@ -1785,6 +1786,7 @@ export const dispatchTelegramMessage = async ({
         });
       },
       resolveFinalTextCandidate: () => resolveCurrentTurnTranscriptFinalText(),
+      prepareFinalText: ({ text }) => consumeTelegramSilentNotificationMarker(text),
       log: logVerbose,
       markDelivered: () => {
         deliveryState.markDelivered();

--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -40,6 +40,7 @@ import {
 import { resolveTelegramInteractiveTextFallback } from "../interactive-fallback.js";
 import { splitTelegramRichMessageTextChunks, TELEGRAM_RICH_TEXT_LIMIT } from "../rich-message.js";
 import { buildInlineKeyboard, reactMessageTelegram } from "../send.js";
+import { consumeTelegramSilentNotificationMarker } from "../silent-marker.js";
 import { resolveTelegramVoiceSend } from "../voice.js";
 import {
   buildTelegramSendParams,
@@ -819,7 +820,7 @@ export async function deliverReplies(params: {
     const hasMedia = mediaList.length > 0;
     const presentation = normalizeMessagePresentation(reply?.presentation);
     const interactive = reply?.interactive;
-    const resolvedReplyText =
+    const rawResolvedReplyText =
       resolveTelegramInteractiveTextFallback({
         text: reply?.text,
         interactive,
@@ -827,6 +828,12 @@ export async function deliverReplies(params: {
       }) ??
       reply?.text ??
       "";
+    const markerDelivery = consumeTelegramSilentNotificationMarker(
+      rawResolvedReplyText,
+      params.silent,
+    );
+    let resolvedReplyText = markerDelivery.text;
+    let replySilent = markerDelivery.silent;
     if (reply && resolvedReplyText !== (reply.text ?? "")) {
       reply = { ...reply, text: resolvedReplyText };
     }
@@ -842,6 +849,9 @@ export async function deliverReplies(params: {
     if (!resolvedReplyText && !hasMedia && !reactionEmoji) {
       if (reply?.audioAsVoice) {
         logVerbose("telegram reply has audioAsVoice without media/text; skipping");
+        continue;
+      }
+      if (rawResolvedReplyText !== resolvedReplyText) {
         continue;
       }
       params.runtime.error?.(danger("reply missing text/media"));
@@ -885,9 +895,15 @@ export async function deliverReplies(params: {
         continue;
       }
       if (typeof hookResult?.content === "string" && hookResult.content !== hookContent) {
+        const hookMarkerDelivery = consumeTelegramSilentNotificationMarker(
+          hookResult.content,
+          replySilent,
+        );
+        resolvedReplyText = spokenHookContent ? resolvedReplyText : hookMarkerDelivery.text;
+        replySilent = hookMarkerDelivery.silent;
         reply = spokenHookContent
-          ? { ...reply, spokenText: hookResult.content }
-          : { ...reply, text: hookResult.content };
+          ? { ...reply, spokenText: hookMarkerDelivery.text }
+          : { ...reply, text: hookMarkerDelivery.text };
       }
     }
 
@@ -936,7 +952,7 @@ export async function deliverReplies(params: {
           richMessages: params.richMessages,
           tableMode: params.tableMode,
           linkPreview: params.linkPreview,
-          silent: params.silent,
+          silent: replySilent,
           replyToId,
           replyToMode: params.replyToMode,
           progress,
@@ -957,7 +973,7 @@ export async function deliverReplies(params: {
           mediaLoader,
           onVoiceRecording: params.onVoiceRecording,
           linkPreview: params.linkPreview,
-          silent: params.silent,
+          silent: replySilent,
           replyQuoteMessageId: replyQuote.messageId,
           replyQuoteText: replyQuote.text,
           replyQuotePosition: replyQuote.position,

--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -572,6 +572,45 @@ describe("deliverReplies", () => {
     expectRecordFields(mockCallArg(sendMessage, 0, 2), { disable_notification: true });
   });
 
+  it("converts trailing notify=false markers to silent native replies", async () => {
+    const runtime = createRuntime();
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 5,
+      chat: { id: "123" },
+    });
+    const bot = createBot({ sendMessage });
+
+    await deliverWith({
+      replies: [{ text: "No interruption needed.\n\nnotify=false" }],
+      runtime,
+      bot,
+    });
+
+    expect(firstMockCallArg(sendMessage, 0)).toBe("123");
+    expect(firstSendText(sendMessage)).toBe("No interruption needed.");
+    expectRecordFields(mockCallArg(sendMessage, 0, 2), { disable_notification: true });
+  });
+
+  it("leaves inline notify=false text visible in native replies", async () => {
+    const runtime = createRuntime();
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 5,
+      chat: { id: "123" },
+    });
+    const bot = createBot({ sendMessage });
+
+    await deliverWith({
+      replies: [{ text: "The config line is notify=false when notifications are disabled." }],
+      runtime,
+      bot,
+    });
+
+    expect(firstSendText(sendMessage)).toBe(
+      "The config line is notify=false when notifications are disabled.",
+    );
+    expect(mockCallArg(sendMessage, 0, 2)).not.toHaveProperty("disable_notification");
+  });
+
   it("emits internal message:sent when session hook context is available", async () => {
     const runtime = createRuntime(false);
     const sendMessage = vi.fn().mockResolvedValue({ message_id: 9, chat: { id: "123" } });

--- a/extensions/telegram/src/lane-delivery-text-deliverer.ts
+++ b/extensions/telegram/src/lane-delivery-text-deliverer.ts
@@ -68,6 +68,10 @@ type CreateLaneTextDelivererParams = {
     finalText: string;
     laneName: LaneName;
   }) => Promise<string | undefined> | string | undefined;
+  prepareFinalText?: (params: { text: string; laneName: LaneName }) => {
+    text: string;
+    silent?: boolean;
+  };
   log: (message: string) => void;
   markDelivered: () => void;
 };
@@ -543,29 +547,44 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     durable: requestedDurable,
   }: DeliverLaneTextParams): Promise<LaneDeliveryResult> => {
     const lane = params.lanes[laneName];
-    const reply = resolveSendableOutboundReplyParts(payload, { text });
     const isDurableFinal = infoKind === "final";
+    const preparedFinal = isDurableFinal
+      ? (params.prepareFinalText?.({ text, laneName }) ?? { text })
+      : { text };
+    const finalText = preparedFinal.text;
+    const reply = resolveSendableOutboundReplyParts(payload, { text: finalText });
     const finalizePreview = requestedFinalizePreview ?? isDurableFinal;
     const durable = requestedDurable ?? isDurableFinal;
-    const streamed = !reply.hasMedia
-      ? await streamText(laneName, lane, text, payload, isDurableFinal, finalizePreview, buttons)
-      : undefined;
+    const shouldFinalizeViaStream = preparedFinal.silent !== true;
+    const streamed =
+      !reply.hasMedia && shouldFinalizeViaStream
+        ? await streamText(
+            laneName,
+            lane,
+            finalText,
+            payload,
+            isDurableFinal,
+            finalizePreview,
+            buttons,
+          )
+        : undefined;
     if (streamed) {
       return streamed;
     }
 
     if (
       finalizePreview &&
+      shouldFinalizeViaStream &&
       reply.hasMedia &&
       lane.stream &&
       lane.hasStreamedMessage &&
       !lane.finalized &&
-      text.trim().length > 0
+      finalText.trim().length > 0
     ) {
       const finalizedPreview = await streamText(
         laneName,
         lane,
-        text,
+        finalText,
         textOnlyPayload(payload),
         isDurableFinal,
         true,
@@ -576,7 +595,9 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
           finalizedPreview.kind === "preview-finalized" &&
           finalizedPreview.delivery.buttonsAttached === true;
         const mediaText =
-          finalizedPreview.kind === "preview-finalized" ? finalizedPreview.delivery.content : text;
+          finalizedPreview.kind === "preview-finalized"
+            ? finalizedPreview.delivery.content
+            : finalText;
         await params.sendPayload(
           mediaOnlyPayload(payload, mediaText, {
             stripButtons,
@@ -594,8 +615,9 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
       await clearUnfinalizedStream(lane);
     }
 
-    const delivered = await params.sendPayload(params.applyTextToPayload(payload, text), {
+    const delivered = await params.sendPayload(params.applyTextToPayload(payload, finalText), {
       durable,
+      ...(preparedFinal.silent !== undefined ? { silent: preparedFinal.silent } : {}),
     });
     if (delivered && finalizePreview) {
       lane.finalized = true;

--- a/extensions/telegram/src/lane-delivery.test.ts
+++ b/extensions/telegram/src/lane-delivery.test.ts
@@ -10,6 +10,13 @@ import {
 } from "./lane-delivery.js";
 
 const HELLO_FINAL = "Hello final";
+const TRAILING_MARKER = "\nnotify=false";
+
+function consumeTestSilentMarker(text: string): { text: string; silent?: boolean } {
+  return text.endsWith(TRAILING_MARKER)
+    ? { text: text.slice(0, -TRAILING_MARKER.length), silent: true }
+    : { text };
+}
 
 function createHarness(params?: {
   answerMessageId?: number;
@@ -20,6 +27,10 @@ function createHarness(params?: {
     finalText: string;
     laneName: LaneName;
   }) => string | undefined;
+  prepareFinalText?: (params: { text: string; laneName: LaneName }) => {
+    text: string;
+    silent?: boolean;
+  };
 }) {
   const answer =
     params?.answerStream === null
@@ -67,6 +78,7 @@ function createHarness(params?: {
     clearDraftLane,
     editStreamMessage,
     resolveFinalTextCandidate: params?.resolveFinalTextCandidate,
+    prepareFinalText: params?.prepareFinalText,
     log,
     markDelivered,
   });
@@ -177,6 +189,39 @@ describe("createLaneTextDeliverer", () => {
     expect(harness.sendPayload).toHaveBeenCalledWith({ text: "done" }, { durable: true });
     expect(harness.markDelivered).not.toHaveBeenCalled();
     expect(harness.lanes.answer.finalized).toBe(true);
+  });
+
+  it("sends trailing marker finals silently instead of finalizing the preview", async () => {
+    const harness = createHarness({
+      answerMessageId: 999,
+      prepareFinalText: ({ text }) => consumeTestSilentMarker(text),
+    });
+
+    const result = await deliverFinalAnswer(harness, "No interruption needed.\nnotify=false");
+
+    expect(result.kind).toBe("sent");
+    expect(harness.answer?.update).not.toHaveBeenCalled();
+    expect(harness.clearDraftLane).toHaveBeenCalledTimes(1);
+    expect(harness.sendPayload).toHaveBeenCalledWith(
+      { text: "No interruption needed." },
+      { durable: true, silent: true },
+    );
+    expect(harness.lanes.answer.finalized).toBe(true);
+  });
+
+  it("keeps inline marker text on preview-finalized finals", async () => {
+    const harness = createHarness({
+      answerMessageId: 999,
+      prepareFinalText: ({ text }) => consumeTestSilentMarker(text),
+    });
+
+    const text = "The config line is notify=false when notifications are disabled.";
+    const result = await deliverFinalAnswer(harness, text);
+
+    const delivery = expectPreviewFinalized(result);
+    expect(delivery.content).toBe(text);
+    expect(harness.answer?.update).toHaveBeenCalledWith(text);
+    expect(harness.sendPayload).not.toHaveBeenCalled();
   });
 
   it("keeps media fallback non-durable when materializing an intermediate preview", async () => {

--- a/extensions/telegram/src/outbound-adapter.test.ts
+++ b/extensions/telegram/src/outbound-adapter.test.ts
@@ -514,6 +514,116 @@ describe("telegramOutbound", () => {
     expect(result).toEqual({ channel: "telegram", messageId: "tg-silent", chatId: "12345" });
   });
 
+  it("converts trailing notify=false markers to silent durable payload sends", async () => {
+    sendMessageTelegramMock.mockResolvedValueOnce({ messageId: "tg-marker", chatId: "12345" });
+
+    await telegramOutbound.sendPayload!({
+      cfg: {} as never,
+      to: "12345",
+      text: "",
+      payload: { text: "No interruption needed.\n\nnotify=false" },
+      deps: { sendTelegram: sendMessageTelegramMock },
+    });
+
+    const options = callOptionsAt(sendMessageTelegramMock, 0, "12345", "No interruption needed.");
+    expect(options.silent).toBe(true);
+  });
+
+  it("applies trailing notify=false markers before durable text chunking", async () => {
+    const longText = `${"A".repeat(4000)}\nB\nnotify=false`;
+    sendMessageTelegramMock.mockResolvedValueOnce({ messageId: "tg-long", chatId: "12345" });
+
+    await telegramOutbound.sendPayload!({
+      cfg: {} as never,
+      to: "12345",
+      text: "",
+      payload: { text: longText },
+      deps: { sendTelegram: sendMessageTelegramMock },
+    });
+
+    const options = callOptionsAt(sendMessageTelegramMock, 0, "12345", `${"A".repeat(4000)}\nB`);
+    expect(options.silent).toBe(true);
+  });
+
+  it("treats marker-only durable payloads as no-op sends", async () => {
+    const result = await telegramOutbound.sendPayload!({
+      cfg: {} as never,
+      to: "12345",
+      text: "",
+      payload: { text: "notify=false" },
+      deps: { sendTelegram: sendMessageTelegramMock },
+    });
+
+    expect(sendMessageTelegramMock).not.toHaveBeenCalled();
+    expect(result).toEqual({ channel: "telegram", messageId: "" });
+  });
+
+  it("treats marker-only durable button payloads as no-op sends", async () => {
+    expect(
+      telegramOutbound.normalizePayload?.({
+        payload: {
+          text: "notify=false",
+          channelData: {
+            telegram: {
+              buttons: [[{ text: "Details", callback_data: "/details" }]],
+            },
+          },
+        },
+        cfg: {} as never,
+      }),
+    ).toBeNull();
+
+    const result = await telegramOutbound.sendPayload!({
+      cfg: {} as never,
+      to: "12345",
+      text: "",
+      payload: {
+        text: "notify=false",
+        channelData: {
+          telegram: {
+            buttons: [[{ text: "Details", callback_data: "/details" }]],
+          },
+        },
+      },
+      deps: { sendTelegram: sendMessageTelegramMock },
+    });
+
+    expect(sendMessageTelegramMock).not.toHaveBeenCalled();
+    expect(result).toEqual({ channel: "telegram", messageId: "" });
+  });
+
+  it("treats marker-only direct text as a no-op send", async () => {
+    const result = await telegramOutbound.sendText!({
+      cfg: {} as never,
+      to: "12345",
+      text: "notify=false",
+      deps: { sendTelegram: sendMessageTelegramMock },
+    });
+
+    expect(sendMessageTelegramMock).not.toHaveBeenCalled();
+    expect(result).toEqual({ channel: "telegram", messageId: "" });
+  });
+
+  it("leaves inline notify=false text visible in durable payload sends", async () => {
+    sendMessageTelegramMock.mockResolvedValueOnce({ messageId: "tg-inline", chatId: "12345" });
+
+    await telegramOutbound.sendPayload!({
+      cfg: {} as never,
+      to: "12345",
+      text: "",
+      payload: { text: "The config line is notify=false when notifications are disabled." },
+      deps: { sendTelegram: sendMessageTelegramMock },
+    });
+
+    const options = callOptionsAt(
+      sendMessageTelegramMock,
+      0,
+      "12345",
+      "The config line is notify=false when notifications are disabled.",
+    );
+    expect(options.silent).toBeUndefined();
+  });
+
   it("does not plain-text sanitize Telegram HTML before durable delivery", async () => {
     sendMessageTelegramMock.mockResolvedValueOnce({ messageId: "tg-html", chatId: "12345" });
 

--- a/extensions/telegram/src/outbound-adapter.ts
+++ b/extensions/telegram/src/outbound-adapter.ts
@@ -5,7 +5,10 @@ import {
   sanitizeForPlainText,
   type OutboundSendDeps,
 } from "openclaw/plugin-sdk/channel-outbound";
-import type { ChannelOutboundAdapter } from "openclaw/plugin-sdk/channel-send-result";
+import type {
+  ChannelOutboundAdapter,
+  OutboundDeliveryResult,
+} from "openclaw/plugin-sdk/channel-send-result";
 import {
   attachChannelToResult,
   createAttachedChannelResultAdapter,
@@ -14,7 +17,6 @@ import {
   normalizeMessagePresentation,
   renderMessagePresentationFallbackText,
 } from "openclaw/plugin-sdk/interactive-runtime";
-import type { OutboundDeliveryResult } from "openclaw/plugin-sdk/outbound-runtime";
 import { chunkMarkdownTextWithMode } from "openclaw/plugin-sdk/reply-chunking";
 import {
   resolvePayloadMediaUrls,

--- a/extensions/telegram/src/outbound-adapter.ts
+++ b/extensions/telegram/src/outbound-adapter.ts
@@ -28,6 +28,7 @@ import { splitTelegramHtmlChunks } from "./format.js";
 import { resolveTelegramInteractiveTextFallback } from "./interactive-fallback.js";
 import { parseTelegramReplyToMessageId, parseTelegramThreadId } from "./outbound-params.js";
 import { loadTelegramSendModule, type TelegramSendModule } from "./send-runtime.js";
+import { consumeTelegramSilentNotificationMarker } from "./silent-marker.js";
 import { normalizeTelegramOutboundTarget, parseTelegramTarget } from "./targets.js";
 
 export const TELEGRAM_TEXT_CHUNK_LIMIT = 4000;
@@ -133,6 +134,7 @@ export async function sendTelegramPayloadMessages(params: {
         buttons?: TelegramInlineButtons;
         quoteText?: string;
         reaction?: { emoji?: unknown; replyToId?: unknown; replyToCurrent?: unknown };
+        silent?: unknown;
       }
     | undefined;
   const quoteText =
@@ -140,12 +142,17 @@ export async function sendTelegramPayloadMessages(params: {
   const reactionEmoji =
     typeof telegramData?.reaction?.emoji === "string" ? telegramData.reaction.emoji : undefined;
   const presentation = normalizeMessagePresentation(params.payload.presentation);
-  const text =
+  const rawText =
     resolveTelegramInteractiveTextFallback({
       text: params.payload.text,
       interactive: params.payload.interactive,
       presentation,
     }) ?? "";
+  const normalizedDelivery = consumeTelegramSilentNotificationMarker(
+    rawText,
+    params.baseOpts.silent === true || telegramData?.silent === true ? true : undefined,
+  );
+  const text = normalizedDelivery.text;
   const mediaUrls = resolvePayloadMediaUrls(params.payload);
   const buttons = resolveTelegramInlineButtons({
     buttons: telegramData?.buttons,
@@ -155,6 +162,7 @@ export async function sendTelegramPayloadMessages(params: {
   const replyToMessageId = params.baseOpts.replyToMessageId;
   const payloadOpts = {
     ...params.baseOpts,
+    silent: normalizedDelivery.silent,
     quoteText,
     ...(params.payload.audioAsVoice === true ? { asVoice: true } : {}),
   };
@@ -187,6 +195,9 @@ export async function sendTelegramPayloadMessages(params: {
   }
   if (reactionEmoji && !text && mediaUrls.length === 0 && !buttons?.length) {
     return { messageId: String(replyToMessageId), chatId: params.to };
+  }
+  if (!text && mediaUrls.length === 0 && (!buttons?.length || normalizedDelivery.consumed)) {
+    return { messageId: "" };
   }
 
   // Telegram allows reply_markup on media; attach buttons only to the first send.
@@ -310,8 +321,16 @@ export function createTelegramOutboundAdapter(
           ...params,
           resolveSend,
         });
-        return await send(outboundTo, params.text, {
+        const normalizedDelivery = consumeTelegramSilentNotificationMarker(
+          params.text,
+          baseOpts.silent,
+        );
+        if (!normalizedDelivery.text) {
+          return { messageId: "" };
+        }
+        return await send(outboundTo, normalizedDelivery.text, {
           ...baseOpts,
+          silent: normalizedDelivery.silent,
         });
       },
       sendMedia: async (params) => {
@@ -319,8 +338,13 @@ export function createTelegramOutboundAdapter(
           ...params,
           resolveSend,
         });
-        return await send(outboundTo, params.text, {
+        const normalizedDelivery = consumeTelegramSilentNotificationMarker(
+          params.text,
+          baseOpts.silent,
+        );
+        return await send(outboundTo, normalizedDelivery.text, {
           ...baseOpts,
+          silent: normalizedDelivery.silent,
           mediaUrl: params.mediaUrl,
           mediaLocalRoots: params.mediaLocalRoots,
           mediaReadFile: params.mediaReadFile,
@@ -347,6 +371,41 @@ export function createTelegramOutboundAdapter(
         },
       });
       return attachChannelToResult("telegram", result);
+    },
+    normalizePayload: ({ payload }) => {
+      const text = payload.text ?? "";
+      const markerDelivery = consumeTelegramSilentNotificationMarker(text);
+      if (markerDelivery.text === text && markerDelivery.silent !== true) {
+        return payload;
+      }
+      const telegramData =
+        payload.channelData?.telegram &&
+        typeof payload.channelData.telegram === "object" &&
+        !Array.isArray(payload.channelData.telegram)
+          ? (payload.channelData.telegram as Record<string, unknown>)
+          : {};
+      if (
+        markerDelivery.consumed &&
+        !markerDelivery.text &&
+        !payload.mediaUrl?.trim() &&
+        !payload.mediaUrls?.some((url) => url.trim()) &&
+        !payload.presentation &&
+        !payload.interactive &&
+        !telegramData.reaction
+      ) {
+        return null;
+      }
+      return {
+        ...payload,
+        text: markerDelivery.text,
+        channelData: {
+          ...payload.channelData,
+          telegram: {
+            ...telegramData,
+            silent: true,
+          },
+        },
+      };
     },
     sendPoll: async ({
       cfg,

--- a/extensions/telegram/src/outbound-adapter.ts
+++ b/extensions/telegram/src/outbound-adapter.ts
@@ -14,6 +14,7 @@ import {
   normalizeMessagePresentation,
   renderMessagePresentationFallbackText,
 } from "openclaw/plugin-sdk/interactive-runtime";
+import type { OutboundDeliveryResult } from "openclaw/plugin-sdk/outbound-runtime";
 import { chunkMarkdownTextWithMode } from "openclaw/plugin-sdk/reply-chunking";
 import {
   resolvePayloadMediaUrls,
@@ -128,7 +129,7 @@ export async function sendTelegramPayloadMessages(params: {
   to: string;
   payload: ReplyPayload;
   baseOpts: Omit<NonNullable<TelegramSendOpts>, "buttons" | "mediaUrl" | "quoteText">;
-}): Promise<Awaited<ReturnType<TelegramSendFn>>> {
+}): Promise<Omit<OutboundDeliveryResult, "channel">> {
   const telegramData = params.payload.channelData?.telegram as
     | {
         buttons?: TelegramInlineButtons;

--- a/extensions/telegram/src/silent-marker.ts
+++ b/extensions/telegram/src/silent-marker.ts
@@ -1,0 +1,18 @@
+// Telegram plugin module implements legacy silent marker parsing.
+
+const TRAILING_NOTIFY_FALSE_RE = /(?:^|\r?\n)[ \t]*notify=false[ \t]*(?:\r?\n[ \t]*)*$/i;
+
+export function consumeTelegramSilentNotificationMarker(
+  text: string,
+  silent?: boolean,
+): { text: string; silent?: boolean; consumed: boolean } {
+  const match = TRAILING_NOTIFY_FALSE_RE.exec(text);
+  if (!match) {
+    return { text, silent, consumed: false };
+  }
+  return {
+    text: text.slice(0, match.index).trimEnd(),
+    silent: true,
+    consumed: true,
+  };
+}

--- a/src/agents/cli-runner.reliability.test.ts
+++ b/src/agents/cli-runner.reliability.test.ts
@@ -1546,6 +1546,7 @@ describe("runCliAgent reliability", () => {
             ...context.params,
             agentId: "main",
             sessionFile,
+            timeoutMs: 5_000,
             workspaceDir: dir,
             onBeforeFreshCliSessionRetry: clearBeforeRetry,
           },


### PR DESCRIPTION
Closes #80569

## What Problem This Solves

Fixes an issue where Telegram replies that ended with a standalone `notify=false` delivery marker would still notify users and leak that marker into the visible Telegram message body.

## Why This Change Was Made

Telegram now consumes only a trailing standalone `notify=false` marker at Telegram delivery boundaries, strips it from the sent text, and maps it to the existing silent-delivery option. The marker is normalized before durable text chunking so every Telegram send for that payload inherits `silent`, while inline explanatory text containing `notify=false` remains visible.

Marker-only payloads are suppressed as no-op deliveries instead of fabricating Telegram message identities or attempting empty Telegram sends. Native reply delivery and final streamed lane delivery both use the same marker semantics so hook-mutated replies, durable payloads, and final visible Telegram replies follow the same rule.

## User Impact

Telegram users no longer see `notify=false` as message text when it is used as a trailing delivery-control marker, and silent-intent replies are sent with Telegram silent notification metadata. Normal Telegram text that merely mentions `notify=false` is unchanged.

## Evidence

- Duplicate PR gate before implementation:
  - `gh search prs --repo openclaw/openclaw --state open --match title,body --limit 20 --json number,title,url,body -- "80569"` -> no open PRs.
  - `gh search prs --repo openclaw/openclaw --state open --match title,body --limit 20 --json number,title,url,body -- "notify=false"` -> no direct open fix for this issue.
- Earlier real Telegram Desktop proof found the final-lane gap:
  - Mantis run `28379800481` on old candidate SHA `639fa9ddf82efad87fbb74a4edd538db65fc3880` showed the PR still delivered `notify=false` in the chat.
  - PR comment: https://github.com/openclaw/openclaw/pull/97809#issuecomment-4834037661
  - This was addressed in follow-up commit `5f2733df09` by consuming the marker before final lane delivery chooses preview-finalization vs silent payload send.
- Focused Telegram delivery coverage:
  - `node scripts/run-vitest.mjs extensions/telegram/src/lane-delivery.test.ts extensions/telegram/src/outbound-adapter.test.ts extensions/telegram/src/bot/delivery.test.ts`
  - Result: 3 files passed, 142 tests passed.
- Final lane / stream-dispatch regression slice:
  - `node scripts/run-vitest.mjs extensions/telegram/src/bot-message-dispatch.test.ts -- -t "silent|notify=false|preview-finalized|mirrors preview-finalized"`
  - Result: 1 file passed, 6 tests passed, 130 skipped.
- Heartbeat response-tool regression slice:
  - `node scripts/run-vitest.mjs src/infra/heartbeat-runner.tool-response.test.ts -- -t "treats notify=false as a quiet heartbeat ack|delivers notificationText when notify=true"`
  - Result: 1 file passed, 2 tests passed, 14 skipped.
- Extension type gates after the no-op payload result typing fix:
  - `node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.local-pr.tsbuildinfo` -> passed.
  - `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.local-pr.tsbuildinfo` -> passed.
- Deprecated SDK subpath guard for the result-type import repair:
  - `node scripts/run-vitest.mjs src/plugins/contracts/plugin-sdk-package-contract-guardrails.test.ts -- -t "keeps deprecated public SDK subpaths unused by extension production code"` -> 1 test passed, 21 skipped.
- Formatting and whitespace:
  - `E:\code\openclaw\node_modules\.bin\oxfmt.CMD --check --threads=1 extensions/telegram/src/bot-message-dispatch.ts extensions/telegram/src/lane-delivery-text-deliverer.ts extensions/telegram/src/lane-delivery.test.ts extensions/telegram/src/silent-marker.ts extensions/telegram/src/outbound-adapter.ts extensions/telegram/src/outbound-adapter.test.ts extensions/telegram/src/bot/delivery.replies.ts extensions/telegram/src/bot/delivery.test.ts` -> all matched files use the correct format.
  - `git diff --check` -> clean.
- Autoreview:
  - `python .agents\skills\autoreview\scripts\autoreview --mode local`
  - Final result: `autoreview clean: no accepted/actionable findings reported`.

Not tested by me locally: a live Telegram bot/group/topic delivery with real credentials. Local proof tooling was blocked by a missing Convex env file at `~/.codex/skills/custom/telegram-e2e-bot-to-bot/convex.local.env`. A fresh Mantis Telegram Desktop run is requested after commit `5f2733df09` to provide the maintainer-owned live proof.