### PR TITLE
feat: add one-step gateway setup pairing

### DIFF
--- a/docs/channels/pairing.md
+++ b/docs/channels/pairing.md
@@ -113,8 +113,12 @@ If you use the `device-pair` plugin, you can do first-time device pairing entire
 1. In Telegram, message your bot: `/pair`
 2. The bot replies with two messages: an instruction message and a separate **setup code** message (easy to copy/paste in Telegram).
 3. On your phone, open the OpenClaw iOS app → Settings → Gateway.
-4. Scan the QR code or paste the setup code and connect.
-5. Back in Telegram: `/pair pending` (review request IDs, role, and scopes), then approve.
+4. Scan the QR code or paste the setup code and connect. For the built-in
+   setup-code mobile baseline, the Gateway silently approves the fresh mobile
+   device and its node pairing during the bootstrap handshake.
+5. Back in Telegram: `/pair pending` only if the app reports a pending repair or
+   upgrade. Review request IDs, role, scopes, and capability changes before
+   approving.
 
 The setup code is a base64-encoded JSON payload that contains:
 
@@ -127,13 +131,17 @@ That bootstrap token carries the built-in pairing bootstrap profile:
   `node` plus a bounded `operator` handoff
 - the handed-off `node` token stays `scopes: []`
 - the handed-off `operator` token is limited to `operator.approvals`,
-  `operator.read`, and `operator.write`
+  `operator.read`, `operator.talk.secrets`, and `operator.write`
 - `operator.admin` and `operator.pairing` are not granted by QR/setup-code
   bootstrap; they require a separate approved operator pairing or token flow
 - later token rotation/revocation remains bounded by both the device's approved
   role contract and the caller session's operator scopes
 
-Treat the setup code like a password while it is valid.
+Treat the setup code like a password while it is valid. `openclaw qr` also
+prints an 8-character setup short code. The short code is a 5-minute, single-use
+pointer to the same setup-code payload on that Gateway. A QR/setup code carries
+the Gateway URL directly; a bare short code still requires the app to know which
+Gateway host to redeem against.
 
 For Tailscale, public, or other remote mobile pairing, use Tailscale Serve/Funnel
 or another `wss://` Gateway URL. Plaintext `ws://` setup codes are accepted only
@@ -141,12 +149,14 @@ for loopback, private LAN addresses, `.local` Bonjour hosts, and the Android
 emulator host. Tailnet CGNAT addresses, `.ts.net` names, and public hosts still
 fail closed before QR/setup-code issuance.
 
-### Approve a node device
+### Approve a node device or upgrade
 
 ```bash
 openclaw devices list
 openclaw devices approve <requestId>
 openclaw devices reject <requestId>
+openclaw nodes pending
+openclaw nodes approve <requestId>
 ```
 
 When an explicit approval is denied because the approving paired-device session

--- a/docs/cli/qr.md
+++ b/docs/cli/qr.md
@@ -29,14 +29,18 @@ openclaw qr --url wss://gateway.example/ws
 - `--password <password>`: override which gateway password the bootstrap flow authenticates against
 - `--setup-code-only`: print only setup code
 - `--no-ascii`: skip ASCII QR rendering
-- `--json`: emit JSON (`setupCode`, `gatewayUrl`, `auth`, `urlSource`)
+- `--json`: emit JSON (`setupCode`, optional `shortCode`/`shortCodeExpiresAtMs`, `gatewayUrl`, `auth`, `urlSource`)
 
 ## Notes
 
 - `--token` and `--password` are mutually exclusive.
 - The setup code itself now carries an opaque short-lived `bootstrapToken`, not the shared gateway token/password.
+- Normal QR/setup-code mobile onboarding is one step: scan the QR or paste the setup code, then the app connects with bootstrap auth and the Gateway silently approves the fresh baseline mobile device plus its node pairing.
+- `openclaw qr` also prints an 8-character setup short code. The short code is a 5-minute, single-use pointer to the same setup-code payload on that Gateway. A bare short code still needs the app to know which Gateway host to redeem against; the QR/setup code carries the Gateway URL directly.
 - Built-in setup-code bootstrap returns a primary `node` token with `scopes: []` plus a bounded `operator` handoff token for trusted mobile onboarding.
 - The handed-off operator token is limited to `operator.approvals`, `operator.read`, `operator.talk.secrets`, and `operator.write`; `operator.admin` and `operator.pairing` require a separate approved operator pairing or token flow.
+- Auto-approval is limited to the fresh setup-code mobile baseline. Later role, scope, metadata, or node capability upgrades still create pending requests that require explicit approval.
+- Dangerous node commands such as camera capture, screen recording, contact/calendar writes, and SMS are still excluded unless explicitly enabled with `gateway.nodes.allowCommands`; `gateway.nodes.denyCommands` still removes matching mobile node commands from the auto-approved baseline.
 - Mobile pairing fails closed for Tailscale/public `ws://` gateway URLs. Private LAN addresses and `.local` Bonjour hosts remain supported over `ws://`, but Tailscale/public mobile routes should use Tailscale Serve/Funnel or a `wss://` gateway URL.
 - With `--remote`, OpenClaw requires either `gateway.remote.url` or
   `gateway.tailscale.mode=serve|funnel`.
@@ -46,9 +50,10 @@ openclaw qr --url wss://gateway.example/ws
   - `gateway.auth.password` resolves when password auth can win (explicit `gateway.auth.mode="password"` or inferred mode with no winning token from auth/env).
 - If both `gateway.auth.token` and `gateway.auth.password` are configured (including SecretRefs) and `gateway.auth.mode` is unset, setup-code resolution fails until mode is set explicitly.
 - Gateway version skew note: this command path requires a gateway that supports `secrets.resolve`; older gateways return an unknown-method error.
-- After scanning, approve device pairing with:
+- If onboarding reports a pending repair or upgrade instead of connecting, review it with:
   - `openclaw devices list`
-  - `openclaw devices approve <requestId>`
+  - `openclaw nodes pending`
+  - `openclaw devices approve <requestId>` or `openclaw nodes approve <requestId>`
 
 ## Related
 

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -756,7 +756,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H3: Where the state lives
   - H2: 2) Node device pairing (iOS/Android/macOS/headless nodes)
   - H3: Pair via Telegram (recommended for iOS)
-  - H3: Approve a node device
+  - H3: Approve a node device or upgrade
   - H3: Optional trusted-CIDR node auto-approve
   - H3: Node pairing state storage
   - H3: Notes
@@ -3555,6 +3555,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
 - Headings:
   - H2: Transport
   - H2: Handshake (connect)
+  - H3: Setup Short-Code Redeem
   - H3: Node example
   - H2: Framing
   - H2: Roles + scopes

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -177,6 +177,40 @@ a separate approved operator pairing or token flow. Clients should persist
 when the connect used bootstrap auth on trusted transport such as `wss://` or
 loopback/local pairing.
 
+For current native onboarding, that same baseline setup-code bootstrap can also
+silently approve the fresh mobile device and its first node pairing. This is
+limited to the built-in setup profile and mobile client metadata. Later role,
+scope, device metadata, or node capability changes still create pending pairing
+requests for explicit review.
+
+### Setup Short-Code Redeem
+
+`POST /api/v1/pairing/setup-code/redeem` redeems the 8-character setup short
+code printed by `openclaw qr` into the canonical setup-code payload:
+
+```json
+{ "code": "ABCD2345" }
+```
+
+Success:
+
+```json
+{
+  "ok": true,
+  "payload": {
+    "url": "wss://gateway.example.com",
+    "bootstrapToken": "…"
+  },
+  "expiresAtMs": 1737264300000
+}
+```
+
+The endpoint is intentionally pre-auth so a fresh mobile app can redeem a code.
+The short code is single-use, expires after 5 minutes, is rate-limited per
+client IP, and points only to the same setup-code payload that the QR/setup-code
+path would have carried. It does not expose the long-lived shared Gateway token
+or password by default.
+
 ### Node example
 
 ```json

--- a/src/cli/qr-cli.test.ts
+++ b/src/cli/qr-cli.test.ts
@@ -12,6 +12,13 @@ const mocks = vi.hoisted(() => ({
     diagnostics: [] as string[],
   })),
   renderTerminal: vi.fn(async () => "ASCII-QR"),
+  registerShortCode: vi.fn(() => ({
+    ok: true as const,
+    code: "ABCD2345",
+    expiresAtMs: 456,
+    authLabel: "token" as const,
+    urlSource: "test",
+  })),
 }));
 const { defaultRuntime: runtime, resetRuntimeCapture } = createCliRuntimeCapture();
 const runtimeLog = runtime.log;
@@ -32,6 +39,10 @@ vi.mock("../process/exec.js", () => ({ runCommandWithTimeout: mocks.runCommandWi
 vi.mock("../media/qr-terminal.ts", () => ({
   renderQrTerminal: mocks.renderTerminal,
 }));
+vi.mock("../pairing/setup-short-code.js", () => ({
+  formatPairingSetupShortCode: (code: string) => `${code.slice(0, 4)}-${code.slice(4)}`,
+  registerPairingSetupShortCode: mocks.registerShortCode,
+}));
 vi.mock("./command-secret-gateway.js", () => ({
   resolveCommandSecretRefsViaGateway: mocks.resolveCommandSecretRefsViaGateway,
 }));
@@ -45,6 +56,7 @@ const loadConfig = mocks.loadConfig;
 const runCommandWithTimeout = mocks.runCommandWithTimeout;
 const resolveCommandSecretRefsViaGateway = mocks.resolveCommandSecretRefsViaGateway;
 const renderTerminal = mocks.renderTerminal;
+const registerShortCode = mocks.registerShortCode;
 
 const { registerQrCli } = await import("./qr-cli.js");
 
@@ -140,6 +152,8 @@ describe("registerQrCli", () => {
     const raw = calls[calls.length - 1]?.[0];
     return JSON.parse(typeof raw === "string" ? raw : "{}") as {
       setupCode?: string;
+      shortCode?: string;
+      shortCodeExpiresAtMs?: number;
       gatewayUrl?: string;
       auth?: string;
       urlSource?: string;
@@ -197,6 +211,7 @@ describe("registerQrCli", () => {
     });
     expect(runtime.log).toHaveBeenCalledWith(expected);
     expect(renderTerminal).not.toHaveBeenCalled();
+    expect(registerShortCode).not.toHaveBeenCalled();
     expect(resolveCommandSecretRefsViaGateway).not.toHaveBeenCalled();
   });
 
@@ -215,8 +230,66 @@ describe("registerQrCli", () => {
     const output = runtimeLog.mock.calls.map((call) => readRuntimeCallText(call)).join("\n");
     expect(output).toContain("Pairing QR");
     expect(output).toContain("ASCII-QR");
+    expect(output).toContain("Short code:");
+    expect(output).toContain("ABCD-2345");
     expect(output).toContain("Gateway:");
+    expect(output).toContain("Fresh mobile setup auto-approves");
+    expect(output).toContain("openclaw nodes pending");
     expect(output).toContain("openclaw devices approve <requestId>");
+    expect(output).toContain("openclaw nodes approve <requestId>");
+    expect(registerShortCode).toHaveBeenCalledWith({
+      payload: {
+        url: "ws://127.0.0.1:18789",
+        bootstrapToken: "bootstrap-123",
+      },
+      authLabel: "token",
+      urlSource: "gateway.bind=custom",
+    });
+  });
+
+  it("still prints the setup QR when short-code registration is unavailable", async () => {
+    loadConfig.mockReturnValue({
+      gateway: {
+        bind: "custom",
+        customBindHost: "127.0.0.1",
+        auth: { mode: "token", token: "tok" },
+      },
+    });
+    registerShortCode.mockImplementationOnce(() => {
+      throw new Error("state unavailable");
+    });
+
+    await runQr([]);
+
+    expect(renderTerminal).toHaveBeenCalledTimes(1);
+    const output = runtimeLog.mock.calls.map((call) => readRuntimeCallText(call)).join("\n");
+    expect(output).toContain("Pairing QR");
+    expect(output).toContain("ASCII-QR");
+    expect(output).toContain("Short code:");
+    expect(output).toContain("unavailable");
+    expect(output).toContain("Setup code:");
+    expect(output).toContain("Gateway:");
+  });
+
+  it("omits unavailable short-code fields from json output", async () => {
+    loadConfig.mockReturnValue({
+      gateway: {
+        bind: "custom",
+        customBindHost: "127.0.0.1",
+        auth: { mode: "token", token: "tok" },
+      },
+    });
+    registerShortCode.mockImplementationOnce(() => {
+      throw new Error("state unavailable");
+    });
+
+    await runQr(["--json"]);
+
+    const payload = parseLastLoggedQrJson();
+    expect(payload.setupCode).toBeTruthy();
+    expect(payload.gatewayUrl).toBe("ws://127.0.0.1:18789");
+    expect(payload.shortCode).toBeUndefined();
+    expect(payload.shortCodeExpiresAtMs).toBeUndefined();
   });
 
   it("fails fast for insecure remote mobile pairing setup urls", async () => {
@@ -482,8 +555,11 @@ describe("registerQrCli", () => {
 
     const payload = parseLastLoggedQrJson();
     expect(payload.gatewayUrl).toBe("wss://remote.example.com:444");
+    expect(payload.shortCode).toBeUndefined();
+    expect(payload.shortCodeExpiresAtMs).toBeUndefined();
     expect(payload.auth).toBe("token");
     expect(payload.urlSource).toBe("gateway.remote.url");
+    expect(registerShortCode).not.toHaveBeenCalled();
     expect(runCommandWithTimeout).not.toHaveBeenCalled();
   });
 
@@ -545,7 +621,10 @@ describe("registerQrCli", () => {
 
     const payload = parseLastLoggedQrJson();
     expect(payload.gatewayUrl).toBe("wss://ts-host.tailnet.ts.net");
+    expect(payload.shortCode).toBe("ABCD2345");
+    expect(payload.shortCodeExpiresAtMs).toBe(456);
     expect(payload.auth).toBe("token");
     expect(payload.urlSource).toBe("gateway.tailscale.mode=serve");
+    expect(registerShortCode).toHaveBeenCalled();
   });
 });

--- a/src/cli/qr-cli.ts
+++ b/src/cli/qr-cli.ts
@@ -9,6 +9,11 @@ import { trimToUndefined } from "../gateway/credentials.js";
 import { resolveRequiredConfiguredSecretRefInputString } from "../gateway/resolve-configured-secret-input-string.js";
 import { renderQrTerminal } from "../media/qr-terminal.ts";
 import { resolvePairingSetupFromConfig, encodePairingSetupCode } from "../pairing/setup-code.js";
+import {
+  formatPairingSetupShortCode,
+  registerPairingSetupShortCode,
+  type PairingSetupShortCodeIssueResult,
+} from "../pairing/setup-short-code.js";
 import { runCommandWithTimeout } from "../process/exec.js";
 import { defaultRuntime } from "../runtime.js";
 import { resolveCommandSecretRefsViaGateway } from "./command-secret-gateway.js";
@@ -28,6 +33,31 @@ type QrCliOptions = {
 function renderQrAscii(data: string): Promise<string> {
   return renderQrTerminal(data);
 }
+
+function tryRegisterPairingSetupShortCode(
+  params: Parameters<typeof registerPairingSetupShortCode>[0],
+): PairingSetupShortCodeIssueResult {
+  try {
+    return registerPairingSetupShortCode(params);
+  } catch {
+    return { ok: false, error: "short code unavailable" };
+  }
+}
+
+function shouldRegisterPairingSetupShortCode(params: {
+  explicitUrl?: string;
+  urlSource: string;
+}): boolean {
+  if (params.explicitUrl) {
+    return false;
+  }
+  return (
+    params.urlSource.startsWith("gateway.bind=") ||
+    params.urlSource.startsWith("gateway.tailscale.mode=") ||
+    params.urlSource === "plugins.entries.device-pair.config.publicUrl"
+  );
+}
+
 function readDevicePairPublicUrlFromConfig(cfg: OpenClawConfig): string | undefined {
   const value = cfg.plugins?.entries?.["device-pair"]?.config?.["publicUrl"];
   if (typeof value !== "string") {
@@ -216,9 +246,22 @@ export function registerQrCli(program: Command) {
           return;
         }
 
+        const shortCode = shouldRegisterPairingSetupShortCode({
+          explicitUrl,
+          urlSource: resolved.urlSource,
+        })
+          ? tryRegisterPairingSetupShortCode({
+              payload: resolved.payload,
+              authLabel: resolved.authLabel,
+              urlSource: resolved.urlSource,
+            })
+          : ({ ok: false, error: "short code unavailable" } satisfies PairingSetupShortCodeIssueResult);
+
         if (opts.json) {
           defaultRuntime.writeJson({
             setupCode,
+            shortCode: shortCode.ok ? shortCode.code : undefined,
+            shortCodeExpiresAtMs: shortCode.ok ? shortCode.expiresAtMs : undefined,
             gatewayUrl: resolved.payload.url,
             auth: resolved.authLabel,
             urlSource: resolved.urlSource,
@@ -238,14 +281,18 @@ export function registerQrCli(program: Command) {
         }
 
         lines.push(
+          `${theme.muted("Short code:")} ${shortCode.ok ? formatPairingSetupShortCode(shortCode.code) : "unavailable"}`,
           `${theme.muted("Setup code:")} ${setupCode}`,
           `${theme.muted("Gateway:")} ${resolved.payload.url}`,
           `${theme.muted("Auth:")} ${resolved.authLabel}`,
           `${theme.muted("Source:")} ${resolved.urlSource}`,
           "",
-          "Approve after scan with:",
+          "Fresh mobile setup auto-approves the baseline device and node.",
+          "If an upgraded surface remains pending:",
           `  ${theme.command("openclaw devices list")}`,
+          `  ${theme.command("openclaw nodes pending")}`,
           `  ${theme.command("openclaw devices approve <requestId>")}`,
+          `  ${theme.command("openclaw nodes approve <requestId>")}`,
         );
 
         defaultRuntime.log(lines.join("\n"));

--- a/src/gateway/auth-rate-limit.ts
+++ b/src/gateway/auth-rate-limit.ts
@@ -55,6 +55,7 @@ export const AUTH_RATE_LIMIT_SCOPE_NODE_REAPPROVAL = "node-reapproval";
 // device signature can queue the bootstrap-pairing flow behind their
 // requests, blocking legitimate node onboarding during the attack.
 export const AUTH_RATE_LIMIT_SCOPE_BOOTSTRAP_TOKEN = "bootstrap-token";
+export const AUTH_RATE_LIMIT_SCOPE_PAIRING_SETUP_SHORT_CODE = "pairing-setup-short-code";
 export const AUTH_RATE_LIMIT_SCOPE_HOOK_AUTH = "hook-auth";
 const BROWSER_ORIGIN_RATE_LIMIT_KEY_PREFIX = "browser-origin:";
 const IDENTITY_RATE_LIMIT_KEY_PREFIX = "identity:";

--- a/src/gateway/hooks-test-helpers.ts
+++ b/src/gateway/hooks-test-helpers.ts
@@ -1,5 +1,6 @@
 // Gateway hook test fixtures.
 // Builds resolved hook config and IncomingMessage-like requests for tests.
+import { EventEmitter } from "node:events";
 import type { IncomingMessage } from "node:http";
 import type { HooksConfigResolved } from "./hooks.js";
 
@@ -31,6 +32,7 @@ export function createGatewayRequest(params: {
   remoteAddress?: string;
   host?: string;
   headers?: Record<string, string>;
+  body?: string;
 }): IncomingMessage {
   const headers: Record<string, string> = {
     host: params.host ?? "localhost:18789",
@@ -39,10 +41,44 @@ export function createGatewayRequest(params: {
   if (params.authorization) {
     headers.authorization = params.authorization;
   }
-  return {
+  if (params.body !== undefined) {
+    headers["content-length"] ??= String(Buffer.byteLength(params.body, "utf8"));
+    headers["content-type"] ??= "application/json";
+  }
+  const body = params.body;
+  let bodyScheduled = false;
+  const emitter = new EventEmitter();
+  const request = Object.assign(emitter, {
     method: params.method ?? "GET",
     url: params.path,
     headers,
     socket: { remoteAddress: params.remoteAddress ?? "127.0.0.1" },
-  } as IncomingMessage;
+    destroyed: false,
+  }) as IncomingMessage & { destroyed: boolean };
+  request.destroy = () => {
+    request.destroyed = true;
+    emitter.emit("close");
+    return request;
+  };
+  if (body !== undefined) {
+    const scheduleBody = () => {
+      if (bodyScheduled) {
+        return;
+      }
+      bodyScheduled = true;
+      setImmediate(() => {
+        if (request.destroyed) {
+          return;
+        }
+        request.emit("data", Buffer.from(body, "utf8"));
+        request.emit("end");
+      });
+    };
+    request.on("newListener", (eventName) => {
+      if (eventName === "data" || eventName === "end") {
+        scheduleBody();
+      }
+    });
+  }
+  return request;
 }

--- a/src/gateway/pairing-setup-short-code-http.ts
+++ b/src/gateway/pairing-setup-short-code-http.ts
@@ -1,0 +1,85 @@
+// Redeems setup short codes into the canonical mobile setup-code payload.
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import {
+  normalizePairingSetupShortCodeInput,
+  redeemPairingSetupShortCode,
+} from "../pairing/setup-short-code.js";
+import {
+  AUTH_RATE_LIMIT_SCOPE_PAIRING_SETUP_SHORT_CODE,
+  type AuthRateLimiter,
+} from "./auth-rate-limit.js";
+import {
+  readJsonBodyOrError,
+  sendInvalidRequest,
+  sendJson,
+  sendMethodNotAllowed,
+  sendRateLimited,
+} from "./http-common.js";
+import { resolveRequestClientIp } from "./net.js";
+
+const PAIRING_SETUP_SHORT_CODE_REDEEM_MAX_BODY_BYTES = 1024;
+
+function resolveRequestCode(body: unknown): string | undefined {
+  if (!isRecord(body)) {
+    return undefined;
+  }
+  return normalizePairingSetupShortCodeInput(body.code);
+}
+
+export async function handlePairingSetupShortCodeRedeemHttpRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  opts: {
+    trustedProxies: string[];
+    allowRealIpFallback: boolean;
+    rateLimiter?: AuthRateLimiter;
+  },
+): Promise<boolean> {
+  const method = (req.method ?? "GET").toUpperCase();
+  if (method !== "POST") {
+    sendMethodNotAllowed(res);
+    return true;
+  }
+
+  const clientIp = resolveRequestClientIp(req, opts.trustedProxies, opts.allowRealIpFallback);
+  const limit = opts.rateLimiter?.check(clientIp, AUTH_RATE_LIMIT_SCOPE_PAIRING_SETUP_SHORT_CODE);
+  if (limit && !limit.allowed) {
+    sendRateLimited(res, limit.retryAfterMs);
+    return true;
+  }
+
+  const body = await readJsonBodyOrError(req, res, PAIRING_SETUP_SHORT_CODE_REDEEM_MAX_BODY_BYTES);
+  if (body === undefined) {
+    opts.rateLimiter?.recordFailure(clientIp, AUTH_RATE_LIMIT_SCOPE_PAIRING_SETUP_SHORT_CODE);
+    return true;
+  }
+
+  const code = resolveRequestCode(body);
+  if (!code) {
+    opts.rateLimiter?.recordFailure(clientIp, AUTH_RATE_LIMIT_SCOPE_PAIRING_SETUP_SHORT_CODE);
+    sendInvalidRequest(res, "Invalid or expired setup code.");
+    return true;
+  }
+
+  const redeemed = redeemPairingSetupShortCode(code);
+  if (!redeemed.ok) {
+    opts.rateLimiter?.recordFailure(clientIp, AUTH_RATE_LIMIT_SCOPE_PAIRING_SETUP_SHORT_CODE);
+    sendJson(res, 404, {
+      ok: false,
+      error: {
+        type: "invalid_or_expired_setup_code",
+        message: "Invalid or expired setup code.",
+      },
+    });
+    return true;
+  }
+
+  opts.rateLimiter?.reset(clientIp, AUTH_RATE_LIMIT_SCOPE_PAIRING_SETUP_SHORT_CODE);
+  sendJson(res, 200, {
+    ok: true,
+    payload: redeemed.payload,
+    expiresAtMs: redeemed.expiresAtMs,
+  });
+  return true;
+}

--- a/src/gateway/server-http.probe.test.ts
+++ b/src/gateway/server-http.probe.test.ts
@@ -1,6 +1,13 @@
 // Server HTTP probe tests cover readiness, health, disabled compat routes, and
 // auth handling through the in-memory HTTP harness.
 import { describe, expect, it, vi } from "vitest";
+import { issuePairingSetupShortCode } from "../pairing/setup-short-code.js";
+import {
+  clearPluginStateStoreForTests,
+  resetPluginStateStoreForTests,
+} from "../plugin-state/plugin-state-store.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { createAuthRateLimiter } from "./auth-rate-limit.js";
 import {
   AUTH_TOKEN,
   AUTH_NONE,
@@ -40,6 +47,117 @@ describe("gateway OpenAI-compatible disabled HTTP routes", () => {
         }
       },
     });
+  });
+});
+
+describe("gateway pairing setup short-code redeem endpoint", () => {
+  it("redeems a valid setup short code once without gateway auth", async () => {
+    await withOpenClawTestState({ label: "gateway-setup-short-code-redeem" }, async () => {
+      clearPluginStateStoreForTests();
+      const issued = await issuePairingSetupShortCode(
+        {
+          gateway: {
+            bind: "custom",
+            customBindHost: "127.0.0.1",
+            port: 19001,
+            auth: { mode: "token", token: "tok_123" },
+          },
+        },
+        { codeGenerator: () => "ABCD2345" },
+      );
+      expect(issued.ok).toBe(true);
+
+      await withGatewayServer({
+        prefix: "pairing-setup-short-code-redeem",
+        resolvedAuth: AUTH_TOKEN,
+        run: async (server) => {
+          const first = await sendGatewayRequest(server, {
+            path: "/api/v1/pairing/setup-code/redeem",
+            method: "POST",
+            body: JSON.stringify({ code: "abcd-2345" }),
+            remoteAddress: "10.0.0.8",
+            host: "gateway.test",
+          });
+
+          expect(first.res.statusCode).toBe(200);
+          expect(JSON.parse(first.getBody())).toEqual({
+            ok: true,
+            payload: {
+              url: "ws://127.0.0.1:19001",
+              bootstrapToken: expect.any(String),
+            },
+            expiresAtMs: expect.any(Number),
+          });
+
+          const replay = await sendGatewayRequest(server, {
+            path: "/api/v1/pairing/setup-code/redeem",
+            method: "POST",
+            body: JSON.stringify({ code: "ABCD2345" }),
+            remoteAddress: "10.0.0.8",
+            host: "gateway.test",
+          });
+
+          expect(replay.res.statusCode).toBe(404);
+          expect(JSON.parse(replay.getBody())).toMatchObject({
+            ok: false,
+            error: { type: "invalid_or_expired_setup_code" },
+          });
+        },
+      });
+    });
+    resetPluginStateStoreForTests();
+  });
+
+  it("rejects non-POST requests before reading a code", async () => {
+    await withGatewayServer({
+      prefix: "pairing-setup-short-code-method",
+      resolvedAuth: AUTH_NONE,
+      run: async (server) => {
+        const response = await sendGatewayRequest(server, {
+          path: "/api/v1/pairing/setup-code/redeem",
+          method: "GET",
+        });
+
+        expect(response.res.statusCode).toBe(405);
+        expect(response.getBody()).toBe("Method Not Allowed");
+      },
+    });
+  });
+
+  it("rate-limits invalid setup short-code redemption attempts", async () => {
+    const rateLimiter = createAuthRateLimiter({
+      maxAttempts: 1,
+      exemptLoopback: false,
+      pruneIntervalMs: 0,
+    });
+    try {
+      await withGatewayServer({
+        prefix: "pairing-setup-short-code-rate-limit",
+        resolvedAuth: AUTH_NONE,
+        overrides: { rateLimiter },
+        run: async (server) => {
+          const first = await sendGatewayRequest(server, {
+            path: "/api/v1/pairing/setup-code/redeem",
+            method: "POST",
+            body: JSON.stringify({ code: "BAD-CODE" }),
+            remoteAddress: "10.0.0.9",
+            host: "gateway.test",
+          });
+          expect(first.res.statusCode).toBe(400);
+
+          const second = await sendGatewayRequest(server, {
+            path: "/api/v1/pairing/setup-code/redeem",
+            method: "POST",
+            body: JSON.stringify({ code: "BAD-CODE" }),
+            remoteAddress: "10.0.0.9",
+            host: "gateway.test",
+          });
+          expect(second.res.statusCode).toBe(429);
+        },
+      });
+    } finally {
+      rateLimiter.dispose();
+    }
   });
 });
 

--- a/src/gateway/server-http.test-harness.ts
+++ b/src/gateway/server-http.test-harness.ts
@@ -37,6 +37,7 @@ export function createRequest(params: {
   remoteAddress?: string;
   host?: string;
   headers?: Record<string, string>;
+  body?: string;
 }): IncomingMessage {
   return createGatewayRequest({
     path: params.path,
@@ -45,6 +46,7 @@ export function createRequest(params: {
     remoteAddress: params.remoteAddress,
     host: params.host,
     headers: params.headers,
+    body: params.body,
   });
 }
 
@@ -184,6 +186,7 @@ export async function sendRequest(
     method?: string;
     remoteAddress?: string;
     host?: string;
+    body?: string;
   },
 ): Promise<ReturnType<typeof createResponse>> {
   const response = createResponse();

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -87,6 +87,9 @@ let pluginNodeCapabilityAuthModulePromise:
   | Promise<typeof import("./server/plugin-node-capability-auth.js")>
   | undefined;
 let httpAuthUtilsModulePromise: Promise<typeof import("./http-auth-utils.js")> | undefined;
+let pairingSetupShortCodeHttpModulePromise:
+  | Promise<typeof import("./pairing-setup-short-code-http.js")>
+  | undefined;
 let pluginRouteRuntimeScopesModulePromise:
   | Promise<typeof import("./server/plugin-route-runtime-scopes.js")>
   | undefined;
@@ -149,6 +152,11 @@ function getPluginNodeCapabilityAuthModule() {
 function getHttpAuthUtilsModule() {
   httpAuthUtilsModulePromise ??= import("./http-auth-utils.js");
   return httpAuthUtilsModulePromise;
+}
+
+function getPairingSetupShortCodeHttpModule() {
+  pairingSetupShortCodeHttpModulePromise ??= import("./pairing-setup-short-code-http.js");
+  return pairingSetupShortCodeHttpModulePromise;
 }
 
 function getPluginRouteRuntimeScopesModule() {
@@ -231,6 +239,10 @@ function isSessionKillPath(pathname: string): boolean {
 
 function isSessionHistoryPath(pathname: string): boolean {
   return /^\/sessions\/[^/]+\/history$/.test(pathname);
+}
+
+function isPairingSetupShortCodeRedeemPath(pathname: string): boolean {
+  return pathname === "/api/v1/pairing/setup-code/redeem";
 }
 
 function shouldEnforceDefaultPluginGatewayAuth(pathContext: PluginRoutePathContext): boolean {
@@ -659,6 +671,19 @@ export function createGatewayHttpServer(opts: {
             (await getSessionHistoryHttpModule()).handleSessionHistoryHttpRequest(req, res, {
               auth: resolvedAuthValue,
               getResolvedAuth,
+              trustedProxies,
+              allowRealIpFallback,
+              rateLimiter,
+            }),
+        });
+      }
+      if (isPairingSetupShortCodeRedeemPath(scopedRequestPath)) {
+        requestStages.push({
+          name: "pairing-setup-short-code-redeem",
+          run: async () =>
+            (
+              await getPairingSetupShortCodeHttpModule()
+            ).handlePairingSetupShortCodeRedeemHttpRequest(req, res, {
               trustedProxies,
               allowRealIpFallback,
               rateLimiter,

--- a/src/gateway/server.auth.control-ui.suite.ts
+++ b/src/gateway/server.auth.control-ui.suite.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { beforeAll, expect, test, vi } from "vitest";
 import { WebSocket } from "ws";
+import { replaceConfigFile as replaceOpenClawConfigFile } from "../config/config.js";
 import {
   BACKEND_GATEWAY_CLIENT,
   connectReq,
@@ -110,6 +111,9 @@ export function registerControlUiAndPairingSuite(): void {
       mode: "node";
       deviceFamily: string;
     };
+    caps?: string[];
+    commands?: string[];
+    permissions?: Record<string, boolean>;
   }) => {
     const { issueDeviceBootstrapToken } = await import("../infra/device-bootstrap.js");
     const { server, port, prevToken } = await startControlUiServer("secret");
@@ -122,6 +126,9 @@ export function registerControlUiAndPairingSuite(): void {
         bootstrapToken: issued.token,
         role: "node",
         scopes: [],
+        caps: params.caps,
+        commands: params.commands,
+        permissions: params.permissions,
         client: params.client,
         deviceIdentityPath: identityPath,
       });
@@ -144,6 +151,112 @@ export function registerControlUiAndPairingSuite(): void {
     const admin = await rpcReq(ws, "set-heartbeats", { enabled: false });
     expect(admin.ok).toBe(true);
   };
+
+  const IOS_SETUP_NODE_CAPS = [
+    "calendar",
+    "camera",
+    "canvas",
+    "contacts",
+    "device",
+    "motion",
+    "photos",
+    "reminders",
+    "screen",
+    "talk",
+  ];
+  const IOS_SETUP_NODE_COMMANDS = [
+    "calendar.add",
+    "calendar.events",
+    "camera.clip",
+    "camera.list",
+    "camera.snap",
+    "canvas.a2ui.push",
+    "canvas.a2ui.pushJSONL",
+    "canvas.a2ui.reset",
+    "canvas.eval",
+    "canvas.hide",
+    "canvas.navigate",
+    "canvas.present",
+    "canvas.snapshot",
+    "chat.push",
+    "contacts.add",
+    "contacts.search",
+    "device.status",
+    "device.info",
+    "motion.activity",
+    "motion.pedometer",
+    "photos.latest",
+    "reminders.add",
+    "reminders.list",
+    "screen.record",
+    "system.notify",
+    "talk.ptt.once",
+    "talk.ptt.start",
+    "talk.ptt.stop",
+    "talk.ptt.cancel",
+  ];
+  const ANDROID_SETUP_NODE_CAPS = [
+    "calendar",
+    "callLog",
+    "camera",
+    "canvas",
+    "contacts",
+    "device",
+    "location",
+    "motion",
+    "notifications",
+    "photos",
+    "sms",
+    "system",
+    "talk",
+    "voiceWake",
+  ];
+  const ANDROID_SETUP_NODE_COMMANDS = [
+    "calendar.add",
+    "calendar.events",
+    "callLog.search",
+    "camera.clip",
+    "camera.list",
+    "camera.snap",
+    "canvas.a2ui.push",
+    "canvas.a2ui.pushJSONL",
+    "canvas.a2ui.reset",
+    "canvas.eval",
+    "canvas.hide",
+    "canvas.navigate",
+    "canvas.present",
+    "canvas.snapshot",
+    "contacts.add",
+    "contacts.search",
+    "device.apps",
+    "device.health",
+    "device.info",
+    "device.permissions",
+    "device.status",
+    "location.get",
+    "motion.activity",
+    "motion.pedometer",
+    "notifications.actions",
+    "notifications.list",
+    "photos.latest",
+    "sms.search",
+    "sms.send",
+    "system.notify",
+    "talk.ptt.cancel",
+    "talk.ptt.once",
+    "talk.ptt.start",
+    "talk.ptt.stop",
+  ];
+  const DANGEROUS_SETUP_NODE_COMMANDS = new Set([
+    "calendar.add",
+    "camera.clip",
+    "camera.snap",
+    "contacts.add",
+    "reminders.add",
+    "screen.record",
+    "sms.search",
+    "sms.send",
+  ]);
 
   const connectControlUiWithoutDeviceAndExpectOk = async (params: {
     ws: WebSocket;
@@ -1140,6 +1253,7 @@ export function registerControlUiAndPairingSuite(): void {
     const { publicKeyRawBase64UrlFromPem } = await import("../infra/device-identity.js");
     const { getPairedDevice, listDevicePairing, verifyDeviceToken } =
       await import("../infra/device-pairing.js");
+    const { listNodePairing } = await import("../infra/node-pairing.js");
     const { server, port, prevToken } = await startControlUiServer("secret");
 
     const { identityPath, identity } = await createOperatorIdentityFixture(
@@ -1161,6 +1275,9 @@ export function registerControlUiAndPairingSuite(): void {
         bootstrapToken: issued.token,
         role: "node",
         scopes: [],
+        caps: IOS_SETUP_NODE_CAPS,
+        commands: IOS_SETUP_NODE_COMMANDS,
+        permissions: { photos: true },
         client,
         deviceIdentityPath: identityPath,
       });
@@ -1208,6 +1325,10 @@ export function registerControlUiAndPairingSuite(): void {
         (entry) => entry.deviceId === identity.deviceId,
       );
       expect(pendingForDevice).toEqual([]);
+      const pendingNodeAfterInitial = (await listNodePairing()).pending.filter(
+        (entry) => entry.nodeId === identity.deviceId,
+      );
+      expect(pendingNodeAfterInitial).toEqual([]);
       wsBootstrap.close();
 
       const afterBootstrap = await listDevicePairing();
@@ -1231,6 +1352,16 @@ export function registerControlUiAndPairingSuite(): void {
         "operator.talk.secrets",
         "operator.write",
       ]);
+      const pairedNode = (await listNodePairing()).paired.find(
+        (entry) => entry.nodeId === identity.deviceId,
+      );
+      expect(pairedNode?.caps).toEqual(IOS_SETUP_NODE_CAPS);
+      expect(pairedNode?.commands).toEqual(
+        IOS_SETUP_NODE_COMMANDS.filter(
+          (command) => !DANGEROUS_SETUP_NODE_COMMANDS.has(command),
+        ),
+      );
+      expect(pairedNode?.permissions).toEqual({ photos: true });
 
       const wsReplay = await openWs(port, REMOTE_BOOTSTRAP_HEADERS);
       const replay = await connectReq(wsReplay, {
@@ -1316,6 +1447,9 @@ export function registerControlUiAndPairingSuite(): void {
     {
       name: "Android",
       identityPrefix: "openclaw-bootstrap-android-node-",
+      caps: ANDROID_SETUP_NODE_CAPS,
+      commands: ANDROID_SETUP_NODE_COMMANDS,
+      permissions: undefined,
       client: {
         id: "openclaw-android",
         version: "2026.6.2",
@@ -1327,6 +1461,9 @@ export function registerControlUiAndPairingSuite(): void {
     {
       name: "iPadOS",
       identityPrefix: "openclaw-bootstrap-ipados-node-",
+      caps: IOS_SETUP_NODE_CAPS,
+      commands: IOS_SETUP_NODE_COMMANDS,
+      permissions: { photos: true },
       client: {
         id: "openclaw-ios",
         version: "2026.6.2",
@@ -1337,11 +1474,15 @@ export function registerControlUiAndPairingSuite(): void {
     },
   ])(
     "qr setup code auto-approves $name clients when mobile metadata matches",
-    async ({ client, identityPrefix }) => {
+    async ({ caps, client, commands, identityPrefix, permissions }) => {
       const { getPairedDevice, listDevicePairing } = await import("../infra/device-pairing.js");
+      const { listNodePairing } = await import("../infra/node-pairing.js");
       const { identity, initial } = await connectSetupCodeBootstrapNode({
         identityPrefix,
         client,
+        caps,
+        commands,
+        permissions,
       });
       expect(initial.ok).toBe(true);
       const approvedPayload = initial.payload as
@@ -1384,8 +1525,139 @@ export function registerControlUiAndPairingSuite(): void {
         "operator.talk.secrets",
         "operator.write",
       ]);
+      const nodePairing = await listNodePairing();
+      expect(nodePairing.pending.filter((entry) => entry.nodeId === identity.deviceId)).toEqual([]);
+      const pairedNode = nodePairing.paired.find((entry) => entry.nodeId === identity.deviceId);
+      expect(pairedNode?.caps).toEqual(caps);
+      expect(pairedNode?.commands).toEqual(
+        commands.filter((command) => !DANGEROUS_SETUP_NODE_COMMANDS.has(command)),
+      );
+      expect(pairedNode?.permissions).toEqual(permissions);
     },
   );
+
+  test("qr setup code leaves Android-only iOS node surfaces pending", async () => {
+    const { listNodePairing } = await import("../infra/node-pairing.js");
+    const { identity, initial } = await connectSetupCodeBootstrapNode({
+      identityPrefix: "openclaw-bootstrap-ios-android-surface-",
+      client: {
+        id: "openclaw-ios",
+        version: "2026.6.2",
+        platform: "iOS 26.3.1",
+        mode: "node",
+        deviceFamily: "iPhone",
+      },
+      caps: [...IOS_SETUP_NODE_CAPS, "callLog"],
+      commands: [...IOS_SETUP_NODE_COMMANDS, "callLog.search"],
+      permissions: { photos: true },
+    });
+
+    expect(initial.ok).toBe(true);
+    const nodePairing = await listNodePairing();
+    const pending = nodePairing.pending.filter((entry) => entry.nodeId === identity.deviceId);
+    expect(pending).toHaveLength(1);
+    expect(pending[0]?.caps).toContain("callLog");
+    expect(nodePairing.paired.find((entry) => entry.nodeId === identity.deviceId)).toBeUndefined();
+  });
+
+  test("qr setup code honors denied mobile node commands during auto-approval", async () => {
+    const { listNodePairing } = await import("../infra/node-pairing.js");
+    const deniedCommand = "camera.snap";
+    await replaceOpenClawConfigFile({
+      nextConfig: {
+        gateway: {
+          nodes: {
+            denyCommands: [deniedCommand],
+          },
+        },
+      },
+    });
+    try {
+      const { identity, initial } = await connectSetupCodeBootstrapNode({
+        identityPrefix: "openclaw-bootstrap-ios-denied-command-",
+        client: {
+          id: "openclaw-ios",
+          version: "2026.6.2",
+          platform: "iOS 26.3.1",
+          mode: "node",
+          deviceFamily: "iPhone",
+        },
+        caps: IOS_SETUP_NODE_CAPS,
+        commands: IOS_SETUP_NODE_COMMANDS,
+        permissions: { photos: true },
+      });
+
+      expect(initial.ok).toBe(true);
+      const nodePairing = await listNodePairing();
+      const pairedNode = nodePairing.paired.find((entry) => entry.nodeId === identity.deviceId);
+      expect(pairedNode?.commands).not.toContain(deniedCommand);
+      expect(nodePairing.pending.filter((entry) => entry.nodeId === identity.deviceId)).toEqual([]);
+    } finally {
+      await replaceOpenClawConfigFile({ nextConfig: {} });
+    }
+  });
+
+  test("qr setup code auto-approves explicitly allowed dangerous mobile node commands", async () => {
+    const { listNodePairing } = await import("../infra/node-pairing.js");
+    const allowedCommand = "camera.snap";
+    await replaceOpenClawConfigFile({
+      nextConfig: {
+        gateway: {
+          nodes: {
+            allowCommands: [allowedCommand],
+          },
+        },
+      },
+    });
+    try {
+      const { identity, initial } = await connectSetupCodeBootstrapNode({
+        identityPrefix: "openclaw-bootstrap-ios-allowed-dangerous-command-",
+        client: {
+          id: "openclaw-ios",
+          version: "2026.6.2",
+          platform: "iOS 26.3.1",
+          mode: "node",
+          deviceFamily: "iPhone",
+        },
+        caps: IOS_SETUP_NODE_CAPS,
+        commands: IOS_SETUP_NODE_COMMANDS,
+        permissions: { photos: true },
+      });
+
+      expect(initial.ok).toBe(true);
+      const nodePairing = await listNodePairing();
+      const pairedNode = nodePairing.paired.find((entry) => entry.nodeId === identity.deviceId);
+      expect(pairedNode?.commands).toContain(allowedCommand);
+      expect(nodePairing.pending.filter((entry) => entry.nodeId === identity.deviceId)).toEqual([]);
+    } finally {
+      await replaceOpenClawConfigFile({ nextConfig: {} });
+    }
+  });
+
+  test("qr setup code requires owner approval for setup-code bootstrap node surfaces outside mobile baseline", async () => {
+    const { listNodePairing } = await import("../infra/node-pairing.js");
+    const extraCap = "plugin.demo";
+    const { identity, initial } = await connectSetupCodeBootstrapNode({
+      identityPrefix: "openclaw-bootstrap-extra-node-command-",
+      client: {
+        id: "openclaw-ios",
+        version: "2026.6.2",
+        platform: "iOS 26.3.1",
+        mode: "node",
+        deviceFamily: "iPhone",
+      },
+      caps: [...IOS_SETUP_NODE_CAPS, extraCap],
+      commands: IOS_SETUP_NODE_COMMANDS,
+      permissions: { photos: true },
+    });
+
+    expect(initial.ok).toBe(true);
+    const nodePairing = await listNodePairing();
+    const pending = nodePairing.pending.filter((entry) => entry.nodeId === identity.deviceId);
+    expect(pending).toHaveLength(1);
+    expect(pending[0]?.caps).toContain(extraCap);
+    expect(nodePairing.paired.find((entry) => entry.nodeId === identity.deviceId)).toBeUndefined();
+  });
 
   test.each([
     {

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -42,6 +42,7 @@ import {
 } from "../../../../packages/gateway-protocol/src/startup-unavailable.js";
 import { getRuntimeConfig } from "../../../config/io.js";
 import { resolveStateDir } from "../../../config/paths.js";
+import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import {
   getBoundDeviceBootstrapProfile,
   getDeviceBootstrapTokenProfile,
@@ -77,6 +78,7 @@ import {
 } from "../../../infra/diagnostic-trace-context.js";
 import {
   beginNodePairingConnect,
+  approveNodePairing,
   finalizeNodePairingCleanupClaim,
   releaseNodePairingCleanupClaim,
   requestNodePairing,
@@ -123,6 +125,7 @@ import {
   resolveNodePairingClientIpSource,
   shouldAutoApproveNodePairingFromTrustedCidrs,
 } from "../../node-pairing-auto-approve.js";
+import { DEFAULT_DANGEROUS_NODE_COMMANDS } from "../../node-command-policy.js";
 import type { NodeReapprovalCoordinator } from "../../node-reapproval-coordinator.js";
 import { isOperatorApprovalRuntimeToken } from "../../operator-approval-runtime-token.js";
 import { checkBrowserOrigin } from "../../origin-check.js";
@@ -349,6 +352,211 @@ function isSetupCodeMobileBootstrapClient(client: {
     return /^(?:ios|ipados)(?:\s|$)/.test(platform) && /^(?:iphone|ipad|ios)$/.test(deviceFamily);
   }
   return false;
+}
+
+type SetupCodeMobileNodeApprovalProfile = {
+  caps: ReadonlySet<string>;
+  commands: ReadonlySet<string>;
+  permissionKeys: ReadonlySet<string>;
+};
+
+const SETUP_CODE_IOS_NODE_CAPS = new Set([
+  "calendar",
+  "camera",
+  "canvas",
+  "contacts",
+  "device",
+  "location",
+  "motion",
+  "photos",
+  "reminders",
+  "screen",
+  "talk",
+  "voiceWake",
+  "watch",
+]);
+
+const SETUP_CODE_IOS_NODE_COMMANDS = new Set([
+  "calendar.events",
+  "calendar.add",
+  "camera.list",
+  "camera.clip",
+  "camera.snap",
+  "chat.push",
+  "canvas.a2ui.push",
+  "canvas.a2ui.pushJSONL",
+  "canvas.a2ui.reset",
+  "canvas.eval",
+  "canvas.hide",
+  "canvas.navigate",
+  "canvas.present",
+  "canvas.snapshot",
+  "contacts.search",
+  "contacts.add",
+  "device.info",
+  "device.status",
+  "location.get",
+  "motion.activity",
+  "motion.pedometer",
+  "photos.latest",
+  "reminders.list",
+  "reminders.add",
+  "screen.record",
+  "system.notify",
+  "talk.ptt.cancel",
+  "talk.ptt.once",
+  "talk.ptt.start",
+  "talk.ptt.stop",
+  "watch.notify",
+  "watch.status",
+]);
+
+const SETUP_CODE_ANDROID_NODE_CAPS = new Set([
+  "calendar",
+  "callLog",
+  "camera",
+  "canvas",
+  "contacts",
+  "device",
+  "location",
+  "motion",
+  "notifications",
+  "photos",
+  "sms",
+  "system",
+  "talk",
+  "voiceWake",
+]);
+
+const SETUP_CODE_ANDROID_NODE_COMMANDS = new Set([
+  "calendar.events",
+  "calendar.add",
+  "callLog.search",
+  "camera.list",
+  "camera.clip",
+  "camera.snap",
+  "canvas.a2ui.push",
+  "canvas.a2ui.pushJSONL",
+  "canvas.a2ui.reset",
+  "canvas.eval",
+  "canvas.hide",
+  "canvas.navigate",
+  "canvas.present",
+  "canvas.snapshot",
+  "contacts.search",
+  "contacts.add",
+  "device.apps",
+  "device.health",
+  "device.info",
+  "device.permissions",
+  "device.status",
+  "location.get",
+  "motion.activity",
+  "motion.pedometer",
+  "notifications.actions",
+  "notifications.list",
+  "photos.latest",
+  "sms.search",
+  "sms.send",
+  "system.notify",
+  "talk.ptt.cancel",
+  "talk.ptt.once",
+  "talk.ptt.start",
+  "talk.ptt.stop",
+]);
+
+const SETUP_CODE_IOS_NODE_PERMISSION_KEYS = new Set([
+  "calendar",
+  "camera",
+  "contacts",
+  "location",
+  "microphone",
+  "motion",
+  "photos",
+  "reminders",
+  "screenRecording",
+  "speechRecognition",
+  "watchAppInstalled",
+  "watchPaired",
+  "watchReachable",
+  "watchSupported",
+]);
+
+const SETUP_CODE_ANDROID_NODE_PERMISSION_KEYS = new Set<string>();
+
+const SETUP_CODE_IOS_NODE_APPROVAL_PROFILE = {
+  caps: SETUP_CODE_IOS_NODE_CAPS,
+  commands: SETUP_CODE_IOS_NODE_COMMANDS,
+  permissionKeys: SETUP_CODE_IOS_NODE_PERMISSION_KEYS,
+} satisfies SetupCodeMobileNodeApprovalProfile;
+
+const SETUP_CODE_ANDROID_NODE_APPROVAL_PROFILE = {
+  caps: SETUP_CODE_ANDROID_NODE_CAPS,
+  commands: SETUP_CODE_ANDROID_NODE_COMMANDS,
+  permissionKeys: SETUP_CODE_ANDROID_NODE_PERMISSION_KEYS,
+} satisfies SetupCodeMobileNodeApprovalProfile;
+
+function isSubsetOfAllowed(values: readonly string[], allowed: ReadonlySet<string>): boolean {
+  return values.every((value) => allowed.has(value));
+}
+
+function resolveSetupCodeMobileNodeApprovalProfile(client: {
+  id?: string;
+}): SetupCodeMobileNodeApprovalProfile | undefined {
+  if (client.id === GATEWAY_CLIENT_IDS.IOS_APP) {
+    return SETUP_CODE_IOS_NODE_APPROVAL_PROFILE;
+  }
+  if (client.id === GATEWAY_CLIENT_IDS.ANDROID_APP) {
+    return SETUP_CODE_ANDROID_NODE_APPROVAL_PROFILE;
+  }
+  return undefined;
+}
+
+function isSetupCodeMobileNodeApprovalSurface(
+  profile: SetupCodeMobileNodeApprovalProfile,
+  params: {
+  caps: readonly string[];
+  commands: readonly string[];
+  permissions?: Record<string, boolean>;
+  },
+): boolean {
+  // QR/setup-code bootstrap may approve only built-in mobile app surfaces.
+  // Operator-configured extra node commands still require normal owner approval.
+  if (!isSubsetOfAllowed(params.caps, profile.caps)) {
+    return false;
+  }
+  if (!isSubsetOfAllowed(params.commands, profile.commands)) {
+    return false;
+  }
+  return Object.keys(params.permissions ?? {}).every((key) =>
+    profile.permissionKeys.has(key)
+  );
+}
+
+function withSetupCodeMobileNodeCommandAllowlist(
+  cfg: OpenClawConfig,
+  profile: SetupCodeMobileNodeApprovalProfile,
+): OpenClawConfig {
+  const configuredAllowCommands = cfg.gateway?.nodes?.allowCommands ?? [];
+  const configuredAllowSet = new Set(configuredAllowCommands.map((command) => command.trim()));
+  const dangerousCommands = new Set(DEFAULT_DANGEROUS_NODE_COMMANDS);
+  const setupCodeAllowCommands = [...profile.commands].filter(
+    (command) => !dangerousCommands.has(command) || configuredAllowSet.has(command),
+  );
+  const allowCommands = normalizeSortedUniqueTrimmedStringList([
+    ...configuredAllowCommands,
+    ...setupCodeAllowCommands,
+  ]);
+  return {
+    ...cfg,
+    gateway: {
+      ...cfg.gateway,
+      nodes: {
+        ...cfg.gateway?.nodes,
+        allowCommands,
+      },
+    },
+  };
 }
 
 function resolveTrustedProxyControlUiScopes(params: {
@@ -1269,6 +1477,7 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
             ? await getDeviceBootstrapTokenProfile({ token: bootstrapTokenCandidate })
             : null;
         let handoffBootstrapProfile: DeviceBootstrapProfile | null = null;
+        let setupCodeMobileDeviceBootstrapApproved = false;
         const trustedProxyAuthOk = isTrustedProxyControlUiOperatorAuth({
           isControlUi,
           role,
@@ -1460,6 +1669,7 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
               if (approved?.status === "approved") {
                 if (allowSetupCodeMobileBootstrapPairing && boundBootstrapProfile) {
                   handoffBootstrapProfile = boundBootstrapProfile;
+                  setupCodeMobileDeviceBootstrapApproved = true;
                 }
                 logGateway.info(
                   `device pairing auto-approved device=${approved.device.deviceId} role=${approved.device.role ?? "unknown"}`,
@@ -1770,10 +1980,18 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
           const nodePairingSnapshot = await beginNodePairingConnect(nodeId);
           const pairedNode = nodePairingSnapshot.pairedNode;
           pendingNodePairingCleanup = nodePairingSnapshot.cleanupClaim;
+          const setupCodeMobileApprovalProfile = setupCodeMobileDeviceBootstrapApproved
+            ? resolveSetupCodeMobileNodeApprovalProfile(connectParams.client)
+            : undefined;
           let reconciliation: Awaited<ReturnType<typeof reconcileNodePairingOnConnect>>;
           try {
             reconciliation = await reconcileNodePairingOnConnect({
-              cfg: getRuntimeConfig(),
+              cfg: setupCodeMobileApprovalProfile
+                ? withSetupCodeMobileNodeCommandAllowlist(
+                    getRuntimeConfig(),
+                    setupCodeMobileApprovalProfile,
+                  )
+                : getRuntimeConfig(),
               connectParams,
               pairedNode,
               reportedClientIp,
@@ -1788,6 +2006,48 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
                 });
               },
             });
+            if (
+              setupCodeMobileDeviceBootstrapApproved &&
+              setupCodeMobileApprovalProfile &&
+              pairedNode === null &&
+              reconciliation.pendingPairing &&
+              isSetupCodeMobileNodeApprovalSurface(setupCodeMobileApprovalProfile, {
+                caps: reconciliation.declaredCaps,
+                commands: reconciliation.declaredCommands,
+                permissions: reconciliation.declaredPermissions,
+              })
+            ) {
+              const bootstrapNodeApproval = await approveNodePairing(
+                reconciliation.pendingPairing.request.requestId,
+                {
+                  callerScopes: ["operator.pairing", "operator.write"],
+                },
+              );
+              if (bootstrapNodeApproval && "node" in bootstrapNodeApproval) {
+                const { pendingPairing: _pendingPairing, ...approvedReconciliation } =
+                  reconciliation;
+                reconciliation = {
+                  ...approvedReconciliation,
+                  effectiveCaps: reconciliation.declaredCaps,
+                  effectiveCommands: reconciliation.declaredCommands,
+                  effectivePermissions: reconciliation.declaredPermissions,
+                  shouldClearPendingPairings: true,
+                };
+                buildRequestContext().broadcast(
+                  "node.pair.resolved",
+                  {
+                    requestId: bootstrapNodeApproval.requestId,
+                    nodeId: bootstrapNodeApproval.node.nodeId,
+                    decision: "approved",
+                    ts: Date.now(),
+                  },
+                  { dropIfSlow: true },
+                );
+                logGateway.info(
+                  `node pairing auto-approved via setup-code bootstrap node=${bootstrapNodeApproval.node.nodeId}`,
+                );
+              }
+            }
           } catch (error) {
             await releasePendingNodePairingCleanup();
             if (error instanceof NodePairingRateLimitError) {

--- a/src/pairing/setup-short-code.test.ts
+++ b/src/pairing/setup-short-code.test.ts
@@ -1,0 +1,129 @@
+// Tests setup short-code issue and one-time redemption.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearPluginStateStoreForTests,
+  resetPluginStateStoreForTests,
+} from "../plugin-state/plugin-state-store.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+
+vi.mock("../infra/device-bootstrap.js", () => ({
+  issueDeviceBootstrapToken: vi.fn(async () => ({
+    token: "bootstrap-123",
+    expiresAtMs: 123,
+  })),
+}));
+
+const {
+  formatPairingSetupShortCode,
+  issuePairingSetupShortCode,
+  normalizePairingSetupShortCodeInput,
+  registerPairingSetupShortCode,
+  redeemPairingSetupShortCode,
+} = await import("./setup-short-code.js");
+
+const gatewayConfig = {
+  gateway: {
+    bind: "custom",
+    customBindHost: "127.0.0.1",
+    port: 19001,
+    auth: { mode: "token", token: "tok_123" },
+  },
+} as const;
+
+beforeEach(() => {
+  vi.useRealTimers();
+  clearPluginStateStoreForTests();
+});
+
+describe("pairing setup short code", () => {
+  it("issues a short code that redeems once into the setup payload", async () => {
+    await withOpenClawTestState({ label: "setup-short-code" }, async () => {
+      vi.setSystemTime(new Date("2026-06-30T12:00:00.000Z"));
+      const issued = await issuePairingSetupShortCode(gatewayConfig, {
+        codeGenerator: () => "ABCD2345",
+      });
+
+      expect(issued).toEqual({
+        ok: true,
+        code: "ABCD2345",
+        expiresAtMs: Date.parse("2026-06-30T12:05:00.000Z"),
+        authLabel: "token",
+        urlSource: "gateway.bind=custom",
+      });
+      expect(redeemPairingSetupShortCode("abcd-2345")).toEqual({
+        ok: true,
+        payload: {
+          url: "ws://127.0.0.1:19001",
+          bootstrapToken: "bootstrap-123",
+        },
+        expiresAtMs: Date.parse("2026-06-30T12:05:00.000Z"),
+      });
+      expect(redeemPairingSetupShortCode("ABCD2345")).toEqual({
+        ok: false,
+        reason: "invalid_or_expired",
+      });
+    });
+  });
+
+  it("treats expired short codes as invalid without returning the payload", async () => {
+    await withOpenClawTestState({ label: "setup-short-code-expired" }, async () => {
+      vi.setSystemTime(new Date("2026-06-30T12:00:00.000Z"));
+      await issuePairingSetupShortCode(gatewayConfig, {
+        ttlMs: 1_000,
+        codeGenerator: () => "EFGH2345",
+      });
+
+      vi.setSystemTime(new Date("2026-06-30T12:00:01.001Z"));
+      expect(redeemPairingSetupShortCode("EFGH2345")).toEqual({
+        ok: false,
+        reason: "invalid_or_expired",
+      });
+    });
+  });
+
+  it("normalizes grouped human input and rejects ambiguous characters", () => {
+    expect(normalizePairingSetupShortCodeInput("abcd-2345")).toBe("ABCD2345");
+    expect(normalizePairingSetupShortCodeInput("ABCD 2345")).toBe("ABCD2345");
+    expect(normalizePairingSetupShortCodeInput("ABCD1045")).toBeUndefined();
+    expect(formatPairingSetupShortCode("abcd2345")).toBe("ABCD-2345");
+  });
+
+  it("registers an already-issued setup payload without minting a replacement", async () => {
+    await withOpenClawTestState({ label: "setup-short-code-register" }, async () => {
+      vi.setSystemTime(new Date("2026-06-30T12:00:00.000Z"));
+
+      expect(
+        registerPairingSetupShortCode(
+          {
+            payload: {
+              url: "wss://gateway.example.com",
+              bootstrapToken: "existing-bootstrap",
+            },
+            authLabel: "token",
+            urlSource: "test",
+          },
+          { codeGenerator: () => "JKLM2345" },
+        ),
+      ).toEqual({
+        ok: true,
+        code: "JKLM2345",
+        expiresAtMs: Date.parse("2026-06-30T12:05:00.000Z"),
+        authLabel: "token",
+        urlSource: "test",
+      });
+      expect(redeemPairingSetupShortCode("JKLM-2345")).toEqual({
+        ok: true,
+        payload: {
+          url: "wss://gateway.example.com",
+          bootstrapToken: "existing-bootstrap",
+        },
+        expiresAtMs: Date.parse("2026-06-30T12:05:00.000Z"),
+      });
+    });
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  resetPluginStateStoreForTests();
+});

--- a/src/pairing/setup-short-code.ts
+++ b/src/pairing/setup-short-code.ts
@@ -1,0 +1,219 @@
+// Issues and redeems human-entered setup short codes for mobile onboarding.
+import crypto from "node:crypto";
+import type { OpenClawConfig } from "../config/types.js";
+import { createCorePluginStateSyncKeyedStore } from "../plugin-state/plugin-state-store.js";
+import type { PluginStateSyncKeyedStore } from "../plugin-state/plugin-state-store.types.js";
+import {
+  resolvePairingSetupFromConfig,
+  type PairingSetupPayload,
+  type ResolvePairingSetupOptions,
+} from "./setup-code.js";
+
+const SETUP_SHORT_CODE_LENGTH = 8;
+const SETUP_SHORT_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+const SETUP_SHORT_CODE_MAX_GENERATION_ATTEMPTS = 500;
+const SETUP_SHORT_CODE_TTL_MS = 5 * 60 * 1000;
+const SETUP_SHORT_CODE_MAX_ENTRIES = 200;
+const SETUP_SHORT_CODE_NAMESPACE = "setup-short-codes";
+
+type PairingSetupShortCodeRecord = {
+  payload: PairingSetupPayload;
+  issuedAtMs: number;
+  expiresAtMs: number;
+  authLabel: "token" | "password";
+  urlSource: string;
+};
+
+export type PairingSetupShortCodeIssueResult =
+  | {
+      ok: true;
+      code: string;
+      expiresAtMs: number;
+      authLabel: "token" | "password";
+      urlSource: string;
+    }
+  | {
+      ok: false;
+      error: string;
+    };
+
+export type RegisterPairingSetupShortCodeOptions = {
+  ttlMs?: number;
+  codeGenerator?: () => string;
+  store?: PairingSetupShortCodeStore;
+};
+
+export type PairingSetupShortCodeRedeemResult =
+  | {
+      ok: true;
+      payload: PairingSetupPayload;
+      expiresAtMs: number;
+    }
+  | {
+      ok: false;
+      reason: "invalid_or_expired";
+    };
+
+type PairingSetupShortCodeStore = PluginStateSyncKeyedStore<PairingSetupShortCodeRecord>;
+
+export type IssuePairingSetupShortCodeOptions = ResolvePairingSetupOptions &
+  RegisterPairingSetupShortCodeOptions;
+
+export type RedeemPairingSetupShortCodeOptions = {
+  nowMs?: number;
+  store?: PairingSetupShortCodeStore;
+};
+
+function createSetupShortCodeStore(): PairingSetupShortCodeStore {
+  return createCorePluginStateSyncKeyedStore<PairingSetupShortCodeRecord>({
+    ownerId: "core:pairing",
+    namespace: SETUP_SHORT_CODE_NAMESPACE,
+    maxEntries: SETUP_SHORT_CODE_MAX_ENTRIES,
+    defaultTtlMs: SETUP_SHORT_CODE_TTL_MS,
+  });
+}
+
+export function normalizePairingSetupShortCodeInput(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const normalized = value
+    .toUpperCase()
+    .replace(/[\s-]+/g, "")
+    .trim();
+  if (normalized.length !== SETUP_SHORT_CODE_LENGTH) {
+    return undefined;
+  }
+  for (const char of normalized) {
+    if (!SETUP_SHORT_CODE_ALPHABET.includes(char)) {
+      return undefined;
+    }
+  }
+  return normalized;
+}
+
+export function formatPairingSetupShortCode(code: string): string {
+  const normalized = normalizePairingSetupShortCodeInput(code);
+  if (!normalized) {
+    return code;
+  }
+  return `${normalized.slice(0, 4)}-${normalized.slice(4)}`;
+}
+
+function generatePairingSetupShortCode(): string {
+  let out = "";
+  for (let i = 0; i < SETUP_SHORT_CODE_LENGTH; i += 1) {
+    const index = crypto.randomInt(0, SETUP_SHORT_CODE_ALPHABET.length);
+    const char = SETUP_SHORT_CODE_ALPHABET[index];
+    if (!char) {
+      throw new Error("setup short-code alphabet lookup failed");
+    }
+    out += char;
+  }
+  return out;
+}
+
+function resolveTtlMs(value: number | undefined): number {
+  if (
+    typeof value === "number" &&
+    Number.isSafeInteger(value) &&
+    value > 0 &&
+    value <= SETUP_SHORT_CODE_TTL_MS
+  ) {
+    return value;
+  }
+  return SETUP_SHORT_CODE_TTL_MS;
+}
+
+function registerUniqueShortCode(params: {
+  store: PairingSetupShortCodeStore;
+  record: PairingSetupShortCodeRecord;
+  ttlMs: number;
+  codeGenerator: () => string;
+}): string {
+  for (let attempt = 0; attempt < SETUP_SHORT_CODE_MAX_GENERATION_ATTEMPTS; attempt += 1) {
+    const code = normalizePairingSetupShortCodeInput(params.codeGenerator());
+    if (!code) {
+      continue;
+    }
+    if (params.store.registerIfAbsent(code, params.record, { ttlMs: params.ttlMs })) {
+      return code;
+    }
+  }
+  throw new Error(
+    `failed to generate unique setup short code after ${SETUP_SHORT_CODE_MAX_GENERATION_ATTEMPTS} attempts`,
+  );
+}
+
+export async function issuePairingSetupShortCode(
+  cfg: OpenClawConfig,
+  options: IssuePairingSetupShortCodeOptions = {},
+): Promise<PairingSetupShortCodeIssueResult> {
+  const resolved = await resolvePairingSetupFromConfig(cfg, options);
+  if (!resolved.ok) {
+    return resolved;
+  }
+  return registerPairingSetupShortCode(
+    {
+      payload: resolved.payload,
+      authLabel: resolved.authLabel,
+      urlSource: resolved.urlSource,
+    },
+    options,
+  );
+}
+
+export function registerPairingSetupShortCode(
+  setup: {
+    payload: PairingSetupPayload;
+    authLabel: "token" | "password";
+    urlSource: string;
+  },
+  options: RegisterPairingSetupShortCodeOptions = {},
+): PairingSetupShortCodeIssueResult {
+  const nowMs = Date.now();
+  const ttlMs = resolveTtlMs(options.ttlMs);
+  const expiresAtMs = nowMs + ttlMs;
+  const store = options.store ?? createSetupShortCodeStore();
+  const code = registerUniqueShortCode({
+    store,
+    ttlMs,
+    codeGenerator: options.codeGenerator ?? generatePairingSetupShortCode,
+    record: {
+      payload: setup.payload,
+      issuedAtMs: nowMs,
+      expiresAtMs,
+      authLabel: setup.authLabel,
+      urlSource: setup.urlSource,
+    },
+  });
+
+  return {
+    ok: true,
+    code,
+    expiresAtMs,
+    authLabel: setup.authLabel,
+    urlSource: setup.urlSource,
+  };
+}
+
+export function redeemPairingSetupShortCode(
+  rawCode: unknown,
+  options: RedeemPairingSetupShortCodeOptions = {},
+): PairingSetupShortCodeRedeemResult {
+  const code = normalizePairingSetupShortCodeInput(rawCode);
+  if (!code) {
+    return { ok: false, reason: "invalid_or_expired" };
+  }
+  const store = options.store ?? createSetupShortCodeStore();
+  const record = store.consume(code);
+  const nowMs = options.nowMs ?? Date.now();
+  if (!record || record.expiresAtMs <= nowMs) {
+    return { ok: false, reason: "invalid_or_expired" };
+  }
+  return {
+    ok: true,
+    payload: record.payload,
+    expiresAtMs: record.expiresAtMs,
+  };
+}


### PR DESCRIPTION
Related: #98242
Supersedes the gateway half of #98243.

## What Problem This Solves

Users setting up OpenClaw Mobile had to scan or paste a long setup code and then complete separate device/node approval steps. That made QR/setup-code onboarding feel like many steps instead of the intended one-step mobile setup.

## Why This Change Was Made

This makes Setup Code and QR onboarding the primary one-step path: the app receives the Gateway URL/bootstrap auth from the setup-code payload, connects, and the Gateway silently approves only fresh baseline mobile device/node surfaces. The setup short code is a gateway-local convenience for typing the same setup-code payload on reachable local/co-resident Gateway flows; the long setup-code QR remains the durable fallback.

The node approval boundary is platform-specific for current iOS and Android app-declared capabilities/commands/permissions. Cross-platform, plugin, arbitrary, upgraded, or dangerous node command surfaces remain pending unless the Gateway owner explicitly allows them.

## User Impact

A fresh mobile app can scan the QR or enter the setup code, save the Gateway URL/bootstrap auth, connect, receive bounded node/operator handoff tokens, and land connected without a separate manual approval step. Operators still get explicit pending approval flows for non-baseline or upgraded node surfaces.

## Evidence

- Physical iPhone + Tailscale QR proof succeeded locally: app connected; Gateway showed pending device/node counts at 0 after setup.
- Redacted visual proof: https://gist.github.com/Solvely-Colin/0d647e2ffd90500925a062dc043d3764
- `node scripts/run-vitest.mjs src/gateway/server.auth.control-ui.test.ts --testNamePattern "qr setup code"` passed: 7 tests, 33 skipped.
- `node scripts/run-vitest.mjs src/plugins/contracts/deprecated-internal-config-api.test.ts` passed.
- `node scripts/run-vitest.mjs src/pairing/setup-short-code.test.ts src/gateway/server-http.probe.test.ts src/cli/qr-cli.test.ts` passed: 3 shards, 4 + 28 + 25 tests.
- `node scripts/format-docs.mjs --check docs/cli/qr.md docs/channels/pairing.md docs/gateway/protocol.md docs/docs_map.md && node scripts/check-docs-mdx.mjs docs/cli/qr.md docs/channels/pairing.md docs/gateway/protocol.md docs/docs_map.md && node scripts/docs-link-audit.mjs docs/cli/qr.md docs/channels/pairing.md docs/gateway/protocol.md docs/docs_map.md && node scripts/generate-docs-map.mjs --check` passed.
- `git diff --check && node scripts/run-oxlint.mjs src/pairing/setup-short-code.ts src/gateway/pairing-setup-short-code-http.ts src/gateway/server.auth.control-ui.suite.ts src/gateway/server/ws-connection/message-handler.ts && node scripts/check-deprecated-api-usage.mjs` passed.
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.src.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-src.gateway-comments.tsbuildinfo` passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local --prompt "Review the PR #98263 final comment-response patch only..."` clean: no accepted/actionable findings.
- Crabbox/Testbox not run per request to skip Crabbox.
