### PR TITLE
fix: extension api.exec leaves child processes after timeout

### DIFF
--- a/src/agents/sessions/exec.test.ts
+++ b/src/agents/sessions/exec.test.ts
@@ -3,7 +3,8 @@
 import { EventEmitter } from "node:events";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { spawnMock, waitForChildProcessMock } = vi.hoisted(() => ({
+const { killProcessTreeMock, spawnMock, waitForChildProcessMock } = vi.hoisted(() => ({
+  killProcessTreeMock: vi.fn(),
   spawnMock: vi.fn(),
   waitForChildProcessMock: vi.fn(),
 }));
@@ -16,14 +17,20 @@ vi.mock("../utils/child-process.js", () => ({
   waitForChildProcess: waitForChildProcessMock,
 }));
 
+vi.mock("../../process/kill-tree.js", () => ({
+  killProcessTree: killProcessTreeMock,
+}));
+
 type StubChild = EventEmitter & {
   kill: ReturnType<typeof vi.fn>;
+  pid?: number;
   stderr: EventEmitter;
   stdout: EventEmitter;
 };
 
 function createStubChild(): StubChild {
   const child = new EventEmitter() as StubChild;
+  child.pid = 1234;
   child.stdout = new EventEmitter();
   child.stderr = new EventEmitter();
   child.kill = vi.fn();
@@ -42,6 +49,7 @@ function createDeferred<T>() {
 
 describe("execCommand", () => {
   beforeEach(() => {
+    killProcessTreeMock.mockReset();
     spawnMock.mockReset();
     waitForChildProcessMock.mockReset();
     vi.useRealTimers();
@@ -76,6 +84,26 @@ describe("execCommand", () => {
     expect(result.stderrTruncatedChars).toBeGreaterThan(0);
   });
 
+  it("spawns commands with process-tree cleanup options", async () => {
+    const child = createStubChild();
+    const wait = createDeferred<number | null>();
+    spawnMock.mockReturnValue(child);
+    waitForChildProcessMock.mockReturnValue(wait.promise);
+    const { execCommand } = await import("./exec.js");
+
+    const resultPromise = execCommand("cmd", ["arg"], "/tmp");
+    wait.resolve(0);
+    await resultPromise;
+
+    expect(spawnMock).toHaveBeenCalledWith("cmd", ["arg"], {
+      cwd: "/tmp",
+      detached: process.platform !== "win32",
+      shell: false,
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+    });
+  });
+
   it("honors caller-supplied small output caps", async () => {
     const child = createStubChild();
     const wait = createDeferred<number | null>();
@@ -105,7 +133,11 @@ describe("execCommand", () => {
     wait.resolve(0);
 
     const result = await resultPromise;
-    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+    expect(killProcessTreeMock).toHaveBeenCalledWith(1234, {
+      detached: process.platform !== "win32",
+      graceMs: 5000,
+    });
+    expect(child.kill).not.toHaveBeenCalled();
     expect(result.code).toBe(1);
     expect(result.killed).toBe(true);
     expect(result.outputLimitExceeded).toBe("stdout");
@@ -114,9 +146,9 @@ describe("execCommand", () => {
     expect(result.stderr).toContain("exec stdout exceeded output limit");
   });
 
-  it("escalates timed-out commands to SIGKILL after the grace period", async () => {
-    // SIGTERM gives child processes a chance to clean up; SIGKILL is the
-    // bounded fallback so an ignored signal cannot hang the session.
+  it("terminates timed-out commands through the process-tree killer", async () => {
+    // Extension exec uses the same tree-kill boundary as the built-in shell so
+    // timed-out wrappers do not leave descendant processes running.
     vi.useFakeTimers();
     const child = createStubChild();
     const wait = createDeferred<number | null>();
@@ -126,13 +158,11 @@ describe("execCommand", () => {
 
     const resultPromise = execCommand("cmd", [], "/tmp", { timeout: 10 });
     await vi.advanceTimersByTimeAsync(10);
-    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
-    expect(child.kill).not.toHaveBeenCalledWith("SIGKILL");
-
-    await vi.advanceTimersByTimeAsync(4_999);
-    expect(child.kill).not.toHaveBeenCalledWith("SIGKILL");
-    await vi.advanceTimersByTimeAsync(1);
-    expect(child.kill).toHaveBeenCalledWith("SIGKILL");
+    expect(killProcessTreeMock).toHaveBeenCalledWith(1234, {
+      detached: process.platform !== "win32",
+      graceMs: 5000,
+    });
+    expect(child.kill).not.toHaveBeenCalled();
 
     wait.resolve(null);
     const result = await resultPromise;

--- a/src/agents/sessions/exec.ts
+++ b/src/agents/sessions/exec.ts
@@ -3,6 +3,7 @@
  */
 
 import { spawn } from "node:child_process";
+import { killProcessTree } from "../../process/kill-tree.js";
 import { waitForChildProcess } from "../utils/child-process.js";
 
 const DEFAULT_OUTPUT_LIMIT_CHARS = 16 * 1024 * 1024;
@@ -81,8 +82,10 @@ export async function execCommand(
   return new Promise((resolve) => {
     const proc = spawn(command, args, {
       cwd,
+      detached: process.platform !== "win32",
       shell: false,
       stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
     });
 
     let stdout: OutputCapture = { text: "", truncatedChars: 0 };
@@ -136,13 +139,20 @@ export async function execCommand(
     const killProcess = () => {
       if (!killed) {
         killed = true;
-        proc.kill("SIGTERM");
-        forceKillTimer = setTimeout(() => {
-          if (!settled) {
-            proc.kill("SIGKILL");
-          }
-        }, FORCE_KILL_GRACE_MS);
-        forceKillTimer.unref?.();
+        if (proc.pid) {
+          killProcessTree(proc.pid, {
+            detached: process.platform !== "win32",
+            graceMs: FORCE_KILL_GRACE_MS,
+          });
+        } else {
+          proc.kill("SIGTERM");
+          forceKillTimer = setTimeout(() => {
+            if (!settled) {
+              proc.kill("SIGKILL");
+            }
+          }, FORCE_KILL_GRACE_MS);
+          forceKillTimer.unref?.();
+        }
       }
     };
 


### PR DESCRIPTION
Fixes #98335

## What Problem This Solves

Fixes an issue where session extensions using `api.exec()` could leave descendant processes running when a command timed out, was aborted, or exceeded the default output cap. The API reported the command as killed, but the old termination path only signaled the direct child process.

## Why This Change Was Made

`api.exec()` now uses the shared OpenClaw process-tree termination helper for timeout, abort, and output-limit cleanup, with the same detached Unix process-group setup used by the built-in shell execution paths. The direct `proc.kill()` fallback is retained only for the rare case where Node does not expose a child PID.

The runtime entry point is `ExtensionAPI.exec` in `src/agents/sessions/extensions/loader.ts`, which delegates extension commands to `execCommand()`. This PR keeps the `api.exec()` result shape unchanged and only changes how cleanup is performed after the command must be stopped.

## User Impact

Extension authors and operators can expect `api.exec()` cleanup to stop wrapper commands and their descendants instead of leaving background child processes behind after cancellation or timeout. The command output/result contract is unchanged.

## Evidence

- Source-level before evidence on current `main`: `src/agents/sessions/exec.ts` previously called `proc.kill(SIGTERM)` and later `proc.kill(SIGKILL)` in `killProcess()`, so timeout/abort/output-limit cleanup targeted only the direct child process.
- After-patch source proof: `execCommand()` now spawns with `detached: process.platform !== "win32"` and calls `killProcessTree(proc.pid, { detached: process.platform !== "win32", graceMs: 5000 })` when cleanup is required.
- Live Windows proof through the extension API boundary: I loaded an inline extension with `loadExtensionFromFactory()`, registered a command whose handler calls `api.exec(process.execPath, ["-e", parentScript], { timeout: 500 })`, and made that parent spawn a 30-second descendant Node process before idling. After the timeout, the descendant PID was no longer alive:

```text
platform=win32
entrypoint=ExtensionAPI.exec via registered command
timeout_ms=500
elapsed_ms=5952
result.killed=true
result.code=1
stdout="descendant_pid=3128"
descendant_pid=3128
descendant_alive_after_timeout=false
```

- Focused tests: `node scripts/run-vitest.mjs src/agents/sessions/exec.test.ts` passed, 1 file / 5 tests.
- Lint/static checks: `.\node_modules\.bin\oxlint.cmd src/agents/sessions/exec.ts src/agents/sessions/exec.test.ts` passed.
- Whitespace check: `git diff --check` passed.
- Autoreview: `python .agents\skills\autoreview\scripts\autoreview --mode local` returned `autoreview clean: no accepted/actionable findings reported`.
- Proof limitation: I did not run a full packaged third-party extension install. The live proof exercises the same `ExtensionAPI.exec` method that loaded extensions receive and the same backend cleanup path this PR changes.
