### PR TITLE
fix(auth-profiles): preserve secret refs and OAuth fields during doctor auth migration

### DIFF
--- a/src/agents/auth-profiles/persisted-boundary.test.ts
+++ b/src/agents/auth-profiles/persisted-boundary.test.ts
@@ -3,10 +3,19 @@
  * Covers malformed credential coercion, state merging, legacy OAuth refs, and
  * main/agent store drift repair.
  */
-import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
 import { AUTH_STORE_VERSION } from "./constants.js";
 import { resolveAuthProfileOrder } from "./order.js";
-import { coercePersistedAuthProfileStore, mergeAuthProfileStores } from "./persisted.js";
+import {
+  applyLegacyAuthStore,
+  coercePersistedAuthProfileStore,
+  loadLegacyAuthProfileStore,
+  mergeAuthProfileStores,
+} from "./persisted.js";
+import type { AuthProfileStore } from "./types.js";
 
 describe("persisted auth profile boundary", () => {
   it("normalizes malformed persisted credentials and state before runtime use", () => {
@@ -418,5 +427,83 @@ describe("persisted auth profile boundary", () => {
     });
     expect(merged.order?.anthropic).toEqual([profileId]);
     expect(merged.lastGood?.anthropic).toBe(profileId);
+  });
+});
+
+describe("applyLegacyAuthStore", () => {
+  const agentDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of agentDirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function writeLegacyAuthJson(value: unknown): string {
+    const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "oc-legacy-auth-"));
+    agentDirs.push(agentDir);
+    fs.writeFileSync(path.join(agentDir, "auth.json"), JSON.stringify(value), "utf8");
+    return agentDir;
+  }
+
+  it("preserves OAuth refresh material when migrating legacy auth.json", () => {
+    const agentDir = writeLegacyAuthJson({
+      chutes: {
+        type: "oauth",
+        provider: "chutes",
+        access: "ACCESS_TOKEN",
+        refresh: "REFRESH_TOKEN",
+        expires: 1_900_000_000_000,
+        clientId: "chutes-client-id-123",
+        idToken: "ID_TOKEN_xyz",
+        chatgptPlanType: "pro",
+      },
+    });
+    const legacy = loadLegacyAuthProfileStore(agentDir);
+    expect(legacy).not.toBeNull();
+
+    const store: AuthProfileStore = { version: AUTH_STORE_VERSION, profiles: {} };
+    applyLegacyAuthStore(store, legacy ?? {});
+
+    expect(store.profiles["chutes:default"]).toMatchObject({
+      type: "oauth",
+      provider: "chutes",
+      access: "ACCESS_TOKEN",
+      refresh: "REFRESH_TOKEN",
+      clientId: "chutes-client-id-123",
+      idToken: "ID_TOKEN_xyz",
+      chatgptPlanType: "pro",
+    });
+  });
+
+  it("preserves secret-ref credentials when migrating legacy auth.json", () => {
+    const agentDir = writeLegacyAuthJson({
+      openai: {
+        type: "api_key",
+        provider: "openai",
+        keyRef: { source: "env", id: "OPENAI_API_KEY" },
+      },
+      anthropic: {
+        type: "token",
+        provider: "anthropic",
+        tokenRef: { source: "env", id: "ANTHROPIC_TOKEN" },
+      },
+    });
+    const legacy = loadLegacyAuthProfileStore(agentDir);
+    expect(legacy).not.toBeNull();
+
+    const store: AuthProfileStore = { version: AUTH_STORE_VERSION, profiles: {} };
+    applyLegacyAuthStore(store, legacy ?? {});
+
+    expect(store.profiles["openai:default"]).toMatchObject({
+      type: "api_key",
+      provider: "openai",
+      keyRef: { source: "env", id: "OPENAI_API_KEY" },
+    });
+    expect(store.profiles["anthropic:default"]).toMatchObject({
+      type: "token",
+      provider: "anthropic",
+      tokenRef: { source: "env", id: "ANTHROPIC_TOKEN" },
+    });
   });
 });

--- a/src/agents/auth-profiles/persisted.ts
+++ b/src/agents/auth-profiles/persisted.ts
@@ -227,6 +227,15 @@ function parseCredentialEntry(
   };
 }
 
+/** Normalizes a single legacy credential entry into a canonical credential. */
+export function parseLegacyCredentialEntry(
+  raw: unknown,
+  fallbackProvider?: string,
+): AuthProfileCredential | null {
+  const parsed = parseCredentialEntry(raw, fallbackProvider);
+  return parsed.ok ? parsed.credential : null;
+}
+
 function warnRejectedCredentialEntries(source: string, rejected: RejectedCredentialEntry[]): void {
   if (rejected.length === 0) {
     return;
@@ -744,37 +753,9 @@ export function buildPersistedAuthProfileSecretsStore(
 /** Applies legacy auth.json credentials into an auth profile store. */
 export function applyLegacyAuthStore(store: AuthProfileStore, legacy: LegacyAuthStore): void {
   for (const [provider, cred] of Object.entries(legacy)) {
-    const profileId = `${provider}:default`;
-    const credentialProvider = cred.provider ?? provider;
-    if (cred.type === "api_key") {
-      store.profiles[profileId] = {
-        type: "api_key",
-        provider: credentialProvider,
-        key: cred.key,
-        ...(cred.email ? { email: cred.email } : {}),
-      };
-      continue;
-    }
-    if (cred.type === "token") {
-      store.profiles[profileId] = {
-        type: "token",
-        provider: credentialProvider,
-        token: cred.token,
-        ...(typeof cred.expires === "number" ? { expires: cred.expires } : {}),
-        ...(cred.email ? { email: cred.email } : {}),
-      };
-      continue;
-    }
-    store.profiles[profileId] = {
-      type: "oauth",
-      provider: credentialProvider,
-      access: cred.access,
-      refresh: cred.refresh,
-      expires: cred.expires,
-      ...(cred.enterpriseUrl ? { enterpriseUrl: cred.enterpriseUrl } : {}),
-      ...(cred.projectId ? { projectId: cred.projectId } : {}),
-      ...(cred.accountId ? { accountId: cred.accountId } : {}),
-      ...(cred.email ? { email: cred.email } : {}),
+    store.profiles[`${provider}:default`] = {
+      ...cred,
+      provider: cred.provider ?? provider,
     };
   }
 }

--- a/src/commands/doctor-auth-flat-profiles.test.ts
+++ b/src/commands/doctor-auth-flat-profiles.test.ts
@@ -117,6 +117,55 @@ describe("maybeMigrateAuthProfileJsonStoresToSqlite", () => {
     expect(fs.existsSync(`${statePath}.sqlite-import.456.bak`)).toBe(true);
   });
 
+  it("preserves secret refs and OAuth material when migrating a flat auth-profiles.json", async () => {
+    const state = await makeTestState();
+    const authPath = await writeLegacyAuthProfilesJson(state, {
+      chutes: {
+        type: "oauth",
+        provider: "chutes",
+        access: "ACCESS_TOKEN",
+        refresh: "REFRESH_TOKEN",
+        expires: 1_900_000_000_000,
+        clientId: "chutes-client-id-123",
+        idToken: "ID_TOKEN_xyz",
+        chatgptPlanType: "pro",
+      },
+      openai: {
+        type: "api_key",
+        provider: "openai",
+        keyRef: { source: "env", id: "OPENAI_API_KEY" },
+      },
+    });
+
+    const result = await maybeMigrateAuthProfileJsonStoresToSqlite({
+      cfg: {},
+      prompter: makePrompter(true),
+      now: () => 472,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(loadPersistedAuthProfileStore(state.agentDir())).toMatchObject({
+      profiles: {
+        "chutes:default": {
+          type: "oauth",
+          provider: "chutes",
+          access: "ACCESS_TOKEN",
+          refresh: "REFRESH_TOKEN",
+          clientId: "chutes-client-id-123",
+          idToken: "ID_TOKEN_xyz",
+          chatgptPlanType: "pro",
+        },
+        "openai:default": {
+          type: "api_key",
+          provider: "openai",
+          keyRef: { source: "env", id: "OPENAI_API_KEY" },
+        },
+      },
+    });
+    expect(fs.existsSync(authPath)).toBe(false);
+    expect(fs.existsSync(`${authPath}.sqlite-import.472.bak`)).toBe(true);
+  });
+
   it("moves legacy aws-sdk auth markers to config before removing JSON", async () => {
     const state = await makeTestState();
     const cfg = {};

--- a/src/commands/doctor-auth-flat-profiles.ts
+++ b/src/commands/doctor-auth-flat-profiles.ts
@@ -16,6 +16,7 @@ import {
   coercePersistedAuthProfileStore,
   loadLegacyAuthProfileStore,
   loadPersistedAuthProfileStore,
+  parseLegacyCredentialEntry,
 } from "../agents/auth-profiles/persisted.js";
 import { coerceAuthProfileState } from "../agents/auth-profiles/state.js";
 import {
@@ -188,7 +189,13 @@ function inferLegacyCredentialType(
   if (readNonEmptyString(record.key) ?? readNonEmptyString(record.apiKey)) {
     return "api_key";
   }
+  if (coerceSecretRef(record.keyRef)) {
+    return "api_key";
+  }
   if (readNonEmptyString(record.token)) {
+    return "token";
+  }
+  if (coerceSecretRef(record.tokenRef)) {
     return "token";
   }
   if (
@@ -208,50 +215,16 @@ function coerceLegacyFlatCredential(
   if (!isRecord(raw)) {
     return null;
   }
-  const provider = readNonEmptyString(raw.provider) ?? providerId;
   const type = inferLegacyCredentialType(raw);
-  const email = readNonEmptyString(raw.email);
-  if (type === "api_key") {
-    const key = readNonEmptyString(raw.key) ?? readNonEmptyString(raw.apiKey);
-    return key ? { type, provider, key, ...(email ? { email } : {}) } : null;
+  if (!type) {
+    return null;
   }
-  if (type === "token") {
-    const token = readNonEmptyString(raw.token);
-    return token
-      ? {
-          type,
-          provider,
-          token,
-          ...(typeof raw.expires === "number" ? { expires: raw.expires } : {}),
-          ...(email ? { email } : {}),
-        }
-      : null;
+  const provider = readNonEmptyString(raw.provider) ?? providerId;
+  const credential = parseLegacyCredentialEntry({ ...raw, type, provider }, providerId);
+  if (!credential || !hasUsableAuthProfileCredential(credential)) {
+    return null;
   }
-  if (type === "oauth") {
-    const access = readNonEmptyString(raw.access);
-    const refresh = readNonEmptyString(raw.refresh);
-    if (!access || !refresh || typeof raw.expires !== "number") {
-      return null;
-    }
-    return {
-      type,
-      provider,
-      access,
-      refresh,
-      expires: raw.expires,
-      ...(readNonEmptyString(raw.enterpriseUrl)
-        ? { enterpriseUrl: readNonEmptyString(raw.enterpriseUrl) }
-        : {}),
-      ...(readNonEmptyString(raw.projectId)
-        ? { projectId: readNonEmptyString(raw.projectId) }
-        : {}),
-      ...(readNonEmptyString(raw.accountId)
-        ? { accountId: readNonEmptyString(raw.accountId) }
-        : {}),
-      ...(email ? { email } : {}),
-    };
-  }
-  return null;
+  return credential;
 }
 
 function coerceLegacyFlatAuthProfileStore(raw: unknown): AuthProfileStore | null {


### PR DESCRIPTION
## What Problem This Solves

`openclaw doctor --fix` migrates a user's legacy auth credentials into the canonical per-agent SQLite store and then backs up and removes the old JSON files. Both migration writers rebuild each credential from a hardcoded subset of fields and silently drop the rest, so the migration permanently loses refresh-critical and secret material:

- `applyLegacyAuthStore` (`src/agents/auth-profiles/persisted.ts`), which imports the legacy `auth.json` file, drops `keyRef` and `tokenRef` (secret-ref indirection) and the OAuth `clientId`, `idToken`, and `chatgptPlanType` fields.
- `coerceLegacyFlatCredential` (`src/commands/doctor-auth-flat-profiles.ts`), which imports a flat-shaped `auth-profiles.json`, drops the identical fields and returns `null` for a secret-ref-only credential, so that credential is not imported at all.

The post-migration verification only checks that profile ids exist, so the corruption passes silently. The legacy file is then removed, and the user later hits auth failures (OAuth that can no longer refresh, or an API key with no secret) with no upgrade-time warning. The two writers read different files (`auth.json` vs a flat `auth-profiles.json`), so each is independently reachable; fixing one is not enough.

This is distinct from #97522/#97541 (doctor overwrites a second OAuth account), #96544 (map-key collision), and #93814 (trajectory export). The open #93352 adds a runtime read-path importer in different functions and does not address the dropped fields.

## Why This Change Was Made

The asymmetry is reader vs writer. The canonical credential reader `parseCredentialEntry` (used by `loadLegacyAuthProfileStore` and `coercePersistedAuthProfileStore`) already normalizes and preserves the full credential, including `keyRef`, `tokenRef`, `clientId`, `idToken`, and `chatgptPlanType`. The two migration writers hand-rebuilt a lossy copy of that normalization instead of reusing it.

- `applyLegacyAuthStore` receives an already-parsed `AuthProfileCredential` (`LegacyAuthStore = Record<string, AuthProfileCredential>`), so it now preserves that credential as-is and only defaults the provider from the map key. This deletes the duplicate field-by-field rebuild.
- `coerceLegacyFlatCredential` now delegates field extraction to the same canonical parser via the new `parseLegacyCredentialEntry`, keeping its existing flat-shape type inference as the acceptance gate and `hasUsableAuthProfileCredential` as the usability gate. This keeps every prior accept/reject decision identical while preserving all fields, and removes the duplicate parser.

Net production code drops by 46 lines, and both migration paths now share one normalization path, so they cannot drift apart again.

## User Impact

Users running `openclaw doctor --fix` with a legacy `auth.json` or a flat `auth-profiles.json` keep their full credentials after migration: OAuth refresh material (`clientId`, `idToken`, `chatgptPlanType`) survives, secret-ref-backed API keys and tokens survive, and secret-ref-only credentials are no longer dropped. No config or behavior change for credentials that already migrated cleanly.

## Evidence

Both migration legs were driven with their real production entry points on pristine `origin/main` (`6de357ad47`) and on this patch, with identical inputs.

The legacy `auth.json` leg was driven through `loadLegacyAuthProfileStore` + `applyLegacyAuthStore` (the exact functions the doctor import calls). The flat `auth-profiles.json` leg was driven end to end through `maybeMigrateAuthProfileJsonStoresToSqlite` (the real doctor migration), then read back from the real SQLite store via `loadPersistedAuthProfileStore`.

## Verification

- `node scripts/run-vitest.mjs src/agents/auth-profiles/persisted-boundary.test.ts src/commands/doctor-auth-flat-profiles.test.ts` passes (38 tests). The 3 new tests fail on pristine `origin/main` and pass with this patch.
- `oxlint` and `oxfmt --check` clean on the 4 changed files.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json` and `-p test/tsconfig/tsconfig.core.test.json` both clean.
- Full build not run (no packaging, dynamic-import, or module-boundary changes).

## Real behavior proof
Behavior addressed: openclaw doctor --fix migration dropped OAuth refresh fields (clientId/idToken/chatgptPlanType) and secret refs (keyRef/tokenRef) from both the legacy auth.json writer and the flat auth-profiles.json writer, silently degrading or destroying credentials.
Real environment tested: drove the real migration functions on pristine origin/main 6de357ad47 and on the patched tree with identical inputs. The legacy leg ran loadLegacyAuthProfileStore + applyLegacyAuthStore against an on-disk auth.json. The flat leg ran maybeMigrateAuthProfileJsonStoresToSqlite end to end and read the result back from the real per-agent SQLite store via loadPersistedAuthProfileStore. Everything stayed real; nothing stubbed.
Exact steps or command run after this patch: wrote a legacy auth.json and a flat auth-profiles.json holding OAuth extras and secret-ref credentials, ran the real migration, then printed the resulting credential fields.
Evidence after fix:
```
# BEFORE (pristine origin/main 6de357ad47)
# legacy auth.json leg (loadLegacyAuthProfileStore + applyLegacyAuthStore)
migrated.clientId       = undefined
migrated.idToken        = undefined
migrated.chatgptPlanType= undefined
migrated openai api_key has neither key nor keyRef -> credential is unusable (auth lost).
migrated anthropic token has neither token nor tokenRef -> credential is unusable (auth lost).
# flat auth-profiles.json leg (real migration -> SQLite -> loadPersistedAuthProfileStore)
chutes:default  clientId        = undefined
chutes:default  idToken         = undefined
chutes:default  chatgptPlanType = undefined
openai:default  keyRef          = undefined

# AFTER (this patch, identical inputs)
# legacy auth.json leg
migrated.clientId       = "chutes-client-id-123"
migrated.idToken        = "ID_TOKEN_xyz"
migrated.chatgptPlanType= "pro"
migrated api_key fields: email,keyRef,provider,type
migrated token   fields: expires,provider,tokenRef,type
# flat auth-profiles.json leg
chutes:default  clientId        = "chutes-client-id-123"
chutes:default  idToken         = "ID_TOKEN_xyz"
chutes:default  chatgptPlanType = "pro"
openai:default  keyRef          = {"source":"env","provider":"default","id":"OPENAI_API_KEY"}
```
Observed result after fix: on identical inputs the migrated credentials now retain clientId, idToken, chatgptPlanType, and the keyRef/tokenRef secret references on both the legacy auth.json path and the flat auth-profiles.json path, where before they were undefined or the credential was dropped entirely.
What was not tested: no live provider auth request was made against a real OAuth or API endpoint; full build was not run.

### Open question for maintainers
The code-level loss is proven and unmasked on both writers. The real-world blast radius depends on whether shipped flat auth.json / auth-profiles.json files actually carried keyRef, tokenRef, clientId, idToken, or chatgptPlanType. The canonical reader contains explicit parsing for exactly these fields out of the legacy flat shape, which is strong evidence they shipped, but a maintainer who knows the shipped on-disk history can confirm severity.
