### PR TITLE
fix(exec): use killProcessTree so api.exec terminates descendant processes

### DIFF
--- a/src/agents/sessions/exec.ts
+++ b/src/agents/sessions/exec.ts
@@ -3,6 +3,7 @@
  */
 
 import { spawn } from "node:child_process";
+import { killProcessTree } from "../shell-utils.js";
 import { waitForChildProcess } from "../utils/child-process.js";
 
 const DEFAULT_OUTPUT_LIMIT_CHARS = 16 * 1024 * 1024;
@@ -83,6 +84,9 @@ export async function execCommand(
       cwd,
       shell: false,
       stdio: ["ignore", "pipe", "pipe"],
+      // Spawn as a separate process group so killProcessTree can reach
+      // descendants that were forked by the direct child (e.g. wrappers).
+      ...(process.platform === "win32" ? {} : { detached: true }),
     });
 
     let stdout: OutputCapture = { text: "", truncatedChars: 0 };
@@ -136,10 +140,10 @@ export async function execCommand(
     const killProcess = () => {
       if (!killed) {
         killed = true;
-        proc.kill("SIGTERM");
+        if (proc.pid) killProcessTree(proc.pid);
         forceKillTimer = setTimeout(() => {
-          if (!settled) {
-            proc.kill("SIGKILL");
+          if (!settled && proc.pid) {
+            killProcessTree(proc.pid);
           }
         }, FORCE_KILL_GRACE_MS);
         forceKillTimer.unref?.();

--- a/src/agents/sessions/exec.ts
+++ b/src/agents/sessions/exec.ts
@@ -140,7 +140,9 @@ export async function execCommand(
     const killProcess = () => {
       if (!killed) {
         killed = true;
-        if (proc.pid) killProcessTree(proc.pid);
+        if (proc.pid) {
+          killProcessTree(proc.pid);
+        }
         forceKillTimer = setTimeout(() => {
           if (!settled && proc.pid) {
             killProcessTree(proc.pid);


### PR DESCRIPTION
## What Problem This Solves

`api.exec()` only kills the direct child process via `proc.kill()`, leaving descendant processes running after timeout, abort, or output-limit termination. The shared `killProcessTree` helper already used by built-in shell execution paths terminates the full process tree, but the extension session path was not using it.

Closes #98335

## Fix

- Spawn Unix commands with `detached: true` for process-group isolation
- Replace `proc.kill("SIGTERM")` / `proc.kill("SIGKILL")` with `killProcessTree(proc.pid)`
- Retain `FORCE_KILL_GRACE_MS` grace period for stuck processes
- **1 file, 7 lines**

## Evidence

### Real behavior proof — before/after with live processes

```
════════════════════════════════════════════════════════════
  #98335 Proof — killProcessTree vs proc.kill
════════════════════════════════════════════════════════════
  ❌ BEFORE: child 3109363 survived proc.kill
  ✅ AFTER: killProcessTree terminated descendants

  Result: BEFORE bug confirmed | AFTER fix works
════════════════════════════════════════════════════════════
```

Proof script spawns a bash wrapper that forks a `sleep 120` child, then:
1. **BEFORE** (`proc.kill`): child survives — bug confirmed
2. **AFTER** (`killProcessTree`): child terminated — fix verified

### Test suite

```
npx vitest run src/agents/sessions/exec.test.ts
  Test Files  1 passed (1)    Tests  5 passed (5)
```

### Formatting

```
pnpm exec oxfmt --check src/agents/sessions/exec.ts
  All matched files use the correct format.
```

## Change Type

- [x] Bug fix

## Scope

- [x] Agents (session extensions / api.exec)

## Security Impact

- New permissions? No
- Secrets handling changed? No
- New network calls? No