### PR TITLE
Update QA Lab Crabline integration

### DIFF
--- a/docs/concepts/qa-e2e-automation.md
+++ b/docs/concepts/qa-e2e-automation.md
@@ -74,7 +74,7 @@ pnpm openclaw qa run \
 ```
 
 Use `smoke-ci` for deterministic profile proof with mock model providers and
-Crabline fake provider servers. Use `release` for Stable/LTS proof against live
+Crabline local provider servers. Use `release` for Stable/LTS proof against live
 channels. Use `all` only for explicit full-taxonomy evidence runs; it selects
 every active maturity category and can be dispatched through the `QA Profile
 Evidence` workflow with `qa_profile=all`. When a command also needs an OpenClaw
@@ -890,7 +890,7 @@ At the architecture level, the split is:
 
 Adding a channel to the YAML QA system requires the channel implementation plus
 a scenario pack that exercises the channel contract. For smoke CI coverage, add
-the matching Crabline fake provider server and expose it through the `crabline`
+the matching Crabline local provider server and expose it through the `crabline`
 driver.
 
 Do not add a new top-level QA command root when the shared `qa-lab` host can own the flow.

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -1129,6 +1129,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: ClawSweeper activity forwarding
   - H2: Manual dispatches
   - H2: Runners
+  - H2: Runner registration budget
   - H2: Local equivalents
   - H2: OpenClaw Performance
   - H2: Full Release Validation
@@ -1756,6 +1757,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
 - Headings:
   - H2: Commands
   - H3: Author
+  - H3: Provider Scaffold
   - H3: Install
   - H4: Marketplace shorthand
   - H3: List
@@ -2885,6 +2887,12 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
 - Headings:
   - H2: What it is
   - H2: Where it shows up
+  - H2: Default usage footer mode
+  - H3: Three distinct session states
+  - H3: Precedence
+  - H3: Resetting vs. turning off
+  - H3: Toggle behavior
+  - H3: Config
   - H2: Custom /usage full footer
   - H3: Shape
   - H3: Contract Paths
@@ -4188,6 +4196,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H3: Health checks
   - H3: LAN vs loopback
   - H3: Host Local Providers
+  - H3: Claude CLI backend in Docker
   - H3: Bonjour / mDNS
   - H3: Storage and persistence
   - H3: Shell helpers (optional)
@@ -4592,6 +4601,32 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Troubleshooting tips
   - H2: Related
 
+## maturity/scorecard.md
+
+- Route: /maturity/scorecard
+- Headings:
+  - H1: Maturity scorecard
+  - H2: What this page is for
+  - H2: At a glance
+  - H2: Score bands
+  - H2: Surface explorer
+  - H2: QA evidence summary
+  - H3: Readiness by area
+
+## maturity/taxonomy.md
+
+- Route: /maturity/taxonomy
+- Headings:
+  - H1: Maturity taxonomy
+  - H2: How to read this page
+  - H2: Maturity levels
+  - H2: Product areas
+  - H2: Details
+  - H3: Core
+  - H3: Platform
+  - H3: Channel
+  - H3: Provider and tool
+
 ## network.md
 
 - Route: /network
@@ -4922,6 +4957,8 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Install the CLI (required for local mode)
   - H2: Launchd (Gateway as LaunchAgent)
   - H2: Version compatibility
+  - H2: State directory on macOS
+  - H2: Debug app connectivity
   - H2: Smoke check
   - H2: Related
 
@@ -5126,20 +5163,12 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
 
 - Route: /platforms/macos
 - Headings:
-  - H2: What it does
-  - H2: Local vs remote mode
-  - H2: Launchd control
-  - H2: Node capabilities (mac)
-  - H2: Exec approvals (system.run)
-  - H2: Deep links
-  - H3: openclaw://agent
-  - H2: Onboarding flow (typical)
-  - H2: State dir placement (macOS)
-  - H2: Build and dev workflow (native)
-  - H2: Debug gateway connectivity (macOS CLI)
-  - H2: Remote connection plumbing (SSH tunnels)
-  - H3: Control tunnel (Gateway WebSocket port)
-  - H2: Related docs
+  - H2: Download
+  - H2: First run
+  - H2: Choose a Gateway mode
+  - H2: What the app owns
+  - H2: macOS detail pages
+  - H2: Related
 
 ## platforms/oracle.md
 
@@ -5437,6 +5466,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Plugin install
   - H2: Quickstart
   - H2: Supported providers
+  - H2: BYOK
   - H2: Auth
   - H2: Configuration surface
   - H2: Compaction
@@ -6830,6 +6860,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H3: Tool-result middleware
   - H3: Terminal outcome classification
   - H3: Agent-end side effects
+  - H3: User input and tool surfaces
   - H3: Native Codex harness mode
   - H2: Runtime strictness
   - H2: Native sessions and transcript mirror

--- a/extensions/qa-lab/package.json
+++ b/extensions/qa-lab/package.json
@@ -16,7 +16,7 @@
     "@openclaw/plugin-sdk": "workspace:*",
     "@openclaw/slack": "workspace:*",
     "@openclaw/whatsapp": "workspace:*",
-    "@openclaw/crabline": "0.1.4",
+    "@openclaw/crabline": "0.1.5",
     "openclaw": "2026.5.28"
   },
   "peerDependencies": {

--- a/extensions/qa-lab/src/crabline-transport.test.ts
+++ b/extensions/qa-lab/src/crabline-transport.test.ts
@@ -1,4 +1,4 @@
-// Qa Lab tests cover Crabline fake-provider transport integration behavior.
+// Qa Lab tests cover Crabline local-provider transport integration behavior.
 import fs from "node:fs/promises";
 import path from "node:path";
 import { OPENCLAW_CRABLINE_MANIFEST_PATH } from "@openclaw/crabline";
@@ -18,7 +18,7 @@ function createSelection(channel: "slack" | "telegram" | "whatsapp" = "telegram"
 }
 
 describe("crabline transport", () => {
-  it("configures OpenClaw's Telegram plugin against a Crabline fake provider server", async () => {
+  it("configures OpenClaw's Telegram plugin against a Crabline local provider server", async () => {
     await withTempDir("qa-crabline-transport-", async (outputDir) => {
       const transport = await createQaCrablineTransportAdapter({
         outputDir,
@@ -59,7 +59,7 @@ describe("crabline transport", () => {
     });
   });
 
-  it("configures OpenClaw's Slack plugin against a Crabline fake provider server", async () => {
+  it("configures OpenClaw's Slack plugin against a Crabline local provider server", async () => {
     await withTempDir("qa-crabline-transport-", async (outputDir) => {
       const transport = await createQaCrablineTransportAdapter({
         outputDir,

--- a/extensions/qa-lab/src/crabline-transport.ts
+++ b/extensions/qa-lab/src/crabline-transport.ts
@@ -1,4 +1,4 @@
-// Qa Lab plugin module implements Crabline fake-provider transport behavior.
+// Qa Lab plugin module implements Crabline local-provider transport behavior.
 import fs from "node:fs/promises";
 import path from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
@@ -225,7 +225,7 @@ class QaCrablineTransport extends QaStateBackedTransportAdapter {
   }) {
     super({
       id: CRABLINE_TRANSPORT_ID,
-      label: `crabline fake ${params.selection.channel}`,
+      label: `crabline local ${params.selection.channel}`,
       accountId: params.adapter.accountId,
       requiredPluginIds: params.adapter.requiredPluginIds,
       state: params.state,
@@ -263,11 +263,11 @@ class QaCrablineTransport extends QaStateBackedTransportAdapter {
     cfg: OpenClawConfig;
     accountId?: string | null;
   }) => {
-    throw new Error(`Crabline fake-provider transport does not support ${_params.action} yet.`);
+    throw new Error(`Crabline local-provider transport does not support ${_params.action} yet.`);
   };
 
   createReportNotes = (_params: QaTransportReportParams) => [
-    `Runs OpenClaw's ${this.#selection.channel} channel plugin against a Crabline fake provider server.`,
+    `Runs OpenClaw's ${this.#selection.channel} channel plugin against a Crabline local provider server.`,
     "No live channel service or external credential lease is required.",
   ];
 

--- a/extensions/qa-lab/src/suite.test.ts
+++ b/extensions/qa-lab/src/suite.test.ts
@@ -1,7 +1,7 @@
 // Qa Lab tests cover suite plugin behavior.
 import fs from "node:fs/promises";
 import path from "node:path";
-import { CRABLINE_FAKE_PROVIDER_CHANNELS } from "@openclaw/crabline";
+import { CRABLINE_SERVER_CHANNELS } from "@openclaw/crabline";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { QA_EVIDENCE_FILENAME, QA_EVIDENCE_SUMMARY_KIND } from "./evidence-summary.js";
 import type { QaLabServerHandle } from "./lab-server.types.js";
@@ -387,7 +387,7 @@ describe("qa suite", () => {
       };
       expect(matrix.report?.result).toMatchObject({
         selectedChannel: "telegram",
-        supportedChannels: [...CRABLINE_FAKE_PROVIDER_CHANNELS].toSorted(),
+        supportedChannels: [...CRABLINE_SERVER_CHANNELS].toSorted(),
       });
       const smoke = JSON.parse(
         await fs.readFile(path.join(outputDir, "crabline-fake-provider-smoke.json"), "utf8"),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1346,8 +1346,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@openclaw/crabline':
-        specifier: 0.1.4
-        version: 0.1.4
+        specifier: 0.1.5
+        version: 0.1.5
       '@openclaw/discord':
         specifier: workspace:*
         version: link:../discord
@@ -3182,8 +3182,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@openclaw/crabline@0.1.4':
-    resolution: {integrity: sha512-93WlCaqhppzdBKwRps7hP9mNgu6KHI1IATcQrRX+egaIhNTsfEFfZ5SJJUag8+WIHr982y4Fy5SQRQLWEs5WvA==}
+  '@openclaw/crabline@0.1.5':
+    resolution: {integrity: sha512-OK1YUdM6GO1qgTEvcHhMl/MQ77yw9MmcM84jB1uPNXutQnIjPbIhRin6MXRSMbuYqH5feu4CmTzAtH5VtHv8gA==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -9269,14 +9269,17 @@ snapshots:
   '@openai/codex@0.139.0-win32-x64':
     optional: true
 
-  '@openclaw/crabline@0.1.4':
+  '@openclaw/crabline@0.1.5':
     dependencies:
-      commander: 14.0.3
+      commander: 15.0.0
       curve25519-js: 0.0.4
       picocolors: 1.1.1
       ws: 8.21.0
       yaml: 2.9.0
       zod: 4.4.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   '@openclaw/fs-safe@0.3.0':
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,7 +7,7 @@ packages:
 minimumReleaseAge: 2880
 
 minimumReleaseAgeExclude:
-  - "@openclaw/crabline@0.1.4"
+  - "@openclaw/crabline@0.1.5"
   - "@openclaw/fs-safe@0.3.0"
   - "@openclaw/proxyline@0.3.3"
   - "acpx"


### PR DESCRIPTION
## What Problem This Solves

QA Lab still consumed `@openclaw/crabline` 0.1.4 and referenced the old fake-provider public API naming after Crabline 0.1.5 shipped the provider/server rename.

## Why This Change Was Made

This updates QA Lab to `@openclaw/crabline` 0.1.5, switches the direct channel constant import to `CRABLINE_SERVER_CHANNELS`, and updates user-facing QA Lab/docs wording to the current local provider server naming. The legacy Crabline artifact filenames stay unchanged because 0.1.5 intentionally preserves those compatibility paths.

## User Impact

QA Lab's `crabline` channel driver stays compatible with the newly released Crabline package while its labels, errors, report notes, and docs use the current provider server terminology.

## Evidence

- `pnpm docs:list`
- `pnpm install --frozen-lockfile`
- `node scripts/run-vitest.mjs extensions/qa-lab/src/crabline-transport.test.ts extensions/qa-lab/src/suite.test.ts extensions/qa-lab/src/suite.summary-json.test.ts extensions/qa-lab/src/cli.runtime.test.ts extensions/qa-lab/src/multipass.runtime.test.ts extensions/qa-lab/src/suite-launch.runtime.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
