### PR TITLE
fix(memory-wiki): ignore code spans during wikilink lint

### DIFF
--- a/extensions/memory-wiki/src/lint.test.ts
+++ b/extensions/memory-wiki/src/lint.test.ts
@@ -67,6 +67,65 @@ describe("lintMemoryWikiVault", () => {
     expect(result.issues.map((issue) => issue.code)).not.toContain("broken-wikilink");
   });
 
+  it("ignores wikilink-looking syntax inside markdown code when linting links", async () => {
+    const { rootDir, config } = await createVault({
+      prefix: "memory-wiki-lint-code-wikilinks-",
+      config: {
+        vault: { renderMode: "obsidian" },
+      },
+    });
+    await Promise.all(
+      ["entities", "sources"].map((dir) => fs.mkdir(path.join(rootDir, dir), { recursive: true })),
+    );
+
+    await fs.writeFile(
+      path.join(rootDir, "sources", "alpha.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "source",
+          id: "source.alpha",
+          title: "Alpha Source",
+        },
+        body: "# Alpha Source\n",
+      }),
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(rootDir, "entities", "alpha.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "entity",
+          id: "entity.alpha",
+          title: "Alpha",
+          sourceIds: ["source.alpha"],
+        },
+        body: [
+          "# Alpha",
+          "",
+          "Real link: [[sources/alpha]].",
+          "",
+          "Inline code is not a link: `[[inline-fake]]`.",
+          "",
+          "```bash",
+          'if [[ "$name" == "Alice" ]]; then',
+          "  echo [[fenced-fake]]",
+          "fi",
+          "```",
+          "",
+        ].join("\n"),
+      }),
+      "utf8",
+    );
+
+    const result = await lintMemoryWikiVault(config);
+
+    expect(
+      result.issues.filter(
+        (issue) => issue.code === "broken-wikilink" && issue.path === "entities/alpha.md",
+      ),
+    ).toHaveLength(0);
+  });
+
   it("accepts unmanaged raw markdown source pages without page frontmatter", async () => {
     const { rootDir, config } = await createVault({
       prefix: "memory-wiki-lint-raw-sources-",

--- a/extensions/memory-wiki/src/markdown.test.ts
+++ b/extensions/memory-wiki/src/markdown.test.ts
@@ -74,6 +74,13 @@ describe("toWikiPageSummary", () => {
           "fi",
           "```",
           "",
+          "```md",
+          "```ts",
+          "const nestedFenceFake = '[[nested-fence-fake]]';",
+          "```",
+          "",
+          "After the code block, links count again: [[after-code]].",
+          "",
           "```scala",
           "val maybeUser: Future[Option[User]] = loadUser()",
           "```",
@@ -82,7 +89,7 @@ describe("toWikiPageSummary", () => {
       }),
     });
 
-    expect(summary?.linkTargets).toEqual(["real-target", "sources/guide.md"]);
+    expect(summary?.linkTargets).toEqual(["real-target", "after-code", "sources/guide.md"]);
   });
 
   it("marks raw and generated source body metadata", () => {

--- a/extensions/memory-wiki/src/markdown.test.ts
+++ b/extensions/memory-wiki/src/markdown.test.ts
@@ -51,6 +51,40 @@ describe("slugifyWikiSegment", () => {
 });
 
 describe("toWikiPageSummary", () => {
+  it("ignores wikilink-looking syntax inside fenced and inline code", () => {
+    const summary = toWikiPageSummary({
+      absolutePath: "/tmp/wiki/entities/code-notes.md",
+      relativePath: "entities/code-notes.md",
+      raw: renderWikiMarkdown({
+        frontmatter: {
+          pageType: "entity",
+          id: "entity.code-notes",
+          title: "Code Notes",
+        },
+        body: [
+          "# Code Notes",
+          "",
+          "Real links still count: [[real-target]] and [Guide](../sources/guide.md).",
+          "",
+          "Inline code does not: `[[inline-fake]]` or `[inline markdown](missing.md)`.",
+          "",
+          "```bash",
+          'if [[ "$name" == "Alice" ]]; then',
+          "  echo [[fenced-fake]]",
+          "fi",
+          "```",
+          "",
+          "```scala",
+          "val maybeUser: Future[Option[User]] = loadUser()",
+          "```",
+          "",
+        ].join("\n"),
+      }),
+    });
+
+    expect(summary?.linkTargets).toEqual(["real-target", "sources/guide.md"]);
+  });
+
   it("marks raw and generated source body metadata", () => {
     const rawSource = toWikiPageSummary({
       absolutePath: "/tmp/wiki/sources/raw-alpha.md",

--- a/extensions/memory-wiki/src/markdown.ts
+++ b/extensions/memory-wiki/src/markdown.ts
@@ -116,7 +116,7 @@ const RELATED_BLOCK_PATTERN = new RegExp(
   `${WIKI_RELATED_START_MARKER}[\\s\\S]*?${WIKI_RELATED_END_MARKER}`,
   "g",
 );
-const FENCED_CODE_START_PATTERN = /^(?: {0,3})(`{3,}|~{3,})/;
+const FENCED_CODE_LINE_PATTERN = /^(?: {0,3})(`{3,}|~{3,})(.*)$/;
 const MAX_WIKI_SEGMENT_BYTES = 240;
 const MAX_WIKI_FILENAME_COMPONENT_BYTES = 255;
 const FS_SAFE_PINNED_WRITE_TEMP_SUFFIX = ".00000000-0000-4000-8000-000000000000.fallback.tmp";
@@ -420,10 +420,15 @@ function maskMarkdownCode(markdown: string): string {
   let fence: { marker: "`" | "~"; length: number } | null = null;
 
   for (const line of lines) {
-    const fenceMatch = FENCED_CODE_START_PATTERN.exec(line);
+    const fenceMatch = FENCED_CODE_LINE_PATTERN.exec(line);
     const fenceDelimiter = fenceMatch?.[1];
+    const fenceRest = fenceMatch?.[2] ?? "";
     if (fence) {
-      if (fenceDelimiter?.startsWith(fence.marker) && fenceDelimiter.length >= fence.length) {
+      if (
+        fenceDelimiter?.startsWith(fence.marker) &&
+        fenceDelimiter.length >= fence.length &&
+        fenceRest.trim().length === 0
+      ) {
         fence = null;
       }
       maskedLines.push("");

--- a/extensions/memory-wiki/src/markdown.ts
+++ b/extensions/memory-wiki/src/markdown.ts
@@ -116,6 +116,7 @@ const RELATED_BLOCK_PATTERN = new RegExp(
   `${WIKI_RELATED_START_MARKER}[\\s\\S]*?${WIKI_RELATED_END_MARKER}`,
   "g",
 );
+const FENCED_CODE_START_PATTERN = /^(?: {0,3})(`{3,}|~{3,})/;
 const MAX_WIKI_SEGMENT_BYTES = 240;
 const MAX_WIKI_FILENAME_COMPONENT_BYTES = 255;
 const FS_SAFE_PINNED_WRITE_TEMP_SUFFIX = ".00000000-0000-4000-8000-000000000000.fallback.tmp";
@@ -386,8 +387,64 @@ function normalizeMarkdownLinkTarget(sourceRelativePath: string, target: string)
   return path.posix.normalize(path.posix.join(path.posix.dirname(sourceRelativePath), target));
 }
 
+function maskInlineCodeSpans(markdown: string): string {
+  let masked = "";
+  let index = 0;
+  while (index < markdown.length) {
+    if (markdown[index] !== "`") {
+      masked += markdown[index];
+      index += 1;
+      continue;
+    }
+
+    const delimiterStart = index;
+    while (index < markdown.length && markdown[index] === "`") {
+      index += 1;
+    }
+    const delimiter = markdown.slice(delimiterStart, index);
+    const closingIndex = markdown.indexOf(delimiter, index);
+    if (closingIndex === -1) {
+      masked += delimiter;
+      continue;
+    }
+
+    masked += " ";
+    index = closingIndex + delimiter.length;
+  }
+  return masked;
+}
+
+function maskMarkdownCode(markdown: string): string {
+  const lines = markdown.replace(/\r\n?/g, "\n").split("\n");
+  const maskedLines: string[] = [];
+  let fence: { marker: "`" | "~"; length: number } | null = null;
+
+  for (const line of lines) {
+    const fenceMatch = FENCED_CODE_START_PATTERN.exec(line);
+    const fenceDelimiter = fenceMatch?.[1];
+    if (fence) {
+      if (fenceDelimiter?.startsWith(fence.marker) && fenceDelimiter.length >= fence.length) {
+        fence = null;
+      }
+      maskedLines.push("");
+      continue;
+    }
+    if (fenceDelimiter) {
+      fence = {
+        marker: fenceDelimiter[0] as "`" | "~",
+        length: fenceDelimiter.length,
+      };
+      maskedLines.push("");
+      continue;
+    }
+    maskedLines.push(line);
+  }
+
+  return maskInlineCodeSpans(maskedLines.join("\n"));
+}
+
 function extractWikiLinks(markdown: string, sourceRelativePath: string): string[] {
-  const searchable = markdown.replace(RELATED_BLOCK_PATTERN, "");
+  const searchable = maskMarkdownCode(markdown).replace(RELATED_BLOCK_PATTERN, "");
   const links: string[] = [];
   for (const match of searchable.matchAll(OBSIDIAN_LINK_PATTERN)) {
     const target = match[1]?.trim();


### PR DESCRIPTION
Closes #97945

## What Problem This Solves

Fixes an issue where `openclaw wiki lint` reported false `Broken wikilink target` warnings for `[[...]]` text inside fenced code blocks and inline code spans. Real vaults with Bash, Scala, or Markdown examples could receive noisy link diagnostics for code that was never meant to be a Memory Wiki link.

## Why This Change Was Made

The Memory Wiki extractor now masks Markdown fenced code blocks and inline code before collecting Obsidian-style wikilinks and Markdown links. The change is scoped to link extraction: real links outside code are still collected, and the existing related-block masking remains in place.

The fence handling also requires a closing fence line to contain only the matching fence delimiter plus optional whitespace. That keeps common Markdown examples, such as an outer Markdown code block containing a literal fenced snippet line like ` ```ts`, from closing the mask early.

## User Impact

Memory Wiki lint output is quieter and more trustworthy. Users can keep Bash conditionals, Scala generics, and Markdown examples in wiki pages without those code samples producing broken-link warnings, while genuine broken links outside code continue to be reported.

## Evidence

- `extensions/memory-wiki/src/markdown.test.ts` covers extractor behavior for real links outside code, inline code, fenced Bash/Scala samples, and nested-fence Markdown examples.
- `extensions/memory-wiki/src/lint.test.ts` covers the user-visible lint path so code-only `[[...]]` text no longer becomes a `broken-wikilink` warning.
- Local: `node scripts/run-vitest.mjs extensions/memory-wiki/src/markdown.test.ts extensions/memory-wiki/src/lint.test.ts` -> passed.
- Local: `git diff --check` -> passed.
- Autoreview: `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` -> clean, no accepted/actionable findings.
