### PR TITLE
fix(zai): send user agent during endpoint detection

### DIFF
--- a/extensions/zai/detect.test.ts
+++ b/extensions/zai/detect.test.ts
@@ -90,6 +90,36 @@ function makeFetch(map: Record<string, FetchResponse>) {
 describe("detectZaiEndpoint", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it("sends OpenClaw User-Agent on endpoint detection probes", async () => {
+    vi.stubEnv("OPENCLAW_VERSION", "2026.6.30-test");
+    const captured: Array<{ url: string; userAgent: string | null }> = [];
+    const fetchFn = (async (url: string, init?: RequestInit) => {
+      captured.push({
+        url,
+        userAgent: new Headers(init?.headers).get("user-agent"),
+      });
+      return new Response("{}", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const detected = await detectZaiEndpoint({
+      apiKey: "sk-test", // pragma: allowlist secret
+      endpoint: "coding-global",
+      fetchFn,
+    });
+
+    expect(detected?.endpoint).toBe("coding-global");
+    expect(captured).toEqual([
+      {
+        url: "https://api.z.ai/api/coding/paas/v4/chat/completions",
+        userAgent: "openclaw/2026.6.30-test",
+      },
+    ]);
   });
 
   it("resolves preferred/fallback endpoints and null when probes fail", async () => {

--- a/extensions/zai/detect.ts
+++ b/extensions/zai/detect.ts
@@ -40,6 +40,11 @@ const UNSUPPORTED_MODEL_ERROR_CODES = new Set(["1211", "1311"]);
 /** Cap for the Z.AI probe error body; bounds untrusted error responses to avoid unbounded buffering/OOM. */
 const ZAI_DETECT_ERROR_BODY_MAX_BYTES = 16 * 1024 * 1024;
 
+function resolveZaiDetectUserAgent(): string {
+  const version = process.env.OPENCLAW_VERSION?.trim();
+  return version ? `openclaw/${version}` : "openclaw";
+}
+
 function isUnsupportedModelResult(result: ProbeResult): boolean {
   if (result.ok) {
     return false;
@@ -92,6 +97,7 @@ async function probeZaiChatCompletions(params: {
         headers: {
           authorization: `Bearer ${params.apiKey}`,
           "content-type": "application/json",
+          "User-Agent": resolveZaiDetectUserAgent(),
         },
         body: JSON.stringify({
           model: params.modelId,


### PR DESCRIPTION
Closes #98100

AI-assisted: yes, authored with Codex.

## What Problem This Solves

Fixes an issue where users onboarding Z.AI Coding Plan credentials could have endpoint auto-detection return `null` when the Z.AI edge rejected probe requests that did not include a `User-Agent`.

## Why This Change Was Made

The Z.AI endpoint detection probe now sends an explicit OpenClaw `User-Agent`, matching the existing OpenClaw attribution shape used by other provider HTTP flows. The change stays inside the Z.AI plugin detection boundary and does not alter endpoint ordering, model fallback behavior, or onboarding defaults.

## User Impact

Z.AI Coding Plan onboarding has a concrete probe header for endpoint detection, so keys that are valid for the coding endpoint are less likely to fall through to the manual/default path because the edge rejected an otherwise valid probe.

## Evidence

- `node scripts/run-vitest.mjs extensions/zai/detect.test.ts` - passed, including a regression that captures the coding-global probe request and verifies `User-Agent: openclaw/<OPENCLAW_VERSION>`.
- `node scripts/run-vitest.mjs extensions/zai/onboard.test.ts` - passed.
- `node scripts/run-vitest.mjs src/commands/auth-choice.test.ts` - passed.
- `pnpm exec oxfmt --check --threads=1 extensions/zai/detect.ts extensions/zai/detect.test.ts` - passed.
- `node scripts/run-oxlint.mjs extensions/zai/detect.ts extensions/zai/detect.test.ts` - passed.
- `git diff --check` - passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local` - passed with no accepted/actionable findings.

Known gap: no live Z.AI Coding Plan smoke was run because no redacted Z.AI Coding Plan key is available in this environment. With a redacted key, maintainers can run a live endpoint-detection smoke to prove coding-global selection against the real service.
