### PR TITLE
fix(gateway): strip provider defaults for config.patch

### DIFF
--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -859,7 +859,26 @@ export const configHandlers: GatewayRequestHandlers = {
       });
       return;
     }
-    const validated = validateConfigObjectWithPlugins(restoredMerge.result);
+    const validationCandidate = stripBundledProviderRuntimeDefaults({
+      candidate: restoredMerge.result,
+      sourceConfig: snapshot.sourceConfig,
+    });
+    const sourceValidated = validateConfigObjectRawWithPlugins(validationCandidate);
+    if (!sourceValidated.ok) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          summarizeConfigValidationIssues(sourceValidated.issues),
+          {
+            details: { issues: sourceValidated.issues },
+          },
+        ),
+      );
+      return;
+    }
+    const validated = validateConfigObjectWithPlugins(validationCandidate);
     if (!validated.ok) {
       respond(
         false,
@@ -870,6 +889,7 @@ export const configHandlers: GatewayRequestHandlers = {
       );
       return;
     }
+    const writeConfig = validationCandidate as OpenClawConfig;
     const preparedSecretsSnapshot = await ensureResolvableSecretRefsOrRespond({
       config: validated.config,
       respond,
@@ -908,7 +928,7 @@ export const configHandlers: GatewayRequestHandlers = {
     const writeResult = await commitGatewayConfigWrite({
       snapshot,
       writeOptions,
-      nextConfig: validated.config,
+      nextConfig: writeConfig,
       context,
       disconnectSharedAuthClients,
     });

--- a/src/gateway/server.config-patch.test.ts
+++ b/src/gateway/server.config-patch.test.ts
@@ -449,6 +449,78 @@ describe("gateway config methods", () => {
     expect(after.payload?.hash).toBe(current.payload?.hash);
   });
 
+  it("accepts config.patch when bundled provider baseUrl was only defaulted", async () => {
+    const { createConfigIO, resetConfigRuntimeState } = await import("../config/config.js");
+    const configPath = createConfigIO().configPath;
+    try {
+      await writeJsonFile(configPath, {
+        models: {
+          providers: {
+            openai: {
+              agentRuntime: { id: "openclaw" },
+            },
+          },
+        },
+      });
+      resetConfigRuntimeState();
+
+      const current = await getCurrentConfigObject();
+      const res = await rpcReq<{
+        ok?: boolean;
+        error?: { message?: string };
+      }>(requireWs(), "config.patch", {
+        raw: JSON.stringify({ gateway: { port: 19003 } }),
+        baseHash: current.hash,
+      });
+
+      expect(res.error).toBeUndefined();
+      expect(res.ok).toBe(true);
+      const persisted = await fs.readFile(configPath, "utf-8");
+      expect(persisted).toContain('"port": 19003');
+      expect(persisted).not.toContain('"baseUrl"');
+    } finally {
+      await fs.rm(configPath, { force: true });
+      resetConfigRuntimeState();
+    }
+  });
+
+  it("preserves authored empty bundled provider models during config.patch", async () => {
+    const { createConfigIO, resetConfigRuntimeState } = await import("../config/config.js");
+    const configPath = createConfigIO().configPath;
+    try {
+      await writeJsonFile(configPath, {
+        models: {
+          providers: {
+            openai: {
+              agentRuntime: { id: "openclaw" },
+              models: [],
+            },
+          },
+        },
+      });
+      resetConfigRuntimeState();
+
+      const current = await getCurrentConfigObject();
+      const res = await rpcReq<{
+        ok?: boolean;
+        error?: { message?: string };
+      }>(requireWs(), "config.patch", {
+        raw: JSON.stringify({ gateway: { port: 19004 } }),
+        baseHash: current.hash,
+      });
+
+      expect(res.error).toBeUndefined();
+      expect(res.ok).toBe(true);
+      const persisted = JSON.parse(await fs.readFile(configPath, "utf-8")) as {
+        models?: { providers?: { openai?: { models?: unknown } } };
+      };
+      expect(persisted.models?.providers?.openai?.models).toEqual([]);
+    } finally {
+      await fs.rm(configPath, { force: true });
+      resetConfigRuntimeState();
+    }
+  });
+
   it("rejects config.patch when raw is null", async () => {
     const res = await rpcReq<{ ok?: boolean }>(requireWs(), "config.patch", {
       raw: "null",


### PR DESCRIPTION
Closes #98270.

### What Problem This Solves
`config.patch` restored gateway config through validated runtime defaults, so bundled provider defaults such as empty `baseUrl`/`models` could make unrelated source config patches fail or get written back into the user's config.

### Evidence
At PR head `307eca7c5e`, the focused gateway-server integration suite starts the gateway test server, calls the real `config.patch` RPC, and verifies persisted config output. It covers the original defaulted-`baseUrl` failure and a compatibility regression where a source-authored `models: []` must survive an unrelated patch.

Terminal result: `src/gateway/server.config-patch.test.ts` passed with 36 tests, including the two `config.patch` provider-default cases.

Live gateway proof from a temporary auth-none loopback gateway whose source config omitted `models.providers.openai.baseUrl` and `models.providers.openai.models`:

```text
gateway config.get ok
runtime openai provider baseUrl="" modelsLength=0
base hash 0a0d7cc85ab68b0862a7188032929492a518537e275873990c5376e388875e5c
gateway config.patch result: response ok=true error=none
persisted auth.cooldowns.billingBackoffHours=7
persisted openai has baseUrl=false models=false
```
