### PR TITLE
fix(nostr): resolve SecretRef private key so the channel connects

### DIFF
--- a/docs/reference/secretref-credential-surface.md
+++ b/docs/reference/secretref-credential-surface.md
@@ -112,6 +112,7 @@ The lists below are generated from the source target registry and checked agains
 - `channels.matrix.password`
 - `channels.matrix.accounts.*.accessToken`
 - `channels.matrix.accounts.*.password`
+- `channels.nostr.privateKey`
 - `channels.nextcloud-talk.botSecret`
 - `channels.nextcloud-talk.apiPassword`
 - `channels.nextcloud-talk.accounts.*.botSecret`

--- a/docs/reference/secretref-user-supplied-credentials-matrix.json
+++ b/docs/reference/secretref-user-supplied-credentials-matrix.json
@@ -284,6 +284,13 @@
       "optIn": true
     },
     {
+      "id": "channels.nostr.privateKey",
+      "configFile": "openclaw.json",
+      "path": "channels.nostr.privateKey",
+      "secretShape": "secret_input",
+      "optIn": true
+    },
+    {
       "id": "channels.qqbot.accounts.*.clientSecret",
       "configFile": "openclaw.json",
       "path": "channels.qqbot.accounts.*.clientSecret",

--- a/extensions/nostr/index.ts
+++ b/extensions/nostr/index.ts
@@ -39,6 +39,10 @@ export default defineBundledChannelEntry({
     specifier: "./channel-plugin-api.js",
     exportName: "nostrPlugin",
   },
+  secrets: {
+    specifier: "./secret-contract-api.js",
+    exportName: "channelSecrets",
+  },
   runtime: {
     specifier: "./api.js",
     exportName: "setNostrRuntime",

--- a/extensions/nostr/secret-contract-api.ts
+++ b/extensions/nostr/secret-contract-api.ts
@@ -1,0 +1,6 @@
+// Nostr API module exposes the plugin public contract.
+export {
+  channelSecrets,
+  collectRuntimeConfigAssignments,
+  secretTargetRegistryEntries,
+} from "./src/secret-contract.js";

--- a/extensions/nostr/setup-entry.ts
+++ b/extensions/nostr/setup-entry.ts
@@ -7,4 +7,8 @@ export default defineBundledChannelSetupEntry({
     specifier: "./setup-plugin-api.js",
     exportName: "nostrSetupPlugin",
   },
+  secrets: {
+    specifier: "./secret-contract-api.js",
+    exportName: "channelSecrets",
+  },
 });

--- a/extensions/nostr/src/channel.ts
+++ b/extensions/nostr/src/channel.ts
@@ -32,10 +32,7 @@ import {
 } from "./gateway.js";
 import { normalizePubkey } from "./nostr-key-utils.js";
 import type { ProfilePublishResult } from "./nostr-profile.js";
-import {
-  collectRuntimeConfigAssignments,
-  secretTargetRegistryEntries,
-} from "./secret-contract.js";
+import { collectRuntimeConfigAssignments, secretTargetRegistryEntries } from "./secret-contract.js";
 import { resolveNostrOutboundSessionRoute } from "./session-route.js";
 import { nostrSetupAdapter, nostrSetupContract, nostrSetupWizard } from "./setup-surface.js";
 import {

--- a/extensions/nostr/src/channel.ts
+++ b/extensions/nostr/src/channel.ts
@@ -32,6 +32,10 @@ import {
 } from "./gateway.js";
 import { normalizePubkey } from "./nostr-key-utils.js";
 import type { ProfilePublishResult } from "./nostr-profile.js";
+import {
+  collectRuntimeConfigAssignments,
+  secretTargetRegistryEntries,
+} from "./secret-contract.js";
 import { resolveNostrOutboundSessionRoute } from "./session-route.js";
 import { nostrSetupAdapter, nostrSetupContract, nostrSetupWizard } from "./setup-surface.js";
 import {
@@ -191,6 +195,10 @@ export const nostrPlugin: ChannelPlugin<ResolvedNostrAccount> = createChatChanne
           },
         }),
       }),
+    },
+    secrets: {
+      secretTargetRegistryEntries,
+      collectRuntimeConfigAssignments,
     },
     gateway: {
       startAccount: startNostrGatewayAccount,

--- a/extensions/nostr/src/secret-contract.test.ts
+++ b/extensions/nostr/src/secret-contract.test.ts
@@ -6,6 +6,7 @@ import {
   resolveSecretRefValues,
 } from "openclaw/plugin-sdk/secret-ref-runtime";
 import { describe, expect, it } from "vitest";
+import { nostrPlugin } from "./channel.js";
 import { collectRuntimeConfigAssignments, secretTargetRegistryEntries } from "./secret-contract.js";
 import { listNostrAccountIds, resolveNostrAccount } from "./types.js";
 
@@ -45,6 +46,10 @@ describe("nostr secret contract", () => {
     expect(secretTargetRegistryEntries.map((entry) => entry.id)).toEqual([
       "channels.nostr.privateKey",
     ]);
+    expect(nostrPlugin.secrets).toMatchObject({
+      collectRuntimeConfigAssignments,
+      secretTargetRegistryEntries,
+    });
   });
 
   it("materializes a SecretRef privateKey so the channel resolves as configured", async () => {

--- a/extensions/nostr/src/secret-contract.test.ts
+++ b/extensions/nostr/src/secret-contract.test.ts
@@ -1,0 +1,90 @@
+// Nostr tests cover secret contract plugin behavior.
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import {
+  applyResolvedAssignments,
+  createResolverContext,
+  resolveSecretRefValues,
+} from "openclaw/plugin-sdk/secret-ref-runtime";
+import { describe, expect, it } from "vitest";
+import { collectRuntimeConfigAssignments, secretTargetRegistryEntries } from "./secret-contract.js";
+import { listNostrAccountIds, resolveNostrAccount } from "./types.js";
+
+const PRIVATE_KEY_HEX = "0000000000000000000000000000000000000000000000000000000000000001";
+
+async function resolveNostrSecretAssignments(
+  sourceConfig: OpenClawConfig,
+  env: NodeJS.ProcessEnv,
+): Promise<{
+  config: OpenClawConfig;
+  warnings: ReturnType<typeof createResolverContext>["warnings"];
+}> {
+  const resolvedConfig: OpenClawConfig = structuredClone(sourceConfig);
+  const context = createResolverContext({ sourceConfig, env });
+
+  collectRuntimeConfigAssignments({
+    config: resolvedConfig,
+    defaults: sourceConfig.secrets?.defaults,
+    context,
+  });
+
+  const resolved = await resolveSecretRefValues(
+    context.assignments.map((assignment) => assignment.ref),
+    {
+      config: sourceConfig,
+      env: context.env,
+      cache: context.cache,
+    },
+  );
+  applyResolvedAssignments({ assignments: context.assignments, resolved });
+
+  return { config: resolvedConfig, warnings: context.warnings };
+}
+
+describe("nostr secret contract", () => {
+  it("publishes the Nostr private key target", () => {
+    expect(secretTargetRegistryEntries.map((entry) => entry.id)).toEqual([
+      "channels.nostr.privateKey",
+    ]);
+  });
+
+  it("materializes a SecretRef privateKey so the channel resolves as configured", async () => {
+    const resolved = await resolveNostrSecretAssignments(
+      {
+        channels: {
+          nostr: {
+            enabled: true,
+            privateKey: { source: "env", provider: "default", id: "NOSTR_PRIVATE_KEY" },
+          },
+        },
+      } as OpenClawConfig,
+      { NOSTR_PRIVATE_KEY: PRIVATE_KEY_HEX },
+    );
+
+    expect(resolved.config.channels?.nostr?.privateKey).toBe(PRIVATE_KEY_HEX);
+    expect(resolved.warnings).toStrictEqual([]);
+
+    const account = resolveNostrAccount({ cfg: resolved.config });
+    expect(account.configured).toBe(true);
+    expect(account.privateKey).toBe(PRIVATE_KEY_HEX);
+    expect(account.publicKey.length).toBeGreaterThan(0);
+    expect(listNostrAccountIds(resolved.config)).toEqual([account.accountId]);
+  });
+
+  it("keeps a plaintext privateKey configured", async () => {
+    const resolved = await resolveNostrSecretAssignments(
+      {
+        channels: {
+          nostr: {
+            enabled: true,
+            privateKey: PRIVATE_KEY_HEX,
+          },
+        },
+      } as OpenClawConfig,
+      {},
+    );
+
+    expect(resolved.config.channels?.nostr?.privateKey).toBe(PRIVATE_KEY_HEX);
+    expect(resolveNostrAccount({ cfg: resolved.config }).configured).toBe(true);
+    expect(listNostrAccountIds(resolved.config)).toEqual(["default"]);
+  });
+});

--- a/extensions/nostr/src/secret-contract.ts
+++ b/extensions/nostr/src/secret-contract.ts
@@ -1,0 +1,49 @@
+// Nostr plugin module implements secret contract behavior.
+import {
+  collectSimpleChannelFieldAssignments,
+  getChannelSurface,
+  type ResolverContext,
+  type SecretDefaults,
+} from "openclaw/plugin-sdk/channel-secret-basic-runtime";
+
+export const secretTargetRegistryEntries: import("openclaw/plugin-sdk/channel-secret-basic-runtime").SecretTargetRegistryEntry[] =
+  [
+    {
+      id: "channels.nostr.privateKey",
+      targetType: "channels.nostr.privateKey",
+      configFile: "openclaw.json",
+      pathPattern: "channels.nostr.privateKey",
+      secretShape: "secret_input",
+      expectedResolvedValue: "string",
+      includeInPlan: true,
+      includeInConfigure: true,
+      includeInAudit: true,
+    },
+  ];
+
+export function collectRuntimeConfigAssignments(params: {
+  config: { channels?: Record<string, unknown> };
+  defaults?: SecretDefaults;
+  context: ResolverContext;
+}): void {
+  const resolved = getChannelSurface(params.config, "nostr");
+  if (!resolved) {
+    return;
+  }
+  const { channel: nostr, surface } = resolved;
+  collectSimpleChannelFieldAssignments({
+    channelKey: "nostr",
+    field: "privateKey",
+    channel: nostr,
+    surface,
+    defaults: params.defaults,
+    context: params.context,
+    topInactiveReason: "no enabled account inherits this top-level Nostr private key.",
+    accountInactiveReason: "Nostr account is disabled.",
+  });
+}
+
+export const channelSecrets = {
+  secretTargetRegistryEntries,
+  collectRuntimeConfigAssignments,
+};


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators who configure their Nostr private key as a SecretRef (the `{ source: "env" | "file" | "exec", provider, id }` shape that `channels.nostr.privateKey` accepts, and that the docs steer operators toward instead of storing the raw key in `openclaw.json`) get a Nostr channel that silently never connects. It never subscribes, never sends, and never receives DMs, with no error surfaced. A plaintext key in the same field works, so the failure looks arbitrary.

The setup wizard makes this worse: it reports the SecretRef key as "configured" because it uses the SecretRef-aware `hasConfiguredSecretInput`, while the runtime treats the exact same config as unconfigured. The operator follows guidance, sees green in setup, and gets a dead channel.

## Why This Change Was Made

Root cause is a missing plugin contract, not a runtime bug in the resolver. Every other secret-backed channel (discord, feishu, irc, mattermost, matrix, sms, ...) ships a `secret-contract.ts` that declares its credential paths so the gateway materializes their SecretRefs into plain strings before runtime reads config. Nostr had no such contract, so `channels.nostr.privateKey` was never collected as a secret assignment and the raw SecretRef object survived into `resolveNostrAccount`.

`resolveNostrAccount` (extensions/nostr/src/types.ts:65-67) derives `configured` through the string-only `normalizeSecretInputString`, which returns `undefined` for any non-string. An unresolved SecretRef object collapses to `""`, so `configured` is `false` and `listNostrAccountIds` drops the account, so the channel start gate (`isConfigured: (account) => account.configured`) never fires.

The fix adds the missing Nostr secret contract at the same boundary every sibling channel uses. It keeps the runtime resolver string-only like all other channels, rather than teaching one channel's resolver to special-case SecretRefs. No config shape, default, or documented surface changes; this restores the SecretRef capability the schema already advertises.

## User Impact

Operators can now set `channels.nostr.privateKey` to an env/file/exec SecretRef and the Nostr channel connects, sends, and receives exactly as it does with a plaintext key. The private key path also joins the secret plan/configure/audit surfaces via the new registry entry. Plaintext keys keep working unchanged.

## Evidence

New files:
- `extensions/nostr/src/secret-contract.ts` declares `channels.nostr.privateKey` as a `secret_input` target and collects it via the shared `collectSimpleChannelFieldAssignments` helper.
- `extensions/nostr/secret-contract-api.ts` exposes it as the plugin public artifact the core loader discovers (mirrors `extensions/irc/secret-contract-api.ts`).
- `extensions/nostr/src/secret-contract.test.ts` drives the real collect -> resolve -> apply path with an env-backed SecretRef and asserts the resolved key, `resolveNostrAccount(...).configured === true`, a derived public key, and a non-empty account list. It also covers the plaintext control.

Changed files:
- `extensions/nostr/index.ts` and `extensions/nostr/setup-entry.ts` register the `secrets` bundled entrypoint so both the runtime and setup loaders discover the contract.
- `extensions/nostr/src/channel.ts` exposes the same contract through `nostrPlugin.secrets`.
- `docs/reference/secretref-credential-surface.md` and `docs/reference/secretref-user-supplied-credentials-matrix.json` are the generated surface maps; they now list `channels.nostr.privateKey`, regenerated against current main so `src/secrets/target-registry.docs.test.ts` stays in sync.

Before this change, the offending derivation (extensions/nostr/src/types.ts:65-67):

```ts
const baseEnabled = nostrCfg?.enabled !== false;
const privateKey = normalizeSecretInputString(nostrCfg?.privateKey) ?? "";
const configured = Boolean(privateKey);
```

`normalizeSecretInputString` returns `undefined` for a SecretRef object, so `configured` is `false`.

The fix (new `extensions/nostr/src/secret-contract.ts`) makes the gateway resolve the SecretRef into that string before the resolver runs:

```ts
export function collectRuntimeConfigAssignments(params: {
  config: { channels?: Record<string, unknown> };
  defaults?: SecretDefaults;
  context: ResolverContext;
}): void {
  const resolved = getChannelSurface(params.config, "nostr");
  if (!resolved) {
    return;
  }
  const { channel: nostr, surface } = resolved;
  collectSimpleChannelFieldAssignments({
    channelKey: "nostr",
    field: "privateKey",
    channel: nostr,
    surface,
    defaults: params.defaults,
    context: params.context,
    topInactiveReason: "no enabled account inherits this top-level Nostr private key.",
    accountInactiveReason: "Nostr account is disabled.",
  });
}
```

### Why this is the right boundary

Nostr is the only secret-backed channel missing a `secret-contract.ts`; the fix adds it rather than diverging the runtime resolver. Channel-specific secret wiring is required to live in the plugin, not core (`src/secrets/channel-contract-surface-guardrails.test.ts` forbids channel names in the core collectors). Nostr's config is a single top-level `channels.nostr.privateKey` with no `accounts.*` nesting, so `collectSimpleChannelFieldAssignments` handles it exactly like irc's top-level password. No sibling surface is left unfixed; the plaintext path is preserved.

## Verification

Run on the rebased head against `openclaw/openclaw@1695854877`:

- `node scripts/run-vitest.mjs extensions/nostr` -> 20 files, 244 tests passed (includes the 3 new secret-contract tests).
- `node scripts/run-vitest.mjs src/secrets/target-registry.docs.test.ts` -> 2 passed, so both regenerated `docs/reference/secretref-*` baselines match the registry output on current main.
- `node scripts/run-vitest.mjs src/secrets/channel-contract-surface-guardrails.test.ts src/secrets/runtime-config-collectors-channels.test.ts src/secrets/runtime.coverage.test.ts src/secrets/channel-env-vars.dynamic.test.ts src/secrets/plan.test.ts src/secrets/configure-plan.test.ts src/secrets/audit.test.ts` -> 7 files, 139 tests passed.
- `node scripts/run-tsgo.mjs -p tsconfig.extensions.json` -> clean.
- `oxlint` and `oxfmt --check` on the six changed files -> clean.

## Real behavior proof
Behavior addressed: a SecretRef-backed `channels.nostr.privateKey` is treated as missing, so the Nostr channel reports unconfigured and never starts; a plaintext key in the same field works.
Real environment tested: drove the real core channel secret discovery function `collectChannelConfigAssignments` (which loads Nostr's bundled `secret-contract-api` via `loadChannelSecretContractApi`), then the real `resolveSecretRefValues` env provider and `applyResolvedAssignments`, then the real `resolveNostrAccount` / `listNostrAccountIds`, on pristine main (`1695854877ff74b66582f4af7371b1fb7da276a1`, contract absent) and on the patched tree at head `2d7f08835c845072526f003b8c6bb7dcb42e0e26` with identical input. Real: the core discovery seam, the env secret provider, the on-disk resolver, and the Nostr account resolver. Nothing was stubbed.
Exact steps or command run after this patch: build a config with `channels.nostr.privateKey = { source: "env", provider: "default", id: "NOSTR_PRIVATE_KEY" }` and env `NOSTR_PRIVATE_KEY=<hex>`, run `collectChannelConfigAssignments` -> `resolveSecretRefValues` -> `applyResolvedAssignments`, then `resolveNostrAccount({ cfg })` and `listNostrAccountIds(cfg)`, in a pristine `origin/main` worktree and in this branch's worktree.
Evidence after fix:
```
# BEFORE (pristine main 1695854877, no Nostr secret contract)
assignments.collected = 0
config.privateKey.type = {"source":"env","provider":"default","id":"NOSTR_PRIVATE_KEY"}
account.configured = false
account.publicKey.length = 0
listNostrAccountIds = []
# AFTER (this patch at 2d7f08835c, identical input)
assignments.collected = 1
config.privateKey.type = string
account.configured = true
account.publicKey.length = 64
listNostrAccountIds = ["default"]
```
Observed result after fix: the env-backed SecretRef is now materialized into the private key string, so the Nostr account resolves as configured with a derived public key and a live account id, where before it resolved as unconfigured with an empty account list.
What was not tested: no live relay round trip and no live file/exec secret provider beyond the env source; full build not run (change is a plugin contract file plus its public artifacts, no dynamic-import or packaging boundary touched).

## Refresh (2026-07-27)

- Rebased onto `openclaw/openclaw@1695854877ff74b66582f4af7371b1fb7da276a1` with no conflicts and force-pushed with a guarded lease. Current exact head: [`2d7f08835c845072526f003b8c6bb7dcb42e0e26`](https://github.com/openclaw/openclaw/commit/2d7f08835c845072526f003b8c6bb7dcb42e0e26).
- Re-confirmed the defect is still live on current main: `extensions/nostr` remains the only secret-backed channel with no `secret-contract.ts`, and `resolveNostrAccount` still derives `configured` from the string-only `normalizeSecretInputString`.
- Both generated `docs/reference/secretref-*` baselines were re-verified against the registry on the new base; `src/secrets/target-registry.docs.test.ts` passes, so `check-docs` stays green after the rebase.
- The Real behavior proof above was regenerated from scratch on the new base and the new head. No output was reused.
- The previously red `checks-node-compact-small-7` was an unrelated infrastructure timeout: three `src/cli/acp-cli-exit.process.test.ts` subprocess cases failed with `spawnSync ... ETIMEDOUT` while 3,119 other tests in that shard passed. This PR touches only Nostr plugin contract files, their tests, and the two generated docs baselines; it does not touch ACP or `src/cli`.
