### PR TITLE
fix(mcp): require owner for Claude permission replies

### DIFF
--- a/docs/cli/mcp.md
+++ b/docs/cli/mcp.md
@@ -253,7 +253,7 @@ Current bridge behavior:
 
 - inbound `user` transcript messages are forwarded as `notifications/claude/channel`
 - Claude permission requests received over MCP are tracked in-memory
-- if the linked conversation later sends `yes abcde` or `no abcde`, the bridge converts that to `notifications/claude/channel/permission`
+- if the command owner in the linked conversation later sends `yes abcde` or `no abcde`, the bridge converts that to `notifications/claude/channel/permission`
 - these notifications are live-session only; if the MCP client disconnects, there is no push target
 
 This is intentionally client-specific. Generic MCP clients should rely on the standard polling tools.

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -2833,6 +2833,9 @@ describe("runPreparedReply media-only handling", () => {
 
     const call = requireRunReplyAgentCall();
     expect(call?.followupRun.run.senderIsOwner).toBe(true);
+    expect(call?.followupRun.userTurnTranscriptRecorder?.message).toMatchObject({
+      __openclaw: { senderIsOwner: true },
+    });
   });
 
   it("keeps sender ownership when drained system events are present", async () => {

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -1247,6 +1247,7 @@ export async function runPreparedReply(
     userTurnTranscriptText !== undefined || userTurnMediaForPersistence.length > 0
       ? {
           text: userTurnTranscriptText,
+          senderIsOwner: command.senderIsOwner,
           ...(inputProvenance ? { provenance: inputProvenance } : {}),
           ...(userTurnMediaForPersistence.length > 0
             ? {

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -4401,6 +4401,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       content: "bench update",
       timestamp: expect.any(Number),
       idempotencyKey: "idem-system-provenance-acp:user",
+      __openclaw: { senderIsOwner: true },
       provenance: {
         ...provenance,
         sourceSessionKey: undefined,

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1320,7 +1320,7 @@ function isAcpBridgeClient(client: GatewayRequestHandlerOptions["client"]): bool
   );
 }
 
-function canInjectSystemProvenance(client: GatewayRequestHandlerOptions["client"]): boolean {
+function hasGatewayAdminScope(client: GatewayRequestHandlerOptions["client"]): boolean {
   const scopes = Array.isArray(client?.connect?.scopes) ? client.connect.scopes : [];
   return scopes.includes(ADMIN_SCOPE);
 }
@@ -3437,7 +3437,7 @@ export const chatHandlers: GatewayRequestHandlers = {
         p.systemProvenanceReceipt ||
         suppressCommandInterpretation ||
         explicitOriginResult.value) &&
-      !canInjectSystemProvenance(client)
+      !hasGatewayAdminScope(client)
     ) {
       respond(
         false,
@@ -3884,6 +3884,7 @@ export const chatHandlers: GatewayRequestHandlers = {
         text: rawMessage,
         timestamp: now,
         idempotencyKey: `${clientRunId}:user`,
+        ...(hasGatewayAdminScope(client) ? { senderIsOwner: true } : {}),
         ...(systemInputProvenance ? { provenance: systemInputProvenance } : {}),
       };
       const userTurnInputPromise: Promise<UserTurnInput> = userTurnMediaPromise.then((media) => ({

--- a/src/gateway/server-session-events.test.ts
+++ b/src/gateway/server-session-events.test.ts
@@ -100,4 +100,16 @@ describe("createTranscriptUpdateBroadcastHandler", () => {
       },
     });
   });
+
+  it("broadcasts the authenticated sender ownership decision", async () => {
+    await expect(
+      emitAssistantTranscriptUpdate(false, {
+        role: "user",
+        content: [{ type: "text", text: "Owner turn" }],
+        __openclaw: { senderIsOwner: true },
+      }),
+    ).resolves.toMatchObject({
+      senderIsOwner: true,
+    });
+  });
 });

--- a/src/gateway/server-session-events.ts
+++ b/src/gateway/server-session-events.ts
@@ -38,6 +38,18 @@ function readMessageIdempotencyKey(message: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value : undefined;
 }
 
+function readMessageSenderIsOwner(message: unknown): boolean | undefined {
+  if (!message || typeof message !== "object" || Array.isArray(message)) {
+    return undefined;
+  }
+  const openclaw = (message as Record<string, unknown>)["__openclaw"];
+  if (!openclaw || typeof openclaw !== "object" || Array.isArray(openclaw)) {
+    return undefined;
+  }
+  const value = (openclaw as Record<string, unknown>).senderIsOwner;
+  return typeof value === "boolean" ? value : undefined;
+}
+
 function resolveSessionMessageBroadcastKeys(sessionKey: string, agentId?: string): string[] {
   // Global sessions can be subscribed through either the raw global key or the
   // default-agent scoped key; non-default agent global sessions stay scoped.
@@ -182,6 +194,7 @@ async function handleTranscriptUpdateBroadcast(
     hasActiveRun,
   });
   const idempotencyKey = readMessageIdempotencyKey(update.message);
+  const senderIsOwner = readMessageSenderIsOwner(update.message);
   const rawMessage = attachOpenClawTranscriptMeta(update.message, {
     ...(typeof update.messageId === "string" ? { id: update.messageId } : {}),
     ...(idempotencyKey ? { idempotencyKey } : {}),
@@ -193,6 +206,7 @@ async function handleTranscriptUpdateBroadcast(
       "session.message",
       {
         sessionKey,
+        ...(senderIsOwner === undefined ? {} : { senderIsOwner }),
         ...(visibleAgentId ? { agentId: visibleAgentId } : {}),
         message,
         ...(typeof update.messageId === "string" ? { messageId: update.messageId } : {}),

--- a/src/mcp/channel-bridge.test.ts
+++ b/src/mcp/channel-bridge.test.ts
@@ -16,7 +16,10 @@ type BridgeInternals = {
   pendingClaudePermissions: Map<string, unknown>;
   pendingApprovals: Map<string, unknown>;
   pendingSweepInterval: NodeJS.Timeout | null;
-  pollEvents: (filter: WaitFilter, limit?: number) => {
+  pollEvents: (
+    filter: WaitFilter,
+    limit?: number,
+  ) => {
     events: QueueEvent[];
     nextCursor: number;
   };
@@ -31,6 +34,11 @@ type BridgeInternals = {
     event: string;
     payload?: Record<string, unknown>;
   }) => Promise<void>;
+  handleSessionMessageEvent: (payload: {
+    sessionKey: string;
+    senderIsOwner?: boolean;
+    message: { role: string; content: unknown };
+  }) => Promise<void>;
   listPendingApprovals: () => unknown[];
   close: () => Promise<void>;
   server: { server: { notification: (n: unknown) => Promise<void> } } | null;
@@ -43,6 +51,72 @@ function makeBridge(verbose = false): BridgeInternals {
     verbose,
   }) as unknown as BridgeInternals;
 }
+
+describe("OpenClawChannelBridge — Claude permission authorization", () => {
+  test.each([
+    { name: "non-owner", senderIsOwner: false, role: "user" },
+    { name: "missing owner metadata", senderIsOwner: undefined, role: "user" },
+    { name: "assistant message", senderIsOwner: true, role: "assistant" },
+  ])("does not resolve a pending permission from a $name reply", async (reply) => {
+    const bridge = makeBridge();
+    const notification = vi.fn(async () => undefined);
+    bridge.server = { server: { notification } };
+    try {
+      await bridge.handleClaudePermissionRequest({
+        requestId: "abcde",
+        toolName: "Bash",
+        description: "run npm test",
+        inputPreview: "{}",
+      });
+
+      await bridge.handleSessionMessageEvent({
+        sessionKey: "agent:main:telegram:group:-100123",
+        senderIsOwner: reply.senderIsOwner,
+        message: {
+          role: reply.role,
+          content: [{ type: "text", text: "yes abcde" }],
+        },
+      });
+
+      expect(notification).not.toHaveBeenCalled();
+      expect(bridge.pendingClaudePermissions.has("abcde")).toBe(true);
+      expect(bridge.queue.at(-1)).toMatchObject({ type: "message", text: "yes abcde" });
+    } finally {
+      await bridge.close();
+    }
+  });
+
+  test("resolves a pending permission from an owner user reply", async () => {
+    const bridge = makeBridge();
+    const notification = vi.fn(async () => undefined);
+    bridge.server = { server: { notification } };
+    try {
+      await bridge.handleClaudePermissionRequest({
+        requestId: "abcde",
+        toolName: "Bash",
+        description: "run npm test",
+        inputPreview: "{}",
+      });
+
+      await bridge.handleSessionMessageEvent({
+        sessionKey: "agent:main:telegram:group:-100123",
+        senderIsOwner: true,
+        message: {
+          role: "user",
+          content: [{ type: "text", text: "yes abcde" }],
+        },
+      });
+
+      expect(notification).toHaveBeenCalledWith({
+        method: "notifications/claude/channel/permission",
+        params: { request_id: "abcde", behavior: "allow" },
+      });
+      expect(bridge.pendingClaudePermissions.has("abcde")).toBe(false);
+    } finally {
+      await bridge.close();
+    }
+  });
+});
 
 describe("OpenClawChannelBridge — pendingClaudePermissions / pendingApprovals memory bounds", () => {
   beforeEach(() => {

--- a/src/mcp/channel-bridge.ts
+++ b/src/mcp/channel-bridge.ts
@@ -584,7 +584,9 @@ export class OpenClawChannelBridge {
     const role = toText(payload.message?.role);
     const text = extractFirstTextBlock(payload.message);
     const permissionMatch = text ? CLAUDE_PERMISSION_REPLY_RE.exec(text) : null;
-    if (permissionMatch) {
+    // Ownership is decided at authenticated channel ingress and carried on the
+    // live transcript event. Missing metadata fails closed for approvals.
+    if (role === "user" && payload.senderIsOwner === true && permissionMatch) {
       const requestId = normalizeOptionalLowercaseString(permissionMatch[2]);
       if (requestId && this.pendingClaudePermissions.has(requestId)) {
         this.pendingClaudePermissions.delete(requestId);

--- a/src/mcp/channel-server.test.ts
+++ b/src/mcp/channel-server.test.ts
@@ -324,6 +324,7 @@ describe("openclaw channel mcp server", () => {
             }
           ).handleSessionMessageEvent({
             sessionKey,
+            senderIsOwner: true,
             lastChannel: "imessage",
             lastTo: "+15551234567",
             messageId: "msg-user-1",
@@ -358,6 +359,7 @@ describe("openclaw channel mcp server", () => {
             }
           ).handleSessionMessageEvent({
             sessionKey,
+            senderIsOwner: true,
             lastChannel: "imessage",
             lastTo: "+15551234567",
             messageId: "msg-user-2",

--- a/src/mcp/channel-shared.ts
+++ b/src/mcp/channel-shared.ts
@@ -71,6 +71,7 @@ export type ChatHistoryResult = {
 /** Gateway session.message payload fields consumed by the MCP event bridge. */
 export type SessionMessagePayload = {
   sessionKey?: string;
+  senderIsOwner?: boolean;
   messageId?: string;
   messageSeq?: number;
   message?: { role?: string; content?: unknown; [key: string]: unknown };

--- a/src/sessions/user-turn-transcript.test.ts
+++ b/src/sessions/user-turn-transcript.test.ts
@@ -272,6 +272,7 @@ describe("user turn transcript persistence", () => {
           text: "What is in this image?",
           media: [{ path: "/tmp/image.png", contentType: "image/png" }],
           timestamp: 123,
+          senderIsOwner: true,
           provenance,
         },
         updateMode: "none",
@@ -287,6 +288,7 @@ describe("user turn transcript persistence", () => {
           role: "user",
           content: "What is in this image?",
           MediaPath: "/tmp/image.png",
+          __openclaw: { senderIsOwner: true },
           provenance,
           MediaType: "image/png",
         }),
@@ -398,6 +400,7 @@ describe("user turn transcript persistence", () => {
         input: {
           text: "secret prompt",
           idempotencyKey: "chat-run-1:user",
+          senderIsOwner: true,
           provenance,
         },
         beforeMessageWrite: runAgentHarnessBeforeMessageWriteHook,
@@ -407,6 +410,7 @@ describe("user turn transcript persistence", () => {
         input: {
           text: "secret prompt",
           idempotencyKey: "chat-run-1:user",
+          senderIsOwner: true,
           provenance,
         },
         beforeMessageWrite: runAgentHarnessBeforeMessageWriteHook,
@@ -417,6 +421,7 @@ describe("user turn transcript persistence", () => {
           role: "user",
           content: "[redacted by hook]",
           idempotencyKey: "chat-run-1:user",
+          __openclaw: { senderIsOwner: true },
           provenance,
         }),
       ]);

--- a/src/sessions/user-turn-transcript.ts
+++ b/src/sessions/user-turn-transcript.ts
@@ -243,6 +243,9 @@ function buildPersistedUserTurnMessage(params: UserTurnInput): PersistedUserTurn
     content,
     timestamp: params.timestamp ?? Date.now(),
     ...(params.idempotencyKey ? { idempotencyKey: params.idempotencyKey } : {}),
+    ...(params.senderIsOwner === undefined
+      ? {}
+      : { __openclaw: { senderIsOwner: params.senderIsOwner } }),
     ...mediaFields,
   } as PersistedUserTurnMessage;
   return applyInputProvenanceToUserMessage(message, params.provenance) as PersistedUserTurnMessage;
@@ -317,12 +320,26 @@ export function preparePersistedUserTurnMessageForTranscriptWrite(
   const nextUserMessage = provenance
     ? (applyInputProvenanceToUserMessage(nextMessage, provenance) as PersistedUserTurnMessage)
     : nextMessage;
-  return idempotencyKey
-    ? ({
-        ...(nextUserMessage as unknown as Record<string, unknown>),
-        idempotencyKey,
-      } as unknown as PersistedUserTurnMessage)
-    : nextUserMessage;
+  const originalOpenClaw = (message as unknown as { __openclaw?: unknown })["__openclaw"];
+  const senderIsOwner =
+    originalOpenClaw && typeof originalOpenClaw === "object"
+      ? (originalOpenClaw as { senderIsOwner?: unknown }).senderIsOwner
+      : undefined;
+  if (!idempotencyKey && typeof senderIsOwner !== "boolean") {
+    return nextUserMessage;
+  }
+  const nextRecord = nextUserMessage as unknown as Record<string, unknown>;
+  const nextOpenClaw =
+    nextRecord["__openclaw"] && typeof nextRecord["__openclaw"] === "object"
+      ? (nextRecord["__openclaw"] as Record<string, unknown>)
+      : {};
+  return {
+    ...nextRecord,
+    ...(idempotencyKey ? { idempotencyKey } : {}),
+    ...(typeof senderIsOwner === "boolean"
+      ? { __openclaw: { ...nextOpenClaw, senderIsOwner } }
+      : {}),
+  } as unknown as PersistedUserTurnMessage;
 }
 
 export async function appendUserTurnTranscriptMessage(

--- a/src/sessions/user-turn-transcript.types.ts
+++ b/src/sessions/user-turn-transcript.types.ts
@@ -23,6 +23,7 @@ export type UserTurnInput = {
   media?: readonly PersistedUserTurnMediaInput[] | null;
   timestamp?: number;
   idempotencyKey?: string;
+  senderIsOwner?: boolean;
   provenance?: InputProvenance;
   mediaOnlyText?: string;
 };

--- a/test/e2e/qa-lab/runtime/mcp-channels-docker-client.ts
+++ b/test/e2e/qa-lab/runtime/mcp-channels-docker-client.ts
@@ -1,5 +1,6 @@
 // MCP channels Docker client drives the QA-owned channel bridge smoke.
 import { randomUUID } from "node:crypto";
+import { setTimeout as delay } from "node:timers/promises";
 import {
   assert,
   ClaudeChannelNotificationSchema,
@@ -28,6 +29,8 @@ function summarizeSessionRows(rows: Array<Record<string, unknown>> | undefined) 
     lastThreadId: entry.lastThreadId,
   }));
 }
+
+const NON_OWNER_PERMISSION_QUIET_WINDOW_MS = 1_000;
 
 function formatUnknownError(error: unknown): string {
   if (error instanceof Error) {
@@ -96,6 +99,7 @@ async function main() {
   assert(gatewayToken, "missing GW_TOKEN");
 
   const gateway = await connectGateway({ url: gatewayUrl, token: gatewayToken });
+  let nonOwnerGateway: GatewayRpcClient | undefined;
   let mcpHandle: Awaited<ReturnType<typeof connectMcpClient>> | undefined;
   const mcpTempState = createMcpClientTempState({ gatewayToken });
 
@@ -349,6 +353,36 @@ async function main() {
       },
     });
 
+    nonOwnerGateway = await connectGateway({
+      url: gatewayUrl,
+      token: gatewayToken,
+      scopes: ["operator.read", "operator.write"],
+    });
+    await nonOwnerGateway.request("chat.send", {
+      sessionKey: "agent:main:main",
+      message: "yes abcde",
+      idempotencyKey: randomUUID(),
+    });
+    await waitFor(
+      "non-owner reply forwarded as an ordinary Claude channel message",
+      () =>
+        mcpHandle.rawMessages
+          .map((entry) => ClaudeChannelNotificationSchema.safeParse(entry))
+          .find(
+            (entry) =>
+              entry.success &&
+              entry.data.params.meta.session_key === "agent:main:main" &&
+              entry.data.params.content === "yes abcde",
+          )?.data.params,
+      60_000,
+    );
+    await delay(NON_OWNER_PERMISSION_QUIET_WINDOW_MS);
+    const nonOwnerPermission = mcpHandle.rawMessages
+      .map((entry) => ClaudePermissionNotificationSchema.safeParse(entry))
+      .find((entry) => entry.success && entry.data.params.request_id === "abcde");
+    assert(!nonOwnerPermission, "non-owner reply must not resolve the Claude permission");
+
+    const ownerNotificationStart = mcpHandle.rawMessages.length;
     await gateway.request("chat.send", {
       sessionKey: "agent:main:main",
       message: "yes abcde",
@@ -360,6 +394,7 @@ async function main() {
         "Claude permission notification",
         () =>
           mcpHandle.rawMessages
+            .slice(ownerNotificationStart)
             .map((entry) => ClaudePermissionNotificationSchema.safeParse(entry))
             .find((entry) => entry.success && entry.data.params.request_id === "abcde")?.data
             .params,
@@ -389,6 +424,9 @@ async function main() {
         {
           ok: true,
           sessionKey: "agent:main:main",
+          nonOwnerReplyForwarded: true,
+          nonOwnerPermissionBlocked: true,
+          ownerPermissionAllowed: permission.behavior === "allow",
           rawNotifications: mcpHandle.rawMessages.filter(
             (entry) =>
               ClaudeChannelNotificationSchema.safeParse(entry).success ||
@@ -401,6 +439,9 @@ async function main() {
     );
   } finally {
     const closeTasks: Array<Promise<unknown>> = [gateway.close()];
+    if (nonOwnerGateway) {
+      closeTasks.push(nonOwnerGateway.close());
+    }
     if (mcpHandle) {
       closeTasks.push(mcpHandle.client.close(), mcpHandle.transport.close());
     }

--- a/test/e2e/qa-lab/runtime/mcp-channels.fixture.ts
+++ b/test/e2e/qa-lab/runtime/mcp-channels.fixture.ts
@@ -114,6 +114,7 @@ export async function waitFor<T>(
 export async function connectGateway(params: {
   url: string;
   token: string;
+  scopes?: readonly string[];
 }): Promise<GatewayRpcClient> {
   const startedAt = Date.now();
   let attempt = 0;
@@ -138,8 +139,14 @@ export async function connectGateway(params: {
 async function connectGatewayOnce(params: {
   url: string;
   token: string;
+  scopes?: readonly string[];
 }): Promise<GatewayRpcClient> {
-  const requestedScopes = ["operator.read", "operator.write", "operator.pairing", "operator.admin"];
+  const requestedScopes = params.scopes ?? [
+    "operator.read",
+    "operator.write",
+    "operator.pairing",
+    "operator.admin",
+  ];
   const events: Array<{ event: string; payload: Record<string, unknown> }> = [];
   const gatewayClient = createGatewayWsClient({
     handshakeTimeoutMs: GATEWAY_WS_OPEN_TIMEOUT_MS,


### PR DESCRIPTION
## Summary

### What Problem This Solves

Claude channel permission replies were matched only by the short pending request ID. A non-owner channel participant could therefore resolve a privileged Claude Code permission prompt by sending a matching `yes <id>` or `no <id>` message.

## Changes

### Why This Change Was Made

- Carry the authenticated `senderIsOwner` decision from channel and Gateway ingress through user-turn transcript persistence and `session.message` broadcasts.
- Require an explicit owner user message before converting a reply into `notifications/claude/channel/permission`.
- Fail closed when ownership metadata is missing while preserving the message as an ordinary channel event.
- Document that Claude permission replies come from the command owner.
- Extend the packaged MCP-channel Docker scenario with a non-admin reply followed by an owner reply.

### User Impact

Command owners retain the existing text-reply approval flow. Non-owners, assistant messages, and messages without authenticated ownership metadata can no longer approve or deny Claude Code permission requests.

## Validation

### Evidence

- [Targeted packaged Docker MCP/channel run](https://github.com/eleqtrizit/openclaw/actions/runs/28472137502) — passed on the current PR head. The functional image launched a real Gateway and stdio MCP bridge; an authenticated non-admin reply was forwarded as an ordinary channel message without resolving the permission, then an authenticated admin-owner reply resolved the same pending permission. Redacted artifact markers: `nonOwnerReplyForwarded: true`, `nonOwnerPermissionBlocked: true`, `ownerPermissionAllowed: true`.
- `node scripts/run-vitest.mjs src/mcp/channel-bridge.test.ts src/mcp/channel-server.test.ts src/gateway/server-session-events.test.ts src/sessions/user-turn-transcript.test.ts src/auto-reply/reply/get-reply-run.media-only.test.ts src/gateway/server-methods/chat.directive-tags.test.ts` — 8 files, 408 tests passed across 3 shards.
- `node scripts/run-vitest.mjs test/scripts/docker-e2e-observability.test.ts test/scripts/test-projects.test.ts` — 2 files, 188 tests passed.
- `node_modules/.bin/oxfmt --check --threads=1 <changed files>` — passed.
- `node scripts/check-docs-mdx.mjs docs/cli/mcp.md` — passed.
- `git diff --check upstream/main...HEAD` — passed.
- Structured Codex autoreview — clean after fixing the initial negative-proof ordering finding; no accepted/actionable findings remain.
- Current upstream CI includes passing lint, production/test types, docs, architecture/boundary guards, QA smoke, and affected test shards.

## Notes

- AI-assisted change; the implementation and test results were reviewed locally.
- No config, CLI, or migration changes.
- Missing trusted ownership metadata intentionally fails closed for permission decisions while preserving ordinary message delivery. This compatibility choice still requires explicit maintainer acceptance.
