### PR TITLE
fix(channels): prevent channel stop failure from skipping restart

### DIFF
--- a/src/gateway/channel-health-monitor.ts
+++ b/src/gateway/channel-health-monitor.ts
@@ -175,17 +175,24 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
             restartRecords.set(key, record);
           }
 
-          try {
-            if (status.running) {
+          if (status.running) {
+            try {
               await channelManager.stopChannel(channelId as ChannelId, accountId, {
                 manual: false,
               });
+            } catch (err) {
+              log.error?.(
+                `[${channelId}:${accountId}] health-monitor: stop failed during restart: ${String(err)}`,
+              );
             }
+          }
+
+          try {
             channelManager.resetRestartAttempts(channelId as ChannelId, accountId);
             await channelManager.startChannel(channelId as ChannelId, accountId);
           } catch (err) {
             log.error?.(
-              `[${channelId}:${accountId}] health-monitor: restart failed: ${String(err)}`,
+              `[${channelId}:${accountId}] health-monitor: start failed during restart: ${String(err)}`,
             );
           }
         }

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -846,18 +846,23 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
         abort?.abort();
         const log = ensureChannelLog(channelId);
         const runtime = ensureChannelRuntime(channelId);
+        let stopError: unknown;
         if (plugin?.gateway?.stopAccount) {
-          const account = plugin.config.resolveAccount(cfg, id);
-          await plugin.gateway.stopAccount({
-            cfg,
-            accountId: id,
-            account,
-            runtime,
-            abortSignal: abort?.signal ?? new AbortController().signal,
-            log,
-            getStatus: () => getRuntime(channelId, id),
-            setStatus: (next) => setRuntime(channelId, id, next),
-          });
+          try {
+            const account = plugin.config.resolveAccount(cfg, id);
+            await plugin.gateway.stopAccount({
+              cfg,
+              accountId: id,
+              account,
+              runtime,
+              abortSignal: abort?.signal ?? new AbortController().signal,
+              log,
+              getStatus: () => getRuntime(channelId, id),
+              setStatus: (next) => setRuntime(channelId, id, next),
+            });
+          } catch (err) {
+            stopError = err;
+          }
         }
         const stoppedCleanly = await waitForChannelStopGracefully(
           task,
@@ -893,6 +898,9 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
           restartPending: false,
           lastStopAt: Date.now(),
         });
+        if (stopError) {
+          throw stopError;
+        }
       }),
     );
   };


### PR DESCRIPTION
Closes #97797

### What Problem This Solves
When a channel fails health checks, the health monitor tries to stop it, reset restart attempts, and then start it again. Previously, if the \stopChannel\ call threw an error before completing its cleanup, the subsequent \esetRestartAttempts\ and \startChannel\ calls would be skipped. Even with the split try/catch added in the health-monitor, the channel-manager's stale task state would remain uncleared because \stopAccount\ rejecting skipped \waitForChannelStopGracefully\. This resulted in the channel remaining in a permanently failed state without actually restarting, since \startChannelInternal\ would bail out early on the stale task state.

### Why This Change Was Made
This change updates \stopChannel\ in \server-channels.ts\ to wrap the \plugin.gateway.stopAccount\ call in a try/catch, capturing the error but proceeding to \waitForChannelStopGracefully\ to ensure stale task state is cleaned up before throwing the error. This works in conjunction with the split try/catch in \channel-health-monitor.ts\ so that the health monitor logs the stop failure, then successfully clears restart attempts and calls \startChannel\. Because the stale task was cleaned up by \stopChannel\, \startChannelInternal\ can now successfully spawn a replacement task.

### User Impact
Channels that fail during stop operations due to plugin errors or timeouts will now correctly recover and restart automatically, rather than getting stuck permanently until the gateway process restarts.

### Evidence
- Added try/catch to \stopChannel\ in \src/gateway/server-channels.ts\ to defer \stopAccount\ errors and guarantee \	asks.delete\ runs on completion.
- Added split try/catch to \health-monitor\ so it continues after a stop failure.
- Checked locally that \stopChannel\ properly clears tasks after an abort and allows restarts to proceed.