### PR TITLE
fix(update): validate bundle plugin payloads by manifest contract

### DIFF
--- a/src/cli/update-cli/plugin-payload-validation.test.ts
+++ b/src/cli/update-cli/plugin-payload-validation.test.ts
@@ -3,8 +3,15 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { PluginInstallRecord } from "../../config/types.plugins.js";
 import { resolveOpenClawPackageRootSync } from "../../infra/openclaw-root.js";
 import { runPluginPayloadSmokeCheck } from "./plugin-payload-validation.js";
+
+type BundleFormat = "codex" | "claude" | "cursor";
+type FormatMarkedBundleInstallRecord = PluginInstallRecord & {
+  format: "bundle";
+  bundleFormat?: BundleFormat;
+};
 
 describe("runPluginPayloadSmokeCheck", () => {
   let tmpRoot: string;
@@ -32,7 +39,7 @@ describe("runPluginPayloadSmokeCheck", () => {
 
   async function writeBundle(params: {
     dir: string;
-    format: "codex" | "claude" | "cursor";
+    format: BundleFormat;
     manifest?: unknown;
     markerOnly?: boolean;
   }) {
@@ -54,6 +61,19 @@ describe("runPluginPayloadSmokeCheck", () => {
       "utf8",
     );
     await fs.mkdir(path.join(params.dir, "skills"), { recursive: true });
+  }
+
+  function formatMarkedBundleRecord(params: {
+    installPath: string;
+    bundleFormat?: BundleFormat;
+  }): PluginInstallRecord {
+    const record: FormatMarkedBundleInstallRecord = {
+      source: "marketplace",
+      format: "bundle",
+      ...(params.bundleFormat ? { bundleFormat: params.bundleFormat } : {}),
+      installPath: params.installPath,
+    };
+    return record;
   }
 
   function resolveTestHostRoot(): string {
@@ -141,12 +161,7 @@ describe("runPluginPayloadSmokeCheck", () => {
                   clawhubFamily: "bundle-plugin",
                   installPath: dir,
                 }
-              : {
-                  source: "marketplace",
-                  format: "bundle",
-                  bundleFormat,
-                  installPath: dir,
-                },
+              : formatMarkedBundleRecord({ installPath: dir, bundleFormat }),
         },
         env: {},
       });
@@ -160,11 +175,7 @@ describe("runPluginPayloadSmokeCheck", () => {
     await writeBundle({ dir, format: "claude", markerOnly: true });
     const result = await runPluginPayloadSmokeCheck({
       records: {
-        "manifestless-claude-bundle": {
-          source: "marketplace",
-          format: "bundle",
-          installPath: dir,
-        } as const,
+        "manifestless-claude-bundle": formatMarkedBundleRecord({ installPath: dir }),
       },
       env: {},
     });
@@ -177,12 +188,7 @@ describe("runPluginPayloadSmokeCheck", () => {
     await fs.mkdir(path.join(dir, ".codex-plugin"), { recursive: true });
     const result = await runPluginPayloadSmokeCheck({
       records: {
-        "broken-bundle": {
-          source: "marketplace",
-          format: "bundle",
-          bundleFormat: "codex",
-          installPath: dir,
-        } as const,
+        "broken-bundle": formatMarkedBundleRecord({ installPath: dir, bundleFormat: "codex" }),
       },
       env: {},
     });
@@ -215,6 +221,34 @@ describe("runPluginPayloadSmokeCheck", () => {
         installPath: dir,
         reason: "invalid-bundle-manifest",
         detail: "Bundle manifest validation failed: plugin manifest must be an object",
+      },
+    ]);
+  });
+
+  it("keeps dual-format bundle records on native package validation", async () => {
+    const dir = path.join(tmpRoot, "dual-format-bundle");
+    await writeBundle({ dir, format: "codex" });
+    await writePackage(dir, {
+      name: "dual-format-bundle",
+      openclaw: { extensions: ["./missing-extension.js"] },
+    });
+    const result = await runPluginPayloadSmokeCheck({
+      records: {
+        "dual-format-bundle": {
+          source: "clawhub",
+          clawhubFamily: "bundle-plugin",
+          installPath: dir,
+        },
+      },
+      env: {},
+    });
+    expect(result.failures).toStrictEqual([
+      {
+        pluginId: "dual-format-bundle",
+        installPath: dir,
+        reason: "missing-extension-entry",
+        detail:
+          "Plugin extension entry validation failed: extension entry not found: ./missing-extension.js",
       },
     ]);
   });

--- a/src/cli/update-cli/plugin-payload-validation.test.ts
+++ b/src/cli/update-cli/plugin-payload-validation.test.ts
@@ -30,6 +30,32 @@ describe("runPluginPayloadSmokeCheck", () => {
     }
   }
 
+  async function writeBundle(params: {
+    dir: string;
+    format: "codex" | "claude" | "cursor";
+    manifest?: unknown;
+    markerOnly?: boolean;
+  }) {
+    await fs.mkdir(params.dir, { recursive: true });
+    if (params.markerOnly) {
+      await fs.mkdir(path.join(params.dir, "skills"), { recursive: true });
+      return;
+    }
+    const manifestDir =
+      params.format === "codex"
+        ? ".codex-plugin"
+        : params.format === "cursor"
+          ? ".cursor-plugin"
+          : ".claude-plugin";
+    await fs.mkdir(path.join(params.dir, manifestDir), { recursive: true });
+    await fs.writeFile(
+      path.join(params.dir, manifestDir, "plugin.json"),
+      JSON.stringify(params.manifest ?? { name: `${params.format}-bundle` }),
+      "utf8",
+    );
+    await fs.mkdir(path.join(params.dir, "skills"), { recursive: true });
+  }
+
   function resolveTestHostRoot(): string {
     const hostRoot = resolveOpenClawPackageRootSync({
       argv1: process.argv[1],
@@ -93,6 +119,102 @@ describe("runPluginPayloadSmokeCheck", () => {
         installPath: dir,
         reason: "missing-package-json",
         detail: `package.json is missing under ${dir}`,
+      },
+    ]);
+  });
+
+  it.each([
+    ["codex", "clawhubFamily"],
+    ["claude", "format"],
+    ["cursor", "format"],
+  ] as const)(
+    "accepts a tracked %s bundle record with no package.json via %s metadata",
+    async (bundleFormat, metadataKind) => {
+      const dir = path.join(tmpRoot, `${bundleFormat}-bundle`);
+      await writeBundle({ dir, format: bundleFormat });
+      const result = await runPluginPayloadSmokeCheck({
+        records: {
+          [`${bundleFormat}-bundle`]:
+            metadataKind === "clawhubFamily"
+              ? {
+                  source: "clawhub",
+                  clawhubFamily: "bundle-plugin",
+                  installPath: dir,
+                }
+              : {
+                  source: "marketplace",
+                  format: "bundle",
+                  bundleFormat,
+                  installPath: dir,
+                },
+        },
+        env: {},
+      });
+      expect(result.checked).toEqual([`${bundleFormat}-bundle`]);
+      expect(result.failures).toEqual([]);
+    },
+  );
+
+  it("accepts a tracked manifestless Claude bundle record with no package.json", async () => {
+    const dir = path.join(tmpRoot, "manifestless-claude-bundle");
+    await writeBundle({ dir, format: "claude", markerOnly: true });
+    const result = await runPluginPayloadSmokeCheck({
+      records: {
+        "manifestless-claude-bundle": {
+          source: "marketplace",
+          format: "bundle",
+          installPath: dir,
+        } as const,
+      },
+      env: {},
+    });
+    expect(result.checked).toEqual(["manifestless-claude-bundle"]);
+    expect(result.failures).toEqual([]);
+  });
+
+  it("reports a bundle manifest failure instead of requiring package.json for bundle records", async () => {
+    const dir = path.join(tmpRoot, "broken-bundle");
+    await fs.mkdir(path.join(dir, ".codex-plugin"), { recursive: true });
+    const result = await runPluginPayloadSmokeCheck({
+      records: {
+        "broken-bundle": {
+          source: "marketplace",
+          format: "bundle",
+          bundleFormat: "codex",
+          installPath: dir,
+        } as const,
+      },
+      env: {},
+    });
+    expect(result.failures).toStrictEqual([
+      {
+        pluginId: "broken-bundle",
+        installPath: dir,
+        reason: "missing-bundle-manifest",
+        detail: `No supported bundle manifest or bundle marker found under ${dir}`,
+      },
+    ]);
+  });
+
+  it("reports invalid bundle manifest when a parseable bundle manifest is not an object", async () => {
+    const dir = path.join(tmpRoot, "non-object-bundle");
+    await writeBundle({ dir, format: "codex", manifest: [] });
+    const result = await runPluginPayloadSmokeCheck({
+      records: {
+        "non-object-bundle": {
+          source: "clawhub",
+          clawhubFamily: "bundle-plugin",
+          installPath: dir,
+        },
+      },
+      env: {},
+    });
+    expect(result.failures).toStrictEqual([
+      {
+        pluginId: "non-object-bundle",
+        installPath: dir,
+        reason: "invalid-bundle-manifest",
+        detail: "Bundle manifest validation failed: plugin manifest must be an object",
       },
     ]);
   });

--- a/src/cli/update-cli/plugin-payload-validation.test.ts
+++ b/src/cli/update-cli/plugin-payload-validation.test.ts
@@ -183,6 +183,25 @@ describe("runPluginPayloadSmokeCheck", () => {
     expect(result.failures).toEqual([]);
   });
 
+  it("accepts a persisted marketplace bundle record without transient format metadata", async () => {
+    const dir = path.join(tmpRoot, "marketplace-bundle");
+    await writeBundle({ dir, format: "cursor" });
+    const result = await runPluginPayloadSmokeCheck({
+      records: {
+        "marketplace-bundle": {
+          source: "marketplace",
+          installPath: dir,
+          marketplaceName: "Local",
+          marketplaceSource: "local/repo",
+          marketplacePlugin: "marketplace-bundle",
+        },
+      },
+      env: {},
+    });
+    expect(result.checked).toEqual(["marketplace-bundle"]);
+    expect(result.failures).toEqual([]);
+  });
+
   it("reports a bundle manifest failure instead of requiring package.json for bundle records", async () => {
     const dir = path.join(tmpRoot, "broken-bundle");
     await fs.mkdir(path.join(dir, ".codex-plugin"), { recursive: true });

--- a/src/cli/update-cli/plugin-payload-validation.ts
+++ b/src/cli/update-cli/plugin-payload-validation.ts
@@ -82,105 +82,164 @@ export async function runPluginPayloadSmokeCheck(params: {
       continue;
     }
 
+    const isBundleRecord = isBundleInstallRecord(record);
+    const packagePayload = await readPackagePayloadManifest(installPath);
+    if (packagePayload.status === "present") {
+      const usePackagePayload =
+        !isBundleRecord || hasNativePackageMetadata(packagePayload.manifest);
+      if (usePackagePayload) {
+        failures.push(
+          ...(await validatePackagePayload({
+            pluginId,
+            installPath,
+            manifest: packagePayload.manifest,
+          })),
+        );
+        continue;
+      }
+    } else {
+      if (!isBundleRecord) {
+        failures.push(formatPackagePayloadReadFailure({ pluginId, installPath, packagePayload }));
+        continue;
+      }
+    }
+
     const bundleFailure = validateBundleInstallRecordPayload({ pluginId, installPath, record });
     if (bundleFailure) {
       failures.push(bundleFailure);
-      continue;
-    }
-    if (isBundleInstallRecord(record)) {
-      continue;
-    }
-
-    const packageJsonPath = path.join(installPath, "package.json");
-    const packageJsonStat = await safeStat(packageJsonPath);
-    if (!packageJsonStat?.isFile()) {
-      failures.push({
-        pluginId,
-        installPath,
-        reason: "missing-package-json",
-        detail: `package.json is missing under ${installPath}`,
-      });
-      continue;
-    }
-
-    let manifest: PackageManifest & { main?: unknown; exports?: unknown };
-    try {
-      manifest = JSON.parse(await fs.readFile(packageJsonPath, "utf8")) as typeof manifest;
-    } catch (err) {
-      failures.push({
-        pluginId,
-        installPath,
-        reason: "invalid-package-json",
-        detail: `Could not parse package.json: ${err instanceof Error ? err.message : String(err)}`,
-      });
-      continue;
-    }
-
-    if (manifestDeclaresOpenClawPeer(manifest)) {
-      const peerIssue = await auditOpenClawPeerDependencyLink({
-        packageDir: installPath,
-        packageName: manifest.name ?? pluginId,
-      });
-      if (peerIssue) {
-        failures.push({
-          pluginId,
-          installPath,
-          reason: "missing-openclaw-peer-link",
-          detail: `Plugin declares peerDependency "openclaw" but peer link audit failed: ${peerIssue.reason}.`,
-        });
-      }
-    }
-
-    const extensionResolution = resolvePackageExtensionEntries(manifest);
-    if (extensionResolution.status === "invalid" || extensionResolution.status === "empty") {
-      failures.push({
-        pluginId,
-        installPath,
-        reason: "missing-extension-entry",
-        detail: `Plugin extension entry validation failed: ${
-          extensionResolution.status === "invalid"
-            ? extensionResolution.error
-            : "package.json openclaw.extensions is empty"
-        }`,
-      });
-      continue;
-    } else if (extensionResolution.status === "ok") {
-      const extensionValidation = await validatePackageExtensionEntriesForInstall({
-        packageDir: installPath,
-        extensions: extensionResolution.entries,
-        manifest,
-      });
-      if (!extensionValidation.ok) {
-        failures.push({
-          pluginId,
-          installPath,
-          reason: "missing-extension-entry",
-          detail: `Plugin extension entry validation failed: ${extensionValidation.error}`,
-        });
-      }
-    }
-
-    // Only fail on `missing-main-entry` when `main` is *explicitly declared*
-    // and absent on disk. Fully resolving `exports` conditional sub-keys is
-    // out of scope for a static smoke check, so packages with only `exports`
-    // remain intentionally permissive.
-    if (typeof manifest.main !== "string" || !manifest.main.trim()) {
-      continue;
-    }
-    const mainRel = manifest.main.trim();
-    const mainPath = path.join(installPath, mainRel);
-    const mainStat = await safeStat(mainPath);
-    if (!mainStat?.isFile()) {
-      failures.push({
-        pluginId,
-        installPath,
-        reason: "missing-main-entry",
-        detail: `Plugin main entry "${mainRel}" not found at ${mainPath}`,
-      });
     }
   }
 
   return { checked, failures };
+}
+
+type PackagePayloadManifest = PackageManifest & { main?: unknown; exports?: unknown };
+
+type PackagePayloadManifestReadResult =
+  | { status: "missing" }
+  | { status: "invalid"; error: string }
+  | { status: "present"; manifest: PackagePayloadManifest };
+
+async function readPackagePayloadManifest(
+  installPath: string,
+): Promise<PackagePayloadManifestReadResult> {
+  const packageJsonPath = path.join(installPath, "package.json");
+  const packageJsonStat = await safeStat(packageJsonPath);
+  if (!packageJsonStat?.isFile()) {
+    return { status: "missing" };
+  }
+  try {
+    return {
+      status: "present",
+      manifest: JSON.parse(await fs.readFile(packageJsonPath, "utf8")) as PackagePayloadManifest,
+    };
+  } catch (err) {
+    return { status: "invalid", error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+function formatPackagePayloadReadFailure(params: {
+  pluginId: string;
+  installPath: string;
+  packagePayload: Exclude<PackagePayloadManifestReadResult, { status: "present" }>;
+}): PluginPayloadSmokeFailure {
+  if (params.packagePayload.status === "invalid") {
+    return {
+      pluginId: params.pluginId,
+      installPath: params.installPath,
+      reason: "invalid-package-json",
+      detail: `Could not parse package.json: ${params.packagePayload.error}`,
+    };
+  }
+  return {
+    pluginId: params.pluginId,
+    installPath: params.installPath,
+    reason: "missing-package-json",
+    detail: `package.json is missing under ${params.installPath}`,
+  };
+}
+
+function hasNativePackageMetadata(manifest: PackageManifest): boolean {
+  return resolvePackageExtensionEntries(manifest).status !== "missing";
+}
+
+export async function hasNativePackageInstallPayload(installPath: string): Promise<boolean> {
+  const packagePayload = await readPackagePayloadManifest(installPath);
+  return (
+    packagePayload.status === "present" && hasNativePackageMetadata(packagePayload.manifest)
+  );
+}
+
+async function validatePackagePayload(params: {
+  pluginId: string;
+  installPath: string;
+  manifest: PackagePayloadManifest;
+}): Promise<PluginPayloadSmokeFailure[]> {
+  const failures: PluginPayloadSmokeFailure[] = [];
+
+  if (manifestDeclaresOpenClawPeer(params.manifest)) {
+    const peerIssue = await auditOpenClawPeerDependencyLink({
+      packageDir: params.installPath,
+      packageName: params.manifest.name ?? params.pluginId,
+    });
+    if (peerIssue) {
+      failures.push({
+        pluginId: params.pluginId,
+        installPath: params.installPath,
+        reason: "missing-openclaw-peer-link",
+        detail: `Plugin declares peerDependency "openclaw" but peer link audit failed: ${peerIssue.reason}.`,
+      });
+    }
+  }
+
+  const extensionResolution = resolvePackageExtensionEntries(params.manifest);
+  if (extensionResolution.status === "invalid" || extensionResolution.status === "empty") {
+    failures.push({
+      pluginId: params.pluginId,
+      installPath: params.installPath,
+      reason: "missing-extension-entry",
+      detail: `Plugin extension entry validation failed: ${
+        extensionResolution.status === "invalid"
+          ? extensionResolution.error
+          : "package.json openclaw.extensions is empty"
+      }`,
+    });
+    return failures;
+  } else if (extensionResolution.status === "ok") {
+    const extensionValidation = await validatePackageExtensionEntriesForInstall({
+      packageDir: params.installPath,
+      extensions: extensionResolution.entries,
+      manifest: params.manifest,
+    });
+    if (!extensionValidation.ok) {
+      failures.push({
+        pluginId: params.pluginId,
+        installPath: params.installPath,
+        reason: "missing-extension-entry",
+        detail: `Plugin extension entry validation failed: ${extensionValidation.error}`,
+      });
+    }
+  }
+
+  // Only fail on `missing-main-entry` when `main` is *explicitly declared*
+  // and absent on disk. Fully resolving `exports` conditional sub-keys is
+  // out of scope for a static smoke check, so packages with only `exports`
+  // remain intentionally permissive.
+  if (typeof params.manifest.main !== "string" || !params.manifest.main.trim()) {
+    return failures;
+  }
+  const mainRel = params.manifest.main.trim();
+  const mainPath = path.join(params.installPath, mainRel);
+  const mainStat = await safeStat(mainPath);
+  if (!mainStat?.isFile()) {
+    failures.push({
+      pluginId: params.pluginId,
+      installPath: params.installPath,
+      reason: "missing-main-entry",
+      detail: `Plugin main entry "${mainRel}" not found at ${mainPath}`,
+    });
+  }
+  return failures;
 }
 
 export function isBundleInstallRecord(record: PluginInstallRecord): boolean {

--- a/src/cli/update-cli/plugin-payload-validation.ts
+++ b/src/cli/update-cli/plugin-payload-validation.ts
@@ -97,11 +97,9 @@ export async function runPluginPayloadSmokeCheck(params: {
         );
         continue;
       }
-    } else {
-      if (!isBundleRecord) {
-        failures.push(formatPackagePayloadReadFailure({ pluginId, installPath, packagePayload }));
-        continue;
-      }
+    } else if (!isBundleRecord) {
+      failures.push(formatPackagePayloadReadFailure({ pluginId, installPath, packagePayload }));
+      continue;
     }
 
     const bundleFailure = validateBundleInstallRecordPayload({ pluginId, installPath, record });

--- a/src/cli/update-cli/plugin-payload-validation.ts
+++ b/src/cli/update-cli/plugin-payload-validation.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import type { PluginInstallRecord } from "../../config/types.plugins.js";
 import { detectBundleManifestFormat, loadBundleManifest } from "../../plugins/bundle-manifest.js";
+import type { PluginBundleFormat } from "../../plugins/manifest-types.js";
 import { resolvePackageExtensionEntries, type PackageManifest } from "../../plugins/manifest.js";
 import { validatePackageExtensionEntriesForInstall } from "../../plugins/package-entry-resolution.js";
 import { auditOpenClawPeerDependencyLink } from "../../plugins/plugin-peer-link.js";
@@ -82,11 +83,11 @@ export async function runPluginPayloadSmokeCheck(params: {
       continue;
     }
 
-    const isBundleRecord = isBundleInstallRecord(record);
+    const bundlePayload = resolveBundleInstallRecordPayload({ record, installPath });
     const packagePayload = await readPackagePayloadManifest(installPath);
     if (packagePayload.status === "present") {
       const usePackagePayload =
-        !isBundleRecord || hasNativePackageMetadata(packagePayload.manifest);
+        !bundlePayload.isBundlePayload || hasNativePackageMetadata(packagePayload.manifest);
       if (usePackagePayload) {
         failures.push(
           ...(await validatePackagePayload({
@@ -97,12 +98,17 @@ export async function runPluginPayloadSmokeCheck(params: {
         );
         continue;
       }
-    } else if (!isBundleRecord) {
+    } else if (!bundlePayload.isBundlePayload) {
       failures.push(formatPackagePayloadReadFailure({ pluginId, installPath, packagePayload }));
       continue;
     }
 
-    const bundleFailure = validateBundleInstallRecordPayload({ pluginId, installPath, record });
+    const bundleFailure = validateBundleInstallRecordPayload({
+      pluginId,
+      installPath,
+      record,
+      bundleFormat: bundlePayload.bundleFormat,
+    });
     if (bundleFailure) {
       failures.push(bundleFailure);
     }
@@ -163,9 +169,7 @@ function hasNativePackageMetadata(manifest: PackageManifest): boolean {
 
 export async function hasNativePackageInstallPayload(installPath: string): Promise<boolean> {
   const packagePayload = await readPackagePayloadManifest(installPath);
-  return (
-    packagePayload.status === "present" && hasNativePackageMetadata(packagePayload.manifest)
-  );
+  return packagePayload.status === "present" && hasNativePackageMetadata(packagePayload.manifest);
 }
 
 async function validatePackagePayload(params: {
@@ -246,15 +250,35 @@ export function isBundleInstallRecord(record: PluginInstallRecord): boolean {
   );
 }
 
+export function resolveBundleInstallRecordPayload(params: {
+  record: PluginInstallRecord;
+  installPath: string;
+}): { isBundlePayload: boolean; bundleFormat: PluginBundleFormat | null } {
+  const hasBundleRecordMetadata = isBundleInstallRecord(params.record);
+  if (!hasBundleRecordMetadata && params.record.source !== "marketplace") {
+    return { isBundlePayload: false, bundleFormat: null };
+  }
+  const bundleFormat = detectBundleManifestFormat(params.installPath);
+  return {
+    isBundlePayload: hasBundleRecordMetadata || bundleFormat !== null,
+    bundleFormat,
+  };
+}
+
 export function validateBundleInstallRecordPayload(params: {
   pluginId: string;
   installPath: string;
   record: PluginInstallRecord;
+  bundleFormat?: PluginBundleFormat | null;
 }): PluginPayloadSmokeFailure | null {
-  if (!isBundleInstallRecord(params.record)) {
+  const hasBundleRecordMetadata = isBundleInstallRecord(params.record);
+  const bundleFormat =
+    params.bundleFormat === undefined
+      ? detectBundleManifestFormat(params.installPath)
+      : params.bundleFormat;
+  if (!hasBundleRecordMetadata && !bundleFormat) {
     return null;
   }
-  const bundleFormat = detectBundleManifestFormat(params.installPath);
   if (!bundleFormat) {
     return {
       pluginId: params.pluginId,

--- a/src/cli/update-cli/plugin-payload-validation.ts
+++ b/src/cli/update-cli/plugin-payload-validation.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { PluginInstallRecord } from "../../config/types.plugins.js";
+import { detectBundleManifestFormat, loadBundleManifest } from "../../plugins/bundle-manifest.js";
 import { resolvePackageExtensionEntries, type PackageManifest } from "../../plugins/manifest.js";
 import { validatePackageExtensionEntriesForInstall } from "../../plugins/package-entry-resolution.js";
 import { auditOpenClawPeerDependencyLink } from "../../plugins/plugin-peer-link.js";
@@ -12,6 +13,8 @@ export type PluginPayloadSmokeFailureReason =
   | "missing-package-dir"
   | "missing-package-json"
   | "invalid-package-json"
+  | "missing-bundle-manifest"
+  | "invalid-bundle-manifest"
   | "missing-main-entry"
   | "missing-extension-entry"
   | "missing-openclaw-peer-link";
@@ -32,8 +35,9 @@ const TRACKED_SOURCES: ReadonlySet<string> = new Set(["npm", "clawhub", "git", "
 
 /**
  * Verify that each tracked plugin install record on disk is structurally
- * loadable: the install dir exists, contains a parseable `package.json`,
- * and any declared package entry files exist.
+ * loadable: code packages contain a parseable `package.json` and declared
+ * package entry files, while bundle packages satisfy their bundle manifest
+ * contract.
  *
  * IMPORTANT: this is intentionally a *static* check. We do NOT execute the
  * plugin's code, so post-update side effects (network calls, filesystem
@@ -75,6 +79,15 @@ export async function runPluginPayloadSmokeCheck(params: {
         reason: "missing-package-dir",
         detail: `Install dir is missing: ${installPath}`,
       });
+      continue;
+    }
+
+    const bundleFailure = validateBundleInstallRecordPayload({ pluginId, installPath, record });
+    if (bundleFailure) {
+      failures.push(bundleFailure);
+      continue;
+    }
+    if (isBundleInstallRecord(record)) {
       continue;
     }
 
@@ -168,6 +181,46 @@ export async function runPluginPayloadSmokeCheck(params: {
   }
 
   return { checked, failures };
+}
+
+export function isBundleInstallRecord(record: PluginInstallRecord): boolean {
+  return (
+    (record as { format?: unknown }).format === "bundle" || record.clawhubFamily === "bundle-plugin"
+  );
+}
+
+export function validateBundleInstallRecordPayload(params: {
+  pluginId: string;
+  installPath: string;
+  record: PluginInstallRecord;
+}): PluginPayloadSmokeFailure | null {
+  if (!isBundleInstallRecord(params.record)) {
+    return null;
+  }
+  const bundleFormat = detectBundleManifestFormat(params.installPath);
+  if (!bundleFormat) {
+    return {
+      pluginId: params.pluginId,
+      installPath: params.installPath,
+      reason: "missing-bundle-manifest",
+      detail: `No supported bundle manifest or bundle marker found under ${params.installPath}`,
+    };
+  }
+  const bundleManifest = loadBundleManifest({
+    rootDir: params.installPath,
+    bundleFormat,
+  });
+  if (bundleManifest.ok) {
+    return null;
+  }
+  return {
+    pluginId: params.pluginId,
+    installPath: params.installPath,
+    reason: bundleManifest.error.startsWith("plugin manifest not found")
+      ? "missing-bundle-manifest"
+      : "invalid-bundle-manifest",
+    detail: `Bundle manifest validation failed: ${bundleManifest.error}`,
+  };
 }
 
 function manifestDeclaresOpenClawPeer(manifest: PackageManifest): boolean {

--- a/src/cli/update-cli/update-command.test.ts
+++ b/src/cli/update-cli/update-command.test.ts
@@ -324,6 +324,41 @@ describe("collectMissingPluginInstallPayloads", () => {
     }
   });
 
+  it("keeps dual-format bundle records on the native package payload path", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-update-plugin-payload-"));
+    const bundleDir = path.join(tmpDir, "state", "clawhub", "dual-format-bundle");
+    try {
+      await fs.mkdir(path.join(bundleDir, ".codex-plugin"), { recursive: true });
+      await fs.writeFile(
+        path.join(bundleDir, ".codex-plugin", "plugin.json"),
+        JSON.stringify({ name: "dual-format-bundle" }),
+        "utf8",
+      );
+      await fs.writeFile(
+        path.join(bundleDir, "package.json"),
+        JSON.stringify({
+          name: "dual-format-bundle",
+          openclaw: { extensions: ["./missing-extension.js"] },
+        }),
+        "utf8",
+      );
+      await expect(
+        collectMissingPluginInstallPayloads({
+          env: { HOME: tmpDir } as NodeJS.ProcessEnv,
+          records: {
+            "dual-format-bundle": {
+              source: "clawhub",
+              clawhubFamily: "bundle-plugin",
+              installPath: bundleDir,
+            },
+          },
+        }),
+      ).resolves.toEqual([]);
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("keeps corrupt tracked bundle records eligible for payload repair", async () => {
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-update-plugin-payload-"));
     const bundleDir = path.join(tmpDir, "state", "clawhub", "bad-bundle");

--- a/src/cli/update-cli/update-command.test.ts
+++ b/src/cli/update-cli/update-command.test.ts
@@ -324,6 +324,35 @@ describe("collectMissingPluginInstallPayloads", () => {
     }
   });
 
+  it("accepts persisted marketplace bundle records without transient format metadata", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-update-plugin-payload-"));
+    const bundleDir = path.join(tmpDir, "state", "marketplace", "cursor-bundle");
+    try {
+      await fs.mkdir(path.join(bundleDir, ".cursor-plugin"), { recursive: true });
+      await fs.writeFile(
+        path.join(bundleDir, ".cursor-plugin", "plugin.json"),
+        JSON.stringify({ name: "cursor-bundle" }),
+        "utf8",
+      );
+      await expect(
+        collectMissingPluginInstallPayloads({
+          env: { HOME: tmpDir } as NodeJS.ProcessEnv,
+          records: {
+            "cursor-bundle": {
+              source: "marketplace",
+              installPath: bundleDir,
+              marketplaceName: "Local",
+              marketplaceSource: "local/repo",
+              marketplacePlugin: "cursor-bundle",
+            },
+          },
+        }),
+      ).resolves.toEqual([]);
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("keeps dual-format bundle records on the native package payload path", async () => {
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-update-plugin-payload-"));
     const bundleDir = path.join(tmpDir, "state", "clawhub", "dual-format-bundle");

--- a/src/cli/update-cli/update-command.test.ts
+++ b/src/cli/update-cli/update-command.test.ts
@@ -297,6 +297,62 @@ describe("collectMissingPluginInstallPayloads", () => {
     }
   });
 
+  it("accepts tracked bundle records validated by the shared bundle loader", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-update-plugin-payload-"));
+    const bundleDir = path.join(tmpDir, "state", "clawhub", "cursor-bundle");
+    try {
+      await fs.mkdir(path.join(bundleDir, ".cursor-plugin"), { recursive: true });
+      await fs.writeFile(
+        path.join(bundleDir, ".cursor-plugin", "plugin.json"),
+        JSON.stringify({ name: "cursor-bundle" }),
+        "utf8",
+      );
+      await expect(
+        collectMissingPluginInstallPayloads({
+          env: { HOME: tmpDir } as NodeJS.ProcessEnv,
+          records: {
+            "cursor-bundle": {
+              source: "clawhub",
+              clawhubFamily: "bundle-plugin",
+              installPath: bundleDir,
+            },
+          },
+        }),
+      ).resolves.toEqual([]);
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps corrupt tracked bundle records eligible for payload repair", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-update-plugin-payload-"));
+    const bundleDir = path.join(tmpDir, "state", "clawhub", "bad-bundle");
+    try {
+      await fs.mkdir(path.join(bundleDir, ".codex-plugin"), { recursive: true });
+      await fs.writeFile(path.join(bundleDir, ".codex-plugin", "plugin.json"), "[]", "utf8");
+      await expect(
+        collectMissingPluginInstallPayloads({
+          env: { HOME: tmpDir } as NodeJS.ProcessEnv,
+          records: {
+            "bad-bundle": {
+              source: "clawhub",
+              clawhubFamily: "bundle-plugin",
+              installPath: bundleDir,
+            },
+          },
+        }),
+      ).resolves.toEqual([
+        {
+          pluginId: "bad-bundle",
+          installPath: bundleDir,
+          reason: "missing-package-json",
+        },
+      ]);
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("skips disabled tracked records when requested", async () => {
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-update-plugin-payload-"));
     const missingDir = path.join(tmpDir, "state", "npm", "node_modules", "@openclaw", "missing");

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -141,6 +141,7 @@ import { commitPluginInstallRecordsWithConfig } from "../plugins-install-record-
 import { listPersistedBundledPluginLocationBridges } from "../plugins-location-bridges.js";
 import { refreshPluginRegistryAfterConfigMutation } from "../plugins-registry-refresh.js";
 import {
+  hasNativePackageInstallPayload,
   isBundleInstallRecord,
   validateBundleInstallRecordPayload,
 } from "./plugin-payload-validation.js";
@@ -578,12 +579,14 @@ export async function collectMissingPluginInstallPayloads(params: {
       missing.push({ pluginId, installPath, reason: "missing-package-dir" });
       continue;
     }
-    const bundleFailure = validateBundleInstallRecordPayload({ pluginId, installPath, record });
-    if (bundleFailure) {
-      missing.push({ pluginId, installPath, reason: "missing-package-json" });
-      continue;
-    }
     if (isBundleInstallRecord(record)) {
+      if (await hasNativePackageInstallPayload(installPath)) {
+        continue;
+      }
+      const bundleFailure = validateBundleInstallRecordPayload({ pluginId, installPath, record });
+      if (bundleFailure) {
+        missing.push({ pluginId, installPath, reason: "missing-package-json" });
+      }
       continue;
     }
     const packageJsonPath = path.join(installPath, "package.json");

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -142,7 +142,7 @@ import { listPersistedBundledPluginLocationBridges } from "../plugins-location-b
 import { refreshPluginRegistryAfterConfigMutation } from "../plugins-registry-refresh.js";
 import {
   hasNativePackageInstallPayload,
-  isBundleInstallRecord,
+  resolveBundleInstallRecordPayload,
   validateBundleInstallRecordPayload,
 } from "./plugin-payload-validation.js";
 import {
@@ -579,11 +579,17 @@ export async function collectMissingPluginInstallPayloads(params: {
       missing.push({ pluginId, installPath, reason: "missing-package-dir" });
       continue;
     }
-    if (isBundleInstallRecord(record)) {
+    const bundlePayload = resolveBundleInstallRecordPayload({ record, installPath });
+    if (bundlePayload.isBundlePayload) {
       if (await hasNativePackageInstallPayload(installPath)) {
         continue;
       }
-      const bundleFailure = validateBundleInstallRecordPayload({ pluginId, installPath, record });
+      const bundleFailure = validateBundleInstallRecordPayload({
+        pluginId,
+        installPath,
+        record,
+        bundleFormat: bundlePayload.bundleFormat,
+      });
       if (bundleFailure) {
         missing.push({ pluginId, installPath, reason: "missing-package-json" });
       }

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -141,6 +141,10 @@ import { commitPluginInstallRecordsWithConfig } from "../plugins-install-record-
 import { listPersistedBundledPluginLocationBridges } from "../plugins-location-bridges.js";
 import { refreshPluginRegistryAfterConfigMutation } from "../plugins-registry-refresh.js";
 import {
+  isBundleInstallRecord,
+  validateBundleInstallRecordPayload,
+} from "./plugin-payload-validation.js";
+import {
   convergenceWarningsToOutcomes,
   runPostCorePluginConvergence,
 } from "./post-core-plugin-convergence.js";
@@ -572,6 +576,14 @@ export async function collectMissingPluginInstallPayloads(params: {
     const installPath = resolveUserPath(rawInstallPath, env);
     if (!(await pathExists(installPath))) {
       missing.push({ pluginId, installPath, reason: "missing-package-dir" });
+      continue;
+    }
+    const bundleFailure = validateBundleInstallRecordPayload({ pluginId, installPath, record });
+    if (bundleFailure) {
+      missing.push({ pluginId, installPath, reason: "missing-package-json" });
+      continue;
+    }
+    if (isBundleInstallRecord(record)) {
       continue;
     }
     const packageJsonPath = path.join(installPath, "package.json");


### PR DESCRIPTION
Closes #97985

## Summary

- Update-time plugin payload checks now classify bundle installs by persisted record metadata or by the installed bundle manifest/marker on disk.
- Marketplace installs that persist only `source`, `installPath`, and marketplace identity fields no longer fail only because they lack `package.json`.
- Native package payloads still stay on the package validation path, and npm/code plugins still fail closed when their package payload is missing or corrupt.

## Change Type

- [x] Bug fix

## Scope

- [x] CLI update
- [x] Plugin install payload validation

## Verification

- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo` passed.
- `node scripts/run-vitest.mjs run src/cli/update-cli/plugin-payload-validation.test.ts src/cli/update-cli/update-command.test.ts` passed.
- `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/cli/update-cli/plugin-payload-validation.ts src/cli/update-cli/plugin-payload-validation.test.ts src/cli/update-cli/update-command.ts src/cli/update-cli/update-command.test.ts` passed.
- `git diff --check` passed.

## Real behavior proof

**Behavior addressed:** Bundle install payloads are validated by the bundle manifest contract even when persisted marketplace install records do not carry transient `format` fields.
**Environment tested:** Node v22.22.0 on Linux 4.19.112-2.el8.x86_64 x86_64.
**Steps run after the patch:** Called the actual `runPluginPayloadSmokeCheck` and `collectMissingPluginInstallPayloads` production functions from source with a ClawHub bundle record, two marketplace bundle records without `format`, and a broken npm payload.
**Evidence after fix:**

```bash
node --import tsx --no-warnings -e "
import fs from 'node:fs/promises';
import os from 'node:os';
import path from 'node:path';
import { runPluginPayloadSmokeCheck } from './src/cli/update-cli/plugin-payload-validation.ts';
import { collectMissingPluginInstallPayloads } from './src/cli/update-cli/update-command.ts';
const root = await fs.mkdtemp(path.join(os.tmpdir(), 'openclaw-proof-97985-'));
async function writeJson(file, value) {
  await fs.mkdir(path.dirname(file), { recursive: true });
  await fs.writeFile(file, JSON.stringify(value), 'utf8');
}
try {
  const marketplaceBundleDir = path.join(root, 'marketplace-cursor-bundle');
  await writeJson(path.join(marketplaceBundleDir, '.cursor-plugin', 'plugin.json'), { name: 'marketplace-cursor-bundle' });
  const clawhubBundleDir = path.join(root, 'clawhub-codex-bundle');
  await writeJson(path.join(clawhubBundleDir, '.codex-plugin', 'plugin.json'), { name: 'clawhub-codex-bundle' });
  const manifestlessBundleDir = path.join(root, 'manifestless-bundle');
  await fs.mkdir(path.join(manifestlessBundleDir, 'skills'), { recursive: true });
  const npmDir = path.join(root, 'npm-plugin');
  await fs.mkdir(npmDir, { recursive: true });
  const records = {
    'clawhub-codex-bundle': { source: 'clawhub', clawhubFamily: 'bundle-plugin', installPath: clawhubBundleDir },
    'manifestless-bundle': { source: 'marketplace', installPath: manifestlessBundleDir, marketplaceName: 'Local', marketplaceSource: 'local/repo', marketplacePlugin: 'manifestless-bundle' },
    'marketplace-cursor-bundle': { source: 'marketplace', installPath: marketplaceBundleDir, marketplaceName: 'Local', marketplaceSource: 'local/repo', marketplacePlugin: 'marketplace-cursor-bundle' },
    'npm-plugin': { source: 'npm', installPath: npmDir },
  };
  const smoke = await runPluginPayloadSmokeCheck({ records, env: {} });
  const missing = await collectMissingPluginInstallPayloads({ records, env: {} });
  console.log(JSON.stringify({
    smokeChecked: smoke.checked,
    smokeFailures: smoke.failures.map((failure) => ({ pluginId: failure.pluginId, reason: failure.reason })),
    missingPayloads: missing.map((entry) => ({ pluginId: entry.pluginId, reason: entry.reason })),
  }, null, 2));
} finally {
  await fs.rm(root, { recursive: true, force: true });
}
"
```

Output:

```json
{
  "smokeChecked": [
    "clawhub-codex-bundle",
    "manifestless-bundle",
    "marketplace-cursor-bundle",
    "npm-plugin"
  ],
  "smokeFailures": [
    {
      "pluginId": "npm-plugin",
      "reason": "missing-package-json"
    }
  ],
  "missingPayloads": [
    {
      "pluginId": "npm-plugin",
      "reason": "missing-package-json"
    }
  ]
}
```

**Observed result after the fix:** Valid bundle payloads pass both update-time payload checks without `package.json`; the npm payload that lacks `package.json` still fails with `missing-package-json`.
**What was not tested:** Full macOS package upgrade plus service restart; this proof exercises the update payload functions directly and the targeted test suites cover the related update paths.

## Root Cause

The update payload checks treated tracked plugin install records as npm/code packages unless the record carried bundle-specific transient fields. Marketplace install records persist source and marketplace identity fields but not those transient format fields, so valid bundle directories could still be reported as missing package payloads.

## Regression Test Plan

- Added coverage for persisted marketplace bundle records without transient `format` metadata in the smoke check path.
- Added coverage for the same persisted marketplace record shape in the missing-payload collector path.
- Existing coverage still checks bundle records, manifestless bundle layouts, dual-format native package validation, invalid bundle manifests, and unchanged npm `package.json` failures.

## User-visible / Behavior Changes

Users with valid bundle marketplace plugins no longer get a post-update payload failure solely because the persisted install record lacks transient bundle format fields.

## Security Impact

No new permissions, network calls, or secret handling changes. The change reads local bundle manifests through the existing shared bundle loader.
