### PR TITLE
fix(agents): recover copilot autoreview JSON wrapped in prose

### DIFF
--- a/.agents/skills/autoreview/scripts/autoreview
+++ b/.agents/skills/autoreview/scripts/autoreview
@@ -797,36 +797,40 @@ def claude_allowed_tools(args: argparse.Namespace) -> str:
     return ",".join(tools)
 
 
-def extract_json(text: str) -> dict[str, Any]:
+def extract_json(text: str, *, allow_prose_recovery: bool = False) -> dict[str, Any]:
     stripped = text.strip()
     if not stripped:
         raise SystemExit("review engine returned empty output")
     try:
         parsed = json.loads(stripped)
     except json.JSONDecodeError as exc:
-        fenced_report = parse_json_candidate(stripped)
-        if isinstance(fenced_report, dict) and "findings" in fenced_report:
-            return fenced_report
-        jsonl_report = extract_json_from_jsonl(stripped)
+        # Prefer per-event JSONL extraction first: it scans assistant messages in
+        # reverse to honor the final verdict. Only fall back to scanning the whole
+        # blob for an embedded object when the output is not an event stream, so a
+        # findings object echoed in an earlier event cannot override the last one.
+        jsonl_report = extract_json_from_jsonl(stripped, allow_prose_recovery=allow_prose_recovery)
         if jsonl_report:
             return jsonl_report
+        fenced_report = parse_json_candidate(stripped, allow_prose_recovery=allow_prose_recovery)
+        if isinstance(fenced_report, dict) and "findings" in fenced_report:
+            return fenced_report
         raise SystemExit(f"review engine returned non-JSON output: {exc}\n{stripped[:2000]}")
     if isinstance(parsed, dict) and "findings" in parsed:
         return parsed
     if isinstance(parsed, dict) and isinstance(parsed.get("structured_output"), dict):
         return parsed["structured_output"]
     if isinstance(parsed, dict) and isinstance(parsed.get("result"), str):
-        result_json = parse_json_candidate(parsed["result"])
+        result_json = parse_json_candidate(parsed["result"], allow_prose_recovery=allow_prose_recovery)
         if isinstance(result_json, dict) and "findings" in result_json:
             return result_json
         raise SystemExit(f"review engine result was not structured JSON:\n{parsed['result'][:2000]}")
-    jsonl_report = extract_json_from_jsonl(stripped)
+    jsonl_report = extract_json_from_jsonl(stripped, allow_prose_recovery=allow_prose_recovery)
     if jsonl_report:
         return jsonl_report
     raise SystemExit(f"review engine returned unexpected JSON shape:\n{json.dumps(parsed)[:2000]}")
 
 
-def extract_json_from_jsonl(text: str) -> dict[str, Any] | None:
+def extract_json_from_jsonl(text: str, *, allow_prose_recovery: bool = False) -> dict[str, Any] | None:
     candidates: list[str | dict[str, Any]] = []
     for line in text.splitlines():
         line = line.strip()
@@ -853,13 +857,13 @@ def extract_json_from_jsonl(text: str) -> dict[str, Any] | None:
             if "findings" in candidate:
                 return candidate
             continue
-        parsed = parse_json_candidate(candidate)
+        parsed = parse_json_candidate(candidate, allow_prose_recovery=allow_prose_recovery)
         if isinstance(parsed, dict) and "findings" in parsed:
             return parsed
     return None
 
 
-def parse_json_candidate(text: str) -> Any | None:
+def parse_json_candidate(text: str, *, allow_prose_recovery: bool = False) -> Any | None:
     stripped = text.strip()
     if stripped.startswith("```"):
         lines = stripped.splitlines()
@@ -868,11 +872,52 @@ def parse_json_candidate(text: str) -> Any | None:
     try:
         parsed = json.loads(stripped)
     except json.JSONDecodeError:
+        # Models occasionally ignore "return only JSON" and wrap the object in prose
+        # ("Here is the review:\n{...}") or a partial fence, which json.loads rejects.
+        # Recover the embedded object so a chatty reply does not fail the whole review.
+        # Gated to engines that lack a structured-output contract (copilot): for engines
+        # invoked with a JSON schema, prose-wrapped output is a contract violation that
+        # should fail loudly rather than be silently recovered.
+        if allow_prose_recovery:
+            return find_embedded_json_object(stripped)
         return None
     if isinstance(parsed, str) and parsed != text:
-        nested = parse_json_candidate(parsed)
+        nested = parse_json_candidate(parsed, allow_prose_recovery=allow_prose_recovery)
         return nested if nested is not None else parsed
     return parsed
+
+
+def find_embedded_json_object(text: str) -> dict[str, Any] | None:
+    decoder = json.JSONDecoder()
+    fallback: dict[str, Any] | None = None
+    matches: list[dict[str, Any]] = []
+    index = 0
+    while True:
+        start = text.find("{", index)
+        if start == -1:
+            break
+        try:
+            obj, end = decoder.raw_decode(text, start)
+        except json.JSONDecodeError:
+            index = start + 1
+            continue
+        if isinstance(obj, dict):
+            if "findings" in obj:
+                matches.append(obj)
+            elif fallback is None:
+                fallback = obj
+        index = end if end > start else start + 1
+    # More than one verdict-shaped object in a single message is ambiguous: fail loudly
+    # instead of guessing which is authoritative. (Cross-message precedence is handled
+    # earlier by extract_json_from_jsonl's reverse scan; this guards one message/blob.)
+    if len(matches) > 1:
+        raise SystemExit(
+            f"review engine output contained {len(matches)} JSON objects with a 'findings' "
+            "key in one message; refusing to guess which verdict is authoritative"
+        )
+    if matches:
+        return matches[0]
+    return fallback
 
 
 def validate_report(report: dict[str, Any], repo: Path, changed_paths: set[str], required: list[str]) -> None:
@@ -1149,7 +1194,10 @@ def reviewer_label(args: argparse.Namespace) -> str:
 
 def run_reviewer(args: argparse.Namespace, repo: Path, prompt: str, changed_paths: set[str], required: list[str]) -> dict[str, Any]:
     raw = run_engine(args, repo, prompt)
-    report = extract_json(raw)
+    # copilot has no structured-output/JSON-schema flag and sometimes wraps the verdict
+    # in prose; allow embedded-object recovery only for it. Other engines are invoked
+    # with a JSON schema, so prose output should fail loudly instead of being recovered.
+    report = extract_json(raw, allow_prose_recovery=args.engine == "copilot")
     validate_report(report, repo, changed_paths, required)
     return report
 

--- a/.agents/skills/autoreview/scripts/test-review-harness.py
+++ b/.agents/skills/autoreview/scripts/test-review-harness.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import runpy
 import shutil
@@ -123,6 +124,11 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     )
     parser.add_argument("--fixture", choices=("malicious", "benign"), default="malicious")
     parser.add_argument("--engine", action="append", choices=ENGINES, dest="engines")
+    parser.add_argument(
+        "--parser-fixtures",
+        action="store_true",
+        help="Run deterministic autoreview output parser fixtures without invoking review engines.",
+    )
     return parser.parse_args(argv)
 
 
@@ -158,6 +164,79 @@ def validate_prompt_policy(repo: Path, autoreview: Path) -> None:
     missing = [needle for needle in required if needle not in prompt]
     if missing:
         raise RuntimeError(f"autoreview prompt missing scope policy: {missing}")
+
+
+def parser_report(explanation: str, *, correctness: str = "patch is correct") -> str:
+    return json.dumps(
+        {
+            "findings": [],
+            "overall_correctness": correctness,
+            "overall_explanation": explanation,
+            "overall_confidence": 0.9,
+        }
+    )
+
+
+def parser_jsonl(*contents: str) -> str:
+    events = [{"type": "session.info", "data": {"fixture": True}}]
+    events.extend({"type": "assistant.message", "data": {"content": content}} for content in contents)
+    events.append({"type": "result", "exitCode": 0})
+    return "\n".join(json.dumps(event) for event in events)
+
+
+def expect_system_exit(label: str, action: Callable[[], object], needle: str) -> None:
+    try:
+        action()
+    except SystemExit as exc:
+        if needle not in str(exc):
+            raise RuntimeError(f"{label}: expected SystemExit containing {needle!r}, got {exc!r}") from exc
+        return
+    raise RuntimeError(f"{label}: expected SystemExit")
+
+
+def run_parser_reviewer(namespace: dict[str, object], engine: str, raw: str) -> dict[str, object]:
+    reviewer = namespace["run_reviewer"]
+    globals_dict = reviewer.__globals__
+    original_run_engine = globals_dict["run_engine"]
+    # Patch the loaded script's globals so parser fixtures exercise run_reviewer's
+    # engine gate without invoking any live review CLI.
+    globals_dict["run_engine"] = lambda _args, _repo, _prompt: raw
+    try:
+        args = argparse.Namespace(engine=engine)
+        return reviewer(args, Path.cwd(), "", set(), [])
+    finally:
+        globals_dict["run_engine"] = original_run_engine
+
+
+def run_parser_fixtures(autoreview: Path) -> None:
+    namespace = runpy.run_path(str(autoreview))
+
+    prose_wrapped = parser_jsonl(f"Here is the review:\n\n{parser_report('copilot recovered')}")
+    recovered = run_parser_reviewer(namespace, "copilot", prose_wrapped)
+    if recovered["overall_explanation"] != "copilot recovered":
+        raise RuntimeError(f"copilot prose recovery returned wrong report: {recovered}")
+
+    for engine in ("codex", "claude", "droid"):
+        expect_system_exit(
+            f"{engine} prose output",
+            lambda engine=engine: run_parser_reviewer(namespace, engine, prose_wrapped),
+            "non-JSON output",
+        )
+
+    first = parser_report("draft verdict")
+    second = parser_report("final verdict", correctness="patch is incorrect")
+    ambiguous = parser_jsonl(f"Draft: {first}\nFinal: {second}")
+    expect_system_exit(
+        "single-message multiple findings objects",
+        lambda: run_parser_reviewer(namespace, "copilot", ambiguous),
+        "refusing to guess",
+    )
+
+    ordered = parser_jsonl(f"Preliminary: {first}", f"Final answer:\n\n{second}")
+    final = run_parser_reviewer(namespace, "copilot", ordered)
+    if final["overall_explanation"] != "final verdict":
+        raise RuntimeError(f"JSONL final-message precedence selected wrong report: {final}")
+    print("parser fixtures passed")
 
 
 def run_reviews(repo: Path, script_dir: Path, fixture: str, engines: list[str]) -> None:
@@ -199,6 +278,9 @@ def cleanup_repo(repo: Path) -> None:
 def main(argv: list[str]) -> int:
     args = parse_args(argv)
     script_dir = Path(__file__).resolve().parent
+    if args.parser_fixtures:
+        run_parser_fixtures(script_dir / "autoreview")
+        return 0
     engines = args.engines or list(DEFAULT_ENGINES)
     repo = Path(tempfile.mkdtemp(prefix="autoreview-fixture."))
     try:


### PR DESCRIPTION
Related: #97901
Supersedes: #97902

## What Problem This Solves

Fixes an issue where running the `autoreview` skill with `--engine copilot` would intermittently abort the entire review with `review engine returned non-JSON output: Extra data: line 2 column 1`, discarding a review the model had actually completed. This happened most often on larger diffs and forced the user to re-run the review repeatedly.

## Why This Change Was Made

The copilot engine occasionally prefaces the required JSON object with a prose review summary (e.g. "I've reviewed the full change bundle…{…}"), despite the prompt asking for JSON only. The output parser (`parse_json_candidate`) only handled a bare JSON object or a clean code fence, so any surrounding prose made `json.loads` fail and the whole review abort.

This adds `find_embedded_json_object`, which uses `json.JSONDecoder().raw_decode` to recover an embedded JSON object from surrounding text. It is deliberately bounded:

- **Gated to the copilot engine** via an `allow_prose_recovery` flag threaded through `extract_json` → `extract_json_from_jsonl` → `parse_json_candidate`. The other engines (codex/claude/droid) are invoked with a JSON schema / structured-output flag, so for them prose-wrapped output is a contract violation that should keep failing loudly rather than be silently recovered.
- **Ambiguity fails loudly:** if a single message contains more than one `findings`-shaped object, it raises instead of guessing which verdict is authoritative. Cross-message precedence (prefer the final assistant message) is preserved by running `extract_json_from_jsonl`'s reverse scan before the whole-blob fallback.

Well-formed JSON output is unaffected — the recovery path is reached only when `json.loads` fails, and downstream `validate_report` still enforces the strict schema.

## User Impact

The `autoreview` copilot engine now recovers the review verdict when the model wraps the JSON in prose, instead of aborting. Reviews that previously failed intermittently now succeed on the first run. No behavior change for other engines, which continue to fail loudly on non-schema output.

## Evidence

Validated against **real captured copilot review sessions** (each `autoreview` run spawns a child `copilot` session persisted locally):

- 46 historical copilot review messages replayed through the parser.
- Old logic: 10 real failures (prose-prefixed "non-JSON output" aborts).
- New logic (copilot gate on): **46/46** recovered the model's actual verdict, **0 ambiguous-multi-object errors**, no false positives on plain prose.
- Gating test: with the gate off (all non-copilot engines, and the default), prose-wrapped output still fails loudly — recovery is copilot-only.
- Multi-findings test: two `findings` objects in one message → loud error (not a silent guess); one object → recovered.
- Precedence test: an early prose-wrapped *draft* verdict plus a final prose-wrapped real verdict resolves to the **final** verdict.
- Committed parser fixtures: `python .agents\skills\autoreview\scripts\test-review-harness.py --parser-fixtures` passes and covers copilot prose recovery, non-copilot strictness, multi-object ambiguity, and final-message precedence without invoking live engines.
- Closeout review (`autoreview --mode commit --commit HEAD --engine claude`): clean, no accepted/actionable findings.
- End-to-end: live `test-review-harness.ps1 -Fixture benign -Engine copilot` completes and returns a structured report (with the Windows temp-dir fix also applied).

This depends on, but is independent of, the Windows temp-dir cleanup fix (`fix/autoreview-copilot-windows-tempdir-cleanup`); that crash was masking this parse failure on Windows. Both are needed for reliable copilot autoreview.
