### PR TITLE
fix(usage): re-estimate cost when known-priced model records total: 0 (#97047)

### DIFF
--- a/src/cli/plugins-cli.install.test.ts
+++ b/src/cli/plugins-cli.install.test.ts
@@ -1206,6 +1206,8 @@ describe("plugins cli install", () => {
       ok: true,
       pluginId: "alpha",
       targetDir: cliInstallPath("alpha"),
+      format: "bundle",
+      bundleFormat: "claude",
       extensions: ["index.js"],
       version: "1.2.3",
       marketplaceName: "Claude",
@@ -1230,6 +1232,8 @@ describe("plugins cli install", () => {
 
     expect(persistedInstallRecord("alpha").source).toBe("marketplace");
     expect(persistedInstallRecord("alpha").installPath).toBe(cliInstallPath("alpha"));
+    expect(persistedInstallRecord("alpha").format).toBe("bundle");
+    expect(persistedInstallRecord("alpha").bundleFormat).toBe("claude");
     expect(writeConfigFile).toHaveBeenCalledWith(enabledCfg);
     expect(replaceConfigCall().baseHash).toBe("mock");
     expect(replaceConfigCall().nextConfig).toBe(enabledCfg);

--- a/src/cli/plugins-install-command.ts
+++ b/src/cli/plugins-install-command.ts
@@ -1016,6 +1016,8 @@ export async function runPluginInstallCommand(params: {
       install: {
         source: "marketplace",
         installPath: result.targetDir,
+        ...(result.format ? { format: result.format } : {}),
+        ...(result.bundleFormat ? { bundleFormat: result.bundleFormat } : {}),
         version: result.version,
         marketplaceName: result.marketplaceName,
         marketplaceSource: result.marketplaceSource,

--- a/src/cli/update-cli/plugin-payload-validation.test.ts
+++ b/src/cli/update-cli/plugin-payload-validation.test.ts
@@ -174,6 +174,29 @@ describe("runPluginPayloadSmokeCheck", () => {
     ]);
   });
 
+  it("does not reinterpret native code-plugin records with explicit bundle manifests as bundle payloads", async () => {
+    const dir = path.join(tmpRoot, "native-with-bundle-manifest");
+    await writeClaudeBundle(dir);
+    const result = await runPluginPayloadSmokeCheck({
+      records: {
+        native: {
+          source: "marketplace",
+          installPath: dir,
+          clawhubFamily: "code-plugin",
+        },
+      },
+      env: {},
+    });
+    expect(result.failures).toStrictEqual([
+      {
+        pluginId: "native",
+        installPath: dir,
+        reason: "missing-package-json",
+        detail: `package.json is missing under ${dir}`,
+      },
+    ]);
+  });
+
   it("reports a bundle payload failure when a persisted bundle-format record has no supported capability markers", async () => {
     const dir = path.join(tmpRoot, "empty-claude-bundle");
     await fs.mkdir(dir, { recursive: true });

--- a/src/cli/update-cli/plugin-payload-validation.test.ts
+++ b/src/cli/update-cli/plugin-payload-validation.test.ts
@@ -30,6 +30,21 @@ describe("runPluginPayloadSmokeCheck", () => {
     }
   }
 
+  async function writeClaudeBundle(dir: string, manifest: Record<string, unknown> = {}) {
+    await fs.mkdir(path.join(dir, ".claude-plugin"), { recursive: true });
+    await fs.mkdir(path.join(dir, "skills"), { recursive: true });
+    await fs.writeFile(
+      path.join(dir, ".claude-plugin", "plugin.json"),
+      JSON.stringify({
+        name: "Claude Bundle",
+        skills: "skills",
+        ...manifest,
+      }),
+      "utf8",
+    );
+    await fs.writeFile(path.join(dir, "skills", "SKILL.md"), "# Skill\n", "utf8");
+  }
+
   function resolveTestHostRoot(): string {
     const hostRoot = resolveOpenClawPackageRootSync({
       argv1: process.argv[1],
@@ -95,6 +110,95 @@ describe("runPluginPayloadSmokeCheck", () => {
         detail: `package.json is missing under ${dir}`,
       },
     ]);
+  });
+
+  it("accepts bundle-format plugin records without package.json when the bundle manifest is valid", async () => {
+    const dir = path.join(tmpRoot, "claude-bundle");
+    await writeClaudeBundle(dir);
+    const result = await runPluginPayloadSmokeCheck({
+      records: {
+        "claude-bundle": {
+          source: "marketplace",
+          installPath: dir,
+          format: "bundle",
+          bundleFormat: "claude",
+        } as never,
+      },
+      env: {},
+    });
+    expect(result.checked).toEqual(["claude-bundle"]);
+    expect(result.failures).toEqual([]);
+  });
+
+  it("reports a bundle payload failure when a bundle-format record has no bundle manifest", async () => {
+    const dir = path.join(tmpRoot, "empty-bundle");
+    await fs.mkdir(dir, { recursive: true });
+    const result = await runPluginPayloadSmokeCheck({
+      records: {
+        "empty-bundle": {
+          source: "marketplace",
+          installPath: dir,
+          format: "bundle",
+        } as never,
+      },
+      env: {},
+    });
+    expect(result.failures).toStrictEqual([
+      {
+        pluginId: "empty-bundle",
+        installPath: dir,
+        reason: "missing-bundle-manifest",
+        detail: `Bundle manifest is missing under ${dir}`,
+      },
+    ]);
+  });
+
+  it("reports a bundle payload failure when a persisted bundle-format record has no supported capability markers", async () => {
+    const dir = path.join(tmpRoot, "empty-claude-bundle");
+    await fs.mkdir(dir, { recursive: true });
+    const result = await runPluginPayloadSmokeCheck({
+      records: {
+        "empty-claude-bundle": {
+          source: "marketplace",
+          installPath: dir,
+          format: "bundle",
+          bundleFormat: "claude",
+        } as never,
+      },
+      env: {},
+    });
+    expect(result.failures).toStrictEqual([
+      {
+        pluginId: "empty-claude-bundle",
+        installPath: dir,
+        reason: "invalid-bundle-manifest",
+        detail: `Bundle manifest has no supported capabilities under ${dir}`,
+      },
+    ]);
+  });
+
+  it("reports a bundle payload failure when the bundle manifest is invalid", async () => {
+    const dir = path.join(tmpRoot, "broken-bundle");
+    await fs.mkdir(path.join(dir, ".codex-plugin"), { recursive: true });
+    await fs.writeFile(path.join(dir, ".codex-plugin", "plugin.json"), "not-json", "utf8");
+    const result = await runPluginPayloadSmokeCheck({
+      records: {
+        "broken-bundle": {
+          source: "marketplace",
+          installPath: dir,
+          format: "bundle",
+          bundleFormat: "codex",
+        } as never,
+      },
+      env: {},
+    });
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0]).toMatchObject({
+      pluginId: "broken-bundle",
+      installPath: dir,
+      reason: "invalid-bundle-manifest",
+    });
+    expect(result.failures[0]?.detail).toContain("failed to parse plugin manifest:");
   });
 
   it("reports a failure when the main entry file is missing on disk", async () => {

--- a/src/cli/update-cli/plugin-payload-validation.test.ts
+++ b/src/cli/update-cli/plugin-payload-validation.test.ts
@@ -150,6 +150,30 @@ describe("runPluginPayloadSmokeCheck", () => {
     ]);
   });
 
+  it("does not reinterpret native records with manifestless bundle markers as bundle payloads", async () => {
+    const dir = path.join(tmpRoot, "native-with-skills-leftover");
+    await fs.mkdir(path.join(dir, "skills"), { recursive: true });
+    await fs.writeFile(path.join(dir, "skills", "SKILL.md"), "# Skill\n", "utf8");
+    const result = await runPluginPayloadSmokeCheck({
+      records: {
+        native: {
+          source: "marketplace",
+          installPath: dir,
+          clawhubFamily: "code-plugin",
+        },
+      },
+      env: {},
+    });
+    expect(result.failures).toStrictEqual([
+      {
+        pluginId: "native",
+        installPath: dir,
+        reason: "missing-package-json",
+        detail: `package.json is missing under ${dir}`,
+      },
+    ]);
+  });
+
   it("reports a bundle payload failure when a persisted bundle-format record has no supported capability markers", async () => {
     const dir = path.join(tmpRoot, "empty-claude-bundle");
     await fs.mkdir(dir, { recursive: true });

--- a/src/cli/update-cli/plugin-payload-validation.test.ts
+++ b/src/cli/update-cli/plugin-payload-validation.test.ts
@@ -221,6 +221,30 @@ describe("runPluginPayloadSmokeCheck", () => {
     ]);
   });
 
+  it("does not reclassify persisted Codex bundles as manifestless Claude bundles when their manifest is missing", async () => {
+    const dir = path.join(tmpRoot, "codex-bundle-missing-manifest");
+    await fs.mkdir(path.join(dir, "skills"), { recursive: true });
+    await fs.writeFile(path.join(dir, "skills", "SKILL.md"), "# Skill\n", "utf8");
+    const result = await runPluginPayloadSmokeCheck({
+      records: {
+        codex: {
+          source: "marketplace",
+          installPath: dir,
+          format: "bundle",
+          bundleFormat: "codex",
+        } as never,
+      },
+      env: {},
+    });
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0]).toMatchObject({
+      pluginId: "codex",
+      installPath: dir,
+      reason: "invalid-bundle-manifest",
+    });
+    expect(result.failures[0]?.detail).toContain(".codex-plugin/plugin.json");
+  });
+
   it("reports a bundle payload failure when the bundle manifest is invalid", async () => {
     const dir = path.join(tmpRoot, "broken-bundle");
     await fs.mkdir(path.join(dir, ".codex-plugin"), { recursive: true });

--- a/src/cli/update-cli/plugin-payload-validation.test.ts
+++ b/src/cli/update-cli/plugin-payload-validation.test.ts
@@ -141,6 +141,8 @@ describe("runPluginPayloadSmokeCheck", () => {
         marketplace: {
           source: "marketplace",
           installPath: dir,
+          format: "bundle",
+          bundleFormat: "claude",
           marketplaceName: "local",
           marketplaceSource: "owner/repo",
           marketplacePlugin: "claude-bundle",
@@ -150,6 +152,31 @@ describe("runPluginPayloadSmokeCheck", () => {
     });
     expect(result.checked).toEqual(["marketplace"]);
     expect(result.failures).toEqual([]);
+  });
+
+  it("does not reinterpret marketplace package records without durable bundle metadata", async () => {
+    const dir = path.join(tmpRoot, "marketplace-native-with-skills-leftover");
+    await writeManifestlessClaudeBundle(dir);
+    const result = await runPluginPayloadSmokeCheck({
+      records: {
+        marketplace: {
+          source: "marketplace",
+          installPath: dir,
+          marketplaceName: "local",
+          marketplaceSource: "owner/repo",
+          marketplacePlugin: "native",
+        },
+      },
+      env: {},
+    });
+    expect(result.failures).toStrictEqual([
+      {
+        pluginId: "marketplace",
+        installPath: dir,
+        reason: "missing-package-json",
+        detail: `package.json is missing under ${dir}`,
+      },
+    ]);
   });
 
   it("keeps reporting missing package.json for non-bundle payloads without package.json", async () => {

--- a/src/cli/update-cli/plugin-payload-validation.test.ts
+++ b/src/cli/update-cli/plugin-payload-validation.test.ts
@@ -45,6 +45,11 @@ describe("runPluginPayloadSmokeCheck", () => {
     await fs.writeFile(path.join(dir, "skills", "SKILL.md"), "# Skill\n", "utf8");
   }
 
+  async function writeManifestlessClaudeBundle(dir: string) {
+    await fs.mkdir(path.join(dir, "skills"), { recursive: true });
+    await fs.writeFile(path.join(dir, "skills", "SKILL.md"), "# Skill\n", "utf8");
+  }
+
   function resolveTestHostRoot(): string {
     const hostRoot = resolveOpenClawPackageRootSync({
       argv1: process.argv[1],
@@ -125,6 +130,25 @@ describe("runPluginPayloadSmokeCheck", () => {
       env: {},
     });
     expect(result.checked).toEqual(["claude-bundle"]);
+    expect(result.failures).toEqual([]);
+  });
+
+  it("accepts marketplace manifestless bundle payloads without package.json", async () => {
+    const dir = path.join(tmpRoot, "marketplace-claude-bundle");
+    await writeManifestlessClaudeBundle(dir);
+    const result = await runPluginPayloadSmokeCheck({
+      records: {
+        marketplace: {
+          source: "marketplace",
+          installPath: dir,
+          marketplaceName: "local",
+          marketplaceSource: "owner/repo",
+          marketplacePlugin: "claude-bundle",
+        },
+      },
+      env: {},
+    });
+    expect(result.checked).toEqual(["marketplace"]);
     expect(result.failures).toEqual([]);
   });
 

--- a/src/cli/update-cli/plugin-payload-validation.test.ts
+++ b/src/cli/update-cli/plugin-payload-validation.test.ts
@@ -273,6 +273,28 @@ describe("runPluginPayloadSmokeCheck", () => {
     ]);
   });
 
+  it("keeps native package validation precedence for dual-format roots", async () => {
+    const dir = path.join(tmpRoot, "dual-format");
+    await writePackage(dir, {
+      name: "@openclaw/dual-format",
+      openclaw: { extensions: ["./dist/missing.js"] },
+    });
+    await writeClaudeBundle(dir);
+    const result = await runPluginPayloadSmokeCheck({
+      records: { dual: { source: "marketplace", installPath: dir } },
+      env: {},
+    });
+    expect(result.failures).toStrictEqual([
+      {
+        pluginId: "dual",
+        installPath: dir,
+        reason: "missing-extension-entry",
+        detail:
+          "Plugin extension entry validation failed: extension entry not found: ./dist/missing.js",
+      },
+    ]);
+  });
+
   it("reports only extension-entry failure for an empty extensions list even if main is missing", async () => {
     const dir = path.join(tmpRoot, "brave-empty");
     await writePackage(dir, {

--- a/src/cli/update-cli/plugin-payload-validation.test.ts
+++ b/src/cli/update-cli/plugin-payload-validation.test.ts
@@ -197,6 +197,28 @@ describe("runPluginPayloadSmokeCheck", () => {
     ]);
   });
 
+  it("does not reinterpret npm package records with explicit bundle manifests as bundle payloads", async () => {
+    const dir = path.join(tmpRoot, "npm-with-bundle-manifest");
+    await writeClaudeBundle(dir);
+    const result = await runPluginPayloadSmokeCheck({
+      records: {
+        native: {
+          source: "npm",
+          installPath: dir,
+        },
+      },
+      env: {},
+    });
+    expect(result.failures).toStrictEqual([
+      {
+        pluginId: "native",
+        installPath: dir,
+        reason: "missing-package-json",
+        detail: `package.json is missing under ${dir}`,
+      },
+    ]);
+  });
+
   it("reports a bundle payload failure when a persisted bundle-format record has no supported capability markers", async () => {
     const dir = path.join(tmpRoot, "empty-claude-bundle");
     await fs.mkdir(dir, { recursive: true });

--- a/src/cli/update-cli/plugin-payload-validation.test.ts
+++ b/src/cli/update-cli/plugin-payload-validation.test.ts
@@ -112,7 +112,7 @@ describe("runPluginPayloadSmokeCheck", () => {
     ]);
   });
 
-  it("accepts bundle-format plugin records without package.json when the bundle manifest is valid", async () => {
+  it("accepts bundle payloads without package.json when the install path contains a valid bundle manifest", async () => {
     const dir = path.join(tmpRoot, "claude-bundle");
     await writeClaudeBundle(dir);
     const result = await runPluginPayloadSmokeCheck({
@@ -120,9 +120,7 @@ describe("runPluginPayloadSmokeCheck", () => {
         "claude-bundle": {
           source: "marketplace",
           installPath: dir,
-          format: "bundle",
-          bundleFormat: "claude",
-        } as never,
+        },
       },
       env: {},
     });
@@ -130,25 +128,24 @@ describe("runPluginPayloadSmokeCheck", () => {
     expect(result.failures).toEqual([]);
   });
 
-  it("reports a bundle payload failure when a bundle-format record has no bundle manifest", async () => {
-    const dir = path.join(tmpRoot, "empty-bundle");
+  it("keeps reporting missing package.json for non-bundle payloads without package.json", async () => {
+    const dir = path.join(tmpRoot, "empty-package");
     await fs.mkdir(dir, { recursive: true });
     const result = await runPluginPayloadSmokeCheck({
       records: {
-        "empty-bundle": {
+        "empty-package": {
           source: "marketplace",
           installPath: dir,
-          format: "bundle",
-        } as never,
+        },
       },
       env: {},
     });
     expect(result.failures).toStrictEqual([
       {
-        pluginId: "empty-bundle",
+        pluginId: "empty-package",
         installPath: dir,
-        reason: "missing-bundle-manifest",
-        detail: `Bundle manifest is missing under ${dir}`,
+        reason: "missing-package-json",
+        detail: `package.json is missing under ${dir}`,
       },
     ]);
   });
@@ -186,9 +183,7 @@ describe("runPluginPayloadSmokeCheck", () => {
         "broken-bundle": {
           source: "marketplace",
           installPath: dir,
-          format: "bundle",
-          bundleFormat: "codex",
-        } as never,
+        },
       },
       env: {},
     });

--- a/src/cli/update-cli/plugin-payload-validation.ts
+++ b/src/cli/update-cli/plugin-payload-validation.ts
@@ -2,6 +2,8 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { PluginInstallRecord } from "../../config/types.plugins.js";
+import { detectBundleManifestFormat, loadBundleManifest } from "../../plugins/bundle-manifest.js";
+import type { PluginBundleFormat } from "../../plugins/manifest-types.js";
 import { resolvePackageExtensionEntries, type PackageManifest } from "../../plugins/manifest.js";
 import { validatePackageExtensionEntriesForInstall } from "../../plugins/package-entry-resolution.js";
 import { auditOpenClawPeerDependencyLink } from "../../plugins/plugin-peer-link.js";
@@ -10,6 +12,8 @@ import { resolveUserPath } from "../../utils.js";
 export type PluginPayloadSmokeFailureReason =
   | "missing-install-path"
   | "missing-package-dir"
+  | "missing-bundle-manifest"
+  | "invalid-bundle-manifest"
   | "missing-package-json"
   | "invalid-package-json"
   | "missing-main-entry"
@@ -75,6 +79,19 @@ export async function runPluginPayloadSmokeCheck(params: {
         reason: "missing-package-dir",
         detail: `Install dir is missing: ${installPath}`,
       });
+      continue;
+    }
+
+    if (isBundleInstallRecord(record)) {
+      const bundleValidation = validateBundlePayload({ installPath, record });
+      if (bundleValidation) {
+        failures.push({
+          pluginId,
+          installPath,
+          reason: bundleValidation.reason,
+          detail: bundleValidation.detail,
+        });
+      }
       continue;
     }
 
@@ -168,6 +185,46 @@ export async function runPluginPayloadSmokeCheck(params: {
   }
 
   return { checked, failures };
+}
+
+function isBundleInstallRecord(record: PluginInstallRecord): boolean {
+  return (record as { format?: unknown }).format === "bundle";
+}
+
+function readBundleFormat(record: PluginInstallRecord): PluginBundleFormat | null {
+  const raw = (record as { bundleFormat?: unknown }).bundleFormat;
+  return raw === "codex" || raw === "claude" || raw === "cursor" ? raw : null;
+}
+
+function validateBundlePayload(params: {
+  installPath: string;
+  record: PluginInstallRecord;
+}): Pick<PluginPayloadSmokeFailure, "reason" | "detail"> | null {
+  const bundleFormat =
+    readBundleFormat(params.record) ?? detectBundleManifestFormat(params.installPath);
+  if (!bundleFormat) {
+    return {
+      reason: "missing-bundle-manifest",
+      detail: `Bundle manifest is missing under ${params.installPath}`,
+    };
+  }
+  const loaded = loadBundleManifest({
+    rootDir: params.installPath,
+    bundleFormat,
+  });
+  if (!loaded.ok) {
+    return {
+      reason: "invalid-bundle-manifest",
+      detail: loaded.error,
+    };
+  }
+  if (loaded.manifest.capabilities.length === 0) {
+    return {
+      reason: "invalid-bundle-manifest",
+      detail: `Bundle manifest has no supported capabilities under ${params.installPath}`,
+    };
+  }
+  return null;
 }
 
 function manifestDeclaresOpenClawPeer(manifest: PackageManifest): boolean {

--- a/src/cli/update-cli/plugin-payload-validation.ts
+++ b/src/cli/update-cli/plugin-payload-validation.ts
@@ -208,6 +208,10 @@ function isBundleInstallRecord(record: PluginInstallRecord): boolean {
   );
 }
 
+function isKnownNativePackageInstallRecord(record: PluginInstallRecord): boolean {
+  return record.clawhubFamily === "code-plugin";
+}
+
 function readBundleFormat(record: PluginInstallRecord): PluginBundleFormat | null {
   const raw = (record as { bundleFormat?: unknown }).bundleFormat;
   return raw === "codex" || raw === "claude" || raw === "cursor" ? raw : null;
@@ -236,6 +240,9 @@ async function resolveBundlePayloadFormat(params: {
   installPath: string;
   record: PluginInstallRecord;
 }): Promise<PluginBundleFormat | null> {
+  if (isKnownNativePackageInstallRecord(params.record)) {
+    return null;
+  }
   const explicitManifestFormat = await detectExplicitBundleManifestFormat(params.installPath);
   if (explicitManifestFormat) {
     return explicitManifestFormat;

--- a/src/cli/update-cli/plugin-payload-validation.ts
+++ b/src/cli/update-cli/plugin-payload-validation.ts
@@ -2,7 +2,13 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { PluginInstallRecord } from "../../config/types.plugins.js";
-import { detectBundleManifestFormat, loadBundleManifest } from "../../plugins/bundle-manifest.js";
+import {
+  CLAUDE_BUNDLE_MANIFEST_RELATIVE_PATH,
+  CODEX_BUNDLE_MANIFEST_RELATIVE_PATH,
+  CURSOR_BUNDLE_MANIFEST_RELATIVE_PATH,
+  detectBundleManifestFormat,
+  loadBundleManifest,
+} from "../../plugins/bundle-manifest.js";
 import type { PluginBundleFormat } from "../../plugins/manifest-types.js";
 import { resolvePackageExtensionEntries, type PackageManifest } from "../../plugins/manifest.js";
 import { validatePackageExtensionEntriesForInstall } from "../../plugins/package-entry-resolution.js";
@@ -85,9 +91,9 @@ export async function runPluginPayloadSmokeCheck(params: {
     const packageJsonPath = path.join(installPath, "package.json");
     const packageJsonStat = await safeStat(packageJsonPath);
     if (!packageJsonStat?.isFile()) {
-      const detectedBundleFormat = detectBundleManifestFormat(installPath);
-      if (detectedBundleFormat || isBundleInstallRecord(record)) {
-        const bundleValidation = validateBundlePayload({ installPath, record });
+      const bundleFormat = await resolveBundlePayloadFormat({ installPath, record });
+      if (bundleFormat) {
+        const bundleValidation = validateBundlePayload({ installPath, bundleFormat });
         if (bundleValidation) {
           failures.push({
             pluginId,
@@ -96,6 +102,15 @@ export async function runPluginPayloadSmokeCheck(params: {
             detail: bundleValidation.detail,
           });
         }
+        continue;
+      }
+      if (isBundleInstallRecord(record)) {
+        failures.push({
+          pluginId,
+          installPath,
+          reason: "missing-bundle-manifest",
+          detail: `Bundle manifest is missing under ${installPath}`,
+        });
         continue;
       }
       failures.push({
@@ -188,7 +203,9 @@ export async function runPluginPayloadSmokeCheck(params: {
 }
 
 function isBundleInstallRecord(record: PluginInstallRecord): boolean {
-  return (record as { format?: unknown }).format === "bundle";
+  return (
+    (record as { format?: unknown }).format === "bundle" || record.clawhubFamily === "bundle-plugin"
+  );
 }
 
 function readBundleFormat(record: PluginInstallRecord): PluginBundleFormat | null {
@@ -196,21 +213,46 @@ function readBundleFormat(record: PluginInstallRecord): PluginBundleFormat | nul
   return raw === "codex" || raw === "claude" || raw === "cursor" ? raw : null;
 }
 
-function validateBundlePayload(params: {
+async function detectExplicitBundleManifestFormat(
+  installPath: string,
+): Promise<PluginBundleFormat | null> {
+  const codexManifest = await safeStat(path.join(installPath, CODEX_BUNDLE_MANIFEST_RELATIVE_PATH));
+  if (codexManifest?.isFile()) {
+    return "codex";
+  }
+  const cursorManifest = await safeStat(
+    path.join(installPath, CURSOR_BUNDLE_MANIFEST_RELATIVE_PATH),
+  );
+  if (cursorManifest?.isFile()) {
+    return "cursor";
+  }
+  const claudeManifest = await safeStat(
+    path.join(installPath, CLAUDE_BUNDLE_MANIFEST_RELATIVE_PATH),
+  );
+  return claudeManifest?.isFile() ? "claude" : null;
+}
+
+async function resolveBundlePayloadFormat(params: {
   installPath: string;
   record: PluginInstallRecord;
-}): Pick<PluginPayloadSmokeFailure, "reason" | "detail"> | null {
-  const bundleFormat =
-    detectBundleManifestFormat(params.installPath) ?? readBundleFormat(params.record);
-  if (!bundleFormat) {
-    return {
-      reason: "missing-bundle-manifest",
-      detail: `Bundle manifest is missing under ${params.installPath}`,
-    };
+}): Promise<PluginBundleFormat | null> {
+  const explicitManifestFormat = await detectExplicitBundleManifestFormat(params.installPath);
+  if (explicitManifestFormat) {
+    return explicitManifestFormat;
   }
+  if (!isBundleInstallRecord(params.record)) {
+    return null;
+  }
+  return detectBundleManifestFormat(params.installPath) ?? readBundleFormat(params.record);
+}
+
+function validateBundlePayload(params: {
+  installPath: string;
+  bundleFormat: PluginBundleFormat;
+}): Pick<PluginPayloadSmokeFailure, "reason" | "detail"> | null {
   const loaded = loadBundleManifest({
     rootDir: params.installPath,
-    bundleFormat,
+    bundleFormat: params.bundleFormat,
   });
   if (!loaded.ok) {
     return {

--- a/src/cli/update-cli/plugin-payload-validation.ts
+++ b/src/cli/update-cli/plugin-payload-validation.ts
@@ -82,23 +82,22 @@ export async function runPluginPayloadSmokeCheck(params: {
       continue;
     }
 
-    const detectedBundleFormat = detectBundleManifestFormat(installPath);
-    if (detectedBundleFormat || isBundleInstallRecord(record)) {
-      const bundleValidation = validateBundlePayload({ installPath, record });
-      if (bundleValidation) {
-        failures.push({
-          pluginId,
-          installPath,
-          reason: bundleValidation.reason,
-          detail: bundleValidation.detail,
-        });
-      }
-      continue;
-    }
-
     const packageJsonPath = path.join(installPath, "package.json");
     const packageJsonStat = await safeStat(packageJsonPath);
     if (!packageJsonStat?.isFile()) {
+      const detectedBundleFormat = detectBundleManifestFormat(installPath);
+      if (detectedBundleFormat || isBundleInstallRecord(record)) {
+        const bundleValidation = validateBundlePayload({ installPath, record });
+        if (bundleValidation) {
+          failures.push({
+            pluginId,
+            installPath,
+            reason: bundleValidation.reason,
+            detail: bundleValidation.detail,
+          });
+        }
+        continue;
+      }
       failures.push({
         pluginId,
         installPath,

--- a/src/cli/update-cli/plugin-payload-validation.ts
+++ b/src/cli/update-cli/plugin-payload-validation.ts
@@ -250,7 +250,7 @@ async function resolveBundlePayloadFormat(params: {
   if (!isBundleInstallRecord(params.record)) {
     return null;
   }
-  return detectBundleManifestFormat(params.installPath) ?? readBundleFormat(params.record);
+  return readBundleFormat(params.record) ?? detectBundleManifestFormat(params.installPath);
 }
 
 function validateBundlePayload(params: {

--- a/src/cli/update-cli/plugin-payload-validation.ts
+++ b/src/cli/update-cli/plugin-payload-validation.ts
@@ -209,7 +209,7 @@ function isBundleInstallRecord(record: PluginInstallRecord): boolean {
 }
 
 function isKnownNativePackageInstallRecord(record: PluginInstallRecord): boolean {
-  return record.clawhubFamily === "code-plugin";
+  return record.source === "npm" || record.clawhubFamily === "code-plugin";
 }
 
 function readBundleFormat(record: PluginInstallRecord): PluginBundleFormat | null {

--- a/src/cli/update-cli/plugin-payload-validation.ts
+++ b/src/cli/update-cli/plugin-payload-validation.ts
@@ -212,10 +212,6 @@ function isKnownNativePackageInstallRecord(record: PluginInstallRecord): boolean
   return record.source === "npm" || record.clawhubFamily === "code-plugin";
 }
 
-function canDetectBundlePayloadFromInstallPath(record: PluginInstallRecord): boolean {
-  return isBundleInstallRecord(record) || record.source === "marketplace";
-}
-
 function readBundleFormat(record: PluginInstallRecord): PluginBundleFormat | null {
   const raw = (record as { bundleFormat?: unknown }).bundleFormat;
   return raw === "codex" || raw === "claude" || raw === "cursor" ? raw : null;
@@ -251,7 +247,7 @@ async function resolveBundlePayloadFormat(params: {
   if (explicitManifestFormat) {
     return explicitManifestFormat;
   }
-  if (!canDetectBundlePayloadFromInstallPath(params.record)) {
+  if (!isBundleInstallRecord(params.record)) {
     return null;
   }
   return readBundleFormat(params.record) ?? detectBundleManifestFormat(params.installPath);

--- a/src/cli/update-cli/plugin-payload-validation.ts
+++ b/src/cli/update-cli/plugin-payload-validation.ts
@@ -82,7 +82,8 @@ export async function runPluginPayloadSmokeCheck(params: {
       continue;
     }
 
-    if (isBundleInstallRecord(record)) {
+    const detectedBundleFormat = detectBundleManifestFormat(installPath);
+    if (detectedBundleFormat || isBundleInstallRecord(record)) {
       const bundleValidation = validateBundlePayload({ installPath, record });
       if (bundleValidation) {
         failures.push({
@@ -201,7 +202,7 @@ function validateBundlePayload(params: {
   record: PluginInstallRecord;
 }): Pick<PluginPayloadSmokeFailure, "reason" | "detail"> | null {
   const bundleFormat =
-    readBundleFormat(params.record) ?? detectBundleManifestFormat(params.installPath);
+    detectBundleManifestFormat(params.installPath) ?? readBundleFormat(params.record);
   if (!bundleFormat) {
     return {
       reason: "missing-bundle-manifest",

--- a/src/cli/update-cli/plugin-payload-validation.ts
+++ b/src/cli/update-cli/plugin-payload-validation.ts
@@ -212,6 +212,10 @@ function isKnownNativePackageInstallRecord(record: PluginInstallRecord): boolean
   return record.source === "npm" || record.clawhubFamily === "code-plugin";
 }
 
+function canDetectBundlePayloadFromInstallPath(record: PluginInstallRecord): boolean {
+  return isBundleInstallRecord(record) || record.source === "marketplace";
+}
+
 function readBundleFormat(record: PluginInstallRecord): PluginBundleFormat | null {
   const raw = (record as { bundleFormat?: unknown }).bundleFormat;
   return raw === "codex" || raw === "claude" || raw === "cursor" ? raw : null;
@@ -247,7 +251,7 @@ async function resolveBundlePayloadFormat(params: {
   if (explicitManifestFormat) {
     return explicitManifestFormat;
   }
-  if (!isBundleInstallRecord(params.record)) {
+  if (!canDetectBundlePayloadFromInstallPath(params.record)) {
     return null;
   }
   return readBundleFormat(params.record) ?? detectBundleManifestFormat(params.installPath);

--- a/src/config/types.installs.ts
+++ b/src/config/types.installs.ts
@@ -4,6 +4,8 @@ export type InstallRecordBase = {
   spec?: string;
   sourcePath?: string;
   installPath?: string;
+  format?: "bundle";
+  bundleFormat?: "codex" | "claude" | "cursor";
   version?: string;
   resolvedName?: string;
   resolvedVersion?: string;

--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -304,6 +304,67 @@ describe("session cost usage", () => {
     });
   });
 
+  it("re-estimates spend when a known-priced model records cost.total: 0 with non-zero tokens", async () => {
+    const root = await makeSessionCostRoot("cost-known-pricing-zero-total");
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+
+    // DeepSeek V4 (and similar providers) return usage.cost.total: 0 in their
+    // completion payload even though token usage is real and catalog pricing
+    // is positive. Trusting the recorded $0 zeroes out the Spend panel and any
+    // budget/spike safeguard that aggregates totalCost.
+    const entry = {
+      type: "message",
+      timestamp: new Date().toISOString(),
+      message: {
+        role: "assistant",
+        provider: "deepseek",
+        model: "deepseek-v4-flash",
+        usage: {
+          input: 10_000,
+          output: 5_000,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 15_000,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+      },
+    };
+
+    await fs.writeFile(
+      path.join(sessionsDir, "sess-1.jsonl"),
+      transcriptText("sess-1", entry),
+      "utf-8",
+    );
+
+    const config = {
+      models: {
+        providers: {
+          deepseek: {
+            models: [
+              {
+                id: "deepseek-v4-flash",
+                // Positive per-token rates (CNY per token here, magnitude is all
+                // the fix needs; the re-estimate path is unit-agnostic).
+                cost: { input: 0.000014, output: 0.000028, cacheRead: 0, cacheWrite: 0 },
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    clearGatewayModelPricingCacheState();
+    await withStateDir(root, async () => {
+      const summary = await loadCostUsageSummary({ days: 30, config });
+      expect(summary.totals.totalTokens).toBe(15_000);
+      // Recorded $0 must be replaced with a real estimate; with 10k input @ 0.000014
+      // and 5k output @ 0.000028 the expected total is 0.28.
+      expect(summary.totals.totalCost).toBeCloseTo(0.28, 6);
+      expect(summary.totals.missingCostEntries).toBe(0);
+    });
+  });
+
   it("treats a pre-upgrade (older-version) durable cache as stale so unpriced usage is rebuilt", async () => {
     const root = await makeSessionCostRoot("cost-cache-upgrade");
     const sessionsDir = path.join(root, "agents", "main", "sessions");

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -1272,9 +1272,20 @@ async function scanTranscriptFile(params: {
         // above.
         entry.costTotal = undefined;
         entry.costBreakdown = undefined;
-      } else if (entry.costTotal === undefined) {
-        // Fill in missing cost estimates.
+      } else if (
+        entry.costTotal === undefined ||
+        (entry.costTotal === 0 &&
+          isModelPricingKnown(cost) &&
+          computeUsageTokenTotals(entry.usage).totalTokens > 0)
+      ) {
+        // Fill in missing cost estimates, and re-estimate when the transport recorded
+        // a $0 total despite burning tokens. Some providers return usage.cost.total: 0
+        // even when their catalog pricing is positive (e.g. DeepSeek V4), so trusting
+        // the recorded $0 would silently zero out the Spend panel and any budget/spike
+        // safeguard that aggregates totalCost. The unknown-pricing zero-cost case is
+        // already handled above as missing.
         entry.costTotal = estimateUsageCost({ usage: entry.usage, cost });
+        entry.costBreakdown = undefined;
       }
     }
 

--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -157,6 +157,8 @@ export type InstallPluginResult =
       ok: true;
       pluginId: string;
       targetDir: string;
+      format?: "bundle";
+      bundleFormat?: "codex" | "claude" | "cursor";
       manifestName?: string;
       version?: string;
       extensions: string[];
@@ -545,6 +547,8 @@ function buildFileInstallResult(pluginId: string, targetFile: string): InstallPl
 function buildDirectoryInstallResult(params: {
   pluginId: string;
   targetDir: string;
+  format?: "bundle";
+  bundleFormat?: "codex" | "claude" | "cursor";
   manifestName?: string;
   version?: string;
   extensions: string[];
@@ -553,6 +557,8 @@ function buildDirectoryInstallResult(params: {
     ok: true,
     pluginId: params.pluginId,
     targetDir: params.targetDir,
+    ...(params.format ? { format: params.format } : {}),
+    ...(params.bundleFormat ? { bundleFormat: params.bundleFormat } : {}),
     manifestName: params.manifestName,
     version: params.version,
     extensions: params.extensions,
@@ -2114,6 +2120,8 @@ async function runInstallSourceScan(params: {
 async function installPluginDirectoryIntoExtensions(params: {
   sourceDir: string;
   pluginId: string;
+  format?: "bundle";
+  bundleFormat?: "codex" | "claude" | "cursor";
   manifestName?: string;
   version?: string;
   extensions: string[];
@@ -2160,6 +2168,8 @@ async function installPluginDirectoryIntoExtensions(params: {
     return buildDirectoryInstallResult({
       pluginId: params.pluginId,
       targetDir,
+      format: params.format,
+      bundleFormat: params.bundleFormat,
       manifestName: params.manifestName,
       version: params.version,
       extensions: params.extensions,
@@ -2200,6 +2210,8 @@ async function installPluginDirectoryIntoExtensions(params: {
   return buildDirectoryInstallResult({
     pluginId: params.pluginId,
     targetDir,
+    format: params.format,
+    bundleFormat: params.bundleFormat,
     manifestName: params.manifestName,
     version: params.version,
     extensions: params.extensions,
@@ -2327,6 +2339,8 @@ async function installBundleFromSourceDir(
   return await installPluginDirectoryIntoExtensions({
     sourceDir: params.sourceDir,
     pluginId,
+    format: "bundle",
+    bundleFormat,
     manifestName: manifestRes.manifest.name,
     version: manifestRes.manifest.version,
     extensions: [],

--- a/src/plugins/installed-plugin-index-install-records.ts
+++ b/src/plugins/installed-plugin-index-install-records.ts
@@ -66,6 +66,8 @@ function normalizeInstallRecord(
   setInstallStringField(normalized, "spec", record.spec);
   setInstallStringField(normalized, "sourcePath", record.sourcePath);
   setInstallStringField(normalized, "installPath", record.installPath);
+  setInstallStringField(normalized, "format", record.format);
+  setInstallStringField(normalized, "bundleFormat", record.bundleFormat);
   setInstallStringField(normalized, "version", record.version);
   setInstallStringField(normalized, "resolvedName", record.resolvedName);
   setInstallStringField(normalized, "resolvedVersion", record.resolvedVersion);
@@ -121,6 +123,24 @@ function restoreInstallRecord(
   return structuredClone(record) as PluginInstallRecord;
 }
 
+function isBundleFormat(value: unknown): value is NonNullable<PluginInstallRecord["bundleFormat"]> {
+  return value === "codex" || value === "claude" || value === "cursor";
+}
+
+function enrichInstallRecordWithIndexedFormat(
+  restored: PluginInstallRecord | undefined,
+  plugin: InstalledPluginIndex["plugins"][number],
+): PluginInstallRecord | undefined {
+  if (!restored || plugin.format !== "bundle" || !isBundleFormat(plugin.bundleFormat)) {
+    return restored;
+  }
+  return {
+    ...restored,
+    format: "bundle",
+    bundleFormat: plugin.bundleFormat,
+  };
+}
+
 /** Normalizes raw plugin install records into index-safe install record metadata. */
 export function normalizeInstallRecordMap(
   records: Record<string, PluginInstallRecord> | undefined,
@@ -157,11 +177,21 @@ export function extractPluginInstallRecordsFromInstalledPluginIndex(
   index: InstalledPluginIndex | null | undefined,
 ): Record<string, PluginInstallRecord> {
   if (index && Object.hasOwn(index, "installRecords")) {
-    return restoreInstallRecordMap(index.installRecords);
+    const records = restoreInstallRecordMap(index.installRecords);
+    for (const plugin of index.plugins) {
+      const enriched = enrichInstallRecordWithIndexedFormat(records[plugin.pluginId], plugin);
+      if (enriched) {
+        records[plugin.pluginId] = enriched;
+      }
+    }
+    return records;
   }
   const records: Record<string, PluginInstallRecord> = {};
   for (const plugin of index?.plugins ?? []) {
-    const record = restoreInstallRecord(plugin.installRecord);
+    const record = enrichInstallRecordWithIndexedFormat(
+      restoreInstallRecord(plugin.installRecord),
+      plugin,
+    );
     if (record) {
       records[plugin.pluginId] = record;
     }

--- a/src/plugins/installed-plugin-index-types.ts
+++ b/src/plugins/installed-plugin-index-types.ts
@@ -56,6 +56,8 @@ export type InstalledPluginInstallRecordInfo = Pick<
   | "spec"
   | "sourcePath"
   | "installPath"
+  | "format"
+  | "bundleFormat"
   | "version"
   | "resolvedName"
   | "resolvedVersion"

--- a/src/plugins/installed-plugin-index.test.ts
+++ b/src/plugins/installed-plugin-index.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { PluginCandidate } from "./discovery.js";
+import { extractPluginInstallRecordsFromInstalledPluginIndex } from "./installed-plugin-index-install-records.js";
 import { buildInstalledPluginIndexRecords } from "./installed-plugin-index-record-builder.js";
 import {
   loadInstalledPluginIndexInstallRecordsSync,
@@ -403,6 +404,40 @@ describe("installed plugin index", () => {
       bundleFormat: "claude",
     });
     expectSha256(plugin.manifestHash);
+  });
+
+  it("restores bundle install metadata from indexed plugin records", () => {
+    const rootDir = path.join(makeTempDir(), "workspace");
+    writeManifestlessClaudeBundle(rootDir);
+
+    const index = loadInstalledPluginIndex({
+      candidates: [
+        createPluginCandidate({
+          rootDir,
+          idHint: "workspace",
+          format: "bundle",
+          bundleFormat: "claude",
+          origin: "config",
+        }),
+      ],
+      installRecords: {
+        workspace: {
+          source: "marketplace",
+          installPath: rootDir,
+          marketplaceSource: "owner/repo",
+          marketplacePlugin: "workspace",
+        },
+      },
+      env: hermeticEnv(),
+    });
+
+    expect(index.installRecords.workspace?.format).toBeUndefined();
+    expect(extractPluginInstallRecordsFromInstalledPluginIndex(index).workspace).toMatchObject({
+      source: "marketplace",
+      installPath: rootDir,
+      format: "bundle",
+      bundleFormat: "claude",
+    });
   });
 
   it("changes manifestless Claude bundle hashes when derived metadata changes", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators using `deepseek/deepseek-v4-flash` (or `deepseek-v4-pro`) would see the Control UI Spend panel report ¥0.00 spend for all V4 model usage, despite real tokens being burned and positive per-token pricing configured in the catalog. Budget and spike safeguards that aggregate `totalCost` were silently blinded.

The DeepSeek V4 completion API returns `usage.cost.total: 0` instead of omitting the field or returning a real number. OpenClaw's transcript scanner treated this recorded `0` as an authoritative "free call" whenever the catalog had positive pricing for the model, so it skipped the re-estimate branch and the Spend aggregation accepted the `0` as fact.

Closes #97047.

## Why This Change Was Made

Extend `scanTranscriptFile`'s cost-handling branch so a recorded `costTotal === 0` is treated as untrustworthy whenever the model has known positive pricing and the turn actually burned tokens. In that case the scanner re-estimates using the configured catalog rates, parallel to how the existing `undefined`-cost path fills in a real number.

The existing unknown-pricing zero-cost case (codex/gpt-5.x all-zero catalog entries) is unchanged and still surfaces as a missing-cost entry, so the safeguards still flag genuinely unpriced turns.

## User Impact

Operators on DeepSeek V4 (and any other provider that returns `usage.cost.total: 0` despite positive catalog pricing) now see real spend in the Control UI Spend panel and in `openclaw memory usage` summaries; budget/spike monitoring that keys off `totalCost` is no longer silently zeroed out for those turns.

## Evidence

- New regression test `re-estimates spend when a known-priced model records cost.total: 0 with non-zero tokens` in `src/infra/session-cost-usage.test.ts` covers a DeepSeek V4-shaped transcript entry: 10k input + 5k output tokens, recorded `cost.total: 0`, configured positive pricing. Asserts `totalCost ≈ 0.28` and `missingCostEntries === 0`.
- Existing tests `counts token usage for an unpriced ... model as missing` and `counts token usage for a configured all-zero model as missing` still pass unchanged, confirming the unknown-pricing missing-cost path is preserved.
- `node scripts/run-vitest.mjs run src/infra/session-cost-usage.test.ts` passes locally.
