### PR TITLE
[codex] Support Android selected photo access

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -243,7 +243,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 281,
+      "line": 282,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt",
       "source": "Photos",
       "surface": "android",
@@ -1475,7 +1475,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 430,
+      "line": 432,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "OPENCLAW",
       "surface": "android",
@@ -1483,7 +1483,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 435,
+      "line": 437,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Your personal AI assistant.\nExfoliate! Exfoliate!",
       "surface": "android",
@@ -1491,7 +1491,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 445,
+      "line": 447,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Connect Gateway",
       "surface": "android",
@@ -1499,7 +1499,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 589,
+      "line": 591,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Setup code issue",
       "surface": "android",
@@ -1507,7 +1507,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 606,
+      "line": 608,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Advanced",
       "surface": "android",
@@ -1515,7 +1515,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 615,
+      "line": 617,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Setup code",
       "surface": "android",
@@ -1523,7 +1523,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 617,
+      "line": 619,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Host",
       "surface": "android",
@@ -1531,7 +1531,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 618,
+      "line": 620,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Port",
       "surface": "android",
@@ -1539,7 +1539,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 621,
+      "line": 623,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "TLS off",
       "surface": "android",
@@ -1547,7 +1547,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 621,
+      "line": 623,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "TLS on",
       "surface": "android",
@@ -1555,7 +1555,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 622,
+      "line": 624,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Local",
       "surface": "android",
@@ -1563,7 +1563,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 624,
+      "line": 626,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Token optional",
       "surface": "android",
@@ -1571,7 +1571,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 625,
+      "line": 627,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Password optional",
       "surface": "android",
@@ -1579,7 +1579,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 630,
+      "line": 632,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Pair with Gateway",
       "surface": "android",
@@ -1587,7 +1587,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 699,
+      "line": 701,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Last gateway",
       "surface": "android",
@@ -1595,7 +1595,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 741,
+      "line": 743,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Retry connection",
       "surface": "android",
@@ -1603,7 +1603,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 746,
+      "line": 748,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Edit connection",
       "surface": "android",
@@ -1611,7 +1611,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 747,
+      "line": 749,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Copy diagnostic",
       "surface": "android",
@@ -1619,7 +1619,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 781,
+      "line": 783,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Copy approval command",
       "surface": "android",
@@ -1627,7 +1627,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 808,
+      "line": 810,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Allow permissions",
       "surface": "android",
@@ -1635,7 +1635,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 813,
+      "line": 815,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "These permissions keep OpenClaw secure\nand useful.",
       "surface": "android",
@@ -1643,7 +1643,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 891,
+      "line": 893,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Open $title",
       "surface": "android",
@@ -1651,7 +1651,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 952,
+      "line": 954,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Choose what this phone can share with OpenClaw. You can change these later in Settings.",
       "surface": "android",
@@ -1659,7 +1659,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 973,
+      "line": 975,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Back",
       "surface": "android",
@@ -1667,7 +1667,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 977,
+      "line": 979,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Permission Setup",
       "surface": "android",
@@ -1675,7 +1675,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1032,
+      "line": 1034,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Granted",
       "surface": "android",
@@ -1683,7 +1683,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1032,
+      "line": 1034,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Not granted",
       "surface": "android",
@@ -1691,7 +1691,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1057,
+      "line": 1059,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Continue",
       "surface": "android",
@@ -1699,7 +1699,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1238,
+      "line": 1240,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Setup code expired. Scan a fresh setup QR.",
       "surface": "android",
@@ -1707,7 +1707,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1242,
+      "line": 1244,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway password is required. Enter it again or edit this connection.",
       "surface": "android",
@@ -1715,7 +1715,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1243,
+      "line": 1245,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway password is invalid. Re-enter it or reset this gateway connection.",
       "surface": "android",
@@ -1723,7 +1723,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1244,
+      "line": 1246,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway token is required. Enter it again or edit this connection.",
       "surface": "android",
@@ -1731,7 +1731,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1246,
+      "line": 1248,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway requires this device identity. Re-authenticate or reset this gateway connection.",
       "surface": "android",
@@ -1739,7 +1739,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1250,
+      "line": 1252,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Saved authentication is invalid. Re-authenticate or reset this gateway connection.",
       "surface": "android",
@@ -1747,7 +1747,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1251,
+      "line": 1253,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway authentication is not configured. Edit this connection and try again.",
       "surface": "android",
@@ -1755,7 +1755,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1252,
+      "line": 1254,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway authentication needs review. Check gateway settings, then retry.",
       "surface": "android",
@@ -1763,7 +1763,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1269,
+      "line": 1271,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "$summary $it",
       "surface": "android",
@@ -1771,7 +1771,7 @@
     },
     {
       "kind": "ui-toast",
-      "line": 1307,
+      "line": 1309,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Approval command copied",
       "surface": "android",
@@ -1779,7 +1779,7 @@
     },
     {
       "kind": "ui-toast",
-      "line": 1333,
+      "line": 1335,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Diagnostic copied",
       "surface": "android",
@@ -2091,7 +2091,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 177,
+      "line": 186,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Usage",
       "surface": "android",
@@ -2099,7 +2099,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 197,
+      "line": 206,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to load usage.",
       "surface": "android",
@@ -2107,7 +2107,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 202,
+      "line": 211,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No usage data yet.",
       "surface": "android",
@@ -2115,7 +2115,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 203,
+      "line": 212,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Provider limits will appear here when your gateway reports them.",
       "surface": "android",
@@ -2123,7 +2123,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 228,
+      "line": 237,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Cron Jobs",
       "surface": "android",
@@ -2131,7 +2131,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 232,
+      "line": 241,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Enabled",
       "surface": "android",
@@ -2139,7 +2139,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 239,
+      "line": 248,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Android shows scheduled work status. Create and edit schedules from the desktop app.",
       "surface": "android",
@@ -2147,7 +2147,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 249,
+      "line": 258,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to load cron jobs.",
       "surface": "android",
@@ -2155,7 +2155,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 254,
+      "line": 263,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No scheduled jobs.",
       "surface": "android",
@@ -2163,7 +2163,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 255,
+      "line": 264,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Create recurring OpenClaw work from the desktop app.",
       "surface": "android",
@@ -2171,7 +2171,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 278,
+      "line": 287,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Agents",
       "surface": "android",
@@ -2179,7 +2179,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 289,
+      "line": 298,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to load agents.",
       "surface": "android",
@@ -2187,7 +2187,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 293,
+      "line": 302,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No agents loaded yet.",
       "surface": "android",
@@ -2195,7 +2195,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 319,
+      "line": 328,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Approvals",
       "surface": "android",
@@ -2203,7 +2203,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 330,
+      "line": 339,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Refresh",
       "surface": "android",
@@ -2211,7 +2211,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 330,
+      "line": 339,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Refreshing",
       "surface": "android",
@@ -2219,7 +2219,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 343,
+      "line": 352,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Gateway disconnected.",
       "surface": "android",
@@ -2227,7 +2227,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 344,
+      "line": 353,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to load approval requests in the app.",
       "surface": "android",
@@ -2235,7 +2235,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 350,
+      "line": 359,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No gateway approvals.",
       "surface": "android",
@@ -2243,7 +2243,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 351,
+      "line": 360,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Exec approval requests will appear here while this phone is connected.",
       "surface": "android",
@@ -2251,7 +2251,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 358,
+      "line": 367,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Session activity",
       "surface": "android",
@@ -2259,7 +2259,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 359,
+      "line": 368,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Chat tool calls waiting in the active session remain visible here.",
       "surface": "android",
@@ -2267,7 +2267,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 373,
+      "line": 382,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Profile",
       "surface": "android",
@@ -2275,7 +2275,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 376,
+      "line": 385,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Device name",
       "surface": "android",
@@ -2283,7 +2283,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 377,
+      "line": 386,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Save Profile",
       "surface": "android",
@@ -2291,7 +2291,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 392,
+      "line": 401,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Talk Provider Setup",
       "surface": "android",
@@ -2299,7 +2299,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 397,
+      "line": 406,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Audio Test",
       "surface": "android",
@@ -2307,7 +2307,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 398,
+      "line": 407,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Check that OpenClaw can speak clearly on this phone.",
       "surface": "android",
@@ -2315,7 +2315,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 401,
+      "line": 410,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Enable speaker",
       "surface": "android",
@@ -2323,7 +2323,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 401,
+      "line": 410,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Mute speaker",
       "surface": "android",
@@ -2331,7 +2331,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 402,
+      "line": 411,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Assistant speech muted",
       "surface": "android",
@@ -2339,7 +2339,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 402,
+      "line": 411,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Replies play aloud",
       "surface": "android",
@@ -2347,7 +2347,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 404,
+      "line": 413,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Muted",
       "surface": "android",
@@ -2355,7 +2355,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 404,
+      "line": 413,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "On",
       "surface": "android",
@@ -2363,7 +2363,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 408,
+      "line": 417,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Done",
       "surface": "android",
@@ -2371,7 +2371,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 419,
+      "line": 428,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Realtime Provider",
       "surface": "android",
@@ -2379,7 +2379,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 422,
+      "line": 431,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Live",
       "surface": "android",
@@ -2387,7 +2387,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 426,
+      "line": 435,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Voice",
       "surface": "android",
@@ -2395,7 +2395,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 433,
+      "line": 442,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Transport",
       "surface": "android",
@@ -2403,7 +2403,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 551,
+      "line": 560,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allowlist",
       "surface": "android",
@@ -2411,7 +2411,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 551,
+      "line": 560,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Blocklist",
       "surface": "android",
@@ -2419,7 +2419,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 584,
+      "line": 593,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Notifications",
       "surface": "android",
@@ -2427,7 +2427,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 588,
+      "line": 597,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Alerts stay on this phone.",
       "surface": "android",
@@ -2435,7 +2435,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 588,
+      "line": 597,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw can receive selected alerts.",
       "surface": "android",
@@ -2443,7 +2443,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 600,
+      "line": 609,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Granted",
       "surface": "android",
@@ -2451,7 +2451,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 600,
+      "line": 609,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Setup",
       "surface": "android",
@@ -2459,7 +2459,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 605,
+      "line": 614,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Check Access",
       "surface": "android",
@@ -2467,7 +2467,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 605,
+      "line": 614,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open System Access",
       "surface": "android",
@@ -2475,7 +2475,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 615,
+      "line": 624,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Forwarding Mode",
       "surface": "android",
@@ -2483,7 +2483,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 664,
+      "line": 673,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "App Filter",
       "surface": "android",
@@ -2491,7 +2491,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 671,
+      "line": 680,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Close App Picker",
       "surface": "android",
@@ -2499,7 +2499,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 671,
+      "line": 680,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open App Picker",
       "surface": "android",
@@ -2507,7 +2507,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 676,
+      "line": 685,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Search apps",
       "surface": "android",
@@ -2515,7 +2515,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 679,
+      "line": 688,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Show System Apps",
       "surface": "android",
@@ -2523,7 +2523,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 687,
+      "line": 696,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No matching apps.",
       "surface": "android",
@@ -2531,7 +2531,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 698,
+      "line": 707,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Showing ${visibleApps.size} of ${apps.size}. Refine search for more.",
       "surface": "android",
@@ -2539,7 +2539,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 806,
+      "line": 842,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Phone Capabilities",
       "surface": "android",
@@ -2547,7 +2547,23 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 814,
+      "line": 851,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "Allow photo library access.",
+      "surface": "android",
+      "id": "native.android.7d943661c4341ef0"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 851,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "Selected or full photo access granted.",
+      "surface": "android",
+      "id": "native.android.8424669e7840699a"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 861,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "App list stays on this phone.",
       "surface": "android",
@@ -2555,7 +2571,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 814,
+      "line": 861,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw can list launcher-visible apps.",
       "surface": "android",
@@ -2563,7 +2579,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 825,
+      "line": 872,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Location",
       "surface": "android",
@@ -2571,7 +2587,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 828,
+      "line": 875,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "While Using",
       "surface": "android",
@@ -2579,7 +2595,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 865,
+      "line": 912,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connected",
       "surface": "android",
@@ -2587,7 +2603,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 865,
+      "line": 912,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Offline",
       "surface": "android",
@@ -2595,7 +2611,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 866,
+      "line": 913,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Not paired",
       "surface": "android",
@@ -2603,7 +2619,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 866,
+      "line": 913,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Online",
       "surface": "android",
@@ -2611,7 +2627,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 873,
+      "line": 920,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Reconnect",
       "surface": "android",
@@ -2619,7 +2635,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 874,
+      "line": 921,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Disconnect",
       "surface": "android",
@@ -2627,7 +2643,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 879,
+      "line": 926,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Clear this phone's saved gateway access and scan a fresh setup code.",
       "surface": "android",
@@ -2635,7 +2651,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 881,
+      "line": 928,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Pair New Gateway",
       "surface": "android",
@@ -2643,7 +2659,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 882,
+      "line": 929,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Setup Code",
       "surface": "android",
@@ -2651,7 +2667,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 886,
+      "line": 933,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Android can scan or paste an existing setup code, but this gateway does not expose setup-code generation to the app yet. Generate the QR/code on the gateway host with openclaw qr, then scan it here or paste the setup code below.",
       "surface": "android",
@@ -2659,7 +2675,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 895,
+      "line": 942,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connection Setup",
       "surface": "android",
@@ -2667,7 +2683,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 896,
+      "line": 943,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Setup code",
       "surface": "android",
@@ -2675,7 +2691,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 898,
+      "line": 945,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Host",
       "surface": "android",
@@ -2683,7 +2699,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 899,
+      "line": 946,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Port",
       "surface": "android",
@@ -2691,7 +2707,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 903,
+      "line": 950,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Local",
       "surface": "android",
@@ -2699,7 +2715,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 907,
+      "line": 954,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Token",
       "surface": "android",
@@ -2707,7 +2723,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 908,
+      "line": 955,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Bootstrap",
       "surface": "android",
@@ -2715,7 +2731,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 910,
+      "line": 957,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Password",
       "surface": "android",
@@ -2723,7 +2739,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 915,
+      "line": 962,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Save & Connect",
       "surface": "android",
@@ -2731,7 +2747,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 971,
+      "line": 1018,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Appearance",
       "surface": "android",
@@ -2739,7 +2755,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 982,
+      "line": 1029,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Theme",
       "surface": "android",
@@ -2747,7 +2763,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1004,
+      "line": 1051,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Ready",
       "surface": "android",
@@ -2755,7 +2771,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1031,
+      "line": 1078,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "About",
       "surface": "android",
@@ -2763,7 +2779,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1043,
+      "line": 1090,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Gateway",
       "surface": "android",
@@ -2771,7 +2787,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1045,
+      "line": 1092,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Runtime",
       "surface": "android",
@@ -2779,7 +2795,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1048,
+      "line": 1095,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Update",
       "surface": "android",
@@ -2787,7 +2803,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1083,
+      "line": 1130,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Check",
       "surface": "android",
@@ -2795,7 +2811,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1115,
+      "line": 1162,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Back",
       "surface": "android",
@@ -2803,7 +2819,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1180,
+      "line": 1227,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Sending",
       "surface": "android",
@@ -2811,7 +2827,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1189,
+      "line": 1236,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow Once",
       "surface": "android",
@@ -2819,7 +2835,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1189,
+      "line": 1236,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allowing",
       "surface": "android",
@@ -2827,7 +2843,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1197,
+      "line": 1244,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Always",
       "surface": "android",
@@ -2835,7 +2851,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1197,
+      "line": 1244,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Saving",
       "surface": "android",
@@ -2843,7 +2859,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1205,
+      "line": 1252,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Deny",
       "surface": "android",
@@ -2851,7 +2867,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1205,
+      "line": 1252,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Denying",
       "surface": "android",
@@ -2859,7 +2875,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1230,
+      "line": 1277,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Review",
       "surface": "android",
@@ -2867,7 +2883,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1255,
+      "line": 1302,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Issue",
       "surface": "android",
@@ -2875,7 +2891,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1286,
+      "line": 1333,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Default assistant",
       "surface": "android",
@@ -2883,7 +2899,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1288,
+      "line": 1335,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Default",
       "surface": "android",
@@ -2891,7 +2907,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1344,
+      "line": 1391,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Needs attention",
       "surface": "android",
@@ -2899,7 +2915,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1347,
+      "line": 1394,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Waiting ${minutes}m",
       "surface": "android",
@@ -2907,7 +2923,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1347,
+      "line": 1394,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Waiting for review",
       "surface": "android",
@@ -2915,7 +2931,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1375,
+      "line": 1422,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "${job.scheduleLabel} · ${formatCronWake(job.nextRunAtMs)} · ${job.promptPreview}",
       "surface": "android",
@@ -2923,7 +2939,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1382,
+      "line": 1429,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No limits reported",
       "surface": "android",
@@ -2931,7 +2947,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1403,
+      "line": 1450,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Off",
       "surface": "android",

--- a/apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/PermissionRequester.kt
@@ -278,6 +278,7 @@ class PermissionRequester internal constructor(
       Manifest.permission.READ_CALL_LOG -> "Read Call Log"
       Manifest.permission.ACTIVITY_RECOGNITION -> "Motion Activity"
       Manifest.permission.READ_MEDIA_IMAGES -> "Photos"
+      Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED -> "Photos"
       Manifest.permission.READ_EXTERNAL_STORAGE -> "Photos"
       else -> permission
     }

--- a/apps/android/app/src/main/java/ai/openclaw/app/PhotoPermissions.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/PhotoPermissions.kt
@@ -1,0 +1,23 @@
+package ai.openclaw.app
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.content.ContextCompat
+
+fun photoReadPermissionsForRequest(): List<String> =
+  when {
+    Build.VERSION.SDK_INT >= 34 ->
+      listOf(
+        Manifest.permission.READ_MEDIA_IMAGES,
+        Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED,
+      )
+    Build.VERSION.SDK_INT >= 33 -> listOf(Manifest.permission.READ_MEDIA_IMAGES)
+    else -> listOf(Manifest.permission.READ_EXTERNAL_STORAGE)
+  }
+
+fun hasPhotoReadPermission(context: Context): Boolean =
+  photoReadPermissionsForRequest().any { permission ->
+    ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
+  }

--- a/apps/android/app/src/main/java/ai/openclaw/app/PhotoPermissions.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/PhotoPermissions.kt
@@ -6,7 +6,7 @@ import android.content.pm.PackageManager
 import android.os.Build
 import androidx.core.content.ContextCompat
 
-fun photoReadPermissionsForRequest(): List<String> =
+internal fun photoReadPermissionsForRequest(): List<String> =
   when {
     Build.VERSION.SDK_INT >= 34 ->
       listOf(
@@ -17,7 +17,7 @@ fun photoReadPermissionsForRequest(): List<String> =
     else -> listOf(Manifest.permission.READ_EXTERNAL_STORAGE)
   }
 
-fun hasPhotoReadPermission(context: Context): Boolean =
+internal fun hasPhotoReadPermission(context: Context): Boolean =
   photoReadPermissionsForRequest().any { permission ->
     ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
   }

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/DeviceHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/DeviceHandler.kt
@@ -3,6 +3,7 @@ package ai.openclaw.app.node
 import ai.openclaw.app.BuildConfig
 import ai.openclaw.app.SensitiveFeatureConfig
 import ai.openclaw.app.gateway.GatewaySession
+import ai.openclaw.app.hasPhotoReadPermission
 import android.Manifest
 import android.annotation.SuppressLint
 import android.app.ActivityManager
@@ -322,11 +323,8 @@ class DeviceHandler private constructor(
     val photosGranted =
       if (!photosEnabled) {
         false
-      } else if (Build.VERSION.SDK_INT >= 33) {
-        // Android 13 split media permissions; earlier versions use external storage.
-        hasPermission(Manifest.permission.READ_MEDIA_IMAGES)
       } else {
-        hasPermission(Manifest.permission.READ_EXTERNAL_STORAGE)
+        hasPhotoReadPermission(appContext)
       }
     val motionGranted = hasPermission(Manifest.permission.ACTIVITY_RECOGNITION)
     val notificationsGranted =

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/PhotosHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/PhotosHandler.kt
@@ -1,17 +1,15 @@
 package ai.openclaw.app.node
 
 import ai.openclaw.app.gateway.GatewaySession
-import android.Manifest
+import ai.openclaw.app.hasPhotoReadPermission
 import android.content.ContentResolver
 import android.content.ContentUris
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.net.Uri
-import android.os.Build
 import android.os.Bundle
 import android.provider.MediaStore
-import androidx.core.content.ContextCompat
 import androidx.core.graphics.scale
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonPrimitive
@@ -56,16 +54,7 @@ internal interface PhotosDataSource {
 }
 
 private object SystemPhotosDataSource : PhotosDataSource {
-  /** Checks the API-specific image read permission used by MediaStore image access. */
-  override fun hasPermission(context: Context): Boolean {
-    val permission =
-      if (Build.VERSION.SDK_INT >= 33) {
-        Manifest.permission.READ_MEDIA_IMAGES
-      } else {
-        Manifest.permission.READ_EXTERNAL_STORAGE
-      }
-    return ContextCompat.checkSelfPermission(context, permission) == android.content.pm.PackageManager.PERMISSION_GRANTED
-  }
+  override fun hasPermission(context: Context): Boolean = hasPhotoReadPermission(context)
 
   override fun latest(
     context: Context,

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
@@ -6,7 +6,9 @@ import ai.openclaw.app.LocationMode
 import ai.openclaw.app.MainViewModel
 import ai.openclaw.app.R
 import ai.openclaw.app.SensitiveFeatureConfig
+import ai.openclaw.app.hasPhotoReadPermission
 import ai.openclaw.app.node.DeviceNotificationListenerService
+import ai.openclaw.app.photoReadPermissionsForRequest
 import ai.openclaw.app.ui.design.ClawDesignTheme
 import ai.openclaw.app.ui.design.ClawErrorState
 import ai.openclaw.app.ui.design.ClawListItem
@@ -1378,8 +1380,8 @@ private fun rememberPermissionState(
   var locationGranted by rememberSaveable {
     mutableStateOf(hasPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) || hasPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION))
   }
-  val photosPermission = if (Build.VERSION.SDK_INT >= 33) Manifest.permission.READ_MEDIA_IMAGES else Manifest.permission.READ_EXTERNAL_STORAGE
-  var photosGranted by rememberSaveable { mutableStateOf(hasPermission(context, photosPermission)) }
+  val photosPermissions = photoReadPermissionsForRequest()
+  var photosGranted by rememberSaveable { mutableStateOf(hasPhotoReadPermission(context)) }
   var contactsGranted by rememberSaveable { mutableStateOf(hasPermission(context, Manifest.permission.READ_CONTACTS)) }
   var calendarGranted by rememberSaveable { mutableStateOf(hasPermission(context, Manifest.permission.READ_CALENDAR)) }
   var notificationsGranted by rememberSaveable {
@@ -1426,7 +1428,7 @@ private fun rememberPermissionState(
         permissions[Manifest.permission.ACCESS_FINE_LOCATION] == true ||
         permissions[Manifest.permission.ACCESS_COARSE_LOCATION] == true ||
         locationGranted
-      photosGranted = permissions[photosPermission] ?: photosGranted
+      photosGranted = hasPhotoReadPermission(context) || photosPermissions.any { permissions[it] == true }
       contactsGranted = permissions[Manifest.permission.READ_CONTACTS] ?: contactsGranted
       calendarGranted = permissions[Manifest.permission.READ_CALENDAR] ?: calendarGranted
       notificationsGranted =
@@ -1459,7 +1461,7 @@ private fun rememberPermissionState(
       },
       if (photosAvailable) {
         PermissionRowModel("Photos", "Attach photos and media", Icons.Default.Image, photosGranted) {
-          request(photosPermission)
+          request(*photosPermissions.toTypedArray())
         }
       } else {
         null

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
@@ -9,8 +9,11 @@ import ai.openclaw.app.GatewayUsageProviderSummary
 import ai.openclaw.app.LocationMode
 import ai.openclaw.app.MainViewModel
 import ai.openclaw.app.NotificationPackageFilterMode
+import ai.openclaw.app.SensitiveFeatureConfig
 import ai.openclaw.app.chat.ChatPendingToolCall
+import ai.openclaw.app.hasPhotoReadPermission
 import ai.openclaw.app.node.DeviceNotificationListenerService
+import ai.openclaw.app.photoReadPermissionsForRequest
 import ai.openclaw.app.ui.design.ClawDetailRow
 import ai.openclaw.app.ui.design.ClawIconBadge
 import ai.openclaw.app.ui.design.ClawListPanel
@@ -32,6 +35,7 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.media.AudioManager
 import android.media.ToneGenerator
+import android.net.Uri
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
@@ -68,6 +72,7 @@ import androidx.compose.material.icons.filled.Bolt
 import androidx.compose.material.icons.filled.CameraAlt
 import androidx.compose.material.icons.filled.Cloud
 import androidx.compose.material.icons.filled.GraphicEq
+import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.Lock
@@ -84,6 +89,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -98,6 +104,9 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 
 /**
  * Detail routes reachable from the Android settings home surface.
@@ -749,12 +758,16 @@ private fun PhoneCapabilitiesScreen(
   onBack: () -> Unit,
 ) {
   val context = LocalContext.current
+  val lifecycleOwner = LocalLifecycleOwner.current
   val cameraEnabled by viewModel.cameraEnabled.collectAsState()
   val locationMode by viewModel.locationMode.collectAsState()
   val locationPreciseEnabled by viewModel.locationPreciseEnabled.collectAsState()
   val preventSleep by viewModel.preventSleep.collectAsState()
   val canvasDebugStatusEnabled by viewModel.canvasDebugStatusEnabled.collectAsState()
   val installedAppsSharingEnabled by viewModel.installedAppsSharingEnabled.collectAsState()
+  val photosAvailable = remember { SensitiveFeatureConfig.photosEnabled }
+  val photoPermissions = remember { photoReadPermissionsForRequest() }
+  var photosGranted by remember { mutableStateOf(photosAvailable && hasPhotoReadPermission(context)) }
   val cameraPermissionLauncher =
     rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
       viewModel.setCameraEnabled(granted)
@@ -765,6 +778,21 @@ private fun PhoneCapabilitiesScreen(
       viewModel.setLocationMode(if (granted) LocationMode.WhileUsing else LocationMode.Off)
       viewModel.setLocationPreciseEnabled(grants[Manifest.permission.ACCESS_FINE_LOCATION] == true)
     }
+  val photoPermissionLauncher =
+    rememberLauncherForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) {
+      photosGranted = photosAvailable && hasPhotoReadPermission(context)
+    }
+
+  DisposableEffect(lifecycleOwner, context, photosAvailable) {
+    val observer =
+      LifecycleEventObserver { _, event ->
+        if (event == Lifecycle.Event.ON_RESUME) {
+          photosGranted = photosAvailable && hasPhotoReadPermission(context)
+        }
+      }
+    lifecycleOwner.lifecycle.addObserver(observer)
+    onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+  }
 
   fun setCameraAccess(checked: Boolean) {
     if (!checked) {
@@ -803,12 +831,31 @@ private fun PhoneCapabilitiesScreen(
     }
   }
 
+  fun setPhotoAccess(checked: Boolean) {
+    if (checked && !hasPhotoReadPermission(context)) {
+      photoPermissionLauncher.launch(photoPermissions.toTypedArray())
+    } else {
+      openAppPermissionSettings(context)
+    }
+  }
+
   SettingsDetailFrame(title = "Phone Capabilities", subtitle = "Choose what this phone can share.", icon = Icons.AutoMirrored.Filled.ScreenShare, onBack = onBack) {
     SettingsTogglePanel(
       rows =
-        listOf(
+        listOfNotNull(
           SettingsToggleRow("Camera", "Allow camera tools when requested.", Icons.Default.CameraAlt, cameraEnabled, ::setCameraAccess),
           SettingsToggleRow("Precise Location", "Share precise location while location is enabled.", Icons.Default.LocationOn, locationPreciseEnabled, ::setPreciseLocation),
+          if (photosAvailable) {
+            SettingsToggleRow(
+              "Photos",
+              if (photosGranted) "Selected or full photo access granted." else "Allow photo library access.",
+              Icons.Default.Image,
+              photosGranted,
+              ::setPhotoAccess,
+            )
+          } else {
+            null
+          },
           SettingsToggleRow(
             "Installed Apps",
             if (installedAppsSharingEnabled) "OpenClaw can list launcher-visible apps." else "App list stays on this phone.",
@@ -1564,5 +1611,14 @@ private fun hasLocationPermission(context: Context): Boolean =
 
 private fun openNotificationListenerSettings(context: Context) {
   val intent = Intent(Settings.ACTION_NOTIFICATION_LISTENER_SETTINGS).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+  context.startActivity(intent)
+}
+
+private fun openAppPermissionSettings(context: Context) {
+  val intent =
+    Intent(
+      Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+      Uri.fromParts("package", context.packageName, null),
+    ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
   context.startActivity(intent)
 }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsSheet.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsSheet.kt
@@ -5,10 +5,8 @@ import ai.openclaw.app.LocationMode
 import ai.openclaw.app.MainViewModel
 import ai.openclaw.app.NotificationPackageFilterMode
 import ai.openclaw.app.SensitiveFeatureConfig
-import ai.openclaw.app.hasPhotoReadPermission
 import ai.openclaw.app.node.DeviceNotificationListenerService
 import ai.openclaw.app.normalizeLocalHourMinute
-import ai.openclaw.app.photoReadPermissionsForRequest
 import android.Manifest
 import android.app.role.RoleManager
 import android.content.Context
@@ -215,7 +213,12 @@ fun SettingsSheet(viewModel: MainViewModel) {
     }
   val callLogPermissionAvailable = remember { SensitiveFeatureConfig.callLogEnabled }
   val photosPermissionAvailable = remember { SensitiveFeatureConfig.photosEnabled }
-  val photosPermissions = photoReadPermissionsForRequest()
+  val photosPermission =
+    if (Build.VERSION.SDK_INT >= 33) {
+      Manifest.permission.READ_MEDIA_IMAGES
+    } else {
+      Manifest.permission.READ_EXTERNAL_STORAGE
+    }
   val motionPermissionRequired = true
   val motionAvailable = remember(context) { hasMotionCapabilities(context) }
 
@@ -247,15 +250,15 @@ fun SettingsSheet(viewModel: MainViewModel) {
     remember {
       mutableStateOf(
         if (photosPermissionAvailable) {
-          hasPhotoReadPermission(context)
+          ContextCompat.checkSelfPermission(context, photosPermission) == PackageManager.PERMISSION_GRANTED
         } else {
           false
         },
       )
     }
   val photosPermissionLauncher =
-    rememberLauncherForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { permissions ->
-      photosPermissionGranted = hasPhotoReadPermission(context) || photosPermissions.any { permissions[it] == true }
+    rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
+      photosPermissionGranted = granted
     }
 
   var contactsPermissionGranted by
@@ -354,7 +357,7 @@ fun SettingsSheet(viewModel: MainViewModel) {
           installedNotificationApps = queryInstalledApps(context, notificationForwardingPackages)
           photosPermissionGranted =
             if (photosPermissionAvailable) {
-              hasPhotoReadPermission(context)
+              ContextCompat.checkSelfPermission(context, photosPermission) == PackageManager.PERMISSION_GRANTED
             } else {
               false
             }
@@ -1001,11 +1004,7 @@ fun SettingsSheet(viewModel: MainViewModel) {
                     if (photosPermissionGranted) {
                       openAppSettings(context)
                     } else {
-                      photosPermissionLauncher.launch(
-                        photosPermissions
-                          .filterNot { ContextCompat.checkSelfPermission(context, it) == PackageManager.PERMISSION_GRANTED }
-                          .toTypedArray(),
-                      )
+                      photosPermissionLauncher.launch(photosPermission)
                     }
                   },
                   colors = settingsPrimaryButtonColors(),

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsSheet.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsSheet.kt
@@ -5,8 +5,10 @@ import ai.openclaw.app.LocationMode
 import ai.openclaw.app.MainViewModel
 import ai.openclaw.app.NotificationPackageFilterMode
 import ai.openclaw.app.SensitiveFeatureConfig
+import ai.openclaw.app.hasPhotoReadPermission
 import ai.openclaw.app.node.DeviceNotificationListenerService
 import ai.openclaw.app.normalizeLocalHourMinute
+import ai.openclaw.app.photoReadPermissionsForRequest
 import android.Manifest
 import android.app.role.RoleManager
 import android.content.Context
@@ -213,12 +215,7 @@ fun SettingsSheet(viewModel: MainViewModel) {
     }
   val callLogPermissionAvailable = remember { SensitiveFeatureConfig.callLogEnabled }
   val photosPermissionAvailable = remember { SensitiveFeatureConfig.photosEnabled }
-  val photosPermission =
-    if (Build.VERSION.SDK_INT >= 33) {
-      Manifest.permission.READ_MEDIA_IMAGES
-    } else {
-      Manifest.permission.READ_EXTERNAL_STORAGE
-    }
+  val photosPermissions = photoReadPermissionsForRequest()
   val motionPermissionRequired = true
   val motionAvailable = remember(context) { hasMotionCapabilities(context) }
 
@@ -250,15 +247,15 @@ fun SettingsSheet(viewModel: MainViewModel) {
     remember {
       mutableStateOf(
         if (photosPermissionAvailable) {
-          ContextCompat.checkSelfPermission(context, photosPermission) == PackageManager.PERMISSION_GRANTED
+          hasPhotoReadPermission(context)
         } else {
           false
         },
       )
     }
   val photosPermissionLauncher =
-    rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
-      photosPermissionGranted = granted
+    rememberLauncherForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { permissions ->
+      photosPermissionGranted = hasPhotoReadPermission(context) || photosPermissions.any { permissions[it] == true }
     }
 
   var contactsPermissionGranted by
@@ -357,7 +354,7 @@ fun SettingsSheet(viewModel: MainViewModel) {
           installedNotificationApps = queryInstalledApps(context, notificationForwardingPackages)
           photosPermissionGranted =
             if (photosPermissionAvailable) {
-              ContextCompat.checkSelfPermission(context, photosPermission) == PackageManager.PERMISSION_GRANTED
+              hasPhotoReadPermission(context)
             } else {
               false
             }
@@ -1004,7 +1001,11 @@ fun SettingsSheet(viewModel: MainViewModel) {
                     if (photosPermissionGranted) {
                       openAppSettings(context)
                     } else {
-                      photosPermissionLauncher.launch(photosPermission)
+                      photosPermissionLauncher.launch(
+                        photosPermissions
+                          .filterNot { ContextCompat.checkSelfPermission(context, it) == PackageManager.PERMISSION_GRANTED }
+                          .toTypedArray(),
+                      )
                     }
                   },
                   colors = settingsPrimaryButtonColors(),

--- a/apps/android/app/src/test/java/ai/openclaw/app/PhotoPermissionsTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/PhotoPermissionsTest.kt
@@ -1,0 +1,48 @@
+package ai.openclaw.app
+
+import android.Manifest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+class PhotoPermissionsTest {
+  @Test
+  @Config(sdk = [34])
+  fun api34RequestsFullAndSelectedPhotoPermissions() {
+    assertEquals(
+      listOf(
+        Manifest.permission.READ_MEDIA_IMAGES,
+        Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED,
+      ),
+      photoReadPermissionsForRequest(),
+    )
+  }
+
+  @Test
+  @Config(sdk = [34])
+  fun api34TreatsSelectedPhotoPermissionAsPhotoAccess() {
+    val app = RuntimeEnvironment.getApplication()
+    shadowOf(app).grantPermissions(Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED)
+
+    assertTrue(hasPhotoReadPermission(app))
+  }
+
+  @Test
+  @Config(sdk = [34])
+  fun api34ReportsNoPhotoAccessWhenNeitherFullNorSelectedPermissionIsGranted() {
+    assertFalse(hasPhotoReadPermission(RuntimeEnvironment.getApplication()))
+  }
+
+  @Test
+  @Config(sdk = [33])
+  fun api33RequestsImagePermissionOnly() {
+    assertEquals(listOf(Manifest.permission.READ_MEDIA_IMAGES), photoReadPermissionsForRequest())
+  }
+}


### PR DESCRIPTION
## What Problem This Solves

Android 14 partial photo access can grant `READ_MEDIA_VISUAL_USER_SELECTED` without granting full `READ_MEDIA_IMAGES`. The Android app declared the selected-photo permission, but runtime checks and UI state only looked for the full image permission, so selected-only access still appeared denied and `photos.latest` could reject usable MediaStore access.

## Why This Change Was Made

This adds one shared photo permission helper for the Android app. API 34+ now requests both full-image and selected-photo permissions, and permission checks treat either grant as photo access. The helper is used by `photos.latest`, `device.permissions`, onboarding, and settings so the status and request paths stay aligned.

## User Impact

Users who choose Android's selected-photos option can use the Android Photos capability with the selected library items instead of being treated as unpermitted. Settings/onboarding also reflect selected-photo access as granted and let users manage it afterward.

## Evidence

Prepared on exact head `db11e9f0f3e24cf33d1e2eb31e5b468666b4204e`.

| Before | After |
| --- | --- |
| Current `main` had no Photos state on the reachable Phone Capabilities screen. ![Before: Phone Capabilities without Photos](https://github.com/user-attachments/assets/da59fa6f-b071-4ae7-882b-412925a79178) | The selected-only grant is recognized and enabled. ![After: selected photo access enabled](https://github.com/user-attachments/assets/dec67d35-2388-4e09-a328-a04cb62d18a3) |

Android 16 emulator state: `READ_MEDIA_VISUAL_USER_SELECTED` granted; `READ_MEDIA_IMAGES` denied. Tapping the enabled Photos row opened Android app-info for permission management.

Commands run:

```text
ANDROID_HOME="$HOME/Library/Android/sdk" ANDROID_SDK_ROOT="$HOME/Library/Android/sdk" ./gradlew :app:testThirdPartyDebugUnitTest --tests ai.openclaw.app.PhotoPermissionsTest --tests ai.openclaw.app.node.PhotosHandlerTest --tests ai.openclaw.app.node.DeviceHandlerTest --tests ai.openclaw.app.node.InvokeDispatcherTest :app:ktlintCheck :app:assembleThirdPartyDebug
node --import tsx scripts/native-app-i18n.ts check
git diff --check
.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
```

Results: focused permission/handler/dispatcher tests, ktlint, third-party debug assembly, native i18n validation, diff validation, and fresh autoreview passed. Exact-head GitHub CI passed 48/48 jobs: https://github.com/openclaw/openclaw/actions/runs/28576179076.

Known proof boundary: the emulator proves selected-only grant recognition and the reachable settings interaction. `photos.latest` behavior is covered by focused handler/dispatcher tests rather than a live MediaStore result.
