### PR TITLE
fix: allow reentrant session lock in compaction path (fixes #97747)

### DIFF
--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -1181,6 +1181,7 @@ async function compactEmbeddedAgentSessionDirectOnce(
     const compactionTimeoutMs = resolveCompactionTimeoutMs(params.config);
     const sessionLock = await acquireSessionWriteLock({
       sessionFile: params.sessionFile,
+      allowReentrant: true,
       ...resolveSessionWriteLockOptions(params.config, {
         maxHoldMsFallback: resolveSessionLockMaxHoldFromTimeout({
           timeoutMs: compactionTimeoutMs,


### PR DESCRIPTION
## What Problem This Solves

When an embedded agent attempt triggers overflow-recovery auto-compaction, the compaction path in `compactEmbeddedAgentSessionDirectOnce` re-acquires the same session's write lock inside the same process. Since `acquireSessionWriteLock` defaults `allowReentrant` to `false`, the nested acquire blocks for 60 seconds and then fails with `SessionWriteLockTimeoutError`. Each model in the fallback chain repeats the same cycle, producing an ~18-minute window where every new webchat message is rejected with "session file locked."

## Why This Change Was Made

The `compact.ts` compaction path and the `plugin-sdk/file-lock.ts` path both use the same underlying lock manager (`SESSION_LOCKS`), but they have inconsistent `allowReentrant` defaults:

- `plugin-sdk/file-lock.ts:106` → `allowReentrant: true`
- `compact.ts:1182` → (missing, defaults to `false`)

The compaction path is always called from within an agent run that already holds the session write lock, so it must be reentrant. Adding `allowReentrant: true` aligns it with the plugin-sdk behavior.

## User Impact

- **Before fix:** Long-running sessions that hit context overflow experience an ~18-minute lockout where all messages fail with "session file locked." The auto-compaction recovery loop never actually succeeds — only a manual `/compact` resolves it.
- **After fix:** The compaction path acquires the lock reentrantly in <1ms and proceeds to compact the session normally.

## Evidence

## Real behavior proof

- **Behavior addressed:** Session write lock contention during overflow-recovery auto-compaction
- **Environment tested:** macOS, Node 22.22.3, OpenClaw source checkout at `6cb82eaab`
- **Steps run after the patch:** Ran a lock reentrancy demonstration script that imports `acquireSessionWriteLock` from the patched source, acquires a lock, then attempts a nested acquire with `allowReentrant: true` (fix) and `allowReentrant: false` (pre-fix behavior)
- **Evidence after fix:**

```
=== Reentrant Lock Proof for #97747 ===
Lock A acquired (simulates agent run holding session write lock)
Lock B acquired reentrantly in 1ms (compaction path after fix: allowReentrant=true)
Both locks released — lock file cleaned up

Without allowReentrant: timed out after 802ms
Error: session file locked (timeout 800ms): pid=14810 alive=true ageMs=802
(Pre-fix behavior in compact.ts: blocks 60s per fallback model, then SessionWriteLockTimeoutError)

=== Proof complete ===
```

- **Observed result after fix:** Nested lock acquisition with `allowReentrant: true` completes in 1ms. Without the flag, it times out after 800ms with `SessionWriteLockTimeoutError` — matching the exact error signature from the issue logs.
- **What was not tested:** Full end-to-end context overflow scenario with a live model (requires specific session state and model configuration). The lock mechanism behavior is verified directly against the production `acquireSessionWriteLock` function.

- [x] AI-assisted (Hermes Agent)
