### PR TITLE
fix(llm): use thinking.type param for zai GLM-4.5+ models (#97772)

### DIFF
--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -6844,6 +6844,51 @@ describe("openai transport stream", () => {
     expect(disabled.reasoning_effort).toBe("none");
   });
 
+  it("maps zai thinking format to thinking.type and reasoning_effort for GLM-4.5+", () => {
+    const baseModel = {
+      id: "glm-5.2",
+      name: "GLM 5.2",
+      api: "openai-completions",
+      provider: "zai",
+      baseUrl: "https://open.bigmodel.cn/api/paas/v4",
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 131072,
+      maxTokens: 8192,
+      compat: {
+        thinkingFormat: "zai",
+      },
+    } as unknown as Model<"openai-completions">;
+    const context = {
+      systemPrompt: "system",
+      messages: [],
+      tools: [],
+    } as never;
+
+    const enabled = buildOpenAICompletionsParams(baseModel, context, {
+      reasoning: "medium",
+    } as never) as {
+      thinking?: { type: string };
+      reasoning_effort?: unknown;
+      enable_thinking?: unknown;
+    };
+    const disabled = buildOpenAICompletionsParams(baseModel, context, {
+      reasoning: "off",
+    } as never) as {
+      thinking?: { type: string };
+      reasoning_effort?: unknown;
+      enable_thinking?: unknown;
+    };
+
+    expect(enabled.thinking).toEqual({ type: "enabled" });
+    expect(enabled.reasoning_effort).toBe("medium");
+    expect(enabled).not.toHaveProperty("enable_thinking");
+    expect(disabled.thinking).toEqual({ type: "disabled" });
+    expect(disabled).not.toHaveProperty("reasoning_effort");
+    expect(disabled).not.toHaveProperty("enable_thinking");
+  });
+
   it("maps qwen thinking format to top-level enable_thinking", () => {
     const baseModel = {
       id: "qwen3.5-32b",

--- a/src/llm/providers/openai-completions.ts
+++ b/src/llm/providers/openai-completions.ts
@@ -724,7 +724,15 @@ function buildParams(
   }
 
   if (compat.thinkingFormat === "zai" && model.reasoning) {
-    params.enable_thinking = Boolean(options?.reasoningEffort);
+    // ZAI/Zhipu GLM-4.5+ (including GLM-5.2) dropped the legacy `enable_thinking`
+    // top-level boolean in favor of `thinking: { type: "enabled" | "disabled" }`,
+    // matching the DeepSeek thinking contract. The legacy param was silently ignored,
+    // so `/reasoning on` produced no `reasoning_content` in responses.
+    params.thinking = { type: options?.reasoningEffort ? "enabled" : "disabled" };
+    if (options?.reasoningEffort) {
+      params.reasoning_effort =
+        model.thinkingLevelMap?.[options.reasoningEffort] ?? options.reasoningEffort;
+    }
   } else if (compat.thinkingFormat === "qwen" && model.reasoning) {
     params.enable_thinking = Boolean(options?.reasoningEffort);
   } else if (compat.thinkingFormat === "qwen-chat-template" && model.reasoning) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators enabling `/reasoning on` (or `reasoning: true` in the model config) on ZAI/Zhipu GLM-4.5+ models (including GLM-5.2) would silently get **no reasoning output** in responses. `reasoning_content` was absent from both streaming and non-streaming completions, so users could not see the thinking process even though reasoning was explicitly enabled.

The `zai` thinkingFormat adapter was still sending the legacy `enable_thinking: <boolean>` top-level parameter. ZAI/Zhipu dropped that param for GLM-4.5+ in favor of `thinking: { "type": "enabled" | "disabled" }`, so the API ignored the legacy field entirely.

Closes #97772.

## Why This Change Was Made

Switch the `zai` thinkingFormat branch from `params.enable_thinking = ...` to the same `params.thinking = { type: ... }` + optional `reasoning_effort` contract already used by the `deepseek` thinkingFormat. The official Zhipu docs for GLM-5.2 document `thinking: { "type": "enabled" }` and a top-level `reasoning_effort` field — both are now sent when reasoning is enabled.

The `qwen` and `qwen-chat-template` formats are untouched because their providers still expect the legacy `enable_thinking` field.

## User Impact

Operators on GLM-4.5+, GLM-4.6, GLM-5, and GLM-5.2 now see real `reasoning_content` in responses when `/reasoning on` or `/reasoning stream` is enabled, matching the documented Zhipu thinking behavior.

## Evidence

- New regression test `maps zai thinking format to thinking.type and reasoning_effort for GLM-4.5+` in `src/agents/openai-transport-stream.test.ts` covers a GLM-5.2 model: asserts `thinking: { type: "enabled" }` and `reasoning_effort: "medium"` when reasoning is on, `thinking: { type: "disabled" }` and no `reasoning_effort` when off, and that the legacy `enable_thinking` is no longer present in either case.
- Existing `qwen` and `qwen-chat-template` thinkingFormat tests still pass unchanged.
- `node scripts/run-vitest.mjs run src/agents/openai-transport-stream.test.ts` passes locally.
- Zhipu official docs (linked in #97772) show `thinking: { "type": "enabled" }` as the current param; `enable_thinking` is no longer mentioned.
