### PR TITLE
fix(memory): detect unindexed session transcripts in status mode (fixes #97814)

### DIFF
--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -2290,4 +2290,26 @@ describe("memory index", () => {
       restoreMemoryIndexStateDir();
     }
   });
+  it("status-purpose manager detects unindexed session transcripts as dirty", async () => {
+    // Regression test for #97814: plain openclaw memory status (purpose: status)
+    // must report dirty=true when session files exist without index rows.
+    const cfg = createCfg({ sources: ["sessions"], sessionMemory: true });
+    const stateDirName = ".state-status-dirty-test";
+    setMemoryIndexStateDir(path.join(workspaceDir, stateDirName));
+    try {
+      const sessionsDir = resolveSessionTranscriptsDirForAgent("main");
+      await fs.mkdir(sessionsDir, { recursive: true });
+      const transcriptPath = path.join(sessionsDir, "status-dirty-test.jsonl");
+      await fs.writeFile(transcriptPath, JSON.stringify({ type: "test", ts: 1 }) + "\n");
+
+      const manager = await getFreshManager(cfg, "status");
+      managersForCleanup.add(manager);
+
+      const result = manager.status();
+      expect(result.dirty).toBe(true);
+    } finally {
+      restoreMemoryIndexStateDir();
+    }
+  });
+
 });

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -435,6 +435,15 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       this.batch = this.resolveBatchConfig();
       if (!transient) {
         this.ensureSessionStartupCatchup();
+      } else if (params.purpose === "status" && this.sources.has("sessions")) {
+        // Lightweight detection for status mode: check for unindexed session
+        // files on disk without triggering a full sync. If found, sessionsDirty
+        // is set to true so memory status reports dirty=true instead of a false
+        // clean state. The full catchup + sync runs on the next non-transient
+        // manager cycle (CLI sync or normal runtime init).
+        void this.markSessionStartupCatchupDirtyFiles().catch((err: unknown) => {
+          log.warn("memory status session dirty detection failed: " + String(err));
+        });
       }
     } catch (err) {
       closeMemoryDatabase(this.db);

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -355,8 +355,8 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       pending: INDEX_CACHE_PENDING,
       key,
       bypassCache: transient,
-      create: async () =>
-        new MemoryIndexManager({
+      create: async () => {
+        const manager = new MemoryIndexManager({
           cacheKey: key,
           cfg,
           agentId,
@@ -364,7 +364,20 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
           settings,
           providerRequirement,
           purpose: params.purpose,
-        }),
+        });
+        // Lightweight dirty-file detection for status mode: check for unindexed
+        // session files on disk without triggering a full sync. This runs before
+        // any caller reads manager.status(), so the dirty flag is accurate when
+        // status() reads sessionsDirty.
+        if (purpose === "status" && manager.sources.has("sessions")) {
+          try {
+            await manager.markSessionStartupCatchupDirtyFiles();
+          } catch (err) {
+            log.warn("memory status session dirty detection failed: " + String(err));
+          }
+        }
+        return manager;
+      },
     });
   }
 
@@ -435,15 +448,6 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       this.batch = this.resolveBatchConfig();
       if (!transient) {
         this.ensureSessionStartupCatchup();
-      } else if (params.purpose === "status" && this.sources.has("sessions")) {
-        // Lightweight detection for status mode: check for unindexed session
-        // files on disk without triggering a full sync. If found, sessionsDirty
-        // is set to true so memory status reports dirty=true instead of a false
-        // clean state. The full catchup + sync runs on the next non-transient
-        // manager cycle (CLI sync or normal runtime init).
-        void this.markSessionStartupCatchupDirtyFiles().catch((err: unknown) => {
-          log.warn("memory status session dirty detection failed: " + String(err));
-        });
       }
     } catch (err) {
       closeMemoryDatabase(this.db);


### PR DESCRIPTION
## What Problem This Solves

Fixes #97814.

`openclaw memory status` reports `dirty=false` when unindexed session transcripts exist on disk. This is a **false-clean state**: the operator sees no backlog, but memory search silently misses the unindexed transcript.

**Root cause:** The status-purpose `MemoryIndexManager` init skips `ensureSessionStartupCatchup()`, which is the only path that detects on-disk session files without corresponding `memory_index_sources` rows and marks `sessionsDirty=true`.

## Changes Made

Move the status-mode dirty detection from the constructor (fire-and-forget via `void`) into the `create()` factory method where it is **awaited** before returning the manager. This guarantees `sessionsDirty` is set before any caller reads `manager.status()`.

- Runs `markSessionStartupCatchupDirtyFiles()` in status mode — checks for on-disk session files without corresponding `memory_index_sources` rows
- Does **not** trigger a full `sync()` — status remains lightweight
- The full catchup+sync runs on the next non-transient manager cycle (CLI sync or normal runtime init)

## Evidence

### Real CLI output — `openclaw memory status --json` (after fix)

```bash
$ echo '{"type":"message","role":"user","content":"proof for #97814"}' \
  > ~/.openclaw/agents/main/sessions/proof-97814.jsonl

$ openclaw memory status --json
[
  {
    "status": {
      "dirty": true,         ← BEFORE fix: false (false-clean, bug #97814)
      "files": 104,          ← includes the unindexed session file
      "chunks": 820
    }
  }
]
```

### Regression test (exercises actual `purpose: "status"` manager)

```
✓ status-purpose manager detects unindexed session transcripts as dirty
```

Creates a session file without an index row, creates a `purpose: "status"` manager, verifies `status().dirty === true`.

### Unit tests (22/22 all green)

```
 Test Files  2 passed (2)
      Tests  21 passed (21)  # status-state + startup-catchup
 Test Files  1 passed (1)
      Tests   1 passed (1)   # status-purpose regression test
```

## Review

- Manually verified: code + regression test + real CLI output confirm the detection completes before `status()` reads the dirty flag
- AI-assisted: Yes