### PR TITLE
fix: keep iOS LAN QR pairing authenticated after bootstrap

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
@@ -743,10 +743,11 @@ public actor GatewayChannelActor {
         if scheme == "wss" {
             return true
         }
-        if let host = self.url.host, LoopbackHost.isLoopback(host) {
-            return true
-        }
-        return false
+        guard scheme == "ws", let host = self.url.host else { return false }
+        // Setup codes intentionally allow plaintext WebSocket bootstrap on local networks
+        // for QR pairing. Persist the resulting bounded device token so reconnects do not
+        // fall back to auth=none after the single-use bootstrap token is cleared.
+        return LoopbackHost.isLocalNetworkHost(host)
     }
 
     private func filteredBootstrapHandoffScopes(role: String, scopes: [String]) -> [String]? {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
@@ -761,6 +761,76 @@ struct GatewayNodeSessionTests {
     }
 
     @Test
+    func `private lan bootstrap hello persists bootstrap handoff tokens`() async throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let previousStateDir = ProcessInfo.processInfo.environment["OPENCLAW_STATE_DIR"]
+        setenv("OPENCLAW_STATE_DIR", tempDir.path, 1)
+        defer {
+            if let previousStateDir {
+                setenv("OPENCLAW_STATE_DIR", previousStateDir, 1)
+            } else {
+                unsetenv("OPENCLAW_STATE_DIR")
+            }
+            try? FileManager.default.removeItem(at: tempDir)
+        }
+
+        let identity = DeviceIdentityStore.loadOrCreate()
+        let session = FakeGatewayWebSocketSession(helloAuth: [
+            "deviceToken": "lan-node-token",
+            "role": "node",
+            "scopes": [],
+            "deviceTokens": [
+                [
+                    "deviceToken": "lan-operator-token",
+                    "role": "operator",
+                    "scopes": [
+                        "operator.approvals",
+                        "operator.read",
+                    ],
+                ],
+            ],
+        ])
+        let gateway = GatewayNodeSession()
+        let options = GatewayConnectOptions(
+            role: "node",
+            scopes: [],
+            caps: [],
+            commands: [],
+            permissions: [:],
+            clientId: "openclaw-ios-test",
+            clientMode: "node",
+            clientDisplayName: "iOS Test",
+            includeDeviceIdentity: true)
+
+        try await gateway.connect(
+            url: #require(URL(string: "ws://192.168.50.164:18889")),
+            token: nil,
+            bootstrapToken: "fresh-bootstrap-token",
+            password: nil,
+            connectOptions: options,
+            sessionBox: WebSocketSessionBox(session: session),
+            onConnected: {},
+            onDisconnected: { _ in },
+            onInvoke: { req in
+                BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil)
+            })
+
+        let nodeEntry = try #require(DeviceAuthStore.loadToken(deviceId: identity.deviceId, role: "node"))
+        let operatorEntry = try #require(DeviceAuthStore.loadToken(deviceId: identity.deviceId, role: "operator"))
+        #expect(nodeEntry.token == "lan-node-token")
+        #expect(nodeEntry.scopes == [])
+        #expect(operatorEntry.token == "lan-operator-token")
+        #expect(operatorEntry.scopes == [
+            "operator.approvals",
+            "operator.read",
+        ])
+
+        await gateway.disconnect()
+    }
+
+    @Test
     func `normalize canvas host url preserves explicit secure canvas port`() throws {
         let normalized = try canonicalizeCanvasHostUrl(
             raw: "https://canvas.example.com:9443/__openclaw__/cap/token",

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
@@ -761,7 +761,7 @@ struct GatewayNodeSessionTests {
     }
 
     @Test
-    func `private lan bootstrap hello persists bootstrap handoff tokens`() async throws {
+    func `private lan bootstrap persists handoff tokens for reconnect`() async throws {
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
@@ -777,7 +777,8 @@ struct GatewayNodeSessionTests {
         }
 
         let identity = DeviceIdentityStore.loadOrCreate()
-        let session = FakeGatewayWebSocketSession(helloAuth: [
+        let url = try #require(URL(string: "ws://192.168.50.164:18889"))
+        let bootstrapSession = FakeGatewayWebSocketSession(helloAuth: [
             "deviceToken": "lan-node-token",
             "role": "node",
             "scopes": [],
@@ -805,67 +806,6 @@ struct GatewayNodeSessionTests {
             includeDeviceIdentity: true)
 
         try await gateway.connect(
-            url: #require(URL(string: "ws://192.168.50.164:18889")),
-            token: nil,
-            bootstrapToken: "fresh-bootstrap-token",
-            password: nil,
-            connectOptions: options,
-            sessionBox: WebSocketSessionBox(session: session),
-            onConnected: {},
-            onDisconnected: { _ in },
-            onInvoke: { req in
-                BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil)
-            })
-
-        let nodeEntry = try #require(DeviceAuthStore.loadToken(deviceId: identity.deviceId, role: "node"))
-        let operatorEntry = try #require(DeviceAuthStore.loadToken(deviceId: identity.deviceId, role: "operator"))
-        #expect(nodeEntry.token == "lan-node-token")
-        #expect(nodeEntry.scopes == [])
-        #expect(operatorEntry.token == "lan-operator-token")
-        #expect(operatorEntry.scopes == [
-            "operator.approvals",
-            "operator.read",
-        ])
-
-        await gateway.disconnect()
-    }
-
-    @Test
-    func `private lan bootstrap reconnect uses persisted handoff token`() async throws {
-        let tempDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-        let previousStateDir = ProcessInfo.processInfo.environment["OPENCLAW_STATE_DIR"]
-        setenv("OPENCLAW_STATE_DIR", tempDir.path, 1)
-        defer {
-            if let previousStateDir {
-                setenv("OPENCLAW_STATE_DIR", previousStateDir, 1)
-            } else {
-                unsetenv("OPENCLAW_STATE_DIR")
-            }
-            try? FileManager.default.removeItem(at: tempDir)
-        }
-
-        let identity = DeviceIdentityStore.loadOrCreate()
-        let url = try #require(URL(string: "ws://192.168.50.164:18889"))
-        let bootstrapSession = FakeGatewayWebSocketSession(helloAuth: [
-            "deviceToken": "lan-node-token",
-            "role": "node",
-            "scopes": [],
-        ])
-        let gateway = GatewayNodeSession()
-        let options = GatewayConnectOptions(
-            role: "node",
-            scopes: [],
-            caps: [],
-            commands: [],
-            permissions: [:],
-            clientId: "openclaw-ios-test",
-            clientMode: "node",
-            clientDisplayName: "iOS Test",
-            includeDeviceIdentity: true)
-
-        try await gateway.connect(
             url: url,
             token: nil,
             bootstrapToken: "fresh-bootstrap-token",
@@ -879,7 +819,15 @@ struct GatewayNodeSessionTests {
             })
         await gateway.disconnect()
 
-        #expect(DeviceAuthStore.loadToken(deviceId: identity.deviceId, role: "node")?.token == "lan-node-token")
+        let nodeEntry = try #require(DeviceAuthStore.loadToken(deviceId: identity.deviceId, role: "node"))
+        let operatorEntry = try #require(DeviceAuthStore.loadToken(deviceId: identity.deviceId, role: "operator"))
+        #expect(nodeEntry.token == "lan-node-token")
+        #expect(nodeEntry.scopes == [])
+        #expect(operatorEntry.token == "lan-operator-token")
+        #expect(operatorEntry.scopes == [
+            "operator.approvals",
+            "operator.read",
+        ])
 
         let reconnectSession = FakeGatewayWebSocketSession()
         try await gateway.connect(

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
@@ -831,6 +831,79 @@ struct GatewayNodeSessionTests {
     }
 
     @Test
+    func `private lan bootstrap reconnect uses persisted handoff token`() async throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let previousStateDir = ProcessInfo.processInfo.environment["OPENCLAW_STATE_DIR"]
+        setenv("OPENCLAW_STATE_DIR", tempDir.path, 1)
+        defer {
+            if let previousStateDir {
+                setenv("OPENCLAW_STATE_DIR", previousStateDir, 1)
+            } else {
+                unsetenv("OPENCLAW_STATE_DIR")
+            }
+            try? FileManager.default.removeItem(at: tempDir)
+        }
+
+        let identity = DeviceIdentityStore.loadOrCreate()
+        let url = try #require(URL(string: "ws://192.168.50.164:18889"))
+        let bootstrapSession = FakeGatewayWebSocketSession(helloAuth: [
+            "deviceToken": "lan-node-token",
+            "role": "node",
+            "scopes": [],
+        ])
+        let gateway = GatewayNodeSession()
+        let options = GatewayConnectOptions(
+            role: "node",
+            scopes: [],
+            caps: [],
+            commands: [],
+            permissions: [:],
+            clientId: "openclaw-ios-test",
+            clientMode: "node",
+            clientDisplayName: "iOS Test",
+            includeDeviceIdentity: true)
+
+        try await gateway.connect(
+            url: url,
+            token: nil,
+            bootstrapToken: "fresh-bootstrap-token",
+            password: nil,
+            connectOptions: options,
+            sessionBox: WebSocketSessionBox(session: bootstrapSession),
+            onConnected: {},
+            onDisconnected: { _ in },
+            onInvoke: { req in
+                BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil)
+            })
+        await gateway.disconnect()
+
+        #expect(DeviceAuthStore.loadToken(deviceId: identity.deviceId, role: "node")?.token == "lan-node-token")
+
+        let reconnectSession = FakeGatewayWebSocketSession()
+        try await gateway.connect(
+            url: url,
+            token: nil,
+            bootstrapToken: nil,
+            password: nil,
+            connectOptions: options,
+            sessionBox: WebSocketSessionBox(session: reconnectSession),
+            onConnected: {},
+            onDisconnected: { _ in },
+            onInvoke: { req in
+                BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil)
+            })
+
+        let reconnectAuth = try #require(reconnectSession.latestTask()?.latestConnectAuth())
+        #expect(reconnectAuth["token"] as? String == "lan-node-token")
+        #expect(reconnectAuth["bootstrapToken"] == nil)
+        #expect(reconnectAuth["deviceToken"] == nil)
+
+        await gateway.disconnect()
+    }
+
+    @Test
     func `normalize canvas host url preserves explicit secure canvas port`() throws {
         let normalized = try canonicalizeCanvasHostUrl(
             raw: "https://canvas.example.com:9443/__openclaw__/cap/token",


### PR DESCRIPTION
﻿Fixes #98064

## What Problem This Solves

Fixes an issue where users scanning `/pair qr` with the iOS app against a LAN Gateway could see the Control/Gateway card become online while Chat stayed disconnected and the Gateway still reported that a token was required.

In the real repro, the Gateway accepted the setup bootstrap once, then the next iPhone node/chat WebSocket reconnected with no auth and was rejected as `token_missing`.

## Why This Change Was Made

The iOS setup-code parser already allows plaintext `ws://` bootstrap URLs when the host is local-network scoped, such as `192.168.x.x`, while still rejecting public plaintext hosts. This change aligns bootstrap handoff token persistence with that same local-network boundary: `wss://` remains allowed, public `ws://` remains non-persistent, and private LAN `ws://` now persists the bounded device tokens issued by the Gateway after bootstrap succeeds.

This does not change token validation, expired setup-code handling, or public/non-local plaintext WebSocket policy.

## User Impact

Users can scan a fresh `/pair qr` code from a phone on the same LAN and keep the iOS app connected after the one-time bootstrap token is consumed. Chat should no longer fall back to `auth=none` immediately after an otherwise successful local pairing.

## Evidence

AI-assisted: yes, Codex.

- Issue/repro: #98064 tracks the real Windows Gateway + iOS LAN pairing failure on OpenClaw `2026.6.11-beta.2`, where Control showed the Main gateway online but Chat showed `Disconnected` / `not connected`.
- Before-fix live log evidence, redacted: `device pairing auto-approved ... role=node`, followed by `unauthorized ... client=iPhone node v2026.6.10 role=node scopes=0 auth=none ... reason=token_missing`, then `closed before connect ... gateway token missing`.
- Source-level boundary check: `apps/shared/OpenClawKit/Sources/OpenClawKit/DeepLinks.swift` accepts private LAN `ws://` setup-code hosts through `LoopbackHost.isLocalNetworkHost`, while the pre-fix `GatewayChannel.shouldPersistBootstrapHandoffTokens()` only persisted bootstrap-issued tokens for `wss://` or loopback.
- Regression coverage added: `GatewayNodeSessionTests` verifies that a bootstrap hello from `ws://192.168.x.x:18889` persists the issued node and operator device tokens.
- After-fix reconnect coverage added: `GatewayNodeSessionTests.private lan bootstrap reconnect uses persisted handoff token` simulates a fresh LAN bootstrap over `ws://192.168.x.x:18889`, disconnects after the one-time bootstrap succeeds, reconnects with no bootstrap token, and asserts the next connect request sends the persisted `token=lan-node-token` while sending no `bootstrapToken` and no `deviceToken`. This is the source-level regression for the observed `auth=none` / `token_missing` reconnect failure.
- Existing guard retained: the adjacent untrusted bootstrap test still covers public plaintext `ws://example.invalid` not persisting bootstrap handoff tokens.
- Diff sanity passed: `git diff --check`.
- Autoreview passed after the reconnect test was added: `python .agents\skills\autoreview\scripts\autoreview --mode branch --base upstream/main --thinking low` reported `autoreview clean: no accepted/actionable findings reported`.
- Local test limitation: the focused Swift tests were added but not executed locally because this Windows environment does not have `swift`/Xcode installed. CI should run the OpenClawKit Swift/iOS lanes on the PR head.
- Remaining live-device proof limitation: I do not have a PR/TestFlight iOS app build installed on a real iPhone, so I cannot honestly claim an after-patch real-device QR scan. The real incident evidence and the new reconnect regression cover the same auth transition that caused Chat to reconnect as `auth=none` after the bootstrap token was consumed.

