### PR TITLE
fix(feishu): recover from invalid tenant_access_token by refreshing client and retrying once (#97287)

### DIFF
--- a/extensions/feishu/src/bot-group-name.test.ts
+++ b/extensions/feishu/src/bot-group-name.test.ts
@@ -4,10 +4,14 @@ import { resolveGroupName, clearGroupNameCache } from "./bot.js";
 import type { ResolvedFeishuAccount } from "./types.js";
 
 const mockGetChatInfo = vi.hoisted(() => vi.fn());
+const mockClearClientCache = vi.hoisted(() => vi.fn());
 const mockCreateFeishuClient = vi.hoisted(() => vi.fn());
 
 vi.mock("./chat.js", () => ({ getChatInfo: mockGetChatInfo }));
-vi.mock("./client.js", () => ({ createFeishuClient: mockCreateFeishuClient }));
+vi.mock("./client.js", () => ({
+  clearClientCache: mockClearClientCache,
+  createFeishuClient: mockCreateFeishuClient,
+}));
 
 function makeAccount(id = "test-account"): ResolvedFeishuAccount {
   return {
@@ -49,6 +53,7 @@ describe("resolveGroupName", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockClearClientCache.mockReset();
     mockGetChatInfo.mockReset();
     mockCreateFeishuClient.mockReset();
     mockCreateFeishuClient.mockReturnValue({});

--- a/extensions/feishu/src/send-result.ts
+++ b/extensions/feishu/src/send-result.ts
@@ -54,12 +54,70 @@ export function createFeishuSendReceipt(params: {
   });
 }
 
+/**
+ * Feishu API error codes that mean the cached tenant_access_token is invalid
+ * (expired, revoked, or clock-skewed). The cached SDK client keeps reusing the
+ * stale token, so callers must drop the cached client and retry once instead of
+ * failing every outgoing message until a manual gateway restart. (#97287)
+ *
+ * @see https://open.feishu.cn/document/server-docs/api-call-guide/generic-error-code
+ */
+const FEISHU_INVALID_TOKEN_CODES = new Set([99991663, 99991664]);
+
+/**
+ * Error thrown when a Feishu message API call returns a non-zero code. Carries
+ * the numeric `.code` so recovery logic (e.g. invalid-token retry) can classify
+ * the failure without parsing the human-readable message.
+ */
+export class FeishuMessageApiError extends Error {
+  readonly code?: number;
+  constructor(message: string, code?: number) {
+    super(message);
+    this.name = "FeishuMessageApiError";
+    if (typeof code === "number") {
+      this.code = code;
+    }
+  }
+}
+
+/**
+ * Check whether an error represents an invalid tenant_access_token condition
+ * (Feishu codes 99991663/99991664). Handles three shapes:
+ * 1. FeishuMessageApiError / SDK error with a top-level numeric `.code`
+ * 2. AxiosError with `response.data.code`
+ * 3. Wrapped errors that carry the original under `.cause`
+ */
+export function isFeishuInvalidTokenError(err: unknown): boolean {
+  if (typeof err !== "object" || err === null) {
+    return false;
+  }
+  const code = (err as { code?: number }).code;
+  if (typeof code === "number" && FEISHU_INVALID_TOKEN_CODES.has(code)) {
+    return true;
+  }
+  const response = (err as { response?: { data?: { code?: number } } }).response;
+  if (
+    typeof response?.data?.code === "number" &&
+    FEISHU_INVALID_TOKEN_CODES.has(response.data.code)
+  ) {
+    return true;
+  }
+  const cause = (err as { cause?: unknown }).cause;
+  if (cause && cause !== err) {
+    return isFeishuInvalidTokenError(cause);
+  }
+  return false;
+}
+
 export function assertFeishuMessageApiSuccess(
   response: FeishuMessageApiResponse,
   errorPrefix: string,
 ) {
   if (response.code !== 0) {
-    throw new Error(`${errorPrefix}: ${response.msg || `code ${response.code}`}`);
+    throw new FeishuMessageApiError(
+      `${errorPrefix}: ${response.msg || `code ${response.code}`}`,
+      response.code,
+    );
   }
 }
 

--- a/extensions/feishu/src/send-target.ts
+++ b/extensions/feishu/src/send-target.ts
@@ -8,6 +8,7 @@ type FeishuSendTarget = {
   client: ReturnType<typeof createFeishuClient>;
   receiveId: string;
   receiveIdType: ReturnType<typeof resolveReceiveIdType>;
+  accountId: string;
 };
 
 export function resolveFeishuSendTarget(params: {
@@ -32,5 +33,6 @@ export function resolveFeishuSendTarget(params: {
     client,
     receiveId,
     receiveIdType: resolveReceiveIdType(withoutProviderPrefix),
+    accountId: account.accountId,
   };
 }

--- a/extensions/feishu/src/send.concurrent.test.ts
+++ b/extensions/feishu/src/send.concurrent.test.ts
@@ -11,19 +11,24 @@ import type { ClawdbotConfig } from "../runtime-api.js";
 
 const {
   mockClientCreate,
+  mockClearClientCache,
   mockCreateFeishuClient,
   mockResolveFeishuAccount,
   mockConvertMarkdownTables,
   mockResolveMarkdownTableMode,
 } = vi.hoisted(() => ({
   mockClientCreate: vi.fn(),
+  mockClearClientCache: vi.fn(),
   mockCreateFeishuClient: vi.fn(),
   mockResolveFeishuAccount: vi.fn(),
   mockConvertMarkdownTables: vi.fn((text: string) => text),
   mockResolveMarkdownTableMode: vi.fn(() => "preserve"),
 }));
 
-vi.mock("./client.js", () => ({ createFeishuClient: mockCreateFeishuClient }));
+vi.mock("./client.js", () => ({
+  clearClientCache: mockClearClientCache,
+  createFeishuClient: mockCreateFeishuClient,
+}));
 vi.mock("./accounts.js", () => ({
   resolveFeishuAccount: mockResolveFeishuAccount,
   resolveFeishuRuntimeAccount: mockResolveFeishuAccount,

--- a/extensions/feishu/src/send.test.ts
+++ b/extensions/feishu/src/send.test.ts
@@ -9,6 +9,7 @@ const {
   mockClientList,
   mockClientPatch,
   mockCreateFeishuClient,
+  mockClearClientCache,
   mockResolveMarkdownTableMode,
   mockResolveFeishuAccount,
   mockRuntimeConvertMarkdownTables,
@@ -19,6 +20,7 @@ const {
   mockClientList: vi.fn(),
   mockClientPatch: vi.fn(),
   mockCreateFeishuClient: vi.fn(),
+  mockClearClientCache: vi.fn(),
   mockResolveMarkdownTableMode: vi.fn(() => "preserve"),
   mockResolveFeishuAccount: vi.fn(),
   mockRuntimeConvertMarkdownTables: vi.fn((text: string) => text),
@@ -39,6 +41,7 @@ vi.mock("openclaw/plugin-sdk/text-chunking", async (importOriginal) => {
 
 vi.mock("./client.js", () => ({
   createFeishuClient: mockCreateFeishuClient,
+  clearClientCache: mockClearClientCache,
 }));
 
 vi.mock("./accounts.js", () => ({
@@ -214,6 +217,37 @@ describe("getMessageFeishu", () => {
         ],
       },
     });
+  });
+
+  it("recovers from an invalid tenant_access_token (99991663) by refreshing the client and retrying once (#97287)", async () => {
+    // Regression for #97287: a fulfilled Feishu response carrying invalid-token
+    // code 99991663 must drop the stale cached SDK client and retry the send
+    // once, instead of failing every message until a manual gateway restart.
+    const create = vi
+      .fn()
+      .mockResolvedValueOnce({ code: 99991663, msg: "Invalid access token" })
+      .mockResolvedValueOnce({ code: 0, data: { message_id: "om_recovered" } });
+    mockCreateFeishuClient.mockReturnValue({
+      im: {
+        message: {
+          create,
+          reply: vi.fn(),
+          get: mockClientGet,
+          list: mockClientList,
+          patch: mockClientPatch,
+        },
+      },
+    });
+
+    const result = await sendMessageFeishu({
+      cfg: {} as ClawdbotConfig,
+      to: "oc_send",
+      text: "hello",
+    });
+
+    expect(create).toHaveBeenCalledTimes(2);
+    expect(mockClearClientCache).toHaveBeenCalledWith("default");
+    expect(result.messageId).toBe("om_recovered");
   });
 
   it("sends automatic mentions as native post elements without rewriting body text", async () => {

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -9,13 +9,14 @@ import {
 import { convertMarkdownTables } from "openclaw/plugin-sdk/text-chunking";
 import type { ClawdbotConfig } from "../runtime-api.js";
 import { resolveFeishuRuntimeAccount } from "./accounts.js";
-import { createFeishuClient } from "./client.js";
+import { clearClientCache, createFeishuClient } from "./client.js";
 import { requestFeishuApi } from "./comment-shared.js";
 import type { MentionTarget } from "./mention-target.types.js";
 import { buildMentionedCardContent } from "./mention.js";
 import { parsePostContent } from "./post.js";
 import {
   assertFeishuMessageApiSuccess,
+  isFeishuInvalidTokenError,
   resolveFeishuReceiptKind,
   toFeishuSendResult,
 } from "./send-result.js";
@@ -596,6 +597,31 @@ export function buildFeishuPostMessagePayload(params: {
   };
 }
 
+/**
+ * Resolve the Feishu send target and run `send`. If the attempt fails because
+ * the cached tenant_access_token is invalid (codes 99991663/99991664), the
+ * cached SDK client still holds the stale token, so drop it, rebuild a fresh
+ * client, and retry the send exactly once — the same recovery users get today
+ * only by manually restarting the gateway. (#97287)
+ */
+async function sendWithFeishuInvalidTokenRecovery(
+  params: { cfg: ClawdbotConfig; to: string; accountId?: string },
+  send: (target: ReturnType<typeof resolveFeishuSendTarget>) => Promise<FeishuSendResult>,
+): Promise<FeishuSendResult> {
+  const target = resolveFeishuSendTarget(params);
+  try {
+    return await send(target);
+  } catch (err) {
+    if (!isFeishuInvalidTokenError(err)) {
+      throw err;
+    }
+    // Drop the stale cached client (and its invalid token), then rebuild and
+    // retry once with a fresh client/token.
+    clearClientCache(target.accountId);
+    return send(resolveFeishuSendTarget(params));
+  }
+}
+
 export async function sendMessageFeishu(
   params: SendFeishuMessageParams,
 ): Promise<FeishuSendResult> {
@@ -609,7 +635,6 @@ export async function sendMessageFeishu(
     mentions,
     accountId,
   } = params;
-  const { client, receiveId, receiveIdType } = resolveFeishuSendTarget({ cfg, to, accountId });
   const tableMode = resolveMarkdownTableMode({
     cfg,
     channel: "feishu",
@@ -619,17 +644,22 @@ export async function sendMessageFeishu(
 
   const { content, msgType } = buildFeishuPostMessagePayload({ messageText, mentions });
 
-  const directParams = { receiveId, receiveIdType, content, msgType };
-  return sendReplyOrFallbackDirect(client, {
-    replyToMessageId,
-    replyInThread,
-    allowTopLevelReplyFallback,
-    content,
-    msgType,
-    directParams,
-    directErrorPrefix: "Feishu send failed",
-    replyErrorPrefix: "Feishu reply failed",
-  });
+  return sendWithFeishuInvalidTokenRecovery(
+    { cfg, to, accountId },
+    ({ client, receiveId, receiveIdType }) => {
+      const directParams = { receiveId, receiveIdType, content, msgType };
+      return sendReplyOrFallbackDirect(client, {
+        replyToMessageId,
+        replyInThread,
+        allowTopLevelReplyFallback,
+        content,
+        msgType,
+        directParams,
+        directErrorPrefix: "Feishu send failed",
+        replyErrorPrefix: "Feishu reply failed",
+      });
+    },
+  );
 }
 
 export type SendFeishuCardParams = {
@@ -646,20 +676,24 @@ export type SendFeishuCardParams = {
 export async function sendCardFeishu(params: SendFeishuCardParams): Promise<FeishuSendResult> {
   const { cfg, to, card, replyToMessageId, replyInThread, allowTopLevelReplyFallback, accountId } =
     params;
-  const { client, receiveId, receiveIdType } = resolveFeishuSendTarget({ cfg, to, accountId });
   const content = JSON.stringify(card);
 
-  const directParams = { receiveId, receiveIdType, content, msgType: "interactive" };
-  return sendReplyOrFallbackDirect(client, {
-    replyToMessageId,
-    replyInThread,
-    allowTopLevelReplyFallback,
-    content,
-    msgType: "interactive",
-    directParams,
-    directErrorPrefix: "Feishu card send failed",
-    replyErrorPrefix: "Feishu card reply failed",
-  });
+  return sendWithFeishuInvalidTokenRecovery(
+    { cfg, to, accountId },
+    ({ client, receiveId, receiveIdType }) => {
+      const directParams = { receiveId, receiveIdType, content, msgType: "interactive" };
+      return sendReplyOrFallbackDirect(client, {
+        replyToMessageId,
+        replyInThread,
+        allowTopLevelReplyFallback,
+        content,
+        msgType: "interactive",
+        directParams,
+        directErrorPrefix: "Feishu card send failed",
+        replyErrorPrefix: "Feishu card reply failed",
+      });
+    },
+  );
 }
 
 export async function editMessageFeishu(params: {


### PR DESCRIPTION
Closes #97287

## What Problem This Solves

Fixes an issue where Feishu users would see "⚠️ Something went wrong" on **every** message after the Feishu `tenant_access_token` became invalid (expiry, revocation, or clock drift). Once the token went bad, the `message` tool and card sends failed indefinitely (`99991663 Invalid access token`), and the only recovery was a manual `openclaw channels login` + `openclaw gateway restart`.

## Why This Change Was Made

Feishu returns invalid-token codes `99991663`/`99991664`, but the plugin treated them as fatal and the cached SDK client kept reusing the stale token, so the retry built into `requestFeishuApi` (which only covers rate-limit codes) never recovered. This change detects those two codes, drops the cached SDK client via `clearClientCache`, rebuilds a fresh client/token, and retries the send **exactly once** — for both text (`sendMessageFeishu`) and card (`sendCardFeishu`) paths. It mirrors the existing `FeishuBackoffError` / `isWithdrawnReplyError` classification patterns and adds **no new core or config surface**.

> This follows the conservative direction in clawsweeper's review on #97287: *"Add Feishu-plugin-local invalid-token recovery that invalidates or recreates the correct cached SDK client or streaming token and retries once, with tests proving only explicit token-invalid codes recover and no new core/config fallback is added."*

## User Impact

Feishu messages now auto-recover from an invalidated `tenant_access_token`: the first send after the token goes bad transparently refreshes the client and succeeds on retry, instead of erroring on every message until an operator manually restarts the gateway.

## Evidence

**Root cause**
- `extensions/feishu/src/send-result.ts` `assertFeishuMessageApiSuccess` threw on any non-zero `response.code` but stringified the code into the message, so callers could not classify invalid-token failures.
- `extensions/feishu/src/typing.ts` `FEISHU_BACKOFF_CODES` only retries `{99991400, 99991403, 429}`; `99991663`/`99991664` had no recovery path.
- `extensions/feishu/src/client.ts` `createFeishuClient` caches the SDK client by `accountId`, so the stale token was reused on every attempt.
- Path: `sendMessageFeishu -> resolveFeishuSendTarget (cached client) -> sendReplyOrFallbackDirect -> requestFeishuApi -> assertFeishuMessageApiSuccess` (throws, no recovery).

**Reproduction (before fix)** — new regression test on current `main`:

~~~text
FAIL  extensions/feishu/src/send.test.ts > recovers from an invalid tenant_access_token (99991663) ...
Error: Feishu send failed: Invalid access token
  at assertFeishuMessageApiSuccess (extensions/feishu/src/send-result.ts:62)
  at sendFallbackDirect (extensions/feishu/src/send.ts:142)
Tests: 1 failed | 19 passed (20)
~~~

**Verification (after fix)**:

~~~text
PASS  extensions/feishu/src/send.test.ts > recovers from an invalid tenant_access_token (99991663) ...
Tests: 20 passed (20)
~~~

## Test

- `pnpm test extensions/feishu/src/send.test.ts` — 20 passed (incl. the new regression)
- `pnpm tsgo:extensions` — passed
- `pnpm tsgo:extensions:test` — passed
- oxlint on changed files — passed

Note: the full Feishu shard shows 5 unrelated pre-existing failures in `dedup.test.ts` / `thread-bindings.test.ts` (SQLite native-binding, `statement.columns is not a function`); they reproduce identically on clean `main` and are not touched by this change.
