### PR TITLE
fix(memory): detect unindexed session transcripts in status mode (fixes #97814)

### DIFF
--- a/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts
@@ -151,6 +151,10 @@ class SessionStartupCatchupHarness extends MemoryManagerSyncOps {
     return await this.markSessionStartupCatchupDirtyFiles();
   }
 
+  detectStartupDirtySync(): void {
+    this.detectSessionStartupDirtySync();
+  }
+
   async runSyncForTest(params?: MemorySyncParams): Promise<void> {
     await this.runSync(params);
   }
@@ -345,6 +349,17 @@ describe("session startup catch-up", () => {
     await expect(harness.markStartupDirtyFiles()).resolves.toEqual([session.filePath]);
     expect(harness.getDirtySessionFiles()).toEqual([session.filePath]);
     expect(harness.isSessionsDirty()).toBe(true);
+    expect(harness.syncCalls).toEqual([]);
+  });
+
+  it("detects unindexed session files synchronously for status mode", async () => {
+    const session = await writeSessionFile("thread.jsonl");
+    const harness = new SessionStartupCatchupHarness([]);
+
+    harness.detectStartupDirtySync();
+    expect(harness.getDirtySessionFiles()).toEqual([session.filePath]);
+    expect(harness.isSessionsDirty()).toBe(true);
+    // Sync detection does not trigger background sync
     expect(harness.syncCalls).toEqual([]);
   });
 

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -1496,6 +1496,62 @@ export abstract class MemoryManagerSyncOps {
     });
   }
 
+  /**
+   * Synchronous detection of unindexed session transcripts for status-mode
+   * initialization. Sets sessionsDirty when on-disk session files have no
+   * corresponding memory_index_sources rows, so plain `memory status`
+   * reports accurate dirty state without performing a full sync.
+   */
+  protected detectSessionStartupDirtySync(): void {
+    if (!this.sources.has("sessions")) {
+      return;
+    }
+    try {
+      const sessionsDir = resolveSessionTranscriptsDirForAgent(this.agentId);
+      if (!fsSync.existsSync(sessionsDir)) {
+        return;
+      }
+      const entries = fsSync.readdirSync(sessionsDir, { withFileTypes: true });
+      const sessionFiles: MemorySessionStartupFileState[] = [];
+      for (const entry of entries) {
+        if (!entry.isFile() || !isUsageCountedSessionTranscriptFileName(entry.name)) {
+          continue;
+        }
+        const absPath = path.join(sessionsDir, entry.name);
+        try {
+          const stat = fsSync.statSync(absPath);
+          sessionFiles.push({
+            absPath,
+            path: sessionPathForFile(absPath),
+            mtimeMs: stat.mtimeMs,
+            size: stat.size,
+          });
+        } catch {
+          // File may have been deleted between readdir and stat; skip.
+        }
+      }
+      if (sessionFiles.length === 0) {
+        return;
+      }
+      const existingRows = loadMemorySourceFileState({
+        db: this.db,
+        source: "sessions",
+      }).rows;
+      const dirtyFiles = resolveMemorySessionStartupDirtyFiles({
+        files: sessionFiles,
+        existingRows,
+      });
+      if (dirtyFiles.length > 0) {
+        for (const file of dirtyFiles) {
+          this.sessionsDirtyFiles.add(file);
+        }
+        this.sessionsDirty = true;
+      }
+    } catch {
+      // Non-fatal: status will report whatever persisted flags exist.
+    }
+  }
+
   protected async markSessionStartupCatchupDirtyFiles(): Promise<string[]> {
     if (!this.sources.has("sessions") || this.closed) {
       return [];

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -22,6 +22,7 @@ import {
   isUsageCountedSessionTranscriptFileName,
   listSessionFilesForAgent,
   listSessionTranscriptCorpusEntriesForAgent,
+  listSessionTranscriptCorpusEntriesForAgentSync,
   parseCanonicalSessionSyncTargetFromPath,
   resolveSessionFileForSyncTarget,
   sessionPathForFile,
@@ -1501,25 +1502,27 @@ export abstract class MemoryManagerSyncOps {
    * initialization. Sets sessionsDirty when on-disk session files have no
    * corresponding memory_index_sources rows, so plain `memory status`
    * reports accurate dirty state without performing a full sync.
+   *
+   * Uses the session corpus listing (same contract as startup catch-up) so
+   * configured/fixed custom session stores and ownership filtering are respected.
    */
   protected detectSessionStartupDirtySync(): void {
     if (!this.sources.has("sessions")) {
       return;
     }
     try {
-      const sessionsDir = resolveSessionTranscriptsDirForAgent(this.agentId);
-      if (!fsSync.existsSync(sessionsDir)) {
+      const corpusEntries = listSessionTranscriptCorpusEntriesForAgentSync(this.agentId);
+      if (corpusEntries.length === 0) {
         return;
       }
-      const entries = fsSync.readdirSync(sessionsDir, { withFileTypes: true });
       const sessionFiles: MemorySessionStartupFileState[] = [];
-      for (const entry of entries) {
-        if (!entry.isFile() || !isUsageCountedSessionTranscriptFileName(entry.name)) {
-          continue;
-        }
-        const absPath = path.join(sessionsDir, entry.name);
+      for (const entry of corpusEntries) {
+        const absPath = entry.sessionFile;
         try {
           const stat = fsSync.statSync(absPath);
+          if (!stat.isFile()) {
+            continue;
+          }
           sessionFiles.push({
             absPath,
             path: sessionPathForFile(absPath),
@@ -1527,7 +1530,7 @@ export abstract class MemoryManagerSyncOps {
             size: stat.size,
           });
         } catch {
-          // File may have been deleted between readdir and stat; skip.
+          // File may have been deleted between corpus listing and stat; skip.
         }
       }
       if (sessionFiles.length === 0) {

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -448,6 +448,8 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       this.batch = this.resolveBatchConfig();
       if (!transient) {
         this.ensureSessionStartupCatchup();
+      } else if (params.purpose === "status") {
+        this.detectSessionStartupDirtySync();
       }
     } catch (err) {
       closeMemoryDatabase(this.db);

--- a/packages/memory-host-sdk/src/engine-qmd.ts
+++ b/packages/memory-host-sdk/src/engine-qmd.ts
@@ -5,6 +5,7 @@ export {
   buildSessionEntry,
   listSessionFilesForAgent,
   listSessionTranscriptCorpusEntriesForAgent,
+  listSessionTranscriptCorpusEntriesForAgentSync,
   loadDreamingNarrativeTranscriptPathSetForAgent,
   loadSessionTranscriptClassificationForAgent,
   normalizeSessionTranscriptPathForComparison,

--- a/packages/memory-host-sdk/src/host/session-files.ts
+++ b/packages/memory-host-sdk/src/host/session-files.ts
@@ -31,6 +31,7 @@ import type { MemorySessionSyncTarget } from "./types.js";
 
 export {
   listSessionTranscriptCorpusEntriesForAgent,
+  listSessionTranscriptCorpusEntriesForAgentSync,
   type SessionTranscriptCorpusArtifactKind,
   type SessionTranscriptCorpusEntry,
 } from "./session-transcript-corpus.js";


### PR DESCRIPTION
## What Problem This Solves

`openclaw memory status` (plain, without `--index`) reports `dirty=false` when unindexed usage-counted session transcripts exist on disk. Operators rely on this command as the primary health check for memory recall — a false-clean signal means session transcripts go unindexed indefinitely, causing silent recall gaps.

The root cause is that the status-mode `MemoryManager` initialization path skips `ensureSessionStartupCatchup()`. When `purpose === "status"`, the constructor does not detect whether on-disk session files have corresponding `memory_index_sources` rows.

## Why This Change Was Made

The constructor at `extensions/memory-core/src/memory/manager.ts:436` gates `ensureSessionStartupCatchup()` behind `!transient`, and `transient` is `true` for `purpose === "status"`. This means `sessionsDirty` is never set during status-mode initialization, so `status()` at line 1146 always reports `dirty: false` for the sessions dimension.

PR #82341 added startup catch-up for normal manager startup, but the status-purpose initialization path still bypasses it.

## User Impact

- Operators running `openclaw memory status` get a false-clean `dirty=false` signal when unindexed session transcripts exist
- Memory search silently misses unindexed transcripts until `--index` or `--force` is used
- During incident triage, the false-clean state compounds confusion because the fleet appears healthier than it is

## Evidence

## Real behavior proof

- **Behavior addressed:** `openclaw memory status` reports `dirty=false` when unindexed usage-counted session transcripts exist on disk
- **Environment tested:** macOS 26.4.1, OpenClaw 2026.6.10 (d21ddd3), Node 22.19+
- **Steps run after the patch:** Built from source with `pnpm build`, ran `node openclaw.mjs memory status --json` to verify baseline behavior, then ran the memory-core extension test suite to verify the fix
- **Evidence after fix:**

Baseline behavior (no sessions source configured on local agent):
```
$ node openclaw.mjs memory status --json
agent=main dirty=False sources=['memory'] files=0 chunks=0
```

Test verification (1000/1000 pass, including new sync detection test):
```
$ pnpm test:extension memory-core
Test Files  65 passed (65)
     Tests  1000 passed (1000)
```

New test `detects unindexed session files synchronously for status mode` verifies that `detectSessionStartupDirtySync()` correctly sets `sessionsDirty=true` when unindexed session files exist, without triggering background sync.

- **Observed result after fix:** The synchronous detection method correctly compares on-disk session files against `memory_index_sources` rows during status-mode construction. When unindexed files exist, `sessionsDirty` is set to `true` and `status()` reports `dirty: true`.
- **What was not tested:** The local agent (`main`) does not have `sessions` configured as a memory source, so the CLI behavior is unchanged on this machine. The fix is verified through the extension test suite which creates a test harness with sessions source configured.

## Changes Made

- `extensions/memory-core/src/memory/manager-sync-ops.ts` — Added `detectSessionStartupDirtySync()`: synchronous detection of unindexed session transcripts for status-mode initialization
- `extensions/memory-core/src/memory/manager.ts` — Call `detectSessionStartupDirtySync()` when `purpose === "status"` in constructor
- `extensions/memory-core/src/memory/manager-sync-ops.startup-catchup.test.ts` — Added test for synchronous status-mode detection

- [x] AI-assisted (Hermes Agent)
