### PR TITLE
fix(gateway): log terminal persistence failures in chat abort cleanup

### DIFF
--- a/src/gateway/chat-abort.test.ts
+++ b/src/gateway/chat-abort.test.ts
@@ -265,6 +265,45 @@ describe("registerChatAbortController", () => {
     expect(chatAbortControllers.has("run-persisting")).toBe(false);
   });
 
+  it("logs an error and still removes the registration when terminal persistence fails", async () => {
+    const chatAbortControllers = new Map<string, ChatAbortControllerEntry>();
+    const errorSpy = vi.fn();
+    const log = { error: errorSpy } as unknown as import("../logging/subsystem.js").SubsystemLogger;
+    const registration = registerChatAbortController({
+      chatAbortControllers,
+      runId: "run-persist-failure",
+      sessionId: "sess-1",
+      sessionKey: "main",
+      timeoutMs: 60_000,
+      log,
+    });
+    const persistenceError = new Error("persist failed");
+    let rejectPersistence: (err: Error) => void = () => undefined;
+    const persistence = new Promise<void>((_, reject) => {
+      rejectPersistence = reject;
+    });
+    if (!registration.entry) {
+      throw new Error("expected registered entry");
+    }
+    registration.entry.projectSessionActive = false;
+    registration.entry.projectSessionTerminalPersistence = persistence;
+
+    registration.cleanup();
+
+    expect(chatAbortControllers.has("run-persist-failure")).toBe(true);
+    rejectPersistence(persistenceError);
+    await expect(persistence).rejects.toThrow("persist failed");
+    await Promise.resolve();
+    expect(errorSpy).toHaveBeenCalledOnce();
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Failed to persist chat abort terminal state for run run-persist-failure",
+      ),
+      expect.objectContaining({ error: persistenceError }),
+    );
+    expect(chatAbortControllers.has("run-persist-failure")).toBe(false);
+  });
+
   it("retains registrations when terminal lifecycle was observed before caller cleanup", () => {
     const chatAbortControllers = new Map<string, ChatAbortControllerEntry>();
     const registration = registerChatAbortController({

--- a/src/gateway/chat-abort.ts
+++ b/src/gateway/chat-abort.ts
@@ -10,7 +10,9 @@ import { createAgentRunRestartAbortError } from "../agents/run-termination.js";
 import { isAbortRequestText } from "../auto-reply/reply/abort-primitives.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { emitAgentEvent, getAgentEventLifecycleGeneration } from "../infra/agent-events.js";
+import { formatErrorMessage } from "../infra/errors.js";
 import { jsonUtf8Bytes } from "../infra/json-utf8-bytes.js";
+import type { SubsystemLogger } from "../logging/subsystem.js";
 import { projectLiveAssistantBufferedText } from "./live-chat-projector.js";
 import { createChatAbortMarker, type ChatAbortMarker } from "./server-chat-state.js";
 
@@ -150,6 +152,7 @@ export function registerChatAbortController(params: {
   lifecycleGeneration?: string;
   now?: number;
   expiresAtMs?: number;
+  log?: SubsystemLogger;
 }): RegisteredChatAbortController {
   const controller = new AbortController();
   const cleanup = (opts?: { force?: boolean }) => {
@@ -173,7 +176,11 @@ export function registerChatAbortController(params: {
               params.chatAbortControllers.delete(params.runId);
             }
           })
-          .catch(() => {
+          .catch((err) => {
+            params.log?.error(
+              `Failed to persist chat abort terminal state for run ${params.runId}: ${formatErrorMessage(err)}`,
+              { error: err },
+            );
             if (params.chatAbortControllers.get(params.runId)?.controller === controller) {
               params.chatAbortControllers.delete(params.runId);
             }

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -105,6 +105,7 @@ describe("agent event handler", () => {
     const toolEventRecipients = createToolEventRecipientRegistry();
     const sessionEventSubscribers = createSessionEventSubscriberRegistry();
     const sessionMessageSubscribers = createSessionMessageSubscriberRegistry();
+    const log = { error: vi.fn() } as unknown as import("../logging/subsystem.js").SubsystemLogger;
 
     const handler = createAgentEventHandler({
       broadcast,
@@ -124,6 +125,7 @@ describe("agent event handler", () => {
       markTrackedRunTerminalPersisted: params?.markTrackedRunTerminalPersisted,
       trackTrackedRunTerminalPersistence: params?.trackTrackedRunTerminalPersistence,
       resolveActiveLifecycleGenerationForRun: params?.resolveActiveLifecycleGenerationForRun,
+      log,
     });
 
     return {
@@ -139,6 +141,7 @@ describe("agent event handler", () => {
       sessionEventSubscribers,
       sessionMessageSubscribers,
       handler,
+      log,
     };
   }
 
@@ -2502,7 +2505,7 @@ describe("agent event handler", () => {
     });
     persistGatewaySessionLifecycleEventMock.mockRejectedValueOnce(new Error("disk full"));
     const markTrackedRunTerminalPersisted = vi.fn();
-    const { broadcastToConnIds, handler, sessionEventSubscribers } = createHarness({
+    const { broadcastToConnIds, handler, log, sessionEventSubscribers } = createHarness({
       resolveSessionKeyForRun: () => "session-failed-write",
       lifecycleErrorRetryGraceMs: 0,
       markTrackedRunTerminalPersisted,
@@ -2533,6 +2536,13 @@ describe("agent event handler", () => {
       abortedLastRun: false,
     });
     expect(markTrackedRunTerminalPersisted).not.toHaveBeenCalled();
+    expect(log.error).toHaveBeenCalledOnce();
+    expect(log.error).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Failed to persist terminal lifecycle event for run run-failed-write",
+      ),
+      expect.objectContaining({ runId: "run-failed-write" }),
+    );
   });
 
   it("does not clear a same-id retry when an old restart terminal arrives", () => {

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -7,8 +7,9 @@ import { DEFAULT_HEARTBEAT_ACK_MAX_CHARS, stripHeartbeatToken } from "../auto-re
 import { normalizeVerboseLevel } from "../auto-reply/thinking.js";
 import { getRuntimeConfig } from "../config/io.js";
 import { type AgentEventPayload, getAgentRunContext } from "../infra/agent-events.js";
-import { detectErrorKind, type ErrorKind } from "../infra/errors.js";
+import { detectErrorKind, formatErrorMessage, type ErrorKind } from "../infra/errors.js";
 import { resolveHeartbeatVisibility } from "../infra/heartbeat-visibility.js";
+import type { SubsystemLogger } from "../logging/subsystem.js";
 import { isAcpSessionKey, isSubagentSessionKey } from "../sessions/session-key-utils.js";
 import { resolveAssistantEventPhase } from "../shared/chat-message-content.js";
 import { setSafeTimeout } from "../utils/timer-delay.js";
@@ -290,6 +291,7 @@ export type AgentEventHandlerOptions = {
     persistence: Promise<void>;
   }) => void;
   resolveActiveLifecycleGenerationForRun?: (runId: string) => string | undefined;
+  log?: SubsystemLogger;
 };
 
 function roundedChatSendTimingMs(value: number): number {
@@ -314,6 +316,7 @@ export function createAgentEventHandler({
   markTrackedRunTerminalPersisted,
   trackTrackedRunTerminalPersistence,
   resolveActiveLifecycleGenerationForRun = () => undefined,
+  log,
 }: AgentEventHandlerOptions) {
   type TerminalLifecycleOptions = {
     skipChatErrorFinal?: boolean;
@@ -716,7 +719,11 @@ export function createAgentEventHandler({
             markPersisted();
             broadcastSessionChange();
           })
-          .catch(() => {
+          .catch((err) => {
+            log?.error(
+              `Failed to persist terminal lifecycle event for run ${evt.runId}: ${formatErrorMessage(err)}`,
+              { error: err, runId: evt.runId },
+            );
             // Persistence recovery remains tracked by the controller entry, but
             // subscribers still need a terminal projection instead of hanging.
             broadcastSessionChange(evt);

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -2547,6 +2547,7 @@ export const agentHandlers: GatewayRequestHandlers = {
         controlUiVisible: !suppressVisibleSessionEffects,
         kind: "agent",
         lifecycleGeneration,
+        log: context.logGateway,
       });
       const existingRunAbort = context.chatAbortControllers.get(runId);
       if (!activeRunAbort.registered && existingRunAbort) {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -3655,6 +3655,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       authProviderId: resolvedSessionAuthProvider,
       kind: "chat-send",
       lifecycleGeneration,
+      log: context.logGateway,
     });
     if (!activeRunAbort.registered) {
       respond(true, { runId: clientRunId, status: "in_flight" as const }, undefined, {

--- a/src/gateway/server-runtime-subscriptions.ts
+++ b/src/gateway/server-runtime-subscriptions.ts
@@ -1,6 +1,8 @@
 // Gateway event subscription wiring for agent, heartbeat, transcript, and lifecycle broadcasts.
 import { clearAgentRunContext, onAgentEvent } from "../infra/agent-events.js";
+import { formatErrorMessage } from "../infra/errors.js";
 import { onHeartbeatEvent } from "../infra/heartbeat-events.js";
+import type { SubsystemLogger } from "../logging/subsystem.js";
 import { onSessionLifecycleEvent } from "../sessions/session-lifecycle-events.js";
 import { onInternalSessionTranscriptUpdate } from "../sessions/transcript-events.js";
 import type { ChatAbortControllerEntry, RestartRecoveryCandidate } from "./chat-abort.js";
@@ -28,6 +30,7 @@ export function startGatewayEventSubscriptions(params: {
   sessionMessageSubscribers: SessionMessageSubscriberRegistry;
   chatAbortControllers: Map<string, ChatAbortControllerEntry>;
   restartRecoveryCandidates: Map<string, RestartRecoveryCandidate>;
+  log?: SubsystemLogger;
 }) {
   let agentEventHandlerPromise: Promise<
     ReturnType<typeof import("./server-chat.js").createAgentEventHandler>
@@ -49,6 +52,7 @@ export function startGatewayEventSubscriptions(params: {
         toolEventRecipients: params.toolEventRecipients,
         sessionEventSubscribers: params.sessionEventSubscribers,
         sessionMessageSubscribers: params.sessionMessageSubscribers,
+        log: params.log,
         clearTrackedActiveRun: ({ runId, clientRunId }) => {
           const candidateRunIds = runId === clientRunId ? [runId] : [runId, clientRunId];
           for (const candidateRunId of candidateRunIds) {
@@ -99,7 +103,13 @@ export function startGatewayEventSubscriptions(params: {
               entry.projectSessionTerminalPersistence = persistence;
               if (entry.registrationCleanupRequested === true) {
                 void persistence
-                  .catch(() => undefined)
+                  .catch((err) => {
+                    params.log?.error(
+                      `Failed to persist tracked terminal state for run ${candidateRunId}: ${formatErrorMessage(err)}`,
+                      { error: err, runId: candidateRunId },
+                    );
+                    return undefined;
+                  })
                   .then(() => {
                     if (params.chatAbortControllers.get(candidateRunId) === entry) {
                       params.chatAbortControllers.delete(candidateRunId);

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -1195,6 +1195,7 @@ export async function startGatewayServer(
         sessionMessageSubscribers,
         chatAbortControllers,
         restartRecoveryCandidates,
+        log,
       }),
     );
     Object.assign(runtimeState, runtimeSubscriptions);


### PR DESCRIPTION
Fixes #97795

## Summary

Fix silent swallowing of terminal-state persistence failures across three Gateway boundaries:

1. `src/gateway/chat-abort.ts` — cleanup catch block
2. `src/gateway/server-runtime-subscriptions.ts` — delayed cleanup ordering (persistence attached after `cleanup()` was requested)
3. `src/gateway/server-chat.ts` — owner-side terminal lifecycle persistence fallback catch

## Real Behavior Proof

Environment: Linux, Node v22.23.1, pnpm 11.2.2, worktree SHA 1052652a71

Before fix (new regression test on old code):
```bash
$ pnpm test src/gateway/chat-abort.test.ts
AssertionError: expected "vi.fn()" to be called once, but got 0 times
Tests  4 failed | 124 passed (128)
```

After fix:
```bash
$ node scripts/run-vitest.mjs src/gateway/chat-abort.test.ts src/gateway/server-chat.agent-events.test.ts
Test Files  6 passed (6)
     Tests  326 passed (326)
```

Real behavior proof (chat-abort cleanup path):
```bash
$ tsx /tmp/proof-97795.mjs
[PROOF LOGGER] Failed to persist chat abort terminal state for run proof-run-1: simulated persistence failure {"error":{}}
Controllers remaining after cleanup: 0
```

The script creates a `registerChatAbortController` registration with a real `log.error` logger, attaches a rejecting `projectSessionTerminalPersistence` promise, calls `cleanup()`, and observes the diagnostic log plus correct controller removal.

Lint / Format checks (changed files):
```bash
$ oxlint src/gateway/chat-abort.ts src/gateway/chat-abort.test.ts src/gateway/server-methods/agent.ts src/gateway/server-methods/chat.ts src/gateway/server-chat.ts src/gateway/server-chat.agent-events.test.ts src/gateway/server-runtime-subscriptions.ts src/gateway/server.impl.ts
Found 0 warnings and 0 errors.

$ oxfmt --check ...
All matched files use the correct format.
```

## Regression Test Plan

- `src/gateway/chat-abort.test.ts`
  - Added `logs an error and still removes the registration when terminal persistence fails`
- `src/gateway/server-chat.agent-events.test.ts`
  - Updated `broadcasts a terminal fallback snapshot when persistence fails` to assert `log.error` is called

## Root Cause

Three separate `.catch(() => { ... })` handlers discarded the rejection reason:
- `src/gateway/chat-abort.ts:176`
- `src/gateway/server-runtime-subscriptions.ts:100`
- `src/gateway/server-chat.ts:714`

## Implementation Plan Details

1. Add optional `log?: SubsystemLogger` to `registerChatAbortController`;
2. Add optional `log?: SubsystemLogger` to `startGatewayEventSubscriptions` and pass it to `createAgentEventHandler`;
3. Add optional `log?: SubsystemLogger` to `createAgentEventHandler`;
4. Pass `context.logGateway` from `agent.ts` / `chat.ts` to `registerChatAbortController`;
5. Pass `log` from `server.impl.ts` to `startGatewayEventSubscriptions`;
6. Call `log?.error(...)` in all three catch blocks, using `formatErrorMessage(err)`;
7. Add/update regression tests;
8. Demonstrate real log output for the chat-abort path with a standalone script.

## Change Details

- `src/gateway/chat-abort.ts`
  - Import `formatErrorMessage`, `SubsystemLogger`
  - `registerChatAbortController` params gain `log?: SubsystemLogger`
  - Cleanup catch now logs the error

- `src/gateway/server-methods/agent.ts` / `chat.ts`
  - `registerChatAbortController(...)` calls add `log: context.logGateway`

- `src/gateway/server-chat.ts`
  - Import `formatErrorMessage`, `SubsystemLogger`
  - `AgentEventHandlerOptions` gains `log?: SubsystemLogger`
  - `createAgentEventHandler` destructures `log`
  - Terminal lifecycle persistence catch now logs the error

- `src/gateway/server-runtime-subscriptions.ts`
  - Import `formatErrorMessage`, `SubsystemLogger`
  - `startGatewayEventSubscriptions` params gain `log?: SubsystemLogger`
  - Delayed cleanup catch now logs the error
  - Pass `log` to `createAgentEventHandler`

- `src/gateway/server.impl.ts`
  - `startGatewayEventSubscriptions(...)` call adds `log`

- `src/gateway/chat-abort.test.ts`
  - New regression test

- `src/gateway/server-chat.agent-events.test.ts`
  - `createHarness` creates a mock logger and passes it to `createAgentEventHandler`
  - Updated persistence-failure test asserts `log.error` is called

## Test Points

- chat-abort new test fails before fix (RED) and passes after fix (GREEN)
- server-chat existing persistence-failure test now asserts `log.error` and passes
- All 326 relevant tests pass
- Changed files pass oxlint / oxfmt
- `pnpm tsgo:core`, `pnpm tsgo:core:test`, `pnpm check:import-cycles` pass

## Next Steps

1. Commit the updated changes;
2. Force-push the updated branch (amended commit);
3. Paste the updated PR body;
4. Comment `@clawsweeper re-review`.

