### PR TITLE
fix(gateway): log chat-abort terminal persistence failures instead of swallowing

### DIFF
--- a/src/gateway/chat-abort.test.ts
+++ b/src/gateway/chat-abort.test.ts
@@ -16,6 +16,24 @@ import {
   updateChatRunProvider,
 } from "./chat-abort.js";
 
+// Capture the subsystem logger's error spy so the terminal-persistence failure
+// path can be asserted to emit a log line instead of swallowing it.
+const chatAbortLogError = vi.hoisted(() => vi.fn());
+vi.mock("../logging/subsystem.js", () => ({
+  createSubsystemLogger: vi.fn(() => ({
+    warn: vi.fn(),
+    info: vi.fn(),
+    error: chatAbortLogError,
+    debug: vi.fn(),
+    trace: vi.fn(),
+    fatal: vi.fn(),
+    raw: vi.fn(),
+    child: vi.fn(),
+    isEnabled: vi.fn(() => false),
+    subsystem: "test",
+  })),
+}));
+
 type ChatAbortPayload = {
   runId: string;
   sessionKey: string;
@@ -263,6 +281,46 @@ describe("registerChatAbortController", () => {
     await persistence;
     await Promise.resolve();
     expect(chatAbortControllers.has("run-persisting")).toBe(false);
+  });
+
+  it("logs an error and still clears the entry when terminal persistence fails", async () => {
+    chatAbortLogError.mockClear();
+    const chatAbortControllers = new Map<string, ChatAbortControllerEntry>();
+    const registration = registerChatAbortController({
+      chatAbortControllers,
+      runId: "run-persist-failed",
+      sessionId: "sess-1",
+      sessionKey: "main",
+      timeoutMs: 60_000,
+    });
+    let rejectPersistence: (err: Error) => void = () => undefined;
+    const persistence = new Promise<void>((_resolve, reject) => {
+      rejectPersistence = reject;
+    });
+    if (!registration.entry) {
+      throw new Error("expected registered entry");
+    }
+    registration.entry.projectSessionActive = false;
+    registration.entry.projectSessionTerminalPersistence = persistence;
+
+    registration.cleanup();
+
+    // Entry is retained while persistence is still in flight.
+    expect(chatAbortControllers.has("run-persist-failed")).toBe(true);
+    expect(chatAbortLogError).not.toHaveBeenCalled();
+
+    const failure = new Error("disk full");
+    rejectPersistence(failure);
+    // Allow the rejection to propagate to the .catch() handler.
+    await expect(persistence).rejects.toBe(failure);
+    await Promise.resolve();
+
+    // Entry must still be cleaned up (no leak) AND the failure must be logged
+    // rather than silently swallowed — the regression this guards against.
+    expect(chatAbortControllers.has("run-persist-failed")).toBe(false);
+    expect(chatAbortLogError).toHaveBeenCalledTimes(1);
+    expect(chatAbortLogError.mock.calls[0][0]).toContain("run-persist-failed");
+    expect(chatAbortLogError.mock.calls[0][0]).toContain("disk full");
   });
 
   it("retains registrations when terminal lifecycle was observed before caller cleanup", () => {

--- a/src/gateway/chat-abort.ts
+++ b/src/gateway/chat-abort.ts
@@ -11,8 +11,11 @@ import { isAbortRequestText } from "../auto-reply/reply/abort-primitives.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { emitAgentEvent, getAgentEventLifecycleGeneration } from "../infra/agent-events.js";
 import { jsonUtf8Bytes } from "../infra/json-utf8-bytes.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import { projectLiveAssistantBufferedText } from "./live-chat-projector.js";
 import { createChatAbortMarker, type ChatAbortMarker } from "./server-chat-state.js";
+
+const log = createSubsystemLogger("gateway/chat-abort");
 
 const DEFAULT_CHAT_RUN_ABORT_GRACE_MS = 60_000;
 
@@ -173,7 +176,15 @@ export function registerChatAbortController(params: {
               params.chatAbortControllers.delete(params.runId);
             }
           })
-          .catch(() => {
+          .catch((err) => {
+            // The terminal session-store update is the persistence contract for a
+            // run's final state. If it fails we still must drop the abort controller
+            // (otherwise it leaks and blocks idempotent retry cleanup), but the
+            // failure must be visible to operators — otherwise terminal states can
+            // fail to persist in production with no trace in logs or telemetry.
+            log.error(
+              `chat-abort: failed to persist terminal session state for run ${params.runId}: ${err}`,
+            );
             if (params.chatAbortControllers.get(params.runId)?.controller === controller) {
               params.chatAbortControllers.delete(params.runId);
             }


### PR DESCRIPTION
## Summary

Fixes #97795.

When a chat run's terminal session-store persistence failed, `registerChatAbortController`'s cleanup path caught the rejection with an empty handler — silently dropping the error and any operator signal while still deleting the abort controller.

In production this meant terminal states could fail to persist (DB / file-system issues) with **zero trace** in logs or telemetry, and the swallowed error masked infrastructure health problems.

## Root cause

`src/gateway/chat-abort.ts`, in the cleanup closure of `registerChatAbortController`:

```ts
.catch(() => {            // ← err dropped, nothing logged
  if (params.chatAbortControllers.get(params.runId)?.controller === controller) {
    params.chatAbortControllers.delete(params.runId);
  }
});
```

The rejection handler swallowed the error entirely. The controller cleanup (correctly) remained, but there was no way for an operator to learn that persistence had failed.

## Fix

Surface the failure through the project's standard subsystem logger (`gateway/chat-abort`), at error level, including the run id and underlying error — while preserving the existing controller cleanup so idempotent retry cleanup is not blocked:

```ts
.catch((err) => {
  log.error(
    `chat-abort: failed to persist terminal session state for run ${params.runId}: ${err}`,
  );
  if (params.chatAbortControllers.get(params.runId)?.controller === controller) {
    params.chatAbortControllers.delete(params.runId);
  }
});
```

Note: the issue suggested `log.error?.(...)`, but `SubsystemLogger.error` is a required (non-optional) method per `src/logging/subsystem.ts`, so this uses the plain `log.error(...)` call matching the existing `channel-health-monitor.ts` convention.

## Test

Added a regression test in `chat-abort.test.ts` alongside the existing success-path test. It asserts that, on terminal-persistence rejection:
1. the abort-controller entry is still cleaned up (no leak), **and**
2. the failure is logged (run id + error message present) rather than silently swallowed.

The subsystem logger is mocked (`createSubsystemLogger`) following the existing pattern in `gateway-processes.test.ts`.

## Verification

- `vitest run src/gateway/chat-abort.test.ts` → 96/96 passing (3 projects × 32 tests, including the new case)
- Regression test confirmed meaningful: reverting only the source fix makes the new test fail; restoring it makes it pass.
- `oxlint` on changed files → 0 warnings, 0 errors
- `oxfmt --check` on changed files → format OK
- `vitest --typecheck` on the target file → OK