### PR TITLE
fix(agents): surface claude-cli OAuth-expiry 401 as a re-auth hint

### DIFF
--- a/src/agents/auth-profiles/oauth-refresh-failure.test.ts
+++ b/src/agents/auth-profiles/oauth-refresh-failure.test.ts
@@ -8,6 +8,7 @@ import {
   buildOAuthRefreshFailureLoginCommand,
   classifyOAuthRefreshFailure,
   classifyOAuthRefreshFailureError,
+  classifyOAuthRefreshFailureReason,
   OAuthRefreshFailureError,
 } from "./oauth-refresh-failure.js";
 
@@ -36,5 +37,28 @@ describe("oauth refresh failure hints", () => {
       provider: "openai",
       reason: "invalid_grant",
     });
+  });
+
+  it("recognises external CLI subprocess 401 expiry (claude-cli) as a refresh failure", () => {
+    // The `claude` CLI, spawned under CLAUDE_CLI_CLEAR_ENV, emits its own 401
+    // message on OAuth token expiry. This must classify as a refresh failure so
+    // the operator gets the re-auth hint instead of a generic "something went
+    // wrong" error (see issue #97553).
+    expect(
+      classifyOAuthRefreshFailure(
+        "Failed to authenticate. API Error: 401 Invalid authentication credentials",
+      ),
+    ).toEqual({
+      provider: null,
+      reason: "revoked",
+    });
+  });
+
+  it("does not classify a bare 401 as a refresh failure", () => {
+    // A network 401 without the "failed to authenticate" signal must not be
+    // promoted to an OAuth refresh failure — guards against mis-hinting on
+    // unrelated 401 responses from other surfaces.
+    expect(classifyOAuthRefreshFailure("Request failed with status 401")).toBeNull();
+    expect(classifyOAuthRefreshFailureReason("Request failed with status 401")).toBeNull();
   });
 });

--- a/src/agents/auth-profiles/oauth-refresh-failure.ts
+++ b/src/agents/auth-profiles/oauth-refresh-failure.ts
@@ -40,7 +40,14 @@ function isOAuthRefreshFailureMessage(message: string): boolean {
   return (
     lower.includes("oauth token refresh failed") ||
     lower.includes("access token could not be refreshed") ||
-    lower.includes("authentication session could not be refreshed automatically")
+    lower.includes("authentication session could not be refreshed automatically") ||
+    // External CLI subprocesses (e.g. the `claude` CLI spawned under
+    // CLAUDE_CLI_CLEAR_ENV, which strips the API key so the subprocess can only
+    // authenticate via its stored OAuth token) emit their own 401 message on
+    // token expiry. Recognise it so the re-auth hint fires instead of a generic
+    // "something went wrong" error. Requires both the authenticate and 401
+    // signals together to avoid matching unrelated network 401 responses.
+    (lower.includes("failed to authenticate") && lower.includes("401"))
   );
 }
 
@@ -74,6 +81,14 @@ export function classifyOAuthRefreshFailureReason(
     return "invalid_refresh_token";
   }
   if (lower.includes("expired or revoked") || lower.includes("revoked")) {
+    return "revoked";
+  }
+  // An external CLI subprocess 401 (e.g. `claude` CLI under CLAUDE_CLI_CLEAR_ENV)
+  // means its stored OAuth token is no longer valid — treat as revoked/expired so
+  // the consumer surfaces the "login expired" re-auth hint rather than a generic
+  // failure. Mirrors the isOAuthRefreshFailureMessage gating: requires both
+  // "failed to authenticate" and 401 together.
+  if (lower.includes("failed to authenticate") && lower.includes("401")) {
     return "revoked";
   }
   return null;


### PR DESCRIPTION
<!-- Linked context -->
Closes #97553

## What Problem This Solves

Fixes an issue where operators using a `claude-cli/*` model would see a generic *"⚠️ Something went wrong while processing your request..."* error when the Claude CLI's stored OAuth token expired, instead of the actionable re-auth hint that already exists in the codebase. The affected workflow is any channel reply (Telegram, etc.) after the `claude` subprocess's OAuth token has expired — the operator gets no guidance on how to recover.

## Why This Change Was Made

The `claude` subprocess is spawned under `CLAUDE_CLI_CLEAR_ENV`, which strips `ANTHROPIC_API_KEY`, so it can only authenticate via its stored OAuth token. On expiry it emits its own message (`Failed to authenticate. API Error: 401 ...`), but `isOAuthRefreshFailureMessage` only recognised openclaw's own refresh-machinery strings, so `classifyOAuthRefreshFailure` returned `null` and the re-auth hint branch was never reached.

The fix recognises the subprocess 401 as an OAuth refresh failure and classifies it as `revoked`/expired, so `buildExternalRunFailureReply` surfaces the existing *"Model login expired ... Re-auth with ..."* hint. The match requires **both** `"failed to authenticate"` **and** `"401"` together — this avoids promoting unrelated network 401 responses to OAuth failures. No new reason enum is needed; the existing `revoked` already carries the expired/invalid semantics the consumer keys on.

## User Impact

Operators using `claude-cli/*` models now see a clear, actionable re-auth hint when the CLI's OAuth token expires, instead of an opaque generic error — telling them exactly which command to run (`openclaw models auth login --provider claude-cli`) to recover. Unrelated 401 errors are not affected and are not misclassified.

## Evidence

### Real behavior — before vs after (real source function, real inputs)

The real `classifyOAuthRefreshFailure()` was driven with real-world inputs (no mocks) on both `main` (pre-fix) and this branch (post-fix). Terminal output below.

**BEFORE (main) — claude-cli 401 is NOT recognised, so the re-auth hint never fires:**
```
[claude-cli 401 (issue #97553 exact output)]
  input : "Failed to authenticate. API Error: 401 Invalid authentication credentials"
  result: null

[openclaw own refresh-failure (baseline, must keep working)]
  input : "OAuth token refresh failed for claude-cli: invalid_grant"
  result: {"provider":"claude-cli","reason":"invalid_grant"}

[bare network 401 (must NOT be misclassified)]
  input : "Request failed with status 401"
  result: null
```

**AFTER (this branch) — claude-cli 401 now classifies as revoked/expired, triggering the re-auth hint, while baseline and negative cases are unchanged:**
```
[claude-cli 401 (issue #97553 exact output)]
  input : "Failed to authenticate. API Error: 401 Invalid authentication credentials"
  result: {"provider":null,"reason":"revoked"}

[openclaw own refresh-failure (baseline, must keep working)]
  input : "OAuth token refresh failed for claude-cli: invalid_grant"
  result: {"provider":"claude-cli","reason":"invalid_grant"}

[bare network 401 (must NOT be misclassified)]
  input : "Request failed with status 401"
  result: null
```

The null → `{"reason":"revoked"}` change on the claude-cli 401 input is what makes the consumer (`agent-runner-execution.ts`) render *"⚠️ Model login expired on the gateway ... Re-auth with ..."* instead of the generic failure text.

### Focused tests

`vitest run src/agents/auth-profiles/oauth-refresh-failure.test.ts` → **4/4 passing** (2 existing + 2 new regression cases: the claude-cli 401 now classifies as revoked; a bare 401 is not misclassified). Reverse-proof confirmed: reverting only the source fix makes the claude-cli test fail; restoring it passes.

### Local checks

- `oxlint` on changed files → 0 warnings, 0 errors
- `oxfmt --check` on changed files → format OK
- `check-lint` (CI, full rule set) → pass
