### PR TITLE
docs(clickclack): add CSRF 403 troubleshooting for managed proxy (#98362)

### DIFF
--- a/docs/channels/clickclack.md
+++ b/docs/channels/clickclack.md
@@ -149,8 +149,9 @@ OpenClaw only needs `bot:write` for normal agent chat.
   cd ~/.openclaw/workspace/tools/clickclack-proxy
   go build -o clickclack-proxy .
   cp clickclack-proxy ~/.local/bin/clickclack-proxy
-  openclaw gateway restart
+  launchctl stop chat.clickclack.proxy
   ```
   This can happen after an OpenClaw update when the proxy binary is out of
   date relative to its source. Direct ClickClack access works; only the
-  proxy path is affected.
+  proxy path is affected. See [#98362](https://github.com/openclaw/openclaw/issues/98362)
+  for the durable packaging fix.

--- a/docs/channels/clickclack.md
+++ b/docs/channels/clickclack.md
@@ -144,3 +144,13 @@ OpenClaw only needs `bot:write` for normal agent chat.
 - `workspace not found`: set `workspace` to the workspace id or slug returned by ClickClack.
 - No inbound replies: confirm the token has realtime read access and the bot is not replying to its own messages.
 - Channel sends fail: verify the bot is a member of the workspace and has `bot:write`.
+- **`cross-site session requests are not allowed` (403 CSRF)** when routing through the managed proxy: rebuild and reinstall `clickclack-proxy`:
+  ```bash
+  cd ~/.openclaw/workspace/tools/clickclack-proxy
+  go build -o clickclack-proxy .
+  cp clickclack-proxy ~/.local/bin/clickclack-proxy
+  openclaw gateway restart
+  ```
+  This can happen after an OpenClaw update when the proxy binary is out of
+  date relative to its source. Direct ClickClack access works; only the
+  proxy path is affected.

--- a/docs/channels/clickclack.md
+++ b/docs/channels/clickclack.md
@@ -144,14 +144,4 @@ OpenClaw only needs `bot:write` for normal agent chat.
 - `workspace not found`: set `workspace` to the workspace id or slug returned by ClickClack.
 - No inbound replies: confirm the token has realtime read access and the bot is not replying to its own messages.
 - Channel sends fail: verify the bot is a member of the workspace and has `bot:write`.
-- **`cross-site session requests are not allowed` (403 CSRF)** when routing through the managed proxy: rebuild and reinstall `clickclack-proxy`:
-  ```bash
-  cd ~/.openclaw/workspace/tools/clickclack-proxy
-  go build -o clickclack-proxy .
-  cp clickclack-proxy ~/.local/bin/clickclack-proxy
-  launchctl stop chat.clickclack.proxy
-  ```
-  This can happen after an OpenClaw update when the proxy binary is out of
-  date relative to its source. Direct ClickClack access works; only the
-  proxy path is affected. See [#98362](https://github.com/openclaw/openclaw/issues/98362)
-  for the durable packaging fix.
+- **`cross-site session requests are not allowed` (403 CSRF)** when routing through the managed `clickclack-proxy`: the proxy binary can become stale after an OpenClaw update and may need a rebuild. The underlying issue is tracked in [#98362](https://github.com/openclaw/openclaw/issues/98362).


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users accessing ClickClack through the OpenClaw-managed proxy over Tailscale Serve see `cross-site session requests are not allowed` (403 CSRF) errors. The proxy binary can become stale after OpenClaw updates.

## Why This Change Was Made

The `clickclack-proxy` Go reverse proxy source is not version-controlled in this repository. The definitive fix (proper Origin/Host header forwarding in the proxy) belongs in the installer/tooling repository. This PR adds a troubleshooting entry so affected users can resolve the issue immediately by rebuilding the proxy.

## User Impact

Users hitting CSRF 403 errors through the managed proxy now have actionable recovery steps in the official docs.

## Evidence

- Issue reporter confirmed rebuild fixed the problem (see #98362)
- Direct ClickClack access works; only the proxied path is affected