### PR TITLE
fix(feishu): fall back media replies

### DIFF
--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -521,6 +521,97 @@ describe("sendMediaFeishu msg_type routing", () => {
     expect(replyRequest.data?.reply_in_thread).toBe(true);
   });
 
+  it("falls back to top-level image sends for withdrawn reply targets", async () => {
+    messageReplyMock.mockResolvedValueOnce({
+      code: 230011,
+      msg: "The message was withdrawn.",
+    });
+    messageCreateMock.mockResolvedValueOnce({
+      code: 0,
+      data: { message_id: "msg_image_fallback" },
+    });
+
+    const result = await sendMediaFeishu({
+      cfg: emptyConfig,
+      to: "user:ou_target",
+      mediaBuffer: Buffer.from("image"),
+      fileName: "photo.png",
+      replyToMessageId: "om_parent",
+    });
+
+    expect(result.messageId).toBe("msg_image_fallback");
+    expect(messageCreateMock).toHaveBeenCalledTimes(1);
+    expect(callData<{ msg_type?: string; receive_id?: string }>(messageCreateMock)).toMatchObject({
+      msg_type: "image",
+      receive_id: "ou_target",
+    });
+  });
+
+  it("falls back to top-level file sends for thrown withdrawn reply errors", async () => {
+    messageReplyMock.mockRejectedValueOnce(Object.assign(new Error("request failed"), { code: 230011 }));
+    messageCreateMock.mockResolvedValueOnce({
+      code: 0,
+      data: { message_id: "msg_file_fallback" },
+    });
+
+    const result = await sendMediaFeishu({
+      cfg: emptyConfig,
+      to: "user:ou_target",
+      mediaBuffer: Buffer.from("video"),
+      fileName: "reply.mp4",
+      replyToMessageId: "om_parent",
+    });
+
+    expect(result.messageId).toBe("msg_file_fallback");
+    expect(callData<{ msg_type?: string }>(messageCreateMock).msg_type).toBe("media");
+  });
+
+  it("keeps thread reply failures top-level safe when fallback is disallowed", async () => {
+    messageReplyMock.mockResolvedValueOnce({
+      code: 230011,
+      msg: "The message was withdrawn.",
+    });
+
+    await expect(
+      sendMediaFeishu({
+        cfg: emptyConfig,
+        to: "user:ou_target",
+        mediaBuffer: Buffer.from("video"),
+        fileName: "reply.mp4",
+        replyToMessageId: "om_parent",
+        replyInThread: true,
+      }),
+    ).rejects.toThrow(
+      "Feishu thread reply failed: reply target is unavailable and cannot safely fall back to a top-level send.",
+    );
+
+    expect(messageCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("allows media thread replies to fall back when the dispatcher marks top-level fallback safe", async () => {
+    messageReplyMock.mockResolvedValueOnce({
+      code: 231003,
+      msg: "The message is not found",
+    });
+    messageCreateMock.mockResolvedValueOnce({
+      code: 0,
+      data: { message_id: "msg_thread_fallback" },
+    });
+
+    const result = await sendMediaFeishu({
+      cfg: emptyConfig,
+      to: "user:ou_target",
+      mediaBuffer: Buffer.from("video"),
+      fileName: "reply.mp4",
+      replyToMessageId: "om_parent",
+      replyInThread: true,
+      allowTopLevelReplyFallback: true,
+    });
+
+    expect(result.messageId).toBe("msg_thread_fallback");
+    expect(callData<{ msg_type?: string }>(messageCreateMock).msg_type).toBe("media");
+  });
+
   it("omits reply_in_thread when replyInThread is false", async () => {
     await sendMediaFeishu({
       cfg: emptyConfig,

--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -548,7 +548,9 @@ describe("sendMediaFeishu msg_type routing", () => {
   });
 
   it("falls back to top-level file sends for thrown withdrawn reply errors", async () => {
-    messageReplyMock.mockRejectedValueOnce(Object.assign(new Error("request failed"), { code: 230011 }));
+    messageReplyMock.mockRejectedValueOnce(
+      Object.assign(new Error("request failed"), { code: 230011 }),
+    );
     messageCreateMock.mockResolvedValueOnce({
       code: 0,
       data: { message_id: "msg_file_fallback" },

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -26,13 +26,13 @@ import { requestFeishuApi } from "./comment-shared.js";
 import { normalizeFeishuExternalKey } from "./external-keys.js";
 import { saveMediaStreamWithIdleTimeout } from "./media-chunk-idle.js";
 import { getFeishuRuntime } from "./runtime.js";
-import { sendReplyOrFallbackDirect } from "./send.js";
 import {
   assertFeishuMessageApiSuccess,
   resolveFeishuReceiptKind,
   toFeishuSendResult,
 } from "./send-result.js";
 import { resolveFeishuSendTarget } from "./send-target.js";
+import { sendReplyOrFallbackDirect } from "./send.js";
 
 const FEISHU_MEDIA_HTTP_TIMEOUT_MS = 120_000;
 const FEISHU_VOICE_FILE_NAME = "voice.ogg";

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -26,6 +26,7 @@ import { requestFeishuApi } from "./comment-shared.js";
 import { normalizeFeishuExternalKey } from "./external-keys.js";
 import { saveMediaStreamWithIdleTimeout } from "./media-chunk-idle.js";
 import { getFeishuRuntime } from "./runtime.js";
+import { sendReplyOrFallbackDirect } from "./send.js";
 import {
   assertFeishuMessageApiSuccess,
   resolveFeishuReceiptKind,
@@ -511,9 +512,18 @@ async function sendImageFeishu(params: {
   imageKey: string;
   replyToMessageId?: string;
   replyInThread?: boolean;
+  allowTopLevelReplyFallback?: boolean;
   accountId?: string;
 }): Promise<SendMediaResult> {
-  const { cfg, to, imageKey, replyToMessageId, replyInThread, accountId } = params;
+  const {
+    cfg,
+    to,
+    imageKey,
+    replyToMessageId,
+    replyInThread,
+    allowTopLevelReplyFallback,
+    accountId,
+  } = params;
   const { client, receiveId, receiveIdType } = resolveFeishuSendTarget({
     cfg,
     to,
@@ -522,21 +532,21 @@ async function sendImageFeishu(params: {
   const content = JSON.stringify({ image_key: imageKey });
 
   if (replyToMessageId) {
-    const response = await requestFeishuApi(
-      () =>
-        client.im.message.reply({
-          path: { message_id: replyToMessageId },
-          data: {
-            content,
-            msg_type: "image",
-            ...(replyInThread ? { reply_in_thread: true } : {}),
-          },
-        }),
-      "Feishu image reply failed",
-      { includeNestedErrorLogId: true },
-    );
-    assertFeishuMessageApiSuccess(response, "Feishu image reply failed");
-    return toFeishuSendResult(response, receiveId, "media");
+    return sendReplyOrFallbackDirect(client, {
+      replyToMessageId,
+      replyInThread,
+      allowTopLevelReplyFallback,
+      content,
+      msgType: "image",
+      directParams: {
+        receiveId,
+        receiveIdType,
+        content,
+        msgType: "image",
+      },
+      directErrorPrefix: "Feishu image send failed",
+      replyErrorPrefix: "Feishu image reply failed",
+    });
   }
 
   const response = await requestFeishuApi(
@@ -567,9 +577,18 @@ async function sendFileFeishu(params: {
   msgType?: "file" | "audio" | "media";
   replyToMessageId?: string;
   replyInThread?: boolean;
+  allowTopLevelReplyFallback?: boolean;
   accountId?: string;
 }): Promise<SendMediaResult> {
-  const { cfg, to, fileKey, replyToMessageId, replyInThread, accountId } = params;
+  const {
+    cfg,
+    to,
+    fileKey,
+    replyToMessageId,
+    replyInThread,
+    allowTopLevelReplyFallback,
+    accountId,
+  } = params;
   const msgType = params.msgType ?? "file";
   const { client, receiveId, receiveIdType } = resolveFeishuSendTarget({
     cfg,
@@ -579,21 +598,21 @@ async function sendFileFeishu(params: {
   const content = JSON.stringify({ file_key: fileKey });
 
   if (replyToMessageId) {
-    const response = await requestFeishuApi(
-      () =>
-        client.im.message.reply({
-          path: { message_id: replyToMessageId },
-          data: {
-            content,
-            msg_type: msgType,
-            ...(replyInThread ? { reply_in_thread: true } : {}),
-          },
-        }),
-      "Feishu file reply failed",
-      { includeNestedErrorLogId: true },
-    );
-    assertFeishuMessageApiSuccess(response, "Feishu file reply failed");
-    return toFeishuSendResult(response, receiveId, resolveFeishuReceiptKind(msgType));
+    return sendReplyOrFallbackDirect(client, {
+      replyToMessageId,
+      replyInThread,
+      allowTopLevelReplyFallback,
+      content,
+      msgType,
+      directParams: {
+        receiveId,
+        receiveIdType,
+        content,
+        msgType,
+      },
+      directErrorPrefix: "Feishu file send failed",
+      replyErrorPrefix: "Feishu file reply failed",
+    });
   }
 
   const response = await requestFeishuApi(
@@ -880,6 +899,7 @@ export async function sendMediaFeishu(params: {
   fileName?: string;
   replyToMessageId?: string;
   replyInThread?: boolean;
+  allowTopLevelReplyFallback?: boolean;
   accountId?: string;
   /** Allowed roots for local path reads; required for local filePath to work. */
   mediaLocalRoots?: readonly string[];
@@ -894,6 +914,7 @@ export async function sendMediaFeishu(params: {
     fileName,
     replyToMessageId,
     replyInThread,
+    allowTopLevelReplyFallback,
     accountId,
     mediaLocalRoots,
     audioAsVoice,
@@ -945,6 +966,7 @@ export async function sendMediaFeishu(params: {
       imageKey,
       replyToMessageId,
       replyInThread,
+      allowTopLevelReplyFallback,
       accountId,
     });
     return {
@@ -973,6 +995,7 @@ export async function sendMediaFeishu(params: {
     msgType: routing.msgType,
     replyToMessageId,
     replyInThread,
+    allowTopLevelReplyFallback,
     accountId,
   });
   return {

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -1632,9 +1632,17 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       threadReply: true,
       rootId: "om_original_msg",
     });
-    await options.deliver({ text: "plain text" }, { kind: "final" });
+    await options.deliver(
+      { text: "plain text", mediaUrl: "https://example.com/reply.png" },
+      { kind: "final" },
+    );
 
     expectMockArgFields(sendMessageFeishuMock, "message send params", {
+      replyToMessageId: "om_quote_reply",
+      replyInThread: true,
+      allowTopLevelReplyFallback: true,
+    });
+    expectMockArgFields(sendMediaFeishuMock, "media send params", {
       replyToMessageId: "om_quote_reply",
       replyInThread: true,
       allowTopLevelReplyFallback: true,
@@ -1649,9 +1657,17 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       threadReply: true,
       rootId: "om_topic_root",
     });
-    await options.deliver({ text: "plain text" }, { kind: "final" });
+    await options.deliver(
+      { text: "plain text", mediaUrl: "https://example.com/reply.png" },
+      { kind: "final" },
+    );
 
     expectMockArgFields(sendMessageFeishuMock, "message send params", {
+      replyToMessageId: "om_topic_root",
+      replyInThread: true,
+      allowTopLevelReplyFallback: false,
+    });
+    expectMockArgFields(sendMediaFeishuMock, "media send params", {
       replyToMessageId: "om_topic_root",
       replyInThread: true,
       allowTopLevelReplyFallback: false,

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -565,6 +565,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           mediaUrl,
           replyToMessageId: sendReplyToMessageId,
           replyInThread: effectiveReplyInThread,
+          allowTopLevelReplyFallback,
           accountId,
           ...(payload.audioAsVoice === true ? { audioAsVoice: true } : {}),
         });

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -134,7 +134,7 @@ async function sendFallbackDirect(
   return toFeishuSendResult(response, params.receiveId, resolveFeishuReceiptKind(params.msgType));
 }
 
-async function sendReplyOrFallbackDirect(
+export async function sendReplyOrFallbackDirect(
   client: FeishuCreateMessageClient,
   params: {
     replyToMessageId?: string;


### PR DESCRIPTION
## Summary

Fixes Feishu image and file delivery when the quoted reply target has been withdrawn or deleted.

- route image and file replies through the existing `sendReplyOrFallbackDirect` contract
- preserve the native-thread safety gate through `allowTopLevelReplyFallback`
- forward that safety flag from the reply dispatcher into media sends
- cover returned and thrown unavailable-target errors for image and file replies

Closes #98311.

## Verification

- `node scripts/run-vitest.mjs extensions/feishu/src/media.test.ts extensions/feishu/src/reply-dispatcher.test.ts` (126 tests passed)
- `node_modules/oxfmt/bin/oxfmt --check extensions/feishu/src/media.test.ts extensions/feishu/src/media.ts extensions/feishu/src/reply-dispatcher.ts extensions/feishu/src/send.ts`
- `git diff --check upstream/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main --codex-bin /Applications/ChatGPT.app/Contents/Resources/codex --stream-engine-output` (clean; no accepted/actionable findings, correctness 0.9)
- `node_modules/.bin/tsx /private/tmp/feishu-98320-live-proof-20260716.mts` (real image and file recovery passed; proof messages cleaned up)
- refreshed from current `upstream/main` `9c6c8446a7d`; exact tested head `951c75ff096ddd35d3a0ae99c7de47134fb864d5`

## Real behavior proof

Behavior addressed: Feishu image and file replies no longer disappear when their quoted reply target was withdrawn; the existing guarded fallback delivers them as top-level messages when that fallback is allowed.

Real environment tested: Exact head `951c75ff096ddd35d3a0ae99c7de47134fb864d5` on macOS arm64, using the configured real Feishu Open Platform app and a paired Feishu recipient. The run used the current branch's real `sendMessageFeishu`, `sendMediaFeishu`, upload, reply-fallback, direct-create, and message-readback paths.

Exact steps or command run after this patch: `node_modules/.bin/tsx /private/tmp/feishu-98320-live-proof-20260716.mts`. For both image and file cases, the harness created a real Feishu message, withdrew it through the real API, called `sendMediaFeishu` with that withdrawn message as `replyToMessageId` and `allowTopLevelReplyFallback: true`, read the recovered message back from Feishu, verified its type and receipt, then deleted the proof message.

Evidence after fix:

```json
{
  "head": "951c75ff096",
  "environment": "real Feishu Open Platform app + paired recipient",
  "results": [
    {
      "kind": "image",
      "withdrawnCode": 230011,
      "recoveredTopLevel": true,
      "readbackType": "image",
      "receiptMatchesReadback": true
    },
    {
      "kind": "file",
      "withdrawnCode": 230011,
      "recoveredTopLevel": true,
      "readbackType": "file",
      "receiptMatchesReadback": true
    }
  ],
  "cleanupCompleted": true
}
```

Observed result after fix: Both real reply attempts returned Feishu code `230011` (`The message was withdrawn.`). The current OpenClaw path recovered both uploads through top-level creation; Feishu readback reported `image` and `file`, both returned message IDs matched the OpenClaw receipts, and all proof messages were removed afterward.

What was not tested: Feishu code `231003` (message not found) was covered by focused regression tests but not induced in the live tenant. Native topic-thread fallback was not exercised live because it would require creating a user-visible topic scenario; its allow/deny boundary is covered by the focused tests. The live run used one configured Feishu tenant and one paired recipient.
