### PR TITLE
fix(zai): add user-agent header to endpoint detection probe

### DIFF
--- a/extensions/zai/detect.ts
+++ b/extensions/zai/detect.ts
@@ -88,6 +88,7 @@ async function probeZaiChatCompletions(params: {
         headers: {
           authorization: `Bearer ${params.apiKey}`,
           "content-type": "application/json",
+          "user-agent": "openclaw",
         },
         body: JSON.stringify({
           model: params.modelId,


### PR DESCRIPTION
Closes #98100

### What Problem This Solves
The Z.AI endpoint auto-detection probe was failing with 429 errors from strict edge firewalls because it did not include a User-Agent header.

### Why This Change Was Made
Adding the `user-agent: openclaw` header satisfies the firewall rules that block requests lacking a User-Agent, ensuring the auto-detection probe completes successfully.

### User Impact
Users in environments with strict edge firewalls will no longer experience onboarding failures or false negatives during Z.AI endpoint auto-detection.

### Evidence
Log proof showing the `user-agent` header is correctly injected during the probe request:

```
Fetch called with:
URL: https://api.z.ai/api/paas/v4/chat/completions
Headers: {
  authorization: 'Bearer dummy-key-for-testing',
  'content-type': 'application/json',
  'user-agent': 'openclaw'
}
Result: null
```
