### PR TITLE
fix(ui): avoid toSorted in sidebar recent sessions

### DIFF
--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -81,11 +81,12 @@ import {
   resolveDashboardHeaderContext,
   resolveSessionOptionGroups,
   resolveSessionDisplayName,
+  sortSessionRowsByUpdatedAtDesc,
   switchChatSession,
   switchChatSessionAndWait,
 } from "./app-render.helpers.ts";
 import type { AppViewState } from "./app-view-state.ts";
-import type { SessionsListResult } from "./types.ts";
+import type { GatewaySessionRow, SessionsListResult } from "./types.ts";
 
 type SessionRow = SessionsListResult["sessions"][number];
 
@@ -1599,5 +1600,51 @@ describe("dismissRealtimeTalkError", () => {
     expect(state.realtimeTalkStatus).toBe("idle");
     expect(state.realtimeTalkDetail).toBeNull();
     expect(state.realtimeTalkTranscript).toBeNull();
+  });
+});
+
+describe("sortSessionRowsByUpdatedAtDesc", () => {
+  function sessionRow(
+    key: string,
+    updatedAt: number | null,
+    overrides: Partial<GatewaySessionRow> = {},
+  ): GatewaySessionRow {
+    return { key, kind: "direct", updatedAt, ...overrides } as GatewaySessionRow;
+  }
+
+  it("sorts sessions newest first and treats missing updatedAt as 0", () => {
+    const rows = [
+      sessionRow("a", 100),
+      sessionRow("b", 300),
+      sessionRow("c", null),
+      sessionRow("d", 200),
+    ];
+    const sorted = sortSessionRowsByUpdatedAtDesc(rows);
+    expect(sorted.map((entry) => entry.key)).toEqual(["b", "d", "a", "c"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const rows = [sessionRow("old", 1), sessionRow("new", 2)];
+    const snapshot = rows.map((entry) => entry.key);
+    sortSessionRowsByUpdatedAtDesc(rows);
+    expect(rows.map((entry) => entry.key)).toEqual(snapshot);
+  });
+
+  it("works on browsers without Array.prototype.toSorted (regression for #98158)", () => {
+    // Simulate older Chrome (e.g. Chrome 109 on Windows 7) which does not
+    // implement Array.prototype.toSorted. The sidebar render path must not
+    // rely on it, otherwise the whole Control UI white-screens on load.
+    const arrayProto = Array.prototype as unknown as { toSorted?: unknown };
+    const originalToSorted = arrayProto.toSorted;
+    delete arrayProto.toSorted;
+    try {
+      const rows = [sessionRow("older", 50), sessionRow("newer", 150)];
+      const sorted = sortSessionRowsByUpdatedAtDesc(rows);
+      expect(sorted.map((entry) => entry.key)).toEqual(["newer", "older"]);
+    } finally {
+      if (originalToSorted !== undefined) {
+        arrayProto.toSorted = originalToSorted;
+      }
+    }
   });
 });

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -42,7 +42,7 @@ import {
 import { normalizeChatAutoScrollMode, type ChatAutoScrollMode } from "./storage.ts";
 import { normalizeLowercaseStringOrEmpty, normalizeOptionalString } from "./string-coerce.ts";
 import type { ThemeMode } from "./theme.ts";
-import type { SessionsListResult } from "./types.ts";
+import type { GatewaySessionRow, SessionsListResult } from "./types.ts";
 import type { ChatQueueItem } from "./ui-types.ts";
 
 export { isCronSessionKey, parseSessionKey, resolveSessionDisplayName, resolveSessionOptionGroups };
@@ -892,4 +892,15 @@ export function renderSidebarConnectionStatus(state: AppViewState) {
       title=${t("chat.gatewayStatus", { status: label })}
     ></span>
   `;
+}
+
+// Browsers that predate ES2023 (e.g. Chrome 109 / last Win7-supporting Chrome) do
+// not implement Array.prototype.toSorted, so calling it on the sidebar load path
+// crashes the whole Control UI render. Use a plain copy-then-sort so the sidebar
+// stays renderable on those browsers without depending on a polyfill.
+export function sortSessionRowsByUpdatedAtDesc(
+  rows: readonly GatewaySessionRow[],
+): GatewaySessionRow[] {
+  // oxlint-disable-next-line unicorn/no-array-sort -- intentional fallback for browsers without Array.prototype.toSorted (#98158)
+  return rows.slice().sort((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0));
 }

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -21,6 +21,7 @@ import {
   resolveDashboardHeaderContext,
   renderSidebarConnectionStatus,
   renderTopbarThemeModeToggle,
+  sortSessionRowsByUpdatedAtDesc,
   createChatSession,
   dismissChatError,
   dismissRealtimeTalkError,
@@ -532,20 +533,18 @@ function resolveSidebarRecentSessions(state: AppViewState): GatewaySessionRow[] 
   const selectedAgentId = resolveSidebarSelectedAgentId(state);
   const shouldFilterByAgent =
     normalizeOptionalString(state.sessionKey)?.toLowerCase() !== "unknown";
-  return (state.sessionsResult?.sessions ?? [])
-    .filter(
-      (row) =>
-        !row.archived &&
-        row.kind !== "global" &&
-        row.kind !== "unknown" &&
-        row.kind !== "cron" &&
-        !isCronSessionKey(row.key) &&
-        !isSubagentSessionKey(row.key) &&
-        !row.spawnedBy &&
-        (!shouldFilterByAgent || isSidebarSessionForSelectedAgent(state, row, selectedAgentId)),
-    )
-    .toSorted((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0))
-    .slice(0, 5);
+  const filtered = (state.sessionsResult?.sessions ?? []).filter(
+    (row) =>
+      !row.archived &&
+      row.kind !== "global" &&
+      row.kind !== "unknown" &&
+      row.kind !== "cron" &&
+      !isCronSessionKey(row.key) &&
+      !isSubagentSessionKey(row.key) &&
+      !row.spawnedBy &&
+      (!shouldFilterByAgent || isSidebarSessionForSelectedAgent(state, row, selectedAgentId)),
+  );
+  return sortSessionRowsByUpdatedAtDesc(filtered).slice(0, 5);
 }
 
 function renderSidebarSessions(state: AppViewState) {


### PR DESCRIPTION
Fixes #98158

## What Problem This Solves

Fixes an issue where users on browsers older than ES2023 (notably Chrome 109, the last release that supports Windows 7) see the Control UI dashboard render as a blank page on first load, with the console showing `TypeError: ((intermediate value) ?? []).filter(...).toSorted is not a function`.

The sidebar's recent-sessions resolution runs on the very first paint. When `Array.prototype.toSorted` is missing, the sidebar render throws before anything else mounts, so the whole dashboard never paints. Users in this group are still in the Control UI's documented Windows-friendly install path but cannot reach the dashboard at all.

This is the same class of regression handled previously for the cron suggestion render in #31775, surfacing on a separate sidebar load-path call site.

## Why This Change Was Made

`resolveSidebarRecentSessions` in `ui/src/ui/app-render.ts` chained `.toSorted(...)` directly on the filtered sessions list. That call is on the unavoidable sidebar render path on every Control UI dashboard load, so older browsers that lack `Array.prototype.toSorted` crash before anything renders.

The fix extracts the sort into a small `sortSessionRowsByUpdatedAtDesc` helper in `ui/src/ui/app-render.helpers.ts` and uses a copy-then-sort (`rows.slice().sort(...)`) so the behavior is identical (non-mutating, descending by `updatedAt`) without depending on `Array.prototype.toSorted`. The original `.slice(0, 5)` cap is preserved.

Scope is intentionally limited to the one sidebar call site reported in #98158 plus a tiny shared helper for its tests. Other `toSorted` usages in the codebase are out of scope here; they should be addressed in their own issue-driven PRs (matching the precedent set by #31775).

## User Impact

Users on browsers without `Array.prototype.toSorted` (e.g. Chrome 109 on Windows 7) can again reach the Control UI dashboard and see the sidebar render its recent sessions list. No behavior change for users on browsers that already implement `toSorted`: the sort order, item cap (5), and non-mutating semantics are preserved.

## Evidence

**Reproducer (locked baseline before fix):**

```
$ node /tmp/repro-98158.mjs
BASE (broken) threw as expected: (rows ?? []).filter(...).toSorted is not a function
FIX result: [ 'b', 'a' ]
```

The "BASE" branch runs the exact pre-fix expression from `app-render.ts:547` after `delete Array.prototype.toSorted`. The error string matches the one reported in #98158.

**Regression test (`ui/src/ui/app-render.helpers.node.test.ts`):**

Added three tests for `sortSessionRowsByUpdatedAtDesc`, including an explicit "works on browsers without `Array.prototype.toSorted` (regression for #98158)" case that deletes `Array.prototype.toSorted` on the spot and asserts the helper still sorts correctly. Both directions verified:

- On `main` (no patch, with the new tests): `sortSessionRowsByUpdatedAtDesc is not a function` → 3 new tests fail as expected.
- With the patch: all 78 tests in the file pass:

```
$ pnpm exec vitest run src/ui/app-render.helpers.node.test.ts --config vitest.config.ts
 ✓ unit-node src/ui/app-render.helpers.node.test.ts (78 tests) 10ms
 Test Files  1 passed (1)
      Tests  78 passed (78)
```

Broader `app-render*` suites stay green: 111 / 111 passing across `app-render-usage-tab`, `app-render.helpers.node`, `app-render.exec-policy`, `app-render.dreaming`, and `app-render.assistant-avatar`.

**Lint:**

```
$ pnpm exec oxlint ui/src/ui/app-render.ts ui/src/ui/app-render.helpers.ts ui/src/ui/app-render.helpers.node.test.ts
Found 0 warnings and 0 errors.
```

The helper carries a single targeted `oxlint-disable-next-line unicorn/no-array-sort` with a comment explaining the intentional `Array#sort` fallback (calling `.sort()` on a fresh `.slice()`, which is already non-mutating).

**Diff scope (`git diff origin/main..HEAD --stat`):**

```
 ui/src/ui/app-render.helpers.node.test.ts | 49 ++++++++++++++++++++++++++++++-
 ui/src/ui/app-render.helpers.ts           | 13 +++++++-
 ui/src/ui/app-render.ts                   | 27 ++++++++---------
 3 files changed, 73 insertions(+), 16 deletions(-)
```

No drive-by changes. No CHANGELOG edit (per CONTRIBUTING).

## AI Assistance Disclosure

This change was written with the assistance of Claude. I reviewed the diff and the regression coverage end to end, ran the reproducer and the Vitest suite locally to confirm both fail-on-base and pass-with-fix directions, and own the change.
