### PR TITLE
fix(agents): keep merged delivery routes account-bound

### DIFF
--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -395,6 +395,27 @@ async function deliverSlackChannelAnnouncement(params: {
 }
 
 describe("resolveAnnounceOrigin threaded route targets", () => {
+  it("does not inherit a target or thread from another account on the same channel", () => {
+    expect(
+      resolveAnnounceOrigin(
+        {
+          lastChannel: "telegram",
+          lastTo: "peer-b",
+          lastAccountId: "bot-b",
+          lastThreadId: 99,
+        },
+        {
+          channel: "telegram",
+          accountId: "bot-a",
+        },
+      ),
+    ).toEqual({
+      channel: "telegram",
+      to: undefined,
+      accountId: "bot-a",
+    });
+  });
+
   it("preserves stored thread ids when requester origin omits one for the same chat", () => {
     expect(
       resolveAnnounceOrigin(

--- a/src/agents/tools/media-generate-background-shared.ts
+++ b/src/agents/tools/media-generate-background-shared.ts
@@ -19,12 +19,7 @@ import {
   resolveRequiredCompletionDeliveryFailureTerminalResult,
   type RequiredCompletionTerminalResult,
 } from "../../tasks/task-completion-contract.js";
-import {
-  deliveryContextFromSession,
-  normalizeDeliveryContext,
-  type DeliveryContext,
-} from "../../utils/delivery-context.js";
-import type { DeliveryContextSessionSource } from "../../utils/delivery-context.types.js";
+import { normalizeDeliveryContext, type DeliveryContext } from "../../utils/delivery-context.js";
 import {
   INTERNAL_MESSAGE_CHANNEL,
   isDeliverableMessageChannel,
@@ -64,21 +59,6 @@ export type MediaGenerateBackgroundScheduler = (work: () => Promise<void>) => vo
 
 /** Optional callback invoked when async media generation starts. */
 export type MediaGenerateAsyncStartCallback = (message: string) => Promise<void> | void;
-
-function resolvePinnedMediaRequesterOrigin(params: {
-  requesterOrigin?: DeliveryContext;
-  sessionEntry?: DeliveryContextSessionSource;
-}): DeliveryContext | undefined {
-  const requesterOrigin = normalizeDeliveryContext(params.requesterOrigin);
-  const sessionOrigin = deliveryContextFromSession(params.sessionEntry);
-  const accountsConflict =
-    requesterOrigin?.accountId &&
-    sessionOrigin?.accountId &&
-    requesterOrigin.accountId !== sessionOrigin.accountId;
-  return accountsConflict
-    ? requesterOrigin
-    : resolveAnnounceOrigin(params.sessionEntry, requesterOrigin);
-}
 
 /** Returns whether a media generation request should detach for a session. */
 export function shouldDetachMediaGenerationTask(sessionKey: string | undefined): boolean {
@@ -168,10 +148,10 @@ function createMediaGenerationTaskRun(params: {
   try {
     // Pin the complete requester route when detached work starts. Completion-time
     // session state can move to another peer while generation is still running.
-    const requesterOrigin = resolvePinnedMediaRequesterOrigin({
-      requesterOrigin: params.requesterOrigin,
-      sessionEntry: loadRequesterSessionEntry(sessionKey).entry,
-    });
+    const requesterOrigin = resolveAnnounceOrigin(
+      loadRequesterSessionEntry(sessionKey).entry,
+      params.requesterOrigin,
+    );
     const task = createRunningTaskRun({
       runtime: "cli",
       taskKind: params.taskKind,

--- a/src/utils/delivery-context.shared.ts
+++ b/src/utils/delivery-context.shared.ts
@@ -243,17 +243,20 @@ export function mergeDeliveryContext(
     normalizedPrimary?.channel &&
     normalizedFallback?.channel &&
     normalizedPrimary.channel !== normalizedFallback.channel;
+  const accountsConflict =
+    normalizedPrimary?.accountId &&
+    normalizedFallback?.accountId &&
+    normalizedPrimary.accountId !== normalizedFallback.accountId;
+  const routesConflict = channelsConflict || accountsConflict;
   return normalizeDeliveryContext({
     channel: normalizedPrimary?.channel ?? normalizedFallback?.channel,
     // Keep route fields paired to their channel; avoid crossing fields between
     // unrelated channels during session context merges.
-    to: channelsConflict
-      ? normalizedPrimary?.to
-      : (normalizedPrimary?.to ?? normalizedFallback?.to),
-    accountId: channelsConflict
+    to: routesConflict ? normalizedPrimary?.to : (normalizedPrimary?.to ?? normalizedFallback?.to),
+    accountId: routesConflict
       ? normalizedPrimary?.accountId
       : (normalizedPrimary?.accountId ?? normalizedFallback?.accountId),
-    threadId: channelsConflict
+    threadId: routesConflict
       ? normalizedPrimary?.threadId
       : (normalizedPrimary?.threadId ?? normalizedFallback?.threadId),
   });

--- a/src/utils/delivery-context.shared.ts
+++ b/src/utils/delivery-context.shared.ts
@@ -229,7 +229,7 @@ export function deliveryContextFromSession(
   return normalizeSessionDeliveryFields(source).deliveryContext;
 }
 
-/** Merges delivery contexts without mixing target/account/thread fields across channels. */
+/** Merges delivery contexts without mixing target/account/thread fields across route owners. */
 export function mergeDeliveryContext(
   primary?: DeliveryContext,
   fallback?: DeliveryContext,
@@ -249,9 +249,11 @@ export function mergeDeliveryContext(
     normalizedPrimary.accountId !== normalizedFallback.accountId;
   const routesConflict = channelsConflict || accountsConflict;
   return normalizeDeliveryContext({
-    channel: normalizedPrimary?.channel ?? normalizedFallback?.channel,
-    // Keep route fields paired to their channel; avoid crossing fields between
-    // unrelated channels during session context merges.
+    channel: accountsConflict
+      ? normalizedPrimary?.channel
+      : (normalizedPrimary?.channel ?? normalizedFallback?.channel),
+    // Keep route fields paired to their channel account; crossing either owner
+    // can address one account's target through another account's credentials.
     to: routesConflict ? normalizedPrimary?.to : (normalizedPrimary?.to ?? normalizedFallback?.to),
     accountId: routesConflict
       ? normalizedPrimary?.accountId

--- a/src/utils/delivery-context.test.ts
+++ b/src/utils/delivery-context.test.ts
@@ -53,6 +53,20 @@ describe("delivery context helpers", () => {
     });
   });
 
+  it("does not inherit route fields from a different account on the same channel", () => {
+    const merged = mergeDeliveryContext(
+      { channel: "telegram", accountId: "bot-a" },
+      { channel: "telegram", to: "123", accountId: "bot-b", threadId: "99" },
+    );
+
+    expect(merged).toEqual({
+      channel: "telegram",
+      to: undefined,
+      accountId: "bot-a",
+    });
+    expect(merged?.threadId).toBeUndefined();
+  });
+
   it("uses fallback route fields when fallback has no channel", () => {
     const merged = mergeDeliveryContext(
       { channel: "demo-channel" },

--- a/src/utils/delivery-context.test.ts
+++ b/src/utils/delivery-context.test.ts
@@ -65,6 +65,17 @@ describe("delivery context helpers", () => {
       accountId: "bot-a",
     });
     expect(merged?.threadId).toBeUndefined();
+
+    expect(
+      mergeDeliveryContext(
+        { accountId: "bot-a" },
+        { channel: "telegram", to: "123", accountId: "bot-b", threadId: "99" },
+      ),
+    ).toEqual({
+      channel: undefined,
+      to: undefined,
+      accountId: "bot-a",
+    });
   });
 
   it("uses fallback route fields when fallback has no channel", () => {


### PR DESCRIPTION
## What Problem This Solves

Multi-account deployments can merge a completion origin for one account with the saved target and thread of another account on the same channel. That can misroute or drop subagent, cron, media, and agent-harness completions.

The account guard was added in `1ed8592467`, then removed while the media route-pin path was introduced in `025db6cf9e` / #89949. Current `main` therefore allows a Telegram `bot-a` origin with no target to inherit `bot-b`'s `to` and `threadId`.

## Why This Change Was Made

`mergeDeliveryContext` is the canonical owner of route-field crossing. It now treats two explicit, differing account IDs as a route conflict and keeps the primary route isolated: fallback channel, target, thread, and account do not cross the account boundary. Same-account and missing-account merges retain the existing backfill behavior.

The patch also removes the media-only duplicate account guard and sends media route pinning through the same `resolveAnnounceOrigin` path used by subagent, cron, and harness completions. This is the best fix because all callers share one invariant instead of carrying caller-specific defenses.

## User Impact

Completions from one configured account can no longer inherit another same-channel account's destination or thread. Single-account, same-account, and channel-conflict behavior is unchanged.

## Evidence

- Focused production-path suite: 138 tests passed across `delivery-context`, subagent announcement delivery, media completion routing, and the plugin SDK harness runtime.
- Blacksmith Testbox `tbx_01kwdkbva1c8zh4f73zv22rkjs` (`jade-shrimp`): `pnpm check:changed` passed, including core/core-test type checks, lint, dependency guards, database-first/media/runtime guards, and import-cycle checks.
- Production before/after probe used real `resolveAnnounceOrigin` and `resolveExternalBestEffortDeliveryTarget` for same-channel and account-only primary origins. Current `main` produced `{channel:"telegram",to:"peer-b",accountId:"bot-a",threadId:99}` and a deliverable bot-a/peer-b target; this head produces `{channel:"telegram",accountId:"bot-a"}` (or `{accountId:"bot-a"}`) and `{deliver:false}`.
- Fresh autoreview after the refinement: no findings; patch correct (0.97 confidence).
- `oxfmt --check` and `git diff --check`: clean.

The credentialed Telegram Desktop proof lane was attempted, but its harness provisions only one bot account and cannot express this two-account condition. The strongest feasible live-like proof is therefore the real production resolver/target path on retained Testbox with two distinct account IDs; no Bot API message was sent with two real bot tokens.

No linked issue was found. No docs or changelog change is needed for this internal routing correction.
