### PR TITLE
fix(exec): emit approval timeout suppression events

### DIFF
--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -3823,6 +3823,8 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
             case "exec.process.completed":
               recordExecProcessCompleted(evt);
               return;
+            case "exec.approval.timeout-suppressed":
+              return;
             case "log.record":
               recordLogRecord?.(evt, metadata);
               return;

--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -127,7 +127,7 @@ const defaultPublicDeprecatedExportsByEntrypointBudget = Object.freeze({
   "outbound-send-deps": 4,
   "outbound-runtime": 16,
   "file-access-runtime": 2,
-  "infra-runtime": 584,
+  "infra-runtime": 585,
   "ssrf-policy": 1,
   "ssrf-runtime": 1,
   "media-runtime": 2,
@@ -202,11 +202,11 @@ let publicDeprecatedExportsByEntrypointBudget;
 try {
   budgets = {
     publicEntrypoints: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_ENTRYPOINTS", 322),
-    publicExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS", 10400),
+    publicExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS", 10401),
     publicFunctionExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_FUNCTION_EXPORTS", 5219),
     publicDeprecatedExports: readBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_DEPRECATED_EXPORTS",
-      3256,
+      3257,
     ),
     publicWildcardReexports: readBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_WILDCARD_REEXPORTS",

--- a/src/agents/bash-tools.exec-approval-followup.test.ts
+++ b/src/agents/bash-tools.exec-approval-followup.test.ts
@@ -3,7 +3,7 @@
  * Covers denied prompts, agent-session resume, wait handling, direct fallback,
  * and elevated runtime handoff routing.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("./tools/gateway.js", () => ({
   callGatewayTool: vi.fn(async () => ({ status: "ok" })),
@@ -18,6 +18,12 @@ import os from "node:os";
 import path from "node:path";
 import { clearSessionStoreCacheForTest } from "../config/sessions/store.js";
 import { writeSessionStoreForTest } from "../config/sessions/test-helpers.js";
+import {
+  onDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+  waitForDiagnosticEventsDrained,
+  type DiagnosticEventPayload,
+} from "../infra/diagnostic-events.js";
 import { sendMessage } from "../infra/outbound/message.js";
 import {
   buildExecApprovalFollowupPrompt,
@@ -26,6 +32,18 @@ import {
 import { callGatewayTool } from "./tools/gateway.js";
 
 const tempStoreDirs: string[] = [];
+
+function collectApprovalSuppressionEvents() {
+  const events: Array<
+    Extract<DiagnosticEventPayload, { type: "exec.approval.timeout-suppressed" }>
+  > = [];
+  const stop = onDiagnosticEvent((event) => {
+    if (event.type === "exec.approval.timeout-suppressed") {
+      events.push(event);
+    }
+  });
+  return { events, stop };
+}
 
 // Seed the same JSON session store path the runtime reads; mocking this
 // boundary would hide stale-session regressions in shared workers.
@@ -37,8 +55,13 @@ function writeTempSessionStore(entries: Record<string, { sessionId: string }>): 
   return storePath;
 }
 
+beforeEach(() => {
+  resetDiagnosticEventsForTest();
+});
+
 afterEach(() => {
   vi.resetAllMocks();
+  resetDiagnosticEventsForTest();
   clearSessionStoreCacheForTest();
   while (tempStoreDirs.length > 0) {
     const dir = tempStoreDirs.pop();
@@ -171,21 +194,36 @@ describe("exec approval followup", () => {
     const sessionStore = writeTempSessionStore({
       "agent:main:main": { sessionId: "session-after-reset" },
     });
+    const { events, stop } = collectApprovalSuppressionEvents();
 
-    const result = await sendExecApprovalFollowup({
-      approvalId: "req-denied-rebound",
-      sessionKey: "agent:main:main",
-      expectedSessionId: "session-original",
-      sessionStore,
-      direct: true,
-      turnSourceChannel: "telegram",
-      turnSourceTo: "-100123",
-      resultText: "Exec denied (gateway id=req-denied-rebound, user-denied): uname -a",
-    });
+    try {
+      const result = await sendExecApprovalFollowup({
+        approvalId: "req-denied-rebound",
+        sessionKey: "agent:main:main",
+        expectedSessionId: "session-original",
+        sessionStore,
+        direct: true,
+        turnSourceChannel: "telegram",
+        turnSourceTo: "-100123",
+        resultText: "Exec denied (gateway id=req-denied-rebound, user-denied): uname -a",
+      });
+      await waitForDiagnosticEventsDrained();
 
-    expect(result).toBe(false);
-    expect(sendMessage).not.toHaveBeenCalled();
-    expect(callGatewayTool).not.toHaveBeenCalled();
+      expect(result).toBe(false);
+      expect(sendMessage).not.toHaveBeenCalled();
+      expect(callGatewayTool).not.toHaveBeenCalled();
+      expect(events).toEqual([
+        expect.objectContaining({
+          type: "exec.approval.timeout-suppressed",
+          approvalId: "req-denied-rebound",
+          source: "agent-direct",
+          reason: "session-rebound",
+          ts: expect.any(Number),
+        }),
+      ]);
+    } finally {
+      stop();
+    }
   });
 
   it("delivers a denied direct followup when the key still resolves to the approval-time session", async () => {

--- a/src/agents/bash-tools.exec-approval-followup.ts
+++ b/src/agents/bash-tools.exec-approval-followup.ts
@@ -9,6 +9,7 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import { resolveStorePath } from "../config/sessions/paths.js";
 import { loadSessionStore } from "../config/sessions/store-load.js";
+import { emitDiagnosticEvent } from "../infra/diagnostic-events.js";
 import {
   resolveExternalBestEffortDeliveryTarget,
   type ExternalBestEffortDeliveryTarget,
@@ -397,6 +398,12 @@ export async function sendExecApprovalFollowup(
       log.info(
         `Dropping stale denied exec approval followup ${params.approvalId}: session ${sessionKey ?? ""} was rebound before the approval resolved`,
       );
+      emitDiagnosticEvent({
+        type: "exec.approval.timeout-suppressed",
+        approvalId: params.approvalId,
+        source: "agent-direct",
+        reason: "session-rebound",
+      });
       return false;
     }
     if (
@@ -426,6 +433,12 @@ export async function sendExecApprovalFollowup(
     log.info(
       `Dropping stale exec approval followup ${params.approvalId} direct fallback: session ${sessionKey ?? ""} was rebound before the approval resolved`,
     );
+    emitDiagnosticEvent({
+      type: "exec.approval.timeout-suppressed",
+      approvalId: params.approvalId,
+      source: "agent-direct",
+      reason: "session-rebound",
+    });
     return false;
   }
 

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -15,6 +15,12 @@ import {
   testing as subagentRegistryTesting,
 } from "../../agents/subagent-registry.js";
 import {
+  onDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+  waitForDiagnosticEventsDrained,
+  type DiagnosticEventPayload,
+} from "../../infra/diagnostic-events.js";
+import {
   getDetachedTaskLifecycleRuntime,
   resetDetachedTaskLifecycleRuntimeForTests,
   setDetachedTaskLifecycleRuntime,
@@ -34,6 +40,18 @@ import { expectSubagentFollowupReactivation } from "./subagent-followup.test-hel
 import type { GatewayRequestContext } from "./types.js";
 
 const envSnapshot = captureEnv(["OPENCLAW_STATE_DIR"]);
+
+function collectApprovalSuppressionEvents() {
+  const events: Array<
+    Extract<DiagnosticEventPayload, { type: "exec.approval.timeout-suppressed" }>
+  > = [];
+  const stop = onDiagnosticEvent((event) => {
+    if (event.type === "exec.approval.timeout-suppressed") {
+      events.push(event);
+    }
+  });
+  return { events, stop };
+}
 
 const mocks = vi.hoisted(() => ({
   loadSessionEntry: vi.fn(),
@@ -599,6 +617,7 @@ async function invokeAgentIdentityGet(
 describe("gateway agent handler", () => {
   afterEach(() => {
     envSnapshot.restore();
+    resetDiagnosticEventsForTest();
     resetDetachedTaskLifecycleRuntimeForTests();
     resetTaskRegistryForTests();
     resetSubagentRegistryForTests({ persist: false });
@@ -3214,37 +3233,53 @@ describe("gateway agent handler", () => {
     const context = makeContext();
     const updateSessionStoreCallsBefore = mocks.updateSessionStore.mock.calls.length;
     const agentCommandCallsBefore = mocks.agentCommand.mock.calls.length;
+    resetDiagnosticEventsForTest();
+    const { events, stop } = collectApprovalSuppressionEvents();
 
-    const respond = await invokeAgent(
-      {
-        message: "exec followup",
-        sessionKey: "agent:main:telegram:direct:123",
-        channel: "telegram",
-        idempotencyKey: registration.idempotencyKey,
-        internalRuntimeHandoffId: registration.handoffId,
-        execApprovalFollowupExpectedSessionId: "approval-time-session-id",
-      },
-      {
-        reqId: "exec-followup-rebound-drop",
-        client: backendGatewayClient(),
-        context,
-        flushDispatch: false,
-      },
-    );
+    try {
+      const respond = await invokeAgent(
+        {
+          message: "exec followup",
+          sessionKey: "agent:main:telegram:direct:123",
+          channel: "telegram",
+          idempotencyKey: registration.idempotencyKey,
+          internalRuntimeHandoffId: registration.handoffId,
+          execApprovalFollowupExpectedSessionId: "approval-time-session-id",
+        },
+        {
+          reqId: "exec-followup-rebound-drop",
+          client: backendGatewayClient(),
+          context,
+          flushDispatch: false,
+        },
+      );
+      await waitForDiagnosticEventsDrained();
 
-    expect(mockCallArg(respond, 0, 1)).toMatchObject({
-      runId: registration.idempotencyKey,
-      status: "ok",
-      summary: expect.stringContaining("exec approval followup dropped"),
-    });
-    expect(mocks.updateSessionStore.mock.calls.length).toBe(updateSessionStoreCallsBefore);
-    expect(mocks.agentCommand.mock.calls.length).toBe(agentCommandCallsBefore);
-    const dedupeEntry = context.dedupe.get("agent:exec-approval-followup:req-rebound-followup");
-    expect(dedupeEntry?.ok).toBe(true);
-    expect(dedupeEntry?.payload).toMatchObject({
-      status: "ok",
-      summary: expect.stringContaining("exec approval followup dropped"),
-    });
+      expect(mockCallArg(respond, 0, 1)).toMatchObject({
+        runId: registration.idempotencyKey,
+        status: "ok",
+        summary: expect.stringContaining("exec approval followup dropped"),
+      });
+      expect(mocks.updateSessionStore.mock.calls.length).toBe(updateSessionStoreCallsBefore);
+      expect(mocks.agentCommand.mock.calls.length).toBe(agentCommandCallsBefore);
+      const dedupeEntry = context.dedupe.get("agent:exec-approval-followup:req-rebound-followup");
+      expect(dedupeEntry?.ok).toBe(true);
+      expect(dedupeEntry?.payload).toMatchObject({
+        status: "ok",
+        summary: expect.stringContaining("exec approval followup dropped"),
+      });
+      expect(events).toEqual([
+        expect.objectContaining({
+          type: "exec.approval.timeout-suppressed",
+          approvalId: "req-rebound-followup",
+          source: "gateway-preflight",
+          reason: "session-rebound",
+          ts: expect.any(Number),
+        }),
+      ]);
+    } finally {
+      stop();
+    }
   });
 
   it("does not honor caller-supplied exec approval runtime handoff ids without registry state", async () => {

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -81,6 +81,7 @@ import {
   clearAgentRunContext,
   getAgentEventLifecycleGeneration,
 } from "../../infra/agent-events.js";
+import { emitDiagnosticEvent } from "../../infra/diagnostic-events.js";
 import { formatUncaughtError, readErrorName } from "../../infra/errors.js";
 import {
   resolveAgentDeliveryPlanWithSessionRoute,
@@ -1516,6 +1517,12 @@ export const agentHandlers: GatewayRequestHandlers = {
         context.logGateway.info(
           `Dropping stale exec approval followup ${execApprovalFollowupApprovalId}: session ${requestedSessionKeyRaw} rebound (expected ${expectedSessionId}, current ${currentSessionId}) before the approval resolved`,
         );
+        emitDiagnosticEvent({
+          type: "exec.approval.timeout-suppressed",
+          approvalId: execApprovalFollowupApprovalId,
+          source: "gateway-preflight",
+          reason: "session-rebound",
+        });
         const droppedPayload = {
           runId,
           status: "ok" as const,

--- a/src/infra/diagnostic-events.test.ts
+++ b/src/infra/diagnostic-events.test.ts
@@ -801,6 +801,33 @@ describe("diagnostic-events", () => {
     expect(internalEvents).toEqual(["log.record"]);
   });
 
+  it("exposes exec approval timeout suppression events on the public diagnostic stream", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(123);
+    const events: DiagnosticEventPayload[] = [];
+    onDiagnosticEvent((event) => {
+      events.push(event);
+    });
+
+    emitDiagnosticEvent({
+      type: "exec.approval.timeout-suppressed",
+      approvalId: "req-timeout-1",
+      source: "gateway-preflight",
+      reason: "session-rebound",
+    });
+    await waitForDiagnosticEventsDrained();
+
+    expect(events).toEqual([
+      {
+        type: "exec.approval.timeout-suppressed",
+        approvalId: "req-timeout-1",
+        source: "gateway-preflight",
+        reason: "session-rebound",
+        seq: 1,
+        ts: 123,
+      },
+    ]);
+  });
+
   it("keeps trusted private data off shared internal diagnostic listeners", async () => {
     const internalEvents: DiagnosticEventPayload[] = [];
     const trustedEvents: Array<{

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -514,6 +514,13 @@ export type DiagnosticExecProcessCompletedEvent = DiagnosticBaseEvent & {
     | "runtime-error";
 };
 
+export type DiagnosticExecApprovalTimeoutSuppressedEvent = DiagnosticBaseEvent & {
+  type: "exec.approval.timeout-suppressed";
+  approvalId: string;
+  source: "agent-direct" | "gateway-preflight";
+  reason: "session-rebound";
+};
+
 type DiagnosticRunBaseEvent = DiagnosticBaseEvent & {
   runId: string;
   sessionKey?: string;
@@ -769,6 +776,7 @@ export type DiagnosticEventPayload =
   | DiagnosticToolExecutionBlockedEvent
   | DiagnosticSkillUsedEvent
   | DiagnosticExecProcessCompletedEvent
+  | DiagnosticExecApprovalTimeoutSuppressedEvent
   | DiagnosticRunStartedEvent
   | DiagnosticRunCompletedEvent
   | DiagnosticHarnessRunStartedEvent
@@ -863,6 +871,7 @@ const ASYNC_DIAGNOSTIC_EVENT_TYPES = new Set<DiagnosticEventPayload["type"]>([
   "tool.execution.blocked",
   "skill.used",
   "exec.process.completed",
+  "exec.approval.timeout-suppressed",
   "message.delivery.started",
   "message.delivery.completed",
   "message.delivery.error",

--- a/src/logging/diagnostic-stability-bundle.test.ts
+++ b/src/logging/diagnostic-stability-bundle.test.ts
@@ -334,6 +334,57 @@ describe("diagnostic stability bundles", () => {
     }
   });
 
+  it("preserves safe approval ids when reading imported stability events", () => {
+    const file = path.join(tempDir, "imported-approval-id.json");
+    const bundle = createImportedBundle();
+    const snapshot = bundle.snapshot as Record<string, unknown>;
+    Object.assign(snapshot, {
+      count: 2,
+      events: [
+        {
+          seq: 1,
+          ts: 1,
+          type: "exec.approval.timeout-suppressed",
+          approvalId: "req-timeout-1",
+          source: "gateway-preflight",
+          reason: "session-rebound",
+        },
+        {
+          seq: 2,
+          ts: 2,
+          type: "exec.approval.timeout-suppressed",
+          approvalId: "req timeout secret",
+          source: "agent-direct",
+          reason: "session-rebound",
+        },
+      ],
+      summary: { byType: { "exec.approval.timeout-suppressed": 2 } },
+    });
+    fs.writeFileSync(file, `${JSON.stringify(bundle, null, 2)}\n`, "utf8");
+
+    const result = readDiagnosticStabilityBundleFileSync(file);
+
+    expect(result.status).toBe("found");
+    if (result.status !== "found") {
+      return;
+    }
+    expect(result.bundle.snapshot.events[0]).toEqual({
+      seq: 1,
+      ts: 1,
+      type: "exec.approval.timeout-suppressed",
+      approvalId: "req-timeout-1",
+      source: "gateway-preflight",
+      reason: "session-rebound",
+    });
+    expect(result.bundle.snapshot.events[1]).toEqual({
+      seq: 2,
+      ts: 2,
+      type: "exec.approval.timeout-suppressed",
+      source: "agent-direct",
+      reason: "session-rebound",
+    });
+  });
+
   it("rejects malformed bundle files", () => {
     const file = path.join(tempDir, "invalid.json");
     fs.writeFileSync(file, "{}\n", "utf8");

--- a/src/logging/diagnostic-stability-bundle.ts
+++ b/src/logging/diagnostic-stability-bundle.ts
@@ -688,6 +688,7 @@ function readStabilityEventRecord(
   };
 
   assignOptionalCodeString(sanitized, "channel", record.channel, `${label}.channel`);
+  assignOptionalCodeString(sanitized, "approvalId", record.approvalId, `${label}.approvalId`);
   assignOptionalCodeString(sanitized, "pluginId", record.pluginId, `${label}.pluginId`);
   assignOptionalCodeString(sanitized, "source", record.source, `${label}.source`);
   assignOptionalCodeString(sanitized, "surface", record.surface, `${label}.surface`);

--- a/src/logging/diagnostic-stability.test.ts
+++ b/src/logging/diagnostic-stability.test.ts
@@ -144,6 +144,31 @@ describe("diagnostic stability recorder", () => {
     expect(snapshot.events[1]).not.toHaveProperty("reason");
   });
 
+  it("projects exec approval timeout suppression events with approval id and timestamp", async () => {
+    startDiagnosticStabilityRecorder();
+
+    emitDiagnosticEvent({
+      type: "exec.approval.timeout-suppressed",
+      approvalId: "req-timeout-2",
+      source: "gateway-preflight",
+      reason: "session-rebound",
+    });
+    await waitForDiagnosticEventsDrained();
+
+    const snapshot = getDiagnosticStabilitySnapshot({ limit: 10 });
+
+    expectFields(snapshot.summary.byType, {
+      "exec.approval.timeout-suppressed": 1,
+    });
+    expectFields(snapshot.events[0], {
+      type: "exec.approval.timeout-suppressed",
+      approvalId: "req-timeout-2",
+      source: "gateway-preflight",
+      reason: "session-rebound",
+    });
+    expect(snapshot.events[0]?.ts).toEqual(expect.any(Number));
+  });
+
   it("summarizes inbound delivery proof events without message content", () => {
     startDiagnosticStabilityRecorder();
 

--- a/src/logging/diagnostic-stability.ts
+++ b/src/logging/diagnostic-stability.ts
@@ -39,6 +39,7 @@ export type DiagnosticStabilityEventRecord = {
   pairedToolName?: string;
   provider?: string;
   model?: string;
+  approvalId?: string;
   durationMs?: number;
   requestBytes?: number;
   responseBytes?: number;
@@ -430,6 +431,11 @@ function sanitizeDiagnosticEvent(event: DiagnosticEventPayload): DiagnosticStabi
       record.timedOut = event.timedOut;
       record.failureKind = event.failureKind;
       assignReasonCode(record, event.failureKind);
+      break;
+    case "exec.approval.timeout-suppressed":
+      record.approvalId = event.approvalId;
+      record.source = event.source;
+      assignReasonCode(record, event.reason);
       break;
     case "run.started":
       record.provider = event.provider;


### PR DESCRIPTION
## Summary

- Adds a public `exec.approval.timeout-suppressed` diagnostic event for stale exec approval timeout follow-ups that are intentionally dropped after a session rebound.
- Emits the event from both suppression paths: direct follow-up delivery and gateway preflight.
- Carries only bounded operator metadata: `approvalId`, `source`, and `reason`; no session key, route id, command text, or channel target is added.
- Projects the event into diagnostic stability snapshots and preserves safe approval ids when persisted stability bundles are read back.
- Updates the plugin SDK surface budget for the new public diagnostic event type.

## What Problem This Solves

When an exec approval timeout follow-up is stale because the target session was rebound by reset/new-session flow, OpenClaw intentionally suppresses the follow-up. Before this patch, that suppression was only visible through a free-form log line, so operator tooling could not reliably distinguish an intentional stale suppression from lost delivery or a stuck approval path.

Closes #98279

## Why This Change Was Made

The existing stale-session guards already know when the approval-time session no longer matches the current session. The fix emits a structured diagnostic event at those existing guards without changing delivery, dedupe, session mutation, or approval resolution behavior.

The event name follows the issue wording: `exec.approval.timeout-suppressed`. The payload uses `source: "agent-direct" | "gateway-preflight"` to identify which suppression point fired and `reason: "session-rebound"` for a stable low-cardinality reason code.

## User Impact

Operators and diagnostics consumers can subscribe to the public diagnostic stream or inspect stability/support bundles to see when an approval timeout follow-up was intentionally suppressed. Existing end-user behavior is unchanged.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security
- [ ] Chore

## Scope

- [x] Gateway
- [ ] Skills
- [ ] Auth
- [ ] Memory
- [ ] Integrations
- [x] API
- [ ] UI/UX
- [ ] CI

## Evidence

- `node scripts/run-vitest.mjs src/agents/bash-tools.exec-approval-followup.test.ts` passed.
- `node scripts/run-vitest.mjs src/infra/diagnostic-events.test.ts src/logging/diagnostic-stability.test.ts src/logging/diagnostic-stability-bundle.test.ts` passed.
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/server-methods/agent.test.ts -t "drops a stale exec approval followup at preflight"` exited 0.
- `node scripts/plugin-sdk-surface-report.mjs --check` passed.
- `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json <changed files>` passed.
- `timeout 360s node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo` passed.
- `timeout 180s node scripts/run-tsgo.mjs -p extensions/diagnostics-otel/tsconfig.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/diagnostics-otel.tsbuildinfo` passed.
- `timeout 180s node scripts/run-tsgo.mjs -p extensions/diagnostics-prometheus/tsconfig.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/diagnostics-prometheus.tsbuildinfo` passed.
- `git diff --check` passed.

## Real behavior proof

**Behavior addressed:** A stale approval-timeout follow-up is suppressed and emits a structured `exec.approval.timeout-suppressed` event with the approval id, suppression source, reason, and dispatcher timestamp.

**Environment tested:** Linux workspace, Node 22.22.0, current `main` plus this patch.

**Steps run after the patch:** Ran `node --import tsx --no-warnings -e ...` and imported the real `sendExecApprovalFollowup`, `onDiagnosticEvent`, and `waitForDiagnosticEventsDrained` functions. The script seeded a temp session store where `agent:main:main` had already rebound from `session-original` to `session-after-reset`, then sent an approval-timeout follow-up for the original session.

**Evidence after fix:**

```text
[agents/exec-approval-followup] Dropping stale denied exec approval followup req-proof-rebound: session agent:main:main was rebound before the approval resolved
{
  "result": false,
  "events": [
    {
      "type": "exec.approval.timeout-suppressed",
      "approvalId": "req-proof-rebound",
      "source": "agent-direct",
      "reason": "session-rebound",
      "seq": 2,
      "ts": 1782863776172
    }
  ]
}
```

**Observed result after the fix:** The follow-up returned `false`, no delivery was attempted, and the public diagnostic subscriber received exactly the new suppression event with `approvalId`, `source`, `reason`, and `ts`.

**What was not tested:** A live external channel timeout with real user interaction was not exercised; the proof calls the production follow-up function directly with a real session-store rebound scenario.

## Root Cause

- Root cause: stale approval-timeout follow-ups were intentionally dropped after session rebound, but the drop paths only wrote free-form log messages.
- Missing guardrail: the existing diagnostic event stream and stability recorder had no event type for this suppression.

## Regression Test Plan

- Direct follow-up test asserts the public diagnostic stream receives `exec.approval.timeout-suppressed` when a denied timeout follow-up is stale.
- Gateway preflight test asserts the event is emitted before the rebound session is touched.
- Diagnostic events test confirms public subscribers receive the event.
- Stability recorder test confirms snapshots include approval id, source, reason, and timestamp.
- Stability bundle test confirms safe approval ids survive imported bundle sanitization and unsafe ids are dropped.

## Impact Assessment

- Scope: additive diagnostic event emitted from two existing stale-session guards.
- Downstream: public diagnostic stream and stability/support-bundle readers gain a new event type; delivery behavior and session mutation are unchanged.
- Edge cases: empty or malformed imported approval ids are not preserved by the bundle reader because it only keeps safe diagnostic code strings.
- Hard-coded values: no runtime configuration defaults were added; event values are derived from the suppression path and approval id already present at the call site.
- Existing fixes: open PRs #98292 and #98293 were checked. This patch keeps the event payload narrow, covers direct and gateway suppression paths, preserves persisted stability correlation, and includes production-function proof.

## Security Impact

- New permissions: No
- Secrets handling changed: No
- New network calls: No
- Payload text, command text, session keys, chat ids, and route ids are not added to the event.
