### PR TITLE
fix(anthropic): wire buildGuardedModelFetch into the Cloudflare createClient branch

### DIFF
--- a/src/llm/providers/anthropic-cloudflare.fetch-proof.test.ts
+++ b/src/llm/providers/anthropic-cloudflare.fetch-proof.test.ts
@@ -1,15 +1,11 @@
-// Anthropic Cloudflare AI Gateway constructor guard-specific proof: SSRF-blocks a
-// private IP before the SDK's default global fetch is ever reached, then
-// streams Anthropic SSE end-to-end through buildGuardedModelFetch against
-// a real local HTTP server.
+// Anthropic Cloudflare AI Gateway constructor guard-specific proof: the SSRF
+// guard blocks a private-IP request before the SDK's default global fetch is
+// ever reached. This proves `buildGuardedModelFetch` is actively wired into
+// the Cloudflare branch, not just present in constructor options.
 //
 // Unlike anthropic.test.ts (which mocks the Anthropic SDK to verify
-// constructor options), this test does NOT mock the SDK for the SSRF
-// block or loopback proof — it stubs globalThis.fetch to COUNT calls and
-// proves the guard intercepts the request before the final fetch hop.
-// Behavior only buildGuardedModelFetch can produce.
-import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
-import type { AddressInfo } from "node:net";
+// constructor options), this test stubs `globalThis.fetch` to COUNT calls.
+// Behavior only `buildGuardedModelFetch` can produce.
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Context, Model } from "../types.js";
 
@@ -61,128 +57,5 @@ describe("Anthropic Cloudflare guard-specific SSRF blocking proof", () => {
     // Guard-specific: SSRF blocked the private-IP request before
     // globalThis.fetch was ever called.
     expect(globalFetchCalled).toBe(0);
-  });
-});
-
-describe("Anthropic Cloudflare guard real wire loopback proof (http.createServer)", () => {
-  it("streams Anthropic SSE end-to-end through buildGuardedModelFetch against a real loopback server", async () => {
-    const recorded: Array<{
-      method: string;
-      url: string;
-      bodyBytes: number;
-      authorization: string;
-      contentType: string;
-    }> = [];
-    const sseEvents: Array<Record<string, unknown>> = [
-      {
-        type: "message_start",
-        message: {
-          id: "msg_loopback",
-          type: "message",
-          role: "assistant",
-          model: "claude-sonnet-4-6",
-          content: [],
-          stop_reason: null,
-          usage: { input_tokens: 9, output_tokens: 1 },
-        },
-      },
-      {
-        type: "content_block_start",
-        index: 0,
-        content_block: { type: "text", text: "" },
-      },
-      {
-        type: "content_block_delta",
-        index: 0,
-        delta: { type: "text_delta", text: "Hello from local Cloudflare Anthropic loopback." },
-      },
-      {
-        type: "content_block_stop",
-        index: 0,
-      },
-      {
-        type: "message_delta",
-        delta: { stop_reason: "end_turn" },
-        usage: { output_tokens: 7 },
-      },
-      {
-        type: "message_stop",
-      },
-    ];
-    const sseBody = sseEvents
-      .map((e) => `event: ${String(e["type"])}\ndata: ${JSON.stringify(e)}\n\n`)
-      .join("");
-
-    const server = createServer((req: IncomingMessage, res: ServerResponse) => {
-      const chunks: Buffer[] = [];
-      req.on("data", (c: Buffer) => chunks.push(c));
-      req.on("end", () => {
-        const body = Buffer.concat(chunks);
-        recorded.push({
-          method: req.method ?? "?",
-          url: req.url ?? "?",
-          bodyBytes: body.byteLength,
-          authorization: (req.headers.authorization as string) ?? "<absent>",
-          contentType: (req.headers["content-type"] as string) ?? "<absent>",
-        });
-        res.writeHead(200, { "content-type": "text/event-stream; charset=utf-8" });
-        res.end(sseBody);
-      });
-    });
-
-    await new Promise<void>((resolve) => {
-      server.listen(0, "127.0.0.1", () => resolve());
-    });
-    const port = (server.address() as AddressInfo).port;
-
-    try {
-      const { attachModelProviderRequestTransport } =
-        await import("../../agents/provider-request-config.js");
-      const loopbackModel = attachModelProviderRequestTransport(
-        {
-          ...CLOUDFLARE_ANTHROPIC_MODEL,
-          baseUrl: `http://127.0.0.1:${port}`,
-        },
-        { allowPrivateNetwork: true },
-      );
-
-      const { streamAnthropic } = await import("./anthropic.js");
-      const stream = streamAnthropic(loopbackModel, context, {
-        apiKey: "sk-ant-loopback-proof",
-      });
-
-      let textBytes = 0;
-      for await (const event of stream) {
-        if (event.type === "text_delta") {
-          textBytes += event.delta.length;
-        }
-      }
-      const result = await stream.result();
-
-      const hit = recorded[0];
-      expect(recorded.length).toBeGreaterThanOrEqual(1);
-      expect(hit.method).toBe("POST");
-      // Anthropic SDK appends "/v1/messages" to baseUrl, so with
-      // baseUrl "http://127.0.0.1:PORT" the wire URL is "/v1/messages".
-      expect(hit.url).toBe("/v1/messages");
-      expect(hit.bodyBytes).toBeGreaterThan(0);
-      expect(hit.contentType).toBe("application/json");
-
-      expect(textBytes).toBeGreaterThan(0);
-      expect(result.stopReason).toBe("stop");
-      expect(result.errorMessage).toBeUndefined();
-
-      console.log(
-        `[layer3 loopback proof] server_hits=${recorded.length} ` +
-          `request_url=${hit.url} request_bytes=${hit.bodyBytes} ` +
-          `content_type=${hit.contentType} ` +
-          `text_bytes=${textBytes} ` +
-          `stop_reason=${result.stopReason}`,
-      );
-    } finally {
-      await new Promise<void>((resolve) => {
-        server.close(() => resolve());
-      });
-    }
   });
 });

--- a/src/llm/providers/anthropic-cloudflare.fetch-proof.test.ts
+++ b/src/llm/providers/anthropic-cloudflare.fetch-proof.test.ts
@@ -1,3 +1,15 @@
+// Anthropic Cloudflare AI Gateway constructor guard-specific proof: SSRF-blocks a
+// private IP before the SDK's default global fetch is ever reached, then
+// streams Anthropic SSE end-to-end through buildGuardedModelFetch against
+// a real local HTTP server.
+//
+// Unlike anthropic.test.ts (which mocks the Anthropic SDK to verify
+// constructor options), this test does NOT mock the SDK for the SSRF
+// block or loopback proof — it stubs globalThis.fetch to COUNT calls and
+// proves the guard intercepts the request before the final fetch hop.
+// Behavior only buildGuardedModelFetch can produce.
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Context, Model } from "../types.js";
 
@@ -14,32 +26,163 @@ const CLOUDFLARE_ANTHROPIC_MODEL = {
   maxTokens: 4096,
 } satisfies Model<"anthropic-messages">;
 
-const CONTEXT = {
+const context = {
   messages: [{ role: "user", content: "hi", timestamp: 1 }],
 } satisfies Context;
 
-describe("Anthropic Cloudflare guarded fetch", () => {
+describe("Anthropic Cloudflare guard-specific SSRF blocking proof", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
   });
 
-  it("blocks private-network requests before the Anthropic SDK reaches global fetch", async () => {
-    const globalFetch = vi.fn(async () => new Response(null, { status: 500 }));
-    vi.stubGlobal("fetch", globalFetch);
+  it("blocks a private-IP request before globalThis.fetch is called (guard-specific behavior)", async () => {
+    let globalFetchCalled = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        globalFetchCalled++;
+        return new Response(null, { status: 500 });
+      }),
+    );
+
+    // Override the model baseUrl to a private link-local IP that the guard blocks.
+    const blockedModel = {
+      ...CLOUDFLARE_ANTHROPIC_MODEL,
+      baseUrl: "http://169.254.169.254/v1",
+    } satisfies Model<"anthropic-messages">;
 
     const { streamAnthropic } = await import("./anthropic.js");
-    const stream = streamAnthropic(
-      {
-        ...CLOUDFLARE_ANTHROPIC_MODEL,
-        baseUrl: "http://169.254.169.254/v1",
-      },
-      CONTEXT,
-      { apiKey: "sk-ant-test" },
-    );
+    const stream = streamAnthropic(blockedModel, context, { apiKey: "sk-ant-test" });
     const result = await stream.result();
 
     expect(result.stopReason).toBe("error");
     expect(result.errorMessage).toBeTruthy();
-    expect(globalFetch).not.toHaveBeenCalled();
+
+    // Guard-specific: SSRF blocked the private-IP request before
+    // globalThis.fetch was ever called.
+    expect(globalFetchCalled).toBe(0);
+  });
+});
+
+describe("Anthropic Cloudflare guard real wire loopback proof (http.createServer)", () => {
+  it("streams Anthropic SSE end-to-end through buildGuardedModelFetch against a real loopback server", async () => {
+    const recorded: Array<{
+      method: string;
+      url: string;
+      bodyBytes: number;
+      authorization: string;
+      contentType: string;
+    }> = [];
+    const sseEvents: Array<Record<string, unknown>> = [
+      {
+        type: "message_start",
+        message: {
+          id: "msg_loopback",
+          type: "message",
+          role: "assistant",
+          model: "claude-sonnet-4-6",
+          content: [],
+          stop_reason: null,
+          usage: { input_tokens: 9, output_tokens: 1 },
+        },
+      },
+      {
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "text", text: "" },
+      },
+      {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "text_delta", text: "Hello from local Cloudflare Anthropic loopback." },
+      },
+      {
+        type: "content_block_stop",
+        index: 0,
+      },
+      {
+        type: "message_delta",
+        delta: { stop_reason: "end_turn" },
+        usage: { output_tokens: 7 },
+      },
+      {
+        type: "message_stop",
+      },
+    ];
+    const sseBody = sseEvents
+      .map((e) => `event: ${String(e["type"])}\ndata: ${JSON.stringify(e)}\n\n`)
+      .join("");
+
+    const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (c: Buffer) => chunks.push(c));
+      req.on("end", () => {
+        const body = Buffer.concat(chunks);
+        recorded.push({
+          method: req.method ?? "?",
+          url: req.url ?? "?",
+          bodyBytes: body.byteLength,
+          authorization: (req.headers.authorization as string) ?? "<absent>",
+          contentType: (req.headers["content-type"] as string) ?? "<absent>",
+        });
+        res.writeHead(200, { "content-type": "text/event-stream; charset=utf-8" });
+        res.end(sseBody);
+      });
+    });
+
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+    const port = (server.address() as AddressInfo).port;
+
+    try {
+      const { attachModelProviderRequestTransport } =
+        await import("../../agents/provider-request-config.js");
+      const loopbackModel = attachModelProviderRequestTransport(
+        {
+          ...CLOUDFLARE_ANTHROPIC_MODEL,
+          baseUrl: `http://127.0.0.1:${port}`,
+        },
+        { allowPrivateNetwork: true },
+      );
+
+      const { streamAnthropic } = await import("./anthropic.js");
+      const stream = streamAnthropic(loopbackModel, context, {
+        apiKey: "sk-ant-loopback-proof",
+      });
+
+      let textBytes = 0;
+      for await (const event of stream) {
+        if (event.type === "text_delta") {
+          textBytes += event.delta.length;
+        }
+      }
+      const result = await stream.result();
+
+      const hit = recorded[0];
+      expect(recorded.length).toBeGreaterThanOrEqual(1);
+      expect(hit.method).toBe("POST");
+      // Anthropic SDK appends "/v1/messages" to baseUrl, so with
+      // baseUrl "http://127.0.0.1:PORT" the wire URL is "/v1/messages".
+      expect(hit.url).toBe("/v1/messages");
+      expect(hit.bodyBytes).toBeGreaterThan(0);
+      expect(hit.contentType).toBe("application/json");
+
+      expect(textBytes).toBeGreaterThan(0);
+      expect(result.stopReason).toBe("stop");
+      expect(result.errorMessage).toBeUndefined();
+
+      console.log(
+        `[layer3 loopback proof] server_hits=${recorded.length} ` +
+          `request_url=${hit.url} request_bytes=${hit.bodyBytes} ` +
+          `content_type=${hit.contentType} ` +
+          `text_bytes=${textBytes} ` +
+          `stop_reason=${result.stopReason}`,
+      );
+    } finally {
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+    }
   });
 });

--- a/src/llm/providers/anthropic-cloudflare.fetch-proof.test.ts
+++ b/src/llm/providers/anthropic-cloudflare.fetch-proof.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Context, Model } from "../types.js";
+
+const CLOUDFLARE_ANTHROPIC_MODEL = {
+  id: "claude-sonnet-4-6",
+  name: "Claude Sonnet 4.6",
+  api: "anthropic-messages",
+  provider: "cloudflare-ai-gateway",
+  baseUrl: "https://gateway.ai.cloudflare.com/v1/account/gateway/anthropic/v1/messages",
+  reasoning: true,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 200_000,
+  maxTokens: 4096,
+} satisfies Model<"anthropic-messages">;
+
+const CONTEXT = {
+  messages: [{ role: "user", content: "hi", timestamp: 1 }],
+} satisfies Context;
+
+describe("Anthropic Cloudflare guarded fetch", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("blocks private-network requests before the Anthropic SDK reaches global fetch", async () => {
+    const globalFetch = vi.fn(async () => new Response(null, { status: 500 }));
+    vi.stubGlobal("fetch", globalFetch);
+
+    const { streamAnthropic } = await import("./anthropic.js");
+    const stream = streamAnthropic(
+      {
+        ...CLOUDFLARE_ANTHROPIC_MODEL,
+        baseUrl: "http://169.254.169.254/v1",
+      },
+      CONTEXT,
+      { apiKey: "sk-ant-test" },
+    );
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    expect(result.errorMessage).toBeTruthy();
+    expect(globalFetch).not.toHaveBeenCalled();
+  });
+});

--- a/src/llm/providers/anthropic.test.ts
+++ b/src/llm/providers/anthropic.test.ts
@@ -75,12 +75,14 @@ describe("Anthropic provider", () => {
       apiKey?: string | null;
       authToken?: string | null;
       defaultHeaders?: Record<string, string | null>;
+      fetch?: unknown;
     };
 
     expect(config.apiKey).toBe("sk-ant-provider");
     expect(config.authToken).toBeNull();
     expect(config.defaultHeaders?.["x-api-key"]).toBeUndefined();
     expect(config.defaultHeaders?.["cf-aig-authorization"]).toBe("Bearer gateway-token");
+    expect(typeof config.fetch).toBe("function");
   });
 
   it("uses bearer auth for Microsoft Foundry Anthropic requests", async () => {

--- a/src/llm/providers/anthropic.ts
+++ b/src/llm/providers/anthropic.ts
@@ -15,6 +15,7 @@ import {
   type AnthropicProjectedToolChoice,
   type AnthropicToolProjection,
 } from "../../agents/anthropic-tool-projection.js";
+import { buildGuardedModelFetch } from "../../agents/provider-transport-fetch.js";
 import {
   splitSystemPromptCacheBoundary,
   stripSystemPromptCacheBoundary,
@@ -947,6 +948,7 @@ function createClient(
         model.headers,
         optionsHeaders,
       ),
+      fetch: buildGuardedModelFetch(model),
     });
 
     return { client, isOAuthToken: false };


### PR DESCRIPTION
## What Problem This Solves

The Anthropic provider (`anthropic.ts`) creates five `Anthropic` SDK clients — one for Cloudflare AI Gateway, one for GitHub Copilot, one for Microsoft Foundry bearer auth, one for OAuth, and one for the API-key fallback. None of them passed a custom `fetch` option. Streaming Anthropic calls from these providers bypassed the guarded provider transport — SSRF protection, request timeout, retry-hint injection, and response lifecycle management that every other Anthropic SDK path already has.

This PR injects `fetch: buildGuardedModelFetch(model)` into the **Cloudflare AI Gateway** SDK constructor specifically, bringing that branch to guarded-fetch parity with:
- `anthropic-transport-stream.ts:788` (managed Anthropic transport)
- `openai-responses.ts` (#97848)
- `openai-completions.ts` (#97228)
- `azure-openai-responses.ts`
- Sibling PRs (same 5-constructor split):
  - GitHub Copilot (#98014)
  - Microsoft Foundry bearer (#98015)
  - OAuth (#98016)
  - API-key (#98017)

This is **one of five split PRs** that supersede #97868.

## Why This Change Was Made

`buildGuardedModelFetch` is the canonical fetch wrapper applied to every Anthropic SDK constructor in the codebase. The Anthropic SDK accepts `fetch?: Fetch` per its constructor options. The Cloudflare branch was missing this wrapper.

The change is 2 lines in production code (`+1 import, +1 fetch:` option). The proof is focused on showing the guard is actually in scope and active:
- A mocked constructor assertion in `anthropic.test.ts`.
- An SSRF-block test that stubs `globalThis.fetch` and proves the guard intercepts a private IP before the SDK reaches the default fetch.

## Evidence

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.unit.config.ts \
  src/llm/providers/anthropic.test.ts \
  src/llm/providers/anthropic-cloudflare.fetch-proof.test.ts \
  --run
```

Results:

```
 Test Files  2 passed (2)
      Tests  37 passed (37)
   Duration  4.87s
```

### Layer 1: Constructor wiring

`anthropic.test.ts` asserts the Cloudflare branch config now includes a `fetch:` function.

### Layer 2: SSRF-block guard-specific proof

`anthropic-cloudflare.fetch-proof.test.ts` stubs `globalThis.fetch` as a call counter, configures `baseUrl: http://169.254.169.254/v1`, and asserts `globalFetchCalled === 0`. This proves `buildGuardedModelFetch` intercepts the blocked target before the SDK falls back to `globalThis.fetch`.

### Maintainer-hosted smoke

@altaywtf ran a hosted live smoke against the fixed `cloudflare-ai-gateway` Anthropic constructor branch using a real Anthropic API request; that passed.

## Real behavior proof

- **Behavior addressed**: `createClient` in `src/llm/providers/anthropic.ts` (Cloudflare branch) now passes `fetch: buildGuardedModelFetch(model)` to `new Anthropic({...})`, so Anthropic calls routed through the Cloudflare AI Gateway inherit OpenClaw guarded-fetch policy.
- **Real environment tested**: Linux x86_64, Node v22.22.0, local source checkout.
- **Exact steps**: see Evidence above.
- **Evidence after fix**: 37/37 tests pass. Layer 1 proves the wrapper is wired; Layer 2 proves the guard actively blocks private-IP targets.
- **Observed result after fix**: the Cloudflare Anthropic constructor now carries a custom `fetch`, and the guard rejects `169.254.169.254` before any network call.
- **What was not tested**: no live Anthropic API call from the author side (no API key); no true Cloudflare AI Gateway end-to-end routed request (no `CLOUDFLARE_AI_GATEWAY_*` account or gateway secrets). Maintainer-hosted smoke validated the constructor branch against a real Anthropic endpoint.

## Diff scope

```
3 files changed, 63 insertions(+), 14 deletions(-)
  src/llm/providers/anthropic.ts                              |  2 ++
  src/llm/providers/anthropic.test.ts                         |  2 +-
  src/llm/providers/anthropic-cloudflare.fetch-proof.test.ts  | 59 ++++++++++
```

- Source: 2 insertions in `anthropic.ts`
- Tests: constructor wiring assertion + SSRF-block test

## Security & Privacy

- Hardening change: previously-unwrapped Cloudflare Anthropic SDK fetch calls now inherit OpenClaw SSRF guard, timeout, retry hints, and response lifecycle.
- No new network calls, no persisted data, no secret logging.
- Standard Anthropic SDK `fetch` option; no monkey-patching.

## Compatibility

- Existing Cloudflare AI Gateway Anthropic requests now use guarded fetch instead of SDK-default fetch. Default endpoints are transparent.
- Custom base URLs (enterprise proxy, self-hosted gateway) now inherit the same SSRF policy as sibling guarded Anthropic paths.
- Risk acknowledged: custom endpoints that worked with unguarded SDK-default fetch may now fail closed under SSRF policy. This is the intended hardening behavior and matches all other Anthropic SDK paths.
- No config/env changes, no migration.

## Related

- Supersedes #97868
- Sibling: openai-responses (#97848), openai-completions (#97228)
- Sibling constructors: GitHub Copilot (#98014), Microsoft Foundry bearer (#98015), OAuth (#98016), API-key (#98017)

## AI disclosure

AI-assisted (Claude); reviewed by human author before submission.
