### PR TITLE
fix(infra): guard delivery queue inflate against corrupted entry_json

### DIFF
--- a/src/infra/delivery-queue-sqlite.test.ts
+++ b/src/infra/delivery-queue-sqlite.test.ts
@@ -1,0 +1,162 @@
+// Validates SQLite delivery queue inflate guards against corrupted entry_json.
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { openOpenClawStateDatabase } from "../state/openclaw-state-db.js";
+import {
+  deleteDeliveryQueueEntry,
+  loadDeliveryQueueEntries,
+  loadDeliveryQueueEntry,
+  moveDeliveryQueueEntryToFailed,
+  updateDeliveryQueueEntry,
+  upsertDeliveryQueueEntry,
+} from "./delivery-queue-sqlite.js";
+import { resolvePreferredOpenClawTmpDir } from "./tmp-openclaw-dir.js";
+
+describe("delivery-queue-sqlite corrupt JSON resilience", () => {
+  let stateDir: string;
+  let tmpDir: string;
+  const QUEUE = "test-q";
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(resolvePreferredOpenClawTmpDir(), "openclaw-dq-case-"));
+    stateDir = path.join(tmpDir, "state");
+    fs.mkdirSync(stateDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function insertCorruptRow(id: string, json: string) {
+    const { db } = openOpenClawStateDatabase({
+      env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+    });
+    db.prepare(
+      `INSERT INTO delivery_queue_entries
+         (queue_name, id, status, entry_kind, session_key, channel, target, account_id,
+          retry_count, last_attempt_at, last_error, platform_send_started_at, recovery_state,
+          entry_json, enqueued_at, updated_at, failed_at)
+       VALUES (?, ?, 'pending', NULL, NULL, NULL, NULL, NULL,
+               0, NULL, NULL, NULL, NULL, ?, ?, ?, NULL)`,
+    ).run(QUEUE, id, json, Date.now(), Date.now());
+    db.close();
+  }
+
+  function enqueueValid(id: string) {
+    upsertDeliveryQueueEntry({
+      queueName: QUEUE,
+      entry: { id, enqueuedAt: Date.now(), retryCount: 0 },
+      stateDir,
+    });
+  }
+
+  describe("loadDeliveryQueueEntry", () => {
+    it("returns null for a row with corrupted entry_json", () => {
+      insertCorruptRow("bad-1", "{corrupt: true, >>>NOT JSON<<<");
+      expect(loadDeliveryQueueEntry(QUEUE, "bad-1", stateDir)).toBeNull();
+    });
+
+    it("returns the entry for valid JSON", () => {
+      enqueueValid("good-1");
+      const result = loadDeliveryQueueEntry(QUEUE, "good-1", stateDir);
+      expect(result).not.toBeNull();
+      expect(result!.id).toBe("good-1");
+    });
+
+    it("returns null for a nonexistent entry", () => {
+      expect(loadDeliveryQueueEntry(QUEUE, "nonexistent", stateDir)).toBeNull();
+    });
+  });
+
+  describe("loadDeliveryQueueEntries", () => {
+    it("skips corrupt rows, returns only valid entries", () => {
+      enqueueValid("valid-a");
+      insertCorruptRow("bad-x", "{{{broken");
+      enqueueValid("valid-b");
+
+      const entries = loadDeliveryQueueEntries(QUEUE, stateDir);
+      expect(entries).toHaveLength(2);
+      expect(entries.map((e) => e.id).sort()).toEqual(["valid-a", "valid-b"]);
+    });
+
+    it("returns empty array when all rows are corrupt", () => {
+      insertCorruptRow("bad-1", "not json");
+      insertCorruptRow("bad-2", "{also broken");
+
+      expect(loadDeliveryQueueEntries(QUEUE, stateDir)).toEqual([]);
+    });
+
+    it("returns all entries when all rows are valid", () => {
+      enqueueValid("v1");
+      enqueueValid("v2");
+      enqueueValid("v3");
+
+      expect(loadDeliveryQueueEntries(QUEUE, stateDir)).toHaveLength(3);
+    });
+  });
+
+  describe("updateDeliveryQueueEntry with corrupt row", () => {
+    it("throws ENOENT (unrecoverable corrupt JSON)", () => {
+      insertCorruptRow("bad-update", "{corrupt");
+
+      expect(() => updateDeliveryQueueEntry(QUEUE, "bad-update", stateDir, (e) => e)).toThrow(
+        /No pending test-q delivery queue entry bad-update/,
+      );
+    });
+  });
+
+  describe("moveDeliveryQueueEntryToFailed with corrupt row", () => {
+    it("throws ENOENT (unrecoverable corrupt JSON)", () => {
+      insertCorruptRow("bad-move", "{corrupt");
+
+      expect(() => moveDeliveryQueueEntryToFailed(QUEUE, "bad-move", stateDir)).toThrow(
+        /No pending test-q delivery queue entry bad-move/,
+      );
+    });
+  });
+
+  describe("valid entry round-trips", () => {
+    it("upsert then load is identity", () => {
+      upsertDeliveryQueueEntry({
+        queueName: QUEUE,
+        entry: { id: "rt-1", enqueuedAt: 1000, retryCount: 0 },
+        stateDir,
+      });
+
+      const loaded = loadDeliveryQueueEntry(QUEUE, "rt-1", stateDir);
+      expect(loaded).toMatchObject({ id: "rt-1", enqueuedAt: 1000, retryCount: 0 });
+    });
+
+    it("update increments retry count", () => {
+      upsertDeliveryQueueEntry({
+        queueName: QUEUE,
+        entry: { id: "rt-2", enqueuedAt: 1000, retryCount: 0 },
+        stateDir,
+      });
+
+      updateDeliveryQueueEntry(QUEUE, "rt-2", stateDir, (entry) => ({
+        ...entry,
+        retryCount: entry.retryCount + 1,
+        lastError: "timeout",
+      }));
+
+      expect(loadDeliveryQueueEntry(QUEUE, "rt-2", stateDir)).toMatchObject({
+        id: "rt-2",
+        retryCount: 1,
+        lastError: "timeout",
+      });
+    });
+
+    it("delete removes the entry", () => {
+      upsertDeliveryQueueEntry({
+        queueName: QUEUE,
+        entry: { id: "rt-3", enqueuedAt: 1000, retryCount: 0 },
+        stateDir,
+      });
+
+      deleteDeliveryQueueEntry(QUEUE, "rt-3", stateDir);
+      expect(loadDeliveryQueueEntry(QUEUE, "rt-3", stateDir)).toBeNull();
+    });
+  });
+});

--- a/src/infra/delivery-queue-sqlite.test.ts
+++ b/src/infra/delivery-queue-sqlite.test.ts
@@ -77,7 +77,7 @@ describe("delivery-queue-sqlite corrupt JSON resilience", () => {
 
       const entries = loadDeliveryQueueEntries(QUEUE, stateDir);
       expect(entries).toHaveLength(2);
-      expect(entries.map((e) => e.id).sort()).toEqual(["valid-a", "valid-b"]);
+      expect(entries.map((e) => e.id).toSorted()).toEqual(["valid-a", "valid-b"]);
     });
 
     it("returns empty array when all rows are corrupt", () => {

--- a/src/infra/delivery-queue-sqlite.ts
+++ b/src/infra/delivery-queue-sqlite.ts
@@ -57,9 +57,15 @@ function enoent(queueName: string, id: string): Error & { code: string } {
   return err;
 }
 
-function inflate(row: QueueRow): DeliveryQueueEntryState {
+function inflate(row: QueueRow): DeliveryQueueEntryState | null {
+  let parsed: DeliveryQueueEntryState;
+  try {
+    parsed = JSON.parse(row.entry_json) as DeliveryQueueEntryState;
+  } catch {
+    return null;
+  }
   return {
-    ...(JSON.parse(row.entry_json) as DeliveryQueueEntryState),
+    ...parsed,
     id: row.id,
     enqueuedAt: Number(row.enqueued_at),
     retryCount: Number(row.retry_count),
@@ -205,7 +211,7 @@ export function loadDeliveryQueueEntries(
       .orderBy("enqueued_at", "asc")
       .orderBy("id", "asc"),
   ).rows as QueueRow[];
-  return rows.map(inflate);
+  return rows.map(inflate).filter((entry): entry is DeliveryQueueEntryState => entry != null);
 }
 
 /** Delete a pending delivery queue entry after successful delivery. */


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a single corrupted `entry_json` row in the SQLite delivery queue (session or outbound) crashes the entire pending-entry load, preventing delivery recovery from making progress. The `inflate()` helper calls `JSON.parse(row.entry_json)` without a try-catch — a corrupt row throws an uncaught `SyntaxError` that propagates through `loadDeliveryQueueEntry` (single load), `loadDeliveryQueueEntries` (batch load — one bad row kills **all** pending entries), `updateDeliveryQueueEntry`, and `moveDeliveryQueueEntryToFailed`. Callers in session-delivery recovery, outbound recovery, and the gateway restart sentinel do not catch this error, so a single corrupt SQLite row can block all queued delivery retries.

## Why This Change Was Made

Guard `inflate()` itself — the shared chokepoint through which all queue reads flow. On parse failure it returns `null`. `loadDeliveryQueueEntry` already returns `null` for a missing row, so corrupt rows are treated the same way (unrecoverable → not found). `loadDeliveryQueueEntries` filters out `null` inflate results, so one corrupt row no longer discards every other pending entry in the same queue. `updateDeliveryQueueEntry` and `moveDeliveryQueueEntryToFailed` now throw a clean `ENOENT` (via `loadDeliveryQueueEntry`) instead of a raw `SyntaxError`, consistent with how they behave when an entry is genuinely absent. No API surface changes.

## User Impact

No user-visible impact under normal operation. When `entry_json` is somehow corrupted (disk error, manual edit, partial write), delivery recovery now skips the bad entry instead of crashing. Recovery and gateway restart sentinel paths remain operational for the remaining valid entries.

## Real behavior proof

- **Behavior addressed:** a corrupt `entry_json` row in the SQLite `delivery_queue_entries` table must not crash delivery queue loads; the corrupt row should be treated as unrecoverable (null/skipped) while valid rows continue to load.
- **Real environment tested:** Linux, Node v22.22.0, local source checkout on branch `fix/delivery-queue-inflate-json-parse`, driving the **real exported** `loadDeliveryQueueEntry`, `loadDeliveryQueueEntries`, `updateDeliveryQueueEntry`, and `moveDeliveryQueueEntryToFailed` from `src/infra/delivery-queue-sqlite.ts` against a **real on-disk SQLite database** (`OPENCLAW_STATE_DIR`). Corrupt rows are inserted directly via raw SQL (same write path as `upsertDeliveryQueueEntry` uses internally) and read back through the real exported loaders across the SQLite disk boundary. 18 assertions covering 6 scenarios.
- **Evidence after fix:**

```text
=== Real behavior proof: delivery queue inflate corrupt JSON guards ===

[case 1] loadDeliveryQueueEntry: corrupt row returns null
  ok: valid row returns entry with correct id
  ok: valid row has retryCount
  ok: corrupt row returns null (not SyntaxError)
  ok: nonexistent row returns null

[case 2] loadDeliveryQueueEntries: skips corrupt, returns only valid
  ok: returns 2 valid entries (corrupt skipped)
  ok: valid ids: s-ok-1, s-ok-2 (s-bad excluded)
  ok: outbound: 1 valid entry (corrupt skipped)
  ok: outbound valid id: o-ok

[case 3] all-corrupt queue
  ok: all-corrupt → empty array (not crash)

[case 4] updateDeliveryQueueEntry: corrupt → ENOENT (not SyntaxError)
  ok: throws ENOENT for corrupt row
  ok: error code is ENOENT

[case 5] moveDeliveryQueueEntryToFailed: corrupt → ENOENT (not SyntaxError)
  ok: throws ENOENT for corrupt row

[case 6] SQLite disk readback: round-trip across real DB boundary
  ok: round-trip: enqueuedAt preserved
  ok: round-trip: retryCount preserved
  ok: round-trip: lastError preserved
  ok: round-trip: lastAttemptAt preserved
  ok: round-trip: platformSendStartedAt preserved
  ok: round-trip: recoveryState preserved

=== Summary ===
ALL PROOF ASSERTIONS: 18 passed, 0 failed
```

- **Negative control (pre-fix behavior reproduced):** reverting `src/infra/delivery-queue-sqlite.ts` to main (`4ac5cf8636`) and re-running the same proof harness crashes on case 1 with the uncaught `SyntaxError` — the corrupt row that returns `null` after the fix instead throws and aborts the entire batch:

```text
=== NEGATIVE CONTROL: main version of delivery-queue-sqlite.ts ===
[case 1] loadDeliveryQueueEntry: corrupt row returns null
  ok: valid row returns entry with correct id
  ok: valid row has retryCount

SyntaxError: Expected property name or '}' in JSON at position 1 (line 1 column 2)
    at JSON.parse (<anonymous>)
    at inflate (src/infra/delivery-queue-sqlite.ts:62:14)
    at loadDeliveryQueueEntry (src/infra/delivery-queue-sqlite.ts:179:16)

exit=1
```

The negative control is load-bearing: the **same proof harness, same corrupt rows, same disk boundary** crashes on main and passes 18/18 after the fix. Restoring the fix from the branch (`git checkout HEAD -- src/infra/delivery-queue-sqlite.ts`) and re-running returns to 18/18 green.

- **What was not tested:** a live gateway with real recovery loops processing corrupt entries end-to-end — no gateway was running. The proof drives the exact same exported SQLite loader functions that recovery uses (`loadDeliveryQueueEntry` ← `loadPendingDelivery`, `loadDeliveryQueueEntries` ← `loadPendingDeliveries` / `loadPendingSessionDeliveries`), against a real SQLite database across the disk boundary, which exercises the shared chokepoint.

## Evidence

**Regression tests (11 tests, all pass):**

```text
$ node scripts/run-vitest.mjs src/infra/delivery-queue-sqlite.test.ts --run
 Test Files  1 passed (1)
      Tests  11 passed (11)
```

Covers: corrupt single-row → null, corrupt-in-batch → skipped, all-corrupt-batch → empty array, update-with-corrupt → clean ENOENT, move-to-failed-with-corrupt → clean ENOENT, plus valid-entry round-trips (upsert/load, update, delete).

**Existing tests — no regressions:**

```text
$ node scripts/run-vitest.mjs src/infra/outbound/delivery-queue.storage.test.ts --run
 Test Files  1 passed (1)
      Tests  12 passed (12)

$ node scripts/run-vitest.mjs src/infra/session-delivery-queue.storage.test.ts --run
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

**Lint:** `oxlint` clean on both changed files.

AI-assisted.