### PR TITLE
fix(agents): scope silent-error retry safety to current attempt

### DIFF
--- a/src/agents/embedded-agent-runner/run.empty-error-retry.test.ts
+++ b/src/agents/embedded-agent-runner/run.empty-error-retry.test.ts
@@ -6,7 +6,6 @@ import {
   mockedClassifyAssistantFailoverReason,
   mockedClassifyFailoverReason,
   mockedGlobalHookRunner,
-  mockedLog,
   mockedRunEmbeddedAttempt,
   overflowBaseRunParams,
   resetRunOverflowCompactionHarnessMocks,
@@ -84,8 +83,6 @@ describe("runEmbeddedAgent silent-error retry", () => {
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
     expect(result.payloads).toBeUndefined();
-    // Proof: [empty-error-retry] log fires in the real runner path
-    expect(mockedLog.warn).toHaveBeenCalledWith(expect.stringContaining("[empty-error-retry]"));
   });
 
   it("retries when stopReason=error emitted only thinking blocks and output tokens", async () => {
@@ -170,9 +167,6 @@ describe("runEmbeddedAgent silent-error retry", () => {
   });
 
   it("retries server_error when the attempt is otherwise silent and side-effect-free", async () => {
-    // Real provider 5xx produces server_error. #97877 fix ensures
-    // server_error enters the retry gate; shouldRetrySilentErrorAssistantTurn
-    // then checks content/tools/side-effects before allowing retry.
     mockedClassifyAssistantFailoverReason.mockReturnValue("server_error");
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       emptyErrorAttempt("anthropic", "claude-opus-4-8", 0, [], "Internal server error"),
@@ -188,7 +182,6 @@ describe("runEmbeddedAgent silent-error retry", () => {
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
     expect(result.payloads).toBeUndefined();
-    expect(mockedLog.warn).toHaveBeenCalledWith(expect.stringContaining("[empty-error-retry]"));
   });
 
   it("does not intercept concrete non-transient failover errors", async () => {
@@ -299,9 +292,7 @@ describe("runEmbeddedAgent silent-error retry", () => {
   });
 
   it("does not retry when the failed attempt recorded side effects", async () => {
-    // Legacy fallback: no currentAttemptReplayMetadata → falls back to
-    // cumulative replayMetadata (which is dirty from toolMetas).
-    // Conservatively blocks retry when any metadata signal is dirty.
+    // Without per-attempt metadata, cumulative side effects remain fail-closed.
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: [],
@@ -326,15 +317,9 @@ describe("runEmbeddedAgent silent-error retry", () => {
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
     expect(result.payloads?.[0]?.isError).toBe(true);
-    // Proof: no retry log when dirty cumulative metadata blocks retry
-    expect(mockedLog.warn).not.toHaveBeenCalledWith(expect.stringContaining("[empty-error-retry]"));
   });
 
   it("does not retry when currentAttemptReplayMetadata records same-attempt tool side effects", async () => {
-    // Same-attempt unsafe tool detected via buildAttemptReplayMetadata
-    // with actual toolMetasNormalized (independent of cumulative state).
-    // Even if cumulative replayMetadata is clean, the current-attempt
-    // signal must block retry to prevent duplicate tool execution.
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         ...emptyErrorAttempt("ollama", "glm-5.1:cloud"),
@@ -354,52 +339,13 @@ describe("runEmbeddedAgent silent-error retry", () => {
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
     expect(result.payloads?.[0]?.isError).toBe(true);
-    expect(mockedLog.warn).not.toHaveBeenCalledWith(expect.stringContaining("[empty-error-retry]"));
-  });
-
-  it("does not retry when prior state is dirty AND same-attempt tool also ran", async () => {
-    // Session already had side effects from earlier turns, AND the current
-    // attempt ran a replay-unsafe tool.  currentAttemptReplayMetadata is
-    // dirty (independent of prior cumulative) so retry must stay blocked.
-    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
-      makeAttemptResult({
-        ...emptyErrorAttempt("ollama", "glm-5.1:cloud"),
-        // Cumulative: dirty from prior turns
-        replayMetadata: { hadPotentialSideEffects: true, replaySafe: false },
-        // Per-attempt: also dirty (tool ran this attempt)
-        currentAttemptReplayMetadata: {
-          hadPotentialSideEffects: true,
-          replaySafe: false,
-        },
-      }),
-    );
-
-    const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      provider: "ollama",
-      model: "glm-5.1:cloud",
-      runId: "run-empty-error-retry-prior-dirty-same-attempt-tool",
-    });
-
-    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
-    expect(result.payloads?.[0]?.isError).toBe(true);
-    expect(mockedLog.warn).not.toHaveBeenCalledWith(expect.stringContaining("[empty-error-retry]"));
   });
 
   it("retries when prior turns had side effects but current 5xx attempt ran no tools", async () => {
-    // Regression for #97877: cumulative replayMetadata from prior-turn tool
-    // activity must not block retry of a later turn whose model call itself
-    // produced no tools. attempt.ts emits currentAttemptReplayMetadata from
-    // observedReplayMetadata before accumulation — clean per-attempt + dirty
-    // cumulative → retry allowed.
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         ...emptyErrorAttempt("ollama", "glm-5.1:cloud"),
-        // Simulate cumulative prior-turn side effects — hadPotentialSideEffects
-        // is true from session accumulation even though this attempt was clean.
         replayMetadata: { hadPotentialSideEffects: true, replaySafe: false },
-        // Per-attempt: emitted by attempt.ts from observedReplayMetadata before
-        // accumulation.  This is clean — no tools ran in this attempt.
         currentAttemptReplayMetadata: { hadPotentialSideEffects: false, replaySafe: true },
       }),
     );
@@ -414,36 +360,6 @@ describe("runEmbeddedAgent silent-error retry", () => {
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
     expect(result.payloads).toBeUndefined();
-    // Proof: [empty-error-retry] fires in the real runner, even with
-    // cumulative replayMetadata dirty from prior-turn tool activity
-    expect(mockedLog.warn).toHaveBeenCalledWith(expect.stringContaining("[empty-error-retry]"));
-  });
-
-  it("does not retry when cumulative replayMetadata is dirty and currentAttemptReplayMetadata is absent", async () => {
-    // Legacy harnesses that do not emit currentAttemptReplayMetadata
-    // must stay conservative: dirty cumulative → no retry.
-    // normalizeEmbeddedRunAttemptResult passes through raw.currentAttemptReplayMetadata
-    // as undefined; shouldRetrySilentErrorAssistantTurn falls back to cumulative.
-    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
-      makeAttemptResult({
-        ...emptyErrorAttempt("ollama", "glm-5.1:cloud"),
-        // Cumulative dirty from prior turns
-        replayMetadata: { hadPotentialSideEffects: true, replaySafe: false },
-        // Legacy harness: no currentAttemptReplayMetadata
-      }),
-    );
-
-    const result = await runEmbeddedAgent({
-      ...overflowBaseRunParams,
-      provider: "ollama",
-      model: "glm-5.1:cloud",
-      runId: "run-empty-error-retry-legacy-absent",
-    });
-
-    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
-    expect(result.payloads?.[0]?.isError).toBe(true);
-    // Proof: no retry log — legacy harness stays conservative
-    expect(mockedLog.warn).not.toHaveBeenCalledWith(expect.stringContaining("[empty-error-retry]"));
   });
 
   it.each([

--- a/src/agents/embedded-agent-runner/run.empty-error-retry.test.ts
+++ b/src/agents/embedded-agent-runner/run.empty-error-retry.test.ts
@@ -6,6 +6,7 @@ import {
   mockedClassifyAssistantFailoverReason,
   mockedClassifyFailoverReason,
   mockedGlobalHookRunner,
+  mockedLog,
   mockedRunEmbeddedAttempt,
   overflowBaseRunParams,
   resetRunOverflowCompactionHarnessMocks,
@@ -83,6 +84,8 @@ describe("runEmbeddedAgent silent-error retry", () => {
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
     expect(result.payloads).toBeUndefined();
+    // Proof: [empty-error-retry] log fires in the real runner path
+    expect(mockedLog.warn).toHaveBeenCalledWith(expect.stringContaining("[empty-error-retry]"));
   });
 
   it("retries when stopReason=error emitted only thinking blocks and output tokens", async () => {
@@ -138,11 +141,8 @@ describe("runEmbeddedAgent silent-error retry", () => {
     expect(result.payloads).toBeUndefined();
   });
 
-  it.each([
-    ["timeout", "LLM request timed out."],
-    ["server_error", "Internal server error"],
-  ] as const)("does not intercept recognized %s failover errors", async (reason, errorMessage) => {
-    mockedClassifyAssistantFailoverReason.mockReturnValue(reason);
+  it("does not intercept recognized timeout failover errors", async () => {
+    mockedClassifyAssistantFailoverReason.mockReturnValue("timeout");
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       emptyErrorAttempt(
         "anthropic",
@@ -155,7 +155,7 @@ describe("runEmbeddedAgent silent-error retry", () => {
             thinkingSignature: JSON.stringify({ id: "rs_error", type: "reasoning" }),
           },
         ],
-        errorMessage,
+        "LLM request timed out.",
       ),
     );
 
@@ -163,10 +163,32 @@ describe("runEmbeddedAgent silent-error retry", () => {
       ...overflowBaseRunParams,
       provider: "anthropic",
       model: "claude-opus-4-8",
-      runId: `run-empty-error-retry-${reason}`,
+      runId: "run-empty-error-retry-timeout",
     });
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries server_error when the attempt is otherwise silent and side-effect-free", async () => {
+    // Real provider 5xx produces server_error. #97877 fix ensures
+    // server_error enters the retry gate; shouldRetrySilentErrorAssistantTurn
+    // then checks content/tools/side-effects before allowing retry.
+    mockedClassifyAssistantFailoverReason.mockReturnValue("server_error");
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      emptyErrorAttempt("anthropic", "claude-opus-4-8", 0, [], "Internal server error"),
+    );
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(successAttempt("anthropic", "claude-opus-4-8"));
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "anthropic",
+      model: "claude-opus-4-8",
+      runId: "run-empty-error-retry-server-error",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(result.payloads).toBeUndefined();
+    expect(mockedLog.warn).toHaveBeenCalledWith(expect.stringContaining("[empty-error-retry]"));
   });
 
   it("does not intercept concrete non-transient failover errors", async () => {
@@ -277,8 +299,9 @@ describe("runEmbeddedAgent silent-error retry", () => {
   });
 
   it("does not retry when the failed attempt recorded side effects", async () => {
-    // Resubmission would duplicate side effects when replay metadata cannot
-    // prove the failed turn is safe to replay.
+    // Legacy fallback: no currentAttemptReplayMetadata → falls back to
+    // cumulative replayMetadata (which is dirty from toolMetas).
+    // Conservatively blocks retry when any metadata signal is dirty.
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: [],
@@ -290,10 +313,7 @@ describe("runEmbeddedAgent silent-error retry", () => {
           content: [],
           usage: { input: 100, output: 0, totalTokens: 100 },
         } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
-        replayMetadata: {
-          hadPotentialSideEffects: true,
-          replaySafe: false,
-        },
+        toolMetas: [{ toolName: "browser", replaySafe: false }],
       }),
     );
 
@@ -306,6 +326,124 @@ describe("runEmbeddedAgent silent-error retry", () => {
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
     expect(result.payloads?.[0]?.isError).toBe(true);
+    // Proof: no retry log when dirty cumulative metadata blocks retry
+    expect(mockedLog.warn).not.toHaveBeenCalledWith(expect.stringContaining("[empty-error-retry]"));
+  });
+
+  it("does not retry when currentAttemptReplayMetadata records same-attempt tool side effects", async () => {
+    // Same-attempt unsafe tool detected via buildAttemptReplayMetadata
+    // with actual toolMetasNormalized (independent of cumulative state).
+    // Even if cumulative replayMetadata is clean, the current-attempt
+    // signal must block retry to prevent duplicate tool execution.
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        ...emptyErrorAttempt("ollama", "glm-5.1:cloud"),
+        currentAttemptReplayMetadata: {
+          hadPotentialSideEffects: true,
+          replaySafe: false,
+        },
+      }),
+    );
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "ollama",
+      model: "glm-5.1:cloud",
+      runId: "run-empty-error-retry-skip-same-attempt-tools",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    expect(result.payloads?.[0]?.isError).toBe(true);
+    expect(mockedLog.warn).not.toHaveBeenCalledWith(expect.stringContaining("[empty-error-retry]"));
+  });
+
+  it("does not retry when prior state is dirty AND same-attempt tool also ran", async () => {
+    // Session already had side effects from earlier turns, AND the current
+    // attempt ran a replay-unsafe tool.  currentAttemptReplayMetadata is
+    // dirty (independent of prior cumulative) so retry must stay blocked.
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        ...emptyErrorAttempt("ollama", "glm-5.1:cloud"),
+        // Cumulative: dirty from prior turns
+        replayMetadata: { hadPotentialSideEffects: true, replaySafe: false },
+        // Per-attempt: also dirty (tool ran this attempt)
+        currentAttemptReplayMetadata: {
+          hadPotentialSideEffects: true,
+          replaySafe: false,
+        },
+      }),
+    );
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "ollama",
+      model: "glm-5.1:cloud",
+      runId: "run-empty-error-retry-prior-dirty-same-attempt-tool",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    expect(result.payloads?.[0]?.isError).toBe(true);
+    expect(mockedLog.warn).not.toHaveBeenCalledWith(expect.stringContaining("[empty-error-retry]"));
+  });
+
+  it("retries when prior turns had side effects but current 5xx attempt ran no tools", async () => {
+    // Regression for #97877: cumulative replayMetadata from prior-turn tool
+    // activity must not block retry of a later turn whose model call itself
+    // produced no tools. attempt.ts emits currentAttemptReplayMetadata from
+    // observedReplayMetadata before accumulation — clean per-attempt + dirty
+    // cumulative → retry allowed.
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        ...emptyErrorAttempt("ollama", "glm-5.1:cloud"),
+        // Simulate cumulative prior-turn side effects — hadPotentialSideEffects
+        // is true from session accumulation even though this attempt was clean.
+        replayMetadata: { hadPotentialSideEffects: true, replaySafe: false },
+        // Per-attempt: emitted by attempt.ts from observedReplayMetadata before
+        // accumulation.  This is clean — no tools ran in this attempt.
+        currentAttemptReplayMetadata: { hadPotentialSideEffects: false, replaySafe: true },
+      }),
+    );
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(successAttempt("ollama", "glm-5.1:cloud"));
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "ollama",
+      model: "glm-5.1:cloud",
+      runId: "run-empty-error-retry-prior-side-effects",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(result.payloads).toBeUndefined();
+    // Proof: [empty-error-retry] fires in the real runner, even with
+    // cumulative replayMetadata dirty from prior-turn tool activity
+    expect(mockedLog.warn).toHaveBeenCalledWith(expect.stringContaining("[empty-error-retry]"));
+  });
+
+  it("does not retry when cumulative replayMetadata is dirty and currentAttemptReplayMetadata is absent", async () => {
+    // Legacy harnesses that do not emit currentAttemptReplayMetadata
+    // must stay conservative: dirty cumulative → no retry.
+    // normalizeEmbeddedRunAttemptResult passes through raw.currentAttemptReplayMetadata
+    // as undefined; shouldRetrySilentErrorAssistantTurn falls back to cumulative.
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        ...emptyErrorAttempt("ollama", "glm-5.1:cloud"),
+        // Cumulative dirty from prior turns
+        replayMetadata: { hadPotentialSideEffects: true, replaySafe: false },
+        // Legacy harness: no currentAttemptReplayMetadata
+      }),
+    );
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "ollama",
+      model: "glm-5.1:cloud",
+      runId: "run-empty-error-retry-legacy-absent",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    expect(result.payloads?.[0]?.isError).toBe(true);
+    // Proof: no retry log — legacy harness stays conservative
+    expect(mockedLog.warn).not.toHaveBeenCalledWith(expect.stringContaining("[empty-error-retry]"));
   });
 
   it.each([

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -2929,78 +2929,40 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     ).toBe(false);
   });
 
-  it("retries when cumulative replayMetadata is dirty but currentAttemptReplayMetadata proves clean", () => {
-    // Regression for #97877: prior-turn tool activity left cumulative
-    // replayMetadata.hadPotentialSideEffects=true, but the current 5xx
-    // attempt produced no tools and has clean per-attempt metadata.
-    const assistant = {
-      role: "assistant",
-      stopReason: "error",
-      provider: "openrouter",
-      model: "test-model",
-      content: [],
-      usage: { input: 100, output: 0, totalTokens: 100 },
-    } as unknown as EmbeddedRunAttemptResult["lastAssistant"];
-    expect(
-      shouldRetrySilentErrorAssistantTurn({
-        attempt: makeAttemptResult({
-          assistantTexts: [],
-          lastAssistant: assistant,
-          // Cumulative: dirty from prior turns
-          replayMetadata: { hadPotentialSideEffects: true, replaySafe: false },
-          // Per-attempt: clean — current model call ran no tools
-          currentAttemptReplayMetadata: { hadPotentialSideEffects: false, replaySafe: true },
+  it.each([
+    ["current clean overrides cumulative dirty", true, false, true],
+    ["current dirty overrides cumulative clean", false, true, false],
+    ["both clean remain retryable", false, false, true],
+  ] as const)(
+    "uses current-attempt replay metadata when %s",
+    (_label, cumulativeDirty, currentDirty, expected) => {
+      const assistant = {
+        role: "assistant",
+        stopReason: "error",
+        provider: "openrouter",
+        model: "test-model",
+        content: [],
+        usage: { input: 100, output: 0, totalTokens: 100 },
+      } as unknown as EmbeddedRunAttemptResult["lastAssistant"];
+      expect(
+        shouldRetrySilentErrorAssistantTurn({
+          attempt: makeAttemptResult({
+            assistantTexts: [],
+            lastAssistant: assistant,
+            replayMetadata: {
+              hadPotentialSideEffects: cumulativeDirty,
+              replaySafe: !cumulativeDirty,
+            },
+            currentAttemptReplayMetadata: {
+              hadPotentialSideEffects: currentDirty,
+              replaySafe: !currentDirty,
+            },
+          }),
+          assistant,
         }),
-        assistant,
-      }),
-    ).toBe(true);
-  });
-
-  it("does not retry when currentAttemptReplayMetadata records side effects", () => {
-    // Current attempt ran tools; must not retry even if cumulative
-    // replayMetadata accidentally appears clean.
-    const assistant = {
-      role: "assistant",
-      stopReason: "error",
-      provider: "openrouter",
-      model: "test-model",
-      content: [],
-      usage: { input: 100, output: 0, totalTokens: 100 },
-    } as unknown as EmbeddedRunAttemptResult["lastAssistant"];
-    expect(
-      shouldRetrySilentErrorAssistantTurn({
-        attempt: makeAttemptResult({
-          assistantTexts: [],
-          lastAssistant: assistant,
-          replayMetadata: { hadPotentialSideEffects: false, replaySafe: true },
-          currentAttemptReplayMetadata: { hadPotentialSideEffects: true, replaySafe: false },
-        }),
-        assistant,
-      }),
-    ).toBe(false);
-  });
-
-  it("retries when both replayMetadata and currentAttemptReplayMetadata are clean", () => {
-    const assistant = {
-      role: "assistant",
-      stopReason: "error",
-      provider: "openrouter",
-      model: "test-model",
-      content: [],
-      usage: { input: 100, output: 0, totalTokens: 100 },
-    } as unknown as EmbeddedRunAttemptResult["lastAssistant"];
-    expect(
-      shouldRetrySilentErrorAssistantTurn({
-        attempt: makeAttemptResult({
-          assistantTexts: [],
-          lastAssistant: assistant,
-          replayMetadata: { hadPotentialSideEffects: false, replaySafe: true },
-          currentAttemptReplayMetadata: { hadPotentialSideEffects: false, replaySafe: true },
-        }),
-        assistant,
-      }),
-    ).toBe(true);
-  });
+      ).toBe(expected);
+    },
+  );
 
   it("detects empty openai-compatible stop turns with non-zero output usage", () => {
     const retryInstruction = resolveEmptyResponseRetryInstruction({

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -2929,6 +2929,79 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     ).toBe(false);
   });
 
+  it("retries when cumulative replayMetadata is dirty but currentAttemptReplayMetadata proves clean", () => {
+    // Regression for #97877: prior-turn tool activity left cumulative
+    // replayMetadata.hadPotentialSideEffects=true, but the current 5xx
+    // attempt produced no tools and has clean per-attempt metadata.
+    const assistant = {
+      role: "assistant",
+      stopReason: "error",
+      provider: "openrouter",
+      model: "test-model",
+      content: [],
+      usage: { input: 100, output: 0, totalTokens: 100 },
+    } as unknown as EmbeddedRunAttemptResult["lastAssistant"];
+    expect(
+      shouldRetrySilentErrorAssistantTurn({
+        attempt: makeAttemptResult({
+          assistantTexts: [],
+          lastAssistant: assistant,
+          // Cumulative: dirty from prior turns
+          replayMetadata: { hadPotentialSideEffects: true, replaySafe: false },
+          // Per-attempt: clean — current model call ran no tools
+          currentAttemptReplayMetadata: { hadPotentialSideEffects: false, replaySafe: true },
+        }),
+        assistant,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not retry when currentAttemptReplayMetadata records side effects", () => {
+    // Current attempt ran tools; must not retry even if cumulative
+    // replayMetadata accidentally appears clean.
+    const assistant = {
+      role: "assistant",
+      stopReason: "error",
+      provider: "openrouter",
+      model: "test-model",
+      content: [],
+      usage: { input: 100, output: 0, totalTokens: 100 },
+    } as unknown as EmbeddedRunAttemptResult["lastAssistant"];
+    expect(
+      shouldRetrySilentErrorAssistantTurn({
+        attempt: makeAttemptResult({
+          assistantTexts: [],
+          lastAssistant: assistant,
+          replayMetadata: { hadPotentialSideEffects: false, replaySafe: true },
+          currentAttemptReplayMetadata: { hadPotentialSideEffects: true, replaySafe: false },
+        }),
+        assistant,
+      }),
+    ).toBe(false);
+  });
+
+  it("retries when both replayMetadata and currentAttemptReplayMetadata are clean", () => {
+    const assistant = {
+      role: "assistant",
+      stopReason: "error",
+      provider: "openrouter",
+      model: "test-model",
+      content: [],
+      usage: { input: 100, output: 0, totalTokens: 100 },
+    } as unknown as EmbeddedRunAttemptResult["lastAssistant"];
+    expect(
+      shouldRetrySilentErrorAssistantTurn({
+        attempt: makeAttemptResult({
+          assistantTexts: [],
+          lastAssistant: assistant,
+          replayMetadata: { hadPotentialSideEffects: false, replaySafe: true },
+          currentAttemptReplayMetadata: { hadPotentialSideEffects: false, replaySafe: true },
+        }),
+        assistant,
+      }),
+    ).toBe(true);
+  });
+
   it("detects empty openai-compatible stop turns with non-zero output usage", () => {
     const retryInstruction = resolveEmptyResponseRetryInstruction({
       provider: "llamacpp",

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -421,6 +421,9 @@ function normalizeEmbeddedRunAttemptResult(
       | null;
     didDeliverSourceReplyViaMessageTool?: boolean | null;
     itemLifecycle?: EmbeddedRunAttemptForRunner["itemLifecycle"] | null;
+    currentAttemptReplayMetadata?:
+      | EmbeddedRunAttemptForRunner["currentAttemptReplayMetadata"]
+      | null;
   };
   return {
     ...attempt,
@@ -439,10 +442,6 @@ function normalizeEmbeddedRunAttemptResult(
       activeCount: 0,
     },
     replayMetadata: resolveAttemptReplayMetadata(raw),
-    // Per-attempt metadata: only populated when the attempt producer (attempt.ts)
-    // explicitly sets it from observedReplayMetadata before accumulation.
-    // Legacy harnesses that do not emit this field trigger the ?? fallback in
-    // shouldRetrySilentErrorAssistantTurn, keeping the conservative behavior.
     currentAttemptReplayMetadata: raw.currentAttemptReplayMetadata ?? undefined,
   };
 }
@@ -3292,7 +3291,7 @@ async function runEmbeddedAgentInternal(
               promptFailoverReason === "timeout" &&
               !attempt.codexAppServerFailure &&
               attempt.promptTimeoutOutcome?.replayInvalid !== true &&
-              resolveAttemptReplayMetadata(attempt).replaySafe;
+              attempt.replayMetadata.replaySafe;
             // Capture the failing profile before auth-profile rotation mutates `lastProfileId`.
             const failedPromptProfileId = lastProfileId;
             const logPromptFailoverDecision = createFailoverDecisionLogger({

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -439,6 +439,11 @@ function normalizeEmbeddedRunAttemptResult(
       activeCount: 0,
     },
     replayMetadata: resolveAttemptReplayMetadata(raw),
+    // Per-attempt metadata: only populated when the attempt producer (attempt.ts)
+    // explicitly sets it from observedReplayMetadata before accumulation.
+    // Legacy harnesses that do not emit this field trigger the ?? fallback in
+    // shouldRetrySilentErrorAssistantTurn, keeping the conservative behavior.
+    currentAttemptReplayMetadata: raw.currentAttemptReplayMetadata ?? undefined,
   };
 }
 
@@ -3287,7 +3292,7 @@ async function runEmbeddedAgentInternal(
               promptFailoverReason === "timeout" &&
               !attempt.codexAppServerFailure &&
               attempt.promptTimeoutOutcome?.replayInvalid !== true &&
-              attempt.replayMetadata.replaySafe;
+              resolveAttemptReplayMetadata(attempt).replaySafe;
             // Capture the failing profile before auth-profile rotation mutates `lastProfileId`.
             const failedPromptProfileId = lastProfileId;
             const logPromptFailoverDecision = createFailoverDecisionLogger({
@@ -3478,7 +3483,8 @@ async function runEmbeddedAgentInternal(
             genericUnknownReasoningError ||
             assistantFailoverReason === "no_error_details" ||
             assistantFailoverReason === "unclassified" ||
-            assistantFailoverReason === "unknown";
+            assistantFailoverReason === "unknown" ||
+            assistantFailoverReason === "server_error";
           // Retry replay-safe non-visible provider errors before assistant
           // failover surfaces them as terminal provider failures.
           if (

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -307,6 +307,7 @@ import {
   validateReplayTurns,
 } from "../replay-history.js";
 import { observeReplayMetadata, replayMetadataFromState } from "../replay-state.js";
+import type { EmbeddedRunReplayMetadata } from "../replay-state.js";
 import { createEmbeddedAgentResourceLoader } from "../resource-loader.js";
 import {
   clearActiveEmbeddedRun,
@@ -5794,6 +5795,20 @@ export async function runEmbeddedAttempt(
       const replayMetadata = replayMetadataFromState(
         observeReplayMetadata(getReplayState(), observedReplayMetadata),
       );
+      // Derive current-attempt replay metadata independently from the
+      // current attempt's observable fields (toolMetasNormalized records
+      // per-tool replaySafe from handleToolExecutionEnd).  This is a
+      // clean source — it does not depend on accumulated replay state,
+      // so same-attempt unsafe tools are always detected regardless of
+      // prior-turn history.
+      const currentAttemptReplayMetadata: EmbeddedRunReplayMetadata = buildAttemptReplayMetadata({
+        toolMetas: toolMetasNormalized,
+        didSendViaMessagingTool: didSendViaMessagingTool(),
+        messagingToolSentTexts: getMessagingToolSentTexts(),
+        messagingToolSentMediaUrls: getMessagingToolSentMediaUrls(),
+        acceptedSessionSpawns,
+        successfulCronAdds: getSuccessfulCronAdds(),
+      });
       const completedClientToolCalls = clientToolCallSlots.flatMap((slot) =>
         slot.completed && slot.params
           ? [
@@ -5970,6 +5985,7 @@ export async function runEmbeddedAttempt(
 
       return {
         replayMetadata,
+        currentAttemptReplayMetadata,
         itemLifecycle: getItemLifecycle(),
         setTerminalLifecycleMeta,
         aborted,

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -307,7 +307,6 @@ import {
   validateReplayTurns,
 } from "../replay-history.js";
 import { observeReplayMetadata, replayMetadataFromState } from "../replay-state.js";
-import type { EmbeddedRunReplayMetadata } from "../replay-state.js";
 import { createEmbeddedAgentResourceLoader } from "../resource-loader.js";
 import {
   clearActiveEmbeddedRun,
@@ -5795,13 +5794,9 @@ export async function runEmbeddedAttempt(
       const replayMetadata = replayMetadataFromState(
         observeReplayMetadata(getReplayState(), observedReplayMetadata),
       );
-      // Derive current-attempt replay metadata independently from the
-      // current attempt's observable fields (toolMetasNormalized records
-      // per-tool replaySafe from handleToolExecutionEnd).  This is a
-      // clean source — it does not depend on accumulated replay state,
-      // so same-attempt unsafe tools are always detected regardless of
-      // prior-turn history.
-      const currentAttemptReplayMetadata: EmbeddedRunReplayMetadata = buildAttemptReplayMetadata({
+      // Keep current-attempt effects separate from cumulative replay state so
+      // a later clean provider failure remains retryable.
+      const currentAttemptReplayMetadata = buildAttemptReplayMetadata({
         toolMetas: toolMetasNormalized,
         didSendViaMessagingTool: didSendViaMessagingTool(),
         messagingToolSentTexts: getMessagingToolSentTexts(),

--- a/src/agents/embedded-agent-runner/run/incomplete-turn.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn.ts
@@ -526,6 +526,7 @@ export function shouldRetrySilentErrorAssistantTurn(params: {
     | "didDeliverSourceReplyViaMessageTool"
     | "messagingToolSourceReplyPayloads"
     | "replayMetadata"
+    | "currentAttemptReplayMetadata"
   >;
   assistant: EmbeddedRunAttemptResult["lastAssistant"] | null | undefined;
 }): boolean {
@@ -535,7 +536,12 @@ export function shouldRetrySilentErrorAssistantTurn(params: {
   if (hasAttemptTerminalState(params.attempt)) {
     return false;
   }
-  if (resolveAttemptReplayMetadata(params.attempt).hadPotentialSideEffects) {
+  // Prefer current-attempt metadata to decide whether this specific model
+  // call had side effects. Falls back to cumulative replayMetadata for
+  // harnesses that do not yet populate currentAttemptReplayMetadata.
+  const currentAttemptMeta =
+    params.attempt.currentAttemptReplayMetadata ?? params.attempt.replayMetadata;
+  if (currentAttemptMeta?.hadPotentialSideEffects) {
     return false;
   }
 

--- a/src/agents/embedded-agent-runner/run/incomplete-turn.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn.ts
@@ -536,12 +536,12 @@ export function shouldRetrySilentErrorAssistantTurn(params: {
   if (hasAttemptTerminalState(params.attempt)) {
     return false;
   }
-  // Prefer current-attempt metadata to decide whether this specific model
-  // call had side effects. Falls back to cumulative replayMetadata for
-  // harnesses that do not yet populate currentAttemptReplayMetadata.
-  const currentAttemptMeta =
-    params.attempt.currentAttemptReplayMetadata ?? params.attempt.replayMetadata;
-  if (currentAttemptMeta?.hadPotentialSideEffects) {
+  // Current-attempt evidence avoids blocking on prior committed effects; older
+  // harnesses retain the cumulative, fail-closed behavior.
+  const retryReplayMetadata = resolveAttemptReplayMetadata({
+    replayMetadata: params.attempt.currentAttemptReplayMetadata ?? params.attempt.replayMetadata,
+  });
+  if (retryReplayMetadata.hadPotentialSideEffects) {
     return false;
   }
 

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -248,6 +248,13 @@ export type EmbeddedRunAttemptResult = {
   /** True when sessions_yield tool was called during this attempt. */
   yieldDetected?: boolean;
   replayMetadata: EmbeddedRunReplayMetadata;
+  /**
+   * Replay metadata for the current attempt only, before accumulation with
+   * prior session state. Used by the silent-error retry gate to distinguish
+   * "this model call failed before tools ran" from "prior turns had side
+   * effects." Absent when the attempt returned before tool execution started.
+   */
+  currentAttemptReplayMetadata?: EmbeddedRunReplayMetadata | null;
   itemLifecycle: {
     startedCount: number;
     completedCount: number;

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -249,12 +249,10 @@ export type EmbeddedRunAttemptResult = {
   yieldDetected?: boolean;
   replayMetadata: EmbeddedRunReplayMetadata;
   /**
-   * Replay metadata for the current attempt only, before accumulation with
-   * prior session state. Used by the silent-error retry gate to distinguish
-   * "this model call failed before tools ran" from "prior turns had side
-   * effects." Absent when the attempt returned before tool execution started.
+   * Replay metadata for this attempt before prior session state is accumulated.
+   * Older harnesses may omit it and retain conservative cumulative retry gating.
    */
-  currentAttemptReplayMetadata?: EmbeddedRunReplayMetadata | null;
+  currentAttemptReplayMetadata?: EmbeddedRunReplayMetadata;
   itemLifecycle: {
     startedCount: number;
     completedCount: number;


### PR DESCRIPTION
Fixes #97877.

## What Problem This Solves

The embedded runner used cumulative replay metadata when deciding whether a silent provider failure was safe to retry. Once an earlier outer attempt recorded a possible side effect, a later clean provider failure could be blocked even though replaying that failing attempt could not duplicate the earlier effect.

Classified provider `server_error` failures also did not enter the silent-error retry gate, so real structured provider 5xx responses missed this recovery path.

## Why This Change Was Made

- `runEmbeddedAttempt` now emits `currentAttemptReplayMetadata` from the current attempt's tool, messaging, spawn, and cron facts while retaining cumulative `replayMetadata` for the wider run.
- The retry predicate prefers current-attempt evidence. Older harnesses that omit it fall back to cumulative evidence, and wholly missing evidence remains fail-closed.
- Classified `server_error` failures now use the existing bounded silent-error retry gate.
- Maintainer cleanup removed the earlier replay-state delta helper and an unrelated prompt-timeout change, normalized legacy `null` once at the runner boundary, and compacted the regression matrix.

## User Impact

Agents can recover from a transient structured provider 5xx when the failing attempt produced no visible output or potential side effects, even if an earlier attempt already committed work. A retry remains blocked after a tool, message, session spawn, or cron effect in the failing attempt, preventing duplicate execution.

| Current-attempt evidence | Cumulative evidence | Result |
| --- | --- | --- |
| clean | dirty | retry once |
| dirty | clean or dirty | do not retry |
| absent | dirty | do not retry |
| absent | clean | retry once |
| absent | absent | do not retry |

## Evidence

Exact prepared PR head: `5e15424153a7404c30848ac717fa6cdfa0afd213`.

- Fresh whole-branch Codex autoreview after rebase: no findings.
- Focused Blacksmith runner tests: 2 files, 142 tests passed (24 + 118): [run 29106059601](https://github.com/openclaw/openclaw/actions/runs/29106059601).
- Blacksmith `check:changed`: all selected core/coreTests type, lint, dependency, storage, sidecar, import-cycle, and guard lanes passed: [run 29106713218](https://github.com/openclaw/openclaw/actions/runs/29106713218).
- Real-Gateway QA on the same Testbox lease: `anthropic-thinking-error-recovery-replay-safe-read` and `reasoning-only-no-auto-retry-after-write`, 2/2 passed: [run 29106713218](https://github.com/openclaw/openclaw/actions/runs/29106713218).
- Exact-head hosted CI: all jobs passed: [run 29105928409](https://github.com/openclaw/openclaw/actions/runs/29105928409).
- Workflow Sanity, CodeQL, CodeQL Critical Quality, OpenGrep, and Real behavior proof also passed at the exact head.

Focused command:

```sh
corepack pnpm test \
  src/agents/embedded-agent-runner/run.empty-error-retry.test.ts \
  src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
```

The focused matrix covers clean `server_error` retry, same-attempt dirty no-retry, current-clean/cumulative-dirty retry, legacy missing-current fallback, and wholly missing evidence failing closed.

The public Gateway API cannot naturally omit current-attempt metadata or reliably seed dirty cumulative state across internal outer attempts. The real-Gateway pair therefore proves the adjacent safe-recovery and post-write no-retry behaviors; it does not claim the internal current-vs-cumulative decision table as live proof.

## AI Assistance

- AI-assisted: yes
- Contributor model: Claude Opus 4.8
- Maintainer cleanup/review: Codex GPT-5.5
