### PR TITLE
fix(web-search): auto-select keyless providers

### DIFF
--- a/src/flows/search-setup.ts
+++ b/src/flows/search-setup.ts
@@ -462,7 +462,7 @@ export async function runSearchSetupFlow(
       providers: [...providerOptions],
     });
     const autoDetected = providerOptions.find((entry) => entry.id === autoDetectedId);
-    if (autoDetected) {
+    if (autoDetected && providerNeedsCredential(autoDetected)) {
       return autoDetected.id;
     }
     const detected = providerOptions.find(

--- a/src/web-search/runtime.test.ts
+++ b/src/web-search/runtime.test.ts
@@ -568,7 +568,7 @@ describe("web search runtime", () => {
     });
   });
 
-  it("does not auto-select keyless providers when no provider is configured", async () => {
+  it("auto-selects keyless providers when no credentialed provider is configured", async () => {
     resolveRuntimeWebSearchProvidersMock.mockReturnValue([
       createDuckDuckGoSearchProvider({
         getCredentialValue: () => "duckduckgo-no-key-needed",
@@ -587,7 +587,10 @@ describe("web search runtime", () => {
         config: {},
         args: { query: "fallback" },
       }),
-    ).rejects.toThrow("web_search is disabled or no provider is available.");
+    ).resolves.toEqual({
+      provider: "parallel-free",
+      result: { query: "fallback", provider: "parallel-free" },
+    });
   });
 
   it("uses a keyless provider when the user explicitly selects it", async () => {
@@ -680,7 +683,7 @@ describe("web search runtime", () => {
     });
   });
 
-  it("ignores auto-detected keyless runtime metadata when no provider is configured", async () => {
+  it("honors auto-detected keyless runtime metadata when no provider is configured", async () => {
     resolveRuntimeWebSearchProvidersMock.mockReturnValue([
       createWebSearchTestProvider({
         pluginId: "parallel",
@@ -715,7 +718,10 @@ describe("web search runtime", () => {
         config: {},
         args: { query: "stale-keyless-runtime" },
       }),
-    ).rejects.toThrow("web_search is disabled or no provider is available.");
+    ).resolves.toEqual({
+      provider: "parallel-free",
+      result: { query: "stale-keyless-runtime", provider: "parallel-free" },
+    });
   });
 
   it("ignores auto-detected runtime metadata after config names an unknown provider", async () => {

--- a/src/web-search/runtime.ts
+++ b/src/web-search/runtime.ts
@@ -4,6 +4,12 @@ import {
   normalizeOptionalLowercaseString,
 } from "@openclaw/normalization-core/string-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
+import {
+  hasWebProviderEntryCredential,
+  providerRequiresCredential,
+  readWebProviderEnvValue,
+  resolveWebProviderConfig,
+} from "../../packages/web-content-core/src/provider-runtime-shared.js";
 import { resolveDefaultAgentDir } from "../agents/agent-scope-config.js";
 import { hasAuthProfileForProvider } from "../agents/tools/model-config.helpers.js";
 import {
@@ -22,12 +28,6 @@ import {
 import { sortWebSearchProvidersForAutoDetect } from "../plugins/web-search-providers.shared.js";
 import { getActiveRuntimeWebToolsMetadata } from "../secrets/runtime-web-tools-state.js";
 import type { RuntimeWebSearchMetadata } from "../secrets/runtime-web-tools.types.js";
-import {
-  hasWebProviderEntryCredential,
-  providerRequiresCredential,
-  readWebProviderEnvValue,
-  resolveWebProviderConfig,
-} from "../../packages/web-content-core/src/provider-runtime-shared.js";
 import type {
   ResolveWebSearchDefinitionParams,
   RunWebSearchParams,
@@ -119,7 +119,7 @@ function hasImplicitProviderSelectionSignal(
   agentDir?: string,
 ): boolean {
   if (!providerRequiresCredential(provider)) {
-    return false;
+    return true;
   }
   return hasEntryCredential(provider, config, search, agentDir);
 }


### PR DESCRIPTION
## Summary

Fixes implicit web_search provider selection for keyless providers such as DuckDuckGo.

## Issue

Fixes #97880.

## Changes

- Treats `requiresCredential=false` providers as eligible implicit provider selections.
- Keeps credential-gated providers requiring an actual configured credential before implicit auto-detect can select them.
- Updates runtime tests so keyless providers and keyless runtime metadata work without a configured provider.

## Testing

- `node scripts/run-vitest.mjs src/web-search/runtime.test.ts` — 30 tests passed
- `oxfmt --check --threads=1 src/web-search/runtime.ts src/web-search/runtime.test.ts` — passed
- `git diff --check && git diff --cached --check` — passed
- added-line secret scan — clean

## What Problem This Solves

Fixes #97880. Keyless web search providers such as DuckDuckGo declared `requiresCredential=false`, but implicit provider selection still treated them like credential-gated providers. As a result `web_search` could fail to auto-select a usable keyless provider even though no credential was needed.

## Evidence

- `node scripts/run-vitest.mjs src/web-search/runtime.test.ts` — 30 tests passed
- `oxfmt --check --threads=1 src/web-search/runtime.ts src/web-search/runtime.test.ts` — passed
- `git diff --check && git diff --cached --check` — passed
- Added-line secret scan — clean
- Regression coverage verifies keyless providers and keyless runtime metadata work without a configured provider.
