### PR TITLE
fix(android): clarify gateway auth recovery states

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
@@ -1213,11 +1213,9 @@ internal fun recoveryGatewayDetail(
   nodeCapabilityApprovalState: GatewayNodeApprovalState,
   gatewayConnectionProblem: GatewayConnectionProblem?,
 ): String =
-  remoteAddress
-    ?.takeIf { it.isNotBlank() }
-    ?: if (ready) {
-      "Ready for chat and voice"
-    } else if (
+  if (ready) {
+    remoteAddress?.takeIf { it.isNotBlank() } ?: "Ready for chat and voice"
+  } else if (
       nodeCapabilityApprovalState == GatewayNodeApprovalState.PendingApproval ||
       nodeCapabilityApprovalState == GatewayNodeApprovalState.PendingReapproval ||
       nodeCapabilityApprovalState == GatewayNodeApprovalState.Unapproved
@@ -1238,7 +1236,7 @@ internal fun recoveryGatewayDetail(
     } else if (gatewayStatusLooksLikePairing(statusText)) {
       "Gateway approval is in progress. OpenClaw will retry automatically."
     } else {
-      "Gateway unreachable"
+      remoteAddress?.takeIf { it.isNotBlank() } ?: "Gateway unreachable"
     }
 
 internal fun recoveryGatewayAuthDetail(gatewayConnectionProblem: GatewayConnectionProblem): String =

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
@@ -1206,7 +1206,7 @@ private fun resolveGatewayConfig(
 }
 
 /** Selects the recovery detail line from endpoint metadata and transient gateway status. */
-private fun recoveryGatewayDetail(
+internal fun recoveryGatewayDetail(
   ready: Boolean,
   remoteAddress: String?,
   statusText: String,
@@ -1229,6 +1229,8 @@ private fun recoveryGatewayDetail(
       recoveryGatewayApprovalCommand(gatewayConnectionProblem)
         ?.let { "Gateway approval is pending. Run this on the gateway host:" }
         ?: "Gateway approval is pending. Run openclaw devices list on the gateway host, approve this phone, then retry."
+    } else if (gatewayConnectionProblem?.isPairingRequired == true && gatewayConnectionProblem.canAutoRetry) {
+      "Gateway approval is in progress. OpenClaw will retry automatically."
     } else if (gatewayConnectionProblem != null) {
       recoveryGatewayAuthDetail(gatewayConnectionProblem)
     } else if (statusText.contains("operator offline", ignoreCase = true)) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
@@ -1221,8 +1221,6 @@ internal fun recoveryGatewayDetail(
       nodeCapabilityApprovalState == GatewayNodeApprovalState.Unapproved
     ) {
       "Gateway paired. Waiting for node capability approval."
-    } else if (nodeCapabilityApprovalState == GatewayNodeApprovalState.Loading) {
-      "Gateway paired. Checking node capability approval."
     } else if (gatewayConnectionProblem?.isPairingRequired == true && !gatewayConnectionProblem.canAutoRetry) {
       recoveryGatewayApprovalCommand(gatewayConnectionProblem)
         ?.let { "Gateway approval is pending. Run this on the gateway host:" }
@@ -1231,6 +1229,8 @@ internal fun recoveryGatewayDetail(
       "Gateway approval is in progress. OpenClaw will retry automatically."
     } else if (gatewayConnectionProblem != null) {
       recoveryGatewayAuthDetail(gatewayConnectionProblem)
+    } else if (nodeCapabilityApprovalState == GatewayNodeApprovalState.Loading) {
+      "Gateway paired. Checking node capability approval."
     } else if (statusText.contains("operator offline", ignoreCase = true)) {
       "Gateway paired. Waiting for operator access."
     } else if (gatewayStatusLooksLikePairing(statusText)) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
@@ -1229,6 +1229,8 @@ private fun recoveryGatewayDetail(
       recoveryGatewayApprovalCommand(gatewayConnectionProblem)
         ?.let { "Gateway approval is pending. Run this on the gateway host:" }
         ?: "Gateway approval is pending. Run openclaw devices list on the gateway host, approve this phone, then retry."
+    } else if (gatewayConnectionProblem != null) {
+      recoveryGatewayAuthDetail(gatewayConnectionProblem)
     } else if (statusText.contains("operator offline", ignoreCase = true)) {
       "Gateway paired. Waiting for operator access."
     } else if (gatewayStatusLooksLikePairing(statusText)) {
@@ -1236,6 +1238,27 @@ private fun recoveryGatewayDetail(
     } else {
       "Gateway unreachable"
     }
+
+internal fun recoveryGatewayAuthDetail(gatewayConnectionProblem: GatewayConnectionProblem): String =
+  when (gatewayConnectionProblem.code) {
+    "AUTH_BOOTSTRAP_TOKEN_INVALID" -> "Setup code expired. Scan a fresh setup QR."
+    "AUTH_DEVICE_TOKEN_MISMATCH",
+    "AUTH_TOKEN_MISMATCH",
+    -> "Saved authentication is invalid. Re-authenticate or reset this gateway connection."
+    "AUTH_PASSWORD_MISSING" -> "Gateway password is required. Enter it again or edit this connection."
+    "AUTH_PASSWORD_MISMATCH" -> "Gateway password is invalid. Re-enter it or reset this gateway connection."
+    "AUTH_TOKEN_MISSING" -> "Gateway token is required. Enter it again or edit this connection."
+    "CONTROL_UI_DEVICE_IDENTITY_REQUIRED",
+    "DEVICE_IDENTITY_REQUIRED",
+    -> "Gateway requires this device identity. Re-authenticate or reset this gateway connection."
+    else ->
+      when (gatewayConnectionProblem.recommendedNextStep) {
+        "update_auth_credentials" -> "Saved authentication is invalid. Re-authenticate or reset this gateway connection."
+        "update_auth_configuration" -> "Gateway authentication is not configured. Edit this connection and try again."
+        "review_auth_configuration" -> "Gateway authentication needs review. Check gateway settings, then retry."
+        else -> gatewayConnectionProblem.message.takeIf { it.isNotBlank() } ?: "Gateway authentication needs attention."
+      }
+  }
 
 private fun recoveryGatewayApprovalCommand(gatewayConnectionProblem: GatewayConnectionProblem?): String? {
   if (gatewayConnectionProblem?.isPairingRequired != true || gatewayConnectionProblem.canAutoRetry) return null

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/OnboardingFlowLogicTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/OnboardingFlowLogicTest.kt
@@ -203,6 +203,29 @@ class OnboardingFlowLogicTest {
   }
 
   @Test
+  fun recoveryGatewayDetailPreservesRetryablePairingGuidance() {
+    assertEquals(
+      "Gateway approval is in progress. OpenClaw will retry automatically.",
+      recoveryGatewayDetail(
+        ready = false,
+        remoteAddress = null,
+        statusText = "Connected (node offline)",
+        nodeCapabilityApprovalState = GatewayNodeApprovalState.Approved,
+        gatewayConnectionProblem =
+          GatewayConnectionProblem(
+            code = "PAIRING_REQUIRED",
+            message = "pairing required: device approval is required",
+            reason = "not-paired",
+            requestId = "request-1",
+            recommendedNextStep = "wait_then_retry",
+            pauseReconnect = false,
+            retryable = true,
+          ),
+      ),
+    )
+  }
+
+  @Test
   fun recoveryGatewayAuthDetailShowsSpecificAuthRecoveryActions() {
     val cases =
       listOf(

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/OnboardingFlowLogicTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/OnboardingFlowLogicTest.kt
@@ -226,6 +226,29 @@ class OnboardingFlowLogicTest {
   }
 
   @Test
+  fun recoveryGatewayDetailPrefersAuthProblemOverStaleAddressWhenNotReady() {
+    assertEquals(
+      "Saved authentication is invalid. Re-authenticate or reset this gateway connection.",
+      recoveryGatewayDetail(
+        ready = false,
+        remoteAddress = "wss://gateway.example.test",
+        statusText = "Connected (node offline)",
+        nodeCapabilityApprovalState = GatewayNodeApprovalState.Approved,
+        gatewayConnectionProblem =
+          GatewayConnectionProblem(
+            code = "AUTH_DEVICE_TOKEN_MISMATCH",
+            message = "authentication needed",
+            reason = null,
+            requestId = null,
+            recommendedNextStep = "update_auth_credentials",
+            pauseReconnect = true,
+            retryable = false,
+          ),
+      ),
+    )
+  }
+
+  @Test
   fun recoveryGatewayAuthDetailShowsSpecificAuthRecoveryActions() {
     val cases =
       listOf(

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/OnboardingFlowLogicTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/OnboardingFlowLogicTest.kt
@@ -203,6 +203,67 @@ class OnboardingFlowLogicTest {
   }
 
   @Test
+  fun recoveryGatewayAuthDetailShowsSpecificAuthRecoveryActions() {
+    val cases =
+      listOf(
+        "AUTH_BOOTSTRAP_TOKEN_INVALID" to "Setup code expired. Scan a fresh setup QR.",
+        "AUTH_DEVICE_TOKEN_MISMATCH" to "Saved authentication is invalid. Re-authenticate or reset this gateway connection.",
+        "AUTH_PASSWORD_MISMATCH" to "Gateway password is invalid. Re-enter it or reset this gateway connection.",
+        "AUTH_TOKEN_MISSING" to "Gateway token is required. Enter it again or edit this connection.",
+        "DEVICE_IDENTITY_REQUIRED" to "Gateway requires this device identity. Re-authenticate or reset this gateway connection.",
+      )
+
+    cases.forEach { (code, expected) ->
+      assertEquals(
+        expected,
+        recoveryGatewayAuthDetail(
+          GatewayConnectionProblem(
+            code = code,
+            message = "authentication needed",
+            reason = null,
+            requestId = null,
+            recommendedNextStep = null,
+            pauseReconnect = true,
+            retryable = false,
+          ),
+        ),
+      )
+    }
+  }
+
+  @Test
+  fun recoveryGatewayAuthDetailUsesRecommendedNextStepFallbacks() {
+    assertEquals(
+      "Gateway authentication is not configured. Edit this connection and try again.",
+      recoveryGatewayAuthDetail(
+        GatewayConnectionProblem(
+          code = "UNKNOWN",
+          message = "authentication needed",
+          reason = null,
+          requestId = null,
+          recommendedNextStep = "update_auth_configuration",
+          pauseReconnect = true,
+          retryable = false,
+        ),
+      ),
+    )
+    assertEquals(
+      "gateway says no",
+      recoveryGatewayAuthDetail(
+        GatewayConnectionProblem(
+          code = "UNKNOWN",
+          message = "gateway says no",
+          reason = null,
+          requestId = null,
+          recommendedNextStep = null,
+          pauseReconnect = true,
+          retryable = false,
+        ),
+      ),
+    )
+  }
+
+  @Test
   fun showsFinishingStateWhileGatewayConnectionSettles() {
     assertEquals(
       GatewayRecoveryUiState.Finishing,

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/OnboardingFlowLogicTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/OnboardingFlowLogicTest.kt
@@ -249,6 +249,29 @@ class OnboardingFlowLogicTest {
   }
 
   @Test
+  fun recoveryGatewayDetailPrefersAuthProblemWhileNodeApprovalIsLoading() {
+    assertEquals(
+      "Saved authentication is invalid. Re-authenticate or reset this gateway connection.",
+      recoveryGatewayDetail(
+        ready = false,
+        remoteAddress = "wss://gateway.example.test",
+        statusText = "Connected (node offline)",
+        nodeCapabilityApprovalState = GatewayNodeApprovalState.Loading,
+        gatewayConnectionProblem =
+          GatewayConnectionProblem(
+            code = "AUTH_DEVICE_TOKEN_MISMATCH",
+            message = "authentication needed",
+            reason = null,
+            requestId = null,
+            recommendedNextStep = "update_auth_credentials",
+            pauseReconnect = true,
+            retryable = false,
+          ),
+      ),
+    )
+  }
+
+  @Test
   fun recoveryGatewayAuthDetailShowsSpecificAuthRecoveryActions() {
     val cases =
       listOf(


### PR DESCRIPTION
Related: #98046

## What Problem This Solves

Fixes an issue where Android users recovering gateway setup would see generic gateway-unreachable/authentication messaging when the gateway had already returned a structured auth failure such as an expired setup code, stale saved credential, missing token, or password mismatch.

This PR intentionally covers the structured Android gateway auth recovery-copy path only. Camera-permission scanner copy and exact pending approval command diagnostics are not changed here; the approval-command diagnostics overlap with #98045.

## Why This Change Was Made

The Android recovery detail now consumes the existing `GatewayConnectionProblem` code and recommended next-step fields before falling back to generic copy. Pairing approval handling stays on the existing approval-command path, retryable `PAIRING_REQUIRED` keeps the existing auto-retry guidance, and this change does not add new gateway protocol fields.

A follow-up ordering fix also keeps structured auth failures visible while node capability approval is still loading, so stale credentials are not masked by the generic `Gateway paired. Checking node capability approval.` line.

## User Impact

Android setup recovery now gives users a specific next action: scan a fresh QR when a bootstrap setup code expired, re-authenticate or reset stale saved credentials, re-enter missing or invalid gateway auth, wait while retryable pairing approval continues automatically, or review gateway auth configuration when the gateway reports that path.

## Evidence

- Claim proved: Android recovery now prefers structured non-ready `GatewayConnectionProblem` guidance over stale saved address and over the generic node-approval loading detail. It also preserves the existing ready-address, explicit node-approval, and pairing guidance paths.
- Head under review: `50b70610344714c87ef0c017bbd5273530905c35` (`fix(android): show auth recovery while approval loads`).
- Commands / artifacts:
  - `git diff --check` passed locally after the latest ordering fix.
  - `apps/android/gradlew.bat :app:testPlayDebugUnitTest --tests "ai.openclaw.app.ui.OnboardingFlowLogicTest" --no-daemon --console=plain --rerun-tasks` passed locally with exit code 0. The JUnit XML reports `tests="27" skipped="0" failures="0" errors="0"` and includes `recoveryGatewayDetailPrefersAuthProblemWhileNodeApprovalIsLoading`.
  - `python .agents\skills\autoreview\scripts\autoreview --mode local` reported `autoreview clean: no accepted/actionable findings reported` and `overall: patch is correct (0.88)`. The helper emitted a late Windows GBK reader-thread decode exception after the clean result; no code finding was reported.
  - Installed this PR branch debug app on the real phone with `apps/android/gradlew.bat :app:installPlayDebug --no-daemon --console=plain`; Gradle reported `Installed on 1 device` for `openclaw-2026.6.10-play-debug.apk`.
  - Real Android device proof:
    - `adb devices -l` showed `3B665800MT900000 device product:PLW110 model:PLW110 device:OP61B7L1 transport_id:4`.
    - `adb shell getprop ro.product.model` -> `PLW110`; `adb shell getprop ro.build.version.release` -> `16`; `adb shell getprop ro.build.version.sdk` -> `36`.
    - `adb reverse --list` showed `UsbFfs tcp:18789 tcp:18789` for the USB-only local fixture tunnel.
    - Local fixture returned a structured connect error with `code: "AUTH_DEVICE_TOKEN_MISMATCH"`, `recommendedNextStep: "update_auth_credentials"`, `retryable: false`, and `pauseReconnect: true`. Raw fixture logs were not pasted because Android connect frames include device tokens/signatures.
    - Captured real-device screenshot locally with `adb shell screencap -p` then `adb pull`: `E:\code\openclaw-android-proof-tools\artifacts\auth-detail-final-20260630-210457\openclaw-auth-detail-final.png` (not committed to the repo per PR artifact policy).
    - Captured real-device UIAutomator XML from the same screen: `E:\code\openclaw-android-proof-tools\artifacts\auth-detail-final-20260630-210457\window-auth-detail-final.xml` (not committed). Relevant visible text excerpt:

```xml
<node text="Gateway Recovery" package="ai.openclaw.app" />
<node text="Connection issue" package="ai.openclaw.app" />
<node text="Home Gateway" package="ai.openclaw.app" />
<node text="Saved authentication is invalid. Re-authenticate or reset this gateway connection." package="ai.openclaw.app" />
<node text="Needs attention" package="ai.openclaw.app" />
```

  - GitHub checks on head `50b70610344714c87ef0c017bbd5273530905c35` at the time of this update:
    - `Real behavior proof` SUCCESS: https://github.com/openclaw/openclaw/actions/runs/28446695032/job/84297812479
    - `android-test-play` SUCCESS: https://github.com/openclaw/openclaw/actions/runs/28446697265/job/84297928308
    - `android-test-third-party` SUCCESS: https://github.com/openclaw/openclaw/actions/runs/28446697265/job/84297928339
    - `android-build-play` SUCCESS: https://github.com/openclaw/openclaw/actions/runs/28446697265/job/84297928343
- Observed result: focused unit coverage covers bootstrap expiry, stale credential/device-token mismatch, password mismatch, missing token, device identity required, recommended-next-step fallback, unknown-message fallback, retryable `PAIRING_REQUIRED`, stale remote address plus structured auth problem, and structured auth problem while node approval is loading. The OPPO Reno15 real-device run rendered the newly mapped auth-detail recovery copy: `Saved authentication is invalid. Re-authenticate or reset this gateway connection.`
- Not tested / proof gaps: raw fixture logs and screenshots are intentionally kept outside the repository and not pasted publicly because the WebSocket connect frames include device identifiers, public keys, and signatures. Production Gateway setup-code onboarding was also exercised over USB earlier and reached `Node Approval Pending`, but the auth-detail proof above uses a local structured WebSocket fixture so the exact `AUTH_DEVICE_TOKEN_MISMATCH` recovery detail can be held on screen long enough for UIAutomator/screenshot capture.