### PR TITLE
fix(openrouter): avoid DeepSeek V4 reasoning conflicts

### DIFF
--- a/extensions/openrouter/index.test.ts
+++ b/extensions/openrouter/index.test.ts
@@ -1058,6 +1058,48 @@ describe("openrouter provider hooks", () => {
     expect(baseStreamFn).toHaveBeenCalledOnce();
   });
 
+  it("does not leave both OpenRouter reasoning and DeepSeek V4 reasoning_effort", async () => {
+    const provider = await registerSingleProviderPlugin(openrouterPlugin);
+    let capturedPayload: Record<string, unknown> | undefined;
+    const baseStreamFn = vi.fn(
+      (
+        ...args: Parameters<import("openclaw/plugin-sdk/agent-core").StreamFn>
+      ): ReturnType<import("openclaw/plugin-sdk/agent-core").StreamFn> => {
+        const payload = {
+          reasoning: { effort: "low" },
+          messages: [{ role: "user", content: "hello" }],
+        };
+        void args[2]?.onPayload?.(payload, args[0]);
+        capturedPayload = payload;
+        return { async *[Symbol.asyncIterator]() {} } as never;
+      },
+    );
+
+    const wrapped = provider.wrapStreamFn?.({
+      provider: "openrouter",
+      modelId: "openrouter/deepseek/deepseek-v4-pro",
+      streamFn: baseStreamFn,
+      thinkingLevel: "high",
+    } as never);
+
+    void wrapped?.(
+      {
+        provider: "openrouter",
+        api: "openai-completions",
+        id: "openrouter/deepseek/deepseek-v4-pro",
+        baseUrl: "https://openrouter.ai/api/v1",
+        compat: {},
+      } as never,
+      { messages: [] } as never,
+      {},
+    );
+
+    expect(capturedPayload?.thinking).toEqual({ type: "enabled" });
+    expect(capturedPayload?.reasoning_effort).toBe("high");
+    expect(capturedPayload).not.toHaveProperty("reasoning");
+    expect(baseStreamFn).toHaveBeenCalledOnce();
+  });
+
   it("keeps OpenRouter DeepSeek V4 reasoning_effort within OpenRouter values", async () => {
     const provider = await registerSingleProviderPlugin(openrouterPlugin);
     const payloads: Array<Record<string, unknown>> = [];

--- a/src/plugin-sdk/provider-stream-shared.test.ts
+++ b/src/plugin-sdk/provider-stream-shared.test.ts
@@ -234,6 +234,31 @@ describe("normalizeOpenAICompatibleReasoningPayload", () => {
 });
 
 describe("createDeepSeekV4OpenAICompatibleThinkingWrapper", () => {
+  it("removes nested reasoning when writing DeepSeek V4 reasoning_effort", () => {
+    const payload: Record<string, unknown> = {
+      reasoning: { effort: "low" },
+      messages: [{ role: "user", content: "hello" }],
+    };
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      options?.onPayload?.(payload as never, _model as never);
+      return {} as ReturnType<StreamFn>;
+    };
+    const wrapped = createDeepSeekV4OpenAICompatibleThinkingWrapper({
+      baseStreamFn,
+      thinkingLevel: "high",
+      shouldPatchModel: () => true,
+      resolveReasoningEffort: () => "high",
+    });
+
+    void wrapped?.({} as never, {} as never, {});
+
+    expect(payload).toMatchObject({
+      thinking: { type: "enabled" },
+      reasoning_effort: "high",
+    });
+    expect(payload).not.toHaveProperty("reasoning");
+  });
+
   it("backfills reasoning_content on every replayed assistant message when thinking is enabled", () => {
     const payload = {
       messages: [

--- a/src/plugin-sdk/provider-stream-shared.ts
+++ b/src/plugin-sdk/provider-stream-shared.ts
@@ -550,6 +550,7 @@ export function createDeepSeekV4OpenAICompatibleThinkingWrapper(params: {
       }
 
       payload.thinking = { type: "enabled" };
+      delete payload.reasoning;
       payload.reasoning_effort = resolveReasoningEffort(params.thinkingLevel);
       ensureDeepSeekV4AssistantReasoningContent(payload, {
         shouldBackfillAssistantMessage: params.shouldBackfillAssistantReasoningContent,


### PR DESCRIPTION
﻿Closes #97196

## What Problem This Solves

Fixes an issue where OpenRouter-routed DeepSeek V4 requests could fail with HTTP 400 because the final OpenAI-compatible payload contained both nested `reasoning.effort` and top-level `reasoning_effort`.

## Why This Change Was Made

The DeepSeek V4 OpenAI-compatible thinking wrapper now removes nested `reasoning` whenever it writes top-level `reasoning_effort`, so composed OpenRouter payload wrappers leave exactly one reasoning-effort representation. This keeps the existing DeepSeek V4 replay/backfill behavior intact and does not change OpenRouter routing or provider auth behavior.

## User Impact

Users can run OpenRouter DeepSeek V4 models without manually pinning `compat.thinkingFormat = "openrouter"` to avoid conflicting reasoning fields.

## Evidence

- `git diff --check`
- `oxfmt --check extensions/openrouter/index.test.ts src/plugin-sdk/provider-stream-shared.ts src/plugin-sdk/provider-stream-shared.test.ts`
- Added regression coverage at the shared DeepSeek V4 wrapper level and at the OpenRouter wrapper composition level to assert the final payload does not contain both `reasoning` and `reasoning_effort`.

Local validation gap: this fresh worktree does not have `node_modules`, so `node scripts/run-vitest.mjs src/plugin-sdk/provider-stream-shared.test.ts -t "removes nested reasoning when writing DeepSeek V4 reasoning_effort"` could not resolve Vitest. A sibling installed worktree was used only for `oxfmt`; CI should run the focused Vitest/type lanes from a clean Linux runner.
