### PR TITLE
fix(auto-reply): stop level directives from eating the next message word

### DIFF
--- a/src/auto-reply/reply.directive.parse.test.ts
+++ b/src/auto-reply/reply.directive.parse.test.ts
@@ -307,3 +307,48 @@ describe("directive parsing", () => {
     expect(res.cleaned).toBe("line 1\nline 2\n\nline 3");
   });
 });
+
+describe("level directive preserves message text after an invalid level", () => {
+  it("keeps the message when /verbose is followed by prose", () => {
+    const res = parseInlineDirectives("/verbose explain quantum computing");
+    expect(res.hasVerboseDirective).toBe(true);
+    expect(res.verboseLevel).toBeUndefined();
+    expect(res.rawVerboseLevel).toBeUndefined();
+    expect(res.cleaned).toBe("explain quantum computing");
+  });
+
+  it("keeps the next line when /verbose is on its own line", () => {
+    const res = extractVerboseDirective("/verbose\nSummarize this document");
+    expect(res.hasDirective).toBe(true);
+    expect(res.verboseLevel).toBeUndefined();
+    expect(res.cleaned).toBe("Summarize this document");
+  });
+
+  it("keeps the message when /think is followed by prose", () => {
+    const res = extractThinkDirective("/think about my deployment plan");
+    expect(res.hasDirective).toBe(true);
+    expect(res.thinkLevel).toBeUndefined();
+    expect(res.rawLevel).toBeUndefined();
+    expect(res.cleaned).toBe("about my deployment plan");
+  });
+
+  it("still consumes a valid level argument", () => {
+    const res = extractThinkDirective("/think high");
+    expect(res.hasDirective).toBe(true);
+    expect(res.thinkLevel).toBe("high");
+    expect(res.cleaned).toBe("");
+  });
+
+  it("still consumes off so it persists rather than clears", () => {
+    const elevated = extractElevatedDirective("hello there /elevated off");
+    expect(elevated.elevatedLevel).toBe("off");
+    expect(elevated.cleaned).toBe("hello there");
+  });
+
+  it("still reports a single unrecognized trailing token", () => {
+    const res = extractElevatedDirective("/elevated maybe");
+    expect(res.hasDirective).toBe(true);
+    expect(res.elevatedLevel).toBeUndefined();
+    expect(res.rawLevel).toBe("maybe");
+  });
+});

--- a/src/auto-reply/reply/directives.ts
+++ b/src/auto-reply/reply/directives.ts
@@ -37,14 +37,15 @@ const STATUS_DIRECTIVE_PATTERN = compileDirectivePattern(["status"], `(?:\\s*:\\
 const matchLevelDirective = (
   body: string,
   pattern: RegExp,
+  normalize: (raw?: string) => unknown,
 ): { start: number; end: number; rawLevel?: string } | null => {
   const match = body.match(pattern);
   if (!match || match.index === undefined) {
     return null;
   }
   const start = match.index;
-  let end = match.index + match[0].length;
-  let i = end;
+  const directiveEnd = match.index + match[0].length;
+  let i = directiveEnd;
   while (i < body.length && /\s/.test(body[i])) {
     i += 1;
   }
@@ -58,9 +59,14 @@ const matchLevelDirective = (
   while (i < body.length && /[A-Za-z-]/.test(body[i])) {
     i += 1;
   }
-  const rawLevel = i > argStart ? body.slice(argStart, i) : undefined;
-  end = i;
-  return { start, end, rawLevel };
+  const candidate = i > argStart ? body.slice(argStart, i) : undefined;
+  if (
+    candidate !== undefined &&
+    (normalize(candidate) !== undefined || body.slice(i).trim().length === 0)
+  ) {
+    return { start, end: i, rawLevel: candidate };
+  }
+  return { start, end: argStart };
 };
 
 const extractLevelDirective = <T>(
@@ -68,7 +74,7 @@ const extractLevelDirective = <T>(
   pattern: RegExp,
   normalize: (raw?: string) => T | undefined,
 ): ExtractedLevel<T> => {
-  const match = matchLevelDirective(body, pattern);
+  const match = matchLevelDirective(body, pattern, normalize);
   if (!match) {
     return { cleaned: body.trim(), hasDirective: false };
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users who combine a level directive with a message in one turn would have the first word of their message silently dropped before it reaches the agent. Typing `/verbose explain quantum computing` sent the agent `quantum computing`, and `/think about my deployment plan` arrived as `my deployment plan`. Because the whitespace scan also crossed newlines, putting the directive on its own line, such as `/verbose` followed by `Summarize this document`, dropped `Summarize` as well. In every case the directive itself was a no-op (the trailing token was not a valid level), so the user lost a word and changed nothing.

## Why This Change Was Made

`matchLevelDirective` in `src/auto-reply/reply/directives.ts` always consumed the token after the directive as the level argument and `extractLevelDirective` stripped it from the body regardless of whether it was a valid level. The fix threads the level validator into `matchLevelDirective` and only consumes the trailing token when it normalizes to a valid level or is the sole remaining token. When two or more words follow the directive, the directive acts argument-less and the message text is preserved intact. This matches the sibling exec and queue parsers, which deliberately stop at an unrecognized token, while keeping the existing single-token affordances: the unrecognized-level hint (such as `/elevated maybe`) and the `default` / `inherit` clear sentinels still work because a lone trailing token is still treated as the argument.

## User Impact

Users can now prefix a real message with a level directive without losing the first word. `/verbose explain quantum computing` reaches the agent as `explain quantum computing`, and a directive on its own line no longer eats the start of the next line. Valid usage is unchanged: `/think high` still sets the level and strips cleanly, `/think off` still persists off, `/elevated maybe` still returns the unrecognized-level hint, and `/think default` still clears to the session default.

## Evidence

Driving the real `parseInlineDirectives` production entry point (the function that feeds the cleaned body to the agent) on identical inputs, pristine main at 15de9d881a versus this patch:

```
# BEFORE (pristine main 15de9d881a)
input="/verbose explain quantum computing" -> cleaned="quantum computing"
input="/verbose\nSummarize this document"  -> cleaned="this document"
input="/think about my deployment plan"    -> cleaned="my deployment plan"
input="/think high"                         -> cleaned="" think=high
input="/elevated maybe"                     -> cleaned="" rawElevated=maybe

# AFTER (this patch, identical inputs)
input="/verbose explain quantum computing" -> cleaned="explain quantum computing"
input="/verbose\nSummarize this document"  -> cleaned="Summarize this document"
input="/think about my deployment plan"    -> cleaned="about my deployment plan"
input="/think high"                         -> cleaned="" think=high
input="/elevated maybe"                     -> cleaned="" rawElevated=maybe
```

The three buggy rows recover the dropped word while the two control rows (`/think high` consuming a valid level, `/elevated maybe` reporting an unrecognized token) are byte-identical before and after, isolating the change to the defect.

### Validation

- `node scripts/run-vitest.mjs src/auto-reply/reply.directive.parse.test.ts` (47 passed; the three new word-preservation cases fail on pristine main, pass with the patch).
- Adjacent suites green with no regression: `directive-handling.levels.test.ts`, `directive-handling.model.test.ts` (covers persists thinkingLevel=off), `reply.directive.directive-behavior.shows-current-verbose-level-verbose-has-no.test.ts` (covers the Unrecognized elevated level hint), plus the remaining `directive-handling.*` and `get-reply-directive*` suites.
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json` and `oxfmt --check` clean on both changed files.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json` and `-p test/tsconfig/tsconfig.core.test.json` both clean.
