### PR TITLE
test(config): add unit tests for resolveExecCommandHighlighting

### DIFF
--- a/src/config/exec-command-highlighting.test.ts
+++ b/src/config/exec-command-highlighting.test.ts
@@ -1,0 +1,154 @@
+// Verifies exec command highlighting resolution across global and agent-scoped config.
+import { describe, expect, it } from "vitest";
+import { resolveExecCommandHighlighting } from "./exec-command-highlighting.js";
+import type { OpenClawConfig } from "./types.openclaw.js";
+
+describe("resolveExecCommandHighlighting", () => {
+  it("defaults to false when no config is provided", () => {
+    expect(resolveExecCommandHighlighting({})).toBe(false);
+  });
+
+  it("defaults to false when config is null", () => {
+    expect(resolveExecCommandHighlighting({ config: null })).toBe(false);
+  });
+
+  it("reads global exec commandHighlighting", () => {
+    const config = {
+      tools: { exec: { commandHighlighting: true } },
+    } satisfies OpenClawConfig;
+
+    expect(resolveExecCommandHighlighting({ config })).toBe(true);
+  });
+
+  it("returns false when global exec commandHighlighting is disabled", () => {
+    const config = {
+      tools: { exec: { commandHighlighting: false } },
+    } satisfies OpenClawConfig;
+
+    expect(resolveExecCommandHighlighting({ config })).toBe(false);
+  });
+
+  it("agent-scoped true overrides global false", () => {
+    const config = {
+      agents: {
+        list: [
+          {
+            id: "alpha",
+            tools: { exec: { commandHighlighting: true } },
+          },
+        ],
+      },
+      tools: { exec: { commandHighlighting: false } },
+    } satisfies OpenClawConfig;
+
+    expect(resolveExecCommandHighlighting({ config, agentId: "alpha" })).toBe(true);
+  });
+
+  it("agent-scoped false overrides global true", () => {
+    const config = {
+      agents: {
+        list: [
+          {
+            id: "alpha",
+            tools: { exec: { commandHighlighting: false } },
+          },
+        ],
+      },
+      tools: { exec: { commandHighlighting: true } },
+    } satisfies OpenClawConfig;
+
+    expect(resolveExecCommandHighlighting({ config, agentId: "alpha" })).toBe(false);
+  });
+
+  it("agent without override falls back to global true", () => {
+    const config = {
+      agents: {
+        list: [{ id: "alpha" }],
+      },
+      tools: { exec: { commandHighlighting: true } },
+    } satisfies OpenClawConfig;
+
+    expect(resolveExecCommandHighlighting({ config, agentId: "alpha" })).toBe(true);
+  });
+
+  it("agent without override falls back to global false", () => {
+    const config = {
+      agents: {
+        list: [{ id: "alpha" }],
+      },
+      tools: { exec: { commandHighlighting: false } },
+    } satisfies OpenClawConfig;
+
+    expect(resolveExecCommandHighlighting({ config, agentId: "alpha" })).toBe(false);
+  });
+
+  it("agent with explicit true and no global returns true", () => {
+    const config = {
+      agents: {
+        list: [
+          {
+            id: "alpha",
+            tools: { exec: { commandHighlighting: true } },
+          },
+        ],
+      },
+    } satisfies OpenClawConfig;
+
+    expect(resolveExecCommandHighlighting({ config, agentId: "alpha" })).toBe(true);
+  });
+
+  it("agent with explicit false and no global falls back to false", () => {
+    const config = {
+      agents: {
+        list: [
+          {
+            id: "alpha",
+            tools: { exec: { commandHighlighting: false } },
+          },
+        ],
+      },
+    } satisfies OpenClawConfig;
+
+    expect(resolveExecCommandHighlighting({ config, agentId: "alpha" })).toBe(false);
+  });
+
+  it("falls back to global config when agent ID is not in the agent list", () => {
+    const config = {
+      tools: { exec: { commandHighlighting: true } },
+    } satisfies OpenClawConfig;
+
+    expect(resolveExecCommandHighlighting({ config, agentId: "nonexistent" })).toBe(true);
+  });
+
+  it("agent ID normalization matches agent list entries", () => {
+    // normalizeAgentId lowercases and trims the agent ID, so "ALPHA" should
+    // match an entry with id "alpha".
+    const config = {
+      agents: {
+        list: [
+          {
+            id: "alpha",
+            tools: { exec: { commandHighlighting: true } },
+          },
+        ],
+      },
+    } satisfies OpenClawConfig;
+
+    expect(resolveExecCommandHighlighting({ config, agentId: "ALPHA" })).toBe(true);
+  });
+
+  it("unrelated agent ID does not affect the result", () => {
+    const config = {
+      agents: {
+        list: [
+          {
+            id: "other",
+            tools: { exec: { commandHighlighting: true } },
+          },
+        ],
+      },
+    } satisfies OpenClawConfig;
+
+    expect(resolveExecCommandHighlighting({ config, agentId: "alpha" })).toBe(false);
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

The `exec-command-highlighting.ts` module resolves whether exec command highlighting is enabled, with agent-scoped config overriding the global setting. Despite being used by two production callers (`agent-tools.ts`, `exec-approval.ts`), this function had no direct unit tests.

## Why This Change Was Made

Add focused unit tests for `resolveExecCommandHighlighting` to verify:
- Global config defaults (no config, null config, global true/false)
- Agent-scoped override (agent true overrides global false, agent false overrides global true)
- Fallback chain (agent without override falls back to global, no global falls to false)
- Agent ID normalization matching (case-insensitive lookup)
- Non-existent and unrelated agent IDs

This improves test coverage and prevents regressions when the exec config surface is modified.

## User Impact

No user-facing behavior change. Strictly additive test coverage.

## Evidence

Direct behavior probe:

```
$ node --import tsx -e "import { resolveExecCommandHighlighting } from './src/config/exec-command-highlighting.js'; const results = [ ... ]; console.log(JSON.stringify(results, null, 2));"
[
  { "desc": "no config", "result": false },
  { "desc": "null config", "result": false },
  { "desc": "global true, no agent", "result": true },
  { "desc": "global false, no agent", "result": false },
  { "desc": "agent true overrides global false", "result": true },
  { "desc": "agent false overrides global true", "result": false },
  { "desc": "agent without override falls back to global", "result": true },
  { "desc": "agent with explicit true, no global", "result": true },
  { "desc": "normalized agent ID match", "result": true }
]
```

Unit test run:

```
$ pnpm test src/config/exec-command-highlighting.test.ts

 RUN  v4.1.8

 Test Files  1 passed (1)
      Tests  13 passed (13)
```

Formatting:

```
$ pnpm oxfmt -- src/config/exec-command-highlighting.test.ts
Finished in 119ms on 1 files using 8 threads.
```

Whitespace:

```
$ git diff --check
```