### PR TITLE
fix(ios): preserve assistant line breaks in chat

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownPreprocessor.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownPreprocessor.swift
@@ -220,4 +220,58 @@ enum ChatMarkdownPreprocessor {
         output = output.replacingOccurrences(of: "\n\n\n", with: "\n\n")
         return output.trimmingCharacters(in: .whitespacesAndNewlines)
     }
+
+    static func markdownForRendering(_ raw: String) -> String {
+        let lines = raw.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        var fenceMarker: Character?
+        var fenceLength = 0
+        var output: [String] = []
+
+        for index in lines.indices {
+            let line = lines[index]
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            let next = index + 1 < lines.count ? lines[index + 1] : nil
+            let nextTrimmed = next?.trimmingCharacters(in: .whitespaces) ?? ""
+            if let fence = self.fenceBoundary(in: line) {
+                if let currentMarker = fenceMarker {
+                    if fence.marker == currentMarker, fence.count >= fenceLength, !fence.hasTrailingContent {
+                        fenceMarker = nil
+                        fenceLength = 0
+                    }
+                } else {
+                    fenceMarker = fence.marker
+                    fenceLength = fence.count
+                }
+                output.append(line)
+                continue
+            }
+            if fenceMarker != nil ||
+                line.hasPrefix("    ") ||
+                line.hasPrefix("\t") ||
+                trimmed.isEmpty ||
+                next == nil ||
+                nextTrimmed.isEmpty ||
+                self.fenceBoundary(in: next ?? "") != nil ||
+                line.hasSuffix("  ") ||
+                line.hasSuffix("\\")
+            {
+                output.append(line)
+                continue
+            }
+            output.append("\(line)  ")
+        }
+
+        return output.joined(separator: "\n")
+    }
+
+    private static func fenceBoundary(in line: String) -> (marker: Character, count: Int, hasTrailingContent: Bool)? {
+        let leadingSpaces = line.prefix { $0 == " " }.count
+        guard leadingSpaces < 4, !line.hasPrefix("\t") else { return nil }
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        guard let marker = trimmed.first, marker == "`" || marker == "~" else { return nil }
+        let markerCount = trimmed.prefix { $0 == marker }.count
+        guard markerCount >= 3 else { return nil }
+        let remaining = trimmed.dropFirst(markerCount).trimmingCharacters(in: .whitespaces)
+        return (marker: marker, count: markerCount, hasTrailingContent: !remaining.isEmpty)
+    }
 }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownRenderer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownRenderer.swift
@@ -40,10 +40,11 @@ struct ChatMarkdownRenderer: View {
     }
 
     private func markdownText(_ markdown: String) -> AttributedString {
+        let renderMarkdown = ChatMarkdownPreprocessor.markdownForRendering(markdown)
         let options = AttributedString.MarkdownParsingOptions(
             interpretedSyntax: .full,
             failurePolicy: .returnPartiallyParsedIfPossible)
-        return (try? AttributedString(markdown: markdown, options: options)) ?? AttributedString(markdown)
+        return (try? AttributedString(markdown: renderMarkdown, options: options)) ?? AttributedString(markdown)
     }
 }
 

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatMarkdownPreprocessorTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatMarkdownPreprocessorTests.swift
@@ -150,6 +150,91 @@ struct ChatMarkdownPreprocessorTests {
         #expect(result.cleaned == "Hello there\nActual message")
     }
 
+    @Test func keepsCleanedTextPlainWhenInputHasSingleLineBreaks() {
+        let markdown = """
+        First line
+        Second line
+
+        Third paragraph
+        """
+
+        let result = ChatMarkdownPreprocessor.preprocess(markdown: markdown)
+
+        #expect(result.cleaned == "First line\nSecond line\n\nThird paragraph")
+    }
+
+    @Test func addsMarkdownHardBreaksForVisibleSingleLineRendering() {
+        let markdown = """
+        First line
+        Second line
+
+        Third paragraph
+        """
+
+        let result = ChatMarkdownPreprocessor.markdownForRendering(markdown)
+
+        #expect(result == "First line  \nSecond line\n\nThird paragraph")
+    }
+
+    @Test func leavesFencedCodeLineBreaksUntouchedForRendering() {
+        let markdown = """
+        Before
+        ```text
+        alpha
+        beta
+        ```
+        After
+        """
+
+        let result = ChatMarkdownPreprocessor.markdownForRendering(markdown)
+
+        #expect(result == "Before\n```text\nalpha\nbeta\n```\nAfter")
+    }
+
+    @Test func leavesTildeFencedCodeLineBreaksUntouchedForRendering() {
+        let markdown = """
+        Before
+        ~~~text
+        alpha
+        beta
+        ~~~
+        After
+        """
+
+        let result = ChatMarkdownPreprocessor.markdownForRendering(markdown)
+
+        #expect(result == "Before\n~~~text\nalpha\nbeta\n~~~\nAfter")
+    }
+
+    @Test func leavesIndentedCodeLineBreaksUntouchedForRendering() {
+        let markdown = """
+        Before
+            alpha
+            beta
+        After
+        """
+
+        let result = ChatMarkdownPreprocessor.markdownForRendering(markdown)
+
+        #expect(result == "Before  \n    alpha\n    beta\nAfter")
+    }
+
+    @Test func leavesShorterFenceTextInsideLongFenceUntouchedForRendering() {
+        let markdown = """
+        Before
+        ````markdown
+        ```text
+        alpha
+        ```
+        ````
+        After
+        """
+
+        let result = ChatMarkdownPreprocessor.markdownForRendering(markdown)
+
+        #expect(result == "Before\n````markdown\n```text\nalpha\n```\n````\nAfter")
+    }
+
     @Test func stripsTrailingUntrustedContextSuffix() {
         let markdown = """
         User-visible text


### PR DESCRIPTION
Closes #98028

## What Problem This Solves

Fixes an issue where iOS users reading assistant responses would see multi-line replies flattened into one continuous paragraph when the assistant text contained visible single line breaks.

## Why This Change Was Made

The shared native chat renderer now converts visible single newlines in cleaned display text into Markdown hard breaks before Swift Markdown parsing, while leaving paragraph breaks, existing hard breaks, escaped line breaks, fenced code blocks, and indented code blocks unchanged. This keeps the fix local to the chat Markdown rendering path without changing assistant text extraction or provider/gateway behavior.

## User Impact

Assistant responses in the iOS chat can display intentional line breaks as separate lines, matching the readable structure users expect from multi-line replies.

## Evidence

- Claim proved: the renderer receives a Markdown-safe display string that preserves visible prose line breaks without mutating common code-block Markdown forms.
- Commands / artifacts:
  - `git diff --check` passed.
  - `python .agents\skills\autoreview\scripts\autoreview --mode local` first reported an indented-code-block mutation risk; fixed in this branch.
  - `python .agents\skills\autoreview\scripts\autoreview --mode local` second reported a longer-fence Markdown mutation risk; fixed in this branch.
  - `python .agents\skills\autoreview\scripts\autoreview --mode local` final run: `autoreview clean: no accepted/actionable findings reported`.
  - `swift test --package-path apps/shared/OpenClawKit --filter ChatMarkdownPreprocessorTests` attempted locally but Windows does not have `swift` installed (`swift : The term 'swift' is not recognized...`).
  - `swift test --package-path apps/shared/OpenClawKit --filter ChatEventTextTests` attempted locally but Windows does not have `swift` installed (`swift : The term 'swift' is not recognized...`).
  - GitHub Actions iOS Simulator proof workflow passed: https://github.com/qingminglong/openclaw/actions/runs/28437348097
  - Proof artifact: `ios-chat-line-break-proof-pr-98054` (artifact id `7977787938`, 211269 bytes) from workflow run `28437348097`.
  - Proof screenshot file inside the artifact: `iPhone 17-ios-chat-line-break-proof.png`.
  - Proof run target SHA: `92531758b3081fd314e4f76a0f74523af7f2606f`.
- Observed result: the iPhone 17 simulator screenshot shows the assistant fixture rendering `Line one should stay on its own row`, `Line two should stay on its own row`, and `Line three should stay on its own row` on separate visible rows. The same screenshot also shows the fenced Swift code contents (`let first = "alpha"`, `let second = "beta"`, `print(first + second)`) and indented code lines A/B remaining multi-line instead of being collapsed into a single line.
- Not tested / proof gaps: no physical iOS device was available; the after-fix visible proof was captured on the GitHub Actions iOS Simulator lane above.
