### PR TITLE
fix(agents): allow reentrant session write lock in direct compaction

### DIFF
--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -1181,6 +1181,7 @@ async function compactEmbeddedAgentSessionDirectOnce(
     const compactionTimeoutMs = resolveCompactionTimeoutMs(params.config);
     const sessionLock = await acquireSessionWriteLock({
       sessionFile: params.sessionFile,
+      allowReentrant: true,
       ...resolveSessionWriteLockOptions(params.config, {
         maxHoldMsFallback: resolveSessionLockMaxHoldFromTimeout({
           timeoutMs: compactionTimeoutMs,


### PR DESCRIPTION
## Summary

- Allow reentrant session write lock acquisition in `compactEmbeddedAgentSessionDirectOnce` by passing `allowReentrant: true` to `acquireSessionWriteLock`
- When an embedded agent attempt triggers overflow-recovery auto-compaction, the compaction path re-acquires the same session's write lock inside the same process. The default `allowReentrant: false` causes a 60s deadlock followed by `SessionWriteLockTimeoutError`
- This matches the behavior of `plugin-sdk/file-lock.ts:74` which already passes `allowReentrant: true` to the same underlying lock manager

Fixes #97747

## Linked context

- Issue #97747 — detailed report with logs showing 18-minute recovery window across fallback chain
- PR #88919 — open proof-positive candidate for the exact fix path
- `src/agents/session-write-lock.ts:895` — default `allowReentrant` is `false`
- `src/agents/embedded-agent-runner/compact.ts:1182` — the call site that was missing `allowReentrant`

## Real behavior proof (required for external PRs)

**Behavior addressed**: Overflow-recovery auto-compaction now re-enters the session write lock instead of deadlocking for 60s

**Real setup tested**: Source code inspection — the fix adds a single parameter that matches an existing pattern in the codebase

- **Runtime**: node

**Exact steps or command run after fix**:

```bash
grep -n "allowReentrant" src/agents/session-write-lock.ts
grep -n "allowReentrant" src/agents/embedded-agent-runner/compact.ts
```

**After-fix evidence**:

```
src/agents/session-write-lock.ts:895:  const allowReentrant = params.allowReentrant ?? false;
src/agents/embedded-agent-runner/compact.ts:1184:      allowReentrant: true,
```

**Observed result after the fix**: The compaction path now passes `allowReentrant: true`, matching the plugin-sdk pattern. When the same process holds the lock and compaction re-acquires it, the lock manager bumps the reference count and returns immediately instead of blocking.

**What was not tested**: Live DeepSeek/MiniMax overflow scenario was not run; confidence comes from source tracing, the existing PR #88919 proof, and the reporter's logs.

## Tests and validation

- Existing `compact.hooks.harness.ts` tests mock `acquireSessionWriteLock` without checking parameters — no test update needed
- The fix is a single boolean parameter addition with no logic change

## Risk checklist

Did user-visible behavior change? (`No`)
Did config, environment, or migration behavior change? (`No`)
Did security, auth, secrets, network, or tool execution behavior change? (`No`)
What is the highest-risk area?
- Session lock reentrancy could theoretically allow concurrent writes if the inner lock holder modifies state that the outer holder depends on
How is that risk mitigated?
- The outer holder (attempt) has already yielded control to compaction; there is no concurrent mutation — compaction is called *by* the attempt, sequentially
- The same pattern is already used safely in `plugin-sdk/file-lock.ts:74`

## Current review state

What is the next action?
- Maintainer review

What is still waiting on author, maintainer, CI, or external proof?
- Live overflow/fallback validation would strengthen confidence but is not required given the source-level proof