### PR TITLE
docs: refresh docs map for v2026.6.11

### DIFF
--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -8449,12 +8449,36 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: What the wizard writes
   - H2: Related docs
 
+## releases/2026.6.11.md
+
+- Route: /releases/2026.6.11
+- Headings:
+  - H1: OpenClaw v2026.6.11 Release Notes (2026-06-30)
+  - H2: Highlights
+  - H3: Channel delivery reliability
+  - H3: Provider and model recovery
+  - H3: Session, memory, and trust continuity
+  - H3: Slack router relay mode
+  - H3: Raft External Agent wake bridge
+  - H3: Official plugin installation and repair
+  - H2: Channels and Messaging
+  - H3: Additional channel fixes
+  - H2: Gateway, Security, and Trust
+  - H3: Restart and readiness recovery
+  - H3: Remote result and media delivery
+  - H2: Clients and Interfaces
+  - H3: Client sends and reconnects
+  - H3: Interface, settings, and onboarding fixes
+  - H2: Docs and Admin Tools
+  - H3: Setup and command reliability
+  - H3: Tools and scheduled work
+
 ## releases/index.md
 
 - Route: /releases
 - Headings:
   - H1: Release notes
-  - H2: Coming soon
+  - H2: Releases
   - H2: Raw release history
 
 ## security/CONTRIBUTING-THREAT-MODEL.md


### PR DESCRIPTION
## What Problem This Solves

Fixes the post-merge docs check failure that skipped the Mintlify deployment because `docs/docs_map.md` was out of date.

## Why This Change Was Made

Regenerates the committed docs map after adding the v2026.6.11 release page and navigation entry.

## User Impact

The docs pipeline can pass and deploy the v2026.6.11 release notes page.

## Evidence

- `pnpm docs:map:check`
- `pnpm format:docs:check`