### PR TITLE
Verify signed marketplace feed refresh

### DIFF
--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -105,7 +105,7 @@ const defaultPublicDeprecatedExportsByEntrypointBudget = Object.freeze({
   "approval-reply-runtime": 1,
   "config-runtime": 123,
   "config-contracts": 1,
-  "config-types": 421,
+  "config-types": 423,
   "config-schema": 3,
   "reply-dedupe": 1,
   "inbound-reply-dispatch": 33,
@@ -205,7 +205,7 @@ export function readPluginSdkSurfaceBudgets(env = process.env) {
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_DEPRECATED_EXPORTS",
-      3263,
+      3265,
       env,
     ),
     publicWildcardReexports: readPluginSdkSurfaceBudgetEnv(

--- a/src/plugins/official-external-plugin-catalog-envelope.test.ts
+++ b/src/plugins/official-external-plugin-catalog-envelope.test.ts
@@ -138,6 +138,81 @@ describe("official external plugin catalog signed envelopes", () => {
     expect(result.ok).toBe(true);
   });
 
+  it("enforces the configured trusted signature threshold", () => {
+    const first = signedEnvelope({ keyId: "clawhub-root-a" });
+    const second = signedEnvelope({ keyId: "clawhub-root-b" });
+    const firstSignature = first.envelope.signatures?.[0];
+    const secondSignature = second.envelope.signatures?.[0];
+    if (!firstSignature || !secondSignature) {
+      throw new Error("expected signatures");
+    }
+    const envelope = {
+      ...first.envelope,
+      signatures: [firstSignature, secondSignature],
+    };
+
+    expect(
+      verifyOfficialExternalPluginCatalogSignedEnvelope(envelope, {
+        trustedKeys: [
+          { keyId: "clawhub-root-a", publicKey: first.publicKeyPem },
+          { keyId: "clawhub-root-b", publicKey: second.publicKeyPem },
+        ],
+        threshold: 2,
+      }),
+    ).toMatchObject({
+      ok: true,
+      signedBy: "clawhub-root-a",
+      signedByKeyIds: ["clawhub-root-a", "clawhub-root-b"],
+      signatureCount: 2,
+      threshold: 2,
+    });
+
+    expect(
+      verifyOfficialExternalPluginCatalogSignedEnvelope(first.envelope, {
+        trustedKeys: [
+          { keyId: "clawhub-root-a", publicKey: first.publicKeyPem },
+          { keyId: "clawhub-root-b", publicKey: second.publicKeyPem },
+        ],
+        threshold: 2,
+      }),
+    ).toMatchObject({
+      ok: false,
+      error: "invalid-signature",
+    });
+  });
+
+  it("does not count duplicate trust key material toward the signature threshold", () => {
+    const { envelope, publicKeyPem } = signedEnvelope({ keyId: "clawhub-root-a" });
+    const firstSignature = envelope.signatures?.[0];
+    if (!firstSignature) {
+      throw new Error("expected signature");
+    }
+    const result = verifyOfficialExternalPluginCatalogSignedEnvelope(
+      {
+        ...envelope,
+        signatures: [
+          firstSignature,
+          {
+            ...firstSignature,
+            keyId: "clawhub-root-b",
+          },
+        ],
+      },
+      {
+        trustedKeys: [
+          { keyId: "clawhub-root-a", publicKey: publicKeyPem },
+          { keyId: "clawhub-root-b", publicKey: publicKeyPem },
+        ],
+        threshold: 2,
+      },
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: "invalid-signature",
+    });
+  });
+
   it("rejects payload bytes changed after signing", () => {
     const { envelope, publicKeyPem } = signedEnvelope();
     const tamperedFeed = { ...fixtureFeed(), sequence: 43 };

--- a/src/plugins/official-external-plugin-catalog-envelope.ts
+++ b/src/plugins/official-external-plugin-catalog-envelope.ts
@@ -1,4 +1,7 @@
-import { verifyEd25519SignatureBytes } from "../infra/ed25519-signature.js";
+import {
+  normalizeEd25519PublicKeyBase64Url,
+  verifyEd25519SignatureBytes,
+} from "../infra/ed25519-signature.js";
 import { isRecord } from "../utils.js";
 import {
   isOfficialExternalPluginCatalogFeed,
@@ -32,6 +35,9 @@ export type OfficialExternalPluginCatalogEnvelopeVerificationResult =
       ok: true;
       feed: OfficialExternalPluginCatalogFeed;
       signedBy: string;
+      signedByKeyIds?: readonly string[];
+      signatureCount?: number;
+      threshold?: number;
     }
   | {
       ok: false;
@@ -61,6 +67,7 @@ export function verifyOfficialExternalPluginCatalogSignedEnvelope(
   raw: unknown,
   params: {
     trustedKeys: readonly OfficialExternalPluginCatalogTrustedSigningKey[];
+    threshold?: number;
   },
 ): OfficialExternalPluginCatalogEnvelopeVerificationResult {
   const envelope = parseOfficialExternalPluginCatalogSignedEnvelope(raw);
@@ -90,11 +97,17 @@ export function verifyOfficialExternalPluginCatalogSignedEnvelope(
     payloadType: envelope.payloadType,
     payloadBytes,
   });
-  let trustedSignatureKeyId: string | undefined;
+  const threshold = Math.max(1, Math.trunc(params.threshold ?? 1));
+  const trustedSignatureKeyIds: string[] = [];
+  const trustedSignaturePublicKeys = new Set<string>();
   for (const envelopeSignature of envelope.signatures) {
     const keyId = envelopeSignature.keyId;
     const trustedKey = params.trustedKeys.find((candidate) => candidate.keyId === keyId);
-    if (!trustedKey) {
+    if (!trustedKey || trustedSignatureKeyIds.includes(trustedKey.keyId)) {
+      continue;
+    }
+    const normalizedPublicKey = normalizeEd25519PublicKeyBase64Url(trustedKey.publicKey);
+    if (!normalizedPublicKey || trustedSignaturePublicKeys.has(normalizedPublicKey)) {
       continue;
     }
     if (
@@ -104,11 +117,14 @@ export function verifyOfficialExternalPluginCatalogSignedEnvelope(
         signatureBase64Url: envelopeSignature.signature,
       })
     ) {
-      trustedSignatureKeyId = trustedKey.keyId;
-      break;
+      trustedSignatureKeyIds.push(trustedKey.keyId);
+      trustedSignaturePublicKeys.add(normalizedPublicKey);
+      if (trustedSignaturePublicKeys.size >= threshold) {
+        break;
+      }
     }
   }
-  if (trustedSignatureKeyId) {
+  if (trustedSignaturePublicKeys.size >= threshold) {
     const feed = decodeOfficialExternalPluginCatalogEnvelopePayload(payloadBytes);
     if (!feed) {
       return {
@@ -120,7 +136,14 @@ export function verifyOfficialExternalPluginCatalogSignedEnvelope(
     return {
       ok: true,
       feed,
-      signedBy: trustedSignatureKeyId,
+      signedBy: trustedSignatureKeyIds[0] ?? "",
+      ...(threshold > 1
+        ? {
+            signedByKeyIds: trustedSignatureKeyIds,
+            signatureCount: trustedSignaturePublicKeys.size,
+            threshold,
+          }
+        : {}),
     };
   }
   const hasKnownKey = envelope.signatures.some((signature) =>
@@ -130,7 +153,10 @@ export function verifyOfficialExternalPluginCatalogSignedEnvelope(
     ? {
         ok: false,
         error: "invalid-signature",
-        message: "hosted catalog signed envelope signature is invalid",
+        message:
+          trustedSignatureKeyIds.length > 0
+            ? "hosted catalog signed envelope did not meet the configured signature threshold"
+            : "hosted catalog signed envelope signature is invalid",
       }
     : {
         ok: false,

--- a/src/plugins/official-external-plugin-catalog-snapshot-store.ts
+++ b/src/plugins/official-external-plugin-catalog-snapshot-store.ts
@@ -15,6 +15,7 @@ import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths
 import type {
   HostedOfficialExternalPluginCatalogMetadata,
   HostedOfficialExternalPluginCatalogSnapshot,
+  HostedOfficialExternalPluginCatalogSnapshotMonotonicState,
   HostedOfficialExternalPluginCatalogSnapshotStore,
   HostedOfficialExternalPluginCatalogTrustState,
 } from "./official-external-plugin-catalog.js";
@@ -97,6 +98,69 @@ function rowToTrustState(
   };
 }
 
+function decodeBase64Payload(payload: string): string {
+  const normalized = payload.replace(/-/g, "+").replace(/_/g, "/");
+  return Buffer.from(normalized, "base64").toString("utf8");
+}
+
+function readMonotonicStateFromBody(
+  body: string,
+): HostedOfficialExternalPluginCatalogSnapshotMonotonicState | undefined {
+  try {
+    const document = JSON.parse(body) as {
+      payload?: unknown;
+      sequence?: unknown;
+      generatedAt?: unknown;
+    };
+    const feed =
+      typeof document.payload === "string"
+        ? (JSON.parse(decodeBase64Payload(document.payload)) as {
+            sequence?: unknown;
+            generatedAt?: unknown;
+          })
+        : document;
+    if (typeof feed.sequence !== "number" || typeof feed.generatedAt !== "string") {
+      return undefined;
+    }
+    return {
+      mode: "signed-feed",
+      sequence: feed.sequence,
+      generatedAt: feed.generatedAt,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function isMonotonicRollback(params: {
+  candidate: HostedOfficialExternalPluginCatalogSnapshotMonotonicState;
+  current: HostedOfficialExternalPluginCatalogSnapshotMonotonicState;
+}): boolean {
+  if (params.candidate.sequence < params.current.sequence) {
+    return true;
+  }
+  if (params.candidate.sequence > params.current.sequence) {
+    return false;
+  }
+  return Date.parse(params.candidate.generatedAt) < Date.parse(params.current.generatedAt);
+}
+
+function assertSignedSnapshotWriteIsMonotonic(params: {
+  candidate: HostedOfficialExternalPluginCatalogSnapshotMonotonicState | undefined;
+  current: HostedCatalogSnapshotRow | undefined;
+}): void {
+  if (params.candidate?.mode !== "signed-feed" || params.current?.trust_mode !== "signed") {
+    return;
+  }
+  const current = readMonotonicStateFromBody(params.current.body);
+  if (!current) {
+    return;
+  }
+  if (isMonotonicRollback({ candidate: params.candidate, current })) {
+    throw new Error("hosted catalog signed feed sequence is older than current snapshot");
+  }
+}
+
 function rowToSnapshot(
   row: HostedCatalogSnapshotRow | undefined,
 ): HostedOfficialExternalPluginCatalogSnapshot | null {
@@ -157,6 +221,30 @@ export function createSqliteHostedOfficialExternalPluginCatalogSnapshotStore(
       const now = Date.now();
       runOpenClawStateWriteTransaction((database) => {
         const stateDb = getNodeSqliteKysely<HostedCatalogSnapshotDatabase>(database.db);
+        const current = executeSqliteQueryTakeFirstSync(
+          database.db,
+          stateDb
+            .selectFrom("official_external_plugin_catalog_snapshots")
+            .select([
+              "feed_url",
+              "body",
+              "status",
+              "etag",
+              "last_modified",
+              "checksum",
+              "saved_at",
+              "trust_mode",
+              "trust_key_id",
+              "trust_signature_count",
+              "trust_threshold",
+              "trust_verified_at",
+            ])
+            .where("feed_url", "=", snapshot.metadata.url),
+        ) as HostedCatalogSnapshotRow | undefined;
+        assertSignedSnapshotWriteIsMonotonic({
+          candidate: snapshot.monotonic,
+          current,
+        });
         executeSqliteQuerySync(
           database.db,
           stateDb

--- a/src/plugins/official-external-plugin-catalog-snapshot-store.ts
+++ b/src/plugins/official-external-plugin-catalog-snapshot-store.ts
@@ -16,6 +16,7 @@ import type {
   HostedOfficialExternalPluginCatalogMetadata,
   HostedOfficialExternalPluginCatalogSnapshot,
   HostedOfficialExternalPluginCatalogSnapshotStore,
+  HostedOfficialExternalPluginCatalogTrustState,
 } from "./official-external-plugin-catalog.js";
 
 export type HostedOfficialExternalPluginCatalogSnapshotStoreOptions = {
@@ -32,6 +33,11 @@ type HostedCatalogSnapshotRow = {
   last_modified: string | null;
   checksum: string;
   saved_at: string;
+  trust_mode: string | null;
+  trust_key_id: string | null;
+  trust_signature_count: number | bigint | null;
+  trust_threshold: number | bigint | null;
+  trust_verified_at: string | null;
 };
 
 type HostedCatalogSnapshotDatabase = Pick<
@@ -70,6 +76,27 @@ function resolveStateDatabasePath(
   return resolveOpenClawStateSqlitePath(resolveStoreEnv(options) ?? process.env);
 }
 
+function rowToTrustState(
+  row: HostedCatalogSnapshotRow,
+): HostedOfficialExternalPluginCatalogTrustState | undefined {
+  if (
+    row.trust_mode !== "signed" ||
+    !row.trust_key_id ||
+    row.trust_signature_count === null ||
+    row.trust_threshold === null ||
+    !row.trust_verified_at
+  ) {
+    return undefined;
+  }
+  return {
+    mode: "signed",
+    signedBy: row.trust_key_id,
+    signatureCount: Number(row.trust_signature_count),
+    threshold: Number(row.trust_threshold),
+    verifiedAt: row.trust_verified_at,
+  };
+}
+
 function rowToSnapshot(
   row: HostedCatalogSnapshotRow | undefined,
 ): HostedOfficialExternalPluginCatalogSnapshot | null {
@@ -83,10 +110,12 @@ function rowToSnapshot(
     ...(row.etag ? { etag: row.etag } : {}),
     ...(row.last_modified ? { lastModified: row.last_modified } : {}),
   };
+  const trust = rowToTrustState(row);
   return {
     body: row.body,
     metadata,
     savedAt: row.saved_at,
+    ...(trust ? { trust } : {}),
   };
 }
 
@@ -106,7 +135,20 @@ export function createSqliteHostedOfficialExternalPluginCatalogSnapshotStore(
         database.db,
         stateDb
           .selectFrom("official_external_plugin_catalog_snapshots")
-          .select(["feed_url", "body", "status", "etag", "last_modified", "checksum", "saved_at"])
+          .select([
+            "feed_url",
+            "body",
+            "status",
+            "etag",
+            "last_modified",
+            "checksum",
+            "saved_at",
+            "trust_mode",
+            "trust_key_id",
+            "trust_signature_count",
+            "trust_threshold",
+            "trust_verified_at",
+          ])
           .where("feed_url", "=", url),
       ) as HostedCatalogSnapshotRow | undefined;
       return rowToSnapshot(row);
@@ -128,6 +170,11 @@ export function createSqliteHostedOfficialExternalPluginCatalogSnapshotStore(
               checksum: snapshot.metadata.checksum,
               saved_at: snapshot.savedAt,
               updated_at_ms: now,
+              trust_mode: snapshot.trust?.mode ?? null,
+              trust_key_id: snapshot.trust?.signedBy ?? null,
+              trust_signature_count: snapshot.trust?.signatureCount ?? null,
+              trust_threshold: snapshot.trust?.threshold ?? null,
+              trust_verified_at: snapshot.trust?.verifiedAt ?? null,
             })
             .onConflict((conflict) =>
               conflict.column("feed_url").doUpdateSet({
@@ -138,6 +185,11 @@ export function createSqliteHostedOfficialExternalPluginCatalogSnapshotStore(
                 checksum: snapshot.metadata.checksum,
                 saved_at: snapshot.savedAt,
                 updated_at_ms: now,
+                trust_mode: snapshot.trust?.mode ?? null,
+                trust_key_id: snapshot.trust?.signedBy ?? null,
+                trust_signature_count: snapshot.trust?.signatureCount ?? null,
+                trust_threshold: snapshot.trust?.threshold ?? null,
+                trust_verified_at: snapshot.trust?.verifiedAt ?? null,
               }),
             ),
         );

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -1,9 +1,16 @@
+import crypto from "node:crypto";
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import officialExternalPluginCatalog from "../../scripts/lib/official-external-plugin-catalog.json" with { type: "json" };
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import {
+  OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PAYLOAD_TYPE,
+  createOfficialExternalPluginCatalogEnvelopePayload,
+  createOfficialExternalPluginCatalogEnvelopeSigningInput,
+  type OfficialExternalPluginCatalogSignedEnvelope,
+} from "./official-external-plugin-catalog-envelope.js";
 import { createSqliteHostedOfficialExternalPluginCatalogSnapshotStore } from "./official-external-plugin-catalog-snapshot-store.js";
 import {
   type OfficialExternalPluginCatalogEntry,
@@ -24,6 +31,7 @@ import {
   resolveOfficialExternalPluginInstall,
   resolveOfficialExternalPluginCatalogProfileConfigFromConfig,
   validateOfficialExternalPluginCatalogEntrySourceRefs,
+  type OfficialExternalPluginCatalogFeed,
 } from "./official-external-plugin-catalog.js";
 
 function expectCatalogEntry(id: string): OfficialExternalPluginCatalogEntry {
@@ -36,6 +44,59 @@ function expectCatalogEntry(id: string): OfficialExternalPluginCatalogEntry {
 
 function expectRequestUrl(input: RequestInfo | URL): string {
   return typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+}
+
+function signedHostedCatalogFeed(params?: {
+  feed?: OfficialExternalPluginCatalogFeed;
+  keyId?: string;
+}): {
+  body: string;
+  publicKeyPem: string;
+} {
+  const { publicKey, privateKey } = crypto.generateKeyPairSync("ed25519", {
+    publicKeyEncoding: { type: "spki", format: "pem" },
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+  });
+  const payload = createOfficialExternalPluginCatalogEnvelopePayload(
+    params?.feed ?? {
+      schemaVersion: 1,
+      id: "openclaw-official-external-plugins",
+      generatedAt: "2026-06-22T00:00:00.000Z",
+      sequence: 8,
+      entries: [
+        {
+          name: "@openclaw/signed-refresh-proof",
+          kind: "plugin",
+          openclaw: {
+            plugin: { id: "signed-refresh-proof" },
+            install: { sourceRef: "acme-npm", npmSpec: "@openclaw/signed-refresh-proof" },
+          },
+        },
+      ],
+    },
+  );
+  const signingInput = createOfficialExternalPluginCatalogEnvelopeSigningInput({
+    payloadType: OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PAYLOAD_TYPE,
+    payload,
+  });
+  const envelope: OfficialExternalPluginCatalogSignedEnvelope = {
+    schemaVersion: 1,
+    payloadType: OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PAYLOAD_TYPE,
+    payload,
+    signatures: [
+      {
+        keyId: params?.keyId ?? "acme-root",
+        algorithm: "ed25519",
+        signature: crypto
+          .sign(null, Buffer.from(signingInput, "utf8"), crypto.createPrivateKey(privateKey))
+          .toString("base64url"),
+      },
+    ],
+  };
+  return {
+    body: JSON.stringify(envelope),
+    publicKeyPem: publicKey,
+  };
 }
 
 describe("official external plugin catalog", () => {
@@ -552,8 +613,75 @@ describe("official external plugin catalog", () => {
     expect(result.entries.map((entry) => entry.name)).toEqual(["@acme/private-proof"]);
   });
 
-  it("fails closed for signed feed profiles until envelope enforcement is wired", async () => {
-    const fetchImpl = vi.fn();
+  it("loads and snapshots a signed hosted feed profile after envelope verification", async () => {
+    const snapshotStore = createInMemoryHostedOfficialExternalPluginCatalogSnapshotStore();
+    const writeSpy = vi.spyOn(snapshotStore, "write");
+    const signed = signedHostedCatalogFeed();
+
+    const result = await loadHostedOfficialExternalPluginCatalogEntries({
+      feedProfile: "acme",
+      catalogConfig: {
+        feeds: {
+          acme: {
+            url: "https://packages.acme.example/openclaw/feed",
+            verification: {
+              mode: "signed",
+              keys: [
+                {
+                  keyId: "acme-root",
+                  publicKey: signed.publicKeyPem,
+                },
+              ],
+            },
+          },
+        },
+        sources: { "acme-npm": { type: "npm", registry: "https://packages.acme.example/npm/" } },
+      },
+      fetchImpl: vi.fn(async () => new Response(signed.body, { status: 200 })),
+      now: () => new Date("2026-06-22T04:05:06.000Z"),
+      snapshotStore,
+    });
+
+    expect(result.source).toBe("hosted");
+    expect(result.entries.map((entry) => entry.name)).toEqual(["@openclaw/signed-refresh-proof"]);
+    if (result.source === "hosted") {
+      expect(result.trust).toEqual({
+        mode: "signed",
+        signedBy: "acme-root",
+        signatureCount: 1,
+        threshold: 1,
+        verifiedAt: "2026-06-22T04:05:06.000Z",
+      });
+    }
+    expect(writeSpy).toHaveBeenCalledTimes(1);
+    await expect(
+      snapshotStore.read("https://packages.acme.example/openclaw/feed"),
+    ).resolves.toMatchObject({
+      body: signed.body,
+      trust: {
+        mode: "signed",
+        signedBy: "acme-root",
+        signatureCount: 1,
+        threshold: 1,
+        verifiedAt: "2026-06-22T04:05:06.000Z",
+      },
+    });
+  });
+
+  it("fails closed when a signed feed profile receives unsigned JSON", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            schemaVersion: 1,
+            id: "openclaw-official-external-plugins",
+            generatedAt: "2026-06-22T00:00:00.000Z",
+            sequence: 8,
+            entries: [],
+          }),
+          { status: 200 },
+        ),
+    );
 
     await expect(
       loadHostedOfficialExternalPluginCatalogEntries({
@@ -574,12 +702,15 @@ describe("official external plugin catalog", () => {
             },
           },
         },
-        fetchImpl,
-        snapshotStore: null,
-      }),
-    ).rejects.toThrow("signed feed verification is not wired yet");
+      },
+      fetchImpl,
+      snapshotStore: createInMemoryHostedOfficialExternalPluginCatalogSnapshotStore(),
+    });
 
-    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(result.source).toBe("bundled-fallback");
+    expect(result.entries).toEqual([]);
+    expect(result.error).toContain("signed envelope is malformed");
   });
 
   it("keeps direct hosted feed URL overrides constrained to the public allowlist", async () => {
@@ -1083,6 +1214,113 @@ describe("official external plugin catalog", () => {
     }
   });
 
+  it("re-verifies a signed snapshot before using it in offline mode", async () => {
+    const signed = signedHostedCatalogFeed();
+    const snapshotStore = createInMemoryHostedOfficialExternalPluginCatalogSnapshotStore([
+      {
+        body: signed.body,
+        metadata: {
+          url: "https://packages.acme.example/openclaw/feed",
+          status: 200,
+          checksum: `sha256:${crypto.createHash("sha256").update(signed.body).digest("hex")}`,
+        },
+        savedAt: "2026-06-22T04:05:06.000Z",
+        trust: {
+          mode: "signed",
+          signedBy: "acme-root",
+          signatureCount: 1,
+          threshold: 1,
+          verifiedAt: "2026-06-22T04:05:06.000Z",
+        },
+      },
+    ]);
+
+    const result = await loadHostedOfficialExternalPluginCatalogEntries({
+      feedProfile: "acme",
+      catalogConfig: {
+        feeds: {
+          acme: {
+            url: "https://packages.acme.example/openclaw/feed",
+            verification: {
+              mode: "signed",
+              keys: [{ keyId: "acme-root", publicKey: signed.publicKeyPem }],
+            },
+          },
+        },
+        sources: { "acme-npm": { type: "npm", registry: "https://packages.acme.example/npm/" } },
+      },
+      snapshotStore,
+      offline: true,
+      fetchImpl: vi.fn(),
+    });
+
+    expect(result.source).toBe("hosted-snapshot");
+    expect(result.entries.map((entry) => entry.name)).toEqual(["@openclaw/signed-refresh-proof"]);
+    if (result.source === "hosted-snapshot") {
+      expect(result.trust).toMatchObject({
+        mode: "signed",
+        signedBy: "acme-root",
+        signatureCount: 1,
+        threshold: 1,
+      });
+    }
+  });
+
+  it("does not use an old unsigned snapshot for a signed feed profile", async () => {
+    const unsignedBody = JSON.stringify({
+      schemaVersion: 1,
+      id: "openclaw-official-external-plugins",
+      generatedAt: "2026-06-22T00:00:00.000Z",
+      sequence: 9,
+      entries: [
+        {
+          name: "@openclaw/unsigned-snapshot-proof",
+          kind: "plugin",
+          openclaw: { plugin: { id: "unsigned-snapshot-proof" } },
+        },
+      ],
+    });
+    const snapshotStore = createInMemoryHostedOfficialExternalPluginCatalogSnapshotStore([
+      {
+        body: unsignedBody,
+        metadata: {
+          url: "https://packages.acme.example/openclaw/feed",
+          status: 200,
+          checksum: `sha256:${crypto.createHash("sha256").update(unsignedBody).digest("hex")}`,
+        },
+        savedAt: "2026-06-22T04:05:06.000Z",
+      },
+    ]);
+
+    const result = await loadHostedOfficialExternalPluginCatalogEntries({
+      feedProfile: "acme",
+      catalogConfig: {
+        feeds: {
+          acme: {
+            url: "https://packages.acme.example/openclaw/feed",
+            verification: {
+              mode: "signed",
+              keys: [
+                {
+                  keyId: "acme-root",
+                  publicKey: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                },
+              ],
+            },
+          },
+        },
+      },
+      snapshotStore,
+      offline: true,
+      fetchImpl: vi.fn(),
+    });
+
+    expect(result.source).toBe("bundled-fallback");
+    expect(result.entries).toEqual([]);
+    expect(result.error).toContain("snapshot fallback failed");
+    expect(result.error).toContain("signed envelope is malformed");
+  });
+
   it("persists hosted feed snapshots in OpenClaw state for HTTP 304 reuse", async () => {
     const stateDir = mkdtempSync(path.join(os.tmpdir(), "openclaw-hosted-catalog-"));
     try {
@@ -1167,6 +1405,13 @@ describe("official external plugin catalog", () => {
           checksum: "sha256:second",
         },
         savedAt: "2026-06-22T03:04:05.000Z",
+        trust: {
+          mode: "signed",
+          signedBy: "acme-root",
+          signatureCount: 1,
+          threshold: 1,
+          verifiedAt: "2026-06-22T03:04:05.000Z",
+        },
       });
 
       await expect(store.read(url)).resolves.toMatchObject({
@@ -1178,6 +1423,13 @@ describe("official external plugin catalog", () => {
           checksum: "sha256:second",
         },
         savedAt: "2026-06-22T03:04:05.000Z",
+        trust: {
+          mode: "signed",
+          signedBy: "acme-root",
+          signatureCount: 1,
+          threshold: 1,
+          verifiedAt: "2026-06-22T03:04:05.000Z",
+        },
       });
     } finally {
       closeOpenClawStateDatabaseForTest();

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -49,14 +49,24 @@ function expectRequestUrl(input: RequestInfo | URL): string {
 function signedHostedCatalogFeed(params?: {
   feed?: OfficialExternalPluginCatalogFeed;
   keyId?: string;
+  privateKeyPem?: string;
 }): {
   body: string;
   publicKeyPem: string;
+  privateKeyPem: string;
 } {
-  const { publicKey, privateKey } = crypto.generateKeyPairSync("ed25519", {
-    publicKeyEncoding: { type: "spki", format: "pem" },
-    privateKeyEncoding: { type: "pkcs8", format: "pem" },
-  });
+  const { publicKey, privateKey } =
+    params?.privateKeyPem === undefined
+      ? crypto.generateKeyPairSync("ed25519", {
+          publicKeyEncoding: { type: "spki", format: "pem" },
+          privateKeyEncoding: { type: "pkcs8", format: "pem" },
+        })
+      : {
+          publicKey: crypto
+            .createPublicKey(params.privateKeyPem)
+            .export({ type: "spki", format: "pem" }) as string,
+          privateKey: params.privateKeyPem,
+        };
   const payload = createOfficialExternalPluginCatalogEnvelopePayload(
     params?.feed ?? {
       schemaVersion: 1,
@@ -96,6 +106,7 @@ function signedHostedCatalogFeed(params?: {
   return {
     body: JSON.stringify(envelope),
     publicKeyPem: publicKey,
+    privateKeyPem: privateKey,
   };
 }
 
@@ -668,6 +679,86 @@ describe("official external plugin catalog", () => {
     });
   });
 
+  it("rejects signed hosted feed rollback before replacing snapshots", async () => {
+    const snapshotStore = createInMemoryHostedOfficialExternalPluginCatalogSnapshotStore();
+    const newer = signedHostedCatalogFeed({
+      feed: {
+        schemaVersion: 1,
+        id: "openclaw-official-external-plugins",
+        generatedAt: "2026-06-22T00:00:10.000Z",
+        sequence: 10,
+        entries: [
+          {
+            name: "@openclaw/signed-refresh-proof-v10",
+            kind: "plugin",
+            openclaw: {
+              plugin: { id: "signed-refresh-proof-v10" },
+              install: { sourceRef: "acme-npm", npmSpec: "@openclaw/signed-refresh-proof-v10" },
+            },
+          },
+        ],
+      },
+    });
+    const older = signedHostedCatalogFeed({
+      privateKeyPem: newer.privateKeyPem,
+      feed: {
+        schemaVersion: 1,
+        id: "openclaw-official-external-plugins",
+        generatedAt: "2026-06-22T00:00:09.000Z",
+        sequence: 9,
+        entries: [
+          {
+            name: "@openclaw/signed-refresh-proof-v9",
+            kind: "plugin",
+            openclaw: {
+              plugin: { id: "signed-refresh-proof-v9" },
+              install: { sourceRef: "acme-npm", npmSpec: "@openclaw/signed-refresh-proof-v9" },
+            },
+          },
+        ],
+      },
+    });
+    const catalogConfig = {
+      feeds: {
+        acme: {
+          url: "https://packages.acme.example/openclaw/feed",
+          verification: {
+            mode: "signed" as const,
+            keys: [{ keyId: "acme-root", publicKey: newer.publicKeyPem }],
+          },
+        },
+      },
+      sources: {
+        "acme-npm": { type: "npm" as const, registry: "https://packages.acme.example/npm/" },
+      },
+    };
+
+    await loadHostedOfficialExternalPluginCatalogEntries({
+      feedProfile: "acme",
+      catalogConfig,
+      fetchImpl: vi.fn(async () => new Response(newer.body, { status: 200 })),
+      snapshotStore,
+    });
+    const writeSpy = vi.spyOn(snapshotStore, "write");
+
+    const result = await loadHostedOfficialExternalPluginCatalogEntries({
+      feedProfile: "acme",
+      catalogConfig,
+      fetchImpl: vi.fn(async () => new Response(older.body, { status: 200 })),
+      snapshotStore,
+    });
+
+    expect(result.source).toBe("hosted-snapshot");
+    expect(result.entries.map((entry) => entry.name)).toEqual([
+      "@openclaw/signed-refresh-proof-v10",
+    ]);
+    if (result.source === "hosted-snapshot") {
+      expect(result.error).toContain("signed feed sequence is older");
+      expect(result.feed.sequence).toBe(10);
+    }
+    expect(writeSpy).not.toHaveBeenCalled();
+  });
+
   it("fails closed when a signed feed profile receives unsigned JSON", async () => {
     const fetchImpl = vi.fn(
       async () =>
@@ -697,6 +788,48 @@ describe("official external plugin catalog", () => {
                   publicKey: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                 },
               ],
+            },
+          },
+        },
+      },
+      fetchImpl,
+      snapshotStore: createInMemoryHostedOfficialExternalPluginCatalogSnapshotStore(),
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(result.source).toBe("bundled-fallback");
+    expect(result.entries).toEqual([]);
+    if (result.source === "bundled-fallback") {
+      expect(result.error).toContain("signed envelope is malformed");
+    }
+  });
+
+  it("preserves signed feed profile verification for direct URL overrides", async () => {
+    const signed = signedHostedCatalogFeed();
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            schemaVersion: 1,
+            id: "openclaw-official-external-plugins",
+            generatedAt: "2026-06-22T00:00:00.000Z",
+            sequence: 8,
+            entries: [],
+          }),
+          { status: 200 },
+        ),
+    );
+
+    const result = await loadHostedOfficialExternalPluginCatalogEntries({
+      feedProfile: "acme",
+      feedUrl: "https://clawhub.ai/v1/feeds/plugins",
+      catalogConfig: {
+        feeds: {
+          acme: {
+            url: "https://packages.acme.example/openclaw/feed",
+            verification: {
+              mode: "signed",
+              keys: [{ keyId: "acme-root", publicKey: signed.publicKeyPem }],
             },
           },
         },

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -683,22 +683,20 @@ describe("official external plugin catalog", () => {
         ),
     );
 
-    await expect(
-      loadHostedOfficialExternalPluginCatalogEntries({
-        feedProfile: "acme",
-        catalogConfig: {
-          feeds: {
-            acme: {
-              url: "https://packages.acme.example/openclaw/feed",
-              verification: {
-                mode: "signed",
-                keys: [
-                  {
-                    keyId: "acme-root",
-                    publicKey: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                  },
-                ],
-              },
+    const result = await loadHostedOfficialExternalPluginCatalogEntries({
+      feedProfile: "acme",
+      catalogConfig: {
+        feeds: {
+          acme: {
+            url: "https://packages.acme.example/openclaw/feed",
+            verification: {
+              mode: "signed",
+              keys: [
+                {
+                  keyId: "acme-root",
+                  publicKey: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                },
+              ],
             },
           },
         },
@@ -710,7 +708,9 @@ describe("official external plugin catalog", () => {
     expect(fetchImpl).toHaveBeenCalledTimes(1);
     expect(result.source).toBe("bundled-fallback");
     expect(result.entries).toEqual([]);
-    expect(result.error).toContain("signed envelope is malformed");
+    if (result.source === "bundled-fallback") {
+      expect(result.error).toContain("signed envelope is malformed");
+    }
   });
 
   it("keeps direct hosted feed URL overrides constrained to the public allowlist", async () => {
@@ -1317,8 +1317,10 @@ describe("official external plugin catalog", () => {
 
     expect(result.source).toBe("bundled-fallback");
     expect(result.entries).toEqual([]);
-    expect(result.error).toContain("snapshot fallback failed");
-    expect(result.error).toContain("signed envelope is malformed");
+    if (result.source === "bundled-fallback") {
+      expect(result.error).toContain("snapshot fallback failed");
+      expect(result.error).toContain("signed envelope is malformed");
+    }
   });
 
   it("persists hosted feed snapshots in OpenClaw state for HTTP 304 reuse", async () => {

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -87,7 +87,7 @@ function signedHostedCatalogFeed(params?: {
   );
   const signingInput = createOfficialExternalPluginCatalogEnvelopeSigningInput({
     payloadType: OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PAYLOAD_TYPE,
-    payload,
+    payloadBytes: Buffer.from(payload, "base64"),
   });
   const envelope: OfficialExternalPluginCatalogSignedEnvelope = {
     schemaVersion: 1,
@@ -98,7 +98,7 @@ function signedHostedCatalogFeed(params?: {
         keyId: params?.keyId ?? "acme-root",
         algorithm: "ed25519",
         signature: crypto
-          .sign(null, Buffer.from(signingInput, "utf8"), crypto.createPrivateKey(privateKey))
+          .sign(null, signingInput, crypto.createPrivateKey(privateKey))
           .toString("base64url"),
       },
     ],

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -759,6 +759,77 @@ describe("official external plugin catalog", () => {
     expect(writeSpy).not.toHaveBeenCalled();
   });
 
+  it("keeps signed SQLite snapshot replacement monotonic under concurrent writes", async () => {
+    const tempDir = mkdtempSync(path.join(os.tmpdir(), "openclaw-signed-snapshot-race-"));
+    const url = "https://packages.acme.example/openclaw/feed";
+    const newer = signedHostedCatalogFeed({
+      feed: {
+        schemaVersion: 1,
+        id: "openclaw-official-external-plugins",
+        generatedAt: "2026-06-22T00:00:10.000Z",
+        sequence: 10,
+        entries: [
+          {
+            name: "@openclaw/signed-refresh-proof-v10",
+            kind: "plugin",
+            openclaw: { plugin: { id: "signed-refresh-proof-v10" } },
+          },
+        ],
+      },
+    });
+    const older = signedHostedCatalogFeed({
+      privateKeyPem: newer.privateKeyPem,
+      feed: {
+        schemaVersion: 1,
+        id: "openclaw-official-external-plugins",
+        generatedAt: "2026-06-22T00:00:09.000Z",
+        sequence: 9,
+        entries: [
+          {
+            name: "@openclaw/signed-refresh-proof-v9",
+            kind: "plugin",
+            openclaw: { plugin: { id: "signed-refresh-proof-v9" } },
+          },
+        ],
+      },
+    });
+    const snapshotStore = createSqliteHostedOfficialExternalPluginCatalogSnapshotStore({
+      stateDir: tempDir,
+    });
+    const trust = {
+      mode: "signed" as const,
+      signedBy: "acme-root",
+      signatureCount: 1,
+      threshold: 1,
+      verifiedAt: "2026-06-22T04:05:06.000Z",
+    };
+    const snapshotFor = (body: string, sequence: number, generatedAt: string) => ({
+      body,
+      metadata: {
+        url,
+        status: 200,
+        checksum: "sha256:" + crypto.createHash("sha256").update(body).digest("hex"),
+      },
+      savedAt: "2026-06-22T04:05:06.000Z",
+      trust,
+      monotonic: { mode: "signed-feed" as const, sequence, generatedAt },
+    });
+
+    try {
+      await Promise.allSettled([
+        snapshotStore.write(snapshotFor(older.body, 9, "2026-06-22T00:00:09.000Z")),
+        snapshotStore.write(snapshotFor(newer.body, 10, "2026-06-22T00:00:10.000Z")),
+      ]);
+
+      const snapshot = await snapshotStore.read(url);
+      expect(snapshot?.body).toBe(newer.body);
+      expect(snapshot?.trust).toMatchObject(trust);
+    } finally {
+      closeOpenClawStateDatabaseForTest();
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("fails closed when a signed feed profile receives unsigned JSON", async () => {
     const fetchImpl = vi.fn(
       async () =>

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -370,19 +370,24 @@ function resolveHostedCatalogFeedSource(params: {
 } {
   const profileConfig = resolveOfficialExternalPluginCatalogProfileConfig(params.catalogConfig);
   const explicitFeedUrl = normalizeOptionalString(params.feedUrl);
+  const explicitProfileName = normalizeOptionalString(params.feedProfile);
   if (explicitFeedUrl) {
     const url = resolveHostedCatalogFeedUrl(explicitFeedUrl);
     if (!OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_HOSTNAME_ALLOWLIST.includes(url.hostname)) {
       throw new Error("hosted catalog feed URL hostname is not allowed");
     }
+    const profile =
+      explicitProfileName === undefined ? undefined : profileConfig.feeds[explicitProfileName];
+    if (explicitProfileName !== undefined && !profile) {
+      throw new Error(`hosted catalog feed profile "${explicitProfileName}" is not configured`);
+    }
     return {
       url,
       hostnameAllowlist: OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_HOSTNAME_ALLOWLIST,
+      ...(profile?.verification ? { verification: profile.verification } : {}),
     };
   }
-  const profileName =
-    normalizeOptionalString(params.feedProfile) ??
-    DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PROFILE;
+  const profileName = explicitProfileName ?? DEFAULT_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_FEED_PROFILE;
   const profile = profileConfig.feeds[profileName];
   if (!profile) {
     throw new Error(`hosted catalog feed profile "${profileName}" is not configured`);
@@ -776,6 +781,19 @@ async function loadHostedCatalogSnapshotResult(params: {
   };
 }
 
+function isHostedCatalogSignedFeedRollback(params: {
+  candidate: OfficialExternalPluginCatalogFeed;
+  current: OfficialExternalPluginCatalogFeed;
+}): boolean {
+  if (params.candidate.sequence < params.current.sequence) {
+    return true;
+  }
+  if (params.candidate.sequence > params.current.sequence) {
+    return false;
+  }
+  return Date.parse(params.candidate.generatedAt) < Date.parse(params.current.generatedAt);
+}
+
 function assertSnapshotMatchesRequestValidators(params: {
   snapshot: HostedOfficialExternalPluginCatalogSnapshot;
   ifNoneMatch?: string;
@@ -1042,6 +1060,24 @@ export async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
     });
     if ("source" in parsed) {
       return parsed;
+    }
+    if (snapshotStore && parsed.trust?.mode === "signed") {
+      const currentSnapshot = await snapshotStore.read(url.href);
+      if (currentSnapshot?.trust?.mode === "signed") {
+        const current = await parseHostedCatalogFeedBody({
+          body: currentSnapshot.body,
+          verification: source.verification,
+          verifiedAt: currentSnapshot.trust.verifiedAt,
+        });
+        if (
+          isHostedCatalogSignedFeedRollback({
+            candidate: parsed.feed,
+            current: current.feed,
+          })
+        ) {
+          throw new Error("hosted catalog signed feed sequence is older than current snapshot");
+        }
+      }
     }
     const entries = filterOfficialExternalPluginCatalogEntriesBySourceRefs(
       parseOfficialExternalPluginCatalogEntries(parsed.feed),

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -184,11 +184,20 @@ export type HostedOfficialExternalPluginCatalogSnapshot = {
   body: string;
   metadata: HostedOfficialExternalPluginCatalogMetadata;
   savedAt: string;
+  trust?: HostedOfficialExternalPluginCatalogTrustState;
 };
 
 export type HostedOfficialExternalPluginCatalogSnapshotStore = {
   read: (url: string) => Promise<HostedOfficialExternalPluginCatalogSnapshot | null | undefined>;
   write: (snapshot: HostedOfficialExternalPluginCatalogSnapshot) => Promise<void>;
+};
+
+export type HostedOfficialExternalPluginCatalogTrustState = {
+  mode: "signed";
+  signedBy: string;
+  signatureCount: number;
+  threshold: number;
+  verifiedAt: string;
 };
 
 export type HostedOfficialExternalPluginCatalogLoadResult =
@@ -197,6 +206,7 @@ export type HostedOfficialExternalPluginCatalogLoadResult =
       entries: OfficialExternalPluginCatalogEntry[];
       feed: OfficialExternalPluginCatalogFeed;
       metadata: HostedOfficialExternalPluginCatalogMetadata;
+      trust?: HostedOfficialExternalPluginCatalogTrustState;
     }
   | {
       source: "hosted-snapshot";
@@ -204,6 +214,7 @@ export type HostedOfficialExternalPluginCatalogLoadResult =
       feed: OfficialExternalPluginCatalogFeed;
       metadata: HostedOfficialExternalPluginCatalogMetadata;
       snapshot: HostedOfficialExternalPluginCatalogSnapshot;
+      trust?: HostedOfficialExternalPluginCatalogTrustState;
       error: string;
     }
   | {
@@ -674,7 +685,52 @@ function bundledFallbackResult(
   };
 }
 
-function loadHostedCatalogSnapshotResult(params: {
+function emptyBundledFallbackResult(error: unknown): HostedOfficialExternalPluginCatalogLoadResult {
+  return {
+    source: "bundled-fallback",
+    entries: [],
+    error: formatHostedCatalogError(error),
+  };
+}
+
+async function parseHostedCatalogFeedBody(params: {
+  body: string;
+  verification?: OfficialExternalPluginCatalogFeedVerification;
+  verifiedAt: string;
+}): Promise<{
+  feed: OfficialExternalPluginCatalogFeed;
+  trust?: HostedOfficialExternalPluginCatalogTrustState;
+}> {
+  const raw = JSON.parse(params.body) as unknown;
+  if (params.verification?.mode === "signed") {
+    const { verifyOfficialExternalPluginCatalogSignedEnvelope } =
+      await import("./official-external-plugin-catalog-envelope.js");
+    const threshold = params.verification.threshold ?? 1;
+    const verification = verifyOfficialExternalPluginCatalogSignedEnvelope(raw, {
+      trustedKeys: params.verification.keys,
+      threshold,
+    });
+    if (!verification.ok) {
+      throw new Error(verification.message);
+    }
+    return {
+      feed: verification.feed,
+      trust: {
+        mode: "signed",
+        signedBy: verification.signedBy,
+        signatureCount: verification.signatureCount ?? 1,
+        threshold,
+        verifiedAt: params.verifiedAt,
+      },
+    };
+  }
+  if (!isOfficialExternalPluginCatalogFeed(raw)) {
+    throw new Error("hosted catalog feed did not match a supported schema version");
+  }
+  return { feed: raw };
+}
+
+async function loadHostedCatalogSnapshotResult(params: {
   snapshot: HostedOfficialExternalPluginCatalogSnapshot;
   error: unknown;
   expectedSha256?: string;
@@ -682,7 +738,8 @@ function loadHostedCatalogSnapshotResult(params: {
   ifModifiedSince?: string;
   catalogConfig?: OfficialExternalPluginCatalogProfileConfig;
   requireManifestInstallSourceRef?: boolean;
-}): HostedOfficialExternalPluginCatalogLoadResult {
+  verification?: OfficialExternalPluginCatalogFeedVerification;
+}): Promise<HostedOfficialExternalPluginCatalogLoadResult> {
   assertSnapshotMatchesRequestValidators({
     snapshot: params.snapshot,
     ifNoneMatch: params.ifNoneMatch,
@@ -695,24 +752,26 @@ function loadHostedCatalogSnapshotResult(params: {
   if (params.expectedSha256 && params.expectedSha256 !== checksum) {
     throw new Error("hosted catalog snapshot checksum did not match expected checksum");
   }
-  const raw = JSON.parse(params.snapshot.body) as unknown;
-  if (!isOfficialExternalPluginCatalogFeed(raw)) {
-    throw new Error("hosted catalog snapshot did not match a supported schema version");
-  }
+  const parsed = await parseHostedCatalogFeedBody({
+    body: params.snapshot.body,
+    verification: params.verification,
+    verifiedAt: params.snapshot.trust?.verifiedAt ?? params.snapshot.savedAt,
+  });
   return {
     source: "hosted-snapshot",
     entries: dedupeOfficialExternalPluginCatalogEntries(
       filterOfficialExternalPluginCatalogEntriesBySourceRefs(
-        parseOfficialExternalPluginCatalogEntries(raw),
+        parseOfficialExternalPluginCatalogEntries(parsed.feed),
         {
           catalogConfig: params.catalogConfig,
           requireManifestInstallSourceRef: params.requireManifestInstallSourceRef,
         },
       ),
     ),
-    feed: raw,
+    feed: parsed.feed,
     metadata: params.snapshot.metadata,
     snapshot: params.snapshot,
+    ...(parsed.trust ? { trust: parsed.trust } : {}),
     error: formatHostedCatalogError(params.error),
   };
 }
@@ -744,12 +803,13 @@ async function snapshotOrBundledFallbackResult(params: {
   ifModifiedSince?: string;
   catalogConfig?: OfficialExternalPluginCatalogProfileConfig;
   requireManifestInstallSourceRef?: boolean;
+  verification?: OfficialExternalPluginCatalogFeedVerification;
 }): Promise<HostedOfficialExternalPluginCatalogLoadResult> {
   if (params.snapshotStore) {
     try {
       const snapshot = await params.snapshotStore.read(params.url);
       if (snapshot) {
-        return loadHostedCatalogSnapshotResult({
+        return await loadHostedCatalogSnapshotResult({
           snapshot,
           error: params.error,
           expectedSha256: params.expectedSha256,
@@ -757,14 +817,23 @@ async function snapshotOrBundledFallbackResult(params: {
           ifModifiedSince: params.ifModifiedSince,
           catalogConfig: params.catalogConfig,
           requireManifestInstallSourceRef: params.requireManifestInstallSourceRef,
+          verification: params.verification,
         });
       }
     } catch (snapshotErr) {
+      if (params.verification?.mode === "signed") {
+        return emptyBundledFallbackResult(
+          `${formatHostedCatalogError(params.error)}; snapshot fallback failed: ${formatHostedCatalogError(snapshotErr)}`,
+        );
+      }
       return bundledFallbackResult(
         `${formatHostedCatalogError(params.error)}; snapshot fallback failed: ${formatHostedCatalogError(snapshotErr)}`,
         params.metadata,
       );
     }
+  }
+  if (params.verification?.mode === "signed") {
+    return emptyBundledFallbackResult(params.error);
   }
   return bundledFallbackResult(params.error, params.metadata);
 }
@@ -843,9 +912,6 @@ export async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
     return bundledFallbackResult(err);
   }
   const { url } = source;
-  if (source.verification?.mode === "signed") {
-    throw new Error("hosted catalog signed feed verification is not wired yet");
-  }
   const snapshotStore = await resolveHostedCatalogSnapshotStore({
     snapshotStore: params?.snapshotStore,
     env: params?.env,
@@ -866,6 +932,7 @@ export async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
       expectedSha256,
       catalogConfig: params?.catalogConfig,
       requireManifestInstallSourceRef,
+      verification: source.verification,
     });
   }
   const headers = new Headers();
@@ -915,6 +982,7 @@ export async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
         ifModifiedSince,
         catalogConfig: params?.catalogConfig,
         requireManifestInstallSourceRef,
+        verification: source.verification,
       });
     }
     if (!response.ok) {
@@ -928,6 +996,7 @@ export async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
         ifModifiedSince,
         catalogConfig: params?.catalogConfig,
         requireManifestInstallSourceRef,
+        verification: source.verification,
       });
     }
     const body = await readHostedCatalogResponseText({
@@ -949,12 +1018,17 @@ export async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
         ifModifiedSince,
         catalogConfig: params?.catalogConfig,
         requireManifestInstallSourceRef,
+        verification: source.verification,
       });
     }
-    const raw = JSON.parse(body) as unknown;
-    if (!isOfficialExternalPluginCatalogFeed(raw)) {
+    const verifiedAt = (params?.now?.() ?? new Date()).toISOString();
+    const parsed = await parseHostedCatalogFeedBody({
+      body,
+      verification: source.verification,
+      verifiedAt,
+    }).catch(async (err: unknown) => {
       return await snapshotOrBundledFallbackResult({
-        error: "hosted catalog feed did not match a supported schema version",
+        error: err,
         snapshotStore,
         url: url.href,
         metadata,
@@ -963,10 +1037,14 @@ export async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
         ifModifiedSince,
         catalogConfig: params?.catalogConfig,
         requireManifestInstallSourceRef,
+        verification: source.verification,
       });
+    });
+    if ("source" in parsed) {
+      return parsed;
     }
     const entries = filterOfficialExternalPluginCatalogEntriesBySourceRefs(
-      parseOfficialExternalPluginCatalogEntries(raw),
+      parseOfficialExternalPluginCatalogEntries(parsed.feed),
       {
         catalogConfig: params?.catalogConfig,
         requireManifestInstallSourceRef,
@@ -976,7 +1054,8 @@ export async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
       ?.write({
         body,
         metadata,
-        savedAt: (params?.now?.() ?? new Date()).toISOString(),
+        savedAt: verifiedAt,
+        ...(parsed.trust ? { trust: parsed.trust } : {}),
       })
       .catch((err: unknown) => {
         if (params?.requireSnapshotWrite) {
@@ -986,8 +1065,9 @@ export async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
     return {
       source: "hosted",
       entries: dedupeOfficialExternalPluginCatalogEntries(entries),
-      feed: raw,
+      feed: parsed.feed,
       metadata,
+      ...(parsed.trust ? { trust: parsed.trust } : {}),
     };
   } catch (err) {
     if (err instanceof HostedCatalogSnapshotWriteError) {
@@ -1002,6 +1082,7 @@ export async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
       ifModifiedSince,
       catalogConfig: params?.catalogConfig,
       requireManifestInstallSourceRef,
+      verification: source.verification,
     });
   } finally {
     if (response?.bodyUsed !== true) {

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -185,6 +185,7 @@ export type HostedOfficialExternalPluginCatalogSnapshot = {
   metadata: HostedOfficialExternalPluginCatalogMetadata;
   savedAt: string;
   trust?: HostedOfficialExternalPluginCatalogTrustState;
+  monotonic?: HostedOfficialExternalPluginCatalogSnapshotMonotonicState;
 };
 
 export type HostedOfficialExternalPluginCatalogSnapshotStore = {
@@ -198,6 +199,12 @@ export type HostedOfficialExternalPluginCatalogTrustState = {
   signatureCount: number;
   threshold: number;
   verifiedAt: string;
+};
+
+export type HostedOfficialExternalPluginCatalogSnapshotMonotonicState = {
+  mode: "signed-feed";
+  sequence: number;
+  generatedAt: string;
 };
 
 export type HostedOfficialExternalPluginCatalogLoadResult =
@@ -1092,8 +1099,23 @@ export async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
         metadata,
         savedAt: verifiedAt,
         ...(parsed.trust ? { trust: parsed.trust } : {}),
+        ...(parsed.trust?.mode === "signed"
+          ? {
+              monotonic: {
+                mode: "signed-feed",
+                sequence: parsed.feed.sequence,
+                generatedAt: parsed.feed.generatedAt,
+              },
+            }
+          : {}),
       })
       .catch((err: unknown) => {
+        if (
+          err instanceof Error &&
+          err.message.includes("hosted catalog signed feed sequence is older")
+        ) {
+          throw err;
+        }
         if (params?.requireSnapshotWrite) {
           throw new HostedCatalogSnapshotWriteError(err);
         }

--- a/src/state/openclaw-state-db.generated.d.ts
+++ b/src/state/openclaw-state-db.generated.d.ts
@@ -761,6 +761,11 @@ export interface OfficialExternalPluginCatalogSnapshots {
   last_modified: string | null;
   saved_at: string;
   status: number;
+  trust_key_id: string | null;
+  trust_mode: string | null;
+  trust_signature_count: number | null;
+  trust_threshold: number | null;
+  trust_verified_at: string | null;
   updated_at_ms: number;
 }
 

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -385,6 +385,44 @@ describe("openclaw state database", () => {
     });
   });
 
+  it("adds hosted catalog snapshot trust columns to existing state databases", () => {
+    const stateDir = createTempStateDir();
+    const database = openOpenClawStateDatabase({
+      env: { OPENCLAW_STATE_DIR: stateDir },
+    });
+    const databasePath = database.path;
+    closeOpenClawStateDatabaseForTest();
+
+    const { DatabaseSync } = requireNodeSqlite();
+    const legacyDb = new DatabaseSync(databasePath);
+    legacyDb.exec(`
+      ALTER TABLE official_external_plugin_catalog_snapshots DROP COLUMN trust_mode;
+      ALTER TABLE official_external_plugin_catalog_snapshots DROP COLUMN trust_key_id;
+      ALTER TABLE official_external_plugin_catalog_snapshots DROP COLUMN trust_signature_count;
+      ALTER TABLE official_external_plugin_catalog_snapshots DROP COLUMN trust_threshold;
+      ALTER TABLE official_external_plugin_catalog_snapshots DROP COLUMN trust_verified_at;
+    `);
+    legacyDb.close();
+
+    const reopened = openOpenClawStateDatabase({
+      env: { OPENCLAW_STATE_DIR: stateDir },
+    });
+    const columns = reopened.db
+      .prepare("PRAGMA table_info(official_external_plugin_catalog_snapshots)")
+      .all() as Array<{ name?: string }>;
+
+    expect(columns.map((column) => column.name)).toEqual(
+      expect.arrayContaining([
+        "trust_mode",
+        "trust_key_id",
+        "trust_signature_count",
+        "trust_threshold",
+        "trust_verified_at",
+      ]),
+    );
+    closeOpenClawStateDatabaseForTest();
+  });
+
   it("rolls back the requester attribution column when its backfill fails", () => {
     const stateDir = createTempStateDir();
     const database = openOpenClawStateDatabase({

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -915,6 +915,11 @@ function ensureAdditiveStateColumns(db: DatabaseSync): void {
   ensureColumn(db, "gateway_restart_sentinel", "doctor_hint TEXT");
   ensureColumn(db, "gateway_restart_sentinel", "stats_json TEXT");
   ensureColumn(db, "gateway_boot_lifecycle", "startup_reason TEXT");
+  ensureColumn(db, "official_external_plugin_catalog_snapshots", "trust_mode TEXT");
+  ensureColumn(db, "official_external_plugin_catalog_snapshots", "trust_key_id TEXT");
+  ensureColumn(db, "official_external_plugin_catalog_snapshots", "trust_signature_count INTEGER");
+  ensureColumn(db, "official_external_plugin_catalog_snapshots", "trust_threshold INTEGER");
+  ensureColumn(db, "official_external_plugin_catalog_snapshots", "trust_verified_at TEXT");
   runSqliteImmediateTransactionSync(db, () => {
     const addedTaskRequesterAgentId = ensureColumn(db, "task_runs", "requester_agent_id TEXT");
     if (addedTaskRequesterAgentId) {

--- a/src/state/openclaw-state-schema.generated.ts
+++ b/src/state/openclaw-state-schema.generated.ts
@@ -578,6 +578,11 @@ CREATE TABLE IF NOT EXISTS official_external_plugin_catalog_snapshots (
   last_modified TEXT,
   checksum TEXT NOT NULL,
   saved_at TEXT NOT NULL,
+  trust_mode TEXT,
+  trust_key_id TEXT,
+  trust_signature_count INTEGER,
+  trust_threshold INTEGER,
+  trust_verified_at TEXT,
   updated_at_ms INTEGER NOT NULL
 );
 

--- a/src/state/openclaw-state-schema.sql
+++ b/src/state/openclaw-state-schema.sql
@@ -573,6 +573,11 @@ CREATE TABLE IF NOT EXISTS official_external_plugin_catalog_snapshots (
   last_modified TEXT,
   checksum TEXT NOT NULL,
   saved_at TEXT NOT NULL,
+  trust_mode TEXT,
+  trust_key_id TEXT,
+  trust_signature_count INTEGER,
+  trust_threshold INTEGER,
+  trust_verified_at TEXT,
   updated_at_ms INTEGER NOT NULL
 );
 


### PR DESCRIPTION
## Summary

- Wire signed marketplace feed profiles into hosted catalog refresh using the signed envelope verifier and configured threshold.
- Persist bounded signed-feed trust state with hosted snapshots, and re-verify signed snapshots with the current source profile before using them.
- Count signed-feed thresholds over unique normalized Ed25519 public-key material so duplicate key IDs or duplicate key material cannot weaken a multi-signature threshold.
- Keep signed profiles fail-closed on invalid live bodies or unsigned old snapshots, without changing install eligibility or the existing marketplace refresh/entries payload shape.

## Validation

```text
> node scripts/run-vitest.mjs src/config/zod-schema.marketplaces.test.ts src/plugins/official-external-plugin-catalog.test.ts src/plugins/official-external-plugin-catalog-envelope.test.ts src/state/openclaw-state-db.test.ts --reporter=dot
Test Files 4 passed (4)
Tests 106 passed (106)
[test] passed 4 Vitest shards

> npx oxfmt --check <touched source/test files>
All matched files use the correct format.

> npx oxlint <touched source/test files>
Found 0 warnings and 0 errors.

> git diff --check origin/main...HEAD && git diff --check
PASS

> pnpm tsgo:core
PASS

> node scripts/plugin-sdk-surface-report.mjs --check
PASS

> pnpm db:kysely:check
PASS
```
