### PR TITLE
fix(agents): bound MiniMax VLM JSON response reads, fix test mocks and lint

### DIFF
--- a/src/agents/minimax-vlm.normalizes-api-key.test.ts
+++ b/src/agents/minimax-vlm.normalizes-api-key.test.ts
@@ -1,4 +1,6 @@
-// Covers MiniMax VLM auth/header normalization and provider-specific routing.
+// Covers MiniMax VLM auth/header normalization, provider-specific routing,
+// and bounded JSON response enforcement including oversized-response rejection.
+import * as http from "node:http";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { withFetchPreconnect } from "../test-utils/fetch-mock.js";
@@ -204,6 +206,84 @@ describe("minimaxUnderstandImage apiKey normalization", () => {
 
     expect(timeoutSpy).toHaveBeenCalledOnce();
     expect(timeoutSpy).toHaveBeenCalledWith(MAX_TIMER_TIMEOUT_MS);
+  });
+
+  it("rejects oversized VLM response bodies, preserves Trace-Id, and cancels the stream", async () => {
+    let canceled = false;
+    const ONE_MIB = 1024 * 1024;
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (let i = 0; i < 18; i++) controller.enqueue(new Uint8Array(ONE_MIB));
+        controller.close();
+      },
+      cancel() {
+        canceled = true;
+      },
+    });
+    const fetchSpy = vi.fn(async () => {
+      return new Response(body, {
+        status: 200,
+        headers: { "Content-Type": "application/json", "Trace-Id": "trace-abc" },
+      });
+    });
+    global.fetch = withFetchPreconnect(fetchSpy);
+
+    await expect(
+      minimaxUnderstandImage({
+        apiKey: "minimax-test-key",
+        prompt: "hi",
+        imageDataUrl: "data:image/png;base64,AAAA",
+        apiHost: "https://api.minimax.io",
+      }),
+    ).rejects.toThrow("MiniMax VLM: JSON response exceeds 16777216 bytes. Trace-Id: trace-abc");
+
+    expect(canceled).toBe(true);
+  });
+
+  it("rejects oversized VLM responses from a real HTTP server (behavior proof)", async () => {
+    // Real TCP server proof: oversized JSON stream is cancelled mid-flight
+    // by the bounded reader before the full body is buffered.
+    let bytesWritten = 0;
+    let socketDestroyed = false;
+    const server = http.createServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      const ONE_MIB = 1024 * 1024;
+      const chunk = Buffer.alloc(ONE_MIB, 0x41);
+      const writeMore = () => {
+        // Stop writing once the client cancels (socket is destroyed).
+        if (socketDestroyed) return;
+        for (let i = 0; i < 4 && !socketDestroyed; i++) {
+          bytesWritten += chunk.length;
+          if (!res.write(chunk)) {
+            res.once("drain", writeMore);
+            return;
+          }
+        }
+        if (!socketDestroyed) setImmediate(writeMore);
+      };
+      writeMore();
+    });
+    server.on("connection", (socket) => {
+      socket.on("close", () => {
+        socketDestroyed = true;
+      });
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const port = (server.address() as { port: number }).port;
+
+    try {
+      await expect(
+        minimaxUnderstandImage({
+          apiKey: "test-key",
+          prompt: "hi",
+          imageDataUrl: "data:image/png;base64,AAAA",
+          apiHost: `http://127.0.0.1:${port}`,
+        }),
+      ).rejects.toThrow("MiniMax VLM: JSON response exceeds");
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
   });
 
   it("bounds large provider error response bodies", async () => {

--- a/src/agents/minimax-vlm.ts
+++ b/src/agents/minimax-vlm.ts
@@ -6,6 +6,7 @@ import { ensureGlobalUndiciEnvProxyDispatcher } from "../infra/net/undici-global
 import { resolvePositiveTimerTimeoutMs } from "../shared/number-coercion.js";
 import { isRecord } from "../utils.js";
 import { normalizeSecretInput } from "../utils/normalize-secret-input.js";
+import { readProviderJsonResponse } from "./provider-http-errors.js";
 
 type MinimaxBaseResp = {
   status_code?: number;
@@ -142,7 +143,14 @@ export async function minimaxUnderstandImage(params: {
     );
   }
 
-  const json = (await res.json().catch(() => null)) as unknown;
+  let json: Record<string, unknown>;
+  try {
+    json = await readProviderJsonResponse<Record<string, unknown>>(res, "MiniMax VLM");
+  } catch (err) {
+    const trace = traceId ? ` Trace-Id: ${traceId}` : "";
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`${msg}${trace ? `.${trace}` : ""}`);
+  }
   if (!isRecord(json)) {
     const trace = traceId ? ` Trace-Id: ${traceId}` : "";
     throw new Error(`MiniMax VLM response was not JSON.${trace}`);

--- a/src/agents/minimax-vlm.ts
+++ b/src/agents/minimax-vlm.ts
@@ -149,7 +149,7 @@ export async function minimaxUnderstandImage(params: {
   } catch (err) {
     const trace = traceId ? ` Trace-Id: ${traceId}` : "";
     const msg = err instanceof Error ? err.message : String(err);
-    throw new Error(`${msg}${trace ? `.${trace}` : ""}`);
+    throw new Error(`${msg}${trace ? `.${trace}` : ""}`, { cause: err });
   }
   if (!isRecord(json)) {
     const trace = traceId ? ` Trace-Id: ${traceId}` : "";

--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -472,15 +472,14 @@ function registerImageToolEnvReset(priorFetch: typeof global.fetch, keys: string
 }
 
 function stubMinimaxOkFetch() {
+  const payload = { content: "ok", base_resp: { status_code: 0, status_msg: "" } };
   const fetch = vi.fn().mockResolvedValue({
     ok: true,
     status: 200,
     statusText: "OK",
     headers: new Headers(),
-    json: async () => ({
-      content: "ok",
-      base_resp: { status_code: 0, status_msg: "" },
-    }),
+    json: async () => payload,
+    arrayBuffer: async () => new TextEncoder().encode(JSON.stringify(payload)).buffer,
   });
   global.fetch = withFetchPreconnect(fetch);
   vi.stubEnv("MINIMAX_API_KEY", "minimax-test");
@@ -488,15 +487,14 @@ function stubMinimaxOkFetch() {
 }
 
 function stubMinimaxFetch(baseResp: { status_code: number; status_msg: string }, content = "ok") {
+  const payload = { content, base_resp: baseResp };
   const fetch = vi.fn().mockResolvedValue({
     ok: true,
     status: 200,
     statusText: "OK",
     headers: new Headers(),
-    json: async () => ({
-      content,
-      base_resp: baseResp,
-    }),
+    json: async () => payload,
+    arrayBuffer: async () => new TextEncoder().encode(JSON.stringify(payload)).buffer,
   });
   global.fetch = withFetchPreconnect(fetch);
   return fetch;


### PR DESCRIPTION
## What Problem This Solves

`minimaxUnderstandImage` calls `await res.json()` on the MiniMax VLM API response without a read limit. A large or malicious response could buffer arbitrarily large payloads before parsing, risking OOM.

The original fix replaced `res.json()` with `readProviderJsonResponse` (16 MiB cap). However, the existing test mocks (`stubMinimaxOkFetch` / `stubMinimaxFetch`) only provided `.json()` but not `.arrayBuffer()`, causing 10 test failures because `readResponseWithLimit` falls back to `res.arrayBuffer()` when the response has no `ReadableStream` body.

This PR adds the missing `.arrayBuffer()` to the test mocks and fixes the `preserve-caught-error` lint.

Closes #97872 (or supersedes #98191).

## Why This Change Was Made

All provider response reads should use `readProviderJsonResponse` (16 MiB cap) to prevent unbounded memory consumption. This is the same pattern used by native PDF paths (#97872). Trace-Id diagnostics are preserved through the error chain.

## User Impact

MiniMax VLM image understanding calls are now protected against oversized JSON responses. Normal responses work identically. Oversized responses fail with a clear error including the Trace-Id.

## Evidence

**Environment**: Linux, Node 22

**188/188 image-tool tests pass**: `pnpm test -- src/agents/tools/image-tool.test.ts`

```sh
$ npx vitest run src/agents/tools/image-tool.test.ts
 Test Files  2 passed (2)
      Tests  188 passed (188)
```

**Lint**: `npx oxlint --quiet src/agents/minimax-vlm.ts src/agents/tools/image-tool.test.ts` passes.

**Fixes**:
- `stubMinimaxOkFetch()` / `stubMinimaxFetch()` mock responses now include `.arrayBuffer()` encoding the same JSON payload
- `minimax-vlm.ts` catch block preserves the original error via `{ cause: err }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)