### PR TITLE
Fix/97985 bundle plugin update smoke check

### DIFF
--- a/src/cli/update-cli/plugin-payload-kind.test.ts
+++ b/src/cli/update-cli/plugin-payload-kind.test.ts
@@ -1,0 +1,64 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { resolvePluginInstallPayloadKind } from "./plugin-payload-kind.js";
+
+describe("resolvePluginInstallPayloadKind", () => {
+  let tmpRoot: string;
+  beforeEach(async () => {
+    tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-payload-kind-"));
+  });
+  afterEach(async () => {
+    await fs.rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("returns 'bundle' for a codex bundle layout", async () => {
+    const dir = path.join(tmpRoot, "codex-plugin");
+    await fs.mkdir(path.join(dir, ".codex-plugin"), { recursive: true });
+    await fs.writeFile(path.join(dir, ".codex-plugin", "plugin.json"), "{}", "utf8");
+    expect(resolvePluginInstallPayloadKind(dir)).toBe("bundle");
+  });
+
+  it("returns 'bundle' for a claude bundle layout", async () => {
+    const dir = path.join(tmpRoot, "claude-plugin");
+    await fs.mkdir(path.join(dir, ".claude-plugin"), { recursive: true });
+    await fs.writeFile(path.join(dir, ".claude-plugin", "plugin.json"), "{}", "utf8");
+    expect(resolvePluginInstallPayloadKind(dir)).toBe("bundle");
+  });
+
+  it("returns 'bundle' for a cursor bundle layout", async () => {
+    const dir = path.join(tmpRoot, "cursor-plugin");
+    await fs.mkdir(path.join(dir, ".cursor-plugin"), { recursive: true });
+    await fs.writeFile(path.join(dir, ".cursor-plugin", "plugin.json"), "{}", "utf8");
+    expect(resolvePluginInstallPayloadKind(dir)).toBe("bundle");
+  });
+
+  it("returns 'bundle' for a manifestless claude layout", async () => {
+    const dir = path.join(tmpRoot, "manifestless-claude");
+    await fs.mkdir(path.join(dir, "skills"), { recursive: true });
+    await fs.writeFile(path.join(dir, "skills", "SKILL.md"), "---\n", "utf8");
+    expect(resolvePluginInstallPayloadKind(dir)).toBe("bundle");
+  });
+
+  it("returns 'npm-package' when package.json exists", async () => {
+    const dir = path.join(tmpRoot, "npm-plugin");
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, "package.json"), '{"name":"@openclaw/npm"}', "utf8");
+    expect(resolvePluginInstallPayloadKind(dir)).toBe("npm-package");
+  });
+
+  it("returns 'unknown' for an empty directory", async () => {
+    const dir = path.join(tmpRoot, "empty");
+    await fs.mkdir(dir, { recursive: true });
+    expect(resolvePluginInstallPayloadKind(dir)).toBe("unknown");
+  });
+
+  it("prefers bundle when both bundle manifest and package.json exist", async () => {
+    const dir = path.join(tmpRoot, "dual");
+    await fs.mkdir(path.join(dir, ".claude-plugin"), { recursive: true });
+    await fs.writeFile(path.join(dir, ".claude-plugin", "plugin.json"), "{}", "utf8");
+    await fs.writeFile(path.join(dir, "package.json"), '{"name":"@openclaw/dual"}', "utf8");
+    expect(resolvePluginInstallPayloadKind(dir)).toBe("bundle");
+  });
+});

--- a/src/cli/update-cli/plugin-payload-kind.ts
+++ b/src/cli/update-cli/plugin-payload-kind.ts
@@ -1,0 +1,25 @@
+import path from "node:path";
+import { detectBundleManifestFormat } from "../../plugins/bundle-manifest.js";
+import { pluginScanExistsSync } from "../../plugins/plugin-scan-existence-cache.js";
+
+export type PluginInstallPayloadKind = "npm-package" | "bundle" | "unknown";
+
+/**
+ * Classify the payload kind of a plugin install directory.
+ *
+ * Bundle formats are detected first because a directory may contain both a
+ * bundle manifest and a package.json; the runtime loader prefers the native
+ * package install in that case, but for the smoke check we only need to know
+ * that the directory is not an npm-only payload. Treating it as a bundle means
+ * we skip the package.json requirement, which matches the observed layout of
+ * format=bundle plugins.
+ */
+export function resolvePluginInstallPayloadKind(installPath: string): PluginInstallPayloadKind {
+  if (detectBundleManifestFormat(installPath) !== null) {
+    return "bundle";
+  }
+  if (pluginScanExistsSync(path.join(installPath, "package.json"))) {
+    return "npm-package";
+  }
+  return "unknown";
+}

--- a/src/cli/update-cli/plugin-payload-validation.test.ts
+++ b/src/cli/update-cli/plugin-payload-validation.test.ts
@@ -64,6 +64,22 @@ describe("runPluginPayloadSmokeCheck", () => {
     expect(result.checked).toEqual(["discord"]);
   });
 
+  it("accepts bundle-format plugins without a package.json", async () => {
+    const dir = path.join(tmpRoot, "claude-bundle");
+    await fs.mkdir(path.join(dir, ".claude-plugin"), { recursive: true });
+    await fs.writeFile(
+      path.join(dir, ".claude-plugin", "plugin.json"),
+      JSON.stringify({ name: "claude-bundle" }),
+      "utf8",
+    );
+    const result = await runPluginPayloadSmokeCheck({
+      records: { "claude-bundle": { source: "npm", installPath: dir } },
+      env: {},
+    });
+    expect(result.failures).toEqual([]);
+    expect(result.checked).toEqual(["claude-bundle"]);
+  });
+
   it("reports a failure when the package directory is missing", async () => {
     const dir = path.join(tmpRoot, "brave");
     const result = await runPluginPayloadSmokeCheck({

--- a/src/cli/update-cli/plugin-payload-validation.ts
+++ b/src/cli/update-cli/plugin-payload-validation.ts
@@ -6,6 +6,7 @@ import { resolvePackageExtensionEntries, type PackageManifest } from "../../plug
 import { validatePackageExtensionEntriesForInstall } from "../../plugins/package-entry-resolution.js";
 import { auditOpenClawPeerDependencyLink } from "../../plugins/plugin-peer-link.js";
 import { resolveUserPath } from "../../utils.js";
+import { resolvePluginInstallPayloadKind } from "./plugin-payload-kind.js";
 
 export type PluginPayloadSmokeFailureReason =
   | "missing-install-path"
@@ -66,6 +67,10 @@ export async function runPluginPayloadSmokeCheck(params: {
     }
     const installPath = resolveUserPath(rawInstallPath, params.env);
     checked.push(pluginId);
+
+    if (resolvePluginInstallPayloadKind(installPath) === "bundle") {
+      continue;
+    }
 
     const dirStat = await safeStat(installPath);
     if (!dirStat?.isDirectory()) {

--- a/src/cli/update-cli/update-command.test.ts
+++ b/src/cli/update-cli/update-command.test.ts
@@ -297,6 +297,46 @@ describe("collectMissingPluginInstallPayloads", () => {
     }
   });
 
+  it("does not report missing package.json for bundle-format plugins", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-update-bundle-payload-"));
+    const claudeBundleDir = path.join(tmpDir, "extensions", "claude-bundle");
+    const codexBundleDir = path.join(tmpDir, "extensions", "codex-bundle");
+    try {
+      await fs.mkdir(path.join(claudeBundleDir, ".claude-plugin"), { recursive: true });
+      await fs.writeFile(
+        path.join(claudeBundleDir, ".claude-plugin", "plugin.json"),
+        JSON.stringify({ name: "claude-bundle" }),
+        "utf8",
+      );
+      await fs.mkdir(path.join(codexBundleDir, ".codex-plugin"), { recursive: true });
+      await fs.writeFile(
+        path.join(codexBundleDir, ".codex-plugin", "plugin.json"),
+        JSON.stringify({ name: "codex-bundle", skills: "skills" }),
+        "utf8",
+      );
+
+      await expect(
+        collectMissingPluginInstallPayloads({
+          env: { HOME: tmpDir } as NodeJS.ProcessEnv,
+          records: {
+            "claude-bundle": {
+              source: "npm",
+              spec: "claude-bundle@beta",
+              installPath: claudeBundleDir,
+            },
+            "codex-bundle": {
+              source: "npm",
+              spec: "codex-bundle@beta",
+              installPath: codexBundleDir,
+            },
+          },
+        }),
+      ).resolves.toEqual([]);
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("skips disabled tracked records when requested", async () => {
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-update-plugin-payload-"));
     const missingDir = path.join(tmpDir, "state", "npm", "node_modules", "@openclaw", "missing");

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -140,6 +140,7 @@ import {
 import { commitPluginInstallRecordsWithConfig } from "../plugins-install-record-commit.js";
 import { listPersistedBundledPluginLocationBridges } from "../plugins-location-bridges.js";
 import { refreshPluginRegistryAfterConfigMutation } from "../plugins-registry-refresh.js";
+import { resolvePluginInstallPayloadKind } from "./plugin-payload-kind.js";
 import {
   convergenceWarningsToOutcomes,
   runPostCorePluginConvergence,
@@ -572,6 +573,9 @@ export async function collectMissingPluginInstallPayloads(params: {
     const installPath = resolveUserPath(rawInstallPath, env);
     if (!(await pathExists(installPath))) {
       missing.push({ pluginId, installPath, reason: "missing-package-dir" });
+      continue;
+    }
+    if (resolvePluginInstallPayloadKind(installPath) === "bundle") {
       continue;
     }
     const packageJsonPath = path.join(installPath, "package.json");


### PR DESCRIPTION
Fixes #97985

## Summary

Fix `openclaw update` so its post-update plugin sync no longer treats `format=bundle` plugins as npm packages. Bundle plugins (Codex/Claude/Cursor layouts) have no `package.json`, so the post-update smoke check reported `missing-package-json`, caused the update to exit 1, and incorrectly unloaded the gateway.

The fix introduces a shared helper `resolvePluginInstallPayloadKind` that classifies an install path as `"npm-package"`, `"bundle"`, or `"unknown"`. Both check points — `runPluginPayloadSmokeCheck` and `collectMissingPluginInstallPayloads` — consume this helper and skip npm-specific validation for bundle paths.

## Real Behavior Proof

Environment: Linux, Node v22.23.1, pnpm 11.2.2, OpenClaw worktree SHA 1052652a7168025dfa7d52c75e80460fde87f8cd

Test fixtures:
- `/tmp/openclaw-bundle-proof/extensions/claude-bundle/.claude-plugin/plugin.json` (bundle plugin, no package.json)
- `/tmp/openclaw-bundle-proof/extensions/npm-plugin/package.json` (npm plugin)

After the fix, calling the real check functions:

```bash
$ tsx /tmp/bundle-proof.mjs
=== collectMissingPluginInstallPayloads ===
[]

=== runPluginPayloadSmokeCheck ===
{
  "checked": ["claude-bundle", "npm-plugin"],
  "failures": [
    {
      "pluginId": "npm-plugin",
      "installPath": "/tmp/openclaw-bundle-proof/extensions/npm-plugin",
      "reason": "missing-main-entry",
      "detail": "Plugin main entry \"dist/index.js\" not found at /tmp/openclaw-bundle-proof/extensions/npm-plugin/dist/index.js"
    }
  ]
}
```

Results:
- Bundle plugin `claude-bundle` no longer produces `missing-package-json`.
- Npm plugin `npm-plugin` is still checked under npm rules (the fixture intentionally lacks `dist/index.js` to show the path is unaffected).

## Regression Test Plan

- `src/cli/update-cli/plugin-payload-kind.test.ts`: 7 cases covering codex/claude/cursor bundles, manifestless claude, npm package, empty directory, dual-format precedence
- `src/cli/update-cli/plugin-payload-validation.test.ts`: new bundle plugin smoke-check acceptance test
- `src/cli/update-cli/update-command.test.ts`: new bundle plugin `missing-package-json` skip test

## Root Cause

The post-update payload checks in `src/cli/update-cli/plugin-payload-validation.ts` and `src/cli/update-cli/update-command.ts` assumed every tracked plugin was an npm package. They checked `installPath/package.json` directly without distinguishing `format=bundle` plugins. Bundle plugins use manifest files such as `.claude-plugin/plugin.json` and have no `package.json`, so every update falsely flagged them as corrupted payloads.

## Implementation Plan Details

1. Create `src/cli/update-cli/plugin-payload-kind.ts`
   - `resolvePluginInstallPayloadKind(installPath)` reuses `detectBundleManifestFormat` to detect bundles
   - Falls back to checking `package.json` for `"npm-package"`
   - Returns `"unknown"` otherwise
2. Modify `src/cli/update-cli/plugin-payload-validation.ts`
   - In `runPluginPayloadSmokeCheck`, call the helper after confirming the install dir exists
   - `"bundle"` causes `continue`, skipping package.json / extension / main / peer-link checks
3. Modify `src/cli/update-cli/update-command.ts`
   - In `collectMissingPluginInstallPayloads`, call the helper after confirming the install dir exists
   - `"bundle"` causes `continue`, avoiding the `missing-package-json` entry
4. Add regression tests in the three test files
5. Verify with `pnpm test src/cli/update-cli/` and `pnpm build`

## Change Details

- `src/cli/update-cli/plugin-payload-kind.ts` (new)
- `src/cli/update-cli/plugin-payload-kind.test.ts` (new)
- `src/cli/update-cli/plugin-payload-validation.ts`: skip npm checks for bundle paths
- `src/cli/update-cli/plugin-payload-validation.test.ts`: bundle smoke-check regression test
- `src/cli/update-cli/update-command.ts`: skip `missing-package-json` for bundle paths
- `src/cli/update-cli/update-command.test.ts`: bundle payload-scan regression test

## Test Points

- `pnpm test src/cli/update-cli/plugin-payload-kind.test.ts`: 7 passed
- `pnpm test src/cli/update-cli/plugin-payload-validation.test.ts`: 22 passed
- `pnpm test src/cli/update-cli/update-command.test.ts`: 36 passed
- `pnpm test src/cli/update-cli/`: 124 passed
- `pnpm build`: succeeded
- oxlint / oxfmt: 0 warnings / 0 format issues

## Next Steps

1. Push branch to personal fork
2. Open PR using the body below
3. Comment `@clawsweeper re-review`
