### PR TITLE
fix: log terminal session persistence failures

### DIFF
--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -5,10 +5,15 @@ import { formatChannelProgressDraftLine } from "../channels/streaming.js";
 import { registerAgentRunContext, resetAgentRunContextForTest } from "../infra/agent-events.js";
 
 const persistGatewaySessionLifecycleEventMock = vi.fn();
+const logErrorMock = vi.fn();
 
 vi.mock("./server-chat.persist-session-lifecycle.runtime.js", () => ({
   persistGatewaySessionLifecycleEvent: (...args: unknown[]) =>
     persistGatewaySessionLifecycleEventMock(...args),
+}));
+
+vi.mock("../logger.js", () => ({
+  logError: (...args: unknown[]) => logErrorMock(...args),
 }));
 
 vi.mock("../config/io.js", () => ({
@@ -74,6 +79,7 @@ describe("agent event handler", () => {
       });
     vi.mocked(loadGatewaySessionRow).mockReset().mockReturnValue(null);
     persistGatewaySessionLifecycleEventMock.mockReset().mockResolvedValue(undefined);
+    logErrorMock.mockReset();
     resetAgentRunContextForTest();
   });
 
@@ -2532,6 +2538,9 @@ describe("agent event handler", () => {
       updatedAt: 2_100,
       abortedLastRun: false,
     });
+    expect(logErrorMock).toHaveBeenCalledWith(
+      "gateway: failed to persist terminal session lifecycle event for run run-failed-write: Error: disk full",
+    );
     expect(markTrackedRunTerminalPersisted).not.toHaveBeenCalled();
   });
 

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -2506,7 +2506,9 @@ describe("agent event handler", () => {
       startedAt: 1_000,
       abortedLastRun: false,
     });
-    persistGatewaySessionLifecycleEventMock.mockRejectedValueOnce(new Error("disk full"));
+    persistGatewaySessionLifecycleEventMock.mockRejectedValueOnce(
+      new Error("disk full sk-abcdefghijklmnopqrstuvwxyz123456"),
+    );
     const markTrackedRunTerminalPersisted = vi.fn();
     const { broadcastToConnIds, handler, sessionEventSubscribers } = createHarness({
       resolveSessionKeyForRun: () => "session-failed-write",
@@ -2539,7 +2541,7 @@ describe("agent event handler", () => {
       abortedLastRun: false,
     });
     expect(logErrorMock).toHaveBeenCalledWith(
-      "gateway: failed to persist terminal session lifecycle event for run run-failed-write: Error: disk full",
+      "gateway: failed to persist terminal session lifecycle event for run run-failed-write: Error: disk full sk-abc…3456",
     );
     expect(markTrackedRunTerminalPersisted).not.toHaveBeenCalled();
   });

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -2540,8 +2540,9 @@ describe("agent event handler", () => {
       updatedAt: 2_100,
       abortedLastRun: false,
     });
+    expect(logErrorMock).toHaveBeenCalledTimes(1);
     expect(logErrorMock).toHaveBeenCalledWith(
-      "gateway: failed to persist terminal session lifecycle event for run run-failed-write: Error: disk full sk-abc…3456",
+      "gateway: terminal session persistence failed session=session-failed-write run=run-failed-write error=Error: disk full sk-abc…3456",
     );
     expect(markTrackedRunTerminalPersisted).not.toHaveBeenCalled();
   });

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -9,6 +9,7 @@ import { getRuntimeConfig } from "../config/io.js";
 import { type AgentEventPayload, getAgentRunContext } from "../infra/agent-events.js";
 import { detectErrorKind, type ErrorKind } from "../infra/errors.js";
 import { resolveHeartbeatVisibility } from "../infra/heartbeat-visibility.js";
+import { logError } from "../logger.js";
 import { isAcpSessionKey, isSubagentSessionKey } from "../sessions/session-key-utils.js";
 import { resolveAssistantEventPhase } from "../shared/chat-message-content.js";
 import { setSafeTimeout } from "../utils/timer-delay.js";
@@ -716,7 +717,10 @@ export function createAgentEventHandler({
             markPersisted();
             broadcastSessionChange();
           })
-          .catch(() => {
+          .catch((err: unknown) => {
+            logError(
+              `gateway: failed to persist terminal session lifecycle event for run ${evt.runId}: ${String(err)}`,
+            );
             // Persistence recovery remains tracked by the controller entry, but
             // subscribers still need a terminal projection instead of hanging.
             broadcastSessionChange(evt);

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -719,7 +719,7 @@ export function createAgentEventHandler({
           })
           .catch((err: unknown) => {
             logError(
-              `gateway: failed to persist terminal session lifecycle event for run ${evt.runId}: ${String(err)}`,
+              `gateway: failed to persist terminal session lifecycle event for run ${evt.runId}: ${formatForLog(err)}`,
             );
             // Persistence recovery remains tracked by the controller entry, but
             // subscribers still need a terminal projection instead of hanging.

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -719,7 +719,7 @@ export function createAgentEventHandler({
           })
           .catch((err: unknown) => {
             logError(
-              `gateway: failed to persist terminal session lifecycle event for run ${evt.runId}: ${formatForLog(err)}`,
+              `gateway: terminal session persistence failed session=${formatForLog(sessionKey)} run=${formatForLog(evt.runId)} error=${formatForLog(err)}`,
             );
             // Persistence recovery remains tracked by the controller entry, but
             // subscribers still need a terminal projection instead of hanging.


### PR DESCRIPTION
Fixes #97795

## What Problem This Solves

Fixes an issue where operators would not see any diagnostic output when a terminal session lifecycle persistence write failed during gateway run completion. The gateway still broadcast a fallback terminal snapshot, but the persistence failure itself was silent.

## Why This Change Was Made

The terminal lifecycle persistence failure path now logs the rejected write at the gateway event handling boundary before preserving the existing fallback broadcast behavior. The rejection is formatted through the existing gateway `formatForLog(err)` helper so arbitrary error text is redacted and capped before it reaches operator-visible logs.

## User Impact

Operators get an actionable gateway error log when terminal session persistence fails, making session-state storage problems easier to diagnose without changing normal chat or abort behavior.

## Evidence

RED: `node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/server-chat.agent-events.test.ts` failed before the implementation because `logError` was not called.

GREEN:

```text
node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/server-chat.agent-events.test.ts
Test Files  1 passed (1)
Tests  99 passed (99)
```

Focused related proof after the formatter update:

```text
node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/chat-abort.test.ts src/gateway/server-chat.agent-events.test.ts
Test Files  4 passed (4)
Tests  192 passed (192)
```

`git diff --check` passed.

Real runtime persistence rejection proof after the formatter update:

A temporary `node --import tsx` script seeded a real `OPENCLAW_STATE_DIR` with `state/agents/main/sessions/sessions.json`, denied writes to that sessions directory with `icacls`, then invoked `createAgentEventHandler` with the real `persistGatewaySessionLifecycleEvent` path. The script was not committed and used synthetic ids only.

```text
[gateway] failed to persist terminal session lifecycle event for run proof-run: Error: EPERM: operation not permitted, open 'C:\Users\16500\AppData\Local\Temp\openclaw-pr-97839-proof-pqeeeO\state\agents\main\sessions\sessions.json.24092.c92dfce1-5b4b-4b11-b00b-19690d9c141b.tmp': code=EPERM
sessions.changed fallback status=done run=proof-run
```

Formatter safety proof:

The focused handler test now rejects with `Error("disk full sk-abcdefghijklmnopqrstuvwxyz123456")` and asserts the gateway log contains the formatted/redacted value `sk-abc…3456`, proving the new catch uses `formatForLog(err)` instead of raw `String(err)`.

Autoreview note: attempted `python .agents\skills\autoreview\scripts\autoreview --mode local`, but the helper failed before review on Windows path handling with `NotADirectoryError: [WinError 267]` in this non-ASCII worktree path, even when retried through a `subst` drive.
