### PR TITLE
fix(devices): hint toward nodes approve when device approve fails with unknown requestId

### DIFF
--- a/src/cli/devices-cli.runtime.ts
+++ b/src/cli/devices-cli.runtime.ts
@@ -686,6 +686,10 @@ async function tryFetchPendingNodeRequests(opts: DevicesRpcOpts) {
   }
 }
 
+function formatNodeApproveCommand(requestId: string): string {
+  return formatCliCommand(["openclaw", "nodes", "approve", requestId].map(quoteCliArg).join(" "));
+}
+
 function buildNodeApprovalHint(
   arg: string,
   pending: ReturnType<typeof parsePairingList>["pending"],
@@ -711,7 +715,7 @@ function buildNodeApprovalHint(
     for (const req of pending) {
       const identity = req.displayName ?? req.nodeId;
       lines.push(
-        `  Run: openclaw nodes approve ${req.requestId}  — ${sanitizeForLog(identity)}${req.remoteIp ? ` · ${sanitizeForLog(req.remoteIp)}` : ""}`,
+        `  Run: ${formatNodeApproveCommand(req.requestId)}  — ${sanitizeForLog(identity)}${req.remoteIp ? ` · ${sanitizeForLog(req.remoteIp)}` : ""}`,
       );
     }
     return lines.join("\n");
@@ -720,7 +724,7 @@ function buildNodeApprovalHint(
   return [
     `No pending device pairing request matches "${sanitizeForLog(arg)}".`,
     `Node reapproval pending for "${sanitizeForLog(identity)}"${target.remoteIp ? ` (${sanitizeForLog(target.remoteIp)})` : ""}.`,
-    `Run: openclaw nodes approve ${target.requestId}`,
+    `Run: ${formatNodeApproveCommand(target.requestId)}`,
   ].join("\n");
 }
 
@@ -840,7 +844,7 @@ export async function runDevicesListCommand(opts: DevicesRpcOpts): Promise<void>
       defaultRuntime.log(
         `  Node: ${sanitizeForLog(identity)}${req.remoteIp ? ` · ${sanitizeForLog(req.remoteIp)}` : ""}`,
       );
-      defaultRuntime.log(`  Run:  ${formatCliCommand(`openclaw nodes approve ${req.requestId}`)}`);
+      defaultRuntime.log(`  Run:  ${formatNodeApproveCommand(req.requestId)}`);
     }
   }
 }

--- a/src/cli/devices-cli.runtime.ts
+++ b/src/cli/devices-cli.runtime.ts
@@ -702,7 +702,7 @@ function buildNodeApprovalHint(
       (req.displayName !== undefined &&
         normalizeLowercaseStringOrEmpty(req.displayName) === lowerArg),
   );
-  const target = matched ?? (pending.length === 1 ? pending[0]! : null);
+  const target = matched ?? (pending.length === 1 ? pending[0] : null);
   if (!target) {
     const lines = [
       `No pending device pairing request matches "${sanitizeForLog(arg)}".`,

--- a/src/cli/devices-cli.runtime.ts
+++ b/src/cli/devices-cli.runtime.ts
@@ -38,6 +38,7 @@ import {
   type DevicePairingAccessSummary,
   type PendingDeviceApprovalKind,
 } from "../shared/device-pairing-access.js";
+import { parsePairingList } from "../shared/node-list-parse.js";
 import { formatCliCommand } from "./command-format.js";
 import { parseTimeoutMsWithFallback } from "./parse-timeout.js";
 import { withProgress } from "./progress.js";
@@ -666,6 +667,69 @@ function formatAuthFlagReminder(opts: DevicesRpcOpts): string {
   return `Reuse the same ${flags.join("/")} option${flags.length === 1 ? "" : "s"} when rerunning.`;
 }
 
+async function tryFetchPendingNodeRequests(opts: DevicesRpcOpts) {
+  try {
+    const result = await callGateway({
+      url: opts.url,
+      token: opts.token,
+      password: opts.password,
+      method: "node.pair.list",
+      params: {},
+      timeoutMs: parseTimeoutMsWithFallback(opts.timeout, DEFAULT_DEVICES_TIMEOUT_MS),
+      clientName: GATEWAY_CLIENT_NAMES.CLI,
+      mode: GATEWAY_CLIENT_MODES.CLI,
+      scopes: [PAIRING_SCOPE] as OperatorScope[],
+    });
+    return parsePairingList(result).pending;
+  } catch {
+    return [];
+  }
+}
+
+function buildNodeApprovalHint(
+  arg: string,
+  pending: ReturnType<typeof parsePairingList>["pending"],
+): string | null {
+  if (pending.length === 0) {
+    return null;
+  }
+  const lowerArg = normalizeLowercaseStringOrEmpty(arg);
+  const matched = pending.find(
+    (req) =>
+      req.remoteIp === arg ||
+      req.nodeId === arg ||
+      req.requestId === arg ||
+      (req.displayName !== undefined &&
+        normalizeLowercaseStringOrEmpty(req.displayName) === lowerArg),
+  );
+  const target = matched ?? (pending.length === 1 ? pending[0]! : null);
+  if (!target) {
+    const lines = [
+      `No pending device pairing request matches "${sanitizeForLog(arg)}".`,
+      `${pending.length} pending node approval${pending.length === 1 ? "" : "s"} exist at the node layer:`,
+    ];
+    for (const req of pending) {
+      const identity = req.displayName ?? req.nodeId;
+      lines.push(
+        `  Run: openclaw nodes approve ${req.requestId}  — ${sanitizeForLog(identity)}${req.remoteIp ? ` · ${sanitizeForLog(req.remoteIp)}` : ""}`,
+      );
+    }
+    return lines.join("\n");
+  }
+  const identity = target.displayName ?? target.nodeId;
+  return [
+    `No pending device pairing request matches "${sanitizeForLog(arg)}".`,
+    `Node reapproval pending for "${sanitizeForLog(identity)}"${target.remoteIp ? ` (${sanitizeForLog(target.remoteIp)})` : ""}.`,
+    `Run: openclaw nodes approve ${target.requestId}`,
+  ].join("\n");
+}
+
+function isUnknownDeviceApprovalRequestIdError(error: unknown): boolean {
+  return normalizeLowercaseStringOrEmpty(normalizeErrorMessage(error)).includes(
+    "unknown requestid",
+  );
+}
+
 function resolveRequiredDeviceRole(
   opts: DevicesRpcOpts,
 ): { deviceId: string; role: string } | null {
@@ -765,6 +829,19 @@ export async function runDevicesListCommand(opts: DevicesRpcOpts): Promise<void>
   }
   if (!list.pending?.length && !list.paired?.length) {
     defaultRuntime.log(theme.muted("No device pairing entries."));
+  }
+  const pendingNodes = await tryFetchPendingNodeRequests(opts);
+  if (pendingNodes.length > 0) {
+    defaultRuntime.log(
+      `${theme.heading("Pending node approvals")} ${theme.muted(`(${pendingNodes.length})`)}`,
+    );
+    for (const req of pendingNodes) {
+      const identity = req.displayName ?? req.nodeId;
+      defaultRuntime.log(
+        `  Node: ${sanitizeForLog(identity)}${req.remoteIp ? ` · ${sanitizeForLog(req.remoteIp)}` : ""}`,
+      );
+      defaultRuntime.log(`  Run:  ${formatCliCommand(`openclaw nodes approve ${req.requestId}`)}`);
+    }
   }
 }
 
@@ -917,8 +994,31 @@ export async function runDevicesApproveCommand(
     defaultRuntime.exit(1);
     return;
   }
-  const result = await approvePairingWithFallback(opts, resolvedRequestId);
+  let result: Awaited<ReturnType<typeof approvePairingWithFallback>>;
+  try {
+    result = await approvePairingWithFallback(opts, resolvedRequestId);
+  } catch (error) {
+    if (opts.json !== true && isUnknownDeviceApprovalRequestIdError(error)) {
+      const pending = await tryFetchPendingNodeRequests(opts);
+      const hint = buildNodeApprovalHint(resolvedRequestId, pending);
+      if (hint) {
+        defaultRuntime.error(hint);
+        defaultRuntime.exit(1);
+        return;
+      }
+    }
+    throw error;
+  }
   if (!result) {
+    if (opts.json !== true) {
+      const pending = await tryFetchPendingNodeRequests(opts);
+      const hint = buildNodeApprovalHint(resolvedRequestId, pending);
+      if (hint) {
+        defaultRuntime.error(hint);
+        defaultRuntime.exit(1);
+        return;
+      }
+    }
     defaultRuntime.error("unknown requestId");
     defaultRuntime.exit(1);
     return;

--- a/src/cli/devices-cli.test.ts
+++ b/src/cli/devices-cli.test.ts
@@ -545,6 +545,31 @@ describe("devices cli approve", () => {
     );
     expect(hasGatewayMethod("node.pair.list")).toBe(false);
   });
+
+  it("shell-quotes node request IDs containing metacharacters in the approval hint", async () => {
+    callGateway
+      .mockResolvedValueOnce({ pending: [], paired: [] })
+      .mockRejectedValueOnce(new Error("unknown requestId"))
+      .mockResolvedValueOnce({
+        pending: [
+          {
+            requestId: "req 1; rm -rf /",
+            nodeId: "node-id-evil",
+            displayName: "Sneaky Node",
+            remoteIp: "192.168.0.202",
+            ts: 1,
+          },
+        ],
+        paired: [],
+      });
+
+    await runDevicesApprove(["192.168.0.202"]);
+
+    const errorOutput = readRuntimeErrorOutput();
+    expect(errorOutput).toContain("openclaw nodes approve 'req 1; rm -rf /'");
+    expect(errorOutput).not.toContain("approve req 1; rm -rf /");
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+  });
 });
 
 describe("devices cli remove", () => {

--- a/src/cli/devices-cli.test.ts
+++ b/src/cli/devices-cli.test.ts
@@ -485,6 +485,66 @@ describe("devices cli approve", () => {
     expect(runtime.exit).toHaveBeenCalledWith(1);
     expect(hasGatewayMethod("device.pair.approve")).toBe(false);
   });
+
+  it("hints toward openclaw nodes approve when device approve throws unknown requestId and node IP matches", async () => {
+    callGateway
+      .mockResolvedValueOnce({ pending: [], paired: [] })
+      .mockRejectedValueOnce(new Error("unknown requestId"))
+      .mockResolvedValueOnce({
+        pending: [
+          {
+            requestId: "node-req-1",
+            nodeId: "node-id-1",
+            displayName: "Colin's S25",
+            remoteIp: "192.168.0.202",
+            ts: 1,
+          },
+        ],
+        paired: [],
+      });
+
+    await runDevicesApprove(["192.168.0.202"]);
+
+    const errorOutput = readRuntimeErrorOutput();
+    expect(errorOutput).toContain("openclaw nodes approve node-req-1");
+    expect(errorOutput).toContain("192.168.0.202");
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(hasGatewayMethod("node.pair.list")).toBe(true);
+  });
+
+  it("hints toward openclaw nodes approve when device approve returns null and a node IP matches", async () => {
+    rejectGatewayForLocalFallback("device pairing required (requestId: req-profile)");
+    rejectGatewayForLocalFallback("device pairing required (requestId: req-profile)");
+    callGateway.mockResolvedValueOnce({
+      pending: [
+        {
+          requestId: "node-req-2",
+          nodeId: "node-id-2",
+          displayName: "My Android",
+          remoteIp: "192.168.0.202",
+          ts: 1,
+        },
+      ],
+      paired: [],
+    });
+
+    await runDevicesApprove(["192.168.0.202"]);
+
+    const errorOutput = readRuntimeErrorOutput();
+    expect(errorOutput).toContain("openclaw nodes approve node-req-2");
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("does not show node approval hint in JSON mode when device approve throws unknown requestId", async () => {
+    callGateway
+      .mockResolvedValueOnce({ pending: [], paired: [] })
+      .mockRejectedValueOnce(new Error("unknown requestId"));
+
+    await expect(runDevicesApprove(["192.168.0.202", "--json"])).rejects.toThrow(
+      "unknown requestId",
+    );
+    expect(hasGatewayMethod("node.pair.list")).toBe(false);
+  });
 });
 
 describe("devices cli remove", () => {
@@ -1380,6 +1440,49 @@ describe("devices cli list", () => {
     expect(output).toContain("BadName");
     expect(output).toContain("spoof");
     expect(output).toContain("Paired");
+  });
+
+  it("shows pending node approvals section when node.pair.list returns pending requests", async () => {
+    callGateway.mockResolvedValueOnce({ pending: [], paired: [] }).mockResolvedValueOnce({
+      pending: [
+        {
+          requestId: "node-req-abc",
+          nodeId: "node-id-abc",
+          displayName: "Colin's S25",
+          remoteIp: "192.168.0.202",
+          ts: 1,
+        },
+      ],
+      paired: [],
+    });
+
+    await runDevicesCommand(["list"]);
+
+    const output = readRuntimeOutput();
+    expect(output).toContain("Pending node approvals");
+    expect(output).toContain("openclaw nodes approve node-req-abc");
+    expect(output).toContain("Colin's S25");
+    expect(output).toContain("192.168.0.202");
+  });
+
+  it("does not show node approvals section when node.pair.list returns no pending requests", async () => {
+    callGateway
+      .mockResolvedValueOnce({ pending: [], paired: [] })
+      .mockResolvedValueOnce({ pending: [], paired: [] });
+
+    await runDevicesCommand(["list"]);
+
+    expect(readRuntimeOutput()).not.toContain("Pending node approvals");
+  });
+
+  it("does not show node approvals section when node.pair.list call fails", async () => {
+    callGateway
+      .mockResolvedValueOnce({ pending: [], paired: [] })
+      .mockRejectedValueOnce(new Error("gateway error"));
+
+    await runDevicesCommand(["list"]);
+
+    expect(readRuntimeOutput()).not.toContain("Pending node approvals");
   });
 
   it("emits JSON when the gateway transport fails in JSON mode", async () => {


### PR DESCRIPTION
## What Problem This Solves

When an Android node is reconnecting and needs node-layer reapproval, running `openclaw devices approve <ip>` either throws an "unknown requestId" error or silently returns null. The node UUID required to run `openclaw nodes approve <uuid>` is not visible anywhere in the device CLI output or in the Android app, leaving the user stranded with no actionable guidance.

Addresses the CLI portion of #98045 (using `Refs` rather than `Closes` deliberately — see scope note below).

> **Scope:** Issue #98045 lists four surfaces — the Android app setup/auth screen, `openclaw gateway diagnostic` output, `openclaw devices list`, and `openclaw devices approve <ip>` error output. This PR covers the two device-CLI surfaces (`devices list` and `devices approve`). The Android-app and gateway-diagnostic surfaces are intentionally left as follow-up work. I've used `Refs #98045` instead of `Closes` so maintainers can decide whether to close the issue on the CLI coverage or keep it open for the remaining surfaces.

## Why This Change Was Made

The `devices` and `nodes` pairing layers are easy to confuse because the same physical phone appears in both. The issue requests that failed `devices approve` paths and `devices list` surface pending node approval IDs and the exact `openclaw nodes approve <uuid>` command so users can self-recover without needing to already know about the node layer.

The fix is scoped to the CLI human-readable path only (no JSON schema changes) to avoid breaking automation callers. Generated `openclaw nodes approve <id>` commands are built through the existing `quoteCliArg` + `formatCliCommand` pattern (same as the sibling `nodes status` formatter), so request IDs from permissive `node.pair.list` payloads are safely shell-quoted before being shown as copy-paste commands.

## User Impact

**Before:** `openclaw devices approve 10.0.0.5` would either throw a cryptic "unknown requestId" error or return nothing. Users had no hint that they needed to run `openclaw nodes approve <uuid>` instead.

**After:**

1. `openclaw devices list` shows a "Pending node approvals" section when `node.pair.list` returns pending requests.
2. `openclaw devices approve <ip-or-id>` that fails with "unknown requestId" or returns null shows a targeted hint matching the argument against pending node requests by IP, display name, nodeId, or requestId. The hint is suppressed in `--json` mode to avoid breaking automation.

## Evidence

### Real behavior proof (redacted)

Captured by driving the real `runDevicesListCommand` / `runDevicesApproveCommand` code paths with a mocked gateway returning one pending node approval (private IP redacted to `10.0.0.5`):

```text
$ openclaw devices list
Paired (1)
┌─────────────────────────────┬───────┬────────┬────────┬────┐
│ Device                      │ Roles │ Scopes │ Tokens │ IP │
├─────────────────────────────┼───────┼────────┼────────┼────┤
│ Phone                       │       │        │ none   │    │
└─────────────────────────────┴───────┴────────┴────────┴────┘
Pending node approvals (1)
  Node: Colin's S25 · 10.0.0.5
  Run:  openclaw nodes approve 8bb57418-07c0-4a32-bca7-5d691aa3cc69

$ openclaw devices approve 10.0.0.5
No pending device pairing request matches "10.0.0.5".
Node reapproval pending for "Colin's S25" (10.0.0.5).
Run: openclaw nodes approve 8bb57418-07c0-4a32-bca7-5d691aa3cc69
```

### Tests

All 50 tests pass (42 existing + 8 new):

```
node scripts/run-vitest.mjs src/cli/devices-cli.test.ts
...
Tests  50 passed (50)
```

New tests cover:
- hint shown when `devices approve` throws "unknown requestId" and node IP matches
- hint shown when `devices approve` returns null and a node IP matches
- hint suppressed in JSON mode
- node request IDs containing shell metacharacters are shell-quoted in the hint (regression test)
- "Pending node approvals" section shown in `devices list` output
- section hidden when `node.pair.list` returns no pending requests
- section hidden when `node.pair.list` call fails

TypeScript type check (`tsgo`) and `oxlint` both pass with no errors.

---

> **AI-assisted PR**: This change was implemented with Claude (Claude Code). The AI session explored the gateway RPC architecture, `parsePairingList`, the sibling `nodes status` command-quoting pattern, and existing test conventions before implementing the fix.

