### PR TITLE
fix: Android TLS fingerprint verification times out on slow handshakes

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -1676,6 +1676,8 @@ class NodeRuntime(
     when (failure) {
       GatewayTlsProbeFailure.TLS_UNAVAILABLE ->
         "Failed: this host requires wss:// or Tailscale Serve. No TLS endpoint detected."
+      GatewayTlsProbeFailure.TLS_HANDSHAKE_TIMEOUT ->
+        "Failed: secure endpoint reached, but TLS fingerprint verification timed out. Check Tailscale Serve or gateway TLS and retry."
       GatewayTlsProbeFailure.ENDPOINT_UNREACHABLE, null ->
         "Failed: couldn't reach the secure gateway endpoint for this host."
     }

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayTls.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayTls.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.withContext
 import java.io.EOFException
 import java.net.ConnectException
 import java.net.InetSocketAddress
+import java.net.SocketException
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
 import java.security.MessageDigest
@@ -43,6 +44,7 @@ data class GatewayTlsConfig(
 /** Distinguishes non-TLS endpoints from unreachable endpoints during probing. */
 enum class GatewayTlsProbeFailure {
   TLS_UNAVAILABLE,
+  TLS_HANDSHAKE_TIMEOUT,
   ENDPOINT_UNREACHABLE,
 }
 
@@ -51,6 +53,9 @@ data class GatewayTlsProbeResult(
   val fingerprintSha256: String? = null,
   val failure: GatewayTlsProbeFailure? = null,
 )
+
+internal const val GATEWAY_TLS_PROBE_CONNECT_TIMEOUT_MS = 3_000
+internal const val GATEWAY_TLS_PROBE_HANDSHAKE_TIMEOUT_MS = 10_000
 
 /** Builds a TLS config that supports pinned fingerprints and trust-on-first-use. */
 fun buildGatewayTlsConfig(
@@ -119,11 +124,24 @@ fun buildGatewayTlsConfig(
 suspend fun probeGatewayTlsFingerprint(
   host: String,
   port: Int,
-  timeoutMs: Int = 3_000,
+): GatewayTlsProbeResult =
+  probeGatewayTlsFingerprint(
+    host = host,
+    port = port,
+    connectTimeoutMs = GATEWAY_TLS_PROBE_CONNECT_TIMEOUT_MS,
+    handshakeTimeoutMs = GATEWAY_TLS_PROBE_HANDSHAKE_TIMEOUT_MS,
+  )
+
+internal suspend fun probeGatewayTlsFingerprint(
+  host: String,
+  port: Int,
+  connectTimeoutMs: Int,
+  handshakeTimeoutMs: Int,
 ): GatewayTlsProbeResult {
   val trimmedHost = host.trim()
   if (trimmedHost.isEmpty()) return GatewayTlsProbeResult(failure = GatewayTlsProbeFailure.ENDPOINT_UNREACHABLE)
   if (port !in 1..65535) return GatewayTlsProbeResult(failure = GatewayTlsProbeFailure.ENDPOINT_UNREACHABLE)
+  if (connectTimeoutMs <= 0 || handshakeTimeoutMs <= 0) return GatewayTlsProbeResult(failure = GatewayTlsProbeFailure.ENDPOINT_UNREACHABLE)
 
   return withContext(Dispatchers.IO) {
     val fingerprintRef = AtomicReference<String?>(null)
@@ -152,9 +170,14 @@ suspend fun probeGatewayTlsFingerprint(
     context.init(null, arrayOf(probeTrustManager), SecureRandom())
 
     val socket = (context.socketFactory.createSocket() as SSLSocket)
+    var connected = false
     try {
-      socket.soTimeout = timeoutMs
-      socket.connect(InetSocketAddress(trimmedHost, port), timeoutMs)
+      // TCP reachability and TLS handshake progress fail differently on mobile
+      // tailnets; keep the budgets separate so a reachable-but-slow secure
+      // endpoint does not collapse into generic gateway unreachable guidance.
+      socket.soTimeout = handshakeTimeoutMs
+      socket.connect(InetSocketAddress(trimmedHost, port), connectTimeoutMs)
+      connected = true
 
       // Best-effort SNI for hostnames (avoid crashing on IP literals).
       try {
@@ -180,10 +203,21 @@ suspend fun probeGatewayTlsFingerprint(
           is SSLException,
           is EOFException,
           -> GatewayTlsProbeFailure.TLS_UNAVAILABLE
+          is SocketTimeoutException ->
+            if (connected) {
+              GatewayTlsProbeFailure.TLS_HANDSHAKE_TIMEOUT
+            } else {
+              GatewayTlsProbeFailure.ENDPOINT_UNREACHABLE
+            }
           is ConnectException,
-          is SocketTimeoutException,
           is UnknownHostException,
           -> GatewayTlsProbeFailure.ENDPOINT_UNREACHABLE
+          is SocketException ->
+            if (connected) {
+              GatewayTlsProbeFailure.TLS_UNAVAILABLE
+            } else {
+              GatewayTlsProbeFailure.ENDPOINT_UNREACHABLE
+            }
           else -> GatewayTlsProbeFailure.ENDPOINT_UNREACHABLE
         }
       GatewayTlsProbeResult(failure = failure)

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
@@ -1007,6 +1007,8 @@ private fun gatewayStatusLabel(
     status.contains("connecting") || status.contains("reconnecting") -> "Connecting..."
     status.contains("pair") -> "Pairing needed"
     status.contains("auth") -> "Authentication needed"
+    status.contains("fingerprint verification timed out") -> "TLS timed out"
+    status.contains("no tls endpoint") -> "No TLS endpoint"
     status.contains("certificate") || status.contains("tls") -> "Certificate review needed"
     status.contains("failed") || status.contains("error") || status.contains("offline") || status.contains("not connected") -> "Cannot reach gateway"
     status.isBlank() -> "Not connected"

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt
@@ -1801,6 +1801,8 @@ private fun gatewaySummary(
     status.contains("connecting") || status.contains("reconnecting") -> "Connecting..."
     status.contains("pairing") -> "Waiting for pairing"
     status.contains("auth") -> "Authentication needed"
+    status.contains("fingerprint verification timed out") -> "TLS timed out"
+    status.contains("no tls endpoint") -> "No TLS endpoint"
     status.contains("certificate") || status.contains("tls") -> "Certificate review needed"
     else -> "Not connected"
   }

--- a/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
@@ -350,6 +350,29 @@ class GatewayBootstrapAuthTest {
   }
 
   @Test
+  fun connect_showsTlsTimeoutGuidanceWhenFingerprintProbeTimesOut() {
+    val app = RuntimeEnvironment.getApplication()
+    val runtime =
+      NodeRuntime(
+        app,
+        tlsFingerprintProbe = { _, _ ->
+          GatewayTlsProbeResult(failure = GatewayTlsProbeFailure.TLS_HANDSHAKE_TIMEOUT)
+        },
+      )
+
+    runtime.connect(
+      GatewayEndpoint.manual(host = "gateway.example", port = 18789),
+      NodeRuntime.GatewayConnectAuth(token = "shared-token", bootstrapToken = null, password = null),
+    )
+
+    assertEquals(
+      "Failed: secure endpoint reached, but TLS fingerprint verification timed out. Check Tailscale Serve or gateway TLS and retry.",
+      waitForStatusText(runtime),
+    )
+    assertNull(runtime.pendingGatewayTrust.value)
+  }
+
+  @Test
   fun resetGatewaySetupAuth_clearsStoredGatewayAndDeviceTokens() {
     val app = RuntimeEnvironment.getApplication()
     val securePrefs =

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewayTlsTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewayTlsTest.kt
@@ -1,0 +1,121 @@
+package ai.openclaw.app.gateway
+
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.net.InetAddress
+import java.net.ServerSocket
+import java.net.Socket
+import java.net.SocketException
+import kotlin.concurrent.thread
+
+class GatewayTlsTest {
+  @Test
+  fun probeGatewayTlsFingerprint_reportsHandshakeTimeoutAfterTcpConnect() =
+    runBlocking {
+      TcpTestServer { socket ->
+        socket.soTimeout = 1_000
+        runCatching { socket.getInputStream().read(ByteArray(512)) }
+        Thread.sleep(700)
+      }.use { server ->
+        val result =
+          probeGatewayTlsFingerprint(
+            host = LOOPBACK_HOST,
+            port = server.port,
+            connectTimeoutMs = 250,
+            handshakeTimeoutMs = 250,
+          )
+
+        assertEquals(GatewayTlsProbeFailure.TLS_HANDSHAKE_TIMEOUT, result.failure)
+      }
+    }
+
+  @Test
+  fun probeGatewayTlsFingerprint_reportsTlsUnavailableForPlainHttpEndpoint() =
+    runBlocking {
+      TcpTestServer { socket ->
+        socket.soTimeout = 1_000
+        runCatching { socket.getInputStream().read(ByteArray(512)) }
+        socket.getOutputStream().write("HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\n\r\n".toByteArray())
+        socket.getOutputStream().flush()
+      }.use { server ->
+        val result =
+          probeGatewayTlsFingerprint(
+            host = LOOPBACK_HOST,
+            port = server.port,
+            connectTimeoutMs = 250,
+            handshakeTimeoutMs = 1_000,
+          )
+
+        assertEquals(GatewayTlsProbeFailure.TLS_UNAVAILABLE, result.failure)
+      }
+    }
+
+  @Test
+  fun probeGatewayTlsFingerprint_reportsTlsUnavailableForConnectedReset() =
+    runBlocking {
+      TcpTestServer { socket ->
+        socket.close()
+      }.use { server ->
+        val result =
+          probeGatewayTlsFingerprint(
+            host = LOOPBACK_HOST,
+            port = server.port,
+            connectTimeoutMs = 250,
+            handshakeTimeoutMs = 1_000,
+          )
+
+        assertEquals(GatewayTlsProbeFailure.TLS_UNAVAILABLE, result.failure)
+      }
+    }
+
+  @Test
+  fun probeGatewayTlsFingerprint_reportsUnreachableWhenTcpConnectFails() =
+    runBlocking {
+      val result =
+        probeGatewayTlsFingerprint(
+          host = LOOPBACK_HOST,
+          port = unusedLoopbackPort(),
+          connectTimeoutMs = 250,
+          handshakeTimeoutMs = 250,
+        )
+
+      assertEquals(GatewayTlsProbeFailure.ENDPOINT_UNREACHABLE, result.failure)
+    }
+
+  private class TcpTestServer(
+    private val handler: (Socket) -> Unit,
+  ) : AutoCloseable {
+    private val serverSocket = ServerSocket(0, 50, LOOPBACK_ADDRESS)
+    private var acceptedSocket: Socket? = null
+    private val worker =
+      thread(start = true, isDaemon = true, name = "openclaw-tls-probe-test-server") {
+        try {
+          serverSocket.accept().use { socket ->
+            acceptedSocket = socket
+            handler(socket)
+          }
+        } catch (_: SocketException) {
+          // Closing the server during test cleanup interrupts accept/read.
+        }
+      }
+
+    val port: Int = serverSocket.localPort
+
+    override fun close() {
+      runCatching { acceptedSocket?.close() }
+      runCatching { serverSocket.close() }
+      worker.join(1_000)
+    }
+  }
+
+  private companion object {
+    const val LOOPBACK_HOST = "127.0.0.1"
+    val LOOPBACK_ADDRESS: InetAddress = InetAddress.getByName(LOOPBACK_HOST)
+
+    fun unusedLoopbackPort(): Int =
+      ServerSocket(0, 50, LOOPBACK_ADDRESS).use { server ->
+        server.localPort
+      }
+  }
+}


### PR DESCRIPTION
Closes #98365

## What Problem This Solves

Fixes an issue where Android users connecting to remote/Tailnet gateways could see TLS fingerprint verification fail as a generic unreachable gateway error when the TCP endpoint was reachable but the TLS handshake was slow or stalled.

## Why This Change Was Made

The Android TLS fingerprint probe now treats TCP connect and TLS handshake as separate phases with separate bounded timeouts. It preserves the existing remote gateway TLS requirement and fingerprint trust flow, but reports a distinct TLS verification timeout when the socket connects and the handshake stalls.

AI-assisted: yes.

## User Impact

Android users get a trust prompt for slow-but-valid TLS handshakes that complete inside the handshake budget, and get actionable `TLS timed out` guidance when a secure endpoint is reached but fingerprint verification does not complete. Remote/Tailnet gateways still require TLS and do not silently downgrade to cleartext.

## Evidence

- Focused tests passed:
  - `./gradlew :app:testPlayDebugUnitTest --tests 'ai.openclaw.app.gateway.GatewayTlsTest' --tests 'ai.openclaw.app.GatewayBootstrapAuthTest' --console=plain`
- Autoreview passed before commit:
  - `.agents/skills/autoreview/scripts/autoreview --mode local`
  - Result: `autoreview clean: no accepted/actionable findings reported`
- Build passed after commit:
  - `./gradlew :app:assemblePlayDebug --console=plain`
- Live Android E2E proof on Android 15 / API 35 emulator:
  - Delayed Tailnet TLS endpoint wrapped TLS after about 6001ms; Android reached `Trust this gateway?` with the certificate fingerprint.
  - Stalled Tailnet TLS endpoint accepted Android connections, received 233 ClientHello bytes per socket, and Android closed after about 10.4s with UI status `TLS timed out`.
- Additional check attempted:
  - `./gradlew :app:ktlintCheck --console=plain` currently fails on unrelated current-main files: `GatewayExecApprovals.kt`, `ClawSurfaces.kt`, and `OnboardingFlow.kt`. The touched files were not reported by ktlint.

Agent transcript: omitted for now; a sanitized local session was found and can be added later if requested.
