### PR TITLE
fix: recover anthropic thinking retries from errorBody

### DIFF
--- a/src/agents/embedded-agent-runner/thinking.test.ts
+++ b/src/agents/embedded-agent-runner/thinking.test.ts
@@ -738,6 +738,30 @@ describe("wrapAnthropicStreamWithRecovery", () => {
         }),
     },
     {
+      name: "ProviderHttpError errorBody",
+      createError: () =>
+        Object.assign(new Error(genericizedProviderError), {
+          errorBody: JSON.stringify({
+            error: {
+              message: terminalThinkingSignatureError,
+              type: "invalid_request_error",
+            },
+          }),
+        }),
+    },
+    {
+      name: "object response body",
+      createError: () =>
+        Object.assign(new Error(genericizedProviderError), {
+          data: {
+            error: {
+              message: terminalThinkingSignatureError,
+              type: "invalid_request_error",
+            },
+          },
+        }),
+    },
+    {
       name: "cyclic cause graph",
       createError: () => {
         const root = new Error(genericizedProviderError) as Error & { cause?: unknown };

--- a/src/agents/embedded-agent-runner/thinking.ts
+++ b/src/agents/embedded-agent-runner/thinking.ts
@@ -546,6 +546,11 @@ function shouldRecoverAnthropicThinkingError(
     current.rawError,
     current.errorMessage,
     current.message,
+    current.errorBody,
+    current.body,
+    current.detail,
+    current.responseBody,
+    current.data,
   ]);
   for (const candidate of candidates) {
     if (
@@ -553,6 +558,32 @@ function shouldRecoverAnthropicThinkingError(
       shouldRecoverAnthropicThinkingErrorMessage(candidate, sessionMeta)
     ) {
       return true;
+    }
+    if (!candidate || typeof candidate !== "object") {
+      continue;
+    }
+    const candidateRecord = candidate as Record<string, unknown>;
+    if (
+      !("error" in candidateRecord) &&
+      !("errorBody" in candidateRecord) &&
+      !("body" in candidateRecord) &&
+      !("detail" in candidateRecord) &&
+      !("responseBody" in candidateRecord) &&
+      !("data" in candidateRecord)
+    ) {
+      continue;
+    }
+    try {
+      const serialized = JSON.stringify(candidate);
+      if (
+        typeof serialized === "string" &&
+        serialized.length <= 20_000 &&
+        shouldRecoverAnthropicThinkingErrorMessage(serialized, sessionMeta)
+      ) {
+        return true;
+      }
+    } catch {
+      // ignore serialization failures from cyclic/non-JSON provider payloads
     }
   }
   return false;


### PR DESCRIPTION
## Summary

Extends Anthropic thinking-block recovery detection so genericized provider errors still retry when the original invalid-signature detail only survives in `ProviderHttpError.errorBody` or similar nested response payloads.

## Changes

- inspect additional error carriers such as `errorBody`, `body`, `detail`, `responseBody`, and `data`
- JSON-serialize structured provider payloads when needed to recover nested invalid-thinking-signature messages safely
- add regression coverage for `ProviderHttpError.errorBody` and structured response-body payloads

## Testing

- `pnpm vitest run src/agents/embedded-agent-runner/thinking.test.ts`

Fixes openclaw/openclaw#98308