### PR TITLE
fix: align gateway agent timeout default

### DIFF
--- a/docs/cli/agent.md
+++ b/docs/cli/agent.md
@@ -38,7 +38,7 @@ Related:
 - `--reply-account <id>`: delivery account override
 - `--local`: run the embedded agent directly (after plugin registry preload)
 - `--deliver`: send the reply back to the selected channel/target
-- `--timeout <seconds>`: override agent timeout (default 600 or config value)
+- `--timeout <seconds>`: override agent timeout (config value or runtime default 172800 seconds)
 - `--json`: output JSON
 
 ## Examples

--- a/docs/gateway/config-agents.md
+++ b/docs/gateway/config-agents.md
@@ -408,7 +408,6 @@ Time format in system prompt. Default: `auto` (OS preference).
       toolProgressDetail: "explain",
       reasoningDefault: "off",
       elevatedDefault: "on",
-      timeoutSeconds: 600,
       mediaMaxMb: 5,
       contextTokens: 200000,
       maxConcurrent: 3,
@@ -420,6 +419,8 @@ Time format in system prompt. Default: `auto` (OS preference).
 - `model`: accepts either a string (`"provider/model"`) or an object (`{ primary, fallbacks }`).
   - String form sets only the primary model.
   - Object form sets primary plus ordered failover models.
+- `timeoutSeconds`: when omitted, whole-agent runs use the runtime default of `172800` seconds (48 hours). Set this only when you intentionally want a
+  shorter global ceiling for every agent run.
 - `imageModel`: accepts either a string (`"provider/model"`) or an object (`{ primary, fallbacks }`).
   - Used by the `image` tool path as its vision-model config.
   - Also used as fallback routing when the selected/default model cannot accept image input.

--- a/docs/gateway/configuration-examples.md
+++ b/docs/gateway/configuration-examples.md
@@ -268,7 +268,6 @@ Save to `~/.openclaw/openclaw.json` and you can DM the bot from that number.
       humanDelay: {
         mode: "natural",
       },
-      timeoutSeconds: 600,
       mediaMaxMb: 5,
       typingIntervalSeconds: 5,
       maxConcurrent: 3,
@@ -473,6 +472,10 @@ Save to `~/.openclaw/openclaw.json` and you can DM the bot from that number.
   },
 }
 ```
+
+Omit `agents.defaults.timeoutSeconds` to use the runtime default of `172800`
+seconds (48 hours). Add it only for deployments that intentionally want a
+shorter global ceiling for every agent run.
 
 ### Symlinked sibling skill repo
 

--- a/src/agents/timeout.ts
+++ b/src/agents/timeout.ts
@@ -9,7 +9,7 @@ import {
 } from "@openclaw/normalization-core/number-coercion";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 
-const DEFAULT_AGENT_TIMEOUT_SECONDS = 48 * 60 * 60;
+export const DEFAULT_AGENT_TIMEOUT_SECONDS = 48 * 60 * 60;
 
 const normalizeNumber = (value: unknown): number | undefined =>
   typeof value === "number" && Number.isFinite(value) ? Math.floor(value) : undefined;

--- a/src/agents/timeout.ts
+++ b/src/agents/timeout.ts
@@ -14,7 +14,7 @@ const DEFAULT_AGENT_TIMEOUT_SECONDS = 48 * 60 * 60;
 const normalizeNumber = (value: unknown): number | undefined =>
   typeof value === "number" && Number.isFinite(value) ? Math.floor(value) : undefined;
 
-function resolveAgentTimeoutSeconds(cfg?: OpenClawConfig): number {
+export function resolveAgentTimeoutSeconds(cfg?: OpenClawConfig): number {
   const raw = normalizeNumber(cfg?.agents?.defaults?.timeoutSeconds);
   const seconds = raw ?? DEFAULT_AGENT_TIMEOUT_SECONDS;
   return Math.max(seconds, 1);

--- a/src/cli/program/register.agent-turn.ts
+++ b/src/cli/program/register.agent-turn.ts
@@ -62,7 +62,7 @@ export function registerAgentTurnCommand(
     .option("--json", "Output result as JSON", false)
     .option(
       "--timeout <seconds>",
-      "Override agent command timeout (seconds, default 600 or config value)",
+      "Override agent command timeout (seconds, config value or runtime default 172800)",
     )
     .addHelpText(
       "after",

--- a/src/commands/agent-via-gateway.test.ts
+++ b/src/commands/agent-via-gateway.test.ts
@@ -290,9 +290,12 @@ describe("agentCliCommand", () => {
     });
   });
 
-  it("omits the gateway timeout override when --timeout is omitted", async () => {
+  it("omits the gateway timeout override and preserves longer server-owned waits", async () => {
     await withTempStore(async ({ store }) => {
-      const config = { agents: { defaults: {} }, session: { store, mainKey: "main" } };
+      const config = {
+        agents: { defaults: { timeoutSeconds: 200_000 } },
+        session: { store, mainKey: "main" },
+      };
       loadConfig.mockReturnValue(config);
       loadRuntimeConfig.mockReturnValue(config);
       loadConfigWithShellEnvFallback.mockResolvedValue(config);
@@ -304,7 +307,7 @@ describe("agentCliCommand", () => {
       const request = requireRecord(requireFirstCallArg(callGateway, "gateway"), "gateway request");
       const params = requireRecord(request.params, "gateway request params");
       expect(params).not.toHaveProperty("timeout");
-      expect(request.timeoutMs).toBe(172_830_000);
+      expect(request.timeoutMs).toBe(2_147_000_000);
     });
   });
 

--- a/src/commands/agent-via-gateway.test.ts
+++ b/src/commands/agent-via-gateway.test.ts
@@ -290,6 +290,24 @@ describe("agentCliCommand", () => {
     });
   });
 
+  it("uses the runtime default timeout when config omits the agent default", async () => {
+    await withTempStore(async ({ store }) => {
+      const config = { agents: { defaults: {} }, session: { store, mainKey: "main" } };
+      loadConfig.mockReturnValue(config);
+      loadRuntimeConfig.mockReturnValue(config);
+      loadConfigWithShellEnvFallback.mockResolvedValue(config);
+      mockGatewaySuccessReply();
+
+      await agentCliCommand({ message: "hi", to: "+1555" }, runtime);
+
+      expect(callGateway).toHaveBeenCalledTimes(1);
+      const request = requireRecord(requireFirstCallArg(callGateway, "gateway"), "gateway request");
+      const params = requireRecord(request.params, "gateway request params");
+      expect(params.timeout).toBe(172_800);
+      expect(request.timeoutMs).toBe(172_830_000);
+    });
+  });
+
   it("uses gateway by default", async () => {
     await withTempStore(async () => {
       mockGatewaySuccessReply();

--- a/src/commands/agent-via-gateway.test.ts
+++ b/src/commands/agent-via-gateway.test.ts
@@ -290,7 +290,7 @@ describe("agentCliCommand", () => {
     });
   });
 
-  it("uses the runtime default timeout when config omits the agent default", async () => {
+  it("omits the gateway timeout override when --timeout is omitted", async () => {
     await withTempStore(async ({ store }) => {
       const config = { agents: { defaults: {} }, session: { store, mainKey: "main" } };
       loadConfig.mockReturnValue(config);
@@ -303,8 +303,22 @@ describe("agentCliCommand", () => {
       expect(callGateway).toHaveBeenCalledTimes(1);
       const request = requireRecord(requireFirstCallArg(callGateway, "gateway"), "gateway request");
       const params = requireRecord(request.params, "gateway request params");
-      expect(params.timeout).toBe(172_800);
+      expect(params).not.toHaveProperty("timeout");
       expect(request.timeoutMs).toBe(172_830_000);
+    });
+  });
+
+  it("sends the gateway timeout override when --timeout is explicit", async () => {
+    await withTempStore(async () => {
+      mockGatewaySuccessReply();
+
+      await agentCliCommand({ message: "hi", to: "+1555", timeout: "600" }, runtime);
+
+      expect(callGateway).toHaveBeenCalledTimes(1);
+      const request = requireRecord(requireFirstCallArg(callGateway, "gateway"), "gateway request");
+      const params = requireRecord(request.params, "gateway request params");
+      expect(params.timeout).toBe(600);
+      expect(request.timeoutMs).toBe(630_000);
     });
   });
 

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -9,7 +9,6 @@ import {
   GATEWAY_CLIENT_NAMES,
 } from "../../packages/gateway-protocol/src/client-info.js";
 import { listAgentIds, resolveDefaultAgentId } from "../agents/agent-scope-config.js";
-import { DEFAULT_AGENT_TIMEOUT_SECONDS } from "../agents/timeout.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { CliDeps } from "../cli/deps.types.js";
 import { withProgress } from "../cli/progress.js";
@@ -714,9 +713,10 @@ async function agentViaGatewayCommand(
     }
   }
   const timeoutSeconds = parseTimeoutSeconds(opts.timeout);
-  const gatewayTimeoutMs = resolveGatewayAgentTimeoutMs(
-    timeoutSeconds ?? DEFAULT_AGENT_TIMEOUT_SECONDS,
-  );
+  const gatewayTimeoutMs =
+    timeoutSeconds === undefined
+      ? NO_GATEWAY_TIMEOUT_MS
+      : resolveGatewayAgentTimeoutMs(timeoutSeconds);
 
   const sessionKey =
     classifySessionKeyShape(explicitSessionKey) === "agent"

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -9,7 +9,7 @@ import {
   GATEWAY_CLIENT_NAMES,
 } from "../../packages/gateway-protocol/src/client-info.js";
 import { listAgentIds, resolveDefaultAgentId } from "../agents/agent-scope-config.js";
-import { resolveAgentTimeoutSeconds } from "../agents/timeout.js";
+import { DEFAULT_AGENT_TIMEOUT_SECONDS } from "../agents/timeout.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { CliDeps } from "../cli/deps.types.js";
 import { withProgress } from "../cli/progress.js";
@@ -237,11 +237,11 @@ async function resolveAgentMessageOpts(opts: AgentCliOpts): Promise<AgentDispatc
   return { ...rest, message };
 }
 
-function parseTimeoutSeconds(opts: { cfg: OpenClawConfig; timeout?: string }) {
-  const raw =
-    opts.timeout !== undefined
-      ? parseStrictNonNegativeInteger(opts.timeout)
-      : resolveAgentTimeoutSeconds(opts.cfg);
+function parseTimeoutSeconds(timeout?: string) {
+  if (timeout === undefined) {
+    return undefined;
+  }
+  const raw = parseStrictNonNegativeInteger(timeout);
   if (raw === undefined) {
     throw new Error(
       `Invalid --timeout. Use seconds as a non-negative integer, for example --timeout 600. Use --timeout 0 to disable the timeout.`,
@@ -713,8 +713,10 @@ async function agentViaGatewayCommand(
       );
     }
   }
-  const timeoutSeconds = parseTimeoutSeconds({ cfg, timeout: opts.timeout });
-  const gatewayTimeoutMs = resolveGatewayAgentTimeoutMs(timeoutSeconds);
+  const timeoutSeconds = parseTimeoutSeconds(opts.timeout);
+  const gatewayTimeoutMs = resolveGatewayAgentTimeoutMs(
+    timeoutSeconds ?? DEFAULT_AGENT_TIMEOUT_SECONDS,
+  );
 
   const sessionKey =
     classifySessionKeyShape(explicitSessionKey) === "agent"
@@ -773,7 +775,7 @@ async function agentViaGatewayCommand(
             replyChannel: opts.replyChannel,
             replyAccountId: opts.replyAccount,
             bestEffortDeliver: opts.bestEffortDeliver,
-            timeout: timeoutSeconds,
+            ...(timeoutSeconds !== undefined ? { timeout: timeoutSeconds } : {}),
             lane: opts.lane,
             extraSystemPrompt: opts.extraSystemPrompt,
             cleanupBundleMcpOnRunEnd: true,

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -9,6 +9,7 @@ import {
   GATEWAY_CLIENT_NAMES,
 } from "../../packages/gateway-protocol/src/client-info.js";
 import { listAgentIds, resolveDefaultAgentId } from "../agents/agent-scope-config.js";
+import { resolveAgentTimeoutSeconds } from "../agents/timeout.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { CliDeps } from "../cli/deps.types.js";
 import { withProgress } from "../cli/progress.js";
@@ -240,7 +241,7 @@ function parseTimeoutSeconds(opts: { cfg: OpenClawConfig; timeout?: string }) {
   const raw =
     opts.timeout !== undefined
       ? parseStrictNonNegativeInteger(opts.timeout)
-      : (opts.cfg.agents?.defaults?.timeoutSeconds ?? 600);
+      : resolveAgentTimeoutSeconds(opts.cfg);
   if (raw === undefined) {
     throw new Error(
       `Invalid --timeout. Use seconds as a non-negative integer, for example --timeout 600. Use --timeout 0 to disable the timeout.`,


### PR DESCRIPTION
Closes #98180

## What Problem This Solves

Fixes an issue where users copying generic agent config examples could accidentally cap normal agent runs at 10 minutes even though OpenClaw's runtime default is 48 hours when `agents.defaults.timeoutSeconds` is omitted.

## Why This Change Was Made

The generic docs/examples now omit `agents.defaults.timeoutSeconds` and explicitly explain that omitted values use the `172800` second runtime default. The gateway-backed `openclaw agent` path now preserves omitted CLI timeouts as server-owned instead of carrying a separate `600` second RPC override. Explicit `--timeout` remains an override. Heartbeat-specific 600 second caps are left unchanged because they are intentionally bounded and already documented as heartbeat behavior.

## User Impact

Users and operators can copy the general agent examples without silently shortening whole-agent runtime to 10 minutes. Gateway operators keep control of server-side `agents.defaults.timeoutSeconds` when CLI callers omit `--timeout`; callers can still set an explicit per-run timeout with `--timeout <seconds>`.

## Evidence

- `pnpm docs:list >/tmp/openclaw-timeout-docs-list.txt`
- `pnpm docs:list >/tmp/openclaw-timeout-docs-list-2.txt`
- `git diff --check`
- `node scripts/format-docs.mjs --check docs/gateway/config-agents.md docs/gateway/configuration-examples.md docs/cli/agent.md`
- `node scripts/check-docs-mdx.mjs docs/gateway/config-agents.md docs/gateway/configuration-examples.md docs/cli/agent.md`
- `pnpm exec oxfmt --check src/agents/timeout.ts src/commands/agent-via-gateway.ts src/commands/agent-via-gateway.test.ts src/cli/program/register.agent-turn.ts`
- `node scripts/run-vitest.mjs src/commands/agent-via-gateway.test.ts src/cli/program/register.agent.test.ts` (70 agent-via-gateway tests + 16 CLI registration tests passed)
- CLI help proof: `pnpm exec tsx src/index.ts agent --help | rg -n -A2 -- "--timeout"` prints `Override agent command timeout (seconds, config value or runtime default 172800)`.
- Gateway dispatch regression proof in `src/commands/agent-via-gateway.test.ts`: omitted `--timeout` does not serialize `params.timeout` and uses a 172830000ms client wait ceiling; explicit `--timeout 600` serializes `params.timeout: 600` and uses a 630000ms client wait ceiling.

AI-assisted PR. I understand the change: it removes generic 600s agent-runtime examples, documents the 48h runtime default, and keeps omitted gateway CLI timeouts server-owned while preserving explicit timeout overrides.

## Real Gateway-Backed Timeout Proof

Ran against an isolated temporary OpenClaw gateway, not the live gateway. The gateway config set `agents.defaults.timeoutSeconds: 123` to prove omitted CLI timeout remains server-owned. A local WebSocket proxy only recorded the outbound CLI RPC frame and forwarded it to the real gateway; temp ports were redacted. The command used `/new` so the real `agent` gateway method completed without calling a model.

```json
{
  "gateway": {
    "isolated": true,
    "target": "127.0.0.1:<temp>",
    "proxy": "127.0.0.1:<temp>",
    "serverDefaultTimeoutSeconds": 123
  },
  "commands": {
    "omittedExit": 0,
    "explicitExit": 0,
    "omittedStderr": "",
    "explicitStderr": ""
  },
  "agentRpcFrames": [
    {
      "index": 1,
      "message": "/new",
      "sessionKey": "agent:main:timeout-proof-omitted",
      "hasTimeout": false,
      "paramsKeys": [
        "agentId",
        "cleanupBundleMcpOnRunEnd",
        "deliver",
        "idempotencyKey",
        "message",
        "sessionKey"
      ]
    },
    {
      "index": 2,
      "message": "/new",
      "sessionKey": "agent:main:timeout-proof-explicit",
      "hasTimeout": true,
      "timeout": 600,
      "paramsKeys": [
        "agentId",
        "cleanupBundleMcpOnRunEnd",
        "deliver",
        "idempotencyKey",
        "message",
        "sessionKey",
        "timeout"
      ]
    }
  ]
}
```

Interpretation: current PR head preserves omitted `--timeout` as no `params.timeout` in the real CLI-to-gateway request, while explicit `--timeout 600` still serializes `params.timeout: 600`. Both calls were accepted by the actual gateway-backed `agent` method and returned `status: ok` reset acknowledgements.

Compatibility note: this intentionally changes omitted gateway CLI calls from the old local 600-second fallback to server-owned/default timeout behavior. Explicit `--timeout` remains the per-run override path.