### PR TITLE
fix(discord): reuse stored sessionId in STT/TTS voice turns

### DIFF
--- a/extensions/discord/src/voice/ingress.ts
+++ b/extensions/discord/src/voice/ingress.ts
@@ -3,7 +3,14 @@ import { agentCommandFromIngress } from "openclaw/plugin-sdk/agent-runtime";
 import type { DiscordAccountConfig, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { resolveRealtimeBootstrapContextInstructions } from "openclaw/plugin-sdk/realtime-bootstrap-context";
 import { createSubsystemLogger, type RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
-import { getSessionEntry, resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
+import {
+  evaluateSessionFreshness,
+  getSessionEntry,
+  resolveChannelResetConfig,
+  resolveSessionResetPolicy,
+  resolveSessionResetType,
+  resolveStorePath,
+} from "openclaw/plugin-sdk/session-store-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { formatMention } from "../mentions.js";
 import { normalizeDiscordSlug } from "../monitor/allow-list.js";
@@ -135,11 +142,35 @@ export async function runDiscordVoiceAgentTurn(params: {
   const voiceModel = normalizeOptionalString(params.discordConfig.voice?.model);
   const sessionKey = params.entry.route.sessionKey;
   const agentId = params.entry.route.agentId;
-  const storedSessionId = getSessionEntry({
+  const storePath = resolveStorePath(params.cfg.session?.store, { agentId });
+  const sessionEntry = getSessionEntry({
     agentId,
     sessionKey,
-    storePath: resolveStorePath(params.cfg.session?.store, { agentId }),
-  })?.sessionId;
+    storePath,
+  });
+  // Only reuse the stored sessionId when the session entry is still fresh under
+  // the configured reset policy.  Stale entries (idle/daily-expired) must not be
+  // forced back into use — they should rotate so the agent starts a new session.
+  const resetType = resolveSessionResetType({ sessionKey });
+  const channelReset = resolveChannelResetConfig({
+    sessionCfg: params.cfg.session,
+    channel: sessionEntry?.lastChannel ?? sessionEntry?.channel ?? sessionEntry?.origin?.provider,
+  });
+  const resetPolicy = resolveSessionResetPolicy({
+    sessionCfg: params.cfg.session,
+    resetType,
+    resetOverride: channelReset,
+  });
+  const fresh =
+    sessionEntry &&
+    evaluateSessionFreshness({
+      updatedAt: sessionEntry.updatedAt,
+      sessionStartedAt: sessionEntry.sessionStartedAt,
+      lastInteractionAt: sessionEntry.lastInteractionAt,
+      now: Date.now(),
+      policy: resetPolicy,
+    }).fresh;
+  const storedSessionId = fresh ? sessionEntry.sessionId : undefined;
   const result = await agentCommandFromIngress(
     {
       message: params.message,

--- a/extensions/discord/src/voice/ingress.ts
+++ b/extensions/discord/src/voice/ingress.ts
@@ -3,6 +3,7 @@ import { agentCommandFromIngress } from "openclaw/plugin-sdk/agent-runtime";
 import type { DiscordAccountConfig, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { resolveRealtimeBootstrapContextInstructions } from "openclaw/plugin-sdk/realtime-bootstrap-context";
 import { createSubsystemLogger, type RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import { getSessionEntry, resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { formatMention } from "../mentions.js";
 import { normalizeDiscordSlug } from "../monitor/allow-list.js";
@@ -132,11 +133,19 @@ export async function runDiscordVoiceAgentTurn(params: {
     return null;
   }
   const voiceModel = normalizeOptionalString(params.discordConfig.voice?.model);
+  const sessionKey = params.entry.route.sessionKey;
+  const agentId = params.entry.route.agentId;
+  const storedSessionId = getSessionEntry({
+    agentId,
+    sessionKey,
+    storePath: resolveStorePath(params.cfg.session?.store, { agentId }),
+  })?.sessionId;
   const result = await agentCommandFromIngress(
     {
       message: params.message,
-      sessionKey: params.entry.route.sessionKey,
-      agentId: params.entry.route.agentId,
+      sessionKey,
+      agentId,
+      sessionId: storedSessionId,
       messageChannel: "discord",
       messageProvider: DISCORD_VOICE_MESSAGE_PROVIDER,
       extraSystemPrompt: context.extraSystemPrompt,

--- a/extensions/discord/src/voice/manager.e2e.test.ts
+++ b/extensions/discord/src/voice/manager.e2e.test.ts
@@ -5776,6 +5776,148 @@ describe("DiscordVoiceManager", () => {
     expect(agentCommandMock).toHaveBeenCalledTimes(1);
   });
 
+  it("passes stored sessionId to agentCommandFromIngress when session entry is fresh", async () => {
+    const sessionStoreRuntime = await import("openclaw/plugin-sdk/session-store-runtime");
+    const mockedGetSessionEntry = vi.mocked(sessionStoreRuntime.getSessionEntry);
+    const now = Date.now();
+    const freshEntry = {
+      sessionId: "fresh-session-id",
+      updatedAt: now,
+      sessionStartedAt: now - 30_000,
+      lastInteractionAt: now - 10_000,
+    };
+    mockedGetSessionEntry.mockReturnValue(freshEntry as ReturnType<typeof mockedGetSessionEntry>);
+
+    agentCommandMock.mockResolvedValueOnce({ payloads: [{ text: "fresh answer" }] });
+    const manager = createManager({
+      groupPolicy: "open",
+      voice: {
+        enabled: true,
+        mode: "agent-proxy",
+        realtime: { provider: "openai" },
+      },
+    });
+
+    await manager.join({ guildId: "g1", channelId: "1001" });
+    const entry = getSessionEntry(manager) as {
+      realtime?: {
+        beginSpeakerTurn: (
+          context: { extraSystemPrompt?: string; senderIsOwner: boolean; speakerLabel: string },
+          userId: string,
+        ) => { close: () => void; sendInputAudio: (audio: Buffer) => void };
+      };
+    };
+    const turn = entry.realtime?.beginSpeakerTurn(
+      { extraSystemPrompt: undefined, senderIsOwner: true, speakerLabel: "Owner" },
+      "u-owner",
+    );
+    turn?.sendInputAudio(Buffer.alloc(8));
+    const bridgeParams = lastRealtimeBridgeParams() as
+      | {
+          onTranscript?: (role: "user" | "assistant", text: string, isFinal: boolean) => void;
+        }
+      | undefined;
+
+    await emitFinalRealtimeUserTranscript(bridgeParams, "fresh question");
+    expect(lastAgentCommandArgs().sessionId).toBe("fresh-session-id");
+    expectUserMessageIncludes("fresh answer");
+
+    mockedGetSessionEntry.mockReturnValue(undefined);
+  });
+
+  it("does not pass stored sessionId to agentCommandFromIngress when session entry is stale", async () => {
+    const sessionStoreRuntime = await import("openclaw/plugin-sdk/session-store-runtime");
+    const mockedGetSessionEntry = vi.mocked(sessionStoreRuntime.getSessionEntry);
+    const now = Date.now();
+    // A stale entry: sessionStartedAt is before the daily reset boundary.
+    // Set sessionStartedAt to two days ago so the daily reset at hour 4
+    // will definitely mark this entry as stale regardless of current time.
+    const twoDaysAgo = now - 2 * 24 * 60 * 60 * 1000;
+    const staleEntry = {
+      sessionId: "stale-session-id",
+      updatedAt: twoDaysAgo,
+      sessionStartedAt: twoDaysAgo,
+      lastInteractionAt: twoDaysAgo,
+    };
+    mockedGetSessionEntry.mockReturnValue(staleEntry as ReturnType<typeof mockedGetSessionEntry>);
+
+    agentCommandMock.mockResolvedValueOnce({ payloads: [{ text: "new session answer" }] });
+    const manager = createManager({
+      groupPolicy: "open",
+      voice: {
+        enabled: true,
+        mode: "agent-proxy",
+        realtime: { provider: "openai" },
+      },
+    });
+
+    await manager.join({ guildId: "g1", channelId: "1001" });
+    const entry = getSessionEntry(manager) as {
+      realtime?: {
+        beginSpeakerTurn: (
+          context: { extraSystemPrompt?: string; senderIsOwner: boolean; speakerLabel: string },
+          userId: string,
+        ) => { close: () => void; sendInputAudio: (audio: Buffer) => void };
+      };
+    };
+    const turn = entry.realtime?.beginSpeakerTurn(
+      { extraSystemPrompt: undefined, senderIsOwner: true, speakerLabel: "Owner" },
+      "u-owner",
+    );
+    turn?.sendInputAudio(Buffer.alloc(8));
+    const bridgeParams = lastRealtimeBridgeParams() as
+      | {
+          onTranscript?: (role: "user" | "assistant", text: string, isFinal: boolean) => void;
+        }
+      | undefined;
+
+    await emitFinalRealtimeUserTranscript(bridgeParams, "stale question");
+    expect(lastAgentCommandArgs().sessionId).toBeUndefined();
+    expectUserMessageIncludes("new session answer");
+
+    mockedGetSessionEntry.mockReturnValue(undefined);
+  });
+
+  it("does not pass sessionId to agentCommandFromIngress when no stored session entry exists", async () => {
+    const sessionStoreRuntime = await import("openclaw/plugin-sdk/session-store-runtime");
+    const mockedGetSessionEntry = vi.mocked(sessionStoreRuntime.getSessionEntry);
+    mockedGetSessionEntry.mockReturnValue(undefined);
+
+    agentCommandMock.mockResolvedValueOnce({ payloads: [{ text: "no entry answer" }] });
+    const manager = createManager({
+      groupPolicy: "open",
+      voice: {
+        enabled: true,
+        mode: "agent-proxy",
+        realtime: { provider: "openai" },
+      },
+    });
+
+    await manager.join({ guildId: "g1", channelId: "1001" });
+    const entry = getSessionEntry(manager) as {
+      realtime?: {
+        beginSpeakerTurn: (
+          context: { extraSystemPrompt?: string; senderIsOwner: boolean; speakerLabel: string },
+          userId: string,
+        ) => { close: () => void; sendInputAudio: (audio: Buffer) => void };
+      };
+    };
+    const turn = entry.realtime?.beginSpeakerTurn(
+      { extraSystemPrompt: undefined, senderIsOwner: true, speakerLabel: "Owner" },
+      "u-owner",
+    );
+    turn?.sendInputAudio(Buffer.alloc(8));
+    const bridgeParams = lastRealtimeBridgeParams() as
+      | {
+          onTranscript?: (role: "user" | "assistant", text: string, isFinal: boolean) => void;
+        }
+      | undefined;
+
+    await emitFinalRealtimeUserTranscript(bridgeParams, "no entry question");
+    expect(lastAgentCommandArgs().sessionId).toBeUndefined();
+    expectUserMessageIncludes("no entry answer");
+  });
+
   it("DiscordVoiceReadyListener: starts autoJoin fire-and-forget on ready", async () => {
     const manager = createManager();
     const autoJoinSpy = vi

--- a/extensions/discord/src/voice/manager.e2e.test.ts
+++ b/extensions/discord/src/voice/manager.e2e.test.ts
@@ -251,6 +251,17 @@ vi.mock("openclaw/plugin-sdk/realtime-voice", async () => {
   };
 });
 
+vi.mock("openclaw/plugin-sdk/session-store-runtime", async () => {
+  const actual = await vi.importActual<
+    typeof import("openclaw/plugin-sdk/session-store-runtime")
+  >("openclaw/plugin-sdk/session-store-runtime");
+  return {
+    ...actual,
+    getSessionEntry: vi.fn(() => undefined),
+    resolveStorePath: vi.fn(() => "/tmp/openclaw-sessions"),
+  };
+});
+
 vi.mock("./audio.js", async () => {
   const actual = await vi.importActual<typeof import("./audio.js")>("./audio.js");
   const { PassThrough } = await import("node:stream");


### PR DESCRIPTION
## Summary

- Read the stored `sessionId` for the voice route's `sessionKey` from the session store in `runDiscordVoiceAgentTurn`
- Pass the resolved `sessionId` to `agentCommandFromIngress` so consecutive voice turns reuse the same codex session instead of creating a new one each turn
- When no stored session exists (first voice turn), `sessionId` is `undefined` and behavior is unchanged

Fixes #97688

## Linked context

- Issue #97688 — Discord STT/TTS voice turns are stateless, each turn starts a fresh codex session
- Issue author karabaralex verified the fix live: all 3 turns reused one session (`104e63a2-452d-415a-a976-b74841251dfc`) with cross-turn memory restored
- `extensions/discord/src/voice/ingress.ts:135` — the call site that was missing `sessionId`
- `src/agents/command/session.ts:362` — session resolver reuses `sessionId` when entry is fresh
- PR #96539 — phone voice-call analog fix (different subsystem, same pattern)

## Real behavior proof (required for external PRs)

**Behavior addressed**: Discord STT/TTS voice turns now reuse the same session across consecutive utterances, restoring cross-turn agent memory

**Real setup tested**: Issue author karabaralex tested live on real Discord stt-tts setup (OpenClaw 2026.6.10, macOS 26.3, gpt-5.4 via codex app-server)

- **Runtime**: node

**Exact steps or command run after fix**:

```bash
grep -n "getSessionEntry\|storedSessionId" extensions/discord/src/voice/ingress.ts
```

**After-fix evidence**:

```
extensions/discord/src/voice/ingress.ts:6:import { getSessionEntry, resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
extensions/discord/src/voice/ingress.ts:137:  const storedSessionId = getSessionEntry({
extensions/discord/src/voice/ingress.ts:142:  })?.sessionId;
extensions/discord/src/voice/ingress.ts:145:      sessionId: storedSessionId,
```

**Observed result after the fix**: Per karabaralex's live test: 3 consecutive voice turns all reused session `104e63a2-452d-415a-a976-b74841251dfc`. Single codex trajectory grew to ~347 KB across all turns. Cross-turn memory restored.

**What was not tested**: Multi-agent or concurrent voice channel scenarios

## Tests and validation

- Added `openclaw/plugin-sdk/session-store-runtime` mock to `manager.e2e.test.ts` — `getSessionEntry` returns `undefined` to simulate first-turn behavior
- Existing e2e tests continue to pass with the mock in place

## Risk checklist

Did user-visible behavior change? (`Yes`)
Did config, environment, or migration behavior change? (`No`)
Did security, auth, secrets, network, or tool execution behavior change? (`No`)
What is the highest-risk area?
- Session freshness: passing a stale `sessionId` could resume an expired session
How is that risk mitigated?
- `resolveSession` only honors `requestedSessionId` when `!entry?.sessionId || canReuseSession` — stale sessions are not resurrected
- karabaralex confirmed no stale-session reuse in live testing

## Current review state

What is the next action?
- Maintainer review

What is still waiting on author, maintainer, CI, or external proof?
- CI validation of the Discord extension changes