### PR TITLE
test(agents): add unit tests for thinking block detection

### DIFF
--- a/src/agents/thinking-block.test.ts
+++ b/src/agents/thinking-block.test.ts
@@ -1,0 +1,37 @@
+// Tests for thinking block detection.
+import { describe, expect, it } from "vitest";
+import { isThinkingLikeBlock } from "./thinking-block.js";
+
+describe("isThinkingLikeBlock", () => {
+  it("returns true for thinking type", () => {
+    expect(isThinkingLikeBlock({ type: "thinking" })).toBe(true);
+  });
+
+  it("returns true for redacted_thinking type", () => {
+    expect(isThinkingLikeBlock({ type: "redacted_thinking" })).toBe(true);
+  });
+
+  it("returns false for non-thinking type", () => {
+    expect(isThinkingLikeBlock({ type: "text" })).toBe(false);
+  });
+
+  it("returns false for missing type field", () => {
+    expect(isThinkingLikeBlock({ content: "hello" })).toBe(false);
+  });
+
+  it("returns false for null", () => {
+    expect(isThinkingLikeBlock(null)).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isThinkingLikeBlock(undefined)).toBe(false);
+  });
+
+  it("returns false for string", () => {
+    expect(isThinkingLikeBlock("thinking")).toBe(false);
+  });
+
+  it("returns false for empty object", () => {
+    expect(isThinkingLikeBlock({})).toBe(false);
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

The `thinking-block.ts` module detects thinking/redacted_thinking blocks in agent responses. Without tests, the type guard could silently break when new block types are introduced.

## Why This Change Was Made

Add unit tests for `isThinkingLikeBlock` covering thinking types, non-thinking types, null/undefined, non-object values, and empty object.

## User Impact

Thinking block detection now has comprehensive test coverage, reducing regression risk.

## Evidence

Reproducibility: not applicable. This PR adds direct coverage for existing helper behavior.

Direct behavior probe:

```text
$ node --import tsx -e "import('./src/agents/thinking-block.js').then(({isThinkingLikeBlock})=>console.log(JSON.stringify([{type:'thinking',r:isThinkingLikeBlock({type:'thinking'}),e:true},{type:'text',r:isThinkingLikeBlock({type:'text'}),e:false},{type:'null',r:isThinkingLikeBlock(null),e:false}])))"
[{"type":"thinking","r":true,"e":true},{"type":"text","r":false,"e":false},{"type":"null","r":false,"e":false}]
```

Targeted test:

```text
$ node scripts/run-vitest.mjs run src/agents/thinking-block.test.ts

Test Files  1 passed (1)
     Tests  8 passed (8)
  Duration  398ms
```

Formatting:

```text
$ npx oxfmt --check src/agents/thinking-block.ts src/agents/thinking-block.test.ts
All matched files use the correct format.
```

Whitespace:

```text
$ git diff --check
```