### PR TITLE
fix(nextcloud-talk): bound bot preflight error reads

### DIFF
--- a/extensions/nextcloud-talk/src/bot-preflight.test.ts
+++ b/extensions/nextcloud-talk/src/bot-preflight.test.ts
@@ -37,6 +37,28 @@ function account(
   };
 }
 
+function cancelTrackedResponse(
+  text: string,
+  init: ResponseInit,
+): {
+  response: Response;
+  wasCanceled: () => boolean;
+} {
+  let canceled = false;
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(text));
+    },
+    cancel() {
+      canceled = true;
+    },
+  });
+  return {
+    response: new Response(stream, init),
+    wasCanceled: () => canceled,
+  };
+}
+
 function mockBotAdmin(features: number | string): void {
   hoisted.fetchWithSsrFGuard.mockResolvedValueOnce({
     response: new Response(
@@ -150,6 +172,30 @@ describe("probeNextcloudTalkBotResponseFeature", () => {
       message:
         "Nextcloud Talk bot response feature probe failed: Nextcloud Talk bot response feature probe failed: malformed JSON response",
     });
+  });
+
+  it("bounds bot admin error bodies without using response.text()", async () => {
+    const tracked = cancelTrackedResponse(`${"nextcloud bot admin failure ".repeat(1024)}tail`, {
+      status: 503,
+      headers: { "content-type": "text/plain" },
+    });
+    const textSpy = vi.spyOn(tracked.response, "text").mockRejectedValue(new Error("unbounded"));
+    hoisted.fetchWithSsrFGuard.mockResolvedValueOnce({
+      response: tracked.response,
+      release: async () => {},
+      finalUrl: "https://cloud.example.com/ocs/v2.php/apps/spreed/api/v1/bot/admin",
+    });
+
+    await expect(probeNextcloudTalkBotResponseFeature({ account: account() })).resolves.toEqual({
+      ok: false,
+      code: "api_error",
+      status: 503,
+      message: expect.stringContaining(
+        "Nextcloud Talk bot response feature probe failed (503): nextcloud bot admin failure",
+      ),
+    });
+    expect(textSpy).not.toHaveBeenCalled();
+    expect(tracked.wasCanceled()).toBe(true);
   });
 
   it("skips when API credentials are absent", async () => {

--- a/extensions/nextcloud-talk/src/bot-preflight.ts
+++ b/extensions/nextcloud-talk/src/bot-preflight.ts
@@ -1,13 +1,17 @@
 // Nextcloud Talk plugin module implements bot preflight behavior.
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { parseStrictNonNegativeInteger } from "openclaw/plugin-sdk/number-runtime";
-import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
+import {
+  readProviderJsonResponse,
+  readResponseTextLimited,
+} from "openclaw/plugin-sdk/provider-http";
 import { fetchWithSsrFGuard } from "../runtime-api.js";
 import type { ResolvedNextcloudTalkAccount } from "./accounts.js";
 import { resolveNextcloudTalkApiCredentials } from "./api-credentials.js";
 import { ssrfPolicyFromPrivateNetworkOptIn } from "./send.runtime.js";
 
 const BOT_FEATURE_RESPONSE = 2;
+const BOT_PREFLIGHT_ERROR_BODY_LIMIT_BYTES = 8 * 1024;
 
 type NextcloudTalkBotAdminEntry = {
   id?: number | string;
@@ -125,7 +129,10 @@ export async function probeNextcloudTalkBotResponseFeature(params: {
     });
     try {
       if (!response.ok) {
-        const body = await response.text().catch(() => "");
+        const body = await readResponseTextLimited(
+          response,
+          BOT_PREFLIGHT_ERROR_BODY_LIMIT_BYTES,
+        ).catch(() => "");
         return {
           ok: false,
           code: "api_error",


### PR DESCRIPTION
## What Problem This Solves

`probeNextcloudTalkBotResponseFeature` reads the bot-admin error body with an unbounded `await response.text()` when the Nextcloud Talk bot-admin API returns a non-OK status during channel startup preflight. A Nextcloud endpoint that returns a large body with no `Content-Length` (broken reverse proxy, error page, or hostile/compromised host the operator pointed at) makes the gateway buffer the **entire** payload into memory before building the diagnostic — a memory-pressure vector on the startup-check path.

Affected surface: `extensions/nextcloud-talk/src/bot-preflight.ts` — the `!response.ok` branch of the bot-response feature probe.

## Why This Change Was Made

Successful JSON reads in the same probe are already bounded via `readProviderJsonResponse`, but the error branch still called `response.text()` directly. This routes that read through the existing shared bounded reader `readResponseTextLimited` (from `openclaw/plugin-sdk/provider-http`) with an 8 KiB cap (`BOT_PREFLIGHT_ERROR_BODY_LIMIT_BYTES`), matching the bound already used in `send.ts`. The reader stops pulling and cancels the upstream stream once the diagnostic budget is full, so the surfaced failure message stays useful while the body can no longer grow without bound. The existing `.catch(() => "")` is preserved, so diagnostics degrade exactly as before on read failure.

No new abstraction — reuses the existing plugin-SDK helper. Plugin-local change, one call site.

## User Impact

Operators still get the same bot-preflight failure diagnostic (status + bounded body snippet) when the Nextcloud API errors during startup, but a misbehaving or hostile Nextcloud endpoint can no longer drive the gateway to buffer an arbitrarily large error body into memory.

## Evidence

**1. Real-behavior proof with a negative control (real HTTP, not mock-only).** A harness drives the **real exported** `probeNextcloudTalkBotResponseFeature` through the **real `fetchWithSsrFGuard` SSRF-guarded path** (`allowPrivateNetwork: true` to permit localhost) against a real `node:http` server that streams a **25 MiB** `503` bot-admin error body in chunks with **no `Content-Length`**, and measures bytes actually flushed on the wire before the socket closes. The negative control runs the pre-fix `await response.text()` against the same server. All endpoints are `127.0.0.1`; no secrets or private hosts involved.

```
$ tsx nc-proof.mts
Hostile bot-admin error body = 25.00 MiB, 503, streamed with NO Content-Length

[WITH FIX] probeNextcloudTalkBotResponseFeature
PASS: returns api_error — code=api_error status=503
PASS: error snippet bounded — message = 8248 bytes
PASS: upstream stopped early (cap load-bearing) — server flushed only 0.22 MiB before socket closed

[NEGATIVE CONTROL] old `await response.text()` on same server
PASS: old path buffers entire body — response.text() returned 25.01 MiB (server sent 25.01 MiB)

ALL PROOF ASSERTIONS PASSED
```

Without the fix the error read returns the full **25.01 MiB** body; with the fix the surfaced diagnostic is capped (8 KiB body + the fixed `... probe failed (503): ` prefix = 8248 bytes) and the server flushes only **0.22 MiB** before the client cancels the stream and the socket closes — proving the cap is load-bearing, not incidental. The residual ~0.22 MiB is in-flight TCP/socket buffering, not buffered by the reader.

**2. Committed regression test** (`extensions/nextcloud-talk/src/bot-preflight.test.ts`) streams an oversized error body through a tracked `ReadableStream`, asserts `response.text()` is never called, and asserts the stream is canceled after the bounded read.

```
$ node scripts/run-vitest.mjs extensions/nextcloud-talk/src/bot-preflight.test.ts
 Test Files  1 passed (1)
      Tests  8 passed (8)
```

**3. Lint on the changed file:**

```
$ node scripts/run-oxlint.mjs extensions/nextcloud-talk/src/bot-preflight.ts   # exit 0
```

**What was NOT tested:** I did not point the probe at a live production Nextcloud instance and did not drive the gateway to an actual OOM. The cap is proven by bytes-on-wire + early socket close against a local server reproducing the unbounded-stream condition over the real SSRF-guarded fetch path, plus the negative control showing the old path buffering the full body.

AI-assisted: implementation, tests, and the proof harness were drafted with agent assistance; all commands above were run locally.
