### PR TITLE
fix(agents): xAI/Grok requests fail after a stale reasoning replay ("could not decrypt encrypted_content")

### DIFF
--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -4997,6 +4997,129 @@ describe("openai transport stream", () => {
     });
   });
 
+  it("retries xAI's code-less 'could not decrypt encrypted_content' 400 once without encrypted reasoning content", async () => {
+    const request = {
+      model: "grok-4.3",
+      stream: true,
+      input: [
+        {
+          type: "reasoning",
+          id: "rs_prior",
+          encrypted_content: "ciphertext",
+          summary: [],
+        },
+        {
+          type: "message",
+          id: "msg_prior",
+          role: "assistant",
+          content: [{ type: "output_text", text: "visible answer" }],
+        },
+      ],
+    };
+    const recoveredStream = streamChunks([]);
+    const create = vi
+      .fn()
+      .mockRejectedValueOnce(
+        // xAI/Grok returns no error code — only this prose message — so the match must
+        // come from the message text, not `code`.
+        new OpenAI.BadRequestError(
+          400,
+          {
+            message:
+              "Could not decrypt the provided encrypted_content. Ensure the value is the unmodified encrypted_content from a previous response.",
+            type: "invalid_request_error",
+          },
+          undefined,
+          new Headers(),
+        ),
+      )
+      .mockResolvedValueOnce(recoveredStream);
+
+    await expect(
+      testing.createResponsesStreamWithEncryptedContentRetry({
+        client: { responses: { create } } as never,
+        request: request as never,
+        requestOptions: undefined,
+        model: {
+          id: "grok-4.3",
+          name: "Grok 4.3",
+          api: "openai-responses",
+          provider: "xai",
+          baseUrl: "https://api.x.ai/v1",
+          reasoning: true,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 200_000,
+          maxTokens: 8192,
+        },
+      }),
+    ).resolves.toBe(recoveredStream);
+
+    expect(create).toHaveBeenCalledTimes(2);
+    expect(create.mock.calls[0]?.[0]).toBe(request);
+    expect(create.mock.calls[1]?.[0]).toEqual({
+      ...request,
+      input: [
+        {
+          type: "reasoning",
+          id: "rs_prior",
+          summary: [],
+        },
+        request.input[1],
+      ],
+    });
+  });
+
+  it("does not retry an unrelated 'could not decrypt' error that does not mention encrypted_content", async () => {
+    // Same shape as above (a reasoning item with encrypted_content IS present, so a retry
+    // WOULD strip something) — proving it is the message matcher, not a strip no-op, that
+    // correctly declines: this message has "decrypt" but no "encrypted_content" token.
+    const request = {
+      model: "grok-4.3",
+      stream: true,
+      input: [
+        {
+          type: "reasoning",
+          id: "rs_prior",
+          encrypted_content: "ciphertext",
+          summary: [],
+        },
+      ],
+    };
+    const unrelated = new OpenAI.BadRequestError(
+      400,
+      {
+        message: "Could not decrypt legacy OAuth sidecar for profile foo; re-authenticate this profile.",
+        type: "invalid_request_error",
+      },
+      undefined,
+      new Headers(),
+    );
+    const create = vi.fn().mockRejectedValue(unrelated);
+
+    await expect(
+      testing.createResponsesStreamWithEncryptedContentRetry({
+        client: { responses: { create } } as never,
+        request: request as never,
+        requestOptions: undefined,
+        model: {
+          id: "grok-4.3",
+          name: "Grok 4.3",
+          api: "openai-responses",
+          provider: "xai",
+          baseUrl: "https://api.x.ai/v1",
+          reasoning: true,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 200_000,
+          maxTokens: 8192,
+        },
+      }),
+    ).rejects.toBe(unrelated);
+
+    expect(create).toHaveBeenCalledTimes(1);
+  });
+
   it("normalizes overlong Copilot Responses replay tool ids before dispatch", () => {
     const longToolItemId = "iVec" + "A".repeat(360);
     const longToolCallId = `call_ug6lFGKwZDjHfzW8H0PDQRwN|${longToolItemId}`;

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -4997,127 +4997,30 @@ describe("openai transport stream", () => {
     });
   });
 
-  it("retries xAI's code-less 'could not decrypt encrypted_content' 400 once without encrypted reasoning content", async () => {
-    const request = {
-      model: "grok-4.3",
-      stream: true,
-      input: [
-        {
-          type: "reasoning",
-          id: "rs_prior",
-          encrypted_content: "ciphertext",
-          summary: [],
-        },
-        {
-          type: "message",
-          id: "msg_prior",
-          role: "assistant",
-          content: [{ type: "output_text", text: "visible answer" }],
-        },
-      ],
-    };
-    const recoveredStream = streamChunks([]);
-    const create = vi
-      .fn()
-      .mockRejectedValueOnce(
-        // xAI/Grok returns no error code — only this prose message — so the match must
-        // come from the message text, not `code`.
-        new OpenAI.BadRequestError(
-          400,
-          {
-            message:
-              "Could not decrypt the provided encrypted_content. Ensure the value is the unmodified encrypted_content from a previous response.",
-            type: "invalid_request_error",
-          },
-          undefined,
-          new Headers(),
-        ),
-      )
-      .mockResolvedValueOnce(recoveredStream);
+  it.each([
+    {
+      label: "matches xAI's code-less encrypted-content 400",
+      status: 400,
+      message:
+        "Could not decrypt the provided encrypted_content. Ensure the value is the unmodified encrypted_content from a previous response.",
+      expected: true,
+    },
+    {
+      label: "rejects an unrelated decrypt 400",
+      status: 400,
+      message: "Could not decrypt encrypted_content metadata for the OAuth sidecar.",
+      expected: false,
+    },
+    {
+      label: "rejects the xAI phrase on a 500",
+      status: 500,
+      message: "Could not decrypt the provided encrypted_content.",
+      expected: false,
+    },
+  ])("$label", ({ status, message, expected }) => {
+    const error = OpenAI.APIError.generate(status, { error: message }, undefined, new Headers());
 
-    await expect(
-      testing.createResponsesStreamWithEncryptedContentRetry({
-        client: { responses: { create } } as never,
-        request: request as never,
-        requestOptions: undefined,
-        model: {
-          id: "grok-4.3",
-          name: "Grok 4.3",
-          api: "openai-responses",
-          provider: "xai",
-          baseUrl: "https://api.x.ai/v1",
-          reasoning: true,
-          input: ["text"],
-          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-          contextWindow: 200_000,
-          maxTokens: 8192,
-        },
-      }),
-    ).resolves.toBe(recoveredStream);
-
-    expect(create).toHaveBeenCalledTimes(2);
-    expect(create.mock.calls[0]?.[0]).toBe(request);
-    expect(create.mock.calls[1]?.[0]).toEqual({
-      ...request,
-      input: [
-        {
-          type: "reasoning",
-          id: "rs_prior",
-          summary: [],
-        },
-        request.input[1],
-      ],
-    });
-  });
-
-  it("does not retry an unrelated 'could not decrypt' error that does not mention encrypted_content", async () => {
-    // Same shape as above (a reasoning item with encrypted_content IS present, so a retry
-    // WOULD strip something) — proving it is the message matcher, not a strip no-op, that
-    // correctly declines: this message has "decrypt" but no "encrypted_content" token.
-    const request = {
-      model: "grok-4.3",
-      stream: true,
-      input: [
-        {
-          type: "reasoning",
-          id: "rs_prior",
-          encrypted_content: "ciphertext",
-          summary: [],
-        },
-      ],
-    };
-    const unrelated = new OpenAI.BadRequestError(
-      400,
-      {
-        message: "Could not decrypt legacy OAuth sidecar for profile foo; re-authenticate this profile.",
-        type: "invalid_request_error",
-      },
-      undefined,
-      new Headers(),
-    );
-    const create = vi.fn().mockRejectedValue(unrelated);
-
-    await expect(
-      testing.createResponsesStreamWithEncryptedContentRetry({
-        client: { responses: { create } } as never,
-        request: request as never,
-        requestOptions: undefined,
-        model: {
-          id: "grok-4.3",
-          name: "Grok 4.3",
-          api: "openai-responses",
-          provider: "xai",
-          baseUrl: "https://api.x.ai/v1",
-          reasoning: true,
-          input: ["text"],
-          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-          contextWindow: 200_000,
-          maxTokens: 8192,
-        },
-      }),
-    ).rejects.toBe(unrelated);
-
-    expect(create).toHaveBeenCalledTimes(1);
+    expect(testing.isInvalidEncryptedContentError(error)).toBe(expected);
   });
 
   it("normalizes overlong Copilot Responses replay tool ids before dispatch", () => {

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -812,7 +812,12 @@ function isInvalidEncryptedContentError(error: unknown): boolean {
   return (
     typeof record.message === "string" &&
     (record.message.includes("invalid_encrypted_content") ||
-      record.message.includes("thinking_signature_invalid"))
+      record.message.includes("thinking_signature_invalid") ||
+      // xAI/Grok returns a prose 400 with no error code when a replayed reasoning blob
+      // is stale: "Could not decrypt the provided encrypted_content. Ensure the value is
+      // the unmodified encrypted_content from a previous response." Strip and retry too.
+      (record.message.includes("encrypted_content") &&
+        record.message.toLowerCase().includes("decrypt")))
   );
 }
 

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -805,19 +805,17 @@ function isInvalidEncryptedContentError(error: unknown): boolean {
   if (!error || typeof error !== "object") {
     return false;
   }
-  const record = error as { code?: unknown; message?: unknown };
+  const record = error as { code?: unknown; message?: unknown; status?: unknown };
   if (record.code === "invalid_encrypted_content" || record.code === "thinking_signature_invalid") {
     return true;
   }
+  const message = typeof record.message === "string" ? record.message : "";
   return (
-    typeof record.message === "string" &&
-    (record.message.includes("invalid_encrypted_content") ||
-      record.message.includes("thinking_signature_invalid") ||
-      // xAI/Grok returns a prose 400 with no error code when a replayed reasoning blob
-      // is stale: "Could not decrypt the provided encrypted_content. Ensure the value is
-      // the unmodified encrypted_content from a previous response." Strip and retry too.
-      (record.message.includes("encrypted_content") &&
-        record.message.toLowerCase().includes("decrypt")))
+    message.includes("invalid_encrypted_content") ||
+    message.includes("thinking_signature_invalid") ||
+    // xAI reports this exact prose contract without an error code.
+    (record.status === 400 &&
+      message.toLowerCase().includes("could not decrypt the provided encrypted_content"))
   );
 }
 
@@ -4508,6 +4506,7 @@ export const testing = {
   formatModelTransportDebugBaseUrl,
   buildResponsesFailedNoDetailsObservation,
   buildOpenAIResponsesReasoningReplayMetadata,
+  isInvalidEncryptedContentError,
   normalizeResponsesFailedEvent,
   prepareOpenAIResponsesReasoningItemForReplay,
   createResponsesStreamWithEncryptedContentRetry,


### PR DESCRIPTION
Closes #97925

_AI-assisted by the original contributor; maintainer-reviewed and tightened._

## What Problem This Solves

xAI can reject stale encrypted reasoning replay with a code-less HTTP 400 whose message begins `Could not decrypt the provided encrypted_content`. OpenClaw already strips `encrypted_content` and retries once for known replay-validation errors, but this exact xAI response was not classified as recoverable, so the turn failed instead.

The linked production report also observed a downstream `Circuit breaker open` message. Current OpenClaw source does not implement the claimed model-wide xAI circuit breaker, so this PR intentionally makes only the source-proven request-recovery claim.

## Why This Change Was Made

Extend the existing replay-error classifier at its single owner boundary. The new branch requires both HTTP 400 and xAI's exact case-insensitive phrase, then reuses the existing bounded strip-and-retry path. Existing `invalid_encrypted_content` and `thinking_signature_invalid` code/message handling remains unchanged.

The matcher does not accept a generic decrypt message, and the same phrase on HTTP 500 remains terminal. The retry still occurs only when the request actually contains an `encrypted_content` field to remove.

## User Impact

xAI/Grok Responses turns can transparently recover once from this stale-replay error instead of failing immediately. Unrelated 400s, 500s, requests without encrypted replay content, and other transport failures keep their existing behavior.

## Evidence

- Production evidence in #97925 contains the exact code-less xAI HTTP 400 response.
- Direct inspection of OpenAI SDK 6.39.1 confirms `APIError.generate(400, { error: <string> }, ...)` produces a 400 `BadRequestError` whose message contains that string and whose code/type are absent.
- Tests use that actual SDK factory shape and cover the matching 400, an unrelated decrypt 400, and the matching phrase on 500.
- Existing integration coverage proves a positive replay-error classification triggers exactly one retry with `encrypted_content` stripped.
- Targeted `oxfmt`, `oxlint --deny-warnings`, and `git diff --check`: passed.
- Fresh structured autoreview: clean, no accepted/actionable findings (0.91 confidence).
- Controlled real-key xAI proof: corrupting a genuine encrypted reasoning item returned the exact code-less HTTP 400; replaying the same request with only `encrypted_content` removed returned HTTP 200.
- Secretless fork CI passed at `ddd8feddbbea3995234c5647e084837c4db743bf` in [run 29075725109](https://github.com/openclaw/openclaw/actions/runs/29075725109).
