### PR TITLE
fix(llm): skip native DeepSeek V4 wrapper for OpenRouter routes

### DIFF
--- a/src/agents/embedded-agent-runner/extra-params.deepseek-v4-thinking-format.test.ts
+++ b/src/agents/embedded-agent-runner/extra-params.deepseek-v4-thinking-format.test.ts
@@ -46,6 +46,40 @@ describe("extra-params: DeepSeek V4 OpenAI-compatible thinking fallback", () => 
     expect(payload.reasoning_effort).toBe("high");
   });
 
+  it("does not inject thinking on OpenRouter-routed DeepSeek V4 (provider id)", () => {
+    // The OpenAI-completions builder auto-detects thinkingFormat: "openrouter" for
+    // provider === "openrouter" and emits `reasoning: { effort }`. The native DeepSeek
+    // wrapper must not also fire, otherwise both `reasoning_effort` and `reasoning.effort`
+    // land in the request and DeepSeek rejects with HTTP 400.
+    const payload = runDeepSeekV4Case({
+      provider: "openrouter",
+      thinkingLevel: "high",
+    });
+    expect(payload).not.toHaveProperty("thinking");
+    expect(payload).not.toHaveProperty("reasoning_effort");
+  });
+
+  it("does not inject thinking on OpenRouter-routed DeepSeek V4 (baseUrl)", () => {
+    const payload = runExtraParamsCase({
+      applyProvider: "custom-proxy",
+      applyModelId: "deepseek-v4-pro",
+      mockProviderRuntime: true,
+      thinkingLevel: "high",
+      model: {
+        api: "openai-completions",
+        provider: "custom-proxy",
+        id: "deepseek-v4-pro",
+        baseUrl: "https://openrouter.ai/api/v1",
+      } as Model<"openai-completions">,
+      payload: {
+        model: "deepseek-v4-pro",
+        messages: [],
+      },
+    }).payload as Record<string, unknown>;
+    expect(payload).not.toHaveProperty("thinking");
+    expect(payload).not.toHaveProperty("reasoning_effort");
+  });
+
   it("does not inject thinking on canonical Microsoft Foundry", () => {
     const payload = runDeepSeekV4Case({
       provider: "microsoft-foundry",

--- a/src/agents/embedded-agent-runner/extra-params.ts
+++ b/src/agents/embedded-agent-runner/extra-params.ts
@@ -933,7 +933,30 @@ function normalizeDeepSeekV4CandidateId(modelId: unknown): string | undefined {
 }
 
 function isDeepSeekV4OpenAICompatibleModel(model: Parameters<StreamFn>[0]): boolean {
-  return isDeepSeekV4OpenAICompletionsModel(model) && !isMicrosoftFoundryProviderId(model.provider);
+  return (
+    isDeepSeekV4OpenAICompletionsModel(model) &&
+    !isMicrosoftFoundryProviderId(model.provider) &&
+    !isOpenRouterRoutingProvider(model)
+  );
+}
+
+/**
+ * OpenRouter-routed DeepSeek V4 models are a documented OpenClaw wire-format route
+ * (`docs/providers/openrouter.md`): the OpenAI-completions builder auto-detects
+ * `thinkingFormat: "openrouter"` from `provider === "openrouter"` and emits
+ * `reasoning: { effort }`. The native DeepSeek V4 wrapper would otherwise also
+ * fire (its gate reads only user-config `compat.thinkingFormat`, which is unset
+ * for the OpenRouter route) and write a conflicting `reasoning_effort` field,
+ * causing HTTP 400 `"reasoning_effort" and "reasoning.effort" are both provided
+ * with conflicting values`. Excluding OpenRouter here matches the existing
+ * Microsoft Foundry exclusion: a non-DeepSeek-native provider should not receive
+ * the native DeepSeek thinking payload.
+ */
+function isOpenRouterRoutingProvider(model: Parameters<StreamFn>[0]): boolean {
+  if (typeof model.provider === "string" && model.provider === "openrouter") {
+    return true;
+  }
+  return typeof model.baseUrl === "string" && model.baseUrl.includes("openrouter.ai");
 }
 
 function isDeepSeekV4OpenAICompletionsModel(model: Parameters<StreamFn>[0]): boolean {


### PR DESCRIPTION
## What Problem This Solves

DeepSeek V4 models routed through OpenRouter (`openrouter/deepseek/deepseek-v4-flash`, `openrouter/deepseek/deepseek-v4-pro`) reject every request with:

```
400 "reasoning_effort" and "reasoning.effort" are both provided with conflicting values
```

Closes #97196.

## Why This Change Was Made

Two code paths emit reasoning-control fields and they disagree on the source of truth for `thinkingFormat`:

- `openai-completions.ts` chat-completions builder reads the **merged** compat from `getCompat(model)`, which auto-detects `thinkingFormat: "openrouter"` for any `provider === "openrouter"` model and emits `reasoning: { effort }`.
- The DeepSeek V4 stream wrapper (`extra-params.ts` `isDeepSeekV4OpenAICompatibleModel`) gates only on the user-config compat (`model.compat.thinkingFormat`), which stays `undefined` even after auto-detection. The wrapper then fires and writes `reasoning_effort`, so the request ends up with both fields and DeepSeek returns HTTP 400.

The wrapper already excludes `microsoft-foundry` provider ids. This change extends that pattern to OpenRouter-routed models, matching the existing exclusion semantics and the documented OpenRouter route for DeepSeek V4 (`docs/providers/openrouter.md`).

## User Impact

- OpenRouter-routed DeepSeek V4 calls no longer fail with HTTP 400; only `reasoning: { effort }` is sent (the OpenRouter-supported shape).
- Other providers (canonical DeepSeek, Microsoft Foundry, Azure Foundry via `thinkingFormat: "openai"`, ZAI, Qwen) keep their existing behavior.

## Evidence

- New regression tests in `extra-params.deepseek-v4-thinking-format.test.ts`:
  - `does not inject thinking on OpenRouter-routed DeepSeek V4 (provider id)`
  - `does not inject thinking on OpenRouter-routed DeepSeek V4 (baseUrl)`
- Verified with `node scripts/run-vitest.mjs extra-params.deepseek-v4-thinking-format` (exit 0).
- Existing assertions still cover the canonical DeepSeek injection (`injects deepseek-native thinking for unowned proxy providers`) and the Microsoft Foundry exclusions.