### PR TITLE
fix(pairing): fail closed when allowFrom store is unreadable before rewrite

### DIFF
--- a/src/pairing/pairing-store.test.ts
+++ b/src/pairing/pairing-store.test.ts
@@ -620,6 +620,48 @@ describe("pairing store", () => {
     });
   });
 
+  it("refuses to clobber the allowFrom store when the base file is present-but-unreadable", async () => {
+    await withTempStateDir(async (stateDir, env) => {
+      const allowFromPath = resolveAllowFromFilePath(stateDir, "telegram", "yy");
+      await writeAllowFromFixture({
+        stateDir,
+        channel: "telegram",
+        accountId: "yy",
+        allowFrom: ["1001", "1002"],
+      });
+      clearPairingAllowFromReadCacheForTest();
+
+      const error = Object.assign(new Error("permission denied"), { code: "EACCES" });
+      const originalReadFile = fsSync.promises.readFile.bind(fsSync.promises);
+      const readSpy = vi
+        .spyOn(fsSync.promises, "readFile")
+        .mockImplementation(async (target, ...rest) => {
+          if (typeof target === "string" && target === allowFromPath) {
+            throw error;
+          }
+          return await originalReadFile(target as never, ...(rest as []));
+        });
+
+      try {
+        await expect(
+          addChannelAllowFromStoreEntry({
+            channel: "telegram",
+            accountId: "yy",
+            entry: "1003",
+            env,
+          }),
+        ).rejects.toBe(error);
+      } finally {
+        readSpy.mockRestore();
+      }
+
+      const persisted = JSON.parse(fsSync.readFileSync(allowFromPath, "utf8")) as {
+        allowFrom: string[];
+      };
+      expect(persisted.allowFrom).toEqual(["1001", "1002"]);
+    });
+  });
+
   it("reads allowFrom variants with account-scoped isolation", async () => {
     await withTempStateDir(async (stateDir, env) => {
       for (const { setup, accountId, expected, expectedLegacy } of [

--- a/src/pairing/pairing-store.ts
+++ b/src/pairing/pairing-store.ts
@@ -359,14 +359,14 @@ async function readAllowFromState(params: {
   filePath: string;
   pairingAdapter?: ChannelPairingAdapter;
 }): Promise<{ current: string[]; normalized: string | null }> {
-  const { value } = await readJsonFile<AllowFromStore>(params.filePath, {
-    version: 1,
-    allowFrom: [],
-  });
   const pairingAdapter = resolvePairingAdapter(params.channel, params.pairingAdapter);
-  const current = normalizeAllowFromList(value, pairingAdapter);
+  const { entries } = await readAllowFromFileWithExists({
+    cacheNamespace: PAIRING_ALLOW_FROM_CACHE_NAMESPACE,
+    filePath: params.filePath,
+    normalizeStore: (store) => normalizeAllowFromList(store, pairingAdapter),
+  });
   const normalized = normalizeAllowFromInput(params.entry, pairingAdapter);
-  return { current, normalized: normalized || null };
+  return { current: entries, normalized: normalized || null };
 }
 
 async function writeAllowFromState(filePath: string, allowFrom: string[]): Promise<void> {


### PR DESCRIPTION
## What Problem This Solves

`allowFrom` is the durable per-channel list of who is authorized to reach the bot. It is mutated from two real user surfaces: the in-chat `/allow` command (`src/auto-reply/reply/commands-allowlist.ts`) and pairing approve (`approveChannelPairingCode` -> `addChannelAllowFromStoreEntry`). Both route through `updateAllowFromStoreEntry`, whose internal read went through `readJsonFile`.

`readJsonFile` (via `tryReadJson`) swallows every non-ENOENT filesystem error and returns an empty fallback. If the store file is present but unreadable to the running gateway (the classic case of a root-owned `0600` file left behind after a `sudo` run once the service runs unprivileged, the same trigger that motivated the config guard in #78493), the mutator reads the current list as empty, then writes only the new entry. Every previously authorized sender is silently deleted (`changed: true`, no error thrown), locking the whole team out until each re-pairs.

This diverges from the enforcement path (`readChannelAllowFromStore`), which already reads through `readAllowFromFileWithExists` and rethrows non-ENOENT errors. The read that guards access fails closed; the read that precedes a full-file rewrite did not.

## Why This Change Was Made

An access-control list should never be silently destroyed because its backing file briefly became unreadable. The mutator was simply never migrated to the fail-closed read contract the enforcement path already uses. Routing it through the same reader makes an unreadable base abort the write instead of overwriting durable state with an empty-derived list.

## User Impact

Operators whose `allowFrom` store becomes root-owned or otherwise unreadable no longer lose their entire authorization list on the next `/allow` or pairing approval. The mutation now surfaces the underlying `EACCES` and leaves the stored list intact, so recovery is fixing the file permission rather than re-pairing every authorized sender. A genuinely missing file (first-ever pairing) still reads as empty and writes normally.

## Root cause

`src/pairing/pairing-store.ts`, `readAllowFromState` (the read half of `updateAllowFromStoreEntry`):

```ts
// before
const { value } = await readJsonFile<AllowFromStore>(params.filePath, {
  version: 1,
  allowFrom: [],
});
const pairingAdapter = resolvePairingAdapter(params.channel, params.pairingAdapter);
const current = normalizeAllowFromList(value, pairingAdapter);
```

`readJsonFile` -> `tryReadJson` catches all read errors and returns `null`, so a present-but-unreadable store collapses to the empty fallback. `updateAllowFromStoreEntry` then appends the new entry to `[]` and writes it, dropping the real list.

## Fix

```ts
// after
const pairingAdapter = resolvePairingAdapter(params.channel, params.pairingAdapter);
const { entries } = await readAllowFromFileWithExists({
  cacheNamespace: PAIRING_ALLOW_FROM_CACHE_NAMESPACE,
  filePath: params.filePath,
  normalizeStore: (store) => normalizeAllowFromList(store, pairingAdapter),
});
```

`readAllowFromFileWithExists` rethrows non-ENOENT errors and only treats a missing file as empty, the same contract the enforcement reads already use. On an unreadable base the mutation now throws before writing, so the stored list is preserved.

## Why this is the right boundary

- One canonical reader. The enforcement path and the mutator now share `readAllowFromFileWithExists` and the same cache namespace, removing the divergent `readJsonFile` read that caused the asymmetry.
- Both mutation surfaces are covered. `/allow` and pairing approve both go through `updateAllowFromStoreEntry` -> `readAllowFromState`; add and remove (`addChannelAllowFromStoreEntry`, `removeChannelAllowFromStoreEntry`) share this single read.
- Missing-file behavior is unchanged: `readAllowFromFileWithExists` returns empty entries for ENOENT, so first-time pairing still writes normally.
- Net production change is smaller than before.

## Verification

- `node scripts/run-vitest.mjs src/pairing/pairing-store.test.ts src/pairing/allow-from-store-file.test.ts` -> 17 passed. New case fails on pristine main (mutation does not reject, file left mutated) and passes with the patch.
- `node scripts/run-oxlint.mjs src/pairing/pairing-store.ts src/pairing/pairing-store.test.ts` -> clean.
- `oxfmt --check src/pairing/pairing-store.ts src/pairing/pairing-store.test.ts` -> clean.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json` and `-p test/tsconfig/tsconfig.core.test.json` -> exit 0.

## Real behavior proof

Behavior addressed: pairing approve / `/allow` (real `addChannelAllowFromStoreEntry`) clobbered the whole `allowFrom` list to just the new entry when the store file was present but unreadable to the gateway.

Real environment tested: drove the real exported `addChannelAllowFromStoreEntry` on the real on-disk pairing store, on pristine main and on the patched tree (head afccca7). A root-owned `0600` `allowFrom.json` seeded with `["userA","userB"]` was made genuinely unreadable by running the mutation in a child process dropped to the unprivileged `nobody` user (`spawnSync` with `uid`/`gid` of `nobody`). Real filesystem permissions, the real `withFileLock`, the real reader, and the real atomic writer stayed in play; nothing was mocked.

Exact steps or command run after this patch: seed `telegram-team-allowFrom.json = {"version":1,"allowFrom":["userA","userB"]}` root-owned `0600`, confirm `nobody` cannot read it, then call `addChannelAllowFromStoreEntry({channel:"telegram", accountId:"team", entry:"userC"})` as `nobody`, and read the file back as root.

Evidence after fix:
```
# BEFORE (pristine main)
SEED   telegram-team-allowFrom.json = { "version": 1, "allowFrom": [ "userA", "userB" ] }
READ   as nobody -> Permission denied
RESULT changed=true  allowFrom=["userC"]
FINAL  telegram-team-allowFrom.json = { "version": 1, "allowFrom": [ "userC" ] }

# AFTER (this patch, identical inputs)
SEED   telegram-team-allowFrom.json = { "version": 1, "allowFrom": [ "userA", "userB" ] }
READ   as nobody -> Permission denied
RESULT threw code=EACCES (EACCES: permission denied, open '.../telegram-team-allowFrom.json')
FINAL  telegram-team-allowFrom.json = { "version": 1, "allowFrom": [ "userA", "userB" ] }
```

Observed result after fix: with an unreadable store the mutation now fails with EACCES and leaves `["userA","userB"]` intact, instead of silently rewriting the file to `["userC"]` and dropping every prior authorized sender.

What was not tested: no live channel gateway or real pairing message round-trip; the exercised surface is the on-disk allowFrom store mutation reached by `/allow` and pairing approve. Full build not run.
