### PR TITLE
fix: guard JSON.parse calls against malformed external responses

### DIFF
--- a/extensions/openrouter/music-generation-provider.test.ts
+++ b/extensions/openrouter/music-generation-provider.test.ts
@@ -286,6 +286,28 @@ describe("openrouter music generation provider", () => {
     );
   });
 
+  it("skips malformed SSE data lines without crashing", async () => {
+    const audioBase64 = Buffer.from("wav-bytes").toString("base64");
+    postJsonRequestMock.mockResolvedValue({
+      response: sseResponse([
+        `data: {not valid json either}\n`,
+        `data: ${JSON.stringify({ choices: [{ delta: { audio: { data: audioBase64 } } }] })}\n`,
+        "data: [DONE]\n",
+      ]),
+      release: vi.fn(async () => {}),
+    });
+
+    const result = await buildOpenRouterMusicGenerationProvider().generateMusic({
+      provider: "openrouter",
+      model: "google/lyria-3-pro-preview",
+      prompt: "handle malformed sse",
+      cfg: {},
+    });
+
+    // Valid audio after the malformed line should still be processed
+    expect(result.tracks[0]?.buffer).toEqual(Buffer.from("wav-bytes"));
+  });
+
   it("times out stalled OpenRouter audio streams after headers", async () => {
     postJsonRequestMock.mockResolvedValue({
       response: stalledSseResponse(

--- a/extensions/openrouter/music-generation-provider.ts
+++ b/extensions/openrouter/music-generation-provider.ts
@@ -125,7 +125,13 @@ function processOpenRouterSseLine(
   if (data === "[DONE]") {
     return true;
   }
-  const audio = readDeltaAudio(JSON.parse(data));
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(data);
+  } catch {
+    return false;
+  }
+  const audio = readDeltaAudio(parsed);
   if (audio?.data) {
     result.audioBuffers.push(Buffer.from(audio.data, "base64"));
   }

--- a/src/agents/cli-runner/bundle-mcp-claude.ts
+++ b/src/agents/cli-runner/bundle-mcp-claude.ts
@@ -51,7 +51,12 @@ export async function writeClaudeMcpCaptureConfig(params: {
   mcpConfigPath: string;
   captureKey: string;
 }): Promise<void> {
-  const raw = JSON.parse(await fs.readFile(params.mcpConfigPath, "utf-8")) as unknown;
+  let raw: unknown;
+  try {
+    raw = JSON.parse(await fs.readFile(params.mcpConfigPath, "utf-8"));
+  } catch {
+    throw new Error(`Claude MCP config at ${params.mcpConfigPath} is not valid JSON`);
+  }
   if (!isRecord(raw)) {
     throw new Error("Claude MCP capture requires an object config");
   }

--- a/src/agents/cli-runner/bundle-mcp-claude.ts
+++ b/src/agents/cli-runner/bundle-mcp-claude.ts
@@ -51,9 +51,10 @@ export async function writeClaudeMcpCaptureConfig(params: {
   mcpConfigPath: string;
   captureKey: string;
 }): Promise<void> {
+  const content = await fs.readFile(params.mcpConfigPath, "utf-8");
   let raw: unknown;
   try {
-    raw = JSON.parse(await fs.readFile(params.mcpConfigPath, "utf-8"));
+    raw = JSON.parse(content);
   } catch {
     throw new Error(`Claude MCP config at ${params.mcpConfigPath} is not valid JSON`);
   }

--- a/src/commands/docs.test.ts
+++ b/src/commands/docs.test.ts
@@ -95,6 +95,22 @@ describe("docsSearchCommand", () => {
     expect(runtime.log).toHaveBeenCalled();
   });
 
+  it("handles malformed JSON from docs search API gracefully", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response("not json at all", {
+        status: 200,
+        headers: { "Content-Type": "text/plain" },
+      }),
+    );
+    const runtime = makeRuntime();
+
+    await docsSearchCommand(["plugin", "allowlist"], runtime);
+
+    expect(runtime.error).not.toHaveBeenCalled();
+    expect(runtime.exit).not.toHaveBeenCalled();
+    expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining("No results"));
+  });
+
   it("rejects oversized docs search responses", async () => {
     const ONE_MIB = 1024 * 1024;
     const cancel = vi.fn();

--- a/src/commands/docs.test.ts
+++ b/src/commands/docs.test.ts
@@ -95,7 +95,7 @@ describe("docsSearchCommand", () => {
     expect(runtime.log).toHaveBeenCalled();
   });
 
-  it("handles malformed JSON from docs search API gracefully", async () => {
+  it("reports malformed JSON from docs search API as an error", async () => {
     fetchMock.mockResolvedValueOnce(
       new Response("not json at all", {
         status: 200,
@@ -106,9 +106,8 @@ describe("docsSearchCommand", () => {
 
     await docsSearchCommand(["plugin", "allowlist"], runtime);
 
-    expect(runtime.error).not.toHaveBeenCalled();
-    expect(runtime.exit).not.toHaveBeenCalled();
-    expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining("No results"));
+    expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("invalid response"));
+    expect(runtime.exit).toHaveBeenCalledWith(1);
   });
 
   it("rejects oversized docs search responses", async () => {

--- a/src/commands/docs.ts
+++ b/src/commands/docs.ts
@@ -80,7 +80,12 @@ async function fetchDocsSearch(query: string): Promise<DocResult[]> {
     const bytes = await readResponseWithLimit(response, DOCS_SEARCH_RESPONSE_MAX_BYTES, {
       onOverflow: ({ maxBytes }) => new Error(`Docs search response exceeds ${maxBytes} bytes`),
     });
-    const payload = JSON.parse(new TextDecoder().decode(bytes)) as DocsSearchResponse;
+    let payload: DocsSearchResponse;
+    try {
+      payload = JSON.parse(new TextDecoder().decode(bytes)) as DocsSearchResponse;
+    } catch {
+      return [];
+    }
     return parseDocsSearchResults(payload.results);
   } finally {
     clearTimeout(timeout);

--- a/src/commands/docs.ts
+++ b/src/commands/docs.ts
@@ -84,7 +84,7 @@ async function fetchDocsSearch(query: string): Promise<DocResult[]> {
     try {
       payload = JSON.parse(new TextDecoder().decode(bytes)) as DocsSearchResponse;
     } catch {
-      return [];
+      throw new Error("Docs search returned an invalid response");
     }
     return parseDocsSearchResults(payload.results);
   } finally {


### PR DESCRIPTION
## What Problem This Solves

Fixes crashes when external data sources return malformed JSON in three locations:

1. **Docs search** — malformed API response causes unhandled `SyntaxError` in `fetchDocsSearch()` (try/finally without catch).
2. **OpenRouter music generation** — malformed SSE event data during audio streaming crashes `processOpenRouterSseLine()`.
3. **Claude MCP config** — corrupted/invalid MCP config file throws unhandled `SyntaxError` in `writeClaudeMcpCaptureConfig()`.

## Why This Change Was Made

Each `JSON.parse()` processes data from an external or user-controlled source. The existing code assumed input would always be valid JSON. The fix wraps each parse in try/catch with descriptive error messages, preserves the documented CLI failure path (exit 1) for docs search, and separates filesystem errors from parse errors for MCP config.

## User Impact

- **Docs search**: malformed API response → clear `"invalid response"` error + `exit(1)`. Normal searches unaffected.
- **OpenRouter music generation**: transient SSE glitch → malformed line skipped, stream continues, valid audio decoded normally.
- **Claude MCP config**: corrupted file → `"Claude MCP config at <path> is not valid JSON"`; missing file → original `ENOENT` preserved (catch only wraps `JSON.parse`).

## Evidence

### Before/After comparison (real terminal output)

```
╔══════════════════════════════════════════════════════╗
║  JSON.parse defensive hardening — Before/After      ║
╚══════════════════════════════════════════════════════╝

 Scenario 1: Docs Search — malformed API response "not json at all"

   Before: raw JSON.parse
   SyntaxError — Unexpected token 'o', "not json at all" is not valid JSON
   Uncaught exception propagates to caller

   After: try/catch + descriptive error
   Docs search returned an invalid response
   Error path preserved → runtime.error() + exit(1)

 Scenario 2: OpenRouter SSE — malformed stream data
   SSE stream: data: {not valid json either}
               data: {"choices":[{"delta":{"audio":{"data":"d2F2LWJ5dGVz"}}}]}
               data: [DONE]

   Before: raw JSON.parse
   SyntaxError on line 1 — audio generation aborted, valid data lost

   After: try/catch + skip
   Line 1 (invalid JSON) → skipped, stream continues
   Line 2 (valid audio) → decoded successfully
   Line 3 ([DONE]) → stream completes normally
   Result: 1 audio chunk "wav-bytes"

 Scenario 3: Claude MCP Config

   3A: Missing file
   [ENOENT] ENOENT — filesystem error preserved
   catch only wraps JSON.parse, does not mask readFile errors

   3B: Corrupted file
   Before: SyntaxError — Expected property name or '}'
   After: Claude MCP config at <path> is not valid JSON

   3C: Valid config
   capture key written successfully
   x-openclaw-cli-capture-key: test-key-123
```

### Real CLI — docs search

```
$ pnpm openclaw docs "plugin"
# Docs search: plugin — 12 results from live API

$ pnpm openclaw docs "xyznonexistent12345"
# Docs search: xyznonexistent12345
_No results._
```

### Unit tests

```
$ pnpm test src/commands/docs.test.ts --reporter=verbose
 ✓ reports malformed JSON from docs search API as an error (1ms)
 ✓ fails loudly when the Cloudflare docs search API fails (3ms)
 ✓ rejects oversized docs search responses (9ms)
 Test Files  1 passed (1), Tests 5 passed (5)

$ pnpm test extensions/openrouter/music-generation-provider.test.ts --reporter=verbose
 ✓ skips malformed SSE data lines without crashing (1ms)
 ✓ streams OpenRouter audio chunks into a generated music asset (15ms)
 Test Files  1 passed (1), Tests 9 passed (9)
```

### Negative controls

- Docs search HTTP 503 test still triggers the same `runtime.error` + `exit(1)` path — unchanged
- OpenRouter streams ending without `[DONE]` still reject with original error — unchanged
- All existing bundle MCP tests for valid config injection pass — unchanged

### Build

```
$ pnpm build
✓ built successfully — 0 errors
```

## Real environment

| Key | Value |
|-----|-------|
| OS | Linux 4.19.112 (x86_64, el8) |
| Node | v22.19.0 |
| Build | OpenClaw 2026.6.11 (commit 70e51e8) |
| CLI | `pnpm openclaw` (source checkout) |

## Files changed

| File | Change |
|------|--------|
| `src/commands/docs.ts` | Wrap JSON.parse in try/catch → throw descriptive error (preserves exit(1)) |
| `src/commands/docs.test.ts` | Regression test for malformed API response |
| `extensions/openrouter/music-generation-provider.ts` | Wrap SSE JSON.parse in try/catch → skip malformed line |
| `extensions/openrouter/music-generation-provider.test.ts` | Regression test for malformed SSE line |
| `src/agents/cli-runner/bundle-mcp-claude.ts` | Separate `fs.readFile` from `JSON.parse`; filesystem errors preserved |

## Notes

- **OpenRouter overlap**: This PR's OpenRouter music-generation hunk overlaps with #98047. Maintainers should pick one canonical branch before landing duplicate provider changes.
- **AI-assisted**: yes (Claude Code).