### PR TITLE
fix(telegram): honor inbound debounce for forwarded bursts

### DIFF
--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -302,7 +302,9 @@ export const registerTelegramHandlers = ({
   };
   const resolveTelegramDebounceEntryMs = (entry: TelegramDebounceEntry): number =>
     entry.debounceLane === "forward"
-      ? Math.max(debounceMs, FORWARD_BURST_MIN_DEBOUNCE_MS)
+      ? debounceMs > 0
+        ? debounceMs
+        : FORWARD_BURST_MIN_DEBOUNCE_MS
       : debounceMs;
   const shouldDebounceTelegramEntry = (entry: TelegramDebounceEntry): boolean => {
     const text = getTelegramTextParts(entry.msg).text;

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -284,7 +284,7 @@ export const registerTelegramHandlers = ({
   };
 
   const debounceMs = resolveInboundDebounceMs({ cfg, channel: "telegram" });
-  const FORWARD_BURST_DEBOUNCE_MS = 80;
+  const FORWARD_BURST_MIN_DEBOUNCE_MS = 80;
   type TelegramDebounceLane = "default" | "forward";
   type TelegramDebounceEntry = {
     ctx: TelegramContext;
@@ -301,7 +301,9 @@ export const registerTelegramHandlers = ({
     spooledReplayParticipant?: TelegramSpooledReplayDeferredParticipant;
   };
   const resolveTelegramDebounceEntryMs = (entry: TelegramDebounceEntry): number =>
-    entry.debounceLane === "forward" ? FORWARD_BURST_DEBOUNCE_MS : debounceMs;
+    entry.debounceLane === "forward"
+      ? Math.max(debounceMs, FORWARD_BURST_MIN_DEBOUNCE_MS)
+      : debounceMs;
   const shouldDebounceTelegramEntry = (entry: TelegramDebounceEntry): boolean => {
     const text = getTelegramTextParts(entry.msg).text;
     const hasDebounceableText = shouldDebounceTextInbound({

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -1064,7 +1064,7 @@ describe("createTelegramBot", () => {
     await expect(deferredWork.task).resolves.toEqual({ kind: "skipped" });
   });
 
-  it("lets stop cancel pending same-chat forwarded debounce", async () => {
+  it("lets stop cancel pending same-chat forwarded debounce using configured inbound timing", async () => {
     const DEBOUNCE_MS = 4321;
     loadConfig.mockReturnValue({
       agents: {
@@ -1094,7 +1094,9 @@ describe("createTelegramBot", () => {
     });
 
     const extractLatestForwardDebounceFlush = () => {
-      const debounceCallIndex = setTimeoutSpy.mock.calls.findLastIndex((call) => call[1] === 80);
+      const debounceCallIndex = setTimeoutSpy.mock.calls.findLastIndex(
+        (call) => call[1] === DEBOUNCE_MS,
+      );
       expect(debounceCallIndex).toBeGreaterThanOrEqual(0);
       clearTimeout(
         setTimeoutSpy.mock.results[debounceCallIndex]?.value as ReturnType<typeof setTimeout>,

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -1065,7 +1065,7 @@ describe("createTelegramBot", () => {
   });
 
   it("lets stop cancel pending same-chat forwarded debounce using configured inbound timing", async () => {
-    const DEBOUNCE_MS = 4321;
+    const DEBOUNCE_MS = 42;
     loadConfig.mockReturnValue({
       agents: {
         defaults: {
@@ -1154,6 +1154,69 @@ describe("createTelegramBot", () => {
       expect(sendMessageSpy.mock.calls.map((call) => String(call[1])).join("\n")).not.toContain(
         "reply:forwarded first",
       );
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
+  });
+
+  it("uses the forwarded debounce fallback when inbound debounce is disabled", async () => {
+    const FORWARDED_FALLBACK_MS = 80;
+    loadConfig.mockReturnValue({
+      agents: {
+        defaults: {
+          envelopeTimezone: "utc",
+        },
+      },
+      messages: {
+        inbound: {
+          debounceMs: 0,
+        },
+      },
+      channels: {
+        telegram: { dmPolicy: "open", allowFrom: ["*"] },
+      },
+    });
+
+    installPerKeySequentializer();
+
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    replySpy.mockImplementation(async (ctx: MsgContext) => {
+      return { text: `reply:${ctx.Body ?? ""}` };
+    });
+
+    try {
+      createTelegramBot({ token: "tok" });
+      const messageHandler = getOnHandler("message") as (
+        ctx: TelegramMiddlewareTestContext,
+      ) => Promise<void>;
+
+      await runTelegramMiddlewareChain({
+        ctx: {
+          update: { update_id: 123 },
+          message: {
+            chat: { id: 7, type: "private" },
+            text: "forwarded first",
+            date: 1736380800,
+            message_id: 123,
+            from: { id: 42, first_name: "Ada" },
+            forward_date: 1736380700,
+          },
+          me: { username: "openclaw_bot" },
+          getFile: async () => ({}),
+        },
+        finalHandler: messageHandler,
+      });
+
+      const fallbackDebounceCallIndex = setTimeoutSpy.mock.calls.findLastIndex(
+        (call) => call[1] === FORWARDED_FALLBACK_MS,
+      );
+      expect(fallbackDebounceCallIndex).toBeGreaterThanOrEqual(0);
+      clearTimeout(
+        setTimeoutSpy.mock.results[fallbackDebounceCallIndex]?.value as ReturnType<
+          typeof setTimeout
+        >,
+      );
+      expect(replySpy).not.toHaveBeenCalled();
     } finally {
       setTimeoutSpy.mockRestore();
     }


### PR DESCRIPTION
## What Problem This Solves

Telegram already supports native inbound debouncing through `messages.inbound`, but forwarded/shared-message bursts used a separate Telegram adapter lane with a hardcoded 80ms delay. When Telegram delivered split chunks more than 80ms apart, OpenClaw could dispatch them as separate turns even when the channel configured a longer native quiet window.

The first PR revision reused the configured inbound window only when it was at least 80ms, so configured positive windows from 1-79ms were still silently floored to the legacy fallback. This update makes every configured positive inbound debounce value apply to the forwarded lane and keeps 80ms only for the disabled `0` path.

## Summary

- make Telegram forwarded/shared-message burst dispatch honour every configured positive native inbound debounce window
- keep the previous 80ms forwarded delay only as the fallback when native inbound batching is disabled
- add regression coverage for both the sub-80ms configured path and disabled fallback path

## Evidence

- `git diff --check`
- `npx oxfmt --check --threads=1 extensions/telegram/src/bot-handlers.runtime.ts extensions/telegram/src/bot.create-telegram-bot.test.ts`
- `node scripts/run-vitest.mjs run extensions/telegram/src/bot.create-telegram-bot.test.ts`
- Targeted Vitest file passed 112 tests locally on the clean PR branch.

Known proof gap: native Telegram/Mantis visible proof is still pending, so this PR remains draft until that proof is attached or maintainers explicitly accept source-level and focused-test proof only.
