### PR TITLE
fix: guard setDeep against empty keys array in Chrome profile decoration

### DIFF
--- a/extensions/browser/src/browser/chrome.profile-decoration.ts
+++ b/extensions/browser/src/browser/chrome.profile-decoration.ts
@@ -38,6 +38,9 @@ function readNestedRecord(root: unknown, key: string): Record<string, unknown> |
 }
 
 function setDeep(obj: Record<string, unknown>, keys: string[], value: unknown) {
+  if (keys.length === 0) {
+    return;
+  }
   let node: Record<string, unknown> = obj;
   for (const key of keys.slice(0, -1)) {
     const next = node[key];
@@ -46,7 +49,7 @@ function setDeep(obj: Record<string, unknown>, keys: string[], value: unknown) {
     }
     node = node[key] as Record<string, unknown>;
   }
-  node[keys[keys.length - 1] ?? ""] = value;
+  node[keys[keys.length - 1]] = value;
 }
 
 function parseHexRgbToSignedArgbInt(hex: string): number | null {


### PR DESCRIPTION
Related: #98465

## What Problem This Solves

`setDeep()` with empty `keys` creates `obj[""] = value` via `keys[-1] ?? ""`.

## Why This Change Was Made

Add early `if (keys.length === 0) return;` guard.

## User Impact

No user-visible change. Defensive guard.

## Evidence

**Runtime terminal proof (Node v24.13.1):**

![screenshot](https://raw.githubusercontent.com/zhangLei99586/openclaw/proof-screenshots/pr-98138-proof.png)

- 36/36 tests passed (`profiles.test.ts`) — `setDeep(obj,[],"v") → keys: [ ]`