### PR TITLE
fix(plugin-sdk): guard legacy dedupe JSON parse against malformed files

### DIFF
--- a/src/plugin-sdk/memory-host-events.test.ts
+++ b/src/plugin-sdk/memory-host-events.test.ts
@@ -232,6 +232,20 @@ describe("createPersistentDedupe", () => {
     ]);
   });
 
+  it("treats malformed legacy JSON cache files as empty", async () => {
+    const root = await createTempDir("openclaw-legacy-dedupe-malformed-");
+    const legacyPath = path.join(root, "legacy.json");
+    await fs.writeFile(legacyPath, "{not valid json");
+
+    await expect(
+      listPersistentDedupeLegacyJsonFileEntries({
+        filePath: legacyPath,
+        ttlMs: 500,
+        now: 1_100,
+      }),
+    ).resolves.toStrictEqual([]);
+  });
+
   it("warms empty namespaces and ignores retired JSON cache files", async () => {
     const root = await createTempDir("openclaw-dedupe-");
     const emptyReader = createDedupe(root, { ttlMs: 10_000 });

--- a/src/plugin-sdk/persistent-dedupe.ts
+++ b/src/plugin-sdk/persistent-dedupe.ts
@@ -326,7 +326,12 @@ function parseLegacyDedupeData(raw: string): {
   data: Record<string, number>;
   invalidCount: number;
 } {
-  const parsed = JSON.parse(raw) as unknown;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw) as unknown;
+  } catch {
+    return { data: {}, invalidCount: 0 };
+  }
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
     return { data: {}, invalidCount: 0 };
   }


### PR DESCRIPTION
## What Problem This Solves

`listPersistentDedupeLegacyJsonFileEntries` (used during `openclaw doctor` legacy dedupe migration) calls `JSON.parse` on retired JSON cache files without catching parse errors. If a legacy dedupe file is partially written, truncated, or otherwise malformed, the entire doctor repair flow throws a `SyntaxError` instead of treating the file as empty.

## Changes

- `src/plugin-sdk/persistent-dedupe.ts`: `parseLegacyDedupeData` now wraps `JSON.parse` in a try/catch. Malformed JSON is treated the same way as `{}` or `[]` — returning `{ data: {}, invalidCount: 0 }` — so the legacy migration continues instead of crashing.
- `src/plugin-sdk/memory-host-events.test.ts`: added a regression test that writes `{not valid json` to a legacy dedupe file and asserts `listPersistentDedupeLegacyJsonFileEntries` resolves to an empty array.

## Real behavior proof

- **Behavior addressed**: A malformed legacy dedupe JSON file must not crash the migration entry reader; it must be treated as empty while well-formed files continue to load normally.
- **Real environment tested**: Local Node v22 workspace, using the exported production function `listPersistentDedupeLegacyJsonFileEntries` against a real temporary file on disk.
- **Exact steps**: `node --import tsx /tmp/proof-persistent-dedupe.mts` writes a malformed legacy dedupe file, calls the production reader, and prints the result. The same script also verifies a well-formed file still returns the expected entry.
- **Observed result after fix**: malformed file → `RESULT: ok, entries=0`; well-formed file → `RESULT: ok, entries=1`. Before the fix the malformed file threw `SyntaxError: Expected property name or '}' in JSON at position 1`.
- **What was not tested**: The full `openclaw doctor --fix` end-to-end flow was not run; the proof focuses on the exact entry-point function that doctor uses, and the in-repo Vitest regression locks the behavior.

## Evidence

Terminal proof (real production function, real malformed file on disk):

```
$ node --import tsx /tmp/proof-persistent-dedupe.mts
malformed: RESULT: ok, entries=0
valid:     RESULT: ok, entries=1
```

Negative control (temporary revert to `origin/main`):

```
$ git checkout origin/main -- src/plugin-sdk/persistent-dedupe.ts
$ node --import tsx /tmp/proof-persistent-dedupe.mts
malformed: RESULT: error, Expected property name or '}' in JSON at position 1 (line 1 column 2)
valid:     RESULT: ok, entries=1
$ git checkout HEAD -- src/plugin-sdk/persistent-dedupe.ts
```

Focused Vitest:

```
$ node scripts/run-vitest.mjs src/plugin-sdk/memory-host-events.test.ts --run

Test Files  1 passed (1)
      Tests  13 passed (13)
   Duration  1.37s
```

Type checks:

```
$ pnpm tsgo:core      # exit 0
$ pnpm tsgo:test:src  # exit 0
```
