### PR TITLE
fix(codex): require admin for native controls

### DIFF
--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -8448,6 +8448,14 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: What the wizard writes
   - H2: Related docs
 
+## releases/index.md
+
+- Route: /releases
+- Headings:
+  - H1: Release notes
+  - H2: Coming soon
+  - H2: Raw release history
+
 ## security/CONTRIBUTING-THREAT-MODEL.md
 
 - Route: /security/CONTRIBUTING-THREAT-MODEL

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -404,6 +404,12 @@ timeout behavior, see [Codex harness reference](/plugins/codex-harness-reference
 The bundled plugin registers `/codex` as a slash command on any channel that
 supports OpenClaw text commands.
 
+Native execution and control require an owner or an `operator.admin` Gateway
+client. This includes binding or resuming threads, sending or stopping turns,
+changing model, fast-mode, or permission state, compacting or reviewing, and
+detaching a binding. Other authorized senders retain read-only status, help,
+account, model, thread, MCP server, skill, and binding inspection commands.
+
 Common forms:
 
 - `/codex status` checks app-server connectivity, models, account, rate limits,

--- a/extensions/codex/src/command-authorization.ts
+++ b/extensions/codex/src/command-authorization.ts
@@ -1,5 +1,13 @@
 import type { PluginCommandContext } from "openclaw/plugin-sdk/plugin-entry";
 
-export function canMutateCodexHost(ctx: PluginCommandContext): boolean {
+type CodexHostMutationAuthContext = Pick<
+  PluginCommandContext,
+  "gatewayClientScopes" | "senderIsOwner"
+>;
+
+export const CODEX_NATIVE_EXECUTION_AUTH_ERROR =
+  "Only an owner or operator.admin can control Codex native execution.";
+
+export function canMutateCodexHost(ctx: CodexHostMutationAuthContext): boolean {
   return ctx.senderIsOwner === true || ctx.gatewayClientScopes?.includes("operator.admin") === true;
 }

--- a/extensions/codex/src/command-handlers.ts
+++ b/extensions/codex/src/command-handlers.ts
@@ -24,10 +24,7 @@ import {
   writeCodexAppServerBinding,
 } from "./app-server/session-binding.js";
 import { readCodexAccountAuthOverview } from "./command-account.js";
-import {
-  canMutateCodexHost,
-  CODEX_NATIVE_EXECUTION_AUTH_ERROR,
-} from "./command-authorization.js";
+import { canMutateCodexHost, CODEX_NATIVE_EXECUTION_AUTH_ERROR } from "./command-authorization.js";
 import {
   buildHelp,
   formatAccount,

--- a/extensions/codex/src/command-handlers.ts
+++ b/extensions/codex/src/command-handlers.ts
@@ -24,7 +24,10 @@ import {
   writeCodexAppServerBinding,
 } from "./app-server/session-binding.js";
 import { readCodexAccountAuthOverview } from "./command-account.js";
-import { canMutateCodexHost } from "./command-authorization.js";
+import {
+  canMutateCodexHost,
+  CODEX_NATIVE_EXECUTION_AUTH_ERROR,
+} from "./command-authorization.js";
 import {
   buildHelp,
   formatAccount,
@@ -233,6 +236,12 @@ const CODEX_NATIVE_EXECUTION_SUBCOMMANDS = new Set([
   "compact",
   "review",
 ]);
+const CODEX_NATIVE_CONTROL_SUBCOMMANDS = new Set([
+  ...CODEX_NATIVE_EXECUTION_SUBCOMMANDS,
+  "detach",
+  "unbind",
+  "stop",
+]);
 
 const lastCodexDiagnosticsUploadByThread = new Map<string, number>();
 const lastCodexDiagnosticsUploadByScope = new Map<string, number>();
@@ -377,6 +386,13 @@ export async function handleCodexSubcommand(
   const normalized = subcommand.toLowerCase();
   if (normalized === "help") {
     return { text: buildHelp() };
+  }
+  if (
+    CODEX_NATIVE_CONTROL_SUBCOMMANDS.has(normalized) &&
+    !returnsBeforeNativeCodexExecution(normalized, rest) &&
+    !canMutateCodexHost(ctx)
+  ) {
+    return { text: CODEX_NATIVE_EXECUTION_AUTH_ERROR };
   }
   const sandboxBlock = resolveCodexNativeCommandSandboxBlock(ctx, normalized, rest);
   if (sandboxBlock) {
@@ -603,6 +619,8 @@ function returnsBeforeNativeCodexExecution(subcommand: string, args: readonly st
       );
     case "compact":
     case "review":
+    case "detach":
+    case "unbind":
     case "stop":
       return args.length > 0;
     default:
@@ -1000,14 +1018,14 @@ async function setConversationPermissions(
   if (args.length > 1) {
     return "Usage: /codex permissions [default|yolo|status]";
   }
-  const target = await resolveControlTarget(ctx);
-  if (!target) {
-    return "Cannot set Codex permissions because this command did not include an OpenClaw session file.";
-  }
   const value = args[0];
   const parsed = parseCodexPermissionsModeArg(value);
   if (value && !parsed && value.trim().toLowerCase() !== "status") {
     return "Usage: /codex permissions [default|yolo|status]";
+  }
+  const target = await resolveControlTarget(ctx);
+  if (!target) {
+    return "Cannot set Codex permissions because this command did not include an OpenClaw session file.";
   }
   return await deps.setCodexConversationPermissions({
     sessionFile: target.sessionFile,

--- a/extensions/codex/src/commands.test.ts
+++ b/extensions/codex/src/commands.test.ts
@@ -3878,6 +3878,106 @@ describe("codex command", () => {
     });
   });
 
+  it("requires an owner or operator.admin for Codex binding and permission changes", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const startCodexConversationThread = vi.fn();
+    const codexControlRequest = vi.fn();
+    const resolveCodexCliSessionForBindingOnNode = vi.fn();
+    const stopCodexConversationTurn = vi.fn();
+    const steerCodexConversationTurn = vi.fn();
+    const setCodexConversationModel = vi.fn();
+    const setCodexConversationFastMode = vi.fn();
+    const setCodexConversationPermissions = vi.fn(
+      async () => "Codex permissions set to full access.",
+    );
+    const cases = [
+      ["bind", createDeps({ startCodexConversationThread }), startCodexConversationThread],
+      ["resume thread-123", createDeps({ codexControlRequest }), codexControlRequest],
+      [
+        "resume cli-session --host worker-1 --bind here",
+        createDeps({ resolveCodexCliSessionForBindingOnNode }),
+        resolveCodexCliSessionForBindingOnNode,
+      ],
+      ["stop", createDeps({ stopCodexConversationTurn }), stopCodexConversationTurn],
+      [
+        "permissions yolo",
+        createDeps({ setCodexConversationPermissions }),
+        setCodexConversationPermissions,
+      ],
+      ["steer continue", createDeps({ steerCodexConversationTurn }), steerCodexConversationTurn],
+      ["model gpt-5.5", createDeps({ setCodexConversationModel }), setCodexConversationModel],
+      ["fast on", createDeps({ setCodexConversationFastMode }), setCodexConversationFastMode],
+      ["compact", createDeps({ codexControlRequest }), codexControlRequest],
+      ["review", createDeps({ codexControlRequest }), codexControlRequest],
+    ] as const;
+
+    for (const [args, deps, sideEffect] of cases) {
+      await expect(
+        handleCodexCommand(
+          createContext(args, sessionFile, {
+            senderIsOwner: false,
+            gatewayClientScopes: ["operator.write"],
+          }),
+          { deps },
+        ),
+      ).resolves.toEqual({
+        text: "Only an owner or operator.admin can control Codex native execution.",
+      });
+      expect(sideEffect).not.toHaveBeenCalled();
+    }
+
+    const detachConversationBinding = vi.fn();
+    for (const args of ["detach", "unbind"]) {
+      await expect(
+        handleCodexCommand(
+          createContext(args, sessionFile, {
+            senderIsOwner: false,
+            gatewayClientScopes: ["operator.write"],
+            detachConversationBinding,
+          }),
+          { deps: createDeps() },
+        ),
+      ).resolves.toEqual({
+        text: "Only an owner or operator.admin can control Codex native execution.",
+      });
+    }
+    expect(detachConversationBinding).not.toHaveBeenCalled();
+
+    const readCodexPermissions = vi.fn(async () => "Codex permissions: full access.");
+    await expect(
+      handleCodexCommand(
+        createContext("permissions status", sessionFile, {
+          senderIsOwner: false,
+          gatewayClientScopes: ["operator.write"],
+        }),
+        { deps: createDeps({ setCodexConversationPermissions: readCodexPermissions }) },
+      ),
+    ).resolves.toEqual({ text: "Codex permissions: full access." });
+    expect(readCodexPermissions).toHaveBeenCalledTimes(1);
+
+    await expect(
+      handleCodexCommand(
+        createContext("permissions yolo", sessionFile, {
+          senderIsOwner: true,
+          gatewayClientScopes: ["operator.write"],
+        }),
+        { deps: createDeps({ setCodexConversationPermissions }) },
+      ),
+    ).resolves.toEqual({ text: "Codex permissions set to full access." });
+    expect(setCodexConversationPermissions).toHaveBeenCalledTimes(1);
+
+    await expect(
+      handleCodexCommand(
+        createContext("permissions yolo", sessionFile, {
+          senderIsOwner: false,
+          gatewayClientScopes: ["operator.admin"],
+        }),
+        { deps: createDeps({ setCodexConversationPermissions }) },
+      ),
+    ).resolves.toEqual({ text: "Codex permissions set to full access." });
+    expect(setCodexConversationPermissions).toHaveBeenCalledTimes(2);
+  });
+
   it("escapes current bound model status before chat display", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     await fs.writeFile(

--- a/extensions/codex/src/conversation-binding.test.ts
+++ b/extensions/codex/src/conversation-binding.test.ts
@@ -581,7 +581,6 @@ describe("codex conversation binding", () => {
         channel: "discord",
         isGroup: true,
         senderIsOwner: false,
-        gatewayClientScopes: ["operator.write"],
       },
       {
         channelId: "discord",
@@ -606,17 +605,14 @@ describe("codex conversation binding", () => {
     expect(result).toEqual({ handled: true });
   });
 
-  it.each([
-    { senderIsOwner: false },
-    { senderIsOwner: false, gatewayClientScopes: ["operator.write"] },
-  ])("blocks inbound bound turns without current owner or admin authority", async (auth) => {
+  it("blocks inbound bound turns without current owner or admin authority", async () => {
     const result = await handleCodexConversationInboundClaim(
       {
         content: "run this",
         channel: "discord",
         isGroup: true,
         commandAuthorized: true,
-        ...auth,
+        senderIsOwner: false,
       },
       {
         channelId: "discord",

--- a/extensions/codex/src/conversation-binding.test.ts
+++ b/extensions/codex/src/conversation-binding.test.ts
@@ -580,6 +580,8 @@ describe("codex conversation binding", () => {
         content: "run this",
         channel: "discord",
         isGroup: true,
+        senderIsOwner: false,
+        gatewayClientScopes: ["operator.write"],
       },
       {
         channelId: "discord",

--- a/extensions/codex/src/conversation-binding.test.ts
+++ b/extensions/codex/src/conversation-binding.test.ts
@@ -73,9 +73,15 @@ vi.mock("openclaw/plugin-sdk/agent-runtime", () => agentRuntimeMocks);
 import { resolveCodexAppServerRuntimeOptions } from "./app-server/config.js";
 import {
   handleCodexConversationBindingResolved,
-  handleCodexConversationInboundClaim,
+  handleCodexConversationInboundClaim as handleCodexConversationInboundClaimImpl,
   startCodexConversationThread,
 } from "./conversation-binding.js";
+
+function handleCodexConversationInboundClaim(
+  ...[event, ...rest]: Parameters<typeof handleCodexConversationInboundClaimImpl>
+) {
+  return handleCodexConversationInboundClaimImpl({ senderIsOwner: true, ...event }, ...rest);
+}
 
 let tempDir: string;
 
@@ -596,6 +602,45 @@ describe("codex conversation binding", () => {
     );
 
     expect(result).toEqual({ handled: true });
+  });
+
+  it.each([
+    { senderIsOwner: false },
+    { senderIsOwner: false, gatewayClientScopes: ["operator.write"] },
+  ])("blocks inbound bound turns without current owner or admin authority", async (auth) => {
+    const result = await handleCodexConversationInboundClaim(
+      {
+        content: "run this",
+        channel: "discord",
+        isGroup: true,
+        commandAuthorized: true,
+        ...auth,
+      },
+      {
+        channelId: "discord",
+        pluginBinding: {
+          bindingId: "binding-1",
+          pluginId: "codex",
+          pluginRoot: tempDir,
+          channel: "discord",
+          accountId: "default",
+          conversationId: "channel-1",
+          boundAt: Date.now(),
+          data: {
+            kind: "codex-app-server-session",
+            version: 1,
+            sessionFile: path.join(tempDir, "session.jsonl"),
+            workspaceDir: tempDir,
+          },
+        },
+      },
+    );
+
+    expect(result).toEqual({
+      handled: true,
+      reply: { text: "Only an owner or operator.admin can control Codex native execution." },
+    });
+    expect(sharedClientMocks.getSharedCodexAppServerClient).not.toHaveBeenCalled();
   });
 
   it("routes bound Codex CLI node sessions through node resume", async () => {

--- a/extensions/codex/src/conversation-binding.ts
+++ b/extensions/codex/src/conversation-binding.ts
@@ -53,10 +53,7 @@ import {
   CODEX_NATIVE_PERSONALITY_NONE,
   resolveCodexAppServerRequestModelSelection,
 } from "./app-server/thread-lifecycle.js";
-import {
-  canMutateCodexHost,
-  CODEX_NATIVE_EXECUTION_AUTH_ERROR,
-} from "./command-authorization.js";
+import { canMutateCodexHost, CODEX_NATIVE_EXECUTION_AUTH_ERROR } from "./command-authorization.js";
 import { formatCodexDisplayText } from "./command-formatters.js";
 import {
   createCodexConversationBindingData,

--- a/extensions/codex/src/conversation-binding.ts
+++ b/extensions/codex/src/conversation-binding.ts
@@ -53,6 +53,10 @@ import {
   CODEX_NATIVE_PERSONALITY_NONE,
   resolveCodexAppServerRequestModelSelection,
 } from "./app-server/thread-lifecycle.js";
+import {
+  canMutateCodexHost,
+  CODEX_NATIVE_EXECUTION_AUTH_ERROR,
+} from "./command-authorization.js";
 import { formatCodexDisplayText } from "./command-formatters.js";
 import {
   createCodexConversationBindingData,
@@ -236,6 +240,9 @@ export async function handleCodexConversationInboundClaim(
   const data = readCodexConversationBindingData(ctx.pluginBinding);
   if (!data) {
     return undefined;
+  }
+  if (!canMutateCodexHost(event)) {
+    return { handled: true, reply: { text: CODEX_NATIVE_EXECUTION_AUTH_ERROR } };
   }
   if (event.commandAuthorized !== true) {
     return { handled: true };

--- a/extensions/codex/src/conversation-binding.ts
+++ b/extensions/codex/src/conversation-binding.ts
@@ -238,15 +238,15 @@ export async function handleCodexConversationInboundClaim(
   if (!data) {
     return undefined;
   }
-  if (!canMutateCodexHost(event)) {
-    return { handled: true, reply: { text: CODEX_NATIVE_EXECUTION_AUTH_ERROR } };
-  }
   if (event.commandAuthorized !== true) {
     return { handled: true };
   }
   const prompt = event.bodyForAgent?.trim() || event.content?.trim() || "";
   if (!prompt) {
     return { handled: true };
+  }
+  if (!canMutateCodexHost(event)) {
+    return { handled: true, reply: { text: CODEX_NATIVE_EXECUTION_AUTH_ERROR } };
   }
   const nativeExecutionBlock =
     data.kind === "codex-cli-node-session"

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -6601,7 +6601,6 @@ describe("dispatchReplyFromConfig", () => {
             channel?: unknown;
             content?: unknown;
             conversationId?: unknown;
-            gatewayClientScopes?: unknown;
             senderIsOwner?: unknown;
           },
           {
@@ -6618,7 +6617,7 @@ describe("dispatchReplyFromConfig", () => {
     expect(inboundClaimCall?.[1]?.conversationId).toBe("channel:1481858418548412579");
     expect(inboundClaimCall?.[1]?.content).toBe("who are you");
     expect(inboundClaimCall?.[1]?.senderIsOwner).toBe(true);
-    expect(inboundClaimCall?.[1]?.gatewayClientScopes).toEqual(["operator.write"]);
+    expect(inboundClaimCall?.[1]).not.toHaveProperty("gatewayClientScopes");
     expect(inboundClaimCall?.[2]?.channelId).toBe("discord");
     expect(inboundClaimCall?.[2]?.accountId).toBe("default");
     expect(inboundClaimCall?.[2]?.conversationId).toBe("channel:1481858418548412579");

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -6576,6 +6576,8 @@ describe("dispatchReplyFromConfig", () => {
       AccountId: "default",
       SenderId: "user-9",
       SenderUsername: "ada",
+      OwnerAllowFrom: ["user-9"],
+      GatewayClientScopes: ["operator.write"],
       CommandAuthorized: true,
       WasMentioned: false,
       CommandBody: "who are you",
@@ -6594,7 +6596,14 @@ describe("dispatchReplyFromConfig", () => {
       .calls[0] as unknown as
       | [
           unknown,
-          { accountId?: unknown; channel?: unknown; content?: unknown; conversationId?: unknown },
+          {
+            accountId?: unknown;
+            channel?: unknown;
+            content?: unknown;
+            conversationId?: unknown;
+            gatewayClientScopes?: unknown;
+            senderIsOwner?: unknown;
+          },
           {
             accountId?: unknown;
             channelId?: unknown;
@@ -6608,6 +6617,8 @@ describe("dispatchReplyFromConfig", () => {
     expect(inboundClaimCall?.[1]?.accountId).toBe("default");
     expect(inboundClaimCall?.[1]?.conversationId).toBe("channel:1481858418548412579");
     expect(inboundClaimCall?.[1]?.content).toBe("who are you");
+    expect(inboundClaimCall?.[1]?.senderIsOwner).toBe(true);
+    expect(inboundClaimCall?.[1]?.gatewayClientScopes).toEqual(["operator.write"]);
     expect(inboundClaimCall?.[2]?.channelId).toBe("discord");
     expect(inboundClaimCall?.[2]?.accountId).toBe("default");
     expect(inboundClaimCall?.[2]?.conversationId).toBe("channel:1481858418548412579");

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -2150,7 +2150,7 @@ export async function dispatchReplyFromConfig(
         `plugin-bound inbound routed to ${pluginOwnedBinding.pluginId} conversation=${pluginOwnedBinding.conversationId}`,
       );
       // Bound native runtimes need the current owner decision, not stale bind-time identity.
-      // Gateway scopes remain explicit so plugins can preserve scope precedence over owner status.
+      // The resolver folds internal operator.admin authority into this owner decision.
       const bindingAuthorization = resolveCommandAuthorization({
         ctx,
         cfg,
@@ -2162,9 +2162,6 @@ export async function dispatchReplyFromConfig(
             const authorizedInboundClaimEvent = {
               ...inboundClaimEvent,
               senderIsOwner: bindingAuthorization.senderIsOwner,
-              ...(ctx.GatewayClientScopes
-                ? { gatewayClientScopes: [...ctx.GatewayClientScopes] }
-                : {}),
             };
             return hookRunner.runInboundClaimForPluginOutcome(
               pluginOwnedBinding.pluginId,

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -104,6 +104,7 @@ import {
   shouldAttemptTtsPayload,
 } from "../../tts/tts-config.js";
 import { INTERNAL_MESSAGE_CHANNEL, normalizeMessageChannel } from "../../utils/message-channel.js";
+import { resolveCommandAuthorization } from "../command-auth.js";
 import {
   isNativeCommandTurn,
   resolveCommandTurnContext,
@@ -2148,12 +2149,26 @@ export async function dispatchReplyFromConfig(
       logVerbose(
         `plugin-bound inbound routed to ${pluginOwnedBinding.pluginId} conversation=${pluginOwnedBinding.conversationId}`,
       );
+      // Bound native runtimes need the current owner decision, not stale bind-time identity.
+      // Gateway scopes remain explicit so plugins can preserve scope precedence over owner status.
+      const bindingAuthorization = resolveCommandAuthorization({
+        ctx,
+        cfg,
+        commandAuthorized: ctx.CommandAuthorized,
+      });
       const targetedClaimOutcome = hookRunner?.runInboundClaimForPluginOutcome
         ? await (async () => {
             await prepareHookMediaMetadata();
+            const authorizedInboundClaimEvent = {
+              ...inboundClaimEvent,
+              senderIsOwner: bindingAuthorization.senderIsOwner,
+              ...(ctx.GatewayClientScopes
+                ? { gatewayClientScopes: [...ctx.GatewayClientScopes] }
+                : {}),
+            };
             return hookRunner.runInboundClaimForPluginOutcome(
               pluginOwnedBinding.pluginId,
-              inboundClaimEvent,
+              authorizedInboundClaimEvent,
               { ...inboundClaimContext, pluginBinding: pluginOwnedBinding },
             );
           })()

--- a/src/plugins/hook-message.types.ts
+++ b/src/plugins/hook-message.types.ts
@@ -92,7 +92,6 @@ export type PluginHookInboundClaimEvent = {
   isGroup: boolean;
   commandAuthorized?: boolean;
   senderIsOwner?: boolean;
-  gatewayClientScopes?: string[];
   wasMentioned?: boolean;
   metadata?: Record<string, unknown>;
 };

--- a/src/plugins/hook-message.types.ts
+++ b/src/plugins/hook-message.types.ts
@@ -91,6 +91,8 @@ export type PluginHookInboundClaimEvent = {
   parentSpanId?: string;
   isGroup: boolean;
   commandAuthorized?: boolean;
+  senderIsOwner?: boolean;
+  gatewayClientScopes?: string[];
   wasMentioned?: boolean;
   metadata?: Record<string, unknown>;
 };


### PR DESCRIPTION
## Summary

### What Problem This Solves

Sensitive native Codex controls did not consistently consume the owner/admin authorization facts already available to the command and bound-conversation paths.

### Why This Change Was Made

Native execution and binding mutation should follow the existing privileged-control boundary while read-only status, help, and invalid-usage responses remain available.

## Changes

- Rebase onto merged #97955 and reuse its canonical `canMutateCodexHost` owner-or-`operator.admin` predicate.
- Preserve #97955's `/codex computer-use install` authorization and documentation unchanged.
- Require current owner identity or `operator.admin` scope for native Codex execution, control, binding, and detach operations.
- Recheck current sender authority before every bound Codex turn.
- Return an explicit denial for command-authorized, non-empty blocked bound turns while preserving silent handling for unauthorized and empty traffic.
- Carry the canonical current owner/admin decision through the generic inbound-claim event without exposing raw Gateway scopes.
- Document the native-control authorization boundary.
- Regenerate `docs/docs_map.md` after rebasing onto current `main`.
- Add regression coverage for denied side effects, owner/admin allowance, current-sender propagation, visible denial, silent unauthorized handling, and read-only status access.

## Validation

### Evidence

- `node scripts/run-vitest.mjs extensions/codex/src/commands.test.ts extensions/codex/src/conversation-binding.test.ts src/auto-reply/reply/dispatch-from-config.test.ts src/auto-reply/command-auth.owner-default.test.ts` — 4 files, 391 tests passed across 3 shards.
- `node scripts/generate-docs-map.mjs --check` — generated docs map is current.
- `node scripts/check-src-extension-import-boundary.mjs --json` — no violations.
- `node scripts/check-sdk-package-extension-import-boundary.mjs --json` — no violations.
- `node scripts/check-test-helper-extension-import-boundary.mjs --json` — no violations.
- `node scripts/format-docs.mjs --check` — 670 files clean.
- `node scripts/check-docs-mdx.mjs docs README.md` — 686 files passed.
- `node scripts/docs-link-audit.mjs` — 5,494 internal links checked, zero broken.
- `git diff --check` — passed.
- Structured Codex autoreview after the docs and hook-contract refinement — clean, no accepted/actionable findings (0.94 confidence).
- Existing real stdio child-process proof remains attached with its original proof SHA and current-head alignment notes.

## Notes

### User Impact

Owners and `operator.admin` callers retain native Codex control. Ordinary command-authorized senders can still use read-only/status surfaces but cannot start, mutate, detach, or drive native Codex execution. Command-authorized, non-empty blocked bound turns explain the owner/admin requirement; ordinary unauthorized or empty bound traffic remains silently handled.

Maintainer acceptance: the fail-closed access change and the single optional `senderIsOwner` inbound-claim field are intentional. Command authorization alone must not grant native Codex control, and the prepared owner/admin decision is required to recheck authority at bound-turn time. Raw `gatewayClientScopes` are not added to the hook event.

`pnpm docs:list` was attempted but pnpm aborted an interactive modules-directory reconciliation in the non-TTY checkout. The underlying generated-map, formatting, MDX, and link checks were run directly and passed.

AI-assisted change; I reviewed the implementation and validation results.
