### PR TITLE
fix(gateway): distinguish reachable gateway from failed status probe

### DIFF
--- a/src/cli/daemon-cli/status.print.test.ts
+++ b/src/cli/daemon-cli/status.print.test.ts
@@ -907,6 +907,47 @@ describe("printDaemonStatus", () => {
     expect(logged).not.toContain("Warm-up: launch agents");
   });
 
+  it("keeps the warm-up hint (not owns-port guidance) when healthy is reachability-only and a stale gateway PID is still held", () => {
+    // inspectGatewayRestart can set healthy from reachability after ownership failed,
+    // while still returning non-empty staleGatewayPids. That must not be treated as
+    // owns-port proof, or this message would contradict the stale-PID diagnostic below.
+    printDaemonStatus(
+      {
+        service: {
+          label: "LaunchAgent",
+          loaded: true,
+          loadedText: "loaded",
+          notLoadedText: "not loaded",
+          runtime: { status: "running", pid: 8000 },
+        },
+        gateway: {
+          bindMode: "loopback",
+          bindHost: "127.0.0.1",
+          port: 18789,
+          portSource: "env/config",
+          probeUrl: "ws://127.0.0.1:18789",
+        },
+        rpc: {
+          ok: false,
+          error: "gateway closed (1008 policy violation: invalid token)",
+          url: "ws://127.0.0.1:18789",
+        },
+        health: {
+          healthy: true,
+          staleGatewayPids: [9000],
+        },
+        extraServices: [],
+      },
+      { json: false },
+    );
+
+    const logged = runtime.log.mock.calls.map(([line]) => line).join("\n");
+    expect(logged).toContain("Warm-up: launch agents can take a few seconds");
+    expect(logged).not.toContain("Gateway process is running and owns the gateway port");
+    const errors = runtime.error.mock.calls.map(([line]) => line).join("\n");
+    expect(errors).toContain("Gateway runtime PID does not own the listening port");
+  });
+
   it("keeps the warm-up hint for an unhealthy gateway, even with the port held", () => {
     printDaemonStatus(
       {

--- a/src/cli/daemon-cli/status.print.test.ts
+++ b/src/cli/daemon-cli/status.print.test.ts
@@ -866,4 +866,121 @@ describe("printDaemonStatus", () => {
     expect(errors).toContain("Service is loaded but not running (likely exited immediately).");
     expect(errors).not.toContain("systemd stopped restarting the gateway");
   });
+
+  it("steers a failed RPC probe to credentials/config when the gateway process owns the port", () => {
+    printDaemonStatus(
+      {
+        service: {
+          label: "LaunchAgent",
+          loaded: true,
+          loadedText: "loaded",
+          notLoadedText: "not loaded",
+          runtime: { status: "running", pid: 8000 },
+        },
+        gateway: {
+          bindMode: "loopback",
+          bindHost: "127.0.0.1",
+          port: 18789,
+          portSource: "env/config",
+          probeUrl: "ws://127.0.0.1:18789",
+        },
+        rpc: {
+          ok: false,
+          error: "gateway closed (1008 policy violation: invalid token)",
+          url: "ws://127.0.0.1:18789",
+        },
+        health: {
+          healthy: true,
+          staleGatewayPids: [],
+        },
+        extraServices: [],
+      },
+      { json: false },
+    );
+
+    expectMockLineContains(
+      runtime.log,
+      "Gateway process is running and owns the gateway port, so this is not a warm-up delay",
+    );
+    expectMockLineContains(runtime.log, "Check the probe credentials/config");
+    const logged = runtime.log.mock.calls.map(([line]) => line).join("\n");
+    expect(logged).not.toContain("Warm-up: launch agents");
+  });
+
+  it("keeps the warm-up hint for an unhealthy gateway, even with the port held", () => {
+    printDaemonStatus(
+      {
+        service: {
+          label: "LaunchAgent",
+          loaded: true,
+          loadedText: "loaded",
+          notLoadedText: "not loaded",
+          runtime: { status: "running", pid: 8000 },
+        },
+        gateway: {
+          bindMode: "loopback",
+          bindHost: "127.0.0.1",
+          port: 18789,
+          portSource: "env/config",
+          probeUrl: "ws://127.0.0.1:18789",
+        },
+        rpc: {
+          ok: false,
+          error: "gateway closed (1006 abnormal closure (no close frame))",
+          url: "ws://127.0.0.1:18789",
+        },
+        port: {
+          port: 18789,
+          status: "busy",
+          listeners: [],
+          hints: [],
+        },
+        health: {
+          healthy: false,
+          staleGatewayPids: [],
+        },
+        extraServices: [],
+      },
+      { json: false },
+    );
+
+    // health.healthy === false is ambiguous (not-yet-bound / foreign port conflict / stale
+    // PID), so it keeps the warm-up hint rather than steering to a restart; the dedicated
+    // stale-PID / port-not-listening / port-conflict blocks own those cases.
+    expectMockLineContains(runtime.log, "Warm-up: launch agents can take a few seconds");
+    const logged = runtime.log.mock.calls.map(([line]) => line).join("\n");
+    expect(logged).not.toContain("Gateway process is");
+  });
+
+  it("keeps the warm-up hint when gateway health is unknown", () => {
+    printDaemonStatus(
+      {
+        service: {
+          label: "LaunchAgent",
+          loaded: true,
+          loadedText: "loaded",
+          notLoadedText: "not loaded",
+          runtime: { status: "running", pid: 8000 },
+        },
+        gateway: {
+          bindMode: "loopback",
+          bindHost: "127.0.0.1",
+          port: 18789,
+          portSource: "env/config",
+          probeUrl: "ws://127.0.0.1:18789",
+        },
+        rpc: {
+          ok: false,
+          error: "gateway closed (1006 abnormal closure (no close frame))",
+          url: "ws://127.0.0.1:18789",
+        },
+        extraServices: [],
+      },
+      { json: false },
+    );
+
+    expectMockLineContains(runtime.log, "Warm-up: launch agents can take a few seconds");
+    const logged = runtime.log.mock.calls.map(([line]) => line).join("\n");
+    expect(logged).not.toContain("Gateway process is");
+  });
 });

--- a/src/cli/daemon-cli/status.print.ts
+++ b/src/cli/daemon-cli/status.print.ts
@@ -265,15 +265,19 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean; d
 
   if (rpc && !rpc.ok && service.loaded && service.runtime?.status === "running") {
     // The RPC probe failed while the service is loaded and running. Only the case where
-    // the gateway process is up and owns the listening port (health.healthy === true,
-    // deep status only) is an unambiguous "not warm-up" signal, so it gets recovery
-    // guidance. Every health.healthy === false sub-case — a just-started gateway that has
-    // not bound the port yet, a foreign process holding the port, or a stale gateway PID —
-    // is either a normal warm-up window or is already covered by the dedicated stale-PID /
-    // port-not-listening / port-conflict diagnostics below, so it keeps the warm-up hint
-    // (as does unknown health from shallow status). A wedged gateway that owns the port is
-    // reported as healthy === true, so it is steered by the first branch.
-    if (status.health?.healthy === true) {
+    // the gateway process is up and owns the listening port (health.healthy === true with
+    // no stale gateway PIDs, deep status only) is an unambiguous "not warm-up" signal, so it
+    // gets recovery guidance. `healthy` can also be set from bare reachability after
+    // ownership failed (see restart-health.ts), which can coexist with a non-empty
+    // staleGatewayPids; treat that combination as ambiguous rather than owns-port so it
+    // doesn't contradict the dedicated stale-PID diagnostic below. Every other
+    // health.healthy === false sub-case — a just-started gateway that has not bound the port
+    // yet, a foreign process holding the port, or a stale gateway PID — is either a normal
+    // warm-up window or is already covered by the dedicated stale-PID / port-not-listening /
+    // port-conflict diagnostics below, so it keeps the warm-up hint (as does unknown health
+    // from shallow status). A wedged gateway that owns the port is reported as healthy ===
+    // true with no stale gateway PIDs, so it is steered by the first branch.
+    if (status.health?.healthy === true && status.health.staleGatewayPids.length === 0) {
       defaultRuntime.log(
         warnText(
           "Gateway process is running and owns the gateway port, so this is not a warm-up delay. Check the probe credentials/config, or restart the gateway and inspect its logs if it stays unresponsive.",

--- a/src/cli/daemon-cli/status.print.ts
+++ b/src/cli/daemon-cli/status.print.ts
@@ -264,9 +264,26 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean; d
   }
 
   if (rpc && !rpc.ok && service.loaded && service.runtime?.status === "running") {
-    defaultRuntime.log(
-      warnText("Warm-up: launch agents can take a few seconds. Try again shortly."),
-    );
+    // The RPC probe failed while the service is loaded and running. Only the case where
+    // the gateway process is up and owns the listening port (health.healthy === true,
+    // deep status only) is an unambiguous "not warm-up" signal, so it gets recovery
+    // guidance. Every health.healthy === false sub-case — a just-started gateway that has
+    // not bound the port yet, a foreign process holding the port, or a stale gateway PID —
+    // is either a normal warm-up window or is already covered by the dedicated stale-PID /
+    // port-not-listening / port-conflict diagnostics below, so it keeps the warm-up hint
+    // (as does unknown health from shallow status). A wedged gateway that owns the port is
+    // reported as healthy === true, so it is steered by the first branch.
+    if (status.health?.healthy === true) {
+      defaultRuntime.log(
+        warnText(
+          "Gateway process is running and owns the gateway port, so this is not a warm-up delay. Check the probe credentials/config, or restart the gateway and inspect its logs if it stays unresponsive.",
+        ),
+      );
+    } else {
+      defaultRuntime.log(
+        warnText("Warm-up: launch agents can take a few seconds. Try again shortly."),
+      );
+    }
   }
   if (rpc) {
     const probeLabel = formatProbeKindLabel(rpc.kind);


### PR DESCRIPTION
## What Problem This Solves

`openclaw gateway status` prints `Warm-up: launch agents can take a few seconds. Try again shortly.` whenever the RPC probe fails while the managed service is loaded and running — even when the gateway process is up and owns its port and the probe is failing for an unrelated reason such as a wrong probe auth token or bad config.

In that state the gateway is clearly not "warming up", so telling the operator to wait and retry is the wrong nudge — they should be checking the probe credentials/config (or restarting if the gateway is wedged). This follows the same status-distinction lineage as the recent `/status` slices (#97479, #97878).

## Why This Change Was Made

Deep status already computes `status.health.healthy`, which is `running && owns-the-listening-port` (it is not a reachability proof). When that is true and the RPC probe still fails, it is an unambiguous "not warm-up" signal, so the message changes from warm-up to recovery guidance. Everything else keeps the existing warm-up message:

- `health.healthy === true`: the gateway process is running and owns the port, so a failed probe is not a warm-up delay. The cause is probe credentials/config or a wedged gateway (a wedged gateway that still owns the port is also reported as `healthy === true`), so we point the operator at both paths without asserting a single cause.
- otherwise: keep the existing warm-up message. `health.healthy === false` is deliberately not redirected — it is ambiguous (a just-started gateway reports `false` until it binds the port; the port may be held by a foreign process; or a stale gateway PID may own it), and those cases are already covered by the dedicated stale-PID, "port not listening", and port-conflict diagnostics elsewhere in the status output. Unknown health (shallow status) also keeps warm-up.

This is presentation-only. Health computation, probe behavior, service-manager behavior, config, and RPC are untouched; no new config/default surfaces, no new imports.

## User Impact

When the RPC probe fails on a running service whose gateway owns the port, `openclaw gateway status` now prints:

> Gateway process is running and owns the gateway port, so this is not a warm-up delay. Check the probe credentials/config, or restart the gateway and inspect its logs if it stays unresponsive.

instead of the generic warm-up line. All other states (gateway still starting up, port held by another process, stale PID, or unknown health) keep the existing warm-up message and the existing dedicated diagnostics. No behavior change beyond the printed guidance text.

## Evidence

- Focused render tests — `pnpm test src/cli/daemon-cli/status.print.test.ts` → 20 passed (17 existing + 3 new):
  - `health.healthy:true` + failed probe + running → owns-port "not a warm-up delay" guidance, no warm-up line.
  - `health.healthy:false` + port busy + running → warm-up line preserved, no "Gateway process is …" guidance (guards against misfiring restart guidance on a foreign port conflict).
  - no `health` → existing warm-up line preserved, no "Gateway process is …" line.
- Typecheck: `pnpm tsgo:core` and `pnpm tsgo:test:src` clean. Format: `oxfmt --check` clean.
- Render-path capture — invoked the real `printDaemonStatus` (no mocks; real CLI status styles, real `formatCliCommand`, real runtime) with a constructed `DaemonStatus` per case. This exercises the changed render path, not gather/deep status (which is unchanged). Excerpted output (surrounding status lines omitted):

```
########## health.healthy=true + port busy (running, owns port, probe failed) ##########
Runtime: running (pid 8000)
Gateway process is running and owns the gateway port, so this is not a warm-up delay. Check the probe credentials/config, or restart the gateway and inspect its logs if it stays unresponsive.
Connectivity probe: failed
  gateway closed (1008 policy violation: invalid token)

########## health.healthy=false + port busy (unhealthy/ambiguous) ##########
Runtime: running (pid 8000)
Warm-up: launch agents can take a few seconds. Try again shortly.

########## health=undefined + port busy (shallow status, unknown) ##########
Runtime: running (pid 8000)
Warm-up: launch agents can take a few seconds. Try again shortly.
```
