### PR TITLE
fix(gateway): log terminal session persistence failures in chat abort cleanup

### DIFF
--- a/src/gateway/chat-abort.terminal-persistence-logging.test.ts
+++ b/src/gateway/chat-abort.terminal-persistence-logging.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from "vitest";
+
+// Capture the subsystem logger's error spy so the test can assert that a
+// rejected terminal persistence is logged instead of silently swallowed.
+const loggerMocks = vi.hoisted(() => {
+  const error = vi.fn();
+  const noop = vi.fn();
+  const make = (): Record<string, unknown> => ({
+    subsystem: "gateway/chat-abort",
+    isEnabled: () => true,
+    trace: noop,
+    debug: noop,
+    info: noop,
+    warn: noop,
+    error,
+    fatal: noop,
+    raw: noop,
+    child: () => make(),
+  });
+  return { error, make };
+});
+
+vi.mock("../logging/subsystem.js", () => ({
+  createSubsystemLogger: () => loggerMocks.make(),
+}));
+
+import { type ChatAbortControllerEntry, registerChatAbortController } from "./chat-abort.js";
+
+describe("chat abort terminal persistence logging", () => {
+  it("logs and still releases the controller when terminal persistence rejects", async () => {
+    loggerMocks.error.mockClear();
+    const chatAbortControllers = new Map<string, ChatAbortControllerEntry>();
+    const registration = registerChatAbortController({
+      chatAbortControllers,
+      runId: "run-rejecting",
+      sessionId: "sess-1",
+      sessionKey: "main",
+      timeoutMs: 60_000,
+    });
+    if (!registration.entry) {
+      throw new Error("expected registered entry");
+    }
+    const persistence = Promise.reject(new Error("disk full"));
+    registration.entry.projectSessionActive = false;
+    registration.entry.projectSessionTerminalPersistence = persistence;
+
+    registration.cleanup();
+
+    // Settle the rejected persistence and the trailing cleanup microtask.
+    await persistence.catch(() => undefined);
+    await Promise.resolve();
+
+    expect(chatAbortControllers.has("run-rejecting")).toBe(false);
+    expect(loggerMocks.error).toHaveBeenCalledTimes(1);
+    expect(loggerMocks.error.mock.calls[0]?.[0]).toContain("run-rejecting");
+    expect(loggerMocks.error.mock.calls[0]?.[0]).toContain("disk full");
+  });
+});

--- a/src/gateway/chat-abort.ts
+++ b/src/gateway/chat-abort.ts
@@ -11,8 +11,11 @@ import { isAbortRequestText } from "../auto-reply/reply/abort-primitives.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { emitAgentEvent, getAgentEventLifecycleGeneration } from "../infra/agent-events.js";
 import { jsonUtf8Bytes } from "../infra/json-utf8-bytes.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import { projectLiveAssistantBufferedText } from "./live-chat-projector.js";
 import { createChatAbortMarker, type ChatAbortMarker } from "./server-chat-state.js";
+
+const log = createSubsystemLogger("gateway/chat-abort");
 
 const DEFAULT_CHAT_RUN_ABORT_GRACE_MS = 60_000;
 
@@ -173,7 +176,13 @@ export function registerChatAbortController(params: {
               params.chatAbortControllers.delete(params.runId);
             }
           })
-          .catch(() => {
+          .catch((err) => {
+            // A rejected terminal persistence must still release the controller,
+            // but log it so operators can see DB/file-system health failures
+            // instead of losing the terminal state silently.
+            log.error?.(
+              `failed to persist terminal session state for run ${params.runId}: ${String(err)}`,
+            );
             if (params.chatAbortControllers.get(params.runId)?.controller === controller) {
               params.chatAbortControllers.delete(params.runId);
             }

--- a/src/gateway/chat-abort.ts
+++ b/src/gateway/chat-abort.ts
@@ -176,7 +176,7 @@ export function registerChatAbortController(params: {
               params.chatAbortControllers.delete(params.runId);
             }
           })
-          .catch((err) => {
+          .catch((err: unknown) => {
             // A rejected terminal persistence must still release the controller,
             // but log it so operators can see DB/file-system health failures
             // instead of losing the terminal state silently.

--- a/src/gateway/server-runtime-subscriptions.ts
+++ b/src/gateway/server-runtime-subscriptions.ts
@@ -102,7 +102,7 @@ export function startGatewayEventSubscriptions(params: {
               entry.projectSessionTerminalPersistence = persistence;
               if (entry.registrationCleanupRequested === true) {
                 void persistence
-                  .catch((err) => {
+                  .catch((err: unknown) => {
                     // Still release the entry on failure, but surface the
                     // persistence error instead of swallowing it silently.
                     log.error?.(
@@ -124,7 +124,7 @@ export function startGatewayEventSubscriptions(params: {
                 sessionKey &&
                 sessionId
               ) {
-                void persistence.catch((err) => {
+                void persistence.catch((err: unknown) => {
                   // Fall back to restart recovery on failure, and log the
                   // persistence error so the fallback is not silent.
                   log.error?.(

--- a/src/gateway/server-runtime-subscriptions.ts
+++ b/src/gateway/server-runtime-subscriptions.ts
@@ -1,6 +1,7 @@
 // Gateway event subscription wiring for agent, heartbeat, transcript, and lifecycle broadcasts.
 import { clearAgentRunContext, onAgentEvent } from "../infra/agent-events.js";
 import { onHeartbeatEvent } from "../infra/heartbeat-events.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import { onSessionLifecycleEvent } from "../sessions/session-lifecycle-events.js";
 import { onInternalSessionTranscriptUpdate } from "../sessions/transcript-events.js";
 import type { ChatAbortControllerEntry, RestartRecoveryCandidate } from "./chat-abort.js";
@@ -10,6 +11,8 @@ import type {
   SessionMessageSubscriberRegistry,
   ToolEventRecipientRegistry,
 } from "./server-chat-state.js";
+
+const log = createSubsystemLogger("gateway/runtime-subscriptions");
 
 /** Register gateway runtime event subscriptions and return unsubscribe handles. */
 export function startGatewayEventSubscriptions(params: {
@@ -99,7 +102,13 @@ export function startGatewayEventSubscriptions(params: {
               entry.projectSessionTerminalPersistence = persistence;
               if (entry.registrationCleanupRequested === true) {
                 void persistence
-                  .catch(() => undefined)
+                  .catch((err) => {
+                    // Still release the entry on failure, but surface the
+                    // persistence error instead of swallowing it silently.
+                    log.error?.(
+                      `failed to persist terminal session state for run ${candidateRunId}: ${String(err)}`,
+                    );
+                  })
                   .then(() => {
                     if (params.chatAbortControllers.get(candidateRunId) === entry) {
                       params.chatAbortControllers.delete(candidateRunId);
@@ -115,7 +124,12 @@ export function startGatewayEventSubscriptions(params: {
                 sessionKey &&
                 sessionId
               ) {
-                void persistence.catch(() => {
+                void persistence.catch((err) => {
+                  // Fall back to restart recovery on failure, and log the
+                  // persistence error so the fallback is not silent.
+                  log.error?.(
+                    `failed to persist terminal session state for run ${candidateRunId}, falling back to restart recovery: ${String(err)}`,
+                  );
                   params.restartRecoveryCandidates.set(candidateRunId, {
                     runId: candidateRunId,
                     lifecycleGeneration,


### PR DESCRIPTION
## What Problem This Solves

Fixes #97795.

In the gateway, terminal session-store persistence is awaited in the chat-abort
cleanup path and in the runtime-subscription terminal handler. When that
persistence promise **rejects**, the existing `.catch()` blocks either release
the abort controller or fall back to restart recovery **without recording the
error**. A failed terminal-state write (e.g. database or file-system health
problem) therefore leaves no trace in logs or telemetry, so operators cannot see
that terminal state failed to persist.

Affected sites (all consume the same `projectSessionTerminalPersistence`
promise):

- `src/gateway/chat-abort.ts` cleanup `.catch(() => {})` — releases the controller silently.
- `src/gateway/server-runtime-subscriptions.ts` cleanup `.catch(() => undefined)` — releases the entry silently.
- `src/gateway/server-runtime-subscriptions.ts` fallback `.catch(() => { restartRecoveryCandidates.set(...) })` — falls back to restart recovery silently.

## Why This Change Was Made

The terminal persistence rejection is a real, operator-relevant signal (storage
health). Swallowing it hides production failures. This logs the rejection at
each site **before** the existing cleanup / restart-recovery behavior runs, so
the control-flow and fallback semantics are unchanged — only observability is
added.

The single-site fix the issue links would leave the sibling
runtime-subscription sites silent. #97813 takes that single-site approach: it
only touches `src/gateway/chat-abort.ts` and misses the two
`src/gateway/server-runtime-subscriptions.ts` consumers of the same
`projectSessionTerminalPersistence` promise — so a rejected terminal write in
the runtime-subscription cleanup or the restart-recovery fallback would still be
swallowed silently there. ClawSweeper's review explicitly names both the
"clean up" and "broadcast fallback state" paths, so all three sites are the
minimum complete fix unit; this PR covers them with no product-policy change.

## User Impact

No behavior change for end users. Operators now get a `gateway/chat-abort` /
`gateway/runtime-subscriptions` `error` log line when terminal session
persistence fails, instead of a silent swallow. No new config or surface.

## Evidence

- New regression `src/gateway/chat-abort.terminal-persistence-logging.test.ts`:
  a rejected `projectSessionTerminalPersistence` now logs `error` (with run id +
  reason) and still releases the controller. RED/GREEN confirmed — the test
  fails on current `main` (no log) and passes with the fix.
- Local validation (Mac, Node 22.22.3):
  - `node scripts/run-vitest.mjs run src/gateway/chat-abort.terminal-persistence-logging.test.ts src/gateway/chat-abort.test.ts` — 128 tests pass
  - `pnpm tsgo:core` and `pnpm tsgo:core:test`
  - `pnpm exec oxfmt --check` on the 3 touched files
  - `git diff --check origin/main...HEAD`
  - `gitleaks protect --staged --redact` — no leaks
- Net diff: 3 files, +84/-3.
