### PR TITLE
fix(runtime): throw ExitError from non-exiting runtime

### DIFF
--- a/src/runtime.test.ts
+++ b/src/runtime.test.ts
@@ -10,7 +10,7 @@ vi.mock("../packages/terminal-core/src/restore.js", () => ({
   restoreTerminalState: vi.fn(),
 }));
 
-import { createNonExitingRuntime, writeRuntimeJson } from "./runtime.js";
+import { createNonExitingRuntime, ExitError, writeRuntimeJson } from "./runtime.js";
 
 describe("createNonExitingRuntime", () => {
   it("returns runtime with exit function", () => {
@@ -26,6 +26,18 @@ describe("createNonExitingRuntime", () => {
   it("exit function includes code in error message", () => {
     const runtime = createNonExitingRuntime();
     expect(() => runtime.exit(42)).toThrow("exit 42");
+  });
+
+  it("throws an ExitError so callers can distinguish the simulated exit from runtime errors", () => {
+    const runtime = createNonExitingRuntime();
+    let caught: unknown;
+    try {
+      runtime.exit(7);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(ExitError);
+    expect((caught as ExitError).exitCode).toBe(7);
   });
 });
 

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -8,6 +8,22 @@ export type RuntimeEnv = {
   exit: (code: number) => void;
 };
 
+/**
+ * Control-flow signal thrown in place of `process.exit` by non-exiting runtimes.
+ *
+ * Generic `try/catch` blocks around CLI command bodies can accidentally swallow
+ * the simulated exit if it is a plain `Error`. Callers that need to honor the
+ * exit can check `err instanceof ExitError` instead of relying on message text.
+ */
+export class ExitError extends Error {
+  readonly exitCode: number;
+  constructor(code: number) {
+    super(`exit ${code}`);
+    this.name = "ExitError";
+    this.exitCode = code;
+  }
+}
+
 export type OutputRuntimeEnv = RuntimeEnv & {
   writeStdout: (value: string) => void;
   writeJson: (value: unknown, space?: number) => void;
@@ -99,7 +115,7 @@ export function createNonExitingRuntime(): OutputRuntimeEnv {
   return {
     ...createRuntimeIo(),
     exit: (code: number) => {
-      throw new Error(`exit ${code}`);
+      throw new ExitError(code);
     },
   };
 }


### PR DESCRIPTION
## What Problem This Solves

`createNonExitingRuntime()` simulated a process exit by throwing a generic `new Error("exit ${code}")`. Upstream `try/catch` blocks written to log real runtime crashes accidentally caught this control-flow signal too, logging it as a bug instead of terminating the CLI command.

Closes #97796.

## Why This Change Was Made

A generic `Error` cannot be distinguished from a real runtime failure at the type level, so any caller that wants to honor the simulated exit has to inspect the message text. Introducing a strongly-typed `ExitError` subclass lets callers explicitly check `err instanceof ExitError` and re-throw or terminate accordingly. The message format (`exit <code>`) is preserved so existing string-based assertions continue to match.

## User Impact

- No behavior change for existing CLI flows; existing tests that assert on the `exit N` message text still pass.
- Callers that want to differentiate the simulated exit from real runtime errors can now use `instanceof ExitError` and read `err.exitCode` directly.

## Evidence

- New test in `src/runtime.test.ts`: `throws an ExitError so callers can distinguish the simulated exit from runtime errors`. Asserts the thrown value is an `ExitError` carrying `exitCode`.
- Existing tests (`exit function throws error`, `exit function includes code in error message`) still pass — the message text is preserved.
- `node scripts/run-vitest.mjs runtime.test` exits 0.