### PR TITLE
fix: clear stale Claude CLI sessions after failover

### DIFF
--- a/src/auto-reply/reply/agent-runner-cli-dispatch.test.ts
+++ b/src/auto-reply/reply/agent-runner-cli-dispatch.test.ts
@@ -1,8 +1,12 @@
 // Tests CLI dispatch arguments and runtime selection for agent runner turns.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { EmbeddedAgentRunResult } from "../../agents/embedded-agent-runner/types.js";
 import { FailoverError } from "../../agents/failover-error.js";
 import { createAgentRunRestartAbortError } from "../../agents/run-termination.js";
+import type { SessionEntry } from "../../config/sessions.js";
 import {
   emitAgentEvent,
   getAgentEventLifecycleGeneration,
@@ -14,6 +18,7 @@ import type {
   ReasoningTextPayload,
 } from "./agent-runner-cli-dispatch.js";
 import {
+  clearFailedReusedCliSessionBinding,
   createCliToolSummaryTracker,
   keepCliSessionBindingOnlyWhenReused,
   runCliAgentWithLifecycle,
@@ -422,6 +427,54 @@ describe("keepCliSessionBindingOnlyWhenReused", () => {
     expect(onDroppedReplacement).toHaveBeenCalledOnce();
     expect(result.meta.agentMeta?.sessionId).toBe("");
     expect(result.meta.agentMeta?.cliSessionBinding).toBeUndefined();
+  });
+});
+
+describe("clearFailedReusedCliSessionBinding", () => {
+  it("clears reused Claude CLI session state from memory and sessions.json after failover", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cli-dispatch-"));
+    const storePath = path.join(tmpDir, "sessions.json");
+    const sessionKey = "agent:main:telegram:direct:user";
+    const sessionEntry: SessionEntry = {
+      sessionId: "openclaw-session",
+      updatedAt: 1,
+      cliSessionBindings: {
+        "claude-cli": { sessionId: "stale-claude-session" },
+      },
+      cliSessionIds: { "claude-cli": "stale-claude-session" },
+      claudeCliSessionId: "stale-claude-session",
+    };
+    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
+    await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2), "utf-8");
+
+    try {
+      await clearFailedReusedCliSessionBinding({
+        provider: "claude-cli",
+        error: new FailoverError("Not logged in", {
+          reason: "auth",
+          provider: "claude-cli",
+          model: "claude-opus-4-6",
+        }),
+        cliSessionBinding: { sessionId: "stale-claude-session" },
+        sessionKey,
+        sessionStore,
+        storePath,
+        activeSessionEntry: sessionEntry,
+      });
+
+      expect(sessionStore[sessionKey]?.cliSessionBindings).toBeUndefined();
+      expect(sessionStore[sessionKey]?.cliSessionIds).toBeUndefined();
+      expect(sessionStore[sessionKey]?.claudeCliSessionId).toBeUndefined();
+      const persisted = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+        string,
+        SessionEntry
+      >;
+      expect(persisted[sessionKey]?.cliSessionBindings).toBeUndefined();
+      expect(persisted[sessionKey]?.cliSessionIds).toBeUndefined();
+      expect(persisted[sessionKey]?.claudeCliSessionId).toBeUndefined();
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/auto-reply/reply/agent-runner-cli-dispatch.ts
+++ b/src/auto-reply/reply/agent-runner-cli-dispatch.ts
@@ -3,10 +3,11 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { runCliAgent } from "../../agents/cli-runner.js";
 import type { RunCliAgentParams } from "../../agents/cli-runner/types.js";
-import { clearCliSession } from "../../agents/cli-session.js";
+import { clearCliSession, getCliSessionBinding } from "../../agents/cli-session.js";
 import { extractToolResultText } from "../../agents/embedded-agent-subscribe.tools.js";
 import { inferToolMetaFromArgs } from "../../agents/embedded-agent-utils.js";
 import type { EmbeddedAgentRunResult } from "../../agents/embedded-agent.js";
+import { FailoverError } from "../../agents/failover-error.js";
 import {
   DEFAULT_FAST_MODE_AUTO_ON_SECONDS,
   formatFastModeAutoProgressText,
@@ -26,10 +27,15 @@ import {
   onAgentEvent,
   withAgentRunLifecycleGeneration,
 } from "../../infra/agent-events.js";
+import { readErrorName } from "../../infra/errors.js";
 import { FAST_MODE_AUTO_PROGRESS_KIND, type ReplyPayload } from "../reply-payload.js";
 import { formatToolAggregate } from "../tool-meta.js";
 import type { GetReplyOptions } from "../types.js";
 import { resolveAgentLifecycleTerminalMetadata } from "./agent-lifecycle-terminal.js";
+
+function isClaudeCliProvider(provider: string): boolean {
+  return provider.trim().toLowerCase() === "claude-cli";
+}
 
 function createAgentEventBridge<T>(params: {
   runId: string;
@@ -258,10 +264,17 @@ export async function clearDroppedCliSessionBinding(params: {
   sessionStore?: Record<string, SessionEntry>;
   storePath?: string;
   activeSessionEntry?: SessionEntry;
+  expectedSessionId?: string;
 }): Promise<void> {
   const updatedAt = Date.now();
   const clearEntry = (entry: SessionEntry | undefined) => {
     if (!entry) {
+      return;
+    }
+    if (
+      params.expectedSessionId &&
+      getCliSessionBinding(entry, params.provider)?.sessionId !== params.expectedSessionId
+    ) {
       return;
     }
     clearCliSession(entry, params.provider);
@@ -279,6 +292,32 @@ export async function clearDroppedCliSessionBinding(params: {
       return entry;
     },
   );
+}
+
+export async function clearFailedReusedCliSessionBinding(params: {
+  provider: string;
+  error: unknown;
+  cliSessionBinding?: { sessionId?: string };
+  sessionKey?: string;
+  sessionStore?: Record<string, SessionEntry>;
+  storePath?: string;
+  activeSessionEntry?: SessionEntry;
+}): Promise<void> {
+  const sessionId = normalizeOptionalString(params.cliSessionBinding?.sessionId);
+  if (!sessionId || !isClaudeCliProvider(params.provider)) {
+    return;
+  }
+  if (!(params.error instanceof FailoverError) && readErrorName(params.error) !== "AbortError") {
+    return;
+  }
+  await clearDroppedCliSessionBinding({
+    provider: params.provider,
+    sessionKey: params.sessionKey,
+    sessionStore: params.sessionStore,
+    storePath: params.storePath,
+    activeSessionEntry: params.activeSessionEntry,
+    expectedSessionId: sessionId,
+  });
 }
 
 function createToolEventBridge(params: {

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -2954,6 +2954,59 @@ describe("runAgentTurnWithFallback", () => {
     });
   });
 
+  it("clears reused Claude CLI bindings after channel FailoverError", async () => {
+    state.isCliProviderMock.mockImplementation((provider: unknown) => provider === "claude-cli");
+    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
+      result: await params.run("claude-cli", "claude-opus-4-6"),
+      provider: "claude-cli",
+      model: "claude-opus-4-6",
+      attempts: [],
+    }));
+    state.runCliAgentMock.mockRejectedValueOnce(
+      new FailoverError("Not logged in", {
+        reason: "auth",
+        provider: "claude-cli",
+        model: "claude-opus-4-6",
+      }),
+    );
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const followupRun = createFollowupRun();
+    followupRun.run.provider = "claude-cli";
+    followupRun.run.model = "claude-opus-4-6";
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      sessionFile: "/tmp/session.jsonl",
+      updatedAt: 1,
+      cliSessionBindings: {
+        "claude-cli": { sessionId: "stale-claude-session" },
+      },
+      cliSessionIds: { "claude-cli": "stale-claude-session" },
+      claudeCliSessionId: "stale-claude-session",
+    };
+    const activeSessionStore = { main: sessionEntry };
+    const { replyOperation, failMock } = createMockReplyOperation();
+
+    const result = await runAgentTurnWithFallback({
+      ...createMinimalRunAgentTurnParams({ followupRun, replyOperation }),
+      activeSessionStore,
+      getActiveSessionEntry: () => activeSessionStore.main,
+    });
+
+    expect(result.kind).toBe("final");
+    expect(failMock).toHaveBeenCalledWith("run_failed", expect.any(FailoverError));
+    expect(state.runCliAgentMock).toHaveBeenCalledOnce();
+    expectMockCallArgFields(state.runCliAgentMock, 0, "CLI run params", {
+      cliSessionId: "stale-claude-session",
+      cliSessionBinding: {
+        sessionId: "stale-claude-session",
+      },
+    });
+    expect(activeSessionStore.main.cliSessionBindings).toBeUndefined();
+    expect(activeSessionStore.main.cliSessionIds).toBeUndefined();
+    expect(activeSessionStore.main.claudeCliSessionId).toBeUndefined();
+  });
+
   it("keeps the first CLI session created by a room-event turn", async () => {
     state.isCliProviderMock.mockReturnValue(true);
     state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -116,6 +116,7 @@ import {
 } from "./agent-lifecycle-terminal.js";
 import { resolveRunAuthProfile } from "./agent-runner-auth-profile.js";
 import {
+  clearFailedReusedCliSessionBinding,
   clearDroppedCliSessionBinding,
   createCliReasoningStreamBridge,
   createCliToolSummaryTracker,
@@ -2464,7 +2465,22 @@ async function runAgentTurnWithFallbackInternal(
                   onFastModeAutoProgress: async (payload) => {
                     await params.opts?.onToolResult?.(payload);
                   },
-                  onErrorBeforeLifecycle: async () => {
+                  onErrorBeforeLifecycle: async (error) => {
+                    try {
+                      await clearFailedReusedCliSessionBinding({
+                        provider: cliExecutionProvider,
+                        error,
+                        cliSessionBinding,
+                        sessionKey: params.sessionKey,
+                        sessionStore: params.activeSessionStore,
+                        storePath: params.storePath,
+                        activeSessionEntry: params.getActiveSessionEntry(),
+                      });
+                    } catch (clearError) {
+                      logVerbose(
+                        `failed to clear failed CLI session binding (non-fatal): ${String(clearError)}`,
+                      );
+                    }
                     if (!rollbackFallbackCandidateSelection) {
                       return;
                     }

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -65,6 +65,7 @@ import {
   type AgentLifecycleTerminalBackstop,
 } from "./agent-lifecycle-terminal.js";
 import {
+  clearFailedReusedCliSessionBinding,
   clearDroppedCliSessionBinding,
   createCliReasoningStreamBridge,
   createCliToolSummaryTracker,
@@ -1153,6 +1154,23 @@ export function createFollowupRunner(params: {
                         { kind: "tool", mirror: false, runId },
                       );
                     });
+                  },
+                  onErrorBeforeLifecycle: async (error) => {
+                    try {
+                      await clearFailedReusedCliSessionBinding({
+                        provider: cliExecutionProvider,
+                        error,
+                        cliSessionBinding,
+                        sessionKey: replySessionKey,
+                        sessionStore,
+                        storePath,
+                        activeSessionEntry,
+                      });
+                    } catch (clearError) {
+                      logVerbose(
+                        `failed to clear failed followup CLI session binding (non-fatal): ${String(clearError)}`,
+                      );
+                    }
                   },
                   transformResult:
                     queued.currentInboundEventKind === "room_event"


### PR DESCRIPTION
Closes #97887

## What Problem This Solves

Fixes an issue where users running inbound channel conversations through `claude-cli` could get stuck in a repeated failure loop after a reused CLI session became invalid. When the CLI turn failed with a `FailoverError`, the stale `cliSessionBindings`, `cliSessionIds`, and legacy `claudeCliSessionId` fields could remain in `sessions.json`, so the next message retried the same dead Claude CLI session instead of starting cleanly.

## Why This Change Was Made

The channel CLI lifecycle now clears a failed reused Claude CLI binding on `FailoverError` or `AbortError`, using the same provider-owned session cleanup behavior that already exists for command attempts. The cleanup is guarded by the exact reused CLI session id so it does not remove a newer binding written by another path; follow-up turns use the same helper so queued channel work does not keep the stale state either. Risk note: this touches session state cleanup, so the regression tests cover both persisted `sessions.json` fields and the channel runner failure path.

AI-assisted.

## User Impact

After a gateway restart or similar invalidation, a failed Claude CLI resume no longer poisons the conversation indefinitely. The next inbound message can create a fresh Claude CLI session instead of repeatedly resuming a stale id until the user manually edits `sessions.json`.

## Evidence

Source-level before premise from #97887: current `main` passed reused CLI bindings into `runCliAgentWithLifecycle` and only persisted `clearCliSessionBinding` after successful run metadata. A thrown `FailoverError` reached the known-failure reply path before that success-only persistence branch, leaving the stale CLI binding available for the next turn.

Focused local stale-session proof using the production cleanup helper, real `FailoverError`, and a temporary `sessions.json` file:

```text
node --import tsx --input-type=module <<'EOF'
import fs from 'node:fs/promises';
import os from 'node:os';
import path from 'node:path';
import { clearFailedReusedCliSessionBinding } from './src/auto-reply/reply/agent-runner-cli-dispatch.ts';
import { getCliSessionBinding } from './src/agents/cli-session.ts';
import { FailoverError } from './src/agents/failover-error.ts';

const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'openclaw-97887-proof-'));
const storePath = path.join(tmp, 'sessions.json');
const sessionKey = 'agent:main:telegram:direct:redacted-user';
const staleSessionId = 'stale-claude-session-redacted';
const sessionEntry = {
  sessionId: 'openclaw-session-redacted',
  updatedAt: 1,
  cliSessionBindings: { 'claude-cli': { sessionId: staleSessionId } },
  cliSessionIds: { 'claude-cli': staleSessionId },
  claudeCliSessionId: staleSessionId,
};
const sessionStore = { [sessionKey]: sessionEntry };
await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2), 'utf8');

const before = JSON.parse(await fs.readFile(storePath, 'utf8'))[sessionKey];
console.log('before file binding:', getCliSessionBinding(before, 'claude-cli')?.sessionId ?? '<none>');
console.log('before legacy field:', before.claudeCliSessionId ?? '<none>');

await clearFailedReusedCliSessionBinding({
  provider: 'claude-cli',
  error: new FailoverError('redacted failover from reused Claude CLI session', {
    reason: 'auth',
    provider: 'claude-cli',
    model: 'claude-redacted',
  }),
  cliSessionBinding: { sessionId: staleSessionId },
  sessionKey,
  sessionStore,
  storePath,
  activeSessionEntry: sessionEntry,
});

const after = JSON.parse(await fs.readFile(storePath, 'utf8'))[sessionKey];
console.log('after file binding:', getCliSessionBinding(after, 'claude-cli')?.sessionId ?? '<none>');
console.log('after legacy field:', after.claudeCliSessionId ?? '<none>');
console.log('next turn reuse lookup:', getCliSessionBinding(after, 'claude-cli')?.sessionId ?? '<fresh start/no reusable binding>');
console.log('in-memory binding:', getCliSessionBinding(sessionStore[sessionKey], 'claude-cli')?.sessionId ?? '<none>');
await fs.rm(tmp, { recursive: true, force: true });
EOF

before file binding: stale-claude-session-redacted
before legacy field: stale-claude-session-redacted
after file binding: <none>
after legacy field: <none>
next turn reuse lookup: <fresh start/no reusable binding>
in-memory binding: <none>
```

After-fix focused tests:

```text
node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-cli-dispatch.test.ts
[test] passed 1 Vitest shard in 18.22s
```

```text
node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-execution.test.ts
[test] passed 1 Vitest shard in 25.21s
```

Type/build/format checks:

```text
node_modules/.bin/oxfmt --write --threads=1 src/auto-reply/reply/agent-runner-cli-dispatch.ts src/auto-reply/reply/agent-runner-execution.ts src/auto-reply/reply/followup-runner.ts src/auto-reply/reply/agent-runner-cli-dispatch.test.ts src/auto-reply/reply/agent-runner-execution.test.ts
Finished in 29ms on 5 files using 1 threads.
```

```text
node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
# passed
```

```text
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.src.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-src.tsbuildinfo
# passed
```

```text
git diff --check
# passed
```

```text
node scripts/build-all.mjs
[build-all] phase timings: total 154.7s; slowest tsdown 102.7s; write-plugin-sdk-entry-dts 25.0s; build:plugin-sdk:dts 12.8s; write-cli-startup-metadata 10.0s; ui:build 1.67s
```

Real local agent proof with the configured DeepSeek provider:

```text
pnpm openclaw agent --local --json --model deepseek/deepseek-v4-pro --session-key agent:main:issue-97887-proof --message "Reply with exactly: issue-97887 proof ok" --timeout 120
[provider-transport-fetch] response provider=deepseek api=openai-completions model=deepseek-v4-pro status=200
"text": "issue-97887 proof ok"
"stopReason": "stop"
```

Local structured review:

```text
.agents/skills/autoreview/scripts/autoreview --mode local
autoreview clean: no accepted/actionable findings reported
```
