### PR TITLE
fix(exec): harden script preflight carrier unwrapping

### DIFF
--- a/src/agents/bash-tools.exec.script-preflight.test.ts
+++ b/src/agents/bash-tools.exec.script-preflight.test.ts
@@ -274,6 +274,85 @@ describeNonWin("exec script preflight", () => {
     });
   });
 
+  it("validates scripts through sudo and env carrier option values before execution", async () => {
+    await withTempDir("openclaw-exec-preflight-", async (tmp) => {
+      await fs.writeFile(path.join(tmp, "bad.py"), "payload = $DM_JSON", "utf-8");
+      await fs.writeFile(path.join(tmp, "bad.js"), "const value = $DM_JSON;", "utf-8");
+
+      const tool = createPreflightTool();
+      const cases = [
+        {
+          name: "sudo-user-option-value",
+          command: "sudo -u openclaw python bad.py",
+        },
+        {
+          name: "sudo-prompt-option-value",
+          command: "sudo -p Password: python bad.py",
+        },
+        {
+          name: "env-search-path-option-value",
+          command: "env -P /usr/bin python bad.py",
+        },
+        {
+          name: "env-unset-option-value",
+          command: "env -u PYTHONPATH python bad.py",
+        },
+        {
+          name: "env-assignment-node",
+          command: "env NODE_ENV=test node bad.js",
+        },
+      ];
+
+      for (const testCase of cases) {
+        await expect(
+          tool.execute(`call-${testCase.name}`, {
+            command: testCase.command,
+            workdir: tmp,
+          }),
+        ).rejects.toThrow(/exec preflight: detected likely shell variable injection \(\$DM_JSON\)/);
+      }
+    });
+  });
+
+  it("validates scripts through clustered sudo/env shell wrappers before execution", async () => {
+    await withTempDir("openclaw-exec-preflight-", async (tmp) => {
+      await fs.writeFile(path.join(tmp, "bad.py"), "payload = $DM_JSON", "utf-8");
+
+      const tool = createPreflightTool();
+      const cases = [
+        {
+          name: "sudo-clustered-shell",
+          command: "sudo -EH bash -lc 'python bad.py'",
+        },
+        {
+          name: "sudo-user-clustered-shell",
+          command: "sudo -Eu openclaw bash -lc 'python bad.py'",
+        },
+        {
+          name: "env-split-string-shell",
+          command: "env -S 'bash -lc' 'python bad.py'",
+        },
+        {
+          name: "nested-env-sudo-shell",
+          command: "env OPENCLAW_TEST=1 sudo -u openclaw bash -lc 'python bad.py'",
+        },
+        {
+          name: "path-qualified-env-sudo-shell",
+          command: "/usr/bin/env -P /usr/bin sudo --user=openclaw bash -lc 'python bad.py'",
+        },
+      ];
+
+      for (const testCase of cases) {
+        await expect(
+          tool.execute(`call-${testCase.name}`, {
+            command: testCase.command,
+            workdir: tmp,
+          }),
+        ).rejects.toThrow(/exec preflight: detected likely shell variable injection \(\$DM_JSON\)/);
+      }
+    });
+  });
+
   it("validates the first positional python script operand when extra args follow", async () => {
     await withTempDir("openclaw-exec-preflight-", async (tmp) => {
       await fs.writeFile(path.join(tmp, "bad.py"), "payload = $DM_JSON", "utf-8");

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -12,6 +12,7 @@ import {
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 import { normalizeChatChannelId } from "../channels/ids.js";
+import { resolveCarrierCommandArgv } from "../infra/command-carriers.js";
 import {
   type ExecAsk,
   type ExecHost,
@@ -562,6 +563,57 @@ function extractInterpreterScriptTargetFromArgv(
   return null;
 }
 
+function commandArgvKey(argv: readonly string[]): string {
+  return argv.join("\0");
+}
+
+function normalizeCommandExecutableToken(token: string | undefined): string | undefined {
+  const normalized = normalizeOptionalLowercaseString(token?.split(/[\\/]/u).at(-1));
+  if (!normalized) {
+    return undefined;
+  }
+  return normalized.endsWith(".exe") ? normalized.slice(0, -4) : normalized;
+}
+
+function extractScriptTargetFromArgvRecursive(
+  argv: string[] | null,
+  seenArgv = new Set<string>(),
+): { kind: "python"; relOrAbsPaths: string[] } | { kind: "node"; relOrAbsPaths: string[] } | null {
+  if (!argv || argv.length === 0) {
+    return null;
+  }
+  const key = commandArgvKey(argv);
+  if (seenArgv.has(key)) {
+    return null;
+  }
+  seenArgv.add(key);
+
+  const directTarget = extractInterpreterScriptTargetFromArgv(argv);
+  if (directTarget) {
+    return directTarget;
+  }
+
+  const carrierArgv = resolveCarrierCommandArgv(argv, 0, { includeExec: true });
+  if (carrierArgv) {
+    const carrierTarget = extractScriptTargetFromArgvRecursive(carrierArgv, seenArgv);
+    if (carrierTarget) {
+      return carrierTarget;
+    }
+  }
+
+  let commandIdx = 0;
+  while (commandIdx < argv.length && isShellEnvAssignmentToken(argv[commandIdx] ?? "")) {
+    commandIdx += 1;
+  }
+  const executable = normalizeCommandExecutableToken(argv[commandIdx]);
+  const shellPayload = extractShellWrappedCommandPayload(executable, argv.slice(commandIdx + 1));
+  if (!shellPayload) {
+    return null;
+  }
+  const shellPayloadArgv = splitShellArgs(shellPayload);
+  return extractScriptTargetFromArgvRecursive(shellPayloadArgv, seenArgv);
+}
+
 function extractInterpreterScriptPathsFromSegment(rawSegment: string): string[] {
   const argv = splitShellArgs(rawSegment.trim());
   if (!argv || argv.length === 0) {
@@ -641,7 +693,7 @@ function extractScriptTargetFromCommand(
   for (const argv of candidateArgv) {
     const attempts = [argv, argv ? stripPreflightEnvPrefix(argv) : null];
     for (const attempt of attempts) {
-      const target = extractInterpreterScriptTargetFromArgv(attempt);
+      const target = extractScriptTargetFromArgvRecursive(attempt);
       if (target) {
         return target;
       }
@@ -1195,6 +1247,7 @@ async function validateScriptFileForShellBleed(params: {
   const fsSafe = await loadFsSafeModule();
   const { FsSafeError, root: fsRoot } = fsSafe;
   const workspaceRoot = await fsRoot(params.workdir);
+  let checkedAnyScript = false;
   for (const relOrAbsPath of target.relOrAbsPaths) {
     const absPath = path.isAbsolute(relOrAbsPath)
       ? path.resolve(relOrAbsPath)
@@ -1235,6 +1288,8 @@ async function validateScriptFileForShellBleed(params: {
       throw error;
     }
 
+    checkedAnyScript = true;
+
     // Common failure mode: shell env var syntax leaking into Python/JS.
     // We deliberately match all-caps/underscore vars to avoid false positives with `$` as a JS identifier.
     const envVarRegex = /\$[A-Z_][A-Z0-9_]{1,}/g;
@@ -1269,6 +1324,29 @@ async function validateScriptFileForShellBleed(params: {
             `This looks like a shell command, not JavaScript.`,
         );
       }
+    }
+  }
+
+  if (!checkedAnyScript) {
+    const {
+      hasInterpreterInvocation,
+      hasComplexSyntax,
+      hasProcessSubstitution,
+      hasInterpreterSegmentScriptHint,
+      hasInterpreterPipelineScriptHint,
+      isDirectInterpreterCommand,
+    } = shouldFailClosedInterpreterPreflight(params.command);
+    if (
+      hasInterpreterInvocation &&
+      hasComplexSyntax &&
+      (hasInterpreterSegmentScriptHint ||
+        hasInterpreterPipelineScriptHint ||
+        (hasProcessSubstitution && isDirectInterpreterCommand))
+    ) {
+      throw new Error(
+        "exec preflight: complex interpreter invocation detected; refusing to run without script preflight validation. " +
+          "Use a direct `python <file>.py` or `node <file>.js` command.",
+      );
     }
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Exec script preflight could miss Python/Node script operands when the interpreter was hidden behind recursive command carriers or wrappers such as `sudo`, `env`, `env -S`, `exec`, or a shell wrapper (`bash -lc 'python bad.py'`). That allowed shell-bleed patterns like `$DM_JSON` in scripts to reach process execution instead of being stopped by preflight validation.

This hardens how the existing preflight heuristic resolves wrapped/carrier script targets when that heuristic runs: it recursively unwraps known carriers/wrappers before extracting script targets, and fails closed for complex interpreter invocations when no script can be validated.

## Relationship to Existing Exec Hardening Work

This is complementary to active and prior upstream exec-hardening work:

- #97107 relaxes the fail-closed interpreter heuristic under `exec.security=full`, which is a different trust regime.
- #59398 closed a fail-open bypass in exec script preflight.
- #62333 replaced TOCTOU check-then-read behavior with atomic pinned-fd open in script preflight.
- #67924 addressed tolerating shell-like text inside Python/JS string literals during preflight.

This PR does not change the broader trust policy. It hardens target discovery for the cases where script preflight is already supposed to inspect a Python/Node script but the script operand is hidden behind carriers or shell wrappers.

## Summary

- Recursively unwrap command carriers such as `sudo`, `env`, `exec`, and shell wrappers before exec script preflight validation.
- Catch shell-bleed patterns in Python/Node scripts even when launched through carrier/wrapper chains.
- Add regression coverage for sudo option values, env modifiers, `env -S`, and nested carrier + shell wrapper forms.

## Evidence

- RED: with implementation reverted, targeted new tests failed by reaching `sudo`/`env` execution instead of preflight rejection.
- GREEN targeted tests passed:
  `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-core.config.ts src/agents/bash-tools.exec.script-preflight.test.ts -t "carrier option values before execution|clustered sudo/env shell wrappers"`
  Result: 1 file passed, 2 tests passed / 61 skipped.
- Full targeted preflight suite passed:
  `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-core.config.ts src/agents/bash-tools.exec.script-preflight.test.ts`
  Result: 1 file passed, 59 tests passed / 4 skipped.
- Typecheck passed individually after combined `CI=true pnpm check:test-types` was SIGKILLed during the extensions phase:
  - `CI=true pnpm tsgo:core:test`
  - `CI=true pnpm tsgo:extensions:test`
