### PR TITLE
fix(exec-approvals): clarify why Allow Always is unavailable for one-shot commands (#97069)

### DIFF
--- a/extensions/telegram/src/approval-handler.runtime.test.ts
+++ b/extensions/telegram/src/approval-handler.runtime.test.ts
@@ -51,6 +51,52 @@ describe("telegramApprovalNativeRuntime", () => {
     expect(payload.buttons?.[0]?.map((button) => button.text)).toEqual(["Allow Once", "Deny"]);
   });
 
+  it("preserves ask-always unavailable reason with precomputed decisions", async () => {
+    const payload = (await telegramApprovalNativeRuntime.presentation.buildPendingPayload({
+      cfg: {} as never,
+      accountId: "default",
+      context: {
+        token: "tg-token",
+      },
+      request: {
+        id: "req-ask-always",
+        request: {
+          ask: "always",
+          command: "echo hi",
+        },
+        createdAtMs: 0,
+        expiresAtMs: 60_000,
+      },
+      approvalKind: "exec",
+      nowMs: 0,
+      view: {
+        approvalKind: "exec",
+        approvalId: "req-ask-always",
+        ask: "always",
+        commandText: "echo hi",
+        actions: [
+          {
+            decision: "allow-once",
+            label: "Allow Once",
+            command: "/approve req-ask-always allow-once",
+            style: "success",
+          },
+          {
+            decision: "deny",
+            label: "Deny",
+            command: "/approve req-ask-always deny",
+            style: "danger",
+          },
+        ],
+      } as never,
+    })) as TelegramPayload;
+
+    expect(payload.text).toContain(
+      "The effective approval policy requires approval every time, so Allow Always is unavailable.",
+    );
+    expect(payload.text).not.toContain("no reusable approval pattern");
+  });
+
   it("passes topic thread ids to typing and message delivery", async () => {
     const sendTyping = vi.fn().mockResolvedValue({ ok: true });
     const sendMessage = vi.fn().mockResolvedValue({

--- a/extensions/telegram/src/approval-handler.runtime.ts
+++ b/extensions/telegram/src/approval-handler.runtime.ts
@@ -86,6 +86,7 @@ function buildPendingPayload(params: {
             params.view.approvalKind === "exec" && params.view.host === "node" ? "node" : "gateway",
           nodeId:
             params.view.approvalKind === "exec" ? (params.view.nodeId ?? undefined) : undefined,
+          ask: params.view.approvalKind === "exec" ? (params.view.ask ?? undefined) : undefined,
           allowedDecisions: params.view.actions.map((action) => action.decision),
           expiresAtMs: params.request.expiresAtMs,
           nowMs: params.nowMs,

--- a/extensions/telegram/src/exec-approval-forwarding.ts
+++ b/extensions/telegram/src/exec-approval-forwarding.ts
@@ -40,6 +40,7 @@ export function buildTelegramExecApprovalPendingPayload(params: {
     cwd: params.request.request.cwd ?? undefined,
     host: params.request.request.host === "node" ? "node" : "gateway",
     nodeId: params.request.request.nodeId ?? undefined,
+    ask: params.request.request.ask ?? undefined,
     allowedDecisions: resolveExecApprovalRequestAllowedDecisions(params.request.request),
     expiresAtMs: params.request.expiresAtMs,
     nowMs: params.nowMs,

--- a/src/infra/exec-approval-forwarder.ts
+++ b/src/infra/exec-approval-forwarder.ts
@@ -34,6 +34,7 @@ import {
 import { formatExecApprovalExpiresIn } from "./exec-approval-reply.js";
 import {
   resolveExecApprovalRequestAllowedDecisions,
+  resolveExecApprovalAllowAlwaysUnavailableReason,
   type ExecApprovalRequest,
   type ExecApprovalResolved,
 } from "./exec-approvals.js";
@@ -291,7 +292,9 @@ export function buildExecApprovalRequestMessage(request: ExecApprovalRequest, no
   lines.push(`Reply with: /approve ${request.id} ${decisionText}`);
   if (!allowedDecisions.includes("allow-always")) {
     lines.push(
-      "Allow Always is unavailable because the effective policy requires approval every time.",
+      resolveExecApprovalAllowAlwaysUnavailableReason(request.request.ask) === "ask-always"
+        ? "Allow Always is unavailable because the effective policy requires approval every time."
+        : "Allow Always is unavailable because this command has no reusable approval pattern, so it can only be approved once.",
     );
   }
   return lines.join("\n");

--- a/src/infra/exec-approval-reply.test.ts
+++ b/src/infra/exec-approval-reply.test.ts
@@ -316,6 +316,24 @@ describe("exec approval reply helpers", () => {
     expect(payload.text).not.toContain("C:\\Users\\alice");
   });
 
+  it("explains one-shot commands as no-reusable-pattern, not ask-always, when Allow Always is unavailable (#97069)", () => {
+    const payload = buildExecApprovalPendingReplyPayload({
+      approvalId: "req-oneshot",
+      approvalSlug: "slug-oneshot",
+      ask: "on-miss",
+      allowedDecisions: ["allow-once", "deny"],
+      command: "openclaw --version 2>&1",
+      host: "gateway",
+    });
+
+    // Allow Always is unavailable because the redirected command is one-shot
+    // (no reusable pattern) under ask=on-miss, NOT because the policy is ask-always.
+    expect(payload.text).not.toContain(
+      "The effective approval policy requires approval every time",
+    );
+    expect(payload.text).toContain("no reusable approval pattern");
+  });
+
   it("omits allow-always actions when the effective policy requires approval every time", () => {
     const payload = buildExecApprovalPendingReplyPayload({
       approvalId: "req-ask-always",

--- a/src/infra/exec-approval-reply.ts
+++ b/src/infra/exec-approval-reply.ts
@@ -19,6 +19,7 @@ import {
 } from "./exec-approval-surface.js";
 import {
   resolveExecApprovalAllowedDecisions,
+  resolveExecApprovalAllowAlwaysUnavailableReason,
   type ExecApprovalDecision,
   type ExecHost,
 } from "./exec-approvals.js";
@@ -377,7 +378,9 @@ export function buildExecApprovalPendingReplyPayload(
   }
   if (!allowedDecisions.includes("allow-always")) {
     lines.push(
-      "The effective approval policy requires approval every time, so Allow Always is unavailable.",
+      resolveExecApprovalAllowAlwaysUnavailableReason(params.ask) === "ask-always"
+        ? "The effective approval policy requires approval every time, so Allow Always is unavailable."
+        : "Allow Always is unavailable because this command has no reusable approval pattern, so it can only be approved once.",
     );
   }
   const info: string[] = [];

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -1827,6 +1827,24 @@ export function resolveExecApprovalAllowedDecisions(params?: {
   return DEFAULT_EXEC_APPROVAL_DECISIONS;
 }
 
+export type ExecApprovalAllowAlwaysUnavailableReason = "ask-always" | "no-reusable-pattern";
+
+/**
+ * Explain WHY "Allow Always" is unavailable for an exec approval prompt.
+ * `resolveExecApprovalAllowedDecisions` drops `allow-always` when EITHER the
+ * effective policy is `ask=always` OR the command is one-shot / non-persistable
+ * (no reusable approval pattern, e.g. shell redirection or inline evaluation).
+ * Callers invoke this only when `allow-always` is already known to be
+ * unavailable, so a non-`always` ask means the command simply has no reusable
+ * pattern rather than the policy being ask-always. Without this distinction the
+ * prompt wrongly blames the policy for one-shot commands. (#97069)
+ */
+export function resolveExecApprovalAllowAlwaysUnavailableReason(
+  ask?: string | null,
+): ExecApprovalAllowAlwaysUnavailableReason {
+  return normalizeExecAsk(ask) === "always" ? "ask-always" : "no-reusable-pattern";
+}
+
 export function resolveExecApprovalUnavailableDecisions(params?: {
   ask?: string | null;
   allowAlwaysPersistence?: AllowAlwaysPersistenceDecision | null;


### PR DESCRIPTION
## What Problem This Solves
Exec approval prompts could tell operators that "Allow Always" was unavailable because policy requires approval every time, even when the real reason was a one-shot/non-persistable command with no reusable approval pattern. That made `ask=on-miss` approvals look impossible to remember for the wrong reason.

## Evidence
Focused proof already captured on the PR: the new regression asserts a one-shot command under `ask=on-miss` is described as having no reusable approval pattern, not as `ask=always`; `pnpm exec vitest run src/infra/exec-approval-reply.test.ts src/infra/exec-approval-forwarder.test.ts` passed 55/55; `pnpm tsgo:core`, `pnpm tsgo:core:test`, oxfmt, and oxlint were clean. Native Telegram proof also completed successfully on run 28584536820.

---

## Summary

The exec approval prompt tells operators that "Allow Always is unavailable because the effective policy requires approval every time" even when the real reason is that the command is **one-shot / non-persistable** — it has no reusable approval pattern (for example a shell redirection like `cmd 2>&1` or an inline evaluation). Under `ask=on-miss` such a command can legitimately be approved once, so blaming the policy is misleading and makes it look like approvals can never be remembered.

This PR makes the prompt explain the actual reason.

## Root Cause

`resolveExecApprovalAllowedDecisions` in `src/infra/exec-approvals.ts` drops `allow-always` from the offered decisions in **two** distinct situations:

1. the effective policy is `ask=always`, and
2. the command is one-shot / non-persistable (`allowAlwaysPersistence.kind === "one-shot"`), regardless of the ask.

Both renderers (`exec-approval-reply.ts` and `exec-approval-forwarder.ts`) only checked whether `allow-always` was absent and then hard-coded the ask-always explanation, so case (2) was described with case (1)'s copy.

## Changes

- `src/infra/exec-approvals.ts`: add `ExecApprovalAllowAlwaysUnavailableReason` and `resolveExecApprovalAllowAlwaysUnavailableReason(ask)`. When `allow-always` is already known to be unavailable, a non-`always` ask means the command simply has no reusable pattern.
- `src/infra/exec-approval-reply.ts` and `src/infra/exec-approval-forwarder.ts`: render reason-specific copy ("no reusable approval pattern, so it can only be approved once") instead of always blaming the policy.
- No protocol or schema change; the reason is derived from the existing `ask` value.

## Test

- `src/infra/exec-approval-reply.test.ts`: new regression test asserting a one-shot command under `ask=on-miss` is NOT described as ask-always and IS described as having no reusable approval pattern.
- `pnpm exec vitest run src/infra/exec-approval-reply.test.ts src/infra/exec-approval-forwarder.test.ts` -> 55/55 passing.
- `pnpm tsgo:core` and `pnpm tsgo:core:test` clean; `oxfmt --check` and oxlint clean.

Closes #97069
