### PR TITLE
fix(memory): refresh status dirty sessions

### DIFF
--- a/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts
@@ -151,6 +151,10 @@ class SessionStartupCatchupHarness extends MemoryManagerSyncOps {
     return await this.markSessionStartupCatchupDirtyFiles();
   }
 
+  async refreshStatusDirtyFiles(): Promise<string[]> {
+    return await this.refreshSessionStartupCatchupDirtyFilesForStatus();
+  }
+
   async runSyncForTest(params?: MemorySyncParams): Promise<void> {
     await this.runSync(params);
   }
@@ -343,6 +347,16 @@ describe("session startup catch-up", () => {
     ]);
 
     await expect(harness.markStartupDirtyFiles()).resolves.toEqual([session.filePath]);
+    expect(harness.getDirtySessionFiles()).toEqual([session.filePath]);
+    expect(harness.isSessionsDirty()).toBe(true);
+    expect(harness.syncCalls).toEqual([]);
+  });
+
+  it("status catch-up check marks missing indexed session transcripts dirty without syncing", async () => {
+    const session = await writeSessionFile("status-only.jsonl");
+    const harness = new SessionStartupCatchupHarness([]);
+
+    await expect(harness.refreshStatusDirtyFiles()).resolves.toEqual([session.filePath]);
     expect(harness.getDirtySessionFiles()).toEqual([session.filePath]);
     expect(harness.isSessionsDirty()).toBe(true);
     expect(harness.syncCalls).toEqual([]);

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -1496,6 +1496,10 @@ export abstract class MemoryManagerSyncOps {
     });
   }
 
+  protected async refreshSessionStartupCatchupDirtyFilesForStatus(): Promise<string[]> {
+    return await this.markSessionStartupCatchupDirtyFiles();
+  }
+
   protected async markSessionStartupCatchupDirtyFiles(): Promise<string[]> {
     if (!this.sources.has("sessions") || this.closed) {
       return [];

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -435,6 +435,10 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       this.batch = this.resolveBatchConfig();
       if (!transient) {
         this.ensureSessionStartupCatchup();
+      } else if (this.purpose === "status") {
+        void this.refreshSessionStartupCatchupDirtyFilesForStatus().catch((err: unknown) => {
+          log.warn("memory session status catch-up check failed: " + String(err));
+        });
       }
     } catch (err) {
       closeMemoryDatabase(this.db);


### PR DESCRIPTION
## Summary

Fixes memory status reporting stale `dirty=false` for session transcripts that have been usage-counted but not yet indexed.

## Issue

Fixes #97814.

## Changes

- Adds a status-only session startup catch-up dirty check.
- Reuses the existing session startup catch-up dirty marking path without scheduling a full sync for status reads.
- Covers the status-only path with a regression test.

## Testing

- `node scripts/run-vitest.mjs extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts` — 16 tests passed
- `/root/.hermes/oss-contrib/worktrees/openclaw__openclaw/node_modules/.bin/oxfmt --check --threads=1 extensions/memory-core/src/memory/manager.ts extensions/memory-core/src/memory/manager-sync-ops.ts extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts` — passed
- `git diff --check && git diff --cached --check` — passed
- added-line secret scan — clean

## What Problem This Solves

Fixes #97814. Memory status could report `dirty=false` for session transcripts that had already been usage-counted but had not yet been indexed. That made the status view look clean while a startup catch-up dirty mark was still required.

## Evidence

- `node scripts/run-vitest.mjs extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts` — 16 tests passed
- `oxfmt --check --threads=1 extensions/memory-core/src/memory/manager.ts extensions/memory-core/src/memory/manager-sync-ops.ts extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts` — passed
- `git diff --check && git diff --cached --check` — passed
- Added-line secret scan — clean
- Regression test covers the status-only startup catch-up path without scheduling a full sync.
