### PR TITLE
fix: log failed terminal session persistence

### DIFF
--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -97,6 +97,7 @@ describe("agent event handler", () => {
     const broadcast = vi.fn();
     const broadcastToConnIds = vi.fn();
     const nodeSendToSession = vi.fn();
+    const logGateway = { error: vi.fn() };
     const clearAgentRunContext = vi.fn();
     const clearTrackedActiveRun =
       vi.fn<NonNullable<AgentEventHandlerOptions["clearTrackedActiveRun"]>>();
@@ -117,6 +118,7 @@ describe("agent event handler", () => {
       toolEventRecipients,
       sessionEventSubscribers,
       sessionMessageSubscribers,
+      logGateway,
       loadGatewaySessionRowForSnapshot: loadGatewaySessionRow,
       lifecycleErrorRetryGraceMs: params?.lifecycleErrorRetryGraceMs,
       isChatSendRunActive: params?.isChatSendRunActive,
@@ -131,6 +133,7 @@ describe("agent event handler", () => {
       broadcast,
       broadcastToConnIds,
       nodeSendToSession,
+      logGateway,
       clearAgentRunContext,
       clearTrackedActiveRun,
       agentRunSeq,
@@ -2502,7 +2505,7 @@ describe("agent event handler", () => {
     });
     persistGatewaySessionLifecycleEventMock.mockRejectedValueOnce(new Error("disk full"));
     const markTrackedRunTerminalPersisted = vi.fn();
-    const { broadcastToConnIds, handler, sessionEventSubscribers } = createHarness({
+    const { broadcastToConnIds, handler, logGateway, sessionEventSubscribers } = createHarness({
       resolveSessionKeyForRun: () => "session-failed-write",
       lifecycleErrorRetryGraceMs: 0,
       markTrackedRunTerminalPersisted,
@@ -2532,6 +2535,15 @@ describe("agent event handler", () => {
       updatedAt: 2_100,
       abortedLastRun: false,
     });
+    expect(logGateway.error).toHaveBeenCalledWith(
+      "terminal session persistence failed",
+      expect.objectContaining({
+        runId: "run-failed-write",
+        clientRunId: "run-failed-write",
+        sessionKey: "session-failed-write",
+        error: expect.stringContaining("disk full"),
+      }),
+    );
     expect(markTrackedRunTerminalPersisted).not.toHaveBeenCalled();
   });
 

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -9,6 +9,7 @@ import { getRuntimeConfig } from "../config/io.js";
 import { type AgentEventPayload, getAgentRunContext } from "../infra/agent-events.js";
 import { detectErrorKind, type ErrorKind } from "../infra/errors.js";
 import { resolveHeartbeatVisibility } from "../infra/heartbeat-visibility.js";
+import type { SubsystemLogger } from "../logging/subsystem.js";
 import { isAcpSessionKey, isSubagentSessionKey } from "../sessions/session-key-utils.js";
 import { resolveAssistantEventPhase } from "../shared/chat-message-content.js";
 import { setSafeTimeout } from "../utils/timer-delay.js";
@@ -268,6 +269,7 @@ export type AgentEventHandlerOptions = {
   toolEventRecipients: ToolEventRecipientRegistry;
   sessionEventSubscribers: SessionEventSubscriberRegistry;
   sessionMessageSubscribers: SessionMessageSubscriberRegistry;
+  logGateway?: Pick<SubsystemLogger, "error">;
   loadGatewaySessionRowForSnapshot?: typeof loadGatewaySessionRow;
   lifecycleErrorRetryGraceMs?: number;
   isChatSendRunActive?: (runId: string) => boolean;
@@ -307,6 +309,7 @@ export function createAgentEventHandler({
   toolEventRecipients,
   sessionEventSubscribers,
   sessionMessageSubscribers,
+  logGateway,
   loadGatewaySessionRowForSnapshot = loadGatewaySessionRow,
   lifecycleErrorRetryGraceMs = AGENT_LIFECYCLE_ERROR_RETRY_GRACE_MS,
   isChatSendRunActive = () => false,
@@ -716,7 +719,13 @@ export function createAgentEventHandler({
             markPersisted();
             broadcastSessionChange();
           })
-          .catch(() => {
+          .catch((err: unknown) => {
+            logGateway?.error("terminal session persistence failed", {
+              runId: evt.runId,
+              clientRunId,
+              sessionKey,
+              error: formatForLog(err),
+            });
             // Persistence recovery remains tracked by the controller entry, but
             // subscribers still need a terminal projection instead of hanging.
             broadcastSessionChange(evt);

--- a/src/gateway/server-runtime-subscriptions.ts
+++ b/src/gateway/server-runtime-subscriptions.ts
@@ -1,6 +1,7 @@
 // Gateway event subscription wiring for agent, heartbeat, transcript, and lifecycle broadcasts.
 import { clearAgentRunContext, onAgentEvent } from "../infra/agent-events.js";
 import { onHeartbeatEvent } from "../infra/heartbeat-events.js";
+import type { SubsystemLogger } from "../logging/subsystem.js";
 import { onSessionLifecycleEvent } from "../sessions/session-lifecycle-events.js";
 import { onInternalSessionTranscriptUpdate } from "../sessions/transcript-events.js";
 import type { ChatAbortControllerEntry, RestartRecoveryCandidate } from "./chat-abort.js";
@@ -28,6 +29,7 @@ export function startGatewayEventSubscriptions(params: {
   sessionMessageSubscribers: SessionMessageSubscriberRegistry;
   chatAbortControllers: Map<string, ChatAbortControllerEntry>;
   restartRecoveryCandidates: Map<string, RestartRecoveryCandidate>;
+  logGateway?: Pick<SubsystemLogger, "error">;
 }) {
   let agentEventHandlerPromise: Promise<
     ReturnType<typeof import("./server-chat.js").createAgentEventHandler>
@@ -49,6 +51,7 @@ export function startGatewayEventSubscriptions(params: {
         toolEventRecipients: params.toolEventRecipients,
         sessionEventSubscribers: params.sessionEventSubscribers,
         sessionMessageSubscribers: params.sessionMessageSubscribers,
+        logGateway: params.logGateway,
         clearTrackedActiveRun: ({ runId, clientRunId }) => {
           const candidateRunIds = runId === clientRunId ? [runId] : [runId, clientRunId];
           for (const candidateRunId of candidateRunIds) {

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -1195,6 +1195,7 @@ export async function startGatewayServer(
         sessionMessageSubscribers,
         chatAbortControllers,
         restartRecoveryCandidates,
+        logGateway: log,
       }),
     );
     Object.assign(runtimeState, runtimeSubscriptions);


### PR DESCRIPTION
Closes #97795

## What Problem This Solves

Fixes an issue where operators would lose visibility into terminal session persistence failures when an agent run finished and the session-store write rejected. The gateway still broadcast a terminal fallback projection, but the underlying write error was swallowed, making storage or filesystem problems much harder to diagnose.

## Why This Change Was Made

The fix keeps the existing cleanup, restart-recovery, and fallback broadcast behavior intact, but threads the gateway logger into the agent-event handler and records the rejected terminal persistence promise once at the persistence owner boundary.

## User Impact

Operators now get a gateway error log with run, client run, session key, and sanitized error context when terminal session persistence fails. Users keep the same terminal fallback behavior instead of seeing stalled session state.

## Evidence

- `node scripts/run-vitest.mjs src/gateway/server-chat.agent-events.test.ts src/gateway/chat-abort.test.ts -- --reporter=dot` — 322 passed
- `node scripts/run-vitest.mjs src/gateway/server-chat.agent-events.test.ts -- --reporter=dot` — 198 passed after final trim
- `pnpm exec oxfmt --check src/gateway/server-chat.ts src/gateway/server-runtime-subscriptions.ts src/gateway/server.impl.ts src/gateway/server-chat.agent-events.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --codex-bin .artifacts/codex-flex --no-web-search` — clean, patch correct 0.88
