### PR TITLE
fix(agent): duplicate same-session turn when the gateway connection drops after accepting a run

### DIFF
--- a/src/agents/command/types.ts
+++ b/src/agents/command/types.ts
@@ -31,7 +31,7 @@ export type ImageContent = {
 export type AgentCommandResultMetaOverrides = {
   transport?: "embedded";
   fallbackFrom?: "gateway";
-  fallbackReason?: "gateway_timeout";
+  fallbackReason?: "gateway_timeout" | "gateway_connection_lost";
   fallbackSessionId?: string;
   fallbackSessionKey?: string;
 };

--- a/src/commands/agent-via-gateway-embedded-fallback.ts
+++ b/src/commands/agent-via-gateway-embedded-fallback.ts
@@ -1,0 +1,142 @@
+// Fresh-session embedded fallback for the gateway agent CLI: the paths that must
+// re-run locally on a brand-new `gateway-fallback-<uuid>` session (gateway
+// timeout, and accepted-then-disconnected) instead of reusing a session a
+// still-running detached gateway run may own.
+import { randomUUID } from "node:crypto";
+import { resolveDefaultAgentId } from "../agents/agent-scope-config.js";
+import type { AgentCommandOpts } from "../agents/command/types.js";
+import {
+  classifySessionKeyShape,
+  isUnscopedSessionKeySentinel,
+  normalizeAgentId,
+  resolveAgentIdFromSessionKey,
+} from "../routing/session-key.js";
+import type { RuntimeEnv } from "../runtime.js";
+import {
+  EMBEDDED_FALLBACK_META,
+  getGatewayDispatchConfig,
+  loadAgentSessionModule,
+  loadEmbeddedAgentCommand,
+  returnAfterSignalExit,
+  type AgentCliDeps,
+  type AgentCliSignal,
+  type AgentDispatchOpts,
+} from "./agent-via-gateway.js";
+
+const GATEWAY_TIMEOUT_FALLBACK_SESSION_PREFIX = "gateway-fallback-";
+
+/**
+ * Raised when the gateway already accepted (and detached) a run but the
+ * CLI↔gateway connection closed non-transiently before the final frame. The
+ * detached gateway run still owns the original session, so the CLI fallback
+ * must re-run on a FRESH session (matching the gateway-timeout path) instead of
+ * re-executing the same message on the original session and colliding with the
+ * in-flight gateway run. Carries the accepted run identity for diagnostics.
+ */
+export class GatewayAgentAcceptedRunDisconnectError extends Error {
+  readonly acceptedRunId: string | undefined;
+  readonly acceptedSessionKey: string | undefined;
+  constructor(params: {
+    acceptedRunId: string | undefined;
+    acceptedSessionKey: string | undefined;
+    cause: unknown;
+  }) {
+    super("gateway accepted the run but the connection closed before completion", {
+      cause: params.cause,
+    });
+    this.name = "GatewayAgentAcceptedRunDisconnectError";
+    this.acceptedRunId = params.acceptedRunId;
+    this.acceptedSessionKey = params.acceptedSessionKey;
+  }
+}
+
+export function isGatewayAgentAcceptedRunDisconnectError(
+  err: unknown,
+): err is GatewayAgentAcceptedRunDisconnectError {
+  return err instanceof GatewayAgentAcceptedRunDisconnectError;
+}
+
+function createGatewayTimeoutFallbackSessionId(): string {
+  return `${GATEWAY_TIMEOUT_FALLBACK_SESSION_PREFIX}${randomUUID()}`;
+}
+
+function createGatewayTimeoutFallbackSession(agentId?: string): {
+  sessionId: string;
+  sessionKey: string;
+} {
+  const sessionId = createGatewayTimeoutFallbackSessionId();
+  return {
+    sessionId,
+    sessionKey: `agent:${normalizeAgentId(agentId)}:explicit:${sessionId.trim()}`,
+  };
+}
+
+async function resolveAgentIdForGatewayTimeoutFallback(
+  opts: AgentDispatchOpts,
+): Promise<string | undefined> {
+  const explicitSessionKey = opts.sessionKey?.trim();
+  if (classifySessionKeyShape(explicitSessionKey) === "agent") {
+    return resolveAgentIdFromSessionKey(explicitSessionKey);
+  }
+  if (isUnscopedSessionKeySentinel(explicitSessionKey)) {
+    return resolveDefaultAgentId(await getGatewayDispatchConfig());
+  }
+
+  const agentIdRaw = opts.agent?.trim();
+  if (agentIdRaw) {
+    return normalizeAgentId(agentIdRaw);
+  }
+
+  if (!opts.to && !opts.sessionId) {
+    return undefined;
+  }
+  const cfg = await getGatewayDispatchConfig();
+  const { resolveSessionKeyForRequest } = await loadAgentSessionModule();
+  const resolvedSessionKey = resolveSessionKeyForRequest({
+    cfg,
+    to: opts.to,
+    sessionId: opts.sessionId,
+  }).sessionKey;
+  return classifySessionKeyShape(resolvedSessionKey) === "agent"
+    ? resolveAgentIdFromSessionKey(resolvedSessionKey)
+    : undefined;
+}
+
+/**
+ * Runs the embedded agent on a brand-new `gateway-fallback-<uuid>` session. Both
+ * the gateway-timeout and accepted-then-disconnected paths use this so the
+ * fallback never reuses a session a still-running gateway run may own. The
+ * fresh session id doubles as the embedded run id and is reported via
+ * `fallbackReason` metadata.
+ */
+export async function runGatewayEmbeddedFallbackOnFreshSession(params: {
+  dispatchOpts: AgentDispatchOpts;
+  localOpts: AgentCommandOpts;
+  runtime: RuntimeEnv;
+  deps: AgentCliDeps | undefined;
+  signalBridge: { getReceivedSignal: () => AgentCliSignal | undefined };
+  fallbackReason: "gateway_timeout" | "gateway_connection_lost";
+  describeFailure: (fallbackSessionId: string) => string;
+}) {
+  const fallbackAgentId = await resolveAgentIdForGatewayTimeoutFallback(params.dispatchOpts);
+  const fallbackSession = createGatewayTimeoutFallbackSession(fallbackAgentId);
+  params.runtime.error?.(params.describeFailure(fallbackSession.sessionId));
+  const agentCommand = await loadEmbeddedAgentCommand();
+  const result = await agentCommand(
+    {
+      ...params.localOpts,
+      sessionId: fallbackSession.sessionId,
+      sessionKey: fallbackSession.sessionKey,
+      runId: fallbackSession.sessionId,
+      resultMetaOverrides: {
+        ...EMBEDDED_FALLBACK_META,
+        fallbackReason: params.fallbackReason,
+        fallbackSessionId: fallbackSession.sessionId,
+        fallbackSessionKey: fallbackSession.sessionKey,
+      },
+    },
+    params.runtime,
+    params.deps,
+  );
+  return returnAfterSignalExit(result, params.signalBridge.getReceivedSignal(), params.runtime);
+}

--- a/src/commands/agent-via-gateway.test.ts
+++ b/src/commands/agent-via-gateway.test.ts
@@ -1693,6 +1693,102 @@ describe("agentCliCommand", () => {
     });
   });
 
+  it("uses a fresh embedded session when the connection closes after the gateway accepts the run", async () => {
+    await withTempStore(async () => {
+      // The gateway accepts (and detaches) the run, then the connection drops
+      // non-transiently before the final frame. The detached gateway run still
+      // owns agent:main:incident-42, so the embedded fallback must not reuse it.
+      callGateway.mockImplementation(async (requestValue: unknown) => {
+        const request = requireRecord(requestValue, "gateway request");
+        const onAccepted = request.onAccepted as ((payload: unknown) => void) | undefined;
+        onAccepted?.({
+          status: "accepted",
+          runId: "run-accepted-close",
+          sessionKey: "agent:main:incident-42",
+        });
+        throw createGatewayClosedError();
+      });
+      mockLocalAgentReply();
+
+      await agentCliCommand({ message: "hi", sessionKey: "agent:main:incident-42" }, runtime);
+
+      expect(callGateway).toHaveBeenCalledTimes(1);
+      expect(agentCommand).toHaveBeenCalledTimes(1);
+      const fallbackOpts = requireRecord(
+        requireFirstCallArg(agentCommand, "embedded agent"),
+        "embedded agent options",
+      );
+      const fallbackSessionId = String(fallbackOpts.sessionId);
+      const fallbackSessionKey = String(fallbackOpts.sessionKey);
+      expect(fallbackSessionId).toMatch(/^gateway-fallback-/);
+      expect(fallbackSessionKey).not.toBe("agent:main:incident-42");
+      expect(fallbackSessionKey).toBe(`agent:main:explicit:${fallbackSessionId}`);
+      expect(fallbackOpts.runId).toBe(fallbackSessionId);
+      const resultMetaOverrides = requireRecord(
+        fallbackOpts.resultMetaOverrides,
+        "fallback metadata",
+      );
+      expect(resultMetaOverrides.transport).toBe("embedded");
+      expect(resultMetaOverrides.fallbackFrom).toBe("gateway");
+      expect(resultMetaOverrides.fallbackReason).toBe("gateway_connection_lost");
+      expect(resultMetaOverrides.fallbackSessionId).toBe(fallbackSessionId);
+      expect(resultMetaOverrides.fallbackSessionKey).toBe(fallbackSessionKey);
+      expect(
+        mockMessages(runtime.error).some((message) =>
+          message.includes(
+            "Gateway connection closed after the run was accepted; running embedded agent with fresh session",
+          ),
+        ),
+      ).toBe(true);
+      expect(runtime.log).toHaveBeenCalledWith("local");
+    });
+  });
+
+  it("reconnects to the in-flight gateway run when a transient close follows acceptance", async () => {
+    vi.useFakeTimers();
+    try {
+      await withTempStore(async () => {
+        callGateway
+          .mockImplementationOnce(async (requestValue: unknown) => {
+            const request = requireRecord(requestValue, "gateway request");
+            const onAccepted = request.onAccepted as ((payload: unknown) => void) | undefined;
+            onAccepted?.({
+              status: "accepted",
+              runId: "idem-1",
+              sessionKey: "agent:main:incident-42",
+            });
+            // Transient normal close (1000, no reason) after acceptance: the
+            // accepted run is still in flight, so the connect-retry loop must
+            // reconnect rather than reroute to a fresh embedded session.
+            throw createGatewayNormalCloseError();
+          })
+          .mockResolvedValue({
+            runId: "idem-1",
+            status: "in_flight",
+            result: { payloads: [], meta: { stub: true } },
+          });
+
+        const command = agentCliCommand(
+          { message: "hi", sessionKey: "agent:main:incident-42" },
+          runtime,
+        );
+        await vi.advanceTimersByTimeAsync(1_000);
+        await command;
+
+        expect(callGateway).toHaveBeenCalledTimes(2);
+        // Reconnect hits the gateway's server-side accepted/in_flight dedupe
+        // (server-methods/agent.ts), so no embedded fallback runs and the
+        // original session is never re-executed locally.
+        expect(agentCommand).not.toHaveBeenCalled();
+        expect(
+          mockMessages(runtime.error).some((message) => message.includes("already in flight")),
+        ).toBe(true);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("does not fall back to embedded agent for gateway request errors", async () => {
     await withTempStore(async () => {
       callGateway.mockRejectedValue(

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -1,5 +1,4 @@
 // Gateway-first agent CLI implementation with embedded fallback for local/runtime failures.
-import { randomUUID } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { TextDecoder } from "node:util";
 import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
@@ -40,6 +39,11 @@ import {
 import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
 import { createLazyPromiseLoader } from "../shared/lazy-runtime.js";
 import { normalizeMessageChannel } from "../utils/message-channel-normalize.js";
+import {
+  GatewayAgentAcceptedRunDisconnectError,
+  isGatewayAgentAcceptedRunDisconnectError,
+  runGatewayEmbeddedFallbackOnFreshSession,
+} from "./agent-via-gateway-embedded-fallback.js";
 
 type AgentGatewayResult = {
   payloads?: Array<{
@@ -60,11 +64,10 @@ type GatewayAgentResponse = {
 };
 
 const NO_GATEWAY_TIMEOUT_MS = 2_147_000_000;
-const EMBEDDED_FALLBACK_META = {
+export const EMBEDDED_FALLBACK_META = {
   transport: "embedded",
   fallbackFrom: "gateway",
 } as const;
-const GATEWAY_TIMEOUT_FALLBACK_SESSION_PREFIX = "gateway-fallback-";
 const GATEWAY_TRANSIENT_CONNECT_RETRY_DELAYS_MS = [1_000, 2_000, 5_000, 10_000, 15_000] as const;
 
 type AgentCliOpts = {
@@ -90,16 +93,16 @@ type AgentCliOpts = {
   extraSystemPrompt?: string;
   local?: boolean;
 };
-type AgentDispatchOpts = Omit<AgentCliOpts, "messageFile"> & {
+export type AgentDispatchOpts = Omit<AgentCliOpts, "messageFile"> & {
   message: string;
 };
 
-type AgentCliSignal = "SIGINT" | "SIGTERM";
+export type AgentCliSignal = "SIGINT" | "SIGTERM";
 type AgentCliProcessLike = {
   on(signal: AgentCliSignal, handler: () => void): unknown;
   off(signal: AgentCliSignal, handler: () => void): unknown;
 };
-type AgentCliDeps = CliDeps & {
+export type AgentCliDeps = CliDeps & {
   process?: AgentCliProcessLike;
 };
 type AgentGatewayCallIdentity = Pick<
@@ -141,8 +144,8 @@ function resolveGatewayAbortRetryDelaysMs(): readonly number[] {
   return gatewayAbortRetryDelaysMsForTests ?? GATEWAY_ABORT_RETRY_DELAYS_MS;
 }
 
-const loadEmbeddedAgentCommand = embeddedAgentCommandLoader.load;
-const loadAgentSessionModule = agentSessionModuleCache.load;
+export const loadEmbeddedAgentCommand = embeddedAgentCommandLoader.load;
+export const loadAgentSessionModule = agentSessionModuleCache.load;
 
 async function loadRuntimeConfig(): Promise<OpenClawConfig> {
   const { getRuntimeConfig } = await runtimeConfigModuleLoader.load();
@@ -253,7 +256,7 @@ function resolveGatewayAgentTimeoutMs(timeoutSeconds: number): number {
   return resolveTimerTimeoutMs((timeoutSeconds + 30) * 1000, 10_000, 10_000);
 }
 
-async function getGatewayDispatchConfig(options?: {
+export async function getGatewayDispatchConfig(options?: {
   skipShellEnvFallback?: boolean;
 }): Promise<OpenClawConfig> {
   // Scoped gateway turns need core agent/session/gateway fields only. The
@@ -319,6 +322,20 @@ function isTransientGatewayAgentConnectClose(err: unknown): boolean {
   const code = typeof err.code === "number" ? err.code : undefined;
   const reason = normalizeOptionalString(err.reason);
   return code === 1000 && (!reason || reason === "no close reason");
+}
+
+/**
+ * A non-transient gateway transport close: a closed transport error that is
+ * neither a timeout (handled by its own fresh-session path) nor a transient
+ * normal close (handled by the connect-retry loop). The accepted-run gating
+ * lives at the call site, so this predicate stays purely about the close shape.
+ */
+function isNonTransientGatewayAgentClose(err: unknown): boolean {
+  return (
+    isGatewayAgentEmbeddedFallbackError(err) &&
+    !isGatewayAgentTimeoutError(err) &&
+    !isTransientGatewayAgentConnectClose(err)
+  );
 }
 
 function validateExplicitSessionKeyForDispatch(
@@ -604,58 +621,12 @@ function exitForReceivedSignal(signal: AgentCliSignal | undefined, runtime: Runt
   return true;
 }
 
-function returnAfterSignalExit<T>(
+export function returnAfterSignalExit<T>(
   value: T,
   signal: AgentCliSignal | undefined,
   runtime: RuntimeEnv,
 ): T | undefined {
   return exitForReceivedSignal(signal, runtime) ? undefined : value;
-}
-
-function createGatewayTimeoutFallbackSessionId(): string {
-  return `${GATEWAY_TIMEOUT_FALLBACK_SESSION_PREFIX}${randomUUID()}`;
-}
-
-function createGatewayTimeoutFallbackSession(agentId?: string): {
-  sessionId: string;
-  sessionKey: string;
-} {
-  const sessionId = createGatewayTimeoutFallbackSessionId();
-  return {
-    sessionId,
-    sessionKey: `agent:${normalizeAgentId(agentId)}:explicit:${sessionId.trim()}`,
-  };
-}
-
-async function resolveAgentIdForGatewayTimeoutFallback(
-  opts: AgentDispatchOpts,
-): Promise<string | undefined> {
-  const explicitSessionKey = opts.sessionKey?.trim();
-  if (classifySessionKeyShape(explicitSessionKey) === "agent") {
-    return resolveAgentIdFromSessionKey(explicitSessionKey);
-  }
-  if (isUnscopedSessionKeySentinel(explicitSessionKey)) {
-    return resolveDefaultAgentId(await getGatewayDispatchConfig());
-  }
-
-  const agentIdRaw = opts.agent?.trim();
-  if (agentIdRaw) {
-    return normalizeAgentId(agentIdRaw);
-  }
-
-  if (!opts.to && !opts.sessionId) {
-    return undefined;
-  }
-  const cfg = await getGatewayDispatchConfig();
-  const { resolveSessionKeyForRequest } = await loadAgentSessionModule();
-  const resolvedSessionKey = resolveSessionKeyForRequest({
-    cfg,
-    to: opts.to,
-    sessionId: opts.sessionId,
-  }).sessionKey;
-  return classifySessionKeyShape(resolvedSessionKey) === "agent"
-    ? resolveAgentIdFromSessionKey(resolvedSessionKey)
-    : undefined;
 }
 
 function buildGatewayJsonResponse(response: GatewayAgentResponse): GatewayAgentResponse {
@@ -844,6 +815,16 @@ async function agentViaGatewayCommand(
           config: cfg,
         });
       }
+      // Once the gateway accepted (and detached) the run, surface the accepted
+      // identity so the CLI fallback re-runs on a fresh session instead of
+      // colliding with the still-running gateway run on the original session.
+      if (acceptedGatewayRun && isNonTransientGatewayAgentClose(err)) {
+        throw new GatewayAgentAcceptedRunDisconnectError({
+          acceptedRunId,
+          acceptedSessionKey,
+          cause: err,
+        });
+      }
       throw err;
     }
   }
@@ -964,29 +945,33 @@ export async function agentCliCommand(
         throw err;
       }
       if (isGatewayAgentTimeoutError(err)) {
-        const fallbackAgentId = await resolveAgentIdForGatewayTimeoutFallback(dispatchOpts);
-        const fallbackSession = createGatewayTimeoutFallbackSession(fallbackAgentId);
-        runtime.error?.(
-          `EMBEDDED FALLBACK: Gateway agent timed out; running embedded agent with fresh session ${fallbackSession.sessionId}: ${String(err)}`,
-        );
-        const agentCommand = await loadEmbeddedAgentCommand();
-        const result = await agentCommand(
-          {
-            ...localOpts,
-            sessionId: fallbackSession.sessionId,
-            sessionKey: fallbackSession.sessionKey,
-            runId: fallbackSession.sessionId,
-            resultMetaOverrides: {
-              ...EMBEDDED_FALLBACK_META,
-              fallbackReason: "gateway_timeout",
-              fallbackSessionId: fallbackSession.sessionId,
-              fallbackSessionKey: fallbackSession.sessionKey,
-            },
-          },
+        return await runGatewayEmbeddedFallbackOnFreshSession({
+          dispatchOpts,
+          localOpts,
           runtime,
           deps,
-        );
-        return returnAfterSignalExit(result, signalBridge.getReceivedSignal(), runtime);
+          signalBridge,
+          fallbackReason: "gateway_timeout",
+          describeFailure: (fallbackSessionId) =>
+            `EMBEDDED FALLBACK: Gateway agent timed out; running embedded agent with fresh session ${fallbackSessionId}: ${String(err)}`,
+        });
+      }
+
+      // The gateway accepted (and detached) the run before the connection
+      // dropped, so it still owns the original session. Fall back on a fresh
+      // session to avoid re-running the same message there and duplicating the
+      // in-flight gateway run's turn.
+      if (isGatewayAgentAcceptedRunDisconnectError(err)) {
+        return await runGatewayEmbeddedFallbackOnFreshSession({
+          dispatchOpts,
+          localOpts,
+          runtime,
+          deps,
+          signalBridge,
+          fallbackReason: "gateway_connection_lost",
+          describeFailure: (fallbackSessionId) =>
+            `EMBEDDED FALLBACK: Gateway connection closed after the run was accepted; running embedded agent with fresh session ${fallbackSessionId} to avoid duplicating the in-flight gateway run${err.acceptedRunId ? ` ${err.acceptedRunId}` : ""} on ${err.acceptedSessionKey ?? "the original session"}: ${String(err)}`,
+        });
       }
 
       if (!isGatewayAgentEmbeddedFallbackError(err)) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `openclaw agent` users (the default gateway path, not `--local`) could have a single message executed twice in the **same session** when the CLI↔gateway WebSocket dropped at the wrong moment.

Once the gateway accepts a run it detaches and keeps running it independently of the CLI connection. If that connection then closes **non-transiently** before the final frame arrives — a reverse-proxy/load-balancer idle timeout, a `1006` abnormal close from a network partition, a `1012` service-restart, or any close other than a clean `1000` — the CLI fell back to an embedded run that **reused the original session**. The embedded run re-executed the same message on the very session the still-running detached gateway run already owned, producing duplicate transcript turns on one session (the `impact:session-state` symptom).

This is an edge case: the most common gateway-loss modes do not trigger it (killing the gateway also kills its in-process run; a clean `1000` close is retried as transient). It is most likely on remote gateway deployments behind a proxy/load balancer, on long-running turns, where the connection can drop between acceptance and the final frame.

## Why This Change Was Made

The root cause was that the "run was accepted" signal never left `agentViaGatewayCommand`: `acceptedGatewayRun` was a function-local flag, so the fallback decision in `agentCliCommand` could not tell an accepted-then-disconnected close apart from a never-accepted one, and always reused the original session.

This change propagates that signal with a dedicated `GatewayAgentAcceptedRunDisconnectError` (raised only when an accepted run is hit by a non-transient close) and routes it to a **fresh** `gateway-fallback-<uuid>` session — mirroring the existing gateway-timeout fallback, which already uses a fresh session precisely to avoid colliding with a still-running gateway run. The two fresh-session paths now share one helper. Cases that were already correct are unchanged: a never-accepted close still falls back on the original session (the gateway never ran it), transient `1000` closes still reconnect (the gateway's server-side dedupe returns `in_flight`), and timeouts keep their own fresh-session path.

Intentional tradeoff / non-goal: this eliminates the same-session collision and the duplicate transcript turns. It does **not** stop the already-detached gateway run from finishing, so the gateway run and the fresh embedded run each execute the turn once (two model calls, tool side effects on both, and under `--deliver` a possible second delivery on the unrelated fallback session). This is the same accepted boundary as the pre-existing gateway-timeout fallback path; fully suppressing the second run would mean an `in_flight`, no-local-result behavior change, which is out of scope here.

## User Impact

`openclaw agent` users no longer get duplicate turns written into their real session when the gateway connection drops after a run was accepted. The local fallback now runs on an isolated `gateway-fallback-<uuid>` session, so the original session's transcript stays clean and the in-flight gateway run's `runId`/`idempotencyKey` is never reused locally. Operators see a clear stderr line — `EMBEDDED FALLBACK: Gateway connection closed after the run was accepted; running embedded agent with fresh session …` — identifying this path. No config, CLI flags, or public signatures change.

## Evidence

Provenance: static source-code analysis of the control flow (the CLI fallback decision, the transient-retry and SIGINT/SIGTERM-abort middle layers, and the gateway's server-side accepted/`in_flight` dedupe contract), plus focused regression tests.

New/updated tests in `src/commands/agent-via-gateway.test.ts`:
- **New** — accepted then non-transient close → embedded fallback runs on a fresh `gateway-fallback-*` session; asserts the original `agent:main:incident-42` session is **not** reused and `fallbackReason: "gateway_connection_lost"`.
- **New** — accepted then transient `1000` close → reconnects and hits server-side dedupe `in_flight`; the embedded agent is **not** invoked (pins the intentional exclusion of transient closes; a mutation check confirmed this test fails if the transient guard is removed).
- **Preserved** — never-accepted close still reuses the explicit session key.

Local validation:
- `node scripts/run-vitest.mjs src/commands/agent-via-gateway.test.ts` → **70 passed**
- core typecheck `tsgo -p tsconfig.core.json` → exit 0
- test typecheck `tsgo -p test/tsconfig/tsconfig.test.src.json` → exit 0
- `oxfmt --check` and `scripts/run-oxlint.mjs` on the changed files → exit 0


### Live behavior proof — real gateway + controlled WebSocket close

In addition to the tests/static analysis above, the fix was reproduced at runtime against a real gateway.

Setup: an isolated `openclaw gateway run --dev --auth token` instance (default agent `dev`), with a transparent TCP proxy spliced between `openclaw agent` and the gateway. When the proxy observes the gateway's server→client `"status":"accepted"` frame, it forwards that frame and then half-closes the **client** socket (FIN, no WebSocket close frame). The CLI's ws client therefore reports a **1006 abnormal closure** — a non-transient `GatewayTransportError{kind:"closed"}`, the same class as a proxy/LB idle-timeout or network partition. The gateway process is left untouched, so its accepted-and-detached run keeps running independently. The CLI is pointed at the proxy via `OPENCLAW_GATEWAY_URL` and runs the gateway path (no `--local`).

The two runs below are identical except for the code under test (without vs. with this PR), same isolated gateway, same agent, same proxy:

```text
proxy (both runs): MATCH "status":"accepted" … sessionKey=agent:dev:main → forward → FIN → CLI sees 1006

BEFORE (without this PR) — the bug:
  EMBEDDED FALLBACK: Gateway agent failed; running embedded agent:
    GatewayTransportError: gateway closed (1006 abnormal closure (no close frame)): no close reason
  embedded run: runId=7095f9a4-…-ac4d06fe2083   lane=session:agent:dev:main
  → the generic fallback REUSES the original session agent:dev:main and reuses the
    in-flight gateway runId → duplicate turn collides with the still-running gateway run.

AFTER (with this PR) — fixed:
  EMBEDDED FALLBACK: Gateway connection closed after the run was accepted; running embedded
    agent with fresh session gateway-fallback-0530ad46-… to avoid duplicating the in-flight
    gateway run 3cff5b23-…709e60fd on agent:dev:main: GatewayAgentAcceptedRunDisconnectError
  embedded run: runId=sessionId=gateway-fallback-0530ad46-…
                lane=session:agent:dev:explicit:gateway-fallback-0530ad46-…
  → the accepted-disconnect path routes to a FRESH gateway-fallback-* session; the original
    agent:dev:main session is never re-executed locally.
```

Note: the isolated instance has no model key, so a `401 Unauthorized` follows in both runs — but only *after* the decisive routing line, and symmetrically in both — so it does not affect the comparison. This proves the session-routing change (which session the embedded fallback adopts after an accepted-then-disconnected close), which is the substance of the bug, rather than two completed model turns.
