### PR TITLE
test(gateway): add unit tests for node wake state tracking and testing seam

### DIFF
--- a/src/gateway/server-methods/nodes-wake-state.test.ts
+++ b/src/gateway/server-methods/nodes-wake-state.test.ts
@@ -1,0 +1,136 @@
+// Tests for node wake state tracking and testing seam.
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  NODE_WAKE_RECONNECT_WAIT_MS,
+  NODE_WAKE_RECONNECT_RETRY_WAIT_MS,
+  NODE_WAKE_RECONNECT_POLL_MS,
+  clearNodeWakeState,
+  nodeWakeById,
+  nodeWakeNudgeById,
+  testing,
+} from "./nodes-wake-state.js";
+
+afterEach(() => {
+  testing.resetWakeState();
+});
+
+describe("constants", () => {
+  it("exports expected wait/poll constants", () => {
+    expect(NODE_WAKE_RECONNECT_WAIT_MS).toBe(3_000);
+    expect(NODE_WAKE_RECONNECT_RETRY_WAIT_MS).toBe(12_000);
+    expect(NODE_WAKE_RECONNECT_POLL_MS).toBe(150);
+  });
+});
+
+describe("nodeWakeById", () => {
+  it("starts empty", () => {
+    expect(nodeWakeById.size).toBe(0);
+  });
+
+  it("stores NodeWakeState entries", () => {
+    const now = Date.now();
+    nodeWakeById.set("node-1", { lastWakeAtMs: now });
+    expect(nodeWakeById.size).toBe(1);
+    expect(nodeWakeById.get("node-1")?.lastWakeAtMs).toBe(now);
+  });
+
+  it("stores multiple entries", () => {
+    nodeWakeById.set("a", { lastWakeAtMs: 100 });
+    nodeWakeById.set("b", { lastWakeAtMs: 200 });
+    nodeWakeById.set("c", { lastWakeAtMs: 300 });
+    expect(nodeWakeById.size).toBe(3);
+  });
+
+  it("overwrites existing entry when key is reused", () => {
+    nodeWakeById.set("node-1", { lastWakeAtMs: 100 });
+    nodeWakeById.set("node-1", { lastWakeAtMs: 200 });
+    expect(nodeWakeById.size).toBe(1);
+  });
+
+  it("supports inFlight promise property", () => {
+    const promise = Promise.resolve({
+      available: true,
+      throttled: false,
+      path: "sent" as const,
+      durationMs: 50,
+    });
+    nodeWakeById.set("node-1", { lastWakeAtMs: Date.now(), inFlight: promise });
+    expect(nodeWakeById.get("node-1")?.inFlight).toBe(promise);
+  });
+});
+
+describe("nodeWakeNudgeById", () => {
+  it("starts empty", () => {
+    expect(nodeWakeNudgeById.size).toBe(0);
+  });
+
+  it("stores nudge timestamps", () => {
+    nodeWakeNudgeById.set("node-1", 1000);
+    expect(nodeWakeNudgeById.size).toBe(1);
+    expect(nodeWakeNudgeById.get("node-1")).toBe(1000);
+  });
+
+  it("independently tracked from nodeWakeById", () => {
+    nodeWakeById.set("node-1", { lastWakeAtMs: 500 });
+    nodeWakeNudgeById.set("node-1", 1000);
+    expect(nodeWakeById.size).toBe(1);
+    expect(nodeWakeNudgeById.size).toBe(1);
+  });
+});
+
+describe("clearNodeWakeState", () => {
+  it("removes the wake entry and nudge for the given node", () => {
+    nodeWakeById.set("node-1", { lastWakeAtMs: 100 });
+    nodeWakeNudgeById.set("node-1", 200);
+    clearNodeWakeState("node-1");
+    expect(nodeWakeById.has("node-1")).toBe(false);
+    expect(nodeWakeNudgeById.has("node-1")).toBe(false);
+  });
+
+  it("is a no-op when the node id does not exist", () => {
+    expect(() => clearNodeWakeState("ghost")).not.toThrow();
+    expect(nodeWakeById.size).toBe(0);
+    expect(nodeWakeNudgeById.size).toBe(0);
+  });
+
+  it("only removes the specified node, leaving others intact", () => {
+    nodeWakeById.set("a", { lastWakeAtMs: 1 });
+    nodeWakeById.set("b", { lastWakeAtMs: 2 });
+    nodeWakeNudgeById.set("a", 10);
+    nodeWakeNudgeById.set("b", 20);
+    clearNodeWakeState("a");
+    expect(nodeWakeById.has("a")).toBe(false);
+    expect(nodeWakeById.has("b")).toBe(true);
+    expect(nodeWakeNudgeById.has("a")).toBe(false);
+    expect(nodeWakeNudgeById.has("b")).toBe(true);
+  });
+});
+
+describe("testing seam", () => {
+  it("getNodeWakeByIdSize returns 0 when nothing is stored", () => {
+    expect(testing.getNodeWakeByIdSize()).toBe(0);
+  });
+
+  it("getNodeWakeByIdSize reflects inserted entries", () => {
+    nodeWakeById.set("x", { lastWakeAtMs: 1 });
+    nodeWakeById.set("y", { lastWakeAtMs: 2 });
+    expect(testing.getNodeWakeByIdSize()).toBe(2);
+  });
+
+  it("hasNodeWakeEntry returns true for stored ids", () => {
+    nodeWakeById.set("present", { lastWakeAtMs: 1 });
+    expect(testing.hasNodeWakeEntry("present")).toBe(true);
+  });
+
+  it("hasNodeWakeEntry returns false for unknown ids", () => {
+    expect(testing.hasNodeWakeEntry("missing")).toBe(false);
+  });
+
+  it("resetWakeState clears both maps", () => {
+    nodeWakeById.set("a", { lastWakeAtMs: 1 });
+    nodeWakeNudgeById.set("a", 100);
+    testing.resetWakeState();
+    expect(nodeWakeById.size).toBe(0);
+    expect(nodeWakeNudgeById.size).toBe(0);
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

The `nodes-wake-state.ts` module provides node wake state tracking for APNs wake attempts and reconnect nudges, with a narrow read-only testing seam (`getNodeWakeByIdSize`, `hasNodeWakeEntry`, `resetWakeState`). Despite being a core path in gateway server methods, this module had no unit tests.

## Why This Change Was Made

Add unit tests for the node wake state module covering:
- Exported wait/poll constants (`NODE_WAKE_RECONNECT_WAIT_MS`, `NODE_WAKE_RECONNECT_RETRY_WAIT_MS`, `NODE_WAKE_RECONNECT_POLL_MS`)
- `nodeWakeById` Map operations (insert, overwrite, multi-entry, inFlight promise)
- `nodeWakeNudgeById` Map operations (independent tracking from wake state)
- `clearNodeWakeState` function (removal, no-op for unknown ids, scoped deletion)
- Testing seam (`getNodeWakeByIdSize`, `hasNodeWakeEntry`, `resetWakeState`)

This improves test coverage and prevents regressions when the module is modified.

## User Impact

Node wake state tracking now has dedicated unit coverage, reducing the risk of regressions when the function is modified.

## Evidence

Reproducibility: not applicable. This PR adds direct coverage for existing helper behavior rather than reporting a user-visible runtime bug. Source inspection confirms the helper behavior the tests target.

Direct behavior probe (no mocks — real functions exercised directly):

```text
$ node --import tsx -e "import('./src/gateway/server-methods/nodes-wake-state.js').then((m) => { const r = []; r.push({ desc: 'testing exports', exports: Object.keys(m.testing) }); m.testing.resetWakeState(); r.push({ desc: 'empty after reset', size: m.testing.getNodeWakeByIdSize() }); r.push({ desc: 'getNodeWakeByIdSize works', result: m.testing.getNodeWakeByIdSize() }); r.push({ desc: 'hasNodeWakeEntry returns false for unknown', result: m.testing.hasNodeWakeEntry('unknown') }); m.nodeWakeById.set('node-1', { lastWakeAtMs: Date.now() }); r.push({ desc: 'hasNodeWakeEntry after set', result: m.testing.hasNodeWakeEntry('node-1') }); r.push({ desc: 'size after set', size: m.testing.getNodeWakeByIdSize() }); m.testing.resetWakeState(); r.push({ desc: 'size after reset', size: m.testing.getNodeWakeByIdSize() }); console.log(JSON.stringify(r, null, 2)); })"
[
  {
    "desc": "testing exports",
    "exports": [
      "getNodeWakeByIdSize",
      "hasNodeWakeEntry",
      "resetWakeState"
    ]
  },
  {
    "desc": "empty after reset",
    "size": 0
  },
  {
    "desc": "getNodeWakeByIdSize works",
    "result": 0
  },
  {
    "desc": "hasNodeWakeEntry returns false for unknown",
    "result": false
  },
  {
    "desc": "hasNodeWakeEntry after set",
    "result": true
  },
  {
    "desc": "size after set",
    "size": 1
  },
  {
    "desc": "size after reset",
    "size": 0
  }
]
```

Targeted test:

```text
$ node scripts/run-vitest.mjs run src/gateway/server-methods/nodes-wake-state.test.ts

 RUN  v4.1.8

 Test Files  2 passed (2)
      Tests  34 passed (34)
   Start at  00:05:26
   Duration  3.51s

[test] passed 1 Vitest shard in 29.85s
```

Formatting:

```text
$ npx oxfmt --check src/gateway/server-methods/nodes-wake-state.ts src/gateway/server-methods/nodes-wake-state.test.ts
Checking formatting...

All matched files use the correct format.
```

Whitespace:

```text
$ git diff --check
```
