### PR TITLE
docs(matrix): document missing streaming.progress mode, progress sub-fields, and mentionPatterns config

### DIFF
--- a/docs/channels/matrix.md
+++ b/docs/channels/matrix.md
@@ -221,9 +221,9 @@ The full object form accepts `{ mode, preview, progress }`:
       streaming: {
         mode: "progress",
         progress: {
-          label: "Working", // optional custom label (false to hide)
-          labels: ["Thinking", "Writing", "Searching"], // auto-rotate pool
-          maxLines: 8, // max compact progress lines (default: 8)
+          label: "auto", // pick from configured or built-in labels (false to hide)
+          labels: ["Thinking", "Writing", "Searching"], // candidates for label: "auto"
+          maxLines: 8, // max rolling progress lines (default: 8)
           maxLineChars: 120, // max chars per line before truncation (default: 120)
           toolProgress: true, // show tool/progress activity (default: true)
         },
@@ -233,9 +233,9 @@ The full object form accepts `{ mode, preview, progress }`:
 }
 ```
 
-- `progress.label`: a custom label, `"auto"` for built-in single-word labels, or `false` to hide the title.
-- `progress.labels`: candidate labels for `label: "auto"` rotation. Leave unset for built-in defaults.
-- `progress.maxLines`: maximum compact progress lines kept below the draft label. After this limit, older lines are trimmed.
+- `progress.label`: a custom label, `"auto"` or unset to choose from configured or built-in labels, or `false` to hide the label line.
+- `progress.labels`: candidate labels used only when `label` is `"auto"` or unset. Leave unset for built-in defaults.
+- `progress.maxLines`: maximum rolling progress lines kept in the draft. After this limit, older lines are trimmed.
 - `progress.maxLineChars`: maximum characters per compact progress line before truncation.
 - `progress.toolProgress`: when `true` (default), live tool/progress activity appears in the draft.
 

--- a/docs/channels/matrix.md
+++ b/docs/channels/matrix.md
@@ -212,11 +212,39 @@ form:
 }
 ```
 
+The full object form accepts `{ mode, preview, progress }`:
+
+```json5
+{
+  channels: {
+    matrix: {
+      streaming: {
+        mode: "progress",
+        progress: {
+          label: "Working", // optional custom label (false to hide)
+          labels: ["Thinking", "Writing", "Searching"], // auto-rotate pool
+          maxLines: 8, // max compact progress lines (default: 8)
+          maxLineChars: 120, // max chars per line before truncation (default: 120)
+          toolProgress: true, // show tool/progress activity (default: true)
+        },
+      },
+    },
+  },
+}
+```
+
+- `progress.label`: a custom label, `"auto"` for built-in single-word labels, or `false` to hide the title.
+- `progress.labels`: candidate labels for `label: "auto"` rotation. Leave unset for built-in defaults.
+- `progress.maxLines`: maximum compact progress lines kept below the draft label. After this limit, older lines are trimmed.
+- `progress.maxLineChars`: maximum characters per compact progress line before truncation.
+- `progress.toolProgress`: when `true` (default), live tool/progress activity appears in the draft.
+
 | `streaming`       | Behavior                                                                                                                                                            |
 | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `"off"` (default) | Wait for the full reply, send once. `true` ↔ `"partial"`, `false` ↔ `"off"`.                                                                                        |
 | `"partial"`       | Edit one normal text message in place as the model writes the current block. Stock Matrix clients may notify on the first preview, not the final edit.              |
 | `"quiet"`         | Same as `"partial"` but the message is a non-notifying notice. Recipients only get a notification once a per-user push rule matches the finalized edit (see below). |
+| `"progress"`      | Sends individual compact progress lines using a progress draft.                                                                                                     |
 
 `blockStreaming` is independent of `streaming`:
 
@@ -877,6 +905,7 @@ Room allowlist keys (`groups`, legacy `rooms`) should be room IDs or aliases. Pl
 
 - `groupPolicy`: `"open"`, `"allowlist"`, or `"disabled"`. Default: `"allowlist"`.
 - `groupAllowFrom`: allowlist of user IDs for room traffic.
+- `mentionPatterns`: scoped regex patterns for room mentions. Object with `{ mode: "allow"|"deny", allowIn: [roomId, ...], denyIn: [roomId, ...] }`. Controls whether configured `agents.list[].groupChat.mentionPatterns` apply per-room.
 - `dm.enabled`: when `false`, ignore all DMs. Default: `true`.
 - `dm.policy`: `"pairing"` (default), `"allowlist"`, `"open"`, or `"disabled"`. Applies after the bot has joined and classified the room as a DM; it does not affect invite handling.
 - `dm.allowFrom`: allowlist of user IDs for DM traffic.
@@ -894,7 +923,7 @@ Room allowlist keys (`groups`, legacy `rooms`) should be room IDs or aliases. Pl
 - `replyToMode`: `"off"`, `"first"`, `"all"`, or `"batched"`.
 - `threadReplies`: `"off"`, `"inbound"`, or `"always"`.
 - `threadBindings`: per-channel overrides for thread-bound session routing and lifecycle.
-- `streaming`: `"off"` (default), `"partial"`, `"quiet"`, or object form `{ mode, preview: { toolProgress } }`. `true` ↔ `"partial"`, `false` ↔ `"off"`.
+- `streaming`: `"off"` (default), `"partial"`, `"quiet"`, `"progress"`, or object form `{ mode, preview: { toolProgress }, progress: { label, labels, maxLines, maxLineChars, toolProgress } }`. `true` ↔ `"partial"`, `false` ↔ `"off"`.
 - `blockStreaming`: when `true`, completed assistant blocks are kept as separate progress messages.
 - `markdown`: optional Markdown rendering config for outbound text.
 - `responsePrefix`: optional string prepended to outbound replies.
@@ -914,7 +943,10 @@ Room allowlist keys (`groups`, legacy `rooms`) should be room IDs or aliases. Pl
 - `actions`: per-action tool gating (`messages`, `reactions`, `pins`, `profile`, `memberInfo`, `channelInfo`, `verification`).
 - `groups`: per-room policy map. Session identity uses the stable room ID after resolution. (`rooms` is a legacy alias.)
   - `groups.<room>.account`: restrict one inherited room entry to a specific account.
+  - `groups.<room>.enabled`: per-room toggle. When `false`, the room is ignored as if it were not in the map.
+  - `groups.<room>.requireMention`: per-room override of the channel-level mention requirement.
   - `groups.<room>.allowBots`: per-room override of the channel-level setting (`true` or `"mentions"`).
+  - `groups.<room>.botLoopProtection`: per-room override for bot-to-bot loop protection budget.
   - `groups.<room>.users`: per-room sender allowlist.
   - `groups.<room>.tools`: per-room tool allow/deny overrides.
   - `groups.<room>.autoReply`: per-room mention-gating override. `true` disables mention requirements for that room; `false` forces them back on.


### PR DESCRIPTION
## What Problem This Solves

Four config areas in the Matrix config schema (`extensions/matrix/src/config-schema.ts`) had missing or incomplete documentation in `docs/channels/matrix.md`:

1. **`streaming: "progress"`** — a valid streaming mode value accepted by the schema but missing from the streaming behavior table
2. **`streaming.progress`** object — 5 sub-fields (`label`, `labels`, `maxLines`, `maxLineChars`, `toolProgress`) with no documentation
3. **`mentionPatterns`** — a top-level channel config field completely absent from the 937-line doc
4. **Per-room fields** — `enabled`, `requireMention`, and `botLoopProtection` exist in `matrixRoomSchema` but were missing from the per-room reference section

## Why This Change Was Made

Added documentation for schema-valid but undocumented Matrix config fields. `streaming: "progress"` was missing from the streaming mode table and reference bullet despite being a first-class `z.enum` member. The `progress` sub-object (5 nested fields controlling progress-draft rendering) had no config example or field descriptions. `mentionPatterns` was absent from the access-policy reference section. Three per-room fields (`enabled`, `requireMention`, `botLoopProtection`) were missing from the per-room overrides reference. All additions are editorial-only — the schema and runtime already support these fields.

## User Impact

Users can now discover three previously-valid-but-undocumented config features from the Matrix channel docs. No code behavior changes.

## Evidence

All three fields exist in the schema (`extensions/matrix/src/config-schema.ts`) and are consumed at runtime.

### `streaming: "progress"` mode — schema + runtime

Schema at `config-schema.ts:84,130` includes `"progress"` in the enum:

```ts
z.enum(["partial", "quiet", "progress", "off"])
```

Runtime at `monitor/index.ts:85-87` resolves it:

```ts
if (streaming === "progress") {
  return "progress";
}
```

### `streaming.progress` sub-object — schema

Schema at `config-schema.ts:85-94`:

```ts
progress: z.object({
  label: z.union([z.string(), z.literal(false)]).optional(),
  labels: z.array(z.string()).optional(),
  maxLines: z.number().int().positive().optional(),
  maxLineChars: z.number().int().positive().optional(),
  toolProgress: z.boolean().optional(),
}).strict().optional(),
```

UI hints at `config-ui-hints.ts:49-69` confirm field labels and descriptions.

### `mentionPatterns` — schema + runtime

Schema at `config-schema.ts:126`:

```ts
mentionPatterns: MentionPatternsPolicySchema.optional(),
```

Runtime at `handler.ts:1124-1128` reads it as `providerPolicy` on the mention-regex builder:

```ts
const agentMentionRegexes = core.channel.mentions.buildMentionRegexes(cfg, _route.agentId, {
  provider: "matrix",
  conversationId: roomId,
  providerPolicy: accountConfig?.mentionPatterns,
});
```

### Per-room fields — `enabled`, `requireMention`, `botLoopProtection`

Schema at `config-schema.ts:60-73` defines `matrixRoomSchema` with 10 fields:

```ts
const matrixRoomSchema = z.object({
  account: z.string().optional(),
  enabled: z.boolean().optional(),          // ← undocumented
  requireMention: z.boolean().optional(),   // ← undocumented
  allowBots: z.union([z.boolean(), z.literal("mentions")]).optional(),
  botLoopProtection: botLoopProtectionSchema, // ← undocumented in reference
  tools: ToolPolicySchema,
  autoReply: z.boolean().optional(),
  users: AllowFromListSchema,
  skills: z.array(z.string()).optional(),
  systemPrompt: z.string().optional(),
}).optional();
```

Only 7 of 10 fields were listed in the per-room reference at `docs/channels/matrix.md:944-951`. `enabled`, `requireMention`, and `botLoopProtection` are now added.
