### PR TITLE
fix: warn when Slack bot token authenticates as a user

### DIFF
--- a/extensions/slack/src/channel.test.ts
+++ b/extensions/slack/src/channel.test.ts
@@ -446,12 +446,66 @@ describe("slackPlugin status", () => {
       cfg,
     });
 
-    expect(probeSpy).toHaveBeenCalledWith("xoxb-test", 2500);
+    expect(probeSpy).toHaveBeenCalledWith("xoxb-test", 2500, { accountId: "default" });
     expect(result).toEqual({
       ok: true,
       status: 200,
       bot: { id: "B1", name: "openclaw-bot" },
       team: { id: "T1", name: "OpenClaw" },
+    });
+  });
+
+  it("renders Slack probe token warnings in capabilities output", () => {
+    const lines = slackPlugin.status?.formatCapabilitiesProbe?.({
+      probe: {
+        ok: true,
+        warning:
+          'slack auth.test returned user_id=UUSER without bot_id for account "default"; channels.slack.botToken or SLACK_BOT_TOKEN may contain a Slack user token (xoxp-...) instead of a bot token (xoxb-...).',
+        bot: { id: "UUSER", name: "human-installer" },
+        team: { id: "T1", name: "OpenClaw" },
+      },
+    });
+
+    expect(lines).toStrictEqual([
+      {
+        text: expect.stringContaining("without bot_id"),
+        tone: "warn",
+      },
+      { text: "Bot: @human-installer" },
+      { text: "Team: OpenClaw (T1)" },
+    ]);
+  });
+
+  it("passes named Slack account ids into probe warnings", async () => {
+    const probeSpy = vi.spyOn(probeModule, "probeSlack").mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      warning:
+        'slack auth.test returned user_id=UWORK without bot_id for account "work"; channels.slack.accounts.work.botToken may contain a Slack user token (xoxp-...) instead of a bot token (xoxb-...).',
+    });
+    const cfg = {
+      channels: {
+        slack: {
+          accounts: {
+            work: {
+              botToken: "xoxp-work",
+              appToken: "xapp-work",
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const account = slackPlugin.config.resolveAccount(cfg, "work");
+
+    const result = await slackPlugin.status!.probeAccount!({
+      account,
+      timeoutMs: 2500,
+      cfg,
+    });
+
+    expect(probeSpy).toHaveBeenCalledWith("xoxp-work", 2500, { accountId: "work" });
+    expect(result).toMatchObject({
+      warning: expect.stringContaining("channels.slack.accounts.work.botToken"),
     });
   });
 

--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -696,11 +696,18 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount, SlackProbe> = crea
         if (!token) {
           return { ok: false, error: "missing token" };
         }
-        return await (await loadSlackProbeModule()).probeSlack(token, timeoutMs);
+        return await (
+          await loadSlackProbeModule()
+        ).probeSlack(token, timeoutMs, {
+          accountId: account.accountId,
+        });
       },
       formatCapabilitiesProbe: ({ probe }) => {
         const slackProbe = probe as SlackProbe | undefined;
         const lines = [];
+        if (slackProbe?.warning) {
+          lines.push({ text: `Warning: ${slackProbe.warning}`, tone: "warn" } as const);
+        }
         if (slackProbe?.bot?.name) {
           lines.push({ text: `Bot: @${slackProbe.bot.name}` });
         }

--- a/extensions/slack/src/monitor.test-helpers.ts
+++ b/extensions/slack/src/monitor.test-helpers.ts
@@ -1,5 +1,6 @@
 // Slack helper module supports monitor helpers behavior.
 import type { ChannelRuntimeSurface } from "openclaw/plugin-sdk/channel-contract";
+import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { vi } from "vitest";
 import type { Mock } from "vitest";
 import { clearSlackInboundDeliveryStateForTest } from "./monitor/inbound-delivery-state.js";
@@ -12,6 +13,7 @@ type SlackProviderMonitor = (params: {
   abortSignal: AbortSignal;
   config?: Record<string, unknown>;
   channelRuntime?: ChannelRuntimeSurface;
+  runtime?: RuntimeEnv;
 }) => Promise<unknown>;
 
 type SlackTestState = {
@@ -86,7 +88,7 @@ function ensureSlackTestRuntime(): {
   }
   if (!globalState["__slackClient"]) {
     globalState["__slackClient"] = {
-      auth: { test: vi.fn().mockResolvedValue({ user_id: "bot-user" }) },
+      auth: { test: vi.fn().mockResolvedValue({ user_id: "bot-user", bot_id: "bot-id" }) },
       conversations: {
         info: vi.fn().mockResolvedValue({
           channel: { name: "dm", is_im: true },
@@ -138,7 +140,12 @@ async function waitForSlackEvent(name: string) {
 
 export function startSlackMonitor(
   monitorSlackProvider: SlackProviderMonitor,
-  opts?: { botToken?: string; appToken?: string; channelRuntime?: ChannelRuntimeSurface },
+  opts?: {
+    botToken?: string;
+    appToken?: string;
+    channelRuntime?: ChannelRuntimeSurface;
+    runtime?: RuntimeEnv;
+  },
 ) {
   const controller = new AbortController();
   const run = monitorSlackProvider({
@@ -147,6 +154,7 @@ export function startSlackMonitor(
     abortSignal: controller.signal,
     config: slackTestState.config,
     channelRuntime: opts?.channelRuntime,
+    runtime: opts?.runtime,
   });
   return { controller, run };
 }
@@ -225,7 +233,7 @@ export function resetSlackTestState(config: Record<string, unknown> = defaultSla
       entries.map((input) => ({ input, resolved: false })),
     );
   const client = getSlackClient();
-  client.auth.test.mockReset().mockResolvedValue({ user_id: "bot-user" });
+  client.auth.test.mockReset().mockResolvedValue({ user_id: "bot-user", bot_id: "bot-id" });
   client.conversations.info.mockReset().mockResolvedValue({
     channel: { name: "dm", is_im: true },
   });

--- a/extensions/slack/src/monitor/provider.auth-test-token.test.ts
+++ b/extensions/slack/src/monitor/provider.auth-test-token.test.ts
@@ -1,5 +1,5 @@
 // Slack tests cover auth.test token handling during provider boot.
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   getSlackClient,
   resetSlackTestState,
@@ -27,5 +27,30 @@ describe("auth.test boot call", () => {
     if (firstArg != null) {
       expect(firstArg).not.toHaveProperty("token");
     }
+  });
+
+  it("warns when auth.test returns a user id without bot_id", async () => {
+    const runtimeLog = vi.fn();
+    const client = getSlackClient();
+    client.auth.test.mockResolvedValueOnce({
+      user_id: "UUSER",
+      user: "human-installer",
+      team_id: "T1",
+      team: "OpenClaw",
+    });
+
+    const monitor = startSlackMonitor(monitorSlackProvider, {
+      botToken: "xoxp-user-token",
+      runtime: {
+        log: runtimeLog,
+        error: vi.fn(),
+        exit: vi.fn(),
+      },
+    });
+    await stopSlackMonitor(monitor);
+
+    expect(runtimeLog).toHaveBeenCalledWith(expect.stringContaining("without bot_id"));
+    expect(runtimeLog).toHaveBeenCalledWith(expect.stringContaining("xoxp-"));
+    expect(runtimeLog).toHaveBeenCalledWith(expect.stringContaining("xoxb-"));
   });
 });

--- a/extensions/slack/src/monitor/provider.ts
+++ b/extensions/slack/src/monitor/provider.ts
@@ -37,7 +37,11 @@ import { normalizeSlackWebhookPath, registerSlackHttpHandler } from "../http/ind
 import { SLACK_TEXT_LIMIT } from "../limits.js";
 import { resolveSlackChannelAllowlist } from "../resolve-channels.js";
 import { resolveSlackUserAllowlist, type SlackUserResolution } from "../resolve-users.js";
-import { resolveSlackAppToken, resolveSlackBotToken } from "../token.js";
+import {
+  formatSlackBotTokenIdentityWarning,
+  resolveSlackAppToken,
+  resolveSlackBotToken,
+} from "../token.js";
 import { normalizeAllowList } from "./allow-list.js";
 import { resolveSlackSlashCommandConfig } from "./commands.js";
 import {
@@ -343,12 +347,17 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
     slackMode === "socket" ? parseApiAppIdFromAppToken(appToken) : undefined;
   let authTestFailed = false;
   let authTestError: string | undefined;
+  let authIdentityWarning: string | undefined;
   try {
     const auth = await app.client.auth.test();
     botUserId = auth.user_id ?? "";
     botId = (auth as { bot_id?: string }).bot_id ?? "";
     teamId = auth.team_id ?? "";
     apiAppId = (auth as { api_app_id?: string }).api_app_id ?? "";
+    authIdentityWarning = formatSlackBotTokenIdentityWarning({
+      auth,
+      accountId: account.accountId,
+    });
     if (!botUserId) {
       authTestFailed = true;
       authTestError = "auth.test returned no user_id";
@@ -364,6 +373,9 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
           "explicit bot-mention detection will be disabled until restart with a valid bot token",
       ),
     );
+  }
+  if (authIdentityWarning) {
+    runtime.log?.(warn(authIdentityWarning));
   }
 
   if (apiAppId && expectedApiAppIdFromAppToken && apiAppId !== expectedApiAppIdFromAppToken) {

--- a/extensions/slack/src/probe.test.ts
+++ b/extensions/slack/src/probe.test.ts
@@ -41,6 +41,7 @@ describe("probeSlack", () => {
     authTestMock.mockResolvedValue({
       ok: true,
       user_id: "U123",
+      bot_id: "B123",
       user: "openclaw-bot",
       team_id: "T123",
       team: "OpenClaw",
@@ -58,6 +59,22 @@ describe("probeSlack", () => {
     const [promise, timeoutMs] = requireFirstTimeoutCall();
     expect(promise).toBeInstanceOf(Promise);
     expect(timeoutMs).toBe(2500);
+  });
+
+  it("warns when auth.test looks like a user token in the bot token slot", async () => {
+    vi.spyOn(Date, "now").mockReturnValueOnce(100).mockReturnValueOnce(145);
+    authTestMock.mockResolvedValue({
+      ok: true,
+      user_id: "UUSER",
+      user: "human-installer",
+      team_id: "T123",
+      team: "OpenClaw",
+    });
+
+    await expect(probeSlack("xoxp-user-token", 2500)).resolves.toMatchObject({
+      ok: true,
+      warning: expect.stringContaining("without bot_id"),
+    });
   });
 
   it("keeps optional auth metadata fields undefined when Slack omits them", async () => {

--- a/extensions/slack/src/probe.ts
+++ b/extensions/slack/src/probe.ts
@@ -3,12 +3,14 @@ import type { BaseProbeResult } from "openclaw/plugin-sdk/channel-contract";
 import { withTimeout } from "openclaw/plugin-sdk/text-utility-runtime";
 import { createSlackWebClient } from "./client.js";
 import { formatSlackError } from "./errors.js";
+import { formatSlackBotTokenIdentityWarning } from "./token.js";
 
 export type SlackProbe = BaseProbeResult & {
   status?: number | null;
   elapsedMs?: number | null;
   bot?: { id?: string; name?: string };
   team?: { id?: string; name?: string };
+  warning?: string;
 };
 
 export async function probeSlack(token: string, timeoutMs = 2500): Promise<SlackProbe> {
@@ -24,12 +26,14 @@ export async function probeSlack(token: string, timeoutMs = 2500): Promise<Slack
         elapsedMs: Date.now() - start,
       };
     }
+    const warning = formatSlackBotTokenIdentityWarning({ auth: result });
     return {
       ok: true,
       status: 200,
       elapsedMs: Date.now() - start,
       bot: { id: result.user_id, name: result.user },
       team: { id: result.team_id, name: result.team },
+      ...(warning ? { warning } : {}),
     };
   } catch (err) {
     const message = formatSlackError(err);

--- a/extensions/slack/src/probe.ts
+++ b/extensions/slack/src/probe.ts
@@ -13,7 +13,11 @@ export type SlackProbe = BaseProbeResult & {
   warning?: string;
 };
 
-export async function probeSlack(token: string, timeoutMs = 2500): Promise<SlackProbe> {
+export async function probeSlack(
+  token: string,
+  timeoutMs = 2500,
+  opts?: { accountId?: string | null },
+): Promise<SlackProbe> {
   const client = createSlackWebClient(token);
   const start = Date.now();
   try {
@@ -26,7 +30,10 @@ export async function probeSlack(token: string, timeoutMs = 2500): Promise<Slack
         elapsedMs: Date.now() - start,
       };
     }
-    const warning = formatSlackBotTokenIdentityWarning({ auth: result });
+    const warning = formatSlackBotTokenIdentityWarning({
+      auth: result,
+      accountId: opts?.accountId,
+    });
     return {
       ok: true,
       status: 200,

--- a/extensions/slack/src/token.ts
+++ b/extensions/slack/src/token.ts
@@ -1,6 +1,32 @@
 // Slack plugin module implements token behavior.
 import { normalizeResolvedSecretInputString } from "openclaw/plugin-sdk/secret-input";
 
+export type SlackAuthTestIdentity = {
+  user_id?: unknown;
+  bot_id?: unknown;
+};
+
+function readSlackAuthString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+export function formatSlackBotTokenIdentityWarning(params: {
+  auth: SlackAuthTestIdentity;
+  accountId?: string | null;
+}): string | undefined {
+  const userId = readSlackAuthString(params.auth.user_id);
+  const botId = readSlackAuthString(params.auth.bot_id);
+  if (!userId || botId) {
+    return undefined;
+  }
+  const accountId = readSlackAuthString(params.accountId) ?? "default";
+  const tokenPath =
+    accountId === "default"
+      ? "channels.slack.botToken or SLACK_BOT_TOKEN"
+      : `channels.slack.accounts.${accountId}.botToken`;
+  return `slack auth.test returned user_id=${userId} without bot_id for account "${accountId}"; ${tokenPath} may contain a Slack user token (xoxp-...) instead of a bot token (xoxb-...). Slack mentions of that user can be mistaken for bot mentions until the token is replaced.`;
+}
+
 export function resolveSlackBotToken(
   raw?: unknown,
   path = "channels.slack.botToken",

--- a/src/commands/channels/capabilities.test.ts
+++ b/src/commands/channels/capabilities.test.ts
@@ -189,6 +189,49 @@ describe("channelsCapabilitiesCommand", () => {
     ]);
   });
 
+  it("prints Slack auth warnings returned by a channel probe", async () => {
+    const plugin = buildPlugin({
+      id: "slack",
+      account: {
+        accountId: "default",
+        botToken: "xoxp-user-token",
+      },
+      probe: {
+        ok: true,
+        warning:
+          'slack auth.test returned user_id=UUSER without bot_id for account "default"; channels.slack.botToken or SLACK_BOT_TOKEN may contain a Slack user token (xoxp-...) instead of a bot token (xoxb-...).',
+      },
+    });
+    plugin.status = {
+      ...plugin.status,
+      formatCapabilitiesProbe: ({ probe }) => [
+        {
+          text: `Warning: ${(probe as { warning: string }).warning}`,
+          tone: "warn",
+        },
+      ],
+    };
+    vi.mocked(listChannelPlugins).mockReturnValue([plugin]);
+    vi.mocked(getChannelPlugin).mockReturnValue(plugin);
+    mocks.resolveInstallableChannelPlugin.mockResolvedValue({
+      cfg: { channels: {} },
+      channelId: "slack",
+      plugin,
+      configChanged: false,
+    });
+
+    await channelsCapabilitiesCommand({ channel: "slack" }, runtime);
+
+    expect(logs).toStrictEqual([
+      [
+        "slack:default",
+        "Support: chatTypes=direct",
+        "Actions: send, broadcast, poll",
+        'Warning: slack auth.test returned user_id=UUSER without bot_id for account "default"; channels.slack.botToken or SLACK_BOT_TOKEN may contain a Slack user token (xoxp-...) instead of a bot token (xoxb-...).',
+      ].join("\n"),
+    ]);
+  });
+
   it("prints an empty all-channel report when no channels are configured", async () => {
     await channelsCapabilitiesCommand({ json: true }, runtime);
 


### PR DESCRIPTION
Closes #98357

## What Problem This Solves

Fixes an issue where Slack operators could accidentally put a Slack user token in the bot-token slot and still see Slack startup/probe succeed without any warning that `auth.test` returned a human `user_id` but no `bot_id`.

Because Slack mention and self-author handling uses the authenticated identity, silently accepting that ambiguous response makes misconfiguration hard to diagnose. It was also possible for `openclaw channels capabilities --channel slack` to look healthy because the Slack probe formatter only showed bot/team lines.

## Why This Change Was Made

This adds a shared Slack `auth.test` identity warning for successful responses that include `user_id` but omit `bot_id`. The warning is surfaced in provider startup logs and account probe/capabilities output, with the probed Slack account id carried into the diagnostic so named accounts point to `channels.slack.accounts.<id>.botToken`.

The change intentionally does not alter token precedence, Slack client setup, or startup failure behavior, and it does not log token values.

## User Impact

Slack users now get a clear diagnostic when a bot-token field appears to contain a user token (`xoxp-...`) instead of a bot token (`xoxb-...`). Correctly configured bot tokens continue through the existing startup and probe paths without extra warnings.

Named Slack accounts now get account-specific guidance instead of being told to edit the default account.

## Evidence

- Before/source proof: on current main, a successful Slack `auth.test` response with `user_id` and no `bot_id` is accepted by provider startup and `probeSlack()` without any warning, and the Slack capabilities formatter has no path to print a probe warning.
- After-fix Slack WebClient probe proof, using a temporary redacted Slack `auth.test`-compatible endpoint and a redacted `xoxp-...` token-shaped value. This exercises the PR branch's Slack WebClient probe path, not only the formatter:

```text
SLACK_API_URL=http://127.0.0.1:<mock-port>/api/ node --import tsx <probeSlack accountId=work>

REQUESTS: POST /api/auth.test
RESULT:
{
  "ok": true,
  "status": 200,
  "bot": {
    "id": "UWORK",
    "name": "human-installer"
  },
  "team": {
    "id": "TREDACTED",
    "name": "Redacted Workspace"
  },
  "warning": "slack auth.test returned user_id=UWORK without bot_id for account \"work\"; channels.slack.accounts.work.botToken may contain a Slack user token (xoxp-...) instead of a bot token (xoxb-...). Slack mentions of that user can be mistaken for bot mentions until the token is replaced."
}
```

- After-fix capabilities-display proof, using the Slack plugin status adapter on the same probed account result. This verifies the warning reaches the user-visible capabilities/probe lines:

```text
SLACK_API_URL=http://127.0.0.1:<mock-port>/api/ node --import tsx <slackPlugin.status.probeAccount + formatCapabilitiesProbe>

REQUESTS: POST /api/auth.test
Warning: slack auth.test returned user_id=UWORK without bot_id for account "work"; channels.slack.accounts.work.botToken may contain a Slack user token (xoxp-...) instead of a bot token (xoxb-...). Slack mentions of that user can be mistaken for bot mentions until the token is replaced.
Bot: @human-installer
Team: Redacted Workspace (TREDACTED)
```

- Live Slack API proof (July 1, 2026): created a disposable Slack app named `OpenClaw Proof 98358` in the test workspace `pep-ucd-AY2019`, installed it with bot scope `chat:write` and user scope `users:read`, then invoked Slack's real `https://slack.com/api/auth.test` through this PR branch's `probeSlack()` path. Token values, user ids, and team details were redacted from output.

```text
node --import tsx <live-proof-harness importing extensions/slack/src/probe.ts>

{
  "label": "user-token-in-bot-slot",
  "ok": true,
  "status": 200,
  "team": { "idPrefix": "TQ", "name": "<redacted>" },
  "bot": { "idPrefix": "UQ", "name": "<redacted>" },
  "warning": "slack auth.test returned user_id=<redacted> without bot_id for account \"live-work\"; channels.slack.accounts.live-work.botToken may contain a Slack user token (xoxp-...) instead of a bot token (xoxb-...). Slack mentions of that user can be mistaken for bot mentions until the token is replaced."
}
{
  "label": "bot-token-control",
  "ok": true,
  "status": 200,
  "team": { "idPrefix": "TQ", "name": "<redacted>" },
  "bot": { "idPrefix": "U0", "name": "<redacted>" },
  "warning": null
}
```

- Live capabilities-display proof using the same real Slack user token in the bot-token slot and this PR branch's `slackPlugin.status.probeAccount + formatCapabilitiesProbe` path:

```text
warn Warning: slack auth.test returned user_id=<redacted> without bot_id for account "live-work"; channels.slack.accounts.live-work.botToken may contain a Slack user token (xoxp-...) instead of a bot token (xoxb-...). Slack mentions of that user can be mistaken for bot mentions until the token is replaced.
info Bot: @<redacted>
info Team: <redacted> (TQ...)
```
- After-fix focused tests:
  - `node scripts/run-vitest.mjs extensions/slack/src/probe.test.ts extensions/slack/src/channel.test.ts src/commands/channels/capabilities.test.ts extensions/slack/src/monitor/provider.auth-test-token.test.ts`
  - Result: 4 test files passed across 2 Vitest shards; 63 tests passed.
- Static checks:
  - `.\node_modules\.bin\oxlint.cmd extensions\slack\src\token.ts extensions\slack\src\probe.ts extensions\slack\src\channel.ts extensions\slack\src\channel.test.ts src\commands\channels\capabilities.test.ts extensions\slack\src\monitor\provider.ts extensions\slack\src\monitor.test-helpers.ts extensions\slack\src\probe.test.ts extensions\slack\src\monitor\provider.auth-test-token.test.ts`
  - `git diff --check`
- Autoreview:
  - `$env:PYTHONUTF8='1'; python .agents\skills\autoreview\scripts\autoreview --mode local`
  - Result: `autoreview clean: no accepted/actionable findings reported`.
- Live proof cleanup: the disposable Slack app was used only for this PR proof; secrets were kept out of the PR body and local screenshots/token scratch files were removed after recording the redacted output.