### PR TITLE
fix(feishu): route HTTP API calls through ambient proxy agent

### DIFF
--- a/extensions/feishu/src/client.ts
+++ b/extensions/feishu/src/client.ts
@@ -105,7 +105,9 @@ function setRequestUserAgent(req: unknown) {
       defaults: Record<string, unknown>;
     };
     inst.defaults.proxy = false;
-    if (httpAgent) inst.defaults.httpAgent = httpAgent;
+    if (httpAgent) {
+      inst.defaults.httpAgent = httpAgent;
+    }
     inst.defaults.httpsAgent = httpsAgent;
   }
 }

--- a/extensions/feishu/src/client.ts
+++ b/extensions/feishu/src/client.ts
@@ -3,6 +3,7 @@ import type { Agent } from "node:https";
 import { createRequire } from "node:module";
 import * as Lark from "@larksuiteoapi/node-sdk";
 import {
+  createAmbientNodeProxyAgent,
   readPluginPackageVersion,
   resolveAmbientNodeProxyAgent,
 } from "openclaw/plugin-sdk/extension-shared";
@@ -89,6 +90,24 @@ function setRequestUserAgent(req: unknown) {
 {
   const inst = Lark.defaultHttpInstance as FeishuDefaultHttpInstanceWithInterceptors;
   inst.interceptors?.request?.use(setRequestUserAgent);
+}
+
+// Route Feishu API requests through the ambient HTTP proxy when one is
+// configured (HTTPS_PROXY / HTTP_PROXY env vars). Disabling axios's built-in
+// proxy detection (proxy: false) prevents the forward-proxy path rewriting
+// that breaks HTTPS CONNECT tunneling; the injected proxyline agent handles
+// the tunnel instead.
+{
+  const httpsAgent = createAmbientNodeProxyAgent({ protocol: "https" });
+  if (httpsAgent) {
+    const httpAgent = createAmbientNodeProxyAgent({ protocol: "http" });
+    const inst = Lark.defaultHttpInstance as FeishuDefaultHttpInstanceWithInterceptors & {
+      defaults: Record<string, unknown>;
+    };
+    inst.defaults.proxy = false;
+    if (httpAgent) inst.defaults.httpAgent = httpAgent;
+    inst.defaults.httpsAgent = httpsAgent;
+  }
 }
 
 export { FEISHU_HTTP_TIMEOUT_ENV_VAR, FEISHU_HTTP_TIMEOUT_MAX_MS, FEISHU_HTTP_TIMEOUT_MS };
@@ -227,6 +246,10 @@ export async function createFeishuWSClient(
     ...callbacks,
     loggerLevel: feishuClientSdk.LoggerLevel.info,
     wsConfig: FEISHU_WS_CONFIG,
+    // Pass the proxy-aware httpInstance so WSClient's internal
+    // pullConnectConfig() (which refreshes the WebSocket endpoint URL)
+    // also routes through the ambient proxy.
+    httpInstance: createTimeoutHttpInstance(resolveConfiguredHttpTimeoutMs(account)),
     ...(agent ? { agent } : {}),
   } as ConstructorParameters<typeof feishuClientSdk.WSClient>[0] & {
     wsConfig: typeof FEISHU_WS_CONFIG;

--- a/src/plugin-sdk/extension-shared.ts
+++ b/src/plugin-sdk/extension-shared.ts
@@ -1,5 +1,6 @@
 // Extension shared helpers expose cross-plugin runtime utilities that remain SDK-safe.
 import { createAmbientNodeProxyAgent, hasAmbientNodeProxyConfigured } from "@openclaw/proxyline";
+export { createAmbientNodeProxyAgent };
 import type { z } from "zod";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveActiveManagedProxyTlsOptions } from "../infra/net/proxy/managed-proxy-undici.js";


### PR DESCRIPTION
## What Problem This Solves

Feishu channel API calls fail in environments that require an HTTP proxy (`HTTPS_PROXY` / `HTTP_PROXY`) to reach external hosts. Users see `Parse Error: Expected HTTP/` followed by `bot open_id: unknown` and `pullConnectConfig failed` at gateway startup, rendering the Feishu channel completely inoperable behind a corporate proxy.

The root cause is twofold:

1. **HTTP client path** — `Lark.defaultHttpInstance` (axios) detects proxy env vars and switches to HTTP forward-proxy mode, rewriting the request path as a full URL. This breaks HTTPS endpoints because the proxy receives a plain HTTP request on a TLS port, returns garbage, and Node.js fails with `HPE_INVALID_CONSTANT`.

2. **WebSocket refresh path** — `createFeishuWSClient()` passed an `agent` for the WebSocket connection itself but did not pass an `httpInstance`. When the WSClient calls `pullConnectConfig()` internally (e.g., on reconnect) to refresh the WebSocket endpoint URL, it used the SDK's default axios instance—which does not go through the proxy, hits the same `Parse Error`, and fails with `pullConnectConfig failed: code=undefined, msg=undefined`.

## Why This Change Was Made

The existing proxy support for WebSocket (`agent`) was correct but incomplete. The HTTP side was never wired up because:

- **axios 1.x auto-detects proxy env vars** but implements HTTP forward-proxy mode (rewrites the path into a full URL like `POST http://open.feishu.cn/...`). This works for plain HTTP targets but is fundamentally wrong for HTTPS—the proxy sees a cleartext request on port 443, can't perform TLS, and returns garbage.
- **The fix mirrors what cURL does**: disable axios's built-in proxy detection (`proxy: false`) and inject a `ProxylineNodeProxyAgent` that handles the CONNECT tunnel transparently (client → `CONNECT open.feishu.cn:443` → proxy tunnels TCP → client performs TLS → normal HTTPS request).

The approach reuses the same pattern already established by the User-Agent override (lines 87–93): mutate `Lark.defaultHttpInstance.defaults` at module init so all callers inherit the proxy configuration automatically.

## What Changed

**`src/plugin-sdk/extension-shared.ts`** — export `createAmbientNodeProxyAgent` (synchronous variant) so channel plugins can inject proxy agents without the async overhead of `resolveAmbientNodeProxyAgent`.

**`extensions/feishu/src/client.ts`** — two changes:

1. **Module-init block** (lines 95–111): when `HTTPS_PROXY` / `HTTP_PROXY` is configured, set `Lark.defaultHttpInstance.defaults.proxy = false` and inject `httpAgent` / `httpsAgent`. Because `createTimeoutHttpInstance` delegates to `defaultHttpInstance`, both `createFeishuClient` and `createFeishuWSClient` inherit this automatically—no new axios instances, no cache keys, no interceptor duplication.

2. **`createFeishuWSClient`** — pass `httpInstance` from `createTimeoutHttpInstance` so the WSClient's internal `pullConnectConfig()` refresh path also goes through the proxy.

## Evidence

**Before** (no proxy injection, via `proxy.example.com:8080`):

```
[feishu] feishu[default]: bot open_id resolved: unknown
[feishu] feishu[default]: bot open_id unknown; starting background retry
[ws] Parse Error: Expected HTTP/, RTSP/ or ICE/
[ws] connect failed
[ws] pullConnectConfig failed: code=undefined, msg=undefined
```

**After** (proxy injection via `defaultHttpInstance.defaults`):

```
[feishu] feishu[default]: bot open_id resolved: ou_54458ca95535ed882fe4e7052a4d4d14
[ws] ws client ready
```

**curl verification** — the target proxy `proxy.example.com:8080` handles CONNECT-tunneled HTTPS correctly:

```sh
$ curl -s --proxy http://proxy.example.com:8080 \
    -X POST 'https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal' \
    -d '{"app_id":"...","app_secret":"..."}'
{"code":0,"expire":2784,"msg":"ok","tenant_access_token":"t-..."}
```

**Gateway smoke** — `pnpm openclaw gateway` starts cleanly with zero `Parse Error`, zero `token` warnings, and WebSocket `ws client ready`.

