### PR TITLE
fix(browser): persist managed Chrome cookies across restarts

### DIFF
--- a/extensions/browser/src/browser/chrome.internal.test.ts
+++ b/extensions/browser/src/browser/chrome.internal.test.ts
@@ -418,18 +418,36 @@ describe("chrome.ts internal", () => {
     });
 
     it("adds --disable-dev-shm-usage on linux", () => {
-      const originalPlatform = process.platform;
-      Object.defineProperty(process, "platform", { value: "linux" });
-      try {
-        const args = buildOpenClawChromeLaunchArgs({
-          resolved: baseResolved(),
-          profile: baseProfile,
-          userDataDir: "/tmp/foo",
-        });
-        expect(args).toContain("--disable-dev-shm-usage");
-      } finally {
-        Object.defineProperty(process, "platform", { value: originalPlatform });
-      }
+      const args = buildOpenClawChromeLaunchArgs({
+        resolved: baseResolved(),
+        profile: baseProfile,
+        userDataDir: "/tmp/foo",
+        platform: "linux",
+      });
+      expect(args).toContain("--disable-dev-shm-usage");
+      expect(args).not.toContain("--use-mock-keychain");
+    });
+
+    it("uses a non-interactive keychain for isolated managed profiles on macOS", () => {
+      const args = buildOpenClawChromeLaunchArgs({
+        resolved: baseResolved(),
+        profile: baseProfile,
+        userDataDir: "/tmp/foo",
+        platform: "darwin",
+        useMockKeychain: true,
+      });
+      expect(args).toContain("--use-mock-keychain");
+      expect(args).not.toContain("--disable-dev-shm-usage");
+    });
+
+    it("keeps existing macOS profiles on their original keychain", () => {
+      const args = buildOpenClawChromeLaunchArgs({
+        resolved: baseResolved(),
+        profile: baseProfile,
+        userDataDir: "/tmp/foo",
+        platform: "darwin",
+      });
+      expect(args).not.toContain("--use-mock-keychain");
     });
 
     it("propagates extraArgs", () => {
@@ -1138,10 +1156,12 @@ describe("chrome.ts internal", () => {
     it("escalates to SIGKILL when CDP keeps reporting reachable past the deadline", async () => {
       vi.stubGlobal(
         "fetch",
-        vi.fn().mockResolvedValue({
-          ok: true,
-          json: async () => ({ webSocketDebuggerUrl: "ws://127.0.0.1/devtools" }),
-        } as unknown as Response),
+        vi.fn(
+          async () =>
+            new Response(JSON.stringify({ webSocketDebuggerUrl: "ws://127.0.0.1/devtools" }), {
+              headers: { "content-type": "application/json" },
+            }),
+        ),
       );
       const proc = makeFakeProc();
       await stopOpenClawChrome(

--- a/extensions/browser/src/browser/chrome.profile-decoration.ts
+++ b/extensions/browser/src/browser/chrome.profile-decoration.ts
@@ -37,6 +37,10 @@ function readNestedRecord(root: unknown, key: string): Record<string, unknown> |
   return asRecord(asRecord(root)?.[key]);
 }
 
+function readDefaultProfileInfo(localState: unknown): Record<string, unknown> | null {
+  return readNestedRecord(readNestedRecord(asRecord(localState)?.profile, "info_cache"), "Default");
+}
+
 function setDeep(obj: Record<string, unknown>, keys: string[], value: unknown) {
   if (keys.length === 0) {
     return;
@@ -76,8 +80,7 @@ export function isProfileDecorated(
   const preferencesPath = path.join(userDataDir, "Default", "Preferences");
 
   const localState = safeReadJson(localStatePath);
-  const profile = localState?.profile;
-  const info = readNestedRecord(readNestedRecord(profile, "info_cache"), "Default");
+  const info = readDefaultProfileInfo(localState);
 
   const prefs = safeReadJson(preferencesPath);
   const browserTheme = readNestedRecord(prefs?.browser, "theme");
@@ -111,13 +114,19 @@ export function isProfileDecorated(
   return nameOk && localSeedOk && prefOk && downloadOk;
 }
 
+/** Return whether this profile was initialized with Chromium's automation keychain. */
+export function usesOpenClawMockKeychain(userDataDir: string): boolean {
+  const localState = safeReadJson(path.join(userDataDir, "Local State"));
+  return readDefaultProfileInfo(localState)?.openclaw_mock_keychain === true;
+}
+
 /**
  * Best-effort profile decoration (name + lobster-orange). Chrome preference keys
  * vary by version; we keep this conservative and idempotent.
  */
 export function decorateOpenClawProfile(
   userDataDir: string,
-  opts?: { name?: string; color?: string; downloadDir?: string },
+  opts?: { name?: string; color?: string; downloadDir?: string; mockKeychain?: boolean },
 ) {
   const desiredName = opts?.name ?? DEFAULT_OPENCLAW_BROWSER_PROFILE_NAME;
   const desiredColor = (opts?.color ?? DEFAULT_OPENCLAW_BROWSER_COLOR).toUpperCase();
@@ -131,6 +140,11 @@ export function decorateOpenClawProfile(
   setDeep(localState, ["profile", "info_cache", "Default", "name"], desiredName);
   setDeep(localState, ["profile", "info_cache", "Default", "shortcut_name"], desiredName);
   setDeep(localState, ["profile", "info_cache", "Default", "user_name"], desiredName);
+  if (opts?.mockKeychain) {
+    // Chrome preserves extra fields in this per-profile dictionary. Recording
+    // the key source here keeps later launches on the same encryption backend.
+    setDeep(localState, ["profile", "info_cache", "Default", "openclaw_mock_keychain"], true);
+  }
   // Color keys are best-effort (Chrome changes these frequently).
   setDeep(localState, ["profile", "info_cache", "Default", "profile_color"], desiredColor);
   setDeep(localState, ["profile", "info_cache", "Default", "user_color"], desiredColor);

--- a/extensions/browser/src/browser/chrome.test.ts
+++ b/extensions/browser/src/browser/chrome.test.ts
@@ -29,6 +29,7 @@ import {
   resolveBrowserExecutableForPlatform,
   stopOpenClawChrome,
 } from "./chrome.js";
+import { usesOpenClawMockKeychain } from "./chrome.profile-decoration.js";
 import {
   DEFAULT_OPENCLAW_BROWSER_COLOR,
   DEFAULT_OPENCLAW_BROWSER_PROFILE_NAME,
@@ -230,6 +231,22 @@ describe("browser chrome profile decoration", () => {
         DEFAULT_DOWNLOAD_DIR,
       ),
     ).toBe(true);
+  });
+
+  it("records the managed profile keychain backend without changing existing profiles", async () => {
+    const userDataDir = await createUserDataDir();
+    decorateOpenClawProfile(userDataDir, {
+      color: DEFAULT_OPENCLAW_BROWSER_COLOR,
+      mockKeychain: true,
+    });
+
+    expect(usesOpenClawMockKeychain(userDataDir)).toBe(true);
+    decorateOpenClawProfile(userDataDir, { color: DEFAULT_OPENCLAW_BROWSER_COLOR });
+    expect(usesOpenClawMockKeychain(userDataDir)).toBe(true);
+
+    const existingUserDataDir = await createUserDataDir();
+    decorateOpenClawProfile(existingUserDataDir, { color: DEFAULT_OPENCLAW_BROWSER_COLOR });
+    expect(usesOpenClawMockKeychain(existingUserDataDir)).toBe(false);
   });
 
   it("treats missing managed download prefs as undecorated when required", async () => {
@@ -874,15 +891,64 @@ describe("browser chrome helpers", () => {
     expect(proc.kill).toHaveBeenCalledWith("SIGTERM");
   });
 
-  it("stopOpenClawChrome escalates to SIGKILL when CDP stays reachable", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue(jsonResponse({ webSocketDebuggerUrl: "ws://127.0.0.1/devtools" })),
-    );
-    const proc = makeChromeTestProc();
-    await stopChromeWithProc(proc, 1);
-    expect(proc.kill).toHaveBeenNthCalledWith(1, "SIGTERM");
-    expect(proc.kill).toHaveBeenNthCalledWith(2, "SIGKILL");
+  it("stopOpenClawChrome asks Chrome to close gracefully before sending a signal", async () => {
+    let closeRequested = false;
+    await withMockChromeCdpServer({
+      wsPath: "/devtools/browser/graceful-stop",
+      onConnection: (wss) => {
+        wss.on("connection", (ws) => {
+          ws.on("message", (data) => {
+            const req = JSON.parse(rawDataToString(data)) as { id: number; method: string };
+            expect(req.method).toBe("Browser.close");
+            closeRequested = true;
+            ws.send(JSON.stringify({ id: req.id, result: {} }));
+          });
+        });
+      },
+      run: async (baseUrl) => {
+        const browserWsUrl = `${baseUrl.replace("http://", "ws://")}/devtools/browser/graceful-stop`;
+        vi.stubGlobal(
+          "fetch",
+          vi.fn(async () => {
+            if (closeRequested) {
+              throw new Error("down");
+            }
+            return jsonResponse({ webSocketDebuggerUrl: browserWsUrl });
+          }),
+        );
+        const proc = makeChromeTestProc();
+        await stopChromeWithProc(proc, 20);
+
+        expect(closeRequested).toBe(true);
+        expect(proc.kill).not.toHaveBeenCalled();
+      },
+    });
+  });
+
+  it("stopOpenClawChrome escalates when graceful close leaves CDP reachable", async () => {
+    await withMockChromeCdpServer({
+      wsPath: "/devtools/browser/stuck-stop",
+      onConnection: (wss) => {
+        wss.on("connection", (ws) => {
+          ws.on("message", (data) => {
+            const req = JSON.parse(rawDataToString(data)) as { id: number; method: string };
+            expect(req.method).toBe("Browser.close");
+            ws.send(JSON.stringify({ id: req.id, result: {} }));
+          });
+        });
+      },
+      run: async (baseUrl) => {
+        const browserWsUrl = `${baseUrl.replace("http://", "ws://")}/devtools/browser/stuck-stop`;
+        vi.stubGlobal(
+          "fetch",
+          vi.fn(async () => jsonResponse({ webSocketDebuggerUrl: browserWsUrl })),
+        );
+        const proc = makeChromeTestProc();
+        await stopChromeWithProc(proc, 1);
+        expect(proc.kill).toHaveBeenNthCalledWith(1, "SIGTERM");
+        expect(proc.kill).toHaveBeenNthCalledWith(2, "SIGKILL");
+      },
+    });
   });
 
   it("stopOpenClawChrome releases the managed-proxy CDP bypass exactly once on a double stop", async () => {
@@ -902,7 +968,7 @@ describe("browser chrome helpers", () => {
   it("stopOpenClawChrome still releases the bypass when the SIGKILL fallback fires", async () => {
     vi.stubGlobal(
       "fetch",
-      vi.fn().mockResolvedValue(jsonResponse({ webSocketDebuggerUrl: "ws://127.0.0.1/devtools" })),
+      vi.fn(async () => jsonResponse({ webSocketDebuggerUrl: "ws://127.0.0.1/devtools" })),
     );
     const proc = makeChromeTestProc();
     const release = vi.fn();

--- a/extensions/browser/src/browser/chrome.test.ts
+++ b/extensions/browser/src/browser/chrome.test.ts
@@ -138,10 +138,17 @@ async function stopChromeWithProc(proc: ReturnType<typeof makeChromeTestProc>, t
   );
 }
 
-function makeChromeTestProc(overrides?: Partial<{ killed: boolean; exitCode: number | null }>) {
+function makeChromeTestProc(
+  overrides?: Partial<{
+    killed: boolean;
+    exitCode: number | null;
+    signalCode: NodeJS.Signals | null;
+  }>,
+) {
   return {
     killed: overrides?.killed ?? false,
     exitCode: overrides?.exitCode ?? null,
+    signalCode: overrides?.signalCode ?? null,
     kill: vi.fn(),
   };
 }
@@ -881,6 +888,19 @@ describe("browser chrome helpers", () => {
   it("stopOpenClawChrome no-ops when process is already killed", async () => {
     const proc = makeChromeTestProc({ killed: true });
     await stopChromeWithProc(proc, 10);
+    expect(proc.kill).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { label: "exited", proc: makeChromeTestProc({ exitCode: 0 }) },
+    { label: "signaled", proc: makeChromeTestProc({ signalCode: "SIGTERM" }) },
+  ])("does not close a reused CDP port after the tracked process has $label", async ({ proc }) => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await stopChromeWithProc(proc, 10);
+
+    expect(fetchMock).not.toHaveBeenCalled();
     expect(proc.kill).not.toHaveBeenCalled();
   });
 

--- a/extensions/browser/src/browser/chrome.ts
+++ b/extensions/browser/src/browser/chrome.ts
@@ -1204,7 +1204,9 @@ export async function stopOpenClawChrome(
 ) {
   const proc = running.proc;
   try {
-    if (proc.killed) {
+    // The fixed CDP port may already belong to a replacement. Once the
+    // tracked child exits, never send Browser.close to the current listener.
+    if (proc.killed || proc.exitCode != null || proc.signalCode != null) {
       return;
     }
 

--- a/extensions/browser/src/browser/chrome.ts
+++ b/extensions/browser/src/browser/chrome.ts
@@ -42,6 +42,7 @@ import {
   isWebSocketUrl,
   normalizeCdpHttpBaseForJsonEndpoints,
   openCdpWebSocket,
+  withCdpSocket,
 } from "./cdp.helpers.js";
 import { normalizeCdpWsUrl } from "./cdp.js";
 import {
@@ -60,6 +61,7 @@ import {
   decorateOpenClawProfile,
   ensureProfileCleanExit,
   isProfileDecorated,
+  usesOpenClawMockKeychain,
 } from "./chrome.profile-decoration.js";
 import {
   getManagedBrowserMissingDisplayError,
@@ -85,6 +87,7 @@ const CHROME_SINGLETON_LOCK_PATHS = [
 ] as const;
 const CHROME_SINGLETON_IN_USE_PATTERN = /profile appears to be in use by another chromium process/i;
 const CHROME_MISSING_DISPLAY_PATTERN = /missing x server|\$DISPLAY/i;
+const CHROME_GRACEFUL_CLOSE_COMMAND_TIMEOUT_MS = 500;
 const CHROME_HTTP_DISCOVERY_FAILURE_CODES = new Set([
   "ssrf_blocked",
   "http_unreachable",
@@ -732,8 +735,10 @@ export function buildOpenClawChromeLaunchArgs(params: {
   headlessOverride?: boolean;
   env?: NodeJS.ProcessEnv;
   platform?: NodeJS.Platform;
+  useMockKeychain?: boolean;
 }): string[] {
   const { resolved, profile, userDataDir } = params;
+  const platform = params.platform ?? process.platform;
   const headlessMode = resolveManagedBrowserHeadlessMode(resolved, profile, params);
   const args: string[] = [
     `--remote-debugging-port=${profile.cdpPort}`,
@@ -749,6 +754,12 @@ export function buildOpenClawChromeLaunchArgs(params: {
     "--password-store=basic",
   ];
 
+  if (platform === "darwin" && params.useMockKeychain) {
+    // This is an isolated OpenClaw-owned profile, not the user's Chrome profile.
+    // Keep its basic password store non-interactive so headless Chrome can
+    // encrypt and persist cookies without login-keychain prompts.
+    args.push("--use-mock-keychain");
+  }
   if (headlessMode.headless) {
     args.push("--headless=new");
     args.push("--disable-gpu");
@@ -756,7 +767,7 @@ export function buildOpenClawChromeLaunchArgs(params: {
   if (resolved.noSandbox) {
     args.push("--no-sandbox");
   }
-  if (process.platform === "linux") {
+  if (platform === "linux") {
     args.push("--disable-dev-shm-usage");
   }
   if (!hasChromeProxyControlArg(resolved.extraArgs)) {
@@ -933,6 +944,16 @@ export async function launchOpenClawChrome(
   fs.mkdirSync(userDataDir, { recursive: true });
   await ensureOutputDirectory(DEFAULT_DOWNLOAD_DIR);
 
+  const localStatePath = path.join(userDataDir, "Local State");
+  const preferencesPath = path.join(userDataDir, "Default", "Preferences");
+  const profileIsNew = !exists(localStatePath);
+  const needsBootstrap = profileIsNew || !exists(preferencesPath);
+  // Never change the encryption key source for an established profile: doing
+  // so would make its existing cookies unreadable. New headless profiles opt in.
+  const useMockKeychain =
+    process.platform === "darwin" &&
+    (usesOpenClawMockKeychain(userDataDir) || (profileIsNew && headlessMode.headless));
+
   const needsDecorate = !isProfileDecorated(
     userDataDir,
     profile.name,
@@ -947,6 +968,7 @@ export async function launchOpenClawChrome(
       profile,
       userDataDir,
       ...launchOptions,
+      useMockKeychain,
     });
     const env: NodeJS.ProcessEnv = {
       ...omitChromeProxyEnv(process.env),
@@ -972,10 +994,6 @@ export async function launchOpenClawChrome(
   };
 
   const startedAt = Date.now();
-
-  const localStatePath = path.join(userDataDir, "Local State");
-  const preferencesPath = path.join(userDataDir, "Default", "Preferences");
-  const needsBootstrap = !exists(localStatePath) || !exists(preferencesPath);
 
   // If the profile doesn't exist yet, bootstrap it once so Chrome creates defaults.
   // Then decorate (if needed) before the "real" run.
@@ -1012,6 +1030,7 @@ export async function launchOpenClawChrome(
         name: profile.name,
         color: profile.color,
         downloadDir: DEFAULT_DOWNLOAD_DIR,
+        mockKeychain: useMockKeychain,
       });
       log.info(`🦞 openclaw browser profile decorated (${profile.color})`);
     } catch (err) {
@@ -1129,6 +1148,55 @@ export async function launchOpenClawChrome(
   return await launchOnceAndWait(true);
 }
 
+async function requestGracefulChromeClose(cdpPort: number, timeoutMs: number): Promise<boolean> {
+  const commandTimeoutMs = Math.max(
+    1,
+    Math.min(timeoutMs, CHROME_GRACEFUL_CLOSE_COMMAND_TIMEOUT_MS),
+  );
+  let commandSent = false;
+  try {
+    const wsUrl = await getChromeWebSocketUrl(
+      cdpUrlForPort(cdpPort),
+      Math.min(commandTimeoutMs, CHROME_STOP_PROBE_TIMEOUT_MS),
+    );
+    if (!wsUrl) {
+      return false;
+    }
+    await withCdpSocket(
+      wsUrl,
+      async (send) => {
+        commandSent = true;
+        await send("Browser.close");
+      },
+      {
+        commandTimeoutMs,
+        handshakeTimeoutMs: commandTimeoutMs,
+        handshakeRetries: 0,
+      },
+    );
+    return true;
+  } catch (err) {
+    log.debug(`Chrome graceful close skipped: ${safeChromeCdpErrorMessage(err)}`);
+    // Chrome may close the socket before acknowledging Browser.close. Once the
+    // command was sent, still give it time to flush the profile and exit.
+    return commandSent;
+  }
+}
+
+async function waitForChromeCdpShutdown(cdpPort: number, timeoutMs: number): Promise<boolean> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (!(await isChromeReachable(cdpUrlForPort(cdpPort), CHROME_STOP_PROBE_TIMEOUT_MS))) {
+      return true;
+    }
+    const remainingMs = timeoutMs - (Date.now() - start);
+    await new Promise((resolve) => {
+      setTimeout(resolve, Math.max(1, Math.min(100, remainingMs)));
+    });
+  }
+  return !(await isChromeReachable(cdpUrlForPort(cdpPort), CHROME_STOP_PROBE_TIMEOUT_MS));
+}
+
 /** Stop a managed Chrome process and wait for shutdown. */
 export async function stopOpenClawChrome(
   running: RunningChrome,
@@ -1139,26 +1207,22 @@ export async function stopOpenClawChrome(
     if (proc.killed) {
       return;
     }
+
+    // Gateway shutdown/restart awaits the Browser plugin stop chain into this
+    // method. Browser.close keeps cookies in Chromium's protected profile;
+    // signals remain a bounded fallback without duplicating credentials.
+    const gracefulCloseRequested = await requestGracefulChromeClose(running.cdpPort, timeoutMs);
+    if (gracefulCloseRequested && (await waitForChromeCdpShutdown(running.cdpPort, timeoutMs))) {
+      return;
+    }
     try {
       proc.kill("SIGTERM");
     } catch {
       // ignore
     }
 
-    const start = Date.now();
-    while (Date.now() - start < timeoutMs) {
-      if (!proc.exitCode && proc.killed) {
-        break;
-      }
-      if (
-        !(await isChromeReachable(cdpUrlForPort(running.cdpPort), CHROME_STOP_PROBE_TIMEOUT_MS))
-      ) {
-        return;
-      }
-      const remainingMs = timeoutMs - (Date.now() - start);
-      await new Promise((r) => {
-        setTimeout(r, Math.max(1, Math.min(100, remainingMs)));
-      });
+    if (await waitForChromeCdpShutdown(running.cdpPort, timeoutMs)) {
+      return;
     }
 
     try {


### PR DESCRIPTION
## Summary
- Preserve managed `openclaw` browser cookies across restarts by letting Chrome close gracefully through browser-level CDP `Browser.close` before falling back to signals.
- For new local macOS headless managed profiles, launch Chrome with `--use-mock-keychain` and mark the profile so future launches keep the same cookie encryption backend.
- Leave existing managed profiles on their existing keychain backend; the PR does not switch an established profile to mock keychain.
- Add focused browser lifecycle/profile tests.

## What Problem This Solves
Managed browser sessions can hold login cookies in Chrome's live CDP cookie store while the profile's SQLite cookie DB remains empty. When OpenClaw stops and relaunches the managed browser without a graceful Chrome close, those cookies can disappear, so users lose authenticated browser state even when reusing the same managed profile.

Issue #96704 has a live repro against current upstream `origin/main` showing a CDP-visible persistent cookie before restart, `0` rows in Chrome's cookie DB, and `0` cookies after relaunch with the same profile.

## Security / Product Shape
This final version does **not** store cookies in an OpenClaw plaintext sidecar. Cookie material stays in Chrome's profile storage.

For new local macOS headless managed profiles, the PR opts the isolated OpenClaw-owned profile into Chromium's mock keychain so headless Chrome can persist encrypted cookies without login-keychain prompts. That marker is stored in the managed profile's `Local State`.

For existing managed profiles created before this PR, the PR does not change the cookie encryption backend. The recovery path is: existing profiles keep their current backend and gain graceful `Browser.close` shutdown; sessions already lost by previous ungraceful restarts cannot be reconstructed and require signing in again.

## Evidence
- Before-fix live repro against upstream main: https://github.com/openclaw/openclaw/issues/96704#issuecomment-4848117522
- Exact-head proof was captured on `96e8fa6c6629d9f0d7950fd295de0bf894dbecf6` using isolated temp gateway/browser ports `19984`/`19995`, synthetic cookies only, temp state dirs under `/private/tmp`, and channel startup disabled.
- Branch refresh `4377e6203386a3536e4125e8449543ef2d45d4ec` rebased onto current `origin/main`, removed the release-owned `CHANGELOG.md` edit, and kept the browser files identical to the proven head (`git diff --name-status 96e8fa6c6629..4377e620338 -- browser files` is empty).

Fresh profile proof:
- Built PR head locally with `pnpm build`.
- Started a fresh managed profile on PR head with `--headless`; process args included `--use-mock-keychain`.
- Profile marker after launch: `profile.info_cache.Default.openclaw_mock_keychain=true`.
- Set synthetic persistent cookie `oc98284_smoke` through browser-level CDP `Storage.setCookies`; `Storage.getCookies` returned `matchingCookies=1`.
- Stopped browser through `openclaw browser stop`; Chrome Cookies DB contained `example.test|oc98284_smoke|valueLen=0|encryptedLen=51|isPersistent=1`.
- Relaunched same profile on PR head; `Storage.getCookies` returned `totalCookies=1`, `matchingCookies=1`, value present.

Upgraded current-main profile proof:
- Built current `origin/main` at `45f561ab6c2`.
- Created the managed profile on current main with `--headless`; process args did **not** include `--use-mock-keychain`.
- Current-main-created profile marker before upgrade: `openclaw_mock_keychain=false`.
- Switched the same temp home/state dir to PR head `96e8fa6c6629`.
- Started the existing profile on PR head; process args still did **not** include `--use-mock-keychain`, and the marker remained `false`.
- Set synthetic persistent cookie `oc98284_after_upgrade` through browser-level CDP; `Storage.getCookies` returned `matchingCookies=1`.
- Stopped browser through PR-head `openclaw browser stop`; Chrome Cookies DB contained `after-upgrade.example.test|oc98284_after_upgrade|valueLen=0|encryptedLen=67|isPersistent=1`.
- Relaunched the same upgraded profile on PR head; `Storage.getCookies` returned `totalCookies=1`, `matchingCookies=1`, value present.

Validation on refreshed PR head `4377e6203386a3536e4125e8449543ef2d45d4ec`:
- `node scripts/run-vitest.mjs extensions/browser/src/browser/chrome.internal.test.ts extensions/browser/src/browser/chrome.test.ts`: `107/107` passed.
- `node_modules/.bin/oxfmt --check extensions/browser/src/browser/chrome.ts extensions/browser/src/browser/chrome.test.ts extensions/browser/src/browser/chrome.internal.test.ts extensions/browser/src/browser/chrome.profile-decoration.ts`
- `node_modules/.bin/oxlint extensions/browser/src/browser/chrome.ts extensions/browser/src/browser/chrome.test.ts extensions/browser/src/browser/chrome.internal.test.ts extensions/browser/src/browser/chrome.profile-decoration.ts`
- `git diff --cached --check && git diff --check`

Fixes #96704

