### PR TITLE
fix(agents): return delivered=false for pending completion announces

### DIFF
--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -1547,6 +1547,19 @@ async function sendSubagentAnnounceDirectly(params: {
 
     const directAnnounceStillPending = isGatewayAgentRunPending(directAnnounceResponse);
     if (directAnnounceStillPending) {
+      if (params.expectsCompletionMessage) {
+        // A pending gateway response means the completion-agent handoff has not
+        // completed yet. Treating this as delivered: true would silently drop the
+        // completion notification across all spawn depths, leaving the parent
+        // session waiting forever. Return delivered: false so the dispatch falls
+        // through to the steering fallback, which uses the active-requester queue
+        // wake path and may still succeed. (#93323)
+        return {
+          delivered: false,
+          path: "direct",
+          reason: "completion_handoff_pending",
+        };
+      }
       return {
         delivered: true,
         path: "direct",


### PR DESCRIPTION
## Summary

- Gateway direct announces that return `pending` status when `expectsCompletionMessage=true` were incorrectly treated as successfully delivered.
- This silently drops completion notifications across all spawn depths, leaving parent sessions waiting forever.
- Fix: return `delivered: false` with `reason: "completion_handoff_pending"` so the dispatch falls through to the steering fallback (active-requester queue wake path).

## Root Cause

`sendSubagentAnnounceDirectly` at `src/agents/subagent-announce-delivery.ts:1548` unconditionally returns `delivered: true` when `isGatewayAgentRunPending()` is true, regardless of whether a completion message is expected. For `expectsCompletionMessage=true`, a pending handoff means the completion was **not** delivered, and treating it as success causes the notification to be silently dropped.

## Verification

- Code logic verified by reading the source: the `params.expectsCompletionMessage` field is available in scope at the fix location.
- The `completion_handoff_pending` reason type is already defined in `SubagentAnnounceDeliveryFailureReason`.
- The dispatch fallback at `subagent-announce-dispatch.ts:116` checks `primaryDirect.delivered || primaryDirect.terminal` with `delivered: false` and no `terminal` flag, it correctly falls through to `steer-fallback`.

## Real behavior proof

**Behavior addressed:** Gateway direct announces returning pending status no longer silently drop completion notifications when expectsCompletionMessage is true.

**Environment tested:** Code analysis on openclaw main (Node 22, Linux).

**Steps run after the patch:** The fix was verified by tracing the full delivery flow:

- `sendSubagentAnnounceDirectly` now returns `delivered: false` with `reason: "completion_handoff_pending"` when `expectsCompletionMessage=true` and the gateway response is pending.
- `runSubagentAnnounceDispatch` at line 116 correctly falls through to the steering fallback when `delivered` is false.
- The `completion_handoff_pending` reason is already a valid member of the `SubagentAnnounceDeliveryFailureReason` union type.

**Evidence after fix:**

```text
Before: pending + expectsCompletionMessage=true -> delivered: true (silent drop)
After:  pending + expectsCompletionMessage=true -> delivered: false -> steer-fallback
```

**Observed result after the fix:** When the gateway returns pending for a completion handoff, the announce delivery no longer returns a false `delivered: true`. Instead, the dispatch falls through to the steering fallback path, which uses the active-requester queue wake mechanism. If the steering fallback also fails, the parent session correctly sees `delivered: false`.

**Not tested:** Live gateway session under production event-loop pressure. The fix logic is straightforward: a return value change with no new code paths.

Closes #93323
