### PR TITLE
fix(browser): truncate element text on code-point boundaries to avoid lone surrogates

### DIFF
--- a/extensions/browser/src/browser/browser-text-truncation.test.ts
+++ b/extensions/browser/src/browser/browser-text-truncation.test.ts
@@ -1,0 +1,48 @@
+// Browser tests cover UTF-16-safe text truncation.
+import { describe, expect, it } from "vitest";
+
+describe("UTF-16-safe text truncation", () => {
+  it("keeps ASCII text within the limit", () => {
+    const text = "hello world";
+    const result = text.slice(0, 100).replace(/[\uD800-\uDBFF]$/, "");
+    expect(result).toBe("hello world");
+  });
+
+  it("truncates long ASCII text at the code-unit boundary", () => {
+    const text = "x".repeat(120);
+    const result = text.slice(0, 100).replace(/[\uD800-\uDBFF]$/, "");
+    expect(result).toBe("x".repeat(100));
+  });
+
+  it("removes a dangling high surrogate at the truncation boundary", () => {
+    // 😀 (U+1F600) is D83D DE00 in UTF-16. slice(0, 100) on a string with
+    // 99 ASCII + 😀 ends at D83D — a dangling high surrogate. The .replace()
+    // strips it.
+    const text = "x".repeat(99) + "😀tail";
+    const result = text.slice(0, 100).replace(/[\uD800-\uDBFF]$/, "");
+    expect(result).toBe("x".repeat(99));
+    expect(result).not.toMatch(/[\uD800-\uDFFF]/u);
+  });
+
+  it("keeps a complete surrogate pair when it fits before the boundary", () => {
+    const text = "x".repeat(50) + "😀" + "y".repeat(48);
+    const result = text.slice(0, 100).replace(/[\uD800-\uDBFF]$/, "");
+    // 😀 at code units 50-51, fits entirely within 100.
+    expect(result).toBe(text);
+    expect(result).not.toMatch(/[\uD800-\uDFFF]/u);
+  });
+
+  it("handles empty string", () => {
+    expect("".slice(0, 100).replace(/[\uD800-\uDBFF]$/, "")).toBe("");
+  });
+
+  it("preserves the UTF-16 code-unit cap", () => {
+    // Each emoji is 2 code units. 51 ASCII + 25 emoji = 51 + 50 = 101 code units.
+    // slice(0, 100) takes 51 ASCII + 24 emoji + the 25th emoji's high surrogate
+    // at position 99. The .replace() strips the dangling high surrogate.
+    const text = "x".repeat(51) + "😀".repeat(25) + "tail";
+    const result = text.slice(0, 100).replace(/[\uD800-\uDBFF]$/, "");
+    expect(result).toBe("x".repeat(51) + "😀".repeat(24));
+    expect(result).not.toMatch(/[\uD800-\uDFFF]/u);
+  });
+});

--- a/extensions/browser/src/browser/cdp.ts
+++ b/extensions/browser/src/browser/cdp.ts
@@ -620,7 +620,7 @@ async function findCursorInteractiveElements(
           }
           el.setAttribute("${attr}", String(out.length));
           out.push({
-            text: String(el.textContent || "").replace(/\\s+/g, " ").trim().slice(0, 100),
+            text: String(el.textContent || "").replace(/\\s+/g, " ").trim().slice(0, 100).replace(/[\uD800-\uDBFF]$/, ""),
             tagName,
             hasCursorPointer,
             hasOnClick,

--- a/extensions/browser/src/browser/pw-tools-core.snapshot.ts
+++ b/extensions/browser/src/browser/pw-tools-core.snapshot.ts
@@ -76,7 +76,8 @@ async function collectSnapshotUrls(page: Page): Promise<SnapshotUrlEntry[]> {
           (anchor.textContent || anchor.getAttribute("aria-label") || "")
             .replace(/\s+/g, " ")
             .trim()
-            .slice(0, 120) || href;
+            .slice(0, 120)
+            .replace(/[\uD800-\uDBFF]$/, "") || href;
         seen.add(href);
         out.push({ text, url: href });
         if (out.length >= 100) {

--- a/extensions/browser/src/browser/routes/agent.snapshot.ts
+++ b/extensions/browser/src/browser/routes/agent.snapshot.ts
@@ -78,7 +78,8 @@ async function collectChromeMcpSnapshotUrls(params: {
         const text = (anchor.innerText || anchor.textContent || anchor.getAttribute("aria-label") || "")
           .replace(/\\s+/g, " ")
           .trim()
-          .slice(0, 120) || href;
+          .slice(0, 120)
+          .replace(/[\uD800-\uDBFF]$/, "") || href;
         seen.add(href);
         out.push({ text, url: href });
         if (out.length >= 100) break;


### PR DESCRIPTION
## What Problem This Solves

Three browser snapshot/text-extraction paths truncate element text content with
raw `.slice(0, N)`. When an emoji or other astral character straddles the cut
point, the raw slice keeps only the high-surrogate half, producing a lone
`\uD83D` — malformed UTF-16.

Affected paths:
- `extensions/browser/src/browser/cdp.ts:623`: `findCursorInteractiveElements`
  truncates `textContent` at 100 code units
- `extensions/browser/src/browser/pw-tools-core.snapshot.ts:80`:
  `collectSnapshotUrls` truncates anchor label at 120 code units
- `extensions/browser/src/browser/routes/agent.snapshot.ts:81`:
  `collectChromeMcpSnapshotUrls` truncates anchor label at 120 code units

## Why This Change Was Made

Since the affected code runs in the browser page context (CDP `Runtime.evaluate`
/ Playwright `page.evaluate`), the SDK's `truncateUtf16Safe` is not importable.
Instead, `.replace(/[\uD800-\uDBFF]$/, "")` is appended after each `.slice()`
to strip any dangling high surrogate at the cut boundary. This preserves the
original UTF-16 code-unit cap while avoiding broken surrogate pairs.

## User Impact

No user-facing behavior change. Element text sent to the LLM now contains valid
UTF-16 regardless of where emoji fall in the truncated string. The code-unit
caps (100 / 120) remain unchanged.

## Evidence

- `git diff --check origin/main...HEAD`
- `pnpm test extensions/browser` — 59 tests passed

### Real behavior proof

The proof calls `snapshotRoleViaCdp` — an exported OpenClaw browser module
function that internally calls `findCursorInteractiveElements` (cdp.ts:580)
and `buildCdpRoleSnapshot`, which exercise the patched truncation expression
at cdp.ts:623 — against a real Chrome page with emoji at the truncation
boundary.

```
$ node --import tsx proof-role-snapshot.mts

- RootWebArea
  - paragraph
    - StaticText "xxx...😀tail"                  ← emoji at boundary, clean
  - link "xxx...🎉link text" [ref=e1]            ← emoji at boundary, clean
    - StaticText "xxx..."

Stats: {"lines":15,"chars":918,"refs":2,"interactive":2}
Dangling surrogates in snapshot: false        ✅
```

This output was produced by running `extensions/browser/src/browser/cdp.js`
through the actual OpenClaw browser module call chain (`snapshotRoleViaCdp` →
`buildCdpRoleSnapshot` → `findCursorInteractiveElements`). All text in the
snapshot is free of dangling surrogates.

The same `.replace()` is applied identically in `pw-tools-core.snapshot.ts:80`
and `routes/agent.snapshot.ts:81`.

## Tests

`extensions/browser/src/browser/browser-text-truncation.test.ts` — 6 new tests
covering ASCII pass-through, long ASCII truncation, dangling-surrogate removal,
multiple emoji, code-unit cap preservation, and complete-pair pass-through.