### PR TITLE
fix(google): bound OAuth token exchange response reads to prevent OOM

### DIFF
--- a/extensions/google/oauth.token.ts
+++ b/extensions/google/oauth.token.ts
@@ -3,6 +3,7 @@ import {
   asDateTimestampMs,
   resolveExpiresAtMsFromDurationSeconds,
 } from "openclaw/plugin-sdk/number-runtime";
+import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import { resolveOAuthClientConfig } from "./oauth.credentials.js";
 import { fetchWithTimeout } from "./oauth.http.js";
 import { resolveGoogleOAuthIdentity, resolveGooglePersonalOAuthIdentity } from "./oauth.project.js";
@@ -27,15 +28,27 @@ async function requestTokenGrant(body: URLSearchParams): Promise<{
   });
 
   if (!response.ok) {
-    const errorText = await response.text();
+    let errorText: string;
+    try {
+      const buf = await readResponseWithLimit(response, 16 * 1024, {
+        onOverflow: () => new Error("Token exchange error response exceeds 16 KB"),
+      });
+      errorText = new TextDecoder().decode(buf);
+    } catch {
+      errorText = `HTTP ${response.status}`;
+    }
     throw new Error(`Token exchange failed: ${errorText}`);
   }
 
-  return (await response.json()) as {
+  const buf = await readResponseWithLimit(response, 16 * 1024 * 1024, {
+    onOverflow: () => new Error("Token grant response exceeds 16 MB"),
+  });
+  const json = JSON.parse(new TextDecoder().decode(buf)) as {
     access_token?: string;
     refresh_token?: string;
     expires_in?: unknown;
   };
+  return json;
 }
 
 function resolveExpiredTokenTimestampMs(nowMs: number): number {


### PR DESCRIPTION
## Summary
**Problem**: The `requestTokenGrant` function in the Google extension (`extensions/google/oauth.token.ts`) calls the Google OAuth token endpoint with unbounded `response.text()` on the error path and unbounded `response.json()` on the success path. Neither read applies any byte cap — the entire response body is buffered into memory regardless of size. A misconfigured, attacker-controlled, or compromised OAuth provider can return an oversized response body that exhausts gateway heap before the existing `AbortSignal.timeout` fires (that timeout only bounds connection latency, not body size). This is a well-recognized vulnerability class in OpenClaw, already addressed across 50+ other provider integrations in prior hardening PRs (#96868 through #97620).

**Solution**: Replace the two unbounded reads with `readResponseWithLimit`, the project's standard bounded reader exported from `openclaw/plugin-sdk/response-limit-runtime`. The error path receives a 16 KB cap — sufficient for any realistic OAuth error payload (typically a small JSON object like `{"error":"invalid_grant","error_description":"..."}`). On overflow the catch block falls back to `HTTP ${response.status}`, ensuring the error message is always informative even if the provider sends an abnormally large error body. The success path receives a 16 MB cap — a Google OAuth token response is a tiny JSON object (~200 bytes), so this cap is purely defensive. The bounded reader cancels the underlying stream (`reader.cancel()`) on overflow, preventing any further data from being buffered.

**What changed**: One file modified. `extensions/google/oauth.token.ts` gains one new import (`readResponseWithLimit`) and the `requestTokenGrant` function's two response reads are wrapped with byte limits and overflow handling. The function signature, exports, and calling convention are unchanged.

**What did NOT change**:
- No change to the function signature, exported API (`exchangeCodeForTokens`, `refreshTokensForGeminiCli`), or OAuth flow logic.
- No change to `extensions/google/oauth.test.ts` — the existing 27 test cases pass without modification.
- No change to lockfile, documentation, configuration, or any other file.
- No change to any TypeScript types or interfaces consumed by callers.
## Real behavior proof

**Behavior addressed**: Unbounded HTTP response body reads in Google OAuth token exchange can cause gateway OOM when a provider returns an oversized response. The fix caps both error and success reads with byte limits and cancels the stream on overflow.

**Real environment tested**: Windows 11 Pro 10.0.26200 / Node v22.19.0 / OpenClaw main@6cb82eaab8

**Exact steps or command run after this patch**:

```bash
# Step 1: Run existing unit tests to confirm zero regression
pnpm test -- extensions/google/oauth.test.ts

# Step 2: Verify normal token response is parsed correctly
node --input-type=module -e "
import { readResponseWithLimit } from 'openclaw/plugin-sdk/response-limit-runtime';
const r = new Response(JSON.stringify({access_token:'tok'}), {status:200});
const b = await readResponseWithLimit(r, 16 * 1024 * 1024);
const p = JSON.parse(new TextDecoder().decode(b));
console.log('normal:', p.access_token);
"

# Step 3: Verify oversized response is rejected with meaningful error
node --input-type=module -e "
import { readResponseWithLimit } from 'openclaw/plugin-sdk/response-limit-runtime';
const r = new Response('x'.repeat(16 * 1024 * 1024 + 4096), {status:200});
try { await readResponseWithLimit(r, 16 * 1024 * 1024); }
catch(e) { console.log('rejected:', e.message); }
"

# Step 4: Verify error response oversize is handled gracefully
node --input-type=module -e "
import { readResponseWithLimit } from 'openclaw/plugin-sdk/response-limit-runtime';
const r = new Response('y'.repeat(20 * 1024), {status:400});
try { await readResponseWithLimit(r, 16 * 1024, {
  onOverflow: () => new Error('error detail exceeds permitted size'),
}); }
catch(e) { console.log('rejected:', e.message); }
"
```

**After-fix evidence**:
```
$ pnpm test -- extensions/google/oauth.test.ts
 RUN  v4.1.8
 Test Files  1 passed (1)
      Tests  27 passed (27)
   Duration  2.98s

$ node --input-type=module [... normal response test ...]
normal: tok

$ node --input-type=module [... oversized body test ...]
rejected: Content too large: 16781312 bytes (limit: 16777216 bytes)

$ node --input-type=module [... oversized error test ...]
rejected: error detail exceeds permitted size
```

**Observed result after the fix**: All four verification steps pass as expected. Normal token responses (~200 bytes) are parsed identically to the original `response.json()` behavior. Oversized responses (16 MB + 4 KB) are cleanly rejected with the error message "Content too large: 16781312 bytes (limit: 16777216 bytes)". Oversized error bodies (20 KB exceeding the 16 KB diagnostic cap) are also rejected. The test suite confirms zero regression across all 27 existing test cases covering the full login and token refresh flow.

**What was not tested**: End-to-end token exchange against the live Google OAuth endpoint. This requires interactive browser-based OAuth flow with valid client credentials and consent UI interaction, which cannot be automated in a CI or dev environment. The bounded reader is a mechanical replacement of `response.json()` / `response.text()` with byte-capped stream reads — its behavior for normal-sized responses is byte-identical to the original code, and overflow behavior is independently verified above through direct calls to `readResponseWithLimit`. The existing 27 test cases cover all OAuth flow paths through mocked HTTP, confirming the integration surfaces remain intact.

## Tests and validation

The change was validated through two complementary approaches: existing regression tests and independent bounded-reader verification.

### Regression tests (27/27 pass)

The full Google OAuth test suite runs against the modified code with zero failures:

```
$ pnpm test -- extensions/google/oauth.test.ts

 RUN  v4.1.8 D:/workspace/openclaw/.worktrees/fix-google-oauth-bound-token-exchange

 Test Files  1 passed (1)
      Tests  27 passed (27)
   Duration  2.98s (transform 2.14s, setup 250ms, import 27ms, tests 2.61s)

[test] passed 1 Vitest shard in 7.33s
```

The test suite covers: credential extraction from multiple Gemini CLI installation layouts (npm shim, Homebrew, bundled, Windows nvm), OAuth state and PKCE verifier separation, manual callback URL validation, loadCodeAssist endpoint fallback across prod/daily/autopush, personal OAuth mode token refresh, and edge cases around malformed token expiry values.

### Bounded-reader verification (3 scenarios)

The bounded reader behaviour was independently verified against the real `readResponseWithLimit` implementation at the module boundary:

```
Scenario 1 — Normal-sized token response (~200 bytes):
  Input:   new Response(JSON.stringify({access_token:"tok"}), {status:200})
  Method:  readResponseWithLimit(response, 16 MB)
  Output:  JSON.parse(TextDecoder.decode(buffer)) → { access_token: "tok" }
  Result:  ✅ Identical behaviour to original response.json()

Scenario 2 — Oversized response body (16 MB + 4 KB):
  Input:   new Response("x".repeat(16 MB + 4 KB), {status:200})
  Method:  readResponseWithLimit(response, 16 MB)
  Output:  Throws "Content too large: 16781312 bytes (limit: 16777216 bytes)"
  Result:  ✅ Stream cancelled at cap, no OOM risk

Scenario 3 — Oversized error response (20 KB > 16 KB error cap):
  Input:   new Response("y".repeat(20 KB), {status:400})
  Method:  readResponseWithLimit(response, 16 KB, {onOverflow: ...})
  Output:  Throws "error detail exceeds permitted size"
  Result:  ✅ Diagnostic budget respected, overflow is fail-closed
```

These three scenarios cover: (1) no regression for normal payloads, (2) success-path OOM protection, and (3) error-path OOM protection. In each case the fix behaves correctly.

## Risk checklist

- [x] This change is backwards compatible
- [x] This change has been tested with existing configurations
- [ ] I have updated relevant documentation (N/A — no API/CLI/config or public interface change)
- [ ] Breaking changes (if any) are documented in Summary (none)

Merge-risk explanation: Low — the change is a mechanical replacement of two unbounded HTTP body reads with the project's standard `readResponseWithLimit` bounded reader. Identical pattern has been merged in 50+ prior hardening PRs (PRs #96868 through #97620). The byte caps (16 KB for errors, 16 MB for success) are generous relative to the actual payload sizes (OAuth token responses are ~200 bytes; error payloads are typically under 1 KB). All 27 existing tests pass without modification. The bounded reader also includes idle-timeout protection (`chunkTimeoutMs`) which will cancel a slow-streaming response even before the byte cap is reached.

## Current review state

- [x] Self-review completed
- [ ] At least one maintainer review
- [ ] All CI checks passed

