### PR TITLE
fix(telegram): prefer current replied photo media

### DIFF
--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -4214,9 +4214,17 @@ describe("createTelegramBot", () => {
     ) as {
       MediaPath?: string;
       MediaPaths?: string[];
+      MediaType?: string;
+      MediaTypes?: string[];
       ReplyToBody?: string;
     };
     expect(payload.ReplyToBody).toBe("<media:image>");
+    expect(payload.MediaPath).toBeTypeOf("string");
+    expect(payload.MediaPath).toContain("/media/inbound/");
+    expect(payload.MediaPaths).toHaveLength(1);
+    expect(payload.MediaPaths?.[0]).toBe(payload.MediaPath);
+    expect(payload.MediaType).toBe("image/png");
+    expect(payload.MediaTypes).toEqual(["image/png"]);
     expect(getFileSpy).toHaveBeenCalledWith("reply-photo-1", expect.any(AbortSignal));
     expect(replyGetFileSignal?.aborted).toBe(true);
     expect(botShutdown.signal.aborted).toBe(false);

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -1845,6 +1845,39 @@ describe("runAgentTurnWithFallback", () => {
     await runPromise;
   });
 
+  it("does not rehydrate stale session media when the followup run already has current images", async () => {
+    const currentImage = { type: "image" as const, data: "current", mimeType: "image/png" };
+    const followupRun = createFollowupRun();
+    followupRun.images = [currentImage];
+    followupRun.imageOrder = ["inline"];
+    state.resolveCurrentTurnImagesMock.mockImplementationOnce(async () => {
+      throw new Error("stale session media should not be rehydrated");
+    });
+    state.runEmbeddedAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "ok" }],
+      meta: {},
+    });
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    await runAgentTurnWithFallback(
+      createMinimalRunAgentTurnParams({
+        followupRun,
+        sessionCtx: {
+          Provider: "telegram",
+          MessageSid: "msg",
+          MediaPaths: ["/tmp/stale.png"],
+          MediaTypes: ["image/png"],
+        } as unknown as TemplateContext,
+      }),
+    );
+
+    expect(state.resolveCurrentTurnImagesMock).not.toHaveBeenCalled();
+    expectMockCallArgFields(state.runEmbeddedAgentMock, 0, "embedded run params", {
+      images: [currentImage],
+      imageOrder: ["inline"],
+    });
+  });
+
   it("clears run ownership when image preflight fails", async () => {
     const agentEvents = await import("../../infra/agent-events.js");
     const clearAgentRunContext = vi.mocked(agentEvents.clearAgentRunContext);

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1600,14 +1600,22 @@ async function runAgentTurnWithFallbackInternal(
           requesterSenderE164: params.followupRun.run.senderE164,
         }),
       );
-    currentTurnImages = await agentTurnTiming.measure("current_turn_images", () =>
-      resolveCurrentTurnImages({
-        ctx: params.sessionCtx,
-        cfg: runtimeConfig,
-        images: params.followupRun.images ?? params.opts?.images,
-        imageOrder: params.followupRun.imageOrder ?? params.opts?.imageOrder,
-      }),
-    );
+    const preparedTurnImages = params.followupRun.images ?? params.opts?.images;
+    const preparedTurnImageOrder = params.followupRun.imageOrder ?? params.opts?.imageOrder;
+    currentTurnImages =
+      preparedTurnImages && preparedTurnImages.length > 0
+        ? {
+            images: preparedTurnImages,
+            imageOrder: preparedTurnImageOrder,
+          }
+        : await agentTurnTiming.measure("current_turn_images", () =>
+            resolveCurrentTurnImages({
+              ctx: params.sessionCtx,
+              cfg: runtimeConfig,
+              images: preparedTurnImages,
+              imageOrder: preparedTurnImageOrder,
+            }),
+          );
   } catch (error) {
     clearAgentRunContext(runId, lifecycleGeneration);
     throw error;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Telegram users replying with text to a photo could have native image input use older session media instead of the current replied photo.

## Why This Change Was Made

The reply runner now trusts images already prepared for the current turn before falling back to session media hydration. Telegram reply-photo handling is also covered by tests that verify text replies to photos carry `MediaPath`, `MediaPaths`, `MediaType`, and `MediaTypes` into the reply context.

## User Impact

When a Telegram user replies to a photo, the agent should inspect the current replied photo rather than an older image from the same session.

## Evidence

- `node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-execution.test.ts src/auto-reply/reply/current-turn-images.test.ts` passed: 219 tests.
- `node scripts/run-vitest.mjs extensions/telegram/src/bot.test.ts -t "reply media"` passed: 12 focused tests.
- `git diff --check` passed.
- Autoreview was attempted but blocked by local Codex auth: `token_invalidated` / refresh token revoked.

Privacy: no screenshots, raw chat logs, real event text, account identifiers, chat identifiers, or OCR output are included. Tests use synthetic media names and neutral fixture text only.
