### PR TITLE
fix: hide expired pairing QR cards in Control UI

### DIFF
--- a/ui/src/ui/chat/grouped-render.test.ts
+++ b/ui/src/ui/chat/grouped-render.test.ts
@@ -1684,6 +1684,7 @@ describe("grouped chat rendering", () => {
             type: "openclaw_pairing_qr",
             image_url: "data:image/png;base64,cXJwbmc=",
             alt: "OpenClaw pairing QR code",
+            expiresAtMs: Date.now() + 60_000,
           },
         ],
         timestamp: Date.now(),
@@ -1694,6 +1695,29 @@ describe("grouped chat rendering", () => {
       pairingQrContainer.querySelector<HTMLImageElement>(".chat-message-image");
     expect(pairingQrImage?.getAttribute("src")).toBe("data:image/png;base64,cXJwbmc=");
     expect(pairingQrImage?.getAttribute("alt")).toBe("OpenClaw pairing QR code");
+
+    const expiredPairingQrContainer = document.createElement("div");
+    renderAssistantMessage(
+      expiredPairingQrContainer,
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "openclaw_pairing_qr",
+            image_url: "data:image/png;base64,ZXhwaXJlZA==",
+            alt: "OpenClaw pairing QR code",
+            expiresAtMs: Date.now() - 1,
+          },
+        ],
+        timestamp: Date.now(),
+      },
+      { showToolCalls: false },
+    );
+    expect(expiredPairingQrContainer.querySelector(".chat-message-image")).toBeNull();
+    expect(expiredPairingQrContainer.textContent).toContain("Pairing QR expired");
+    expect(expiredPairingQrContainer.textContent).toContain(
+      "Run /pair qr again to generate a fresh setup code.",
+    );
 
     container = renderUserMedia({
       id: "user-history-image-blocked",

--- a/ui/src/ui/chat/grouped-render.test.ts
+++ b/ui/src/ui/chat/grouped-render.test.ts
@@ -1719,6 +1719,40 @@ describe("grouped chat rendering", () => {
       "Run /pair qr again to generate a fresh setup code.",
     );
 
+    resetAssistantAttachmentAvailabilityCacheForTest();
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-06-30T05:45:00Z"));
+      const refreshPairingQr = vi.fn();
+      const expiringPairingQrContainer = document.createElement("div");
+      renderAssistantMessage(
+        expiringPairingQrContainer,
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "openclaw_pairing_qr",
+              image_url: "data:image/png;base64,cXJwbmc=",
+              alt: "OpenClaw pairing QR code",
+              expiresAtMs: Date.now() + 1_000,
+            },
+          ],
+          timestamp: Date.now(),
+        },
+        { showToolCalls: false, onRequestUpdate: refreshPairingQr },
+      );
+      expect(expiringPairingQrContainer.querySelector(".chat-message-image")).not.toBeNull();
+
+      await vi.advanceTimersByTimeAsync(999);
+      expect(refreshPairingQr).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(refreshPairingQr).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+      resetAssistantAttachmentAvailabilityCacheForTest();
+    }
+
     container = renderUserMedia({
       id: "user-history-image-blocked",
       role: "user",

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -46,9 +46,15 @@ type PairingQrExpiryNotice = {
   title: string;
   reason: string;
 };
+type PairingQrExpiryRefreshTimer = {
+  expiresAtMs: number;
+  onRequestUpdate: () => void;
+  timer: ReturnType<typeof setTimeout>;
+};
 
 const assistantAttachmentAvailabilityCache = new Map<string, AssistantAttachmentAvailability>();
 const assistantAttachmentRefreshTimers = new Map<string, ReturnType<typeof setTimeout>>();
+const pairingQrExpiryRefreshTimers = new Map<string, PairingQrExpiryRefreshTimer>();
 const ASSISTANT_ATTACHMENT_UNAVAILABLE_RETRY_MS = 5_000;
 const ASSISTANT_ATTACHMENT_MEDIA_TICKET_REFRESH_SKEW_MS = 30_000;
 const PAIRING_QR_EXPIRED_NOTICE: PairingQrExpiryNotice = {
@@ -114,6 +120,10 @@ export function resetAssistantAttachmentAvailabilityCacheForTest() {
     clearTimeout(timer);
   }
   assistantAttachmentRefreshTimers.clear();
+  for (const { timer } of pairingQrExpiryRefreshTimers.values()) {
+    clearTimeout(timer);
+  }
+  pairingQrExpiryRefreshTimers.clear();
   for (const blobUrl of managedImageBlobUrlResolvedCache.values()) {
     URL.revokeObjectURL(blobUrl);
   }
@@ -381,6 +391,71 @@ function extractPairingQrExpiryNotices(
     }
   }
   return notices;
+}
+
+function resolveNearestFuturePairingQrExpiresAtMs(
+  message: unknown,
+  nowMs = Date.now(),
+): number | undefined {
+  const m = message as Record<string, unknown>;
+  const content = m.content;
+  if (!Array.isArray(content)) {
+    return undefined;
+  }
+  let nearestExpiresAtMs: number | undefined;
+  for (const block of content) {
+    if (!block || typeof block !== "object") {
+      continue;
+    }
+    const b = block as Record<string, unknown>;
+    if (b.type !== "openclaw_pairing_qr") {
+      continue;
+    }
+    const expiresAtMs = readPairingQrExpiresAtMs(b);
+    if (expiresAtMs === undefined || expiresAtMs <= nowMs) {
+      continue;
+    }
+    nearestExpiresAtMs =
+      nearestExpiresAtMs === undefined ? expiresAtMs : Math.min(nearestExpiresAtMs, expiresAtMs);
+  }
+  return nearestExpiresAtMs;
+}
+
+function clearPairingQrExpiryRefreshTimer(messageKey: string) {
+  const existing = pairingQrExpiryRefreshTimers.get(messageKey);
+  if (!existing) {
+    return;
+  }
+  clearTimeout(existing.timer);
+  pairingQrExpiryRefreshTimers.delete(messageKey);
+}
+
+function schedulePairingQrExpiryRefresh(
+  messageKey: string,
+  message: unknown,
+  onRequestUpdate: (() => void) | undefined,
+) {
+  const nowMs = Date.now();
+  const expiresAtMs = resolveNearestFuturePairingQrExpiresAtMs(message, nowMs);
+  const existing = pairingQrExpiryRefreshTimers.get(messageKey);
+  if (!expiresAtMs || !onRequestUpdate) {
+    if (existing) {
+      clearPairingQrExpiryRefreshTimer(messageKey);
+    }
+    return;
+  }
+  if (existing?.expiresAtMs === expiresAtMs && existing.onRequestUpdate === onRequestUpdate) {
+    return;
+  }
+  clearPairingQrExpiryRefreshTimer(messageKey);
+  const timer = setTimeout(
+    () => {
+      pairingQrExpiryRefreshTimers.delete(messageKey);
+      onRequestUpdate();
+    },
+    Math.max(0, expiresAtMs - nowMs),
+  );
+  pairingQrExpiryRefreshTimers.set(messageKey, { expiresAtMs, onRequestUpdate, timer });
 }
 
 function extractTranscriptAttachments(message: unknown): AttachmentItem[] {
@@ -1735,6 +1810,7 @@ function renderGroupedMessage(
     authToken: opts.assistantAttachmentAuthToken,
     onRequestUpdate: opts.onRequestUpdate,
   };
+  schedulePairingQrExpiryRefresh(messageKey, message, opts.onRequestUpdate);
   const images = resolveRenderableMessageImages(extractImages(message), imageRenderOptions);
   const hasImages = images.length > 0;
   const pairingQrExpiryNotices = extractPairingQrExpiryNotices(message);

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -42,11 +42,19 @@ type AssistantAttachmentAvailability =
   | { status: "checking" }
   | { status: "available"; mediaTicket?: string; mediaTicketExpiresAt?: number }
   | { status: "unavailable"; reason: string; checkedAt: number };
+type PairingQrExpiryNotice = {
+  title: string;
+  reason: string;
+};
 
 const assistantAttachmentAvailabilityCache = new Map<string, AssistantAttachmentAvailability>();
 const assistantAttachmentRefreshTimers = new Map<string, ReturnType<typeof setTimeout>>();
 const ASSISTANT_ATTACHMENT_UNAVAILABLE_RETRY_MS = 5_000;
 const ASSISTANT_ATTACHMENT_MEDIA_TICKET_REFRESH_SKEW_MS = 30_000;
+const PAIRING_QR_EXPIRED_NOTICE: PairingQrExpiryNotice = {
+  title: "Pairing QR expired",
+  reason: "Run /pair qr again to generate a fresh setup code.",
+};
 let assistantAttachmentAvailabilityRenderVersion = 0;
 
 export type ChatTimestampDisplay = {
@@ -319,6 +327,9 @@ function extractImages(message: unknown): ImageBlock[] {
           });
         }
       } else if (b.type === "openclaw_pairing_qr") {
+        if (isExpiredPairingQrBlock(b)) {
+          continue;
+        }
         const imageUrl = b.image_url;
         if (typeof imageUrl === "string") {
           appendImageBlock(images, {
@@ -338,6 +349,38 @@ function extractImages(message: unknown): ImageBlock[] {
   }
 
   return images;
+}
+
+function readPairingQrExpiresAtMs(block: Record<string, unknown>): number | undefined {
+  const expiresAtMs = block.expiresAtMs;
+  return typeof expiresAtMs === "number" && Number.isFinite(expiresAtMs) ? expiresAtMs : undefined;
+}
+
+function isExpiredPairingQrBlock(block: Record<string, unknown>, nowMs = Date.now()): boolean {
+  const expiresAtMs = readPairingQrExpiresAtMs(block);
+  return expiresAtMs !== undefined && expiresAtMs <= nowMs;
+}
+
+function extractPairingQrExpiryNotices(
+  message: unknown,
+  nowMs = Date.now(),
+): PairingQrExpiryNotice[] {
+  const m = message as Record<string, unknown>;
+  const content = m.content;
+  if (!Array.isArray(content)) {
+    return [];
+  }
+  const notices: PairingQrExpiryNotice[] = [];
+  for (const block of content) {
+    if (!block || typeof block !== "object") {
+      continue;
+    }
+    const b = block as Record<string, unknown>;
+    if (b.type === "openclaw_pairing_qr" && isExpiredPairingQrBlock(b, nowMs)) {
+      notices.push(PAIRING_QR_EXPIRED_NOTICE);
+    }
+  }
+  return notices;
 }
 
 function extractTranscriptAttachments(message: unknown): AttachmentItem[] {
@@ -1012,6 +1055,32 @@ function renderReplyPill(replyTarget: NormalizedMessage["replyTarget"]) {
   `;
 }
 
+function renderPairingQrExpiryNotices(notices: PairingQrExpiryNotice[]) {
+  if (notices.length === 0) {
+    return nothing;
+  }
+  return html`
+    <div class="chat-pairing-qr-notices">
+      ${notices.map(
+        (notice) => html`
+          <div
+            class="chat-assistant-attachment-card chat-assistant-attachment-card--blocked chat-pairing-qr-expired"
+          >
+            <div class="chat-assistant-attachment-card__header">
+              <span class="chat-assistant-attachment-card__icon">${icons.alertTriangle}</span>
+              <span class="chat-assistant-attachment-card__title">${notice.title}</span>
+              <span class="chat-assistant-attachment-badge chat-assistant-attachment-badge--muted"
+                >Expired</span
+              >
+            </div>
+            <div class="chat-assistant-attachment-card__reason">${notice.reason}</div>
+          </div>
+        `,
+      )}
+    </div>
+  `;
+}
+
 function isLocalAssistantAttachmentSource(source: string): boolean {
   const trimmed = source.trim();
   if (/^\/(?:__openclaw__|media|api\/chat\/media\/outgoing)\//.test(trimmed)) {
@@ -1668,6 +1737,8 @@ function renderGroupedMessage(
   };
   const images = resolveRenderableMessageImages(extractImages(message), imageRenderOptions);
   const hasImages = images.length > 0;
+  const pairingQrExpiryNotices = extractPairingQrExpiryNotices(message);
+  const hasPairingQrExpiryNotices = pairingQrExpiryNotices.length > 0;
 
   const normalizedMessage = normalizeMessage(message);
   const extractedText = normalizedMessage.content
@@ -1733,6 +1804,7 @@ function renderGroupedMessage(
     !markdown &&
     !visibleToolCards &&
     !hasImages &&
+    !hasPairingQrExpiryNotices &&
     visibleAttachments.length === 0 &&
     assistantViewBlocks.length === 0 &&
     !normalizedMessage.replyTarget
@@ -1837,6 +1909,7 @@ function renderGroupedMessage(
               ${toolMessageExpanded
                 ? html`
                     <div class="chat-tool-msg-body">
+                      ${renderPairingQrExpiryNotices(pairingQrExpiryNotices)}
                       ${renderMessageImages(images, imageRenderOptions)}
                       ${renderAssistantAttachments(
                         visibleAttachments,
@@ -1895,6 +1968,7 @@ function renderGroupedMessage(
             </div>
           `
         : html`
+            ${renderPairingQrExpiryNotices(pairingQrExpiryNotices)}
             ${renderMessageImages(images, imageRenderOptions)}
             ${renderAssistantAttachments(
               visibleAttachments,


### PR DESCRIPTION
Fixes #98039

## What Problem This Solves

Fixes an issue where users scanning an old `/pair qr` card in Control UI would see `Setup code expired` in the mobile app because the chat surface kept rendering an expired pairing QR as a normal scannable image.

## Why This Change Was Made

Control UI already receives `expiresAtMs` metadata on `openclaw_pairing_qr` blocks. This change uses that metadata to suppress expired QR images, render a clear expired notice that tells users to run `/pair qr` again, and schedule a one-shot UI refresh when a visible QR reaches its expiry time. Gateway/mobile auth semantics are unchanged; expired bootstrap tokens remain rejected.

## User Impact

Users no longer see stale pairing QR cards as usable. When a setup code expires, Control UI now moves the card into an expired state and points the user at the fresh-code path instead of letting them scan a token that the mobile app must reject.

## Evidence

AI-assisted: yes, Codex.

- Issue/repro: #98039 tracks the real Windows Control UI + iOS app pairing failure on OpenClaw 2026.6.11-beta.2, where the mobile app displayed `Setup code expired` after scanning a stale `/pair qr` card.
- Focused UI test passed: `node scripts/run-vitest.mjs ui/src/ui/chat/grouped-render.test.ts --testNamePattern="renders allowed transcript and content image variants"`.
- The focused test covers future pairing QR images, expired pairing QR notices, and the refresh callback scheduled when a visible QR reaches expiry.
- Diff sanity passed: `git diff --check`.
- Autoreview passed: `python .agents\skills\autoreview\scripts\autoreview --mode branch --base upstream/main --thinking low` reported `autoreview clean: no accepted/actionable findings reported`.
- Related full-file local run: `node scripts/run-vitest.mjs ui/src/ui/chat/grouped-render.test.ts` passed 64/65 tests and hit the existing locale-sensitive AM/PM assertion on this Chinese Windows locale (`2026骞?鏈?6鏃?涓婂崍3:30` vs `/AM|PM/i`), unrelated to this QR change.
- Visible Control UI proof on the PR branch: ran a one-off Playwright/Chromium check against the real Control UI with `startControlUiE2eServer()` and mocked Gateway history containing one fresh `openclaw_pairing_qr` block and one expired `openclaw_pairing_qr` block. The browser-rendered page kept the fresh QR image visible, rendered the expired notice card, and did not render the expired QR image:

```text
Control UI expired pairing QR visual proof
Mocked Gateway URL: http://127.0.0.1:<redacted>/chat
Fresh QR images visible: 1
Fresh QR exact image rendered: true
Expired QR notice cards visible: 1
Expired QR exact image rendered: false
Expired notice text visible: Pairing QR expired / Run /pair qr again to generate a fresh setup code.
Screenshot: .artifacts/control-ui-e2e/expired-pairing-qr-proof/expired-pairing-qr-control-ui.png (local, not committed)
```