### PR TITLE
fix(ui): keep failed agent turns visibly failed [AI-assisted]

### DIFF
--- a/ui/src/ui/chat/build-chat-items.test.ts
+++ b/ui/src/ui/chat/build-chat-items.test.ts
@@ -1140,13 +1140,14 @@ function createAssistantCanvasBlock(params: { suffix: string }) {
 }
 
 describe("tool turn outcome annotation (#89683)", () => {
-  function failedTool(timestamp: number) {
+  function failedTool(timestamp: number, runId?: string) {
     return {
       role: "toolResult",
       toolName: "shell",
       content: JSON.stringify({ status: "failed", exitCode: 1 }),
       isError: true,
       timestamp,
+      ...(runId ? { runId } : {}),
     };
   }
   function userMsg(text: string, timestamp: number) {
@@ -1154,6 +1155,9 @@ describe("tool turn outcome annotation (#89683)", () => {
   }
   function assistantReply(text: string, timestamp: number) {
     return { role: "assistant", content: [{ type: "text", text }], timestamp };
+  }
+  function assistantRunReply(text: string, timestamp: number, runId: string) {
+    return { ...assistantReply(text, timestamp), runId };
   }
   function toolGroups(messages: unknown[]): MessageGroup[] {
     return messageGroups({ messages }).filter((group) => group.role === "tool");
@@ -1193,5 +1197,15 @@ describe("tool turn outcome annotation (#89683)", () => {
       failedTool(5),
     ]);
     expect(tools.map((group) => group.turnSucceeded)).toEqual([true, false]);
+  });
+
+  it("does not carry an agent-initiated reply across run boundaries", () => {
+    const tools = toolGroups([
+      failedTool(1, "run-terminal-failure"),
+      failedTool(2, "run-later-success"),
+      assistantRunReply("Recovered on the later turn.", 3, "run-later-success"),
+    ]);
+    expect(tools).toHaveLength(2);
+    expect(tools.map((group) => group.turnSucceeded)).toEqual([false, true]);
   });
 });

--- a/ui/src/ui/chat/build-chat-items.ts
+++ b/ui/src/ui/chat/build-chat-items.ts
@@ -89,6 +89,34 @@ function safeNormalizeMessage(message: unknown): NormalizedMessage | null {
   }
 }
 
+function messageTurnKey(message: unknown): string | null {
+  const record = asRecord(message);
+  if (!record) {
+    return null;
+  }
+  const metadata = asRecord(record.__openclaw);
+  const key = [
+    record.runId,
+    record.agentRunId,
+    record.turnId,
+    metadata?.runId,
+    metadata?.agentRunId,
+    metadata?.turnId,
+  ].find((value): value is string => typeof value === "string" && value.trim().length > 0);
+  return key?.trim() ?? null;
+}
+
+function groupTurnKey(group: MessageGroup): string | null {
+  const keys = new Set<string>();
+  for (const entry of group.messages) {
+    const key = messageTurnKey(entry.message);
+    if (key) {
+      keys.add(key);
+    }
+  }
+  return keys.size === 1 ? (keys.values().next().value ?? null) : null;
+}
+
 function extractChatMessagePreview(toolMessage: unknown): {
   preview: Extract<NonNullable<ToolCard["preview"]>, { kind: "canvas" }>;
   text: string | null;
@@ -193,17 +221,23 @@ function groupMessages(items: ChatItem[]): Array<ChatItem | MessageGroup> {
 
     const normalized = normalizeMessage(item.message);
     const role = normalizeRoleForGrouping(normalized.role);
+    const roleKey = role.toLowerCase();
     const senderLabel =
-      role.toLowerCase() === "user" || role.toLowerCase() === "assistant"
-        ? (normalized.senderLabel ?? null)
-        : null;
+      roleKey === "user" || roleKey === "assistant" ? (normalized.senderLabel ?? null) : null;
+    const itemTurnKey = messageTurnKey(item.message);
     const timestamp = normalized.timestamp || Date.now();
-    const shouldSplitBySender = role.toLowerCase() === "user" || role.toLowerCase() === "assistant";
+    const shouldSplitBySender = roleKey === "user" || roleKey === "assistant";
+    const currentTurnKey = currentGroup ? groupTurnKey(currentGroup) : null;
+    const shouldSplitByTurn =
+      (roleKey === "assistant" || roleKey === "tool") &&
+      currentGroup?.role === role &&
+      Boolean(itemTurnKey && currentTurnKey && itemTurnKey !== currentTurnKey);
 
     if (
       !currentGroup ||
       currentGroup.role !== role ||
-      (shouldSplitBySender && currentGroup.senderLabel !== senderLabel)
+      (shouldSplitBySender && currentGroup.senderLabel !== senderLabel) ||
+      shouldSplitByTurn
     ) {
       if (currentGroup) {
         result.push(currentGroup);
@@ -348,12 +382,14 @@ function assistantGroupHasReplyText(group: MessageGroup): boolean {
 // failure (e.g. a no-match search) must not render as a primary error banner
 // once a clean reply exists. Backward pass: a user group ends the turn
 // downstream; an assistant reply marks success for earlier tool groups in the
-// same turn. turnSucceeded stays undefined for terminal or in-progress failures,
-// preserving the existing error banner.
+// same turn. Explicit run/turn metadata scopes agent-initiated turns that have
+// no user boundary; legacy transcripts without that metadata still use the user
+// boundary fallback. Terminal or in-progress failures keep the error banner.
 function annotateToolTurnOutcome(
   items: Array<ChatItem | MessageGroup>,
 ): Array<ChatItem | MessageGroup> {
   let sawAssistantReply = false;
+  const successfulTurnKeys = new Set<string>();
   for (let i = items.length - 1; i >= 0; i -= 1) {
     const item = items[i];
     if (item.kind !== "group") {
@@ -362,12 +398,19 @@ function annotateToolTurnOutcome(
     const role = item.role.toLowerCase();
     if (role === "user") {
       sawAssistantReply = false;
+      successfulTurnKeys.clear();
     } else if (role === "assistant") {
       if (assistantGroupHasReplyText(item)) {
-        sawAssistantReply = true;
+        const turnKey = groupTurnKey(item);
+        if (turnKey) {
+          successfulTurnKeys.add(turnKey);
+        } else {
+          sawAssistantReply = true;
+        }
       }
     } else if (role === "tool") {
-      item.turnSucceeded = sawAssistantReply;
+      const turnKey = groupTurnKey(item);
+      item.turnSucceeded = turnKey ? successfulTurnKeys.has(turnKey) : sawAssistantReply;
     }
   }
   return items;


### PR DESCRIPTION
Closes #97849

## What Problem This Solves

Fixes an issue where users reviewing cron, scheduled, or autonomous Control UI/WebChat sessions could see a genuinely failed earlier agent-initiated turn as successful when a later adjacent run produced an assistant reply.

## Why This Change Was Made

The shared chat item projection now scopes tool-error success suppression to explicit run/turn metadata (`runId`, `agentRunId`, `turnId`, and the same keys under `__openclaw`). Adjacent assistant/tool display groups split when that metadata changes, while legacy transcripts without run metadata keep the existing user-boundary fallback from #90122.

## User Impact

Failed autonomous turns stay visibly failed instead of silently collapsing their red tool-error banner. The prior behavior for a failed internal tool followed by a same-run assistant reply is preserved.

## Evidence

Behavior addressed: a genuinely failed agent-initiated turn was marked as succeeded when a later adjacent agent turn produced an assistant reply.

Real environment tested: local OpenClaw source checkout on current `main` fast-forwarded to `6de357ad47`, using the exported `buildChatItems` projection and the grouped renderer unit coverage.

Exact steps or command run after this patch:

```bash
node scripts/run-vitest.mjs ui/src/ui/chat/build-chat-items.test.ts
node scripts/run-vitest.mjs ui/src/ui/chat/grouped-render.test.ts
node scripts/run-vitest.mjs ui/src/ui/chat/build-chat-items.test.ts ui/src/ui/chat/grouped-render.test.ts
git diff --check
```

Evidence after fix:

- `build-chat-items.test.ts`: 48 tests passed, including the new adjacent run-boundary regression.
- `grouped-render.test.ts`: 65 tests passed.
- Combined focused run: 113 tests passed.
- `git diff --check`: clean.

Observed result after fix: the earlier failed run keeps `turnSucceeded=false`, while the later run with the assistant reply is `turnSucceeded=true`.

What was not tested: no browser screenshot or live scheduled job was run; this is a shared projection fix covered at the deterministic UI model and renderer boundary. Local autoreview was attempted with `.agents/skills/autoreview/scripts/autoreview --mode local` but the Codex app rejected it under the external-review data-export policy, so no workaround was attempted.

AI-assisted: yes. I understand the change: it keeps the #90122 same-turn suppression behavior, but prevents explicit run/turn metadata from leaking a later reply backward into an earlier failed autonomous turn.
