### PR TITLE
fix(telegram): clear reasoning preview before forceNewMessage rotation (#80862)

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -4892,6 +4892,37 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(updates.join("\n")).not.toContain("CheckingReading");
   });
 
+  it("repositions split reasoning before deleting the prior preview", async () => {
+    const answerDraftStream = createDraftStream(2001);
+    const reasoningDraftStream = createSequencedDraftStream(3001);
+    createTelegramDraftStream
+      .mockImplementationOnce(() => answerDraftStream)
+      .mockImplementationOnce(() => reasoningDraftStream);
+    let replacementMessageId: number | undefined;
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+      await replyOptions?.onReasoningStream?.({ text: "<think>First thought</think>" });
+      await replyOptions?.onReasoningEnd?.();
+      await replyOptions?.onReasoningStream?.({ text: "<think>Second thought</think>" });
+      replacementMessageId = reasoningDraftStream.messageId();
+      return { queuedFinal: false };
+    });
+
+    await dispatchWithContext({ context: createReasoningStreamContext() });
+
+    expect(reasoningDraftStream.update).toHaveBeenNthCalledWith(1, "🧠 _First thought_");
+    expect(reasoningDraftStream.update).toHaveBeenNthCalledWith(2, "🧠 _Second thought_");
+    expect(reasoningDraftStream.rotateToNewMessageDeferringDelete).toHaveBeenCalledTimes(1);
+    expect(reasoningDraftStream.forceNewMessage).not.toHaveBeenCalled();
+    expect(reasoningDraftStream.clear).toHaveBeenCalledTimes(1);
+    expect(
+      reasoningDraftStream.rotateToNewMessageDeferringDelete.mock.invocationCallOrder[0],
+    ).toBeLessThan(reasoningDraftStream.update.mock.invocationCallOrder[1]);
+    expect(reasoningDraftStream.update.mock.invocationCallOrder[1]).toBeLessThan(
+      reasoningDraftStream.clear.mock.invocationCallOrder[0],
+    );
+    expect(replacementMessageId).toBe(3002);
+  });
+
   it("streams reasoning from configured defaults", async () => {
     const { answerDraftStream, reasoningDraftStream } = setupDraftStreams({
       answerMessageId: 2001,

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -1287,6 +1287,12 @@ export const dispatchTelegramMessage = async ({
       lastAnswerBlockButtons = undefined;
     }
   };
+  const repositionDraftLaneForNewMessage = (lane: DraftLaneState) => {
+    // Reposition instead of delete-then-repost: the replacement must land
+    // before deferred cleanup or Telegram can jump and retain a stale preview.
+    lane.stream?.rotateToNewMessageDeferringDelete();
+    resetDraftLaneState(lane);
+  };
   const rotateLaneForNewMessage = async (lane: DraftLaneState) => {
     if (!lane.hasStreamedMessage && typeof lane.stream?.messageId() !== "number") {
       resetDraftLaneState(lane);
@@ -1306,16 +1312,7 @@ export const dispatchTelegramMessage = async ({
     if (!activeAnswerDraftIsToolProgressOnly) {
       return false;
     }
-    // Reposition, don't delete-then-repost: rewind so the replacement message
-    // sends below, and defer the tool-progress window's delete until after it
-    // lands. Deleting first (clear) scroll-jumps the client when a durable 🧠
-    // was posted between the window and the replacement (the on-off jump).
-    if (answerLane.stream?.rotateToNewMessageDeferringDelete) {
-      answerLane.stream.rotateToNewMessageDeferringDelete();
-    } else {
-      answerLane.stream?.forceNewMessage();
-    }
-    resetDraftLaneState(answerLane);
+    repositionDraftLaneForNewMessage(answerLane);
     suppressProgressDraftState();
     rotateAnswerLaneWhenQueuedBlocksSettle = false;
     return true;
@@ -2693,8 +2690,7 @@ export const dispatchTelegramMessage = async ({
                     ? (payload) =>
                         enqueueDraftLaneEvent(async () => {
                           if (splitReasoningOnNextStream) {
-                            reasoningLane.stream?.forceNewMessage();
-                            resetDraftLaneState(reasoningLane);
+                            repositionDraftLaneForNewMessage(reasoningLane);
                             splitReasoningOnNextStream = false;
                           }
                           await ingestDraftLaneSegments(payload, true);


### PR DESCRIPTION
## What Problem This Solves

Fixes #80862.

With `/reasoning stream`, a second reasoning burst rotated the Telegram draft with `forceNewMessage()`. That discarded the prior preview's message id before terminal cleanup, so the superseded preview could remain visible indefinitely.

## Why This Change Was Made

The current patch routes split reasoning through Telegram's existing `rotateToNewMessageDeferringDelete()` lifecycle. The stream captures the old bot message id, advances to a new generation, lets the replacement preview land, and deletes the superseded preview on its detached cleanup schedule. A shared dispatcher helper now applies the same reposition-and-reset invariant to reasoning splits and answer/tool-progress rotation.

This is preferable to clear-before-rotate: deleting first can make Telegram Desktop jump before the replacement appears, and dispatcher-owned deletion would duplicate the draft stream's in-flight-send and reply-target logic.

## User Impact

Split reasoning previews no longer lose ownership of the prior Telegram message. Users should see the replacement preview and cleanup behavior instead of stale reasoning bubbles accumulating. Final answer delivery and durable messages are unchanged.

## Evidence

- Exact-head CI passed at `e60a700a27d445efc9c89e71517eff53c3cf379a`: https://github.com/openclaw/openclaw/actions/runs/29132593350
- Fresh structured autoreview: clean; patch correct; confidence 0.88.
- Dispatcher regression exercises reasoning -> end -> reasoning and verifies reposition -> replacement update -> final cleanup ordering.
- Existing draft-stream coverage proves replacement send before superseded deletion, no-message behavior, in-flight first-send cleanup, reply-target ownership, and delete failure handling.
- Real-user Mantis run: https://github.com/openclaw/openclaw/actions/runs/29133165694. Baseline and candidate burner-user product turns completed and their leases were released. The comparison gate failed because the transient Desktop crops were inconclusive, not because the candidate turn failed. The maintainer explicitly accepts this remaining visual-proof gap.
