### PR TITLE
fix(gateway): inline identity avatar paths

### DIFF
--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -5901,6 +5901,42 @@ describe("gateway agent handler", () => {
     expect(mockCallArg(respond, 0, 2)).toBeUndefined();
   });
 
+  it("inlines workspace avatar paths in agent.identity.get", async () => {
+    await withTempDir({ prefix: "openclaw-gateway-agent-identity-avatar-" }, async (root) => {
+      const workspace = `${root}/workspace`;
+      await fs.mkdir(`${workspace}/avatar`, { recursive: true });
+      await fs.writeFile(`${workspace}/avatar/photo.png`, "avatar", "utf8");
+      mocks.loadConfigReturn = {
+        agents: {
+          list: [
+            {
+              id: "main",
+              default: true,
+              workspace,
+              identity: { avatar: "avatar/photo.png" },
+            },
+          ],
+        },
+      };
+
+      const respond = await invokeAgentIdentityGet(
+        {
+          sessionKey: "agent:main:main",
+        },
+        { reqId: "5-avatar-inline" },
+      );
+
+      expect(mockCallArg(respond)).toBe(true);
+      expectRecordFields(mockCallArg(respond, 0, 1), {
+        agentId: "main",
+        avatar: `data:image/png;base64,${Buffer.from("avatar").toString("base64")}`,
+        avatarSource: "avatar/photo.png",
+        avatarStatus: "local",
+      });
+      expect(mockCallArg(respond, 0, 2)).toBeUndefined();
+    });
+  });
+
   it("allows non-delivery agent invocations when sendPolicy is deny", async () => {
     mocks.agentCommand.mockClear();
     primeMainAgentRun();

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -152,6 +152,7 @@ import {
   canonicalizeSpawnedByForAgent,
   loadSessionEntry,
   migrateAndPruneGatewaySessionStoreKey,
+  resolveIdentityAvatarUrl,
   resolveGatewaySessionStoreTarget,
   resolveGatewayModelSupportsImages,
   resolveSessionStoreKey,
@@ -2910,11 +2911,13 @@ export const agentHandlers: GatewayRequestHandlers = {
     const cfg = context.getRuntimeConfig();
     const identity = resolveAssistantIdentity({ cfg, agentId });
     const avatarValue =
+      resolveIdentityAvatarUrl(cfg, identity.agentId, identity.avatar) ??
       resolveAssistantAvatarUrl({
         avatar: identity.avatar,
         agentId: identity.agentId,
         basePath: cfg.gateway?.controlUi?.basePath,
-      }) ?? identity.avatar;
+      }) ??
+      identity.avatar;
     const avatarResolution = resolveAgentAvatar(cfg, identity.agentId, { includeUiOverride: true });
     respond(
       true,

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -30,6 +30,7 @@ import {
   resolveGatewayModelSupportsImages,
   resolveGatewaySessionStoreTarget,
   resolveGatewaySessionStoreTargetWithStore,
+  resolveIdentityAvatarUrl,
   resolveSessionDisplayModelIdentityRef,
   resolveSessionModelIdentityRef,
   resolveSessionModelRef,
@@ -1495,6 +1496,22 @@ describe("gateway session utils", () => {
 
     const result = listAgentsForGateway(cfg);
     expect(result.agents[0]?.identity?.avatarUrl).toBe(
+      `data:image/png;base64,${Buffer.from("avatar").toString("base64")}`,
+    );
+  });
+
+  test("resolveIdentityAvatarUrl inlines workspace-relative avatar paths", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "session-utils-avatar-inline-"));
+    const workspace = path.join(root, "workspace");
+    fs.mkdirSync(path.join(workspace, "avatar"), { recursive: true });
+    fs.writeFileSync(path.join(workspace, "avatar", "photo.png"), "avatar", "utf8");
+    const cfg = {
+      agents: {
+        list: [{ id: "main", default: true, workspace }],
+      },
+    } as OpenClawConfig;
+
+    expect(resolveIdentityAvatarUrl(cfg, "main", "avatar/photo.png")).toBe(
       `data:image/png;base64,${Buffer.from("avatar").toString("base64")}`,
     );
   });

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -164,7 +164,7 @@ function tryResolveExistingPath(value: string): string | null {
   }
 }
 
-function resolveIdentityAvatarUrl(
+export function resolveIdentityAvatarUrl(
   cfg: OpenClawConfig,
   agentId: string,
   avatar: string | undefined,


### PR DESCRIPTION
﻿Closes #97602

## What Problem This Solves

Fixes an issue where users with workspace-relative agent avatars would see a broken Personal card avatar in Control UI because `agent.identity.get` returned an auth-gated `/avatar/<agentId>` URL that browser `<img>` requests cannot load with bearer auth.

## Why This Change Was Made

The identity RPC now reuses the same workspace-safe avatar data URI projection already used by `agents.list` before falling back to the existing Control UI avatar URL resolver. This keeps `/avatar/<agentId>` authentication unchanged while making the Personal card and agent list agree for local workspace avatars.

## User Impact

Control UI can display configured local agent avatars consistently in the Personal card without requiring users to refresh credentials, change config, or expose the avatar route without auth.

## Evidence

- `git diff --check`
- `node_modules/.bin/oxfmt.cmd --check src/gateway/server-methods/agent.ts src/gateway/server-methods/agent.test.ts src/gateway/session-utils.ts src/gateway/session-utils.test.ts`
- Added regression coverage for `agent.identity.get` returning a data URI for workspace-relative avatars and for the shared resolver used by `agents.list`.

Local validation gap: in this Windows worktree, `node scripts/run-vitest.mjs src/gateway/server-methods/agent.test.ts -t "inlines workspace avatar paths in agent.identity.get"`, `node scripts/run-vitest.mjs src/gateway/session-utils.test.ts -t "resolveIdentityAvatarUrl inlines workspace-relative avatar paths"`, direct `vitest run`, and `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.src.json ...` all started but produced no test output before timing out. Crabbox wrapper also failed local sanity checks before dispatch. CI should run the focused tests/type lanes from a clean Linux runner.
