### PR TITLE
fix: forward response-frame meta to clients

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -201,7 +201,7 @@ public struct ResponseFrame: Codable, Sendable {
         ok: Bool,
         payload: AnyCodable?,
         error: ErrorShape?,
-        meta: [String: AnyCodable]?)
+        meta: [String: AnyCodable]? = nil)
     {
         self.type = type
         self.id = id

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -193,19 +193,22 @@ public struct ResponseFrame: Codable, Sendable {
     public let ok: Bool
     public let payload: AnyCodable?
     public let error: ErrorShape?
+    public let meta: [String: AnyCodable]?
 
     public init(
         type: String,
         id: String,
         ok: Bool,
         payload: AnyCodable?,
-        error: ErrorShape?)
+        error: ErrorShape?,
+        meta: [String: AnyCodable]?)
     {
         self.type = type
         self.id = id
         self.ok = ok
         self.payload = payload
         self.error = error
+        self.meta = meta
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -214,6 +217,7 @@ public struct ResponseFrame: Codable, Sendable {
         case ok
         case payload
         case error
+        case meta
     }
 }
 

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -215,10 +215,19 @@ loopback/local pairing.
 ## Framing
 
 - **Request**: `{type:"req", id, method, params}`
-- **Response**: `{type:"res", id, ok, payload|error}`
+- **Response**: `{type:"res", id, ok, payload|error, meta?}`
 - **Event**: `{type:"event", event, payload, seq?, stateVersion?}`
 
 Side-effecting methods require **idempotency keys** (see schema).
+
+`meta` is an **optional** free-form object of server-emitted response metadata.
+Method handlers may attach it (for example agent methods set `meta.cached: true`
+on a deduplicated/idempotency-replayed response, alongside `meta.runId`). It is
+advisory, never required, and absent for handlers that supply none — clients that
+do not read it are unaffected. Clients can use it to distinguish a replayed/cached
+response from a fresh one (for example to suppress a retry on a cached failure).
+`meta` is additive to the v4 response envelope; clients that strictly reject
+unknown top-level fields should tolerate or ignore it.
 
 ## Roles + scopes
 

--- a/packages/gateway-protocol/src/index.test.ts
+++ b/packages/gateway-protocol/src/index.test.ts
@@ -34,6 +34,7 @@ import {
   validateTalkSessionTurnParams,
   validateTalkSessionTurnResult,
   validateWakeParams,
+  validateResponseFrame,
   type ValidationError,
 } from "./index.js";
 
@@ -845,5 +846,31 @@ describe("validateNodeEventResult", () => {
         reason: "persisted",
       }),
     ).toBe(true);
+  });
+});
+
+describe("validateResponseFrame", () => {
+  it("accepts a response frame without meta (backward compatible)", () => {
+    expect(validateResponseFrame({ type: "res", id: "req-1", ok: true })).toBe(true);
+    expect(validateResponseFrame.errors).toBeNull();
+  });
+
+  it("accepts a response frame carrying server-emitted meta", () => {
+    expect(
+      validateResponseFrame({
+        type: "res",
+        id: "req-2",
+        ok: true,
+        payload: { runId: "run-1" },
+        meta: { cached: true, runId: "run-1" },
+      }),
+    ).toBe(true);
+    expect(validateResponseFrame.errors).toBeNull();
+  });
+
+  it("still rejects unknown top-level fields", () => {
+    expect(
+      validateResponseFrame({ type: "res", id: "req-3", ok: false, unexpected: true }),
+    ).toBe(false);
   });
 });

--- a/packages/gateway-protocol/src/schema/frames.ts
+++ b/packages/gateway-protocol/src/schema/frames.ts
@@ -167,6 +167,7 @@ export const ResponseFrameSchema = Type.Object(
     ok: Type.Boolean(),
     payload: Type.Optional(Type.Unknown()),
     error: Type.Optional(ErrorShapeSchema),
+    meta: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
   },
   { additionalProperties: false },
 );

--- a/scripts/protocol-gen-swift.ts
+++ b/scripts/protocol-gen-swift.ts
@@ -83,6 +83,9 @@ const DEFAULTED_OPTIONAL_INIT_PARAM_ENTRIES: readonly [string, readonly string[]
   ["ExecApprovalRequestParams", ["requireDeliveryRoute", "suppressDelivery"]],
   ["AgentSummary", ["thinkingLevels", "thinkingOptions", "thinkingDefault"]],
   ["ModelChoice", ["available"]],
+  // Optional response metadata is additive to the v4 envelope; defaulting it to
+  // nil keeps existing `ResponseFrame(..., error:)` Swift call sites compiling.
+  ["ResponseFrame", ["meta"]],
 ];
 
 const DEFAULTED_OPTIONAL_INIT_PARAMS: Record<string, Set<string>> = Object.fromEntries(

--- a/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
+++ b/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
@@ -13,6 +13,7 @@ import { mintAgentRuntimeIdentityToken } from "../../agent-runtime-identity-toke
 import type { ResolvedGatewayAuth } from "../../auth.js";
 import { getOperatorApprovalRuntimeToken } from "../../operator-approval-runtime-token.js";
 import { handleGatewayRequest } from "../../server-methods.js";
+import type { GatewayRequestHandlers } from "../../server-methods/shared-types.js";
 import type { GatewayRequestContext } from "../../server-methods/types.js";
 
 const {
@@ -188,6 +189,7 @@ function attachGatewayHarness(options: {
   close?: CloseGatewayConnection;
   isClosed?: () => boolean;
   setCloseCause?: SetCloseCause;
+  extraHandlers?: GatewayRequestHandlers;
 }) {
   const socketSend = vi.fn((_payload: string, cb?: (err?: Error) => void) => {
     cb?.();
@@ -230,7 +232,7 @@ function attachGatewayHarness(options: {
     getResolvedAuth: () => resolvedAuth,
     gatewayMethods: [],
     events: [],
-    extraHandlers: {},
+    extraHandlers: options.extraHandlers ?? {},
     buildRequestContext: () => ({}) as GatewayRequestContext,
     refreshHealthSnapshot:
       options.refreshHealthSnapshot ?? vi.fn(async () => createHealthSummary()),
@@ -257,6 +259,7 @@ function attachGatewayHarness(options: {
   const sendMessage = onMessage;
   return {
     socketSend,
+    send,
     sendRequest: (id: string, method: string, params: Record<string, unknown> = {}) => {
       sendMessage(
         JSON.stringify({
@@ -939,5 +942,69 @@ describe("resolvePinnedClientMetadata", () => {
       pinnedPlatform: undefined,
       pinnedDeviceFamily: "Linux",
     });
+  });
+});
+
+describe("attachGatewayWsMessageHandler response meta forwarding", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("forwards handler meta (e.g. cached) onto the emitted res frame", async () => {
+    const client = createConnectedTestClient({ connId: "conn-meta-proof" });
+    // Mirrors the agent dedupe path: server-methods/agent.ts calls
+    // respond(cached.ok, cached.payload, cached.error, { cached: true, runId }).
+    vi.mocked(handleGatewayRequest).mockImplementation(async (opts) => {
+      opts.respond(true, { value: 1 }, undefined, { cached: true, runId: "run-meta-proof" });
+    });
+
+    const harness = attachGatewayHarness({
+      connId: "conn-meta-proof",
+      connectNonce: "nonce-meta-proof",
+      client,
+    });
+
+    harness.sendRequest("req-meta", "agent.wait");
+
+    let frame: Record<string, unknown> | undefined;
+    await vi.waitFor(() => {
+      frame = harness.send.mock.calls
+        .map((call) => call[0] as Record<string, unknown>)
+        .find((sent) => sent?.type === "res" && sent.id === "req-meta");
+      expect(frame).toBeDefined();
+    });
+
+    expect(frame).toMatchObject({
+      type: "res",
+      id: "req-meta",
+      ok: true,
+      payload: { value: 1 },
+      meta: { cached: true, runId: "run-meta-proof" },
+    });
+  });
+
+  it("omits meta on the res frame when the handler supplies none", async () => {
+    const client = createConnectedTestClient({ connId: "conn-no-meta" });
+    vi.mocked(handleGatewayRequest).mockImplementation(async (opts) => {
+      opts.respond(true, { value: 2 }, undefined);
+    });
+
+    const harness = attachGatewayHarness({
+      connId: "conn-no-meta",
+      connectNonce: "nonce-no-meta",
+      client,
+    });
+
+    harness.sendRequest("req-no-meta", "agent.wait");
+
+    let frame: Record<string, unknown> | undefined;
+    await vi.waitFor(() => {
+      frame = harness.send.mock.calls
+        .map((call) => call[0] as Record<string, unknown>)
+        .find((sent) => sent?.type === "res" && sent.id === "req-no-meta");
+      expect(frame).toBeDefined();
+    });
+
+    expect(frame).not.toHaveProperty("meta");
   });
 });

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -2271,7 +2271,7 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
         error?: ErrorShape,
         meta?: Record<string, unknown>,
       ) => {
-        send({ type: "res", id: req.id, ok, payload, error });
+        send({ type: "res", id: req.id, ok, payload, error, ...(meta ? { meta } : {}) });
         const unauthorizedRoleError = isUnauthorizedRoleError(error);
         let logMeta = meta;
         if (unauthorizedRoleError) {


### PR DESCRIPTION
Closes #98203

## What Problem This Solves

Clients connected to the gateway cannot read per-response metadata. The `respond(ok, payload, error, meta)` callback in `message-handler.ts` accepts a `meta` argument, and the agent method handlers already populate it — `server-methods/agent.ts` returns `{ cached: true, runId }` when it serves a deduplicated request, and passes `{ runId }` / `{ aborted }` elsewhere — but the `res` frame is built as `{ type, id, ok, payload, error }` and `meta` is forwarded only to `logWs`. Combined with `ResponseFrameSchema` being `additionalProperties: false` with no `meta` key, the metadata the gateway computes never reaches the wire. A transport bridge reading `res.meta?.cached` to suppress retries on an already-cached failure always sees `undefined` and re-sends it.

## Why This Change Was Made

This wires up an already-built-but-dropped channel rather than adding a new feature:

- `packages/gateway-protocol/src/schema/frames.ts` — add `meta: Type.Optional(Type.Record(Type.String(), Type.Unknown()))` to `ResponseFrameSchema` (same idiom already used for `args`/`data` records elsewhere in the package), keeping `additionalProperties: false`.
- `src/gateway/server/ws-connection/message-handler.ts` — spread the existing `meta` onto the `res` frame: `send({ type: "res", id: req.id, ok, payload, error, ...(meta ? { meta } : {}) })`. `send` is typed `(obj: unknown) => void`, so the spread is type-safe, and the frame stays backward compatible when no handler supplies `meta`.
- `docs/gateway/protocol.md` — document the optional `res.meta` field and its additive-to-v4 compatibility expectation.
- Regenerated the Swift protocol baseline (`apps/shared/.../GatewayModels.swift`) so `checks-fast-bundled-protocol` passes, and added `ResponseFrame.meta` to the generator's `DEFAULTED_OPTIONAL_INIT_PARAMS` so the initializer defaults `meta` to `nil` — existing `ResponseFrame(..., error:)` Swift call sites stay source-compatible.

Non-goal: this PR does not change which handlers populate `meta` or introduce new metadata fields — it only makes the existing `meta` observable to clients.

## User Impact

Clients can now read response metadata (e.g. `cached`) from `res` frames, so transports/bridges can stop retrying responses the gateway already cached or deduplicated. No behavior change for clients that ignore `meta`; frames without `meta` are unchanged.

## Evidence

Built and ran the repo's vitest suite locally (vitest 4.1.8) against the changed modules:

- **Real WS frame emission** — `src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts` (`-t "meta forwarding"`): drives the **real** `attachGatewayWsMessageHandler` `respond` → `send` path, with `handleGatewayRequest` stubbed to mirror the actual agent dedupe call `respond(ok, payload, error, { cached: true, runId })`. Asserts the **emitted `res` frame** carries `meta: { cached: true, runId }`, and omits `meta` entirely when the handler supplies none. The mock boundary is only the dispatch — the envelope/forwarding under test (the line this PR changes) and the frame construction are the real code path. **2 passed.**

  ```
  ✓ forwards handler meta (e.g. cached) onto the emitted res frame
  ✓ omits meta on the res frame when the handler supplies none
   Test Files  3 passed (3)
        Tests  6 passed | 66 skipped (72)
  ```

- **Schema contract** — `packages/gateway-protocol/src/index.test.ts` (`-t "validateResponseFrame"`): a frame without `meta` validates (backward compatible), a frame carrying `{ cached, runId }` validates, an unknown top-level field is still rejected. **passed.**

  ```
   Test Files  2 passed (2)
        Tests  6 passed | 90 skipped (96)
  ```

Note on environment: the npm registry available in my sandbox could not complete a full `pnpm install` (timeouts on a few optional native packages), so I could not run the entire `pnpm build && pnpm check && pnpm test` lane; CI on this PR exercises it. A live channel capture of `res.meta` on the wire would additionally require triggering the gateway's dedupe replay against a configured model, which the above test reproduces deterministically through the real respond/send path instead.

---
🤖 AI-assisted (authored with Claude).



---

## Live-gateway capture — supersedes the environment note above

_Update: the live capture the note above said it would require is now provided. A full `pnpm install` succeeds once pnpm's `minimumReleaseAge` gate is disabled for the recently-published `@openclaw/*` deps (`--config.minimumReleaseAge=0`)._

## Real-behavior proof — live gateway + WebSocket client

Captured from a **real** `startGatewayServer` instance (loopback bind, `auth.mode=token`)
with a **real** `GatewayClient` connected over `ws://`, through a transparent logging
proxy that records the exact frames on the wire. Branch = this PR head
(`fix/forward-res-frame-meta`); the `message-handler.ts` forwarding line is present.
The two `agent` requests reuse the **same `idempotencyKey`** to exercise both metadata
paths in one run.

**Harness / setup (redacted):**
```
[gateway] agent model: mock-openai/gpt-5.4 (thinking=off, fast=off)
[gateway] http server listening (9 plugins)
[gateway] ready
gateway started on ws://127.0.0.1:<port>
logging proxy   on ws://127.0.0.1:<proxy> -> gateway
[gateway] device pairing auto-approved device=<redacted> role=operator
client connected through proxy
```

**Request #1 — fresh agent run → `res` carries `meta.runId`:**
```
REQUEST #1 (fresh) -> method "agent" idempotencyKey=<idem>
<<< res frame received by client on the wire:
{
  "type": "res",
  "id": "2b511fad-e5bd-4f6d-a6e5-a91653577e49",
  "ok": true,
  "payload": {
    "runId": "<idem>",
    "sessionKey": "agent:dev:cap",
    "status": "accepted",
    "acceptedAt": 1782889141078
  },
  "meta": {
    "runId": "<idem>"
  }
}
```

**Request #2 — same `idempotencyKey` → idempotency/dedupe replay → `res` carries `meta.cached`:**
```
REQUEST #2 (same idempotencyKey -> dedupe replay)
<<< res frame received by client on the wire:
{
  "type": "res",
  "id": "c678c8a0-d6b7-44d7-96cc-588e6c01d542",
  "ok": true,
  "payload": {
    "runId": "<idem>",
    "status": "in_flight",
    "sessionKey": "agent:dev:cap"
  },
  "meta": {
    "cached": true,
    "runId": "<idem>"
  }
}
```

**Summary line printed by the capture:**
```
================ SUMMARY: res frames on the wire ================
{ id: <hello-ok>, ok: true, meta: "(absent)" }              # connect handler emits no meta ✓
{ id: <req#1>,    ok: true, payload.status: "accepted",  meta: { runId } }            ✓
{ id: <req#2>,    ok: true, payload.status: "in_flight", meta: { cached: true, runId } } ✓
res frames total=3, with meta=2
```

**Before (current `main`):** `src/gateway/server/ws-connection/message-handler.ts`
builds the frame as `send({ type: "res", id: req.id, ok, payload, error })` — the
handler-supplied `meta` (which `server-methods/agent.ts` already passes as
`{ runId }` on the accept path and `{ cached: true }` on the dedupe path) is dropped
before it reaches the socket, so a client sees no `meta`. This PR changes that one
line to spread `meta` when present; the capture above is that same code path now
delivering `meta.runId` / `meta.cached` on the wire.
