### PR TITLE
fix(codex): keep plugin apps available when inventory is missing

### DIFF
--- a/extensions/codex/src/app-server/app-inventory-cache.test.ts
+++ b/extensions/codex/src/app-server/app-inventory-cache.test.ts
@@ -65,19 +65,13 @@ describe("Codex app inventory cache", () => {
     expect(request).not.toHaveBeenCalled();
   });
 
-  it("stops paginated refresh once target app ids are found", async () => {
+  it("finds a targeted app on a later large page", async () => {
     const cache = new CodexAppInventoryCache({ ttlMs: 100 });
     const request = vi.fn(async (_method: "app/list", params: v2.AppsListParams) => {
-      if (!params.cursor) {
-        return { data: [app("app-1")], nextCursor: "page-2" } satisfies v2.AppsListResponse;
-      }
-      if (params.cursor === "page-2") {
-        return {
-          data: [app("google-calendar-app")],
-          nextCursor: "page-3",
-        } satisfies v2.AppsListResponse;
-      }
-      return { data: [app("app-3")], nextCursor: null } satisfies v2.AppsListResponse;
+      return {
+        data: [app(params.cursor ? "google-calendar-app" : "app-1")],
+        nextCursor: params.cursor ? "page-3" : "page-2",
+      } satisfies v2.AppsListResponse;
     });
 
     const snapshot = await cache.refreshNow({
@@ -88,7 +82,55 @@ describe("Codex app inventory cache", () => {
 
     expect(snapshot.apps.map((item) => item.id)).toEqual(["app-1", "google-calendar-app"]);
     expect(request).toHaveBeenCalledTimes(2);
-    expect(request.mock.calls.map(([, params]) => params.cursor ?? null)).toEqual([null, "page-2"]);
+    expect(request).toHaveBeenNthCalledWith(1, "app/list", {
+      cursor: undefined,
+      limit: 1_000,
+      forceRefetch: false,
+    });
+    expect(request).toHaveBeenNthCalledWith(2, "app/list", {
+      cursor: "page-2",
+      limit: 1_000,
+      forceRefetch: false,
+    });
+  });
+
+  it("exhausts targeted refresh pages when a target app is absent", async () => {
+    const cache = new CodexAppInventoryCache({ ttlMs: 100 });
+    const request = vi.fn(async (_method: "app/list", params: v2.AppsListParams) => {
+      return {
+        data: [app(params.cursor ? "app-2" : "app-1")],
+        nextCursor: params.cursor ? null : "page-2",
+      } satisfies v2.AppsListResponse;
+    });
+
+    const snapshot = await cache.refreshNow({
+      key: "runtime",
+      request,
+      targetAppIds: ["missing-app"],
+    });
+
+    expect(snapshot.apps.map((item) => item.id)).toEqual(["app-1", "app-2"]);
+    expect(request).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects a repeated app/list cursor instead of caching a partial snapshot", async () => {
+    const cache = new CodexAppInventoryCache({ ttlMs: 100 });
+    const request = vi.fn(async () => ({
+      data: [app(`app-${request.mock.calls.length}`)],
+      nextCursor: "page-2",
+    }));
+
+    await expect(
+      cache.refreshNow({
+        key: "runtime",
+        request,
+        targetAppIds: ["missing-app"],
+      }),
+    ).rejects.toThrow("app/list returned repeated cursor page-2");
+
+    const read = cache.read({ key: "runtime", request, suppressRefresh: true });
+    expect(read.state).toBe("missing");
+    expect(read.snapshot).toBeUndefined();
   });
 
   it("uses stale inventory for the current read while still refreshing asynchronously", async () => {

--- a/extensions/codex/src/app-server/app-inventory-cache.ts
+++ b/extensions/codex/src/app-server/app-inventory-cache.ts
@@ -13,6 +13,7 @@ import type { JsonValue, v2 } from "./protocol.js";
 
 /** Default app inventory cache freshness window. */
 export const CODEX_APP_INVENTORY_CACHE_TTL_MS = 60 * 60 * 1_000;
+const CODEX_TARGETED_APP_INVENTORY_LIMIT = 1_000;
 const MAX_SERIALIZED_ERROR_MESSAGE_LENGTH = 500;
 
 /** App-server request function used to list installed/available apps. */
@@ -293,23 +294,31 @@ async function listAllApps(
 ): Promise<v2.AppInfo[]> {
   const apps: v2.AppInfo[] = [];
   const targetIds = new Set(targetAppIds.filter(Boolean));
-  const foundTargetIds = new Set<string>();
+  const remainingTargetIds = new Set(targetIds);
+  const seenCursors = new Set<string>();
   let cursor: string | null | undefined;
   do {
     const response = await request("app/list", {
       cursor,
-      limit: 100,
+      // Thread startup only needs to recover the configured plugin-owned apps.
+      // Large pages minimize startup latency while pagination still proves an
+      // absent target instead of publishing a known-incomplete lookup.
+      limit: targetIds.size > 0 ? CODEX_TARGETED_APP_INVENTORY_LIMIT : 100,
       forceRefetch,
     });
     apps.push(...response.data);
     for (const app of response.data) {
-      if (targetIds.has(app.id)) {
-        foundTargetIds.add(app.id);
-      }
+      remainingTargetIds.delete(app.id);
+    }
+    if (targetIds.size > 0 && remainingTargetIds.size === 0) {
+      break;
     }
     cursor = response.nextCursor;
-    if (targetIds.size > 0 && foundTargetIds.size === targetIds.size) {
-      break;
+    if (cursor && seenCursors.has(cursor)) {
+      throw new Error(`app/list returned repeated cursor ${cursor}`);
+    }
+    if (cursor) {
+      seenCursors.add(cursor);
     }
   } while (cursor);
   return apps;

--- a/extensions/codex/src/app-server/plugin-activation.test.ts
+++ b/extensions/codex/src/app-server/plugin-activation.test.ts
@@ -237,6 +237,12 @@ describe("Codex plugin activation", () => {
             ...pluginList([remoteSummary]),
             marketplaces: [
               {
+                name: CODEX_PLUGINS_MARKETPLACE_NAME,
+                path: "/marketplaces/openai-curated",
+                interface: null,
+                plugins: [pluginSummary("github")],
+              },
+              {
                 name: "openai-curated-remote",
                 path: null,
                 interface: null,

--- a/extensions/codex/src/app-server/plugin-activation.test.ts
+++ b/extensions/codex/src/app-server/plugin-activation.test.ts
@@ -220,29 +220,35 @@ describe("Codex plugin activation", () => {
     ]);
   });
 
-  it("installs from a remote curated marketplace when no local marketplace path is present", async () => {
+  it("installs a disabled remote curated plugin by its resolved remote id", async () => {
     const calls: Array<{ method: string; params: unknown }> = [];
+    const remoteSummary = pluginSummary("google-calendar@openai-curated-remote", {
+      name: "google-calendar",
+      remotePluginId: "plugin_connector_google_calendar",
+      installed: false,
+      enabled: false,
+    });
     const result = await ensureCodexPluginActivation({
       identity: identity("google-calendar"),
       request: async (method, params) => {
         calls.push({ method, params });
         if (method === "plugin/list") {
           return {
-            ...pluginList([pluginSummary("google-calendar", { installed: false, enabled: false })]),
+            ...pluginList([remoteSummary]),
             marketplaces: [
               {
-                name: CODEX_PLUGINS_MARKETPLACE_NAME,
+                name: "openai-curated-remote",
                 path: null,
                 interface: null,
-                plugins: [pluginSummary("google-calendar", { installed: false, enabled: false })],
+                plugins: [remoteSummary],
               },
             ],
           } satisfies v2.PluginListResponse;
         }
         if (method === "plugin/install") {
           expect(params).toEqual({
-            remoteMarketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
-            pluginName: "google-calendar",
+            remoteMarketplaceName: "openai-curated-remote",
+            pluginName: "plugin_connector_google_calendar",
           });
           return { authPolicy: "ON_USE", appsNeedingAuth: [] } satisfies v2.PluginInstallResponse;
         }

--- a/extensions/codex/src/app-server/plugin-activation.ts
+++ b/extensions/codex/src/app-server/plugin-activation.ts
@@ -98,7 +98,9 @@ export async function ensureCodexPluginActivation(
     "plugin/install",
     pluginReadParams(
       resolved.marketplace,
-      params.identity.pluginName,
+      resolved.marketplace.remoteMarketplaceName && resolved.summary.remotePluginId
+        ? resolved.summary.remotePluginId
+        : params.identity.pluginName,
     ) satisfies v2.PluginInstallParams,
   )) as v2.PluginInstallResponse;
   const refreshDiagnostics: CodexPluginActivationDiagnostic[] = [];

--- a/extensions/codex/src/app-server/plugin-inventory.test.ts
+++ b/extensions/codex/src/app-server/plugin-inventory.test.ts
@@ -150,17 +150,25 @@ describe("Codex plugin inventory", () => {
         nextCursor: null,
       }),
     });
-    const listed = pluginList(
-      [
-        pluginSummary("google-calendar@openai-curated-remote", {
-          name: "google-calendar",
-          remotePluginId: "plugin_connector_google_calendar",
-          installed: true,
-          enabled: true,
-        }),
+    const remoteSummary = pluginSummary("google-calendar@openai-curated-remote", {
+      name: "google-calendar",
+      remotePluginId: "plugin_connector_google_calendar",
+      installed: true,
+      enabled: true,
+    });
+    const localListed = pluginList([pluginSummary("github")]);
+    const listed = {
+      ...localListed,
+      marketplaces: [
+        ...localListed.marketplaces,
+        {
+          name: "openai-curated-remote",
+          path: null,
+          interface: null,
+          plugins: [remoteSummary],
+        },
       ],
-      { name: "openai-curated-remote", path: null },
-    );
+    } satisfies v2.PluginListResponse;
 
     const inventory = await readCodexPluginInventory({
       pluginConfig: {

--- a/extensions/codex/src/app-server/plugin-inventory.test.ts
+++ b/extensions/codex/src/app-server/plugin-inventory.test.ts
@@ -140,6 +140,67 @@ describe("Codex plugin inventory", () => {
     );
   });
 
+  it("accepts the remote curated marketplace wire name", async () => {
+    const appCache = new CodexAppInventoryCache();
+    await appCache.refreshNow({
+      key: "runtime",
+      nowMs: 0,
+      request: async () => ({
+        data: [appInfo("google-calendar-app", true)],
+        nextCursor: null,
+      }),
+    });
+    const listed = pluginList(
+      [
+        pluginSummary("google-calendar@openai-curated-remote", {
+          name: "google-calendar",
+          remotePluginId: "plugin_connector_google_calendar",
+          installed: true,
+          enabled: true,
+        }),
+      ],
+      { name: "openai-curated-remote", path: null },
+    );
+
+    const inventory = await readCodexPluginInventory({
+      pluginConfig: {
+        codexPlugins: {
+          enabled: true,
+          plugins: {
+            "google-calendar": {
+              marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
+              pluginName: "google-calendar",
+            },
+          },
+        },
+      },
+      appCache,
+      appCacheKey: "runtime",
+      nowMs: 1,
+      request: async (method, params) => {
+        if (method === "plugin/list") {
+          return listed;
+        }
+        if (method === "plugin/read") {
+          expect(params).toEqual({
+            remoteMarketplaceName: "openai-curated-remote",
+            pluginName: "plugin_connector_google_calendar",
+          });
+          return pluginDetail("google-calendar", [appSummary("google-calendar-app")]);
+        }
+        throw new Error(`unexpected request ${method}`);
+      },
+    });
+
+    expect(inventory.marketplace).toEqual({
+      name: CODEX_PLUGINS_MARKETPLACE_NAME,
+      remoteMarketplaceName: "openai-curated-remote",
+    });
+    expect(inventory.records[0]?.ownedAppIds).toStrictEqual(["google-calendar-app"]);
+    expect(inventory.records[0]?.apps[0]?.accessible).toBe(true);
+    expect(inventory.diagnostics).toStrictEqual([]);
+  });
+
   it("fails closed when plugin detail apps are absent from app inventory", async () => {
     const appCache = new CodexAppInventoryCache();
     await appCache.refreshNow({
@@ -283,12 +344,15 @@ describe("Codex plugin inventory", () => {
   });
 });
 
-function pluginList(plugins: v2.PluginSummary[]): v2.PluginListResponse {
+function pluginList(
+  plugins: v2.PluginSummary[],
+  marketplace: { name?: string; path?: string | null } = {},
+): v2.PluginListResponse {
   return {
     marketplaces: [
       {
-        name: CODEX_PLUGINS_MARKETPLACE_NAME,
-        path: "/marketplaces/openai-curated",
+        name: marketplace.name ?? CODEX_PLUGINS_MARKETPLACE_NAME,
+        path: marketplace.path === undefined ? "/marketplaces/openai-curated" : marketplace.path,
         interface: null,
         plugins,
       },

--- a/extensions/codex/src/app-server/plugin-inventory.ts
+++ b/extensions/codex/src/app-server/plugin-inventory.ts
@@ -126,7 +126,7 @@ export async function readCodexPluginInventory(
     };
   }
 
-  const marketplace = marketplaceRef(marketplaceEntry);
+  let marketplace = marketplaceRef(marketplaceEntry);
   const diagnostics: CodexPluginInventoryDiagnostic[] = [];
   const records: CodexPluginInventoryRecord[] = [];
   if (appInventory?.state === "missing") {
@@ -145,8 +145,8 @@ export async function readCodexPluginInventory(
     if (!pluginPolicy.enabled) {
       continue;
     }
-    const summary = findPluginSummary(marketplaceEntry, pluginPolicy.pluginName);
-    if (!summary) {
+    const resolvedPlugin = findOpenAiCuratedMarketplacePlugin(listed, pluginPolicy.pluginName);
+    if (!resolvedPlugin) {
       diagnostics.push({
         code: "plugin_missing",
         plugin: pluginPolicy,
@@ -154,8 +154,19 @@ export async function readCodexPluginInventory(
       });
       continue;
     }
+    const { summary } = resolvedPlugin;
+    const pluginMarketplace = marketplaceRef(resolvedPlugin.marketplace);
+    if (records.length === 0) {
+      marketplace = pluginMarketplace;
+    }
 
-    const detail = await readPluginDetail(params, marketplace, pluginPolicy, summary, diagnostics);
+    const detail = await readPluginDetail(
+      params,
+      pluginMarketplace,
+      pluginPolicy,
+      summary,
+      diagnostics,
+    );
     const ownedAppIds =
       detail?.apps
         .map((app) => app.id)
@@ -213,12 +224,10 @@ export function findOpenAiCuratedPluginSummary(
   listed: v2.PluginListResponse,
   pluginName: string,
 ): { marketplace: CodexPluginMarketplaceRef; summary: v2.PluginSummary } | undefined {
-  const marketplaceEntry = listed.marketplaces.find(isOpenAiCuratedMarketplace);
-  if (!marketplaceEntry) {
-    return undefined;
-  }
-  const summary = findPluginSummary(marketplaceEntry, pluginName);
-  return summary ? { marketplace: marketplaceRef(marketplaceEntry), summary } : undefined;
+  const resolved = findOpenAiCuratedMarketplacePlugin(listed, pluginName);
+  return resolved
+    ? { marketplace: marketplaceRef(resolved.marketplace), summary: resolved.summary }
+    : undefined;
 }
 
 /** Builds plugin/read or plugin/install params from a marketplace reference. */
@@ -353,6 +362,22 @@ function findPluginSummary(
       plugin.id === `${pluginName}@${marketplace.name}` ||
       pluginNameFromPluginId(plugin.id, marketplace.name) === pluginName,
   );
+}
+
+function findOpenAiCuratedMarketplacePlugin(
+  listed: v2.PluginListResponse,
+  pluginName: string,
+): { marketplace: v2.PluginMarketplaceEntry; summary: v2.PluginSummary } | undefined {
+  for (const marketplace of listed.marketplaces) {
+    if (!isOpenAiCuratedMarketplace(marketplace)) {
+      continue;
+    }
+    const summary = findPluginSummary(marketplace, pluginName);
+    if (summary) {
+      return { marketplace, summary };
+    }
+  }
+  return undefined;
 }
 
 function pluginNameFromPluginId(pluginId: string, marketplaceName: string): string | undefined {

--- a/extensions/codex/src/app-server/plugin-inventory.ts
+++ b/extensions/codex/src/app-server/plugin-inventory.ts
@@ -16,6 +16,8 @@ import {
 } from "./config.js";
 import type { v2 } from "./protocol.js";
 
+const CODEX_PLUGINS_REMOTE_MARKETPLACE_NAME = `${CODEX_PLUGINS_MARKETPLACE_NAME}-remote`;
+
 /** Request callback used to call Codex app-server plugin/app methods. */
 export type CodexPluginRuntimeRequest = (method: string, params?: unknown) => Promise<unknown>;
 
@@ -108,9 +110,7 @@ export async function readCodexPluginInventory(
   const listed = (await params.request("plugin/list", {
     cwds: [],
   } satisfies v2.PluginListParams)) as v2.PluginListResponse;
-  const marketplaceEntry = listed.marketplaces.find(
-    (marketplace) => marketplace.name === CODEX_PLUGINS_MARKETPLACE_NAME,
-  );
+  const marketplaceEntry = listed.marketplaces.find(isOpenAiCuratedMarketplace);
   if (!marketplaceEntry) {
     return {
       policy,
@@ -155,7 +155,7 @@ export async function readCodexPluginInventory(
       continue;
     }
 
-    const detail = await readPluginDetail(params, marketplace, pluginPolicy, diagnostics);
+    const detail = await readPluginDetail(params, marketplace, pluginPolicy, summary, diagnostics);
     const ownedAppIds =
       detail?.apps
         .map((app) => app.id)
@@ -213,9 +213,7 @@ export function findOpenAiCuratedPluginSummary(
   listed: v2.PluginListResponse,
   pluginName: string,
 ): { marketplace: CodexPluginMarketplaceRef; summary: v2.PluginSummary } | undefined {
-  const marketplaceEntry = listed.marketplaces.find(
-    (marketplace) => marketplace.name === CODEX_PLUGINS_MARKETPLACE_NAME,
-  );
+  const marketplaceEntry = listed.marketplaces.find(isOpenAiCuratedMarketplace);
   if (!marketplaceEntry) {
     return undefined;
   }
@@ -257,6 +255,7 @@ async function readPluginDetail(
   params: ReadCodexPluginInventoryParams,
   marketplace: CodexPluginMarketplaceRef,
   pluginPolicy: ResolvedCodexPluginPolicy,
+  summary: v2.PluginSummary,
   diagnostics: CodexPluginInventoryDiagnostic[],
 ): Promise<v2.PluginDetail | undefined> {
   if (params.readPluginDetails === false) {
@@ -265,7 +264,12 @@ async function readPluginDetail(
   try {
     const response = (await params.request(
       "plugin/read",
-      pluginReadParams(marketplace, pluginPolicy.pluginName),
+      pluginReadParams(
+        marketplace,
+        marketplace.remoteMarketplaceName && summary.remotePluginId
+          ? summary.remotePluginId
+          : pluginPolicy.pluginName,
+      ),
     )) as v2.PluginReadResponse;
     return response.plugin;
   } catch (error) {
@@ -369,4 +373,11 @@ function marketplaceRef(marketplace: v2.PluginMarketplaceEntry): CodexPluginMark
     ...(marketplace.path ? { path: marketplace.path } : {}),
     ...(!marketplace.path ? { remoteMarketplaceName: marketplace.name } : {}),
   };
+}
+
+function isOpenAiCuratedMarketplace(marketplace: v2.PluginMarketplaceEntry): boolean {
+  return (
+    marketplace.name === CODEX_PLUGINS_MARKETPLACE_NAME ||
+    marketplace.name === CODEX_PLUGINS_REMOTE_MARKETPLACE_NAME
+  );
 }

--- a/extensions/codex/src/app-server/plugin-thread-config.test.ts
+++ b/extensions/codex/src/app-server/plugin-thread-config.test.ts
@@ -776,8 +776,8 @@ describe("Codex plugin thread config", () => {
     expect(appListParams).toEqual([
       {
         cursor: undefined,
-        limit: 100,
-        forceRefetch: true,
+        limit: 1_000,
+        forceRefetch: false,
       },
     ]);
   });
@@ -887,7 +887,7 @@ describe("Codex plugin thread config", () => {
     expect(appListParams).toEqual([
       {
         cursor: undefined,
-        limit: 100,
+        limit: 1_000,
         forceRefetch: true,
       },
     ]);
@@ -1076,7 +1076,7 @@ describe("Codex plugin thread config", () => {
     expect(appListParams).toEqual([
       {
         cursor: undefined,
-        limit: 100,
+        limit: 1_000,
         forceRefetch: true,
       },
     ]);
@@ -1182,12 +1182,12 @@ describe("Codex plugin thread config", () => {
     expect(appListParams).toEqual([
       {
         cursor: undefined,
-        limit: 100,
+        limit: 1_000,
         forceRefetch: true,
       },
       {
         cursor: undefined,
-        limit: 100,
+        limit: 1_000,
         forceRefetch: true,
       },
     ]);

--- a/extensions/codex/src/app-server/plugin-thread-config.ts
+++ b/extensions/codex/src/app-server/plugin-thread-config.ts
@@ -131,7 +131,10 @@ export async function buildCodexPluginThreadConfig(
     shouldRefreshMissingAppInventory(params, policy, inventory);
   if (shouldWaitForInitialAppInventory(params, policy, inventory)) {
     await refreshAppInventoryNow(params, appCache, {
-      forceRefetch: true,
+      // OpenClaw is missing its process-local snapshot, but Codex may already
+      // have a current inventory. Avoid rebuilding the entire remote catalog
+      // during thread startup; post-install and readiness repair still force.
+      forceRefetch: false,
       reason: "initial_missing",
       targetAppIds: collectInventoryOwnedAppIds(inventory),
     });

--- a/extensions/codex/src/app-server/protocol.ts
+++ b/extensions/codex/src/app-server/protocol.ts
@@ -397,6 +397,7 @@ export type CodexLoginAccountParams =
 
 export type CodexPluginSummary = {
   id: string;
+  remotePluginId?: string;
   name: string;
   source?: JsonObject;
   installed: boolean;

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -5479,6 +5479,32 @@ describe("runCodexAppServerAttempt", () => {
     expect(turnRequestParams?.approvalsReviewer).toBe("user");
   });
 
+  it("enables Guardian on the first turn after a fresh thread confirms the OpenAI provider", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const { requests, waitForMethod, completeTurn } = createStartedThreadHarness();
+    const params = createParams(sessionFile, workspaceDir);
+
+    const run = runCodexAppServerAttempt(params, {
+      pluginConfig: {
+        appServer: {
+          mode: "guardian",
+        },
+      },
+    });
+    await waitForMethod("turn/start");
+    await completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await run;
+
+    const startRequest = requests.find((request) => request.method === "thread/start");
+    const startRequestParams = startRequest?.params as Record<string, unknown> | undefined;
+    expect(startRequestParams?.approvalsReviewer).toBe("user");
+
+    const turnRequest = requests.find((request) => request.method === "turn/start");
+    const turnRequestParams = turnRequest?.params as Record<string, unknown> | undefined;
+    expect(turnRequestParams?.approvalsReviewer).toBe("auto_review");
+  });
+
   it("uses human approval instead of Guardian for custom OpenAI-compatible endpoints", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -1506,6 +1506,52 @@ export async function runCodexAppServerAttempt(
     client = startupResult.client;
     thread = startupResult.thread;
     pluginAppServer = startupResult.pluginAppServer;
+    if (thread.lifecycle.action === "started") {
+      const activeThreadReviewerPolicyContext = resolveCodexModelBackedReviewerPolicyContext({
+        provider: params.provider,
+        model: params.modelId,
+        bindingModelProvider: thread.modelProvider,
+        bindingModel: thread.model,
+        nativeAuthProfile: isCodexAppServerNativeAuthProfile({
+          authProfileId: startupAuthProfileId,
+          authProfileStore: params.authProfileStore,
+          agentDir,
+          config: params.config,
+        }),
+      });
+      const activeThreadConfiguredAppServer = resolveCodexAppServerRuntimeOptions({
+        pluginConfig,
+        execPolicy,
+        modelProvider: activeThreadReviewerPolicyContext.modelProvider,
+        model: activeThreadReviewerPolicyContext.model,
+        config: params.config,
+        agentDir,
+        openClawSandboxActive: sandbox?.enabled === true,
+      });
+      const activeThreadAppServer = resolveCodexAppServerForModelProvider({
+        appServer: activeThreadConfiguredAppServer,
+        provider: activeThreadReviewerPolicyContext.modelProvider,
+        model: activeThreadReviewerPolicyContext.model,
+        config: params.config,
+        env: process.env,
+        agentDir,
+      });
+      const previousApprovalsReviewer = pluginAppServer.approvalsReviewer;
+      pluginAppServer = {
+        ...pluginAppServer,
+        approvalsReviewer: activeThreadAppServer.approvalsReviewer,
+      };
+      if (pluginAppServer.approvalsReviewer !== previousApprovalsReviewer) {
+        embeddedAgentLog.info(
+          "codex app-server approval reviewer updated from active thread model provider",
+          {
+            from: previousApprovalsReviewer,
+            to: pluginAppServer.approvalsReviewer,
+            modelProvider: activeThreadReviewerPolicyContext.modelProvider,
+          },
+        );
+      }
+    }
     sandboxExecEnvironmentAcquired = Boolean(startupResult.sandboxEnvironment);
     codexEnvironmentSelection = startupResult.environmentSelection;
     codexExecutionCwd = startupResult.executionCwd;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users starting a Codex-backed OpenClaw thread could lose configured plugin-owned apps when OpenClaw's process-local app inventory was missing. It also fixes remote curated plugins failing detail or activation calls when Codex requires the backend remote plugin ID rather than the display name, and fixes Guardian not reviewing the first turn of a newly created native OpenAI thread.

## Why This Change Was Made

Thread startup now refreshes a missing app inventory before building the app config, paginating until the configured app IDs are found or the inventory is exhausted and rejecting repeated cursors instead of caching a known-partial result. Remote curated plugin reads and installs consistently use Codex's `remotePluginId`, and marketplace selection searches each accepted curated marketplace for the requested plugin instead of assuming the first curated entry owns it. After a fresh thread confirms its active model provider, OpenClaw recomputes only the approval reviewer used for the first `turn/start`; local and custom OpenAI-compatible providers continue to fall back to human review.

## User Impact

Configured Codex plugin apps remain available on new OpenClaw threads when the local inventory snapshot has not been populated. Remote curated plugins can also be inspected and activated through the current Codex app-server wire contract, including when Codex returns a local curated marketplace before the remote catalog. Guardian now reviews the first turn of eligible native OpenAI threads, while genuinely absent or inaccessible apps and ineligible model providers remain fail-closed.

## Evidence

- Current head: `4930308487` on current `main`.
- Inventory-focused Vitest run: 4 files passed, 53 tests passed.
- Marketplace review-fix Vitest run: 2 files passed, 13 tests passed.
- First-turn Guardian and adjacent custom-endpoint safety tests: 2 passed, 114 skipped.
- Focused `oxlint` passed for the 5 review-fix and Guardian files.
- `oxfmt --check` passed for all 9 originally touched files; later review-fix and Guardian files were formatted with `oxfmt`.
- `git diff --check` passed.
- The Codex app-server implementation was checked directly: `plugin/list` can return multiple local and remote marketplace entries; `plugin/read` selects remote catalogs through `remoteMarketplaceName`; and `turn/start.approvalsReviewer` is a persistent turn-level reviewer override.
- The complete 116-test `run-attempt.test.ts` file produced 112 passes and 4 unrelated failures locally: three pre-start approval-policy expectations received `on-request`, and one managed-web-search test timed out after 120 seconds. The new first-turn Guardian test and its adjacent custom-endpoint regression pass in isolation; current-head CI is the broad clean-environment proof.
- A local Slack/OpenClaw integration run on the pre-review implementation exercised the user-facing path: Calendar read and write/read-back passed; a Linear write produced an approval prompt and created exactly one issue after approval; an untouched Linear approval expired after 120 seconds and exact-title search returned zero issues.
- The live Slack flow was not rerun after the final review and Guardian commits.
- AI-assisted change; I reviewed the implementation and understand the resulting app inventory, remote plugin activation, and first-turn approval-reviewer behavior.
