### PR TITLE
fix(agents): stop copilot autoreview cleanup crash on Windows

### DIFF
--- a/.agents/skills/autoreview/scripts/autoreview
+++ b/.agents/skills/autoreview/scripts/autoreview
@@ -624,7 +624,11 @@ def run_copilot(args: argparse.Namespace, repo: Path, prompt: str) -> str:
         raise SystemExit("--thinking is not supported by the copilot engine")
     if not args.tools:
         raise SystemExit("--no-tools is not supported by the copilot engine; copilot requires a read-only file view tool to load the review bundle without exposing it in argv")
-    with tempfile.TemporaryDirectory(prefix="autoreview-copilot.") as tempdir:
+    # ignore_cleanup_errors: on Windows the spawned copilot process (and its MCP
+    # subprocesses) keep `tempdir` as their cwd briefly after exit, holding a directory
+    # handle that makes rmtree fail with WinError 32. The review already completed, so a
+    # cleanup race must not abort the run; best-effort delete is correct here.
+    with tempfile.TemporaryDirectory(prefix="autoreview-copilot.", ignore_cleanup_errors=True) as tempdir:
         prompt_path = Path(tempdir) / "prompt.txt"
         prompt_path.write_text(prompt)
         os.chmod(prompt_path, 0o600)


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where running the `autoreview` skill with `--engine copilot` on Windows could crash with a Python traceback (`PermissionError: [WinError 32] The process cannot access the file because it is being used by another process`) even though the code review itself completed successfully. The structured review result was discarded and the command exited non-zero for that run.

## Why This Change Was Made

`run_copilot` runs inside a `tempfile.TemporaryDirectory(...)` context manager whose `__exit__` deletes the directory. The spawned `copilot -C <tempdir>` process (and its MCP subprocesses) keep that directory as their working directory for a brief moment after exit, so on Windows the lingering directory handle makes `rmtree` raise `WinError 32`. Because the review had already finished, the cleanup race should never fail the run. Passing `ignore_cleanup_errors=True` makes the temp-dir cleanup best-effort, matching how the other engines already tolerate post-run temp-file cleanup. This is the only engine that used `TemporaryDirectory`; no other behavior changes.

## User Impact

The `autoreview` copilot engine no longer fails a completed review because Windows has not released the temporary directory handle yet. No intended behavior change on macOS/Linux.

## Evidence

- Before: `test-review-harness.ps1 -Fixture benign -Engine copilot` aborted with the `WinError 32` traceback from `TemporaryDirectory.__exit__` (`shutil.rmtree`), exit code 1.
- After: the same harness no longer aborts with the `WinError 32` cleanup traceback; the separate prose-wrapped JSON parser failure is handled in the companion copilot parser PR.
- Local `%TEMP%\autoreview-copilot.*` leftovers confirmed cleanup can fail without deleting the prompt directory; this change makes that cleanup best-effort instead of turning the finished review into a failure.
- Closeout review on this commit (`autoreview --mode commit --commit HEAD --engine claude`): `autoreview clean: no accepted/actionable findings reported`, patch is correct (0.9).
- `ignore_cleanup_errors` requires Python 3.10+; the script already targets 3.10+ (verified, runtime 3.14) and declares no older floor.
