### PR TITLE
fix: preserve feishu media reply fallback

### DIFF
--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -30,6 +30,7 @@ import {
   toFeishuSendResult,
 } from "./send-result.js";
 import { resolveFeishuSendTarget } from "./send-target.js";
+import { sendReplyOrFallbackDirect } from "./send.js";
 
 const FEISHU_MEDIA_HTTP_TIMEOUT_MS = 120_000;
 const FEISHU_VOICE_FILE_NAME = "voice.ogg";
@@ -520,9 +521,18 @@ export async function sendImageFeishu(params: {
   imageKey: string;
   replyToMessageId?: string;
   replyInThread?: boolean;
+  allowTopLevelReplyFallback?: boolean;
   accountId?: string;
 }): Promise<SendMediaResult> {
-  const { cfg, to, imageKey, replyToMessageId, replyInThread, accountId } = params;
+  const {
+    cfg,
+    to,
+    imageKey,
+    replyToMessageId,
+    replyInThread,
+    allowTopLevelReplyFallback,
+    accountId,
+  } = params;
   const { client, receiveId, receiveIdType } = resolveFeishuSendTarget({
     cfg,
     to,
@@ -530,39 +540,21 @@ export async function sendImageFeishu(params: {
   });
   const content = JSON.stringify({ image_key: imageKey });
 
-  if (replyToMessageId) {
-    const response = await requestFeishuApi(
-      () =>
-        client.im.message.reply({
-          path: { message_id: replyToMessageId },
-          data: {
-            content,
-            msg_type: "image",
-            ...(replyInThread ? { reply_in_thread: true } : {}),
-          },
-        }),
-      "Feishu image reply failed",
-      { includeNestedErrorLogId: true },
-    );
-    assertFeishuMessageApiSuccess(response, "Feishu image reply failed");
-    return toFeishuSendResult(response, receiveId, "media");
-  }
-
-  const response = await requestFeishuApi(
-    () =>
-      client.im.message.create({
-        params: { receive_id_type: receiveIdType },
-        data: {
-          receive_id: receiveId,
-          content,
-          msg_type: "image",
-        },
-      }),
-    "Feishu image send failed",
-    { includeNestedErrorLogId: true },
-  );
-  assertFeishuMessageApiSuccess(response, "Feishu image send failed");
-  return toFeishuSendResult(response, receiveId, "media");
+  return await sendReplyOrFallbackDirect(client, {
+    replyToMessageId,
+    replyInThread,
+    allowTopLevelReplyFallback,
+    content,
+    msgType: "image",
+    directParams: {
+      receiveId,
+      receiveIdType,
+      content,
+      msgType: "image",
+    },
+    directErrorPrefix: "Feishu image send failed",
+    replyErrorPrefix: "Feishu image reply failed",
+  });
 }
 
 /**
@@ -576,9 +568,18 @@ export async function sendFileFeishu(params: {
   msgType?: "file" | "audio" | "media";
   replyToMessageId?: string;
   replyInThread?: boolean;
+  allowTopLevelReplyFallback?: boolean;
   accountId?: string;
 }): Promise<SendMediaResult> {
-  const { cfg, to, fileKey, replyToMessageId, replyInThread, accountId } = params;
+  const {
+    cfg,
+    to,
+    fileKey,
+    replyToMessageId,
+    replyInThread,
+    allowTopLevelReplyFallback,
+    accountId,
+  } = params;
   const msgType = params.msgType ?? "file";
   const { client, receiveId, receiveIdType } = resolveFeishuSendTarget({
     cfg,
@@ -587,39 +588,21 @@ export async function sendFileFeishu(params: {
   });
   const content = JSON.stringify({ file_key: fileKey });
 
-  if (replyToMessageId) {
-    const response = await requestFeishuApi(
-      () =>
-        client.im.message.reply({
-          path: { message_id: replyToMessageId },
-          data: {
-            content,
-            msg_type: msgType,
-            ...(replyInThread ? { reply_in_thread: true } : {}),
-          },
-        }),
-      "Feishu file reply failed",
-      { includeNestedErrorLogId: true },
-    );
-    assertFeishuMessageApiSuccess(response, "Feishu file reply failed");
-    return toFeishuSendResult(response, receiveId, resolveFeishuReceiptKind(msgType));
-  }
-
-  const response = await requestFeishuApi(
-    () =>
-      client.im.message.create({
-        params: { receive_id_type: receiveIdType },
-        data: {
-          receive_id: receiveId,
-          content,
-          msg_type: msgType,
-        },
-      }),
-    "Feishu file send failed",
-    { includeNestedErrorLogId: true },
-  );
-  assertFeishuMessageApiSuccess(response, "Feishu file send failed");
-  return toFeishuSendResult(response, receiveId, resolveFeishuReceiptKind(msgType));
+  return await sendReplyOrFallbackDirect(client, {
+    replyToMessageId,
+    replyInThread,
+    allowTopLevelReplyFallback,
+    content,
+    msgType,
+    directParams: {
+      receiveId,
+      receiveIdType,
+      content,
+      msgType,
+    },
+    directErrorPrefix: "Feishu file send failed",
+    replyErrorPrefix: "Feishu file reply failed",
+  });
 }
 
 /**

--- a/extensions/feishu/src/send.reply-fallback.test.ts
+++ b/extensions/feishu/src/send.reply-fallback.test.ts
@@ -23,6 +23,8 @@ vi.mock("./runtime.js", () => ({
 
 let sendCardFeishu: typeof import("./send.js").sendCardFeishu;
 let sendMessageFeishu: typeof import("./send.js").sendMessageFeishu;
+let sendImageFeishu: typeof import("./media.js").sendImageFeishu;
+let sendFileFeishu: typeof import("./media.js").sendFileFeishu;
 
 describe("Feishu reply fallback for withdrawn/deleted targets", () => {
   const replyMock = vi.fn();
@@ -40,6 +42,7 @@ describe("Feishu reply fallback for withdrawn/deleted targets", () => {
 
   beforeAll(async () => {
     ({ sendCardFeishu, sendMessageFeishu } = await import("./send.js"));
+    ({ sendImageFeishu, sendFileFeishu } = await import("./media.js"));
   });
 
   afterAll(() => {
@@ -133,6 +136,51 @@ describe("Feishu reply fallback for withdrawn/deleted targets", () => {
           replyToMessageId: "om_parent",
         }),
       "om_card_new",
+    );
+  });
+
+  it("falls back to create for withdrawn image replies", async () => {
+    replyMock.mockResolvedValue({
+      code: 230011,
+      msg: "The message was withdrawn.",
+    });
+    createMock.mockResolvedValue({
+      code: 0,
+      data: { message_id: "om_image_new" },
+    });
+
+    await expectFallbackResult(
+      () =>
+        sendImageFeishu({
+          cfg: {} as never,
+          to: "user:ou_target",
+          imageKey: "img_key",
+          replyToMessageId: "om_parent",
+        }),
+      "om_image_new",
+    );
+  });
+
+  it("falls back to create for withdrawn file replies", async () => {
+    replyMock.mockRejectedValue(
+      Object.assign(new Error("Request failed"), {
+        response: { status: 200, data: { code: 231003, msg: "The message is not found" } },
+      }),
+    );
+    createMock.mockResolvedValue({
+      code: 0,
+      data: { message_id: "om_file_new" },
+    });
+
+    await expectFallbackResult(
+      () =>
+        sendFileFeishu({
+          cfg: {} as never,
+          to: "user:ou_target",
+          fileKey: "file_key",
+          replyToMessageId: "om_parent",
+        }),
+      "om_file_new",
     );
   });
 

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -143,7 +143,7 @@ async function sendFallbackDirect(
   return toFeishuSendResult(response, params.receiveId, resolveFeishuReceiptKind(params.msgType));
 }
 
-async function sendReplyOrFallbackDirect(
+export async function sendReplyOrFallbackDirect(
   client: FeishuCreateMessageClient,
   params: {
     replyToMessageId?: string;


### PR DESCRIPTION
## Summary

Reuses the existing Feishu withdrawn/not-found reply fallback path for image and file replies so recalled targets still deliver the media as a top-level send instead of failing the whole reply.

## Changes

- route `sendImageFeishu` through `sendReplyOrFallbackDirect`
- route `sendFileFeishu` through the same fallback helper, including top-level fallback support
- add regression coverage for withdrawn image replies and not-found file replies

## Testing

- `pnpm vitest run extensions/feishu/src/send.reply-fallback.test.ts`

Fixes openclaw/openclaw#98311