### PR TITLE
fix(cron): warn when web_search is in toolsAllow but no search provider is enabled

### DIFF
--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -35,6 +35,7 @@ import {
   type SourceDeliveryVisibleDelivery,
 } from "../../infra/outbound/source-delivery-plan.js";
 import { createDiagnosticMessageLifecycle } from "../../logging/message-lifecycle.js";
+import { checkWebSearchAvailability } from "../../plugins/web-search-tool-availability.js";
 import { isCommandLaneTaskTimeoutError } from "../../process/command-queue.js";
 import { CommandLane } from "../../process/lanes.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
@@ -131,6 +132,9 @@ const cronModelPreflightRuntimeLoader = createLazyImportLoader(
 );
 const runtimePluginsLoader = createLazyImportLoader(
   () => import("../../plugins/runtime-plugins.runtime.js"),
+);
+const webSearchProvidersLoader = createLazyImportLoader(
+  () => import("../../plugins/web-search-providers.runtime.js"),
 );
 
 async function loadSessionStoreRuntime() {
@@ -1138,6 +1142,22 @@ async function finalizeCronRun(params: {
   const agentDiagnostics = createCronRunDiagnosticsFromAgentResult(finalRunResult, {
     finalStatus: hasFatalErrorPayload ? "error" : "ok",
   });
+
+  // Preflight: warn when web_search is in toolsAllow but no search provider
+  // plugin is enabled, so operators see a diagnostic instead of a silent apology.
+  const { resolveRuntimeWebSearchProviders } = await webSearchProvidersLoader();
+  const webSearchWarning = checkWebSearchAvailability({
+    toolsAllow: prepared.context.agentPayload?.toolsAllow,
+    providers: resolveRuntimeWebSearchProviders({
+      config: prepared.cfgWithAgentDefaults,
+      workspaceDir: prepared.workspaceDir,
+    }),
+  });
+  const webSearchPreflightDiagnostics = webSearchWarning
+    ? createCronRunDiagnosticsFromError("cron-preflight", webSearchWarning.warning, {
+        severity: "warn",
+      })
+    : undefined;
   const resolveRunOutcome = (result?: {
     delivered?: boolean;
     deliveryAttempted?: boolean;
@@ -1160,8 +1180,9 @@ async function finalizeCronRun(params: {
               "agent-run",
               embeddedRunError ?? "cron isolated run returned an error payload",
             ),
+            webSearchPreflightDiagnostics,
           )
-        : agentDiagnostics,
+        : mergeCronRunDiagnostics(agentDiagnostics, webSearchPreflightDiagnostics),
       ...telemetry,
     });
   const failPendingPresentationWarningUnlessDelivered = (delivered?: boolean) => {
@@ -1267,6 +1288,7 @@ async function finalizeCronRun(params: {
       diagnostics: mergeCronRunDiagnostics(
         agentDiagnostics,
         deliveryResult.result.diagnostics,
+        webSearchPreflightDiagnostics,
         deliveryResult.result.status === "error" && deliveryResult.result.error
           ? createCronRunDiagnosticsFromError("delivery", deliveryResult.result.error)
           : undefined,

--- a/src/plugins/web-search-tool-availability.test.ts
+++ b/src/plugins/web-search-tool-availability.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import type { PluginWebSearchProviderEntry } from "./types.js";
+import { checkWebSearchAvailability } from "./web-search-tool-availability.js";
+
+function makeProvider(id: string): PluginWebSearchProviderEntry {
+  return {
+    id,
+    label: id,
+    pluginId: `plugin-${id}`,
+    contracts: ["webSearchProviders"],
+  } as PluginWebSearchProviderEntry;
+}
+
+describe("checkWebSearchAvailability", () => {
+  it("returns undefined when toolsAllow is undefined", () => {
+    expect(checkWebSearchAvailability({ toolsAllow: undefined, providers: [] })).toBeUndefined();
+  });
+
+  it("returns undefined when toolsAllow is null", () => {
+    expect(checkWebSearchAvailability({ toolsAllow: null, providers: [] })).toBeUndefined();
+  });
+
+  it("returns undefined when toolsAllow does not contain web_search", () => {
+    expect(
+      checkWebSearchAvailability({
+        toolsAllow: ["exec", "read", "write"],
+        providers: [],
+      }),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when toolsAllow is empty", () => {
+    expect(checkWebSearchAvailability({ toolsAllow: [], providers: [] })).toBeUndefined();
+  });
+
+  it("returns undefined when web_search is in toolsAllow and providers are available", () => {
+    expect(
+      checkWebSearchAvailability({
+        toolsAllow: ["web_search"],
+        providers: [makeProvider("duckduckgo")],
+      }),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when web_search is in toolsAllow with multiple providers", () => {
+    expect(
+      checkWebSearchAvailability({
+        toolsAllow: ["web_search", "web_fetch"],
+        providers: [makeProvider("duckduckgo"), makeProvider("tavily")],
+      }),
+    ).toBeUndefined();
+  });
+
+  it("returns warning when web_search is in toolsAllow but no providers are available", () => {
+    const result = checkWebSearchAvailability({
+      toolsAllow: ["web_search"],
+      providers: [],
+    });
+    expect(result).toBeDefined();
+    expect(result!.warning).toContain("web_search is in toolsAllow");
+    expect(result!.warning).toContain("openclaw plugins enable duckduckgo");
+  });
+
+  it("returns warning when toolsAllow includes web_search among other tools and no providers", () => {
+    const result = checkWebSearchAvailability({
+      toolsAllow: ["read", "web_search", "exec"],
+      providers: [],
+    });
+    expect(result).toBeDefined();
+    expect(result!.warning).toContain("web_search is in toolsAllow");
+  });
+
+  it("returns warning when toolsAllow has only web_search and no providers", () => {
+    const result = checkWebSearchAvailability({
+      toolsAllow: ["web_search"],
+      providers: [],
+    });
+    expect(result).toBeDefined();
+    expect(result!.warning).toContain("no web search provider plugin is enabled");
+  });
+
+  it("handles case-sensitive match correctly", () => {
+    // toolsAllow is expected to use the exact tool name
+    const result = checkWebSearchAvailability({
+      toolsAllow: ["web_search"],
+      providers: [],
+    });
+    expect(result).toBeDefined();
+  });
+});

--- a/src/plugins/web-search-tool-availability.ts
+++ b/src/plugins/web-search-tool-availability.ts
@@ -1,0 +1,38 @@
+/**
+ * Validates that web_search is only requested when at least one web search
+ * provider is available. Returns a diagnostic warning when the tool is in
+ * toolsAllow but no provider plugin is enabled — this prevents silent
+ * failures where the model apologizes instead of searching.
+ */
+import type { PluginWebSearchProviderEntry } from "./types.js";
+
+export type WebSearchAvailabilityCheck = {
+  /** Human-readable warning when web_search is requested but unavailable. */
+  warning: string;
+};
+
+const WARNING_TEXT =
+  "web_search is in toolsAllow but no web search provider plugin is enabled. " +
+  "Enable one with: openclaw plugins enable duckduckgo";
+
+/**
+ * Resolves whether the requested toolsAllow list includes web_search while
+ * no web search providers are currently available.
+ *
+ * Returns `undefined` when everything is fine (no warning needed).
+ * Returns a {@link WebSearchAvailabilityCheck} with a diagnostic warning
+ * when web_search is requested but has no registered provider.
+ */
+export function checkWebSearchAvailability(params: {
+  toolsAllow?: string[] | null;
+  providers: PluginWebSearchProviderEntry[];
+}): WebSearchAvailabilityCheck | undefined {
+  const hasWebSearch = params.toolsAllow?.includes("web_search");
+  if (!hasWebSearch) {
+    return undefined;
+  }
+  if (params.providers.length === 0) {
+    return { warning: WARNING_TEXT };
+  }
+  return undefined;
+}


### PR DESCRIPTION
## What Problem This Solves

When a cron job has `web_search` in its `toolsAllow` list but no web search provider plugin is enabled, OpenClaw silently makes the tool unavailable. The model then apologizes instead of searching, and the run completes with `status: ok` — giving the operator no signal that anything is wrong.

Closes #97654

## Why This Change Was Made

This adds a preflight diagnostic check in the cron isolated agent runner. When `web_search` is in `toolsAllow` but no search providers are registered, the run produces a warning diagnostic visible in the cron run log, so operators can see the misconfiguration and enable a provider.

## User Impact

- Cron job operators now see a diagnostic warning when `web_search` is misconfigured
- No change to tool behavior — `web_search` continues to work normally when providers are available
- Warning message: "web_search is in toolsAllow but no web search provider plugin is enabled. Enable one with: openclaw plugins enable duckduckgo"

## Evidence

- New helper function `checkWebSearchAvailability` in `src/plugins/web-search-tool-availability.ts`
- 10 unit tests covering all cases (no toolsAllow, empty providers, available providers, etc.)
- Integrated into the cron isolated agent run preflight path
- All existing tests pass