### PR TITLE
[codex] docs: add release notes placeholder

### DIFF
--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -624,6 +624,10 @@
     "target": "发布策略"
   },
   {
+    "source": "Release notes",
+    "target": "发布说明"
+  },
+  {
     "source": "for full details",
     "target": "了解详情"
   },

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1860,6 +1860,7 @@
               {
                 "group": "Release and CI",
                 "pages": [
+                  "releases/index",
                   "maturity/scorecard",
                   "maturity/taxonomy",
                   "reference/RELEASING",

--- a/docs/releases/index.md
+++ b/docs/releases/index.md
@@ -1,0 +1,24 @@
+---
+title: "Release notes"
+summary: "Curated OpenClaw release notes for people who want the product story, not the raw changelog."
+description: "Browse polished OpenClaw release notes with highlights, reader-facing context, source links, and contributor credits."
+---
+
+# Release notes
+
+These pages will be the reader-facing version of OpenClaw releases. They keep
+the main story, practical impact, source links, and contributor credit together
+without making you scan the raw changelog first.
+
+## Coming soon
+
+The release archive is being backfilled. New polished release notes will appear
+here after the release copy is finalized.
+
+## Raw release history
+
+Use the curated notes when you want the product story. Use the raw history when
+you need compact maintainer accounting:
+
+- [GitHub releases](https://github.com/openclaw/openclaw/releases)
+- [CHANGELOG.md](https://github.com/openclaw/openclaw/blob/main/CHANGELOG.md)


### PR DESCRIPTION
## What changed

Adds a `Release notes` page under the existing Reference -> Release and CI docs navigation.

The page is intentionally a placeholder for now: it has no version entries and says the archive is being backfilled, with links to GitHub releases and `CHANGELOG.md` for current raw release history.

## Why

We want a nicer home for polished release notes without publishing unfinished v2026.6.11 copy or cluttering the main docs navigation with individual version pages.

## Impact

Readers get a stable release-notes destination now, and future finalized/backfilled release pages can be added from this archive page later.

## Validation

- `pnpm check:docs`
