### PR TITLE
fix: deliver background task completions through owning sessions

### DIFF
--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -620,6 +620,29 @@ describe("subagent announce formatting", () => {
     expect(call?.params?.internalEvents?.[0]?.result).toContain("Worker executed successfully");
   });
 
+  it("marks required progress-only completion handoffs as blocked in the requester prompt", async () => {
+    await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:worker",
+      childRunId: "run-progress-only-required",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      ...defaultOutcomeAnnounce,
+      expectsCompletionMessage: true,
+      roundOneReply: "I'll inspect the repo now.",
+    });
+
+    const call = getAgentCall() as {
+      params?: {
+        internalEvents?: Array<{ status?: string; statusLabel?: string; result?: string }>;
+      };
+    };
+    expect(call?.params?.internalEvents?.[0]?.status).toBe("error");
+    expect(call?.params?.internalEvents?.[0]?.statusLabel).toBe(
+      "Required completion ended with progress-only text, not a final deliverable.",
+    );
+    expect(call?.params?.internalEvents?.[0]?.result).toBe("I'll inspect the repo now.");
+  });
+
   it("uses child-run announce identity for direct idempotency", async () => {
     await runSubagentAnnounceFlow({
       childSessionKey: "agent:main:subagent:worker",

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -14,6 +14,7 @@ import {
 import { defaultRuntime } from "../runtime.js";
 import { isCronSessionKey } from "../sessions/session-key-utils.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
+import { resolveRequiredCompletionTerminalResult } from "../tasks/task-completion-contract.js";
 import { type DeliveryContext, normalizeDeliveryContext } from "../utils/delivery-context.js";
 import { INTERNAL_MESSAGE_CHANNEL } from "../utils/message-channel.js";
 import {
@@ -465,19 +466,28 @@ export async function runSubagentAnnounceFlow(params: {
       outcome = { status: "unknown" };
     }
 
-    // Build status label
-    const statusLabel =
-      outcome.status === "ok"
-        ? "completed; ready for parent review"
-        : outcome.status === "timeout"
-          ? "timed out"
-          : outcome.status === "error"
-            ? `failed: ${outcome.error || "unknown error"}`
-            : "finished with unknown status";
-
     const taskLabel = params.label || params.task || "task";
     const announceSessionId = childSessionId || "unknown";
     const findings = childCompletionFindings || reply || "(no output)";
+    const requiredCompletionTerminal =
+      expectsCompletionMessage && outcome.status === "ok"
+        ? resolveRequiredCompletionTerminalResult(findings)
+        : {};
+
+    // Build status label. Required completion handoffs must never present a
+    // progress-only or empty child output as a successful final deliverable.
+    const statusLabel =
+      requiredCompletionTerminal.terminalOutcome === "blocked"
+        ? requiredCompletionTerminal.terminalSummary
+        : outcome.status === "ok"
+          ? "completed; ready for parent review"
+          : outcome.status === "timeout"
+            ? "timed out"
+            : outcome.status === "error"
+              ? `failed: ${outcome.error || "unknown error"}`
+              : "finished with unknown status";
+    const eventStatus =
+      requiredCompletionTerminal.terminalOutcome === "blocked" ? "error" : outcome.status;
 
     let requesterIsSubagent = requesterIsInternalSession();
     if (requesterIsSubagent) {
@@ -526,7 +536,7 @@ export async function runSubagentAnnounceFlow(params: {
         childSessionId: announceSessionId,
         announceType,
         taskLabel,
-        status: outcome.status,
+        status: eventStatus,
         statusLabel,
         result: findings,
         statsLine,

--- a/src/infra/heartbeat-runner.ghost-reminder.test.ts
+++ b/src/infra/heartbeat-runner.ghost-reminder.test.ts
@@ -1,5 +1,6 @@
 // Covers heartbeat handling of queued reminder system events.
 import fs from "node:fs/promises";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveMainSessionKey } from "../config/sessions/main-session.js";
@@ -511,6 +512,74 @@ describe("Ghost reminder bug (issue #13317)", () => {
         to: "-100155462274",
         text: "Restart complete",
         messageThreadId: 42,
+      });
+    });
+  });
+
+  it("delivers background-task wake events from the owning session when heartbeat isolation is enabled", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      await fs.writeFile(path.join(tmpDir, "HEARTBEAT.md"), "", "utf-8");
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: {
+              every: "5m",
+              isolatedSession: true,
+            },
+          },
+        },
+        channels: { telegram: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const sessionKey = "agent:main:telegram:group:-1003774691294:topic:47";
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          [sessionKey]: {
+            sessionId: "sid",
+            updatedAt: Date.now(),
+            lastChannel: "telegram",
+            lastTo: "telegram:-1003774691294:topic:2175",
+            lastThreadId: 2175,
+          },
+        }),
+      );
+
+      const sendTelegram = vi.fn().mockResolvedValue({
+        messageId: "m1",
+        chatId: "-1003774691294",
+      });
+      replySpy.mockResolvedValue({ text: "The background task is done." });
+      enqueueSystemEvent("Background task done: health-text-only.", {
+        sessionKey,
+        deliveryContext: {
+          channel: "telegram",
+          to: "telegram:-1003774691294:topic:47",
+          threadId: 47,
+        },
+      });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        agentId: "main",
+        sessionKey,
+        source: "background-task",
+        intent: "immediate",
+        reason: "background-task",
+        deps: {
+          getReplyFromConfig: replySpy,
+          telegram: sendTelegram,
+        },
+      });
+
+      expect(result.status).toBe("ran");
+      expect(getFirstReplyContext(replySpy).SessionKey).toBe(sessionKey);
+      expect(peekSystemEvents(sessionKey)).toStrictEqual([]);
+      expectTelegramSend(sendTelegram, {
+        to: "telegram:-1003774691294:topic:47",
+        text: "The background task is done.",
+        messageThreadId: 47,
       });
     });
   });

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -907,6 +907,7 @@ type HeartbeatWakePayloadFlags = {
   isExecEventWake: boolean;
   isCronWake: boolean;
   isWakePayload: boolean;
+  isBackgroundTaskWake: boolean;
 };
 
 type HeartbeatSkipReason = "empty-heartbeat-file";
@@ -1004,10 +1005,17 @@ function resolveHeartbeatWakePayloadFlags(params: {
 }): HeartbeatWakePayloadFlags {
   const source = params.source ?? inferHeartbeatWakeSourceFromReason(params.reason);
   const reason = (params.reason ?? "").trim();
+  const isBackgroundTaskWake =
+    source === "background-task" ||
+    source === "background-task-blocked" ||
+    reason === "background-task" ||
+    reason === "background-task-blocked";
   return {
     isExecEventWake: source === "exec-event",
     isCronWake: source === "cron",
-    isWakePayload: source === "hook" || source === "acp-spawn" || reason === "wake",
+    isWakePayload:
+      source === "hook" || source === "acp-spawn" || isBackgroundTaskWake || reason === "wake",
+    isBackgroundTaskWake,
   };
 }
 
@@ -1050,6 +1058,9 @@ async function resolveHeartbeatPreflight(params: {
   const shouldInspectWakePendingEvents = (() => {
     if (!wakeFlags.isWakePayload) {
       return false;
+    }
+    if (wakeFlags.isBackgroundTaskWake) {
+      return true;
     }
     if (params.heartbeat?.isolatedSession !== true) {
       return true;
@@ -1530,7 +1541,7 @@ export async function runHeartbeatOnce(opts: {
   // a new session ID (empty transcript) each run, avoiding the cost of
   // sending the full conversation history (~100K tokens) to the LLM.
   // Delivery routing still uses the main session entry (lastChannel, lastTo).
-  const useIsolatedSession = heartbeat?.isolatedSession === true;
+  const useIsolatedSession = heartbeat?.isolatedSession === true && !preflight.isBackgroundTaskWake;
   const firstDueCommitment =
     canHeartbeatDeliverCommitments(heartbeat) && dueHeartbeatTasks.length === 0
       ? preflight.dueCommitments[0]

--- a/src/tasks/task-completion-contract.ts
+++ b/src/tasks/task-completion-contract.ts
@@ -2,10 +2,15 @@
 import type { TaskTerminalOutcome } from "./task-registry.types.js";
 
 /** Terminal fields required when a mandatory detached task completion is invalid. */
-export type RequiredCompletionTerminalResult = {
-  terminalOutcome?: Extract<TaskTerminalOutcome, "blocked">;
-  terminalSummary?: string;
-};
+export type RequiredCompletionTerminalResult =
+  | {
+      terminalOutcome: Extract<TaskTerminalOutcome, "blocked">;
+      terminalSummary: string;
+    }
+  | {
+      terminalOutcome?: undefined;
+      terminalSummary?: undefined;
+    };
 
 const PROGRESS_ONLY_PATTERN =
   /^(?:i(?:'|\u2019)ll|i will|i(?:'|\u2019)m|i am|i(?:'|\u2019)m going to|i am going to|let me|i need to)\s+(?:now\s+)?(?:analyz(?:e|ing)|apply|check(?:ing)?|continue|debug(?:ging)?|follow(?:ing)?\s+up|inspect(?:ing)?|investigat(?:e|ing)|look(?:ing)?(?:\s+into)?|map(?:ping)?|open(?:ing)?|read(?:ing)?|report(?:ing)?(?:\s+back)?|review(?:ing)?|run(?:ning)?|start(?:ing)?|test(?:ing)?|trace|trac(?:e|ing)|try(?:ing)?|update|verify(?:ing)?|work(?:ing)?)/i;


### PR DESCRIPTION
## What Problem This Solves
Background task completion events can be queued on the real requester session, such as a Telegram topic session, while heartbeat isolation runs the wake in a separate `:heartbeat` session. That can leave the requester without a visible final or blocked completion message even though the background task finished.

Required subagent completions also had a second failure mode: progress-only child output could be presented as a successful handoff instead of being treated as blocked.

## Why This Change Was Made
The fix keeps the behaviour narrow and native:
- Background-task completion wake sources now inspect the owning session queue and bypass heartbeat isolation only for `background-task` and `background-task-blocked` delivery wakes.
- Ordinary heartbeat isolation remains enabled for non-background-task wakes.
- Required subagent completion formatting now reuses the existing required-completion terminal classifier so progress-only output becomes a blocked handoff.
- The required-completion terminal result type now encodes the invariant that blocked completions always carry a status summary.

## User Impact
Users waiting in the original requester session, including Telegram topic sessions, should receive the terminal completion/blocker path instead of losing it to an isolated heartbeat session. Parent agents should no longer treat a progress-only required subagent completion as a successful final deliverable.

## Evidence
Local source proof after rebasing onto current `origin/main`:
- `git diff --check origin/main...HEAD`
- `node scripts/run-vitest.mjs src/infra/heartbeat-runner.ghost-reminder.test.ts src/agents/subagent-announce.test.ts src/agents/subagent-announce-delivery.test.ts src/agents/subagent-announce-dispatch.test.ts src/agents/subagent-announce-output.test.ts src/agents/subagent-announce.capture-completion-reply.test.ts src/agents/subagent-announce.format.e2e.test.ts src/agents/subagent-announce.timeout.test.ts`
  - Passed: 3 shards, 8 test files, 258 tests total.
- `PATH="/tmp/openclaw-pnpm-shims:$PATH" pnpm tsgo:prod`
- `PATH="/tmp/openclaw-pnpm-shims:$PATH" pnpm check:test-types`
- `node scripts/run-oxlint.mjs src/agents/subagent-announce.ts src/agents/subagent-announce.format.e2e.test.ts src/infra/heartbeat-runner.ts src/infra/heartbeat-runner.ghost-reminder.test.ts src/tasks/task-completion-contract.ts`
- `PATH="/tmp/openclaw-pnpm-shims:$PATH" NODE_OPTIONS=--max-old-space-size=8192 pnpm build:plugin-sdk:strict-smoke`
- `PATH="/tmp/openclaw-pnpm-shims:$PATH" pnpm lint:extensions:channels`
- `PATH="/tmp/openclaw-pnpm-shims:$PATH" pnpm lint:extensions:bundled`
- `node scripts/build-all.mjs gatewayWatch`

Upstream CI passed on pushed head `47e4354a287c2148cbc04e863bad77dbc26c8e77`, including `check-prod-types`, `check-test-types`, `check-guards`, `check-lint`, `QA Smoke CI`, and `Real behavior proof`.

Known proof gap: live Telegram/Mantis visible delivery proof is still pending. The PR is labelled for `mantis: telegram-visible-proof`; merge should wait for redacted live proof or an explicit maintainer decision to accept source-level proof only.

## Risks and Counterexamples
- Heartbeat isolation remains enabled for ordinary heartbeat wakes.
- The owning-session wake bypass is limited to background-task completion delivery sources.
- Progress-only required completion output is blocked, while normal successful worker output remains successful.
- No config, migration, dependency, package, or runtime install changes are included.

