### PR TITLE
fix(browser): CDP auth fails with percent-encoded credentials

### DIFF
--- a/extensions/browser/src/browser/browser-utils.test.ts
+++ b/extensions/browser/src/browser/browser-utils.test.ts
@@ -199,6 +199,13 @@ describe("cdp.helpers", () => {
     expect(headers.Authorization).toBe(`Basic ${Buffer.from("user:pass").toString("base64")}`);
   });
 
+  it("decodes percent-encoded basic auth credentials from URLs", () => {
+    const headers = getHeadersWithAuth("https://alice:p%40ss%20word@example.com");
+    expect(headers.Authorization).toBe(
+      `Basic ${Buffer.from("alice:p@ss word").toString("base64")}`,
+    );
+  });
+
   it("keeps preexisting authorization headers", () => {
     const headers = getHeadersWithAuth("https://user:pass@example.com", {
       Authorization: "Bearer token",

--- a/extensions/browser/src/browser/cdp.helpers.test.ts
+++ b/extensions/browser/src/browser/cdp.helpers.test.ts
@@ -146,6 +146,28 @@ describe("cdp helpers", () => {
     expect(release).toHaveBeenCalledTimes(1);
   });
 
+  it("decodes URL credentials before sending guarded CDP auth headers", async () => {
+    const release = vi.fn(async () => {});
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: {
+        ok: true,
+        status: 200,
+      },
+      release,
+    });
+
+    await expect(
+      fetchOk("http://alice:p%40ss%20word@127.0.0.1:9222/json/version", 250),
+    ).resolves.toBeUndefined();
+
+    const request = requireGuardedFetchRequest();
+    expect(request?.url).toBe("http://127.0.0.1:9222/json/version");
+    expect(request?.init?.headers).toEqual({
+      Authorization: `Basic ${Buffer.from("alice:p@ss word").toString("base64")}`,
+    });
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
   it("preserves hostname allowlist while allowing exact loopback CDP fetches", async () => {
     const release = vi.fn(async () => {});
     fetchWithSsrFGuardMock.mockResolvedValueOnce({

--- a/extensions/browser/src/browser/cdp.helpers.ts
+++ b/extensions/browser/src/browser/cdp.helpers.ts
@@ -113,6 +113,14 @@ export type CdpSendFn = (
   sessionId?: string,
 ) => Promise<unknown>;
 
+function decodeUrlUserInfo(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
 function rawCdpMessageToString(data: WebSocket.RawData): string {
   if (typeof data === "string") {
     return data;
@@ -141,7 +149,9 @@ export function getHeadersWithAuth(url: string, headers: Record<string, string> 
       return mergedHeaders;
     }
     if (parsed.username || parsed.password) {
-      const auth = Buffer.from(`${parsed.username}:${parsed.password}`).toString("base64");
+      const username = decodeUrlUserInfo(parsed.username);
+      const password = decodeUrlUserInfo(parsed.password);
+      const auth = Buffer.from(`${username}:${password}`).toString("base64");
       return { ...mergedHeaders, Authorization: `Basic ${auth}` };
     }
   } catch {


### PR DESCRIPTION
This PR fixes browser CDP Basic auth failures when the configured endpoint URL contains percent-encoded username or password characters.

Related: #93680 also extends `getHeadersWithAuth` for extension-bridge Bearer auth. This PR is complementary: it only decodes percent-encoded URL username/password before constructing the existing Basic Authorization header, and preserves the current precedence where explicit URL credentials win over fallback auth.

## What Problem This Solves

Browser CDP endpoints can be configured with URL-embedded Basic auth credentials, for example:

```text
http://alice:p%40ss%20word@127.0.0.1:9222/json/version
```

In URL userinfo, reserved characters must be percent-encoded. The password above represents the real credential value `p@ss word`, where `%40` is `@` and `%20` is a space.

The browser CDP helper read `URL.username` and `URL.password` directly when constructing the `Authorization: Basic ...` header. In Node's WHATWG URL implementation, those properties remain percent-encoded when read, so OpenClaw built the Basic auth payload from the literal string:

```text
alice:p%40ss%20word
```

instead of the credential the user configured:

```text
alice:p@ss word
```

That causes remote CDP services requiring Basic auth to reject otherwise valid credentials whenever the username or password contains characters such as `@`, spaces, `:`, or other URL-reserved characters that are commonly percent-encoded in URLs.

## Why This Change Was Made

Decode the URL username/password components before building the Basic auth header, while preserving the existing fallback behavior if decoding fails.

This keeps the browser CDP authentication surface narrow: guarded HTTP CDP fetches, WebSocket CDP connections, and Playwright CDP attach paths continue to share the same `getHeadersWithAuth` helper. Explicit `Authorization` headers still take precedence over URL credentials, and this PR does not change URL credential stripping from outbound request URLs.

## User Impact

Users can configure browser CDP endpoints whose Basic auth credentials contain reserved characters such as `@`, spaces, or other percent-encoded characters, and OpenClaw will send the decoded credentials expected by the remote CDP service.

## Change

- Decode `URL.username` and `URL.password` before constructing the Basic auth payload.
- Keep the prior defensive behavior for malformed percent-encoding by falling back to the original value.
- Add regression coverage for both direct `getHeadersWithAuth()` behavior and the guarded CDP fetch path.

## Evidence

Before this fix, the credential-bearing URL:

```text
http://alice:p%40ss%20word@127.0.0.1:9222/json/version
```

produced a Basic auth payload for:

```text
alice:p%40ss%20word
```

After this fix, the same URL produces a Basic auth payload for:

```text
alice:p@ss word
```

The guarded CDP fetch regression also verifies that the request URL still has credentials stripped before fetch:

```text
http://127.0.0.1:9222/json/version
```

while the decoded Basic auth header is sent through request headers.

Real behavior proof after this fix:

- Started a real local Chrome instance with `--remote-debugging-port`.
- Placed Chrome's `/json/version` endpoint behind a loopback Basic-auth proxy.
- Configured the proxy to accept only the decoded credential `alice:p@ss word`.
- Called the proxy URL with encoded URL credentials: `http://alice:p%40ss%20word@127.0.0.1:<proxy-port>/json/version`.
- Used the current branch's `getHeadersWithAuth()` output for the request headers.

Observed terminal output:

```text
OpenClaw browser CDP encoded Basic credentials proof
Scope: local real Chrome CDP /json/version behind a loopback Basic-auth proxy.
No external service contacted; no file writes except a temporary Chrome profile.

Chrome CDP endpoint: http://127.0.0.1:55495/json/version
Basic-auth proxy: http://127.0.0.1:57127/json/version
configured credential URL: http://alice:p%40ss%20word@127.0.0.1:57127/json/version
expected decoded credential: alice:p@ss word

Before-fix source behavior (Node WHATWG URL read):
URL.password read value: p%40ss%20word
vulnerable Basic payload would be: alice:p%40ss%20word

After-fix request behavior:
request URL sent to proxy: http://127.0.0.1:57127/json/version
proxy observed request target: GET /json/version
proxy decoded Authorization payload: alice:p@ss word
CDP response status through proxy: 200
CDP response has webSocketDebuggerUrl: true
Chrome reported browser: Chrome/<version>

verdict: PASS - encoded URL credentials were decoded and accepted by the real CDP proxy path.
```

This proof covers the real Chrome CDP HTTP discovery path through the shared auth helper. The credentials in the proof are synthetic, and the only endpoint is local loopback.

## Possible call chain / impact

The affected helper is shared by the browser CDP connection paths:

```text
extensions/browser/src/browser/cdp.helpers.ts
  -> getHeadersWithAuth(...)
    -> fetchCdpChecked(...) / fetchJson(...) / fetchOk(...)
    -> openCdpWebSocket(...) / withCdpSocket(...)
    -> Playwright CDP attach headers through the shared helper
```

This PR only changes how URL-embedded Basic auth credentials are converted into an auth header. It does not change CDP endpoint parsing, SSRF policy, proxy handling, explicit `Authorization` header precedence, WebSocket connection behavior, or browser tool behavior after authentication succeeds.

## Testing

- `pnpm install --frozen-lockfile`
- `node scripts/run-vitest.mjs extensions/browser/src/browser/cdp.helpers.test.ts extensions/browser/src/browser/browser-utils.test.ts`
  - 2 test files passed
  - 43 tests passed
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/browser/src/browser/browser-utils.test.ts extensions/browser/src/browser/cdp.helpers.test.ts extensions/browser/src/browser/cdp.helpers.ts`
- `pnpm tsgo:extensions`
- `pnpm tsgo:extensions:test`
- `git diff --check`
- Local real-behavior proof with Chrome CDP `/json/version` behind a loopback Basic-auth proxy, using encoded URL credentials and the current branch's `getHeadersWithAuth()` output.

Limitations:

- `pnpm test:extension browser` started the browser extension test lane but the Windows process exited with `3221226505` (`0xc0000409`) before reporting test assertions.
- `codex review --base origin/main` could not run on this machine because Windows returned `Access is denied` for `codex.exe`.
- The real-behavior proof covers local Chrome CDP HTTP discovery through a Basic-auth proxy. WebSocket and Playwright attach paths inherit the same shared helper behavior but are not separately integration-tested in this PR.
