### PR TITLE
Show marketplace feed trust state

### DIFF
--- a/src/cli/plugins-cli.marketplace-entries.test.ts
+++ b/src/cli/plugins-cli.marketplace-entries.test.ts
@@ -115,6 +115,13 @@ describe("plugins marketplace entries", () => {
         },
         savedAt: "2026-06-23T01:02:03.000Z",
       },
+      trust: {
+        mode: "signed",
+        signedBy: "acme-root-2026",
+        signatureCount: 1,
+        threshold: 1,
+        verifiedAt: "2026-06-23T01:02:03.000Z",
+      },
       error: "hosted catalog feed offline mode",
     });
 
@@ -129,6 +136,13 @@ describe("plugins marketplace entries", () => {
       expect.objectContaining({
         source: "hosted-snapshot",
         entryCount: 1,
+        trust: {
+          mode: "signed",
+          signedBy: "acme-root-2026",
+          signatureCount: 1,
+          threshold: 1,
+          verifiedAt: "2026-06-23T01:02:03.000Z",
+        },
         entries: [
           expect.objectContaining({
             id: "acme-calendar",
@@ -213,6 +227,53 @@ describe("plugins marketplace entries", () => {
     expect(mocks.defaultRuntime.exit).not.toHaveBeenCalled();
   });
 
+  it("prints bounded signed feed trust state in text output", async () => {
+    mocks.getRuntimeConfig.mockReturnValue({});
+    mocks.loadConfiguredHostedOfficialExternalPluginCatalogEntries.mockResolvedValue({
+      source: "hosted-snapshot",
+      entries: [],
+      feed: {
+        schemaVersion: 1,
+        id: "acme-marketplace",
+        generatedAt: "2026-06-23T00:00:00.000Z",
+        sequence: 7,
+        entries: [],
+      },
+      metadata: {
+        url: "https://packages.acme.example/openclaw/feed",
+        status: 200,
+        checksum: "feed-sha",
+      },
+      snapshot: {
+        body: "{}",
+        metadata: {
+          url: "https://packages.acme.example/openclaw/feed",
+          status: 200,
+          checksum: "feed-sha",
+        },
+        savedAt: "2026-06-23T01:02:03.000Z",
+      },
+      trust: {
+        mode: "signed",
+        signedBy: "acme-root-2026",
+        signatureCount: 1,
+        threshold: 1,
+        verifiedAt: "2026-06-23T01:02:03.000Z",
+      },
+      error: "hosted catalog feed offline mode",
+    });
+
+    const { runPluginMarketplaceEntriesCommand } = await import("./plugins-cli.runtime.js");
+    await runPluginMarketplaceEntriesCommand({ offline: true });
+
+    const output = mocks.defaultRuntime.log.mock.calls.map(([value]) => String(value)).join("\n");
+    expect(output).toContain("Trust:");
+    expect(output).toContain("signed by acme-root-2026 (1/1)");
+    expect(output).toContain("2026-06-23T01:02:03.000Z");
+    expect(output).not.toContain("publicKey");
+    expect(output).not.toContain("signature:");
+  });
+
   it("emits bounded diagnostics for feed entry listing", async () => {
     const timelinePath = await createTimelinePath();
     vi.stubEnv("OPENCLAW_DIAGNOSTICS", "1");
@@ -247,6 +308,13 @@ describe("plugins marketplace entries", () => {
         },
         savedAt: "2026-06-23T01:02:03.000Z",
       },
+      trust: {
+        mode: "signed",
+        signedBy: "acme-root-2026",
+        signatureCount: 1,
+        threshold: 1,
+        verifiedAt: "2026-06-23T01:02:03.000Z",
+      },
       error: "hosted catalog feed offline mode",
     });
 
@@ -263,6 +331,10 @@ describe("plugins marketplace entries", () => {
       feedIdPresent: true,
       feedProfileProvided: true,
       feedSequence: 7,
+      feedTrustMode: "signed",
+      feedTrustSignatureCount: 1,
+      feedTrustThreshold: 1,
+      feedTrustVerified: true,
       offline: true,
       payloadChecksumPresent: true,
       snapshotUsed: true,
@@ -271,6 +343,7 @@ describe("plugins marketplace entries", () => {
     expect(JSON.stringify(event)).not.toContain("packages.acme.example");
     expect(JSON.stringify(event)).not.toContain("acme-marketplace");
     expect(JSON.stringify(event)).not.toContain("feed-sha");
+    expect(JSON.stringify(event)).not.toContain("acme-root-2026");
     expect(JSON.stringify(event)).not.toContain("secret");
     expect(JSON.stringify(event)).not.toContain("token=leak");
   });

--- a/src/cli/plugins-cli.marketplace-refresh.test.ts
+++ b/src/cli/plugins-cli.marketplace-refresh.test.ts
@@ -87,6 +87,13 @@ describe("plugins marketplace refresh", () => {
         checksum: "feed-sha",
         etag: '"abc"',
       },
+      trust: {
+        mode: "signed",
+        signedBy: "acme-root-2026",
+        signatureCount: 1,
+        threshold: 1,
+        verifiedAt: "2026-06-23T00:01:02.000Z",
+      },
     });
 
     const { runPluginMarketplaceRefreshCommand } = await import("./plugins-cli.runtime.js");
@@ -114,7 +121,51 @@ describe("plugins marketplace refresh", () => {
         checksum: "feed-sha",
         etag: '"abc"',
       },
+      trust: {
+        mode: "signed",
+        signedBy: "acme-root-2026",
+        signatureCount: 1,
+        threshold: 1,
+        verifiedAt: "2026-06-23T00:01:02.000Z",
+      },
     });
+  });
+
+  it("prints bounded signed feed trust state in text output", async () => {
+    mocks.getRuntimeConfig.mockReturnValue({});
+    mocks.loadConfiguredHostedOfficialExternalPluginCatalogEntries.mockResolvedValue({
+      source: "hosted",
+      entries: [{ name: "@acme/calendar" }],
+      feed: {
+        schemaVersion: 1,
+        id: "acme-marketplace",
+        generatedAt: "2026-06-23T00:00:00.000Z",
+        sequence: 7,
+        entries: [],
+      },
+      metadata: {
+        url: "https://packages.acme.example/openclaw/feed",
+        status: 200,
+        checksum: "feed-sha",
+      },
+      trust: {
+        mode: "signed",
+        signedBy: "acme-root-2026",
+        signatureCount: 1,
+        threshold: 1,
+        verifiedAt: "2026-06-23T00:01:02.000Z",
+      },
+    });
+
+    const { runPluginMarketplaceRefreshCommand } = await import("./plugins-cli.runtime.js");
+    await runPluginMarketplaceRefreshCommand({});
+
+    const output = mocks.defaultRuntime.log.mock.calls.map(([value]) => String(value)).join("\n");
+    expect(output).toContain("Trust:");
+    expect(output).toContain("signed by acme-root-2026 (1/1)");
+    expect(output).toContain("2026-06-23T00:01:02.000Z");
+    expect(output).not.toContain("publicKey");
+    expect(output).not.toContain("signature:");
   });
 
   it("normalizes bare SHA-256 pins before refreshing", async () => {
@@ -288,6 +339,13 @@ describe("plugins marketplace refresh", () => {
         checksum: "feed-sha",
         etag: '"abc"',
       },
+      trust: {
+        mode: "signed",
+        signedBy: "acme-root-2026",
+        signatureCount: 1,
+        threshold: 1,
+        verifiedAt: "2026-06-23T00:01:02.000Z",
+      },
     });
 
     const { runPluginMarketplaceRefreshCommand } = await import("./plugins-cli.runtime.js");
@@ -313,6 +371,10 @@ describe("plugins marketplace refresh", () => {
       feedIdPresent: true,
       feedProfileProvided: true,
       feedSequence: 7,
+      feedTrustMode: "signed",
+      feedTrustSignatureCount: 1,
+      feedTrustThreshold: 1,
+      feedTrustVerified: true,
       feedUrlOverride: true,
       hasEtag: true,
       payloadChecksumPresent: true,
@@ -321,6 +383,7 @@ describe("plugins marketplace refresh", () => {
     expect(JSON.stringify(event)).not.toContain("packages.acme.example");
     expect(JSON.stringify(event)).not.toContain("acme-marketplace");
     expect(JSON.stringify(event)).not.toContain("feed-sha");
+    expect(JSON.stringify(event)).not.toContain("acme-root-2026");
     expect(JSON.stringify(event)).not.toContain("secret");
     expect(JSON.stringify(event)).not.toContain("token=leak");
     expect(JSON.stringify(event)).not.toContain("override-leak");

--- a/src/cli/plugins-cli.runtime.ts
+++ b/src/cli/plugins-cli.runtime.ts
@@ -467,7 +467,16 @@ type MarketplaceRefreshPayload = {
   snapshot?: {
     savedAt: string;
   };
+  trust?: MarketplaceFeedTrustPayload;
   error?: string;
+};
+
+type MarketplaceFeedTrustPayload = {
+  mode: "signed";
+  signedBy: string;
+  signatureCount: number;
+  threshold: number;
+  verifiedAt: string;
 };
 
 type MarketplaceEntryPayload = {
@@ -559,6 +568,12 @@ function emitMarketplaceFeedTelemetry(params: {
   if (params.payload.snapshot) {
     attributes.snapshotUsed = true;
   }
+  if (params.payload.trust) {
+    attributes.feedTrustVerified = true;
+    attributes.feedTrustMode = params.payload.trust.mode;
+    attributes.feedTrustSignatureCount = params.payload.trust.signatureCount;
+    attributes.feedTrustThreshold = params.payload.trust.threshold;
+  }
   const fallbackCategory = classifyMarketplaceFeedFallback(params.payload.error);
   if (fallbackCategory) {
     attributes.fallbackCategory = fallbackCategory;
@@ -597,6 +612,15 @@ function buildMarketplaceRefreshPayload(
       generatedAt: result.feed.generatedAt,
       sequence: result.feed.sequence,
     };
+    if (result.trust) {
+      payload.trust = {
+        mode: result.trust.mode,
+        signedBy: result.trust.signedBy,
+        signatureCount: result.trust.signatureCount,
+        threshold: result.trust.threshold,
+        verifiedAt: result.trust.verifiedAt,
+      };
+    }
   }
   if (result.source === "hosted-snapshot") {
     payload.snapshot = { savedAt: result.snapshot.savedAt };
@@ -679,6 +703,10 @@ function formatMarketplaceRefreshSource(source: MarketplaceRefreshPayload["sourc
     return theme.warn("hosted snapshot");
   }
   return theme.warn("bundled fallback");
+}
+
+function formatMarketplaceFeedTrust(trust: MarketplaceFeedTrustPayload): string {
+  return `${trust.mode} by ${trust.signedBy} (${trust.signatureCount}/${trust.threshold}) verified ${trust.verifiedAt}`;
 }
 
 function shouldFailPinnedMarketplaceRefresh(params: {
@@ -778,6 +806,9 @@ export async function runPluginMarketplaceEntriesCommand(
   if (summary.snapshot?.savedAt) {
     lines.push(theme.muted("Snapshot:") + " " + summary.snapshot.savedAt);
   }
+  if (summary.trust) {
+    lines.push(theme.muted("Trust:") + " " + formatMarketplaceFeedTrust(summary.trust));
+  }
   if (summary.error) {
     lines.push(theme.muted("Fallback reason:") + " " + summary.error);
   }
@@ -844,6 +875,9 @@ export async function runPluginMarketplaceRefreshCommand(
   }
   if (payload.snapshot?.savedAt) {
     lines.push(`${theme.muted("Snapshot:")} ${payload.snapshot.savedAt}`);
+  }
+  if (payload.trust) {
+    lines.push(`${theme.muted("Trust:")} ${formatMarketplaceFeedTrust(payload.trust)}`);
   }
   if (payload.error) {
     lines.push(`${theme.muted("Fallback reason:")} ${payload.error}`);


### PR DESCRIPTION
## Summary

- show verified hosted feed trust state in `plugins marketplace refresh --json` and `plugins marketplace entries --json`
- print a bounded `Trust:` line in text output for hosted live and hosted snapshot results
- add bounded diagnostics attributes for signed feed verification without emitting signing key ids, raw URLs, checksums, or signing material

## Stack

- Stacked after #98338 (`feeds-trust-refresh-state`).
- This head is `1a0102e1ea`, rebased onto #98338 head `231292f3cee`, #98316 head `09734e867b`, and #98299 head `297003b252c`.
- This PR intentionally targets `main` while dependency branches are on the fork; review should focus on the top CLI visibility commit until the predecessors land.

## Real behavior proof

Behavior or issue addressed:
Signed hosted marketplace refresh state is verified and persisted by the previous slice, and this PR exposes that bounded trust state from the marketplace CLI JSON/text output while diagnostics expose only low-cardinality verification facts.

Real environment tested:
Windows checkout at `C:\src\openclaw-feeds-trust-cli-visibility`, source-level CLI runtime tests with mocked marketplace loader results for verified live hosted and verified hosted-snapshot responses, plus the rebased signed envelope/config tests from the fixed trust stack.

Exact steps or command run after this patch:
1. `node scripts/run-vitest.mjs src/cli/plugins-cli.marketplace-refresh.test.ts src/cli/plugins-cli.marketplace-entries.test.ts src/plugins/official-external-plugin-catalog-envelope.test.ts src/config/zod-schema.marketplaces.test.ts`
2. `pnpm exec oxlint --deny-warnings src/cli/plugins-cli.runtime.ts src/cli/plugins-cli.marketplace-refresh.test.ts src/cli/plugins-cli.marketplace-entries.test.ts`
3. `pnpm exec oxfmt --check src/cli/plugins-cli.runtime.ts src/cli/plugins-cli.marketplace-refresh.test.ts src/cli/plugins-cli.marketplace-entries.test.ts`
4. `pnpm tsgo:core`
5. `pnpm db:kysely:check`
6. `git diff --check`
7. `codex review --base fork/feeds-trust-refresh-state` - clean after verifier hardening

Evidence after fix:
Focused Vitest output covered four files and passed the envelope, config, marketplace-refresh CLI, and marketplace-entries CLI suites. Targeted lint, targeted format, TypeScript, Kysely type generation verification, whitespace checks, and Codex review completed without findings.

Observed result after fix:
`plugins marketplace refresh` and `plugins marketplace entries` include a bounded signed-feed trust object in JSON and print `Trust: signed by <key-id> (<signature-count>/<threshold>) verified <timestamp>` in text output. Diagnostics emit `feedTrustVerified`, `feedTrustMode`, `feedTrustSignatureCount`, and `feedTrustThreshold`, and tests assert diagnostics do not include the signing key id, raw feed host, feed id, checksum, URL credentials, token query string, or override token.

What was not tested:
No live ClawHub signed feed was available for this CLI-only slice. The previous stack slice covers signed refresh verification and signed snapshot re-verification; this PR covers the CLI/runtime rendering contract for that already-verified trust object.

## Validation

```text
> node scripts/run-vitest.mjs src/cli/plugins-cli.marketplace-entries.test.ts src/cli/plugins-cli.marketplace-refresh.test.ts src/config/zod-schema.marketplaces.test.ts src/plugins/official-external-plugin-catalog.test.ts src/plugins/official-external-plugin-catalog-envelope.test.ts src/state/openclaw-state-db.test.ts --reporter=dot
Test Files 6 passed (6)
Tests 118 passed (118)
[test] passed 5 Vitest shards

> npx oxfmt --check <touched source/test files>
All matched files use the correct format.

> npx oxlint <touched source/test files>
Found 0 warnings and 0 errors.

> git diff --check origin/main...HEAD && git diff --check
PASS

> pnpm tsgo:core
PASS

> node scripts/plugin-sdk-surface-report.mjs --check
PASS

> pnpm db:kysely:check
PASS
```
