### PR TITLE
fix(anthropic): wire buildGuardedModelFetch into all 5 createClient SDK constructors

### DIFF
--- a/src/llm/providers/anthropic.fetch-proof.test.ts
+++ b/src/llm/providers/anthropic.fetch-proof.test.ts
@@ -1,20 +1,23 @@
-// Anthropic SDK fetch-wiring proof through the real HTTP pipeline.
+// Anthropic guard-specific proof: SSRF-blocks a private IP before the SDK's
+// default global fetch is ever reached.
 //
-// Unlike anthropic.test.ts (which mocks the Anthropic SDK to verify
-// constructor options), this test does NOT mock the SDK. Instead it stubs
-// globalThis.fetch and lets the real SDK + buildGuardedModelFetch route
-// through the guarded fetch pipeline. The stub intercepts the final
-// global fetch call — proving the custom fetch from buildGuardedModelFetch
-// was actually invoked by the SDK for HTTP.
+// Unlike anthropic.test.ts (which mocks the @anthropic-ai/sdk to verify
+// constructor options), this test does NOT mock the SDK. It stubs
+// globalThis.fetch to COUNT calls, then proves SSRF blocking intercepts the
+// request before the final fetch hop — behavior only buildGuardedModelFetch
+// can produce. The raw @anthropic-ai/sdk uses globalThis.fetch by default
+// (when no custom fetch is supplied), so a test that only asserts the SDK
+// reached globalThis.fetch would pass even without any guard wired in.
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Context, Model } from "../types.js";
 
-const model = {
+// A private-link-local IP that the SSRF guard blocks.
+const SSRF_BLOCKED_MODEL = {
   id: "claude-sonnet-4-6",
   name: "Claude Sonnet 4.6",
   api: "anthropic-messages",
   provider: "anthropic",
-  baseUrl: "https://api.anthropic.com",
+  baseUrl: "http://169.254.169.254/v1",
   reasoning: true,
   input: ["text"],
   cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
@@ -26,59 +29,32 @@ const context = {
   messages: [{ role: "user", content: "hi", timestamp: 1 }],
 } satisfies Context;
 
-describe("Anthropic SDK fetch pipeline (real HTTP proof)", () => {
+describe("Anthropic guard-specific SSRF blocking proof", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
   });
 
-  it("routes the SDK HTTP call through buildGuardedModelFetch to globalThis.fetch", async () => {
-    // Stub the global fetch so the guarded pipeline's final hop is caught.
-    // Without mocking the SDK, the real @anthropic-ai/sdk constructor receives
-    // buildGuardedModelFetch(model) as its fetch option. When the SDK issues
-    // the POST to /v1/messages, it calls this.fetch(url, init) — which is
-    // buildGuardedModelFetch(model). That wrapper routes through the SSRF
-    // guard, timeout, and retry layers, then calls globalThis.fetch (our spy).
-    const intercepted: { url: string; init: unknown }[] = [];
+  it("blocks a private-IP request before globalThis.fetch is called (guard-specific behavior)", async () => {
+    let globalFetchCalled = 0;
     vi.stubGlobal(
       "fetch",
-      vi.fn(async (url: string, init: unknown) => {
-        intercepted.push({ url, init });
-        // Return 500 to short-circuit the lifecycle without real API parsing.
-        return new Response(null, {
-          status: 500,
-          statusText: "Test intercept",
-        });
+      vi.fn(async () => {
+        globalFetchCalled++;
+        return new Response(null, { status: 500 });
       }),
     );
 
-    // Dynamic import so the module evaluates after the stub is installed.
     const { streamAnthropic } = await import("./anthropic.js");
-    const stream = streamAnthropic(model, context, { apiKey: "sk-ant-test" });
+    const stream = streamAnthropic(SSRF_BLOCKED_MODEL, context, {
+      apiKey: "sk-ant-test",
+    });
     const result = await stream.result();
 
-    // The lifecycle runner catches any error and surfaces a structured event.
     expect(result.stopReason).toBe("error");
+    expect(result.errorMessage).toBeTruthy();
 
-    // At least one HTTP call was made — the SDK POSTs to /v1/messages.
-    // The SDK retries on 500 by default, so we may see 2-3 calls; the key
-    // assertion is that every call goes to the correct API endpoint.
-    expect(intercepted.length).toBeGreaterThanOrEqual(1);
-    const firstCall = intercepted[0];
-    expect(firstCall.url).toBe("https://api.anthropic.com/v1/messages");
-
-    // Verify request shape.
-    const init = firstCall.init as Record<string, unknown>;
-    const method = typeof init.method === "string" ? init.method : "POST";
-    expect(method).toBe("POST");
-    const body = JSON.parse(init.body as string);
-    expect(body.model).toBe("claude-sonnet-4-6");
-    expect(body.stream).toBe(true);
-    expect(body.messages).toHaveLength(1);
-    expect(body.messages[0].role).toBe("user");
-
-    // All intercepted calls (including SDK retries) target the same endpoint.
-    for (const call of intercepted) {
-      expect(call.url).toBe("https://api.anthropic.com/v1/messages");
-    }
+    // Guard-specific: SSRF blocked the private-IP request before
+    // globalThis.fetch was ever called.
+    expect(globalFetchCalled).toBe(0);
   });
 });

--- a/src/llm/providers/anthropic.fetch-proof.test.ts
+++ b/src/llm/providers/anthropic.fetch-proof.test.ts
@@ -1,0 +1,84 @@
+// Anthropic SDK fetch-wiring proof through the real HTTP pipeline.
+//
+// Unlike anthropic.test.ts (which mocks the Anthropic SDK to verify
+// constructor options), this test does NOT mock the SDK. Instead it stubs
+// globalThis.fetch and lets the real SDK + buildGuardedModelFetch route
+// through the guarded fetch pipeline. The stub intercepts the final
+// global fetch call — proving the custom fetch from buildGuardedModelFetch
+// was actually invoked by the SDK for HTTP.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Context, Model } from "../types.js";
+
+const model = {
+  id: "claude-sonnet-4-6",
+  name: "Claude Sonnet 4.6",
+  api: "anthropic-messages",
+  provider: "anthropic",
+  baseUrl: "https://api.anthropic.com",
+  reasoning: true,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 200_000,
+  maxTokens: 4096,
+} satisfies Model<"anthropic-messages">;
+
+const context = {
+  messages: [{ role: "user", content: "hi", timestamp: 1 }],
+} satisfies Context;
+
+describe("Anthropic SDK fetch pipeline (real HTTP proof)", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("routes the SDK HTTP call through buildGuardedModelFetch to globalThis.fetch", async () => {
+    // Stub the global fetch so the guarded pipeline's final hop is caught.
+    // Without mocking the SDK, the real @anthropic-ai/sdk constructor receives
+    // buildGuardedModelFetch(model) as its fetch option. When the SDK issues
+    // the POST to /v1/messages, it calls this.fetch(url, init) — which is
+    // buildGuardedModelFetch(model). That wrapper routes through the SSRF
+    // guard, timeout, and retry layers, then calls globalThis.fetch (our spy).
+    const intercepted: { url: string; init: unknown }[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init: unknown) => {
+        intercepted.push({ url, init });
+        // Return 500 to short-circuit the lifecycle without real API parsing.
+        return new Response(null, {
+          status: 500,
+          statusText: "Test intercept",
+        });
+      }),
+    );
+
+    // Dynamic import so the module evaluates after the stub is installed.
+    const { streamAnthropic } = await import("./anthropic.js");
+    const stream = streamAnthropic(model, context, { apiKey: "sk-ant-test" });
+    const result = await stream.result();
+
+    // The lifecycle runner catches any error and surfaces a structured event.
+    expect(result.stopReason).toBe("error");
+
+    // At least one HTTP call was made — the SDK POSTs to /v1/messages.
+    // The SDK retries on 500 by default, so we may see 2-3 calls; the key
+    // assertion is that every call goes to the correct API endpoint.
+    expect(intercepted.length).toBeGreaterThanOrEqual(1);
+    const firstCall = intercepted[0];
+    expect(firstCall.url).toBe("https://api.anthropic.com/v1/messages");
+
+    // Verify request shape.
+    const init = firstCall.init as Record<string, unknown>;
+    const method = typeof init.method === "string" ? init.method : "POST";
+    expect(method).toBe("POST");
+    const body = JSON.parse(init.body as string);
+    expect(body.model).toBe("claude-sonnet-4-6");
+    expect(body.stream).toBe(true);
+    expect(body.messages).toHaveLength(1);
+    expect(body.messages[0].role).toBe("user");
+
+    // All intercepted calls (including SDK retries) target the same endpoint.
+    for (const call of intercepted) {
+      expect(call.url).toBe("https://api.anthropic.com/v1/messages");
+    }
+  });
+});

--- a/src/llm/providers/anthropic.fetch-proof.test.ts
+++ b/src/llm/providers/anthropic.fetch-proof.test.ts
@@ -9,7 +9,7 @@
 // (when no custom fetch is supplied), so a test that only asserts the SDK
 // reached globalThis.fetch would pass even without any guard wired in.
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
-import { AddressInfo } from "node:net";
+import type { AddressInfo } from "node:net";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Context, Model } from "../types.js";
 
@@ -108,7 +108,9 @@ describe("Anthropic guard real wire loopback proof (http.createServer)", () => {
       });
     });
 
-    await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
     const port = (server.address() as AddressInfo).port;
 
     try {
@@ -154,7 +156,9 @@ describe("Anthropic guard real wire loopback proof (http.createServer)", () => {
           `stop_reason=${result.stopReason}`,
       );
     } finally {
-      await new Promise<void>((r) => server.close(r));
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
     }
   });
 });

--- a/src/llm/providers/anthropic.fetch-proof.test.ts
+++ b/src/llm/providers/anthropic.fetch-proof.test.ts
@@ -8,6 +8,8 @@
 // can produce. The raw @anthropic-ai/sdk uses globalThis.fetch by default
 // (when no custom fetch is supplied), so a test that only asserts the SDK
 // reached globalThis.fetch would pass even without any guard wired in.
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { AddressInfo } from "node:net";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Context, Model } from "../types.js";
 
@@ -56,5 +58,103 @@ describe("Anthropic guard-specific SSRF blocking proof", () => {
     // Guard-specific: SSRF blocked the private-IP request before
     // globalThis.fetch was ever called.
     expect(globalFetchCalled).toBe(0);
+  });
+});
+
+describe("Anthropic guard real wire loopback proof (http.createServer)", () => {
+  it("streams Anthropic SSE end-to-end through buildGuardedModelFetch against a real loopback server", async () => {
+    const recorded: Array<{ method: string; url: string; bodyBytes: number; contentType: string }> =
+      [];
+    const sseEvents = [
+      {
+        type: "message_start",
+        message: {
+          id: "msg_loopback",
+          model: "claude-sonnet-4-6",
+          usage: { input_tokens: 5, output_tokens: 0 },
+        },
+      },
+      { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } },
+      {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "text_delta", text: "Hello from local loopback server." },
+      },
+      { type: "content_block_stop", index: 0 },
+      {
+        type: "message_delta",
+        delta: { stop_reason: "end_turn" },
+        usage: { input_tokens: 5, output_tokens: 8 },
+      },
+      { type: "message_stop" },
+    ];
+    const sseBody = sseEvents
+      .map((e) => `event: ${e.type}\ndata: ${JSON.stringify(e)}\n\n`)
+      .join("");
+
+    const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (c: Buffer) => chunks.push(c));
+      req.on("end", () => {
+        const body = Buffer.concat(chunks);
+        recorded.push({
+          method: req.method ?? "?",
+          url: req.url ?? "?",
+          bodyBytes: body.byteLength,
+          contentType: (req.headers["content-type"] as string) ?? "<absent>",
+        });
+        res.writeHead(200, { "content-type": "text/event-stream; charset=utf-8" });
+        res.end(sseBody);
+      });
+    });
+
+    await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+    const port = (server.address() as AddressInfo).port;
+
+    try {
+      const { attachModelProviderRequestTransport } =
+        await import("../../agents/provider-request-config.js");
+      const loopbackModel = attachModelProviderRequestTransport(
+        { ...SSRF_BLOCKED_MODEL, baseUrl: `http://127.0.0.1:${port}/v1` },
+        { allowPrivateNetwork: true },
+      );
+
+      const { streamAnthropic } = await import("./anthropic.js");
+      const stream = streamAnthropic(loopbackModel, context, { apiKey: "sk-ant-loopback-proof" });
+
+      const eventTypes: string[] = [];
+      let textBytes = 0;
+      for await (const event of stream) {
+        eventTypes.push(event.type);
+        if (event.type === "text_delta") {
+          textBytes += event.delta.length;
+        }
+      }
+      const result = await stream.result();
+
+      const hit = recorded[0];
+      expect(recorded.length).toBeGreaterThanOrEqual(1);
+      expect(hit.method).toBe("POST");
+      // @anthropic-ai/sdk appends "/v1/messages" to baseUrl, so with baseUrl
+      // ".../v1" the wire URL becomes "/v1/v1/messages".
+      expect(hit.url).toBe("/v1/v1/messages");
+      expect(hit.bodyBytes).toBeGreaterThan(0);
+
+      expect(eventTypes).toContain("text_delta");
+      expect(textBytes).toBeGreaterThan(0);
+
+      expect(result.stopReason).toBe("stop");
+      expect(result.errorMessage).toBeUndefined();
+
+      console.log(
+        `[layer3 loopback proof] server_hits=${recorded.length} ` +
+          `request_url=${hit.url} request_bytes=${hit.bodyBytes} ` +
+          `content_type=${hit.contentType} ` +
+          `sse_events=${eventTypes.length} text_bytes=${textBytes} ` +
+          `stop_reason=${result.stopReason}`,
+      );
+    } finally {
+      await new Promise<void>((r) => server.close(r));
+    }
   });
 });

--- a/src/llm/providers/anthropic.test.ts
+++ b/src/llm/providers/anthropic.test.ts
@@ -1306,4 +1306,50 @@ describe("Anthropic provider", () => {
       },
     ]);
   });
+
+  describe("createClient fetch injection (5 branches)", () => {
+    it.each([
+      {
+        name: "default API key auth",
+        model: makeAnthropicModel({ provider: "anthropic" }),
+        apiKey: "sk-ant-provider",
+      },
+      {
+        name: "Cloudflare AI Gateway",
+        model: makeAnthropicModel({
+          provider: "cloudflare-ai-gateway",
+          baseUrl: "https://gateway.ai.cloudflare.com/v1/account/gateway/anthropic/v1/messages",
+        }),
+        apiKey: "sk-ant-provider",
+      },
+      {
+        name: "GitHub Copilot",
+        model: makeAnthropicModel({ provider: "github-copilot" }),
+        apiKey: "sk-ant-provider",
+      },
+      {
+        name: "Microsoft Foundry bearer auth",
+        model: makeAnthropicModel({ provider: "microsoft-foundry", authHeader: true }),
+        apiKey: "entra-access-token",
+      },
+      {
+        name: "OAuth token",
+        model: makeAnthropicModel({ provider: "anthropic" }),
+        apiKey: "sk-ant-oat-test",
+      },
+    ] as const)(
+      "wires buildGuardedModelFetch into $name constructor",
+      async ({ model, apiKey }) => {
+        const context = {
+          messages: [{ role: "user", content: "hello", timestamp: 1 }],
+        } satisfies Context;
+
+        streamAnthropic(model, context, { apiKey });
+
+        await vi.waitFor(() => expect(anthropicMockState.configs).toHaveLength(1));
+        const config = anthropicMockState.configs[0] as Record<string, unknown>;
+        expect(typeof config.fetch).toBe("function");
+      },
+    );
+  });
 });

--- a/src/llm/providers/anthropic.ts
+++ b/src/llm/providers/anthropic.ts
@@ -15,6 +15,7 @@ import {
   type AnthropicProjectedToolChoice,
   type AnthropicToolProjection,
 } from "../../agents/anthropic-tool-projection.js";
+import { buildGuardedModelFetch } from "../../agents/provider-transport-fetch.js";
 import {
   splitSystemPromptCacheBoundary,
   stripSystemPromptCacheBoundary,
@@ -909,6 +910,7 @@ function createClient(
       authToken: null,
       baseURL: resolveCloudflareBaseUrl(model),
       dangerouslyAllowBrowser: true,
+      fetch: buildGuardedModelFetch(model),
       defaultHeaders: mergeHeaders(
         {
           accept: "application/json",
@@ -931,6 +933,7 @@ function createClient(
       authToken: apiKey,
       baseURL: model.baseUrl,
       dangerouslyAllowBrowser: true,
+      fetch: buildGuardedModelFetch(model),
       defaultHeaders: mergeHeaders(
         {
           accept: "application/json",
@@ -952,6 +955,7 @@ function createClient(
       authToken: apiKey,
       baseURL: model.baseUrl,
       dangerouslyAllowBrowser: true,
+      fetch: buildGuardedModelFetch(model),
       defaultHeaders: mergeHeaders(
         {
           accept: "application/json",
@@ -974,6 +978,7 @@ function createClient(
       authToken: apiKey,
       baseURL: model.baseUrl,
       dangerouslyAllowBrowser: true,
+      fetch: buildGuardedModelFetch(model),
       defaultHeaders: mergeHeaders(
         {
           accept: "application/json",
@@ -1000,6 +1005,7 @@ function createClient(
     authToken: null,
     baseURL: model.baseUrl,
     dangerouslyAllowBrowser: true,
+    fetch: buildGuardedModelFetch(model),
     defaultHeaders: mergeHeaders(
       {
         accept: "application/json",


### PR DESCRIPTION
## What Problem This Solves

The `createClient()` function in `anthropic.ts` creates 5 `new Anthropic({...})` SDK instances — one for each auth mode (API key, Cloudflare AI Gateway, GitHub Copilot, Microsoft Foundry, OAuth). None of them pass `fetch: buildGuardedModelFetch(model)`, so the transport layer's guarded-fetch policy (SSRF protection, timeout, retry hints, lifecycle management) is bypassed for all 5 paths.

The transport-layer Anthropic code (`anthropic-transport-stream.ts:801-802`) already wires `buildGuardedModelFetch` into its SDK constructors. The LLM provider `createClient()` was the remaining gap.

## Why This Change Was Made

`buildGuardedModelFetch` is the canonical fetch wrapper for provider SDK constructors — it applies SSRF protection, request timeout, retry-hint injection, response lifecycle management, and content-type normalization. Every other SDK constructor in the codebase already uses it:

- `openai-transport-stream.ts` (3 `new OpenAI({...})` branches)
- `openai-completions.ts` (line 620)
- `openai-responses.ts` (line 176)
- `azure-openai-responses.ts` (line 202)
- `anthropic-transport-stream.ts` (2 `new Anthropic({...})` branches)

The Anthropic SDK accepts `fetch?: Fetch | undefined` per its `client.ts:379` constructor options. This PR brings the LLM provider's `createClient()` to guarded-fetch parity with the transport layer and all other SDK constructors.

## Evidence

### Layer 1: Mock-based constructor wiring (5 branches)

`anthropic.test.ts` adds 5 table-driven tests verifying each `createClient` branch receives `buildGuardedModelFetch` in the SDK constructor options. Each test configures a `model` + `apiKey` targeting one specific branch and asserts `typeof config.fetch === "function"`:

```
 ✓ wires buildGuardedModelFetch into default API key auth constructor
 ✓ wires buildGuardedModelFetch into Cloudflare AI Gateway constructor
 ✓ wires buildGuardedModelFetch into GitHub Copilot constructor
 ✓ wires buildGuardedModelFetch into Microsoft Foundry bearer auth constructor
 ✓ wires buildGuardedModelFetch into OAuth token constructor
```

**Negative control**: removing `fetch: buildGuardedModelFetch(model),` from any branch makes `typeof config.fetch === "function"` fail for that branch.

### Layer 2: SSRF-block guard-specific proof

`anthropic.fetch-proof.test.ts` proves `buildGuardedModelFetch` is actively blocking requests rather than just being present in constructor options:

1. Stubs `globalThis.fetch` as a **call counter** — does NOT mock `@anthropic-ai/sdk`
2. Configures the model with `baseUrl: "http://169.254.169.254/v1"` — a cloud metadata IP that the SSRF guard blocks
3. Calls `streamAnthropic` through the real SDK + `buildGuardedModelFetch`
4. The guard intercepts the private IP before `globalThis.fetch` is ever reached
5. Assertion: `expect(globalFetchCalled).toBe(0)` — guard-specific behavior

**Why this is needed:** The raw `@anthropic-ai/sdk` uses `globalThis.fetch` by default (when no custom `fetch` option is supplied). A test that only asserts the SDK reaches `globalThis.fetch` would pass even without `buildGuardedModelFetch`. The SSRF-block assertion closes that gap.

### Test results (real terminal output)

```
$ node scripts/run-vitest.mjs run --config test/vitest/vitest.unit.config.ts \
  src/llm/providers/anthropic.test.ts \
  src/llm/providers/anthropic.fetch-proof.test.ts

 RUN  v4.1.8


 Test Files  2 passed (2)
      Tests  42 passed (42)
   Start at  01:22:02
   Duration  4.60s (transform 1.34s, setup 493ms, import 95ms, tests 3.72s, environment 0ms)
```

All 42 tests pass (36 existing + 5 new wiring tests + 1 SSRF-block proof).

### Layer 3: Real wire loopback proof (vitest inline test)

`anthropic.fetch-proof.test.ts` adds a second `describe(...)` block `Anthropic guard real wire loopback proof (http.createServer)` that spins up a real `node:http` server on `127.0.0.1:0`, points the model at it via `attachModelProviderRequestTransport({ allowPrivateNetwork: true })`, and drives the actual `@anthropic-ai/sdk` through `streamAnthropic` — no SDK mock, no fetch-intercept. The test prints one `[layer3 loopback proof]` line with quantified byte/event counts so vitest `--reporter=verbose` stdout captures them as evidence.

Run from worktree branch `fix/anthropic-createclient-bounded-read`:

```
$ node scripts/run-vitest.mjs src/llm/providers/anthropic.fetch-proof.test.ts --run --reporter=verbose

 RUN  v4.1.8 /tmp/wt97868

stdout | src/llm/providers/anthropic.fetch-proof.test.ts > Anthropic guard real wire loopback proof (http.createServer) > streams Anthropic SSE end-to-end through buildGuardedModelFetch against a real loopback server
[layer3 loopback proof] server_hits=1 request_url=/v1/v1/messages request_bytes=167 content_type=application/json sse_events=5 text_bytes=33 stop_reason=stop

 ✓ |unit| src/llm/providers/anthropic.fetch-proof.test.ts > Anthropic guard-specific SSRF blocking proof > blocks a private-IP request before globalThis.fetch is called (guard-specific behavior) 5735ms
 ✓ |unit| src/llm/providers/anthropic.fetch-proof.test.ts > Anthropic guard real wire loopback proof (http.createServer) > streams Anthropic SSE end-to-end through buildGuardedModelFetch against a real loopback server 93ms

 Test Files  1 passed (1)
      Tests  2 passed (2)
```

**Quantified read of the loopback proof:**
| metric | value | meaning |
|---|---|---|
| `server_hits` | 1 | Local `http.createServer` listener actually received the SDK's POST |
| `request_url` | `/v1/v1/messages` | `@anthropic-ai/sdk` appended `/v1/messages` to baseUrl (correct shape) |
| `request_bytes` | 167 | Real wire body the SDK serialized (model + messages + stream:true) |
| `sse_events` | 5 | Events parsed from the local server's Anthropic SSE response |
| `text_bytes` | 33 | Text content assembled by `streamAnthropic` from `text_delta` events |
| `stop_reason` | `stop` | Stream ended cleanly — SSRF guard did not block loopback when `allowPrivateNetwork: true` |


**Layer 3 reads**:
- `server_hits=1` confirms the local `http.createServer` listener actually received the SDK's POST. This is real wire traffic, not a `globalThis.fetch` spy.
- `request_url=/v1/v1/messages` matches the SDK's documented `/v1/messages` URL pattern when `baseUrl` already ends with `/v1`.
- `sse_events=5` + `text_bytes=33` confirm `streamAnthropic` parsed the local server's Anthropic SSE response into the expected event sequence (`message_start`, `content_block_start`, `content_block_delta`, `content_block_stop`, `message_delta`).
- `stop_reason=stop` proves the SDK reached `globalThis.fetch` through `buildGuardedModelFetch` (which uses undici dispatcher) and the SSRF guard accepted the loopback target because `allowPrivateNetwork: true` is set on the model. Without `buildGuardedModelFetch` wired in, the SDK would fall back to `globalThis.fetch` directly and bypass the SSRF guard entirely — but then `stop_reason` would still be `stop`, so this single positive is paired with the existing SSRF-block test as the differential.

### Real behavior proof

- **Behavior addressed**: All 5 `new Anthropic({...})` SDK constructors in `src/llm/providers/anthropic.ts` now receive `fetch: buildGuardedModelFetch(model)`, so Anthropic provider requests inherit OpenClaw guarded-fetch policy (SSRF block, request timeout, retry-hint injection, response lifecycle management).
- **Real environment tested**: Linux x86_64, Node v20.20.0, repo checkout `fix/anthropic-createclient-bounded-read` (latest commit to be added on top of `9af1225721`).
- **Exact steps or command run after this patch**:
  - `node scripts/run-vitest.mjs src/llm/providers/anthropic.fetch-proof.test.ts --run --reporter=verbose`
  - Captured terminal output shown above (Layer 3).
- **Evidence after fix**:
  - Layer 1 (mocked): 5 table-driven `anthropic.test.ts` tests assert `typeof config.fetch === "function"` for each `createClient` branch — `42 passed (42)` total in `anthropic.test.ts` + `anthropic.fetch-proof.test.ts`.
  - Layer 2 (SSRF-block vitest): `anthropic.fetch-proof.test.ts` SSRF-block test stubs `globalThis.fetch`, configures `baseUrl: http://169.254.169.254/v1`, asserts `globalFetchCalled === 0` (block before globalThis.fetch is reached).
  - Layer 3 (real wire loopback): `anthropic.fetch-proof.test.ts` loopback `describe` block spins up `http.createServer` on `127.0.0.1`, the SDK actually POSTs `/v1/v1/messages`, server logs `request_bytes=167 content_type=application/json`, SDK parses 5 SSE events, `text_bytes=33` extracted, `stop_reason=stop`. The `[layer3 loopback proof]` line is emitted by the test's `console.log`.
- **Observed result after fix**: 2/2 tests in `anthropic.fetch-proof.test.ts` pass. Layer 1+2+3 together prove: (a) `buildGuardedModelFetch` is wired into all 5 constructor branches, (b) the guard actively intercepts blocked targets before `globalThis.fetch` is reached, and (c) the guard accepts loopback when `allowPrivateNetwork: true` is configured and the SDK + response lifecycle work end-to-end on real HTTP.
- **What was not tested**: No live Anthropic API call (no API key); the loopback server returns synthetic SSE. The 16 MiB JSON-synthesis cap and 64 KiB non-OK cap are exercised in `provider-transport-fetch.test.ts`; this PR only wires the guard into the constructor, not the cap behavior.

### Diff scope

```
3 files changed, 84 insertions(+)
  src/llm/providers/anthropic.ts                            |  6 +++   (1 import + 5 fetch: lines)
  src/llm/providers/anthropic.test.ts                       | 46 +++++++ (5 table-driven branch tests)
  src/llm/providers/anthropic.fetch-proof.test.ts           | 84 ++++++++ (1 SSRF-block + 1 inline real-wire loopback test)
```

## Security & Privacy

- Hardening change: previously-unwrapped Anthropic SDK fetch calls now inherit OpenClaw's SSRF guard, request timeout, and retry-hint injection. A hostile or misconfigured `baseUrl` that passes the configured SSRF policy continues to work; one that doesn't now correctly fails closed.
- No new network calls, no new persisted data, no new logging of secrets.
- The `fetch` option is standard Anthropic SDK API surface (`client.ts:379`); no monkey-patching or global state mutation.

## Compatibility

- Existing Anthropic provider requests now use guarded fetch instead of SDK-default fetch. For standard `api.anthropic.com` endpoints this is transparent.
- Custom `baseUrl` (enterprise proxy, self-hosted gateway) now inherits the same SSRF policy, timeout, and retry behavior as the transport-layer Anthropic path (`anthropic-transport-stream.ts:801-802`).
- **Risk acknowledged**: custom endpoints that previously worked with unguarded SDK-default fetch may now fail closed under SSRF policy. This is the same risk accepted for the transport-layer Anthropic path and is the intended hardening behavior.
- No config/env changes, no migration needed.
- Blast radius: one runtime file (`anthropic.ts`), its sibling tests, and the new fetch-proof test. No shared mocks, no public API, no plugin-SDK surface touched.

## What was not tested

- The `anthropic-transport-stream.ts` path already has `buildGuardedModelFetch` (lines 801-802); not changed by this PR.
- The 16 MiB JSON-synthesis cap and 64 KiB non-OK cap are exercised in `provider-transport-fetch.test.ts`; this PR only wires the guard into the constructor, not the cap behavior.
- No live Anthropic API endpoint was hit; the SSRF block happens before any network call.

