### PR TITLE
Restore Telegram /steer for active Codex runs

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.steering.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.steering.test.ts
@@ -17,6 +17,30 @@ import {
   turnStartResult,
 } from "./run-attempt-test-harness.js";
 
+const activeRunRegistrationMocks = vi.hoisted(() => ({
+  clearActiveEmbeddedRun: vi.fn(),
+  setActiveEmbeddedRun: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/agent-harness-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/agent-harness-runtime")>();
+  return {
+    ...actual,
+    clearActiveEmbeddedRun: (
+      ...args: Parameters<typeof actual.clearActiveEmbeddedRun>
+    ): ReturnType<typeof actual.clearActiveEmbeddedRun> => {
+      activeRunRegistrationMocks.clearActiveEmbeddedRun(...args);
+      return actual.clearActiveEmbeddedRun(...args);
+    },
+    setActiveEmbeddedRun: (
+      ...args: Parameters<typeof actual.setActiveEmbeddedRun>
+    ): ReturnType<typeof actual.setActiveEmbeddedRun> => {
+      activeRunRegistrationMocks.setActiveEmbeddedRun(...args);
+      return actual.setActiveEmbeddedRun(...args);
+    },
+  };
+});
+
 setupRunAttemptTestHooks();
 
 let steeringSessionIndex = 0;
@@ -119,6 +143,52 @@ describe("runCodexAppServerAttempt steering", () => {
 
     await completeTurn({ threadId: "thread-1", turnId: "turn-1" });
     await run;
+  });
+
+  it("passes session files through active Codex app-server registration for command lookup", async () => {
+    const { requests, waitForMethod, completeTurn } = createStartedThreadHarness();
+    const params = createSteeringParams();
+    activeRunRegistrationMocks.setActiveEmbeddedRun.mockClear();
+    activeRunRegistrationMocks.clearActiveEmbeddedRun.mockClear();
+
+    const run = runCodexAppServerAttempt(params);
+    await waitForMethod("turn/start");
+
+    expect(activeRunRegistrationMocks.setActiveEmbeddedRun).toHaveBeenCalledWith(
+      params.sessionId,
+      expect.anything(),
+      params.sessionKey,
+      params.sessionFile,
+    );
+
+    await waitAndQueueActiveRunMessage(params.sessionId, "session-file registered", {
+      debounceMs: 0,
+    });
+
+    await vi.waitFor(
+      () =>
+        expect(requests.filter((entry) => entry.method === "turn/steer")).toEqual([
+          {
+            method: "turn/steer",
+            params: {
+              threadId: "thread-1",
+              expectedTurnId: "turn-1",
+              input: [{ type: "text", text: "session-file registered", text_elements: [] }],
+            },
+          },
+        ]),
+      fastWait,
+    );
+
+    await completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await run;
+
+    expect(activeRunRegistrationMocks.clearActiveEmbeddedRun).toHaveBeenCalledWith(
+      params.sessionId,
+      expect.anything(),
+      params.sessionKey,
+      params.sessionFile,
+    );
   });
 
   it("flushes batched default queued steering during normal turn cleanup", async () => {

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -2886,12 +2886,13 @@ export async function runCodexAppServerAttempt(
     queueMessage: async (text: string, optionsLocal?: CodexSteeringQueueOptions) =>
       activeSteeringQueue.queue(text, optionsLocal),
     isStreaming: () => !completed && !runAbortController.signal.aborted,
+    isStopped: () => completed || timedOut || runAbortController.signal.aborted,
     isCompacting: () => projectorRef.current?.isCompacting() ?? false,
     sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
     cancel: () => runAbortController.abort("cancelled"),
     abort: () => runAbortController.abort("aborted"),
   };
-  setActiveEmbeddedRun(params.sessionId, handle, params.sessionKey);
+  setActiveEmbeddedRun(params.sessionId, handle, params.sessionKey, params.sessionFile);
   const notifyUserMessagePersisted = createCodexAppServerUserMessagePersistenceNotifier(params);
   void mirrorPromptAtTurnStartBestEffort({
     params,
@@ -3281,7 +3282,7 @@ export async function runCodexAppServerAttempt(
     runAbortController.signal.removeEventListener("abort", abortListener);
     params.abortSignal?.removeEventListener("abort", abortFromUpstream);
     steeringQueueRef.current?.cancel();
-    clearActiveEmbeddedRun(params.sessionId, handle, params.sessionKey);
+    clearActiveEmbeddedRun(params.sessionId, handle, params.sessionKey, params.sessionFile);
   }
 }
 

--- a/extensions/telegram/src/sequential-key.test.ts
+++ b/extensions/telegram/src/sequential-key.test.ts
@@ -80,6 +80,18 @@ describe("getTelegramSequentialKey", () => {
       "telegram:123:control",
     ],
     [
+      { message: mockMessage({ chat: mockChat({ id: 123 }), text: "/steer keep going" }) },
+      "telegram:123:control",
+    ],
+    [
+      { message: mockMessage({ chat: mockChat({ id: 123 }), text: "/tell use the cache" }) },
+      "telegram:123:control",
+    ],
+    [
+      { message: mockMessage({ chat: mockChat({ id: 123 }), text: "/queue status" }) },
+      "telegram:123:control",
+    ],
+    [
       {
         message: mockMessage({
           chat: mockChat({ id: -100, type: "supergroup", is_forum: true }),
@@ -89,6 +101,41 @@ describe("getTelegramSequentialKey", () => {
         }),
       },
       "telegram:-100:control",
+    ],
+    [
+      {
+        message: mockMessage({
+          chat: mockChat({ id: -100, type: "supergroup", is_forum: true }),
+          is_topic_message: true,
+          message_thread_id: 5907,
+          text: "/steer@vacs_tars_bot keep going",
+        }),
+      },
+      "telegram:-100:control",
+    ],
+    [
+      {
+        me: { username: "openclaw_bot" } as never,
+        message: mockMessage({
+          chat: mockChat({ id: -100, type: "supergroup", is_forum: true }),
+          is_topic_message: true,
+          message_thread_id: 5907,
+          text: "/tell@openclaw_bot keep going!",
+        }),
+      },
+      "telegram:-100:control",
+    ],
+    [
+      {
+        me: { username: "openclaw_bot" } as never,
+        message: mockMessage({
+          chat: mockChat({ id: -100, type: "supergroup", is_forum: true }),
+          is_topic_message: true,
+          message_thread_id: 5907,
+          text: "/queue@some_other_bot status",
+        }),
+      },
+      "telegram:-100:topic:5907",
     ],
     [
       {

--- a/extensions/telegram/src/sequential-key.ts
+++ b/extensions/telegram/src/sequential-key.ts
@@ -25,6 +25,8 @@ const TELEGRAM_READ_ONLY_STATUS_COMMAND_KEYS = new Set([
   "whoami",
 ]);
 
+const TELEGRAM_ACTIVE_RUN_CONTROL_COMMAND_KEYS = new Set(["queue", "steer"]);
+
 type TelegramSequentialKeyContext = {
   chat?: { id?: number };
   me?: UserFromGetMe;
@@ -80,6 +82,50 @@ function isTelegramTargetedStopCommand(rawText?: string, botUsername?: string): 
   return match[1]?.toLowerCase() === normalizedBotUsername;
 }
 
+function resolveTelegramCommandAliasForControlLane(
+  rawText?: string,
+  botUsername?: string,
+): string | undefined {
+  const trimmed = rawText?.trim();
+  if (!trimmed?.startsWith("/")) {
+    return undefined;
+  }
+
+  const targetedMatch = trimmed.match(
+    /^\/([A-Za-z0-9_-]+)(?:@([A-Za-z0-9_]+))?(?:$|\s|[.!?…,，。;；:：'"’”)\]}])/iu,
+  );
+  const targetBotUsername = targetedMatch?.[2]?.trim().toLowerCase();
+  const normalizedBotUsername = botUsername?.trim().toLowerCase();
+  if (targetBotUsername && normalizedBotUsername && targetBotUsername !== normalizedBotUsername) {
+    return undefined;
+  }
+
+  if (targetBotUsername && !normalizedBotUsername) {
+    const commandAlias = `/${targetedMatch?.[1]?.toLowerCase() ?? ""}`;
+    return commandAlias === "/" ? undefined : commandAlias;
+  }
+
+  return (
+    maybeResolveTextAlias(
+      normalizeCommandBody(trimmed, botUsername ? { botUsername } : undefined),
+    ) ?? undefined
+  );
+}
+
+function isTelegramActiveRunControlLaneText(params: {
+  rawText?: string;
+  botUsername?: string;
+}): boolean {
+  const alias = resolveTelegramCommandAliasForControlLane(params.rawText, params.botUsername);
+  if (!alias) {
+    return false;
+  }
+  const command = listChatCommands().find((entry) =>
+    entry.textAliases.some((candidate) => candidate.trim().toLowerCase() === alias),
+  );
+  return command ? TELEGRAM_ACTIVE_RUN_CONTROL_COMMAND_KEYS.has(command.key) : false;
+}
+
 export function isTelegramControlLaneText(params: {
   rawText?: string;
   botUsername?: string;
@@ -93,6 +139,9 @@ export function isTelegramControlLaneText(params: {
     return true;
   }
   if (isTelegramTargetedStopCommand(params.rawText, params.botUsername)) {
+    return true;
+  }
+  if (isTelegramActiveRunControlLaneText(params)) {
     return true;
   }
   return isTelegramReadOnlyControlLaneText(params);

--- a/src/agents/embedded-agent-runner/run-state.ts
+++ b/src/agents/embedded-agent-runner/run-state.ts
@@ -20,6 +20,7 @@ export type EmbeddedAgentQueueHandle = {
   kind?: "embedded";
   queueMessage: (text: string, options?: EmbeddedAgentQueueMessageOptions) => Promise<void>;
   isStreaming: () => boolean;
+  isStopped?: () => boolean;
   isCompacting: () => boolean;
   supportsTranscriptCommitWait?: boolean;
   cancel?: (reason?: "user_abort" | "restart" | "superseded") => void;

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -3759,6 +3759,7 @@ export async function runEmbeddedAttempt(
         params.onAttemptAbort?.();
         abortRun(false, reason === "restart" ? createAgentRunRestartAbortError() : undefined);
       };
+      let acceptingSteerMessages = true;
       const queueHandle: EmbeddedAgentQueueHandle & {
         kind: "embedded";
         cancel: (reason?: "user_abort" | "restart" | "superseded") => void;
@@ -3771,6 +3772,7 @@ export async function runEmbeddedAttempt(
           await steerActiveSessionWithOptionalDeliveryWait(activeSession, text, options);
         },
         isStreaming: () => activeSession.isStreaming,
+        isStopped: () => !acceptingSteerMessages || aborted || runAbortController.signal.aborted,
         isCompacting: () => subscription.isCompacting(),
         supportsTranscriptCommitWait: true,
         sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
@@ -4918,6 +4920,7 @@ export async function runEmbeddedAttempt(
             promptErrorSource = "prompt";
           }
         } finally {
+          acceptingSteerMessages = false;
           log.debug(
             `embedded run prompt end: runId=${params.runId} sessionId=${params.sessionId} durationMs=${Date.now() - promptStartedAt}`,
           );

--- a/src/agents/embedded-agent-runner/runs.test.ts
+++ b/src/agents/embedded-agent-runner/runs.test.ts
@@ -47,6 +47,11 @@ function createRunHandle(
     abort?: () => void;
     isCompacting?: boolean;
     isStreaming?: boolean;
+    isStopped?: () => boolean;
+    queueMessage?: (
+      text: string,
+      options?: Parameters<RunHandle["queueMessage"]>[1],
+    ) => Promise<void>;
     supportsTranscriptCommitWait?: boolean;
   } = {},
 ): RunHandle {
@@ -54,8 +59,9 @@ function createRunHandle(
   // behavior; individual tests supply queue/abort behavior when needed.
   const abort = overrides.abort ?? (() => {});
   return {
-    queueMessage: async () => {},
+    queueMessage: overrides.queueMessage ?? (async () => {}),
     isStreaming: () => overrides.isStreaming ?? true,
+    ...(overrides.isStopped ? { isStopped: overrides.isStopped } : {}),
     isCompacting: () => overrides.isCompacting ?? false,
     supportsTranscriptCommitWait: overrides.supportsTranscriptCommitWait,
     abort,
@@ -229,6 +235,68 @@ describe("embedded-agent runner run registry", () => {
     );
 
     expect(queueMessage).toHaveBeenCalledWith("continue", { steeringMode: "all" });
+  });
+
+  it("queues into active non-streaming handles that expose live stopped state", () => {
+    const queueMessage = vi.fn(async () => {});
+    setActiveEmbeddedRun(
+      "session-active-non-streaming",
+      createRunHandle({
+        isStreaming: false,
+        isStopped: () => false,
+        queueMessage,
+      }),
+    );
+
+    expect(
+      queueEmbeddedAgentMessageWithOutcome("session-active-non-streaming", "continue").queued,
+    ).toBe(true);
+    expect(queueMessage).toHaveBeenCalledWith("continue", { steeringMode: "all" });
+  });
+
+  it("does not queue into stopped handles", () => {
+    const queueMessage = vi.fn(async () => {});
+    setActiveEmbeddedRun(
+      "session-stopped",
+      createRunHandle({
+        isStreaming: true,
+        isStopped: () => true,
+        queueMessage,
+      }),
+    );
+
+    const outcome = queueEmbeddedAgentMessageWithOutcome("session-stopped", "continue");
+
+    expect(outcome).toEqual({
+      queued: false,
+      sessionId: "session-stopped",
+      reason: "not_streaming",
+      gatewayHealth: "live",
+    });
+    expect(queueMessage).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when stopped state checks throw", () => {
+    const queueMessage = vi.fn(async () => {});
+    setActiveEmbeddedRun(
+      "session-bad-state",
+      createRunHandle({
+        isStopped: () => {
+          throw new Error("bad stopped state");
+        },
+        queueMessage,
+      }),
+    );
+
+    const outcome = queueEmbeddedAgentMessageWithOutcome("session-bad-state", "continue");
+
+    expect(outcome).toEqual({
+      queued: false,
+      sessionId: "session-bad-state",
+      reason: "not_streaming",
+      gatewayHealth: "live",
+    });
+    expect(queueMessage).not.toHaveBeenCalled();
   });
 
   it("returns a structured no-active-run queue failure", () => {
@@ -588,5 +656,4 @@ describe("embedded-agent runner run registry", () => {
     clearActiveEmbeddedRun("session-snapshot", handle);
     expect(getActiveEmbeddedRunSnapshot("session-snapshot")).toBeUndefined();
   });
-
 });

--- a/src/agents/embedded-agent-runner/runs.ts
+++ b/src/agents/embedded-agent-runner/runs.ts
@@ -333,6 +333,20 @@ function formatQueueError(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
+function isEmbeddedQueueHandleMessageInjectable(
+  sessionId: string,
+  handle: EmbeddedAgentQueueHandle,
+): boolean {
+  try {
+    return handle.isStopped === undefined ? handle.isStreaming() : !handle.isStopped();
+  } catch (err) {
+    diag.warn(
+      `queue message failed: sessionId=${sessionId} reason=injectable_check_failed err=${String(err)}`,
+    );
+    return false;
+  }
+}
+
 export async function queueEmbeddedAgentMessageWithOutcomeAsync(
   sessionId: string,
   text: string,
@@ -395,7 +409,7 @@ function prepareEmbeddedAgentQueueMessage(
     diag.debug(`queue message failed: sessionId=${sessionId} reason=no_active_run`);
     return { kind: "complete", outcome: createQueueFailureOutcome(sessionId, "no_active_run") };
   }
-  if (!handle.isStreaming()) {
+  if (!isEmbeddedQueueHandleMessageInjectable(sessionId, handle)) {
     diag.debug(`queue message failed: sessionId=${sessionId} reason=not_streaming`);
     return { kind: "complete", outcome: createQueueFailureOutcome(sessionId, "not_streaming") };
   }

--- a/src/auto-reply/reply/agent-runner.media-paths.test.ts
+++ b/src/auto-reply/reply/agent-runner.media-paths.test.ts
@@ -407,7 +407,7 @@ describe("runReplyAgent media path normalization", () => {
     expect(createReplyMediaContextRuntimeMock).not.toHaveBeenCalled();
   });
 
-  it("steers active prompts in steer queue mode", async () => {
+  it("steers active non-streaming prompts in steer queue mode", async () => {
     queueEmbeddedAgentMessageWithOutcomeAsyncMock.mockImplementation(async (sessionId: string) => ({
       queued: true,
       sessionId,
@@ -420,7 +420,8 @@ describe("runReplyAgent media path normalization", () => {
         resolvedQueue: { mode: "steer" } as QueueSettings,
         shouldSteer: true,
         shouldFollowup: true,
-        isStreaming: true,
+        isActive: true,
+        isStreaming: false,
       }),
     );
 

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1189,7 +1189,6 @@ export async function runReplyAgent(params: {
     shouldFollowup,
     isActive,
     isRunActive,
-    isStreaming,
     opts,
     typing,
     sessionEntry,
@@ -1275,7 +1274,7 @@ export async function runReplyAgent(params: {
     }
   };
 
-  if (effectiveShouldSteer && isStreaming) {
+  if (effectiveShouldSteer && isActive) {
     const steerSessionId =
       (sessionKey ? replyRunRegistry.resolveSessionId(sessionKey) : undefined) ??
       followupRun.run.sessionId;

--- a/src/auto-reply/reply/commands-steer.runtime.ts
+++ b/src/auto-reply/reply/commands-steer.runtime.ts
@@ -5,4 +5,5 @@ export {
   queueEmbeddedAgentMessage,
   queueEmbeddedAgentMessageWithOutcomeAsync,
   resolveActiveEmbeddedRunSessionId,
+  resolveActiveEmbeddedRunSessionIdBySessionFile,
 } from "../../agents/embedded-agent-runner/runs.js";

--- a/src/auto-reply/reply/commands-steer.test.ts
+++ b/src/auto-reply/reply/commands-steer.test.ts
@@ -8,6 +8,7 @@ const steerRuntimeMocks = vi.hoisted(() => ({
   isEmbeddedAgentRunActive: vi.fn(),
   queueEmbeddedAgentMessageWithOutcomeAsync: vi.fn(),
   resolveActiveEmbeddedRunSessionId: vi.fn(),
+  resolveActiveEmbeddedRunSessionIdBySessionFile: vi.fn(),
 }));
 
 vi.mock("./commands-steer.runtime.js", () => steerRuntimeMocks);
@@ -38,6 +39,9 @@ describe("handleSteerCommand", () => {
       gatewayHealth: "live",
     });
     steerRuntimeMocks.resolveActiveEmbeddedRunSessionId.mockReset().mockReturnValue(undefined);
+    steerRuntimeMocks.resolveActiveEmbeddedRunSessionIdBySessionFile
+      .mockReset()
+      .mockReturnValue(undefined);
   });
 
   it("queues steering for the active current text-command session", async () => {
@@ -100,6 +104,72 @@ describe("handleSteerCommand", () => {
     expect(steerRuntimeMocks.queueEmbeddedAgentMessageWithOutcomeAsync).toHaveBeenCalledWith(
       "stored-session-id",
       "continue from state",
+      {
+        steeringMode: "all",
+        debounceMs: 0,
+      },
+    );
+  });
+
+  it("resolves an active run from the target session file before stored session id fallback", async () => {
+    steerRuntimeMocks.resolveActiveEmbeddedRunSessionIdBySessionFile.mockReturnValue(
+      "session-file-active",
+    );
+
+    const params = buildParams("/steer check the active file");
+    params.ctx.CommandSource = "native";
+    params.ctx.CommandTargetSessionKey = "agent:main:telegram:topic:5907";
+    params.sessionKey = "agent:main:telegram:control";
+    params.sessionStore = {
+      "agent:main:telegram:topic:5907": {
+        sessionId: "stored-session-id",
+        sessionFile: "/tmp/openclaw-topic-5907.jsonl",
+        updatedAt: Date.now(),
+      },
+    };
+
+    await handleSteerCommand(params, true);
+
+    expect(steerRuntimeMocks.resolveActiveEmbeddedRunSessionId).toHaveBeenCalledWith(
+      "agent:main:telegram:topic:5907",
+    );
+    expect(steerRuntimeMocks.resolveActiveEmbeddedRunSessionIdBySessionFile).toHaveBeenCalledWith(
+      "/tmp/openclaw-topic-5907.jsonl",
+    );
+    expect(steerRuntimeMocks.isEmbeddedAgentRunActive).not.toHaveBeenCalledWith(
+      "stored-session-id",
+    );
+    expect(steerRuntimeMocks.queueEmbeddedAgentMessageWithOutcomeAsync).toHaveBeenCalledWith(
+      "session-file-active",
+      "check the active file",
+      {
+        steeringMode: "all",
+        debounceMs: 0,
+      },
+    );
+  });
+
+  it("falls back from a slash-lane command session to an active direct sibling", async () => {
+    steerRuntimeMocks.resolveActiveEmbeddedRunSessionId.mockImplementation((key: string) =>
+      key === "agent:main:telegram:direct:123" ? "session-direct-active" : undefined,
+    );
+
+    const params = buildParams("/steer use the active direct lane");
+    params.sessionKey = "agent:main:telegram:slash:123";
+
+    await handleSteerCommand(params, true);
+
+    expect(steerRuntimeMocks.resolveActiveEmbeddedRunSessionId).toHaveBeenNthCalledWith(
+      1,
+      "agent:main:telegram:slash:123",
+    );
+    expect(steerRuntimeMocks.resolveActiveEmbeddedRunSessionId).toHaveBeenNthCalledWith(
+      2,
+      "agent:main:telegram:direct:123",
+    );
+    expect(steerRuntimeMocks.queueEmbeddedAgentMessageWithOutcomeAsync).toHaveBeenCalledWith(
+      "session-direct-active",
+      "use the active direct lane",
       {
         steeringMode: "all",
         debounceMs: 0,

--- a/src/auto-reply/reply/commands-steer.ts
+++ b/src/auto-reply/reply/commands-steer.ts
@@ -13,6 +13,7 @@ import {
   isEmbeddedAgentRunActive,
   queueEmbeddedAgentMessageWithOutcomeAsync,
   resolveActiveEmbeddedRunSessionId,
+  resolveActiveEmbeddedRunSessionIdBySessionFile,
 } from "./commands-steer.runtime.js";
 import type {
   CommandHandler,
@@ -57,21 +58,50 @@ function resolveStoredSessionEntry(
   return undefined;
 }
 
+function listSteerCandidateSessionKeys(targetSessionKey: string): string[] {
+  const candidates = [targetSessionKey];
+  if (targetSessionKey.includes(":slash:")) {
+    candidates.push(
+      targetSessionKey.replace(":slash:", ":direct:"),
+      targetSessionKey.replace(":slash:", ":dm:"),
+    );
+  }
+  return [...new Set(candidates)];
+}
+
 function resolveSteerSessionId(params: {
   commandParams: HandleCommandsParams;
   targetSessionKey: string;
 }): string | undefined {
-  const activeSessionId = resolveActiveEmbeddedRunSessionId(params.targetSessionKey);
-  if (activeSessionId) {
-    return activeSessionId;
+  const candidateKeys = listSteerCandidateSessionKeys(params.targetSessionKey);
+  for (const candidateKey of candidateKeys) {
+    const activeSessionId = resolveActiveEmbeddedRunSessionId(candidateKey);
+    if (activeSessionId) {
+      return activeSessionId;
+    }
   }
 
-  const entry = resolveStoredSessionEntry(params.commandParams, params.targetSessionKey);
-  const sessionId = normalizeOptionalString(entry?.sessionId);
-  if (!sessionId || !isEmbeddedAgentRunActive(sessionId)) {
-    return undefined;
+  for (const candidateKey of candidateKeys) {
+    const entry = resolveStoredSessionEntry(params.commandParams, candidateKey);
+    const sessionFile = normalizeOptionalString(entry?.sessionFile);
+    if (!sessionFile) {
+      continue;
+    }
+    const activeSessionId = resolveActiveEmbeddedRunSessionIdBySessionFile(sessionFile);
+    if (activeSessionId) {
+      return activeSessionId;
+    }
   }
-  return sessionId;
+
+  for (const candidateKey of candidateKeys) {
+    const entry = resolveStoredSessionEntry(params.commandParams, candidateKey);
+    const sessionId = normalizeOptionalString(entry?.sessionId);
+    if (sessionId && isEmbeddedAgentRunActive(sessionId)) {
+      return sessionId;
+    }
+  }
+
+  return undefined;
 }
 
 function applySteerFallbackPrompt(ctx: HandleCommandsParams["ctx"], message: string): void {

--- a/src/auto-reply/reply/reply-run-registry.test.ts
+++ b/src/auto-reply/reply/reply-run-registry.test.ts
@@ -475,6 +475,71 @@ describe("reply run registry", () => {
     expect(queueMessage).toHaveBeenCalledWith("hello");
   });
 
+  it("queues messages through active non-streaming backends with live stopped state", () => {
+    const queueMessage = vi.fn(async () => {});
+    const operation = createReplyOperation({
+      sessionKey: "agent:main:main",
+      sessionId: "session-running",
+      resetTriggered: false,
+    });
+
+    operation.attachBackend({
+      kind: "embedded",
+      cancel: vi.fn(),
+      isStreaming: () => false,
+      isStopped: () => false,
+      queueMessage,
+    });
+    operation.setPhase("running");
+
+    expect(queueReplyRunMessage("session-running", "hello")).toBe(true);
+    expect(queueMessage).toHaveBeenCalledWith("hello");
+  });
+
+  it("does not queue messages through stopped backends", () => {
+    const queueMessage = vi.fn(async () => {});
+    const operation = createReplyOperation({
+      sessionKey: "agent:main:main",
+      sessionId: "session-running",
+      resetTriggered: false,
+    });
+
+    operation.attachBackend({
+      kind: "embedded",
+      cancel: vi.fn(),
+      isStreaming: () => true,
+      isStopped: () => true,
+      queueMessage,
+    });
+    operation.setPhase("running");
+
+    expect(queueReplyRunMessage("session-running", "hello")).toBe(false);
+    expect(queueMessage).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when backend stopped state checks throw", () => {
+    const queueMessage = vi.fn(async () => {});
+    const operation = createReplyOperation({
+      sessionKey: "agent:main:main",
+      sessionId: "session-running",
+      resetTriggered: false,
+    });
+
+    operation.attachBackend({
+      kind: "embedded",
+      cancel: vi.fn(),
+      isStreaming: () => true,
+      isStopped: () => {
+        throw new Error("bad stopped state");
+      },
+      queueMessage,
+    });
+    operation.setPhase("running");
+
+    expect(queueReplyRunMessage("session-running", "hello")).toBe(false);
+    expect(queueMessage).not.toHaveBeenCalled();
+  });
+
   it("aborts compacting runs through the registry compatibility helper", () => {
     const compactingOperation = createReplyOperation({
       sessionKey: "agent:main:main",

--- a/src/auto-reply/reply/reply-run-registry.ts
+++ b/src/auto-reply/reply/reply-run-registry.ts
@@ -19,6 +19,7 @@ export type ReplyBackendHandle = {
   readonly kind: ReplyBackendKind;
   cancel(reason?: ReplyBackendCancelReason): void;
   isStreaming(): boolean;
+  isStopped?: () => boolean;
   queueMessage?: (text: string) => Promise<void>;
   /**
    * Compatibility-only hook so legacy "abort compacting runs" paths can still
@@ -233,6 +234,14 @@ const afterClearCallbacksByOperation = new WeakMap<
 
 function getAttachedBackend(operation: ReplyOperation): ReplyBackendHandle | undefined {
   return attachedBackendByOperation.get(operation);
+}
+
+function isReplyBackendMessageInjectable(backend: ReplyBackendHandle): boolean {
+  try {
+    return backend.isStopped === undefined ? backend.isStreaming() : !backend.isStopped();
+  } catch {
+    return false;
+  }
 }
 
 /** Run work after an operation no longer owns its session lane. */
@@ -726,7 +735,7 @@ export function queueReplyRunMessage(sessionId: string, text: string): boolean {
   if (!operation || operation.phase !== "running" || !backend?.queueMessage) {
     return false;
   }
-  if (!backend.isStreaming()) {
+  if (!isReplyBackendMessageInjectable(backend)) {
     return false;
   }
   void backend.queueMessage(text);


### PR DESCRIPTION
## Summary

- Route Telegram `/steer`, `/tell`, and `/queue` text commands through the Telegram control lane so active-run management does not wait behind the busy chat/topic lane.
- Teach `/steer` active-run lookup to recover from slash-lane targeting by checking the active session key, session file, sibling direct/DM lanes, and then the legacy stored session id fallback.
- Register Codex app-server active runs with their `sessionFile`, matching the generic embedded runner so channel command lookup can find active Codex turns and deliver through existing `turn/steer`.
- Fix shared `messages.queue.mode: "steer"` admission for active non-streaming runs by using active/not-stopped handles instead of stream-only checks.

Fixes #81594.
Refs #48003.
Refs #82479.
Supersedes #81592 and #81613.

## What Problem This Solves

Users sending `/steer` or `/tell` from Telegram during an active Codex run can currently see the command arrive too late or get treated as a separate prompt. That makes channel-native steering unreliable exactly when a user is trying to correct a long-running Codex turn without terminal access.

There is also a related steer-mode failure: when `messages.queue.mode` is set to `steer`, active runs that are no longer streaming but are still accepting input could be rejected as `not_streaming`, causing the message to fall through to queued follow-up behavior instead of steering the active run.

## Root Cause

Telegram `/steer` text commands had two independent ways to miss an active Codex turn:

1. Telegram sequentialization did not classify `/steer`, `/tell`, or `/queue` as control-lane commands, so they could wait behind the same long-running chat/topic lane they were meant to control.
2. `/steer` active-run resolution stopped after the selected session key and stored session id. If the selected key was a slash lane, or if the active Codex run was only recoverable from the transcript session file, the command fell through as a new prompt instead of steering the active turn.

Codex app-server already supports steering with `turn/steer`; the missing piece was registering the active run with the same `sessionFile` lookup used by the generic embedded runner.

For steer mode, the shared runtime admission gate used `isStreaming()` as a proxy for whether a run could accept steering. That was too narrow. Active non-streaming prompt phases can still accept queued steering, so the queue handles now expose optional `isStopped()` state. Legacy handles keep the old stream-only behavior; updated embedded/Codex/reply handles accept steering while active and not stopped, and fail closed if stopped-state checks throw.

## Flow

```text
Telegram /steer or /tell
  -> Telegram control sequential lane
  -> shared /steer command handler
  -> active run lookup:
       target key
       target session file
       slash sibling direct/DM keys
       sibling session files
       stored active session id
  -> Codex steering queue
  -> app-server turn/steer
```

```text
messages.queue.mode = steer
  -> active reply handling
  -> queue admission checks active/not-stopped
  -> active embedded/Codex/reply queue handle
  -> turn/steer instead of delayed follow-up
```

## Scope

This restores the Telegram command path for active Codex runs and fixes shared runtime steer-mode admission for active non-streaming runs once a message reaches reply handling.

This intentionally does not claim to fix every #48003 case. Ordinary Telegram text messages are still serialized by `botRuntime.sequentialize(getTelegramSequentialKey)` before OpenClaw resolves the final `SessionKey`, thread binding, and queue mode. A safe ordinary-message steer-mode bypass needs a post-context, active-session-aware ingress design so we do not route first turns or cross-topic messages to the wrong active run.

## Evidence

- RED checks first:
  - Telegram control-lane tests failed for `/steer`, `/tell`, `/queue`, and targeted command forms.
  - `/steer` resolver tests failed for session-file lookup and slash-lane direct sibling fallback.
  - Codex app-server steering test failed because active runs were not resolvable by session file.
  - Steer-mode admission tests failed because active non-streaming runs were rejected as not streaming and fell through toward follow-up behavior.
- GREEN command-path suite:
  - `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run extensions/telegram/src/sequential-key.test.ts src/auto-reply/reply/commands-steer.test.ts extensions/codex/src/app-server/run-attempt.steering.test.ts --reporter=verbose`
  - Result: 3 test files passed, 63 tests passed.
- GREEN steer-mode suite:
  - `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run src/auto-reply/reply/agent-runner.media-paths.test.ts src/agents/embedded-agent-runner/runs.test.ts src/auto-reply/reply/reply-run-registry.test.ts --reporter=verbose`
  - Result: auto-reply shard 2 files / 29 tests passed; agents shard 1 file / 29 tests passed.
- Static checks:
  - `git diff --check`
  - `./node_modules/.bin/oxlint` on touched files.
  - `./node_modules/.bin/oxfmt --check --threads=1` on touched files.
  - `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo`
- Broader type note:
  - `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo` currently fails on unrelated `extensions/qa-lab` crabline type errors. The new Codex steering test type error found during development was fixed and did not recur.
- GitNexus:
  - `detect_changes` reports medium risk, with affected processes limited to Telegram dispatch/sequential-key flow and shared active-run steering admission.

## Proof Request

After CI starts, please run Telegram visible proof for this PR:

```text
@openclaw-mantis telegram live proof: verify /steer and /tell bypass a busy Telegram Codex run and reach the active Codex turn via turn/steer instead of becoming a delayed follow-up.
```
