### PR TITLE
fix(ios): assistant chat replies collapse multi-line responses into one line

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownRenderer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownRenderer.swift
@@ -40,10 +40,80 @@ struct ChatMarkdownRenderer: View {
     }
 
     private func markdownText(_ markdown: String) -> AttributedString {
+        Self.parsedMarkdown(markdown)
+    }
+
+    /// Parse `markdown` as an `AttributedString`, first promoting solo
+    /// newlines into CommonMark hard breaks so the iOS chat bubble keeps
+    /// the line layout the assistant emitted. Exposed for tests.
+    nonisolated static func parsedMarkdown(_ markdown: String) -> AttributedString {
+        let prepared = self.preserveSoftLineBreaks(in: markdown)
         let options = AttributedString.MarkdownParsingOptions(
             interpretedSyntax: .full,
             failurePolicy: .returnPartiallyParsedIfPossible)
-        return (try? AttributedString(markdown: markdown, options: options)) ?? AttributedString(markdown)
+        return (try? AttributedString(markdown: prepared, options: options))
+            ?? AttributedString(prepared)
+    }
+
+    /// CommonMark collapses a single `\n` into a space, which strips the
+    /// visible line breaks assistant responses emit (issue #98028 on iOS).
+    /// Append two trailing spaces to every intra-paragraph newline so the
+    /// parser keeps them as hard breaks. Blank lines remain paragraph
+    /// separators and fenced code blocks are left untouched so their
+    /// literal layout survives verbatim.
+    nonisolated static func preserveSoftLineBreaks(in markdown: String) -> String {
+        let lines = markdown
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map(String.init)
+        guard lines.count > 1 else { return markdown }
+
+        var output: [String] = []
+        output.reserveCapacity(lines.count)
+        var openFence: String?
+
+        for index in lines.indices {
+            let current = lines[index]
+            let trimmedLead = String(current.drop(while: { $0 == " " }))
+
+            if let marker = self.fenceMarker(in: trimmedLead) {
+                if openFence == nil {
+                    openFence = marker
+                } else if openFence == marker {
+                    openFence = nil
+                }
+                output.append(current)
+                continue
+            }
+
+            if openFence != nil {
+                output.append(current)
+                continue
+            }
+
+            guard index + 1 < lines.count else {
+                output.append(current)
+                continue
+            }
+
+            let next = lines[index + 1]
+            let nextIsBlank = next.allSatisfy({ $0 == " " || $0 == "\t" })
+            let currentIsBlank = current.allSatisfy({ $0 == " " || $0 == "\t" })
+            let alreadyHardBreak = current.hasSuffix("  ") || current.hasSuffix("\\")
+            if nextIsBlank || currentIsBlank || alreadyHardBreak {
+                output.append(current)
+                continue
+            }
+
+            output.append(current + "  ")
+        }
+
+        return output.joined(separator: "\n")
+    }
+
+    private static func fenceMarker(in trimmed: String) -> String? {
+        if trimmed.hasPrefix("```") { return "```" }
+        if trimmed.hasPrefix("~~~") { return "~~~" }
+        return nil
     }
 }
 

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatMarkdownRendererTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatMarkdownRendererTests.swift
@@ -1,0 +1,87 @@
+import Foundation
+import Testing
+@testable import OpenClawChatUI
+
+@Suite("ChatMarkdownRenderer")
+struct ChatMarkdownRendererTests {
+    // Regression for issue #98028: assistant responses on iOS were rendered
+    // as a single line because Foundation's CommonMark parser collapses solo
+    // newlines into spaces. The renderer now promotes intra-paragraph
+    // newlines into CommonMark hard breaks before parsing.
+
+    @Test func `preserves single newlines between assistant lines`() {
+        let parsed = ChatMarkdownRenderer.parsedMarkdown("hello\nworld")
+        let characters = String(parsed.characters)
+        #expect(characters.contains("\n"))
+        #expect(characters == "hello\nworld")
+    }
+
+    @Test func `preserves multiple solo newlines across lines`() {
+        let parsed = ChatMarkdownRenderer.parsedMarkdown("Line 1\nLine 2\nLine 3")
+        #expect(String(parsed.characters) == "Line 1\nLine 2\nLine 3")
+    }
+
+    @Test func `injects hard breaks for intra-paragraph newlines`() {
+        let prepared = ChatMarkdownRenderer.preserveSoftLineBreaks(in: "hello\nworld")
+        #expect(prepared == "hello  \nworld")
+    }
+
+    @Test func `keeps blank line paragraph separators`() {
+        let prepared = ChatMarkdownRenderer.preserveSoftLineBreaks(in: "Para1\n\nPara2")
+        #expect(prepared == "Para1\n\nPara2")
+    }
+
+    @Test func `leaves fenced code blocks untouched`() {
+        let input = "before\n```\nlet x = 1\nlet y = 2\n```\nafter"
+        let prepared = ChatMarkdownRenderer.preserveSoftLineBreaks(in: input)
+        // `before` and `after` flank the fence and pick up hard breaks because
+        // each is adjacent to a non-blank line, but lines inside the fence
+        // stay verbatim so code keeps its layout.
+        #expect(prepared == "before  \n```\nlet x = 1\nlet y = 2\n```\nafter")
+    }
+
+    @Test func `does not double-break already hard-broken lines`() {
+        let input = "Already hard  \nbreak"
+        let prepared = ChatMarkdownRenderer.preserveSoftLineBreaks(in: input)
+        #expect(prepared == "Already hard  \nbreak")
+    }
+
+    @Test func `leaves backslash hard breaks alone`() {
+        let input = "Above\\\nBelow"
+        let prepared = ChatMarkdownRenderer.preserveSoftLineBreaks(in: input)
+        #expect(prepared == "Above\\\nBelow")
+    }
+
+    @Test func `passes through single-line and empty inputs`() {
+        #expect(ChatMarkdownRenderer.preserveSoftLineBreaks(in: "") == "")
+        #expect(ChatMarkdownRenderer.preserveSoftLineBreaks(in: "solo") == "solo")
+    }
+
+    @Test func `keeps unordered list semantics intact`() {
+        let prepared = ChatMarkdownRenderer.preserveSoftLineBreaks(in: "- one\n- two")
+        // Trailing spaces on a list-item content line do not disturb the
+        // CommonMark list parser; the second line still begins a list item.
+        let parsed = ChatMarkdownRenderer.parsedMarkdown("- one\n- two")
+        var sawListItem = false
+        for run in parsed.runs {
+            if let intent = run.presentationIntent, "\(intent)".contains("listItem") {
+                sawListItem = true
+                break
+            }
+        }
+        #expect(sawListItem)
+        #expect(prepared == "- one  \n- two")
+    }
+
+    @Test func `keeps header followed by paragraph as header`() {
+        let parsed = ChatMarkdownRenderer.parsedMarkdown("# Heading\nBody")
+        var sawHeader = false
+        for run in parsed.runs {
+            if let intent = run.presentationIntent, "\(intent)".contains("header") {
+                sawHeader = true
+                break
+            }
+        }
+        #expect(sawHeader)
+    }
+}


### PR DESCRIPTION
Closes #98028

## What Problem This Solves

Fixes an issue where users sending or receiving multi-line assistant replies in the iOS app would see the entire response render as one wrapped line, even when the message was emitted line-by-line. Every `\n` in the assistant bubble collapsed into a single space, so structured responses (steps, paragraphs, blockquotes typed out line-by-line) lost their layout and became visually unreadable. The macOS app does not show this because it does not route assistant text through `AttributedString(markdown:)`. Reported on iOS 18.5 across multiple models (Sonnet 3.7, GPT-4.5, Gemini 2.5 Flash, GLM 4.5).

## Why This Change Was Made

The iOS chat bubble parses assistant markdown with `AttributedString(markdown:options:)` using `interpretedSyntax: .full`, which follows the CommonMark spec; CommonMark treats a solo `\n` inside a paragraph as a soft line break and renders it as a space. The fix pre-processes the cleaned markdown before parsing and appends two trailing spaces (the CommonMark hard-break marker) to every intra-paragraph newline. Blank lines remain paragraph separators, fenced code blocks are left verbatim so their literal layout survives, and lines that already end in two spaces or a backslash hard break are not touched. User messages still flow through `ChatMarkdownPreprocessor.preprocess` unchanged because the transform lives in `ChatMarkdownRenderer.parsedMarkdown`, not in the shared preprocessor.

## User Impact

Multi-line assistant responses in the iOS chat now render with the same line layout the model produced. Lists, headers, blockquotes, fenced code, and paragraph breaks behave exactly as before; only the previously-invisible intra-paragraph newlines become visible hard breaks.

## Evidence

Local reproduction of the underlying parser behavior on macOS 26.5 with Swift 6.2 (mirrors the iOS Foundation path):

```
input:    "hello\nworld"
base out: "hello world"  (no \n, bug)
fix out:  "hello\nworld" (newline preserved)
```

`ChatMarkdownRendererTests` (Swift Testing) added in this PR cover:

- `preserves single newlines between assistant lines`: round-trips `"hello\nworld"` through `parsedMarkdown` and asserts the rendered characters still contain `\n` (fails on `main`, passes with this change).
- `preserves multiple solo newlines across lines`: three-line input round-trips intact.
- `injects hard breaks for intra-paragraph newlines`: `preserveSoftLineBreaks(in:)` produces `"hello  \nworld"`.
- `keeps blank line paragraph separators`: `"Para1\n\nPara2"` is left untouched (no spurious hard break).
- `leaves fenced code blocks untouched`: content between ``` fences is byte-for-byte unchanged.
- `does not double-break already hard-broken lines` and `leaves backslash hard breaks alone`.
- `passes through single-line and empty inputs`.
- `keeps unordered list semantics intact`: list-item runs still carry `listItem` presentation intent after the transform.
- `keeps header followed by paragraph as header`: `# Heading\nBody` still parses the header as `header 1`.

Scope is contained: only `ChatMarkdownRenderer.swift` (logic) and the new `ChatMarkdownRendererTests.swift`.

```
 apps/.../OpenClawChatUI/ChatMarkdownRenderer.swift | 72 ++++++++++++++++++-
 .../ChatMarkdownRendererTests.swift                | 87 ++++++++++++++++++++++
 2 files changed, 158 insertions(+), 1 deletion(-)
```

## AI Disclosure

Written with the assistance of Claude. I have reviewed the diff and the test and take responsibility for the code.
