### PR TITLE
fix: retry image describe fallback models

### DIFF
--- a/docs/cli/infer.md
+++ b/docs/cli/infer.md
@@ -129,7 +129,7 @@ This table maps common inference tasks to the corresponding infer command.
 - Use `model run --thinking <level>` to pass a one-shot thinking/reasoning level (`off`, `minimal`, `low`, `medium`, `high`, `adaptive`, `xhigh`, or `max`) while keeping the run raw.
 - For `image describe`, `audio transcribe`, and `video describe`, `--model` must use the form `<provider/model>`.
 - For `image describe`, `--file` accepts local paths and HTTP(S) image URLs. Remote URLs use the normal media-fetch SSRF policy.
-- For `image describe`, an explicit `--model` runs that provider/model directly. The model must be image-capable in the model catalog or provider config. `codex/<model>` runs a bounded Codex app-server image-understanding turn; `openai/<model>` uses the OpenAI provider path with either API-key or ChatGPT/Codex OAuth auth.
+- For `image describe`, an explicit `--model` runs that provider/model first, then tries configured `agents.defaults.imageModel.fallbacks` when the model call fails. Input preparation errors, such as missing files or unsupported URLs, fail before fallback attempts. The model must be image-capable in the model catalog or provider config. `codex/<model>` runs a bounded Codex app-server image-understanding turn; `openai/<model>` uses the OpenAI provider path with either API-key or ChatGPT/Codex OAuth auth.
 - Stateless execution commands default to local.
 - Gateway-managed state commands default to gateway.
 - The normal local path does not require the gateway to be running.
@@ -235,6 +235,8 @@ Notes:
 - For `image describe` and `image describe-many`, use `--prompt` to give the vision model a task-specific instruction such as OCR, comparison, UI inspection, or concise captioning.
 - Use `--timeout-ms` with slow local vision models or cold Ollama starts.
 - For `image describe`, `--model` must be an image-capable `<provider/model>`.
+  When set, OpenClaw tries that explicit model first and then configured
+  image-model fallbacks if the model call fails.
 - For local Ollama vision models, pull the model first and set `OLLAMA_API_KEY` to any placeholder value, for example `ollama-local`. See [Ollama](/providers/ollama#vision-and-image-description).
 
 ## Audio

--- a/docs/providers/ollama.md
+++ b/docs/providers/ollama.md
@@ -324,7 +324,7 @@ openclaw infer image describe \
   --json
 ```
 
-`--model` must be a full `<provider/model>` ref. When it is set, `openclaw infer image describe` runs that model directly instead of skipping description because the model supports native vision.
+`--model` must be a full `<provider/model>` ref. When it is set, `openclaw infer image describe` tries that model first instead of skipping description because the model supports native vision. If the model call fails, OpenClaw can continue through configured `agents.defaults.imageModel.fallbacks`; file or URL preparation errors still fail before fallback attempts.
 
 Use `infer image describe` when you want OpenClaw's image-understanding provider flow, configured `agents.defaults.imageModel`, and image-description output shape. Use `infer model run --file` when you want a raw multimodal model probe with a custom prompt and one or more images.
 

--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -81,6 +81,15 @@ const mocks = vi.hoisted(() => ({
     provider: "openai",
     model: "gpt-4.1-mini",
   })),
+  prepareImageDescriptionInput: vi.fn(async () => ({
+    buffer: Buffer.from("image"),
+    fileName: "photo.jpg",
+    mime: "image/jpeg",
+  })),
+  describePreparedImageWithModel: vi.fn(async () => ({
+    text: "friendly lobster",
+    model: "gpt-4.1-mini",
+  })),
   describeImageFileWithModel: vi.fn(async () => ({
     text: "friendly lobster",
     model: "gpt-4.1-mini",
@@ -289,6 +298,10 @@ vi.mock("../gateway/connection-details.js", () => ({
 vi.mock("../media-understanding/runtime.js", () => ({
   describeImageFile:
     mocks.describeImageFile as typeof import("../media-understanding/runtime.js").describeImageFile,
+  prepareImageDescriptionInput:
+    mocks.prepareImageDescriptionInput as typeof import("../media-understanding/runtime.js").prepareImageDescriptionInput,
+  describePreparedImageWithModel:
+    mocks.describePreparedImageWithModel as typeof import("../media-understanding/runtime.js").describePreparedImageWithModel,
   describeImageFileWithModel:
     mocks.describeImageFileWithModel as typeof import("../media-understanding/runtime.js").describeImageFileWithModel,
   describeVideoFile: vi.fn(),
@@ -498,6 +511,8 @@ describe("capability cli", () => {
       return {};
     }) as never);
     mocks.describeImageFile.mockClear();
+    mocks.prepareImageDescriptionInput.mockClear();
+    mocks.describePreparedImageWithModel.mockClear();
     mocks.describeImageFileWithModel.mockClear();
     mocks.generateImage.mockReset();
     mocks.generateVideo.mockReset();
@@ -630,8 +645,15 @@ describe("capability cli", () => {
     return calls[index]?.[0];
   }
 
+  function firstImagePrepareCall() {
+    const calls = mocks.prepareImageDescriptionInput.mock.calls as unknown as Array<
+      [ImageDescribeParams]
+    >;
+    return calls[0]?.[0];
+  }
+
   function firstImageDescribeWithModelCall() {
-    const calls = mocks.describeImageFileWithModel.mock.calls as unknown as Array<
+    const calls = mocks.describePreparedImageWithModel.mock.calls as unknown as Array<
       [ImageDescribeParams]
     >;
     return calls[0]?.[0];
@@ -1333,8 +1355,9 @@ describe("capability cli", () => {
       ],
     });
 
+    const prepareCall = firstImagePrepareCall();
     const describeCall = firstImageDescribeWithModelCall();
-    expect(path.basename(describeCall?.filePath ?? "")).toBe("photo.jpg");
+    expect(path.basename(prepareCall?.filePath ?? "")).toBe("photo.jpg");
     expect(describeCall?.provider).toBe("ollama");
     expect(describeCall?.model).toBe("qwen2.5vl:7b");
     expect(describeCall?.prompt).toBe("Count visible buttons");
@@ -1359,9 +1382,9 @@ describe("capability cli", () => {
       ],
     });
 
-    const describeCall = firstImageDescribeWithModelCall();
-    expect(describeCall?.filePath).toBe("https://example.com/photo.png");
-    expect(describeCall?.mediaUrl).toBe("https://example.com/photo.png");
+    const prepareCall = firstImagePrepareCall();
+    expect(prepareCall?.filePath).toBe("https://example.com/photo.png");
+    expect(prepareCall?.mediaUrl).toBe("https://example.com/photo.png");
     expect(mocks.describeImageFile).not.toHaveBeenCalled();
     const outputs = firstJsonOutput()?.outputs as Array<Record<string, unknown>>;
     expect(outputs[0]?.path).toBe("https://example.com/photo.png");
@@ -1382,11 +1405,115 @@ describe("capability cli", () => {
       ],
     });
 
+    const prepareCall = firstImagePrepareCall();
     const describeCall = firstImageDescribeWithModelCall();
-    expect(describeCall?.filePath).toBe("https://httpbin.org/image/png");
+    expect(prepareCall?.filePath).toBe("https://httpbin.org/image/png");
     expect(describeCall?.provider).toBe("minimax-cn");
     expect(describeCall?.model).toBe("MiniMax-VL-01");
     expect(mocks.describeImageFile).not.toHaveBeenCalled();
+  });
+
+  it("falls back to configured image models for explicit-model image describe", async () => {
+    mocks.resolveCommandConfigWithSecrets.mockResolvedValueOnce({
+      resolvedConfig: {},
+      effectiveConfig: {
+        agents: {
+          defaults: {
+            imageModel: {
+              primary: "openrouter/google/gemma-4-31b-it:free",
+              fallbacks: ["openrouter/google/gemma-4-31b-it"],
+            },
+          },
+        },
+      },
+      diagnostics: [],
+    });
+    mocks.describePreparedImageWithModel
+      .mockRejectedValueOnce(new Error("upstream 429 rate limit"))
+      .mockResolvedValueOnce({
+        text: "fallback description",
+        model: "google/gemma-4-31b-it",
+      });
+
+    await runRegisteredCli({
+      register: registerCapabilityCli as (program: Command) => void,
+      argv: [
+        "capability",
+        "image",
+        "describe",
+        "--file",
+        "photo.jpg",
+        "--model",
+        "openrouter/google/gemma-4-31b-it:free",
+        "--json",
+      ],
+    });
+
+    expect(mocks.prepareImageDescriptionInput).toHaveBeenCalledTimes(1);
+    const calls = mocks.describePreparedImageWithModel.mock.calls as unknown as Array<
+      [ImageDescribeParams]
+    >;
+    expect(calls.map(([call]) => `${String(call.provider)}/${String(call.model)}`)).toEqual([
+      "openrouter/google/gemma-4-31b-it:free",
+      "openrouter/google/gemma-4-31b-it",
+    ]);
+    expect(firstJsonOutput()).toMatchObject({
+      ok: true,
+      capability: "image.describe",
+      provider: "openrouter",
+      model: "google/gemma-4-31b-it",
+      attempts: [
+        {
+          provider: "openrouter",
+          model: "google/gemma-4-31b-it:free",
+          error: "upstream 429 rate limit",
+        },
+      ],
+      outputs: [
+        {
+          text: "fallback description",
+          model: "google/gemma-4-31b-it",
+        },
+      ],
+    });
+  });
+
+  it("does not retry image input preparation failures as model fallbacks", async () => {
+    mocks.resolveCommandConfigWithSecrets.mockResolvedValueOnce({
+      resolvedConfig: {},
+      effectiveConfig: {
+        agents: {
+          defaults: {
+            imageModel: {
+              primary: "openrouter/google/gemma-4-31b-it:free",
+              fallbacks: ["openrouter/google/gemma-4-31b-it"],
+            },
+          },
+        },
+      },
+      diagnostics: [],
+    });
+    mocks.prepareImageDescriptionInput.mockRejectedValueOnce(new Error("image file not found"));
+
+    await expect(
+      runRegisteredCli({
+        register: registerCapabilityCli as (program: Command) => void,
+        argv: [
+          "capability",
+          "image",
+          "describe",
+          "--file",
+          "missing.jpg",
+          "--model",
+          "openrouter/google/gemma-4-31b-it:free",
+          "--json",
+        ],
+      }),
+    ).rejects.toThrow("exit 1");
+
+    expectRuntimeErrorContains("image file not found");
+    expect(runtimeErrorMessages().join("\n")).not.toContain("All image models failed");
+    expect(mocks.describePreparedImageWithModel).not.toHaveBeenCalled();
   });
 
   it("passes describe-many prompts to each image", async () => {

--- a/src/cli/capability-cli.ts
+++ b/src/cli/capability-cli.ts
@@ -30,6 +30,7 @@ import { DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { resolveMemorySearchConfig } from "../agents/memory-search.js";
 import { resolveApiKeyForProvider } from "../agents/model-auth.js";
 import { loadModelCatalog } from "../agents/model-catalog.js";
+import { runWithImageModelFallback } from "../agents/model-fallback.js";
 import { canonicalizeCaseOnlyCatalogModelRef } from "../agents/model-selection.js";
 import { assertOkOrThrowHttpError } from "../agents/provider-http-errors.js";
 import {
@@ -62,8 +63,9 @@ import {
 import { buildMediaUnderstandingRegistry } from "../media-understanding/provider-registry.js";
 import type { RunMediaUnderstandingFileResult } from "../media-understanding/runtime-types.js";
 import {
+  describePreparedImageWithModel,
   describeImageFile,
-  describeImageFileWithModel,
+  prepareImageDescriptionInput,
   describeVideoFile,
   transcribeAudioFile,
 } from "../media-understanding/runtime.js";
@@ -1083,27 +1085,50 @@ async function runImageDescribe(params: {
     params.files.map(async (filePath) => {
       const resolvedPath = resolveImageDescribeInput(filePath);
       const isRemoteUrl = /^https?:\/\//i.test(resolvedPath);
-      const result = activeModel
-        ? await describeImageFileWithModel({
+      const preparedImage = activeModel
+        ? await prepareImageDescriptionInput({
             filePath: resolvedPath,
             ...(isRemoteUrl ? { mediaUrl: resolvedPath } : {}),
             cfg,
-            agentDir,
-            provider: activeModel.provider,
-            model: activeModel.model,
-            prompt: prompt ?? "Describe the image.",
             timeoutMs: params.timeoutMs,
           })
-        : await describeImageFile({
-            filePath: resolvedPath,
-            ...(isRemoteUrl ? { mediaUrl: resolvedPath } : {}),
-            cfg,
-            agentDir,
-            prompt,
-            timeoutMs: params.timeoutMs,
-          });
-      if (!result.text) {
-        if (isMissingMediaUnderstandingProvider(result)) {
+        : undefined;
+      const result =
+        activeModel && preparedImage
+          ? await runWithImageModelFallback({
+              cfg,
+              modelOverride: `${activeModel.provider}/${activeModel.model}`,
+              run: async (provider, model) => {
+                const described = await describePreparedImageWithModel({
+                  image: preparedImage,
+                  cfg,
+                  agentDir,
+                  provider,
+                  model,
+                  prompt: prompt ?? "Describe the image.",
+                  timeoutMs: params.timeoutMs,
+                });
+                if (!described.text?.trim()) {
+                  throw new Error(`No description returned for image: ${resolvedPath}`);
+                }
+                return described;
+              },
+            })
+          : {
+              result: await describeImageFile({
+                filePath: resolvedPath,
+                ...(isRemoteUrl ? { mediaUrl: resolvedPath } : {}),
+                cfg,
+                agentDir,
+                prompt,
+                timeoutMs: params.timeoutMs,
+              }),
+              provider: undefined,
+              model: undefined,
+              attempts: [],
+            };
+      if (!result.result.text) {
+        if (isMissingMediaUnderstandingProvider(result.result)) {
           throw new Error(
             "No image understanding provider is configured or ready. Configure tools.media.image.models or agents.defaults.imageModel.primary, or pass --model <provider/model> after configuring that provider's auth/API key.",
           );
@@ -1112,9 +1137,10 @@ async function runImageDescribe(params: {
       }
       return {
         path: resolvedPath,
-        text: result.text,
-        provider: activeModel?.provider ?? ("provider" in result ? result.provider : undefined),
-        model: result.model,
+        text: result.result.text,
+        provider: result.provider ?? result.result.provider,
+        model: result.result.model ?? result.model,
+        attempts: result.attempts,
         kind: "image.description",
       };
     }),
@@ -1125,8 +1151,8 @@ async function runImageDescribe(params: {
     transport: "local" as const,
     provider: outputs[0]?.provider,
     model: outputs[0]?.model,
-    attempts: [],
-    outputs,
+    attempts: outputs.flatMap((output) => output.attempts),
+    outputs: outputs.map(({ attempts: _attempts, ...output }) => output),
   } satisfies CapabilityEnvelope;
 }
 

--- a/src/media-understanding/runtime-types.ts
+++ b/src/media-understanding/runtime-types.ts
@@ -1,8 +1,8 @@
+import type { ActiveMediaModel } from "../../packages/media-understanding-common/src/active-model.js";
 // Public media-understanding runtime API types for file-based image/audio/video
 // helpers and direct structured extraction.
 import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
 import type { OpenClawConfig } from "../config/types.js";
-import type { ActiveMediaModel } from "../../packages/media-understanding-common/src/active-model.js";
 import type {
   MediaUnderstandingDecision,
   MediaUnderstandingOutput,
@@ -65,6 +65,24 @@ export type DescribeImageFileWithModelParams = {
   timeoutMs?: number;
 };
 
+export type PreparedImageDescriptionInput = {
+  buffer: Buffer;
+  fileName: string;
+  mime?: string;
+};
+
+export type PrepareImageDescriptionInputParams = Pick<
+  DescribeImageFileWithModelParams,
+  "filePath" | "mediaUrl" | "mime" | "cfg" | "timeoutMs"
+>;
+
+export type DescribePreparedImageWithModelParams = Omit<
+  DescribeImageFileWithModelParams,
+  "filePath" | "mediaUrl" | "mime"
+> & {
+  image: PreparedImageDescriptionInput;
+};
+
 type DescribeImageFileWithModelResult = Awaited<
   ReturnType<NonNullable<MediaUnderstandingProvider["describeImage"]>>
 >;
@@ -115,6 +133,12 @@ export type MediaUnderstandingRuntime = {
     params: RunMediaUnderstandingFileParams,
   ) => Promise<RunMediaUnderstandingFileResult>;
   describeImageFile: (params: DescribeImageFileParams) => Promise<RunMediaUnderstandingFileResult>;
+  prepareImageDescriptionInput: (
+    params: PrepareImageDescriptionInputParams,
+  ) => Promise<PreparedImageDescriptionInput>;
+  describePreparedImageWithModel: (
+    params: DescribePreparedImageWithModelParams,
+  ) => Promise<DescribeImageFileWithModelResult>;
   describeImageFileWithModel: (
     params: DescribeImageFileWithModelParams,
   ) => Promise<DescribeImageFileWithModelResult>;

--- a/src/media-understanding/runtime.ts
+++ b/src/media-understanding/runtime.ts
@@ -21,8 +21,10 @@ import {
   runCapability,
 } from "./runner.js";
 import type {
+  DescribePreparedImageWithModelParams,
   DescribeImageFileParams,
   DescribeImageFileWithModelParams,
+  PrepareImageDescriptionInputParams,
   DescribeVideoFileParams,
   ExtractStructuredWithModelParams,
   RunMediaUnderstandingFileParams,
@@ -30,8 +32,11 @@ import type {
   TranscribeAudioFileParams,
 } from "./runtime-types.js";
 export type {
+  DescribePreparedImageWithModelParams,
   DescribeImageFileParams,
   DescribeImageFileWithModelParams,
+  PreparedImageDescriptionInput,
+  PrepareImageDescriptionInputParams,
   DescribeVideoFileParams,
   ExtractStructuredWithModelParams,
   RunMediaUnderstandingFileParams,
@@ -240,11 +245,9 @@ export async function describeImageFile(
   return await runMediaUnderstandingFile({ ...params, capability: "image" });
 }
 
-/** Describes one image with an explicit provider/model, bypassing configured media model selection. */
-export async function describeImageFileWithModel(params: DescribeImageFileWithModelParams) {
+/** Reads and normalizes image input once before explicit-model fallback attempts. */
+export async function prepareImageDescriptionInput(params: PrepareImageDescriptionInputParams) {
   const timeoutMs = resolveMediaRuntimeTimeoutMs(params.timeoutMs);
-  const providerRegistry = buildProviderRegistry(undefined, params.cfg);
-  const provider = providerRegistry.get(normalizeMediaProviderId(params.provider));
   const image = await readImageDescriptionInput({
     filePath: params.filePath,
     mediaUrl: params.mediaUrl,
@@ -258,11 +261,23 @@ export async function describeImageFileWithModel(params: DescribeImageFileWithMo
     mime: image.mime,
     maxBytes: DEFAULT_MAX_BYTES.image,
   });
-  const describeImage = provider?.describeImage ?? describeImageWithModel;
-  return await describeImage({
+  return {
     buffer: normalizedImage.buffer,
     fileName: image.fileName,
     mime: normalizedImage.mime,
+  };
+}
+
+/** Describes a prepared image with an explicit provider/model. */
+export async function describePreparedImageWithModel(params: DescribePreparedImageWithModelParams) {
+  const timeoutMs = resolveMediaRuntimeTimeoutMs(params.timeoutMs);
+  const providerRegistry = buildProviderRegistry(undefined, params.cfg);
+  const provider = providerRegistry.get(normalizeMediaProviderId(params.provider));
+  const describeImage = provider?.describeImage ?? describeImageWithModel;
+  return await describeImage({
+    buffer: params.image.buffer,
+    fileName: params.image.fileName,
+    mime: params.image.mime,
     provider: params.provider,
     model: params.model,
     prompt: params.prompt,
@@ -271,6 +286,15 @@ export async function describeImageFileWithModel(params: DescribeImageFileWithMo
     cfg: params.cfg,
     agentDir: params.agentDir ?? "",
     ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
+  });
+}
+
+/** Describes one image with an explicit provider/model, bypassing configured media model selection. */
+export async function describeImageFileWithModel(params: DescribeImageFileWithModelParams) {
+  const image = await prepareImageDescriptionInput(params);
+  return await describePreparedImageWithModel({
+    ...params,
+    image,
   });
 }
 


### PR DESCRIPTION
Related: #98264

## What Problem This Solves

Fixes an issue where users running `openclaw infer image describe` or `describe-many` with an explicit configured image model could lose the configured fallback recovery path when the primary provider/model failed, such as an upstream 429 from an image model route.

## Why This Change Was Made

The CLI explicit-model image describe path now reuses OpenClaw's existing image model fallback runner. It prepares image input once before fallback attempts, tries the requested `--model` first, then walks `agents.defaults.imageModel.fallbacks` before failing, and reports failed model attempts in the JSON `attempts` field. This intentionally addresses the reported CLI/tool-wrapper path without adding a broad fail-closed skill contract system.

The docs now spell out the chosen semantics: explicit `--model` is still the first model attempted, but model-call failures can continue through configured image fallbacks. Input preparation errors, such as missing files, blocked downloads, or normalization failures, still fail before fallback attempts.

## User Impact

Users and skills that call `openclaw infer image describe` or `describe-many --model <provider/model> --json` can expect configured image fallback models to be attempted automatically after provider/model failures. Bad image paths, blocked/failed downloads, and normalization errors still fail before model fallback, so input problems are not reported as model failures.

## Evidence

AI-assisted with Codex.

- `node scripts/run-vitest.mjs src/cli/capability-cli.test.ts` passed: 1 file, 106 tests.
- `pnpm tsgo:test:src` passed.
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/cli/capability-cli.test.ts src/cli/capability-cli.ts src/media-understanding/runtime.ts src/media-understanding/runtime-types.ts` passed.
- `pnpm lint:docs -- docs/cli/infer.md docs/providers/ollama.md` passed.
- `git diff --check` passed.
- `codex review --base origin/main` completed with no actionable correctness issues after the input-preparation retry finding was addressed.

Real CLI behavior proof with a temporary local OpenAI-compatible mock provider, redacted for local paths and port:

```text
$ OPENCLAW_CONFIG_PATH=<tmp>/openclaw.json OPENCLAW_STATE_DIR=<tmp>/state \
  openclaw infer image describe --file <tmp>/pixel.png \
  --model localmock/primary-rate-limit \
  --prompt "Describe in one short sentence." --timeout-ms 30000 --json

exit_code=0
http_models=primary-rate-limit:stream=true,fallback-vision:stream=true
{
  "ok": true,
  "capability": "image.describe",
  "transport": "local",
  "provider": "localmock",
  "model": "fallback-vision",
  "attempts": [
    {
      "provider": "localmock",
      "model": "primary-rate-limit",
      "error": "Image model failed (localmock/primary-rate-limit): 429 mock upstream 429 for primary"
    }
  ],
  "outputs": [
    {
      "path": "<tmp>/pixel.png",
      "text": "fallback mock description",
      "provider": "localmock",
      "model": "fallback-vision",
      "kind": "image.description"
    }
  ]
}
```

The regression tests also simulate `openrouter/google/gemma-4-31b-it:free` failing with an upstream 429, then verify `openrouter/google/gemma-4-31b-it` is attempted and the failed primary attempt is included in CLI JSON output. A companion test verifies image input preparation failures do not consume fallback candidates or produce `All image models failed`.
