### PR TITLE
fix(system-prompt): move exec-approval + Authorized Senders below cache boundary

### DIFF
--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -2046,7 +2046,7 @@ jobs:
           - suite_id: native-live-src-gateway-profiles-anthropic-smoke
             suite_group: native-live-src-gateway-profiles-anthropic
             label: Native live gateway profiles Anthropic smoke
-            command: OPENCLAW_LIVE_GATEWAY_PROVIDERS=anthropic OPENCLAW_LIVE_GATEWAY_SMOKE=1 OPENCLAW_LIVE_GATEWAY_MAX_MODELS=1 node .release-harness/scripts/test-live-shard.mjs native-live-src-gateway-profiles
+            command: OPENCLAW_LIVE_GATEWAY_PROVIDERS=anthropic OPENCLAW_LIVE_GATEWAY_MODELS=anthropic/claude-sonnet-4-6,anthropic/claude-haiku-4-5 OPENCLAW_LIVE_GATEWAY_SMOKE=1 OPENCLAW_LIVE_GATEWAY_MAX_MODELS=2 node .release-harness/scripts/test-live-shard.mjs native-live-src-gateway-profiles
             timeout_minutes: 45
             profile_env_only: false
             profiles: stable

--- a/apps/ios/Sources/Onboarding/OnboardingWizardView.swift
+++ b/apps/ios/Sources/Onboarding/OnboardingWizardView.swift
@@ -730,6 +730,7 @@ extension OnboardingWizardView {
         self.showQRScanner = false
         self.connectMessage = "Connecting via QR code..."
         self.statusLine = "QR loaded. Connecting to \(link.host):\(link.port)..."
+        self.step = .connect
         Task { await self.connectManual() }
     }
 

--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -169,6 +169,9 @@ If stdout is non-empty, that text is the delivered result. If stdout is empty an
 <ParamField path="--thinking" type="string">
   Thinking level override.
 </ParamField>
+<ParamField path="--clear-thinking" type="boolean">
+  On `cron edit`, removes the per-job thinking override so the job follows normal cron thinking precedence. Cannot be combined with `--thinking`.
+</ParamField>
 <ParamField path="--light-context" type="boolean">
   Skip workspace bootstrap file injection.
 </ParamField>

--- a/docs/cli/cron.md
+++ b/docs/cli/cron.md
@@ -170,7 +170,7 @@ Use `--due` when you want the manual command to run only if the job is currently
 
 ## Models
 
-`cron add|edit --model <ref>` selects an allowed model for the job. `cron add|edit --fallbacks <list>` sets per-job fallback models, for example `--fallbacks openrouter/gpt-4.1-mini,openai/gpt-5`; pass `--fallbacks ""` for a strict run with no fallbacks. `cron edit <job-id> --clear-fallbacks` removes the per-job fallback override. `cron edit <job-id> --clear-model` removes the per-job model override so the job follows normal cron model-selection precedence (a stored cron-session override if present, otherwise the agent/default model); it cannot be combined with `--model`.
+`cron add|edit --model <ref>` selects an allowed model for the job. `cron add|edit --fallbacks <list>` sets per-job fallback models, for example `--fallbacks openrouter/gpt-4.1-mini,openai/gpt-5`; pass `--fallbacks ""` for a strict run with no fallbacks. `cron edit <job-id> --clear-fallbacks` removes the per-job fallback override. `cron edit <job-id> --clear-model` removes the per-job model override so the job follows normal cron model-selection precedence (a stored cron-session override if present, otherwise the agent/default model); it cannot be combined with `--model`. `cron add|edit --thinking <level>` sets a per-job thinking override; `cron edit <job-id> --clear-thinking` removes it so the job follows normal cron thinking precedence, and it cannot be combined with `--thinking`.
 
 <Warning>
 If the model is not allowed or cannot be resolved, cron fails the run with an explicit validation error instead of falling back to the job's agent or default model selection.

--- a/docs/cli/mcp.md
+++ b/docs/cli/mcp.md
@@ -253,7 +253,7 @@ Current bridge behavior:
 
 - inbound `user` transcript messages are forwarded as `notifications/claude/channel`
 - Claude permission requests received over MCP are tracked in-memory
-- if the linked conversation later sends `yes abcde` or `no abcde`, the bridge converts that to `notifications/claude/channel/permission`
+- if the command owner in the linked conversation later sends `yes abcde` or `no abcde`, the bridge converts that to `notifications/claude/channel/permission`
 - these notifications are live-session only; if the MCP client disconnects, there is no push target
 
 This is intentionally client-specific. Generic MCP clients should rely on the standard polling tools.

--- a/docs/gateway/cli-backends.md
+++ b/docs/gateway/cli-backends.md
@@ -382,8 +382,11 @@ api.registerTextTransforms({
 ```
 
 `input` rewrites the system prompt and user prompt passed to the CLI. `output`
-rewrites streamed assistant deltas and parsed final text before OpenClaw handles
-its own control markers and channel delivery.
+rewrites streamed assistant text and parsed final text before OpenClaw handles
+its own control markers and channel delivery. For provider-backed model calls,
+`output` also restores string values inside structured tool-call arguments after
+stream repair and before tool execution. Raw provider JSON fragments remain
+unchanged; consumers should use the structured partial, end, or result payload.
 
 For CLIs that emit provider-specific JSONL events, set `jsonlDialect` on that
 backend's config. Supported dialects are `claude-stream-json` for Claude

--- a/extensions/clickclack/package.json
+++ b/extensions/clickclack/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",
-    "openclaw": "2026.5.28"
+    "openclaw": "workspace:*"
   },
   "peerDependencies": {
     "openclaw": ">=2026.6.11"

--- a/extensions/codex/src/app-server/run-attempt-test-harness.ts
+++ b/extensions/codex/src/app-server/run-attempt-test-harness.ts
@@ -540,6 +540,6 @@ export function setupRunAttemptTestHooks(): void {
     vi.useRealTimers();
     vi.unstubAllEnvs();
     await closeCodexSandboxExecServersForTests();
-    await fs.rm(tempDir, { recursive: true, force: true });
+    await fs.rm(tempDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
   });
 }

--- a/extensions/discord/package.json
+++ b/extensions/discord/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",
-    "openclaw": "2026.5.28"
+    "openclaw": "workspace:*"
   },
   "peerDependencies": {
     "openclaw": ">=2026.6.11"

--- a/extensions/discord/src/api.test.ts
+++ b/extensions/discord/src/api.test.ts
@@ -1,9 +1,12 @@
 // Discord tests cover api plugin behavior.
+import { createServer, type Server } from "node:http";
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { withFetchPreconnect } from "openclaw/plugin-sdk/test-env";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { DiscordApiError, fetchDiscord, requestDiscord } from "./api.js";
 import { jsonResponse } from "./test-http-helpers.js";
+
+const DISCORD_SUCCESS_RESPONSE_LIMIT_BYTES = 4 * 1024 * 1024;
 
 function cancelTrackedResponse(
   text: string,
@@ -27,9 +30,54 @@ function cancelTrackedResponse(
   };
 }
 
+async function listenLoopbackServer(server: Server): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("expected loopback TCP address"));
+        return;
+      }
+      resolve(address.port);
+    });
+  });
+}
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve) => {
+    server.close(() => resolve());
+  });
+}
+
+function stubDiscordFetchToLoopback(
+  baseUrl: string,
+  onResponse?: (response: Response) => void,
+): void {
+  const realFetch = globalThis.fetch.bind(globalThis);
+  vi.stubGlobal(
+    "fetch",
+    withFetchPreconnect(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const originalUrl = new URL(input instanceof Request ? input.url : String(input));
+      expect(originalUrl.origin).toBe("https://discord.com");
+      expect(originalUrl.pathname).toMatch(/^\/api\/v10\//);
+      const loopbackUrl = new URL(`${originalUrl.pathname}${originalUrl.search}`, baseUrl);
+      const response = await realFetch(loopbackUrl, init);
+      onResponse?.(response);
+      return response;
+    }),
+  );
+}
+
 describe("fetchDiscord", () => {
   beforeEach(() => {
     vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   it("formats rate limit payloads without raw JSON", async () => {
@@ -271,5 +319,97 @@ describe("fetchDiscord", () => {
 
     expect(timeoutSpy).toHaveBeenCalledWith(MAX_TIMER_TIMEOUT_MS);
     expect(request?.signal).toBe(timeoutController.signal);
+  });
+
+  it("returns under-cap requestDiscord responses from a real loopback HTTP server", async () => {
+    const payload = { id: "channel-42", name: "loopback", type: 0 };
+    let contentLength: string | null | undefined;
+    let requestUrl: string | undefined;
+    let authorization: string | undefined;
+    const server = createServer((req, res) => {
+      requestUrl = req.url;
+      authorization = req.headers.authorization;
+      const body = JSON.stringify(payload);
+      res.writeHead(200, { "content-type": "application/json" });
+      res.write(body.slice(0, 12));
+      res.end(body.slice(12));
+    });
+    const port = await listenLoopbackServer(server);
+
+    try {
+      stubDiscordFetchToLoopback(`http://127.0.0.1:${port}`, (response) => {
+        contentLength = response.headers.get("content-length");
+      });
+
+      const result = await requestDiscord<typeof payload>("/channels/channel-42", "test-token", {
+        retry: { attempts: 1 },
+      });
+
+      expect(result).toEqual(payload);
+      expect(requestUrl).toBe("/api/v10/channels/channel-42");
+      expect(authorization).toBe("Bot test-token");
+      expect(contentLength).toBeNull();
+      console.log(
+        `[discord requestDiscord loopback proof] normal path: returned=${JSON.stringify(result)} content_length=${contentLength ?? "none"}`,
+      );
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it("rejects oversized valid JSON requestDiscord responses from a real loopback HTTP server", async () => {
+    const oversizedPayloadBytes = DISCORD_SUCCESS_RESPONSE_LIMIT_BYTES + 256 * 1024;
+    let contentLength: string | null | undefined;
+    let requestUrl: string | undefined;
+    let streamedBytes = 0;
+    const server = createServer((req, res) => {
+      requestUrl = req.url;
+      const chunk = Buffer.alloc(64 * 1024, 0x78);
+      res.writeHead(200, { "content-type": "application/json" });
+      res.write('{"id":"');
+
+      const writeMore = () => {
+        while (streamedBytes < oversizedPayloadBytes) {
+          if (res.destroyed) {
+            return;
+          }
+          streamedBytes += chunk.byteLength;
+          if (!res.write(chunk)) {
+            res.once("drain", writeMore);
+            return;
+          }
+        }
+        res.end('"}');
+      };
+
+      writeMore();
+    });
+    const port = await listenLoopbackServer(server);
+
+    try {
+      stubDiscordFetchToLoopback(`http://127.0.0.1:${port}`, (response) => {
+        contentLength = response.headers.get("content-length");
+      });
+
+      let error: unknown;
+      try {
+        await requestDiscord("/channels/123/messages", "test-token", {
+          retry: { attempts: 1 },
+        });
+      } catch (err) {
+        error = err;
+      }
+
+      expect(error).toBeInstanceOf(Error);
+      expect(String(error)).toContain("Discord API /channels/123/messages response body too large");
+      expect(String(error)).toContain(`limit: ${DISCORD_SUCCESS_RESPONSE_LIMIT_BYTES} bytes`);
+      expect(requestUrl).toBe("/api/v10/channels/123/messages");
+      expect(contentLength).toBeNull();
+      console.log(
+        `[discord requestDiscord loopback proof] oversized path: cap=${DISCORD_SUCCESS_RESPONSE_LIMIT_BYTES} streamed>=${streamedBytes} content_length=${contentLength ?? "none"} rejected=${String(error)}`,
+      );
+    } finally {
+      await closeServer(server);
+    }
   });
 });

--- a/extensions/discord/src/api.ts
+++ b/extensions/discord/src/api.ts
@@ -2,6 +2,7 @@
 import { resolveFetch } from "openclaw/plugin-sdk/fetch-runtime";
 import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 import { readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
+import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import {
   resolveRetryConfig,
   retryAsync,
@@ -19,6 +20,7 @@ const DISCORD_API_RETRY_DEFAULTS = {
 };
 const DISCORD_API_429_FALLBACK_RETRY_AFTER_SECONDS = 60;
 const DISCORD_API_ERROR_BODY_LIMIT_BYTES = 8 * 1024;
+const DISCORD_API_RESPONSE_BODY_LIMIT_BYTES = 4 * 1024 * 1024;
 
 type DiscordApiErrorPayload = {
   message?: string;
@@ -191,7 +193,13 @@ export async function requestDiscord<T>(
           retryAfter,
         );
       }
-      const text = await res.text().catch(() => "");
+      const responseBody = await readResponseWithLimit(res, DISCORD_API_RESPONSE_BODY_LIMIT_BYTES, {
+        onOverflow: ({ size, maxBytes }) =>
+          new Error(
+            `Discord API ${path} response body too large: ${size} bytes (limit: ${maxBytes} bytes)`,
+          ),
+      });
+      const text = new TextDecoder().decode(responseBody);
       if (!text.trim()) {
         return undefined as T;
       }

--- a/extensions/feishu/package.json
+++ b/extensions/feishu/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",
-    "openclaw": "2026.5.28"
+    "openclaw": "workspace:*"
   },
   "peerDependencies": {
     "openclaw": ">=2026.6.11"

--- a/extensions/google-meet/package.json
+++ b/extensions/google-meet/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",
-    "openclaw": "2026.5.28"
+    "openclaw": "workspace:*"
   },
   "peerDependencies": {
     "openclaw": ">=2026.6.11"

--- a/extensions/googlechat/package.json
+++ b/extensions/googlechat/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",
-    "openclaw": "2026.5.28"
+    "openclaw": "workspace:*"
   },
   "peerDependencies": {
     "openclaw": ">=2026.6.11"

--- a/extensions/irc/src/protocol.test.ts
+++ b/extensions/irc/src/protocol.test.ts
@@ -36,4 +36,52 @@ describe("irc protocol", () => {
     expect(() => sanitizeIrcTarget(" user")).toThrow(/Invalid IRC target/);
   });
 
+  describe("\\u escape surrogate-range guard", () => {
+    const LONE_SURROGATE = /[\uD800-\uDFFF]/;
+
+    it("preserves literal \\uXXXX when codepoint is a high surrogate", () => {
+      const out = sanitizeIrcOutboundText("\\uD800");
+      expect(LONE_SURROGATE.test(out)).toBe(false);
+    });
+
+    it("preserves literal \\uXXXX when codepoint is a low surrogate", () => {
+      const out = sanitizeIrcOutboundText("\\uDFFF");
+      expect(LONE_SURROGATE.test(out)).toBe(false);
+    });
+
+    it("still decodes valid BMP codepoints outside the surrogate range", () => {
+      expect(sanitizeIrcOutboundText("\\u0041")).toBe("A");
+      expect(sanitizeIrcOutboundText("\\u00e9")).toBe("é"); // é
+    });
+
+    it("decodes adjacent surrogate-pair escapes to the astral character", () => {
+      expect(sanitizeIrcOutboundText("\\uD83D\\uDE00")).toBe("😀");
+      expect(sanitizeIrcOutboundText("\\uD83D\\uDE00\\uD83D\\uDE01")).toBe("😀😁");
+    });
+
+    it("preserves lone high surrogate even when followed by a non-surrogate \\u", () => {
+      const out = sanitizeIrcOutboundText("\\uD800\\u0041");
+      expect(LONE_SURROGATE.test(out)).toBe(false);
+      expect(out).toContain("A");
+    });
+
+    it("decodes BMP-escaped prefix before a surrogate pair correctly", () => {
+      // Regression: \\u0041\\uD83D\\uDE00 must yield A😀, not A\\uD83D\\uDE00.
+      // The old step-1 regex \\u(xxxx)\\u(xxxx) would consume \\u0041\\uD83D as a
+      // non-pair, leaving \\uDE00 as a lone surrogate.
+      expect(sanitizeIrcOutboundText("\\u0041\\uD83D\\uDE00")).toBe("A😀");
+    });
+
+    it("handles lone high surrogate followed by a different surrogate pair", () => {
+      // \\uD800\\uD83D\\uDE00: D800 is lone (no matching low), D83D+DE00 form 😀.
+      // Use toBe rather than LONE_SURROGATE regex: emoji contains surrogate
+      // code units internally that would trigger a naive /[\uD800-\uDFFF]/ check.
+      expect(sanitizeIrcOutboundText("\\uD800\\uD83D\\uDE00")).toBe("\\uD800😀");
+    });
+
+    it("preserves two consecutive lone high surrogates", () => {
+      const out = sanitizeIrcOutboundText("\\uD800\\uD801");
+      expect(LONE_SURROGATE.test(out)).toBe(false);
+    });
+  });
 });

--- a/extensions/irc/src/protocol.ts
+++ b/extensions/irc/src/protocol.ts
@@ -109,13 +109,28 @@ export function parseIrcPrefix(prefix?: string): ParsedIrcPrefix {
 function decodeLiteralEscapes(input: string): string {
   // Defensive: this is not a full JS string unescaper.
   // It's just enough to catch common "\r\n" / "\u0001" style payloads.
-  return input
-    .replace(/\\r/g, "\r")
-    .replace(/\\n/g, "\n")
-    .replace(/\\t/g, "\t")
-    .replace(/\\0/g, "\0")
-    .replace(/\\x([0-9a-fA-F]{2})/g, (_, hex) => String.fromCharCode(Number.parseInt(hex, 16)))
-    .replace(/\\u([0-9a-fA-F]{4})/g, (_, hex) => String.fromCharCode(Number.parseInt(hex, 16)));
+  return (
+    input
+      .replace(/\\r/g, "\r")
+      .replace(/\\n/g, "\n")
+      .replace(/\\t/g, "\t")
+      .replace(/\\0/g, "\0")
+      .replace(/\\x([0-9a-fA-F]{2})/g, (_, hex) => String.fromCharCode(Number.parseInt(hex, 16)))
+      // Step 1: decode surrogate pairs — first group locked to high surrogate range
+      // (U+D800–U+DBFF: [dD][89abAB]xx), second to low surrogate range
+      // (U+DC00–U+DFFF: [dD][c-fC-F]xx). This prevents a non-surrogate \uXXXX
+      // from being greedily paired with the following high surrogate and consuming it.
+      .replace(/\\u([dD][89abAB][0-9a-fA-F]{2})\\u([dD][c-fC-F][0-9a-fA-F]{2})/g, (_match, h, l) =>
+        String.fromCodePoint(
+          0x10000 + ((Number.parseInt(h, 16) - 0xd800) << 10) + (Number.parseInt(l, 16) - 0xdc00),
+        ),
+      )
+      // Step 2: decode BMP codepoints; preserve lone surrogates as literals
+      .replace(/\\u([0-9a-fA-F]{4})/g, (match, hex) => {
+        const codePoint = Number.parseInt(hex, 16);
+        return codePoint >= 0xd800 && codePoint <= 0xdfff ? match : String.fromCharCode(codePoint);
+      })
+  );
 }
 
 export function sanitizeIrcOutboundText(text: string): string {

--- a/extensions/line/package.json
+++ b/extensions/line/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",
-    "openclaw": "2026.5.28"
+    "openclaw": "workspace:*"
   },
   "peerDependencies": {
     "openclaw": ">=2026.6.11"

--- a/extensions/matrix/package.json
+++ b/extensions/matrix/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",
-    "openclaw": "2026.5.28"
+    "openclaw": "workspace:*"
   },
   "peerDependencies": {
     "openclaw": ">=2026.6.11"

--- a/extensions/mattermost/package.json
+++ b/extensions/mattermost/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",
-    "openclaw": "2026.5.28"
+    "openclaw": "workspace:*"
   },
   "peerDependencies": {
     "openclaw": ">=2026.6.11"

--- a/extensions/memory-core/package.json
+++ b/extensions/memory-core/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",
-    "openclaw": "2026.5.28"
+    "openclaw": "workspace:*"
   },
   "peerDependencies": {
     "openclaw": ">=2026.6.11"

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -2290,4 +2290,26 @@ describe("memory index", () => {
       restoreMemoryIndexStateDir();
     }
   });
+  it("status-purpose manager detects unindexed session transcripts as dirty", async () => {
+    // Regression test for #97814: plain openclaw memory status (purpose: status)
+    // must report dirty=true when session files exist without index rows.
+    const cfg = createCfg({ sources: ["sessions"], sessionMemory: true });
+    const stateDirName = ".state-status-dirty-test";
+    setMemoryIndexStateDir(path.join(workspaceDir, stateDirName));
+    try {
+      const sessionsDir = resolveSessionTranscriptsDirForAgent("main");
+      await fs.mkdir(sessionsDir, { recursive: true });
+      const transcriptPath = path.join(sessionsDir, "status-dirty-test.jsonl");
+      await fs.writeFile(transcriptPath, JSON.stringify({ type: "test", ts: 1 }) + "\n");
+
+      const manager = await getFreshManager(cfg, "status");
+      managersForCleanup.add(manager);
+
+      const result = manager.status();
+      expect(result.dirty).toBe(true);
+    } finally {
+      restoreMemoryIndexStateDir();
+    }
+  });
+
 });

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -355,8 +355,8 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       pending: INDEX_CACHE_PENDING,
       key,
       bypassCache: transient,
-      create: async () =>
-        new MemoryIndexManager({
+      create: async () => {
+        const manager = new MemoryIndexManager({
           cacheKey: key,
           cfg,
           agentId,
@@ -364,7 +364,20 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
           settings,
           providerRequirement,
           purpose: params.purpose,
-        }),
+        });
+        // Lightweight dirty-file detection for status mode: check for unindexed
+        // session files on disk without triggering a full sync. This runs before
+        // any caller reads manager.status(), so the dirty flag is accurate when
+        // status() reads sessionsDirty.
+        if (purpose === "status" && manager.sources.has("sessions")) {
+          try {
+            await manager.markSessionStartupCatchupDirtyFiles();
+          } catch (err) {
+            log.warn("memory status session dirty detection failed: " + String(err));
+          }
+        }
+        return manager;
+      },
     });
   }
 

--- a/extensions/memory-wiki/package.json
+++ b/extensions/memory-wiki/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",
-    "openclaw": "2026.5.28"
+    "openclaw": "workspace:*"
   },
   "peerDependencies": {
     "openclaw": ">=2026.6.11"

--- a/extensions/memory-wiki/src/apply.test.ts
+++ b/extensions/memory-wiki/src/apply.test.ts
@@ -143,6 +143,93 @@ describe("applyMemoryWikiMutation", () => {
     );
   });
 
+  it("applies a write when an unrelated vault page has malformed frontmatter (#96125)", async () => {
+    const { rootDir, config } = await createVault({
+      prefix: "memory-wiki-apply-unrelated-invalid-",
+    });
+    await fs.mkdir(path.join(rootDir, "sources"), { recursive: true });
+    const brokenPath = path.join(rootDir, "sources", "broken.md");
+    const brokenPage = [
+      "---",
+      "pageType: source",
+      "id: source.broken",
+      "sourceIds:",
+      '  - **MEMORY.md line 235**:"some quoted, value"',
+      "---",
+      "",
+      "# Broken",
+    ].join("\n");
+    await fs.writeFile(brokenPath, brokenPage, "utf8");
+
+    const result = await applyMemoryWikiMutation({
+      config,
+      mutation: {
+        op: "create_synthesis",
+        title: "Healthy Synthesis",
+        body: "Healthy summary body.",
+        sourceIds: ["source.healthy"],
+      },
+    });
+
+    expect(result.changed).toBe(true);
+    expect(result.compile.pageCounts.source).toBe(0);
+    expect(result.compile.pageCounts.synthesis).toBe(1);
+    expect(result.compile.frontmatterErrors).toEqual([
+      expect.objectContaining({ relativePath: "sources/broken.md" }),
+    ]);
+    await expect(fs.readFile(brokenPath, "utf8")).resolves.toBe(brokenPage);
+  });
+
+  it.each([
+    {
+      name: "syntax-error",
+      frontmatterLines: [
+        "pageType: synthesis",
+        "id: synthesis.conflicted",
+        "sourceIds:",
+        '  - **MEMORY.md line 235**:"some quoted, value"',
+      ],
+      error: "Unexpected scalar",
+    },
+    {
+      name: "sequence-root",
+      frontmatterLines: ["- pageType: synthesis", "  id: synthesis.conflicted"],
+      error: "Wiki frontmatter must be a YAML mapping",
+    },
+  ])(
+    "rejects a malformed write target without replacing its metadata ($name) (#96125)",
+    async ({ frontmatterLines, error }) => {
+      const { rootDir, config } = await createVault({
+        prefix: "memory-wiki-apply-invalid-target-",
+      });
+      await fs.mkdir(path.join(rootDir, "syntheses"), { recursive: true });
+      const targetPath = path.join(rootDir, "syntheses", "conflicted.md");
+      const original = [
+        "---",
+        ...frontmatterLines,
+        "---",
+        "",
+        "# Conflicted",
+        "",
+        "Keep this body.",
+      ].join("\n");
+      await fs.writeFile(targetPath, original, "utf8");
+
+      await expect(
+        applyMemoryWikiMutation({
+          config,
+          mutation: {
+            op: "create_synthesis",
+            title: "Conflicted",
+            body: "Replacement body.",
+            sourceIds: ["source.new"],
+          },
+        }),
+      ).rejects.toThrow(error);
+      await expect(fs.readFile(targetPath, "utf8")).resolves.toBe(original);
+    },
+  );
+
   it("updates page metadata without overwriting existing human notes", async () => {
     const { rootDir, config } = await createVault({
       prefix: "memory-wiki-apply-",

--- a/extensions/memory-wiki/src/compile.test.ts
+++ b/extensions/memory-wiki/src/compile.test.ts
@@ -121,6 +121,115 @@ describe("compileMemoryWikiVault", () => {
     ).resolves.toContain('"text":"Alpha is the canonical source page."');
   });
 
+  it("excludes malformed pages from indexes, digests, counts, and page writes (#96125)", async () => {
+    const { rootDir, config } = await createVault({
+      rootDir: nextCaseRoot(),
+      initialize: true,
+      config: { render: { createDashboards: false } },
+    });
+    const brokenPath = path.join(rootDir, "syntheses", "broken.md");
+    const brokenPage = [
+      "---",
+      "pageType: synthesis",
+      "id: synthesis.broken",
+      "sourceIds:",
+      '  - **MEMORY.md line 235**:"some quoted, value"',
+      "---",
+      "",
+      "# Broken",
+      "",
+      "Body that compile must not rewrite.",
+    ].join("\n");
+    await fs.writeFile(brokenPath, brokenPage, "utf8");
+    await fs.writeFile(
+      path.join(rootDir, "syntheses", "healthy.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "synthesis",
+          id: "synthesis.healthy",
+          title: "Healthy",
+          sourceIds: ["source.alpha"],
+        },
+        body: "# Healthy\n",
+      }),
+      "utf8",
+    );
+
+    const result = await compileMemoryWikiVault(config);
+
+    expect(result.frontmatterErrors).toHaveLength(1);
+    expect(result.frontmatterErrors[0]).toMatchObject({
+      relativePath: "syntheses/broken.md",
+    });
+    expect(result.pageCounts.synthesis).toBe(1);
+    expect(result.pages.map((page) => page.relativePath)).not.toContain("syntheses/broken.md");
+    await expect(fs.readFile(brokenPath, "utf8")).resolves.toBe(brokenPage);
+    await expect(fs.readFile(path.join(rootDir, "index.md"), "utf8")).resolves.not.toContain(
+      "Broken",
+    );
+    await expect(
+      fs.readFile(path.join(rootDir, ".openclaw-wiki", "cache", "agent-digest.json"), "utf8"),
+    ).resolves.not.toContain("syntheses/broken.md");
+  });
+
+  it.each([
+    {
+      name: "root index with syntax-error frontmatter",
+      relativePath: "index.md",
+      frontmatterLines: [
+        "pageType: report",
+        "sourceIds:",
+        '  - **MEMORY.md line 235**:"some quoted, value"',
+      ],
+      error: "Unexpected scalar",
+    },
+    {
+      name: "root index with sequence-root frontmatter",
+      relativePath: "index.md",
+      frontmatterLines: ["- pageType: report"],
+      error: "Wiki frontmatter must be a YAML mapping",
+    },
+    {
+      name: "directory index with syntax-error frontmatter",
+      relativePath: "sources/index.md",
+      frontmatterLines: [
+        "pageType: report",
+        "sourceIds:",
+        '  - **MEMORY.md line 235**:"some quoted, value"',
+      ],
+      error: "Unexpected scalar",
+    },
+    {
+      name: "directory index with scalar-root frontmatter",
+      relativePath: "sources/index.md",
+      frontmatterLines: ["report"],
+      error: "Wiki frontmatter must be a YAML mapping",
+    },
+  ])(
+    "rejects $name without changing its bytes",
+    async ({ relativePath, frontmatterLines, error }) => {
+      const { rootDir, config } = await createVault({
+        rootDir: nextCaseRoot(),
+        initialize: true,
+        config: { render: { createDashboards: false } },
+      });
+      const targetPath = path.join(rootDir, relativePath);
+      const original = [
+        "---",
+        ...frontmatterLines,
+        "---",
+        "",
+        "# Existing Index",
+        "",
+        "Keep this body.",
+      ].join("\n");
+      await fs.writeFile(targetPath, original, "utf8");
+
+      await expect(compileMemoryWikiVault(config)).rejects.toThrow(error);
+      await expect(fs.readFile(targetPath, "utf8")).resolves.toBe(original);
+    },
+  );
+
   it("discovers pages in nested subdirectories during compile", async () => {
     const { rootDir, config } = await createVault({
       rootDir: nextCaseRoot(),

--- a/extensions/memory-wiki/src/compile.ts
+++ b/extensions/memory-wiki/src/compile.ts
@@ -34,9 +34,10 @@ import {
   isUnmanagedRawSourceSummary,
   parseWikiMarkdown,
   renderWikiMarkdown,
-  toWikiPageSummary,
+  scanWikiPageSummary,
   type WikiClaim,
   type WikiClaimEvidence,
+  type WikiPageFrontmatterError,
   type WikiPageKind,
   type WikiPageSummary,
   type WikiRelationship,
@@ -352,6 +353,7 @@ export type CompileMemoryWikiResult = {
   vaultRoot: string;
   pageCounts: Record<WikiPageKind, number>;
   pages: WikiPageSummary[];
+  frontmatterErrors: WikiPageFrontmatterError[];
   claimCount: number;
   updatedFiles: string[];
 };
@@ -377,7 +379,10 @@ async function collectMarkdownFiles(rootDir: string, relativeDir: string): Promi
     .toSorted((left, right) => left.localeCompare(right));
 }
 
-async function readPageSummaries(rootDir: string): Promise<WikiPageSummary[]> {
+async function readPageSummaries(rootDir: string): Promise<{
+  pages: WikiPageSummary[];
+  frontmatterErrors: WikiPageFrontmatterError[];
+}> {
   const filePaths = (
     await Promise.all(COMPILE_PAGE_GROUPS.map((group) => collectMarkdownFiles(rootDir, group.dir)))
   ).flat();
@@ -389,7 +394,7 @@ async function readPageSummaries(rootDir: string): Promise<WikiPageSummary[]> {
         () => fs.readFile(absolutePath, "utf8"),
         `read wiki page ${absolutePath}`,
       );
-      return toWikiPageSummary({ absolutePath, relativePath, raw });
+      return scanWikiPageSummary({ absolutePath, relativePath, raw });
     }),
     limit: READ_PAGE_SUMMARIES_CONCURRENCY,
     errorMode: "stop",
@@ -398,9 +403,14 @@ async function readPageSummaries(rootDir: string): Promise<WikiPageSummary[]> {
     throw readResult.firstError;
   }
 
-  return readResult.results
-    .flatMap((page) => (page ? [page] : []))
-    .toSorted((left, right) => left.title.localeCompare(right.title));
+  return {
+    pages: readResult.results
+      .flatMap((result) => (result.status === "valid" ? [result.page] : []))
+      .toSorted((left, right) => left.title.localeCompare(right.title)),
+    frontmatterErrors: readResult.results.flatMap((result) =>
+      result.status === "invalid-frontmatter" ? [result.error] : [],
+    ),
+  };
 }
 
 function buildPageCounts(pages: WikiPageSummary[]): Record<WikiPageKind, number> {
@@ -910,6 +920,9 @@ async function writeManagedMarkdownFile(params: {
 }): Promise<boolean> {
   const root = await fsRoot(params.rootDir);
   const original = await root.readText(params.relativePath).catch(() => `# ${params.title}\n`);
+  // Generated indexes bypass page discovery. Parse existing content here so
+  // managed-block updates cannot rewrite malformed frontmatter.
+  parseWikiMarkdown(original);
   const updated = replaceManagedMarkdownBlock({
     original,
     heading: "## Generated",
@@ -1380,10 +1393,12 @@ export async function compileMemoryWikiVault(
   const managedImportedSourcePagePaths = new Set(
     Object.values(sourceSyncState.entries).map((entry) => entry.pagePath.split(path.sep).join("/")),
   );
-  let pages = await readPageSummaries(rootDir);
+  let scan = await readPageSummaries(rootDir);
+  let pages = scan.pages;
   const updatedFiles = await refreshPageRelatedBlocks({ config, pages });
   if (updatedFiles.length > 0) {
-    pages = await readPageSummaries(rootDir);
+    scan = await readPageSummaries(rootDir);
+    pages = scan.pages;
   }
   const dashboardUpdatedFiles = await refreshDashboardPages({
     config,
@@ -1393,7 +1408,8 @@ export async function compileMemoryWikiVault(
   });
   updatedFiles.push(...dashboardUpdatedFiles);
   if (dashboardUpdatedFiles.length > 0) {
-    pages = await readPageSummaries(rootDir);
+    scan = await readPageSummaries(rootDir);
+    pages = scan.pages;
   }
   const counts = buildPageCounts(pages);
   const digestUpdatedFiles = await writeAgentDigestArtifacts({
@@ -1449,6 +1465,7 @@ export async function compileMemoryWikiVault(
     vaultRoot: rootDir,
     pageCounts: counts,
     pages,
+    frontmatterErrors: scan.frontmatterErrors,
     claimCount: pages.reduce((total, page) => total + page.claims.length, 0),
     updatedFiles,
   };

--- a/extensions/memory-wiki/src/lint.test.ts
+++ b/extensions/memory-wiki/src/lint.test.ts
@@ -493,4 +493,89 @@ describe("lintMemoryWikiVault", () => {
     await expect(fs.readFile(result.reportPath, "utf8")).resolves.toContain("### Contradictions");
     await expect(fs.readFile(result.reportPath, "utf8")).resolves.toContain("### Open Questions");
   });
+
+  it("reports unparsable frontmatter as a lint issue instead of failing the whole vault (#96125)", async () => {
+    const { rootDir, config } = await createVault({
+      prefix: "memory-wiki-lint-invalid-frontmatter-",
+    });
+    await fs.mkdir(path.join(rootDir, "syntheses"), { recursive: true });
+    await fs.writeFile(
+      path.join(rootDir, "syntheses", "broken.md"),
+      [
+        "---",
+        "pageType: synthesis",
+        "id: synthesis.broken",
+        "sourceIds:",
+        '  - **MEMORY.md line 235**:"some quoted, value"',
+        "---",
+        "",
+        "# Broken",
+        "",
+        "Body text.",
+      ].join("\n"),
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(rootDir, "syntheses", "healthy.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "synthesis",
+          id: "synthesis.healthy",
+          title: "Healthy",
+          sourceIds: ["source.alpha"],
+        },
+        body: "# Healthy\n",
+      }),
+      "utf8",
+    );
+
+    const result = await lintMemoryWikiVault(config);
+
+    expect(issueCodesForPath(result, "syntheses/broken.md")).toEqual(["invalid-frontmatter"]);
+    expect(issueCodesForPath(result, "syntheses/healthy.md")).not.toContain("invalid-frontmatter");
+    await expect(fs.readFile(result.reportPath, "utf8")).resolves.toContain(
+      "Frontmatter failed to parse: Unexpected scalar",
+    );
+  });
+
+  it.each([
+    {
+      name: "syntax-error",
+      frontmatterLines: [
+        "pageType: report",
+        "id: report.lint",
+        "sourceIds:",
+        '  - **MEMORY.md line 235**:"some quoted, value"',
+      ],
+      error: "Unexpected scalar",
+    },
+    {
+      name: "sequence-root",
+      frontmatterLines: ["- pageType: report", "  id: report.lint"],
+      error: "Wiki frontmatter must be a YAML mapping",
+    },
+  ])(
+    "rejects a malformed lint report without changing its bytes ($name)",
+    async ({ frontmatterLines, error }) => {
+      const { rootDir, config } = await createVault({
+        prefix: "memory-wiki-lint-malformed-report-",
+      });
+      const reportPath = path.join(rootDir, "reports", "lint.md");
+      await fs.mkdir(path.dirname(reportPath), { recursive: true });
+      const malformedReport = [
+        "---",
+        ...frontmatterLines,
+        "---",
+        "",
+        "# Lint Report",
+        "",
+        "Existing report body.",
+        "",
+      ].join("\n");
+      await fs.writeFile(reportPath, malformedReport, "utf8");
+
+      await expect(lintMemoryWikiVault(config)).rejects.toThrow(error);
+      await expect(fs.readFile(reportPath, "utf8")).resolves.toBe(malformedReport);
+    },
+  );
 });

--- a/extensions/memory-wiki/src/lint.ts
+++ b/extensions/memory-wiki/src/lint.ts
@@ -15,6 +15,7 @@ import type { ResolvedMemoryWikiConfig } from "./config.js";
 import { appendMemoryWikiLog } from "./log.js";
 import {
   isUnmanagedRawSourceSummary,
+  parseWikiMarkdown,
   renderWikiMarkdown,
   type WikiPageSummary,
 } from "./markdown.js";
@@ -24,6 +25,7 @@ type MemoryWikiLintIssue = {
   severity: "error" | "warning";
   category: "structure" | "provenance" | "links" | "contradictions" | "open-questions" | "quality";
   code:
+    | "invalid-frontmatter"
     | "missing-id"
     | "duplicate-id"
     | "missing-page-type"
@@ -369,6 +371,9 @@ async function writeLintReport(rootDir: string, issues: MemoryWikiLintIssue[]): 
       body: "# Lint Report\n",
     }),
   );
+  // The lint report is itself a wiki page. Keep its metadata fail-closed before
+  // replacing the managed body so malformed frontmatter is never rewritten.
+  parseWikiMarkdown(original);
   const updated = replaceManagedMarkdownBlock({
     original,
     heading: "## Generated",
@@ -388,7 +393,18 @@ export async function lintMemoryWikiVault(
   const managedImportedSourcePagePaths = new Set(
     Object.values(sourceSyncState.entries).map((entry) => entry.pagePath.split(path.sep).join("/")),
   );
-  const issues = collectPageIssues(compileResult.pages, managedImportedSourcePagePaths);
+  const issues = [
+    ...compileResult.frontmatterErrors.map(
+      (error): MemoryWikiLintIssue => ({
+        severity: "error",
+        category: "structure",
+        code: "invalid-frontmatter",
+        path: error.relativePath,
+        message: `Frontmatter failed to parse: ${error.message}`,
+      }),
+    ),
+    ...collectPageIssues(compileResult.pages, managedImportedSourcePagePaths),
+  ].toSorted((left, right) => left.path.localeCompare(right.path));
   const issuesByCategory = buildIssuesByCategory(issues);
   const reportPath = await writeLintReport(config.vault.path, issues);
 

--- a/extensions/memory-wiki/src/markdown.test.ts
+++ b/extensions/memory-wiki/src/markdown.test.ts
@@ -3,7 +3,9 @@ import { createHash } from "node:crypto";
 import { describe, expect, it } from "vitest";
 import {
   createWikiPageFilename,
+  parseWikiMarkdown,
   renderWikiMarkdown,
+  scanWikiPageSummary,
   slugifyWikiSegment,
   toWikiPageSummary,
   WIKI_RAW_SOURCE_MARKER,
@@ -420,5 +422,85 @@ describe("toWikiPageSummary", () => {
         privacyTier: "local-private",
       },
     ]);
+  });
+
+  it("reports and excludes unparsable frontmatter from page scans (#96125)", () => {
+    const raw = [
+      "---",
+      "pageType: synthesis",
+      "id: synthesis.test",
+      "sourceIds:",
+      '  - **MEMORY.md line 235**:"some quoted, value"',
+      "---",
+      "",
+      "# Test Title",
+      "",
+      "Body text that should be preserved.",
+    ].join("\n");
+
+    const params = {
+      absolutePath: "/tmp/wiki/syntheses/test.md",
+      relativePath: "syntheses/test.md",
+      raw,
+    };
+    const result = scanWikiPageSummary(params);
+    if (result.status !== "invalid-frontmatter") {
+      throw new Error("expected invalid frontmatter result");
+    }
+
+    expect(result.error.relativePath).toBe("syntheses/test.md");
+    expect(result.error.message).toContain("Unexpected scalar");
+    expect(toWikiPageSummary(params)).toBeNull();
+    expect(() => parseWikiMarkdown(raw)).toThrow("Unexpected scalar");
+  });
+
+  it.each([
+    { name: "sequence", frontmatter: "- pageType: synthesis" },
+    { name: "scalar", frontmatter: "synthesis" },
+  ])("reports and excludes $name frontmatter roots from page scans", ({ frontmatter }) => {
+    const raw = ["---", frontmatter, "---", "", "# Invalid Root"].join("\n");
+    const params = {
+      absolutePath: "/tmp/wiki/syntheses/invalid-root.md",
+      relativePath: "syntheses/invalid-root.md",
+      raw,
+    };
+    const result = scanWikiPageSummary(params);
+    if (result.status !== "invalid-frontmatter") {
+      throw new Error("expected invalid frontmatter result");
+    }
+
+    expect(result.error.message).toBe("Wiki frontmatter must be a YAML mapping");
+    expect(toWikiPageSummary(params)).toBeNull();
+    expect(() => parseWikiMarkdown(raw)).toThrow("Wiki frontmatter must be a YAML mapping");
+  });
+
+  it("preserves frontmatter and body for valid YAML (#96125 control)", () => {
+    const raw = [
+      "---",
+      "pageType: synthesis",
+      "id: synthesis.healthy",
+      "sourceIds:",
+      "  - source.alpha",
+      "---",
+      "",
+      "# Healthy Page",
+      "",
+      "Healthy body.",
+    ].join("\n");
+
+    const summary = toWikiPageSummary({
+      absolutePath: "/tmp/wiki/syntheses/healthy.md",
+      relativePath: "syntheses/healthy.md",
+      raw,
+    });
+    if (!summary) {
+      throw new Error("expected wiki summary");
+    }
+
+    expect(summary.hasFrontmatter).toBe(true);
+    expect(summary.title).toBe("Healthy Page");
+    expect(summary.id).toBe("synthesis.healthy");
+    expect(summary.sourceIds).toEqual(["source.alpha"]);
+    expect(summary.pageType).toBe("synthesis");
   });
 });

--- a/extensions/memory-wiki/src/markdown.ts
+++ b/extensions/memory-wiki/src/markdown.ts
@@ -73,6 +73,11 @@ export type WikiRelationship = {
   updatedAt?: string;
 };
 
+export type WikiPageFrontmatterError = {
+  relativePath: string;
+  message: string;
+};
+
 export type WikiPageSummary = {
   absolutePath: string;
   relativePath: string;
@@ -108,6 +113,11 @@ export type WikiPageSummary = {
   lastRefreshedAt?: string;
   updatedAt?: string;
 };
+
+export type WikiPageSummaryScanResult =
+  | { status: "valid"; page: WikiPageSummary }
+  | { status: "invalid-frontmatter"; error: WikiPageFrontmatterError }
+  | { status: "ignored" };
 
 const FRONTMATTER_PATTERN = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/;
 const OBSIDIAN_LINK_PATTERN = /\[\[([^\]|]+)(?:\|[^\]]+)?\]\]/g;
@@ -179,12 +189,14 @@ export function parseWikiMarkdown(content: string): ParsedWikiMarkdown {
     return { hasFrontmatter: false, frontmatter: {}, body: content };
   }
   const parsed = YAML.parse(match[1]) as unknown;
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    // Every writer spreads this value back into YAML. Reject non-mapping roots
+    // so an edit cannot silently replace scalar or sequence frontmatter.
+    throw new TypeError("Wiki frontmatter must be a YAML mapping");
+  }
   return {
     hasFrontmatter: true,
-    frontmatter:
-      parsed && typeof parsed === "object" && !Array.isArray(parsed)
-        ? (parsed as Record<string, unknown>)
-        : {},
+    frontmatter: parsed as Record<string, unknown>,
     body: content.slice(match[0].length),
   };
 }
@@ -613,16 +625,29 @@ export function inferWikiPageKind(relativePath: string): WikiPageKind | null {
   return null;
 }
 
-export function toWikiPageSummary(params: {
+export function scanWikiPageSummary(params: {
   absolutePath: string;
   relativePath: string;
   raw: string;
-}): WikiPageSummary | null {
+}): WikiPageSummaryScanResult {
   const kind = inferWikiPageKind(params.relativePath);
   if (!kind) {
-    return null;
+    return { status: "ignored" };
   }
-  const parsed = parseWikiMarkdown(params.raw);
+  let parsed: ParsedWikiMarkdown;
+  try {
+    parsed = parseWikiMarkdown(params.raw);
+  } catch (error) {
+    // Vault scans exclude malformed pages from derived state, while direct parse callers
+    // stay strict so write paths cannot replace unparsed metadata with empty fields.
+    return {
+      status: "invalid-frontmatter",
+      error: {
+        relativePath: params.relativePath.split(path.sep).join("/"),
+        message: error instanceof Error ? error.message : String(error),
+      },
+    };
+  }
   const title =
     (typeof parsed.frontmatter.title === "string" && parsed.frontmatter.title.trim()) ||
     extractTitleFromMarkdown(parsed.body) ||
@@ -638,44 +663,56 @@ export function toWikiPageSummary(params: {
     detectUnmanagedRawSourceBody(parsed.body);
 
   return {
-    absolutePath: params.absolutePath,
-    relativePath: params.relativePath.split(path.sep).join("/"),
-    kind,
-    title,
-    hasFrontmatter: parsed.hasFrontmatter,
-    id: normalizeOptionalString(parsed.frontmatter.id),
-    pageType: normalizeOptionalString(parsed.frontmatter.pageType),
-    entityType: normalizeOptionalString(parsed.frontmatter.entityType),
-    canonicalId: normalizeOptionalString(parsed.frontmatter.canonicalId),
-    aliases: normalizeSingleOrTrimmedStringList(parsed.frontmatter.aliases),
-    sourceIds: normalizeSourceIds(parsed.frontmatter.sourceIds),
-    linkTargets: extractWikiLinks(params.raw, params.relativePath.split(path.sep).join("/")),
-    claims: normalizeWikiClaims(parsed.frontmatter.claims),
-    contradictions: normalizeSingleOrTrimmedStringList(parsed.frontmatter.contradictions),
-    questions: normalizeSingleOrTrimmedStringList(parsed.frontmatter.questions),
-    confidence:
-      typeof parsed.frontmatter.confidence === "number" &&
-      Number.isFinite(parsed.frontmatter.confidence)
-        ? parsed.frontmatter.confidence
-        : undefined,
-    privacyTier: normalizeOptionalString(parsed.frontmatter.privacyTier),
-    personCard: normalizeWikiPersonCard(parsed.frontmatter.personCard),
-    relationships: normalizeWikiRelationships(parsed.frontmatter.relationships),
-    bestUsedFor: normalizeSingleOrTrimmedStringList(parsed.frontmatter.bestUsedFor),
-    notEnoughFor: normalizeSingleOrTrimmedStringList(parsed.frontmatter.notEnoughFor),
-    sourceType: normalizeOptionalString(parsed.frontmatter.sourceType),
-    provenanceMode: normalizeOptionalString(parsed.frontmatter.provenanceMode),
-    ...(importedSourceBody ? { importedSourceBody } : {}),
-    ...(generatedSourceBody ? { generatedSourceBody } : {}),
-    ...(unmanagedRawSourceBody ? { unmanagedRawSourceBody } : {}),
-    sourcePath: normalizeOptionalString(parsed.frontmatter.sourcePath),
-    bridgeRelativePath: normalizeOptionalString(parsed.frontmatter.bridgeRelativePath),
-    bridgeWorkspaceDir: normalizeOptionalString(parsed.frontmatter.bridgeWorkspaceDir),
-    unsafeLocalConfiguredPath: normalizeOptionalString(
-      parsed.frontmatter.unsafeLocalConfiguredPath,
-    ),
-    unsafeLocalRelativePath: normalizeOptionalString(parsed.frontmatter.unsafeLocalRelativePath),
-    lastRefreshedAt: normalizeOptionalString(parsed.frontmatter.lastRefreshedAt),
-    updatedAt: normalizeOptionalString(parsed.frontmatter.updatedAt),
+    status: "valid",
+    page: {
+      absolutePath: params.absolutePath,
+      relativePath: params.relativePath.split(path.sep).join("/"),
+      kind,
+      title,
+      hasFrontmatter: parsed.hasFrontmatter,
+      id: normalizeOptionalString(parsed.frontmatter.id),
+      pageType: normalizeOptionalString(parsed.frontmatter.pageType),
+      entityType: normalizeOptionalString(parsed.frontmatter.entityType),
+      canonicalId: normalizeOptionalString(parsed.frontmatter.canonicalId),
+      aliases: normalizeSingleOrTrimmedStringList(parsed.frontmatter.aliases),
+      sourceIds: normalizeSourceIds(parsed.frontmatter.sourceIds),
+      linkTargets: extractWikiLinks(params.raw, params.relativePath.split(path.sep).join("/")),
+      claims: normalizeWikiClaims(parsed.frontmatter.claims),
+      contradictions: normalizeSingleOrTrimmedStringList(parsed.frontmatter.contradictions),
+      questions: normalizeSingleOrTrimmedStringList(parsed.frontmatter.questions),
+      confidence:
+        typeof parsed.frontmatter.confidence === "number" &&
+        Number.isFinite(parsed.frontmatter.confidence)
+          ? parsed.frontmatter.confidence
+          : undefined,
+      privacyTier: normalizeOptionalString(parsed.frontmatter.privacyTier),
+      personCard: normalizeWikiPersonCard(parsed.frontmatter.personCard),
+      relationships: normalizeWikiRelationships(parsed.frontmatter.relationships),
+      bestUsedFor: normalizeSingleOrTrimmedStringList(parsed.frontmatter.bestUsedFor),
+      notEnoughFor: normalizeSingleOrTrimmedStringList(parsed.frontmatter.notEnoughFor),
+      sourceType: normalizeOptionalString(parsed.frontmatter.sourceType),
+      provenanceMode: normalizeOptionalString(parsed.frontmatter.provenanceMode),
+      ...(importedSourceBody ? { importedSourceBody } : {}),
+      ...(generatedSourceBody ? { generatedSourceBody } : {}),
+      ...(unmanagedRawSourceBody ? { unmanagedRawSourceBody } : {}),
+      sourcePath: normalizeOptionalString(parsed.frontmatter.sourcePath),
+      bridgeRelativePath: normalizeOptionalString(parsed.frontmatter.bridgeRelativePath),
+      bridgeWorkspaceDir: normalizeOptionalString(parsed.frontmatter.bridgeWorkspaceDir),
+      unsafeLocalConfiguredPath: normalizeOptionalString(
+        parsed.frontmatter.unsafeLocalConfiguredPath,
+      ),
+      unsafeLocalRelativePath: normalizeOptionalString(parsed.frontmatter.unsafeLocalRelativePath),
+      lastRefreshedAt: normalizeOptionalString(parsed.frontmatter.lastRefreshedAt),
+      updatedAt: normalizeOptionalString(parsed.frontmatter.updatedAt),
+    },
   };
+}
+
+export function toWikiPageSummary(params: {
+  absolutePath: string;
+  relativePath: string;
+  raw: string;
+}): WikiPageSummary | null {
+  const result = scanWikiPageSummary(params);
+  return result.status === "valid" ? result.page : null;
 }

--- a/extensions/memory-wiki/src/query.test.ts
+++ b/extensions/memory-wiki/src/query.test.ts
@@ -209,6 +209,38 @@ describe("searchMemoryWiki", () => {
     expect(getActiveMemorySearchManagerMock).not.toHaveBeenCalled();
   });
 
+  it("skips malformed pages while searching the rest of the vault (#96125)", async () => {
+    const { rootDir, config } = await createQueryVault({ initialize: true });
+    await fs.writeFile(
+      path.join(rootDir, "sources", "broken.md"),
+      [
+        "---",
+        "pageType: source",
+        "id: source.broken",
+        "sourceIds:",
+        '  - **MEMORY.md line 235**:"some quoted, value"',
+        "---",
+        "",
+        "# Broken",
+        "",
+        "poison needle",
+      ].join("\n"),
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(rootDir, "sources", "healthy.md"),
+      renderWikiMarkdown({
+        frontmatter: { pageType: "source", id: "source.healthy", title: "Healthy Source" },
+        body: "# Healthy Source\n\nhealthy needle\n",
+      }),
+      "utf8",
+    );
+
+    const results = await searchMemoryWiki({ config, query: "needle" });
+
+    expect(collectWikiResultPaths(results)).toEqual(["sources/healthy.md"]);
+  });
+
   it("uses the default search limit for non-finite maxResults", async () => {
     const { rootDir, config } = await createQueryVault({
       initialize: true,

--- a/extensions/memory-wiki/src/status.test.ts
+++ b/extensions/memory-wiki/src/status.test.ts
@@ -125,6 +125,43 @@ describe("resolveMemoryWikiStatus", () => {
     expect(status.sourceCounts.native).toBe(2);
   });
 
+  it("excludes malformed pages from status counts (#96125)", async () => {
+    const { rootDir, config } = await createVault({
+      prefix: "memory-wiki-status-invalid-frontmatter-",
+      initialize: true,
+    });
+    await fs.writeFile(
+      path.join(rootDir, "sources", "broken.md"),
+      [
+        "---",
+        "pageType: source",
+        "id: source.broken",
+        "sourceIds:",
+        '  - **MEMORY.md line 235**:"some quoted, value"',
+        "---",
+        "",
+        "# Broken",
+      ].join("\n"),
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(rootDir, "sources", "healthy.md"),
+      renderWikiMarkdown({
+        frontmatter: { pageType: "source", id: "source.healthy", title: "Healthy" },
+        body: "# Healthy\n",
+      }),
+      "utf8",
+    );
+
+    const status = await resolveMemoryWikiStatus(config, {
+      pathExists: async () => true,
+      resolveCommand: async () => null,
+    });
+
+    expect(status.pageCounts.source).toBe(1);
+    expect(status.sourceCounts.native).toBe(1);
+  });
+
   it("counts source provenance from the vault", async () => {
     const { rootDir, config } = await createVault({
       prefix: "memory-wiki-status-",

--- a/extensions/memory-wiki/src/status.ts
+++ b/extensions/memory-wiki/src/status.ts
@@ -5,7 +5,7 @@ import { listActiveMemoryPublicArtifacts } from "openclaw/plugin-sdk/memory-host
 import { pathExists } from "openclaw/plugin-sdk/security-runtime";
 import type { OpenClawConfig } from "../api.js";
 import type { ResolvedMemoryWikiConfig } from "./config.js";
-import { inferWikiPageKind, toWikiPageSummary, type WikiPageKind } from "./markdown.js";
+import { toWikiPageSummary, type WikiPageKind } from "./markdown.js";
 import { probeObsidianCli } from "./obsidian.js";
 
 type MemoryWikiStatusWarning = {
@@ -97,37 +97,35 @@ async function collectVaultCounts(vaultPath: string): Promise<{
       }
       const absolutePath = path.join(entry.parentPath ?? dirPath, entry.name);
       const relativeToVault = path.relative(vaultPath, absolutePath).split(path.sep).join("/");
-      const kind = inferWikiPageKind(relativeToVault);
-      if (kind) {
-        pageCounts[kind] += 1;
+      const raw = await fs.readFile(absolutePath, "utf8").catch(() => null);
+      if (raw === null) {
+        continue;
       }
-      if (dir === "sources") {
-        const raw = await fs.readFile(absolutePath, "utf8").catch(() => null);
-        if (!raw) {
-          continue;
-        }
-        const page = toWikiPageSummary({
-          absolutePath,
-          relativePath: relativeToVault,
-          raw,
-        });
-        if (!page) {
-          continue;
-        }
-        if (page.sourceType === "memory-bridge-events") {
-          sourceCounts.bridgeEvents += 1;
-        } else if (page.sourceType === "memory-bridge") {
-          sourceCounts.bridge += 1;
-        } else if (
-          page.provenanceMode === "unsafe-local" ||
-          page.sourceType === "memory-unsafe-local"
-        ) {
-          sourceCounts.unsafeLocal += 1;
-        } else if (!page.sourceType) {
-          sourceCounts.native += 1;
-        } else {
-          sourceCounts.other += 1;
-        }
+      const page = toWikiPageSummary({
+        absolutePath,
+        relativePath: relativeToVault,
+        raw,
+      });
+      if (!page) {
+        continue;
+      }
+      pageCounts[page.kind] += 1;
+      if (page.kind !== "source") {
+        continue;
+      }
+      if (page.sourceType === "memory-bridge-events") {
+        sourceCounts.bridgeEvents += 1;
+      } else if (page.sourceType === "memory-bridge") {
+        sourceCounts.bridge += 1;
+      } else if (
+        page.provenanceMode === "unsafe-local" ||
+        page.sourceType === "memory-unsafe-local"
+      ) {
+        sourceCounts.unsafeLocal += 1;
+      } else if (!page.sourceType) {
+        sourceCounts.native += 1;
+      } else {
+        sourceCounts.other += 1;
       }
     }
   }

--- a/extensions/migrate-claude/package.json
+++ b/extensions/migrate-claude/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",
-    "openclaw": "2026.5.28"
+    "openclaw": "workspace:*"
   },
   "peerDependencies": {
     "openclaw": ">=2026.6.11"

--- a/extensions/migrate-hermes/package.json
+++ b/extensions/migrate-hermes/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",
-    "openclaw": "2026.5.28"
+    "openclaw": "workspace:*"
   },
   "peerDependencies": {
     "openclaw": ">=2026.6.11"

--- a/extensions/msteams/package.json
+++ b/extensions/msteams/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",
     "jose": "6.2.3",
-    "openclaw": "2026.5.28"
+    "openclaw": "workspace:*"
   },
   "peerDependencies": {
     "openclaw": ">=2026.6.11"

--- a/extensions/nextcloud-talk/package.json
+++ b/extensions/nextcloud-talk/package.json
@@ -9,7 +9,7 @@
   "type": "module",
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",
-    "openclaw": "2026.5.28"
+    "openclaw": "workspace:*"
   },
   "peerDependencies": {
     "openclaw": ">=2026.6.11"

--- a/extensions/nostr/package.json
+++ b/extensions/nostr/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",
-    "openclaw": "2026.5.28"
+    "openclaw": "workspace:*"
   },
   "peerDependencies": {
     "openclaw": ">=2026.6.11"

--- a/extensions/oc-path/package.json
+++ b/extensions/oc-path/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",
-    "openclaw": "2026.5.28"
+    "openclaw": "workspace:*"
   },
   "peerDependencies": {
     "openclaw": ">=2026.6.11"

--- a/extensions/pixverse/package.json
+++ b/extensions/pixverse/package.json
@@ -9,7 +9,7 @@
   "type": "module",
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",
-    "openclaw": "2026.5.28"
+    "openclaw": "workspace:*"
   },
   "peerDependencies": {
     "openclaw": ">=2026.6.11"

--- a/extensions/policy/package.json
+++ b/extensions/policy/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",
-    "openclaw": "2026.5.28"
+    "openclaw": "workspace:*"
   },
   "peerDependencies": {
     "openclaw": ">=2026.6.11"

--- a/extensions/qa-channel/package.json
+++ b/extensions/qa-channel/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",
-    "openclaw": "2026.5.28"
+    "openclaw": "workspace:*"
   },
   "peerDependencies": {
     "openclaw": ">=2026.6.11"

--- a/extensions/qa-lab/package.json
+++ b/extensions/qa-lab/package.json
@@ -16,8 +16,8 @@
     "@openclaw/plugin-sdk": "workspace:*",
     "@openclaw/slack": "workspace:*",
     "@openclaw/whatsapp": "workspace:*",
-    "@openclaw/crabline": "0.1.5",
-    "openclaw": "2026.5.28"
+    "@openclaw/crabline": "0.1.6",
+    "openclaw": "workspace:*"
   },
   "peerDependencies": {
     "openclaw": ">=2026.6.11"

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -2615,7 +2615,7 @@ async function buildResponsesPayload(
   if (/memory tools check/i.test(allInputText)) {
     if (!scenarioToolOutput) {
       return buildToolCallEventsWithArgs("memory_search", {
-        query: "project codename ORBIT-9",
+        query: "hidden project codename",
         maxResults: 3,
       });
     }

--- a/extensions/qa-lab/src/runtime-tool-fixture.test.ts
+++ b/extensions/qa-lab/src/runtime-tool-fixture.test.ts
@@ -776,6 +776,253 @@ describe("runtime tool fixture", () => {
     expect(details).toContain("read mock provider failure planned args");
   });
 
+  it("accepts non-required mock fixtures when both paths are planned without direct output", async () => {
+    const env = await makeEnv({
+      mock: { baseUrl: "http://127.0.0.1:9999" },
+    });
+    const fetchJson = vi
+      .fn()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          allInputText: "target=image_generate",
+          plannedToolCallId: "call-image-happy",
+          plannedToolName: "image_generate",
+          plannedToolArgs: { prompt: "QA lighthouse", filename: "runtime-tool-fixture" },
+        },
+        {
+          allInputText: "failure target=image_generate",
+          plannedToolCallId: "call-image-failure",
+          plannedToolName: "image_generate",
+          plannedToolArgs: { __qaFailureMode: "denied-input" },
+        },
+      ]);
+
+    const details = await runRuntimeToolFixture(
+      env,
+      {
+        toolName: "image_generate",
+        toolCoverage: {
+          bucket: "openclaw-dynamic-integration",
+          expectedLayer: "openclaw-dynamic",
+          required: false,
+          action: "optional runtime parity gate with async image completion coverage",
+        },
+        promptSnippet: "target=image_generate",
+        failurePromptSnippet: "failure target=image_generate",
+      },
+      {
+        createSession: vi.fn(async (_env, _label, key) => key!),
+        readEffectiveTools: vi.fn(async () => new Set(["image_generate"])),
+        runAgentPrompt: vi.fn(async () => ({})),
+        fetchJson,
+        ensureImageGenerationConfigured: vi.fn(),
+      },
+    );
+
+    expect(details).toContain("image_generate mock provider report-only");
+    expect(details).toContain("image_generate mock provider happy planned args");
+    expect(details).toContain("image_generate mock provider failure planned args");
+  });
+
+  it("still rejects failed happy output for non-required mock fixtures", async () => {
+    const env = await makeEnv({
+      mock: { baseUrl: "http://127.0.0.1:9999" },
+    });
+    const fetchJson = vi
+      .fn()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          allInputText: "target=image_generate",
+          plannedToolCallId: "call-image-happy",
+          plannedToolName: "image_generate",
+          plannedToolArgs: { prompt: "QA lighthouse" },
+        },
+        {
+          allInputText: "target=image_generate",
+          toolOutputCallId: "call-image-happy",
+          toolOutput: "Failed: provider rejected image request",
+        },
+        {
+          allInputText: "failure target=image_generate",
+          plannedToolCallId: "call-image-failure",
+          plannedToolName: "image_generate",
+          plannedToolArgs: { __qaFailureMode: "denied-input" },
+        },
+      ]);
+
+    await expect(
+      runRuntimeToolFixture(
+        env,
+        {
+          toolName: "image_generate",
+          toolCoverage: {
+            bucket: "openclaw-dynamic-integration",
+            expectedLayer: "openclaw-dynamic",
+            required: false,
+            action: "optional runtime parity gate with async image completion coverage",
+          },
+          promptSnippet: "target=image_generate",
+          failurePromptSnippet: "failure target=image_generate",
+        },
+        {
+          createSession: vi.fn(async (_env, _label, key) => key!),
+          readEffectiveTools: vi.fn(async () => new Set(["image_generate"])),
+          runAgentPrompt: vi.fn(async () => ({})),
+          fetchJson,
+          ensureImageGenerationConfigured: vi.fn(),
+        },
+      ),
+    ).rejects.toThrow("expected mock happy-path successful tool output for image_generate");
+  });
+
+  it("still rejects successful failure output for non-required mock fixtures", async () => {
+    const env = await makeEnv({
+      mock: { baseUrl: "http://127.0.0.1:9999" },
+    });
+    const fetchJson = vi
+      .fn()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          allInputText: "target=image_generate",
+          plannedToolCallId: "call-image-happy",
+          plannedToolName: "image_generate",
+          plannedToolArgs: { prompt: "QA lighthouse" },
+        },
+        {
+          allInputText: "failure target=image_generate",
+          plannedToolCallId: "call-image-failure",
+          plannedToolName: "image_generate",
+          plannedToolArgs: { __qaFailureMode: "denied-input" },
+        },
+        {
+          allInputText: "failure target=image_generate",
+          toolOutputCallId: "call-image-failure",
+          toolOutput: "Task queued for async image delivery",
+        },
+      ]);
+
+    await expect(
+      runRuntimeToolFixture(
+        env,
+        {
+          toolName: "image_generate",
+          toolCoverage: {
+            bucket: "openclaw-dynamic-integration",
+            expectedLayer: "openclaw-dynamic",
+            required: false,
+            action: "optional runtime parity gate with async image completion coverage",
+          },
+          promptSnippet: "target=image_generate",
+          failurePromptSnippet: "failure target=image_generate",
+        },
+        {
+          createSession: vi.fn(async (_env, _label, key) => key!),
+          readEffectiveTools: vi.fn(async () => new Set(["image_generate"])),
+          runAgentPrompt: vi.fn(async () => ({})),
+          fetchJson,
+          ensureImageGenerationConfigured: vi.fn(),
+        },
+      ),
+    ).rejects.toThrow("expected mock failure-path tool failure output for image_generate");
+  });
+
+  it("rejects malformed report-only failure plans for non-required mock fixtures", async () => {
+    const env = await makeEnv({
+      mock: { baseUrl: "http://127.0.0.1:9999" },
+    });
+    const fetchJson = vi
+      .fn()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          allInputText: "target=image_generate",
+          plannedToolCallId: "call-image-happy",
+          plannedToolName: "image_generate",
+          plannedToolArgs: { prompt: "QA lighthouse" },
+        },
+        {
+          allInputText: "failure target=image_generate",
+          plannedToolCallId: "call-image-failure",
+          plannedToolName: "image_generate",
+          plannedToolArgs: { prompt: "not a denied-input failure" },
+        },
+      ]);
+
+    await expect(
+      runRuntimeToolFixture(
+        env,
+        {
+          toolName: "image_generate",
+          toolCoverage: {
+            bucket: "openclaw-dynamic-integration",
+            expectedLayer: "openclaw-dynamic",
+            required: false,
+            action: "optional runtime parity gate with async image completion coverage",
+          },
+          promptSnippet: "target=image_generate",
+          failurePromptSnippet: "failure target=image_generate",
+        },
+        {
+          createSession: vi.fn(async (_env, _label, key) => key!),
+          readEffectiveTools: vi.fn(async () => new Set(["image_generate"])),
+          runAgentPrompt: vi.fn(async () => ({})),
+          fetchJson,
+          ensureImageGenerationConfigured: vi.fn(),
+        },
+      ),
+    ).rejects.toThrow("expected mock failure-path denied-input args for image_generate");
+  });
+
+  it("rejects malformed report-only happy plans for non-required mock fixtures", async () => {
+    const env = await makeEnv({
+      mock: { baseUrl: "http://127.0.0.1:9999" },
+    });
+    const fetchJson = vi
+      .fn()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          allInputText: "target=image_generate",
+          plannedToolCallId: "call-image-happy",
+          plannedToolName: "image_generate",
+          plannedToolArgs: {},
+        },
+        {
+          allInputText: "failure target=image_generate",
+          plannedToolCallId: "call-image-failure",
+          plannedToolName: "image_generate",
+          plannedToolArgs: { __qaFailureMode: "denied-input" },
+        },
+      ]);
+
+    await expect(
+      runRuntimeToolFixture(
+        env,
+        {
+          toolName: "image_generate",
+          toolCoverage: {
+            bucket: "openclaw-dynamic-integration",
+            expectedLayer: "openclaw-dynamic",
+            required: false,
+            action: "optional runtime parity gate with async image completion coverage",
+          },
+          promptSnippet: "target=image_generate",
+          failurePromptSnippet: "failure target=image_generate",
+        },
+        {
+          createSession: vi.fn(async (_env, _label, key) => key!),
+          readEffectiveTools: vi.fn(async () => new Set(["image_generate"])),
+          runAgentPrompt: vi.fn(async () => ({})),
+          fetchJson,
+          ensureImageGenerationConfigured: vi.fn(),
+        },
+      ),
+    ).rejects.toThrow("expected mock happy-path prompt args for image_generate");
+  });
+
   it("rejects failure-shaped mock happy-path tool output", async () => {
     const env = await makeEnv({
       mock: { baseUrl: "http://127.0.0.1:9999" },

--- a/extensions/qa-lab/src/runtime-tool-fixture.ts
+++ b/extensions/qa-lab/src/runtime-tool-fixture.ts
@@ -2,7 +2,10 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { readRuntimeToolCoverageMetadata } from "./runtime-tool-metadata.js";
+import {
+  type QaRuntimeToolCoverageMetadata,
+  readRuntimeToolCoverageMetadata,
+} from "./runtime-tool-metadata.js";
 import { liveTurnTimeoutMs } from "./suite-runtime-agent-common.js";
 import { readRawQaSessionStore } from "./suite-runtime-agent-session.js";
 import type { QaSuiteRuntimeEnv } from "./suite-runtime-types.js";
@@ -555,6 +558,37 @@ function formatCodexNativeWorkspaceDetails(params: {
     .join("\n");
 }
 
+function formatReportOnlyMockDetails(params: {
+  toolName: string;
+  happyRequest: QaRuntimeToolFixtureRequest;
+  failureRequest: QaRuntimeToolFixtureRequest;
+}) {
+  return [
+    `${params.toolName} mock provider report-only: direct tool output is not required by this fixture`,
+    `${params.toolName} mock provider happy planned args (diagnostic only): ${formatPlannedToolArgs(params.happyRequest.plannedToolArgs)}`,
+    `${params.toolName} mock provider failure planned args (diagnostic only): ${formatPlannedToolArgs(params.failureRequest.plannedToolArgs)}`,
+  ].join("\n");
+}
+
+function isAsyncReportOnlyMockCoverage(metadata: QaRuntimeToolCoverageMetadata) {
+  return !metadata.required && /\basync\b/iu.test(metadata.action ?? "");
+}
+
+function plannedRequestHasDeniedInputFailure(request: QaRuntimeToolFixtureRequest) {
+  return (
+    isRecord(request.plannedToolArgs) &&
+    request.plannedToolArgs["__qaFailureMode"] === "denied-input"
+  );
+}
+
+function plannedRequestHasPrompt(request: QaRuntimeToolFixtureRequest) {
+  return (
+    isRecord(request.plannedToolArgs) &&
+    typeof request.plannedToolArgs.prompt === "string" &&
+    request.plannedToolArgs.prompt.trim().length > 0
+  );
+}
+
 function formatKnownHarnessGapDetails(toolName: string, config: QaRuntimeToolFixtureConfig) {
   const knownHarnessGap = isKnownHarnessGap(config.knownHarnessGap) ? config.knownHarnessGap : {};
   const issue = readString(knownHarnessGap.issue);
@@ -722,6 +756,39 @@ export async function runRuntimeToolFixture(
     excludedPromptSnippet: failurePromptSnippet,
     toolName,
   });
+  const failurePlannedRequest = findPlannedRequest({
+    requests,
+    requestCountBefore,
+    promptSnippet: failurePromptSnippet,
+    toolName,
+  });
+  const failureRequest = findExecutedRequest({
+    requests,
+    requestCountBefore,
+    promptSnippet: failurePromptSnippet,
+    toolName,
+  });
+  if (
+    isAsyncReportOnlyMockCoverage(metadata) &&
+    happyPlannedRequest &&
+    failurePlannedRequest &&
+    !happyRequest
+  ) {
+    if (!plannedRequestHasPrompt(happyPlannedRequest)) {
+      throw new Error(`expected mock happy-path prompt args for ${toolName}`);
+    }
+    if (!plannedRequestHasDeniedInputFailure(failurePlannedRequest)) {
+      throw new Error(`expected mock failure-path denied-input args for ${toolName}`);
+    }
+    if (failureRequest && !requestHasFailureLikeToolOutput(failureRequest.outputRequest)) {
+      throw new Error(`expected mock failure-path tool failure output for ${toolName}`);
+    }
+    return formatReportOnlyMockDetails({
+      toolName,
+      happyRequest: happyPlannedRequest,
+      failureRequest: failurePlannedRequest,
+    });
+  }
   // Async runtime tools prove the start call here; completion is covered by
   // their task lifecycle scenarios.
   const happyPlannedOnly = Boolean(happyPlannedRequest && !happyPathOutputRequired);
@@ -749,18 +816,6 @@ export async function runRuntimeToolFixture(
     }
     throw new Error(`expected mock happy-path successful tool output for ${toolName}`);
   }
-  const failurePlannedRequest = findPlannedRequest({
-    requests,
-    requestCountBefore,
-    promptSnippet: failurePromptSnippet,
-    toolName,
-  });
-  const failureRequest = findExecutedRequest({
-    requests,
-    requestCountBefore,
-    promptSnippet: failurePromptSnippet,
-    toolName,
-  });
   if (!failureRequest) {
     if (dynamicExposureIntentionallyExcluded) {
       return formatCodexNativeWorkspaceDetails({

--- a/extensions/qa-matrix/package.json
+++ b/extensions/qa-matrix/package.json
@@ -10,7 +10,7 @@
   "devDependencies": {
     "@openclaw/matrix": "workspace:*",
     "@openclaw/plugin-sdk": "workspace:*",
-    "openclaw": "2026.5.28"
+    "openclaw": "workspace:*"
   },
   "peerDependencies": {
     "openclaw": ">=2026.6.11"

--- a/extensions/qqbot/package.json
+++ b/extensions/qqbot/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",
     "@types/ws": "8.18.1",
-    "openclaw": "2026.5.28"
+    "openclaw": "workspace:*"
   },
   "peerDependencies": {
     "openclaw": ">=2026.6.11"

--- a/extensions/raft/package.json
+++ b/extensions/raft/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",
-    "openclaw": "2026.5.28"
+    "openclaw": "workspace:*"
   },
   "peerDependencies": {
     "openclaw": ">=2026.6.11"

--- a/extensions/slack/package.json
+++ b/extensions/slack/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",
-    "openclaw": "2026.5.28"
+    "openclaw": "workspace:*"
   },
   "peerDependencies": {
     "openclaw": ">=2026.6.11"

--- a/extensions/slack/src/channel.test.ts
+++ b/extensions/slack/src/channel.test.ts
@@ -874,6 +874,33 @@ describe("slackPlugin outbound", () => {
     });
   });
 
+  it.each([
+    {
+      name: "inherited",
+      replyToIsExplicit: false,
+      expectedReplyToId: "1712345678.123456",
+    },
+    { name: "explicit", replyToIsExplicit: true, expectedReplyToId: "1712345688.654321" },
+    { name: "unknown", replyToIsExplicit: undefined, expectedReplyToId: "1712345688.654321" },
+  ])(
+    "routes $name child replies to $expectedReplyToId",
+    ({ replyToIsExplicit, expectedReplyToId }) => {
+      const resolveReplyTransport = slackPlugin.threading?.resolveReplyTransport;
+      if (!resolveReplyTransport) {
+        throw new Error("slack threading.resolveReplyTransport unavailable");
+      }
+
+      expect(
+        resolveReplyTransport({
+          cfg,
+          replyToId: "1712345688.654321",
+          threadId: "1712345678.123456",
+          replyToIsExplicit,
+        }),
+      ).toEqual({ replyToId: expectedReplyToId, threadId: null });
+    },
+  );
+
   it("ignores explicit reply targets for off-mode final delivery", () => {
     const resolveReplyTransport = slackPlugin.threading?.resolveReplyTransport;
     if (!resolveReplyTransport) {

--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -663,8 +663,7 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount, SlackProbe> = crea
         }
         return resolveTargetsWithOptionalToken({
           token:
-            normalizeOptionalString(account.userToken) ??
-            normalizeOptionalString(account.botToken),
+            normalizeOptionalString(account.userToken) ?? normalizeOptionalString(account.botToken),
           inputs,
           missingTokenNote: "missing Slack token",
           resolveWithToken: async ({ token, inputs: inputsLocal }) =>
@@ -819,10 +818,14 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount, SlackProbe> = crea
               toolContext,
             }),
           ),
-    resolveReplyTransport: ({ threadId, replyToId, replyDelivery }) => {
+    resolveReplyTransport: ({ threadId, replyToId, replyToIsExplicit, replyDelivery }) => {
+      const allowedReplyToId = replyDelivery?.replyToMode === "off" ? undefined : replyToId;
+      // Slack's thread_ts identifies the root. Only known inherited replies may let
+      // that root replace a child timestamp; explicit and unknown callers stay reply-first.
+      const preferThreadId = replyToIsExplicit === false;
       const resolvedReplyToId = resolveSlackThreadTsValue({
-        replyToId: replyDelivery?.replyToMode === "off" ? undefined : replyToId,
-        threadId,
+        replyToId: preferThreadId ? threadId : allowedReplyToId,
+        threadId: preferThreadId ? allowedReplyToId : threadId,
       });
       return {
         replyToId:

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -1644,6 +1644,9 @@ describe("TelegramPollingSession", () => {
         await vi.waitFor(() => expect(events).toEqual(["topic10:42"]));
         const before = await claimedAtForUpdate(tempDir, 42);
 
+        await new Promise((resolve) => {
+          setTimeout(resolve, 2);
+        });
         refreshHarness.triggerRefresh();
         await vi.waitFor(async () =>
           expect(await claimedAtForUpdate(tempDir, 42)).toBeGreaterThan(before),

--- a/extensions/tlon/package.json
+++ b/extensions/tlon/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",
-    "openclaw": "2026.5.28"
+    "openclaw": "workspace:*"
   },
   "peerDependencies": {
     "openclaw": ">=2026.6.11"

--- a/extensions/tokenjuice/package.json
+++ b/extensions/tokenjuice/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",
-    "openclaw": "2026.5.28"
+    "openclaw": "workspace:*"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/voice-call/package.json
+++ b/extensions/voice-call/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",
-    "openclaw": "2026.5.28"
+    "openclaw": "workspace:*"
   },
   "peerDependencies": {
     "openclaw": ">=2026.6.11"

--- a/extensions/whatsapp/package.json
+++ b/extensions/whatsapp/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",
-    "openclaw": "2026.5.28"
+    "openclaw": "workspace:*"
   },
   "peerDependencies": {
     "openclaw": ">=2026.6.11"

--- a/extensions/workboard/package.json
+++ b/extensions/workboard/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",
-    "openclaw": "2026.5.28"
+    "openclaw": "workspace:*"
   },
   "peerDependencies": {
     "openclaw": ">=2026.6.11"

--- a/extensions/zalo/package.json
+++ b/extensions/zalo/package.json
@@ -9,7 +9,7 @@
   "type": "module",
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",
-    "openclaw": "2026.5.28"
+    "openclaw": "workspace:*"
   },
   "peerDependencies": {
     "openclaw": ">=2026.6.11"

--- a/extensions/zalouser/package.json
+++ b/extensions/zalouser/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",
-    "openclaw": "2026.5.28"
+    "openclaw": "workspace:*"
   },
   "peerDependencies": {
     "openclaw": ">=2026.6.11"

--- a/package.json
+++ b/package.json
@@ -1926,7 +1926,7 @@
     "test:unit:fast:audit": "node scripts/test-unit-fast-audit.mjs",
     "test:voicecall:closedloop": "node scripts/test-voicecall-closedloop.mjs",
     "test:watch": "node scripts/test-projects.mjs --watch",
-    "test:windows:ci": "node scripts/test-projects.mjs src/shared/runtime-import.test.ts src/process/exec.windows.test.ts src/process/windows-command.test.ts src/infra/windows-install-roots.test.ts extensions/lobster/src/lobster-runner.test.ts test/scripts/format-generated-module.test.ts test/scripts/npm-runner.test.ts test/scripts/pnpm-runner.test.ts test/scripts/run-with-env.test.ts test/scripts/ui.test.ts test/scripts/vitest-process-group.test.ts",
+    "test:windows:ci": "node scripts/test-projects.mjs src/shared/runtime-import.test.ts src/process/exec.windows.test.ts src/process/windows-command.test.ts src/infra/windows-install-roots.test.ts src/node-host/invoke-system-run-allowlist.test.ts extensions/lobster/src/lobster-runner.test.ts test/scripts/format-generated-module.test.ts test/scripts/npm-runner.test.ts test/scripts/pnpm-runner.test.ts test/scripts/run-with-env.test.ts test/scripts/ui.test.ts test/scripts/vitest-process-group.test.ts",
     "tool-display:check": "node --import tsx scripts/tool-display.ts --check",
     "tool-display:write": "node --import tsx scripts/tool-display.ts --write",
     "ts-topology": "node --import tsx scripts/ts-topology.ts",

--- a/packages/gateway-protocol/src/schema/cron.ts
+++ b/packages/gateway-protocol/src/schema/cron.ts
@@ -15,6 +15,7 @@ function cronAgentTurnPayloadSchema(params: {
   model: TSchema;
   fallbacks: TSchema;
   toolsAllow: TSchema;
+  thinking: TSchema;
 }) {
   return Type.Object(
     {
@@ -22,7 +23,7 @@ function cronAgentTurnPayloadSchema(params: {
       message: params.message,
       model: Type.Optional(params.model),
       fallbacks: Type.Optional(params.fallbacks),
-      thinking: Type.Optional(Type.String()),
+      thinking: Type.Optional(params.thinking),
       timeoutSeconds: Type.Optional(Type.Number({ minimum: 0 })),
       allowUnsafeExternalContent: Type.Optional(Type.Boolean()),
       lightContext: Type.Optional(Type.Boolean()),
@@ -238,6 +239,7 @@ export const CronPayloadSchema = Type.Union([
     model: Type.String(),
     fallbacks: Type.Array(Type.String()),
     toolsAllow: Type.Array(Type.String()),
+    thinking: Type.String(),
   }),
   cronCommandPayloadSchema({
     argv: Type.Array(NonEmptyString, { minItems: 1 }),
@@ -258,6 +260,7 @@ export const CronPayloadPatchSchema = Type.Union([
     model: Type.Union([Type.String(), Type.Null()]),
     fallbacks: Type.Union([Type.Array(Type.String()), Type.Null()]),
     toolsAllow: Type.Union([Type.Array(Type.String()), Type.Null()]),
+    thinking: Type.Union([Type.String(), Type.Null()]),
   }),
   cronCommandPayloadSchema({
     argv: Type.Optional(Type.Array(NonEmptyString, { minItems: 1 })),

--- a/packages/speech-core/package.json
+++ b/packages/speech-core/package.json
@@ -34,6 +34,6 @@
     }
   },
   "dependencies": {
-    "openclaw": "2026.5.28"
+    "openclaw": "workspace:*"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -501,8 +501,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
       openclaw:
-        specifier: 2026.5.28
-        version: 2026.5.28
+        specifier: workspace:*
+        version: link:../..
 
   extensions/cloudflare-ai-gateway:
     devDependencies:
@@ -699,8 +699,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
       openclaw:
-        specifier: 2026.5.28
-        version: 2026.5.28
+        specifier: workspace:*
+        version: link:../..
 
   extensions/document-extract:
     dependencies:
@@ -752,8 +752,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
       openclaw:
-        specifier: 2026.5.28
-        version: 2026.5.28
+        specifier: workspace:*
+        version: link:../..
 
   extensions/file-transfer:
     dependencies:
@@ -826,8 +826,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
       openclaw:
-        specifier: 2026.5.28
-        version: 2026.5.28
+        specifier: workspace:*
+        version: link:../..
 
   extensions/googlechat:
     dependencies:
@@ -845,8 +845,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
       openclaw:
-        specifier: 2026.5.28
-        version: 2026.5.28
+        specifier: workspace:*
+        version: link:../..
 
   extensions/gradium:
     devDependencies:
@@ -919,8 +919,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
       openclaw:
-        specifier: 2026.5.28
-        version: 2026.5.28
+        specifier: workspace:*
+        version: link:../..
 
   extensions/litellm:
     devDependencies:
@@ -994,8 +994,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
       openclaw:
-        specifier: 2026.5.28
-        version: 2026.5.28
+        specifier: workspace:*
+        version: link:../..
 
   extensions/mattermost:
     dependencies:
@@ -1010,8 +1010,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
       openclaw:
-        specifier: 2026.5.28
-        version: 2026.5.28
+        specifier: workspace:*
+        version: link:../..
 
   extensions/media-understanding-core:
     devDependencies:
@@ -1035,8 +1035,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
       openclaw:
-        specifier: 2026.5.28
-        version: 2026.5.28
+        specifier: workspace:*
+        version: link:../..
 
   extensions/memory-lancedb:
     dependencies:
@@ -1073,8 +1073,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
       openclaw:
-        specifier: 2026.5.28
-        version: 2026.5.28
+        specifier: workspace:*
+        version: link:../..
 
   extensions/microsoft:
     dependencies:
@@ -1098,8 +1098,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
       openclaw:
-        specifier: 2026.5.28
-        version: 2026.5.28
+        specifier: workspace:*
+        version: link:../..
 
   extensions/migrate-hermes:
     dependencies:
@@ -1111,8 +1111,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
       openclaw:
-        specifier: 2026.5.28
-        version: 2026.5.28
+        specifier: workspace:*
+        version: link:../..
 
   extensions/minimax:
     devDependencies:
@@ -1157,8 +1157,8 @@ importers:
         specifier: 6.2.3
         version: 6.2.3
       openclaw:
-        specifier: 2026.5.28
-        version: 2026.5.28
+        specifier: workspace:*
+        version: link:../..
 
   extensions/nextcloud-talk:
     dependencies:
@@ -1170,8 +1170,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
       openclaw:
-        specifier: 2026.5.28
-        version: 2026.5.28
+        specifier: workspace:*
+        version: link:../..
 
   extensions/nostr:
     dependencies:
@@ -1186,8 +1186,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
       openclaw:
-        specifier: 2026.5.28
-        version: 2026.5.28
+        specifier: workspace:*
+        version: link:../..
 
   extensions/novita:
     devDependencies:
@@ -1220,8 +1220,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
       openclaw:
-        specifier: 2026.5.28
-        version: 2026.5.28
+        specifier: workspace:*
+        version: link:../..
 
   extensions/ollama:
     dependencies:
@@ -1295,8 +1295,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
       openclaw:
-        specifier: 2026.5.28
-        version: 2026.5.28
+        specifier: workspace:*
+        version: link:../..
 
   extensions/policy:
     dependencies:
@@ -1308,8 +1308,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
       openclaw:
-        specifier: 2026.5.28
-        version: 2026.5.28
+        specifier: workspace:*
+        version: link:../..
 
   extensions/qa-channel:
     dependencies:
@@ -1324,8 +1324,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
       openclaw:
-        specifier: 2026.5.28
-        version: 2026.5.28
+        specifier: workspace:*
+        version: link:../..
 
   extensions/qa-lab:
     dependencies:
@@ -1346,8 +1346,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@openclaw/crabline':
-        specifier: 0.1.5
-        version: 0.1.5
+        specifier: 0.1.6
+        version: 0.1.6
       '@openclaw/discord':
         specifier: workspace:*
         version: link:../discord
@@ -1361,8 +1361,8 @@ importers:
         specifier: workspace:*
         version: link:../whatsapp
       openclaw:
-        specifier: 2026.5.28
-        version: 2026.5.28
+        specifier: workspace:*
+        version: link:../..
 
   extensions/qa-matrix:
     dependencies:
@@ -1377,8 +1377,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
       openclaw:
-        specifier: 2026.5.28
-        version: 2026.5.28
+        specifier: workspace:*
+        version: link:../..
 
   extensions/qianfan:
     devDependencies:
@@ -1411,8 +1411,8 @@ importers:
         specifier: 8.18.1
         version: 8.18.1
       openclaw:
-        specifier: 2026.5.28
-        version: 2026.5.28
+        specifier: workspace:*
+        version: link:../..
 
   extensions/qwen:
     devDependencies:
@@ -1430,8 +1430,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
       openclaw:
-        specifier: 2026.5.28
-        version: 2026.5.28
+        specifier: workspace:*
+        version: link:../..
 
   extensions/runway:
     devDependencies:
@@ -1492,8 +1492,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
       openclaw:
-        specifier: 2026.5.28
-        version: 2026.5.28
+        specifier: workspace:*
+        version: link:../..
 
   extensions/sms:
     dependencies:
@@ -1587,8 +1587,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
       openclaw:
-        specifier: 2026.5.28
-        version: 2026.5.28
+        specifier: workspace:*
+        version: link:../..
 
   extensions/together:
     devDependencies:
@@ -1606,8 +1606,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
       openclaw:
-        specifier: 2026.5.28
-        version: 2026.5.28
+        specifier: workspace:*
+        version: link:../..
 
   extensions/tts-local-cli:
     devDependencies:
@@ -1677,8 +1677,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
       openclaw:
-        specifier: 2026.5.28
-        version: 2026.5.28
+        specifier: workspace:*
+        version: link:../..
 
   extensions/volcengine:
     devDependencies:
@@ -1737,8 +1737,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
       openclaw:
-        specifier: 2026.5.28
-        version: 2026.5.28
+        specifier: workspace:*
+        version: link:../..
 
   extensions/workboard:
     dependencies:
@@ -1750,8 +1750,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
       openclaw:
-        specifier: 2026.5.28
-        version: 2026.5.28
+        specifier: workspace:*
+        version: link:../..
 
   extensions/xai:
     dependencies:
@@ -1788,8 +1788,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
       openclaw:
-        specifier: 2026.5.28
-        version: 2026.5.28
+        specifier: workspace:*
+        version: link:../..
 
   extensions/zalouser:
     dependencies:
@@ -1807,8 +1807,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
       openclaw:
-        specifier: 2026.5.28
-        version: 2026.5.28
+        specifier: workspace:*
+        version: link:../..
 
   packages/acp-core:
     dependencies:
@@ -1902,8 +1902,8 @@ importers:
   packages/speech-core:
     dependencies:
       openclaw:
-        specifier: 2026.5.28
-        version: 2026.5.28
+        specifier: workspace:*
+        version: link:../..
 
   packages/terminal-core:
     dependencies:
@@ -2368,16 +2368,8 @@ packages:
     resolution: {integrity: sha512-fT1qHVGAag4IEkrupZ6lRRbNCs1vS9P01KB/sG8zKgvUztbYtFBtQpjSITNwooDZ83tpsPzP0mRNs1/KVszCRA==}
     engines: {node: '>= 20.12.0'}
 
-  '@clack/core@1.4.1':
-    resolution: {integrity: sha512-FILJa1gGKEFTGZAJE9RpVhrjKz3c3h4ar60dSv6cGuDqufQ84YEIS3GAGvZiN+H6yaLbbvTFNejjCC4tXpZEuw==}
-    engines: {node: '>= 20.12.0'}
-
   '@clack/prompts@1.4.0':
     resolution: {integrity: sha512-S0My7XPGIgpRWMDG8uRqalbgT+a6FmCUdOW+HaIOVVpUPHOb7RrpvjTjiODadKp06fsrVDJZlIzc6yCTp4AnxA==}
-    engines: {node: '>= 20.12.0'}
-
-  '@clack/prompts@1.5.1':
-    resolution: {integrity: sha512-zccHj2z2oCCO4yrDiRSlFOxWerGqRiysP7a5jPK6uoI9URKAquwY42Dd/iUP8JWHxEzdRe4TlbvZCo8z1/mhrw==}
     engines: {node: '>= 20.12.0'}
 
   '@clawdbot/lobster@2026.5.22':
@@ -2486,10 +2478,6 @@ packages:
   '@discordjs/voice@0.19.2':
     resolution: {integrity: sha512-3yJ255e4ag3wfZu/DSxeOZK1UtnqNxnspmLaQetGT0pDkThNZoHs+Zg6dgZZ19JEVomXygvfHn9lNpICZuYtEA==}
     engines: {node: '>=22.12.0'}
-
-  '@earendil-works/pi-tui@0.76.0':
-    resolution: {integrity: sha512-TWQEWqc38gVRYr/VTrlfePQPpJk938gNNLL1xuv0M+9cTkVr880/Q3baZQrxKoLrmN/MmVx7TyR8knYZGxTqqg==}
-    engines: {node: '>=22.19.0'}
 
   '@earendil-works/pi-tui@0.78.0':
     resolution: {integrity: sha512-3a705FnsVVUhAyceShNB3kS2rpxcxLcx+hqB0u6MMMpHwQGbW+m++MqA6r7eOzq/8FLx5e3vDh38h/SVTk2qzw==}
@@ -2735,15 +2723,6 @@ packages:
   '@github/copilot@1.0.55':
     resolution: {integrity: sha512-wqzI0L7krORW6jDAQPx7VnInka5BYN5yVgu+dpUK4w8xP5RgnOBa6kRoXpydj/9O1ufs0k6RKRtQjsVLp52TRw==}
     hasBin: true
-
-  '@google/genai@2.6.0':
-    resolution: {integrity: sha512-HjoW3mPuEn7pnuKABJl9VbDoWDSF4nbwYKYvYYor7YjPeDxrrBxHzu2d1Prcd+BAuC4w+85UP6y7ZdcrQAoO7g==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      '@modelcontextprotocol/sdk': ^1.25.2
-    peerDependenciesMeta:
-      '@modelcontextprotocol/sdk':
-        optional: true
 
   '@google/genai@2.7.0':
     resolution: {integrity: sha512-tv0DRtcndt2oEhBYy+5mA0TaXH98+L1Gt0AP9unBfH7DP20KhB7+O3QqAN1Lz+laMARGTHS7BFQSNpLbl4gm1g==}
@@ -3182,8 +3161,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@openclaw/crabline@0.1.5':
-    resolution: {integrity: sha512-OK1YUdM6GO1qgTEvcHhMl/MQ77yw9MmcM84jB1uPNXutQnIjPbIhRin6MXRSMbuYqH5feu4CmTzAtH5VtHv8gA==}
+  '@openclaw/crabline@0.1.6':
+    resolution: {integrity: sha512-nu/XD7eoly5DJOEG7krCfZY68cDcD/AC31mAMLoP36HzmetNVM17OtfnakpuWyBwdO+c4noF7b2LM4AAKvq9CQ==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -4581,6 +4560,7 @@ packages:
 
   '@zed-industries/codex-acp@0.15.0':
     resolution: {integrity: sha512-eAv7sGBeiYrYkOulF729nrM51szS7WIhBtugRj5wWq6csRKZUhAZfoUZlF8xUWdHPtOIzd/eT6MNG6gMHu6z0w==}
+    deprecated: This package has been replaced by @agentclientprotocol/codex-acp. Please migrate to continue receiving updates.
     hasBin: true
 
   abort-controller@3.0.0:
@@ -4934,10 +4914,6 @@ packages:
 
   cjs-module-lexer@2.2.0:
     resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
-
-  clawpdf@0.2.0:
-    resolution: {integrity: sha512-Za4HD3CMRHNqOXOOyVJiQLnEuezRZR/oXiBzraTwL5XEQZuBwFxnyC1UzN4AjQWV2JrLN3ItbzfPRGE0gGOVwg==}
-    engines: {node: '>=20'}
 
   clawpdf@0.3.0:
     resolution: {integrity: sha512-41+3AnKk9yek2sm+/9XvUlDTN8Wi+ag7fmxZuqw+ySn4lqaf/fCgLeamqPLiXY4gVbizKEHGoTG/JrIIFNE2rw==}
@@ -5624,10 +5600,6 @@ packages:
   hosted-git-info@10.1.1:
     resolution: {integrity: sha512-DeOnSPAvOndYKfw075gt8yZzQ7S2hNztw34zBTfhIzLhmBTswIBg5/y+pqu/VD5cYWm5goAFTusDmUEmKZ0PEQ==}
     engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
-
-  hosted-git-info@9.0.3:
-    resolution: {integrity: sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==}
-    engines: {node: ^20.17.0 || >=22.9.0}
 
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
@@ -6521,18 +6493,6 @@ packages:
     resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
     engines: {node: '>=18'}
 
-  openai@6.39.0:
-    resolution: {integrity: sha512-O61LIsimY3acVabwvomwFhwrnN36yvHY2quIfy9keEcFytGgWeV35yLHQ6NVMLSBxRpHmcg2yuhCnlu2HT4pLQ==}
-    hasBin: true
-    peerDependencies:
-      ws: ^8.18.0
-      zod: ^3.25 || ^4.0
-    peerDependenciesMeta:
-      ws:
-        optional: true
-      zod:
-        optional: true
-
   openai@6.39.1:
     resolution: {integrity: sha512-z3dO9fEWOXBzlXynVb/xZ/tujzUjFWQWn3C0n0mw6Vo0zJTbEkaN4b2cLWjhJ6haJQx8LlREoafHRl+Gu/Hl+A==}
     hasBin: true
@@ -6544,11 +6504,6 @@ packages:
         optional: true
       zod:
         optional: true
-
-  openclaw@2026.5.28:
-    resolution: {integrity: sha512-p7jGN9wzCrqEvHNI6Y7+eh6DWoYDzJ1iQGKTm8xqQ2uQ9/2mY1CCf87WoZeb0+m3eHKSGchlI3tN33fE1lMtEA==}
-    engines: {node: '>=22.19.0'}
-    hasBin: true
 
   opus-decoder@0.7.11:
     resolution: {integrity: sha512-+e+Jz3vGQLxRTBHs8YJQPRPc1Tr+/aC6coV/DlZylriA29BdHQAYXhvNRKtjftof17OFng0+P4wsFIqQu3a48A==}
@@ -6878,10 +6833,6 @@ packages:
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
-
-  rastermill@0.3.0:
-    resolution: {integrity: sha512-4g2i0I7M5sba//lFBh19Wi0hDGw8o+isnt/BtEyqQXIZaYclhcNBwL/Fw/6gDCp7aaLwQHADuUvyHCB0Oat5Vw==}
-    engines: {node: '>=20'}
 
   rastermill@0.3.1:
     resolution: {integrity: sha512-CX4nij6+ZLHYIaojJNfLTr7W+AiH/IPJi6E9Aw1br2///1KZL2KBOHd68rkcLedc47MPvb4hhH+fzYeGFa4A/Q==}
@@ -8518,21 +8469,9 @@ snapshots:
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
 
-  '@clack/core@1.4.1':
-    dependencies:
-      fast-wrap-ansi: 0.2.2
-      sisteransi: 1.0.5
-
   '@clack/prompts@1.4.0':
     dependencies:
       '@clack/core': 1.3.1
-      fast-string-width: 3.0.2
-      fast-wrap-ansi: 0.2.2
-      sisteransi: 1.0.5
-
-  '@clack/prompts@1.5.1':
-    dependencies:
-      '@clack/core': 1.4.1
       fast-string-width: 3.0.2
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
@@ -8643,11 +8582,6 @@ snapshots:
       - node-opus
       - opusscript
       - utf-8-validate
-
-  '@earendil-works/pi-tui@0.76.0':
-    dependencies:
-      get-east-asian-width: 1.6.0
-      marked: 15.0.12
 
   '@earendil-works/pi-tui@0.78.0':
     dependencies:
@@ -8798,19 +8732,6 @@ snapshots:
       '@github/copilot-linuxmusl-x64': 1.0.55
       '@github/copilot-win32-arm64': 1.0.55
       '@github/copilot-win32-x64': 1.0.55
-
-  '@google/genai@2.6.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))':
-    dependencies:
-      google-auth-library: 10.7.0
-      p-retry: 4.6.2
-      protobufjs: 7.6.3
-      ws: 8.21.0
-    optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
 
   '@google/genai@2.7.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))':
     dependencies:
@@ -9269,7 +9190,7 @@ snapshots:
   '@openai/codex@0.139.0-win32-x64':
     optional: true
 
-  '@openclaw/crabline@0.1.5':
+  '@openclaw/crabline@0.1.6':
     dependencies:
       commander: 15.0.0
       curve25519-js: 0.0.4
@@ -10987,8 +10908,6 @@ snapshots:
 
   cjs-module-lexer@2.2.0: {}
 
-  clawpdf@0.2.0: {}
-
   clawpdf@0.3.0: {}
 
   cli-cursor@5.0.0:
@@ -11782,10 +11701,6 @@ snapshots:
   hookified@2.2.0: {}
 
   hosted-git-info@10.1.1:
-    dependencies:
-      lru-cache: 11.5.1
-
-  hosted-git-info@9.0.3:
     dependencies:
       lru-cache: 11.5.1
 
@@ -12940,86 +12855,10 @@ snapshots:
       is-inside-container: 1.0.0
       wsl-utils: 0.1.0
 
-  openai@6.39.0(ws@8.21.0)(zod@4.4.3):
-    optionalDependencies:
-      ws: 8.21.0
-      zod: 4.4.3
-
   openai@6.39.1(ws@8.21.0)(zod@4.4.3):
     optionalDependencies:
       ws: 8.21.0
       zod: 4.4.3
-
-  openclaw@2026.5.28:
-    dependencies:
-      '@agentclientprotocol/sdk': 0.22.1(zod@4.4.3)
-      '@anthropic-ai/sdk': 0.100.1(zod@4.4.3)
-      '@clack/core': 1.3.1
-      '@clack/prompts': 1.4.0
-      '@earendil-works/pi-tui': 0.76.0
-      '@google/genai': 2.6.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
-      '@grammyjs/runner': 2.0.3(grammy@1.43.0)
-      '@grammyjs/transformer-throttler': 1.2.1(grammy@1.43.0)
-      '@homebridge/ciao': 1.3.9
-      '@lydell/node-pty': 1.2.0-beta.12
-      '@mistralai/mistralai': 2.2.5
-      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
-      '@mozilla/readability': 0.6.0
-      '@openclaw/fs-safe': 0.3.0
-      '@openclaw/proxyline': 0.3.3(undici@8.5.0)
-      '@silvia-odwyer/photon-node': 0.3.4
-      chalk: 5.6.2
-      chokidar: 5.0.0
-      clawpdf: 0.2.0
-      commander: 14.0.3
-      croner: 10.0.1
-      cross-spawn: 7.0.6
-      diff: 9.0.0
-      dotenv: 17.4.2
-      express: 5.2.1
-      file-type: 22.0.1
-      glob: 13.0.6
-      grammy: 1.43.0
-      highlight.js: 11.11.1
-      hosted-git-info: 9.0.3
-      ignore: 7.0.5
-      ipaddr.js: 2.4.0
-      jiti: 2.7.0
-      json5: 2.2.3
-      jszip: 3.10.1
-      kysely: 0.29.2
-      linkedom: 0.18.12
-      markdown-it: 14.2.0
-      minimatch: 10.2.5
-      node-edge-tts: 1.2.10
-      openai: 6.39.0(ws@8.21.0)(zod@4.4.3)
-      partial-json: 0.1.7
-      playwright-core: 1.60.0
-      proper-lockfile: 4.1.2
-      qrcode: 1.5.4
-      quickjs-wasi: 3.0.0
-      rastermill: 0.3.0
-      tar: 7.5.16
-      tree-sitter-bash: 0.25.1
-      tslog: 4.10.2
-      typebox: 1.1.39
-      typescript: 6.0.3
-      undici: 8.5.0
-      web-push: 3.6.7
-      web-tree-sitter: 0.26.9
-      ws: 8.21.0
-      yaml: 2.9.0
-      zod: 4.4.3
-    optionalDependencies:
-      sqlite-vec: 0.1.9
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - bufferutil
-      - canvas
-      - encoding
-      - supports-color
-      - tree-sitter
-      - utf-8-validate
 
   opus-decoder@0.7.11:
     dependencies:
@@ -13389,10 +13228,6 @@ snapshots:
   quickjs-wasi@3.0.0: {}
 
   range-parser@1.2.1: {}
-
-  rastermill@0.3.0:
-    dependencies:
-      '@silvia-odwyer/photon-node': 0.3.4
 
   rastermill@0.3.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,7 +7,7 @@ packages:
 minimumReleaseAge: 2880
 
 minimumReleaseAgeExclude:
-  - "@openclaw/crabline@0.1.5"
+  - "@openclaw/crabline@0.1.6"
   - "@openclaw/fs-safe@0.3.0"
   - "@openclaw/proxyline@0.3.3"
   - "acpx"

--- a/qa/scenarios/memory/memory-tools-channel-context.yaml
+++ b/qa/scenarios/memory/memory-tools-channel-context.yaml
@@ -25,7 +25,7 @@ scenario:
       channelId: qa-memory-room
       channelTitle: QA Memory Room
       memoryFact: "Hidden QA fact: the project codename is ORBIT-9."
-      memoryQuery: "project codename ORBIT-9"
+      memoryQuery: "hidden project codename"
       expectedNeedle: ORBIT-9
       prompt: "@openclaw Memory tools check: what is the hidden project codename stored only in memory? Use memory tools first."
       promptSnippet: "Memory tools check"

--- a/scripts/e2e/parallels/guest-transports.ts
+++ b/scripts/e2e/parallels/guest-transports.ts
@@ -16,7 +16,6 @@ export interface WindowsBackgroundPowerShellOptions {
   beforeLaunchAttempt?: () => void;
   completedLogDrainGraceMs?: number;
   label: string;
-  logChunkBytes?: number;
   onLaunchRetry?: (message: string) => void;
   pollIntervalMs?: number;
   runCommand?: typeof run;
@@ -59,6 +58,7 @@ function throwIfFailed(label: string, result: CommandResult, check: boolean | un
 }
 
 const POSIX_GUEST_SCRIPT_CLEANUP_TIMEOUT_MS = 30_000;
+const WINDOWS_BACKGROUND_LOG_MAX_BYTES = 8 * 1024 * 1024;
 
 function appendCommandResult(phases: PhaseRunner, result: CommandResult): void {
   phases.append(result.stdout);
@@ -88,36 +88,54 @@ export async function runWindowsBackgroundPowerShell(
     1,
     Math.floor(options.completedLogDrainGraceMs ?? 30_000),
   );
-  const logChunkBytes = Math.max(1, Math.floor(options.logChunkBytes ?? 1024 * 1024));
   const pollIntervalMs = Math.max(1, Math.floor(options.pollIntervalMs ?? 5_000));
   const runCommand = options.runCommand ?? run;
   const safeLabel = options.label.replaceAll(/[^A-Za-z0-9_-]/g, "-");
   const nonce = `${safeLabel}-${randomUUID()}`;
-  const fileBase = `openclaw-parallels-${nonce}`;
-  const logLengthPrefix = `__OPENCLAW_LOG_LENGTH__:${nonce}:`;
-  const logOffsetPrefix = `__OPENCLAW_LOG_OFFSET__:${nonce}:`;
+  const guestRunDir = `openclaw-parallels\\${nonce}`;
+  const windowsDonePath = `%WINDIR%\\Temp\\${guestRunDir}\\done`;
+  const windowsLogPath = `%WINDIR%\\Temp\\${guestRunDir}\\run.log`;
   const backgroundExitPrefix = `__OPENCLAW_BACKGROUND_EXIT__:${nonce}:`;
   const backgroundDoneMarker = `__OPENCLAW_BACKGROUND_DONE__:${nonce}`;
-  const pathsScript = `$base = Join-Path $env:TEMP ${psSingleQuote(fileBase)}
-$scriptPath = "$base.ps1"
-$logPath = "$base.log"
-$donePath = "$base.done"
-$exitPath = "$base.exit"
-$pidPath = "$base.pid"
+  const deadline = Date.now() + options.timeoutMs;
+  const pathsScript = `$runDir = Join-Path (Join-Path $env:WINDIR 'Temp\\openclaw-parallels') ${psSingleQuote(nonce)}
+$scriptPath = Join-Path $runDir 'run.ps1'
+$logPath = Join-Path $runDir 'run.log'
+$donePath = Join-Path $runDir 'done'
+$exitPath = Join-Path $runDir 'exit'
+$pidPath = Join-Path $runDir 'pid'
 function Write-OpenClawUtf8File([string]$Path, [string]$Value) {
   [System.IO.File]::WriteAllText($Path, $Value, [System.Text.UTF8Encoding]::new($false))
 }`;
   const payload = `$ErrorActionPreference = 'Stop'
 $PSNativeCommandUseErrorActionPreference = $false
 ${pathsScript}
+Write-OpenClawUtf8File $pidPath ([string]$PID)
+$script:OpenClawBackgroundLogBytes = 0
 function Add-OpenClawBackgroundLog {
   param([Parameter(ValueFromPipeline=$true)]$InputObject)
   process {
     $text = $InputObject | Out-String
     $bytes = [System.Text.Encoding]::UTF8.GetBytes($text)
+    $remaining = [int64]${WINDOWS_BACKGROUND_LOG_MAX_BYTES} - $script:OpenClawBackgroundLogBytes
+    if ($remaining -le 0) {
+      return
+    }
+    $count = [int][Math]::Min($remaining, $bytes.Length)
+    $needsBoundaryNewline = $count -eq $remaining -and $count -gt 0 -and $bytes[$count - 1] -ne 10
+    if ($needsBoundaryNewline) {
+      $count--
+    }
     $stream = [System.IO.File]::Open($logPath, [System.IO.FileMode]::Append, [System.IO.FileAccess]::Write, [System.IO.FileShare]::ReadWrite)
     try {
-      $stream.Write($bytes, 0, $bytes.Length)
+      if ($count -gt 0) {
+        $stream.Write($bytes, 0, $count)
+        $script:OpenClawBackgroundLogBytes += $count
+      }
+      if ($needsBoundaryNewline) {
+        $stream.WriteByte(10)
+        $script:OpenClawBackgroundLogBytes++
+      }
     } finally {
       $stream.Dispose()
     }
@@ -134,25 +152,41 @@ ${options.script}
 } finally {
   Write-OpenClawUtf8File $donePath 'done'
 }`;
-  const writeScript = runCommand(
-    "prlctl",
-    [
-      "exec",
-      options.vmName,
-      "--current-user",
-      "powershell.exe",
-      "-NoProfile",
-      "-ExecutionPolicy",
-      "Bypass",
-      "-EncodedCommand",
-      encodePowerShell(`${pathsScript}
+  const writeArgs = [
+    "exec",
+    options.vmName,
+    "--current-user",
+    "powershell.exe",
+    "-NoProfile",
+    "-ExecutionPolicy",
+    "Bypass",
+    "-EncodedCommand",
+    encodePowerShell(`${pathsScript}
+New-Item -ItemType Directory -Path $runDir -Force | Out-Null
+& icacls.exe $runDir /inheritance:r /grant:r "\${env:USERNAME}:(OI)(CI)(F)" "SYSTEM:(OI)(CI)(F)" | Out-Null
+if ($LASTEXITCODE -ne 0) { throw "${safeLabel} background directory ACL setup failed" }
 Remove-Item -Path $scriptPath, $logPath, $donePath, $exitPath, $pidPath -Force -ErrorAction SilentlyContinue
 [System.IO.File]::WriteAllText($scriptPath, [Console]::In.ReadToEnd(), [System.Text.UTF8Encoding]::new($false))
 if (!(Test-Path $scriptPath)) { throw "${safeLabel} background script was not written" }`),
-    ],
-    { check: false, input: payload, timeoutMs: Math.min(options.timeoutMs, 120_000) },
-  );
+  ];
+  let writeScript = runCommand("prlctl", writeArgs, {
+    check: false,
+    input: payload,
+    timeoutMs: timeoutBefore(deadline, 120_000),
+  });
   appendOutput(append, writeScript);
+  if (writeScript.status === 255) {
+    options.onLaunchRetry?.(
+      `${options.label} background script write retry after guest transport rc255`,
+    );
+    options.beforeLaunchAttempt?.();
+    writeScript = runCommand("prlctl", writeArgs, {
+      check: false,
+      input: payload,
+      timeoutMs: timeoutBefore(deadline, 120_000),
+    });
+    appendOutput(append, writeScript);
+  }
   if (writeScript.status !== 0) {
     throw new Error(
       `${options.label} background script write failed with exit code ${writeScript.status}`,
@@ -161,7 +195,6 @@ if (!(Test-Path $scriptPath)) { throw "${safeLabel} background script was not wr
 
   let doneSeen = false;
   try {
-    const deadline = Date.now() + options.timeoutMs;
     let launched = false;
     let lastLaunchStatus = 0;
     for (let attempt = 1; attempt <= 5 && Date.now() < deadline; attempt++) {
@@ -178,11 +211,13 @@ if (!(Test-Path $scriptPath)) { throw "${safeLabel} background script was not wr
           "Bypass",
           "-EncodedCommand",
           encodePowerShell(`${pathsScript}
-$process = Start-Process -FilePath powershell.exe -WindowStyle Hidden -ArgumentList @('-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $scriptPath) -PassThru
-Write-OpenClawUtf8File $pidPath ([string]$process.Id)
+cmd.exe /d /s /c start "" /b powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$scriptPath" | Out-Null
 'started'`),
         ],
-        { check: false, quiet: true, timeoutMs: timeoutBefore(deadline, 30_000) },
+        // A busy Windows guest can leave one Parallels Tools session wedged.
+        // Keep polls short so a single transport cancellation cannot consume
+        // the entire install timeout while the detached process continues.
+        { check: false, quiet: true, timeoutMs: timeoutBefore(deadline, 8_000) },
       );
       appendOutput(append, launch);
       if (launch.status === 0 && launch.stdout.includes("started")) {
@@ -221,81 +256,64 @@ Write-OpenClawUtf8File $pidPath ([string]$process.Id)
       );
     }
 
-    let lastLogOffset = 0;
     let completedLogDrainDeadline = 0;
-    const activeDeadline = () => (doneSeen ? completedLogDrainDeadline : deadline);
+    let doneFileSeen = false;
+    const activeDeadline = () => (doneFileSeen ? completedLogDrainDeadline : deadline);
     while (Date.now() < activeDeadline()) {
+      const doneProbe = runCommand(
+        "prlctl",
+        [
+          "exec",
+          options.vmName,
+          "cmd.exe",
+          "/d",
+          "/s",
+          "/c",
+          `if exist "${windowsDonePath}" (echo done) else (echo wait)`,
+        ],
+        { check: false, quiet: true, timeoutMs: timeoutBefore(deadline, 5_000) },
+      );
+      appendOutput(append, doneProbe);
+      if (doneProbe.stdout.split(/\r?\n/u).some((line) => line.trim() === "done")) {
+        doneFileSeen = true;
+        completedLogDrainDeadline ||= Date.now() + completedLogDrainGraceMs;
+      } else {
+        await sleep(pollIntervalMs);
+        continue;
+      }
+
       const poll = runCommand(
         "prlctl",
         [
           "exec",
           options.vmName,
-          "--current-user",
-          "powershell.exe",
-          "-NoProfile",
-          "-ExecutionPolicy",
-          "Bypass",
-          "-EncodedCommand",
-          encodePowerShell(`${pathsScript}
-$offset = ${lastLogOffset}
-if (Test-Path $logPath) {
-  $stream = [System.IO.File]::Open($logPath, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::ReadWrite)
-  try {
-    $length = $stream.Length
-    ${psSingleQuote(logLengthPrefix)} + $length
-    if ($length -gt $offset) {
-      [void]$stream.Seek($offset, [System.IO.SeekOrigin]::Begin)
-      $count = [int][Math]::Min($length - $offset, ${logChunkBytes})
-      $buffer = New-Object byte[] $count
-      $read = $stream.Read($buffer, 0, $count)
-      if ($read -gt 0) {
-        $nextOffset = $offset + $read
-        ${psSingleQuote(logOffsetPrefix)} + $nextOffset
-        [System.Text.Encoding]::UTF8.GetString($buffer, 0, $read)
-      }
-    }
-  } finally {
-    $stream.Dispose()
-  }
-}
-if (Test-Path $donePath) {
-  $backgroundExit = if (Test-Path $exitPath) { (Get-Content -Path $exitPath -Raw).Trim() } else { '0' }
-  ${psSingleQuote(backgroundExitPrefix)} + $backgroundExit
-  ${psSingleQuote(backgroundDoneMarker)}
-  if ($backgroundExit -ne '0') { exit 23 }
-  exit 0
-}`),
+          "cmd.exe",
+          "/d",
+          "/s",
+          "/c",
+          `if exist "${windowsDonePath}" (type "%WINDIR%\\Temp\\${guestRunDir}\\run.log" & for /f "usebackq delims=" %A in ("%WINDIR%\\Temp\\${guestRunDir}\\exit") do @echo ${backgroundExitPrefix}%A & echo ${backgroundDoneMarker}) else (echo wait)`,
         ],
-        { check: false, quiet: true, timeoutMs: timeoutBefore(deadline, 30_000) },
+        { check: false, quiet: true, timeoutMs: timeoutBefore(activeDeadline(), 30_000) },
       );
       appendOutput(append, poll);
-      const offsetRaw = findControlValue(poll.stdout, logOffsetPrefix);
-      if (offsetRaw) {
-        lastLogOffset = Number(offsetRaw);
-      }
-      const lengthRaw = findControlValue(poll.stdout, logLengthPrefix);
-      const logLength = lengthRaw ? Number(lengthRaw) : lastLogOffset;
       if (hasControlLine(poll.stdout, backgroundDoneMarker)) {
         doneSeen = true;
-        completedLogDrainDeadline ||= Date.now() + completedLogDrainGraceMs;
-        if (lastLogOffset < logLength) {
-          await sleep(Math.min(pollIntervalMs, 100));
-          continue;
-        }
         const backgroundExit = findControlValue(poll.stdout, backgroundExitPrefix) ?? "0";
         if (backgroundExit !== "0" || (poll.status !== 0 && poll.status !== 124)) {
           throw new Error(`${options.label} failed`);
         }
         return;
       }
-      await sleep(pollIntervalMs);
+      await sleep(Math.min(pollIntervalMs, 100));
     }
     if (doneSeen) {
       throw new Error(`${options.label} completed but log drain timed out`);
     }
     throw new Error(`${options.label} timed out`);
   } finally {
-    cleanupWindowsBackground(options.vmName, pathsScript, runCommand, {
+    cleanupWindowsBackground(options.vmName, pathsScript, windowsLogPath, runCommand, {
+      append,
+      captureLog: !doneSeen,
       stopProcessTree: !doneSeen,
     });
   }
@@ -325,14 +343,13 @@ async function waitForWindowsBackgroundMaterialized(params: {
       [
         "exec",
         params.vmName,
-        "--current-user",
         "powershell.exe",
         "-NoProfile",
         "-ExecutionPolicy",
         "Bypass",
         "-EncodedCommand",
         encodePowerShell(`${params.pathsScript}
-if ((Test-Path $logPath) -or (Test-Path $donePath)) {
+if ((Test-Path $pidPath) -or (Test-Path $donePath)) {
   'materialized'
 }`),
       ],
@@ -350,8 +367,13 @@ if ((Test-Path $logPath) -or (Test-Path $donePath)) {
 function cleanupWindowsBackground(
   vmName: string,
   pathsScript: string,
+  windowsLogPath: string,
   runCommand: typeof run,
-  options: { stopProcessTree: boolean },
+  options: {
+    append?: (chunk: string | Uint8Array) => void;
+    captureLog: boolean;
+    stopProcessTree: boolean;
+  },
 ): void {
   const stopProcessTree = options.stopProcessTree
     ? `function Stop-OpenClawBackgroundProcessTree([int]$ProcessId) {
@@ -373,15 +395,45 @@ if (Test-Path $pidPath) {
     [
       "exec",
       vmName,
-      "--current-user",
       "powershell.exe",
       "-NoProfile",
       "-ExecutionPolicy",
       "Bypass",
       "-EncodedCommand",
       encodePowerShell(`${pathsScript}
-${stopProcessTree}
-Remove-Item -Path $scriptPath, $logPath, $donePath, $exitPath, $pidPath -Force -ErrorAction SilentlyContinue`),
+${stopProcessTree}`),
+    ],
+    { check: false, quiet: true, timeoutMs: 30_000 },
+  );
+  if (options.captureLog) {
+    const log = runCommand(
+      "prlctl",
+      [
+        "exec",
+        vmName,
+        "cmd.exe",
+        "/d",
+        "/s",
+        "/c",
+        `if exist "${windowsLogPath}" type "${windowsLogPath}"`,
+      ],
+      { check: false, quiet: true, timeoutMs: 30_000 },
+    );
+    appendOutput(options.append, log);
+  }
+  runCommand(
+    "prlctl",
+    [
+      "exec",
+      vmName,
+      "powershell.exe",
+      "-NoProfile",
+      "-ExecutionPolicy",
+      "Bypass",
+      "-EncodedCommand",
+      encodePowerShell(`${pathsScript}
+Remove-Item -Path $scriptPath, $logPath, $donePath, $exitPath, $pidPath -Force -ErrorAction SilentlyContinue
+Remove-Item -Path $runDir -Recurse -Force -ErrorAction SilentlyContinue`),
     ],
     { check: false, quiet: true, timeoutMs: 30_000 },
   );

--- a/scripts/e2e/parallels/npm-update-smoke.ts
+++ b/scripts/e2e/parallels/npm-update-smoke.ts
@@ -1163,6 +1163,7 @@ export class NpmUpdateSmoke {
   ): Promise<void> {
     await runWindowsBackgroundPowerShell({
       append: (chunk) => ctx.append(chunk),
+      beforeLaunchAttempt: () => ensureVmRunning(windowsVm),
       label: "Windows update",
       script,
       timeoutMs,

--- a/scripts/e2e/parallels/windows-smoke.ts
+++ b/scripts/e2e/parallels/windows-smoke.ts
@@ -94,6 +94,9 @@ interface WindowsSummary {
   };
 }
 
+const WINDOWS_PACKAGE_INSTALL_TIMEOUT_SECONDS = 900;
+const WINDOWS_PACKAGE_INSTALL_TIMEOUT_MS = WINDOWS_PACKAGE_INSTALL_TIMEOUT_SECONDS * 1000;
+
 const defaultOptions = (): WindowsOptions => ({
   hostIp: undefined,
   hostPort: 18426,
@@ -362,7 +365,9 @@ class WindowsSmoke extends SmokeRunController<WindowsOptions> {
       ensureGuestGit({ guest: this.guest, minGitZipPath: this.minGitZipPath, server: this.server }),
     );
     await this.phase("fresh.preflight", 120, () => this.logGuestPreflight(true));
-    await this.phase("fresh.install-main", 420, () => this.installMain("openclaw-main-fresh.tgz"));
+    await this.phase("fresh.install-main", WINDOWS_PACKAGE_INSTALL_TIMEOUT_SECONDS, () =>
+      this.installMain("openclaw-main-fresh.tgz"),
+    );
     this.status.freshVersion = await this.extractLastVersion("fresh.install-main");
     await this.phase("fresh.verify-main-version", 120, () => this.verifyTargetVersion());
     await this.phase("fresh.onboard-ref", 720, () => this.runRefOnboard());
@@ -381,8 +386,10 @@ class WindowsSmoke extends SmokeRunController<WindowsOptions> {
     );
     await this.phase("upgrade.preflight", 120, () => this.logGuestPreflight(false));
     if (this.options.targetPackageSpec || this.options.upgradeFromPackedMain) {
-      await this.phase("upgrade.install-baseline-package", 420, () =>
-        this.installMain("openclaw-main-upgrade.tgz"),
+      await this.phase(
+        "upgrade.install-baseline-package",
+        WINDOWS_PACKAGE_INSTALL_TIMEOUT_SECONDS,
+        () => this.installMain("openclaw-main-upgrade.tgz"),
       );
       this.status.latestInstalledVersion = await this.extractLastVersion(
         "upgrade.install-baseline-package",
@@ -391,7 +398,9 @@ class WindowsSmoke extends SmokeRunController<WindowsOptions> {
         this.verifyTargetVersion(),
       );
     } else {
-      await this.phase("upgrade.install-baseline", 420, () => this.installLatestRelease());
+      await this.phase("upgrade.install-baseline", WINDOWS_PACKAGE_INSTALL_TIMEOUT_SECONDS, () =>
+        this.installLatestRelease(),
+      );
       this.status.latestInstalledVersion = await this.extractLastVersion(
         "upgrade.install-baseline",
       );
@@ -538,33 +547,37 @@ ${cleanScript}`,
     );
   }
 
-  private installLatestRelease(): void {
+  private installLatestRelease(): Promise<void> {
     const versionArg = this.installVersion ? ` -Tag ${psSingleQuote(this.installVersion)}` : "";
-    this.guestPowerShell(
+    return this.guestPowerShellBackground(
+      "install-latest",
       `$ErrorActionPreference = 'Stop'
 $script = Invoke-RestMethod -Uri ${psSingleQuote(this.options.installUrl)} -TimeoutSec 120
 & ([scriptblock]::Create($script))${versionArg} -NoOnboard
 if ($LASTEXITCODE -ne 0) { throw "installer failed with exit code $LASTEXITCODE" }
 Invoke-OpenClaw --version
-if ($LASTEXITCODE -ne 0) { throw "openclaw --version failed with exit code $LASTEXITCODE" }`,
-      { timeoutMs: 420_000 },
+      if ($LASTEXITCODE -ne 0) { throw "openclaw --version failed with exit code $LASTEXITCODE" }`,
+      this.remainingPhaseTimeoutMs(WINDOWS_PACKAGE_INSTALL_TIMEOUT_MS) ??
+        WINDOWS_PACKAGE_INSTALL_TIMEOUT_MS,
     );
   }
 
-  private installMain(tempName: string): void {
+  private installMain(tempName: string): Promise<void> {
     if (!this.artifact || !this.server) {
       die("package artifact/server missing");
     }
     const tgzUrl = this.server.urlFor(this.artifact.path);
-    this.guestPowerShell(
+    return this.guestPowerShellBackground(
+      `install-main-${tempName.replaceAll(/[^A-Za-z0-9_-]/g, "-")}`,
       `$ErrorActionPreference = 'Stop'
 $tgz = Join-Path $env:TEMP ${psSingleQuote(tempName)}
 curl.exe -fsSL --connect-timeout 10 --max-time 120 --retry 2 --retry-delay 2 ${psSingleQuote(tgzUrl)} -o $tgz
 npm.cmd install -g $tgz --no-fund --no-audit --loglevel=error
 if ($LASTEXITCODE -ne 0) { throw "npm install failed with exit code $LASTEXITCODE" }
 Invoke-OpenClaw --version
-if ($LASTEXITCODE -ne 0) { throw "openclaw --version failed with exit code $LASTEXITCODE" }`,
-      { timeoutMs: 420_000 },
+      if ($LASTEXITCODE -ne 0) { throw "openclaw --version failed with exit code $LASTEXITCODE" }`,
+      this.remainingPhaseTimeoutMs(WINDOWS_PACKAGE_INSTALL_TIMEOUT_MS) ??
+        WINDOWS_PACKAGE_INSTALL_TIMEOUT_MS,
     );
   }
 
@@ -622,11 +635,14 @@ ${this.windowsPluginIsolationScript()}`,
     await runWindowsBackgroundPowerShell({
       append: (chunk) =>
         this.log(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8")),
-      beforeLaunchAttempt: () => this.waitForGuestReady(120),
+      beforeLaunchAttempt: () => {
+        ensureVmRunning(this.options.vmName, 120);
+        this.waitForGuestReady(120);
+      },
       label,
       onLaunchRetry: warn,
       script: `${windowsOpenClawResolver}\n${script}`,
-      timeoutMs,
+      timeoutMs: this.remainingPhaseTimeoutMs(timeoutMs) ?? timeoutMs,
       vmName: this.options.vmName,
     });
   }

--- a/src/agents/embedded-agent-runner/run/attempt.tool-call-argument-repair.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.tool-call-argument-repair.test.ts
@@ -1,5 +1,6 @@
 // Coverage for repairing malformed streamed tool-call arguments.
 import { describe, expect, it } from "vitest";
+import { wrapStreamFnTextTransforms } from "../../plugin-text-transforms.js";
 import {
   shouldRepairMalformedToolCallArguments,
   wrapStreamFnRepairMalformedToolCallArguments,
@@ -213,6 +214,61 @@ describe("shouldRepairMalformedToolCallArguments", () => {
 });
 
 describe("openai-completions malformed tool-call argument repair", () => {
+  it("restores split replacement tokens after argument repair", async () => {
+    const partialToolCall = { type: "toolCall", name: "send", arguments: {} };
+    const streamedToolCall = { type: "toolCall", name: "send", arguments: {} };
+    const finalToolCall = { type: "toolCall", name: "send", arguments: {} };
+    const partialMessage = { role: "assistant", content: [partialToolCall] };
+    const finalMessage = { role: "assistant", content: [finalToolCall] };
+    const baseFn: FakeStreamFn = () =>
+      createFakeStream({
+        events: [
+          {
+            type: "toolcall_delta",
+            contentIndex: 0,
+            delta: '{"text":"[MAS',
+            partial: partialMessage,
+          },
+          {
+            type: "toolcall_delta",
+            contentIndex: 0,
+            delta: 'KED]"}',
+            partial: partialMessage,
+          },
+          {
+            type: "toolcall_end",
+            contentIndex: 0,
+            toolCall: streamedToolCall,
+            partial: partialMessage,
+          },
+        ],
+        resultMessage: finalMessage,
+      });
+    const repairedFn = wrapStreamFnRepairMalformedToolCallArguments(baseFn as never);
+    const transformedFn = wrapStreamFnTextTransforms({
+      streamFn: repairedFn,
+      output: [{ from: /\[MASKED\]/g, to: "John Smith" }],
+    }) as FakeStreamFn;
+    const stream = await Promise.resolve(transformedFn({} as never, {} as never, {} as never));
+    const events = [];
+    for await (const event of stream) {
+      events.push(event);
+    }
+
+    expect(
+      events
+        .filter((event) => (event as { type?: string }).type === "toolcall_delta")
+        .map((event) => (event as { delta?: string }).delta),
+    ).toEqual(['{"text":"[MAS', 'KED]"}']);
+    const endEvent = events.find(
+      (event) => (event as { type?: string }).type === "toolcall_end",
+    ) as { toolCall?: { arguments?: unknown } } | undefined;
+    expect(endEvent?.toolCall?.arguments).toEqual({ text: "John Smith" });
+    await expect(stream.result()).resolves.toMatchObject({
+      content: [{ arguments: { text: "John Smith" } }],
+    });
+  });
+
   it.each([
     ["openai-completions", "sglang"],
     ["openai-chatgpt-responses", "openai"],

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -2872,11 +2872,10 @@ export async function runEmbeddedAttempt(
         workspaceDir: effectiveWorkspace,
         runtimeHandle: getProviderRuntimeHandle(),
       });
-      if (providerTextTransforms) {
+      if (providerTextTransforms?.input?.length) {
         activeSession.agent.streamFn = wrapStreamFnTextTransforms({
           streamFn: activeSession.agent.streamFn,
           input: providerTextTransforms.input,
-          output: providerTextTransforms.output,
           transformSystemPrompt: false,
         });
       }
@@ -3099,6 +3098,15 @@ export async function runEmbeddedAttempt(
         activeSession.agent.streamFn = wrapStreamFnDecodeXaiToolCallArguments(
           activeSession.agent.streamFn,
         );
+      }
+
+      // Tool-call repair can replace structured arguments from fragmented deltas.
+      // Restore provider-masked text afterward so executable args stay canonical.
+      if (providerTextTransforms?.output?.length) {
+        activeSession.agent.streamFn = wrapStreamFnTextTransforms({
+          streamFn: activeSession.agent.streamFn,
+          output: providerTextTransforms.output,
+        });
       }
 
       if (anthropicPayloadLogger) {

--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -603,10 +603,9 @@ export function buildEmbeddedRunPayloads(params: {
     };
   }> = [];
 
-  const sourceReplyPayloads =
-    params.sourceReplyDeliveryMode === "message_tool_only"
-      ? (params.messagingToolSourceReplyPayloads ?? [])
-      : [];
+  // Internal source replies always need transcript/UI mirror payloads. Only a
+  // message_tool_only run suppresses the separate automatic final answer.
+  const sourceReplyPayloads = params.messagingToolSourceReplyPayloads ?? [];
   const sourceReplyStartIndex = replyItems.length;
   sourceReplyPayloads.forEach((payload, index) => {
     const text = normalizeOptionalString(payload.text) ?? "";
@@ -647,7 +646,7 @@ export function buildEmbeddedRunPayloads(params: {
   const useMarkdown = params.toolResultFormat === "markdown";
   const suppressAssistantArtifacts =
     params.didSendDeterministicApprovalPrompt === true ||
-    hasSourceReplyPayload ||
+    (params.sourceReplyDeliveryMode === "message_tool_only" && hasSourceReplyPayload) ||
     deliveredSourceReplyViaMessageTool;
   const nonEmptyAssistantTexts = params.assistantTexts.filter((text) => text.trim().length > 0);
   const currentAssistant = params.currentAssistant ?? undefined;

--- a/src/agents/plugin-text-transforms.test.ts
+++ b/src/agents/plugin-text-transforms.test.ts
@@ -5,6 +5,7 @@ import {
   type AssistantMessage,
   type Context,
   type Model,
+  type ToolCall,
 } from "openclaw/plugin-sdk/llm";
 import { describe, expect, it } from "vitest";
 import {
@@ -37,6 +38,14 @@ function makeAssistantMessage(text: string): AssistantMessage {
       cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
     },
     timestamp: 0,
+  };
+}
+
+function makeAssistantToolMessage(toolCall: ToolCall): AssistantMessage {
+  return {
+    ...makeAssistantMessage(""),
+    content: [toolCall],
+    stopReason: "toolUse",
   };
 }
 
@@ -179,5 +188,92 @@ describe("plugin text transforms", () => {
     expect(firstEvent?.type).toBe("text_delta");
     expect(firstEvent?.delta).toBe("red basket on the left shelf");
     expect(result.content).toEqual([{ type: "text", text: "final red basket on the left shelf" }]);
+  });
+
+  it("applies output replacements to structured tool-call arguments", async () => {
+    const partialToolCall: ToolCall = {
+      type: "toolCall",
+      id: "call-1",
+      name: "search",
+      arguments: {
+        query: "[MASKED]",
+        nested: { note: "ask [MASKED] again" },
+        entries: ["[MASKED]", 7],
+      },
+    };
+    const finalToolCall: ToolCall = {
+      type: "toolCall",
+      id: "call-2",
+      name: "send_msg",
+      arguments: { text: "[MASKED]" },
+    };
+    const partial = makeAssistantToolMessage(partialToolCall);
+    const baseStreamFn: StreamFn = (_model, _context) => {
+      const stream = createAssistantMessageEventStream();
+      queueMicrotask(() => {
+        stream.push({
+          type: "toolcall_delta",
+          contentIndex: 0,
+          delta: '{"query":"[MASKED]"}',
+          partial,
+        });
+        stream.push({
+          type: "toolcall_end",
+          contentIndex: 0,
+          toolCall: partialToolCall,
+          partial,
+        });
+        stream.push({
+          type: "done",
+          reason: "toolUse",
+          message: makeAssistantToolMessage(finalToolCall),
+        });
+        stream.end();
+      });
+      return stream;
+    };
+
+    const wrapped = wrapStreamFnTextTransforms({
+      streamFn: baseStreamFn,
+      output: [{ from: /\[MASKED\]/g, to: "John" }],
+    });
+    const stream = await Promise.resolve(wrapped(model, {} as Context, undefined));
+    const events = [];
+    for await (const event of stream) {
+      events.push(event);
+    }
+
+    const deltaEvent = events.find((event) => event.type === "toolcall_delta") as
+      | { delta?: string; partial?: AssistantMessage }
+      | undefined;
+    // Raw JSON fragments are provider bytes and may split a replacement token.
+    // Structured arguments are the safe, canonical transform surface.
+    expect(deltaEvent?.delta).toBe('{"query":"[MASKED]"}');
+    expect(deltaEvent?.partial?.content[0]).toMatchObject({
+      name: "search",
+      arguments: {
+        query: "John",
+        nested: { note: "ask John again" },
+        entries: ["John", 7],
+      },
+    });
+
+    const endEvent = events.find((event) => event.type === "toolcall_end") as
+      | { toolCall?: { name?: string; arguments?: Record<string, unknown> } }
+      | undefined;
+    // Tool name is preserved — only arguments are transformed to avoid
+    // breaking tool routing by renaming a registered tool identifier.
+    expect(endEvent?.toolCall?.name).toBe("search");
+    expect(endEvent?.toolCall?.arguments).toEqual({
+      query: "John",
+      nested: { note: "ask John again" },
+      entries: ["John", 7],
+    });
+
+    const result = await stream.result();
+    expect(result.content[0]).toMatchObject({
+      name: "send_msg",
+      arguments: { text: "John" },
+    });
   });
 });

--- a/src/agents/plugin-text-transforms.ts
+++ b/src/agents/plugin-text-transforms.ts
@@ -62,6 +62,9 @@ function transformContentText(content: unknown, replacements?: PluginTextReplace
   if (Object.hasOwn(next, "content")) {
     next.content = transformContentText(next.content, replacements);
   }
+  if (next.type === "toolCall" && Object.hasOwn(next, "arguments")) {
+    next.arguments = transformToolCallArgumentText(next.arguments, replacements);
+  }
   return next;
 }
 
@@ -77,6 +80,27 @@ function transformMessageText(message: unknown, replacements?: PluginTextReplace
     next.errorMessage = applyPluginTextReplacements(next.errorMessage, replacements);
   }
   return next;
+}
+
+function transformToolCallArgumentText(
+  value: unknown,
+  replacements?: PluginTextReplacement[],
+): unknown {
+  if (typeof value === "string") {
+    return applyPluginTextReplacements(value, replacements);
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => transformToolCallArgumentText(entry, replacements));
+  }
+  if (!isRecord(value)) {
+    return value;
+  }
+  return Object.fromEntries(
+    Object.entries(value).map(([key, entry]) => [
+      key,
+      transformToolCallArgumentText(entry, replacements),
+    ]),
+  );
 }
 
 /** Apply input text replacements to a stream context. */
@@ -113,6 +137,17 @@ function transformAssistantEventText(
   }
   if (next.type === "text_end" && typeof next.content === "string") {
     next.content = applyPluginTextReplacements(next.content, replacements);
+  }
+  if (
+    next.type === "toolcall_end" &&
+    isRecord(next.toolCall) &&
+    Object.hasOwn(next.toolCall, "arguments")
+  ) {
+    // Tool names are routing identifiers; only argument values are text.
+    next.toolCall = {
+      ...next.toolCall,
+      arguments: transformToolCallArgumentText(next.toolCall.arguments, replacements),
+    };
   }
   if (Object.hasOwn(next, "partial")) {
     next.partial = transformMessageText(next.partial, replacements);

--- a/src/agents/sessions/session-manager.test.ts
+++ b/src/agents/sessions/session-manager.test.ts
@@ -153,6 +153,36 @@ describe("SessionManager.open", () => {
     expect(SessionManager.continueRecent(longCwd, dir).getSessionFile()).toBe(sessionFile);
   });
 
+  it("does not continue a different cwd from a colliding session directory", async () => {
+    const dir = await makeTempDir();
+    const cwdA = "/home/alice/dev/client/app";
+    const cwdB = "/home/alice/dev/client-app";
+    const sessionA = path.join(dir, "session-a.jsonl");
+    const sessionB = path.join(dir, "session-b.jsonl");
+    const headerA = buildSessionHeader(cwdA, "session-a");
+    const headerB = buildSessionHeader(cwdB, "session-b");
+
+    await fs.writeFile(sessionA, `${JSON.stringify(headerA)}\n`, "utf8");
+    await fs.writeFile(sessionB, `${JSON.stringify(headerB)}\n`, "utf8");
+    await fs.utimes(
+      sessionA,
+      new Date("2026-06-18T00:00:00.000Z"),
+      new Date("2026-06-18T00:00:00.000Z"),
+    );
+    await fs.utimes(
+      sessionB,
+      new Date("2026-06-18T00:00:01.000Z"),
+      new Date("2026-06-18T00:00:01.000Z"),
+    );
+
+    expect(findMostRecentSession(dir)).toBe(sessionB);
+    expect(findMostRecentSession(dir, cwdA)).toBe(sessionA);
+    expect(SessionManager.continueRecent(cwdA, dir).getSessionFile()).toBe(sessionA);
+    await expect(SessionManager.list(cwdA, dir)).resolves.toEqual([
+      expect.objectContaining({ path: sessionA, cwd: cwdA }),
+    ]);
+  });
+
   it("skips oversized recent session headers instead of hiding valid sessions", async () => {
     const dir = await makeTempDir();
     const validSessionFile = path.join(dir, "valid-session.jsonl");

--- a/src/agents/sessions/session-manager.ts
+++ b/src/agents/sessions/session-manager.ts
@@ -1171,27 +1171,34 @@ function readFirstSessionFileLine(filePath: string): string | undefined {
   }
 }
 
-function isValidSessionFile(filePath: string): boolean {
+function readSessionHeaderFromFile(filePath: string): SessionHeader | undefined {
   try {
     const firstLine = readFirstSessionFileLine(filePath);
     if (!firstLine) {
-      return false;
+      return undefined;
     }
     const header = JSON.parse(firstLine);
-    return header.type === "session" && typeof header.id === "string";
+    if (header.type !== "session" || typeof header.id !== "string") {
+      return undefined;
+    }
+    return header as SessionHeader;
   } catch {
-    return false;
+    return undefined;
   }
 }
 
 /** Exported for testing */
-export function findMostRecentSession(sessionDir: string): string | null {
+export function findMostRecentSession(sessionDir: string, cwd?: string): string | null {
   try {
     const files = readdirSync(sessionDir)
       .filter((f) => f.endsWith(".jsonl"))
       .map((f) => join(sessionDir, f))
-      .filter(isValidSessionFile)
-      .map((path) => ({ path, mtime: statSync(path).mtime }))
+      .map((path) => ({ path, header: readSessionHeaderFromFile(path) }))
+      .filter(
+        (candidate): candidate is { path: string; header: SessionHeader } =>
+          candidate.header !== undefined && (cwd === undefined || candidate.header.cwd === cwd),
+      )
+      .map((candidate) => ({ path: candidate.path, mtime: statSync(candidate.path).mtime }))
       .toSorted((a, b) => b.mtime.getTime() - a.mtime.getTime());
 
     return files[0]?.path || null;
@@ -1348,6 +1355,10 @@ async function buildSessionInfo(filePath: string): Promise<SessionInfo | null> {
   }
 }
 
+function sessionInfoMatchesCwd(info: SessionInfo, cwd: string | undefined): boolean {
+  return cwd === undefined || info.cwd === cwd;
+}
+
 export type SessionListProgress = (loaded: number, total: number) => void;
 
 const MAX_CONCURRENT_SESSION_INFO_LOADS = 10;
@@ -1397,6 +1408,7 @@ async function listSessionsFromDir(
   onProgress?: SessionListProgress,
   progressOffset = 0,
   progressTotal?: number,
+  cwd?: string,
 ): Promise<SessionInfo[]> {
   const sessions: SessionInfo[] = [];
   if (!existsSync(dir)) {
@@ -1414,7 +1426,7 @@ async function listSessionsFromDir(
       onProgress?.(progressOffset + loaded, total);
     });
     for (const info of results) {
-      if (info) {
+      if (info && sessionInfoMatchesCwd(info, cwd)) {
         sessions.push(info);
       }
     }
@@ -2921,7 +2933,7 @@ export class SessionManager {
    */
   static continueRecent(cwd: string, sessionDir?: string): SessionManager {
     const dir = sessionDir ?? getDefaultSessionDir(cwd);
-    const mostRecent = findMostRecentSession(dir);
+    const mostRecent = findMostRecentSession(dir, cwd);
     if (mostRecent) {
       return new SessionManager(cwd, dir, mostRecent, true);
     }
@@ -2995,7 +3007,7 @@ export class SessionManager {
     onProgress?: SessionListProgress,
   ): Promise<SessionInfo[]> {
     const dir = sessionDir ?? getDefaultSessionDir(cwd);
-    const sessions = await listSessionsFromDir(dir, onProgress);
+    const sessions = await listSessionsFromDir(dir, onProgress, 0, undefined, cwd);
     sessions.sort((a, b) => b.modified.getTime() - a.modified.getTime());
     return sessions;
   }

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -1388,13 +1388,13 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("Reactions are enabled for Telegram in MINIMAL mode.");
   });
 
-  it("keeps stable project context before all channel/identity-varying guidance for prefix-cache reuse", () => {
-    const prompt = buildAgentSystemPrompt({
+  it("keeps exec-approval and authorized-sender guidance below the stable prefix", () => {
+    const baseParams = {
       workspaceDir: "/tmp/openclaw",
       toolNames: ["message"],
       ownerNumbers: ["+123"],
       runtimeInfo: {
-        channel: "telegram",
+        channel: "webchat",
         capabilities: ["inlineButtons"],
       },
       contextFiles: [
@@ -1406,7 +1406,8 @@ describe("buildAgentSystemPrompt", () => {
       extraSystemPrompt: "Current group-chat facts",
       reactionGuidance: { level: "minimal", channel: "Telegram" },
       ttsHint: "Use short voice-friendly replies.",
-    });
+    } satisfies Parameters<typeof buildAgentSystemPrompt>[0];
+    const prompt = buildAgentSystemPrompt(baseParams);
 
     const projectContextPos = prompt.indexOf("# Project Context");
     const boundaryPos = prompt.indexOf(SYSTEM_PROMPT_CACHE_BOUNDARY);
@@ -1414,9 +1415,8 @@ describe("buildAgentSystemPrompt", () => {
     const groupChatPos = prompt.lastIndexOf("## Group Chat Context");
     const reactionsPos = prompt.lastIndexOf("## Reactions");
     const voicePos = prompt.lastIndexOf("## Voice (TTS)");
-    // Exec-approval guidance (channel-varying) and Authorized Senders (owner/identity-varying,
-    // dropped when minimal) previously leaked ABOVE the boundary, forking the cacheable prefix
-    // at ~token 1,460; they must sit below it like the other channel-varying sections.
+    // These sections vary with approval UI capabilities and owner identity, so
+    // both must stay below the stable prefix boundary.
     const approvalPos = prompt.lastIndexOf("use native approval card");
     const authorizedSendersPos = prompt.lastIndexOf("## Authorized Senders");
 
@@ -1428,6 +1428,23 @@ describe("buildAgentSystemPrompt", () => {
     expect(voicePos).toBeGreaterThan(boundaryPos);
     expect(approvalPos).toBeGreaterThan(boundaryPos);
     expect(authorizedSendersPos).toBeGreaterThan(boundaryPos);
+
+    const stablePrefix = prompt.slice(0, boundaryPos);
+    const otherOwnerPrompt = buildAgentSystemPrompt({
+      ...baseParams,
+      ownerNumbers: ["+456"],
+    });
+    const manualApprovalPrompt = buildAgentSystemPrompt({
+      ...baseParams,
+      runtimeInfo: { channel: "webchat", capabilities: [] },
+    });
+    expect(otherOwnerPrompt).toContain("Authorized senders: +456");
+    expect(otherOwnerPrompt).not.toContain("Authorized senders: +123");
+    expect(manualApprovalPrompt).toContain("send the exact /approve command");
+    expect(manualApprovalPrompt).not.toContain("use native approval card");
+    for (const variant of [otherOwnerPrompt, manualApprovalPrompt]) {
+      expect(variant.slice(0, variant.indexOf(SYSTEM_PROMPT_CACHE_BOUNDARY))).toBe(stablePrefix);
+    }
   });
 });
 

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -976,6 +976,9 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("## Provider Dynamic\n\nDynamic guidance.");
     expect(prompt).toContain("## Tool Call Style\nProvider-specific tool call guidance.");
     expect(prompt).not.toContain("Default: do not narrate routine, low-risk tool calls");
+    // The relocated exec-approval guidance stays suppressed when tool_call_style is
+    // provider-overridden, preserving the "override replaces the whole section" contract.
+    expect(prompt).not.toContain("If exec returns approval-pending");
   });
 
   it("includes inline button style guidance when runtime supports inline buttons", () => {

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -1385,10 +1385,11 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("Reactions are enabled for Telegram in MINIMAL mode.");
   });
 
-  it("keeps stable project context before volatile channel guidance for prefix-cache reuse", () => {
+  it("keeps stable project context before all channel/identity-varying guidance for prefix-cache reuse", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",
       toolNames: ["message"],
+      ownerNumbers: ["+123"],
       runtimeInfo: {
         channel: "telegram",
         capabilities: ["inlineButtons"],
@@ -1410,6 +1411,11 @@ describe("buildAgentSystemPrompt", () => {
     const groupChatPos = prompt.lastIndexOf("## Group Chat Context");
     const reactionsPos = prompt.lastIndexOf("## Reactions");
     const voicePos = prompt.lastIndexOf("## Voice (TTS)");
+    // Exec-approval guidance (channel-varying) and Authorized Senders (owner/identity-varying,
+    // dropped when minimal) previously leaked ABOVE the boundary, forking the cacheable prefix
+    // at ~token 1,460; they must sit below it like the other channel-varying sections.
+    const approvalPos = prompt.lastIndexOf("use native approval card");
+    const authorizedSendersPos = prompt.lastIndexOf("## Authorized Senders");
 
     expect(projectContextPos).toBeGreaterThan(-1);
     expect(boundaryPos).toBeGreaterThan(projectContextPos);
@@ -1417,6 +1423,8 @@ describe("buildAgentSystemPrompt", () => {
     expect(groupChatPos).toBeGreaterThan(boundaryPos);
     expect(reactionsPos).toBeGreaterThan(boundaryPos);
     expect(voicePos).toBeGreaterThan(boundaryPos);
+    expect(approvalPos).toBeGreaterThan(boundaryPos);
+    expect(authorizedSendersPos).toBeGreaterThan(boundaryPos);
   });
 });
 

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -1109,11 +1109,6 @@ export function buildAgentSystemPrompt(params: {
           "Routine low-risk calls: no narration.",
           "Narrate only for complex, sensitive/destructive, or explicitly requested steps.",
           "First-class tool exists: use it; do not ask user to run equivalent CLI/slash command.",
-          buildExecApprovalPromptGuidance({
-            runtimeChannel: params.runtimeInfo?.channel,
-            inlineButtonsEnabled,
-            runtimeCapabilities,
-          }),
           "Never execute /approve through exec or any other shell/tool path; /approve is a user-facing approval command, not a shell command.",
           "Treat allow-once as single-command only: if another elevated command needs approval, request a fresh /approve and do not claim prior approval covered it.",
           "When approvals are required, preserve and show the full command/script exactly as provided (including chained operators like &&, ||, |, ;, or multiline shells) so the user can approve what will actually run, but keep command/script previews separate from the /approve command and never substitute the shell command/script for the approval id or slug.",
@@ -1234,7 +1229,6 @@ export function buildAgentSystemPrompt(params: {
             .join("\n")
         : "",
       params.sandboxInfo?.enabled ? "" : "",
-      ...buildUserIdentitySection(ownerLine, isMinimal),
       ...buildTimeSection({
         userTimezone,
       }),
@@ -1291,6 +1285,15 @@ export function buildAgentSystemPrompt(params: {
   // Channel/session-specific guidance lives below the cache boundary so large
   // stable workspace context can remain a byte-identical prefix across turns.
   lines.push(
+    // Exec-approval guidance varies by channel (CLI /approve vs native approval UI)
+    // and Authorized Senders varies by owner/identity (and is dropped when minimal),
+    // so both must sit below the boundary to keep the static prefix byte-identical.
+    buildExecApprovalPromptGuidance({
+      runtimeChannel: params.runtimeInfo?.channel,
+      inlineButtonsEnabled,
+      runtimeCapabilities,
+    }),
+    ...buildUserIdentitySection(ownerLine, isMinimal),
     ...buildWebchatCanvasSection({
       isMinimal,
       runtimeChannel,

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -1288,11 +1288,17 @@ export function buildAgentSystemPrompt(params: {
     // Exec-approval guidance varies by channel (CLI /approve vs native approval UI)
     // and Authorized Senders varies by owner/identity (and is dropped when minimal),
     // so both must sit below the boundary to keep the static prefix byte-identical.
-    buildExecApprovalPromptGuidance({
-      runtimeChannel: params.runtimeInfo?.channel,
-      inlineButtonsEnabled,
-      runtimeCapabilities,
-    }),
+    // Still suppressed when `tool_call_style` is provider-overridden, preserving the
+    // original contract where that override replaces the whole section (incl. this line).
+    ...(providerSectionOverrides.tool_call_style
+      ? []
+      : [
+          buildExecApprovalPromptGuidance({
+            runtimeChannel: params.runtimeInfo?.channel,
+            inlineButtonsEnabled,
+            runtimeCapabilities,
+          }),
+        ]),
     ...buildUserIdentitySection(ownerLine, isMinimal),
     ...buildWebchatCanvasSection({
       isMinimal,

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -1013,13 +1013,10 @@ export function buildAgentSystemPrompt(params: {
     nativeCommandGuidanceLines,
     providerSectionOverrides,
     providerStablePrefix,
-    ownerLine,
     reasoningHint,
     reasoningLevel,
     userTimezone,
     runtimeChannel,
-    runtimeCapabilities,
-    inlineButtonsEnabled,
     threadBoundAcpSpawnEnabled,
     sourceMessageToolOnly,
     silentReplyPromptMode,
@@ -1285,11 +1282,8 @@ export function buildAgentSystemPrompt(params: {
   // Channel/session-specific guidance lives below the cache boundary so large
   // stable workspace context can remain a byte-identical prefix across turns.
   lines.push(
-    // Exec-approval guidance varies by channel (CLI /approve vs native approval UI)
-    // and Authorized Senders varies by owner/identity (and is dropped when minimal),
-    // so both must sit below the boundary to keep the static prefix byte-identical.
-    // Still suppressed when `tool_call_style` is provider-overridden, preserving the
-    // original contract where that override replaces the whole section (incl. this line).
+    // Approval UI and owner identity vary by turn, so keep both below the stable prefix.
+    // A tool_call_style override owns the complete section and suppresses default guidance.
     ...(providerSectionOverrides.tool_call_style
       ? []
       : [

--- a/src/agents/tools/message-tool.internal-source-reply.integration.test.ts
+++ b/src/agents/tools/message-tool.internal-source-reply.integration.test.ts
@@ -1,0 +1,82 @@
+// Integration coverage for targetless WebChat tool sends through the internal
+// source-reply sink and embedded-run payload projection.
+import { describe, expect, it } from "vitest";
+import { getReplyPayloadMetadata } from "../../auto-reply/reply-payload.js";
+import { buildReplyPayloads } from "../../auto-reply/reply/agent-runner-payloads.js";
+import { buildEmbeddedRunPayloads } from "../embedded-agent-runner/run/payloads.js";
+import { extractMessagingToolSourceReplyPayload } from "../embedded-agent-subscribe.tools.js";
+import { createMessageTool } from "./message-tool.js";
+
+describe("WebChat message tool internal source reply", () => {
+  it("projects a real targetless send and preserves the automatic final reply", async () => {
+    const tool = createMessageTool({
+      config: {},
+      currentChannelProvider: "webchat",
+      sourceReplyDeliveryMode: "automatic",
+      agentSessionKey: "agent:main:webchat:dm:dashboard",
+      runId: "webchat-run",
+      getScopedChannelsCommandSecretTargets: () => ({ targetIds: new Set<string>() }),
+      resolveCommandSecretRefsViaGateway: async ({ config }) => ({
+        resolvedConfig: config,
+        diagnostics: [],
+        targetStatesByPath: {},
+        hadUnresolvedTargets: false,
+      }),
+    });
+
+    const toolResult = await tool.execute("message-call", {
+      action: "send",
+      message: "Visible progress from the message tool.",
+    });
+    expect(toolResult.details).toMatchObject({
+      channel: "webchat",
+      target: "current-run",
+      sourceReplyDeliveryMode: "message_tool_only",
+      sourceReplySink: "internal-ui",
+      sourceReply: { text: "Visible progress from the message tool." },
+    });
+
+    const sourceReply = extractMessagingToolSourceReplyPayload(toolResult);
+    expect(sourceReply).toMatchObject({ text: "Visible progress from the message tool." });
+
+    const embeddedPayloads = buildEmbeddedRunPayloads({
+      assistantTexts: ["Visible automatic final reply."],
+      toolMetas: [],
+      lastAssistant: undefined,
+      currentAssistant: undefined,
+      sessionKey: "agent:main:webchat:dm:dashboard",
+      sourceReplyDeliveryMode: "automatic",
+      messagingToolSourceReplyPayloads: sourceReply ? [sourceReply] : [],
+      runId: "webchat-run",
+      inlineToolResultsAllowed: false,
+      verboseLevel: "off",
+      reasoningLevel: "off",
+      toolResultFormat: "plain",
+    });
+    const { replyPayloads: payloads } = await buildReplyPayloads({
+      payloads: embeddedPayloads,
+      isHeartbeat: false,
+      didLogHeartbeatStrip: false,
+      blockStreamingEnabled: false,
+      blockReplyPipeline: null,
+      replyToMode: "off",
+      messagingToolSentTexts: ["Visible progress from the message tool."],
+    });
+
+    expect(payloads.map((payload) => payload.text)).toEqual([
+      "Visible progress from the message tool.",
+      "Visible automatic final reply.",
+    ]);
+    expect(getReplyPayloadMetadata(payloads[0] as object)).toMatchObject({
+      deliverDespiteSourceReplySuppression: true,
+      sourceReplyTranscriptMirror: {
+        sessionKey: "agent:main:webchat:dm:dashboard",
+        text: "Visible progress from the message tool.",
+        idempotencyKey: "webchat-run:internal-source-reply:0",
+      },
+    });
+    expect(getReplyPayloadMetadata(payloads[1] as object)?.sourceReplyTranscriptMirror).toBe(
+      undefined,
+    );
+  });
+});

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -526,6 +526,44 @@ describe("message tool secret scoping", () => {
     expect(input?.toolContext?.currentChannelProvider).toBe("webchat");
   });
 
+  it("defaults internal WebChat message tool sends to the source-reply sink", async () => {
+    mockSendResult();
+
+    const input = await executeSend({
+      action: { message: "hi" },
+      toolOptions: {
+        currentChannelProvider: "webchat",
+        agentSessionKey: "agent:main:webchat:dm:dashboard",
+      },
+    });
+
+    expect(input?.sourceReplyDeliveryMode).toBe("message_tool_only");
+    expect(input?.toolContext?.currentChannelProvider).toBe("webchat");
+    expect(input?.params).toMatchObject({ action: "send", message: "hi" });
+  });
+
+  it("keeps automatic WebChat final-answer guidance while selecting the tool-local sink", async () => {
+    mockSendResult();
+
+    const input = await executeSend({
+      action: { message: "hi" },
+      toolOptions: {
+        currentChannelProvider: "webchat",
+        sourceReplyDeliveryMode: "automatic",
+        agentSessionKey: "agent:main:webchat:dm:dashboard",
+      },
+    });
+
+    expect(input?.sourceReplyDeliveryMode).toBe("message_tool_only");
+    expect(input?.toolContext?.currentChannelProvider).toBe("webchat");
+    const tool = createMessageTool({
+      currentChannelProvider: "webchat",
+      sourceReplyDeliveryMode: "automatic",
+      agentSessionKey: "agent:main:webchat:dm:dashboard",
+    });
+    expect(tool.description).not.toContain("Normal final answers stay private");
+  });
+
   it("passes current inbound audio to the outbound runner", async () => {
     mockSendResult();
 

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -59,7 +59,7 @@ import { stringifyRouteThreadId } from "../../plugin-sdk/channel-route.js";
 import { POLL_CREATION_PARAM_DEFS, SHARED_POLL_CREATION_PARAM_NAMES } from "../../poll-params.js";
 import { normalizeAccountId, parseSessionDeliveryRoute } from "../../routing/session-key.js";
 import { stripFormattedReasoningMessage } from "../../shared/text/formatted-reasoning-message.js";
-import { normalizeMessageChannel } from "../../utils/message-channel.js";
+import { INTERNAL_MESSAGE_CHANNEL, normalizeMessageChannel } from "../../utils/message-channel.js";
 import { resolveSessionAgentId } from "../agent-scope.js";
 import { listAllChannelSupportedActions, listChannelSupportedActions } from "../channel-tools.js";
 import { stripInternalRuntimeContext } from "../internal-runtime-context.js";
@@ -1147,6 +1147,14 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
   const replyToMode = options?.replyToMode ?? (currentThreadTs ? "all" : undefined);
   const agentAccountId =
     resolveAgentAccountId(options?.agentAccountId) ?? effectiveCurrentChannel.accountId;
+  const currentChannelIsInternal =
+    normalizeMessageChannel(effectiveCurrentChannel.currentChannelProvider) ===
+    INTERNAL_MESSAGE_CHANNEL;
+  // WebChat tool sends use the private sink without changing the run-level
+  // contract: ordinary final answers must remain automatic and visible.
+  const sourceReplySinkDeliveryMode = currentChannelIsInternal
+    ? "message_tool_only"
+    : options?.sourceReplyDeliveryMode;
   const resolvedAgentId =
     options?.agentId ??
     (options?.agentSessionKey
@@ -1387,7 +1395,7 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
           sessionId: options?.sessionId,
           agentId: resolvedAgentId,
           sandboxRoot: options?.sandboxRoot,
-          sourceReplyDeliveryMode: options?.sourceReplyDeliveryMode,
+          sourceReplyDeliveryMode: sourceReplySinkDeliveryMode,
           inboundEventKind: options?.inboundEventKind,
           inboundAudio: options?.currentInboundAudio,
           abortSignal: signal,

--- a/src/agents/tools/pdf-tool.helpers.test.ts
+++ b/src/agents/tools/pdf-tool.helpers.test.ts
@@ -62,6 +62,10 @@ describe("parsePageRange", () => {
     expect(parsePageRange("1-100", 5)).toEqual([1, 2, 3, 4, 5]);
   });
 
+  it("throws when no requested pages are within maxPages", () => {
+    expect(() => parsePageRange("999", 20)).toThrow('No PDF pages matched requested range "999"');
+  });
+
   it("deduplicates and sorts", () => {
     expect(parsePageRange("5,3,1,3,5", 20)).toEqual([1, 3, 5]);
   });

--- a/src/agents/tools/pdf-tool.helpers.ts
+++ b/src/agents/tools/pdf-tool.helpers.ts
@@ -74,7 +74,11 @@ export function parsePageRange(range: string, maxPages: number): number[] {
       }
     }
   }
-  return Array.from(pages).toSorted((a, b) => a - b);
+  const parsedPages = Array.from(pages).toSorted((a, b) => a - b);
+  if (parsedPages.length === 0) {
+    throw new Error(`No PDF pages matched requested range "${range}"`);
+  }
+  return parsedPages;
 }
 
 /** Converts a provider assistant message into PDF text or throws a model-labelled failure. */

--- a/src/agents/tools/pdf-tool.test.ts
+++ b/src/agents/tools/pdf-tool.test.ts
@@ -548,6 +548,26 @@ describe("createPdfTool", () => {
     });
   });
 
+  it("rejects explicit page ranges that resolve to no pages before native PDF analysis", async () => {
+    await withTempPdfAgentDir(async (agentDir) => {
+      await stubPdfToolInfra(agentDir, { provider: "anthropic", input: ["text", "document"] });
+      const nativeSpy = vi
+        .spyOn(pdfNativeProviders, "anthropicAnalyzePdf")
+        .mockResolvedValue("native summary");
+      const cfg = withPdfModel(ANTHROPIC_PDF_MODEL);
+      const tool = requirePdfTool((await loadCreatePdfTool())({ config: cfg, agentDir }));
+
+      await expect(
+        tool.execute("t1", {
+          prompt: "summarize",
+          pdf: "/tmp/doc.pdf",
+          pages: "999",
+        }),
+      ).rejects.toThrow('No PDF pages matched requested range "999"');
+      expect(nativeSpy).not.toHaveBeenCalled();
+    });
+  });
+
   it("rejects password parameter for native PDF providers", async () => {
     await withTempPdfAgentDir(async (agentDir) => {
       await stubPdfToolInfra(agentDir, { provider: "anthropic", input: ["text", "document"] });

--- a/src/auto-reply/inbound.test.ts
+++ b/src/auto-reply/inbound.test.ts
@@ -1,12 +1,11 @@
 /** Tests inbound auto-reply handling across channel message contexts. */
-import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import type { GroupKeyResolution } from "../config/sessions.js";
 import { channelRouteDedupeKey } from "../plugin-sdk/channel-route.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
+import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
 import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
 import { createInboundDebouncer } from "./inbound-debounce.js";
 import { resolveGroupRequireMention } from "./reply/groups.js";
@@ -985,9 +984,21 @@ describe("createInboundDebouncer", () => {
   });
 });
 
+const senderMetaTempDirs = createSuiteTempRootTracker({
+  prefix: "openclaw-sender-meta-",
+});
+
 describe("initSessionState BodyStripped", () => {
+  beforeAll(async () => {
+    await senderMetaTempDirs.setup();
+  });
+
+  afterAll(async () => {
+    await senderMetaTempDirs.cleanup();
+  });
+
   it("prefers BodyForAgent over Body for group chats", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sender-meta-"));
+    const root = await senderMetaTempDirs.make("group");
     const storePath = path.join(root, "sessions.json");
     const cfg = { session: { store: storePath } } as OpenClawConfig;
 
@@ -1009,7 +1020,7 @@ describe("initSessionState BodyStripped", () => {
   });
 
   it("prefers BodyForAgent over Body for direct chats", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sender-meta-direct-"));
+    const root = await senderMetaTempDirs.make("direct");
     const storePath = path.join(root, "sessions.json");
     const cfg = { session: { store: storePath } } as OpenClawConfig;
 

--- a/src/auto-reply/reply/abort.test.ts
+++ b/src/auto-reply/reply/abort.test.ts
@@ -1,10 +1,10 @@
 // Tests abort request handling, cutoff persistence, and active run cleanup.
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SubagentRunRecord } from "../../agents/subagent-registry.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import { createSuiteTempRootTracker } from "../../test-helpers/temp-dir.js";
 import type { SessionAbortTargetResult } from "../../config/sessions/session-accessor.js";
 import {
   testing as abortTesting,
@@ -83,7 +83,17 @@ vi.mock("../../acp/control-plane/manager.js", () => ({
   }),
 }));
 
+const suiteTempDirs = createSuiteTempRootTracker({ prefix: "openclaw-abort-" });
+
 describe("abort detection", () => {
+  beforeAll(async () => {
+    await suiteTempDirs.setup();
+  });
+
+  afterAll(async () => {
+    await suiteTempDirs.cleanup();
+  });
+
   async function writeSessionStore(
     storePath: string,
     sessionIdsByKey: Record<string, string>,
@@ -103,7 +113,7 @@ describe("abort detection", () => {
     sessionIdsByKey?: Record<string, string>;
     nowMs?: number;
   }) {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-abort-"));
+    const root = await suiteTempDirs.make("case");
     const storePath = path.join(root, "sessions.json");
     const cfg = {
       session: { store: storePath },

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -303,6 +303,13 @@ export async function buildReplyPayloads(params: {
     });
     dedupedPayloads = [];
     for (const payload of silentFilteredPayloads) {
+      const payloadMetadata = getReplyPayloadMetadata(payload);
+      // Source mirrors exist because an internal sink send must reach the UI and
+      // transcript; that send is not outbound evidence for dropping the mirror.
+      if (payloadMetadata?.sourceReplyTranscriptMirror) {
+        dedupedPayloads.push(payload);
+        continue;
+      }
       const decision = dedupeRuntime.resolveMessagingToolPayloadDedupe({
         config: params.config,
         messageProvider,
@@ -311,11 +318,9 @@ export async function buildReplyPayloads(params: {
         originatingThreadId: params.originatingThreadId,
         replyToId: payload.replyToId,
         replyToIsExplicit: Boolean(
-          getReplyPayloadMetadata(payload)?.replyToIdExplicit ||
-          payload.replyToTag ||
-          payload.replyToCurrent,
+          payloadMetadata?.replyToIdExplicit || payload.replyToTag || payload.replyToCurrent,
         ),
-        replyDelivery: getReplyPayloadMetadata(payload)?.replyDelivery,
+        replyDelivery: payloadMetadata?.replyDelivery,
         accountId,
       });
       if (!decision.shouldDedupePayloads) {

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -2833,6 +2833,9 @@ describe("runPreparedReply media-only handling", () => {
 
     const call = requireRunReplyAgentCall();
     expect(call?.followupRun.run.senderIsOwner).toBe(true);
+    expect(call?.followupRun.userTurnTranscriptRecorder?.message).toMatchObject({
+      __openclaw: { senderIsOwner: true },
+    });
   });
 
   it("keeps sender ownership when drained system events are present", async () => {

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -1247,6 +1247,7 @@ export async function runPreparedReply(
     userTurnTranscriptText !== undefined || userTurnMediaForPersistence.length > 0
       ? {
           text: userTurnTranscriptText,
+          senderIsOwner: command.senderIsOwner,
           ...(inputProvenance ? { provenance: inputProvenance } : {}),
           ...(userTurnMediaForPersistence.length > 0
             ? {

--- a/src/auto-reply/reply/session-hooks-context.test.ts
+++ b/src/auto-reply/reply/session-hooks-context.test.ts
@@ -1,11 +1,11 @@
 // Tests context passed to session lifecycle hooks.
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import type { HookRunner } from "../../plugins/hooks.js";
+import { createSuiteTempRootTracker } from "../../test-helpers/temp-dir.js";
 import { initSessionState } from "./session.js";
 
 const hookRunnerMocks = vi.hoisted(() => ({
@@ -61,8 +61,10 @@ vi.mock("../../agents/session-write-lock.js", async () => {
   };
 });
 
+const suiteTempDirs = createSuiteTempRootTracker({ prefix: "openclaw-session-hooks-" });
+
 async function createStorePath(prefix: string): Promise<string> {
-  const root = await fs.mkdtemp(path.join(os.tmpdir(), `${prefix}-`));
+  const root = await suiteTempDirs.make(prefix);
   return path.join(root, "sessions.json");
 }
 
@@ -165,6 +167,14 @@ function requireHookCall(
 }
 
 describe("session hook context wiring", () => {
+  beforeAll(async () => {
+    await suiteTempDirs.setup();
+  });
+
+  afterAll(async () => {
+    await suiteTempDirs.cleanup();
+  });
+
   beforeEach(() => {
     hookRunnerMocks.hasHooks.mockReset();
     hookRunnerMocks.runSessionStart.mockReset();

--- a/src/cli/cron-cli/register.cron-edit.test.ts
+++ b/src/cli/cron-cli/register.cron-edit.test.ts
@@ -222,11 +222,50 @@ describe("cron edit command", () => {
     );
   });
 
+  it("clears the thinking override with --clear-thinking (CLI parity with cron.update thinking:null)", async () => {
+    const program = createCronProgram();
+
+    await program.parseAsync(["edit", "job-1", "--clear-thinking"], { from: "user" });
+
+    expect(callGatewayFromCli).toHaveBeenCalledWith(
+      "cron.update",
+      expect.objectContaining({ clearThinking: true }),
+      {
+        id: "job-1",
+        patch: {
+          payload: {
+            kind: "agentTurn",
+            thinking: null,
+          },
+        },
+      },
+    );
+  });
+
+  it("rejects combining --thinking with --clear-thinking", async () => {
+    const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(defaultRuntime, "exit").mockImplementation((() => undefined) as never);
+    const program = createCronProgram();
+
+    await program.parseAsync(["edit", "job-1", "--thinking", "high", "--clear-thinking"], {
+      from: "user",
+    });
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Use --thinking or --clear-thinking, not both"),
+    );
+    expect(callGatewayFromCli).not.toHaveBeenCalled();
+
+    errorSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
   it("documents the --clear-model flag alongside the sibling --clear-tools", () => {
     const editCommand = createCronProgram().commands.find((command) => command.name() === "edit");
     const help = editCommand?.helpInformation() ?? "";
 
     expect(help).toContain("--clear-model");
+    expect(help).toContain("--clear-thinking");
     expect(help).toContain("--clear-tools");
   });
 

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -112,6 +112,11 @@ export function registerCronEditCommand(cron: Command) {
         "--thinking <level>",
         "Thinking level for agent jobs (off|minimal|low|medium|high|xhigh)",
       )
+      .option(
+        "--clear-thinking",
+        "Remove the per-job thinking override (restore normal cron thinking precedence)",
+        false,
+      )
       .option("--model <model>", "Model override for agent jobs")
       .option("--fallbacks <list>", "Fallback model list for agent jobs")
       .option("--clear-fallbacks", "Remove per-job fallback override", false)
@@ -292,6 +297,9 @@ export function registerCronEditCommand(cron: Command) {
             throw new Error("Use --model or --clear-model, not both");
           }
           const thinking = normalizeOptionalString(opts.thinking);
+          if (thinking && opts.clearThinking) {
+            throw new Error("Use --thinking or --clear-thinking, not both");
+          }
           const fallbacks = parseCronFallbacks(opts.fallbacks);
           if (typeof opts.fallbacks === "string" && opts.clearFallbacks) {
             throw new Error("Use --fallbacks or --clear-fallbacks, not both");
@@ -370,6 +378,7 @@ export function registerCronEditCommand(cron: Command) {
             typeof opts.fallbacks !== "string" &&
             !opts.clearFallbacks &&
             !thinking &&
+            !opts.clearThinking &&
             typeof opts.lightContext !== "boolean" &&
             typeof opts.tools !== "string" &&
             !Array.isArray(opts.tools) &&
@@ -385,6 +394,7 @@ export function registerCronEditCommand(cron: Command) {
             typeof opts.fallbacks === "string" ||
             Boolean(opts.clearFallbacks) ||
             Boolean(thinking) ||
+            Boolean(opts.clearThinking) ||
             (hasTimeoutSeconds &&
               !hasCommandSpecificPayloadField &&
               timeoutOnlyPayloadKind !== "command") ||
@@ -418,7 +428,11 @@ export function registerCronEditCommand(cron: Command) {
             }
             assignIf(payload, "fallbacks", fallbacks, typeof opts.fallbacks === "string");
             assignIf(payload, "fallbacks", null, Boolean(opts.clearFallbacks));
-            assignIf(payload, "thinking", thinking, Boolean(thinking));
+            if (opts.clearThinking) {
+              payload.thinking = null;
+            } else {
+              assignIf(payload, "thinking", thinking, Boolean(thinking));
+            }
             assignIf(payload, "timeoutSeconds", timeoutSeconds, hasTimeoutSeconds);
             assignIf(
               payload,

--- a/src/cli/pairing-cli.test.ts
+++ b/src/cli/pairing-cli.test.ts
@@ -224,6 +224,30 @@ describe("pairing cli", () => {
     expect(listChannelPairingRequests).toHaveBeenCalledWith("slack");
   });
 
+  it("redirects to openclaw devices when no pairing channels are configured", async () => {
+    listPairingChannels.mockReturnValueOnce([]);
+
+    const error = await runPairing(["pairing", "list"]).then(
+      () => null,
+      (err: unknown) => err,
+    );
+
+    expect(error).toBeInstanceOf(Error);
+    const message = (error as Error).message;
+    expect(message).toContain("openclaw devices");
+    // Must not leak the empty enum that originally read like a bug.
+    expect(message).not.toContain("expected one of: )");
+    expect(message).not.toContain("()");
+    expect(listChannelPairingRequests).not.toHaveBeenCalled();
+  });
+
+  it("lists supported channels when one is required but omitted", async () => {
+    // Multiple channels configured (default mock) + no channel argument.
+    await expect(runPairing(["pairing", "list"])).rejects.toThrow(
+      "expected one of: telegram, discord, imessage",
+    );
+  });
+
   it("accepts channel as positional for approve (npm-run compatible)", async () => {
     mockApprovedPairing();
 

--- a/src/cli/pairing-cli.ts
+++ b/src/cli/pairing-cli.ts
@@ -88,6 +88,8 @@ async function maybeBootstrapCommandOwnerFromPairing(params: {
 
 export function registerPairingCli(program: Command) {
   const channels = listPairingChannels();
+  // Avoid rendering a bare "()" enum when no channels are configured.
+  const channelHint = channels.length > 0 ? channels.join(", ") : "none configured";
   const pairing = program
     .command("pairing")
     .description("Secure DM pairing (approve inbound requests)")
@@ -100,16 +102,21 @@ export function registerPairingCli(program: Command) {
   pairing
     .command("list")
     .description("List pending pairing requests")
-    .option("--channel <channel>", `Channel (${channels.join(", ")})`)
+    .option("--channel <channel>", `Channel (${channelHint})`)
     .option("--account <accountId>", "Account id (for multi-account channels)")
-    .argument("[channel]", `Channel (${channels.join(", ")})`)
+    .argument("[channel]", `Channel (${channelHint})`)
     .option("--json", "Print JSON", false)
     .action(async (channelArg, opts) => {
       const channelRaw = opts.channel ?? channelArg ?? (channels.length === 1 ? channels[0] : "");
       if (!channelRaw) {
-        throw new Error(
-          `Channel required. Use --channel <channel> or pass it as the first argument (expected one of: ${channels.join(", ")})`,
-        );
+        if (channels.length === 0) {
+          // `pairing` is chat DM only; TUI/device approvals live under `openclaw devices`.
+          throw new Error(
+            `No chat DM pairing channels are configured. To approve a TUI or device request, ` +
+              `use ${formatCliCommand("openclaw devices approve")} instead.`,
+          );
+        }
+        throw new Error(`Channel required (expected one of: ${channelHint}).`);
       }
       const channel = parseChannel(channelRaw, channels);
       const accountId = normalizeStringifiedOptionalString(opts.account) ?? "";
@@ -151,7 +158,7 @@ export function registerPairingCli(program: Command) {
   pairing
     .command("approve")
     .description("Approve a pairing code and allow that sender")
-    .option("--channel <channel>", `Channel (${channels.join(", ")})`)
+    .option("--channel <channel>", `Channel (${channelHint})`)
     .option("--account <accountId>", "Account id (for multi-account channels)")
     .argument("<codeOrChannel>", "Pairing code (or channel when using 2 args)")
     .argument("[code]", "Pairing code (when channel is passed as the 1st arg)")

--- a/src/commands/agents.add.test.ts
+++ b/src/commands/agents.add.test.ts
@@ -1,14 +1,14 @@
 // Agents add tests cover agent creation, workspace setup, channel binding, and onboarding integration.
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { AUTH_STORE_VERSION } from "../agents/auth-profiles/constants.js";
 import { loadPersistedAuthProfileStore } from "../agents/auth-profiles/persisted.js";
 import { saveAuthProfileStore } from "../agents/auth-profiles/store.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import { baseConfigSnapshot, createTestRuntime } from "./test-runtime-config-helpers.js";
 
@@ -116,6 +116,18 @@ import { agentsAddCommand, testing } from "./agents.commands.add.js";
 const runtime = createTestRuntime();
 
 describe("agents add command", () => {
+  const suiteTempDirs = createSuiteTempRootTracker({ prefix: "openclaw-agents-add-" });
+
+  beforeAll(async () => {
+    await suiteTempDirs.setup();
+  });
+
+  afterAll(async () => {
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    await suiteTempDirs.cleanup();
+  });
+
   beforeEach(() => {
     readConfigFileSnapshotMock.mockClear();
     writeConfigFileMock.mockClear();
@@ -136,14 +148,8 @@ describe("agents add command", () => {
     prefix: string,
     run: (root: string) => Promise<void>,
   ): Promise<void> {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
-    try {
-      await withEnvAsync({ OPENCLAW_STATE_DIR: root }, async () => await run(root));
-    } finally {
-      closeOpenClawAgentDatabasesForTest();
-      closeOpenClawStateDatabaseForTest();
-      await fs.rm(root, { recursive: true, force: true });
-    }
+    const root = await suiteTempDirs.make(prefix);
+    await withEnvAsync({ OPENCLAW_STATE_DIR: root }, async () => await run(root));
   }
 
   it("requires --workspace when flags are present", async () => {

--- a/src/commands/doctor-auth.hints.test.ts
+++ b/src/commands/doctor-auth.hints.test.ts
@@ -2,7 +2,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
+  collectAuthProfileHealthFindings,
   formatOAuthRefreshFailureDoctorLine,
+  legacyCodexProviderOverrideToHealthFinding,
   noteLegacyCodexProviderOverride,
   resolveUnusableProfileHint,
 } from "./doctor-auth.js";
@@ -125,6 +127,52 @@ describe("resolveUnusableProfileHint", () => {
       expect.stringContaining("models.providers.openai-codex"),
       "Codex OAuth",
     );
+  });
+
+  it("maps legacy Codex overrides to structured auth profile findings", () => {
+    expect(
+      legacyCodexProviderOverrideToHealthFinding({
+        api: "openai-responses",
+        baseUrl: "https://api.openai.com/v1",
+      }),
+    ).toMatchObject({
+      checkId: "core/doctor/auth-profiles",
+      severity: "warning",
+      message:
+        "Legacy openai-codex transport override can shadow configured Codex OAuth credentials.",
+      path: "models.providers.openai-codex",
+      target: "openai-codex",
+    });
+  });
+
+  it("collects legacy Codex override structured findings", async () => {
+    const findings = await collectAuthProfileHealthFindings({
+      cfg: doctorFixtureConfig({
+        auth: {
+          profiles: {
+            "openai:default": {
+              provider: "openai",
+              mode: "oauth",
+            },
+          },
+        },
+        models: {
+          providers: {
+            "openai-codex": {
+              api: "openai-responses",
+            },
+          },
+        },
+      }),
+    });
+
+    expect(findings).toEqual([
+      expect.objectContaining({
+        checkId: "core/doctor/auth-profiles",
+        path: "models.providers.openai-codex",
+        target: "openai-codex",
+      }),
+    ]);
   });
 
   it("warns when a legacy Codex override shadows stored legacy OAuth state", () => {

--- a/src/commands/doctor-auth.profile-health.test.ts
+++ b/src/commands/doctor-auth.profile-health.test.ts
@@ -3,21 +3,16 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { DoctorPrompter } from "./doctor-prompter.js";
 
-type MockAuthProfileStore = {
-  version: number;
-  profiles: Record<
-    string,
-    | { type: "oauth"; provider: string; access: string; refresh: string; expires: number }
-    | { type: "api_key"; provider: string; key: string }
-  >;
-};
-
 const authProfileMocks = vi.hoisted(() => ({
   ensureAuthProfileStore: vi.fn<
-    (agentDir?: string, options?: { allowKeychainPrompt?: boolean }) => MockAuthProfileStore
+    (
+      agentDir?: string,
+      options?: { allowKeychainPrompt?: boolean; readOnly?: boolean },
+    ) => AuthProfileStore
   >(() => {
     throw new Error("unexpected auth profile load");
   }),
@@ -38,7 +33,7 @@ vi.mock("../agents/auth-profiles.js", () => ({
 vi.mock("../../packages/terminal-core/src/note.js", () => ({ note: vi.fn() }));
 
 import { note } from "../../packages/terminal-core/src/note.js";
-import { noteAuthProfileHealth } from "./doctor-auth.js";
+import { collectAuthProfileHealthFindings, noteAuthProfileHealth } from "./doctor-auth.js";
 
 const noteMock = vi.mocked(note);
 
@@ -67,6 +62,10 @@ describe("noteAuthProfileHealth", () => {
     fs.writeFileSync(path.join(agentDir, "auth-profiles.json"), "{}\n", "utf8");
   }
 
+  function expectedAuthStorePath(agentDir: string): string {
+    return path.join(agentDir, "openclaw-agent.sqlite");
+  }
+
   function expiredStore(profileId: string, expires: number) {
     return {
       version: 1,
@@ -79,8 +78,142 @@ describe("noteAuthProfileHealth", () => {
           expires,
         },
       },
-    };
+    } satisfies AuthProfileStore;
   }
+
+  it("maps expired stored auth profiles to structured findings without refreshing", async () => {
+    const now = 1_700_000_000_000;
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    const mainDir = path.join(tempDir, "main-agent");
+    authProfileMocks.hasAnyAuthProfileStoreSource.mockReturnValue(true);
+    authProfileMocks.ensureAuthProfileStore.mockReturnValue(
+      expiredStore("openai:default", now - 60_000),
+    );
+
+    const findings = await collectAuthProfileHealthFindings({
+      cfg: {
+        agents: {
+          list: [{ id: "main", default: true, agentDir: mainDir }],
+        },
+      } as OpenClawConfig,
+    });
+
+    expect(authProfileMocks.resolveApiKeyForProfile).not.toHaveBeenCalled();
+    expect(findings).toEqual([
+      expect.objectContaining({
+        checkId: "core/doctor/auth-profiles",
+        severity: "warning",
+        message: "Auth profile openai:default is expired (0m).",
+        path: expectedAuthStorePath(mainDir),
+        target: "openai:default",
+      }),
+    ]);
+  });
+
+  it("maps disabled auth profiles to structured findings", async () => {
+    const now = 1_700_000_000_000;
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    const mainDir = path.join(tempDir, "main-agent");
+    authProfileMocks.hasAnyAuthProfileStoreSource.mockReturnValue(true);
+    authProfileMocks.resolveProfileUnusableUntilForDisplay.mockReturnValue(now + 5 * 60_000);
+    authProfileMocks.ensureAuthProfileStore.mockReturnValue({
+      version: 1,
+      profiles: {},
+      usageStats: {
+        "openai:billing": {
+          disabledUntil: now + 5 * 60_000,
+          disabledReason: "billing",
+        },
+      },
+    } satisfies AuthProfileStore);
+
+    const findings = await collectAuthProfileHealthFindings({
+      cfg: {
+        agents: {
+          list: [{ id: "main", default: true, agentDir: mainDir }],
+        },
+      } as OpenClawConfig,
+    });
+
+    expect(findings).toEqual([
+      expect.objectContaining({
+        checkId: "core/doctor/auth-profiles",
+        message: "Auth profile openai:billing is disabled:billing (5m).",
+        path: expectedAuthStorePath(mainDir),
+        target: "openai:billing",
+        fixHint: "Top up credits (provider billing) or switch provider.",
+      }),
+    ]);
+  });
+
+  it("maps malformed API-key auth profiles to structured findings", async () => {
+    const mainDir = path.join(tempDir, "main-agent");
+    authProfileMocks.hasAnyAuthProfileStoreSource.mockReturnValue(true);
+    authProfileMocks.ensureAuthProfileStore.mockReturnValue({
+      version: 1,
+      profiles: {
+        "zai:default": {
+          type: "api_key",
+          provider: "zai",
+          key: "openclaw onboard --auth-choice zai-coding-global",
+        },
+      },
+    } satisfies AuthProfileStore);
+
+    const findings = await collectAuthProfileHealthFindings({
+      cfg: {
+        agents: {
+          list: [{ id: "main", default: true, agentDir: mainDir }],
+        },
+      } as OpenClawConfig,
+    });
+
+    expect(findings).toEqual([
+      expect.objectContaining({
+        checkId: "core/doctor/auth-profiles",
+        severity: "warning",
+        message: "Auth profile zai:default is missing [malformed_api_key].",
+        path: expectedAuthStorePath(mainDir),
+        target: "zai:default",
+        requirement: "malformed_api_key",
+        fixHint: "Paste the API key value, not an OpenClaw onboarding command.",
+      }),
+    ]);
+  });
+
+  it("labels structured auth profile findings by agent when multiple stores are checked", async () => {
+    const now = 1_700_000_000_000;
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    const mainDir = path.join(tempDir, "main-agent");
+    const coderDir = path.join(tempDir, "coder-agent");
+    authProfileMocks.hasAnyAuthProfileStoreSource.mockReturnValue(true);
+    authProfileMocks.hasLocalAuthProfileStoreSource.mockReturnValue(true);
+    authProfileMocks.ensureAuthProfileStore.mockImplementation((agentDir) => {
+      if (agentDir === mainDir) {
+        return expiredStore("openai:main", now - 60_000);
+      }
+      if (agentDir === coderDir) {
+        return expiredStore("openai:coder", now - 60_000);
+      }
+      throw new Error(`unexpected agent dir: ${agentDir ?? "<default>"}`);
+    });
+
+    const findings = await collectAuthProfileHealthFindings({
+      cfg: {
+        agents: {
+          list: [
+            { id: "main", default: true, agentDir: mainDir },
+            { id: "coder", agentDir: coderDir },
+          ],
+        },
+      } as OpenClawConfig,
+    });
+
+    expect(findings.map((finding) => finding.message)).toEqual([
+      "Agent main auth profile openai:main is expired (0m).",
+      "Agent coder auth profile openai:coder is expired (0m).",
+    ]);
+  });
   it("skips external auth profile resolution when no auth source exists", async () => {
     await noteAuthProfileHealth({
       cfg: { channels: { telegram: { enabled: true } } } as OpenClawConfig,
@@ -209,7 +342,7 @@ describe("noteAuthProfileHealth", () => {
     writeAuthStore(agentDir);
     authProfileMocks.hasAnyAuthProfileStoreSource.mockReturnValue(true);
     authProfileMocks.ensureAuthProfileStore.mockImplementation(
-      (receivedAgentDir): MockAuthProfileStore => {
+      (receivedAgentDir): AuthProfileStore => {
         if (receivedAgentDir === agentDir) {
           return {
             version: 1,

--- a/src/commands/doctor-auth.ts
+++ b/src/commands/doctor-auth.ts
@@ -26,8 +26,10 @@ import {
   classifyOAuthRefreshFailure,
   type OAuthRefreshFailureReason,
 } from "../agents/auth-profiles/oauth-refresh-failure.js";
+import { resolveAuthStorePathForDisplay } from "../agents/auth-profiles/path-resolve.js";
 import { buildProviderAuthRecoveryHint } from "../agents/provider-auth-recovery-hint.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { HealthFinding } from "../flows/health-checks.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { isRecord } from "../utils.js";
 import type { DoctorPrompter } from "./doctor-prompter.js";
@@ -37,6 +39,7 @@ const LEGACY_CODEX_PROVIDER_ID = "openai-codex";
 const CODEX_OAUTH_WARNING_TITLE = "Codex OAuth";
 const OPENAI_BASE_URL = "https://api.openai.com/v1";
 const LEGACY_CODEX_APIS = new Set(["openai-responses", "openai-completions"]);
+const AUTH_PROFILES_CHECK_ID = "core/doctor/auth-profiles";
 const DOCTOR_REAUTH_PROVIDER_ALIASES: Readonly<Record<string, string>> = {
   [LEGACY_CODEX_PROVIDER_ID]: OPENAI_PROVIDER_ID,
 };
@@ -50,7 +53,7 @@ function hasConfiguredCodexOAuthProfile(cfg: OpenClawConfig): boolean {
 }
 
 function hasStoredCodexOAuthProfile(): boolean {
-  const store = ensureAuthProfileStore(undefined, { allowKeychainPrompt: false });
+  const store = ensureAuthProfileStore(undefined, { allowKeychainPrompt: false, readOnly: true });
   return Object.values(store.profiles).some(
     (profile) =>
       (profile.provider === OPENAI_PROVIDER_ID || profile.provider === LEGACY_CODEX_PROVIDER_ID) &&
@@ -112,6 +115,22 @@ function buildCodexProviderOverrideWarning(providerOverride: unknown): string {
     "- Custom proxies and header-only overrides can stay; this warning only targets old OpenAI transport settings.",
   );
   return lines.join("\n");
+}
+
+export function legacyCodexProviderOverrideToHealthFinding(
+  providerOverride: unknown,
+): HealthFinding {
+  const message =
+    "Legacy openai-codex transport override can shadow configured Codex OAuth credentials.";
+  const details = buildCodexProviderOverrideWarning(providerOverride);
+  return {
+    checkId: AUTH_PROFILES_CHECK_ID,
+    severity: "warning",
+    message,
+    path: `models.providers.${LEGACY_CODEX_PROVIDER_ID}`,
+    target: LEGACY_CODEX_PROVIDER_ID,
+    fixHint: details,
+  };
 }
 
 /** Emits a warning when legacy Codex transport overrides can shadow configured Codex OAuth. */
@@ -261,6 +280,169 @@ async function formatAuthIssueLine(
   const hint = await resolveAuthIssueHint(issue, cfg, store);
   const reason = issue.reasonCode ? ` [${issue.reasonCode}]` : "";
   return `- ${issue.profileId}: ${issue.status}${reason}${remaining}${hint ? ` — ${hint}` : ""}`;
+}
+
+function resolveAuthProfileStorePath(target: AuthProfileHealthTarget): string {
+  return resolveAuthStorePathForDisplay(target.agentDir);
+}
+
+function authProfileIssueToHealthFinding(params: {
+  issue: AuthIssue;
+  target: AuthProfileHealthTarget;
+  labelAgents: boolean;
+  hint: string | null;
+}): HealthFinding {
+  const remaining =
+    params.issue.remainingMs !== undefined
+      ? ` (${formatRemainingShort(params.issue.remainingMs)})`
+      : "";
+  const reason = params.issue.reasonCode ? ` [${params.issue.reasonCode}]` : "";
+  const owner = params.labelAgents ? `Agent ${params.target.agentId} auth profile` : "Auth profile";
+  return {
+    checkId: AUTH_PROFILES_CHECK_ID,
+    severity: "warning",
+    message: `${owner} ${params.issue.profileId} is ${params.issue.status}${reason}${remaining}.`,
+    path: resolveAuthProfileStorePath(params.target),
+    target: params.issue.profileId,
+    ...(params.issue.reasonCode ? { requirement: params.issue.reasonCode } : {}),
+    fixHint:
+      params.hint ??
+      (params.issue.status === "expiring"
+        ? "Run `openclaw doctor --fix` to refresh expiring OAuth profiles, or re-authenticate static tokens."
+        : "Run `openclaw doctor --fix` to refresh OAuth profiles, or re-authenticate this provider."),
+  };
+}
+
+function authProfileCooldownToHealthFinding(params: {
+  profileId: string;
+  target: AuthProfileHealthTarget;
+  labelAgents: boolean;
+  kind: string;
+  remaining: string;
+  hint: string;
+}): HealthFinding {
+  return {
+    checkId: AUTH_PROFILES_CHECK_ID,
+    severity: "warning",
+    message: params.labelAgents
+      ? `Agent ${params.target.agentId} auth profile ${params.profileId} is ${params.kind} (${params.remaining}).`
+      : `Auth profile ${params.profileId} is ${params.kind} (${params.remaining}).`,
+    path: resolveAuthProfileStorePath(params.target),
+    target: params.profileId,
+    fixHint: params.hint,
+  };
+}
+
+async function collectAuthProfileHealthFindingsForTarget(params: {
+  cfg: OpenClawConfig;
+  allowKeychainPrompt: boolean;
+  target: AuthProfileHealthTarget;
+  labelAgents: boolean;
+}): Promise<readonly HealthFinding[]> {
+  const store = ensureAuthProfileStore(params.target.agentDir, {
+    allowKeychainPrompt: params.allowKeychainPrompt,
+    readOnly: true,
+  });
+  const findings: HealthFinding[] = [];
+  const now = Date.now();
+  for (const profileId of Object.keys(store.usageStats ?? {})) {
+    const until = resolveProfileUnusableUntilForDisplay(store, profileId);
+    if (!until || now >= until) {
+      continue;
+    }
+    const stats = store.usageStats?.[profileId];
+    const remaining = formatRemainingShort(until - now);
+    const disabledActive = typeof stats?.disabledUntil === "number" && now < stats.disabledUntil;
+    const kind = disabledActive
+      ? `disabled${stats.disabledReason ? `:${stats.disabledReason}` : ""}`
+      : "cooldown";
+    const hint = resolveUnusableProfileHint({
+      kind: disabledActive ? "disabled" : "cooldown",
+      reason: stats?.disabledReason,
+    });
+    findings.push(
+      authProfileCooldownToHealthFinding({
+        profileId,
+        target: params.target,
+        labelAgents: params.labelAgents,
+        kind,
+        remaining,
+        hint,
+      }),
+    );
+  }
+
+  const summary = buildAuthHealthSummary({
+    store,
+    cfg: params.cfg,
+    warnAfterMs: DEFAULT_OAUTH_WARN_MS,
+    allowKeychainPrompt: params.allowKeychainPrompt,
+  });
+  const issues = summary.profiles.filter((profile) => {
+    if (profile.type === "api_key") {
+      return profile.status === "missing";
+    }
+    return (
+      (profile.type === "oauth" || profile.type === "token") &&
+      (profile.status === "expired" ||
+        profile.status === "expiring" ||
+        profile.status === "missing")
+    );
+  });
+  for (const issue of issues) {
+    const authIssue: AuthIssue = {
+      profileId: issue.profileId,
+      provider: issue.provider,
+      status: issue.status,
+      reasonCode: issue.reasonCode,
+      remainingMs: issue.remainingMs,
+    };
+    findings.push(
+      authProfileIssueToHealthFinding({
+        issue: authIssue,
+        target: params.target,
+        labelAgents: params.labelAgents,
+        hint: await resolveAuthIssueHint(authIssue, params.cfg, store),
+      }),
+    );
+  }
+  return findings;
+}
+
+/** Collects read-only structured findings for auth profile health. */
+export async function collectAuthProfileHealthFindings(params: {
+  cfg: OpenClawConfig;
+  allowKeychainPrompt?: boolean;
+}): Promise<readonly HealthFinding[]> {
+  const configuredProfiles = Object.keys(params.cfg.auth?.profiles ?? {}).length > 0;
+  const targets = listAuthProfileHealthTargets(params.cfg);
+  const activeTargets = targets.filter((target) =>
+    target.isDefault
+      ? hasAnyAuthProfileStoreSource(target.agentDir) || configuredProfiles
+      : hasLocalAuthProfileStoreSource(target.agentDir),
+  );
+  const findings: HealthFinding[] = [];
+  const labelAgents = activeTargets.length > 1;
+  for (const target of activeTargets) {
+    findings.push(
+      ...(await collectAuthProfileHealthFindingsForTarget({
+        cfg: params.cfg,
+        allowKeychainPrompt: params.allowKeychainPrompt ?? false,
+        target,
+        labelAgents,
+      })),
+    );
+  }
+
+  const providerOverride = params.cfg.models?.providers?.[LEGACY_CODEX_PROVIDER_ID];
+  if (
+    providerOverride &&
+    hasLegacyCodexTransportOverride(providerOverride) &&
+    (hasConfiguredCodexOAuthProfile(params.cfg) || hasStoredCodexOAuthProfile())
+  ) {
+    findings.push(legacyCodexProviderOverrideToHealthFinding(providerOverride));
+  }
+  return findings;
 }
 
 async function noteAuthProfileHealthForTarget(params: {

--- a/src/commands/doctor-plugin-manifests.test.ts
+++ b/src/commands/doctor-plugin-manifests.test.ts
@@ -1,25 +1,21 @@
 // Doctor plugin manifest tests cover manifest validation, missing installs, and repair guidance.
 import fs from "node:fs";
 import path from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { cleanupTrackedTempDirs } from "../plugins/test-helpers/fs-fixtures.js";
 import type { RuntimeEnv } from "../runtime.js";
+import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
 import {
   collectLegacyPluginManifestContractMigrations,
   maybeRepairLegacyPluginManifestContracts,
 } from "./doctor-plugin-manifests.js";
 import type { DoctorPrompter } from "./doctor-prompter.js";
 
-const tempDirs: string[] = [];
-
-function makeTrustedBundledPluginsDir() {
-  const fixturesRoot = path.join(process.cwd(), "dist", "extensions");
-  fs.mkdirSync(fixturesRoot, { recursive: true });
-  const dir = fs.mkdtempSync(path.join(fixturesRoot, "openclaw-doctor-plugin-manifests-"));
-  tempDirs.push(dir);
-  return dir;
-}
+const fixturesRoot = path.join(process.cwd(), "dist", "extensions");
+const suiteTempDirs = createSuiteTempRootTracker({
+  prefix: "openclaw-doctor-plugin-manifests-",
+  parentDir: fixturesRoot,
+});
 
 function configWithPluginLoadPath(pluginRoot: string): OpenClawConfig {
   return {
@@ -86,13 +82,21 @@ function createPrompter(overrides: Partial<DoctorPrompter> = {}): DoctorPrompter
 }
 
 describe("doctor plugin manifest legacy contract repair", () => {
+  beforeAll(async () => {
+    fs.mkdirSync(fixturesRoot, { recursive: true });
+    await suiteTempDirs.setup();
+  });
+
+  afterAll(async () => {
+    await suiteTempDirs.cleanup();
+  });
+
   afterEach(() => {
-    cleanupTrackedTempDirs(tempDirs);
     vi.restoreAllMocks();
   });
 
-  it("collects legacy top-level capability keys for migration", () => {
-    const pluginsRoot = makeTrustedBundledPluginsDir();
+  it("collects legacy top-level capability keys for migration", async () => {
+    const pluginsRoot = await suiteTempDirs.make("legacy-capability");
     const root = path.join(pluginsRoot, "openai");
     fs.mkdirSync(root, { recursive: true });
     writePackageJson(root);
@@ -129,8 +133,8 @@ describe("doctor plugin manifest legacy contract repair", () => {
     ]);
   });
 
-  it("collects legacy top-level plugin tool keys for migration", () => {
-    const pluginsRoot = makeTrustedBundledPluginsDir();
+  it("collects legacy top-level plugin tool keys for migration", async () => {
+    const pluginsRoot = await suiteTempDirs.make("legacy-tool");
     const root = path.join(pluginsRoot, "cortex");
     fs.mkdirSync(root, { recursive: true });
     writePackageJson(root);
@@ -166,7 +170,7 @@ describe("doctor plugin manifest legacy contract repair", () => {
   });
 
   it("rewrites legacy top-level capability keys into contracts", async () => {
-    const pluginsRoot = makeTrustedBundledPluginsDir();
+    const pluginsRoot = await suiteTempDirs.make("rewrite-capability");
     const root = path.join(pluginsRoot, "openai");
     fs.mkdirSync(root, { recursive: true });
     writePackageJson(root);
@@ -207,7 +211,7 @@ describe("doctor plugin manifest legacy contract repair", () => {
   });
 
   it("removes duplicate legacy top-level plugin tools while keeping contracts.tools", async () => {
-    const pluginsRoot = makeTrustedBundledPluginsDir();
+    const pluginsRoot = await suiteTempDirs.make("dedupe-tool");
     const root = path.join(pluginsRoot, "cortex");
     fs.mkdirSync(root, { recursive: true });
     writePackageJson(root);
@@ -241,8 +245,8 @@ describe("doctor plugin manifest legacy contract repair", () => {
     });
   });
 
-  it("ignores non-object contracts payloads when collecting migrations", () => {
-    const pluginsRoot = makeTrustedBundledPluginsDir();
+  it("ignores non-object contracts payloads when collecting migrations", async () => {
+    const pluginsRoot = await suiteTempDirs.make("non-object-contracts");
     const root = path.join(pluginsRoot, "openai");
     fs.mkdirSync(root, { recursive: true });
     writePackageJson(root);

--- a/src/commands/doctor-security.test.ts
+++ b/src/commands/doctor-security.test.ts
@@ -1,9 +1,9 @@
 // Doctor security tests cover security audit checks, config findings, and repair output.
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import { withTempDir } from "../test-helpers/temp-dir.js";
 
 const note = vi.hoisted(() => vi.fn());
 const pluginRegistry = vi.hoisted(() => ({ list: [] as unknown[] }));
@@ -72,14 +72,15 @@ describe("noteSecurityWarnings gateway exposure", () => {
     file: Record<string, unknown>,
     run: () => Promise<void>,
   ): Promise<void> {
-    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-doctor-security-"));
-    process.env.HOME = home;
-    await fs.mkdir(path.join(home, ".openclaw"), { recursive: true });
-    await fs.writeFile(
-      path.join(home, ".openclaw", "exec-approvals.json"),
-      JSON.stringify(file, null, 2),
-    );
-    await run();
+    await withTempDir({ prefix: "openclaw-doctor-security-" }, async (home) => {
+      process.env.HOME = home;
+      await fs.mkdir(path.join(home, ".openclaw"), { recursive: true });
+      await fs.writeFile(
+        path.join(home, ".openclaw", "exec-approvals.json"),
+        JSON.stringify(file, null, 2),
+      );
+      await run();
+    });
   }
 
   async function expectAgentExecHostPolicyWarning(agentKey: "*" | "runner") {

--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -2463,6 +2463,207 @@ describe("legacy model compat migrate", () => {
     ]);
   });
 
+  it("deep-merges colliding retired model refs and reports only unequal fields", () => {
+    const res = migrateLegacyConfigForTest({
+      agents: {
+        defaults: {
+          models: {
+            "openai/gpt-4o": {
+              params: {
+                reasoning: { effort: "high", budget: 100 },
+                tags: ["stable"],
+              },
+              streaming: false,
+            },
+            "openai/gpt-4": {
+              params: {
+                reasoning: { effort: "low", summary: "auto" },
+                tags: ["stable"],
+              },
+              alias: "legacy-four",
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.config?.agents?.defaults?.models).toEqual({
+      "openai/gpt-5.5": {
+        params: {
+          reasoning: { effort: "high", budget: 100, summary: "auto" },
+          tags: ["stable"],
+        },
+        streaming: false,
+        alias: "legacy-four",
+      },
+    });
+    expect(res.changes.filter((change) => change.includes("Merged"))).toEqual([
+      'Merged config.agents.defaults.models key "openai/gpt-4" into "openai/gpt-5.5"; kept existing values for conflicting fields: params.reasoning.effort.',
+    ]);
+  });
+
+  it("does not report conflicts between model refs that normalize to the same value", () => {
+    const res = migrateLegacyConfigForTest({
+      agents: {
+        defaults: {
+          models: {
+            "openai/gpt-5.5": { params: { fallbacks: ["openai/gpt-4"] } },
+            "openai/gpt-4o": { params: { fallbacks: ["openai/gpt-5.5"] } },
+          },
+        },
+      },
+    });
+
+    expect(res.config?.agents?.defaults?.models).toEqual({
+      "openai/gpt-5.5": { params: { fallbacks: ["openai/gpt-5.5"] } },
+    });
+    expect(res.changes.filter((change) => change.includes("Merged"))).toEqual([
+      'Merged config.agents.defaults.models key "openai/gpt-4o" into "openai/gpt-5.5".',
+    ]);
+  });
+
+  it.each(["first", "last"] as const)(
+    "keeps canonical values when the canonical key appears %s",
+    (canonicalPosition) => {
+      const canonical = [
+        "openai/gpt-5.5",
+        {
+          alias: "canonical-five",
+          params: { reasoning: { effort: "medium", canonicalOnly: true } },
+          agentRuntime: { id: "codex" },
+        },
+      ] as const;
+      const retired = [
+        [
+          "openai/gpt-4",
+          {
+            alias: "legacy-four",
+            params: { reasoning: { effort: "low", fourOnly: true } },
+          },
+        ],
+        [
+          "openai/gpt-4o",
+          {
+            streaming: false,
+            params: { reasoning: { effort: "high", fourOOnly: true } },
+          },
+        ],
+      ] as const;
+      const entries =
+        canonicalPosition === "first" ? [canonical, ...retired] : [...retired, canonical];
+      const res = migrateLegacyConfigForTest({
+        agents: { defaults: { models: Object.fromEntries(entries) } },
+      });
+
+      expect(res.config?.agents?.defaults?.models).toEqual({
+        "openai/gpt-5.5": {
+          alias: "canonical-five",
+          params: {
+            reasoning: {
+              effort: "medium",
+              canonicalOnly: true,
+              fourOnly: true,
+              fourOOnly: true,
+            },
+          },
+          agentRuntime: { id: "codex" },
+          streaming: false,
+        },
+      });
+      expect(res.changes.filter((change) => change.includes("Merged"))).toEqual([
+        'Merged config.agents.defaults.models key "openai/gpt-4" into "openai/gpt-5.5"; kept existing values for conflicting fields: alias, params.reasoning.effort.',
+        'Merged config.agents.defaults.models key "openai/gpt-4o" into "openai/gpt-5.5"; kept existing values for conflicting fields: params.reasoning.effort.',
+      ]);
+    },
+  );
+
+  it("merges colliding model refs in per-agent model maps", () => {
+    const res = migrateLegacyConfigForTest({
+      agents: {
+        list: [
+          {
+            id: "research",
+            models: {
+              "openai/gpt-4": { alias: "legacy-four" },
+              "openai/gpt-4o": { streaming: false },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(res.config?.agents?.list?.[0]?.models).toEqual({
+      "openai/gpt-5.5": { alias: "legacy-four", streaming: false },
+    });
+    expect(res.changes.filter((change) => change.includes("Merged"))).toEqual([
+      'Merged config.agents.list.0.models key "openai/gpt-4o" into "openai/gpt-5.5".',
+    ]);
+  });
+
+  it.each([
+    {
+      side: "canonical",
+      raw: '{"agents":{"defaults":{"models":{"openai/gpt-5.5":{"__proto__":{"polluted":true},"alias":"canonical-five","params":{"nested":{"__proto__":{"polluted":true},"model":"openai/gpt-4o"}}},"openai/gpt-4":{"streaming":false}}}}}',
+    },
+    {
+      side: "retired",
+      raw: '{"agents":{"defaults":{"models":{"openai/gpt-5.5":{"alias":"canonical-five"},"openai/gpt-4":{"__proto__":{"polluted":true},"streaming":false,"params":{"nested":{"__proto__":{"polluted":true},"model":"openai/gpt-4o"}}}}}}}',
+    },
+  ])("filters blocked keys recursively from the $side collision side", ({ raw }) => {
+    const res = migrateLegacyConfigForTest(JSON.parse(raw));
+    const merged = res.config?.agents?.defaults?.models?.["openai/gpt-5.5"] as Record<
+      string,
+      unknown
+    >;
+    const params = merged.params as Record<string, unknown>;
+    const nested = params.nested as Record<string, unknown>;
+
+    for (const record of [merged, params, nested]) {
+      expect(Object.getOwnPropertyNames(record)).not.toContain("__proto__");
+      expect(Object.getPrototypeOf(record)).toBe(Object.prototype);
+      expect(record.polluted).toBeUndefined();
+    }
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    expect(merged).toEqual({
+      alias: "canonical-five",
+      params: { nested: { model: "openai/gpt-5.5" } },
+      streaming: false,
+    });
+  });
+
+  it("does not invoke prototype setters when copying the rewritten config root", () => {
+    const raw = JSON.parse(
+      '{"__proto__":{"polluted":true},"agents":{"defaults":{"model":"openai/gpt-4"}}}',
+    ) as Record<string, unknown>;
+    const res = migrateLegacyConfigForTest(raw);
+    const config = res.config as unknown as Record<string, unknown>;
+
+    expect(Object.getPrototypeOf(config)).toBe(Object.prototype);
+    expect(Object.hasOwn(config, "__proto__")).toBe(true);
+    expect(config.polluted).toBeUndefined();
+    expect(res.config?.agents?.defaults?.model).toBe("openai/gpt-5.5");
+  });
+
+  it("reports malformed scalar collisions without claiming equal values conflict", () => {
+    const res = migrateLegacyConfigForTest({
+      agents: {
+        defaults: {
+          models: {
+            "openai/gpt-5.5": false,
+            "openai/gpt-4": true,
+            "openai/gpt-4o": false,
+          },
+        },
+      },
+    });
+
+    expect(res.config?.agents?.defaults?.models?.["openai/gpt-5.5"]).toBe(false);
+    expect(res.changes.filter((change) => change.includes("Merged"))).toEqual([
+      'Merged config.agents.defaults.models key "openai/gpt-4" into "openai/gpt-5.5"; kept existing values for conflicting fields: value.',
+      'Merged config.agents.defaults.models key "openai/gpt-4o" into "openai/gpt-5.5".',
+    ]);
+  });
+
   it("removes unrecognized model compat thinkingFormat values", () => {
     const res = migrateLegacyConfigForTest({
       models: {

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.models.ts
@@ -1,4 +1,5 @@
 // Legacy model runtime config migrations for stale model refs, compat fields, and catalog data.
+import { isDeepStrictEqual } from "node:util";
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { splitTrailingAuthProfile } from "../../../agents/model-ref-profile.js";
 import {
@@ -9,6 +10,7 @@ import {
   type LegacyConfigRule,
 } from "../../../config/legacy.shared.js";
 import { isModelThinkingFormat, type ModelDefinitionConfig } from "../../../config/types.models.js";
+import { isBlockedObjectKey } from "../../../infra/prototype-keys.js";
 import { isLegacyModelsAddCodexMetadataModel } from "./legacy-models-add-metadata.js";
 
 const STALE_CONTEXT_WINDOW_FIXES: Record<string, { stale: number; correct: number }> = {
@@ -847,6 +849,86 @@ function rewriteModelRefString(value: string, path: string, changes: string[]): 
   return upgraded;
 }
 
+function setRecordEntry(record: Record<string, unknown>, key: string, value: unknown): void {
+  // Config dictionaries can contain hostile keys; define own properties so
+  // rebuilding or copying them never invokes Object.prototype setters.
+  Object.defineProperty(record, key, {
+    configurable: true,
+    enumerable: true,
+    value,
+    writable: true,
+  });
+}
+
+function sanitizeModelRefMapEntry(value: unknown): unknown {
+  // Collisions combine both entries before recursive ref rewriting, so blocked
+  // keys must be removed at every depth on both sides of the merge.
+  if (Array.isArray(value)) {
+    return value.map(sanitizeModelRefMapEntry);
+  }
+  const record = getRecord(value);
+  if (!record) {
+    return value;
+  }
+  const sanitized: Record<string, unknown> = {};
+  for (const [field, child] of Object.entries(record)) {
+    if (!isBlockedObjectKey(field)) {
+      setRecordEntry(sanitized, field, sanitizeModelRefMapEntry(child));
+    }
+  }
+  return sanitized;
+}
+
+function modelRefValuesAreEqual(existing: unknown, incoming: unknown, path: string): boolean {
+  if (isDeepStrictEqual(existing, incoming)) {
+    return true;
+  }
+  const normalizedExisting = rewriteKnownModelRefs(existing, path, []).value;
+  const normalizedIncoming = rewriteKnownModelRefs(incoming, path, []).value;
+  return isDeepStrictEqual(normalizedExisting, normalizedIncoming);
+}
+
+function mergeModelRefMapEntries(
+  existing: unknown,
+  incoming: unknown,
+  path: string,
+): { value: unknown; conflicts: string[] } {
+  const existingRecord = getRecord(existing);
+  const incomingRecord = getRecord(incoming);
+  if (!existingRecord || !incomingRecord) {
+    return {
+      value: sanitizeModelRefMapEntry(existing),
+      conflicts: modelRefValuesAreEqual(existing, incoming, path) ? [] : ["value"],
+    };
+  }
+  const merged = sanitizeModelRefMapEntry(existingRecord) as Record<string, unknown>;
+  const conflicts: string[] = [];
+  for (const [field, incomingValue] of Object.entries(incomingRecord)) {
+    if (incomingValue === undefined || isBlockedObjectKey(field)) {
+      continue;
+    }
+    if (!hasOwnDefinedProperty(existingRecord, field)) {
+      setRecordEntry(merged, field, sanitizeModelRefMapEntry(incomingValue));
+      continue;
+    }
+    const existingValue = existingRecord[field];
+    const fieldPath = `${path}.${field}`;
+    if (modelRefValuesAreEqual(existingValue, incomingValue, fieldPath)) {
+      continue;
+    }
+    const existingField = getRecord(existingValue);
+    const incomingField = getRecord(incomingValue);
+    if (existingField && incomingField) {
+      const nested = mergeModelRefMapEntries(existingField, incomingField, fieldPath);
+      setRecordEntry(merged, field, nested.value);
+      conflicts.push(...nested.conflicts.map((c) => `${field}.${c}`));
+      continue;
+    }
+    conflicts.push(field);
+  }
+  return { value: merged, conflicts };
+}
+
 function rewriteModelRefMapKeys(
   record: Record<string, unknown>,
   path: string,
@@ -854,19 +936,40 @@ function rewriteModelRefMapKeys(
 ): { value: Record<string, unknown>; changed: boolean } {
   let changed = false;
   const next: Record<string, unknown> = {};
+  const consumedCanonicalKeys = new Set<string>();
   for (const [key, child] of Object.entries(record)) {
     const upgradedKey = upgradeRetiredModelRef(key);
     const nextKey = upgradedKey ?? key;
+    if (!upgradedKey && consumedCanonicalKeys.has(key)) {
+      continue;
+    }
     if (upgradedKey) {
       changes.push(
         `Upgraded ${path} key from ${JSON.stringify(key)} to ${JSON.stringify(upgradedKey)}.`,
       );
       changed = true;
     }
-    if (nextKey in next && upgradedKey) {
+    if (upgradedKey && !Object.hasOwn(next, nextKey) && Object.hasOwn(record, nextKey)) {
+      // Seed the canonical entry before its retired aliases so canonical conflict
+      // precedence and per-alias change reporting do not depend on authored key order.
+      setRecordEntry(next, nextKey, record[nextKey]);
+      consumedCanonicalKeys.add(nextKey);
+    }
+    if (Object.hasOwn(next, nextKey)) {
+      const existing = next[nextKey];
+      const { value, conflicts } = mergeModelRefMapEntries(existing, child, `${path}.${nextKey}`);
+      setRecordEntry(next, nextKey, value);
+      const sortedConflicts = conflicts.toSorted();
+      if (sortedConflicts.length > 0) {
+        changes.push(
+          `Merged ${path} key ${JSON.stringify(key)} into ${JSON.stringify(nextKey)}; kept existing values for conflicting fields: ${sortedConflicts.join(", ")}.`,
+        );
+      } else {
+        changes.push(`Merged ${path} key ${JSON.stringify(key)} into ${JSON.stringify(nextKey)}.`);
+      }
       continue;
     }
-    next[nextKey] = child;
+    setRecordEntry(next, nextKey, child);
   }
   return { value: changed ? next : record, changed };
 }
@@ -915,7 +1018,7 @@ function rewriteKnownModelRefs(
   for (const [childKey, child] of Object.entries(working)) {
     const rewritten = rewriteKnownModelRefs(child, `${path}.${childKey}`, changes);
     changed ||= rewritten.changed;
-    next[childKey] = rewritten.value;
+    setRecordEntry(next, childKey, rewritten.value);
   }
   return { value: changed ? next : value, changed };
 }
@@ -1333,13 +1436,16 @@ export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_MODELS: LegacyConfigMigrationSpec[
     legacyRules: RETIRED_MODEL_REF_RULES,
     apply: (raw, changes) => {
       const rewritten = rewriteKnownModelRefs(raw, "config", changes);
-      if (!rewritten.changed || !getRecord(rewritten.value)) {
+      const rewrittenRecord = getRecord(rewritten.value);
+      if (!rewritten.changed || !rewrittenRecord) {
         return;
       }
       for (const key of Object.keys(raw)) {
         delete raw[key];
       }
-      Object.assign(raw, rewritten.value);
+      for (const [key, value] of Object.entries(rewrittenRecord)) {
+        setRecordEntry(raw, key, value);
+      }
     },
   }),
   defineLegacyConfigMigration({

--- a/src/commands/migrate/apply.test.ts
+++ b/src/commands/migrate/apply.test.ts
@@ -1,13 +1,12 @@
 // Migration apply tests cover backups, filtering, provider apply calls, and report output.
-import { mkdtempSync } from "node:fs";
-import { tmpdir } from "node:os";
-import path from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import type { MigrationPlan, MigrationProviderPlugin } from "../../plugins/types.js";
 import { createNonExitingRuntime } from "../../runtime.js";
+import { createSuiteTempRootTracker } from "../../test-helpers/temp-dir.js";
 import { runMigrationApply } from "./apply.js";
 
-const stateDir = mkdtempSync(path.join(tmpdir(), "openclaw-migrate-apply-"));
+let stateDir = "";
+const suiteTempDirs = createSuiteTempRootTracker({ prefix: "openclaw-migrate-apply-" });
 
 vi.mock("../../config/paths.js", async (importActual) => {
   const actual = await importActual<typeof import("../../config/paths.js")>();
@@ -36,6 +35,14 @@ function buildEmptyPlan(): MigrationPlan {
 }
 
 describe("runMigrationApply", () => {
+  beforeAll(async () => {
+    stateDir = await suiteTempDirs.setup();
+  });
+
+  afterAll(async () => {
+    await suiteTempDirs.cleanup();
+  });
+
   it("uses the resolved provider id when forwarding Codex options", async () => {
     const plan = vi.fn(async () => buildEmptyPlan());
     const apply = vi.fn(async () => buildEmptyPlan());

--- a/src/cron/normalize.test.ts
+++ b/src/cron/normalize.test.ts
@@ -154,6 +154,20 @@ describe("normalizeCronJobCreate", () => {
     expect(normalized.payload?.model).toBeNull();
   });
 
+  it("preserves explicit null thinking clear in payload patches", () => {
+    const normalized = normalizeCronJobPatch({
+      payload: {
+        kind: "agentTurn",
+        thinking: null,
+      },
+    }) as unknown as Record<string, unknown>;
+
+    const payload = normalized.payload as Record<string, unknown>;
+    expect(payload.kind).toBe("agentTurn");
+    expect(payload.thinking).toBeNull();
+    expect(validateCronUpdateParams({ id: "job-1", patch: normalized })).toBe(true);
+  });
+
   it("coerces ISO schedule.at to normalized ISO (UTC)", () => {
     expectNormalizedAtSchedule({ kind: "at", at: "2026-01-12T18:00:00" });
   });

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -194,11 +194,17 @@ function coercePayload(payload: UnknownRecord) {
     }
   }
   if ("thinking" in next) {
-    const thinking = parseOptionalField(TrimmedNonEmptyStringFieldSchema, next.thinking);
-    if (thinking !== undefined) {
-      next.thinking = thinking;
+    // Preserve an explicit null so patches can clear a stored thinking override,
+    // matching the model/fallbacks/toolsAllow clear paths.
+    if (next.thinking === null) {
+      next.thinking = null;
     } else {
-      delete next.thinking;
+      const thinking = parseOptionalField(TrimmedNonEmptyStringFieldSchema, next.thinking);
+      if (thinking !== undefined) {
+        next.thinking = thinking;
+      } else {
+        delete next.thinking;
+      }
     }
   }
   if ("timeoutSeconds" in next) {

--- a/src/cron/service.jobs.test.ts
+++ b/src/cron/service.jobs.test.ts
@@ -520,6 +520,75 @@ describe("applyJobPatch", () => {
     }
   });
 
+  it("persists agentTurn payload.thinking updates when editing existing jobs", () => {
+    const job = createIsolatedAgentTurnJob("job-thinking", {
+      mode: "announce",
+      channel: "telegram",
+    });
+    job.payload = {
+      kind: "agentTurn",
+      message: "do it",
+      thinking: "high",
+    };
+
+    applyJobPatch(job, {
+      payload: {
+        kind: "agentTurn",
+        message: "do it",
+        thinking: "low",
+      },
+    });
+
+    expect(job.payload.kind).toBe("agentTurn");
+    if (job.payload.kind === "agentTurn") {
+      expect(job.payload.thinking).toBe("low");
+    }
+  });
+
+  it("clears agentTurn payload.thinking when patch requests null", () => {
+    const job = createIsolatedAgentTurnJob("job-thinking-clear", {
+      mode: "announce",
+      channel: "telegram",
+    });
+    job.payload = {
+      kind: "agentTurn",
+      message: "do it",
+      thinking: "high",
+    };
+
+    applyJobPatch(job, {
+      payload: {
+        kind: "agentTurn",
+        thinking: null,
+      },
+    });
+
+    expect(job.payload.kind).toBe("agentTurn");
+    if (job.payload.kind === "agentTurn") {
+      expect(job.payload.message).toBe("do it");
+      expect(job.payload.thinking).toBeUndefined();
+    }
+  });
+
+  it("omits null thinking when patch builds a replacement agentTurn payload", () => {
+    const job = createMainSystemEventJob("job-thinking-replace", { mode: "none" });
+
+    applyJobPatch(job, {
+      sessionTarget: "isolated",
+      payload: {
+        kind: "agentTurn",
+        message: "do it",
+        thinking: null,
+      },
+    });
+
+    expect(job.payload.kind).toBe("agentTurn");
+    if (job.payload.kind === "agentTurn") {
+      expect(job.payload.message).toBe("do it");
+      expect(job.payload.thinking).toBeUndefined();
+    }
+  });
+
   it("applies payload.lightContext when replacing payload kind via patch", () => {
     const job = createIsolatedAgentTurnJob("job-light-context-switch", {
       mode: "announce",

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -1005,6 +1005,8 @@ function mergeCronPayload(existing: CronPayload, patch: CronPayloadPatch): CronP
   applyAgentTurnToolsAllowPatch(next, patch, existing);
   if (typeof patch.thinking === "string") {
     next.thinking = patch.thinking;
+  } else if (patch.thinking === null) {
+    delete next.thinking;
   }
   if (typeof patch.timeoutSeconds === "number") {
     next.timeoutSeconds = patch.timeoutSeconds;
@@ -1051,7 +1053,7 @@ function buildPayloadFromPatch(patch: CronPayloadPatch): CronPayload {
     message: patch.message,
     model: typeof patch.model === "string" ? patch.model : undefined,
     fallbacks: Array.isArray(patch.fallbacks) ? patch.fallbacks : undefined,
-    thinking: patch.thinking,
+    thinking: typeof patch.thinking === "string" ? patch.thinking : undefined,
     timeoutSeconds: patch.timeoutSeconds,
     lightContext: patch.lightContext,
     allowUnsafeExternalContent: patch.allowUnsafeExternalContent,

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -258,10 +258,11 @@ type CronAgentTurnPayload = {
 
 type CronAgentTurnPayloadPatch = {
   kind: "agentTurn";
-} & Partial<Omit<CronAgentTurnPayloadFields, "model" | "fallbacks" | "toolsAllow">> & {
+} & Partial<Omit<CronAgentTurnPayloadFields, "model" | "fallbacks" | "toolsAllow" | "thinking">> & {
     model?: string | null;
     fallbacks?: string[] | null;
     toolsAllow?: string[] | null;
+    thinking?: string | null;
   };
 
 type CronCommandPayloadFields = {

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -21,6 +21,7 @@ const mocks = vi.hoisted(() => ({
   maybeRepairGatewayDaemon: vi.fn().mockResolvedValue(undefined),
   maybeRepairLegacyOAuthProfileIds: vi.fn(async (cfg: unknown) => cfg),
   maybeRepairLegacyOAuthSidecarProfiles: vi.fn().mockResolvedValue(undefined),
+  collectAuthProfileHealthFindings: vi.fn(async () => []),
   noteAuthProfileHealth: vi.fn().mockResolvedValue(undefined),
   noteLegacyCodexProviderOverride: vi.fn(),
   buildGatewayConnectionDetails: vi.fn(() => ({ message: "gateway details" })),
@@ -145,6 +146,7 @@ vi.mock("../commands/doctor-auth-oauth-sidecar.js", () => ({
 }));
 
 vi.mock("../commands/doctor-auth.js", () => ({
+  collectAuthProfileHealthFindings: mocks.collectAuthProfileHealthFindings,
   noteAuthProfileHealth: mocks.noteAuthProfileHealth,
   noteLegacyCodexProviderOverride: mocks.noteLegacyCodexProviderOverride,
 }));
@@ -327,6 +329,8 @@ describe("doctor health contributions", () => {
     mocks.maybeRepairLegacyOAuthProfileIds.mockImplementation(async (cfg: unknown) => cfg);
     mocks.maybeRepairLegacyOAuthSidecarProfiles.mockClear();
     mocks.maybeRepairLegacyOAuthSidecarProfiles.mockResolvedValue(undefined);
+    mocks.collectAuthProfileHealthFindings.mockClear();
+    mocks.collectAuthProfileHealthFindings.mockResolvedValue([]);
     mocks.noteAuthProfileHealth.mockClear();
     mocks.noteAuthProfileHealth.mockResolvedValue(undefined);
     mocks.noteLegacyCodexProviderOverride.mockClear();
@@ -1004,6 +1008,32 @@ describe("doctor health contributions", () => {
     expect(mocks.maybeRepairCanonicalApiKeyFieldAlias).toHaveBeenCalledWith({
       cfg: ctx.cfg,
       prompter: ctx.prompter,
+    });
+  });
+
+  it("registers auth profile health as an opt-in structured check", async () => {
+    const contribution = requireDoctorContribution("doctor:auth-profiles");
+    const [check] = contribution.healthChecks;
+
+    expect(contribution.healthCheckIds).toEqual(["core/doctor/auth-profiles"]);
+    expect(check).toMatchObject({
+      id: "core/doctor/auth-profiles",
+      kind: "core",
+      defaultEnabled: false,
+    });
+    if (!check || !("detect" in check)) {
+      throw new Error("expected split auth profile health check");
+    }
+
+    await check.detect({
+      mode: "lint",
+      cfg: { auth: { profiles: {} } },
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+    });
+
+    expect(mocks.collectAuthProfileHealthFindings).toHaveBeenCalledWith({
+      cfg: { auth: { profiles: {} } },
+      allowKeychainPrompt: false,
     });
   });
 

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -1222,6 +1222,19 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
     createDoctorHealthContribution({
       id: "doctor:auth-profiles",
       label: "Auth profiles",
+      healthChecks: {
+        id: "core/doctor/auth-profiles",
+        kind: "core",
+        description: "Auth profile cooldown, expiry, missing credential, and legacy override state",
+        defaultEnabled: false,
+        async detect(ctx) {
+          const { collectAuthProfileHealthFindings } = await import("../commands/doctor-auth.js");
+          return collectAuthProfileHealthFindings({
+            cfg: ctx.cfg,
+            allowKeychainPrompt: false,
+          });
+        },
+      },
       run: runAuthProfileHealth,
     }),
     createDoctorHealthContribution({

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -4401,6 +4401,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       content: "bench update",
       timestamp: expect.any(Number),
       idempotencyKey: "idem-system-provenance-acp:user",
+      __openclaw: { senderIsOwner: true },
       provenance: {
         ...provenance,
         sourceSessionKey: undefined,

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1320,7 +1320,7 @@ function isAcpBridgeClient(client: GatewayRequestHandlerOptions["client"]): bool
   );
 }
 
-function canInjectSystemProvenance(client: GatewayRequestHandlerOptions["client"]): boolean {
+function hasGatewayAdminScope(client: GatewayRequestHandlerOptions["client"]): boolean {
   const scopes = Array.isArray(client?.connect?.scopes) ? client.connect.scopes : [];
   return scopes.includes(ADMIN_SCOPE);
 }
@@ -3437,7 +3437,7 @@ export const chatHandlers: GatewayRequestHandlers = {
         p.systemProvenanceReceipt ||
         suppressCommandInterpretation ||
         explicitOriginResult.value) &&
-      !canInjectSystemProvenance(client)
+      !hasGatewayAdminScope(client)
     ) {
       respond(
         false,
@@ -3884,6 +3884,7 @@ export const chatHandlers: GatewayRequestHandlers = {
         text: rawMessage,
         timestamp: now,
         idempotencyKey: `${clientRunId}:user`,
+        ...(hasGatewayAdminScope(client) ? { senderIsOwner: true } : {}),
         ...(systemInputProvenance ? { provenance: systemInputProvenance } : {}),
       };
       const userTurnInputPromise: Promise<UserTurnInput> = userTurnMediaPromise.then((media) => ({

--- a/src/gateway/server-session-events.test.ts
+++ b/src/gateway/server-session-events.test.ts
@@ -100,4 +100,16 @@ describe("createTranscriptUpdateBroadcastHandler", () => {
       },
     });
   });
+
+  it("broadcasts the authenticated sender ownership decision", async () => {
+    await expect(
+      emitAssistantTranscriptUpdate(false, {
+        role: "user",
+        content: [{ type: "text", text: "Owner turn" }],
+        __openclaw: { senderIsOwner: true },
+      }),
+    ).resolves.toMatchObject({
+      senderIsOwner: true,
+    });
+  });
 });

--- a/src/gateway/server-session-events.ts
+++ b/src/gateway/server-session-events.ts
@@ -38,6 +38,18 @@ function readMessageIdempotencyKey(message: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value : undefined;
 }
 
+function readMessageSenderIsOwner(message: unknown): boolean | undefined {
+  if (!message || typeof message !== "object" || Array.isArray(message)) {
+    return undefined;
+  }
+  const openclaw = (message as Record<string, unknown>)["__openclaw"];
+  if (!openclaw || typeof openclaw !== "object" || Array.isArray(openclaw)) {
+    return undefined;
+  }
+  const value = (openclaw as Record<string, unknown>).senderIsOwner;
+  return typeof value === "boolean" ? value : undefined;
+}
+
 function resolveSessionMessageBroadcastKeys(sessionKey: string, agentId?: string): string[] {
   // Global sessions can be subscribed through either the raw global key or the
   // default-agent scoped key; non-default agent global sessions stay scoped.
@@ -182,6 +194,7 @@ async function handleTranscriptUpdateBroadcast(
     hasActiveRun,
   });
   const idempotencyKey = readMessageIdempotencyKey(update.message);
+  const senderIsOwner = readMessageSenderIsOwner(update.message);
   const rawMessage = attachOpenClawTranscriptMeta(update.message, {
     ...(typeof update.messageId === "string" ? { id: update.messageId } : {}),
     ...(idempotencyKey ? { idempotencyKey } : {}),
@@ -193,6 +206,7 @@ async function handleTranscriptUpdateBroadcast(
       "session.message",
       {
         sessionKey,
+        ...(senderIsOwner === undefined ? {} : { senderIsOwner }),
         ...(visibleAgentId ? { agentId: visibleAgentId } : {}),
         message,
         ...(typeof update.messageId === "string" ? { messageId: update.messageId } : {}),

--- a/src/gateway/server-startup-log.test.ts
+++ b/src/gateway/server-startup-log.test.ts
@@ -1,10 +1,28 @@
 // Startup log tests cover security warnings, model detail formatting, plugin
 // summaries, bind URLs, ANSI output, and dangerous config reporting.
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { stripAnsi } from "../../packages/terminal-core/src/ansi.js";
 import { formatAgentModelStartupDetails, logGatewayStartup } from "./server-startup-log.js";
 
+const pluginRegistryMocks = vi.hoisted(() => ({
+  loadPluginManifestRegistryForPluginRegistry: vi.fn(),
+}));
+
+vi.mock("../plugins/plugin-registry.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../plugins/plugin-registry.js")>()),
+  loadPluginManifestRegistryForPluginRegistry:
+    pluginRegistryMocks.loadPluginManifestRegistryForPluginRegistry,
+}));
+
 describe("gateway startup log", () => {
+  beforeEach(() => {
+    pluginRegistryMocks.loadPluginManifestRegistryForPluginRegistry.mockReset();
+    pluginRegistryMocks.loadPluginManifestRegistryForPluginRegistry.mockReturnValue({
+      plugins: [],
+      diagnostics: [],
+    });
+  });
+
   afterEach(() => {
     vi.useRealTimers();
   });
@@ -41,6 +59,150 @@ describe("gateway startup log", () => {
 
     await logGatewayStartup({
       cfg: {},
+      bindHost: "127.0.0.1",
+      loadedPluginIds: [],
+      port: 18789,
+      log: { info, warn },
+      isNixMode: false,
+    });
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("warns when a configured channel plugin is blocked from startup", async () => {
+    pluginRegistryMocks.loadPluginManifestRegistryForPluginRegistry.mockReturnValue({
+      plugins: [
+        {
+          id: "slack",
+          origin: "global",
+          channels: ["slack"],
+          enabledByDefault: false,
+        },
+      ],
+      diagnostics: [],
+    });
+    const info = vi.fn();
+    const warn = vi.fn();
+
+    await logGatewayStartup({
+      cfg: {
+        channels: {
+          slack: {
+            enabled: true,
+            botToken: "configured",
+          },
+        },
+      },
+      bindHost: "127.0.0.1",
+      loadedPluginIds: [],
+      port: 18789,
+      log: { info, warn },
+      isNixMode: false,
+    });
+
+    expect(warn.mock.calls).toEqual([
+      [
+        'configured channel warning: channels.slack: channel is configured, but external plugin "slack" is installed without explicit trust. Add plugins.entries.slack.enabled=true. Fix plugin enablement before relying on setup guidance for this channel.',
+      ],
+    ]);
+  });
+
+  it("warns when a configured channel has no owning plugin", async () => {
+    const info = vi.fn();
+    const warn = vi.fn();
+
+    await logGatewayStartup({
+      cfg: {
+        channels: {
+          "missing-chat": {
+            enabled: true,
+            token: "configured",
+          },
+        },
+      },
+      bindHost: "127.0.0.1",
+      loadedPluginIds: [],
+      port: 18789,
+      log: { info, warn },
+      isNixMode: false,
+    });
+
+    expect(warn.mock.calls).toEqual([
+      [
+        "configured channel warning: channels.missing-chat is configured but no channel plugin is installed or loadable (no-channel-owner). Run `openclaw doctor --fix` or install the channel plugin before relying on this channel.",
+      ],
+    ]);
+  });
+
+  it("sanitizes configured channel ids in startup warnings", async () => {
+    const unsafeChannelId = `slack${String.fromCharCode(0x1b)}[31m`;
+    pluginRegistryMocks.loadPluginManifestRegistryForPluginRegistry.mockReturnValue({
+      plugins: [
+        {
+          id: "slack",
+          origin: "global",
+          channels: [unsafeChannelId],
+          enabledByDefault: false,
+        },
+      ],
+      diagnostics: [],
+    });
+    const info = vi.fn();
+    const warn = vi.fn();
+
+    await logGatewayStartup({
+      cfg: {
+        channels: {
+          [unsafeChannelId]: {
+            enabled: true,
+            botToken: "configured",
+          },
+        },
+      },
+      bindHost: "127.0.0.1",
+      loadedPluginIds: [],
+      port: 18789,
+      log: { info, warn },
+      isNixMode: false,
+    });
+
+    expect(warn.mock.calls[0]?.[0]).toContain("channels.slack: channel is configured");
+    expect(warn.mock.calls[0]?.[0]).not.toContain(String.fromCharCode(0x1b));
+  });
+
+  it("does not warn when startup activation enables the configured channel owner", async () => {
+    pluginRegistryMocks.loadPluginManifestRegistryForPluginRegistry.mockReturnValue({
+      plugins: [
+        {
+          id: "openclaw-modern-chat",
+          origin: "global",
+          channels: ["legacy-chat"],
+          enabledByDefault: false,
+        },
+      ],
+      diagnostics: [],
+    });
+    const info = vi.fn();
+    const warn = vi.fn();
+
+    await logGatewayStartup({
+      cfg: {
+        channels: {
+          "legacy-chat": {
+            enabled: true,
+            token: "configured",
+          },
+        },
+      },
+      activationSourceConfig: {
+        plugins: {
+          entries: {
+            "openclaw-modern-chat": {
+              enabled: true,
+            },
+          },
+        },
+      },
       bindHost: "127.0.0.1",
       loadedPluginIds: [],
       port: 18789,

--- a/src/gateway/server-startup-log.ts
+++ b/src/gateway/server-startup-log.ts
@@ -2,6 +2,7 @@
 // Produces the compact ready banner with resolved model and safety state.
 import { normalizeSortedUniqueStringEntries } from "@openclaw/normalization-core/string-normalization";
 import chalk from "chalk";
+import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
 import { resolveDefaultAgentId, resolveAgentConfig } from "../agents/agent-scope.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { formatFastModeValue, resolveFastModeState } from "../agents/fast-mode.js";
@@ -29,6 +30,7 @@ type StartupThinkLevel =
 /** Emit startup summary lines after Gateway bind and plugin loading complete. */
 export async function logGatewayStartup(params: {
   cfg: OpenClawConfig;
+  activationSourceConfig?: OpenClawConfig;
   bindHost: string;
   bindHosts?: string[];
   port: number;
@@ -62,6 +64,13 @@ export async function logGatewayStartup(params: {
   params.log.info(`log file: ${getResolvedLoggerSettings().file}`);
   if (params.isNixMode) {
     params.log.info("gateway: running in Nix mode (config managed externally)");
+  }
+
+  for (const warning of await collectConfiguredChannelStartupWarnings({
+    cfg: params.cfg,
+    activationSourceConfig: params.activationSourceConfig,
+  })) {
+    params.log.warn(warning);
   }
 
   const enabledDangerousFlags =
@@ -163,6 +172,53 @@ export function formatAgentModelStartupDetails(params: {
   });
 
   return `thinking=${thinking}, fast=${formatFastModeValue(fast.mode)}`;
+}
+
+async function collectConfiguredChannelStartupWarnings(params: {
+  cfg: OpenClawConfig;
+  activationSourceConfig?: OpenClawConfig;
+}): Promise<string[]> {
+  const [blockerModule, presencePolicyModule, pluginRegistryModule] = await Promise.all([
+    import("../commands/doctor/shared/channel-plugin-blockers.js"),
+    import("../plugins/channel-presence-policy.js"),
+    import("../plugins/plugin-registry.js"),
+  ]);
+  const manifestRegistry = pluginRegistryModule.loadPluginManifestRegistryForPluginRegistry({
+    config: params.cfg,
+    env: process.env,
+    includeDisabled: true,
+  });
+  const hits = blockerModule.scanConfiguredChannelPluginBlockers(
+    params.cfg,
+    process.env,
+    params.activationSourceConfig,
+  );
+  const blockerWarnings = blockerModule
+    .collectConfiguredChannelPluginBlockerWarnings(hits)
+    .map((warning) => `configured channel warning: ${warning.replace(/^[-]\s*/u, "")}`);
+  const missingOwnerWarnings = presencePolicyModule
+    .resolveConfiguredChannelPresencePolicy({
+      config: params.cfg,
+      activationSourceConfig: params.activationSourceConfig,
+      includePersistedAuthState: false,
+      manifestRecords: manifestRegistry.plugins,
+    })
+    .filter((entry) => !entry.effective && entry.blockedReasons.includes("no-channel-owner"))
+    .map(formatConfiguredChannelMissingOwnerStartupWarning);
+  return [...blockerWarnings, ...missingOwnerWarnings];
+}
+
+function formatConfiguredChannelMissingOwnerStartupWarning(entry: {
+  channelId: string;
+  blockedReasons: readonly string[];
+}): string {
+  const channelId = sanitizeForLog(entry.channelId);
+  const reasons = normalizeSortedUniqueStringEntries(entry.blockedReasons).join(", ");
+  return (
+    `configured channel warning: channels.${channelId} is configured but no channel plugin ` +
+    `is installed or loadable (${reasons}). Run \`openclaw doctor --fix\` or install the ` +
+    "channel plugin before relying on this channel."
+  );
 }
 
 /** Format plugin count/list and optional startup duration for the ready log line. */

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -388,6 +388,11 @@ describe("startGatewayPostAttachRuntime", () => {
     expect(hoisted.setInternalHooksEnabled).not.toHaveBeenCalled();
     expect(hoisted.logGatewayStartup).toHaveBeenCalledTimes(1);
     expect(firstStartupLog().loadedPluginIds).toEqual(["beta", "alpha"]);
+    expect(hoisted.logGatewayStartup).toHaveBeenCalledWith(
+      expect.objectContaining({
+        activationSourceConfig: { hooks: { internal: { enabled: false } } },
+      }),
+    );
     expect(log.info).toHaveBeenCalledWith("gateway ready");
     expect(hoisted.scheduleRestartAbortedMainSessionRecovery).toHaveBeenCalledWith({
       cfg: { hooks: { internal: { enabled: false } } },
@@ -2240,6 +2245,7 @@ function createPostAttachParams(overrides: Partial<PostAttachParams> = {}): Post
       error: vi.fn(),
     },
     gatewayPluginConfigAtStart: { hooks: { internal: { enabled: false } } } as never,
+    activationSourceConfig: { hooks: { internal: { enabled: false } } } as never,
     pluginRegistry: {
       plugins: [
         { id: "beta", status: "loaded" },

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -1096,6 +1096,7 @@ export async function startGatewayPostAttachRuntime(
       debug?: (msg: string) => void;
     };
     gatewayPluginConfigAtStart: OpenClawConfig;
+    activationSourceConfig: OpenClawConfig;
     pluginRegistry: ReturnType<typeof loadOpenClawPlugins>;
     defaultWorkspaceDir: string;
     deps: CliDeps;
@@ -1176,6 +1177,7 @@ export async function startGatewayPostAttachRuntime(
   const startupLogPromise = measureStartup(params.startupTrace, "post-attach.log", () =>
     runtimeDeps.logGatewayStartup({
       cfg: params.cfgAtStart,
+      activationSourceConfig: params.activationSourceConfig,
       bindHost: params.bindHost,
       bindHosts: params.bindHosts,
       port: params.port,

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -1640,6 +1640,7 @@ export async function startGatewayServer(
             controlUiBasePath,
             logTailscale,
             gatewayPluginConfigAtStart,
+            activationSourceConfig: startupActivationSourceConfig,
             pluginRegistry,
             defaultWorkspaceDir,
             deps,

--- a/src/llm/utils/oauth/anthropic.test.ts
+++ b/src/llm/utils/oauth/anthropic.test.ts
@@ -79,4 +79,26 @@ describe("Anthropic OAuth token responses", () => {
       "Anthropic token refresh returned invalid token fields.",
     );
   });
+
+  it("rejects an oversized Anthropic token refresh response", async () => {
+    let pullCount = 0;
+    const cancel = vi.fn(async () => undefined);
+    const oversizedStream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        pullCount += 1;
+        controller.enqueue(new Uint8Array(pullCount === 1 ? 16 * 1024 * 1024 + 1 : 1));
+      },
+      cancel,
+    });
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(oversizedStream, { status: 200 })),
+    );
+
+    await expect(refreshAnthropicToken("old-refresh-token")).rejects.toThrow("too large");
+
+    expect(pullCount).toBeLessThanOrEqual(2);
+    expect(cancel).toHaveBeenCalledOnce();
+  });
 });

--- a/src/llm/utils/oauth/anthropic.ts
+++ b/src/llm/utils/oauth/anthropic.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Server } from "node:http";
+import { readResponseWithLimit } from "@openclaw/media-core/read-response-with-limit";
 import { toErrorObject } from "../../../infra/errors.js";
 import {
   generateOAuthState,
@@ -52,6 +53,10 @@ const CALLBACK_PATH = "/callback";
 const REDIRECT_URI = `http://localhost:${CALLBACK_PORT}${CALLBACK_PATH}`;
 const SCOPES =
   "org:create_api_key user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload";
+
+/** Max response body bytes for Anthropic OAuth token endpoint (16 MiB). */
+const OAUTH_RESPONSE_MAX_BYTES = 16 * 1024 * 1024;
+
 async function getNodeApis(): Promise<NodeApis> {
   if (nodeApis) {
     return nodeApis;
@@ -233,7 +238,10 @@ async function postJson(
     signal: buildOAuthRequestSignal({ signal: options.signal, timeoutMs }),
   });
 
-  const responseBody = await response.text();
+  const buffer = await readResponseWithLimit(response, OAUTH_RESPONSE_MAX_BYTES, {
+    onOverflow: ({ size }) => new Error(`Anthropic OAuth response too large: ${size} bytes`),
+  });
+  const responseBody = new TextDecoder().decode(buffer);
 
   if (!response.ok) {
     throw new Error(

--- a/src/mcp/channel-bridge.test.ts
+++ b/src/mcp/channel-bridge.test.ts
@@ -16,7 +16,10 @@ type BridgeInternals = {
   pendingClaudePermissions: Map<string, unknown>;
   pendingApprovals: Map<string, unknown>;
   pendingSweepInterval: NodeJS.Timeout | null;
-  pollEvents: (filter: WaitFilter, limit?: number) => {
+  pollEvents: (
+    filter: WaitFilter,
+    limit?: number,
+  ) => {
     events: QueueEvent[];
     nextCursor: number;
   };
@@ -31,6 +34,11 @@ type BridgeInternals = {
     event: string;
     payload?: Record<string, unknown>;
   }) => Promise<void>;
+  handleSessionMessageEvent: (payload: {
+    sessionKey: string;
+    senderIsOwner?: boolean;
+    message: { role: string; content: unknown };
+  }) => Promise<void>;
   listPendingApprovals: () => unknown[];
   close: () => Promise<void>;
   server: { server: { notification: (n: unknown) => Promise<void> } } | null;
@@ -43,6 +51,72 @@ function makeBridge(verbose = false): BridgeInternals {
     verbose,
   }) as unknown as BridgeInternals;
 }
+
+describe("OpenClawChannelBridge — Claude permission authorization", () => {
+  test.each([
+    { name: "non-owner", senderIsOwner: false, role: "user" },
+    { name: "missing owner metadata", senderIsOwner: undefined, role: "user" },
+    { name: "assistant message", senderIsOwner: true, role: "assistant" },
+  ])("does not resolve a pending permission from a $name reply", async (reply) => {
+    const bridge = makeBridge();
+    const notification = vi.fn(async () => undefined);
+    bridge.server = { server: { notification } };
+    try {
+      await bridge.handleClaudePermissionRequest({
+        requestId: "abcde",
+        toolName: "Bash",
+        description: "run npm test",
+        inputPreview: "{}",
+      });
+
+      await bridge.handleSessionMessageEvent({
+        sessionKey: "agent:main:telegram:group:-100123",
+        senderIsOwner: reply.senderIsOwner,
+        message: {
+          role: reply.role,
+          content: [{ type: "text", text: "yes abcde" }],
+        },
+      });
+
+      expect(notification).not.toHaveBeenCalled();
+      expect(bridge.pendingClaudePermissions.has("abcde")).toBe(true);
+      expect(bridge.queue.at(-1)).toMatchObject({ type: "message", text: "yes abcde" });
+    } finally {
+      await bridge.close();
+    }
+  });
+
+  test("resolves a pending permission from an owner user reply", async () => {
+    const bridge = makeBridge();
+    const notification = vi.fn(async () => undefined);
+    bridge.server = { server: { notification } };
+    try {
+      await bridge.handleClaudePermissionRequest({
+        requestId: "abcde",
+        toolName: "Bash",
+        description: "run npm test",
+        inputPreview: "{}",
+      });
+
+      await bridge.handleSessionMessageEvent({
+        sessionKey: "agent:main:telegram:group:-100123",
+        senderIsOwner: true,
+        message: {
+          role: "user",
+          content: [{ type: "text", text: "yes abcde" }],
+        },
+      });
+
+      expect(notification).toHaveBeenCalledWith({
+        method: "notifications/claude/channel/permission",
+        params: { request_id: "abcde", behavior: "allow" },
+      });
+      expect(bridge.pendingClaudePermissions.has("abcde")).toBe(false);
+    } finally {
+      await bridge.close();
+    }
+  });
+});
 
 describe("OpenClawChannelBridge — pendingClaudePermissions / pendingApprovals memory bounds", () => {
   beforeEach(() => {

--- a/src/mcp/channel-bridge.ts
+++ b/src/mcp/channel-bridge.ts
@@ -584,7 +584,9 @@ export class OpenClawChannelBridge {
     const role = toText(payload.message?.role);
     const text = extractFirstTextBlock(payload.message);
     const permissionMatch = text ? CLAUDE_PERMISSION_REPLY_RE.exec(text) : null;
-    if (permissionMatch) {
+    // Ownership is decided at authenticated channel ingress and carried on the
+    // live transcript event. Missing metadata fails closed for approvals.
+    if (role === "user" && payload.senderIsOwner === true && permissionMatch) {
       const requestId = normalizeOptionalLowercaseString(permissionMatch[2]);
       if (requestId && this.pendingClaudePermissions.has(requestId)) {
         this.pendingClaudePermissions.delete(requestId);

--- a/src/mcp/channel-server.test.ts
+++ b/src/mcp/channel-server.test.ts
@@ -324,6 +324,7 @@ describe("openclaw channel mcp server", () => {
             }
           ).handleSessionMessageEvent({
             sessionKey,
+            senderIsOwner: true,
             lastChannel: "imessage",
             lastTo: "+15551234567",
             messageId: "msg-user-1",
@@ -358,6 +359,7 @@ describe("openclaw channel mcp server", () => {
             }
           ).handleSessionMessageEvent({
             sessionKey,
+            senderIsOwner: true,
             lastChannel: "imessage",
             lastTo: "+15551234567",
             messageId: "msg-user-2",

--- a/src/mcp/channel-shared.ts
+++ b/src/mcp/channel-shared.ts
@@ -71,6 +71,7 @@ export type ChatHistoryResult = {
 /** Gateway session.message payload fields consumed by the MCP event bridge. */
 export type SessionMessagePayload = {
   sessionKey?: string;
+  senderIsOwner?: boolean;
   messageId?: string;
   messageSeq?: number;
   message?: { role?: string; content?: unknown; [key: string]: unknown };

--- a/src/node-host/invoke-system-run-allowlist.test.ts
+++ b/src/node-host/invoke-system-run-allowlist.test.ts
@@ -1,9 +1,16 @@
 /** Tests system.run allowlist planning, output truncation, and argv resolution. */
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { resolveExecApprovalsFromFile } from "../infra/exec-approvals.js";
+import { resolveExecApprovalsFromFile, type ExecCommandSegment } from "../infra/exec-approvals.js";
 import { planShellAuthorization } from "../infra/exec-authorization-plan.js";
 import { resolveExecSafeBinRuntimePolicy } from "../infra/exec-safe-bin-runtime-policy.js";
-import { resolveSystemRunExecArgv } from "./invoke-system-run-allowlist.js";
+import {
+  evaluateSystemRunAllowlist,
+  resolveSystemRunExecArgv,
+} from "./invoke-system-run-allowlist.js";
 
 function resolveAllowlistApprovals() {
   return resolveExecApprovalsFromFile({
@@ -18,7 +25,193 @@ function resolveAllowlistApprovals() {
   });
 }
 
+function resolveWindowsShellExecArgv(segment: ExecCommandSegment) {
+  return resolveSystemRunExecArgv({
+    plannedAllowlistArgv: undefined,
+    argv: ["powershell.exe", "-Command", "safe --version"],
+    security: "allowlist",
+    approvals: resolveAllowlistApprovals(),
+    safeBins: new Set(),
+    safeBinProfiles: {},
+    trustedSafeBinDirs: new Set(),
+    skillBins: [],
+    autoAllowSkills: false,
+    isWindows: true,
+    policy: {
+      approvedByAsk: false,
+      analysisOk: true,
+      allowlistSatisfied: true,
+    },
+    shellCommand: "safe --version",
+    segments: [segment],
+    segmentSatisfiedBy: ["allowlist"],
+    authorizationPlan: undefined,
+    cwd: "C:\\workspace",
+    env: undefined,
+  });
+}
+
+function runExecutable(params: {
+  argv: string[];
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+}): Promise<{ exitCode: number | null; stdout: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(params.argv[0], params.argv.slice(1), {
+      cwd: params.cwd,
+      env: params.env,
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+    });
+    const stdout: Buffer[] = [];
+    child.stdout.on("data", (chunk: Buffer) => stdout.push(chunk));
+    child.once("error", reject);
+    child.once("close", (exitCode) => {
+      resolve({ exitCode, stdout: Buffer.concat(stdout).toString("utf8") });
+    });
+  });
+}
+
 describe("resolveSystemRunExecArgv", () => {
+  it("pins Windows shell execution to the resolved allowlisted executable", async () => {
+    const trustedExecutable = "C:\\trusted-bin\\safe.exe";
+    const result = await resolveWindowsShellExecArgv({
+      raw: "safe --version",
+      argv: ["safe", "--version"],
+      resolution: {
+        execution: {
+          rawExecutable: "safe",
+          resolvedPath: trustedExecutable,
+          executableName: "safe.exe",
+        },
+        policy: {
+          rawExecutable: "safe",
+          resolvedPath: trustedExecutable,
+          executableName: "safe.exe",
+        },
+      },
+    });
+
+    expect(result).toEqual([trustedExecutable, "--version"]);
+  });
+
+  it("preserves unresolved Windows shell argv authorized by a bare wildcard", async () => {
+    const result = await resolveWindowsShellExecArgv({
+      raw: "safe --version",
+      argv: ["safe", "--version"],
+      resolution: null,
+    });
+
+    expect(result).toEqual(["safe", "--version"]);
+  });
+
+  it("fails closed when the Windows shell execution plan is blocked", async () => {
+    const result = await resolveWindowsShellExecArgv({
+      raw: "safe --version",
+      argv: ["safe", "--version"],
+      resolution: {
+        policyBlocked: true,
+        execution: {
+          rawExecutable: "safe",
+          executableName: "safe",
+        },
+        policy: {
+          rawExecutable: "safe",
+          executableName: "safe",
+        },
+      },
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it.runIf(process.platform === "win32")(
+    "executes the allowlisted path instead of a workspace shadow executable",
+    async () => {
+      const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-windows-shadow-"));
+      const trustedBin = path.join(fixtureRoot, "trusted-bin");
+      const workspace = path.join(fixtureRoot, "workspace");
+      fs.mkdirSync(trustedBin);
+      fs.mkdirSync(workspace);
+      const trustedExecutable = path.join(trustedBin, "safe.exe");
+      const shadowExecutable = path.join(workspace, "safe.exe");
+      const systemRoot = process.env.SystemRoot ?? process.env.WINDIR ?? "C:\\Windows";
+      fs.copyFileSync(path.join(systemRoot, "System32", "cmd.exe"), trustedExecutable);
+      fs.copyFileSync(path.join(systemRoot, "System32", "where.exe"), shadowExecutable);
+      const env = {
+        ...process.env,
+        PATH: `${trustedBin}${path.delimiter}${process.env.PATH ?? ""}`,
+        PATHEXT: process.env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD",
+      };
+      const shellCommand = "safe /d /s /c echo TRUSTED_EXECUTABLE";
+      const commandTail = ["/d", "/s", "/c", "echo", "TRUSTED_EXECUTABLE"];
+
+      try {
+        const bareResult = await runExecutable({
+          argv: ["safe", ...commandTail],
+          cwd: workspace,
+          env,
+        });
+        expect(bareResult.exitCode).not.toBe(0);
+        expect(bareResult.stdout).not.toContain("TRUSTED_EXECUTABLE");
+
+        const approvals = resolveExecApprovalsFromFile({
+          file: {
+            version: 1,
+            defaults: { security: "allowlist", ask: "off", askFallback: "deny" },
+            agents: { main: { allowlist: [{ pattern: trustedExecutable }] } },
+          },
+        });
+        const analysis = await evaluateSystemRunAllowlist({
+          shellCommand,
+          argv: ["powershell.exe", "-Command", shellCommand],
+          approvals,
+          security: "allowlist",
+          safeBins: new Set(),
+          safeBinProfiles: {},
+          trustedSafeBinDirs: new Set(),
+          cwd: workspace,
+          env,
+          skillBins: [],
+          autoAllowSkills: false,
+        });
+        expect(analysis.analysisOk).toBe(true);
+        expect(analysis.allowlistSatisfied).toBe(true);
+
+        const execArgv = await resolveSystemRunExecArgv({
+          plannedAllowlistArgv: undefined,
+          argv: ["powershell.exe", "-Command", shellCommand],
+          security: "allowlist",
+          approvals,
+          safeBins: new Set(),
+          safeBinProfiles: {},
+          trustedSafeBinDirs: new Set(),
+          skillBins: [],
+          autoAllowSkills: false,
+          isWindows: true,
+          policy: {
+            approvedByAsk: false,
+            analysisOk: analysis.analysisOk,
+            allowlistSatisfied: analysis.allowlistSatisfied,
+          },
+          shellCommand,
+          segments: analysis.segments,
+          segmentSatisfiedBy: analysis.segmentSatisfiedBy,
+          authorizationPlan: analysis.authorizationPlan,
+          cwd: workspace,
+          env,
+        });
+        expect(execArgv?.[0]).toBe(fs.realpathSync(trustedExecutable));
+
+        const fixedResult = await runExecutable({ argv: execArgv ?? [], cwd: workspace, env });
+        expect(fixedResult.exitCode).toBe(0);
+        expect(fixedResult.stdout).toContain("TRUSTED_EXECUTABLE");
+      } finally {
+        fs.rmSync(fixtureRoot, { recursive: true, force: true });
+      }
+    },
+  );
+
   it.runIf(process.platform !== "win32")(
     "fails closed when shell rewriting has no authorization plan",
     async () => {

--- a/src/node-host/invoke-system-run-allowlist.ts
+++ b/src/node-host/invoke-system-run-allowlist.ts
@@ -165,11 +165,15 @@ export async function resolveSystemRunExecArgv(params: {
     params.shellCommand &&
     params.policy.analysisOk &&
     params.policy.allowlistSatisfied &&
-    params.segments.length === 1 &&
-    params.segments[0]?.argv.length > 0
+    params.segments.length === 1
   ) {
-    // Windows shell transports expose a parsed argv segment that is safer than the wrapper argv.
-    execArgv = params.segments[0].argv;
+    // Exact-path matches stay bound to the resolved executable, while the bare
+    // wildcard contract can still authorize unresolved Windows commands.
+    const plannedArgv = resolvePlannedSegmentArgv(params.segments[0]);
+    if (!plannedArgv) {
+      return null;
+    }
+    execArgv = plannedArgv;
   }
   if (
     params.security === "allowlist" &&

--- a/src/sessions/user-turn-transcript.test.ts
+++ b/src/sessions/user-turn-transcript.test.ts
@@ -272,6 +272,7 @@ describe("user turn transcript persistence", () => {
           text: "What is in this image?",
           media: [{ path: "/tmp/image.png", contentType: "image/png" }],
           timestamp: 123,
+          senderIsOwner: true,
           provenance,
         },
         updateMode: "none",
@@ -287,6 +288,7 @@ describe("user turn transcript persistence", () => {
           role: "user",
           content: "What is in this image?",
           MediaPath: "/tmp/image.png",
+          __openclaw: { senderIsOwner: true },
           provenance,
           MediaType: "image/png",
         }),
@@ -398,6 +400,7 @@ describe("user turn transcript persistence", () => {
         input: {
           text: "secret prompt",
           idempotencyKey: "chat-run-1:user",
+          senderIsOwner: true,
           provenance,
         },
         beforeMessageWrite: runAgentHarnessBeforeMessageWriteHook,
@@ -407,6 +410,7 @@ describe("user turn transcript persistence", () => {
         input: {
           text: "secret prompt",
           idempotencyKey: "chat-run-1:user",
+          senderIsOwner: true,
           provenance,
         },
         beforeMessageWrite: runAgentHarnessBeforeMessageWriteHook,
@@ -417,6 +421,7 @@ describe("user turn transcript persistence", () => {
           role: "user",
           content: "[redacted by hook]",
           idempotencyKey: "chat-run-1:user",
+          __openclaw: { senderIsOwner: true },
           provenance,
         }),
       ]);

--- a/src/sessions/user-turn-transcript.ts
+++ b/src/sessions/user-turn-transcript.ts
@@ -243,6 +243,9 @@ function buildPersistedUserTurnMessage(params: UserTurnInput): PersistedUserTurn
     content,
     timestamp: params.timestamp ?? Date.now(),
     ...(params.idempotencyKey ? { idempotencyKey: params.idempotencyKey } : {}),
+    ...(params.senderIsOwner === undefined
+      ? {}
+      : { __openclaw: { senderIsOwner: params.senderIsOwner } }),
     ...mediaFields,
   } as PersistedUserTurnMessage;
   return applyInputProvenanceToUserMessage(message, params.provenance) as PersistedUserTurnMessage;
@@ -317,12 +320,26 @@ export function preparePersistedUserTurnMessageForTranscriptWrite(
   const nextUserMessage = provenance
     ? (applyInputProvenanceToUserMessage(nextMessage, provenance) as PersistedUserTurnMessage)
     : nextMessage;
-  return idempotencyKey
-    ? ({
-        ...(nextUserMessage as unknown as Record<string, unknown>),
-        idempotencyKey,
-      } as unknown as PersistedUserTurnMessage)
-    : nextUserMessage;
+  const originalOpenClaw = (message as unknown as { __openclaw?: unknown })["__openclaw"];
+  const senderIsOwner =
+    originalOpenClaw && typeof originalOpenClaw === "object"
+      ? (originalOpenClaw as { senderIsOwner?: unknown }).senderIsOwner
+      : undefined;
+  if (!idempotencyKey && typeof senderIsOwner !== "boolean") {
+    return nextUserMessage;
+  }
+  const nextRecord = nextUserMessage as unknown as Record<string, unknown>;
+  const nextOpenClaw =
+    nextRecord["__openclaw"] && typeof nextRecord["__openclaw"] === "object"
+      ? (nextRecord["__openclaw"] as Record<string, unknown>)
+      : {};
+  return {
+    ...nextRecord,
+    ...(idempotencyKey ? { idempotencyKey } : {}),
+    ...(typeof senderIsOwner === "boolean"
+      ? { __openclaw: { ...nextOpenClaw, senderIsOwner } }
+      : {}),
+  } as unknown as PersistedUserTurnMessage;
 }
 
 export async function appendUserTurnTranscriptMessage(

--- a/src/sessions/user-turn-transcript.types.ts
+++ b/src/sessions/user-turn-transcript.types.ts
@@ -23,6 +23,7 @@ export type UserTurnInput = {
   media?: readonly PersistedUserTurnMediaInput[] | null;
   timestamp?: number;
   idempotencyKey?: string;
+  senderIsOwner?: boolean;
   provenance?: InputProvenance;
   mediaOnlyText?: string;
 };

--- a/src/skills/lifecycle/install-fallback.test.ts
+++ b/src/skills/lifecycle/install-fallback.test.ts
@@ -1,8 +1,7 @@
 // Install fallback tests cover alternate skill install paths when primary paths fail.
-import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createSuiteTempRootTracker } from "../../test-helpers/temp-dir.js";
 import { captureEnv } from "../../test-utils/env.js";
 import { hasBinaryMock, runCommandWithTimeoutMock } from "../test-support/install-test-mocks.js";
 import type { SkillEntry, SkillInstallSpec } from "../types.js";
@@ -82,11 +81,13 @@ function commandCallAt(
   ];
 }
 
+const suiteTempDirs = createSuiteTempRootTracker({ prefix: "openclaw-fallback-test-" });
+
 describe("skills-install fallback edge cases", () => {
   let workspaceDir: string;
 
   beforeAll(async () => {
-    workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-fallback-test-"));
+    workspaceDir = await suiteTempDirs.setup();
     skillsMocks.loadWorkspaceSkillEntries.mockReturnValue([
       makeSkillEntry(workspaceDir, "go-tool-single", {
         kind: "go",
@@ -112,7 +113,7 @@ describe("skills-install fallback edge cases", () => {
 
   afterAll(async () => {
     skillsInstallTesting.setDepsForTest();
-    await fs.rm(workspaceDir, { recursive: true, force: true }).catch(() => undefined);
+    await suiteTempDirs.cleanup();
   });
 
   it("handles sudo probe failures for go install without apt fallback", async () => {

--- a/src/utils/directive-tags.test.ts
+++ b/src/utils/directive-tags.test.ts
@@ -8,6 +8,24 @@ import {
   stripInlineDirectiveTagsFromMessageForDisplay,
 } from "./directive-tags.js";
 
+function hasUnpairedSurrogate(value: string): boolean {
+  for (let i = 0; i < value.length; i += 1) {
+    const code = value.charCodeAt(i);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      // High surrogate must be followed by a low surrogate. charCodeAt past end
+      // returns NaN; NaN comparisons are always false, so guard bounds explicitly.
+      const next = i + 1 < value.length ? value.charCodeAt(i + 1) : -1;
+      if (next < 0xdc00 || next > 0xdfff) {
+        return true;
+      }
+      i += 1;
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      return true;
+    }
+  }
+  return false;
+}
+
 describe("stripInlineDirectiveTagsForDisplay", () => {
   test("removes reply and audio directives", () => {
     const input = "hello [[reply_to_current]] world [[reply_to:abc-123]] [[audio_as_voice]]";
@@ -223,6 +241,26 @@ describe("parseInlineDirectives", () => {
 describe("sanitizeReplyDirectiveId", () => {
   test("strips bracket and control characters from explicit reply ids", () => {
     expect(sanitizeReplyDirectiveId(" [abc]\u0000\r\u0085def ")).toBe("abcdef");
+  });
+
+  test("truncates long ids without splitting surrogate pairs", () => {
+    const prefix = "a".repeat(255);
+    const result = sanitizeReplyDirectiveId(`${prefix}😊tail`);
+
+    expect(result).toBe(`${prefix}😊`);
+    expect(hasUnpairedSurrogate(result ?? "")).toBe(false);
+  });
+
+  test("hasUnpairedSurrogate catches a lone trailing high surrogate", () => {
+    // Proves the helper itself reports the failure mode the production fix prevents.
+    // Pre-fix helper: charCodeAt(out-of-bounds) returned NaN, NaN < 0xdc00 was false,
+    // so a trailing high surrogate was missed and the assertion above was vacuous.
+    expect(hasUnpairedSurrogate("a\ud83d")).toBe(true);
+    expect(hasUnpairedSurrogate(`${"a".repeat(255)}\ud83d`)).toBe(true);
+  });
+
+  test("hasUnpairedSurrogate accepts a properly paired emoji", () => {
+    expect(hasUnpairedSurrogate("a😊b")).toBe(false);
   });
 });
 

--- a/src/utils/directive-tags.ts
+++ b/src/utils/directive-tags.ts
@@ -121,8 +121,9 @@ export function sanitizeReplyDirectiveId(rawReplyToId?: string): string | undefi
   if (!sanitized) {
     return undefined;
   }
-  if (sanitized.length > MAX_REPLY_DIRECTIVE_ID_LENGTH) {
-    return sanitized.slice(0, MAX_REPLY_DIRECTIVE_ID_LENGTH);
+  const chars = Array.from(sanitized);
+  if (chars.length > MAX_REPLY_DIRECTIVE_ID_LENGTH) {
+    return chars.slice(0, MAX_REPLY_DIRECTIVE_ID_LENGTH).join("");
   }
   return sanitized;
 }

--- a/test/e2e/qa-lab/runtime/mcp-channels-docker-client.ts
+++ b/test/e2e/qa-lab/runtime/mcp-channels-docker-client.ts
@@ -1,5 +1,6 @@
 // MCP channels Docker client drives the QA-owned channel bridge smoke.
 import { randomUUID } from "node:crypto";
+import { setTimeout as delay } from "node:timers/promises";
 import {
   assert,
   ClaudeChannelNotificationSchema,
@@ -28,6 +29,8 @@ function summarizeSessionRows(rows: Array<Record<string, unknown>> | undefined) 
     lastThreadId: entry.lastThreadId,
   }));
 }
+
+const NON_OWNER_PERMISSION_QUIET_WINDOW_MS = 1_000;
 
 function formatUnknownError(error: unknown): string {
   if (error instanceof Error) {
@@ -96,6 +99,7 @@ async function main() {
   assert(gatewayToken, "missing GW_TOKEN");
 
   const gateway = await connectGateway({ url: gatewayUrl, token: gatewayToken });
+  let nonOwnerGateway: GatewayRpcClient | undefined;
   let mcpHandle: Awaited<ReturnType<typeof connectMcpClient>> | undefined;
   const mcpTempState = createMcpClientTempState({ gatewayToken });
 
@@ -349,6 +353,36 @@ async function main() {
       },
     });
 
+    nonOwnerGateway = await connectGateway({
+      url: gatewayUrl,
+      token: gatewayToken,
+      scopes: ["operator.read", "operator.write"],
+    });
+    await nonOwnerGateway.request("chat.send", {
+      sessionKey: "agent:main:main",
+      message: "yes abcde",
+      idempotencyKey: randomUUID(),
+    });
+    await waitFor(
+      "non-owner reply forwarded as an ordinary Claude channel message",
+      () =>
+        mcpHandle.rawMessages
+          .map((entry) => ClaudeChannelNotificationSchema.safeParse(entry))
+          .find(
+            (entry) =>
+              entry.success &&
+              entry.data.params.meta.session_key === "agent:main:main" &&
+              entry.data.params.content === "yes abcde",
+          )?.data.params,
+      60_000,
+    );
+    await delay(NON_OWNER_PERMISSION_QUIET_WINDOW_MS);
+    const nonOwnerPermission = mcpHandle.rawMessages
+      .map((entry) => ClaudePermissionNotificationSchema.safeParse(entry))
+      .find((entry) => entry.success && entry.data.params.request_id === "abcde");
+    assert(!nonOwnerPermission, "non-owner reply must not resolve the Claude permission");
+
+    const ownerNotificationStart = mcpHandle.rawMessages.length;
     await gateway.request("chat.send", {
       sessionKey: "agent:main:main",
       message: "yes abcde",
@@ -360,6 +394,7 @@ async function main() {
         "Claude permission notification",
         () =>
           mcpHandle.rawMessages
+            .slice(ownerNotificationStart)
             .map((entry) => ClaudePermissionNotificationSchema.safeParse(entry))
             .find((entry) => entry.success && entry.data.params.request_id === "abcde")?.data
             .params,
@@ -389,6 +424,9 @@ async function main() {
         {
           ok: true,
           sessionKey: "agent:main:main",
+          nonOwnerReplyForwarded: true,
+          nonOwnerPermissionBlocked: true,
+          ownerPermissionAllowed: permission.behavior === "allow",
           rawNotifications: mcpHandle.rawMessages.filter(
             (entry) =>
               ClaudeChannelNotificationSchema.safeParse(entry).success ||
@@ -401,6 +439,9 @@ async function main() {
     );
   } finally {
     const closeTasks: Array<Promise<unknown>> = [gateway.close()];
+    if (nonOwnerGateway) {
+      closeTasks.push(nonOwnerGateway.close());
+    }
     if (mcpHandle) {
       closeTasks.push(mcpHandle.client.close(), mcpHandle.transport.close());
     }

--- a/test/e2e/qa-lab/runtime/mcp-channels.fixture.ts
+++ b/test/e2e/qa-lab/runtime/mcp-channels.fixture.ts
@@ -114,6 +114,7 @@ export async function waitFor<T>(
 export async function connectGateway(params: {
   url: string;
   token: string;
+  scopes?: readonly string[];
 }): Promise<GatewayRpcClient> {
   const startedAt = Date.now();
   let attempt = 0;
@@ -138,8 +139,14 @@ export async function connectGateway(params: {
 async function connectGatewayOnce(params: {
   url: string;
   token: string;
+  scopes?: readonly string[];
 }): Promise<GatewayRpcClient> {
-  const requestedScopes = ["operator.read", "operator.write", "operator.pairing", "operator.admin"];
+  const requestedScopes = params.scopes ?? [
+    "operator.read",
+    "operator.write",
+    "operator.pairing",
+    "operator.admin",
+  ];
   const events: Array<{ event: string; payload: Record<string, unknown> }> = [];
   const gatewayClient = createGatewayWsClient({
     handshakeTimeoutMs: GATEWAY_WS_OPEN_TIMEOUT_MS,

--- a/test/scripts/parallels-npm-update-smoke.test.ts
+++ b/test/scripts/parallels-npm-update-smoke.test.ts
@@ -82,8 +82,6 @@ function decodePowerShellFromArgs(args: string[]): string {
 function extractWindowsBackgroundControlMarkers(decoded: string): {
   done: string;
   exitPrefix: string;
-  lengthPrefix: string;
-  offsetPrefix: string;
 } {
   const marker = (name: string, trailingColon: boolean): string => {
     const suffix = trailingColon ? ":" : "";
@@ -96,8 +94,6 @@ function extractWindowsBackgroundControlMarkers(decoded: string): {
   return {
     done: marker("__OPENCLAW_BACKGROUND_DONE__", false),
     exitPrefix: marker("__OPENCLAW_BACKGROUND_EXIT__", true),
-    lengthPrefix: marker("__OPENCLAW_LOG_LENGTH__", true),
-    offsetPrefix: marker("__OPENCLAW_LOG_OFFSET__", true),
   };
 }
 
@@ -620,7 +616,7 @@ exit 1
     expect(transports).toContain("${options.label} timed out");
   });
 
-  it("cleans timed-out Windows background work and reads bounded log chunks", async () => {
+  it("cleans timed-out Windows background work", async () => {
     const decodedCommands: string[] = [];
     const inputs: string[] = [];
     const fakeRun: typeof hostCommandRun = (_command, args, options) => {
@@ -629,8 +625,11 @@ exit 1
       if (options?.input) {
         inputs.push(String(options.input));
       }
-      if (decoded.includes("Start-Process")) {
+      if (decoded.includes('cmd.exe /d /s /c start "" /b powershell.exe')) {
         return { status: 0, stderr: "", stdout: "started\n" };
+      }
+      if (args.includes("cmd.exe")) {
+        return { status: 0, stderr: "", stdout: "wait\n" };
       }
       return { status: 0, stderr: "", stdout: "" };
     };
@@ -638,7 +637,6 @@ exit 1
     await expect(
       runWindowsBackgroundPowerShell({
         label: "windows background timeout",
-        logChunkBytes: 64,
         pollIntervalMs: 1,
         runCommand: fakeRun,
         script: "Start-Sleep -Seconds 60",
@@ -654,11 +652,9 @@ exit 1
     expect(commands).toContain("[System.Text.UTF8Encoding]::new($false)");
     expect(payloads).toContain("Write-OpenClawUtf8File $exitPath '0'");
     expect(payloads).toContain("Write-OpenClawUtf8File $donePath 'done'");
-    expect(commands).toContain("Write-OpenClawUtf8File $pidPath ([string]$process.Id)");
-    expect(commands).toContain("Start-Process -FilePath powershell.exe");
-    expect(commands).toContain("-PassThru");
-    expect(commands).toContain("[System.IO.File]::Open($logPath");
-    expect(commands).toContain("[Math]::Min($length - $offset, 64)");
+    expect(payloads).toContain("Write-OpenClawUtf8File $pidPath ([string]$PID)");
+    expect(commands).toContain('cmd.exe /d /s /c start "" /b powershell.exe');
+    expect(commands).toContain("icacls.exe $runDir /inheritance:r");
     expect(commands).toContain("Stop-OpenClawBackgroundProcessTree ([int]$backgroundPid)");
     expect(commands).toContain(
       'Get-CimInstance Win32_Process -Filter "ParentProcessId=$ProcessId"',
@@ -677,22 +673,11 @@ exit 1
     const fakeRun: typeof hostCommandRun = (_command, args) => {
       const decoded = decodePowerShellFromArgs(args);
       decodedCommands.push(decoded);
-      if (decoded.includes("Start-Process")) {
+      if (decoded.includes('cmd.exe /d /s /c start "" /b powershell.exe')) {
         return { status: 0, stderr: "", stdout: "started\n" };
       }
-      if (decoded.includes("__OPENCLAW_LOG_LENGTH__")) {
-        const markers = extractWindowsBackgroundControlMarkers(decoded);
-        return {
-          status: 0,
-          stderr: "",
-          stdout: [
-            `${markers.lengthPrefix}128`,
-            `${markers.offsetPrefix}128`,
-            "__OPENCLAW_BACKGROUND_EXIT__:0",
-            "__OPENCLAW_BACKGROUND_DONE__",
-            "",
-          ].join("\n"),
-        };
+      if (args.includes("cmd.exe")) {
+        return { status: 0, stderr: "", stdout: "done\n" };
       }
       return { status: 0, stderr: "", stdout: "" };
     };
@@ -700,11 +685,11 @@ exit 1
     await expect(
       runWindowsBackgroundPowerShell({
         label: "windows background marker smuggle",
-        logChunkBytes: 128,
         pollIntervalMs: 1,
         runCommand: fakeRun,
         script: "Write-Output done",
         timeoutMs: 5,
+        completedLogDrainGraceMs: 5,
         vmName: "Windows Test",
       }),
     ).rejects.toThrow("windows background marker smuggle timed out");
@@ -721,34 +706,24 @@ exit 1
     const fakeRun: typeof hostCommandRun = (_command, args) => {
       const decoded = decodePowerShellFromArgs(args);
       decodedCommands.push(decoded);
-      if (decoded.includes("Start-Process")) {
+      if (decoded.includes('cmd.exe /d /s /c start "" /b powershell.exe')) {
         return { status: 0, stderr: "", stdout: "started\n" };
       }
-      if (decoded.includes("__OPENCLAW_LOG_LENGTH__")) {
-        const markers = extractWindowsBackgroundControlMarkers(decoded);
-        pollCount += 1;
-        return {
-          status: 0,
-          stderr: "",
-          stdout:
-            pollCount === 1
-              ? [
-                  `${markers.lengthPrefix}128`,
-                  `${markers.offsetPrefix}64`,
-                  "first chunk",
-                  `${markers.exitPrefix}0`,
-                  markers.done,
-                  "",
-                ].join("\n")
-              : [
-                  `${markers.lengthPrefix}128`,
-                  `${markers.offsetPrefix}128`,
-                  "second chunk",
-                  `${markers.exitPrefix}0`,
-                  markers.done,
-                  "",
-                ].join("\n"),
-        };
+      if (args.includes("cmd.exe")) {
+        const command = args.at(-1) ?? "";
+        if (command.includes("type")) {
+          pollCount += 1;
+          const markers = extractWindowsBackgroundControlMarkers(command);
+          return {
+            status: 0,
+            stderr: "",
+            stdout: ["first chunk", `${markers.exitPrefix}0`, markers.done, ""].join("\n"),
+          };
+        }
+        if (command.includes("if exist")) {
+          return { status: 0, stderr: "", stdout: "done\n" };
+        }
+        return { status: 0, stderr: "", stdout: "" };
       }
       return { status: 0, stderr: "", stdout: "" };
     };
@@ -758,7 +733,6 @@ exit 1
         append: (chunk) => output.push(String(chunk)),
         completedLogDrainGraceMs: 1000,
         label: "windows background drain",
-        logChunkBytes: 64,
         pollIntervalMs: 5000,
         runCommand: fakeRun,
         script: "Write-Output done",
@@ -767,9 +741,8 @@ exit 1
       }),
     ).resolves.toBeUndefined();
 
-    expect(pollCount).toBe(2);
+    expect(pollCount).toBe(1);
     expect(output.join("")).toContain("first chunk");
-    expect(output.join("")).toContain("second chunk");
     expect(decodedCommands.join("\n")).not.toContain("Stop-OpenClawBackgroundProcessTree");
     expect(decodedCommands.join("\n")).toContain(
       "Remove-Item -Path $scriptPath, $logPath, $donePath, $exitPath, $pidPath",

--- a/test/scripts/parallels-smoke-model.test.ts
+++ b/test/scripts/parallels-smoke-model.test.ts
@@ -424,7 +424,9 @@ describe("Parallels smoke model selection", () => {
     expect(script).not.toContain("'openclaw-parallels-plugin-isolation.cjs'");
     expect(script).toContain("try {");
     expect(script).toContain("} finally {");
-    expect(script).toContain("Remove-Item $isolationScriptPath -Force -ErrorAction SilentlyContinue");
+    expect(script).toContain(
+      "Remove-Item $isolationScriptPath -Force -ErrorAction SilentlyContinue",
+    );
     expect(script).toContain("Remove-Item Env:OPENCLAW_PARALLELS_PLUGIN_ISOLATION");
   });
 
@@ -1463,14 +1465,27 @@ if (isPrlctl) {
 
     expect(script).toContain("guestPowerShellBackground");
     expect(script).toContain("runWindowsBackgroundPowerShell");
-    expect(transports).toContain("Join-Path $env:TEMP");
+    expect(transports).toContain("Join-Path (Join-Path $env:WINDIR 'Temp\\\\openclaw-parallels')");
+    expect(transports).toContain("icacls.exe $runDir /inheritance:r");
     expect(transports).toContain("__OPENCLAW_BACKGROUND_DONE__");
     expect(transports).toContain("__OPENCLAW_BACKGROUND_EXIT__");
-    expect(transports).toContain("__OPENCLAW_LOG_OFFSET__");
     expect(transports).toContain("poll.status !== 0 && poll.status !== 124");
-    expect(transports).toContain("Start-Process -FilePath powershell.exe");
+    expect(transports).toContain('cmd.exe /d /s /c start "" /b powershell.exe');
+    expect(transports).toContain('if exist "${windowsDonePath}"');
+    expect(transports).toContain('type "%WINDIR%\\\\Temp\\\\${guestRunDir}\\\\run.log"');
+    expect(transports).toContain("WINDOWS_BACKGROUND_LOG_MAX_BYTES");
+    expect(transports).toContain("Write-OpenClawUtf8File $pidPath ([string]$PID)");
     expect(transports).toContain('launch.stdout.includes("started")');
     expect(transports).toContain("waitForWindowsBackgroundMaterialized");
+  });
+
+  it("runs Windows package installs through the detached done-file runner", () => {
+    const script = readFileSync(TS_PATHS.windows, "utf8");
+
+    expect(script).toContain('guestPowerShellBackground(\n      "install-latest"');
+    expect(script).toContain("guestPowerShellBackground(\n      `install-main-${");
+    expect(script).not.toMatch(/private installMain\(tempName: string\): void/u);
+    expect(script).not.toMatch(/private installLatestRelease\(\): void/u);
   });
 
   it("paces ambiguous Windows background launch materialization probes", async () => {
@@ -2096,9 +2111,7 @@ setInterval(() => {}, 1000);
     );
 
     expect(duplicateNpmUpdatePlatformResult.status).toBe(1);
-    expect(duplicateNpmUpdatePlatformResult.stderr).toContain(
-      "duplicate --platform entry: macos",
-    );
+    expect(duplicateNpmUpdatePlatformResult.stderr).toContain("duplicate --platform entry: macos");
 
     expect(readFileSync(TS_PATHS.macos, "utf8")).toContain(
       'this.updateDevTimeoutSeconds = readPositiveIntEnv(\n      "OPENCLAW_PARALLELS_MACOS_UPDATE_DEV_TIMEOUT_S"',

--- a/ui/src/ui/controllers/cron.test.ts
+++ b/ui/src/ui/controllers/cron.test.ts
@@ -405,6 +405,108 @@ describe("cron controller", () => {
     });
   });
 
+  it("sends explicit null model/thinking clears when blanking stored overrides on edit", async () => {
+    const request = vi.fn(async (method: string, _payload?: unknown) => {
+      if (method === "cron.update") {
+        return { id: "job-clear-overrides" };
+      }
+      if (method === "cron.list") {
+        return { jobs: [{ id: "job-clear-overrides" }] };
+      }
+      if (method === "cron.status") {
+        return { enabled: true, jobs: 1, nextWakeAtMs: null };
+      }
+      return {};
+    });
+
+    const state = createState({
+      client: {
+        request,
+      } as unknown as CronState["client"],
+      cronEditingJobId: "job-clear-overrides",
+      cronJobs: [
+        {
+          id: "job-clear-overrides",
+          payload: {
+            kind: "agentTurn",
+            message: "do work",
+            model: "openai/gpt-5.5",
+            thinking: "high",
+          },
+        } as unknown as CronState["cronJobs"][number],
+      ],
+      cronForm: {
+        ...DEFAULT_CRON_FORM,
+        name: "clear overrides",
+        scheduleKind: "every",
+        everyAmount: "30",
+        everyUnit: "minutes",
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        payloadKind: "agentTurn",
+        payloadText: "do work",
+        payloadModel: "",
+        payloadThinking: "",
+      },
+    });
+
+    await addCronJob(state);
+
+    const updateCall = findRequestCall(request.mock.calls, "cron.update");
+    expectNestedRecordFields(requestPatch(updateCall), "payload", {
+      kind: "agentTurn",
+      message: "do work",
+      model: null,
+      thinking: null,
+    });
+  });
+
+  it("does not send null model/thinking for a new job with blank fields", async () => {
+    const request = vi.fn(async (method: string, _payload?: unknown) => {
+      if (method === "cron.add") {
+        return { id: "job-new-blank" };
+      }
+      if (method === "cron.list") {
+        return { jobs: [{ id: "job-new-blank" }] };
+      }
+      if (method === "cron.status") {
+        return { enabled: true, jobs: 1, nextWakeAtMs: null };
+      }
+      return {};
+    });
+
+    const state = createState({
+      client: {
+        request,
+      } as unknown as CronState["client"],
+      cronForm: {
+        ...DEFAULT_CRON_FORM,
+        name: "new blank",
+        scheduleKind: "every",
+        everyAmount: "30",
+        everyUnit: "minutes",
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        payloadKind: "agentTurn",
+        payloadText: "do work",
+        payloadModel: "",
+        payloadThinking: "",
+      },
+    });
+
+    await addCronJob(state);
+
+    const addCall = findRequestCall(request.mock.calls, "cron.add");
+    // A new job never had a stored override, so a blank field stays omitted
+    // (no explicit null clear) rather than being mistaken for a cleared value.
+    expectNestedRecordFields(requestPayload(addCall), "payload", {
+      kind: "agentTurn",
+      message: "do work",
+      model: undefined,
+      thinking: undefined,
+    });
+  });
+
   it("does not submit stale announce delivery when unsupported", async () => {
     const request = vi.fn(async (method: string, _payload?: unknown) => {
       if (method === "cron.add") {

--- a/ui/src/ui/controllers/cron.ts
+++ b/ui/src/ui/controllers/cron.ts
@@ -631,8 +631,8 @@ function buildCronPayload(form: CronFormState) {
   const payload: {
     kind: "agentTurn";
     message: string;
-    model?: string;
-    thinking?: string;
+    model?: string | null;
+    thinking?: string | null;
     timeoutSeconds?: number;
     lightContext?: boolean;
   } = { kind: "agentTurn", message };
@@ -721,14 +721,22 @@ export async function addCronJob(state: CronState): Promise<boolean> {
       state.cronEditingJobId && form.payloadLocked && editingPayload?.kind === "command",
     );
     const payload = preserveLockedPayload ? undefined : buildCronPayload(form);
-    if (payload?.kind === "agentTurn") {
-      const existingLightContext =
-        editingPayload?.kind === "agentTurn" ? editingPayload.lightContext : undefined;
-      if (
-        !form.payloadLightContext &&
-        state.cronEditingJobId &&
-        existingLightContext !== undefined
-      ) {
+    if (
+      payload?.kind === "agentTurn" &&
+      state.cronEditingJobId &&
+      editingPayload?.kind === "agentTurn"
+    ) {
+      // When editing, a blanked field that previously held a stored override must
+      // send an explicit clear; an omitted key means "leave unchanged" on merge.
+      // The form only shows stored overrides (not inherited defaults), so a blank
+      // input with a stored value is an intentional clear.
+      if (!form.payloadModel.trim() && editingPayload.model !== undefined) {
+        payload.model = null;
+      }
+      if (!form.payloadThinking.trim() && editingPayload.thinking !== undefined) {
+        payload.thinking = null;
+      }
+      if (!form.payloadLightContext && editingPayload.lightContext !== undefined) {
         payload.lightContext = false;
       }
     }

--- a/ui/src/ui/e2e/chat-flow.e2e.test.ts
+++ b/ui/src/ui/e2e/chat-flow.e2e.test.ts
@@ -271,6 +271,50 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
     }
   });
 
+  it("keeps a targetless message-tool source reply beside the automatic final reply", async () => {
+    const context = await newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page);
+
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+
+      const prompt = "send progress through the message tool and then finish";
+      await page.locator(".agent-chat__composer-combobox textarea").fill(prompt);
+      await page.getByRole("button", { name: "Send message" }).click();
+
+      const sendRequest = await gateway.waitForRequest("chat.send");
+      const params = requireRecord(sendRequest.params);
+      expect(params).toMatchObject({ sessionKey: "main", message: prompt, deliver: false });
+      const runId = requireString(params.idempotencyKey, "chat send idempotency key");
+
+      await gateway.emitChatFinal({
+        runId,
+        text: "Visible progress from the targetless message tool.",
+      });
+      await page
+        .getByText("Visible progress from the targetless message tool.")
+        .waitFor({ timeout: 10_000 });
+
+      await gateway.emitChatFinal({ runId, text: "Visible automatic final reply." });
+      await page.getByText("Visible automatic final reply.").waitFor({ timeout: 10_000 });
+      const bubbleTexts = await page.locator(".chat-thread .chat-bubble").allTextContents();
+      for (const expectedText of [
+        prompt,
+        "Visible progress from the targetless message tool.",
+        "Visible automatic final reply.",
+      ]) {
+        expect(bubbleTexts.some((text) => text.includes(expectedText))).toBe(true);
+      }
+    } finally {
+      await closeBrowserContext(context);
+    }
+  });
+
   it("keeps the composer clear when a stale native input replay arrives after send", async () => {
     const context = await newBrowserContext({
       locale: "en-US",


### PR DESCRIPTION
Fixes #98261.

> 🤖 **AI-assisted (Claude Code).** This fix and its analysis were developed with Claude Code against a live local deployment; I'm filing it as the deployment owner reporting real-world impact rather than as the original author of the analysis. The evidence below is actual measured output, and the commit is co-authored accordingly. Happy to provide more traces or have the approach iterated on — flagging the assistance up front so reviewers know the context.

## What Problem This Solves

Two channel/identity-varying system-prompt sections are emitted into the **static, cacheable prefix** *above* `SYSTEM_PROMPT_CACHE_BOUNDARY` in `buildAgentSystemPrompt` (`src/agents/system-prompt.ts`):

1. **Exec-approval guidance** — `buildExecApprovalPromptGuidance(...)`, called inside the `## Tool Call Style` fallback. Its output branches on `inlineButtonsEnabled` / `runtimeCapabilities` / `runtimeChannel` (the CLI `/approve` line vs the native approval-card line).
2. **Authorized Senders** — `buildUserIdentitySection(ownerLine, isMinimal)`. `ownerLine` varies by owner/identity, and the whole section is dropped when `isMinimal` (cron/subagent).

Because both vary by channel/session, they **fork the cacheable prefix at ~token 1,460**, invalidating client-side prefix caching for the remaining ~17.8K tokens of the system prompt. On local models (llama.cpp / MLX / Ollama) where prefix caching is client-managed, the full system prompt is re-prefilled from scratch on any turn whose channel context differs from what's cached — i.e. **6–16 minute cold prefills** for interactive turns following background (cron/heartbeat) traffic.

Follow-on to #40256, which introduced `SYSTEM_PROMPT_CACHE_BOUNDARY` and moved Messaging/Voice/Reactions below it — but **missed these two sections**, so the prefix forks even earlier than #40256 addressed.

## Why This Change Was Made

The boundary contract (#40256): channel/session-varying content lives below `SYSTEM_PROMPT_CACHE_BOUNDARY` so the large stable workspace context stays byte-identical across turns. These two builders were missed by that relocation. This moves them into the existing below-boundary channel-guidance block, alongside Messaging/Voice/Reactions. It's a **pure cache-stability change with no behavioural difference** — the guidance is instructional and position-independent for correctness; only its position relative to the boundary changes.

## User Impact

- Shared cross-channel cacheable prefix: **~1,460 → ~15K+ tokens** (channel-independent).
- Post-cron interactive latency on local models: **minutes → seconds**.
- No behavioural change for any channel.

## Evidence

Validated on a local deployment (Qwen3.5-122B-A10B Q4_K_M on llama.cpp/ROCm, llama-swap front, OpenClaw 2026.6.10; triage on #98261 confirmed the leak is still present on `main` and v2026.6.11):

| Metric | Before (above boundary) | After (below boundary) |
|---|---:|---:|
| Shared cross-channel prefix | ~1,460 tok | ~15,486 tok |
| First message of the morning | 7m51s cold | 7m49s seed once, then warm |
| Subsequent interactive turns | minutes (after any cron) | 8–16 s warm |
| 13-step task | repeated cold prefills | 9 turns, 0 cold, ~18 s avg |

First divergence was traced to char ~5,854 via a per-request system-prompt diff (owner email redacted).

**Tests:** extended the existing #40256 boundary test in `src/agents/system-prompt.test.ts` to also assert the exec-approval guidance and `## Authorized Senders` now sit below `SYSTEM_PROMPT_CACHE_BOUNDARY`.

```
pnpm exec vitest run src/agents/system-prompt.test.ts   →  Test Files 1 passed, Tests 90 passed
tsc --noEmit                                            →  clean
```

### Optional follow-up (not in this PR)
A dev-time assertion that fails if any section emitted *above* the boundary varies across a representative `{channel, isMinimal, inlineButtonsEnabled}` matrix would prevent future channel-varying sections from silently leaking above the line (would have caught both #40256 and this). Happy to add if maintainers want it here.
