### PR TITLE
feat: make mobile setup-code pairing one step

### DIFF
--- a/apps/ios/Sources/Design/SettingsProTabActions.swift
+++ b/apps/ios/Sources/Design/SettingsProTabActions.swift
@@ -186,7 +186,10 @@ extension SettingsProTab {
 
     func applySetupCodeAndConnect() async {
         self.setupStatusText = nil
-        guard self.applySetupCode() else { return }
+        guard let link = await self.resolveSetupInputForConnect() else { return }
+        self.stagedGatewaySetupLink = nil
+        self.setupCode = ""
+        self.applyGatewayLink(link)
         let host = self.manualGatewayHost.trimmingCharacters(in: .whitespacesAndNewlines)
         guard let port = self.resolvedManualPort(host: host) else {
             self.setupStatusText = "Failed: invalid port"
@@ -195,6 +198,44 @@ extension SettingsProTab {
         guard await self.preflightGateway(host: host, port: port) else { return }
         self.setupStatusText = "Setup code applied. Connecting..."
         await self.connectManual()
+    }
+
+    func resolveSetupInputForConnect() async -> GatewayConnectDeepLink? {
+        let raw = self.setupCode.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let stagedGatewaySetupLink, raw.isEmpty {
+            return stagedGatewaySetupLink
+        }
+        guard !raw.isEmpty else {
+            self.setupStatusText = "Paste a setup code to continue."
+            return nil
+        }
+        if AppleReviewDemoMode.isSetupCode(raw) {
+            self.stagedGatewaySetupLink = nil
+            self.setupCode = ""
+            self.setupStatusText = "Apple Review demo mode enabled."
+            self.appModel.enterAppleReviewDemoMode()
+            return nil
+        }
+        if let link = GatewayConnectDeepLink.fromSetupInput(raw) {
+            return link
+        }
+        guard GatewaySetupShortCode.looksLikeShortCode(raw) else {
+            self.setupStatusText = "Setup code not recognized or uses an insecure ws:// gateway URL."
+            return nil
+        }
+        guard let gateway = self.shortCodeRedemptionGateway() else {
+            self.setupStatusText = "Choose or enter a Gateway host before using a short code."
+            return nil
+        }
+        self.connectingGatewayID = "manual"
+        self.setupStatusText = "Redeeming setup short code..."
+        defer { self.connectingGatewayID = nil }
+        do {
+            return try await GatewaySetupShortCodeRedeemer().redeem(raw, through: gateway)
+        } catch {
+            self.setupStatusText = Self.shortCodeRedeemMessage(error)
+            return nil
+        }
     }
 
     func applyPendingGatewaySetupLinkIfNeeded() {
@@ -258,6 +299,24 @@ extension SettingsProTab {
             }
         }
         self.pendingManualAuthOverride = setupAuth.manualAuthOverride
+    }
+
+    func shortCodeRedemptionGateway() -> GatewayConnectDeepLink? {
+        let host = self.manualGatewayHost.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !host.isEmpty, let port = self.resolvedManualPort(host: host) {
+            let scheme = self.manualGatewayTLS ? "wss" : "ws"
+            if let link = GatewayConnectDeepLink.fromGatewayURL("\(scheme)://\(host):\(port)") {
+                return link
+            }
+        }
+        return nil
+    }
+
+    static func shortCodeRedeemMessage(_ error: Error) -> String {
+        if let error = error as? LocalizedError, let message = error.errorDescription {
+            return message
+        }
+        return "Could not redeem setup short code."
     }
 
     func openGatewayQRScanner() {

--- a/apps/ios/Sources/Design/SettingsProTabSections.swift
+++ b/apps/ios/Sources/Design/SettingsProTabSections.swift
@@ -717,7 +717,7 @@ extension SettingsProTab {
             VStack(alignment: .leading, spacing: 12) {
                 Text("Setup Code")
                     .font(.subheadline.weight(.semibold))
-                TextField("Paste setup code", text: self.$setupCode)
+                TextField("Paste setup or short code", text: self.$setupCode)
                     .textInputAutocapitalization(.never)
                     .autocorrectionDisabled()
                     .textFieldStyle(.roundedBorder)

--- a/apps/ios/Sources/Onboarding/OnboardingWizardView.swift
+++ b/apps/ios/Sources/Onboarding/OnboardingWizardView.swift
@@ -620,7 +620,7 @@ struct OnboardingWizardView: View {
 extension OnboardingWizardView {
     private var setupCodeSection: some View {
         Section {
-            TextField("Paste setup code", text: self.$setupCode)
+            TextField("Paste setup or short code", text: self.$setupCode)
                 .textInputAutocapitalization(.never)
                 .autocorrectionDisabled()
                 .onSubmit {
@@ -652,7 +652,7 @@ extension OnboardingWizardView {
         } header: {
             Text("Setup Code")
         } footer: {
-            Text("Use this if you received a setup code instead of a QR code.")
+            Text("Use this if you received a setup code or short code instead of a QR code.")
         }
     }
 
@@ -709,10 +709,7 @@ extension OnboardingWizardView {
             return
         }
 
-        guard let link = GatewayConnectDeepLink.fromSetupInput(raw) else {
-            self.setupCodeStatus = "Setup code not recognized or uses an insecure ws:// gateway URL."
-            return
-        }
+        guard let link = await self.resolveSetupInput(raw) else { return }
 
         self.connectingGatewayID = "setup-code"
         self.applyGatewayLink(link)
@@ -722,6 +719,47 @@ extension OnboardingWizardView {
         self.statusLine = "Setup code loaded. Connecting to \(link.host):\(link.port)..."
         self.step = .connect
         await self.connectManual()
+    }
+
+    private func resolveSetupInput(_ raw: String) async -> GatewayConnectDeepLink? {
+        if let link = GatewayConnectDeepLink.fromSetupInput(raw) {
+            return link
+        }
+        guard GatewaySetupShortCode.looksLikeShortCode(raw) else {
+            self.setupCodeStatus = "Setup code not recognized or uses an insecure ws:// gateway URL."
+            return nil
+        }
+        guard let gateway = self.shortCodeRedemptionGateway() else {
+            self.setupCodeStatus = "Choose or enter a Gateway host before using a short code."
+            return nil
+        }
+        self.connectingGatewayID = "setup-code"
+        self.setupCodeStatus = "Redeeming setup short code..."
+        do {
+            return try await GatewaySetupShortCodeRedeemer().redeem(raw, through: gateway)
+        } catch {
+            self.connectingGatewayID = nil
+            self.setupCodeStatus = Self.shortCodeRedeemMessage(error)
+            return nil
+        }
+    }
+
+    private func shortCodeRedemptionGateway() -> GatewayConnectDeepLink? {
+        let host = self.manualHost.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !host.isEmpty, self.manualPort > 0, self.manualPort <= 65535 {
+            let scheme = self.manualTLS ? "wss" : "ws"
+            if let link = GatewayConnectDeepLink.fromGatewayURL("\(scheme)://\(host):\(self.manualPort)") {
+                return link
+            }
+        }
+        return nil
+    }
+
+    private static func shortCodeRedeemMessage(_ error: Error) -> String {
+        if let error = error as? LocalizedError, let message = error.errorDescription {
+            return message
+        }
+        return "Could not redeem setup short code."
     }
 
     private func handleScannedLink(_ link: GatewayConnectDeepLink) {

--- a/apps/ios/SwiftSources.input.xcfilelist
+++ b/apps/ios/SwiftSources.input.xcfilelist
@@ -142,6 +142,7 @@ WatchApp/Sources/WatchInboxView.swift
 ../shared/OpenClawKit/Sources/OpenClawKit/Capabilities.swift
 ../shared/OpenClawKit/Sources/OpenClawKit/OpenClawKitResources.swift
 ../shared/OpenClawKit/Sources/OpenClawKit/DeepLinks.swift
+../shared/OpenClawKit/Sources/OpenClawKit/GatewaySetupShortCodeRedeemer.swift
 ../shared/OpenClawKit/Sources/OpenClawKit/JPEGTranscoder.swift
 ../shared/OpenClawKit/Sources/OpenClawKit/NodeError.swift
 ../shared/OpenClawKit/Sources/OpenClawKit/ScreenCommands.swift

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/DeepLinks.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/DeepLinks.swift
@@ -65,6 +65,20 @@ public struct GatewayConnectDeepLink: Codable, Sendable, Equatable {
             password: nil)
     }
 
+    /// Parse a gateway WebSocket/HTTP URL with optional auth fields from a setup source.
+    public static func fromGatewayURL(
+        _ urlString: String,
+        bootstrapToken: String? = nil,
+        token: String? = nil,
+        password: String? = nil) -> GatewayConnectDeepLink?
+    {
+        self.fromGatewayURLString(
+            urlString,
+            bootstrapToken: bootstrapToken,
+            token: token,
+            password: password)
+    }
+
     /// Parse a gateway setup payload from a device-pair setup code or copied setup text.
     ///
     /// Accepted inputs are:

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewaySetupShortCodeRedeemer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewaySetupShortCodeRedeemer.swift
@@ -1,0 +1,134 @@
+import Foundation
+
+public protocol GatewaySetupShortCodeHTTPClient: Sendable {
+    func data(for request: URLRequest) async throws -> (Data, URLResponse)
+}
+
+extension URLSession: GatewaySetupShortCodeHTTPClient {}
+
+public enum GatewaySetupShortCode {
+    private static let alphabet = Set("ABCDEFGHJKLMNPQRSTUVWXYZ23456789")
+    private static let codeLength = 8
+
+    public static func normalize(_ value: String) -> String? {
+        let normalized = value
+            .uppercased()
+            .replacingOccurrences(of: #"\s+"#, with: "", options: .regularExpression)
+            .replacingOccurrences(of: "-", with: "")
+        guard normalized.count == self.codeLength else { return nil }
+        guard normalized.allSatisfy({ self.alphabet.contains($0) }) else { return nil }
+        return normalized
+    }
+
+    public static func looksLikeShortCode(_ value: String) -> Bool {
+        self.normalize(value) != nil
+    }
+}
+
+public struct GatewaySetupShortCodeRedeemer: Sendable {
+    public enum RedeemError: Error, Equatable, LocalizedError {
+        case invalidCode
+        case invalidGateway
+        case invalidResponse
+        case invalidOrExpired
+        case rejected(statusCode: Int)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidCode:
+                "Setup short code is not valid."
+            case .invalidGateway:
+                "Choose a reachable Gateway before using a setup short code."
+            case .invalidResponse:
+                "Gateway returned an invalid setup response."
+            case .invalidOrExpired:
+                "Setup short code is invalid or expired."
+            case let .rejected(statusCode):
+                "Gateway rejected the setup short code (HTTP \(statusCode))."
+            }
+        }
+    }
+
+    private struct RedeemRequest: Encodable {
+        let code: String
+    }
+
+    private struct RedeemResponse: Decodable {
+        let ok: Bool
+        let payload: SetupPayload?
+    }
+
+    private struct SetupPayload: Decodable {
+        let url: String
+        let bootstrapToken: String
+        let token: String?
+        let password: String?
+    }
+
+    public let client: GatewaySetupShortCodeHTTPClient
+
+    public init(client: GatewaySetupShortCodeHTTPClient = URLSession.shared) {
+        self.client = client
+    }
+
+    public func redeem(
+        _ rawCode: String,
+        through gateway: GatewayConnectDeepLink) async throws -> GatewayConnectDeepLink
+    {
+        guard let code = GatewaySetupShortCode.normalize(rawCode) else {
+            throw RedeemError.invalidCode
+        }
+        guard let url = Self.redemptionURL(for: gateway) else {
+            throw RedeemError.invalidGateway
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "content-type")
+        request.httpBody = try JSONEncoder().encode(RedeemRequest(code: code))
+
+        let (data, response) = try await self.client.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw RedeemError.invalidResponse
+        }
+        if http.statusCode == 404 || http.statusCode == 400 {
+            throw RedeemError.invalidOrExpired
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            throw RedeemError.rejected(statusCode: http.statusCode)
+        }
+        let decoded = try JSONDecoder().decode(RedeemResponse.self, from: data)
+        guard decoded.ok, let payload = decoded.payload else {
+            throw RedeemError.invalidResponse
+        }
+        guard let link = GatewayConnectDeepLink.fromGatewayURL(
+            payload.url,
+            bootstrapToken: payload.bootstrapToken,
+            token: payload.token,
+            password: payload.password)
+        else {
+            throw RedeemError.invalidResponse
+        }
+        return link
+    }
+
+    public static func redemptionURL(for gateway: GatewayConnectDeepLink) -> URL? {
+        guard let websocketURL = gateway.websocketURL,
+              GatewayConnectDeepLink.fromGatewayURL(websocketURL.absoluteString) != nil,
+              var components = URLComponents(url: websocketURL, resolvingAgainstBaseURL: false)
+        else {
+            return nil
+        }
+        switch components.scheme?.lowercased() {
+        case "ws":
+            components.scheme = "http"
+        case "wss":
+            components.scheme = "https"
+        default:
+            return nil
+        }
+        components.path = "/api/v1/pairing/setup-code/redeem"
+        components.query = nil
+        components.fragment = nil
+        return components.url
+    }
+}

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewaySetupShortCodeRedeemerTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewaySetupShortCodeRedeemerTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+import OpenClawKit
+import Testing
+
+private struct MockSetupCodeHTTPClient: GatewaySetupShortCodeHTTPClient {
+    let handler: @Sendable (URLRequest) async throws -> (Data, URLResponse)
+
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        try await self.handler(request)
+    }
+}
+
+@Suite struct GatewaySetupShortCodeRedeemerTests {
+    @Test func normalizesGroupedShortCodes() {
+        #expect(GatewaySetupShortCode.normalize(" abcd-2345 ") == "ABCD2345")
+        #expect(GatewaySetupShortCode.normalize("ABCI2345") == nil)
+    }
+
+    @Test func redemptionURLUsesHttpPeerOfWebSocketGateway() {
+        let gateway = GatewayConnectDeepLink(
+            host: "openclaw.local",
+            port: 18789,
+            tls: false,
+            bootstrapToken: nil,
+            token: nil,
+            password: nil)
+
+        #expect(
+            GatewaySetupShortCodeRedeemer.redemptionURL(for: gateway)?.absoluteString ==
+                "http://openclaw.local:18789/api/v1/pairing/setup-code/redeem")
+    }
+
+    @Test func redeemPostsCodeAndReturnsSetupPayloadLink() async throws {
+        let gateway = GatewayConnectDeepLink(
+            host: "gateway.example.com",
+            port: 443,
+            tls: true,
+            bootstrapToken: nil,
+            token: nil,
+            password: nil)
+        let client = MockSetupCodeHTTPClient { request in
+            #expect(request.url?.absoluteString == "https://gateway.example.com:443/api/v1/pairing/setup-code/redeem")
+            #expect(request.httpMethod == "POST")
+            #expect(request.value(forHTTPHeaderField: "content-type") == "application/json")
+            #expect(String(data: request.httpBody ?? Data(), encoding: .utf8) == #"{"code":"ABCD2345"}"#)
+            let data = Data(
+                #"{"ok":true,"payload":{"url":"wss://gateway.example.com","bootstrapToken":"boot-123"}}"#.utf8)
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil)!
+            return (data, response)
+        }
+
+        let link = try await GatewaySetupShortCodeRedeemer(client: client).redeem("abcd-2345", through: gateway)
+
+        #expect(link == GatewayConnectDeepLink(
+            host: "gateway.example.com",
+            port: 443,
+            tls: true,
+            bootstrapToken: "boot-123",
+            token: nil,
+            password: nil))
+    }
+
+    @Test func redeemMapsInvalidOrExpiredResponses() async {
+        let gateway = GatewayConnectDeepLink(
+            host: "openclaw.local",
+            port: 18789,
+            tls: false,
+            bootstrapToken: nil,
+            token: nil,
+            password: nil)
+        let client = MockSetupCodeHTTPClient { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 404,
+                httpVersion: nil,
+                headerFields: nil)!
+            return (Data(#"{"ok":false}"#.utf8), response)
+        }
+
+        await #expect(throws: GatewaySetupShortCodeRedeemer.RedeemError.invalidOrExpired) {
+            _ = try await GatewaySetupShortCodeRedeemer(client: client).redeem("ABCD2345", through: gateway)
+        }
+    }
+}

--- a/docs/channels/pairing.md
+++ b/docs/channels/pairing.md
@@ -113,8 +113,12 @@ If you use the `device-pair` plugin, you can do first-time device pairing entire
 1. In Telegram, message your bot: `/pair`
 2. The bot replies with two messages: an instruction message and a separate **setup code** message (easy to copy/paste in Telegram).
 3. On your phone, open the OpenClaw iOS app → Settings → Gateway.
-4. Scan the QR code or paste the setup code and connect.
-5. Back in Telegram: `/pair pending` (review request IDs, role, and scopes), then approve.
+4. Scan the QR code or paste the setup code and connect. For the built-in
+   setup-code mobile baseline, the Gateway silently approves the fresh mobile
+   device and its node pairing during the bootstrap handshake.
+5. Back in Telegram: `/pair pending` only if the app reports a pending repair or
+   upgrade. Review request IDs, role, scopes, and capability changes before
+   approving.
 
 The setup code is a base64-encoded JSON payload that contains:
 
@@ -127,13 +131,17 @@ That bootstrap token carries the built-in pairing bootstrap profile:
   `node` plus a bounded `operator` handoff
 - the handed-off `node` token stays `scopes: []`
 - the handed-off `operator` token is limited to `operator.approvals`,
-  `operator.read`, and `operator.write`
+  `operator.read`, `operator.talk.secrets`, and `operator.write`
 - `operator.admin` and `operator.pairing` are not granted by QR/setup-code
   bootstrap; they require a separate approved operator pairing or token flow
 - later token rotation/revocation remains bounded by both the device's approved
   role contract and the caller session's operator scopes
 
-Treat the setup code like a password while it is valid.
+Treat the setup code like a password while it is valid. `openclaw qr` also
+prints an 8-character setup short code. The short code is a 5-minute, single-use
+pointer to the same setup-code payload on that Gateway. A QR/setup code carries
+the Gateway URL directly; a bare short code still requires the app to know which
+Gateway host to redeem against.
 
 For Tailscale, public, or other remote mobile pairing, use Tailscale Serve/Funnel
 or another `wss://` Gateway URL. Plaintext `ws://` setup codes are accepted only
@@ -141,12 +149,14 @@ for loopback, private LAN addresses, `.local` Bonjour hosts, and the Android
 emulator host. Tailnet CGNAT addresses, `.ts.net` names, and public hosts still
 fail closed before QR/setup-code issuance.
 
-### Approve a node device
+### Approve a node device or upgrade
 
 ```bash
 openclaw devices list
 openclaw devices approve <requestId>
 openclaw devices reject <requestId>
+openclaw nodes pending
+openclaw nodes approve <requestId>
 ```
 
 When an explicit approval is denied because the approving paired-device session

--- a/docs/cli/qr.md
+++ b/docs/cli/qr.md
@@ -29,14 +29,17 @@ openclaw qr --url wss://gateway.example/ws
 - `--password <password>`: override which gateway password the bootstrap flow authenticates against
 - `--setup-code-only`: print only setup code
 - `--no-ascii`: skip ASCII QR rendering
-- `--json`: emit JSON (`setupCode`, `gatewayUrl`, `auth`, `urlSource`)
+- `--json`: emit JSON (`setupCode`, `shortCode`, `shortCodeExpiresAtMs`, `gatewayUrl`, `auth`, `urlSource`)
 
 ## Notes
 
 - `--token` and `--password` are mutually exclusive.
 - The setup code itself now carries an opaque short-lived `bootstrapToken`, not the shared gateway token/password.
+- Normal QR/setup-code mobile onboarding is one step: scan the QR or paste the setup code, then the app connects with bootstrap auth and the Gateway silently approves the fresh baseline mobile device plus its node pairing.
+- `openclaw qr` also prints an 8-character setup short code. The short code is a 5-minute, single-use pointer to the same setup-code payload on that Gateway. A bare short code still needs the app to know which Gateway host to redeem against; the QR/setup code carries the Gateway URL directly.
 - Built-in setup-code bootstrap returns a primary `node` token with `scopes: []` plus a bounded `operator` handoff token for trusted mobile onboarding.
 - The handed-off operator token is limited to `operator.approvals`, `operator.read`, `operator.talk.secrets`, and `operator.write`; `operator.admin` and `operator.pairing` require a separate approved operator pairing or token flow.
+- Auto-approval is limited to the fresh setup-code mobile baseline. Later role, scope, metadata, or node capability upgrades still create pending requests that require explicit approval.
 - Mobile pairing fails closed for Tailscale/public `ws://` gateway URLs. Private LAN addresses and `.local` Bonjour hosts remain supported over `ws://`, but Tailscale/public mobile routes should use Tailscale Serve/Funnel or a `wss://` gateway URL.
 - With `--remote`, OpenClaw requires either `gateway.remote.url` or
   `gateway.tailscale.mode=serve|funnel`.
@@ -46,9 +49,10 @@ openclaw qr --url wss://gateway.example/ws
   - `gateway.auth.password` resolves when password auth can win (explicit `gateway.auth.mode="password"` or inferred mode with no winning token from auth/env).
 - If both `gateway.auth.token` and `gateway.auth.password` are configured (including SecretRefs) and `gateway.auth.mode` is unset, setup-code resolution fails until mode is set explicitly.
 - Gateway version skew note: this command path requires a gateway that supports `secrets.resolve`; older gateways return an unknown-method error.
-- After scanning, approve device pairing with:
+- If onboarding reports a pending repair or upgrade instead of connecting, review it with:
   - `openclaw devices list`
-  - `openclaw devices approve <requestId>`
+  - `openclaw nodes pending`
+  - `openclaw devices approve <requestId>` or `openclaw nodes approve <requestId>`
 
 ## Related
 

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -177,6 +177,40 @@ a separate approved operator pairing or token flow. Clients should persist
 when the connect used bootstrap auth on trusted transport such as `wss://` or
 loopback/local pairing.
 
+For current native onboarding, that same baseline setup-code bootstrap can also
+silently approve the fresh mobile device and its first node pairing. This is
+limited to the built-in setup profile and mobile client metadata. Later role,
+scope, device metadata, or node capability changes still create pending pairing
+requests for explicit review.
+
+### Setup Short-Code Redeem
+
+`POST /api/v1/pairing/setup-code/redeem` redeems the 8-character setup short
+code printed by `openclaw qr` into the canonical setup-code payload:
+
+```json
+{ "code": "ABCD2345" }
+```
+
+Success:
+
+```json
+{
+  "ok": true,
+  "payload": {
+    "url": "wss://gateway.example.com",
+    "bootstrapToken": "…"
+  },
+  "expiresAtMs": 1737264300000
+}
+```
+
+The endpoint is intentionally pre-auth so a fresh mobile app can redeem a code.
+The short code is single-use, expires after 5 minutes, is rate-limited per
+client IP, and points only to the same setup-code payload that the QR/setup-code
+path would have carried. It does not expose the long-lived shared Gateway token
+or password by default.
+
 ### Node example
 
 ```json

--- a/src/cli/qr-cli.test.ts
+++ b/src/cli/qr-cli.test.ts
@@ -12,6 +12,13 @@ const mocks = vi.hoisted(() => ({
     diagnostics: [] as string[],
   })),
   renderTerminal: vi.fn(async () => "ASCII-QR"),
+  registerShortCode: vi.fn(() => ({
+    ok: true as const,
+    code: "ABCD2345",
+    expiresAtMs: 456,
+    authLabel: "token" as const,
+    urlSource: "test",
+  })),
 }));
 const { defaultRuntime: runtime, resetRuntimeCapture } = createCliRuntimeCapture();
 const runtimeLog = runtime.log;
@@ -32,6 +39,10 @@ vi.mock("../process/exec.js", () => ({ runCommandWithTimeout: mocks.runCommandWi
 vi.mock("../media/qr-terminal.ts", () => ({
   renderQrTerminal: mocks.renderTerminal,
 }));
+vi.mock("../pairing/setup-short-code.js", () => ({
+  formatPairingSetupShortCode: (code: string) => `${code.slice(0, 4)}-${code.slice(4)}`,
+  registerPairingSetupShortCode: mocks.registerShortCode,
+}));
 vi.mock("./command-secret-gateway.js", () => ({
   resolveCommandSecretRefsViaGateway: mocks.resolveCommandSecretRefsViaGateway,
 }));
@@ -45,6 +56,7 @@ const loadConfig = mocks.loadConfig;
 const runCommandWithTimeout = mocks.runCommandWithTimeout;
 const resolveCommandSecretRefsViaGateway = mocks.resolveCommandSecretRefsViaGateway;
 const renderTerminal = mocks.renderTerminal;
+const registerShortCode = mocks.registerShortCode;
 
 const { registerQrCli } = await import("./qr-cli.js");
 
@@ -140,6 +152,8 @@ describe("registerQrCli", () => {
     const raw = calls[calls.length - 1]?.[0];
     return JSON.parse(typeof raw === "string" ? raw : "{}") as {
       setupCode?: string;
+      shortCode?: string;
+      shortCodeExpiresAtMs?: number;
       gatewayUrl?: string;
       auth?: string;
       urlSource?: string;
@@ -197,6 +211,7 @@ describe("registerQrCli", () => {
     });
     expect(runtime.log).toHaveBeenCalledWith(expected);
     expect(renderTerminal).not.toHaveBeenCalled();
+    expect(registerShortCode).not.toHaveBeenCalled();
     expect(resolveCommandSecretRefsViaGateway).not.toHaveBeenCalled();
   });
 
@@ -215,8 +230,18 @@ describe("registerQrCli", () => {
     const output = runtimeLog.mock.calls.map((call) => readRuntimeCallText(call)).join("\n");
     expect(output).toContain("Pairing QR");
     expect(output).toContain("ASCII-QR");
+    expect(output).toContain("Short code:");
+    expect(output).toContain("ABCD-2345");
     expect(output).toContain("Gateway:");
     expect(output).toContain("openclaw devices approve <requestId>");
+    expect(registerShortCode).toHaveBeenCalledWith({
+      payload: {
+        url: "ws://127.0.0.1:18789",
+        bootstrapToken: "bootstrap-123",
+      },
+      authLabel: "token",
+      urlSource: "gateway.bind=custom",
+    });
   });
 
   it("fails fast for insecure remote mobile pairing setup urls", async () => {
@@ -482,6 +507,8 @@ describe("registerQrCli", () => {
 
     const payload = parseLastLoggedQrJson();
     expect(payload.gatewayUrl).toBe("wss://remote.example.com:444");
+    expect(payload.shortCode).toBe("ABCD2345");
+    expect(payload.shortCodeExpiresAtMs).toBe(456);
     expect(payload.auth).toBe("token");
     expect(payload.urlSource).toBe("gateway.remote.url");
     expect(runCommandWithTimeout).not.toHaveBeenCalled();

--- a/src/cli/qr-cli.ts
+++ b/src/cli/qr-cli.ts
@@ -9,6 +9,10 @@ import { trimToUndefined } from "../gateway/credentials.js";
 import { resolveRequiredConfiguredSecretRefInputString } from "../gateway/resolve-configured-secret-input-string.js";
 import { renderQrTerminal } from "../media/qr-terminal.ts";
 import { resolvePairingSetupFromConfig, encodePairingSetupCode } from "../pairing/setup-code.js";
+import {
+  formatPairingSetupShortCode,
+  registerPairingSetupShortCode,
+} from "../pairing/setup-short-code.js";
 import { runCommandWithTimeout } from "../process/exec.js";
 import { defaultRuntime } from "../runtime.js";
 import { resolveCommandSecretRefsViaGateway } from "./command-secret-gateway.js";
@@ -216,9 +220,17 @@ export function registerQrCli(program: Command) {
           return;
         }
 
+        const shortCode = registerPairingSetupShortCode({
+          payload: resolved.payload,
+          authLabel: resolved.authLabel,
+          urlSource: resolved.urlSource,
+        });
+
         if (opts.json) {
           defaultRuntime.writeJson({
             setupCode,
+            shortCode: shortCode.ok ? shortCode.code : undefined,
+            shortCodeExpiresAtMs: shortCode.ok ? shortCode.expiresAtMs : undefined,
             gatewayUrl: resolved.payload.url,
             auth: resolved.authLabel,
             urlSource: resolved.urlSource,
@@ -238,6 +250,7 @@ export function registerQrCli(program: Command) {
         }
 
         lines.push(
+          `${theme.muted("Short code:")} ${shortCode.ok ? formatPairingSetupShortCode(shortCode.code) : "unavailable"}`,
           `${theme.muted("Setup code:")} ${setupCode}`,
           `${theme.muted("Gateway:")} ${resolved.payload.url}`,
           `${theme.muted("Auth:")} ${resolved.authLabel}`,

--- a/src/gateway/auth-rate-limit.ts
+++ b/src/gateway/auth-rate-limit.ts
@@ -55,6 +55,7 @@ export const AUTH_RATE_LIMIT_SCOPE_NODE_REAPPROVAL = "node-reapproval";
 // device signature can queue the bootstrap-pairing flow behind their
 // requests, blocking legitimate node onboarding during the attack.
 export const AUTH_RATE_LIMIT_SCOPE_BOOTSTRAP_TOKEN = "bootstrap-token";
+export const AUTH_RATE_LIMIT_SCOPE_PAIRING_SETUP_SHORT_CODE = "pairing-setup-short-code";
 export const AUTH_RATE_LIMIT_SCOPE_HOOK_AUTH = "hook-auth";
 const BROWSER_ORIGIN_RATE_LIMIT_KEY_PREFIX = "browser-origin:";
 const IDENTITY_RATE_LIMIT_KEY_PREFIX = "identity:";

--- a/src/gateway/hooks-test-helpers.ts
+++ b/src/gateway/hooks-test-helpers.ts
@@ -1,5 +1,6 @@
 // Gateway hook test fixtures.
 // Builds resolved hook config and IncomingMessage-like requests for tests.
+import { EventEmitter } from "node:events";
 import type { IncomingMessage } from "node:http";
 import type { HooksConfigResolved } from "./hooks.js";
 
@@ -31,6 +32,7 @@ export function createGatewayRequest(params: {
   remoteAddress?: string;
   host?: string;
   headers?: Record<string, string>;
+  body?: string;
 }): IncomingMessage {
   const headers: Record<string, string> = {
     host: params.host ?? "localhost:18789",
@@ -39,10 +41,44 @@ export function createGatewayRequest(params: {
   if (params.authorization) {
     headers.authorization = params.authorization;
   }
-  return {
+  if (params.body !== undefined) {
+    headers["content-length"] ??= String(Buffer.byteLength(params.body, "utf8"));
+    headers["content-type"] ??= "application/json";
+  }
+  const body = params.body;
+  let bodyScheduled = false;
+  const emitter = new EventEmitter();
+  const request = Object.assign(emitter, {
     method: params.method ?? "GET",
     url: params.path,
     headers,
     socket: { remoteAddress: params.remoteAddress ?? "127.0.0.1" },
-  } as IncomingMessage;
+    destroyed: false,
+  }) as IncomingMessage & { destroyed: boolean };
+  request.destroy = () => {
+    request.destroyed = true;
+    emitter.emit("close");
+    return request;
+  };
+  if (body !== undefined) {
+    const scheduleBody = () => {
+      if (bodyScheduled) {
+        return;
+      }
+      bodyScheduled = true;
+      setImmediate(() => {
+        if (request.destroyed) {
+          return;
+        }
+        request.emit("data", Buffer.from(body, "utf8"));
+        request.emit("end");
+      });
+    };
+    request.on("newListener", (eventName) => {
+      if (eventName === "data" || eventName === "end") {
+        scheduleBody();
+      }
+    });
+  }
+  return request;
 }

--- a/src/gateway/pairing-setup-short-code-http.ts
+++ b/src/gateway/pairing-setup-short-code-http.ts
@@ -1,0 +1,90 @@
+// Redeems setup short codes into the canonical mobile setup-code payload.
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import {
+  normalizePairingSetupShortCodeInput,
+  redeemPairingSetupShortCode,
+} from "../pairing/setup-short-code.js";
+import {
+  AUTH_RATE_LIMIT_SCOPE_PAIRING_SETUP_SHORT_CODE,
+  type AuthRateLimiter,
+} from "./auth-rate-limit.js";
+import {
+  readJsonBodyOrError,
+  sendInvalidRequest,
+  sendJson,
+  sendMethodNotAllowed,
+  sendRateLimited,
+} from "./http-common.js";
+import { resolveRequestClientIp } from "./net.js";
+
+const PAIRING_SETUP_SHORT_CODE_REDEEM_PATH = "/api/v1/pairing/setup-code/redeem";
+const PAIRING_SETUP_SHORT_CODE_REDEEM_MAX_BODY_BYTES = 1024;
+
+export function isPairingSetupShortCodeRedeemPath(pathname: string): boolean {
+  return pathname === PAIRING_SETUP_SHORT_CODE_REDEEM_PATH;
+}
+
+function resolveRequestCode(body: unknown): string | undefined {
+  if (!isRecord(body)) {
+    return undefined;
+  }
+  return normalizePairingSetupShortCodeInput(body.code);
+}
+
+export async function handlePairingSetupShortCodeRedeemHttpRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  opts: {
+    trustedProxies: string[];
+    allowRealIpFallback: boolean;
+    rateLimiter?: AuthRateLimiter;
+  },
+): Promise<boolean> {
+  const method = (req.method ?? "GET").toUpperCase();
+  if (method !== "POST") {
+    sendMethodNotAllowed(res);
+    return true;
+  }
+
+  const clientIp = resolveRequestClientIp(req, opts.trustedProxies, opts.allowRealIpFallback);
+  const limit = opts.rateLimiter?.check(clientIp, AUTH_RATE_LIMIT_SCOPE_PAIRING_SETUP_SHORT_CODE);
+  if (limit && !limit.allowed) {
+    sendRateLimited(res, limit.retryAfterMs);
+    return true;
+  }
+
+  const body = await readJsonBodyOrError(req, res, PAIRING_SETUP_SHORT_CODE_REDEEM_MAX_BODY_BYTES);
+  if (body === undefined) {
+    opts.rateLimiter?.recordFailure(clientIp, AUTH_RATE_LIMIT_SCOPE_PAIRING_SETUP_SHORT_CODE);
+    return true;
+  }
+
+  const code = resolveRequestCode(body);
+  if (!code) {
+    opts.rateLimiter?.recordFailure(clientIp, AUTH_RATE_LIMIT_SCOPE_PAIRING_SETUP_SHORT_CODE);
+    sendInvalidRequest(res, "Invalid or expired setup code.");
+    return true;
+  }
+
+  const redeemed = redeemPairingSetupShortCode(code);
+  if (!redeemed.ok) {
+    opts.rateLimiter?.recordFailure(clientIp, AUTH_RATE_LIMIT_SCOPE_PAIRING_SETUP_SHORT_CODE);
+    sendJson(res, 404, {
+      ok: false,
+      error: {
+        type: "invalid_or_expired_setup_code",
+        message: "Invalid or expired setup code.",
+      },
+    });
+    return true;
+  }
+
+  opts.rateLimiter?.reset(clientIp, AUTH_RATE_LIMIT_SCOPE_PAIRING_SETUP_SHORT_CODE);
+  sendJson(res, 200, {
+    ok: true,
+    payload: redeemed.payload,
+    expiresAtMs: redeemed.expiresAtMs,
+  });
+  return true;
+}

--- a/src/gateway/server-http.probe.test.ts
+++ b/src/gateway/server-http.probe.test.ts
@@ -1,6 +1,13 @@
 // Server HTTP probe tests cover readiness, health, disabled compat routes, and
 // auth handling through the in-memory HTTP harness.
 import { describe, expect, it, vi } from "vitest";
+import { issuePairingSetupShortCode } from "../pairing/setup-short-code.js";
+import {
+  clearPluginStateStoreForTests,
+  resetPluginStateStoreForTests,
+} from "../plugin-state/plugin-state-store.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { createAuthRateLimiter } from "./auth-rate-limit.js";
 import {
   AUTH_TOKEN,
   AUTH_NONE,
@@ -40,6 +47,117 @@ describe("gateway OpenAI-compatible disabled HTTP routes", () => {
         }
       },
     });
+  });
+});
+
+describe("gateway pairing setup short-code redeem endpoint", () => {
+  it("redeems a valid setup short code once without gateway auth", async () => {
+    await withOpenClawTestState({ label: "gateway-setup-short-code-redeem" }, async () => {
+      clearPluginStateStoreForTests();
+      const issued = await issuePairingSetupShortCode(
+        {
+          gateway: {
+            bind: "custom",
+            customBindHost: "127.0.0.1",
+            port: 19001,
+            auth: { mode: "token", token: "tok_123" },
+          },
+        },
+        { codeGenerator: () => "ABCD2345" },
+      );
+      expect(issued.ok).toBe(true);
+
+      await withGatewayServer({
+        prefix: "pairing-setup-short-code-redeem",
+        resolvedAuth: AUTH_TOKEN,
+        run: async (server) => {
+          const first = await sendGatewayRequest(server, {
+            path: "/api/v1/pairing/setup-code/redeem",
+            method: "POST",
+            body: JSON.stringify({ code: "abcd-2345" }),
+            remoteAddress: "10.0.0.8",
+            host: "gateway.test",
+          });
+
+          expect(first.res.statusCode).toBe(200);
+          expect(JSON.parse(first.getBody())).toEqual({
+            ok: true,
+            payload: {
+              url: "ws://127.0.0.1:19001",
+              bootstrapToken: expect.any(String),
+            },
+            expiresAtMs: expect.any(Number),
+          });
+
+          const replay = await sendGatewayRequest(server, {
+            path: "/api/v1/pairing/setup-code/redeem",
+            method: "POST",
+            body: JSON.stringify({ code: "ABCD2345" }),
+            remoteAddress: "10.0.0.8",
+            host: "gateway.test",
+          });
+
+          expect(replay.res.statusCode).toBe(404);
+          expect(JSON.parse(replay.getBody())).toMatchObject({
+            ok: false,
+            error: { type: "invalid_or_expired_setup_code" },
+          });
+        },
+      });
+    });
+    resetPluginStateStoreForTests();
+  });
+
+  it("rejects non-POST requests before reading a code", async () => {
+    await withGatewayServer({
+      prefix: "pairing-setup-short-code-method",
+      resolvedAuth: AUTH_NONE,
+      run: async (server) => {
+        const response = await sendGatewayRequest(server, {
+          path: "/api/v1/pairing/setup-code/redeem",
+          method: "GET",
+        });
+
+        expect(response.res.statusCode).toBe(405);
+        expect(response.getBody()).toBe("Method Not Allowed");
+      },
+    });
+  });
+
+  it("rate-limits invalid setup short-code redemption attempts", async () => {
+    const rateLimiter = createAuthRateLimiter({
+      maxAttempts: 1,
+      exemptLoopback: false,
+      pruneIntervalMs: 0,
+    });
+    try {
+      await withGatewayServer({
+        prefix: "pairing-setup-short-code-rate-limit",
+        resolvedAuth: AUTH_NONE,
+        overrides: { rateLimiter },
+        run: async (server) => {
+          const first = await sendGatewayRequest(server, {
+            path: "/api/v1/pairing/setup-code/redeem",
+            method: "POST",
+            body: JSON.stringify({ code: "BAD-CODE" }),
+            remoteAddress: "10.0.0.9",
+            host: "gateway.test",
+          });
+          expect(first.res.statusCode).toBe(400);
+
+          const second = await sendGatewayRequest(server, {
+            path: "/api/v1/pairing/setup-code/redeem",
+            method: "POST",
+            body: JSON.stringify({ code: "BAD-CODE" }),
+            remoteAddress: "10.0.0.9",
+            host: "gateway.test",
+          });
+          expect(second.res.statusCode).toBe(429);
+        },
+      });
+    } finally {
+      rateLimiter.dispose();
+    }
   });
 });
 

--- a/src/gateway/server-http.test-harness.ts
+++ b/src/gateway/server-http.test-harness.ts
@@ -37,6 +37,7 @@ export function createRequest(params: {
   remoteAddress?: string;
   host?: string;
   headers?: Record<string, string>;
+  body?: string;
 }): IncomingMessage {
   return createGatewayRequest({
     path: params.path,
@@ -45,6 +46,7 @@ export function createRequest(params: {
     remoteAddress: params.remoteAddress,
     host: params.host,
     headers: params.headers,
+    body: params.body,
   });
 }
 
@@ -184,6 +186,7 @@ export async function sendRequest(
     method?: string;
     remoteAddress?: string;
     host?: string;
+    body?: string;
   },
 ): Promise<ReturnType<typeof createResponse>> {
   const response = createResponse();

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -87,6 +87,9 @@ let pluginNodeCapabilityAuthModulePromise:
   | Promise<typeof import("./server/plugin-node-capability-auth.js")>
   | undefined;
 let httpAuthUtilsModulePromise: Promise<typeof import("./http-auth-utils.js")> | undefined;
+let pairingSetupShortCodeHttpModulePromise:
+  | Promise<typeof import("./pairing-setup-short-code-http.js")>
+  | undefined;
 let pluginRouteRuntimeScopesModulePromise:
   | Promise<typeof import("./server/plugin-route-runtime-scopes.js")>
   | undefined;
@@ -149,6 +152,11 @@ function getPluginNodeCapabilityAuthModule() {
 function getHttpAuthUtilsModule() {
   httpAuthUtilsModulePromise ??= import("./http-auth-utils.js");
   return httpAuthUtilsModulePromise;
+}
+
+function getPairingSetupShortCodeHttpModule() {
+  pairingSetupShortCodeHttpModulePromise ??= import("./pairing-setup-short-code-http.js");
+  return pairingSetupShortCodeHttpModulePromise;
 }
 
 function getPluginRouteRuntimeScopesModule() {
@@ -231,6 +239,10 @@ function isSessionKillPath(pathname: string): boolean {
 
 function isSessionHistoryPath(pathname: string): boolean {
   return /^\/sessions\/[^/]+\/history$/.test(pathname);
+}
+
+function isPairingSetupShortCodeRedeemPath(pathname: string): boolean {
+  return pathname === "/api/v1/pairing/setup-code/redeem";
 }
 
 function shouldEnforceDefaultPluginGatewayAuth(pathContext: PluginRoutePathContext): boolean {
@@ -659,6 +671,19 @@ export function createGatewayHttpServer(opts: {
             (await getSessionHistoryHttpModule()).handleSessionHistoryHttpRequest(req, res, {
               auth: resolvedAuthValue,
               getResolvedAuth,
+              trustedProxies,
+              allowRealIpFallback,
+              rateLimiter,
+            }),
+        });
+      }
+      if (isPairingSetupShortCodeRedeemPath(scopedRequestPath)) {
+        requestStages.push({
+          name: "pairing-setup-short-code-redeem",
+          run: async () =>
+            (
+              await getPairingSetupShortCodeHttpModule()
+            ).handlePairingSetupShortCodeRedeemHttpRequest(req, res, {
               trustedProxies,
               allowRealIpFallback,
               rateLimiter,

--- a/src/gateway/server.auth.control-ui.suite.ts
+++ b/src/gateway/server.auth.control-ui.suite.ts
@@ -110,6 +110,9 @@ export function registerControlUiAndPairingSuite(): void {
       mode: "node";
       deviceFamily: string;
     };
+    caps?: string[];
+    commands?: string[];
+    permissions?: Record<string, boolean>;
   }) => {
     const { issueDeviceBootstrapToken } = await import("../infra/device-bootstrap.js");
     const { server, port, prevToken } = await startControlUiServer("secret");
@@ -122,6 +125,9 @@ export function registerControlUiAndPairingSuite(): void {
         bootstrapToken: issued.token,
         role: "node",
         scopes: [],
+        caps: params.caps,
+        commands: params.commands,
+        permissions: params.permissions,
         client: params.client,
         deviceIdentityPath: identityPath,
       });
@@ -144,6 +150,15 @@ export function registerControlUiAndPairingSuite(): void {
     const admin = await rpcReq(ws, "set-heartbeats", { enabled: false });
     expect(admin.ok).toBe(true);
   };
+
+  const IOS_SETUP_NODE_CAPS = ["device", "photos", "talk"];
+  const IOS_SETUP_NODE_COMMANDS = [
+    "device.status",
+    "device.info",
+    "photos.latest",
+    "system.notify",
+    "talk.ptt.once",
+  ];
 
   const connectControlUiWithoutDeviceAndExpectOk = async (params: {
     ws: WebSocket;
@@ -1140,6 +1155,7 @@ export function registerControlUiAndPairingSuite(): void {
     const { publicKeyRawBase64UrlFromPem } = await import("../infra/device-identity.js");
     const { getPairedDevice, listDevicePairing, verifyDeviceToken } =
       await import("../infra/device-pairing.js");
+    const { listNodePairing } = await import("../infra/node-pairing.js");
     const { server, port, prevToken } = await startControlUiServer("secret");
 
     const { identityPath, identity } = await createOperatorIdentityFixture(
@@ -1161,6 +1177,9 @@ export function registerControlUiAndPairingSuite(): void {
         bootstrapToken: issued.token,
         role: "node",
         scopes: [],
+        caps: IOS_SETUP_NODE_CAPS,
+        commands: IOS_SETUP_NODE_COMMANDS,
+        permissions: { photos: true },
         client,
         deviceIdentityPath: identityPath,
       });
@@ -1208,6 +1227,10 @@ export function registerControlUiAndPairingSuite(): void {
         (entry) => entry.deviceId === identity.deviceId,
       );
       expect(pendingForDevice).toEqual([]);
+      const pendingNodeAfterInitial = (await listNodePairing()).pending.filter(
+        (entry) => entry.nodeId === identity.deviceId,
+      );
+      expect(pendingNodeAfterInitial).toEqual([]);
       wsBootstrap.close();
 
       const afterBootstrap = await listDevicePairing();
@@ -1231,6 +1254,12 @@ export function registerControlUiAndPairingSuite(): void {
         "operator.talk.secrets",
         "operator.write",
       ]);
+      const pairedNode = (await listNodePairing()).paired.find(
+        (entry) => entry.nodeId === identity.deviceId,
+      );
+      expect(pairedNode?.caps).toEqual(IOS_SETUP_NODE_CAPS);
+      expect(pairedNode?.commands).toEqual(IOS_SETUP_NODE_COMMANDS);
+      expect(pairedNode?.permissions).toEqual({ photos: true });
 
       const wsReplay = await openWs(port, REMOTE_BOOTSTRAP_HEADERS);
       const replay = await connectReq(wsReplay, {
@@ -1339,9 +1368,13 @@ export function registerControlUiAndPairingSuite(): void {
     "qr setup code auto-approves $name clients when mobile metadata matches",
     async ({ client, identityPrefix }) => {
       const { getPairedDevice, listDevicePairing } = await import("../infra/device-pairing.js");
+      const { listNodePairing } = await import("../infra/node-pairing.js");
       const { identity, initial } = await connectSetupCodeBootstrapNode({
         identityPrefix,
         client,
+        caps: IOS_SETUP_NODE_CAPS,
+        commands: IOS_SETUP_NODE_COMMANDS,
+        permissions: { photos: true },
       });
       expect(initial.ok).toBe(true);
       const approvedPayload = initial.payload as
@@ -1384,6 +1417,12 @@ export function registerControlUiAndPairingSuite(): void {
         "operator.talk.secrets",
         "operator.write",
       ]);
+      const nodePairing = await listNodePairing();
+      expect(nodePairing.pending.filter((entry) => entry.nodeId === identity.deviceId)).toEqual([]);
+      const pairedNode = nodePairing.paired.find((entry) => entry.nodeId === identity.deviceId);
+      expect(pairedNode?.caps).toEqual(IOS_SETUP_NODE_CAPS);
+      expect(pairedNode?.commands).toEqual(IOS_SETUP_NODE_COMMANDS);
+      expect(pairedNode?.permissions).toEqual({ photos: true });
     },
   );
 

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -77,6 +77,7 @@ import {
 } from "../../../infra/diagnostic-trace-context.js";
 import {
   beginNodePairingConnect,
+  approveNodePairing,
   finalizeNodePairingCleanupClaim,
   releaseNodePairingCleanupClaim,
   requestNodePairing,
@@ -1269,6 +1270,7 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
             ? await getDeviceBootstrapTokenProfile({ token: bootstrapTokenCandidate })
             : null;
         let handoffBootstrapProfile: DeviceBootstrapProfile | null = null;
+        let setupCodeMobileDeviceBootstrapApproved = false;
         const trustedProxyAuthOk = isTrustedProxyControlUiOperatorAuth({
           isControlUi,
           role,
@@ -1460,6 +1462,7 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
               if (approved?.status === "approved") {
                 if (allowSetupCodeMobileBootstrapPairing && boundBootstrapProfile) {
                   handoffBootstrapProfile = boundBootstrapProfile;
+                  setupCodeMobileDeviceBootstrapApproved = true;
                 }
                 logGateway.info(
                   `device pairing auto-approved device=${approved.device.deviceId} role=${approved.device.role ?? "unknown"}`,
@@ -1788,6 +1791,42 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
                 });
               },
             });
+            if (
+              setupCodeMobileDeviceBootstrapApproved &&
+              pairedNode === null &&
+              reconciliation.pendingPairing
+            ) {
+              const bootstrapNodeApproval = await approveNodePairing(
+                reconciliation.pendingPairing.request.requestId,
+                {
+                  callerScopes: ["operator.pairing", "operator.write"],
+                },
+              );
+              if (bootstrapNodeApproval && "node" in bootstrapNodeApproval) {
+                const { pendingPairing: _pendingPairing, ...approvedReconciliation } =
+                  reconciliation;
+                reconciliation = {
+                  ...approvedReconciliation,
+                  effectiveCaps: reconciliation.declaredCaps,
+                  effectiveCommands: reconciliation.declaredCommands,
+                  effectivePermissions: reconciliation.declaredPermissions,
+                  shouldClearPendingPairings: true,
+                };
+                buildRequestContext().broadcast(
+                  "node.pair.resolved",
+                  {
+                    requestId: bootstrapNodeApproval.requestId,
+                    nodeId: bootstrapNodeApproval.node.nodeId,
+                    decision: "approved",
+                    ts: Date.now(),
+                  },
+                  { dropIfSlow: true },
+                );
+                logGateway.info(
+                  `node pairing auto-approved via setup-code bootstrap node=${bootstrapNodeApproval.node.nodeId}`,
+                );
+              }
+            }
           } catch (error) {
             await releasePendingNodePairingCleanup();
             if (error instanceof NodePairingRateLimitError) {

--- a/src/pairing/setup-short-code.test.ts
+++ b/src/pairing/setup-short-code.test.ts
@@ -1,0 +1,129 @@
+// Tests setup short-code issue and one-time redemption.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearPluginStateStoreForTests,
+  resetPluginStateStoreForTests,
+} from "../plugin-state/plugin-state-store.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+
+vi.mock("../infra/device-bootstrap.js", () => ({
+  issueDeviceBootstrapToken: vi.fn(async () => ({
+    token: "bootstrap-123",
+    expiresAtMs: 123,
+  })),
+}));
+
+const {
+  formatPairingSetupShortCode,
+  issuePairingSetupShortCode,
+  normalizePairingSetupShortCodeInput,
+  registerPairingSetupShortCode,
+  redeemPairingSetupShortCode,
+} = await import("./setup-short-code.js");
+
+const gatewayConfig = {
+  gateway: {
+    bind: "custom",
+    customBindHost: "127.0.0.1",
+    port: 19001,
+    auth: { mode: "token", token: "tok_123" },
+  },
+} as const;
+
+beforeEach(() => {
+  vi.useRealTimers();
+  clearPluginStateStoreForTests();
+});
+
+describe("pairing setup short code", () => {
+  it("issues a short code that redeems once into the setup payload", async () => {
+    await withOpenClawTestState({ label: "setup-short-code" }, async () => {
+      vi.setSystemTime(new Date("2026-06-30T12:00:00.000Z"));
+      const issued = await issuePairingSetupShortCode(gatewayConfig, {
+        codeGenerator: () => "ABCD2345",
+      });
+
+      expect(issued).toEqual({
+        ok: true,
+        code: "ABCD2345",
+        expiresAtMs: Date.parse("2026-06-30T12:05:00.000Z"),
+        authLabel: "token",
+        urlSource: "gateway.bind=custom",
+      });
+      expect(redeemPairingSetupShortCode("abcd-2345")).toEqual({
+        ok: true,
+        payload: {
+          url: "ws://127.0.0.1:19001",
+          bootstrapToken: "bootstrap-123",
+        },
+        expiresAtMs: Date.parse("2026-06-30T12:05:00.000Z"),
+      });
+      expect(redeemPairingSetupShortCode("ABCD2345")).toEqual({
+        ok: false,
+        reason: "invalid_or_expired",
+      });
+    });
+  });
+
+  it("treats expired short codes as invalid without returning the payload", async () => {
+    await withOpenClawTestState({ label: "setup-short-code-expired" }, async () => {
+      vi.setSystemTime(new Date("2026-06-30T12:00:00.000Z"));
+      await issuePairingSetupShortCode(gatewayConfig, {
+        ttlMs: 1_000,
+        codeGenerator: () => "EFGH2345",
+      });
+
+      vi.setSystemTime(new Date("2026-06-30T12:00:01.001Z"));
+      expect(redeemPairingSetupShortCode("EFGH2345")).toEqual({
+        ok: false,
+        reason: "invalid_or_expired",
+      });
+    });
+  });
+
+  it("normalizes grouped human input and rejects ambiguous characters", () => {
+    expect(normalizePairingSetupShortCodeInput("abcd-2345")).toBe("ABCD2345");
+    expect(normalizePairingSetupShortCodeInput("ABCD 2345")).toBe("ABCD2345");
+    expect(normalizePairingSetupShortCodeInput("ABCD1045")).toBeUndefined();
+    expect(formatPairingSetupShortCode("abcd2345")).toBe("ABCD-2345");
+  });
+
+  it("registers an already-issued setup payload without minting a replacement", async () => {
+    await withOpenClawTestState({ label: "setup-short-code-register" }, async () => {
+      vi.setSystemTime(new Date("2026-06-30T12:00:00.000Z"));
+
+      expect(
+        registerPairingSetupShortCode(
+          {
+            payload: {
+              url: "wss://gateway.example.com",
+              bootstrapToken: "existing-bootstrap",
+            },
+            authLabel: "token",
+            urlSource: "test",
+          },
+          { codeGenerator: () => "JKLM2345" },
+        ),
+      ).toEqual({
+        ok: true,
+        code: "JKLM2345",
+        expiresAtMs: Date.parse("2026-06-30T12:05:00.000Z"),
+        authLabel: "token",
+        urlSource: "test",
+      });
+      expect(redeemPairingSetupShortCode("JKLM-2345")).toEqual({
+        ok: true,
+        payload: {
+          url: "wss://gateway.example.com",
+          bootstrapToken: "existing-bootstrap",
+        },
+        expiresAtMs: Date.parse("2026-06-30T12:05:00.000Z"),
+      });
+    });
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  resetPluginStateStoreForTests();
+});

--- a/src/pairing/setup-short-code.ts
+++ b/src/pairing/setup-short-code.ts
@@ -1,0 +1,217 @@
+// Issues and redeems human-entered setup short codes for mobile onboarding.
+import crypto from "node:crypto";
+import type { OpenClawConfig } from "../config/types.js";
+import { createCorePluginStateSyncKeyedStore } from "../plugin-state/plugin-state-store.js";
+import type { PluginStateSyncKeyedStore } from "../plugin-state/plugin-state-store.types.js";
+import {
+  resolvePairingSetupFromConfig,
+  type PairingSetupPayload,
+  type ResolvePairingSetupOptions,
+} from "./setup-code.js";
+
+const SETUP_SHORT_CODE_LENGTH = 8;
+const SETUP_SHORT_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+const SETUP_SHORT_CODE_MAX_GENERATION_ATTEMPTS = 500;
+const SETUP_SHORT_CODE_TTL_MS = 5 * 60 * 1000;
+const SETUP_SHORT_CODE_MAX_ENTRIES = 200;
+const SETUP_SHORT_CODE_NAMESPACE = "setup-short-codes";
+
+type PairingSetupShortCodeRecord = {
+  payload: PairingSetupPayload;
+  issuedAtMs: number;
+  expiresAtMs: number;
+  authLabel: "token" | "password";
+  urlSource: string;
+};
+
+export type PairingSetupShortCodeIssueResult =
+  | {
+      ok: true;
+      code: string;
+      expiresAtMs: number;
+      authLabel: "token" | "password";
+      urlSource: string;
+    }
+  | {
+      ok: false;
+      error: string;
+    };
+
+export type RegisterPairingSetupShortCodeOptions = {
+  ttlMs?: number;
+  codeGenerator?: () => string;
+  store?: PairingSetupShortCodeStore;
+};
+
+export type PairingSetupShortCodeRedeemResult =
+  | {
+      ok: true;
+      payload: PairingSetupPayload;
+      expiresAtMs: number;
+    }
+  | {
+      ok: false;
+      reason: "invalid_or_expired";
+    };
+
+type PairingSetupShortCodeStore = PluginStateSyncKeyedStore<PairingSetupShortCodeRecord>;
+
+export type IssuePairingSetupShortCodeOptions = ResolvePairingSetupOptions &
+  RegisterPairingSetupShortCodeOptions;
+
+export type RedeemPairingSetupShortCodeOptions = {
+  nowMs?: number;
+  store?: PairingSetupShortCodeStore;
+};
+
+function createSetupShortCodeStore(): PairingSetupShortCodeStore {
+  return createCorePluginStateSyncKeyedStore<PairingSetupShortCodeRecord>({
+    ownerId: "core:pairing",
+    namespace: SETUP_SHORT_CODE_NAMESPACE,
+    maxEntries: SETUP_SHORT_CODE_MAX_ENTRIES,
+    defaultTtlMs: SETUP_SHORT_CODE_TTL_MS,
+  });
+}
+
+export function normalizePairingSetupShortCodeInput(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const normalized = value
+    .toUpperCase()
+    .replace(/[\s-]+/g, "")
+    .trim();
+  if (
+    normalized.length !== SETUP_SHORT_CODE_LENGTH ||
+    ![...normalized].every((char) => SETUP_SHORT_CODE_ALPHABET.includes(char))
+  ) {
+    return undefined;
+  }
+  return normalized;
+}
+
+export function formatPairingSetupShortCode(code: string): string {
+  const normalized = normalizePairingSetupShortCodeInput(code);
+  if (!normalized) {
+    return code;
+  }
+  return `${normalized.slice(0, 4)}-${normalized.slice(4)}`;
+}
+
+function generatePairingSetupShortCode(): string {
+  let out = "";
+  for (let i = 0; i < SETUP_SHORT_CODE_LENGTH; i += 1) {
+    const index = crypto.randomInt(0, SETUP_SHORT_CODE_ALPHABET.length);
+    const char = SETUP_SHORT_CODE_ALPHABET[index];
+    if (!char) {
+      throw new Error("setup short-code alphabet lookup failed");
+    }
+    out += char;
+  }
+  return out;
+}
+
+function resolveTtlMs(value: number | undefined): number {
+  if (
+    typeof value === "number" &&
+    Number.isSafeInteger(value) &&
+    value > 0 &&
+    value <= SETUP_SHORT_CODE_TTL_MS
+  ) {
+    return value;
+  }
+  return SETUP_SHORT_CODE_TTL_MS;
+}
+
+function registerUniqueShortCode(params: {
+  store: PairingSetupShortCodeStore;
+  record: PairingSetupShortCodeRecord;
+  ttlMs: number;
+  codeGenerator: () => string;
+}): string {
+  for (let attempt = 0; attempt < SETUP_SHORT_CODE_MAX_GENERATION_ATTEMPTS; attempt += 1) {
+    const code = normalizePairingSetupShortCodeInput(params.codeGenerator());
+    if (!code) {
+      continue;
+    }
+    if (params.store.registerIfAbsent(code, params.record, { ttlMs: params.ttlMs })) {
+      return code;
+    }
+  }
+  throw new Error(
+    `failed to generate unique setup short code after ${SETUP_SHORT_CODE_MAX_GENERATION_ATTEMPTS} attempts`,
+  );
+}
+
+export async function issuePairingSetupShortCode(
+  cfg: OpenClawConfig,
+  options: IssuePairingSetupShortCodeOptions = {},
+): Promise<PairingSetupShortCodeIssueResult> {
+  const resolved = await resolvePairingSetupFromConfig(cfg, options);
+  if (!resolved.ok) {
+    return resolved;
+  }
+  return registerPairingSetupShortCode(
+    {
+      payload: resolved.payload,
+      authLabel: resolved.authLabel,
+      urlSource: resolved.urlSource,
+    },
+    options,
+  );
+}
+
+export function registerPairingSetupShortCode(
+  setup: {
+    payload: PairingSetupPayload;
+    authLabel: "token" | "password";
+    urlSource: string;
+  },
+  options: RegisterPairingSetupShortCodeOptions = {},
+): PairingSetupShortCodeIssueResult {
+  const nowMs = Date.now();
+  const ttlMs = resolveTtlMs(options.ttlMs);
+  const expiresAtMs = nowMs + ttlMs;
+  const store = options.store ?? createSetupShortCodeStore();
+  const code = registerUniqueShortCode({
+    store,
+    ttlMs,
+    codeGenerator: options.codeGenerator ?? generatePairingSetupShortCode,
+    record: {
+      payload: setup.payload,
+      issuedAtMs: nowMs,
+      expiresAtMs,
+      authLabel: setup.authLabel,
+      urlSource: setup.urlSource,
+    },
+  });
+
+  return {
+    ok: true,
+    code,
+    expiresAtMs,
+    authLabel: setup.authLabel,
+    urlSource: setup.urlSource,
+  };
+}
+
+export function redeemPairingSetupShortCode(
+  rawCode: unknown,
+  options: RedeemPairingSetupShortCodeOptions = {},
+): PairingSetupShortCodeRedeemResult {
+  const code = normalizePairingSetupShortCodeInput(rawCode);
+  if (!code) {
+    return { ok: false, reason: "invalid_or_expired" };
+  }
+  const store = options.store ?? createSetupShortCodeStore();
+  const record = store.consume(code);
+  const nowMs = options.nowMs ?? Date.now();
+  if (!record || record.expiresAtMs <= nowMs) {
+    return { ok: false, reason: "invalid_or_expired" };
+  }
+  return {
+    ok: true,
+    payload: record.payload,
+    expiresAtMs: record.expiresAtMs,
+  };
+}


### PR DESCRIPTION
Closes #98242

## What Problem This Solves

Resolves a problem where fresh mobile users had to perform QR/setup-code entry plus separate device/node approval steps before iOS or Android could land connected to the Gateway.

## Why This Change Was Made

This makes the existing QR/setup-code bootstrap path the one-step mobile onboarding baseline: the setup payload configures the app, the Gateway approves the fresh native mobile device handoff, and the matching fresh node pairing is approved through the same bounded setup-code bootstrap. It also adds an 8-character gateway-local short-code redemption seam for cases where the app already knows which Gateway URL to contact.

The security boundary stays narrow: setup bootstrap keeps the bounded node/operator profile, does not grant `operator.admin` or `operator.pairing`, short codes are TTL-bound and single-use, and insecure public Gateway URLs still fail closed outside loopback/private LAN allowances.

## User Impact

Users can scan a QR code or paste a setup code and land connected without walking through separate pending approvals for the fresh mobile device and node. Operators still get explicit approval boundaries for later role, scope, capability, or pairing upgrades.

## Evidence

- Redacted visual proof animation: https://gist.github.com/Solvely-Colin/0d647e2ffd90500925a062dc043d3764

![Redacted setup-code mobile pairing proof](https://gist.githubusercontent.com/Solvely-Colin/0d647e2ffd90500925a062dc043d3764/raw/setup-code-flow-redacted.svg)

- Physical iPhone + Tailscale QR proof: scanned the QR, app connected, Gateway showed device auto-approval and node auto-approval via setup-code bootstrap, and pending device/node counts were `0` afterward.
- Simulator setup-code proof: clean iPhone 17 simulator install, generated setup code against the running dev Gateway state, pasted setup code, app reached `Connected` / `Gateway Online` for `127.0.0.1:19001`; redacted GIF generated locally from that run.
- `node scripts/run-vitest.mjs src/pairing/setup-short-code.test.ts src/gateway/server-http.probe.test.ts src/cli/qr-cli.test.ts`
- `node scripts/run-vitest.mjs src/gateway/server.auth.control-ui.test.ts --testNamePattern "qr setup code"`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.src.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-src.tsbuildinfo`
- `swift test --filter GatewaySetupShortCodeRedeemerTests` from `apps/shared/OpenClawKit`
- `node scripts/format-docs.mjs --check docs/cli/qr.md docs/channels/pairing.md docs/gateway/protocol.md`
- `node scripts/check-docs-mdx.mjs docs/cli/qr.md docs/channels/pairing.md docs/gateway/protocol.md`
- `node scripts/docs-link-audit.mjs docs/cli/qr.md docs/channels/pairing.md docs/gateway/protocol.md`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local --prompt-file /tmp/openclaw-qr-setup-pr-prep.md` returned `autoreview clean: no accepted/actionable findings reported`.

Notes:
- iOS simulator build/run succeeded through XcodeBuildMCP; existing unrelated SwiftLint/Swift warnings remain in `GatewaySettingsStore.swift`, `NodeAppModel.swift`, `TalkModeManager.swift`, `ChatViewModel.swift`, and `RealtimeTalkRelaySession.swift`.
- Broad Crabbox/Testbox `check:changed` was skipped by request after the local Crabbox binary/toolbox path failed before running the repo check.
