### PR TITLE
fix(runtime): type non-exiting runtime exits

### DIFF
--- a/docs/plugins/sdk-migration.md
+++ b/docs/plugins/sdk-migration.md
@@ -540,8 +540,8 @@ releases.
   | `plugin-sdk/channel-runtime` | Deprecated compatibility shim | Legacy channel runtime utilities only |
   | `plugin-sdk/channel-send-result` | Send result types | Reply result types |
   | `plugin-sdk/runtime-store` | Persistent plugin storage | `createPluginRuntimeStore` |
-  | `plugin-sdk/runtime` | Broad runtime helpers | Runtime/logging/backup/plugin-install helpers |
-  | `plugin-sdk/runtime-env` | Narrow runtime env helpers | Logger/runtime env, timeout, retry, and backoff helpers |
+  | `plugin-sdk/runtime` | Broad runtime helpers | Runtime/logging/backup/plugin-install helpers, including `RuntimeExitError` for non-exiting runtime control flow |
+  | `plugin-sdk/runtime-env` | Narrow runtime env helpers | Logger/runtime env, timeout, retry, backoff, and `RuntimeExitError` helpers |
   | `plugin-sdk/plugin-runtime` | Shared plugin runtime helpers | Plugin commands/hooks/http/interactive helpers |
   | `plugin-sdk/hook-runtime` | Hook pipeline helpers | Shared webhook/internal hook pipeline helpers |
   | `plugin-sdk/lazy-runtime` | Lazy runtime helpers | `createLazyRuntimeModule`, `createLazyRuntimeMethod`, `createLazyRuntimeMethodBinder`, `createLazyRuntimeNamedExport`, `createLazyRuntimeSurface` |

--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -215,8 +215,8 @@ usage endpoint failed or returned no usable usage data.
   <Accordion title="Runtime and storage subpaths">
     | Subpath | Key exports |
     | --- | --- |
-    | `plugin-sdk/runtime` | Broad runtime/logging/backup/plugin-install helpers |
-    | `plugin-sdk/runtime-env` | Narrow runtime env, logger, timeout, retry, and backoff helpers |
+    | `plugin-sdk/runtime` | Broad runtime/logging/backup/plugin-install helpers, including `RuntimeExitError` for non-exiting runtime control flow |
+    | `plugin-sdk/runtime-env` | Narrow runtime env, logger, timeout, retry, backoff, and `RuntimeExitError` helpers |
     | `plugin-sdk/browser-config` | Supported browser config facade for normalized profile/defaults, CDP URL parsing, and browser-control auth helpers |
     | `plugin-sdk/agent-harness-task-runtime` | Generic task lifecycle and completion delivery helpers for harness-backed agents using a host-issued task scope |
     | `plugin-sdk/codex-mcp-projection` | Reserved bundled Codex helper for projecting user MCP server config into Codex thread config; not for third-party plugins |

--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -202,7 +202,7 @@ let publicDeprecatedExportsByEntrypointBudget;
 try {
   budgets = {
     publicEntrypoints: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_ENTRYPOINTS", 322),
-    publicExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS", 10400),
+    publicExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS", 10402),
     publicFunctionExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_FUNCTION_EXPORTS", 5219),
     publicDeprecatedExports: readBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_DEPRECATED_EXPORTS",

--- a/src/plugin-sdk/runtime-env.ts
+++ b/src/plugin-sdk/runtime-env.ts
@@ -2,7 +2,7 @@
 // logger wiring, runtime env shims, and global verbose console helpers.
 
 export type { RuntimeEnv } from "../runtime.js";
-export { createNonExitingRuntime, defaultRuntime } from "../runtime.js";
+export { createNonExitingRuntime, defaultRuntime, RuntimeExitError } from "../runtime.js";
 export {
   danger,
   info,

--- a/src/plugin-sdk/runtime.ts
+++ b/src/plugin-sdk/runtime.ts
@@ -2,7 +2,7 @@
  * Public SDK subpath for runtime logging, env, backup, and process helpers.
  */
 export type { OutputRuntimeEnv, RuntimeEnv } from "../runtime.js";
-export { createNonExitingRuntime, defaultRuntime } from "../runtime.js";
+export { createNonExitingRuntime, defaultRuntime, RuntimeExitError } from "../runtime.js";
 export { resolveCommandSecretRefsViaGateway } from "../cli/command-secret-gateway.js";
 export { getChannelsCommandSecretTargetIds } from "../cli/command-secret-targets.js";
 export {

--- a/src/runtime.test.ts
+++ b/src/runtime.test.ts
@@ -10,7 +10,7 @@ vi.mock("../packages/terminal-core/src/restore.js", () => ({
   restoreTerminalState: vi.fn(),
 }));
 
-import { createNonExitingRuntime, writeRuntimeJson } from "./runtime.js";
+import { createNonExitingRuntime, RuntimeExitError, writeRuntimeJson } from "./runtime.js";
 
 describe("createNonExitingRuntime", () => {
   it("returns runtime with exit function", () => {
@@ -18,9 +18,22 @@ describe("createNonExitingRuntime", () => {
     expect(typeof runtime.exit).toBe("function");
   });
 
-  it("exit function throws error", () => {
+  it("exit function throws typed runtime exit error", () => {
     const runtime = createNonExitingRuntime();
-    expect(() => runtime.exit(1)).toThrow("exit 1");
+    let thrown: unknown;
+
+    try {
+      runtime.exit(42);
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeInstanceOf(RuntimeExitError);
+    expect(thrown).toMatchObject({
+      name: "RuntimeExitError",
+      code: 42,
+      message: "exit 42",
+    });
   });
 
   it("exit function includes code in error message", () => {

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -13,6 +13,16 @@ export type OutputRuntimeEnv = RuntimeEnv & {
   writeJson: (value: unknown, space?: number) => void;
 };
 
+export class RuntimeExitError extends Error {
+  readonly code: number;
+
+  constructor(code: number) {
+    super(`exit ${code}`);
+    this.name = "RuntimeExitError";
+    this.code = code;
+  }
+}
+
 function shouldEmitRuntimeLog(env: NodeJS.ProcessEnv = process.env): boolean {
   if (env.VITEST !== "true") {
     return true;
@@ -99,7 +109,7 @@ export function createNonExitingRuntime(): OutputRuntimeEnv {
   return {
     ...createRuntimeIo(),
     exit: (code: number) => {
-      throw new Error(`exit ${code}`);
+      throw new RuntimeExitError(code);
     },
   };
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes https://github.com/openclaw/openclaw/issues/97796.

`createNonExitingRuntime()` used a generic `Error` to simulate process exit control flow. Generic errors are hard for callers to distinguish from real runtime failures, which can cause exit control flow to be swallowed or reported as an unexpected crash.

## Why This Change Was Made

This adds `RuntimeExitError`, throws it from `createNonExitingRuntime().exit(code)`, and exposes it through the public runtime SDK subpaths so callers can explicitly detect simulated runtime exits.

## User Impact

Callers can now safely distinguish non-exiting runtime exit control flow from ordinary runtime errors while preserving the existing `"exit <code>"` message shape.

## Real behavior proof

On PR head `f0c66f0096f26a8f895bb1396c35ca3f1e7ee548`, the focused runtime test exercises the actual helper and confirms `createNonExitingRuntime().exit(42)` now throws `RuntimeExitError` with `name: "RuntimeExitError"`, `code: 42`, and `message: "exit 42"`.

Command run against the PR head:

```bash
node scripts/run-vitest.mjs src/runtime.test.ts -- --reporter=verbose
```

Relevant output:

```text
✓ |unit| src/runtime.test.ts > createNonExitingRuntime > exit function throws typed runtime exit error
Test Files  1 passed (1)
Tests  7 passed (7)
```

## Evidence

- `node scripts/run-vitest.mjs src/runtime.test.ts test/scripts/plugin-sdk-surface-report.test.ts` passed
- `node scripts/plugin-sdk-surface-report.mjs --check` passed
- `pnpm plugin-sdk:api:check` passed
- `git diff --check` passed
- `autoreview` clean, no actionable findings
