### PR TITLE
fix(cli): explain how to recover from device approve deadlock

### DIFF
--- a/src/cli/devices-cli.runtime.ts
+++ b/src/cli/devices-cli.runtime.ts
@@ -308,7 +308,6 @@ function isDevicePairingApprovalDenied(error: unknown): boolean {
   );
 }
 
-<<<<<<< HEAD
 function isUnknownRequestIdError(error: unknown): boolean {
   const maybeGatewayError =
     typeof error === "object" && error !== null
@@ -323,26 +322,10 @@ function isUnknownRequestIdError(error: unknown): boolean {
       ? maybeGatewayError.message
       : normalizeErrorMessage(error);
   return normalizeLowercaseStringOrEmpty(message).includes("unknown requestid");
-=======
-// True when an approve failed because the device lacks approval permission, not for a
-// transport or "request not found" reason — i.e. the user needs owner credentials.
-function isApprovalAuthorizationError(error: unknown): boolean {
-  const message = normalizeLowercaseStringOrEmpty(normalizeErrorMessage(error));
-  return (
-    message.includes("scope upgrade pending approval") ||
-    message.includes("device pairing approval denied") ||
-    message.includes("missing scope")
-  );
 }
 
-// Guidance for when a device can't approve its own scope upgrade (needs operator.approvals).
-function formatApprovalDeadlockGuidance(): string {
-  return [
-    "This device can't approve its own scope upgrade (needs the operator.approvals scope).",
-    `Run ${formatCliCommand("openclaw devices list")}, then rerun with --token/--password ` +
-      "(owner credentials) or approve from a device that has it, e.g. the Control UI.",
-  ].join("\n");
->>>>>>> d38578a248f (fix(cli): explain how to recover from device approve deadlock)
+function isScopeUpgradePendingApproval(error: unknown): boolean {
+  return readConnectPairingRequiredMessage(normalizeErrorMessage(error))?.reason === "scope-upgrade";
 }
 
 function resolveLocalPairingFallback(
@@ -1127,35 +1110,23 @@ export async function runDevicesApproveCommand(
   try {
     result = await approvePairingWithFallback(opts, resolvedRequestId);
   } catch (error) {
-    // Auth denial: the device can't approve itself, so show owner-credential
-    // guidance instead of rethrowing the raw, dead-end error.
-    if (isApprovalAuthorizationError(error)) {
-      defaultRuntime.error(normalizeErrorMessage(error));
-      defaultRuntime.error(formatApprovalDeadlockGuidance());
-      const authReminder = formatAuthFlagReminder(opts);
-      if (authReminder) {
-        defaultRuntime.error(authReminder);
-      }
+    if (isScopeUpgradePendingApproval(error)) {
+      defaultRuntime.error(
+        "This device can't approve its own scope upgrade. Retry with owner credentials (--token or --password), or approve it from the Control UI.",
+      );
       defaultRuntime.exit(1);
       return;
     }
     throw error;
   }
   if (!result) {
-<<<<<<< HEAD
-    defaultRuntime.error("unknown requestId");
+    defaultRuntime.error(
+      `No pending device request matches ${sanitizeForLog(resolvedRequestId)}. Run ${formatCliCommand("openclaw devices list")} and retry with the current request ID.`,
+    );
     const nodeApprovalNotices = await findQueryPendingNodeApprovalNotices(opts, resolvedRequestId);
     for (const notice of nodeApprovalNotices) {
       defaultRuntime.error(formatNodeApprovalNotice(notice));
     }
-=======
-    defaultRuntime.error(
-      [
-        `No pending request matches ${sanitizeForLog(resolvedRequestId)} (already approved, expired, or superseded).`,
-        `Run ${formatCliCommand("openclaw devices list")} and approve the latest with ${formatCliCommand("openclaw devices approve --latest")}.`,
-      ].join("\n"),
-    );
->>>>>>> d38578a248f (fix(cli): explain how to recover from device approve deadlock)
     defaultRuntime.exit(1);
     return;
   }

--- a/src/cli/devices-cli.runtime.ts
+++ b/src/cli/devices-cli.runtime.ts
@@ -308,6 +308,7 @@ function isDevicePairingApprovalDenied(error: unknown): boolean {
   );
 }
 
+<<<<<<< HEAD
 function isUnknownRequestIdError(error: unknown): boolean {
   const maybeGatewayError =
     typeof error === "object" && error !== null
@@ -322,6 +323,26 @@ function isUnknownRequestIdError(error: unknown): boolean {
       ? maybeGatewayError.message
       : normalizeErrorMessage(error);
   return normalizeLowercaseStringOrEmpty(message).includes("unknown requestid");
+=======
+// True when an approve failed because the device lacks approval permission, not for a
+// transport or "request not found" reason — i.e. the user needs owner credentials.
+function isApprovalAuthorizationError(error: unknown): boolean {
+  const message = normalizeLowercaseStringOrEmpty(normalizeErrorMessage(error));
+  return (
+    message.includes("scope upgrade pending approval") ||
+    message.includes("device pairing approval denied") ||
+    message.includes("missing scope")
+  );
+}
+
+// Guidance for when a device can't approve its own scope upgrade (needs operator.approvals).
+function formatApprovalDeadlockGuidance(): string {
+  return [
+    "This device can't approve its own scope upgrade (needs the operator.approvals scope).",
+    `Run ${formatCliCommand("openclaw devices list")}, then rerun with --token/--password ` +
+      "(owner credentials) or approve from a device that has it, e.g. the Control UI.",
+  ].join("\n");
+>>>>>>> d38578a248f (fix(cli): explain how to recover from device approve deadlock)
 }
 
 function resolveLocalPairingFallback(
@@ -1102,13 +1123,39 @@ export async function runDevicesApproveCommand(
     defaultRuntime.exit(1);
     return;
   }
-  const result = await approvePairingWithFallback(opts, resolvedRequestId);
+  let result: Record<string, unknown> | null;
+  try {
+    result = await approvePairingWithFallback(opts, resolvedRequestId);
+  } catch (error) {
+    // Auth denial: the device can't approve itself, so show owner-credential
+    // guidance instead of rethrowing the raw, dead-end error.
+    if (isApprovalAuthorizationError(error)) {
+      defaultRuntime.error(normalizeErrorMessage(error));
+      defaultRuntime.error(formatApprovalDeadlockGuidance());
+      const authReminder = formatAuthFlagReminder(opts);
+      if (authReminder) {
+        defaultRuntime.error(authReminder);
+      }
+      defaultRuntime.exit(1);
+      return;
+    }
+    throw error;
+  }
   if (!result) {
+<<<<<<< HEAD
     defaultRuntime.error("unknown requestId");
     const nodeApprovalNotices = await findQueryPendingNodeApprovalNotices(opts, resolvedRequestId);
     for (const notice of nodeApprovalNotices) {
       defaultRuntime.error(formatNodeApprovalNotice(notice));
     }
+=======
+    defaultRuntime.error(
+      [
+        `No pending request matches ${sanitizeForLog(resolvedRequestId)} (already approved, expired, or superseded).`,
+        `Run ${formatCliCommand("openclaw devices list")} and approve the latest with ${formatCliCommand("openclaw devices approve --latest")}.`,
+      ].join("\n"),
+    );
+>>>>>>> d38578a248f (fix(cli): explain how to recover from device approve deadlock)
     defaultRuntime.exit(1);
     return;
   }

--- a/src/cli/devices-cli.runtime.ts
+++ b/src/cli/devices-cli.runtime.ts
@@ -325,7 +325,9 @@ function isUnknownRequestIdError(error: unknown): boolean {
 }
 
 function isScopeUpgradePendingApproval(error: unknown): boolean {
-  return readConnectPairingRequiredMessage(normalizeErrorMessage(error))?.reason === "scope-upgrade";
+  return (
+    readConnectPairingRequiredMessage(normalizeErrorMessage(error))?.reason === "scope-upgrade"
+  );
 }
 
 function resolveLocalPairingFallback(
@@ -1112,7 +1114,7 @@ export async function runDevicesApproveCommand(
   } catch (error) {
     if (isScopeUpgradePendingApproval(error)) {
       defaultRuntime.error(
-        "This device can't approve its own scope upgrade. Retry with owner credentials (--token or --password), or approve it from the Control UI.",
+        "This device can't approve its own scope upgrade. Approve it from the Control UI or another authorized device.",
       );
       defaultRuntime.exit(1);
       return;

--- a/src/cli/devices-cli.test.ts
+++ b/src/cli/devices-cli.test.ts
@@ -1414,7 +1414,7 @@ describe("devices cli local fallback", () => {
     expect(approveDevicePairing).not.toHaveBeenCalled();
   });
 
-  it("surfaces owner-credential guidance when the device can't approve its own upgrade", async () => {
+  it("explains how to approve an upgrade from another device", async () => {
     // Explicit --url disables the loopback local fallback, so the scope-upgrade
     // denial propagates as the authorization error the user must resolve. The
     // first rejection is consumed by the pre-approve context lookup, the second
@@ -1426,8 +1426,10 @@ describe("devices cli local fallback", () => {
 
     const errorOutput = stripAnsi(readRuntimeErrorOutput());
     expect(errorOutput).toContain("can't approve its own scope upgrade");
-    expect(errorOutput).toContain("--token");
     expect(errorOutput).toContain("Control UI");
+    expect(errorOutput).toContain("another authorized device");
+    expect(errorOutput).not.toContain("--token");
+    expect(errorOutput).not.toContain("--password");
     expect(runtime.exit).toHaveBeenCalledWith(1);
   });
 

--- a/src/cli/devices-cli.test.ts
+++ b/src/cli/devices-cli.test.ts
@@ -534,7 +534,7 @@ describe("devices cli approve", () => {
     expectGatewayCall(3, { method: "node.list" });
     expectGatewayCall(4, { method: "device.pair.list" });
     const errorOutput = readRuntimeErrorOutput();
-    expect(errorOutput).toContain("unknown requestId");
+    expect(errorOutput).toContain("No pending device request matches");
     expect(errorOutput).toContain("Node reapproval pending for Colin's S25");
     expect(errorOutput).toContain("openclaw nodes approve node-req-1");
     expect(errorOutput).toContain(
@@ -590,7 +590,7 @@ describe("devices cli approve", () => {
     expectGatewayCall(3, { method: "node.list" });
     expectGatewayCall(4, { method: "device.pair.list" });
     const errorOutput = readRuntimeErrorOutput();
-    expect(errorOutput).toContain("unknown requestId");
+    expect(errorOutput).toContain("No pending device request matches");
     expect(errorOutput).not.toContain("node-req-unrelated");
     expect(errorOutput).not.toContain("openclaw nodes approve");
   });
@@ -634,7 +634,7 @@ describe("devices cli approve", () => {
     expectGatewayCall(2, { method: "node.list" });
     expectGatewayCall(3, { method: "device.pair.list" });
     const errorOutput = readRuntimeErrorOutput();
-    expect(errorOutput).toContain("unknown requestId");
+    expect(errorOutput).toContain("No pending device request matches");
     expect(errorOutput).not.toContain("node-req-display-name");
     expect(errorOutput).not.toContain("openclaw nodes approve");
   });
@@ -1368,7 +1368,7 @@ describe("devices cli local fallback", () => {
     expect(approveDevicePairing).not.toHaveBeenCalled();
   });
 
-  it("keeps unknown requestId behavior when neither the original nor replacement request remains pending", async () => {
+  it("explains how to recover when neither the original nor replacement request remains pending", async () => {
     rejectGatewayForLocalFallback("scope upgrade pending approval (requestId: req-new)");
     rejectGatewayForLocalFallback("scope upgrade pending approval (requestId: req-new)");
     listDevicePairing
@@ -1406,9 +1406,29 @@ describe("devices cli local fallback", () => {
 
     await runDevicesApprove(["req-old"]);
 
-    expect(runtime.error).toHaveBeenCalledWith("unknown requestId");
+    const errorOutput = stripAnsi(readRuntimeErrorOutput());
+    expect(errorOutput).toContain("No pending device request matches req-old");
+    expect(errorOutput).toContain("openclaw devices list");
+    expect(errorOutput).not.toContain("unknown requestId");
     expect(runtime.exit).toHaveBeenCalledWith(1);
     expect(approveDevicePairing).not.toHaveBeenCalled();
+  });
+
+  it("surfaces owner-credential guidance when the device can't approve its own upgrade", async () => {
+    // Explicit --url disables the loopback local fallback, so the scope-upgrade
+    // denial propagates as the authorization error the user must resolve. The
+    // first rejection is consumed by the pre-approve context lookup, the second
+    // by the approve call itself.
+    rejectGatewayForLocalFallback("scope upgrade pending approval (requestId: req-remote)");
+    rejectGatewayForLocalFallback("scope upgrade pending approval (requestId: req-remote)");
+
+    await runDevicesApprove(["req-remote", "--url", "wss://gateway.example.com/ws"]);
+
+    const errorOutput = stripAnsi(readRuntimeErrorOutput());
+    expect(errorOutput).toContain("can't approve its own scope upgrade");
+    expect(errorOutput).toContain("--token");
+    expect(errorOutput).toContain("Control UI");
+    expect(runtime.exit).toHaveBeenCalledWith(1);
   });
 
   it("falls back to local pairing list when gateway returns a scope upgrade message on loopback", async () => {
@@ -1445,14 +1465,16 @@ describe("devices cli local fallback", () => {
     expect(readRuntimeOutput()).not.toContain(fallbackNotice);
   });
 
-  it("keeps unknown requestId behavior instead of approving a different local request", async () => {
+  it("explains recovery instead of approving a different local request", async () => {
     rejectGatewayForLocalFallback("device pairing required (requestId: req-profile)");
     rejectGatewayForLocalFallback("device pairing required (requestId: req-profile)");
 
     await runDevicesApprove(["req-default"]);
 
     expect(approveDevicePairing).not.toHaveBeenCalled();
-    expect(runtime.error).toHaveBeenCalledWith("unknown requestId");
+    const errorOutput = stripAnsi(readRuntimeErrorOutput());
+    expect(errorOutput).toContain("No pending device request matches req-default");
+    expect(errorOutput).toContain("openclaw devices list");
     expect(runtime.exit).toHaveBeenCalledWith(1);
   });
 


### PR DESCRIPTION
## What Problem This Solves

When `openclaw devices approve` cannot complete an approval, two remaining failure modes were unnecessarily hard to recover from:

1. A device connected to an explicit or remote Gateway can request a scope upgrade but cannot approve its own upgrade. The raw `scope upgrade pending approval` error did not explain that approval must come from another authorized device.
2. A request ID that is no longer pending produced only `unknown requestId`.

#98145 fixed request-ID churn for subset reconnects. This PR covers the remaining remote/self-approval and genuinely missing-request cases.

## Why This Change Was Made

- Recognize only the structured scope-upgrade pairing error, rather than treating unrelated authorization denials as self-approval failures.
- Tell the user to approve the upgrade from the Control UI or another authorized device.
- Replace bare `unknown requestId` with a concise `openclaw devices list` recovery step.
- Preserve the newer node-approval recovery added by #98115 when a device request was attempted at the wrong layer.

## User Impact

Users now get short, actionable guidance without weakening approval checks or automatically consuming owner credentials:

- `This device can't approve its own scope upgrade. Approve it from the Control UI or another authorized device.`
- `No pending device request matches <id>. Run openclaw devices list and retry with the current request ID.`

## Evidence

- `node scripts/run-vitest.mjs src/cli/devices-cli.test.ts` — 49 passed.
- `pnpm build` — passed.
- `pnpm check` — passed.
- `.agents/skills/autoreview/scripts/autoreview --mode branch` — clean; no accepted/actionable findings.
- Broad `pnpm test` was also attempted. It failed only in unrelated provider catalog and plugin metadata snapshot suites; the affected devices CLI suite remains green.

🤖 AI-assisted, authored/reviewed by @RomneyDa.
