### PR TITLE
fix(feishu): include video upload duration

### DIFF
--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -214,6 +214,8 @@ describe("sendMediaFeishu msg_type routing", () => {
   });
 
   it("uses msg_type=media for mp4 video", async () => {
+    runFfprobeMock.mockResolvedValueOnce("4.2\n");
+
     await sendMediaFeishu({
       cfg: emptyConfig,
       to: "user:ou_target",
@@ -222,6 +224,17 @@ describe("sendMediaFeishu msg_type routing", () => {
     });
 
     expect(callData<{ file_type?: string }>(fileCreateMock).file_type).toBe("mp4");
+    expect(callData<{ duration?: number }>(fileCreateMock).duration).toBe(4200);
+    const ffprobeArgs = mockCallArg<string[]>(runFfprobeMock, 0, 0);
+    expect(ffprobeArgs.slice(0, -1)).toEqual([
+      "-v",
+      "error",
+      "-show_entries",
+      "format=duration",
+      "-of",
+      "csv=p=0",
+    ]);
+    expect(ffprobeArgs.at(-1)).toMatch(/input\.mp4$/);
     expect(callData<{ msg_type?: string }>(messageCreateMock).msg_type).toBe("media");
   });
 
@@ -297,6 +310,7 @@ describe("sendMediaFeishu msg_type routing", () => {
   });
 
   it("uses msg_type=media for remote mp4 content even when the filename is generic", async () => {
+    runFfprobeMock.mockResolvedValueOnce("6.789\n");
     loadWebMediaMock.mockResolvedValueOnce({
       buffer: Buffer.from("remote-video"),
       fileName: "download",
@@ -311,6 +325,9 @@ describe("sendMediaFeishu msg_type routing", () => {
     });
 
     expect(callData<{ file_type?: string }>(fileCreateMock).file_type).toBe("mp4");
+    expect(callData<{ duration?: number }>(fileCreateMock).duration).toBe(6789);
+    const ffprobeArgs = mockCallArg<string[]>(runFfprobeMock, 0, 0);
+    expect(ffprobeArgs.at(-1)).toMatch(/input\.mp4$/);
     expect(callData<{ msg_type?: string }>(messageCreateMock).msg_type).toBe("media");
   });
 

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -822,12 +822,23 @@ async function prepareFeishuVoiceMedia(params: {
   }
 }
 
-async function probeAudioDurationMs(buffer: Buffer): Promise<number | undefined> {
+async function probeMediaDurationMs(params: {
+  buffer: Buffer;
+  fileName: string;
+  contentType?: string;
+}): Promise<number | undefined> {
   try {
     return await withTempWorkspace(
-      { rootDir: resolvePreferredOpenClawTmpDir(), prefix: "feishu-audio-probe-" },
+      { rootDir: resolvePreferredOpenClawTmpDir(), prefix: "feishu-media-probe-" },
       async (workspace) => {
-        const inputPath = await workspace.write("input.ogg", buffer);
+        const ext = normalizeLowercaseStringOrEmpty(path.extname(params.fileName));
+        const inferredExt =
+          ext && ext.length <= 12
+            ? ext
+            : mediaKindFromMime(params.contentType) === "video"
+              ? ".mp4"
+              : ".ogg";
+        const inputPath = await workspace.write(`input${inferredExt}`, params.buffer);
         const stdout = await runFfprobe(
           ["-v", "error", "-show_entries", "format=duration", "-of", "csv=p=0", inputPath],
           { timeoutMs: 5_000 },
@@ -840,9 +851,21 @@ async function probeAudioDurationMs(buffer: Buffer): Promise<number | undefined>
       },
     );
   } catch (err) {
-    console.warn("[feishu] failed to probe audio duration; voice bubble will omit it:", err);
+    console.warn("[feishu] failed to probe media duration; upload will omit it:", err);
     return undefined;
   }
+}
+
+async function maybeProbeUploadDurationMs(params: {
+  buffer: Buffer;
+  fileName: string;
+  contentType?: string;
+  msgType: "file" | "audio" | "media";
+}): Promise<number | undefined> {
+  if (params.msgType !== "audio" && params.msgType !== "media") {
+    return undefined;
+  }
+  return await probeMediaDurationMs(params);
 }
 
 /**
@@ -930,7 +953,12 @@ export async function sendMediaFeishu(params: {
       ...(voiceIntentDegradedToFile ? { voiceIntentDegradedToFile: true } : {}),
     };
   }
-  const durationMs = routing.msgType === "audio" ? await probeAudioDurationMs(buffer) : undefined;
+  const durationMs = await maybeProbeUploadDurationMs({
+    buffer,
+    fileName: name,
+    contentType,
+    msgType: routing.msgType,
+  });
   const { fileKey } = await uploadFileFeishu({
     cfg,
     file: buffer,


### PR DESCRIPTION
## What Problem This Solves
Feishu voice/audio bubbles already get upload `duration` from ffprobe. Video uploads use `file_type=mp4` and `msg_type=media`, but the duration probe was gated on `msgType === "audio"`, so videos were uploaded without duration and could display without a visible length.

## Summary
- Probe outbound Feishu upload duration for both audio and video/media messages.
- Preserve best-effort behavior: if ffprobe fails, omit `duration` and still send the message.
- Add local and remote mp4 coverage asserting Feishu file upload receives duration while keeping `msg_type=media`.
- Rebased the same Feishu-only diff onto current `main` as head `ee07c2c0` to pick up unrelated core CI fixes.

## Evidence
- Current head: `ee07c2c01279bc08875af20e3b9592775c464882`
- `pnpm install --frozen-lockfile`
- `pnpm exec oxfmt --check --threads=1 extensions/feishu/src/media.ts extensions/feishu/src/media.test.ts`
- `pnpm exec node scripts/run-vitest.mjs run extensions/feishu/src/media.test.ts` (44 passed)
- Live Feishu proof captured on the equivalent pre-rebase commit `550c361fbec2b63746321a57828e839e2f9024c5`: sent `openclaw-pr-98235-duration-test-5s.mp4` through the PR branch `sendMediaFeishu` path; local `ffprobe` reported `5.000000` seconds and Feishu rendered the received video bubble with `00:05` duration. Thumbnail/preview-frame generation is unchanged and outside this PR.

![Feishu video bubble showing 00:05 duration](https://raw.githubusercontent.com/areslp/openclaw/codex/pr-98235-feishu-proof/pr-evidence/feishu-video-duration-00-05.jpg)