### PR TITLE
fix(imessage): drop dangling surrogates in debounced merge preview and probe snippet

### DIFF
--- a/extensions/imessage/src/monitor/monitor-provider.truncation.test.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.truncation.test.ts
@@ -1,0 +1,37 @@
+// Imessage tests cover the UTF-16-safe debounced-merge preview in
+// monitor-provider.ts:731. Verifies that `sliceUtf16Safe` drops a surrogate
+// pair that straddles the 50-char truncation boundary instead of leaving a
+// lone high-surrogate half in the preview, and that the existing conditional
+// `"..."` ellipsis at L732 still fires correctly when the original input
+// exceeded the cap.
+import { describe, expect, it } from "vitest";
+import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+
+describe("monitor-provider debounced-merge preview truncation", () => {
+  const emoji = "🎉";
+
+  it("sliceUtf16Safe drops a trailing surrogate straddling the 50-char boundary", () => {
+    const input = "a".repeat(49) + emoji;
+    const out = sliceUtf16Safe(input, 0, 50);
+    expect(out.length).toBe(49);
+    expect(out.charCodeAt(out.length - 1)).toBeLessThan(0xd800);
+  });
+
+  it("ellipsis marker is appended when the original text exceeded 50 chars (no surrogate regression)", () => {
+    const input = "a".repeat(60);
+    const out = sliceUtf16Safe(input, 0, 50);
+    const ellipsis = input.length > 50 ? "..." : "";
+    expect(out + ellipsis).toBe("a".repeat(50) + "...");
+  });
+
+  it("empty input stays empty", () => {
+    expect(sliceUtf16Safe("", 0, 50)).toBe("");
+  });
+
+  it("emoji fully inside the window is preserved (no false-positive drops)", () => {
+    const input = emoji + "a".repeat(50);
+    const out = sliceUtf16Safe(input, 0, 50);
+    expect(out.startsWith(emoji)).toBe(true);
+    expect(out.length).toBe(50);
+  });
+});

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -45,7 +45,10 @@ import {
   resolveSendPolicy,
   resolveStorePath,
 } from "openclaw/plugin-sdk/session-store-runtime";
-import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+import {
+  sliceUtf16Safe,
+  truncateUtf16Safe,
+} from "openclaw/plugin-sdk/text-utility-runtime";
 import { waitForTransportReady } from "openclaw/plugin-sdk/transport-ready-runtime";
 import { resolveIMessageAccount } from "../accounts.js";
 import { pollPendingIMessageApprovalReactions } from "../approval-reaction-poller.js";
@@ -728,7 +731,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       const combined = combineIMessagePayloads(messages);
       if (shouldLogVerbose()) {
         const text = combined.text ?? "";
-        const preview = text.slice(0, 50);
+        const preview = sliceUtf16Safe(text, 0, 50);
         const ellipsis = text.length > 50 ? "..." : "";
         logVerbose(
           `[imessage] merged ${entries.length} debounced messages: "${preview}${ellipsis}"`,

--- a/extensions/imessage/src/probe.test.ts
+++ b/extensions/imessage/src/probe.test.ts
@@ -1,5 +1,6 @@
 // Imessage tests cover probe plugin behavior.
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import {
   clearCachedIMessagePrivateApiStatus,
   getCachedIMessagePrivateApiStatus,
@@ -133,5 +134,37 @@ describe("iMessage private API status cache", () => {
     );
 
     expect(getCachedIMessagePrivateApiStatus("imsg-overflow-private-clock")).toBeUndefined();
+  });
+});
+
+// Verifies the `lines[0]?.slice(0, 120)` snippet site in probe.ts:161 drops a
+// surrogate pair that straddles the truncation boundary instead of leaving a
+// lone high-surrogate half in the diagnostic preview.
+describe("probe first-line snippet truncation", () => {
+  const emoji = "🎉";
+
+  it("truncateUtf16Safe drops a trailing surrogate straddling the 120-char boundary", () => {
+    const input = "a".repeat(119) + emoji;
+    const out = truncateUtf16Safe(input, 120);
+    expect(out.length).toBe(119);
+    expect(out.charCodeAt(out.length - 1)).toBeLessThan(0xd800);
+  });
+
+  it("plain ASCII under the cap passes through unchanged", () => {
+    const input = "x".repeat(50);
+    expect(truncateUtf16Safe(input, 120)).toBe(input);
+  });
+
+  it("undefined input is preserved (no truncation attempted)", () => {
+    const lines: string[] = [];
+    const snippet = lines[0] ? truncateUtf16Safe(lines[0], 120) : undefined;
+    expect(snippet).toBeUndefined();
+  });
+
+  it("emoji fully inside the 120-char window is preserved", () => {
+    const input = emoji + "a".repeat(120);
+    const out = truncateUtf16Safe(input, 120);
+    expect(out.startsWith(emoji)).toBe(true);
+    expect(out.length).toBe(120);
   });
 });

--- a/extensions/imessage/src/probe.ts
+++ b/extensions/imessage/src/probe.ts
@@ -13,6 +13,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeStringEntries,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { createIMessageRpcClient } from "./client.js";
 import { DEFAULT_IMESSAGE_PROBE_TIMEOUT_MS } from "./constants.js";
 import {
@@ -158,7 +159,7 @@ function parseStatusPayload(stdout: string): {
   // No JSONL line parsed. Surface a small snippet of the first non-empty
   // line so the operator can grep imsg release notes if the status output
   // schema has shifted.
-  const snippet = lines[0]?.slice(0, 120);
+  const snippet = lines[0] ? truncateUtf16Safe(lines[0], 120) : undefined;
   return { payload: null, firstLineSnippet: snippet };
 }
 


### PR DESCRIPTION
## What Problem This Solves

`extensions/imessage/src/monitor/monitor-provider.ts:731` and `extensions/imessage/src/probe.ts:161` use raw `.slice(0, N)` on inbound message bodies for debug-log previews and JSONL-parse-failure diagnostics. When an emoji or other astral character straddles position `N`, the slice keeps only the high-surrogate half (`0xD83C` for `🎉`), producing malformed UTF-16 (`?`/`�`) in verbose logs.

Note: `extensions/imessage/src/monitor/coalesce.ts:139` already uses `sliceUtf16Safe` (commit `352f47f888` by llagy009 on 2026-06-29). This PR covers the two remaining iMessage sites that still used raw `.slice()`.

## Why This Change Was Made

The plugin SDK provides `sliceUtf16Safe` / `truncateUtf16Safe` in `openclaw/plugin-sdk/text-utility-runtime` for exactly this pattern. Alix-007 landed the same fix for Twitch (#98008) and Signal (#97982); their PR bodies explicitly list "Discord, Feishu, Telegram, Signal, Mattermost, Slack" as already using these helpers. iMessage had one site fixed (coalesce.ts) and two still raw; this PR closes the remaining gap.

The two call sites map to the two helpers:
- `monitor-provider.ts:731` — `text.slice(0, 50)` followed by a conditional `"..."` ellipsis at L732. The conditional `text.length > 50` must keep firing against the original `text.length`, so the safe slice returns 49 when a lone surrogate is dropped (one code unit less than `text.length`). → `sliceUtf16Safe(text, 0, 50)` keeps the existing ellipsis logic intact.
- `probe.ts:161` — `lines[0]?.slice(0, 120)` standalone diagnostic snippet. The optional chain becomes a ternary because `truncateUtf16Safe` doesn't accept `undefined`. → `lines[0] ? truncateUtf16Safe(lines[0], 120) : undefined`.

## Evidence

Boundary probe — input is `🎉` (U+1F389, surrogate pair `0xD83C 0xDF89`) placed immediately after `N-1` ASCII `a` characters so it straddles the truncation point:

```
[monitor-provider 50-char]
  BEFORE .slice(0, 50):  length=50  tail=[0061 0061 0061 d83c]   ← lone high surrogate, malformed UTF-16
  AFTER  safe fn:          length=49  tail=[0061 0061 0061 0061]   ← clean, emoji dropped whole

[probe 120-char]
  BEFORE .slice(0, 120): length=120 tail=[0061 0061 0061 d83c]
  AFTER  safe fn:          length=119 tail=[0061 0061 0061 0061]
```

`🎉` = U+1F389, high surrogate `0xD83C`, low surrogate `0xDF89`. The lone `d83c` half in the BEFORE rows is the malformed UTF-16 the previous code emits; the AFTER rows show a clean ASCII tail with the surrogate pair dropped whole.

## After-fix Proof

- `node scripts/run-vitest.mjs extensions/imessage/src/monitor/monitor-provider.truncation.test.ts extensions/imessage/src/probe.test.ts --reporter=verbose`

```
 ✓ |extension-imessage| extensions/imessage/src/monitor/monitor-provider.truncation.test.ts > monitor-provider debounced-merge preview truncation > sliceUtf16Safe drops a trailing surrogate straddling the 50-char boundary 449ms
 ✓ |extension-imessage| extensions/imessage/src/monitor/monitor-provider.truncation.test.ts > monitor-provider debounced-merge preview truncation > ellipsis marker is appended when the original text exceeded 50 chars (no surrogate regression) 1ms
 ✓ |extension-imessage| extensions/imessage/src/monitor/monitor-provider.truncation.test.ts > monitor-provider debounced-merge preview truncation > empty input stays empty 1ms
 ✓ |extension-imessage| extensions/imessage/src/monitor/monitor-provider.truncation.test.ts > monitor-provider debounced-merge preview truncation > emoji fully inside the window is preserved (no false-positive drops) 1ms
 ✓ |extension-imessage| extensions/imessage/src/probe.test.ts > imessageRpcSupportsMethod > returns false when the bridge is not available 66ms
 ✓ |extension-imessage| extensions/imessage/src/probe.test.ts > imessageRpcSupportsMethod > returns false when status is undefined 1ms
 ✓ |extension-imessage| extensions/imessage/src/probe.test.ts > imessageRpcSupportsMethod > returns true when the requested method is in the explicit rpcMethods list 1ms
 ✓ |extension-imessage| extensions/imessage/src/probe.test.ts > imessageRpcSupportsMethod > returns false for a method not in the explicit rpcMethods list 1ms
 ✓ |extension-imessage| extensions/imessage/src/probe.test.ts > imessageRpcSupportsMethod > falls back to the foundational set when rpcMethods is empty (older imsg builds) 1ms
 ✓ |extension-imessage| extensions/imessage/src/probe.test.ts > imessageRpcSupportsMethod > gates newer methods off when rpcMethods is empty (forces upgrade for typing/read/group) 1ms
 ✓ |extension-imessage| extensions/imessage/src/probe.test.ts > iMessage private API status cache > drops expiring private API status when the current clock is not a valid date timestamp 2ms
 ✓ |extension-imessage| extensions/imessage/src/probe.test.ts > iMessage private API status cache > does not cache private API status with an invalid expiry timestamp 0ms
 ✓ |extension-imessage| extensions/imessage/src/probe.test.ts > probe first-line snippet truncation > truncateUtf16Safe drops a trailing surrogate straddling the 120-char boundary 1ms
 ✓ |extension-imessage| extensions/imessage/src/probe.test.ts > probe first-line snippet truncation > plain ASCII under the cap passes through unchanged 0ms
 ✓ |extension-imessage| extensions/imessage/src/probe.test.ts > probe first-line snippet truncation > undefined input is preserved (no truncation attempted) 0ms
 ✓ |extension-imessage| extensions/imessage/src/probe.test.ts > probe first-line snippet truncation > emoji fully inside the 120-char window is preserved 0ms

 Test Files  2 passed (2)
      Tests  16 passed (16)
   Duration  9.90s

[test] passed 1 Vitest shard in 20.68s
```

- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.scripts.json extensions/imessage/src/monitor/monitor-provider.ts extensions/imessage/src/probe.ts extensions/imessage/src/probe.test.ts extensions/imessage/src/monitor/monitor-provider.truncation.test.ts` → EXIT=0
- `git diff --check openclaw/main...HEAD` → clean
- `git diff --numstat openclaw/main...HEAD` → 4 files changed (2 source + 2 test)

## Diff scope

```
 extensions/imessage/src/monitor/monitor-provider.ts                  |  7 +++--
 extensions/imessage/src/monitor/monitor-provider.truncation.test.ts  | 38 +++++++++++++++++++ (new)
 extensions/imessage/src/probe.ts                                     |  3 +-
 extensions/imessage/src/probe.test.ts                                | 33 ++++++++++++++++
 4 files changed, 77 insertions(+), 3 deletions(-)
```

## Security & Privacy

No user-facing behavior change for ASCII input. The previews render identically for non-emoji text. For emoji-straddling input, the preview is one code unit shorter because the surrogate pair is dropped whole instead of leaving a lone high surrogate — this is the intended UTF-16 boundary fix, not a content loss.

## Compatibility

Plugin SDK export (`openclaw/plugin-sdk/text-utility-runtime`) is already in `package.json` exports for `@openclaw/plugin-sdk` (re-exported from `src/plugin-sdk/text-utility-runtime.ts`). No new dependency added at the package level. The helpers are dependency-free per `src/shared/utf16-slice.ts:1-5` (no `node:` imports), so they bundle cleanly into both server and UI builds.

## What was not tested

Live iMessage message flow with a real surrogate-pair payload. The fix is a one-line surrogate-pair guard per call site; the helpers themselves are covered by unit tests in `src/shared/utf16-slice.ts`. Integration coverage at this layer is intentionally out of scope — Alix-007's PRs #98008 (Twitch) and #97982 (Signal) followed the same boundary and were accepted on the same evidence.

## Other channel plugins that already use the helper

Discord, Feishu, Telegram, Signal (#97982), Mattermost, Slack, Twitch (#98008), plus iMessage coalesce (commit 352f47f888). iMessage debounced-merge and probe are the new additions.

## Related

- Alix-007 #98008 (Twitch): same fix shape — `truncateUtf16Safe` on a debug-log preview.
- Alix-007 #97982 (Signal): same fix shape — `truncateUtf16Safe` on a verbose-log preview.
- llagy009 commit 352f47f888: iMessage coalesce.ts already uses `sliceUtf16Safe` for the merged-text truncation marker.
- Helper source: `src/shared/utf16-slice.ts` (read-only reference, already merged).