### PR TITLE
fix(browser): block node routes when sandbox host control is disabled

### DIFF
--- a/extensions/browser/src/browser-tool.test.ts
+++ b/extensions/browser/src/browser-tool.test.ts
@@ -871,6 +871,21 @@ describe("browser tool snapshot maxChars", () => {
     expect(browserClientMocks.browserStatus).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ["target=node", { target: "node" }],
+    ["an explicit node pin", { node: "node-1" }],
+    ["automatic node routing", {}],
+  ])("blocks %s when host control is disabled", async (_label, route) => {
+    mockSingleBrowserProxyNode();
+    const tool = createBrowserTool({ allowHostControl: false });
+
+    await expect(tool.execute?.("call-1", { action: "status", ...route })).rejects.toThrow(
+      /browser control is disabled by sandbox policy/i,
+    );
+    expect(gatewayMocks.callGatewayTool).not.toHaveBeenCalled();
+    expect(browserClientMocks.browserStatus).not.toHaveBeenCalled();
+  });
+
   it("fails node proxy calls cleanly when payloadJSON is malformed", async () => {
     mockSingleBrowserProxyNode();
     gatewayMocks.callGatewayTool.mockResolvedValueOnce({
@@ -1247,7 +1262,7 @@ describe("browser tool snapshot maxChars", () => {
     setResolvedBrowserProfiles({
       user: { driver: "existing-session", attachOnly: true, color: "#00AA00" },
     });
-    const tool = createBrowserTool();
+    const tool = createBrowserTool({ allowHostControl: true });
     await tool.execute?.("call-1", { action: "status", profile: "user", target: "node" });
 
     const { options, request } = lastNodeInvokeCall();

--- a/extensions/browser/src/browser-tool.ts
+++ b/extensions/browser/src/browser-tool.ts
@@ -262,7 +262,15 @@ async function resolveBrowserNodeTarget(params: {
   requestedNode?: string;
   target?: "sandbox" | "host" | "node";
   sandboxBridgeUrl?: string;
+  allowHostControl?: boolean;
 }): Promise<BrowserNodeTarget | null> {
+  if (params.allowHostControl === false) {
+    if (params.target === "node" || params.requestedNode) {
+      throw new Error("Node browser control is disabled by sandbox policy.");
+    }
+    return null;
+  }
+
   const cfg = browserToolDeps.getRuntimeConfig();
   const policy = cfg.gateway?.nodes?.browser;
   const mode = policy?.mode ?? "auto";
@@ -538,6 +546,7 @@ export function createBrowserTool(opts?: {
           requestedNode: requestedNode ?? undefined,
           target,
           sandboxBridgeUrl: opts?.sandboxBridgeUrl,
+          allowHostControl: opts?.allowHostControl,
         });
       } catch (error) {
         // Keep the logged-in user browser usable on the host when auto-discovery


### PR DESCRIPTION
## Summary

Enforce the existing sandbox browser host-control policy for paired browser-node routes.

## What Problem This Solves

Fixes an issue where sandboxed agents with `allowHostControl: false` could still reach a signed-in host browser by selecting or automatically resolving a paired browser node.

## Changes

- Carry the existing `allowHostControl` policy into browser-node target resolution.
- Reject explicit node targets and node pins when host browser control is disabled.
- Skip automatic browser-node routing under the same policy.
- Add focused coverage for explicit, pinned, and automatic node routes.
- Preserve the existing `operator.admin` scope requirement for browser proxy invocation.

## Why This Change Was Made

Browser target resolution owns the choice between sandbox, host, and node routes. Enforcing the policy there closes every node-routing variant before discovery or dispatch without changing trusted host-control behavior.

## User Impact

Sandboxed agents can no longer bypass disabled host browser control through a paired node. Explicitly authorized host and node browser workflows continue to work.

## Validation

- `node scripts/run-vitest.mjs extensions/browser/src/browser-tool.test.ts` — 74/74 tests passed.
- Focused `oxfmt` check — passed.
- Focused `oxlint` check — passed.
- `git diff --check` — passed.
- Structured autoreview — no accepted or actionable findings.

## Evidence

The regression test covers `target=node`, an explicit node pin, and automatic node routing with `allowHostControl: false`; all three fail before gateway or local browser dispatch. Existing coverage confirms authorized node access remains available with `allowHostControl: true`.

## Notes

- Related tracking issue: https://github.com/NVIDIA-dev/openclaw-tracking/issues/794
- Related advisory: GHSA-9x88-f7rh-4c83
- AI-assisted change; the implementation and focused validation were reviewed before submission.
- No configuration, schema, protocol, or changelog changes.
