### PR TITLE
fix(gateway): guard JSON.stringify undefined return in SSE write helpers

### DIFF
--- a/src/gateway/http-common.test.ts
+++ b/src/gateway/http-common.test.ts
@@ -434,4 +434,29 @@ describe("guardJsonStringify", () => {
   it("includes the value type in the error message", () => {
     expect(() => guardJsonStringify("test", undefined)).toThrow("undefined");
   });
+
+  it("serializes before any writes — no partial output on failure", () => {
+    // Regression: guard must throw before the caller can issue any
+    // res.write.  Simulate the writeSse/sseWrite order: serialize first,
+    // then write.  A non-serializable root must never reach the write.
+    const writes: string[] = [];
+    const write = (s: string) => writes.push(s);
+
+    const sseWrite = (event: string, payload: unknown) => {
+      const data = guardJsonStringify("sseWrite", payload);
+      write(`event: ${event}\n`);
+      write(`data: ${data}\n\n`);
+    };
+
+    // Non-serializable: throw before any write
+    expect(() => sseWrite("history", undefined)).toThrow(TypeError);
+    expect(writes).toHaveLength(0);
+
+    // Serializable: both lines written
+    sseWrite("history", { ok: true });
+    expect(writes).toEqual([
+      "event: history\n",
+      'data: {"ok":true}\n\n',
+    ]);
+  });
 });

--- a/src/gateway/http-common.test.ts
+++ b/src/gateway/http-common.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../infra/diagnostic-events.js";
 import type { GatewayAuthResult } from "./auth.js";
 import {
+  guardJsonStringify,
   readJsonBodyOrError,
   sendGatewayAuthFailure,
   sendInvalidRequest,
@@ -390,5 +391,47 @@ describe("watchClientDisconnect", () => {
     expect(socket.listenerCount("close")).toBe(1);
     cleanup();
     expect(socket.listenerCount("close")).toBe(0);
+  });
+});
+
+describe("guardJsonStringify", () => {
+  it("serializes a plain object to JSON", () => {
+    expect(guardJsonStringify("test", { ok: true })).toBe('{"ok":true}');
+  });
+
+  it("serializes a string", () => {
+    expect(guardJsonStringify("test", "hello")).toBe('"hello"');
+  });
+
+  it("serializes a number", () => {
+    expect(guardJsonStringify("test", 42)).toBe("42");
+  });
+
+  it("serializes null as the JSON literal null", () => {
+    expect(guardJsonStringify("test", null)).toBe("null");
+  });
+
+  it("serializes an array", () => {
+    expect(guardJsonStringify("test", [1, 2, 3])).toBe("[1,2,3]");
+  });
+
+  it("throws TypeError for an undefined root value", () => {
+    expect(() => guardJsonStringify("test", undefined)).toThrow(TypeError);
+  });
+
+  it("throws TypeError for a function root value", () => {
+    expect(() => guardJsonStringify("test", () => 42)).toThrow(TypeError);
+  });
+
+  it("throws TypeError for a symbol root value", () => {
+    expect(() => guardJsonStringify("test", Symbol("x"))).toThrow(TypeError);
+  });
+
+  it("includes the caller name in the error message", () => {
+    expect(() => guardJsonStringify("writeSse", undefined)).toThrow("writeSse");
+  });
+
+  it("includes the value type in the error message", () => {
+    expect(() => guardJsonStringify("test", undefined)).toThrow("undefined");
   });
 });

--- a/src/gateway/http-common.ts
+++ b/src/gateway/http-common.ts
@@ -122,6 +122,24 @@ export async function readJsonBodyOrError(
   return body.value;
 }
 
+/**
+ * Serialize a value for SSE/JSON output, throwing on non-serializable roots.
+ *
+ * JSON.stringify returns undefined when the root value is undefined, a
+ * function, or a symbol (ECMA-262 §24.5.2).  Without this guard a template
+ * literal coerces the undefined to the literal string "undefined", which
+ * produces garbled SSE/JSON output.
+ */
+export function guardJsonStringify(caller: string, value: unknown): string {
+  const serialized = JSON.stringify(value);
+  if (serialized === undefined) {
+    throw new TypeError(
+      `${caller}: value of type ${typeof value} is not JSON-serializable (JSON.stringify returned undefined)`,
+    );
+  }
+  return serialized;
+}
+
 export function writeDone(res: ServerResponse) {
   res.write("data: [DONE]\n\n");
 }

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -154,7 +154,16 @@ function resolveOpenAiChatCompletionsLimits(
 }
 
 function writeSse(res: ServerResponse, data: unknown) {
-  res.write(`data: ${JSON.stringify(data)}\n\n`);
+  const serialized = JSON.stringify(data);
+  // JSON.stringify returns undefined when the root value is undefined, a
+  // function, or a symbol — guard to avoid writing the literal string
+  // "undefined" as SSE data, which would produce garbled client output.
+  if (serialized === undefined) {
+    throw new TypeError(
+      `writeSse: data of type ${typeof data} is not JSON-serializable (JSON.stringify returned undefined)`,
+    );
+  }
+  res.write(`data: ${serialized}\n\n`);
 }
 
 function buildAgentCommandInput(params: {

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -48,6 +48,7 @@ import {
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
 import {
+  guardJsonStringify,
   sendJson,
   sendMissingScopeForbidden,
   setSseHeaders,
@@ -154,16 +155,7 @@ function resolveOpenAiChatCompletionsLimits(
 }
 
 function writeSse(res: ServerResponse, data: unknown) {
-  const serialized = JSON.stringify(data);
-  // JSON.stringify returns undefined when the root value is undefined, a
-  // function, or a symbol — guard to avoid writing the literal string
-  // "undefined" as SSE data, which would produce garbled client output.
-  if (serialized === undefined) {
-    throw new TypeError(
-      `writeSse: data of type ${typeof data} is not JSON-serializable (JSON.stringify returned undefined)`,
-    );
-  }
-  res.write(`data: ${serialized}\n\n`);
+  res.write(`data: ${guardJsonStringify("writeSse", data)}\n\n`);
 }
 
 function buildAgentCommandInput(params: {

--- a/src/gateway/sessions-history-http.ts
+++ b/src/gateway/sessions-history-http.ts
@@ -82,8 +82,11 @@ function resolveLimit(req: IncomingMessage): number | undefined {
 }
 
 function sseWrite(res: ServerResponse, event: string, payload: unknown): void {
+  // Serialize before any res.write so a non-serializable root throws
+  // without emitting a partial SSE frame (event line with no data).
+  const data = guardJsonStringify("sseWrite", payload);
   res.write(`event: ${event}\n`);
-  res.write(`data: ${guardJsonStringify("sseWrite", payload)}\n\n`);
+  res.write(`data: ${data}\n\n`);
 }
 
 /** Handle `/sessions/:sessionKey/history` JSON/SSE requests. */

--- a/src/gateway/sessions-history-http.ts
+++ b/src/gateway/sessions-history-http.ts
@@ -81,8 +81,17 @@ function resolveLimit(req: IncomingMessage): number | undefined {
 }
 
 function sseWrite(res: ServerResponse, event: string, payload: unknown): void {
+  const serialized = JSON.stringify(payload);
+  // JSON.stringify returns undefined when the root value is undefined, a
+  // function, or a symbol — guard to avoid writing the literal string
+  // "undefined" as SSE data, which would produce garbled client output.
+  if (serialized === undefined) {
+    throw new TypeError(
+      `sseWrite: payload of type ${typeof payload} is not JSON-serializable (JSON.stringify returned undefined)`,
+    );
+  }
   res.write(`event: ${event}\n`);
-  res.write(`data: ${JSON.stringify(payload)}\n\n`);
+  res.write(`data: ${serialized}\n\n`);
 }
 
 /** Handle `/sessions/:sessionKey/history` JSON/SSE requests. */

--- a/src/gateway/sessions-history-http.ts
+++ b/src/gateway/sessions-history-http.ts
@@ -13,6 +13,7 @@ import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
 import { DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS } from "./chat-display-projection.js";
 import {
+  guardJsonStringify,
   sendInvalidRequest,
   sendJson,
   sendMethodNotAllowed,
@@ -81,17 +82,8 @@ function resolveLimit(req: IncomingMessage): number | undefined {
 }
 
 function sseWrite(res: ServerResponse, event: string, payload: unknown): void {
-  const serialized = JSON.stringify(payload);
-  // JSON.stringify returns undefined when the root value is undefined, a
-  // function, or a symbol — guard to avoid writing the literal string
-  // "undefined" as SSE data, which would produce garbled client output.
-  if (serialized === undefined) {
-    throw new TypeError(
-      `sseWrite: payload of type ${typeof payload} is not JSON-serializable (JSON.stringify returned undefined)`,
-    );
-  }
   res.write(`event: ${event}\n`);
-  res.write(`data: ${serialized}\n\n`);
+  res.write(`data: ${guardJsonStringify("sseWrite", payload)}\n\n`);
 }
 
 /** Handle `/sessions/:sessionKey/history` JSON/SSE requests. */


### PR DESCRIPTION
## What Problem This Solves

`writeSse` (`src/gateway/openai-http.ts`) and `sseWrite` (`src/gateway/sessions-history-http.ts`) call `JSON.stringify(data)` where `data` is typed `unknown`, then write the result into an SSE response via template literal. When the root value is `undefined`, a function, or a symbol, `JSON.stringify` returns `undefined` (ECMA-262), which the template literal coerces to the literal string `"undefined"` — producing garbled SSE output like `data: undefined\n\n` instead of a valid JSON payload.

This is the same class of bug fixed by #97356 (`serializeJsonlLine`) in the transcript serialization path.

## Why This Change Was Made

SSE is a hot path for both OpenAI-compatible chat completions and session history streaming. A non-serializable value reaching either function would produce silently corrupted client output with no error signal. The fix adds the same `JSON.stringify` → undefined guard pattern already established in `transcript-jsonl.ts` and `diagnostic-llm-content.ts`.

## User Impact

Non-serializable values that reach `writeSse` or `sseWrite` now throw a `TypeError` instead of writing garbled `"data: undefined\n\n"` to SSE clients. All legitimate callers pass object literals and are unaffected.

## Evidence

**Environment**: Linux, Node 22, OpenClaw main

**Proof script** (`node proof-gateway-sse.mjs`):
```
PASS: all JSON.stringify guard proof checks passed

Summary:
  Non-serializable roots (undefined/function/symbol): throw TypeError
  Legitimate values (null/string/number/object): unchanged output
```

**Existing tests pass with no regression**:
```
$ pnpm test src/gateway/openai-http.test.ts
 Test Files  3 passed (3)
      Tests  60 passed (60)

$ pnpm test src/gateway/sessions-history-http.test.ts
 Test Files  1 passed (1)
      Tests  20 passed (20)
```

## Risk

Low. All existing callers pass object literals (`{ ... }`), so the guard is never tripped in normal operation. The `TypeError` class matches existing `JSON.stringify` error conventions (circular reference, BigInt). Pure defensive hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
