### PR TITLE
fix(streaming): annotate empty catch blocks in stream cleanup paths

### DIFF
--- a/src/infra/http-error-body.ts
+++ b/src/infra/http-error-body.ts
@@ -42,7 +42,7 @@ export async function readResponseBodySnippet(
       }
       try {
         reader.releaseLock();
-      } catch {}
+      } catch { /* reader already released or stream closed during abort */ }
     }
 
     return new TextDecoder().decode(Buffer.concat(chunks, total)).slice(0, limits.maxChars);

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -457,7 +457,7 @@ async function* responseBodyChunks(
     }
     try {
       reader.releaseLock();
-    } catch {}
+    } catch { /* reader already released or stream closed during abort */ }
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

Two empty `catch {}` blocks in stream cleanup paths silently swallow I/O errors that may indicate stream corruption or connection issues during fetch/response body reads. Following the same pattern established in #97701, these sites now include comments explaining why the error is intentionally ignored.

## Changes

- `src/infra/http-error-body.ts:45` — `reader.releaseLock()` after stream abort
- `src/media/fetch.ts:460` — `reader.releaseLock()` in finally block

## Evidence

**git diff:**
```diff
 src/infra/http-error-body.ts | 2 +-
 src/media/fetch.ts           | 2 +-
 2 files changed, 2 insertions(+), 2 deletions(-)

diff --git a/src/infra/http-error-body.ts b/src/infra/http-error-body.ts
index 799434b568..c228978a61 100644
--- a/src/infra/http-error-body.ts
+++ b/src/infra/http-error-body.ts
@@ -42,7 +42,7 @@
       }
       try {
         reader.releaseLock();
-      } catch {}
+      } catch { /* reader already released or stream closed during abort */ }
     }

diff --git a/src/media/fetch.ts b/src/media/fetch.ts
index d2d10ee113..f0415a0b3b 100644
--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -457,7 +457,7 @@
     }
     try {
       reader.releaseLock();
-    } catch {}
+    } catch { /* reader already released or stream closed during abort */ }
   }
 }
```

**Annotated catch sites:**
```
1. src/infra/http-error-body.ts:43-45
      try {
        reader.releaseLock();
      } catch { /* reader already released or stream closed during abort */ }

2. src/media/fetch.ts:458-460
    try {
      reader.releaseLock();
    } catch { /* reader already released or stream closed during abort */ }
```

**git diff --check:** No whitespace errors.

## AI Assistance

- AI-assisted: Yes