### PR TITLE
fix(mattermost): bound null-body error response reads

### DIFF
--- a/extensions/mattermost/src/mattermost/client.test.ts
+++ b/extensions/mattermost/src/mattermost/client.test.ts
@@ -15,6 +15,7 @@ import {
   createMattermostClient,
   createMattermostPost,
   normalizeMattermostBaseUrl,
+  readMattermostError,
   updateMattermostPost,
 } from "./client.js";
 
@@ -155,6 +156,38 @@ describe("normalizeMattermostBaseUrl", () => {
   });
 });
 
+// ── readMattermostError ───────────────────────────────────────────────
+
+describe("readMattermostError", () => {
+  it("bounds null-body JSON errors without response.json/text", async () => {
+    const response = new Response(null, {
+      status: 401,
+      headers: { "content-type": "application/json" },
+    });
+    const jsonSpy = vi.spyOn(response, "json").mockRejectedValue(new Error("unbounded"));
+    const textSpy = vi.spyOn(response, "text").mockRejectedValue(new Error("unbounded"));
+
+    await expect(readMattermostError(response)).resolves.toBe("");
+
+    expect(jsonSpy).not.toHaveBeenCalled();
+    expect(textSpy).not.toHaveBeenCalled();
+  });
+
+  it("parses bounded JSON error messages from response bodies", async () => {
+    const response = new Response(JSON.stringify({ message: "invalid token", id: "app.error" }), {
+      status: 401,
+      headers: { "content-type": "application/json" },
+    });
+    const jsonSpy = vi.spyOn(response, "json").mockRejectedValue(new Error("unbounded"));
+    const textSpy = vi.spyOn(response, "text").mockRejectedValue(new Error("unbounded"));
+
+    await expect(readMattermostError(response)).resolves.toBe("invalid token");
+
+    expect(jsonSpy).not.toHaveBeenCalled();
+    expect(textSpy).not.toHaveBeenCalled();
+  });
+});
+
 // ── createMattermostClient ───────────────────────────────────────────
 
 describe("createMattermostClient", () => {
@@ -170,6 +203,29 @@ describe("createMattermostClient", () => {
     await expect(client.request("/users/me")).resolves.toEqual({ id: "u1" });
 
     expect(arrayBuffer).not.toHaveBeenCalled();
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it("reads guarded null-body Mattermost errors without response.json/text", async () => {
+    const release = vi.fn(async () => {});
+    const response = new Response(null, {
+      status: 503,
+      statusText: "Service Unavailable",
+      headers: { "content-type": "application/json" },
+    });
+    const jsonSpy = vi.spyOn(response, "json").mockRejectedValue(new Error("unbounded"));
+    const textSpy = vi.spyOn(response, "text").mockRejectedValue(new Error("unbounded"));
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({ response, release });
+    const client = createMattermostClient({
+      baseUrl: "https://chat.example.com",
+      botToken: "test-token",
+    });
+
+    await expect(client.request("/users/me")).rejects.toThrow(
+      "Mattermost API 503 Service Unavailable: unknown error",
+    );
+    expect(jsonSpy).not.toHaveBeenCalled();
+    expect(textSpy).not.toHaveBeenCalled();
     expect(release).toHaveBeenCalledTimes(1);
   });
 

--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -105,16 +105,6 @@ async function readMattermostSuccessText(res: Response, path: string): Promise<s
 
 export async function readMattermostError(res: Response): Promise<string> {
   const contentType = res.headers.get("content-type") ?? "";
-  if (!res.body) {
-    if (contentType.includes("application/json")) {
-      const data = (await res.json()) as { message?: string } | undefined;
-      if (data?.message) {
-        return data.message;
-      }
-      return JSON.stringify(data);
-    }
-    return await res.text();
-  }
   const text = await readResponseTextLimited(res, MATTERMOST_ERROR_BODY_LIMIT_BYTES);
   if (contentType.includes("application/json")) {
     try {


### PR DESCRIPTION
## What Problem This Solves

`readMattermostError()` had a `!res.body` fallback that bypassed the bounded reader and called native `res.json()` / `res.text()` directly. For a null-body error response with a JSON content-type (a 401/503 with `content-type: application/json` and an empty body — common from reverse proxies and gateways), `await res.json()` throws `SyntaxError: Unexpected end of JSON input`. That rejection propagates out of `readMattermostError()`, so the caller's intended `Mattermost API <status>: unknown error` is replaced by a confusing JSON-parse crash. It was also the last remaining unbounded `json()` / `text()` read in this error path after #96033 bounded the success path.

Affected surface: `extensions/mattermost/src/mattermost/client.ts` — `readMattermostError()`, reached by `client.request()`, the file-upload path, and `probe.ts`.

## Why This Change Was Made

The `!res.body` special-case is removed entirely, so every error read goes through the existing bounded `readResponseTextLimited` (8 KiB) and the JSON `message` is parsed from that bounded text. `readResponseTextLimited` returns `""` when there is no readable body, so a null-body response now yields an empty detail instead of throwing — and all three callers already coalesce that to a clean message (`detail || "unknown error"` / `detail || res.statusText`). One canonical read path, no second buffering strategy.

Net change is a deletion (`client.ts` +0/−10): removes the divergent branch rather than adding code.

## User Impact

Operators and agents talking to self-hosted or misbehaving Mattermost servers get a clean, accurate API error (`Mattermost API 503 Service Unavailable: unknown error`) on null-body JSON error responses, instead of an internal `Unexpected end of JSON input` crash — and every error read now goes through the bounded reader.

## Evidence

**1. Real-behavior proof with a negative control (real HTTP).** A harness drives the **real exported** `readMattermostError` and the **real** `createMattermostClient().request()` (through the real `fetchWithSsrFGuard` SSRF path, `allowPrivateNetwork: true` for localhost) against a real `node:http` server returning `503 Service Unavailable` with `content-type: application/json` and **no body**. The negative control runs the deleted branch's exact logic (`await res.json()`) on the same response.

```
$ tsx mm-proof.mts
Server returns 503 Service Unavailable, content-type application/json, NO body

[NEGATIVE CONTROL] old `!res.body` json branch: await res.json()
PASS: old branch crashes on null-body JSON error — THREW SyntaxError: Unexpected end of JSON input

[WITH FIX] readMattermostError(real null-body 503 json response)
PASS: returns empty string, no throw — detail=""

[WITH FIX] createMattermostClient().request() against null-body 503
PASS: clean bounded API error (no JSON crash) — "Mattermost API 503 Service Unavailable: unknown error"

ALL PROOF ASSERTIONS PASSED
```

Without the fix the null-body JSON error path throws `SyntaxError: Unexpected end of JSON input`; with the fix `readMattermostError` returns `""` and the client surfaces the clean `... 503 Service Unavailable: unknown error`.

**2. Committed regression tests** (`extensions/mattermost/src/mattermost/client.test.ts`) cover: null-body JSON errors never call `response.json()` / `response.text()`; bounded JSON `message` fields still parse from normal bodies; and a guarded null-body failure surfaced end-to-end through `createMattermostClient().request()`.

```
$ node scripts/run-vitest.mjs extensions/mattermost/src/mattermost/client.test.ts
 Test Files  1 passed (1)
      Tests  27 passed (27)
```

**3. Lint on the changed file:**

```
$ node scripts/run-oxlint.mjs extensions/mattermost/src/mattermost/client.ts   # exit 0
```

**What was NOT tested:** I did not run against a live production Mattermost server. The null-body JSON error condition is reproduced with a real local HTTP server over the real SSRF-guarded fetch path, including the negative control showing the pre-fix crash.

AI-assisted: implementation, tests, and the proof harness were drafted with agent assistance; all commands above were run locally.
