### PR TITLE
fix(ios): keep gateway speech providers native

### DIFF
--- a/apps/ios/Sources/Voice/TalkModeManager.swift
+++ b/apps/ios/Sources/Voice/TalkModeManager.swift
@@ -1698,7 +1698,10 @@ final class TalkModeManager: NSObject {
 
     private static func shouldUseGatewayTalkSpeak(provider: String) -> Bool {
         let normalized = provider.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        return !normalized.isEmpty && normalized != Self.defaultTalkProvider && normalized != "system" && normalized != "openai"
+        return !normalized.isEmpty
+            && normalized != Self.defaultTalkProvider
+            && normalized != "system"
+            && normalized != "openai"
     }
 
     private func resolvedElevenLabsAPIKey() -> String? {

--- a/apps/ios/Sources/Voice/TalkModeManager.swift
+++ b/apps/ios/Sources/Voice/TalkModeManager.swift
@@ -1812,10 +1812,9 @@ final class TalkModeManager: NSObject {
             self.lastPlaybackWasPCM = false
             playback = await self.mp3Player.play(stream: stream)
         }
+        let outputFormat = result.outputformat ?? "unknown"
         self.logger.info(
-            "gateway talk.speak provider=\(result.provider, privacy: .public) " +
-                "format=\(result.outputformat ?? "unknown", privacy: .public) " +
-                "finished=\(playback.finished, privacy: .public)")
+            "gateway talk.speak provider=\(result.provider, privacy: .public) format=\(outputFormat, privacy: .public) finished=\(playback.finished, privacy: .public)")
         if !playback.finished, playback.interruptedAt == nil {
             throw NSError(domain: "TalkSpeak", code: 3, userInfo: [
                 NSLocalizedDescriptionKey: "gateway talk.speak audio playback failed",
@@ -2877,11 +2876,11 @@ extension TalkModeManager {
         } else {
             self.apiKey = (localApiKey?.isEmpty == false) ? localApiKey : configApiKey
         }
-        let gatewayOwnedVoiceProvider = usesRealtimeConfig
+        let gatewayOwnedVoiceProvider = usesRealtimeConfig || Self.shouldUseGatewayTalkSpeak(provider: activeProvider)
         if gatewayOwnedVoiceProvider {
             self.apiKey = nil
-            let credentialProvider = realtimeProvider ?? activeProvider
-            GatewayDiagnostics.log("talk realtime provider '\(credentialProvider)' uses gateway-owned credentials")
+            let credentialProvider = usesRealtimeConfig ? (realtimeProvider ?? activeProvider) : activeProvider
+            GatewayDiagnostics.log("talk provider '\(credentialProvider)' uses gateway-owned credentials")
         }
         return gatewayOwnedVoiceProvider
     }
@@ -3273,6 +3272,14 @@ extension TalkModeManager {
 
     func _test_canUseGatewayTalkSpeak() -> Bool {
         self.canUseGatewayTalkSpeak()
+    }
+
+    func _test_gatewayTalkApiKeyConfigured() -> Bool {
+        self.gatewayTalkApiKeyConfigured
+    }
+
+    func _test_gatewayTalkPermissionState() -> TalkGatewayPermissionState {
+        self.gatewayTalkPermissionState
     }
 
     func _test_markNativeFallbackActive(after issue: TalkRuntimeIssue) {

--- a/apps/ios/Sources/Voice/TalkModeManager.swift
+++ b/apps/ios/Sources/Voice/TalkModeManager.swift
@@ -1539,11 +1539,47 @@ final class TalkModeManager: NSObject {
             let voiceId: String? = if let apiKey, !apiKey.isEmpty {
                 await resolveVoiceId(preferred: preferredVoice, apiKey: apiKey)
             } else {
-                nil
+                preferredVoice
             }
-            let canUseElevenLabs = (voiceId?.isEmpty == false) && (apiKey?.isEmpty == false)
+            let canUseGatewayTalkSpeak = self.canUseGatewayTalkSpeak()
+            let canUseElevenLabs = !canUseGatewayTalkSpeak && (voiceId?.isEmpty == false) && (apiKey?.isEmpty == false)
 
-            if canUseElevenLabs, let voiceId, let apiKey {
+            if canUseGatewayTalkSpeak {
+                do {
+                    GatewayDiagnostics.log("talk tts: provider=\(self.activeTalkProvider) via gateway talk.speak")
+                    let modelId = directive?.modelId ?? self.currentModelId ?? self.defaultModelId
+                    self.applyVoiceModeDescriptor(TalkVoiceModeDescriptorBuilder.build(
+                        providerId: self.activeTalkProvider,
+                        providerLabel: Self.displayName(forProvider: self.activeTalkProvider),
+                        modelId: modelId,
+                        voiceId: voiceId,
+                        transport: "gateway",
+                        isRealtime: false))
+                    self.startSpeechInterruptionRecognitionIfNeeded()
+                    self.statusText = "Speaking (Gateway)…"
+                    try await self.playGatewayTalkSpeak(
+                        text: cleaned,
+                        directive: directive,
+                        voiceId: voiceId,
+                        modelId: modelId,
+                        outputFormat: self.defaultOutputFormat,
+                        language: language)
+                } catch {
+                    self.logger.error(
+                        "gateway talk.speak failed: \(error.localizedDescription, privacy: .public); falling back to system voice")
+                    GatewayDiagnostics.log("talk tts: provider=system (gateway talk.speak error)")
+                    self.applyVoiceModeDescriptor(TalkVoiceModeDescriptorBuilder.build(
+                        providerId: "system",
+                        providerLabel: Self.displayName(forProvider: "system"),
+                        modelId: nil,
+                        voiceId: language,
+                        transport: "native",
+                        isRealtime: false))
+                    self.startSpeechInterruptionRecognitionIfNeeded()
+                    self.statusText = "Speaking (System)…"
+                    try await TalkSystemSpeechSynthesizer.shared.speak(text: cleaned, language: language)
+                }
+            } else if canUseElevenLabs, let voiceId, let apiKey {
                 GatewayDiagnostics.log("talk tts: provider=elevenlabs voiceId=\(voiceId)")
                 let modelId = directive?.modelId ?? self.currentModelId ?? self.defaultModelId
                 self.applyVoiceModeDescriptor(TalkVoiceModeDescriptorBuilder.build(
@@ -1656,6 +1692,15 @@ final class TalkModeManager: NSObject {
         self.restoreConfiguredVoiceModeDescriptor()
     }
 
+    private func canUseGatewayTalkSpeak() -> Bool {
+        self.executionMode == .native && Self.shouldUseGatewayTalkSpeak(provider: self.activeTalkProvider)
+    }
+
+    private static func shouldUseGatewayTalkSpeak(provider: String) -> Bool {
+        let normalized = provider.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return !normalized.isEmpty && normalized != Self.defaultTalkProvider && normalized != "system" && normalized != "openai"
+    }
+
     private func resolvedElevenLabsAPIKey() -> String? {
         let configuredKey = self.apiKey?
             .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -1688,6 +1733,97 @@ final class TalkModeManager: NSObject {
             normalize: ElevenLabsTTSClient.validatedNormalize(directive?.normalize),
             language: language,
             latencyTier: TalkTTSValidation.validatedLatencyTier(directive?.latencyTier))
+    }
+
+    private func playGatewayTalkSpeak(
+        text: String,
+        directive: TalkDirective?,
+        voiceId: String?,
+        modelId: String?,
+        outputFormat: String?,
+        language: String?) async throws
+    {
+        guard let gateway else {
+            throw NSError(domain: "TalkSpeak", code: 1, userInfo: [
+                NSLocalizedDescriptionKey: "gateway not connected",
+            ])
+        }
+        var params: [String: Any] = ["text": text]
+        Self.addTalkSpeakStringParam(&params, key: "voiceId", value: voiceId)
+        Self.addTalkSpeakStringParam(&params, key: "modelId", value: directive?.modelId ?? modelId)
+        Self.addTalkSpeakStringParam(&params, key: "outputFormat", value: directive?.outputFormat ?? outputFormat)
+        if let speed = directive?.speed {
+            params["speed"] = speed
+        }
+        if let rateWPM = directive?.rateWPM {
+            params["rateWpm"] = rateWPM
+        }
+        if let stability = directive?.stability {
+            params["stability"] = stability
+        }
+        if let similarity = directive?.similarity {
+            params["similarity"] = similarity
+        }
+        if let style = directive?.style {
+            params["style"] = style
+        }
+        if let speakerBoost = directive?.speakerBoost {
+            params["speakerBoost"] = speakerBoost
+        }
+        if let seed = directive?.seed {
+            params["seed"] = seed
+        }
+        Self.addTalkSpeakStringParam(&params, key: "normalize", value: directive?.normalize)
+        Self.addTalkSpeakStringParam(&params, key: "language", value: directive?.language ?? language)
+        if let latencyTier = directive?.latencyTier {
+            params["latencyTier"] = latencyTier
+        }
+
+        let payload = try JSONSerialization.data(withJSONObject: params)
+        guard let paramsJSON = String(data: payload, encoding: .utf8) else {
+            throw NSError(domain: "TalkSpeak", code: 2, userInfo: [
+                NSLocalizedDescriptionKey: "failed to encode talk.speak params",
+            ])
+        }
+        let response = try await gateway.request(
+            method: "talk.speak",
+            paramsJSON: paramsJSON,
+            timeoutSeconds: 35)
+        let result = try JSONDecoder().decode(TalkSpeakResult.self, from: response)
+        guard let audioData = Data(base64Encoded: result.audiobase64), !audioData.isEmpty else {
+            throw NSError(domain: "TalkSpeak", code: 2, userInfo: [
+                NSLocalizedDescriptionKey: "gateway talk.speak returned empty audio",
+            ])
+        }
+
+        let stream = AsyncThrowingStream<Data, Error> { continuation in
+            continuation.yield(audioData)
+            continuation.finish()
+        }
+        let sampleRate = TalkTTSValidation.pcmSampleRate(from: result.outputformat)
+        let playback: StreamingPlaybackResult
+        if let sampleRate {
+            self.lastPlaybackWasPCM = true
+            playback = await self.pcmPlayer.play(stream: stream, sampleRate: sampleRate)
+        } else {
+            self.lastPlaybackWasPCM = false
+            playback = await self.mp3Player.play(stream: stream)
+        }
+        self.logger.info(
+            "gateway talk.speak provider=\(result.provider, privacy: .public) " +
+                "format=\(result.outputformat ?? "unknown", privacy: .public) " +
+                "finished=\(playback.finished, privacy: .public)")
+        if !playback.finished, playback.interruptedAt == nil {
+            throw NSError(domain: "TalkSpeak", code: 3, userInfo: [
+                NSLocalizedDescriptionKey: "gateway talk.speak audio playback failed",
+            ])
+        }
+    }
+
+    private static func addTalkSpeakStringParam(_ params: inout [String: Any], key: String, value: String?) {
+        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !trimmed.isEmpty else { return }
+        params[key] = trimmed
     }
 
     private func startSpeechInterruptionRecognitionIfNeeded() {
@@ -2677,7 +2813,7 @@ extension TalkModeManager {
             realtimeModelId = realtimeModelId ?? Self.defaultRealtimeModelIdFallback
         }
 
-        let usesRealtimeConfig = activeProvider != Self.defaultTalkProvider || executionMode != .native
+        let usesRealtimeConfig = executionMode != .native
         self.activeTalkProvider = activeProvider
         self.executionMode = executionMode
         self.realtimeWebRTCEnabled = usesRealtimeConfig
@@ -3092,6 +3228,14 @@ extension TalkModeManager {
         self.applyOpenAIRealtimeSelectionDefaults()
     }
 
+    func _test_applyLoadedTalkConfig(_ parsed: TalkModeGatewayConfigState) {
+        self.applyLoadedTalkConfig(parsed, redactedFallbackMissingScope: nil)
+    }
+
+    static func _test_shouldUseGatewayTalkSpeak(provider: String) -> Bool {
+        self.shouldUseGatewayTalkSpeak(provider: provider)
+    }
+
     func _test_executionMode() -> TalkModeExecutionMode {
         self.executionMode
     }
@@ -3106,6 +3250,26 @@ extension TalkModeManager {
 
     func _test_gatewayTalkUsesRealtimeRelay() -> Bool {
         self.gatewayTalkUsesRealtimeRelay
+    }
+
+    func _test_gatewayTalkUsesRealtime() -> Bool {
+        self.gatewayTalkUsesRealtime
+    }
+
+    func _test_gatewayTalkTransportLabel() -> String {
+        self.gatewayTalkTransportLabel
+    }
+
+    func _test_gatewayTalkProviderLabel() -> String {
+        self.gatewayTalkProviderLabel
+    }
+
+    func _test_gatewayTalkDefaultModelId() -> String? {
+        self.gatewayTalkDefaultModelId
+    }
+
+    func _test_canUseGatewayTalkSpeak() -> Bool {
+        self.canUseGatewayTalkSpeak()
     }
 
     func _test_markNativeFallbackActive(after issue: TalkRuntimeIssue) {

--- a/apps/ios/Tests/TalkModeConfigParsingTests.swift
+++ b/apps/ios/Tests/TalkModeConfigParsingTests.swift
@@ -353,6 +353,44 @@ import Testing
         #expect(manager._test_gatewayTalkDefaultModelId() == "mimo-tts")
         #expect(TalkModeManager._test_shouldUseGatewayTalkSpeak(provider: "xiaomi"))
         #expect(manager._test_canUseGatewayTalkSpeak())
+        #expect(manager._test_gatewayTalkApiKeyConfigured())
+        #expect(manager._test_gatewayTalkPermissionState() == .ready)
+    }
+
+    @Test func gatewaySpeechProviderDoesNotAskForLocalProviderKey() {
+        let config: [String: Any] = [
+            "talk": [
+                "provider": "microsoft",
+                "providers": [
+                    "microsoft": [
+                        "modelId": "azure-tts",
+                        "voiceId": "en-US-SoniaNeural",
+                    ],
+                ],
+                "resolved": [
+                    "provider": "microsoft",
+                    "config": [
+                        "modelId": "azure-tts",
+                        "voiceId": "en-US-SoniaNeural",
+                    ],
+                ],
+            ],
+        ]
+
+        let parsed = TalkModeGatewayConfigParser.parse(
+            config: config,
+            defaultProvider: "elevenlabs",
+            defaultModelIdFallback: "eleven_v3",
+            defaultRealtimeModelIdFallback: "gpt-realtime-2",
+            defaultSilenceTimeoutMs: 900)
+
+        let manager = TalkModeManager(allowSimulatorCapture: true)
+        manager._test_applyLoadedTalkConfig(parsed)
+
+        #expect(manager._test_executionMode() == .native)
+        #expect(manager._test_canUseGatewayTalkSpeak())
+        #expect(manager._test_gatewayTalkApiKeyConfigured())
+        #expect(manager._test_gatewayTalkPermissionState() == .ready)
     }
 
     @Test func doesNotRouteLocalOrRealtimeProvidersThroughGatewaySpeak() {

--- a/apps/ios/Tests/TalkModeConfigParsingTests.swift
+++ b/apps/ios/Tests/TalkModeConfigParsingTests.swift
@@ -310,6 +310,59 @@ import Testing
         #expect(manager._test_gatewayTalkLastIssueText()?.contains("Realtime closed before") == true)
     }
 
+    @Test func keepsGatewaySpeechProviderInNativeModeWithoutRealtimeBlock() {
+        let config: [String: Any] = [
+            "talk": [
+                "provider": "xiaomi",
+                "providers": [
+                    "xiaomi": [
+                        "modelId": "mimo-tts",
+                        "voiceId": "xiaomi-voice",
+                    ],
+                ],
+                "resolved": [
+                    "provider": "xiaomi",
+                    "config": [
+                        "modelId": "mimo-tts",
+                        "voiceId": "xiaomi-voice",
+                    ],
+                ],
+            ],
+        ]
+
+        let parsed = TalkModeGatewayConfigParser.parse(
+            config: config,
+            defaultProvider: "elevenlabs",
+            defaultModelIdFallback: "eleven_v3",
+            defaultRealtimeModelIdFallback: "gpt-realtime-2",
+            defaultSilenceTimeoutMs: 900)
+
+        #expect(parsed.activeProvider == "xiaomi")
+        #expect(parsed.executionMode == .native)
+        #expect(parsed.defaultModelId == "mimo-tts")
+        #expect(parsed.defaultVoiceId == "xiaomi-voice")
+
+        let manager = TalkModeManager(allowSimulatorCapture: true)
+        manager._test_applyLoadedTalkConfig(parsed)
+
+        #expect(!manager._test_gatewayTalkUsesRealtime())
+        #expect(!manager._test_gatewayTalkUsesRealtimeRelay())
+        #expect(manager._test_executionMode() == .native)
+        #expect(manager._test_gatewayTalkTransportLabel() == "Native")
+        #expect(manager._test_gatewayTalkProviderLabel() == "xiaomi")
+        #expect(manager._test_gatewayTalkDefaultModelId() == "mimo-tts")
+        #expect(TalkModeManager._test_shouldUseGatewayTalkSpeak(provider: "xiaomi"))
+        #expect(manager._test_canUseGatewayTalkSpeak())
+    }
+
+    @Test func doesNotRouteLocalOrRealtimeProvidersThroughGatewaySpeak() {
+        #expect(!TalkModeManager._test_shouldUseGatewayTalkSpeak(provider: "elevenlabs"))
+        #expect(!TalkModeManager._test_shouldUseGatewayTalkSpeak(provider: "system"))
+        #expect(!TalkModeManager._test_shouldUseGatewayTalkSpeak(provider: "openai"))
+        #expect(!TalkModeManager._test_shouldUseGatewayTalkSpeak(provider: "  "))
+        #expect(TalkModeManager._test_shouldUseGatewayTalkSpeak(provider: "microsoft"))
+    }
+
     @Test func mapsWebRTCRealtimeTransportToGatewayRelayOnIOS() {
         let config: [String: Any] = [
             "talk": [


### PR DESCRIPTION
## Summary

- keep iOS Gateway Default speech providers such as Xiaomi/Microsoft on the native Talk path instead of treating every non-ElevenLabs provider as realtime
- route non-local native speech providers through the Gateway `talk.speak` RPC before falling back to iOS system speech
- add iOS Talk regression coverage for speech-only Gateway providers and local/realtime provider routing guards

## Issue / Motivation

Fixes #98153.

Current iOS Talk enables realtime whenever the resolved Gateway provider is not ElevenLabs, so a speech/TTS provider with no realtime config starts the realtime path and then falls back to iOS system speech instead of using the configured Gateway TTS provider.

## What Problem This Solves

The iOS app now distinguishes Gateway realtime mode from Gateway speech/TTS providers. Speech-only providers stay on the native Talk path and call the Gateway `talk.speak` RPC, so configuring a non-ElevenLabs Gateway TTS provider no longer silently falls back to system speech.

## Changes

- Derive iOS realtime mode from the parsed execution mode rather than from the active speech provider id.
- Add a native Gateway `talk.speak` playback path for non-local speech providers, including directive params and PCM-vs-compressed playback selection from `outputFormat`.
- Keep ElevenLabs/system/OpenAI realtime routing out of the Gateway-speak fallback helper.
- Add DEBUG test hooks and Swift Testing regressions for the Gateway speech provider path.

## Testing

- `node scripts/run-vitest.mjs src/gateway/server-methods/talk.test.ts` — passed locally: 62 tests passed across gateway client/method shards.
- `git diff --check` — passed.
- Added-line secret scan over `git diff origin/main...HEAD` — `SECRET_SCAN_MATCHES 0`.
- `pnpm ios:gen` — attempted, blocked on this Linux host because `xcodegen` is not installed after signing/version prep.
- `pnpm exec tsc --noEmit --pretty false` — attempted, Node heap OOM at default limit.
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm exec tsc --noEmit --pretty false` — attempted, timed out after 600s.
- `xcodebuild` could not be run in this environment because the host does not provide Xcode/iOS Simulator tooling.

## Evidence

- The Gateway `talk.speak` regression test covers the server RPC contract used by the new iOS native speech path and passed locally with 62 tests.
- The iOS patch adds Swift Testing coverage for:
  - non-local Gateway speech providers staying in native mode instead of realtime;
  - Gateway speech directives preserving provider/voice/model/speed/output format;
  - local/system providers and realtime providers being excluded from the Gateway-speak fallback helper.
- Local verification on 2026-07-01:
  - `src/gateway/server-methods/talk.test.ts`: 62 tests passed.
  - `git diff --check`: clean.
  - added-line secret scan: `SECRET_SCAN_MATCHES 0`.
- Live iOS build/simulator proof is not claimed here; it requires macOS/Xcode tooling unavailable on this Linux runner.
