### PR TITLE
[codex] Gate Android Talk capture starts in background

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -75,7 +75,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1686,
+      "line": 1695,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: this host requires wss:// or Tailscale Serve. No TLS endpoint detected.",
       "surface": "android",
@@ -83,7 +83,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1688,
+      "line": 1697,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: secure endpoint reached, but TLS fingerprint verification timed out. Check Tailscale Serve or gateway TLS and retry.",
       "surface": "android",
@@ -91,7 +91,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1690,
+      "line": 1699,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "surface": "android",
@@ -4931,7 +4931,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 336,
+      "line": 342,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Listening",
       "surface": "android",
@@ -4939,7 +4939,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 336,
+      "line": 342,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Ready",
       "surface": "android",
@@ -4947,7 +4947,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1623,
+      "line": 1629,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Aborted",
       "surface": "android",
@@ -4955,7 +4955,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1623,
+      "line": 1629,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Chat error",
       "surface": "android",

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -1248,7 +1248,7 @@ class NodeRuntime(
         return@runTalkPttCommand GatewaySession.InvokeResult.ok(payload.toJson())
       }
       runPreparedTalkPttCommand {
-        val payload = talkMode.beginPushToTalk()
+        val payload = talkMode.beginPushToTalk(allowNewCapture = true)
         GatewaySession.InvokeResult.ok(payload.toJson())
       }
     }

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -1242,9 +1242,15 @@ class NodeRuntime(
   }
 
   private suspend fun handleTalkPttStart(): GatewaySession.InvokeResult =
-    runPreparedTalkPttCommand {
-      val payload = talkMode.beginPushToTalk()
-      GatewaySession.InvokeResult.ok(payload.toJson())
+    runTalkPttCommand {
+      if (!_isForeground.value) {
+        val payload = talkMode.beginPushToTalk(allowNewCapture = false)
+        return@runTalkPttCommand GatewaySession.InvokeResult.ok(payload.toJson())
+      }
+      runPreparedTalkPttCommand {
+        val payload = talkMode.beginPushToTalk()
+        GatewaySession.InvokeResult.ok(payload.toJson())
+      }
     }
 
   private suspend fun handleTalkPttStop(): GatewaySession.InvokeResult =
@@ -1288,6 +1294,9 @@ class NodeRuntime(
     }
 
   private suspend fun prepareTalkCapture() {
+    if (!_isForeground.value) {
+      throw IllegalStateException("NODE_BACKGROUND_UNAVAILABLE: command requires foreground")
+    }
     if (!hasRecordAudioPermission()) {
       throw IllegalStateException("MIC_PERMISSION_REQUIRED: grant Microphone permission")
     }

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/InvokeCommandRegistry.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/InvokeCommandRegistry.kt
@@ -163,6 +163,7 @@ object InvokeCommandRegistry {
       ),
       InvokeCommandSpec(
         name = OpenClawTalkCommand.PttOnce.rawValue,
+        requiresForeground = true,
       ),
       InvokeCommandSpec(
         name = OpenClawCameraCommand.List.rawValue,

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/InvokeDispatcher.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/InvokeDispatcher.kt
@@ -104,10 +104,10 @@ class InvokeDispatcher(
           message = "INVALID_REQUEST: unknown command",
         )
     if (spec.requiresForeground && !isForeground()) {
-      // Canvas, camera, and screen-backed commands need an active Activity/WebView surface.
+      // Foreground-only commands need an active Activity surface before touching UI or capture APIs.
       return GatewaySession.InvokeResult.error(
         code = "NODE_BACKGROUND_UNAVAILABLE",
-        message = "NODE_BACKGROUND_UNAVAILABLE: canvas/camera/screen commands require foreground",
+        message = "NODE_BACKGROUND_UNAVAILABLE: command requires foreground",
       )
     }
     availabilityError(spec.availability)?.let { return it }

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -243,13 +243,19 @@ class TalkModeManager internal constructor(
   }
 
   /** Starts a push-to-talk capture session for gateway node.invoke callers. */
-  suspend fun beginPushToTalk(): TalkPttStartPayload {
+  suspend fun beginPushToTalk(allowNewCapture: Boolean = true): TalkPttStartPayload {
+    if (!allowNewCapture && activePttCaptureId == null) {
+      throw IllegalStateException("NODE_BACKGROUND_UNAVAILABLE: command requires foreground")
+    }
     if (!isConnected()) {
       _statusText.value = "Gateway not connected"
       throw IllegalStateException("UNAVAILABLE: Gateway not connected")
     }
     // PTT begin is idempotent so gateway retries don't start multiple recognizers.
     activePttCaptureId?.let { return TalkPttStartPayload(captureId = it) }
+    if (!allowNewCapture) {
+      throw IllegalStateException("NODE_BACKGROUND_UNAVAILABLE: command requires foreground")
+    }
 
     stopSpeaking(resetInterrupt = false)
     pttTimeoutJob?.cancel()

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -243,9 +243,12 @@ class TalkModeManager internal constructor(
   }
 
   /** Starts a push-to-talk capture session for gateway node.invoke callers. */
-  suspend fun beginPushToTalk(allowNewCapture: Boolean = true): TalkPttStartPayload {
-    if (!allowNewCapture && activePttCaptureId == null) {
-      throw IllegalStateException("NODE_BACKGROUND_UNAVAILABLE: command requires foreground")
+  suspend fun beginPushToTalk(allowNewCapture: Boolean): TalkPttStartPayload {
+    if (!allowNewCapture) {
+      // A background retry may reconcile an existing capture, but must never create one.
+      return activePttCaptureId
+        ?.let(::TalkPttStartPayload)
+        ?: throw IllegalStateException("NODE_BACKGROUND_UNAVAILABLE: command requires foreground")
     }
     if (!isConnected()) {
       _statusText.value = "Gateway not connected"
@@ -253,9 +256,6 @@ class TalkModeManager internal constructor(
     }
     // PTT begin is idempotent so gateway retries don't start multiple recognizers.
     activePttCaptureId?.let { return TalkPttStartPayload(captureId = it) }
-    if (!allowNewCapture) {
-      throw IllegalStateException("NODE_BACKGROUND_UNAVAILABLE: command requires foreground")
-    }
 
     stopSpeaking(resetInterrupt = false)
     pttTimeoutJob?.cancel()
@@ -359,7 +359,7 @@ class TalkModeManager internal constructor(
       )
     }
 
-    beginPushToTalk()
+    beginPushToTalk(allowNewCapture = true)
     val completion = CompletableDeferred<TalkPttStopPayload>()
     pttCompletion = completion
     pttAutoStopEnabled = true

--- a/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
@@ -435,6 +435,23 @@ class GatewayBootstrapAuthTest {
       assertFalse(talkMode.ttsOnAllResponses)
     }
 
+  @Test
+  fun talkPttStart_rejectsNewCaptureWhenBackgrounded() =
+    runBlocking {
+      val app = RuntimeEnvironment.getApplication()
+      shadowOf(app).grantPermissions(Manifest.permission.RECORD_AUDIO)
+      val runtime = NodeRuntime(app)
+      runtime.setForeground(false)
+      val dispatcher = readField<InvokeDispatcher>(runtime, "invokeDispatcher")
+
+      val result = dispatcher.handleInvoke(OpenClawTalkCommand.PttStart.rawValue, null)
+
+      assertEquals("NODE_BACKGROUND_UNAVAILABLE", result.error?.code)
+      assertEquals("NODE_BACKGROUND_UNAVAILABLE: command requires foreground", result.error?.message)
+      assertEquals(VoiceCaptureMode.Off, runtime.voiceCaptureMode.value)
+      assertFalse(readField<MutableStateFlow<Boolean>>(runtime, "externalAudioCaptureActive").value)
+    }
+
   private fun waitForGatewayTrustPrompt(runtime: NodeRuntime): NodeRuntime.GatewayTrustPrompt {
     repeat(50) {
       runtime.pendingGatewayTrust.value?.let { return it }

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/InvokeCommandRegistryTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/InvokeCommandRegistryTest.kt
@@ -249,11 +249,23 @@ class InvokeCommandRegistryTest {
   fun find_returnsForegroundMetadataForCameraCommands() {
     val list = InvokeCommandRegistry.find(OpenClawCameraCommand.List.rawValue)
     val location = InvokeCommandRegistry.find(OpenClawLocationCommand.Get.rawValue)
+    val pttStart = InvokeCommandRegistry.find(OpenClawTalkCommand.PttStart.rawValue)
+    val pttStop = InvokeCommandRegistry.find(OpenClawTalkCommand.PttStop.rawValue)
+    val pttCancel = InvokeCommandRegistry.find(OpenClawTalkCommand.PttCancel.rawValue)
+    val pttOnce = InvokeCommandRegistry.find(OpenClawTalkCommand.PttOnce.rawValue)
 
     assertNotNull(list)
     assertEquals(true, list?.requiresForeground)
     assertNotNull(location)
     assertEquals(false, location?.requiresForeground)
+    assertNotNull(pttStart)
+    assertEquals(false, pttStart?.requiresForeground)
+    assertNotNull(pttStop)
+    assertEquals(false, pttStop?.requiresForeground)
+    assertNotNull(pttCancel)
+    assertEquals(false, pttCancel?.requiresForeground)
+    assertNotNull(pttOnce)
+    assertEquals(true, pttOnce?.requiresForeground)
   }
 
   @Test

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/InvokeDispatcherTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/InvokeDispatcherTest.kt
@@ -256,7 +256,27 @@ class InvokeDispatcherTest {
       )
     }
 
+  @Test
+  fun handleInvoke_blocksTalkOnceButLeavesPttStartToRuntimeStateGateWhenBackgrounded() =
+    runTest {
+      val talk = InvokeDispatcherFakeTalkHandler()
+      val dispatcher = newDispatcher(isForeground = false, talkHandler = talk)
+
+      val start = dispatcher.handleInvoke(OpenClawTalkCommand.PttStart.rawValue, null)
+      val once = dispatcher.handleInvoke(OpenClawTalkCommand.PttOnce.rawValue, null)
+      val stop = dispatcher.handleInvoke(OpenClawTalkCommand.PttStop.rawValue, null)
+      val cancel = dispatcher.handleInvoke(OpenClawTalkCommand.PttCancel.rawValue, null)
+
+      assertEquals("""{"captureId":"start"}""", start.payloadJson)
+      assertEquals("NODE_BACKGROUND_UNAVAILABLE", once.error?.code)
+      assertEquals("NODE_BACKGROUND_UNAVAILABLE: command requires foreground", once.error?.message)
+      assertEquals("""{"status":"stop"}""", stop.payloadJson)
+      assertEquals("""{"status":"cancel"}""", cancel.payloadJson)
+      assertEquals(listOf("start", "stop", "cancel"), talk.calls)
+    }
+
   private fun newDispatcher(
+    isForeground: Boolean = true,
     cameraEnabled: Boolean = false,
     locationEnabled: Boolean = false,
     sendSmsAvailable: Boolean = false,
@@ -302,7 +322,7 @@ class InvokeDispatcherTest {
         ),
       debugHandler = DebugHandler(appContext, DeviceIdentityStore(appContext)),
       callLogHandler = CallLogHandler.forTesting(appContext, InvokeDispatcherFakeCallLogDataSource()),
-      isForeground = { true },
+      isForeground = { isForeground },
       cameraEnabled = { cameraEnabled },
       locationEnabled = { locationEnabled },
       sendSmsAvailable = { sendSmsAvailable },

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
@@ -60,6 +60,29 @@ class TalkModeManagerTest {
   }
 
   @Test
+  fun beginPushToTalkRejectsNewCaptureWhenNewCaptureIsDisallowed() =
+    runTest {
+      val manager = createManager()
+
+      val error =
+        runCatching { manager.beginPushToTalk(allowNewCapture = false) }
+          .exceptionOrNull()
+
+      assertEquals("NODE_BACKGROUND_UNAVAILABLE: command requires foreground", error?.message)
+    }
+
+  @Test
+  fun beginPushToTalkReturnsActiveCaptureWhenNewCaptureIsDisallowed() =
+    runTest {
+      val manager = createManager()
+      setPrivateField(manager, "activePttCaptureId", "capture-1")
+
+      val payload = manager.beginPushToTalk(allowNewCapture = false)
+
+      assertEquals("capture-1", payload.captureId)
+    }
+
+  @Test
   fun duplicateFinalForPendingTalkRunDoesNotStartAllResponseTts() {
     val manager = createManager()
     val final = CompletableDeferred<Boolean>()


### PR DESCRIPTION
## What Problem This Solves

Android Talk push-to-talk capture can start microphone capture and move `NodeForegroundService` into the microphone foreground-service type. On modern Android, starting a microphone foreground service from the background is restricted, so remote `talk.ptt.start` / `talk.ptt.once` invocations should not start a new capture while the app is backgrounded.

## Why This Change Was Made

This gates new Talk capture starts at the Android runtime boundary. `talk.ptt.once` remains a foreground-only dispatcher command, while `talk.ptt.start` is handled in `NodeRuntime` so idempotent retries for an already-active capture can still return the current capture id. `TalkModeManager.beginPushToTalk(allowNewCapture = false)` owns the final new-capture check to avoid a race between an external active-capture precheck and the actual begin operation.

## User Impact

Background remote commands no longer try to create a new microphone capture path that Android can reject at foreground-service startup time. Existing active PTT sessions can still be stopped/cancelled, and `ptt.start` retries for an active session still reconcile to the same capture id.

## Evidence

- `cd apps/android && ./gradlew :app:testThirdPartyDebugUnitTest --tests ai.openclaw.app.node.InvokeCommandRegistryTest --tests ai.openclaw.app.node.InvokeDispatcherTest --tests ai.openclaw.app.GatewayBootstrapAuthTest --tests ai.openclaw.app.voice.TalkModeManagerTest`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

Known unrelated local check gap:

- `cd apps/android && ./gradlew :app:ktlintCheck` currently fails on untouched upstream files: `apps/android/app/src/main/java/ai/openclaw/app/GatewayExecApprovals.kt` and `apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawSurfaces.kt`.
