### PR TITLE
test(discord): clarify and guardrail gateway proxy selection

### DIFF
--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -927,12 +927,13 @@ Default slash command settings:
 
   <Accordion title="Gateway proxy">
     Route Discord gateway WebSocket traffic and startup REST lookups (application ID + allowlist resolution) through an HTTP(S) proxy with `channels.discord.proxy`.
+    Discord Gateway proxying is explicit; it does not inherit ambient proxy environment variables from the Gateway process. Proxy URLs must target loopback or exactly match the configured process proxy URL, such as `OPENCLAW_PROXY_URL`, `HTTP_PROXY`, `HTTPS_PROXY`, or `ALL_PROXY`.
 
 ```json5
 {
   channels: {
     discord: {
-      proxy: "http://proxy.example:8080",
+      proxy: "http://127.0.0.1:8080",
     },
   },
 }
@@ -946,7 +947,7 @@ Default slash command settings:
     discord: {
       accounts: {
         primary: {
-          proxy: "http://proxy.example:8080",
+          proxy: "http://127.0.0.1:8080",
         },
       },
     },

--- a/extensions/discord/src/client.proxy.test.ts
+++ b/extensions/discord/src/client.proxy.test.ts
@@ -2,7 +2,7 @@
 import http from "node:http";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { fetch as undiciFetch } from "undici";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDiscordRestClient } from "./client.js";
 import { createDiscordRequestClient } from "./proxy-request-client.js";
 
@@ -26,7 +26,12 @@ vi.mock("openclaw/plugin-sdk/fetch-runtime", async () => {
 
 describe("createDiscordRestClient proxy support", () => {
   beforeEach(() => {
+    vi.unstubAllEnvs();
     makeProxyFetchMock.mockClear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it("injects a custom fetch into RequestClient when a Discord proxy is configured", () => {
@@ -48,6 +53,110 @@ describe("createDiscordRestClient proxy support", () => {
     expect(makeProxyFetchMock).toHaveBeenCalledWith("http://127.0.0.1:8080");
     expect(requestClient.options?.fetch).toBe(makeProxyFetchMock.mock.results[0]?.value);
     expect(requestClient.customFetch).toBe(requestClient.options?.fetch);
+  });
+
+  it("accepts the configured process proxy DNS host", () => {
+    vi.stubEnv("HTTPS_PROXY", "http://mitm-proxy:8080");
+    const cfg = {
+      channels: {
+        discord: {
+          token: "Bot test-token",
+          proxy: "http://mitm-proxy:8080",
+        },
+      },
+    } as OpenClawConfig;
+
+    const { rest } = createDiscordRestClient({ cfg });
+    const requestClient = rest as unknown as {
+      customFetch?: typeof fetch;
+      options?: { fetch?: typeof fetch };
+    };
+
+    expect(makeProxyFetchMock).toHaveBeenCalledWith("http://mitm-proxy:8080");
+    expect(requestClient.options?.fetch).toBe(makeProxyFetchMock.mock.results[0]?.value);
+    expect(requestClient.customFetch).toBe(requestClient.options?.fetch);
+  });
+
+  it("accepts a proxy URL that matches ALL_PROXY", () => {
+    vi.stubEnv("ALL_PROXY", "http://mitm-proxy:8080");
+    const cfg = {
+      channels: {
+        discord: {
+          token: "Bot test-token",
+          proxy: "http://mitm-proxy:8080",
+        },
+      },
+    } as OpenClawConfig;
+
+    const { rest } = createDiscordRestClient({ cfg });
+    const requestClient = rest as unknown as {
+      customFetch?: typeof fetch;
+      options?: { fetch?: typeof fetch };
+    };
+
+    expect(makeProxyFetchMock).toHaveBeenCalledWith("http://mitm-proxy:8080");
+    expect(requestClient.options?.fetch).toBe(makeProxyFetchMock.mock.results[0]?.value);
+    expect(requestClient.customFetch).toBe(requestClient.options?.fetch);
+  });
+
+  it("rejects a configured process proxy host when credentials do not match", () => {
+    vi.stubEnv("HTTPS_PROXY", "http://user:secret@mitm-proxy:8080");
+    const cfg = {
+      channels: {
+        discord: {
+          token: "Bot test-token",
+          proxy: "http://mitm-proxy:8080",
+        },
+      },
+    } as OpenClawConfig;
+
+    const { rest } = createDiscordRestClient({ cfg });
+    const requestClient = rest as unknown as {
+      options?: { fetch?: typeof fetch };
+    };
+
+    expect(makeProxyFetchMock).not.toHaveBeenCalledWith("http://mitm-proxy:8080");
+    expect(requestClient.options?.fetch).toBeUndefined();
+  });
+
+  it("rejects a shadowed uppercase proxy env URL", () => {
+    vi.stubEnv("HTTPS_PROXY", "http://mitm-proxy:8080");
+    vi.stubEnv("https_proxy", "http://active-proxy:8080");
+    const cfg = {
+      channels: {
+        discord: {
+          token: "Bot test-token",
+          proxy: "http://mitm-proxy:8080",
+        },
+      },
+    } as OpenClawConfig;
+
+    const { rest } = createDiscordRestClient({ cfg });
+    const requestClient = rest as unknown as {
+      options?: { fetch?: typeof fetch };
+    };
+
+    expect(makeProxyFetchMock).not.toHaveBeenCalledWith("http://mitm-proxy:8080");
+    expect(requestClient.options?.fetch).toBeUndefined();
+  });
+
+  it("falls back to direct fetch when the Discord proxy URL is arbitrary DNS", () => {
+    const cfg = {
+      channels: {
+        discord: {
+          token: "Bot test-token",
+          proxy: "http://proxy.test:8080",
+        },
+      },
+    } as OpenClawConfig;
+
+    const { rest } = createDiscordRestClient({ cfg });
+    const requestClient = rest as unknown as {
+      options?: { fetch?: typeof fetch };
+    };
+
+    expect(makeProxyFetchMock).not.toHaveBeenCalledWith("http://proxy.test:8080");
+    expect(requestClient.options?.fetch).toBeUndefined();
   });
 
   it("does not inject fetch when no proxy is configured", () => {
@@ -86,12 +195,12 @@ describe("createDiscordRestClient proxy support", () => {
     expect(requestClient.options?.fetch).toBeUndefined();
   });
 
-  it("falls back to direct fetch when the Discord proxy URL is remote", () => {
+  it("falls back to direct fetch when the Discord proxy URL is a non-loopback IP", () => {
     const cfg = {
       channels: {
         discord: {
           token: "Bot test-token",
-          proxy: "http://proxy.test:8080",
+          proxy: "http://10.0.0.10:8080",
         },
       },
     } as OpenClawConfig;
@@ -101,7 +210,7 @@ describe("createDiscordRestClient proxy support", () => {
       options?: { fetch?: typeof fetch };
     };
 
-    expect(makeProxyFetchMock).not.toHaveBeenCalledWith("http://proxy.test:8080");
+    expect(makeProxyFetchMock).not.toHaveBeenCalledWith("http://10.0.0.10:8080");
     expect(requestClient.options?.fetch).toBeUndefined();
   });
 

--- a/extensions/discord/src/monitor/gateway-plugin.ts
+++ b/extensions/discord/src/monitor/gateway-plugin.ts
@@ -3,7 +3,11 @@ import { randomUUID } from "node:crypto";
 import type { Agent as HttpAgent } from "node:http";
 import { Agent as HttpsAgent } from "node:https";
 import type { DiscordAccountConfig } from "openclaw/plugin-sdk/config-contracts";
-import { createNodeProxyAgent } from "openclaw/plugin-sdk/fetch-runtime";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import {
+  createNodeProxyAgent,
+  resolveEnvHttpProxyAgentOptions,
+} from "openclaw/plugin-sdk/fetch-runtime";
 import {
   captureWsEvent,
   resolveEffectiveDebugProxyUrl,
@@ -383,6 +387,29 @@ export function waitForDiscordGatewayPluginRegistration(
   return registrationPromises.get(plugin as discordGateway.GatewayPlugin);
 }
 
+function createEnvProxyDiscordGatewayAgent(
+  runtime: RuntimeEnv,
+): DiscordGatewayWebSocketAgent | undefined {
+  const envProxyOptions = resolveEnvHttpProxyAgentOptions();
+  if (!envProxyOptions) {
+    return undefined;
+  }
+  try {
+    return createNodeProxyAgent({
+      mode: "env",
+      targetUrl: "wss://gateway.discord.gg",
+      protocol: "https",
+    });
+  } catch (err) {
+    runtime.error?.(
+      danger(
+        `discord: env proxy unavailable for gateway WebSocket; using direct agent: ${formatErrorMessage(err)}`,
+      ),
+    );
+    return undefined;
+  }
+}
+
 export function createDiscordGatewayPlugin(params: {
   discordConfig: DiscordAccountConfig;
   runtime: RuntimeEnv;
@@ -399,10 +426,21 @@ export function createDiscordGatewayPlugin(params: {
     env: process.env,
   });
   let fetchImpl = createDiscordGatewayMetadataFetch(debugProxySettings.enabled);
-  let wsAgent: DiscordGatewayWebSocketAgent = new HttpsAgent({
-    lookup: discordDnsLookup,
-  });
 
+  // Try env proxy first (HTTP_PROXY/HTTPS_PROXY)
+  let wsAgent: DiscordGatewayWebSocketAgent;
+  const envProxyAgent = createEnvProxyDiscordGatewayAgent(params.runtime);
+  if (envProxyAgent) {
+    wsAgent = envProxyAgent;
+    params.runtime.log?.("discord: gateway WebSocket using env proxy");
+  } else {
+    // Fallback to direct connection
+    wsAgent = new HttpsAgent({
+      lookup: discordDnsLookup,
+    });
+  }
+
+  // Explicit channels.discord.proxy overrides env
   if (proxy) {
     try {
       validateDiscordProxyUrl(proxy);

--- a/extensions/discord/src/monitor/gateway-plugin.ts
+++ b/extensions/discord/src/monitor/gateway-plugin.ts
@@ -3,11 +3,7 @@ import { randomUUID } from "node:crypto";
 import type { Agent as HttpAgent } from "node:http";
 import { Agent as HttpsAgent } from "node:https";
 import type { DiscordAccountConfig } from "openclaw/plugin-sdk/config-contracts";
-import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
-import {
-  createNodeProxyAgent,
-  resolveEnvHttpProxyAgentOptions,
-} from "openclaw/plugin-sdk/fetch-runtime";
+import { createNodeProxyAgent } from "openclaw/plugin-sdk/fetch-runtime";
 import {
   captureWsEvent,
   resolveEffectiveDebugProxyUrl,
@@ -387,29 +383,6 @@ export function waitForDiscordGatewayPluginRegistration(
   return registrationPromises.get(plugin as discordGateway.GatewayPlugin);
 }
 
-function createEnvProxyDiscordGatewayAgent(
-  runtime: RuntimeEnv,
-): DiscordGatewayWebSocketAgent | undefined {
-  const envProxyOptions = resolveEnvHttpProxyAgentOptions();
-  if (!envProxyOptions) {
-    return undefined;
-  }
-  try {
-    return createNodeProxyAgent({
-      mode: "env",
-      targetUrl: "wss://gateway.discord.gg",
-      protocol: "https",
-    });
-  } catch (err) {
-    runtime.error?.(
-      danger(
-        `discord: env proxy unavailable for gateway WebSocket; using direct agent: ${formatErrorMessage(err)}`,
-      ),
-    );
-    return undefined;
-  }
-}
-
 export function createDiscordGatewayPlugin(params: {
   discordConfig: DiscordAccountConfig;
   runtime: RuntimeEnv;
@@ -426,21 +399,10 @@ export function createDiscordGatewayPlugin(params: {
     env: process.env,
   });
   let fetchImpl = createDiscordGatewayMetadataFetch(debugProxySettings.enabled);
+  let wsAgent: DiscordGatewayWebSocketAgent = new HttpsAgent({
+    lookup: discordDnsLookup,
+  });
 
-  // Try env proxy first (HTTP_PROXY/HTTPS_PROXY)
-  let wsAgent: DiscordGatewayWebSocketAgent;
-  const envProxyAgent = createEnvProxyDiscordGatewayAgent(params.runtime);
-  if (envProxyAgent) {
-    wsAgent = envProxyAgent;
-    params.runtime.log?.("discord: gateway WebSocket using env proxy");
-  } else {
-    // Fallback to direct connection
-    wsAgent = new HttpsAgent({
-      lookup: discordDnsLookup,
-    });
-  }
-
-  // Explicit channels.discord.proxy overrides env
   if (proxy) {
     try {
       validateDiscordProxyUrl(proxy);

--- a/extensions/discord/src/monitor/provider.proxy.test.ts
+++ b/extensions/discord/src/monitor/provider.proxy.test.ts
@@ -181,6 +181,16 @@ vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
 }));
 
 describe("createDiscordGatewayPlugin", () => {
+  const proxyEnvKeys = [
+    "ALL_PROXY",
+    "HTTPS_PROXY",
+    "HTTP_PROXY",
+    "NO_PROXY",
+    "all_proxy",
+    "https_proxy",
+    "http_proxy",
+    "no_proxy",
+  ] as const;
   let createDiscordGatewayPlugin: typeof import("./gateway-plugin.js").createDiscordGatewayPlugin;
   let waitForDiscordGatewayPluginRegistration: typeof import("./gateway-plugin.js").waitForDiscordGatewayPluginRegistration;
 
@@ -322,6 +332,9 @@ describe("createDiscordGatewayPlugin", () => {
 
   beforeEach(() => {
     vi.unstubAllEnvs();
+    for (const key of proxyEnvKeys) {
+      vi.stubEnv(key, "");
+    }
     vi.stubEnv("OPENCLAW_DEBUG_PROXY_ENABLED", "");
     vi.stubEnv("OPENCLAW_DEBUG_PROXY_URL", "");
     vi.stubGlobal("fetch", globalFetchMock);
@@ -506,6 +519,86 @@ describe("createDiscordGatewayPlugin", () => {
     expect(runtime.error).not.toHaveBeenCalled();
   });
 
+  it("accepts the configured process proxy DNS host for gateway WebSocket", () => {
+    vi.stubEnv("HTTPS_PROXY", "http://mitm-proxy:8080");
+    const runtime = createRuntime();
+
+    const plugin = createDiscordGatewayPlugin({
+      discordConfig: { proxy: "http://mitm-proxy:8080" },
+      runtime,
+      testing: createProxyTestingOverrides(),
+    });
+
+    const createWebSocket = (plugin as unknown as { createWebSocket: (url: string) => unknown })
+      .createWebSocket;
+    createWebSocket("wss://gateway.discord.gg");
+
+    expect(wsProxyAgentSpy).toHaveBeenCalledWith("http://mitm-proxy:8080");
+    expect(webSocketSpy).toHaveBeenCalledWith("wss://gateway.discord.gg", {
+      agent: getLastProxyAgent(),
+      handshakeTimeout: 30_000,
+    });
+    expect(runtime.log).toHaveBeenCalledWith("discord: gateway proxy enabled");
+    expect(runtime.error).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the default gateway plugin when proxy is arbitrary DNS", () => {
+    const runtime = createRuntime();
+
+    const plugin = createDiscordGatewayPlugin({
+      discordConfig: { proxy: "http://proxy.test:8080" },
+      runtime,
+    });
+
+    expect(Object.getPrototypeOf(plugin)).not.toBe(GatewayPlugin.prototype);
+    expect(runtime.error).toHaveBeenCalledTimes(1);
+    expect(String(firstMockArg(runtime.error, "runtime.error"))).toContain(
+      "configured process proxy",
+    );
+    expect(runtime.log).not.toHaveBeenCalled();
+  });
+
+  it("keeps gateway WebSocket direct when only ambient proxy env is configured", () => {
+    vi.stubEnv("https_proxy", "env-proxy.test:8080");
+    const runtime = createRuntime();
+    const plugin = createDiscordGatewayPlugin({
+      discordConfig: {},
+      runtime,
+    });
+
+    const createWebSocket = (plugin as unknown as { createWebSocket: (url: string) => unknown })
+      .createWebSocket;
+    createWebSocket("wss://gateway.discord.gg");
+
+    expect(httpsAgentSpy).toHaveBeenCalledTimes(1);
+    expect(webSocketSpy).toHaveBeenCalledWith("wss://gateway.discord.gg", {
+      agent: getLastAgent(),
+      handshakeTimeout: 30_000,
+    });
+    expect(runtime.log).not.toHaveBeenCalled();
+  });
+
+  it("does not create env proxy agent when explicit gateway proxy is configured", () => {
+    vi.stubEnv("https_proxy", "http://env-proxy.test:8080");
+    const runtime = createRuntime();
+    const plugin = createDiscordGatewayPlugin({
+      discordConfig: { proxy: "http://127.0.0.1:8080" },
+      runtime,
+      testing: createProxyTestingOverrides(),
+    });
+
+    const createWebSocket = (plugin as unknown as { createWebSocket: (url: string) => unknown })
+      .createWebSocket;
+    createWebSocket("wss://gateway.discord.gg");
+
+    expect(webSocketSpy).toHaveBeenCalledWith("wss://gateway.discord.gg", {
+      agent: getLastProxyAgent(),
+      handshakeTimeout: 30_000,
+    });
+    expect(runtime.log).toHaveBeenCalledTimes(1);
+    expect(runtime.log).toHaveBeenCalledWith("discord: gateway proxy enabled");
+  });
+
   it("falls back to the default gateway plugin when proxy is invalid", () => {
     const runtime = createRuntime();
 
@@ -575,17 +668,19 @@ describe("createDiscordGatewayPlugin", () => {
     expect(runtime.error).not.toHaveBeenCalled();
   });
 
-  it("falls back to the default gateway plugin when proxy is remote", () => {
+  it("falls back to the default gateway plugin when proxy is a non-loopback IP", () => {
     const runtime = createRuntime();
 
     const plugin = createDiscordGatewayPlugin({
-      discordConfig: { proxy: "http://proxy.test:8080" },
+      discordConfig: { proxy: "http://10.0.0.10:8080" },
       runtime,
     });
 
     expect(Object.getPrototypeOf(plugin)).not.toBe(GatewayPlugin.prototype);
     expect(runtime.error).toHaveBeenCalledTimes(1);
-    expect(String(firstMockArg(runtime.error, "runtime.error"))).toContain("loopback host");
+    expect(String(firstMockArg(runtime.error, "runtime.error"))).toContain(
+      "configured process proxy",
+    );
     expect(runtime.log).not.toHaveBeenCalled();
   });
 

--- a/extensions/discord/src/monitor/provider.rest-proxy.test.ts
+++ b/extensions/discord/src/monitor/provider.rest-proxy.test.ts
@@ -190,6 +190,41 @@ describe("resolveDiscordRestFetch", () => {
     expect(runtime.error).not.toHaveBeenCalled();
   });
 
+  it("uses undici proxy fetch when the configured proxy is the process proxy", async () => {
+    vi.stubEnv("HTTPS_PROXY", "http://mitm-proxy:8080");
+    const runtime = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(),
+    } as const;
+    undiciFetchMock.mockClear().mockResolvedValue(new Response("ok", { status: 200 }));
+    proxyAgentSpy.mockClear();
+    const fetcher = resolveDiscordRestFetch("http://mitm-proxy:8080", runtime);
+
+    await fetcher("https://discord.com/api/v10/oauth2/applications/@me");
+
+    const proxyOptions = objectArgAt(proxyAgentSpy, 0, 0);
+    expect(proxyOptions.uri).toBe("http://mitm-proxy:8080");
+    expect(proxyOptions.allowH2).toBe(false);
+    expect(runtime.log).toHaveBeenCalledWith("discord: rest proxy enabled");
+    expect(runtime.error).not.toHaveBeenCalled();
+  });
+
+  it("falls back to global fetch when proxy URL is arbitrary DNS", () => {
+    const runtime = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(),
+    } as const;
+
+    const fetcher = resolveDiscordRestFetch("http://proxy.test:8080", runtime);
+
+    expect(fetcher).toBe(fetch);
+    expect(proxyAgentSpy).not.toHaveBeenCalled();
+    expect(String(argAt(runtime.error, 0, 0))).toContain("configured process proxy");
+    expect(runtime.log).not.toHaveBeenCalled();
+  });
+
   it("uses managed proxy CA trust when a configured REST proxy matches the managed proxy", async () => {
     const caFile = writeTempCa("discord-rest-configured-proxy-ca");
     vi.stubEnv("HTTPS_PROXY", "https://127.0.0.1:8443");
@@ -228,18 +263,18 @@ describe("resolveDiscordRestFetch", () => {
     expect(runtime.log).not.toHaveBeenCalled();
   });
 
-  it("falls back to global fetch when proxy URL is remote", () => {
+  it("falls back to global fetch when proxy URL is a non-loopback IP", () => {
     const runtime = {
       log: vi.fn(),
       error: vi.fn(),
       exit: vi.fn(),
     } as const;
 
-    const fetcher = resolveDiscordRestFetch("http://proxy.test:8080", runtime);
+    const fetcher = resolveDiscordRestFetch("http://10.0.0.10:8080", runtime);
 
     expect(fetcher).toBe(fetch);
     expect(proxyAgentSpy).not.toHaveBeenCalled();
-    expect(String(argAt(runtime.error, 0, 0))).toContain("loopback host");
+    expect(String(argAt(runtime.error, 0, 0))).toContain("configured process proxy");
     expect(runtime.log).not.toHaveBeenCalled();
   });
 

--- a/extensions/discord/src/proxy-fetch.ts
+++ b/extensions/discord/src/proxy-fetch.ts
@@ -66,8 +66,8 @@ export function validateDiscordProxyUrl(proxyUrl: string): string {
   if (!["http:", "https:"].includes(parsed.protocol)) {
     throw new Error("Proxy URL must use http or https");
   }
-  if (!isLoopbackProxyHostname(parsed.hostname)) {
-    throw new Error("Proxy URL must target a loopback host");
+  if (!isLoopbackProxyHostname(parsed.hostname) && !matchesConfiguredProcessProxy(parsed)) {
+    throw new Error("Proxy URL must target loopback or the configured process proxy");
   }
   return proxyUrl;
 }
@@ -90,4 +90,69 @@ function isLoopbackProxyHostname(hostname: string): boolean {
     return bracketless === "::1" || bracketless === "0:0:0:0:0:0:0:1";
   }
   return false;
+}
+
+function matchesConfiguredProcessProxy(proxyUrl: URL): boolean {
+  for (const configured of configuredDiscordProxyUrls(process.env)) {
+    if (configured && proxyEndpointMatches(proxyUrl, configured)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function configuredDiscordProxyUrls(env: NodeJS.ProcessEnv): string[] {
+  return [normalizeProxyEnvValue(env.OPENCLAW_PROXY_URL), resolveHttpsProxyEnvUrl(env)].filter(
+    (value): value is string => typeof value === "string",
+  );
+}
+
+function resolveHttpsProxyEnvUrl(env: NodeJS.ProcessEnv): string | undefined {
+  const httpsProxy = proxyEnvValueWithLowercasePrecedence(env.https_proxy, env.HTTPS_PROXY);
+  const httpProxy = proxyEnvValueWithLowercasePrecedence(env.http_proxy, env.HTTP_PROXY);
+  const allProxy = proxyEnvValueWithLowercasePrecedence(env.all_proxy, env.ALL_PROXY);
+  return httpsProxy ?? httpProxy ?? allProxy ?? undefined;
+}
+
+function proxyEnvValueWithLowercasePrecedence(
+  lowercaseValue: string | undefined,
+  uppercaseValue: string | undefined,
+): string | null | undefined {
+  const lowercase = normalizeProxyEnvValue(lowercaseValue);
+  return lowercase !== undefined ? lowercase : normalizeProxyEnvValue(uppercaseValue);
+}
+
+function normalizeProxyEnvValue(value: string | undefined): string | null | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function proxyEndpointMatches(proxyUrl: URL, configuredProxyUrl: string): boolean {
+  let configured: URL;
+  try {
+    configured = new URL(configuredProxyUrl);
+  } catch {
+    return false;
+  }
+  if (!["http:", "https:"].includes(configured.protocol)) {
+    return false;
+  }
+  return normalizedProxyUrl(proxyUrl) === normalizedProxyUrl(configured);
+}
+
+function normalizedProxyUrl(proxyUrl: URL): string {
+  const normalized = new URL(proxyUrl.href);
+  normalized.hostname = normalizeLowercaseStringOrEmpty(normalized.hostname);
+  normalized.port = effectiveProxyPort(normalized);
+  return normalized.href;
+}
+
+function effectiveProxyPort(proxyUrl: URL): string {
+  if (proxyUrl.port) {
+    return proxyUrl.port;
+  }
+  return proxyUrl.protocol === "https:" ? "443" : "80";
 }

--- a/extensions/discord/src/send.webhook.proxy.test.ts
+++ b/extensions/discord/src/send.webhook.proxy.test.ts
@@ -1,6 +1,6 @@
 // Discord tests cover send.webhook.proxy plugin behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { DiscordError, RateLimitError } from "./internal/rest-errors.js";
 import { sendWebhookMessageDiscord } from "./send.webhook.js";
 
@@ -40,8 +40,13 @@ function cancelTrackedResponse(
 
 describe("sendWebhookMessageDiscord proxy support", () => {
   beforeEach(() => {
+    vi.unstubAllEnvs();
     makeProxyFetchMock.mockReset();
     vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it("falls back to global fetch when the Discord proxy URL is invalid", async () => {
@@ -101,7 +106,35 @@ describe("sendWebhookMessageDiscord proxy support", () => {
     expect(proxiedFetch).toHaveBeenCalledOnce();
   });
 
-  it("uses global fetch when the Discord proxy URL is remote", async () => {
+  it("uses proxy fetch when the Discord proxy is the process proxy", async () => {
+    vi.stubEnv("HTTPS_PROXY", "http://mitm-proxy:8080");
+    const proxiedFetch = vi
+      .fn()
+      .mockResolvedValue(new Response(JSON.stringify({ id: "msg-dns" }), { status: 200 }));
+    makeProxyFetchMock.mockReturnValue(proxiedFetch);
+
+    const cfg = {
+      channels: {
+        discord: {
+          token: "Bot test-token",
+          proxy: "http://mitm-proxy:8080",
+        },
+      },
+    } as OpenClawConfig;
+
+    await sendWebhookMessageDiscord("hello", {
+      cfg,
+      accountId: "default",
+      webhookId: "123",
+      webhookToken: "abc",
+      wait: true,
+    });
+
+    expect(makeProxyFetchMock).toHaveBeenCalledWith("http://mitm-proxy:8080");
+    expect(proxiedFetch).toHaveBeenCalledOnce();
+  });
+
+  it("uses global fetch when the Discord proxy URL is arbitrary DNS", async () => {
     const globalFetchMock = vi
       .spyOn(globalThis, "fetch")
       .mockResolvedValue(new Response(JSON.stringify({ id: "msg-remote" }), { status: 200 }));
@@ -124,6 +157,33 @@ describe("sendWebhookMessageDiscord proxy support", () => {
     });
 
     expect(makeProxyFetchMock).not.toHaveBeenCalledWith("http://proxy.test:8080");
+    expect(globalFetchMock).toHaveBeenCalled();
+    globalFetchMock.mockRestore();
+  });
+
+  it("uses global fetch when the Discord proxy URL is a non-loopback IP", async () => {
+    const globalFetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(JSON.stringify({ id: "msg-remote" }), { status: 200 }));
+
+    const cfg = {
+      channels: {
+        discord: {
+          token: "Bot test-token",
+          proxy: "http://10.0.0.10:8080",
+        },
+      },
+    } as OpenClawConfig;
+
+    await sendWebhookMessageDiscord("hello", {
+      cfg,
+      accountId: "default",
+      webhookId: "123",
+      webhookToken: "abc",
+      wait: true,
+    });
+
+    expect(makeProxyFetchMock).not.toHaveBeenCalledWith("http://10.0.0.10:8080");
     expect(globalFetchMock).toHaveBeenCalled();
     globalFetchMock.mockRestore();
   });


### PR DESCRIPTION
## What Problem This Solves

Restricted Kubernetes/OpenShift deployments need Discord Gateway and Discord REST traffic to leave the Gateway pod through the managed proxy, not through broad direct `:443` egress.

This PR intentionally keeps Discord Gateway proxying explicit. Discord does not auto-inherit ambient `HTTP_PROXY` / `HTTPS_PROXY` / `ALL_PROXY` for Gateway sessions. Instead, deployments configure `channels.discord.proxy`, and OpenClaw now permits a non-loopback proxy URL only when it exactly matches the effective configured process proxy URL.

That gives operators a safe MITM proxy path for Discord without accepting arbitrary remote proxy hosts in Discord config.

## Why This Change Was Made

The existing Discord proxy validator only accepted loopback proxy hosts. That blocked operator-managed proxy services such as:

```json5
{
  channels: {
    discord: {
      proxy: "http://some-proxy:8080",
    },
  },
}
```

The new validation allows this only when the configured proxy matches the effective process proxy endpoint, including normalized full URL, credentials, port, and lower/upper-case env precedence. Arbitrary DNS hosts and non-loopback IPs remain rejected.

## User Impact

Users in restricted-egress environments can run Discord through a configured proxy without granting broad Gateway pod `:443` egress.

Supported path:

```json5
{
  channels: {
    discord: {
      proxy: "http://some-proxy:8080",
    },
  },
}
```

Deployment environments that set `HTTPS_PROXY=http://higgins-proxy:8080` can use the same endpoint explicitly in `channels.discord.proxy`. The Gateway does not silently opt into proxying just because proxy env vars are present.

## Evidence

### Automated Tests

Focused local tests passed:

```sh
node scripts/run-vitest.mjs \
  extensions/discord/src/client.proxy.test.ts \
  extensions/discord/src/send.webhook.proxy.test.ts \
  extensions/discord/src/monitor/provider.proxy.test.ts \
  extensions/discord/src/monitor/provider.rest-proxy.test.ts
```

`git diff --check` passed.

Autoreview passed after fixes:

```text
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.86)
```

### Real Behavior Proof

Environment: K8s cluster, namespace `sallyom-claw`, Claw `higgins`, Discord test server `Test Claws`, bot `Test`.

Image under test:

```text
init:init-volume=quay.io/sallyom/openclaw:latest policy=Always
init:init-config=quay.io/sallyom/openclaw:latest policy=Always
container:gateway=quay.io/sallyom/openclaw:latest policy=Always
```

The Discord plugin loaded from the rebuilt OpenClaw image:

```json
{
  "source": "/app/dist/extensions/discord/index.js",
  "origin": "bundled",
  "status": "loaded"
}
```

Gateway logs showed both proxy paths enabled:

```text
[discord] [default] starting provider
[discord] rest proxy enabled
[discord] gateway proxy enabled
[gateway] ready
[discord] client initialized as 1500860555307520212; awaiting gateway readiness
[discord] [default] Discord bot probe resolved @Test
```

Discord channel status showed the bot connected:

```json
{
  "channels": {
    "discord": {
      "configured": true,
      "running": true,
      "lastError": null
    }
  },
  "channelAccounts": {
    "discord": [
      {
        "accountId": "default",
        "running": true,
        "connected": true,
        "tokenStatus": "available",
        "bot": {
          "username": "Test"
        }
      }
    ]
  }
}
```

The Gateway egress NetworkPolicy had no broad `:443` rule. It allowed only the proxy pod on `:8080` plus DNS:

```yaml
egress:
- ports:
  - port: 8080
    protocol: TCP
  to:
  - podSelector:
      matchLabels:
        app: claw-proxy
        claw.sandbox.com/instance: higgins
- ports:
  - port: 53
    protocol: UDP
  - port: 53
    protocol: TCP
  - port: 5353
    protocol: UDP
  - port: 5353
    protocol: TCP
  to:
  - namespaceSelector: {}
```

A live Discord REST proof message was posted through the MITM proxy:

```json
{
  "proxy": "http://some-proxy:8080",
  "guild": "Test",
  "textChannel": "general",
  "messageCreated": true,
  "content": "OpenClaw final Discord proxy proof 2026-07-01T23:17:06.190Z"
}
```

Discord status then showed inbound Gateway activity:

```json
{
  "connected": true,
  "lastInboundAt": 1782947826282,
  "lastTransportActivityAt": 1782947816644,
  "lastError": null
}
```

## Related

- Related to #98266, but this PR does not implement ambient env proxy fallback. Maintainer decision: use explicit `channels.discord.proxy` for token-bearing Discord Gateway routing.
- Related to #60035 for broader proxy configuration behavior.
