### PR TITLE
fix: classify overloaded 429 responses as overloaded, not rate_limit (fixes #98101)

### DIFF
--- a/src/agents/embedded-agent-helpers/errors.ts
+++ b/src/agents/embedded-agent-helpers/errors.ts
@@ -809,6 +809,13 @@ function classifyFailoverClassificationFromHttpStatus(
     if (message && isBilling429MessageForProvider(message, provider)) {
       return toReasonClassification("billing");
     }
+    // Overloaded 429 (e.g. z.ai code 1305, "temporarily overloaded") must be
+    // distinguished from genuine rate limits so the user-facing copy and
+    // failover reason are accurate.  503 and 499 already perform this check;
+    // 429 should follow the same pattern.
+    if (messageReason === "overloaded") {
+      return messageClassification;
+    }
     return toReasonClassification("rate_limit");
   }
   if (status === 401 || status === 403) {
@@ -1052,11 +1059,11 @@ function classifyFailoverClassificationFromMessage(
   if (isPeriodicUsageLimitErrorMessage(raw)) {
     return toReasonClassification(isBillingErrorMessage(raw) ? "billing" : "rate_limit");
   }
-  if (isRateLimitErrorMessage(raw)) {
-    return toReasonClassification("rate_limit");
-  }
   if (isOverloadedErrorMessage(raw)) {
     return toReasonClassification("overloaded");
+  }
+  if (isRateLimitErrorMessage(raw)) {
+    return toReasonClassification("rate_limit");
   }
   if (
     isStructuredServerErrorMessage(raw) &&

--- a/src/agents/embedded-agent-helpers/failover-matches.test.ts
+++ b/src/agents/embedded-agent-helpers/failover-matches.test.ts
@@ -1,6 +1,6 @@
 // Covers provider-specific failover matcher regressions.
 import { describe, expect, it } from "vitest";
-import { classifyFailoverReason } from "./errors.js";
+import { classifyFailoverReason, classifyFailoverReasonFromHttpStatus } from "./errors.js";
 import {
   isAuthErrorMessage,
   isBillingErrorMessage,
@@ -208,5 +208,25 @@ describe("generic assistant error text classification (#93931)", () => {
     expect(
       isTimeoutErrorMessage("LLM request failed: connection refused by the provider endpoint."),
     ).toBe(false);
+  });
+});
+
+describe("HTTP 429 overloaded vs rate-limit classification (#98101)", () => {
+  it("classifies a 429 with overloaded body as overloaded, not rate_limit", () => {
+    // z.ai code 1305: "The service may be temporarily overloaded, please try again later"
+    const message =
+      "429 status code (exceeded limit)\n" +
+      '{"code":1305,"message":"The service may be temporarily overloaded, please try again later."}';
+    expect(classifyFailoverReasonFromHttpStatus(429, message)).toBe("overloaded");
+  });
+
+  it("classifies a 429 with generic rate-limit body as rate_limit", () => {
+    const message = "429 status code (exceeded limit)\nRate limit exceeded. Try again in 60s.";
+    expect(classifyFailoverReasonFromHttpStatus(429, message)).toBe("rate_limit");
+  });
+
+  it("classifies a 429 with billing body as billing, not rate_limit", () => {
+    const message = "429 status code\nInsufficient balance or no resource package.";
+    expect(classifyFailoverReasonFromHttpStatus(429, message)).toBe("billing");
   });
 });


### PR DESCRIPTION
## What Problem This Solves

When a provider returns HTTP 429 with an "overloaded" body (e.g. z.ai code 1305: "The service may be temporarily overloaded, please try again later"), OpenClaw misclassifies it as a rate limit instead of an overload. This causes:

- Users see "⚠️ API rate limit reached" instead of the less alarming "temporarily overloaded" message
- The failover reason is `rate_limit` instead of `overloaded`, which triggers incorrect cooldown/rate-limit handling
- Users waste time debugging non-existent rate limits (rotating keys, waiting for limit resets)

The same class of bug was already fixed for billing 429 responses (#43447, #32828), but the overloaded case at 429 was missed.

## Why This Change Was Made

Two-level fix addressing both classification paths:

1. **Message classifier** (`classifyFailoverClassificationFromMessage`): `isRateLimitErrorMessage` matched the bare `429` pattern (`/rate[_ ]limit|too many requests|429/`) before `isOverloadedErrorMessage` could run. Reordered overloaded check before rate-limit check.

2. **HTTP status classifier** (`classifyFailoverClassificationFromHttpStatus`): The `status === 429` branch only checked billing then defaulted to `rate_limit`. Added an overloaded check matching the existing 503/499 pattern.

## User Impact

- Providers returning 429 + overloaded body now surface the correct "temporarily overloaded" message
- Failover reason correctly set to `overloaded` instead of `rate_limit`
- No change for genuine rate-limit 429 responses or billing 429 responses

## Evidence

## Real behavior proof

- **Behavior addressed:** HTTP 429 with overloaded body classified as `overloaded` instead of `rate_limit`
- **Environment tested:** macOS, Node 24, OpenClaw 2026.5.28 local build from `upstream/main` (738b2be4b)
- **Steps run after the patch:**
  1. Built OpenClaw from the fix branch (`pnpm build`)
  2. Ran the failover classification test suite: `node scripts/verification script run src/agents/embedded-agent-helpers/failover-matches.test.ts`
  3. Verified the specific classification function with `classifyFailoverReasonFromHttpStatus(429, overloadedBody)` returns `"overloaded"`
- **Evidence after fix:**
```
✓  unit-fast  src/agents/embedded-agent-helpers/failover-matches.test.ts (32 tests) 10ms

 Test Files  1 passed (1)
      Tests  32 passed (32)
```
- **Observed result after fix:** All 32 pass including 3 new tests for 429 overloaded classification. The function `classifyFailoverReasonFromHttpStatus(429, overloadedMessage)` correctly returns `"overloaded"`, while `classifyFailoverReasonFromHttpStatus(429, rateLimitMessage)` still returns `"rate_limit"` and `classifyFailoverReasonFromHttpStatus(429, billingMessage)` returns `"billing"`.
- **What was not tested:** Live provider interaction with z.ai (requires real API key). The fix is validated at the classification function level which is the same code path used by the production CLI.

- [x] AI-assisted (Hermes Agent)
