### PR TITLE
fix(memory): detect session drift in status mode to avoid false-clean dirty flag

### DIFF
--- a/extensions/memory-core/src/cli.runtime.ts
+++ b/extensions/memory-core/src/cli.runtime.ts
@@ -3,6 +3,7 @@ import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { isUsageCountedSessionTranscriptFileName } from "openclaw/plugin-sdk/memory-core-host-engine-qmd";
 import type { MemoryEmbeddingProbeResult } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import {
   resolveMemoryDreamingConfig,
@@ -10,7 +11,6 @@ import {
   resolveMemoryRemDreamingConfig,
 } from "openclaw/plugin-sdk/memory-core-host-status";
 import { buildAgentSessionKey } from "openclaw/plugin-sdk/routing";
-import { isUsageCountedSessionTranscriptFileName } from "openclaw/plugin-sdk/memory-core-host-engine-qmd";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import {
   colorize,
@@ -720,6 +720,18 @@ export async function runMemoryStatus(opts: MemoryCommandOptions) {
       agentId,
       purpose: managerPurpose,
       run: async (manager) => {
+        // For plain status (no --index), ensure session-drift detection from
+        // the constructor has settled before reading status, so unindexed
+        // transcripts surface as dirty=true instead of a false-clean state.
+        // The builtin MemoryIndexManager exposes this; other backends do not.
+        if (!opts.index) {
+          const refresher = (
+            manager as { refreshSessionStartupDirtyDetection?: () => Promise<void> }
+          ).refreshSessionStartupDirtyDetection;
+          if (typeof refresher === "function") {
+            await refresher.call(manager);
+          }
+        }
         const deep = Boolean(opts.deep || opts.index);
         let embeddingProbe: MemoryEmbeddingProbeResult | undefined;
         let indexError: string | undefined;

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -1240,6 +1240,49 @@ describe("memory index", () => {
     }
   });
 
+  it("reports dirty in status mode when an unindexed session transcript exists (#97814)", async () => {
+    try {
+      setMemoryIndexStateDir(path.join(workspaceDir, ".state-status-session-drift"));
+      const sessionsDir = resolveSessionTranscriptsDirForAgent("main");
+      await fs.mkdir(sessionsDir, { recursive: true });
+      await fs.writeFile(
+        path.join(sessionsDir, "session-status-drift.jsonl"),
+        [
+          JSON.stringify({
+            type: "session",
+            id: "session-status-drift",
+            timestamp: "2026-04-07T15:24:04.113Z",
+          }),
+          JSON.stringify({
+            type: "message",
+            message: {
+              role: "user",
+              timestamp: "2026-04-07T15:25:04.113Z",
+              content: [{ type: "text", text: "Status drift marker." }],
+            },
+          }),
+        ].join("\n") + "\n",
+        "utf8",
+      );
+
+      const cfg = createCfg({ sources: ["sessions"], sessionMemory: true });
+      const manager = await getFreshManager(cfg, "status");
+      try {
+        await (
+          manager as unknown as {
+            refreshSessionStartupDirtyDetection: () => Promise<void>;
+          }
+        ).refreshSessionStartupDirtyDetection();
+        const status = manager.status();
+        expect(status.dirty).toBe(true);
+      } finally {
+        await manager.close?.();
+      }
+    } finally {
+      restoreMemoryIndexStateDir();
+    }
+  });
+
   it("keeps provider cutover vector search paused during targeted session sync", async () => {
     try {
       setMemoryIndexStateDir(path.join(workspaceDir, ".state-targeted-cutover"));

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -286,6 +286,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   protected override sessionPendingFiles = new Set<string>();
   protected override sessionPendingTargets = new Map<string, MemorySessionSyncTarget>();
   private indexIdentityDirty = false;
+  private sessionStartupDirtyDetectionPromise: Promise<string[]> | null = null;
   protected override sessionDeltas = new Map<
     string,
     { lastSize: number; pendingBytes: number; pendingMessages: number }
@@ -435,6 +436,11 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       this.batch = this.resolveBatchConfig();
       if (!transient) {
         this.ensureSessionStartupCatchup();
+      } else if (params.purpose === "status") {
+        // Status mode skips the full catch-up sync to stay light, but still
+        // detects on-disk session drift so status() does not report a false
+        // clean state when unindexed transcripts exist. See #97814.
+        this.sessionStartupDirtyDetectionPromise = this.detectSessionStartupDirtyFilesForStatus();
       }
     } catch (err) {
       closeMemoryDatabase(this.db);
@@ -1109,6 +1115,30 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       from: params.from,
       lines: params.lines,
     });
+  }
+
+  /**
+   * Runs session-drift detection without triggering a sync, so status mode
+   * reports dirty=true when unindexed transcripts exist on disk. Awaits the
+   * detection started in the constructor; safe to call from status-path CLI
+   * commands before reading {@link status}. See #97814.
+   */
+  async refreshSessionStartupDirtyDetection(): Promise<void> {
+    if (this.sessionStartupDirtyDetectionPromise) {
+      await this.sessionStartupDirtyDetectionPromise;
+    }
+  }
+
+  private async detectSessionStartupDirtyFilesForStatus(): Promise<string[]> {
+    if (this.closed || !this.sources.has("sessions")) {
+      return [];
+    }
+    try {
+      return await this.markSessionStartupCatchupDirtyFiles();
+    } catch (err) {
+      log.warn("memory status session drift detection failed: " + String(err));
+      return [];
+    }
   }
 
   status(): MemoryProviderStatus {


### PR DESCRIPTION
## What Problem This Solves

Fixes #97814.

`openclaw memory status` (plain, no `--index`) can report `dirty=false` while a usage-counted session transcript exists on disk with zero rows in `memory_index_sources` / `memory_index_chunks`. The operator sees no backlog but memory search silently misses the unindexed transcript. During a recent incident this false-clean state compounded triage confusion because the fleet appeared healthier than it was.

Root cause: status-purpose manager init skips `ensureSessionStartupCatchup()`, so on-disk session drift is never surfaced through the dirty flag in the plain status path.

## Why This Change Was Made

Status mode intentionally avoids the full catch-up sync to stay light, but the previous implementation also skipped drift detection, which made the dirty flag unreliable. This PR threads detection (without sync) through the status path so `status()` reflects reality, then waits for that detection to settle before the CLI reads status.

Design choice: detection-only, no sync in the status path. The status-purpose manager now records a promise that resolves with the list of unindexed session files (using the existing `markSessionStartupCatchupDirtyFiles()` helper). `status()` already honors the dirty flag set by detection. The CLI status path calls a new `refreshSessionStartupDirtyDetection()` method to await detection before reading status, so the response is accurate even when the manager was constructed milliseconds ago.

## User Impact

- `openclaw memory status` no longer claims `dirty=false` when unindexed session transcripts exist; operators can trust the dirty flag as a health signal.
- No behavioral change for `--index` / `--force` / `--deep` paths — they already triggered catch-up.
- No performance regression: status mode still does not perform a full sync; it only runs the existing lightweight on-disk-vs-DB file comparison.

## Evidence

- New test: `extensions/memory-core/src/memory/index.test.ts` — "reports dirty in status mode when an unindexed session transcript exists (#97814)". Creates a session transcript on disk, constructs a status-purpose manager, awaits `refreshSessionStartupDirtyDetection()`, and asserts `status().dirty === true`.
- Local typecheck: `tsgo` clean against touched files.
- Local tests: `node scripts/run-vitest.mjs extensions/memory-core/src/memory/index.test.ts` exits 0.

The new method is thread-local to the builtin `MemoryIndexManager`; the CLI uses type narrowing with a runtime `typeof === "function"` guard so other backend implementations are unaffected.
