### PR TITLE
Add Swedish mobile app localization

### DIFF
--- a/apps/android/app/src/main/res/values-sv/strings.xml
+++ b/apps/android/app/src/main/res/values-sv/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">OpenClaw-nod</string>
+</resources>

--- a/apps/ios/ActivityWidget/sv.lproj/InfoPlist.strings
+++ b/apps/ios/ActivityWidget/sv.lproj/InfoPlist.strings
@@ -1,0 +1,1 @@
+"CFBundleDisplayName" = "OpenClaw-aktivitet";

--- a/apps/ios/ShareExtension/sv.lproj/InfoPlist.strings
+++ b/apps/ios/ShareExtension/sv.lproj/InfoPlist.strings
@@ -1,0 +1,1 @@
+"CFBundleDisplayName" = "Dela till OpenClaw";

--- a/apps/ios/Sources/sv.lproj/InfoPlist.strings
+++ b/apps/ios/Sources/sv.lproj/InfoPlist.strings
@@ -1,0 +1,14 @@
+"CFBundleDisplayName" = "OpenClaw";
+"NSLocalNetworkUsageDescription" = "OpenClaw hittar och ansluter till din OpenClaw Gateway i det lokala nätverket.";
+"NSCameraUsageDescription" = "OpenClaw kan ta bilder eller korta videoklipp när du begär det via gatewayen.";
+"NSCalendarsUsageDescription" = "OpenClaw använder dina kalendrar för att visa händelser och schemainformation när du aktiverar kalenderåtkomst.";
+"NSCalendarsFullAccessUsageDescription" = "OpenClaw använder dina kalendrar för att visa händelser och schemainformation när du aktiverar kalenderåtkomst.";
+"NSCalendarsWriteOnlyAccessUsageDescription" = "OpenClaw använder dina kalendrar för att lägga till händelser när du aktiverar kalenderåtkomst.";
+"NSContactsUsageDescription" = "OpenClaw använder dina kontakter så att du kan söka efter och hänvisa till personer när du använder assistenten.";
+"NSLocationWhenInUseUsageDescription" = "OpenClaw använder din plats när du tillåter platsdelning.";
+"NSLocationAlwaysAndWhenInUseUsageDescription" = "OpenClaw kan dela din plats i bakgrunden när du aktiverar Alltid.";
+"NSMicrophoneUsageDescription" = "OpenClaw använder mikrofonen för realtidschatt, röstaktivering och tryck-och-prata.";
+"NSMotionUsageDescription" = "OpenClaw kan använda rörelsedata för att stödja enhetsmedvetna interaktioner och automatiseringar.";
+"NSPhotoLibraryUsageDescription" = "OpenClaw behöver åtkomst till bildbiblioteket när du väljer befintliga bilder att dela med din assistent.";
+"NSRemindersFullAccessUsageDescription" = "OpenClaw använder dina påminnelser för att lista, lägga till och slutföra uppgifter när du aktiverar åtkomst till påminnelser.";
+"NSSpeechRecognitionUsageDescription" = "OpenClaw använder taligenkänning på enheten för Talk-läge och röstaktivering.";

--- a/apps/ios/WatchApp/sv.lproj/InfoPlist.strings
+++ b/apps/ios/WatchApp/sv.lproj/InfoPlist.strings
@@ -1,0 +1,1 @@
+"CFBundleDisplayName" = "OpenClaw";

--- a/apps/ios/WatchExtension/Sources/sv.lproj/InfoPlist.strings
+++ b/apps/ios/WatchExtension/Sources/sv.lproj/InfoPlist.strings
@@ -1,1 +1,0 @@
-"CFBundleDisplayName" = "OpenClaw";

--- a/apps/ios/WatchExtension/Sources/sv.lproj/InfoPlist.strings
+++ b/apps/ios/WatchExtension/Sources/sv.lproj/InfoPlist.strings
@@ -1,0 +1,1 @@
+"CFBundleDisplayName" = "OpenClaw";

--- a/apps/ios/fastlane/metadata/README.md
+++ b/apps/ios/fastlane/metadata/README.md
@@ -44,7 +44,7 @@ Or set `APP_STORE_CONNECT_API_KEY_PATH`.
 
 ## Notes
 
-- Locale files live under `metadata/en-US/`.
+- Locale files live under `metadata/<locale>/`, for example `metadata/en-US/` and `metadata/sv-SE/`. Each locale directory should use the public metadata filenames consumed by the `ios metadata` lane.
 - `release_notes.txt` is generated from `apps/ios/CHANGELOG.md`; after changelog updates, run `pnpm ios:version:sync`.
 - `apps/ios/APP-REVIEW-NOTES.md` is rendered to `apps/ios/build/app-review/APP-REVIEW-NOTES.pdf` and uploaded as the App Review attachment when metadata is uploaded.
 - Release notes resolve from `## <pinned iOS version>` first, then fall back to `## Unreleased` while a TestFlight train is still in progress.

--- a/apps/ios/fastlane/metadata/sv-SE/description.txt
+++ b/apps/ios/fastlane/metadata/sv-SE/description.txt
@@ -1,0 +1,19 @@
+OpenClaw är en personlig AI-assistent som du kör på dina egna enheter.
+
+Parkoppla iOS-appen med din OpenClaw Gateway och använd din iPhone som en säker nod för chatt, röst, godkännanden, delning och enhetsmedveten automatisering.
+
+Det här kan du göra:
+- Parkoppla med din privata OpenClaw Gateway via QR-kod eller installationskod
+- Chatta med din assistent från iPhone
+- Använd Talk-läge i realtid och tryck-och-prata
+- Granska åtgärder som väntar på godkännande från gatewayen
+- Dela text, länkar och media direkt från iOS till OpenClaw
+- Aktivera enhetsfunktioner som kamera, skärm, plats, bilder, kontakter, kalender och påminnelser när du vill
+- Ta emot pushväckningar och nodstatus för anslutna arbetsflöden
+
+OpenClaw är byggt för lokal kontroll: du styr din gateway, dina nycklar, din konfiguration och dina behörigheter. Åtkomst till enheten hanteras av iOS-behörigheter och aktiveras bara för de funktioner du vill använda.
+
+Kom igång:
+1. Konfigurera din OpenClaw Gateway
+2. Öppna iOS-appen och parkoppla den med gatewayen
+3. Börja använda chatt, Talk-läge, godkännanden och automatiseringar från din iPhone

--- a/apps/ios/fastlane/metadata/sv-SE/keywords.txt
+++ b/apps/ios/fastlane/metadata/sv-SE/keywords.txt
@@ -1,0 +1,1 @@
+openclaw,ai-assistent,lokal ai,iphone ai,röstassistent,automatisering,gateway,chatt,agent

--- a/apps/ios/fastlane/metadata/sv-SE/marketing_url.txt
+++ b/apps/ios/fastlane/metadata/sv-SE/marketing_url.txt
@@ -1,0 +1,1 @@
+https://openclaw.ai

--- a/apps/ios/fastlane/metadata/sv-SE/name.txt
+++ b/apps/ios/fastlane/metadata/sv-SE/name.txt
@@ -1,0 +1,1 @@
+OpenClaw - iOS-klient

--- a/apps/ios/fastlane/metadata/sv-SE/privacy_url.txt
+++ b/apps/ios/fastlane/metadata/sv-SE/privacy_url.txt
@@ -1,0 +1,1 @@
+https://openclaw.ai/privacy

--- a/apps/ios/fastlane/metadata/sv-SE/promotional_text.txt
+++ b/apps/ios/fastlane/metadata/sv-SE/promotional_text.txt
@@ -1,0 +1,1 @@
+Parkoppla din iPhone med OpenClaw Gateway för chatt, röst i realtid, godkännanden, enhetsfunktioner och privat automatisering.

--- a/apps/ios/fastlane/metadata/sv-SE/release_notes.txt
+++ b/apps/ios/fastlane/metadata/sv-SE/release_notes.txt
@@ -1,0 +1,3 @@
+OpenClaw finns nu för iPhone.
+
+Anslut till din OpenClaw Gateway för att chatta med din assistent, använda Talk-läge i realtid, granska godkännanden, dela innehåll från iOS och använda enhetsfunktioner som kamera, plats, skärm och aviseringar i dina privata automatiseringar.

--- a/apps/ios/fastlane/metadata/sv-SE/subtitle.txt
+++ b/apps/ios/fastlane/metadata/sv-SE/subtitle.txt
@@ -1,0 +1,1 @@
+Personlig AI på dina enheter

--- a/apps/ios/fastlane/metadata/sv-SE/support_url.txt
+++ b/apps/ios/fastlane/metadata/sv-SE/support_url.txt
@@ -1,0 +1,1 @@
+https://docs.openclaw.ai/platforms/ios


### PR DESCRIPTION
## What Problem This Solves

OpenClaw has mobile app surfaces for iOS and Android, but this repo did not include Swedish localization for the Android node app label, iOS permission prompts/display names, or iOS App Store Connect metadata. Swedish users would therefore see English mobile app copy even when using a Swedish device/store locale.

## Summary

- Add Swedish Android app resources for the mobile node app label.
- Add Swedish iOS InfoPlist localizations for permission prompts and extension display names.
- Add Swedish `sv-SE` App Store Connect metadata for the iOS app.
- Keep the iOS localization files only under active project targets: `Sources`, `ShareExtension`, `ActivityWidget`, and `WatchApp`.

## Evidence

- `xmllint --noout apps/android/app/src/main/res/values/strings.xml apps/android/app/src/main/res/values-sv/strings.xml`
- `find apps/ios -path '*/sv.lproj/InfoPlist.strings' -print0 | xargs -0 -n1 plutil -lint`
- Ruby metadata length check for App Store fields: `name.txt` 21/30, `subtitle.txt` 28/30, `promotional_text.txt` 126/170, `keywords.txt` 89/100
- `find apps/ios -path '*/sv.lproj/InfoPlist.strings' -print | sort` shows only `ActivityWidget`, `ShareExtension`, `Sources`, and `WatchApp`
- `rg -n 'WatchExtension' apps/ios/project.yml` returns no matches
- `git diff --check origin/main..HEAD`
- GitHub `ios-build` on head `777acaf35f` ran `xcodegen generate` and `xcodebuild -project OpenClaw.xcodeproj -scheme OpenClaw -destination "platform=iOS Simulator,name=iPhone 17" -configuration Debug build`, built `OpenClaw`, `OpenClawWatchApp`, `OpenClawActivityWidget`, and `OpenClawShareExtension`, embedded the watch app and extensions into `OpenClaw.app`, and ended with `BUILD SUCCEEDED`
- GitHub `android-build-play` on head `777acaf35f` ran `./gradlew --no-daemon --build-cache :app:assemblePlayDebug` and ended with `BUILD SUCCESSFUL`
- Local Fastlane public metadata payload proof, using the same public metadata file selection as `apps/ios/fastlane/Fastfile`, includes `locale=sv-SE` with Swedish `name.txt`, `subtitle.txt`, `description.txt`, `promotional_text.txt`, `release_notes.txt`, URLs, and keywords

AI-assisted: yes.

## Real behavior proof

Behavior addressed: Swedish users now get Swedish mobile app metadata/resources where the repo exposes localizable Android resources, iOS permission strings, extension display names, and App Store Connect metadata.

Real environments tested:

- GitHub Actions iOS simulator build on head `777acaf35f`.
- GitHub Actions Android Play debug build on head `777acaf35f`.
- Local macOS checkout of `openclaw/openclaw` on PR head `777acaf35f`, based on current `origin/main` (`56c2d637d9`). No App Store Connect credentials or Android SDK were configured locally.

Actual mobile build proof:

```text
ios-build: xcodegen generate && xcodebuild -project OpenClaw.xcodeproj -scheme OpenClaw -destination "platform=iOS Simulator,name=iPhone 17" -configuration Debug build
ios-build: Target 'OpenClaw' in project 'OpenClaw'
ios-build: Target 'OpenClawWatchApp' in project 'OpenClaw'
ios-build: Target 'OpenClawActivityWidget' in project 'OpenClaw'
ios-build: Target 'OpenClawShareExtension' in project 'OpenClaw'
ios-build: Copy .../OpenClaw.app/PlugIns/OpenClawShareExtension.appex .../OpenClawShareExtension.appex
ios-build: Copy .../OpenClaw.app/PlugIns/OpenClawActivityWidget.appex .../OpenClawActivityWidget.appex
ios-build: Copy .../OpenClaw.app/Watch/OpenClawWatchApp.app .../OpenClawWatchApp.app
ios-build: ** BUILD SUCCEEDED **

android-build-play: ./gradlew --no-daemon --build-cache :app:assemblePlayDebug
android-build-play: > Task :app:assemblePlayDebug
android-build-play: BUILD SUCCESSFUL in 1m 40s
```

Actual App Store metadata-flow proof:

```text
Fastlane public metadata payload: /Users/bosse/.openclaw/tmp/openclaw-app-store-metadata-proof...
locale=en-US
locale=sv-SE
  description.txt: OpenClaw är en personlig AI-assistent som du kör på dina egna enheter. Parkoppla iOS-appen med d...
  keywords.txt: openclaw,ai-assistent,lokal ai,iphone ai,röstassistent,automatisering,gateway,chatt,agent
  marketing_url.txt: https://openclaw.ai
  name.txt: OpenClaw - iOS-klient
  privacy_url.txt: https://openclaw.ai/privacy
  promotional_text.txt: Parkoppla din iPhone med OpenClaw Gateway för chatt, röst i realtid, godkännanden, enhetsfunktio...
  release_notes.txt: OpenClaw finns nu för iPhone. Anslut till din OpenClaw Gateway för att chatta med din assistent,...
  subtitle.txt: Personlig AI på dina enheter
  support_url.txt: https://docs.openclaw.ai/platforms/ios
```

Local commands run after this patch:

```sh
xmllint --noout apps/android/app/src/main/res/values/strings.xml apps/android/app/src/main/res/values-sv/strings.xml
find apps/ios -path '*/sv.lproj/InfoPlist.strings' -print0 | xargs -0 -n1 plutil -lint
ruby -e 'limits={"name.txt"=>30,"subtitle.txt"=>30,"promotional_text.txt"=>170,"keywords.txt"=>100}; limits.each{|file,limit| path="apps/ios/fastlane/metadata/sv-SE/#{file}"; text=File.read(path).strip; puts "#{file}: #{text.length}/#{limit}"; exit 1 if text.length>limit }'
find apps/ios -path '*/sv.lproj/InfoPlist.strings' -print | sort
rg -n 'WatchExtension' apps/ios/project.yml || true
git diff --check origin/main..HEAD
```

Evidence after fix: Android XML lint passed. All four active iOS Swedish `InfoPlist.strings` files linted successfully with `plutil`: `apps/ios/Sources/sv.lproj/InfoPlist.strings`, `apps/ios/ShareExtension/sv.lproj/InfoPlist.strings`, `apps/ios/ActivityWidget/sv.lproj/InfoPlist.strings`, and `apps/ios/WatchApp/sv.lproj/InfoPlist.strings`. The stale `apps/ios/WatchExtension/Sources/sv.lproj/InfoPlist.strings` file was removed, and `apps/ios/project.yml` has no `WatchExtension` target references. App Store field lengths are within limits: `name.txt` 21/30, `subtitle.txt` 28/30, `promotional_text.txt` 126/170, `keywords.txt` 89/100. `git diff --check origin/main..HEAD` passed.

Observed result after fix: The repo now contains Swedish Android resources, Swedish iOS runtime permission/display-name strings for active iOS targets, and complete Swedish `sv-SE` iOS store metadata. The previous dead WatchExtension localization path is no longer part of the PR diff.

What was not tested: App Store Connect upload was not run because no `apps/ios/fastlane/.env` or ASC auth environment variables were available.

