### PR TITLE
fix(cron): keep provider-owned CLI sessions across the daily default reset

### DIFF
--- a/src/agents/command/session.provider-owned-reset.test.ts
+++ b/src/agents/command/session.provider-owned-reset.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import type { SessionEntry } from "../../config/sessions/types.js";
+
+const hoisted = vi.hoisted(() => ({
+  store: {} as Record<string, SessionEntry>,
+}));
+
+vi.mock("../../config/sessions/store-load.js", () => ({
+  loadSessionStore: () => hoisted.store,
+}));
+
+vi.mock("../../config/sessions/paths.js", () => ({
+  resolveStorePath: () => "/stores/main.json",
+}));
+
+const { resolveSession } = await import("./session.js");
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function seedProviderOwned(sessionKey: string): void {
+  const startedAt = Date.now() - DAY_MS;
+  hoisted.store = {
+    [sessionKey]: {
+      sessionId: "old-session-id",
+      updatedAt: startedAt,
+      sessionStartedAt: startedAt,
+      lastInteractionAt: startedAt,
+      model: "claude-opus-4-6",
+      modelProvider: "claude-cli",
+      cliSessionBindings: { "claude-cli": { sessionId: "cli-conversation-xyz" } },
+    },
+  };
+}
+
+describe("command resolveSession provider-owned daily reset", () => {
+  it("keeps a provider-owned CLI session across the default daily boundary", () => {
+    const sessionKey = "agent:main:cli";
+    seedProviderOwned(sessionKey);
+
+    const result = resolveSession({
+      cfg: { session: {} } as OpenClawConfig,
+      sessionKey,
+      agentId: "main",
+    });
+
+    expect(result.isNewSession).toBe(false);
+    expect(result.sessionId).toBe("old-session-id");
+  });
+
+  it("still rotates a non-provider-owned session across the daily boundary", () => {
+    const sessionKey = "agent:main:cli";
+    const startedAt = Date.now() - DAY_MS;
+    hoisted.store = {
+      [sessionKey]: {
+        sessionId: "old-session-id",
+        updatedAt: startedAt,
+        sessionStartedAt: startedAt,
+        lastInteractionAt: startedAt,
+      },
+    };
+
+    const result = resolveSession({
+      cfg: { session: {} } as OpenClawConfig,
+      sessionKey,
+      agentId: "main",
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.sessionId).not.toBe("old-session-id");
+  });
+});

--- a/src/agents/command/session.ts
+++ b/src/agents/command/session.ts
@@ -9,6 +9,7 @@ import {
   type ThinkLevel,
   type VerboseLevel,
 } from "../../auto-reply/thinking.js";
+import { hasProviderOwnedSession } from "../../config/sessions/entry-freshness.js";
 import {
   hasTerminalMainSessionTranscriptNewerThanRegistrySync,
   resolveSessionLifecycleTimestamps,
@@ -386,18 +387,21 @@ export function resolveSession(opts: {
           storePath,
         })
       : false;
+  const skipImplicitExpiry =
+    resetPolicy.configured !== true && hasProviderOwnedSession(sessionEntry);
   const fresh = sessionEntry
     ? !terminalMainTranscriptNewerThanRegistry &&
-      evaluateSessionFreshness({
-        updatedAt: sessionEntry.updatedAt,
-        ...resolveSessionLifecycleTimestamps({
-          entry: sessionEntry,
-          agentId: sessionAgentId,
-          storePath,
-        }),
-        now,
-        policy: resetPolicy,
-      }).fresh
+      (skipImplicitExpiry ||
+        evaluateSessionFreshness({
+          updatedAt: sessionEntry.updatedAt,
+          ...resolveSessionLifecycleTimestamps({
+            entry: sessionEntry,
+            agentId: sessionAgentId,
+            storePath,
+          }),
+          now,
+          policy: resetPolicy,
+        }).fresh)
     : false;
   const sessionId =
     requestedSessionId || (fresh ? sessionEntry?.sessionId : undefined) || crypto.randomUUID();

--- a/src/cron/isolated-agent/session.provider-owned-reset.test.ts
+++ b/src/cron/isolated-agent/session.provider-owned-reset.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { getCliSessionBinding } from "../../config/sessions/cli-session-binding.js";
+import type { SessionEntry } from "../../config/sessions/types.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resolveCronSession } from "./session.js";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const NOW_MS = 1_737_600_000_000;
+
+function providerOwnedEntry(): SessionEntry {
+  const startedAt = NOW_MS - DAY_MS;
+  return {
+    sessionId: "old-session-id",
+    updatedAt: startedAt,
+    sessionStartedAt: startedAt,
+    lastInteractionAt: startedAt,
+    model: "claude-opus-4-6",
+    modelProvider: "claude-cli",
+    cliSessionBindings: { "claude-cli": { sessionId: "cli-conversation-xyz" } },
+  };
+}
+
+describe("resolveCronSession provider-owned daily reset", () => {
+  it("keeps a provider-owned CLI session across the default daily boundary", () => {
+    const sessionKey = "agent:main:cron:daily-job";
+    const entry = providerOwnedEntry();
+
+    const result = resolveCronSession({
+      cfg: { session: {} } as OpenClawConfig,
+      sessionKey,
+      agentId: "main",
+      nowMs: NOW_MS,
+      forceNew: false,
+      store: { [sessionKey]: entry },
+    });
+
+    expect(result.isNewSession).toBe(false);
+    expect(result.sessionEntry.sessionId).toBe("old-session-id");
+    expect(getCliSessionBinding(result.sessionEntry, "claude-cli")).toEqual({
+      sessionId: "cli-conversation-xyz",
+    });
+  });
+
+  it("still rotates a non-provider-owned session across the daily boundary", () => {
+    const sessionKey = "agent:main:cron:daily-job";
+    const startedAt = NOW_MS - DAY_MS;
+    const entry: SessionEntry = {
+      sessionId: "old-session-id",
+      updatedAt: startedAt,
+      sessionStartedAt: startedAt,
+      lastInteractionAt: startedAt,
+    };
+
+    const result = resolveCronSession({
+      cfg: { session: {} } as OpenClawConfig,
+      sessionKey,
+      agentId: "main",
+      nowMs: NOW_MS,
+      forceNew: false,
+      store: { [sessionKey]: entry },
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.sessionEntry.sessionId).not.toBe("old-session-id");
+  });
+
+  it("still rotates a provider-owned session when reset is explicitly configured", () => {
+    const sessionKey = "agent:main:cron:daily-job";
+    const entry = providerOwnedEntry();
+
+    const result = resolveCronSession({
+      cfg: { session: { reset: { mode: "daily" } } } as OpenClawConfig,
+      sessionKey,
+      agentId: "main",
+      nowMs: NOW_MS,
+      forceNew: false,
+      store: { [sessionKey]: entry },
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.sessionEntry.sessionId).not.toBe("old-session-id");
+    expect(getCliSessionBinding(result.sessionEntry, "claude-cli")).toBeUndefined();
+  });
+});

--- a/src/cron/isolated-agent/session.ts
+++ b/src/cron/isolated-agent/session.ts
@@ -1,12 +1,14 @@
 /** Resolves session rollover and carried state for isolated cron runs. */
 import crypto from "node:crypto";
 import { clearBootstrapSnapshotOnSessionRollover } from "../../agents/bootstrap-cache.js";
+import { hasProviderOwnedSession } from "../../config/sessions/entry-freshness.js";
 import { resolveSessionLifecycleTimestamps } from "../../config/sessions/lifecycle.js";
 import { hasSessionAutoModelFallbackProvenance } from "../../config/sessions/model-override-provenance.js";
 import { resolveStorePath } from "../../config/sessions/paths.js";
 import {
   evaluateSessionFreshness,
   resolveSessionResetPolicy,
+  type SessionFreshness,
 } from "../../config/sessions/reset-policy.js";
 import { loadSessionStore } from "../../config/sessions/store-load.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
@@ -131,16 +133,19 @@ export function resolveCronSession(params: {
       sessionCfg,
       resetType: "direct",
     });
-    const freshness = evaluateSessionFreshness({
-      updatedAt: entry.updatedAt,
-      ...resolveSessionLifecycleTimestamps({
-        entry,
-        agentId: params.agentId,
-        storePath,
-      }),
-      now: params.nowMs,
-      policy: resetPolicy,
-    });
+    const skipImplicitExpiry = resetPolicy.configured !== true && hasProviderOwnedSession(entry);
+    const freshness = skipImplicitExpiry
+      ? ({ fresh: true } satisfies SessionFreshness)
+      : evaluateSessionFreshness({
+          updatedAt: entry.updatedAt,
+          ...resolveSessionLifecycleTimestamps({
+            entry,
+            agentId: params.agentId,
+            storePath,
+          }),
+          now: params.nowMs,
+          policy: resetPolicy,
+        });
 
     if (freshness.fresh) {
       sessionId = entry.sessionId;


### PR DESCRIPTION
## What Problem This Solves

The provider-owned CLI session exemption shipped for the gateway `agent.run` path in #97931 (merged as `d9aedc32a1`) was applied only to the two gateway freshness decision sites (`src/gateway/server-methods/agent.ts`, `src/config/sessions/entry-freshness.ts`). The scheduled isolated-agent cron path does not go through `agent.run`; it runs through `runCronIsolatedAgentTurn` -> `resolveCronSession` (`src/cron/isolated-agent/session.ts`), which still called `evaluateSessionFreshness` directly with no provider-owned guard.

As a result, a recurring cron job with a persistent session target on a CLI runtime (`claude-cli`, `codex`, `gemini-cli`) had its session rotated after the daily boundary under the default reset config. The rollover minted a new `sessionId` and, because `sanitizeFreshCronSessionEntry` does not carry `cliSessionBindings`, dropped the CLI binding and split the transcript. The cron agent silently lost its underlying CLI conversation every morning (default `atHour: 4`), with no memory of prior runs, and the user had no signal.

The local `openclaw` command resolver (`src/agents/command/session.ts` `resolveSession`) shared the identical gap.

## Why This Change Was Made

`#97931` documented the invariant that a provider-owned CLI session must survive the implicit daily/idle reset unless the operator configured a reset (or explicitly ran `session.reset` / `/reset`). The inbound auto-reply path (`src/auto-reply/reply/session.ts`) and the gateway path both honor it via `resetPolicy.configured !== true && hasProviderOwnedSession(entry)`. The two remaining non-gateway resolvers did not, so the exemption users rely on was not applied to scheduled or command-line turns.

## User Impact

Recurring cron jobs with persistent session targets, and local `openclaw agent` command runs, now preserve provider-owned CLI conversations across the implicit daily reset boundary. Behavior is unchanged when a reset is configured, when `session.reset` / `/reset` is invoked, or for non-provider-owned sessions; those still rotate. The command path additionally still rotates when the terminal main transcript is newer than the registry.

## Root cause

`src/cron/isolated-agent/session.ts` (before):

```ts
const freshness = evaluateSessionFreshness({
  updatedAt: entry.updatedAt,
  ...resolveSessionLifecycleTimestamps({ entry, agentId: params.agentId, storePath }),
  now: params.nowMs,
  policy: resetPolicy,
});
```

No `hasProviderOwnedSession` guard, unlike the inbound and (post-#97931) gateway paths. `resolveCronSession` is reached for persistent-target jobs via `src/gateway/server-cron.ts` -> `runCronIsolatedAgentTurn` -> `src/cron/isolated-agent/run.ts:648` `resolveCronSession({ forceNew: input.job.sessionTarget === "isolated" })`, where `forceNew` is `false`.

## Fix

`src/cron/isolated-agent/session.ts` (after):

```ts
const skipImplicitExpiry = resetPolicy.configured !== true && hasProviderOwnedSession(entry);
const freshness = skipImplicitExpiry
  ? ({ fresh: true } satisfies SessionFreshness)
  : evaluateSessionFreshness({
      updatedAt: entry.updatedAt,
      ...resolveSessionLifecycleTimestamps({ entry, agentId: params.agentId, storePath }),
      now: params.nowMs,
      policy: resetPolicy,
    });
```

The command resolver gets the same guard, kept subordinate to the terminal-main-transcript rotation so that signal still rotates:

```ts
const skipImplicitExpiry = resetPolicy.configured !== true && hasProviderOwnedSession(sessionEntry);
const fresh = sessionEntry
  ? !terminalMainTranscriptNewerThanRegistry &&
    (skipImplicitExpiry || evaluateSessionFreshness({ ... }).fresh)
  : false;
```

## Why this is the right boundary

`hasProviderOwnedSession` is the single shared predicate `#97931` exported for exactly this purpose. This change routes the two remaining non-gateway resolvers through it rather than adding a fourth copy, so all four session-admission surfaces (inbound, gateway, cron, command) now honor the same exemption. No new config, no runtime shim.

## Verification

- `node scripts/run-vitest.mjs src/cron/isolated-agent/session.provider-owned-reset.test.ts src/agents/command/session.provider-owned-reset.test.ts` - passes with the patch; the "keeps a provider-owned CLI session" case fails on pristine `origin/main` (4ac5cf8636) and passes after, in both files.
- `node scripts/run-vitest.mjs src/cron/isolated-agent/session.test.ts` - existing suite still green.
- `oxlint`, `oxfmt --check`, and `tsgo` (`tsconfig.core.json` + `tsconfig.core.test.json`) clean on the changed files.

## Real behavior proof
Behavior addressed: a scheduled provider-owned CLI cron session was rotated to a new sessionId and lost its claude-cli binding after crossing the daily default reset boundary.
Real environment tested: drove the real `resolveCronSession` (the function `runCronIsolatedAgentTurn` invokes at `run.ts:648`) against an on-disk `sessions.json` store, on pristine main 4ac5cf8636 and on the patched head fdbe84d686. The session store file read, the freshness evaluator, the reset-policy resolver, and the `hasProviderOwnedSession` predicate all stayed real; nothing was stubbed.
Exact steps or command run after this patch: wrote a `sessions.json` holding one `claude-cli` provider-owned entry (`model` set, `cliSessionBindings["claude-cli"]` present) whose `sessionStartedAt` predates the 04:00 daily boundary by 29 hours, pointed `session.store` at it with the default unconfigured reset config, then called `resolveCronSession({ forceNew: false })` and read back `isNewSession`, the resulting `sessionId`, and the reloaded `claude-cli` binding.
Evidence after fix:
```
# BEFORE (pristine main 4ac5cf8636)
isNewSession=true
sessionId=4a918a2f-563a-48e3-83b3-9668b56f7ae9
sessionIdChanged=true
claudeCliBinding=DROPPED
# AFTER (this patch, identical inputs)
isNewSession=false
sessionId=sess-2f9c1e
sessionIdChanged=false
claudeCliBinding=claude-cli-conv-88b2
```
Observed result after fix: the persistent-target cron session now keeps its original sessionId and its claude-cli conversation binding across the daily boundary instead of rolling to a fresh id and dropping the binding.
What was not tested: no live provider request was issued and no full build was run; the daily boundary was reached by backdating the stored session rather than waiting real time.
