### PR TITLE
fix: count harness context in overflow guard

### DIFF
--- a/src/agents/embedded-agent-runner/tool-result-char-estimator.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-char-estimator.test.ts
@@ -2,11 +2,34 @@
 // character estimates used by context pressure guards.
 import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
 import { describe, expect, it } from "vitest";
+import { convertToLlm } from "../../../packages/agent-core/src/harness/messages.js";
 import {
   createMessageCharEstimateCache,
   estimateMessageCharsCached,
   getToolResultText,
 } from "./tool-result-char-estimator.js";
+
+function providerRenderedTextChars(message: AgentMessage): number {
+  const [llm] = convertToLlm([message]);
+  const content = (llm as { content?: unknown } | undefined)?.content;
+  if (typeof content === "string") {
+    return content.length;
+  }
+  if (!Array.isArray(content)) {
+    return 0;
+  }
+  return content.reduce((sum, block) => {
+    if (
+      block &&
+      typeof block === "object" &&
+      (block as { type?: unknown }).type === "text" &&
+      typeof (block as { text?: unknown }).text === "string"
+    ) {
+      return sum + (block as { text: string }).text.length;
+    }
+    return sum;
+  }, 0);
+}
 
 /**
  * Regression tests for malformed tool result content blocks.
@@ -66,5 +89,77 @@ describe("tool-result-char-estimator", () => {
     const cache = createMessageCharEstimateCache();
     const chars = estimateMessageCharsCached(msg, cache);
     expect(chars).toBe(22);
+  });
+
+  it("estimates bashExecution from the provider-rendered context text", () => {
+    const msg = {
+      role: "bashExecution",
+      command: "npm run build",
+      output: "build log line\n".repeat(100),
+      exitCode: 0,
+      cancelled: false,
+      truncated: false,
+      timestamp: Date.now(),
+    } as unknown as AgentMessage;
+
+    const cache = createMessageCharEstimateCache();
+    const chars = estimateMessageCharsCached(msg, cache);
+
+    expect(chars).toBe(providerRenderedTextChars(msg));
+    expect(chars).toBeGreaterThan(256);
+  });
+
+  it("drops bashExecution messages excluded from model context", () => {
+    const msg = {
+      role: "bashExecution",
+      command: "npm run build",
+      output: "build log line\n".repeat(100),
+      exitCode: 0,
+      cancelled: false,
+      truncated: false,
+      timestamp: Date.now(),
+      excludeFromContext: true,
+    } as unknown as AgentMessage;
+
+    const cache = createMessageCharEstimateCache();
+    expect(estimateMessageCharsCached(msg, cache)).toBe(0);
+  });
+
+  it.each([
+    [
+      "compactionSummary",
+      {
+        role: "compactionSummary",
+        summary: "recap ".repeat(100),
+        tokensBefore: 12,
+        timestamp: Date.now(),
+      },
+    ],
+    [
+      "branchSummary",
+      {
+        role: "branchSummary",
+        summary: "branch recap ".repeat(100),
+        fromId: "branch-1",
+        timestamp: Date.now(),
+      },
+    ],
+    [
+      "custom",
+      {
+        role: "custom",
+        customType: "notice",
+        content: "custom context ".repeat(100),
+        display: true,
+        timestamp: Date.now(),
+      },
+    ],
+  ])("estimates %s from the provider-rendered context text", (_role, message) => {
+    const msg = message as unknown as AgentMessage;
+    const cache = createMessageCharEstimateCache();
+    const chars = estimateMessageCharsCached(msg, cache);
+
+    expect(chars).toBe(providerRenderedTextChars(msg));
+    expect(chars).toBeGreaterThan(256);
   });
 });

--- a/src/agents/embedded-agent-runner/tool-result-char-estimator.ts
+++ b/src/agents/embedded-agent-runner/tool-result-char-estimator.ts
@@ -1,7 +1,14 @@
 /**
  * Estimates message and tool-result character costs for context guards.
  */
-import type { AgentMessage } from "../runtime/index.js";
+import type { AgentMessage, BashExecutionMessage } from "../runtime/index.js";
+import {
+  BRANCH_SUMMARY_PREFIX,
+  BRANCH_SUMMARY_SUFFIX,
+  bashExecutionToText,
+  COMPACTION_SUMMARY_PREFIX,
+  COMPACTION_SUMMARY_SUFFIX,
+} from "../runtime/index.js";
 
 export const CHARS_PER_TOKEN_ESTIMATE = 4;
 export const TOOL_RESULT_CHARS_PER_TOKEN_ESTIMATE = 2;
@@ -137,6 +144,35 @@ function estimateMessageChars(msg: AgentMessage): number {
       chars * (CHARS_PER_TOKEN_ESTIMATE / TOOL_RESULT_CHARS_PER_TOKEN_ESTIMATE),
     );
     return Math.max(chars, weightedChars);
+  }
+
+  const record = msg as unknown as Record<string, unknown>;
+  if (record.role === "bashExecution") {
+    if (record.excludeFromContext === true) {
+      return 0;
+    }
+    return bashExecutionToText(record as unknown as BashExecutionMessage).length;
+  }
+
+  if (record.role === "branchSummary") {
+    const summary = typeof record.summary === "string" ? record.summary : "";
+    return (BRANCH_SUMMARY_PREFIX + summary + BRANCH_SUMMARY_SUFFIX).length;
+  }
+
+  if (record.role === "compactionSummary") {
+    const summary = typeof record.summary === "string" ? record.summary : "";
+    return (COMPACTION_SUMMARY_PREFIX + summary + COMPACTION_SUMMARY_SUFFIX).length;
+  }
+
+  if (record.role === "custom") {
+    const content = record.content;
+    if (typeof content === "string") {
+      return content.length;
+    }
+    if (Array.isArray(content)) {
+      return estimateContentBlockChars(content);
+    }
+    return 0;
   }
 
   return 256;

--- a/src/agents/embedded-agent-runner/tool-result-context-guard.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-context-guard.test.ts
@@ -25,6 +25,27 @@ function makeUser(text: string): AgentMessage {
   });
 }
 
+function makeBashExecution(output: string): AgentMessage {
+  return castAgentMessage({
+    role: "bashExecution",
+    command: "npm run build",
+    output,
+    exitCode: 0,
+    cancelled: false,
+    truncated: false,
+    timestamp: Date.now(),
+  });
+}
+
+function makeCompactionSummary(summary: string): AgentMessage {
+  return castAgentMessage({
+    role: "compactionSummary",
+    summary,
+    tokensBefore: 12_345,
+    timestamp: Date.now(),
+  });
+}
+
 function makeToolResult(id: string, text: string, toolName = "grep"): AgentMessage {
   return castAgentMessage({
     role: "toolResult",
@@ -280,6 +301,18 @@ describe("installToolResultContextGuard", () => {
       PREEMPTIVE_CONTEXT_OVERFLOW_MESSAGE,
     );
     expect(getToolResultText(contextForNextCall[1])).toBe("x".repeat(5_000));
+  });
+
+  it("throws a preemptive overflow for large provider-rendered harness messages", async () => {
+    const agent = makeGuardableAgent();
+    const contextForNextCall = [
+      makeCompactionSummary("summary ".repeat(40_000)),
+      makeBashExecution("build log line\n".repeat(40_000)),
+    ];
+
+    await expect(applyGuardToContext(agent, contextForNextCall, 100_000)).rejects.toThrow(
+      PREEMPTIVE_CONTEXT_OVERFLOW_MESSAGE,
+    );
   });
 
   it("throws instead of rewriting older tool results under aggregate pressure", async () => {


### PR DESCRIPTION
Closes #97927

AI-assisted.

## What Problem This Solves

Fixes an issue where embedded agent turns could submit an over-window prompt during a tool loop when most of the pending transcript was carried by harness roles such as `bashExecution`, `compactionSummary`, `branchSummary`, or `custom`.

Those roles are rendered into provider-visible user messages before model submission, but the in-loop overflow guard estimated them as a flat 256 characters each. A large bash output or compaction summary could therefore bypass the fallback overflow protection even though the provider-bound prompt was already too large.

## Why This Change Was Made

The tool-result char estimator now sizes the affected harness roles from the same rendered text contract used by `convertToLlm`, including returning zero for `bashExecution` entries marked `excludeFromContext`. This keeps the fix at the guard estimator boundary and leaves tool-result truncation, pre-prompt compaction routing, and provider conversion behavior unchanged.

## User Impact

Long-running agent sessions get a more reliable last-resort context overflow guard during tool loops. Instead of allowing oversized summary/bash/custom transcript content to reach the model request, OpenClaw now detects the pressure consistently with equivalent provider-rendered user messages.

## Evidence

Real guard proof, using `installToolResultContextGuard` directly with a ~1.26M rendered-character payload and `contextWindowTokens=100000` (`maxContextChars=360000`):

```json
// patch temporarily reversed to current-main behavior
{
  "contextWindowTokens": 100000,
  "maxContextChars": 360000,
  "renderedChars": 1260135,
  "harnessGuardThrows": false,
  "visibleGuardThrows": true
}

// after this patch
{
  "contextWindowTokens": 100000,
  "maxContextChars": 360000,
  "renderedChars": 1260135,
  "harnessGuardThrows": true,
  "visibleGuardThrows": true
}
```

Focused validation:

```text
node scripts/run-vitest.mjs src/agents/embedded-agent-runner/tool-result-char-estimator.test.ts
[test] passed 1 Vitest shard; 9 tests passed

node scripts/run-vitest.mjs src/agents/embedded-agent-runner/tool-result-context-guard.test.ts
[test] passed 1 Vitest shard; 46 tests passed

oxfmt --check --threads=1 src/agents/embedded-agent-runner/tool-result-char-estimator.ts src/agents/embedded-agent-runner/tool-result-char-estimator.test.ts src/agents/embedded-agent-runner/tool-result-context-guard.test.ts
All matched files use the correct format.

oxlint --type-aware --tsconfig config/tsconfig/oxlint.json --report-unused-disable-directives-severity error --threads=1 src/agents/embedded-agent-runner/tool-result-char-estimator.ts src/agents/embedded-agent-runner/tool-result-char-estimator.test.ts src/agents/embedded-agent-runner/tool-result-context-guard.test.ts
passed

tsgo -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo --declaration false
passed

tsgo -p test/tsconfig/tsconfig.test.src.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-src.tsbuildinfo --declaration false
passed

node scripts/build-all.mjs
passed; phase timings total 175.9s

.agents/skills/autoreview/scripts/autoreview --mode local
autoreview clean: no accepted/actionable findings reported
```

Live local agent smoke with the configured DeepSeek profile:

```text
node dist/entry.js agent --local --agent main --model deepseek/deepseek-v4-pro --message "Reply exactly: openclaw-smoke-ok" --json --timeout 120
provider=deepseek model=deepseek-v4-pro status=200
finalAssistantVisibleText=openclaw-smoke-ok
stopReason=stop
```
