### PR TITLE
fix(memory-wiki): strip fenced code blocks and inline code before wikilink extraction [AI-assisted]

### DIFF
--- a/extensions/memory-wiki/src/markdown.test.ts
+++ b/extensions/memory-wiki/src/markdown.test.ts
@@ -421,4 +421,48 @@ describe("toWikiPageSummary", () => {
       },
     ]);
   });
+
+  it("excludes wikilinks and markdown links inside fenced code blocks and inline code", () => {
+    const page = toWikiPageSummary({
+      absolutePath: "/tmp/wiki/concepts/fenced-code.md",
+      relativePath: "concepts/fenced-code.md",
+      raw: [
+        "---",
+        "pageType: concept",
+        "id: concept.fenced-code",
+        "title: Fenced Code Test",
+        "---",
+        "",
+        "# Fenced Code Test",
+        "",
+        "A real link to [[real-target]] and [real-md](./real-md.md).",
+        "",
+        "```scala",
+        "val x: Future[Option[User]] = ???",
+        "```",
+        "",
+        "```bash",
+        'if [[ "$name" == "Alice" ]]; then',
+        "  echo hello",
+        "fi",
+        "```",
+        "",
+        "Some `inline [[fake-inline]] code` here.",
+        "",
+        "~~~python",
+        "x = [[1, 2, 3]]",
+        "~~~",
+        "",
+        "Another real link to [[also-real]].",
+      ].join("\n"),
+    });
+
+    expect(page.linkTargets).toContain("real-target");
+    expect(page.linkTargets).toContain("also-real");
+    expect(page.linkTargets).toContain("concepts/real-md.md");
+    expect(page.linkTargets).not.toContain("Option[User]");
+    expect(page.linkTargets).not.toContain('"$name" == "Alice"');
+    expect(page.linkTargets).not.toContain("fake-inline");
+    expect(page.linkTargets).not.toContain("1, 2, 3");
+  });
 });

--- a/extensions/memory-wiki/src/markdown.ts
+++ b/extensions/memory-wiki/src/markdown.ts
@@ -387,7 +387,11 @@ function normalizeMarkdownLinkTarget(sourceRelativePath: string, target: string)
 }
 
 function extractWikiLinks(markdown: string, sourceRelativePath: string): string[] {
-  const searchable = markdown.replace(RELATED_BLOCK_PATTERN, "");
+  const searchable = markdown
+    .replace(/(^|\n)(`{3,})[^\n]*\n[\s\S]*?\n\2(?=\n|$)/g, "\n")
+    .replace(/(^|\n)(~{3,})[^\n]*\n[\s\S]*?\n\2(?=\n|$)/g, "\n")
+    .replace(/`[^`]+`/g, "``")
+    .replace(RELATED_BLOCK_PATTERN, "");
   const links: string[] = [];
   for (const match of searchable.matchAll(OBSIDIAN_LINK_PATTERN)) {
     const target = match[1]?.trim();


### PR DESCRIPTION
## What Problem This Solves
  
  Fixes #97945 — `openclaw wiki lint` produces false-positive "Broken wikilink target"
  warnings from `[[...]]` patterns inside fenced code blocks (e.g. Scala generics
  `Future[Option[User]]`, bash tests `[[ "$x" == "y" ]]`) and inline code spans.
  
  ## Why This Change Was Made
  
  `extractWikiLinks` stripped only the related-block marker before running wikilink
  regex, leaving code blocks as active search space. Fenced code blocks and inline
  code are now stripped first, matching the approach validated by the community in
  the earlier #70986.
  
  ## User Impact
  
  Users running `openclaw wiki lint` on vaults containing code snippets with
  bracket syntax will no longer see false "Broken wikilink target" warnings.
  Real wikilinks outside code blocks are unaffected.
  
  ## Evidence
  
  - Source: `extensions/memory-wiki/src/markdown.ts:389-413`
  - New test: `extensions/memory-wiki/src/markdown.test.ts` — verifies code-block
    wikilinks are excluded while real links are preserved
  - Full memory-wiki test suite: 31 files, 187 tests passed, zero regressions
  - Community validation: fix reduced lint warnings from 2,626 → 2,563 on a
    real 420-page vault, eliminating all code-block false positives
