### PR TITLE
fix(reply): skip gateway secrets.resolve for exec SecretRefs

### DIFF
--- a/src/cli/command-secret-gateway.test.ts
+++ b/src/cli/command-secret-gateway.test.ts
@@ -748,6 +748,43 @@ describe("resolveCommandSecretRefsViaGateway", () => {
     );
   });
 
+  it("skips gateway resolution when active target SecretRefs use exec providers", async () => {
+    const { markerPath, config: execConfig } = await createExecProviderConfig(
+      "models/providers/google/api-key",
+    );
+    const result = await resolveCommandSecretRefsViaGateway({
+      config: {
+        ...execConfig,
+        models: {
+          providers: {
+            google: {
+              enabled: true,
+              apiKey: {
+                source: "exec",
+                provider: "default",
+                id: "models/providers/google/api-key",
+              },
+            },
+          },
+        },
+      } as OpenClawConfig,
+      commandName: "reply",
+      targetIds: new Set(["models.providers.*.apiKey"]),
+    });
+
+    expect(callGateway).not.toHaveBeenCalled();
+    expect(result.resolvedConfig.models?.providers?.google?.apiKey).toBe("exec-local-key");
+    expect(result.targetStatesByPath["models.providers.google.apiKey"]).toBe("resolved_local");
+    expect(
+      result.diagnostics.some((entry) =>
+        entry.includes(
+          "reply: skipped gateway secrets.resolve because active target SecretRefs use exec providers at models.providers.google.apiKey; resolved command secrets locally.",
+        ),
+      ),
+    ).toBe(true);
+    expect(await markerExists(markerPath)).toBe(true);
+  });
+
   it("falls back to local resolution for web search SecretRefs when gateway is unavailable", async () => {
     const restoreDeps = setGoogleWebSearchTargetDeps();
     const envKey = "WEB_SEARCH_GEMINI_API_KEY_LOCAL_FALLBACK";

--- a/src/cli/command-secret-gateway.ts
+++ b/src/cli/command-secret-gateway.ts
@@ -350,6 +350,50 @@ function collectConfiguredTargetRefPaths(params: {
   return configuredTargetRefPaths;
 }
 
+function collectActiveConfiguredExecSecretRefPaths(params: {
+  config: OpenClawConfig;
+  targetIds: Set<string>;
+  allowedPaths?: ReadonlySet<string>;
+  forcedActivePaths?: ReadonlySet<string>;
+  optionalActivePaths?: ReadonlySet<string>;
+}): string[] {
+  const defaults = params.config.secrets?.defaults;
+  const context = createResolverContext({
+    sourceConfig: params.config,
+    env: process.env,
+  });
+  commandSecretGatewayDeps.collectConfigAssignments({
+    config: structuredClone(params.config),
+    context,
+  });
+  const activePaths = new Set(context.assignments.map((assignment) => assignment.path));
+  const execRefPaths = new Set<string>();
+  for (const target of commandSecretGatewayDeps.discoverConfigSecretTargetsByIds(
+    params.config,
+    params.targetIds,
+  )) {
+    if (params.allowedPaths && !params.allowedPaths.has(target.path)) {
+      continue;
+    }
+    const { ref } = resolveSecretInputRef({
+      value: target.value,
+      refValue: target.refValue,
+      defaults,
+    });
+    if (ref?.source !== "exec") {
+      continue;
+    }
+    if (
+      activePaths.has(target.path) ||
+      params.forcedActivePaths?.has(target.path) ||
+      params.optionalActivePaths?.has(target.path)
+    ) {
+      execRefPaths.add(target.path);
+    }
+  }
+  return [...execRefPaths].sort();
+}
+
 function classifyConfiguredTargetRefs(params: {
   config: OpenClawConfig;
   configuredTargetRefPaths: Set<string>;
@@ -935,6 +979,31 @@ export async function resolveCommandSecretRefsViaGateway(params: {
       hadUnresolvedTargets: false,
     };
   }
+  const activeTargetExecSecretRefPaths =
+    resolutionPolicy.allowExecSecretRefs && params.commandName === "reply"
+      ? collectActiveConfiguredExecSecretRefPaths({
+          config: params.config,
+          targetIds: params.targetIds,
+          allowedPaths: params.allowedPaths,
+          forcedActivePaths: params.forcedActivePaths,
+          optionalActivePaths: params.optionalActivePaths,
+        })
+      : [];
+  if (activeTargetExecSecretRefPaths.length > 0) {
+    return await resolveCommandSecretRefsWithoutGateway({
+      config: params.config,
+      commandName: params.commandName,
+      targetIds: params.targetIds,
+      preflightDiagnostics: preflight.diagnostics,
+      mode,
+      allowedPaths: params.allowedPaths,
+      forcedActivePaths: params.forcedActivePaths,
+      optionalActivePaths: params.optionalActivePaths,
+      resolutionPolicy,
+      reasonDiagnostic: `${params.commandName}: skipped gateway secrets.resolve because active target SecretRefs use exec providers at ${activeTargetExecSecretRefPaths.join(", ")}; resolved command secrets locally.`,
+    });
+  }
+
   const gatewayExecSecretRefCredentialPaths = resolutionPolicy.allowExecSecretRefs
     ? []
     : collectActiveGatewayExecSecretRefCredentialPaths(params.config);


### PR DESCRIPTION
## What Problem This Solves
Reply turns with exec-backed `models.providers.*.apiKey` SecretRefs currently call `secrets.resolve` against the gateway even though that RPC cannot execute those providers. The client immediately falls back to local resolution, so the turn succeeds, but every reply floods the gateway log with a misleading `UNAVAILABLE` error.

## Summary
- bypass reply-path `secrets.resolve` RPCs when active target SecretRefs already require local exec resolution
- resolve those reply credentials locally up front instead of emitting a guaranteed `UNAVAILABLE` gateway error each turn
- add a regression test covering `models.providers.*.apiKey` exec SecretRefs on the reply path

## Evidence
- `pnpm exec vitest run src/agents/provider-transport-fetch.test.ts src/cli/command-secret-gateway.test.ts --maxWorkers 1`
- added regression coverage that asserts `reply` skips the gateway RPC, resolves `models.providers.google.apiKey` locally, and records `resolved_local` without calling `callGateway`

Closes #96653