### PR TITLE
fix: bump ClawHub publish CLI pin

### DIFF
--- a/.github/workflows/plugin-clawhub-new.yml
+++ b/.github/workflows/plugin-clawhub-new.yml
@@ -34,7 +34,7 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   NODE_VERSION: "24.15.0"
   CLAWHUB_REGISTRY: "https://clawhub.ai"
-  CLAWHUB_CLI_PACKAGE: "clawhub@0.21.0"
+  CLAWHUB_CLI_PACKAGE: "clawhub@0.23.1"
 
 jobs:
   resolve_bootstrap_plan:

--- a/.github/workflows/plugin-clawhub-release.yml
+++ b/.github/workflows/plugin-clawhub-release.yml
@@ -42,7 +42,7 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   NODE_VERSION: "24.15.0"
   CLAWHUB_REGISTRY: "https://clawhub.ai"
-  CLAWHUB_CLI_PACKAGE: "clawhub@0.21.0"
+  CLAWHUB_CLI_PACKAGE: "clawhub@0.23.1"
 
 jobs:
   preview_plugins_clawhub:

--- a/scripts/plugin-release-pretag-pack-check.ts
+++ b/scripts/plugin-release-pretag-pack-check.ts
@@ -8,7 +8,7 @@ import { pathToFileURL } from "node:url";
 import { collectClawHubPublishablePluginPackages } from "./lib/plugin-clawhub-release.ts";
 import { collectPublishablePluginPackages } from "./lib/plugin-npm-release.ts";
 
-const DEFAULT_CLAWHUB_CLI_PACKAGE = "clawhub@0.21.0";
+const DEFAULT_CLAWHUB_CLI_PACKAGE = "clawhub@0.23.1";
 
 export type PluginReleasePretagPackTarget = {
   packageDir: string;

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -2114,7 +2114,7 @@ describe("package artifact reuse", () => {
     expect(pluginPretagPackScript).toContain("scripts/check-plugin-npm-runtime-builds.mjs");
     expect(pluginPretagPackScript).toContain("scripts/plugin-npm-publish.sh");
     expect(pluginPretagPackScript).toContain("scripts/plugin-clawhub-publish.sh");
-    expect(clawHubWorkflow).toContain('CLAWHUB_CLI_PACKAGE: "clawhub@0.21.0"');
+    expect(clawHubWorkflow).toContain('CLAWHUB_CLI_PACKAGE: "clawhub@0.23.1"');
     expect(clawHubWorkflow).not.toContain("CLAWHUB_REPOSITORY:");
     expect(clawHubWorkflow).not.toContain("CLAWHUB_REF:");
     expect(clawHubWorkflow).toContain("pack_plugins_clawhub_artifacts:");
@@ -2287,7 +2287,7 @@ describe("package artifact reuse", () => {
     expect(pluginNpmWorkflow).toContain("environment: npm-release");
     expect(clawHubWorkflow.match(/environment: clawhub-plugin-release/g)?.length).toBe(1);
     expect(clawHubNewWorkflow).toContain("name: Plugin ClawHub New");
-    expect(clawHubNewWorkflow).toContain('CLAWHUB_CLI_PACKAGE: "clawhub@0.21.0"');
+    expect(clawHubNewWorkflow).toContain('CLAWHUB_CLI_PACKAGE: "clawhub@0.23.1"');
     expect(clawHubNewWorkflow).not.toContain("CLAWHUB_REPOSITORY:");
     expect(clawHubNewWorkflow).not.toContain("CLAWHUB_REF:");
     expect(clawHubNewWorkflow).toContain("environment: clawhub-plugin-bootstrap");


### PR DESCRIPTION
## What Problem This Solves

OpenClaw's ClawHub plugin publish workflows still invoke `clawhub@0.21.0` in OpenClaw-owned pack/bootstrap/pretag paths, even though the ClawHub reusable publish workflow has moved to the fixed ClawHub implementation. That stale CLI can keep the registry family-conflict fix out of release publishing.

## Why This Change Was Made

Bump the OpenClaw workflow/default ClawHub CLI pin to `clawhub@0.23.1`, which includes the ClawHub package-family conflict fix, while leaving plugin versions and publish behavior unchanged.

## User Impact

Official OpenClaw plugins can be republished to ClawHub with the fixed CLI path, without requiring plugin version bumps or source changes.

## Evidence

- `git diff --check`
- `actionlint .github/workflows/plugin-clawhub-release.yml .github/workflows/plugin-clawhub-new.yml`
- `node scripts/run-vitest.mjs test/scripts/package-acceptance-workflow.test.ts test/scripts/plugin-release-pretag-pack-check.test.ts` — 2 files, 42 tests passed
