### PR TITLE
fix(signal): truncate verbose inbound preview on code-point boundaries

### DIFF
--- a/extensions/signal/src/monitor/event-handler.truncation.test.ts
+++ b/extensions/signal/src/monitor/event-handler.truncation.test.ts
@@ -1,0 +1,52 @@
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+// Signal tests cover event handler.truncation plugin behavior.
+import { describe, expect, it } from "vitest";
+
+describe("signal inbound preview truncation", () => {
+  it("drops an emoji whole when it straddles the 200-char preview boundary", () => {
+    // Emoji 😀 (U+1F600) occupies UTF-16 indices 199-200.
+    // A raw .slice(0, 200) would keep the high surrogate at index 199 and
+    // drop the low surrogate at index 200, leaving a dangling U+D83D.
+    const body = `${"a".repeat(199)}\u{1F600}${"b".repeat(50)}`;
+    expect(body.length).toBeGreaterThanOrEqual(251);
+
+    const preview = truncateUtf16Safe(body, 200).replace(/\n/g, "\\n");
+
+    // No lone surrogate halves in the output
+    expect(/[\u{D800}-\u{DFFF}]/u.test(preview)).toBe(false);
+
+    // The safe truncation drops both surrogates, yielding 199 ASCII chars
+    expect(preview.length).toBe(199);
+    expect(preview).toBe("a".repeat(199));
+  });
+
+  it("preserves emoji when it fits within the 200-char limit", () => {
+    const body = `${"a".repeat(50)}\u{1F600}${"b".repeat(50)}`;
+    const preview = truncateUtf16Safe(body, 200).replace(/\n/g, "\\n");
+
+    expect(/[\u{D800}-\u{DFFF}]/u.test(preview)).toBe(false);
+    expect(preview).toBe(body);
+  });
+
+  it("truncates long plain ASCII text without modification", () => {
+    const body = "x".repeat(500);
+    const preview = truncateUtf16Safe(body, 200).replace(/\n/g, "\\n");
+
+    expect(preview.length).toBe(200);
+    expect(preview).toBe("x".repeat(200));
+  });
+
+  it("handles boundary at position 0", () => {
+    const body = "\u{1F600}" + "a".repeat(50);
+    const preview = truncateUtf16Safe(body, 1).replace(/\n/g, "\\n");
+    // The emoji takes 2 code units, so truncating at 1 drops it
+    expect(preview.length).toBe(0);
+    expect(/[\u{D800}-\u{DFFF}]/u.test(preview)).toBe(false);
+  });
+
+  it("handles body already shorter than limit", () => {
+    const body = "hello";
+    const preview = truncateUtf16Safe(body, 200).replace(/\n/g, "\\n");
+    expect(preview).toBe("hello");
+  });
+});

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -38,7 +38,7 @@ import { resolvePinnedMainDmOwnerFromAllowlist } from "openclaw/plugin-sdk/secur
 import { readSessionUpdatedAt, resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { enqueueSystemEvent } from "openclaw/plugin-sdk/system-event-runtime";
-import { normalizeE164 } from "openclaw/plugin-sdk/text-utility-runtime";
+import { normalizeE164, truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import {
   maybeResolveSignalApprovalReaction,
   resolveSignalApprovalConversationKey,
@@ -263,7 +263,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     });
 
     if (shouldLogVerbose()) {
-      const preview = body.slice(0, 200).replace(/\\n/g, "\\\\n");
+      const preview = truncateUtf16Safe(body, 200).replace(/\\n/g, "\\\\n");
       logVerbose(`signal inbound: from=${ctxPayload.From} len=${body.length} preview="${preview}"`);
     }
 


### PR DESCRIPTION
## What Problem This Solves

Signal verbose inbound message previews truncate the message body with
`body.slice(0, 200)`. When an emoji or other astral character straddles
position 200, the raw slice keeps only the high-surrogate half, producing
a lone `\uD83D` in the debug log — malformed UTF-16.

## Why This Change Was Made

The plugin SDK provides `truncateUtf16Safe` for this exact pattern. Other
channel plugins (Discord, Feishu, Telegram, Tlon, Mattermost, Slack)
already use it for the same purpose.

## User Impact

No user-facing behavior change. The verbose debug log now emits valid
UTF-16 previews regardless of where emoji fall in the truncated message.

## Evidence

- `git diff --check origin/main...HEAD`
- `pnpm test extensions/signal` — 30 files, 375 tests passed
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

## After-fix Proof

Boundary probe on this PR branch:

```
input length: 251 code units
unit at 199: U+D83D (high surrogate of 😀)

BEFORE .slice(0,200):
  length: 200  hasLoneSurrogate: true
  tail: [61 61 d83d]   ← broken

AFTER truncateUtf16Safe(body, 200):
  length: 199  hasLoneSurrogate: false
  tail: [61 61 61]   ← clean, emoji dropped whole

✅ All paths produce well-formed UTF-16.
```

## Tests

`extensions/signal/src/monitor/event-handler.truncation.test.ts` — 5 tests
covering the straddling-emoji boundary, emoji-before-boundary, plain ASCII
truncation, position-0 edge case, and short-body pass-through.