### PR TITLE
fix(agents): classify Anthropic orphaned tool-use replay errors

### DIFF
--- a/src/auto-reply/reply/provider-request-error-classifier.test.ts
+++ b/src/auto-reply/reply/provider-request-error-classifier.test.ts
@@ -113,6 +113,10 @@ describe("provider request error classifier", () => {
       "local replay invariant guard",
       "invalid_replay_transcript: OpenAI Responses replay contains dangling_tool_call toolCallId=call_1 at message index 4",
     ],
+    [
+      "Anthropic orphaned tool_use replay",
+      "messages.1: `tool_use` ids were found without `tool_result` blocks immediately after: toolu_01A09q90qw90lq917835lq9. Each `tool_use` block must have a corresponding `tool_result` block in the next message.",
+    ],
   ])("classifies %s as provider conversation-state errors", (_label, message) => {
     expect(classifyProviderRequestError(new Error(message))).toEqual({
       code: "provider_conversation_state_error",
@@ -123,6 +127,16 @@ describe("provider request error classifier", () => {
 
   it("leaves bare no-body 400 provider failures unclassified", () => {
     expect(classifyProviderRequestError(new Error("400 status code (no body)"))).toBeUndefined();
+  });
+
+  it("does not classify generic tool_use/tool_result mentions without the orphan signal", () => {
+    // Both block names appear but there is no "without" orphan signal, so this
+    // generic guidance text must not trip the conversation-state classifier.
+    expect(
+      classifyProviderRequestError(
+        new Error("Each tool_use block must have a corresponding tool_result block."),
+      ),
+    ).toBeUndefined();
   });
 
   it("leaves explicit HTTP 429 rate-limit failures on the existing rate-limit path", () => {

--- a/src/auto-reply/reply/provider-request-error-classifier.ts
+++ b/src/auto-reply/reply/provider-request-error-classifier.ts
@@ -105,6 +105,10 @@ export function isProviderConversationStateErrorMessage(message: string): boolea
       lower.includes("tooluse") &&
       lower.includes("exceeds the number") &&
       lower.includes("previous turn")) ||
+    // Anthropic/Bedrock orphaned tool-call replay: "`tool_use` ids were found
+    // without `tool_result` blocks immediately after: ...". Same broken-turn
+    // shape as the toolResult/toolUse count mismatch above, just snake_case.
+    (lower.includes("tool_use") && lower.includes("tool_result") && lower.includes("without")) ||
     lower.includes("function call turn comes immediately after") ||
     lower.includes("incorrect role information") ||
     lower.includes("roles must alternate") ||


### PR DESCRIPTION
## What Problem This Solves

When Anthropic (and Bedrock-on-Anthropic) rejects a request because the conversation has an orphaned tool call, the API returns a 400 whose message reads:

```
`tool_use` ids were found without `tool_result` blocks immediately after: ...
```

The user gets a generic failure with no guidance. Other provider conversation-state rejections that share the same broken-turn shape — OpenAI's missing custom tool output, Bedrock's toolResult/toolUse count mismatch, Gemini's function-call ordering, and role-alternation errors — already surface a recovery hint telling the user to retry or start a fresh session. This one phrasing was not recognized, so the same class of error produced an unhelpful message instead.

## Why This Change Was Made

`isProviderConversationStateErrorMessage` in `src/auto-reply/reply/provider-request-error-classifier.ts` is the single place that recognizes provider-side broken conversation and tool-turn state, but it only matched the camelCase Bedrock count-mismatch wording. This adds one narrow clause that matches when the error text contains all of `tool_use`, `tool_result`, and `without` together, routing the Anthropic orphaned-tool-call 400 through the existing `provider_conversation_state_error` path. Requiring all three tokens — with `without` as the orphan signal — keeps generic prose that merely names both block types from matching. The change is limited to that classifier function: it adds no new error code, no recovery copy, and no provider behavior; the user-facing message and recovery flow are the ones that already exist for this category.

## User Impact

When this specific provider rejection occurs, `openclaw` users now see the existing conversation-state guidance — "The model provider rejected the conversation state. Please try again, or use /new to start a fresh session." — instead of a generic failure, so the actionable next step is clear. No other classification, message, or behavior changes.

## Evidence

**Real production-path invocation (no mocks).** A Node/tsx script imports the exported `classifyProviderRequestError` and `PROVIDER_CONVERSATION_STATE_ERROR_USER_MESSAGE` directly from `src/auto-reply/reply/provider-request-error-classifier.ts`, constructs a real `Error` carrying the Anthropic-style orphaned-tool-call rejection text, and prints the routed result. Redacted terminal output (the `toolu_…` id is synthetic and redacted; no user content or secrets are present):

```
input Error.message = "messages.57: `tool_use` ids were found without `tool_result` blocks immediately after: toolu_01<redacted>. Each `tool_use` block must have a corresponding `tool_result` block in the next message."
----------------------------------------------------------------
classifyProviderRequestError(err).code        = provider_conversation_state_error
classifyProviderRequestError(err).userMessage = "⚠️ The model provider rejected the conversation state. Please try again, or use /new to start a fresh session."
----------------------------------------------------------------
userMessage includes "use /new to start a fresh session" = true
userMessage === PROVIDER_CONVERSATION_STATE_ERROR_USER_MESSAGE = true
```

The real `classifyProviderRequestError` (which internally runs the real `formatErrorMessage` and `isProviderConversationStateErrorMessage`) returns `code: provider_conversation_state_error` and the existing recovery message, confirming the orphaned-tool-call rejection now reaches the "use /new to start a fresh session" guidance.

**Deterministic unit coverage** (`src/auto-reply/reply/provider-request-error-classifier.test.ts`): a verbatim Anthropic-style orphaned-tool-call 400 classifies as `provider_conversation_state_error`, and a generic message naming both block types but without the orphan signal stays unclassified (no over-match). Focused tests: 23 passed. Typecheck clean on the core prod (`tsgo:core`) and core-test (`tsgo:test:src`) lanes; `oxfmt --check` clean on both touched files.

AI-assisted.
