### PR TITLE
docs(ci): update runner registration budget

### DIFF
--- a/.agents/skills/openclaw-ci-limits/SKILL.md
+++ b/.agents/skills/openclaw-ci-limits/SKILL.md
@@ -13,14 +13,17 @@ registration edge limit.
 
 - The scarce resource is Blacksmith runner registrations, not Blacksmith vCPU
   capacity.
-- GitHub runner registrations for `openclaw` are currently capped at 3,000 per
-  5 minutes per repository, organization, or enterprise. The `openclaw`
+- GitHub runner registrations for `openclaw` currently report a 10,000 per
+  5-minute bucket in `actions_runner_registration`. Verify the live bucket
+  before each tuning pass because GitHub can change it. The `openclaw`
   organization shares one bucket.
 - Core REST quota does not draw down this bucket. Check
   `actions_runner_registration` separately; core quota can be healthy while
   runner registration is throttled.
-- Use 2,000 registrations per 5 minutes as the operating target. Leave the last
-  third for other repos, retries, and burst overlap.
+- Use about 60% of the live bucket as the operating target. With the current
+  10,000-registration bucket, keep planned Blacksmith burst load under 6,000
+  registrations per 5 minutes and leave the rest for other repos, retries, and
+  burst overlap.
 - Jobs that route, notify, summarize, choose shards, or run short CodeQL quality
   scans should stay on GitHub-hosted runners unless measured evidence says
   Blacksmith is required.
@@ -88,9 +91,10 @@ admission. The debounce only suppresses pushes that arrive while
 registrations are spent even if a later push cancels the run. If timing is
 uncertain, count every sequential push in the window.
 
-Reject a change unless the org-level worst case stays below 2,000 registrations
-per 5 minutes with headroom for ClawSweeper, ClawHub, Clownfish, OpenClaw RTT,
-and Clawbench.
+Reject a change unless the org-level worst case stays below about 60% of the
+live bucket. With the current 10,000-registration bucket, keep planned
+Blacksmith burst load under 6,000 registrations per 5 minutes with headroom for
+ClawSweeper, ClawHub, Clownfish, OpenClaw RTT, and Clawbench.
 
 ## Safe Levers
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -145,18 +145,21 @@ gh workflow run full-release-validation.yml --ref main -f ref=<branch-or-sha>
 
 ## Runner registration budget
 
-OpenClaw's current GitHub runner-registration bucket allows 3,000 self-hosted
-runner registrations per 5 minutes. The limit is shared by all Blacksmith runner
-registrations in the `openclaw` organization, so adding another Blacksmith
-installation does not add a new bucket.
+OpenClaw's current GitHub runner-registration bucket reports 10,000 self-hosted
+runner registrations per 5 minutes in `ghx api rate_limit`. Re-check
+`actions_runner_registration` before each tuning pass because GitHub can change
+this bucket. The limit is shared by all Blacksmith runner registrations in the
+`openclaw` organization, so adding another Blacksmith installation does not add
+a new bucket.
 
 Treat Blacksmith labels as the scarce resource for burst control. Jobs that
 only route, notify, summarize, select shards, or run short CodeQL scans should
 stay on GitHub-hosted runners unless they have measured Blacksmith-specific
 needs. Any new Blacksmith matrix, larger `max-parallel`, or high-frequency
 workflow must show its worst-case registration count and keep the org-level
-target below 2,000 registrations per 5 minutes, leaving headroom for concurrent
-repositories and retried jobs.
+target below about 60% of the live bucket. With the current 10,000-registration
+bucket, that means a 6,000-registration operating target, leaving headroom for
+concurrent repositories, retries, and burst overlap.
 
 Canonical-repo CI keeps Blacksmith as the default runner path for normal push and pull-request runs. `workflow_dispatch` and non-canonical repository runs use GitHub-hosted runners, but normal canonical runs do not currently probe Blacksmith queue health or automatically fall back to GitHub-hosted labels when Blacksmith is unavailable.
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where OpenClaw CI operator guidance still used the older 3,000-runner-registration bucket and 2,000-registration target after live GitHub rate-limit evidence showed the current bucket is higher.

## Why This Change Was Made

The CI runbook and maintainer skill now tell operators to verify `actions_runner_registration` live before tuning and to target about 60% of the live bucket. With the current 10,000-registration bucket, the documented operating target is 6,000 registrations per 5 minutes.

## User Impact

Maintainers get current, reusable guidance for right-sizing Blacksmith-backed CI without overreacting to stale quota numbers. No workflow behavior changes in this PR.

## Evidence

- `ghx api rate_limit --jq '{core:.resources.core,graphql:.resources.graphql,actions_runner_registration:.resources.actions_runner_registration}'` reported `actions_runner_registration.limit=10000` and `remaining=10000` during this pass.
- `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts`
- `node scripts/check-workflows.mjs`
- `node scripts/docs-list.js`
- `./node_modules/.bin/oxfmt --check .github/workflows/ci.yml .github/workflows/codeql-critical-quality.yml docs/ci.md test/scripts/ci-workflow-guards.test.ts .agents/skills/openclaw-ci-limits/SKILL.md .agents/skills/openclaw-ci-limits/agents/openai.yaml`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local` clean, no accepted/actionable findings
