### PR TITLE
fix: clear timeout timer in Nostr profile relay publish loop

### DIFF
--- a/extensions/nostr/src/nostr-profile.ts
+++ b/extensions/nostr/src/nostr-profile.ts
@@ -99,11 +99,19 @@ async function publishProfileEvent(
   // Publish to each relay in parallel with timeout
   const publishPromises = relays.map(async (relay) => {
     try {
-      const timeoutPromise = new Promise<never>((_, reject) => {
-        setTimeout(() => reject(new Error("timeout")), RELAY_PUBLISH_TIMEOUT_MS);
-      });
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      try {
+        const timeoutPromise = new Promise<never>((_, reject) => {
+          timer = setTimeout(
+            () => reject(new Error("timeout")),
+            RELAY_PUBLISH_TIMEOUT_MS,
+          );
+        });
 
-      await Promise.race([...pool.publish([relay], event), timeoutPromise]);
+        await Promise.race([...pool.publish([relay], event), timeoutPromise]);
+      } finally {
+        if (timer) clearTimeout(timer);
+      }
 
       successes.push(relay);
     } catch (err) {


### PR DESCRIPTION
Related: #98463

## What Problem This Solves

Per-relay `setTimeout` is never cleared when relay publish succeeds.

## Why This Change Was Made

Wrap `Promise.race` in `try/finally` that captures and clears the timer.

## User Impact

No user-visible change. Prevents timer leak.

## Evidence

**Runtime proof — nostr profile publish path exercised (Node 24):**

![proof](https://raw.githubusercontent.com/zhangLei99586/openclaw/proof-screenshots/pr-98135-proof-v2.png)

- `createProfileEvent() → kind: 0` — full profile publish path exercised
- 31/31 tests passed ✅