### PR TITLE
chore(ci): dedupe Crabbox Docker check

### DIFF
--- a/.github/workflows/crabbox-hydrate.yml
+++ b/.github/workflows/crabbox-hydrate.yml
@@ -190,7 +190,8 @@ jobs:
           PNPM
           sudo chmod 0755 /usr/local/bin/pnpm
 
-      - name: Ensure Docker is running
+      - &crabbox_ensure_docker_step
+        name: Ensure Docker is running
         shell: bash
         run: |
           set -euo pipefail
@@ -612,59 +613,7 @@ jobs:
           PNPM
           sudo chmod 0755 /usr/local/bin/pnpm
 
-      - name: Ensure Docker is running
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          if ! command -v docker >/dev/null 2>&1; then
-            echo "docker not found; installing fallback engine"
-            curl --fail --show-error --location \
-              --connect-timeout "${OPENCLAW_CRABBOX_HYDRATE_DOWNLOAD_CONNECT_TIMEOUT_SECONDS:-15}" \
-              --max-time "${OPENCLAW_CRABBOX_HYDRATE_DOWNLOAD_TIMEOUT_SECONDS:-300}" \
-              --retry "${OPENCLAW_CRABBOX_HYDRATE_DOWNLOAD_RETRIES:-3}" \
-              --retry-delay "${OPENCLAW_CRABBOX_HYDRATE_DOWNLOAD_RETRY_DELAY_SECONDS:-5}" \
-              --retry-all-errors \
-              https://get.docker.com | sudo sh
-          fi
-
-          if command -v systemctl >/dev/null 2>&1; then
-            sudo systemctl start docker || true
-          elif command -v service >/dev/null 2>&1; then
-            sudo service docker start || true
-          fi
-
-          if [ -S /var/run/docker.sock ]; then
-            sudo usermod -aG docker "$USER" || true
-            # The runner process keeps its original groups; grant this
-            # ephemeral runner session access without requiring a relogin.
-            sudo chmod 666 /var/run/docker.sock
-          fi
-
-          if ! docker buildx version >/dev/null 2>&1; then
-            arch="$(uname -m)"
-            case "$arch" in
-              aarch64|arm64) buildx_arch=arm64 ;;
-              x86_64|amd64) buildx_arch=amd64 ;;
-              *) echo "unsupported buildx arch: $arch" >&2; exit 2 ;;
-            esac
-            buildx_version="${DOCKER_BUILDX_VERSION:-v0.15.1}"
-            mkdir -p "$HOME/.docker/cli-plugins"
-            curl --fail --show-error --location \
-              --connect-timeout "${OPENCLAW_CRABBOX_HYDRATE_DOWNLOAD_CONNECT_TIMEOUT_SECONDS:-15}" \
-              --max-time "${OPENCLAW_CRABBOX_HYDRATE_DOWNLOAD_TIMEOUT_SECONDS:-300}" \
-              --retry "${OPENCLAW_CRABBOX_HYDRATE_DOWNLOAD_RETRIES:-3}" \
-              --retry-delay "${OPENCLAW_CRABBOX_HYDRATE_DOWNLOAD_RETRY_DELAY_SECONDS:-5}" \
-              --retry-all-errors \
-              "https://github.com/docker/buildx/releases/download/${buildx_version}/buildx-${buildx_version}.linux-${buildx_arch}" \
-              -o "$HOME/.docker/cli-plugins/docker-buildx"
-            chmod 0755 "$HOME/.docker/cli-plugins/docker-buildx"
-          fi
-
-          docker version
-          docker buildx version
-          docker compose version || true
-
+      - *crabbox_ensure_docker_step
       - name: Ensure SSH is available
         shell: bash
         run: |


### PR DESCRIPTION
## What Problem This Solves

Resolves a CI maintenance problem where the same `Ensure Docker is running` step was copied in both Crabbox hydrate jobs in `.github/workflows/crabbox-hydrate.yml`.

## Why This Change Was Made

This uses a YAML anchor on the first Docker readiness step and aliases the second exact copy. Before editing, the two candidate blocks had one parsed YAML value and one normalized-source hash, so only fully identical chunks were deduplicated.

This PR was prepared with Codex.

## User Impact

No product behavior changes. CI maintainers get one canonical Crabbox Docker readiness block instead of two copies.

## Evidence

Duplicate proof before editing:

- Jobs checked: `hydrate`, `hydrate-github`
- Normalized source hash for both: `2b6fff5522038f028f14c2ff6094905a089c6167f891d26989806493cf2826cd`
- Parsed YAML values: one unique value across both blocks

Validation:

- `actionlint .github/workflows/crabbox-hydrate.yml`
- `git diff --check`
