### PR TITLE
fix: hoist timer declaration to avoid TDZ ReferenceError in abortable delay

### DIFF
--- a/extensions/feishu/src/async.ts
+++ b/extensions/feishu/src/async.ts
@@ -75,6 +75,7 @@ export function waitForAbortableDelay(
 
   return new Promise((resolve) => {
     let settled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
 
     const finish = (value: boolean) => {
       if (settled) {
@@ -100,7 +101,7 @@ export function waitForAbortableDelay(
       return;
     }
 
-    const timer: ReturnType<typeof setTimeout> | undefined = setTimeout(
+    timer = setTimeout(
       () => finish(true),
       resolveTimerTimeoutMs(delayMs, 1),
     );


### PR DESCRIPTION
Related: #98464

## What Problem This Solves

`finish()` closure references `timer` declared as `const` after `finish`. TDZ ReferenceError risk if abort fires before assignment.

## Why This Change Was Made

Hoist `timer` as `let` above `finish` so it is safely `undefined`.

## User Impact

No user-visible change. Eliminates fragile declaration-order dependency.

## Evidence

**Runtime terminal proof (Node v24.13.1):**

![screenshot](https://raw.githubusercontent.com/zhangLei99586/openclaw/proof-screenshots/pr-98137-proof.png)

- 5/5 tests passed (`async.test.ts`)
- `waitForAbortableDelay(100, alreadyAborted signal) → false` — no ReferenceError