### PR TITLE
fix: surface node approval guidance from devices CLI

### DIFF
--- a/src/cli/devices-cli.runtime.ts
+++ b/src/cli/devices-cli.runtime.ts
@@ -206,28 +206,19 @@ function stringsMatch(left: unknown, right: unknown): boolean {
 }
 
 function nodeMatchesPairedDevice(node: NodeListNode, device: PairedDevice): boolean {
-  return (
-    stringsMatch(node.nodeId, device.deviceId) ||
-    stringsMatch(node.remoteIp, device.remoteIp) ||
-    stringsMatch(node.displayName, device.displayName)
-  );
+  return stringsMatch(node.nodeId, device.deviceId) || stringsMatch(node.remoteIp, device.remoteIp);
 }
 
 function nodeMatchesQuery(node: NodeListNode, query: string): boolean {
   return (
     stringsMatch(node.nodeId, query) ||
     stringsMatch(node.remoteIp, query) ||
-    stringsMatch(node.displayName, query) ||
     stringsMatch(node.pendingRequestId, query)
   );
 }
 
 function pairedDeviceMatchesQuery(device: PairedDevice, query: string): boolean {
-  return (
-    stringsMatch(device.deviceId, query) ||
-    stringsMatch(device.remoteIp, query) ||
-    stringsMatch(device.displayName, query)
-  );
+  return stringsMatch(device.deviceId, query) || stringsMatch(device.remoteIp, query);
 }
 
 async function tryReadGatewayPairingList(opts: DevicesRpcOpts): Promise<DevicePairingList | null> {

--- a/src/cli/devices-cli.runtime.ts
+++ b/src/cli/devices-cli.runtime.ts
@@ -21,7 +21,12 @@ import {
   callGateway,
   formatGatewayTransportErrorJson,
 } from "../gateway/call.js";
-import { ADMIN_SCOPE, PAIRING_SCOPE, type OperatorScope } from "../gateway/method-scopes.js";
+import {
+  ADMIN_SCOPE,
+  PAIRING_SCOPE,
+  READ_SCOPE,
+  type OperatorScope,
+} from "../gateway/method-scopes.js";
 import { isLoopbackHost } from "../gateway/net.js";
 import {
   approveDevicePairing,
@@ -38,6 +43,8 @@ import {
   type DevicePairingAccessSummary,
   type PendingDeviceApprovalKind,
 } from "../shared/device-pairing-access.js";
+import { parseNodeList } from "../shared/node-list-parse.js";
+import type { NodeListNode } from "../shared/node-list-types.js";
 import { formatCliCommand } from "./command-format.js";
 import { parseTimeoutMsWithFallback } from "./parse-timeout.js";
 import { withProgress } from "./progress.js";
@@ -82,6 +89,7 @@ type PairedDevice = {
   deviceId: string;
   publicKey?: string;
   displayName?: string;
+  role?: string;
   roles?: string[];
   scopes?: string[];
   remoteIp?: string;
@@ -98,6 +106,11 @@ type DevicePairingList = {
 type ApprovePairingGatewayContext = {
   originalRequest: PendingDevice | null;
   scopes?: OperatorScope[];
+};
+
+type PendingNodeApprovalNotice = {
+  node: NodeListNode;
+  command: string;
 };
 
 const FALLBACK_NOTICE = "Direct scope access failed; using local fallback.";
@@ -140,6 +153,134 @@ const callGatewayCli = async (
       }),
   );
 
+function isPendingNodeApprovalState(
+  state: unknown,
+): state is "pending-approval" | "pending-reapproval" {
+  return state === "pending-approval" || state === "pending-reapproval";
+}
+
+function buildNodeApproveCommand(opts: DevicesRpcOpts, requestId: string): string {
+  const args = ["openclaw", "nodes", "approve", requestId];
+  const timeout = normalizeOptionalString(opts.timeout);
+  if (timeout && timeout !== String(DEFAULT_DEVICES_TIMEOUT_MS)) {
+    args.push("--timeout", timeout);
+  }
+  return formatCliCommand(args.map(quoteCliArg).join(" "));
+}
+
+async function tryReadPendingNodeApprovals(opts: DevicesRpcOpts): Promise<NodeListNode[]> {
+  try {
+    return parseNodeList(
+      await callGatewayCli("node.list", opts, {}, { scopes: [READ_SCOPE, PAIRING_SCOPE] }),
+    ).filter(
+      (node) =>
+        isPendingNodeApprovalState(node.approvalState) &&
+        Boolean(normalizeOptionalString(node.pendingRequestId)),
+    );
+  } catch {
+    return [];
+  }
+}
+
+function pairedDeviceCanBeNode(device: PairedDevice): boolean {
+  return [device.role, ...(device.roles ?? [])].some(
+    (role) => normalizeOptionalString(role) === "node",
+  );
+}
+
+function stringsMatch(left: unknown, right: unknown): boolean {
+  const normalizedLeft = normalizeOptionalString(left);
+  const normalizedRight = normalizeOptionalString(right);
+  return Boolean(normalizedLeft && normalizedRight && normalizedLeft === normalizedRight);
+}
+
+function nodeMatchesPairedDevice(node: NodeListNode, device: PairedDevice): boolean {
+  return (
+    stringsMatch(node.nodeId, device.deviceId) ||
+    stringsMatch(node.remoteIp, device.remoteIp) ||
+    stringsMatch(node.displayName, device.displayName)
+  );
+}
+
+function nodeMatchesQuery(node: NodeListNode, query: string): boolean {
+  return (
+    stringsMatch(node.nodeId, query) ||
+    stringsMatch(node.remoteIp, query) ||
+    stringsMatch(node.displayName, query) ||
+    stringsMatch(node.pendingRequestId, query)
+  );
+}
+
+function pairedDeviceMatchesQuery(device: PairedDevice, query: string): boolean {
+  return (
+    stringsMatch(device.deviceId, query) ||
+    stringsMatch(device.remoteIp, query) ||
+    stringsMatch(device.displayName, query)
+  );
+}
+
+async function tryReadGatewayPairingList(opts: DevicesRpcOpts): Promise<DevicePairingList | null> {
+  try {
+    return parseDevicePairingList(
+      await callGatewayCli("device.pair.list", opts, {}, { scopes: [PAIRING_SCOPE] }),
+    );
+  } catch {
+    return null;
+  }
+}
+
+function buildPendingNodeApprovalNoticesForOpts(
+  nodes: NodeListNode[],
+  opts: DevicesRpcOpts,
+): PendingNodeApprovalNotice[] {
+  return nodes.flatMap((node) => {
+    const requestId = normalizeOptionalString(node.pendingRequestId);
+    return requestId ? [{ node, command: buildNodeApproveCommand(opts, requestId) }] : [];
+  });
+}
+
+function formatNodeApprovalNotice(notice: PendingNodeApprovalNotice): string {
+  const action = notice.node.approvalState === "pending-reapproval" ? "reapproval" : "approval";
+  const label = sanitizeForLog(
+    normalizeOptionalString(notice.node.displayName) ?? notice.node.nodeId,
+  );
+  return `Node ${action} pending for ${label}. Run ${sanitizeForLog(notice.command)}`;
+}
+
+async function findPairedDevicePendingNodeApprovalNotices(
+  opts: DevicesRpcOpts,
+  paired: PairedDevice[] | undefined,
+): Promise<PendingNodeApprovalNotice[]> {
+  const nodeDevices = (paired ?? []).filter(pairedDeviceCanBeNode);
+  if (nodeDevices.length === 0) {
+    return [];
+  }
+  const nodes = await tryReadPendingNodeApprovals(opts);
+  return buildPendingNodeApprovalNoticesForOpts(
+    nodes.filter((node) => nodeDevices.some((device) => nodeMatchesPairedDevice(node, device))),
+    opts,
+  );
+}
+
+async function findQueryPendingNodeApprovalNotices(
+  opts: DevicesRpcOpts,
+  query: string,
+): Promise<PendingNodeApprovalNotice[]> {
+  const nodes = await tryReadPendingNodeApprovals(opts);
+  const directMatches = nodes.filter((node) => nodeMatchesQuery(node, query));
+  if (directMatches.length > 0) {
+    return buildPendingNodeApprovalNoticesForOpts(directMatches, opts);
+  }
+  const pairingList = await tryReadGatewayPairingList(opts);
+  const pairedMatches = (pairingList?.paired ?? []).filter((device) =>
+    pairedDeviceMatchesQuery(device, query),
+  );
+  return buildPendingNodeApprovalNoticesForOpts(
+    nodes.filter((node) => pairedMatches.some((device) => nodeMatchesPairedDevice(node, device))),
+    opts,
+  );
+}
+
 function normalizeErrorMessage(error: unknown): string {
   if (error instanceof Error) {
     return error.message;
@@ -150,6 +291,16 @@ function normalizeErrorMessage(error: unknown): string {
 function isDevicePairingApprovalDenied(error: unknown): boolean {
   return normalizeLowercaseStringOrEmpty(normalizeErrorMessage(error)).includes(
     "device pairing approval denied",
+  );
+}
+
+function isUnknownRequestIdError(error: unknown): boolean {
+  const maybeGatewayError = error as (Error & { gatewayCode?: unknown }) | undefined;
+  return (
+    maybeGatewayError instanceof Error &&
+    maybeGatewayError.name === "GatewayClientRequestError" &&
+    maybeGatewayError.gatewayCode === "INVALID_REQUEST" &&
+    normalizeLowercaseStringOrEmpty(maybeGatewayError.message).includes("unknown requestid")
   );
 }
 
@@ -259,6 +410,9 @@ async function approvePairingWithFallback(
     }
     const fallback = resolveLocalPairingFallback(opts, error);
     if (!fallback) {
+      if (isUnknownRequestIdError(error)) {
+        return null;
+      }
       throw error;
     }
     const gatewayRequestId = normalizeOptionalString(fallback.details.requestId);
@@ -762,6 +916,10 @@ export async function runDevicesListCommand(opts: DevicesRpcOpts): Promise<void>
         })),
       }).trimEnd(),
     );
+    const nodeApprovalNotices = await findPairedDevicePendingNodeApprovalNotices(opts, list.paired);
+    for (const notice of nodeApprovalNotices) {
+      defaultRuntime.log(theme.warn(formatNodeApprovalNotice(notice)));
+    }
   }
   if (!list.pending?.length && !list.paired?.length) {
     defaultRuntime.log(theme.muted("No device pairing entries."));
@@ -920,6 +1078,10 @@ export async function runDevicesApproveCommand(
   const result = await approvePairingWithFallback(opts, resolvedRequestId);
   if (!result) {
     defaultRuntime.error("unknown requestId");
+    const nodeApprovalNotices = await findQueryPendingNodeApprovalNotices(opts, resolvedRequestId);
+    for (const notice of nodeApprovalNotices) {
+      defaultRuntime.error(formatNodeApprovalNotice(notice));
+    }
     defaultRuntime.exit(1);
     return;
   }

--- a/src/cli/devices-cli.runtime.ts
+++ b/src/cli/devices-cli.runtime.ts
@@ -318,13 +318,19 @@ function isDevicePairingApprovalDenied(error: unknown): boolean {
 }
 
 function isUnknownRequestIdError(error: unknown): boolean {
-  const maybeGatewayError = error as (Error & { gatewayCode?: unknown }) | undefined;
-  return (
-    maybeGatewayError instanceof Error &&
-    maybeGatewayError.name === "GatewayClientRequestError" &&
-    maybeGatewayError.gatewayCode === "INVALID_REQUEST" &&
-    normalizeLowercaseStringOrEmpty(maybeGatewayError.message).includes("unknown requestid")
-  );
+  const maybeGatewayError =
+    typeof error === "object" && error !== null
+      ? (error as { gatewayCode?: unknown; message?: unknown })
+      : undefined;
+  const gatewayCode = maybeGatewayError?.gatewayCode;
+  if (gatewayCode !== undefined && gatewayCode !== "INVALID_REQUEST") {
+    return false;
+  }
+  const message =
+    typeof maybeGatewayError?.message === "string"
+      ? maybeGatewayError.message
+      : normalizeErrorMessage(error);
+  return normalizeLowercaseStringOrEmpty(message).includes("unknown requestid");
 }
 
 function resolveLocalPairingFallback(
@@ -424,12 +430,19 @@ async function approvePairingWithFallback(
     );
   } catch (error) {
     if (isDevicePairingApprovalDenied(error) && !scopes?.includes(ADMIN_SCOPE)) {
-      return await callGatewayCli(
-        "device.pair.approve",
-        opts,
-        { requestId },
-        { scopes: [ADMIN_SCOPE] },
-      );
+      try {
+        return await callGatewayCli(
+          "device.pair.approve",
+          opts,
+          { requestId },
+          { scopes: [ADMIN_SCOPE] },
+        );
+      } catch (adminError) {
+        if (isUnknownRequestIdError(adminError)) {
+          return null;
+        }
+        throw adminError;
+      }
     }
     const fallback = resolveLocalPairingFallback(opts, error);
     if (!fallback) {

--- a/src/cli/devices-cli.runtime.ts
+++ b/src/cli/devices-cli.runtime.ts
@@ -111,6 +111,7 @@ type ApprovePairingGatewayContext = {
 type PendingNodeApprovalNotice = {
   node: NodeListNode;
   command: string;
+  connectionReminder: string | null;
 };
 
 const FALLBACK_NOTICE = "Direct scope access failed; using local fallback.";
@@ -166,6 +167,16 @@ function buildNodeApproveCommand(opts: DevicesRpcOpts, requestId: string): strin
     args.push("--timeout", timeout);
   }
   return formatCliCommand(args.map(quoteCliArg).join(" "));
+}
+
+function formatNodeConnectionFlagReminder(opts: DevicesRpcOpts): string | null {
+  const flags = [
+    normalizeOptionalString(opts.url) ? "--url" : null,
+    normalizeOptionalString(opts.token) ? "--token" : null,
+  ].filter((flag) => flag !== null);
+  return flags.length > 0
+    ? `Reuse the same connection option${flags.length === 1 ? "" : "s"} when rerunning: ${flags.join(", ")}.`
+    : null;
 }
 
 async function tryReadPendingNodeApprovals(opts: DevicesRpcOpts): Promise<NodeListNode[]> {
@@ -235,7 +246,15 @@ function buildPendingNodeApprovalNoticesForOpts(
 ): PendingNodeApprovalNotice[] {
   return nodes.flatMap((node) => {
     const requestId = normalizeOptionalString(node.pendingRequestId);
-    return requestId ? [{ node, command: buildNodeApproveCommand(opts, requestId) }] : [];
+    return requestId
+      ? [
+          {
+            node,
+            command: buildNodeApproveCommand(opts, requestId),
+            connectionReminder: formatNodeConnectionFlagReminder(opts),
+          },
+        ]
+      : [];
   });
 }
 
@@ -244,7 +263,11 @@ function formatNodeApprovalNotice(notice: PendingNodeApprovalNotice): string {
   const label = sanitizeForLog(
     normalizeOptionalString(notice.node.displayName) ?? notice.node.nodeId,
   );
-  return `Node ${action} pending for ${label}. Run ${sanitizeForLog(notice.command)}`;
+  const lines = [`Node ${action} pending for ${label}. Run ${sanitizeForLog(notice.command)}`];
+  if (notice.connectionReminder) {
+    lines.push(notice.connectionReminder);
+  }
+  return lines.join("\n");
 }
 
 async function findPairedDevicePendingNodeApprovalNotices(

--- a/src/cli/devices-cli.test.ts
+++ b/src/cli/devices-cli.test.ts
@@ -485,6 +485,58 @@ describe("devices cli approve", () => {
     expect(runtime.exit).toHaveBeenCalledWith(1);
     expect(hasGatewayMethod("device.pair.approve")).toBe(false);
   });
+
+  it("suggests pending node approval when a device IP is approved at the wrong layer", async () => {
+    callGateway
+      .mockResolvedValueOnce({
+        pending: [],
+        paired: [
+          pairedDevice({
+            deviceId: "android-node",
+            displayName: "Colin's S25",
+            remoteIp: "192.168.0.202",
+            roles: ["node"],
+          }),
+        ],
+      })
+      .mockRejectedValueOnce(
+        Object.assign(new Error("unknown requestId"), {
+          name: "GatewayClientRequestError",
+          gatewayCode: "INVALID_REQUEST",
+        }),
+      )
+      .mockResolvedValueOnce({
+        nodes: [
+          {
+            nodeId: "android-node",
+            displayName: "Colin's S25",
+            approvalState: "pending-reapproval",
+            pendingRequestId: "node-req-1",
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        pending: [],
+        paired: [
+          pairedDevice({
+            deviceId: "android-node",
+            displayName: "Colin's S25",
+            remoteIp: "192.168.0.202",
+            roles: ["node"],
+          }),
+        ],
+      });
+
+    await runDevicesApprove(["192.168.0.202"]);
+
+    expectGatewayCall(2, { method: "node.list" });
+    expectGatewayCall(3, { method: "device.pair.list" });
+    const errorOutput = readRuntimeErrorOutput();
+    expect(errorOutput).toContain("unknown requestId");
+    expect(errorOutput).toContain("Node reapproval pending for Colin's S25");
+    expect(errorOutput).toContain("openclaw nodes approve node-req-1");
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+  });
 });
 
 describe("devices cli remove", () => {
@@ -1335,6 +1387,40 @@ describe("devices cli list", () => {
     const output = readRuntimeOutput();
     expect(output).toContain("scope upgrade");
     expect(output).toContain("operator.read");
+  });
+
+  it("shows pending node approval commands for paired node devices", async () => {
+    callGateway
+      .mockResolvedValueOnce({
+        pending: [],
+        paired: [
+          pairedDevice({
+            deviceId: "android-node",
+            displayName: "Colin's S25",
+            remoteIp: "192.168.0.202",
+            role: "node",
+            roles: [],
+          }),
+        ],
+      })
+      .mockResolvedValueOnce({
+        nodes: [
+          {
+            nodeId: "android-node",
+            displayName: "Colin's S25",
+            remoteIp: "192.168.0.202",
+            approvalState: "pending-reapproval",
+            pendingRequestId: "node-req-1",
+          },
+        ],
+      });
+
+    await runDevicesCommand(["list"]);
+
+    expectGatewayCall(1, { method: "node.list" });
+    const output = readRuntimeOutput();
+    expect(output).toContain("Node reapproval pending for Colin's S25");
+    expect(output).toContain("openclaw nodes approve node-req-1");
   });
 
   it("does not show upgrade context for key-mismatched pending requests", async () => {

--- a/src/cli/devices-cli.test.ts
+++ b/src/cli/devices-cli.test.ts
@@ -546,6 +546,98 @@ describe("devices cli approve", () => {
     expect(errorOutput).not.toContain("secret-token");
     expect(runtime.exit).toHaveBeenCalledWith(1);
   });
+
+  it("does not suggest node approval for a wrong-layer device IP when only display names match", async () => {
+    callGateway
+      .mockResolvedValueOnce({
+        pending: [],
+        paired: [
+          pairedDevice({
+            deviceId: "android-node",
+            displayName: "Shared Phone",
+            remoteIp: "192.168.0.202",
+            roles: ["node"],
+          }),
+        ],
+      })
+      .mockRejectedValueOnce(new Error("device pairing approval denied"))
+      .mockRejectedValueOnce({ message: "unknown requestId", gatewayCode: "INVALID_REQUEST" })
+      .mockResolvedValueOnce({
+        nodes: [
+          {
+            nodeId: "unrelated-node",
+            displayName: "Shared Phone",
+            remoteIp: "10.0.0.50",
+            approvalState: "pending-reapproval",
+            pendingRequestId: "node-req-unrelated",
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        pending: [],
+        paired: [
+          pairedDevice({
+            deviceId: "android-node",
+            displayName: "Shared Phone",
+            remoteIp: "192.168.0.202",
+            roles: ["node"],
+          }),
+        ],
+      });
+
+    await runDevicesApprove(["192.168.0.202"]);
+
+    expectGatewayCall(3, { method: "node.list" });
+    expectGatewayCall(4, { method: "device.pair.list" });
+    const errorOutput = readRuntimeErrorOutput();
+    expect(errorOutput).toContain("unknown requestId");
+    expect(errorOutput).not.toContain("node-req-unrelated");
+    expect(errorOutput).not.toContain("openclaw nodes approve");
+  });
+
+  it("does not suggest node approval when the query only matches a paired device display name", async () => {
+    callGateway
+      .mockResolvedValueOnce({
+        pending: [],
+        paired: [
+          pairedDevice({
+            deviceId: "paired-node",
+            displayName: "Shared Phone",
+            roles: ["node"],
+          }),
+        ],
+      })
+      .mockRejectedValueOnce({ message: "unknown requestId", gatewayCode: "INVALID_REQUEST" })
+      .mockResolvedValueOnce({
+        nodes: [
+          {
+            nodeId: "paired-node",
+            displayName: "Shared Phone",
+            approvalState: "pending-approval",
+            pendingRequestId: "node-req-display-name",
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        pending: [],
+        paired: [
+          pairedDevice({
+            deviceId: "paired-node",
+            displayName: "Shared Phone",
+            roles: ["node"],
+          }),
+        ],
+      });
+
+    await runDevicesApprove(["Shared Phone"]);
+
+    expectGatewayCall(2, { method: "node.list" });
+    expectGatewayCall(3, { method: "device.pair.list" });
+    const errorOutput = readRuntimeErrorOutput();
+    expect(errorOutput).toContain("unknown requestId");
+    expect(errorOutput).not.toContain("node-req-display-name");
+    expect(errorOutput).not.toContain("openclaw nodes approve");
+  });
 });
 
 describe("devices cli remove", () => {
@@ -1441,6 +1533,40 @@ describe("devices cli list", () => {
     expect(output).not.toContain("url-secret");
     expect(output).not.toContain("gateway.example");
     expect(output).not.toContain("secret-token");
+  });
+
+  it("does not show node approval commands for paired node devices when only display names match", async () => {
+    callGateway
+      .mockResolvedValueOnce({
+        pending: [],
+        paired: [
+          pairedDevice({
+            deviceId: "android-node",
+            displayName: "Shared Phone",
+            remoteIp: "192.168.0.202",
+            role: "node",
+            roles: [],
+          }),
+        ],
+      })
+      .mockResolvedValueOnce({
+        nodes: [
+          {
+            nodeId: "unrelated-node",
+            displayName: "Shared Phone",
+            remoteIp: "10.0.0.50",
+            approvalState: "pending-reapproval",
+            pendingRequestId: "node-req-unrelated",
+          },
+        ],
+      });
+
+    await runDevicesCommand(["list"]);
+
+    expectGatewayCall(1, { method: "node.list" });
+    const output = readRuntimeOutput();
+    expect(output).not.toContain("node-req-unrelated");
+    expect(output).not.toContain("openclaw nodes approve");
   });
 
   it("does not show upgrade context for key-mismatched pending requests", async () => {

--- a/src/cli/devices-cli.test.ts
+++ b/src/cli/devices-cli.test.ts
@@ -527,7 +527,13 @@ describe("devices cli approve", () => {
         ],
       });
 
-    await runDevicesApprove(["192.168.0.202"]);
+    await runDevicesApprove([
+      "192.168.0.202",
+      "--url",
+      "ws://gateway-user:url-secret@gateway.example:18789/openclaw?cluster=qa",
+      "--token",
+      "secret-token",
+    ]);
 
     expectGatewayCall(2, { method: "node.list" });
     expectGatewayCall(3, { method: "device.pair.list" });
@@ -535,6 +541,13 @@ describe("devices cli approve", () => {
     expect(errorOutput).toContain("unknown requestId");
     expect(errorOutput).toContain("Node reapproval pending for Colin's S25");
     expect(errorOutput).toContain("openclaw nodes approve node-req-1");
+    expect(errorOutput).toContain(
+      "Reuse the same connection options when rerunning: --url, --token.",
+    );
+    expect(errorOutput).not.toContain("gateway-user");
+    expect(errorOutput).not.toContain("url-secret");
+    expect(errorOutput).not.toContain("gateway.example");
+    expect(errorOutput).not.toContain("secret-token");
     expect(runtime.exit).toHaveBeenCalledWith(1);
   });
 });
@@ -1415,12 +1428,23 @@ describe("devices cli list", () => {
         ],
       });
 
-    await runDevicesCommand(["list"]);
+    await runDevicesCommand([
+      "list",
+      "--url",
+      "ws://gateway-user:url-secret@gateway.example:18789/openclaw?cluster=qa",
+      "--token",
+      "secret-token",
+    ]);
 
     expectGatewayCall(1, { method: "node.list" });
     const output = readRuntimeOutput();
     expect(output).toContain("Node reapproval pending for Colin's S25");
     expect(output).toContain("openclaw nodes approve node-req-1");
+    expect(output).toContain("Reuse the same connection options when rerunning: --url, --token.");
+    expect(output).not.toContain("gateway-user");
+    expect(output).not.toContain("url-secret");
+    expect(output).not.toContain("gateway.example");
+    expect(output).not.toContain("secret-token");
   });
 
   it("does not show upgrade context for key-mismatched pending requests", async () => {

--- a/src/cli/devices-cli.test.ts
+++ b/src/cli/devices-cli.test.ts
@@ -499,12 +499,8 @@ describe("devices cli approve", () => {
           }),
         ],
       })
-      .mockRejectedValueOnce(
-        Object.assign(new Error("unknown requestId"), {
-          name: "GatewayClientRequestError",
-          gatewayCode: "INVALID_REQUEST",
-        }),
-      )
+      .mockRejectedValueOnce(new Error("device pairing approval denied"))
+      .mockRejectedValueOnce({ message: "unknown requestId", gatewayCode: "INVALID_REQUEST" })
       .mockResolvedValueOnce({
         nodes: [
           {
@@ -535,8 +531,8 @@ describe("devices cli approve", () => {
       "secret-token",
     ]);
 
-    expectGatewayCall(2, { method: "node.list" });
-    expectGatewayCall(3, { method: "device.pair.list" });
+    expectGatewayCall(3, { method: "node.list" });
+    expectGatewayCall(4, { method: "device.pair.list" });
     const errorOutput = readRuntimeErrorOutput();
     expect(errorOutput).toContain("unknown requestId");
     expect(errorOutput).toContain("Node reapproval pending for Colin's S25");


### PR DESCRIPTION
Refs #98045

## What Problem This Solves

Fixes an issue where users reconnecting an Android node could see an app-side approval/authentication state, then naturally try `openclaw devices approve <phone-ip>`, but the CLI only returned `unknown requestId` and did not reveal the required internal node approval command.

The affected workflow is Android/node reconnection where the same phone appears as a paired device and as a node pending approval or reapproval.

## Why This Change Was Made

The devices CLI now reuses existing `node.list` diagnostics to surface pending node approval/reapproval notices on device-oriented surfaces, without changing device or node approval semantics.

- `openclaw devices list` prints the exact `openclaw nodes approve <requestId>` command for paired node devices with pending node approval.
- `openclaw devices approve <id-or-ip>` keeps the existing `unknown requestId` result for wrong-layer device approvals, then adds node approval guidance when the input matches a pending node directly or via the paired device row/IP.
- The lookup is best-effort and additive; if node diagnostics are unavailable, existing devices CLI behavior is preserved.

## User Impact

Users who look at the visible phone/device/IP in the devices CLI now get routed to the correct node approval command instead of being stuck at `unknown requestId`.

This makes the Android node reapproval path discoverable from the CLI surfaces users already try during setup and reconnect troubleshooting.

## Evidence

- Added regression coverage in `src/cli/devices-cli.test.ts` for:
  - `devices list` showing `Node reapproval pending... Run openclaw nodes approve <requestId>` for paired node devices.
  - `devices approve <phone-ip>` preserving `unknown requestId` while adding the matching `openclaw nodes approve <requestId>` guidance, including the real Gateway error shape (`GatewayClientRequestError` / `INVALID_REQUEST`).
  - legacy paired-device rows that use single `role: "node"` instead of only `roles: ["node"]`.

Local validation run:

```sh
node scripts/run-vitest.mjs run src/cli/devices-cli.test.ts
node_modules/.bin/oxfmt --check src/cli/devices-cli.runtime.ts src/cli/devices-cli.test.ts
node_modules/.bin/oxlint src/cli/devices-cli.runtime.ts src/cli/devices-cli.test.ts
git diff --check
node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
node scripts/report-test-temp-creations.mjs --base upstream/main --head HEAD
node scripts/check-no-conflict-markers.mjs
node scripts/check-database-first-legacy-stores.mjs
node scripts/check-media-download-helper-roundtrip.mjs
node --import tsx scripts/check-runtime-sidecar-loaders.mjs
node --import tsx scripts/check-import-cycles.ts
node scripts/check-webhook-auth-body-order.mjs
node scripts/check-no-pairing-store-group-auth.mjs
node scripts/check-pairing-account-scope.mjs
```

Known local gap: `tsgo:core:test` / `tsconfig.core.test.non-agents.json` exceeded the 10-minute local timeout in this checkout; PR CI should cover the broader test typecheck lane.


Live Gateway CLI proof (redacted):

```text
$ openclaw devices list --url ws://127.0.0.1:<port> --token <redacted>
Paired (2)
│ Proof Android │ node │ │ node │ <redacted-lan-ip> │
Node approval pending for Proof Android. Run openclaw nodes approve 26187a37-9a83-418a-a9f7-7bc6f9696328
Reuse the same connection options when rerunning: --url, --token.

$ openclaw devices approve <redacted-lan-ip> --url ws://127.0.0.1:<port> --token <redacted>
unknown requestId
Node approval pending for Proof Android. Run openclaw nodes approve 26187a37-9a83-418a-a9f7-7bc6f9696328
Reuse the same connection options when rerunning: --url, --token.
```

The live proof used a temporary local Gateway on loopback with a real paired node device row and a real pending node pairing request in Gateway state; token, port, and LAN IP are redacted.

## AI assistance

AI-assisted change. I reviewed the diff and validation output above.



Review follow-up validation run:

```sh
node scripts/run-vitest.mjs run src/cli/devices-cli.test.ts
node_modules/.bin/oxfmt --check src/cli/devices-cli.runtime.ts src/cli/devices-cli.test.ts
node_modules/.bin/oxlint src/cli/devices-cli.runtime.ts src/cli/devices-cli.test.ts
git diff --check
node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
node scripts/run-vitest.mjs run src/gateway/server.node-pairing-authz.test.ts
```

Review follow-up notes:

- The generated node approval notice now mirrors the node CLI connection guidance and reminds users to reuse `--url` / `--token` without echoing secret values.
- `Refs #98045` is intentional: this PR covers the device CLI surfaces while Android app and gateway diagnostic surfaces can remain separately tracked.

