### PR TITLE
i18n(zh-CN): translate 46 glossary entries and update navigation labels

### DIFF
--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -17,11 +17,11 @@
   },
   {
     "source": "Coming from BlueBubbles",
-    "target": "Coming from BlueBubbles"
+    "target": "从 BlueBubbles 迁移"
   },
   {
     "source": "BlueBubbles removal and the imsg iMessage path",
-    "target": "BlueBubbles removal and the imsg iMessage path"
+    "target": "从 BlueBubbles 迁移到 imsg iMessage"
   },
   {
     "source": "BlueBubbles",
@@ -29,7 +29,7 @@
   },
   {
     "source": "Configuration reference - iMessage",
-    "target": "Configuration reference - iMessage"
+    "target": "iMessage 配置参考"
   },
   {
     "source": "Pairing",
@@ -49,7 +49,7 @@
   },
   {
     "source": "OpenAI provider",
-    "target": "OpenAI provider"
+    "target": "OpenAI Provider"
   },
   {
     "source": "Mantis",
@@ -93,7 +93,7 @@
   },
   {
     "source": "Azure Speech provider",
-    "target": "Azure Speech provider"
+    "target": "Azure Speech Provider"
   },
   {
     "source": "Web tools",
@@ -129,11 +129,11 @@
   },
   {
     "source": "Agent runtimes",
-    "target": "Agent Runtimes"
+    "target": "Agent 运行时"
   },
   {
     "source": "Agent Runtimes",
-    "target": "Agent Runtimes"
+    "target": "Agent 运行时"
   },
   {
     "source": "Code mode",
@@ -141,19 +141,19 @@
   },
   {
     "source": "Codex harness",
-    "target": "Codex harness"
+    "target": "Codex Harness"
   },
   {
     "source": "Codex harness reference",
-    "target": "Codex harness reference"
+    "target": "Codex Harness 参考"
   },
   {
     "source": "Codex harness runtime",
-    "target": "Codex harness runtime"
+    "target": "Codex Harness 运行时"
   },
   {
     "source": "Native Codex plugins",
-    "target": "Native Codex plugins"
+    "target": "Codex 原生插件"
   },
   {
     "source": "Codex Computer Use",
@@ -165,47 +165,47 @@
   },
   {
     "source": "Agent harness plugins",
-    "target": "Agent harness plugins"
+    "target": "Agent Harness 插件"
   },
   {
     "source": "Agent harness plugins (SDK reference)",
-    "target": "Agent harness plugins (SDK reference)"
+    "target": "Agent Harness 插件（SDK 参考）"
   },
   {
     "source": "Copilot SDK harness",
-    "target": "Copilot SDK harness"
+    "target": "Copilot SDK Harness"
   },
   {
     "source": "Copilot plugin",
-    "target": "Copilot plugin"
+    "target": "Copilot 插件"
   },
   {
     "source": "GitHub Copilot agent runtime",
-    "target": "GitHub Copilot agent runtime"
+    "target": "GitHub Copilot Agent 运行时"
   },
   {
     "source": "copilot",
-    "target": "copilot"
+    "target": "Copilot"
   },
   {
     "source": "Agent loop",
-    "target": "Agent loop"
+    "target": "Agent 循环"
   },
   {
     "source": "Steering queue",
-    "target": "Steering queue"
+    "target": "引导队列"
   },
   {
     "source": "Steer",
-    "target": "Steer"
+    "target": "引导"
   },
   {
     "source": "Models",
-    "target": "Models"
+    "target": "模型"
   },
   {
     "source": "Skills",
-    "target": "Skills"
+    "target": "技能"
   },
   {
     "source": "Skills config",
@@ -217,7 +217,7 @@
   },
   {
     "source": "local loopback",
-    "target": "local loopback"
+    "target": "本地回环地址"
   },
   {
     "source": "Tailscale",
@@ -253,7 +253,7 @@
   },
   {
     "source": "Feishu",
-    "target": "Feishu"
+    "target": "飞书（Feishu/Lark）"
   },
   {
     "source": "ClickClack",
@@ -361,7 +361,7 @@
   },
   {
     "source": "NVIDIA API key",
-    "target": "NVIDIA API key"
+    "target": "NVIDIA API Key"
   },
   {
     "source": "Provider directory",
@@ -373,11 +373,11 @@
   },
   {
     "source": "Diffs",
-    "target": "Diffs"
+    "target": "差异对比"
   },
   {
     "source": "Dreaming",
-    "target": "Dreaming"
+    "target": "梦境"
   },
   {
     "source": "Capability Cookbook",
@@ -565,7 +565,7 @@
   },
   {
     "source": "Memory Wiki",
-    "target": "Memory Wiki"
+    "target": "记忆 Wiki"
   },
   {
     "source": "Memory overview",
@@ -589,7 +589,7 @@
   },
   {
     "source": "Heartbeat",
-    "target": "Heartbeat"
+    "target": "心跳"
   },
   {
     "source": "Scheduled tasks",
@@ -601,7 +601,7 @@
   },
   {
     "source": "wiki",
-    "target": "wiki"
+    "target": "Wiki"
   },
   {
     "source": "Polls",
@@ -937,7 +937,7 @@
   },
   {
     "source": "Async Exec Duplicate Completion Investigation",
-    "target": "Async Exec Duplicate Completion Investigation"
+    "target": "Async Exec 重复完成问题调查"
   },
   {
     "source": "QA Refactor",
@@ -961,11 +961,11 @@
   },
   {
     "source": "QA overview",
-    "target": "QA overview"
+    "target": "测试概览"
   },
   {
     "source": "QA channel",
-    "target": "QA channel"
+    "target": "测试频道"
   },
   {
     "source": "Rich Output Protocol",
@@ -981,7 +981,7 @@
   },
   {
     "source": "Codex Harness Context Engine Port",
-    "target": "Codex Harness Context Engine Port"
+    "target": "Codex Harness 上下文引擎移植"
   },
   {
     "source": "Plugin refactor plan",
@@ -1069,7 +1069,7 @@
   },
   {
     "source": "fs-safe Cleanup Plan",
-    "target": "fs-safe Cleanup Plan"
+    "target": "fs-safe 清理计划"
   },
   {
     "source": "Tool Search",
@@ -1101,7 +1101,7 @@
   },
   {
     "source": "Doctor lint mode",
-    "target": "Doctor lint mode"
+    "target": "Doctor lint 模式"
   },
   {
     "source": "ds4 (local DeepSeek V4)",
@@ -1137,7 +1137,7 @@
   },
   {
     "source": "Meeting Notes CLI",
-    "target": "Meeting Notes CLI"
+    "target": "会议纪要 CLI"
   },
   {
     "source": "Discord voice",
@@ -1153,15 +1153,15 @@
   },
   {
     "source": "Agent runtime architecture",
-    "target": "Agent runtime architecture"
+    "target": "Agent 运行时架构"
   },
   {
     "source": "OpenClaw agent runtime workflow",
-    "target": "OpenClaw agent runtime workflow"
+    "target": "OpenClaw Agent 运行时流程"
   },
   {
     "source": "OpenClaw agent runtime architecture",
-    "target": "OpenClaw agent runtime architecture"
+    "target": "OpenClaw Agent 运行时架构"
   },
   {
     "source": "Install and Configure Plugins",
@@ -1169,11 +1169,11 @@
   },
   {
     "source": "Building Plugins",
-    "target": "Building Plugins"
+    "target": "插件开发"
   },
   {
     "source": "Plugin Manifest",
-    "target": "Plugin Manifest"
+    "target": "插件清单"
   },
   {
     "source": "Workboard plugin",
@@ -1181,11 +1181,11 @@
   },
   {
     "source": "workboard",
-    "target": "workboard"
+    "target": "工作看板"
   },
   {
     "source": "Control UI",
-    "target": "Control UI"
+    "target": "控制界面"
   },
   {
     "source": "Models CLI",
@@ -1193,7 +1193,7 @@
   },
   {
     "source": "Z.AI (GLM)",
-    "target": "Z.AI (GLM)"
+    "target": "Z.AI（GLM）"
   },
   {
     "source": "Cohere",
@@ -1205,7 +1205,7 @@
   },
   {
     "source": "cohere",
-    "target": "cohere"
+    "target": "Cohere"
   },
   {
     "source": "Zalo ClawBot",

--- a/docs/.i18n/zh-Hans-navigation.json
+++ b/docs/.i18n/zh-Hans-navigation.json
@@ -6,23 +6,35 @@
       "groups": [
         {
           "group": "首页",
-          "pages": ["zh-CN/index"]
+          "pages": [
+            "zh-CN/index"
+          ]
         },
         {
           "group": "概览",
-          "pages": ["zh-CN/start/showcase"]
+          "pages": [
+            "zh-CN/start/showcase"
+          ]
         },
         {
           "group": "核心概念",
-          "pages": ["zh-CN/concepts/features"]
+          "pages": [
+            "zh-CN/concepts/features"
+          ]
         },
         {
           "group": "第一步",
-          "pages": ["zh-CN/start/getting-started", "zh-CN/start/wizard", "zh-CN/start/onboarding"]
+          "pages": [
+            "zh-CN/start/getting-started",
+            "zh-CN/start/wizard",
+            "zh-CN/start/onboarding"
+          ]
         },
         {
           "group": "指南",
-          "pages": ["zh-CN/start/openclaw"]
+          "pages": [
+            "zh-CN/start/openclaw"
+          ]
         }
       ]
     },
@@ -31,7 +43,10 @@
       "groups": [
         {
           "group": "安装概览",
-          "pages": ["zh-CN/install/index", "zh-CN/install/installer"]
+          "pages": [
+            "zh-CN/install/index",
+            "zh-CN/install/installer"
+          ]
         },
         {
           "group": "安装方式",
@@ -44,7 +59,11 @@
         },
         {
           "group": "维护",
-          "pages": ["zh-CN/install/updating", "zh-CN/install/migrating", "zh-CN/install/uninstall"]
+          "pages": [
+            "zh-CN/install/updating",
+            "zh-CN/install/migrating",
+            "zh-CN/install/uninstall"
+          ]
         },
         {
           "group": "托管与部署",
@@ -62,7 +81,9 @@
         },
         {
           "group": "高级",
-          "pages": ["zh-CN/install/development-channels"]
+          "pages": [
+            "zh-CN/install/development-channels"
+          ]
         }
       ]
     },
@@ -71,7 +92,9 @@
       "groups": [
         {
           "group": "概览",
-          "pages": ["zh-CN/channels/index"]
+          "pages": [
+            "zh-CN/channels/index"
+          ]
         },
         {
           "group": "消息平台",
@@ -112,7 +135,7 @@
       ]
     },
     {
-      "tab": "代理",
+      "tab": "Agent",
       "groups": [
         {
           "group": "基础",
@@ -129,7 +152,9 @@
         },
         {
           "group": "引导",
-          "pages": ["zh-CN/start/bootstrapping"]
+          "pages": [
+            "zh-CN/start/bootstrapping"
+          ]
         },
         {
           "group": "会话与记忆",
@@ -153,8 +178,11 @@
           ]
         },
         {
-          "group": "多代理",
-          "pages": ["zh-CN/concepts/multi-agent", "zh-CN/concepts/presence"]
+          "group": "多Agent",
+          "pages": [
+            "zh-CN/concepts/multi-agent",
+            "zh-CN/concepts/presence"
+          ]
         },
         {
           "group": "消息与投递",
@@ -172,7 +200,9 @@
       "groups": [
         {
           "group": "概览",
-          "pages": ["zh-CN/tools/index"]
+          "pages": [
+            "zh-CN/tools/index"
+          ]
         },
         {
           "group": "内置工具",
@@ -200,7 +230,7 @@
           ]
         },
         {
-          "group": "代理协作",
+          "group": "Agent协作",
           "pages": [
             "zh-CN/tools/agent-send",
             "zh-CN/tools/subagents",
@@ -229,7 +259,10 @@
         },
         {
           "group": "自动化与任务",
-          "pages": ["zh-CN/automation/hooks", "zh-CN/automation/cron-jobs"]
+          "pages": [
+            "zh-CN/automation/hooks",
+            "zh-CN/automation/cron-jobs"
+          ]
         },
         {
           "group": "媒体与设备",
@@ -253,15 +286,23 @@
       "groups": [
         {
           "group": "概览",
-          "pages": ["zh-CN/providers/index", "zh-CN/providers/models"]
+          "pages": [
+            "zh-CN/providers/index",
+            "zh-CN/providers/models"
+          ]
         },
         {
           "group": "模型概念",
-          "pages": ["zh-CN/concepts/models"]
+          "pages": [
+            "zh-CN/concepts/models"
+          ]
         },
         {
           "group": "配置",
-          "pages": ["zh-CN/concepts/model-providers", "zh-CN/concepts/model-failover"]
+          "pages": [
+            "zh-CN/concepts/model-providers",
+            "zh-CN/concepts/model-failover"
+          ]
         },
         {
           "group": "提供商",
@@ -393,11 +434,16 @@
         },
         {
           "group": "运维专题",
-          "pages": ["zh-CN/network", "zh-CN/logging"]
+          "pages": [
+            "zh-CN/network",
+            "zh-CN/logging"
+          ]
         },
         {
           "group": "安全",
-          "pages": ["zh-CN/security/formal-verification"]
+          "pages": [
+            "zh-CN/security/formal-verification"
+          ]
         },
         {
           "group": "Web 界面",
@@ -462,7 +508,10 @@
         },
         {
           "group": "RPC 与 API",
-          "pages": ["zh-CN/reference/rpc", "zh-CN/reference/device-models"]
+          "pages": [
+            "zh-CN/reference/rpc",
+            "zh-CN/reference/device-models"
+          ]
         },
         {
           "group": "模板",
@@ -500,11 +549,16 @@
         },
         {
           "group": "项目",
-          "pages": ["zh-CN/reference/credits"]
+          "pages": [
+            "zh-CN/reference/credits"
+          ]
         },
         {
           "group": "发布策略",
-          "pages": ["zh-CN/reference/RELEASING", "zh-CN/reference/test"]
+          "pages": [
+            "zh-CN/reference/RELEASING",
+            "zh-CN/reference/test"
+          ]
         }
       ]
     },
@@ -513,11 +567,17 @@
       "groups": [
         {
           "group": "帮助",
-          "pages": ["zh-CN/help/index", "zh-CN/help/troubleshooting", "zh-CN/help/faq"]
+          "pages": [
+            "zh-CN/help/index",
+            "zh-CN/help/troubleshooting",
+            "zh-CN/help/faq"
+          ]
         },
         {
           "group": "社区",
-          "pages": ["zh-CN/start/lore"]
+          "pages": [
+            "zh-CN/start/lore"
+          ]
         },
         {
           "group": "环境与调试",
@@ -532,19 +592,30 @@
         },
         {
           "group": "Node 运行时",
-          "pages": ["zh-CN/install/node"]
+          "pages": [
+            "zh-CN/install/node"
+          ]
         },
         {
           "group": "压缩机制内部参考",
-          "pages": ["zh-CN/reference/session-management-compaction"]
+          "pages": [
+            "zh-CN/reference/session-management-compaction"
+          ]
         },
         {
           "group": "开发者设置",
-          "pages": ["zh-CN/start/setup", "zh-CN/pi-dev"]
+          "pages": [
+            "zh-CN/start/setup",
+            "zh-CN/pi-dev"
+          ]
         },
         {
           "group": "文档元信息",
-          "pages": ["zh-CN/start/hubs", "zh-CN/start/docs-directory", "zh-CN/AGENTS"]
+          "pages": [
+            "zh-CN/start/hubs",
+            "zh-CN/start/docs-directory",
+            "zh-CN/AGENTS"
+          ]
         }
       ]
     }

--- a/docs/.i18n/zh-Hans-navigation.json
+++ b/docs/.i18n/zh-Hans-navigation.json
@@ -178,7 +178,7 @@
           ]
         },
         {
-          "group": "多Agent",
+          "group": "多 Agent",
           "pages": [
             "zh-CN/concepts/multi-agent",
             "zh-CN/concepts/presence"
@@ -230,7 +230,7 @@
           ]
         },
         {
-          "group": "Agent协作",
+          "group": "Agent 协作",
           "pages": [
             "zh-CN/tools/agent-send",
             "zh-CN/tools/subagents",


### PR DESCRIPTION
## What Problem This Solves

补全 glossary.zh-CN.json 中 46 条未翻译词条的中文译文，修正部分已有表达，并将导航中易与 "proxy" 混淆的「代理」改为「Agent」。翻译策略：品牌名/产品名/协议名保留英文，通用技术术语中文化。

Translates 46 untranslated glossary entries, improves several existing Chinese translations, and renames navigation labels from "代理" (easily confused with "proxy" in Chinese) to "Agent". Brand/product/protocol names preserved in English; general technical terms localized.

## User Impact

中文用户现在可以在文档和控制界面中看到更完整、更自然的中文表达。导航中的「代理」不再容易和网络代理混淆，改用「Agent」后语义更清晰。

Chinese-speaking users will see more complete and natural Chinese text in documentation and the Control UI. Navigation no longer uses the ambiguous term "代理", replaced with the unambiguous "Agent".

## Evidence

已在本地 Control UI  和 docs.openclaw.ai 文档站上逐条对照过词条的实际出现位置与功能语境，确保翻译准确。
- glossary.zh-CN.json: 46 增 / 46 删
- zh-Hans-navigation.json: 3 处标签变更

All entries were cross-checked against their actual context in the local Control UI and docs.openclaw.ai to ensure accuracy.
- glossary.zh-CN.json: 46 additions / 46 deletions
- zh-Hans-navigation.json: 3 label changes