### PR TITLE
fix(media): probe video dimensions via seekable temp file (#97826)

### DIFF
--- a/src/media/video-dimensions.test.ts
+++ b/src/media/video-dimensions.test.ts
@@ -1,14 +1,32 @@
 // Video dimension tests cover ffprobe parsing and fallback behavior.
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { parseFfprobeVideoDimensions, probeVideoDimensions } from "./video-dimensions.js";
 
-const { runFfprobe } = vi.hoisted(() => ({
+const { runFfprobe, open, unlink } = vi.hoisted(() => ({
   runFfprobe: vi.fn(),
+  open: vi.fn(),
+  unlink: vi.fn(),
 }));
 
 vi.mock("./ffmpeg-exec.js", () => ({
   runFfprobe,
 }));
+
+vi.mock("node:fs/promises", () => ({
+  open,
+  unlink,
+}));
+
+const handle = {
+  writeFile: vi.fn().mockResolvedValue(undefined),
+  close: vi.fn().mockResolvedValue(undefined),
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+  handle.writeFile.mockResolvedValue(undefined);
+  handle.close.mockResolvedValue(undefined);
+});
 
 describe("parseFfprobeVideoDimensions", () => {
   it("returns positive integer dimensions from ffprobe JSON", () => {
@@ -29,33 +47,63 @@ describe("parseFfprobeVideoDimensions", () => {
 });
 
 describe("probeVideoDimensions", () => {
-  it("probes video dimensions through ffprobe stdin", async () => {
+  it("writes buffer to seekable temp file then probes path", async () => {
     const buffer = Buffer.from("video");
+    open.mockResolvedValueOnce(handle);
+    unlink.mockResolvedValueOnce(undefined);
     runFfprobe.mockResolvedValueOnce(JSON.stringify({ streams: [{ width: 720, height: 1280 }] }));
 
     await expect(probeVideoDimensions(buffer)).resolves.toEqual({ width: 720, height: 1280 });
 
-    expect(runFfprobe).toHaveBeenCalledWith(
-      [
-        "-v",
-        "error",
-        "-select_streams",
-        "v:0",
-        "-show_entries",
-        "stream=width,height",
-        "-of",
-        "json",
-        "pipe:0",
-      ],
-      { input: buffer },
-    );
+    expect(open).toHaveBeenCalledTimes(1);
+    const tempPath = open.mock.calls[0]![0] as string;
+    expect(tempPath).toContain("openclaw-ffprobe-");
+    expect(tempPath).toContain(".bin");
+    expect(handle.writeFile).toHaveBeenCalledWith(buffer);
+    expect(runFfprobe).toHaveBeenCalledWith([
+      "-v",
+      "error",
+      "-select_streams",
+      "v:0",
+      "-show_entries",
+      "stream=width,height",
+      "-of",
+      "json",
+      tempPath,
+    ]);
+    expect(unlink).toHaveBeenCalledWith(tempPath);
   });
 
   it("falls back when ffprobe fails or returns malformed output", async () => {
+    const buffer = Buffer.from("video");
+    open.mockResolvedValue(handle);
+    unlink.mockResolvedValue(undefined);
+
     runFfprobe.mockRejectedValueOnce(new Error("missing ffprobe"));
-    await expect(probeVideoDimensions(Buffer.from("video"))).resolves.toBeUndefined();
+    await expect(probeVideoDimensions(buffer)).resolves.toBeUndefined();
 
     runFfprobe.mockResolvedValueOnce("{");
-    await expect(probeVideoDimensions(Buffer.from("video"))).resolves.toBeUndefined();
+    await expect(probeVideoDimensions(buffer)).resolves.toBeUndefined();
+  });
+
+  it("still unlinks the temp file when ffprobe rejects", async () => {
+    const buffer = Buffer.from("video");
+    open.mockResolvedValueOnce(handle);
+    unlink.mockResolvedValueOnce(undefined);
+    runFfprobe.mockRejectedValueOnce(new Error("boom"));
+
+    await expect(probeVideoDimensions(buffer)).resolves.toBeUndefined();
+    expect(unlink).toHaveBeenCalledTimes(1);
+  });
+
+  it("unlinks the temp file when the write itself rejects", async () => {
+    const buffer = Buffer.from("video");
+    open.mockResolvedValueOnce(handle);
+    unlink.mockResolvedValueOnce(undefined);
+    handle.writeFile.mockRejectedValueOnce(new Error("disk full"));
+
+    await expect(probeVideoDimensions(buffer)).resolves.toBeUndefined();
+    expect(handle.close).toHaveBeenCalled();
+    expect(unlink).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/media/video-dimensions.test.ts
+++ b/src/media/video-dimensions.test.ts
@@ -2,10 +2,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { parseFfprobeVideoDimensions, probeVideoDimensions } from "./video-dimensions.js";
 
-const { runFfprobe, open, unlink } = vi.hoisted(() => ({
+const { runFfprobe, open, unlink, resolvePreferredOpenClawTmpDir } = vi.hoisted(() => ({
   runFfprobe: vi.fn(),
   open: vi.fn(),
   unlink: vi.fn(),
+  resolvePreferredOpenClawTmpDir: vi.fn(),
 }));
 
 vi.mock("./ffmpeg-exec.js", () => ({
@@ -17,6 +18,10 @@ vi.mock("node:fs/promises", () => ({
   unlink,
 }));
 
+vi.mock("../infra/tmp-openclaw-dir.js", () => ({
+  resolvePreferredOpenClawTmpDir,
+}));
+
 const handle = {
   writeFile: vi.fn().mockResolvedValue(undefined),
   close: vi.fn().mockResolvedValue(undefined),
@@ -26,6 +31,7 @@ afterEach(() => {
   vi.clearAllMocks();
   handle.writeFile.mockResolvedValue(undefined);
   handle.close.mockResolvedValue(undefined);
+  resolvePreferredOpenClawTmpDir.mockReturnValue("/tmp/openclaw");
 });
 
 describe("parseFfprobeVideoDimensions", () => {
@@ -56,7 +62,7 @@ describe("probeVideoDimensions", () => {
     await expect(probeVideoDimensions(buffer)).resolves.toEqual({ width: 720, height: 1280 });
 
     expect(open).toHaveBeenCalledTimes(1);
-    const tempPath = open.mock.calls[0]![0] as string;
+    const tempPath = open.mock.calls[0][0];
     expect(tempPath).toContain("openclaw-ffprobe-");
     expect(tempPath).toContain(".bin");
     expect(handle.writeFile).toHaveBeenCalledWith(buffer);

--- a/src/media/video-dimensions.ts
+++ b/src/media/video-dimensions.ts
@@ -1,8 +1,8 @@
 // Video dimension helpers read video dimensions through ffprobe.
 import { randomUUID } from "node:crypto";
 import { open, unlink } from "node:fs/promises";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import { runFfprobe } from "./ffmpeg-exec.js";
 
 /** Positive video dimensions reported by ffprobe for the first video stream. */
@@ -34,7 +34,7 @@ export function parseFfprobeVideoDimensions(stdout: string): VideoDimensions | u
  * Temp-file probing resolves dimensions reliably for any buffer size.
  */
 export async function probeVideoDimensions(buffer: Buffer): Promise<VideoDimensions | undefined> {
-  const tempPath = join(tmpdir(), `openclaw-ffprobe-${randomUUID()}.bin`);
+  const tempPath = join(resolvePreferredOpenClawTmpDir(), `openclaw-ffprobe-${randomUUID()}.bin`);
   let handle;
   try {
     handle = await open(tempPath, "w", 0o600);

--- a/src/media/video-dimensions.ts
+++ b/src/media/video-dimensions.ts
@@ -1,4 +1,8 @@
 // Video dimension helpers read video dimensions through ffprobe.
+import { randomUUID } from "node:crypto";
+import { open, unlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { runFfprobe } from "./ffmpeg-exec.js";
 
 /** Positive video dimensions reported by ffprobe for the first video stream. */
@@ -23,25 +27,38 @@ export function parseFfprobeVideoDimensions(stdout: string): VideoDimensions | u
   return width && height ? { width, height } : undefined;
 }
 
-/** Probes a video buffer through ffprobe stdin and treats probe failures as unknown dimensions. */
+/**
+ * Probes video dimensions via a seekable temp file. Pipe:0 probing fails for
+ * large MP4s because ffprobe needs to seek the MOOV atom (located at the end
+ * for faststart files), which is impossible over a non-seekable stdin pipe.
+ * Temp-file probing resolves dimensions reliably for any buffer size.
+ */
 export async function probeVideoDimensions(buffer: Buffer): Promise<VideoDimensions | undefined> {
+  const tempPath = join(tmpdir(), `openclaw-ffprobe-${randomUUID()}.bin`);
+  let handle;
   try {
-    const stdout = await runFfprobe(
-      [
-        "-v",
-        "error",
-        "-select_streams",
-        "v:0",
-        "-show_entries",
-        "stream=width,height",
-        "-of",
-        "json",
-        "pipe:0",
-      ],
-      { input: buffer },
-    );
+    handle = await open(tempPath, "w", 0o600);
+    await handle.writeFile(buffer);
+    await handle.close();
+    handle = undefined;
+    const stdout = await runFfprobe([
+      "-v",
+      "error",
+      "-select_streams",
+      "v:0",
+      "-show_entries",
+      "stream=width,height",
+      "-of",
+      "json",
+      tempPath,
+    ]);
     return parseFfprobeVideoDimensions(stdout);
   } catch {
     return undefined;
+  } finally {
+    if (handle) {
+      await handle.close().catch(() => undefined);
+    }
+    await unlink(tempPath).catch(() => undefined);
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes #97826.

`sendVideo` lost the width/height aspect ratio for large videos because `probeVideoDimensions` piped the buffer through `ffprobe … pipe:0`. For faststart MP4s the MOOV atom sits at the end of the file and ffprobe needs to seek it; a non-seekable stdin pipe cannot satisfy that seek, so the probe failed silently and `sendVideo` was called without dimensions. Telegram then re-derived the aspect ratio itself, producing visibly stretched playback for files roughly ≥16 MB.

## Why This Change Was Made

`probeVideoDimensions` is the only producer of `width`/`height` for the video send path (`extensions/telegram/src/bot/delivery.replies.ts:426` and `extensions/telegram/src/send.ts:1138`). Both callers spread the dimensions into `sendVideo` parameters. When the probe returned `undefined`, the parameters were missing entirely.

The previous implementation swallowed probe failures (per the function's own JSDoc: *"treats probe failures as unknown dimensions"*), so the silent regression had no log signal. The fix:

- Write the buffer to a per-call seekable temp file under `os.tmpdir()` with a randomized name and `0o600` mode.
- Pass the path to ffprobe (no `pipe:0`, no `input` payload). ffprobe can now seek the MOOV atom regardless of file size.
- Unlink the temp file in a `finally` block on every path — success, probe failure, or write failure. The file handle is closed before the ffprobe call and also defensively closed in `finally` if the write rejected.

This is a localized change to one helper. The public API (`(buffer) => Promise<VideoDimensions | undefined>`) and all call sites are unchanged.

## User Impact

Telegram recipients will see videos play at the correct aspect ratio regardless of file size. Small videos (≤8 MB) were already working because their MOOV atom fit within ffprobe's pipe read window; this fix extends the same correct behavior to large faststart MP4s (slideshows, screen recordings, etc.).

## Evidence

Local deterministic proof (mocked ffprobe + mocked `node:fs/promises`):

```
$ node scripts/test-projects.mjs src/media/video-dimensions.test.ts
Test Files  1 passed (1)
    Tests  6 passed (6)
```

New regression coverage:
- Writes buffer to seekable temp file then probes path (asserts the path is passed to ffprobe, not `pipe:0`)
- Falls back to `undefined` when ffprobe rejects or returns malformed JSON (preserves prior behavior)
- Unlinks the temp file when ffprobe rejects (no file leak on probe failure)
- Unlinks the temp file and closes the handle when the write itself rejects (no file leak on disk-full)

Full media test surface green:
```
$ node scripts/test-projects.mjs src/media/
Test Files  19 passed (19)
      Tests  265 passed (265)
```

Telegram send tests (which mock `probeVideoDimensions` at the seam) still green:
```
$ node scripts/test-projects.mjs extensions/telegram/src/send.test.ts
Test Files  1 passed (1)
      Tests  139 passed (139)
```

Live ffprobe-on-large-file proof would require a real ≥16 MB faststart MP4 and is the merge gate per the issue's `clawsweeper:needs-live-repro` label. I do not have a representative large video asset in this environment; maintainer may request a real ffprobe comparison before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
