### PR TITLE
fix: close readline interface and destroy read stream in transcript store

### DIFF
--- a/src/transcripts/store.ts
+++ b/src/transcripts/store.ts
@@ -215,6 +215,11 @@ export class TranscriptsStore {
         } finally {
           lines.close();
           stream.destroy();
+          if (!stream.closed) {
+            await new Promise<void>((resolve) => {
+              stream.once("close", resolve);
+            });
+          }
         }
       } catch (err) {
         if (err && typeof err === "object" && "code" in err && err.code === "ENOENT") {

--- a/src/transcripts/store.ts
+++ b/src/transcripts/store.ts
@@ -196,19 +196,25 @@ export class TranscriptsStore {
     if (maxUtterances !== undefined) {
       const utterances: TranscriptUtterance[] = [];
       try {
+        const stream = createReadStream(transcriptPath, { encoding: "utf8" });
         const lines = createInterface({
-          input: createReadStream(transcriptPath, { encoding: "utf8" }),
+          input: stream,
           crlfDelay: Infinity,
         });
-        for await (const line of lines) {
-          if (!line) {
-            continue;
+        try {
+          for await (const line of lines) {
+            if (!line) {
+              continue;
+            }
+            utterances.push(JSON.parse(line) as TranscriptUtterance);
+            if (utterances.length > maxUtterances) {
+              // Stream and keep only the tail so large transcripts do not require full-file memory.
+              utterances.shift();
+            }
           }
-          utterances.push(JSON.parse(line) as TranscriptUtterance);
-          if (utterances.length > maxUtterances) {
-            // Stream and keep only the tail so large transcripts do not require full-file memory.
-            utterances.shift();
-          }
+        } finally {
+          lines.close();
+          stream.destroy();
         }
       } catch (err) {
         if (err && typeof err === "object" && "code" in err && err.code === "ENOENT") {


### PR DESCRIPTION
Related: #98467

## What Problem This Solves

`createReadStream` + `readline.createInterface` not cleaned up after `for await` loop — fd leaks on `JSON.parse` throw.

## Why This Change Was Made

Wrap loop in `try/finally` that calls `lines.close()` and `stream.destroy()`.

## User Impact

No user-visible change. Prevents fd exhaustion reading large transcripts.

## Evidence

**Runtime terminal proof:**

![screenshot](https://raw.githubusercontent.com/zhangLei99586/openclaw/proof-screenshots/pr-98140-proof.png)

- 10/10 tests passed (`transcripts-tool.test.ts`) — `stream.destroyed: true` confirmed at runtime