### PR TITLE
ci: bump ClawHub package publish workflow on release branch

### DIFF
--- a/.github/workflows/plugin-clawhub-release.yml
+++ b/.github/workflows/plugin-clawhub-release.yml
@@ -387,7 +387,7 @@ jobs:
     needs:
       [preview_plugins_clawhub, pack_plugins_clawhub_artifacts, approve_plugins_clawhub_release]
     if: always() && github.event_name == 'workflow_dispatch' && needs.preview_plugins_clawhub.outputs.has_candidates == 'true' && needs.pack_plugins_clawhub_artifacts.result == 'success' && (inputs.dry_run == true || needs.approve_plugins_clawhub_release.result == 'success')
-    uses: openclaw/clawhub/.github/workflows/package-publish.yml@9d49df109d4ad3dc8a6ecf05d26b39f46d294721
+    uses: openclaw/clawhub/.github/workflows/package-publish.yml@28409ee6ce9d088c9ddf0d6913cde6597f83f362
     permissions:
       actions: read
       contents: read

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -1531,10 +1531,7 @@ describe("package artifact reuse", () => {
 
     for (const item of cases) {
       const label = `${item.workflowPath} ${item.jobName}`;
-      const uploadStep = workflowStep(
-        workflowJob(item.workflowPath, item.jobName),
-        item.stepName,
-      );
+      const uploadStep = workflowStep(workflowJob(item.workflowPath, item.jobName), item.stepName);
 
       expect(uploadStep.if, label).toContain("always()");
       expect(uploadStep.uses, label).toBe(UPLOAD_ARTIFACT_V7);
@@ -2137,7 +2134,7 @@ describe("package artifact reuse", () => {
       "github.event_name == 'workflow_dispatch' && inputs.dry_run != true && inputs.publish_scope == 'selected' && steps.plan.outputs.skipped_published_count != '0'",
     );
     expect(clawHubWorkflow).toContain(
-      "uses: openclaw/clawhub/.github/workflows/package-publish.yml@9d49df109d4ad3dc8a6ecf05d26b39f46d294721",
+      "uses: openclaw/clawhub/.github/workflows/package-publish.yml@28409ee6ce9d088c9ddf0d6913cde6597f83f362",
     );
     expect(clawHubWorkflow).toContain("dry_run:");
     expect(clawHubWorkflow).toContain("default: false");


### PR DESCRIPTION
## What Problem This Solves

The `v2026.6.11-beta.2` Plugin ClawHub Release run failed because the release branch still pins ClawHub's reusable `package-publish.yml` workflow to the old ClawHub SHA. That old publisher classifies packages containing both `openclaw.plugin.json` and top-level `skills/` as `bundle-plugin`, causing the four existing code-plugin rows to hit the server-side `family changes are not allowed` guard.

Affected beta2 packages:

- `@openclaw/discord`
- `@openclaw/slack`
- `@openclaw/voice-call`
- `@openclaw/whatsapp`

## Why This Change Was Made

ClawHub PR https://github.com/openclaw/clawhub/pull/2931 fixed package-family detection so `openclaw.plugin.json` wins over loose `skills/` markers for OpenClaw code plugins. This release-branch PR carries the same reusable workflow pin that already landed on `main` in https://github.com/openclaw/openclaw/pull/97907, so the beta2 publish workflow can run from `release/2026.6.11` using the fixed publisher.

## User Impact

After this lands, the selected beta2 packages can be published through the normal OIDC ClawHub workflow from `release/2026.6.11`, without changing package contents or weakening ClawHub's server-side family guard.

## Evidence

- `pnpm format:check .github/workflows/plugin-clawhub-release.yml test/scripts/package-acceptance-workflow.test.ts`
- `git diff --check`
- `node scripts/run-vitest.mjs test/scripts/package-acceptance-workflow.test.ts` (40 passed)
- `PATH="/opt/homebrew/bin:$PATH" pnpm check:workflows`
- Autoreview local mode: clean, no accepted/actionable findings
- Live ClawHub check: beta2 versions for the four affected packages currently return 404, while beta1 rows are `code-plugin` and tagged `beta`.
