### PR TITLE
feat(chunking): enhance paragraph and table merging logic for QQ Bot

### DIFF
--- a/extensions/qqbot/src/engine/messaging/markdown-table-chunking.test.ts
+++ b/extensions/qqbot/src/engine/messaging/markdown-table-chunking.test.ts
@@ -260,11 +260,99 @@ describe("chunkQQBotMarkdownText", () => {
       "后置说明第二段。",
     ].join("\n");
 
+    // Front prose merges with the table (both fit under 3600 bytes), and the
+    // trailing prose becomes its own chunk because no table/fence follows it.
     expect(chunkQQBotMarkdownText(text, 180, baseChunker)).toEqual([
-      "前置说明第一段，长度足够触发普通文本先发送。\n前置说明第二段继续解释。",
-      ["| Id | Value |", "|---:|---|", "| 1 | alpha |", "| 2 | beta |"].join("\n"),
-      "后置说明第一段，表格结束后继续普通文字。\n后置说明第二段。",
+      [
+        "前置说明第一段，长度足够触发普通文本先发送。",
+        "前置说明第二段继续解释。",
+        "| Id | Value |",
+        "|---:|---|",
+        "| 1 | alpha |",
+        "| 2 | beta |",
+      ].join("\n"),
+      ["后置说明第一段，表格结束后继续普通文字。", "后置说明第二段。"].join("\n"),
     ]);
+  });
+
+  it("merges a short paragraph with a short table when total bytes fit the QQ limit", () => {
+    const paragraph = "Short intro paragraph that wraps the table below.";
+    const tableText = ["| Id | Value |", "|---:|---|", "| 1 | alpha |", "| 2 | beta |"].join("\n");
+    const text = `${paragraph}\n${tableText}`;
+
+    const chunks = chunkQQBotMarkdownText(text, 5000, baseChunker);
+
+    expect(chunks).toEqual([text]);
+  });
+
+  it("merges a short paragraph with a short fenced block when total bytes fit the QQ limit", () => {
+    const paragraph = "Brief intro before the code block.";
+    const fenceText = ["```ts", "const a = 1;", "const b = 2;", "```"].join("\n");
+    const text = `${paragraph}\n${fenceText}`;
+
+    const chunks = chunkQQBotMarkdownText(text, 5000, baseChunker);
+
+    expect(chunks).toEqual([text]);
+  });
+
+  it("does not merge a paragraph with a table that would push the chunk past 3600 bytes", () => {
+    // A 3000-byte paragraph plus a table whose combined UTF-8 byte length
+    // would exceed the 3600-byte safety limit. The paragraph must therefore
+    // be emitted as its own chunk, separate from the table.
+    const paragraph = "x".repeat(3000);
+    const tableText = ["| Id | Value |", "|---:|---|", `| 1 | ${"y".repeat(1500)} |`].join("\n");
+
+    const chunks = chunkQQBotMarkdownText(`${paragraph}\n${tableText}`, 5000, baseChunker);
+
+    expect(chunks).toContain(paragraph);
+    expect(chunks).toContain(tableText);
+    expect(chunks.find((c) => c.includes(paragraph) && c.includes("| Id |"))).toBeUndefined();
+  });
+
+  it("does not merge a paragraph with a fenced block that would push the chunk past 3600 bytes", () => {
+    const paragraph = "x".repeat(3000);
+    const fenceLine = "y".repeat(1500);
+    const fenceText = ["```ts", fenceLine, "```"].join("\n");
+
+    const chunks = chunkQQBotMarkdownText(`${paragraph}\n${fenceText}`, 5000, baseChunker);
+
+    expect(chunks).toContain(paragraph);
+    expect(chunks).toContain(fenceText);
+    expect(chunks.find((c) => c.includes(paragraph) && c.includes("```ts"))).toBeUndefined();
+  });
+
+  it("emits only prose unchanged when no table or fence is present", () => {
+    const text = "First paragraph line.\nSecond paragraph line.";
+    expect(chunkQQBotMarkdownText(text, 5000, baseChunker)).toEqual([text]);
+  });
+
+  it("emits only a table unchanged when no surrounding prose exists", () => {
+    const text = ["| Id | Value |", "|---:|---|", "| 1 | alpha |", "| 2 | beta |"].join("\n");
+    expect(chunkQQBotMarkdownText(text, 5000, baseChunker)).toEqual([text]);
+  });
+
+  it("emits only a fenced block unchanged when no surrounding prose exists", () => {
+    const text = ["```ts", "const a = 1;", "```"].join("\n");
+    expect(chunkQQBotMarkdownText(text, 5000, baseChunker)).toEqual([text]);
+  });
+
+  it("emits a paragraph with no trailing table or fence inside chunkText itself", () => {
+    // A paragraph that does not border a table or fence must not wait for a
+    // future structural block; it is emitted as its own chunk before chunkText
+    // returns, so flushPendingText has nothing left to flush.
+    const chunker = createQQBotMarkdownChunker((text) => [text]);
+    const chunks = chunker.chunkText("Paragraph that ends without any table or fence.", 5000);
+    expect(chunks).toEqual(["Paragraph that ends without any table or fence."]);
+    expect(chunker.flushPendingText(5000)).toEqual([]);
+  });
+
+  it("falls back to the base chunker when a single oversized paragraph exceeds 3600 bytes", () => {
+    const text = "x".repeat(4000);
+    const chunks = chunkQQBotMarkdownText(text, 5000, baseChunker);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(Buffer.byteLength(chunk, "utf8")).toBeLessThanOrEqual(3600);
+    }
   });
 });
 

--- a/extensions/qqbot/src/engine/messaging/markdown-table-chunking.test.ts
+++ b/extensions/qqbot/src/engine/messaging/markdown-table-chunking.test.ts
@@ -336,6 +336,48 @@ describe("chunkQQBotMarkdownText", () => {
     expect(chunkQQBotMarkdownText(text, 5000, baseChunker)).toEqual([text]);
   });
 
+  it("preserves an empty fenced block", () => {
+    const text = ["Intro", "```ts", "```"].join("\n");
+    expect(chunkQQBotMarkdownText(text, 5000, baseChunker)).toEqual([text]);
+  });
+
+  it("keeps pending prose available for a table completed by a later stream block", () => {
+    const chunker = createQQBotMarkdownChunker((text) => [text]);
+
+    expect(chunker.chunkText(["Intro", "| A | B |"].join("\n"), 5000)).toEqual([]);
+    expect(chunker.chunkText(["|---|---|", "| 1 | 2 |"].join("\n"), 5000)).toEqual([
+      ["Intro", "| A | B |", "|---|---|", "| 1 | 2 |"].join("\n"),
+    ]);
+  });
+
+  it("keeps prose before a rejected streamed table header", () => {
+    const chunker = createQQBotMarkdownChunker((text) => [text]);
+
+    expect(chunker.chunkText(["Intro", "| maybe | header |"].join("\n"), 5000)).toEqual([]);
+    expect(chunker.chunkText("plain continuation", 5000)).toEqual([
+      ["Intro", "| maybe | header |", "plain continuation"].join("\n"),
+    ]);
+  });
+
+  it("keeps pending prose available for a fenced block completed by a later stream block", () => {
+    const chunker = createQQBotMarkdownChunker((text) => [text]);
+
+    expect(chunker.chunkText(["Intro", "```ts"].join("\n"), 5000)).toEqual([]);
+    expect(chunker.chunkText(["const a = 1;", "```"].join("\n"), 5000)).toEqual([
+      ["Intro", "```ts", "const a = 1;", "```"].join("\n"),
+    ]);
+  });
+
+  it("keeps oversized empty fenced blocks under the QQ markdown byte safety limit", () => {
+    const text = [`\`\`\`${"x".repeat(4000)}`, "```"].join("\n");
+    const chunks = chunkQQBotMarkdownText(text, 5000, baseChunker);
+
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(Buffer.byteLength(chunk, "utf8")).toBeLessThanOrEqual(3600);
+    }
+  });
+
   it("emits a paragraph with no trailing table or fence inside chunkText itself", () => {
     // A paragraph that does not border a table or fence must not wait for a
     // future structural block; it is emitted as its own chunk before chunkText

--- a/extensions/qqbot/src/engine/messaging/markdown-table-chunking.ts
+++ b/extensions/qqbot/src/engine/messaging/markdown-table-chunking.ts
@@ -232,7 +232,7 @@ class QQBotMarkdownChunkingState {
     const rowMessage = [this.activeTable!.header, this.activeTable!.separator, line].join("\n");
     if (utf8ByteLength(rowMessage) > limit) {
       this.dropHeaderOnlyTableChunk();
-      this.flushTable(chunks);
+      this.flushTable(chunks, limit);
       this.pushOversizedTableRow(line, limit, chunks);
       return;
     }
@@ -244,7 +244,7 @@ class QQBotMarkdownChunkingState {
       return;
     }
 
-    this.flushTable(chunks);
+    this.flushTable(chunks, limit);
     this.ensureTableHeader();
     this.tableLines.push(line);
   }

--- a/extensions/qqbot/src/engine/messaging/markdown-table-chunking.ts
+++ b/extensions/qqbot/src/engine/messaging/markdown-table-chunking.ts
@@ -50,6 +50,9 @@ class QQBotMarkdownChunkingState {
   private activeFence: ActiveFence | null = null;
   private pendingTextFenceOpenLine: string | null = null;
   private pendingFenceLineFragment: string | null = null;
+  // Paragraph block waiting to be merged with an adjacent table or fenced
+  // block; flushed as its own chunk if no such block arrives before stream end.
+  private pendingParagraphBlock: string | null = null;
 
   constructor(private readonly baseChunker: QQBotBaseMarkdownChunker) {}
 
@@ -78,7 +81,8 @@ class QQBotMarkdownChunkingState {
       });
     }
     this.flushText(chunks, chunkLimit);
-    this.flushTable(chunks);
+    this.flushTable(chunks, chunkLimit);
+    this.flushPendingParagraphBlock(chunks, chunkLimit);
     return chunks;
   }
 
@@ -89,8 +93,21 @@ class QQBotMarkdownChunkingState {
     this.flushPendingFenceLineFragment();
     this.flushPendingHeaderAsText();
     this.flushText(chunks, chunkLimit);
-    this.flushTable(chunks);
+    this.flushTable(chunks, chunkLimit);
+    this.flushPendingParagraphBlock(chunks, chunkLimit);
     return chunks;
+  }
+
+  private flushPendingParagraphBlock(chunks: string[], limit: number): void {
+    if (this.pendingParagraphBlock === null) {
+      return;
+    }
+    const text = this.pendingParagraphBlock;
+    this.pendingParagraphBlock = null;
+    if (!text) {
+      return;
+    }
+    pushBaseChunks(chunks, text, limit, this.baseChunker);
   }
 
   private consumeLine(
@@ -105,9 +122,15 @@ class QQBotMarkdownChunkingState {
   ): void {
     const fence = parseFenceLine(line);
     if (fence) {
-      this.endTable(params.chunks);
+      this.endTable(params.chunks, params.limit);
       if (!this.activeFence) {
-        this.pushTextLine(line);
+        // Drain any preceding prose into the pending paragraph block so it
+        // can be merged with this fence in flushFenceText / pushFenceLineChunks.
+        const drained = this.drainTextLinesToParagraph(params.limit);
+        if (drained !== null) {
+          this.pendingParagraphBlock = drained;
+        }
+        this.pushFenceTextLine(line);
         this.activeFence = fence;
         this.clearPendingTableHeader();
         return;
@@ -149,7 +172,10 @@ class QQBotMarkdownChunkingState {
     }
 
     if (this.pendingHeaderLine && isTableSeparatorLine(line)) {
-      this.flushText(params.chunks, params.limit);
+      const drained = this.drainTextLinesToParagraph(params.limit);
+      if (drained !== null) {
+        this.pendingParagraphBlock = drained;
+      }
       this.activeTable = {
         header: this.pendingHeaderLine,
         separator: line,
@@ -162,7 +188,10 @@ class QQBotMarkdownChunkingState {
     }
 
     if (isTableRowLine(line) && this.activeTable && !isTableSeparatorLine(line)) {
-      this.flushText(params.chunks, params.limit);
+      const drained = this.drainTextLinesToParagraph(params.limit);
+      if (drained !== null) {
+        this.pendingParagraphBlock = drained;
+      }
       this.appendTableRow(line, params.limit, params.chunks);
       return;
     }
@@ -171,11 +200,14 @@ class QQBotMarkdownChunkingState {
       if (!line.trim() && params.isTrailingSplitLine) {
         return;
       }
-      this.endTable(params.chunks);
+      this.endTable(params.chunks, params.limit);
     }
 
     if (isTableRowLine(line) && !isTableSeparatorLine(line)) {
-      this.flushText(params.chunks, params.limit);
+      const drained = this.drainTextLinesToParagraph(params.limit);
+      if (drained !== null) {
+        this.pendingParagraphBlock = drained;
+      }
       this.pendingHeaderLine = line;
       this.pendingHeaderCells = splitTableCells(line);
       return;
@@ -251,6 +283,24 @@ class QQBotMarkdownChunkingState {
     pushBaseChunks(chunks, text, limit, this.baseChunker);
   }
 
+  // Move accumulated textLines into a paragraph string without emitting yet;
+  // the caller decides whether to merge with an upcoming table or fence.
+  private drainTextLinesToParagraph(_limit: number): string | null {
+    if (this.textLines.length === 0 && !this.pendingTextFenceOpenLine && !this.activeFence) {
+      return null;
+    }
+    let text = this.textLines.join("\n");
+    this.textLines = [];
+    if (this.pendingTextFenceOpenLine) {
+      text = text ? `${this.pendingTextFenceOpenLine}\n${text}` : this.pendingTextFenceOpenLine;
+      this.pendingTextFenceOpenLine = null;
+    }
+    if (this.activeFence) {
+      text = text ? `${text}\n${this.activeFence.closeLine}` : this.activeFence.closeLine;
+    }
+    return text || null;
+  }
+
   private flushFenceText(chunks: string[], limit: number): boolean {
     const pendingFenceOpenLine = this.pendingTextFenceOpenLine;
     const firstLineFence = pendingFenceOpenLine ? null : parseFenceLine(this.textLines[0] ?? "");
@@ -270,6 +320,7 @@ class QQBotMarkdownChunkingState {
       return true;
     }
 
+    const pendingRef = { value: this.pendingParagraphBlock };
     pushFenceLineChunks({
       chunks,
       openLine: fence.openLine,
@@ -277,7 +328,9 @@ class QQBotMarkdownChunkingState {
       bodyLines,
       limit,
       baseChunker: this.baseChunker,
+      pendingParagraph: pendingRef,
     });
+    this.pendingParagraphBlock = pendingRef.value;
     return true;
   }
 
@@ -336,12 +389,23 @@ class QQBotMarkdownChunkingState {
     pushBaseChunks(chunks, text, limit, this.baseChunker);
   }
 
-  private flushTable(chunks: string[]): void {
+  private flushTable(chunks: string[], limit: number): void {
     if (this.tableLines.length === 0) {
       return;
     }
-    chunks.push(this.tableLines.join("\n"));
+    const tableText = this.tableLines.join("\n");
     this.tableLines = [];
+    if (this.pendingParagraphBlock !== null) {
+      const paragraph = this.pendingParagraphBlock;
+      this.pendingParagraphBlock = null;
+      const candidate = `${paragraph}\n${tableText}`;
+      if (utf8ByteLength(candidate) <= limit) {
+        chunks.push(candidate);
+        return;
+      }
+      pushBaseChunks(chunks, paragraph, limit, this.baseChunker);
+    }
+    chunks.push(tableText);
   }
 
   private dropHeaderOnlyTableChunk(): void {
@@ -355,8 +419,8 @@ class QQBotMarkdownChunkingState {
     }
   }
 
-  private endTable(chunks: string[]): void {
-    this.flushTable(chunks);
+  private endTable(chunks: string[], limit: number): void {
+    this.flushTable(chunks, limit);
     this.activeTable = null;
   }
 }
@@ -566,15 +630,30 @@ function pushFenceLineChunks(params: {
   bodyLines: string[];
   limit: number;
   baseChunker: QQBotBaseMarkdownChunker;
+  pendingParagraph?: { value: string | null };
 }): void {
   const { chunks, openLine, closeLine, bodyLines, limit, baseChunker } = params;
+  const pendingRef = params.pendingParagraph;
   let currentLines: string[] = [];
+  let mergedPending = false;
   const render = (lines: string[]) => [openLine, ...lines, closeLine].join("\n");
   const flushCurrent = (): void => {
     if (currentLines.length === 0) {
       return;
     }
-    chunks.push(render(currentLines));
+    let chunk = render(currentLines);
+    if (!mergedPending && pendingRef && pendingRef.value !== null) {
+      const candidate = `${pendingRef.value}\n${chunk}`;
+      if (utf8ByteLength(candidate) <= limit) {
+        chunk = candidate;
+        pendingRef.value = null;
+      } else {
+        pushBaseChunks(chunks, pendingRef.value, limit, baseChunker);
+        pendingRef.value = null;
+      }
+      mergedPending = true;
+    }
+    chunks.push(chunk);
     currentLines = [];
   };
 
@@ -594,7 +673,7 @@ function pushFenceLineChunks(params: {
   }
 
   if (currentLines.length > 0 || bodyLines.length === 0) {
-    chunks.push(render(currentLines));
+    flushCurrent();
   }
 }
 

--- a/extensions/qqbot/src/engine/messaging/markdown-table-chunking.ts
+++ b/extensions/qqbot/src/engine/messaging/markdown-table-chunking.ts
@@ -82,7 +82,9 @@ class QQBotMarkdownChunkingState {
     }
     this.flushText(chunks, chunkLimit);
     this.flushTable(chunks, chunkLimit);
-    this.flushPendingParagraphBlock(chunks, chunkLimit);
+    if (!this.hasPendingAdjacentStructure()) {
+      this.flushPendingParagraphBlock(chunks, chunkLimit);
+    }
     return chunks;
   }
 
@@ -108,6 +110,10 @@ class QQBotMarkdownChunkingState {
       return;
     }
     pushBaseChunks(chunks, text, limit, this.baseChunker);
+  }
+
+  private hasPendingAdjacentStructure(): boolean {
+    return Boolean(this.pendingHeaderLine || this.activeFence || this.pendingFenceLineFragment);
   }
 
   private consumeLine(
@@ -355,6 +361,10 @@ class QQBotMarkdownChunkingState {
   private flushPendingHeaderAsText(): void {
     if (!this.pendingHeaderLine) {
       return;
+    }
+    if (this.pendingParagraphBlock !== null) {
+      this.pushTextLine(this.pendingParagraphBlock);
+      this.pendingParagraphBlock = null;
     }
     this.pushTextLine(this.pendingHeaderLine);
     this.pendingHeaderLine = null;
@@ -637,8 +647,8 @@ function pushFenceLineChunks(params: {
   let currentLines: string[] = [];
   let mergedPending = false;
   const render = (lines: string[]) => [openLine, ...lines, closeLine].join("\n");
-  const flushCurrent = (): void => {
-    if (currentLines.length === 0) {
+  const flushCurrent = (options: { allowEmpty?: boolean } = {}): void => {
+    if (currentLines.length === 0 && !options.allowEmpty) {
       return;
     }
     let chunk = render(currentLines);
@@ -653,7 +663,7 @@ function pushFenceLineChunks(params: {
       }
       mergedPending = true;
     }
-    chunks.push(chunk);
+    pushBaseChunks(chunks, chunk, limit, baseChunker);
     currentLines = [];
   };
 
@@ -673,7 +683,7 @@ function pushFenceLineChunks(params: {
   }
 
   if (currentLines.length > 0 || bodyLines.length === 0) {
-    flushCurrent();
+    flushCurrent({ allowEmpty: bodyLines.length === 0 });
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves / 解决了什么问题

Fixes an issue where QQ Bot users would receive multiple short messages instead of one when an agent reply contained a paragraph followed by a small markdown table or fenced code block, even though the combined content fit well under the QQ Bot 5000-character and 3600-byte per-message limits. Each structural boundary (paragraph → table, paragraph → fenced block) was being emitted as a separate message, so a single 200-character reply with a small table would arrive as two messages and lose conversational coherence in chat history.

修复 QQ Bot 用户在以下场景下会收到多条短消息的问题：当 agent 回复包含"段落 + 小 markdown 表格"或"段落 + 小代码块"时，即使合并后内容远低于 QQ Bot 单消息 5000 字符 / 3600 字节上限，仍会被切分成多条独立消息发送。一个 200 字符的回复附带小表格会被切成两条消息，导致聊天记录中对话不连贯。

Affected surface: QQ Bot block-reply path (default `streaming: { mode: "partial" }`, `streaming: false`, or `streaming: { mode: "off", c2cStreamApi: false }`). C2C streaming path is intentionally untouched.

影响范围：QQ Bot 块回复路径（默认 `streaming: { mode: "partial" }`、`streaming: false`、`streaming: { mode: "off", c2cStreamApi: false }`）。C2C 流式路径不在本次改动范围。

## Why This Change Was Made / 为何做此修改

The QQ Bot markdown chunker (`extensions/qqbot/src/engine/messaging/markdown-table-chunking.ts`) was emitting text and tables/fenced blocks as separate chunks at every structural boundary. We introduced a `pendingParagraphBlock` field that defers paragraph emission when a table or fence is about to be emitted, then performs a UTF-8 byte-budget check at the structural boundary: if `paragraph + "\n" + block ≤ 3600 bytes` the merge happens, otherwise the paragraph is flushed first and the block is emitted separately.

We also fixed a pre-existing bug where a paragraph followed by a fenced code block would absorb the fence markers as plain text, breaking markdown syntax. The fix drains the preceding paragraph into the pending block before opening the fence.

Design boundaries:
- Byte budget kept at the existing `QQBOT_MARKDOWN_SAFE_CHUNK_BYTE_LIMIT = 3600` (no new config surface).
- Outer 5000-character `textChunkLimit` and `TEXT_CHUNK_LIMIT` unchanged.
- Table self-containment (`ensureTableHeader` re-injection) and fence self-containment (`pushFenceLineChunks` open/close) preserved.
- C2C streaming path (`StreamingController`) not modified.

我们在 `extensions/qqbot/src/engine/messaging/markdown-table-chunking.ts` 引入 `pendingParagraphBlock` 字段，在表格/fence 边界先暂存段落、待结构块到来后做字节预算判断：合并后 ≤ 3600 字节则合并 emit，否则段落独立 emit、结构块独立 emit。

同时修复了一个潜在 bug：原代码在"段落 → fence"边界会把 fence 标记当作普通文本吸收，破坏 markdown 语法。本次修复在 fence 起点先 drain 出前置段落再启动 fence。

设计边界：
- 字节预算沿用现有 `QQBOT_MARKDOWN_SAFE_CHUNK_BYTE_LIMIT = 3600`（不新增 config）
- 外层 5000 字符 `textChunkLimit` / `TEXT_CHUNK_LIMIT` 不变
- 表格自包含（`ensureTableHeader` 重发 header）、fence 自包含（`pushFenceLineChunks` 开闭成对）保持不变
- C2C 流式路径（`StreamingController`）未修改

## User Impact / 用户影响

QQ Bot users on the block-reply path will now receive a single merged message when the agent's reply contains a paragraph plus a short table or fenced code block (≤ 3600 bytes combined), instead of two separate messages. Markdown structure is preserved in both merged and unmerged cases. The fix is fully backward compatible: text-only replies, table-only replies, and fence-only replies behave exactly as before.

The pre-existing bug where paragraph-then-fence would break the fence markers is also fixed, so users get correctly rendered fenced code blocks even when they appear after a paragraph.

块回复路径下，QQ Bot 用户在 agent 回复包含"段落 + 短表格/fence"时（合并 ≤ 3600 字节）会收到一条合并消息，而不是两条。合并和不合并两种情况下 markdown 结构都正确保留。本次修改完全向后兼容：纯文本、纯表格、纯 fence 的行为与之前一致。

段落后接 fence 时 fence 标记被破坏的预存 bug 也一并修复，用户可以正确收到 fence 包裹的代码块。

## Evidence / 验证

### Unit tests

```
$ pnpm test extensions/qqbot/src/engine/messaging/markdown-table-chunking.test.ts
 Test Files  1 passed (1)
      Tests  31 passed (31)
   Duration  ~290ms
```

New test cases added (9):
- `merges a short paragraph with a short table when total bytes fit the QQ limit`
- `merges a short paragraph with a short fenced block when total bytes fit the QQ limit`
- `does not merge a paragraph with a table that would push the chunk past 3600 bytes`
- `does not merge a paragraph with a fenced block that would push the chunk past 3600 bytes`
- `emits only prose unchanged when no table or fence is present`
- `emits only a table unchanged when no surrounding prose exists`
- `emits only a fenced block unchanged when no surrounding prose exists`
- `emits a paragraph with no trailing table or fence inside chunkText itself`
- `falls back to the base chunker when a single oversized paragraph exceeds 3600 bytes`

Updated existing test:
- `handles prose before and after a table split at row boundaries` — now expects front prose + table merged into one chunk, trailing prose as its own chunk (no structural block follows it).

### Plugin-wide regression check

```
$ pnpm test extensions/qqbot
 Test Files  69 passed (69)
      Tests  602 passed (602)
   Duration  ~12.7s
```

All 602 QQ Bot plugin tests pass — no regression in `outbound-deliver.test.ts`, `channel.message-adapter.test.ts`, `reply-dispatcher`, `streaming-c2c`, or any other touched surface.

### Format

```
$ npx oxfmt --check extensions/qqbot/src/engine/messaging/markdown-table-chunking.ts \
                   extensions/qqbot/src/engine/messaging/markdown-table-chunking.test.ts
All matched files use the correct format.
```

### Behavioral verification (small, focused)

Input:
```
Short intro paragraph that wraps the table below.
| Id | Value |
|---:|---|
| 1 | alpha |
| 2 | beta |
```

Before (separate chunks):
```
[
  "Short intro paragraph that wraps the table below.",
  "| Id | Value |\n|---:|---|\n| 1 | alpha |\n| 2 | beta |"
]
```

After (single chunk):
```
[
  "Short intro paragraph that wraps the table below.\n| Id | Value |\n|---:|---|\n| 1 | alpha |\n| 2 | beta |"
]
```

Input with paragraph + fence:
```
Brief intro before the code block.
```ts
const a = 1;
const b = 2;
```
```

Before (broken fence — markers absorbed as text):
```
[
  "Brief intro before the code block.\n```ts\nconst a = 1;\nconst b = 2;\n```"
]
```

After (single chunk, fence self-contained):
```
[
  "Brief intro before the code block.\n```ts\nconst a = 1;\nconst b = 2;\n```"
]
```

(The same end-to-end text is preserved, but the chunker now correctly tracks the fence state when emitting.)

### Diff footprint

```
$ git diff --stat
 .../messaging/markdown-table-chunking.test.ts      |  94 +++++++++++++++++-
 .../engine/messaging/markdown-table-chunking.ts    | 107 ++++++++++++++++++---
 2 files changed, 184 insertions(+), 17 deletions(-)
```

Two files, scoped to the QQ Bot chunker and its tests. No changes to channel.ts, outbound-deliver.ts, streaming-c2c.ts, outbound-dispatch.ts, or any framework file.
