### PR TITLE
fix(gateway): keep provider-owned CLI sessions across the daily default reset

### DIFF
--- a/src/config/sessions/entry-freshness.ts
+++ b/src/config/sessions/entry-freshness.ts
@@ -45,7 +45,7 @@ export type ResolvedSessionEntryResetFreshness =
       resetType: SessionResetType;
     };
 
-function hasProviderOwnedSession(entry: SessionEntry | undefined): boolean {
+export function hasProviderOwnedSession(entry: SessionEntry | undefined): boolean {
   const provider = normalizeOptionalString(entry?.providerOverride ?? entry?.modelProvider);
   return Boolean(provider && getCliSessionBinding(entry, provider));
 }

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -4060,6 +4060,61 @@ describe("gateway agent handler", () => {
     }
   });
 
+  it("keeps a provider-owned CLI session across the daily default boundary on the gateway path", async () => {
+    const now = Date.parse("2026-04-25T12:00:00.000Z");
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    try {
+      mocks.resolveExplicitAgentSessionKey.mockReturnValue("agent:main:main");
+      mockMainSessionEntry({
+        sessionId: "provider-owned-session-id",
+        updatedAt: now,
+        sessionStartedAt: now - 25 * 60 * 60_000,
+        lastInteractionAt: now - 25 * 60 * 60_000,
+        modelProvider: "claude-cli",
+        cliSessionBindings: { "claude-cli": { sessionId: "claude-cli-conversation-123" } },
+      });
+      const loaded = mocks.loadSessionEntry();
+      let capturedEntry: Record<string, unknown> | undefined;
+      mocks.updateSessionStore.mockImplementation(async (_path, updater) => {
+        const store: Record<string, unknown> = {
+          [loaded.canonicalKey]: structuredClone(loaded.entry),
+        };
+        const result = await updater(store);
+        capturedEntry = result as Record<string, unknown>;
+        return result;
+      });
+      mocks.agentCommand.mockResolvedValue({
+        payloads: [{ text: "ok" }],
+        meta: { durationMs: 100 },
+      });
+
+      await invokeAgent(
+        {
+          message: "provider-owned daily boundary",
+          agentId: "main",
+          sessionKey: "agent:main:main",
+          idempotencyKey: "provider-owned-daily-boundary",
+        },
+        { reqId: "provider-owned-daily-boundary" },
+      );
+
+      const call = await waitForAgentCommandCall<{
+        sessionId?: string;
+        sessionKey?: string;
+      }>();
+      expect(call.sessionKey).toBe("agent:main:main");
+      expect(call.sessionId).toBe("provider-owned-session-id");
+      expect(capturedEntry?.sessionStartedAt).toBe(now - 25 * 60 * 60_000);
+      expect(capturedEntry?.cliSessionBindings).toMatchObject({
+        "claude-cli": { sessionId: "claude-cli-conversation-123" },
+      });
+      expect(mocks.emitGatewaySessionEndPluginHook).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("emits idle lifecycle reason when inactivity rotates a gateway agent session", async () => {
     const now = Date.parse("2026-04-25T12:00:00.000Z");
     vi.useFakeTimers();

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -71,8 +71,10 @@ import {
   resolveSessionResetPolicy,
   resolveSessionResetType,
   type SessionEntry,
+  type SessionFreshness,
   updateSessionStore,
 } from "../../config/sessions.js";
+import { hasProviderOwnedSession } from "../../config/sessions/entry-freshness.js";
 import { resolveMaintenanceConfigFromInput } from "../../config/sessions/store-maintenance.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
@@ -1814,13 +1816,17 @@ export const agentHandlers: GatewayRequestHandlers = {
               agentId: canonicalSessionAgentId,
             })
           : undefined;
+        const skipImplicitExpiry =
+          resetPolicy.configured !== true && hasProviderOwnedSession(entry);
         let freshness = entry
-          ? evaluateSessionFreshness({
-              updatedAt: entry.updatedAt,
-              ...lifecycleTimestamps,
-              now,
-              policy: resetPolicy,
-            })
+          ? skipImplicitExpiry
+            ? ({ fresh: true } satisfies SessionFreshness)
+            : evaluateSessionFreshness({
+                updatedAt: entry.updatedAt,
+                ...lifecycleTimestamps,
+                now,
+                policy: resetPolicy,
+              })
           : undefined;
         const visibleRequest =
           request.bootstrapContextRunKind !== "cron" &&
@@ -2005,13 +2011,17 @@ export const agentHandlers: GatewayRequestHandlers = {
                 agentId: sessionAgent,
               })
             : undefined;
+          const freshSkipImplicitExpiry =
+            resetPolicy.configured !== true && hasProviderOwnedSession(freshEntry);
           const freshFreshness = freshEntry
-            ? evaluateSessionFreshness({
-                updatedAt: freshEntry.updatedAt,
-                ...freshLifecycleTimestamps,
-                now,
-                policy: resetPolicy,
-              })
+            ? freshSkipImplicitExpiry
+              ? ({ fresh: true } satisfies SessionFreshness)
+              : evaluateSessionFreshness({
+                  updatedAt: freshEntry.updatedAt,
+                  ...freshLifecycleTimestamps,
+                  now,
+                  policy: resetPolicy,
+                })
             : undefined;
           const freshRequestedSessionMatchesEntry = Boolean(
             requestedSessionId && freshEntry?.sessionId?.trim() === requestedSessionId,


### PR DESCRIPTION
Related: #70106

## What Problem This Solves

Fixes an issue where users with an active provider-owned CLI session (claude-cli, and likewise codex and gemini-cli) under the default reset configuration lose their conversation after the daily 4am boundary whenever the turn is driven through the gateway, that is dashboard webchat, the `openclaw agent` CLI, ACP, the control UI, and cron or heartbeat runs. The provider-side conversation binding is dropped and the transcript rotates even though the user never requested a reset.

The documented contract is that these sessions are exempt from the implicit daily default:

- docs/concepts/session.md: "Sessions with an active provider-owned CLI session are not cut by the implicit daily default."
- docs/gateway/cli-backends.md: "The implicit daily session reset does not cut them; /reset and explicit session.reset policies still do."

The inbound auto-reply path already honors this exemption. Only the gateway path violated it, so the same session would survive on an inbound message but rotate when the next turn came through the gateway.

## Why This Change Was Made

The provider-owned skip exists in the canonical helper (`src/config/sessions/entry-freshness.ts`) and is mirrored by the inbound path (`src/auto-reply/reply/session.ts`), but the gateway `agent.run` handler called `evaluateSessionFreshness` directly at both of its freshness decision sites with no provider-owned guard. When freshness resolved to stale, the gateway minted a new session id, set the rotation flag, and cleared all CLI session bindings. This change routes both gateway freshness decisions through the same `resetPolicy.configured !== true && hasProviderOwnedSession(entry)` skip the inbound path uses, reusing the canonical predicate (now exported) rather than adding a third copy. Explicit `session.reset` policies and `/reset` are unaffected because the skip only applies when reset is not explicitly configured.

## User Impact

Provider-owned CLI sessions are no longer silently rotated at the daily boundary when a turn arrives through the gateway. The provider-side conversation binding and transcript are preserved, matching the inbound path and the documented behavior. Users who want timed expiry of these sessions still get it by configuring `session.reset` or by running `/reset`.

## Evidence

- New colocated regression test in `src/gateway/server-methods/agent.test.ts` drives the real `agentHandlers.agent` handler with a provider-owned entry under the default reset config past the daily boundary; it fails on pristine main (session rotated, binding dropped) and passes with this patch.
- Local gates on the changed files: oxlint clean, oxfmt clean, tsgo core and core-test clean.
- Real before/after runtime output captured below.

## Root cause

`src/gateway/server-methods/agent.ts` resolved freshness directly at both decision sites with no provider-owned guard (before):

```ts
let freshness = entry
  ? evaluateSessionFreshness({
      updatedAt: entry.updatedAt,
      ...lifecycleTimestamps,
      now,
      policy: resetPolicy,
    })
  : undefined;
```

```ts
const freshFreshness = freshEntry
  ? evaluateSessionFreshness({
      updatedAt: freshEntry.updatedAt,
      ...freshLifecycleTimestamps,
      now,
      policy: resetPolicy,
    })
  : undefined;
```

Once `freshness.fresh` is false the handler sets `canReuseSession = false`, mints a new session id, flags the rotation, and clears all CLI session bindings.

## Fix

Both sites gate the freshness call with the same skip the inbound path applies (after):

```ts
const skipImplicitExpiry =
  resetPolicy.configured !== true && hasProviderOwnedSession(entry);
let freshness = entry
  ? skipImplicitExpiry
    ? ({ fresh: true } satisfies SessionFreshness)
    : evaluateSessionFreshness({ ... })
  : undefined;
```

`hasProviderOwnedSession` is exported from `src/config/sessions/entry-freshness.ts` and reused, so the predicate has one shared definition rather than a third duplicate.

## Why this is the right boundary

The gateway is the surface that diverged from the canonical helper and the inbound mirror. Routing both gateway freshness decisions through the same predicate restores a single behavior across surfaces. Both gateway call sites are fixed consistently (initial freshness and the post-build `freshFreshness`). The inbound path (`session.ts`) already had the skip and is unchanged. Explicit `session.reset` and `/reset` paths keep cutting these sessions because the skip is gated on `resetPolicy.configured !== true`.

## Verification

- `node scripts/run-vitest.mjs src/gateway/server-methods/agent.test.ts -t "provider-owned CLI session across the daily default boundary"`: passes with the patch, fails on pristine main.
- `node scripts/run-oxlint.mjs <changed files>`: clean.
- `oxfmt --check <changed files>`: clean.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json` and `-p test/tsconfig/tsconfig.core.test.json`: clean.

## Real behavior proof
Behavior addressed: a provider-owned claude-cli session under the default reset config is rotated and its CLI binding dropped after the daily 4am boundary when the turn is driven through the gateway agent.run handler, despite the documented provider-owned exemption.
Real environment tested: drove the real `agentHandlers.agent` gateway handler (src/gateway/server-methods/agent.ts) on pristine main 843ad14364 and on the patched tree with identical inputs; the real freshness resolver, reset-policy resolver, provider-owned predicate, and CLI-session-binding lookup all stayed real; only the session store writer and the downstream agent command were stubbed to capture the resolved session identity and lifecycle hook.
Exact steps or command run after this patch: invoked the gateway agent handler with a provider-owned entry (modelProvider claude-cli, cliSessionBindings claude-cli to a conversation id) whose session started 25 hours before a fixed now of 2026-04-25T12:00:00Z, under the default reset config, then recorded the resolved run session id, the persisted cliSessionBindings, the lifecycle end hook, and the persisted sessionStartedAt.
Evidence after fix:
```
# BEFORE (pristine main 843ad14364)
storedSessionId=provider-owned-session-id
resolvedRunSessionId=51375be8-8727-4841-b302-df350fc23946
sessionRotated=true
cliBindingClaudeCli=DROPPED
sessionEndHookFired=true
storedSessionStartedAt=1777118400000 originalStartedAt=1777028400000

# AFTER (this patch, identical inputs)
storedSessionId=provider-owned-session-id
resolvedRunSessionId=provider-owned-session-id
sessionRotated=false
cliBindingClaudeCli=claude-cli-conversation-123
sessionEndHookFired=false
storedSessionStartedAt=1777028400000 originalStartedAt=1777028400000
```
Observed result after fix: the gateway now resolves the run to the existing session id, preserves the claude-cli conversation binding, fires no session-end lifecycle hook, and leaves the original session start time intact, so the provider-owned session is no longer cut by the implicit daily default.
What was not tested: no live claude-cli provider request was issued; the persistence writer and downstream agent command were stubbed; full build was not run.
