### PR TITLE
fix(doctor): merge legacy flat auth repair into existing SQLite store

### DIFF
--- a/src/commands/doctor-auth-flat-profiles.test.ts
+++ b/src/commands/doctor-auth-flat-profiles.test.ts
@@ -887,6 +887,53 @@ describe("maybeRepairLegacyFlatAuthProfileStores", () => {
     expect(JSON.parse(fs.readFileSync(`${authPath}.legacy-flat.123.bak`, "utf8"))).toEqual(legacy);
   });
 
+  it("preserves existing SQLite auth profiles when migrating a legacy flat store", async () => {
+    const state = await makeTestState();
+    saveAuthProfileStore(
+      {
+        version: 1,
+        profiles: {
+          "anthropic:default": {
+            type: "oauth",
+            provider: "anthropic",
+            access: "sk-access-live",
+            refresh: "sk-refresh-live",
+            expires: 9999999999999,
+          },
+        },
+      },
+      state.agentDir(),
+    );
+    const legacy = { openai: { apiKey: "sk-openai-flat" } };
+    const authPath = await writeLegacyAuthProfilesJson(state, legacy);
+
+    const result = await maybeRepairLegacyFlatAuthProfileStores({
+      cfg: {},
+      prompter: makePrompter(true),
+      now: () => 123,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.changes).toStrictEqual([
+      `Migrated ${authPath} to the SQLite auth profile store (backup: ${authPath}.legacy-flat.123.bak).`,
+    ]);
+    expect(loadPersistedAuthProfileStore(state.agentDir())?.profiles).toEqual({
+      "anthropic:default": {
+        type: "oauth",
+        provider: "anthropic",
+        access: "sk-access-live",
+        refresh: "sk-refresh-live",
+        expires: 9999999999999,
+      },
+      "openai:default": {
+        type: "api_key",
+        provider: "openai",
+        key: "sk-openai-flat",
+      },
+    });
+    expect(fs.existsSync(authPath)).toBe(false);
+  });
+
   it("reports legacy flat stores without rewriting when repair is declined", async () => {
     const state = await makeTestState();
     const legacy = {

--- a/src/commands/doctor-auth-flat-profiles.ts
+++ b/src/commands/doctor-auth-flat-profiles.ts
@@ -1198,8 +1198,29 @@ export async function maybeRepairLegacyFlatAuthProfileStores(params: {
 
   for (const entry of legacyStores) {
     try {
+      const existing = loadPersistedAuthProfileStore(entry.agentDir) ?? {
+        version: AUTH_STORE_VERSION,
+        profiles: {},
+      };
+      const importedProfileIds = new Set(Object.keys(entry.store.profiles));
+      const merged = mergeImportedAuthProfiles({
+        store: { ...existing, version: Math.max(existing.version, entry.store.version) },
+        profiles: entry.store.profiles,
+        existingProfileIds: new Set(Object.keys(existing.profiles)),
+      });
       const backupPath = backupAuthProfileStore(entry.authPath, now);
-      saveAuthProfileStore(entry.store, entry.agentDir, { syncExternalCli: false });
+      saveAuthProfileStore(merged, entry.agentDir, { syncExternalCli: false });
+      const verificationFailure = formatMissingAuthProfileSqliteVerification({
+        expected: merged,
+        importedProfileIds,
+        loaded: loadPersistedAuthProfileStore(entry.agentDir),
+      });
+      if (verificationFailure) {
+        result.warnings.push(
+          `Left auth profile JSON in place for ${shortenHomePath(entry.authPath)} because SQLite verification did not find ${verificationFailure}.`,
+        );
+        continue;
+      }
       fs.unlinkSync(entry.authPath);
       result.changes.push(
         `Migrated ${shortenHomePath(entry.authPath)} to the SQLite auth profile store (backup: ${shortenHomePath(backupPath)}).`,


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where running `openclaw doctor` can silently and permanently destroy stored auth credentials. When an install carries an ancient pre-versioned flat `auth-profiles.json` (a provider to credential map with no `{version, profiles}` wrapper) alongside a populated SQLite auth profile store, the legacy-flat repair rewrites the entire SQLite store with the flat file's profiles only. Any credential that lives in SQLite but not in the flat file, for example an OAuth refresh token from a login performed after the SQLite migration, is wiped. The backup captures only the flat JSON, so the destroyed SQLite credential is unrecoverable and the affected provider must be re-authenticated. This runs on the default `openclaw doctor` path (the auto-fix prompt defaults to yes), so a routine maintenance run is enough to trigger it.

## Why This Change Was Made

`maybeRepairLegacyFlatAuthProfileStores` in `src/commands/doctor-auth-flat-profiles.ts` built its store solely from the flat JSON and then called `saveAuthProfileStore`, which replaces the whole `auth_profile_store` SQLite row instead of merging. This path predates the SQLite auth migration: whole-store overwrite was harmless against a JSON store but became destructive once a populated SQLite store could exist, and `backupAuthProfileStore` only ever copied the flat JSON.

The fix mirrors the sibling SQLite migration (`maybeMigrateAuthProfileJsonStoresToSqlite`): load the existing SQLite store, merge the legacy flat profiles into it so existing credentials win, then verify the imported profiles persisted before removing the flat file. It reuses the in-file helpers `loadPersistedAuthProfileStore`, `mergeImportedAuthProfiles`, and `formatMissingAuthProfileSqliteVerification` rather than adding a second strategy. Behavior is unchanged for the intended case: when SQLite is empty the merge yields exactly the flat profiles. The aws-sdk marker branch in the same function is unaffected; it moves routing metadata into config and never touched the SQLite credential store.

This is distinct from open PR #97881, which edits the same file but only in the credential-coercion helpers (`coerceLegacyFlatCredential` and an import) and addresses field loss in the other migration path; it does not touch `maybeRepairLegacyFlatAuthProfileStores`. The two changes are in different functions and independent, needing at most a trivial rebase if both land.

```ts
// before
const backupPath = backupAuthProfileStore(entry.authPath, now);
saveAuthProfileStore(entry.store, entry.agentDir, { syncExternalCli: false });
fs.unlinkSync(entry.authPath);

// after
const existing = loadPersistedAuthProfileStore(entry.agentDir) ?? {
  version: AUTH_STORE_VERSION,
  profiles: {},
};
const importedProfileIds = new Set(Object.keys(entry.store.profiles));
const merged = mergeImportedAuthProfiles({
  store: { ...existing, version: Math.max(existing.version, entry.store.version) },
  profiles: entry.store.profiles,
  existingProfileIds: new Set(Object.keys(existing.profiles)),
});
const backupPath = backupAuthProfileStore(entry.authPath, now);
saveAuthProfileStore(merged, entry.agentDir, { syncExternalCli: false });
const verificationFailure = formatMissingAuthProfileSqliteVerification({
  expected: merged,
  importedProfileIds,
  loaded: loadPersistedAuthProfileStore(entry.agentDir),
});
if (verificationFailure) {
  result.warnings.push(/* leave the flat JSON in place */);
  continue;
}
fs.unlinkSync(entry.authPath);
```

## User Impact

Running `openclaw doctor` on an install that still has a legacy flat `auth-profiles.json` no longer deletes SQLite-only credentials. Existing OAuth and API credentials in the SQLite store are preserved, the legacy flat profiles are merged in alongside them, and the flat file is removed only after the imported profiles are confirmed present. If verification fails the flat file is left in place with a warning instead of losing data.

## Evidence

Drove the real `maybeRepairLegacyFlatAuthProfileStores` against a real on-disk per-agent SQLite auth store (populated through the real `saveAuthProfileStore`) plus a real legacy flat `auth-profiles.json`, on pristine main `66e676d29b` and on the patched tree with identical inputs. The auth store, the repair entry point, and the SQLite read-back were all real; nothing was mocked. Steps: seed SQLite with an `anthropic:default` OAuth credential, write a pre-versioned flat `auth-profiles.json` holding only `openai`, run the repair with auto-fix accepted, then read the raw SQLite store back.

```
# BEFORE (pristine main 66e676d29b)
BEFORE doctor, SQLite store: {"anthropic:default":{"type":"oauth","provider":"anthropic","access":"sk-access-LIVE","refresh":"sk-refresh-LIVE-unrecoverable","expires":9999999999999}}
AFTER  doctor, SQLite store: {"openai:default":{"type":"api_key","provider":"openai","key":"sk-openai-flat"}}
anthropic OAuth refresh token survived: false

# AFTER (this patch, identical inputs)
BEFORE doctor, SQLite store: {"anthropic:default":{"type":"oauth","provider":"anthropic","access":"sk-access-LIVE","refresh":"sk-refresh-LIVE-unrecoverable","expires":9999999999999}}
AFTER  doctor, SQLite store: {"anthropic:default":{"type":"oauth","provider":"anthropic","access":"sk-access-LIVE","refresh":"sk-refresh-LIVE-unrecoverable","expires":9999999999999},"openai:default":{"type":"api_key","provider":"openai","key":"sk-openai-flat"}}
anthropic OAuth refresh token survived: true
```

On pristine main the `anthropic` OAuth profile and its refresh token vanish from SQLite after the repair; with the patch both the preserved `anthropic` OAuth credential and the migrated `openai` key are present.

Additional checks:
- `node scripts/run-vitest.mjs src/commands/doctor-auth-flat-profiles.test.ts` passes 28/28. The new case `preserves existing SQLite auth profiles when migrating a legacy flat store` fails on pristine main and passes with the patch.
- `node scripts/run-oxlint.mjs` and `oxfmt --check` on both changed files are clean.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json` and `-p test/tsconfig/tsconfig.core.test.json` are clean.
- No live provider auth request was issued and the full build was not run; the proof exercises the on-disk SQLite store and the real repair function.
