### PR TITLE
fix(codex): honor denied deferred tools

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -13,6 +13,7 @@ import {
   addSandboxShellDynamicToolsIfAvailable,
   buildDynamicTools,
   filterCodexDynamicToolsForAllowlist,
+  filterCodexDynamicToolsForDenylist,
   hasWildcardCodexToolsAllow,
   includeForcedCodexDynamicToolAllow,
   mapCodexAppServerRemoteWorkspacePath,
@@ -1209,6 +1210,70 @@ describe("Codex app-server dynamic tool build", () => {
 
     expect(filterCodexDynamicToolsForAllowlist(tools, [" * "])).toEqual(tools);
     expect(hasWildcardCodexToolsAllow([" * "])).toBe(true);
+  });
+
+  it("applies explicit tools.deny after Codex dynamic allowlist expansion", () => {
+    const tools = ["message", "skill_workshop", "web_search"].map((name) => ({ name }));
+    const allowFiltered = filterCodexDynamicToolsForAllowlist(tools, ["*"]);
+
+    expect(filterCodexDynamicToolsForDenylist(allowFiltered, ["skill_*"])).toEqual([
+      { name: "message" },
+      { name: "web_search" },
+    ]);
+    expect(filterCodexDynamicToolsForDenylist(allowFiltered, ["*"])).toEqual([]);
+  });
+
+  it("applies explicit tools.deny to Codex shell aliases", () => {
+    const tools = [
+      "exec",
+      "sandbox_exec",
+      "node_exec",
+      "process",
+      "sandbox_process",
+      "node_process",
+      "message",
+    ].map((name) => ({ name }));
+
+    expect(filterCodexDynamicToolsForDenylist(tools, ["exec"])).toEqual([
+      { name: "process" },
+      { name: "sandbox_process" },
+      { name: "node_process" },
+      { name: "message" },
+    ]);
+    expect(filterCodexDynamicToolsForDenylist(tools, ["process"])).toEqual([
+      { name: "exec" },
+      { name: "sandbox_exec" },
+      { name: "node_exec" },
+      { name: "message" },
+    ]);
+    expect(filterCodexDynamicToolsForDenylist(tools, ["bash"])).toEqual([
+      { name: "process" },
+      { name: "sandbox_process" },
+      { name: "node_process" },
+      { name: "message" },
+    ]);
+  });
+
+  it("hides config-denied deferred tools from Codex developer instructions", async () => {
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
+    params.disableTools = false;
+    params.runtimePlan = createCodexRuntimePlanFixture();
+    params.config = { tools: { deny: ["skill_workshop"] } };
+    setOpenClawCodingToolsFactoryForTests(() => [
+      createRuntimeDynamicTool("message"),
+      createRuntimeDynamicTool("skill_workshop"),
+    ]);
+
+    const tools = await buildDynamicToolsForTest(params, workspaceDir);
+    const specs = createCodexDynamicToolBridge({
+      tools,
+      signal: new AbortController().signal,
+      loading: "searchable",
+    }).availableSpecs;
+    const toolNames = flattenCodexDynamicToolFunctions(specs).map((tool) => tool.name);
+
+    expect(toolNames).toEqual(["message"]);
   });
 
   it("disables Codex native tool surfaces for restricted runtime allowlists", () => {

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -19,6 +19,7 @@ import {
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { resolveAgentDir } from "openclaw/plugin-sdk/agent-runtime";
 import { isToolAllowed } from "openclaw/plugin-sdk/sandbox";
+import { isToolAllowedByPolicyName } from "../../../../src/agents/tool-policy-match.js";
 import { readCodexPluginConfig, type CodexPluginConfig } from "./config.js";
 import {
   filterCodexDynamicTools,
@@ -381,7 +382,11 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
         webSearchPolicy.persistentAllowed),
   );
   const toolsAllow = includeForcedCodexDynamicToolAllow(params.toolsAllow, messagePolicyParams);
-  const filteredTools = filterCodexDynamicToolsForAllowlist(visionFilteredTools, toolsAllow);
+  const allowFilteredTools = filterCodexDynamicToolsForAllowlist(visionFilteredTools, toolsAllow);
+  const filteredTools = filterCodexDynamicToolsForDenylist(
+    allowFilteredTools,
+    params.config?.tools?.deny,
+  );
   toolBuildStages.mark("allowlist-filter");
   const normalizedTools = normalizeAgentRuntimeTools({
     runtimePlan: input.ignoreRuntimePlan ? undefined : params.runtimePlan,
@@ -933,6 +938,28 @@ export function filterCodexDynamicToolsForAllowlist<T extends { name: string }>(
       (normalized === CODEX_NODE_EXEC_DYNAMIC_TOOL_NAME && allowSet.has("exec")) ||
       (normalized === CODEX_NODE_PROCESS_DYNAMIC_TOOL_NAME &&
         (allowSet.has("exec") || allowSet.has("process")))
+    );
+  });
+}
+
+/** Applies the explicit OpenClaw tools.deny policy to the Codex dynamic-tool projection. */
+export function filterCodexDynamicToolsForDenylist<T extends { name: string }>(
+  tools: T[],
+  toolsDeny?: string[],
+): T[] {
+  if (!toolsDeny || toolsDeny.length === 0) {
+    return tools;
+  }
+  return tools.filter((tool) => {
+    const normalized = normalizeCodexDynamicToolName(tool.name);
+    return (
+      isToolAllowedByPolicyName(normalized, { deny: toolsDeny }) &&
+      (normalized === "sandbox_exec" || normalized === CODEX_NODE_EXEC_DYNAMIC_TOOL_NAME
+        ? isToolAllowedByPolicyName("exec", { deny: toolsDeny })
+        : true) &&
+      (normalized === "sandbox_process" || normalized === CODEX_NODE_PROCESS_DYNAMIC_TOOL_NAME
+        ? isToolAllowedByPolicyName("process", { deny: toolsDeny })
+        : true)
     );
   });
 }


### PR DESCRIPTION
## Summary
- Apply the configured `tools.deny` policy to Codex app-server dynamic tools after Codex allowlist expansion.
- Hide denied deferred tools such as `skill_workshop` from Codex `tool_search`/developer-instruction visibility.
- Keep deny semantics aligned with the shared OpenClaw policy matcher, including wildcard/glob entries and Codex shell aliases.

## Issue / Motivation
Fixes #97911.

When `tools.deny` includes `skill_workshop`, normal OpenClaw tool policy removes the tool, but Codex app-server's deferred dynamic-tool projection could still advertise it through the searchable tool manifest. That makes the model see and potentially load a tool the operator explicitly denied.

## Changes
- Filter Codex dynamic tools with `config.tools.deny` after runtime allowlist handling.
- Reuse `isToolAllowedByPolicyName` for deny matching so wildcard/glob/group-style policy behavior stays consistent.
- Treat Codex shell aliases (`sandbox_exec`, `node_exec`, `sandbox_process`, `node_process`) as their canonical `exec`/`process` policy targets for deny checks.
- Add regression coverage for denied `skill_workshop`, wildcard deny, shell alias deny behavior, and the resulting Codex dynamic tool specs.

## Testing
- `pnpm exec vitest run extensions/codex/src/app-server/dynamic-tool-build.test.ts -t 'tools.deny|config-denied deferred'`
- `pnpm exec oxfmt --check extensions/codex/src/app-server/dynamic-tool-build.ts extensions/codex/src/app-server/dynamic-tool-build.test.ts`
- `pnpm exec oxlint extensions/codex/src/app-server/dynamic-tool-build.ts extensions/codex/src/app-server/dynamic-tool-build.test.ts`
- `git diff --check`
- Added-line secret scan over the diff for token/password/secret-style assignments

## Evidence
The focused Vitest run passed 3 matching regression tests, including the config-denied deferred-tool case and shell alias deny coverage.
