### PR TITLE
fix(agents): bound body-less MCP HTTP text responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 
 - **Diffs rendering:** render viewer and image output from one SSR preload, preserve language-pack highlighting through hydration, normalize language hints case-insensitively, skip identical before/after inputs with an explicit `changed` result, report truthful file-render and input errors, cache hash-pinned viewer runtimes, and prefer canonical file settings over stale aliases. (#100487)
 - **Remote browser reliability:** bound persistent Playwright tab enumeration by the existing remote CDP timeout budget and retire timed-out connection attempts so late completions cannot restore a stuck connection. (#80147, #58968) Thanks @HemantSudarshan and @KeaneYan.
+- **MCP OAuth response bounds:** avoid unbounded text fallbacks for body-less foreign error responses while preserving status and headers for SDK diagnostics. (#98143) Thanks @Pick-cat.
 - **Control UI approval prompts:** keep stale resolve failures and busy-state cleanup from leaking across newer approvals or Gateway reconnects. (#98394) Thanks @haruaiclone-droid.
 - **Agent empty replies:** surface a visible failure when a completed interactive turn has no deliverable reply, including queued follow-ups, while preserving explicit silence, pending continuations, and committed side effects. (#100456) Thanks @mushuiyu886.
 - **Child process output safety:** prevent stdout/stderr pipe failures from crashing agent exec sessions, local TUI shell commands, and bounded process execution. (#100407, #100406, #100410) Thanks @cxbAsDev.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Docs: https://docs.openclaw.ai
 
 - **Diffs rendering:** render viewer and image output from one SSR preload, preserve language-pack highlighting through hydration, normalize language hints case-insensitively, skip identical before/after inputs with an explicit `changed` result, report truthful file-render and input errors, cache hash-pinned viewer runtimes, and prefer canonical file settings over stale aliases. (#100487)
 - **Remote browser reliability:** bound persistent Playwright tab enumeration by the existing remote CDP timeout budget and retire timed-out connection attempts so late completions cannot restore a stuck connection. (#80147, #58968) Thanks @HemantSudarshan and @KeaneYan.
-- **MCP OAuth response bounds:** avoid unbounded text fallbacks for body-less foreign error responses while preserving status and headers for SDK diagnostics. (#98143) Thanks @Pick-cat.
+- **MCP OAuth response bounds:** reject body-less foreign error bodies without calling their inherently unbounded `text()` fallback, while preserving HTTP status and headers for safe SDK diagnostics. (#98143) Thanks @Pick-cat.
 - **Control UI approval prompts:** keep stale resolve failures and busy-state cleanup from leaking across newer approvals or Gateway reconnects. (#98394) Thanks @haruaiclone-droid.
 - **Agent empty replies:** surface a visible failure when a completed interactive turn has no deliverable reply, including queued follow-ups, while preserving explicit silence, pending continuations, and committed side effects. (#100456) Thanks @mushuiyu886.
 - **Child process output safety:** prevent stdout/stderr pipe failures from crashing agent exec sessions, local TUI shell commands, and bounded process execution. (#100407, #100406, #100410) Thanks @cxbAsDev.

--- a/src/agents/mcp-http-fetch.test.ts
+++ b/src/agents/mcp-http-fetch.test.ts
@@ -33,6 +33,36 @@ class TestProxyAgent {
   constructor(readonly options: unknown) {}
 }
 
+const MAX_FOREIGN_TEXT_BYTES = 1024 * 1024;
+
+function useBodylessForeignResponse(params: { text: string; contentLength?: string }) {
+  const text = vi.fn(async () => params.text);
+  const headers = new Headers({ "content-type": "application/json" });
+  if (params.contentLength !== undefined) {
+    headers.set("content-length", params.contentLength);
+  }
+  testGlobal[TEST_UNDICI_RUNTIME_DEPS_KEY] = {
+    Agent: TestAgent,
+    EnvHttpProxyAgent: TestEnvHttpProxyAgent,
+    ProxyAgent: TestProxyAgent,
+    fetch: async () =>
+      ({
+        status: 400,
+        statusText: "Bad Request",
+        headers,
+        body: null,
+        ok: false,
+        text,
+      }) as unknown as Response,
+  };
+  return text;
+}
+
+async function fetchOAuthRegistrationError(): Promise<Response> {
+  const fetch = buildMcpHttpFetch({ resourceUrl: "https://mcp.example.com/mcp" });
+  return await fetch("https://auth.example.com/oauth/register", { method: "POST" });
+}
+
 function redirectResponse(location: string, status = 302): Response {
   return new Response(null, {
     status,
@@ -214,168 +244,45 @@ describe("MCP HTTP fetch helpers", () => {
 
   it("returns fetch responses compatible with MCP SDK OAuth error parsing", async () => {
     const body = '{"error":"invalid_client_metadata","error_description":"bad redirect"}';
-    class ForeignResponse {
-      status = 400;
-      statusText = "Bad Request";
-      headers = new Headers({
-        "content-length": String(Buffer.byteLength(body, "utf8")),
-        "content-type": "application/json",
-      });
-      body = null;
-      get ok() {
-        return false;
-      }
-      async text() {
-        return body;
-      }
-    }
-
-    testGlobal[TEST_UNDICI_RUNTIME_DEPS_KEY] = {
-      Agent: TestAgent,
-      EnvHttpProxyAgent: TestEnvHttpProxyAgent,
-      ProxyAgent: TestProxyAgent,
-      fetch: async (url: string | URL | Request, init?: unknown) => {
-        fetchCalls.push({ url, init });
-        return new ForeignResponse() as unknown as Response;
-      },
-    };
-    const fetch = buildMcpHttpFetch({
-      resourceUrl: "https://mcp.example.com/mcp",
+    useBodylessForeignResponse({
+      text: body,
+      contentLength: String(Buffer.byteLength(body, "utf8")),
     });
 
-    const response = await fetch("https://auth.example.com/oauth/register", { method: "POST" });
+    const response = await fetchOAuthRegistrationError();
     expect(response).toBeInstanceOf(Response);
     const error = await parseErrorResponse(response);
     expect(error.message).toContain("bad redirect");
     expect(error.message).not.toContain("[object Response]");
   });
 
-  it("drops body-less oversized OAuth error text to avoid OOM", async () => {
-    const text = vi.fn(async () => "x".repeat(1024 * 1024 + 1));
-    class OversizedForeignResponse {
-      status = 400;
-      statusText = "Bad Request";
-      headers = new Headers({
-        "content-length": String(1024 * 1024 + 1),
-        "content-type": "application/json",
-      });
-      body = null;
-      get ok() {
-        return false;
-      }
-      text = text;
-    }
-
-    testGlobal[TEST_UNDICI_RUNTIME_DEPS_KEY] = {
-      Agent: TestAgent,
-      EnvHttpProxyAgent: TestEnvHttpProxyAgent,
-      ProxyAgent: TestProxyAgent,
-      fetch: async () => new OversizedForeignResponse() as unknown as Response,
-    };
-    const fetch = buildMcpHttpFetch({
-      resourceUrl: "https://mcp.example.com/mcp",
+  it.each([
+    { label: "missing length", contentLength: undefined },
+    { label: "exponent length", contentLength: "1e3" },
+    { label: "hex length", contentLength: "0x40" },
+    { label: "oversized length", contentLength: String(MAX_FOREIGN_TEXT_BYTES + 1) },
+  ])("drops body-less OAuth text with $label before reading", async ({ contentLength }) => {
+    const text = useBodylessForeignResponse({
+      text: '{"error_description":"unbounded"}',
+      contentLength,
     });
 
-    const response = await fetch("https://auth.example.com/oauth/register", { method: "POST" });
+    const response = await fetchOAuthRegistrationError();
+
     expect(response).toBeInstanceOf(Response);
     expect(response.status).toBe(400);
     expect(response.body).toBeNull();
     expect(text).not.toHaveBeenCalled();
   });
 
-  it("drops body-less OAuth error text without content length before reading", async () => {
-    const text = vi.fn(async () => '{"error_description":"too large"}');
-    class UnboundedForeignResponse {
-      status = 400;
-      statusText = "Bad Request";
-      headers = new Headers({ "content-type": "application/json" });
-      body = null;
-      get ok() {
-        return false;
-      }
-      text = text;
-    }
-
-    testGlobal[TEST_UNDICI_RUNTIME_DEPS_KEY] = {
-      Agent: TestAgent,
-      EnvHttpProxyAgent: TestEnvHttpProxyAgent,
-      ProxyAgent: TestProxyAgent,
-      fetch: async () => new UnboundedForeignResponse() as unknown as Response,
-    };
-    const fetch = buildMcpHttpFetch({
-      resourceUrl: "https://mcp.example.com/mcp",
+  it("drops body-less text when the returned bytes exceed the declared safe length", async () => {
+    const text = useBodylessForeignResponse({
+      text: "x".repeat(MAX_FOREIGN_TEXT_BYTES + 1),
+      contentLength: "64",
     });
 
-    const response = await fetch("https://auth.example.com/oauth/register", { method: "POST" });
-    expect(response).toBeInstanceOf(Response);
-    expect(response.status).toBe(400);
-    expect(response.body).toBeNull();
-    expect(text).not.toHaveBeenCalled();
-  });
+    const response = await fetchOAuthRegistrationError();
 
-  it.each(["1e3", "0x40"])(
-    "drops body-less OAuth error text with malformed content length %s before reading",
-    async (contentLength) => {
-      const text = vi.fn(async () => '{"error_description":"too large"}');
-      class MalformedLengthForeignResponse {
-        status = 400;
-        statusText = "Bad Request";
-        headers = new Headers({
-          "content-length": contentLength,
-          "content-type": "application/json",
-        });
-        body = null;
-        get ok() {
-          return false;
-        }
-        text = text;
-      }
-
-      testGlobal[TEST_UNDICI_RUNTIME_DEPS_KEY] = {
-        Agent: TestAgent,
-        EnvHttpProxyAgent: TestEnvHttpProxyAgent,
-        ProxyAgent: TestProxyAgent,
-        fetch: async () => new MalformedLengthForeignResponse() as unknown as Response,
-      };
-      const fetch = buildMcpHttpFetch({
-        resourceUrl: "https://mcp.example.com/mcp",
-      });
-
-      const response = await fetch("https://auth.example.com/oauth/register", { method: "POST" });
-      expect(response).toBeInstanceOf(Response);
-      expect(response.status).toBe(400);
-      expect(response.body).toBeNull();
-      expect(text).not.toHaveBeenCalled();
-    },
-  );
-
-  it("drops body-less text when declared content length is smaller than returned text", async () => {
-    const text = vi.fn(async () => "x".repeat(1024 * 1024 + 1));
-    class LyingForeignResponse {
-      status = 400;
-      statusText = "Bad Request";
-      headers = new Headers({
-        "content-length": "64",
-        "content-type": "application/json",
-      });
-      body = null;
-      get ok() {
-        return false;
-      }
-      text = text;
-    }
-
-    testGlobal[TEST_UNDICI_RUNTIME_DEPS_KEY] = {
-      Agent: TestAgent,
-      EnvHttpProxyAgent: TestEnvHttpProxyAgent,
-      ProxyAgent: TestProxyAgent,
-      fetch: async () => new LyingForeignResponse() as unknown as Response,
-    };
-    const fetch = buildMcpHttpFetch({
-      resourceUrl: "https://mcp.example.com/mcp",
-    });
-
-    const response = await fetch("https://auth.example.com/oauth/register", { method: "POST" });
     expect(response).toBeInstanceOf(Response);
     expect(response.status).toBe(400);
     expect(response.body).toBeNull();

--- a/src/agents/mcp-http-fetch.test.ts
+++ b/src/agents/mcp-http-fetch.test.ts
@@ -33,8 +33,6 @@ class TestProxyAgent {
   constructor(readonly options: unknown) {}
 }
 
-const MAX_FOREIGN_TEXT_BYTES = 1024 * 1024;
-
 function useBodylessForeignResponse(params: { text: string; contentLength?: string }) {
   const text = vi.fn(async () => params.text);
   const headers = new Headers({ "content-type": "application/json" });
@@ -242,42 +240,28 @@ describe("MCP HTTP fetch helpers", () => {
     expect(calls[1]?.[1]?.headers).toBeUndefined();
   });
 
-  it("returns fetch responses compatible with MCP SDK OAuth error parsing", async () => {
-    const body = '{"error":"invalid_client_metadata","error_description":"bad redirect"}';
-    useBodylessForeignResponse({
-      text: body,
-      contentLength: String(Buffer.byteLength(body, "utf8")),
-    });
+  it.each([undefined, "64", "1048577"])(
+    "drops body-less foreign OAuth text without trusting Content-Length %s",
+    async (contentLength) => {
+      const text = useBodylessForeignResponse({
+        text: '{"error_description":"unbounded"}',
+        contentLength,
+      });
 
-    const response = await fetchOAuthRegistrationError();
-    expect(response).toBeInstanceOf(Response);
-    const error = await parseErrorResponse(response);
-    expect(error.message).toContain("bad redirect");
-    expect(error.message).not.toContain("[object Response]");
-  });
+      const response = await fetchOAuthRegistrationError();
 
-  it.each([
-    { label: "missing length", contentLength: undefined },
-    { label: "exponent length", contentLength: "1e3" },
-    { label: "hex length", contentLength: "0x40" },
-    { label: "oversized length", contentLength: String(MAX_FOREIGN_TEXT_BYTES + 1) },
-  ])("drops body-less OAuth text with $label before reading", async ({ contentLength }) => {
+      expect(response).toBeInstanceOf(Response);
+      expect(response.status).toBe(400);
+      expect(response.body).toBeNull();
+      expect(text).not.toHaveBeenCalled();
+      const error = await parseErrorResponse(response);
+      expect(error.message).toContain("HTTP 400");
+    },
+  );
+
+  it("never materializes a body-less foreign response with a lying safe length", async () => {
     const text = useBodylessForeignResponse({
-      text: '{"error_description":"unbounded"}',
-      contentLength,
-    });
-
-    const response = await fetchOAuthRegistrationError();
-
-    expect(response).toBeInstanceOf(Response);
-    expect(response.status).toBe(400);
-    expect(response.body).toBeNull();
-    expect(text).not.toHaveBeenCalled();
-  });
-
-  it("drops body-less text when the returned bytes exceed the declared safe length", async () => {
-    const text = useBodylessForeignResponse({
-      text: "x".repeat(MAX_FOREIGN_TEXT_BYTES + 1),
+      text: "x".repeat(1024 * 1024 + 1),
       contentLength: "64",
     });
 
@@ -286,6 +270,6 @@ describe("MCP HTTP fetch helpers", () => {
     expect(response).toBeInstanceOf(Response);
     expect(response.status).toBe(400);
     expect(response.body).toBeNull();
-    expect(text).toHaveBeenCalledOnce();
+    expect(text).not.toHaveBeenCalled();
   });
 });

--- a/src/agents/mcp-http-fetch.test.ts
+++ b/src/agents/mcp-http-fetch.test.ts
@@ -313,6 +313,42 @@ describe("MCP HTTP fetch helpers", () => {
     expect(text).not.toHaveBeenCalled();
   });
 
+  it.each(["1e3", "0x40"])(
+    "drops body-less OAuth error text with malformed content length %s before reading",
+    async (contentLength) => {
+      const text = vi.fn(async () => '{"error_description":"too large"}');
+      class MalformedLengthForeignResponse {
+        status = 400;
+        statusText = "Bad Request";
+        headers = new Headers({
+          "content-length": contentLength,
+          "content-type": "application/json",
+        });
+        body = null;
+        get ok() {
+          return false;
+        }
+        text = text;
+      }
+
+      testGlobal[TEST_UNDICI_RUNTIME_DEPS_KEY] = {
+        Agent: TestAgent,
+        EnvHttpProxyAgent: TestEnvHttpProxyAgent,
+        ProxyAgent: TestProxyAgent,
+        fetch: async () => new MalformedLengthForeignResponse() as unknown as Response,
+      };
+      const fetch = buildMcpHttpFetch({
+        resourceUrl: "https://mcp.example.com/mcp",
+      });
+
+      const response = await fetch("https://auth.example.com/oauth/register", { method: "POST" });
+      expect(response).toBeInstanceOf(Response);
+      expect(response.status).toBe(400);
+      expect(response.body).toBeNull();
+      expect(text).not.toHaveBeenCalled();
+    },
+  );
+
   it("drops body-less text when declared content length is smaller than returned text", async () => {
     const text = vi.fn(async () => "x".repeat(1024 * 1024 + 1));
     class LyingForeignResponse {

--- a/src/agents/mcp-http-fetch.test.ts
+++ b/src/agents/mcp-http-fetch.test.ts
@@ -213,16 +213,20 @@ describe("MCP HTTP fetch helpers", () => {
   });
 
   it("returns fetch responses compatible with MCP SDK OAuth error parsing", async () => {
+    const body = '{"error":"invalid_client_metadata","error_description":"bad redirect"}';
     class ForeignResponse {
       status = 400;
       statusText = "Bad Request";
-      headers = new Headers({ "content-type": "application/json" });
+      headers = new Headers({
+        "content-length": String(Buffer.byteLength(body, "utf8")),
+        "content-type": "application/json",
+      });
       body = null;
       get ok() {
         return false;
       }
       async text() {
-        return '{"error":"invalid_client_metadata","error_description":"bad redirect"}';
+        return body;
       }
     }
 
@@ -247,17 +251,19 @@ describe("MCP HTTP fetch helpers", () => {
   });
 
   it("drops body-less oversized OAuth error text to avoid OOM", async () => {
+    const text = vi.fn(async () => "x".repeat(1024 * 1024 + 1));
     class OversizedForeignResponse {
       status = 400;
       statusText = "Bad Request";
-      headers = new Headers({ "content-type": "application/json" });
+      headers = new Headers({
+        "content-length": String(1024 * 1024 + 1),
+        "content-type": "application/json",
+      });
       body = null;
       get ok() {
         return false;
       }
-      async text() {
-        return "x".repeat(1024 * 1024 + 1);
-      }
+      text = text;
     }
 
     testGlobal[TEST_UNDICI_RUNTIME_DEPS_KEY] = {
@@ -274,5 +280,36 @@ describe("MCP HTTP fetch helpers", () => {
     expect(response).toBeInstanceOf(Response);
     expect(response.status).toBe(400);
     expect(response.body).toBeNull();
+    expect(text).not.toHaveBeenCalled();
+  });
+
+  it("drops body-less OAuth error text without content length before reading", async () => {
+    const text = vi.fn(async () => '{"error_description":"too large"}');
+    class UnboundedForeignResponse {
+      status = 400;
+      statusText = "Bad Request";
+      headers = new Headers({ "content-type": "application/json" });
+      body = null;
+      get ok() {
+        return false;
+      }
+      text = text;
+    }
+
+    testGlobal[TEST_UNDICI_RUNTIME_DEPS_KEY] = {
+      Agent: TestAgent,
+      EnvHttpProxyAgent: TestEnvHttpProxyAgent,
+      ProxyAgent: TestProxyAgent,
+      fetch: async () => new UnboundedForeignResponse() as unknown as Response,
+    };
+    const fetch = buildMcpHttpFetch({
+      resourceUrl: "https://mcp.example.com/mcp",
+    });
+
+    const response = await fetch("https://auth.example.com/oauth/register", { method: "POST" });
+    expect(response).toBeInstanceOf(Response);
+    expect(response.status).toBe(400);
+    expect(response.body).toBeNull();
+    expect(text).not.toHaveBeenCalled();
   });
 });

--- a/src/agents/mcp-http-fetch.test.ts
+++ b/src/agents/mcp-http-fetch.test.ts
@@ -245,4 +245,34 @@ describe("MCP HTTP fetch helpers", () => {
     expect(error.message).toContain("bad redirect");
     expect(error.message).not.toContain("[object Response]");
   });
+
+  it("drops body-less oversized OAuth error text to avoid OOM", async () => {
+    class OversizedForeignResponse {
+      status = 400;
+      statusText = "Bad Request";
+      headers = new Headers({ "content-type": "application/json" });
+      body = null;
+      get ok() {
+        return false;
+      }
+      async text() {
+        return "x".repeat(1024 * 1024 + 1);
+      }
+    }
+
+    testGlobal[TEST_UNDICI_RUNTIME_DEPS_KEY] = {
+      Agent: TestAgent,
+      EnvHttpProxyAgent: TestEnvHttpProxyAgent,
+      ProxyAgent: TestProxyAgent,
+      fetch: async () => new OversizedForeignResponse() as unknown as Response,
+    };
+    const fetch = buildMcpHttpFetch({
+      resourceUrl: "https://mcp.example.com/mcp",
+    });
+
+    const response = await fetch("https://auth.example.com/oauth/register", { method: "POST" });
+    expect(response).toBeInstanceOf(Response);
+    expect(response.status).toBe(400);
+    expect(response.body).toBeNull();
+  });
 });

--- a/src/agents/mcp-http-fetch.test.ts
+++ b/src/agents/mcp-http-fetch.test.ts
@@ -312,4 +312,37 @@ describe("MCP HTTP fetch helpers", () => {
     expect(response.body).toBeNull();
     expect(text).not.toHaveBeenCalled();
   });
+
+  it("drops body-less text when declared content length is smaller than returned text", async () => {
+    const text = vi.fn(async () => "x".repeat(1024 * 1024 + 1));
+    class LyingForeignResponse {
+      status = 400;
+      statusText = "Bad Request";
+      headers = new Headers({
+        "content-length": "64",
+        "content-type": "application/json",
+      });
+      body = null;
+      get ok() {
+        return false;
+      }
+      text = text;
+    }
+
+    testGlobal[TEST_UNDICI_RUNTIME_DEPS_KEY] = {
+      Agent: TestAgent,
+      EnvHttpProxyAgent: TestEnvHttpProxyAgent,
+      ProxyAgent: TestProxyAgent,
+      fetch: async () => new LyingForeignResponse() as unknown as Response,
+    };
+    const fetch = buildMcpHttpFetch({
+      resourceUrl: "https://mcp.example.com/mcp",
+    });
+
+    const response = await fetch("https://auth.example.com/oauth/register", { method: "POST" });
+    expect(response).toBeInstanceOf(Response);
+    expect(response.status).toBe(400);
+    expect(response.body).toBeNull();
+    expect(text).toHaveBeenCalledOnce();
+  });
 });

--- a/src/agents/mcp-http-fetch.ts
+++ b/src/agents/mcp-http-fetch.ts
@@ -27,11 +27,6 @@ const fetchWithUndiciGuard = async (
 
 const MCP_HTTP_MAX_REDIRECTS = 20;
 const MCP_HTTP_MAX_TEXT_RESPONSE_BYTES = 1024 * 1024;
-const managedMcpResponseCleanupRegistry = new FinalizationRegistry<{
-  finalize: () => Promise<void>;
-}>((held) => {
-  void held.finalize();
-});
 
 function resolveFetchRequest(input: RequestInfo | URL, init?: RequestInit) {
   if (input instanceof Request) {

--- a/src/agents/mcp-http-fetch.ts
+++ b/src/agents/mcp-http-fetch.ts
@@ -26,6 +26,12 @@ const fetchWithUndiciGuard = async (
 ): Promise<Response> => await fetchWithUndici(input instanceof Request ? input.url : input, init);
 
 const MCP_HTTP_MAX_REDIRECTS = 20;
+const MCP_HTTP_MAX_TEXT_RESPONSE_BYTES = 1024 * 1024;
+const managedMcpResponseCleanupRegistry = new FinalizationRegistry<{
+  finalize: () => Promise<void>;
+}>((held) => {
+  void held.finalize();
+});
 
 function resolveFetchRequest(input: RequestInfo | URL, init?: RequestInit) {
   if (input instanceof Request) {
@@ -62,7 +68,17 @@ async function ensureGlobalFetchResponse(response: Response): Promise<Response> 
     return new Response(null, init);
   }
   if (typeof response.text === "function") {
+    const contentLength = response.headers.get("content-length");
+    if (contentLength) {
+      const size = Number(contentLength);
+      if (Number.isSafeInteger(size) && size > MCP_HTTP_MAX_TEXT_RESPONSE_BYTES) {
+        return new Response(null, init);
+      }
+    }
     const text = await response.text();
+    if (text.length > MCP_HTTP_MAX_TEXT_RESPONSE_BYTES) {
+      return new Response(null, init);
+    }
     return new Response(text, init);
   }
   return new Response(null, init);

--- a/src/agents/mcp-http-fetch.ts
+++ b/src/agents/mcp-http-fetch.ts
@@ -72,6 +72,8 @@ async function ensureGlobalFetchResponse(response: Response): Promise<Response> 
     if (contentLengthBytes === null || contentLengthBytes > MCP_HTTP_MAX_TEXT_RESPONSE_BYTES) {
       return new Response(null, init);
     }
+    // Bodyless foreign responses only expose text(); trust Content-Length to avoid
+    // no-size reads, then verify the returned UTF-8 size before preserving it.
     const text = await response.text();
     if (Buffer.byteLength(text, "utf8") > MCP_HTTP_MAX_TEXT_RESPONSE_BYTES) {
       return new Response(null, init);

--- a/src/agents/mcp-http-fetch.ts
+++ b/src/agents/mcp-http-fetch.ts
@@ -87,7 +87,11 @@ function parseSafeContentLength(value: string | null): number | null {
   if (!value) {
     return null;
   }
-  const size = Number(value);
+  const trimmed = value.trim();
+  if (!/^\d+$/.test(trimmed)) {
+    return null;
+  }
+  const size = Number(trimmed);
   return Number.isSafeInteger(size) && size >= 0 ? size : null;
 }
 

--- a/src/agents/mcp-http-fetch.ts
+++ b/src/agents/mcp-http-fetch.ts
@@ -26,7 +26,6 @@ const fetchWithUndiciGuard = async (
 ): Promise<Response> => await fetchWithUndici(input instanceof Request ? input.url : input, init);
 
 const MCP_HTTP_MAX_REDIRECTS = 20;
-const MCP_HTTP_MAX_TEXT_RESPONSE_BYTES = 1024 * 1024;
 
 function resolveFetchRequest(input: RequestInfo | URL, init?: RequestInit) {
   if (input instanceof Request) {
@@ -62,32 +61,9 @@ async function ensureGlobalFetchResponse(response: Response): Promise<Response> 
   if (response.status === 204 || response.status === 205 || response.status === 304) {
     return new Response(null, init);
   }
-  if (typeof response.text === "function") {
-    const contentLengthBytes = parseSafeContentLength(response.headers.get("content-length"));
-    if (contentLengthBytes === null || contentLengthBytes > MCP_HTTP_MAX_TEXT_RESPONSE_BYTES) {
-      return new Response(null, init);
-    }
-    // Bodyless foreign responses only expose text(); trust Content-Length to avoid
-    // no-size reads, then verify the returned UTF-8 size before preserving it.
-    const text = await response.text();
-    if (Buffer.byteLength(text, "utf8") > MCP_HTTP_MAX_TEXT_RESPONSE_BYTES) {
-      return new Response(null, init);
-    }
-    return new Response(text, init);
-  }
+  // A body-less foreign Response exposes no bounded reader. Calling text() or
+  // arrayBuffer() can allocate an attacker-controlled body before any cap applies.
   return new Response(null, init);
-}
-
-function parseSafeContentLength(value: string | null): number | null {
-  if (!value) {
-    return null;
-  }
-  const trimmed = value.trim();
-  if (!/^\d+$/.test(trimmed)) {
-    return null;
-  }
-  const size = Number(trimmed);
-  return Number.isSafeInteger(size) && size >= 0 ? size : null;
 }
 
 async function buildManagedMcpResponse(

--- a/src/agents/mcp-http-fetch.ts
+++ b/src/agents/mcp-http-fetch.ts
@@ -68,20 +68,25 @@ async function ensureGlobalFetchResponse(response: Response): Promise<Response> 
     return new Response(null, init);
   }
   if (typeof response.text === "function") {
-    const contentLength = response.headers.get("content-length");
-    if (contentLength) {
-      const size = Number(contentLength);
-      if (Number.isSafeInteger(size) && size > MCP_HTTP_MAX_TEXT_RESPONSE_BYTES) {
-        return new Response(null, init);
-      }
+    const contentLengthBytes = parseSafeContentLength(response.headers.get("content-length"));
+    if (contentLengthBytes === null || contentLengthBytes > MCP_HTTP_MAX_TEXT_RESPONSE_BYTES) {
+      return new Response(null, init);
     }
     const text = await response.text();
-    if (text.length > MCP_HTTP_MAX_TEXT_RESPONSE_BYTES) {
+    if (Buffer.byteLength(text, "utf8") > MCP_HTTP_MAX_TEXT_RESPONSE_BYTES) {
       return new Response(null, init);
     }
     return new Response(text, init);
   }
   return new Response(null, init);
+}
+
+function parseSafeContentLength(value: string | null): number | null {
+  if (!value) {
+    return null;
+  }
+  const size = Number(value);
+  return Number.isSafeInteger(size) && size >= 0 ? size : null;
 }
 
 async function buildManagedMcpResponse(


### PR DESCRIPTION
## What Problem This Solves

The MCP HTTP wrapper converted body-less foreign `Response` implementations by calling `text()`. That API materializes the complete remote body before OpenClaw can enforce a byte limit, so a hostile or compressed OAuth error response could exhaust memory.

Closes #97521.

## Why This Change Was Made

This takes the issue's fail-closed policy option. A body-less foreign response has no genuinely bounded reader: `Content-Length` is remote-controlled and can describe compressed wire bytes rather than decoded text. The wrapper now preserves status and headers but never calls `text()` or `arrayBuffer()` for that shape. Normal responses with readable body streams are unchanged.

The test rewrite removes repetitive response classes and covers missing, plausible, oversized, and dishonest `Content-Length` values. MCP SDK source was checked directly: `parseErrorResponse` reads the global `Response.text()`, so the synthesized empty body still produces a useful HTTP-status diagnostic without touching the foreign unbounded method.

## User Impact

Malformed/nonconforming body-less MCP OAuth responses now report a generic status-based OAuth error instead of preserving their raw error text. This is intentional: it removes the memory-exhaustion path while retaining status and headers. Standards-compliant streamed responses retain full error parsing.

## Evidence

- Blacksmith Testbox `tbx_01kwt6qx4r4ptdbg4ps3yhnj55`: `src/agents/mcp-http-fetch.test.ts`, 13/13 passed.
- Remote `oxfmt --check` passed for the changed source, tests, and changelog.
- Fresh full-diff autoreview after the fail-closed rewrite: no actionable findings, confidence 0.94.
- `git diff --check` passed.

No docs change is needed; the Unreleased changelog entry is included.
