### PR TITLE
fix(telegram): deliver durable reasoning when enabled

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -3623,6 +3623,10 @@ describe("dispatchTelegramMessage draft streaming", () => {
   });
 
   it("opts shared dispatch into durable reasoning payload delivery when reasoning streams", async () => {
+    setupDraftStreams({
+      answerMessageId: 2001,
+      reasoningMessageId: 3001,
+    });
     dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue({
       queuedFinal: false,
       counts: { block: 0, final: 0, tool: 0 },
@@ -3634,6 +3638,24 @@ describe("dispatchTelegramMessage draft streaming", () => {
       replyOptions?: { reasoningPayloadsEnabled?: boolean };
     };
     expect(dispatchParams.replyOptions?.reasoningPayloadsEnabled).toBe(true);
+  });
+
+  it("keeps shared durable reasoning payloads disabled in progress stream mode", async () => {
+    setupDraftStreams({ answerMessageId: 2001 });
+    dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue({
+      queuedFinal: false,
+      counts: { block: 0, final: 0, tool: 0 },
+    });
+
+    await dispatchWithContext({
+      context: createReasoningStreamContext(),
+      streamMode: "progress",
+    });
+
+    const dispatchParams = mockCallArg(dispatchReplyWithBufferedBlockDispatcher) as {
+      replyOptions?: { reasoningPayloadsEnabled?: boolean };
+    };
+    expect(dispatchParams.replyOptions?.reasoningPayloadsEnabled).toBe(false);
   });
 
   it("suppresses typed reasoning-only finals without raw text fallback", async () => {

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -3608,6 +3608,34 @@ describe("dispatchTelegramMessage draft streaming", () => {
     await run;
   });
 
+  it("keeps shared durable reasoning payloads disabled when reasoning is off", async () => {
+    dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue({
+      queuedFinal: false,
+      counts: { block: 0, final: 0, tool: 0 },
+    });
+
+    await dispatchWithContext({ context: createContext() });
+
+    const dispatchParams = mockCallArg(dispatchReplyWithBufferedBlockDispatcher) as {
+      replyOptions?: { reasoningPayloadsEnabled?: boolean };
+    };
+    expect(dispatchParams.replyOptions?.reasoningPayloadsEnabled).toBe(false);
+  });
+
+  it("opts shared dispatch into durable reasoning payload delivery when reasoning streams", async () => {
+    dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue({
+      queuedFinal: false,
+      counts: { block: 0, final: 0, tool: 0 },
+    });
+
+    await dispatchWithContext({ context: createReasoningStreamContext() });
+
+    const dispatchParams = mockCallArg(dispatchReplyWithBufferedBlockDispatcher) as {
+      replyOptions?: { reasoningPayloadsEnabled?: boolean };
+    };
+    expect(dispatchParams.replyOptions?.reasoningPayloadsEnabled).toBe(true);
+  });
+
   it("suppresses typed reasoning-only finals without raw text fallback", async () => {
     setupDraftStreams({ answerMessageId: 2001, reasoningMessageId: 3001 });
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -3711,9 +3711,8 @@ describe("dispatchTelegramMessage draft streaming", () => {
       }),
     });
 
-    expectDeliveredReply(0, { text: "Thinking\n\n_hidden_" });
-    const delivered = expectDeliverRepliesParams().replies as Array<ReplyPayload>;
-    expect(delivered[0]?.isReasoning).toBeUndefined();
+    const delivered = expectDeliveredReply(0, { text: "Thinking\n\n_hidden_" });
+    expect(delivered).not.toHaveProperty("isReasoning");
   });
 
   it("does not persist typed reasoning-only finals in progress stream mode", async () => {

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -3652,6 +3652,67 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(editMessageTelegram).not.toHaveBeenCalled();
   });
 
+  it("routes typed reasoning-only finals to the reasoning lane when reasoning streams", async () => {
+    const { reasoningDraftStream } = setupDraftStreams({
+      answerMessageId: 2001,
+      reasoningMessageId: 3001,
+    });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver(
+        { text: "<think>hidden</think>", isReasoning: true },
+        { kind: "final" },
+      );
+      return { queuedFinal: true };
+    });
+
+    await dispatchWithContext({ context: createReasoningStreamContext() });
+
+    expect(reasoningDraftStream.update).toHaveBeenCalledWith("Thinking\n\n_hidden_");
+    expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
+  it("routes typed reasoning-only finals to durable delivery when reasoning is persistent", async () => {
+    loadSessionStore.mockReturnValue({
+      s1: { reasoningLevel: "on" },
+    });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver(
+        { text: "<think>hidden</think>", isReasoning: true },
+        { kind: "final" },
+      );
+      return { queuedFinal: true };
+    });
+
+    await dispatchWithContext({
+      context: createContext({
+        ctxPayload: { SessionKey: "s1" } as unknown as TelegramMessageContext["ctxPayload"],
+      }),
+    });
+
+    expectDeliveredReply(0, { text: "Thinking\n\n_hidden_" });
+    const delivered = expectDeliverRepliesParams().replies as Array<ReplyPayload>;
+    expect(delivered[0]?.isReasoning).toBeUndefined();
+  });
+
+  it("does not persist typed reasoning-only finals in progress stream mode", async () => {
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver(
+        { text: "<think>hidden</think>", isReasoning: true },
+        { kind: "final" },
+      );
+      return { queuedFinal: true };
+    });
+
+    await dispatchWithContext({
+      context: createReasoningStreamContext(),
+      streamMode: "progress",
+    });
+
+    expect(deliverReplies).not.toHaveBeenCalled();
+    expect(answerDraftStream.update).not.toHaveBeenCalled();
+  });
+
   it("keeps unflagged angle-bracket text visible on the answer lane", async () => {
     const { answerDraftStream } = setupDraftStreams({
       answerMessageId: 2001,

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -1005,6 +1005,8 @@ export const dispatchTelegramMessage = async ({
   };
   const answerLane = lanes.answer;
   const reasoningLane = lanes.reasoning;
+  const durableReasoningPayloadsEnabled =
+    resolvedReasoningLevel === "on" || Boolean(reasoningLane.stream);
   const streamToolProgressEnabled = resolveChannelStreamingPreviewToolProgress(telegramCfg);
   let lastAnswerPartialText = "";
   let activeAnswerDraftIsToolProgressOnly = false;
@@ -1600,9 +1602,7 @@ export const dispatchTelegramMessage = async ({
       return { ...payload, replyToId: implicitQuoteReplyTargetId };
     };
     const normalizeDeliveryPayload = (payload: ReplyPayload): ReplyPayload | undefined => {
-      const keepReasoningLane =
-        payload.isReasoning === true &&
-        (resolvedReasoningLevel === "on" || Boolean(reasoningLane.stream));
+      const keepReasoningLane = payload.isReasoning === true && durableReasoningPayloadsEnabled;
       const payloadForPlan = keepReasoningLane ? { ...payload } : payload;
       if (keepReasoningLane) {
         delete payloadForPlan.isReasoning;
@@ -2419,7 +2419,7 @@ export const dispatchTelegramMessage = async ({
                   },
                   commentaryProgressEnabled:
                     streamMode === "progress" ? progressDraft.commentaryProgressEnabled : undefined,
-                  reasoningPayloadsEnabled: resolvedReasoningLevel !== "off",
+                  reasoningPayloadsEnabled: durableReasoningPayloadsEnabled,
                   onToolStart: async (payload) => {
                     const toolName = payload.name?.trim();
                     const progressPromise = pushStreamToolProgress(

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -2411,6 +2411,7 @@ export const dispatchTelegramMessage = async ({
                   },
                   commentaryProgressEnabled:
                     streamMode === "progress" ? progressDraft.commentaryProgressEnabled : undefined,
+                  reasoningPayloadsEnabled: resolvedReasoningLevel !== "off",
                   onToolStart: async (payload) => {
                     const toolName = payload.name?.trim();
                     const progressPromise = pushStreamToolProgress(

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -1600,13 +1600,21 @@ export const dispatchTelegramMessage = async ({
       return { ...payload, replyToId: implicitQuoteReplyTargetId };
     };
     const normalizeDeliveryPayload = (payload: ReplyPayload): ReplyPayload | undefined => {
-      return projectOutboundPayloadPlanForDelivery(
-        createOutboundPayloadPlan([payload], {
+      const keepReasoningLane =
+        payload.isReasoning === true &&
+        (resolvedReasoningLevel === "on" || Boolean(reasoningLane.stream));
+      const payloadForPlan = keepReasoningLane ? { ...payload } : payload;
+      if (keepReasoningLane) {
+        delete payloadForPlan.isReasoning;
+      }
+      const normalized = projectOutboundPayloadPlanForDelivery(
+        createOutboundPayloadPlan([payloadForPlan], {
           cfg,
           sessionKey: ctxPayload.SessionKey,
           surface: "telegram",
         }),
       )[0];
+      return normalized;
     };
     const usesNativeTelegramQuote = (payload: ReplyPayload): boolean => {
       if (replyQuoteText != null) {

--- a/src/auto-reply/get-reply-options.types.ts
+++ b/src/auto-reply/get-reply-options.types.ts
@@ -155,6 +155,8 @@ export type GetReplyOptions = {
   }) => Promise<void> | void;
   /** In progress mode, classify Claude pre-tool text; true also renders it as commentary. */
   commentaryProgressEnabled?: boolean;
+  /** Deliver durable reasoning payloads to channels that own a separate reasoning lane. */
+  reasoningPayloadsEnabled?: boolean;
   /** Called when the agent emits a structured plan update. */
   onPlanUpdate?: (payload: {
     phase?: string;

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -7932,6 +7932,53 @@ describe("dispatchReplyFromConfig", () => {
     expect((finalCalls[0]?.[0] as ReplyPayload | undefined)?.text).toBe("The answer is 42");
   });
 
+  it("delivers isReasoning final replies when the channel opts in", async () => {
+    setNoAbort();
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({ Provider: "telegram", Surface: "telegram" });
+    const replyResolver = async () =>
+      [
+        { text: "thinking...", isReasoning: true },
+        { text: "The answer is 42" },
+      ] satisfies ReplyPayload[];
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg: emptyConfig,
+      dispatcher,
+      replyOptions: { reasoningPayloadsEnabled: true },
+      replyResolver,
+    });
+
+    const finalCalls = (dispatcher.sendFinalReply as ReturnType<typeof vi.fn>).mock.calls;
+    expect(finalCalls.map((call) => (call[0] as ReplyPayload).text)).toEqual([
+      "thinking...",
+      "The answer is 42",
+    ]);
+  });
+
+  it("does not synthesize opted-in final reasoning payloads into TTS media", async () => {
+    setNoAbort();
+    ttsMocks.state.synthesizeFinalAudio = true;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({ Provider: "telegram", Surface: "telegram" });
+    const reasoningPayload = {
+      text: "thinking...",
+      isReasoning: true,
+    } satisfies ReplyPayload;
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg: emptyConfig,
+      dispatcher,
+      replyOptions: { reasoningPayloadsEnabled: true },
+      replyResolver: async () => reasoningPayload,
+    });
+
+    expect(ttsMocks.maybeApplyTtsToPayload).not.toHaveBeenCalled();
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith(reasoningPayload);
+  });
+
   it("suppresses isReasoning payloads from block replies (generic dispatch path)", async () => {
     setNoAbort();
     const dispatcher = createDispatcher();
@@ -7958,6 +8005,43 @@ describe("dispatchReplyFromConfig", () => {
     await dispatchReplyFromConfig({ ctx, cfg: emptyConfig, dispatcher, replyResolver });
     expect(blockReplySentTexts).not.toContain("thinking...");
     expect(blockReplySentTexts).toContain("The answer is 42");
+  });
+
+  it("delivers opted-in block reasoning payloads without applying TTS", async () => {
+    setNoAbort();
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({ Provider: "telegram", Surface: "telegram" });
+    const blockReplySentTexts: string[] = [];
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+    ): Promise<ReplyPayload | undefined> => {
+      await opts?.onBlockReply?.({ text: "thinking...", isReasoning: true });
+      await opts?.onBlockReply?.({ text: "The answer is 42" });
+      return undefined;
+    };
+    (dispatcher.sendBlockReply as ReturnType<typeof vi.fn>).mockImplementation(
+      (payload: ReplyPayload) => {
+        if (payload.text) {
+          blockReplySentTexts.push(payload.text);
+        }
+        return true;
+      },
+    );
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg: emptyConfig,
+      dispatcher,
+      replyOptions: { reasoningPayloadsEnabled: true },
+      replyResolver,
+    });
+
+    expect(blockReplySentTexts).toEqual(["thinking...", "The answer is 42"]);
+    const blockTtsCalls = ttsMocks.maybeApplyTtsToPayload.mock.calls
+      .map(([call]) => call as { kind?: unknown; payload?: ReplyPayload })
+      .filter((call) => call.kind === "block");
+    expect(blockTtsCalls.map((call) => call.payload?.text)).toEqual(["The answer is 42"]);
   });
 
   it("strips split TTS directives from streamed block text before delivery", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -2050,6 +2050,7 @@ export async function dispatchReplyFromConfig(
     suppressHookUserDelivery,
     suppressHookReplyLifecycle,
   } = sourceReplyPolicy;
+  const reasoningPayloadsEnabled = params.replyOptions?.reasoningPayloadsEnabled === true;
   const attachSourceReplyDeliveryMode = (
     result: DispatchFromConfigResult,
   ): DispatchFromConfigResult =>
@@ -2481,16 +2482,19 @@ export async function dispatchReplyFromConfig(
         markInboundDedupeReplayUnsafe();
         finalReplyDeliveryStarted = true;
       }
-      const ttsPayload = await maybeApplyTtsToReplyPayload({
-        payload,
-        cfg,
-        channel: deliveryChannel,
-        kind: "final",
-        inboundAudio,
-        ttsAuto: sessionTtsAuto,
-        agentId: sessionAgentId,
-        accountId: replyRoute.accountId,
-      });
+      const ttsPayload =
+        payload.isReasoning === true
+          ? payload
+          : await maybeApplyTtsToReplyPayload({
+              payload,
+              cfg,
+              channel: deliveryChannel,
+              kind: "final",
+              inboundAudio,
+              ttsAuto: sessionTtsAuto,
+              agentId: sessionAgentId,
+              accountId: replyRoute.accountId,
+            });
       throwIfFinalDeliveryAborted();
       const normalizedPayload = await normalizeReplyMediaPayload(ttsPayload);
       throwIfFinalDeliveryAborted();
@@ -3078,6 +3082,7 @@ export async function dispatchReplyFromConfig(
               deliverStandaloneCommentaryProgress ||
               canForwardSuppressedSourceItemEvents ||
               params.replyOptions?.commentaryProgressEnabled,
+            reasoningPayloadsEnabled,
             onCommandOutput: wrapProgressCallback(params.replyOptions?.onCommandOutput, {
               forwardWhenSourceDeliverySuppressed: true,
               requiresToolSummaryVisibility: true,
@@ -3306,17 +3311,16 @@ export async function dispatchReplyFromConfig(
                 if (suppressDelivery) {
                   return;
                 }
-                // Suppress reasoning payloads — channels using this generic dispatch
-                // path (WhatsApp, web, etc.) do not have a dedicated reasoning lane.
-                // Telegram has its own dispatch path that handles reasoning splitting.
-                if (payload.isReasoning === true) {
+                // Durable reasoning is a channel-owned lane; generic channels
+                // keep the historical suppression unless they explicitly opt in.
+                if (payload.isReasoning === true && !reasoningPayloadsEnabled) {
                   return;
                 }
                 // Accumulate block text for TTS generation after streaming.
                 // Exclude status notices — they are informational UI signals
                 // and must not be synthesised into the spoken reply.
                 const isStatusNotice = isReplyPayloadStatusNotice(payload);
-                if (payload.text && !isStatusNotice) {
+                if (payload.text && !isStatusNotice && payload.isReasoning !== true) {
                   const joinsBufferedTtsDirective =
                     cleanBlockTtsDirectiveText?.hasBufferedDirectiveText() === true;
                   if (accumulatedBlockText.length > 0) {
@@ -3330,7 +3334,10 @@ export async function dispatchReplyFromConfig(
                   blockCount++;
                 }
                 const visiblePayload =
-                  payload.text && cleanBlockTtsDirectiveText && !isStatusNotice
+                  payload.text &&
+                  cleanBlockTtsDirectiveText &&
+                  !isStatusNotice &&
+                  payload.isReasoning !== true
                     ? (() => {
                         const text = cleanBlockTtsDirectiveText.push(payload.text);
                         return copyReplyPayloadMetadata(payload, {
@@ -3359,16 +3366,19 @@ export async function dispatchReplyFromConfig(
                 if (isDispatchOperationAborted()) {
                   return;
                 }
-                const ttsPayload = await maybeApplyTtsToReplyPayload({
-                  payload: visiblePayload,
-                  cfg,
-                  channel: deliveryChannel,
-                  kind: "block",
-                  inboundAudio,
-                  ttsAuto: sessionTtsAuto,
-                  agentId: sessionAgentId,
-                  accountId: replyRoute.accountId,
-                });
+                const ttsPayload =
+                  payload.isReasoning === true
+                    ? visiblePayload
+                    : await maybeApplyTtsToReplyPayload({
+                        payload: visiblePayload,
+                        cfg,
+                        channel: deliveryChannel,
+                        kind: "block",
+                        inboundAudio,
+                        ttsAuto: sessionTtsAuto,
+                        agentId: sessionAgentId,
+                        accountId: replyRoute.accountId,
+                      });
                 const normalizedPayload = await normalizeReplyMediaPayload(ttsPayload);
                 if (isDispatchOperationAborted()) {
                   return;
@@ -3479,9 +3489,9 @@ export async function dispatchReplyFromConfig(
       (ctx.InboundEventKind !== "room_event" || explicitCommandTurnCtx);
     for (const [replyIndex, reply] of replies.entries()) {
       throwIfDispatchOperationAborted();
-      // Suppress reasoning payloads from channel delivery — channels using this
-      // generic dispatch path do not have a dedicated reasoning lane.
-      if (reply.isReasoning === true) {
+      // Durable reasoning is a channel-owned lane; generic channels keep the
+      // historical suppression unless they explicitly opt in.
+      if (reply.isReasoning === true && !reasoningPayloadsEnabled) {
         continue;
       }
       if (suppressDelivery && !shouldDeliverDespiteSourceReplySuppression(reply)) {


### PR DESCRIPTION
Related: #94937
Related: #95051
Related: #96106

## What Problem This Solves

Fixes an issue where Telegram users with reasoning enabled could lose durable reasoning replies when an agent emitted them as reasoning block or final payloads. The shared reply dispatcher suppressed those payloads before Telegram's reasoning lane could render them.

## Why This Change Was Made

This adds an explicit shared `reasoningPayloadsEnabled` opt-in for channels that own a separate reasoning lane. Telegram enables that opt-in only when its resolved reasoning level is not `off`; generic channels keep the historical suppression, and shared TTS no longer synthesizes reasoning payloads.

## User Impact

Telegram can show durable reasoning in the reasoning lane when users have reasoning enabled, without exposing hidden reasoning when the lane is off. Other channels keep their previous behavior unless they deliberately opt into the shared reasoning payload path.

## Evidence

- `node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.test.ts extensions/telegram/src/bot-message-dispatch.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local --base upstream/main` -> clean: no accepted/actionable findings reported

AI-assisted with Codex.
