### PR TITLE
fix(secrets): scrub migrated env keys only

### DIFF
--- a/src/secrets/apply.test.ts
+++ b/src/secrets/apply.test.ts
@@ -38,6 +38,12 @@ const OPENAI_API_KEY_ENV_REF = {
   id: "OPENAI_API_KEY",
 } as const;
 
+const ANTHROPIC_API_KEY_ENV_REF = {
+  source: "env",
+  provider: "default",
+  id: "ANTHROPIC_API_KEY",
+} as const;
+
 type ApplyFixture = {
   rootDir: string;
   stateDir: string;
@@ -182,13 +188,14 @@ function createOpenAiProviderTarget(params?: {
   path?: string;
   pathSegments?: string[];
   providerId?: string;
+  ref?: SecretsApplyPlan["targets"][number]["ref"];
 }): SecretsApplyPlan["targets"][number] {
   return {
     type: "models.providers.apiKey",
     path: params?.path ?? "models.providers.openai.apiKey",
     ...(params?.pathSegments ? { pathSegments: params.pathSegments } : {}),
     providerId: params?.providerId ?? "openai",
-    ref: OPENAI_API_KEY_ENV_REF,
+    ref: params?.ref ?? OPENAI_API_KEY_ENV_REF,
   };
 }
 
@@ -328,7 +335,143 @@ describe("secrets apply", () => {
     expect(nextAuthJson.openai).toBeUndefined();
 
     const nextEnv = await fs.readFile(fixture.envPath, "utf8");
-    expect(nextEnv).not.toContain("sk-openai-plaintext");
+    expect(nextEnv).not.toContain("sk-ope...text");
+    expect(nextEnv).toContain("UNRELATED=value");
+  });
+
+  it("preserves same-value env credentials that were not migrated", async () => {
+    await writeJsonFile(fixture.configPath, {
+      models: {
+        providers: {
+          openai: createOpenAiProviderConfig("shared...y"), // pragma: allowlist secret
+          anthropic: {
+            baseUrl: "https://api.anthropic.com/v1",
+            api: "anthropic-messages",
+            apiKey: "shared...y", // pragma: allowlist secret
+            models: [{ id: "claude-opus-5", name: "claude-opus-5" }],
+          },
+        },
+      },
+    });
+    await fs.writeFile(
+      fixture.envPath,
+      [
+        "OPENAI_API_KEY=shared...y", // pragma: allowlist secret
+        "ANTHROPIC_API_KEY=shared...y", // pragma: allowlist secret
+        "UNRELATED=value",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    const plan = createPlan({
+      targets: [createOpenAiProviderTarget()],
+      options: createOneWayScrubOptions(),
+    });
+
+    await runSecretsApply({ plan, env: fixture.env, write: true });
+
+    const nextEnv = await fs.readFile(fixture.envPath, "utf8");
+    expect(nextEnv).not.toContain("OPENAI_API_KEY=shared...y");
+    expect(nextEnv).toContain("ANTHROPIC_API_KEY=shared...y");
+    expect(nextEnv).toContain("UNRELATED=value");
+
+    const nextConfig = JSON.parse(await fs.readFile(fixture.configPath, "utf8")) as {
+      models: {
+        providers: {
+          openai: { apiKey: unknown };
+          anthropic: { apiKey: unknown };
+        };
+      };
+    };
+    expect(nextConfig.models.providers.openai.apiKey).toEqual(OPENAI_API_KEY_ENV_REF);
+    expect(nextConfig.models.providers.anthropic.apiKey).toBe("shared...y");
+  });
+
+  it("scrubs each migrated env key when multiple targets share a value", async () => {
+    await writeJsonFile(fixture.configPath, {
+      models: {
+        providers: {
+          openai: createOpenAiProviderConfig("shared...y"), // pragma: allowlist secret
+          anthropic: {
+            baseUrl: "https://api.anthropic.com/v1",
+            api: "anthropic-messages",
+            apiKey: "shared...y", // pragma: allowlist secret
+            models: [{ id: "claude-opus-5", name: "claude-opus-5" }],
+          },
+        },
+      },
+    });
+    await fs.writeFile(
+      fixture.envPath,
+      [
+        "OPENAI_API_KEY=shared...y", // pragma: allowlist secret
+        "ANTHROPIC_API_KEY=shared...y", // pragma: allowlist secret
+        "UNRELATED=value",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    const plan = createPlan({
+      targets: [
+        createOpenAiProviderTarget(),
+        createOpenAiProviderTarget({
+          path: "models.providers.anthropic.apiKey",
+          pathSegments: ["models", "providers", "anthropic", "apiKey"],
+          providerId: "anthropic",
+          ref: ANTHROPIC_API_KEY_ENV_REF,
+        }),
+      ],
+      options: createOneWayScrubOptions(),
+    });
+    fixture.env.ANTHROPIC_API_KEY = "shared...y"; // pragma: allowlist secret
+
+    await runSecretsApply({ plan, env: fixture.env, write: true });
+
+    const nextEnv = await fs.readFile(fixture.envPath, "utf8");
+    expect(nextEnv).not.toContain("OPENAI_API_KEY=shared...y");
+    expect(nextEnv).not.toContain("ANTHROPIC_API_KEY=shared...y");
+    expect(nextEnv).toContain("UNRELATED=value");
+  });
+
+  it("only scrubs migrated env keys for auth-profile targets", async () => {
+    await writeJsonFile(fixture.authStorePath, {
+      version: 1,
+      profiles: {
+        "openai:default": {
+          type: "api_key",
+          provider: "openai",
+          key: "shared...y", // pragma: allowlist secret
+        },
+      },
+    });
+    await fs.writeFile(
+      fixture.envPath,
+      [
+        "OPENAI_API_KEY=shared...y", // pragma: allowlist secret
+        "ANTHROPIC_API_KEY=shared...y", // pragma: allowlist secret
+        "UNRELATED=value",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    const plan = createPlan({
+      targets: [
+        {
+          type: "auth-profiles.api_key.key",
+          path: "profiles.openai:default.key",
+          pathSegments: ["profiles", "openai:default", "key"],
+          agentId: "main",
+          ref: OPENAI_API_KEY_ENV_REF,
+        },
+      ],
+      options: createOneWayScrubOptions(),
+    });
+
+    await runSecretsApply({ plan, env: fixture.env, write: true });
+
+    const nextEnv = await fs.readFile(fixture.envPath, "utf8");
+    expect(nextEnv).not.toContain("OPENAI_API_KEY=shared...y");
+    expect(nextEnv).toContain("ANTHROPIC_API_KEY=shared...y");
     expect(nextEnv).toContain("UNRELATED=value");
   });
 

--- a/src/secrets/apply.ts
+++ b/src/secrets/apply.ts
@@ -37,7 +37,6 @@ import {
   normalizeSecretsPlanOptions,
   resolveValidatedPlanTarget,
 } from "./plan.js";
-import { listKnownSecretEnvVarNames } from "./provider-env-vars.js";
 import { resolveSecretRefValue } from "./resolve.js";
 import { prepareSecretsRuntimeSnapshot } from "./runtime.js";
 import { assertExpectedResolvedSecretValue } from "./secret-value.js";
@@ -90,6 +89,7 @@ type ResolvedPlanTargetEntry = {
 type ConfigTargetMutationResult = {
   resolvedTargets: ResolvedPlanTargetEntry[];
   scrubbedValues: Set<string>;
+  scrubbedEnvKeys: Set<string>;
   providerTargets: Set<string>;
   configChanged: boolean;
   authStoreByPath: Map<string, Record<string, unknown>>;
@@ -278,6 +278,7 @@ async function projectPlanState(params: {
   const envRawByPath = scrubEnvFiles({
     env: params.env,
     scrubbedValues: targetMutations.scrubbedValues,
+    scrubbedEnvKeys: targetMutations.scrubbedEnvKeys,
     changedFiles,
     enabled: options.scrubEnv,
   });
@@ -323,6 +324,7 @@ function applyConfigTargetMutations(params: {
     resolved: resolveTarget(target),
   }));
   const scrubbedValues = new Set<string>();
+  const scrubbedEnvKeys = new Set<string>();
   const providerTargets = new Set<string>();
   let configChanged = false;
 
@@ -336,6 +338,7 @@ function applyConfigTargetMutations(params: {
         authStoreByPath: params.authStoreByPath,
         authStoreAgentDirByPath: params.authStoreAgentDirByPath,
         scrubbedValues,
+        scrubbedEnvKeys,
       });
       if (authStoreChanged) {
         const agentId = (target.agentId ?? "").trim();
@@ -359,6 +362,9 @@ function applyConfigTargetMutations(params: {
       const previous = getPath(params.nextConfig, targetPathSegments);
       if (isNonEmptyString(previous)) {
         scrubbedValues.add(previous.trim());
+        if (target.ref.source === "env") {
+          scrubbedEnvKeys.add(target.ref.id);
+        }
       }
       const refPathSegments = resolved.refPathSegments;
       if (!refPathSegments) {
@@ -375,6 +381,9 @@ function applyConfigTargetMutations(params: {
     const previous = getPath(params.nextConfig, targetPathSegments);
     if (isNonEmptyString(previous)) {
       scrubbedValues.add(previous.trim());
+      if (target.ref.source === "env") {
+        scrubbedEnvKeys.add(target.ref.id);
+      }
     }
     const wroteRef = setPathCreateStrict(params.nextConfig, targetPathSegments, target.ref);
     if (wroteRef) {
@@ -388,6 +397,7 @@ function applyConfigTargetMutations(params: {
   return {
     resolvedTargets,
     scrubbedValues,
+    scrubbedEnvKeys,
     providerTargets,
     configChanged,
     authStoreByPath: params.authStoreByPath,
@@ -594,6 +604,7 @@ function applyAuthProfileTargetMutation(params: {
   authStoreByPath: Map<string, Record<string, unknown>>;
   authStoreAgentDirByPath: Map<string, string>;
   scrubbedValues: Set<string>;
+  scrubbedEnvKeys: Set<string>;
 }): boolean {
   if (params.resolved.entry.configFile !== "auth-profiles.json") {
     return false;
@@ -616,6 +627,9 @@ function applyAuthProfileTargetMutation(params: {
     const previous = getPath(store, targetPathSegments);
     if (isNonEmptyString(previous)) {
       params.scrubbedValues.add(previous.trim());
+      if (params.target.ref.source === "env") {
+        params.scrubbedEnvKeys.add(params.target.ref.id);
+      }
     }
     const refPathSegments = params.resolved.refPathSegments;
     if (!refPathSegments) {
@@ -629,6 +643,9 @@ function applyAuthProfileTargetMutation(params: {
   const previous = getPath(store, targetPathSegments);
   if (isNonEmptyString(previous)) {
     params.scrubbedValues.add(previous.trim());
+    if (params.target.ref.source === "env") {
+      params.scrubbedEnvKeys.add(params.target.ref.id);
+    }
   }
   const wroteRef = setPathCreateStrict(store, targetPathSegments, params.target.ref);
   changed = changed || wroteRef;
@@ -672,11 +689,12 @@ function scrubLegacyAuthJsonStores(params: {
 function scrubEnvFiles(params: {
   env: NodeJS.ProcessEnv;
   scrubbedValues: Set<string>;
+  scrubbedEnvKeys: Set<string>;
   changedFiles: Set<string>;
   enabled: boolean;
 }): Map<string, string> {
   const envRawByPath = new Map<string, string>();
-  if (!params.enabled || params.scrubbedValues.size === 0) {
+  if (!params.enabled || params.scrubbedValues.size === 0 || params.scrubbedEnvKeys.size === 0) {
     return envRawByPath;
   }
   const envPath = path.join(resolveConfigDir(params.env, os.homedir), ".env");
@@ -684,11 +702,7 @@ function scrubEnvFiles(params: {
     return envRawByPath;
   }
   const current = fs.readFileSync(envPath, "utf8");
-  const scrubbed = scrubEnvRaw(
-    current,
-    params.scrubbedValues,
-    new Set(listKnownSecretEnvVarNames()),
-  );
+  const scrubbed = scrubEnvRaw(current, params.scrubbedValues, params.scrubbedEnvKeys);
   if (scrubbed.removed > 0 && scrubbed.nextRaw !== current) {
     envRawByPath.set(envPath, scrubbed.nextRaw);
     params.changedFiles.add(envPath);


### PR DESCRIPTION
## Summary
- Limit `secrets apply` env scrubbing to the env keys that were actually migrated by the current plan.
- Preserve unrelated provider credentials when two `.env` entries share the same plaintext value.
- Cover config-target, multi-target, and auth-profile target migrations with regression tests.

## Issue / Motivation
Fixes #97660. The previous scrub pass matched migrated plaintext values against every known secret env var name, so migrating one provider could delete another non-migrated provider credential if both env vars held the same value.

## Changes
- Track migrated env ref IDs alongside migrated plaintext values during config and auth-profile target mutation.
- Pass only those migrated env keys to `.env` scrubbing instead of the global known-secret env key list.
- Add regression tests that verify unrelated same-value env credentials are preserved, while multiple explicitly migrated same-value keys are still scrubbed.

## Testing
- `node scripts/run-vitest.mjs src/secrets/apply.test.ts`
- `git diff --check`
- Diff secret scan over `src/secrets/apply.ts` and `src/secrets/apply.test.ts`

Fixes #97660

## What Problem This Solves

Fixes #97660. Migrating one secret env var could scrub a different non-migrated credential when both env vars shared the same plaintext value. That made `secrets apply` destructive outside the current migration plan instead of limiting writes to the env keys that were actually migrated.

## Evidence

- `node scripts/run-vitest.mjs src/secrets/apply.test.ts`
- `git diff --check`
- Diff secret scan over `src/secrets/apply.ts` and `src/secrets/apply.test.ts` — clean
- Added regression coverage for config-target, multi-target, and auth-profile target migrations, including same-value credentials that must remain untouched unless explicitly migrated.
