### PR TITLE
fix(cli-runner): return updatedInput for allowed Claude can_use_tool responses

### DIFF
--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -1960,14 +1960,13 @@ ${JSON.stringify({
       response: {
         subtype: string;
         request_id: string;
-        response: { behavior: string; toolUseID?: string };
+        response: { updatedInput: { command: string } };
       };
     };
     expect(parsed.type).toBe("control_response");
     expect(parsed.response.subtype).toBe("success");
     expect(parsed.response.request_id).toBe("req-allow");
-    expect(parsed.response.response.behavior).toBe("allow");
-    expect(parsed.response.response.toolUseID).toBe("tool-allow-1");
+    expect(parsed.response.response.updatedInput).toEqual({ command: "ls" });
   });
 
   it("reports Claude live stream progress and keeps native tools fresh while they are running", async () => {
@@ -2329,11 +2328,10 @@ ${JSON.stringify({
       response: {
         subtype: string;
         request_id: string;
-        response: { behavior: string; toolUseID?: string };
+        response: { updatedInput: { command: string } };
       };
     };
-    expect(parsed.response.response.behavior).toBe("allow");
-    expect(parsed.response.response.toolUseID).toBe("tool-default-allow-1");
+    expect(parsed.response.response.updatedInput).toEqual({ command: "echo hi" });
   });
 
   it("answers Claude live control_request can_use_tool with deny when approval defaults are restrictive", async () => {
@@ -2765,11 +2763,10 @@ ${JSON.stringify({
       response: {
         subtype: string;
         request_id: string;
-        response: { behavior: string; toolUseID?: string };
+        response: { updatedInput: { command: string } };
       };
     };
-    expect(parsed.response.response.behavior).toBe("allow");
-    expect(parsed.response.response.toolUseID).toBe("tool-permmode-allow-1");
+    expect(parsed.response.response.updatedInput).toEqual({ command: "ls" });
     const spawnArg = supervisorSpawnMock.mock.calls.at(-1)?.[0] as { argv?: string[] };
     expect(requireArgAfter(spawnArg.argv, "--permission-mode")).toBe("bypassPermissions");
   });

--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -1960,13 +1960,15 @@ ${JSON.stringify({
       response: {
         subtype: string;
         request_id: string;
-        response: { updatedInput: { command: string } };
+        response: { behavior: string; updatedInput: { command: string }; toolUseID?: string };
       };
     };
     expect(parsed.type).toBe("control_response");
     expect(parsed.response.subtype).toBe("success");
     expect(parsed.response.request_id).toBe("req-allow");
+    expect(parsed.response.response.behavior).toBe("allow");
     expect(parsed.response.response.updatedInput).toEqual({ command: "ls" });
+    expect(parsed.response.response.toolUseID).toBe("tool-allow-1");
   });
 
   it("reports Claude live stream progress and keeps native tools fresh while they are running", async () => {
@@ -2328,10 +2330,12 @@ ${JSON.stringify({
       response: {
         subtype: string;
         request_id: string;
-        response: { updatedInput: { command: string } };
+        response: { behavior: string; updatedInput: { command: string }; toolUseID?: string };
       };
     };
+    expect(parsed.response.response.behavior).toBe("allow");
     expect(parsed.response.response.updatedInput).toEqual({ command: "echo hi" });
+    expect(parsed.response.response.toolUseID).toBe("tool-default-allow-1");
   });
 
   it("answers Claude live control_request can_use_tool with deny when approval defaults are restrictive", async () => {
@@ -2763,10 +2767,12 @@ ${JSON.stringify({
       response: {
         subtype: string;
         request_id: string;
-        response: { updatedInput: { command: string } };
+        response: { behavior: string; updatedInput: { command: string }; toolUseID?: string };
       };
     };
+    expect(parsed.response.response.behavior).toBe("allow");
     expect(parsed.response.response.updatedInput).toEqual({ command: "ls" });
+    expect(parsed.response.response.toolUseID).toBe("tool-permmode-allow-1");
     const spawnArg = supervisorSpawnMock.mock.calls.at(-1)?.[0] as { argv?: string[] };
     expect(requireArgAfter(spawnArg.argv, "--permission-mode")).toBe("bypassPermissions");
   });

--- a/src/agents/cli-runner/claude-live-session.can-use-tool.test.ts
+++ b/src/agents/cli-runner/claude-live-session.can-use-tool.test.ts
@@ -2,10 +2,11 @@ import { describe, expect, it } from "vitest";
 import { buildClaudeLiveCanUseToolResponse } from "./claude-live-session.js";
 
 describe("buildClaudeLiveCanUseToolResponse", () => {
-  it("returns the updatedInput shape for allowed can_use_tool requests", () => {
+  it("returns the additive allow shape with behavior, updatedInput, and toolUseID", () => {
     const response = buildClaudeLiveCanUseToolResponse({
       requestId: "req-allow-1",
       toolInput: { command: "date" },
+      toolUseId: "tool-allow-1",
       allowed: true,
       denyMessage: "denied",
     });
@@ -15,7 +16,32 @@ describe("buildClaudeLiveCanUseToolResponse", () => {
       response: {
         subtype: "success",
         request_id: "req-allow-1",
-        response: { updatedInput: { command: "date" } },
+        response: {
+          behavior: "allow",
+          updatedInput: { command: "date" },
+          toolUseID: "tool-allow-1",
+        },
+      },
+    });
+  });
+
+  it("omits toolUseID when not provided for allowed can_use_tool requests", () => {
+    const response = buildClaudeLiveCanUseToolResponse({
+      requestId: "req-allow-2",
+      toolInput: { command: "echo hi" },
+      allowed: true,
+      denyMessage: "denied",
+    });
+
+    expect(response).toEqual({
+      type: "control_response",
+      response: {
+        subtype: "success",
+        request_id: "req-allow-2",
+        response: {
+          behavior: "allow",
+          updatedInput: { command: "echo hi" },
+        },
       },
     });
   });

--- a/src/agents/cli-runner/claude-live-session.can-use-tool.test.ts
+++ b/src/agents/cli-runner/claude-live-session.can-use-tool.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { buildClaudeLiveCanUseToolResponse } from "./claude-live-session.js";
+
+describe("buildClaudeLiveCanUseToolResponse", () => {
+  it("returns the updatedInput shape for allowed can_use_tool requests", () => {
+    const response = buildClaudeLiveCanUseToolResponse({
+      requestId: "req-allow-1",
+      toolInput: { command: "date" },
+      allowed: true,
+      denyMessage: "denied",
+    });
+
+    expect(response).toEqual({
+      type: "control_response",
+      response: {
+        subtype: "success",
+        request_id: "req-allow-1",
+        response: { updatedInput: { command: "date" } },
+      },
+    });
+  });
+
+  it("keeps the deny behavior shape for disallowed can_use_tool requests", () => {
+    const response = buildClaudeLiveCanUseToolResponse({
+      requestId: "req-deny-1",
+      toolInput: { command: "rm -rf /" },
+      allowed: false,
+      denyMessage: "OpenClaw exec policy denied Claude native tool use.",
+    });
+
+    expect(response).toEqual({
+      type: "control_response",
+      response: {
+        subtype: "success",
+        request_id: "req-deny-1",
+        response: {
+          behavior: "deny",
+          decisionClassification: "user_reject",
+          message: "OpenClaw exec policy denied Claude native tool use.",
+        },
+      },
+    });
+  });
+});

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -852,6 +852,7 @@ function writeClaudeLiveControlResponse(session: ClaudeLiveSession, response: un
 export function buildClaudeLiveCanUseToolResponse(params: {
   requestId: string;
   toolInput: Record<string, unknown>;
+  toolUseId?: string;
   allowed: boolean;
   denyMessage: string;
 }): Record<string, unknown> {
@@ -861,7 +862,11 @@ export function buildClaudeLiveCanUseToolResponse(params: {
       subtype: "success",
       request_id: params.requestId,
       response: params.allowed
-        ? { updatedInput: params.toolInput }
+        ? {
+            behavior: "allow",
+            updatedInput: params.toolInput,
+            ...(params.toolUseId ? { toolUseID: params.toolUseId } : {}),
+          }
         : {
             behavior: "deny",
             decisionClassification: "user_reject",
@@ -889,12 +894,14 @@ function handleClaudeLiveControlRequest(
   }
   const rawInput = request.input;
   const toolInput = isRecord(rawInput) ? rawInput : {};
+  const toolUseId = typeof request.tool_use_id === "string" ? request.tool_use_id : undefined;
   const allowed = turn.execPermission.security === "full" && turn.execPermission.ask === "off";
   writeClaudeLiveControlResponse(
     session,
     buildClaudeLiveCanUseToolResponse({
       requestId,
       toolInput,
+      toolUseId,
       allowed,
       denyMessage: `OpenClaw exec policy denied Claude native tool use (security=${turn.execPermission.security}, ask=${turn.execPermission.ask}).`,
     }),

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -849,6 +849,28 @@ function writeClaudeLiveControlResponse(session: ClaudeLiveSession, response: un
   stdin.write(`${JSON.stringify(response)}\n`);
 }
 
+export function buildClaudeLiveCanUseToolResponse(params: {
+  requestId: string;
+  toolInput: Record<string, unknown>;
+  allowed: boolean;
+  denyMessage: string;
+}): Record<string, unknown> {
+  return {
+    type: "control_response",
+    response: {
+      subtype: "success",
+      request_id: params.requestId,
+      response: params.allowed
+        ? { updatedInput: params.toolInput }
+        : {
+            behavior: "deny",
+            decisionClassification: "user_reject",
+            message: params.denyMessage,
+          },
+    },
+  };
+}
+
 function handleClaudeLiveControlRequest(
   session: ClaudeLiveSession,
   turn: ClaudeLiveTurn,
@@ -865,25 +887,18 @@ function handleClaudeLiveControlRequest(
   if (!requestId) {
     return;
   }
-  const toolUseId = typeof request.tool_use_id === "string" ? request.tool_use_id : undefined;
+  const rawInput = request.input;
+  const toolInput = isRecord(rawInput) ? rawInput : {};
   const allowed = turn.execPermission.security === "full" && turn.execPermission.ask === "off";
-  writeClaudeLiveControlResponse(session, {
-    type: "control_response",
-    response: {
-      subtype: "success",
-      request_id: requestId,
-      response: allowed
-        ? {
-            behavior: "allow",
-            ...(toolUseId ? { toolUseID: toolUseId } : {}),
-          }
-        : {
-            behavior: "deny",
-            decisionClassification: "user_reject",
-            message: `OpenClaw exec policy denied Claude native tool use (security=${turn.execPermission.security}, ask=${turn.execPermission.ask}).`,
-          },
-    },
-  });
+  writeClaudeLiveControlResponse(
+    session,
+    buildClaudeLiveCanUseToolResponse({
+      requestId,
+      toolInput,
+      allowed,
+      denyMessage: `OpenClaw exec policy denied Claude native tool use (security=${turn.execPermission.security}, ask=${turn.execPermission.ask}).`,
+    }),
+  );
 }
 
 function handleClaudeLiveLine(session: ClaudeLiveSession, line: string): void {


### PR DESCRIPTION
### What Problem This Solves

Claude Code 2.1.156 rejects the allow response OpenClaw sends for `can_use_tool` control requests because it still uses the deprecated `{ behavior: "allow" }` shape. Every tool call that goes through the permission/approval flow fails with a ZodError before the tool runs (see #95171).

### Why This Change Was Made

The Claude Code 2.1.x `PermissionResult` allow branch now requires `{ updatedInput: <input> }`. The fix adds `updatedInput` while preserving the existing `behavior: "allow"` discriminator and `toolUseID` passthrough, maximizing compatibility with inspected Claude Code 2.1.x SDK declarations. The deny branch is unchanged.

### User Impact

Users on Claude Code >= 2.1.156 can now use tools that hit the exec approval flow (e.g. `Bash`, `WebFetch`, `Grep` outside cwd) without getting a ZodError.

### Evidence

Added/updated `src/agents/cli-runner/claude-live-session.can-use-tool.test.ts`.

```bash
node scripts/run-vitest.mjs run src/agents/cli-runner/claude-live-session.can-use-tool.test.ts
```

Result:

```
[test] starting test/vitest/vitest.unit-fast.config.ts

 RUN  v4.1.8 /home/0668001525/PR解决/openclaw

 ✓ |unit-fast| src/agents/cli-runner/claude-live-session.can-use-tool.test.ts (3 tests) 7ms

 Test Files  1 passed (1)
      Tests  3 passed (3)
   Start at  17:47:28
   Duration  19.73s (transform 15.47s, setup 0ms, import 19.49s, tests 7ms, environment 0ms)

[test] passed 1 Vitest shard in 28.10s
```

### Real behavior proof

Protocol-level verification against the installed Claude Code 2.1.76 binary, using the actual PR code path:

```
=== Claude Code version ===
2.1.76 (Claude Code)

=== OpenClaw can_use_tool allow response (real PR code) ===
{
  "type": "control_response",
  "response": {
    "subtype": "success",
    "request_id": "req-allow-1",
    "response": {
      "behavior": "allow",
      "updatedInput": {
        "command": "date"
      },
      "toolUseID": "tool-allow-1"
    }
  }
}

=== OpenClaw can_use_tool deny response (real PR code) ===
{
  "type": "control_response",
  "response": {
    "subtype": "success",
    "request_id": "req-deny-1",
    "response": {
      "behavior": "deny",
      "decisionClassification": "user_reject",
      "message": "OpenClaw exec policy denied Claude native tool use."
    }
  }
}

✓ Allow response contains behavior:'allow', updatedInput, and toolUseID

=== Claude Code 2.1.x initialize handshake ===
Claude Code initialize succeeded
Available models: Default (recommended), Sonnet (1M context), Opus, Opus (1M context), Haiku ...

=== Proof summary ===
- Claude Code binary: 2.1.76 (Claude Code)
- OpenClaw allow response shape: { behavior: 'allow', updatedInput: <tool input>, toolUseID: <id> }
- Claude Code 2.1.x initialize control_response handshake: OK
```

This confirms the actual OpenClaw code path now emits an additive allow payload `{ behavior: "allow", updatedInput: <tool input>, toolUseID: <id> }` for allowed `can_use_tool` requests, matching the inspected Claude Code 2.1.x `PermissionResult` allow contract. A complete end-to-end recording of an approved live tool call reaching execution (e.g. `Bash("date")`) requires Anthropic API access, which is not present in this environment.

Fixes #95171
