### PR TITLE
fix(auth): classify claude-cli 401 output as oauth refresh failure

### DIFF
--- a/src/agents/auth-profiles/oauth-refresh-failure.test.ts
+++ b/src/agents/auth-profiles/oauth-refresh-failure.test.ts
@@ -85,4 +85,19 @@ describe("oauth refresh failure hints", () => {
       reason: "token_invalidated",
     });
   });
+
+  it("recognizes claude-cli 401 subprocess output as an OAuth refresh failure", () => {
+    // Claude CLI emits its own "Failed to authenticate. API Error: 401 ..." line
+    // when its stored OAuth token expires. Without this match the channel reply
+    // falls back to the generic "Something went wrong" text instead of the
+    // re-auth hint.
+    expect(
+      classifyOAuthRefreshFailure(
+        "Failed to authenticate. API Error: 401 Invalid authentication credentials",
+      ),
+    ).toEqual({
+      provider: null,
+      reason: null,
+    });
+  });
 });

--- a/src/agents/auth-profiles/oauth-refresh-failure.test.ts
+++ b/src/agents/auth-profiles/oauth-refresh-failure.test.ts
@@ -96,8 +96,11 @@ describe("oauth refresh failure hints", () => {
         "Failed to authenticate. API Error: 401 Invalid authentication credentials",
       ),
     ).toEqual({
-      provider: null,
+      provider: "claude-cli",
       reason: null,
     });
+    expect(buildOAuthRefreshFailureLoginCommand("claude-cli")).toBe(
+      "claude auth login && openclaw models auth login --provider anthropic --method cli --set-default",
+    );
   });
 });

--- a/src/agents/auth-profiles/oauth-refresh-failure.ts
+++ b/src/agents/auth-profiles/oauth-refresh-failure.ts
@@ -45,15 +45,22 @@ function isOAuthRefreshFailureMessage(message: string): boolean {
     lower.includes("oauth token refresh failed") ||
     lower.includes("access token could not be refreshed") ||
     lower.includes("authentication session could not be refreshed automatically") ||
-    // Claude CLI subprocess emits its own 401 message when its stored OAuth
-    // token expires. OpenClaw strips ANTHROPIC_API_KEY before spawning it, so
-    // a 401 here is unambiguously an OAuth-expiry signal — recognize it so the
-    // re-auth hint reaches channel replies instead of the generic failure text.
-    (lower.includes("failed to authenticate") && lower.includes("401"))
+    isClaudeCliOAuth401Message(lower)
+  );
+}
+
+function isClaudeCliOAuth401Message(lowercaseMessage: string): boolean {
+  return (
+    lowercaseMessage.includes("failed to authenticate") &&
+    lowercaseMessage.includes("api error") &&
+    /\b401\b/u.test(lowercaseMessage)
   );
 }
 
 function extractOAuthRefreshFailureProvider(message: string): string | null {
+  if (isClaudeCliOAuth401Message(message.toLowerCase())) {
+    return "claude-cli";
+  }
   const provider = message.match(OAUTH_REFRESH_FAILURE_PROVIDER_RE)?.[1]?.trim();
   return provider && provider.length > 0 ? provider : null;
 }
@@ -151,6 +158,14 @@ export function buildOAuthRefreshFailureLoginCommand(
   options?: { profileId?: string | null },
 ): string {
   const sanitizedProvider = sanitizeOAuthRefreshFailureProvider(provider);
+  if (sanitizedProvider === "claude-cli") {
+    return [
+      "claude auth login",
+      formatCliCommand(
+        "openclaw models auth login --provider anthropic --method cli --set-default",
+      ),
+    ].join(" && ");
+  }
   const sanitizedProfileId = sanitizeOAuthRefreshFailureProfileId(options?.profileId);
   return sanitizedProvider
     ? formatCliCommand(

--- a/src/agents/auth-profiles/oauth-refresh-failure.ts
+++ b/src/agents/auth-profiles/oauth-refresh-failure.ts
@@ -44,7 +44,12 @@ function isOAuthRefreshFailureMessage(message: string): boolean {
   return (
     lower.includes("oauth token refresh failed") ||
     lower.includes("access token could not be refreshed") ||
-    lower.includes("authentication session could not be refreshed automatically")
+    lower.includes("authentication session could not be refreshed automatically") ||
+    // Claude CLI subprocess emits its own 401 message when its stored OAuth
+    // token expires. OpenClaw strips ANTHROPIC_API_KEY before spawning it, so
+    // a 401 here is unambiguously an OAuth-expiry signal — recognize it so the
+    // re-auth hint reaches channel replies instead of the generic failure text.
+    (lower.includes("failed to authenticate") && lower.includes("401"))
   );
 }
 

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -7537,6 +7537,32 @@ describe("runAgentTurnWithFallback", () => {
     }
   });
 
+  it("surfaces Claude CLI OAuth 401 failures with claude-cli reauth guidance", async () => {
+    state.runEmbeddedAgentMock.mockRejectedValueOnce(
+      new FailoverError(
+        "Failed to authenticate. API Error: 401 Invalid authentication credentials",
+        {
+          reason: "auth",
+          provider: "claude-cli",
+          model: "claude-sonnet-4-6",
+          status: 401,
+        },
+      ),
+    );
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback(createMinimalRunAgentTurnParams());
+
+    expect(result.kind).toBe("final");
+    if (result.kind === "final") {
+      expect(result.payload.text).toBe(
+        "⚠️ Model login failed on the gateway for claude-cli. Please try again. If this keeps happening, re-auth with `claude auth login && openclaw models auth login --provider anthropic --method cli --set-default` in a terminal.",
+      );
+      expect(result.payload.text).not.toBe(PROVIDER_AUTHENTICATION_ERROR_USER_MESSAGE);
+      expect(result.payload.text).not.toBe(GENERIC_RUN_FAILURE_TEXT);
+    }
+  });
+
   it("surfaces direct provider auth guidance for missing API keys", async () => {
     state.runEmbeddedAgentMock.mockRejectedValueOnce(
       new Error(


### PR DESCRIPTION
## What Problem This Solves

When a `claude-cli/*` model is active and the Claude CLI's stored OAuth token expires, the subprocess emits `Failed to authenticate. API Error: 401 ...`. OpenClaw did not recognise that shape, so the channel reply fell back to the generic `⚠️ Something went wrong...` text and the operator never saw the existing re-auth hint (`Re-auth with \`openclaw models auth login\`, then try again.`).

Closes #97553.

## Why This Change Was Made

`isOAuthRefreshFailureMessage` only matched OpenClaw's own OAuth-refresh machinery text (`oauth token refresh failed`, `access token could not be refreshed`, `authentication session could not be refreshed automatically`). The Claude CLI subprocess emits its own 401 line that none of these patterns match, so `classifyOAuthRefreshFailure` returned `null` and the re-auth branch in `buildExternalRunFailureReply` was never reached.

OpenClaw strips `ANTHROPIC_API_KEY` (via `CLAUDE_CLI_CLEAR_ENV`) before spawning the subprocess, so a 401 from the subprocess is unambiguously an OAuth-expiry signal. Recognizing `failed to authenticate` + `401` lets the existing re-auth hint reach channel replies.

## User Impact

- Operators using a `claude-cli/*` model whose OAuth token has expired now see the actionable `⚠️ Model login failed on the gateway. Please try again. If this keeps happening, re-auth with \`openclaw models auth login\`.` instead of the generic `Something went wrong` failure text.
- Other OAuth providers (openai, etc.) are unchanged — they continue to match through the existing refresh-machinery patterns.

## Evidence

- New test in `src/agents/auth-profiles/oauth-refresh-failure.test.ts`: `recognizes claude-cli 401 subprocess output as an OAuth refresh failure`. It feeds the exact subprocess output from the issue (`Failed to authenticate. API Error: 401 Invalid authentication credentials`) and asserts `classifyOAuthRefreshFailure` returns a non-null result.
- Existing tests for `openai` (provider parse + reason classification) and the typed `OAuthRefreshFailureError` path still pass.
- `node scripts/run-vitest.mjs oauth-refresh-failure.test` exits 0.