### PR TITLE
fix(ios): open app on Chat by default

### DIFF
--- a/apps/ios/Sources/RootTabs.swift
+++ b/apps/ios/Sources/RootTabs.swift
@@ -47,16 +47,21 @@ struct RootTabs: View {
     @State private var suppressedExecApprovalPromptIDForNotificationSettings: String?
 
     private static var initialTab: AppTab {
-        let arguments = ProcessInfo.processInfo.arguments
+        Self.initialTab(arguments: ProcessInfo.processInfo.arguments)
+    }
+
+    static func initialTab(arguments: [String]) -> AppTab {
         guard let flagIndex = arguments.firstIndex(of: "--openclaw-initial-tab") else {
-            return .control
+            return self.fallbackInitialTab(arguments: arguments)
         }
         let valueIndex = arguments.index(after: flagIndex)
         guard arguments.indices.contains(valueIndex) else {
-            return .control
+            return Self.fallbackInitialTab(arguments: arguments)
         }
 
         switch arguments[valueIndex].lowercased() {
+        case "control", "overview":
+            return .control
         case "chat":
             return .chat
         case "talk", "voice":
@@ -66,8 +71,12 @@ struct RootTabs: View {
         case "settings":
             return .settings
         default:
-            return .control
+            return Self.fallbackInitialTab(arguments: arguments)
         }
+    }
+
+    private static func fallbackInitialTab(arguments: [String]) -> AppTab {
+        self.requestedInitialSidebarDestination(arguments: arguments)?.appTab ?? .chat
     }
 
     private static var initialSidebarDestination: SidebarDestination {
@@ -78,7 +87,10 @@ struct RootTabs: View {
     }
 
     private static var requestedInitialSidebarDestination: SidebarDestination? {
-        let arguments = ProcessInfo.processInfo.arguments
+        Self.requestedInitialSidebarDestination(arguments: ProcessInfo.processInfo.arguments)
+    }
+
+    static func requestedInitialSidebarDestination(arguments: [String]) -> SidebarDestination? {
         guard let flagIndex = arguments.firstIndex(of: "--openclaw-initial-destination") else {
             return nil
         }
@@ -139,14 +151,6 @@ struct RootTabs: View {
 
     private var phoneTabContent: some View {
         TabView(selection: self.$selectedTab) {
-            RootTabsPhoneControlHub(
-                groups: Self.phoneControlGroups,
-                initialDestination: Self.requestedInitialSidebarDestination,
-                openRootDestination: { self.selectSidebarDestination($0) })
-                .tabItem { Label("Control", systemImage: "square.grid.2x2") }
-                .badge(self.appModel.pendingExecApprovalPrompt == nil ? 0 : 1)
-                .tag(AppTab.control)
-
             ChatProTab(openSettings: { self.selectSidebarDestination(.gateway) })
                 .tabItem { Label("Chat", systemImage: "bubble.left.fill") }
                 .tag(AppTab.chat)
@@ -158,6 +162,14 @@ struct RootTabs: View {
                         systemImage: self.appModel.talkMode.isEnabled ? "waveform.circle.fill" : "waveform.circle")
                 }
                 .tag(AppTab.talk)
+
+            RootTabsPhoneControlHub(
+                groups: Self.phoneControlGroups,
+                initialDestination: Self.requestedInitialSidebarDestination,
+                openRootDestination: { self.selectSidebarDestination($0) })
+                .tabItem { Label("Control", systemImage: "square.grid.2x2") }
+                .badge(self.appModel.pendingExecApprovalPrompt == nil ? 0 : 1)
+                .tag(AppTab.control)
 
             NavigationStack {
                 AgentProTab(

--- a/apps/ios/Tests/RootTabsPresentationTests.swift
+++ b/apps/ios/Tests/RootTabsPresentationTests.swift
@@ -128,10 +128,41 @@ import UIKit
         #expect(RootTabs.shouldOpenRootTabFromPhoneHub(.settings))
 
         for destination in RootTabs.SidebarDestination.allCases
-            where destination != .chat && destination != .talk && destination != .agents && destination != .gateway && destination != .settings
+            where destination != .chat && destination != .talk && destination != .agents && destination != .gateway &&
+            destination != .settings
         {
             #expect(!RootTabs.shouldOpenRootTabFromPhoneHub(destination))
         }
+    }
+
+    @Test func appLaunchDefaultsToChatTab() {
+        #expect(RootTabs.initialTab(arguments: ["OpenClaw"]) == .chat)
+        #expect(RootTabs.initialTab(arguments: ["OpenClaw", "--openclaw-initial-tab"]) == .chat)
+        #expect(RootTabs.initialTab(arguments: ["OpenClaw", "--openclaw-initial-tab", "unknown"]) == .chat)
+    }
+
+    @Test func appLaunchUsesRequestedDestinationBeforeChatFallback() {
+        #expect(RootTabs.initialTab(arguments: ["OpenClaw", "--openclaw-initial-destination", "overview"]) == .control)
+        #expect(RootTabs.initialTab(arguments: ["OpenClaw", "--openclaw-initial-destination", "chat"]) == .chat)
+        #expect(RootTabs.initialTab(arguments: ["OpenClaw", "--openclaw-initial-destination", "agents"]) == .agent)
+        #expect(RootTabs.initialTab(arguments: ["OpenClaw", "--openclaw-initial-destination", "gateway"]) == .settings)
+        #expect(
+            RootTabs.initialTab(arguments: [
+                "OpenClaw",
+                "--openclaw-initial-tab",
+                "unknown",
+                "--openclaw-initial-destination",
+                "activity",
+            ]) == .control)
+    }
+
+    @Test func appLaunchRespectsExplicitInitialTabOverride() {
+        #expect(RootTabs.initialTab(arguments: ["OpenClaw", "--openclaw-initial-tab", "control"]) == .control)
+        #expect(RootTabs.initialTab(arguments: ["OpenClaw", "--openclaw-initial-tab", "overview"]) == .control)
+        #expect(RootTabs.initialTab(arguments: ["OpenClaw", "--openclaw-initial-tab", "chat"]) == .chat)
+        #expect(RootTabs.initialTab(arguments: ["OpenClaw", "--openclaw-initial-tab", "voice"]) == .talk)
+        #expect(RootTabs.initialTab(arguments: ["OpenClaw", "--openclaw-initial-tab", "agents"]) == .agent)
+        #expect(RootTabs.initialTab(arguments: ["OpenClaw", "--openclaw-initial-tab", "settings"]) == .settings)
     }
 
     @Test func legacyInitialTabsMapToMatchingSidebarDestinations() {

--- a/apps/ios/Tests/RootTabsSourceGuardTests.swift
+++ b/apps/ios/Tests/RootTabsSourceGuardTests.swift
@@ -67,6 +67,25 @@ struct RootTabsSourceGuardTests {
         #expect(!drawerContent.contains("NavigationSplitView"))
     }
 
+    @Test func `phone tab bar keeps chat first product order`() throws {
+        let source = try String(contentsOf: Self.rootTabsSourceURL(), encoding: .utf8)
+        let phoneTabContent = try Self.extract(
+            source,
+            from: "private var phoneTabContent: some View",
+            to: "private var sidebarSplitContent: some View")
+
+        let chatRange = try #require(phoneTabContent.range(of: "ChatProTab(openSettings:"))
+        let talkRange = try #require(phoneTabContent.range(of: "TalkProTab(openSettings:"))
+        let controlRange = try #require(phoneTabContent.range(of: "RootTabsPhoneControlHub("))
+        let agentRange = try #require(phoneTabContent.range(of: "AgentProTab("))
+        let settingsRange = try #require(phoneTabContent.range(of: "SettingsProTab("))
+
+        #expect(chatRange.lowerBound < talkRange.lowerBound)
+        #expect(talkRange.lowerBound < controlRange.lowerBound)
+        #expect(controlRange.lowerBound < agentRange.lowerBound)
+        #expect(agentRange.lowerBound < settingsRange.lowerBound)
+    }
+
     @Test func `sidebar keeps navigation model destination only`() throws {
         let source = try String(contentsOf: Self.rootTabsSourceURL(), encoding: .utf8)
         let navigationSource = try String(contentsOf: Self.rootTabsNavigationSourceURL(), encoding: .utf8)
@@ -618,7 +637,8 @@ struct RootTabsSourceGuardTests {
         #expect(actionsSource.contains("self.gatewayController.refreshActiveGatewayRegistrationFromSettings()"))
         #expect(actionsSource.contains("self.gatewayController.restartDiscovery()"))
         #expect(actionsSource.contains("await self.appModel.refreshGatewayOverviewIfConnected()"))
-        #expect(actionsSource.contains("self.gatewayController.requestLocalNetworkAccess(reason: \"settings_preflight\")"))
+        #expect(actionsSource
+            .contains("self.gatewayController.requestLocalNetworkAccess(reason: \"settings_preflight\")"))
         #expect(actionsSource.contains("await TCPProbe.probe(host: trimmed, port: port"))
         #expect(actionsSource.contains("Check Tailscale or LAN."))
         #expect(actionsSource.contains("Tailscale is off on this device. Turn it on, then try again."))
@@ -658,7 +678,8 @@ struct RootTabsSourceGuardTests {
 
         #expect(onboardingSource.contains("self.requestLocalNetworkAccess(reason: \"onboarding_continue\")"))
         #expect(onboardingSource.contains("self.requestLocalNetworkAccessIfPastIntro(reason: \"onboarding_appear\")"))
-        #expect(actionsSource.contains("self.gatewayController.requestLocalNetworkAccess(reason: \"settings_preflight\")"))
+        #expect(actionsSource
+            .contains("self.gatewayController.requestLocalNetworkAccess(reason: \"settings_preflight\")"))
     }
 
     @Test func `gateway settings preview matrix covers primary states`() throws {


### PR DESCRIPTION
## What Problem This Solves

The iOS app currently opens on the Control tab by default, even though the first-use product moment should lead with the familiar assistant chat surface.

## Why This Change Was Made

Opening directly to Chat makes the app feel more like a modern AI assistant while keeping Talk, Control, Agent, and Settings available from the tab bar. Explicit launch overrides still work, destination-only launches now derive the correct initial tab before falling back to Chat, and the iPhone tab bar order now matches the Chat-first product direction.

## User Impact

Users land on the Chat tab on a normal app launch instead of the Control hub. On iPhone, the bottom bar now reads Chat, Talk, Control, Agent, Settings so the visual order matches the default selection. Existing screenshot and destination launch flows can still request Control, Settings, Agent, Talk, or nested Control destinations explicitly.

## Evidence

- `swiftformat --config config/swiftformat apps/ios/Sources/RootTabs.swift apps/ios/Tests/RootTabsSourceGuardTests.swift`
- `git diff --check`
- XcodeBuildMCP `test_sim` on `OpenClaw` scheme with `-only-testing:OpenClawTests/RootTabsPresentationTests` and `-only-testing:OpenClawTests/RootTabsSourceGuardTests`: 77 passed, 0 failed
- XcodeBuildMCP `build_run_sim` on iPhone 17 Pro simulator: build and launch succeeded
- XcodeBuildMCP runtime proof: no-argument launch reported bottom tabs in order `Chat|1`, `Talk|0`, `Control|0`, `Agent|0`, `Settings|0`
- Previous XcodeBuildMCP runtime proof: after dismissing the gateway setup sheet, the visible root showed the Chat tab selected with the chat composer
- `codex review --base origin/main` found a destination-only launch regression; this PR now covers that case by deriving the initial tab from `--openclaw-initial-destination` before falling back to Chat
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`: clean, no accepted/actionable findings

## AI Assistance

AI-assisted with Codex. I reviewed the changed code and validation output before opening this PR.