### PR TITLE
Allow MCP server-name projection for embedded agents

### DIFF
--- a/src/agents/embedded-agent-runner/effective-tool-policy.test.ts
+++ b/src/agents/embedded-agent-runner/effective-tool-policy.test.ts
@@ -246,4 +246,50 @@ describe("applyFinalEffectiveToolPolicy", () => {
 
     expect(filtered).toStrictEqual([]);
   });
+
+  it("allows a scoped MCP server while denying unsafe execution-shaped tools", () => {
+    const driveTool = makeTool("composio-dawson__GOOGLEDRIVE_SEARCH");
+    const sheetsTool = makeTool("composio-dawson__GOOGLESHEETS_UPDATE");
+    const remoteBashTool = makeTool("composio-dawson__remote_bash");
+    const workbenchTool = makeTool("composio-dawson__workbench_run");
+    const unrelatedTool = makeTool("pipedream__GOOGLESHEETS_UPDATE");
+    for (const tool of [driveTool, sheetsTool, remoteBashTool, workbenchTool]) {
+      setPluginToolMeta(tool, {
+        pluginId: "bundle-mcp",
+        optional: false,
+        mcp: {
+          serverName: "composio-dawson",
+          safeServerName: "composio-dawson",
+          toolName: tool.name.split("__")[1] ?? tool.name,
+          operation: "tool",
+        },
+      });
+    }
+    setPluginToolMeta(unrelatedTool, {
+      pluginId: "bundle-mcp",
+      optional: false,
+      mcp: {
+        serverName: "pipedream",
+        safeServerName: "pipedream",
+        toolName: "GOOGLESHEETS_UPDATE",
+        operation: "tool",
+      },
+    });
+
+    const filtered = applyFinalEffectiveToolPolicy({
+      bundledTools: [driveTool, sheetsTool, remoteBashTool, workbenchTool, unrelatedTool],
+      config: {
+        tools: {
+          allow: ["composio-dawson"],
+          deny: ["*bash*", "*shell*", "*workbench*"],
+        },
+      },
+      warn: () => {},
+    });
+
+    expect(filtered.map((tool) => tool.name)).toEqual([
+      "composio-dawson__GOOGLEDRIVE_SEARCH",
+      "composio-dawson__GOOGLESHEETS_UPDATE",
+    ]);
+  });
 });

--- a/src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.test.ts
@@ -99,8 +99,9 @@ describe("applyEmbeddedAttemptToolsAllow", () => {
   it("keeps plugin-only allowlists on the shared tool policy path", () => {
     const tools = [{ name: "memory_search" }, { name: "plugin_extra" }];
 
-    expect(resolveEmbeddedAttemptToolConstructionPlan({ toolsAllow: ["memory_search"] }))
-      .toHaveProperty("includeCoreTools", false);
+    expect(
+      resolveEmbeddedAttemptToolConstructionPlan({ toolsAllow: ["memory_search"] }),
+    ).toHaveProperty("includeCoreTools", false);
     expect(
       applyEmbeddedAttemptToolsAllow(tools, ["memory_search"]).map((tool) => tool.name),
     ).toEqual(["memory_search"]);
@@ -430,6 +431,13 @@ describe("shouldCreateBundleMcpRuntimeForAttempt", () => {
       shouldCreateBundleMcpRuntimeForAttempt({
         toolsEnabled: true,
         toolsAllow: ["bundle-mcp"],
+      }),
+    ).toBe(true);
+    expect(
+      shouldCreateBundleMcpRuntimeForAttempt({
+        toolsEnabled: true,
+        toolsAllow: ["composio-dawson"],
+        mcpServerNames: ["composio-dawson"],
       }),
     ).toBe(true);
     expect(

--- a/src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.ts
@@ -1,7 +1,7 @@
 /**
  * Plans which core, bundle MCP, and bundle LSP tools an attempt should build.
  */
-import { TOOL_NAME_SEPARATOR } from "../../agent-bundle-mcp-names.js";
+import { sanitizeServerName, TOOL_NAME_SEPARATOR } from "../../agent-bundle-mcp-names.js";
 import type { OpenClawCodingToolConstructionPlan } from "../../agent-tools.js";
 import { isToolAllowedByPolicyName } from "../../tool-policy-match.js";
 import {
@@ -79,6 +79,22 @@ function isBundleMcpAllowlistName(normalized: string): boolean {
 
 function isPluginGroupAllowlistName(normalized: string): boolean {
   return normalized === "group:plugins";
+}
+
+function buildMcpServerAllowlistNames(serverNames?: readonly string[]): Set<string> {
+  const names = new Set<string>();
+  const usedSafeNames = new Set<string>();
+  for (const serverName of serverNames ?? []) {
+    const rawName = normalizeToolName(serverName);
+    if (rawName) {
+      names.add(rawName);
+    }
+    const safeName = normalizeToolName(sanitizeServerName(serverName, usedSafeNames));
+    if (safeName) {
+      names.add(safeName);
+    }
+  }
+  return names;
 }
 
 function hasWildcardToolAllowlist(toolsAllow: string[]): boolean {
@@ -261,9 +277,15 @@ export function shouldCreateBundleMcpRuntimeForAttempt(params: {
   toolsEnabled: boolean;
   disableTools?: boolean;
   toolsAllow?: string[];
+  mcpServerNames?: readonly string[];
 }): boolean {
+  const mcpServerAllowlistNames = buildMcpServerAllowlistNames(params.mcpServerNames);
   return shouldCreateBundleRuntimeForAttempt(params, (normalized) => {
-    return isBundleMcpAllowlistName(normalized) || isPluginGroupAllowlistName(normalized);
+    return (
+      isBundleMcpAllowlistName(normalized) ||
+      isPluginGroupAllowlistName(normalized) ||
+      mcpServerAllowlistNames.has(normalized)
+    );
   });
 }
 

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -95,6 +95,7 @@ import { createBundleLspToolRuntime } from "../../agent-bundle-lsp-runtime.js";
 import {
   getOrCreateSessionMcpRuntime,
   materializeBundleMcpToolsForRun,
+  resolveSessionMcpConfigSummary,
 } from "../../agent-bundle-mcp-tools.js";
 import { createPreparedEmbeddedAgentSettingsManager } from "../../agent-project-settings.js";
 import { resolveAgentDir, resolveSessionAgentIds } from "../../agent-scope.js";
@@ -1532,10 +1533,18 @@ export async function runEmbeddedAttempt(
         }),
     });
     const clientTools = toolsEnabled && !isRawModelRun ? params.clientTools : undefined;
+    const bundleMcpServerNames =
+      effectiveToolsAllow && effectiveToolsAllow.length > 0
+        ? resolveSessionMcpConfigSummary({
+            workspaceDir: effectiveWorkspace,
+            cfg: params.config,
+          }).serverNames
+        : undefined;
     const bundleMcpEnabled = shouldCreateBundleMcpRuntimeForAttempt({
       toolsEnabled,
       disableTools: params.disableTools || isRawModelRun,
-      toolsAllow: params.toolsAllow,
+      toolsAllow: effectiveToolsAllow,
+      mcpServerNames: bundleMcpServerNames,
     });
     const bundleMcpSessionRuntime = bundleMcpEnabled
       ? await getOrCreateSessionMcpRuntime({

--- a/src/agents/tool-policy.ts
+++ b/src/agents/tool-policy.ts
@@ -31,6 +31,14 @@ export type PluginToolGroups = {
   byPlugin: Map<string, string[]>;
 };
 
+type PluginToolGroupMeta = {
+  pluginId?: string;
+  mcp?: {
+    serverName?: string;
+    safeServerName?: string;
+  };
+};
+
 /** Analysis of an allowlist after matching core and plugin tool ids. */
 type AllowlistResolution = {
   policy: ToolPolicyLike | undefined;
@@ -130,10 +138,19 @@ export function collectExplicitDenylist(policies: Array<ToolPolicyLike | undefin
 /** Builds plugin tool groups from tool metadata. */
 export function buildPluginToolGroups<T extends { name: string }>(params: {
   tools: T[];
-  toolMeta: (tool: T) => { pluginId: string } | undefined;
+  toolMeta: (tool: T) => PluginToolGroupMeta | undefined;
 }): PluginToolGroups {
   const all: string[] = [];
   const byPlugin = new Map<string, string[]>();
+  const addGroupEntry = (groupId: string | undefined, toolName: string) => {
+    const normalizedGroupId = normalizeOptionalLowercaseString(groupId);
+    if (!normalizedGroupId) {
+      return;
+    }
+    const list = byPlugin.get(normalizedGroupId) ?? [];
+    list.push(toolName);
+    byPlugin.set(normalizedGroupId, list);
+  };
   for (const tool of params.tools) {
     const meta = params.toolMeta(tool);
     if (!meta) {
@@ -141,13 +158,9 @@ export function buildPluginToolGroups<T extends { name: string }>(params: {
     }
     const name = normalizeToolName(tool.name);
     all.push(name);
-    const pluginId = normalizeOptionalLowercaseString(meta.pluginId);
-    if (!pluginId) {
-      continue;
-    }
-    const list = byPlugin.get(pluginId) ?? [];
-    list.push(name);
-    byPlugin.set(pluginId, list);
+    addGroupEntry(meta.pluginId, name);
+    addGroupEntry(meta.mcp?.serverName, name);
+    addGroupEntry(meta.mcp?.safeServerName, name);
   }
   return { all, byPlugin };
 }


### PR DESCRIPTION
## Summary

Allows embedded-agent bundle MCP startup to recognize configured MCP server names such as `composio-dawson` when a narrow tool allowlist names that server.

The change is generic and does not hardcode Dawson or Composio. Final tool policy still expands from materialized tool metadata, and explicit deny/filter rules continue to remove unsafe tools such as remote shell/workbench-style tools.

## What Problem This Solves

Ascension/Dawson sessions can have a correctly configured Composio MCP server, but an embedded run with a narrow allowlist such as `composio-dawson` did not start the bundle-MCP runtime unless the allowlist named `bundle-mcp` or an already-materialized `server__tool` name. That meant native Google Drive/Sheets tools could exist in configuration while fresh Telegram sessions still fell back to raw Pipedream action plumbing.

This PR lets the startup gate recognize configured MCP server names and sanitized server names. It keeps the final safety boundary in the existing materialized tool policy and deny filters.

## Evidence

- Added regression coverage for server-name allowlisted bundle-MCP startup.
- Added policy coverage proving server-scoped bundle-MCP allows expand to materialized Drive/Sheets-shaped tools while deny filters still remove unsafe shell/workbench-shaped tools.
- Local focused validation passed:
  - `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.test.ts src/agents/embedded-agent-runner/effective-tool-policy.test.ts src/agents/tool-policy.plugin-only-allowlist.test.ts src/agents/tool-policy-pipeline.test.ts src/agents/embedded-agent-runner/run/attempt.test.ts`
  - `pnpm exec oxfmt --check --threads=1 src/agents/embedded-agent-runner/effective-tool-policy.test.ts src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.test.ts src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.ts src/agents/embedded-agent-runner/run/attempt.ts src/agents/tool-policy.ts`
  - `git diff --check`

## Tracking

- Parent tracker: electricsheephq/eric-wilder#145
- Supports: electricsheephq/eric-wilder#146

## Validation Details

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.test.ts src/agents/embedded-agent-runner/effective-tool-policy.test.ts src/agents/tool-policy.plugin-only-allowlist.test.ts src/agents/tool-policy-pipeline.test.ts src/agents/embedded-agent-runner/run/attempt.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/agents/embedded-agent-runner/effective-tool-policy.test.ts src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.test.ts src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.ts src/agents/embedded-agent-runner/run/attempt.ts src/agents/tool-policy.ts`
- `git diff --check`

## Proof boundary

This proves projection and policy behavior in OpenClaw tests. It does not run a live Dawson/Ascension Telegram session or mutate a customer VM.
