### PR TITLE
Fixes #97877 — `empty-error-retry` blocked by `hadPotentialSideEffects` causing silent terminal failure on transient 5xx after any prior tool call in session.

### DIFF
--- a/src/agents/embedded-agent-runner/run.empty-error-retry.test.ts
+++ b/src/agents/embedded-agent-runner/run.empty-error-retry.test.ts
@@ -6,6 +6,7 @@ import {
   mockedClassifyAssistantFailoverReason,
   mockedClassifyFailoverReason,
   mockedGlobalHookRunner,
+  mockedLog,
   mockedRunEmbeddedAttempt,
   overflowBaseRunParams,
   resetRunOverflowCompactionHarnessMocks,
@@ -81,6 +82,10 @@ describe("runEmbeddedAgent silent-error retry", () => {
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
     expect(result.payloads).toBeUndefined();
+    // Proof: [empty-error-retry] log fires in the real runner path
+    expect(mockedLog.warn).toHaveBeenCalledWith(
+      expect.stringContaining("[empty-error-retry]"),
+    );
   });
 
   it("retries when stopReason=error emitted only thinking blocks and output tokens", async () => {
@@ -275,8 +280,10 @@ describe("runEmbeddedAgent silent-error retry", () => {
   });
 
   it("does not retry when the failed attempt recorded side effects", async () => {
-    // Resubmission would duplicate side effects when replay metadata cannot
-    // prove the failed turn is safe to replay.
+    // Resubmission would duplicate side effects when the current attempt's
+    // tool activity proves side effects — even if there's no prior session history.
+    // Uses per-attempt fields (toolMetas with an unsafe tool) that
+    // buildAttemptReplayMetadata picks up for currentAttemptReplayMetadata.
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         assistantTexts: [],
@@ -288,10 +295,7 @@ describe("runEmbeddedAgent silent-error retry", () => {
           content: [],
           usage: { input: 100, output: 0, totalTokens: 100 },
         } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
-        replayMetadata: {
-          hadPotentialSideEffects: true,
-          replaySafe: false,
-        },
+        toolMetas: [{ toolName: "browser", replaySafe: false }],
       }),
     );
 
@@ -304,6 +308,10 @@ describe("runEmbeddedAgent silent-error retry", () => {
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
     expect(result.payloads?.[0]?.isError).toBe(true);
+    // Proof: no retry log when side effects detected
+    expect(mockedLog.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("[empty-error-retry]"),
+    );
   });
 
   it.each([
@@ -358,6 +366,40 @@ describe("runEmbeddedAgent silent-error retry", () => {
       expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
     },
   );
+
+  it("retries when prior turns had side effects but current 5xx attempt ran no tools (#97877)", async () => {
+    // Regression for #97877: cumulative replayMetadata from prior-turn tool
+    // activity must not block retry of a later turn whose model call itself
+    // produced no tools. The mock sets replayMetadata dirty (simulating
+    // accumulated session history) but leaves per-attempt fields clean so
+    // currentAttemptReplayMetadata = clean → retry allowed.
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        ...emptyErrorAttempt("ollama", "glm-5.1:cloud"),
+        // Simulate cumulative prior-turn side effects — hadPotentialSideEffects
+        // is true from session accumulation even though this attempt was clean.
+        replayMetadata: { hadPotentialSideEffects: true, replaySafe: false },
+      }),
+    );
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      successAttempt("ollama", "glm-5.1:cloud"),
+    );
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "ollama",
+      model: "glm-5.1:cloud",
+      runId: "run-empty-error-retry-prior-side-effects",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(result.payloads).toBeUndefined();
+    // Proof: [empty-error-retry] fires in the real runner, even with
+    // cumulative replayMetadata dirty from prior-turn tool activity
+    expect(mockedLog.warn).toHaveBeenCalledWith(
+      expect.stringContaining("[empty-error-retry]"),
+    );
+  });
 
   it("does not mark incomplete turns fallback-safe after a terminal heartbeat response", async () => {
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(

--- a/src/agents/embedded-agent-runner/run.empty-error-retry.test.ts
+++ b/src/agents/embedded-agent-runner/run.empty-error-retry.test.ts
@@ -141,11 +141,39 @@ describe("runEmbeddedAgent silent-error retry", () => {
     expect(result.payloads).toBeUndefined();
   });
 
-  it.each([
-    ["timeout", "LLM request timed out."],
-    ["server_error", "Internal server error"],
-  ] as const)("does not intercept recognized %s failover errors", async (reason, errorMessage) => {
-    mockedClassifyAssistantFailoverReason.mockReturnValue(reason);
+  it("does not intercept recognized timeout failover errors", async () => {
+    mockedClassifyAssistantFailoverReason.mockReturnValue("timeout");
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      emptyErrorAttempt(
+        "anthropic",
+        "claude-opus-4-8",
+        1120,
+        [
+          {
+            type: "thinking",
+            thinking: "internal reasoning before provider error",
+            thinkingSignature: JSON.stringify({ id: "rs_timeout", type: "reasoning" }),
+          },
+        ],
+        "LLM request timed out.",
+      ),
+    );
+
+    await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "anthropic",
+      model: "claude-opus-4-8",
+      runId: "run-empty-error-retry-timeout",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries on classified server_error with clean per-attempt state (#97877)", async () => {
+    // server_error from OpenRouter-style HTTP 500 must reach the empty-error
+    // retry path, not be terminated by failover.  The per-attempt guard still
+    // blocks retry when the current attempt itself had side effects.
+    mockedClassifyAssistantFailoverReason.mockReturnValue("server_error");
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       emptyErrorAttempt(
         "anthropic",
@@ -158,18 +186,25 @@ describe("runEmbeddedAgent silent-error retry", () => {
             thinkingSignature: JSON.stringify({ id: "rs_error", type: "reasoning" }),
           },
         ],
-        errorMessage,
+        "Internal server error",
       ),
     );
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      successAttempt("anthropic", "claude-opus-4-8"),
+    );
 
-    await runEmbeddedAgent({
+    const result = await runEmbeddedAgent({
       ...overflowBaseRunParams,
       provider: "anthropic",
       model: "claude-opus-4-8",
-      runId: `run-empty-error-retry-${reason}`,
+      runId: "run-empty-error-retry-server-error",
     });
 
-    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(result.payloads).toBeUndefined();
+    expect(mockedLog.warn).toHaveBeenCalledWith(
+      expect.stringContaining("[empty-error-retry]"),
+    );
   });
 
   it("does not intercept concrete non-transient failover errors", async () => {

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -2785,6 +2785,79 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     ).toBe(false);
   });
 
+  it("retries when cumulative replayMetadata is dirty but currentAttemptReplayMetadata proves clean (#97877)", () => {
+    // Regression for #97877: prior-turn tool activity left cumulative
+    // replayMetadata.hadPotentialSideEffects=true, but the current 5xx
+    // attempt produced no tools and has clean per-attempt metadata.
+    const assistant = {
+      role: "assistant",
+      stopReason: "error",
+      provider: "openrouter",
+      model: "test-model",
+      content: [],
+      usage: { input: 100, output: 0, totalTokens: 100 },
+    } as unknown as EmbeddedRunAttemptResult["lastAssistant"];
+    expect(
+      shouldRetrySilentErrorAssistantTurn({
+        attempt: makeAttemptResult({
+          assistantTexts: [],
+          lastAssistant: assistant,
+          // Cumulative: dirty from prior turns
+          replayMetadata: { hadPotentialSideEffects: true, replaySafe: false },
+          // Per-attempt: clean — current model call ran no tools
+          currentAttemptReplayMetadata: { hadPotentialSideEffects: false, replaySafe: true },
+        }),
+        assistant,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not retry when currentAttemptReplayMetadata records side effects", () => {
+    // Current attempt ran tools; must not retry even if cumulative
+    // replayMetadata accidentally appears clean.
+    const assistant = {
+      role: "assistant",
+      stopReason: "error",
+      provider: "openrouter",
+      model: "test-model",
+      content: [],
+      usage: { input: 100, output: 0, totalTokens: 100 },
+    } as unknown as EmbeddedRunAttemptResult["lastAssistant"];
+    expect(
+      shouldRetrySilentErrorAssistantTurn({
+        attempt: makeAttemptResult({
+          assistantTexts: [],
+          lastAssistant: assistant,
+          replayMetadata: { hadPotentialSideEffects: false, replaySafe: true },
+          currentAttemptReplayMetadata: { hadPotentialSideEffects: true, replaySafe: false },
+        }),
+        assistant,
+      }),
+    ).toBe(false);
+  });
+
+  it("retries when both replayMetadata and currentAttemptReplayMetadata are clean", () => {
+    const assistant = {
+      role: "assistant",
+      stopReason: "error",
+      provider: "openrouter",
+      model: "test-model",
+      content: [],
+      usage: { input: 100, output: 0, totalTokens: 100 },
+    } as unknown as EmbeddedRunAttemptResult["lastAssistant"];
+    expect(
+      shouldRetrySilentErrorAssistantTurn({
+        attempt: makeAttemptResult({
+          assistantTexts: [],
+          lastAssistant: assistant,
+          replayMetadata: { hadPotentialSideEffects: false, replaySafe: true },
+          currentAttemptReplayMetadata: { hadPotentialSideEffects: false, replaySafe: true },
+        }),
+        assistant,
+      }),
+    ).toBe(true);
+  });
+
   it("detects empty openai-compatible stop turns with non-zero output usage", () => {
     const retryInstruction = resolveEmptyResponseRetryInstruction({
       provider: "llamacpp",

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -209,6 +209,7 @@ import {
   stepIdleTimeoutBreaker,
 } from "./run/idle-timeout-breaker.js";
 import {
+  buildAttemptReplayMetadata,
   DEFAULT_EMPTY_RESPONSE_RETRY_LIMIT,
   DEFAULT_REASONING_ONLY_RETRY_LIMIT,
   hasAttemptTerminalState,
@@ -419,6 +420,20 @@ function normalizeEmbeddedRunAttemptResult(
       activeCount: 0,
     },
     replayMetadata: resolveAttemptReplayMetadata(raw),
+    // Per-attempt metadata re-derived from raw fields so the retry gate can
+    // distinguish "this model call had no tool side effects" from "cumulative
+    // session replayMetadata carries prior-turn history". Using raw.replayMetadata
+    // would give the already-accumulated value (attempt.ts merges with accumulated
+    // replay state before returning).
+    currentAttemptReplayMetadata: buildAttemptReplayMetadata({
+      toolMetas: raw.toolMetas ?? [],
+      didSendViaMessagingTool: raw.didSendViaMessagingTool ?? false,
+      messagingToolSentTexts: raw.messagingToolSentTexts ?? [],
+      messagingToolSentMediaUrls: raw.messagingToolSentMediaUrls ?? [],
+      messagingToolSentTargets: raw.messagingToolSentTargets ?? [],
+      successfulCronAdds: raw.successfulCronAdds ?? 0,
+      acceptedSessionSpawns: raw.acceptedSessionSpawns ?? [],
+    }),
   };
 }
 
@@ -3170,7 +3185,7 @@ async function runEmbeddedAgentInternal(
               promptFailoverReason === "timeout" &&
               !attempt.codexAppServerFailure &&
               attempt.promptTimeoutOutcome?.replayInvalid !== true &&
-              attempt.replayMetadata.replaySafe;
+              resolveAttemptReplayMetadata(attempt).replaySafe;
             // Capture the failing profile before auth-profile rotation mutates `lastProfileId`.
             const failedPromptProfileId = lastProfileId;
             const logPromptFailoverDecision = createFailoverDecisionLogger({

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -3375,7 +3375,8 @@ async function runEmbeddedAgentInternal(
             genericUnknownReasoningError ||
             assistantFailoverReason === "no_error_details" ||
             assistantFailoverReason === "unclassified" ||
-            assistantFailoverReason === "unknown";
+            assistantFailoverReason === "unknown" ||
+            assistantFailoverReason === "server_error";
           // Retry replay-safe non-visible provider errors before assistant
           // failover surfaces them as terminal provider failures.
           if (

--- a/src/agents/embedded-agent-runner/run/incomplete-turn.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn.ts
@@ -536,6 +536,7 @@ export function shouldRetrySilentErrorAssistantTurn(params: {
     | "didDeliverSourceReplyViaMessageTool"
     | "messagingToolSourceReplyPayloads"
     | "replayMetadata"
+    | "currentAttemptReplayMetadata"
   >;
   assistant: EmbeddedRunAttemptResult["lastAssistant"] | null | undefined;
 }): boolean {
@@ -545,7 +546,12 @@ export function shouldRetrySilentErrorAssistantTurn(params: {
   if (hasAttemptTerminalState(params.attempt)) {
     return false;
   }
-  if (resolveAttemptReplayMetadata(params.attempt).hadPotentialSideEffects) {
+  // Prefer current-attempt metadata to decide whether this specific model
+  // call had side effects. Falls back to cumulative replayMetadata for
+  // harnesses that do not yet populate currentAttemptReplayMetadata.
+  const currentAttemptMeta =
+    params.attempt.currentAttemptReplayMetadata ?? params.attempt.replayMetadata;
+  if (currentAttemptMeta?.hadPotentialSideEffects) {
     return false;
   }
 

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -238,6 +238,13 @@ export type EmbeddedRunAttemptResult = {
   /** True when sessions_yield tool was called during this attempt. */
   yieldDetected?: boolean;
   replayMetadata: EmbeddedRunReplayMetadata;
+  /**
+   * Replay metadata for the current attempt only, before accumulation with
+   * prior session state. Used by the silent-error retry gate to distinguish
+   * "this model call failed before tools ran" from "prior turns had side
+   * effects." Absent when the attempt returned before tool execution started.
+   */
+  currentAttemptReplayMetadata?: EmbeddedRunReplayMetadata | null;
   itemLifecycle: {
     startedCount: number;
     completedCount: number;


### PR DESCRIPTION
## What Problem This Solves

Fixes #97877 — two bugs in the `empty-error-retry` path:

**Bug 1:** `server_error` classification was not routed into the silent-error retry path. When OpenRouter/Anthropic returned HTTP 500 with `errorType: "server_error"`, the classifier correctly returned `"server_error"`, but it was missing from the `silentErrorRetryReason` allowlist — causing immediate terminal failover instead of retry.

**Bug 2:** Cumulative `replayMetadata.hadPotentialSideEffects` blocked retry after any prior-turn tool call. Once a session executed tools on Turn 1, the monotonically OR-merged flag stayed `true` forever, permanently disabling retry for all subsequent turns — even when the 5xx error occurred on a clean model call with zero tool side effects.

## Why This Change Was Made

**Bug 1 fix** (`run.ts`): Added `assistantFailoverReason === "server_error"` to the `silentErrorRetryReason` list (line 3379), alongside `null`, `no_error_details`, `unclassified`, `unknown`, and `genericUnknownReasoningError`.

**Bug 2 fix** (3 files):

1. **`types.ts`** — Added `currentAttemptReplayMetadata?: EmbeddedRunReplayMetadata | null` field, computed from raw per-attempt fields *before* accumulation with session state.

2. **`run.ts`** — `normalizeEmbeddedRunAttemptResult` computes `currentAttemptReplayMetadata` via `buildAttemptReplayMetadata` from per-attempt raw fields (`toolMetas`, `didSendViaMessagingTool`, etc.).

3. **`incomplete-turn.ts`** — `shouldRetrySilentErrorAssistantTurn` now prefers `currentAttemptReplayMetadata` to decide side effects, falling back to cumulative `replayMetadata` for backward compat:
   ```typescript
   const currentAttemptMeta =
     params.attempt.currentAttemptReplayMetadata ?? params.attempt.replayMetadata;
   if (currentAttemptMeta?.hadPotentialSideEffects) {
     return false;
   }
   ```

## Evidence

### Real behavior proof

Uses the **real** `classifyAssistantFailoverReason` (via `vi.importActual`, not mocked) with realistic provider error payloads flowing through the full pipeline: classify → retry gate → retry loop → `[empty-error-retry]` log.

**Real log output captured from production `run.ts:3397`:**

```
═══ REAL LOG ═══
[empty-error-retry] stopReason=error non-visible-output; resubmitting
  attempt=1/3 provider=openrouter model=anthropic/claude-opus-4-8 sessionKey=test-key
═══════════════

═══ REAL LOG ═══
[empty-error-retry] stopReason=error non-visible-output; resubmitting
  attempt=2/3 provider=openrouter model=anthropic/claude-opus-4-8 sessionKey=test-key
═══════════════

═══ REAL LOG ═══
[empty-error-retry] stopReason=error non-visible-output; resubmitting
  attempt=3/3 provider=openrouter model=anthropic/claude-opus-4-8 sessionKey=test-key
═══════════════
```

### Real behavior proof discovery

Tested the real `classifyAssistantFailoverReason` with exhaustive payload shapes to determine when `"server_error"` is returned:

| errorType | errorMessage | errorBody | Classifier returns |
|-----------|-------------|-----------|--------------------|
| `"server_error"` | empty/absent | absent | `"server_error"` ✅ |
| `"upstream_error"` | empty/absent | absent | `"server_error"` ✅ |
| absent | empty | `{"type":"server_error"}` | `"server_error"` ✅ |
| absent | `{"code":"server_error"}` (JSON) | absent | `"server_error"` ✅ |
| `"server_error"` | `"Internal server error"` | absent | `"timeout"` (HTTP status takes priority) |

### Real runner-path E2E matrix (8/8 passing)

| Test | Real Data Shape | Real Classifier | Retry? | Result |
|------|----------------|-----------------|--------|--------|
| errorType-based, no msg | `errorType="server_error"`, empty msg | ✅ | ✅ | 2 attempts |
| errorBody structured | `{"type":"server_error"}` in body, empty msg | ✅ | ✅ | 2 attempts |
| errorMessage JSON | `{"code":"server_error"}` as msg | ✅ | ✅ | 2 attempts |
| Zero tokens, no content | `errorType="server_error"`, 0 tokens | ✅ | ✅ | 2 attempts |
| Log field verification | sessionKey, provider, model in log | ✅ | ✅ | All fields present |
| Current attempt with tools | `toolMetas: [{browser, unsafe}]` | ✅ | ❌ | 1 attempt, error surfaced |
| Cumulative dirty, current clean | `replayMetadata` dirty, per-attempt clean | ✅ | ✅ | 2 attempts |
| Exhaustion cap (3 retries) | 4 consecutive server_error | ✅ | ❌ (4th) | 4 attempts, error surfaced |

### Existing test coverage

```
All tests passing:

run.empty-error-retry.test.ts          23/23 passed
run.empty-error-retry.real-data.test.ts  8/8 passed  (NEW)
run.incomplete-turn.test.ts           114/114 passed (includes 3 new #97877 tests)
```

### Behavior matrix

| currentAttempt side effects | cumulative session side effects | Retry? | Scenario |
|---|---|---|---|
| clean | clean | ✅ | No tools in session |
| clean | dirty (prior-turn tools) | ✅ | **#97877 fix** |
| dirty | dirty | ❌ | Tools ran in this attempt |
| dirty | clean | ❌ | Tools ran in this attempt |
| legacy (no field) | dirty | ❌ | Backward compat |

## Diff scope

```
6 files changed, 612 insertions(+), 17 deletions(-)
  run.ts                                    |  20 +++-
  run/incomplete-turn.ts                    |   8 +-
  run/types.ts                              |   7 +
  run.empty-error-retry.test.ts             | 105 ++++++++++--
  run.incomplete-turn.test.ts               |  73 ++++++++
  run.empty-error-retry.real-data.test.ts   | 416 +++++++++++++++++++++  (NEW)
```

## Compatibility

- `currentAttemptReplayMetadata` is optional and nullable; absent for harnesses that don't populate it.
- Fallback `?? params.attempt.replayMetadata` preserves backward compat.
- No config/env changes, no migration needed.