### PR TITLE
fix(openrouter): send explicit auth headers

### DIFF
--- a/extensions/openrouter/index.test.ts
+++ b/extensions/openrouter/index.test.ts
@@ -65,6 +65,26 @@ function createOpenRouterDoneStream(params: { responseId: string; totalCost: num
   return stream;
 }
 
+function createOpenRouterDoneStreamWithoutGeneration() {
+  const stream = createAssistantMessageEventStream();
+  queueMicrotask(() => {
+    stream.push({
+      type: "done",
+      reason: "stop",
+      message: {
+        role: "assistant",
+        api: "openai-completions",
+        provider: "openrouter",
+        model: "openrouter/auto",
+        content: [{ type: "text", text: "ok" }],
+        stopReason: "stop",
+        timestamp: Date.now(),
+      } as never,
+    });
+  });
+  return stream;
+}
+
 function createOpenRouterAbortedStream() {
   const stream = createAssistantMessageEventStream();
   queueMicrotask(() => {
@@ -746,6 +766,40 @@ describe("openrouter provider hooks", () => {
     expect(capturedPayload?.provider).toEqual({
       order: ["moonshot"],
     });
+  });
+
+  it("forwards resolved API keys as explicit OpenRouter auth headers", async () => {
+    const provider = await registerSingleProviderPlugin(openrouterPlugin);
+    const baseStreamFn = vi.fn(() => createOpenRouterDoneStreamWithoutGeneration());
+
+    const wrapped = provider.wrapStreamFn?.({
+      provider: "openrouter",
+      modelId: "openrouter/auto",
+      streamFn: baseStreamFn,
+    } as never);
+    if (!wrapped) {
+      throw new Error("expected OpenRouter wrapper");
+    }
+
+    const stream = await wrapped(
+      {
+        provider: "openrouter",
+        api: "openai-completions",
+        id: "openrouter/auto",
+        baseUrl: "https://openrouter.ai/api/v1",
+        compat: {},
+      } as never,
+      { messages: [] } as never,
+      { apiKey: "or-test-key" } as never,
+    );
+    await stream.result();
+
+    expect(baseStreamFn).toHaveBeenCalledOnce();
+    const options = baseStreamFn.mock.calls[0]?.[2] as { headers?: HeadersInit } | undefined;
+    const headers = new Headers(options?.headers);
+    expect(headers.get("authorization")).toBe("Bearer or-test-key");
+    expect(headers.get("http-referer")).toBe("https://openclaw.ai");
+    expect(headers.get("x-openrouter-title")).toBe("OpenClaw");
   });
 
   it("reconciles OpenRouter streamed usage with generation metadata cost", async () => {

--- a/extensions/openrouter/index.test.ts
+++ b/extensions/openrouter/index.test.ts
@@ -770,7 +770,9 @@ describe("openrouter provider hooks", () => {
 
   it("forwards resolved API keys as explicit OpenRouter auth headers", async () => {
     const provider = await registerSingleProviderPlugin(openrouterPlugin);
-    const baseStreamFn = vi.fn(() => createOpenRouterDoneStreamWithoutGeneration());
+    const baseStreamFn = vi.fn((..._args: unknown[]) =>
+      createOpenRouterDoneStreamWithoutGeneration(),
+    );
 
     const wrapped = provider.wrapStreamFn?.({
       provider: "openrouter",

--- a/extensions/openrouter/stream.ts
+++ b/extensions/openrouter/stream.ts
@@ -206,6 +206,41 @@ function createOpenRouterBilledCostWrapper(
   };
 }
 
+function mergeOpenRouterAuthHeaders(options: Parameters<StreamFn>[2]): Parameters<StreamFn>[2] {
+  const apiKey = readString(options?.apiKey);
+  if (!apiKey) {
+    return options;
+  }
+  const headers = new Headers((options as { headers?: HeadersInit } | undefined)?.headers);
+  if (!headers.has("authorization")) {
+    headers.set("Authorization", `Bearer ${apiKey}`);
+  }
+  if (!headers.has("http-referer")) {
+    headers.set("HTTP-Referer", "https://openclaw.ai");
+  }
+  if (!headers.has("x-openrouter-title")) {
+    headers.set("X-OpenRouter-Title", "OpenClaw");
+  }
+  return {
+    ...options,
+    headers: Object.fromEntries(headers.entries()),
+  } as Parameters<StreamFn>[2];
+}
+
+function createOpenRouterAuthHeaderWrapper(
+  baseStreamFn: StreamFn | undefined,
+): StreamFn | undefined {
+  if (!baseStreamFn) {
+    return baseStreamFn;
+  }
+  return (model, context, options) =>
+    baseStreamFn(
+      model,
+      context,
+      isVerifiedOpenRouterRoute(model) ? mergeOpenRouterAuthHeaders(options) : options,
+    );
+}
+
 function assistantMessageHasOpenAIToolCalls(message: Record<string, unknown>): boolean {
   return Array.isArray(message.tool_calls) && message.tool_calls.length > 0;
 }
@@ -376,7 +411,9 @@ export function wrapOpenRouterProviderStream(
   if (!wrapStreamFn) {
     return createOpenRouterBilledCostWrapper(
       createOpenRouterAnthropicPrefillWrapper(
-        createOpenRouterDeepSeekV4ThinkingWrapper(routedStreamFn, ctx.thinkingLevel),
+        createOpenRouterAuthHeaderWrapper(
+          createOpenRouterDeepSeekV4ThinkingWrapper(routedStreamFn, ctx.thinkingLevel),
+        ),
       ),
     );
   }
@@ -390,7 +427,9 @@ export function wrapOpenRouterProviderStream(
     }) ?? undefined;
   return createOpenRouterBilledCostWrapper(
     createOpenRouterAnthropicPrefillWrapper(
-      createOpenRouterDeepSeekV4ThinkingWrapper(wrappedStreamFn, ctx.thinkingLevel),
+      createOpenRouterAuthHeaderWrapper(
+        createOpenRouterDeepSeekV4ThinkingWrapper(wrappedStreamFn, ctx.thinkingLevel),
+      ),
     ),
   );
 }

--- a/src/llm/providers/openai-compatible-auth.test.ts
+++ b/src/llm/providers/openai-compatible-auth.test.ts
@@ -1,14 +1,29 @@
 // OpenAI-compatible auth tests cover API key and base URL normalization.
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { captureEnv } from "../../test-utils/env.js";
 import type { Context, Model } from "../types.js";
 import { streamOpenAICompletions } from "./openai-completions.js";
 import { streamOpenAIResponses } from "./openai-responses.js";
 
+const mocks = vi.hoisted(() => ({
+  fetchWithSsrFGuard: vi.fn(),
+}));
+
+vi.mock("../../infra/net/fetch-guard.js", async () => {
+  const actual = await vi.importActual<typeof import("../../infra/net/fetch-guard.js")>(
+    "../../infra/net/fetch-guard.js",
+  );
+  return {
+    ...actual,
+    fetchWithSsrFGuard: mocks.fetchWithSsrFGuard,
+  };
+});
+
 const originalEnv = captureEnv(["OPENAI_API_KEY"]);
 
 afterEach(() => {
   originalEnv.restore();
+  mocks.fetchWithSsrFGuard.mockReset();
 });
 
 const context = {
@@ -51,6 +66,33 @@ describe("OpenAI-compatible provider credentials", () => {
 
     expect(result.stopReason).toBe("error");
     expect(result.errorMessage).toBe("No API key for provider: custom-openai-compatible");
+  });
+
+  it("sends explicit API keys as bearer auth for generic chat-completions providers", async () => {
+    let capturedHeaders: Headers | undefined;
+    mocks.fetchWithSsrFGuard.mockImplementationOnce(async (params: { init?: RequestInit }) => {
+      capturedHeaders = new Headers(params.init?.headers);
+      return {
+        response: new Response(
+          [
+            'data: {"id":"chatcmpl-test","object":"chat.completion.chunk","created":0,"model":"custom-model","choices":[{"index":0,"delta":{"content":"OK"},"finish_reason":null}]}',
+            'data: {"id":"chatcmpl-test","object":"chat.completion.chunk","created":0,"model":"custom-model","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}',
+            "data: [DONE]",
+            "",
+          ].join("\n\n"),
+          { headers: { "content-type": "text/event-stream" } },
+        ),
+        release: async () => undefined,
+      };
+    });
+
+    const stream = streamOpenAICompletions(createBaseModel("openai-completions"), context, {
+      apiKey: "sk-third-party",
+    });
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("stop");
+    expect(capturedHeaders?.get("authorization")).toBe("Bearer sk-third-party");
   });
 
   it("does not replay Responses item ids for direct store-disabled requests", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where OpenRouter API-key model probes and runs could reach OpenRouter without an explicit bearer auth header, producing `401 Missing Authentication header` even though OpenClaw had resolved a valid API key.

Fixes #97934

## Why This Change Was Made

OpenRouter's provider stream wrapper now forwards the resolved runtime API key as an explicit `Authorization: Bearer <key>` header on verified OpenRouter routes, alongside the existing app attribution headers. This keeps the fix inside the OpenRouter transport path and does not change profile/env credential selection.

## User Impact

OpenRouter users with env or profile API-key auth should get authenticated model requests instead of missing-header 401s.

## Evidence

- `node scripts/run-vitest.mjs src/commands/models/list.probe.test.ts src/agents/embedded-agent-runner/stream-resolution.test.ts src/agents/model-auth.test.ts src/agents/auth-profiles.sqlite-store.test.ts src/llm/providers/openai-compatible-auth.test.ts extensions/openrouter/index.test.ts`: passed 4 Vitest shards.
- `node scripts/run-vitest.mjs extensions/openrouter/index.test.ts src/llm/providers/openai-compatible-auth.test.ts && git diff --check`: passed.
- Live proof with `OPENROUTER_API_KEY` set in the shell; key details and local paths redacted:

```json
$ pnpm openclaw models status --probe --probe-provider openrouter --json
[openclaw] Building TypeScript (dist is stale: missing_build_stamp - build stamp missing).
[openclaw] Building bundled plugin assets.
22:15:37 [provider-transport-fetch] [model-fetch] start provider=openrouter api=openai-completions model=moonshotai/kimi-k2.5 method=POST url=https://openrouter.ai/api/v1/chat/completions timeoutMs=undefined proxy=none policy=custom
22:15:45 [provider-transport-fetch] [model-fetch] error provider=openrouter api=openai-completions model=moonshotai/kimi-k2.5 elapsedMs=8068 name=AbortError code=number causeName=undefined causeCode=undefined message=This operation was aborted
{
  "auth": {
    "storePath": "<redacted>/openclaw-agent.sqlite",
    "providers": [
      {
        "provider": "openrouter",
        "effective": {
          "kind": "env",
          "detail": "<redacted>"
        },
        "env": {
          "value": "<redacted>",
          "source": "env: OPENROUTER_API_KEY"
        }
      }
    ],
    "probes": {
      "totalTargets": 1,
      "options": {
        "provider": "openrouter",
        "profileIds": [],
        "timeoutMs": 8000,
        "concurrency": 2,
        "maxTokens": 8
      },
      "results": [
        {
          "provider": "openrouter",
          "model": "openrouter/moonshotai/kimi-k2.5",
          "label": "env",
          "source": "env",
          "mode": "api_key",
          "status": "ok",
          "latencyMs": 22847
        }
      ]
    }
  }
}
```

AI-assisted: built with Codex
