### PR TITLE
fix(providers): bound successful OAuth and webhook responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Docs: https://docs.openclaw.ai
 
 - **Agent helper downloads:** bound fd and ripgrep archive downloads and extraction with declared and streamed byte caps, extraction limits, timeouts, traversal-safe unpacking, and partial-file cleanup. (#98988) Thanks @LeonidasLux.
 - **Control UI cron actions:** localize the overflow-menu label and due-only run action across all supported locales.
+- **OpenRouter OAuth and Discord webhook response bounds:** cap successful JSON response bodies while preserving Discord's no-body webhook mode. (#98098) Thanks @lwy-2.
 - **OpenAI Realtime Codex auth:** reuse external Codex OAuth profiles for Realtime voice sessions when no explicit OpenAI API key is configured.
 - **OpenAI-compatible TTS voice notes:** route configured MP3 speech output through native voice-message delivery when the channel supports it, while keeping WAV output on the audio-file path. (#83227, #80317) Thanks @HemantSudarshan.
 - **Talk transcription providers:** cold-load explicitly configured Voice Call streaming providers, including runtime aliases, when another provider registry is already active, keeping catalog and session selection aligned. (#97170, #97738) Thanks @solavrc.

--- a/extensions/discord/src/send.webhook.proxy.test.ts
+++ b/extensions/discord/src/send.webhook.proxy.test.ts
@@ -212,6 +212,61 @@ describe("sendWebhookMessageDiscord proxy support", () => {
     globalFetchMock.mockRestore();
   });
 
+  it("accepts Discord's no-body webhook response when wait is false", async () => {
+    const response = new Response(null, { status: 204 });
+    const jsonSpy = vi.spyOn(response, "json");
+    const globalFetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(response);
+
+    const result = await sendWebhookMessageDiscord("hello", {
+      cfg: { channels: { discord: { token: "Bot test-token" } } } as OpenClawConfig,
+      accountId: "default",
+      webhookId: "123",
+      webhookToken: "abc",
+      wait: false,
+    });
+
+    expect(result.messageId).toBe("unknown");
+    expect(jsonSpy).not.toHaveBeenCalled();
+    globalFetchMock.mockRestore();
+  });
+
+  it("keeps a successful send when the webhook response body exceeds the limit", async () => {
+    const tracked = cancelTrackedResponse(`{"id":"${"x".repeat(16 * 1024 * 1024)}"}`, {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+    const globalFetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(tracked.response);
+
+    const result = await sendWebhookMessageDiscord("hello", {
+      cfg: { channels: { discord: { token: "Bot test-token" } } } as OpenClawConfig,
+      accountId: "default",
+      webhookId: "123",
+      webhookToken: "abc",
+      wait: true,
+    });
+
+    expect(result.messageId).toBe("unknown");
+    expect(tracked.wasCanceled()).toBe(true);
+    globalFetchMock.mockRestore();
+  });
+
+  it("keeps a successful send when the webhook response body is malformed", async () => {
+    const globalFetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("not json", { status: 200 }));
+
+    const result = await sendWebhookMessageDiscord("hello", {
+      cfg: { channels: { discord: { token: "Bot test-token" } } } as OpenClawConfig,
+      accountId: "default",
+      webhookId: "123",
+      webhookToken: "abc",
+      wait: true,
+    });
+
+    expect(result.messageId).toBe("unknown");
+    globalFetchMock.mockRestore();
+  });
+
   it("throws typed rate limit errors for webhook 429 responses", async () => {
     const globalFetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(JSON.stringify({ message: "Slow down", retry_after: 0.25, global: false }), {

--- a/extensions/discord/src/send.webhook.ts
+++ b/extensions/discord/src/send.webhook.ts
@@ -1,7 +1,10 @@
 // Discord plugin module implements send.webhook behavior.
 import { recordChannelActivity } from "openclaw/plugin-sdk/channel-activity-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
+import {
+  readProviderJsonResponse,
+  readResponseTextLimited,
+} from "openclaw/plugin-sdk/provider-http";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { resolveDiscordClientAccountContext } from "./client.js";
@@ -121,10 +124,16 @@ export async function sendWebhookMessageDiscord(
     await throwWebhookResponseError(response);
   }
 
-  const payload = (await response.json().catch(() => ({}))) as {
+  const payload: {
     id?: string;
     channel_id?: string;
-  };
+  } =
+    response.status === 204
+      ? {}
+      : await readProviderJsonResponse<{ id?: string; channel_id?: string }>(
+          response,
+          "Discord webhook send",
+        ).catch(() => ({}));
   try {
     recordChannelActivity({
       channel: "discord",

--- a/extensions/openrouter/oauth.test.ts
+++ b/extensions/openrouter/oauth.test.ts
@@ -24,7 +24,10 @@ function jsonResponse(value: unknown, init?: ResponseInit): Response {
   });
 }
 
-function boundedTextErrorResponse(body: string, status = 502): {
+function boundedTextErrorResponse(
+  body: string,
+  status = 502,
+): {
   response: Response;
   cancel: ReturnType<typeof vi.fn>;
   releaseLock: ReturnType<typeof vi.fn>;
@@ -58,6 +61,25 @@ function boundedTextErrorResponse(body: string, status = 502): {
   } as unknown as Response;
 
   return { response, cancel, releaseLock, text };
+}
+
+function oversizedJsonResponse(): { response: Response; wasCanceled: () => boolean } {
+  let canceled = false;
+  const body = new TextEncoder().encode(`{"key":"${"x".repeat(16 * 1024 * 1024)}"}`);
+  return {
+    response: new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(body);
+        },
+        cancel() {
+          canceled = true;
+        },
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    ),
+    wasCanceled: () => canceled,
+  };
 }
 
 function requestUrl(input: RequestInfo | URL): string {
@@ -188,6 +210,19 @@ describe("OpenRouter OAuth", () => {
       key: "sk-or-v1-test",
       userId: "user-1",
     });
+  });
+
+  it("bounds successful OpenRouter OAuth responses", async () => {
+    const oversized = oversizedJsonResponse();
+
+    await expect(
+      exchangeOpenRouterOAuthCode({
+        code: "AUTHCODE",
+        codeVerifier: "verifier-1",
+        fetchImpl: vi.fn(async () => oversized.response),
+      }),
+    ).rejects.toThrow("OpenRouter OAuth key exchange: JSON response exceeds 16777216 bytes");
+    expect(oversized.wasCanceled()).toBe(true);
   });
 
   it("surfaces OpenRouter OAuth exchange errors without credential material", async () => {

--- a/extensions/openrouter/oauth.ts
+++ b/extensions/openrouter/oauth.ts
@@ -8,7 +8,10 @@ import {
   type ProviderAuthResult,
 } from "openclaw/plugin-sdk/provider-auth";
 import { generateOAuthState } from "openclaw/plugin-sdk/provider-auth-runtime";
-import { readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
+import {
+  readProviderJsonResponse,
+  readResponseTextLimited,
+} from "openclaw/plugin-sdk/provider-http";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { applyOpenrouterConfig, OPENROUTER_DEFAULT_MODEL_REF } from "./onboard.js";
 
@@ -71,11 +74,13 @@ function extractOpenRouterError(value: unknown): string | undefined {
 }
 
 async function readResponseBody(response: Response): Promise<unknown> {
-  const text = response.ok
-    ? await response.text()
-    : await readResponseTextLimited(response, OPENROUTER_OAUTH_ERROR_BODY_LIMIT_BYTES).catch(
-        () => "",
-      );
+  if (response.ok) {
+    return await readProviderJsonResponse(response, "OpenRouter OAuth key exchange");
+  }
+  const text = await readResponseTextLimited(
+    response,
+    OPENROUTER_OAUTH_ERROR_BODY_LIMIT_BYTES,
+  ).catch(() => "");
   if (!text.trim()) {
     return null;
   }


### PR DESCRIPTION
## What Problem This Solves

Caps successful JSON response bodies in the two provider-controlled paths that were still unbounded on current `main`:

- Discord webhook execution responses.
- OpenRouter OAuth code exchange responses.

The original Google path was removed because `fetchWithTimeout` already applies the same 16 MiB response cap. The proposed Nextcloud path was also already fixed on `main`.

## Why This Change Was Made

Both remaining paths now use the shared `readProviderJsonResponse` helper, which rejects and cancels oversized streams. Discord keeps its existing transport contract: `wait=false` 204 responses require no body, and malformed or oversized optional bodies after a successful non-idempotent POST do not turn the completed send into an error that could trigger a duplicate bot fallback.

## User Impact

- Hostile or broken successful OpenRouter responses cannot be buffered without a bound.
- Successful Discord webhook sends remain successful even when Discord's optional response body is absent, malformed, or oversized.
- No new configuration or compatibility surface.

## Evidence

- Blacksmith Testbox [focused run 28775960314](https://github.com/openclaw/openclaw/actions/runs/28775960314): formatting plus 12 Discord webhook and 9 OpenRouter OAuth tests passed.
- Blacksmith Testbox [changed gate 28776116220](https://github.com/openclaw/openclaw/actions/runs/28776116220): extension typechecks, test typechecks, lint, dependency guards, database-first guard, sidecar checks, and import-cycle checks passed.
- Oversized-stream tests verify rejection/cancellation for OpenRouter and cancellation without duplicate-send failure for Discord.
- Live unauthenticated probes reached the current Discord, OpenRouter, and Google JSON error endpoints; no credentials or external writes were used.
- Fresh autoreview: clean after fixing duplicate-send semantics and generic typing.

Closes no issue.
