### PR TITLE
fix(cli): explicitly terminate on root help fast path error

### DIFF
--- a/src/entry.ts
+++ b/src/entry.ts
@@ -159,7 +159,7 @@ export async function tryHandleRootHelpFastPath(
         "[openclaw] Failed to display help:",
         error instanceof Error ? (error.stack ?? error.message) : error,
       );
-      process.exitCode = 1;
+      process.exit(1);
     });
   try {
     const loadRootHelpRenderOptionsForConfigSensitivePlugins =


### PR DESCRIPTION
Fixes a dangling event loop bug where the CLI could hang instead of exiting when help display fails in the fast path.