### PR TITLE
feat: add manifest JSON-RPC plugin bindings

### DIFF
--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -5574,6 +5574,10 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Minimal example
   - H2: Rich example
   - H2: Top-level field reference
+  - H2: jsonRpc reference
+  - H3: Generic API registrations
+  - H3: Child-to-host calls
+  - H3: Callbacks, cancellation, and streams
   - H2: Generation provider metadata reference
   - H2: Tool metadata reference
   - H2: providerAuthChoices reference

--- a/docs/plugins/building-plugins.md
+++ b/docs/plugins/building-plugins.md
@@ -26,7 +26,10 @@ Bare package specs still install from npm during the launch cutover. Use the
 ## Requirements
 
 - Use Node 22.19 or newer and a package manager such as `npm` or `pnpm`.
-- Be familiar with TypeScript ESM modules.
+- Be familiar with TypeScript ESM modules for native JavaScript plugins.
+- For Rust, Python, Go, or other non-JavaScript runtimes, declare
+  [`jsonRpc`](/plugins/manifest#jsonrpc-reference) in `openclaw.plugin.json`
+  instead of writing a TypeScript entry file.
 - For in-repo bundled plugin work, clone the repository and run `pnpm install`.
   Source-checkout plugin development is pnpm-only because OpenClaw loads bundled
   plugins from `extensions/*` workspace packages.

--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -219,10 +219,14 @@ Gateway method dispatch.
     "tools": ["rust_echo"]
   },
   "jsonRpc": {
+    "protocolVersion": 1,
     "process": {
       "command": "target/release/rust-tools",
       "args": ["--stdio"],
       "inheritEnv": false
+    },
+    "permissions": {
+      "host": ["runtime.state.openKeyedStore", "runtime.llm.complete"]
     },
     "registrations": [
       {
@@ -243,9 +247,11 @@ Gateway method dispatch.
 | `args`                    | No       | `string[]`              | Arguments passed to the executable.                                                                         |
 | `cwd`                     | No       | `string`                | Working directory. Relative paths resolve from the plugin root.                                             |
 | `env`                     | No       | `Record<string,string>` | Environment variables passed to the child process.                                                          |
-| `inheritEnv`              | No       | `boolean`               | Whether to inherit the OpenClaw process environment. Defaults to `true`.                                    |
+| `inheritEnv`              | No       | `boolean`               | Whether to inherit the OpenClaw process environment. Defaults to `false`.                                   |
 | `timeoutMs`               | No       | `number`                | Default request timeout.                                                                                    |
 | `initializationTimeoutMs` | No       | `number`                | Timeout for `openclaw.initialize`.                                                                          |
+| `maxFrameBytes`           | No       | `number`                | Maximum newline-delimited JSON frame size. Defaults to 8 MiB.                                               |
+| `maxPendingRequests`      | No       | `number`                | Maximum concurrent outbound requests. Defaults to 256.                                                      |
 | `logStderr`               | No       | `boolean`               | Forward child stderr to the plugin logger. Defaults to `true`.                                              |
 
 `jsonRpc.registrations` supports these `type` values:
@@ -256,13 +262,118 @@ Gateway method dispatch.
 | `hook`          | `hook`                | `description`, `options.priority`, `options.timeoutMs`, `method`, `timeoutMs`                                     |
 | `httpRoute`     | `path`, `auth`        | `match`, `gatewayRuntimeScopeSurface`, `nodeCapability`, `replaceExisting`, `method`, `timeoutMs`, `maxBodyBytes` |
 | `gatewayMethod` | `method`              | `scope`, `rpcMethod`, `timeoutMs`                                                                                 |
+| `api`           | `method`, `args`      | None. Calls an OpenClaw registration method with JSON descriptors.                                                |
 
 OpenClaw sends one JSON-RPC request per registered surface. The default method
 names are `openclaw.tool.execute`, `openclaw.hook.handle`,
 `openclaw.http.handle`, and `openclaw.gateway.handle`; set `method` or
 `rpcMethod` on a registration to override them. After startup, OpenClaw first
 sends `openclaw.initialize` with plugin identity metadata and the validated
-plugin config.
+plugin config. The initialization payload also includes protocol version 1,
+enabled protocol features, and the exact host capabilities declared under
+`jsonRpc.permissions.host`.
+
+### Generic API registrations
+
+Use an `api` registration for callback-shaped plugin surfaces that do not have
+a shorthand descriptor. Replace function values with
+`{ "$rpc": "plugin.method" }`; OpenClaw materializes those references as
+callbacks that dispatch to the child process.
+
+```json
+{
+  "type": "api",
+  "method": "registerCommand",
+  "args": [
+    {
+      "name": "native-status",
+      "description": "Read status from the native plugin.",
+      "handler": { "$rpc": "plugin.command.status", "timeoutMs": 10000 }
+    }
+  ]
+}
+```
+
+Generic descriptors support asynchronous callbacks and static JSON metadata.
+OpenClaw accepts these registration methods and callback paths in protocol
+version 1:
+
+- `registerAgentEventSubscription`: `args[0].handle`
+- `registerAgentToolResultMiddleware`: `args[0]`
+- `registerCommand`: `args[0].handler`
+- `registerCompactionProvider`: `args[0].summarize`
+- `registerGatewayDiscoveryService`: `args[0].advertise`
+- `registerHostedMediaResolver`: `args[0]`
+- `registerInteractiveHandler`: `args[0].handler`
+- `registerNodeHostCommand` and `registerNodeInvokePolicy`: `args[0].handle`
+- `registerRuntimeLifecycle`: `args[0].cleanup`
+- `registerService`: `args[0].start` and `args[0].stop`
+- `registerSessionAction`: `args[0].handler`
+- `registerTool`: `args[0].execute`
+- `onConversationBindingResolved`: `args[0]`
+
+Static-only descriptors are also accepted for `registerControlUiDescriptor`,
+`registerReload`, `registerSessionExtension`, `registerSessionSchedulerJob`, and
+`registerToolMetadata`. OpenClaw rejects `$rpc` markers anywhere except the
+callback paths above. Contracts that require a synchronous return value,
+receive sensitive host state, or receive broad callable runtime objects are not
+available through protocol version 1. This includes speech-provider
+configuration probes, migration providers, security audit collectors, model
+catalog providers, and the `tool_result_persist` and `before_message_write`
+hooks.
+
+### Child-to-host calls
+
+The child process can call a permitted OpenClaw host capability with a JSON-RPC
+request:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "host-1",
+  "method": "openclaw.host.call",
+  "params": {
+    "method": "runtime.llm.complete",
+    "args": [{ "messages": [{ "role": "user", "content": "Summarize this." }] }]
+  }
+}
+```
+
+The requested method must appear exactly in `jsonRpc.permissions.host`.
+Supported roots are `runtime.*`, `session.*`, `agent.*`, and `runContext.*`.
+OpenClaw rejects undeclared or non-callable paths. Permissions do not sandbox
+the executable; installed plugins still run with the operating-system access of
+the OpenClaw process.
+
+### Callbacks, cancellation, and streams
+
+OpenClaw serializes callable host values as `{ "$callback": "id" }`. Invoke one
+with `openclaw.callback.invoke`, then release a retained callback with the
+`$/callback/release` notification. Remote callback arguments and results use
+the same value codec.
+
+When either side aborts a request, it sends `$/cancelRequest` with the original
+request id. Long-running handlers should stop work when their local JSON-RPC
+implementation receives that notification.
+
+Async iterables and Node readable streams cross the protocol as
+`{ "$stream": "id" }`. The consumer must send `$/stream/ready` with that id
+before the producer sends any values. The producer then sends `$/stream/chunk`,
+followed by `$/stream/end` or `$/stream/error`. This handshake prevents stream
+notifications from racing ahead of the JSON-RPC response that introduced the
+stream. OpenClaw bounds active streams to 256 and remote buffering to 256 unread
+values; consumers must drain streams instead of treating them as unbounded
+queues. A consumer that stops early sends `$/stream/cancel`; producers must stop
+work and release the matching iterator.
+
+OpenClaw also bounds child-to-host requests with `maxPendingRequests` and keeps
+at most 1,024 unreleased host callback handles. Children should still send
+`$/callback/release` as soon as a retained callback is no longer needed.
+
+Every message is one UTF-8 JSON-RPC 2.0 object followed by a newline. Request
+ids may be strings or numbers. Binary values should be base64-encoded or passed
+through a capability-specific file/media handle; raw binary frames are not part
+of protocol version 1.
 
 ## Generation provider metadata reference
 

--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -47,11 +47,13 @@ plugin runtime.
 - activation hints for control-plane surfaces
 - shorthand model-family ownership
 - static capability-ownership snapshots (`contracts`)
+- declarative JSON-RPC child-process tools, hooks, HTTP routes, and Gateway methods
 - QA runner metadata the shared `openclaw qa` host can inspect
 - channel-specific config metadata merged into catalog and validation surfaces
 
-**Do not use it for:** registering runtime behavior, declaring code entrypoints,
-or npm install metadata. Those belong in your plugin code and `package.json`.
+**Do not use it for:** arbitrary runtime behavior, JavaScript code entrypoints,
+or npm install metadata. Native JavaScript registration belongs in plugin code
+and `package.json`; JSON-RPC child-process registration uses `jsonRpc`.
 
 ## Minimal example
 
@@ -170,6 +172,7 @@ or npm install metadata. Those belong in your plugin code and `package.json`.
 | `providerEndpoints`                  | No       | `object[]`                       | Manifest-owned endpoint host/baseUrl metadata for provider routes that core must classify before provider runtime loads.                                                                                                                        |
 | `providerRequest`                    | No       | `object`                         | Cheap provider-family and request-compatibility metadata used by generic request policy before provider runtime loads.                                                                                                                          |
 | `secretProviderIntegrations`         | No       | `Record<string, object>`         | Declarative SecretRef exec provider presets that setup or install surfaces can offer without hardcoding provider-specific integrations in core.                                                                                                 |
+| `jsonRpc`                            | No       | `object`                         | Declarative stdio JSON-RPC child-process runtime. Use this when the plugin implementation lives in Rust, Python, Go, or another non-JavaScript runtime.                                                                                         |
 | `cliBackends`                        | No       | `string[]`                       | CLI inference backend ids owned by this plugin. Used for startup auto-activation from explicit config refs.                                                                                                                                     |
 | `syntheticAuthRefs`                  | No       | `string[]`                       | Provider or CLI backend refs whose plugin-owned synthetic auth hook should be probed during cold model discovery before runtime loads.                                                                                                          |
 | `nonSecretAuthMarkers`               | No       | `string[]`                       | Bundled-plugin-owned placeholder API key values that represent non-secret local, OAuth, or ambient credential state.                                                                                                                            |
@@ -194,6 +197,72 @@ or npm install metadata. Those belong in your plugin code and `package.json`.
 | `icon`                               | No       | `string`                         | HTTPS image URL for marketplace/catalog cards. ClawHub accepts any valid `https://` URL and falls back to the default plugin icon when this is omitted or invalid.                                                                              |
 | `version`                            | No       | `string`                         | Informational plugin version.                                                                                                                                                                                                                   |
 | `uiHints`                            | No       | `Record<string, object>`         | UI labels, placeholders, and sensitivity hints for config fields.                                                                                                                                                                               |
+
+## jsonRpc reference
+
+Use `jsonRpc` when the plugin implementation runs in Rust, Python, Go, or any
+other runtime that can speak newline-delimited JSON-RPC over stdio. The plugin
+does not need a TypeScript entry file. OpenClaw discovers the plugin from
+`openclaw.plugin.json` and registers each listed surface when the plugin loads.
+The declared child process starts lazily on the first tool, hook, HTTP route, or
+Gateway method dispatch.
+
+```json
+{
+  "id": "rust-tools",
+  "name": "Rust Tools",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false
+  },
+  "contracts": {
+    "tools": ["rust_echo"]
+  },
+  "jsonRpc": {
+    "process": {
+      "command": "target/release/rust-tools",
+      "args": ["--stdio"],
+      "inheritEnv": false
+    },
+    "registrations": [
+      {
+        "type": "tool",
+        "name": "rust_echo",
+        "description": "Echo text through the Rust plugin process."
+      }
+    ]
+  }
+}
+```
+
+`jsonRpc.process` fields:
+
+| Field                     | Required | Type                    | What it means                                                                                               |
+| ------------------------- | -------- | ----------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `command`                 | Yes      | `string`                | Executable to start. Commands containing `/` or `\` resolve from the plugin root; bare commands use `PATH`. |
+| `args`                    | No       | `string[]`              | Arguments passed to the executable.                                                                         |
+| `cwd`                     | No       | `string`                | Working directory. Relative paths resolve from the plugin root.                                             |
+| `env`                     | No       | `Record<string,string>` | Environment variables passed to the child process.                                                          |
+| `inheritEnv`              | No       | `boolean`               | Whether to inherit the OpenClaw process environment. Defaults to `true`.                                    |
+| `timeoutMs`               | No       | `number`                | Default request timeout.                                                                                    |
+| `initializationTimeoutMs` | No       | `number`                | Timeout for `openclaw.initialize`.                                                                          |
+| `logStderr`               | No       | `boolean`               | Forward child stderr to the plugin logger. Defaults to `true`.                                              |
+
+`jsonRpc.registrations` supports these `type` values:
+
+| Type            | Required fields       | Optional fields                                                                                                   |
+| --------------- | --------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `tool`          | `name`, `description` | `parameters`, `displaySummary`, `method`, `timeoutMs`                                                             |
+| `hook`          | `hook`                | `description`, `options.priority`, `options.timeoutMs`, `method`, `timeoutMs`                                     |
+| `httpRoute`     | `path`, `auth`        | `match`, `gatewayRuntimeScopeSurface`, `nodeCapability`, `replaceExisting`, `method`, `timeoutMs`, `maxBodyBytes` |
+| `gatewayMethod` | `method`              | `scope`, `rpcMethod`, `timeoutMs`                                                                                 |
+
+OpenClaw sends one JSON-RPC request per registered surface. The default method
+names are `openclaw.tool.execute`, `openclaw.hook.handle`,
+`openclaw.http.handle`, and `openclaw.gateway.handle`; set `method` or
+`rpcMethod` on a registration to override them. After startup, OpenClaw first
+sends `openclaw.initialize` with plugin identity metadata and the validated
+plugin config.
 
 ## Generation provider metadata reference
 

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -23,6 +23,7 @@ import { readLegacyNpmPluginDeclaration } from "./legacy-npm-declaration.js";
 import type { PluginBundleFormat, PluginDiagnostic, PluginFormat } from "./manifest-types.js";
 import {
   DEFAULT_PLUGIN_ENTRY_CANDIDATES,
+  PLUGIN_MANIFEST_FILENAME,
   getPackageManifestMetadata,
   loadPluginManifest,
   type PluginManifest,
@@ -1094,6 +1095,27 @@ function discoverInDirectory(params: {
       continue;
     }
 
+    if (candidateManifest?.manifest.jsonRpc) {
+      addCandidate({
+        candidates: params.candidates,
+        diagnostics: params.diagnostics,
+        seen: params.seen,
+        idHint: manifestId ?? entry.name,
+        source: candidateManifest.manifestPath,
+        ...(setupSource ? { setupSource } : {}),
+        rootDir: fullPath,
+        origin: params.origin,
+        ownershipUid: params.ownershipUid,
+        workspaceDir: params.workspaceDir,
+        manifest,
+        packageDir: fullPath,
+        requiredPluginIds: candidateManifest.manifest.requiresPlugins,
+        requiredPluginSource: candidateManifest.manifestPath,
+        realpathCache: params.realpathCache,
+      });
+      continue;
+    }
+
     const bundleDiscovery = discoverBundleInRoot({
       rootDir: fullPath,
       origin: params.origin,
@@ -1235,6 +1257,34 @@ function discoverFromPath(params: {
 
   const stat = fs.statSync(resolved);
   if (stat.isFile()) {
+    if (path.basename(resolved) === PLUGIN_MANIFEST_FILENAME) {
+      const rootDir = path.dirname(resolved);
+      const rootRealPath = safeRealpathSync(rootDir, params.realpathCache) ?? undefined;
+      const rejectHardlinks = shouldRejectHardlinkedPluginFiles({
+        origin: params.origin,
+        rootDir,
+        env: params.env,
+        realpathCache: params.realpathCache,
+      });
+      const candidateManifest = resolveCandidateManifest(rootDir, rejectHardlinks, rootRealPath);
+      if (candidateManifest?.manifest.jsonRpc) {
+        addCandidate({
+          candidates: params.candidates,
+          diagnostics: params.diagnostics,
+          seen: params.seen,
+          idHint: candidateManifest.manifest.id,
+          source: candidateManifest.manifestPath,
+          rootDir,
+          origin: params.origin,
+          ownershipUid: params.ownershipUid,
+          workspaceDir: params.workspaceDir,
+          requiredPluginIds: candidateManifest.manifest.requiresPlugins,
+          requiredPluginSource: candidateManifest.manifestPath,
+          realpathCache: params.realpathCache,
+        });
+        return;
+      }
+    }
     if (!isExtensionFile(resolved)) {
       params.diagnostics.push({
         level: "error",
@@ -1353,6 +1403,27 @@ function discoverFromPath(params: {
           realpathCache: params.realpathCache,
         });
       }
+      return;
+    }
+
+    if (candidateManifest?.manifest.jsonRpc) {
+      addCandidate({
+        candidates: params.candidates,
+        diagnostics: params.diagnostics,
+        seen: params.seen,
+        idHint: manifestId ?? path.basename(resolved),
+        source: candidateManifest.manifestPath,
+        ...(setupSource ? { setupSource } : {}),
+        rootDir: resolved,
+        origin: params.origin,
+        ownershipUid: params.ownershipUid,
+        workspaceDir: params.workspaceDir,
+        manifest,
+        packageDir: resolved,
+        requiredPluginIds: candidateManifest.manifest.requiresPlugins,
+        requiredPluginSource: candidateManifest.manifestPath,
+        realpathCache: params.realpathCache,
+      });
       return;
     }
 

--- a/src/plugins/json-rpc-manifest-runtime.process.test.ts
+++ b/src/plugins/json-rpc-manifest-runtime.process.test.ts
@@ -60,6 +60,7 @@ describe("createJsonRpcManifestPluginDefinition process management", () => {
       },
     });
     const entry = createJsonRpcManifestPluginDefinition({
+      protocolVersion: 1,
       id: "json-rpc-process-test",
       name: "JSON RPC Process Test",
       description: "Test spawn resolution",
@@ -110,6 +111,7 @@ describe("createJsonRpcManifestPluginDefinition process management", () => {
       },
     });
     const entry = createJsonRpcManifestPluginDefinition({
+      protocolVersion: 1,
       id: "json-rpc-process-abort-test",
       name: "JSON RPC Process Abort Test",
       description: "Test pre-aborted process requests",
@@ -134,6 +136,175 @@ describe("createJsonRpcManifestPluginDefinition process management", () => {
 
     expect(mocks.resolveWindowsSpawnProgram).not.toHaveBeenCalled();
     expect(mocks.spawn).not.toHaveBeenCalled();
+  });
+
+  it("materializes callbacks only at audited generic registration paths", () => {
+    let service: Parameters<OpenClawPluginApi["registerService"]>[0] | undefined;
+    let subscription:
+      | Parameters<OpenClawPluginApi["registerAgentEventSubscription"]>[0]
+      | undefined;
+    const api = createProcessTestApi({
+      registerService(registration) {
+        service = registration;
+      },
+      registerAgentEventSubscription(registration) {
+        subscription = registration;
+      },
+    });
+    const entry = createJsonRpcManifestPluginDefinition({
+      protocolVersion: 1,
+      id: "json-rpc-generic-registration-test",
+      name: "JSON RPC Generic Registration Test",
+      description: "Generic registration test",
+      process: { command: "json-rpc-child" },
+      registrations: [
+        {
+          type: "api",
+          method: "registerService",
+          args: [
+            {
+              id: "remote-service",
+              start: { $rpc: "service.start" },
+              stop: { $rpc: "service.stop" },
+            },
+          ],
+        },
+        {
+          type: "api",
+          method: "registerAgentEventSubscription",
+          args: [
+            {
+              id: "remote-events",
+              streams: ["run"],
+              handle: { $rpc: "events.handle" },
+            },
+          ],
+        },
+      ],
+    });
+
+    entry.register?.(api);
+
+    expect(service?.start).toBeTypeOf("function");
+    expect(service?.stop).toBeTypeOf("function");
+    expect(subscription?.handle).toBeTypeOf("function");
+    expect(mocks.spawn).not.toHaveBeenCalled();
+  });
+
+  it("registers process disposal after remote lifecycle cleanup", () => {
+    const lifecycleIds: string[] = [];
+    const registerRuntimeLifecycle: OpenClawPluginApi["registerRuntimeLifecycle"] = (lifecycle) => {
+      lifecycleIds.push(lifecycle.id);
+    };
+    const api = createProcessTestApi({
+      registerRuntimeLifecycle,
+      lifecycle: { registerRuntimeLifecycle } as OpenClawPluginApi["lifecycle"],
+    });
+    const entry = createJsonRpcManifestPluginDefinition({
+      protocolVersion: 1,
+      id: "json-rpc-lifecycle-order-test",
+      name: "JSON RPC Lifecycle Order Test",
+      description: "Lifecycle order test",
+      process: { command: "json-rpc-child" },
+      registrations: [
+        {
+          type: "api",
+          method: "registerRuntimeLifecycle",
+          args: [{ id: "remote-cleanup", cleanup: { $rpc: "lifecycle.cleanup" } }],
+        },
+      ],
+    });
+
+    entry.register?.(api);
+
+    expect(lifecycleIds).toEqual([
+      "remote-cleanup",
+      "json-rpc-lifecycle-order-test.json-rpc-process",
+    ]);
+  });
+
+  it("rejects generic registrations with synchronous or unaudited callback paths", () => {
+    const api = createProcessTestApi();
+    const syncProvider = createJsonRpcManifestPluginDefinition({
+      protocolVersion: 1,
+      id: "json-rpc-sync-provider-test",
+      name: "JSON RPC Sync Provider Test",
+      description: "Sync provider test",
+      process: { command: "json-rpc-child" },
+      registrations: [
+        {
+          type: "api",
+          method: "registerSpeechProvider",
+          args: [{ id: "remote-speech", isConfigured: { $rpc: "speech.isConfigured" } }],
+        },
+      ],
+    });
+    expect(() => syncProvider.register?.(api)).toThrow(
+      "unsupported JSON-RPC plugin registration method: registerSpeechProvider",
+    );
+
+    const wrongPath = createJsonRpcManifestPluginDefinition({
+      protocolVersion: 1,
+      id: "json-rpc-callback-path-test",
+      name: "JSON RPC Callback Path Test",
+      description: "Callback path test",
+      process: { command: "json-rpc-child" },
+      registrations: [
+        {
+          type: "api",
+          method: "registerService",
+          args: [{ id: "remote-service", unexpected: { $rpc: "service.unexpected" } }],
+        },
+      ],
+    });
+    expect(() => wrongPath.register?.(api)).toThrow(
+      "JSON-RPC callback is not supported at registration argument path: 0.unexpected",
+    );
+
+    const wireMarker = createJsonRpcManifestPluginDefinition({
+      protocolVersion: 1,
+      id: "json-rpc-wire-marker-test",
+      name: "JSON RPC Wire Marker Test",
+      description: "Wire marker test",
+      process: { command: "json-rpc-child" },
+      registrations: [
+        {
+          type: "api",
+          method: "registerSessionExtension",
+          args: [{ id: "remote-state", project: { $callback: "smuggled" } }],
+        },
+      ],
+    });
+    expect(() => wireMarker.register?.(api)).toThrow(
+      "JSON-RPC wire marker is not allowed in registration arguments: $callback",
+    );
+  });
+
+  it("rejects unsupported protocol versions and synchronous hooks", () => {
+    const api = createProcessTestApi();
+    const unsupported = createJsonRpcManifestPluginDefinition({
+      protocolVersion: 2 as never,
+      id: "json-rpc-version-test",
+      name: "JSON RPC Version Test",
+      description: "Version test",
+      process: { command: "json-rpc-child" },
+      registrations: [{ type: "tool", name: "version", description: "Version" }],
+    });
+    expect(() => unsupported.register?.(api)).toThrow(
+      "unsupported JSON-RPC plugin protocol version",
+    );
+
+    const syncHook = createJsonRpcManifestPluginDefinition({
+      protocolVersion: 1,
+      id: "json-rpc-sync-hook-test",
+      name: "JSON RPC Sync Hook Test",
+      description: "Sync hook test",
+      process: { command: "json-rpc-child" },
+      registrations: [{ type: "hook", hook: "before_message_write" }],
+    });
+    expect(() => syncHook.register?.(api)).toThrow(
+      "JSON-RPC plugins cannot register synchronous hook",
+    );
   });
 
   it("honors aborts while initialization is pending without canceling shared initialization", async () => {
@@ -161,6 +332,7 @@ describe("createJsonRpcManifestPluginDefinition process management", () => {
       },
     });
     const entry = createJsonRpcManifestPluginDefinition({
+      protocolVersion: 1,
       id: "json-rpc-process-init-abort-test",
       name: "JSON RPC Process Init Abort Test",
       description: "Test initialization abort",
@@ -186,6 +358,50 @@ describe("createJsonRpcManifestPluginDefinition process management", () => {
     const active = tools[0]?.execute("tool-call-active", {});
     child.resolveInitialize();
     await expect(active).resolves.toEqual({ content: [{ type: "text", text: "ok" }] });
+  });
+
+  it("stops a child before buffering an oversized unterminated frame", async () => {
+    mocks.resolveWindowsSpawnProgram.mockReturnValue({
+      command: "json-rpc-child",
+      leadingArgv: [],
+      resolution: "direct",
+      windowsHide: true,
+    });
+    mocks.materializeWindowsSpawnProgram.mockReturnValue({
+      command: "json-rpc-child",
+      argv: [],
+      shell: false,
+      windowsHide: true,
+    });
+    const child = new FakeJsonRpcChild({ deferInitialize: true });
+    mocks.spawn.mockReturnValue(asSpawnedChild(child));
+    const tools: AnyAgentTool[] = [];
+    const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const api = createProcessTestApi({
+      logger,
+      registerTool(tool) {
+        if (typeof tool !== "function") {
+          tools.push(tool);
+        }
+      },
+    });
+    const entry = createJsonRpcManifestPluginDefinition({
+      protocolVersion: 1,
+      id: "json-rpc-frame-limit-test",
+      name: "JSON RPC Frame Limit Test",
+      description: "Frame limit test",
+      process: { command: "json-rpc-child", maxFrameBytes: 16 },
+      registrations: [{ type: "tool", name: "frame_limit", description: "Frame limit" }],
+    });
+
+    entry.register?.(api);
+    const pending = tools[0]?.execute("tool-call", {});
+    child.stdout.write(Buffer.alloc(17, 0x78));
+
+    await expect(pending).rejects.toThrow("JSON-RPC plugin process was disposed");
+    expect(logger.warn).toHaveBeenCalledWith(
+      "JSON-RPC plugin json-rpc-process-test exceeded the frame size limit",
+    );
   });
 
   it("uses process-tree cleanup when stdin shutdown does not stop the child", async () => {
@@ -219,6 +435,7 @@ describe("createJsonRpcManifestPluginDefinition process management", () => {
       },
     });
     const entry = createJsonRpcManifestPluginDefinition({
+      protocolVersion: 1,
       id: "json-rpc-process-cleanup-test",
       name: "JSON RPC Process Cleanup Test",
       description: "Test process-tree cleanup",
@@ -296,13 +513,14 @@ class FakeJsonRpcChild extends EventEmitter {
       }
       const message = JSON.parse(line) as { id: unknown; method: string };
       if (message.method === "openclaw.initialize" && deferInitialize) {
-        this.deferredInitialize = () => this.writeJsonRpcResult(message.id, { ok: true });
+        this.deferredInitialize = () =>
+          this.writeJsonRpcResult(message.id, { ok: true, protocolVersion: 1 });
         continue;
       }
       const result =
         message.method === "openclaw.tool.execute"
           ? { content: [{ type: "text", text: "ok" }] }
-          : { ok: true };
+          : { ok: true, protocolVersion: 1 };
       this.writeJsonRpcResult(message.id, result);
     }
   }

--- a/src/plugins/json-rpc-manifest-runtime.process.test.ts
+++ b/src/plugins/json-rpc-manifest-runtime.process.test.ts
@@ -1,0 +1,332 @@
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { PassThrough, Writable } from "node:stream";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AnyAgentTool, OpenClawPluginApi } from "./types.js";
+
+const mocks = vi.hoisted(() => ({
+  spawn: vi.fn(),
+  killProcessTree: vi.fn(),
+  signalProcessTree: vi.fn(),
+  resolveWindowsSpawnProgram: vi.fn(),
+  materializeWindowsSpawnProgram: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({
+  spawn: mocks.spawn,
+}));
+
+vi.mock("../process/kill-tree.js", () => ({
+  killProcessTree: mocks.killProcessTree,
+  signalProcessTree: mocks.signalProcessTree,
+}));
+
+vi.mock("../plugin-sdk/windows-spawn.js", () => ({
+  resolveWindowsSpawnProgram: mocks.resolveWindowsSpawnProgram,
+  materializeWindowsSpawnProgram: mocks.materializeWindowsSpawnProgram,
+}));
+
+import { createTestPluginApi } from "../plugin-sdk/plugin-test-api.js";
+import { createJsonRpcManifestPluginDefinition } from "./json-rpc-manifest-runtime.js";
+
+describe("createJsonRpcManifestPluginDefinition process management", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("resolves child commands through the Windows spawn resolver", async () => {
+    const program = {
+      command: "resolved-node",
+      leadingArgv: ["entry.mjs"],
+      resolution: "node-entrypoint",
+      windowsHide: true,
+    };
+    mocks.resolveWindowsSpawnProgram.mockReturnValue(program);
+    mocks.materializeWindowsSpawnProgram.mockReturnValue({
+      command: "resolved-node",
+      argv: ["entry.mjs", "--stdio"],
+      shell: false,
+      windowsHide: true,
+    });
+    mocks.spawn.mockReturnValue(asSpawnedChild(new FakeJsonRpcChild()));
+
+    const tools: AnyAgentTool[] = [];
+    const api = createProcessTestApi({
+      registerTool(tool) {
+        if (typeof tool !== "function") {
+          tools.push(tool);
+        }
+      },
+    });
+    const entry = createJsonRpcManifestPluginDefinition({
+      id: "json-rpc-process-test",
+      name: "JSON RPC Process Test",
+      description: "Test spawn resolution",
+      process: {
+        command: "json-rpc-child",
+        args: ["--stdio"],
+        env: { JSON_RPC_PROCESS_TEST: "1" },
+      },
+      registrations: [
+        {
+          type: "tool",
+          name: "json_rpc_process",
+          description: "Process",
+        },
+      ],
+    });
+
+    entry.register?.(api);
+    await tools[0]?.execute("tool-call-1", {});
+
+    expect(mocks.resolveWindowsSpawnProgram).toHaveBeenCalledWith({
+      command: "json-rpc-child",
+      platform: process.platform,
+      env: expect.objectContaining({ JSON_RPC_PROCESS_TEST: "1" }),
+      execPath: process.execPath,
+      allowShellFallback: false,
+    });
+    expect(mocks.materializeWindowsSpawnProgram).toHaveBeenCalledWith(program, ["--stdio"]);
+    expect(mocks.spawn).toHaveBeenCalledWith(
+      "resolved-node",
+      ["entry.mjs", "--stdio"],
+      expect.objectContaining({
+        detached: process.platform !== "win32",
+        shell: false,
+        stdio: ["pipe", "pipe", "pipe"],
+        windowsHide: true,
+      }),
+    );
+  });
+
+  it("does not start a child process for a pre-aborted request", async () => {
+    const tools: AnyAgentTool[] = [];
+    const api = createProcessTestApi({
+      registerTool(tool) {
+        if (typeof tool !== "function") {
+          tools.push(tool);
+        }
+      },
+    });
+    const entry = createJsonRpcManifestPluginDefinition({
+      id: "json-rpc-process-abort-test",
+      name: "JSON RPC Process Abort Test",
+      description: "Test pre-aborted process requests",
+      process: {
+        command: "json-rpc-child",
+      },
+      registrations: [
+        {
+          type: "tool",
+          name: "json_rpc_process_abort",
+          description: "Process abort",
+        },
+      ],
+    });
+    const controller = new AbortController();
+    controller.abort();
+
+    entry.register?.(api);
+    await expect(tools[0]?.execute("tool-call-abort", {}, controller.signal)).rejects.toThrow(
+      "JSON-RPC plugin request aborted",
+    );
+
+    expect(mocks.resolveWindowsSpawnProgram).not.toHaveBeenCalled();
+    expect(mocks.spawn).not.toHaveBeenCalled();
+  });
+
+  it("honors aborts while initialization is pending without canceling shared initialization", async () => {
+    mocks.resolveWindowsSpawnProgram.mockReturnValue({
+      command: "json-rpc-child",
+      leadingArgv: [],
+      resolution: "direct",
+      windowsHide: true,
+    });
+    mocks.materializeWindowsSpawnProgram.mockReturnValue({
+      command: "json-rpc-child",
+      argv: [],
+      shell: false,
+      windowsHide: true,
+    });
+    const child = new FakeJsonRpcChild({ deferInitialize: true });
+    mocks.spawn.mockReturnValue(asSpawnedChild(child));
+
+    const tools: AnyAgentTool[] = [];
+    const api = createProcessTestApi({
+      registerTool(tool) {
+        if (typeof tool !== "function") {
+          tools.push(tool);
+        }
+      },
+    });
+    const entry = createJsonRpcManifestPluginDefinition({
+      id: "json-rpc-process-init-abort-test",
+      name: "JSON RPC Process Init Abort Test",
+      description: "Test initialization abort",
+      process: {
+        command: "json-rpc-child",
+      },
+      registrations: [
+        {
+          type: "tool",
+          name: "json_rpc_process_init_abort",
+          description: "Process init abort",
+        },
+      ],
+    });
+    const controller = new AbortController();
+
+    entry.register?.(api);
+    const aborted = tools[0]?.execute("tool-call-abort", {}, controller.signal);
+    controller.abort();
+
+    await expect(observeSettled(aborted)).resolves.toBe("JSON-RPC plugin request aborted");
+
+    const active = tools[0]?.execute("tool-call-active", {});
+    child.resolveInitialize();
+    await expect(active).resolves.toEqual({ content: [{ type: "text", text: "ok" }] });
+  });
+
+  it("uses process-tree cleanup when stdin shutdown does not stop the child", async () => {
+    vi.useFakeTimers();
+    mocks.resolveWindowsSpawnProgram.mockReturnValue({
+      command: "json-rpc-child",
+      leadingArgv: [],
+      resolution: "direct",
+      windowsHide: true,
+    });
+    mocks.materializeWindowsSpawnProgram.mockReturnValue({
+      command: "json-rpc-child",
+      argv: [],
+      shell: false,
+      windowsHide: true,
+    });
+    mocks.spawn.mockReturnValue(asSpawnedChild(new FakeJsonRpcChild({ closeOnStdinEnd: false })));
+
+    const tools: AnyAgentTool[] = [];
+    let cleanup:
+      | NonNullable<Parameters<OpenClawPluginApi["registerRuntimeLifecycle"]>[0]["cleanup"]>
+      | undefined;
+    const api = createProcessTestApi({
+      registerTool(tool) {
+        if (typeof tool !== "function") {
+          tools.push(tool);
+        }
+      },
+      registerRuntimeLifecycle(lifecycle) {
+        cleanup = lifecycle.cleanup;
+      },
+    });
+    const entry = createJsonRpcManifestPluginDefinition({
+      id: "json-rpc-process-cleanup-test",
+      name: "JSON RPC Process Cleanup Test",
+      description: "Test process-tree cleanup",
+      process: {
+        command: "json-rpc-child",
+      },
+      registrations: [
+        {
+          type: "tool",
+          name: "json_rpc_process_cleanup",
+          description: "Process cleanup",
+        },
+      ],
+    });
+
+    entry.register?.(api);
+    await tools[0]?.execute("tool-call-1", {});
+
+    const cleanupPromise = cleanup?.({ reason: "restart" });
+    await vi.advanceTimersByTimeAsync(5_000);
+    await cleanupPromise;
+
+    expect(mocks.killProcessTree).toHaveBeenCalledWith(4321, { graceMs: 500 });
+    expect(mocks.signalProcessTree).toHaveBeenCalledWith(4321, "SIGKILL");
+  });
+});
+
+function createProcessTestApi(overrides: Partial<OpenClawPluginApi> = {}): OpenClawPluginApi {
+  return createTestPluginApi({
+    id: "json-rpc-process-test",
+    name: "JSON RPC Process Test",
+    source: "src/plugins/json-rpc-manifest-runtime.process.test.ts",
+    rootDir: process.cwd(),
+    ...overrides,
+  });
+}
+
+class FakeJsonRpcChild extends EventEmitter {
+  readonly stdout = new PassThrough();
+  readonly stderr = new PassThrough();
+  readonly pid = 4321;
+  readonly kill = vi.fn();
+  readonly stdin: Writable;
+  private deferredInitialize: (() => void) | undefined;
+  exitCode: number | null = null;
+  signalCode: NodeJS.Signals | null = null;
+
+  constructor(options: { closeOnStdinEnd?: boolean; deferInitialize?: boolean } = {}) {
+    super();
+    const closeOnStdinEnd = options.closeOnStdinEnd ?? true;
+    this.stdin = new Writable({
+      write: (chunk, _encoding, callback) => {
+        this.writeResponse(String(chunk), options.deferInitialize === true);
+        callback();
+      },
+      final: (callback) => {
+        if (closeOnStdinEnd) {
+          this.exitCode = 0;
+          this.emit("close", 0, null);
+        }
+        callback();
+      },
+    });
+  }
+
+  resolveInitialize(): void {
+    this.deferredInitialize?.();
+    this.deferredInitialize = undefined;
+  }
+
+  private writeResponse(chunk: string, deferInitialize: boolean): void {
+    for (const line of chunk.split("\n")) {
+      if (line.length === 0) {
+        continue;
+      }
+      const message = JSON.parse(line) as { id: unknown; method: string };
+      if (message.method === "openclaw.initialize" && deferInitialize) {
+        this.deferredInitialize = () => this.writeJsonRpcResult(message.id, { ok: true });
+        continue;
+      }
+      const result =
+        message.method === "openclaw.tool.execute"
+          ? { content: [{ type: "text", text: "ok" }] }
+          : { ok: true };
+      this.writeJsonRpcResult(message.id, result);
+    }
+  }
+
+  private writeJsonRpcResult(id: unknown, result: unknown): void {
+    this.stdout.write(`${JSON.stringify({ jsonrpc: "2.0", id, result })}\n`);
+  }
+}
+
+function asSpawnedChild(child: FakeJsonRpcChild): ChildProcessWithoutNullStreams {
+  return child as unknown as ChildProcessWithoutNullStreams;
+}
+
+function observeSettled(promise: Promise<unknown> | undefined): Promise<string> {
+  if (!promise) {
+    return Promise.resolve("missing");
+  }
+  return Promise.race([
+    promise.then(
+      () => "resolved",
+      (error: unknown) => (error instanceof Error ? error.message : String(error)),
+    ),
+    new Promise<string>((resolve) => {
+      setTimeout(() => resolve("pending"), 25);
+    }),
+  ]);
+}

--- a/src/plugins/json-rpc-manifest-runtime.test.ts
+++ b/src/plugins/json-rpc-manifest-runtime.test.ts
@@ -3,7 +3,7 @@ import type { IncomingMessage } from "node:http";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { Readable, Writable } from "node:stream";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createTestPluginApi } from "../plugin-sdk/plugin-test-api.js";
 import { createJsonRpcManifestPluginDefinition } from "./json-rpc-manifest-runtime.js";
 import type { AnyAgentTool, OpenClawPluginApi } from "./types.js";
@@ -78,6 +78,7 @@ describe("createJsonRpcManifestPluginDefinition", () => {
     });
 
     const entry = createJsonRpcManifestPluginDefinition({
+      protocolVersion: 1,
       id: "json-rpc-test",
       name: "JSON RPC Test",
       description: "Test plugin",
@@ -223,6 +224,7 @@ describe("createJsonRpcManifestPluginDefinition", () => {
     });
 
     const entry = createJsonRpcManifestPluginDefinition({
+      protocolVersion: 1,
       id: "json-rpc-env-test",
       name: "JSON RPC Env Test",
       description: "Test plugin env isolation",
@@ -246,6 +248,63 @@ describe("createJsonRpcManifestPluginDefinition", () => {
 
     await expect(tools[0]?.execute("tool-call-env", {})).resolves.toEqual({
       content: [{ type: "text", text: "missing" }],
+    });
+  });
+
+  it("registers generic API descriptors and permits declared child-to-host calls", async () => {
+    const rootDir = mkdtempSync(path.join(tmpdir(), "openclaw-json-rpc-plugin-api-"));
+    tempDirs.push(rootDir);
+    const childPath = path.join(rootDir, "child.mjs");
+    writeFileSync(childPath, BIDIRECTIONAL_RUNTIME, "utf8");
+    let command: Parameters<OpenClawPluginApi["registerCommand"]>[0] | undefined;
+    const requestHeartbeat = vi.fn(() => ({ requested: true }));
+    const api = createTestPluginApi({
+      id: "json-rpc-api-test",
+      name: "JSON RPC API Test",
+      source: path.join(rootDir, "index.ts"),
+      rootDir,
+      runtime: {
+        system: { requestHeartbeat },
+      } as never,
+      registerCommand(registration) {
+        command = registration;
+      },
+      registerRuntimeLifecycle(lifecycle) {
+        if (lifecycle.cleanup) {
+          runtimeCleanups.push(lifecycle.cleanup);
+        }
+      },
+    });
+    const entry = createJsonRpcManifestPluginDefinition({
+      protocolVersion: 1,
+      id: "json-rpc-api-test",
+      name: "JSON RPC API Test",
+      description: "Generic API registration test",
+      process: { command: process.execPath, args: [childPath], cwd: rootDir },
+      permissions: { host: ["runtime.system.requestHeartbeat"] },
+      registrations: [
+        {
+          type: "api",
+          method: "registerCommand",
+          args: [
+            {
+              name: "rpc-command",
+              description: "RPC command",
+              handler: { $rpc: "plugin.command.handle" },
+            },
+          ],
+        },
+      ],
+    });
+
+    entry.register?.(api);
+    await expect(command?.handler({ args: "hello" } as never)).resolves.toEqual({
+      text: "heartbeat:hello:true",
+    });
+    expect(requestHeartbeat).toHaveBeenCalledWith({
+      source: "other",
+      intent: "event",
+      reason: "rpc-command",
     });
   });
 
@@ -278,6 +337,7 @@ describe("createJsonRpcManifestPluginDefinition", () => {
     });
 
     const entry = createJsonRpcManifestPluginDefinition({
+      protocolVersion: 1,
       id: "json-rpc-dispose-test",
       name: "JSON RPC Dispose Test",
       description: "Test plugin-wide cleanup",
@@ -333,6 +393,7 @@ describe("createJsonRpcManifestPluginDefinition", () => {
     });
 
     const entry = createJsonRpcManifestPluginDefinition({
+      protocolVersion: 1,
       id: "json-rpc-retry-test",
       name: "JSON RPC Retry Test",
       description: "Test plugin initialization retry",
@@ -384,6 +445,7 @@ describe("createJsonRpcManifestPluginDefinition", () => {
     });
 
     const entry = createJsonRpcManifestPluginDefinition({
+      protocolVersion: 1,
       id: "json-rpc-abort-test",
       name: "JSON RPC Abort Test",
       description: "Test plugin initialization abort isolation",
@@ -476,7 +538,7 @@ function handle(method, params) {
   if (method === "openclaw.initialize") {
     initializeCount += 1;
     greeting = params.pluginConfig.greeting;
-    return { ok: true };
+    return { ok: true, protocolVersion: 1 };
   }
   if (method === "openclaw.tool.execute") {
     toolCallCount += 1;
@@ -511,6 +573,46 @@ function handle(method, params) {
 }
 `;
 
+const BIDIRECTIONAL_RUNTIME = `
+import readline from "node:readline";
+
+let nextId = 1;
+const pending = new Map();
+const rl = readline.createInterface({ input: process.stdin });
+rl.on("line", async (line) => {
+  const message = JSON.parse(line);
+  if (message.method === "openclaw.initialize") {
+    respond(message.id, { ok: true, protocolVersion: 1 });
+    return;
+  }
+  if (message.method === "plugin.command.handle") {
+    const hostResult = await request("openclaw.host.call", {
+      method: "runtime.system.requestHeartbeat",
+      args: [{ source: "other", intent: "event", reason: "rpc-command" }],
+    });
+    respond(message.id, {
+      text: "heartbeat:" + message.params.args[0].args + ":" + hostResult.requested,
+    });
+    return;
+  }
+  if (message.id !== undefined && pending.has(message.id)) {
+    const resolve = pending.get(message.id);
+    pending.delete(message.id);
+    resolve(message.result);
+  }
+});
+
+function request(method, params) {
+  const id = "child-" + nextId++;
+  process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id, method, params }) + "\\n");
+  return new Promise((resolve) => pending.set(id, resolve));
+}
+
+function respond(id, result) {
+  process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id, result }) + "\\n");
+}
+`;
+
 const ENV_RUNTIME = `
 import readline from "node:readline";
 
@@ -525,9 +627,9 @@ rl.on("line", (line) => {
   process.stdout.write(JSON.stringify({
     jsonrpc: "2.0",
     id: message.id,
-    result: message.method === "openclaw.tool.execute"
-      ? { content: [{ type: "text", text }] }
-      : { ok: true },
+    result: message.method === "openclaw.initialize"
+      ? { ok: true, protocolVersion: 1 }
+      : { content: [{ type: "text", text }] },
   }) + "\\n");
 });
 `;
@@ -552,7 +654,7 @@ rl.on("line", (line) => {
       return;
     }
     initializeCount += 1;
-    process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: message.id, result: { ok: true } }) + "\\n");
+    process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: message.id, result: { ok: true, protocolVersion: 1 } }) + "\\n");
     return;
   }
   process.stdout.write(JSON.stringify({
@@ -571,7 +673,7 @@ rl.on("line", (line) => {
   const message = JSON.parse(line);
   if (message.method === "openclaw.initialize") {
     setTimeout(() => {
-      process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: message.id, result: { ok: true } }) + "\\n");
+      process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: message.id, result: { ok: true, protocolVersion: 1 } }) + "\\n");
     }, 25);
     return;
   }

--- a/src/plugins/json-rpc-manifest-runtime.test.ts
+++ b/src/plugins/json-rpc-manifest-runtime.test.ts
@@ -1,0 +1,584 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import type { IncomingMessage } from "node:http";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { Readable, Writable } from "node:stream";
+import { afterEach, describe, expect, it } from "vitest";
+import { createTestPluginApi } from "../plugin-sdk/plugin-test-api.js";
+import { createJsonRpcManifestPluginDefinition } from "./json-rpc-manifest-runtime.js";
+import type { AnyAgentTool, OpenClawPluginApi } from "./types.js";
+
+describe("createJsonRpcManifestPluginDefinition", () => {
+  const tempDirs: string[] = [];
+  const runtimeCleanups: Array<
+    NonNullable<Parameters<OpenClawPluginApi["registerRuntimeLifecycle"]>[0]["cleanup"]>
+  > = [];
+
+  afterEach(async () => {
+    for (const cleanup of runtimeCleanups.splice(0)) {
+      await cleanup({ reason: "restart" });
+    }
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    delete process.env.OPENCLAW_JSON_RPC_TEST_SECRET;
+  });
+
+  it("registers OpenClaw descriptors synchronously and dispatches calls to a stdio JSON-RPC child", async () => {
+    const rootDir = mkdtempSync(path.join(tmpdir(), "openclaw-json-rpc-plugin-"));
+    tempDirs.push(rootDir);
+    const childPath = path.join(rootDir, "child.mjs");
+    writeFileSync(childPath, CHILD_RUNTIME, "utf8");
+
+    const tools: AnyAgentTool[] = [];
+    let hookHandler: ((event: unknown, context: unknown) => unknown) | undefined;
+    let gatewayStopHandler: ((event: unknown, context: unknown) => unknown) | undefined;
+    let route: Parameters<OpenClawPluginApi["registerHttpRoute"]>[0] | undefined;
+    let gateway:
+      | {
+          method: string;
+          handler: Parameters<OpenClawPluginApi["registerGatewayMethod"]>[1];
+        }
+      | undefined;
+    const cleanupCallbacks: Array<
+      NonNullable<Parameters<OpenClawPluginApi["registerRuntimeLifecycle"]>[0]["cleanup"]>
+    > = [];
+
+    const api = createTestPluginApi({
+      id: "json-rpc-test",
+      name: "JSON RPC Test",
+      source: path.join(rootDir, "index.ts"),
+      rootDir,
+      pluginConfig: { greeting: "hello" },
+      registerTool(tool) {
+        if (typeof tool !== "function") {
+          tools.push(tool);
+        }
+      },
+      on(hookName, handler) {
+        if (hookName === "gateway_start") {
+          hookHandler = handler as (event: unknown, context: unknown) => unknown;
+        }
+        if (hookName === "gateway_stop") {
+          gatewayStopHandler = handler as () => unknown;
+        }
+      },
+      registerHttpRoute(params) {
+        route = params;
+      },
+      registerGatewayMethod(method, handler) {
+        gateway = { method, handler };
+      },
+      registerRuntimeLifecycle(lifecycle) {
+        if (lifecycle.cleanup) {
+          cleanupCallbacks.push(lifecycle.cleanup);
+          runtimeCleanups.push(lifecycle.cleanup);
+        }
+      },
+    });
+
+    const entry = createJsonRpcManifestPluginDefinition({
+      id: "json-rpc-test",
+      name: "JSON RPC Test",
+      description: "Test plugin",
+      process: {
+        command: process.execPath,
+        args: [childPath],
+        cwd: rootDir,
+        inheritEnv: false,
+      },
+      registrations: [
+        {
+          type: "tool",
+          name: "json_rpc_echo",
+          description: "Echo through JSON-RPC",
+          parameters: {
+            type: "object",
+            properties: {
+              value: { type: "string" },
+            },
+          },
+        },
+        {
+          type: "hook",
+          hook: "gateway_start",
+          description: "Gateway startup hook",
+        },
+        {
+          type: "hook",
+          hook: "gateway_stop",
+          description: "Gateway shutdown hook",
+        },
+        {
+          type: "httpRoute",
+          path: "/plugins/json-rpc-test/echo",
+          auth: "plugin",
+        },
+        {
+          type: "gatewayMethod",
+          method: "jsonRpcTest.status",
+          scope: "operator.read",
+        },
+      ],
+    });
+
+    entry.register?.(api);
+
+    expect(tools).toHaveLength(1);
+    expect(route?.path).toBe("/plugins/json-rpc-test/echo");
+    expect(gateway?.method).toBe("jsonRpcTest.status");
+
+    await expect(tools[0]?.execute("tool-call-1", { value: "tool-value" })).resolves.toEqual({
+      content: [
+        {
+          type: "text",
+          text: "tool:json_rpc_echo:tool-value:tool-call-1:1:1:hello",
+        },
+      ],
+    });
+
+    const gatewayResponses: unknown[] = [];
+    await gateway?.handler({
+      req: { id: "gateway-1", method: "jsonRpcTest.status" },
+      params: { value: "gateway-value" },
+      client: {
+        connId: "conn-1",
+        clientIp: "127.0.0.1",
+        connect: { scopes: ["operator.read"] },
+      },
+      respond: (ok: boolean, payload?: unknown, error?: unknown) =>
+        gatewayResponses.push({ ok, payload, error }),
+    } as never);
+    expect(gatewayResponses).toEqual([
+      {
+        ok: true,
+        payload: {
+          method: "jsonRpcTest.status",
+          value: "gateway-value",
+          initializeCount: 1,
+        },
+        error: undefined,
+      },
+    ]);
+
+    const req = makeRequest("POST", "/plugins/json-rpc-test/echo", "http-body");
+    const res = new TestResponse();
+    await route?.handler(req, res as never);
+    expect(res.statusCode).toBe(202);
+    expect(res.bodyText()).toBe("POST:/plugins/json-rpc-test/echo:http-body:1");
+
+    const event = {
+      type: "gateway",
+      action: "startup",
+      sessionKey: "session-1",
+      context: {},
+      timestamp: new Date("2026-06-30T00:00:00.000Z"),
+      messages: [],
+    };
+    await expect(hookHandler?.(event, { registrationMode: "full" })).resolves.toEqual({
+      messages: ["hook:startup:1"],
+    });
+
+    await cleanupCallbacks[0]?.({ reason: "reset", sessionKey: "session-1" });
+    await expect(tools[0]?.execute("tool-call-2", { value: "after-reset" })).resolves.toEqual({
+      content: [
+        {
+          type: "text",
+          text: "tool:json_rpc_echo:after-reset:tool-call-2:1:2:hello",
+        },
+      ],
+    });
+
+    await expect(gatewayStopHandler?.({ action: "stop" }, {})).resolves.toEqual({
+      messages: ["hook:stop:1"],
+    });
+    await expect(tools[0]?.execute("tool-call-after-stop", {})).rejects.toThrow(
+      "JSON-RPC plugin process was disposed",
+    );
+  });
+
+  it("does not inherit parent env when inheritEnv is false", async () => {
+    process.env.OPENCLAW_JSON_RPC_TEST_SECRET = "parent-secret";
+    const rootDir = mkdtempSync(path.join(tmpdir(), "openclaw-json-rpc-plugin-env-"));
+    tempDirs.push(rootDir);
+    const childPath = path.join(rootDir, "child.mjs");
+    writeFileSync(childPath, ENV_RUNTIME, "utf8");
+
+    const tools: AnyAgentTool[] = [];
+    const api = createTestPluginApi({
+      id: "json-rpc-env-test",
+      name: "JSON RPC Env Test",
+      source: path.join(rootDir, "index.ts"),
+      rootDir,
+      registerTool(tool) {
+        if (typeof tool !== "function") {
+          tools.push(tool);
+        }
+      },
+      registerRuntimeLifecycle(lifecycle) {
+        if (lifecycle.cleanup) {
+          runtimeCleanups.push(lifecycle.cleanup);
+        }
+      },
+    });
+
+    const entry = createJsonRpcManifestPluginDefinition({
+      id: "json-rpc-env-test",
+      name: "JSON RPC Env Test",
+      description: "Test plugin env isolation",
+      process: {
+        command: process.execPath,
+        args: [childPath],
+        cwd: rootDir,
+        inheritEnv: false,
+        timeoutMs: 1000,
+      },
+      registrations: [
+        {
+          type: "tool",
+          name: "json_rpc_env",
+          description: "Read env",
+        },
+      ],
+    });
+
+    entry.register?.(api);
+
+    await expect(tools[0]?.execute("tool-call-env", {})).resolves.toEqual({
+      content: [{ type: "text", text: "missing" }],
+    });
+  });
+
+  it("does not restart the child after plugin-wide cleanup", async () => {
+    const rootDir = mkdtempSync(path.join(tmpdir(), "openclaw-json-rpc-plugin-dispose-"));
+    tempDirs.push(rootDir);
+    const childPath = path.join(rootDir, "child.mjs");
+    writeFileSync(childPath, ENV_RUNTIME, "utf8");
+
+    const tools: AnyAgentTool[] = [];
+    let cleanup:
+      | NonNullable<Parameters<OpenClawPluginApi["registerRuntimeLifecycle"]>[0]["cleanup"]>
+      | undefined;
+    const api = createTestPluginApi({
+      id: "json-rpc-dispose-test",
+      name: "JSON RPC Dispose Test",
+      source: path.join(rootDir, "index.ts"),
+      rootDir,
+      registerTool(tool) {
+        if (typeof tool !== "function") {
+          tools.push(tool);
+        }
+      },
+      registerRuntimeLifecycle(lifecycle) {
+        cleanup = lifecycle.cleanup;
+        if (lifecycle.cleanup) {
+          runtimeCleanups.push(lifecycle.cleanup);
+        }
+      },
+    });
+
+    const entry = createJsonRpcManifestPluginDefinition({
+      id: "json-rpc-dispose-test",
+      name: "JSON RPC Dispose Test",
+      description: "Test plugin-wide cleanup",
+      process: {
+        command: process.execPath,
+        args: [childPath],
+        cwd: rootDir,
+        inheritEnv: false,
+      },
+      registrations: [
+        {
+          type: "tool",
+          name: "json_rpc_dispose",
+          description: "Dispose",
+        },
+      ],
+    });
+
+    entry.register?.(api);
+
+    await expect(tools[0]?.execute("tool-call-before-dispose", {})).resolves.toEqual({
+      content: [{ type: "text", text: "missing" }],
+    });
+    await cleanup?.({ reason: "restart" });
+    await expect(tools[0]?.execute("tool-call-after-dispose", {})).rejects.toThrow(
+      "JSON-RPC plugin process was disposed",
+    );
+  });
+
+  it("retries initialization after a child reports an initialization error", async () => {
+    const rootDir = mkdtempSync(path.join(tmpdir(), "openclaw-json-rpc-plugin-retry-"));
+    tempDirs.push(rootDir);
+    const childPath = path.join(rootDir, "child.mjs");
+    const markerPath = path.join(rootDir, "failed-once");
+    writeFileSync(childPath, INIT_FAIL_ONCE_RUNTIME, "utf8");
+
+    const tools: AnyAgentTool[] = [];
+    const api = createTestPluginApi({
+      id: "json-rpc-retry-test",
+      name: "JSON RPC Retry Test",
+      source: path.join(rootDir, "index.ts"),
+      rootDir,
+      registerTool(tool) {
+        if (typeof tool !== "function") {
+          tools.push(tool);
+        }
+      },
+      registerRuntimeLifecycle(lifecycle) {
+        if (lifecycle.cleanup) {
+          runtimeCleanups.push(lifecycle.cleanup);
+        }
+      },
+    });
+
+    const entry = createJsonRpcManifestPluginDefinition({
+      id: "json-rpc-retry-test",
+      name: "JSON RPC Retry Test",
+      description: "Test plugin initialization retry",
+      process: {
+        command: process.execPath,
+        args: [childPath, markerPath],
+        cwd: rootDir,
+        inheritEnv: false,
+      },
+      registrations: [
+        {
+          type: "tool",
+          name: "json_rpc_retry",
+          description: "Retry init",
+        },
+      ],
+    });
+
+    entry.register?.(api);
+
+    await expect(tools[0]?.execute("tool-call-fail", {})).rejects.toThrow("fail once");
+    await expect(tools[0]?.execute("tool-call-retry", {})).resolves.toEqual({
+      content: [{ type: "text", text: "initialized:1" }],
+    });
+  });
+
+  it("does not let one aborted caller cancel shared initialization", async () => {
+    const rootDir = mkdtempSync(path.join(tmpdir(), "openclaw-json-rpc-plugin-abort-"));
+    tempDirs.push(rootDir);
+    const childPath = path.join(rootDir, "child.mjs");
+    writeFileSync(childPath, SLOW_INIT_RUNTIME, "utf8");
+
+    const tools: AnyAgentTool[] = [];
+    const api = createTestPluginApi({
+      id: "json-rpc-abort-test",
+      name: "JSON RPC Abort Test",
+      source: path.join(rootDir, "index.ts"),
+      rootDir,
+      registerTool(tool) {
+        if (typeof tool !== "function") {
+          tools.push(tool);
+        }
+      },
+      registerRuntimeLifecycle(lifecycle) {
+        if (lifecycle.cleanup) {
+          runtimeCleanups.push(lifecycle.cleanup);
+        }
+      },
+    });
+
+    const entry = createJsonRpcManifestPluginDefinition({
+      id: "json-rpc-abort-test",
+      name: "JSON RPC Abort Test",
+      description: "Test plugin initialization abort isolation",
+      process: {
+        command: process.execPath,
+        args: [childPath],
+        cwd: rootDir,
+        inheritEnv: false,
+      },
+      registrations: [
+        {
+          type: "tool",
+          name: "json_rpc_abort",
+          description: "Abort isolation",
+        },
+      ],
+    });
+
+    entry.register?.(api);
+
+    const controller = new AbortController();
+    controller.abort();
+    const aborted = tools[0]?.execute("tool-call-aborted", {}, controller.signal);
+    const active = tools[0]?.execute("tool-call-active", {});
+
+    await expect(aborted).rejects.toThrow("JSON-RPC plugin request aborted");
+    await expect(active).resolves.toEqual({
+      content: [{ type: "text", text: "active:tool-call-active" }],
+    });
+  });
+});
+
+function makeRequest(method: string, url: string, body: string): IncomingMessage {
+  return Object.assign(Readable.from([Buffer.from(body)]), {
+    method,
+    url,
+    headers: {
+      "content-type": "text/plain",
+    },
+  }) as IncomingMessage;
+}
+
+class TestResponse extends Writable {
+  statusCode = 200;
+  readonly headers = new Map<string, number | string | string[]>();
+  private readonly chunks: Buffer[] = [];
+
+  setHeader(name: string, value: number | string | string[]): this {
+    this.headers.set(name.toLowerCase(), value);
+    return this;
+  }
+
+  override _write(
+    chunk: unknown,
+    _encoding: BufferEncoding,
+    callback: (error?: Error | null) => void,
+  ): void {
+    this.chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)));
+    callback();
+  }
+
+  bodyText(): string {
+    return Buffer.concat(this.chunks).toString("utf8");
+  }
+}
+
+const CHILD_RUNTIME = `
+import readline from "node:readline";
+
+let initializeCount = 0;
+let toolCallCount = 0;
+let greeting = "missing";
+
+const rl = readline.createInterface({ input: process.stdin });
+rl.on("line", (line) => {
+  const message = JSON.parse(line);
+  try {
+    const result = handle(message.method, message.params);
+    process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: message.id, result }) + "\\n");
+  } catch (error) {
+    process.stdout.write(JSON.stringify({
+      jsonrpc: "2.0",
+      id: message.id,
+      error: { message: error instanceof Error ? error.message : String(error) },
+    }) + "\\n");
+  }
+});
+
+function handle(method, params) {
+  if (method === "openclaw.initialize") {
+    initializeCount += 1;
+    greeting = params.pluginConfig.greeting;
+    return { ok: true };
+  }
+  if (method === "openclaw.tool.execute") {
+    toolCallCount += 1;
+    return {
+      content: [{
+        type: "text",
+        text: \`tool:\${params.tool.name}:\${params.params.value}:\${params.toolCallId}:\${initializeCount}:\${toolCallCount}:\${greeting}\`,
+      }],
+    };
+  }
+  if (method === "openclaw.gateway.handle") {
+    return {
+      ok: true,
+      payload: {
+        method: params.method,
+        value: params.params.value,
+        initializeCount,
+      },
+    };
+  }
+  if (method === "openclaw.http.handle") {
+    return {
+      status: 202,
+      headers: { "content-type": "text/plain" },
+      bodyText: \`\${params.request.method}:\${params.request.url}:\${Buffer.from(params.request.bodyBase64, "base64").toString("utf8")}:\${initializeCount}\`,
+    };
+  }
+  if (method === "openclaw.hook.handle") {
+    return { messages: [\`hook:\${params.event.action}:\${initializeCount}\`] };
+  }
+  throw new Error(\`unexpected method: \${method}\`);
+}
+`;
+
+const ENV_RUNTIME = `
+import readline from "node:readline";
+
+process.stderr.write("x".repeat(256 * 1024));
+
+const rl = readline.createInterface({ input: process.stdin });
+rl.on("line", (line) => {
+  const message = JSON.parse(line);
+  const text = message.method === "openclaw.tool.execute"
+    ? (process.env.OPENCLAW_JSON_RPC_TEST_SECRET ?? "missing")
+    : "ok";
+  process.stdout.write(JSON.stringify({
+    jsonrpc: "2.0",
+    id: message.id,
+    result: message.method === "openclaw.tool.execute"
+      ? { content: [{ type: "text", text }] }
+      : { ok: true },
+  }) + "\\n");
+});
+`;
+
+const INIT_FAIL_ONCE_RUNTIME = `
+import fs from "node:fs";
+import readline from "node:readline";
+
+const markerPath = process.argv[2];
+let initializeCount = 0;
+const rl = readline.createInterface({ input: process.stdin });
+rl.on("line", (line) => {
+  const message = JSON.parse(line);
+  if (message.method === "openclaw.initialize") {
+    if (!fs.existsSync(markerPath)) {
+      fs.writeFileSync(markerPath, "failed", "utf8");
+      process.stdout.write(JSON.stringify({
+        jsonrpc: "2.0",
+        id: message.id,
+        error: { message: "fail once" },
+      }) + "\\n");
+      return;
+    }
+    initializeCount += 1;
+    process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: message.id, result: { ok: true } }) + "\\n");
+    return;
+  }
+  process.stdout.write(JSON.stringify({
+    jsonrpc: "2.0",
+    id: message.id,
+    result: { content: [{ type: "text", text: \`initialized:\${initializeCount}\` }] },
+  }) + "\\n");
+});
+`;
+
+const SLOW_INIT_RUNTIME = `
+import readline from "node:readline";
+
+const rl = readline.createInterface({ input: process.stdin });
+rl.on("line", (line) => {
+  const message = JSON.parse(line);
+  if (message.method === "openclaw.initialize") {
+    setTimeout(() => {
+      process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: message.id, result: { ok: true } }) + "\\n");
+    }, 25);
+    return;
+  }
+  process.stdout.write(JSON.stringify({
+    jsonrpc: "2.0",
+    id: message.id,
+    result: { content: [{ type: "text", text: \`active:\${message.params.toolCallId}\` }] },
+  }) + "\\n");
+});
+`;

--- a/src/plugins/json-rpc-manifest-runtime.ts
+++ b/src/plugins/json-rpc-manifest-runtime.ts
@@ -1,0 +1,707 @@
+// JSON-RPC manifest entries bridge static plugin descriptors to child-process runtimes.
+import { Buffer } from "node:buffer";
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import type { IncomingMessage } from "node:http";
+import type { ServerResponse } from "node:http";
+import path from "node:path";
+import { createInterface, type Interface as ReadlineInterface } from "node:readline";
+import type { Readable } from "node:stream";
+import type { ErrorShape } from "../../packages/gateway-protocol/src/index.js";
+import type { RespondFn } from "../gateway/server-methods/types.js";
+import {
+  materializeWindowsSpawnProgram,
+  resolveWindowsSpawnProgram,
+} from "../plugin-sdk/windows-spawn.js";
+import { killProcessTree, signalProcessTree } from "../process/kill-tree.js";
+import { isPluginHookName, type PluginHookHandlerMap } from "./hook-types.js";
+import type { PluginManifestJsonRpc, PluginManifestJsonRpcRegistration } from "./manifest.js";
+import type {
+  AnyAgentTool,
+  OpenClawPluginApi,
+  OpenClawPluginConfigSchema,
+  OpenClawPluginDefinition,
+} from "./types.js";
+
+export type JsonRpcPluginJsonPrimitive = string | number | boolean | null;
+export type JsonRpcPluginJsonValue =
+  | JsonRpcPluginJsonPrimitive
+  | { [key: string]: JsonRpcPluginJsonValue }
+  | JsonRpcPluginJsonValue[];
+export type JsonRpcPluginJsonObject = { [key: string]: JsonRpcPluginJsonValue };
+
+export type JsonRpcPluginProcessOptions = PluginManifestJsonRpc["process"];
+
+export type JsonRpcPluginRegistration = PluginManifestJsonRpcRegistration;
+export type JsonRpcPluginToolRegistration = Extract<JsonRpcPluginRegistration, { type: "tool" }>;
+export type JsonRpcPluginHookRegistration = Extract<JsonRpcPluginRegistration, { type: "hook" }>;
+export type JsonRpcPluginHttpRouteRegistration = Extract<
+  JsonRpcPluginRegistration,
+  { type: "httpRoute" }
+>;
+export type JsonRpcPluginGatewayMethodRegistration = Extract<
+  JsonRpcPluginRegistration,
+  { type: "gatewayMethod" }
+>;
+
+export type JsonRpcManifestPluginOptions = {
+  id: string;
+  name: string;
+  description: string;
+  kind?: OpenClawPluginDefinition["kind"];
+  configSchema?: OpenClawPluginConfigSchema;
+  process: JsonRpcPluginProcessOptions;
+  registrations: readonly JsonRpcPluginRegistration[];
+};
+
+type PendingRequest = {
+  resolve: (value: unknown) => void;
+  reject: (error: Error) => void;
+  timeout: NodeJS.Timeout;
+};
+
+type JsonRpcResponse = {
+  jsonrpc?: "2.0";
+  id?: unknown;
+  result?: unknown;
+  error?: {
+    code?: number | string;
+    message?: string;
+    data?: unknown;
+  };
+};
+
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+const DEFAULT_INITIALIZATION_TIMEOUT_MS = 10_000;
+const DEFAULT_HTTP_BODY_LIMIT_BYTES = 1024 * 1024;
+const PROCESS_CLOSE_TIMEOUT_MS = 2_000;
+const PROCESS_TREE_KILL_GRACE_MS = 500;
+const SIGKILL_REAP_TIMEOUT_MS = 500;
+const DEFAULT_TOOL_METHOD = "openclaw.tool.execute";
+const DEFAULT_HOOK_METHOD = "openclaw.hook.handle";
+const DEFAULT_HTTP_METHOD = "openclaw.http.handle";
+const DEFAULT_GATEWAY_METHOD = "openclaw.gateway.handle";
+const EMPTY_OBJECT_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+} as const satisfies JsonRpcPluginJsonObject;
+
+export function createJsonRpcManifestPluginDefinition(
+  options: JsonRpcManifestPluginOptions,
+): OpenClawPluginDefinition {
+  return {
+    id: options.id,
+    name: options.name,
+    description: options.description,
+    ...(options.kind ? { kind: options.kind } : {}),
+    ...(options.configSchema ? { configSchema: options.configSchema } : {}),
+    register(api) {
+      const client = new JsonRpcPluginClient(api, options.process);
+      api.lifecycle.registerRuntimeLifecycle({
+        id: `${options.id}.json-rpc-process`,
+        description: "JSON-RPC child process owned by this plugin",
+        cleanup: async ({ reason }) => {
+          if (reason === "disable" || reason === "restart") {
+            await client.dispose();
+          }
+        },
+      });
+
+      const gatewayStopHooks = options.registrations.filter(isGatewayStopHookRegistration);
+      for (const registration of options.registrations) {
+        if (isGatewayStopHookRegistration(registration)) {
+          continue;
+        }
+        registerJsonRpcSurface(api, client, registration);
+      }
+      registerJsonRpcGatewayStopHook(api, client, gatewayStopHooks);
+    },
+  };
+}
+
+function registerJsonRpcSurface(
+  api: OpenClawPluginApi,
+  client: JsonRpcPluginClient,
+  registration: JsonRpcPluginRegistration,
+): void {
+  if (registration.type === "tool") {
+    registerJsonRpcTool(api, client, registration);
+    return;
+  }
+  if (registration.type === "hook") {
+    registerJsonRpcHook(api, client, registration);
+    return;
+  }
+  if (registration.type === "httpRoute") {
+    registerJsonRpcHttpRoute(api, client, registration);
+    return;
+  }
+  registerJsonRpcGatewayMethod(api, client, registration);
+}
+
+function isGatewayStopHookRegistration(
+  registration: JsonRpcPluginRegistration,
+): registration is JsonRpcPluginHookRegistration {
+  return registration.type === "hook" && registration.hook === "gateway_stop";
+}
+
+function registerJsonRpcTool(
+  api: OpenClawPluginApi,
+  client: JsonRpcPluginClient,
+  registration: JsonRpcPluginToolRegistration,
+): void {
+  const tool: AnyAgentTool = {
+    name: registration.name,
+    label: registration.name,
+    description: registration.description,
+    parameters: registration.parameters ?? EMPTY_OBJECT_SCHEMA,
+    ...(registration.displaySummary ? { displaySummary: registration.displaySummary } : {}),
+    async execute(toolCallId, params, signal) {
+      return (await client.request(
+        registration.method ?? DEFAULT_TOOL_METHOD,
+        {
+          tool: {
+            name: registration.name,
+          },
+          toolCallId,
+          params: toJsonRpcValue(params),
+        },
+        { timeoutMs: registration.timeoutMs, signal },
+      )) as Awaited<ReturnType<AnyAgentTool["execute"]>>;
+    },
+  };
+  api.registerTool(tool);
+}
+
+function registerJsonRpcHook(
+  api: OpenClawPluginApi,
+  client: JsonRpcPluginClient,
+  registration: JsonRpcPluginHookRegistration,
+): void {
+  if (!isPluginHookName(registration.hook)) {
+    throw new Error(`unknown JSON-RPC plugin hook: ${registration.hook}`);
+  }
+  api.on(
+    registration.hook,
+    (async (event: unknown, context: unknown) => {
+      return await dispatchJsonRpcHook(client, registration, event, context);
+    }) as Parameters<OpenClawPluginApi["on"]>[1],
+    registration.options,
+  );
+}
+
+function registerJsonRpcGatewayStopHook(
+  api: OpenClawPluginApi,
+  client: JsonRpcPluginClient,
+  registrations: readonly JsonRpcPluginHookRegistration[],
+): void {
+  if (registrations.length === 0) {
+    api.on("gateway_stop", () => client.dispose());
+    return;
+  }
+  const handler: PluginHookHandlerMap["gateway_stop"] = async (event, context) => {
+    try {
+      let result: unknown;
+      for (const registration of registrations) {
+        result = await dispatchJsonRpcHook(client, registration, event, context);
+      }
+      return result as void;
+    } finally {
+      await client.dispose();
+    }
+  };
+  api.on("gateway_stop", handler, registrations[0]?.options);
+}
+
+function dispatchJsonRpcHook(
+  client: JsonRpcPluginClient,
+  registration: JsonRpcPluginHookRegistration,
+  event: unknown,
+  context: unknown,
+): Promise<unknown> {
+  return client.request(
+    registration.method ?? DEFAULT_HOOK_METHOD,
+    {
+      hook: {
+        name: registration.hook,
+      },
+      event: toJsonRpcValue(event),
+      context: toJsonRpcValue(context),
+    },
+    { timeoutMs: registration.timeoutMs },
+  );
+}
+
+function registerJsonRpcHttpRoute(
+  api: OpenClawPluginApi,
+  client: JsonRpcPluginClient,
+  registration: JsonRpcPluginHttpRouteRegistration,
+): void {
+  api.registerHttpRoute({
+    path: registration.path,
+    auth: registration.auth,
+    handler: async (req, res) => {
+      const body = await readRequestBody(
+        req,
+        registration.maxBodyBytes ?? DEFAULT_HTTP_BODY_LIMIT_BYTES,
+      );
+      const result = await client.request(
+        registration.method ?? DEFAULT_HTTP_METHOD,
+        {
+          route: {
+            path: registration.path,
+            auth: registration.auth,
+          },
+          request: {
+            method: req.method ?? "GET",
+            url: req.url ?? "/",
+            headers: normalizeHeaders(req.headers),
+            bodyBase64: body.toString("base64"),
+          },
+        },
+        { timeoutMs: registration.timeoutMs },
+      );
+      writeJsonRpcHttpResponse(res, result);
+      return true;
+    },
+    ...(registration.match ? { match: registration.match } : {}),
+    ...(registration.gatewayRuntimeScopeSurface
+      ? { gatewayRuntimeScopeSurface: registration.gatewayRuntimeScopeSurface }
+      : {}),
+    ...(registration.nodeCapability ? { nodeCapability: registration.nodeCapability } : {}),
+    ...(registration.replaceExisting !== undefined
+      ? { replaceExisting: registration.replaceExisting }
+      : {}),
+  });
+}
+
+function registerJsonRpcGatewayMethod(
+  api: OpenClawPluginApi,
+  client: JsonRpcPluginClient,
+  registration: JsonRpcPluginGatewayMethodRegistration,
+): void {
+  api.registerGatewayMethod(
+    registration.method,
+    async ({ req, params, client: gatewayClient, respond }) => {
+      const result = await client.request(
+        registration.rpcMethod ?? DEFAULT_GATEWAY_METHOD,
+        {
+          method: registration.method,
+          request: {
+            id: req.id,
+            method: req.method,
+          },
+          params: toJsonRpcValue(params),
+          client: gatewayClient
+            ? {
+                connId: gatewayClient.connId,
+                clientIp: gatewayClient.clientIp,
+                scopes: gatewayClient.connect?.scopes,
+              }
+            : null,
+        },
+        { timeoutMs: registration.timeoutMs },
+      );
+      respondWithJsonRpcGatewayResult(respond, result);
+    },
+    registration.scope ? { scope: registration.scope } : undefined,
+  );
+}
+
+class JsonRpcPluginClient {
+  private child: ChildProcessWithoutNullStreams | undefined;
+  private lines: ReadlineInterface | undefined;
+  private nextId = 1;
+  private pending = new Map<number, PendingRequest>();
+  private initializing: Promise<unknown> | undefined;
+  private disposed = false;
+
+  constructor(
+    private readonly api: OpenClawPluginApi,
+    private readonly options: JsonRpcPluginProcessOptions,
+  ) {}
+
+  async request(
+    method: string,
+    params: unknown,
+    options: { timeoutMs?: number; signal?: AbortSignal } = {},
+  ): Promise<unknown> {
+    rejectIfAborted(options.signal);
+    await waitForAbortable(this.ensureInitialized(), options.signal);
+    return this.requestRaw(method, params, options);
+  }
+
+  async dispose(): Promise<void> {
+    this.disposed = true;
+    await this.stop();
+  }
+
+  async stop(): Promise<void> {
+    this.lines?.close();
+    this.lines = undefined;
+    for (const [, pending] of this.pending) {
+      clearTimeout(pending.timeout);
+      pending.reject(new Error("JSON-RPC plugin process was disposed"));
+    }
+    this.pending.clear();
+    const child = this.child;
+    this.child = undefined;
+    this.initializing = undefined;
+    await stopJsonRpcChild(child);
+  }
+
+  private async ensureInitialized(): Promise<void> {
+    this.ensureStarted();
+    if (!this.initializing) {
+      const initialization = this.requestRaw(
+        "openclaw.initialize",
+        {
+          plugin: {
+            id: this.api.id,
+            name: this.api.name,
+            version: this.api.version,
+            description: this.api.description,
+            source: this.api.source,
+            rootDir: this.api.rootDir,
+            registrationMode: this.api.registrationMode,
+          },
+          pluginConfig: toJsonRpcValue(this.api.pluginConfig ?? {}),
+        },
+        {
+          timeoutMs: this.options.initializationTimeoutMs ?? DEFAULT_INITIALIZATION_TIMEOUT_MS,
+        },
+      ).catch(async (error: unknown) => {
+        if (this.initializing === initialization) {
+          this.initializing = undefined;
+        }
+        await this.stop();
+        throw error;
+      });
+      this.initializing = initialization;
+    }
+    await this.initializing;
+  }
+
+  private ensureStarted(): void {
+    if (this.disposed) {
+      throw new Error("JSON-RPC plugin process was disposed");
+    }
+    if (this.child) {
+      return;
+    }
+    const env =
+      this.options.inheritEnv === false
+        ? { ...this.options.env }
+        : {
+            ...process.env,
+            ...this.options.env,
+          };
+    const spawnInvocation = resolveJsonRpcSpawnInvocation({
+      command: resolveJsonRpcProcessCommand(this.api, this.options.command),
+      args: [...(this.options.args ?? [])],
+      env,
+    });
+    const cwd = this.options.cwd ? this.api.resolvePath(this.options.cwd) : this.api.rootDir;
+    const child = spawn(spawnInvocation.command, spawnInvocation.argv, {
+      cwd,
+      detached: process.platform !== "win32",
+      env,
+      shell: spawnInvocation.shell,
+      stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: spawnInvocation.windowsHide,
+    });
+    this.child = child;
+    this.lines = createInterface({ input: child.stdout });
+    this.lines.on("line", (line) => this.handleLine(line));
+    child.once("error", (error) => {
+      if (this.child === child) {
+        this.failAll(error);
+      }
+    });
+    child.once("close", (code, signal) => {
+      if (this.child !== child) {
+        return;
+      }
+      const label = signal ? `signal ${signal}` : `exit code ${code ?? "unknown"}`;
+      this.failAll(new Error(`JSON-RPC plugin process closed with ${label}`));
+      this.child = undefined;
+      this.lines?.close();
+      this.lines = undefined;
+      this.initializing = undefined;
+    });
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk) => {
+      if (this.options.logStderr === false) {
+        return;
+      }
+      const message = String(chunk).trim();
+      if (message) {
+        this.api.logger.warn(`[${this.api.id}] ${message}`);
+      }
+    });
+  }
+
+  private requestRaw(
+    method: string,
+    params: unknown,
+    options: { timeoutMs?: number; signal?: AbortSignal } = {},
+  ): Promise<unknown> {
+    rejectIfAborted(options.signal);
+    this.ensureStarted();
+    const child = this.child;
+    if (!child) {
+      return Promise.reject(new Error("JSON-RPC plugin process is not running"));
+    }
+    const id = this.nextId++;
+    const timeoutMs = options.timeoutMs ?? this.options.timeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`JSON-RPC plugin request timed out: ${method}`));
+      }, timeoutMs);
+      const abort = () => {
+        clearTimeout(timeout);
+        this.pending.delete(id);
+        reject(new Error(`JSON-RPC plugin request aborted: ${method}`));
+      };
+      options.signal?.addEventListener("abort", abort, { once: true });
+      this.pending.set(id, {
+        resolve: (value) => {
+          options.signal?.removeEventListener("abort", abort);
+          resolve(value);
+        },
+        reject: (error) => {
+          options.signal?.removeEventListener("abort", abort);
+          reject(error);
+        },
+        timeout,
+      });
+      child.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", id, method, params })}\n`, (error) => {
+        if (!error) {
+          return;
+        }
+        const pending = this.pending.get(id);
+        if (!pending) {
+          return;
+        }
+        clearTimeout(pending.timeout);
+        this.pending.delete(id);
+        pending.reject(error);
+      });
+    });
+  }
+
+  private handleLine(line: string): void {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      return;
+    }
+    let response: JsonRpcResponse;
+    try {
+      response = JSON.parse(trimmed) as JsonRpcResponse;
+    } catch {
+      this.api.logger.warn(`Ignoring invalid JSON-RPC response from plugin ${this.api.id}`);
+      return;
+    }
+    if (typeof response.id !== "number") {
+      return;
+    }
+    const pending = this.pending.get(response.id);
+    if (!pending) {
+      return;
+    }
+    clearTimeout(pending.timeout);
+    this.pending.delete(response.id);
+    if (response.error) {
+      pending.reject(new Error(response.error.message ?? "JSON-RPC plugin request failed"));
+      return;
+    }
+    pending.resolve(response.result);
+  }
+
+  private failAll(error: Error): void {
+    for (const [, pending] of this.pending) {
+      clearTimeout(pending.timeout);
+      pending.reject(error);
+    }
+    this.pending.clear();
+  }
+}
+
+function resolveJsonRpcSpawnInvocation(params: {
+  command: string;
+  args: string[];
+  env: NodeJS.ProcessEnv;
+}): {
+  command: string;
+  argv: string[];
+  shell?: boolean;
+  windowsHide?: boolean;
+} {
+  const program = resolveWindowsSpawnProgram({
+    command: params.command,
+    platform: process.platform,
+    env: params.env,
+    execPath: process.execPath,
+    allowShellFallback: false,
+  });
+  return materializeWindowsSpawnProgram(program, params.args);
+}
+
+function resolveJsonRpcProcessCommand(api: OpenClawPluginApi, command: string): string {
+  if (path.isAbsolute(command)) {
+    return command;
+  }
+  if (!command.includes("/") && !command.includes("\\")) {
+    return command;
+  }
+  return api.resolvePath(command);
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms).unref();
+  });
+}
+
+function hasChildExited(child: ChildProcessWithoutNullStreams): boolean {
+  return child.exitCode !== null || child.signalCode !== null;
+}
+
+function rejectIfAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) {
+    throw new Error("JSON-RPC plugin request aborted");
+  }
+}
+
+function waitForAbortable<T>(promise: Promise<T>, signal: AbortSignal | undefined): Promise<T> {
+  rejectIfAborted(signal);
+  if (!signal) {
+    return promise;
+  }
+  return new Promise<T>((resolve, reject) => {
+    const cleanup = () => signal.removeEventListener("abort", handleAbort);
+    const handleAbort = () => {
+      cleanup();
+      reject(new Error("JSON-RPC plugin request aborted"));
+    };
+    signal.addEventListener("abort", handleAbort, { once: true });
+    promise.then(
+      (value) => {
+        cleanup();
+        resolve(value);
+      },
+      (error: unknown) => {
+        cleanup();
+        reject(error instanceof Error ? error : new Error(String(error)));
+      },
+    );
+  });
+}
+
+async function stopJsonRpcChild(child: ChildProcessWithoutNullStreams | undefined): Promise<void> {
+  if (!child || hasChildExited(child)) {
+    return;
+  }
+  const closePromise = new Promise<void>((resolve) => {
+    child.once("close", () => resolve());
+  });
+  try {
+    child.stdin.end();
+  } catch {
+    // best-effort
+  }
+  await Promise.race([closePromise, delay(PROCESS_CLOSE_TIMEOUT_MS)]);
+  if (hasChildExited(child) || !child.pid) {
+    return;
+  }
+  killProcessTree(child.pid, { graceMs: PROCESS_TREE_KILL_GRACE_MS });
+  await Promise.race([closePromise, delay(PROCESS_CLOSE_TIMEOUT_MS)]);
+  if (hasChildExited(child) || !child.pid) {
+    return;
+  }
+  signalProcessTree(child.pid, "SIGKILL");
+  await Promise.race([closePromise, delay(SIGKILL_REAP_TIMEOUT_MS)]);
+}
+
+function toJsonRpcValue(value: unknown): JsonRpcPluginJsonValue {
+  // oxlint-disable-next-line unicorn/prefer-structured-clone -- JSON-RPC params must be JSON-serialized, not cloned with Date/Map/object prototypes intact.
+  return JSON.parse(JSON.stringify(value ?? null)) as JsonRpcPluginJsonValue;
+}
+
+function normalizeHeaders(headers: IncomingMessage["headers"]): JsonRpcPluginJsonObject {
+  const normalized: JsonRpcPluginJsonObject = {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (typeof value === "string") {
+      normalized[key] = value;
+    } else if (Array.isArray(value)) {
+      normalized[key] = value;
+    }
+  }
+  return normalized;
+}
+
+async function readRequestBody(req: IncomingMessage, maxBytes: number): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  let totalBytes = 0;
+  for await (const chunk of req as Readable) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    totalBytes += buffer.length;
+    if (totalBytes > maxBytes) {
+      throw new Error(`JSON-RPC plugin HTTP request body exceeded ${maxBytes} bytes`);
+    }
+    chunks.push(buffer);
+  }
+  return Buffer.concat(chunks);
+}
+
+function writeJsonRpcHttpResponse(res: ServerResponse, result: unknown): void {
+  if (!isRecord(result)) {
+    res.statusCode = 502;
+    res.end("JSON-RPC plugin returned an invalid HTTP response");
+    return;
+  }
+  const status = typeof result.status === "number" ? result.status : 200;
+  res.statusCode = status;
+  if (isRecord(result.headers)) {
+    for (const [key, value] of Object.entries(result.headers)) {
+      if (typeof value === "string" || Array.isArray(value)) {
+        res.setHeader(key, value);
+      }
+    }
+  }
+  if (typeof result.bodyBase64 === "string") {
+    res.end(Buffer.from(result.bodyBase64, "base64"));
+    return;
+  }
+  res.end(typeof result.bodyText === "string" ? result.bodyText : "");
+}
+
+function respondWithJsonRpcGatewayResult(respond: RespondFn, result: unknown): void {
+  if (isRecord(result) && typeof result.ok === "boolean") {
+    respond(
+      result.ok,
+      result.payload,
+      toGatewayError(result.error),
+      isRecord(result.meta) ? result.meta : undefined,
+    );
+    return;
+  }
+  respond(true, result);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function toGatewayError(error: unknown): ErrorShape | undefined {
+  if (!isRecord(error)) {
+    return undefined;
+  }
+  const message = typeof error.message === "string" ? error.message : "Plugin request failed";
+  const code = typeof error.code === "string" ? error.code : "plugin_error";
+  return {
+    code,
+    message,
+    ...(error.details !== undefined ? { details: toJsonRpcValue(error.details) } : {}),
+  };
+}

--- a/src/plugins/json-rpc-manifest-runtime.ts
+++ b/src/plugins/json-rpc-manifest-runtime.ts
@@ -4,7 +4,6 @@ import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import type { IncomingMessage } from "node:http";
 import type { ServerResponse } from "node:http";
 import path from "node:path";
-import { createInterface, type Interface as ReadlineInterface } from "node:readline";
 import type { Readable } from "node:stream";
 import type { ErrorShape } from "../../packages/gateway-protocol/src/index.js";
 import type { RespondFn } from "../gateway/server-methods/types.js";
@@ -14,6 +13,11 @@ import {
 } from "../plugin-sdk/windows-spawn.js";
 import { killProcessTree, signalProcessTree } from "../process/kill-tree.js";
 import { isPluginHookName, type PluginHookHandlerMap } from "./hook-types.js";
+import { JsonRpcPeer } from "./json-rpc-peer.js";
+import {
+  JSON_RPC_PLUGIN_PROTOCOL_VERSION,
+  JsonRpcPluginProtocol,
+} from "./json-rpc-plugin-protocol.js";
 import type { PluginManifestJsonRpc, PluginManifestJsonRpcRegistration } from "./manifest.js";
 import type {
   AnyAgentTool,
@@ -42,6 +46,7 @@ export type JsonRpcPluginGatewayMethodRegistration = Extract<
   JsonRpcPluginRegistration,
   { type: "gatewayMethod" }
 >;
+export type JsonRpcPluginApiRegistration = Extract<JsonRpcPluginRegistration, { type: "api" }>;
 
 export type JsonRpcManifestPluginOptions = {
   id: string;
@@ -49,29 +54,16 @@ export type JsonRpcManifestPluginOptions = {
   description: string;
   kind?: OpenClawPluginDefinition["kind"];
   configSchema?: OpenClawPluginConfigSchema;
+  protocolVersion: PluginManifestJsonRpc["protocolVersion"];
   process: JsonRpcPluginProcessOptions;
+  permissions?: PluginManifestJsonRpc["permissions"];
   registrations: readonly JsonRpcPluginRegistration[];
-};
-
-type PendingRequest = {
-  resolve: (value: unknown) => void;
-  reject: (error: Error) => void;
-  timeout: NodeJS.Timeout;
-};
-
-type JsonRpcResponse = {
-  jsonrpc?: "2.0";
-  id?: unknown;
-  result?: unknown;
-  error?: {
-    code?: number | string;
-    message?: string;
-    data?: unknown;
-  };
 };
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
 const DEFAULT_INITIALIZATION_TIMEOUT_MS = 10_000;
+const DEFAULT_MAX_FRAME_BYTES = 8 * 1024 * 1024;
+const DEFAULT_MAX_PENDING_REQUESTS = 256;
 const DEFAULT_HTTP_BODY_LIMIT_BYTES = 1024 * 1024;
 const PROCESS_CLOSE_TIMEOUT_MS = 2_000;
 const PROCESS_TREE_KILL_GRACE_MS = 500;
@@ -84,6 +76,27 @@ const EMPTY_OBJECT_SCHEMA = {
   type: "object",
   additionalProperties: false,
 } as const satisfies JsonRpcPluginJsonObject;
+const JSON_RPC_API_CALLBACK_PATHS = new Map<keyof OpenClawPluginApi, ReadonlySet<string>>([
+  ["registerAgentEventSubscription", new Set(["0.handle"])],
+  ["registerAgentToolResultMiddleware", new Set(["0"])],
+  ["registerCommand", new Set(["0.handler"])],
+  ["registerCompactionProvider", new Set(["0.summarize"])],
+  ["registerControlUiDescriptor", new Set()],
+  ["registerGatewayDiscoveryService", new Set(["0.advertise"])],
+  ["registerHostedMediaResolver", new Set(["0"])],
+  ["registerInteractiveHandler", new Set(["0.handler"])],
+  ["registerNodeHostCommand", new Set(["0.handle"])],
+  ["registerNodeInvokePolicy", new Set(["0.handle"])],
+  ["registerReload", new Set()],
+  ["registerRuntimeLifecycle", new Set(["0.cleanup"])],
+  ["registerService", new Set(["0.start", "0.stop"])],
+  ["registerSessionAction", new Set(["0.handler"])],
+  ["registerSessionExtension", new Set()],
+  ["registerSessionSchedulerJob", new Set()],
+  ["registerTool", new Set(["0.execute"])],
+  ["registerToolMetadata", new Set()],
+  ["onConversationBindingResolved", new Set(["0"])],
+]);
 
 export function createJsonRpcManifestPluginDefinition(
   options: JsonRpcManifestPluginOptions,
@@ -95,7 +108,19 @@ export function createJsonRpcManifestPluginDefinition(
     ...(options.kind ? { kind: options.kind } : {}),
     ...(options.configSchema ? { configSchema: options.configSchema } : {}),
     register(api) {
-      const client = new JsonRpcPluginClient(api, options.process);
+      if (options.protocolVersion !== JSON_RPC_PLUGIN_PROTOCOL_VERSION) {
+        throw new Error("unsupported JSON-RPC plugin protocol version");
+      }
+      const client = new JsonRpcPluginClient(api, options);
+      const gatewayStopHooks = options.registrations.filter(isGatewayStopHookRegistration);
+      for (const registration of options.registrations) {
+        if (isGatewayStopHookRegistration(registration)) {
+          continue;
+        }
+        registerJsonRpcSurface(api, client, registration);
+      }
+      registerJsonRpcGatewayStopHook(api, client, gatewayStopHooks);
+      // Remote cleanup must run before the transport that carries it is terminated.
       api.lifecycle.registerRuntimeLifecycle({
         id: `${options.id}.json-rpc-process`,
         description: "JSON-RPC child process owned by this plugin",
@@ -105,15 +130,6 @@ export function createJsonRpcManifestPluginDefinition(
           }
         },
       });
-
-      const gatewayStopHooks = options.registrations.filter(isGatewayStopHookRegistration);
-      for (const registration of options.registrations) {
-        if (isGatewayStopHookRegistration(registration)) {
-          continue;
-        }
-        registerJsonRpcSurface(api, client, registration);
-      }
-      registerJsonRpcGatewayStopHook(api, client, gatewayStopHooks);
     },
   };
 }
@@ -135,7 +151,64 @@ function registerJsonRpcSurface(
     registerJsonRpcHttpRoute(api, client, registration);
     return;
   }
-  registerJsonRpcGatewayMethod(api, client, registration);
+  if (registration.type === "gatewayMethod") {
+    registerJsonRpcGatewayMethod(api, client, registration);
+    return;
+  }
+  registerJsonRpcApi(api, client, registration);
+}
+
+function registerJsonRpcApi(
+  api: OpenClawPluginApi,
+  client: JsonRpcPluginClient,
+  registration: JsonRpcPluginApiRegistration,
+): void {
+  const methodName = registration.method as keyof OpenClawPluginApi;
+  const callbackPaths = JSON_RPC_API_CALLBACK_PATHS.get(methodName);
+  if (!callbackPaths) {
+    throw new Error(`unsupported JSON-RPC plugin registration method: ${registration.method}`);
+  }
+  validateJsonRpcCallbackPaths(registration.args, callbackPaths);
+  const method = api[methodName];
+  if (typeof method !== "function") {
+    throw new Error(`unknown JSON-RPC plugin registration method: ${registration.method}`);
+  }
+  Reflect.apply(
+    method,
+    api,
+    registration.args.map((arg) => client.materialize(arg)),
+  );
+}
+
+function validateJsonRpcCallbackPaths(value: unknown, allowed: ReadonlySet<string>): void {
+  const visit = (current: unknown, valuePath: string): void => {
+    if (Array.isArray(current)) {
+      current.forEach((entry, index) =>
+        visit(entry, valuePath ? `${valuePath}.${index}` : String(index)),
+      );
+      return;
+    }
+    if (!isRecord(current)) {
+      return;
+    }
+    for (const marker of ["$callback", "$stream", "$abortSignal", "$bytes"] as const) {
+      if (marker in current) {
+        throw new Error(`JSON-RPC wire marker is not allowed in registration arguments: ${marker}`);
+      }
+    }
+    if (typeof current.$rpc === "string") {
+      if (!allowed.has(valuePath)) {
+        throw new Error(
+          `JSON-RPC callback is not supported at registration argument path: ${valuePath}`,
+        );
+      }
+      return;
+    }
+    for (const [key, entry] of Object.entries(current)) {
+      visit(entry, valuePath ? `${valuePath}.${key}` : key);
+    }
+  };
+  visit(value, "");
 }
 
 function isGatewayStopHookRegistration(
@@ -155,7 +228,7 @@ function registerJsonRpcTool(
     description: registration.description,
     parameters: registration.parameters ?? EMPTY_OBJECT_SCHEMA,
     ...(registration.displaySummary ? { displaySummary: registration.displaySummary } : {}),
-    async execute(toolCallId, params, signal) {
+    async execute(toolCallId, params, signal, onUpdate) {
       return (await client.request(
         registration.method ?? DEFAULT_TOOL_METHOD,
         {
@@ -164,6 +237,7 @@ function registerJsonRpcTool(
           },
           toolCallId,
           params: toJsonRpcValue(params),
+          ...(onUpdate ? { onUpdate } : {}),
         },
         { timeoutMs: registration.timeoutMs, signal },
       )) as Awaited<ReturnType<AnyAgentTool["execute"]>>;
@@ -180,11 +254,19 @@ function registerJsonRpcHook(
   if (!isPluginHookName(registration.hook)) {
     throw new Error(`unknown JSON-RPC plugin hook: ${registration.hook}`);
   }
-  api.on(
+  if (registration.hook === "tool_result_persist" || registration.hook === "before_message_write") {
+    throw new Error(`JSON-RPC plugins cannot register synchronous hook: ${registration.hook}`);
+  }
+  const registerAsyncHook = api.on as (
+    hookName: string,
+    handler: (event: unknown, context: unknown) => Promise<unknown>,
+    options?: { priority?: number; timeoutMs?: number },
+  ) => void;
+  registerAsyncHook(
     registration.hook,
-    (async (event: unknown, context: unknown) => {
+    async (event: unknown, context: unknown) => {
       return await dispatchJsonRpcHook(client, registration, event, context);
-    }) as Parameters<OpenClawPluginApi["on"]>[1],
+    },
     registration.options,
   );
 }
@@ -309,16 +391,27 @@ function registerJsonRpcGatewayMethod(
 
 class JsonRpcPluginClient {
   private child: ChildProcessWithoutNullStreams | undefined;
-  private lines: ReadlineInterface | undefined;
-  private nextId = 1;
-  private pending = new Map<number, PendingRequest>();
+  private stdoutBuffer = Buffer.alloc(0);
+  private peer: JsonRpcPeer | undefined;
+  private protocol: JsonRpcPluginProtocol;
   private initializing: Promise<unknown> | undefined;
   private disposed = false;
 
   constructor(
     private readonly api: OpenClawPluginApi,
-    private readonly options: JsonRpcPluginProcessOptions,
-  ) {}
+    private readonly manifestOptions: JsonRpcManifestPluginOptions,
+  ) {
+    this.protocol = new JsonRpcPluginProtocol(
+      api,
+      new Set(manifestOptions.permissions?.host ?? []),
+      () => this.requirePeer(),
+      (method, params, options) => this.request(method, params, options),
+    );
+  }
+
+  materialize(value: unknown): unknown {
+    return this.protocol.materialize(value);
+  }
 
   async request(
     method: string,
@@ -327,7 +420,9 @@ class JsonRpcPluginClient {
   ): Promise<unknown> {
     rejectIfAborted(options.signal);
     await waitForAbortable(this.ensureInitialized(), options.signal);
-    return this.requestRaw(method, params, options);
+    return this.protocol.materialize(
+      await this.requirePeer().request(method, this.protocol.serialize(params), options),
+    );
   }
 
   async dispose(): Promise<void> {
@@ -336,13 +431,10 @@ class JsonRpcPluginClient {
   }
 
   async stop(): Promise<void> {
-    this.lines?.close();
-    this.lines = undefined;
-    for (const [, pending] of this.pending) {
-      clearTimeout(pending.timeout);
-      pending.reject(new Error("JSON-RPC plugin process was disposed"));
-    }
-    this.pending.clear();
+    this.peer?.close(new Error("JSON-RPC plugin process was disposed"));
+    this.peer = undefined;
+    this.protocol.dispose(new Error("JSON-RPC plugin process was disposed"));
+    this.stdoutBuffer = Buffer.alloc(0);
     const child = this.child;
     this.child = undefined;
     this.initializing = undefined;
@@ -365,17 +457,32 @@ class JsonRpcPluginClient {
             registrationMode: this.api.registrationMode,
           },
           pluginConfig: toJsonRpcValue(this.api.pluginConfig ?? {}),
+          protocol: {
+            version: this.manifestOptions.protocolVersion,
+            hostCapabilities: [...(this.manifestOptions.permissions?.host ?? [])],
+            features: ["bidirectional", "callbacks", "cancellation", "streams", "subscriptions"],
+          },
         },
         {
-          timeoutMs: this.options.initializationTimeoutMs ?? DEFAULT_INITIALIZATION_TIMEOUT_MS,
+          timeoutMs:
+            this.manifestOptions.process.initializationTimeoutMs ??
+            DEFAULT_INITIALIZATION_TIMEOUT_MS,
         },
-      ).catch(async (error: unknown) => {
-        if (this.initializing === initialization) {
-          this.initializing = undefined;
-        }
-        await this.stop();
-        throw error;
-      });
+      )
+        .then((result) => {
+          if (!isRecord(result) || result.protocolVersion !== JSON_RPC_PLUGIN_PROTOCOL_VERSION) {
+            throw new Error(
+              "JSON-RPC plugin initialization did not acknowledge protocol version 1",
+            );
+          }
+        })
+        .catch(async (error: unknown) => {
+          if (this.initializing === initialization) {
+            this.initializing = undefined;
+          }
+          await this.stop();
+          throw error;
+        });
       this.initializing = initialization;
     }
     await this.initializing;
@@ -389,18 +496,20 @@ class JsonRpcPluginClient {
       return;
     }
     const env =
-      this.options.inheritEnv === false
-        ? { ...this.options.env }
-        : {
+      this.manifestOptions.process.inheritEnv === true
+        ? {
             ...process.env,
-            ...this.options.env,
-          };
+            ...this.manifestOptions.process.env,
+          }
+        : { ...this.manifestOptions.process.env };
     const spawnInvocation = resolveJsonRpcSpawnInvocation({
-      command: resolveJsonRpcProcessCommand(this.api, this.options.command),
-      args: [...(this.options.args ?? [])],
+      command: resolveJsonRpcProcessCommand(this.api, this.manifestOptions.process.command),
+      args: [...(this.manifestOptions.process.args ?? [])],
       env,
     });
-    const cwd = this.options.cwd ? this.api.resolvePath(this.options.cwd) : this.api.rootDir;
+    const cwd = this.manifestOptions.process.cwd
+      ? this.api.resolvePath(this.manifestOptions.process.cwd)
+      : this.api.rootDir;
     const child = spawn(spawnInvocation.command, spawnInvocation.argv, {
       cwd,
       detached: process.platform !== "win32",
@@ -410,11 +519,19 @@ class JsonRpcPluginClient {
       windowsHide: spawnInvocation.windowsHide,
     });
     this.child = child;
-    this.lines = createInterface({ input: child.stdout });
-    this.lines.on("line", (line) => this.handleLine(line));
+    this.peer = new JsonRpcPeer({
+      write: child.stdin,
+      requestTimeoutMs: this.manifestOptions.process.timeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
+      maxPendingRequests:
+        this.manifestOptions.process.maxPendingRequests ?? DEFAULT_MAX_PENDING_REQUESTS,
+      requestHandlers: this.protocol.requestHandlers,
+      notificationHandlers: this.protocol.notificationHandlers,
+      onProtocolError: (message) => this.api.logger.warn(`[${this.api.id}] ${message}`),
+    });
+    child.stdout.on("data", (chunk: Buffer | string) => this.handleStdoutChunk(chunk));
     child.once("error", (error) => {
       if (this.child === child) {
-        this.failAll(error);
+        this.peer?.close(error);
       }
     });
     child.once("close", (code, signal) => {
@@ -422,15 +539,16 @@ class JsonRpcPluginClient {
         return;
       }
       const label = signal ? `signal ${signal}` : `exit code ${code ?? "unknown"}`;
-      this.failAll(new Error(`JSON-RPC plugin process closed with ${label}`));
+      this.peer?.close(new Error(`JSON-RPC plugin process closed with ${label}`));
+      this.protocol.dispose(new Error(`JSON-RPC plugin process closed with ${label}`));
       this.child = undefined;
-      this.lines?.close();
-      this.lines = undefined;
+      this.peer = undefined;
+      this.stdoutBuffer = Buffer.alloc(0);
       this.initializing = undefined;
     });
     child.stderr.setEncoding("utf8");
     child.stderr.on("data", (chunk) => {
-      if (this.options.logStderr === false) {
+      if (this.manifestOptions.process.logStderr === false) {
         return;
       }
       const message = String(chunk).trim();
@@ -445,85 +563,61 @@ class JsonRpcPluginClient {
     params: unknown,
     options: { timeoutMs?: number; signal?: AbortSignal } = {},
   ): Promise<unknown> {
-    rejectIfAborted(options.signal);
     this.ensureStarted();
-    const child = this.child;
-    if (!child) {
-      return Promise.reject(new Error("JSON-RPC plugin process is not running"));
-    }
-    const id = this.nextId++;
-    const timeoutMs = options.timeoutMs ?? this.options.timeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
-    return new Promise((resolve, reject) => {
-      const timeout = setTimeout(() => {
-        this.pending.delete(id);
-        reject(new Error(`JSON-RPC plugin request timed out: ${method}`));
-      }, timeoutMs);
-      const abort = () => {
-        clearTimeout(timeout);
-        this.pending.delete(id);
-        reject(new Error(`JSON-RPC plugin request aborted: ${method}`));
-      };
-      options.signal?.addEventListener("abort", abort, { once: true });
-      this.pending.set(id, {
-        resolve: (value) => {
-          options.signal?.removeEventListener("abort", abort);
-          resolve(value);
-        },
-        reject: (error) => {
-          options.signal?.removeEventListener("abort", abort);
-          reject(error);
-        },
-        timeout,
-      });
-      child.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", id, method, params })}\n`, (error) => {
-        if (!error) {
-          return;
-        }
-        const pending = this.pending.get(id);
-        if (!pending) {
-          return;
-        }
-        clearTimeout(pending.timeout);
-        this.pending.delete(id);
-        pending.reject(error);
-      });
-    });
+    return this.requirePeer().request(method, this.protocol.serialize(params), options);
   }
 
-  private handleLine(line: string): void {
-    const trimmed = line.trim();
+  private handleStdoutChunk(chunk: Buffer | string): void {
+    let remaining = typeof chunk === "string" ? Buffer.from(chunk) : chunk;
+    const maxFrameBytes = this.manifestOptions.process.maxFrameBytes ?? DEFAULT_MAX_FRAME_BYTES;
+    while (true) {
+      const newlineIndex = remaining.indexOf(0x0a);
+      if (newlineIndex === -1) {
+        if (this.stdoutBuffer.length + remaining.length > maxFrameBytes) {
+          this.rejectOversizedFrame();
+          return;
+        }
+        this.stdoutBuffer = Buffer.concat([this.stdoutBuffer, remaining]);
+        return;
+      }
+      const frameTail = remaining.subarray(0, newlineIndex);
+      if (this.stdoutBuffer.length + frameTail.length > maxFrameBytes) {
+        this.rejectOversizedFrame();
+        return;
+      }
+      const frame = Buffer.concat([this.stdoutBuffer, frameTail]);
+      this.stdoutBuffer = Buffer.alloc(0);
+      this.handleFrame(frame);
+      remaining = remaining.subarray(newlineIndex + 1);
+    }
+  }
+
+  private rejectOversizedFrame(): void {
+    this.stdoutBuffer = Buffer.alloc(0);
+    this.api.logger.warn(`JSON-RPC plugin ${this.api.id} exceeded the frame size limit`);
+    void this.stop();
+  }
+
+  private handleFrame(frame: Buffer): void {
+    const trimmed = frame.toString("utf8").trim();
     if (!trimmed) {
       return;
     }
-    let response: JsonRpcResponse;
+    let message: unknown;
     try {
-      response = JSON.parse(trimmed) as JsonRpcResponse;
+      message = JSON.parse(trimmed) as unknown;
     } catch {
-      this.api.logger.warn(`Ignoring invalid JSON-RPC response from plugin ${this.api.id}`);
+      this.api.logger.warn(`Ignoring invalid JSON-RPC message from plugin ${this.api.id}`);
       return;
     }
-    if (typeof response.id !== "number") {
-      return;
-    }
-    const pending = this.pending.get(response.id);
-    if (!pending) {
-      return;
-    }
-    clearTimeout(pending.timeout);
-    this.pending.delete(response.id);
-    if (response.error) {
-      pending.reject(new Error(response.error.message ?? "JSON-RPC plugin request failed"));
-      return;
-    }
-    pending.resolve(response.result);
+    this.peer?.handle(message);
   }
 
-  private failAll(error: Error): void {
-    for (const [, pending] of this.pending) {
-      clearTimeout(pending.timeout);
-      pending.reject(error);
+  private requirePeer(): JsonRpcPeer {
+    if (!this.peer) {
+      throw new Error("JSON-RPC plugin process is not running");
     }
-    this.pending.clear();
+    return this.peer;
   }
 }
 

--- a/src/plugins/json-rpc-peer.test.ts
+++ b/src/plugins/json-rpc-peer.test.ts
@@ -1,0 +1,143 @@
+import { PassThrough } from "node:stream";
+import { describe, expect, it, vi } from "vitest";
+import { JsonRpcPeer } from "./json-rpc-peer.js";
+
+describe("JsonRpcPeer", () => {
+  it("handles bidirectional requests and notifications", async () => {
+    const output = new PassThrough();
+    const written: string[] = [];
+    output.setEncoding("utf8");
+    output.on("data", (chunk) => written.push(String(chunk)));
+    const peer = new JsonRpcPeer({
+      write: output,
+      requestTimeoutMs: 1000,
+      maxPendingRequests: 4,
+      requestHandlers: new Map([["host.echo", async (params) => ({ params })]]),
+    });
+
+    peer.handle({ jsonrpc: "2.0", id: "child-1", method: "host.echo", params: { value: 1 } });
+    await vi.waitFor(() => expect(written.join("")).toContain('"id":"child-1"'));
+
+    const pending = peer.request("plugin.echo", { value: 2 });
+    peer.handle({ jsonrpc: "2.0", id: 1, result: { value: 2 } });
+    await expect(pending).resolves.toEqual({ value: 2 });
+  });
+
+  it("sends cancellation notifications", async () => {
+    const output = new PassThrough();
+    let written = "";
+    output.setEncoding("utf8");
+    output.on("data", (chunk) => (written += String(chunk)));
+    const peer = new JsonRpcPeer({
+      write: output,
+      requestTimeoutMs: 1000,
+      maxPendingRequests: 4,
+    });
+    const controller = new AbortController();
+    const pending = peer.request("plugin.slow", {}, { signal: controller.signal });
+
+    controller.abort();
+
+    await expect(pending).rejects.toThrow("aborted");
+    expect(written).toContain('"method":"$/cancelRequest"');
+  });
+
+  it("enforces the pending request limit", async () => {
+    const peer = new JsonRpcPeer({
+      write: new PassThrough(),
+      requestTimeoutMs: 1000,
+      maxPendingRequests: 1,
+    });
+    const first = peer.request("plugin.first");
+
+    await expect(peer.request("plugin.second")).rejects.toThrow("pending request limit");
+    peer.close(new Error("done"));
+    await expect(first).rejects.toThrow("done");
+  });
+
+  it("rejects duplicate and excess child requests", async () => {
+    const output = new PassThrough();
+    let written = "";
+    output.setEncoding("utf8");
+    output.on("data", (chunk) => (written += String(chunk)));
+    let release: (() => void) | undefined;
+    const peer = new JsonRpcPeer({
+      write: output,
+      requestTimeoutMs: 1000,
+      maxPendingRequests: 1,
+      requestHandlers: new Map([
+        [
+          "host.slow",
+          () =>
+            new Promise<void>((resolve) => {
+              release = resolve;
+            }),
+        ],
+      ]),
+    });
+
+    peer.handle({ jsonrpc: "2.0", id: "active", method: "host.slow" });
+    peer.handle({ jsonrpc: "2.0", id: "active", method: "host.slow" });
+    peer.handle({ jsonrpc: "2.0", id: "excess", method: "host.slow" });
+
+    await vi.waitFor(() => expect(written).toContain("Duplicate request id"));
+    expect(written).toContain("incoming request limit exceeded");
+    release?.();
+  });
+
+  it("drops late handler responses after close", async () => {
+    const output = new PassThrough();
+    let written = "";
+    output.setEncoding("utf8");
+    output.on("data", (chunk) => (written += String(chunk)));
+    let release: (() => void) | undefined;
+    const peer = new JsonRpcPeer({
+      write: output,
+      requestTimeoutMs: 1000,
+      maxPendingRequests: 1,
+      requestHandlers: new Map([
+        [
+          "host.slow",
+          () =>
+            new Promise<string>((resolve) => {
+              release = () => resolve("late");
+            }),
+        ],
+      ]),
+    });
+
+    peer.handle({ jsonrpc: "2.0", id: "late", method: "host.slow" });
+    peer.close(new Error("closed"));
+    release?.();
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+
+    expect(written).toBe("");
+  });
+
+  it("times out child requests and releases the incoming slot", async () => {
+    vi.useFakeTimers();
+    const output = new PassThrough();
+    let written = "";
+    output.setEncoding("utf8");
+    output.on("data", (chunk) => (written += String(chunk)));
+    const peer = new JsonRpcPeer({
+      write: output,
+      requestTimeoutMs: 10,
+      maxPendingRequests: 1,
+      requestHandlers: new Map(
+        ["host.slow"].map((method) => [method, () => new Promise(() => {})]),
+      ),
+    });
+
+    peer.handle({ jsonrpc: "2.0", id: "slow", method: "host.slow" });
+    await vi.advanceTimersByTimeAsync(10);
+    peer.handle({ jsonrpc: "2.0", id: "next", method: "host.slow" });
+
+    expect(written).toContain("request timed out");
+    expect(written).not.toContain("incoming request limit exceeded");
+    peer.close(new Error("done"));
+    vi.useRealTimers();
+  });
+});

--- a/src/plugins/json-rpc-peer.ts
+++ b/src/plugins/json-rpc-peer.ts
@@ -1,0 +1,327 @@
+import type { Writable } from "node:stream";
+
+export type JsonRpcId = number | string;
+export type JsonRpcRequestHandler = (params: unknown, signal: AbortSignal) => unknown;
+export type JsonRpcNotificationHandler = (params: unknown) => void | Promise<void>;
+
+type JsonRpcRequest = {
+  jsonrpc: "2.0";
+  id: JsonRpcId;
+  method: string;
+  params?: unknown;
+};
+
+type JsonRpcNotification = {
+  jsonrpc: "2.0";
+  method: string;
+  params?: unknown;
+};
+
+type JsonRpcResponse = {
+  jsonrpc: "2.0";
+  id: JsonRpcId;
+  result?: unknown;
+  error?: { code: number; message: string; data?: unknown };
+};
+
+type PendingRequest = {
+  resolve: (value: unknown) => void;
+  reject: (error: Error) => void;
+  timeout: NodeJS.Timeout;
+  signal?: AbortSignal;
+  abort?: () => void;
+};
+
+type IncomingRequest = {
+  controller: AbortController;
+  timeout: NodeJS.Timeout;
+};
+
+export type JsonRpcPeerOptions = {
+  write: Writable;
+  requestTimeoutMs: number;
+  maxPendingRequests: number;
+  requestHandlers?: ReadonlyMap<string, JsonRpcRequestHandler>;
+  notificationHandlers?: ReadonlyMap<string, JsonRpcNotificationHandler>;
+  onProtocolError?: (message: string) => void;
+};
+
+const JSON_RPC_METHOD_NOT_FOUND = -32601;
+const JSON_RPC_INVALID_REQUEST = -32600;
+const JSON_RPC_INTERNAL_ERROR = -32603;
+const JSON_RPC_SERVER_BUSY = -32000;
+const JSON_RPC_REQUEST_TIMEOUT = -32001;
+
+export class JsonRpcPeer {
+  private nextId = 1;
+  private readonly pending = new Map<JsonRpcId, PendingRequest>();
+  private readonly incoming = new Map<JsonRpcId, IncomingRequest>();
+  private closedError: Error | undefined;
+
+  constructor(private readonly options: JsonRpcPeerOptions) {
+    options.write.on("error", (error) => this.close(error));
+  }
+
+  request(
+    method: string,
+    params?: unknown,
+    options: { timeoutMs?: number; signal?: AbortSignal } = {},
+  ): Promise<unknown> {
+    if (this.closedError) {
+      return Promise.reject(this.closedError);
+    }
+    if (options.signal?.aborted) {
+      return Promise.reject(new Error(`JSON-RPC request aborted: ${method}`));
+    }
+    if (this.pending.size >= this.options.maxPendingRequests) {
+      return Promise.reject(new Error("JSON-RPC pending request limit exceeded"));
+    }
+
+    const id = this.nextId++;
+    const timeoutMs = options.timeoutMs ?? this.options.requestTimeoutMs;
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        const pending = this.pending.get(id);
+        this.pending.delete(id);
+        if (pending?.signal && pending.abort) {
+          pending.signal.removeEventListener("abort", pending.abort);
+        }
+        reject(new Error(`JSON-RPC request timed out: ${method}`));
+        this.notify("$/cancelRequest", { id });
+      }, timeoutMs);
+      const abort = options.signal
+        ? () => {
+            clearTimeout(timeout);
+            this.pending.delete(id);
+            reject(new Error(`JSON-RPC request aborted: ${method}`));
+            this.notify("$/cancelRequest", { id });
+          }
+        : undefined;
+      options.signal?.addEventListener("abort", abort!, { once: true });
+      this.pending.set(id, {
+        resolve,
+        reject,
+        timeout,
+        ...(options.signal ? { signal: options.signal } : {}),
+        ...(abort ? { abort } : {}),
+      });
+      try {
+        this.write(
+          { jsonrpc: "2.0", id, method, ...(params === undefined ? {} : { params }) },
+          (error) => {
+            if (!error || !this.pending.has(id)) {
+              return;
+            }
+            clearTimeout(timeout);
+            this.pending.delete(id);
+            if (options.signal && abort) {
+              options.signal.removeEventListener("abort", abort);
+            }
+            reject(error);
+          },
+        );
+      } catch (error) {
+        clearTimeout(timeout);
+        this.pending.delete(id);
+        if (options.signal && abort) {
+          options.signal.removeEventListener("abort", abort);
+        }
+        reject(error instanceof Error ? error : new Error(String(error)));
+      }
+    });
+  }
+
+  notify(method: string, params?: unknown): void {
+    if (this.closedError) {
+      return;
+    }
+    try {
+      this.write({ jsonrpc: "2.0", method, ...(params === undefined ? {} : { params }) });
+    } catch (error) {
+      this.options.onProtocolError?.(
+        `JSON-RPC notification write failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  notifyAsync(method: string, params?: unknown): Promise<void> {
+    if (this.closedError) {
+      return Promise.reject(this.closedError);
+    }
+    return new Promise((resolve, reject) => {
+      this.write(
+        { jsonrpc: "2.0", method, ...(params === undefined ? {} : { params }) },
+        (error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          if (this.closedError) {
+            reject(this.closedError);
+            return;
+          }
+          resolve();
+        },
+      );
+    });
+  }
+
+  handle(value: unknown): void {
+    if (!isRecord(value) || value.jsonrpc !== "2.0") {
+      this.options.onProtocolError?.("Ignoring invalid JSON-RPC message");
+      return;
+    }
+    if (isJsonRpcResponse(value)) {
+      this.handleResponse(value);
+      return;
+    }
+    if (isJsonRpcRequest(value)) {
+      void this.handleRequest(value);
+      return;
+    }
+    if (isJsonRpcNotification(value)) {
+      void this.handleNotification(value);
+      return;
+    }
+    this.options.onProtocolError?.("Ignoring unsupported JSON-RPC message");
+  }
+
+  close(error: Error): void {
+    if (this.closedError) {
+      return;
+    }
+    this.closedError = error;
+    for (const [, pending] of this.pending) {
+      clearTimeout(pending.timeout);
+      if (pending.signal && pending.abort) {
+        pending.signal.removeEventListener("abort", pending.abort);
+      }
+      pending.reject(error);
+    }
+    this.pending.clear();
+    for (const [, incoming] of this.incoming) {
+      clearTimeout(incoming.timeout);
+      incoming.controller.abort();
+    }
+    this.incoming.clear();
+  }
+
+  private handleResponse(response: JsonRpcResponse): void {
+    const pending = this.pending.get(response.id);
+    if (!pending) {
+      return;
+    }
+    clearTimeout(pending.timeout);
+    this.pending.delete(response.id);
+    if (pending.signal && pending.abort) {
+      pending.signal.removeEventListener("abort", pending.abort);
+    }
+    if (response.error) {
+      const error = new Error(response.error.message);
+      Object.assign(error, { code: response.error.code, data: response.error.data });
+      pending.reject(error);
+      return;
+    }
+    pending.resolve(response.result);
+  }
+
+  private async handleRequest(request: JsonRpcRequest): Promise<void> {
+    if (this.closedError) {
+      return;
+    }
+    if (this.incoming.has(request.id)) {
+      this.writeError(request.id, JSON_RPC_INVALID_REQUEST, `Duplicate request id: ${request.id}`);
+      return;
+    }
+    if (this.incoming.size >= this.options.maxPendingRequests) {
+      this.writeError(request.id, JSON_RPC_SERVER_BUSY, "JSON-RPC incoming request limit exceeded");
+      return;
+    }
+    const handler = this.options.requestHandlers?.get(request.method);
+    if (!handler) {
+      this.writeError(request.id, JSON_RPC_METHOD_NOT_FOUND, `Unknown method: ${request.method}`);
+      return;
+    }
+    const controller = new AbortController();
+    const timeout = setTimeout(() => {
+      const incoming = this.incoming.get(request.id);
+      if (incoming?.controller !== controller || this.closedError) {
+        return;
+      }
+      this.incoming.delete(request.id);
+      controller.abort();
+      this.writeError(request.id, JSON_RPC_REQUEST_TIMEOUT, `JSON-RPC request timed out`);
+    }, this.options.requestTimeoutMs);
+    this.incoming.set(request.id, { controller, timeout });
+    try {
+      const result = await handler(request.params, controller.signal);
+      if (!this.closedError && this.incoming.get(request.id)?.controller === controller) {
+        this.write({ jsonrpc: "2.0", id: request.id, result: result ?? null });
+      }
+    } catch (error) {
+      if (!this.closedError && this.incoming.get(request.id)?.controller === controller) {
+        this.writeError(
+          request.id,
+          JSON_RPC_INTERNAL_ERROR,
+          error instanceof Error ? error.message : String(error),
+        );
+      }
+    } finally {
+      clearTimeout(timeout);
+      if (this.incoming.get(request.id)?.controller === controller) {
+        this.incoming.delete(request.id);
+      }
+    }
+  }
+
+  private async handleNotification(notification: JsonRpcNotification): Promise<void> {
+    if (notification.method === "$/cancelRequest") {
+      const id = isRecord(notification.params) ? notification.params.id : undefined;
+      if (typeof id === "number" || typeof id === "string") {
+        this.incoming.get(id)?.controller.abort();
+      }
+      return;
+    }
+    try {
+      await this.options.notificationHandlers?.get(notification.method)?.(notification.params);
+    } catch (error) {
+      this.options.onProtocolError?.(
+        `JSON-RPC notification handler failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  private writeError(id: JsonRpcId, code: number, message: string): void {
+    this.write({ jsonrpc: "2.0", id, error: { code, message } });
+  }
+
+  private write(
+    message: JsonRpcRequest | JsonRpcNotification | JsonRpcResponse,
+    callback?: (error?: Error | null) => void,
+  ): void {
+    this.options.write.write(`${JSON.stringify(message)}\n`, callback);
+  }
+}
+
+function isJsonRpcRequest(value: Record<string, unknown>): value is JsonRpcRequest {
+  return (
+    (typeof value.id === "number" || typeof value.id === "string") &&
+    typeof value.method === "string"
+  );
+}
+
+function isJsonRpcNotification(value: Record<string, unknown>): value is JsonRpcNotification {
+  return value.id === undefined && typeof value.method === "string";
+}
+
+function isJsonRpcResponse(value: Record<string, unknown>): value is JsonRpcResponse {
+  return (
+    (typeof value.id === "number" || typeof value.id === "string") &&
+    value.method === undefined &&
+    ("result" in value || "error" in value)
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}

--- a/src/plugins/json-rpc-plugin-protocol.test.ts
+++ b/src/plugins/json-rpc-plugin-protocol.test.ts
@@ -1,0 +1,415 @@
+import { PassThrough, Writable } from "node:stream";
+import { describe, expect, it, vi } from "vitest";
+import { createTestPluginApi } from "../plugin-sdk/plugin-test-api.js";
+import { JsonRpcPeer } from "./json-rpc-peer.js";
+import { JsonRpcPluginProtocol } from "./json-rpc-plugin-protocol.js";
+
+describe("JsonRpcPluginProtocol", () => {
+  it("dispatches permitted host calls and rejects undeclared capabilities", async () => {
+    const output = new PassThrough();
+    let written = "";
+    output.setEncoding("utf8");
+    output.on("data", (chunk) => (written += String(chunk)));
+    const api = createTestPluginApi({
+      runtime: {
+        system: {
+          requestHeartbeat: async () => ({ ok: true }),
+        },
+      } as never,
+    });
+    const peerRef: { current?: JsonRpcPeer } = {};
+    const protocol = new JsonRpcPluginProtocol(
+      api,
+      new Set(["runtime.system.requestHeartbeat"]),
+      () => peerRef.current!,
+    );
+    const peer = new JsonRpcPeer({
+      write: output,
+      requestTimeoutMs: 1000,
+      maxPendingRequests: 4,
+      requestHandlers: protocol.requestHandlers,
+    });
+    peerRef.current = peer;
+
+    peer.handle({
+      jsonrpc: "2.0",
+      id: "allowed",
+      method: "openclaw.host.call",
+      params: { method: "runtime.system.requestHeartbeat", args: [] },
+    });
+    peer.handle({
+      jsonrpc: "2.0",
+      id: "denied",
+      method: "openclaw.host.call",
+      params: { method: "runtime.config.current", args: [] },
+    });
+
+    await vi.waitFor(() => expect(written.split("\n").filter(Boolean)).toHaveLength(2));
+    const responses = written
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(responses).toContainEqual({ jsonrpc: "2.0", id: "allowed", result: { ok: true } });
+    expect(responses).toContainEqual({
+      jsonrpc: "2.0",
+      id: "denied",
+      error: {
+        code: -32603,
+        message: "host capability not permitted: runtime.config.current",
+      },
+    });
+  });
+
+  it("materializes RPC callbacks and remote streams", async () => {
+    const output = new PassThrough();
+    let written = "";
+    output.setEncoding("utf8");
+    output.on("data", (chunk) => (written += String(chunk)));
+    const api = createTestPluginApi();
+    const peerRef: { current?: JsonRpcPeer } = {};
+    const protocol = new JsonRpcPluginProtocol(api, new Set(), () => peerRef.current!);
+    const peer = new JsonRpcPeer({
+      write: output,
+      requestTimeoutMs: 1000,
+      maxPendingRequests: 4,
+      notificationHandlers: protocol.notificationHandlers,
+    });
+    peerRef.current = peer;
+    const callback = protocol.materialize({ $rpc: "plugin.callback" }) as (
+      value: string,
+    ) => Promise<unknown>;
+    const result = callback("value");
+    peer.handle({ jsonrpc: "2.0", id: 1, result: { ok: true } });
+    await expect(result).resolves.toEqual({ ok: true });
+    expect(written).toContain('"method":"plugin.callback"');
+
+    const stream = protocol.materialize({ $stream: "plugin-stream" }) as AsyncIterable<string>;
+    const collected = collect(stream);
+    peer.handle({
+      jsonrpc: "2.0",
+      method: "$/stream/chunk",
+      params: { id: "plugin-stream", chunk: "a" },
+    });
+    peer.handle({ jsonrpc: "2.0", method: "$/stream/end", params: { id: "plugin-stream" } });
+    await expect(collected).resolves.toEqual(["a"]);
+  });
+
+  it("encodes bytes and rejects cyclic values", () => {
+    const api = createTestPluginApi();
+    const peer = new JsonRpcPeer({
+      write: new PassThrough(),
+      requestTimeoutMs: 1000,
+      maxPendingRequests: 4,
+    });
+    const protocol = new JsonRpcPluginProtocol(api, new Set(), () => peer);
+
+    expect(protocol.serialize(Buffer.from("hello"))).toEqual({
+      $bytes: Buffer.from("hello").toString("base64"),
+    });
+    expect(protocol.materialize({ $bytes: "aGVsbG8=" })).toEqual(Buffer.from("hello"));
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+    expect(() => protocol.serialize(cyclic)).toThrow("contains a cycle");
+  });
+
+  it("fails pending remote streams when the protocol is disposed", async () => {
+    const peer = new JsonRpcPeer({
+      write: new PassThrough(),
+      requestTimeoutMs: 1000,
+      maxPendingRequests: 4,
+    });
+    const protocol = new JsonRpcPluginProtocol(createTestPluginApi(), new Set(), () => peer);
+    const stream = protocol.materialize({ $stream: "pending-stream" }) as AsyncIterable<unknown>;
+    const next = stream[Symbol.asyncIterator]().next();
+
+    protocol.dispose(new Error("transport closed"));
+
+    await expect(next).rejects.toThrow("transport closed");
+  });
+
+  it("waits for stream readiness before publishing values", async () => {
+    const output = new PassThrough();
+    let written = "";
+    output.setEncoding("utf8");
+    output.on("data", (chunk) => (written += String(chunk)));
+    const peerRef: { current?: JsonRpcPeer } = {};
+    const protocol = new JsonRpcPluginProtocol(
+      createTestPluginApi(),
+      new Set(),
+      () => peerRef.current!,
+    );
+    const peer = new JsonRpcPeer({
+      write: output,
+      requestTimeoutMs: 1000,
+      maxPendingRequests: 4,
+      notificationHandlers: protocol.notificationHandlers,
+    });
+    peerRef.current = peer;
+    const reference = protocol.serialize(
+      (async function* () {
+        yield "first";
+      })(),
+    );
+
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    expect(written).toBe("");
+    peer.handle({
+      jsonrpc: "2.0",
+      method: "$/stream/ready",
+      params: { id: (reference as { $stream: string }).$stream },
+    });
+    await vi.waitFor(() => expect(written).toContain('"method":"$/stream/chunk"'));
+    expect(written).toContain('"method":"$/stream/end"');
+  });
+
+  it("bounds retained callbacks", () => {
+    const peer = new JsonRpcPeer({
+      write: new PassThrough(),
+      requestTimeoutMs: 1000,
+      maxPendingRequests: 4,
+    });
+    const protocol = new JsonRpcPluginProtocol(createTestPluginApi(), new Set(), () => peer);
+    for (let index = 0; index < 1024; index += 1) {
+      protocol.serialize(() => index);
+    }
+    expect(() => protocol.serialize(() => undefined)).toThrow("retained callback limit exceeded");
+  });
+
+  it("cancels active published streams on disposal", async () => {
+    const peerRef: { current?: JsonRpcPeer } = {};
+    const protocol = new JsonRpcPluginProtocol(
+      createTestPluginApi(),
+      new Set(),
+      () => peerRef.current!,
+    );
+    const peer = new JsonRpcPeer({
+      write: new PassThrough(),
+      requestTimeoutMs: 1000,
+      maxPendingRequests: 4,
+      notificationHandlers: protocol.notificationHandlers,
+    });
+    peerRef.current = peer;
+    let returned = false;
+    const iterable: AsyncIterable<unknown> = {
+      [Symbol.asyncIterator]() {
+        return {
+          next: () => new Promise(() => {}),
+          return: async () => {
+            returned = true;
+            return { done: true, value: undefined };
+          },
+        };
+      },
+    };
+    const reference = protocol.serialize(iterable) as { $stream: string };
+    peer.handle({
+      jsonrpc: "2.0",
+      method: "$/stream/ready",
+      params: { id: reference.$stream },
+    });
+
+    protocol.dispose();
+
+    await vi.waitFor(() => expect(returned).toBe(true));
+  });
+
+  it("waits for transport writes before pulling the next stream value", async () => {
+    const writeCallbacks: Array<() => void> = [];
+    const output = new Writable({
+      write(_chunk, _encoding, callback) {
+        writeCallbacks.push(callback);
+      },
+    });
+    const peerRef: { current?: JsonRpcPeer } = {};
+    const protocol = new JsonRpcPluginProtocol(
+      createTestPluginApi(),
+      new Set(),
+      () => peerRef.current!,
+    );
+    const peer = new JsonRpcPeer({
+      write: output,
+      requestTimeoutMs: 1000,
+      maxPendingRequests: 4,
+      notificationHandlers: protocol.notificationHandlers,
+    });
+    peerRef.current = peer;
+    let pulls = 0;
+    const reference = protocol.serialize(
+      (async function* () {
+        pulls += 1;
+        yield "first";
+        pulls += 1;
+        yield "second";
+      })(),
+    ) as { $stream: string };
+
+    peer.handle({
+      jsonrpc: "2.0",
+      method: "$/stream/ready",
+      params: { id: reference.$stream },
+    });
+    await vi.waitFor(() => expect(writeCallbacks).toHaveLength(1));
+    expect(pulls).toBe(1);
+    writeCallbacks.shift()?.();
+    await vi.waitFor(() => expect(writeCallbacks).toHaveLength(1));
+    expect(pulls).toBe(2);
+    peer.close(new Error("done"));
+    writeCallbacks.shift()?.();
+  });
+
+  it("cancels remote producers when a consumer stops early", async () => {
+    const output = new PassThrough();
+    let written = "";
+    output.setEncoding("utf8");
+    output.on("data", (chunk) => (written += String(chunk)));
+    const peerRef: { current?: JsonRpcPeer } = {};
+    const protocol = new JsonRpcPluginProtocol(
+      createTestPluginApi(),
+      new Set(),
+      () => peerRef.current!,
+    );
+    const peer = new JsonRpcPeer({
+      write: output,
+      requestTimeoutMs: 1000,
+      maxPendingRequests: 4,
+      notificationHandlers: protocol.notificationHandlers,
+    });
+    peerRef.current = peer;
+    const stream = protocol.materialize({ $stream: "remote" }) as AsyncIterable<string>;
+    const iterator = stream[Symbol.asyncIterator]();
+    peer.handle({
+      jsonrpc: "2.0",
+      method: "$/stream/chunk",
+      params: { id: "remote", chunk: "first" },
+    });
+    await expect(iterator.next()).resolves.toEqual({ done: false, value: "first" });
+
+    await iterator.return?.();
+
+    await vi.waitFor(() => expect(written).toContain('"method":"$/stream/cancel"'));
+  });
+
+  it("returns host iterators when the remote consumer cancels", async () => {
+    const peerRef: { current?: JsonRpcPeer } = {};
+    const protocol = new JsonRpcPluginProtocol(
+      createTestPluginApi(),
+      new Set(),
+      () => peerRef.current!,
+    );
+    const peer = new JsonRpcPeer({
+      write: new PassThrough(),
+      requestTimeoutMs: 1000,
+      maxPendingRequests: 4,
+      notificationHandlers: protocol.notificationHandlers,
+    });
+    peerRef.current = peer;
+    let returned = false;
+    const reference = protocol.serialize({
+      [Symbol.asyncIterator]() {
+        return {
+          next: () => new Promise(() => {}),
+          return: async () => {
+            returned = true;
+            return { done: true, value: undefined };
+          },
+        };
+      },
+    }) as { $stream: string };
+    peer.handle({ jsonrpc: "2.0", method: "$/stream/ready", params: { id: reference.$stream } });
+    peer.handle({ jsonrpc: "2.0", method: "$/stream/cancel", params: { id: reference.$stream } });
+
+    await vi.waitFor(() => expect(returned).toBe(true));
+  });
+
+  it("passes callback request cancellation to abort-signal arguments", async () => {
+    const output = new PassThrough();
+    const peerRef: { current?: JsonRpcPeer } = {};
+    let receivedSignal: AbortSignal | undefined;
+    const protocol = new JsonRpcPluginProtocol(
+      createTestPluginApi(),
+      new Set(),
+      () => peerRef.current!,
+    );
+    const reference = protocol.serialize((signal: AbortSignal) => {
+      receivedSignal = signal;
+    }) as { $callback: string };
+    const peer = new JsonRpcPeer({
+      write: output,
+      requestTimeoutMs: 1000,
+      maxPendingRequests: 4,
+      requestHandlers: protocol.requestHandlers,
+    });
+    peerRef.current = peer;
+    peer.handle({
+      jsonrpc: "2.0",
+      id: "callback",
+      method: "openclaw.callback.invoke",
+      params: { id: reference.$callback, args: [{ $abortSignal: true }] },
+    });
+    peer.handle({
+      jsonrpc: "2.0",
+      method: "$/cancelRequest",
+      params: { id: "callback" },
+    });
+
+    await vi.waitFor(() => expect(receivedSignal?.aborted).toBe(true));
+  });
+
+  it("uses nested abort signals to cancel remote callbacks", async () => {
+    const output = new PassThrough();
+    let written = "";
+    output.setEncoding("utf8");
+    output.on("data", (chunk) => (written += String(chunk)));
+    const peer = new JsonRpcPeer({
+      write: output,
+      requestTimeoutMs: 1000,
+      maxPendingRequests: 4,
+    });
+    const protocol = new JsonRpcPluginProtocol(createTestPluginApi(), new Set(), () => peer);
+    const callback = protocol.materialize({ $rpc: "compaction.summarize" }) as (params: {
+      signal: AbortSignal;
+    }) => Promise<unknown>;
+    const controller = new AbortController();
+    const pending = callback({ signal: controller.signal });
+
+    controller.abort();
+
+    await expect(pending).rejects.toThrow("aborted");
+    expect(written).toContain('"$abortSignal":true');
+    expect(written).toContain('"method":"$/cancelRequest"');
+  });
+
+  it("uses nested abort signals to cancel child-owned callback handles", async () => {
+    const output = new PassThrough();
+    let written = "";
+    output.setEncoding("utf8");
+    output.on("data", (chunk) => (written += String(chunk)));
+    const peer = new JsonRpcPeer({
+      write: output,
+      requestTimeoutMs: 1000,
+      maxPendingRequests: 4,
+    });
+    const protocol = new JsonRpcPluginProtocol(createTestPluginApi(), new Set(), () => peer);
+    const callback = protocol.materialize({ $callback: "child-callback" }) as (params: {
+      signal: AbortSignal;
+    }) => Promise<unknown>;
+    const controller = new AbortController();
+    const pending = callback({ signal: controller.signal });
+
+    controller.abort();
+
+    await expect(pending).rejects.toThrow("aborted");
+    expect(written).toContain('"$abortSignal":true');
+    expect(written).toContain('"method":"$/cancelRequest"');
+  });
+});
+
+async function collect<T>(values: AsyncIterable<T>): Promise<T[]> {
+  const result: T[] = [];
+  for await (const value of values) {
+    result.push(value);
+  }
+  return result;
+}

--- a/src/plugins/json-rpc-plugin-protocol.ts
+++ b/src/plugins/json-rpc-plugin-protocol.ts
@@ -1,0 +1,483 @@
+import { Buffer } from "node:buffer";
+import { Readable } from "node:stream";
+import type { JsonRpcPeer } from "./json-rpc-peer.js";
+import type { OpenClawPluginApi } from "./types.js";
+
+export const JSON_RPC_PLUGIN_PROTOCOL_VERSION = 1;
+
+type RpcReference = { $rpc: string; timeoutMs?: number };
+type CallbackReference = { $callback: string };
+type StreamReference = { $stream: string };
+type AbortSignalReference = { $abortSignal: true; aborted?: boolean };
+type BytesReference = { $bytes: string };
+
+type StreamState = {
+  values: unknown[];
+  waiters: Array<() => void>;
+  done: boolean;
+  error?: Error;
+};
+
+const MAX_BUFFERED_STREAM_VALUES = 256;
+const MAX_LOCAL_CALLBACKS = 1024;
+const MAX_STREAMS = 256;
+const MAX_WIRE_VALUE_DEPTH = 32;
+
+export class JsonRpcPluginProtocol {
+  private nextCallbackId = 1;
+  private nextStreamId = 1;
+  private readonly localCallbacks = new Map<string, (...args: unknown[]) => unknown>();
+  private readonly remoteStreams = new Map<string, StreamState>();
+  private readonly publishedStreams = new Map<string, AsyncIterable<unknown>>();
+  private readonly activePublishedStreams = new Map<string, AsyncIterator<unknown>>();
+
+  constructor(
+    private readonly api: OpenClawPluginApi,
+    private readonly hostPermissions: ReadonlySet<string>,
+    private readonly getPeer: () => JsonRpcPeer,
+    private readonly requestRemote: (
+      method: string,
+      params: unknown,
+      options?: { timeoutMs?: number; signal?: AbortSignal },
+    ) => Promise<unknown> = (method, params, options) =>
+      this.getPeer().request(method, params, options),
+  ) {}
+
+  readonly requestHandlers = new Map([
+    ["openclaw.host.call", (params: unknown, signal: AbortSignal) => this.callHost(params, signal)],
+    [
+      "openclaw.callback.invoke",
+      (params: unknown, signal: AbortSignal) => this.invokeCallback(params, signal),
+    ],
+  ]);
+
+  readonly notificationHandlers = new Map([
+    ["$/callback/release", (params: unknown) => this.releaseCallback(params)],
+    ["$/stream/chunk", (params: unknown) => this.handleStreamChunk(params)],
+    ["$/stream/end", (params: unknown) => this.handleStreamEnd(params)],
+    ["$/stream/error", (params: unknown) => this.handleStreamError(params)],
+    ["$/stream/ready", (params: unknown) => this.startPublishedStream(params)],
+    ["$/stream/cancel", (params: unknown) => this.cancelPublishedStream(params)],
+  ]);
+
+  materialize(value: unknown, signal?: AbortSignal): unknown {
+    if (Array.isArray(value)) {
+      return value.map((entry) => this.materialize(entry, signal));
+    }
+    if (!isRecord(value)) {
+      return value;
+    }
+    if (isRpcReference(value)) {
+      return async (...args: unknown[]) => {
+        const abortSignal = findAbortSignal(args);
+        const serializedArgs = args.map((arg) => this.serialize(arg));
+        return await this.materialize(
+          await this.requestRemote(
+            value.$rpc,
+            { args: serializedArgs },
+            { timeoutMs: value.timeoutMs, signal: abortSignal },
+          ),
+        );
+      };
+    }
+    if (isCallbackReference(value)) {
+      return async (...args: unknown[]) => {
+        const abortSignal = findAbortSignal(args);
+        return this.materialize(
+          await this.requestRemote(
+            "openclaw.callback.invoke",
+            {
+              id: value.$callback,
+              args: args.map((arg) => this.serialize(arg)),
+            },
+            { signal: abortSignal },
+          ),
+        );
+      };
+    }
+    if (isStreamReference(value)) {
+      return this.consumeRemoteStream(value.$stream);
+    }
+    if (isAbortSignalReference(value)) {
+      return signal ?? AbortSignal.abort();
+    }
+    if (isBytesReference(value)) {
+      return Buffer.from(value.$bytes, "base64");
+    }
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [key, this.materialize(entry, signal)]),
+    );
+  }
+
+  serialize(value: unknown): unknown {
+    return this.serializeValue(value, 0, new WeakSet());
+  }
+
+  dispose(error = new Error("JSON-RPC plugin protocol was disposed")): void {
+    this.localCallbacks.clear();
+    this.publishedStreams.clear();
+    for (const [, iterator] of this.activePublishedStreams) {
+      void iterator.return?.();
+    }
+    this.activePublishedStreams.clear();
+    for (const [, state] of this.remoteStreams) {
+      state.error = error;
+      state.done = true;
+      wakeStream(state);
+    }
+    this.remoteStreams.clear();
+  }
+
+  private serializeValue(value: unknown, depth: number, seen: WeakSet<object>): unknown {
+    if (depth > MAX_WIRE_VALUE_DEPTH) {
+      throw new Error("JSON-RPC wire value depth limit exceeded");
+    }
+    if (typeof value === "function") {
+      if (this.localCallbacks.size >= MAX_LOCAL_CALLBACKS) {
+        throw new Error("JSON-RPC retained callback limit exceeded");
+      }
+      const id = `host-callback-${this.nextCallbackId++}`;
+      this.localCallbacks.set(id, value as (...args: unknown[]) => unknown);
+      return { $callback: id } satisfies CallbackReference;
+    }
+    if (isAbortSignal(value)) {
+      return { $abortSignal: true, aborted: value.aborted } satisfies AbortSignalReference;
+    }
+    if (isAsyncIterable(value)) {
+      return this.publishStream(value);
+    }
+    if (value instanceof Readable) {
+      return this.publishStream(value);
+    }
+    if (Array.isArray(value)) {
+      return value.map((entry) => this.serializeValue(entry, depth + 1, seen));
+    }
+    if (!isRecord(value)) {
+      return value ?? null;
+    }
+    if (Buffer.isBuffer(value) || value instanceof Uint8Array) {
+      return { $bytes: Buffer.from(value).toString("base64") } satisfies BytesReference;
+    }
+    if (value instanceof Date) {
+      return value.toISOString();
+    }
+    if (value instanceof Error) {
+      return {
+        name: value.name,
+        message: value.message,
+        ...(value.stack ? { stack: value.stack } : {}),
+      };
+    }
+    if (seen.has(value)) {
+      throw new Error("JSON-RPC wire value contains a cycle");
+    }
+    seen.add(value);
+    const result = Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [
+        key,
+        this.serializeValue(entry, depth + 1, seen),
+      ]),
+    );
+    seen.delete(value);
+    return result;
+  }
+
+  private async callHost(params: unknown, signal: AbortSignal): Promise<unknown> {
+    if (!isRecord(params) || typeof params.method !== "string") {
+      throw new Error("openclaw.host.call requires a method");
+    }
+    if (!this.hostPermissions.has(params.method)) {
+      throw new Error(`host capability not permitted: ${params.method}`);
+    }
+    const target = resolveApiMethod(this.api, params.method);
+    const args = Array.isArray(params.args)
+      ? params.args.map((arg) => this.materialize(arg, signal))
+      : [];
+    if (target.acceptsSignal) {
+      args.push(signal);
+    }
+    return this.serialize(await target.call(...args));
+  }
+
+  private async invokeCallback(params: unknown, signal: AbortSignal): Promise<unknown> {
+    if (!isRecord(params) || typeof params.id !== "string") {
+      throw new Error("openclaw.callback.invoke requires an id");
+    }
+    const callback = this.localCallbacks.get(params.id);
+    if (!callback) {
+      throw new Error(`unknown callback: ${params.id}`);
+    }
+    const args = Array.isArray(params.args)
+      ? params.args.map((arg) => this.materialize(arg, signal))
+      : [];
+    return this.serialize(await callback(...args));
+  }
+
+  private publishStream(iterable: AsyncIterable<unknown>): StreamReference {
+    if (this.publishedStreams.size + this.activePublishedStreams.size >= MAX_STREAMS) {
+      throw new Error("JSON-RPC published stream limit exceeded");
+    }
+    const id = `host-stream-${this.nextStreamId++}`;
+    this.publishedStreams.set(id, iterable);
+    return { $stream: id };
+  }
+
+  private startPublishedStream(params: unknown): void {
+    if (!isRecord(params) || typeof params.id !== "string") {
+      return;
+    }
+    const iterable = this.publishedStreams.get(params.id);
+    if (!iterable) {
+      return;
+    }
+    const id = params.id;
+    const iterator = iterable[Symbol.asyncIterator]();
+    this.publishedStreams.delete(id);
+    this.activePublishedStreams.set(id, iterator);
+    void (async () => {
+      try {
+        while (this.activePublishedStreams.get(id) === iterator) {
+          const next = await iterator.next();
+          if (next.done) {
+            break;
+          }
+          const chunk = next.value;
+          await this.notifyRemote("$/stream/chunk", { id, chunk: this.serialize(chunk) });
+        }
+        if (this.activePublishedStreams.get(id) === iterator) {
+          await this.notifyRemote("$/stream/end", { id });
+        }
+      } catch (error) {
+        if (this.activePublishedStreams.get(id) === iterator) {
+          try {
+            await this.notifyRemote("$/stream/error", {
+              id,
+              message: error instanceof Error ? error.message : String(error),
+            });
+          } catch {
+            // The transport failure that stopped the stream is already owned by the peer.
+          }
+        }
+      } finally {
+        if (this.activePublishedStreams.get(id) === iterator) {
+          this.activePublishedStreams.delete(id);
+        }
+      }
+    })();
+  }
+
+  private async notifyRemote(method: string, params: unknown): Promise<void> {
+    await this.getPeer().notifyAsync(method, params);
+  }
+
+  private consumeRemoteStream(id: string): AsyncIterable<unknown> {
+    if (this.remoteStreams.has(id)) {
+      throw new Error(`duplicate remote stream: ${id}`);
+    }
+    if (this.remoteStreams.size >= MAX_STREAMS) {
+      throw new Error("JSON-RPC remote stream limit exceeded");
+    }
+    const state: StreamState = { values: [], waiters: [], done: false };
+    this.remoteStreams.set(id, state);
+    void this.notifyRemote("$/stream/ready", { id }).catch((error: unknown) => {
+      state.error = error instanceof Error ? error : new Error(String(error));
+      state.done = true;
+      this.remoteStreams.delete(id);
+      wakeStream(state);
+    });
+    const remoteStreams = this.remoteStreams;
+    const cancelRemoteStream = () => this.notifyRemote("$/stream/cancel", { id });
+    const wait = () =>
+      new Promise<void>((resolve) => {
+        state.waiters.push(resolve);
+      });
+    return {
+      async *[Symbol.asyncIterator]() {
+        try {
+          while (!state.done || state.values.length > 0) {
+            if (state.values.length === 0) {
+              await wait();
+              continue;
+            }
+            yield state.values.shift();
+          }
+          if (state.error) {
+            throw state.error;
+          }
+        } finally {
+          remoteStreams.delete(id);
+          if (!state.done) {
+            void cancelRemoteStream().catch(() => undefined);
+          }
+        }
+      },
+    };
+  }
+
+  private cancelPublishedStream(params: unknown): void {
+    if (!isRecord(params) || typeof params.id !== "string") {
+      return;
+    }
+    this.publishedStreams.delete(params.id);
+    const iterator = this.activePublishedStreams.get(params.id);
+    if (!iterator) {
+      return;
+    }
+    this.activePublishedStreams.delete(params.id);
+    void iterator.return?.();
+  }
+
+  private handleStreamChunk(params: unknown): void {
+    const state = streamStateFor(this.remoteStreams, params);
+    if (!state || !isRecord(params)) {
+      return;
+    }
+    if (state.values.length >= MAX_BUFFERED_STREAM_VALUES) {
+      state.error = new Error("remote stream buffer limit exceeded");
+      state.done = true;
+      this.remoteStreams.delete(params.id as string);
+      void this.notifyRemote("$/stream/cancel", { id: params.id }).catch(() => undefined);
+      wakeStream(state);
+      return;
+    }
+    state.values.push(this.materialize(params.chunk));
+    wakeStream(state);
+  }
+
+  private handleStreamEnd(params: unknown): void {
+    const state = streamStateFor(this.remoteStreams, params);
+    if (!state) {
+      return;
+    }
+    state.done = true;
+    if (isRecord(params) && typeof params.id === "string") {
+      this.remoteStreams.delete(params.id);
+    }
+    wakeStream(state);
+  }
+
+  private handleStreamError(params: unknown): void {
+    const state = streamStateFor(this.remoteStreams, params);
+    if (!state || !isRecord(params)) {
+      return;
+    }
+    state.error = new Error(
+      typeof params.message === "string" ? params.message : "remote stream failed",
+    );
+    state.done = true;
+    this.remoteStreams.delete(params.id as string);
+    wakeStream(state);
+  }
+
+  private releaseCallback(params: unknown): void {
+    if (isRecord(params) && typeof params.id === "string") {
+      this.localCallbacks.delete(params.id);
+    }
+  }
+}
+
+function resolveApiMethod(
+  api: OpenClawPluginApi,
+  path: string,
+): { call: (...args: unknown[]) => unknown; acceptsSignal: boolean } {
+  if (
+    !path.startsWith("runtime.") &&
+    !path.startsWith("session.") &&
+    !path.startsWith("agent.") &&
+    !path.startsWith("runContext.")
+  ) {
+    throw new Error(`unsupported host capability path: ${path}`);
+  }
+  const segments = path.split(".");
+  let owner: unknown = api;
+  for (const segment of segments.slice(0, -1)) {
+    if (!isRecord(owner) || isBlockedKey(segment)) {
+      throw new Error(`unknown host capability: ${path}`);
+    }
+    owner = owner[segment];
+  }
+  const methodName = segments.at(-1);
+  if (!methodName || !isRecord(owner) || isBlockedKey(methodName)) {
+    throw new Error(`unknown host capability: ${path}`);
+  }
+  const method = owner[methodName];
+  if (typeof method !== "function") {
+    throw new Error(`host capability is not callable: ${path}`);
+  }
+  return { call: method.bind(owner) as (...args: unknown[]) => unknown, acceptsSignal: false };
+}
+
+function streamStateFor(
+  streams: ReadonlyMap<string, StreamState>,
+  params: unknown,
+): StreamState | undefined {
+  return isRecord(params) && typeof params.id === "string" ? streams.get(params.id) : undefined;
+}
+
+function wakeStream(state: StreamState): void {
+  for (const wake of state.waiters.splice(0)) {
+    wake();
+  }
+}
+
+function isRpcReference(value: Record<string, unknown>): value is RpcReference {
+  return typeof value.$rpc === "string";
+}
+
+function isCallbackReference(value: Record<string, unknown>): value is CallbackReference {
+  return typeof value.$callback === "string";
+}
+
+function isStreamReference(value: Record<string, unknown>): value is StreamReference {
+  return typeof value.$stream === "string";
+}
+
+function isAbortSignalReference(value: Record<string, unknown>): value is AbortSignalReference {
+  return value.$abortSignal === true;
+}
+
+function isBytesReference(value: Record<string, unknown>): value is BytesReference {
+  return typeof value.$bytes === "string";
+}
+
+function isAsyncIterable(value: unknown): value is AsyncIterable<unknown> {
+  return value !== null && typeof value === "object" && Symbol.asyncIterator in value;
+}
+
+function isAbortSignal(value: unknown): value is AbortSignal {
+  return value instanceof AbortSignal;
+}
+
+function findAbortSignal(value: unknown, seen = new WeakSet<object>()): AbortSignal | undefined {
+  if (isAbortSignal(value)) {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      const signal = findAbortSignal(entry, seen);
+      if (signal) {
+        return signal;
+      }
+    }
+    return undefined;
+  }
+  if (!isRecord(value) || seen.has(value)) {
+    return undefined;
+  }
+  seen.add(value);
+  for (const entry of Object.values(value)) {
+    const signal = findAbortSignal(entry, seen);
+    if (signal) {
+      return signal;
+    }
+  }
+  return undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isBlockedKey(value: string): boolean {
+  return value === "__proto__" || value === "prototype" || value === "constructor";
+}

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -1222,6 +1222,7 @@ rl.on("line", (line) => {
           configSchema: EMPTY_PLUGIN_SCHEMA,
           contracts: { tools: ["manifest_echo"] },
           jsonRpc: {
+            protocolVersion: 1,
             process: {
               command: process.execPath,
               args: [childPath],

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -1198,6 +1198,66 @@ describe("loadOpenClawPlugins", () => {
     });
   });
 
+  it("loads JSON-RPC plugins declared entirely from the plugin manifest", () => {
+    useNoBundledPlugins();
+    const pluginDir = makeTempDir();
+    const childPath = path.join(pluginDir, "json-rpc-child.cjs");
+    const manifestPath = path.join(pluginDir, "openclaw.plugin.json");
+    fs.writeFileSync(
+      childPath,
+      `const readline = require("node:readline");
+const rl = readline.createInterface({ input: process.stdin });
+rl.on("line", (line) => {
+  const message = JSON.parse(line);
+  process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: message.id, result: { ok: true } }) + "\\n");
+});`,
+      "utf-8",
+    );
+    fs.writeFileSync(
+      manifestPath,
+      JSON.stringify(
+        {
+          id: "manifest-json-rpc-plugin",
+          name: "Manifest JSON-RPC Plugin",
+          configSchema: EMPTY_PLUGIN_SCHEMA,
+          contracts: { tools: ["manifest_echo"] },
+          jsonRpc: {
+            process: {
+              command: process.execPath,
+              args: [childPath],
+              inheritEnv: false,
+            },
+            registrations: [
+              {
+                type: "tool",
+                name: "manifest_echo",
+                description: "Echoes through a manifest-owned JSON-RPC child process.",
+              },
+            ],
+          },
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    const registry = loadOpenClawPlugins({
+      cache: false,
+      workspaceDir: pluginDir,
+      config: {
+        plugins: {
+          load: { paths: [manifestPath] },
+          allow: ["manifest-json-rpc-plugin"],
+        },
+      },
+    });
+
+    const record = registry.plugins.find((entry) => entry.id === "manifest-json-rpc-plugin");
+    expect(record?.status).toBe("loaded");
+    expect(registry.tools.flatMap((entry) => entry.names)).toContain("manifest_echo");
+  });
+
   it("emits loader startup trace failure counts for load and register failures", () => {
     useNoBundledPlugins();
     const loadFailPlugin = writePlugin({

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -2454,7 +2454,9 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
           description: record.description ?? "",
           kind: record.kind,
           configSchema: { jsonSchema: manifestRecord.configSchema },
+          protocolVersion: manifestRecord.jsonRpc.protocolVersion,
           process: manifestRecord.jsonRpc.process,
+          permissions: manifestRecord.jsonRpc.permissions,
           registrations: manifestRecord.jsonRpc.registrations,
         });
       } else {
@@ -3243,7 +3245,9 @@ export async function loadOpenClawPluginCliRegistry(
         description: record.description ?? "",
         kind: record.kind,
         configSchema: { jsonSchema: manifestRecord.configSchema },
+        protocolVersion: manifestRecord.jsonRpc.protocolVersion,
         process: manifestRecord.jsonRpc.process,
+        permissions: manifestRecord.jsonRpc.permissions,
         registrations: manifestRecord.jsonRpc.registrations,
       });
     } else {

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -74,6 +74,7 @@ import {
   listPluginInteractiveHandlers,
   restorePluginInteractiveHandlers,
 } from "./interactive-registry.js";
+import { createJsonRpcManifestPluginDefinition } from "./json-rpc-manifest-runtime.js";
 import { PluginLoaderCacheState } from "./loader-cache-state.js";
 import {
   channelPluginIdBelongsToManifest,
@@ -2438,67 +2439,80 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
         continue;
       }
 
-      const loadEntry =
-        registrationPlan.loadSetupEntry && runtimeSetupEntry
-          ? runtimeSetupEntry
-          : runtimeCandidateEntry;
-      const moduleLoadSource = resolveCanonicalDistRuntimeSource(loadEntry.source);
-      const moduleRoot = resolveCanonicalDistRuntimeSource(loadEntry.rootDir);
+      let mod: OpenClawPluginModule | null = null;
+      let safeSource = record.source;
+      let moduleLoadMs = 0;
       const rejectHardlinks = shouldRejectHardlinkedPluginFiles({
         origin: candidate.origin,
         rootDir: candidate.rootDir,
         env,
       });
-      const opened = openRootFileSync({
-        absolutePath: moduleLoadSource,
-        rootPath: moduleRoot,
-        boundaryLabel: "plugin root",
-        rejectHardlinks,
-        skipLexicalRootCheck: true,
-      });
-      if (!opened.ok) {
-        pushPluginLoadError("plugin entry path escapes plugin root or fails alias checks");
-        continue;
-      }
-      const safeSource = opened.path;
-      fs.closeSync(opened.fd);
-
-      let mod: OpenClawPluginModule | null = null;
-      let moduleLoadMs = 0;
-      let moduleLoadFailed = false;
-      const beforeModuleLoad = performance.now();
-      try {
-        // Track the plugin as imported once module evaluation begins. Top-level
-        // code may have already executed even if evaluation later throws.
-        recordImportedPluginId(record.id);
-        pluginLoadAttemptCount++;
-        logger.debug?.(`[plugins] loading ${record.id} from ${safeSource}`);
-        mod = withProfile(
-          { pluginId: record.id, source: safeSource },
-          registrationMode,
-          () => loadPluginModule(safeSource) as OpenClawPluginModule,
-        );
-      } catch (err) {
-        recordPluginError({
-          logger,
-          registry,
-          record,
-          seenIds,
-          pluginId,
-          origin: candidate.origin,
-          phase: "load",
-          error: err,
-          logPrefix: `[plugins] ${record.id} failed to load from ${record.source}: `,
-          diagnosticMessagePrefix: "failed to load plugin: ",
+      if (manifestRecord.jsonRpc) {
+        mod = createJsonRpcManifestPluginDefinition({
+          id: record.id,
+          name: record.name ?? record.id,
+          description: record.description ?? "",
+          kind: record.kind,
+          configSchema: { jsonSchema: manifestRecord.configSchema },
+          process: manifestRecord.jsonRpc.process,
+          registrations: manifestRecord.jsonRpc.registrations,
         });
-        moduleLoadFailed = true;
-        continue;
-      } finally {
-        moduleLoadMs = performance.now() - beforeModuleLoad;
-        detailPluginStartupTrace(options.startupTrace, record.id, [
-          ["loadMs", moduleLoadMs],
-          ["loadFailedCount", moduleLoadFailed ? 1 : 0],
-        ]);
+      } else {
+        const loadEntry =
+          registrationPlan.loadSetupEntry && runtimeSetupEntry
+            ? runtimeSetupEntry
+            : runtimeCandidateEntry;
+        const moduleLoadSource = resolveCanonicalDistRuntimeSource(loadEntry.source);
+        const moduleRoot = resolveCanonicalDistRuntimeSource(loadEntry.rootDir);
+        const opened = openRootFileSync({
+          absolutePath: moduleLoadSource,
+          rootPath: moduleRoot,
+          boundaryLabel: "plugin root",
+          rejectHardlinks,
+          skipLexicalRootCheck: true,
+        });
+        if (!opened.ok) {
+          pushPluginLoadError("plugin entry path escapes plugin root or fails alias checks");
+          continue;
+        }
+        safeSource = opened.path;
+        fs.closeSync(opened.fd);
+
+        let moduleLoadFailed = false;
+        const beforeModuleLoad = performance.now();
+        try {
+          // Track the plugin as imported once module evaluation begins. Top-level
+          // code may have already executed even if evaluation later throws.
+          recordImportedPluginId(record.id);
+          pluginLoadAttemptCount++;
+          logger.debug?.(`[plugins] loading ${record.id} from ${safeSource}`);
+          mod = withProfile(
+            { pluginId: record.id, source: safeSource },
+            registrationMode,
+            () => loadPluginModule(safeSource) as OpenClawPluginModule,
+          );
+        } catch (err) {
+          recordPluginError({
+            logger,
+            registry,
+            record,
+            seenIds,
+            pluginId,
+            origin: candidate.origin,
+            phase: "load",
+            error: err,
+            logPrefix: `[plugins] ${record.id} failed to load from ${record.source}: `,
+            diagnosticMessagePrefix: "failed to load plugin: ",
+          });
+          moduleLoadFailed = true;
+          continue;
+        } finally {
+          moduleLoadMs = performance.now() - beforeModuleLoad;
+          detailPluginStartupTrace(options.startupTrace, record.id, [
+            ["loadMs", moduleLoadMs],
+            ["loadFailedCount", moduleLoadFailed ? 1 : 0],
+          ]);
+        }
       }
 
       if (registrationPlan.loadSetupEntry && manifestRecord.setupSource) {
@@ -3221,59 +3235,71 @@ export async function loadOpenClawPluginCliRegistry(
       continue;
     }
 
-    const pluginRoot = safeRealpathOrResolve(candidate.rootDir);
-    const cliMetadataSource = resolveCliMetadataEntrySource(candidate.rootDir);
-    const sourceForCliMetadata =
-      candidate.origin === "bundled"
-        ? cliMetadataSource
-          ? safeRealpathOrResolve(cliMetadataSource)
-          : null
-        : (cliMetadataSource ?? candidate.source);
-    if (!sourceForCliMetadata) {
-      record.status = "loaded";
-      registry.plugins.push(record);
-      seenIds.set(pluginId, candidate.origin);
-      continue;
-    }
-    const opened = openRootFileSync({
-      absolutePath: sourceForCliMetadata,
-      rootPath: pluginRoot,
-      boundaryLabel: "plugin root",
-      rejectHardlinks: shouldRejectHardlinkedPluginFiles({
-        origin: candidate.origin,
-        rootDir: candidate.rootDir,
-        env,
-      }),
-      skipLexicalRootCheck: true,
-    });
-    if (!opened.ok) {
-      pushPluginLoadError("plugin entry path escapes plugin root or fails alias checks");
-      continue;
-    }
-    const safeSource = opened.path;
-    fs.closeSync(opened.fd);
-
     let mod: OpenClawPluginModule | null;
-    try {
-      mod = withProfile(
-        { pluginId: record.id, source: safeSource },
-        "cli-metadata",
-        () => loadPluginModule(safeSource) as OpenClawPluginModule,
-      );
-    } catch (err) {
-      recordPluginError({
-        logger,
-        registry,
-        record,
-        seenIds,
-        pluginId,
-        origin: candidate.origin,
-        phase: "load",
-        error: err,
-        logPrefix: `[plugins] ${record.id} failed to load from ${record.source}: `,
-        diagnosticMessagePrefix: "failed to load plugin: ",
+    if (manifestRecord.jsonRpc) {
+      mod = createJsonRpcManifestPluginDefinition({
+        id: record.id,
+        name: record.name ?? record.id,
+        description: record.description ?? "",
+        kind: record.kind,
+        configSchema: { jsonSchema: manifestRecord.configSchema },
+        process: manifestRecord.jsonRpc.process,
+        registrations: manifestRecord.jsonRpc.registrations,
       });
-      continue;
+    } else {
+      const pluginRoot = safeRealpathOrResolve(candidate.rootDir);
+      const cliMetadataSource = resolveCliMetadataEntrySource(candidate.rootDir);
+      const sourceForCliMetadata =
+        candidate.origin === "bundled"
+          ? cliMetadataSource
+            ? safeRealpathOrResolve(cliMetadataSource)
+            : null
+          : (cliMetadataSource ?? candidate.source);
+      if (!sourceForCliMetadata) {
+        record.status = "loaded";
+        registry.plugins.push(record);
+        seenIds.set(pluginId, candidate.origin);
+        continue;
+      }
+      const opened = openRootFileSync({
+        absolutePath: sourceForCliMetadata,
+        rootPath: pluginRoot,
+        boundaryLabel: "plugin root",
+        rejectHardlinks: shouldRejectHardlinkedPluginFiles({
+          origin: candidate.origin,
+          rootDir: candidate.rootDir,
+          env,
+        }),
+        skipLexicalRootCheck: true,
+      });
+      if (!opened.ok) {
+        pushPluginLoadError("plugin entry path escapes plugin root or fails alias checks");
+        continue;
+      }
+      const safeSource = opened.path;
+      fs.closeSync(opened.fd);
+
+      try {
+        mod = withProfile(
+          { pluginId: record.id, source: safeSource },
+          "cli-metadata",
+          () => loadPluginModule(safeSource) as OpenClawPluginModule,
+        );
+      } catch (err) {
+        recordPluginError({
+          logger,
+          registry,
+          record,
+          seenIds,
+          pluginId,
+          origin: candidate.origin,
+          phase: "load",
+          error: err,
+          logPrefix: `[plugins] ${record.id} failed to load from ${record.source}: `,
+          diagnosticMessagePrefix: "failed to load plugin: ",
+        });
+        continue;
+      }
     }
 
     const resolved = resolvePluginModuleExport(mod);

--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -2897,4 +2897,87 @@ describe("loadPluginManifestRegistry", () => {
     expect(newerHost.plugins.map((plugin) => plugin.id)).toContain("synology-chat");
     expectNoRegistryDiagnosticContains(newerHost, "this host is 2026.3.21");
   });
+
+  it("normalizes versioned JSON-RPC plugin manifests", () => {
+    const dir = makeTempDir();
+    writeManifest(dir, {
+      id: "json-rpc-normalized",
+      configSchema: { type: "object" },
+      jsonRpc: {
+        protocolVersion: 1,
+        process: {
+          command: "bin/plugin",
+          timeoutMs: 5000,
+          maxFrameBytes: 1024,
+          maxPendingRequests: 8,
+        },
+        permissions: {
+          host: ["runtime.llm.complete", "invalid", "runtime.__proto__.pollute"],
+        },
+        registrations: [
+          {
+            type: "api",
+            method: "registerCommand",
+            args: [
+              {
+                name: "remote",
+                description: "Remote command",
+                handler: { $rpc: "plugin.command" },
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const registry = loadSingleCandidateRegistry({
+      idHint: "json-rpc-normalized",
+      rootDir: dir,
+      origin: "workspace",
+    });
+
+    expect(registry.plugins[0]?.jsonRpc).toEqual({
+      protocolVersion: 1,
+      process: {
+        command: "bin/plugin",
+        timeoutMs: 5000,
+        maxFrameBytes: 1024,
+        maxPendingRequests: 8,
+      },
+      permissions: { host: ["runtime.llm.complete"] },
+      registrations: [
+        {
+          type: "api",
+          method: "registerCommand",
+          args: [
+            {
+              name: "remote",
+              description: "Remote command",
+              handler: { $rpc: "plugin.command" },
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("rejects JSON-RPC manifests without protocol negotiation", () => {
+    const dir = makeTempDir();
+    writeManifest(dir, {
+      id: "json-rpc-unversioned",
+      configSchema: { type: "object" },
+      jsonRpc: {
+        process: { command: "bin/plugin" },
+        registrations: [{ type: "tool", name: "remote", description: "Remote" }],
+      },
+    });
+
+    const registry = loadSingleCandidateRegistry({
+      idHint: "json-rpc-unversioned",
+      rootDir: dir,
+      origin: "workspace",
+    });
+
+    expect(registry.plugins[0]?.jsonRpc).toBeUndefined();
+  });
 });

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -41,6 +41,7 @@ import {
   type PluginManifestChannelConfig,
   type PluginManifestContracts,
   type PluginManifestMediaUnderstandingProviderMetadata,
+  type PluginManifestJsonRpc,
   type PluginManifestModelCatalog,
   type PluginManifestModelIdNormalization,
   type PluginManifestModelPricing,
@@ -265,6 +266,7 @@ export type PluginManifestRecord = {
   toolMetadata?: Record<string, PluginManifestToolMetadata>;
   configContracts?: PluginManifestConfigContracts;
   channelConfigs?: Record<string, PluginManifestChannelConfig>;
+  jsonRpc?: PluginManifestJsonRpc;
   channelCatalogMeta?: {
     id: string;
     label?: string;
@@ -563,6 +565,7 @@ function buildRecord(params: {
     toolMetadata: params.manifest.toolMetadata,
     configContracts: params.manifest.configContracts,
     channelConfigs,
+    jsonRpc: params.manifest.jsonRpc,
     ...(params.candidate.packageManifest?.channel?.id
       ? {
           channelCatalogMeta: {

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -9,6 +9,7 @@ import { normalizeTrimmedStringList } from "../../packages/normalization-core/sr
 import type { ChannelConfigRuntimeSchema } from "../channels/plugins/types.config.js";
 import { MANIFEST_KEY } from "../compat/legacy-names.js";
 import { ENV_SECRET_REF_ID_RE } from "../config/types.secrets.js";
+import { isOperatorScope, type OperatorScope } from "../gateway/operator-scopes.js";
 import { matchRootFileOpenFailure, openRootFileSync } from "../infra/boundary-file-read.js";
 import { isBlockedObjectKey } from "../infra/prototype-keys.js";
 import type { JsonSchemaObject } from "../shared/json-schema.types.js";
@@ -21,6 +22,11 @@ import {
 import type { PluginConfigUiHint } from "./manifest-types.js";
 import { createPluginCacheKey, PluginLruCache } from "./plugin-cache-primitives.js";
 import type { PluginKind } from "./plugin-kind.types.js";
+import type {
+  OpenClawPluginGatewayRuntimeScopeSurface,
+  OpenClawPluginHttpRouteAuth,
+  OpenClawPluginHttpRouteMatch,
+} from "./types.js";
 
 /** Canonical plugin manifest filename inside plugin roots. */
 export const PLUGIN_MANIFEST_FILENAME = "openclaw.plugin.json";
@@ -294,6 +300,72 @@ export type PluginManifestConfigContracts = {
   secretInputs?: PluginManifestSecretInputContracts;
 };
 
+export type PluginManifestJsonRpcJsonPrimitive = string | number | boolean | null;
+export type PluginManifestJsonRpcJsonValue =
+  | PluginManifestJsonRpcJsonPrimitive
+  | { [key: string]: PluginManifestJsonRpcJsonValue }
+  | PluginManifestJsonRpcJsonValue[];
+export type PluginManifestJsonRpcJsonObject = {
+  [key: string]: PluginManifestJsonRpcJsonValue;
+};
+
+export type PluginManifestJsonRpcProcess = {
+  command: string;
+  args?: string[];
+  cwd?: string;
+  env?: Record<string, string>;
+  inheritEnv?: boolean;
+  timeoutMs?: number;
+  initializationTimeoutMs?: number;
+  logStderr?: boolean;
+};
+
+export type PluginManifestJsonRpcRegistration =
+  | {
+      type: "tool";
+      name: string;
+      description: string;
+      parameters?: PluginManifestJsonRpcJsonObject;
+      displaySummary?: string;
+      method?: string;
+      timeoutMs?: number;
+    }
+  | {
+      type: "hook";
+      hook: string;
+      description?: string;
+      options?: { priority?: number; timeoutMs?: number };
+      method?: string;
+      timeoutMs?: number;
+    }
+  | {
+      type: "httpRoute";
+      path: string;
+      auth: OpenClawPluginHttpRouteAuth;
+      match?: OpenClawPluginHttpRouteMatch;
+      gatewayRuntimeScopeSurface?: OpenClawPluginGatewayRuntimeScopeSurface;
+      nodeCapability?: {
+        surface: string;
+        ttlMs?: number;
+      };
+      replaceExisting?: boolean;
+      method?: string;
+      timeoutMs?: number;
+      maxBodyBytes?: number;
+    }
+  | {
+      type: "gatewayMethod";
+      method: string;
+      scope?: OperatorScope;
+      rpcMethod?: string;
+      timeoutMs?: number;
+    };
+
+export type PluginManifestJsonRpc = {
+  process: PluginManifestJsonRpcProcess;
+  registrations: PluginManifestJsonRpcRegistration[];
+};
+
 export type PluginManifest = {
   id: string;
   configSchema: JsonSchemaObject;
@@ -401,6 +473,8 @@ export type PluginManifest = {
   /** Manifest-owned config behavior consumed by generic core helpers. */
   configContracts?: PluginManifestConfigContracts;
   channelConfigs?: Record<string, PluginManifestChannelConfig>;
+  /** Declarative JSON-RPC child-process runtime descriptors. */
+  jsonRpc?: PluginManifestJsonRpc;
 };
 
 export type PluginManifestContracts = {
@@ -570,6 +644,185 @@ function normalizeStringRecord(value: unknown): Record<string, string> | undefin
     normalized[key] = valueLocal;
   }
   return Object.keys(normalized).length > 0 ? normalized : undefined;
+}
+
+function normalizeStringEnvRecord(value: unknown): Record<string, string> | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const normalized: Record<string, string> = Object.create(null);
+  for (const [rawKey, rawValue] of Object.entries(value)) {
+    const key = normalizeOptionalString(rawKey) ?? "";
+    if (!key || isBlockedObjectKey(key) || typeof rawValue !== "string") {
+      continue;
+    }
+    normalized[key] = rawValue;
+  }
+  return Object.keys(normalized).length > 0 ? normalized : undefined;
+}
+
+function normalizeOptionalNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function normalizeJsonRpcJsonObject(value: unknown): PluginManifestJsonRpcJsonObject | undefined {
+  return isRecord(value) ? (value as PluginManifestJsonRpcJsonObject) : undefined;
+}
+
+function normalizeJsonRpcProcess(value: unknown): PluginManifestJsonRpcProcess | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const command = normalizeOptionalString(value.command);
+  if (!command) {
+    return undefined;
+  }
+  const args = normalizeTrimmedStringList(value.args);
+  const cwd = normalizeOptionalString(value.cwd);
+  const env = normalizeStringEnvRecord(value.env);
+  const timeoutMs = normalizeOptionalNumber(value.timeoutMs);
+  const initializationTimeoutMs = normalizeOptionalNumber(value.initializationTimeoutMs);
+  return {
+    command,
+    ...(args.length > 0 ? { args } : {}),
+    ...(cwd ? { cwd } : {}),
+    ...(env ? { env } : {}),
+    ...(typeof value.inheritEnv === "boolean" ? { inheritEnv: value.inheritEnv } : {}),
+    ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+    ...(initializationTimeoutMs !== undefined ? { initializationTimeoutMs } : {}),
+    ...(typeof value.logStderr === "boolean" ? { logStderr: value.logStderr } : {}),
+  };
+}
+
+function normalizeJsonRpcRegistration(
+  value: unknown,
+): PluginManifestJsonRpcRegistration | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  if (value.type === "tool") {
+    const name = normalizeOptionalString(value.name);
+    const description = normalizeOptionalString(value.description);
+    if (!name || !description) {
+      return undefined;
+    }
+    const method = normalizeOptionalString(value.method);
+    const displaySummary = normalizeOptionalString(value.displaySummary);
+    const parameters = normalizeJsonRpcJsonObject(value.parameters);
+    const timeoutMs = normalizeOptionalNumber(value.timeoutMs);
+    return {
+      type: "tool",
+      name,
+      description,
+      ...(parameters ? { parameters } : {}),
+      ...(displaySummary ? { displaySummary } : {}),
+      ...(method ? { method } : {}),
+      ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+    };
+  }
+  if (value.type === "hook") {
+    const hook = normalizeOptionalString(value.hook);
+    if (!hook) {
+      return undefined;
+    }
+    const description = normalizeOptionalString(value.description);
+    const method = normalizeOptionalString(value.method);
+    const priority = isRecord(value.options)
+      ? normalizeOptionalNumber(value.options.priority)
+      : undefined;
+    const optionTimeoutMs = isRecord(value.options)
+      ? normalizeOptionalNumber(value.options.timeoutMs)
+      : undefined;
+    const options = isRecord(value.options)
+      ? {
+          ...(priority !== undefined ? { priority } : {}),
+          ...(optionTimeoutMs !== undefined ? { timeoutMs: optionTimeoutMs } : {}),
+        }
+      : undefined;
+    const timeoutMs = normalizeOptionalNumber(value.timeoutMs);
+    return {
+      type: "hook",
+      hook,
+      ...(description ? { description } : {}),
+      ...(options && Object.keys(options).length > 0 ? { options } : {}),
+      ...(method ? { method } : {}),
+      ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+    };
+  }
+  if (value.type === "httpRoute") {
+    const pathValue = normalizeOptionalString(value.path);
+    const auth = value.auth === "gateway" || value.auth === "plugin" ? value.auth : undefined;
+    if (!pathValue || !auth) {
+      return undefined;
+    }
+    const match = value.match === "exact" || value.match === "prefix" ? value.match : undefined;
+    const gatewayRuntimeScopeSurface =
+      value.gatewayRuntimeScopeSurface === "write-default" ||
+      value.gatewayRuntimeScopeSurface === "trusted-operator"
+        ? value.gatewayRuntimeScopeSurface
+        : undefined;
+    const nodeCapabilityTtlMs = isRecord(value.nodeCapability)
+      ? normalizeOptionalNumber(value.nodeCapability.ttlMs)
+      : undefined;
+    const nodeCapability = isRecord(value.nodeCapability)
+      ? {
+          surface: normalizeOptionalString(value.nodeCapability.surface) ?? "",
+          ...(nodeCapabilityTtlMs !== undefined ? { ttlMs: nodeCapabilityTtlMs } : {}),
+        }
+      : undefined;
+    const method = normalizeOptionalString(value.method);
+    const timeoutMs = normalizeOptionalNumber(value.timeoutMs);
+    const maxBodyBytes = normalizeOptionalNumber(value.maxBodyBytes);
+    return {
+      type: "httpRoute",
+      path: pathValue,
+      auth,
+      ...(match ? { match } : {}),
+      ...(gatewayRuntimeScopeSurface ? { gatewayRuntimeScopeSurface } : {}),
+      ...(nodeCapability?.surface ? { nodeCapability } : {}),
+      ...(typeof value.replaceExisting === "boolean"
+        ? { replaceExisting: value.replaceExisting }
+        : {}),
+      ...(method ? { method } : {}),
+      ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+      ...(maxBodyBytes !== undefined ? { maxBodyBytes } : {}),
+    };
+  }
+  if (value.type === "gatewayMethod") {
+    const method = normalizeOptionalString(value.method);
+    if (!method) {
+      return undefined;
+    }
+    const rpcMethod = normalizeOptionalString(value.rpcMethod);
+    const timeoutMs = normalizeOptionalNumber(value.timeoutMs);
+    return {
+      type: "gatewayMethod",
+      method,
+      ...(isOperatorScope(value.scope) ? { scope: value.scope } : {}),
+      ...(rpcMethod ? { rpcMethod } : {}),
+      ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+    };
+  }
+  return undefined;
+}
+
+function normalizeJsonRpcManifest(value: unknown): PluginManifestJsonRpc | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const process = normalizeJsonRpcProcess(value.process);
+  if (!process || !Array.isArray(value.registrations)) {
+    return undefined;
+  }
+  const registrations = value.registrations
+    .map(normalizeJsonRpcRegistration)
+    .filter((registration): registration is PluginManifestJsonRpcRegistration =>
+      Boolean(registration),
+    );
+  if (registrations.length === 0) {
+    return undefined;
+  }
+  return { process, registrations };
 }
 
 const MEDIA_UNDERSTANDING_CAPABILITIES = new Set(["image", "audio", "video"]);
@@ -1816,6 +2069,7 @@ export function loadPluginManifest(
   const toolMetadata = normalizePluginToolMetadata(raw.toolMetadata);
   const configContracts = normalizeManifestConfigContracts(raw.configContracts);
   const channelConfigs = normalizeChannelConfigs(raw.channelConfigs);
+  const jsonRpc = normalizeJsonRpcManifest(raw.jsonRpc);
 
   let uiHints: Record<string, PluginConfigUiHint> | undefined;
   if (isRecord(raw.uiHints)) {
@@ -1870,6 +2124,7 @@ export function loadPluginManifest(
       toolMetadata,
       configContracts,
       channelConfigs,
+      jsonRpc,
     },
     manifestPath,
   });

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -38,6 +38,14 @@ const MAX_SECRET_PROVIDER_EXEC_ARG_BYTES = 1024;
 const MAX_SECRET_PROVIDER_EXEC_TIMEOUT_MS = 120_000;
 const MAX_SECRET_PROVIDER_EXEC_OUTPUT_BYTES = 20 * 1024 * 1024;
 const MAX_SECRET_PROVIDER_EXEC_PASS_ENV = 128;
+const MAX_JSON_RPC_VALUE_DEPTH = 32;
+const MAX_JSON_RPC_ARRAY_ITEMS = 4096;
+const MAX_JSON_RPC_OBJECT_KEYS = 4096;
+const MAX_JSON_RPC_FRAME_BYTES = 64 * 1024 * 1024;
+const MAX_JSON_RPC_PENDING_REQUESTS = 4096;
+const MAX_JSON_RPC_TIMEOUT_MS = 10 * 60 * 1000;
+const JSON_RPC_HOST_CAPABILITY_RE =
+  /^(?:runtime|session|agent|runContext)(?:\.[A-Za-z][A-Za-z0-9_]*)+$/u;
 const SECRET_PROVIDER_NODE_COMMAND_PLACEHOLDER = "${node}";
 
 type PluginManifestLoadCacheEntry = {
@@ -317,7 +325,13 @@ export type PluginManifestJsonRpcProcess = {
   inheritEnv?: boolean;
   timeoutMs?: number;
   initializationTimeoutMs?: number;
+  maxFrameBytes?: number;
+  maxPendingRequests?: number;
   logStderr?: boolean;
+};
+
+export type PluginManifestJsonRpcPermissions = {
+  host?: string[];
 };
 
 export type PluginManifestJsonRpcRegistration =
@@ -359,10 +373,17 @@ export type PluginManifestJsonRpcRegistration =
       scope?: OperatorScope;
       rpcMethod?: string;
       timeoutMs?: number;
+    }
+  | {
+      type: "api";
+      method: string;
+      args: PluginManifestJsonRpcJsonValue[];
     };
 
 export type PluginManifestJsonRpc = {
+  protocolVersion: 1;
   process: PluginManifestJsonRpcProcess;
+  permissions?: PluginManifestJsonRpcPermissions;
   registrations: PluginManifestJsonRpcRegistration[];
 };
 
@@ -665,8 +686,56 @@ function normalizeOptionalNumber(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
 
+function normalizePositiveInteger(value: unknown, maximum: number): number | undefined {
+  return Number.isSafeInteger(value) && Number(value) > 0 && Number(value) <= maximum
+    ? Number(value)
+    : undefined;
+}
+
 function normalizeJsonRpcJsonObject(value: unknown): PluginManifestJsonRpcJsonObject | undefined {
-  return isRecord(value) ? (value as PluginManifestJsonRpcJsonObject) : undefined;
+  const normalized = normalizeJsonRpcJsonValue(value);
+  return isRecord(normalized) ? (normalized as PluginManifestJsonRpcJsonObject) : undefined;
+}
+
+function normalizeJsonRpcJsonValue(
+  value: unknown,
+  depth = 0,
+): PluginManifestJsonRpcJsonValue | undefined {
+  if (depth > MAX_JSON_RPC_VALUE_DEPTH) {
+    return undefined;
+  }
+  if (value === null || typeof value === "string" || typeof value === "boolean") {
+    return value;
+  }
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : undefined;
+  }
+  if (Array.isArray(value)) {
+    if (value.length > MAX_JSON_RPC_ARRAY_ITEMS) {
+      return undefined;
+    }
+    const items = value.map((entry) => normalizeJsonRpcJsonValue(entry, depth + 1));
+    return items.every((entry) => entry !== undefined) ? items : undefined;
+  }
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const entries = Object.entries(value);
+  if (entries.length > MAX_JSON_RPC_OBJECT_KEYS) {
+    return undefined;
+  }
+  const normalized: Record<string, PluginManifestJsonRpcJsonValue> = Object.create(null);
+  for (const [key, entry] of entries) {
+    if (isBlockedObjectKey(key)) {
+      return undefined;
+    }
+    const normalizedEntry = normalizeJsonRpcJsonValue(entry, depth + 1);
+    if (normalizedEntry === undefined) {
+      return undefined;
+    }
+    normalized[key] = normalizedEntry;
+  }
+  return normalized;
 }
 
 function normalizeJsonRpcProcess(value: unknown): PluginManifestJsonRpcProcess | undefined {
@@ -680,8 +749,16 @@ function normalizeJsonRpcProcess(value: unknown): PluginManifestJsonRpcProcess |
   const args = normalizeTrimmedStringList(value.args);
   const cwd = normalizeOptionalString(value.cwd);
   const env = normalizeStringEnvRecord(value.env);
-  const timeoutMs = normalizeOptionalNumber(value.timeoutMs);
-  const initializationTimeoutMs = normalizeOptionalNumber(value.initializationTimeoutMs);
+  const timeoutMs = normalizePositiveInteger(value.timeoutMs, MAX_JSON_RPC_TIMEOUT_MS);
+  const initializationTimeoutMs = normalizePositiveInteger(
+    value.initializationTimeoutMs,
+    MAX_JSON_RPC_TIMEOUT_MS,
+  );
+  const maxFrameBytes = normalizePositiveInteger(value.maxFrameBytes, MAX_JSON_RPC_FRAME_BYTES);
+  const maxPendingRequests = normalizePositiveInteger(
+    value.maxPendingRequests,
+    MAX_JSON_RPC_PENDING_REQUESTS,
+  );
   return {
     command,
     ...(args.length > 0 ? { args } : {}),
@@ -690,8 +767,20 @@ function normalizeJsonRpcProcess(value: unknown): PluginManifestJsonRpcProcess |
     ...(typeof value.inheritEnv === "boolean" ? { inheritEnv: value.inheritEnv } : {}),
     ...(timeoutMs !== undefined ? { timeoutMs } : {}),
     ...(initializationTimeoutMs !== undefined ? { initializationTimeoutMs } : {}),
+    ...(maxFrameBytes !== undefined ? { maxFrameBytes } : {}),
+    ...(maxPendingRequests !== undefined ? { maxPendingRequests } : {}),
     ...(typeof value.logStderr === "boolean" ? { logStderr: value.logStderr } : {}),
   };
+}
+
+function normalizeJsonRpcPermissions(value: unknown): PluginManifestJsonRpcPermissions | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const host = normalizeTrimmedStringList(value.host).filter((entry) =>
+    JSON_RPC_HOST_CAPABILITY_RE.test(entry),
+  );
+  return host.length > 0 ? { host } : undefined;
 }
 
 function normalizeJsonRpcRegistration(
@@ -803,6 +892,21 @@ function normalizeJsonRpcRegistration(
       ...(timeoutMs !== undefined ? { timeoutMs } : {}),
     };
   }
+  if (value.type === "api") {
+    const method = normalizeOptionalString(value.method);
+    if (!method || !Array.isArray(value.args)) {
+      return undefined;
+    }
+    const args = value.args.map((entry) => normalizeJsonRpcJsonValue(entry));
+    if (args.some((entry) => entry === undefined)) {
+      return undefined;
+    }
+    return {
+      type: "api",
+      method,
+      args: args as PluginManifestJsonRpcJsonValue[],
+    };
+  }
   return undefined;
 }
 
@@ -814,6 +918,11 @@ function normalizeJsonRpcManifest(value: unknown): PluginManifestJsonRpc | undef
   if (!process || !Array.isArray(value.registrations)) {
     return undefined;
   }
+  const protocolVersion = value.protocolVersion === 1 ? 1 : undefined;
+  if (protocolVersion === undefined) {
+    return undefined;
+  }
+  const permissions = normalizeJsonRpcPermissions(value.permissions);
   const registrations = value.registrations
     .map(normalizeJsonRpcRegistration)
     .filter((registration): registration is PluginManifestJsonRpcRegistration =>
@@ -822,7 +931,12 @@ function normalizeJsonRpcManifest(value: unknown): PluginManifestJsonRpc | undef
   if (registrations.length === 0) {
     return undefined;
   }
-  return { process, registrations };
+  return {
+    protocolVersion,
+    process,
+    ...(permissions ? { permissions } : {}),
+    registrations,
+  };
 }
 
 const MEDIA_UNDERSTANDING_CAPABILITIES = new Set(["image", "audio", "video"]);


### PR DESCRIPTION
Closes #98004

## What Problem This Solves

OpenClaw plugins are normally in-process TypeScript modules. Authors using Rust, Go, Python, or another language otherwise have to handroll process framing, callbacks, lifecycle, permissions, streams, cancellation, and registration adapters for every plugin.

## Why This Change Was Made

This makes `openclaw.plugin.json` a complete language-neutral entrypoint for the plugin surfaces that can safely cross an asynchronous process boundary. A manifest can declare a JSON-RPC 2.0 child process and register tools, asynchronous hooks, HTTP routes, Gateway methods, and audited generic plugin API registrations without a TypeScript shim.

Protocol version 1 includes:

- bidirectional newline-framed JSON-RPC over stdio
- initialization/version negotiation and lazy process startup
- manifest-declared host capability permissions
- callback handles in both directions
- request timeout and cancellation propagation, including nested `AbortSignal` values
- streams with ready/cancel handshakes, backpressure, bounded buffering, and lifecycle cleanup
- bounded incoming/outgoing requests, callback handles, streams, and frame sizes
- binary value encoding and recursive wire-value validation
- exact callback-path validation for generic registration adapters
- environment isolation by default (`inheritEnv: false`)

The earlier TypeScript shim approach is fully removed. Non-JavaScript plugins declare the runtime and registrations only in JSON.

## User Impact

Plugin authors can implement the supported OpenClaw plugin surfaces entirely in another language. OpenClaw still owns manifest/config validation, host registration, auth, operator scopes, HTTP/Gateway integration, process lifecycle, and capability enforcement.

Protocol v1 intentionally rejects native contracts that cannot preserve their semantics across an async process boundary or expose unsafe host state. This includes synchronous hooks and probes, migration providers, security audit collectors, and model catalog providers. The supported generic methods and exact callback paths are documented in `docs/plugins/manifest.md`.

AI-assisted: yes. I understand the code change and validated the touched protocol, plugin loader, manifest, docs, and generated SDK baseline surfaces.

## Evidence

Proof on `e69451f208edba278e9a6726028866507ea7eb51`:

- `node scripts/run-vitest.mjs src/plugins/manifest-registry.test.ts src/plugins/json-rpc-peer.test.ts src/plugins/json-rpc-plugin-protocol.test.ts src/plugins/json-rpc-manifest-runtime.process.test.ts src/plugins/json-rpc-manifest-runtime.test.ts src/plugins/loader.test.ts` — 279 tests passed
- `pnpm tsgo:core`
- scoped `pnpm exec oxlint` on all touched TypeScript files
- `pnpm docs:map:gen && pnpm docs:map:check`
- `pnpm docs:check-mdx`
- `pnpm plugin-sdk:api:check`
- `git diff --check`
- `pnpm build` — passed on the final commit (207.6s)
- final `$autoreview` pass: clean, no accepted/actionable findings


Implementation size: 13 files changed, +2246/-148. The added production surface is the protocol kernel, process host, capability dispatcher, validation, and registration adapters; the rest is focused tests and author documentation.
