### PR TITLE
fix(cli): stop `pairing list` crashing with empty channel enum

### DIFF
--- a/src/cli/pairing-cli.test.ts
+++ b/src/cli/pairing-cli.test.ts
@@ -224,6 +224,30 @@ describe("pairing cli", () => {
     expect(listChannelPairingRequests).toHaveBeenCalledWith("slack");
   });
 
+  it("redirects to openclaw devices when no pairing channels are configured", async () => {
+    listPairingChannels.mockReturnValueOnce([]);
+
+    const error = await runPairing(["pairing", "list"]).then(
+      () => null,
+      (err: unknown) => err,
+    );
+
+    expect(error).toBeInstanceOf(Error);
+    const message = (error as Error).message;
+    expect(message).toContain("openclaw devices");
+    // Must not leak the empty enum that originally read like a bug.
+    expect(message).not.toContain("expected one of: )");
+    expect(message).not.toContain("()");
+    expect(listChannelPairingRequests).not.toHaveBeenCalled();
+  });
+
+  it("lists supported channels when one is required but omitted", async () => {
+    // Multiple channels configured (default mock) + no channel argument.
+    await expect(runPairing(["pairing", "list"])).rejects.toThrow(
+      "expected one of: telegram, discord, imessage",
+    );
+  });
+
   it("accepts channel as positional for approve (npm-run compatible)", async () => {
     mockApprovedPairing();
 

--- a/src/cli/pairing-cli.ts
+++ b/src/cli/pairing-cli.ts
@@ -88,6 +88,8 @@ async function maybeBootstrapCommandOwnerFromPairing(params: {
 
 export function registerPairingCli(program: Command) {
   const channels = listPairingChannels();
+  // Avoid rendering a bare "()" enum when no channels are configured.
+  const channelHint = channels.length > 0 ? channels.join(", ") : "none configured";
   const pairing = program
     .command("pairing")
     .description("Secure DM pairing (approve inbound requests)")
@@ -100,16 +102,21 @@ export function registerPairingCli(program: Command) {
   pairing
     .command("list")
     .description("List pending pairing requests")
-    .option("--channel <channel>", `Channel (${channels.join(", ")})`)
+    .option("--channel <channel>", `Channel (${channelHint})`)
     .option("--account <accountId>", "Account id (for multi-account channels)")
-    .argument("[channel]", `Channel (${channels.join(", ")})`)
+    .argument("[channel]", `Channel (${channelHint})`)
     .option("--json", "Print JSON", false)
     .action(async (channelArg, opts) => {
       const channelRaw = opts.channel ?? channelArg ?? (channels.length === 1 ? channels[0] : "");
       if (!channelRaw) {
-        throw new Error(
-          `Channel required. Use --channel <channel> or pass it as the first argument (expected one of: ${channels.join(", ")})`,
-        );
+        if (channels.length === 0) {
+          // `pairing` is chat DM only; TUI/device approvals live under `openclaw devices`.
+          throw new Error(
+            `No chat DM pairing channels are configured. To approve a TUI or device request, ` +
+              `use ${formatCliCommand("openclaw devices approve")} instead.`,
+          );
+        }
+        throw new Error(`Channel required (expected one of: ${channelHint}).`);
       }
       const channel = parseChannel(channelRaw, channels);
       const accountId = normalizeStringifiedOptionalString(opts.account) ?? "";
@@ -151,7 +158,7 @@ export function registerPairingCli(program: Command) {
   pairing
     .command("approve")
     .description("Approve a pairing code and allow that sender")
-    .option("--channel <channel>", `Channel (${channels.join(", ")})`)
+    .option("--channel <channel>", `Channel (${channelHint})`)
     .option("--account <accountId>", "Account id (for multi-account channels)")
     .argument("<codeOrChannel>", "Pairing code (or channel when using 2 args)")
     .argument("[code]", "Pairing code (when channel is passed as the 1st arg)")


### PR DESCRIPTION
## Problem

Running `openclaw pairing list` with no channel argument when no chat DM pairing channels are configured throws:

```
Channel required. Use --channel <channel> or pass it as the first argument (expected one of: )
```

The empty `(expected one of: )` enum reads like a bug. The deeper UX trap is a **naming collision**: `openclaw pairing` manages *chat DM* pairing, but users reasonably reach for it when trying to approve a **TUI/device or scope-upgrade** request — which actually lives under `openclaw devices`. So they land on an opaque error for a command that was never going to help them.

## Fix

`src/cli/pairing-cli.ts`:
- Guard the supported-channel hint used in help text and error messages so an empty channel list no longer renders a bare `()` / `(expected one of: )` (shows `none configured` instead).
- When no pairing channels are configured, throw an actionable error that redirects to `openclaw devices list` / `openclaw devices approve` rather than failing with an empty enum.

## Tests

`src/cli/pairing-cli.test.ts`:
- `pairing list` with zero configured channels → error mentions `openclaw devices`, never emits `()` or `expected one of: )`, and does not call into the pairing store.
- `pairing list` with multiple channels and no argument → still lists the supported channels (`expected one of: telegram, discord, imessage`).

All 15 tests in the file pass; `oxlint` clean on changed files.

## Notes

- Does not touch `CHANGELOG.md` (per CONTRIBUTING — maintainers/ClawSweeper add entries on landing).
- This is one of a set of fixes for the device scope-upgrade approval flow; the related TUI copy, request-ID churn, and self-approval deadlock are separate PRs.
- 🤖 AI-assisted (Claude Code), authored/reviewed by @RomneyDa.