### PR TITLE
fix(usage): re-estimate cost when known-priced model records total: 0 (#97047)

### DIFF
--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -304,6 +304,67 @@ describe("session cost usage", () => {
     });
   });
 
+  it("re-estimates spend when a known-priced model records cost.total: 0 with non-zero tokens", async () => {
+    const root = await makeSessionCostRoot("cost-known-pricing-zero-total");
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+
+    // DeepSeek V4 (and similar providers) return usage.cost.total: 0 in their
+    // completion payload even though token usage is real and catalog pricing
+    // is positive. Trusting the recorded $0 zeroes out the Spend panel and any
+    // budget/spike safeguard that aggregates totalCost.
+    const entry = {
+      type: "message",
+      timestamp: new Date().toISOString(),
+      message: {
+        role: "assistant",
+        provider: "deepseek",
+        model: "deepseek-v4-flash",
+        usage: {
+          input: 10_000,
+          output: 5_000,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 15_000,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+      },
+    };
+
+    await fs.writeFile(
+      path.join(sessionsDir, "sess-1.jsonl"),
+      transcriptText("sess-1", entry),
+      "utf-8",
+    );
+
+    const config = {
+      models: {
+        providers: {
+          deepseek: {
+            models: [
+              {
+                id: "deepseek-v4-flash",
+                // Positive per-token rates (CNY per token here, magnitude is all
+                // the fix needs; the re-estimate path is unit-agnostic).
+                cost: { input: 0.000014, output: 0.000028, cacheRead: 0, cacheWrite: 0 },
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    clearGatewayModelPricingCacheState();
+    await withStateDir(root, async () => {
+      const summary = await loadCostUsageSummary({ days: 30, config });
+      expect(summary.totals.totalTokens).toBe(15_000);
+      // Recorded $0 must be replaced with a real estimate; with 10k input @ 0.000014
+      // and 5k output @ 0.000028 the expected total is 0.28.
+      expect(summary.totals.totalCost).toBeCloseTo(0.28, 6);
+      expect(summary.totals.missingCostEntries).toBe(0);
+    });
+  });
+
   it("treats a pre-upgrade (older-version) durable cache as stale so unpriced usage is rebuilt", async () => {
     const root = await makeSessionCostRoot("cost-cache-upgrade");
     const sessionsDir = path.join(root, "agents", "main", "sessions");

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -78,7 +78,11 @@ export type {
 // caches written by older builds are rebuilt instead of served stale. Bumped to 4:
 // unpriced (unknown) zero-cost usage now counts toward missingCostEntries, so a warm
 // cache from a pre-change build would otherwise keep reporting the old complete-$0 totals.
-const USAGE_COST_CACHE_VERSION = 4;
+// Bumped to 5: known-priced zero-cost usage (e.g. DeepSeek V4 returns usage.cost.total: 0
+// despite positive catalog rates) is now re-estimated from token counts instead of trusted
+// as a real $0, so a warm cache from a pre-change build would still show $0 spend for those
+// turns.
+const USAGE_COST_CACHE_VERSION = 5;
 const USAGE_COST_CACHE_FILE = ".usage-cost-cache.json";
 const USAGE_COST_CACHE_LOCK_WRITE_GRACE_MS = 10_000;
 const USAGE_COST_CACHE_TEMP_FILE_GRACE_MS = USAGE_COST_CACHE_LOCK_WRITE_GRACE_MS;

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -1272,9 +1272,20 @@ async function scanTranscriptFile(params: {
         // above.
         entry.costTotal = undefined;
         entry.costBreakdown = undefined;
-      } else if (entry.costTotal === undefined) {
-        // Fill in missing cost estimates.
+      } else if (
+        entry.costTotal === undefined ||
+        (entry.costTotal === 0 &&
+          isModelPricingKnown(cost) &&
+          computeUsageTokenTotals(entry.usage).totalTokens > 0)
+      ) {
+        // Fill in missing cost estimates, and re-estimate when the transport recorded
+        // a $0 total despite burning tokens. Some providers return usage.cost.total: 0
+        // even when their catalog pricing is positive (e.g. DeepSeek V4), so trusting
+        // the recorded $0 would silently zero out the Spend panel and any budget/spike
+        // safeguard that aggregates totalCost. The unknown-pricing zero-cost case is
+        // already handled above as missing.
         entry.costTotal = estimateUsageCost({ usage: entry.usage, cost });
+        entry.costBreakdown = undefined;
       }
     }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators using `deepseek/deepseek-v4-flash` (or `deepseek-v4-pro`) would see the Control UI Spend panel report ¥0.00 spend for all V4 model usage, despite real tokens being burned and positive per-token pricing configured in the catalog. Budget and spike safeguards that aggregate `totalCost` were silently blinded.

The DeepSeek V4 completion API returns `usage.cost.total: 0` instead of omitting the field or returning a real number. OpenClaw's transcript scanner treated this recorded `0` as an authoritative "free call" whenever the catalog had positive pricing for the model, so it skipped the re-estimate branch and the Spend aggregation accepted the `0` as fact.

Supersedes #98025, which was closed because the branch mistakenly carried unrelated plugin install/update metadata changes. This PR is a narrow usage-only fix.

Closes #97047.

## Why This Change Was Made

Extend `scanTranscriptFile`'s cost-handling branch so a recorded `costTotal === 0` is treated as untrustworthy whenever the model has known positive pricing and the turn actually burned tokens. In that case the scanner re-estimates using the configured catalog rates, parallel to how the existing `undefined`-cost path fills in a real number.

The existing unknown-pricing zero-cost case (codex/gpt-5.x all-zero catalog entries) is unchanged and still surfaces as a missing-cost entry, so the safeguards still flag genuinely unpriced turns.

Bump `USAGE_COST_CACHE_VERSION` from 4 to 5 so durable caches written by older builds are rebuilt under the new re-estimate semantics instead of continuing to serve the stale $0 totals.

## User Impact

Operators on DeepSeek V4 (and any other provider that returns `usage.cost.total: 0` despite positive catalog pricing) now see real spend in the Control UI Spend panel and in `openclaw memory usage` summaries; budget/spike monitoring that keys off `totalCost` is no longer silently zeroed out for those turns.

## Evidence

- New regression test `re-estimates spend when a known-priced model records cost.total: 0 with non-zero tokens` in `src/infra/session-cost-usage.test.ts` covers a DeepSeek V4-shaped transcript entry: 10k input + 5k output tokens, recorded `cost.total: 0`, configured positive pricing. Asserts `totalCost ≈ 0.28` and `missingCostEntries === 0`.
- Existing tests `counts token usage for an unpriced ... model as missing` and `counts token usage for a configured all-zero model as missing` still pass unchanged, confirming the unknown-pricing missing-cost path is preserved.
- Existing cache-staleness test `treats a pre-upgrade (older-version) durable cache as stale so unpriced usage is rebuilt` still stamps `version: 3` and is treated as stale under the new `USAGE_COST_CACHE_VERSION = 5`, confirming old caches are rebuilt.
- `node scripts/run-vitest.mjs run src/infra/session-cost-usage.test.ts` passes locally.
