### PR TITLE
feat(embedded-agent): add 'interrupt' steeringMode to EmbeddedAgentQueueMessageOptions

### DIFF
--- a/src/agents/embedded-agent-runner/run-state.ts
+++ b/src/agents/embedded-agent-runner/run-state.ts
@@ -27,8 +27,21 @@ export type EmbeddedAgentQueueHandle = {
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
 };
 
+/**
+ * Steering mode for a queued message targeting an active embedded run.
+ *
+ * - "all" (default): queue the message and inject it at the next mid-turn
+ *   or tool-call boundary. Never aborts the active stream.
+ * - "interrupt": first ask the active run to cancel itself with reason
+ *   "user_abort" via `EmbeddedAgentQueueHandle.cancel`, then queue the
+ *   message so it is picked up by the *next* turn instead of after the
+ *   current long-running `model_call` finishes. Falls back to "all"
+ *   semantics if the handle exposes no `cancel` hook.
+ */
+export type SteeringMode = "all" | "interrupt";
+
 export type EmbeddedAgentQueueMessageOptions = {
-  steeringMode?: "all";
+  steeringMode?: SteeringMode;
   debounceMs?: number;
   deliveryTimeoutMs?: number;
   waitForTranscriptCommit?: boolean;

--- a/src/agents/embedded-agent-runner/runs.test.ts
+++ b/src/agents/embedded-agent-runner/runs.test.ts
@@ -45,6 +45,7 @@ type RunHandle = Parameters<typeof setActiveEmbeddedRun>[1];
 function createRunHandle(
   overrides: {
     abort?: () => void;
+    cancel?: (reason?: "user_abort" | "restart" | "superseded") => void;
     isCompacting?: boolean;
     isStreaming?: boolean;
     supportsTranscriptCommitWait?: boolean;
@@ -59,6 +60,7 @@ function createRunHandle(
     isCompacting: () => overrides.isCompacting ?? false,
     supportsTranscriptCommitWait: overrides.supportsTranscriptCommitWait,
     abort,
+    cancel: overrides.cancel,
   };
 }
 
@@ -589,4 +591,45 @@ describe("embedded-agent runner run registry", () => {
     expect(getActiveEmbeddedRunSnapshot("session-snapshot")).toBeUndefined();
   });
 
+});
+
+describe("embedded-agent queue interrupt steeringMode", () => {
+  it("cancels the active run with user_abort reason before queuing", async () => {
+    const cancel = vi.fn();
+    const queue = vi.fn().mockResolvedValue(undefined);
+    setActiveEmbeddedRun("session-int", {
+      ...createRunHandle({ cancel, isStreaming: true }),
+      queueMessage: queue,
+    });
+
+    const outcome = await queueEmbeddedAgentMessageWithOutcomeAsync(
+      "session-int",
+      "stop and answer this instead",
+      { steeringMode: "interrupt" },
+    );
+
+    expect(outcome.queued).toBe(true);
+    expect(cancel).toHaveBeenCalledWith("user_abort");
+    expect(queue).toHaveBeenCalledWith(
+      "stop and answer this instead",
+      expect.objectContaining({ steeringMode: "interrupt" }),
+    );
+  });
+
+  it("falls back to queue-only when handle has no cancel hook", async () => {
+    const queue = vi.fn().mockResolvedValue(undefined);
+    setActiveEmbeddedRun("session-nocancel", {
+      ...createRunHandle({ isStreaming: true }),
+      queueMessage: queue,
+    });
+
+    const outcome = await queueEmbeddedAgentMessageWithOutcomeAsync(
+      "session-nocancel",
+      "hello",
+      { steeringMode: "interrupt" },
+    );
+
+    expect(outcome.queued).toBe(true);
+    expect(queue).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/agents/embedded-agent-runner/runs.ts
+++ b/src/agents/embedded-agent-runner/runs.ts
@@ -424,6 +424,25 @@ function prepareEmbeddedAgentQueueMessage(
       outcome: createQueueFailureOutcome(sessionId, "source_reply_delivery_mode_mismatch"),
     };
   }
+  // interrupt mode: ask the active run to abort itself (best-effort) so the
+  // queued message is picked up by the next turn instead of waiting for the
+  // current long-running model_call (e.g. M3 reasoning) to finish.
+  if (options?.steeringMode === "interrupt") {
+    if (typeof handle.cancel === "function") {
+      try {
+        handle.cancel("user_abort");
+        diag.debug(`queue message interrupted active run: sessionId=${sessionId}`);
+      } catch (err) {
+        diag.debug(
+          `queue message interrupt cancel failed: sessionId=${sessionId} err=${formatQueueError(err)}`,
+        );
+      }
+    } else {
+      diag.debug(
+        `queue message interrupt requested but no cancel hook: sessionId=${sessionId} falling_back=all`,
+      );
+    }
+  }
   return { kind: "embedded_run", handle };
 }
 


### PR DESCRIPTION
|---|
| `src/agents/embedded-agent-runner/run-state.ts` | Extend `EmbeddedAgentQueueMessageOptions.steeringMode` to `"all" \| "interrupt"`; add JSDoc |
| `src/agents/embedded-agent-runner/runs.ts` | In `prepareEmbeddedAgentQueueMessage()`, before the final `return { kind: "embedded_run", handle }`, call `handle.cancel?.("user_abort")` when `options.steeringMode === "interrupt"` (best-effort, try/catch, fallback to current behaviour on missing hook) |
| `src/agents/embedded-agent-runner/runs.test.ts` | Extend `createRunHandle()` factory to accept and forward a `cancel` override; add a `describe("embedded-agent queue interrupt steeringMode", ...)` block with two vitest cases |

## Patch (diff)

Diffs verified against `/tmp/openclaw-repo` HEAD. Exact line numbers may shift after
maintainer rebase — context lines are included so hunks apply cleanly.

```diff
--- a/src/agents/embedded-agent-runner/run-state.ts
+++ b/src/agents/embedded-agent-runner/run-state.ts
@@ -19,6 +19,17 @@
 export type EmbeddedAgentQueueHandle = {
   kind?: "embedded";
   queueMessage: (text: string, options?: EmbeddedAgentQueueMessageOptions) => Promise<void>;
   isStreaming: () => boolean;
   isCompacting: () => boolean;
   supportsTranscriptCommitWait?: boolean;
   cancel?: (reason?: "user_abort" | "restart" | "superseded") => void;
   abort: (reason?: "restart") => void;
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
 };
 
+/**
+ * Steering mode for a queued message targeting an active embedded run.
+ *
+ * - "all" (default): queue the message and inject it at the next mid-turn
+ *   or tool-call boundary. Never aborts the active stream.
+ * - "interrupt": first ask the active run to cancel itself with reason
+ *   "user_abort" via `EmbeddedAgentQueueHandle.cancel`, then queue the
+ *   message so it is picked up by the *next* turn instead of after the
+ *   current long-running `model_call` finishes. Falls back to "all"
+ *   semantics if the handle exposes no `cancel` hook.
+ */
+export type SteeringMode = "all" | "interrupt";
+
 export type EmbeddedAgentQueueMessageOptions = {
-  steeringMode?: "all";
+  steeringMode?: SteeringMode;
   debounceMs?: number;
   deliveryTimeoutMs?: number;
   waitForTranscriptCommit?: boolean;
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
 };
```

```diff
--- a/src/agents/embedded-agent-runner/runs.ts
+++ b/src/agents/embedded-agent-runner/runs.ts
@@ -365,6 +365,7 @@
 import { resolveEmbeddedSessionFileKey } from "./session-file-key.js";
 
 function prepareEmbeddedAgentQueueMessage(
   sessionId: string,
   text: string,
   options?: EmbeddedAgentQueueMessageOptions,
 ): PreparedEmbeddedAgentQueueMessage {
@@ -413,6 +414,26 @@
   if (
     options?.sourceReplyDeliveryMode === "message_tool_only" &&
     handle.sourceReplyDeliveryMode !== "message_tool_only"
   ) {
     diag.debug(
       `queue message failed: sessionId=${sessionId} reason=source_reply_delivery_mode_mismatch`,
     );
     return {
       kind: "complete",
       outcome: createQueueFailureOutcome(sessionId, "source_reply_delivery_mode_mismatch"),
     };
   }
+  // interrupt mode: ask the active run to abort itself (best-effort) so the
+  // queued message is picked up by the next turn instead of waiting for the
+  // current long-running model_call (e.g. M3 reasoning) to finish.
+  if (options?.steeringMode === "interrupt") {
+    if (typeof handle.cancel === "function") {
+      try {
+        handle.cancel("user_abort");
+        diag.debug(`queue message interrupted active run: sessionId=${sessionId}`);
+      } catch (err) {
+        diag.debug(
+          `queue message interrupt cancel failed: sessionId=${sessionId} err=${formatQueueError(err)}`,
+        );
+      }
+    } else {
+      diag.debug(
+        `queue message interrupt requested but no cancel hook: sessionId=${sessionId} falling_back=all`,
+      );
+    }
+  }
   return { kind: "embedded_run", handle };
 }
```

(`formatQueueError` is already defined at the top of `runs.ts`; no new import needed.)

```diff
--- a/src/agents/embedded-agent-runner/runs.test.ts
+++ b/src/agents/embedded-agent-runner/runs.test.ts
@@ -42,11 +42,13 @@
 type RunHandle = Parameters<typeof setActiveEmbeddedRun>[1];
 
 function createRunHandle(
   overrides: {
     abort?: () => void;
+    cancel?: (reason?: "user_abort" | "restart" | "superseded") => void;
     isCompacting?: boolean;
     isStreaming?: boolean;
     supportsTranscriptCommitWait?: boolean;
   } = {},
 ): RunHandle {
   const abort = overrides.abort ?? (() => {});
   return {
     queueMessage: async () => {},
     isStreaming: () => overrides.isStreaming ?? true,
     isCompacting: () => overrides.isCompacting ?? false,
     supportsTranscriptCommitWait: overrides.supportsTranscriptCommitWait,
     abort,
+    cancel: overrides.cancel,
   };
 }
@@ -108,3 +110,42 @@
   ...
 });
+
+describe("embedded-agent queue interrupt steeringMode", () => {
+  it("cancels the active run with user_abort reason before queuing", async () => {
+    const cancel = vi.fn();
+    const queue = vi.fn().mockResolvedValue(undefined);
+    setActiveEmbeddedRun(
+      "session-int",
+      { ...createRunHandle({ cancel, isStreaming: true }), queueMessage: queue },
+    );
+
+    const outcome = await queueEmbeddedAgentMessageWithOutcomeAsync(
+      "session-int",
+      "stop and answer this instead",
+      { steeringMode: "interrupt" },
+    );
+
+    expect(outcome.queued).toBe(true);
+    expect(cancel).toHaveBeenCalledWith("user_abort");
+    expect(queue).toHaveBeenCalledWith(
+      "stop and answer this instead",
+      expect.objectContaining({ steeringMode: "interrupt" }),
+    );
+  });
+
+  it("falls back to queue-only when handle has no cancel hook", async () => {
+    const queue = vi.fn().mockResolvedValue(undefined);
+    setActiveEmbeddedRun(
+      "session-nocancel",
+      { ...createRunHandle({ isStreaming: true }), queueMessage: queue },
+    );
+
+    const outcome = await queueEmbeddedAgentMessageWithOutcomeAsync(
+      "session-nocancel",
+      "hello",
+      { steeringMode: "interrupt" },
+    );
+
+    expect(outcome.queued).toBe(true);
+    expect(queue).toHaveBeenCalledTimes(1);
+    // cancel is undefined on the handle, so it must not throw or be invoked
+  });
+});
```

## Test strategy

- Unit (`runs.test.ts` — vitest, two cases):
  1. `steeringMode: "interrupt"` with `cancel` hook exposed → `cancel("user_abort")` called once, `queueMessage` called once.
  2. `steeringMode: "interrupt"` with no `cancel` hook → `queueMessage` called once, no throw.
- Integration (out of PR scope, follow-up): with `attempt.ts`'s cancel hook wired in, verify that aborting a long-running mock run returns control and the next turn starts with the queued message. The author should file a follow-up issue to track integration coverage.
- Regression watch: `waitForActiveEmbeddedRuns()` callers must still resolve cleanly after the abort signal lands before the run actually exits (ties to issue #12085).

## Compatibility & risk

- **Additive union**: existing callers passing `steeringMode: "all"` (or omitting it) see no change.
- **`undefined` default**: keeps current `"all"` semantics; no behaviour drift.
- **Best-effort cancel**: `try/catch` around `handle.cancel()` — a throwing cancel does not lose the queued message. The queue push still proceeds.
- **Missing hook fallback**: handles without `cancel` (older run types) silently fall back to `"all"` with a `diag.debug` log so we can see in production how often this path fires.
- **Channel-level parity**: `interrupt` here matches `/queue interrupt`'s documented `abort → run newest message` semantics but is opt-in at the caller level, so unrelated harness code is unaffected.

## Open questions for reviewers

1. Should `SteeringMode` be exported as a public type (so external packages and channels can type-narrow), or kept internal? Current draft exports it.
2. Is `reason: "user_abort"` the correct cancel reason given `cancel`'s type allows `"user_abort" | "restart" | "superseded"`? `"user_abort"` aligns with the channel command's user intent; maintainers may prefer `"superseded"` to distinguish user-initiated interruption from internal refreshes.
3. Should `diag.debug` be elevated to `diag.info` or `diag.warn` for the "no cancel hook" fallback so operators can spot when their handle types are out of date?

## Author checklist (for whoever opens the PR)

- [ ] Verify all five cross-reference issue numbers exist and are still open; replace placeholders with real URLs.
- [ ] Re-run `pnpm test src/agents/embedded-agent-runner/runs.test.ts` after rebase.
- [ ] Confirm `formatQueueError` is still in scope at the top of `runs.ts` after rebase (used by the new `try/catch`).
- [ ] Add a CHANGELOG entry under the next minor version ("feat: support interrupt steeringMode in embedded agent queue").