### PR TITLE
fix(openai-completions): preserve upstream SSE frames in JSON fallback

### DIFF
--- a/src/agents/provider-transport-fetch.test.ts
+++ b/src/agents/provider-transport-fetch.test.ts
@@ -1268,6 +1268,48 @@ describe("buildGuardedModelFetch", () => {
     expect(items).toEqual([{ ok: true }]);
   });
 
+  it("preserves already-SSE-framed bodies when synthesizing streaming fallbacks", async () => {
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response(
+        'data: {"id":"068B33628193CE8053B9400D777ED001","created":1782317155,"choices":[{"index":0,"delta":{"content":"hello"}}]}\n\n',
+        { headers: { "content-type": "application/json; charset=utf-8" } },
+      ),
+      finalUrl: "https://openrouter.ai/api/v1/chat/completions",
+      release: vi.fn(async () => undefined),
+    });
+    const model = {
+      id: "MiniMax-M3",
+      provider: "openrouter",
+      api: "openai-completions",
+      baseUrl: "https://openrouter.ai/api/v1",
+    } as unknown as Model<"openai-completions">;
+
+    const response = await buildGuardedModelFetch(model)(
+      "https://openrouter.ai/api/v1/chat/completions",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ model: "MiniMax-M3", stream: true }),
+      },
+    );
+
+    const text = await response.clone().text();
+    const items = [];
+    for await (const item of Stream.fromSSEResponse(response, new AbortController())) {
+      items.push(item);
+    }
+
+    expect(text).toContain('data: {"id":"068B33628193CE8053B9400D777ED001"');
+    expect(text).not.toContain("data: data:");
+    expect(items).toEqual([
+      {
+        id: "068B33628193CE8053B9400D777ED001",
+        created: 1782317155,
+        choices: [{ index: 0, delta: { content: "hello" } }],
+      },
+    ]);
+  });
+
   it("preserves JSON bodies when the request is not streaming", async () => {
     fetchWithSsrFGuardMock.mockResolvedValue({
       response: new Response('{"ok": true}', {

--- a/src/agents/provider-transport-fetch.ts
+++ b/src/agents/provider-transport-fetch.ts
@@ -96,6 +96,10 @@ function findSseEventBoundary(buffer: string): { index: number; length: number }
   return best;
 }
 
+function looksLikeSsePayload(text: string): boolean {
+  return hasReadableSseData(text) || /^\s*(?:event|id|retry|:)\s*:?/m.test(text);
+}
+
 function capNonOkResponseBodyLazily(response: Response, maxBytes: number): Response {
   const source = response.body;
   if (!source) {
@@ -156,7 +160,11 @@ function sanitizeOpenAISdkSseResponse(
               buffer += decoder.decode();
               const data = buffer.trim();
               if (data) {
-                controller.enqueue(encoder.encode(`data: ${data}\n\n`));
+                if (looksLikeSsePayload(data)) {
+                  controller.enqueue(encoder.encode(data.endsWith("\n\n") ? data : `${data}\n\n`));
+                } else {
+                  controller.enqueue(encoder.encode(`data: ${data}\n\n`));
+                }
               }
               controller.enqueue(encoder.encode("data: [DONE]\n\n"));
               controller.close();


### PR DESCRIPTION
## What Problem This Solves
Custom OpenAI-compatible gateways sometimes send streaming payloads that are already SSE-framed even when the HTTP content type still says JSON. Our JSON fallback was blindly wrapping that body in a new `data:` frame, producing `data: data: {...}` and causing the openai-completions parser to fail before the agent could answer.

## Summary
- preserve already-SSE-framed upstream bodies when the JSON fallback rewraps streaming responses
- keep synthesizing `data:` frames for real JSON bodies so OpenAI-compatible SDK callers still stream
- add a regression test covering the `data: data: {...}` failure shape from #96497

## Evidence
- `pnpm exec vitest run src/agents/provider-transport-fetch.test.ts src/cli/command-secret-gateway.test.ts --maxWorkers 1`
- added regression coverage that keeps `data: {"id":"068B33628193CE8053B9400D777ED001","created":1782317155,...}` intact and asserts the transformed stream does **not** contain `data: data:`

Closes #96497