### PR TITLE
fix(agents): preserve overload wording for rate-limited responses

### DIFF
--- a/src/agents/embedded-agent-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/embedded-agent-helpers.formatassistanterrortext.test.ts
@@ -71,6 +71,14 @@ describe("formatAssistantErrorText", () => {
       "The AI service is temporarily overloaded. Please try again in a moment.",
     );
   });
+  it("preserves overload wording for Z.AI rate-limit errors", () => {
+    const msg = makeAssistantError(
+      '429 status code (exceeded limit)\n{"code":1305,"message":"The service may be temporarily overloaded, please try again later."}',
+    );
+    expect(formatAssistantErrorText(msg)).toBe(
+      "The AI service is temporarily overloaded. Please try again in a moment.",
+    );
+  });
   it("rewrites generic provider internal errors without support request ids", () => {
     const msg = makeAssistantError(
       "An error occurred while processing your request. You can retry your request, or contact us through our help center at help.openai.com if the error persists. Please include the request ID synthetic-provider-request-001 in your message.",

--- a/src/agents/embedded-agent-helpers/errors.ts
+++ b/src/agents/embedded-agent-helpers/errors.ts
@@ -820,6 +820,12 @@ function classifyFailoverClassificationFromHttpStatus(
     if (message && isBilling429MessageForProvider(message, provider)) {
       return toReasonClassification("billing");
     }
+    // Overloaded 429 bodies (e.g. z.ai code 1305, "temporarily overloaded")
+    // are transient server-side overloads, not per-account rate limits.
+    // 503/499 already check overloaded before defaulting; 429 should too.
+    if (messageReason === "overloaded") {
+      return messageClassification;
+    }
     return toReasonClassification("rate_limit");
   }
   if (status === 401 || status === 403) {
@@ -1063,11 +1069,14 @@ function classifyFailoverClassificationFromMessage(
   if (isPeriodicUsageLimitErrorMessage(raw)) {
     return toReasonClassification(isBillingErrorMessage(raw) ? "billing" : "rate_limit");
   }
-  if (isRateLimitErrorMessage(raw)) {
-    return toReasonClassification("rate_limit");
-  }
+  // Check overloaded BEFORE rate limit: isRateLimitErrorMessage matches the
+  // bare "429" token, so an overloaded-worded 429 body (z.ai code 1305 etc.)
+  // would be misclassified as rate_limit if rate-limit runs first.
   if (isOverloadedErrorMessage(raw)) {
     return toReasonClassification("overloaded");
+  }
+  if (isRateLimitErrorMessage(raw)) {
+    return toReasonClassification("rate_limit");
   }
   if (
     isStructuredServerErrorMessage(raw) &&

--- a/src/agents/embedded-agent-helpers/errors.ts
+++ b/src/agents/embedded-agent-helpers/errors.ts
@@ -820,12 +820,6 @@ function classifyFailoverClassificationFromHttpStatus(
     if (message && isBilling429MessageForProvider(message, provider)) {
       return toReasonClassification("billing");
     }
-    // Overloaded 429 bodies (e.g. z.ai code 1305, "temporarily overloaded")
-    // are transient server-side overloads, not per-account rate limits.
-    // 503/499 already check overloaded before defaulting; 429 should too.
-    if (messageReason === "overloaded") {
-      return messageClassification;
-    }
     return toReasonClassification("rate_limit");
   }
   if (status === 401 || status === 403) {
@@ -1069,14 +1063,11 @@ function classifyFailoverClassificationFromMessage(
   if (isPeriodicUsageLimitErrorMessage(raw)) {
     return toReasonClassification(isBillingErrorMessage(raw) ? "billing" : "rate_limit");
   }
-  // Check overloaded BEFORE rate limit: isRateLimitErrorMessage matches the
-  // bare "429" token, so an overloaded-worded 429 body (z.ai code 1305 etc.)
-  // would be misclassified as rate_limit if rate-limit runs first.
-  if (isOverloadedErrorMessage(raw)) {
-    return toReasonClassification("overloaded");
-  }
   if (isRateLimitErrorMessage(raw)) {
     return toReasonClassification("rate_limit");
+  }
+  if (isOverloadedErrorMessage(raw)) {
+    return toReasonClassification("overloaded");
   }
   if (
     isStructuredServerErrorMessage(raw) &&

--- a/src/agents/embedded-agent-helpers/failover-matches.test.ts
+++ b/src/agents/embedded-agent-helpers/failover-matches.test.ts
@@ -223,4 +223,12 @@ describe("HTTP 429 overload wording (#98101)", () => {
       "The AI service is temporarily overloaded. Please try again in a moment.",
     );
   });
+
+  it("preserves actionable retry details when a rate limit also mentions overload", () => {
+    expect(
+      formatRateLimitOrOverloadedErrorCopy(
+        "429 rate limit: service overloaded, try again in 30 seconds",
+      ),
+    ).toBe("⚠️ rate limit: service overloaded, try again in 30 seconds");
+  });
 });

--- a/src/agents/embedded-agent-helpers/failover-matches.test.ts
+++ b/src/agents/embedded-agent-helpers/failover-matches.test.ts
@@ -212,60 +212,15 @@ describe("generic assistant error text classification (#93931)", () => {
   });
 });
 
-describe("HTTP 429 overloaded vs rate-limit classification (#98101)", () => {
-  // Some providers (z.ai/GLM) return HTTP 429 with an "overloaded" message
-  // body (code 1305, "temporarily overloaded"). This is a transient server-side
-  // overload, not a per-account rate limit — it must be classified as
-  // "overloaded" so the failover path retries instead of falling over.
-
-  it("classifies 429 'temporarily overloaded' as overloaded via message path", () => {
-    const raw =
-      "429 status code (exceeded limit)\n" +
-      '{"code":1305,"message":"The service may be temporarily overloaded, please try again later."}';
-    expect(isOverloadedErrorMessage(raw)).toBe(true);
-    expect(classifyFailoverReason(raw)).toBe("overloaded");
-  });
-
-  it("classifies 429 'overloaded' (bare) as overloaded via message path", () => {
-    const raw = "429 overloaded";
-    expect(isOverloadedErrorMessage(raw)).toBe(true);
-    expect(classifyFailoverReason(raw)).toBe("overloaded");
-  });
-
-  it("classifies 429 overloaded via HTTP status path", () => {
+describe("HTTP 429 overload wording (#98101)", () => {
+  it("keeps Z.AI code 1305 in rate-limit backoff while preserving overload copy", () => {
     const message =
       "429 status code (exceeded limit)\n" +
       '{"code":1305,"message":"The service may be temporarily overloaded, please try again later."}';
-    expect(classifyFailoverReasonFromHttpStatus(429, message)).toBe("overloaded");
-  });
-
-  it("still classifies 429 'rate limit exceeded' as rate_limit via message path", () => {
-    const raw = "429 Rate limit exceeded. Try again in 60s.";
-    expect(isRateLimitErrorMessage(raw)).toBe(true);
-    expect(classifyFailoverReason(raw)).toBe("rate_limit");
-  });
-
-  it("still classifies 429 generic rate-limit as rate_limit via HTTP status path", () => {
-    const message = "429 status code (exceeded limit)\nRate limit exceeded. Try again in 60s.";
+    expect(classifyFailoverReason(message)).toBe("rate_limit");
     expect(classifyFailoverReasonFromHttpStatus(429, message)).toBe("rate_limit");
-  });
-
-  it("still classifies 429 billing as billing via HTTP status path", () => {
-    const message = "429 status code\nInsufficient balance or no resource package.";
-    expect(classifyFailoverReasonFromHttpStatus(429, message)).toBe("billing");
-  });
-
-  it("returns overloaded user-facing copy for 429 overloaded body", () => {
-    const message =
-      "429 status code (exceeded limit)\n" +
-      '{"code":1305,"message":"The service may be temporarily overloaded, please try again later."}';
-    const copy = formatRateLimitOrOverloadedErrorCopy(message);
-    expect(copy).toBe("The AI service is temporarily overloaded. Please try again in a moment.");
-  });
-
-  it("returns rate-limit user-facing copy for genuine 429 rate-limit body", () => {
-    const message = "429 Too many requests. Rate limit exceeded.";
-    const copy = formatRateLimitOrOverloadedErrorCopy(message);
-    expect(copy?.toLowerCase()).toContain("rate limit");
+    expect(formatRateLimitOrOverloadedErrorCopy(message)).toBe(
+      "The AI service is temporarily overloaded. Please try again in a moment.",
+    );
   });
 });

--- a/src/agents/embedded-agent-helpers/failover-matches.test.ts
+++ b/src/agents/embedded-agent-helpers/failover-matches.test.ts
@@ -1,6 +1,6 @@
 // Covers provider-specific failover matcher regressions.
 import { describe, expect, it } from "vitest";
-import { classifyFailoverReason } from "./errors.js";
+import { classifyFailoverReason, classifyFailoverReasonFromHttpStatus } from "./errors.js";
 import {
   isAuthErrorMessage,
   isBillingErrorMessage,
@@ -9,6 +9,7 @@ import {
   isServerErrorMessage,
   isTimeoutErrorMessage,
 } from "./failover-matches.js";
+import { formatRateLimitOrOverloadedErrorCopy } from "./sanitize-user-facing-text.js";
 
 describe("Z.ai vendor error codes (#48988)", () => {
   describe("error 1311 — model not included in subscription plan", () => {
@@ -208,5 +209,63 @@ describe("generic assistant error text classification (#93931)", () => {
     expect(
       isTimeoutErrorMessage("LLM request failed: connection refused by the provider endpoint."),
     ).toBe(false);
+  });
+});
+
+describe("HTTP 429 overloaded vs rate-limit classification (#98101)", () => {
+  // Some providers (z.ai/GLM) return HTTP 429 with an "overloaded" message
+  // body (code 1305, "temporarily overloaded"). This is a transient server-side
+  // overload, not a per-account rate limit — it must be classified as
+  // "overloaded" so the failover path retries instead of falling over.
+
+  it("classifies 429 'temporarily overloaded' as overloaded via message path", () => {
+    const raw =
+      "429 status code (exceeded limit)\n" +
+      '{"code":1305,"message":"The service may be temporarily overloaded, please try again later."}';
+    expect(isOverloadedErrorMessage(raw)).toBe(true);
+    expect(classifyFailoverReason(raw)).toBe("overloaded");
+  });
+
+  it("classifies 429 'overloaded' (bare) as overloaded via message path", () => {
+    const raw = "429 overloaded";
+    expect(isOverloadedErrorMessage(raw)).toBe(true);
+    expect(classifyFailoverReason(raw)).toBe("overloaded");
+  });
+
+  it("classifies 429 overloaded via HTTP status path", () => {
+    const message =
+      "429 status code (exceeded limit)\n" +
+      '{"code":1305,"message":"The service may be temporarily overloaded, please try again later."}';
+    expect(classifyFailoverReasonFromHttpStatus(429, message)).toBe("overloaded");
+  });
+
+  it("still classifies 429 'rate limit exceeded' as rate_limit via message path", () => {
+    const raw = "429 Rate limit exceeded. Try again in 60s.";
+    expect(isRateLimitErrorMessage(raw)).toBe(true);
+    expect(classifyFailoverReason(raw)).toBe("rate_limit");
+  });
+
+  it("still classifies 429 generic rate-limit as rate_limit via HTTP status path", () => {
+    const message = "429 status code (exceeded limit)\nRate limit exceeded. Try again in 60s.";
+    expect(classifyFailoverReasonFromHttpStatus(429, message)).toBe("rate_limit");
+  });
+
+  it("still classifies 429 billing as billing via HTTP status path", () => {
+    const message = "429 status code\nInsufficient balance or no resource package.";
+    expect(classifyFailoverReasonFromHttpStatus(429, message)).toBe("billing");
+  });
+
+  it("returns overloaded user-facing copy for 429 overloaded body", () => {
+    const message =
+      "429 status code (exceeded limit)\n" +
+      '{"code":1305,"message":"The service may be temporarily overloaded, please try again later."}';
+    const copy = formatRateLimitOrOverloadedErrorCopy(message);
+    expect(copy).toBe("The AI service is temporarily overloaded. Please try again in a moment.");
+  });
+
+  it("returns rate-limit user-facing copy for genuine 429 rate-limit body", () => {
+    const message = "429 Too many requests. Rate limit exceeded.";
+    const copy = formatRateLimitOrOverloadedErrorCopy(message);
+    expect(copy?.toLowerCase()).toContain("rate limit");
   });
 });

--- a/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
+++ b/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
@@ -127,16 +127,11 @@ function extractProviderRateLimitMessage(raw: string): string | undefined {
 }
 
 export function formatRateLimitOrOverloadedErrorCopy(raw: string): string | undefined {
-  // MODEL_CAPACITY_ERROR_RE is the most specific overloaded variant ("selected
-  // model is at capacity") and must be checked first — otherwise the broader
-  // isOverloadedErrorMessage matcher (which also covers "model at capacity")
-  // would shadow it with a less specific message.
   if (MODEL_CAPACITY_ERROR_RE.test(raw)) {
     return MODEL_CAPACITY_ERROR_USER_MESSAGE;
   }
-  // Check overloaded BEFORE rate limit: isRateLimitErrorMessage matches the
-  // bare "429" token, so an overloaded-worded 429 body (z.ai code 1305 etc.)
-  // would surface the wrong user-facing copy ("API rate limit reached").
+  // Retry classification still owns 429 backoff; user copy can preserve the provider's
+  // overload wording without changing cooldown semantics.
   if (isOverloadedErrorMessage(raw)) {
     return OVERLOADED_ERROR_USER_MESSAGE;
   }

--- a/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
+++ b/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
@@ -127,16 +127,18 @@ function extractProviderRateLimitMessage(raw: string): string | undefined {
 }
 
 export function formatRateLimitOrOverloadedErrorCopy(raw: string): string | undefined {
+  // MODEL_CAPACITY_ERROR_RE is the most specific overloaded variant ("selected
+  // model is at capacity") and must be checked first — otherwise the broader
+  // isOverloadedErrorMessage matcher (which also covers "model at capacity")
+  // would shadow it with a less specific message.
+  if (MODEL_CAPACITY_ERROR_RE.test(raw)) {
+    return MODEL_CAPACITY_ERROR_USER_MESSAGE;
+  }
   // Check overloaded BEFORE rate limit: isRateLimitErrorMessage matches the
   // bare "429" token, so an overloaded-worded 429 body (z.ai code 1305 etc.)
   // would surface the wrong user-facing copy ("API rate limit reached").
-  // 503/499 already follow this order in the HTTP status classifier; the
-  // user-facing copy should match.
   if (isOverloadedErrorMessage(raw)) {
     return OVERLOADED_ERROR_USER_MESSAGE;
-  }
-  if (MODEL_CAPACITY_ERROR_RE.test(raw)) {
-    return MODEL_CAPACITY_ERROR_USER_MESSAGE;
   }
   if (isRateLimitErrorMessage(raw)) {
     return extractProviderRateLimitMessage(raw) ?? RATE_LIMIT_ERROR_USER_MESSAGE;

--- a/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
+++ b/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
@@ -130,13 +130,20 @@ export function formatRateLimitOrOverloadedErrorCopy(raw: string): string | unde
   if (MODEL_CAPACITY_ERROR_RE.test(raw)) {
     return MODEL_CAPACITY_ERROR_USER_MESSAGE;
   }
+  const isRateLimit = isRateLimitErrorMessage(raw);
+  if (isRateLimit) {
+    const providerMessage = extractProviderRateLimitMessage(raw);
+    if (providerMessage) {
+      return providerMessage;
+    }
+  }
   // Retry classification still owns 429 backoff; user copy can preserve the provider's
-  // overload wording without changing cooldown semantics.
+  // overload wording when there is no more actionable retry/reset detail.
   if (isOverloadedErrorMessage(raw)) {
     return OVERLOADED_ERROR_USER_MESSAGE;
   }
-  if (isRateLimitErrorMessage(raw)) {
-    return extractProviderRateLimitMessage(raw) ?? RATE_LIMIT_ERROR_USER_MESSAGE;
+  if (isRateLimit) {
+    return RATE_LIMIT_ERROR_USER_MESSAGE;
   }
   return undefined;
 }

--- a/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
+++ b/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
@@ -127,14 +127,19 @@ function extractProviderRateLimitMessage(raw: string): string | undefined {
 }
 
 export function formatRateLimitOrOverloadedErrorCopy(raw: string): string | undefined {
-  if (isRateLimitErrorMessage(raw)) {
-    return extractProviderRateLimitMessage(raw) ?? RATE_LIMIT_ERROR_USER_MESSAGE;
+  // Check overloaded BEFORE rate limit: isRateLimitErrorMessage matches the
+  // bare "429" token, so an overloaded-worded 429 body (z.ai code 1305 etc.)
+  // would surface the wrong user-facing copy ("API rate limit reached").
+  // 503/499 already follow this order in the HTTP status classifier; the
+  // user-facing copy should match.
+  if (isOverloadedErrorMessage(raw)) {
+    return OVERLOADED_ERROR_USER_MESSAGE;
   }
   if (MODEL_CAPACITY_ERROR_RE.test(raw)) {
     return MODEL_CAPACITY_ERROR_USER_MESSAGE;
   }
-  if (isOverloadedErrorMessage(raw)) {
-    return OVERLOADED_ERROR_USER_MESSAGE;
+  if (isRateLimitErrorMessage(raw)) {
+    return extractProviderRateLimitMessage(raw) ?? RATE_LIMIT_ERROR_USER_MESSAGE;
   }
   return undefined;
 }


### PR DESCRIPTION
Related to #98101

## What Problem This Solves

Z.AI can return HTTP 429 / business code 1305 with the message “temporarily overloaded.” OpenClaw correctly routes that response through rate-limit backoff, but the user-facing formatter previously stopped at the bare 429 token and displayed the generic “API rate limit reached” copy instead of preserving the provider's overload wording.

## Why This Change Was Made

User-facing wording and retry classification are separate decisions. The formatter now:

1. keeps the dedicated model-capacity guidance;
2. preserves actionable provider retry/reset details when present;
3. uses the transient overload copy when the response says overloaded but has no more specific timing guidance; and
4. otherwise falls back to the generic rate-limit copy.

The internal 429 classification remains `rate_limit`. Z.AI's official error contract defines HTTP 429 as concurrency/frequency/account limiting and business code 1305 as a triggered rate limit; changing it to `overloaded` would incorrectly alter profile cooldown and fallback behavior.

## User Impact

Users now see “The AI service is temporarily overloaded. Please try again in a moment.” for overload-worded Z.AI 1305 responses, while explicit retry windows still surface and documented rate-limit backoff remains intact.

Thanks @SunnyShu0925 for surfacing the overlapping 429/overload formatter path and contributing the original regression coverage.

## Evidence

- Exact prepared head: `0b1b722a1adfb61f284d1e453518b72c089bf777` ([exact-head CI](https://github.com/openclaw/openclaw/actions/runs/28811197401)).
- Sanitized direct AWS Crabbox `cbx_059970447f01`, run [`run_9d9bfcd2a344`](https://crabbox.openclaw.ai/portal/runs/run_9d9bfcd2a344): public networking, no Tailscale, no instance role, no credential hydration, and reviewed-SHA pinning.
- Same run: 444 assertions passed across formatter, sanitizer, failover classification, and model-fallback suites.
- [Official Z.AI error contract](https://docs.z.ai/api-reference/api-code): HTTP 429 covers concurrency/frequency/account limiting; code 1305 means the API triggered a rate limit; code 1312 is the distinct model-high-traffic condition.
- Fresh whole-branch AutoReview found no accepted/actionable findings after preserving explicit retry details (confidence 0.84).
- Targeted formatting and `git diff --check` passed.
