### PR TITLE
fix(ios): avoid transient duplicate final replies

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
@@ -47,6 +47,7 @@ public final class OpenClawChatViewModel {
     }
 
     private var pendingLocalUserEchoMessageIDsByRunID: [String: UUID] = [:]
+    private var provisionalFinalMessageIDs = Set<UUID>()
     private var sessionGeneration: UInt64 = 0
     private var bootstrapGeneration: UInt64 = 0
     // A newer same-session history request only invalidates older responses after it applies.
@@ -359,6 +360,7 @@ public final class OpenClawChatViewModel {
             Self.reconcileMessageIDs(previous: self.messages, incoming: incoming)
         }
         self.prunePendingLocalUserEchoMessageIDs()
+        self.pruneProvisionalFinalMessageIDs()
         self.sessionId = payload.sessionId
         // Incomplete refreshes can arrive before durable assistant history.
         // The latest visible user turn must survive answered before it can reject older replies.
@@ -526,6 +528,14 @@ public final class OpenClawChatViewModel {
         }.joined(separator: "\\u{001E}")
     }
 
+    private static func finalMessageContentFingerprint(for message: OpenClawChatMessage) -> String {
+        message.content.map { item in
+            let type = (item.type ?? "text").trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            let text = (item.text ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+            return [type, text].joined(separator: "\\u{001F}")
+        }.joined(separator: "\\u{001E}")
+    }
+
     private static func messageIdentityKey(for message: OpenClawChatMessage) -> String? {
         let role = message.role.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         guard !role.isEmpty else { return nil }
@@ -557,12 +567,43 @@ public final class OpenClawChatViewModel {
         return [role, toolCallId, toolName, contentFingerprint].joined(separator: "|")
     }
 
+    private static func finalMessageReconciliationKey(for message: OpenClawChatMessage) -> String? {
+        let role = message.role.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard role == "assistant" else { return nil }
+
+        let contentFingerprint = Self.finalMessageContentFingerprint(for: message)
+        let toolCallId = (message.toolCallId ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        let toolName = (message.toolName ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        if contentFingerprint.isEmpty, toolCallId.isEmpty, toolName.isEmpty {
+            return nil
+        }
+        return [role, toolCallId, toolName, contentFingerprint].joined(separator: "|")
+    }
+
+    private func hasCanonicalFinalMessageMatching(_ message: OpenClawChatMessage) -> Bool {
+        guard let key = Self.finalMessageReconciliationKey(for: message) else { return false }
+        let searchStart = self.messages.lastIndex(where: { existing in
+            existing.role.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "user"
+        }).map { self.messages.index(after: $0) } ?? self.messages.startIndex
+
+        return self.messages[searchStart...].contains { existing in
+            !self.provisionalFinalMessageIDs.contains(existing.id) &&
+                Self.finalMessageReconciliationKey(for: existing) == key
+        }
+    }
+
     private func prunePendingLocalUserEchoMessageIDs() {
         guard !self.pendingLocalUserEchoMessageIDsByRunID.isEmpty else { return }
         let visibleMessageIDs = Set(messages.map(\.id))
         self.pendingLocalUserEchoMessageIDsByRunID = self.pendingLocalUserEchoMessageIDsByRunID.filter {
             self.pendingRuns.contains($0.key) && visibleMessageIDs.contains($0.value)
         }
+    }
+
+    private func pruneProvisionalFinalMessageIDs() {
+        guard !self.provisionalFinalMessageIDs.isEmpty else { return }
+        let visibleMessageIDs = Set(messages.map(\.id))
+        self.provisionalFinalMessageIDs = self.provisionalFinalMessageIDs.intersection(visibleMessageIDs)
     }
 
     private func adoptPendingLocalUserEcho(incoming: OpenClawChatMessage) -> Bool {
@@ -591,6 +632,37 @@ public final class OpenClawChatViewModel {
             errorMessage: incoming.errorMessage)
         self.messages = Self.dedupeMessages(updated)
         self.prunePendingLocalUserEchoMessageIDs()
+        return true
+    }
+
+    private func adoptProvisionalFinalMessage(incoming: OpenClawChatMessage) -> Bool {
+        guard let incomingKey = Self.finalMessageReconciliationKey(for: incoming) else { return false }
+        let searchStart = self.messages.lastIndex(where: { existing in
+            existing.role.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "user"
+        }).map { self.messages.index(after: $0) } ?? self.messages.startIndex
+
+        guard let matchIndex = messages[searchStart...].lastIndex(where: { existing in
+            self.provisionalFinalMessageIDs.contains(existing.id) &&
+                Self.finalMessageReconciliationKey(for: existing) == incomingKey
+        }) else {
+            return false
+        }
+
+        let existing = self.messages[matchIndex]
+        var updated = self.messages
+        updated[matchIndex] = OpenClawChatMessage(
+            id: existing.id,
+            role: incoming.role,
+            content: incoming.content,
+            timestamp: incoming.timestamp ?? existing.timestamp,
+            toolCallId: incoming.toolCallId,
+            toolName: incoming.toolName,
+            usage: incoming.usage,
+            stopReason: incoming.stopReason,
+            errorMessage: incoming.errorMessage)
+        self.provisionalFinalMessageIDs.remove(existing.id)
+        self.messages = Self.dedupeMessages(updated)
+        self.pruneProvisionalFinalMessageIDs()
         return true
     }
 
@@ -955,6 +1027,7 @@ public final class OpenClawChatViewModel {
         self.modelSelectionID = Self.defaultModelSelectionID
         self.messages = []
         self.pendingLocalUserEchoMessageIDsByRunID.removeAll()
+        self.provisionalFinalMessageIDs.removeAll()
         self.sessionId = nil
         self.pendingToolCallsById = [:]
         self.streamingAssistantText = nil
@@ -989,6 +1062,7 @@ public final class OpenClawChatViewModel {
         self.modelSelectionID = Self.defaultModelSelectionID
         self.messages = []
         self.pendingLocalUserEchoMessageIDsByRunID.removeAll()
+        self.provisionalFinalMessageIDs.removeAll()
         self.sessionId = nil
         self.pendingToolCallsById = [:]
         self.streamingAssistantText = nil
@@ -1519,9 +1593,13 @@ public final class OpenClawChatViewModel {
         if self.adoptPendingLocalUserEcho(incoming: sanitized) {
             return
         }
+        if self.adoptProvisionalFinalMessage(incoming: sanitized) {
+            return
+        }
 
         let reconciled = Self.reconcileMessageIDs(previous: self.messages, incoming: self.messages + [sanitized])
         self.messages = Self.dedupeMessages(reconciled)
+        self.pruneProvisionalFinalMessageIDs()
     }
 
     private func handleChatEvent(_ chat: OpenClawChatEventPayload) {
@@ -1608,8 +1686,16 @@ public final class OpenClawChatViewModel {
                 stopReason: "stop")
         }
 
+        if self.hasCanonicalFinalMessageMatching(message) {
+            return
+        }
+
         let reconciled = Self.reconcileMessageIDs(previous: self.messages, incoming: self.messages + [message])
         self.messages = Self.dedupeMessages(reconciled)
+        if self.messages.contains(where: { $0.id == message.id }) {
+            self.provisionalFinalMessageIDs.insert(message.id)
+        }
+        self.pruneProvisionalFinalMessageIDs()
     }
 
     private static func isAssistantMessage(_ message: OpenClawChatMessage) -> Bool {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
@@ -587,6 +587,9 @@ public final class OpenClawChatViewModel {
         let role = message.role.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         guard role == "assistant" else { return nil }
 
+        // chat.final and session.message can serialize the same final row with
+        // different timestamps/content ids; the run user-turn scope owns safety
+        // for repeated same-text replies across turns.
         let contentFingerprint = Self.finalMessageContentFingerprint(for: message)
         let toolCallId = (message.toolCallId ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
         let toolName = (message.toolName ?? "").trimmingCharacters(in: .whitespacesAndNewlines)

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
@@ -47,7 +47,11 @@ public final class OpenClawChatViewModel {
     }
 
     private var pendingLocalUserEchoMessageIDsByRunID: [String: UUID] = [:]
-    private var provisionalFinalMessageIDs = Set<UUID>()
+    // Final chat events and durable session-message rows arrive independently.
+    // Keep each provisional final scoped to the run's user turn so a later identical
+    // answer in the same session does not adopt or suppress the wrong row.
+    private var runMessageScopesByRunID: [String: RunMessageScope] = [:]
+    private var provisionalFinalMessagesByID: [UUID: ProvisionalFinalMessage] = [:]
     private var sessionGeneration: UInt64 = 0
     private var bootstrapGeneration: UInt64 = 0
     // A newer same-session history request only invalidates older responses after it applies.
@@ -110,6 +114,17 @@ public final class OpenClawChatViewModel {
         var refreshKey: String?
         var occurrence: Int
         var timestamp: Double?
+    }
+
+    private struct RunMessageScope {
+        var session: SessionSnapshot
+        var latestUserTurn: LatestUserTurn?
+    }
+
+    private struct ProvisionalFinalMessage {
+        var reconciliationKey: String
+        var runId: String?
+        var scope: RunMessageScope
     }
 
     private var pendingToolCallsById: [String: OpenClawChatPendingToolCall] = [:] {
@@ -360,7 +375,8 @@ public final class OpenClawChatViewModel {
             Self.reconcileMessageIDs(previous: self.messages, incoming: incoming)
         }
         self.prunePendingLocalUserEchoMessageIDs()
-        self.pruneProvisionalFinalMessageIDs()
+        self.pruneProvisionalFinalMessages()
+        self.pruneRunMessageScopes()
         self.sessionId = payload.sessionId
         // Incomplete refreshes can arrive before durable assistant history.
         // The latest visible user turn must survive answered before it can reject older replies.
@@ -580,14 +596,84 @@ public final class OpenClawChatViewModel {
         return [role, toolCallId, toolName, contentFingerprint].joined(separator: "|")
     }
 
-    private func hasCanonicalFinalMessageMatching(_ message: OpenClawChatMessage) -> Bool {
+    private static func normalizedRunID(_ runId: String?) -> String? {
+        let trimmed = runId?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private func currentRunMessageScope() -> RunMessageScope {
+        RunMessageScope(
+            session: self.currentSessionSnapshot(),
+            latestUserTurn: Self.latestUserTurn(in: self.messages))
+    }
+
+    private func runMessageScope(for runId: String?) -> RunMessageScope {
+        guard let runId = Self.normalizedRunID(runId),
+              let scope = self.runMessageScopesByRunID[runId],
+              self.isCurrentSession(scope.session)
+        else {
+            return self.currentRunMessageScope()
+        }
+        return scope
+    }
+
+    private static func isSameUserTurnBoundary(_ lhs: LatestUserTurn?, _ rhs: LatestUserTurn?) -> Bool {
+        switch (lhs, rhs) {
+        case (nil, nil):
+            return true
+        case let (lhs?, rhs?):
+            if let lhsKey = lhs.refreshKey, let rhsKey = rhs.refreshKey {
+                return lhsKey == rhsKey && lhs.occurrence == rhs.occurrence
+            }
+            return lhs.refreshKey == nil &&
+                rhs.refreshKey == nil &&
+                lhs.occurrence == rhs.occurrence &&
+                lhs.timestamp == rhs.timestamp
+        default:
+            return false
+        }
+    }
+
+    private static func indexAfterLatestUserTurn(
+        _ latestUserTurn: LatestUserTurn?,
+        in messages: [OpenClawChatMessage])
+        -> [OpenClawChatMessage].Index
+    {
+        guard let latestUserTurn else { return messages.startIndex }
+        if let refreshKey = latestUserTurn.refreshKey {
+            var occurrence = 0
+            for index in messages.indices {
+                guard self.userRefreshIdentityKey(for: messages[index]) == refreshKey else { continue }
+                occurrence += 1
+                if occurrence == latestUserTurn.occurrence {
+                    return messages.index(after: index)
+                }
+            }
+        } else if let timestamp = latestUserTurn.timestamp,
+                  let index = messages.lastIndex(where: { message in
+                      message.role.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "user" &&
+                          message.timestamp == timestamp
+                  })
+        {
+            return messages.index(after: index)
+        }
+
+        return messages.lastIndex(where: { message in
+            message.role.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "user"
+        }).map { messages.index(after: $0) } ?? messages.startIndex
+    }
+
+    private func hasCanonicalFinalMessageMatching(
+        _ message: OpenClawChatMessage,
+        scope: RunMessageScope) -> Bool
+    {
         guard let key = Self.finalMessageReconciliationKey(for: message) else { return false }
-        let searchStart = self.messages.lastIndex(where: { existing in
-            existing.role.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "user"
-        }).map { self.messages.index(after: $0) } ?? self.messages.startIndex
+        guard self.isCurrentSession(scope.session) else { return false }
+        let searchStart = Self.indexAfterLatestUserTurn(scope.latestUserTurn, in: self.messages)
+        guard searchStart < self.messages.endIndex else { return false }
 
         return self.messages[searchStart...].contains { existing in
-            !self.provisionalFinalMessageIDs.contains(existing.id) &&
+            self.provisionalFinalMessagesByID[existing.id] == nil &&
                 Self.finalMessageReconciliationKey(for: existing) == key
         }
     }
@@ -600,10 +686,24 @@ public final class OpenClawChatViewModel {
         }
     }
 
-    private func pruneProvisionalFinalMessageIDs() {
-        guard !self.provisionalFinalMessageIDs.isEmpty else { return }
+    private func pruneProvisionalFinalMessages() {
+        guard !self.provisionalFinalMessagesByID.isEmpty else { return }
         let visibleMessageIDs = Set(messages.map(\.id))
-        self.provisionalFinalMessageIDs = self.provisionalFinalMessageIDs.intersection(visibleMessageIDs)
+        self.provisionalFinalMessagesByID = self.provisionalFinalMessagesByID.filter { entry in
+            visibleMessageIDs.contains(entry.key) && self.isCurrentSession(entry.value.scope.session)
+        }
+    }
+
+    private func pruneRunMessageScopes() {
+        self.runMessageScopesByRunID = self.runMessageScopesByRunID.filter { entry in
+            self.isCurrentSession(entry.value.session)
+        }
+        guard self.runMessageScopesByRunID.count > 64 else { return }
+        let referencedRunIDs = Set(self.pendingRuns)
+            .union(self.provisionalFinalMessagesByID.values.compactMap(\.runId))
+        self.runMessageScopesByRunID = self.runMessageScopesByRunID.filter { entry in
+            referencedRunIDs.contains(entry.key)
+        }
     }
 
     private func adoptPendingLocalUserEcho(incoming: OpenClawChatMessage) -> Bool {
@@ -637,18 +737,20 @@ public final class OpenClawChatViewModel {
 
     private func adoptProvisionalFinalMessage(incoming: OpenClawChatMessage) -> Bool {
         guard let incomingKey = Self.finalMessageReconciliationKey(for: incoming) else { return false }
-        let searchStart = self.messages.lastIndex(where: { existing in
-            existing.role.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "user"
-        }).map { self.messages.index(after: $0) } ?? self.messages.startIndex
+        let canonicalScope = self.currentRunMessageScope()
+        let searchStart = Self.indexAfterLatestUserTurn(canonicalScope.latestUserTurn, in: self.messages)
+        guard searchStart < self.messages.endIndex else { return false }
 
         guard let matchIndex = messages[searchStart...].lastIndex(where: { existing in
-            self.provisionalFinalMessageIDs.contains(existing.id) &&
-                Self.finalMessageReconciliationKey(for: existing) == incomingKey
+            guard let provisional = self.provisionalFinalMessagesByID[existing.id] else { return false }
+            return provisional.reconciliationKey == incomingKey &&
+                Self.isSameUserTurnBoundary(provisional.scope.latestUserTurn, canonicalScope.latestUserTurn)
         }) else {
             return false
         }
 
         let existing = self.messages[matchIndex]
+        let provisional = self.provisionalFinalMessagesByID[existing.id]
         var updated = self.messages
         updated[matchIndex] = OpenClawChatMessage(
             id: existing.id,
@@ -660,9 +762,13 @@ public final class OpenClawChatViewModel {
             usage: incoming.usage,
             stopReason: incoming.stopReason,
             errorMessage: incoming.errorMessage)
-        self.provisionalFinalMessageIDs.remove(existing.id)
+        self.provisionalFinalMessagesByID.removeValue(forKey: existing.id)
+        if let runId = provisional?.runId {
+            self.runMessageScopesByRunID.removeValue(forKey: runId)
+        }
         self.messages = Self.dedupeMessages(updated)
-        self.pruneProvisionalFinalMessageIDs()
+        self.pruneProvisionalFinalMessages()
+        self.pruneRunMessageScopes()
         return true
     }
 
@@ -912,6 +1018,7 @@ public final class OpenClawChatViewModel {
                 content: userContent,
                 timestamp: userMessageTimestamp))
         self.pendingLocalUserEchoMessageIDsByRunID[runId] = userMessageID
+        self.runMessageScopesByRunID[runId] = self.currentRunMessageScope()
 
         // Clear input immediately for responsive UX (before network await)
         self.input = ""
@@ -935,9 +1042,11 @@ public final class OpenClawChatViewModel {
                     + "localRunId=\(runId) remoteRunId=\(response.runId)")
             if response.runId != runId {
                 let pendingUserMessageID = self.pendingLocalUserEchoMessageIDsByRunID.removeValue(forKey: runId)
+                let runScope = self.runMessageScopesByRunID.removeValue(forKey: runId)
                 self.clearPendingRun(runId)
                 self.pendingRuns.insert(response.runId)
                 self.pendingLocalUserEchoMessageIDsByRunID[response.runId] = pendingUserMessageID
+                self.runMessageScopesByRunID[response.runId] = runScope
                 self.armPendingRunTimeout(runId: response.runId)
             }
             if response.status == "ok" {
@@ -966,6 +1075,7 @@ public final class OpenClawChatViewModel {
         } catch {
             guard self.isCurrentSession(sessionSnapshot) else { return }
             self.removePendingLocalUserEcho(for: runId)
+            self.runMessageScopesByRunID.removeValue(forKey: runId)
             self.clearPendingRun(runId)
             self.errorText = error.localizedDescription
             self.logDiagnostic(
@@ -1027,7 +1137,8 @@ public final class OpenClawChatViewModel {
         self.modelSelectionID = Self.defaultModelSelectionID
         self.messages = []
         self.pendingLocalUserEchoMessageIDsByRunID.removeAll()
-        self.provisionalFinalMessageIDs.removeAll()
+        self.runMessageScopesByRunID.removeAll()
+        self.provisionalFinalMessagesByID.removeAll()
         self.sessionId = nil
         self.pendingToolCallsById = [:]
         self.streamingAssistantText = nil
@@ -1062,7 +1173,8 @@ public final class OpenClawChatViewModel {
         self.modelSelectionID = Self.defaultModelSelectionID
         self.messages = []
         self.pendingLocalUserEchoMessageIDsByRunID.removeAll()
-        self.provisionalFinalMessageIDs.removeAll()
+        self.runMessageScopesByRunID.removeAll()
+        self.provisionalFinalMessagesByID.removeAll()
         self.sessionId = nil
         self.pendingToolCallsById = [:]
         self.streamingAssistantText = nil
@@ -1090,6 +1202,8 @@ public final class OpenClawChatViewModel {
             return
         }
 
+        self.runMessageScopesByRunID.removeAll()
+        self.provisionalFinalMessagesByID.removeAll()
         self.startBootstrap()
     }
 
@@ -1599,7 +1713,8 @@ public final class OpenClawChatViewModel {
 
         let reconciled = Self.reconcileMessageIDs(previous: self.messages, incoming: self.messages + [sanitized])
         self.messages = Self.dedupeMessages(reconciled)
-        self.pruneProvisionalFinalMessageIDs()
+        self.pruneProvisionalFinalMessages()
+        self.pruneRunMessageScopes()
     }
 
     private func handleChatEvent(_ chat: OpenClawChatEventPayload) {
@@ -1686,16 +1801,28 @@ public final class OpenClawChatViewModel {
                 stopReason: "stop")
         }
 
-        if self.hasCanonicalFinalMessageMatching(message) {
+        let runId = Self.normalizedRunID(chat.runId)
+        let scope = self.runMessageScope(for: runId)
+        guard self.isCurrentSession(scope.session) else { return }
+        guard let reconciliationKey = Self.finalMessageReconciliationKey(for: message) else { return }
+
+        if self.hasCanonicalFinalMessageMatching(message, scope: scope) {
+            if let runId {
+                self.runMessageScopesByRunID.removeValue(forKey: runId)
+            }
             return
         }
 
         let reconciled = Self.reconcileMessageIDs(previous: self.messages, incoming: self.messages + [message])
         self.messages = Self.dedupeMessages(reconciled)
         if self.messages.contains(where: { $0.id == message.id }) {
-            self.provisionalFinalMessageIDs.insert(message.id)
+            self.provisionalFinalMessagesByID[message.id] = ProvisionalFinalMessage(
+                reconciliationKey: reconciliationKey,
+                runId: runId,
+                scope: scope)
         }
-        self.pruneProvisionalFinalMessageIDs()
+        self.pruneProvisionalFinalMessages()
+        self.pruneRunMessageScopes()
     }
 
     private static func isAssistantMessage(_ message: OpenClawChatMessage) -> Bool {
@@ -1847,7 +1974,7 @@ public final class OpenClawChatViewModel {
     }
 
     private func removePendingLocalUserEcho(for runId: String) {
-        guard let messageID = self.pendingLocalUserEchoMessageIDsByRunID[runId] else { return }
+        guard let messageID = pendingLocalUserEchoMessageIDsByRunID[runId] else { return }
         self.messages.removeAll { $0.id == messageID }
         self.pendingLocalUserEchoMessageIDsByRunID[runId] = nil
     }
@@ -1938,7 +2065,7 @@ public final class OpenClawChatViewModel {
         guard let lastUserIndex = messages.lastIndex(where: { $0.role.lowercased() == "user" }) else {
             return nil
         }
-        guard let refreshKey = self.userRefreshIdentityKey(for: messages[lastUserIndex]) else {
+        guard let refreshKey = userRefreshIdentityKey(for: messages[lastUserIndex]) else {
             return LatestUserTurn(
                 refreshKey: nil,
                 occurrence: 0,

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
@@ -3,12 +3,30 @@ import OpenClawKit
 import Testing
 @testable import OpenClawChatUI
 
-private func chatTextMessage(role: String, text: String, timestamp: Double) -> AnyCodable {
+private func chatTextMessage(role: String, text: String, timestamp: Double, contentId: String? = nil) -> AnyCodable {
+    var content: [String: Any] = ["type": "text", "text": text]
+    if let contentId {
+        content["id"] = contentId
+    }
     AnyCodable([
         "role": role,
-        "content": [["type": "text", "text": text]],
+        "content": [content],
         "timestamp": timestamp,
     ])
+}
+
+private func chatTextModelMessage(role: String, text: String, timestamp: Double) -> OpenClawChatMessage {
+    OpenClawChatMessage(
+        role: role,
+        content: [
+            OpenClawChatMessageContent(
+                type: "text",
+                text: text,
+                mimeType: nil,
+                fileName: nil,
+                content: nil),
+        ],
+        timestamp: timestamp)
 }
 
 private func chatErrorMessage(role: String, errorMessage: String, timestamp: Double) -> AnyCodable {
@@ -797,6 +815,182 @@ struct ChatViewModelTests {
                     }
             }
         }
+    }
+
+    @Test func `session message adopts provisional final event reply`() async throws {
+        let sessionId = "sess-main"
+        let now = Date().timeIntervalSince1970 * 1000
+        let finalRefreshGate = SessionSubscribeGate()
+        let historyCount = AsyncCounter()
+        let history = historyPayload(sessionId: sessionId)
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [history, history],
+            requestHistoryHook: { _ in
+                let count = await historyCount.increment()
+                if count == 2 {
+                    await finalRefreshGate.wait()
+                }
+            })
+        try await loadAndWaitBootstrap(vm: vm, sessionId: sessionId)
+
+        await sendUserMessage(vm, text: "hello")
+        try await waitUntil("pending run starts") { await MainActor.run { vm.pendingRunCount == 1 } }
+        let runId = try await waitForLastSentRunId(transport)
+
+        transport.emit(
+            .chat(
+                OpenClawChatEventPayload(
+                    runId: runId,
+                    sessionKey: "main",
+                    state: "final",
+                    message: chatTextMessage(
+                        role: "assistant",
+                        text: "dedupe me",
+                        timestamp: now + 1,
+                        contentId: "live-final-content"),
+                    errorMessage: nil)))
+
+        try await waitUntil("provisional final visible once") {
+            await MainActor.run {
+                vm.messages.count(where: { msg in
+                    msg.role == "assistant" && msg.content.first?.text == "dedupe me"
+                }) == 1
+            }
+        }
+
+        transport.emit(
+            .sessionMessage(
+                OpenClawSessionMessageEventPayload(
+                    sessionKey: "agent:main:main",
+                    message: chatTextModelMessage(role: "assistant", text: "dedupe me", timestamp: now + 2),
+                    messageId: "msg-assistant-final",
+                    messageSeq: 2)))
+
+        try await waitUntil("canonical session message adopted final event row") {
+            await MainActor.run {
+                let matches = vm.messages.filter { msg in
+                    msg.role == "assistant" && msg.content.first?.text == "dedupe me"
+                }
+                return matches.count == 1 && matches.first?.timestamp == now + 2
+            }
+        }
+
+        await finalRefreshGate.release()
+    }
+
+    @Test func `final event does not duplicate canonical assistant session message`() async throws {
+        let sessionId = "sess-main"
+        let now = Date().timeIntervalSince1970 * 1000
+        let finalRefreshGate = SessionSubscribeGate()
+        let historyCount = AsyncCounter()
+        let history = historyPayload(sessionId: sessionId)
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [history, history],
+            requestHistoryHook: { _ in
+                let count = await historyCount.increment()
+                if count == 2 {
+                    await finalRefreshGate.wait()
+                }
+            })
+        try await loadAndWaitBootstrap(vm: vm, sessionId: sessionId)
+
+        await sendUserMessage(vm, text: "hello")
+        try await waitUntil("pending run starts") { await MainActor.run { vm.pendingRunCount == 1 } }
+        let runId = try await waitForLastSentRunId(transport)
+
+        transport.emit(
+            .sessionMessage(
+                OpenClawSessionMessageEventPayload(
+                    sessionKey: "agent:main:main",
+                    message: chatTextModelMessage(role: "assistant", text: "canonical first", timestamp: now + 2),
+                    messageId: "msg-assistant-first",
+                    messageSeq: 2)))
+
+        try await waitUntil("canonical assistant visible once") {
+            await MainActor.run {
+                vm.messages.count(where: { msg in
+                    msg.role == "assistant" && msg.content.first?.text == "canonical first"
+                }) == 1
+            }
+        }
+
+        transport.emit(
+            .chat(
+                OpenClawChatEventPayload(
+                    runId: runId,
+                    sessionKey: "main",
+                    state: "final",
+                    message: chatTextMessage(role: "assistant", text: "canonical first", timestamp: now + 1),
+                    errorMessage: nil)))
+
+        try await Task.sleep(nanoseconds: 50_000_000)
+        #expect(await MainActor.run {
+            let matches = vm.messages.filter { msg in
+                msg.role == "assistant" && msg.content.first?.text == "canonical first"
+            }
+            return matches.count == 1 && matches.first?.timestamp == now + 2
+        })
+
+        await finalRefreshGate.release()
+    }
+
+    @Test func `later identical session reply does not adopt prior turn provisional final`() async throws {
+        let sessionId = "sess-main"
+        let now = Date().timeIntervalSince1970 * 1000
+        let finalRefreshGate = SessionSubscribeGate()
+        let historyCount = AsyncCounter()
+        let history = historyPayload(sessionId: sessionId)
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [history, history],
+            requestHistoryHook: { _ in
+                let count = await historyCount.increment()
+                if count == 2 {
+                    await finalRefreshGate.wait()
+                }
+            })
+        try await loadAndWaitBootstrap(vm: vm, sessionId: sessionId)
+
+        await sendUserMessage(vm, text: "first turn")
+        try await waitUntil("first pending run starts") { await MainActor.run { vm.pendingRunCount == 1 } }
+        let firstRunId = try await waitForLastSentRunId(transport)
+        transport.emit(
+            .chat(
+                OpenClawChatEventPayload(
+                    runId: firstRunId,
+                    sessionKey: "main",
+                    state: "final",
+                    message: chatTextMessage(role: "assistant", text: "OK", timestamp: now + 1),
+                    errorMessage: nil)))
+
+        try await waitUntil("first provisional final visible") {
+            await MainActor.run {
+                vm.messages.count(where: { msg in
+                    msg.role == "assistant" && msg.content.first?.text == "OK"
+                }) == 1
+            }
+        }
+
+        await sendUserMessage(vm, text: "second turn")
+        try await waitUntil("second pending run starts") { await MainActor.run { vm.pendingRunCount == 1 } }
+
+        transport.emit(
+            .sessionMessage(
+                OpenClawSessionMessageEventPayload(
+                    sessionKey: "agent:main:main",
+                    message: chatTextModelMessage(role: "assistant", text: "OK", timestamp: now + 4),
+                    messageId: "msg-second-assistant",
+                    messageSeq: 4)))
+
+        try await waitUntil("second identical reply appends after second user") {
+            await MainActor.run {
+                let okReplies = vm.messages.filter { msg in
+                    msg.role == "assistant" && msg.content.first?.text == "OK"
+                }
+                return okReplies.count == 2 && vm.messages.last?.timestamp == now + 4
+            }
+        }
+
+        await finalRefreshGate.release()
     }
 
     @Test func `completion wait refreshes history and clears pending run`() async throws {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
@@ -8,7 +8,7 @@ private func chatTextMessage(role: String, text: String, timestamp: Double, cont
     if let contentId {
         content["id"] = contentId
     }
-    AnyCodable([
+    return AnyCodable([
         "role": role,
         "content": [content],
         "timestamp": timestamp,
@@ -937,16 +937,11 @@ struct ChatViewModelTests {
     @Test func `later identical session reply does not adopt prior turn provisional final`() async throws {
         let sessionId = "sess-main"
         let now = Date().timeIntervalSince1970 * 1000
-        let finalRefreshGate = SessionSubscribeGate()
-        let historyCount = AsyncCounter()
         let history = historyPayload(sessionId: sessionId)
         let (transport, vm) = await makeViewModel(
             historyResponses: [history, history],
-            requestHistoryHook: { _ in
-                let count = await historyCount.increment()
-                if count == 2 {
-                    await finalRefreshGate.wait()
-                }
+            sendMessageHook: { runId in
+                OpenClawChatSendResponse(runId: runId, status: "pending")
             })
         try await loadAndWaitBootstrap(vm: vm, sessionId: sessionId)
 
@@ -989,8 +984,6 @@ struct ChatViewModelTests {
                 return okReplies.count == 2 && vm.messages.last?.timestamp == now + 4
             }
         }
-
-        await finalRefreshGate.release()
     }
 
     @Test func `completion wait refreshes history and clears pending run`() async throws {
@@ -1649,7 +1642,11 @@ struct ChatViewModelTests {
     }
 
     @Test func `dedupes gateway echo of local user message`() async throws {
-        let (transport, vm) = await makeViewModel(historyResponses: [historyPayload()])
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [historyPayload()],
+            sendMessageHook: { runId in
+                OpenClawChatSendResponse(runId: runId, status: "pending")
+            })
 
         await MainActor.run { vm.load() }
         try await waitUntil("bootstrap history loaded") { await MainActor.run { vm.messages.isEmpty } }


### PR DESCRIPTION
Fixes #98116

## What Problem This Solves

Fixes an issue where users viewing an iOS Chat conversation could briefly see the same assistant final reply twice when the live final event and canonical transcript event both arrived for the same turn. The later history refresh eventually reconciled the transcript back to one row, but the intermediate UI looked like OpenClaw duplicated and then deleted a final answer.

## Why This Change Was Made

The shared chat view model now treats assistant rows inserted from live `chat.final` events as provisional for the current turn. A matching canonical `session.message` adopts that provisional row instead of appending a duplicate, and a later live final is skipped when the canonical assistant row is already visible after the latest user message. The match is intentionally scoped to messages after the latest user turn so an older provisional `OK`/`Done` response cannot consume a later identical reply.

This does not globally dedupe assistant messages by text, and it does not change the Gateway, Tailscale/Funnel, or pairing behavior.

## User Impact

Users on iOS remote-domain or LAN Chat surfaces should see one stable final assistant row per turn while live final, session transcript, and history refresh events reconcile. Repeated identical answers on separate turns remain visible as separate replies.

## Evidence

AI-assisted: yes, Codex.

- Linked issue: #98116 describes the real iOS remote-domain symptom, environment, and source-level reproduction path.
- Added shared OpenClawKit regression coverage:
  - `session message adopts provisional final event reply` covers live `chat.final` first, canonical `session.message` second, including a live content id that the canonical transcript does not carry.
  - `final event does not duplicate canonical assistant session message` covers canonical `session.message` first, later matching live `chat.final` second.
  - `later identical session reply does not adopt prior turn provisional final` covers the important repeated short-answer case so a stale provisional `OK` from a previous user turn cannot steal the next turn's canonical `OK` reply.
- Diff sanity: `git diff --check HEAD~1 HEAD` passed.
- Tooling limitation: this Windows host does not have Swift installed (`swift --version` is not recognized), so the Swift tests could not be executed locally here. They are added for the macOS/iOS CI lane to run.
- Auto review: first local autoreview found a valid P2 stale-provisional-turn issue; that finding was accepted and fixed by scoping provisional adoption to messages after the latest user turn and adding the repeated `OK` regression test. A second autoreview rerun timed out after 6 minutes without a final verdict, so this PR is not claimed as autoreview-clean.