### PR TITLE
test: cover versioned inline eval approval [AI]

### DIFF
--- a/src/agents/bash-tools.exec-host-gateway.test.ts
+++ b/src/agents/bash-tools.exec-host-gateway.test.ts
@@ -369,6 +369,8 @@ describe("processGatewayAllowlist", () => {
     security: "full" | "allowlist";
     askFallback: "full" | "allowlist";
     approvedByAsk: boolean;
+    command?: string;
+    inlineEvalHit?: typeof INLINE_EVAL_HIT;
   }) {
     buildExecApprovalFollowupTargetMock.mockImplementation((value) => value);
     resolveExecHostApprovalContextMock.mockReturnValue({
@@ -377,7 +379,7 @@ describe("processGatewayAllowlist", () => {
       hostAsk: "always",
       askFallback: params.askFallback,
     });
-    detectInterpreterInlineEvalArgvMock.mockReturnValue(INLINE_EVAL_HIT);
+    detectInterpreterInlineEvalArgvMock.mockReturnValue(params.inlineEvalHit ?? INLINE_EVAL_HIT);
     resolveApprovalDecisionOrUndefinedMock.mockResolvedValue(null);
     createExecApprovalDecisionStateMock.mockReturnValue({
       baseDecision: { timedOut: true },
@@ -390,7 +392,7 @@ describe("processGatewayAllowlist", () => {
     });
 
     return runGatewayAllowlist({
-      command: "python3 -c 'print(1)'",
+      command: params.command ?? "python3 -c 'print(1)'",
       security: params.security,
       ask: "always",
       strictInlineEval: true,
@@ -1671,6 +1673,74 @@ EOF`,
       );
     });
     expect(sendExecApprovalFollowupResultMock).toHaveBeenCalledTimes(1);
+    expect(runExecProcessMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      command: "python3.13 -c 'print(1)'",
+      executable: "python3.13",
+      normalizedExecutable: "python3.13",
+      flag: "-c",
+      argv: ["python3.13", "-c", "print(1)"],
+    },
+    {
+      command: "/usr/bin/pypy3.10 -c 'print(1)'",
+      executable: "/usr/bin/pypy3.10",
+      normalizedExecutable: "pypy3.10",
+      flag: "-c",
+      argv: ["/usr/bin/pypy3.10", "-c", "print(1)"],
+    },
+    {
+      command: "php -B 'system(\"id\")'",
+      executable: "php",
+      normalizedExecutable: "php",
+      flag: "-B",
+      argv: ["php", "-B", 'system("id")'],
+    },
+    {
+      command: "php -E 'system(\"id\")'",
+      executable: "php",
+      normalizedExecutable: "php",
+      flag: "-E",
+      argv: ["php", "-E", 'system("id")'],
+    },
+    {
+      command: "Rscript -e 'system(\"id\")'",
+      executable: "Rscript",
+      normalizedExecutable: "rscript",
+      flag: "-e",
+      argv: ["Rscript", "-e", 'system("id")'],
+    },
+  ])("denies timed-out inline-eval requests before execution for $command", async (carrier) => {
+    const result = await runTimedOutStrictInlineEval({
+      security: "allowlist",
+      askFallback: "allowlist",
+      approvedByAsk: false,
+      command: carrier.command,
+      inlineEvalHit: {
+        executable: carrier.executable,
+        normalizedExecutable: carrier.normalizedExecutable,
+        flag: carrier.flag,
+        argv: carrier.argv,
+      },
+    });
+
+    expect(result.pendingResult?.details.status).toBe("approval-pending");
+    expect(enforceStrictInlineEvalApprovalBoundaryMock).toHaveBeenCalledWith(
+      expect.objectContaining({ requiresInlineEvalApproval: true }),
+    );
+    await vi.waitFor(() => {
+      expect(sendExecApprovalFollowupResultMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          approvalId: "req-1",
+          sessionKey: "agent:main:main",
+          turnSourceChannel: undefined,
+          direct: false,
+        }),
+        `Exec denied (gateway id=req-1, approval-timeout): ${carrier.command}`,
+      );
+    });
     expect(runExecProcessMock).not.toHaveBeenCalled();
   });
 

--- a/src/infra/command-analysis/inline-eval.test.ts
+++ b/src/infra/command-analysis/inline-eval.test.ts
@@ -25,6 +25,7 @@ describe("exec inline eval detection", () => {
     { argv: ["php", "-B", "system('id');"], expected: "php -B" },
     { argv: ["php", "-E", "system('id');"], expected: "php -E" },
     { argv: ["php", "-R", "system('id');"], expected: "php -R" },
+    { argv: ["php8.3", "-B", "system('id');"], expected: "php8.3 -B" },
     { argv: ["Rscript", "-e", "system('id')"], expected: "rscript -e" },
     { argv: ["osascript", "-e", "beep"], expected: "osascript -e" },
     { argv: ["awk", "BEGIN { print 1 }"], expected: "awk inline program" },
@@ -89,6 +90,7 @@ describe("exec inline eval detection", () => {
     expect(isInterpreterLikeAllowlistPattern("/usr/bin/python3.13")).toBe(true);
     expect(isInterpreterLikeAllowlistPattern("python3.*")).toBe(true);
     expect(isInterpreterLikeAllowlistPattern("pypy3.10")).toBe(true);
+    expect(isInterpreterLikeAllowlistPattern("php8.3")).toBe(true);
     expect(isInterpreterLikeAllowlistPattern("**/node")).toBe(true);
     expect(isInterpreterLikeAllowlistPattern("Rscript")).toBe(true);
     expect(isInterpreterLikeAllowlistPattern("r2")).toBe(false);

--- a/src/infra/command-analysis/inline-eval.ts
+++ b/src/infra/command-analysis/inline-eval.ts
@@ -15,8 +15,12 @@ type PrefixFlagSpec = {
   prefix: string;
 };
 
-type InterpreterFlagSpec = {
+type InterpreterNameSpec = {
   names: readonly string[];
+  versionedNames?: readonly string[];
+};
+
+type InterpreterFlagSpec = InterpreterNameSpec & {
   exactFlags: ReadonlySet<string>;
   rawExactFlags?: ReadonlyMap<string, string>;
   rawPrefixFlags?: readonly PrefixFlagSpec[];
@@ -24,8 +28,7 @@ type InterpreterFlagSpec = {
   scanPastDoubleDash?: boolean;
 };
 
-type PositionalInterpreterSpec = {
-  names: readonly string[];
+type PositionalInterpreterSpec = InterpreterNameSpec & {
   fileFlags?: ReadonlySet<string>;
   fileFlagPrefixes?: readonly string[];
   exactValueFlags?: ReadonlySet<string>;
@@ -37,7 +40,11 @@ type PositionalInterpreterSpec = {
 const VERSION_SUFFIX_PATTERN = /-?\d+(?:\.\d+)*$/;
 
 const FLAG_INTERPRETER_INLINE_EVAL_SPECS: readonly InterpreterFlagSpec[] = [
-  { names: ["python", "python2", "python3", "pypy", "pypy3"], exactFlags: new Set(["-c"]) },
+  {
+    names: ["python", "python2", "python3", "pypy", "pypy3"],
+    versionedNames: ["python", "pypy"],
+    exactFlags: new Set(["-c"]),
+  },
   {
     names: ["node", "nodejs", "bun", "deno"],
     exactFlags: new Set(["-e", "--eval", "-p", "--print"]),
@@ -51,6 +58,7 @@ const FLAG_INTERPRETER_INLINE_EVAL_SPECS: readonly InterpreterFlagSpec[] = [
   { names: ["perl"], exactFlags: new Set(["-e", "-E"]) },
   {
     names: ["php"],
+    versionedNames: ["php"],
     exactFlags: new Set(["-r"]),
     rawExactFlags: new Map([
       ["-B", "-B"],
@@ -58,7 +66,7 @@ const FLAG_INTERPRETER_INLINE_EVAL_SPECS: readonly InterpreterFlagSpec[] = [
       ["-R", "-R"],
     ]),
   },
-  { names: ["r", "rscript"], exactFlags: new Set(["-e"]) },
+  { names: ["r", "rscript"], versionedNames: ["rscript"], exactFlags: new Set(["-e"]) },
   { names: ["lua"], exactFlags: new Set(["-e"]) },
   { names: ["osascript"], exactFlags: new Set(["-e"]) },
   {
@@ -160,9 +168,9 @@ const POSITIONAL_INTERPRETER_INLINE_EVAL_SPECS: readonly PositionalInterpreterSp
 ];
 
 const INTERPRETER_ALLOWLIST_NAMES = new Set(
-  FLAG_INTERPRETER_INLINE_EVAL_SPECS.flatMap((entry) => entry.names).concat(
-    POSITIONAL_INTERPRETER_INLINE_EVAL_SPECS.flatMap((entry) => entry.names),
-  ),
+  FLAG_INTERPRETER_INLINE_EVAL_SPECS.flatMap((entry) =>
+    entry.names.concat(entry.versionedNames ?? []),
+  ).concat(POSITIONAL_INTERPRETER_INLINE_EVAL_SPECS.flatMap((entry) => entry.names)),
 );
 
 function stripInterpreterVersionSuffix(value: string): string {
@@ -177,16 +185,21 @@ function interpreterNameVariants(value: string): readonly string[] {
   return stripped === value || stripped.length < 2 ? [value] : [value, stripped];
 }
 
-function specNamesInclude(names: readonly string[], normalizedExecutable: string): boolean {
-  return interpreterNameVariants(normalizedExecutable).some((candidate) =>
-    names.includes(candidate),
-  );
+function specNamesInclude(spec: InterpreterNameSpec, normalizedExecutable: string): boolean {
+  if (spec.names.includes(normalizedExecutable)) {
+    return true;
+  }
+  const stripped = stripInterpreterVersionSuffix(normalizedExecutable);
+  if (stripped === normalizedExecutable || stripped.length < 2) {
+    return false;
+  }
+  return (spec.versionedNames ?? spec.names).includes(stripped);
 }
 
 function findInterpreterSpec(executable: string): InterpreterFlagSpec | null {
   const normalized = normalizeExecutableToken(executable);
   for (const spec of FLAG_INTERPRETER_INLINE_EVAL_SPECS) {
-    if (specNamesInclude(spec.names, normalized)) {
+    if (specNamesInclude(spec, normalized)) {
       return spec;
     }
   }
@@ -196,7 +209,7 @@ function findInterpreterSpec(executable: string): InterpreterFlagSpec | null {
 function findPositionalInterpreterSpec(executable: string): PositionalInterpreterSpec | null {
   const normalized = normalizeExecutableToken(executable);
   for (const spec of POSITIONAL_INTERPRETER_INLINE_EVAL_SPECS) {
-    if (specNamesInclude(spec.names, normalized)) {
+    if (specNamesInclude(spec, normalized)) {
       return spec;
     }
   }

--- a/src/infra/exec-approvals-allow-always.test.ts
+++ b/src/infra/exec-approvals-allow-always.test.ts
@@ -434,6 +434,54 @@ describe("resolveAllowAlwaysPatterns", () => {
     expect(persisted).toStrictEqual([]);
   });
 
+  it.each([
+    {
+      name: "versioned Python",
+      executable: "python3.13",
+      command: "python3.13 -c 'print(1)'",
+    },
+    {
+      name: "versioned PyPy",
+      executable: "pypy3.10",
+      command: "pypy3.10 -c 'print(1)'",
+    },
+    {
+      name: "PHP begin flag",
+      executable: "php",
+      command: "php -B 'system(\"id\")'",
+    },
+    {
+      name: "PHP end flag",
+      executable: "php",
+      command: "php -E 'system(\"id\")'",
+    },
+    {
+      name: "Rscript eval",
+      executable: "Rscript",
+      command: "Rscript -e 'system(\"id\")'",
+    },
+  ])(
+    "keeps $name inline-eval commands out of allow-always persistence in strict mode",
+    async ({ command, executable }) => {
+      if (process.platform === "win32") {
+        return;
+      }
+      const dir = makeTempDir();
+      makeExecutable(dir, executable);
+      const env = makePathEnv(dir);
+      const safeBins = resolveSafeBins(undefined);
+
+      const { persisted } = await resolvePersistedPatterns({
+        command,
+        dir,
+        env,
+        safeBins,
+        strictInlineEval: true,
+      });
+      expect(persisted).toStrictEqual([]);
+    },
+  );
+
   it("unwraps reusable shell wrappers and persists the inner executable instead", async () => {
     if (process.platform === "win32") {
       return;


### PR DESCRIPTION
## What Problem This Solves

The strict inline-eval approval boundary needs source-level and gateway-path coverage for version-suffixed interpreter names and inline flags so those command forms continue to require explicit approval under `strictInlineEval=true`.

## Why This Change Was Made

This makes versioned interpreter matching explicit in the inline-eval detector specs for the affected interpreter families, adds direct detector coverage for a versioned PHP binary, and broadens approval-path regression coverage for the reported carrier forms. It also verifies those carriers do not become reusable allow-always entries in strict mode.

This PR was AI-assisted.

## User Impact

Operators keep the same strict inline-eval guardrail behavior for interpreter inline-code commands. The change is limited to detector matching and regression coverage; it does not add config, migration, provider, plugin, channel, storage, or protocol behavior.

## Evidence

- `node scripts/run-vitest.mjs src/infra/command-analysis/inline-eval.test.ts src/infra/command-analysis/risks.test.ts src/infra/exec-approvals-allow-always.test.ts src/agents/bash-tools.exec-host-gateway.test.ts`
