### PR TITLE
fix(agents): include sender in duplicate-user-message dedup key

### DIFF
--- a/src/agents/embedded-agent-runner/compaction-duplicate-user-messages.test.ts
+++ b/src/agents/embedded-agent-runner/compaction-duplicate-user-messages.test.ts
@@ -7,8 +7,6 @@ import {
 
 describe("compaction duplicate user message pruning", () => {
   it("drops identical long user messages inside the duplicate window", () => {
-    // Whitespace-normalized duplicates inside the short window are transport
-    // artifacts; keeping both wastes compaction budget and distorts summaries.
     const first = {
       role: "user",
       content: "please run the deployment status check for production",
@@ -32,8 +30,6 @@ describe("compaction duplicate user message pruning", () => {
   });
 
   it("keeps short repeated acknowledgements and distant repeats", () => {
-    // Short repeats and distant repeats are plausible user intent, so only
-    // high-confidence duplicated long prompts are removed.
     const short = { role: "user", content: "next", timestamp: 1_000 } as const;
     const shortAgain = { role: "user", content: "next", timestamp: 2_000 } as const;
     const long = {
@@ -77,5 +73,54 @@ describe("compaction duplicate user message pruning", () => {
     ]);
 
     expect(duplicateIds).toEqual(new Set(["entry-2"]));
+  });
+
+  it("keeps same text from different senders when senderId differs (#98310)", () => {
+    const alice = {
+      role: "user",
+      content: "please run the deployment status check for production",
+      timestamp: 1_000,
+      __openclaw: { senderId: "user-alice" },
+    } as const;
+    const bob = {
+      role: "user",
+      content: "please run the deployment status check for production",
+      timestamp: 2_000,
+      __openclaw: { senderId: "user-bob" },
+    } as const;
+
+    expect(dedupeDuplicateUserMessagesForCompaction([alice, bob])).toEqual([alice, bob]);
+  });
+
+  it("still dedupes same sender inside the duplicate window (#98310)", () => {
+    const first = {
+      role: "user",
+      content: "please run the deployment status check for production",
+      timestamp: 1_000,
+      __openclaw: { senderId: "user-alice" },
+    } as const;
+    const retry = {
+      role: "user",
+      content: "please run the deployment status check for production",
+      timestamp: 2_000,
+      __openclaw: { senderId: "user-alice" },
+    } as const;
+
+    expect(dedupeDuplicateUserMessagesForCompaction([first, retry])).toEqual([first]);
+  });
+
+  it("uses empty senderId prefix when __openclaw has no sender metadata", () => {
+    const first = {
+      role: "user",
+      content: "please run the deployment status check for production",
+      timestamp: 1_000,
+    } as const;
+    const second = {
+      role: "user",
+      content: "please run the deployment status check for production",
+      timestamp: 2_000,
+    } as const;
+
+    expect(dedupeDuplicateUserMessagesForCompaction([first, second])).toEqual([first]);
   });
 });

--- a/src/agents/embedded-agent-runner/compaction-duplicate-user-messages.test.ts
+++ b/src/agents/embedded-agent-runner/compaction-duplicate-user-messages.test.ts
@@ -5,8 +5,21 @@ import {
   dedupeDuplicateUserMessagesForCompaction,
 } from "./compaction-duplicate-user-messages.js";
 
+const LONG_PROMPT = "please run the deployment status check for production";
+
+function userMessage(params: { timestamp: number; senderId?: string; content?: string }) {
+  return {
+    role: "user" as const,
+    content: params.content ?? LONG_PROMPT,
+    timestamp: params.timestamp,
+    ...(params.senderId ? { __openclaw: { senderId: params.senderId } } : {}),
+  };
+}
+
 describe("compaction duplicate user message pruning", () => {
   it("drops identical long user messages inside the duplicate window", () => {
+    // Whitespace-normalized duplicates inside the short window are transport
+    // artifacts; keeping both wastes compaction budget and distorts summaries.
     const first = {
       role: "user",
       content: "please run the deployment status check for production",
@@ -30,6 +43,8 @@ describe("compaction duplicate user message pruning", () => {
   });
 
   it("keeps short repeated acknowledgements and distant repeats", () => {
+    // Short repeats and distant repeats are plausible user intent, so only
+    // high-confidence duplicated long prompts are removed.
     const short = { role: "user", content: "next", timestamp: 1_000 } as const;
     const shortAgain = { role: "user", content: "next", timestamp: 2_000 } as const;
     const long = {
@@ -75,52 +90,40 @@ describe("compaction duplicate user message pruning", () => {
     expect(duplicateIds).toEqual(new Set(["entry-2"]));
   });
 
-  it("keeps same text from different senders when senderId differs (#98310)", () => {
-    const alice = {
-      role: "user",
-      content: "please run the deployment status check for production",
-      timestamp: 1_000,
-      __openclaw: { senderId: "user-alice" },
-    } as const;
-    const bob = {
-      role: "user",
-      content: "please run the deployment status check for production",
-      timestamp: 2_000,
-      __openclaw: { senderId: "user-bob" },
-    } as const;
+  it("keys duplicate retries by sender identity (#98310)", () => {
+    const alice = userMessage({ timestamp: 1_000, senderId: "user-alice" });
+    const bob = userMessage({ timestamp: 2_000, senderId: "user-bob" });
+    const aliceRetry = userMessage({ timestamp: 3_000, senderId: "user-alice" });
 
-    expect(dedupeDuplicateUserMessagesForCompaction([alice, bob])).toEqual([alice, bob]);
+    expect(dedupeDuplicateUserMessagesForCompaction([alice, bob, aliceRetry])).toEqual([
+      alice,
+      bob,
+    ]);
   });
 
-  it("still dedupes same sender inside the duplicate window (#98310)", () => {
-    const first = {
-      role: "user",
-      content: "please run the deployment status check for production",
-      timestamp: 1_000,
-      __openclaw: { senderId: "user-alice" },
-    } as const;
-    const retry = {
-      role: "user",
-      content: "please run the deployment status check for production",
-      timestamp: 2_000,
-      __openclaw: { senderId: "user-alice" },
-    } as const;
+  it("keeps same text from different senders in successor transcript pruning", () => {
+    const alice = userMessage({ timestamp: 1_000, senderId: "user-alice" });
+    const bob = userMessage({ timestamp: 2_000, senderId: "user-bob" });
+    const duplicateIds = collectDuplicateUserMessageEntryIdsForCompaction([
+      { id: "entry-alice", type: "message", message: alice },
+      { id: "entry-bob", type: "message", message: bob },
+    ]);
 
-    expect(dedupeDuplicateUserMessagesForCompaction([first, retry])).toEqual([first]);
+    expect(duplicateIds).toEqual(new Set());
   });
 
-  it("uses empty senderId prefix when __openclaw has no sender metadata", () => {
-    const first = {
-      role: "user",
-      content: "please run the deployment status check for production",
+  it("does not collide when sender ids and text contain the old delimiter", () => {
+    const first = userMessage({
+      content: "b|please run deployment status now",
       timestamp: 1_000,
-    } as const;
-    const second = {
-      role: "user",
-      content: "please run the deployment status check for production",
+      senderId: "a",
+    });
+    const second = userMessage({
+      content: "please run deployment status now",
       timestamp: 2_000,
-    } as const;
+      senderId: "a|b",
+    });
 
-    expect(dedupeDuplicateUserMessagesForCompaction([first, second])).toEqual([first]);
+    expect(dedupeDuplicateUserMessagesForCompaction([first, second])).toEqual([first, second]);
   });
 });

--- a/src/agents/embedded-agent-runner/compaction-duplicate-user-messages.ts
+++ b/src/agents/embedded-agent-runner/compaction-duplicate-user-messages.ts
@@ -10,6 +10,7 @@ type MessageLike = {
   role?: unknown;
   content?: unknown;
   timestamp?: unknown;
+  __openclaw?: unknown;
 };
 
 type EntryLike = {
@@ -52,8 +53,22 @@ function duplicateSignature(message: unknown): { key: string; timestamp: number 
   if (!text || text.length < MIN_DUPLICATE_USER_MESSAGE_CHARS) {
     return undefined;
   }
+  // Include sender identity in the dedup key so two different participants who
+  // happen to send the same message within the window are both kept (#98310).
+  // Sender metadata is set by buildPersistedUserTurnMessage in the transcript
+  // persist path (senderId, senderName, senderUsername under __openclaw).
+  // Fall back to empty prefix when no senderId is available (direct chats,
+  // legacy transcripts).
+  // Use bracket notation to avoid no-underscore-dangle lint on `__openclaw`.
+  const openclaw = isRecord((message as Record<string, unknown>)["__openclaw"])
+    ? (message as Record<string, unknown>)["__openclaw"]
+    : undefined;
+  const rawSenderId: unknown = openclaw
+    ? (openclaw as Record<string, unknown>).senderId
+    : undefined;
+  const senderId: string = typeof rawSenderId === "string" ? rawSenderId : "";
   return {
-    key: text.normalize("NFC").toLowerCase(),
+    key: `${senderId}|${text.normalize("NFC").toLowerCase()}`,
     timestamp: message.timestamp,
   };
 }

--- a/src/agents/embedded-agent-runner/compaction-duplicate-user-messages.ts
+++ b/src/agents/embedded-agent-runner/compaction-duplicate-user-messages.ts
@@ -53,22 +53,13 @@ function duplicateSignature(message: unknown): { key: string; timestamp: number 
   if (!text || text.length < MIN_DUPLICATE_USER_MESSAGE_CHARS) {
     return undefined;
   }
-  // Include sender identity in the dedup key so two different participants who
-  // happen to send the same message within the window are both kept (#98310).
-  // Sender metadata is set by buildPersistedUserTurnMessage in the transcript
-  // persist path (senderId, senderName, senderUsername under __openclaw).
-  // Fall back to empty prefix when no senderId is available (direct chats,
-  // legacy transcripts).
-  // Use bracket notation to avoid no-underscore-dangle lint on `__openclaw`.
-  const openclaw = isRecord((message as Record<string, unknown>)["__openclaw"])
-    ? (message as Record<string, unknown>)["__openclaw"]
-    : undefined;
-  const rawSenderId: unknown = openclaw
-    ? (openclaw as Record<string, unknown>).senderId
-    : undefined;
-  const senderId: string = typeof rawSenderId === "string" ? rawSenderId : "";
+  // Persisted sender identity keeps distinct participants separate while senderless legacy
+  // turns retain the old retry behavior. A JSON tuple avoids sender/text delimiter collisions.
+  const metadata = message["__openclaw"];
+  const senderId =
+    isRecord(metadata) && typeof metadata.senderId === "string" ? metadata.senderId : "";
   return {
-    key: `${senderId}|${text.normalize("NFC").toLowerCase()}`,
+    key: JSON.stringify([senderId, text.normalize("NFC").toLowerCase()]),
     timestamp: message.timestamp,
   };
 }


### PR DESCRIPTION
## What Problem This Solves

Multi-user session compaction keyed duplicate long user turns only by normalized text. When Alice and Bob sent the same text inside the 60-second window, the later participant's turn could be omitted from the compaction branch.

Fixes #98310. Depends on the sender-attribution persistence landed in #90552.

## Why This Change Was Made

Both compaction consumers share `duplicateSignature`, so that helper now keys retry pruning by the canonical persisted `__openclaw.senderId` plus normalized text. The key is a serialized tuple rather than a delimiter-joined string, preventing collisions when either field contains punctuation. Senderless legacy/direct turns keep the old text-only behavior through an empty sender component.

The PR was reduced to the two owning files. A committed one-off proof script and unrelated branch changes were removed. Tests now cover same-sender retries, distinct participants in direct and successor-transcript pruning, senderless messages, and the former delimiter-collision shape.

## User Impact

Group and multi-user sessions retain each participant's identical long message during compaction. A single sender's short-window duplicate retry is still pruned.

## Evidence

- Exact head: `e7041a5f3158588497fab2957e563f2d8f12dbe7`.
- Sanitized public-network AWS Crabbox, no IAM role/Tailscale/credentials: [run `run_535da0cfb8e5`](https://crabbox.openclaw.ai/portal/runs/run_535da0cfb8e5).
  - `compaction-duplicate-user-messages.test.ts`: 6 passed.
  - `compaction-successor-transcript.test.ts`: 12 passed.
  - `user-turn-transcript.test.ts`: 32 passed.
- Standalone runtime against the exported production helpers: [run `run_981e1a1b288b`](https://crabbox.openclaw.ai/portal/runs/run_981e1a1b288b).
  - Output: `{"keptSenders":["alice","bob"],"duplicateEntryIds":["entry-alice-retry"]}`.
- Fresh Codex autoreview: clean, 0.97 confidence.
- `git diff --check` and focused oxfmt: passed.

No screenshot is useful for this internal transcript-state correction; the proof records the exact retained sender ids and pruned retry id.

## Security Impact

No new identity data is stored. The patch reads the sender id already persisted under the approved `__openclaw` envelope by #90552 and adds no permissions, secrets, network calls, or execution surface.

## Best-fix Verdict

This is the narrowest owner-correct fix: one shared signature covers both compaction paths, uses the existing sender contract, retains legacy behavior, and avoids a parallel attribution or escaping scheme.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## AI Assistance

- AI-assisted: yes
- Human maintainer review: complete
