### PR TITLE
Fix subagent announce restart recovery cascade

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -1526,6 +1526,15 @@ describe("Codex app-server dynamic tool build", () => {
     expect(shouldEnableCodexAppServerNativeToolSurface(params)).toBe(false);
   });
 
+  it("disables Codex native tool surfaces when all tools are disabled", () => {
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
+    params.disableTools = true;
+    params.toolsAllow = undefined;
+
+    expect(shouldEnableCodexAppServerNativeToolSurface(params)).toBe(false);
+  });
+
   it("keeps Codex native tool surfaces when the effective exec target is node", () => {
     const workspaceDir = path.join(tempDir, "workspace");
     const sessionParams = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -508,6 +508,9 @@ export function shouldEnableCodexAppServerNativeToolSurface(
   if (isCodexMemoryFlushRun(params)) {
     return false;
   }
+  if (params.disableTools) {
+    return false;
+  }
   const toolsAllow = includeForcedCodexDynamicToolAllow(params.toolsAllow, params);
   if (toolsAllow === undefined) {
     return canCodexAppServerNativeToolSurfaceHonorSandbox(sandbox, options);

--- a/src/agents/announce-idempotency.ts
+++ b/src/agents/announce-idempotency.ts
@@ -12,7 +12,20 @@ export function buildAnnounceIdFromChildRun(params: AnnounceIdFromChildRunParams
   return `v1:${params.childSessionKey}:${params.childRunId}`;
 }
 
+const ANNOUNCE_IDEMPOTENCY_KEY_PREFIX = "announce:";
+
 /** Build the idempotency key used by announce delivery storage. */
 export function buildAnnounceIdempotencyKey(announceId: string): string {
-  return `announce:${announceId}`;
+  return `${ANNOUNCE_IDEMPOTENCY_KEY_PREFIX}${announceId}`;
+}
+
+/**
+ * True when a gateway run id belongs to an announce/completion delivery turn.
+ * The `agent` method reuses the idempotency key as the run id
+ * (`server-methods/agent.ts`: `runId = idem`), so this prefix check is the only
+ * announce-vs-human-turn signal that survives a gateway restart into persisted
+ * `restartRecoveryRuns`.
+ */
+export function isAnnounceRunId(runId: string | null | undefined): boolean {
+  return typeof runId === "string" && runId.startsWith(ANNOUNCE_IDEMPOTENCY_KEY_PREFIX);
 }

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -2198,6 +2198,74 @@ describe("CLI attempt execution", () => {
     });
   });
 
+  it("forwards subagent announce tool isolation into CLI attempts", async () => {
+    const sessionKey = "agent:main:direct:claude-announce-tools-disabled";
+    const sessionEntry: SessionEntry = {
+      sessionId: "openclaw-session-cli-announce-tools-disabled",
+      updatedAt: Date.now(),
+    };
+    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
+    await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2), "utf-8");
+    runCliAgentMock.mockResolvedValueOnce(makeCliResult("tool-free announce cli"));
+
+    await runAgentAttempt({
+      providerOverride: "claude-cli",
+      originalProvider: "claude-cli",
+      modelOverride: "opus",
+      cfg: {} as OpenClawConfig,
+      sessionEntry,
+      sessionId: sessionEntry.sessionId,
+      sessionKey,
+      sessionAgentId: "main",
+      sessionFile: path.join(tmpDir, "session.jsonl"),
+      workspaceDir: tmpDir,
+      body: "A background task finished. Process the completion update now.",
+      isFallbackRetry: false,
+      resolvedThinkLevel: "medium",
+      timeoutMs: 1_000,
+      runId: "run-cli-announce-tools-disabled",
+      disableTools: true,
+      opts: {
+        inputProvenance: {
+          kind: "inter_session",
+          sourceSessionKey: "agent:openclaw:subagent:child",
+          sourceChannel: "internal",
+          sourceTool: "subagent_announce",
+        },
+        internalEvents: [
+          {
+            type: "task_completion",
+            source: "subagent",
+            childSessionKey: "agent:openclaw:subagent:child",
+            announceType: "completion",
+            taskLabel: "read-only review",
+            status: "ok",
+            statusLabel: "completed",
+            result: "child output",
+            replyInstruction: "Relay this completion.",
+          },
+        ],
+      } as Parameters<typeof runAgentAttempt>[0]["opts"],
+      runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
+      spawnedBy: undefined,
+      messageChannel: "telegram",
+      skillsSnapshot: undefined,
+      resolvedVerboseLevel: undefined,
+      agentDir: tmpDir,
+      onAgentEvent: vi.fn(),
+      authProfileProvider: "claude-cli",
+      sessionStore,
+      storePath,
+      sessionHasHistory: false,
+    });
+
+    expectMockArgFields(runCliAgentMock, {
+      provider: "claude-cli",
+      disableTools: true,
+    });
+    expect(runEmbeddedAgentMock).not.toHaveBeenCalled();
+  });
+
   it("stamps CLI prompts with current timestamp context", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2024-06-05T15:30:00Z"));

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -74,6 +74,7 @@ import { buildAgentRuntimeAuthPlan } from "../runtime-plan/auth.js";
 import type { AgentMessage } from "../runtime/index.js";
 import { withLocalSessionPlacementTurnAdmission } from "../session-placement-admission.js";
 import { buildUsageWithNoCost } from "../stream-message-shared.js";
+import { isSubagentAnnounceCompletionHandoff } from "../subagent-announce-handoff.js";
 import {
   buildClaudeCliFallbackContextPrelude,
   claudeCliSessionTranscriptHasContent,
@@ -474,6 +475,8 @@ export function runAgentAttempt(params: {
   runTimeoutOverrideMs?: number;
   runId: string;
   lifecycleGeneration: string;
+  /** Run this attempt LLM-only (no built-in tools), e.g. an announce relay turn. */
+  disableTools?: boolean;
   opts: AgentCommandOpts;
   runContext: ReturnType<typeof resolveAgentRunContext>;
   spawnedBy: string | undefined;
@@ -964,7 +967,13 @@ export function runAgentAttempt(params: {
     oneShotCliRun: params.opts.oneShotCliRun,
     modelRun: params.opts.modelRun,
     promptMode: params.opts.promptMode,
-    disableTools: params.opts.modelRun === true,
+    disableTools:
+      params.opts.modelRun === true ||
+      params.disableTools === true ||
+      isSubagentAnnounceCompletionHandoff({
+        inputProvenance: params.opts.inputProvenance,
+        internalEvents: params.opts.internalEvents,
+      }),
     onAgentEvent: params.onAgentEvent,
     deferTerminalLifecycle: params.deferTerminalLifecycle,
     suppressNextUserMessagePersistence: params.suppressPromptPersistenceOnRetry === true,

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -830,6 +830,7 @@ export function runAgentAttempt(params: {
             oneShotCliRun: params.opts.oneShotCliRun,
             userTurnTranscriptRecorder: params.userTurnTranscriptRecorder,
             suppressNextUserMessagePersistence: params.suppressPromptPersistenceOnRetry === true,
+            disableTools: params.disableTools === true,
             ...(mutableCliSessionStore && !forkCliSessionOnResume
               ? {
                   onBeforeFreshCliSessionRetry: async (retry) => {

--- a/src/agents/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-restart-recovery.test.ts
@@ -5648,8 +5648,10 @@ describe("main-session-restart-recovery", () => {
 
     expect(callGateway).not.toHaveBeenCalled();
     expect(result).toEqual({ recovered: 0, failed: 0, skipped: 1 });
-    const store = loadSessionStore(path.join(sessionsDir, "sessions.json"));
-    const entry = store["agent:openclaw:telegram:group:-100:topic:2"];
+    const entry = loadSessionEntry({
+      sessionKey: "agent:openclaw:telegram:group:-100:topic:2",
+      storePath: path.join(sessionsDir, "sessions.json"),
+    });
     expect(entry?.status).not.toBe("running");
     expect(entry?.abortedLastRun).toBe(false);
     expect(entry?.restartRecoveryRuns).toBeUndefined();
@@ -5679,8 +5681,10 @@ describe("main-session-restart-recovery", () => {
 
     expect(callGateway).not.toHaveBeenCalled();
     expect(result).toEqual({ recovered: 0, failed: 0, skipped: 1 });
-    const store = loadSessionStore(path.join(sessionsDir, "sessions.json"));
-    const entry = store["agent:openclaw:telegram:group:-100:topic:8893"];
+    const entry = loadSessionEntry({
+      sessionKey: "agent:openclaw:telegram:group:-100:topic:8893",
+      storePath: path.join(sessionsDir, "sessions.json"),
+    });
     expect(entry?.status).not.toBe("running");
     expect(entry?.announceLastRun).toBeUndefined();
   });

--- a/src/agents/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-restart-recovery.test.ts
@@ -5616,5 +5616,99 @@ describe("main-session-restart-recovery", () => {
     expect(result).toEqual({ recovered: 0, failed: 1, skipped: 0 });
     expect(callGateway).not.toHaveBeenCalled();
   });
+
+  it("reconciles an announce-run interrupted human topic to non-running without resuming", async () => {
+    // A subagent-completion announce turn runs on the PARENT topic session and
+    // reuses its `announce:v1:...` idempotency key as the gateway run id. When a
+    // restart interrupts it, the parent topic must NOT be revived as a
+    // "[System] previous turn interrupted" recovery task; it must be reconciled
+    // back to a responsive non-running state. (incident A/B/C: announce:v1 lane)
+    const sessionsDir = await makeSessionsDir("openclaw");
+    await writeStore(sessionsDir, {
+      "agent:openclaw:telegram:group:-100:topic:2": {
+        sessionId: "topic-2-session",
+        updatedAt: Date.now() - 10_000,
+        status: "running",
+        abortedLastRun: true,
+        restartRecoveryRuns: [
+          {
+            runId: "announce:v1:agent:openclaw:subagent:abc:run-1",
+            lifecycleGeneration: "gen-old",
+          },
+        ],
+      },
+    });
+    await writeTranscript(sessionsDir, "topic-2-session", [
+      { role: "user", content: "earlier human request" },
+      { role: "assistant", content: "earlier human reply" },
+      { role: "toolResult", content: "child announce completion" },
+    ]);
+
+    const result = await recoverRestartAbortedMainSessions({ stateDir: tmpDir });
+
+    expect(callGateway).not.toHaveBeenCalled();
+    expect(result).toEqual({ recovered: 0, failed: 0, skipped: 1 });
+    const store = loadSessionStore(path.join(sessionsDir, "sessions.json"));
+    const entry = store["agent:openclaw:telegram:group:-100:topic:2"];
+    expect(entry?.status).not.toBe("running");
+    expect(entry?.abortedLastRun).toBe(false);
+    expect(entry?.restartRecoveryRuns).toBeUndefined();
+  });
+
+  it("reconciles a persisted announceLastRun human session even without recovery runs", async () => {
+    // After a full process restart the in-memory run context is gone and the
+    // orphan sweep marks the stale running row abortedLastRun. The persisted
+    // announceLastRun marker is then the only signal that the interrupted run
+    // was a delivery-only announce turn, so recovery must still reconcile it
+    // rather than enqueue a human recovery turn.
+    const sessionsDir = await makeSessionsDir("openclaw");
+    await writeStore(sessionsDir, {
+      "agent:openclaw:telegram:group:-100:topic:8893": {
+        sessionId: "topic-8893-session",
+        updatedAt: Date.now() - 10_000,
+        status: "running",
+        abortedLastRun: true,
+        announceLastRun: true,
+      },
+    });
+    await writeTranscript(sessionsDir, "topic-8893-session", [
+      { role: "user", content: "resumable looking tail" },
+    ]);
+
+    const result = await recoverRestartAbortedMainSessions({ stateDir: tmpDir });
+
+    expect(callGateway).not.toHaveBeenCalled();
+    expect(result).toEqual({ recovered: 0, failed: 0, skipped: 1 });
+    const store = loadSessionStore(path.join(sessionsDir, "sessions.json"));
+    const entry = store["agent:openclaw:telegram:group:-100:topic:8893"];
+    expect(entry?.status).not.toBe("running");
+    expect(entry?.announceLastRun).toBeUndefined();
+  });
+
+  it("still resumes a genuine human turn that shares the session with a finished announce run", async () => {
+    // A non-announce interrupted run must still recover normally: the announce
+    // guard keys on the run id / persisted marker, not on the topic being a group.
+    const sessionsDir = await makeSessionsDir("openclaw");
+    await writeStore(sessionsDir, {
+      "agent:openclaw:telegram:group:-100:topic:41817": {
+        sessionId: "topic-41817-session",
+        updatedAt: Date.now() - 10_000,
+        status: "running",
+        abortedLastRun: true,
+        restartRecoveryRuns: [{ runId: "human-run-1", lifecycleGeneration: "gen-old" }],
+      },
+    });
+    await writeTranscript(sessionsDir, "topic-41817-session", [
+      { role: "user", content: "real human request" },
+      { role: "assistant", content: [{ type: "toolCall", id: "call-1", name: "exec" }] },
+      { role: "toolResult", content: "done" },
+    ]);
+
+    const result = await recoverRestartAbortedMainSessions({ stateDir: tmpDir });
+
+    expect(result).toEqual({ recovered: 1, failed: 0, skipped: 0 });
+    expect(callGateway).toHaveBeenCalledOnce();
+    expect(firstGatewayParams().sessionKey).toBe("agent:openclaw:telegram:group:-100:topic:41817");
+  });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/agents/main-session-restart-recovery.ts
+++ b/src/agents/main-session-restart-recovery.ts
@@ -43,6 +43,7 @@ import {
 } from "../sessions/session-lifecycle-admission.js";
 import { buildRunUserTurnIdempotencyKey } from "../sessions/user-turn-transcript.js";
 import type { DeliveryContext } from "../utils/delivery-context.shared.js";
+import { isAnnounceRunId } from "./announce-idempotency.js";
 import { CODE_MODE_EXEC_TOOL_NAME, CODE_MODE_WAIT_TOOL_NAME } from "./code-mode-control-tools.js";
 import {
   listActiveEmbeddedRunSessionIds,
@@ -424,6 +425,48 @@ export async function markStartupOrphanedMainSessionsForRecovery(params: {
     log.warn(`marked ${result.marked} startup-orphaned main session(s) for restart recovery`);
   }
   return result;
+}
+
+function isAnnounceInterruptedEntry(entry: SessionEntry): boolean {
+  // A subagent-completion announce turn runs on the parent topic session and
+  // reuses its `announce:v1:...` idempotency key as the gateway run id. It is a
+  // delivery turn, not a human turn, so it must never be revived as a
+  // "[System] previous turn interrupted" recovery task.
+  if (entry.announceLastRun === true) {
+    return true;
+  }
+  const runs = entry.restartRecoveryRuns;
+  return Array.isArray(runs) && runs.length > 0 && runs.every((run) => isAnnounceRunId(run.runId));
+}
+
+async function reconcileAnnounceInterruptedSession(params: {
+  storePath: string;
+  sessionKey: string;
+}): Promise<void> {
+  await applyRestartRecoveryLifecycle({
+    storePath: params.storePath,
+    update: (entries) => {
+      const current = entries.find((entry) => entry.sessionKey === params.sessionKey);
+      const entry = current?.entry;
+      if (!entry || entry.status !== "running") {
+        return { result: undefined };
+      }
+      const now = Date.now();
+      entry.status = "killed";
+      entry.abortedLastRun = false;
+      entry.announceLastRun = undefined;
+      entry.restartRecoveryRuns = undefined;
+      entry.endedAt = now;
+      entry.updatedAt = now;
+      entry.restartRecoveryDeliveryContext = undefined;
+      entry.restartRecoveryDeliveryRunId = undefined;
+      return {
+        result: undefined,
+        replacements: [{ sessionKey: params.sessionKey, entry }],
+      };
+    },
+  });
+  log.info(`reconciled interrupted announce main session to non-running: ${params.sessionKey}`);
 }
 
 function getMessageRole(message: unknown): string | undefined {
@@ -1590,6 +1633,16 @@ async function recoverStore(params: {
     }
     const resumeDedupeKey = sessionKey;
     if (params.resumedSessionKeys.has(resumeDedupeKey)) {
+      result.skipped++;
+      continue;
+    }
+
+    if (isAnnounceInterruptedEntry(entry)) {
+      await reconcileAnnounceInterruptedSession({
+        storePath: params.storePath,
+        sessionKey,
+      });
+      params.resumedSessionKeys.add(resumeDedupeKey);
       result.skipped++;
       continue;
     }

--- a/src/agents/main-session-restart-recovery.ts
+++ b/src/agents/main-session-restart-recovery.ts
@@ -443,8 +443,10 @@ async function reconcileAnnounceInterruptedSession(params: {
   storePath: string;
   sessionKey: string;
 }): Promise<void> {
-  await applyRestartRecoveryLifecycle({
+  await applySessionEntryReplacements({
     storePath: params.storePath,
+    sessionKeys: [params.sessionKey],
+    statuses: ["running"],
     update: (entries) => {
       const current = entries.find((entry) => entry.sessionKey === params.sessionKey);
       const entry = current?.entry;

--- a/src/agents/subagent-announce-handoff.test.ts
+++ b/src/agents/subagent-announce-handoff.test.ts
@@ -1,0 +1,60 @@
+// A subagent-completion announce turn relays frozen child output into the
+// parent topic. It must run tool-free so a child completion can never drive
+// parent-topic bash/apply_patch. This guards the classifier that selects that
+// tool-free handoff path.
+import { describe, expect, it } from "vitest";
+import { AGENT_INTERNAL_EVENT_TYPE_TASK_COMPLETION } from "./internal-event-contract.js";
+import type { AgentInternalEvent } from "./internal-events.js";
+import { isSubagentAnnounceCompletionHandoff } from "./subagent-announce-handoff.js";
+
+const announceProvenance = {
+  kind: "inter_session",
+  sourceSessionKey: "agent:openclaw:subagent:child",
+  sourceChannel: "internal",
+  sourceTool: "subagent_announce",
+} as const;
+
+const subagentCompletionEvent: AgentInternalEvent = {
+  type: AGENT_INTERNAL_EVENT_TYPE_TASK_COMPLETION,
+  source: "subagent",
+  status: "ok",
+  result: "child finished",
+} as AgentInternalEvent;
+
+describe("isSubagentAnnounceCompletionHandoff", () => {
+  it("matches a subagent_announce inter-session completion handoff", () => {
+    expect(
+      isSubagentAnnounceCompletionHandoff({
+        inputProvenance: announceProvenance,
+        internalEvents: [subagentCompletionEvent],
+      }),
+    ).toBe(true);
+  });
+
+  it("does not match a normal human turn (no inter-session provenance)", () => {
+    expect(
+      isSubagentAnnounceCompletionHandoff({
+        inputProvenance: undefined,
+        internalEvents: [subagentCompletionEvent],
+      }),
+    ).toBe(false);
+  });
+
+  it("does not match an inter-session turn from a different source tool", () => {
+    expect(
+      isSubagentAnnounceCompletionHandoff({
+        inputProvenance: { ...announceProvenance, sourceTool: "sessions_send" },
+        internalEvents: [subagentCompletionEvent],
+      }),
+    ).toBe(false);
+  });
+
+  it("does not match an announce handoff without a subagent completion event", () => {
+    expect(
+      isSubagentAnnounceCompletionHandoff({
+        inputProvenance: announceProvenance,
+        internalEvents: [],
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/agents/subagent-announce-handoff.ts
+++ b/src/agents/subagent-announce-handoff.ts
@@ -1,0 +1,31 @@
+import type { InputProvenance } from "../sessions/input-provenance.js";
+import { AGENT_INTERNAL_EVENT_TYPE_TASK_COMPLETION } from "./internal-event-contract.js";
+import type { AgentInternalEvent } from "./internal-events.js";
+
+/**
+ * Classifier for the subagent-completion announce delivery handoff.
+ *
+ * A subagent completion is delivered by waking the parent/requester session with
+ * the frozen child output as an `inter_session` turn tagged `subagent_announce`.
+ * That turn must relay the completion, not act on it: it runs tool-free so a
+ * child completion can never drive parent-topic `bash`/`apply_patch`. This is
+ * the single predicate that selects the constrained path; both tool gating and
+ * prompt-persistence suppression key off it so they cannot drift apart.
+ */
+export function isSubagentAnnounceCompletionHandoff(params: {
+  inputProvenance?: InputProvenance;
+  internalEvents?: AgentInternalEvent[];
+}): boolean {
+  if (
+    params.inputProvenance?.kind !== "inter_session" ||
+    params.inputProvenance.sourceTool !== "subagent_announce"
+  ) {
+    return false;
+  }
+  return (
+    params.internalEvents?.some(
+      (event) =>
+        event.type === AGENT_INTERNAL_EVENT_TYPE_TASK_COMPLETION && event.source === "subagent",
+    ) === true
+  );
+}

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -307,6 +307,13 @@ export type SessionEntry = SessionRestartRecoveryState &
     inheritedToolAllow?: string[];
     systemSent?: boolean;
     abortedLastRun?: boolean;
+    /**
+     * True when the currently interrupted run is a subagent completion announce delivery
+     * (`announce:v1:...`), not a human turn. Persisted on run start so restart
+     * recovery can reconcile the parent topic to non-running instead of reviving
+     * a "[System] previous turn interrupted" task after the announce run is lost.
+     */
+    announceLastRun?: boolean;
     /** Interrupted run generations whose late lifecycle events must be ignored. */
     restartRecoveryRuns?: RestartRecoveryRun[];
     /** Keeps automatic restart recovery limited to replay-safe tools until the run terminates. */

--- a/src/gateway/session-lifecycle-state.ts
+++ b/src/gateway/session-lifecycle-state.ts
@@ -2,6 +2,7 @@
 // Converts agent run lifecycle events into session row/store status updates.
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { isAgentLifecycleYieldedWaiting } from "../agents/agent-lifecycle-parent-state.js";
+import { isAnnounceRunId } from "../agents/announce-idempotency.js";
 import {
   buildAgentRunTerminalOutcome,
   type AgentRunTerminalOutcome,
@@ -52,6 +53,7 @@ type PersistedLifecycleSessionShape = Pick<
   | "endedAt"
   | "runtimeMs"
   | "abortedLastRun"
+  | "announceLastRun"
   | "restartRecoveryRuns"
   | "mainRestartRecovery"
 >;
@@ -224,6 +226,13 @@ function derivePersistedSessionLifecyclePatch(params: {
     ...snapshot,
     updatedAt: typeof snapshot.updatedAt === "number" ? snapshot.updatedAt : undefined,
   };
+  const runId = params.event.runId?.trim();
+  const phaseForAnnounce = resolveLifecyclePhase(params.event);
+  if (phaseForAnnounce === "start") {
+    snapshotPatch.announceLastRun = isAnnounceRunId(runId) ? true : undefined;
+  } else if (phaseForAnnounce === "end" || phaseForAnnounce === "error") {
+    snapshotPatch.announceLastRun = undefined;
+  }
   const projection = projectMainSessionRecoveryLifecycle({
     currentLifecycleGeneration: getAgentEventLifecycleGeneration(),
     entry: params.entry,

--- a/src/plugins/session-entry-slot-keys.ts
+++ b/src/plugins/session-entry-slot-keys.ts
@@ -46,6 +46,7 @@ const SESSION_ENTRY_RESERVED_SLOT_KEY_LIST = [
   "pluginOwnerId",
   "systemSent",
   "abortedLastRun",
+  "announceLastRun",
   "restartRecoveryRuns",
   "restartRecoveryForceSafeTools",
   "goal",


### PR DESCRIPTION
## What Problem This Solves

Fixes a real Telegram-topic reliability cascade where subagent completion announce turns were treated as normal parent-topic agent turns.

The incident path was:

1. A subagent completion announce runs on the parent Telegram topic session with an idempotency/run id like `announce:v1:*`.
2. Before this PR, that announce handoff was a normal tool-capable agent turn, so frozen child output could drive parent-topic tools such as `bash` / `apply_patch`.
3. If the gateway restarted mid-announce, restart recovery saw the parent topic as `status: "running" + abortedLastRun` and resumed it as `[System] Your previous turn was interrupted...`, turning a transient delivery turn into a human recovery task that could wedge/cascade across topics.

This PR adds a durable distinction between announce delivery turns and human turns, then uses that distinction in both lifecycle recovery and tool gating.

## Summary

- Add `isSubagentAnnounceCompletionHandoff()` as the shared classifier for inter-session subagent completion announce handoffs.
- Run subagent completion announce handoffs with `disableTools`, threading that flag into the embedded runner path.
- Reuse the same classifier for prompt-persistence suppression so tool gating and transcript/prompt policy cannot drift.
- Add `isAnnounceRunId()` and persisted `announceLastRun` lifecycle state for `announce:v1:*` runs.
- Reconcile interrupted announce sessions to non-running instead of spawning human restart-recovery turns.
- Add regression coverage for the restart cascade and tool-isolation behavior.

## Evidence

Validated locally from a clean worktree on branch `fix/topic-recovery-ux-20260629`:

- `git diff --check` → pass
- `corepack pnpm tsgo:core` → pass
- `corepack pnpm tsgo:core:test` → pass
- `corepack pnpm check:import-cycles` → `0 runtime value cycle(s)`
- `node scripts/run-vitest.mjs` with:
  - `src/agents/subagent-announce-handoff.test.ts`
  - `src/agents/agent-command.compaction-rotation.test.ts`
  - `src/agents/main-session-restart-recovery.test.ts`
  - `src/gateway/session-lifecycle-state.test.ts`
  - `src/gateway/server.agent.gateway-server-agent-a.test.ts`
  - `src/gateway/server.agent.gateway-server-agent-b.test.ts`
  - `src/agents/subagent-announce-delivery.test.ts`
  - `src/agents/command/attempt-execution.test.ts`

Vitest result from the final verification run:

- 3 Vitest shards passed
- 13 test files passed
- 365 tests passed

Additional regression evidence:

- New restart-recovery tests prove `announce:v1:*` interrupted topic sessions are reconciled to non-running and never call gateway recovery.
- New agent-command test proves subagent completion announce handoffs set `disableTools: true`.
- New lifecycle tests prove `announceLastRun` is set for announce starts and cleared for normal/terminal runs.

<!-- proof-body-refreshed-after-local-policy-pass -->
