### PR TITLE
fix(codex): restrict computer-use installation

### DIFF
--- a/docs/plugins/codex-computer-use.md
+++ b/docs/plugins/codex-computer-use.md
@@ -147,6 +147,9 @@ report disabled even after a one-off install command.
 `install` enables Codex app-server plugin support, optionally adds a configured
 marketplace source, installs or re-enables the configured plugin through Codex
 app-server, reloads MCP servers, and verifies that the MCP server exposes tools.
+Because installation changes trusted host resources, only an owner or an
+`operator.admin` Gateway client can run `install`. Other authorized senders can
+continue to use the read-only `status` command, including with overrides.
 
 ## Marketplace choices
 

--- a/extensions/codex/src/command-authorization.ts
+++ b/extensions/codex/src/command-authorization.ts
@@ -1,0 +1,5 @@
+import type { PluginCommandContext } from "openclaw/plugin-sdk/plugin-entry";
+
+export function canMutateCodexHost(ctx: PluginCommandContext): boolean {
+  return ctx.senderIsOwner === true || ctx.gatewayClientScopes?.includes("operator.admin") === true;
+}

--- a/extensions/codex/src/command-handlers.ts
+++ b/extensions/codex/src/command-handlers.ts
@@ -24,6 +24,7 @@ import {
   writeCodexAppServerBinding,
 } from "./app-server/session-binding.js";
 import { readCodexAccountAuthOverview } from "./command-account.js";
+import { canMutateCodexHost } from "./command-authorization.js";
 import {
   buildHelp,
   formatAccount,
@@ -497,7 +498,7 @@ export async function handleCodexSubcommand(
       return buildCodexComputerUseMenuReply();
     }
     return {
-      text: await handleComputerUseCommand(deps, options.pluginConfig, rest),
+      text: await handleComputerUseCommand(deps, ctx, options.pluginConfig, rest),
     };
   }
   if (normalized === "mcp") {
@@ -631,6 +632,7 @@ function returnsBeforeNativeCodexResume(args: readonly string[]): boolean {
 
 async function handleComputerUseCommand(
   deps: CodexCommandDeps,
+  ctx: PluginCommandContext,
   pluginConfig: unknown,
   args: string[],
 ): Promise<string> {
@@ -640,6 +642,9 @@ async function handleComputerUseCommand(
       "Usage: /codex computer-use [status|install] [--source <marketplace-source>] [--marketplace-path <path>] [--marketplace <name>]",
       "Checks or installs the configured Codex Computer Use plugin through app-server.",
     ].join("\n");
+  }
+  if (parsed.action === "install" && !canMutateCodexHost(ctx)) {
+    return "Only an owner or operator.admin gateway client can configure Codex Computer Use.";
   }
   const params: CodexComputerUseSetupParams = {
     pluginConfig,

--- a/extensions/codex/src/command-plugins-management.ts
+++ b/extensions/codex/src/command-plugins-management.ts
@@ -1,5 +1,6 @@
 // Codex plugin module implements command plugins management behavior.
 import type { PluginCommandContext, PluginCommandResult } from "openclaw/plugin-sdk/plugin-entry";
+import { canMutateCodexHost } from "./command-authorization.js";
 import { formatCodexDisplayText } from "./command-formatters.js";
 import {
   buildCodexCommandPickerPresentation,
@@ -79,7 +80,7 @@ export async function handleCodexPluginsSubcommand(
     if (!target || args.length > 1) {
       return { text: `Usage: /codex plugins ${normalized} <name>` };
     }
-    if (!canMutateCodexPlugins(ctx)) {
+    if (!canMutateCodexHost(ctx)) {
       return {
         text: `Only an owner or operator.admin gateway client can run /codex plugins ${normalized}.`,
       };
@@ -195,13 +196,6 @@ function buildPluginNamePickerReply(
       buttons,
     ),
   };
-}
-
-function canMutateCodexPlugins(ctx: PluginCommandContext): boolean {
-  if (ctx.senderIsOwner === true) {
-    return true;
-  }
-  return ctx.gatewayClientScopes?.includes("operator.admin") === true;
 }
 
 export function buildPluginsHelp(): string {

--- a/extensions/codex/src/commands.test.ts
+++ b/extensions/codex/src/commands.test.ts
@@ -2100,6 +2100,68 @@ describe("codex command", () => {
     });
   });
 
+  it("rejects Computer Use installation from non-owner non-admin callers", async () => {
+    const installCodexComputerUse = vi.fn(async () => computerUseReadyStatus());
+    const ctx = createContext(
+      "computer-use install --source attacker/marketplace --plugin untrusted",
+      undefined,
+      { senderIsOwner: false, gatewayClientScopes: ["operator.write"] },
+    );
+
+    const result = await handleCodexCommand(ctx, {
+      deps: createDeps({ installCodexComputerUse }),
+    });
+
+    expectResultTextContains(result, "Only an owner or operator.admin");
+    expect(installCodexComputerUse).not.toHaveBeenCalled();
+  });
+
+  it("keeps Computer Use status overrides read-only for non-owner callers", async () => {
+    const readCodexComputerUseStatus = vi.fn(async () => computerUseReadyStatus());
+    const installCodexComputerUse = vi.fn(async () => computerUseReadyStatus());
+    const ctx = createContext(
+      "computer-use status --source existing/source --marketplace-path /existing/marketplace --marketplace existing --plugin existing-plugin --mcp-server existing-server",
+      undefined,
+      {
+        senderIsOwner: false,
+        gatewayClientScopes: ["operator.write"],
+      },
+    );
+
+    const result = await handleCodexCommand(ctx, {
+      deps: createDeps({ readCodexComputerUseStatus, installCodexComputerUse }),
+    });
+
+    expectResultTextContains(result, "Computer Use: ready");
+    expect(readCodexComputerUseStatus).toHaveBeenCalledWith({
+      pluginConfig: undefined,
+      forceEnable: true,
+      overrides: {
+        marketplaceSource: "existing/source",
+        marketplacePath: "/existing/marketplace",
+        marketplaceName: "existing",
+        pluginName: "existing-plugin",
+        mcpServerName: "existing-server",
+      },
+    });
+    expect(installCodexComputerUse).not.toHaveBeenCalled();
+  });
+
+  it("allows operator.admin gateway callers to install Codex Computer Use", async () => {
+    const installCodexComputerUse = vi.fn(async () => computerUseReadyStatus());
+    const ctx = createContext("computer-use install", undefined, {
+      senderIsOwner: false,
+      gatewayClientScopes: ["operator.admin"],
+    });
+
+    const result = await handleCodexCommand(ctx, {
+      deps: createDeps({ installCodexComputerUse }),
+    });
+
+    expectResultTextContains(result, "Computer Use: ready");
+    expect(installCodexComputerUse).toHaveBeenCalledOnce();
+  });
+
   it("shows help when Computer Use option values are missing", async () => {
     const installCodexComputerUse = vi.fn(async () => computerUseReadyStatus());
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an authorized non-owner chat sender could run `/codex computer-use install` and select Codex marketplace, plugin, and MCP server resources. Installation mutates trusted host state and can make installed MCP processes available without the owner or `operator.admin` authority required by sibling plugin-write commands.

## Why This Change Was Made

The Codex command handler now applies the existing owner-or-`operator.admin` policy only to the mutating `install` action. Read-only `status` behavior, including existing overrides, remains available to authorized senders for compatibility.

## User Impact

Owners and `operator.admin` Gateway clients retain the complete Computer Use setup workflow. Other authorized senders can still inspect status but can no longer install or reconfigure trusted Computer Use resources.

## Evidence

- A focused production-entry-point regression proves non-owner installation is denied before `installCodexComputerUse` is called.
- An `operator.admin` regression proves privileged installation remains available.
- A compatibility regression covers every status override class and proves the read-only path never invokes installation.
- Direct inspection of OpenAI Codex `rust-v0.139.0` confirmed that `plugin/install` installs and loads plugin MCP definitions, while `plugin/read` is the separate status lookup path.
- Fresh structured Codex autoreview completed with no accepted or actionable findings.

### Real Codex app-server behavior proof

Ran the production `handleCodexCommand` entry point against the bundled `@openai/codex` 0.139.0 app-server with an isolated `OPENCLAW_STATE_DIR` and a disposable local marketplace/plugin whose MCP server exposes one proof tool. No model credentials or personal Codex state were used.

```text
$ corepack pnpm exec tsx /tmp/openclaw-798-real-app-server-proof.ts
REAL_CODEX_APP_SERVER_PROOF=PASS
CODEX_VERSION=0.139.0
NON_OWNER_OPERATOR_WRITE=DENIED_BEFORE_INSTALL
DENIED_PLUGIN_CACHE_ENTRIES=0
DENIED_MCP_LAUNCHES=0
OPERATOR_ADMIN=INSTALL_ALLOWED
ADMIN_PLUGIN_CACHE_ENTRIES=1
ADMIN_MCP_LAUNCHED=true
ADMIN_RESPONSE_READY=true
```

The same disposable setup was used for both calls. The denied `operator.write` caller returned before Codex plugin installation or MCP launch; the `operator.admin` caller installed the plugin through the real app-server, launched its MCP process, discovered its tool, and returned `Computer Use: ready`. The temporary state was removed after the run.

## Summary

Restrict Codex Computer Use installation to trusted owner/admin callers without breaking the existing read-only command surface.

## Changes

- Share the Codex host-mutation authorization predicate with plugin-management writes.
- Gate `/codex computer-use install` at the command-handler boundary.
- Preserve help, menu, plain status, override-bearing status, aliases, flags, config, and protocol behavior.
- Document the install authorization boundary.

## Validation

- `node scripts/run-vitest.mjs extensions/codex/src/commands.test.ts extensions/codex/src/command-plugins-management.test.ts` — 134 passed.
- `corepack pnpm build` — passed.
- `corepack pnpm exec oxfmt --check extensions/codex/src/command-authorization.ts extensions/codex/src/command-handlers.ts extensions/codex/src/command-plugins-management.ts extensions/codex/src/commands.test.ts docs/plugins/codex-computer-use.md` — passed.
- `corepack pnpm docs:check-mdx` — passed for 685 files.
- `git diff --check upstream/main...HEAD` — passed.

## Notes

- AI-assisted change; the implementation and dependency behavior were manually verified.
- No config, schema, migration, gateway protocol, or Plugin SDK contract changes.
- No changelog entry; release generation owns `CHANGELOG.md`.
- Remote Crabbox/Testbox proof was unavailable in this environment because the Crabbox binary failed its startup sanity check and no Blacksmith client was installed; the real dependency process was exercised locally instead.
