### PR TITLE
fix(gateway): log chat-abort terminal persistence failures

### DIFF
--- a/src/gateway/chat-abort.test.ts
+++ b/src/gateway/chat-abort.test.ts
@@ -16,6 +16,17 @@ import {
   updateChatRunProvider,
 } from "./chat-abort.js";
 
+const subsystemLoggerMock = vi.hoisted(() => ({
+  error: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+  debug: vi.fn(),
+}));
+
+vi.mock("../logging/subsystem.js", () => ({
+  createSubsystemLogger: vi.fn(() => subsystemLoggerMock),
+}));
+
 type ChatAbortPayload = {
   runId: string;
   sessionKey: string;
@@ -45,6 +56,10 @@ type CreatedChatAbortOps = ChatAbortOps & {
 
 afterEach(() => {
   vi.useRealTimers();
+  subsystemLoggerMock.error.mockClear();
+  subsystemLoggerMock.warn.mockClear();
+  subsystemLoggerMock.info.mockClear();
+  subsystemLoggerMock.debug.mockClear();
 });
 
 function createActiveEntry(sessionKey: string): ChatAbortControllerEntry {
@@ -263,6 +278,39 @@ describe("registerChatAbortController", () => {
     await persistence;
     await Promise.resolve();
     expect(chatAbortControllers.has("run-persisting")).toBe(false);
+  });
+
+  it("logs and still removes the controller when terminal persistence rejects", async () => {
+    const chatAbortControllers = new Map<string, ChatAbortControllerEntry>();
+    const registration = registerChatAbortController({
+      chatAbortControllers,
+      runId: "run-persist-failed",
+      sessionId: "sess-1",
+      sessionKey: "main",
+      timeoutMs: 60_000,
+    });
+
+    if (!registration.entry) {
+      throw new Error("expected registered entry");
+    }
+    registration.entry.projectSessionActive = false;
+    registration.entry.projectSessionTerminalPersistence = Promise.reject(
+      new Error("db write failed"),
+    );
+
+    registration.cleanup();
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(chatAbortControllers.has("run-persist-failed")).toBe(false);
+    expect(subsystemLoggerMock.error).toHaveBeenCalledOnce();
+    const [message, meta] = subsystemLoggerMock.error.mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+    ];
+    expect(message).toContain("persist chat abort terminal state");
+    expect(meta).toMatchObject({ runId: "run-persist-failed", error: "db write failed" });
   });
 
   it("retains registrations when terminal lifecycle was observed before caller cleanup", () => {

--- a/src/gateway/chat-abort.ts
+++ b/src/gateway/chat-abort.ts
@@ -176,7 +176,7 @@ export function registerChatAbortController(params: {
               params.chatAbortControllers.delete(params.runId);
             }
           })
-          .catch((err) => {
+          .catch((err: unknown) => {
             // Persistence failures here are typically DB or filesystem health
             // issues. Logging gives operators visibility; the controller entry
             // is still removed so memory does not leak.

--- a/src/gateway/chat-abort.ts
+++ b/src/gateway/chat-abort.ts
@@ -11,8 +11,11 @@ import { isAbortRequestText } from "../auto-reply/reply/abort-primitives.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { emitAgentEvent, getAgentEventLifecycleGeneration } from "../infra/agent-events.js";
 import { jsonUtf8Bytes } from "../infra/json-utf8-bytes.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import { projectLiveAssistantBufferedText } from "./live-chat-projector.js";
 import { createChatAbortMarker, type ChatAbortMarker } from "./server-chat-state.js";
+
+const log = createSubsystemLogger("gateway/chat-abort");
 
 const DEFAULT_CHAT_RUN_ABORT_GRACE_MS = 60_000;
 
@@ -173,7 +176,14 @@ export function registerChatAbortController(params: {
               params.chatAbortControllers.delete(params.runId);
             }
           })
-          .catch(() => {
+          .catch((err) => {
+            // Persistence failures here are typically DB or filesystem health
+            // issues. Logging gives operators visibility; the controller entry
+            // is still removed so memory does not leak.
+            log.error("Failed to persist chat abort terminal state", {
+              runId: params.runId,
+              error: err instanceof Error ? err.message : String(err),
+            });
             if (params.chatAbortControllers.get(params.runId)?.controller === controller) {
               params.chatAbortControllers.delete(params.runId);
             }


### PR DESCRIPTION
## What Problem This Solves

Fixes #97795.

When the project session terminal persistence promise inside `registerChatAbortController` rejected, the `.catch()` block removed the abort controller without ever recording why. In production this silently masks DB or filesystem health failures during run cleanup — operators get no trace in telemetry or logs that a terminal state failed to persist.

## Why This Change Was Made

The bug is a missing telemetry signal, not a logic flaw. The existing behavior (remove the controller either way so memory does not leak) is correct; the only gap is observability. The fix adds a `gateway/chat-abort` subsystem `error` log on rejection carrying `runId` and the underlying error message, then keeps the existing cleanup behavior unchanged.

A subsystem logger is used (matching `src/gateway/boot.ts` and `src/gateway/channel-health-monitor.ts`) rather than the bare `logError` helper so the failure is attributable to this code path in structured logs.

## User Impact

- Operators can now observe chat-abort terminal persistence failures through the standard subsystem logger and correlate them with DB/filesystem health incidents.
- No behavioral change to run cleanup; abort controllers are still removed on persistence failure so memory does not leak.
- No gateway runtime or API contract change.

## Evidence

- New test in `src/gateway/chat-abort.test.ts`: "logs and still removes the controller when terminal persistence rejects". It registers a controller, attaches a rejecting `projectSessionTerminalPersistence`, calls `cleanup()`, and asserts both that the entry is removed and that the subsystem logger received `error` with the expected message and `{ runId, error }` metadata.
- Existing test "retains completed registrations until terminal persistence succeeds" still covers the success path.
- Local tests: `node scripts/run-vitest.mjs src/gateway/chat-abort.test.ts` exits 0.
- Local typecheck: `node scripts/run-tsgo.mjs -p tsconfig.core.json` exits 0.
