### PR TITLE
fix(irc): classify host-less nick!user allowlist entries as mutable

### DIFF
--- a/extensions/irc/src/doctor.test.ts
+++ b/extensions/irc/src/doctor.test.ts
@@ -1,0 +1,31 @@
+// Irc tests cover doctor mutable allowlist warnings.
+import { describe, expect, it } from "vitest";
+import { collectIrcMutableAllowlistWarnings } from "./doctor.js";
+
+describe("collectIrcMutableAllowlistWarnings", () => {
+  it("warns on a host-less nick!user allowlist entry", () => {
+    const warnings = collectIrcMutableAllowlistWarnings({
+      cfg: {
+        channels: {
+          irc: {
+            allowFrom: ["alice!ident"],
+          },
+        },
+      } as never,
+    });
+    expect(warnings).toContain("- channels.irc.allowFrom: alice!ident");
+  });
+
+  it("does not warn on a full nick!user@host allowlist entry", () => {
+    const warnings = collectIrcMutableAllowlistWarnings({
+      cfg: {
+        channels: {
+          irc: {
+            allowFrom: ["alice!ident@example.com"],
+          },
+        },
+      } as never,
+    });
+    expect(warnings).toStrictEqual([]);
+  });
+});

--- a/extensions/irc/src/doctor.ts
+++ b/extensions/irc/src/doctor.ts
@@ -19,7 +19,7 @@ function isIrcMutableAllowEntry(raw: string): boolean {
     .replace(/^user:/, "")
     .trim();
 
-  return !normalized.includes("!") && !normalized.includes("@");
+  return !normalized.includes("@");
 }
 
 export const collectIrcMutableAllowlistWarnings =

--- a/extensions/irc/src/inbound.behavior.test.ts
+++ b/extensions/irc/src/inbound.behavior.test.ts
@@ -244,4 +244,71 @@ describe("irc inbound behavior", () => {
     expect(ctx?.To).toBe("channel:#ops");
     expect(ctx?.OriginatingTo).toBe("channel:#ops");
   });
+
+  it("drops a spoofed sender for a host-less nick!user DM allowlist entry", async () => {
+    const coreRuntime = createPluginRuntimeMock();
+    const runtime = createRuntimeEnv();
+    setIrcRuntime(coreRuntime as never);
+
+    await handleIrcInbound({
+      message: createMessage({
+        target: "alice",
+        senderNick: "alice",
+        senderUser: "ident",
+        senderHost: "attacker.example",
+        text: "hello",
+      }),
+      account: createAccount({
+        config: {
+          dmPolicy: "allowlist",
+          allowFrom: ["alice!ident"],
+          groupPolicy: "allowlist",
+          groupAllowFrom: [],
+        },
+      }),
+      config: { channels: { irc: {} } } as CoreConfig,
+      runtime,
+      sendReply: vi.fn(async () => {}),
+    });
+
+    expect(
+      (coreRuntime.channel.inbound.dispatchReply as unknown as { mock: { calls: unknown[][] } })
+        .mock.calls.length,
+    ).toBe(0);
+    expect(runtime.log).toHaveBeenCalledWith(
+      "irc: drop DM sender alice!ident@attacker.example (dmPolicy=allowlist)",
+    );
+  });
+
+  it("admits a sender matching a full nick!user@host DM allowlist entry", async () => {
+    const coreRuntime = createPluginRuntimeMock();
+    const runtime = createRuntimeEnv();
+    setIrcRuntime(coreRuntime as never);
+
+    await handleIrcInbound({
+      message: createMessage({
+        target: "alice",
+        senderNick: "alice",
+        senderUser: "ident",
+        senderHost: "example.com",
+        text: "hello",
+      }),
+      account: createAccount({
+        config: {
+          dmPolicy: "allowlist",
+          allowFrom: ["alice!ident@example.com"],
+          groupPolicy: "allowlist",
+          groupAllowFrom: [],
+        },
+      }),
+      config: { channels: { irc: {} } } as CoreConfig,
+      runtime,
+      sendReply: vi.fn(async () => {}),
+    });
+
+    expect(
+      (coreRuntime.channel.inbound.dispatchReply as unknown as { mock: { calls: unknown[][] } })
+        .mock.calls.length,
+    ).toBe(1);
+  });
 });

--- a/extensions/irc/src/inbound.ts
+++ b/extensions/irc/src/inbound.ts
@@ -42,13 +42,21 @@ const ircIngressIdentity = defineStableChannelIngressIdentity({
   normalizeSubject: normalizeLowercaseStringOrEmpty,
   sensitivity: "pii",
   aliases: [
-    ...["irc-id-nick-user", "irc-id-nick-host"].map((key) => ({
-      key,
+    {
+      key: "irc-id-nick-user",
+      kind: "stable-id" as const,
+      normalizeEntry: normalizeIrcNickUserEntry,
+      normalizeSubject: normalizeLowercaseStringOrEmpty,
+      dangerous: true,
+      sensitivity: "pii" as const,
+    },
+    {
+      key: "irc-id-nick-host",
       kind: "stable-id" as const,
       normalizeEntry: () => null,
       normalizeSubject: normalizeLowercaseStringOrEmpty,
       sensitivity: "pii" as const,
-    })),
+    },
     {
       key: "irc-nick",
       kind: IRC_NICK_KIND,
@@ -69,9 +77,25 @@ function isBareNick(value: string): boolean {
   return !value.includes("!") && !value.includes("@");
 }
 
+function hasVerifiedHost(value: string): boolean {
+  return value.includes("@");
+}
+
+function isHostlessNickUser(value: string): boolean {
+  return value.includes("!") && !value.includes("@");
+}
+
 function normalizeIrcStableEntry(value: string): string | null {
   const normalized = normalizeIrcAllowEntry(value);
-  if (!normalized || normalized === "*" || isBareNick(normalized)) {
+  if (!normalized || normalized === "*" || !hasVerifiedHost(normalized)) {
+    return null;
+  }
+  return normalized;
+}
+
+function normalizeIrcNickUserEntry(value: string): string | null {
+  const normalized = normalizeIrcAllowEntry(value);
+  if (!normalized || normalized === "*" || !isHostlessNickUser(normalized)) {
     return null;
   }
   return normalized;
@@ -91,14 +115,12 @@ function hasEntries(entries: Array<string | number> | undefined): boolean {
 
 function createIrcIngressSubject(message: IrcInboundMessage) {
   const candidates = buildIrcAllowlistCandidates(message, { allowNameMatching: true });
-  const stableCandidates = candidates.filter((candidate) => !isBareNick(candidate));
+  const stableCandidates = candidates.filter((candidate) => hasVerifiedHost(candidate));
   const nick = normalizeLowercaseStringOrEmpty(message.senderNick);
   return {
     stableId: stableCandidates[stableCandidates.length - 1] ?? nick,
     aliases: {
-      "irc-id-nick-user": stableCandidates.find(
-        (candidate) => candidate.includes("!") && !candidate.includes("@"),
-      ),
+      "irc-id-nick-user": candidates.find((candidate) => isHostlessNickUser(candidate)),
       "irc-id-nick-host": stableCandidates.find(
         (candidate) => !candidate.includes("!") && candidate.includes("@"),
       ),


### PR DESCRIPTION
## What Problem This Solves

An IRC sender mask is `nick!user@host`. Only `host` is verified by the IRC server; `nick` and `user` (ident) are client supplied and trivially spoofable. The IRC allowlist identity classifier in `extensions/irc/src/inbound.ts` treated any allowlist entry containing `!` or `@` as a verified "stable" identity. Only a bare nick (no `!` and no `@`) was routed to the dangerous/mutable field.

That means a host-less `nick!user` allowlist entry was misclassified as stable. The subject built for an inbound message always includes a host-less `nick!user` candidate, so with `dangerouslyAllowNameMatching` at its secure default (off), the mutable-identifier policy (`applyMutableIdentifierPolicy`) never stripped the entry, because that policy only strips entries owned by a field marked dangerous. A remote user presenting the same nick and ident from a different host was therefore admitted, even though the operator never enabled name matching.

This is low severity and config-shape dependent: it only affects an undocumented allowlist shape. The documented full mask `nick!user@host` is unaffected because the host is present and verified. The most broadly useful part of this change is the doctor warning: every operator who typed the host-less shape now gets told it is a mutable identifier, whether or not anyone ever tried to spoof it.

## Why This Change Was Made

The classifier keyed "stable" off the presence of `!` or `@`, but the only server-verified component is the host. Requiring a verified `@host` component before classifying an entry or subject as stable makes the classification match what the transport can actually attest. A host-less `nick` and a host-less `nick!user` are both mutable identifiers and must be gated by the same name-matching policy.

## User Impact

- A host-less `nick!user` DM/group allowlist entry no longer authorizes a sender while name matching is disabled (the secure default). It is treated as mutable, exactly like a bare nick.
- `openclaw doctor` now flags host-less `nick!user` allowlist entries as mutable identifiers, with the existing break-glass and recommended-fix guidance.
- Documented `nick!user@host` allowlist entries are unchanged: they stay stable and continue to match only the exact verified host.
- Operators who intentionally rely on host-less name matching can still opt in with `dangerouslyAllowNameMatching=true`; the entry then matches under the mutable policy just like a bare nick.

## Evidence

Root cause, `extensions/irc/src/inbound.ts` (before):

```ts
function normalizeIrcStableEntry(value: string): string | null {
  const normalized = normalizeIrcAllowEntry(value);
  if (!normalized || normalized === "*" || isBareNick(normalized)) {
    return null;
  }
  return normalized;
}
```

`isBareNick` is false as soon as the value contains `!`, so `nick!user` was returned as a stable (non-dangerous) entry, and the `irc-id-nick-user` subject alias (the host-less `nick!user` candidate) matched it under a non-dangerous field.

Fix (after): stable classification now requires a verified host, and host-less `nick!user` is owned by a dangerous field so the mutable policy gates it:

```ts
function hasVerifiedHost(value: string): boolean {
  return value.includes("@");
}

function normalizeIrcStableEntry(value: string): string | null {
  const normalized = normalizeIrcAllowEntry(value);
  if (!normalized || normalized === "*" || !hasVerifiedHost(normalized)) {
    return null;
  }
  return normalized;
}
```

`doctor` detector now flags host-less `nick!user` (change from `!includes("!") && !includes("@")` to `!includes("@")`).

Verification (kept out of the parsed proof fields below):
- `node scripts/run-vitest.mjs extensions/irc/src/inbound.behavior.test.ts extensions/irc/src/doctor.test.ts extensions/irc/src/normalize.test.ts` -> 11 passed with the patch.
- Both new regression cases fail on pristine `main` (the spoofed sender is admitted; doctor emits no warning) and pass with the patch.
- `scripts/run-oxlint.mjs` and `oxfmt --check` clean on the four changed files. `scripts/run-tsgo.mjs -p tsconfig.extensions.json` clean; the extension test-types lane has one pre-existing unrelated error in `extensions/qa-lab/src/suite.test.ts` (a `@openclaw/crabline` export rename), untouched by this change. Full build not run (OOM-prone box).

## Real behavior proof

Behavior addressed: with name matching off (secure default), a host-less `nick!user` IRC allowlist entry admitted a remote sender presenting the same nick and ident from any host; it is now treated as mutable and dropped, while the documented `nick!user@host` mask still admits the verified host.
Real environment tested: drove the real `handleIrcInbound` dispatcher on pristine main 816038e97a and on the patched tree with identical inputs. The real channel ingress resolver, the real `ircIngressIdentity` classifier, the real `applyMutableIdentifierPolicy`, and the real `collectIrcMutableAllowlistWarnings` doctor collector all stayed real; only the downstream reply-dispatch and pairing plumbing were the standard plugin runtime doubles, so the observed value is whether ingress admitted the sender.
Exact steps or command run after this patch: build a DM with `dmPolicy: "allowlist"`, `allowFrom: ["alice!ident"]` and `dangerouslyAllowNameMatching` unset, deliver it from `alice!ident@attacker.example`, and record whether `dispatchReply` fired and the drop log; repeat with `allowFrom: ["alice!ident@example.com"]` from `alice!ident@example.com`; and read the doctor warnings for `allowFrom: ["alice!ident"]`.
Evidence after fix:
```
# BEFORE (pristine main 816038e97a)
allowFrom=["alice!ident"] sender=alice!ident@attacker.example dangerousNameMatching=off
  admitted=true
  droplog=(none)
allowFrom=["alice!ident@example.com"] sender=alice!ident@example.com
  admitted=true
doctor(allowFrom=["alice!ident"]) warnings:
  (no warning emitted)
# AFTER (this patch, identical inputs)
allowFrom=["alice!ident"] sender=alice!ident@attacker.example dangerousNameMatching=off
  admitted=false
  droplog=irc: drop DM sender alice!ident@attacker.example (dmPolicy=allowlist)
allowFrom=["alice!ident@example.com"] sender=alice!ident@example.com
  admitted=true
doctor(allowFrom=["alice!ident"]) warnings:
  - Found 1 mutable allowlist entry across irc while name matching is disabled by default.
  - channels.irc.allowFrom: alice!ident
  - Option A (break-glass): enable channels.irc.dangerouslyAllowNameMatching=true to keep name/email/nick matching.
  - Option B (recommended): resolve names/emails/nicks to stable sender IDs and rewrite the allowlist entries.
```
Observed result after fix: the host-less entry flips from admitting the spoofed sender to dropping it while name matching stays off, the documented full-host entry keeps admitting its verified host, and doctor now surfaces the host-less entry as mutable.
What was not tested: no live IRC server round trip; the reply-dispatch and pairing surfaces were the standard plugin runtime doubles; full build not run on this OOM-prone box.
