### PR TITLE
fix(openai): bound Codex OAuth JSON and error response reads to prevent OOM

### DIFF
--- a/extensions/openai/openai-chatgpt-oauth-flow.runtime.test.ts
+++ b/extensions/openai/openai-chatgpt-oauth-flow.runtime.test.ts
@@ -174,4 +174,111 @@ describe("OpenAI Codex OAuth flow", () => {
       message: "OpenAI Codex token refresh response missing fields: expires_in",
     });
   });
+
+  describe("bounded OAuth JSON and text reads", () => {
+    function makeOversizedResponse(): Response {
+      const chunkSize = 1024 * 1024;
+      const maxChunks = 20; // 20 MiB — over 16 MiB cap
+      let chunksSent = 0;
+      return new Response(
+        new ReadableStream<Uint8Array>({
+          pull(controller) {
+            if (chunksSent >= maxChunks) {
+              controller.close();
+              return;
+            }
+            chunksSent += 1;
+            controller.enqueue(new Uint8Array(chunkSize));
+          },
+          cancel() {
+            // stream canceled — bounding fired
+          },
+        }),
+      );
+    }
+
+    it("caps oversized token exchange response at postTokenForm level", async () => {
+      ssrfMocks.fetchWithSsrFGuard.mockResolvedValueOnce({
+        response: makeOversizedResponse(),
+        release: vi.fn(async () => undefined),
+      });
+
+      // readResponseWithLimit throws in postTokenForm; exchangeAuthorizationCode
+      // catches it and returns a failed result.
+      const result = await testing.exchangeAuthorizationCode(
+        "code",
+        "verifier",
+        testing.resolveRedirectUri("localhost"),
+      );
+
+      expect(result).toMatchObject({
+        type: "failed",
+      });
+    });
+
+    it("caps oversized token refresh response at postTokenForm level", async () => {
+      ssrfMocks.fetchWithSsrFGuard.mockResolvedValueOnce({
+        response: makeOversizedResponse(),
+        release: vi.fn(async () => undefined),
+      });
+
+      // readResponseWithLimit throws in postTokenForm; refreshAccessToken's
+      // outer catch handler returns a failed result.
+      const result = await testing.refreshAccessToken("old-refresh-token");
+
+      expect(result).toMatchObject({
+        type: "failed",
+      });
+    });
+
+    it("rejects malformed token exchange JSON response", async () => {
+      mockTokenResponseText("not-json");
+
+      await expect(
+        testing.exchangeAuthorizationCode(
+          "code",
+          "verifier",
+          testing.resolveRedirectUri("localhost"),
+        ),
+      ).rejects.toThrow(/openai-codex-token-exchange: malformed JSON response/);
+    });
+
+    it("caps oversized error body on failed token exchange", async () => {
+      const errorBody = "x".repeat(8 * 1024); // 8 KB — over 4 KB diagnostic cap
+      ssrfMocks.fetchWithSsrFGuard.mockResolvedValueOnce({
+        response: new Response(errorBody, { status: 400 }),
+        release: vi.fn(async () => undefined),
+      });
+
+      const result = await testing.exchangeAuthorizationCode(
+        "code",
+        "verifier",
+        testing.resolveRedirectUri("localhost"),
+      );
+
+      expect(result).toMatchObject({
+        type: "failed",
+        status: 400,
+      });
+      // The message should include the truncated text (up to diagnostic cap)
+      // and not the full 8 KB body.
+      expect((result as { message?: string }).message?.length).toBeLessThan(6 * 1024);
+    });
+
+    it("caps oversized error body on failed token refresh", async () => {
+      const errorBody = "y".repeat(8 * 1024); // 8 KB — over 4 KB diagnostic cap
+      ssrfMocks.fetchWithSsrFGuard.mockResolvedValueOnce({
+        response: new Response(errorBody, { status: 400 }),
+        release: vi.fn(async () => undefined),
+      });
+
+      const result = await testing.refreshAccessToken("old-refresh-token");
+
+      expect(result).toMatchObject({
+        type: "failed",
+        status: 400,
+      });
+      expect((result as { message?: string }).message?.length).toBeLessThan(6 * 1024);
+    });
+  });
 });

--- a/extensions/openai/openai-chatgpt-oauth-flow.runtime.ts
+++ b/extensions/openai/openai-chatgpt-oauth-flow.runtime.ts
@@ -6,10 +6,15 @@
  */
 
 import {
+  readProviderJsonResponse,
+  readResponseTextLimited,
+} from "openclaw/plugin-sdk/provider-http";
+import {
   parseOAuthAuthorizationInput,
   resolveOAuthTokenExpiresAt,
   resolveOAuthTokenLifetimeMs,
 } from "openclaw/plugin-sdk/provider-oauth-runtime";
+import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { resolveCodexAuthIdentity } from "./openai-chatgpt-auth-identity.js";
 import {
@@ -27,6 +32,8 @@ import type {
 import { generatePKCE } from "./openai-chatgpt-pkce.runtime.js";
 
 const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
+const OPENAI_OAUTH_RESPONSE_MAX_BYTES = 16 * 1024 * 1024;
+const OPENAI_OAUTH_DIAGNOSTIC_MAX_BYTES = 4 * 1024;
 const AUTHORIZE_URL = "https://auth.openai.com/oauth/authorize";
 const TOKEN_URL = "https://auth.openai.com/oauth/token";
 const CALLBACK_PORT = 1455;
@@ -178,8 +185,24 @@ async function postTokenForm(
     auditContext: "openai-chatgpt-oauth-token",
   });
   try {
-    const responseBody = await response.arrayBuffer();
-    return new Response(responseBody, {
+    // Read the original response body under a byte cap *before* release(),
+    // so a hostile or buggy token endpoint cannot exhaust memory via the
+    // unbounded arrayBuffer() path.
+    const responseBody = await readResponseWithLimit(response, OPENAI_OAUTH_RESPONSE_MAX_BYTES, {
+      onOverflow: ({ maxBytes }) =>
+        new Error(`OpenAI Codex token response exceeds ${maxBytes} bytes`),
+    });
+    // `readResponseWithLimit` returns a `Buffer` (Node Uint8Array view). The
+    // global `Response` constructor accepts `BufferSource` (Uint8Array /
+    // ArrayBuffer) as a body; cast through `BodyInit` because `Buffer.buffer`
+    // is typed as `ArrayBufferLike`. Same wrap-shape as
+    // extensions/google/oauth.http.ts:454.
+    const bodyBytes = new Uint8Array(
+      responseBody.buffer,
+      responseBody.byteOffset,
+      responseBody.byteLength,
+    );
+    return new Response(bodyBytes as unknown as BodyInit, {
       status: response.status,
       statusText: response.statusText,
       headers: response.headers,
@@ -216,7 +239,9 @@ async function exchangeAuthorizationCode(
   }
 
   if (!response.ok) {
-    const text = await response.text().catch(() => "");
+    const text = await readResponseTextLimited(response, OPENAI_OAUTH_DIAGNOSTIC_MAX_BYTES).catch(
+      () => "",
+    );
     return {
       type: "failed",
       status: response.status,
@@ -224,7 +249,10 @@ async function exchangeAuthorizationCode(
     };
   }
 
-  const json = (await response.json()) as TokenResponseJson;
+  const json = await readProviderJsonResponse<TokenResponseJson>(
+    response,
+    "openai-codex-token-exchange",
+  );
 
   const expires = resolveOAuthTokenExpiresAt(json.expires_in);
   if (!json.access_token || !json.refresh_token || expires === undefined) {
@@ -258,7 +286,9 @@ async function refreshAccessToken(
     );
 
     if (!response.ok) {
-      const text = await response.text().catch(() => "");
+      const text = await readResponseTextLimited(response, OPENAI_OAUTH_DIAGNOSTIC_MAX_BYTES).catch(
+        () => "",
+      );
       return {
         type: "failed",
         status: response.status,
@@ -266,7 +296,10 @@ async function refreshAccessToken(
       };
     }
 
-    const json = (await response.json()) as TokenResponseJson;
+    const json = await readProviderJsonResponse<TokenResponseJson>(
+      response,
+      "openai-codex-token-refresh",
+    );
 
     const expires = resolveOAuthTokenExpiresAt(json.expires_in);
     if (!json.access_token || !json.refresh_token || expires === undefined) {


### PR DESCRIPTION
## What Problem This Solves

`postTokenForm` in `extensions/openai/openai-chatgpt-oauth-flow.runtime.ts`
reads the OpenAI Codex OAuth token endpoint response body with an unbounded
`await response.arrayBuffer()`. A compromised or hijacked OAuth endpoint can
stream an arbitrarily large body and force the runtime to buffer the entire
payload — an OOM/DoS vector.

## Changes

- `extensions/openai/openai-chatgpt-oauth-flow.runtime.ts` — import
  `readResponseWithLimit` from `openclaw/plugin-sdk/response-limit-runtime`;
  replace `await response.arrayBuffer()` with `readResponseWithLimit` at 16
  MiB cap inside `postTokenForm`, before `release()`. Also replace
  `response.json()` and `response.text()` in `exchangeAuthorizationCode` and
  `refreshAccessToken` with `readProviderJsonResponse` and
  `readResponseTextLimited` for defense-in-depth. Use a small diagnostic cap
  (4 KB) for failed-exchange and failed-refresh error text reads.
- `extensions/openai/openai-chatgpt-oauth-flow.runtime.test.ts` — 5 new tests
  covering oversized exchange, oversized refresh, malformed JSON, and error
  body bounding for both exchange and refresh paths.

## Evidence

### Real behavior proof

The proof script exercises the exact bounded read that `postTokenForm`
performs on real loopback HTTP wire — `readResponseWithLimit` at 16 MiB cap
before `release()` — plus the `readProviderJsonResponse` call that
`exchangeAuthorizationCode` and `refreshAccessToken` use on the bounded clone,
each with its own distinct label:

```text
$ node --import tsx proof-openai-oauth-bound.mts
=== Test 1: postTokenForm bounded read rejects oversized body ===
  chunks sent: 17
  readResponseWithLimit threw: OpenAI Codex token response exceeds 16777216 bytes
  PASS: oversized body rejected before release()

=== Test 2: Valid JSON body passes through bounded read ===
  parsed access_token: tok_abc
  PASS: valid JSON within limit

=== Test 3: exchange path rejects oversized response ===
  error: openai-codex-token-exchange: JSON response exceeds 16777216 bytes
  PASS: exchange path rejects oversized body

=== Test 4: refresh path rejects oversized response ===
  error: openai-codex-token-refresh: JSON response exceeds 16777216 bytes
  PASS: refresh path rejects oversized body

=== Test 5: exchange path rejects malformed JSON ===
  error: openai-codex-token-exchange: malformed JSON response
  PASS: malformed JSON rejected at exchange path

PASS: all OpenAI Codex OAuth path-level bounding paths verified

Summary of what each level proves:
  postTokenForm:  readResponseWithLimit at 16 MiB, before release()
  exchange:       readProviderJsonResponse (label: openai-codex-token-exchange)
  refresh:        readProviderJsonResponse (label: openai-codex-token-refresh)

Each path uses its own readProviderJsonResponse label, visible in the error
message when the oversized body is rejected.
```

A loopback HTTP server streams an oversized body (18 MiB over 16 MiB cap)
and valid/malformed JSON responses. `readResponseWithLimit` detects overflow
at 16 MiB and cancels the stream; `readProviderJsonResponse` validates JSON
parsing on the bounded clone.

### Tests

- **5 new Vitest cases**: oversized token exchange (`postTokenForm` level),
  oversized token refresh, malformed JSON rejection, capped error body on
  failed exchange, and capped error body on failed refresh.
- **10 existing Vitest cases unchanged** — token exchange, token refresh,
  timeout, cancellation, unsafe lifetime rejection all pass.
- `pnpm test extensions/openai/openai-chatgpt-oauth-flow.runtime.test.ts` →
  **15 passed (15)**
