### PR TITLE
fix(memory-wiki): strip fenced code blocks before wikilink extraction (fixes #97945)

### DIFF
--- a/extensions/memory-wiki/src/markdown.ts
+++ b/extensions/memory-wiki/src/markdown.ts
@@ -116,6 +116,10 @@ const RELATED_BLOCK_PATTERN = new RegExp(
   `${WIKI_RELATED_START_MARKER}[\\s\\S]*?${WIKI_RELATED_END_MARKER}`,
   "g",
 );
+/** Matches fenced code blocks (```...```) including the language tag. */
+const FENCED_CODE_BLOCK_PATTERN = /```[\s\S]*?```/g;
+/** Matches inline code spans (`...`). */
+const INLINE_CODE_PATTERN = /`[^`]+`/g;
 const MAX_WIKI_SEGMENT_BYTES = 240;
 const MAX_WIKI_FILENAME_COMPONENT_BYTES = 255;
 const FS_SAFE_PINNED_WRITE_TEMP_SUFFIX = ".00000000-0000-4000-8000-000000000000.fallback.tmp";
@@ -387,7 +391,14 @@ function normalizeMarkdownLinkTarget(sourceRelativePath: string, target: string)
 }
 
 function extractWikiLinks(markdown: string, sourceRelativePath: string): string[] {
-  const searchable = markdown.replace(RELATED_BLOCK_PATTERN, "");
+  // Strip fenced code blocks and inline code spans before searching for
+  // wikilinks, so [[...]] patterns inside code (e.g. Scala generics like
+  // Future[Option[User]], bash [[ "$x" == "y" ]]) are not falsely
+  // reported as broken wikilink targets. (#97945)
+  const searchable = markdown
+    .replace(RELATED_BLOCK_PATTERN, "")
+    .replace(FENCED_CODE_BLOCK_PATTERN, "")
+    .replace(INLINE_CODE_PATTERN, "");
   const links: string[] = [];
   for (const match of searchable.matchAll(OBSIDIAN_LINK_PATTERN)) {
     const target = match[1]?.trim();


### PR DESCRIPTION
## What Problem This Solves

Fixes #97945 (reopening #70986).

`openclaw wiki lint` produces large numbers of false-positive `Broken wikilink target` warnings from `[[...]]` patterns inside fenced code blocks (e.g. Scala generics `Future[Option[User]]`, bash `[[ "$x" == "y" ]]`) and inline code spans.

## Changes

- Strip fenced code blocks (```` ```...``` ````) and inline code spans (`` `...` ``) from the searchable text before running the wikilink regex in `extractWikiLinks()`

## Evidence

**Unit tests (10/10 passed):**
```
$ node scripts/run-vitest.mjs run extensions/memory-wiki/src/lint.test.ts
 Test Files  1 passed (1)
      Tests  7 passed (7)

$ node scripts/run-vitest.mjs run extensions/memory-wiki/src/tool.test.ts
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

**git diff:**
```diff
 const RELATED_BLOCK_PATTERN = new RegExp(
   `${WIKI_RELATED_START_MARKER}[\\s\\S]*?${WIKI_RELATED_END_MARKER}`,
   "g",
 );
+/** Matches fenced code blocks (```...```) including the language tag. */
+const FENCED_CODE_BLOCK_PATTERN = /```[\s\S]*?```/g;
+/** Matches inline code spans (`...`). */
+const INLINE_CODE_PATTERN = /`[^`]+`/g;
 
 function extractWikiLinks(markdown: string, sourceRelativePath: string): string[] {
-  const searchable = markdown.replace(RELATED_BLOCK_PATTERN, "");
+  const searchable = markdown
+    .replace(RELATED_BLOCK_PATTERN, "")
+    .replace(FENCED_CODE_BLOCK_PATTERN, "")
+    .replace(INLINE_CODE_PATTERN, "");
```

**Before fix:** 2,626 lint warnings including ~1,697 `Broken wikilink target` (from #97945)

**After fix:** code block `[[...]]` patterns no longer produce false positives.

## AI Assistance

- AI-assisted: Yes