### PR TITLE
fix(update): skip npm package.json check for bundle-format plugins in smoke check

### DIFF
--- a/src/cli/update-cli/plugin-payload-validation.test.ts
+++ b/src/cli/update-cli/plugin-payload-validation.test.ts
@@ -461,6 +461,82 @@ describe("runPluginPayloadSmokeCheck", () => {
     ]);
   });
 
+  it("accepts a bundle plugin (clawhubFamily=bundle-plugin) with valid .claude-plugin/plugin.json", async () => {
+    const dir = path.join(tmpRoot, "feishu-bundle");
+    await fs.mkdir(path.join(dir, ".claude-plugin"), { recursive: true });
+    await fs.writeFile(
+      path.join(dir, ".claude-plugin", "plugin.json"),
+      JSON.stringify({ name: "feishu", version: "1.0.0" }),
+      "utf8",
+    );
+    const result = await runPluginPayloadSmokeCheck({
+      records: {
+        feishu: { source: "clawhub", clawhubFamily: "bundle-plugin", installPath: dir },
+      },
+      env: {},
+    });
+    expect(result.failures).toEqual([]);
+    expect(result.checked).toEqual(["feishu"]);
+  });
+
+  it("accepts a bundle plugin detected by .claude-plugin/plugin.json presence", async () => {
+    const dir = path.join(tmpRoot, "feishu-bundle");
+    await fs.mkdir(path.join(dir, ".claude-plugin"), { recursive: true });
+    await fs.writeFile(
+      path.join(dir, ".claude-plugin", "plugin.json"),
+      JSON.stringify({ name: "feishu" }),
+      "utf8",
+    );
+    const result = await runPluginPayloadSmokeCheck({
+      records: {
+        feishu: { source: "clawhub", installPath: dir },
+      },
+      env: {},
+    });
+    expect(result.failures).toEqual([]);
+    expect(result.checked).toEqual(["feishu"]);
+  });
+
+  it("reports a failure for a bundle plugin with missing .claude-plugin/plugin.json", async () => {
+    const dir = path.join(tmpRoot, "bad-bundle");
+    await fs.mkdir(dir, { recursive: true });
+    const result = await runPluginPayloadSmokeCheck({
+      records: {
+        bad: { source: "clawhub", clawhubFamily: "bundle-plugin", installPath: dir },
+      },
+      env: {},
+    });
+    expect(result.failures).toStrictEqual([
+      {
+        pluginId: "bad",
+        installPath: dir,
+        reason: "missing-package-json",
+        detail: `.claude-plugin/plugin.json is missing under ${dir}`,
+      },
+    ]);
+  });
+
+  it("reports a failure for a bundle plugin with unparseable .claude-plugin/plugin.json", async () => {
+    const dir = path.join(tmpRoot, "bad-bundle");
+    await fs.mkdir(path.join(dir, ".claude-plugin"), { recursive: true });
+    await fs.writeFile(path.join(dir, ".claude-plugin", "plugin.json"), "not-json", "utf8");
+    const result = await runPluginPayloadSmokeCheck({
+      records: {
+        bad: { source: "clawhub", clawhubFamily: "bundle-plugin", installPath: dir },
+      },
+      env: {},
+    });
+    expect(result.failures).toStrictEqual([
+      {
+        pluginId: "bad",
+        installPath: dir,
+        reason: "invalid-package-json",
+        detail:
+          "Could not parse .claude-plugin/plugin.json: Unexpected token 'o', \"not-json\" is not valid JSON",
+      },
+    ]);
+  });
+
   it("only checks records whose source is package-tracked (npm/clawhub/git/marketplace)", async () => {
     const dir = path.join(tmpRoot, "tracked");
     await writePackage(dir, { name: "tracked" }, "module.exports = {};");

--- a/src/cli/update-cli/plugin-payload-validation.ts
+++ b/src/cli/update-cli/plugin-payload-validation.ts
@@ -78,6 +78,37 @@ export async function runPluginPayloadSmokeCheck(params: {
       continue;
     }
 
+    // Bundle-format plugins (Claude-plugin layout: .claude-plugin/plugin.json +
+    // skills/) ship without package.json.  Validate the bundle manifest instead
+    // of requiring an npm package.json (#97985).
+    const isBundlePlugin =
+      record.clawhubFamily === "bundle-plugin" ||
+      (await safeStat(path.join(installPath, ".claude-plugin", "plugin.json")))?.isFile();
+    if (isBundlePlugin) {
+      const bundleManifestPath = path.join(installPath, ".claude-plugin", "plugin.json");
+      const bundleManifestStat = await safeStat(bundleManifestPath);
+      if (!bundleManifestStat?.isFile()) {
+        failures.push({
+          pluginId,
+          installPath,
+          reason: "missing-package-json",
+          detail: `.claude-plugin/plugin.json is missing under ${installPath}`,
+        });
+        continue;
+      }
+      try {
+        JSON.parse(await fs.readFile(bundleManifestPath, "utf8"));
+      } catch (err) {
+        failures.push({
+          pluginId,
+          installPath,
+          reason: "invalid-package-json",
+          detail: `Could not parse .claude-plugin/plugin.json: ${err instanceof Error ? err.message : String(err)}`,
+        });
+      }
+      continue;
+    }
+
     const packageJsonPath = path.join(installPath, "package.json");
     const packageJsonStat = await safeStat(packageJsonPath);
     if (!packageJsonStat?.isFile()) {


### PR DESCRIPTION
## What Problem This Solves

`openclaw update` failed with exit 1 and left the gateway unloaded when bundle-format plugins (`.claude-plugin/plugin.json` layout, no `package.json`) were present in `~/.openclaw/extensions/`. The post-update plugin smoke check only recognized npm-format plugins and treated the missing `package.json` as a fatal error.

## Summary

- Problem: Bundle plugins flagged as `missing-package-json` during update smoke check, causing gateway outage
- Solution: Detect bundle plugins via `clawhubFamily: "bundle-plugin"` or `.claude-plugin/plugin.json` presence, validate the bundle manifest instead of requiring npm-style `package.json`
- What changed: `src/cli/update-cli/plugin-payload-validation.ts` — bundle detection before package.json check; `plugin-payload-validation.test.ts` — 4 new tests
- What did NOT change: npm-format plugin validation unchanged; `missing-extension-entry` and `missing-main-entry` checks untouched

## Evidence

25 tests pass (21 existing + 4 new bundle plugin tests):

```console
$ node scripts/run-vitest.mjs src/cli/update-cli/plugin-payload-validation.test.ts --run --reporter=verbose

 ✓ accepts a bundle plugin (clawhubFamily=bundle-plugin) with valid .claude-plugin/plugin.json
 ✓ accepts a bundle plugin detected by .claude-plugin/plugin.json presence
 ✓ reports a failure for a bundle plugin with missing .claude-plugin/plugin.json
 ✓ reports a failure for a bundle plugin with unparseable .claude-plugin/plugin.json
 ✓ only checks records whose source is package-tracked (npm/clawhub/git/marketplace)
 ... 25 passed (25)
```

Bundle plugin behavior matrix:

| Scenario | Result |
|----------|--------|
| `clawhubFamily=bundle-plugin` + valid manifest | ✅ accepted |
| `.claude-plugin/plugin.json` present (no clawhubFamily) | ✅ accepted |
| `clawhubFamily=bundle-plugin` + missing manifest | ❌ reported |
| `clawhubFamily=bundle-plugin` + unparseable manifest | ❌ reported |
| npm-format plugins | unchanged |

## Security Impact

- [x] New permissions/capabilities? No
- [x] Secrets/tokens handling changed? No
- [x] New/changed network calls? No

## AI Assistance

- **AI-assisted**: Yes
- **AI model**: deepseek-v4-pro

---

Fixes #97985
