### PR TITLE
fix(subagents): escalate expected completions on delivery give-up instead of dropping them

### DIFF
--- a/src/agents/agent-steering-queue.ts
+++ b/src/agents/agent-steering-queue.ts
@@ -6,6 +6,7 @@ import type {
   SubagentCompletionDeliveryState,
   SubagentRunRecord,
 } from "./subagent-registry.types.js";
+import { selectDeliverableSessionsReply } from "./tools/sessions-send-tokens.js";
 
 // Steering queue utilities for delivering completed subagent results back into
 // the requester session. Items are leased before injection to avoid duplicate
@@ -43,7 +44,7 @@ function isStaleLease(delivery: SubagentCompletionDeliveryState, now: number): b
 }
 
 function selectResultText(payload: PendingFinalDeliveryPayload): string | undefined {
-  return payload.frozenResultText?.trim() || payload.fallbackFrozenResultText?.trim() || undefined;
+  return selectDeliverableSessionsReply(payload.frozenResultText, payload.fallbackFrozenResultText);
 }
 
 function describeOutcome(payload: PendingFinalDeliveryPayload): string {

--- a/src/agents/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagent-registry-lifecycle.test.ts
@@ -8,6 +8,7 @@ import {
   resetGatewayWorkAdmission,
 } from "../process/gateway-work-admission.js";
 import { SUBAGENT_KILL_TASK_ERROR } from "../tasks/detached-task-runtime-contract.js";
+import { leasePendingAgentSteeringItemsFromSubagentRuns } from "./agent-steering-queue.js";
 import {
   buildAnnounceIdFromChildRun,
   buildAnnounceIdempotencyKey,
@@ -2896,6 +2897,196 @@ describe("subagent registry lifecycle hardening", () => {
 
     expect(entry.cleanupCompletedAt).toBeTypeOf("number");
     expect(Number.isNaN(entry.cleanupCompletedAt)).toBe(false);
+  });
+
+  it.each([
+    {
+      reason: "retry-limit" as const,
+      completion: {
+        required: true,
+        resultText: "final answer",
+        fallbackResultText: undefined,
+      },
+      expectedResult: "final answer",
+    },
+    {
+      reason: "expiry" as const,
+      completion: {
+        required: true,
+        resultText: undefined,
+        fallbackResultText: "fallback final answer",
+      },
+      expectedResult: "fallback final answer",
+    },
+    {
+      reason: "retry-limit" as const,
+      completion: {
+        required: true,
+        resultText: "NO_REPLY",
+        fallbackResultText: "pre-wake final answer",
+      },
+      expectedResult: "pre-wake final answer",
+    },
+  ])(
+    "surfaces a successful delete-mode completion to the requester after $reason give-up",
+    async ({ reason, completion, expectedResult }) => {
+      const persist = vi.fn();
+      const entry = createRunEntry({
+        cleanup: "delete",
+        endedAt: 4_000,
+        endedReason: SUBAGENT_ENDED_REASON_COMPLETE,
+        expectsCompletionMessage: true,
+        completion,
+        delivery: { status: "pending", lastError: "gateway request timeout for agent" },
+        outcome: { status: "ok" },
+      });
+      const runs = new Map([[entry.runId, entry]]);
+      const controller = createLifecycleController({
+        entry,
+        runs,
+        persist,
+        captureSubagentCompletionReply: vi.fn(async () => undefined),
+      });
+
+      await controller.finalizeResumedAnnounceGiveUp({
+        runId: entry.runId,
+        entry,
+        reason,
+      });
+
+      expect(entry.delivery?.status).toBe("suspended");
+      expect(entry.delivery?.payload).toBeDefined();
+      expect(entry.cleanupHandled).toBe(false);
+      expect(entry.cleanupCompletedAt).toBeUndefined();
+
+      const requesterTurn = leasePendingAgentSteeringItemsFromSubagentRuns({
+        runs,
+        requesterSessionKey: entry.requesterSessionKey,
+        leaseId: `requester-turn-${reason}`,
+        now: 5_000,
+      });
+      expect(requesterTurn?.runIds).toEqual([entry.runId]);
+      expect(requesterTurn?.prompt).toContain(expectedResult);
+      expect(requesterTurn?.prompt).not.toContain("NO_REPLY");
+    },
+  );
+
+  it.each([
+    {
+      name: "failed result",
+      overrides: {
+        endedReason: SUBAGENT_ENDED_REASON_ERROR,
+        expectsCompletionMessage: true,
+        completion: { required: true, resultText: "partial failure details" },
+        outcome: { status: "error" as const, error: "child failed" },
+      },
+    },
+    {
+      name: "non-deliverable sentinel",
+      overrides: {
+        endedReason: SUBAGENT_ENDED_REASON_COMPLETE,
+        expectsCompletionMessage: true,
+        completion: {
+          required: true,
+          resultText: "ANNOUNCE_SKIP",
+          fallbackResultText: "stale fallback that must not override the sentinel",
+        },
+        outcome: { status: "ok" as const },
+      },
+    },
+    {
+      name: "missing result",
+      overrides: {
+        endedReason: SUBAGENT_ENDED_REASON_COMPLETE,
+        expectsCompletionMessage: true,
+        completion: { required: true, resultText: null },
+        outcome: { status: "ok" as const },
+      },
+    },
+    {
+      name: "completion that was not expected",
+      overrides: {
+        endedReason: SUBAGENT_ENDED_REASON_COMPLETE,
+        expectsCompletionMessage: false,
+        completion: { required: false, resultText: "final answer" },
+        outcome: { status: "ok" as const },
+      },
+    },
+  ])("keeps delete cleanup terminal for $name on give-up", async ({ overrides }) => {
+    const persist = vi.fn();
+    const entry = createRunEntry({
+      cleanup: "delete",
+      endedAt: 4_000,
+      delivery: { status: "pending", lastError: "gateway request timeout for agent" },
+      ...overrides,
+    });
+    const runs = new Map([[entry.runId, entry]]);
+
+    const controller = createLifecycleController({
+      entry,
+      runs,
+      persist,
+      captureSubagentCompletionReply: vi.fn(async () => undefined),
+    });
+
+    await controller.finalizeResumedAnnounceGiveUp({
+      runId: entry.runId,
+      entry,
+      reason: "retry-limit",
+    });
+
+    expect(entry.delivery?.status).toBe("failed");
+    expect(runs.has(entry.runId)).toBe(false);
+  });
+
+  it("recovers a fallback-only completion from the durable delivery payload", async () => {
+    const entry = createRunEntry({
+      cleanup: "delete",
+      endedAt: 4_000,
+      endedReason: SUBAGENT_ENDED_REASON_COMPLETE,
+      expectsCompletionMessage: true,
+      completion: { required: true },
+      delivery: {
+        status: "in_progress",
+        attemptCount: 3,
+        lastError: "requester turn interrupted",
+        steeringLeaseId: "stale-requester-turn",
+        steeringLeasedAt: 4_500,
+        payload: {
+          requesterSessionKey: "agent:main:main",
+          requesterDisplayKey: "main",
+          childSessionKey: "agent:main:subagent:test",
+          childRunId: "run-test",
+          task: "test task",
+          endedAt: 4_000,
+          outcome: { status: "ok" },
+          expectsCompletionMessage: true,
+          fallbackFrozenResultText: "durable fallback answer",
+        },
+      },
+      outcome: { status: "ok" },
+    });
+    const runs = new Map([[entry.runId, entry]]);
+    const controller = createLifecycleController({
+      entry,
+      runs,
+      captureSubagentCompletionReply: vi.fn(async () => undefined),
+    });
+
+    await controller.finalizeResumedAnnounceGiveUp({
+      runId: entry.runId,
+      entry,
+      reason: "retry-limit",
+    });
+
+    expect(entry.delivery?.status).toBe("suspended");
+    const requesterTurn = leasePendingAgentSteeringItemsFromSubagentRuns({
+      runs,
+      requesterSessionKey: entry.requesterSessionKey,
+      leaseId: "recovered-requester-turn",
+      now: 5_000,
+    });
+    expect(requesterTurn?.prompt).toContain("durable fallback answer");
   });
 
   it("suspends successful keep-mode final delivery instead of completing cleanup on retry exhaustion", async () => {

--- a/src/agents/subagent-registry-lifecycle.ts
+++ b/src/agents/subagent-registry-lifecycle.ts
@@ -75,6 +75,7 @@ import {
   resolveSubagentRunEffectiveEndedAt,
 } from "./subagent-run-timeout.js";
 import { deleteSubagentSessionForCleanup } from "./subagent-session-cleanup.js";
+import { selectDeliverableSessionsReply } from "./tools/sessions-send-tokens.js";
 
 type CaptureSubagentCompletionReply =
   (typeof import("./subagent-announce.js"))["captureSubagentCompletionReply"];
@@ -787,11 +788,26 @@ export function createSubagentRegistryLifecycleController(params: {
     params.persist();
   };
 
-  const shouldSuspendPendingFinalDelivery = (entry: SubagentRunRecord) =>
-    entry.expectsCompletionMessage === true &&
-    entry.cleanup === "keep" &&
-    entry.endedReason === SUBAGENT_ENDED_REASON_COMPLETE &&
-    entry.outcome?.status === "ok";
+  const shouldSuspendPendingFinalDelivery = (entry: SubagentRunRecord) => {
+    if (
+      entry.expectsCompletionMessage !== true ||
+      entry.endedReason !== SUBAGENT_ENDED_REASON_COMPLETE ||
+      entry.outcome?.status !== "ok"
+    ) {
+      return false;
+    }
+    if (entry.cleanup === "keep") {
+      return true;
+    }
+    const payload = entry.delivery?.payload;
+    const completion = entry.completion;
+    return Boolean(
+      selectDeliverableSessionsReply(
+        payload?.frozenResultText ?? completion?.resultText,
+        payload?.fallbackFrozenResultText ?? completion?.fallbackResultText,
+      ),
+    );
+  };
 
   const finalizeResumedAnnounceGiveUp = async (giveUpParams: {
     runId: string;

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -5001,7 +5001,7 @@ describe("subagent registry seam flow", () => {
     );
   });
 
-  it("deletes delete-mode completion runs when announce cleanup gives up after retry limit", async () => {
+  it("surfaces delete-mode completion results after announce cleanup gives up", async () => {
     mocks.runSubagentAnnounceFlow.mockResolvedValue(false);
     const endedAt = Date.parse("2026-03-24T12:00:00Z");
     mocks.callGateway.mockResolvedValueOnce({
@@ -5038,11 +5038,34 @@ describe("subagent registry seam flow", () => {
 
     await vi.advanceTimersByTimeAsync(4_000);
     expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(3);
+    const giveUpRun = mod
+      .listSubagentRunsForRequester("agent:main:main")
+      .find((entry) => entry.runId === "run-delete-give-up");
+    expect(giveUpRun?.delivery?.status).toBe("suspended");
+    expect(giveUpRun?.cleanupCompletedAt).toBeUndefined();
+
+    const requesterTurn = mod.leasePendingAgentSteeringItems({
+      requesterSessionKey: "agent:main:main",
+      leaseId: "requester-turn-1",
+      now: endedAt + 10_000,
+    });
+    expect(requesterTurn?.runIds).toEqual(["run-delete-give-up"]);
+    expect(requesterTurn?.prompt).toContain("final completion reply");
+
     expect(
-      mod
-        .listSubagentRunsForRequester("agent:main:main")
-        .find((entry) => entry.runId === "run-delete-give-up"),
-    ).toBeUndefined();
+      mod.ackPendingAgentSteeringItems({
+        runIds: requesterTurn?.runIds ?? [],
+        leaseId: "requester-turn-1",
+        now: endedAt + 10_001,
+      }),
+    ).toBe(1);
+    await waitForFast(() => {
+      expect(
+        mod
+          .listSubagentRunsForRequester("agent:main:main")
+          .find((entry) => entry.runId === "run-delete-give-up"),
+      ).toBeUndefined();
+    });
   });
 
   it("finalizes retry-budgeted completion delete runs during resume", async () => {

--- a/src/agents/tools/sessions-send-tokens.ts
+++ b/src/agents/tools/sessions-send-tokens.ts
@@ -31,3 +31,19 @@ export function isReplySkip(text?: string) {
 export function isNonDeliverableSessionsReply(text?: string) {
   return NON_DELIVERABLE_REPLY_TOKENS.some((token) => isSilentReplyText(text, token));
 }
+
+/** Selects the first usable reply, allowing a silent primary to fall back to captured output. */
+export function selectDeliverableSessionsReply(
+  primary?: string | null,
+  fallback?: string | null,
+): string | undefined {
+  const primaryReply = primary?.trim();
+  if (primaryReply && !isNonDeliverableSessionsReply(primaryReply)) {
+    return primaryReply;
+  }
+  if (primaryReply && !isSilentReplyText(primaryReply, SILENT_REPLY_TOKEN)) {
+    return undefined;
+  }
+  const fallbackReply = fallback?.trim();
+  return fallbackReply && !isNonDeliverableSessionsReply(fallbackReply) ? fallbackReply : undefined;
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a successful subagent completion could be silently discarded after requester delivery exhausted its retry budget or expired. This affected expected completions with captured result text when the run used `cleanup: "delete"`.

Related: #67777

The broader active-requester consumption race in #92433, yield/direct-text behavior in #90944, and passive completion-processing contract in #92116 are related delivery problems but are not claimed as fixed here.

## Why This Change Was Made

Both lifecycle give-up paths already share one suspension decision. This change extends that decision to successful, expected delete-mode completions only when a deliverable primary or fallback result exists, then leaves the existing requester steering queue to lease, inject, acknowledge, and clean up the retained result.

The steering queue and lifecycle now use one sentinel-aware result selector: `NO_REPLY` may fall back to previously captured output, while `ANNOUNCE_SKIP`, `REPLY_SKIP`, `HEARTBEAT_OK`, missing text, failed outcomes, and unexpected completions remain terminal.

The branch was rebuilt on current `main` to remove stale snapshot drift. It does not restore the removed `extensions/qa-matrix` plugin or change plugin, dependency, config, schema, or SDK surfaces.

## User Impact

A requester can receive a successful subagent's captured result on its next turn even after direct completion delivery gives up, instead of losing the work silently. Failed, intentionally suppressed, empty, and unexpected completions retain current cleanup behavior.

## Evidence

Exact rebased PR head: `01e4b88e8abf90344af8daa9aec872a3f7f34515`
Current `upstream/main` base used locally: `aaf5d23883a14f7224b4e9e2ddb513038716bad7`
Environment: Node `v22.22.3`, pnpm `11.2.2`.

Rebase/build:

- `git rebase upstream/main`: completed cleanly.
- `pnpm build`: passed when run outside the sandbox. The first sandboxed build reached the same final metadata phase but failed with sandbox `spawnSync ... EPERM`, so it was rerun unsandboxed.

Requester-path behavior proof from the focused registry seam tests:

- `surfaces a successful delete-mode completion to the requester after retry-limit give-up`
- `surfaces a successful delete-mode completion to the requester after expiry give-up`
- `surfaces delete-mode completion results after announce cleanup gives up`

These cases exercise the actual requester steering queue path after lifecycle give-up: the successful delete-mode completion is retained, the next requester turn receives the captured result instead of `NO_REPLY`, the acknowledgement count is `1`, and the retained run is removed after acknowledgement/cleanup.

Focused verification run on the rebased head:

- `node --no-maglev ./node_modules/vitest/vitest.mjs run --config test/vitest/vitest.agents.config.ts src/agents/agent-steering-queue.test.ts src/agents/subagent-registry-lifecycle.test.ts src/agents/subagent-registry.test.ts`: passed, 205 tests.
- `node --no-maglev ./node_modules/vitest/vitest.mjs run --config test/vitest/vitest.gateway-server.config.ts src/gateway/server-methods-list.test.ts`: passed, 16 tests.
- `node --no-maglev ./node_modules/vitest/vitest.mjs run --config test/vitest/vitest.unit-src.config.ts src/state/openclaw-state-db.test.ts`: passed, 75 tests, rerun outside sandbox because child-process cases hit sandbox `EPERM`.
- `node --no-maglev ./node_modules/vitest/vitest.mjs run --config test/vitest/vitest.agents-support.config.ts src/agents/harness/selection.test.ts`: passed, 99 tests.
- `node --no-maglev ./node_modules/vitest/vitest.mjs run --config test/vitest/vitest.agents.config.ts src/agents/openai-routing.test.ts src/plugins/provider-model-routes.test.ts`: passed, 17 tests.

The currently changed diff remains scoped to 5 files: `src/agents/agent-steering-queue.ts`, `src/agents/subagent-registry-lifecycle.ts`, `src/agents/tools/sessions-send-tokens.ts`, and the two related subagent registry test files.