### PR TITLE
fix(acp): require owner for runtime controls

### DIFF
--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -790,6 +790,12 @@ If no target resolves, OpenClaw returns a clear error
 | `/acp doctor`        | Backend health, capabilities, actionable fixes.           | `/acp doctor`                                                 |
 | `/acp install`       | Print deterministic install and enable steps.             | `/acp install`                                                |
 
+Runtime controls (`spawn`, `cancel`, `steer`, `close`, `status`, `set-mode`,
+`set`, `cwd`, `permissions`, `timeout`, `model`, and `reset-options`) require
+owner identity from external channels and `operator.admin` from internal Gateway
+clients. Authorized non-owner senders can still use `sessions`, `doctor`,
+`install`, and `help`.
+
 `/acp status` shows the effective runtime options plus runtime-level and
 backend-level session identifiers. Unsupported-control errors surface
 clearly when a backend lacks a capability. `/acp sessions` reads the

--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -256,7 +256,7 @@ plugins.
     | Command | Description |
     | --- | --- |
     | `/subagents list\|log\|info` | Inspect sub-agent runs for the current session |
-    | `/acp spawn\|cancel\|steer\|close\|sessions\|status\|set-mode\|set\|cwd\|permissions\|timeout\|model\|reset-options\|doctor\|install\|help` | Manage ACP sessions and runtime options |
+    | `/acp spawn\|cancel\|steer\|close\|sessions\|status\|set-mode\|set\|cwd\|permissions\|timeout\|model\|reset-options\|doctor\|install\|help` | Manage ACP sessions and runtime options. Runtime controls require external owner or internal Gateway admin identity |
     | `/focus <target>` | Bind the current Discord thread or Telegram topic to a session target |
     | `/unfocus` | Remove the current thread binding |
     | `/agents` | List thread-bound agents for the current session |

--- a/src/auto-reply/reply/commands-acp.test.ts
+++ b/src/auto-reply/reply/commands-acp.test.ts
@@ -518,6 +518,7 @@ function createDiscordParams(commandBody: string, cfg: OpenClawConfig = baseCfg)
     AccountId: "default",
   });
   params.command.senderId = "user-1";
+  params.command.senderIsOwner = true;
   return params;
 }
 
@@ -752,6 +753,7 @@ function createConversationParams(
     ...(fixture.threadParentId ? { ThreadParentId: fixture.threadParentId } : {}),
   });
   params.command.senderId = fixture.senderId ?? "user-1";
+  params.command.senderIsOwner = true;
   return params;
 }
 
@@ -896,7 +898,6 @@ async function runInternalAcpCommand(params: {
   });
   commandParams.command.channel = INTERNAL_MESSAGE_CHANNEL;
   commandParams.command.senderId = "user-1";
-  commandParams.command.senderIsOwner = true;
   return handleAcpCommand(commandParams, true);
 }
 
@@ -1140,6 +1141,37 @@ describe("/acp command", () => {
     const result = await runDiscordAcpCommand("/acp");
     expect(result?.reply?.text).toContain("ACP commands:");
     expect(result?.reply?.text).toContain("/acp spawn");
+  });
+
+  it.each([
+    "spawn codex",
+    "cancel",
+    "steer continue",
+    "close",
+    "status",
+    "set-mode plan",
+    "set model gpt-5.5",
+    "cwd /tmp",
+    "permissions approve-all",
+    "timeout 120",
+    "model openai/gpt-5.5",
+    "reset-options",
+  ])("blocks authorized non-owners from /acp %s", async (action) => {
+    const params = createDiscordParams(`/acp ${action}`);
+    params.command.senderIsOwner = false;
+
+    const result = await handleAcpCommand(params, true);
+
+    expect(result).toEqual({ shouldContinue: false });
+  });
+
+  it("keeps read-only /acp actions available to authorized non-owners", async () => {
+    const params = createDiscordParams("/acp sessions");
+    params.command.senderIsOwner = false;
+
+    const result = await handleAcpCommand(params, true);
+
+    expect(result?.reply?.text).toContain("ACP sessions:");
   });
 
   it("spawns an ACP session and binds a Discord thread", async () => {

--- a/src/auto-reply/reply/commands-acp.ts
+++ b/src/auto-reply/reply/commands-acp.ts
@@ -1,7 +1,7 @@
 // Implements ACP session commands and runtime status formatting.
 import { logVerbose } from "../../globals.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
-import { requireGatewayClientScope } from "./command-gates.js";
+import { rejectNonOwnerCommand, requireGatewayClientScope } from "./command-gates.js";
 import {
   COMMAND,
   type AcpAction,
@@ -71,7 +71,7 @@ async function loadAcpActionHandler(action: Exclude<AcpAction, "help">): Promise
   return diagnosticHandlers[action];
 }
 
-const ACP_MUTATING_ACTIONS = new Set<AcpAction>([
+const ACP_OWNER_REQUIRED_ACTIONS = new Set<AcpAction>([
   "spawn",
   "cancel",
   "steer",
@@ -104,7 +104,7 @@ export const handleAcpCommand: CommandHandler = async (params, _allowTextCommand
     return stopWithText(resolveAcpHelpText());
   }
 
-  if (ACP_MUTATING_ACTIONS.has(action)) {
+  if (ACP_OWNER_REQUIRED_ACTIONS.has(action)) {
     const scopeBlock = requireGatewayClientScope(params, {
       label: "/acp",
       allowedScopes: ["operator.admin"],
@@ -112,6 +112,12 @@ export const handleAcpCommand: CommandHandler = async (params, _allowTextCommand
     });
     if (scopeBlock) {
       return scopeBlock;
+    }
+    // Command auth maps internal operator.admin scope to owner identity, so this
+    // second gate rejects external non-owners without blocking Gateway admins.
+    const nonOwner = rejectNonOwnerCommand(params, "/acp");
+    if (nonOwner) {
+      return nonOwner;
     }
   }
 


### PR DESCRIPTION
## Summary

### What Problem This Solves

Fixes an issue where an authorized non-owner channel sender could invoke ACP runtime controls that are reserved for owners or internal Gateway administrators.

### Why This Change Was Made

ACP runtime-control actions now use the existing owner gate in addition to the existing internal `operator.admin` scope gate. Read-only diagnostics and discovery remain available to authorized non-owner senders.

## Changes

- Require external owner identity for ACP session lifecycle and runtime-option controls.
- Preserve `operator.admin` enforcement for internal Gateway clients.
- Keep `/acp sessions`, `/acp doctor`, `/acp install`, and `/acp help` available to authorized non-owners.
- Document the external-owner and internal-admin requirements.
- Add regression coverage for every gated action and retained read-only access.

### User Impact

Non-owner channel users can no longer create, steer, close, or reconfigure ACP runtime sessions. Existing owner and internal Gateway admin workflows continue to work.

## Validation

### Evidence

- Native Telegram Desktop before/after on PR head `eca0f26e6ca8af7d4d68e971f4b856fd13685939`: the same authorized non-owner `/acp status` request reaches the ACP handler on main, while the candidate replies `You are not authorized to use this command.` ([run](https://github.com/openclaw/openclaw/actions/runs/28409381611), [artifact](https://github.com/openclaw/openclaw/actions/runs/28409381611/artifacts/7967578443), [inline proof](https://github.com/openclaw/openclaw/pull/97953#issuecomment-4838652862))
- Production authorization + ACP dispatcher terminal proof on the candidate, without handler mocks: internal `operator.write` returns `This /acp action requires operator.admin on the internal channel.`; internal `operator.admin` resolves `senderIsOwner: true` and reaches the ACP status handler, which returns the expected `ACP_SESSION_INIT_FAILED` for the deliberately non-ACP proof session.
- `node scripts/run-vitest.mjs src/auto-reply/reply/commands-acp.test.ts --reporter=verbose` (60 tests passed, including all 12 owner-gated actions, retained non-owner diagnostics, internal write denial, and internal admin success)
- `node scripts/run-oxlint.mjs src/auto-reply/reply/commands-acp.ts src/auto-reply/reply/commands-acp.test.ts`
- `node_modules/.bin/oxfmt --check docs/tools/acp-agents.md docs/tools/slash-commands.md src/auto-reply/reply/commands-acp.ts src/auto-reply/reply/commands-acp.test.ts`
- `node scripts/check-docs-mdx.mjs docs README.md`
- `node scripts/format-docs.mjs --check`
- `git diff --check`

## Notes

- AI-assisted change; the repository autoreview gate was run to a clean result before publication.
- The compatibility tightening is intentional: ACP lifecycle, status, and runtime-option controls are owner/admin operations. Authorized non-owners retain `/acp sessions`, `/acp doctor`, `/acp install`, and `/acp help`.
