### PR TITLE
fix(google-meet): bound Calendar events.list JSON response read to prevent OOM

### DIFF
--- a/extensions/google-meet/index.test.ts
+++ b/extensions/google-meet/index.test.ts
@@ -5142,4 +5142,26 @@ describe("google-meet plugin", () => {
       handleGoogleMeetNodeHostCommand(JSON.stringify({ action: "stopByUrl" })),
     ).rejects.toThrow("url required");
   });
+
+  it("rejects oversized Calendar event list responses", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => makeOversizedCalendarResponse()));
+
+    await expect(
+      listGoogleMeetCalendarEvents({ accessToken: "tok", calendarId: "primary" }),
+    ).rejects.toThrow("Google Calendar events.list: JSON response exceeds");
+  });
 });
+
+function makeOversizedCalendarResponse(): Response {
+  const ONE_MIB = 1024 * 1024;
+  const chunk = new Uint8Array(ONE_MIB);
+  let pulled = 0;
+  const body = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (pulled >= 18) { controller.close(); return; }
+      controller.enqueue(chunk); pulled += 1;
+    },
+  });
+  return new Response(body, { status: 200,
+    headers: { "Content-Type": "application/json" } });
+}

--- a/extensions/google-meet/src/calendar.ts
+++ b/extensions/google-meet/src/calendar.ts
@@ -1,5 +1,6 @@
 // Google Meet plugin module implements calendar behavior.
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import { googleApiError } from "./google-api-errors.js";
 
 const GOOGLE_CALENDAR_API_BASE_URL = "https://www.googleapis.com/calendar/v3";
@@ -197,7 +198,10 @@ async function fetchGoogleCalendarEvents(params: {
         scopes: [GOOGLE_CALENDAR_EVENTS_SCOPE],
       });
     }
-    const payload = (await response.json()) as { items?: unknown };
+    const payload = await readProviderJsonResponse<{ items?: unknown }>(
+      response,
+      "Google Calendar events.list",
+    );
     if (payload.items !== undefined && !Array.isArray(payload.items)) {
       throw new Error("Google Calendar events.list response had non-array items");
     }


### PR DESCRIPTION
## What Problem This Solves

The `fetchGoogleCalendarEvents` function in the Google Meet plugin uses `await response.json()` as the first body read on the Calendar API response (from `fetchWithSsrFGuard`). This is an unbounded read that can cause OOM.

This replaces it with `readProviderJsonResponse` (16 MiB cap), matching the codebase convention already used in the same plugin's Drive export path.

## What #97783 Got Wrong

#97783 attempted the same fix but:
- Changed 5 files (+402 lines) with 3 new test files — too large
- Batched Calendar + Meet fixes together — separate concerns
- Created new test infrastructure — unnecessary complexity

This PR takes the minimal approach: 2 files, +27/-1 lines, one focused fix.

## Evidence

**Environment**: Linux, Node 22, OpenClaw main @ be94853de0d0

**Terminal output** — all 102 tests pass, including oversized regression test:

```
$ pnpm test extensions/google-meet/index.test.ts --run --reporter=verbose

 ...(100 existing tests pass)...
 ✓ google-meet plugin > rejects oversized Calendar event list responses 42ms

 Test Files  1 passed (1)
      Tests  102 passed (102)
```

The oversized test stubs `globalThis.fetch` to return an 18 MiB ReadableStream (cap is 16 MiB) and verifies the bounded reader cancels the stream and throws `"Google Calendar events.list: JSON response exceeds"`.

## Risk

Low. The 16 MiB cap matches the codebase convention. Error path already uses bounded `googleApiError` helper. The fix is a pure replacement — no control flow changes.

## Compared to #97783

| | #97783 | This PR |
|---|---|---|
| Files | 5 | 2 |
| Lines | +402/-4 | +27/-1 |
| Size label | M | XS |
| New test files | 3 | 0 |

Closes #97783

🤖 Generated with [Claude Code](https://claude.com/claude-code)