### PR TITLE
Fix silent provider-error retry after prior side effects

### DIFF
--- a/src/agents/agent-tool-handler-state.test-helpers.ts
+++ b/src/agents/agent-tool-handler-state.test-helpers.ts
@@ -9,6 +9,7 @@ import { createEmbeddedRunReplayState } from "./embedded-agent-runner/replay-sta
 export function createBaseToolHandlerState() {
   return {
     replayState: createEmbeddedRunReplayState(),
+    currentAttemptReplayState: createEmbeddedRunReplayState(),
     toolMetaById: new Map<string, unknown>(),
     toolMetas: [] as Array<{ toolName?: string; meta?: string; asyncStarted?: boolean }>,
     acceptedSessionSpawns: [],

--- a/src/agents/embedded-agent-helpers.ts
+++ b/src/agents/embedded-agent-helpers.ts
@@ -46,6 +46,7 @@ export {
   isRawApiErrorPayload,
   isRateLimitAssistantError,
   isRateLimitErrorMessage,
+  isServerErrorMessage,
   isTransientHttpError,
   isTimeoutErrorMessage,
   parseImageDimensionError,

--- a/src/agents/embedded-agent-runner.e2e.test.ts
+++ b/src/agents/embedded-agent-runner.e2e.test.ts
@@ -361,6 +361,10 @@ function firstRunEmbeddedAttemptParams(): { sessionKey?: string } {
   return firstMockCall(runEmbeddedAttemptMock, "embedded attempt")[0] as { sessionKey?: string };
 }
 
+function warnMessages(): string[] {
+  return loggerWarnMock.mock.calls.map(([message]) => String(message));
+}
+
 describe("runEmbeddedAgent", () => {
   it("uses the configured default model when the caller omits provider and model", async () => {
     const sessionFile = nextSessionFile();
@@ -1053,6 +1057,114 @@ describe("runEmbeddedAgent", () => {
     expect(result.payloads?.[0]?.text).toBe(
       "I'll inspect the files, make the change, and run the checks.",
     );
+  });
+
+  it("retries a fault-injected provider 5xx after prior side effects without duplicating delivery", async () => {
+    const sessionFile = nextSessionFile();
+    const sessionKey = nextSessionKey();
+    const cfg = createEmbeddedAgentRunnerOpenAiConfig([]);
+    const priorToolCallId = "call_prior_exec";
+    const priorToolResult = "[redacted prior exec output]";
+    const provider = "openrouter";
+    const model = "minimax/minimax-m3";
+
+    const sessionManager = SessionManager.open(sessionFile);
+    sessionManager.appendMessage({
+      role: "assistant",
+      content: [
+        {
+          type: "toolCall",
+          id: priorToolCallId,
+          name: "exec",
+          arguments: { command: "echo redacted" },
+        },
+      ],
+      stopReason: "toolUse",
+      api: "openai-responses",
+      provider,
+      model,
+      usage: createMockUsage(8, 0),
+      timestamp: Date.now(),
+    });
+    sessionManager.appendMessage({
+      role: "toolResult",
+      toolCallId: priorToolCallId,
+      toolName: "exec",
+      content: [{ type: "text", text: priorToolResult }],
+      isError: false,
+      timestamp: Date.now(),
+    });
+
+    const faultInjectedAssistant = buildEmbeddedRunnerAssistant({
+      provider,
+      model,
+      stopReason: "error",
+      content: [],
+      usage: createMockUsage(100, 0),
+      errorMessage: "Internal Server Error",
+    });
+    runEmbeddedAttemptMock
+      .mockResolvedValueOnce(
+        makeEmbeddedRunnerAttempt({
+          assistantTexts: [],
+          toolMetas: [],
+          lastAssistant: faultInjectedAssistant,
+          currentAttemptAssistant: faultInjectedAssistant,
+          replayMetadata: {
+            hadPotentialSideEffects: true,
+            replaySafe: false,
+          },
+          currentAttemptReplayMetadata: {
+            hadPotentialSideEffects: false,
+            replaySafe: true,
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        makeEmbeddedRunnerAttempt({
+          assistantTexts: ["Recovered after retry."],
+          lastAssistant: buildEmbeddedRunnerAssistant({
+            provider,
+            model,
+            content: [{ type: "text", text: "Recovered after retry." }],
+            usage: createMockUsage(100, 5),
+          }),
+        }),
+      );
+
+    const result = await runEmbeddedAgent({
+      sessionId: "session:test",
+      sessionKey,
+      sessionFile,
+      workspaceDir,
+      config: cfg,
+      prompt: "continue after the prior tool result",
+      provider,
+      model,
+      timeoutMs: 5_000,
+      agentDir,
+      runId: nextRunId("provider-5xx-after-prior-side-effects"),
+      enqueue: immediateEnqueue,
+    });
+
+    expect(runEmbeddedAttemptMock).toHaveBeenCalledTimes(2);
+    expect(warnMessages().join("\n")).toContain("[empty-error-retry]");
+    expect(result.payloads?.[0]?.text).toBe("Recovered after retry.");
+    expect(result.didSendViaMessagingTool).toBe(false);
+    expect(result.messagingToolSentTexts).toEqual([]);
+    expect(result.acceptedSessionSpawns).toEqual([]);
+
+    const retryAttempt = runEmbeddedAttemptMock.mock.calls[1]?.[0] as {
+      initialReplayState?: { hadPotentialSideEffects?: boolean };
+    };
+    expect(retryAttempt.initialReplayState?.hadPotentialSideEffects).toBe(true);
+
+    const messages = await readSessionMessages(sessionFile);
+    const priorToolResults = messages.filter(
+      (message) =>
+        message?.role === "toolResult" && textFromContent(message.content) === priorToolResult,
+    );
+    expect(priorToolResults).toHaveLength(1);
   });
 
   it("handles prompt error paths without dropping user state", async () => {

--- a/src/agents/embedded-agent-runner/run.empty-error-retry.test.ts
+++ b/src/agents/embedded-agent-runner/run.empty-error-retry.test.ts
@@ -274,6 +274,66 @@ describe("runEmbeddedAgent silent-error retry", () => {
     expect(result.payloads).toBeUndefined();
   });
 
+  it("retries when only accumulated replay metadata recorded prior side effects", async () => {
+    const assistant = {
+      role: "assistant",
+      stopReason: "error",
+      provider: "openrouter",
+      model: "minimax/minimax-m3",
+      content: [],
+      usage: { input: 100, output: 0, totalTokens: 100 },
+      errorMessage: "Internal Server Error",
+      errorCode: "500",
+    } as unknown as EmbeddedRunAttemptResult["lastAssistant"];
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: [],
+        lastAssistant: assistant,
+        currentAttemptAssistant: assistant,
+        replayMetadata: {
+          hadPotentialSideEffects: true,
+          replaySafe: false,
+        },
+        currentAttemptReplayMetadata: {
+          hadPotentialSideEffects: false,
+          replaySafe: true,
+        },
+      }),
+    );
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      successAttempt("openrouter", "minimax/minimax-m3"),
+    );
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openrouter",
+      model: "minimax/minimax-m3",
+      runId: "run-empty-error-retry-prior-side-effects",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(result.payloads).toBeUndefined();
+  });
+
+  it("falls back to legacy replay metadata when current-attempt metadata is absent", async () => {
+    const failedAttempt = emptyErrorAttempt("openrouter", "minimax/minimax-m3");
+    delete (failedAttempt as Partial<EmbeddedRunAttemptResult>).currentAttemptReplayMetadata;
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(failedAttempt);
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      successAttempt("openrouter", "minimax/minimax-m3"),
+    );
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openrouter",
+      model: "minimax/minimax-m3",
+      runId: "run-empty-error-retry-legacy-replay-metadata",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(result.payloads).toBeUndefined();
+  });
+
   it("does not retry when the failed attempt recorded side effects", async () => {
     // Resubmission would duplicate side effects when replay metadata cannot
     // prove the failed turn is safe to replay.
@@ -289,6 +349,10 @@ describe("runEmbeddedAgent silent-error retry", () => {
           usage: { input: 100, output: 0, totalTokens: 100 },
         } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
         replayMetadata: {
+          hadPotentialSideEffects: true,
+          replaySafe: false,
+        },
+        currentAttemptReplayMetadata: {
           hadPotentialSideEffects: true,
           replaySafe: false,
         },

--- a/src/agents/embedded-agent-runner/run.empty-error-retry.test.ts
+++ b/src/agents/embedded-agent-runner/run.empty-error-retry.test.ts
@@ -136,11 +136,8 @@ describe("runEmbeddedAgent silent-error retry", () => {
     expect(result.payloads).toBeUndefined();
   });
 
-  it.each([
-    ["timeout", "LLM request timed out."],
-    ["server_error", "Internal server error"],
-  ] as const)("does not intercept recognized %s failover errors", async (reason, errorMessage) => {
-    mockedClassifyAssistantFailoverReason.mockReturnValue(reason);
+  it("does not intercept recognized timeout failover errors", async () => {
+    mockedClassifyAssistantFailoverReason.mockReturnValue("timeout");
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       emptyErrorAttempt(
         "anthropic",
@@ -153,7 +150,7 @@ describe("runEmbeddedAgent silent-error retry", () => {
             thinkingSignature: JSON.stringify({ id: "rs_error", type: "reasoning" }),
           },
         ],
-        errorMessage,
+        "LLM request timed out.",
       ),
     );
 
@@ -161,10 +158,30 @@ describe("runEmbeddedAgent silent-error retry", () => {
       ...overflowBaseRunParams,
       provider: "anthropic",
       model: "claude-opus-4-8",
-      runId: `run-empty-error-retry-${reason}`,
+      runId: "run-empty-error-retry-timeout",
     });
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries classified server_error empty turns before assistant failover", async () => {
+    mockedClassifyAssistantFailoverReason.mockReturnValue("server_error");
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      emptyErrorAttempt("openrouter", "minimax/minimax-m3", 0, [], "Internal Server Error"),
+    );
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      successAttempt("openrouter", "minimax/minimax-m3"),
+    );
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openrouter",
+      model: "minimax/minimax-m3",
+      runId: "run-empty-error-retry-server-error",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(result.payloads).toBeUndefined();
   });
 
   it("does not intercept concrete non-transient failover errors", async () => {

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -2720,6 +2720,61 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     ).toBe(false);
   });
 
+  it("retries errored empty turns when only accumulated replay metadata has side effects", () => {
+    const assistant = {
+      role: "assistant",
+      stopReason: "error",
+      provider: "openrouter",
+      model: "minimax/minimax-m3",
+      content: [],
+      usage: { input: 100, output: 0, totalTokens: 100 },
+    } as unknown as EmbeddedRunAttemptResult["lastAssistant"];
+    expect(
+      shouldRetrySilentErrorAssistantTurn({
+        attempt: makeAttemptResult({
+          assistantTexts: [],
+          replayMetadata: {
+            hadPotentialSideEffects: true,
+            replaySafe: false,
+          },
+          currentAttemptReplayMetadata: {
+            hadPotentialSideEffects: false,
+            replaySafe: true,
+          },
+          lastAssistant: assistant,
+        }),
+        assistant,
+      }),
+    ).toBe(true);
+  });
+
+  it("falls back to legacy replay metadata when current-attempt metadata is absent", () => {
+    const assistant = {
+      role: "assistant",
+      stopReason: "error",
+      provider: "openrouter",
+      model: "minimax/minimax-m3",
+      content: [],
+      usage: { input: 100, output: 0, totalTokens: 100 },
+    } as unknown as EmbeddedRunAttemptResult["lastAssistant"];
+    const attempt = makeAttemptResult({
+      assistantTexts: [],
+      replayMetadata: {
+        hadPotentialSideEffects: false,
+        replaySafe: true,
+      },
+      lastAssistant: assistant,
+    });
+    delete (attempt as Partial<EmbeddedRunAttemptResult>).currentAttemptReplayMetadata;
+
+    expect(
+      shouldRetrySilentErrorAssistantTurn({
+        attempt,
+        assistant,
+      }),
+    ).toBe(true);
+  });
+
   it.each([
     {
       name: "visible text",
@@ -2775,6 +2830,10 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
         attempt: makeAttemptResult({
           assistantTexts: [],
           replayMetadata: {
+            hadPotentialSideEffects: true,
+            replaySafe: false,
+          },
+          currentAttemptReplayMetadata: {
             hadPotentialSideEffects: true,
             replaySafe: false,
           },

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.fixture.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.fixture.ts
@@ -73,6 +73,17 @@ export function makeAttemptResult(
         acceptedSessionSpawns,
         successfulCronAdds,
       }),
+    currentAttemptReplayMetadata:
+      overrides.currentAttemptReplayMetadata ??
+      buildAttemptReplayMetadata({
+        toolMetas,
+        didSendViaMessagingTool,
+        messagingToolSentTexts,
+        messagingToolSentMediaUrls,
+        messagingToolSentTargets,
+        acceptedSessionSpawns,
+        successfulCronAdds,
+      }),
     itemLifecycle: {
       startedCount: 0,
       completedCount: 0,

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
@@ -231,6 +231,9 @@ export const mockedIsFailoverErrorMessage = vi.fn(() => false);
 export const mockedIsGenericUnknownStreamErrorMessage = vi.fn((raw: string) =>
   /^\s*an unknown error occurred\.?\s*$/i.test(raw),
 );
+export const mockedIsServerErrorMessage = vi.fn((raw: string) =>
+  /\b(?:internal server error|server_error|http\s+5\d\d|bad gateway|gateway timeout)\b/i.test(raw),
+);
 export const mockedIsLikelyContextOverflowError = vi.fn((msg?: string) => {
   const lower = normalizeLowercaseStringOrEmpty(msg ?? "");
   return (
@@ -424,6 +427,12 @@ export function resetRunOverflowCompactionHarnessMocks(): void {
   mockedIsGenericUnknownStreamErrorMessage.mockReset();
   mockedIsGenericUnknownStreamErrorMessage.mockImplementation((raw: string) =>
     /^\s*an unknown error occurred\.?\s*$/i.test(raw),
+  );
+  mockedIsServerErrorMessage.mockReset();
+  mockedIsServerErrorMessage.mockImplementation((raw: string) =>
+    /\b(?:internal server error|server_error|http\s+5\d\d|bad gateway|gateway timeout)\b/i.test(
+      raw,
+    ),
   );
   mockedIsLikelyContextOverflowError.mockReset();
   mockedIsLikelyContextOverflowError.mockImplementation((msg?: string) => {
@@ -659,6 +668,7 @@ export async function loadRunOverflowCompactionHarness(): Promise<{
     parseImageSizeError: mockedParseImageSizeError,
     parseImageDimensionError: mockedParseImageDimensionError,
     isRateLimitAssistantError: mockedIsRateLimitAssistantError,
+    isServerErrorMessage: mockedIsServerErrorMessage,
     isTimeoutErrorMessage: mockedIsTimeoutErrorMessage,
     pickFallbackThinkingLevel: mockedPickFallbackThinkingLevel,
     sanitizeUserFacingText: vi.fn((text: unknown) => (typeof text === "string" ? text : "")),

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -80,6 +80,7 @@ import {
   isGenericUnknownStreamErrorMessage,
   isLikelyContextOverflowError,
   isRateLimitAssistantError,
+  isServerErrorMessage,
   parseImageDimensionError,
   parseImageSizeError,
   pickFallbackThinkingLevel,
@@ -3361,8 +3362,13 @@ async function runEmbeddedAgentInternal(
             assistantFailoverReason === "timeout" &&
             isGenericUnknownStreamErrorMessage(assistantForFailover?.errorMessage ?? "") &&
             Boolean(assistantForFailover && hasOnlyAssistantReasoningContent(assistantForFailover));
+          const serverSideSilentErrorReason =
+            assistantFailoverReason === "server_error" ||
+            (assistantFailoverReason === "timeout" &&
+              isServerErrorMessage(assistantForFailover?.errorMessage ?? ""));
           const silentErrorRetryReason =
             assistantFailoverReason === null ||
+            serverSideSilentErrorReason ||
             genericUnknownReasoningError ||
             assistantFailoverReason === "no_error_details" ||
             assistantFailoverReason === "unclassified" ||

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -401,6 +401,9 @@ function normalizeEmbeddedRunAttemptResult(
       | null;
     didDeliverSourceReplyViaMessageTool?: boolean | null;
     itemLifecycle?: EmbeddedRunAttemptForRunner["itemLifecycle"] | null;
+    currentAttemptReplayMetadata?:
+      | EmbeddedRunAttemptForRunner["currentAttemptReplayMetadata"]
+      | null;
   };
   return {
     ...attempt,
@@ -419,6 +422,9 @@ function normalizeEmbeddedRunAttemptResult(
       activeCount: 0,
     },
     replayMetadata: resolveAttemptReplayMetadata(raw),
+    currentAttemptReplayMetadata: resolveAttemptReplayMetadata({
+      replayMetadata: raw.currentAttemptReplayMetadata ?? raw.replayMetadata,
+    }),
   };
 }
 

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
@@ -127,6 +127,10 @@ function createSubscriptionMock(): SubscriptionMock {
       replayInvalid: false,
       hadPotentialSideEffects: false,
     }),
+    getCurrentAttemptReplayState: () => ({
+      replayInvalid: false,
+      hadPotentialSideEffects: false,
+    }),
     didSendViaMessagingTool: () => false,
     didSendDeterministicApprovalPrompt: () => false,
     getLastToolError: () => undefined,

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -3648,6 +3648,7 @@ export async function runEmbeddedAttempt(
         getVisibleBlockReplyCount,
         getSuccessfulCronAdds,
         getReplayState,
+        getCurrentAttemptReplayState,
         didSendViaMessagingTool,
         didSendDeterministicApprovalPrompt,
         getLastToolError,
@@ -5454,6 +5455,11 @@ export async function runEmbeddedAttempt(
       const replayMetadata = replayMetadataFromState(
         observeReplayMetadata(getReplayState(), observedReplayMetadata),
       );
+      // Silent provider-error retries only use currentAttemptReplayMetadata; replayMetadata stays
+      // cumulative so liveness and compaction keep prior retry/session safety evidence.
+      const currentAttemptReplayMetadata = replayMetadataFromState(
+        observeReplayMetadata(getCurrentAttemptReplayState(), observedReplayMetadata),
+      );
       const completedClientToolCalls = clientToolCallSlots.flatMap((slot) =>
         slot.completed && slot.params
           ? [
@@ -5627,6 +5633,7 @@ export async function runEmbeddedAttempt(
 
       return {
         replayMetadata,
+        currentAttemptReplayMetadata,
         itemLifecycle: getItemLifecycle(),
         setTerminalLifecycleMeta,
         aborted,

--- a/src/agents/embedded-agent-runner/run/incomplete-turn.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn.ts
@@ -536,6 +536,7 @@ export function shouldRetrySilentErrorAssistantTurn(params: {
     | "didDeliverSourceReplyViaMessageTool"
     | "messagingToolSourceReplyPayloads"
     | "replayMetadata"
+    | "currentAttemptReplayMetadata"
   >;
   assistant: EmbeddedRunAttemptResult["lastAssistant"] | null | undefined;
 }): boolean {
@@ -545,7 +546,11 @@ export function shouldRetrySilentErrorAssistantTurn(params: {
   if (hasAttemptTerminalState(params.attempt)) {
     return false;
   }
-  if (resolveAttemptReplayMetadata(params.attempt).hadPotentialSideEffects) {
+  if (
+    resolveAttemptReplayMetadata({
+      replayMetadata: params.attempt.currentAttemptReplayMetadata ?? params.attempt.replayMetadata,
+    }).hadPotentialSideEffects
+  ) {
     return false;
   }
 

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -238,6 +238,7 @@ export type EmbeddedRunAttemptResult = {
   /** True when sessions_yield tool was called during this attempt. */
   yieldDetected?: boolean;
   replayMetadata: EmbeddedRunReplayMetadata;
+  currentAttemptReplayMetadata?: EmbeddedRunReplayMetadata;
   itemLifecycle: {
     startedCount: number;
     completedCount: number;

--- a/src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts
@@ -47,6 +47,7 @@ function createContext(
       pendingToolTrustedLocalMedia: false,
       deferredBlockReplies: [],
       replayState: { replayInvalid: false, hadPotentialSideEffects: false },
+      currentAttemptReplayState: { replayInvalid: false, hadPotentialSideEffects: false },
       blockState: {
         thinking: true,
         final: true,

--- a/src/agents/embedded-agent-subscribe.handlers.tools.media.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.media.test.ts
@@ -26,6 +26,7 @@ function createMockContext(overrides?: {
     },
     state: {
       replayState: { replayInvalid: false, hadPotentialSideEffects: false },
+      currentAttemptReplayState: { replayInvalid: false, hadPotentialSideEffects: false },
       toolMetaById: new Map(),
       toolMetas: [],
       toolSummaryById: new Set(),

--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -83,6 +83,7 @@ function createTestContext(): {
       pendingToolTrustedLocalMedia: false,
       deterministicApprovalPromptPending: false,
       replayState: { replayInvalid: false, hadPotentialSideEffects: false },
+      currentAttemptReplayState: { replayInvalid: false, hadPotentialSideEffects: false },
       messagingToolSentTexts: [],
       messagingToolSentTextsNormalized: [],
       messagingToolSentMediaUrls: [],

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -1222,10 +1222,18 @@ export async function handleToolExecutionEnd(
     ctx.state.hadDeterministicSideEffect = true;
   }
   if (attemptedPotentialSideEffect || acceptedSessionSpawn || asyncStarted) {
-    ctx.state.replayState = mergeEmbeddedRunReplayState(ctx.state.replayState, {
+    const sideEffectReplayState = {
       replayInvalid: true,
       hadPotentialSideEffects: true,
-    });
+    };
+    ctx.state.replayState = mergeEmbeddedRunReplayState(
+      ctx.state.replayState,
+      sideEffectReplayState,
+    );
+    ctx.state.currentAttemptReplayState = mergeEmbeddedRunReplayState(
+      ctx.state.currentAttemptReplayState,
+      sideEffectReplayState,
+    );
   }
 
   // Commit messaging tool evidence on success, discard on error.

--- a/src/agents/embedded-agent-subscribe.handlers.types.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.types.ts
@@ -149,6 +149,8 @@ export type EmbeddedAgentSubscribeState = {
   compactionRetryPromise: Promise<void> | null;
   unsubscribed: boolean;
   replayState: EmbeddedRunReplayState;
+  /** Current-attempt replay evidence excludes initial replayState from earlier runner retries. */
+  currentAttemptReplayState: EmbeddedRunReplayState;
   livenessState?: EmbeddedRunLivenessState;
   terminalStopReason?: string;
   yielded?: boolean;
@@ -316,6 +318,7 @@ type ToolHandlerState = Pick<
   | "deterministicApprovalPromptPending"
   | "hadDeterministicSideEffect"
   | "replayState"
+  | "currentAttemptReplayState"
   | "messagingToolSentTexts"
   | "messagingToolSentTextsNormalized"
   | "messagingToolSentMediaUrls"

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
@@ -1391,6 +1391,10 @@ describe("subscribeEmbeddedAgentSession", () => {
       replayInvalid: true,
       hadPotentialSideEffects: true,
     });
+    expect(subscription.getCurrentAttemptReplayState()).toEqual({
+      replayInvalid: true,
+      hadPotentialSideEffects: true,
+    });
     const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
     expectLifecyclePayload(payloads, {
       phase: "end",

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -218,6 +218,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     compactionRetryPromise: null,
     unsubscribed: false,
     replayState: createEmbeddedRunReplayState(params.initialReplayState),
+    currentAttemptReplayState: createEmbeddedRunReplayState(),
     livenessState: "working",
     hadDeterministicSideEffect: false,
     pendingEventChain: null,
@@ -1239,6 +1240,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     state.lastDeliveredBlockReplyText = undefined;
     state.toolExecutionSinceLastBlockReply = false;
     state.replayState = mergeEmbeddedRunReplayState(state.replayState, params.initialReplayState);
+    // Compaction retry is still the same outer attempt; keep current-attempt side effects monotonic.
     state.livenessState = "working";
     resetAssistantMessageState(0);
   };
@@ -1417,6 +1419,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     getVisibleBlockReplyCount: () => state.visibleBlockReplyCount,
     getSuccessfulCronAdds: () => state.successfulCronAdds,
     getReplayState: () => ({ ...state.replayState }),
+    getCurrentAttemptReplayState: () => ({ ...state.currentAttemptReplayState }),
     // Returns true if any messaging tool successfully sent a message.
     // Used to suppress agent's confirmation text (e.g., "Respondi no Telegram!")
     // which is generated AFTER the tool sends the actual answer.

--- a/src/agents/harness/selection.test.ts
+++ b/src/agents/harness/selection.test.ts
@@ -143,6 +143,7 @@ function createAttemptResult(sessionIdUsed: string): EmbeddedRunAttemptResult {
     messagingToolSentTargets: [],
     cloudCodeAssistFormatError: false,
     replayMetadata: { hadPotentialSideEffects: false, replaySafe: true },
+    currentAttemptReplayMetadata: { hadPotentialSideEffects: false, replaySafe: true },
     itemLifecycle: { startedCount: 0, completedCount: 0, activeCount: 0 },
   };
 }

--- a/src/agents/test-helpers/embedded-agent-runner-e2e-fixtures.ts
+++ b/src/agents/test-helpers/embedded-agent-runner-e2e-fixtures.ts
@@ -133,6 +133,16 @@ export function makeEmbeddedRunnerAttempt(
         messagingToolSentTargets,
         successfulCronAdds,
       }),
+    currentAttemptReplayMetadata:
+      overrides.currentAttemptReplayMetadata ??
+      buildAttemptReplayMetadata({
+        toolMetas,
+        didSendViaMessagingTool,
+        messagingToolSentTexts,
+        messagingToolSentMediaUrls,
+        messagingToolSentTargets,
+        successfulCronAdds,
+      }),
     didSendViaMessagingTool,
     messagingToolSentTexts,
     messagingToolSentMediaUrls,


### PR DESCRIPTION
Fixes #97877

## What Problem This Solves

Transient provider errors that return `stopReason="error"` with no visible output could skip the empty-error retry path after earlier tool side effects had marked cumulative replay metadata unsafe. In that case the user could get no Discord reply even though the failed provider call itself did not run tools or deliver output.

## Why This Change Was Made

This separates cumulative replay safety from current-attempt replay safety. `replayMetadata` remains cumulative for liveness, compaction, and replay-invalid reporting, while `currentAttemptReplayMetadata` records side effects from the active outer attempt only. The silent provider-error retry gate now checks current-attempt metadata, with an intentional legacy fallback to `replayMetadata` for bundled or external harnesses that have not started returning the new field yet.

The retry also covers classified empty `server_error` turns and timeout-classified messages that match the existing server-error matcher, so the OpenRouter-style empty 5xx case is retried before failover surfaces it as terminal. Ordinary timeout failover errors remain outside this path.

The current-attempt state stays monotonic across in-attempt compaction retries, so side effects before compaction cannot be erased before a later provider error in the same attempt.

## User Impact

OpenClaw can retry empty transient provider 5xx/server errors after prior session or retry-history side effects when the failed model call itself was safe to replay. Attempts that actually produced tools, deliveries, cron writes, async work, or other current-attempt side effects remain blocked from retry to avoid duplicating actions.

External harnesses that omit the optional `currentAttemptReplayMetadata` keep the previous conservative behavior because the runner falls back to `replayMetadata`; they do not become newly retry-eligible until they explicitly report current-attempt replay metadata.

## Evidence

- Non-test runtime transcript, generated from a temporary local Node script that executed the production retry predicate in `src/agents/embedded-agent-runner/run/incomplete-turn.ts` and mirrored the `server_error` branch in `src/agents/embedded-agent-runner/run.ts` (not Vitest, secrets and local paths redacted):

```text
OPENCLAW_ISSUE_97877_RUNTIME_PROOF_BEGIN
repo=[redacted repo root]
command=node --import tsx .artifacts/issue-97877-runtime-proof.ts
provider=openrouter model=minimax/minimax-m3 secrets=redacted
scenario=current-attempt-metadata
priorSideEffect=redacted prior exec/tool result
attempt=1 stopReason=error error="Internal Server Error"
attempt=1 replayMetadata={"hadPotentialSideEffects":true,"replaySafe":false}
attempt=1 currentAttemptReplayMetadata={"hadPotentialSideEffects":false,"replaySafe":true}
attempt=1 sideEffects={"didSendViaMessagingTool":false,"didDeliverSourceReplyViaMessageTool":false,"messagingTargets":0,"sourceReplyPayloads":0,"acceptedSpawns":0}
attempt=1 serverSideSilentErrorReason=true
attempt=1 shouldRetrySilentErrorAssistantTurn=true
[empty-error-retry] stopReason=error non-visible-output; resubmitting attempt=1/3 provider=openrouter model=minimax/minimax-m3 sessionKey=redacted-session
attempt=2 stopReason=stop
attempt=2 visibleText="Recovered after retry without duplicate delivery."
attempt=2 sideEffects={"didSendViaMessagingTool":false,"didDeliverSourceReplyViaMessageTool":false,"messagingTargets":0,"sourceReplyPayloads":0,"acceptedSpawns":0}
scenario=legacy-missing-current-attempt-metadata
priorSideEffect=redacted prior exec/tool result
attempt=1 stopReason=error error="Internal Server Error"
attempt=1 replayMetadata={"hadPotentialSideEffects":true,"replaySafe":false}
attempt=1 currentAttemptReplayMetadata=undefined
attempt=1 sideEffects={"didSendViaMessagingTool":false,"didDeliverSourceReplyViaMessageTool":false,"messagingTargets":0,"sourceReplyPayloads":0,"acceptedSpawns":0}
attempt=1 serverSideSilentErrorReason=true
attempt=1 shouldRetrySilentErrorAssistantTurn=false
legacyFallback=conservative-no-retry
OPENCLAW_ISSUE_97877_RUNTIME_PROOF_END
```

- Representative fault-injected runner/session proof: `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.empty-error-retry.test.ts src/agents/embedded-agent-runner.e2e.test.ts src/agents/embedded-agent-runner/run.incomplete-turn.test.ts src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts` — 5 files, 241 tests passed.
  - The E2E scenario seeds a session with a prior redacted `exec` tool call/result, injects an OpenRouter-style empty assistant error for `openrouter/minimax/minimax-m3` with `errorMessage="Internal Server Error"`, cumulative `replayMetadata.hadPotentialSideEffects=true`, and `currentAttemptReplayMetadata.hadPotentialSideEffects=false`.
  - The run captures the `[empty-error-retry]` warning, retries once, and returns the visible payload `Recovered after retry.`.
  - Side-effect assertions: `didSendViaMessagingTool=false`, `messagingToolSentTexts=[]`, `acceptedSessionSpawns=[]`, and the prior redacted tool result is still present exactly once after the retry.
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.empty-error-retry.test.ts src/agents/embedded-agent-runner/run.incomplete-turn.test.ts src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts src/agents/embedded-agent-subscribe.handlers.tools.test.ts src/agents/embedded-agent-subscribe.handlers.tools.media.test.ts src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts src/agents/openclaw-owned-tool-runtime-contract.test.ts src/agents/harness/selection.test.ts src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts` — 9 files, 420 tests passed before the review follow-up.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo` — passed.
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.src.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-src.tsbuildinfo` — passed.
- `node scripts/run-oxlint.mjs src/agents/embedded-agent-helpers.ts src/agents/embedded-agent-helpers/errors.ts src/agents/embedded-agent-runner/run.ts src/agents/embedded-agent-runner/run.empty-error-retry.test.ts src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts src/agents/embedded-agent-runner.e2e.test.ts` — passed.
- `git diff --check` — passed.
- `pnpm check:changed -- <touched files>` was attempted earlier but did not reach repo checks because the local Crabbox binary is `0.18.0` and the Testbox delegate requires Crabbox `>= 0.22.0`.
