### PR TITLE
fix(ios): focus missing gateway credentials

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -21163,7 +21163,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 110,
+      "line": 112,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Gateway rejected credentials.",
       "surface": "apple",
@@ -21171,7 +21171,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 114,
+      "line": 116,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Could not reach the gateway.",
       "surface": "apple",
@@ -21179,7 +21179,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 192,
+      "line": 194,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "QR Scanner Unavailable",
       "surface": "apple",
@@ -21187,7 +21187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 198,
+      "line": 200,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "OK",
       "surface": "apple",
@@ -21195,7 +21195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 303,
+      "line": 305,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Scan Setup Code",
       "surface": "apple",
@@ -21203,7 +21203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 311,
+      "line": 313,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Cancel",
       "surface": "apple",
@@ -21211,7 +21211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 318,
+      "line": 320,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Photos",
       "surface": "apple",
@@ -21219,7 +21219,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 359,
+      "line": 361,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Back",
       "surface": "apple",
@@ -21227,7 +21227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 367,
+      "line": 369,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Close",
       "surface": "apple",
@@ -21235,7 +21235,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 393,
+      "line": 395,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Dismiss Keyboard",
       "surface": "apple",
@@ -21243,7 +21243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 444,
+      "line": 446,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Mode",
       "surface": "apple",
@@ -21251,7 +21251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 445,
+      "line": 447,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Discovery",
       "surface": "apple",
@@ -21259,7 +21259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 447,
+      "line": 449,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Status",
       "surface": "apple",
@@ -21267,7 +21267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 465,
+      "line": 467,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Choose a mode first.",
       "surface": "apple",
@@ -21275,7 +21275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 470,
+      "line": 472,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Back to Mode Selection",
       "surface": "apple",
@@ -21283,7 +21283,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 514,
+      "line": 516,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Manual Fallback",
       "surface": "apple",
@@ -21291,7 +21291,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 518,
+      "line": 520,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Domain Settings",
       "surface": "apple",
@@ -21299,7 +21299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 529,
+      "line": 531,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Developer Local",
       "surface": "apple",
@@ -21307,7 +21307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 532,
+      "line": 534,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Default host is localhost. Use your Mac LAN IP if simulator networking requires it.",
       "surface": "apple",
@@ -21315,7 +21315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 560,
+      "line": 562,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Gateway rejected credentials. Scan a fresh setup code or update token/password.",
       "surface": "apple",
@@ -21323,7 +21323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 564,
+      "line": 570,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "OpenClaw is checking gateway and node access.",
       "surface": "apple",
@@ -21331,7 +21331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 578,
+      "line": 584,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Resume After Approval",
       "surface": "apple",
@@ -21339,7 +21339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 584,
+      "line": 590,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Pairing Approval",
       "surface": "apple",
@@ -21347,7 +21347,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 590,
+      "line": 596,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Request ID: %@",
       "surface": "apple",
@@ -21355,7 +21355,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 593,
+      "line": 599,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Request ID: check `openclaw devices list`.",
       "surface": "apple",
@@ -21363,7 +21363,7 @@
     },
     {
       "kind": "ui-localized-call-multiline",
-      "line": 597,
+      "line": 603,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Approve this device on the gateway.\n1) `%1$@`\n2) `/pair approve` in your OpenClaw chat\n%2$@\nOpenClaw will also retry automatically when you return to this app.",
       "surface": "apple",
@@ -21371,7 +21371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 614,
+      "line": 620,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Scan Setup Code Again",
       "surface": "apple",
@@ -21379,7 +21379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 627,
+      "line": 633,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Retry Connection",
       "surface": "apple",
@@ -21387,7 +21387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 658,
+      "line": 664,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Enter setup code",
       "surface": "apple",
@@ -21395,7 +21395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 674,
+      "line": 680,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Apply",
       "surface": "apple",
@@ -21403,7 +21403,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 692,
+      "line": 698,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Setup Code",
       "surface": "apple",
@@ -21411,7 +21411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 695,
+      "line": 701,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Use this if you have a setup code instead of scanning.",
       "surface": "apple",
@@ -21419,7 +21419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 707,
+      "line": 713,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Host",
       "surface": "apple",
@@ -21427,7 +21427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 708,
+      "line": 714,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Port",
       "surface": "apple",
@@ -21435,7 +21435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 711,
+      "line": 717,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Discovery Domain (optional)",
       "surface": "apple",
@@ -21443,7 +21443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 716,
+      "line": 722,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Gateway Auth Token",
       "surface": "apple",
@@ -21451,7 +21451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 720,
+      "line": 726,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Gateway Password",
       "surface": "apple",
@@ -21459,7 +21459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 750,
+      "line": 756,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Unencrypted",
       "surface": "apple",
@@ -21467,7 +21467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 753,
+      "line": 759,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Secure (TLS)",
       "surface": "apple",
@@ -21475,7 +21475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 757,
+      "line": 763,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Connection security",
       "surface": "apple",
@@ -21483,7 +21483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 827,
+      "line": 833,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Connecting…",
       "surface": "apple",
@@ -21491,7 +21491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 831,
+      "line": 837,
       "path": "apps/ios/Sources/Onboarding/OnboardingWizardView.swift",
       "source": "Connect",
       "surface": "apple",

--- a/apps/ios/Sources/Gateway/GatewayConnectionIssue.swift
+++ b/apps/ios/Sources/Gateway/GatewayConnectionIssue.swift
@@ -4,6 +4,7 @@ import OpenClawKit
 enum GatewayConnectionIssue: Equatable {
     case none
     case tokenMissing
+    case passwordMissing
     case unauthorized
     case pairingRequired(requestId: String?)
     case network
@@ -16,9 +17,9 @@ enum GatewayConnectionIssue: Equatable {
         return nil
     }
 
-    var needsAuthToken: Bool {
+    var needsAuthCredentials: Bool {
         switch self {
-        case .tokenMissing, .unauthorized:
+        case .tokenMissing, .passwordMissing, .unauthorized:
             true
         default:
             false
@@ -35,8 +36,14 @@ enum GatewayConnectionIssue: Equatable {
         if problem.needsPairingApproval {
             return .pairingRequired(requestId: problem.requestId)
         }
+        if problem.kind == .gatewayAuthTokenMissing {
+            return .tokenMissing
+        }
+        if problem.kind == .gatewayAuthPasswordMissing {
+            return .passwordMissing
+        }
         if problem.needsCredentialUpdate {
-            return problem.kind == .gatewayAuthTokenMissing ? .tokenMissing : .unauthorized
+            return .unauthorized
         }
         switch problem.kind {
         case .deviceIdentityRequired,
@@ -71,6 +78,9 @@ enum GatewayConnectionIssue: Equatable {
         }
         if lower.contains("gateway token missing") {
             return .tokenMissing
+        }
+        if lower.contains("gateway password missing") {
+            return .passwordMissing
         }
         if lower.contains("unauthorized") {
             return .unauthorized

--- a/apps/ios/Sources/Onboarding/OnboardingWizardView.swift
+++ b/apps/ios/Sources/Onboarding/OnboardingWizardView.swift
@@ -106,6 +106,8 @@ struct OnboardingWizardView: View {
             ""
         case .tokenMissing:
             "Gateway auth token is missing."
+        case .passwordMissing:
+            self.connectMessage ?? self.statusLine
         case .unauthorized:
             "Gateway rejected credentials."
         case let .pairingRequired(requestId):
@@ -556,8 +558,12 @@ struct OnboardingWizardView: View {
                     onShowDetails: {
                         self.showGatewayProblemDetails = true
                     })
-            } else if self.issue.needsAuthToken {
+            } else if self.issue == .unauthorized {
                 Text("Gateway rejected credentials. Scan a fresh setup code or update token/password.")
+                    .font(OpenClawType.footnote)
+                    .foregroundStyle(.secondary)
+            } else if self.issue.needsAuthCredentials {
+                Text(verbatim: self.connectMessage ?? self.statusLine)
                     .font(OpenClawType.footnote)
                     .foregroundStyle(.secondary)
             } else {
@@ -646,7 +652,7 @@ extension OnboardingWizardView {
         if self.issue.needsPairing || self.currentProblem?.needsPairingApproval == true {
             return "Gateway Approval"
         }
-        if self.issue.needsAuthToken || self.currentProblem != nil {
+        if self.issue.needsAuthCredentials || self.currentProblem != nil {
             return "Authentication"
         }
         return "Gateway Status"
@@ -1065,6 +1071,7 @@ extension OnboardingWizardView {
     }
 
     private func updateConnectionIssue(problem: GatewayConnectionProblem?, statusText: String) {
+        let wasOnAuthStep = self.step == .auth
         let next = GatewayConnectionIssue.detect(problem: problem)
         let fallback = next == .none ? GatewayConnectionIssue.detect(from: statusText) : next
 
@@ -1075,7 +1082,7 @@ extension OnboardingWizardView {
             self.issue = .pairingRequired(requestId: mergedRequestId)
         } else if self.issue.needsPairing, !fallback.needsPairing {
             // Ignore non-pairing statuses until the user explicitly retries/scans again, or we connect.
-        } else if self.issue.needsAuthToken, !fallback.needsAuthToken, !fallback.needsPairing {
+        } else if self.issue.needsAuthCredentials, !fallback.needsAuthCredentials, !fallback.needsPairing {
             // Same idea for auth: once we learn credentials are missing/rejected, keep that sticky until
             // the user retries/scans again or we successfully connect.
         } else {
@@ -1086,8 +1093,19 @@ extension OnboardingWizardView {
             self.pairingRequestId = requestId
         }
 
-        if self.issue.needsAuthToken || self.issue.needsPairing || problem?.pauseReconnect == true {
+        if self.issue.needsAuthCredentials || self.issue.needsPairing || problem?.pauseReconnect == true {
             self.step = .auth
+            // Focus only on the transition; repeated status updates must not steal an edited field.
+            if !wasOnAuthStep {
+                switch self.issue {
+                case .passwordMissing:
+                    self.focusedField = .gatewayPassword
+                case .tokenMissing:
+                    self.focusedField = .gatewayToken
+                default:
+                    break
+                }
+            }
         }
 
         if let problem {

--- a/apps/ios/Tests/GatewayConnectionIssueTests.swift
+++ b/apps/ios/Tests/GatewayConnectionIssueTests.swift
@@ -1,32 +1,53 @@
+import OpenClawKit
 import Testing
 @testable import OpenClaw
 
 @Suite(.serialized) struct GatewayConnectionIssueTests {
-    @Test func detectsTokenMissing() {
+    @Test func `detects token missing`() {
         let issue = GatewayConnectionIssue.detect(from: "unauthorized: gateway token missing")
         #expect(issue == .tokenMissing)
-        #expect(issue.needsAuthToken)
+        #expect(issue.needsAuthCredentials)
     }
 
-    @Test func detectsUnauthorized() {
+    @Test func `detects password missing`() {
+        let issue = GatewayConnectionIssue.detect(
+            from: "unauthorized: gateway password missing (provide gateway auth password)")
+        #expect(issue == .passwordMissing)
+        #expect(issue.needsAuthCredentials)
+    }
+
+    @Test func `detects structured password missing`() {
+        let problem = GatewayConnectionProblem(
+            kind: .gatewayAuthPasswordMissing,
+            owner: .gateway,
+            title: "Gateway password required",
+            message: "This gateway requires a password.",
+            retryable: true,
+            pauseReconnect: false)
+        let issue = GatewayConnectionIssue.detect(problem: problem)
+        #expect(issue == .passwordMissing)
+        #expect(issue.needsAuthCredentials)
+    }
+
+    @Test func `detects unauthorized`() {
         let issue = GatewayConnectionIssue.detect(from: "Gateway error: unauthorized role")
         #expect(issue == .unauthorized)
-        #expect(issue.needsAuthToken)
+        #expect(issue.needsAuthCredentials)
     }
 
-    @Test func detectsPairingWithRequestId() {
+    @Test func `detects pairing with request id`() {
         let issue = GatewayConnectionIssue.detect(from: "pairing required (requestId: abc123)")
         #expect(issue == .pairingRequired(requestId: "abc123"))
         #expect(issue.needsPairing)
         #expect(issue.requestId == "abc123")
     }
 
-    @Test func detectsNetworkError() {
+    @Test func `detects network error`() {
         let issue = GatewayConnectionIssue.detect(from: "Gateway error: Connection refused")
         #expect(issue == .network)
     }
 
-    @Test func returnsNoneForBenignStatus() {
+    @Test func `returns none for benign status`() {
         let issue = GatewayConnectionIssue.detect(from: "Connected")
         #expect(issue == .none)
     }

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeModeCoordinatorTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeModeCoordinatorTests.swift
@@ -129,7 +129,9 @@ struct MacNodeModeCoordinatorTests {
             if await condition() {
                 return
             }
-            await Task.yield()
+            // Some callers run on MainActor; a real suspension lets the
+            // notification task make progress instead of polling it out.
+            try await Task.sleep(for: .milliseconds(10))
         }
         Issue.record("timed out waiting for \(description)")
     }


### PR DESCRIPTION
## What Problem This Solves

iOS onboarding previously treated a missing gateway password like a generic credential rejection. Users could land on the authentication step without the app selecting the credential field that actually needs attention.

## Why This Change Was Made

The original onboarding proposal was rewritten on current `main`, which already contains the newer QR, setup-code, LAN/Tailscale discovery, and multi-gateway flows. The focused replacement preserves the useful auth-recovery work: it classifies missing tokens and passwords separately, keeps generic unauthorized failures distinct, and selects the matching credential field only on the first transition into authentication so later status updates do not steal focus.

The rewrite stays inside the iOS onboarding owner boundary and keeps the existing localized UI copy. Colin remains credited as co-author.

## User Impact

When a gateway reports a missing token or password, onboarding opens the authentication step with the corresponding field selected. Missing-credential status remains accurate; only actual unauthorized states use rejection wording.

## Evidence

- Testbox `tbx_01kxcphq1a8mfdr65fa2mnmzyf`: `pnpm check:changed` apps lane passed on the final dirty tree.
- `pnpm native:i18n:check` equivalent: 4,200 entries, 21 locale artifacts, no inventory drift.
- SwiftFormat lint and `git diff --check`: passed.
- Fresh autoreview loop: two findings fixed; final review clean with no actionable findings.
- Hosted iOS build and Swift tests: required on the rewritten exact head before merge.
