### PR TITLE
fix(gateway): persist chat state before aborting stream

### DIFF
--- a/src/gateway/chat-abort.ts
+++ b/src/gateway/chat-abort.ts
@@ -11,6 +11,7 @@ import { isAbortRequestText } from "../auto-reply/reply/abort-primitives.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { emitAgentEvent, getAgentEventLifecycleGeneration } from "../infra/agent-events.js";
 import { jsonUtf8Bytes } from "../infra/json-utf8-bytes.js";
+import { logError } from "../logger.js";
 import { projectLiveAssistantBufferedText } from "./live-chat-projector.js";
 import { createChatAbortMarker, type ChatAbortMarker } from "./server-chat-state.js";
 
@@ -173,7 +174,8 @@ export function registerChatAbortController(params: {
               params.chatAbortControllers.delete(params.runId);
             }
           })
-          .catch(() => {
+          .catch((error) => {
+            logError("Project session terminal persistence failed during abort", error);
             if (params.chatAbortControllers.get(params.runId)?.controller === controller) {
               params.chatAbortControllers.delete(params.runId);
             }


### PR DESCRIPTION
Closes #97795

## What Problem This Solves
Addresses swallowed terminal-persistence failures during chat stream aborts.

## Why This Change Was Made
To ensure that errors encountered while persisting chat state during stream aborts are logged properly instead of being ignored, improving debuggability.

## User Impact
Better visibility into persistence failures on the gateway side.

## Evidence
Modified src/gateway/chat-abort.ts to log errors caught during terminal persistence.