### PR TITLE
fix(ollama): keep tool call arguments as strings for OpenAI-compatible routes

### DIFF
--- a/extensions/ollama/index.test.ts
+++ b/extensions/ollama/index.test.ts
@@ -1552,6 +1552,71 @@ describe("ollama plugin", () => {
     expect((payloadSeen?.options as Record<string, unknown> | undefined)?.num_ctx).toBe(202752);
   });
 
+  it("keeps tool_calls.function.arguments as a JSON string on outbound OpenAI-compat payloads", () => {
+    const provider = registerProvider();
+    let payloadSeen: Record<string, unknown> | undefined;
+    const baseStreamFn = vi.fn((_model, _context, options) => {
+      // OpenAI-completions already emits arguments as a JSON string (per OpenAI spec).
+      const payload: Record<string, unknown> = {
+        options: { temperature: 0.1 },
+        messages: [
+          {
+            role: "assistant",
+            tool_calls: [
+              {
+                id: "call_1",
+                type: "function",
+                function: {
+                  name: "config_get",
+                  arguments: '{"action":"config.get","path":"gateway.port"}',
+                },
+              },
+            ],
+          },
+        ],
+      };
+      options?.onPayload?.(payload, _model);
+      payloadSeen = payload;
+      return {} as never;
+    });
+
+    const wrapped = provider.wrapStreamFn?.({
+      config: {
+        models: {
+          providers: {
+            ollama: {
+              api: "openai-completions",
+              baseUrl: "http://127.0.0.1:11434/v1",
+              models: [],
+            },
+          },
+        },
+      },
+      provider: "ollama",
+      modelId: "glm-5.2:cloud",
+      model: {
+        api: "openai-completions",
+        provider: "ollama",
+        id: "glm-5.2:cloud",
+        baseUrl: "http://127.0.0.1:11434/v1",
+        contextWindow: 128_000,
+      },
+      streamFn: baseStreamFn,
+    });
+
+    if (!wrapped) {
+      throw new Error("expected Ollama OpenAI-compatible stream wrapper");
+    }
+    void wrapped({} as never, {} as never, {});
+
+    const messages = payloadSeen?.messages as
+      | Array<{ tool_calls: Array<{ function: { arguments: unknown } }> }>
+      | undefined;
+    const args = messages?.[0]?.tool_calls?.[0]?.function.arguments;
+    expect(typeof args).toBe("string");
+    expect(args).toBe('{"action":"config.get","path":"gateway.port"}');
+  });
+
   it("owns replay policy for OpenAI-compatible and native Ollama routes", () => {
     const provider = registerProvider();
 

--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -247,7 +247,6 @@ export function wrapOllamaCompatNumCtx(baseFn: StreamFn | undefined, numCtx: num
         payloadRecord.options = {};
       }
       (payloadRecord.options as Record<string, unknown>).num_ctx = numCtx;
-      normalizeOllamaCompatMessageToolArgs(payloadRecord);
     });
 }
 
@@ -739,46 +738,6 @@ function ensureArgsObject(value: unknown): Record<string, unknown> {
 
 function normalizeOllamaToolCallArguments(value: unknown): Record<string, unknown> {
   return ensureArgsObject(value);
-}
-
-function normalizeOllamaCompatMessageToolArgs(payloadRecord: Record<string, unknown>): void {
-  const messages = payloadRecord.messages;
-  if (!Array.isArray(messages)) {
-    return;
-  }
-
-  for (const message of messages) {
-    if (!message || typeof message !== "object" || Array.isArray(message)) {
-      continue;
-    }
-    const messageRecord = message as Record<string, unknown>;
-
-    const functionCall = messageRecord.function_call;
-    if (functionCall && typeof functionCall === "object" && !Array.isArray(functionCall)) {
-      const functionCallRecord = functionCall as Record<string, unknown>;
-      if (Object.hasOwn(functionCallRecord, "arguments")) {
-        functionCallRecord.arguments = ensureArgsObject(functionCallRecord.arguments);
-      }
-    }
-
-    const toolCalls = messageRecord.tool_calls;
-    if (!Array.isArray(toolCalls)) {
-      continue;
-    }
-    for (const toolCall of toolCalls) {
-      if (!toolCall || typeof toolCall !== "object" || Array.isArray(toolCall)) {
-        continue;
-      }
-      const functionSpec = (toolCall as Record<string, unknown>).function;
-      if (!functionSpec || typeof functionSpec !== "object" || Array.isArray(functionSpec)) {
-        continue;
-      }
-      const functionRecord = functionSpec as Record<string, unknown>;
-      if (Object.hasOwn(functionRecord, "arguments")) {
-        functionRecord.arguments = ensureArgsObject(functionRecord.arguments);
-      }
-    }
-  }
 }
 
 function inferOllamaSchemaType(schema: Record<string, unknown>): string | undefined {


### PR DESCRIPTION
Closes #96441

AI-assisted.

## What Problem This Solves

Fixes an issue where Ollama Cloud users could hit a second-turn 400 error after a tool call because the OpenAI-compatible payload sent `tool_calls.function.arguments` as an object instead of the JSON string shape required by the Chat Completions contract.

## Why This Change Was Made

The Ollama OpenAI-compatible wrapper no longer reparses historical tool-call arguments into objects. Native Ollama routes still normalize tool-call arguments for the native API path; the OpenAI-compatible path now preserves the already-stringified arguments emitted by the upstream OpenAI-completions payload builder.

## User Impact

Ollama Cloud tool-calling conversations can continue across turns without the provider rejecting replayed tool-call history for schema shape. This restores multi-turn tool use for the affected OpenAI-compatible Ollama Cloud models.

## Evidence

- `node scripts/run-vitest.mjs extensions/ollama/index.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` -> clean, no accepted/actionable findings
- Contract proof: local OpenAI SDK types declare Chat Completions function/tool-call `arguments: string` in `node_modules/openai/resources/chat/completions/completions.d.ts` and `node_modules/openai/lib/ChatCompletionStream.d.ts`.
