### PR TITLE
feat(ios): redeem gateway setup short codes

### DIFF
--- a/apps/ios/Sources/Design/SettingsProTabActions.swift
+++ b/apps/ios/Sources/Design/SettingsProTabActions.swift
@@ -186,7 +186,10 @@ extension SettingsProTab {
 
     func applySetupCodeAndConnect() async {
         self.setupStatusText = nil
-        guard self.applySetupCode() else { return }
+        guard let link = await self.resolveSetupInputForConnect() else { return }
+        self.stagedGatewaySetupLink = nil
+        self.setupCode = ""
+        self.applyGatewayLink(link)
         let host = self.manualGatewayHost.trimmingCharacters(in: .whitespacesAndNewlines)
         guard let port = self.resolvedManualPort(host: host) else {
             self.setupStatusText = "Failed: invalid port"
@@ -195,6 +198,44 @@ extension SettingsProTab {
         guard await self.preflightGateway(host: host, port: port) else { return }
         self.setupStatusText = "Setup code applied. Connecting..."
         await self.connectManual()
+    }
+
+    func resolveSetupInputForConnect() async -> GatewayConnectDeepLink? {
+        let raw = self.setupCode.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let stagedGatewaySetupLink, raw.isEmpty {
+            return stagedGatewaySetupLink
+        }
+        guard !raw.isEmpty else {
+            self.setupStatusText = "Paste a setup code to continue."
+            return nil
+        }
+        if AppleReviewDemoMode.isSetupCode(raw) {
+            self.stagedGatewaySetupLink = nil
+            self.setupCode = ""
+            self.setupStatusText = "Apple Review demo mode enabled."
+            self.appModel.enterAppleReviewDemoMode()
+            return nil
+        }
+        if let link = GatewayConnectDeepLink.fromSetupInput(raw) {
+            return link
+        }
+        guard GatewaySetupShortCode.looksLikeShortCode(raw) else {
+            self.setupStatusText = "Setup code not recognized or uses an insecure ws:// gateway URL."
+            return nil
+        }
+        guard let gateway = self.shortCodeRedemptionGateway() else {
+            self.setupStatusText = "Choose or enter a Gateway host before using a short code."
+            return nil
+        }
+        self.connectingGatewayID = "manual"
+        self.setupStatusText = "Redeeming setup short code..."
+        defer { self.connectingGatewayID = nil }
+        do {
+            return try await GatewaySetupShortCodeRedeemer().redeem(raw, through: gateway)
+        } catch {
+            self.setupStatusText = Self.shortCodeRedeemMessage(error)
+            return nil
+        }
     }
 
     func applyPendingGatewaySetupLinkIfNeeded() {
@@ -258,6 +299,24 @@ extension SettingsProTab {
             }
         }
         self.pendingManualAuthOverride = setupAuth.manualAuthOverride
+    }
+
+    func shortCodeRedemptionGateway() -> GatewayConnectDeepLink? {
+        let host = self.manualGatewayHost.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !host.isEmpty, let port = self.resolvedManualPort(host: host) {
+            let scheme = self.manualGatewayTLS ? "wss" : "ws"
+            if let link = GatewayConnectDeepLink.fromGatewayURL("\(scheme)://\(host):\(port)") {
+                return link
+            }
+        }
+        return nil
+    }
+
+    static func shortCodeRedeemMessage(_ error: Error) -> String {
+        if let error = error as? LocalizedError, let message = error.errorDescription {
+            return message
+        }
+        return "Could not redeem setup short code."
     }
 
     func openGatewayQRScanner() {

--- a/apps/ios/Sources/Design/SettingsProTabSections.swift
+++ b/apps/ios/Sources/Design/SettingsProTabSections.swift
@@ -717,7 +717,7 @@ extension SettingsProTab {
             VStack(alignment: .leading, spacing: 12) {
                 Text("Setup Code")
                     .font(.subheadline.weight(.semibold))
-                TextField("Paste setup code", text: self.$setupCode)
+                TextField("Paste setup or short code", text: self.$setupCode)
                     .textInputAutocapitalization(.never)
                     .autocorrectionDisabled()
                     .textFieldStyle(.roundedBorder)

--- a/apps/ios/Sources/Onboarding/OnboardingWizardView.swift
+++ b/apps/ios/Sources/Onboarding/OnboardingWizardView.swift
@@ -620,7 +620,7 @@ struct OnboardingWizardView: View {
 extension OnboardingWizardView {
     private var setupCodeSection: some View {
         Section {
-            TextField("Paste setup code", text: self.$setupCode)
+            TextField("Paste setup or short code", text: self.$setupCode)
                 .textInputAutocapitalization(.never)
                 .autocorrectionDisabled()
                 .onSubmit {
@@ -652,7 +652,7 @@ extension OnboardingWizardView {
         } header: {
             Text("Setup Code")
         } footer: {
-            Text("Use this if you received a setup code instead of a QR code.")
+            Text("Use this if you received a setup code or short code instead of a QR code.")
         }
     }
 
@@ -709,10 +709,7 @@ extension OnboardingWizardView {
             return
         }
 
-        guard let link = GatewayConnectDeepLink.fromSetupInput(raw) else {
-            self.setupCodeStatus = "Setup code not recognized or uses an insecure ws:// gateway URL."
-            return
-        }
+        guard let link = await self.resolveSetupInput(raw) else { return }
 
         self.connectingGatewayID = "setup-code"
         self.applyGatewayLink(link)
@@ -722,6 +719,47 @@ extension OnboardingWizardView {
         self.statusLine = "Setup code loaded. Connecting to \(link.host):\(link.port)..."
         self.step = .connect
         await self.connectManual()
+    }
+
+    private func resolveSetupInput(_ raw: String) async -> GatewayConnectDeepLink? {
+        if let link = GatewayConnectDeepLink.fromSetupInput(raw) {
+            return link
+        }
+        guard GatewaySetupShortCode.looksLikeShortCode(raw) else {
+            self.setupCodeStatus = "Setup code not recognized or uses an insecure ws:// gateway URL."
+            return nil
+        }
+        guard let gateway = self.shortCodeRedemptionGateway() else {
+            self.setupCodeStatus = "Choose or enter a Gateway host before using a short code."
+            return nil
+        }
+        self.connectingGatewayID = "setup-code"
+        self.setupCodeStatus = "Redeeming setup short code..."
+        do {
+            return try await GatewaySetupShortCodeRedeemer().redeem(raw, through: gateway)
+        } catch {
+            self.connectingGatewayID = nil
+            self.setupCodeStatus = Self.shortCodeRedeemMessage(error)
+            return nil
+        }
+    }
+
+    private func shortCodeRedemptionGateway() -> GatewayConnectDeepLink? {
+        let host = self.manualHost.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !host.isEmpty, self.manualPort > 0, self.manualPort <= 65535 {
+            let scheme = self.manualTLS ? "wss" : "ws"
+            if let link = GatewayConnectDeepLink.fromGatewayURL("\(scheme)://\(host):\(self.manualPort)") {
+                return link
+            }
+        }
+        return nil
+    }
+
+    private static func shortCodeRedeemMessage(_ error: Error) -> String {
+        if let error = error as? LocalizedError, let message = error.errorDescription {
+            return message
+        }
+        return "Could not redeem setup short code."
     }
 
     private func handleScannedLink(_ link: GatewayConnectDeepLink) {

--- a/apps/ios/SwiftSources.input.xcfilelist
+++ b/apps/ios/SwiftSources.input.xcfilelist
@@ -142,6 +142,7 @@ WatchApp/Sources/WatchInboxView.swift
 ../shared/OpenClawKit/Sources/OpenClawKit/Capabilities.swift
 ../shared/OpenClawKit/Sources/OpenClawKit/OpenClawKitResources.swift
 ../shared/OpenClawKit/Sources/OpenClawKit/DeepLinks.swift
+../shared/OpenClawKit/Sources/OpenClawKit/GatewaySetupShortCodeRedeemer.swift
 ../shared/OpenClawKit/Sources/OpenClawKit/JPEGTranscoder.swift
 ../shared/OpenClawKit/Sources/OpenClawKit/NodeError.swift
 ../shared/OpenClawKit/Sources/OpenClawKit/ScreenCommands.swift

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/DeepLinks.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/DeepLinks.swift
@@ -65,6 +65,20 @@ public struct GatewayConnectDeepLink: Codable, Sendable, Equatable {
             password: nil)
     }
 
+    /// Parse a gateway WebSocket/HTTP URL with optional auth fields from a setup source.
+    public static func fromGatewayURL(
+        _ urlString: String,
+        bootstrapToken: String? = nil,
+        token: String? = nil,
+        password: String? = nil) -> GatewayConnectDeepLink?
+    {
+        self.fromGatewayURLString(
+            urlString,
+            bootstrapToken: bootstrapToken,
+            token: token,
+            password: password)
+    }
+
     /// Parse a gateway setup payload from a device-pair setup code or copied setup text.
     ///
     /// Accepted inputs are:

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewaySetupShortCodeRedeemer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewaySetupShortCodeRedeemer.swift
@@ -1,0 +1,134 @@
+import Foundation
+
+public protocol GatewaySetupShortCodeHTTPClient: Sendable {
+    func data(for request: URLRequest) async throws -> (Data, URLResponse)
+}
+
+extension URLSession: GatewaySetupShortCodeHTTPClient {}
+
+public enum GatewaySetupShortCode {
+    private static let alphabet = Set("ABCDEFGHJKLMNPQRSTUVWXYZ23456789")
+    private static let codeLength = 8
+
+    public static func normalize(_ value: String) -> String? {
+        let normalized = value
+            .uppercased()
+            .replacingOccurrences(of: #"\s+"#, with: "", options: .regularExpression)
+            .replacingOccurrences(of: "-", with: "")
+        guard normalized.count == self.codeLength else { return nil }
+        guard normalized.allSatisfy({ self.alphabet.contains($0) }) else { return nil }
+        return normalized
+    }
+
+    public static func looksLikeShortCode(_ value: String) -> Bool {
+        self.normalize(value) != nil
+    }
+}
+
+public struct GatewaySetupShortCodeRedeemer: Sendable {
+    public enum RedeemError: Error, Equatable, LocalizedError {
+        case invalidCode
+        case invalidGateway
+        case invalidResponse
+        case invalidOrExpired
+        case rejected(statusCode: Int)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidCode:
+                "Setup short code is not valid."
+            case .invalidGateway:
+                "Choose a reachable Gateway before using a setup short code."
+            case .invalidResponse:
+                "Gateway returned an invalid setup response."
+            case .invalidOrExpired:
+                "Setup short code is invalid or expired."
+            case let .rejected(statusCode):
+                "Gateway rejected the setup short code (HTTP \(statusCode))."
+            }
+        }
+    }
+
+    private struct RedeemRequest: Encodable {
+        let code: String
+    }
+
+    private struct RedeemResponse: Decodable {
+        let ok: Bool
+        let payload: SetupPayload?
+    }
+
+    private struct SetupPayload: Decodable {
+        let url: String
+        let bootstrapToken: String
+        let token: String?
+        let password: String?
+    }
+
+    public let client: GatewaySetupShortCodeHTTPClient
+
+    public init(client: GatewaySetupShortCodeHTTPClient = URLSession.shared) {
+        self.client = client
+    }
+
+    public func redeem(
+        _ rawCode: String,
+        through gateway: GatewayConnectDeepLink) async throws -> GatewayConnectDeepLink
+    {
+        guard let code = GatewaySetupShortCode.normalize(rawCode) else {
+            throw RedeemError.invalidCode
+        }
+        guard let url = Self.redemptionURL(for: gateway) else {
+            throw RedeemError.invalidGateway
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "content-type")
+        request.httpBody = try JSONEncoder().encode(RedeemRequest(code: code))
+
+        let (data, response) = try await self.client.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw RedeemError.invalidResponse
+        }
+        if http.statusCode == 404 || http.statusCode == 400 {
+            throw RedeemError.invalidOrExpired
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            throw RedeemError.rejected(statusCode: http.statusCode)
+        }
+        let decoded = try JSONDecoder().decode(RedeemResponse.self, from: data)
+        guard decoded.ok, let payload = decoded.payload else {
+            throw RedeemError.invalidResponse
+        }
+        guard let link = GatewayConnectDeepLink.fromGatewayURL(
+            payload.url,
+            bootstrapToken: payload.bootstrapToken,
+            token: payload.token,
+            password: payload.password)
+        else {
+            throw RedeemError.invalidResponse
+        }
+        return link
+    }
+
+    public static func redemptionURL(for gateway: GatewayConnectDeepLink) -> URL? {
+        guard let websocketURL = gateway.websocketURL,
+              GatewayConnectDeepLink.fromGatewayURL(websocketURL.absoluteString) != nil,
+              var components = URLComponents(url: websocketURL, resolvingAgainstBaseURL: false)
+        else {
+            return nil
+        }
+        switch components.scheme?.lowercased() {
+        case "ws":
+            components.scheme = "http"
+        case "wss":
+            components.scheme = "https"
+        default:
+            return nil
+        }
+        components.path = "/api/v1/pairing/setup-code/redeem"
+        components.query = nil
+        components.fragment = nil
+        return components.url
+    }
+}

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewaySetupShortCodeRedeemerTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewaySetupShortCodeRedeemerTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+import OpenClawKit
+import Testing
+
+private struct MockSetupCodeHTTPClient: GatewaySetupShortCodeHTTPClient {
+    let handler: @Sendable (URLRequest) async throws -> (Data, URLResponse)
+
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        try await self.handler(request)
+    }
+}
+
+@Suite struct GatewaySetupShortCodeRedeemerTests {
+    @Test func normalizesGroupedShortCodes() {
+        #expect(GatewaySetupShortCode.normalize(" abcd-2345 ") == "ABCD2345")
+        #expect(GatewaySetupShortCode.normalize("ABCI2345") == nil)
+    }
+
+    @Test func redemptionURLUsesHttpPeerOfWebSocketGateway() {
+        let gateway = GatewayConnectDeepLink(
+            host: "openclaw.local",
+            port: 18789,
+            tls: false,
+            bootstrapToken: nil,
+            token: nil,
+            password: nil)
+
+        #expect(
+            GatewaySetupShortCodeRedeemer.redemptionURL(for: gateway)?.absoluteString ==
+                "http://openclaw.local:18789/api/v1/pairing/setup-code/redeem")
+    }
+
+    @Test func redeemPostsCodeAndReturnsSetupPayloadLink() async throws {
+        let gateway = GatewayConnectDeepLink(
+            host: "gateway.example.com",
+            port: 443,
+            tls: true,
+            bootstrapToken: nil,
+            token: nil,
+            password: nil)
+        let client = MockSetupCodeHTTPClient { request in
+            #expect(request.url?.absoluteString == "https://gateway.example.com:443/api/v1/pairing/setup-code/redeem")
+            #expect(request.httpMethod == "POST")
+            #expect(request.value(forHTTPHeaderField: "content-type") == "application/json")
+            #expect(String(data: request.httpBody ?? Data(), encoding: .utf8) == #"{"code":"ABCD2345"}"#)
+            let data = Data(
+                #"{"ok":true,"payload":{"url":"wss://gateway.example.com","bootstrapToken":"boot-123"}}"#.utf8)
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil)!
+            return (data, response)
+        }
+
+        let link = try await GatewaySetupShortCodeRedeemer(client: client).redeem("abcd-2345", through: gateway)
+
+        #expect(link == GatewayConnectDeepLink(
+            host: "gateway.example.com",
+            port: 443,
+            tls: true,
+            bootstrapToken: "boot-123",
+            token: nil,
+            password: nil))
+    }
+
+    @Test func redeemMapsInvalidOrExpiredResponses() async {
+        let gateway = GatewayConnectDeepLink(
+            host: "openclaw.local",
+            port: 18789,
+            tls: false,
+            bootstrapToken: nil,
+            token: nil,
+            password: nil)
+        let client = MockSetupCodeHTTPClient { request in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 404,
+                httpVersion: nil,
+                headerFields: nil)!
+            return (Data(#"{"ok":false}"#.utf8), response)
+        }
+
+        await #expect(throws: GatewaySetupShortCodeRedeemer.RedeemError.invalidOrExpired) {
+            _ = try await GatewaySetupShortCodeRedeemer(client: client).redeem("ABCD2345", through: gateway)
+        }
+    }
+}


### PR DESCRIPTION
Related: #98242
Pairs with gateway PR #98263.
Supersedes the iOS half of #98243.

## What Problem This Solves

The iOS app could consume long setup codes/QR payloads, but it had no path for the shorter Gateway-issued setup code flow. That left the mobile side unable to complete the one-step onboarding shape where a user enters a short code and lands connected.

## Why This Change Was Made

This adds a small OpenClawKit short-code redeemer, wires onboarding/settings entry points to try short-code redemption before falling back to existing setup-code parsing, and reuses the existing gateway link application/persistence paths once the gateway returns a setup-code-equivalent payload.

## User Impact

On iOS, users can enter a Gateway setup short code from onboarding or settings, have the app redeem it into the Gateway URL/bootstrap auth payload, persist the connection settings, and connect through the same setup-code path used by QR.

## Evidence

- `swift test --filter GatewaySetupShortCodeRedeemerTests` passed from `apps/shared/OpenClawKit`: 4 tests passed.
- XcodeBuildMCP iOS simulator build passed earlier on this split branch with existing unrelated warnings in `GatewaySettingsStore.swift`, `NodeAppModel.swift`, `TalkModeManager.swift`, `ChatViewModel.swift`, and `RealtimeTalkRelaySession.swift`.
- Integrated local proof before splitting: simulator setup-code flow connected after redeeming a fresh setup code from the Gateway state, and physical iPhone + Tailscale QR connected successfully.
- Redacted visual proof: https://gist.github.com/Solvely-Colin/0d647e2ffd90500925a062dc043d3764
- `git diff --check` passed.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --prompt "Review the iOS split for one-step QR/setup-code mobile pairing..."` clean: no accepted/actionable findings.
- Crabbox/Testbox not run per request to skip Crabbox.
