### PR TITLE
fix(google-meet): bound JSON response reads to prevent OOM

### DIFF
--- a/extensions/google-meet/src/calendar.ts
+++ b/extensions/google-meet/src/calendar.ts
@@ -1,4 +1,5 @@
 // Google Meet plugin module implements calendar behavior.
+import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { googleApiError } from "./google-api-errors.js";
 
@@ -6,6 +7,7 @@ const GOOGLE_CALENDAR_API_BASE_URL = "https://www.googleapis.com/calendar/v3";
 const GOOGLE_CALENDAR_API_HOST = "www.googleapis.com";
 const GOOGLE_MEET_URL_HOST = "meet.google.com";
 const GOOGLE_CALENDAR_EVENTS_SCOPE = "https://www.googleapis.com/auth/calendar.events.readonly";
+const GOOGLE_CALENDAR_JSON_RESPONSE_MAX_BYTES = 4 * 1024 * 1024;
 
 type GoogleCalendarEventDate = {
   date?: string;
@@ -197,7 +199,13 @@ async function fetchGoogleCalendarEvents(params: {
         scopes: [GOOGLE_CALENDAR_EVENTS_SCOPE],
       });
     }
-    const payload = (await response.json()) as { items?: unknown };
+    const body = await readResponseWithLimit(response, GOOGLE_CALENDAR_JSON_RESPONSE_MAX_BYTES, {
+      onOverflow: ({ size, maxBytes }) =>
+        new Error(
+          `Google Calendar API response too large: ${size} bytes (limit: ${maxBytes} bytes)`,
+        ),
+    });
+    const payload = JSON.parse(body.toString("utf8")) as { items?: unknown };
     if (payload.items !== undefined && !Array.isArray(payload.items)) {
       throw new Error("Google Calendar events.list response had non-array items");
     }

--- a/extensions/google-meet/src/meet.ts
+++ b/extensions/google-meet/src/meet.ts
@@ -1,4 +1,5 @@
 // Google Meet plugin module implements meet behavior.
+import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { exportGoogleDriveDocumentText, extractGoogleDriveDocumentId } from "./drive.js";
@@ -13,6 +14,7 @@ const GOOGLE_MEET_MEDIA_SCOPE =
 const GOOGLE_MEET_SPACE_SCOPE = "https://www.googleapis.com/auth/meetings.space.readonly";
 const GOOGLE_MEET_SPACE_CREATED_SCOPE = "https://www.googleapis.com/auth/meetings.space.created";
 const GOOGLE_MEET_SPACE_SETTINGS_SCOPE = "https://www.googleapis.com/auth/meetings.space.settings";
+const GOOGLE_MEET_JSON_RESPONSE_MAX_BYTES = 4 * 1024 * 1024;
 
 export type GoogleMeetAccessType = "OPEN" | "TRUSTED" | "RESTRICTED";
 export type GoogleMeetEntryPointAccess = "ALL" | "CREATOR_APP_ONLY";
@@ -289,7 +291,13 @@ async function fetchGoogleMeetJson<T>(params: {
         scopes: [GOOGLE_MEET_MEDIA_SCOPE],
       });
     }
-    return (await response.json()) as T;
+    const body = await readResponseWithLimit(response, GOOGLE_MEET_JSON_RESPONSE_MAX_BYTES, {
+      onOverflow: ({ size, maxBytes }) =>
+        new Error(
+          `Google Meet API response too large: ${size} bytes (limit: ${maxBytes} bytes)`,
+        ),
+    });
+    return JSON.parse(body.toString("utf8")) as T;
   } finally {
     await release();
   }
@@ -354,7 +362,13 @@ export async function fetchGoogleMeetSpace(params: {
         scopes: [GOOGLE_MEET_SPACE_SCOPE],
       });
     }
-    const payload = (await response.json()) as GoogleMeetSpace;
+    const body = await readResponseWithLimit(response, GOOGLE_MEET_JSON_RESPONSE_MAX_BYTES, {
+      onOverflow: ({ size, maxBytes }) =>
+        new Error(
+          `Google Meet API response too large: ${size} bytes (limit: ${maxBytes} bytes)`,
+        ),
+    });
+    const payload = JSON.parse(body.toString("utf8")) as GoogleMeetSpace;
     if (!payload.name?.trim()) {
       throw new Error("Google Meet spaces.get response was missing name");
     }
@@ -397,7 +411,13 @@ export async function createGoogleMeetSpace(params: {
             : [GOOGLE_MEET_SPACE_CREATED_SCOPE],
       });
     }
-    const payload = (await response.json()) as GoogleMeetSpace;
+    const body = await readResponseWithLimit(response, GOOGLE_MEET_JSON_RESPONSE_MAX_BYTES, {
+      onOverflow: ({ size, maxBytes }) =>
+        new Error(
+          `Google Meet API response too large: ${size} bytes (limit: ${maxBytes} bytes)`,
+        ),
+    });
+    const payload = JSON.parse(body.toString("utf8")) as GoogleMeetSpace;
     if (!payload.name?.trim()) {
       throw new Error("Google Meet spaces.create response was missing name");
     }

--- a/extensions/google-meet/src/oauth.ts
+++ b/extensions/google-meet/src/oauth.ts
@@ -10,6 +10,7 @@ import {
   parseOAuthCallbackInput,
   waitForLocalOAuthCallback,
 } from "openclaw/plugin-sdk/provider-auth-runtime";
+import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { readGoogleApiErrorDetail } from "./google-api-errors.js";
 
@@ -18,6 +19,7 @@ const GOOGLE_MEET_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth";
 const GOOGLE_MEET_TOKEN_URL = "https://oauth2.googleapis.com/token";
 const GOOGLE_MEET_TOKEN_HOST = "oauth2.googleapis.com";
 const GOOGLE_MEET_DEFAULT_TOKEN_LIFETIME_SECONDS = 3600;
+const GOOGLE_MEET_OAUTH_JSON_RESPONSE_MAX_BYTES = 1 * 1024 * 1024;
 const GOOGLE_MEET_SCOPES = [
   "https://www.googleapis.com/auth/meetings.space.created",
   "https://www.googleapis.com/auth/meetings.space.readonly",
@@ -89,7 +91,13 @@ async function executeGoogleTokenRequest(body: URLSearchParams): Promise<GoogleM
       const detail = await readGoogleApiErrorDetail(response);
       throw new Error(`Google OAuth token request failed (${response.status}): ${detail}`);
     }
-    const payload = (await response.json()) as {
+    const body = await readResponseWithLimit(response, GOOGLE_MEET_OAUTH_JSON_RESPONSE_MAX_BYTES, {
+      onOverflow: ({ size, maxBytes }) =>
+        new Error(
+          `Google Meet OAuth token response too large: ${size} bytes (limit: ${maxBytes} bytes)`,
+        ),
+    });
+    const payload = JSON.parse(body.toString("utf8")) as {
       access_token?: string;
       expires_in?: number;
       refresh_token?: string;


### PR DESCRIPTION
## What Problem This Solves

`extensions/google-meet/src/meet.ts`, `oauth.ts`, and `calendar.ts` call raw `response.json()` without a byte cap on Google Meet API responses. The error paths already use bounded readers (`readGoogleApiErrorDetail`, `handleGoogleApiError`), but success paths can buffer arbitrarily large JSON bodies.

This completes the work started in #97693 (drive.ts bounded text reads) and #97620 (Google Drive export bounded reads) by protecting the remaining 5 JSON response sites in the google-meet extension.

## Changes

- `meet.ts`: 3 sites — `performMeetRequest` (generic helper, 4 MiB cap), `getSpace`, `createSpace`
- `oauth.ts`: 1 site — OAuth token exchange (1 MiB cap)
- `calendar.ts`: 1 site — `listCalendarEvents` (4 MiB cap)

All changes follow the same `readResponseWithLimit` pattern already used in `drive.ts` (same extension, merged in #97693).

Label: bugfix | merge-risk: 🟢 minimal | AI-assisted

## Evidence

### All existing tests pass

```
$ pnpm exec vitest run extensions/google-meet/

 Test Files  13 passed (13)
      Tests  178 passed (178)
```

The existing test infrastructure uses `fetchWithSsrFGuardMock` which provides `new Response()` objects compatible with `readResponseWithLimit`. The cap values (4 MiB for meet/calendar, 1 MiB for OAuth) are well above realistic Google Meet API response sizes.