### PR TITLE
fix(voice-call): drop dangling surrogate in partial-transcript tail slice

### DIFF
--- a/extensions/voice-call/src/webhook/realtime-handler.transcript-utf16.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.transcript-utf16.test.ts
@@ -1,0 +1,53 @@
+// Voice-call tests cover the UTF-16-safe partial-transcript tail slice in
+// webhook/realtime-handler.ts (limitPartialUserTranscript). Verifies that
+// `sliceUtf16Safe(text, -MAX_PARTIAL_USER_TRANSCRIPT_CHARS)` drops a surrogate
+// pair that straddles the tail boundary instead of leaving a lone high-
+// surrogate half in the partial transcript fed to the agent.
+import { describe, expect, it } from "vitest";
+import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+
+describe("voice-call partial-transcript tail UTF-16", () => {
+  // Mirrors MAX_PARTIAL_USER_TRANSCRIPT_CHARS in realtime-handler.ts. The
+  // exact cap is not exposed publicly, but the UTF-16-safe slicing contract
+  // is the same regardless of the numeric value, so we mirror a representative
+  // small cap here.
+  const MAX_PARTIAL_USER_TRANSCRIPT_CHARS = 200;
+  const emoji = "🎉";
+
+  it("sliceUtf16Safe drops a surrogate pair straddling the tail-start boundary", () => {
+    // Build a string of length 301 where the emoji sits at positions
+    // (100, 101). With sliceUtf16Safe(input, -200), `from = 301 - 200 = 101`,
+    // which is the low surrogate of the emoji, and position 100 is the high
+    // surrogate. The helper increments `from` past the high surrogate so the
+    // tail does not start with a lone surrogate half.
+    const input = "a".repeat(100) + emoji + "a".repeat(199);
+    const tail = sliceUtf16Safe(input, -MAX_PARTIAL_USER_TRANSCRIPT_CHARS);
+    // Tail was supposed to be 200 code units, but the dangling high surrogate
+    // at position 100 is dropped, so the tail is 199 code units.
+    expect(tail.length).toBe(199);
+    expect(tail.charCodeAt(0)).toBeLessThan(0xd800);
+  });
+
+  it("sliceUtf16Safe is a pass-through for plain ASCII partial transcript", () => {
+    const input = "hello world, this is a normal transcript";
+    expect(sliceUtf16Safe(input, -MAX_PARTIAL_USER_TRANSCRIPT_CHARS)).toBe(input);
+  });
+
+  it("sliceUtf16Safe preserves an emoji that sits entirely inside the tail window", () => {
+    // Input is exactly 200 chars. The emoji at position 100 is fully inside
+    // the tail window (no surrogate straddles the boundary).
+    const input = "a".repeat(100) + emoji + "a".repeat(98);
+    const tail = sliceUtf16Safe(input, -MAX_PARTIAL_USER_TRANSCRIPT_CHARS);
+    expect(tail.length).toBe(200);
+    expect(tail.includes(emoji)).toBe(true);
+  });
+
+  it("limitPartialUserTranscript-shaped behavior: short body passes through", () => {
+    // Mirror the production guard at the top of limitPartialUserTranscript:
+    // when text.length <= MAX_PARTIAL_USER_TRANSCRIPT_CHARS, the helper is
+    // not called (the production guard short-circuits first), so sliceUtf16Safe
+    // here is verifying a no-op for short input.
+    const input = "short";
+    expect(sliceUtf16Safe(input, -MAX_PARTIAL_USER_TRANSCRIPT_CHARS)).toBe(input);
+  });
+});

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -27,6 +27,7 @@ import {
   type TalkSessionController,
 } from "openclaw/plugin-sdk/realtime-voice";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
+import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import WebSocket, { WebSocketServer } from "ws";
 import type { VoiceCallRealtimeConfig } from "../config.js";
 import type { CallManager } from "../manager.js";
@@ -154,7 +155,7 @@ function limitPartialUserTranscript(text: string): string {
   if (text.length <= MAX_PARTIAL_USER_TRANSCRIPT_CHARS) {
     return text;
   }
-  const tail = text.slice(-MAX_PARTIAL_USER_TRANSCRIPT_CHARS);
+  const tail = sliceUtf16Safe(text, -MAX_PARTIAL_USER_TRANSCRIPT_CHARS);
   return tail.replace(/^\S+\s+/, "").trimStart() || tail.trimStart();
 }
 


### PR DESCRIPTION
## What Problem This Solves

`extensions/voice-call/src/webhook/realtime-handler.ts:157` uses raw `text.slice(-MAX_PARTIAL_USER_TRANSCRIPT_CHARS)` in `limitPartialUserTranscript()` to take the tail of a partial user transcript before sending it to the agent. When an emoji or other astral character straddles the tail-start boundary, the slice keeps only the LOW-surrogate half (e.g. `0xDF89` for `🎉`), producing malformed UTF-16 (`?`/`�`) in the agent prompt.

This is the same pattern that Alix-007 fixed for Twitch (#98008), Signal (#97982), and that we just fixed for msteams (#98058) and imessage (#98065). Voice-call was the remaining channel surface using raw `.slice()` on a message body.

## Why This Change Was Made

The plugin SDK provides `sliceUtf16Safe` in `openclaw/plugin-sdk/text-utility-runtime` for exactly this pattern. Its negative-start handling (`start < 0` clamps to `len + start`, equivalent to a tail slice) AND its boundary surrogate-pair drop make it a drop-in replacement for `text.slice(-N)`.

The shape mirrors our msteams PR (#98058) but is even smaller — 1 file, 1 import, 1 line replacement.

## Evidence

Boundary probe — input is `🎉` (U+1F389, surrogate pair `0xD83C 0xDF89`) placed so the LOW surrogate lands at the tail-start boundary:

```
[tail-200 surrogate straddles start]
  BEFORE .slice(-200):                 length=200 start=[df89 0061 0061 0061]   ← lone LOW surrogate, malformed UTF-16
  AFTER  sliceUtf16Safe(s, -200):      length=199 start=[0061 0061 0061 0061]   ← clean, surrogate pair dropped whole

[plain ASCII tail]
  BEFORE .slice(-200):                 length=200 start=[0061 0061 0061 0061]   ← pass-through, no change
  AFTER  sliceUtf16Safe(s, -200):      length=200 start=[0061 0061 0061 0061]

[emoji inside tail window]
  BEFORE .slice(-200):                 length=200 start=[0061 0061 0061 0061]   ← emoji fully inside window, preserved
  AFTER  sliceUtf16Safe(s, -200):      length=200 start=[0061 0061 0061 0061]
```

The first row is the bug — `🎉` straddles the boundary at position 100/101, and `slice(-200)` returns the LOW surrogate half (`0xDF89`) at the start of the tail. `sliceUtf16Safe(s, -200)` detects this (input.charCodeAt(100) is the high surrogate, input.charCodeAt(101) is the low surrogate) and bumps `from` to 102, dropping the surrogate pair whole and returning a 199-char clean ASCII tail.

## After-fix Proof

- `node scripts/run-vitest.mjs extensions/voice-call/src/webhook/realtime-handler.transcript-utf16.test.ts --reporter=verbose`

```
 ✓ |extension-voice-call| extensions/voice-call/src/webhook/realtime-handler.transcript-utf16.test.ts > voice-call partial-transcript tail UTF-16 > sliceUtf16Safe drops a surrogate pair straddling the tail-start boundary 82ms
 ✓ |extension-voice-call| extensions/voice-call/src/webhook/realtime-handler.transcript-utf16.test.ts > voice-call partial-transcript tail UTF-16 > sliceUtf16Safe is a pass-through for plain ASCII partial transcript 1ms
 ✓ |extension-voice-call| extensions/voice-call/src/webhook/realtime-handler.transcript-utf16.test.ts > voice-call partial-transcript tail UTF-16 > sliceUtf16Safe preserves an emoji that sits entirely inside the tail window 1ms
 ✓ |extension-voice-call| extensions/voice-call/src/webhook/realtime-handler.transcript-utf16.test.ts > voice-call partial-transcript tail UTF-16 > limitPartialUserTranscript-shaped behavior: short body passes through 0ms

 Test Files  1 passed (1)
      Tests  4 passed (4)

[test] passed 1 Vitest shard in 10.75s
```

- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.scripts.json extensions/voice-call/src/webhook/realtime-handler.ts extensions/voice-call/src/webhook/realtime-handler.transcript-utf16.test.ts` → EXIT=0
- `git diff --check openclaw/main...HEAD` → clean

## Diff scope

```
 extensions/voice-call/src/webhook/realtime-handler.ts                       |  3 ++-
 extensions/voice-call/src/webhook/realtime-handler.transcript-utf16.test.ts | 53 ++++++++++ (new)
 2 files changed, 55 insertions(+), 1 deletion(-)
```

## Security & Privacy

No user-facing behavior change for ASCII partial transcripts — the tail passes through verbatim. For emoji-straddling transcripts, the tail is one code unit shorter because the surrogate pair is dropped whole instead of leaving a lone surrogate half — this is the intended UTF-16 boundary fix, not a content loss. The partial-transcript cap itself (`MAX_PARTIAL_USER_TRANSCRIPT_CHARS`) is unchanged.

## Compatibility

Plugin SDK export (`openclaw/plugin-sdk/text-utility-runtime`) is already in `package.json` exports for `@openclaw/plugin-sdk`. The helper is dependency-free per `src/shared/utf16-slice.ts:1-5` (no `node:` imports), so it bundles cleanly into both server and UI builds.

## What was not tested

Live voice-call session with a real partial transcript that straddles a surrogate pair. The fix is a one-line surrogate-pair guard; the helper is covered by unit tests in `src/shared/utf16-slice.ts`. Integration coverage at this layer is intentionally out of scope — Alix-007's PRs #98008 (Twitch) and #97982 (Signal) followed the same boundary and were accepted on the same evidence.

## Other channel plugins that already use the helper

Discord, Feishu, Telegram, Signal (#97982), Mattermost, Slack, Twitch (#98008), msteams (#98058), iMessage (#98065). voice-call is the new addition.

## Related

- Alix-007 #98008 (Twitch): same fix shape on `text.slice(0, 100)` debug-log preview.
- Alix-007 #97982 (Signal): same fix shape on `body.slice(0, 200)` verbose-log preview.
- Our #98058 (msteams): same fix shape on `text.slice(0, 50)` debug log + `slice(0, 160)` system event label.
- Our #98065 (imessage): same fix shape on `text.slice(0, 50)` debounced merge preview + `lines[0]?.slice(0, 120)` probe snippet.
- Helper source: `src/shared/utf16-slice.ts` (read-only reference, already merged).