### PR TITLE
fix(gateway): emit stale exec approval followup diagnostics

### DIFF
--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -229,7 +229,7 @@ openclaw gateway stability --json
 
 <AccordionGroup>
   <Accordion title="Privacy and bundle behavior">
-    - Records keep operational metadata: event names, counts, byte sizes, memory readings, queue/session state, channel/plugin names, and redacted session summaries. They do not keep chat text, webhook bodies, tool outputs, raw request or response bodies, tokens, cookies, secret values, hostnames, or raw session ids. Set `diagnostics.enabled: false` to disable the recorder entirely.
+    - Records keep operational metadata: event names, counts, byte sizes, memory readings, queue/session state, approval ids, channel/plugin names, and redacted session summaries. They do not keep chat text, webhook bodies, tool outputs, raw request or response bodies, tokens, cookies, secret values, hostnames, or raw session ids. Set `diagnostics.enabled: false` to disable the recorder entirely.
     - On fatal Gateway exits, shutdown timeouts, and restart startup failures, OpenClaw writes the same diagnostic snapshot to `~/.openclaw/logs/stability/openclaw-stability-*.json` when the recorder has events. Inspect the newest bundle with `openclaw gateway stability --bundle latest`; `--limit`, `--type`, and `--since-seq` also apply to bundle output.
 
   </Accordion>

--- a/docs/gateway/opentelemetry.md
+++ b/docs/gateway/opentelemetry.md
@@ -412,6 +412,10 @@ to them directly without OTLP export.
 - `exec.process.completed` - terminal outcome, duration, target, mode, exit
   code, and failure kind. Command text and working directories are not
   included.
+- `exec.approval.followup_suppressed` - stale approval follow-up dropped after
+  a session rebound. Includes `approvalId`, `reason` (`session_rebound`),
+  `phase` (`direct_delivery` or `gateway_preflight`), and the dispatcher
+  timestamp. Session keys, routes, and command text are not included.
 
 ## Without an exporter
 

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -3823,6 +3823,8 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
             case "exec.process.completed":
               recordExecProcessCompleted(evt);
               return;
+            case "exec.approval.followup_suppressed":
+              return;
             case "log.record":
               recordLogRecord?.(evt, metadata);
               return;

--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -127,7 +127,7 @@ const defaultPublicDeprecatedExportsByEntrypointBudget = Object.freeze({
   "outbound-send-deps": 4,
   "outbound-runtime": 16,
   "file-access-runtime": 2,
-  "infra-runtime": 584,
+  "infra-runtime": 585,
   "ssrf-policy": 1,
   "ssrf-runtime": 1,
   "media-runtime": 2,
@@ -202,11 +202,11 @@ let publicDeprecatedExportsByEntrypointBudget;
 try {
   budgets = {
     publicEntrypoints: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_ENTRYPOINTS", 322),
-    publicExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS", 10401),
+    publicExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS", 10402),
     publicFunctionExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_FUNCTION_EXPORTS", 5220),
     publicDeprecatedExports: readBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_DEPRECATED_EXPORTS",
-      3260,
+      3261,
     ),
     publicWildcardReexports: readBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_WILDCARD_REEXPORTS",

--- a/src/agents/bash-tools.exec-approval-followup.test.ts
+++ b/src/agents/bash-tools.exec-approval-followup.test.ts
@@ -18,6 +18,12 @@ import os from "node:os";
 import path from "node:path";
 import { clearSessionStoreCacheForTest } from "../config/sessions/store.js";
 import { writeSessionStoreForTest } from "../config/sessions/test-helpers.js";
+import {
+  onDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+  waitForDiagnosticEventsDrained,
+  type DiagnosticEventPayload,
+} from "../infra/diagnostic-events.js";
 import { sendMessage } from "../infra/outbound/message.js";
 import {
   buildExecApprovalFollowupPrompt,
@@ -39,6 +45,7 @@ function writeTempSessionStore(entries: Record<string, { sessionId: string }>): 
 
 afterEach(() => {
   vi.resetAllMocks();
+  resetDiagnosticEventsForTest();
   clearSessionStoreCacheForTest();
   while (tempStoreDirs.length > 0) {
     const dir = tempStoreDirs.pop();
@@ -171,6 +178,10 @@ describe("exec approval followup", () => {
     const sessionStore = writeTempSessionStore({
       "agent:main:main": { sessionId: "session-after-reset" },
     });
+    const diagnostics: DiagnosticEventPayload[] = [];
+    onDiagnosticEvent((event) => {
+      diagnostics.push(event);
+    });
 
     const result = await sendExecApprovalFollowup({
       approvalId: "req-denied-rebound",
@@ -184,6 +195,15 @@ describe("exec approval followup", () => {
     });
 
     expect(result).toBe(false);
+    await waitForDiagnosticEventsDrained();
+    expect(diagnostics).toContainEqual(
+      expect.objectContaining({
+        type: "exec.approval.followup_suppressed",
+        approvalId: "req-denied-rebound",
+        reason: "session_rebound",
+        phase: "direct_delivery",
+      }),
+    );
     expect(sendMessage).not.toHaveBeenCalled();
     expect(callGatewayTool).not.toHaveBeenCalled();
   });

--- a/src/agents/bash-tools.exec-approval-followup.test.ts
+++ b/src/agents/bash-tools.exec-approval-followup.test.ts
@@ -232,6 +232,10 @@ describe("exec approval followup", () => {
     const sessionStore = writeTempSessionStore({
       "agent:main:main": { sessionId: "session-after-reset" },
     });
+    const diagnostics: DiagnosticEventPayload[] = [];
+    onDiagnosticEvent((event) => {
+      diagnostics.push(event);
+    });
 
     const result = await sendExecApprovalFollowup({
       approvalId: "req-finished-rebound",
@@ -245,6 +249,15 @@ describe("exec approval followup", () => {
     });
 
     expect(result).toBe(false);
+    await waitForDiagnosticEventsDrained();
+    expect(diagnostics).toContainEqual(
+      expect.objectContaining({
+        type: "exec.approval.followup_suppressed",
+        approvalId: "req-finished-rebound",
+        reason: "session_rebound",
+        phase: "direct_delivery",
+      }),
+    );
     expect(sendMessage).not.toHaveBeenCalled();
     expect(callGatewayTool).not.toHaveBeenCalled();
   });

--- a/src/agents/bash-tools.exec-approval-followup.ts
+++ b/src/agents/bash-tools.exec-approval-followup.ts
@@ -9,6 +9,7 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import { resolveStorePath } from "../config/sessions/paths.js";
 import { loadSessionStore } from "../config/sessions/store-load.js";
+import { emitDiagnosticEvent } from "../infra/diagnostic-events.js";
 import {
   resolveExternalBestEffortDeliveryTarget,
   type ExternalBestEffortDeliveryTarget,
@@ -394,6 +395,12 @@ export async function sendExecApprovalFollowup(
         sessionStore: params.sessionStore,
       })
     ) {
+      emitDiagnosticEvent({
+        type: "exec.approval.followup_suppressed",
+        approvalId: params.approvalId,
+        reason: "session_rebound",
+        phase: "direct_delivery",
+      });
       log.info(
         `Dropping stale denied exec approval followup ${params.approvalId}: session ${sessionKey ?? ""} was rebound before the approval resolved`,
       );
@@ -423,6 +430,12 @@ export async function sendExecApprovalFollowup(
       sessionStore: params.sessionStore,
     })
   ) {
+    emitDiagnosticEvent({
+      type: "exec.approval.followup_suppressed",
+      approvalId: params.approvalId,
+      reason: "session_rebound",
+      phase: "direct_delivery",
+    });
     log.info(
       `Dropping stale exec approval followup ${params.approvalId} direct fallback: session ${sessionKey ?? ""} was rebound before the approval resolved`,
     );

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -5,6 +5,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ErrorCodes } from "../../../packages/gateway-protocol/src/index.js";
 import type { readAcpSessionMeta } from "../../acp/runtime/session-meta.js";
 import {
+  onDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+  waitForDiagnosticEventsDrained,
+  type DiagnosticEventPayload,
+} from "../../infra/diagnostic-events.js";
+import {
   registerExecApprovalFollowupRuntimeHandoff,
   resetExecApprovalFollowupRuntimeHandoffsForTests,
 } from "../../agents/bash-tools.exec-approval-followup-state.js";
@@ -600,6 +606,7 @@ describe("gateway agent handler", () => {
   afterEach(() => {
     envSnapshot.restore();
     resetDetachedTaskLifecycleRuntimeForTests();
+    resetDiagnosticEventsForTest();
     resetTaskRegistryForTests();
     resetSubagentRegistryForTests({ persist: false });
     subagentRegistryTesting.setDepsForTest();
@@ -3212,6 +3219,10 @@ describe("gateway agent handler", () => {
       lastTo: "123",
     });
     const context = makeContext();
+    const diagnostics: DiagnosticEventPayload[] = [];
+    onDiagnosticEvent((event) => {
+      diagnostics.push(event);
+    });
     const updateSessionStoreCallsBefore = mocks.updateSessionStore.mock.calls.length;
     const agentCommandCallsBefore = mocks.agentCommand.mock.calls.length;
 
@@ -3237,6 +3248,15 @@ describe("gateway agent handler", () => {
       status: "ok",
       summary: expect.stringContaining("exec approval followup dropped"),
     });
+    await waitForDiagnosticEventsDrained();
+    expect(diagnostics).toContainEqual(
+      expect.objectContaining({
+        type: "exec.approval.followup_suppressed",
+        approvalId: "req-rebound-followup",
+        reason: "session_rebound",
+        phase: "gateway_preflight",
+      }),
+    );
     expect(mocks.updateSessionStore.mock.calls.length).toBe(updateSessionStoreCallsBefore);
     expect(mocks.agentCommand.mock.calls.length).toBe(agentCommandCallsBefore);
     const dedupeEntry = context.dedupe.get("agent:exec-approval-followup:req-rebound-followup");

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -77,6 +77,7 @@ import {
 import { hasProviderOwnedSession } from "../../config/sessions/entry-freshness.js";
 import { resolveMaintenanceConfigFromInput } from "../../config/sessions/store-maintenance.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { emitDiagnosticEvent } from "../../infra/diagnostic-events.js";
 import {
   assertAgentRunLifecycleGenerationCurrent,
   claimAgentRunContext,
@@ -1516,6 +1517,12 @@ export const agentHandlers: GatewayRequestHandlers = {
           resolvedSessionId: currentSessionId,
         })
       ) {
+        emitDiagnosticEvent({
+          type: "exec.approval.followup_suppressed",
+          approvalId: execApprovalFollowupApprovalId,
+          reason: "session_rebound",
+          phase: "gateway_preflight",
+        });
         context.logGateway.info(
           `Dropping stale exec approval followup ${execApprovalFollowupApprovalId}: session ${requestedSessionKeyRaw} rebound (expected ${expectedSessionId}, current ${currentSessionId}) before the approval resolved`,
         );

--- a/src/infra/diagnostic-events.test.ts
+++ b/src/infra/diagnostic-events.test.ts
@@ -822,6 +822,7 @@ describe("diagnostic-events", () => {
         approvalId: "approval-123",
         reason: "session_rebound",
         phase: "gateway_preflight",
+        ts: expect.any(Number),
       }),
     );
   });

--- a/src/infra/diagnostic-events.test.ts
+++ b/src/infra/diagnostic-events.test.ts
@@ -801,6 +801,31 @@ describe("diagnostic-events", () => {
     expect(internalEvents).toEqual(["log.record"]);
   });
 
+  it("emits exec approval followup suppression events on the public stream", async () => {
+    const events: DiagnosticEventPayload[] = [];
+    onDiagnosticEvent((event) => {
+      events.push(event);
+    });
+
+    emitDiagnosticEvent({
+      type: "exec.approval.followup_suppressed",
+      approvalId: "approval-123",
+      reason: "session_rebound",
+      phase: "gateway_preflight",
+    });
+
+    await waitForDiagnosticEventsDrained();
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "exec.approval.followup_suppressed",
+        approvalId: "approval-123",
+        reason: "session_rebound",
+        phase: "gateway_preflight",
+      }),
+    );
+  });
+
   it("keeps trusted private data off shared internal diagnostic listeners", async () => {
     const internalEvents: DiagnosticEventPayload[] = [];
     const trustedEvents: Array<{

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -514,6 +514,13 @@ export type DiagnosticExecProcessCompletedEvent = DiagnosticBaseEvent & {
     | "runtime-error";
 };
 
+export type DiagnosticExecApprovalFollowupSuppressedEvent = DiagnosticBaseEvent & {
+  type: "exec.approval.followup_suppressed";
+  approvalId: string;
+  reason: "session_rebound";
+  phase: "direct_delivery" | "gateway_preflight";
+};
+
 type DiagnosticRunBaseEvent = DiagnosticBaseEvent & {
   runId: string;
   sessionKey?: string;
@@ -769,6 +776,7 @@ export type DiagnosticEventPayload =
   | DiagnosticToolExecutionBlockedEvent
   | DiagnosticSkillUsedEvent
   | DiagnosticExecProcessCompletedEvent
+  | DiagnosticExecApprovalFollowupSuppressedEvent
   | DiagnosticRunStartedEvent
   | DiagnosticRunCompletedEvent
   | DiagnosticHarnessRunStartedEvent
@@ -863,6 +871,7 @@ const ASYNC_DIAGNOSTIC_EVENT_TYPES = new Set<DiagnosticEventPayload["type"]>([
   "tool.execution.blocked",
   "skill.used",
   "exec.process.completed",
+  "exec.approval.followup_suppressed",
   "message.delivery.started",
   "message.delivery.completed",
   "message.delivery.error",

--- a/src/logging/diagnostic-stability-bundle.test.ts
+++ b/src/logging/diagnostic-stability-bundle.test.ts
@@ -281,10 +281,20 @@ describe("diagnostic stability bundles", () => {
           chatId: "chat-id-secret",
           error: "event-error-secret",
         },
+        {
+          seq: 2,
+          ts: 2,
+          type: "exec.approval.followup_suppressed",
+          approvalId: "approval-imported-123",
+          reason: "session_rebound",
+          phase: "gateway_preflight",
+          command: "raw command secret",
+        },
       ],
       summary: {
         byType: {
           "webhook.error": 1,
+          "exec.approval.followup_suppressed": 1,
           "private summary type": 1,
         },
         privateSummary: "summary-secret",
@@ -312,7 +322,18 @@ describe("diagnostic stability bundles", () => {
       type: "webhook.error",
       channel: "telegram",
     });
-    expect(result.bundle.snapshot.summary.byType).toEqual({ "webhook.error": 1 });
+    expect(result.bundle.snapshot.events[1]).toEqual({
+      seq: 2,
+      ts: 2,
+      type: "exec.approval.followup_suppressed",
+      approvalId: "approval-imported-123",
+      reason: "session_rebound",
+      phase: "gateway_preflight",
+    });
+    expect(result.bundle.snapshot.summary.byType).toEqual({
+      "webhook.error": 1,
+      "exec.approval.followup_suppressed": 1,
+    });
     const sanitized = JSON.stringify(result.bundle);
     for (const secret of [
       "private reason",
@@ -327,6 +348,7 @@ describe("diagnostic stability bundles", () => {
       "raw-secret-session",
       "chat-id-secret",
       "event-error-secret",
+      "raw command secret",
       "private summary type",
       "summary-secret",
     ]) {

--- a/src/logging/diagnostic-stability-bundle.ts
+++ b/src/logging/diagnostic-stability-bundle.ts
@@ -696,6 +696,7 @@ function readStabilityEventRecord(
   assignOptionalCodeString(sanitized, "outcome", record.outcome, `${label}.outcome`);
   assignOptionalCodeString(sanitized, "level", record.level, `${label}.level`);
   assignOptionalCodeString(sanitized, "phase", record.phase, `${label}.phase`);
+  assignOptionalCodeString(sanitized, "approvalId", record.approvalId, `${label}.approvalId`);
   assignOptionalCodeString(sanitized, "detector", record.detector, `${label}.detector`);
   assignOptionalCodeString(sanitized, "toolName", record.toolName, `${label}.toolName`);
   assignOptionalCodeString(

--- a/src/logging/diagnostic-stability.test.ts
+++ b/src/logging/diagnostic-stability.test.ts
@@ -144,6 +144,30 @@ describe("diagnostic stability recorder", () => {
     expect(snapshot.events[1]).not.toHaveProperty("reason");
   });
 
+  it("records exec approval followup suppression metadata", async () => {
+    startDiagnosticStabilityRecorder();
+
+    emitDiagnosticEvent({
+      type: "exec.approval.followup_suppressed",
+      approvalId: "approval-123",
+      reason: "session_rebound",
+      phase: "direct_delivery",
+    });
+
+    await waitForDiagnosticEventsDrained();
+
+    const snapshot = getDiagnosticStabilitySnapshot({ limit: 10 });
+    expectFields(snapshot.summary.byType, {
+      "exec.approval.followup_suppressed": 1,
+    });
+    expectFields(snapshot.events[0], {
+      type: "exec.approval.followup_suppressed",
+      approvalId: "approval-123",
+      reason: "session_rebound",
+      phase: "direct_delivery",
+    });
+  });
+
   it("summarizes inbound delivery proof events without message content", () => {
     startDiagnosticStabilityRecorder();
 

--- a/src/logging/diagnostic-stability.ts
+++ b/src/logging/diagnostic-stability.ts
@@ -35,6 +35,7 @@ export type DiagnosticStabilityEventRecord = {
   transport?: string;
   brain?: string;
   toolName?: string;
+  approvalId?: string;
   activeWorkKind?: string;
   pairedToolName?: string;
   provider?: string;
@@ -430,6 +431,11 @@ function sanitizeDiagnosticEvent(event: DiagnosticEventPayload): DiagnosticStabi
       record.timedOut = event.timedOut;
       record.failureKind = event.failureKind;
       assignReasonCode(record, event.failureKind);
+      break;
+    case "exec.approval.followup_suppressed":
+      record.approvalId = event.approvalId;
+      record.phase = event.phase;
+      assignReasonCode(record, event.reason);
       break;
     case "run.started":
       record.provider = event.provider;


### PR DESCRIPTION
Related: #98279
Alternative to #98292 with the gateway preflight suppression point and public/stability diagnostics covered.

## What Problem This Solves

Fixes an issue where operators could not consume a machine-readable signal when OpenClaw intentionally suppressed a stale exec approval follow-up after the target session was rebound by `/new` or `/reset`.

## Why This Change Was Made

This adds a structured `exec.approval.followup_suppressed` diagnostic event at the existing stale-follow-up drop points without changing delivery behavior. The event includes the approval id, a stable `session_rebound` reason, and the suppression phase while avoiding raw session keys, route ids, command text, or other high-cardinality routing details.

Follow-up repairs also register the new event with the diagnostics OTEL exhaustive switch as an intentional no-op, update the plugin SDK surface budgets for the newly public diagnostic event type, and preserve `approvalId` when reading persisted stability bundles.

## User Impact

Operator status and inbox tooling can now distinguish an intentional stale approval follow-up suppression from missing channel delivery or a stuck approval path. Existing Slack/direct/gateway suppression behavior remains unchanged; this is additive observability only.

AI-assisted with Codex.

## Evidence

- `git diff --check`
- `node scripts/plugin-sdk-surface-report.mjs --check`
- `node scripts/run-vitest.mjs test/scripts/plugin-sdk-surface-report.test.ts` -> 1 file, 8 tests passed.
- `node scripts/run-vitest.mjs src/logging/diagnostic-stability-bundle.test.ts` -> 1 file, 10 tests passed.
- `node scripts/run-vitest.mjs src/agents/bash-tools.exec-approval-followup.test.ts src/gateway/server-methods/agent.test.ts src/infra/diagnostic-events.test.ts src/logging/diagnostic-stability.test.ts src/logging/diagnostic-stability-bundle.test.ts test/scripts/plugin-sdk-surface-report.test.ts` -> 5 Vitest shards passed: tooling 8 tests, gateway 344 tests, infra 30 tests, logging 22 tests, agents 27 tests.
- GitHub CI on `3be1325f` passed the prior failing checks: `check-lint`, `check-additional-extension-bundled`, and `checks-node-compact-small-whole-2`.

Coverage added:
- Direct stale denied follow-up suppression emits `exec.approval.followup_suppressed`.
- Gateway preflight stale follow-up suppression emits the same event before touching the rebound session.
- Public diagnostic subscribers receive the event.
- Diagnostic stability records approval id, reason, and phase for operator tooling.
- Persisted stability bundle reads preserve approval id, reason, and phase while stripping unrelated raw fields.
- Plugin SDK surface budget check covers the new public diagnostic event type.

Local proof notes:
- `node scripts/run-bundled-extension-oxlint.mjs` could not be completed in this checkout because `node_modules/.bin/tsgo` and `node_modules/.bin/oxlint` were unavailable after `pnpm install --frozen-lockfile` timed out on registry downloads for native/package tarballs.
- `OPENCLAW_STATE_DIR=$(mktemp -d /tmp/openclaw-pr98293-state.XXXXXX) node openclaw.mjs gateway stability --bundle latest --json` was attempted as an isolated persisted-bundle CLI proof, but this source checkout has no `dist/entry.(m)js` build output. The command failed with `openclaw: missing dist/entry.(m)js (build output)`.

## Real behavior proof

Crabbox proof added 2026-07-01 UTC.

- Crabbox v0.33.0, provider `local-container`, lease `cbx_14a7f978e2bd`, slug `golden-crab`, target `ubuntu_26.04`.
- Checkout `db2a5de505`; command exit `0`.
- Scenario seeded `agent:main:main` as rebound from `session-original` to `session-after-reset`, called the production `sendExecApprovalFollowup` direct stale guard, wrote a stability bundle, then read it through `corepack pnpm openclaw gateway stability --bundle latest --json --type exec.approval.followup_suppressed`.
- CLI readback showed `exec.approval.followup_suppressed` with `approvalId: req-crabbox-pr98293-rebound`, `reason: session_rebound`, `phase: direct_delivery`, and summary `{ "exec.approval.followup_suppressed": 1 }`.
- Full redacted proof is in https://github.com/openclaw/openclaw/pull/98293#issuecomment-4848976974.

Hosted Crabbox provider attempts were blocked by local auth/tool prerequisites: Azure missing subscription/CLI login, Blacksmith CLI auth timed out, AWS requires Crabbox broker login, and GCP auth returned `invalid_grant`.