### PR TITLE
fix(compaction): count bashExecution and summary turns in pre-prompt overflow precheck

### DIFF
--- a/src/agents/embedded-agent-runner/run/preemptive-compaction.bashexec.test.ts
+++ b/src/agents/embedded-agent-runner/run/preemptive-compaction.bashexec.test.ts
@@ -1,0 +1,85 @@
+import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
+import { describe, expect, it } from "vitest";
+import { convertToLlm } from "../../../../packages/agent-core/src/harness/messages.js";
+import {
+  estimateLlmBoundaryTokenPressure,
+  shouldPreemptivelyCompactBeforePrompt,
+} from "./preemptive-compaction.js";
+
+const BIG_OUTPUT = "build log line ".repeat(90000);
+
+function bashExecMessage(output = BIG_OUTPUT): AgentMessage {
+  return {
+    role: "bashExecution",
+    command: "npm run build",
+    output,
+    exitCode: 0,
+    cancelled: false,
+    truncated: false,
+    timestamp: 1,
+  } as unknown as AgentMessage;
+}
+
+function compactionSummaryMessage(summary: string): AgentMessage {
+  return {
+    role: "compactionSummary",
+    summary,
+    tokensBefore: 0,
+    timestamp: 1,
+  } as unknown as AgentMessage;
+}
+
+function providerTokenApprox(message: AgentMessage): number {
+  const [llm] = convertToLlm([message]);
+  const content =
+    llm && Array.isArray((llm as { content?: unknown }).content)
+      ? (llm as { content: { type: string; text?: string }[] }).content
+      : [];
+  const text = content
+    .filter((b) => b.type === "text")
+    .map((b) => b.text ?? "")
+    .join("");
+  return Math.ceil(text.length / 4);
+}
+
+describe("preemptive precheck counts bashExecution and summary turns", () => {
+  it("estimates a large bash turn near its provider-rendered size", () => {
+    const msg = bashExecMessage();
+    const realProviderTokens = providerTokenApprox(msg);
+    const precheckTokens = estimateLlmBoundaryTokenPressure({ messages: [msg], prompt: "" });
+
+    expect(realProviderTokens).toBeGreaterThan(50000);
+    expect(precheckTokens).toBeGreaterThanOrEqual(realProviderTokens);
+  });
+
+  it("counts compactionSummary text instead of bare boundary overhead", () => {
+    const msg = compactionSummaryMessage("recap ".repeat(20000));
+    const realProviderTokens = providerTokenApprox(msg);
+    const precheckTokens = estimateLlmBoundaryTokenPressure({ messages: [msg], prompt: "" });
+
+    expect(realProviderTokens).toBeGreaterThan(20000);
+    expect(precheckTokens).toBeGreaterThanOrEqual(realProviderTokens);
+  });
+
+  it("drops a bash turn excluded from context", () => {
+    const excluded = {
+      ...(bashExecMessage() as unknown as Record<string, unknown>),
+      excludeFromContext: true,
+    } as unknown as AgentMessage;
+
+    expect(estimateLlmBoundaryTokenPressure({ messages: [excluded], prompt: "" })).toBeLessThan(50);
+  });
+
+  it("routes an oversized bash transcript to compaction", () => {
+    const decision = shouldPreemptivelyCompactBeforePrompt({
+      messages: [bashExecMessage()],
+      prompt: "continue",
+      contextTokenBudget: 128000,
+      reserveTokens: 16384,
+    });
+
+    expect(decision.route).not.toBe("fits");
+    expect(decision.shouldCompact).toBe(true);
+    expect(decision.overflowTokens).toBeGreaterThan(0);
+  });
+});

--- a/src/agents/embedded-agent-runner/run/preemptive-compaction.ts
+++ b/src/agents/embedded-agent-runner/run/preemptive-compaction.ts
@@ -9,7 +9,14 @@ import {
   MIN_PROMPT_BUDGET_TOKENS,
 } from "../../agent-compaction-constants.js";
 import { SAFETY_MARGIN } from "../../compaction.js";
-import type { AgentMessage } from "../../runtime/index.js";
+import type { AgentMessage, BashExecutionMessage } from "../../runtime/index.js";
+import {
+  BRANCH_SUMMARY_PREFIX,
+  BRANCH_SUMMARY_SUFFIX,
+  bashExecutionToText,
+  COMPACTION_SUMMARY_PREFIX,
+  COMPACTION_SUMMARY_SUFFIX,
+} from "../../runtime/index.js";
 import { estimateToolResultReductionPotential } from "../tool-result-truncation.js";
 import type { PreemptiveCompactionRoute } from "./preemptive-compaction.types.js";
 
@@ -155,6 +162,30 @@ function estimateMessageTokenPressure(message: AgentMessage): number {
   if (isToolResultMessage(message)) {
     tokens += estimateToolResultContentTokenPressure(record.content);
     tokens += estimateIdentifierTokenPressure(record.toolName ?? record.tool_name);
+    return tokens;
+  }
+
+  if (record.role === "bashExecution") {
+    if (record.excludeFromContext === true) {
+      return 0;
+    }
+    tokens += estimateStringTokenPressure(
+      bashExecutionToText(record as unknown as BashExecutionMessage),
+    );
+    return tokens;
+  }
+
+  if (record.role === "branchSummary") {
+    const summary = typeof record.summary === "string" ? record.summary : "";
+    tokens += estimateStringTokenPressure(BRANCH_SUMMARY_PREFIX + summary + BRANCH_SUMMARY_SUFFIX);
+    return tokens;
+  }
+
+  if (record.role === "compactionSummary") {
+    const summary = typeof record.summary === "string" ? record.summary : "";
+    tokens += estimateStringTokenPressure(
+      COMPACTION_SUMMARY_PREFIX + summary + COMPACTION_SUMMARY_SUFFIX,
+    );
     return tokens;
   }
 


### PR DESCRIPTION
## What Problem This Solves

The pre-prompt overflow precheck silently under-counts `bashExecution` turns, so a context that holds large `!`-bash output (a `!cat` of a big file, build logs, test output) is scored as nearly empty. `shouldPreemptivelyCompactBeforePrompt` returns `route: "fits"`, `shouldCompact: false`, and the oversized prompt is submitted to the provider, which then rejects it as a context overflow. Bash-heavy sessions skip the very gate meant to keep them under the model limit.

The same under-count corrupts the persisted `SessionContextBudgetStatus` (`remainingPromptBudgetTokens`) and the mid-turn tool-result guard, which both consume the same estimate, so the budget a user sees for these sessions is wildly wrong.

## Why This Change Was Made

Root cause is `estimateMessageTokenPressure` in `src/agents/embedded-agent-runner/run/preemptive-compaction.ts`. It special-cases `toolResult`/`tool`/`assistant` and otherwise falls through to `tokens += estimateContentTokenPressure(record.content)`.

A `BashExecutionMessage` stores its payload in `command`/`output` and has no `content` field (`packages/agent-core/src/types.ts`), so `record.content` is `undefined` and the estimator returns `0`. The whole turn scores as just the boundary overhead (about 29 tokens after the safety margin) no matter how large the output.

The precheck runs on `normalizeMessagesForLlmBoundary(...)`, which does not call `convertToLlm`, so `bashExecution` reaches the gate raw. The actual provider request does expand it via `convertToLlm` -> `bashExecutionToText` into `command` plus the full output as real user text, so the provider sees the tokens the gate scored as ~29.

`branchSummary` and `compactionSummary` hit the same defect at lower magnitude: their payload is in a `summary` field, not `content`, so they too scored as bare overhead.

before:

```ts
  tokens += estimateContentTokenPressure(record.content);
  return tokens;
```

## User Impact

Bash-heavy and summary-bearing sessions no longer skip preflight compaction and submit an oversized prompt. The precheck now scores these turns at their true provider-rendered size, so it routes to compaction or tool-result truncation before the request instead of relying on post-overflow recovery (a failed provider round-trip plus latency). The reported `remainingPromptBudgetTokens` is now correct for these sessions.

## Evidence

Fix: estimate each affected role from the exact text `convertToLlm` renders for the provider.

after:

```ts
  if (record.role === "bashExecution") {
    if (record.excludeFromContext === true) {
      return 0;
    }
    tokens += estimateStringTokenPressure(
      bashExecutionToText(record as unknown as BashExecutionMessage),
    );
    return tokens;
  }

  if (record.role === "branchSummary") {
    const summary = typeof record.summary === "string" ? record.summary : "";
    tokens += estimateStringTokenPressure(BRANCH_SUMMARY_PREFIX + summary + BRANCH_SUMMARY_SUFFIX);
    return tokens;
  }

  if (record.role === "compactionSummary") {
    const summary = typeof record.summary === "string" ? record.summary : "";
    tokens += estimateStringTokenPressure(
      COMPACTION_SUMMARY_PREFIX + summary + COMPACTION_SUMMARY_SUFFIX,
    );
    return tokens;
  }
```

`excludeFromContext` bash records return `0` because `convertToLlm` drops them from the provider request entirely.

### Why this is the right boundary

The estimate must reflect what the provider actually receives. `convertToLlm` is the single function that renders these roles into provider text, so the estimator now reuses its exact renderers (`bashExecutionToText`, the summary prefix/suffix constants) rather than re-deriving sizes. All three affected roles are fixed in the same change; the remaining roles already route through the existing `content`/`toolResult`/`assistant` branches and are unaffected.

## Verification

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/preemptive-compaction.bashexec.test.ts` - 4 passed with the patch; the bash and summary cases fail on pristine main (estimate 29, route `fits`).
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/preemptive-compaction.test.ts` - 16 passed (adjacent suite, no regression).
- `node scripts/run-oxlint.mjs <changed files>` - clean.
- `oxfmt --check <changed files>` - clean.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json` and `-p test/tsconfig/tsconfig.core.test.json` - both clean.

## Real behavior proof
Behavior addressed: a session holding a large bash turn is scored as nearly empty by the pre-prompt overflow precheck, so it routes "fits" and submits an oversized prompt instead of compacting first.
Real environment tested: drove the real exported `estimateLlmBoundaryTokenPressure`, `shouldPreemptivelyCompactBeforePrompt`, and `convertToLlm` on pristine main 1052652a71 and on the patched tree with an identical two-message session (one user message plus one `bashExecution` turn whose output renders to 337,507 provider tokens), under a 128000 context budget with a 16384 reserve. Nothing was mocked; the real estimator, router, and provider-text renderer all ran.
Exact steps or command run after this patch: built the session, called `convertToLlm` to measure the provider-rendered token size, then called `estimateLlmBoundaryTokenPressure` and `shouldPreemptivelyCompactBeforePrompt` on the same session and printed their fields.
Evidence after fix:
```
# BEFORE (pristine main 1052652a71)
provider_tokens_in_request    = 337507
precheck_estimated_tokens     = 59
decision.route                = fits
decision.shouldCompact        = false
decision.overflowTokens       = 0
decision.estimatedPromptTokens= 59
# AFTER (this patch, identical inputs)
provider_tokens_in_request    = 337507
precheck_estimated_tokens     = 405068
decision.route                = compact_only
decision.shouldCompact        = true
decision.overflowTokens       = 293452
decision.estimatedPromptTokens= 405068
```
Observed result after fix: the same 337507-token bash turn that was scored at 59 and waved through as "fits" is now scored at its real rendered size, so the gate reports an overflow of 293452 and routes to compaction before the prompt is submitted.
What was not tested: no live provider request was issued (the provider-side overflow is the documented downstream consequence); the full build was not run because no module/packaging boundary changed.
