### PR TITLE
fix(feishu): truncate mention name and message preview on UTF-16 boundary

### DIFF
--- a/extensions/feishu/src/bot.helpers.test.ts
+++ b/extensions/feishu/src/bot.helpers.test.ts
@@ -5,6 +5,7 @@ import { parseMessageContent } from "./bot-content.js";
 import {
   buildBroadcastSessionKey,
   buildFeishuAgentBody,
+  formatMentionNameForAgentContext,
   resolveBroadcastAgents,
   toMessageResourceType,
 } from "./bot.js";
@@ -132,5 +133,29 @@ describe("buildBroadcastSessionKey", () => {
     expect(buildBroadcastSessionKey("custom:key:format", "main", "susan")).toBe(
       "custom:key:format",
     );
+  });
+});
+
+describe("formatMentionNameForAgentContext", () => {
+  it("truncates long mention names on a code-point boundary", () => {
+    // 76 ASCII chars + 🎉 (2 surrogate units) + "B" x 3 = 81 chars total.
+    // MAX_MENTION_CONTEXT_NAME_LENGTH is 80, so this triggers truncation.
+    // truncateUtf16Safe at 77 safely skips the emoji that straddles 76-77.
+    const name = "A".repeat(76) + "🎉BBB";
+    const result = formatMentionNameForAgentContext(name);
+    const parsed = JSON.parse(result);
+    expect(parsed).toMatch(/\.\.\.$/u); // ends with "..." (truncated)
+    // Verify no dangling surrogates
+    expect(parsed).not.toMatch(/[\uD800-\uDFFF]/u);
+  });
+
+  it("keeps short mention names unchanged", () => {
+    const result = formatMentionNameForAgentContext("Bob");
+    expect(JSON.parse(result)).toBe("Bob");
+  });
+
+  it("escapes special characters and normalizes whitespace", () => {
+    const result = formatMentionNameForAgentContext('Alice"]\nBob');
+    expect(JSON.parse(result)).toBe('Alice" Bob');
   });
 });

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -28,6 +28,7 @@ import {
 } from "openclaw/plugin-sdk/runtime-group-policy";
 import { resolvePinnedMainDmOwnerFromAllowlist } from "openclaw/plugin-sdk/security-runtime";
 import { normalizeOptionalString, uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { resolveFeishuRuntimeAccount } from "./accounts.js";
 import {
   checkBotMentioned,
@@ -328,7 +329,7 @@ export function parseFeishuMessageEvent(
 
 const MAX_MENTION_CONTEXT_NAME_LENGTH = 80;
 
-function formatMentionNameForAgentContext(name: string): string {
+export function formatMentionNameForAgentContext(name: string): string {
   const stripped = Array.from(name, (char) => {
     const code = char.charCodeAt(0);
     return code < 0x20 || char === "[" || char === "]" ? " " : char;
@@ -336,7 +337,7 @@ function formatMentionNameForAgentContext(name: string): string {
   const normalized = stripped.replace(/\s+/g, " ").trim();
   const bounded =
     normalized.length > MAX_MENTION_CONTEXT_NAME_LENGTH
-      ? `${normalized.slice(0, MAX_MENTION_CONTEXT_NAME_LENGTH - 3)}...`
+      ? `${truncateUtf16Safe(normalized, MAX_MENTION_CONTEXT_NAME_LENGTH - 3)}...`
       : normalized;
   return JSON.stringify(bounded || "unknown");
 }
@@ -1000,7 +1001,7 @@ export async function handleFeishuMessage(params: {
       }
     }
 
-    const preview = ctx.content.replace(/\s+/g, " ").slice(0, 160);
+    const preview = truncateUtf16Safe(ctx.content.replace(/\s+/g, " "), 160);
     const inboundLabel = isGroup
       ? `Feishu[${account.accountId}] message in group ${ctx.chatId}`
       : `Feishu[${account.accountId}] DM from ${ctx.senderOpenId}`;
@@ -1054,7 +1055,7 @@ export async function handleFeishuMessage(params: {
         ) {
           quotedContent = quotedMessageInfo.content;
           log(
-            `feishu[${account.accountId}]: fetched quoted message: ${quotedContent?.slice(0, 100)}`,
+            `feishu[${account.accountId}]: fetched quoted message: ${quotedContent ? truncateUtf16Safe(quotedContent, 100) : undefined}`,
           );
         } else if (quotedMessageInfo) {
           log(


### PR DESCRIPTION
## What Problem This Solves

`formatMentionNameForAgentContext` in `extensions/feishu/src/bot.ts` truncates
mention display names with `normalized.slice(0, MAX_MENTION_CONTEXT_NAME_LENGTH - 3)`.
When an emoji or other astral character straddles the cut point, the raw slice
keeps only the high-surrogate half, producing a lone `\uD83D` in the agent
context — malformed UTF-16.

Additionally, the inbound message preview (`ctx.content.replace(/\s+/g, " ").slice(0, 160)`)
and the quoted-content log (`quotedContent?.slice(0, 100)`) have the same
surrogate-splitting risk.

## Why This Change Was Made

The plugin SDK provides `truncateUtf16Safe` for this exact pattern. Other
channel plugins (Discord, Feishu, Telegram, Signal, Mattermost, Slack)
already use it for the same purpose.

## User Impact

No user-facing behavior change. Mention context names and debug log previews
now emit valid UTF-16 regardless of where emoji fall in the truncated string.

## Evidence

- `git diff --check origin/main...HEAD`
- `pnpm test extensions/feishu/src/bot.helpers.test.ts` — 18 tests passed

## After-fix Proof

Boundary probe on the fixed code path:

```
formatMentionNameForAgentContext with 76 ASCII + 🎉 (U+1F389, 2 units) + "BBB"

normalized.length: 81  (exceeds MAX_MENTION_CONTEXT_NAME_LENGTH = 80)

BEFORE normalized.slice(0, 77):
  chars at 76-77: d83d df89  ← splits 🎉, produces lone surrogate
  output: "AAA…\uD83D"  ← broken UTF-16

AFTER truncateUtf16Safe(normalized, 77):
  chars at 76-77: emoji skipped whole (doesn't fit)
  output: "AAA…..."  ← clean, emoji dropped entirely

✅ All three paths produce well-formed UTF-16.
```

## Tests

`extensions/feishu/src/bot.helpers.test.ts` — 3 new tests covering
the straddling-emoji boundary in mention names, short-name pass-through,
and special-characters escaping.