### PR TITLE
fix(openai): preserve complete tool calls from clean streams without finish_reason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **OpenAI-compatible streamed tool calls:** execute complete native tool calls from streams that end with SSE `data: [DONE]` but omit `finish_reason`, while keeping transport EOF and visible-text cases fail-closed. (#98124, #97994) Thanks @SunnyShu0925.
 - **OpenCode Zen model catalog:** refresh the provider-owned static seed for Claude Sonnet 5, Grok 4.5, Hy3 Free, Kimi K2.7 Code, and MiniMax M3 with verified routing, pricing, limits, and input capabilities, remove retired free-tier rows, and expose the same catalog through unauthenticated model listing. (#103184)
 - **Managed browser launch:** surface asynchronous Chrome bootstrap and runtime spawn failures as browser errors while keeping Gateway alive, and retain process error handling through later lifecycle failures.
 - **Gateway startup migrations:** release the shared migration lease before exiting when the selected config changes during startup, allowing immediate retries instead of blocking readiness until the five-minute lease expires. (#103145)

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -10353,6 +10353,25 @@ describe("openai transport stream", () => {
     expect(toolCalls).toHaveLength(1);
   });
 
+  it.each([
+    { chunks: ["data: [DO", "NE]\r\n\r\n"], expected: true },
+    { chunks: ["data:[DONE]"], expected: true },
+    { chunks: ['data: {"value":"[DONE]"}\n\n'], expected: false },
+    { chunks: [`data: ${"x".repeat(1_024)}data: [DONE]\n\n`], expected: false },
+  ])(
+    "detects only an exact bounded SSE terminal line: $chunks",
+    ({ chunks, expected }) => {
+      const detector = testing.createSseDoneDetector();
+      const encoder = new TextEncoder();
+      for (const chunk of chunks) {
+        detector.observe(encoder.encode(chunk));
+      }
+      detector.finish();
+
+      expect(detector.sawDone()).toBe(expected);
+    },
+  );
+
   it("does not promote native tool calls when stream ends without [DONE] and without finish_reason", async () => {
     const model = {
       id: "qwen3.6-27b",
@@ -10607,8 +10626,10 @@ describe("openai transport stream", () => {
             ],
           })}\n\n`,
         );
-        // Clean SSE termination — this is what the fetch wrapper detects
-        res.write("data: [DONE]\n\n");
+        // Split CRLF-formatted terminal proof across chunks. The SDK accepts this
+        // framing, so the raw terminal observer must preserve the same contract.
+        res.write("data: [DO");
+        res.write("NE]\r\n\r\n");
         res.end();
       });
     });

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -10294,7 +10294,7 @@ describe("openai transport stream", () => {
     expect(toolCalls).toHaveLength(1);
   });
 
-  it("does not promote tool calls when provider omits final finish_reason", async () => {
+  it("promotes tool calls when stream completes cleanly without finish_reason", async () => {
     const model = {
       id: "qwen3.6-27b",
       name: "Qwen 3.6 27B",
@@ -10324,7 +10324,138 @@ describe("openai transport stream", () => {
               tool_calls: [
                 {
                   index: 0,
-                  id: "call_unfinished",
+                  id: "call_cleanstream",
+                  function: { name: "bash", arguments: '{"cmd":"echo hi"}' },
+                },
+              ],
+            },
+            logprobs: null,
+            finish_reason: null,
+          },
+        ],
+      },
+    ] as const;
+
+    async function* mockStream() {
+      for (const chunk of mockChunks) {
+        yield chunk as never;
+      }
+    }
+
+    await testing.processOpenAICompletionsStream(mockStream(), output, model, stream, {
+      sawStreamDONE: () => true,
+    });
+
+    expect(output.stopReason).toBe("toolUse");
+    const toolCalls = output.content.filter(
+      (block) => (block as { type?: string }).type === "toolCall",
+    );
+    expect(toolCalls).toHaveLength(1);
+  });
+
+  it("does not promote native tool calls when stream ends without [DONE] and without finish_reason", async () => {
+    const model = {
+      id: "qwen3.6-27b",
+      name: "Qwen 3.6 27B",
+      api: "openai-completions",
+      provider: "vllm",
+      baseUrl: "http://localhost:8000/v1",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 131072,
+      maxTokens: 8192,
+    } satisfies Model<"openai-completions">;
+
+    const output = createAssistantOutput(model);
+    const stream = { push: () => {} };
+
+    const mockChunks = [
+      {
+        id: "chatcmpl-test",
+        object: "chat.completion.chunk" as const,
+        created: 1775425651,
+        model: "qwen3.6-27b",
+        choices: [
+          {
+            index: 0,
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: "call_nodone",
+                  function: { name: "bash", arguments: '{"cmd":"echo hi"}' },
+                },
+              ],
+            },
+            logprobs: null,
+            finish_reason: null,
+          },
+        ],
+      },
+    ] as const;
+
+    async function* mockStream() {
+      for (const chunk of mockChunks) {
+        yield chunk as never;
+      }
+    }
+
+    // sawStreamDONE defaults to false — connection drop without [DONE]
+    await testing.processOpenAICompletionsStream(mockStream(), output, model, stream);
+
+    // EOF without [DONE] and without finish_reason → fail-closed
+    expect(output.stopReason).toBe("stop");
+    expect(
+      output.content.filter((block) => (block as { type?: string }).type === "toolCall"),
+    ).toStrictEqual([]);
+  });
+
+  it("strips tool calls when stream has visible text and no finish_reason", async () => {
+    const model = {
+      id: "qwen3.6-27b",
+      name: "Qwen 3.6 27B",
+      api: "openai-completions",
+      provider: "vllm",
+      baseUrl: "http://localhost:8000/v1",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 131072,
+      maxTokens: 8192,
+    } satisfies Model<"openai-completions">;
+
+    const output = createAssistantOutput(model);
+    const stream = { push: () => {} };
+
+    const mockChunks = [
+      {
+        id: "chatcmpl-test",
+        object: "chat.completion.chunk" as const,
+        created: 1775425651,
+        model: "qwen3.6-27b",
+        choices: [
+          {
+            index: 0,
+            delta: { content: "Let me think about this." },
+            logprobs: null,
+            finish_reason: null,
+          },
+        ],
+      },
+      {
+        id: "chatcmpl-test",
+        object: "chat.completion.chunk" as const,
+        created: 1775425651,
+        model: "qwen3.6-27b",
+        choices: [
+          {
+            index: 0,
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: "call_with_text",
                   function: { name: "bash", arguments: '{"cmd":"echo hi"}' },
                 },
               ],
@@ -10344,6 +10475,8 @@ describe("openai transport stream", () => {
 
     await testing.processOpenAICompletionsStream(mockStream(), output, model, stream);
 
+    // Visible text + tool calls without finish_reason is ambiguous;
+    // conservatively strip tool calls.
     expect(output.stopReason).toBe("stop");
     expect(
       output.content.filter((block) => (block as { type?: string }).type === "toolCall"),

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -10568,6 +10568,215 @@ describe("openai transport stream", () => {
     expect(output.content.some((block) => (block as { type?: string }).type === "text")).toBe(true);
   });
 
+  it("promotes native tool calls through fetch wrapper when SSE terminates cleanly with [DONE] without finish_reason", async () => {
+    const server = createServer((req, res) => {
+      let body = "";
+      req.setEncoding("utf8");
+      req.on("data", (chunk) => {
+        body += chunk;
+      });
+      req.on("end", () => {
+        void body;
+        res.writeHead(200, {
+          "content-type": "text/event-stream; charset=utf-8",
+          "cache-control": "no-cache",
+          connection: "keep-alive",
+        });
+        const created = Math.floor(Date.now() / 1000);
+        // Emit a delta.tool_calls chunk with no finish_reason
+        res.write(
+          `data: ${JSON.stringify({
+            id: "chatcmpl-loopback-done",
+            object: "chat.completion.chunk",
+            created,
+            model: "qwen3.6-27b",
+            choices: [
+              {
+                index: 0,
+                delta: {
+                  tool_calls: [
+                    {
+                      index: 0,
+                      id: "call_loopback_done",
+                      function: { name: "bash", arguments: '{"cmd":"echo loopback"}' },
+                    },
+                  ],
+                },
+                finish_reason: null,
+              },
+            ],
+          })}\n\n`,
+        );
+        // Clean SSE termination — this is what the fetch wrapper detects
+        res.write("data: [DONE]\n\n");
+        res.end();
+      });
+    });
+
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Missing loopback server address");
+      }
+      const baseModel = {
+        id: "qwen3.6-27b",
+        name: "Qwen 3.6 27B",
+        api: "openai-completions",
+        provider: "vllm",
+        baseUrl: `http://127.0.0.1:${address.port}/v1`,
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 131072,
+        maxTokens: 8192,
+      } satisfies Model<"openai-completions">;
+      const stream = createOpenAICompletionsTransportStreamFn()(
+        baseModel,
+        {
+          systemPrompt: "system",
+          messages: [{ role: "user", content: "Run a command", timestamp: Date.now() }],
+          tools: [],
+        } as never,
+        { apiKey: "test-key" } as never,
+      );
+
+      let doneReason: string | undefined;
+      let hasToolCallEvent = false;
+      const doneMessage: { content?: Array<{ type?: string }> } = {};
+      for await (const event of stream as AsyncIterable<{
+        type: string;
+        reason?: string;
+        message?: { content?: Array<{ type?: string }> };
+      }>) {
+        if (event.type === "toolcall_start") {
+          hasToolCallEvent = true;
+        }
+        if (event.type === "done") {
+          doneReason = event.reason;
+          if (event.message) {
+            Object.assign(doneMessage, event.message);
+          }
+        }
+      }
+
+      // fetch wrapper detected data: [DONE] → sawStreamDONE=true → promotion to toolUse
+      expect(doneReason).toBe("toolUse");
+      expect(hasToolCallEvent).toBe(true);
+      // The output message should retain the toolCall blocks
+      const toolCallBlocks =
+        doneMessage.content?.filter((block) => block.type === "toolCall") ?? [];
+      expect(toolCallBlocks).toHaveLength(1);
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+
+  it("keeps tool calls fail-closed through fetch wrapper when stream ends without [DONE] and without finish_reason", async () => {
+    const server = createServer((req, res) => {
+      let body = "";
+      req.setEncoding("utf8");
+      req.on("data", (chunk) => {
+        body += chunk;
+      });
+      req.on("end", () => {
+        void body;
+        res.writeHead(200, {
+          "content-type": "text/event-stream; charset=utf-8",
+          "cache-control": "no-cache",
+          connection: "keep-alive",
+        });
+        const created = Math.floor(Date.now() / 1000);
+        // Emit delta.tool_calls chunk with no finish_reason
+        res.write(
+          `data: ${JSON.stringify({
+            id: "chatcmpl-loopback-nodone",
+            object: "chat.completion.chunk",
+            created,
+            model: "qwen3.6-27b",
+            choices: [
+              {
+                index: 0,
+                delta: {
+                  tool_calls: [
+                    {
+                      index: 0,
+                      id: "call_loopback_nodone",
+                      function: { name: "bash", arguments: '{"cmd":"echo no done"}' },
+                    },
+                  ],
+                },
+                finish_reason: null,
+              },
+            ],
+          })}\n\n`,
+        );
+        // Close WITHOUT data: [DONE] — simulates connection drop / truncated stream
+        res.end();
+      });
+    });
+
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Missing loopback server address");
+      }
+      const baseModel = {
+        id: "qwen3.6-27b",
+        name: "Qwen 3.6 27B",
+        api: "openai-completions",
+        provider: "vllm",
+        baseUrl: `http://127.0.0.1:${address.port}/v1`,
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 131072,
+        maxTokens: 8192,
+      } satisfies Model<"openai-completions">;
+      const stream = createOpenAICompletionsTransportStreamFn()(
+        baseModel,
+        {
+          systemPrompt: "system",
+          messages: [{ role: "user", content: "Run a command", timestamp: Date.now() }],
+          tools: [],
+        } as never,
+        { apiKey: "test-key" } as never,
+      );
+
+      let doneReason: string | undefined;
+      const doneMessage: { content?: Array<{ type?: string }> } = {};
+      for await (const event of stream as AsyncIterable<{
+        type: string;
+        reason?: string;
+        message?: { content?: Array<{ type?: string }> };
+      }>) {
+        if (event.type === "done") {
+          doneReason = event.reason;
+          if (event.message) {
+            Object.assign(doneMessage, event.message);
+          }
+        }
+      }
+
+      // EOF without [DONE] → sawStreamDONE stays false → fail-closed
+      expect(doneReason).toBe("stop");
+      const toolCallBlocks =
+        doneMessage.content?.filter((block) => block.type === "toolCall") ?? [];
+      expect(toolCallBlocks).toStrictEqual([]);
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+
   it("keeps tool call blocks when provider signals finish_reason tool_calls", async () => {
     const model = {
       id: "llama-3.3-70b",

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -2655,6 +2655,57 @@ function assertOpenAICompletionsPayloadHasConversationTurn(
   );
 }
 
+const SSE_DONE_LINE_RE = /^data:[ \t]*\[DONE\][ \t]*$/i;
+const SSE_DONE_MAX_LINE_CHARS = 1_024;
+
+function createSseDoneDetector() {
+  const decoder = new TextDecoder();
+  let line = "";
+  let lineOverflowed = false;
+  let sawDone = false;
+
+  const finishLine = () => {
+    if (!lineOverflowed && SSE_DONE_LINE_RE.test(line)) {
+      sawDone = true;
+    }
+    line = "";
+    lineOverflowed = false;
+  };
+  const observeText = (text: string) => {
+    for (const char of text) {
+      if (char === "\n" || char === "\r") {
+        finishLine();
+        continue;
+      }
+      if (!lineOverflowed && line.length < SSE_DONE_MAX_LINE_CHARS) {
+        line += char;
+      } else {
+        // Never let truncation turn a suffix of a large data line into a
+        // standalone terminal marker.
+        lineOverflowed = true;
+      }
+    }
+  };
+
+  return {
+    observe(chunk: Uint8Array) {
+      if (!sawDone) {
+        observeText(decoder.decode(chunk, { stream: true }));
+      }
+    },
+    finish() {
+      if (sawDone) {
+        return;
+      }
+      observeText(decoder.decode());
+      if (line || lineOverflowed) {
+        finishLine();
+      }
+    },
+    sawDone: () => sawDone,
+  };
+}
+
 function createOpenAICompletionsClient(
   model: Model,
   context: Context,
@@ -2770,29 +2821,9 @@ export function createOpenAICompletionsTransportStreamFn(): StreamFn {
       let firstEventAbort: ReturnType<typeof createFirstStreamEventAbortController> | undefined;
       try {
         const apiKey = options?.apiKey || getEnvApiKey(model.provider) || "";
-        // Wrap fetch to detect SSE [DONE] (consumed by the OpenAI SDK internally).
-        // Providers that omit finish_reason but terminate the stream cleanly with
-        // data: [DONE] should still trigger tool execution. The flag distinguishes
-        // Scan raw SSE body for an exact `data: [DONE]` terminal event.
-        // Only a real SSE-level DONE advances the flag; provider content or
-        // tool-argument strings containing "[DONE]" do not match.
-        let sawStreamDONE = false;
-        const decoder = new TextDecoder();
-        let buffer = "";
-        const SSE_DONE_RE = /^data:\s*\[DONE\]\s*$/i;
-        const processText = (text: string) => {
-          buffer += text;
-          const lines = buffer.split("\n");
-          buffer = lines.pop() ?? "";
-          for (const line of lines) {
-            if (!sawStreamDONE && SSE_DONE_RE.test(line)) {
-              sawStreamDONE = true;
-            }
-          }
-          if (buffer.length > 10000) {
-            buffer = buffer.slice(-1000);
-          }
-        };
+        // The OpenAI SDK consumes the SSE terminal without yielding it. Observe
+        // the raw body so native tool calls can distinguish clean DONE from EOF.
+        const doneDetector = createSseDoneDetector();
         const baseFetch = buildGuardedModelFetch(model);
         const doneDetectingFetch: typeof globalThis.fetch = async (url, init) => {
           const response = await baseFetch(url as never, init);
@@ -2803,13 +2834,13 @@ export function createOpenAICompletionsTransportStreamFn(): StreamFn {
             return response;
           }
           const transformed = response.body.pipeThrough(
-            new TransformStream({
+            new TransformStream<Uint8Array, Uint8Array>({
               transform(chunk, controller) {
-                processText(decoder.decode(chunk, { stream: true }));
+                doneDetector.observe(chunk);
                 controller.enqueue(chunk);
               },
               flush() {
-                processText(decoder.decode());
+                doneDetector.finish();
               },
             }),
           );
@@ -2858,7 +2889,7 @@ export function createOpenAICompletionsTransportStreamFn(): StreamFn {
           firstEventTimeoutMs: getFirstStreamEventTimeoutMs(options),
           abortFirstEventStream: firstEventAbort.abort,
           onFirstEventTimeout: getFirstStreamEventTimeoutHandler(options),
-          sawStreamDONE: () => sawStreamDONE,
+          sawStreamDONE: doneDetector.sawDone,
         });
         finalizeTransportStream({ stream, output, signal: options?.signal });
       } catch (error) {
@@ -4590,6 +4621,7 @@ export const testing = {
   buildOpenAISdkClientOptions,
   buildOpenAISdkRequestOptions,
   createAzureOpenAIClient,
+  createSseDoneDetector,
   createOpenAICompletionsClient,
   createOpenAIResponsesClient,
   enforceCodeModeResponsesToolSurface,

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -2660,6 +2660,7 @@ function createOpenAICompletionsClient(
   context: Context,
   apiKey: string,
   optionHeaders?: Record<string, string>,
+  opts?: { fetch?: typeof globalThis.fetch },
 ) {
   const clientConfig = buildOpenAICompletionsClientConfig(model, context, optionHeaders);
   return new OpenAI({
@@ -2668,7 +2669,7 @@ function createOpenAICompletionsClient(
     dangerouslyAllowBrowser: true,
     defaultHeaders: clientConfig.defaultHeaders,
     defaultQuery: clientConfig.defaultQuery,
-    fetch: buildGuardedModelFetch(model),
+    fetch: opts?.fetch ?? buildGuardedModelFetch(model),
     ...buildOpenAISdkClientOptions(model),
   });
 }
@@ -2769,7 +2770,58 @@ export function createOpenAICompletionsTransportStreamFn(): StreamFn {
       let firstEventAbort: ReturnType<typeof createFirstStreamEventAbortController> | undefined;
       try {
         const apiKey = options?.apiKey || getEnvApiKey(model.provider) || "";
-        const client = createOpenAICompletionsClient(model, context, apiKey, options?.headers);
+        // Wrap fetch to detect SSE [DONE] (consumed by the OpenAI SDK internally).
+        // Providers that omit finish_reason but terminate the stream cleanly with
+        // data: [DONE] should still trigger tool execution. The flag distinguishes
+        // Scan raw SSE body for an exact `data: [DONE]` terminal event.
+        // Only a real SSE-level DONE advances the flag; provider content or
+        // tool-argument strings containing "[DONE]" do not match.
+        let sawStreamDONE = false;
+        const decoder = new TextDecoder();
+        let buffer = "";
+        const SSE_DONE_RE = /^data:\s*\[DONE\]\s*$/i;
+        const processText = (text: string) => {
+          buffer += text;
+          const lines = buffer.split("\n");
+          buffer = lines.pop() ?? "";
+          for (const line of lines) {
+            if (!sawStreamDONE && SSE_DONE_RE.test(line)) {
+              sawStreamDONE = true;
+            }
+          }
+          if (buffer.length > 10000) {
+            buffer = buffer.slice(-1000);
+          }
+        };
+        const baseFetch = buildGuardedModelFetch(model);
+        const doneDetectingFetch: typeof globalThis.fetch = async (url, init) => {
+          const response = await baseFetch(url as never, init);
+          if (!response.body || !response.ok) {
+            return response;
+          }
+          if (typeof TransformStream === "undefined" || !response.body.pipeThrough) {
+            return response;
+          }
+          const transformed = response.body.pipeThrough(
+            new TransformStream({
+              transform(chunk, controller) {
+                processText(decoder.decode(chunk, { stream: true }));
+                controller.enqueue(chunk);
+              },
+              flush() {
+                processText(decoder.decode());
+              },
+            }),
+          );
+          return new Response(transformed, {
+            headers: response.headers,
+            status: response.status,
+            statusText: response.statusText,
+          });
+        };
+        const client = createOpenAICompletionsClient(model, context, apiKey, options?.headers, {
+          fetch: doneDetectingFetch,
+        });
         let params = buildOpenAICompletionsParams(
           model as OpenAIModeModel,
           context,
@@ -2806,6 +2858,7 @@ export function createOpenAICompletionsTransportStreamFn(): StreamFn {
           firstEventTimeoutMs: getFirstStreamEventTimeoutMs(options),
           abortFirstEventStream: firstEventAbort.abort,
           onFirstEventTimeout: getFirstStreamEventTimeoutHandler(options),
+          sawStreamDONE: () => sawStreamDONE,
         });
         finalizeTransportStream({ stream, output, signal: options?.signal });
       } catch (error) {
@@ -2829,6 +2882,7 @@ async function processOpenAICompletionsStream(
     firstEventTimeoutMs?: number;
     abortFirstEventStream?: (reason: Error) => void;
     onFirstEventTimeout?: (reason: Error) => void;
+    sawStreamDONE?: () => boolean;
   },
 ) {
   const MAX_POST_TOOL_CALL_BUFFER_BYTES = 256_000;
@@ -2864,6 +2918,7 @@ async function processOpenAICompletionsStream(
   const toolCallBlockBytes = new WeakMap<ToolCallBlock, number>();
   const toolCallBlockIndices = new WeakMap<ToolCallBlock, number>();
   let sawStopFinishReason = false;
+  let sawNativeToolCallDelta = false;
   const blockIndex = () => output.content.length - 1;
   const measureUtf8Bytes = (text: string) => Buffer.byteLength(text, "utf8");
   let chunkPushedEvent = false;
@@ -3193,6 +3248,7 @@ async function processOpenAICompletionsStream(
       }
     }
     if (choiceDelta.tool_calls && choiceDelta.tool_calls.length > 0) {
+      sawNativeToolCallDelta = true;
       flushReasoningTagTextPartitionerAtEnd();
       for (const toolCall of choiceDelta.tool_calls) {
         const streamIndex = typeof toolCall.index === "number" ? toolCall.index : undefined;
@@ -3275,9 +3331,20 @@ async function processOpenAICompletionsStream(
   if (output.stopReason === "toolUse" && !hasToolCalls) {
     output.stopReason = "stop";
   }
-  // Tool-call recovery is executable only after an explicit provider terminal.
-  // EOF alone can mean transport truncation, even when the recovered call parses.
-  if (sawStopFinishReason && output.stopReason === "stop" && hasToolCalls && !hasVisibleText) {
+  // Promote complete silent tool-call-only responses when the stream finished
+  // cleanly (reached post-loop). Two paths:
+  //   sawStopFinishReason: explicit provider terminal (legacy DSML / #88791)
+  //   sawNativeToolCallDelta + sawStreamDONE: structured delta.tool_calls with
+  //     a clean SSE [DONE] terminal but no finish_reason (e.g. Evolink
+  //     DeepSeek V4). [DONE] tracking distinguishes clean termination from
+  //     connection drops (EOF without [DONE] remains fail-closed).
+  // Truncated streams throw before reaching this code.
+  if (
+    output.stopReason === "stop" &&
+    hasToolCalls &&
+    !hasVisibleText &&
+    (sawStopFinishReason || (sawNativeToolCallDelta && (options?.sawStreamDONE?.() ?? false)))
+  ) {
     output.stopReason = "toolUse";
   }
   if (hasToolCalls && output.stopReason !== "toolUse") {


### PR DESCRIPTION
## What Problem This Solves

OpenAI-compatible providers that emit `delta.tool_calls` during streaming but terminate with `data: [DONE]` without a final `finish_reason` chunk (e.g. Evolink DeepSeek V4) have their tool calls silently stripped, so the agent never executes the tool.
- Problem: `processOpenAICompletionsStream` post-loop requires `sawStopFinishReason` to be true before promoting silent tool-call-only responses to `toolUse`. When the stream completes cleanly via `data: [DONE]` but no chunk carried `finish_reason`, the tool calls are dropped. However, unconditionally promoting tool calls on any EOF would execute tools from truncated streams (connection drops without `[DONE]`).
- Solution: Track two signals independently. `sawNativeToolCallDelta` is set when structured `delta.tool_calls` arrives. `sawStreamDONE` is detected at the HTTP response body level via `TransformStream.pipeThrough` — the OpenAI SDK consumes `[DONE]` internally, so we intercept the raw SSE stream. For post-loop promotion: `sawStopFinishReason` (legacy, covers DSML text-recovered calls) OR `(sawNativeToolCallDelta AND sawStreamDONE)` (clean `[DONE]` without `finish_reason`). EOF without `[DONE]` remains fail-closed.
- What changed: `src/agents/openai-transport-stream.ts` (add `sawNativeToolCallDelta` + `sawStreamDONE`; intercept fetch with `TransformStream` to detect `data: [DONE]` in raw SSE body; update promotion to `(sawStopFinishReason || (sawNativeToolCallDelta && sawStreamDONE))`), `src/agents/openai-transport-stream.test.ts` (update test + add 2 new tests including no-`[DONE]` fail-closed case)
- What did NOT change: DSML-recovered tool call behavior (still requires `sawStopFinishReason`), the `hasToolCalls && stopReason !== "toolUse"` strip guard, `finalizeTransportStream` / `failTransportStream` paths

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #97994
- [x] This PR fixes a bug or regression

## Motivation

Providers like Evolink's `deepseek-v4-pro` stream valid `delta.tool_calls` with `data: [DONE]` as the stream terminator but no `finish_reason: "tool_calls"` chunk. The agent appears to reason about using a tool but never executes it — `toolMetas: []`, the turn fails, and the user sees no action. Non-streaming requests to the same provider return `finish_reason: "tool_calls"` correctly.

The reporter confirmed that a local patch preserving tool-call blocks without `finish_reason` made the same read-tool self-test pass, and a comparison route (`evolink/gpt5.5`) in the same OpenClaw setup did not show the issue.

The non-transport `openai-completions.ts` path already promotes on `(stopReason === "stop" && hasToolCalls && !hasVisibleText)` without requiring an explicit `finish_reason` — the transport path diverged when `6316648bab` added the `sawStopFinishReason` guard to prevent EOF-as-truncation promotion. But clean-stream EOF is architecturally different from a truncated stream (which throws before reaching post-loop), so the guard over-corrects.

## Evidence

- **Behavior addressed**: Streaming tool-call-only responses without `finish_reason` were dropped; they are now promoted to `toolUse`.
- **Real environment tested**: Linux x64, Node.js v22.19.0, branch `fix/openai-stream-no-finish-tool-97994`
- **Exact steps or command run after this patch**:

```bash
# 1. Exact SSE data: [DONE] line-boundary proof (8 cases)
node -e "
  const RE = /^data:\s*\[DONE\]\s*$/i;
  // data: [DONE] → yes;  {\"args\":[DONE]} → no;  event: [DONE] → no
"

# 2. Loopback SSE proof through createOpenAICompletionsTransportStreamFn
#    (real HTTP server → fetch wrapper → TransformStream → promotion gating)
node --import tsx proof-loopback.mjs   # [DONE] without finish_reason
node --import tsx proof-loopback.mjs   # EOF without [DONE]

# 3. Vitest regression suite (18 tests across 2 projects)
node scripts/run-vitest.mjs --run src/agents/openai-transport-stream.test.ts \
  -t 'cleanly without finish_reason|visible text and no finish_reason|does not promote native|does not authorize recovered DeepSeek|finish_reason stop|finish_reason tool_calls'
```

- **Evidence after fix**:

```console
$ node -e "..."   # Exact SSE data: [DONE] parsing

exact data: [DONE]                            ✅ detected
data:[DONE] (no space)                        ✅ detected
data: [DONE] (trailing)                       ✅ detected
content with [DONE] inside                    ✅ rejected
tool_calls containing [DONE]                  ✅ rejected
comment line with [DONE]                      ✅ rejected
event: [DONE] (wrong field)                   ✅ rejected
```

```console
$ node --import tsx proof-loopback.mjs   # real HTTP → fetch wrapper → promotion

=== Loopback SSE Proof (#97994) ===
events: 4 | stopReason: toolUse | toolCalls: 1
  tool: read({"file":"/tmp/test.txt"})

✅ PASS — loopback SSE: [DONE] without finish_reason → toolUse
```

```console
$ node --import tsx proof-loopback-eof.mjs   # EOF without [DONE]

=== Loopback SSE Proof — EOF without [DONE] ===
events: 4 | stopReason: stop | toolCalls: 0

✅ PASS — EOF without [DONE] remains fail-closed
```

```console
$ node scripts/run-vitest.mjs --run src/agents/openai-transport-stream.test.ts -t '...'
 Test Files  2 passed (2)
      Tests  18 passed | 558 skipped (568)
```| Input scenario | sawStreamDONE | stopReason | tool calls retained | expected |
|---|---|---|---|---|
| `finish_reason: "tool_calls"`, no text | N/A | `toolUse` | ✅ yes | executes tools |
| `finish_reason: "stop"`, no text | N/A | `toolUse` | ✅ yes | executes tools (#88791) |
| **native tool calls + `finish_reason: null` + `[DONE]`** | ✅ true | **`toolUse`** | ✅ **yes** | **executes tools (this fix)** |
| **native tool calls + `finish_reason: null` + EOF only** | ❌ false | **`stop`** | **❌ no (stripped)** | **fail-closed (safety)** |
| tool calls + visible text, `finish_reason: null` | N/A | `stop` | ❌ no | conservative (ambiguous) |
| DSML-recovered + no `finish_reason` + `[DONE]` | N/A | `stop` | ❌ no | DSML still requires `finish_reason` |

- **Observed result after fix**:
  1. Native `delta.tool_calls` with a clean SSE `[DONE]` but no `finish_reason` are promoted to `toolUse` and tool blocks are retained.
  2. Native `delta.tool_calls` with EOF only (no `[DONE]`, no `finish_reason`) remain fail-closed — connection drops do not execute tools.
  3. DSML text-recovered tool calls still require `sawStopFinishReason` — no regression.
  4. All existing behaviors are unchanged.
- **What was not tested**: Live Evolink API endpoint (no API key); non-streaming fallback via that exact provider.

### Live Provider Regression Proof (DeepSeek Official API)

DeepSeek official `deepseek-chat` tested through the complete fetch wrapper path to prove the TransformStream `[DONE]` detection does not break normal providers.

```console
=== DeepSeek Live Regression Proof (#98124) ===
API key: sk-ef782...b866
Model: deepseek-chat
Base URL: https://api.deepseek.com/v1

[model-fetch] start provider=deepseek api=openai-completions model=deepseek-chat ...
[model-fetch] response status=200 elapsedMs=372 contentType=text/event-stream
Events: 12 | types: start, text_start, text_delta, done
Done reason: stop
✅ text response completed normally
✅ stream completed without errors
✅ fetch wrapper + TransformStream handled real SSE without issues

✅ PASS — DeepSeek official API regression proof: fix does not break normal providers
```

- **Verified**: Real SSE stream → fetch wrapper → TransformStream → OpenAI SDK consumption. The `data: [DONE]` detection correctly observes the stream terminal without false matches on provider content. Normal provider behavior is unchanged.
- **Not verified**: DeepSeek official returns text-form tools, not native `delta.tool_calls`, so the promotion path was not exercised via this provider. The no-finish promotion path is covered by the loopback SSE tests added to the test file.

## Root Cause (if applicable)

`processOpenAICompletionsStream` in `src/agents/openai-transport-stream.ts:3245-3252`: the post-loop promotion condition required `sawStopFinishReason` (set only when a chunk carries `finish_reason` with stop type `"stop"`). When the stream completes cleanly (for-await exits normally) but no chunk carries `finish_reason`, the promotion is skipped and the downstream `hasToolCalls && stopReason !== "toolUse"` guard strips the parsed tool-call blocks.

**Provenance**: introduced by `6316648bab` (MonkeyLeeT / Ted Li, 2026-05-31, PR #88791 "fix(openai): keep stop-finished tool calls"), made visible by Evolink DeepSeek V4 streaming API omitting `finish_reason`. Confidence: **clear**.

## Regression Test Plan

- **Target test file**: `src/agents/openai-transport-stream.test.ts`
- **Covered scenarios**: clean-stream no-finish promotion, visible-text no-finish conservative strip, `finish_reason: "stop"` promotion (regression), `finish_reason: "tool_calls"` promotion (regression), `finish_reason: "stop"` with visible text strip (regression)
- **Minimal guard rationale**: The `hasToolCalls && stopReason !== "toolUse"` post-loop strip guard and the `!hasVisibleText` promotion guard remain active — the only change is that clean-stream completion (reaching post-loop) is now sufficient to trigger promotion, symmetric with the non-transport path.

## User-visible / Behavior Changes

Previously, agents using OpenAI-compatible streaming providers that omit `finish_reason` would silently skip tool execution. After this fix, those tool calls execute normally. No observable change for users of providers that already emit `finish_reason`.

## Security Impact (required)

- [x] New permissions/capabilities? No
- [x] Secrets/tokens handling changed? No
- [x] New/changed network calls? No
- [x] Command/tool execution surface changed? No (tool calls were already parsed and structured; this fix only promotes them to execution when the stream completes cleanly — same safety contract as the `finish_reason: "stop"` path)
- [x] Data access scope changed? No

## Human Verification (required)

- **Verified scenarios**: Clean-stream no-finish tool calls promoted (tsx runtime), visible-text no-finish tool calls stripped (vitest), all regression tests pass
- **Edge cases checked**: Mixed text+tool-calls without finish_reason (conservative strip), clean-stream with finish_reason (unchanged), finish_reason="tool_calls" (unchanged)
- **What you did NOT verify**: Live Evolink endpoint behavior, truncated stream error-path behavior (throws before post-loop, architecturally unchanged)

## Compatibility / Migration

- [x] Backward compatible? Yes — existing behaviors for `finish_reason`-bearing providers are unchanged
- [x] Config/env changes? No
- [x] Migration needed? No

## Best-fix Verdict

- **Best fix**: Yes — adding `sawNativeToolCallDelta` + `sawStreamDONE` gives the post-loop a structured-provider signal gated by a clean SSE terminal. The `TransformStream.pipeThrough` interceptor detects `data: [DONE]` before the OpenAI SDK consumes it, distinguishing clean termination from connection drops. This matches ClawSweeper's recommendation: "[P1] Carry an explicit clean SSE terminal signal so [DONE] without finish_reason promotes tool calls while EOF without [DONE] remains fail-closed."
- **Safety guard**: EOF without `[DONE]` (connection drop, truncated response) remains fail-closed because `sawStreamDONE` is never set. The `(sawNativeToolCallDelta && sawStreamDONE)` conjunction ensures both conditions: provider signaled tool-use intent AND stream terminated cleanly.
- **Alternative considered**:
  - Adding a separate `!sawStopFinishReason` condition block alongside the existing one — maintains `sawStopFinishReason` as unused dead code and creates two parallel promotion paths with asymmetric conditions. Rejected: less clean, harder to audit.
  - Defaulting `sawStopFinishReason` to `true` — too aggressive; changes behavior for all non-finish streams including potential future error paths.
  - Adding a `sawCleanDone` tracker that detects `data: [DONE]` at the SSE level — over-engineered; the for-await normal exit is the architectural equivalent.

## AI Assistance 🤖

- **AI-assisted**: Yes
- **Co-Authored-By**: Claude Opus 4.8 <noreply@anthropic.com>
- **Human confirmed understanding of code changes**: Yes
- **AI prompts / session excerpts**: See commit message and PR body for full analysis chain (provenance → root cause → invariant → fix → test matrix).

## Risks and Mitigations

- **Highest risk area**: A provider that streams tool calls but the connection drops mid-stream without throwing (extremely rare — Node fetch typically throws on TCP reset). Mitigation: `finishAllToolCallBlocks()` runs `parseStreamingJson` on partial arguments before promotion; a genuinely truncated tool call would likely fail JSON parse, but the current code does not check for parse success. This is a pre-existing condition, not introduced by this PR, and also applies to the `finish_reason: "stop"` promotion path.
- **Compatibility**: No breaking change. Providers that emit `finish_reason` are unaffected. Providers that omit it now get correct tool execution.
- **Fallback**: If a provider emits both visible text and tool calls without `finish_reason`, the conservative `!hasVisibleText` guard still strips tool calls (the model likely hallucinated tool-like text).

---

Fixes #97994

