### PR TITLE
fix(ios): advance onboarding step after QR scan

### DIFF
--- a/apps/ios/Sources/Onboarding/OnboardingWizardView.swift
+++ b/apps/ios/Sources/Onboarding/OnboardingWizardView.swift
@@ -730,6 +730,7 @@ extension OnboardingWizardView {
         self.showQRScanner = false
         self.connectMessage = "Connecting via QR code..."
         self.statusLine = "QR loaded. Connecting to \(link.host):\(link.port)..."
+        self.step = .connect
         Task { await self.connectManual() }
     }
 


### PR DESCRIPTION
## What Problem This Solves

After scanning a QR code from the iOS onboarding welcome screen, the scanner sheet dismisses and the UI returns to the welcome screen instead of advancing to the connection progress step. The connection fires in the background via `connectManual()` but the user sees no visual feedback — the app appears to do nothing.

## Why This Change Was Made

`handleScannedLink` in `OnboardingWizardView.swift` does not set `self.step = .connect` after a successful QR scan. The sibling method `handleScannedSetupCode` (for pasted setup codes) correctly advances the step at line 723, but the QR scan path at line 727 was missing it.

This is a one-line fix to align the QR scan path with the setup code path.

## User Impact

- **Before:** Scanning a pairing QR code from the welcome screen dismisses the scanner and returns to "Welcome" — no connection progress visible. Users think the scan failed.
- **After:** Scanning advances to the connect step showing "Connecting via QR code..." with live status updates.

## Evidence

Reproduced on latest `upstream/main` (`5e572dcf781`), built and deployed to a physical iPhone on a LAN-bound gateway (`ws://192.168.1.249:18789`). After adding `self.step = .connect`, the QR scan correctly navigates to the connect step, shows pairing progress, and completes device pairing after gateway approval.

Fixes #98297

— [Joel Nishanth](https://offlyn.ai) · [offlyn.AI](https://offlyn.ai)

Made with [Cursor](https://cursor.com)