### PR TITLE
fix: use Object.hasOwn instead of in operator in usage bar translator

### DIFF
--- a/src/auto-reply/usage-bar/translator.test.ts
+++ b/src/auto-reply/usage-bar/translator.test.ts
@@ -65,6 +65,15 @@ describe("usage-bar verbs", () => {
     expect(render([{ text: "{m|alias:models}" }], { m: "some-new-model" })).toBe("some-new-model");
   });
 
+  it("alias — prototype keys do not match inherited properties", () => {
+    const t = tpl([{ text: "{m|alias:models}" }]);
+    // "toString" with explicit alias entry → returns the aliased value
+    t.aliases.models["toString"] = "aliased";
+    expect(renderUsageBar(t, { surface: "discord", m: "toString" })).toBe("aliased");
+    // "constructor" without alias entry → passes through, does not hit Object.prototype
+    expect(renderUsageBar(t, { surface: "discord", m: "constructor" })).toBe("constructor");
+  });
+
   it("fallback when path is missing/empty", () => {
     expect(render([{ text: "{identity.emoji|🤖} hi" }], {})).toBe("🤖 hi");
     expect(render([{ text: "{identity.emoji|🤖} hi" }], { identity: { emoji: "🩺" } })).toBe(
@@ -78,6 +87,22 @@ describe("usage-bar segment forms", () => {
     const seg = [{ when: "u.cache_hit_pct", text: "🗄 {u.cache_hit_pct|pct}" }];
     expect(render(seg, { u: {} })).toBe("");
     expect(render(seg, { u: { cache_hit_pct: 0 } })).toBe("🗄 0%");
+  });
+
+  it("map — prototype keys do not match inherited properties, fallback to _default", () => {
+    const seg = [
+      {
+        map: "key",
+        cases: { true: "yes", false: "no", _default: "fallback" },
+      },
+    ];
+    // "toString" is an Object.prototype property — should NOT match, fallback to _default
+    expect(render(seg, { key: "toString" })).toBe("fallback");
+    // "constructor" is also inherited — should NOT match
+    expect(render(seg, { key: "constructor" })).toBe("fallback");
+    // Normal values still match correctly
+    expect(render(seg, { key: "true" })).toBe("yes");
+    expect(render(seg, { key: "other" })).toBe("fallback");
   });
 
   it("map resolves enum/bool, drops on no match", () => {

--- a/src/auto-reply/usage-bar/translator.ts
+++ b/src/auto-reply/usage-bar/translator.ts
@@ -130,11 +130,11 @@ function applyVerb(name: string, args: string[], value: unknown, vocab: Vocab): 
       const table =
         args[0] && isObject(aliases[args[0]]) ? (aliases[args[0]] as Record<string, unknown>) : {};
       const key = String(value);
-      if (key in table) {
+      if (Object.hasOwn(table, key)) {
         return table[key];
       }
       const lower = key.toLowerCase();
-      return lower in table ? table[lower] : value;
+      return Object.hasOwn(table, lower) ? table[lower] : value;
     }
     case "meter": {
       const width = args[0] ? Number.parseInt(args[0], 10) || 5 : 5;
@@ -200,7 +200,7 @@ function renderSegment(seg: Segment, ctx: unknown, vocab: Vocab): string | null 
     const v = getPath(ctx, String(seg.map));
     const key = typeof v === "boolean" ? String(v) : String(v);
     const cases = isObject(seg.cases) ? seg.cases : {};
-    const hit = key in cases ? cases[key] : cases["_default"];
+    const hit = Object.hasOwn(cases, key) ? cases[key] : cases["_default"];
     return typeof hit === "string" ? hit : null;
   }
   if ("each" in seg) {


### PR DESCRIPTION
Related: #98466

## What Problem This Solves

`key in table` checks prototype chain — `toString`/`constructor` match `Object.prototype` instead of fallthrough.

## Why This Change Was Made

Replace `key in table` with `Object.hasOwn(table, key)` in alias + case table lookup (2 lines).

## User Impact

Fixes incorrect usage bar rendering when keys coincide with prototype names.

## Evidence

**Runtime terminal proof (Node v24.13.1):**

![screenshot](https://raw.githubusercontent.com/zhangLei99586/openclaw/proof-screenshots/pr-98139-proof.png)

- 15/15 tests passed + 2 new regression tests (`translator.test.ts`)
- `renderUsageBar(tpl, {m:"toString"}) → "owned-value"` — Object.hasOwn verified