### PR TITLE
Fix Codex dynamic tools returning raw payloads

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.test.ts
@@ -244,6 +244,40 @@ describe("createCodexDynamicToolBridge", () => {
     expectNoNamespace(specs.find((tool) => tool.name === "message"));
   });
 
+  it("normalizes raw plugin payloads before Codex content conversion", async () => {
+    const rawPayload = { ok: true, status: "completed", value: "done" };
+    const execute = vi.fn(async () => rawPayload as unknown as AgentToolResult<unknown>);
+    const bridge = createCodexDynamicToolBridge({
+      tools: [
+        createTool({
+          name: "desktop_bridge_audit_tail",
+          execute,
+        }),
+      ],
+      signal: new AbortController().signal,
+    });
+
+    const response = await bridge.handleToolCall({
+      threadId: "thread-1",
+      turnId: "turn-1",
+      callId: "call-raw-payload",
+      namespace: null,
+      tool: "desktop_bridge_audit_tail",
+      arguments: { limit: 1 },
+    });
+
+    expect(response.success).toBe(true);
+    expect(response.contentItems).toHaveLength(1);
+    const item = response.contentItems[0];
+    expect(item?.type).toBe("inputText");
+    const text = item && "text" in item ? item.text : undefined;
+    if (typeof text !== "string") {
+      throw new Error("expected raw payload response to be converted to input text");
+    }
+    expect(JSON.parse(text)).toEqual(rawPayload);
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
   it("can register a durable tool schema while denying execution for the current turn", async () => {
     const heartbeatExecute = vi.fn(async () => textToolResult("heartbeat recorded"));
     const onAgentToolResult = vi.fn();

--- a/extensions/codex/src/app-server/dynamic-tools.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.ts
@@ -503,7 +503,9 @@ export function createCodexDynamicToolBridge(params: {
             : undefined,
         };
         didStartExecution = true;
-        const rawResult = await tool.execute(call.callId, preparedArgs, signal);
+        const rawResult = normalizeCodexDynamicToolResult(
+          await tool.execute(call.callId, preparedArgs, signal),
+        );
         const adjustedExecutedArgs = consumeAdjustedParamsForToolCall(
           call.callId,
           toolResultHookContext.runId,
@@ -517,23 +519,27 @@ export function createCodexDynamicToolBridge(params: {
         );
         const telemetryRawResult = sanitizeToolResult(rawResult);
         const rawIsError = isCodexToolResultError(rawResult);
-        const middlewareResult = await middlewareRunner.applyToolResultMiddleware({
-          threadId: call.threadId,
-          turnId: call.turnId,
-          toolCallId: call.callId,
-          toolName,
-          args: structuredClone(executedArgs),
-          isError: rawIsError,
-          result: rawResult,
-        });
-        const result = await legacyExtensionRunner.applyToolResultExtensions({
-          threadId: call.threadId,
-          turnId: call.turnId,
-          toolCallId: call.callId,
-          toolName,
-          args: structuredClone(executedArgs),
-          result: middlewareResult,
-        });
+        const middlewareResult = normalizeCodexDynamicToolResult(
+          await middlewareRunner.applyToolResultMiddleware({
+            threadId: call.threadId,
+            turnId: call.turnId,
+            toolCallId: call.callId,
+            toolName,
+            args: structuredClone(executedArgs),
+            isError: rawIsError,
+            result: rawResult,
+          }),
+        );
+        const result = normalizeCodexDynamicToolResult(
+          await legacyExtensionRunner.applyToolResultExtensions({
+            threadId: call.threadId,
+            turnId: call.turnId,
+            toolCallId: call.callId,
+            toolName,
+            args: structuredClone(executedArgs),
+            result: middlewareResult,
+          }),
+        );
         const resultIsError = rawIsError || isCodexToolResultError(result);
         notifyAgentToolResult(options?.onAgentToolResult, toolName, result, resultIsError);
         void runAgentHarnessAfterToolCallHook({
@@ -1154,6 +1160,36 @@ function readPositiveInteger(value: unknown): number | undefined {
     return undefined;
   }
   return Math.floor(value);
+}
+
+function normalizeCodexDynamicToolResult(result: unknown): AgentToolResult<unknown> {
+  if (isAgentToolResultLike(result)) {
+    return result;
+  }
+  const details = sanitizeToolResult(result) ?? null;
+  return {
+    content: [{ type: "text", text: stringifyCodexDynamicToolPayload(details) }],
+    details,
+  };
+}
+
+function isAgentToolResultLike(result: unknown): result is AgentToolResult<unknown> {
+  return isRecord(result) && Array.isArray(result.content);
+}
+
+function stringifyCodexDynamicToolPayload(payload: unknown): string {
+  if (typeof payload === "string") {
+    return payload;
+  }
+  try {
+    const text = JSON.stringify(payload, null, 2);
+    if (typeof text === "string") {
+      return text;
+    }
+  } catch {
+    // Fall through to String() for non-JSON payloads.
+  }
+  return String(payload);
 }
 
 function isCodexToolResultError(result: AgentToolResult<unknown>): boolean {


### PR DESCRIPTION
Fixes #97913.

## What Problem This Solves

OpenClaw's Codex dynamic-tool bridge can receive plugin tool results that are plain payload objects instead of structured `AgentToolResult` envelopes. When a raw payload reaches `convertToolContents(result.content)`, `result.content` is undefined and the bridge can fail with `Cannot read properties of undefined (reading 'reduce')`.

This PR normalizes raw plugin payloads into `AgentToolResult` envelopes before Codex dynamic-tool middleware/extensions and content conversion, while leaving already-structured `AgentToolResult` responses unchanged.

## Downstream Trigger

The bug was surfaced during evaOS Workbench Mac-control visible-agent proof: direct gateway `tools.invoke` for the same bridge tool succeeded, but the Codex dynamic-tool/model-run path failed before the assistant response. That is downstream evidence only; the defect and fix are in OpenClaw's Codex dynamic-tool runtime boundary.

Workbench release readiness remains tracked downstream in `100yenadmin/evaOS-GUI#480`.

## Summary

- Normalize raw plugin payloads into an `AgentToolResult` before Codex dynamic-tool middleware/extensions and content conversion.
- Keep existing structured `AgentToolResult` responses unchanged.
- Add a regression for a plugin tool whose `execute` returns a plain payload object.

## Evidence

- `git diff --check`
- Direct patched-runtime proof against the installed bundled dynamic-tool bridge: raw payload response normalized to `success: true` and `inputText` JSON.
- Evidence artifact: `/Volumes/LEXAR/Codex/evidence/mac-control-contract-unification/openclaw-tool-repro/after-runtime-normalizer/direct-bridge-raw-payload-proof.json`

## Not Run Locally

- Vitest: this Lexar source worktree has no `node_modules`; `scripts/run-vitest.mjs` reports dependencies missing. GitHub CI owns the full repo test gate.

## Release Boundary

This is OpenClaw runtime/tool-result envelope hardening only. It does not claim evaOS Workbench release readiness or customer readiness.
