### PR TITLE
fix(sms): stop internal tool-trace banners from reaching SMS replies

### DIFF
--- a/extensions/sms/src/send.test.ts
+++ b/extensions/sms/src/send.test.ts
@@ -57,4 +57,15 @@ describe("sendSmsTextChunks", () => {
       toSmsPlainText("**Hi** [docs](https://example.com)\n\n```bash\napprove 123\n```\nthere"),
     ).toBe("Hi docs (https://example.com)\n\napprove 123\nthere");
   });
+
+  it("strips internal tool-trace banners before sending SMS chunks", async () => {
+    await sendSmsTextChunks({
+      account: createAccount(1500),
+      to: "+15551234567",
+      text: "**Done.**\n⚠️ 🛠️ `search repos (agent)` failed",
+    });
+
+    expect(sendSmsViaTwilio).toHaveBeenCalledOnce();
+    expect(sendSmsViaTwilio.mock.calls[0]?.[0].text).toBe("Done.");
+  });
 });

--- a/extensions/sms/src/send.ts
+++ b/extensions/sms/src/send.ts
@@ -1,10 +1,15 @@
 // Sms plugin module implements send behavior.
-import { chunkTextForOutbound, stripMarkdown } from "openclaw/plugin-sdk/text-chunking";
+import {
+  chunkTextForOutbound,
+  sanitizeAssistantVisibleText,
+  stripMarkdown,
+} from "openclaw/plugin-sdk/text-chunking";
 import { sendSmsViaTwilio } from "./twilio.js";
 import type { ResolvedSmsAccount, SmsSendResult } from "./types.js";
 
 export function toSmsPlainText(text: string): string {
-  const withoutFencedCodeMarkers = text.replace(
+  const visibleText = sanitizeAssistantVisibleText(text);
+  const withoutFencedCodeMarkers = visibleText.replace(
     /```[^\n]*\n?([\s\S]*?)```/g,
     (_match, body: string) => body.trim(),
   );


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where SMS replies could include internal assistant tool-trace failure banners when the agent output contained delivery-internal scaffolding such as `⚠️ 🛠️ ... (agent) failed`. Other text-channel outbound paths already strip this scaffolding before delivery, but SMS only flattened Markdown, so the internal banner could be sent through Twilio as ordinary user-visible text.


AI-assisted.

## Why This Change Was Made

SMS outbound plain-text normalization now applies the existing `sanitizeAssistantVisibleText` delivery sanitizer before preserving the SMS-specific Markdown, link, and fenced-code flattening behavior. This matches the established outbound delivery boundary used by sibling text channels such as Slack, Matrix, Signal, Telegram, and QQBot.

The change stays inside the SMS plugin outbound path and does not alter Twilio transport, targeting, config, or chunking semantics.

## User Impact

SMS users receive the intended assistant reply text instead of internal tool-trace diagnostics. Ordinary Markdown flattening and SMS chunking behavior are preserved.

## Evidence

Before, the real SMS formatter kept the internal tool-trace banner after flattening Markdown:

```text
$ node --import tsx --no-warnings - <<'NODE'
import { toSmsPlainText } from './extensions/sms/src/send.ts';
const input = 'Done.\n⚠️ 🛠️ `search repos (agent)` failed';
console.log(JSON.stringify(toSmsPlainText(input)));
NODE
"Done.\n⚠️ 🛠️ search repos (agent) failed"
```

After this change, the same real formatter strips the internal banner before SMS delivery:

```text
$ node --import tsx --no-warnings - <<'NODE'
import { toSmsPlainText } from './extensions/sms/src/send.ts';
const input = 'Done.\n⚠️ 🛠️ `search repos (agent)` failed';
console.log(JSON.stringify(toSmsPlainText(input)));
NODE
"Done."
```

Focused validation:

```text
$ node scripts/run-vitest.mjs extensions/sms/src/send.test.ts
[test] passed 1 Vitest shard in 4.08s
```

```text
$ git diff --check upstream/main..HEAD
```

```text
$ pnpm exec oxfmt --check extensions/sms/src/send.ts extensions/sms/src/send.test.ts
All matched files use the correct format.
```

Local review:

```text
$ .agents/skills/autoreview/scripts/autoreview --mode local --base upstream/main
autoreview clean: no accepted/actionable findings reported
```

No live Twilio round-trip was run because this bug is in the pre-send text normalization layer; the focused test verifies the exact payload passed to the Twilio send seam.
