### PR TITLE
fix(feishu): upgrade single newlines to double for md tag

### DIFF
--- a/extensions/feishu/src/send.test.ts
+++ b/extensions/feishu/src/send.test.ts
@@ -105,6 +105,49 @@ describe("buildFeishuPostMessagePayload", () => {
       },
     });
   });
+
+  it("upgrades single newlines to double newlines for Feishu md rendering", () => {
+    const payload = buildFeishuPostMessagePayload({
+      messageText: "first line\nsecond line\nthird line",
+    });
+    const element = JSON.parse(payload.content).zh_cn.content[0][0];
+    expect(element.tag).toBe("md");
+    expect(element.text).toBe("first line\n\nsecond line\n\nthird line");
+  });
+
+  it("preserves existing double newlines and code blocks when upgrading newlines", () => {
+    const payload = buildFeishuPostMessagePayload({
+      messageText: [
+        "paragraph one",
+        "",
+        "paragraph two has\na soft break",
+        "",
+        "```ts",
+        "const x = 1\nconst y = 2",
+        "```",
+        "",
+        "tail with\nsoft break",
+      ].join("\n"),
+    });
+    const element = JSON.parse(payload.content).zh_cn.content[0][0];
+    expect(element.text).toBe(
+      [
+        "paragraph one",
+        "",
+        "paragraph two has",
+        "",
+        "a soft break",
+        "",
+        "```ts",
+        "const x = 1\nconst y = 2",
+        "```",
+        "",
+        "tail with",
+        "",
+        "soft break",
+      ].join("\n"),
+    );
+  });
 });
 
 describe("getMessageFeishu", () => {

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -6,7 +6,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { convertMarkdownTables } from "openclaw/plugin-sdk/text-chunking";
+import { convertMarkdownTables, findCodeRegions } from "openclaw/plugin-sdk/text-chunking";
 import type { ClawdbotConfig } from "../runtime-api.js";
 import { resolveFeishuRuntimeAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
@@ -583,7 +583,7 @@ export function buildFeishuPostMessagePayload(params: {
     ...buildFeishuPostMentionElements(mentions),
     {
       tag: "md",
-      text: messageText,
+      text: upgradeSingleNewlinesForFeishuMd(messageText),
     },
   ];
   return {
@@ -594,6 +594,44 @@ export function buildFeishuPostMessagePayload(params: {
     }),
     msgType: "post",
   };
+}
+
+/**
+ * Upgrades single `\n` to `\n\n` for Feishu `tag: "md"` rendering.
+ *
+ * Feishu's post+md renderer collapses a single `\n` to a space, so paragraph
+ * breaks and soft line wraps show up mashed together. Only `\n\n` is treated
+ * as a paragraph break. Skip fenced/inline code so example output and code
+ * blocks keep their original line shape.
+ */
+function upgradeSingleNewlinesForFeishuMd(text: string): string {
+  if (!text.includes("\n")) {
+    return text;
+  }
+  const codeRegions = findCodeRegions(text);
+  if (codeRegions.length === 0) {
+    return upgradeSingleNewlinesInRange(text);
+  }
+  let result = "";
+  let cursor = 0;
+  for (const region of codeRegions) {
+    if (region.start > cursor) {
+      result += upgradeSingleNewlinesInRange(text.slice(cursor, region.start));
+    }
+    result += text.slice(region.start, region.end);
+    cursor = region.end;
+  }
+  if (cursor < text.length) {
+    result += upgradeSingleNewlinesInRange(text.slice(cursor));
+  }
+  return result;
+}
+
+function upgradeSingleNewlinesInRange(segment: string): string {
+  // Match a `\n` that is neither preceded nor followed by another `\n`.
+  // Lookbehind/lookahead let adjacent single newlines (e.g. `a\nb\nc`) all
+  // upgrade rather than just the first one in the run.
+  return segment.replace(/(?<=[^\n])\n(?=[^\n])/g, "\n\n");
 }
 
 export async function sendMessageFeishu(


### PR DESCRIPTION
## What Problem This Solves

Feishu's `post` + `tag: "md"` renderer collapses a single `\n` to a space, so any agent message with standard single-newline paragraph breaks appears cramped (multiple paragraphs joined into one visually-continuous line).

Closes #97074.

## Why This Change Was Made

`buildFeishuPostMessagePayload` wrapped `messageText` verbatim. Feishu only treats `\n\n` as a paragraph break in `tag: "md"` payloads, so single `\n` between paragraphs disappeared into spaces. The fix upgrades each single `\n` (not adjacent to another `\n`) to `\n\n` before wrapping, while leaving fenced and inline code regions untouched so example output preserves its original line shape. The helper uses the existing `findCodeRegions` exported through `openclaw/plugin-sdk/text-chunking` rather than re-tokenizing markdown.

## User Impact

- Multi-paragraph agent replies in Feishu now render with proper paragraph spacing instead of being mashed together.
- Code blocks and inline code keep their original line shape (no spurious blank lines inserted).
- Existing `\n\n` separators are preserved as-is — no double-upgrading.
- Other channels are unaffected (the change is scoped to Feishu's post-md payload builder).

## Evidence

- New tests in `extensions/feishu/src/send.test.ts`:
  - `upgrades single newlines to double newlines for Feishu md rendering` — verifies `a\nb\nc` becomes `a\n\nb\n\nc`.
  - `preserves existing double newlines and code blocks when upgrading newlines` — verifies `\n\n` separators stay and `\n` inside a ` ``` ` block is left intact.
- Existing tests (`prepends structured mention targets as native post at elements`, `leaves body-supplied at tags literal in the markdown element`) still pass — they don't contain `\n` so the upgrade is a no-op.
- `node scripts/run-vitest.mjs extensions/feishu/src/send.test` exits 0.