### PR TITLE
fix(cli): bound docs search API response reads

### DIFF
--- a/src/commands/docs.test.ts
+++ b/src/commands/docs.test.ts
@@ -94,4 +94,33 @@ describe("docsSearchCommand", () => {
     expect(runtime.exit).not.toHaveBeenCalled();
     expect(runtime.log).toHaveBeenCalled();
   });
+
+  it("rejects oversized docs search responses", async () => {
+    const ONE_MIB = 1024 * 1024;
+    const cancel = vi.fn();
+    const stream = new ReadableStream<Uint8Array>({
+      cancel,
+      start(controller) {
+        for (let i = 0; i < 10; i++) {
+          controller.enqueue(new Uint8Array(ONE_MIB));
+        }
+        controller.close();
+      },
+    });
+    fetchMock.mockResolvedValueOnce(
+      new Response(stream, {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const runtime = makeRuntime();
+
+    await docsSearchCommand(["oversized"], runtime);
+
+    expect(runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("Docs search response exceeds"),
+    );
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(cancel).toHaveBeenCalledOnce();
+  });
 });

--- a/src/commands/docs.ts
+++ b/src/commands/docs.ts
@@ -1,4 +1,5 @@
 // Implements docs link/search output for `openclaw docs`.
+import { readResponseWithLimit } from "@openclaw/media-core/read-response-with-limit";
 import { formatDocsLink } from "../../packages/terminal-core/src/links.js";
 import { isRich, theme } from "../../packages/terminal-core/src/theme.js";
 import { formatCliCommand } from "../cli/command-format.js";
@@ -6,6 +7,7 @@ import type { RuntimeEnv } from "../runtime.js";
 
 const SEARCH_API = "https://docs.openclaw.ai/api/search";
 const SEARCH_TIMEOUT_MS = 30_000;
+const DOCS_SEARCH_RESPONSE_MAX_BYTES = 8 * 1024 * 1024;
 
 type DocResult = {
   title: string;
@@ -75,7 +77,10 @@ async function fetchDocsSearch(query: string): Promise<DocResult[]> {
     if (!response.ok) {
       throw new Error(`HTTP ${response.status}`);
     }
-    const payload = (await response.json()) as DocsSearchResponse;
+    const bytes = await readResponseWithLimit(response, DOCS_SEARCH_RESPONSE_MAX_BYTES, {
+      onOverflow: ({ maxBytes }) => new Error(`Docs search response exceeds ${maxBytes} bytes`),
+    });
+    const payload = JSON.parse(new TextDecoder().decode(bytes)) as DocsSearchResponse;
     return parseDocsSearchResults(payload.results);
   } finally {
     clearTimeout(timeout);


### PR DESCRIPTION
## What Problem This Solves

`fetchDocsSearch` in `src/commands/docs.ts` calls `await response.json()` on the docs.openclaw.ai search API response without a read limit. A large or malicious response could force the CLI to buffer arbitrarily large payloads before JSON parsing, risking OOM.

Supersedes #96251 — adds the committed regression test that ClawSweeper requested.

## Why This Change Was Made

All external HTTP response reads should use `readResponseWithLimit` or `readProviderJsonResponse` to cap memory consumption. The docs search command already had a fetch timeout via `AbortController` but the response body was unbounded.

## User Impact

The `openclaw docs <query>` command is now protected against oversized search API responses. Normal queries work identically. An oversized response produces a clear error message instead of buffering the entire body.

## Evidence

**Environment**: Linux, Node 22, OpenClaw main

**Committed tests pass** (4/4, including oversized response rejection):
```
$ pnpm test src/commands/docs.test.ts --run --reporter=verbose

 ✓ docsSearchCommand > calls the Cloudflare docs search API
 ✓ docsSearchCommand > fails loudly when the Cloudflare docs search API fails
 ✓ docsSearchCommand > renders successful results from the Cloudflare docs search API
 ✓ docsSearchCommand > rejects oversized docs search responses

 Test Files  1 passed (1)
      Tests  4 passed (4)
```

**Oversized response test** proves the 8 MiB cap is enforced:
```ts
const stream = new ReadableStream<Uint8Array>({ cancel, start(controller) {
  for (let i = 0; i < 10; i++) controller.enqueue(new Uint8Array(ONE_MIB));
}});
// bounded reader throws "Docs search response exceeds 8388608 bytes"
// runtime.error called with the overflow message
// runtime.exit called with 1
// stream.cancel called once
```

**Build succeeds** (dist compiled, no type errors).

## Risk

Low. `readResponseWithLimit` is the same utility used by provider JSON/binary reads and ClawHub HTTP clients. The 8 MiB cap is generous for a docs search API response. No config, auth, or API surface changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
