### PR TITLE
fix(mcp): match toolFilter on namespaced names and warn on zero matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **MCP tool filter:** `mcp.servers.<name>.toolFilter` (`openclaw mcp tools --include/--exclude`) now matches both the raw server tool name and the namespaced `<server>__<tool>` form printed by `openclaw mcp probe`, and logs a `bundle-mcp` warning when a non-empty `include` matches no advertised tool instead of silently hiding every tool from the agent. (#98193)
 - **WeChat account routing:** `startAccount` preserves session routing by resolving manifest channel account config from raw account keys with opaque provider ids, while still ignoring manifest account keys that normalize to blocked object keys. (#93686) Thanks @zhangguiping-xydt.
 
 ## 2026.6.10

--- a/docs/cli/mcp.md
+++ b/docs/cli/mcp.md
@@ -444,7 +444,7 @@ Notes:
 - `add` accepts stdio flags such as `--command`, `--arg`, `--env`, and `--cwd`, or HTTP flags such as `--url`, `--transport`, `--header`, `--auth oauth`, TLS, timeout, and tool-selection flags.
 - `set` expects one JSON object value on the command line.
 - `configure` updates enablement, tool filters, timeouts, OAuth, TLS, and parallel-tool-call hints without replacing the whole server definition.
-- `tools` updates per-server tool filters. Include/exclude entries are MCP tool names and simple `*` globs.
+- `tools` updates per-server tool filters. Include/exclude entries are MCP tool names and simple `*` globs. Names match against the server's **raw** tool name (for example `query`) **or** the namespaced `<server>__<tool>` form that `mcp probe` prints (for example `motherduck__query`); either spelling works. A non-empty `--include` that matches no advertised tool logs a `bundle-mcp` warning and leaves the server with no exposed tools, so check the spelling if a filtered server stops appearing.
 - `login` runs the OAuth flow for HTTP servers configured with `auth: "oauth"`. The first run prints an authorization URL; rerun with `--code` after approval.
 - `logout` clears stored OAuth credentials for the named server without removing the saved server definition.
 - `reload` disposes cached in-process MCP runtimes. Gateway or agent processes in another process still need their own reload or restart path.

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -864,6 +864,56 @@ describe("session MCP runtime", () => {
     }
   });
 
+  it("matches toolFilter include using namespaced <server>__<tool> names (#98193)", async () => {
+    // `openclaw mcp probe` shows namespaced names; copying them into
+    // `mcp tools --include` must keep working instead of dropping every tool.
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "bundle-mcp-tool-filter-ns-"));
+    const serverPath = path.join(tempDir, "tool-filter-ns.mjs");
+    const logPath = path.join(tempDir, "server.log");
+    await writeListToolsMcpServer({
+      filePath: serverPath,
+      logPath,
+      tools: [
+        { name: "query", inputSchema: { type: "object", properties: {} } },
+        { name: "list_tables", inputSchema: { type: "object", properties: {} } },
+        { name: "query_rw", inputSchema: { type: "object", properties: {} } },
+      ],
+    });
+
+    const runtime = await getOrCreateSessionMcpRuntime({
+      sessionId: "session-tool-filter-ns",
+      sessionKey: "agent:test:session-tool-filter-ns",
+      workspaceDir: "/workspace",
+      cfg: {
+        mcp: {
+          servers: {
+            duck: {
+              command: process.execPath,
+              args: [serverPath],
+              toolFilter: {
+                // Namespaced names as printed by `mcp probe`.
+                include: ["duck__query", "duck__list_tables"],
+              },
+            },
+          },
+        },
+      },
+    });
+
+    try {
+      const catalog = await runtime.getCatalog();
+      expect(catalog.tools.map((tool) => tool.toolName).toSorted()).toEqual([
+        "list_tables",
+        "query",
+      ]);
+      expect(catalog.servers.duck?.toolCount).toBe(2);
+      expect(catalog.servers.duck?.tools?.filteredCount).toBe(1);
+    } finally {
+      await runtime.dispose();
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("lists MCP tools from servers that omit the tools capability", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "bundle-mcp-unadvertised-tools-"));
     const serverPath = path.join(tempDir, "unadvertised-tools.mjs");

--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -24,7 +24,7 @@ import {
   normalizeJsonSchemaForTypeBox,
 } from "../shared/json-schema-defaults.js";
 import { runTasksWithConcurrency } from "../utils/run-with-concurrency.js";
-import { sanitizeServerName } from "./agent-bundle-mcp-names.js";
+import { sanitizeServerName, TOOL_NAME_SEPARATOR } from "./agent-bundle-mcp-names.js";
 import type {
   McpCatalogTool,
   McpServerCatalog,
@@ -343,13 +343,24 @@ function getMcpToolSelection(rawServer: unknown): McpToolSelection {
   };
 }
 
-function shouldExposeMcpTool(selection: McpToolSelection, toolName: string): boolean {
+/**
+ * Matches a tool against a server's include/exclude filter.
+ *
+ * Patterns are tested against BOTH the raw server tool name (`query`) and the
+ * OpenClaw-namespaced form (`<server>__query`). `openclaw mcp probe` surfaces the
+ * namespaced names, so operators routinely copy those into `mcp tools --include`;
+ * matching either form keeps that intuitive workflow working instead of silently
+ * dropping every tool. See the candidate names built at the filter call site.
+ */
+function shouldExposeMcpTool(selection: McpToolSelection, toolNames: readonly string[]): boolean {
   const include = selection.include ?? [];
   const exclude = selection.exclude ?? [];
-  if (include.length > 0 && !include.some((pattern) => globMatches(pattern, toolName))) {
+  const matchesAny = (patterns: readonly string[]): boolean =>
+    patterns.some((pattern) => toolNames.some((name) => globMatches(pattern, name)));
+  if (include.length > 0 && !matchesAny(include)) {
     return false;
   }
-  return !exclude.some((pattern) => globMatches(pattern, toolName));
+  return !matchesAny(exclude);
 }
 
 function sanitizeMcpMetadataText(value: string | undefined): string | undefined {
@@ -711,9 +722,30 @@ export function createSessionMcpRuntime(params: {
                 });
                 failIfDisposed();
                 const selection = getMcpToolSelection(rawServer);
-                const exposedTools = listedTools.filter((tool) =>
-                  shouldExposeMcpTool(selection, tool.name.trim()),
-                );
+                const exposedTools = listedTools.filter((tool) => {
+                  const rawToolName = tool.name.trim();
+                  return shouldExposeMcpTool(selection, [
+                    rawToolName,
+                    `${safeServerName}${TOOL_NAME_SEPARATOR}${rawToolName}`,
+                  ]);
+                });
+                if (
+                  selection.include &&
+                  selection.include.length > 0 &&
+                  listedTools.length > 0 &&
+                  exposedTools.length === 0
+                ) {
+                  // A non-empty include that matches nothing is almost always a
+                  // name-form mistake (namespaced vs raw). Warn instead of
+                  // silently hiding the whole server from the agent.
+                  const sampleRaw = listedTools[0]?.name?.trim() ?? "<tool>";
+                  logWarn(
+                    `bundle-mcp: server "${serverName}": toolFilter include matched 0 of ` +
+                      `${listedTools.length} advertised tool(s); the server will expose no tools. ` +
+                      `Filter names are matched against the raw server tool name (e.g. "${sampleRaw}") ` +
+                      `or the namespaced "${safeServerName}${TOOL_NAME_SEPARATOR}${sampleRaw}" form.`,
+                  );
+                }
                 const serverEntry: McpServerCatalog = {
                   serverName,
                   safeServerName,


### PR DESCRIPTION
## What Problem This Solves

Fixes #98193. A per-server MCP `toolFilter` (`openclaw mcp tools <server> --include/--exclude`, i.e. `mcp.servers.<name>.toolFilter`) silently drops **all** of a server's tools from the agent runtime when the filter is written with the names shown by `openclaw mcp probe`.

`mcp probe` surfaces the **namespaced** tool names (`<server>__<tool>`, e.g. `motherduck__query`), but the filter was matched only against the **raw** names returned by `client.listTools()` (e.g. `query`). Copying the probe names into `--include` matches nothing, so the server contributes zero tools and disappears from the agent — with no error, no warning, and no log line. This is extremely hard to diagnose: it looks identical to "MCP is not projected into the agent at all", even though `mcp doctor --probe` still reports the server as `ok`.

## Changes

- `shouldExposeMcpTool` now matches include/exclude patterns against **both** the raw server tool name and the namespaced `<server>__<tool>` form, so names copied from `mcp probe` work as users expect.
- When a non-empty `include` matches **zero** advertised tools, emit a `bundle-mcp` warning explaining that names are matched against the raw (`query`) or namespaced (`server__query`) forms, instead of silently exposing nothing.
- Docs: clarify the accepted name forms in `docs/cli/mcp.md`.
- Test: add a regression test that an `include` using namespaced names exposes the expected tools.
- Changelog entry under Unreleased.

Existing raw-name and glob filters keep working (the raw name is still one of the matched candidates); the existing `tool-filter` test is unchanged. The change only broadens matching and adds a diagnostic warning — no tools that previously matched are removed.

## Evidence

Reproduced end-to-end against the MotherDuck hosted MCP (`https://api.motherduck.com/mcp`) on OpenClaw 2026.6.10 (Docker):

- With the filter written using probe's namespaced names (`--include 'motherduck__query,...'`), an agent turn saw **0** `motherduck__*` tools and replied that the tool was unavailable; gateway logs showed **no** `bundle-mcp` activity. A control server (`@modelcontextprotocol/server-memory`) configured at the same time worked, proving MCP projection itself was fine and the filter was the cause.
- Removing the filter exposed all 21 tools. Re-adding it with **raw** names (`--include 'query,list_tables,...'`) exposed exactly the intended read-only set, and the agent successfully ran `SELECT 1 AS test` (returned `test = 1`) from a real Telegram turn.

Added regression test (run focused):

```
pnpm vitest run src/agents/agent-bundle-mcp-runtime.test.ts
```

- New test: `matches toolFilter include using namespaced <server>__<tool> names (#98193)` — asserts a namespaced `include` exposes the expected tools and filters the rest.
- Existing `filters listed MCP tools with per-server include and exclude rules` remains green (raw/glob behavior unchanged).

Full investigation, repro steps, and code references are in #98193.
