### PR TITLE
fix: surface Claude CLI OAuth reauth hints

### DIFF
--- a/src/agents/auth-profiles/oauth-refresh-failure.test.ts
+++ b/src/agents/auth-profiles/oauth-refresh-failure.test.ts
@@ -75,6 +75,63 @@ describe("oauth refresh failure hints", () => {
     );
   });
 
+  it("classifies Claude CLI OAuth 401 provider errors for re-auth guidance", () => {
+    expect(
+      classifyOAuthRefreshFailureError({
+        provider: "claude-cli",
+        rawError: "Failed to authenticate. API Error: 401 Invalid authentication credentials",
+      }),
+    ).toEqual({
+      provider: "claude-cli",
+      reason: "sign_in_again",
+    });
+    expect(
+      classifyOAuthRefreshFailureError({
+        provider: "claude-cli",
+        rawError: "Failed to authenticate. API Error: 401 Invalid bearer token",
+      }),
+    ).toEqual({
+      provider: "claude-cli",
+      reason: "sign_in_again",
+    });
+    expect(
+      classifyOAuthRefreshFailureError({
+        provider: "claude-cli",
+        reason: "auth",
+        status: 401,
+        message: "Invalid authentication credentials",
+      }),
+    ).toEqual({
+      provider: "claude-cli",
+      reason: "sign_in_again",
+    });
+    expect(
+      classifyOAuthRefreshFailureError({
+        provider: "claude-cli",
+        reason: "auth",
+        status: 401,
+        message: "Invalid bearer token",
+      }),
+    ).toEqual({
+      provider: "claude-cli",
+      reason: "sign_in_again",
+    });
+    expect(
+      classifyOAuthRefreshFailureError({
+        provider: "anthropic",
+        reason: "auth",
+        status: 401,
+        message: "Failed to authenticate. API Error: 401 Invalid authentication credentials",
+      }),
+    ).toBeNull();
+    expect(
+      classifyOAuthRefreshFailureError({
+        provider: "claude-cli",
+        message: "Invalid authentication credentials",
+      }),
+    ).toBeNull();
+  });
+
   it("classifies token invalidation refresh failures", () => {
     expect(
       classifyOAuthRefreshFailure(

--- a/src/agents/auth-profiles/oauth-refresh-failure.ts
+++ b/src/agents/auth-profiles/oauth-refresh-failure.ts
@@ -39,6 +39,9 @@ export class OAuthRefreshFailureError extends Error {
 
 const OAUTH_REFRESH_FAILURE_PROVIDER_RE = /OAuth token refresh failed for ([^:]+):/i;
 const SAFE_PROVIDER_ID_RE = /^[a-z0-9][a-z0-9._-]*$/;
+const CLAUDE_CLI_AUTH_FAILURE_RE =
+  /\bfailed to authenticate\b[\s\S]*\b401\b[\s\S]*\binvalid (?:authentication credentials|bearer token)\b/i;
+const CLAUDE_CLI_AUTH_401_DETAIL_RE = /\binvalid (?:authentication credentials|bearer token)\b/i;
 
 function isOAuthRefreshFailureMessage(message: string): boolean {
   const lower = message.toLowerCase();
@@ -114,6 +117,55 @@ export function classifyOAuthRefreshFailure(message: string): OAuthRefreshFailur
   };
 }
 
+/**
+ * Claude CLI 401s come from its local OAuth login state, not inherited API keys,
+ * so route that typed provider failure through the existing re-auth hint path.
+ */
+function classifyProviderOAuthAuthenticationFailure(params: {
+  provider: string | null | undefined;
+  reason?: string | null;
+  status?: number | null;
+  message: string;
+}): OAuthRefreshFailure | null {
+  const provider = sanitizeOAuthRefreshFailureProvider(params.provider);
+  const structuredClaudeCliAuth401 =
+    params.reason?.trim().toLowerCase() === "auth" &&
+    params.status === 401 &&
+    CLAUDE_CLI_AUTH_401_DETAIL_RE.test(params.message);
+  if (
+    provider !== "claude-cli" ||
+    !(CLAUDE_CLI_AUTH_FAILURE_RE.test(params.message) || structuredClaudeCliAuth401)
+  ) {
+    return null;
+  }
+  return {
+    provider,
+    reason: "sign_in_again",
+  };
+}
+
+function classifyProviderOAuthAuthenticationFailureObject(
+  candidate: object,
+): OAuthRefreshFailure | null {
+  const error = candidate as {
+    message?: unknown;
+    provider?: unknown;
+    rawError?: unknown;
+    reason?: unknown;
+    status?: unknown;
+  };
+  const provider = typeof error.provider === "string" ? error.provider : null;
+  const reason = typeof error.reason === "string" ? error.reason : null;
+  const status = typeof error.status === "number" ? error.status : null;
+  const message =
+    typeof error.rawError === "string"
+      ? error.rawError
+      : typeof error.message === "string"
+        ? error.message
+        : "";
+  return classifyProviderOAuthAuthenticationFailure({ provider, reason, status, message });
+}
+
 /** Classify provider/reason from the structured OAuth refresh failure error. */
 export function classifyOAuthRefreshFailureError(err: unknown): OAuthRefreshFailure | null {
   const seen = new Set<object>();
@@ -126,6 +178,10 @@ export function classifyOAuthRefreshFailureError(err: unknown): OAuthRefreshFail
         ...(profileId ? { profileId } : {}),
         reason: candidate.reason,
       };
+    }
+    const providerAuthFailure = classifyProviderOAuthAuthenticationFailureObject(candidate);
+    if (providerAuthFailure) {
+      return providerAuthFailure;
     }
     if (seen.has(candidate)) {
       return null;

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -26,6 +26,7 @@ import { SILENT_REPLY_TOKEN } from "../tokens.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import {
   buildEmptyInteractiveReplyPayload,
+  buildKnownAgentRunFailureReplyPayload,
   buildContextOverflowRecoveryText,
   computeContextAwareReserveTokensFloor,
   MAX_LIVE_SWITCH_RETRIES,
@@ -7625,6 +7626,70 @@ describe("runAgentTurnWithFallback", () => {
         "openclaw models auth login --provider openai` in a terminal",
       );
       expect(result.payload.text).not.toContain("user@example.com");
+    }
+  });
+
+  it("surfaces Claude CLI OAuth reauth guidance for typed 401 auth failures", async () => {
+    state.runEmbeddedAgentMock.mockRejectedValueOnce(
+      new FailoverError("Invalid bearer token", {
+        reason: "auth",
+        provider: "claude-cli",
+        status: 401,
+      }),
+    );
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback(createMinimalRunAgentTurnParams());
+
+    expect(result.kind).toBe("final");
+    if (result.kind === "final") {
+      expect(result.payload.text).toBe(
+        "⚠️ Model login expired on the gateway for claude-cli. Re-auth with `claude auth login`, then refresh OpenClaw's CLI auth profile with `openclaw models auth login --provider anthropic --method cli`, then try again.",
+      );
+    }
+  });
+
+  it("surfaces Claude CLI OAuth reauth guidance through known failure payloads", () => {
+    const payload = buildKnownAgentRunFailureReplyPayload({
+      err: new FailoverError("Invalid bearer token", {
+        reason: "auth",
+        provider: "claude-cli",
+        status: 401,
+      }),
+      sessionCtx: { Provider: "telegram", MessageSid: "msg" } as unknown as TemplateContext,
+      resolvedVerboseLevel: "off",
+    });
+
+    expect(payload?.text).toBe(
+      "⚠️ Model login expired on the gateway for claude-cli. Re-auth with `claude auth login`, then refresh OpenClaw's CLI auth profile with `openclaw models auth login --provider anthropic --method cli`, then try again.",
+    );
+  });
+
+  it("preserves active profile flags in Claude CLI OAuth reauth guidance", async () => {
+    vi.stubEnv("OPENCLAW_PROFILE", "work");
+    try {
+      state.runEmbeddedAgentMock.mockRejectedValueOnce(
+        new FailoverError(
+          "Failed to authenticate. API Error: 401 Invalid authentication credentials",
+          {
+            reason: "auth",
+            provider: "claude-cli",
+            status: 401,
+          },
+        ),
+      );
+
+      const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+      const result = await runAgentTurnWithFallback(createMinimalRunAgentTurnParams());
+
+      expect(result.kind).toBe("final");
+      if (result.kind === "final") {
+        expect(result.payload.text).toContain(
+          "`openclaw --profile work models auth login --provider anthropic --method cli`",
+        );
+      }
+    } finally {
+      vi.unstubAllEnvs();
     }
   });
 

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -71,6 +71,7 @@ import {
   resolveAgentRunAbortLifecycleFields,
 } from "../../agents/run-termination.js";
 import { buildAgentRuntimeOutcomePlan } from "../../agents/runtime-plan/build.js";
+import { formatCliCommand } from "../../cli/command-format.js";
 import { resolveGroupSessionKey, type SessionEntry } from "../../config/sessions.js";
 import { updateSessionEntry } from "../../config/sessions/session-accessor.js";
 import { resolveSilentReplyPolicy } from "../../config/silent-reply.js";
@@ -795,6 +796,9 @@ function collapseRepeatedFailureDetail(message: string): string {
 }
 
 const SAFE_MISSING_API_KEY_PROVIDERS = new Set(["anthropic", "google", "openai"]);
+const CLAUDE_CLI_LOCAL_AUTH_COMMAND = "claude auth login";
+const CLAUDE_CLI_OPENCLAW_AUTH_COMMAND =
+  "openclaw models auth login --provider anthropic --method cli";
 const EXTERNAL_RUN_FAILURE_DETAIL_MAX_CHARS = 900;
 const AGENT_FAILED_BEFORE_REPLY_TEXT = "Agent failed before reply:";
 const PREFLIGHT_COMPACTION_FAILURE_PREFIX = "Preflight compaction required but failed:";
@@ -942,6 +946,52 @@ function buildAuthProfileFailoverFailureText(error: unknown): string | null {
   });
 }
 
+function buildOAuthFailureReplyForError(
+  error: unknown,
+  normalizedMessage: string,
+  options?: {
+    includeAuthProfileId?: boolean;
+  },
+): ExternalRunFailureReply | null {
+  const oauthRefreshFailure =
+    classifyOAuthRefreshFailureError(error) ?? classifyOAuthRefreshFailure(normalizedMessage);
+  if (!oauthRefreshFailure) {
+    return null;
+  }
+  if (oauthRefreshFailure.provider === "claude-cli") {
+    const openClawAuthCommand = formatCliCommand(CLAUDE_CLI_OPENCLAW_AUTH_COMMAND);
+    const text = oauthRefreshFailure.reason
+      ? "⚠️ Model login expired on the gateway for claude-cli."
+      : "⚠️ Model login failed on the gateway for claude-cli.";
+    return {
+      text: `${text} Re-auth with \`${CLAUDE_CLI_LOCAL_AUTH_COMMAND}\`, then refresh OpenClaw's CLI auth profile with \`${openClawAuthCommand}\`, then try again.`,
+      isGenericRunnerFailure: false,
+    };
+  }
+  const loginCommand = buildOAuthRefreshFailureLoginCommand(oauthRefreshFailure.provider, {
+    profileId: options?.includeAuthProfileId ? oauthRefreshFailure.profileId : undefined,
+  });
+  const loginCommandMarkdown = formatOAuthRefreshFailureLoginCommandMarkdown(loginCommand);
+  const providerText = oauthRefreshFailure.provider ? ` for ${oauthRefreshFailure.provider}` : "";
+  const supportsCodexLogin = supportsChannelCodexLogin(oauthRefreshFailure.provider);
+  const channelLoginHint = supportsCodexLogin
+    ? "Send `/login codex` from a private chat or Web UI session to pair a new Codex login, or re-auth"
+    : "Re-auth";
+  const retryLoginHint = supportsCodexLogin
+    ? "send `/login codex` from a private chat or Web UI session to pair a new Codex login, or re-auth"
+    : "re-auth";
+  if (oauthRefreshFailure.reason) {
+    return {
+      text: `⚠️ Model login expired on the gateway${providerText}. ${channelLoginHint} with ${loginCommandMarkdown} in a terminal, then try again.`,
+      isGenericRunnerFailure: false,
+    };
+  }
+  return {
+    text: `⚠️ Model login failed on the gateway${providerText}. Please try again. If this keeps happening, ${retryLoginHint} with ${loginCommandMarkdown} in a terminal.`,
+    isGenericRunnerFailure: false,
+  };
+}
+
 function formatForwardedExternalRunFailureText(message: string): string {
   const sanitized = sanitizeUserFacingText(message, { errorContext: true })
     .trim()
@@ -981,31 +1031,11 @@ function buildExternalRunFailureReply(
   const message = typeof input === "string" ? input : input.message;
   const error = typeof input === "string" ? undefined : input.error;
   const normalizedMessage = collapseRepeatedFailureDetail(message);
-  const oauthRefreshFailure =
-    classifyOAuthRefreshFailureError(error) ?? classifyOAuthRefreshFailure(normalizedMessage);
-  if (oauthRefreshFailure) {
-    const loginCommand = buildOAuthRefreshFailureLoginCommand(oauthRefreshFailure.provider, {
-      profileId: options?.includeAuthProfileId ? oauthRefreshFailure.profileId : undefined,
-    });
-    const loginCommandMarkdown = formatOAuthRefreshFailureLoginCommandMarkdown(loginCommand);
-    const providerText = oauthRefreshFailure.provider ? ` for ${oauthRefreshFailure.provider}` : "";
-    const supportsCodexLogin = supportsChannelCodexLogin(oauthRefreshFailure.provider);
-    const channelLoginHint = supportsCodexLogin
-      ? "Send `/login codex` from a private chat or Web UI session to pair a new Codex login, or re-auth"
-      : "Re-auth";
-    const retryLoginHint = supportsCodexLogin
-      ? "send `/login codex` from a private chat or Web UI session to pair a new Codex login, or re-auth"
-      : "re-auth";
-    if (oauthRefreshFailure.reason) {
-      return {
-        text: `⚠️ Model login expired on the gateway${providerText}. ${channelLoginHint} with ${loginCommandMarkdown} in a terminal, then try again.`,
-        isGenericRunnerFailure: false,
-      };
-    }
-    return {
-      text: `⚠️ Model login failed on the gateway${providerText}. Please try again. If this keeps happening, ${retryLoginHint} with ${loginCommandMarkdown} in a terminal.`,
-      isGenericRunnerFailure: false,
-    };
+  const oauthFailureReply = buildOAuthFailureReplyForError(error, normalizedMessage, {
+    includeAuthProfileId: options?.includeAuthProfileId,
+  });
+  if (oauthFailureReply) {
+    return oauthFailureReply;
   }
   const authProfileFailoverFailure = buildAuthProfileFailoverFailureText(error);
   if (authProfileFailoverFailure) {
@@ -3305,14 +3335,19 @@ async function runAgentTurnWithFallbackInternal(
           : isBillingErrorMessage(message);
       const isContextOverflow = !isBilling && isLikelyContextOverflowError(message);
       const isCompactionFailure = !isBilling && isCompactionFailureError(message);
-      const oauthRefreshFailure =
-        classifyOAuthRefreshFailureError(err) ?? classifyOAuthRefreshFailure(message);
-      const hasAuthProfileFailoverFailure = buildAuthProfileFailoverFailureText(err) !== null;
+      const oauthFailureReply =
+        !isBilling && !shouldSurfaceToControlUi
+          ? buildOAuthFailureReplyForError(err, collapseRepeatedFailureDetail(message), {
+              includeAuthProfileId: !isNonDirectConversationContext(params.sessionCtx),
+            })
+          : null;
+      const hasAuthProfileFailoverFailure =
+        !isBilling && !oauthFailureReply && buildAuthProfileFailoverFailureText(err) !== null;
       const providerRequestError =
         !isBilling &&
-        !oauthRefreshFailure &&
-        !hasAuthProfileFailoverFailure &&
-        !shouldSurfaceToControlUi
+        !shouldSurfaceToControlUi &&
+        !oauthFailureReply &&
+        !hasAuthProfileFailoverFailure
           ? classifyProviderRequestError(err)
           : undefined;
       const isTransientHttp = isTransientHttpError(message);
@@ -3394,6 +3429,16 @@ async function runAgentTurnWithFallbackInternal(
               runtimeModel: attemptedRuntimeModel,
               activeSessionEntry: params.getActiveSessionEntry(),
             }),
+          }),
+        };
+      }
+      if (oauthFailureReply) {
+        takePendingLifecycleTerminal()?.emit("error", err);
+        params.replyOperation?.fail("run_failed", err);
+        return {
+          kind: "final",
+          payload: markAgentRunFailureReplyPayload({
+            text: oauthFailureReply.text,
           }),
         };
       }


### PR DESCRIPTION
Closes #97553

## What Problem This Solves

Fixes an issue where users running Claude through the `claude-cli` backend would see a generic provider authentication failure when the local Claude CLI OAuth login expired.

## Why This Change Was Made

Claude CLI 401 authentication failures are now recognized as Claude CLI OAuth-login failures before the generic provider-authentication copy is used. The recovery hint keeps the runtime id visible, but points users at the owning auth flow: `claude auth login` followed by the Anthropic CLI auth-profile refresh command, formatted through OpenClaw's command formatter so active profile/container flags are preserved and default model selection is not changed.

## User Impact

Users get an actionable re-authentication message for expired Claude CLI login state instead of a generic retry/re-auth note that does not name the correct repair path.

## Evidence

- `node scripts/run-vitest.mjs src/agents/auth-profiles/oauth-refresh-failure.test.ts src/auto-reply/reply/agent-runner-execution.test.ts src/auto-reply/reply/provider-request-error-classifier.test.ts src/agents/cli-runner/execute.supervisor-capture.test.ts -- --reporter=dot` — 3 shards passed: OAuth classifier, auto-reply, provider-request classifier, and CLI-runner supervisor capture.
- `pnpm exec oxfmt --check src/agents/auth-profiles/oauth-refresh-failure.ts src/agents/auth-profiles/oauth-refresh-failure.test.ts src/auto-reply/reply/agent-runner-execution.ts src/auto-reply/reply/agent-runner-execution.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --codex-bin .artifacts/codex-flex --no-web-search` — clean, no accepted/actionable findings; overall patch correct 0.86.
