### PR TITLE
chore: link platform channel QA candidates

### DIFF
--- a/qa/scenarios/channels/telegram-bot-token.yaml
+++ b/qa/scenarios/channels/telegram-bot-token.yaml
@@ -1,0 +1,26 @@
+title: Telegram bot token resolution evidence
+
+scenario:
+  id: telegram-bot-token
+  surface: telegram
+  category: telegram.channel-setup-and-operations
+  coverage:
+    primary:
+      - telegram.bot-token
+  objective: Link deterministic Telegram bot-token source resolution coverage to channel setup maturity accounting.
+  successCriteria:
+    - TELEGRAM_BOT_TOKEN is used when channel-level config is missing.
+    - Configured botToken values take precedence over environment fallback.
+    - tokenFile values are read for channel-level and account-scoped tokens.
+    - Account-scoped botToken and tokenFile values resolve without falling through to unrelated accounts.
+  docsRefs:
+    - docs/channels/telegram.md
+    - docs/plugins/reference/telegram.md
+    - docs/help/testing.md
+  codeRefs:
+    - extensions/telegram/src/token.ts
+    - extensions/telegram/src/token.test.ts
+  execution:
+    kind: vitest
+    path: extensions/telegram/src/token.test.ts
+    summary: Vitest coverage for TELEGRAM_BOT_TOKEN, botToken, tokenFile, and account-scoped token resolution.

--- a/qa/scenarios/channels/voice-call-cli-rpc-agent-tool.yaml
+++ b/qa/scenarios/channels/voice-call-cli-rpc-agent-tool.yaml
@@ -1,0 +1,35 @@
+title: Voice Call CLI, RPC, and agent-tool evidence
+
+scenario:
+  id: voice-call-cli-rpc-agent-tool
+  surface: voice-call-channel
+  category: voice-call-channel.channel-setup-and-operations
+  coverage:
+    primary:
+      - voice-call.cli-rpc-agent-tool
+  objective: Link existing Voice Call CLI gateway fallback, Gateway continue operation, and realtime agent consult tool coverage to Voice Call maturity accounting.
+  successCriteria:
+    - CLI helpers treat unavailable Gateway connections as fallback candidates and cap Gateway operation timeouts.
+    - Gateway continue-call operations expose bounded async polling behavior.
+    - The realtime Voice Call runtime registers the openclaw_agent_consult tool.
+    - The consult tool invokes the routed embedded OpenClaw agent with voice session, channel, model, and tool policy context.
+  docsRefs:
+    - docs/cli/voicecall.md
+    - docs/plugins/voice-call.md
+    - docs/gateway/protocol.md
+    - docs/help/testing.md
+  codeRefs:
+    - test/e2e/qa-lab/channels/voice-call-cli-rpc-agent-tool.ts
+    - extensions/voice-call/src/cli.ts
+    - extensions/voice-call/src/cli.test.ts
+    - extensions/voice-call/src/gateway-continue-operation.test.ts
+    - extensions/voice-call/src/runtime.test.ts
+    - extensions/voice-call/src/response-generator.test.ts
+  execution:
+    kind: script
+    path: test/e2e/qa-lab/channels/voice-call-cli-rpc-agent-tool.ts
+    summary: Runs existing Voice Call CLI, Gateway operation, runtime consult, and response-generator tests and emits QA Lab evidence.
+    timeoutMs: 600000
+    args:
+      - --artifact-base
+      - ${outputDir}

--- a/qa/scenarios/runtime/active-talk-agent-run-status.yaml
+++ b/qa/scenarios/runtime/active-talk-agent-run-status.yaml
@@ -1,0 +1,29 @@
+title: Active Talk agent-run control evidence
+
+scenario:
+  id: active-talk-agent-run-status
+  surface: voice-and-realtime-talk
+  category: voice-and-realtime-talk.realtime-talk-sessions
+  coverage:
+    primary:
+      - voice.active-talk-agent-run-status
+  objective: Link deterministic Talk active-run status, cancel, steer, and follow-up control coverage to realtime Talk maturity accounting.
+  successCriteria:
+    - Talk control phrases are classified conservatively into status, cancel, steer, and follow-up modes.
+    - Status reads active Talk tool progress without queueing another run.
+    - Cancel aborts the active embedded run without enqueueing steering.
+    - Steer and follow-up requests enqueue against the active embedded run with the expected control semantics.
+  docsRefs:
+    - docs/nodes/talk.md
+    - docs/gateway/protocol.md
+    - docs/help/testing.md
+  codeRefs:
+    - src/talk/agent-run-control.ts
+    - src/talk/agent-run-control-shared.ts
+    - src/talk/agent-run-control.test.ts
+    - src/gateway/server-methods/talk-session.ts
+    - src/gateway/server-methods/talk-client.ts
+  execution:
+    kind: vitest
+    path: src/talk/agent-run-control.test.ts
+    summary: Vitest coverage for active Talk run status, cancellation, steering, and follow-up controls.

--- a/test/e2e/qa-lab/channels/voice-call-cli-rpc-agent-tool.ts
+++ b/test/e2e/qa-lab/channels/voice-call-cli-rpc-agent-tool.ts
@@ -1,0 +1,238 @@
+import { spawn } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import {
+  buildScriptEvidenceSummary,
+  QA_EVIDENCE_FILENAME,
+  type QaEvidenceStatus,
+  type QaEvidenceSummaryJson,
+} from "../../../../extensions/qa-lab/src/evidence-summary.js";
+
+const SCENARIO_ID = "voice-call-cli-rpc-agent-tool";
+const SCENARIO_TITLE = "Voice Call CLI, RPC, and agent-tool evidence";
+const SOURCE_PATH = "test/e2e/qa-lab/channels/voice-call-cli-rpc-agent-tool.ts";
+const PRIMARY_COVERAGE_ID = "voice-call.cli-rpc-agent-tool";
+const TEST_FILES = [
+  "extensions/voice-call/src/cli.test.ts",
+  "extensions/voice-call/src/gateway-continue-operation.test.ts",
+  "extensions/voice-call/src/runtime.test.ts",
+  "extensions/voice-call/src/response-generator.test.ts",
+] as const;
+
+type ProducerOptions = {
+  artifactBase: string;
+  repoRoot: string;
+};
+
+type ProofResult = {
+  artifacts: Array<{ kind: string; path: string }>;
+  details?: string;
+  durationMs: number;
+  status: QaEvidenceStatus;
+};
+
+function parseOptions(argv = process.argv.slice(2)): ProducerOptions {
+  let artifactBase = path.join(".artifacts", "qa-e2e", SCENARIO_ID);
+  let repoRoot = process.cwd();
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--artifact-base") {
+      artifactBase = argv[++index] ?? "";
+      continue;
+    }
+    if (arg === "--repo-root") {
+      repoRoot = argv[++index] ?? "";
+      continue;
+    }
+    if (arg === "--help") {
+      printUsage();
+      process.exit(0);
+    }
+    throw new Error(`unknown argument: ${arg}`);
+  }
+
+  if (!artifactBase.trim()) {
+    throw new Error("--artifact-base must not be empty");
+  }
+  if (!repoRoot.trim()) {
+    throw new Error("--repo-root must not be empty");
+  }
+  return { artifactBase, repoRoot };
+}
+
+function printUsage() {
+  console.log(`Usage: node --import tsx ${SOURCE_PATH} [options]
+
+Options:
+  --artifact-base <dir>  Directory for qa-evidence.json and proof logs
+  --repo-root <dir>      Repository root, defaults to cwd
+`);
+}
+
+function relativeArtifactPath(options: ProducerOptions, filePath: string) {
+  return path.relative(options.artifactBase, filePath).replaceAll(path.sep, "/");
+}
+
+function formatErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function appendText(filePath: string, text: string) {
+  await fs.appendFile(filePath, text, "utf8");
+}
+
+async function runVitestProof(options: ProducerOptions): Promise<ProofResult> {
+  const startedAt = Date.now();
+  await fs.mkdir(options.artifactBase, { recursive: true });
+  const logPath = path.join(options.artifactBase, "voice-call-vitest.log");
+  await fs.writeFile(
+    logPath,
+    [
+      "Voice Call CLI/RPC/agent-tool QA proof",
+      `repoRoot=${options.repoRoot}`,
+      `tests=${TEST_FILES.join(", ")}`,
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+
+  try {
+    const result = await runNodeCommand({
+      args: ["scripts/run-vitest.mjs", ...TEST_FILES, "--reporter=verbose"],
+      cwd: options.repoRoot,
+      logPath,
+    });
+    if (result.exitCode !== 0) {
+      return {
+        artifacts: [{ kind: "log", path: relativeArtifactPath(options, logPath) }],
+        details: `Voice Call Vitest proof failed with exit code ${result.exitCode}`,
+        durationMs: Math.max(1, Date.now() - startedAt),
+        status: "fail",
+      };
+    }
+    return {
+      artifacts: [{ kind: "log", path: relativeArtifactPath(options, logPath) }],
+      details:
+        "Voice Call CLI helpers, Gateway continue operation, realtime consult tool, and embedded response generator tests passed.",
+      durationMs: Math.max(1, Date.now() - startedAt),
+      status: "pass",
+    };
+  } catch (error) {
+    const details = formatErrorMessage(error);
+    await appendText(logPath, `\nfail: ${details}\n`);
+    return {
+      artifacts: [{ kind: "log", path: relativeArtifactPath(options, logPath) }],
+      details,
+      durationMs: Math.max(1, Date.now() - startedAt),
+      status: "fail",
+    };
+  }
+}
+
+function runNodeCommand(params: {
+  args: string[];
+  cwd: string;
+  logPath: string;
+}): Promise<{ exitCode: number | null }> {
+  return new Promise((resolve, reject) => {
+    const output: string[] = [];
+    const child = spawn(process.execPath, params.args, {
+      cwd: params.cwd,
+      env: process.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      output.push(chunk.toString("utf8"));
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      output.push(chunk.toString("utf8"));
+    });
+    child.on("error", reject);
+    child.on("close", (exitCode) => {
+      appendText(params.logPath, output.join("")).then(() => resolve({ exitCode }), reject);
+    });
+  });
+}
+
+function buildEvidence(params: {
+  options: ProducerOptions;
+  result: ProofResult;
+}): QaEvidenceSummaryJson {
+  return buildScriptEvidenceSummary({
+    artifactPaths: params.result.artifacts,
+    evidenceMode: "full",
+    env: process.env,
+    generatedAt: new Date().toISOString(),
+    primaryModel: "mock-openai/gpt-5.5",
+    providerMode: "mock-openai",
+    repoRoot: params.options.repoRoot,
+    runner: "script",
+    targets: [
+      {
+        id: SCENARIO_ID,
+        title: SCENARIO_TITLE,
+        sourcePath: SOURCE_PATH,
+        primaryCoverageIds: [PRIMARY_COVERAGE_ID],
+        docsRefs: [
+          "docs/cli/voicecall.md",
+          "docs/plugins/voice-call.md",
+          "docs/gateway/protocol.md",
+          "docs/help/testing.md",
+        ],
+        codeRefs: [
+          SOURCE_PATH,
+          ...TEST_FILES,
+          "extensions/voice-call/src/cli.ts",
+          "extensions/voice-call/src/gateway-continue-operation.ts",
+          "extensions/voice-call/src/runtime.ts",
+          "extensions/voice-call/src/response-generator.ts",
+        ],
+      },
+    ],
+    results: [
+      {
+        id: SCENARIO_ID,
+        status: params.result.status,
+        durationMs: params.result.durationMs,
+        failureMessage: params.result.details,
+      },
+    ],
+  });
+}
+
+async function writeJson(filePath: string, value: unknown) {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+export async function runVoiceCallCliRpcAgentToolProducer(
+  options: ProducerOptions,
+): Promise<QaEvidenceSummaryJson> {
+  const result = await runVitestProof(options);
+  const evidence = buildEvidence({ options, result });
+  await writeJson(path.join(options.artifactBase, QA_EVIDENCE_FILENAME), evidence);
+  await writeJson(path.join(options.artifactBase, "latest-run.json"), {
+    qaEvidence: QA_EVIDENCE_FILENAME,
+    scenarioId: SCENARIO_ID,
+    status: result.status,
+  });
+  return evidence;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  runVoiceCallCliRpcAgentToolProducer(parseOptions()).then(
+    (evidence) => {
+      const entry = evidence.entries.find((candidate) => candidate.test.id === SCENARIO_ID);
+      if (entry?.result.status !== "pass") {
+        process.exitCode = 1;
+      }
+    },
+    (error: unknown) => {
+      console.error(formatErrorMessage(error));
+      process.exitCode = 1;
+    },
+  );
+}


### PR DESCRIPTION
## What Problem This Solves

The final platform/channel candidate batch from the QA maturity audit still had several existing tests that were not visible to QA Lab coverage accounting. That made direct proofs for Telegram bot-token resolution, active Talk agent-run controls, and Voice Call CLI/RPC agent-tool behavior invisible in maturity inventory output.

## Why This Change Was Made

This adds QA Lab scenario metadata for the existing direct proofs and adds one QA-only script producer for Voice Call so the related existing test files emit a single scenario evidence entry. It does not add taxonomy IDs or claim primary coverage for candidates that did not have direct platform/watch proof.

Primary coverage added:

- `telegram.bot-token`: `extensions/telegram/src/token.test.ts` directly proves `TELEGRAM_BOT_TOKEN`, configured `botToken`, `tokenFile`, account-level token/tokenFile resolution, and SecretRef handling.
- `voice.active-talk-agent-run-status`: `src/talk/agent-run-control.test.ts` directly proves active Talk status, cancel, steer, and follow-up control behavior.
- `voice-call.cli-rpc-agent-tool`: the QA producer runs the existing Voice Call CLI, Gateway continue-operation, realtime runtime consult-tool, and response-generator tests as one evidence producer.

Audited but intentionally not claimed as primary:

- `wsl2.npm-pnpm-git-package-root`: existing Parallels npm update smoke is not a direct WSL2 package-root proof.
- `windows.native-windows-chat-window`: existing Windows smoke does not directly exercise the native Windows companion chat window UI.
- `watchos.gateway-side-ios-exec-approval` / `watchos.watch-exec-approval-prompt`: existing gateway exec approval coverage is generic and not direct iOS/watch prompt proof.

## User Impact

No product behavior changes. QA maturity reports can now count three existing direct proofs as primary evidence while avoiding overclaiming the remaining platform/watch candidates.

## Evidence

- `node scripts/run-vitest.mjs extensions/telegram/src/token.test.ts extensions/qa-lab/src/scenario-catalog.test.ts --reporter=verbose` passed.
- `node scripts/run-vitest.mjs extensions/telegram/src/token.test.ts src/talk/agent-run-control.test.ts --reporter=verbose` passed earlier in the branch.
- `node --import tsx test/e2e/qa-lab/channels/voice-call-cli-rpc-agent-tool.ts --artifact-base .artifacts/qa-e2e/voice-call-cli-rpc-agent-tool-local` passed earlier in the branch and emitted passing QA evidence.
- `node scripts/run-node.mjs qa coverage --match telegram.bot-token` matched `telegram-bot-token`.
- `node scripts/run-node.mjs qa coverage --match voice.active-talk-agent-run-status` matched `active-talk-agent-run-status`.
- `node scripts/run-node.mjs qa coverage --match voice-call.cli-rpc-agent-tool` matched `voice-call-cli-rpc-agent-tool`.
- `node scripts/run-node.mjs qa suite --provider-mode mock-openai --scenario telegram-bot-token --scenario active-talk-agent-run-status --scenario voice-call-cli-rpc-agent-tool --concurrency 1 --fast` passed and emitted passing primary evidence for all three scenario IDs.
- `.agents/skills/autoreview/scripts/autoreview --mode local` passed with no accepted/actionable findings after the Telegram metadata overclaim was fixed.
