### PR TITLE
fix(feishu): avoid local media fallback leaks

### DIFF
--- a/extensions/feishu/src/media-fallback.ts
+++ b/extensions/feishu/src/media-fallback.ts
@@ -5,11 +5,18 @@ import {
 
 const FEISHU_MEDIA_UPLOAD_FAILURE_FALLBACK_TEXT = "Media upload failed. Please try again.";
 
+function hasAsciiControlCharacter(value: string): boolean {
+  return Array.from(value).some((character) => {
+    const code = character.charCodeAt(0);
+    return code <= 0x1f || code === 0x7f;
+  });
+}
+
 async function resolvePublicFeishuMediaReference(
   value: string | undefined,
 ): Promise<string | undefined> {
   const raw = value?.trim();
-  if (!raw) {
+  if (!raw || hasAsciiControlCharacter(raw)) {
     return undefined;
   }
   try {
@@ -23,7 +30,7 @@ async function resolvePublicFeishuMediaReference(
     // A proxy route cannot prove its destination is public. Fail closed unless
     // local pinned DNS validates the URL without private or special-use answers.
     await resolvePinnedHostnameWithPolicy(parsed.hostname);
-    return raw;
+    return parsed.href;
   } catch {
     return undefined;
   }

--- a/extensions/feishu/src/media-fallback.ts
+++ b/extensions/feishu/src/media-fallback.ts
@@ -30,11 +30,11 @@ async function resolvePublicFeishuMediaReference(
 export async function buildFeishuMediaFallbackText(params: {
   text?: string;
   mediaUrl?: string;
-  includeAttachmentIcon?: boolean;
+  mediaLinkStyle?: "attachment" | "plain";
 }): Promise<string> {
   const mediaUrl = await resolvePublicFeishuMediaReference(params.mediaUrl);
   const attachmentText = mediaUrl
-    ? `${params.includeAttachmentIcon === false ? "" : "📎 "}${mediaUrl}`
+    ? `${params.mediaLinkStyle === "plain" ? "" : "📎 "}${mediaUrl}`
     : FEISHU_MEDIA_UPLOAD_FAILURE_FALLBACK_TEXT;
   return [params.text?.trim(), attachmentText].filter(Boolean).join("\n\n");
 }

--- a/extensions/feishu/src/media-fallback.ts
+++ b/extensions/feishu/src/media-fallback.ts
@@ -1,0 +1,40 @@
+import {
+  isBlockedHostnameOrIp,
+  resolvePinnedHostnameWithPolicy,
+} from "openclaw/plugin-sdk/ssrf-runtime";
+
+const FEISHU_MEDIA_UPLOAD_FAILURE_FALLBACK_TEXT = "Media upload failed. Please try again.";
+
+async function resolvePublicFeishuMediaReference(
+  value: string | undefined,
+): Promise<string | undefined> {
+  const raw = value?.trim();
+  if (!raw) {
+    return undefined;
+  }
+  try {
+    const parsed = new URL(raw);
+    if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+      return undefined;
+    }
+    if (isBlockedHostnameOrIp(parsed.hostname)) {
+      return undefined;
+    }
+    await resolvePinnedHostnameWithPolicy(parsed.hostname);
+    return raw;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function buildFeishuMediaFallbackText(params: {
+  text?: string;
+  mediaUrl?: string;
+  includeAttachmentIcon?: boolean;
+}): Promise<string> {
+  const mediaUrl = await resolvePublicFeishuMediaReference(params.mediaUrl);
+  const attachmentText = mediaUrl
+    ? `${params.includeAttachmentIcon === false ? "" : "📎 "}${mediaUrl}`
+    : FEISHU_MEDIA_UPLOAD_FAILURE_FALLBACK_TEXT;
+  return [params.text?.trim(), attachmentText].filter(Boolean).join("\n\n");
+}

--- a/extensions/feishu/src/media-fallback.ts
+++ b/extensions/feishu/src/media-fallback.ts
@@ -17,9 +17,11 @@ async function resolvePublicFeishuMediaReference(
     if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
       return undefined;
     }
-    if (isBlockedHostnameOrIp(parsed.hostname)) {
+    if (parsed.username || parsed.password || isBlockedHostnameOrIp(parsed.hostname)) {
       return undefined;
     }
+    // A proxy route cannot prove its destination is public. Fail closed unless
+    // local pinned DNS validates the URL without private or special-use answers.
     await resolvePinnedHostnameWithPolicy(parsed.hostname);
     return raw;
   } catch {

--- a/extensions/feishu/src/outbound.test.ts
+++ b/extensions/feishu/src/outbound.test.ts
@@ -2561,6 +2561,7 @@ describe("feishuOutbound.sendMedia replyToId forwarding", () => {
     ["localhost URL", "https://localhost/tmp/openclaw-voice.mp3"],
     ["private-DNS URL", "https://files.example.test/openclaw-voice.mp3"],
     ["credentialed URL", "https://user@example.com/openclaw-voice.mp3"],
+    ["control-character URL", "https://example.com/\nhttp://127.0.0.1/private"],
   ])("does not leak a %s in the upload failure fallback", async (_label, mediaUrl) => {
     sendMediaFeishuMock.mockRejectedValueOnce(new Error("upload failed"));
 

--- a/extensions/feishu/src/outbound.test.ts
+++ b/extensions/feishu/src/outbound.test.ts
@@ -30,6 +30,26 @@ const shouldSuppressFeishuTextForVoiceMediaMock = vi.hoisted(
         ? params.ttsSupplement.visibleTextAlreadyDelivered === true
         : params.audioAsVoice === true || /\.(?:ogg|opus)(?:[?#]|$)/i.test(params.mediaUrl ?? ""),
 );
+const resolvePinnedHostnameWithPolicyMock = vi.hoisted(() =>
+  vi.fn(async (hostname: string) => {
+    if (hostname === "files.example.test") {
+      throw new Error("Blocked: resolves to private/internal/special-use IP address");
+    }
+    return {
+      hostname,
+      addresses: ["93.184.216.34"],
+      lookup: vi.fn(),
+    };
+  }),
+);
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    resolvePinnedHostnameWithPolicy: resolvePinnedHostnameWithPolicyMock,
+  };
+});
 
 vi.mock("./media.js", () => ({
   sendMediaFeishu: sendMediaFeishuMock,
@@ -193,6 +213,7 @@ afterAll(() => {
   vi.doUnmock("./client.js");
   vi.doUnmock("./drive.js");
   vi.doUnmock("./comment-reaction.js");
+  vi.doUnmock("openclaw/plugin-sdk/ssrf-runtime");
   vi.resetModules();
 });
 
@@ -496,7 +517,7 @@ describe("feishuOutbound.sendText local-image auto-convert", () => {
     expectFeishuResult(result, "native_card_msg");
   });
 
-  it("falls back to plain text if local-image media send fails", async () => {
+  it("does not leak local-image paths if auto-send fails", async () => {
     const { dir, file } = await createTmpImage();
     sendMediaFeishuMock.mockRejectedValueOnce(new Error("upload failed"));
     try {
@@ -509,7 +530,8 @@ describe("feishuOutbound.sendText local-image auto-convert", () => {
 
       expect(sendMediaFeishuMock).toHaveBeenCalledTimes(1);
       expect(sendMessageCall()?.to).toBe("chat_1");
-      expect(sendMessageCall()?.text).toBe(file);
+      expect(sendMessageCall()?.text).toBe("Media upload failed. Please try again.");
+      expect(sendMessageCall()?.text).not.toContain(file);
       expect(sendMessageCall()?.accountId).toBe("main");
     } finally {
       await fs.rm(dir, { recursive: true, force: true });
@@ -2074,6 +2096,26 @@ describe("feishuOutbound comment-thread routing", () => {
     expectFeishuResult(result, "reply_msg");
   });
 
+  it.each([
+    ["local path", path.join(os.tmpdir(), "openclaw-feishu-comment-local-voice.mp3")],
+    ["loopback URL", "http://127.0.0.1:3000/tmp/openclaw-voice.mp3"],
+  ])("does not leak a %s in comment-thread media fallbacks", async (_label, mediaUrl) => {
+    const result = await feishuOutbound.sendMedia?.({
+      cfg: emptyConfig,
+      to: "comment:docx:doxcn123:7623358762119646411",
+      text: "see attachment",
+      mediaUrl,
+      accountId: "main",
+    });
+
+    expect(commentThreadParams()?.content).toBe(
+      "see attachment\n\nMedia upload failed. Please try again.",
+    );
+    expect(commentThreadParams()?.content).not.toContain(mediaUrl);
+    expect(sendMediaFeishuMock).not.toHaveBeenCalled();
+    expectFeishuResult(result, "reply_msg");
+  });
+
   it("preserves comment-thread routing when deliverCommentThreadText falls back to add_comment", async () => {
     deliverCommentThreadTextMock.mockResolvedValueOnce({
       delivery_mode: "add_comment",
@@ -2509,6 +2551,30 @@ describe("feishuOutbound.sendMedia replyToId forwarding", () => {
 
     expect(sendMessageFeishuMock).toHaveBeenCalledTimes(1);
     expect(sendMessageCall()?.text).toBe("spoken reply\n\n📎 https://example.com/reply.mp3");
+  });
+
+  it.each([
+    ["local path", path.join(os.tmpdir(), "openclaw-feishu-local-voice.mp3")],
+    ["file URL", "file:///tmp/openclaw-feishu-local-voice.mp3"],
+    ["relative path", "./outbound/openclaw-feishu-local-voice.mp3"],
+    ["loopback URL", "http://127.0.0.1:3000/tmp/openclaw-voice.mp3"],
+    ["localhost URL", "https://localhost/tmp/openclaw-voice.mp3"],
+    ["private-DNS URL", "https://files.example.test/openclaw-voice.mp3"],
+  ])("does not leak a %s in the upload failure fallback", async (_label, mediaUrl) => {
+    sendMediaFeishuMock.mockRejectedValueOnce(new Error("upload failed"));
+
+    await feishuOutbound.sendMedia?.({
+      cfg: emptyConfig,
+      to: "chat_1",
+      text: "spoken reply",
+      mediaUrl,
+      audioAsVoice: true,
+      accountId: "main",
+    });
+
+    expect(sendMessageFeishuMock).toHaveBeenCalledTimes(1);
+    expect(sendMessageCall()?.text).toBe("spoken reply\n\nMedia upload failed. Please try again.");
+    expect(sendMessageCall()?.text).not.toContain(mediaUrl);
   });
 
   it("forwards replyToId to text caption send", async () => {

--- a/extensions/feishu/src/outbound.test.ts
+++ b/extensions/feishu/src/outbound.test.ts
@@ -2560,6 +2560,7 @@ describe("feishuOutbound.sendMedia replyToId forwarding", () => {
     ["loopback URL", "http://127.0.0.1:3000/tmp/openclaw-voice.mp3"],
     ["localhost URL", "https://localhost/tmp/openclaw-voice.mp3"],
     ["private-DNS URL", "https://files.example.test/openclaw-voice.mp3"],
+    ["credentialed URL", "https://user@example.com/openclaw-voice.mp3"],
   ])("does not leak a %s in the upload failure fallback", async (_label, mediaUrl) => {
     sendMediaFeishuMock.mockRejectedValueOnce(new Error("upload failed"));
 

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -34,12 +34,12 @@ import { cleanupAmbientCommentTypingReaction } from "./comment-reaction.js";
 import { parseFeishuCommentTarget } from "./comment-target.js";
 import { deliverCommentThreadText } from "./drive.js";
 import { resolveFeishuIdentityHeaderTitle } from "./identity-header.js";
-import { buildFeishuMediaFallbackText } from "./media-fallback.js";
 import {
   chunkFeishuMarkdown,
   chunkFeishuPostMarkdown,
   materializeFeishuPostMarkdownSoftBreaks,
 } from "./markdown.js";
+import { buildFeishuMediaFallbackText } from "./media-fallback.js";
 import {
   sendMediaFeishu,
   shouldSuppressFeishuTextForVoiceMedia,
@@ -875,7 +875,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
           ? await buildFeishuMediaFallbackText({
               text,
               mediaUrl,
-              includeAttachmentIcon: false,
+              mediaLinkStyle: "plain",
             })
           : (text?.trim() ?? "");
         return await sendOutboundText({

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -34,6 +34,7 @@ import { cleanupAmbientCommentTypingReaction } from "./comment-reaction.js";
 import { parseFeishuCommentTarget } from "./comment-target.js";
 import { deliverCommentThreadText } from "./drive.js";
 import { resolveFeishuIdentityHeaderTitle } from "./identity-header.js";
+import { buildFeishuMediaFallbackText } from "./media-fallback.js";
 import {
   chunkFeishuMarkdown,
   chunkFeishuPostMarkdown,
@@ -788,7 +789,14 @@ export const feishuOutbound: ChannelOutboundAdapter = {
           });
         } catch (err) {
           console.error(`[feishu] local image path auto-send failed:`, err);
-          // fall through to plain text as last resort
+          return await sendOutboundText({
+            cfg,
+            to,
+            text: await buildFeishuMediaFallbackText({}),
+            accountId: accountId ?? undefined,
+            replyToMessageId,
+            replyInThread,
+          });
         }
       }
 
@@ -863,11 +871,17 @@ export const feishuOutbound: ChannelOutboundAdapter = {
       });
       const commentTarget = parseFeishuCommentTarget(to);
       if (commentTarget) {
-        const commentText = [text?.trim(), mediaUrl?.trim()].filter(Boolean).join("\n\n");
+        const commentText = mediaUrl?.trim()
+          ? await buildFeishuMediaFallbackText({
+              text,
+              mediaUrl,
+              includeAttachmentIcon: false,
+            })
+          : (text?.trim() ?? "");
         return await sendOutboundText({
           cfg,
           to,
-          text: commentText || mediaUrl || text || "",
+          text: commentText,
           accountId: accountId ?? undefined,
           replyToMessageId,
           replyInThread,
@@ -916,10 +930,10 @@ export const feishuOutbound: ChannelOutboundAdapter = {
         } catch (err) {
           // Log the error for debugging
           console.error(`[feishu] sendMediaFeishu failed:`, err);
-          // Fallback to URL link if upload fails
-          const fallbackText = [textSent ? undefined : text?.trim(), `📎 ${mediaUrl}`]
-            .filter(Boolean)
-            .join("\n\n");
+          const fallbackText = await buildFeishuMediaFallbackText({
+            text: textSent ? undefined : text,
+            mediaUrl,
+          });
           const fallbackResult = await sendOutboundText({
             cfg,
             to,

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -1,4 +1,6 @@
 // Feishu tests cover reply dispatcher plugin behavior.
+import os from "node:os";
+import path from "node:path";
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 type StreamingSessionStub = {
@@ -33,6 +35,18 @@ const shouldSuppressFeishuTextForVoiceMediaMock = vi.hoisted(
       params.ttsSupplement
         ? params.ttsSupplement.visibleTextAlreadyDelivered === true
         : params.audioAsVoice === true || /\.(?:ogg|opus)(?:[?#]|$)/i.test(params.mediaUrl ?? ""),
+);
+const resolvePinnedHostnameWithPolicyMock = vi.hoisted(() =>
+  vi.fn(async (hostname: string) => {
+    if (hostname === "files.example.test") {
+      throw new Error("Blocked: resolves to private/internal/special-use IP address");
+    }
+    return {
+      hostname,
+      addresses: ["93.184.216.34"],
+      lookup: vi.fn(),
+    };
+  }),
 );
 
 function mergeStreamingText(
@@ -76,6 +90,13 @@ vi.mock("./media.js", () => ({
   sendMediaFeishu: sendMediaFeishuMock,
   shouldSuppressFeishuTextForVoiceMedia: shouldSuppressFeishuTextForVoiceMediaMock,
 }));
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    resolvePinnedHostnameWithPolicy: resolvePinnedHostnameWithPolicyMock,
+  };
+});
 vi.mock("./client.js", () => ({ createFeishuClient: createFeishuClientMock }));
 vi.mock("./targets.js", () => ({ resolveReceiveIdType: resolveReceiveIdTypeMock }));
 vi.mock("./typing.js", () => ({
@@ -122,6 +143,7 @@ afterAll(() => {
   vi.doUnmock("./targets.js");
   vi.doUnmock("./typing.js");
   vi.doUnmock("./streaming-card.js");
+  vi.doUnmock("openclaw/plugin-sdk/ssrf-runtime");
   vi.resetModules();
 });
 
@@ -1519,6 +1541,26 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expectMockArgFields(sendMessageFeishuMock, "message send params", {
       text: "spoken reply\n\n📎 https://example.com/reply.mp3",
     });
+  });
+
+  it("does not leak local media paths in the upload failure fallback", async () => {
+    const mediaPath = path.join(os.tmpdir(), "openclaw-feishu-reply-local-voice.mp3");
+    sendMediaFeishuMock.mockRejectedValueOnce(new Error("media failed"));
+
+    const { options } = createDispatcherHarness();
+    await options.deliver(
+      {
+        text: "spoken reply",
+        mediaUrl: mediaPath,
+        audioAsVoice: true,
+      },
+      { kind: "final" },
+    );
+
+    expect(sendMessageFeishuMock).toHaveBeenCalledTimes(1);
+    const fallbackText = String(firstMockArg(sendMessageFeishuMock, "message send params").text);
+    expect(fallbackText).toBe("spoken reply\n\nMedia upload failed. Please try again.");
+    expect(fallbackText).not.toContain(mediaPath);
   });
 
   it("falls back to legacy mediaUrl when mediaUrls is an empty array", async () => {

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -19,8 +19,8 @@ import { resolveFeishuRuntimeAccount } from "./accounts.js";
 import { resolveConfiguredHttpTimeoutMs } from "./client-timeout.js";
 import { createFeishuClient } from "./client.js";
 import { resolveFeishuIdentityEmoji } from "./identity-header.js";
-import { buildFeishuMediaFallbackText } from "./media-fallback.js";
 import { chunkFeishuPostMarkdown, materializeFeishuPostMarkdownSoftBreaks } from "./markdown.js";
+import { buildFeishuMediaFallbackText } from "./media-fallback.js";
 import { sendMediaFeishu, shouldSuppressFeishuTextForVoiceMedia } from "./media.js";
 import type { MentionTarget } from "./mention-target.types.js";
 import {

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -19,6 +19,7 @@ import { resolveFeishuRuntimeAccount } from "./accounts.js";
 import { resolveConfiguredHttpTimeoutMs } from "./client-timeout.js";
 import { createFeishuClient } from "./client.js";
 import { resolveFeishuIdentityEmoji } from "./identity-header.js";
+import { buildFeishuMediaFallbackText } from "./media-fallback.js";
 import { chunkFeishuPostMarkdown, materializeFeishuPostMarkdownSoftBreaks } from "./markdown.js";
 import { sendMediaFeishu, shouldSuppressFeishuTextForVoiceMedia } from "./media.js";
 import type { MentionTarget } from "./mention-target.types.js";
@@ -82,12 +83,6 @@ function rememberStreamingStartFailure(accountId: string, now = Date.now()): num
   const backoffUntil = now + STREAMING_START_FAILURE_BACKOFF_MS;
   streamingStartBackoffUntilByAccount.set(accountId, backoffUntil);
   return backoffUntil;
-}
-
-function formatMediaFallbackText(text: string | undefined, mediaUrl: string): string {
-  const trimmedText = text?.trim() ?? "";
-  const attachmentText = `📎 ${mediaUrl}`;
-  return trimmedText ? `${trimmedText}\n\n${attachmentText}` : attachmentText;
 }
 
 function normalizeEpochMs(timestamp: number | undefined): number | undefined {
@@ -581,10 +576,10 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         options?.fallbackText === undefined
           ? undefined
           : async ({ mediaUrl }) => {
-              const fallbackText = formatMediaFallbackText(
-                sentFallbackText ? undefined : options.fallbackText,
+              const fallbackText = await buildFeishuMediaFallbackText({
+                text: sentFallbackText ? undefined : options.fallbackText,
                 mediaUrl,
-              );
+              });
               sentFallbackText = true;
               await sendChunkedTextReply({
                 text: fallbackText,


### PR DESCRIPTION
Closes #98250

## What Problem This Solves

Fixes an issue where Feishu recipients could receive host-local or private media references as fallback text when a media upload/fetch failed. The affected surfaces include local-image text auto-send fallback, `sendMedia` upload fallback, document-comment media fallback, and reply-dispatcher final media fallback.

## Why This Change Was Made

This adds a Feishu-local media fallback helper that only includes `http://` or `https://` fallback links after shared SSRF/DNS validation, suppresses local/private media fetch failures, and otherwise preserves the caption text with `Media upload failed. Please try again.`

The successful media upload path is unchanged. Public URL fallback remains available when the URL passes the existing public-host checks; Feishu auth, account selection, TTS routing, and provider behavior are out of scope.

## User Impact

Feishu users no longer see local filesystem paths, `file://` URLs, relative local references, loopback/private URLs, or DNS-private media references in message/comment fallback text after media upload failure. Public media URLs can still be shown as fallback links when they are safe to expose.

## Evidence

Runtime proof on PR commit `71d08b4bfc`, using synthetic media references only:

```text
Feishu media fallback proof on PR commit 71d08b4bfc
local path:
  output=spoken reply\n\nMedia upload failed. Please try again.
  unsafe reference exposed=false
loopback URL:
  output=spoken reply\n\nMedia upload failed. Please try again.
  unsafe reference exposed=false
public URL:
  output=spoken reply\n\n📎 https://example.com/openclaw-voice.mp3
  public fallback preserved=true
```

Focused verification:

- `node scripts\run-vitest.mjs extensions\feishu\src\outbound.test.ts --testNamePattern="does not leak local-image paths if auto-send fails|does not leak local media paths in comment-thread media fallbacks|does not leak loopback URLs in comment-thread media fallbacks|keeps skipped voice text in the upload failure fallback|does not leak URLs rejected by private-DNS media checks"`
  - `1 Test File passed`
  - `5 passed | 46 skipped`
- `node scripts\run-vitest.mjs extensions\feishu\src\reply-dispatcher.test.ts --testNamePattern="keeps skipped voice text in the upload failure fallback|does not leak local media paths in the upload failure fallback|does not leak URLs rejected by private-DNS checks in the upload failure fallback"`
  - `1 Test File passed`
  - `3 passed | 83 skipped`

Full touched test files:

- `node scripts\run-vitest.mjs extensions\feishu\src\outbound.test.ts`
  - `1 Test File passed`
  - `51 passed`
- `node scripts\run-vitest.mjs extensions\feishu\src\reply-dispatcher.test.ts`
  - `1 Test File passed`
  - `86 passed`

Static checks and review:

- `node_modules\.bin\oxlint.CMD extensions\feishu\src\outbound.ts extensions\feishu\src\outbound.test.ts extensions\feishu\src\reply-dispatcher.ts extensions\feishu\src\reply-dispatcher.test.ts extensions\feishu\src\media-fallback.ts`
- `node scripts\run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions\feishu\src\media-fallback.ts extensions\feishu\src\outbound.ts extensions\feishu\src\outbound.test.ts extensions\feishu\src\reply-dispatcher.ts extensions\feishu\src\reply-dispatcher.test.ts`
- `node scripts\run-oxlint-shards.mjs --threads=8`
- `node scripts\run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo`
- `node scripts\run-tsgo.mjs -p test\tsconfig\tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts\tsgo-cache\extensions-test.tsbuildinfo`
- `node scripts\check-extension-package-tsc-boundary.mjs --mode=compile`
- `node scripts\check-extension-package-tsc-boundary.mjs --mode=canary`
- `git diff --check`
- `$env:PYTHONUTF8='1'; python .agents\skills\autoreview\scripts\autoreview --mode local`
  - `autoreview clean: no accepted/actionable findings reported`
- `$env:PYTHONUTF8='1'; python .agents\skills\autoreview\scripts\autoreview --mode commit --commit HEAD`
  - `autoreview clean: no accepted/actionable findings reported`
