### PR TITLE
fix(qqbot): strip media-store UUID suffix from outbound attachment filenames

### DIFF
--- a/extensions/qqbot/src/engine/messaging/outbound-file-name.test.ts
+++ b/extensions/qqbot/src/engine/messaging/outbound-file-name.test.ts
@@ -1,0 +1,31 @@
+// Qqbot tests cover outbound attachment filename resolution.
+import { describe, expect, it } from "vitest";
+import { resolveOutboundFileName } from "./outbound-file-name.js";
+
+const UUID = "e46cdea3-a285-48f6-958d-ad31352855d6";
+
+describe("resolveOutboundFileName", () => {
+  it("strips the media-store UUID suffix from staged outbound paths", async () => {
+    expect(await resolveOutboundFileName(`/data/media/report---${UUID}.png`)).toBe("report.png");
+  });
+
+  it("strips the suffix regardless of directory depth", async () => {
+    expect(await resolveOutboundFileName(`/a/b/c/quarterly summary---${UUID}.pdf`)).toBe(
+      "quarterly summary.pdf",
+    );
+  });
+
+  it("returns the plain basename for non-staged local paths", async () => {
+    expect(await resolveOutboundFileName("/tmp/photo.png")).toBe("photo.png");
+  });
+
+  it("returns the basename for remote URLs", async () => {
+    expect(await resolveOutboundFileName("https://example.com/files/contract.pdf")).toBe(
+      "contract.pdf",
+    );
+  });
+
+  it("keeps `---` names that are not the UUID staging shape", async () => {
+    expect(await resolveOutboundFileName("/tmp/draft---v2.png")).toBe("draft---v2.png");
+  });
+});

--- a/extensions/qqbot/src/engine/messaging/outbound-file-name.ts
+++ b/extensions/qqbot/src/engine/messaging/outbound-file-name.ts
@@ -1,0 +1,24 @@
+/**
+ * Recipient-facing filename resolution for outbound attachments.
+ */
+
+import { sanitizeFileName } from "../utils/string-normalize.js";
+
+/**
+ * Resolve the filename a QQ recipient should see for an outbound attachment.
+ *
+ * Outbound media is staged in the media store as `<name>---<uuid>.<ext>`
+ * (src/media/store.ts), so the bare basename would leak the internal UUID
+ * suffix to recipients. `extractOriginalFilename` strips only that staging
+ * shape and otherwise returns the plain basename (the same helper the msteams
+ * and signal channels use), so non-staged paths and URLs are unchanged.
+ *
+ * `media-runtime` is imported lazily because the qqbot bridge deliberately
+ * keeps that heavy barrel off the static startup graph (bridge/bootstrap.ts
+ * loads it on demand); a static import here would make that dynamic import
+ * ineffective.
+ */
+export async function resolveOutboundFileName(filePath: string): Promise<string> {
+  const { extractOriginalFilename } = await import("openclaw/plugin-sdk/media-runtime");
+  return sanitizeFileName(extractOriginalFilename(filePath));
+}

--- a/extensions/qqbot/src/engine/messaging/outbound-media-send.test.ts
+++ b/extensions/qqbot/src/engine/messaging/outbound-media-send.test.ts
@@ -1,0 +1,72 @@
+// Qqbot tests cover outbound media send metadata passed to the QQ sender.
+import { randomUUID } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/sandbox";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { sendDocument } from "./outbound-media-send.js";
+
+const sendMediaMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./sender.js", () => ({
+  UploadDailyLimitExceededError: class UploadDailyLimitExceededError extends Error {},
+  accountToCreds: (account: { appId: string; clientSecret: string }) => ({
+    appId: account.appId,
+    clientSecret: account.clientSecret,
+  }),
+  sendMedia: sendMediaMock,
+  sendText: vi.fn(),
+}));
+
+const cleanupPaths: string[] = [];
+
+afterEach(() => {
+  sendMediaMock.mockReset();
+  while (cleanupPaths.length > 0) {
+    const target = cleanupPaths.pop();
+    if (target) {
+      fs.rmSync(target, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
+    }
+  }
+});
+
+function makeTrackedDir(prefix: string): string {
+  const dir = path.join(resolvePreferredOpenClawTmpDir(), `${prefix}${randomUUID()}`);
+  fs.mkdirSync(dir, { recursive: true });
+  cleanupPaths.push(dir);
+  return dir;
+}
+
+describe("sendDocument", () => {
+  it("passes the recipient-facing media-store filename to QQ file sends", async () => {
+    const mediaDir = makeTrackedDir("qqbot-send-doc-");
+    const stagedPath = path.join(mediaDir, "report---e46cdea3-a285-48f6-958d-ad31352855d6.txt");
+    fs.writeFileSync(stagedPath, "hello");
+    sendMediaMock.mockResolvedValue({ id: "qq-msg-1", timestamp: "123" });
+
+    const result = await sendDocument(
+      {
+        targetType: "group",
+        targetId: "group-openid",
+        account: {
+          accountId: "default",
+          appId: "app-id",
+          clientSecret: "client-secret",
+          enabled: true,
+          config: {},
+        },
+      },
+      stagedPath,
+    );
+
+    expect(result).toEqual({ channel: "qqbot", messageId: "qq-msg-1", timestamp: "123" });
+    expect(sendMediaMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "file",
+        fileName: "report.txt",
+        source: { localPath: stagedPath },
+        localPathForMeta: stagedPath,
+      }),
+    );
+  });
+});

--- a/extensions/qqbot/src/engine/messaging/outbound-media-send.ts
+++ b/extensions/qqbot/src/engine/messaging/outbound-media-send.ts
@@ -26,8 +26,9 @@ import {
   isLocalPath as isLocalFilePath,
   normalizePath,
 } from "../utils/platform.js";
-import { normalizeLowercaseStringOrEmpty, sanitizeFileName } from "../utils/string-normalize.js";
+import { normalizeLowercaseStringOrEmpty } from "../utils/string-normalize.js";
 import { audioFileToSilkBase64, shouldTranscodeVoice, waitForFile } from "./outbound-audio-port.js";
+import { resolveOutboundFileName } from "./outbound-file-name.js";
 import {
   buildDailyLimitExceededResult,
   buildFileTooLargeResult,
@@ -545,7 +546,7 @@ export async function sendDocument(
   }
   const mediaPath = resolvedMediaPath.mediaPath;
   const isHttp = mediaPath.startsWith("http://") || mediaPath.startsWith("https://");
-  const fileName = sanitizeFileName(path.basename(mediaPath));
+  const fileName = await resolveOutboundFileName(mediaPath);
 
   if (isHttp && !shouldDirectUploadUrl(ctx.account)) {
     debugLog(`sendDocument: urlDirectUpload=false, downloading URL first...`);
@@ -600,7 +601,7 @@ async function sendDocumentFromLocal(
   ctx: MediaTargetContext,
   mediaPath: string,
 ): Promise<OutboundResult> {
-  const fileName = sanitizeFileName(path.basename(mediaPath));
+  const fileName = await resolveOutboundFileName(mediaPath);
 
   if (!(await fileExistsAsync(mediaPath))) {
     return { channel: "qqbot", error: "File not found" };

--- a/extensions/qqbot/src/engine/messaging/reply-dispatcher.ts
+++ b/extensions/qqbot/src/engine/messaging/reply-dispatcher.ts
@@ -19,8 +19,8 @@ import {
 } from "../utils/payload.js";
 import { normalizePath } from "../utils/platform.js";
 import { normalizeLowercaseStringOrEmpty } from "../utils/string-normalize.js";
-import { sanitizeFileName } from "../utils/string-normalize.js";
 import { openLocalFile } from "./media-source.js";
+import { resolveOutboundFileName } from "./outbound-file-name.js";
 import {
   sendText as senderSendText,
   sendMedia as senderSendMedia,
@@ -545,7 +545,7 @@ async function handleFilePayload(ctx: ReplyContext, payload: MediaPayload): Prom
     const filePath = resolved.path;
     const isHttpUrl = resolved.isHttpUrl;
 
-    const fileName = sanitizeFileName(path.basename(filePath));
+    const fileName = await resolveOutboundFileName(filePath);
     log?.debug?.(
       `File send: ${describeMediaTargetForLog(filePath, isHttpUrl)} (${isHttpUrl ? "URL" : "local"})`,
     );


### PR DESCRIPTION
Related: #96565

## What Problem This Solves

Fixes an issue where QQBot users sending outbound media attachments could expose OpenClaw's internal media-store UUID suffix in recipient-visible filenames when the attachment came from a staged media path.

A staged file such as `report---e46cdea3-a285-48f6-958d-ad31352855d6.txt` should be delivered as `report.txt`, not with the internal suffix included.

## Why This Change Was Made

QQBot now resolves outbound attachment display names through the shared media-store filename helper before falling back to sanitized basenames. The fix keeps the QQBot channel transport-only: it changes filename metadata passed to QQ file sends and does not add config, defaults, or product policy.

The helper import remains lazy at the send boundary so QQBot keeps the existing runtime/bootstrap import shape.

## User Impact

QQBot recipients should see the original attachment filename for OpenClaw-staged outbound media instead of a filename polluted with the internal `---<uuid>` storage suffix.

No operator action or config migration is required.

## Evidence

Before/precedent:

- `upstream/main` QQBot file sends derived recipient filenames from `path.basename(mediaPath)`, which preserves the internal media-store suffix.
- The shared helper in `src/media/store.ts` already strips `---<uuid>` suffixes and is the same filename contract used by other outbound media paths.
- Related seed fix: #96565.

Focused tests and checks after rebasing onto latest `upstream/main`:

```console
node scripts/run-vitest.mjs extensions/qqbot/src/engine/messaging/outbound-file-name.test.ts extensions/qqbot/src/engine/messaging/outbound-media-send.test.ts
Test Files  2 passed (2)
Tests       6 passed (6)
```

```console
node_modules/.bin/oxfmt --check extensions/qqbot/src/engine/messaging/outbound-file-name.ts extensions/qqbot/src/engine/messaging/outbound-file-name.test.ts extensions/qqbot/src/engine/messaging/outbound-media-send.ts extensions/qqbot/src/engine/messaging/outbound-media-send.test.ts extensions/qqbot/src/engine/messaging/reply-dispatcher.ts
All matched files use the correct format.
```

```console
pnpm openclaw config validate
Config valid
```

Closeout review:

```console
.agents/skills/autoreview/scripts/autoreview --mode local --parallel-tests "node scripts/run-vitest.mjs extensions/qqbot/src/engine/messaging/outbound-file-name.test.ts extensions/qqbot/src/engine/messaging/outbound-media-send.test.ts"
autoreview clean: no accepted/actionable findings reported
```

Live QQBot proof with existing local QQBot credentials:

```text
target: qqbot:c2c:<redacted-openid>
sourceBasename: report---e46cdea3-a285-48f6-958d-ad31352855d6.txt
expectedRecipientFilename: report.txt
result.channel: qqbot
result.messageId: <redacted, returned by QQ API>
result.timestamp: 2026-06-30T10:17:39+08:00
```

Live group note:

- Configured group entry `601638342` locally and validated the OpenClaw config.
- A direct live send attempt to `qqbot:group:601638342` reached QQ's `/v2/groups/601638342/files` endpoint but QQ returned `invalid request`.
- This leaves group visual proof as a remaining evidence gap for this PR: the numeric group ID is not sufficient for QQ's group file endpoint without the QQ `group_openid` from an inbound event. The filename derivation and QQ file-send metadata path are covered by the focused `sendDocument` test above and by the successful live C2C send through the shared QQBot file-send path.
