### PR TITLE
fix(imessage): require authorization for group actions

### DIFF
--- a/extensions/imessage/src/actions.test.ts
+++ b/extensions/imessage/src/actions.test.ts
@@ -13,6 +13,11 @@ const runtimeMock = vi.hoisted(() => ({
   sendReaction: vi.fn(),
   sendRichMessage: vi.fn(),
   sendAttachment: vi.fn(),
+  renameGroup: vi.fn(),
+  setGroupIcon: vi.fn(),
+  addParticipant: vi.fn(),
+  removeParticipant: vi.fn(),
+  leaveGroup: vi.fn(),
 }));
 
 const rememberIMessageReplyCacheMock = vi.hoisted(() => vi.fn());
@@ -90,6 +95,11 @@ describe("imessage message actions", () => {
     runtimeMock.sendReaction.mockReset();
     runtimeMock.sendRichMessage.mockReset();
     runtimeMock.sendAttachment.mockReset();
+    runtimeMock.renameGroup.mockReset();
+    runtimeMock.setGroupIcon.mockReset();
+    runtimeMock.addParticipant.mockReset();
+    runtimeMock.removeParticipant.mockReset();
+    runtimeMock.leaveGroup.mockReset();
     rememberIMessageReplyCacheMock.mockReset();
     probeMock.getCachedIMessagePrivateApiStatus.mockReset();
     probeMock.probeIMessagePrivateApi.mockReset();
@@ -181,6 +191,100 @@ describe("imessage message actions", () => {
     expect(described?.actions).not.toContain("react");
     expect(described?.actions).not.toContain("reply");
     expect(described?.actions).toContain("edit");
+  });
+
+  it("requires a trusted requester for group management from iMessage turns", () => {
+    for (const action of [
+      "renameGroup",
+      "setGroupIcon",
+      "addParticipant",
+      "removeParticipant",
+      "leaveGroup",
+    ] as const) {
+      expect(
+        imessageMessageActions.requiresTrustedRequesterSender?.({
+          action,
+          toolContext: { currentChannelProvider: "imessage" },
+        }),
+      ).toBe(true);
+    }
+    expect(
+      imessageMessageActions.requiresTrustedRequesterSender?.({
+        action: "renameGroup",
+        toolContext: { currentChannelProvider: "discord" },
+      }),
+    ).toBe(false);
+    expect(
+      imessageMessageActions.requiresTrustedRequesterSender?.({
+        action: "react",
+        toolContext: { currentChannelProvider: "imessage" },
+      }),
+    ).toBe(false);
+  });
+
+  it.each([
+    ["renameGroup", { name: "Unauthorized rename" }, runtimeMock.renameGroup],
+    [
+      "setGroupIcon",
+      { buffer: Buffer.from("unauthorized icon").toString("base64"), filename: "icon.png" },
+      runtimeMock.setGroupIcon,
+    ],
+    ["addParticipant", { address: "+15551230001" }, runtimeMock.addParticipant],
+    ["removeParticipant", { address: "+15551230002" }, runtimeMock.removeParticipant],
+    ["leaveGroup", {}, runtimeMock.leaveGroup],
+  ] as const)(
+    "rejects %s from non-owner non-admin callers before native mutation",
+    async (action, params, runtimeAction) => {
+      probeMock.getCachedIMessagePrivateApiStatus.mockReturnValue({
+        available: true,
+        v2Ready: true,
+        selectors: {},
+      });
+      await expect(
+        imessageMessageActions.handleAction?.({
+          action,
+          cfg: cfg(),
+          params: { chatGuid: "iMessage;+;chat0000", ...params },
+          senderIsOwner: false,
+          gatewayClientScopes: ["operator.write"],
+        } as never),
+      ).rejects.toThrow("iMessage group management requires an owner or operator.admin requester.");
+      expect(runtimeAction).not.toHaveBeenCalled();
+    },
+  );
+
+  it("allows owner and operator.admin group management", async () => {
+    probeMock.getCachedIMessagePrivateApiStatus.mockReturnValue({
+      available: true,
+      v2Ready: true,
+      selectors: {},
+    });
+    runtimeMock.renameGroup.mockResolvedValue(undefined);
+    runtimeMock.leaveGroup.mockResolvedValue(undefined);
+
+    await imessageMessageActions.handleAction?.({
+      action: "renameGroup",
+      cfg: cfg(),
+      params: { chatGuid: "iMessage;+;chat0000", name: "Renamed group" },
+      senderIsOwner: true,
+    } as never);
+    await imessageMessageActions.handleAction?.({
+      action: "leaveGroup",
+      cfg: cfg(),
+      params: { chatGuid: "iMessage;+;chat0000" },
+      senderIsOwner: false,
+      gatewayClientScopes: ["operator.admin"],
+    } as never);
+
+    expect(runtimeMock.renameGroup).toHaveBeenCalledWith({
+      chatGuid: "iMessage;+;chat0000",
+      displayName: "Renamed group",
+      options: imsgOptions("iMessage;+;chat0000"),
+    });
+    expect(runtimeMock.leaveGroup).toHaveBeenCalledWith({
+      chatGuid: "iMessage;+;chat0000",
+      options: imsgOptions("iMessage;+;chat0000"),
+    });
   });
 
   it("emits a channels/imessage WARN when the private API bridge is unavailable", async () => {

--- a/extensions/imessage/src/actions.ts
+++ b/extensions/imessage/src/actions.ts
@@ -41,6 +41,14 @@ const SUPPORTED_ACTIONS = new Set<ChannelMessageActionName>([
   ...IMESSAGE_ACTION_NAMES,
   "upload-file",
 ]);
+const GROUP_MANAGEMENT_ACTIONS = new Set<ChannelMessageActionName>([
+  "renameGroup",
+  "setGroupIcon",
+  "addParticipant",
+  "removeParticipant",
+  "leaveGroup",
+]);
+
 function readMessageText(params: Record<string, unknown>): string | undefined {
   return readStringParam(params, "text") ?? readStringParam(params, "message");
 }
@@ -388,6 +396,9 @@ function assertActionEnabled(
 export const imessageMessageActions: ChannelMessageActionAdapter = {
   describeMessageTool: describeIMessageMessageTool,
   supportsAction: ({ action }) => SUPPORTED_ACTIONS.has(action),
+  requiresTrustedRequesterSender: ({ action, toolContext }) =>
+    normalizeOptionalLowercaseString(toolContext?.currentChannelProvider) === "imessage" &&
+    GROUP_MANAGEMENT_ACTIONS.has(action),
   messageActionTargetAliases: {
     react: { aliases: ["chatGuid", "chatIdentifier", "chatId"] },
     edit: { aliases: ["chatGuid", "chatIdentifier", "chatId", "messageId"] },
@@ -415,7 +426,24 @@ export const imessageMessageActions: ChannelMessageActionAdapter = {
     leaveGroup: { aliases: ["chatGuid", "chatIdentifier", "chatId"] },
   },
   extractToolSend: ({ args }) => extractToolSend(args, "sendMessage"),
-  handleAction: async ({ action, params, cfg, accountId, toolContext }) => {
+  handleAction: async ({
+    action,
+    params,
+    cfg,
+    accountId,
+    toolContext,
+    senderIsOwner,
+    gatewayClientScopes,
+  }) => {
+    // Group administration mutates the host's Messages identity, so model-driven
+    // actions need owner provenance or an admin-scoped Gateway caller.
+    if (
+      GROUP_MANAGEMENT_ACTIONS.has(action) &&
+      senderIsOwner !== true &&
+      !gatewayClientScopes?.includes("operator.admin")
+    ) {
+      throw new Error("iMessage group management requires an owner or operator.admin requester.");
+    }
     const runtime = await loadIMessageActionsRuntime();
     const account = resolveIMessageAccount({
       cfg,


### PR DESCRIPTION
## Summary

Restricts iMessage group-management actions to owner-authorized message turns or Gateway callers with `operator.admin` scope.

## What Problem This Solves

Fixes an issue where callers with generic message-action write access could invoke iMessage group membership and metadata mutations without owner or administrator authorization.

## Changes

- Require trusted requester identity for group-management actions originating from iMessage turns.
- Reject group mutations unless the requester is the owner or has `operator.admin` scope.
- Cover rename, icon, participant, and leave-group actions with focused regression tests.

## Why This Change Was Made

The implementation follows the existing channel-owned authorization pattern used for privileged Microsoft Teams actions. It keeps ordinary iMessage actions unchanged and enforces the authorization check before loading or invoking native mutation functions.

## User Impact

Authorized owner and administrator flows continue to work. Non-owner, non-admin callers can no longer mutate iMessage group metadata or membership through the shared message-action surface.

This fail-closed change is intentional and compatibility-sensitive: existing Gateway or automation clients that invoke `renameGroup`, `setGroupIcon`, `addParticipant`, `removeParticipant`, or `leaveGroup` with only `operator.write` will now be rejected. Those callers must provide verified owner provenance or connect with `operator.admin`.

## Validation

- `node scripts/run-vitest.mjs extensions/imessage/src/actions.test.ts` — 37 passed
- `node scripts/run-vitest.mjs src/channels/plugins/message-actions.security.test.ts` — 3 passed
- Temporary real Gateway WebSocket harness on Linux/Node 22 — `operator.write` denied before any bridge process; `operator.admin` succeeded and emitted `chat-add-member`
- `node_modules/.bin/oxfmt --check extensions/imessage/src/actions.ts extensions/imessage/src/actions.test.ts`
- `git diff upstream/main...HEAD --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main --stream-engine-output` — clean, no actionable findings

## Evidence

Regression tests verify all five privileged group actions are rejected before their native runtime functions run for an `operator.write` non-owner. Separate assertions verify owner and `operator.admin` requests remain authorized.

A full Gateway WebSocket proof on the exact PR head used separately paired write-only and admin clients against the same `message.action` payload. The write-only response was rejected with the new authorization error and the bridge log did not exist, proving no subprocess ran. The admin response succeeded and the bridge log recorded the expected `status --json` probe followed by `chat-add-member --chat <redacted> --address <redacted> --json`. The deterministic bridge executable avoided mutating a real Messages group while exercising the production Gateway, plugin dispatch, lazy runtime load, probe, subprocess, and command construction paths.

## Notes

AI-assisted. No configuration, protocol, dependency, or documentation surface changes.
