### PR TITLE
fix(codex): normalize raw plugin payloads in dynamic tool bridge (fixes #97913) (AI-assisted)

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.test.ts
@@ -853,7 +853,7 @@ describe("createCodexDynamicToolBridge", () => {
       tools: [
         createTool({
           name: "raw_lookup",
-          execute: vi.fn(async () => ({ answer: 42, status: "ok" })),
+          execute: vi.fn(async () => ({ answer: 42, status: "ok" }) as any),
         }),
       ],
       signal: new AbortController().signal,

--- a/extensions/codex/src/app-server/dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.test.ts
@@ -848,6 +848,35 @@ describe("createCodexDynamicToolBridge", () => {
     },
   );
 
+  it("normalizes raw plugin payloads that lack a content array", async () => {
+    const bridge = createCodexDynamicToolBridge({
+      tools: [
+        createTool({
+          name: "raw_lookup",
+          execute: vi.fn(async () => ({ answer: 42, status: "ok" })),
+        }),
+      ],
+      signal: new AbortController().signal,
+    });
+
+    const result = await bridge.handleToolCall({
+      threadId: "thread-1",
+      turnId: "turn-1",
+      callId: "call-1",
+      namespace: null,
+      tool: "raw_lookup",
+      arguments: {},
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.contentItems).toEqual([
+      {
+        type: "inputText",
+        text: JSON.stringify({ answer: 42, status: "ok" }, null, 2),
+      },
+    ]);
+  });
+
   it("preserves audio-as-voice metadata from tts results", async () => {
     const toolResult = {
       content: [{ type: "text", text: "(spoken) hello" }],

--- a/extensions/codex/src/app-server/dynamic-tools.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.ts
@@ -751,7 +751,7 @@ function normalizePluginToolResult(result: unknown): AgentToolResult<unknown> {
   const text = typeof result === "string" ? result : JSON.stringify(result, null, 2);
   return {
     content: [{ type: "text", text }],
-    details: result as unknown,
+    details: result,
   };
 }
 

--- a/extensions/codex/src/app-server/dynamic-tools.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.ts
@@ -503,7 +503,9 @@ export function createCodexDynamicToolBridge(params: {
             : undefined,
         };
         didStartExecution = true;
-        const rawResult = await tool.execute(call.callId, preparedArgs, signal);
+        const rawResult = normalizePluginToolResult(
+          await tool.execute(call.callId, preparedArgs, signal),
+        );
         const adjustedExecutedArgs = consumeAdjustedParamsForToolCall(
           call.callId,
           toolResultHookContext.runId,
@@ -733,6 +735,23 @@ function failedToolResult(message: string): AgentToolResult<unknown> {
   return {
     content: [{ type: "text", text: message }],
     details: { status: "failed", error: message },
+  };
+}
+
+/**
+ * Ensures a plugin tool result conforms to the `AgentToolResult` envelope.
+ * Plugin tools that return a raw payload object (without a `content` array)
+ * would otherwise crash `convertToolContents` with
+ * `Cannot read properties of undefined (reading 'reduce')`.
+ */
+function normalizePluginToolResult(result: unknown): AgentToolResult<unknown> {
+  if (isRecord(result) && Array.isArray(result.content)) {
+    return result as unknown as AgentToolResult<unknown>;
+  }
+  const text = typeof result === "string" ? result : JSON.stringify(result, null, 2);
+  return {
+    content: [{ type: "text", text }],
+    details: result as unknown,
   };
 }
 


### PR DESCRIPTION
## What Problem This Solves

Plugin tools that return a plain payload object (without a `content` array) crash the Codex dynamic tool bridge with `Cannot read properties of undefined (reading 'reduce')` in `convertToolContents`. This blocks any Codex app-server integration where a plugin's `execute` returns a raw result instead of a structured `AgentToolResult` envelope.

## Why This Change Was Made

`convertToolContents(result.content, ...)` unconditionally calls `content.reduce(...)` on line 1292. When a plugin tool returns `{ answer: 42 }` instead of `{ content: [...], details: {...} }`, `result.content` is `undefined` and the reduce crashes before middleware or extensions can normalize the result.

The fix wraps the raw `tool.execute` return value in `normalizePluginToolResult` immediately after execution, ensuring the middleware/extension pipeline and `convertToolContents` always see a valid `content` array.

## User Impact

- Codex app-server integrations using plugin tools that return raw payloads no longer crash
- Existing structured `AgentToolResult` behavior is unchanged (passthrough path)
- No config or API surface changes

- [x] AI-assisted (Hermes Agent)

## Evidence

- **Behavior addressed:** Codex dynamic tool bridge crashes when a plugin tool returns a raw payload without a `content` array
- **Environment tested:** macOS 26.4.1, Node 22.19, OpenClaw repo at d43366b4e
- **Steps run after the patch:**
  1. `node scripts/verification script run extensions/codex/src/app-server/dynamic-tools.test.ts`
  2. New regression test exercises the exact production code path: `createCodexDynamicToolBridge` → `handleToolCall` with a tool whose `execute` returns a raw payload
- **Evidence after fix:**
```
 ✓  extension-codex  extensions/codex/src/app-server/dynamic-tools.test.ts (81 tests) 1837ms

 Test Files  1 passed (1)
      Tests  81 passed (81)
```
- **Observed result after fix:** All 81 pass including the new regression. The raw payload is normalized into a proper AgentToolResult envelope and returned as a successful tool result.
- **What was not tested:** Live Codex app-server integration; the fix is verified through the same production bridge code path via createCodexDynamicToolBridge.

## Real behavior proof

- **Behavior addressed:** Codex dynamic tool bridge crashes when a plugin tool returns a raw payload without a `content` array
- **Environment tested:** macOS 26.4.1, Node 22.19, OpenClaw repo at d43366b4e
- **Steps run after the patch:**
  1. `node scripts/verification script run extensions/codex/src/app-server/dynamic-tools.test.ts`
  2. New regression test exercises the exact production code path: `createCodexDynamicToolBridge` → `handleToolCall` with a tool whose `execute` returns a raw payload
- **Evidence after fix:**
```
 ✓  extension-codex  extensions/codex/src/app-server/dynamic-tools.test.ts (81 tests) 1837ms

 Test Files  1 passed (1)
      Tests  81 passed (81)
```
- **Observed result after fix:** All 81 pass including the new regression. The raw payload is normalized into a proper AgentToolResult envelope and returned as a successful tool result.
- **What was not tested:** Live Codex app-server integration; the fix is verified through the same production bridge code path via createCodexDynamicToolBridge.
