### PR TITLE
feat(qa): add transport scenario requirements

### DIFF
--- a/extensions/qa-lab/src/live-transports/shared/live-transport-scenarios.ts
+++ b/extensions/qa-lab/src/live-transports/shared/live-transport-scenarios.ts
@@ -15,6 +15,19 @@ export {
   type LiveTransportScenarioDefinition,
   type LiveTransportStandardScenarioId,
 } from "openclaw/plugin-sdk/qa-live-transport-scenarios";
+export {
+  assertQaTransportSupportsScenario,
+  defineQaTransportScenario,
+  filterQaTransportScenariosForTransport,
+  findUnsupportedQaTransportScenarioRequirements,
+  mergeQaTransportScenarioRequirements,
+  qaTransportRequirementsForStandardScenario,
+  type QaTransportCapabilityName,
+  type QaTransportScenarioDefinition,
+  type QaTransportScenarioDefinitionInput,
+  type QaTransportScenarioRequirements,
+  type QaTransportScenarioUnsupportedRequirements,
+} from "../../qa-transport-scenarios.js";
 
 export type LiveTransportCoverageMember = {
   scenarioId?: string;

--- a/extensions/qa-lab/src/qa-channel-transport.ts
+++ b/extensions/qa-lab/src/qa-channel-transport.ts
@@ -135,6 +135,7 @@ class QaChannelTransport extends QaStateBackedTransportAdapter {
       label: "qa-channel + qa-lab bus",
       accountId: QA_CHANNEL_ACCOUNT_ID,
       requiredPluginIds: QA_CHANNEL_REQUIRED_PLUGIN_IDS,
+      supportedActions: ["delete", "edit", "react", "thread-create"],
       state,
     });
   }

--- a/extensions/qa-lab/src/qa-transport-scenarios.test.ts
+++ b/extensions/qa-lab/src/qa-transport-scenarios.test.ts
@@ -1,0 +1,139 @@
+// Qa Lab tests cover transport-backed scenario metadata.
+import { describe, expect, it } from "vitest";
+import { createQaBusState } from "./bus-state.js";
+import { createQaChannelTransport } from "./qa-channel-transport.js";
+import {
+  assertQaTransportSupportsScenario,
+  defineQaTransportScenario,
+  filterQaTransportScenariosForTransport,
+  findUnsupportedQaTransportScenarioRequirements,
+  mergeQaTransportScenarioRequirements,
+  qaTransportRequirementsForStandardScenario,
+} from "./qa-transport-scenarios.js";
+import type { QaTransportAdapter } from "./qa-transport.js";
+
+type ScenarioTransportFixture = Pick<
+  QaTransportAdapter,
+  "capabilities" | "id" | "supportedActions"
+>;
+
+function createScenarioTransportFixture(
+  supportedActions: QaTransportAdapter["supportedActions"],
+): ScenarioTransportFixture {
+  const transport = createQaChannelTransport(createQaBusState());
+  return {
+    capabilities: transport.capabilities,
+    id: "crabline",
+    supportedActions,
+  };
+}
+
+describe("qa transport scenarios", () => {
+  it("maps standard live transport buckets onto existing transport capabilities", () => {
+    expect(qaTransportRequirementsForStandardScenario("canary")).toEqual({
+      capabilities: ["assertNoFailureReplies", "sendInboundMessage", "waitForOutboundMessage"],
+    });
+    expect(qaTransportRequirementsForStandardScenario("restart-resume")).toEqual({
+      capabilities: [
+        "assertNoFailureReplies",
+        "sendInboundMessage",
+        "waitForOutboundMessage",
+        "waitForReady",
+      ],
+    });
+  });
+
+  it("merges standard and explicit requirements without duplicating names", () => {
+    const scenario = defineQaTransportScenario({
+      id: "slack-thread-follow-up",
+      standardId: "thread-follow-up",
+      timeoutMs: 30_000,
+      title: "Thread follow-up",
+      transportRequirements: {
+        actions: ["thread-create", "thread-create"],
+        capabilities: ["waitForOutboundMessage", "waitForCondition"],
+      },
+    });
+
+    expect(scenario.transportRequirements).toEqual({
+      actions: ["thread-create"],
+      capabilities: [
+        "assertNoFailureReplies",
+        "sendInboundMessage",
+        "waitForOutboundMessage",
+        "waitForCondition",
+      ],
+    });
+  });
+
+  it("can merge requirements independently for shared scenario builders", () => {
+    expect(
+      mergeQaTransportScenarioRequirements([
+        { actions: ["react"], capabilities: ["sendInboundMessage"] },
+        { actions: ["react", "delete"], capabilities: ["sendInboundMessage", "waitForReady"] },
+      ]),
+    ).toEqual({
+      actions: ["react", "delete"],
+      capabilities: ["sendInboundMessage", "waitForReady"],
+    });
+  });
+
+  it("validates a scenario against a real qa-channel transport", () => {
+    const transport = createQaChannelTransport(createQaBusState());
+    const scenario = defineQaTransportScenario({
+      id: "qa-channel-reaction",
+      timeoutMs: 30_000,
+      title: "Reaction action",
+      transportRequirements: {
+        actions: ["react"],
+        capabilities: ["executeGenericAction", "waitForCondition"],
+      },
+    });
+
+    expect(() => assertQaTransportSupportsScenario({ scenario, transport })).not.toThrow();
+  });
+
+  it("reports unsupported transport actions without executing the action", () => {
+    const transport = createScenarioTransportFixture([]);
+    const scenario = defineQaTransportScenario({
+      id: "reaction-action",
+      timeoutMs: 30_000,
+      title: "Reaction action",
+      transportRequirements: {
+        actions: ["react"],
+        capabilities: ["executeGenericAction"],
+      },
+    });
+
+    expect(findUnsupportedQaTransportScenarioRequirements({ scenario, transport })).toEqual({
+      actions: ["react"],
+      capabilities: [],
+    });
+    expect(() => assertQaTransportSupportsScenario({ scenario, transport })).toThrow(
+      "QA transport crabline cannot run scenario reaction-action; unsupported actions: react",
+    );
+  });
+
+  it("filters scenarios by the supplied transport contract", () => {
+    const transport = createScenarioTransportFixture([]);
+    const canary = defineQaTransportScenario({
+      id: "canary",
+      standardId: "canary",
+      timeoutMs: 30_000,
+      title: "Canary",
+    });
+    const reaction = defineQaTransportScenario({
+      id: "reaction",
+      timeoutMs: 30_000,
+      title: "Reaction",
+      transportRequirements: { actions: ["react"] },
+    });
+
+    expect(
+      filterQaTransportScenariosForTransport({
+        scenarios: [canary, reaction],
+        transport,
+      }),
+    ).toEqual([canary]);
+  });
+});

--- a/extensions/qa-lab/src/qa-transport-scenarios.ts
+++ b/extensions/qa-lab/src/qa-transport-scenarios.ts
@@ -1,0 +1,157 @@
+// Qa Lab plugin module defines scenario metadata for transport-backed QA runs.
+import type {
+  LiveTransportScenarioDefinition,
+  LiveTransportStandardScenarioId,
+} from "openclaw/plugin-sdk/qa-live-transport-scenarios";
+import type {
+  QaTransportActionName,
+  QaTransportAdapter,
+  QaTransportCapabilities,
+} from "./qa-transport.js";
+
+export type QaTransportCapabilityName = keyof QaTransportCapabilities;
+
+export type QaTransportScenarioRequirements = {
+  actions?: readonly QaTransportActionName[];
+  capabilities?: readonly QaTransportCapabilityName[];
+};
+
+export type QaTransportScenarioDefinition<TId extends string = string> =
+  LiveTransportScenarioDefinition<TId> & {
+    transportRequirements: QaTransportScenarioRequirements;
+  };
+
+export type QaTransportScenarioDefinitionInput<TId extends string = string> =
+  LiveTransportScenarioDefinition<TId> & {
+    transportRequirements?: QaTransportScenarioRequirements;
+  };
+
+export type QaTransportScenarioUnsupportedRequirements = {
+  actions: QaTransportActionName[];
+  capabilities: QaTransportCapabilityName[];
+};
+
+const TEXT_REPLY_CAPABILITIES = [
+  "assertNoFailureReplies",
+  "sendInboundMessage",
+  "waitForOutboundMessage",
+] as const satisfies readonly QaTransportCapabilityName[];
+
+const NO_REPLY_CAPABILITIES = [
+  "assertNoFailureReplies",
+  "sendInboundMessage",
+  "waitForCondition",
+] as const satisfies readonly QaTransportCapabilityName[];
+
+const STANDARD_SCENARIO_REQUIREMENTS = {
+  canary: { capabilities: TEXT_REPLY_CAPABILITIES },
+  "mention-gating": { capabilities: NO_REPLY_CAPABILITIES },
+  "allowlist-block": { capabilities: NO_REPLY_CAPABILITIES },
+  "top-level-reply-shape": { capabilities: TEXT_REPLY_CAPABILITIES },
+  "quote-reply": { capabilities: TEXT_REPLY_CAPABILITIES },
+  "restart-resume": {
+    capabilities: [...TEXT_REPLY_CAPABILITIES, "waitForReady"],
+  },
+  "thread-follow-up": { capabilities: TEXT_REPLY_CAPABILITIES },
+  "thread-isolation": {
+    capabilities: [...TEXT_REPLY_CAPABILITIES, "waitForCondition"],
+  },
+  "reaction-observation": {
+    capabilities: ["getNormalizedMessageState", "waitForCondition"],
+  },
+  "help-command": { capabilities: TEXT_REPLY_CAPABILITIES },
+} as const satisfies Record<LiveTransportStandardScenarioId, QaTransportScenarioRequirements>;
+
+function uniqueInOrder<T extends string>(values: readonly T[]) {
+  const seen = new Set<T>();
+  const unique: T[] = [];
+  for (const value of values) {
+    if (!seen.has(value)) {
+      seen.add(value);
+      unique.push(value);
+    }
+  }
+  return unique;
+}
+
+export function mergeQaTransportScenarioRequirements(
+  requirements: readonly QaTransportScenarioRequirements[],
+): QaTransportScenarioRequirements {
+  return {
+    actions: uniqueInOrder(requirements.flatMap((requirement) => requirement.actions ?? [])),
+    capabilities: uniqueInOrder(
+      requirements.flatMap((requirement) => requirement.capabilities ?? []),
+    ),
+  };
+}
+
+export function qaTransportRequirementsForStandardScenario(
+  standardId: LiveTransportStandardScenarioId,
+): QaTransportScenarioRequirements {
+  return STANDARD_SCENARIO_REQUIREMENTS[standardId];
+}
+
+export function defineQaTransportScenario<TId extends string>(
+  input: QaTransportScenarioDefinitionInput<TId>,
+): QaTransportScenarioDefinition<TId> {
+  const standardRequirements = input.standardId
+    ? qaTransportRequirementsForStandardScenario(input.standardId)
+    : {};
+  return {
+    ...input,
+    transportRequirements: mergeQaTransportScenarioRequirements([
+      standardRequirements,
+      input.transportRequirements ?? {},
+    ]),
+  };
+}
+
+export function findUnsupportedQaTransportScenarioRequirements(params: {
+  scenario: QaTransportScenarioDefinition;
+  transport: Pick<QaTransportAdapter, "capabilities" | "supportedActions">;
+}): QaTransportScenarioUnsupportedRequirements {
+  const supportedActions = new Set(params.transport.supportedActions);
+  return {
+    actions: (params.scenario.transportRequirements.actions ?? []).filter(
+      (action) => !supportedActions.has(action),
+    ),
+    capabilities: (params.scenario.transportRequirements.capabilities ?? []).filter(
+      (capability) => typeof params.transport.capabilities[capability] !== "function",
+    ),
+  };
+}
+
+export function assertQaTransportSupportsScenario(params: {
+  scenario: QaTransportScenarioDefinition;
+  transport: Pick<QaTransportAdapter, "capabilities" | "id" | "supportedActions">;
+}) {
+  const unsupported = findUnsupportedQaTransportScenarioRequirements(params);
+  const problems = [
+    unsupported.capabilities.length > 0
+      ? `missing capabilities: ${unsupported.capabilities.join(", ")}`
+      : undefined,
+    unsupported.actions.length > 0
+      ? `unsupported actions: ${unsupported.actions.join(", ")}`
+      : undefined,
+  ].filter((problem): problem is string => Boolean(problem));
+  if (problems.length > 0) {
+    throw new Error(
+      `QA transport ${params.transport.id} cannot run scenario ${params.scenario.id}; ${problems.join("; ")}`,
+    );
+  }
+}
+
+export function filterQaTransportScenariosForTransport<
+  TScenario extends QaTransportScenarioDefinition,
+>(params: {
+  scenarios: readonly TScenario[];
+  transport: Pick<QaTransportAdapter, "capabilities" | "supportedActions">;
+}): TScenario[] {
+  return params.scenarios.filter((scenario) => {
+    const unsupported = findUnsupportedQaTransportScenarioRequirements({
+      scenario,
+      transport: params.transport,
+    });
+    return unsupported.actions.length === 0 && unsupported.capabilities.length === 0;
+  });
+}

--- a/extensions/qa-lab/src/qa-transport.ts
+++ b/extensions/qa-lab/src/qa-transport.ts
@@ -56,7 +56,7 @@ type QaTransportFailureAssertionOptions = {
   cursorSpace?: QaTransportFailureCursorSpace;
 };
 
-type QaTransportCommonCapabilities = {
+export type QaTransportCapabilities = {
   sendInboundMessage: QaTransportState["addInboundMessage"];
   injectOutboundMessage: QaTransportState["addOutboundMessage"];
   waitForOutboundMessage: (input: QaBusWaitForInput) => Promise<unknown>;
@@ -162,8 +162,9 @@ export type QaTransportAdapter = {
   label: string;
   accountId: string;
   requiredPluginIds: readonly string[];
+  supportedActions: readonly QaTransportActionName[];
   state: QaTransportState;
-  capabilities: QaTransportCommonCapabilities;
+  capabilities: QaTransportCapabilities;
   createGatewayConfig: (params: { baseUrl: string }) => QaTransportGatewayConfig;
   waitReady: (params: {
     gateway: QaTransportGatewayClient;
@@ -192,20 +193,23 @@ export abstract class QaStateBackedTransportAdapter implements QaTransportAdapte
   readonly label: string;
   readonly accountId: string;
   readonly requiredPluginIds: readonly string[];
+  readonly supportedActions: readonly QaTransportActionName[];
   readonly state: QaTransportState;
-  readonly capabilities: QaTransportCommonCapabilities;
+  readonly capabilities: QaTransportCapabilities;
 
   protected constructor(params: {
     id: string;
     label: string;
     accountId: string;
     requiredPluginIds: readonly string[];
+    supportedActions?: readonly QaTransportActionName[];
     state: QaTransportState;
   }) {
     this.id = params.id;
     this.label = params.label;
     this.accountId = params.accountId;
     this.requiredPluginIds = params.requiredPluginIds;
+    this.supportedActions = params.supportedActions ?? [];
     this.state = params.state;
     this.capabilities = {
       sendInboundMessage: this.state.addInboundMessage.bind(this.state),

--- a/extensions/qa-lab/src/scenario-runtime-api.test.ts
+++ b/extensions/qa-lab/src/scenario-runtime-api.test.ts
@@ -4,6 +4,7 @@ import * as fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { createQaBusState } from "./bus-state.js";
+import type { QaTransportCapabilities } from "./qa-transport.js";
 import {
   createQaScenarioRuntimeApi,
   type QaScenarioRuntimeConstants,
@@ -118,7 +119,15 @@ describe("createQaScenarioRuntimeApi", () => {
     const inboundSpy = vi.spyOn(state, "addInboundMessage");
     const outboundSpy = vi.spyOn(state, "addOutboundMessage");
     const readSpy = vi.spyOn(state, "readMessage");
-    const waitForCondition = vi.fn(async (check: () => unknown) => check());
+    const waitForCondition: QaTransportCapabilities["waitForCondition"] = async <T>(
+      check: () => T | Promise<T | null | undefined> | null | undefined,
+    ): Promise<T> => {
+      const value = await check();
+      if (value === null || value === undefined) {
+        throw new Error("waitForCondition test check did not return a value");
+      }
+      return value;
+    };
     const sleep = vi.fn(async () => undefined);
     const env = {
       lab: { baseUrl: "http://127.0.0.1:1234" },
@@ -132,7 +141,11 @@ describe("createQaScenarioRuntimeApi", () => {
           },
           sendInboundMessage: state.addInboundMessage.bind(state),
           injectOutboundMessage: state.addOutboundMessage.bind(state),
+          waitForOutboundMessage: state.waitFor.bind(state),
           readNormalizedMessage: state.readMessage.bind(state),
+          executeGenericAction: vi.fn(async () => undefined),
+          waitForReady: vi.fn(async () => undefined),
+          assertNoFailureReplies: vi.fn(),
         },
       },
     };

--- a/extensions/qa-lab/src/scenario-runtime-api.ts
+++ b/extensions/qa-lab/src/scenario-runtime-api.ts
@@ -1,7 +1,7 @@
 // Qa Lab API module exposes the plugin public contract.
 import type * as NodeFs from "node:fs/promises";
 import type * as NodePath from "node:path";
-import type { QaTransportState } from "./qa-transport.js";
+import type { QaTransportCapabilities, QaTransportState } from "./qa-transport.js";
 import type { QaSeedScenarioWithSource } from "./scenario-catalog.js";
 
 type QaScenarioRuntimeFunction = (...args: never[]) => unknown;
@@ -13,14 +13,7 @@ export type QaScenarioRuntimeEnv<
   lab: TLab;
   transport: {
     state: TTransportState;
-    capabilities: {
-      waitForCondition: QaScenarioRuntimeFunction;
-      getNormalizedMessageState: () => ReturnType<TTransportState["getSnapshot"]>;
-      resetNormalizedMessageState: () => Promise<void>;
-      sendInboundMessage: TTransportState["addInboundMessage"];
-      injectOutboundMessage: TTransportState["addOutboundMessage"];
-      readNormalizedMessage: TTransportState["readMessage"];
-    };
+    capabilities: QaTransportCapabilities;
   };
 };
 

--- a/extensions/qa-lab/src/suite-runtime-flow.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-flow.test.ts
@@ -176,6 +176,7 @@ describe("qa suite runtime flow", () => {
         createGatewayConfig: vi.fn(),
         buildAgentDelivery: vi.fn(),
         requiredPluginIds: [],
+        supportedActions: [],
         handleAction: vi.fn(),
         createReportNotes: vi.fn(),
         state: {


### PR DESCRIPTION
## What Problem This Solves

QA Lab needs a shared foundation for making channel scenarios portable across the existing qa-channel and Crabline suite transports, without introducing a parallel channel-driver abstraction. Today both transports already route through `QaTransportAdapter`, but there was no shared way for a scenario to declare which transport capabilities or generic channel actions it needs before a later PR ports Slack, Telegram, and WhatsApp scenarios onto that path.

## Why This Change Was Made

This PR keeps the existing transport architecture and adds a small scenario-requirements layer on top of it. `QaTransportCapabilities` is now exported from the existing transport adapter surface, transports advertise supported generic actions, and `qa-transport-scenarios.ts` can define/filter/assert scenario requirements using existing live standard scenario IDs plus `QaTransportAdapter` capabilities/actions.

The helper is wired through the existing live transport scenario metadata surface so it is production-reachable QA Lab code, but this PR still does not change runner behavior or port any channel scenarios yet.

## User Impact

No end-user behavior changes. QA developers can now build the next stacked PRs around the existing transport adapter contract instead of adding a new driver concept.

## Evidence

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-qa.config.ts extensions/qa-lab/src/qa-transport-scenarios.test.ts extensions/qa-lab/src/scenario-runtime-api.test.ts extensions/qa-lab/src/qa-channel-transport.test.ts extensions/qa-lab/src/crabline-transport.test.ts extensions/qa-lab/src/suite-runtime-flow.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-qa.config.ts extensions/qa-lab/src/qa-transport-scenarios.test.ts extensions/qa-lab/src/scenario-runtime-api.test.ts`
- `pnpm lint --threads=8`
- `pnpm run lint:extensions:bundled`
- `pnpm run deadcode:dependencies`
- `pnpm deadcode:unused-files`
- `pnpm check:test-types`
- `pnpm tsgo:extensions:test`
- `git diff --check`
