### PR TITLE
Fix/98101 429 overloaded classification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ __openclaw_vitest__/
 __pycache__/
 *.pyc
 *.tsbuildinfo
+comment-*.md
 .pnpm-store
 .worktrees/
 .DS_Store

--- a/src/agents/embedded-agent-helpers/errors.ts
+++ b/src/agents/embedded-agent-helpers/errors.ts
@@ -809,6 +809,9 @@ function classifyFailoverClassificationFromHttpStatus(
     if (message && isBilling429MessageForProvider(message, provider)) {
       return toReasonClassification("billing");
     }
+    if (message && isOverloadedErrorMessage(message)) {
+      return toReasonClassification("overloaded");
+    }
     return toReasonClassification("rate_limit");
   }
   if (status === 401 || status === 403) {
@@ -1051,6 +1054,11 @@ function classifyFailoverClassificationFromMessage(
   }
   if (isPeriodicUsageLimitErrorMessage(raw)) {
     return toReasonClassification(isBillingErrorMessage(raw) ? "billing" : "rate_limit");
+  }
+  // HTTP 429 bodies that explicitly say "overloaded" should classify as
+  // overloaded, not as the generic rate-limit fallback (#98101).
+  if (leadingStatus?.code === 429 && isOverloadedErrorMessage(raw)) {
+    return toReasonClassification("overloaded");
   }
   if (isRateLimitErrorMessage(raw)) {
     return toReasonClassification("rate_limit");

--- a/src/agents/embedded-agent-helpers/failover-matches.test.ts
+++ b/src/agents/embedded-agent-helpers/failover-matches.test.ts
@@ -9,6 +9,7 @@ import {
   isServerErrorMessage,
   isTimeoutErrorMessage,
 } from "./failover-matches.js";
+import { formatRateLimitOrOverloadedErrorCopy } from "./sanitize-user-facing-text.js";
 
 describe("Z.ai vendor error codes (#48988)", () => {
   describe("error 1311 — model not included in subscription plan", () => {
@@ -176,6 +177,21 @@ describe("server error status classification", () => {
 
   it("does not classify prefixed plain internal server error status prose", () => {
     expect(isServerErrorMessage("Proxy notice: Status: Internal Server Error")).toBe(false);
+  });
+});
+
+describe("HTTP 429 overloaded body classification (#98101)", () => {
+  const raw =
+    '429 {"error":{"code":"1305","message":"The service may be temporarily overloaded, please try again later"}}';
+
+  it("classifies a 429 body with overloaded text as overloaded", () => {
+    expect(classifyFailoverReason(raw)).toBe("overloaded");
+  });
+
+  it("returns overloaded user-facing copy for a 429 body with overloaded text", () => {
+    expect(formatRateLimitOrOverloadedErrorCopy(raw)).toBe(
+      "The AI service is temporarily overloaded. Please try again in a moment.",
+    );
   });
 });
 

--- a/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
+++ b/src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts
@@ -127,6 +127,10 @@ function extractProviderRateLimitMessage(raw: string): string | undefined {
 }
 
 export function formatRateLimitOrOverloadedErrorCopy(raw: string): string | undefined {
+  const leadingStatus = extractLeadingHttpStatus(raw.trim());
+  if (leadingStatus?.code === 429 && isOverloadedErrorMessage(raw)) {
+    return OVERLOADED_ERROR_USER_MESSAGE;
+  }
   if (isRateLimitErrorMessage(raw)) {
     return extractProviderRateLimitMessage(raw) ?? RATE_LIMIT_ERROR_USER_MESSAGE;
   }


### PR DESCRIPTION

Fixes #98101

## Summary

Fixes issue #98101: when a provider returns HTTP 429 with a body that explicitly says "overloaded", OpenClaw misclassified it as `rate_limit` and showed users "⚠️ API rate limit reached. Please try again later.". It now correctly classifies as `overloaded` and shows "The AI service is temporarily overloaded. Please try again in a moment.".

## Real Behavior Proof

Before the fix, the new regression test failed on the old code:

```bash
$ pnpm test src/agents/embedded-agent-helpers/failover-matches.test.ts
 FAIL  |unit-fast| src/agents/embedded-agent-helpers/failover-matches.test.ts > HTTP 429 overloaded body classification (#98101) > classifies a 429 body with overloaded text as overloaded
AssertionError: expected 'rate_limit' to be 'overloaded' // Object.is equality

Expected: "overloaded"
Received: "rate_limit"
```

The user-facing copy also returned the rate-limit message on the old code:

```bash
AssertionError: expected '⚠️ API rate limit reached. Please try…' to be 'The AI service is temporarily overloa…' // Object.is equality

Expected: "The AI service is temporarily overloaded. Please try again in a moment."
Received: "⚠️ API rate limit reached. Please try again later."
```

After the fix, all related tests pass:

```bash
$ pnpm test src/agents/embedded-agent-helpers

 Test Files  6 passed (6)
      Tests  91 passed (91)
```

Negative control: a real rate-limit 429 is still classified as `rate_limit` (existing test `rate limit still classified correctly` passes).

## Regression Test Plan

Added the following tests in `src/agents/embedded-agent-helpers/failover-matches.test.ts`:

1. `classifies a 429 body with overloaded text as overloaded` — verifies `classifyFailoverReason` returns `overloaded` for z.ai 1305-style responses.
2. `returns overloaded user-facing copy for a 429 body with overloaded text` — verifies `formatRateLimitOrOverloadedErrorCopy` returns the overloaded user copy.

## Root Cause

1. In `classifyFailoverClassificationFromMessage`, `isRateLimitErrorMessage` was checked before `isOverloadedErrorMessage`. Because `ERROR_PATTERNS.rateLimit` contains a `429` wildcard, any non-billing 429 message hit the rate-limit branch first.
2. `classifyFailoverClassificationFromHttpStatus` unconditionally returned `rate_limit` at the end of its `status === 429` branch, overriding the message-level classification.
3. `formatRateLimitOrOverloadedErrorCopy` also checked `isRateLimitErrorMessage` first, so users saw the rate-limit copy.

## Implementation Plan Details

- In `classifyFailoverClassificationFromMessage`, prefer `overloaded` when the leading HTTP status is 429 and `isOverloadedErrorMessage` matches.
- In `classifyFailoverClassificationFromHttpStatus`, check `isOverloadedErrorMessage` before returning `rate_limit` for status 429.
- In `formatRateLimitOrOverloadedErrorCopy`, return `OVERLOADED_ERROR_USER_MESSAGE` first when the leading status is 429 and the message is overloaded.

## Change Details

- `src/agents/embedded-agent-helpers/errors.ts`
  - `classifyFailoverClassificationFromMessage`: added 429 + overloaded priority check.
  - `classifyFailoverClassificationFromHttpStatus`: added overloaded check in the 429 branch.
- `src/agents/embedded-agent-helpers/sanitize-user-facing-text.ts`
  - `formatRateLimitOrOverloadedErrorCopy`: added 429 + overloaded priority check.
- `src/agents/embedded-agent-helpers/failover-matches.test.ts`
  - Added 2 regression tests.

## Test Points

- 429 + "overloaded" body → `overloaded`
- 429 + "rate limit" body → `rate_limit` (unchanged)
- Non-429 overloaded text → still handled by `isOverloadedErrorMessage`

## Next Steps

- Open a PR linking issue #98101
- Wait for ClawSweeper / maintainer review

Environment: Linux, Node 22.23.1, pnpm 11.2.2
