### PR TITLE
fix(exec): bind Windows allowlist execution path

### DIFF
--- a/package.json
+++ b/package.json
@@ -1926,7 +1926,7 @@
     "test:unit:fast:audit": "node scripts/test-unit-fast-audit.mjs",
     "test:voicecall:closedloop": "node scripts/test-voicecall-closedloop.mjs",
     "test:watch": "node scripts/test-projects.mjs --watch",
-    "test:windows:ci": "node scripts/test-projects.mjs src/shared/runtime-import.test.ts src/process/exec.windows.test.ts src/process/windows-command.test.ts src/infra/windows-install-roots.test.ts extensions/lobster/src/lobster-runner.test.ts test/scripts/format-generated-module.test.ts test/scripts/npm-runner.test.ts test/scripts/pnpm-runner.test.ts test/scripts/run-with-env.test.ts test/scripts/ui.test.ts test/scripts/vitest-process-group.test.ts",
+    "test:windows:ci": "node scripts/test-projects.mjs src/shared/runtime-import.test.ts src/process/exec.windows.test.ts src/process/windows-command.test.ts src/infra/windows-install-roots.test.ts src/node-host/invoke-system-run-allowlist.test.ts extensions/lobster/src/lobster-runner.test.ts test/scripts/format-generated-module.test.ts test/scripts/npm-runner.test.ts test/scripts/pnpm-runner.test.ts test/scripts/run-with-env.test.ts test/scripts/ui.test.ts test/scripts/vitest-process-group.test.ts",
     "tool-display:check": "node --import tsx scripts/tool-display.ts --check",
     "tool-display:write": "node --import tsx scripts/tool-display.ts --write",
     "ts-topology": "node --import tsx scripts/ts-topology.ts",

--- a/src/node-host/invoke-system-run-allowlist.test.ts
+++ b/src/node-host/invoke-system-run-allowlist.test.ts
@@ -1,6 +1,6 @@
 /** Tests system.run allowlist planning, output truncation, and argv resolution. */
 import { describe, expect, it } from "vitest";
-import { resolveExecApprovalsFromFile } from "../infra/exec-approvals.js";
+import { resolveExecApprovalsFromFile, type ExecCommandSegment } from "../infra/exec-approvals.js";
 import { planShellAuthorization } from "../infra/exec-authorization-plan.js";
 import { resolveExecSafeBinRuntimePolicy } from "../infra/exec-safe-bin-runtime-policy.js";
 import { resolveSystemRunExecArgv } from "./invoke-system-run-allowlist.js";
@@ -18,7 +18,65 @@ function resolveAllowlistApprovals() {
   });
 }
 
+function resolveWindowsShellExecArgv(segment: ExecCommandSegment) {
+  return resolveSystemRunExecArgv({
+    plannedAllowlistArgv: undefined,
+    argv: ["powershell.exe", "-Command", "safe --version"],
+    security: "allowlist",
+    approvals: resolveAllowlistApprovals(),
+    safeBins: new Set(),
+    safeBinProfiles: {},
+    trustedSafeBinDirs: new Set(),
+    skillBins: [],
+    autoAllowSkills: false,
+    isWindows: true,
+    policy: {
+      approvedByAsk: false,
+      analysisOk: true,
+      allowlistSatisfied: true,
+    },
+    shellCommand: "safe --version",
+    segments: [segment],
+    segmentSatisfiedBy: ["allowlist"],
+    authorizationPlan: undefined,
+    cwd: "C:\\workspace",
+    env: undefined,
+  });
+}
+
 describe("resolveSystemRunExecArgv", () => {
+  it("pins Windows shell execution to the resolved allowlisted executable", async () => {
+    const trustedExecutable = "C:\\trusted-bin\\safe.exe";
+    const result = await resolveWindowsShellExecArgv({
+      raw: "safe --version",
+      argv: ["safe", "--version"],
+      resolution: {
+        execution: {
+          rawExecutable: "safe",
+          resolvedPath: trustedExecutable,
+          executableName: "safe.exe",
+        },
+        policy: {
+          rawExecutable: "safe",
+          resolvedPath: trustedExecutable,
+          executableName: "safe.exe",
+        },
+      },
+    });
+
+    expect(result).toEqual([trustedExecutable, "--version"]);
+  });
+
+  it("fails closed when Windows shell execution has no resolved plan", async () => {
+    const result = await resolveWindowsShellExecArgv({
+      raw: "safe --version",
+      argv: ["safe", "--version"],
+      resolution: null,
+    });
+
+    expect(result).toBeNull();
+  });
+
   it.runIf(process.platform !== "win32")(
     "fails closed when shell rewriting has no authorization plan",
     async () => {

--- a/src/node-host/invoke-system-run-allowlist.test.ts
+++ b/src/node-host/invoke-system-run-allowlist.test.ts
@@ -113,12 +113,10 @@ describe("resolveSystemRunExecArgv", () => {
         policyBlocked: true,
         execution: {
           rawExecutable: "safe",
-          resolvedPath: null,
           executableName: "safe",
         },
         policy: {
           rawExecutable: "safe",
-          resolvedPath: null,
           executableName: "safe",
         },
       },

--- a/src/node-host/invoke-system-run-allowlist.test.ts
+++ b/src/node-host/invoke-system-run-allowlist.test.ts
@@ -1,9 +1,16 @@
 /** Tests system.run allowlist planning, output truncation, and argv resolution. */
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { resolveExecApprovalsFromFile, type ExecCommandSegment } from "../infra/exec-approvals.js";
 import { planShellAuthorization } from "../infra/exec-authorization-plan.js";
 import { resolveExecSafeBinRuntimePolicy } from "../infra/exec-safe-bin-runtime-policy.js";
-import { resolveSystemRunExecArgv } from "./invoke-system-run-allowlist.js";
+import {
+  evaluateSystemRunAllowlist,
+  resolveSystemRunExecArgv,
+} from "./invoke-system-run-allowlist.js";
 
 function resolveAllowlistApprovals() {
   return resolveExecApprovalsFromFile({
@@ -44,6 +51,27 @@ function resolveWindowsShellExecArgv(segment: ExecCommandSegment) {
   });
 }
 
+function runExecutable(params: {
+  argv: string[];
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+}): Promise<{ exitCode: number | null; stdout: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(params.argv[0], params.argv.slice(1), {
+      cwd: params.cwd,
+      env: params.env,
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+    });
+    const stdout: Buffer[] = [];
+    child.stdout.on("data", (chunk: Buffer) => stdout.push(chunk));
+    child.once("error", reject);
+    child.once("close", (exitCode) => {
+      resolve({ exitCode, stdout: Buffer.concat(stdout).toString("utf8") });
+    });
+  });
+}
+
 describe("resolveSystemRunExecArgv", () => {
   it("pins Windows shell execution to the resolved allowlisted executable", async () => {
     const trustedExecutable = "C:\\trusted-bin\\safe.exe";
@@ -76,6 +104,93 @@ describe("resolveSystemRunExecArgv", () => {
 
     expect(result).toBeNull();
   });
+
+  it.runIf(process.platform === "win32")(
+    "executes the allowlisted path instead of a workspace shadow executable",
+    async () => {
+      const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-windows-shadow-"));
+      const trustedBin = path.join(fixtureRoot, "trusted-bin");
+      const workspace = path.join(fixtureRoot, "workspace");
+      fs.mkdirSync(trustedBin);
+      fs.mkdirSync(workspace);
+      const trustedExecutable = path.join(trustedBin, "safe.exe");
+      const shadowExecutable = path.join(workspace, "safe.exe");
+      const systemRoot = process.env.SystemRoot ?? process.env.WINDIR ?? "C:\\Windows";
+      fs.copyFileSync(path.join(systemRoot, "System32", "cmd.exe"), trustedExecutable);
+      fs.copyFileSync(path.join(systemRoot, "System32", "where.exe"), shadowExecutable);
+      const env = {
+        ...process.env,
+        PATH: `${trustedBin}${path.delimiter}${process.env.PATH ?? ""}`,
+        PATHEXT: process.env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD",
+      };
+      const shellCommand = "safe /d /s /c echo TRUSTED_EXECUTABLE";
+      const commandTail = ["/d", "/s", "/c", "echo", "TRUSTED_EXECUTABLE"];
+
+      try {
+        const bareResult = await runExecutable({
+          argv: ["safe", ...commandTail],
+          cwd: workspace,
+          env,
+        });
+        expect(bareResult.exitCode).not.toBe(0);
+        expect(bareResult.stdout).not.toContain("TRUSTED_EXECUTABLE");
+
+        const approvals = resolveExecApprovalsFromFile({
+          file: {
+            version: 1,
+            defaults: { security: "allowlist", ask: "off", askFallback: "deny" },
+            agents: { main: { allowlist: [{ pattern: trustedExecutable }] } },
+          },
+        });
+        const analysis = await evaluateSystemRunAllowlist({
+          shellCommand,
+          argv: ["powershell.exe", "-Command", shellCommand],
+          approvals,
+          security: "allowlist",
+          safeBins: new Set(),
+          safeBinProfiles: {},
+          trustedSafeBinDirs: new Set(),
+          cwd: workspace,
+          env,
+          skillBins: [],
+          autoAllowSkills: false,
+        });
+        expect(analysis.analysisOk).toBe(true);
+        expect(analysis.allowlistSatisfied).toBe(true);
+
+        const execArgv = await resolveSystemRunExecArgv({
+          plannedAllowlistArgv: undefined,
+          argv: ["powershell.exe", "-Command", shellCommand],
+          security: "allowlist",
+          approvals,
+          safeBins: new Set(),
+          safeBinProfiles: {},
+          trustedSafeBinDirs: new Set(),
+          skillBins: [],
+          autoAllowSkills: false,
+          isWindows: true,
+          policy: {
+            approvedByAsk: false,
+            analysisOk: analysis.analysisOk,
+            allowlistSatisfied: analysis.allowlistSatisfied,
+          },
+          shellCommand,
+          segments: analysis.segments,
+          segmentSatisfiedBy: analysis.segmentSatisfiedBy,
+          authorizationPlan: analysis.authorizationPlan,
+          cwd: workspace,
+          env,
+        });
+        expect(execArgv?.[0]).toBe(fs.realpathSync(trustedExecutable));
+
+        const fixedResult = await runExecutable({ argv: execArgv ?? [], cwd: workspace, env });
+        expect(fixedResult.exitCode).toBe(0);
+        expect(fixedResult.stdout).toContain("TRUSTED_EXECUTABLE");
+      } finally {
+        fs.rmSync(fixtureRoot, { recursive: true, force: true });
+      }
+    },
+  );
 
   it.runIf(process.platform !== "win32")(
     "fails closed when shell rewriting has no authorization plan",

--- a/src/node-host/invoke-system-run-allowlist.test.ts
+++ b/src/node-host/invoke-system-run-allowlist.test.ts
@@ -95,11 +95,33 @@ describe("resolveSystemRunExecArgv", () => {
     expect(result).toEqual([trustedExecutable, "--version"]);
   });
 
-  it("fails closed when Windows shell execution has no resolved plan", async () => {
+  it("preserves unresolved Windows shell argv authorized by a bare wildcard", async () => {
     const result = await resolveWindowsShellExecArgv({
       raw: "safe --version",
       argv: ["safe", "--version"],
       resolution: null,
+    });
+
+    expect(result).toEqual(["safe", "--version"]);
+  });
+
+  it("fails closed when the Windows shell execution plan is blocked", async () => {
+    const result = await resolveWindowsShellExecArgv({
+      raw: "safe --version",
+      argv: ["safe", "--version"],
+      resolution: {
+        policyBlocked: true,
+        execution: {
+          rawExecutable: "safe",
+          resolvedPath: null,
+          executableName: "safe",
+        },
+        policy: {
+          rawExecutable: "safe",
+          resolvedPath: null,
+          executableName: "safe",
+        },
+      },
     });
 
     expect(result).toBeNull();

--- a/src/node-host/invoke-system-run-allowlist.ts
+++ b/src/node-host/invoke-system-run-allowlist.ts
@@ -165,11 +165,19 @@ export async function resolveSystemRunExecArgv(params: {
     params.shellCommand &&
     params.policy.analysisOk &&
     params.policy.allowlistSatisfied &&
-    params.segments.length === 1 &&
-    params.segments[0]?.argv.length > 0
+    params.segments.length === 1
   ) {
-    // Windows shell transports expose a parsed argv segment that is safer than the wrapper argv.
-    execArgv = params.segments[0].argv;
+    // Bind execution to the path resolved during allowlist analysis. A bare
+    // executable would let Windows search cwd before PATH and run a shadow binary.
+    const segment = params.segments[0];
+    const resolvedExecutable =
+      segment.resolution?.execution.resolvedRealPath?.trim() ??
+      segment.resolution?.execution.resolvedPath?.trim();
+    const plannedArgv = resolvePlannedSegmentArgv(segment);
+    if (!resolvedExecutable || !plannedArgv) {
+      return null;
+    }
+    execArgv = plannedArgv;
   }
   if (
     params.security === "allowlist" &&

--- a/src/node-host/invoke-system-run-allowlist.ts
+++ b/src/node-host/invoke-system-run-allowlist.ts
@@ -167,14 +167,10 @@ export async function resolveSystemRunExecArgv(params: {
     params.policy.allowlistSatisfied &&
     params.segments.length === 1
   ) {
-    // Bind execution to the path resolved during allowlist analysis. A bare
-    // executable would let Windows search cwd before PATH and run a shadow binary.
-    const segment = params.segments[0];
-    const resolvedExecutable =
-      segment.resolution?.execution.resolvedRealPath?.trim() ??
-      segment.resolution?.execution.resolvedPath?.trim();
-    const plannedArgv = resolvePlannedSegmentArgv(segment);
-    if (!resolvedExecutable || !plannedArgv) {
+    // Exact-path matches stay bound to the resolved executable, while the bare
+    // wildcard contract can still authorize unresolved Windows commands.
+    const plannedArgv = resolvePlannedSegmentArgv(params.segments[0]);
+    if (!plannedArgv) {
       return null;
     }
     execArgv = plannedArgv;


### PR DESCRIPTION
## Summary

### What Problem This Solves

Fixes an issue where Windows node-host users relying on exec allowlists could have an approved PowerShell payload execute through an ambiguous executable name instead of the executable identity established during policy analysis.

## Changes

### Why This Change Was Made

The Windows shell execution path now uses the existing analyzed execution plan. Exact-path matches launch the resolved executable, unresolved commands authorized by the shipped bare-wildcard contract retain their original argv, and blocked plans fail closed.

- Pin exact-path Windows shell execution to the resolved executable path.
- Preserve existing bare-wildcard behavior for unresolved Windows commands.
- Deny execution when the analyzed plan is explicitly blocked or invalid.
- Add focused unit and native Windows behavioral regression coverage.
- Include the regression file in the Windows CI lane.

## Validation

### Evidence

- `node scripts/run-vitest.mjs src/node-host/invoke-system-run-allowlist.test.ts src/infra/exec-allowlist-matching.test.ts src/infra/exec-approvals-analysis.test.ts src/node-host/invoke-system-run.test.ts` — 83 tests passed, one platform-specific test skipped.
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --pretty false` — passed.
- Native Windows workflow run 28472073797 — all seven Windows Vitest shards passed, including the real workspace-shadow execution proof.
- `node_modules/.bin/oxfmt --check src/node-host/invoke-system-run-allowlist.test.ts` — passed.
- `git diff --check` — passed.
- Fresh structured Auto Review after the compatibility update — no accepted/actionable findings; patch judged correct.

## Notes

### User Impact

Windows exact-path allowlist users can expect node-host execution to launch the same resolved executable that satisfied policy. Existing bare-wildcard configurations retain their unresolved-command behavior, while explicitly blocked execution plans remain denied.

AI-assisted: yes.
