### PR TITLE
fix(core): propagate caller env PATHEXT through isExecutableFile on Windows

### DIFF
--- a/src/infra/executable-path.test.ts
+++ b/src/infra/executable-path.test.ts
@@ -216,3 +216,105 @@ describe("resolveExecutable", () => {
     });
   });
 });
+
+describe("caller env PATHEXT propagation", () => {
+  // These tests verify that isExecutableFile and its callers use the
+  // caller-provided env.PATHEXT (not just process.env.PATHEXT) on Windows.
+  // Regression for: isExecutableFile hardcoded undefined -> ignore caller env.
+
+  it("isExecutableFile respects caller env.PATHEXT on Windows", async () => {
+    await withTempDir({ prefix: "openclaw-exec-path-" }, async (base) => {
+      const ps1File = path.join(base, "script.ps1");
+      await fs.writeFile(ps1File, 'Write-Output "ok"\n', "utf8");
+
+      // On Windows with only .PS1 in caller env, isExecutableFile should accept it
+      withMockedPlatform("win32", () => {
+        expect(isExecutableFile(ps1File, { env: { PATHEXT: ".PS1" } })).toBe(true);
+      });
+    });
+  });
+
+  it("isExecutableFile fallback to process.env when no caller env is given", async () => {
+    await withTempDir({ prefix: "openclaw-exec-path-" }, async (base) => {
+      const ps1File = path.join(base, "script.ps1");
+      await fs.writeFile(ps1File, 'Write-Output "ok"\n', "utf8");
+
+      // Save current process.env.PATHEXT, set it to empty so no extension matches
+      const orig = process.env.PATHEXT;
+      process.env.PATHEXT = ".TXT";
+      try {
+        withMockedPlatform("win32", () => {
+          // .PS1 not in process.env.PATHEXT (which is .TXT)
+          expect(isExecutableFile(ps1File)).toBe(false);
+        });
+      } finally {
+        restoreEnvValue("PATHEXT", orig);
+      }
+    });
+  });
+
+  it("resolveExecutableFromPathEnv uses caller env PATHEXT on Windows", async () => {
+    await withTempDir({ prefix: "openclaw-exec-path-" }, async (base) => {
+      const binDir = path.join(base, "bin");
+      await fs.mkdir(binDir, { recursive: true });
+
+      const ps1Path = path.join(binDir, "tool.ps1");
+      await fs.writeFile(ps1Path, 'Write-Output "ok"\n', "utf8");
+      // On Windows the delimiter is ";", build pathEnv accordingly for mocked platform
+      const pathEnv = `${binDir};${process.env.PATH ?? ""}`;
+
+      withMockedPlatform("win32", () => {
+        // Caller env has .PS1, process.env.PATHEXT does not
+        const result = resolveExecutableFromPathEnv("tool", pathEnv, { PATHEXT: ".PS1" });
+        expect(result).toBe(ps1Path);
+      });
+    });
+  });
+
+  it("resolveExecutablePath with path separator passes env to PATHEXT check on Windows", async () => {
+    await withTempDir({ prefix: "openclaw-exec-path-" }, async (base) => {
+      const ps1File = path.join(base, "script.ps1");
+      await fs.writeFile(ps1File, 'Write-Output "ok"\n', "utf8");
+
+      withMockedPlatform("win32", () => {
+        // Passing an absolute path (has separator) with custom env
+        const result = resolveExecutablePath(ps1File, { env: { PATHEXT: ".PS1" } });
+        expect(result).toBe(ps1File);
+      });
+    });
+  });
+
+  it("resolveExecutablePath without path separator falls back to PATH env", async () => {
+    await withTempDir({ prefix: "openclaw-exec-path-" }, async (base) => {
+      const binDir = path.join(base, "bin");
+      await fs.mkdir(binDir, { recursive: true });
+      const ps1Path = path.join(binDir, "runner.ps1");
+      await fs.writeFile(ps1Path, 'Write-Output "ok"\n', "utf8");
+
+      withMockedPlatform("win32", () => {
+        const result = resolveExecutablePath("runner", {
+          env: { PATH: binDir, PATHEXT: ".PS1" },
+        });
+        expect(result).toBe(ps1Path);
+      });
+    });
+  });
+
+  it("resolveExecutablePath with path separator falls back to process.env when no caller env given", async () => {
+    await withTempDir({ prefix: "openclaw-exec-path-" }, async (base) => {
+      const ps1File = path.join(base, "script.ps1");
+      await fs.writeFile(ps1File, 'Write-Output "ok"\n', "utf8");
+
+      const orig = process.env.PATHEXT;
+      process.env.PATHEXT = ".TXT";
+      try {
+        withMockedPlatform("win32", () => {
+          // No caller env given, process.env.PATHEXT is .TXT -> .PS1 not matched -> undefined
+          expect(resolveExecutablePath(ps1File)).toBeUndefined();
+        });
+      } finally {
+        restoreEnvValue("PATHEXT", orig);
+      }
+    });
+  });
+});

--- a/src/infra/executable-path.test.ts
+++ b/src/infra/executable-path.test.ts
@@ -223,15 +223,21 @@ describe("caller env PATHEXT propagation", () => {
   // Regression for: isExecutableFile hardcoded undefined -> ignore caller env.
 
   it("isExecutableFile respects caller env.PATHEXT on Windows", async () => {
-    await withTempDir({ prefix: "openclaw-exec-path-" }, async (base) => {
-      const ps1File = path.join(base, "script.ps1");
-      await fs.writeFile(ps1File, 'Write-Output "ok"\n', "utf8");
+    const orig = process.env.PATHEXT;
+    process.env.PATHEXT = ".TXT";
+    try {
+      await withTempDir({ prefix: "openclaw-exec-path-" }, async (base) => {
+        const ps1File = path.join(base, "script.ps1");
+        await fs.writeFile(ps1File, 'Write-Output "ok"\n', "utf8");
 
-      // On Windows with only .PS1 in caller env, isExecutableFile should accept it
-      withMockedPlatform("win32", () => {
-        expect(isExecutableFile(ps1File, { env: { PATHEXT: ".PS1" } })).toBe(true);
+        // On Windows with only .PS1 in caller env, isExecutableFile should accept it
+        withMockedPlatform("win32", () => {
+          expect(isExecutableFile(ps1File, { env: { PATHEXT: ".PS1" } })).toBe(true);
+        });
       });
-    });
+    } finally {
+      restoreEnvValue("PATHEXT", orig);
+    }
   });
 
   it("isExecutableFile fallback to process.env when no caller env is given", async () => {
@@ -254,50 +260,68 @@ describe("caller env PATHEXT propagation", () => {
   });
 
   it("resolveExecutableFromPathEnv uses caller env PATHEXT on Windows", async () => {
-    await withTempDir({ prefix: "openclaw-exec-path-" }, async (base) => {
-      const binDir = path.join(base, "bin");
-      await fs.mkdir(binDir, { recursive: true });
+    const orig = process.env.PATHEXT;
+    process.env.PATHEXT = ".TXT";
+    try {
+      await withTempDir({ prefix: "openclaw-exec-path-" }, async (base) => {
+        const binDir = path.join(base, "bin");
+        await fs.mkdir(binDir, { recursive: true });
 
-      const ps1Path = path.join(binDir, "tool.ps1");
-      await fs.writeFile(ps1Path, 'Write-Output "ok"\n', "utf8");
-      // On Windows the delimiter is ";", build pathEnv accordingly for mocked platform
-      const pathEnv = `${binDir};${process.env.PATH ?? ""}`;
+        const ps1Path = path.join(binDir, "tool.ps1");
+        await fs.writeFile(ps1Path, 'Write-Output "ok"\n', "utf8");
+        // On Windows the delimiter is ";", build pathEnv accordingly for mocked platform
+        const pathEnv = `${binDir};${process.env.PATH ?? ""}`;
 
-      withMockedPlatform("win32", () => {
-        // Caller env has .PS1, process.env.PATHEXT does not
-        const result = resolveExecutableFromPathEnv("tool", pathEnv, { PATHEXT: ".PS1" });
-        expect(result).toBe(ps1Path);
+        withMockedPlatform("win32", () => {
+          // Caller env has .PS1, process.env.PATHEXT does not
+          const result = resolveExecutableFromPathEnv("tool", pathEnv, { PATHEXT: ".PS1" });
+          expect(result).toBe(ps1Path);
+        });
       });
-    });
+    } finally {
+      restoreEnvValue("PATHEXT", orig);
+    }
   });
 
   it("resolveExecutablePath with path separator passes env to PATHEXT check on Windows", async () => {
-    await withTempDir({ prefix: "openclaw-exec-path-" }, async (base) => {
-      const ps1File = path.join(base, "script.ps1");
-      await fs.writeFile(ps1File, 'Write-Output "ok"\n', "utf8");
+    const orig = process.env.PATHEXT;
+    process.env.PATHEXT = ".TXT";
+    try {
+      await withTempDir({ prefix: "openclaw-exec-path-" }, async (base) => {
+        const ps1File = path.join(base, "script.ps1");
+        await fs.writeFile(ps1File, 'Write-Output "ok"\n', "utf8");
 
-      withMockedPlatform("win32", () => {
-        // Passing an absolute path (has separator) with custom env
-        const result = resolveExecutablePath(ps1File, { env: { PATHEXT: ".PS1" } });
-        expect(result).toBe(ps1File);
+        withMockedPlatform("win32", () => {
+          // Passing an absolute path (has separator) with custom env
+          const result = resolveExecutablePath(ps1File, { env: { PATHEXT: ".PS1" } });
+          expect(result).toBe(ps1File);
+        });
       });
-    });
+    } finally {
+      restoreEnvValue("PATHEXT", orig);
+    }
   });
 
   it("resolveExecutablePath without path separator falls back to PATH env", async () => {
-    await withTempDir({ prefix: "openclaw-exec-path-" }, async (base) => {
-      const binDir = path.join(base, "bin");
-      await fs.mkdir(binDir, { recursive: true });
-      const ps1Path = path.join(binDir, "runner.ps1");
-      await fs.writeFile(ps1Path, 'Write-Output "ok"\n', "utf8");
+    const orig = process.env.PATHEXT;
+    process.env.PATHEXT = ".TXT";
+    try {
+      await withTempDir({ prefix: "openclaw-exec-path-" }, async (base) => {
+        const binDir = path.join(base, "bin");
+        await fs.mkdir(binDir, { recursive: true });
+        const ps1Path = path.join(binDir, "runner.ps1");
+        await fs.writeFile(ps1Path, 'Write-Output "ok"\n', "utf8");
 
-      withMockedPlatform("win32", () => {
-        const result = resolveExecutablePath("runner", {
-          env: { PATH: binDir, PATHEXT: ".PS1" },
+        withMockedPlatform("win32", () => {
+          const result = resolveExecutablePath("runner", {
+            env: { PATH: binDir, PATHEXT: ".PS1" },
+          });
+          expect(result).toBe(ps1Path);
         });
-        expect(result).toBe(ps1Path);
       });
-    });
+    } finally {
+      restoreEnvValue("PATHEXT", orig);
+    }
   });
 
   it("resolveExecutablePath with path separator falls back to process.env when no caller env given", async () => {

--- a/src/infra/executable-path.ts
+++ b/src/infra/executable-path.ts
@@ -46,8 +46,10 @@ function resolveWindowsExecutableExtensions(
     "",
     ...(
       env?.PATHEXT ??
+      env?.PathExt ??
       env?.Pathext ??
       process.env.PATHEXT ??
+      process.env.PathExt ??
       process.env.Pathext ??
       ".EXE;.CMD;.BAT;.COM"
     )
@@ -60,8 +62,10 @@ function resolveWindowsExecutableExtSet(env: NodeJS.ProcessEnv | undefined): Set
   return new Set(
     (
       env?.PATHEXT ??
+      env?.PathExt ??
       env?.Pathext ??
       process.env.PATHEXT ??
+      process.env.PathExt ??
       process.env.Pathext ??
       ".EXE;.CMD;.BAT;.COM"
     )

--- a/src/infra/executable-path.ts
+++ b/src/infra/executable-path.ts
@@ -71,7 +71,7 @@ function resolveWindowsExecutableExtSet(env: NodeJS.ProcessEnv | undefined): Set
   );
 }
 
-export function isExecutableFile(filePath: string): boolean {
+export function isExecutableFile(filePath: string, options?: { env?: NodeJS.ProcessEnv }): boolean {
   try {
     const stat = fs.statSync(filePath);
     if (!stat.isFile()) {
@@ -82,7 +82,7 @@ export function isExecutableFile(filePath: string): boolean {
       if (!ext) {
         return true;
       }
-      return resolveWindowsExecutableExtSet(undefined).has(ext);
+      return resolveWindowsExecutableExtSet(options?.env).has(ext);
     }
     fs.accessSync(filePath, fs.constants.X_OK);
     return true;
@@ -102,7 +102,7 @@ export function resolveExecutableFromPathEnv(
   for (const entry of entries) {
     for (const ext of extensions) {
       const candidate = path.join(entry, executable + ext);
-      if (isExecutableFile(candidate)) {
+      if (isExecutableFile(candidate, { env })) {
         return candidate;
       }
     }
@@ -119,7 +119,7 @@ export function resolveExecutablePath(
     return undefined;
   }
   if (candidate.includes("/") || candidate.includes("\\")) {
-    return isExecutableFile(candidate) ? candidate : undefined;
+    return isExecutableFile(candidate, options) ? candidate : undefined;
   }
   const envPath =
     options?.env?.PATH ?? options?.env?.Path ?? process.env.PATH ?? process.env.Path ?? "";
@@ -148,7 +148,7 @@ export function resolveExecutable(cmd: string): string {
   for (const entry of entries) {
     for (const ext of extensions) {
       const candidate = path.join(entry, cmd + ext);
-      if (isExecutableFile(candidate)) {
+      if (isExecutableFile(candidate, { env: process.env })) {
         matches.push(candidate);
       }
     }

--- a/src/node-host/invoke.ts
+++ b/src/node-host/invoke.ts
@@ -375,7 +375,13 @@ function resolveExecutable(bin: string, env?: Record<string, string>) {
   }
   const extensions =
     process.platform === "win32"
-      ? (process.env.PATHEXT ?? process.env.PathExt ?? ".EXE;.CMD;.BAT;.COM")
+      ? (
+          env?.PATHEXT ??
+          env?.Pathext ??
+          process.env.PATHEXT ??
+          process.env.PathExt ??
+          ".EXE;.CMD;.BAT;.COM"
+        )
           .split(";")
           .map((ext) => normalizeLowercaseStringOrEmpty(ext))
       : [""];

--- a/src/node-host/invoke.ts
+++ b/src/node-host/invoke.ts
@@ -377,6 +377,7 @@ function resolveExecutable(bin: string, env?: Record<string, string>) {
     process.platform === "win32"
       ? (
           env?.PATHEXT ??
+          env?.PathExt ??
           env?.Pathext ??
           process.env.PATHEXT ??
           process.env.PathExt ??


### PR DESCRIPTION
## What Problem This Solves

On Windows, `isExecutableFile` hardcodes `undefined` when calling `resolveWindowsExecutableExtSet`, ignoring any caller-provided custom `env.PATHEXT`. This means `resolveExecutablePath` and `resolveExecutableFromPathEnv` fall back to `process.env.PATHEXT` even when the caller supplied a different `env` with an extended PATHEXT (e.g. `.PS1`).

The same invariant exists in the sibling `system.which` resolver in `src/node-host/invoke.ts`.

This affects Windows deployments using sandbox/container environments where PATHEXT differs from process.env (Docker Windows containers, CI runners, isolated test environments).

## Evidence

### Windows CI run (windows-latest, all 17 tests pass)

CI run: https://github.com/wendy-chsy/openclaw/actions/runs/28435337278

```
 ✓ caller env PATHEXT propagation > isExecutableFile respects caller env.PATHEXT on Windows
 ✓ caller env PATHEXT propagation > isExecutableFile fallback to process.env when no caller env is given
 ✓ caller env PATHEXT propagation > resolveExecutableFromPathEnv uses caller env PATHEXT on Windows
 ✓ caller env PATHEXT propagation > resolveExecutablePath with path separator passes env to PATHEXT check on Windows
 ✓ caller env PATHEXT propagation > resolveExecutablePath without path separator falls back to PATH env
 ✓ caller env PATHEXT propagation > resolveExecutablePath with path separator falls back to process.env when no caller env given

 Test Files  1 passed (1)
      Tests  17 passed | 1 skipped (18)
```

### Real Windows terminal proof (Windows 11, standalone script)

```
=== Test 1: isExecutableFile with custom PATHEXT ===
File: D:\Temp\openclaw-pathtest-1782824699437\hello.ps1

with env { PATHEXT: '.PS1' } => true
Expected: true

with env { PATHEXT: '.TXT' } => false
Expected: false

=== Test 2: resolveExecutablePath with custom PATHEXT ===
resolveExecutablePath('tool.ps1', env with PATHEXT .PS1) => D:\Temp\openclaw-pathtest-1782824699437\bin\tool.ps1
Expected: D:\Temp\openclaw-pathtest-1782824699437\bin\tool.ps1

resolveExecutablePath('tool.ps1') without env => undefined
Expected: undefined (not executable via default PATHEXT)

=== All tests passed on REAL Windows ===
```

**Evidence:** A standalone Node.js script calling the actual exported functions (`isExecutableFile`, `resolveExecutablePath`) directly on a real Windows 11 machine — not a test framework. All 4 assertions passed, proving:
1. `isExecutableFile` accepts caller env PATHEXT (`.PS1` → `true`)
2. `isExecutableFile` falls back to process.env when no env given (`.TXT` → `false`)
3. `resolveExecutablePath` finds the file when caller env has matching PATHEXT
4. `resolveExecutablePath` returns `undefined` without caller env (backward compat preserved)

**Behavior or issue addressed:** `isExecutableFile` ignored caller env.PATHEXT on Windows, causing false negatives when custom env has extended PATHEXT.

## Fix

- `src/infra/executable-path.ts`: Added optional `options.env` parameter to `isExecutableFile`; `resolveWindowsExecutableExtSet` now reads from `options?.env` instead of `undefined`; all 3 callers pass their available env through
- `src/node-host/invoke.ts`: `system.which` resolver now checks caller env PATHEXT before falling back to `process.env.PATHEXT`
- Fully backward compatible: undefined env falls back to `process.env.PATHEXT`, preserving existing behavior

## Tests and validation

- `pnpm test src/infra/executable-path.test.ts` — 17 passed, 1 skipped (both Linux and real Windows)
- 6 new tests specifically for caller env PATHEXT propagation on Windows
- Real Windows standalone script proving the fix works outside test framework
- The 3 unrelated `errors.test.ts` failures are pre-existing on main

## Risk checklist
- User-facing behavior change: No (backward compatible, undefined env = same behavior)
- Config/API surface change: Yes — `isExecutableFile` signature changed (added optional param)
- Security impact: No
- Breaking for plugins: No (existing callers with single argument still work)

Co-Authored-By: Claude <noreply@anthropic.com>

### Additional fixes (2026-06-30)

- Added  and  casing to both PATHEXT lookup functions — callers using PascalCase  in their env object are now supported
- Isolated all positive PATHEXT tests from host  by explicitly setting it to  before each test
