### PR TITLE
fix: restore return key in iOS chat composer

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
@@ -517,10 +517,7 @@ struct OpenClawChatComposer: View {
                 axis: .vertical)
                 .font(.body)
                 .lineLimit(1...4)
-                .submitLabel(.send)
-                .onSubmit {
-                    self.sendDraftIfEnabled()
-                }
+                .submitLabel(.return)
                 .frame(
                     minHeight: self.textMinHeight,
                     idealHeight: self.textMinHeight,

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatDynamicTypeSourceGuardTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatDynamicTypeSourceGuardTests.swift
@@ -14,6 +14,14 @@ struct ChatDynamicTypeSourceGuardTests {
         #expect(sources.composer.contains("@ScaledMetric(relativeTo: .body)"))
     }
 
+    @Test func `chat composer keeps iOS return key for multiline input`() throws {
+        let sources = try Self.scopedChatTextSources()
+
+        #expect(!sources.composer.contains(".submitLabel(.send)"))
+        #expect(!sources.composer.contains(".onSubmit"))
+        #expect(sources.composer.contains(".submitLabel(.return)"))
+    }
+
     private static func scopedChatTextSources() throws -> (
         messageViews: String,
         chatView: String,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users typing in the iOS chat composer would see a Send key instead of a Return key, making it awkward to enter multiline messages.

AI-assisted: yes.

## Why This Change Was Made

The iOS composer already has a visible arrow send button, so the keyboard submit action should not also be the send path. This changes the vertical chat TextField to advertise Return and removes submit-to-send behavior from the iOS keyboard path while preserving the existing send button behavior.

## User Impact

iOS users can add line breaks while composing longer chat messages and still send with the visible composer send button.

## Evidence

- Ran git diff --check.
- Ran a source guard sanity check confirming ChatComposer.swift no longer contains .submitLabel(.send) or .onSubmit, and now contains .submitLabel(.return).
- Added a focused source guard test for the iOS chat composer return-key behavior.

Not run locally: Swift/iOS test target and simulator proof, because this Windows host does not have swift, xcodebuild, xcodegen, swiftformat, or swiftlint available.
