### PR TITLE
fix(agents): detect thinking-block errors in ProviderHttpError.errorBody (fixes #98308) (AI-assisted)

### DIFF
--- a/src/agents/embedded-agent-runner/thinking.test.ts
+++ b/src/agents/embedded-agent-runner/thinking.test.ts
@@ -746,6 +746,18 @@ describe("wrapAnthropicStreamWithRecovery", () => {
         return root;
       },
     },
+    {
+      name: "ProviderHttpError errorBody",
+      createError: () =>
+        Object.assign(new Error(genericizedProviderError), {
+          errorBody: JSON.stringify({
+            error: {
+              message: "messages.12.content.3: Invalid `signature` in `thinking` block",
+              type: "invalid_request_error",
+            },
+          }),
+        }),
+    },
   ])(
     "retries genericized request errors carrying provider detail in $name",
     async ({ createError }) => {

--- a/src/agents/embedded-agent-runner/thinking.ts
+++ b/src/agents/embedded-agent-runner/thinking.ts
@@ -546,6 +546,7 @@ function shouldRecoverAnthropicThinkingError(
     current.rawError,
     current.errorMessage,
     current.message,
+    current.errorBody,
   ]);
   for (const candidate of candidates) {
     if (


### PR DESCRIPTION
## What Problem This Solves

When Anthropic rejects a replayed thinking block with an invalid signature, the recovery wrapper (`wrapAnthropicStreamWithRecovery`) should detect the error and retry with stripped thinking blocks. However, `ProviderHttpError` stores the raw Anthropic response on `.errorBody` while `.message` carries a generic user-facing string. The detection predicate only traversed `cause`, `error`, `rawError`, `errorMessage`, and `message` — missing `errorBody` entirely. This means sessions become permanently bricked by stale thinking signatures even though a non-destructive repair path exists.

## Why This Change Was Made

The production error shape from `ProviderHttpError` is:
- `.message` → `"LLM request failed: provider rejected the request schema or tool payload."` (generic)
- `.errorBody` → `{"error":{"message":"messages.12.content.3: Invalid \`signature\` in \`thinking\` block",...}}` (specific)

The `THINKING_BLOCK_ERROR_PATTERN` regex correctly matches the error text, but `errorBody` was never fed to it. Adding `current.errorBody` to the error graph traversal in `shouldRecoverAnthropicThinkingError` closes this gap.

## User Impact

Users on Claude opus-4.x, sonnet-4.x, haiku-4.x, and claude-5+ with native extended thinking enabled will no longer have sessions permanently bricked by stale thinking-block signatures. The recovery path now correctly detects the `ProviderHttpError.errorBody` shape and fires the non-destructive repair.

- [x] AI-assisted (Hermes Agent)

## Evidence

- **Behavior addressed:** Anthropic thinking-block recovery fails to detect errors stored in `ProviderHttpError.errorBody`
- **Environment tested:** macOS 26.4.1, Node 22.22.3, OpenClaw 2026.6.11 (816038e)
- **Steps run after the patch:**
  1. Added `current.errorBody` to the error graph traversal in `shouldRecoverAnthropicThinkingError` (thinking.ts:549)
  2. Added a parameterized test case for `ProviderHttpError.errorBody` to the existing `wrapAnthropicStreamWithRecovery` test suite
  3. Ran the full test suite for the changed module
- **Evidence after fix:**
```
 RUN  v4.1.8
 ✓  agents  src/agents/embedded-agent-runner/thinking.test.ts (47 tests) 65ms
 Test Files  1 passed (1)
      Tests  47 passed (47)
```
- **Observed result after fix:** All 47 pass including the new `ProviderHttpError errorBody` test case, which verifies that `wrapAnthropicStreamWithRecovery` now correctly detects thinking-block signature errors stored in `.errorBody` and retries with stripped thinking blocks
- **What was not tested:** Live Anthropic API interaction with real stale thinking signatures (requires specific session state and API timing that cannot be reliably reproduced in a local test environment)

## Real behavior proof

- **Behavior addressed:** Anthropic thinking-block recovery fails to detect errors stored in `ProviderHttpError.errorBody`
- **Environment tested:** macOS 26.4.1, Node 22.22.3, OpenClaw 2026.6.11 (816038e)
- **Steps run after the patch:**
  1. Added `current.errorBody` to the error graph traversal in `shouldRecoverAnthropicThinkingError` (thinking.ts:549)
  2. Added a parameterized test case for `ProviderHttpError.errorBody` to the existing `wrapAnthropicStreamWithRecovery` test suite
  3. Ran the full test suite for the changed module
- **Evidence after fix:**
```
 RUN  v4.1.8
 ✓  agents  src/agents/embedded-agent-runner/thinking.test.ts (47 tests) 65ms
 Test Files  1 passed (1)
      Tests  47 passed (47)
```
- **Observed result after fix:** All 47 pass including the new `ProviderHttpError errorBody` test case, which verifies that `wrapAnthropicStreamWithRecovery` now correctly detects thinking-block signature errors stored in `.errorBody` and retries with stripped thinking blocks
- **What was not tested:** Live Anthropic API interaction with real stale thinking signatures (requires specific session state and API timing that cannot be reliably reproduced in a local test environment)
