### PR TITLE
fix(memory): stop message-level [cron: classification from wiping non-cron archives (fixes #98241) (AI-assisted)

### DIFF
--- a/packages/memory-host-sdk/src/host/session-files.test.ts
+++ b/packages/memory-host-sdk/src/host/session-files.test.ts
@@ -779,7 +779,13 @@ describe("buildSessionEntry", () => {
     expect(checkpointEntry.lineMap).toStrictEqual([]);
   });
 
-  it("keeps cron-run deleted archives opaque when the live session store entry is gone", async () => {
+  it("indexes orphaned cron-run deleted archives when session store entry is gone", async () => {
+    // When a cron archive has no session-meta and no session store entry,
+    // the message-level cron check no longer fires (it was removed because it
+    // incorrectly caught human-typed [cron:...] prefixes). The [cron: prefixed
+    // user message is still stripped by sanitizeSessionText, but assistant
+    // responses are indexed. Real cron sessions are caught by the session store
+    // classification or the record-level isCronRunGeneratedRecord check.
     const archivePath = path.join(tmpDir, "cron-run.jsonl.deleted.2026-02-16T22-27-33.000Z");
     const jsonlLines = [
       JSON.stringify({
@@ -798,9 +804,11 @@ describe("buildSessionEntry", () => {
 
     const entry = requireSessionEntry(await buildSessionEntry(archivePath));
 
-    expect(entry.content).toBe("");
-    expect(entry.lineMap).toStrictEqual([]);
-    expect(entry.generatedByCronRun).toBe(true);
+    // The [cron: user message is stripped by sanitizeSessionText, but the
+    // assistant response is indexed since no session-meta or store classifies
+    // this as a cron session.
+    expect(entry.content).toBe("Assistant: Internal cron output that must stay out.");
+    expect(entry.generatedByCronRun).toBeFalsy();
   });
 
   it("keeps cron-run reset archives opaque when session metadata preserves the cron key", async () => {
@@ -822,6 +830,49 @@ describe("buildSessionEntry", () => {
     expect(entry.content).toBe("");
     expect(entry.lineMap).toStrictEqual([]);
     expect(entry.generatedByCronRun).toBe(true);
+  });
+
+  it("indexes human-typed [cron: content in non-cron reset archives", async () => {
+    // A normal (non-cron) session where the user typed a message starting
+    // with [cron:...]. After reset, the archive should stay indexed so
+    // memory_search can surface the unrelated remembered facts.
+    const archivePath = path.join(tmpDir, "human-session.jsonl.reset.2026-06-30T10-00-00.000Z");
+    const jsonlLines = [
+      JSON.stringify({
+        type: "message",
+        message: {
+          role: "user",
+          content: "[cron:daily-digest] why did my digest job fail last night?",
+        },
+      }),
+      JSON.stringify({
+        type: "message",
+        message: { role: "assistant", content: "The digest job timed out at 3 AM." },
+      }),
+      JSON.stringify({
+        type: "message",
+        message: {
+          role: "user",
+          content: "Please remember: my preferred vendor is Acme Robotics and budget is 5000 USD",
+        },
+      }),
+      JSON.stringify({
+        type: "message",
+        message: {
+          role: "assistant",
+          content: "Noted. I'll remember Acme Robotics, budget 5000 USD.",
+        },
+      }),
+    ];
+    fsSync.writeFileSync(archivePath, jsonlLines.join("\n"));
+
+    const entry = requireSessionEntry(await buildSessionEntry(archivePath));
+
+    // The archive content should be indexed, not wiped. The [cron: prefixed
+    // user message is stripped by sanitizeSessionText, but the rest stays.
+    expect(entry.content).toContain("Acme Robotics");
+    expect(entry.content).toContain("digest job timed out");
+    expect(entry.generatedByCronRun).toBeFalsy();
   });
 
   it("skips blank lines and invalid JSON without breaking lineMap", async () => {

--- a/packages/memory-host-sdk/src/host/session-files.test.ts
+++ b/packages/memory-host-sdk/src/host/session-files.test.ts
@@ -779,13 +779,7 @@ describe("buildSessionEntry", () => {
     expect(checkpointEntry.lineMap).toStrictEqual([]);
   });
 
-  it("indexes orphaned cron-run deleted archives when session store entry is gone", async () => {
-    // When a cron archive has no session-meta and no session store entry,
-    // the message-level cron check no longer fires (it was removed because it
-    // incorrectly caught human-typed [cron:...] prefixes). The [cron: prefixed
-    // user message is still stripped by sanitizeSessionText, but assistant
-    // responses are indexed. Real cron sessions are caught by the session store
-    // classification or the record-level isCronRunGeneratedRecord check.
+  it("keeps cron-run deleted archives opaque when the live session store entry is gone", async () => {
     const archivePath = path.join(tmpDir, "cron-run.jsonl.deleted.2026-02-16T22-27-33.000Z");
     const jsonlLines = [
       JSON.stringify({
@@ -804,11 +798,9 @@ describe("buildSessionEntry", () => {
 
     const entry = requireSessionEntry(await buildSessionEntry(archivePath));
 
-    // The [cron: user message is stripped by sanitizeSessionText, but the
-    // assistant response is indexed since no session-meta or store classifies
-    // this as a cron session.
-    expect(entry.content).toBe("Assistant: Internal cron output that must stay out.");
-    expect(entry.generatedByCronRun).toBeFalsy();
+    expect(entry.content).toBe("");
+    expect(entry.lineMap).toStrictEqual([]);
+    expect(entry.generatedByCronRun).toBe(true);
   });
 
   it("keeps cron-run reset archives opaque when session metadata preserves the cron key", async () => {
@@ -832,12 +824,21 @@ describe("buildSessionEntry", () => {
     expect(entry.generatedByCronRun).toBe(true);
   });
 
-  it("indexes human-typed [cron: content in non-cron reset archives", async () => {
+  it("indexes human-typed [cron: content when it follows prior user messages in a reset archive", async () => {
     // A normal (non-cron) session where the user typed a message starting
-    // with [cron:...]. After reset, the archive should stay indexed so
-    // memory_search can surface the unrelated remembered facts.
+    // with [cron:...] after prior conversation. The archive should stay
+    // indexed so memory_search can surface the unrelated remembered facts.
+    // See https://github.com/openclaw/openclaw/issues/98241.
     const archivePath = path.join(tmpDir, "human-session.jsonl.reset.2026-06-30T10-00-00.000Z");
     const jsonlLines = [
+      JSON.stringify({
+        type: "message",
+        message: { role: "user", content: "Hello, I need help with something." },
+      }),
+      JSON.stringify({
+        type: "message",
+        message: { role: "assistant", content: "Sure, what do you need?" },
+      }),
       JSON.stringify({
         type: "message",
         message: {
@@ -868,8 +869,9 @@ describe("buildSessionEntry", () => {
 
     const entry = requireSessionEntry(await buildSessionEntry(archivePath));
 
-    // The archive content should be indexed, not wiped. The [cron: prefixed
-    // user message is stripped by sanitizeSessionText, but the rest stays.
+    // The [cron: user message is stripped by sanitizeSessionText, but the
+    // surrounding conversation and the remembered facts stay indexed because
+    // the [cron: message is NOT the first user message.
     expect(entry.content).toContain("Acme Robotics");
     expect(entry.content).toContain("digest job timed out");
     expect(entry.generatedByCronRun).toBeFalsy();

--- a/packages/memory-host-sdk/src/host/session-files.test.ts
+++ b/packages/memory-host-sdk/src/host/session-files.test.ts
@@ -779,7 +779,12 @@ describe("buildSessionEntry", () => {
     expect(checkpointEntry.lineMap).toStrictEqual([]);
   });
 
-  it("keeps cron-run deleted archives opaque when the live session store entry is gone", async () => {
+  it("indexes metadata-less cron archives when no session store or record-level provenance exists", async () => {
+    // When a cron session has no session store entry and no record-level
+    // session key, the message-level text heuristic is too broad to safely
+    // distinguish genuine cron prompts from human [cron:] text.
+    // Trusted provenance (session store + record session key) is required.
+    // See https://github.com/openclaw/openclaw/issues/98241.
     const archivePath = path.join(tmpDir, "cron-run.jsonl.deleted.2026-02-16T22-27-33.000Z");
     const jsonlLines = [
       JSON.stringify({
@@ -791,16 +796,18 @@ describe("buildSessionEntry", () => {
       }),
       JSON.stringify({
         type: "message",
-        message: { role: "assistant", content: "Internal cron output that must stay out." },
+        message: { role: "assistant", content: "Internal cron output." },
       }),
     ];
     fsSync.writeFileSync(archivePath, jsonlLines.join("\n"));
 
     const entry = requireSessionEntry(await buildSessionEntry(archivePath));
 
-    expect(entry.content).toBe("");
-    expect(entry.lineMap).toStrictEqual([]);
-    expect(entry.generatedByCronRun).toBe(true);
+    // Without trusted provenance, the archive is indexed so memory_search
+    // can surface its content. The [cron: text is stripped by
+    // sanitizeSessionText but the assistant reply is kept.
+    expect(entry.content).toContain("Internal cron output");
+    expect(entry.generatedByCronRun).toBeFalsy();
   });
 
   it("keeps cron-run reset archives opaque when session metadata preserves the cron key", async () => {
@@ -872,6 +879,51 @@ describe("buildSessionEntry", () => {
     // The [cron: user message is stripped by sanitizeSessionText, but the
     // surrounding conversation and the remembered facts stay indexed because
     // the [cron: message is NOT the first user message.
+    expect(entry.content).toContain("Acme Robotics");
+    expect(entry.content).toContain("digest job timed out");
+    expect(entry.generatedByCronRun).toBeFalsy();
+  });
+
+  it("indexes first-turn human [cron:] text in reset archives without misclassifying as cron", async () => {
+    // A reset archive where the very first user message starts with [cron:...]
+    // should NOT be classified as cron-generated. Without trusted provenance
+    // (session store or record-level session key), text pattern matching
+    // cannot distinguish human [cron:] text from genuine cron prompts.
+    // See https://github.com/openclaw/openclaw/issues/98241.
+    const archivePath = path.join(
+      tmpDir,
+      "human-first-turn-cron.jsonl.reset.2026-06-30T10-00-00.000Z",
+    );
+    const jsonlLines = [
+      JSON.stringify({
+        type: "message",
+        message: {
+          role: "user",
+          content: "[cron:daily-digest] why did my digest job fail last night?",
+        },
+      }),
+      JSON.stringify({
+        type: "message",
+        message: { role: "assistant", content: "The digest job timed out at 3 AM." },
+      }),
+      JSON.stringify({
+        type: "message",
+        message: {
+          role: "user",
+          content: "Please remember: my preferred vendor is Acme Robotics.",
+        },
+      }),
+      JSON.stringify({
+        type: "message",
+        message: { role: "assistant", content: "Noted. Acme Robotics saved." },
+      }),
+    ];
+    fsSync.writeFileSync(archivePath, jsonlLines.join("\n"));
+
+    const entry = requireSessionEntry(await buildSessionEntry(archivePath));
+
+    // The archive should be indexed — the [cron: text is stripped by
+    // sanitizeSessionText but surrounding content is preserved.
     expect(entry.content).toContain("Acme Robotics");
     expect(entry.content).toContain("digest job timed out");
     expect(entry.generatedByCronRun).toBeFalsy();

--- a/packages/memory-host-sdk/src/host/session-files.ts
+++ b/packages/memory-host-sdk/src/host/session-files.ts
@@ -840,16 +840,13 @@ export async function buildSessionEntry(
       if (rawText === null) {
         continue;
       }
-      if (
-        !generatedByCronRun &&
-        allowArchiveContentCronClassification &&
-        isGeneratedCronPromptMessage(normalizeSessionText(rawText), message.role)
-      ) {
-        generatedByCronRun = true;
-        collected.length = 0;
-        lineMap.length = 0;
-        messageTimestampsMs.length = 0;
-      }
+      // NOTE: The message-level isGeneratedCronPromptMessage check that was here
+      // has been removed. It incorrectly caught human-typed [cron:...] prefixes in
+      // user messages, causing the entire archive to be classified as cron-generated
+      // and wiping all indexed content. Real cron sessions are already detected by
+      // the record-level isCronRunGeneratedRecord check above (which inspects
+      // session-meta sessionKey) and the session store classification at the top of
+      // this function. See https://github.com/openclaw/openclaw/issues/98241.
       const text = sanitizeSessionText(rawText, message.role);
       if (!text) {
         // Assistant-side machinery (silent replies, system wrappers) is already

--- a/packages/memory-host-sdk/src/host/session-files.ts
+++ b/packages/memory-host-sdk/src/host/session-files.ts
@@ -789,6 +789,9 @@ export async function buildSessionEntry(
       opts.generatedByCronRun ?? sessionStoreClassification?.generatedByCronRun ?? false;
     const allowArchiveContentCronClassification =
       isUsageCountedSessionArchiveTranscriptPath(absPath);
+    const sessionStoreAlreadyClassifiedCron =
+      sessionStoreClassification?.generatedByCronRun === true;
+    let hasSeenPriorUserMessage = false;
     for (let jsonlIdx = 0, lineStart = 0; lineStart <= raw.length; jsonlIdx++) {
       await yieldSessionEntryParseIfNeeded(jsonlIdx, parseYieldEveryLines);
       const newlineIndex = raw.indexOf("\n", lineStart);
@@ -840,13 +843,21 @@ export async function buildSessionEntry(
       if (rawText === null) {
         continue;
       }
-      // NOTE: The message-level isGeneratedCronPromptMessage check that was here
-      // has been removed. It incorrectly caught human-typed [cron:...] prefixes in
-      // user messages, causing the entire archive to be classified as cron-generated
-      // and wiping all indexed content. Real cron sessions are already detected by
-      // the record-level isCronRunGeneratedRecord check above (which inspects
-      // session-meta sessionKey) and the session store classification at the top of
-      // this function. See https://github.com/openclaw/openclaw/issues/98241.
+      if (
+        !generatedByCronRun &&
+        allowArchiveContentCronClassification &&
+        !sessionStoreAlreadyClassifiedCron &&
+        !hasSeenPriorUserMessage &&
+        isGeneratedCronPromptMessage(normalizeSessionText(rawText), message.role)
+      ) {
+        generatedByCronRun = true;
+        collected.length = 0;
+        lineMap.length = 0;
+        messageTimestampsMs.length = 0;
+      }
+      if (message.role === "user") {
+        hasSeenPriorUserMessage = true;
+      }
       const text = sanitizeSessionText(rawText, message.role);
       if (!text) {
         // Assistant-side machinery (silent replies, system wrappers) is already

--- a/packages/memory-host-sdk/src/host/session-files.ts
+++ b/packages/memory-host-sdk/src/host/session-files.ts
@@ -789,9 +789,6 @@ export async function buildSessionEntry(
       opts.generatedByCronRun ?? sessionStoreClassification?.generatedByCronRun ?? false;
     const allowArchiveContentCronClassification =
       isUsageCountedSessionArchiveTranscriptPath(absPath);
-    const sessionStoreAlreadyClassifiedCron =
-      sessionStoreClassification?.generatedByCronRun === true;
-    let hasSeenPriorUserMessage = false;
     for (let jsonlIdx = 0, lineStart = 0; lineStart <= raw.length; jsonlIdx++) {
       await yieldSessionEntryParseIfNeeded(jsonlIdx, parseYieldEveryLines);
       const newlineIndex = raw.indexOf("\n", lineStart);
@@ -842,21 +839,6 @@ export async function buildSessionEntry(
       const rawText = collectRawSessionText(message.content);
       if (rawText === null) {
         continue;
-      }
-      if (
-        !generatedByCronRun &&
-        allowArchiveContentCronClassification &&
-        !sessionStoreAlreadyClassifiedCron &&
-        !hasSeenPriorUserMessage &&
-        isGeneratedCronPromptMessage(normalizeSessionText(rawText), message.role)
-      ) {
-        generatedByCronRun = true;
-        collected.length = 0;
-        lineMap.length = 0;
-        messageTimestampsMs.length = 0;
-      }
-      if (message.role === "user") {
-        hasSeenPriorUserMessage = true;
       }
       const text = sanitizeSessionText(rawText, message.role);
       if (!text) {


### PR DESCRIPTION
## What Problem This Solves

When a user message in a session transcript starts with `[cron:...]` (e.g., pasting a cron log line, or asking "[cron:daily-digest] why did it fail?"), the `buildSessionEntry` function in `packages/memory-host-sdk/src/host/session-files.ts` incorrectly classifies the entire archive as cron-generated. This wipes all indexed content from that archive, making `memory_search` unable to find any previously remembered facts from the session — even facts unrelated to the `[cron:` message.

The root cause is a message-level `isGeneratedCronPromptMessage` check (`/^\[cron:[^\]]+\]\s*/`) that matches human-typed text patterns. This regex cannot distinguish genuine cron prompts from human text starting with `[cron:...]`.

## Why This Change Was Made

The previous fix (first-user-message heuristic `!hasSeenPriorUserMessage`) was insufficient — it still misclassifies first-turn human `[cron:]` text as cron-generated when the session store entry is gone (reset/deleted archives).

This commit removes the message-level text-pattern cron classification entirely. Trusted provenance sources remain:
- **Session store** (`classifySessionTranscriptFromSessionStore`): checks if the session key in `sessions.json` identifies this transcript as a cron run
- **Record-level session key** (`isCronRunGeneratedRecord`): checks if the JSONL record's `sessionKey` or `data.sessionKey` matches the cron run pattern

If neither trusted source identifies the session as cron-generated, the text pattern is not used. This is a deliberate trade-off: metadata-less genuine cron archives (no session store entry AND no record-level session key) will now be indexed instead of opaque. This is acceptable because:
1. Genuine cron sessions normally have session store entries with cron session keys
2. The JSONL records normally carry the session key in `session-meta` entries
3. The false positive (human `[cron:]` text wiping unrelated memory) is worse than the false negative (metadata-less cron content being indexed)

## User Impact

Users who paste cron log lines or ask about cron jobs in their sessions will no longer lose all their session memory after a reset or delete. The `[cron:` prefixed user message is still stripped by `sanitizeSessionText`, but the surrounding conversation and remembered facts stay indexed.

## Evidence

## Real behavior proof

- **Behavior addressed:** `buildSessionEntry` incorrectly classifies human-typed `[cron:]` user messages as cron-generated in usage-counted archives, wiping all indexed content.
- **Environment tested:** macOS, Node v22.22.3, OpenClaw 2026.6.11 (fa3c9de), `packages/memory-host-sdk/src/host/session-files.ts` from branch `fix/memory-session-archive-cron-classification`.
- **Steps run after the patch:** Ran the production `buildSessionEntry` function via `tsx` with two synthetic session transcripts: (1) a reset archive where a human types `[cron:]` as the first message, and (2) a reset archive with record-level cron session key provenance.
- **Evidence after fix:**

```
=== Scenario 1: First-turn human [cron:] text ===
generatedByCronRun: undefined
contains Acme Robotics: true
contains digest timed out: true

=== Scenario 2: Genuine cron with record-level provenance ===
generatedByCronRun: true
content empty: true

All scenarios verified.
```

- **Observed result after fix:** Human-typed `[cron:]` content in non-cron reset archives is preserved and indexed (Scenario 1: `generatedByCronRun` is undefined/false, content contains both "Acme Robotics" and "digest timed out"). Genuine cron archives with record-level session key provenance remain opaque (Scenario 2: `generatedByCronRun: true`, content empty). The `buildSessionEntry` production function correctly distinguishes between the two cases using trusted provenance (session store + record-level session key) instead of text pattern matching.
- **What was not tested:** Live `memory_search` queries against a running gateway (no embedding provider available in this environment). The proof exercises the exact production code path (`buildSessionEntry`) that feeds the memory index.

- [x] AI-assisted (Hermes Agent)
