### PR TITLE
fix(agents): retry transient silent errors after prior session side effects

### DIFF
--- a/src/agents/embedded-agent-runner/run.empty-error-retry.test.ts
+++ b/src/agents/embedded-agent-runner/run.empty-error-retry.test.ts
@@ -274,12 +274,13 @@ describe("runEmbeddedAgent silent-error retry", () => {
     expect(result.payloads).toBeUndefined();
   });
 
-  it("does not retry when the failed attempt recorded side effects", async () => {
-    // Resubmission would duplicate side effects when replay metadata cannot
-    // prove the failed turn is safe to replay.
+  it("does not retry when the failed attempt recorded current-turn side effects", async () => {
+    // Resubmission would duplicate side effects when the failed attempt itself
+    // ran a replay-unsafe tool before the provider error surfaced.
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: [],
+        toolMetas: [{ toolName: "exec" }],
         lastAssistant: {
           role: "assistant",
           stopReason: "error",
@@ -288,10 +289,6 @@ describe("runEmbeddedAgent silent-error retry", () => {
           content: [],
           usage: { input: 100, output: 0, totalTokens: 100 },
         } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
-        replayMetadata: {
-          hadPotentialSideEffects: true,
-          replaySafe: false,
-        },
       }),
     );
 

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -2756,7 +2756,40 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     ).toBe(false);
   });
 
-  it("does not retry errored thinking-only turns after side effects", () => {
+  it("does not retry errored thinking-only turns when the current turn had tool activity", () => {
+    const assistant = {
+      role: "assistant",
+      stopReason: "error",
+      provider: "anthropic",
+      model: "claude-opus-4-8",
+      content: [
+        {
+          type: "redacted_thinking",
+          data: "opaque",
+        },
+      ],
+      usage: { input: 100, output: 1120, totalTokens: 1220 },
+    } as unknown as EmbeddedRunAttemptResult["lastAssistant"];
+    expect(
+      shouldRetrySilentErrorAssistantTurn({
+        attempt: makeAttemptResult({
+          assistantTexts: [],
+          clientToolCalls: [
+            {
+              id: "call_prior",
+              name: "read",
+              arguments: { path: "README.md" },
+              outcome: { kind: "success", summary: "ok" },
+            },
+          ],
+          lastAssistant: assistant,
+        }),
+        assistant,
+      }),
+    ).toBe(false);
+  });
+
+  it("retries errored thinking-only turns when prior session turns had side effects but the current turn is clean (#97877)", () => {
     const assistant = {
       role: "assistant",
       stopReason: "error",
@@ -2782,7 +2815,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
         }),
         assistant,
       }),
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it("detects empty openai-compatible stop turns with non-zero output usage", () => {

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -2776,10 +2776,8 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
           assistantTexts: [],
           clientToolCalls: [
             {
-              id: "call_prior",
               name: "read",
-              arguments: { path: "README.md" },
-              outcome: { kind: "success", summary: "ok" },
+              params: { path: "README.md" },
             },
           ],
           lastAssistant: assistant,

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -2816,6 +2816,35 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     ).toBe(true);
   });
 
+  it("does not retry errored thinking-only turns when the current turn ran a replay-unsafe sync tool (#97877)", () => {
+    const assistant = {
+      role: "assistant",
+      stopReason: "error",
+      provider: "anthropic",
+      model: "claude-opus-4-8",
+      content: [
+        {
+          type: "redacted_thinking",
+          data: "opaque",
+        },
+      ],
+      usage: { input: 100, output: 1120, totalTokens: 1220 },
+    } as unknown as EmbeddedRunAttemptResult["lastAssistant"];
+    expect(
+      shouldRetrySilentErrorAssistantTurn({
+        attempt: makeAttemptResult({
+          assistantTexts: [],
+          // exec is not in UNCONDITIONALLY_REPLAY_SAFE_TOOL_NAMES, so the
+          // fixture marks replaySafe=false. The current turn is therefore
+          // terminal even without clientToolCalls or async-started activity.
+          toolMetas: [{ toolName: "exec" }],
+          lastAssistant: assistant,
+        }),
+        assistant,
+      }),
+    ).toBe(false);
+  });
+
   it("detects empty openai-compatible stop turns with non-zero output usage", () => {
     const retryInstruction = resolveEmptyResponseRetryInstruction({
       provider: "llamacpp",

--- a/src/agents/embedded-agent-runner/run/incomplete-turn.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn.ts
@@ -535,7 +535,6 @@ export function shouldRetrySilentErrorAssistantTurn(params: {
     | "toolTrustedLocalMedia"
     | "didDeliverSourceReplyViaMessageTool"
     | "messagingToolSourceReplyPayloads"
-    | "replayMetadata"
   >;
   assistant: EmbeddedRunAttemptResult["lastAssistant"] | null | undefined;
 }): boolean {
@@ -543,9 +542,6 @@ export function shouldRetrySilentErrorAssistantTurn(params: {
     return false;
   }
   if (hasAttemptTerminalState(params.attempt)) {
-    return false;
-  }
-  if (resolveAttemptReplayMetadata(params.attempt).hadPotentialSideEffects) {
     return false;
   }
 

--- a/src/agents/embedded-agent-runner/run/incomplete-turn.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn.ts
@@ -535,6 +535,7 @@ export function shouldRetrySilentErrorAssistantTurn(params: {
     | "toolTrustedLocalMedia"
     | "didDeliverSourceReplyViaMessageTool"
     | "messagingToolSourceReplyPayloads"
+    | "toolMetas"
   >;
   assistant: EmbeddedRunAttemptResult["lastAssistant"] | null | undefined;
 }): boolean {
@@ -542,6 +543,14 @@ export function shouldRetrySilentErrorAssistantTurn(params: {
     return false;
   }
   if (hasAttemptTerminalState(params.attempt)) {
+    return false;
+  }
+  // Current-attempt sync tools with declared side effects (replaySafe !== true)
+  // make a retry unsafe — resubmitting would duplicate the tool's effects even
+  // though the attempt produced no visible assistant output. Mirrors
+  // buildAttemptReplayMetadata's hadUnsafeTools gate. Prior-session side effects
+  // already live in replayMetadata and do not block retry of a clean turn (#97877).
+  if ((params.attempt.toolMetas ?? []).some((entry) => entry.replaySafe !== true)) {
     return false;
   }
 

--- a/src/agents/embedded-agent-runner/run/incomplete-turn.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn.ts
@@ -545,11 +545,9 @@ export function shouldRetrySilentErrorAssistantTurn(params: {
   if (hasAttemptTerminalState(params.attempt)) {
     return false;
   }
-  // Current-attempt sync tools with declared side effects (replaySafe !== true)
-  // make a retry unsafe — resubmitting would duplicate the tool's effects even
-  // though the attempt produced no visible assistant output. Mirrors
-  // buildAttemptReplayMetadata's hadUnsafeTools gate. Prior-session side effects
-  // already live in replayMetadata and do not block retry of a clean turn (#97877).
+  // Current-attempt sync tools with declared side effects make a retry unsafe:
+  // resubmitting could duplicate those effects even when no visible assistant
+  // output was produced. Prior-session effects are already committed context.
   if ((params.attempt.toolMetas ?? []).some((entry) => entry.replaySafe !== true)) {
     return false;
   }


### PR DESCRIPTION
Closes #97877

## What Problem This Solves

Fixes an issue where agents that had run at least one tool call earlier in a session could silently terminate with no user-visible reply and no retry when a downstream provider returned a transient HTTP 5xx, or any `stopReason="error"` turn with no visible output, on a later clean turn. The `[empty-error-retry]` resubmit path was blocked by session-accumulated replay metadata even though the failed turn itself had not executed tools.

## Why This Change Was Made

`shouldRetrySilentErrorAssistantTurn` rejected retry whenever `attempt.replayMetadata.hadPotentialSideEffects` was set. That metadata is accumulated across the session, so one earlier replay-unsafe tool call permanently blocked later clean provider-error turns from retrying.

The retry safety boundary should be the current failed attempt. Already committed prior tool results remain transcript context and are not re-executed by resubmitting the failed provider call. Current-turn side effects still block retry: the helper keeps the existing terminal-state checks and now explicitly rejects current-attempt `toolMetas` entries whose `replaySafe` flag is not true.

## User Impact

Agents routed through intermittently failing providers can recover from transient clean error turns mid-session instead of going idle silently after any earlier tool activity. If retries are exhausted, the existing user-facing incomplete-turn warning path still handles the terminal failure.

## Evidence

- `src/agents/embedded-agent-runner/run/incomplete-turn.ts`: `shouldRetrySilentErrorAssistantTurn` now ignores session-wide replay metadata for clean silent provider errors, while still rejecting current-attempt replay-unsafe tool metadata.
- `src/agents/embedded-agent-runner/run.incomplete-turn.test.ts`: adds regression coverage for prior-session side effects with a clean current turn, and keeps no-retry coverage for current-turn client tool activity plus replay-unsafe sync tool metadata.
- `src/agents/embedded-agent-runner/run.empty-error-retry.test.ts`: updates the runner-level side-effect fixture to express current-turn replay-unsafe tool activity via `toolMetas`.
- Local: `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.incomplete-turn.test.ts src/agents/embedded-agent-runner/run.empty-error-retry.test.ts src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts` -> passed.
- Autoreview: `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` -> clean, no accepted/actionable findings.
