### PR TITLE
fix(reply): suppress tool-error progress delivery when messages.suppressToolErrors is set

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -4262,6 +4262,39 @@ describe("dispatchReplyFromConfig", () => {
     expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
   });
 
+  it("suppresses tool error payloads when messages.suppressToolErrors is enabled", async () => {
+    setNoAbort();
+    const dispatcher = createDispatcher();
+    const onToolResult = vi.fn();
+    const ctx = buildTestCtx({
+      Provider: "telegram",
+      ChatType: "direct",
+      SessionKey: "agent:main:main",
+    });
+
+    const replyResolver = async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+      await opts?.onToolResult?.({ text: "⚠️ 🛠️ sqlite3 failed", isError: true });
+      return { text: "handled" } satisfies ReplyPayload;
+    };
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg: {
+        agents: { defaults: { verboseDefault: "on" } },
+        messages: {
+          suppressToolErrors: true,
+        },
+      } as OpenClawConfig,
+      dispatcher,
+      replyResolver,
+      replyOptions: { onToolResult },
+    });
+
+    expect(onToolResult).not.toHaveBeenCalled();
+    expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "handled" });
+  });
+
   it("keeps message-tool-only failed tool output compact in normal verbose mode", async () => {
     setNoAbort();
     sessionStoreMocks.currentEntry = {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -3128,6 +3128,13 @@ export async function dispatchReplyFromConfig(
                 markInboundDedupeReplayUnsafe();
                 // Buffered commentary preceded this tool; land it before the summary.
                 await flushPendingCommentaryProgress();
+                // When the operator opts into messages.suppressToolErrors, never
+                // surface tool-error tool-result payloads as channel progress,
+                // regardless of source delivery mode. payloads.ts already drops
+                // the warning text; this drops the visible progress delivery too.
+                if (payload.isError === true && replyConfig.messages?.suppressToolErrors === true) {
+                  return;
+                }
                 const isFastModeAutoProgress = isFastModeAutoProgressPayload(payload);
                 const isForcedToolProgress =
                   shouldDeliverForcedToolProgressDespiteSourceSuppression();


### PR DESCRIPTION
## Replacement for #88898

This carries the same narrow fix as #88898, rebased onto current `main`, from a Moeed-owned fork branch that agents can update if follow-up is needed. The original PR remains blocked because its contributor-fork branch is conflicting and this account has no write access to that fork or upstream.

Local verification on this replacement branch:

- `git diff --check` passed
- conflict-marker scan passed
- outgoing diff/touched-file secret-pattern scan passed
- focused Vitest command could not run in the fresh clone because `node_modules` is not installed; upstream CI is expected to provide full test proof

## Summary

`messages.suppressToolErrors` is an existing user-facing config knob that hides tool-error noise from chat (landed in #16620 / #81561). Today it only drops the warning TEXT inside `src/auto-reply/reply/payloads.ts`. The error tool-result payload is still delivered as channel progress through the `onToolResult` path in `src/auto-reply/reply/dispatch-from-config.ts` unless `sourceReplyDeliveryMode === "message_tool_only"`. Operators who set `messages.suppressToolErrors: true` therefore still see tool-error noise as progress payloads, contradicting the documented behavior of the knob.

## Change

Add a config-gated early-return inside `onToolResult` in `src/auto-reply/reply/dispatch-from-config.ts` that drops the visible progress delivery when `payload.isError === true` and `replyConfig.messages?.suppressToolErrors === true`, regardless of `sourceReplyDeliveryMode`. Per review feedback, the gate is positioned before the optional source-delivery callback, so a suppressed error payload never reaches progress delivery or the source callback. A focused regression test in `src/auto-reply/reply/dispatch-from-config.test.ts` exercises the suppressed-error path through `dispatchReplyFromConfig` and asserts neither `onToolResult` nor `sendToolResult` is called while the final reply still ships.

## Real behavior proof

Behavior addressed: when `messages.suppressToolErrors: true`, tool-result payloads carrying `isError: true` must not be delivered as channel progress. Non-error tool results and the final reply must continue to flow normally. When `suppressToolErrors` is unset or false, tool-error progress must still deliver (no opt-in, no behavior change).

Real environment tested: live deployed openclaw gateway on rh-bot.lan, pid 71842, build SHA 23804e610c (upgrade-v2026.5.28 includes this commit; deployed bundle `dist/dispatch-D9SNCck_.js` contains the new gate at line 1458).

Exact steps or command run after this patch: copied `/tmp/proof-toolerr-amittell.mjs` to rh-bot.lan and ran `node /tmp/proof-toolerr-amittell.mjs` against the deployed bundle. The script imports `dispatchReplyFromConfig` from the deployed `dist/dispatch-D9SNCck_.js` and `finalizeInboundContext` from the deployed `dist/inbound-context-CbkangX1.js`, builds a minimal telegram-direct ctx, a dispatcher with spy counters on `sendToolResult` / `sendFinalReply`, and a `replyResolver` that fires `onToolResult` with the toggled `isError` flag before returning a final payload. Three scenarios were exercised:

  A. `messages.suppressToolErrors: true` + `isError: true`
  B. `messages.suppressToolErrors: true` + `isError: false`
  C. `messages.suppressToolErrors: false` + `isError: true`

`agents.defaults.verboseDefault: "on"` was set so the verbose-progress gate did not mask the assertion.

Evidence after fix: deployed bundle gate verified at `/Users/alexm/.openclaw/openclaw/dist/dispatch-D9SNCck_.js:1458` as `if (payload.isError === true && replyConfig.messages?.suppressToolErrors === true) return;`. Script output:

```
--- scenario A: suppressToolErrors=true, isError=true (gate should drop tool progress)
    calls: {"sendToolResult":0,"sendBlockReply":0,"sendFinalReply":1}
PASS A sendToolResult NOT called (tool-error progress dropped)
PASS A sendFinalReply called once (final still delivered)
--- scenario B: suppressToolErrors=true, isError=false (preserve normal delivery)
    calls: {"sendToolResult":1,"sendBlockReply":0,"sendFinalReply":1}
PASS B sendToolResult called >=1 (non-error tool result delivered normally)
PASS B sendFinalReply called once
--- scenario C: suppressToolErrors=false, isError=true (preserve normal delivery, no opt-in)
    calls: {"sendToolResult":1,"sendBlockReply":0,"sendFinalReply":1}
PASS C sendToolResult called >=1 (no opt-in, tool error still delivered)
PASS C sendFinalReply called once
OVERALL: PASS
```

Observed result after fix: with `messages.suppressToolErrors: true` and `isError: true`, the deployed bundle dropped the tool-result progress delivery (`sendToolResult` count was 0) while the final reply still shipped (`sendFinalReply` count was 1). With either `suppressToolErrors: true` + non-error payload or `suppressToolErrors: false` + error payload, tool-result delivery was preserved (`sendToolResult` count was 1). Existing behavior is preserved outside the explicit opt-in.

What was not tested: an end-to-end Telegram round-trip through the live channel adapter and a paired check of channels that route through `message_tool_only` source-delivery (which the existing pre-fix path already covered). The change is purely a guard added to the dispatch-site progress path; channel adapter behavior is unchanged.


