### PR TITLE
fix(slack): truncate served arg-menu option labels on a surrogate boundary

### DIFF
--- a/extensions/slack/src/monitor/slash.test.ts
+++ b/extensions/slack/src/monitor/slash.test.ts
@@ -215,10 +215,15 @@ vi.mock("./slash-commands.runtime.js", () => {
       if (params.command?.key === "reportexternal") {
         return {
           arg: { name: "period", description: "period" },
-          choices: Array.from({ length: 140 }, (_v, i) => ({
-            value: `period-${i + 1}`,
-            label: `Period ${i + 1}`,
-          })),
+          choices: [
+            ...Array.from({ length: 140 }, (_v, i) => ({
+              value: `period-${i + 1}`,
+              label: `Period ${i + 1}`,
+            })),
+            // Label whose emoji surrogate pair straddles the 75-char plain_text
+            // limit, to cover surrogate-safe truncation in served options.
+            { value: "emoji-overflow", label: `${"a".repeat(74)}😀 emojioverflow` },
+          ],
         };
       }
       if (params.command?.key === "unsafeconfirm") {
@@ -870,6 +875,37 @@ describe("Slack native command argument menus", () => {
     };
     const optionTexts = (optionsPayload.options ?? []).map((option) => option.text?.text ?? "");
     expect(optionTexts.join("\n")).toContain("Period 12");
+  });
+
+  it("truncates served option labels on a surrogate boundary", async () => {
+    const { blockId } = await runCommandAndResolveActionsBlock(reportExternalHandler);
+    expect(blockId).toContain("openclaw_cmdarg_ext:");
+
+    const ackOptions = vi.fn().mockResolvedValue(undefined);
+    await argMenuOptionsHandler({
+      ack: ackOptions,
+      body: {
+        user: { id: "U1" },
+        value: "emojioverflow",
+        actions: [{ block_id: blockId }],
+      },
+    });
+
+    const optionsPayload = firstCallPayload(ackOptions, "options ack") as {
+      options?: Array<{ text?: { text?: string }; value?: string }>;
+    };
+    // The "emojioverflow" query matches only the long emoji label, so exactly one
+    // option is served.
+    const served = optionsPayload.options ?? [];
+    expect(served).toHaveLength(1);
+    const text = served[0]?.text?.text ?? "";
+    // Plain_text option labels are capped at 75 chars and must not end on a lone
+    // surrogate half, which Slack rejects. The label was long enough to truncate.
+    expect(text.length).toBeGreaterThan(0);
+    expect(text.length).toBeLessThanOrEqual(75);
+    expect(
+      /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(text),
+    ).toBe(false);
   });
 
   it("tracks accepted external_select option requests", async () => {

--- a/extensions/slack/src/monitor/slash.ts
+++ b/extensions/slack/src/monitor/slash.ts
@@ -931,7 +931,13 @@ export async function registerSlackMonitorSlashCommands(params: {
         .filter((choice) => !query || normalizeLowercaseStringOrEmpty(choice.label).includes(query))
         .slice(0, SLACK_COMMAND_ARG_SELECT_OPTIONS_MAX)
         .map((choice) => ({
-          text: { type: "plain_text", text: choice.label.slice(0, 75) },
+          // Surrogate-safe cap (matches the static-select path above) so an emoji
+          // straddling the 75-char Slack plain_text limit is dropped whole rather
+          // than serialized as a lone `\uD83D` half that Slack rejects.
+          text: {
+            type: "plain_text",
+            text: truncateSlackText(choice.label, SLACK_COMMAND_ARG_SELECT_OPTION_TEXT_MAX),
+          },
           value: choice.value,
         }));
       await ack({ options });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a Slack slash-command **external (type-ahead) argument menu** can serve an option label with a broken character (a `�` / mangled emoji) — and Slack can reject the whole options response. When the menu has more choices than the static-select limit, the dynamic `app.options()` handler capped each served `plain_text` option label with a raw `choice.label.slice(0, 75)`. If an emoji or other non-BMP character straddles index 75, that slice cuts a UTF-16 surrogate pair in half, leaving a dangling surrogate in a Slack `plain_text` field.

## Why This Change Was Made

The served label now goes through `truncateSlackText(choice.label, SLACK_COMMAND_ARG_SELECT_OPTION_TEXT_MAX)` — the plugin's existing surrogate-safe Slack-text helper (its own doc comment notes it avoids "a lone surrogate half that serializes to an invalid `\uD83D` in the Slack payload"). This is exactly what the **static-select** path in the same file already does (`slash.ts:237`) and what `blocks-render.ts` does for option/button labels; the external/dynamic options path was the one spot the earlier code-point-boundary fix (#96382) didn't cover. No new imports or constants — both the helper and the `75` limit constant were already present and used.

## User Impact

Slack users of long-choice type-ahead command argument menus get clean, valid option labels instead of a broken glyph or a failed menu response when a choice label has an emoji near the 75-character cap. No configuration changes.

## Evidence

### Real terminal proof (standalone, non-test)

Driving the actual `truncateSlackText` (the helper now used for served labels) on a label whose emoji surrogate pair straddles index 75:

```
label length (UTF-16 units): 90

BEFORE  (raw .slice(0, 75) — current main):
  length:           75
  tail code units:  0x0061 0xd83d
  lone surrogate (broken glyph Slack rejects): true

AFTER   (truncateSlackText — this PR):
  length:           75
  tail code units:  0x0061 0x2026
  value tail:       "aaa…"
  lone surrogate:   false

RESULT: PASS — raw slice was broken; fixed label is valid and within 75
```

`0xd83d` is the high-surrogate half of `😀` (`U+1F600`); on `main` it is left dangling at the end of the served `plain_text` label. With the fix the incomplete emoji is dropped and the label ends on a complete character (`0x2026` = `…`).

### Unit test (drives the real options handler)

Added `truncates served option labels on a surrogate boundary` to `slash.test.ts`, which invokes the real external arg-menu `app.options()` handler with a long emoji label and asserts the served `plain_text` text is ≤75 and contains no lone surrogate. `pnpm test extensions/slack/src/monitor/slash.test.ts` → **39 passed**. The new test fails on the unpatched handler (the raw slice leaves a lone surrogate) and passes with the fix.

oxlint and `oxfmt --check` are clean on both changed files.

AI-assisted (Claude Code); change reviewed and understood by the author.