### PR TITLE
fix(agent-model): omit synthesized maxTokens fallback when nothing was configured

### DIFF
--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -1243,6 +1243,39 @@ describe("resolveModel", () => {
     });
   });
 
+  it("leaves maxTokens undefined when no configured or catalog value is available (regression: #98295)", () => {
+    // Regression for https://github.com/openclaw/openclaw/issues/98295.
+    // A custom provider entry without maxTokens (and no matching bundled
+    // static catalog row) must not synthesize an oversized output cap from
+    // DEFAULT_CONTEXT_TOKENS. Leaving maxTokens undefined lets the transport
+    // omit `max_completion_tokens` so the provider applies its own default,
+    // avoiding HTTP 400 (Param Incorrect) from strict OpenAI-compatible
+    // servers whose completion-token ceiling is below the synthesized value.
+    resolveBundledStaticCatalogModelMock.mockReturnValueOnce(undefined);
+    const cfg = {
+      models: {
+        providers: {
+          xiaomi: {
+            baseUrl: "https://api.xiaomimimo.com/v1",
+            models: [
+              {
+                id: "mimo-v2.5-pro",
+                name: "mimo-v2.5-pro",
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveModelForTest("xiaomi", "mimo-v2.5-pro", "/tmp/agent", cfg);
+    const model = expectResolvedModel(result);
+
+    expect(model.id).toBe("mimo-v2.5-pro");
+    expect(model.baseUrl).toBe("https://api.xiaomimimo.com/v1");
+    expect(model.maxTokens).toBeUndefined();
+  });
+
   it("inherits bundled static transport for configured provider fallback models", () => {
     resolveBundledStaticCatalogModelMock.mockReturnValueOnce({
       provider: "deepseek",

--- a/src/agents/embedded-agent-runner/model.ts
+++ b/src/agents/embedded-agent-runner/model.ts
@@ -1370,14 +1370,8 @@ function resolveConfiguredFallbackModel(params: {
             providerConfig?.contextTokens ??
             providerConfig?.models?.[0]?.contextTokens ??
             staticCatalogModel?.contextTokens,
-          // Do NOT synthesize a `maxTokens` fallback from DEFAULT_CONTEXT_TOKENS.
-          // For strict OpenAI-compatible providers, `model.maxTokens` becomes
-          // the request `max_completion_tokens` (see openai-transport-stream);
-          // fabricating an unrelated wire-level cap when the user configured
-          // no output limit produces HTTP 400 ("Param Incorrect") on providers
-          // whose ceiling is lower than 200k tokens. When nothing is known,
-          // leave it undefined so the transport omits the field and the
-          // provider applies its own default (regression: #98295).
+          // maxTokens is a wire-level output cap, not a context-budget fallback.
+          // Omit an unknown cap so strict providers can apply their own limit.
           ...(resolvedFallbackMaxTokens !== undefined
             ? { maxTokens: resolvedFallbackMaxTokens }
             : {}),

--- a/src/agents/embedded-agent-runner/model.ts
+++ b/src/agents/embedded-agent-runner/model.ts
@@ -1330,6 +1330,11 @@ function resolveConfiguredFallbackModel(params: {
     compat: fallbackCompat,
     reasoning: metadataModel?.reasoning,
   });
+  const resolvedFallbackMaxTokens =
+    configuredModel?.maxTokens ??
+    providerConfig?.maxTokens ??
+    providerConfig?.models?.[0]?.maxTokens ??
+    staticCatalogModel?.maxTokens;
   return normalizeResolvedModel({
     provider,
     cfg,
@@ -1365,12 +1370,17 @@ function resolveConfiguredFallbackModel(params: {
             providerConfig?.contextTokens ??
             providerConfig?.models?.[0]?.contextTokens ??
             staticCatalogModel?.contextTokens,
-          maxTokens:
-            configuredModel?.maxTokens ??
-            providerConfig?.maxTokens ??
-            providerConfig?.models?.[0]?.maxTokens ??
-            staticCatalogModel?.maxTokens ??
-            DEFAULT_CONTEXT_TOKENS,
+          // Do NOT synthesize a `maxTokens` fallback from DEFAULT_CONTEXT_TOKENS.
+          // For strict OpenAI-compatible providers, `model.maxTokens` becomes
+          // the request `max_completion_tokens` (see openai-transport-stream);
+          // fabricating an unrelated wire-level cap when the user configured
+          // no output limit produces HTTP 400 ("Param Incorrect") on providers
+          // whose ceiling is lower than 200k tokens. When nothing is known,
+          // leave it undefined so the transport omits the field and the
+          // provider applies its own default (regression: #98295).
+          ...(resolvedFallbackMaxTokens !== undefined
+            ? { maxTokens: resolvedFallbackMaxTokens }
+            : {}),
           ...(resolvedParams ? { params: resolvedParams } : {}),
           ...(requestTimeoutMs !== undefined ? { requestTimeoutMs } : {}),
           headers: requestConfig.headers,

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -7667,6 +7667,31 @@ describe("openai transport stream", () => {
     expect(params).not.toHaveProperty("max_tokens");
   });
 
+  it("omits output-token fields when the resolved model has no known cap", () => {
+    const params = buildOpenAICompletionsParams(
+      {
+        id: "mimo-v2.5-pro",
+        name: "MiMo V2.5 Pro",
+        api: "openai-completions",
+        provider: "xiaomi",
+        baseUrl: "https://api.xiaomimimo.com/v1",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 1_048_576,
+      } as Model<"openai-completions">,
+      {
+        systemPrompt: "system",
+        messages: [],
+        tools: [],
+      } as never,
+      undefined,
+    );
+
+    expect(params).not.toHaveProperty("max_completion_tokens");
+    expect(params).not.toHaveProperty("max_tokens");
+  });
+
   it("uses model params max_completion_tokens for OpenAI completions before model maxTokens", () => {
     const params = buildOpenAICompletionsParams(
       {


### PR DESCRIPTION
Fixes #98295

## What Problem This Solves

Fixes an issue where users routing through custom OpenAI-compatible providers whose per-request output ceiling is below 200k tokens (e.g. Xiaomi MiMo, whose `max_completion_tokens` cap is 131_072) hit an unrecoverable HTTP 400 on the very first turn:

```
LLMResponseError: Xiaomi MiMo API stream error: [400] Param Incorrect
```

The failure reproduces reliably when the model row was added via `models add` on a provider entry that predates the bundled catalog (or on a provider whose bundled row is under a different provider id, e.g. adding `mimo-v2.5-pro` under `xiaomi` rather than the bundled `xiaomi-token-plan`). In that setup the configured row omits `maxTokens`, so nothing in the config or catalog carries an explicit output cap, and every request is rejected before the first token is returned.

## Why This Change Was Made

When no `maxTokens` is supplied by the configured model, the containing provider entry, the first sibling model, or the matching bundled catalog row, `resolveConfiguredFallbackModel` was defaulting the resolved `model.maxTokens` to `DEFAULT_CONTEXT_TOKENS` (200_000). For strict OpenAI-compatible providers, that resolved value is forwarded on the wire as `max_completion_tokens` on every request (see `resolveOpenAICompletionsMaxTokens` in `src/agents/openai-transport-stream.ts`). The synthesized 200k cap therefore silently becomes a wire-level output budget that has no basis in the actual model and exceeds the provider ceiling.

The sibling `applyConfiguredProviderOverrides` path already omits `maxTokens` when nothing resolves; the transport's `if (clampedMaxTokens)` gate then drops the field entirely and the provider applies its own default. This change aligns `resolveConfiguredFallbackModel` with that behavior: when none of the source layers supply a `maxTokens`, leave it undefined instead of fabricating one from `DEFAULT_CONTEXT_TOKENS`. `contextWindow` still retains `DEFAULT_CONTEXT_TOKENS` as its local budgeting fallback because it is used for compaction/session sizing and is not shipped on the wire.

Scope is narrow on purpose: no changes to bundled catalogs, no new validation errors, no changes to any path where a `maxTokens` value is actually available.

## User Impact

- Users with custom or user-added rows for Xiaomi MiMo (`mimo-v2.5`, `mimo-v2.5-pro`) and any other OpenAI-compatible provider whose ceiling is below 200k can now complete their first turn instead of getting stopped by `[400] Param Incorrect` at request time.
- No behavior change for models that already resolve a real `maxTokens` from the config, the provider entry, or the bundled static catalog: the same value flows through unchanged. The only observable difference is in the "nothing was configured anywhere" case, where the request now goes out without `max_completion_tokens` and the provider applies its own default (the correct behavior when the user has configured no output limit).
- Reduces the surface area for the same class of bug across other providers whose per-request output ceiling is lower than the OpenClaw synthesized default.

## Evidence

Regression test added at `src/agents/embedded-agent-runner/model.test.ts` (`"leaves maxTokens undefined when no configured or catalog value is available (regression: #98295)"`) reproduces the reporter's config (custom `xiaomi` provider with a `mimo-v2.5-pro` row that omits `maxTokens`, no matching bundled catalog row) and asserts `model.maxTokens` is `undefined`.

Verified in both directions on the same worktree:

- Base (fix reverted, test kept): the assertion fails with `Expected: undefined / Received: 200000`, confirming the synthesized wire-level cap is exactly the value that becomes the failing `max_completion_tokens`.
- Fix applied: the assertion passes; `model.maxTokens` is `undefined`, the transport omits `max_completion_tokens`, and the provider applies its own default.

Full `model.test.ts` suite (121 tests) passes locally. Adjacent files also green:

```
model.test.ts                                    121 tests passed
model.static-catalog.test.ts                      17 tests passed
model.forward-compat.errors-and-overrides.test.ts 27 tests passed
model.forward-compat.test.ts                       4 tests passed
model.skip-agent-discovery-hooks.test.ts           1 test  passed
model.startup-retry.test.ts                        2 tests passed
model.inline-provider.test.ts                     13 tests passed
```

`git diff origin/main..HEAD --stat`:

```
 src/agents/embedded-agent-runner/model.test.ts | 33 ++++++++++++++++++++++++++
 src/agents/embedded-agent-runner/model.ts      | 22 ++++++++++++-----
 2 files changed, 49 insertions(+), 6 deletions(-)
```

Lint (`oxlint`) and format (`oxfmt --check`) both clean on the two changed files.

---

*AI disclosure: this change was drafted with the assistance of Claude. I have reviewed the diff and the regression test and take responsibility for the code.*
