### PR TITLE
# fix(embedded): allow reentrant session write lock during overflow-recovery compaction

### DIFF
--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -1185,6 +1185,7 @@ async function compactEmbeddedAgentSessionDirectOnce(
           timeoutMs: compactionTimeoutMs,
         }),
       }),
+      allowReentrant: true,
     });
     try {
       await repairSessionFileIfNeeded({

--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -1087,6 +1087,7 @@ export async function truncateOversizedToolResultsInSession(params: {
     sessionLock = await acquireSessionWriteLock({
       sessionFile,
       ...resolveSessionWriteLockOptions(params.config),
+      allowReentrant: true,
     });
     const state = await readTranscriptFileState(sessionFile);
     return await truncateOversizedToolResultsInTranscriptState({


### PR DESCRIPTION
## Summary
closes #97747 
When an embedded agent attempt triggers overflow-recovery auto-compaction, the compaction path in `compact.ts` calls `acquireSessionWriteLock` without `allowReentrant: true`. Since the outer attempt already holds the same session's write lock, the nested acquire blocks for 60s and then fails with `SessionWriteLockTimeoutError`.

This causes an **18-minute recovery window** where:
- Each fallback model in the chain repeats the same 60s+180s timeout cycle
- Every new webchat message is rejected with `Embedded agent failed before reply: session file locked`
- Compaction never actually completes; only a manual `/compact` ends the cycle

## Root Cause

`acquireSessionWriteLock` defaults `allowReentrant` to `false` ([session-write-lock.ts:895](https://github.com/openclaw/openclaw/blob/main/src/agents/session-write-lock.ts#L895)), unlike the plugin-sdk file-lock path which defaults to `true`. The compaction path and tool-result-truncation path (called from the same overflow-recovery context) did not opt into reentrant behavior.

Other call sites in the same codebase correctly pass `allowReentrant: true`:
- `transcript-append.ts:619`
- `session-accessor.ts:2345`
- `plugin-sdk/file-lock.ts:106`

## Fix

Add `allowReentrant: true` to the `acquireSessionWriteLock` calls in:
- `src/agents/embedded-agent-runner/compact.ts:1188`
- `src/agents/embedded-agent-runner/tool-result-truncation.ts:1090`

**2 files changed, +2 lines.**

```diff
diff --git a/src/agents/embedded-agent-runner/compact.ts b/src/agents/embedded-agent-runner/compact.ts
@@ -1185,6 +1185,7 @@ async function compactEmbeddedAgentSessionDirectOnce(
           timeoutMs: compactionTimeoutMs,
         }),
       }),
+      allowReentrant: true,
     });

diff --git a/src/agents/embedded-agent-runner/tool-result-truncation.ts b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -1087,6 +1087,7 @@ export async function truncateOversizedToolResultsInSession(params: {
     sessionLock = await acquireSessionWriteLock({
       sessionFile,
       ...resolveSessionWriteLockOptions(params.config),
+      allowReentrant: true,
     });
```

## Real-Device Test Logs

**Environment**: Windows 10 Pro 21H2 (19045), Node.js, real filesystem (tmpdir), no mocking.

### 1. Bug Reproduction — nested acquire without allowReentrant

```
[TEST] ✓ Outer lock acquired (simulating attempt holding the lock)
[TEST] → Attempting nested acquire WITHOUT allowReentrant (simulating compaction)...
[TEST] ✗ Nested acquire WITHOUT allowReentrant FAILED after 2007ms
[TEST]   Error: session file locked (timeout 2000ms): pid=14636 alive=true
[TEST]   → compact() returns {ok: false, compacted: false}
[TEST]   → 18-minute recovery window, all messages rejected
```

Key signature matches the production bug report: `pid=<self> alive=true` — the lock is self-held by the same process.

### 2. Fix Verification — nested acquire with allowReentrant: true

```
[TEST] ✓ Outer lock acquired
[TEST] → Attempting nested acquire WITH allowReentrant:true (fixed compaction path)...
[TEST] ✓ Nested acquire WITH allowReentrant:true SUCCEEDED in 0ms
[TEST] ✓ Inner lock released — lock file still exists (reference count > 0)
[TEST] ✓ Outer lock released
[TEST] ✓ Lock file removed after all references released
```

### 3. Full Deadlock Scenario — Before vs After Fix

```
=== BEFORE FIX: overflow-recovery deadlock ===
[TEST] ✓ [attempt] Session write lock acquired for embedded agent run
[TEST] → [overflow-recovery] Context overflow detected, triggering compaction...
[TEST] → [compact] acquireSessionWriteLock WITHOUT allowReentrant...
[TEST] ✗ [compact] Lock acquire FAILED after 2010ms
[TEST]   → Fallback chain repeats: M2.7→GLM→Kimi→Gemini (18min wasted)

=== AFTER FIX: allowReentrant:true ===
[TEST] ✓ [attempt] Session write lock acquired
[TEST] ✓ [compact] Lock acquire SUCCEEDED in 1ms
[TEST]   → Compaction proceeds normally, no recovery window
[TEST] ✓ All locks released — fix confirmed
```

## Existing Test Suite

All existing session-write-lock and tool-result-truncation tests continue to pass. 4 pre-existing stale-lock test failures on Windows are unrelated to this change.

## Production Log Evidence (from bug report)

```
19:04:15 [context-overflow-precheck] provider=minimax/MiniMax-M2.7 estimatedPromptTokens=315930
19:04:15 context overflow detected; attempting auto-compaction for minimax/MiniMax-M2.7
19:07:15 contextEngine.compact() threw: Error: Compaction timed out
19:08:24 SessionWriteLockTimeoutError: pid=13536 alive=true ageMs=61487

19:10:24 repeat for GLM-5.1: 185s timeout
19:13:39 repeat for Kimi-K2.5: 183s timeout
19:16:41 repeat for Gemini-3.1: 182s timeout

Total recovery window: 18 minutes
Every new webchat message during this window: "Embedded agent failed before reply: session file locked"
```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
