### PR TITLE
fix(gateway): keep Android node surfaces usable after setup-code pairing

### DIFF
--- a/src/gateway/node-connect-reconcile.test.ts
+++ b/src/gateway/node-connect-reconcile.test.ts
@@ -271,4 +271,159 @@ describe("reconcileNodePairingOnConnect", () => {
     expect(result.effectivePermissions).toEqual({ camera: false });
     expect(result.pendingPairing?.request.requestId).toBe("req-downgrade");
   });
+
+  // Regression coverage for openclaw/openclaw#87058 and #97967: an Android
+  // node-connect declaration was being collapsed to an empty effective
+  // surface, leaving an already device-approved Android node permanently
+  // unable to invoke any command (including always-safe commands like
+  // device.info), with no user-facing way to approve the resulting upgrade
+  // request.
+  describe("android node-surface auto-adoption", () => {
+    function makeAndroidNodeConnectParams(overrides?: Partial<ConnectParams>): ConnectParams {
+      return makeNodeConnectParams({
+        client: {
+          id: GATEWAY_CLIENT_IDS.ANDROID_APP,
+          version: "test",
+          platform: "android",
+          deviceFamily: "android",
+          mode: GATEWAY_CLIENT_MODES.NODE,
+        },
+        caps: ["device", "contacts"],
+        commands: ["device.info", "contacts.search"],
+        ...overrides,
+      });
+    }
+
+    it("auto-adopts the declared platform-safe surface on a first-time Android node connect", async () => {
+      const requestPairing = makePendingPairingRequest("req-android-first");
+
+      const result = await reconcileNodePairingOnConnect({
+        cfg: {} as never,
+        connectParams: makeAndroidNodeConnectParams(),
+        pairedNode: null,
+        requestPairing,
+      });
+
+      expect(result.declaredCaps).toEqual(["device", "contacts"]);
+      expect(result.effectiveCaps).toEqual(["device", "contacts"]);
+      expect(result.declaredCommands).toEqual(["device.info", "contacts.search"]);
+      expect(result.effectiveCommands).toEqual(["device.info", "contacts.search"]);
+      // A pending pairing record is still created (for visibility/audit via
+      // `openclaw nodes status`), but it no longer gates the live surface.
+      expect(result.pendingPairing?.request.requestId).toBe("req-android-first");
+    });
+
+    it("auto-adopts versioned first-party Android metadata", async () => {
+      const requestPairing = makePendingPairingRequest("req-android-versioned");
+
+      const result = await reconcileNodePairingOnConnect({
+        cfg: {} as never,
+        connectParams: makeAndroidNodeConnectParams({
+          client: {
+            id: GATEWAY_CLIENT_IDS.ANDROID_APP,
+            version: "test",
+            platform: "Android 16",
+            deviceFamily: "Android",
+            mode: GATEWAY_CLIENT_MODES.NODE,
+          },
+        }),
+        pairedNode: null,
+        requestPairing,
+      });
+
+      expect(result.effectiveCaps).toEqual(["device", "contacts"]);
+      expect(result.effectiveCommands).toEqual(["device.info", "contacts.search"]);
+      expect(result.pendingPairing?.request.requestId).toBe("req-android-versioned");
+    });
+
+    it("does not auto-adopt Android-shaped metadata from a non-Android client id", async () => {
+      const requestPairing = makePendingPairingRequest("req-android-spoof");
+
+      const result = await reconcileNodePairingOnConnect({
+        cfg: {} as never,
+        connectParams: makeAndroidNodeConnectParams({
+          client: {
+            id: GATEWAY_CLIENT_IDS.NODE_HOST,
+            version: "test",
+            platform: "Android 16",
+            deviceFamily: "Android",
+            mode: GATEWAY_CLIENT_MODES.NODE,
+          },
+        }),
+        pairedNode: null,
+        requestPairing,
+      });
+
+      expect(result.declaredCommands).toEqual(["device.info", "contacts.search"]);
+      expect(result.effectiveCaps).toEqual([]);
+      expect(result.effectiveCommands).toEqual([]);
+      expect(result.pendingPairing?.request.requestId).toBe("req-android-spoof");
+    });
+
+    it("does not auto-adopt commands outside the Android platform allowlist", async () => {
+      const requestPairing = makePendingPairingRequest("req-android-unsafe");
+
+      const result = await reconcileNodePairingOnConnect({
+        cfg: {} as never,
+        connectParams: makeAndroidNodeConnectParams({
+          commands: ["device.info", "system.run"],
+        }),
+        pairedNode: null,
+        requestPairing,
+      });
+
+      // system.run is not in the android platform allowlist, so it's dropped
+      // before reconciliation ever sees it -- auto-adoption can't widen the
+      // surface beyond what's already platform-safe.
+      expect(result.declaredCommands).toEqual(["device.info"]);
+      expect(result.effectiveCommands).toEqual(["device.info"]);
+    });
+
+    it("does not auto-adopt an existing empty approved Android node surface", async () => {
+      const requestPairing = makePendingPairingRequest("req-android-empty-upgrade");
+
+      const result = await reconcileNodePairingOnConnect({
+        cfg: {} as never,
+        connectParams: makeAndroidNodeConnectParams(),
+        pairedNode: makePairedNode({
+          nodeId: "openclaw-android",
+          caps: [],
+          commands: [],
+        }),
+        requestPairing,
+      });
+
+      expect(requestPairing).toHaveBeenCalledOnce();
+      expect(result.effectiveCaps).toEqual([]);
+      expect(result.effectiveCommands).toEqual([]);
+      expect(result.shouldClearPendingPairings).toBeUndefined();
+      expect(result.pendingPairing?.request.requestId).toBe("req-android-empty-upgrade");
+    });
+
+    it("still requires explicit reapproval once an Android node has a non-empty approved surface", async () => {
+      const requestPairing = makePendingPairingRequest("req-android-upgrade");
+
+      const result = await reconcileNodePairingOnConnect({
+        cfg: {} as never,
+        connectParams: makeAndroidNodeConnectParams({
+          caps: ["device", "contacts", "calendar"],
+          commands: ["device.info", "contacts.search", "calendar.events"],
+        }),
+        pairedNode: makePairedNode({
+          nodeId: "openclaw-android",
+          caps: ["device"],
+          commands: ["device.info"],
+        }),
+        requestPairing,
+      });
+
+      // Once a real node-surface approval exists, the legacy-migration
+      // shortcut no longer applies: new caps/commands beyond what's already
+      // approved still go through the normal upgrade-approval path.
+      expect(requestPairing).toHaveBeenCalledOnce();
+      expect(result.effectiveCaps).toEqual(["device"]);
+      expect(result.effectiveCommands).toEqual(["device.info"]);
+      expect(result.pendingPairing?.request.requestId).toBe("req-android-upgrade");
+    });
+  });
 });

--- a/src/gateway/node-connect-reconcile.ts
+++ b/src/gateway/node-connect-reconcile.ts
@@ -1,5 +1,9 @@
 // Gateway node connect reconciliation.
 // Computes approved runtime surfaces and pending pairing upgrades on reconnect.
+import {
+  GATEWAY_CLIENT_IDS,
+  GATEWAY_CLIENT_MODES,
+} from "../../packages/gateway-protocol/src/client-info.js";
 import type { ConnectParams } from "../../packages/gateway-protocol/src/index.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
@@ -12,6 +16,7 @@ import type {
   NodePairingRequestInput,
   RequestNodePairingResult,
 } from "../infra/node-pairing.js";
+import { normalizeDeviceMetadataForPolicy } from "./device-metadata-normalization.js";
 import {
   normalizeDeclaredNodeCommands,
   resolveNodeCommandAllowlist,
@@ -55,6 +60,28 @@ function normalizePermissionMap(
     leftKey.localeCompare(rightKey),
   );
   return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}
+
+// Android devices that are already approved at the device-pairing level (role
+// "node") but have no separate, explicit node-surface approval on record would
+// otherwise have their entire declared command/cap surface collapsed to []
+// (see openclaw/openclaw#87058, #97967). For Android specifically, the
+// declared surface is already constrained by a platform-specific allowlist
+// (resolveNodePairingCommandAllowlist / resolveNodeCommandAllowlist /
+// normalizeDeclaredNodeCommands) before it ever reaches this function, so
+// auto-adopting it as the effective surface does not expose any command that
+// isn't already platform-safe or explicitly allowlisted via
+// gateway.nodes.allowCommands. Non-Android node hosts keep the existing
+// explicit node-pairing approval path unchanged.
+function isAndroidNodeConnect(connectParams: ConnectParams): boolean {
+  const platform = normalizeDeviceMetadataForPolicy(connectParams.client.platform);
+  const deviceFamily = normalizeDeviceMetadataForPolicy(connectParams.client.deviceFamily);
+  return (
+    connectParams.client.id === GATEWAY_CLIENT_IDS.ANDROID_APP &&
+    connectParams.client.mode === GATEWAY_CLIENT_MODES.NODE &&
+    /^android(?:\s|$)/.test(platform) &&
+    deviceFamily === "android"
+  );
 }
 
 function intersectApprovalSurfaceList(params: {
@@ -148,14 +175,15 @@ export async function reconcileNodePairingOnConnect(params: {
     if (!pendingPairing) {
       throw new Error("node pairing request required");
     }
+    const isFirstConnectAndroidNode = isAndroidNodeConnect(params.connectParams);
     return {
       nodeId,
       declaredCaps,
-      effectiveCaps: [],
+      effectiveCaps: isFirstConnectAndroidNode ? declaredCaps : [],
       declaredCommands: declared,
-      effectiveCommands: [],
+      effectiveCommands: isFirstConnectAndroidNode ? declared : [],
       declaredPermissions,
-      effectivePermissions: undefined,
+      effectivePermissions: isFirstConnectAndroidNode ? declaredPermissions : undefined,
       pendingPairing,
     };
   }
@@ -170,6 +198,7 @@ export async function reconcileNodePairingOnConnect(params: {
   });
   const approvedCaps = normalizeNodeApprovalSurfaceList(params.pairedNode.caps);
   const approvedPermissions = normalizePermissionMap(params.pairedNode.permissions);
+
   const hasCommandUpgrade = declared.some((command) => !approvedCommands.includes(command));
   const hasCapabilityChange = !sameNodeApprovalSurfaceSet(params.pairedNode.caps, declaredCaps);
   const hasPermissionChange = !sameNodePermissionSurface(

--- a/src/gateway/server.auth.control-ui.suite.ts
+++ b/src/gateway/server.auth.control-ui.suite.ts
@@ -101,6 +101,19 @@ export function registerControlUiAndPairingSuite(): void {
     "x-forwarded-for": "10.0.0.14",
   };
 
+  const ANDROID_NODE_CLIENT = {
+    id: "openclaw-android",
+    version: "2026.6.2",
+    platform: "Android 16",
+    mode: "node" as const,
+    deviceFamily: "Android",
+  };
+
+  const ANDROID_OPERATOR_CLIENT = {
+    ...ANDROID_NODE_CLIENT,
+    mode: "ui" as const,
+  };
+
   const connectSetupCodeBootstrapNode = async (params: {
     identityPrefix: string;
     client: {
@@ -1386,6 +1399,133 @@ export function registerControlUiAndPairingSuite(): void {
       ]);
     },
   );
+
+  test("qr setup code Android node exposes safe commands and handles node.invoke", async () => {
+    const { issueDeviceBootstrapToken } = await import("../infra/device-bootstrap.js");
+    const { server, port, prevToken } = await startControlUiServer("secret");
+    const { identityPath, identity } = await createOperatorIdentityFixture(
+      "openclaw-bootstrap-android-node-invoke-",
+    );
+    const wsNode = await openWs(port, REMOTE_BOOTSTRAP_HEADERS);
+    const wsOperator = await openWs(port, REMOTE_BOOTSTRAP_HEADERS);
+
+    try {
+      const issued = await issueDeviceBootstrapToken();
+      const initial = await connectReq(wsNode, {
+        skipDefaultAuth: true,
+        bootstrapToken: issued.token,
+        role: "node",
+        scopes: [],
+        caps: ["device", "contacts", "camera"],
+        commands: ["device.info", "contacts.search", "camera.snap"],
+        client: ANDROID_NODE_CLIENT,
+        deviceIdentityPath: identityPath,
+      });
+      expect(initial.ok).toBe(true);
+
+      const auth = (
+        initial.payload as
+          | {
+              auth?: {
+                deviceToken?: string;
+                deviceTokens?: Array<{ deviceToken?: string; role?: string; scopes?: string[] }>;
+              };
+            }
+          | undefined
+      )?.auth;
+      expect(auth?.deviceToken).toBeTruthy();
+      const operatorHandoff = auth?.deviceTokens?.find((entry) => entry.role === "operator");
+      const operatorToken = operatorHandoff?.deviceToken;
+      const operatorScopes = operatorHandoff?.scopes ?? [];
+      expect(operatorToken).toBeTruthy();
+      expect(operatorScopes).toContain("operator.read");
+      expect(operatorScopes).toContain("operator.write");
+
+      const operatorConnect = await connectReq(wsOperator, {
+        skipDefaultAuth: true,
+        deviceToken: operatorToken,
+        role: "operator",
+        scopes: operatorScopes,
+        client: ANDROID_OPERATOR_CLIENT,
+        deviceIdentityPath: identityPath,
+      });
+      expect(operatorConnect.ok).toBe(true);
+
+      await expect
+        .poll(async () => {
+          const list = await rpcReq<{
+            nodes?: Array<{
+              nodeId?: string;
+              clientId?: string;
+              commands?: string[];
+              connected?: boolean;
+              paired?: boolean;
+            }>;
+          }>(wsOperator, "node.list", {});
+          const node = list.payload?.nodes?.find((entry) => entry.nodeId === identity.deviceId);
+          return {
+            clientId: node?.clientId,
+            commands: node?.commands?.toSorted() ?? [],
+            connected: node?.connected,
+            paired: node?.paired,
+          };
+        })
+        .toEqual({
+          clientId: "openclaw-android",
+          commands: ["contacts.search", "device.info"],
+          connected: true,
+          paired: true,
+        });
+
+      const invokeResponse = rpcReq<{ payload?: unknown }>(wsOperator, "node.invoke", {
+        nodeId: identity.deviceId,
+        command: "device.info",
+        params: {},
+        timeoutMs: 5_000,
+        idempotencyKey: "android-setup-code-device-info-proof",
+      });
+      const invokeRequest = await onceMessage<{
+        event?: string;
+        payload?: {
+          id?: string;
+          nodeId?: string;
+          command?: string;
+        };
+      }>(wsNode, (msg) => {
+        const event = msg as { event?: string; payload?: { command?: string } };
+        return event.event === "node.invoke.request" && event.payload?.command === "device.info";
+      });
+      expect(invokeRequest.payload?.nodeId).toBe(identity.deviceId);
+
+      const result = await rpcReq(wsNode, "node.invoke.result", {
+        id: invokeRequest.payload?.id ?? "",
+        nodeId: invokeRequest.payload?.nodeId ?? identity.deviceId,
+        ok: true,
+        payloadJSON: JSON.stringify({
+          systemName: "Android",
+          systemVersion: "16",
+          model: "proof-device",
+        }),
+      });
+      expect(result.ok).toBe(true);
+
+      await expect(invokeResponse).resolves.toMatchObject({
+        ok: true,
+        payload: {
+          payload: {
+            systemName: "Android",
+            systemVersion: "16",
+            model: "proof-device",
+          },
+        },
+      });
+    } finally {
+      wsNode.close();
+      wsOperator.close();
+      await server.close();
+      restoreGatewayToken(prevToken);
+    }
+  });
 
   test.each([
     {


### PR DESCRIPTION
Related: #87058
Related: #97967

## What Problem This Solves

Fixes an issue where users pairing the Android app as a node through setup-code/device pairing could end up with a paired node whose safe declared command surface was collapsed to empty, leaving Android commands like `device.info` unavailable and `node.invoke` failing with "node did not declare any supported commands."

This covers the Android node-surface half of #87058. The separate Android onboarding connect-nonce retry race remains out of scope.

## Why This Change Was Made

Android WebSocket nodes already use device pairing as the durable approved `node` role contract, while `node.pair.*` is a separate surface store that does not gate WebSocket connect. For first-time first-party Android node connects, the gateway now uses the already-normalized Android declaration as the effective live surface after the existing platform allowlist has removed non-default or unsafe commands.

The shortcut is intentionally narrow: it requires `openclaw-android`, `node` mode, normalized Android platform metadata, and normalized Android device family. Existing paired node records, including explicit empty command approvals, keep the previous approval-intersection behavior and still require reapproval for upgrades.

## User Impact

Android users who pair through setup-code/device pairing can connect a usable node surface immediately for platform-safe commands such as `device.info` and `contacts.search`, instead of seeing a paired node that cannot invoke any declared command.

Non-Android node hosts and Android nodes with an existing approved surface keep their existing approval boundaries. Dangerous commands such as `camera.snap`, `screen.record`, and `sms.search` remain gated by the existing `gateway.nodes.allowCommands` policy.

## Evidence

AI-assisted: yes. I understand the code change and verified the approval-boundary behavior.

Setup-code runtime proof:

- Added `qr setup code Android node exposes safe commands and handles node.invoke` in `src/gateway/server.auth.control-ui.suite.ts`.
- The test uses a setup-code bootstrap token, connects a first-party `openclaw-android` node with Android metadata, then reconnects the same device identity with the bounded operator handoff token returned by bootstrap.
- It verifies `node.list` reports the Android node connected and paired with non-empty safe commands `contacts.search` and `device.info`.
- It also verifies `camera.snap` is filtered out by the existing platform allowlist and then completes a real gateway `node.invoke device.info` round trip over WebSocket through `node.invoke.request` and `node.invoke.result`.

Local proof:

- `node scripts/run-vitest.mjs src/gateway/server.auth.control-ui.test.ts -- -t "qr setup code Android node exposes safe commands and handles node.invoke"` - passed (2 files, 2 tests; 72 skipped)
- `node scripts/run-vitest.mjs src/gateway/node-connect-reconcile.test.ts src/gateway/node-command-policy.test.ts src/gateway/server.auth.control-ui.test.ts` - passed (10 files, 186 tests)
- `corepack pnpm exec oxfmt --check --threads=1 src/gateway/node-connect-reconcile.ts src/gateway/node-connect-reconcile.test.ts src/gateway/node-command-policy.test.ts src/gateway/server.auth.control-ui.suite.ts` - passed
- `git diff --check` - passed
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed --base upstream/main --head HEAD` - passed
- `hook=$(git rev-parse --git-path hooks/pre-commit); "$hook"` - passed
- `.agents/skills/autoreview/scripts/autoreview --mode local` - clean after addressing one accepted finding; clean again after adding the setup-code runtime proof

Review note:

- Autoreview initially flagged that auto-adopting existing empty paired-node records could silently upgrade an explicit commandless approval. This PR now keeps existing paired records on the explicit reapproval path and adds regression coverage for that case.

Not run:

- Physical Android hardware verification. The PR now includes packaged gateway setup-code proof for the bootstrap-to-`node.invoke` path; #87058/#97967 contain live Android reproduction evidence for the empty-surface symptom.
