### PR TITLE
fix: clear timeout timer in Tailscale binary probe Promise.race

### DIFF
--- a/src/infra/tailscale.ts
+++ b/src/infra/tailscale.ts
@@ -40,12 +40,17 @@ export async function findTailscaleBinary(): Promise<string | null> {
     }
     try {
       // Use Promise.race with runExec to implement timeout
-      await Promise.race([
-        runExec(path, ["--version"], { timeoutMs: 3000 }),
-        new Promise<never>((_, reject) => {
-          setTimeout(() => reject(new Error("timeout")), 3000);
-        }),
-      ]);
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      try {
+        await Promise.race([
+          runExec(path, ["--version"], { timeoutMs: 3000 }),
+          new Promise<never>((_, reject) => {
+            timer = setTimeout(() => reject(new Error("timeout")), 3000);
+          }),
+        ]);
+      } finally {
+        if (timer) clearTimeout(timer);
+      }
       return true;
     } catch {
       return false;


### PR DESCRIPTION
Related: #98462

## What Problem This Solves

`checkBinary` in `src/infra/tailscale.ts` races `runExec` against a `setTimeout`-based timeout via `Promise.race`, but never clears the timer handle when `runExec` wins.

## Why This Change Was Made

Wrap `Promise.race` in `try/finally` that captures and clears the timer. Matches `src/node-host/with-timeout.ts`.

## User Impact

No user-visible change. Prevents dangling timers during Tailscale binary discovery.

## Evidence

**Runtime terminal proof (Node v24.13.1):**

![screenshot](https://raw.githubusercontent.com/zhangLei99586/openclaw/proof-screenshots/pr-98134-proof.png)

- 30/30 tests passed (`tailscale.test.ts`: DNS name parsing, IP fallback, noisy JSON, funnel status, sudo fallback)
- Same pattern as `src/node-host/with-timeout.ts:37-45`