### PR TITLE
fix(agent): align gateway CLI timeout default

### DIFF
--- a/docs/gateway/config-agents.md
+++ b/docs/gateway/config-agents.md
@@ -408,7 +408,8 @@ Time format in system prompt. Default: `auto` (OS preference).
       toolProgressDetail: "explain",
       reasoningDefault: "off",
       elevatedDefault: "on",
-      timeoutSeconds: 600,
+      // Omit timeoutSeconds to inherit the 48h runtime default. Set a
+      // shorter value only for intentionally bounded agents.
       mediaMaxMb: 5,
       contextTokens: 200000,
       maxConcurrent: 3,

--- a/docs/gateway/configuration-examples.md
+++ b/docs/gateway/configuration-examples.md
@@ -268,7 +268,8 @@ Save to `~/.openclaw/openclaw.json` and you can DM the bot from that number.
       humanDelay: {
         mode: "natural",
       },
-      timeoutSeconds: 600,
+      // Omit timeoutSeconds to use the shared 48h agent runtime default.
+      // Set a shorter value only for intentionally bounded agents.
       mediaMaxMb: 5,
       typingIntervalSeconds: 5,
       maxConcurrent: 3,

--- a/src/agents/timeout.ts
+++ b/src/agents/timeout.ts
@@ -9,7 +9,7 @@ import {
 } from "@openclaw/normalization-core/number-coercion";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 
-const DEFAULT_AGENT_TIMEOUT_SECONDS = 48 * 60 * 60;
+export const DEFAULT_AGENT_TIMEOUT_SECONDS = 48 * 60 * 60;
 
 const normalizeNumber = (value: unknown): number | undefined =>
   typeof value === "number" && Number.isFinite(value) ? Math.floor(value) : undefined;

--- a/src/commands/agent-via-gateway.test.ts
+++ b/src/commands/agent-via-gateway.test.ts
@@ -55,7 +55,6 @@ function mockConfig(storePath: string, overrides?: Partial<OpenClawConfig>) {
   const config = {
     agents: {
       defaults: {
-        timeoutSeconds: 600,
         ...overrides?.agents?.defaults,
       },
       ...(overrides?.agents?.list ? { list: overrides.agents.list } : {}),
@@ -124,6 +123,11 @@ function requireRecord(value: unknown, label: string): Record<string, unknown> {
     throw new Error(`expected ${label} object`);
   }
   return value as Record<string, unknown>;
+}
+
+function getGatewayRequestParams(): Record<string, unknown> {
+  const request = requireRecord(requireFirstCallArg(callGateway, "gateway"), "gateway request");
+  return requireRecord(request.params, "gateway request params");
 }
 
 function createSignalProcess() {
@@ -288,6 +292,29 @@ describe("agentCliCommand", () => {
       ).rejects.toThrow("Invalid --timeout");
       expect(callGateway).not.toHaveBeenCalled();
     });
+  });
+
+  it("uses the shared 48h agent timeout when config and CLI omit a timeout", async () => {
+    await withTempStore(async () => {
+      mockGatewaySuccessReply();
+
+      await agentCliCommand({ message: "hi", to: "+1555" }, runtime);
+
+      expect(getGatewayRequestParams().timeout).toBe(172_800);
+    });
+  });
+
+  it("uses an explicitly configured agent timeout for gateway dispatch", async () => {
+    await withTempStore(
+      async () => {
+        mockGatewaySuccessReply();
+
+        await agentCliCommand({ message: "hi", to: "+1555" }, runtime);
+
+        expect(getGatewayRequestParams().timeout).toBe(900);
+      },
+      { agents: { defaults: { timeoutSeconds: 900 } } },
+    );
   });
 
   it("uses gateway by default", async () => {

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -9,6 +9,7 @@ import {
   GATEWAY_CLIENT_NAMES,
 } from "../../packages/gateway-protocol/src/client-info.js";
 import { listAgentIds, resolveDefaultAgentId } from "../agents/agent-scope-config.js";
+import { DEFAULT_AGENT_TIMEOUT_SECONDS } from "../agents/timeout.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { CliDeps } from "../cli/deps.types.js";
 import { withProgress } from "../cli/progress.js";
@@ -240,7 +241,7 @@ function parseTimeoutSeconds(opts: { cfg: OpenClawConfig; timeout?: string }) {
   const raw =
     opts.timeout !== undefined
       ? parseStrictNonNegativeInteger(opts.timeout)
-      : (opts.cfg.agents?.defaults?.timeoutSeconds ?? 600);
+      : (opts.cfg.agents?.defaults?.timeoutSeconds ?? DEFAULT_AGENT_TIMEOUT_SECONDS);
   if (raw === undefined) {
     throw new Error(
       `Invalid --timeout. Use seconds as a non-negative integer, for example --timeout 600. Use --timeout 0 to disable the timeout.`,


### PR DESCRIPTION
## Summary

- align `openclaw agent` / agent-via-gateway's omitted timeout with the shared 48h agent runtime default
- keep explicitly configured `agents.defaults.timeoutSeconds` and `--timeout` overrides unchanged
- remove generic 600s agent timeout examples from gateway docs so users do not copy an accidental 10-minute cap

## Issue / Motivation

Fixes #98180.

The embedded runtime defaults unset `agents.defaults.timeoutSeconds` to 48h, but agent-via-gateway still fell back to 600s when config omitted a timeout. That made CLI/gateway-dispatched agent runs shorter than the documented runtime default and reinforced docs examples that looked like a general default.

## What Problem This Solves

Gateway-dispatched agent runs now use the same 48-hour default as embedded agent execution when no timeout is configured. Users who omit `--timeout` or `agents.defaults.timeoutSeconds` no longer get an unexpected 10-minute cap, while explicit short timeouts still work exactly as before.

## Changes

- Export the shared `DEFAULT_AGENT_TIMEOUT_SECONDS` constant from `src/agents/timeout.ts`.
- Use that constant in `src/commands/agent-via-gateway.ts` when neither `--timeout` nor `agents.defaults.timeoutSeconds` is set.
- Add regression coverage for omitted timeout using `172_800` seconds and for explicit configured timeouts.
- Update gateway docs examples to omit `timeoutSeconds: 600` and call out short timeouts as intentional bounds only.

## Testing

- `node scripts/run-vitest.mjs src/commands/agent-via-gateway.test.ts src/agents/subagent-depth.test.ts` — passed locally: commands shard 70 passed, agents shard 11 passed.
- `git diff --check` — passed.
- Secret scan over `git diff origin/main...HEAD` added lines — `SECRET_SCAN_MATCHES 0`.

## Evidence

- Regression coverage exercises the omitted-timeout path and asserts the CLI payload now receives `timeoutSeconds: 172800` when config and CLI flags omit a timeout.
- The same test file keeps explicit `agents.defaults.timeoutSeconds` coverage, proving configured shorter limits still override the shared default.
- Local verification on 2026-07-01:
  - `src/commands/agent-via-gateway.test.ts`: 70 tests passed.
  - `src/agents/subagent-depth.test.ts`: 11 tests passed.
  - `git diff --check`: clean.
  - added-line secret scan: `SECRET_SCAN_MATCHES 0`.
