### PR TITLE
fix(microsoft-foundry): bound connection test error reads

### DIFF
--- a/extensions/microsoft-foundry/onboard.connection.test.ts
+++ b/extensions/microsoft-foundry/onboard.connection.test.ts
@@ -1,0 +1,73 @@
+// Microsoft Foundry tests cover bounded connection-test error reads.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as cli from "./cli.js";
+import { testFoundryConnection } from "./onboard.js";
+import { DEFAULT_API } from "./shared.js";
+
+const hoisted = vi.hoisted(() => ({
+  fetchWithSsrFGuard: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
+  fetchWithSsrFGuard: hoisted.fetchWithSsrFGuard,
+}));
+
+function cancelTrackedResponse(
+  text: string,
+  init: ResponseInit,
+): {
+  response: Response;
+  wasCanceled: () => boolean;
+} {
+  let canceled = false;
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(text));
+    },
+    cancel() {
+      canceled = true;
+    },
+  });
+  return {
+    response: new Response(stream, init),
+    wasCanceled: () => canceled,
+  };
+}
+
+describe("testFoundryConnection", () => {
+  beforeEach(() => {
+    vi.spyOn(cli, "getAccessTokenResult").mockReturnValue({ accessToken: "token" });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    hoisted.fetchWithSsrFGuard.mockReset();
+  });
+
+  it("bounds connection-test error bodies without using response.text()", async () => {
+    const note = vi.fn();
+    const tracked = cancelTrackedResponse(`${"foundry failure ".repeat(1024)}tail`, {
+      status: 503,
+      headers: { "content-type": "text/plain" },
+    });
+    const textSpy = vi.spyOn(tracked.response, "text").mockRejectedValue(new Error("unbounded"));
+    hoisted.fetchWithSsrFGuard.mockResolvedValue({
+      response: tracked.response,
+      release: async () => {},
+    });
+
+    await testFoundryConnection({
+      ctx: { prompter: { note } } as never,
+      endpoint: "https://example.openai.azure.com",
+      modelId: "gpt-4o",
+      api: DEFAULT_API,
+    });
+
+    expect(textSpy).not.toHaveBeenCalled();
+    expect(tracked.wasCanceled()).toBe(true);
+    expect(note).toHaveBeenCalledWith(
+      expect.stringContaining("Warning: test request returned 503"),
+      "Connection Test",
+    );
+  });
+});

--- a/extensions/microsoft-foundry/onboard.ts
+++ b/extensions/microsoft-foundry/onboard.ts
@@ -1,6 +1,7 @@
 // Microsoft Foundry setup module handles plugin onboarding behavior.
 import type { ProviderAuthContext } from "openclaw/plugin-sdk/core";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import {
   normalizeOptionalString,
@@ -31,6 +32,8 @@ import {
   FOUNDRY_ANTHROPIC_SCOPE,
   usesFoundryResponsesByDefault,
 } from "./shared.js";
+
+const FOUNDRY_CONNECTION_TEST_ERROR_BODY_LIMIT_BYTES = 8 * 1024;
 
 export { listSubscriptions } from "./cli.js";
 
@@ -605,13 +608,19 @@ export async function testFoundryConnection(params: {
     });
     try {
       if (res.status === 400) {
-        const body = await res.text().catch(() => "");
+        const body = await readResponseTextLimited(
+          res,
+          FOUNDRY_CONNECTION_TEST_ERROR_BODY_LIMIT_BYTES,
+        ).catch(() => "");
         await params.ctx.prompter.note(
           `Endpoint is reachable but returned 400 Bad Request - check your deployment name and API version.\n${body.slice(0, 200)}`,
           "Connection Test",
         );
       } else if (!res.ok) {
-        const body = await res.text().catch(() => "");
+        const body = await readResponseTextLimited(
+          res,
+          FOUNDRY_CONNECTION_TEST_ERROR_BODY_LIMIT_BYTES,
+        ).catch(() => "");
         await params.ctx.prompter.note(
           `Warning: test request returned ${res.status}. ${body.slice(0, 200)}\nProceeding anyway - you can fix the endpoint later.`,
           "Connection Test",


### PR DESCRIPTION
## What Problem This Solves

`testFoundryConnection` reads the connection-test error body with an unbounded `await res.text()` on both failure branches (`400` and any other non-OK status) during Microsoft Foundry onboarding. The endpoint URL is operator-supplied; a host that returns a large body with no `Content-Length` (wrong endpoint, error page, broken proxy, or hostile host) makes onboarding buffer the **entire** payload into memory just to display a 200-char snippet — a memory-pressure vector on the setup path.

Affected surface: `extensions/microsoft-foundry/onboard.ts` — the `400` and `!res.ok` branches of `testFoundryConnection`.

## Why This Change Was Made

Both branches only ever display `body.slice(0, 200)` in the prompter note, but they read the whole body first. This routes both reads through the existing shared bounded reader `readResponseTextLimited` (from `openclaw/plugin-sdk/provider-http`) with an 8 KiB cap (`FOUNDRY_CONNECTION_TEST_ERROR_BODY_LIMIT_BYTES`) — far above the 200-char display need, so the note is unchanged while the read can no longer grow without bound. The reader cancels the upstream stream once the cap is hit. The existing `.catch(() => "")` is preserved, so the note degrades exactly as before on a read failure.

No new abstraction — reuses the existing plugin-SDK helper. Plugin-local change, two call sites with the identical pattern.

## User Impact

Operators running the Foundry connection test still see the same diagnostic note (status + first 200 chars of the error body), but a misbehaving or hostile endpoint can no longer drive onboarding to buffer an arbitrarily large error body into memory.

## Evidence

**1. Real-behavior proof with a negative control (real HTTP, outside Vitest mocks).** The exact swapped-in reader — `readResponseTextLimited`, imported from the same SDK barrel the fix uses (`openclaw/plugin-sdk/provider-http`) — is driven against a real `node:http` server that streams a **25 MiB** error body in chunks with **no `Content-Length`**, for **both** changed branches (`400` and non-OK `503`), measuring bytes actually flushed on the wire before the socket closes. The negative control runs the pre-fix `await res.text()` against the same server. All endpoints are `127.0.0.1`; no secrets.

```
$ tsx foundry-proof.mts
Hostile connection-test error body = 25.00 MiB, streamed with NO Content-Length

[WITH FIX] 400 Bad Request branch (status 400) -> readResponseTextLimited(res, 8 KiB)
PASS: bounded read <= 8 KiB — read 8192 bytes
PASS: note snippet intact (.slice(0,200) still works) — first 200 chars present: "foundry connection test "...
PASS: upstream stopped early (cap load-bearing) — server flushed only 0.22 MiB before socket closed

[WITH FIX] non-OK branch (status 503) -> readResponseTextLimited(res, 8 KiB)
PASS: bounded read <= 8 KiB — read 8192 bytes
PASS: note snippet intact (.slice(0,200) still works) — first 200 chars present: "foundry connection test "...
PASS: upstream stopped early (cap load-bearing) — server flushed only 0.22 MiB before socket closed

[NEGATIVE CONTROL] old `await res.text()` on same server
PASS: old path buffers entire body — res.text() returned 25.03 MiB (server sent 25.03 MiB)

ALL PROOF ASSERTIONS PASSED
```

Without the fix the read returns the full **25.03 MiB** body; with the fix each branch reads exactly **8192 bytes**, the 200-char note slice is still intact, and the server flushes only **0.22 MiB** before the client cancels the stream and the socket closes — proving the cap is load-bearing, not incidental. The residual ~0.22 MiB is in-flight TCP/socket buffering, not buffered by the reader.

**2. Committed regression test** (`extensions/microsoft-foundry/onboard.connection.test.ts`) drives the **real** `testFoundryConnection` through the non-OK branch with a streamed oversized error body, asserts `res.text()` is never called, asserts the stream is canceled, and asserts the prompter note still renders the bounded snippet.

```
$ node scripts/run-vitest.mjs extensions/microsoft-foundry/onboard.connection.test.ts
 Test Files  1 passed (1)
      Tests  1 passed (1)
```

**3. Lint on the changed file:**

```
$ node scripts/run-oxlint.mjs extensions/microsoft-foundry/onboard.ts   # exit 0
```

**What was NOT tested:** the full `testFoundryConnection` wrapper was not driven end-to-end against a live Azure endpoint, because it first acquires a token via the `az` CLI (`getAccessTokenResult` → `execAz`) and its `fetchWithSsrFGuard` call uses the default (private-network-denying) SSRF policy, so localhost cannot be substituted live. The committed Vitest test exercises that wrapper with the token/fetch boundary stubbed; the bounded read itself — the only line this PR changes — is proven live over a real socket above, including the negative control. I did not drive the process to an actual OOM.

AI-assisted: implementation, tests, and the proof harness were drafted with agent assistance; all commands above were run locally.
