### PR TITLE
fix(net-policy): preserve repeated secret query params

### DIFF
--- a/packages/net-policy/src/redact-sensitive-url.test.ts
+++ b/packages/net-policy/src/redact-sensitive-url.test.ts
@@ -28,6 +28,12 @@ describe("redactSensitiveUrl", () => {
     ).toBe("https://example.com/mcp?client_se%E2%80%8Bcret=***&safe=value");
   });
 
+  it("preserves repeated sensitive query params while redacting each value", () => {
+    expect(redactSensitiveUrl("https://example.com/mcp?token=one&safe=value&token=two")).toBe(
+      "https://example.com/mcp?token=***&safe=value&token=***",
+    );
+  });
+
   it("redacts encoded sensitive query names with decoded whitespace and control separators", () => {
     expect(
       redactSensitiveUrl("https://example.com/mcp?client%5Fse%20cret=space&client%5Fse%00cret=nul"),

--- a/packages/net-policy/src/redact-sensitive-url.ts
+++ b/packages/net-policy/src/redact-sensitive-url.ts
@@ -87,11 +87,19 @@ export function redactSensitiveUrl(value: string): string {
       parsed.password = parsed.password ? "***" : "";
       mutated = true;
     }
-    for (const key of Array.from(parsed.searchParams.keys())) {
+    const queryParams: Array<[string, string]> = [];
+    let queryMutated = false;
+    for (const [key, paramValue] of parsed.searchParams) {
       if (isSensitiveUrlQueryParamName(key)) {
-        parsed.searchParams.set(key, "***");
+        queryParams.push([key, "***"]);
+        queryMutated = true;
         mutated = true;
+      } else {
+        queryParams.push([key, paramValue]);
       }
+    }
+    if (queryMutated) {
+      parsed.search = new URLSearchParams(queryParams).toString();
     }
     return mutated ? parsed.toString() : value;
   } catch {


### PR DESCRIPTION
## What Problem This Solves
Fixes an issue where URL redaction for repeated sensitive query parameters would collapse duplicate entries into one redacted parameter, losing the original URL shape in logs and configuration display.

## Why This Change Was Made
`redactSensitiveUrl` now rebuilds query parameters only when a sensitive query key is redacted, preserving each original query entry in order while replacing sensitive values with `***`. This keeps duplicate secret-bearing query params visible as redacted entries without changing unrelated redaction behavior.

## User Impact
Users and operators inspecting redacted URLs can see the same query parameter structure while secret values remain hidden, including URLs that repeat token-like parameters.

## Evidence
- `node scripts/run-vitest.mjs packages/net-policy/src/redact-sensitive-url.test.ts packages/net-policy/src/ip.test.ts packages/net-policy/src/ipv4.test.ts`
- `pnpm exec oxfmt --check --threads=1 packages/net-policy/src/redact-sensitive-url.ts packages/net-policy/src/redact-sensitive-url.test.ts`
- `node scripts/run-oxlint.mjs packages/net-policy/src/redact-sensitive-url.ts packages/net-policy/src/redact-sensitive-url.test.ts`
- `pnpm --dir packages/net-policy build`

AI-assisted with Codex. I understand the change: it preserves duplicate query parameters while replacing each sensitive value with `***`.

Known proof gap: the repo-recommended Crabbox changed-check wrapper failed before running checks in this environment with `[crabbox] selected binary failed basic --version/--help sanity checks`.