### PR TITLE
test(infra): add unit tests for SQLite user_version pragma helper

### DIFF
--- a/src/infra/sqlite-user-version.test.ts
+++ b/src/infra/sqlite-user-version.test.ts
@@ -1,0 +1,47 @@
+// Tests for SQLite user_version pragma helper.
+import { describe, expect, it } from "vitest";
+import { readSqliteUserVersion } from "./sqlite-user-version.js";
+
+describe("readSqliteUserVersion", () => {
+  it("returns 0 when row is undefined", () => {
+    const db = {
+      prepare: () => ({ get: () => undefined }),
+    } as any;
+    expect(readSqliteUserVersion(db)).toBe(0);
+  });
+
+  it("returns 0 when user_version is null", () => {
+    const db = {
+      prepare: () => ({ get: () => ({ user_version: null }) }),
+    } as any;
+    expect(readSqliteUserVersion(db)).toBe(0);
+  });
+
+  it("returns numeric user_version", () => {
+    const db = {
+      prepare: () => ({ get: () => ({ user_version: 5 }) }),
+    } as any;
+    expect(readSqliteUserVersion(db)).toBe(5);
+  });
+
+  it("returns 0 when user_version is 0", () => {
+    const db = {
+      prepare: () => ({ get: () => ({ user_version: 0 }) }),
+    } as any;
+    expect(readSqliteUserVersion(db)).toBe(0);
+  });
+
+  it("converts string user_version to number", () => {
+    const db = {
+      prepare: () => ({ get: () => ({ user_version: "3" }) }),
+    } as any;
+    expect(readSqliteUserVersion(db)).toBe(3);
+  });
+
+  it("returns 0 for empty object", () => {
+    const db = {
+      prepare: () => ({ get: () => ({}) }),
+    } as any;
+    expect(readSqliteUserVersion(db)).toBe(0);
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

The `sqlite-user-version.ts` module reads SQLite's PRAGMA user_version, handling the boundary where the row may be undefined or user_version may be null. Without tests, the null-coalescing fallback could silently break.

## Why This Change Was Made

Add unit tests for `readSqliteUserVersion` covering the type boundary: undefined row, null user_version, numeric values, zero, string-to-number conversion, and empty object.

## User Impact

SQLite user_version reading now has comprehensive test coverage at the type boundary, reducing regression risk.

## Evidence

Reproducibility: yes. A live `node:sqlite` in-memory database demonstrates the current PRAGMA user_version behavior the tests lock in.

Direct behavior probe with real `node:sqlite`:

```text
$ node --import tsx -e "
import { DatabaseSync } from 'node:sqlite';
import { readSqliteUserVersion } from './src/infra/sqlite-user-version.js';
const db = new DatabaseSync(':memory:');
db.exec('PRAGMA user_version = 5');
console.log('PRAGMA user_version:', readSqliteUserVersion(db));
db.close();
"
PRAGMA user_version: 5
```

Full PRAGMA lifecycle probe:

```text
$ node --import tsx -e "
import { DatabaseSync } from 'node:sqlite';
import { readSqliteUserVersion } from './src/infra/sqlite-user-version.js';
const db = new DatabaseSync(':memory:');
console.log('initial:', readSqliteUserVersion(db));
db.exec('PRAGMA user_version = 5');
console.log('after set:', readSqliteUserVersion(db));
db.exec('PRAGMA user_version = 0');
console.log('zero:', readSqliteUserVersion(db));
db.close();
"
initial: 0
after set: 5
zero: 0
readSqliteUserVersion correctly reads real node:sqlite PRAGMA user_version values.
```

Targeted test:

```text
$ node scripts/run-vitest.mjs run src/infra/sqlite-user-version.test.ts

Test Files  1 passed (1)
     Tests  6 passed (6)
  Duration  378ms
```

Formatting:

```text
$ npx oxfmt --check src/infra/sqlite-user-version.ts src/infra/sqlite-user-version.test.ts
All matched files use the correct format.
```

Whitespace:

```text
$ git diff --check
```