### PR TITLE
fix(agents): move channel-varying system-prompt sections below the ca…

### DIFF
--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -1047,6 +1047,39 @@ describe("buildAgentSystemPrompt", () => {
     expect(plainTelegramPrompt).toContain("enable Telegram rich messages for this channel/account");
   });
 
+  it("keeps channel/identity-varying sections below the cache boundary (#98261)", () => {
+    const base = {
+      workspaceDir: "/tmp/openclaw",
+      runtimeInfo: { channel: "telegram", capabilities: ["inlineButtons"] },
+      ownerNumbers: ["+15551230000"],
+    };
+    const prompt = buildAgentSystemPrompt(base);
+    const boundary = prompt.indexOf(SYSTEM_PROMPT_CACHE_BOUNDARY);
+    expect(boundary).toBeGreaterThan(-1);
+
+    // Channel-varying exec-approval guidance and identity-varying Authorized
+    // Senders must sit below the boundary so the cached prefix stays stable.
+    expect(prompt.indexOf("use native approval card/buttons first")).toBeGreaterThan(boundary);
+    expect(prompt.indexOf("## Authorized Senders")).toBeGreaterThan(boundary);
+
+    // The cacheable prefix (above the boundary) stays byte-identical when only
+    // the owner identity changes — the Authorized Senders section used to fork it.
+    const otherOwner = buildAgentSystemPrompt({ ...base, ownerNumbers: ["+15559999999"] });
+    expect(otherOwner.slice(0, otherOwner.indexOf(SYSTEM_PROMPT_CACHE_BOUNDARY))).toBe(
+      prompt.slice(0, boundary),
+    );
+
+    // ...and byte-identical when only the approval-UI capability changes — the
+    // exec-approval guidance used to fork it.
+    const plainApproval = buildAgentSystemPrompt({
+      ...base,
+      runtimeInfo: { channel: "telegram", capabilities: [] },
+    });
+    expect(plainApproval.slice(0, plainApproval.indexOf(SYSTEM_PROMPT_CACHE_BOUNDARY))).toBe(
+      prompt.slice(0, boundary),
+    );
+  });
+
   it("describes Telegram rich text for automatic final replies without the message tool", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -1109,11 +1109,6 @@ export function buildAgentSystemPrompt(params: {
           "Routine low-risk calls: no narration.",
           "Narrate only for complex, sensitive/destructive, or explicitly requested steps.",
           "First-class tool exists: use it; do not ask user to run equivalent CLI/slash command.",
-          buildExecApprovalPromptGuidance({
-            runtimeChannel: params.runtimeInfo?.channel,
-            inlineButtonsEnabled,
-            runtimeCapabilities,
-          }),
           "Never execute /approve through exec or any other shell/tool path; /approve is a user-facing approval command, not a shell command.",
           "Treat allow-once as single-command only: if another elevated command needs approval, request a fresh /approve and do not claim prior approval covered it.",
           "When approvals are required, preserve and show the full command/script exactly as provided (including chained operators like &&, ||, |, ;, or multiline shells) so the user can approve what will actually run, but keep command/script previews separate from the /approve command and never substitute the shell command/script for the approval id or slug.",
@@ -1234,7 +1229,6 @@ export function buildAgentSystemPrompt(params: {
             .join("\n")
         : "",
       params.sandboxInfo?.enabled ? "" : "",
-      ...buildUserIdentitySection(ownerLine, isMinimal),
       ...buildTimeSection({
         userTimezone,
       }),
@@ -1311,6 +1305,26 @@ export function buildAgentSystemPrompt(params: {
     }),
     ...buildVoiceSection({ isMinimal, ttsHint: params.ttsHint }),
   );
+
+  // Exec-approval guidance varies by channel and Authorized Senders varies by
+  // identity (and is dropped in minimal mode), so both sit below the cache
+  // boundary to keep the stable prefix byte-identical across channels — they
+  // previously leaked above it, forking the cacheable prefix early. See #98261.
+  // Exec-approval guidance stays suppressed when a provider overrides the Tool
+  // Call Style section, preserving the prior fallback-only behavior.
+  const execApprovalGuidance = normalizeProviderPromptBlock(
+    providerSectionOverrides.tool_call_style,
+  )
+    ? []
+    : [
+        buildExecApprovalPromptGuidance({
+          runtimeChannel,
+          inlineButtonsEnabled,
+          runtimeCapabilities,
+        }),
+        "",
+      ];
+  lines.push(...execApprovalGuidance, ...buildUserIdentitySection(ownerLine, isMinimal));
 
   if (extraSystemPrompt) {
     // Use "Subagent Context" header for minimal mode (subagents), otherwise "Group Chat Context"


### PR DESCRIPTION
Closes #98261

## What Problem This Solves

Fixes a prompt-cache stability bug in `buildAgentSystemPrompt()` (`src/agents/system-prompt.ts`). Two **channel/identity-varying** sections were emitted into the **static prefix, above `SYSTEM_PROMPT_CACHE_BOUNDARY`**:

1. **Exec-approval guidance** — the `/approve` instruction differs by channel (CLI/plain `/approve` vs native approval-card channels like iMessage / Slack / Telegram-with-inline-buttons).
2. **`## Authorized Senders`** — varies by owner identity, and is dropped entirely in minimal (cron/subagent) mode.

Because their content differs by channel/identity, they fork the supposedly byte-identical cacheable prefix very early. On local models with client-managed prefix caching (llama.cpp / MLX / Ollama), this re-prefills the entire system prompt from scratch on any turn whose channel context differs from the previous one — e.g. an interactive turn right after background cron/heartbeat traffic — which the linked issue measured as multi-minute cold prefills.

This is the direct follow-on to #40256, which relocated Messaging/Voice/Reactions below the boundary but missed these two sections.

## Why This Change Was Made

Both sections are instructional context — position-independent for correctness — so they were moved into the volatile suffix **below** `SYSTEM_PROMPT_CACHE_BOUNDARY`, mirroring the existing treatment of Messaging/Voice/Reactions. The channel-independent `/approve` rules stay above the boundary, keeping the stable prefix as large as possible.

One behavioral subtlety is preserved: exec-approval guidance previously lived inside the `tool_call_style` fallback array, so a provider that **overrode** `tool_call_style` suppressed it. The relocated emission keeps that gating (it stays suppressed when `providerSectionOverrides.tool_call_style` is set). This is therefore a pure cache-stability change with **no behavioral difference** on any channel.

## User Impact

Local-model deployments stop paying repeated cold prefills when the channel context changes between turns: the cacheable prefix is now channel/identity-independent, so it stays warm across interactive/cron/heartbeat traffic. No behavioral change for any channel or provider; cloud providers (server-side caching) are unaffected either way. No configuration changes.

## Evidence

### Real behavior proof (standalone, non-test)

Drove the **real** `buildAgentSystemPrompt` from a standalone script (`node --import tsx`) for two interactive turns on different channels/owners (CLI vs iMessage), and measured the byte-identical prefix they share — i.e. the region a prefix cache can actually reuse. Run on a minimal workspace, so absolute offsets are smaller than the issue's full ~17.8K-token prompt, but the mechanism and direction are identical:

**BEFORE — unpatched `main`:**

```
CLI prompt:       7217 chars; cache boundary at char 6560
iMessage prompt:  7324 chars; cache boundary at char 6653
shared byte-identical prefix across the two channels: 2020 chars
shared prefix reaches the cache boundary (full prefix cacheable): false
first divergence at char 2020:
  CLI : "send the exact /approve command from \"Reply with:\"; do not ask for another code.\nNever exe"
  iMsg: "use native approval card/buttons first. Include a plain /approve command only when the too"
```

**AFTER — this branch (identical inputs):**

```
CLI prompt:       7217 chars; cache boundary at char 6324
iMessage prompt:  7324 chars; cache boundary at char 6324
shared byte-identical prefix across the two channels: 6850 chars
shared prefix reaches the cache boundary (full prefix cacheable): true
first divergence at char 6850:
  CLI : "send the exact /approve command from \"Reply with:\"; do not ask for another code.\n## Author"
  iMsg: "use native approval card/buttons first. Include a plain /approve command only when the too"
```

The byte-identical cacheable prefix grows from **2,020 → 6,850 chars** and now reaches the boundary (`false → true`); the first cross-channel divergence (the exec-approval line) moves from char 2,020 (above the boundary) to char 6,850 (below it). The two channels' boundaries also converge to the same offset (6560/6653 → 6324/6324), confirming the prefix is byte-identical.

### Regression test

`vitest run src/agents/system-prompt.test.ts` → **91 passed** (90 existing + 1 new guard).

New guard `keeps channel/identity-varying sections below the cache boundary (#98261)` asserts both sections sit below the boundary, and that the above-boundary prefix is byte-identical when only the owner identity changes, and when only the approval-UI capability changes. It **fails on `main`** and passes here:

```
× keeps channel/identity-varying sections below the cache boundary (#98261)
  AssertionError: expected 2020 to be greater than 6653
```

(the exec-approval guidance is at index 2020, above the boundary at 6653, on `main`).

Sibling suites also pass: `system-prompt.memory.test.ts`, `bootstrap-budget.test.ts`, `sanitize-for-prompt.test.ts`, `heartbeat-system-prompt.test.ts` → 36 passed. oxlint and `oxfmt --check` are clean on both files.

> Local note: this machine's disk was too constrained for a full `tsgo` run; the change reuses existing typed helpers with no signature changes, and CI `check-prod-types` / `check-test-types` cover typechecking.