### PR TITLE
fix: kill extension exec descendants on timeout

### DIFF
--- a/src/agents/sessions/exec.test.ts
+++ b/src/agents/sessions/exec.test.ts
@@ -2,8 +2,10 @@
 // termination semantics used by agent sessions.
 import { EventEmitter } from "node:events";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { withMockedPlatform } from "../../test-utils/vitest-spies.js";
 
-const { spawnMock, waitForChildProcessMock } = vi.hoisted(() => ({
+const { killProcessTreeMock, spawnMock, waitForChildProcessMock } = vi.hoisted(() => ({
+  killProcessTreeMock: vi.fn(),
   spawnMock: vi.fn(),
   waitForChildProcessMock: vi.fn(),
 }));
@@ -16,8 +18,13 @@ vi.mock("../utils/child-process.js", () => ({
   waitForChildProcess: waitForChildProcessMock,
 }));
 
+vi.mock("../../process/kill-tree.js", () => ({
+  killProcessTree: killProcessTreeMock,
+}));
+
 type StubChild = EventEmitter & {
   kill: ReturnType<typeof vi.fn>;
+  pid?: number;
   stderr: EventEmitter;
   stdout: EventEmitter;
 };
@@ -42,6 +49,7 @@ function createDeferred<T>() {
 
 describe("execCommand", () => {
   beforeEach(() => {
+    killProcessTreeMock.mockReset();
     spawnMock.mockReset();
     waitForChildProcessMock.mockReset();
     vi.useRealTimers();
@@ -93,8 +101,37 @@ describe("execCommand", () => {
     expect(result.stdoutTruncatedChars).toBe(3);
   });
 
+  it("spawns with a process group when the platform supports tree signaling", async () => {
+    const { execCommand } = await import("./exec.js");
+
+    for (const [platform, expectedDetached] of [
+      ["linux", true],
+      ["win32", false],
+    ] as const) {
+      await withMockedPlatform(platform, async () => {
+        const child = createStubChild();
+        const wait = createDeferred<number | null>();
+        spawnMock.mockReturnValue(child);
+        waitForChildProcessMock.mockReturnValue(wait.promise);
+
+        const resultPromise = execCommand("cmd", ["arg"], "/tmp");
+        wait.resolve(0);
+        await resultPromise;
+
+        expect(spawnMock).toHaveBeenLastCalledWith("cmd", ["arg"], {
+          cwd: "/tmp",
+          detached: expectedDetached,
+          shell: false,
+          stdio: ["ignore", "pipe", "pipe"],
+          windowsHide: true,
+        });
+      });
+    }
+  });
+
   it("fails instead of silently truncating default exec output", async () => {
     const child = createStubChild();
+    child.pid = 2468;
     const wait = createDeferred<number | null>();
     spawnMock.mockReturnValue(child);
     waitForChildProcessMock.mockReturnValue(wait.promise);
@@ -105,7 +142,8 @@ describe("execCommand", () => {
     wait.resolve(0);
 
     const result = await resultPromise;
-    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+    expect(killProcessTreeMock).toHaveBeenCalledWith(2468, { graceMs: 5000 });
+    expect(child.kill).not.toHaveBeenCalled();
     expect(result.code).toBe(1);
     expect(result.killed).toBe(true);
     expect(result.outputLimitExceeded).toBe("stdout");
@@ -114,7 +152,47 @@ describe("execCommand", () => {
     expect(result.stderr).toContain("exec stdout exceeded output limit");
   });
 
-  it("escalates timed-out commands to SIGKILL after the grace period", async () => {
+  it("kills the process tree when commands time out", async () => {
+    vi.useFakeTimers();
+    const child = createStubChild();
+    child.pid = 1357;
+    const wait = createDeferred<number | null>();
+    spawnMock.mockReturnValue(child);
+    waitForChildProcessMock.mockReturnValue(wait.promise);
+    const { execCommand } = await import("./exec.js");
+
+    const resultPromise = execCommand("cmd", [], "/tmp", { timeout: 10 });
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(killProcessTreeMock).toHaveBeenCalledWith(1357, { graceMs: 5000 });
+    expect(child.kill).not.toHaveBeenCalled();
+
+    wait.resolve(null);
+    const result = await resultPromise;
+    expect(result.killed).toBe(true);
+  });
+
+  it("kills the process tree when aborted", async () => {
+    const child = createStubChild();
+    child.pid = 9753;
+    const wait = createDeferred<number | null>();
+    const controller = new AbortController();
+    spawnMock.mockReturnValue(child);
+    waitForChildProcessMock.mockReturnValue(wait.promise);
+    const { execCommand } = await import("./exec.js");
+
+    const resultPromise = execCommand("cmd", [], "/tmp", { signal: controller.signal });
+    controller.abort();
+
+    expect(killProcessTreeMock).toHaveBeenCalledWith(9753, { graceMs: 5000 });
+    expect(child.kill).not.toHaveBeenCalled();
+
+    wait.resolve(null);
+    const result = await resultPromise;
+    expect(result.killed).toBe(true);
+  });
+
+  it("falls back to direct kill when timed-out commands have no pid", async () => {
     // SIGTERM gives child processes a chance to clean up; SIGKILL is the
     // bounded fallback so an ignored signal cannot hang the session.
     vi.useFakeTimers();
@@ -126,6 +204,7 @@ describe("execCommand", () => {
 
     const resultPromise = execCommand("cmd", [], "/tmp", { timeout: 10 });
     await vi.advanceTimersByTimeAsync(10);
+    expect(killProcessTreeMock).not.toHaveBeenCalled();
     expect(child.kill).toHaveBeenCalledWith("SIGTERM");
     expect(child.kill).not.toHaveBeenCalledWith("SIGKILL");
 

--- a/src/agents/sessions/exec.ts
+++ b/src/agents/sessions/exec.ts
@@ -3,6 +3,7 @@
  */
 
 import { spawn } from "node:child_process";
+import { killProcessTree } from "../../process/kill-tree.js";
 import { waitForChildProcess } from "../utils/child-process.js";
 
 const DEFAULT_OUTPUT_LIMIT_CHARS = 16 * 1024 * 1024;
@@ -81,8 +82,10 @@ export async function execCommand(
   return new Promise((resolve) => {
     const proc = spawn(command, args, {
       cwd,
+      detached: process.platform !== "win32",
       shell: false,
       stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
     });
 
     let stdout: OutputCapture = { text: "", truncatedChars: 0 };
@@ -136,13 +139,17 @@ export async function execCommand(
     const killProcess = () => {
       if (!killed) {
         killed = true;
-        proc.kill("SIGTERM");
-        forceKillTimer = setTimeout(() => {
-          if (!settled) {
-            proc.kill("SIGKILL");
-          }
-        }, FORCE_KILL_GRACE_MS);
-        forceKillTimer.unref?.();
+        if (proc.pid && proc.pid > 0) {
+          killProcessTree(proc.pid, { graceMs: FORCE_KILL_GRACE_MS });
+        } else {
+          proc.kill("SIGTERM");
+          forceKillTimer = setTimeout(() => {
+            if (!settled) {
+              proc.kill("SIGKILL");
+            }
+          }, FORCE_KILL_GRACE_MS);
+          forceKillTimer.unref?.();
+        }
       }
     };
 


### PR DESCRIPTION
﻿Closes #98335

## What Problem This Solves

Fixes an issue where session extensions using `api.exec()` could report a timed-out, aborted, or output-limit-killed command as killed while descendant processes launched by that command continued running in the background.

## Why This Change Was Made

`api.exec()` now uses the existing OpenClaw process-tree termination helper for timeout, abort, and default output-limit kills. On Unix it spawns the command in a separate process group so the tree signal reaches descendants; on Windows it stays non-detached and lets the shared helper use the taskkill tree boundary. The no-PID direct-kill fallback is preserved.

## User Impact

Extension authors and operators can expect `api.exec()` cleanup to match the built-in command execution boundary more closely: when OpenClaw reports an extension exec command as killed, wrapper-launched descendants are not left behind under the normal timeout/abort/output-limit kill paths.

## Evidence

- Claim proved: timeout, abort, and default output-limit termination paths now call `killProcessTree()` when a child PID is available, while preserving the direct `SIGTERM`/`SIGKILL` fallback when no PID exists.
  - `node scripts/run-vitest.mjs src/agents/sessions/exec.test.ts src/process/kill-tree.test.ts`
  - Result: passed 2 Vitest shards; `src/agents/sessions/exec.test.ts` 11 tests passed, `src/process/kill-tree.test.ts` 7 tests passed.
- Claim proved: touched files are formatted and have no whitespace errors.
  - `corepack pnpm exec oxfmt --check --threads=1 src/agents/sessions/exec.ts src/agents/sessions/exec.test.ts`
  - Result: passed; both files use the correct format.
  - `git diff --check`
  - Result: passed.
- Claim proved: the Windows real process path kills a wrapper-launched descendant after timeout.
  - Ran a local `node --import tsx -` proof script that invoked `execCommand(process.execPath, ["-e", parentScript], process.cwd(), { timeout: 250 })`, where the parent Node process spawned a marker-bearing child Node process and then idled.
  - Observed result: `{ "killed": true, "code": 1, "leftovers": [] }` for marker `OPENCLAW_EXEC_TREE_PROOF_29996_1782873839097`.
- Review gate:
  - `python .agents\skills\autoreview\scripts\autoreview --mode local`
  - Result: `autoreview clean: no accepted/actionable findings reported`; the helper also printed a late Windows GBK reader-thread decode exception after the clean verdict, but exited 0.

Not tested / proof gaps:

- I did not run full `pnpm check`, full typecheck, or broad test suites per the contributor-scope instructions.
- I did not run a live Unix descendant-process reproduction; the Unix behavior is covered by focused spawn-option and kill-tree unit tests.
