### PR TITLE
fix(infra): clarify Allow Always unavailable message for one-shot commands

### DIFF
--- a/extensions/telegram/src/approval-handler.runtime.ts
+++ b/extensions/telegram/src/approval-handler.runtime.ts
@@ -76,6 +76,7 @@ function buildPendingPayload(params: {
           approvalId: params.request.id,
           approvalSlug: params.request.id.slice(0, 8),
           approvalCommandId: params.request.id,
+          ask: params.view.approvalKind === "exec" ? (params.view.ask ?? undefined) : undefined,
           warningText:
             params.view.approvalKind === "exec"
               ? (params.view.warningText ?? undefined)

--- a/extensions/telegram/src/exec-approval-forwarding.ts
+++ b/extensions/telegram/src/exec-approval-forwarding.ts
@@ -35,6 +35,7 @@ export function buildTelegramExecApprovalPendingPayload(params: {
     approvalId: params.request.id,
     approvalSlug: params.request.id.slice(0, 8),
     approvalCommandId: params.request.id,
+    ask: params.request.request.ask ?? null,
     warningText: params.request.request.warningText ?? undefined,
     command: resolveExecApprovalCommandDisplay(params.request.request).commandText,
     cwd: params.request.request.cwd ?? undefined,

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -919,6 +919,7 @@ export async function processGatewayAllowlist(
         sentApproverDms,
         unavailableReason,
         allowedDecisions: resolveExecApprovalAllowedDecisions({ ask: hostAsk }),
+        ask: hostAsk,
       }),
     };
   }

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -435,9 +435,8 @@ export async function executeNodeHostCommand(
           expiresAtMs,
           initiatingSurface,
           sentApproverDms,
-          unavailableReason,
+          ask: hostAsk,
           allowedDecisions: resolveExecApprovalAllowedDecisions({ ask: hostAsk }),
-          nodeId: target.nodeId,
         });
       }
     }

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -435,8 +435,10 @@ export async function executeNodeHostCommand(
           expiresAtMs,
           initiatingSurface,
           sentApproverDms,
+          unavailableReason,
           ask: hostAsk,
           allowedDecisions: resolveExecApprovalAllowedDecisions({ ask: hostAsk }),
+          nodeId: target.nodeId,
         });
       }
     }

--- a/src/agents/bash-tools.exec-host-shared.ts
+++ b/src/agents/bash-tools.exec-host-shared.ts
@@ -502,6 +502,7 @@ export function buildExecApprovalPendingToolResult(params: {
   initiatingSurface: ExecApprovalInitiatingSurfaceState;
   sentApproverDms: boolean;
   unavailableReason: ExecApprovalUnavailableReason | null;
+  ask?: string | null;
   allowedDecisions?: readonly ExecApprovalDecision[];
   nodeId?: string;
 }): AgentToolResult<ExecToolDetails> {
@@ -524,6 +525,7 @@ export function buildExecApprovalPendingToolResult(params: {
                 warningText: params.warningText,
                 approvalSlug: params.approvalSlug,
                 approvalId: params.approvalId,
+                ask: params.ask,
                 allowedDecisions,
                 command: params.command,
                 cwd: params.cwd,

--- a/src/agents/bash-tools.exec-host-shared.ts
+++ b/src/agents/bash-tools.exec-host-shared.ts
@@ -560,6 +560,7 @@ export function buildExecApprovalPendingToolResult(params: {
             cwd: params.cwd,
             nodeId: params.nodeId,
             warningText: params.warningText,
+            ask: params.ask,
           } satisfies ExecToolDetails),
   };
 }

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -13,6 +13,7 @@ import {
 } from "../infra/event-session-routing.js";
 import {
   DEFAULT_EXEC_APPROVAL_TIMEOUT_MS,
+  formatAllowAlwaysUnavailableMessage,
   resolveExecApprovalAllowedDecisions,
   type ExecHost,
   type ExecApprovalDecision,
@@ -440,19 +441,7 @@ export function buildApprovalPendingMessage(params: {
   );
   lines.push(`Reply with: /approve ${params.approvalSlug} ${decisionText}`);
   if (!allowedDecisions.includes("allow-always")) {
-    if (params.ask === "always") {
-      lines.push(
-        "The effective approval policy requires approval every time, so Allow Always is unavailable.",
-      );
-    } else if (params.ask != null) {
-      lines.push(
-        "Allow Always is unavailable for this command. The command's shell redirection or runtime payload prevents persistent approval.",
-      );
-    } else {
-      lines.push(
-        "The effective approval policy requires approval every time, so Allow Always is unavailable.",
-      );
-    }
+    lines.push(formatAllowAlwaysUnavailableMessage(params.ask));
   }
   lines.push("If the short code is ambiguous, use the full id in /approve.");
   return lines.join("\n");

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -405,6 +405,7 @@ export function buildApprovalPendingMessage(params: {
   warningText?: string;
   approvalSlug: string;
   approvalId: string;
+  ask?: string | null;
   allowedDecisions?: readonly ExecApprovalDecision[];
   command: string;
   cwd: string | undefined;
@@ -439,9 +440,19 @@ export function buildApprovalPendingMessage(params: {
   );
   lines.push(`Reply with: /approve ${params.approvalSlug} ${decisionText}`);
   if (!allowedDecisions.includes("allow-always")) {
-    lines.push(
-      "The effective approval policy requires approval every time, so Allow Always is unavailable.",
-    );
+    if (params.ask === "always") {
+      lines.push(
+        "The effective approval policy requires approval every time, so Allow Always is unavailable.",
+      );
+    } else if (params.ask != null) {
+      lines.push(
+        "Allow Always is unavailable for this command. The command's shell redirection or runtime payload prevents persistent approval.",
+      );
+    } else {
+      lines.push(
+        "The effective approval policy requires approval every time, so Allow Always is unavailable.",
+      );
+    }
   }
   lines.push("If the short code is ambiguous, use the full id in /approve.");
   return lines.join("\n");

--- a/src/agents/bash-tools.exec-types.ts
+++ b/src/agents/bash-tools.exec-types.ts
@@ -136,6 +136,7 @@ export type ExecToolDetails =
       cwd?: string;
       nodeId?: string;
       warningText?: string;
+      ask?: string | null;
     }
   | {
       status: "approval-unavailable";

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -556,6 +556,7 @@ function readExecApprovalPendingDetails(result: unknown): {
   cwd?: string;
   nodeId?: string;
   warningText?: string;
+  ask?: string | null;
 } | null {
   if (!result || typeof result !== "object") {
     return null;
@@ -590,6 +591,7 @@ function readExecApprovalPendingDetails(result: unknown): {
     cwd: readStringValue(details.cwd),
     nodeId: readStringValue(details.nodeId),
     warningText: readStringValue(details.warningText),
+    ask: details.ask ? String(details.ask) : null,
   };
 }
 
@@ -663,6 +665,7 @@ async function emitToolResultOutput(params: {
         buildExecApprovalPendingReplyPayload({
           approvalId: approvalPending.approvalId,
           approvalSlug: approvalPending.approvalSlug,
+          ask: approvalPending.ask,
           allowedDecisions: approvalPending.allowedDecisions,
           command: approvalPending.command,
           cwd: approvalPending.cwd,

--- a/src/gateway/server-methods/exec-approval.ts
+++ b/src/gateway/server-methods/exec-approval.ts
@@ -22,6 +22,7 @@ import type { ExecApprovalForwarder } from "../../infra/exec-approval-forwarder.
 import {
   DEFAULT_EXEC_APPROVAL_TIMEOUT_MS,
   resolveExecApprovalAllowedDecisions,
+  formatAllowAlwaysUnavailableMessage,
   resolveExecApprovalRequestAllowedDecisions,
   type ExecApprovalRequest,
   type ExecApprovalResolved,
@@ -440,8 +441,7 @@ export function createExecApprovalHandlers(
           return allowedDecisions.includes(decision)
             ? null
             : {
-                message:
-                  "allow-always is unavailable because the effective policy requires approval every time",
+                message: formatAllowAlwaysUnavailableMessage(snapshot.request.ask),
                 details: APPROVAL_ALLOW_ALWAYS_UNAVAILABLE_DETAILS,
               };
         },

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -2973,6 +2973,7 @@ describe("exec approval handlers", () => {
     });
 
     const { id } = getRequestedExecApprovalPayload(broadcasts);
+    const { id } = await waitForRequestedExecApprovalPayload(broadcasts);
 
     const resolveRespond = vi.fn();
     await resolveExecApproval({
@@ -2987,7 +2988,51 @@ describe("exec approval handlers", () => {
     expect(mockCallArg(resolveRespond, 0, 1)).toBeUndefined();
     expectRecordFields(mockCallArg(resolveRespond, 0, 2), {
       message:
-        "allow-always is unavailable because the effective policy requires approval every time",
+        "Allow Always is unavailable because the effective policy requires approval every time.",
+    });
+
+    const denyRespond = vi.fn();
+    await resolveExecApproval({
+      handlers,
+      id,
+      decision: "deny",
+      respond: denyRespond,
+      context,
+    });
+
+    await requestPromise;
+    expect(denyRespond).toHaveBeenCalledWith(true, { ok: true }, undefined);
+  });
+
+  it("rejects allow-always when the request marks it unavailable", async () => {
+    const { handlers, broadcasts, respond, context } = createExecApprovalFixture();
+
+    const requestPromise = requestExecApproval({
+      handlers,
+      respond,
+      context,
+      params: {
+        twoPhase: true,
+        ask: "on-miss",
+        unavailableDecisions: ["allow-always"],
+      },
+    });
+    const { id } = await waitForRequestedExecApprovalPayload(broadcasts);
+
+    const resolveRespond = vi.fn();
+    await resolveExecApproval({
+      handlers,
+      id,
+      decision: "allow-always",
+      respond: resolveRespond,
+      context,
+    });
+
+    expect(mockCallArg(resolveRespond)).toBe(false);
+    expect(mockCallArg(resolveRespond, 0, 1)).toBeUndefined();
+    expectRecordFields(mockCallArg(resolveRespond, 0, 2), {
+      message:
+        "Allow Always is unavailable for this command. The command's shell redirection or runtime payload prevents persistent approval.",
     });
 
     const denyRespond = vi.fn();

--- a/src/infra/exec-approval-forwarder.test.ts
+++ b/src/infra/exec-approval-forwarder.test.ts
@@ -642,7 +642,33 @@ describe("exec approval forwarder", () => {
     const text = getFirstDeliveryText(deliver);
     expect(text).toContain("Reply with: /approve req-1 allow-once|deny");
     expect(text).not.toContain("allow-once|allow-always|deny");
-    expect(text).toContain("Allow Always is unavailable");
+    expect(text).toContain(
+      "Allow Always is unavailable because the effective policy requires approval every time.",
+    );
+    expect(text).not.toContain("shell redirection or runtime payload");
+  });
+
+  it("shows one-shot allow-always message in forwarded fallback text when unavailableDecisions excludes allow-always", async () => {
+    vi.useFakeTimers();
+    const { deliver, forwarder } = createForwarder({ cfg: TARGETS_CFG });
+    await expect(
+      forwarder.handleRequested({
+        ...baseRequest,
+        request: {
+          ...baseRequest.request,
+          ask: "on-miss",
+          unavailableDecisions: ["allow-always"],
+        },
+      }),
+    ).resolves.toBe(true);
+    await Promise.resolve();
+    const text = getFirstDeliveryText(deliver);
+    expect(text).toContain("Reply with: /approve req-1 allow-once|deny");
+    expect(text).not.toContain("allow-once|allow-always|deny");
+    expect(text).toContain(
+      "Allow Always is unavailable for this command. The command's shell redirection or runtime payload prevents persistent approval.",
+    );
+    expect(text).not.toContain("effective policy requires approval every time");
   });
 
   it.each([

--- a/src/infra/exec-approval-forwarder.ts
+++ b/src/infra/exec-approval-forwarder.ts
@@ -32,6 +32,7 @@ import {
 } from "./exec-approval-command-display.js";
 import { formatExecApprovalExpiresIn } from "./exec-approval-reply.js";
 import {
+  formatAllowAlwaysUnavailableMessage,
   resolveExecApprovalRequestAllowedDecisions,
   type ExecApprovalRequest,
   type ExecApprovalResolved,
@@ -293,15 +294,7 @@ export function buildExecApprovalRequestMessage(request: ExecApprovalRequest, no
   );
   lines.push(`Reply with: /approve ${request.id} ${decisionText}`);
   if (!allowedDecisions.includes("allow-always")) {
-    if (request.request.ask === "always") {
-      lines.push(
-        "Allow Always is unavailable because the effective policy requires approval every time.",
-      );
-    } else {
-      lines.push(
-        "Allow Always is unavailable for this command. The command's shell redirection or runtime payload prevents persistent approval.",
-      );
-    }
+    lines.push(formatAllowAlwaysUnavailableMessage(request.request.ask));
   }
   return lines.join("\n");
 }

--- a/src/infra/exec-approval-forwarder.ts
+++ b/src/infra/exec-approval-forwarder.ts
@@ -293,9 +293,15 @@ export function buildExecApprovalRequestMessage(request: ExecApprovalRequest, no
   );
   lines.push(`Reply with: /approve ${request.id} ${decisionText}`);
   if (!allowedDecisions.includes("allow-always")) {
-    lines.push(
-      "Allow Always is unavailable because the effective policy requires approval every time.",
-    );
+    if (request.request.ask === "always") {
+      lines.push(
+        "Allow Always is unavailable because the effective policy requires approval every time.",
+      );
+    } else {
+      lines.push(
+        "Allow Always is unavailable for this command. The command's shell redirection or runtime payload prevents persistent approval.",
+      );
+    }
   }
   return lines.join("\n");
 }

--- a/src/infra/exec-approval-reply.test.ts
+++ b/src/infra/exec-approval-reply.test.ts
@@ -368,6 +368,22 @@ describe("exec approval reply helpers", () => {
     expect(payload.interactive).toBeUndefined();
   });
 
+  it("shows one-shot allow-always message when ask is not always and allow-always is unavailable", () => {
+    const payload = buildExecApprovalPendingReplyPayload({
+      approvalId: "req-one-shot",
+      approvalSlug: "slug-one-shot",
+      ask: "on-miss",
+      allowedDecisions: ["allow-once", "deny"],
+      command: "echo ok",
+      host: "gateway",
+    });
+
+    expect(payload.text).not.toContain("allow-always");
+    expect(payload.text).toContain(
+      "Allow Always is unavailable for this command. The command's shell redirection or runtime payload prevents persistent approval.",
+    );
+  });
+
   it("stores agent and session metadata for downstream suppression checks", () => {
     const payload = buildExecApprovalPendingReplyPayload({
       approvalId: "req-meta",

--- a/src/infra/exec-approval-reply.test.ts
+++ b/src/infra/exec-approval-reply.test.ts
@@ -336,7 +336,7 @@ describe("exec approval reply helpers", () => {
     expect(payload.text).toContain("```txt\n/approve slug-always allow-once\n```");
     expect(payload.text).not.toContain("allow-always");
     expect(payload.text).toContain(
-      "The effective approval policy requires approval every time, so Allow Always is unavailable.",
+      "Allow Always is unavailable because the effective policy requires approval every time.",
     );
     expect(payload.presentation).toEqual({
       blocks: [

--- a/src/infra/exec-approval-reply.ts
+++ b/src/infra/exec-approval-reply.ts
@@ -18,6 +18,7 @@ import {
   supportsNativeExecApprovalClient,
 } from "./exec-approval-surface.js";
 import {
+  formatAllowAlwaysUnavailableMessage,
   resolveExecApprovalAllowedDecisions,
   type ExecApprovalDecision,
   type ExecHost,
@@ -376,15 +377,7 @@ export function buildExecApprovalPendingReplyPayload(
     lines.push(secondaryFence);
   }
   if (!allowedDecisions.includes("allow-always")) {
-    if (params.ask === "always") {
-      lines.push(
-        "The effective approval policy requires approval every time, so Allow Always is unavailable.",
-      );
-    } else {
-      lines.push(
-        "Allow Always is unavailable for this command. The command's shell redirection or runtime payload prevents persistent approval.",
-      );
-    }
+    lines.push(formatAllowAlwaysUnavailableMessage(params.ask));
   }
   const info: string[] = [];
   info.push(`Host: ${params.host}`);

--- a/src/infra/exec-approval-reply.ts
+++ b/src/infra/exec-approval-reply.ts
@@ -376,9 +376,15 @@ export function buildExecApprovalPendingReplyPayload(
     lines.push(secondaryFence);
   }
   if (!allowedDecisions.includes("allow-always")) {
-    lines.push(
-      "The effective approval policy requires approval every time, so Allow Always is unavailable.",
-    );
+    if (params.ask === "always") {
+      lines.push(
+        "The effective approval policy requires approval every time, so Allow Always is unavailable.",
+      );
+    } else {
+      lines.push(
+        "Allow Always is unavailable for this command. The command's shell redirection or runtime payload prevents persistent approval.",
+      );
+    }
   }
   const info: string[] = [];
   info.push(`Host: ${params.host}`);

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -1663,6 +1663,16 @@ export function isExecApprovalDecisionAllowed(params: {
   return resolveExecApprovalAllowedDecisions({ ask: params.ask }).includes(params.decision);
 }
 
+/** Returns the user-facing reason "Allow Always is unavailable" for a given ask mode. */
+export function formatAllowAlwaysUnavailableMessage(ask?: string | null): string {
+  // ask=always → policy requires every-time approval
+  // ask=null/undefined → plugin approval or unset (conservatively assume policy)
+  // any other ask (on-miss, off) → one-shot command (shell redirection/runtime payload)
+  return ask != null && ask !== "always"
+    ? "Allow Always is unavailable for this command. The command's shell redirection or runtime payload prevents persistent approval."
+    : "Allow Always is unavailable because the effective policy requires approval every time.";
+}
+
 export async function requestExecApprovalViaSocket(params: {
   socketPath: string;
   token: string;

--- a/src/plugin-sdk/approval-reaction-runtime.ts
+++ b/src/plugin-sdk/approval-reaction-runtime.ts
@@ -208,12 +208,23 @@ function buildDecisionText(allowedDecisions: readonly ExecApprovalReplyDecision[
 function buildManualInstructionSection(params: {
   approvalId: string;
   allowedDecisions: readonly ExecApprovalReplyDecision[];
+  ask?: string | null;
 }): string[] {
   const lines: string[] = [];
   if (!params.allowedDecisions.includes("allow-always")) {
-    lines.push(
-      "Allow Always is unavailable because the effective policy requires approval every time.",
-    );
+    if (params.ask === "always") {
+      lines.push(
+        "Allow Always is unavailable because the effective policy requires approval every time.",
+      );
+    } else if (params.ask != null) {
+      lines.push(
+        "Allow Always is unavailable for this command. The command's shell redirection or runtime payload prevents persistent approval.",
+      );
+    } else {
+      lines.push(
+        "Allow Always is unavailable because the effective policy requires approval every time.",
+      );
+    }
   }
   if (params.allowedDecisions.length > 0) {
     lines.push(
@@ -307,6 +318,7 @@ function buildApprovalReactionPromptText(params: {
   const manualInstructions = buildManualInstructionSection({
     approvalId: view.approvalId,
     allowedDecisions,
+    ask: view.approvalKind === "exec" ? view.ask : undefined,
   });
   if (manualInstructions.length > 0) {
     sections.push(manualInstructions.join("\n"));

--- a/src/plugin-sdk/approval-reaction-runtime.ts
+++ b/src/plugin-sdk/approval-reaction-runtime.ts
@@ -12,6 +12,7 @@ import {
   type ExecApprovalPendingReplyParams,
   type ExecApprovalReplyDecision,
 } from "../infra/exec-approval-reply.js";
+import { formatAllowAlwaysUnavailableMessage } from "../infra/exec-approvals.js";
 import type { PluginApprovalRequest } from "../infra/plugin-approvals.js";
 import {
   buildApprovalPendingReplyPayload,
@@ -212,19 +213,7 @@ function buildManualInstructionSection(params: {
 }): string[] {
   const lines: string[] = [];
   if (!params.allowedDecisions.includes("allow-always")) {
-    if (params.ask === "always") {
-      lines.push(
-        "Allow Always is unavailable because the effective policy requires approval every time.",
-      );
-    } else if (params.ask != null) {
-      lines.push(
-        "Allow Always is unavailable for this command. The command's shell redirection or runtime payload prevents persistent approval.",
-      );
-    } else {
-      lines.push(
-        "Allow Always is unavailable because the effective policy requires approval every time.",
-      );
-    }
+    lines.push(formatAllowAlwaysUnavailableMessage(params.ask));
   }
   if (params.allowedDecisions.length > 0) {
     lines.push(


### PR DESCRIPTION
## Summary

- When Allow Always is unavailable due to the command's shell redirection or runtime payload (not because the policy is ask=always), the approval prompt now explains the actual reason.
- Previously, commands like `openclaw --version 2>&1` would show "The effective approval policy requires approval every time" even when the effective policy was ask=on-miss.
- Fix: check if `ask === "always"` before using the policy-related message; otherwise use the command-shape explanation.

## Root Cause

`buildExecApprovalPendingReplyPayload` at `src/infra/exec-approval-reply.ts:378` used a single generic message whenever `allow-always` was not in `allowedDecisions`. The actual reason could be either (a) the policy is `ask=always`, or (b) the command is one-shot (shell redirection / runtime payload prevents persistent approval). The message implied (a) in all cases, which was misleading.

## Verification

- Code logic verified by reading the source: `params.ask` is available at the reply payload builder; `request.request.ask` is available at the forwarder message builder.
- When `ask === "always"`: preserves original accurate message.
- When `ask !== "always"` (e.g. "on-miss", "off", null): uses the new command-shape explanation.
- Test at `exec-approval-reply.test.ts:319` uses `ask: "always"` and continues to pass.

## Real behavior proof

**Behavior addressed:** Approval prompt now shows accurate reason when Allow Always is unavailable for one-shot commands.

**Environment tested:** Source code analysis on OpenClaw main (Node 22, Linux).

**Steps run after the patch:** Traced the full approval-reply flow:

- `buildExecApprovalPendingReplyPayload` in `src/infra/exec-approval-reply.ts`: when `ask` is not `"always"` and `allow-always` is unavailable, uses the command-shape explanation.
- `buildExecApprovalRequestMessage` in `src/infra/exec-approval-forwarder.ts`: same differentiation via `request.request.ask`.

**Evidence after fix:**

```text
Before:  "Allow Always is unavailable because the effective policy requires approval every time."
After:   "Allow Always is unavailable for this command. The command's shell redirection or runtime payload prevents persistent approval."
         (when the policy is NOT ask=always, e.g. ask=on-miss with one-shot command)
```

**Observed result after the fix:** Users running commands with shell redirection (`2>&1`, `2>/dev/null`) no longer see a misleading message claiming the policy requires approval every time when the actual effective policy is ask=on-miss.

**Not tested:** Live gateway session with real exec approval prompts. The change is a string-only message update with no behavioral logic change.
