### PR TITLE
fix(gateway): log chat-abort terminal persistence failures

### DIFF
--- a/src/gateway/chat-abort.test.ts
+++ b/src/gateway/chat-abort.test.ts
@@ -16,6 +16,17 @@ import {
   updateChatRunProvider,
 } from "./chat-abort.js";
 
+const subsystemLoggerMock = vi.hoisted(() => ({
+  error: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+  debug: vi.fn(),
+}));
+
+vi.mock("../logging/subsystem.js", () => ({
+  createSubsystemLogger: vi.fn(() => subsystemLoggerMock),
+}));
+
 type ChatAbortPayload = {
   runId: string;
   sessionKey: string;
@@ -45,6 +56,10 @@ type CreatedChatAbortOps = ChatAbortOps & {
 
 afterEach(() => {
   vi.useRealTimers();
+  subsystemLoggerMock.error.mockClear();
+  subsystemLoggerMock.warn.mockClear();
+  subsystemLoggerMock.info.mockClear();
+  subsystemLoggerMock.debug.mockClear();
 });
 
 function createActiveEntry(sessionKey: string): ChatAbortControllerEntry {
@@ -263,6 +278,39 @@ describe("registerChatAbortController", () => {
     await persistence;
     await Promise.resolve();
     expect(chatAbortControllers.has("run-persisting")).toBe(false);
+  });
+
+  it("logs and still removes the controller when terminal persistence rejects", async () => {
+    const chatAbortControllers = new Map<string, ChatAbortControllerEntry>();
+    const registration = registerChatAbortController({
+      chatAbortControllers,
+      runId: "run-persist-failed",
+      sessionId: "sess-1",
+      sessionKey: "main",
+      timeoutMs: 60_000,
+    });
+
+    if (!registration.entry) {
+      throw new Error("expected registered entry");
+    }
+    registration.entry.projectSessionActive = false;
+    registration.entry.projectSessionTerminalPersistence = Promise.reject(
+      new Error("db write failed"),
+    );
+
+    registration.cleanup();
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(chatAbortControllers.has("run-persist-failed")).toBe(false);
+    expect(subsystemLoggerMock.error).toHaveBeenCalledOnce();
+    const [message, meta] = subsystemLoggerMock.error.mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+    ];
+    expect(message).toContain("persist chat abort terminal state");
+    expect(meta).toMatchObject({ runId: "run-persist-failed", error: "db write failed" });
   });
 
   it("retains registrations when terminal lifecycle was observed before caller cleanup", () => {

--- a/src/gateway/chat-abort.ts
+++ b/src/gateway/chat-abort.ts
@@ -11,7 +11,10 @@ import { isAbortRequestText } from "../auto-reply/reply/abort-primitives.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { emitAgentEvent, getAgentEventLifecycleGeneration } from "../infra/agent-events.js";
 import { jsonUtf8Bytes } from "../infra/json-utf8-bytes.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import { projectLiveAssistantBufferedText } from "./live-chat-projector.js";
+
+const log = createSubsystemLogger("gateway/chat-abort");
 import { createChatAbortMarker, type ChatAbortMarker } from "./server-chat-state.js";
 
 const DEFAULT_CHAT_RUN_ABORT_GRACE_MS = 60_000;
@@ -173,7 +176,14 @@ export function registerChatAbortController(params: {
               params.chatAbortControllers.delete(params.runId);
             }
           })
-          .catch(() => {
+          .catch((err) => {
+            // Persistence failures here are typically DB or filesystem health
+            // issues. Logging gives operators visibility; the controller entry
+            // is still removed so memory does not leak.
+            log.error("Failed to persist chat abort terminal state", {
+              runId: params.runId,
+              error: err instanceof Error ? err.message : String(err),
+            });
             if (params.chatAbortControllers.get(params.runId)?.controller === controller) {
               params.chatAbortControllers.delete(params.runId);
             }


### PR DESCRIPTION
## What Problem This Solves

The terminal persistence `.catch()` in `registerChatAbortController` silently dropped the rejection, so DB/filesystem health failures during chat-run cleanup left no trace in logs while still removing the abort-controller entry.

Closes #97795.

## Why This Change Was Made

When `projectSessionTerminalPersistence` rejects, the cleanup still needs to remove the controller (otherwise memory leaks), but operators need to see *why* the persistence failed. The previous `.catch(() => { ... })` discarded the error entirely. The new `.catch((err) => { log.error(...); ... })` records the failure through the `gateway/chat-abort` subsystem logger before removing the entry, mirroring how other gateway subsystems surface persistence-layer errors.

## User Impact

- No behavior change for the happy path.
- Operators now see persistence failures in logs (`gateway/chat-abort` subsystem) instead of silent swallowing, so DB or filesystem health issues during run cleanup become diagnosable.
- The abort-controller entry is still removed on rejection, so memory behavior is unchanged.

## Evidence

- New regression test in `src/gateway/chat-abort.test.ts`: `logs and still removes the controller when terminal persistence rejects`. It asserts (1) the controller entry is removed and (2) the subsystem logger recorded the rejection with the run id and error message.
- Existing test `retains completed registrations until terminal persistence succeeds` still covers the success path.
- `node scripts/run-vitest.mjs chat-abort.test` exits 0.