### PR TITLE
fix(provider-transport-fetch): raise SSE sanitize buffer cap to 16 MiB — unbreak gpt-5.5 on chatgpt-responses (main regression from #96989, not in 6.11)

### DIFF
--- a/src/agents/provider-transport-fetch.test.ts
+++ b/src/agents/provider-transport-fetch.test.ts
@@ -1370,7 +1370,7 @@ describe("buildGuardedModelFetch", () => {
   });
 
   it("errors on oversized SSE body without event boundary in sanitizer", async () => {
-    const oversized = "x".repeat(65 * 1024);
+    const oversized = "x".repeat(16 * 1024 * 1024 + 1024);
     const encoder = new TextEncoder();
     fetchWithSsrFGuardMock.mockResolvedValue({
       response: new Response(

--- a/src/agents/provider-transport-fetch.test.ts
+++ b/src/agents/provider-transport-fetch.test.ts
@@ -1369,6 +1369,42 @@ describe("buildGuardedModelFetch", () => {
     expect(refreshTimeout).toHaveBeenCalledTimes(2);
   });
 
+  it("handles a valid large SSE event split before its boundary", async () => {
+    const payload = { text: "x".repeat(70 * 1024) };
+    const encoder = new TextEncoder();
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(encoder.encode(`data: ${JSON.stringify(payload)}`));
+            controller.enqueue(encoder.encode("\n\n"));
+            controller.close();
+          },
+        }),
+        { headers: { "content-type": "text/event-stream" } },
+      ),
+      finalUrl: "https://openrouter.ai/api/v1/chat/completions",
+      release: vi.fn(async () => undefined),
+    });
+    const model = {
+      id: "gpt-5.4",
+      provider: "openrouter",
+      api: "openai-completions",
+      baseUrl: "https://openrouter.ai/api/v1",
+    } as unknown as Model<"openai-completions">;
+
+    const response = await buildGuardedModelFetch(model)(
+      "https://openrouter.ai/api/v1/chat/completions",
+      { method: "POST" },
+    );
+    const items = [];
+    for await (const item of Stream.fromSSEResponse(response, new AbortController())) {
+      items.push(item);
+    }
+
+    expect(items).toEqual([payload]);
+  });
+
   it("errors on oversized SSE body without event boundary in sanitizer", async () => {
     const oversized = "x".repeat(16 * 1024 * 1024 + 1024);
     const encoder = new TextEncoder();

--- a/src/agents/provider-transport-fetch.ts
+++ b/src/agents/provider-transport-fetch.ts
@@ -51,16 +51,11 @@ const log = createSubsystemLogger("provider-transport-fetch");
  *  without Content-Length. */
 const SSE_SYNTHESIZE_JSON_MAX_BYTES = 16 * 1024 * 1024;
 
-/** Max bytes read from a non-OK (error) response body before truncation. Error
- *  payloads are small, so keep this tight to bound memory on a hostile error stream. */
+/** Max bytes read from a non-OK response body before truncation. */
 const SSE_NONOK_BODY_MAX_BYTES = 64 * 1024;
 
-/** Max bytes for the internal SSE sanitization buffer between event boundaries.
- *  A single legitimate event (e.g. a large reasoning summary on the chatgpt-responses
- *  API) can far exceed 64 KiB, so bound this at the same 16 MiB ceiling as the
- *  JSON-synthesis path: only a genuinely boundary-less (hostile/broken) stream trips
- *  the guard, not a real large event. */
-const SSE_SANITIZE_BUFFER_MAX_BYTES = 16 * 1024 * 1024;
+/** Max decoded characters buffered while waiting for the next SSE event boundary. */
+const SSE_SANITIZE_BUFFER_MAX_CHARS = 16 * 1024 * 1024;
 
 const BLOCKED_EXACT_ORIGIN_TRUST_HOSTNAME_LABELS = new Set(["instance-data"]);
 const PLAIN_DECIMAL_NUMBER_RE = /^\d+(?:\.\d+)?$/;
@@ -213,9 +208,9 @@ function sanitizeOpenAISdkSseResponse(
     for (;;) {
       const boundary = findSseEventBoundary(buffer);
       if (!boundary) {
-        if (buffer.length > SSE_SANITIZE_BUFFER_MAX_BYTES) {
+        if (buffer.length > SSE_SANITIZE_BUFFER_MAX_CHARS) {
           throw new Error(
-            `SSE response exceeded max buffer size (${SSE_SANITIZE_BUFFER_MAX_BYTES} bytes) without event boundary`,
+            `SSE response exceeded max buffer size (${SSE_SANITIZE_BUFFER_MAX_CHARS} chars) without event boundary`,
           );
         }
         return enqueued;

--- a/src/agents/provider-transport-fetch.ts
+++ b/src/agents/provider-transport-fetch.ts
@@ -51,10 +51,16 @@ const log = createSubsystemLogger("provider-transport-fetch");
  *  without Content-Length. */
 const SSE_SYNTHESIZE_JSON_MAX_BYTES = 16 * 1024 * 1024;
 
+/** Max bytes read from a non-OK (error) response body before truncation. Error
+ *  payloads are small, so keep this tight to bound memory on a hostile error stream. */
+const SSE_NONOK_BODY_MAX_BYTES = 64 * 1024;
+
 /** Max bytes for the internal SSE sanitization buffer between event boundaries.
- *  A response that cannot find a \n\n boundary within this many characters is
- *  almost certainly hostile or broken — cap the buffer rather than let it grow. */
-const SSE_SANITIZE_BUFFER_MAX_BYTES = 64 * 1024;
+ *  A single legitimate event (e.g. a large reasoning summary on the chatgpt-responses
+ *  API) can far exceed 64 KiB, so bound this at the same 16 MiB ceiling as the
+ *  JSON-synthesis path: only a genuinely boundary-less (hostile/broken) stream trips
+ *  the guard, not a real large event. */
+const SSE_SANITIZE_BUFFER_MAX_BYTES = 16 * 1024 * 1024;
 
 const BLOCKED_EXACT_ORIGIN_TRUST_HOSTNAME_LABELS = new Set(["instance-data"]);
 const PLAIN_DECIMAL_NUMBER_RE = /^\d+(?:\.\d+)?$/;
@@ -132,7 +138,7 @@ function sanitizeOpenAISdkSseResponse(
     return response;
   }
   if (!response.ok) {
-    return capNonOkResponseBodyLazily(response, SSE_SANITIZE_BUFFER_MAX_BYTES);
+    return capNonOkResponseBodyLazily(response, SSE_NONOK_BODY_MAX_BYTES);
   }
   if (
     options?.synthesizeJsonAsSse === true &&


### PR DESCRIPTION
## What Problem This Solves

Fixes #98197.

`gpt-5.5` on the `openai-chatgpt-responses` API is fully broken on current `main`. Since #96989 (`1bccd29304`, merged 2026-06-27), the OpenAI SSE sanitizer caps its inter-event buffer at 64 KiB. `gpt-5.5` emits a single legitimate SSE event (a large reasoning / output blob) larger than 64 KiB before its `\n\n` boundary, so `sanitizeOpenAISdkSseResponse` throws `SSE response exceeded max buffer size (65536 bytes) without event boundary` and the whole request fails with `LLM request failed`.

**Scope:** this is a **`main`-only regression**. #96989 landed 06-27, *after* the 6.11 release branch diverged from `main` (`9e3a917d9e`, 06-24) — so **no 6.11 release contains it** (`v2026.6.11` GA, `-beta.2`, and `-beta.1` are all clean). It sits only on `main` and would ship in the **next release train cut from `main`** unless fixed first.

## Why This Change Was Made

#96989 added two OOM bounds to `sanitizeOpenAISdkSseResponse`: a 16 MiB cap on JSON-to-SSE synthesis, and a 64 KiB cap on the inter-event sanitize buffer (where there was previously **no** bound). The 64 KiB inter-event cap is too small — a single legitimate event can far exceed it (gpt-5.5 reasoning summaries do).

This **decouples** the two bounds instead of sharing one constant:

- **non-OK error-body cap** stays tight at 64 KiB (`SSE_NONOK_BODY_MAX_BYTES`) — error payloads are small, no reason to loosen it.
- **inter-event sanitize buffer** rises to the same 16 MiB ceiling as the JSON-synthesis path (`SSE_SANITIZE_BUFFER_MAX_BYTES`). The guard still trips on a genuinely boundary-less (hostile / broken) stream — just not on a real large event.

## User Impact

Restores `gpt-5.5` (and any model emitting >64 KiB single SSE events) on the default ChatGPT-subscription path. No released build is affected (6.11 GA and its betas are clean); without this, the next release train cut from `main` ships with `gpt-5.5` broken.

## Evidence

- **Live before/after** on a running instance built off current `main`: *before* — 20+ identical `exceeded max buffer size (65536 bytes)` failures, all `api=openai-chatgpt-responses model=gpt-5.5`; *after* raising the cap — clean `stream_done … model=gpt-5.5 events=5422` (213 s) stream, zero buffer errors. The 5,422 parsed events confirm the stream is valid SSE with proper boundaries; only one inter-boundary block exceeded 64 KiB.
- `node scripts/run-vitest.mjs src/agents/provider-transport-fetch.test.ts` → **78/78 pass** (the oversize OOM-guard test is updated to the new 16 MiB threshold; the non-OK body-cap test is unchanged and still green at 64 KiB).

_Authored with AI assistance (Claude)._
