### PR TITLE
fix(memory): require privileged dreaming config changes

### DIFF
--- a/docs/cli/memory.md
+++ b/docs/cli/memory.md
@@ -133,6 +133,9 @@ facts into `MEMORY.md`), and **REM** (reflect and surface themes).
 
 - Enable with `plugins.entries.memory-core.config.dreaming.enabled: true`.
 - Toggle from chat with `/dreaming on|off` (or inspect with `/dreaming status`).
+  Channel callers must be owners to change the setting; Gateway clients need
+  `operator.admin`. Read-only status and help remain available to authorized
+  command senders.
 - Dreaming runs on one managed sweep schedule (`dreaming.frequency`) and executes phases in order: light, REM, deep.
 - Only the deep phase writes durable memory to `MEMORY.md`.
 - Human-readable phase output and diary entries are written to `DREAMS.md` (or existing `dreams.md`), with optional per-phase reports in `memory/dreaming/<phase>/YYYY-MM-DD.md`.

--- a/docs/concepts/dreaming.md
+++ b/docs/concepts/dreaming.md
@@ -197,6 +197,10 @@ Default cadence behavior:
 /dreaming help
 ```
 
+`/dreaming on` and `/dreaming off` change gateway-wide configuration. Channel
+callers must be owners, and Gateway clients must have `operator.admin`.
+`/dreaming status` and `/dreaming help` remain read-only.
+
 ## CLI workflow
 
 <Tabs>

--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -301,14 +301,14 @@ must be in the same identity group.
 
 ### Bundled plugin commands
 
-| Command                                                                                      | Description                                                                       |
-| -------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
-| `/dreaming [on\|off\|status\|help]`                                                          | Toggle memory dreaming. See [Dreaming](/concepts/dreaming)                        |
-| `/pair [qr\|status\|pending\|approve\|cleanup\|notify]`                                      | Manage device pairing. See [Pairing](/channels/pairing)                           |
-| `/phone status\|arm ...\|disarm`                                                             | Temporarily arm high-risk phone node commands                                     |
-| `/voice status\|list\|set <voiceId>`                                                         | Manage Talk voice config. Discord native name: `/talkvoice`                       |
-| `/card ...`                                                                                  | Send LINE rich card presets. See [LINE](/channels/line)                           |
-| `/codex status\|models\|threads\|resume\|compact\|review\|diagnostics\|account\|mcp\|skills` | Control the Codex app-server harness. See [Codex harness](/plugins/codex-harness) |
+| Command                                                                                      | Description                                                                         |
+| -------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| `/dreaming [on\|off\|status\|help]`                                                          | Toggle memory dreaming (owner or Gateway admin). See [Dreaming](/concepts/dreaming) |
+| `/pair [qr\|status\|pending\|approve\|cleanup\|notify]`                                      | Manage device pairing. See [Pairing](/channels/pairing)                             |
+| `/phone status\|arm ...\|disarm`                                                             | Temporarily arm high-risk phone node commands                                       |
+| `/voice status\|list\|set <voiceId>`                                                         | Manage Talk voice config. Discord native name: `/talkvoice`                         |
+| `/card ...`                                                                                  | Send LINE rich card presets. See [LINE](/channels/line)                             |
+| `/codex status\|models\|threads\|resume\|compact\|review\|diagnostics\|account\|mcp\|skills` | Control the Codex app-server harness. See [Codex harness](/plugins/codex-harness)   |
 
 QQBot-only: `/bot-ping`, `/bot-version`, `/bot-help`, `/bot-upgrade`, `/bot-logs`
 

--- a/extensions/memory-core/index.test.ts
+++ b/extensions/memory-core/index.test.ts
@@ -101,6 +101,7 @@ describe("memory-core plugin runtime registration", () => {
 
     expect(command?.name).toBe("dreaming");
     expect(command?.acceptsArgs).toBe(true);
+    expect(command?.exposeSenderIsOwner).toBe(true);
     expect(command?.description).toContain("Enable or disable");
   });
 

--- a/extensions/memory-core/index.ts
+++ b/extensions/memory-core/index.ts
@@ -209,6 +209,7 @@ export default definePluginEntry({
       name: "dreaming",
       description: "Enable or disable memory dreaming.",
       acceptsArgs: true,
+      exposeSenderIsOwner: true,
       handler: async (ctx) => {
         const { handleDreamingCommand } = await import("./src/dreaming-command.js");
         return await handleDreamingCommand(api, ctx);

--- a/extensions/memory-core/src/dreaming-command.test.ts
+++ b/extensions/memory-core/src/dreaming-command.test.ts
@@ -62,7 +62,7 @@ function createHarness(initialConfig: OpenClawConfig = {}) {
 
 function createCommandContext(
   args?: string,
-  overrides?: Partial<Pick<PluginCommandContext, "gatewayClientScopes">>,
+  overrides?: Partial<Pick<PluginCommandContext, "gatewayClientScopes" | "senderIsOwner">>,
 ): PluginCommandContext {
   return {
     channel: "webchat",
@@ -71,6 +71,7 @@ function createCommandContext(
     args,
     config: {},
     gatewayClientScopes: overrides?.gatewayClientScopes,
+    senderIsOwner: overrides?.senderIsOwner,
     requestConversationBinding: async () => ({ status: "error", message: "unsupported" }),
     detachConversationBinding: async () => ({ removed: false }),
     getCurrentConversationBinding: async () => null,
@@ -80,7 +81,7 @@ function createCommandContext(
 async function runDreamingCommand(
   harness: ReturnType<typeof createHarness>,
   args?: string,
-  overrides?: Partial<Pick<PluginCommandContext, "gatewayClientScopes">>,
+  overrides?: Partial<Pick<PluginCommandContext, "gatewayClientScopes" | "senderIsOwner">>,
 ) {
   return await handleDreamingCommand(harness.api, createCommandContext(args, overrides));
 }
@@ -98,7 +99,18 @@ describe("memory-core /dreaming command", () => {
     );
   });
 
-  it("persists global enablement under plugins.entries.memory-core.config.dreaming.enabled", async () => {
+  it("blocks non-owner external channel callers from persisting dreaming config", async () => {
+    const harness = createHarness();
+
+    const result = await runDreamingCommand(harness, "off");
+
+    expect(result.text).toContain(
+      "requires owner status for channel callers or operator.admin for gateway clients",
+    );
+    expect(harness.runtime.config.mutateConfigFile).not.toHaveBeenCalled();
+  });
+
+  it("allows owner external channel callers to persist global enablement", async () => {
     const harness = createHarness({
       plugins: {
         entries: {
@@ -118,7 +130,9 @@ describe("memory-core /dreaming command", () => {
       },
     });
 
-    const result = await runDreamingCommand(harness, "off");
+    const result = await runDreamingCommand(harness, "off", {
+      senderIsOwner: true,
+    });
 
     expect(harness.runtime.config.mutateConfigFile).toHaveBeenCalledTimes(1);
     const storedDreaming = resolveStoredDreaming(harness.getRuntimeConfig());
@@ -134,7 +148,9 @@ describe("memory-core /dreaming command", () => {
       gatewayClientScopes: [],
     });
 
-    expect(result.text).toContain("requires operator.admin");
+    expect(result.text).toContain(
+      "requires owner status for channel callers or operator.admin for gateway clients",
+    );
     expect(harness.runtime.config.mutateConfigFile).not.toHaveBeenCalled();
   });
 
@@ -145,7 +161,9 @@ describe("memory-core /dreaming command", () => {
       gatewayClientScopes: ["operator.write"],
     });
 
-    expect(result.text).toContain("requires operator.admin");
+    expect(result.text).toContain(
+      "requires owner status for channel callers or operator.admin for gateway clients",
+    );
     expect(harness.runtime.config.mutateConfigFile).not.toHaveBeenCalled();
   });
 

--- a/extensions/memory-core/src/dreaming-command.ts
+++ b/extensions/memory-core/src/dreaming-command.ts
@@ -77,8 +77,14 @@ function formatUsage(includeStatus: string): string {
   ].join("\n");
 }
 
-function requiresAdminToMutateDreaming(gatewayClientScopes?: readonly string[]): boolean {
-  return Array.isArray(gatewayClientScopes) && !gatewayClientScopes.includes("operator.admin");
+function lacksAdminOrOwnerForDreamingMutation(params: {
+  gatewayClientScopes?: readonly string[];
+  senderIsOwner?: boolean;
+}): boolean {
+  if (Array.isArray(params.gatewayClientScopes)) {
+    return !params.gatewayClientScopes.includes("operator.admin");
+  }
+  return params.senderIsOwner !== true;
 }
 
 export async function handleDreamingCommand(api: OpenClawPluginApi, ctx: PluginCommandContext) {
@@ -98,8 +104,15 @@ export async function handleDreamingCommand(api: OpenClawPluginApi, ctx: PluginC
   }
 
   if (firstToken === "on" || firstToken === "off") {
-    if (requiresAdminToMutateDreaming(ctx.gatewayClientScopes)) {
-      return { text: "⚠️ /dreaming on|off requires operator.admin for gateway clients." };
+    if (
+      lacksAdminOrOwnerForDreamingMutation({
+        gatewayClientScopes: ctx.gatewayClientScopes,
+        senderIsOwner: ctx.senderIsOwner,
+      })
+    ) {
+      return {
+        text: "⚠️ /dreaming on|off requires owner status for channel callers or operator.admin for gateway clients.",
+      };
     }
     const enabled = firstToken === "on";
     const committed = await api.runtime.config.mutateConfigFile({


### PR DESCRIPTION
## Summary

Tightens Memory Core `/dreaming on|off` so persistent dreaming configuration changes require a privileged caller.

## Changes

- Opts the bundled Memory Core `/dreaming` command into trusted owner-status exposure.
- Requires owner status for channel callers, or `operator.admin` for gateway clients, before mutating dreaming config.
- Keeps `/dreaming status` and help/phase output readable without mutating config.
- Adds regression coverage for non-owner denial, owner success, gateway write-scope denial, gateway admin success, and command registration owner exposure.

## Validation

- `node scripts/run-vitest.mjs extensions/memory-core/src/dreaming-command.test.ts extensions/memory-core/index.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

