### PR TITLE
fix: block no-auth managed gateway LAN installs

### DIFF
--- a/src/cli/daemon-cli/install.test.ts
+++ b/src/cli/daemon-cli/install.test.ts
@@ -513,7 +513,7 @@ describe("runDaemonInstall", () => {
         bind: "lan",
         auth: {
           mode: "none",
-          token: "durable-token",
+          token: "test-token",
         },
       },
     };
@@ -525,7 +525,7 @@ describe("runDaemonInstall", () => {
     });
     resolveGatewayAuthMock.mockReturnValue({
       mode: "none",
-      token: "durable-token",
+      token: "test-token",
       password: undefined,
       allowTailscale: false,
     });

--- a/src/cli/daemon-cli/install.test.ts
+++ b/src/cli/daemon-cli/install.test.ts
@@ -1,7 +1,7 @@
 // Daemon install tests cover service install command behavior and plan handling.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ResolvedGatewayAuth } from "../../gateway/auth.js";
-import { captureFullEnv } from "../../test-utils/env.js";
+import { captureFullEnv, withEnvAsync } from "../../test-utils/env.js";
 import { createCliRuntimeCapture } from "../test-runtime-capture.js";
 import type { DaemonActionResponse } from "./response.js";
 
@@ -495,6 +495,70 @@ describe("runDaemonInstall", () => {
     });
   });
 
+  it("blocks managed install when explicit no-auth would bind to LAN", async () => {
+    const config = {
+      gateway: {
+        mode: "local",
+        bind: "lan",
+        auth: {
+          mode: "none",
+          token: "durable-token",
+        },
+      },
+    };
+    readConfigFileSnapshotMock.mockResolvedValue({
+      exists: true,
+      valid: true,
+      config,
+      sourceConfig: config,
+    });
+    resolveGatewayAuthMock.mockReturnValue({
+      mode: "none",
+      token: "durable-token",
+      password: undefined,
+      allowTailscale: false,
+    });
+
+    await runDaemonInstall({ json: true });
+
+    expect(actionState.failed[0]?.message).toContain("Gateway install blocked");
+    expect(actionState.failed[0]?.message).toContain("gateway.bind=lan");
+    expect(actionState.failed[0]?.message).toContain("gateway.auth.mode=none");
+    expect(actionState.failed[0]?.message).toContain("openclaw config set gateway.auth.mode token");
+    expect(buildGatewayInstallPlanMock).not.toHaveBeenCalled();
+    expect(installDaemonServiceAndEmitMock).not.toHaveBeenCalled();
+  });
+
+  it("allows managed install when explicit no-auth stays on loopback", async () => {
+    const config = {
+      gateway: {
+        mode: "local",
+        bind: "loopback",
+        auth: {
+          mode: "none",
+        },
+      },
+    };
+    readConfigFileSnapshotMock.mockResolvedValue({
+      exists: true,
+      valid: true,
+      config,
+      sourceConfig: config,
+    });
+    resolveGatewayAuthMock.mockReturnValue({
+      mode: "none",
+      token: undefined,
+      password: undefined,
+      allowTailscale: false,
+    });
+
+    await runDaemonInstall({ json: true });
+
+    expect(actionState.failed).toStrictEqual([]);
+    expect(buildGatewayInstallPlanMock).toHaveBeenCalledTimes(1);
+    expect(installDaemonServiceAndEmitMock).toHaveBeenCalledTimes(1);
+  });
+
   it("does not persist gateway mode when runtime validation fails", async () => {
     readConfigFileSnapshotMock.mockResolvedValue({
       exists: true,
@@ -779,27 +843,27 @@ describe("runDaemonInstall", () => {
       },
     } as never);
 
-    const previous = process.env.OPENAI_API_KEY;
-    delete process.env.OPENAI_API_KEY;
-    try {
-      await runDaemonInstall({ json: true, force: true });
+    await withEnvAsync(
+      {
+        OPENAI_API_KEY: undefined,
+        OPENCLAW_STATE_DIR: undefined,
+        OPENCLAW_CONFIG_PATH: undefined,
+        OPENCLAW_GATEWAY_TOKEN: undefined,
+      },
+      async () => {
+        await runDaemonInstall({ json: true, force: true });
 
-      expectFields(readFirstInstallPlanArg().env, {
-        OPENAI_API_KEY: "service-openai-key",
-      });
-      const env = readFirstInstallPlanArg().env as Record<string, string | undefined>;
-      expect(env.OPENCLAW_STATE_DIR).toBeUndefined();
-      expect(env.OPENCLAW_CONFIG_PATH).toBeUndefined();
-      expect(env.OPENCLAW_GATEWAY_TOKEN).toBeUndefined();
-      expect(env.NODE_OPTIONS).toBeUndefined();
-      expect(env.PATH).not.toContain("/tmp/doctor-bin");
-      expect(installDaemonServiceAndEmitMock).toHaveBeenCalledTimes(1);
-    } finally {
-      if (previous === undefined) {
-        delete process.env.OPENAI_API_KEY;
-      } else {
-        process.env.OPENAI_API_KEY = previous;
-      }
-    }
+        expectFields(readFirstInstallPlanArg().env, {
+          OPENAI_API_KEY: "service-openai-key",
+        });
+        const env = readFirstInstallPlanArg().env as Record<string, string | undefined>;
+        expect(env.OPENCLAW_STATE_DIR).toBeUndefined();
+        expect(env.OPENCLAW_CONFIG_PATH).toBeUndefined();
+        expect(env.OPENCLAW_GATEWAY_TOKEN).toBeUndefined();
+        expect(env.NODE_OPTIONS).toBeUndefined();
+        expect(env.PATH).not.toContain("/tmp/doctor-bin");
+        expect(installDaemonServiceAndEmitMock).toHaveBeenCalledTimes(1);
+      },
+    );
   });
 });

--- a/src/cli/daemon-cli/install.test.ts
+++ b/src/cli/daemon-cli/install.test.ts
@@ -30,6 +30,7 @@ const resolveGatewayAuthMock = vi.hoisted(() =>
     allowTailscale: false,
   })),
 );
+const resolveGatewayBindHostMock = vi.hoisted(() => vi.fn(async () => "127.0.0.1"));
 const resolveSecretRefValuesMock = vi.hoisted(() => vi.fn());
 const randomTokenMock = vi.hoisted(() => vi.fn(() => "generated-token"));
 const createInstallPlanFixture = vi.hoisted(() => {
@@ -118,6 +119,14 @@ vi.mock("../../config/types.secrets.js", () => ({
 vi.mock("../../gateway/auth.js", () => ({
   resolveGatewayAuth: resolveGatewayAuthMock,
 }));
+
+vi.mock("../../gateway/net.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../gateway/net.js")>();
+  return {
+    ...actual,
+    resolveGatewayBindHost: resolveGatewayBindHostMock,
+  };
+});
 
 vi.mock("../../secrets/resolve.js", () => ({
   resolveSecretRefValues: resolveSecretRefValuesMock,
@@ -267,6 +276,7 @@ describe("runDaemonInstall", () => {
     resolveIsNixModeMock.mockReset();
     resolveSecretInputRefMock.mockReset();
     resolveGatewayAuthMock.mockReset();
+    resolveGatewayBindHostMock.mockReset();
     resolveSecretRefValuesMock.mockReset();
     randomTokenMock.mockReset();
     buildGatewayInstallPlanMock.mockReset();
@@ -298,6 +308,7 @@ describe("runDaemonInstall", () => {
       password: undefined,
       allowTailscale: false,
     });
+    resolveGatewayBindHostMock.mockResolvedValue("127.0.0.1");
     resolveSecretRefValuesMock.mockResolvedValue(new Map());
     randomTokenMock.mockReturnValue("generated-token");
     buildGatewayInstallPlanMock.mockImplementation(createInstallPlanFixture);
@@ -518,6 +529,7 @@ describe("runDaemonInstall", () => {
       password: undefined,
       allowTailscale: false,
     });
+    resolveGatewayBindHostMock.mockResolvedValue("0.0.0.0");
 
     await runDaemonInstall({ json: true });
 
@@ -529,14 +541,42 @@ describe("runDaemonInstall", () => {
     expect(installDaemonServiceAndEmitMock).not.toHaveBeenCalled();
   });
 
-  it("allows managed install when explicit no-auth stays on loopback", async () => {
+  it.each([
+    {
+      name: "custom bind resolving to a network interface",
+      bind: "custom" as const,
+      customBindHost: "192.168.1.20",
+      resolvedHost: "192.168.1.20",
+      blocked: true,
+    },
+    {
+      name: "tailnet bind resolving to a tailnet interface",
+      bind: "tailnet" as const,
+      customBindHost: undefined,
+      resolvedHost: "100.64.0.20",
+      blocked: true,
+    },
+    {
+      name: "tailnet bind falling back to loopback",
+      bind: "tailnet" as const,
+      customBindHost: undefined,
+      resolvedHost: "127.0.0.1",
+      blocked: false,
+    },
+    {
+      name: "loopback bind",
+      bind: "loopback" as const,
+      customBindHost: undefined,
+      resolvedHost: "127.0.0.1",
+      blocked: false,
+    },
+  ])("handles explicit no-auth for $name", async (testCase) => {
     const config = {
       gateway: {
-        mode: "local",
-        bind: "loopback",
-        auth: {
-          mode: "none",
-        },
+        mode: "local" as const,
+        bind: testCase.bind,
+        customBindHost: testCase.customBindHost,
+        auth: { mode: "none" as const },
       },
     };
     readConfigFileSnapshotMock.mockResolvedValue({
@@ -551,6 +591,44 @@ describe("runDaemonInstall", () => {
       password: undefined,
       allowTailscale: false,
     });
+    resolveGatewayBindHostMock.mockResolvedValue(testCase.resolvedHost);
+
+    await runDaemonInstall({ json: true });
+
+    expect(resolveGatewayBindHostMock).toHaveBeenCalledWith(testCase.bind, testCase.customBindHost);
+    if (testCase.blocked) {
+      expect(actionState.failed[0]?.message).toContain(`gateway.bind=${testCase.bind}`);
+      expect(buildGatewayInstallPlanMock).not.toHaveBeenCalled();
+      expect(installDaemonServiceAndEmitMock).not.toHaveBeenCalled();
+    } else {
+      expect(actionState.failed).toStrictEqual([]);
+      expect(buildGatewayInstallPlanMock).toHaveBeenCalledTimes(1);
+      expect(installDaemonServiceAndEmitMock).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it("allows a managed LAN install with trusted-proxy auth", async () => {
+    const config = {
+      gateway: {
+        mode: "local" as const,
+        bind: "lan" as const,
+        trustedProxies: ["127.0.0.1"],
+        auth: { mode: "trusted-proxy" as const },
+      },
+    };
+    readConfigFileSnapshotMock.mockResolvedValue({
+      exists: true,
+      valid: true,
+      config,
+      sourceConfig: config,
+    });
+    resolveGatewayAuthMock.mockReturnValue({
+      mode: "trusted-proxy",
+      token: undefined,
+      password: undefined,
+      allowTailscale: false,
+    });
+    resolveGatewayBindHostMock.mockResolvedValue("0.0.0.0");
 
     await runDaemonInstall({ json: true });
 

--- a/src/cli/daemon-cli/install.test.ts
+++ b/src/cli/daemon-cli/install.test.ts
@@ -548,6 +548,7 @@ describe("runDaemonInstall", () => {
       customBindHost: "192.168.1.20",
       resolvedHost: "192.168.1.20",
       blocked: true,
+      message: undefined,
     },
     {
       name: "tailnet bind resolving to a tailnet interface",
@@ -555,13 +556,15 @@ describe("runDaemonInstall", () => {
       customBindHost: undefined,
       resolvedHost: "100.64.0.20",
       blocked: true,
+      message: undefined,
     },
     {
       name: "tailnet bind falling back to loopback",
       bind: "tailnet" as const,
       customBindHost: undefined,
       resolvedHost: "127.0.0.1",
-      blocked: false,
+      blocked: true,
+      message: "can later resolve to a Tailnet interface",
     },
     {
       name: "loopback bind",
@@ -569,6 +572,7 @@ describe("runDaemonInstall", () => {
       customBindHost: undefined,
       resolvedHost: "127.0.0.1",
       blocked: false,
+      message: undefined,
     },
   ])("handles explicit no-auth for $name", async (testCase) => {
     const config = {
@@ -598,6 +602,9 @@ describe("runDaemonInstall", () => {
     expect(resolveGatewayBindHostMock).toHaveBeenCalledWith(testCase.bind, testCase.customBindHost);
     if (testCase.blocked) {
       expect(actionState.failed[0]?.message).toContain(`gateway.bind=${testCase.bind}`);
+      if (testCase.message) {
+        expect(actionState.failed[0]?.message).toContain(testCase.message);
+      }
       expect(buildGatewayInstallPlanMock).not.toHaveBeenCalled();
       expect(installDaemonServiceAndEmitMock).not.toHaveBeenCalled();
     } else {

--- a/src/cli/daemon-cli/install.test.ts
+++ b/src/cli/daemon-cli/install.test.ts
@@ -1,7 +1,7 @@
 // Daemon install tests cover service install command behavior and plan handling.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ResolvedGatewayAuth } from "../../gateway/auth.js";
-import { captureFullEnv, withEnvAsync } from "../../test-utils/env.js";
+import { captureFullEnv } from "../../test-utils/env.js";
 import { createCliRuntimeCapture } from "../test-runtime-capture.js";
 import type { DaemonActionResponse } from "./response.js";
 
@@ -921,27 +921,27 @@ describe("runDaemonInstall", () => {
       },
     } as never);
 
-    await withEnvAsync(
-      {
-        OPENAI_API_KEY: undefined,
-        OPENCLAW_STATE_DIR: undefined,
-        OPENCLAW_CONFIG_PATH: undefined,
-        OPENCLAW_GATEWAY_TOKEN: undefined,
-      },
-      async () => {
-        await runDaemonInstall({ json: true, force: true });
+    const previous = process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    try {
+      await runDaemonInstall({ json: true, force: true });
 
-        expectFields(readFirstInstallPlanArg().env, {
-          OPENAI_API_KEY: "service-openai-key",
-        });
-        const env = readFirstInstallPlanArg().env as Record<string, string | undefined>;
-        expect(env.OPENCLAW_STATE_DIR).toBeUndefined();
-        expect(env.OPENCLAW_CONFIG_PATH).toBeUndefined();
-        expect(env.OPENCLAW_GATEWAY_TOKEN).toBeUndefined();
-        expect(env.NODE_OPTIONS).toBeUndefined();
-        expect(env.PATH).not.toContain("/tmp/doctor-bin");
-        expect(installDaemonServiceAndEmitMock).toHaveBeenCalledTimes(1);
-      },
-    );
+      expectFields(readFirstInstallPlanArg().env, {
+        OPENAI_API_KEY: "service-openai-key",
+      });
+      const env = readFirstInstallPlanArg().env as Record<string, string | undefined>;
+      expect(env.OPENCLAW_STATE_DIR).toBeUndefined();
+      expect(env.OPENCLAW_CONFIG_PATH).toBeUndefined();
+      expect(env.OPENCLAW_GATEWAY_TOKEN).toBeUndefined();
+      expect(env.NODE_OPTIONS).toBeUndefined();
+      expect(env.PATH).not.toContain("/tmp/doctor-bin");
+      expect(installDaemonServiceAndEmitMock).toHaveBeenCalledTimes(1);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.OPENAI_API_KEY;
+      } else {
+        process.env.OPENAI_API_KEY = previous;
+      }
+    }
   });
 });

--- a/src/cli/daemon-cli/install.ts
+++ b/src/cli/daemon-cli/install.ts
@@ -18,6 +18,12 @@ import { readEmbeddedGatewayToken } from "../../daemon/service-audit.js";
 import { resolveGatewayService } from "../../daemon/service.js";
 import type { GatewayServiceCommandConfig } from "../../daemon/service.js";
 import { isNonFatalSystemdInstallProbeError } from "../../daemon/systemd.js";
+import { resolveGatewayAuth } from "../../gateway/auth.js";
+import {
+  defaultGatewayBindMode,
+  isLoopbackHost,
+  resolveGatewayBindHost,
+} from "../../gateway/net.js";
 import {
   formatExternalSupervisorActionRequired,
   isGatewayExternallySupervised,
@@ -37,6 +43,46 @@ import {
   parsePort,
 } from "./shared.js";
 import type { DaemonInstallOptions } from "./types.js";
+
+type InstallBindMode = NonNullable<NonNullable<OpenClawConfig["gateway"]>["bind"]>;
+
+function resolveGatewayInstallBindMode(cfg: OpenClawConfig): InstallBindMode {
+  return (cfg.gateway?.bind ??
+    defaultGatewayBindMode(cfg.gateway?.tailscale?.mode ?? "off")) as InstallBindMode;
+}
+
+function formatNoAuthNonLoopbackInstallBlock(params: {
+  bind: InstallBindMode;
+  bindHost: string;
+  config: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+}): string | undefined {
+  const auth = resolveGatewayAuth({
+    authConfig: params.config.gateway?.auth,
+    env: params.env,
+    tailscaleMode: params.config.gateway?.tailscale?.mode ?? "off",
+  });
+  if (auth.mode !== "none" || isLoopbackHost(params.bindHost)) {
+    return undefined;
+  }
+  const hints: string[] = [
+    `gateway.bind=${params.bind} resolves to ${params.bindHost}, but gateway.auth.mode=none disables Gateway auth.`,
+  ];
+  if (normalizeOptionalString(auth.token)) {
+    hints.push(
+      `This config already has gateway.auth.token; run ${formatCliCommand("openclaw config set gateway.auth.mode token")} and then rerun ${formatCliCommand("openclaw gateway install --force")}.`,
+    );
+  } else if (normalizeOptionalString(auth.password)) {
+    hints.push(
+      `This config already has gateway.auth.password; run ${formatCliCommand("openclaw config set gateway.auth.mode password")} and then rerun ${formatCliCommand("openclaw gateway install --force")}.`,
+    );
+  } else {
+    hints.push(
+      `Configure token/password auth, use trusted-proxy auth, or set ${formatCliCommand("openclaw config set gateway.bind loopback")} before installing the managed service.`,
+    );
+  }
+  return hints.join(" ");
+}
 
 /** Merge safe existing service environment into the current install invocation environment. */
 export function mergeInstallInvocationEnv(params: {
@@ -204,6 +250,18 @@ export async function runDaemonInstall(opts: DaemonInstallOptions) {
       fail(`Invalid ${OPENCLAW_WRAPPER_ENV_KEY}: ${String(err)}`);
       return;
     }
+  }
+  const installBind = resolveGatewayInstallBindMode(cfg);
+  const installBindHost = await resolveGatewayBindHost(installBind, cfg.gateway?.customBindHost);
+  const noAuthNonLoopbackBlock = formatNoAuthNonLoopbackInstallBlock({
+    bind: installBind,
+    bindHost: installBindHost,
+    config: cfg,
+    env: installEnv,
+  });
+  if (noAuthNonLoopbackBlock) {
+    fail(`Gateway install blocked: ${noAuthNonLoopbackBlock}`);
+    return;
   }
   if (loaded) {
     if (!opts.force) {

--- a/src/cli/daemon-cli/install.ts
+++ b/src/cli/daemon-cli/install.ts
@@ -12,6 +12,7 @@ import { resolveFutureConfigActionBlock } from "../../config/future-version-guar
 import { readConfigFileSnapshotForWrite } from "../../config/io.js";
 import { replaceConfigFile } from "../../config/mutate.js";
 import { resolveGatewayPort } from "../../config/paths.js";
+import type { GatewayBindMode } from "../../config/types.gateway.js";
 import type { OpenClawConfig } from "../../config/types.js";
 import { OPENCLAW_WRAPPER_ENV_KEY, resolveOpenClawWrapperPath } from "../../daemon/program-args.js";
 import { readEmbeddedGatewayToken } from "../../daemon/service-audit.js";
@@ -44,15 +45,12 @@ import {
 } from "./shared.js";
 import type { DaemonInstallOptions } from "./types.js";
 
-type InstallBindMode = NonNullable<NonNullable<OpenClawConfig["gateway"]>["bind"]>;
-
-function resolveGatewayInstallBindMode(cfg: OpenClawConfig): InstallBindMode {
-  return (cfg.gateway?.bind ??
-    defaultGatewayBindMode(cfg.gateway?.tailscale?.mode ?? "off")) as InstallBindMode;
+function resolveGatewayInstallBindMode(cfg: OpenClawConfig): GatewayBindMode {
+  return cfg.gateway?.bind ?? defaultGatewayBindMode(cfg.gateway?.tailscale?.mode ?? "off");
 }
 
 function formatNoAuthNonLoopbackInstallBlock(params: {
-  bind: InstallBindMode;
+  bind: GatewayBindMode;
   bindHost: string;
   config: OpenClawConfig;
   env: NodeJS.ProcessEnv;

--- a/src/cli/daemon-cli/install.ts
+++ b/src/cli/daemon-cli/install.ts
@@ -60,12 +60,15 @@ function formatNoAuthNonLoopbackInstallBlock(params: {
     env: params.env,
     tailscaleMode: params.config.gateway?.tailscale?.mode ?? "off",
   });
-  if (auth.mode !== "none" || isLoopbackHost(params.bindHost)) {
+  const bindCanExposeNetwork = params.bind === "tailnet" || !isLoopbackHost(params.bindHost);
+  if (auth.mode !== "none" || !bindCanExposeNetwork) {
     return undefined;
   }
-  const hints: string[] = [
-    `gateway.bind=${params.bind} resolves to ${params.bindHost}, but gateway.auth.mode=none disables Gateway auth.`,
-  ];
+  const bindReason =
+    params.bind === "tailnet" && isLoopbackHost(params.bindHost)
+      ? `gateway.bind=tailnet currently resolves to ${params.bindHost} but can later resolve to a Tailnet interface`
+      : `gateway.bind=${params.bind} resolves to ${params.bindHost}`;
+  const hints: string[] = [`${bindReason}, but gateway.auth.mode=none disables Gateway auth.`];
   if (normalizeOptionalString(auth.token)) {
     hints.push(
       `This config already has gateway.auth.token; run ${formatCliCommand("openclaw config set gateway.auth.mode token")} and then rerun ${formatCliCommand("openclaw gateway install --force")}.`,


### PR DESCRIPTION
Related: #97970

## What Problem This Solves

Fixes an issue where users with a managed Gateway service could end up with a dead Dashboard after the service is refreshed or restarted while `gateway.bind` resolves outside loopback and `gateway.auth.mode` is explicitly `none`.

I hit this on a real Windows Scheduled Task install after a Dashboard `/pair qr` attempt. The Gateway service was stopped, a manual gateway start refused to bind, and the Dashboard stopped responding. The redacted config shape was:

```text
gateway.bind = lan
gateway.auth.mode = none
gateway.auth.token = configured
```

The runtime fail-closed message was:

```text
Refusing to bind gateway to lan without auth.
```

## Why This Change Was Made

The existing Gateway runtime safety guard is correct: an unauthenticated Gateway must not silently bind to LAN. This change moves the same safety check earlier into the managed install/refresh path so `openclaw gateway install --force` stops before writing or refreshing a service that the runtime will reject.

The install guard resolves the effective bind host with the Gateway bind resolver, resolves the effective auth mode from the install environment, and blocks only the invalid non-loopback + explicit no-auth combination. Loopback no-auth installs, token/password auth, trusted-proxy auth, and existing token generation paths remain on the existing flow.

## User Impact

Operators get an actionable install-time error instead of a Gateway service that exits or restart-loops and leaves the Dashboard unreachable. When a token is already configured but inactive because `auth.mode` is `none`, the error points users at `openclaw config set gateway.auth.mode token` before rerunning `openclaw gateway install --force`.

## Evidence

Real Windows incident proof, redacted:

```text
OpenClaw 2026.6.11-beta.2
Gateway service: Windows Scheduled Task
Observed config: gateway.bind=lan, gateway.auth.mode=none, gateway.auth.token present
Manual gateway start: Refusing to bind gateway to lan without auth.
After local config repair: gateway.auth.mode=token
openclaw gateway status: running, connectivity probe ok, auth token, listening 0.0.0.0:18889
openclaw status: Gateway reachable, auth token, Gateway service running
```

After-fix managed install proof on this branch, using an isolated `OPENCLAW_CONFIG_PATH` with `gateway.bind=lan`, `gateway.auth.mode=none`, and a redacted configured token:

```text
$ node scripts\run-node.mjs gateway install --force --json
{
  "action": "install",
  "ok": false,
  "error": "Gateway install blocked: gateway.bind=lan resolves to 0.0.0.0, but gateway.auth.mode=none disables Gateway auth. This config already has gateway.auth.token; run openclaw config set gateway.auth.mode token and then rerun openclaw gateway install --force."
}
exit=1
```

This proves the current branch stops the managed install/refresh path before service rewrite for the invalid no-auth LAN configuration.

Local validation on this branch:

```text
node scripts/test-projects.mjs src/cli/daemon-cli/install.test.ts -- --reporter dot --pool threads --maxWorkers 1 --no-file-parallelism
Test Files  1 passed (1)
Tests       25 passed (25)

pnpm tsgo:core --pretty false
passed

pnpm exec oxfmt --check --threads=1 src/cli/daemon-cli/install.ts src/cli/daemon-cli/install.test.ts
All matched files use the correct format.

git diff --check upstream/main...HEAD
passed

python .agents\skills\autoreview\scripts\autoreview --mode branch --base upstream/main
autoreview clean: no accepted/actionable findings reported
```

Proof limitation: I did not prove the broader claim from #97970 that `openclaw update` itself writes `gateway.bind=lan` when the field was previously omitted. This PR intentionally targets the confirmed managed install/refresh boundary and preserves the runtime no-auth LAN refusal.
