### PR TITLE
fix(memory-host-sdk): stop text-pattern cron detection from wiping archive content

### DIFF
--- a/packages/memory-host-sdk/src/host/session-files.test.ts
+++ b/packages/memory-host-sdk/src/host/session-files.test.ts
@@ -779,15 +779,12 @@ describe("buildSessionEntry", () => {
     expect(checkpointEntry.lineMap).toStrictEqual([]);
   });
 
-  it("keeps cron-run deleted archives opaque when the live session store entry is gone", async () => {
+  it("keeps cron-run deleted archives opaque when record metadata preserves the cron key", async () => {
     const archivePath = path.join(tmpDir, "cron-run.jsonl.deleted.2026-02-16T22-27-33.000Z");
     const jsonlLines = [
       JSON.stringify({
-        type: "message",
-        message: {
-          role: "user",
-          content: "[cron:job-1 Codex Sessions Sync] Run internal sync.",
-        },
+        type: "session-meta",
+        data: { sessionKey: "agent:main:cron:job-1:run:run-1" },
       }),
       JSON.stringify({
         type: "message",
@@ -801,6 +798,52 @@ describe("buildSessionEntry", () => {
     expect(entry.content).toBe("");
     expect(entry.lineMap).toStrictEqual([]);
     expect(entry.generatedByCronRun).toBe(true);
+  });
+
+  it("preserves non-cron content in archives when a user message starts with [cron:", async () => {
+    // Human-typed text matching `[cron:...]` must not wipe the archive index.
+    // The individual `[cron:` message is dropped by sanitizeSessionText, but
+    // other messages in the archive remain searchable via memory_search.
+    const archivePath = path.join(tmpDir, "human-cron-like.jsonl.deleted.2026-02-16T22-27-33.000Z");
+    const jsonlLines = [
+      JSON.stringify({
+        type: "message",
+        message: {
+          role: "user",
+          content: "Please remember: my preferred vendor is Acme Robotics.",
+        },
+      }),
+      JSON.stringify({
+        type: "message",
+        message: { role: "assistant", content: "Got it, I'll remember Acme Robotics." },
+      }),
+      JSON.stringify({
+        type: "message",
+        message: {
+          role: "user",
+          content: "[cron:daily-digest] why did my digest job fail last night?",
+        },
+      }),
+      JSON.stringify({
+        type: "message",
+        message: {
+          role: "user",
+          content: "Also my budget is 5000 USD for this quarter.",
+        },
+      }),
+    ];
+    fsSync.writeFileSync(archivePath, jsonlLines.join("\n"));
+
+    const entry = requireSessionEntry(await buildSessionEntry(archivePath));
+
+    // The `[cron:` message itself is dropped but surrounding content is preserved.
+    expect(entry.content).toBe(
+      "User: Please remember: my preferred vendor is Acme Robotics.\n" +
+        "Assistant: Got it, I'll remember Acme Robotics.\n" +
+        "User: Also my budget is 5000 USD for this quarter.",
+    );
+    expect(entry.lineMap).toStrictEqual([1, 2, 4]);
+    expect(entry.generatedByCronRun).toBeUndefined();
   });
 
   it("keeps cron-run reset archives opaque when session metadata preserves the cron key", async () => {

--- a/packages/memory-host-sdk/src/host/session-files.ts
+++ b/packages/memory-host-sdk/src/host/session-files.ts
@@ -840,16 +840,6 @@ export async function buildSessionEntry(
       if (rawText === null) {
         continue;
       }
-      if (
-        !generatedByCronRun &&
-        allowArchiveContentCronClassification &&
-        isGeneratedCronPromptMessage(normalizeSessionText(rawText), message.role)
-      ) {
-        generatedByCronRun = true;
-        collected.length = 0;
-        lineMap.length = 0;
-        messageTimestampsMs.length = 0;
-      }
       const text = sanitizeSessionText(rawText, message.role);
       if (!text) {
         // Assistant-side machinery (silent replies, system wrappers) is already


### PR DESCRIPTION
Fixes #98241

  ## What Problem This Solves

  When a user message starts with `[cron:` (e.g., `[cron:daily-digest] why did my digest job fail last night?`), and the session is later reset or deleted, the usage-counted archive
  transcript (`.jsonl.reset.<iso>` / `.jsonl.deleted.<iso>`) loses **all** its indexed content.

  `buildSessionEntry` in the memory-host-sdk classifies human text matching the `[cron:` prefix as a cron-generated session, clears all collected content, and skips all subsequent
  messages. The session becomes invisible to `memory_search`.

  The code's own comment already acknowledged this risk:

  > user-typed text can match those same patterns (`[cron:...]`)

  — but the clearing logic was still executing.

  ## Why This Change Was Made

  The text-pattern-based cron detection via `isGeneratedCronPromptMessage` is unreliable for archive transcripts: human users can type messages starting with `[cron:`. The metadata-based
  detection via `isCronRunGeneratedRecord` (which checks `data.sessionKey`) is the reliable way to classify cron-run sessions.

  **Changes:**
  - Removed the `isGeneratedCronPromptMessage` → `generatedByCronRun` fallback in `buildSessionEntry` for archive transcripts
  - The individual `[cron:` message is still dropped by `sanitizeSessionText`, but it no longer wipes the entire archive
  - `isCronRunGeneratedRecord` remains the sole mechanism for cron-run detection on archives

  ## User Impact

  Users who mention cron job names in chat and later reset or delete the session will no longer lose indexed memory content. The `[cron:` message itself is excluded from indexing, but
  all surrounding messages remain searchable via `memory_search`.

  ## Evidence

  **38 tests pass** in `packages/memory-host-sdk/src/host/session-files.test.ts`.

  ### New regression test

  `"preserves non-cron content in archives when a user message starts with [cron:"`:

  | Scenario | Before (bug) | After (fix) |
  |----------|-------------|-------------|
  | Messages before `[cron:` line | ❌ wiped | ✅ preserved |
  | `[cron:` message itself | dropped | dropped (unchanged) |
  | Messages after `[cron:` line | ❌ skipped | ✅ preserved |
  | `generatedByCronRun` flag | `true` (incorrect) | `undefined` |

  ### Modified test

  `"keeps cron-run deleted archives opaque when record metadata preserves the cron key"` uses session key metadata (`data.sessionKey`) for cron detection instead of the removed
  text-pattern fallback.

  pnpm test packages/memory-host-sdk/src/host/session-files.test.ts
  ✓ 38 tests passed (8.33s)