### PR TITLE
fix(qqbot): gate updateLastRoute to group/guild turns only

### DIFF
--- a/extensions/qqbot/src/bridge/config-shared.ts
+++ b/extensions/qqbot/src/bridge/config-shared.ts
@@ -30,6 +30,7 @@ export const qqbotMeta = {
   docsPath: "/channels/qqbot",
   blurb: "Connect to QQ via official QQ Bot API",
   order: 50,
+  preferSessionLookupForAnnounceTarget: true,
 } as const;
 
 function validateQQBotSetupInput(params: {

--- a/extensions/qqbot/src/channel.message-adapter.test.ts
+++ b/extensions/qqbot/src/channel.message-adapter.test.ts
@@ -4,6 +4,12 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { describe, expect, it, vi } from "vitest";
 import { qqbotPlugin } from "./channel.js";
 
+describe("qqbotPlugin metadata", () => {
+  it("opts announce delivery into persisted session lookup", () => {
+    expect(qqbotPlugin.meta.preferSessionLookupForAnnounceTarget).toBe(true);
+  });
+});
+
 describe("qqbot outbound sanitizeText", () => {
   it("strips reasoning/thinking tags before delivery", () => {
     const sanitize = qqbotPlugin.outbound?.sanitizeText;

--- a/extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts
+++ b/extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts
@@ -117,6 +117,7 @@ function makeInbound(overrides: Partial<InboundContext> = {}): InboundContext {
 function makeInboundRuntime(
   dispatchReplyWithBufferedBlockDispatcher: (params: unknown) => Promise<unknown>,
   onResolvedContext?: (ctx: Record<string, unknown>) => void,
+  onResolvedTurn?: (turn: Record<string, unknown>) => void,
 ): GatewayPluginRuntime["channel"]["inbound"] {
   return {
     run: vi.fn(async (rawParams: unknown) => {
@@ -138,12 +139,14 @@ function makeInboundRuntime(
       )) as {
         cfg: unknown;
         ctxPayload: Record<string, unknown>;
+        record?: Record<string, unknown>;
         dispatcherOptions?: Record<string, unknown>;
         delivery: { deliver: unknown; onError?: unknown };
         replyOptions?: unknown;
         replyResolver?: unknown;
       };
       onResolvedContext?.(turn.ctxPayload);
+      onResolvedTurn?.(turn as unknown as Record<string, unknown>);
       return {
         dispatchResult: await dispatchReplyWithBufferedBlockDispatcher({
           ctx: turn.ctxPayload,
@@ -163,6 +166,7 @@ function makeInboundRuntime(
 
 function makeRuntime(params: {
   onFinalize?: (ctx: Record<string, unknown>) => void;
+  onTurn?: (turn: Record<string, unknown>) => void;
   isControlCommandMessage?: (text?: string, cfg?: unknown) => boolean;
   skipFreshSettledDelivery?: boolean;
   onDispatch?: (dispatcherOptions: {
@@ -247,7 +251,11 @@ function makeRuntime(params: {
         resolveStorePath: vi.fn(() => "/tmp/openclaw/qqbot-sessions.json"),
         recordInboundSession: vi.fn(async () => undefined),
       },
-      inbound: makeInboundRuntime(dispatchReplyWithBufferedBlockDispatcher, params.onFinalize),
+      inbound: makeInboundRuntime(
+        dispatchReplyWithBufferedBlockDispatcher,
+        params.onFinalize,
+        params.onTurn,
+      ),
       text: {
         chunkMarkdownText: (text: string) => [text],
       },
@@ -1549,6 +1557,81 @@ describe("dispatchOutbound", () => {
         "| 17 | 100ms | Lin | daily cap |",
       ].join("\n"),
     ]);
+  });
+
+  it("persists announce routes only for group and guild turns", async () => {
+    const cases = [
+      {
+        type: "group" as const,
+        isGroupChat: true,
+        eventTarget: { groupOpenid: "group-1001" },
+        peerId: "group-1001",
+        qualifiedTarget: "qqbot:group:group-1001",
+      },
+      {
+        type: "guild" as const,
+        isGroupChat: true,
+        eventTarget: { channelId: "channel-2001", guildId: "guild-2001" },
+        peerId: "channel-2001",
+        qualifiedTarget: "qqbot:channel:channel-2001",
+      },
+      {
+        type: "c2c" as const,
+        isGroupChat: false,
+        eventTarget: {},
+        peerId: "user-openid",
+        qualifiedTarget: "qqbot:c2c:user-openid",
+      },
+      {
+        type: "dm" as const,
+        isGroupChat: false,
+        eventTarget: { guildId: "dm-guild-1" },
+        peerId: "user-openid",
+        qualifiedTarget: "qqbot:dm:dm-guild-1",
+      },
+    ];
+
+    for (const testCase of cases) {
+      let record: Record<string, unknown> | undefined;
+      const runtime = makeRuntime({
+        onTurn: (turn) => {
+          record = turn.record as Record<string, unknown> | undefined;
+        },
+        onDeliver: async (deliver) => {
+          await deliver({ text: "hello" }, { kind: "block" });
+        },
+      });
+      const sessionKey = `agent:main:qqbot:${testCase.type}:${testCase.peerId}`;
+      await dispatchOutbound(
+        makeInbound({
+          event: {
+            type: testCase.type,
+            senderId: "user-openid",
+            messageId: `msg-${testCase.type}`,
+            content: "hello",
+            timestamp: "2026-04-25T00:00:00.000Z",
+            ...testCase.eventTarget,
+          } as InboundContext["event"],
+          isGroupChat: testCase.isGroupChat,
+          peerId: testCase.peerId,
+          qualifiedTarget: testCase.qualifiedTarget,
+          route: { sessionKey, accountId: "qq-main" },
+        }),
+        { runtime, cfg: {}, account },
+      );
+
+      expect(record).toBeDefined();
+      expect(record?.updateLastRoute).toEqual(
+        testCase.isGroupChat
+          ? {
+              sessionKey,
+              channel: "qqbot",
+              to: testCase.qualifiedTarget,
+              accountId: "qq-main",
+            }
+          : undefined,
+      );
+    }
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/qqbot/src/engine/gateway/outbound-dispatch.ts
+++ b/extensions/qqbot/src/engine/gateway/outbound-dispatch.ts
@@ -451,6 +451,16 @@ export async function dispatchOutbound(
               `Session metadata update failed: ${err instanceof Error ? err.message : String(err)}`,
             );
           },
+          ...(inbound.isGroupChat
+            ? {
+                updateLastRoute: {
+                  sessionKey: inbound.route.sessionKey,
+                  channel: "qqbot",
+                  to: qualifiedTarget,
+                  accountId: inbound.route.accountId,
+                },
+              }
+            : {}),
         },
         dispatcherOptions: {
           responsePrefix: messagesConfig.responsePrefix,

--- a/extensions/qqbot/src/engine/gateway/stages/access-stage.test.ts
+++ b/extensions/qqbot/src/engine/gateway/stages/access-stage.test.ts
@@ -171,4 +171,41 @@ describe("runAccessStage — dynamic cfg routing (#69546)", () => {
     expect(seenCfgs.has(cfgB)).toBe(true);
     expect(seenCfgs.has(cfgC)).toBe(true);
   });
+
+  it.each([
+    ["group", true, "group", "GROUP_OPENID", "qqbot:group:GROUP_OPENID"],
+    ["guild", true, "group", "CHANNEL_ID", "qqbot:channel:CHANNEL_ID"],
+    ["c2c", false, "direct", "user-openid", "qqbot:c2c:user-openid"],
+    ["dm", false, "direct", "user-openid", "qqbot:dm:DM_GUILD_ID"],
+  ] as const)(
+    "classifies %s route persistence facts",
+    async (type, isGroupChat, peerKind, peerId, qualifiedTarget) => {
+      const account = buildAccount();
+      let routedPeer: { kind: string; id: string } | undefined;
+      const runtime = buildRuntime((params) => {
+        routedPeer = params.peer;
+        return { sessionKey: `s:${params.peer.id}`, accountId: params.accountId };
+      });
+      const event = {
+        type,
+        senderId: "user-openid",
+        content: "hi",
+        messageId: `m-${type}`,
+        timestamp: "0",
+        ...(type === "group" ? { groupOpenid: "GROUP_OPENID" } : {}),
+        ...(type === "guild" ? { channelId: "CHANNEL_ID", guildId: "GUILD_ID" } : {}),
+        ...(type === "dm" ? { guildId: "DM_GUILD_ID" } : {}),
+      } as QueuedMessage;
+
+      const result = await runAccessStage(event, buildDeps({ bindings: [] }, runtime, account));
+
+      expect(result.kind).toBe("allow");
+      if (result.kind === "allow") {
+        expect(result.isGroupChat).toBe(isGroupChat);
+        expect(result.peerId).toBe(peerId);
+        expect(result.qualifiedTarget).toBe(qualifiedTarget);
+      }
+      expect(routedPeer).toEqual({ kind: peerKind, id: peerId });
+    },
+  );
 });


### PR DESCRIPTION
## What Problem This Solves

QQBot group and guild sessions need their qualified delivery route persisted so `sessions_send` announcements return to the originating conversation. The prior negative event-type guard excluded c2c traffic but still allowed `dm` turns to overwrite the shared route.

Fixes #86387. Supersedes the earlier attempt in #94785.

## Why This Change Was Made

QQBot now uses the existing generic persisted-session announce lookup seam and supplies `updateLastRoute` only when `runAccessStage` has positively classified the inbound turn as a group chat. This keeps the policy in the QQBot plugin, reuses the canonical session recorder, and avoids a parallel routing mechanism.

The final maintainer rewrite reduces the branch to five files and one production decision:

- enable `preferSessionLookupForAnnounceTarget` in QQBot metadata;
- persist the qualified QQBot route for group and guild turns;
- omit route updates for c2c and dm turns;
- cover all four event classes plus metadata opt-in.

## User Impact

`sessions_send` announcements from QQBot group and guild sessions resolve back to the correct QQBot conversation and account. Direct-message traffic no longer replaces that persisted group/guild destination.

No config, protocol, dependency, or public API surface changes. Existing c2c behavior is unchanged.

Contributor credit: implementation and live QQBot proof by @lzyyzznl; maintainer rewrite preserves credit with `Co-authored-by: lzyyzznl <lzyyzznl@users.noreply.github.com>`.

## Evidence

Exact head: `17c46856a7f05cac7709f175af2fdf9dce381c8a`

- Live QQBot proof supplied by the contributor showed `isGroupChat=false` omitting route persistence for c2c traffic and `isGroupChat=true` applying it for group traffic. Temporary instrumentation used to capture that proof is not in the final source.
- `node scripts/run-vitest.mjs extensions/qqbot/src/engine/gateway/stages/access-stage.test.ts extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts extensions/qqbot/src/channel.message-adapter.test.ts` — 62 tests passed.
- `node scripts/run-vitest.mjs src/agents/tools/sessions.test.ts src/agents/tools/sessions-send-tool.a2a.test.ts src/channels/session.test.ts` — 74 tests passed.
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/check-changed.mjs -- <five changed files>` under Node 24.18.0 — extension production/test typechecks, lint, formatting, plugin boundaries, import cycles, and guards passed.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` — clean; no accepted/actionable findings.

Not live-tested on the final rebased commit: concurrent multi-group interleaving and Gateway restart persistence. The final patch is behavior-equivalent to the contributor's live-proven route classification and is covered at the session-recording and announce-resolution boundaries.
