### PR TITLE
fix(gateway): reject invoke for unadvertised node commands

### DIFF
--- a/src/gateway/node-registry.test.ts
+++ b/src/gateway/node-registry.test.ts
@@ -619,4 +619,53 @@ describe("gateway/node-registry", () => {
       (client.connect as { permissions?: Record<string, boolean> }).permissions,
     ).toBeUndefined();
   });
+
+  it("rejects invoke for commands the node did not advertise", async () => {
+    const registry = new NodeRegistry();
+    const client = makeClient("conn-1", "node-1", [], {
+      commands: ["system.run", "system.run.prepare", "system.which"],
+    });
+    registry.register(client, {});
+
+    // The node above does NOT advertise system.execApprovals.get. Without the
+    // capability check the invoke would block waiting for a node-side response
+    // that never comes (or surfaces an unstructured error).
+    await expect(
+      registry.invoke({
+        nodeId: "node-1",
+        command: "system.execApprovals.get",
+        params: {},
+        timeoutMs: 1_000,
+      }),
+    ).resolves.toEqual({
+      ok: false,
+      payload: undefined,
+      payloadJSON: null,
+      error: {
+        code: "UNSUPPORTED_CAPABILITY",
+        message: 'node does not support command "system.execApprovals.get"',
+      },
+    });
+  });
+
+  it("still invokes when the node did not declare a commands list", async () => {
+    // Nodes that never declared commands (empty list) keep legacy behavior:
+    // the invoke is sent and the node-side dispatch decides whether to handle it.
+    const registry = new NodeRegistry();
+    const frames: string[] = [];
+    const client = makeClient("conn-1", "node-1", frames, { commands: [] });
+    registry.register(client, {});
+
+    const invoke = registry.invoke({
+      nodeId: "node-1",
+      command: "system.execApprovals.get",
+      params: {},
+      timeoutMs: 1_000,
+    });
+    // The first frame should be the invoke request, proving we did not short-circuit.
+    await Promise.resolve();
+    expect(frames.length).toBe(1);
+    registry.unregister("conn-1");
+    void invoke.catch(() => {});
+  });
 });

--- a/src/gateway/node-registry.test.ts
+++ b/src/gateway/node-registry.test.ts
@@ -639,8 +639,6 @@ describe("gateway/node-registry", () => {
       }),
     ).resolves.toEqual({
       ok: false,
-      payload: undefined,
-      payloadJSON: null,
       error: {
         code: "UNSUPPORTED_CAPABILITY",
         message: 'node does not support command "system.execApprovals.get"',

--- a/src/gateway/node-registry.ts
+++ b/src/gateway/node-registry.ts
@@ -432,6 +432,21 @@ export class NodeRegistry {
         error: { code: "NOT_CONNECTED", message: "node not connected" },
       };
     }
+    // Nodes that explicitly advertise a command list must include the requested
+    // command. Without this check, a node that omits e.g. system.execApprovals.*
+    // still receives the invoke and the gateway surfaces whatever unstructured
+    // error the node-side dispatch produces (observed as a TypeError reading
+    // 'socket' in the CLI). Returning UNSUPPORTED_CAPABILITY lets callers show
+    // an actionable message instead.
+    if (node.commands.length > 0 && !node.commands.includes(params.command)) {
+      return {
+        ok: false,
+        error: {
+          code: "UNSUPPORTED_CAPABILITY",
+          message: `node does not support command "${params.command}"`,
+        },
+      };
+    }
     const requestId = randomUUID();
     const invokeParams = withSystemRunEventRunId({
       command: params.command,


### PR DESCRIPTION
## What Problem This Solves

`openclaw approvals get --node <id> --json` against a connected node that does not advertise `system.execApprovals.get/set` currently surfaces an unstructured error (`Cannot read properties of undefined (reading 'socket')`) instead of a clear unsupported-capability message.

Closes #97578.

## Why This Change Was Made

`nodeRegistry.invoke` checks only whether the node is connected. It never consults the per-session command list, so a request for a command the node never advertised is sent over the wire and the gateway surfaces whatever the node-side dispatch produces (in practice, an internal TypeError that varies by node implementation). Adding a capability gate inside `invoke` itself — returning a structured `UNSUPPORTED_CAPABILITY` error when the node has explicitly advertised a commands list that does not include the requested command — lets every caller return an actionable error instead of relying on each handler to duplicate the check. The gate mirrors the existing semantics in `isNodeCommandAllowed` (`src/gateway/node-command-policy.ts`): an empty declared-commands list keeps legacy behavior, so the gate only fires when the node has opted into command advertisement.

## User Impact

- `openclaw approvals get/set --node <id>` against a node that does not support exec approvals management now returns a structured error (`UNSUPPORTED_CAPABILITY: node does not support command "system.execApprovals.get"`) instead of a confusing TypeError.
- Nodes that did not declare a commands list are unaffected (legacy behavior preserved).
- Other gateway handlers that route through `nodeRegistry.invoke` (e.g. `system.run`, canvas commands) keep their existing behavior when the node already advertises those commands.

## Evidence

- New regression tests in `src/gateway/node-registry.test.ts`:
  - `rejects invoke for commands the node did not advertised` — verifies a node that advertised `system.run*` and `system.which` returns `UNSUPPORTED_CAPABILITY` for `system.execApprovals.get`.
  - `still invokes when the node did not declare a commands list` — verifies the legacy empty-commands-list path still sends the invoke frame.
- `node scripts/run-vitest.mjs node-registry.test` exits 0.