### PR TITLE
fix: show in-progress status for channel runs

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -194,7 +194,7 @@ import {
   loadOptionalServerMethodModelCatalog,
   startOptionalServerMethodModelCatalogLoad,
 } from "./optional-model-catalog.js";
-import { hasTrackedActiveSessionRun } from "./session-active-runs.js";
+import { hasTrackedActiveSessionRun, hasVisibleActiveSessionRun } from "./session-active-runs.js";
 import { emitSessionsChanged } from "./session-change-event.js";
 import type {
   GatewayClient,
@@ -3042,10 +3042,11 @@ async function handleChatHistoryRequest({
   });
   const activeRunAgentId =
     canonicalKey === "global" ? (selectedAgent.agentId ?? defaultAgentId) : selectedAgent.agentId;
-  sessionInfo.hasActiveRun = hasTrackedActiveSessionRun({
+  sessionInfo.hasActiveRun = hasVisibleActiveSessionRun({
     context,
     requestedKey: sessionKey,
     canonicalKey,
+    sessionId: entry?.sessionId,
     ...(activeRunAgentId ? { agentId: activeRunAgentId } : {}),
     defaultAgentId,
   });

--- a/src/gateway/server-methods/session-active-runs.ts
+++ b/src/gateway/server-methods/session-active-runs.ts
@@ -1,5 +1,6 @@
 // Session active-run helpers decide whether session operations should treat a
 // session as busy based on Control UI-visible active chat/agent runs.
+import { isEmbeddedAgentRunActive } from "../../agents/embedded-agent-runner/runs.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
 import type { GatewayRequestContext } from "./types.js";
 
@@ -83,4 +84,19 @@ export function hasTrackedActiveSessionRun(params: {
         params.defaultAgentId,
       ),
   );
+}
+
+export function hasVisibleActiveSessionRun(params: {
+  context: Partial<Pick<GatewayRequestContext, "chatAbortControllers">>;
+  requestedKey: string;
+  canonicalKey: string;
+  sessionId?: string;
+  agentId?: string;
+  defaultAgentId?: string;
+}): boolean {
+  if (hasTrackedActiveSessionRun(params)) {
+    return true;
+  }
+  const sessionId = params.sessionId?.trim();
+  return sessionId ? isEmbeddedAgentRunActive(sessionId) : false;
 }

--- a/src/gateway/server-methods/session-change-event.ts
+++ b/src/gateway/server-methods/session-change-event.ts
@@ -2,7 +2,7 @@
 import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import { buildGatewaySessionEventFields } from "../session-event-payload.js";
 import { loadGatewaySessionRow } from "../session-utils.js";
-import { hasTrackedActiveSessionRun } from "./session-active-runs.js";
+import { hasVisibleActiveSessionRun } from "./session-active-runs.js";
 import type { GatewayRequestContext } from "./types.js";
 
 export type SessionChangedPayload = {
@@ -45,10 +45,11 @@ export function emitSessionsChanged(
             ...buildGatewaySessionEventFields({
               sessionRow,
               agentId: payload.agentId,
-              hasActiveRun: hasTrackedActiveSessionRun({
+              hasActiveRun: hasVisibleActiveSessionRun({
                 context,
                 requestedKey: payload.sessionKey ?? sessionRow.key,
                 canonicalKey: sessionRow.key,
+                sessionId: sessionRow.sessionId,
                 agentId: sessionRow.key === "global" ? payload.agentId : undefined,
                 defaultAgentId,
               }),

--- a/src/gateway/server-methods/sessions.abort-agent-scope.test.ts
+++ b/src/gateway/server-methods/sessions.abort-agent-scope.test.ts
@@ -8,6 +8,7 @@ const chatAbortMock = vi.fn();
 const resolveSessionKeyForRunMock = vi.fn();
 const listSessionsFromStoreAsyncMock = vi.fn();
 const loadCombinedSessionStoreForGatewayMock = vi.fn();
+const isEmbeddedAgentRunActiveMock = vi.fn();
 const loadSessionEntryMock = vi.fn((sessionKey: string, _opts?: { agentId?: string }) => ({
   canonicalKey: sessionKey,
 }));
@@ -31,6 +32,16 @@ vi.mock("../session-utils.js", async () => {
       loadCombinedSessionStoreForGatewayMock(...args),
     loadSessionEntry: (...args: unknown[]) =>
       loadSessionEntryMock(...(args as [string, { agentId?: string }?])),
+  };
+});
+
+vi.mock("../../agents/embedded-agent-runner/runs.js", async () => {
+  const actual = await vi.importActual<typeof import("../../agents/embedded-agent-runner/runs.js")>(
+    "../../agents/embedded-agent-runner/runs.js",
+  );
+  return {
+    ...actual,
+    isEmbeddedAgentRunActive: (...args: unknown[]) => isEmbeddedAgentRunActiveMock(...args),
   };
 });
 
@@ -170,6 +181,8 @@ describe("sessions.abort agent scope", () => {
       store: {},
     });
     loadSessionEntryMock.mockClear();
+    isEmbeddedAgentRunActiveMock.mockReset();
+    isEmbeddedAgentRunActiveMock.mockReturnValue(false);
   });
 
   it("does not abort an active run whose session key belongs to another requested agent", async () => {
@@ -190,6 +203,39 @@ describe("sessions.abort agent scope", () => {
       abortedRunId: null,
       status: "no-active-run",
     });
+  });
+
+  it("marks listed sessions active when the embedded or channel reply run registry owns the session id", async () => {
+    const context = createContext({
+      extra: { loadGatewayModelCatalog: vi.fn().mockResolvedValue([]) },
+    });
+    listSessionsFromStoreAsyncMock.mockResolvedValue({
+      sessions: [{ key: "agent:main:openclaw-weixin:direct:user", sessionId: "sess-weixin" }],
+    });
+    isEmbeddedAgentRunActiveMock.mockImplementation(
+      (sessionId: string) => sessionId === "sess-weixin",
+    );
+
+    const respond = await callSessions(
+      "sessions.list",
+      { agentId: "main" },
+      { context, reqId: "req-channel-active" },
+    );
+
+    expect(isEmbeddedAgentRunActiveMock).toHaveBeenCalledWith("sess-weixin");
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        sessions: [
+          expect.objectContaining({
+            key: "agent:main:openclaw-weixin:direct:user",
+            sessionId: "sess-weixin",
+            hasActiveRun: true,
+          }),
+        ],
+      }),
+      undefined,
+    );
   });
 
   it("preserves runId-only aborts for active non-default agent runs", async () => {

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -124,7 +124,7 @@ import { resolveSessionKeyFromResolveParams } from "../sessions-resolve.js";
 import { setGatewayDedupeEntry } from "./agent-wait-dedupe.js";
 import { chatHandlers } from "./chat.js";
 import { loadOptionalServerMethodModelCatalog } from "./optional-model-catalog.js";
-import { hasTrackedActiveSessionRun } from "./session-active-runs.js";
+import { hasTrackedActiveSessionRun, hasVisibleActiveSessionRun } from "./session-active-runs.js";
 import { emitSessionsChanged } from "./session-change-event.js";
 import type {
   GatewayClient,
@@ -899,10 +899,11 @@ export const sessionsHandlers: GatewayRequestHandlers = {
           () => {
             return result.sessions.map((session) =>
               Object.assign({}, session, {
-                hasActiveRun: hasTrackedActiveSessionRun({
+                hasActiveRun: hasVisibleActiveSessionRun({
                   context,
                   requestedKey: session.key,
                   canonicalKey: session.key,
+                  sessionId: session.sessionId,
                   ...(session.key === "global" && p.agentId ? { agentId: p.agentId } : {}),
                   defaultAgentId: resolveDefaultAgentId(cfg),
                 }),

--- a/src/gateway/server-session-events.test.ts
+++ b/src/gateway/server-session-events.test.ts
@@ -4,9 +4,11 @@ import type { ChatAbortControllerEntry } from "./chat-abort.js";
 const sessionRow = vi.hoisted(() => ({
   key: "agent:main:main",
   kind: "direct",
+  sessionId: "sess-main",
   status: "done",
   updatedAt: 1,
 }));
+const isEmbeddedAgentRunActiveMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../config/io.js", () => ({ getRuntimeConfig: () => ({}) }));
 vi.mock("./chat-display-projection.js", () => ({
@@ -18,6 +20,15 @@ vi.mock("./session-utils.js", () => ({
   loadSessionEntry: () => ({ entry: undefined, storePath: "" }),
   readSessionMessageCountAsync: vi.fn(),
 }));
+vi.mock("../agents/embedded-agent-runner/runs.js", async () => {
+  const actual = await vi.importActual<typeof import("../agents/embedded-agent-runner/runs.js")>(
+    "../agents/embedded-agent-runner/runs.js",
+  );
+  return {
+    ...actual,
+    isEmbeddedAgentRunActive: (...args: unknown[]) => isEmbeddedAgentRunActiveMock(...args),
+  };
+});
 
 const { createTranscriptUpdateBroadcastHandler } = await import("./server-session-events.js");
 
@@ -62,6 +73,7 @@ async function emitAssistantTranscriptUpdate(
 describe("createTranscriptUpdateBroadcastHandler", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    isEmbeddedAgentRunActiveMock.mockReturnValue(false);
   });
 
   it("keeps transcript snapshots active while plugin finalization delays the terminal event", async () => {
@@ -81,6 +93,17 @@ describe("createTranscriptUpdateBroadcastHandler", () => {
       hasActiveRun: false,
       session: { hasActiveRun: false },
     });
+  });
+
+  it("keeps transcript snapshots active for embedded or channel reply runs", async () => {
+    isEmbeddedAgentRunActiveMock.mockImplementation((sessionId) => sessionId === "sess-main");
+
+    await expect(emitAssistantTranscriptUpdate(false)).resolves.toMatchObject({
+      sessionKey: "agent:main:main",
+      hasActiveRun: true,
+      session: { key: "agent:main:main", sessionId: "sess-main", hasActiveRun: true },
+    });
+    expect(isEmbeddedAgentRunActiveMock).toHaveBeenCalledWith("sess-main");
   });
 
   it("broadcasts user idempotency keys in session.message metadata", async () => {

--- a/src/gateway/server-session-events.ts
+++ b/src/gateway/server-session-events.ts
@@ -14,7 +14,7 @@ import type {
   SessionEventSubscriberRegistry,
   SessionMessageSubscriberRegistry,
 } from "./server-chat.js";
-import { hasTrackedActiveSessionRun } from "./server-methods/session-active-runs.js";
+import { hasVisibleActiveSessionRun } from "./server-methods/session-active-runs.js";
 import { buildGatewaySessionEventFields } from "./session-event-payload.js";
 import { resolveSessionKeyForTranscriptFile } from "./session-transcript-key.js";
 import {
@@ -167,10 +167,11 @@ async function handleTranscriptUpdateBroadcast(
     transcriptUsageMaxBytes: 64 * 1024,
   });
   const hasActiveRun = sessionRow
-    ? hasTrackedActiveSessionRun({
+    ? hasVisibleActiveSessionRun({
         context: params,
         requestedKey: sessionKey,
         canonicalKey: sessionRow.key,
+        sessionId: sessionRow.sessionId,
         ...(sessionRow.key === "global" && visibleAgentId ? { agentId: visibleAgentId } : {}),
         defaultAgentId: normalizeAgentId(resolveDefaultAgentId(getRuntimeConfig())),
       })


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users sending messages through a channel such as Weixin would not see the Control UI run status switch to "In progress" while the agent loop was running.

WebChat-started runs already showed the active state, but channel-started reply runs could leave the session row looking idle in Control UI.

## Why This Change Was Made

This routes every gateway session payload that projects `hasActiveRun` through a single visible active-run helper. The helper keeps the existing Control UI chat abort-controller behavior and also checks the embedded/channel reply-run registry by `sessionId`, so list, startup/history, session-change, and transcript-message snapshots all agree.

## User Impact

Users can now watch channel-triggered agent work in Control UI and see the same "In progress" status they already get for WebChat-triggered runs.

## Evidence

- Focused tests:
  - `pnpm test src/gateway/server-session-events.test.ts src/gateway/server-methods/sessions.abort-agent-scope.test.ts`
  - Result: 4 files passed, 50 tests passed.
- Formatting/diff guard:
  - `git diff --check HEAD`
  - Result: passed.
- Local ClawSweeper review:
  - `pnpm run review -- --local-only --local-range --target-repo openclaw/openclaw --target-dir ../openclaw --base origin/main --codex-timeout-ms 600000`
  - Result: `review_status: complete`, `Overall correctness: patch is correct`, `Full review comments: none`.
- Manual video proof:
  - Before fix: 
  

https://github.com/user-attachments/assets/bac7f0d8-c752-46d8-bf18-b41e6bd8cbbd


  - After fix: 


https://github.com/user-attachments/assets/f399bae2-fe16-47e5-90c4-92e5170d5934


