### PR TITLE
test(utils): add unit tests for chunkItems

### DIFF
--- a/src/utils/chunk-items.test.ts
+++ b/src/utils/chunk-items.test.ts
@@ -1,0 +1,51 @@
+// Chunk items tests cover fixed-size array splitting edge cases.
+import { describe, expect, it } from "vitest";
+import { chunkItems } from "./chunk-items.js";
+
+describe("chunkItems", () => {
+  it("splits items into fixed-size chunks", () => {
+    expect(chunkItems([1, 2, 3, 4, 5], 2)).toEqual([[1, 2], [3, 4], [5]]);
+    expect(chunkItems(["a", "b", "c", "d"], 3)).toEqual([["a", "b", "c"], ["d"]]);
+  });
+
+  it("returns a single chunk when size is 0 or negative", () => {
+    expect(chunkItems([1, 2, 3], 0)).toEqual([[1, 2, 3]]);
+    expect(chunkItems([1, 2, 3], -1)).toEqual([[1, 2, 3]]);
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(chunkItems([], 5)).toEqual([]);
+    expect(chunkItems([], 0)).toEqual([[]]);
+    expect(chunkItems([], -1)).toEqual([[]]);
+  });
+
+  it("wraps each item when size is 1", () => {
+    expect(chunkItems([1, 2, 3], 1)).toEqual([[1], [2], [3]]);
+  });
+
+  it("returns a single chunk when size exceeds array length", () => {
+    expect(chunkItems([1, 2, 3], 10)).toEqual([[1, 2, 3]]);
+  });
+
+  it("exactly divides when size matches array length", () => {
+    expect(chunkItems([1, 2, 3], 3)).toEqual([[1, 2, 3]]);
+  });
+
+  it("preserves readonly input without mutation", () => {
+    const input: readonly number[] = [10, 20, 30, 40];
+    const result = chunkItems(input, 2);
+    expect(result).toEqual([
+      [10, 20],
+      [30, 40],
+    ]);
+    expect(input).toEqual([10, 20, 30, 40]);
+  });
+
+  it("handles fractional size using slice native truncation behavior", () => {
+    // slice() truncates non-integer args, so 2.5 → chunk boundaries at 0, 2.5, 5.0
+    expect(chunkItems([1, 2, 3, 4, 5], 2.5)).toEqual([
+      [1, 2],
+      [3, 4, 5],
+    ]);
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

The `chunkItems` utility in `src/utils/chunk-items.ts` is a zero-dependency pure generic function (`chunkItems<T>(items: readonly T[], size: number): T[][]`) that splits arrays into fixed-size chunks. It is re-exported by `plugin-sdk/text-chunking.ts` for external consumers. Despite being a shared utility, this module had no unit tests.

## Why This Change Was Made

Add unit tests for the `chunkItems` function covering:
- Normal fixed-size chunking (`[1,2,3,4,5]` by 2 → `[[1,2],[3,4],[5]]`)
- Size zero or negative wraps the entire array in a single chunk
- Empty array input (with positive, zero, and negative size)
- Size 1 wrapping each item in its own chunk
- Size exceeding array length returns a single chunk
- Exact division when size equals array length
- Readonly input preservation (input not mutated after chunking)
- Fractional size behavior (slice native truncation)

This improves test coverage and prevents regressions when the module is modified.

## User Impact

No user-visible changes. For developers, `chunkItems` behavioral contract is now documented via tests, enabling safe refactoring of the shared utility.

## Evidence

Reproducibility: not applicable. This PR adds direct coverage for existing utility behavior rather than reporting a user-visible runtime bug. Source inspection confirms the utility behavior the tests target.

Direct behavior probe (no mocks — real functions exercised directly):

```text
$ node --import tsx -e "import('./src/utils/chunk-items.js').then((m) => {
  const r = [];
  r.push({ desc: 'exported function', fn: typeof m.chunkItems });
  r.push({ desc: 'split 5 items by 2', result: m.chunkItems([1,2,3,4,5], 2) });
  r.push({ desc: 'empty array size 5', result: m.chunkItems([], 5) });
  r.push({ desc: 'size zero wraps in single chunk', result: m.chunkItems([1,2,3], 0) });
  r.push({ desc: 'size negative wraps in single chunk', result: m.chunkItems([1,2,3], -1) });
  r.push({ desc: 'empty with size 0 returns empty chunk', result: m.chunkItems([], 0) });
  r.push({ desc: 'empty with size -1 returns empty chunk', result: m.chunkItems([], -1) });
  r.push({ desc: 'size 1 wraps each item', result: m.chunkItems([1,2,3], 1) });
  r.push({ desc: 'size exceeds length returns single chunk', result: m.chunkItems([1,2,3], 10) });
  r.push({ desc: 'exact division', result: m.chunkItems([1,2,3,4], 2) });
  r.push({ desc: 'fractional size uses slice truncation', result: m.chunkItems([1,2,3,4,5], 2.5) });
  const readonlyInput = [10,20,30,40] as const;
  m.chunkItems(readonlyInput, 2);
  r.push({ desc: 'readonly input not mutated', original: [...readonlyInput] });
  console.log(JSON.stringify(r, null, 2));
})"
[
  {
    "desc": "exported function",
    "fn": "function"
  },
  {
    "desc": "split 5 items by 2",
    "result": [
      [1, 2],
      [3, 4],
      [5]
    ]
  },
  {
    "desc": "empty array size 5",
    "result": []
  },
  {
    "desc": "size zero wraps in single chunk",
    "result": [[1, 2, 3]]
  },
  {
    "desc": "size negative wraps in single chunk",
    "result": [[1, 2, 3]]
  },
  {
    "desc": "empty with size 0 returns empty chunk",
    "result": [[]]
  },
  {
    "desc": "empty with size -1 returns empty chunk",
    "result": [[]]
  },
  {
    "desc": "size 1 wraps each item",
    "result": [[1], [2], [3]]
  },
  {
    "desc": "size exceeds length returns single chunk",
    "result": [[1, 2, 3]]
  },
  {
    "desc": "exact division",
    "result": [[1, 2], [3, 4]]
  },
  {
    "desc": "fractional size uses slice truncation",
    "result": [[1, 2], [3, 4, 5]]
  },
  {
    "desc": "readonly input not mutated",
    "original": [10, 20, 30, 40]
  }
]
```

Targeted test:

```text
$ node scripts/run-vitest.mjs run src/utils/chunk-items.test.ts

 RUN  v4.1.8

 Test Files  1 passed (1)
      Tests  8 passed (8)
   Start at  09:07:18
   Duration  323ms

[test] passed 1 Vitest shard in 10.11s
```

Formatting:

```text
$ npx oxfmt --check src/utils/chunk-items.ts src/utils/chunk-items.test.ts
Checking formatting...

All matched files use the correct format.
```

Whitespace:

```text
$ git diff --check
```
