### PR TITLE
ci: bump ClawHub package publish workflow

### DIFF
--- a/.github/workflows/plugin-clawhub-release.yml
+++ b/.github/workflows/plugin-clawhub-release.yml
@@ -387,7 +387,7 @@ jobs:
     needs:
       [preview_plugins_clawhub, pack_plugins_clawhub_artifacts, approve_plugins_clawhub_release]
     if: always() && github.event_name == 'workflow_dispatch' && needs.preview_plugins_clawhub.outputs.has_candidates == 'true' && needs.pack_plugins_clawhub_artifacts.result == 'success' && (inputs.dry_run == true || needs.approve_plugins_clawhub_release.result == 'success')
-    uses: openclaw/clawhub/.github/workflows/package-publish.yml@9d49df109d4ad3dc8a6ecf05d26b39f46d294721
+    uses: openclaw/clawhub/.github/workflows/package-publish.yml@28409ee6ce9d088c9ddf0d6913cde6597f83f362
     permissions:
       actions: read
       contents: read

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -1531,10 +1531,7 @@ describe("package artifact reuse", () => {
 
     for (const item of cases) {
       const label = `${item.workflowPath} ${item.jobName}`;
-      const uploadStep = workflowStep(
-        workflowJob(item.workflowPath, item.jobName),
-        item.stepName,
-      );
+      const uploadStep = workflowStep(workflowJob(item.workflowPath, item.jobName), item.stepName);
 
       expect(uploadStep.if, label).toContain("always()");
       expect(uploadStep.uses, label).toBe(UPLOAD_ARTIFACT_V7);
@@ -2137,7 +2134,7 @@ describe("package artifact reuse", () => {
       "github.event_name == 'workflow_dispatch' && inputs.dry_run != true && inputs.publish_scope == 'selected' && steps.plan.outputs.skipped_published_count != '0'",
     );
     expect(clawHubWorkflow).toContain(
-      "uses: openclaw/clawhub/.github/workflows/package-publish.yml@9d49df109d4ad3dc8a6ecf05d26b39f46d294721",
+      "uses: openclaw/clawhub/.github/workflows/package-publish.yml@28409ee6ce9d088c9ddf0d6913cde6597f83f362",
     );
     expect(clawHubWorkflow).toContain("dry_run:");
     expect(clawHubWorkflow).toContain("default: false");


### PR DESCRIPTION
## What Problem This Solves

OpenClaw's existing-plugin ClawHub publish workflow was pinned to an older ClawHub reusable workflow SHA. That meant republishing code plugins such as `@openclaw/discord`, `@openclaw/slack`, `@openclaw/voice-call`, and `@openclaw/whatsapp` would still use ClawHub code from before the package-family detector fix, so packages containing `openclaw.plugin.json` plus `skills/` markers could continue to be classified as `bundle-plugin`.

## Why This Change Was Made

ClawHub PR https://github.com/openclaw/clawhub/pull/2931 changed package-family detection so real bundle manifests win first, `openclaw.plugin.json` forces `code-plugin`, and loose `skills/` markers only classify as bundle plugins after that. This PR updates the OpenClaw reusable workflow pin to the ClawHub merge commit containing that fix and updates the workflow acceptance assertion that guards the pin.

## User Impact

Republishing the affected OpenClaw plugins through `plugin-clawhub-release.yml` will use the fixed ClawHub package publisher, avoiding the package-family mismatch that blocks updates for plugins that are actually OpenClaw code plugins.

## Evidence

- `pnpm format:check .github/workflows/plugin-clawhub-release.yml test/scripts/package-acceptance-workflow.test.ts`
- `git diff --check`
- `node scripts/run-vitest.mjs test/scripts/package-acceptance-workflow.test.ts` (40 passed)
- `PATH="/opt/homebrew/bin:$PATH" pnpm check:workflows`
- Autoreview local mode: clean, no accepted/actionable findings
