### PR TITLE
fix(ios): use Gateway speech providers in Talk

### DIFF
--- a/apps/ios/Sources/Voice/TalkGatewaySpeechClient.swift
+++ b/apps/ios/Sources/Voice/TalkGatewaySpeechClient.swift
@@ -197,18 +197,25 @@ final class TalkBufferedAudioPlayer: NSObject, TalkBufferedAudioPlaying, @precon
         return interruptedAt
     }
 
-    func audioPlayerDidFinishPlaying(_: AVAudioPlayer, successfully flag: Bool) {
+    func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
         self.finish(
-            playback: self.playback,
+            playback: self.activePlayback(for: player),
             result: .init(finished: flag, interruptedAt: nil))
     }
 
-    func audioPlayerDecodeErrorDidOccur(_: AVAudioPlayer, error: (any Error)?) {
+    func audioPlayerDecodeErrorDidOccur(_ player: AVAudioPlayer, error: (any Error)?) {
         let message = error?.localizedDescription ?? "unknown decode error"
         self.logger.error("talk buffered audio decode failed: \(message, privacy: .public)")
         self.finish(
-            playback: self.playback,
+            playback: self.activePlayback(for: player),
             result: .init(finished: false, interruptedAt: nil))
+    }
+
+    private func activePlayback(for player: AVAudioPlayer) -> Playback? {
+        // AVAudioPlayer can deliver callbacks after stop/replacement. Keep a stale
+        // player from completing the current reply's continuation.
+        guard self.player === player else { return nil }
+        return self.playback
     }
 
     private func stopInternal() {

--- a/apps/ios/Sources/Voice/TalkGatewaySpeechClient.swift
+++ b/apps/ios/Sources/Voice/TalkGatewaySpeechClient.swift
@@ -47,6 +47,7 @@ struct TalkGatewaySpeechAudio: Equatable {
 
 struct TalkGatewaySpeechRequest {
     let text: String
+    // These are talk.speak protocol inputs; each Gateway speech provider owns which overrides it honors.
     let voiceId: String?
     let modelId: String?
     let outputFormat: String?

--- a/apps/ios/Sources/Voice/TalkGatewaySpeechClient.swift
+++ b/apps/ios/Sources/Voice/TalkGatewaySpeechClient.swift
@@ -1,0 +1,271 @@
+import AVFoundation
+import Foundation
+import OpenClawKit
+import OpenClawProtocol
+import OSLog
+
+struct TalkGatewaySpeechAudio: Equatable {
+    enum PlaybackMode: Equatable {
+        case pcm(sampleRate: Double)
+        case buffered
+        case unsupportedRaw(codec: String)
+    }
+
+    let data: Data
+    let provider: String
+    let outputFormat: String?
+
+    var playbackMode: PlaybackMode {
+        if let sampleRate = TalkTTSValidation.pcmSampleRate(from: self.outputFormat) {
+            return .pcm(sampleRate: sampleRate)
+        }
+        let outputFormat = self.outputFormat?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        let isHeaderlessAudio = if let outputFormat {
+            outputFormat.hasPrefix("raw-") ||
+                outputFormat.hasPrefix("raw_") ||
+                outputFormat == "pcm" ||
+                outputFormat == "mulaw" ||
+                outputFormat == "alaw" ||
+                outputFormat.hasPrefix("mulaw_") ||
+                outputFormat.hasPrefix("ulaw_") ||
+                outputFormat.hasPrefix("alaw_")
+        } else {
+            false
+        }
+        if let outputFormat, isHeaderlessAudio {
+            // talk.speak does not expose the sample rate needed to play headerless audio.
+            // Keep these codecs out of AVAudioPlayer until that protocol metadata exists.
+            return .unsupportedRaw(codec: outputFormat)
+        }
+        // Gateway providers return complete audio files (for example MP3, WAV, or FLAC).
+        // AVAudioPlayer performs container detection; raw PCM keeps its sample-rate path above.
+        return .buffered
+    }
+}
+
+struct TalkGatewaySpeechRequest {
+    let text: String
+    let voiceId: String?
+    let modelId: String?
+    let outputFormat: String?
+    let directive: TalkDirective?
+}
+
+@MainActor
+protocol TalkGatewaySpeechSynthesizing {
+    func synthesize(_ request: TalkGatewaySpeechRequest) async throws -> TalkGatewaySpeechAudio
+}
+
+@MainActor
+final class TalkGatewaySpeechClient: TalkGatewaySpeechSynthesizing {
+    typealias Request = (_ method: String, _ paramsJSON: String?, _ timeoutSeconds: Int) async throws -> Data
+    private static let requestTimeoutSeconds = 125
+
+    private let request: Request
+
+    init(gateway: GatewayNodeSession) {
+        self.request = { method, paramsJSON, timeoutSeconds in
+            try await gateway.request(
+                method: method,
+                paramsJSON: paramsJSON,
+                timeoutSeconds: timeoutSeconds)
+        }
+    }
+
+    init(request: @escaping Request) {
+        self.request = request
+    }
+
+    func synthesize(_ speechRequest: TalkGatewaySpeechRequest) async throws -> TalkGatewaySpeechAudio {
+        let directive = speechRequest.directive
+        let params = TalkSpeakParams(
+            text: speechRequest.text,
+            voiceid: speechRequest.voiceId,
+            modelid: speechRequest.modelId,
+            outputformat: speechRequest.outputFormat,
+            speed: directive?.speed,
+            ratewpm: directive?.rateWPM,
+            stability: directive?.stability,
+            similarity: directive?.similarity,
+            style: directive?.style,
+            speakerboost: directive?.speakerBoost,
+            seed: directive?.seed,
+            normalize: directive?.normalize,
+            language: directive?.language,
+            latencytier: directive?.latencyTier)
+        let paramsData = try JSONEncoder().encode(params)
+        guard let paramsJSON = String(data: paramsData, encoding: .utf8) else {
+            throw TalkGatewaySpeechError.invalidRequest
+        }
+        let responseData = try await request(
+            "talk.speak",
+            paramsJSON,
+            Self.requestTimeoutSeconds)
+        let response = try JSONDecoder().decode(TalkSpeakResult.self, from: responseData)
+        guard let audioData = Data(base64Encoded: response.audiobase64), !audioData.isEmpty else {
+            throw TalkGatewaySpeechError.emptyAudio
+        }
+        return TalkGatewaySpeechAudio(
+            data: audioData,
+            provider: response.provider,
+            outputFormat: response.outputformat)
+    }
+}
+
+@MainActor
+protocol TalkBufferedAudioPlaying {
+    func play(data: Data) async -> StreamingPlaybackResult
+    func stop() -> Double?
+}
+
+@MainActor
+final class TalkBufferedAudioPlayer: NSObject, TalkBufferedAudioPlaying, AVAudioPlayerDelegate {
+    static let shared = TalkBufferedAudioPlayer()
+
+    private final class Playback: @unchecked Sendable {
+        private let lock = NSLock()
+        private var finished = false
+        private var continuation: CheckedContinuation<StreamingPlaybackResult, Never>?
+        private var watchdog: Task<Void, Never>?
+
+        func setContinuation(_ continuation: CheckedContinuation<StreamingPlaybackResult, Never>) {
+            self.lock.lock()
+            defer { self.lock.unlock() }
+            self.continuation = continuation
+        }
+
+        func setWatchdog(_ task: Task<Void, Never>?) {
+            self.lock.lock()
+            let old = self.watchdog
+            self.watchdog = task
+            self.lock.unlock()
+            old?.cancel()
+        }
+
+        func finish(_ result: StreamingPlaybackResult) {
+            let continuation: CheckedContinuation<StreamingPlaybackResult, Never>?
+            self.lock.lock()
+            if self.finished {
+                continuation = nil
+            } else {
+                self.finished = true
+                continuation = self.continuation
+                self.continuation = nil
+            }
+            self.lock.unlock()
+            continuation?.resume(returning: result)
+        }
+    }
+
+    private let logger = Logger(subsystem: "ai.openclaw", category: "talk.tts")
+    private var player: AVAudioPlayer?
+    private var playback: Playback?
+
+    func play(data: Data) async -> StreamingPlaybackResult {
+        self.stopInternal()
+
+        let playback = Playback()
+        self.playback = playback
+        return await withCheckedContinuation { continuation in
+            playback.setContinuation(continuation)
+            do {
+                let player = try AVAudioPlayer(data: data)
+                self.player = player
+                player.delegate = self
+                player.prepareToPlay()
+                self.armWatchdog(playback: playback)
+                if !player.play() {
+                    self.logger.error("talk buffered audio player refused to play")
+                    self.finish(playback: playback, result: .init(finished: false, interruptedAt: nil))
+                }
+            } catch {
+                self.logger.error("talk buffered audio player failed: \(error.localizedDescription, privacy: .public)")
+                self.finish(playback: playback, result: .init(finished: false, interruptedAt: nil))
+            }
+        }
+    }
+
+    func stop() -> Double? {
+        guard let player else { return nil }
+        let interruptedAt = player.currentTime
+        self.finish(
+            playback: self.playback,
+            result: .init(finished: false, interruptedAt: interruptedAt))
+        return interruptedAt
+    }
+
+    func audioPlayerDidFinishPlaying(_: AVAudioPlayer, successfully flag: Bool) {
+        self.finish(
+            playback: self.playback,
+            result: .init(finished: flag, interruptedAt: nil))
+    }
+
+    func audioPlayerDecodeErrorDidOccur(_: AVAudioPlayer, error: (any Error)?) {
+        let message = error?.localizedDescription ?? "unknown decode error"
+        self.logger.error("talk buffered audio decode failed: \(message, privacy: .public)")
+        self.finish(
+            playback: self.playback,
+            result: .init(finished: false, interruptedAt: nil))
+    }
+
+    private func stopInternal() {
+        if let player, let playback {
+            self.finish(
+                playback: playback,
+                result: .init(finished: false, interruptedAt: player.currentTime))
+            return
+        }
+        self.player?.stop()
+        self.player = nil
+    }
+
+    private func finish(playback: Playback?, result: StreamingPlaybackResult) {
+        guard let playback else { return }
+        playback.setWatchdog(nil)
+        playback.finish(result)
+
+        guard self.playback === playback else { return }
+        self.playback = nil
+        self.player?.stop()
+        self.player = nil
+    }
+
+    private func armWatchdog(playback: Playback) {
+        playback.setWatchdog(Task { @MainActor [weak self] in
+            guard let self else { return }
+            try? await Task.sleep(nanoseconds: 650_000_000)
+            guard !Task.isCancelled, self.playback === playback else { return }
+            guard self.player?.isPlaying == true else {
+                self.finish(
+                    playback: playback,
+                    result: .init(finished: false, interruptedAt: nil))
+                return
+            }
+
+            let duration = self.player?.duration ?? 0
+            let timeoutSeconds = min(max(2.0, duration + 2.0), 5 * 60.0)
+            try? await Task.sleep(nanoseconds: UInt64(timeoutSeconds * 1_000_000_000))
+            guard !Task.isCancelled, self.playback === playback else { return }
+            self.logger.error("talk buffered audio player watchdog completed unresolved playback")
+            self.finish(
+                playback: playback,
+                result: .init(finished: false, interruptedAt: nil))
+        })
+    }
+}
+
+private enum TalkGatewaySpeechError: LocalizedError {
+    case invalidRequest
+    case emptyAudio
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidRequest:
+            "Failed to encode talk.speak request"
+        case .emptyAudio:
+            "Gateway talk.speak returned empty audio"
+        }
+    }
+}

--- a/apps/ios/Sources/Voice/TalkGatewaySpeechClient.swift
+++ b/apps/ios/Sources/Voice/TalkGatewaySpeechClient.swift
@@ -122,7 +122,7 @@ protocol TalkBufferedAudioPlaying {
 }
 
 @MainActor
-final class TalkBufferedAudioPlayer: NSObject, TalkBufferedAudioPlaying, AVAudioPlayerDelegate {
+final class TalkBufferedAudioPlayer: NSObject, TalkBufferedAudioPlaying, @preconcurrency AVAudioPlayerDelegate {
     static let shared = TalkBufferedAudioPlayer()
 
     private final class Playback: @unchecked Sendable {

--- a/apps/ios/Sources/Voice/TalkModeGatewayConfig.swift
+++ b/apps/ios/Sources/Voice/TalkModeGatewayConfig.swift
@@ -231,6 +231,10 @@ enum TalkModeRuntimeRoute: Equatable {
     }
 
     var usesGatewayTalkSpeak: Bool {
+        self == .gatewayTalkSpeak
+    }
+
+    var gatewayOwnsCredentials: Bool {
         self != .localElevenLabs
     }
 }

--- a/apps/ios/Sources/Voice/TalkModeGatewayConfig.swift
+++ b/apps/ios/Sources/Voice/TalkModeGatewayConfig.swift
@@ -1,7 +1,7 @@
 import Foundation
 import OpenClawKit
 
-enum TalkModeExecutionMode {
+enum TalkModeExecutionMode: Equatable {
     case native
     case realtimeRelay
 }
@@ -60,7 +60,7 @@ struct TalkRuntimeIssue: Equatable {
 
     var technicalDetails: String {
         var lines = [
-            "code: \(self.code.rawValue)",
+            "code: \(code.rawValue)",
             "message: \(self.displayMessage)",
         ]
         if let provider, !provider.isEmpty { lines.append("provider: \(provider)") }
@@ -71,7 +71,7 @@ struct TalkRuntimeIssue: Equatable {
     }
 
     var diagnosticSummary: String {
-        var parts = [self.displayMessage]
+        var parts = [displayMessage]
         if let provider, !provider.isEmpty { parts.append("provider: \(provider)") }
         if let model, !model.isEmpty { parts.append("model: \(model)") }
         if let transport, !transport.isEmpty { parts.append("transport: \(transport)") }
@@ -201,7 +201,7 @@ enum TalkModeProviderSelection: String, CaseIterable, Identifiable {
     static let storageKey = "talk.providerSelection"
 
     var id: String {
-        self.rawValue
+        rawValue
     }
 
     var label: String {
@@ -218,6 +218,75 @@ enum TalkModeProviderSelection: String, CaseIterable, Identifiable {
     static func resolved(_ raw: String?) -> TalkModeProviderSelection {
         let trimmed = (raw ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
         return TalkModeProviderSelection(rawValue: trimmed) ?? .gatewayDefault
+    }
+}
+
+enum TalkModeRuntimeRoute: Equatable {
+    case localElevenLabs
+    case gatewayTalkSpeak
+    case realtimeRelay
+
+    var usesRealtime: Bool {
+        self == .realtimeRelay
+    }
+
+    var usesGatewayTalkSpeak: Bool {
+        self != .localElevenLabs
+    }
+}
+
+struct TalkModeResolvedRouting: Equatable {
+    let activeProvider: String
+    let executionMode: TalkModeExecutionMode
+    let realtimeProvider: String?
+    let realtimeModelId: String?
+    let route: TalkModeRuntimeRoute
+}
+
+enum TalkModeRoutingResolver {
+    static func resolve(
+        parsed: TalkModeGatewayConfigState,
+        providerSelection: TalkModeProviderSelection,
+        defaultProvider: String,
+        defaultRealtimeModelId: String) -> TalkModeResolvedRouting
+    {
+        var activeProvider = parsed.activeProvider
+        var realtimeProvider = parsed.realtimeProvider
+        var realtimeModelId = parsed.realtimeModelId
+        let route: TalkModeRuntimeRoute
+
+        switch providerSelection {
+        case .gatewayDefault:
+            // Only an explicit realtime config selects the realtime transport. Other Gateway
+            // speech providers stay native and synthesize through talk.speak.
+            if parsed.executionMode == .realtimeRelay {
+                route = .realtimeRelay
+            } else if Self.normalized(activeProvider) == Self.normalized(defaultProvider) {
+                // Preserve the shipped local ElevenLabs path, including its streaming playback.
+                route = .localElevenLabs
+            } else {
+                route = .gatewayTalkSpeak
+            }
+        case .nativeElevenLabs:
+            activeProvider = defaultProvider
+            route = .localElevenLabs
+        case .openAIRealtime:
+            activeProvider = "openai"
+            realtimeProvider = realtimeProvider ?? "openai"
+            realtimeModelId = realtimeModelId ?? defaultRealtimeModelId
+            route = .realtimeRelay
+        }
+
+        return TalkModeResolvedRouting(
+            activeProvider: activeProvider,
+            executionMode: route.usesRealtime ? .realtimeRelay : .native,
+            realtimeProvider: realtimeProvider,
+            realtimeModelId: realtimeModelId,
+            route: route)
+    }
+
+    private static func normalized(_ value: String) -> String {
+        value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     }
 }
 
@@ -254,6 +323,7 @@ struct TalkModeGatewayConfigState {
     let executionMode: TalkModeExecutionMode
     let defaultVoiceId: String?
     let voiceAliases: [String: String]
+    let configuredModelId: String?
     let defaultModelId: String
     let defaultOutputFormat: String?
     let realtimeProvider: String?
@@ -325,6 +395,7 @@ enum TalkModeGatewayConfigParser {
             executionMode: executionMode,
             defaultVoiceId: defaultVoiceId,
             voiceAliases: voiceAliases,
+            configuredModelId: model,
             defaultModelId: defaultModelId,
             defaultOutputFormat: defaultOutputFormat,
             realtimeProvider: realtimeProvider,

--- a/apps/ios/Sources/Voice/TalkModeManager.swift
+++ b/apps/ios/Sources/Voice/TalkModeManager.swift
@@ -1729,6 +1729,7 @@ final class TalkModeManager: NSObject {
                 NSLocalizedDescriptionKey: "Gateway talk.speak returned unsupported raw audio codec '\(codec)'",
             ])
         }
+        guard generation == self.speechGeneration, self.isSpeaking else { return }
         GatewayDiagnostics.log(
             "talk tts: provider=\(audio.provider) outputFormat=\(audio.outputFormat ?? "unknown") " +
                 "finished=\(result.finished)")
@@ -2788,7 +2789,7 @@ extension TalkModeManager {
         let gatewayOwnedVoiceProvider = self.applyTalkConfigCredentials(
             parsed: parsed,
             activeProvider: routing.activeProvider,
-            gatewayOwnsCredentials: routing.route.usesGatewayTalkSpeak,
+            gatewayOwnsCredentials: routing.route.gatewayOwnsCredentials,
             credentialProvider: credentialProvider)
         self.applyTalkModeDescriptor(
             routing: routing,
@@ -3201,8 +3202,12 @@ extension TalkModeManager {
         await self.playAssistant(text: text)
     }
 
-    func _test_stopSpeaking() {
-        self.stopSpeaking()
+    func _test_stopSpeaking(storeInterruption: Bool = true) {
+        self.stopSpeaking(storeInterruption: storeInterruption)
+    }
+
+    func _test_lastInterruptedAtSeconds() -> Double? {
+        self.lastInterruptedAtSeconds
     }
 
     func _test_hasRecognitionRequest() -> Bool {

--- a/apps/ios/Sources/Voice/TalkModeManager.swift
+++ b/apps/ios/Sources/Voice/TalkModeManager.swift
@@ -93,6 +93,7 @@ final class TalkModeManager: NSObject {
     private var pttTimeoutTask: Task<Void, Never>?
 
     private let allowSimulatorCapture: Bool
+    private let gatewaySpeechSynthesizerOverride: (any TalkGatewaySpeechSynthesizing)?
 
     private let audioEngine = AVAudioEngine()
     private var inputTapInstalled = false
@@ -117,12 +118,13 @@ final class TalkModeManager: NSObject {
     private var currentVoiceId: String?
     private var defaultModelId: String?
     private var currentModelId: String?
+    private var configuredProviderModelId: String?
     private var voiceOverrideActive = false
     private var modelOverrideActive = false
     private var defaultOutputFormat: String?
     private var activeTalkProvider: String = TalkModeManager.defaultTalkProvider
     private var executionMode: TalkModeExecutionMode = .native
-    private var realtimeWebRTCEnabled: Bool = false
+    private var runtimeRoute: TalkModeRuntimeRoute = .localElevenLabs
     private var realtimeProvider: String?
     private var realtimeModelId: String?
     private var realtimeVoiceId: String?
@@ -143,11 +145,13 @@ final class TalkModeManager: NSObject {
     private var mainSessionKey: String = "main"
     private var fallbackVoiceId: String?
     private var lastPlaybackWasPCM: Bool = false
+    private var speechGeneration = 0
     /// Set when the ElevenLabs API rejects PCM format (e.g. 403 subscription_required).
     /// Once set, all subsequent requests in this session use MP3 instead of re-trying PCM.
     private var pcmFormatUnavailable: Bool = false
     var pcmPlayer: PCMStreamingAudioPlaying = PCMStreamingAudioPlayer.shared
     var mp3Player: StreamingAudioPlaying = StreamingAudioPlayer.shared
+    var bufferedPlayer: TalkBufferedAudioPlaying = TalkBufferedAudioPlayer.shared
 
     private var gateway: GatewayNodeSession?
     private var gatewayConnected = false
@@ -180,8 +184,12 @@ final class TalkModeManager: NSObject {
         max(0, Int((self.nowSeconds() - start) * 1000))
     }
 
-    init(allowSimulatorCapture: Bool = false) {
+    init(
+        allowSimulatorCapture: Bool = false,
+        gatewaySpeechSynthesizer: (any TalkGatewaySpeechSynthesizing)? = nil)
+    {
         self.allowSimulatorCapture = allowSimulatorCapture
+        self.gatewaySpeechSynthesizerOverride = gatewaySpeechSynthesizer
         super.init()
     }
 
@@ -328,14 +336,14 @@ final class TalkModeManager: NSObject {
             return
         }
         guard self.isCurrentStartAttempt(attemptID) else { return }
-        await self.ensureTalkConfigLoadedForStart()
+        await ensureTalkConfigLoadedForStart()
         guard self.isCurrentStartAttempt(attemptID) else { return }
         if self.gatewayTalkPermissionState.requiresTalkPermissionAction {
             self.statusText = "Gateway permission required"
             GatewayDiagnostics.log("talk.timeline manager start blocked gateway permission")
             return
         }
-        if self.realtimeWebRTCEnabled {
+        if self.runtimeRoute.usesRealtime {
             let realtimeStart = self.executionMode == .realtimeRelay
                 ? await self.startRealtimeRelayIfAvailable()
                 : await self.startRealtimeIfAvailable()
@@ -365,10 +373,10 @@ final class TalkModeManager: NSObject {
             self.captureMode = .continuous
             try self.startRecognition()
             self.isListening = true
-            if let issue = self.pendingRealtimeIssue {
-                self.markNativeFallbackActive(after: issue)
+            if let issue = pendingRealtimeIssue {
+                markNativeFallbackActive(after: issue)
             } else {
-                self.markNativeTalkActive()
+                markNativeTalkActive()
             }
             self.startSilenceMonitor()
             await self.subscribeChatIfNeeded(sessionKey: self.mainSessionKey)
@@ -401,7 +409,7 @@ final class TalkModeManager: NSObject {
     private func applyOpenAIRealtimeSelectionDefaults() {
         self.activeTalkProvider = "openai"
         self.executionMode = .realtimeRelay
-        self.realtimeWebRTCEnabled = true
+        self.runtimeRoute = .realtimeRelay
         self.realtimeProvider = self.realtimeProvider ?? "openai"
         self.realtimeModelId = self.realtimeModelId ?? Self.defaultRealtimeModelIdFallback
         self.gatewayTalkProviderLabel = TalkModeProviderSelection.openAIRealtime.label
@@ -1008,7 +1016,7 @@ final class TalkModeManager: NSObject {
             self.logger.info(
                 "chat.send start sessionKey=\(sessionKey, privacy: .public) chars=\(prompt.count, privacy: .public)")
             GatewayDiagnostics.log("talk: chat.send start sessionKey=\(sessionKey) chars=\(prompt.count)")
-            let ack = try await self.sendChat(prompt, gateway: gateway)
+            let ack = try await sendChat(prompt, gateway: gateway)
             let runId = ack.runId
             let normalizedStatus = Self.normalizedChatSendStatus(ack.status)
             self.logger.info(
@@ -1107,10 +1115,10 @@ final class TalkModeManager: NSObject {
 
     private func startRealtimeIfAvailable() async -> RealtimeStartResult {
         guard let gateway else {
-            return .unavailable(self.realtimeIssue(message: "Gateway not connected", phase: "start"))
+            return .unavailable(realtimeIssue(message: "Gateway not connected", phase: "start"))
         }
         let startedAt = Self.nowSeconds()
-        if self.prefetchedRealtimeSession == nil, let prefetchTask = self.realtimePrefetchTask {
+        if self.prefetchedRealtimeSession == nil, let prefetchTask = realtimePrefetchTask {
             GatewayDiagnostics.log("talk.timeline realtime awaiting in-flight prefetch")
             await prefetchTask.value
         }
@@ -1133,7 +1141,7 @@ final class TalkModeManager: NSObject {
             }
             self.isListening = true
             self.captureMode = .continuous
-            self.markRealtimeActive()
+            markRealtimeActive()
             GatewayDiagnostics.log(
                 "talk.timeline realtime start ready elapsedMs=\(Self.elapsedMs(since: startedAt))")
             GatewayDiagnostics.log("talk realtime: started direct OpenAI WebRTC session")
@@ -1144,7 +1152,7 @@ final class TalkModeManager: NSObject {
                 return .ignored
             }
             self.stopRealtimeSession()
-            let issue = self.realtimeIssue(from: error, phase: "start")
+            let issue = realtimeIssue(from: error, phase: "start")
             GatewayDiagnostics
                 .log("talk realtime: unavailable; falling back to speech pipeline error=\(error.localizedDescription)")
             GatewayDiagnostics.log(
@@ -1156,7 +1164,7 @@ final class TalkModeManager: NSObject {
 
     private func startRealtimeRelayIfAvailable() async -> RealtimeStartResult {
         guard let gateway else {
-            return .unavailable(self.realtimeIssue(message: "Gateway not connected", phase: "start"))
+            return .unavailable(realtimeIssue(message: "Gateway not connected", phase: "start"))
         }
         guard self.foregroundAudioCaptureAllowed else {
             self.statusText = "Paused"
@@ -1175,7 +1183,7 @@ final class TalkModeManager: NSObject {
         }
         self.realtimeRelayStartInFlight = true
         defer { self.realtimeRelayStartInFlight = false }
-        self.prepareRealtimeRelayStart()
+        prepareRealtimeRelayStart()
         GatewayDiagnostics.log("talk.timeline realtime relay start attempt sessionKey=\(self.mainSessionKey)")
         let startedAt = Self.nowSeconds()
         let relaySession = RealtimeTalkRelaySession(
@@ -1213,7 +1221,7 @@ final class TalkModeManager: NSObject {
                 relaySession.stop()
                 return .ignored
             }
-            if let issue = self.realtimeRelayStartIssue {
+            if let issue = realtimeRelayStartIssue {
                 self.realtimeRelaySession = nil
                 relaySession.stop()
                 GatewayDiagnostics.log(
@@ -1234,7 +1242,7 @@ final class TalkModeManager: NSObject {
             }
             self.realtimeRelaySession = nil
             let issue = self.realtimeRelayStartIssue
-                ?? self.realtimeIssue(from: error, phase: "start")
+                ?? realtimeIssue(from: error, phase: "start")
             self.realtimeRelayStartIssue = nil
             GatewayDiagnostics.log(
                 "talk.timeline realtime relay start failed elapsedMs=\(Self.elapsedMs(since: startedAt)) "
@@ -1249,7 +1257,7 @@ final class TalkModeManager: NSObject {
               self.realtimeRelaySession == nil,
               !self.isEnabled
         else { return }
-        guard self.realtimeWebRTCEnabled, self.executionMode != .realtimeRelay else { return }
+        guard self.runtimeRoute.usesRealtime, self.executionMode != .realtimeRelay else { return }
         guard self.gatewayTalkPermissionState == .ready else { return }
         guard self.consumePrefetchedRealtimeSession(peekOnly: true) == nil else { return }
         guard self.realtimePrefetchTask == nil else { return }
@@ -1296,7 +1304,7 @@ final class TalkModeManager: NSObject {
     }
 
     private func consumePrefetchedRealtimeSession(peekOnly: Bool = false) -> TalkRealtimeClientSession? {
-        guard let session = self.prefetchedRealtimeSession else { return nil }
+        guard let session = prefetchedRealtimeSession else { return nil }
         if let expiresAt = session.expiresAt {
             let usableUntil = expiresAt - Self.realtimePrefetchExpiryLeewaySeconds
             if Date().timeIntervalSince1970 >= usableUntil {
@@ -1520,14 +1528,45 @@ final class TalkModeManager: NSObject {
         let cleaned = parsed.stripped.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !cleaned.isEmpty else { return }
         self.applyDirective(directive)
+        self.speechGeneration += 1
+        let speechGeneration = self.speechGeneration
 
         self.statusText = "Generating voice…"
         self.isSpeaking = true
         self.lastSpokenText = cleaned
+        defer {
+            if self.speechGeneration == speechGeneration {
+                self.stopRecognition()
+                self.isSpeaking = false
+                self.restoreConfiguredVoiceModeDescriptor()
+            }
+        }
+
+        let language = ElevenLabsTTSClient.validatedLanguage(directive?.language)
+        if self.runtimeRoute.usesGatewayTalkSpeak {
+            do {
+                try await self.playGatewayTalkSpeak(
+                    text: cleaned,
+                    directive: directive,
+                    generation: speechGeneration)
+            } catch {
+                guard self.speechGeneration == speechGeneration else { return }
+                let errorMessage = error.localizedDescription
+                self.logger.error("gateway TTS failed: \(errorMessage, privacy: .public); falling back to system voice")
+                GatewayDiagnostics.log("talk tts: provider=system (gateway error) msg=\(error.localizedDescription)")
+                do {
+                    try await self.playSystemVoice(text: cleaned, language: language)
+                } catch {
+                    guard self.speechGeneration == speechGeneration else { return }
+                    self.statusText = "Speak failed: \(error.localizedDescription)"
+                    self.logger.error("system voice failed: \(error.localizedDescription, privacy: .public)")
+                }
+            }
+            return
+        }
 
         do {
             let started = Date()
-            let language = ElevenLabsTTSClient.validatedLanguage(directive?.language)
             let requestedVoice = directive?.voiceId?.trimmingCharacters(in: .whitespacesAndNewlines)
             let resolvedVoice = resolveVoiceAlias(requestedVoice)
             if requestedVoice?.isEmpty == false, resolvedVoice == nil {
@@ -1546,7 +1585,7 @@ final class TalkModeManager: NSObject {
             if canUseElevenLabs, let voiceId, let apiKey {
                 GatewayDiagnostics.log("talk tts: provider=elevenlabs voiceId=\(voiceId)")
                 let modelId = directive?.modelId ?? self.currentModelId ?? self.defaultModelId
-                self.applyVoiceModeDescriptor(TalkVoiceModeDescriptorBuilder.build(
+                applyVoiceModeDescriptor(TalkVoiceModeDescriptorBuilder.build(
                     providerId: "elevenlabs",
                     providerLabel: Self.displayName(forProvider: "elevenlabs"),
                     modelId: modelId,
@@ -1618,42 +1657,101 @@ final class TalkModeManager: NSObject {
             } else {
                 self.logger.warning("tts unavailable; falling back to system voice (missing key or voiceId)")
                 GatewayDiagnostics.log("talk tts: provider=system (missing key or voiceId)")
-                self.applyVoiceModeDescriptor(TalkVoiceModeDescriptorBuilder.build(
-                    providerId: "system",
-                    providerLabel: Self.displayName(forProvider: "system"),
-                    modelId: nil,
-                    voiceId: language,
-                    transport: "native",
-                    isRealtime: false))
-                self.startSpeechInterruptionRecognitionIfNeeded()
-                self.statusText = "Speaking (System)…"
-                try await TalkSystemSpeechSynthesizer.shared.speak(text: cleaned, language: language)
+                try await self.playSystemVoice(text: cleaned, language: language)
             }
         } catch {
+            guard self.speechGeneration == speechGeneration else { return }
             self.logger.error(
                 "tts failed: \(error.localizedDescription, privacy: .public); falling back to system voice")
             GatewayDiagnostics.log("talk tts: provider=system (error) msg=\(error.localizedDescription)")
             do {
-                let language = ElevenLabsTTSClient.validatedLanguage(directive?.language)
-                self.applyVoiceModeDescriptor(TalkVoiceModeDescriptorBuilder.build(
-                    providerId: "system",
-                    providerLabel: Self.displayName(forProvider: "system"),
-                    modelId: nil,
-                    voiceId: language,
-                    transport: "native",
-                    isRealtime: false))
-                self.startSpeechInterruptionRecognitionIfNeeded()
-                self.statusText = "Speaking (System)…"
-                try await TalkSystemSpeechSynthesizer.shared.speak(text: cleaned, language: language)
+                try await self.playSystemVoice(text: cleaned, language: language)
             } catch {
+                guard self.speechGeneration == speechGeneration else { return }
                 self.statusText = "Speak failed: \(error.localizedDescription)"
                 self.logger.error("system voice failed: \(error.localizedDescription, privacy: .public)")
             }
         }
+    }
 
-        self.stopRecognition()
-        self.isSpeaking = false
-        self.restoreConfiguredVoiceModeDescriptor()
+    private func playGatewayTalkSpeak(
+        text: String,
+        directive: TalkDirective?,
+        generation: Int) async throws
+    {
+        let synthesizer: any TalkGatewaySpeechSynthesizing
+        if let gatewaySpeechSynthesizerOverride {
+            synthesizer = gatewaySpeechSynthesizerOverride
+        } else if let gateway {
+            synthesizer = TalkGatewaySpeechClient(gateway: gateway)
+        } else {
+            throw NSError(domain: "TalkGatewaySpeech", code: 1, userInfo: [
+                NSLocalizedDescriptionKey: "Gateway not connected",
+            ])
+        }
+
+        let requestedVoice = directive?.voiceId?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let voiceId = requestedVoice?.isEmpty == false
+            ? requestedVoice
+            : (self.currentVoiceId ?? self.defaultVoiceId)
+        let modelId = directive?.modelId ?? (self.modelOverrideActive
+            ? self.currentModelId
+            : self.configuredProviderModelId)
+        let outputFormat = directive?.outputFormat ?? self.defaultOutputFormat
+        let audio = try await synthesizer.synthesize(TalkGatewaySpeechRequest(
+            text: text,
+            voiceId: voiceId,
+            modelId: modelId,
+            outputFormat: outputFormat,
+            directive: directive))
+        guard generation == self.speechGeneration, self.isSpeaking else { return }
+
+        applyVoiceModeDescriptor(TalkVoiceModeDescriptorBuilder.build(
+            providerId: audio.provider,
+            providerLabel: Self.displayName(forProvider: audio.provider),
+            modelId: modelId,
+            voiceId: voiceId,
+            transport: "native",
+            isRealtime: false))
+        self.startSpeechInterruptionRecognitionIfNeeded()
+        self.statusText = "Speaking…"
+        let result: StreamingPlaybackResult
+        switch audio.playbackMode {
+        case let .pcm(sampleRate):
+            self.lastPlaybackWasPCM = true
+            let stream = Self.makeBufferedAudioStream(chunks: [audio.data])
+            result = await self.pcmPlayer.play(stream: stream, sampleRate: sampleRate)
+        case .buffered:
+            self.lastPlaybackWasPCM = false
+            result = await self.bufferedPlayer.play(data: audio.data)
+        case let .unsupportedRaw(codec):
+            throw NSError(domain: "TalkGatewaySpeech", code: 2, userInfo: [
+                NSLocalizedDescriptionKey: "Gateway talk.speak returned unsupported raw audio codec '\(codec)'",
+            ])
+        }
+        GatewayDiagnostics.log(
+            "talk tts: provider=\(audio.provider) outputFormat=\(audio.outputFormat ?? "unknown") " +
+                "finished=\(result.finished)")
+        if !result.finished, let interruptedAt = result.interruptedAt {
+            self.lastInterruptedAtSeconds = interruptedAt
+        } else if !result.finished {
+            throw NSError(domain: "TalkGatewaySpeech", code: 3, userInfo: [
+                NSLocalizedDescriptionKey: "Gateway talk.speak audio playback failed",
+            ])
+        }
+    }
+
+    private func playSystemVoice(text: String, language: String?) async throws {
+        applyVoiceModeDescriptor(TalkVoiceModeDescriptorBuilder.build(
+            providerId: "system",
+            providerLabel: Self.displayName(forProvider: "system"),
+            modelId: nil,
+            voiceId: language,
+            transport: "native",
+            isRealtime: false))
+        self.startSpeechInterruptionRecognitionIfNeeded()
+        self.statusText = "Speaking (System)…"
+        try await TalkSystemSpeechSynthesizer.shared.speak(text: text, language: language)
     }
 
     private func resolvedElevenLabsAPIKey() -> String? {
@@ -1700,15 +1798,18 @@ final class TalkModeManager: NSObject {
     }
 
     private func stopSpeaking(storeInterruption: Bool = true) {
+        self.speechGeneration += 1
         let hasIncremental = self.incrementalSpeechActive ||
             self.incrementalSpeechTask != nil ||
             !self.incrementalSpeechQueue.isEmpty
         if self.isSpeaking {
-            let interruptedAt = self.lastPlaybackWasPCM
+            let streamedInterruptedAt = self.lastPlaybackWasPCM
                 ? self.pcmPlayer.stop()
                 : self.mp3Player.stop()
             if storeInterruption {
-                self.lastInterruptedAtSeconds = interruptedAt
+                self.lastInterruptedAtSeconds = self.bufferedPlayer.stop() ?? streamedInterruptedAt
+            } else {
+                _ = self.bufferedPlayer.stop()
             }
             _ = self.lastPlaybackWasPCM
                 ? self.mp3Player.stop()
@@ -1716,10 +1817,11 @@ final class TalkModeManager: NSObject {
         } else if !hasIncremental {
             return
         }
+        self.stopRecognition()
         TalkSystemSpeechSynthesizer.shared.stop()
         self.cancelIncrementalSpeech()
         self.isSpeaking = false
-        self.restoreConfiguredVoiceModeDescriptor()
+        restoreConfiguredVoiceModeDescriptor()
     }
 
     private func shouldInterrupt(with transcript: String) -> Bool {
@@ -1747,7 +1849,7 @@ final class TalkModeManager: NSObject {
     }
 
     private func shouldUseIncrementalTTS() -> Bool {
-        true
+        !self.runtimeRoute.usesGatewayTalkSpeak
     }
 
     private var isSpeechOutputActive: Bool {
@@ -1759,8 +1861,9 @@ final class TalkModeManager: NSObject {
 
     private func applyDirective(_ directive: TalkDirective?) {
         let requestedVoice = directive?.voiceId?.trimmingCharacters(in: .whitespacesAndNewlines)
-        let resolvedVoice = resolveVoiceAlias(requestedVoice)
-        if requestedVoice?.isEmpty == false, resolvedVoice == nil {
+        let usesGatewayVoiceIds = self.runtimeRoute.usesGatewayTalkSpeak
+        let resolvedVoice = usesGatewayVoiceIds ? requestedVoice : resolveVoiceAlias(requestedVoice)
+        if !usesGatewayVoiceIds, requestedVoice?.isEmpty == false, resolvedVoice == nil {
             self.logger.warning("unknown voice alias \(requestedVoice ?? "?", privacy: .public)")
         }
         if let voice = resolvedVoice {
@@ -2525,9 +2628,9 @@ extension TalkModeManager {
         if let gatewayError = error as? GatewayResponseError,
            let issue = Self.talkRuntimeIssue(
                from: gatewayError,
-               fallbackProvider: self.realtimeProvider,
-               fallbackModel: self.realtimeModelId,
-               fallbackTransport: self.executionMode == .realtimeRelay ? "gateway-relay" : "webrtc",
+               fallbackProvider: realtimeProvider,
+               fallbackModel: realtimeModelId,
+               fallbackTransport: executionMode == .realtimeRelay ? "gateway-relay" : "webrtc",
                fallbackPhase: phase)
         {
             return issue
@@ -2597,7 +2700,7 @@ extension TalkModeManager {
         self.pcmFormatUnavailable = false
         self.prefetchedRealtimeSession = nil
         do {
-            guard let loaded = try await self.loadTalkConfig(from: gateway) else { return }
+            guard let loaded = try await loadTalkConfig(from: gateway) else { return }
             let parsed = TalkModeGatewayConfigParser.parse(
                 config: loaded.config,
                 defaultProvider: Self.defaultTalkProvider,
@@ -2649,40 +2752,23 @@ extension TalkModeManager {
 
     private func applyLoadedTalkConfig(
         _ parsed: TalkModeGatewayConfigState,
-        redactedFallbackMissingScope: String?)
+        redactedFallbackMissingScope: String?,
+        providerSelection providerSelectionOverride: TalkModeProviderSelection? = nil)
     {
-        let providerSelection = self.talkProviderSelection
-        var activeProvider = parsed.activeProvider
-        var executionMode = parsed.executionMode
-        var realtimeProvider = parsed.realtimeProvider
-        var realtimeModelId = parsed.realtimeModelId
+        let providerSelection = providerSelectionOverride ?? self.talkProviderSelection
+        let routing = TalkModeRoutingResolver.resolve(
+            parsed: parsed,
+            providerSelection: providerSelection,
+            defaultProvider: Self.defaultTalkProvider,
+            defaultRealtimeModelId: Self.defaultRealtimeModelIdFallback)
         let realtimeVoiceOverride = TalkModeRealtimeVoiceSelection.resolvedOverride(
             UserDefaults.standard.string(forKey: TalkModeRealtimeVoiceSelection.storageKey))
         let realtimeVoiceId = realtimeVoiceOverride ?? parsed.realtimeVoiceId
-        switch providerSelection {
-        case .gatewayDefault:
-            break
-        case .nativeElevenLabs:
-            activeProvider = Self.defaultTalkProvider
-            executionMode = .native
-        case .openAIRealtime:
-            activeProvider = "openai"
-            executionMode = .realtimeRelay
-            realtimeProvider = realtimeProvider ?? "openai"
-            realtimeModelId = realtimeModelId ?? Self.defaultRealtimeModelIdFallback
-        }
-        if activeProvider.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "openai" {
-            executionMode = .realtimeRelay
-            realtimeProvider = realtimeProvider ?? "openai"
-            realtimeModelId = realtimeModelId ?? Self.defaultRealtimeModelIdFallback
-        }
-
-        let usesRealtimeConfig = activeProvider != Self.defaultTalkProvider || executionMode != .native
-        self.activeTalkProvider = activeProvider
-        self.executionMode = executionMode
-        self.realtimeWebRTCEnabled = usesRealtimeConfig
-        self.realtimeProvider = realtimeProvider
-        self.realtimeModelId = realtimeModelId
+        self.activeTalkProvider = routing.activeProvider
+        self.executionMode = routing.executionMode
+        self.runtimeRoute = routing.route
+        self.realtimeProvider = routing.realtimeProvider
+        self.realtimeModelId = routing.realtimeModelId
         self.realtimeVoiceId = realtimeVoiceId
         self.defaultVoiceId = parsed.defaultVoiceId
         self.voiceAliases = parsed.voiceAliases
@@ -2690,23 +2776,26 @@ extension TalkModeManager {
             self.currentVoiceId = self.defaultVoiceId
         }
         self.defaultModelId = parsed.defaultModelId
+        self.configuredProviderModelId = parsed.configuredModelId
         if !self.modelOverrideActive {
             self.currentModelId = self.defaultModelId
         }
         self.defaultOutputFormat = parsed.defaultOutputFormat
 
+        let credentialProvider = routing.route.usesRealtime
+            ? (routing.realtimeProvider ?? routing.activeProvider)
+            : routing.activeProvider
         let gatewayOwnedVoiceProvider = self.applyTalkConfigCredentials(
             parsed: parsed,
-            activeProvider: activeProvider,
-            usesRealtimeConfig: usesRealtimeConfig,
-            realtimeProvider: realtimeProvider)
+            activeProvider: routing.activeProvider,
+            gatewayOwnsCredentials: routing.route.usesGatewayTalkSpeak,
+            credentialProvider: credentialProvider)
         self.applyTalkModeDescriptor(
-            activeProvider: activeProvider,
+            routing: routing,
             providerSelection: providerSelection,
-            usesRealtimeConfig: usesRealtimeConfig,
-            usesRealtimeRelay: executionMode == .realtimeRelay,
-            realtimeProvider: realtimeProvider,
-            realtimeModelId: realtimeModelId,
+            nativeModelId: routing.route == .localElevenLabs
+                ? self.defaultModelId
+                : self.configuredProviderModelId,
             realtimeVoiceId: realtimeVoiceId)
         self.applyTalkPermissionState(
             redactedFallbackMissingScope: redactedFallbackMissingScope,
@@ -2718,15 +2807,16 @@ extension TalkModeManager {
         self.gatewaySpeechLocaleID = parsed.speechLocaleID
         self.silenceWindow = TimeInterval(parsed.silenceTimeoutMs) / 1000
         if parsed.normalizedPayload || parsed.defaultVoiceId != nil || parsed.rawConfigApiKey != nil {
-            GatewayDiagnostics.log("talk config provider=\(activeProvider) silenceTimeoutMs=\(parsed.silenceTimeoutMs)")
+            GatewayDiagnostics.log(
+                "talk config provider=\(routing.activeProvider) silenceTimeoutMs=\(parsed.silenceTimeoutMs)")
         }
     }
 
     private func applyTalkConfigCredentials(
         parsed: TalkModeGatewayConfigState,
         activeProvider: String,
-        usesRealtimeConfig: Bool,
-        realtimeProvider: String?) -> Bool
+        gatewayOwnsCredentials: Bool,
+        credentialProvider: String) -> Bool
     {
         let rawConfigApiKey = parsed.rawConfigApiKey
         let configApiKey = Self.normalizedTalkApiKey(rawConfigApiKey)
@@ -2738,28 +2828,25 @@ extension TalkModeManager {
         } else {
             self.apiKey = (localApiKey?.isEmpty == false) ? localApiKey : configApiKey
         }
-        let gatewayOwnedVoiceProvider = usesRealtimeConfig
-        if gatewayOwnedVoiceProvider {
+        if gatewayOwnsCredentials {
             self.apiKey = nil
-            let credentialProvider = realtimeProvider ?? activeProvider
-            GatewayDiagnostics.log("talk realtime provider '\(credentialProvider)' uses gateway-owned credentials")
+            GatewayDiagnostics.log("talk provider '\(credentialProvider)' uses gateway-owned credentials")
         }
-        return gatewayOwnedVoiceProvider
+        return gatewayOwnsCredentials
     }
 
     private func applyTalkModeDescriptor(
-        activeProvider: String,
+        routing: TalkModeResolvedRouting,
         providerSelection: TalkModeProviderSelection,
-        usesRealtimeConfig: Bool,
-        usesRealtimeRelay: Bool,
-        realtimeProvider: String?,
-        realtimeModelId: String?,
+        nativeModelId: String?,
         realtimeVoiceId: String?)
     {
+        let usesRealtimeConfig = routing.route.usesRealtime
+        let usesRealtimeRelay = routing.executionMode == .realtimeRelay
         self.gatewayTalkDefaultVoiceId = usesRealtimeConfig ? realtimeVoiceId : self.defaultVoiceId
-        self.gatewayTalkDefaultModelId = usesRealtimeConfig ? realtimeModelId : self.defaultModelId
+        self.gatewayTalkDefaultModelId = usesRealtimeConfig ? routing.realtimeModelId : nativeModelId
         let providerLabel = providerSelection == .gatewayDefault
-            ? Self.displayName(forProvider: activeProvider)
+            ? Self.displayName(forProvider: routing.activeProvider)
             : providerSelection.label
         let transport = usesRealtimeConfig ? (usesRealtimeRelay ? "gateway-relay" : "webrtc") : "native"
         let transportLabel = usesRealtimeRelay ? "Gateway Relay" : (usesRealtimeConfig ? "Native WebRTC" : "Native")
@@ -2767,17 +2854,19 @@ extension TalkModeManager {
         self.gatewayTalkUsesRealtime = usesRealtimeConfig
         self.gatewayTalkUsesRealtimeRelay = usesRealtimeRelay
         self.gatewayTalkTransportLabel = transportLabel
-        self.gatewayTalkRealtimeProviderLabel = realtimeProvider.map { Self.displayName(forProvider: $0) }
-        self.gatewayTalkRealtimeModelId = realtimeModelId
+        self.gatewayTalkRealtimeProviderLabel = routing.realtimeProvider.map { Self.displayName(forProvider: $0) }
+        self.gatewayTalkRealtimeModelId = routing.realtimeModelId
         self.gatewayTalkRealtimeVoiceId = realtimeVoiceId
-        let voiceModeProvider = usesRealtimeConfig ? (realtimeProvider ?? "realtime") : activeProvider
+        let voiceModeProvider = usesRealtimeConfig
+            ? (routing.realtimeProvider ?? "realtime")
+            : routing.activeProvider
         let voiceModeLabel = usesRealtimeConfig
             ? Self.displayName(forProvider: voiceModeProvider)
-            : Self.displayName(forProvider: activeProvider)
+            : Self.displayName(forProvider: routing.activeProvider)
         let voiceModeDescriptor = self.buildConfiguredVoiceModeDescriptor(
             provider: voiceModeProvider,
             providerLabel: voiceModeLabel,
-            modelId: usesRealtimeConfig ? realtimeModelId : self.defaultModelId,
+            modelId: usesRealtimeConfig ? routing.realtimeModelId : nativeModelId,
             voiceId: usesRealtimeConfig ? realtimeVoiceId : self.defaultVoiceId,
             transport: transport,
             isRealtime: usesRealtimeConfig)
@@ -2792,7 +2881,7 @@ extension TalkModeManager {
         self.gatewayTalkConfigLoaded = true
         self.talkConfigLoadedAt = Date()
         if let missingScope = redactedFallbackMissingScope,
-           gatewayOwnedVoiceProvider || self.apiKey == nil
+           gatewayOwnedVoiceProvider || apiKey == nil
         {
             self.gatewayTalkPermissionState = .missingScope(missingScope)
             GatewayDiagnostics.log("talk config missing gateway scope=\(missingScope)")
@@ -2804,6 +2893,7 @@ extension TalkModeManager {
     }
 
     private func applyTalkConfigLoadFailure(_ error: Error) {
+        self.configuredProviderModelId = nil
         if self.shouldForceRealtimeRelayFromSelection {
             self.applyOpenAIRealtimeSelectionDefaults()
             GatewayDiagnostics.log("talk config unavailable; keeping openai realtime selection")
@@ -2830,10 +2920,11 @@ extension TalkModeManager {
     private func applyTalkConfigLoadFailureFallback() {
         self.activeTalkProvider = Self.defaultTalkProvider
         self.executionMode = .native
-        self.realtimeWebRTCEnabled = false
+        self.runtimeRoute = .localElevenLabs
         self.realtimeProvider = nil
         self.realtimeModelId = nil
         self.realtimeVoiceId = nil
+        self.configuredProviderModelId = nil
         self.gatewayTalkProviderLabel = "Not loaded"
         self.gatewayTalkTransportLabel = "Not loaded"
         self.gatewayTalkUsesRealtime = false
@@ -3090,6 +3181,32 @@ extension TalkModeManager {
 
     func _test_applyOpenAIRealtimeSelectionDefaults() {
         self.applyOpenAIRealtimeSelectionDefaults()
+    }
+
+    func _test_applyLoadedTalkConfig(
+        _ parsed: TalkModeGatewayConfigState,
+        providerSelection: TalkModeProviderSelection)
+    {
+        self.applyLoadedTalkConfig(
+            parsed,
+            redactedFallbackMissingScope: nil,
+            providerSelection: providerSelection)
+    }
+
+    func _test_runtimeRoute() -> TalkModeRuntimeRoute {
+        self.runtimeRoute
+    }
+
+    func _test_playAssistant(text: String) async {
+        await self.playAssistant(text: text)
+    }
+
+    func _test_stopSpeaking() {
+        self.stopSpeaking()
+    }
+
+    func _test_hasRecognitionRequest() -> Bool {
+        self.recognitionRequest != nil
     }
 
     func _test_executionMode() -> TalkModeExecutionMode {

--- a/apps/ios/SwiftSources.input.xcfilelist
+++ b/apps/ios/SwiftSources.input.xcfilelist
@@ -99,6 +99,7 @@ Sources/Status/VoiceWakeToast.swift
 Sources/Voice/TalkGatewayPermissionState.swift
 Sources/Voice/TalkDefaults.swift
 Sources/Voice/RealtimeTalkRelaySession.swift
+Sources/Voice/TalkGatewaySpeechClient.swift
 Sources/Voice/TalkModeGatewayConfig.swift
 Sources/Voice/TalkModeManager.swift
 Sources/Voice/TalkModeManager+Permissions.swift

--- a/apps/ios/Tests/TalkGatewaySpeechClientTests.swift
+++ b/apps/ios/Tests/TalkGatewaySpeechClientTests.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import Foundation
 import OpenClawKit
 import OpenClawProtocol
@@ -80,8 +81,8 @@ private final class InterruptibleBufferedAudioPlayer: TalkBufferedAudioPlaying {
 }
 
 @MainActor
-@Suite struct TalkGatewaySpeechClientTests {
-    @Test func forwardsTalkDirectivesAndDecodesAudio() async throws {
+struct TalkGatewaySpeechClientTests {
+    @Test func `forwards talk directives and decodes audio`() async throws {
         let expectedAudio = Data([1, 2, 3])
         var requestedMethod: String?
         var requestedParams: TalkSpeakParams?
@@ -127,7 +128,7 @@ private final class InterruptibleBufferedAudioPlayer: TalkBufferedAudioPlaying {
         #expect(audio.playbackMode == .buffered)
     }
 
-    @Test func resolvesGatewayAudioPlaybackMetadata() {
+    @Test func `resolves gateway audio playback metadata`() {
         let pcm = TalkGatewaySpeechAudio(
             data: Data([0, 1]),
             provider: "elevenlabs",
@@ -166,7 +167,7 @@ private final class InterruptibleBufferedAudioPlayer: TalkBufferedAudioPlaying {
         #expect(microsoftRIFF.playbackMode == .buffered)
     }
 
-    @Test func gatewaySpeechProviderStaysNativeAndUsesTalkSpeak() async {
+    @Test func `gateway speech provider stays native and uses talk speak`() async {
         let parsed = Self.parseSpeechProvider("xiaomi")
         let routing = TalkModeRoutingResolver.resolve(
             parsed: parsed,
@@ -200,7 +201,7 @@ private final class InterruptibleBufferedAudioPlayer: TalkBufferedAudioPlaying {
         #expect(audioPlayer.payloads == [expectedAudio])
     }
 
-    @Test func persistedVoiceAndModelOverridesReachLaterGatewayRequests() async {
+    @Test func `persisted voice and model overrides reach later gateway requests`() async {
         let parsed = Self.parseSpeechProvider("xiaomi")
         let synthesizer = RecordingGatewaySpeechSynthesizer(audio: TalkGatewaySpeechAudio(
             data: Data([4, 5, 6]),
@@ -220,7 +221,7 @@ private final class InterruptibleBufferedAudioPlayer: TalkBufferedAudioPlaying {
         #expect(synthesizer.requests[1].modelId == "expressive")
     }
 
-    @Test func omittedGatewayModelDoesNotSendElevenLabsFallback() async {
+    @Test func `omitted gateway model does not send eleven labs fallback`() async {
         let parsed = Self.parseSpeechProvider("openai", model: nil)
         let synthesizer = RecordingGatewaySpeechSynthesizer(audio: TalkGatewaySpeechAudio(
             data: Data([4, 5, 6]),
@@ -239,7 +240,7 @@ private final class InterruptibleBufferedAudioPlayer: TalkBufferedAudioPlaying {
         #expect(manager.gatewayTalkDefaultModelId == nil)
     }
 
-    @Test func stoppedTalkDoesNotPlayCompletedGatewaySynthesis() async {
+    @Test func `stopped talk does not play completed gateway synthesis`() async {
         let parsed = Self.parseSpeechProvider("xiaomi")
         let synthesizer = SuspendedGatewaySpeechSynthesizer()
         let audioPlayer = RecordingBufferedAudioPlayer()
@@ -260,7 +261,23 @@ private final class InterruptibleBufferedAudioPlayer: TalkBufferedAudioPlaying {
         #expect(audioPlayer.payloads.isEmpty)
     }
 
-    @Test func interruptedGatewayPlaybackStopsSpeechRecognition() async {
+    @Test func `stale buffered player callback does not finish replacement`() async throws {
+        let player = TalkBufferedAudioPlayer()
+        let wav = makeWav16Mono(sampleRate: 8000, samples: 8000)
+        let stalePlayer = try AVAudioPlayer(data: wav)
+        let stopAfterStaleCallback = Task { @MainActor in
+            player.audioPlayerDidFinishPlaying(stalePlayer, successfully: true)
+            return player.stop()
+        }
+
+        let result = await player.play(data: wav)
+        let interruptedAt = await stopAfterStaleCallback.value
+
+        #expect(interruptedAt != nil)
+        #expect(!result.finished)
+    }
+
+    @Test func `interrupted gateway playback stops speech recognition`() async {
         let parsed = Self.parseSpeechProvider("xiaomi", interruptOnSpeech: true)
         let synthesizer = RecordingGatewaySpeechSynthesizer(audio: TalkGatewaySpeechAudio(
             data: Data([4, 5, 6]),
@@ -286,7 +303,7 @@ private final class InterruptibleBufferedAudioPlayer: TalkBufferedAudioPlaying {
         #expect(manager._test_lastInterruptedAtSeconds() == nil)
     }
 
-    @Test func openAISpeechProviderWithoutRealtimeConfigUsesTalkSpeak() {
+    @Test func `open AI speech provider without realtime config uses talk speak`() {
         let parsed = Self.parseSpeechProvider("openai")
 
         let routing = TalkModeRoutingResolver.resolve(
@@ -300,7 +317,7 @@ private final class InterruptibleBufferedAudioPlayer: TalkBufferedAudioPlaying {
         #expect(routing.route == .gatewayTalkSpeak)
     }
 
-    @Test func explicitRealtimeConfigKeepsRealtimeRelay() {
+    @Test func `explicit realtime config keeps realtime relay`() {
         let parsed = TalkModeGatewayConfigParser.parse(
             config: [
                 "talk": [
@@ -364,5 +381,42 @@ private final class InterruptibleBufferedAudioPlayer: TalkBufferedAudioPlaying {
             defaultModelIdFallback: "eleven_v3",
             defaultRealtimeModelIdFallback: "gpt-realtime-2",
             defaultSilenceTimeoutMs: 900)
+    }
+}
+
+private func makeWav16Mono(sampleRate: UInt32, samples: Int) -> Data {
+    let channels: UInt16 = 1
+    let bitsPerSample: UInt16 = 16
+    let blockAlign = channels * (bitsPerSample / 8)
+    let byteRate = sampleRate * UInt32(blockAlign)
+    let dataSize = UInt32(samples) * UInt32(blockAlign)
+
+    var data = Data()
+    data.append(contentsOf: [0x52, 0x49, 0x46, 0x46])
+    data.appendTestLEUInt32(36 + dataSize)
+    data.append(contentsOf: [0x57, 0x41, 0x56, 0x45])
+    data.append(contentsOf: [0x66, 0x6D, 0x74, 0x20])
+    data.appendTestLEUInt32(16)
+    data.appendTestLEUInt16(1)
+    data.appendTestLEUInt16(channels)
+    data.appendTestLEUInt32(sampleRate)
+    data.appendTestLEUInt32(byteRate)
+    data.appendTestLEUInt16(blockAlign)
+    data.appendTestLEUInt16(bitsPerSample)
+    data.append(contentsOf: [0x64, 0x61, 0x74, 0x61])
+    data.appendTestLEUInt32(dataSize)
+    data.append(Data(repeating: 0, count: Int(dataSize)))
+    return data
+}
+
+extension Data {
+    fileprivate mutating func appendTestLEUInt16(_ value: UInt16) {
+        var value = value.littleEndian
+        Swift.withUnsafeBytes(of: &value) { self.append(contentsOf: $0) }
+    }
+
+    fileprivate mutating func appendTestLEUInt32(_ value: UInt32) {
+        var value = value.littleEndian
+        Swift.withUnsafeBytes(of: &value) { self.append(contentsOf: $0) }
     }
 }

--- a/apps/ios/Tests/TalkGatewaySpeechClientTests.swift
+++ b/apps/ios/Tests/TalkGatewaySpeechClientTests.swift
@@ -279,10 +279,11 @@ private final class InterruptibleBufferedAudioPlayer: TalkBufferedAudioPlaying {
         }
         #expect(manager._test_hasRecognitionRequest())
 
-        manager._test_stopSpeaking()
+        manager._test_stopSpeaking(storeInterruption: false)
         await playback.value
 
         #expect(!manager._test_hasRecognitionRequest())
+        #expect(manager._test_lastInterruptedAtSeconds() == nil)
     }
 
     @Test func openAISpeechProviderWithoutRealtimeConfigUsesTalkSpeak() {
@@ -337,6 +338,8 @@ private final class InterruptibleBufferedAudioPlayer: TalkBufferedAudioPlaying {
 
         #expect(routing.executionMode == .realtimeRelay)
         #expect(routing.route == .realtimeRelay)
+        #expect(!routing.route.usesGatewayTalkSpeak)
+        #expect(routing.route.gatewayOwnsCredentials)
     }
 
     private static func parseSpeechProvider(

--- a/apps/ios/Tests/TalkGatewaySpeechClientTests.swift
+++ b/apps/ios/Tests/TalkGatewaySpeechClientTests.swift
@@ -1,0 +1,365 @@
+import Foundation
+import OpenClawKit
+import OpenClawProtocol
+import Testing
+@testable import OpenClaw
+
+@MainActor
+private final class RecordingGatewaySpeechSynthesizer: TalkGatewaySpeechSynthesizing {
+    let audio: TalkGatewaySpeechAudio
+    private(set) var requests: [TalkGatewaySpeechRequest] = []
+
+    init(audio: TalkGatewaySpeechAudio) {
+        self.audio = audio
+    }
+
+    func synthesize(_ request: TalkGatewaySpeechRequest) async throws -> TalkGatewaySpeechAudio {
+        self.requests.append(request)
+        return self.audio
+    }
+}
+
+@MainActor
+private final class SuspendedGatewaySpeechSynthesizer: TalkGatewaySpeechSynthesizing {
+    private var continuation: CheckedContinuation<TalkGatewaySpeechAudio, Never>?
+
+    var hasPendingRequest: Bool {
+        self.continuation != nil
+    }
+
+    func synthesize(_: TalkGatewaySpeechRequest) async throws -> TalkGatewaySpeechAudio {
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func complete() {
+        self.continuation?.resume(returning: TalkGatewaySpeechAudio(
+            data: Data([1, 2, 3]),
+            provider: "xiaomi",
+            outputFormat: "mp3"))
+        self.continuation = nil
+    }
+}
+
+@MainActor
+private final class RecordingBufferedAudioPlayer: TalkBufferedAudioPlaying {
+    private(set) var payloads: [Data] = []
+
+    func play(data: Data) async -> StreamingPlaybackResult {
+        self.payloads.append(data)
+        return StreamingPlaybackResult(finished: true, interruptedAt: nil)
+    }
+
+    func stop() -> Double? {
+        nil
+    }
+}
+
+@MainActor
+private final class InterruptibleBufferedAudioPlayer: TalkBufferedAudioPlaying {
+    private var continuation: CheckedContinuation<StreamingPlaybackResult, Never>?
+
+    var isPlaying: Bool {
+        self.continuation != nil
+    }
+
+    func play(data _: Data) async -> StreamingPlaybackResult {
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func stop() -> Double? {
+        self.continuation?.resume(returning: StreamingPlaybackResult(
+            finished: false,
+            interruptedAt: 0))
+        self.continuation = nil
+        return 0
+    }
+}
+
+@MainActor
+@Suite struct TalkGatewaySpeechClientTests {
+    @Test func forwardsTalkDirectivesAndDecodesAudio() async throws {
+        let expectedAudio = Data([1, 2, 3])
+        var requestedMethod: String?
+        var requestedParams: TalkSpeakParams?
+        var requestedTimeout: Int?
+        let client = TalkGatewaySpeechClient { method, paramsJSON, timeoutSeconds in
+            requestedMethod = method
+            requestedTimeout = timeoutSeconds
+            requestedParams = try JSONDecoder().decode(
+                TalkSpeakParams.self,
+                from: Data((paramsJSON ?? "").utf8))
+            return try JSONEncoder().encode(TalkSpeakResult(
+                audiobase64: expectedAudio.base64EncodedString(),
+                provider: "xiaomi",
+                outputformat: "mp3",
+                voicecompatible: false,
+                mimetype: "audio/mpeg",
+                fileextension: ".mp3"))
+        }
+        let directive = TalkDirective(
+            voiceId: "mimo_default",
+            modelId: "mimo-v2.5-tts",
+            speed: 1.1,
+            language: "zh-CN",
+            outputFormat: "mp3")
+
+        let audio = try await client.synthesize(TalkGatewaySpeechRequest(
+            text: "hello",
+            voiceId: "resolved-voice",
+            modelId: "resolved-model",
+            outputFormat: "mp3",
+            directive: directive))
+
+        #expect(requestedMethod == "talk.speak")
+        #expect(requestedTimeout == 125)
+        #expect(requestedParams?.text == "hello")
+        #expect(requestedParams?.voiceid == "resolved-voice")
+        #expect(requestedParams?.modelid == "resolved-model")
+        #expect(requestedParams?.speed == 1.1)
+        #expect(requestedParams?.language == "zh-CN")
+        #expect(requestedParams?.outputformat == "mp3")
+        #expect(audio.data == expectedAudio)
+        #expect(audio.provider == "xiaomi")
+        #expect(audio.playbackMode == .buffered)
+    }
+
+    @Test func resolvesGatewayAudioPlaybackMetadata() {
+        let pcm = TalkGatewaySpeechAudio(
+            data: Data([0, 1]),
+            provider: "elevenlabs",
+            outputFormat: "pcm_24000")
+        let mimeOnlyMP3 = TalkGatewaySpeechAudio(
+            data: Data([0, 1]),
+            provider: "xiaomi",
+            outputFormat: nil)
+        let wav = TalkGatewaySpeechAudio(
+            data: Data([0, 1]),
+            provider: "xiaomi",
+            outputFormat: "wav")
+        let rawPCM = TalkGatewaySpeechAudio(
+            data: Data([0, 1]),
+            provider: "xai",
+            outputFormat: "pcm")
+        let microsoftRawPCM = TalkGatewaySpeechAudio(
+            data: Data([0, 1]),
+            provider: "microsoft",
+            outputFormat: "raw-24khz-16bit-mono-pcm")
+        let rawULaw = TalkGatewaySpeechAudio(
+            data: Data([0, 1]),
+            provider: "microsoft",
+            outputFormat: "ulaw_8000")
+        let microsoftRIFF = TalkGatewaySpeechAudio(
+            data: Data([0, 1]),
+            provider: "microsoft",
+            outputFormat: "riff-24khz-16bit-mono-pcm")
+
+        #expect(pcm.playbackMode == .pcm(sampleRate: 24000))
+        #expect(mimeOnlyMP3.playbackMode == .buffered)
+        #expect(wav.playbackMode == .buffered)
+        #expect(rawPCM.playbackMode == .unsupportedRaw(codec: "pcm"))
+        #expect(microsoftRawPCM.playbackMode == .unsupportedRaw(codec: "raw-24khz-16bit-mono-pcm"))
+        #expect(rawULaw.playbackMode == .unsupportedRaw(codec: "ulaw_8000"))
+        #expect(microsoftRIFF.playbackMode == .buffered)
+    }
+
+    @Test func gatewaySpeechProviderStaysNativeAndUsesTalkSpeak() async {
+        let parsed = Self.parseSpeechProvider("xiaomi")
+        let routing = TalkModeRoutingResolver.resolve(
+            parsed: parsed,
+            providerSelection: .gatewayDefault,
+            defaultProvider: "elevenlabs",
+            defaultRealtimeModelId: "gpt-realtime-2")
+        #expect(routing.activeProvider == "xiaomi")
+        #expect(routing.executionMode == .native)
+        #expect(routing.route == .gatewayTalkSpeak)
+
+        let expectedAudio = Data([4, 5, 6])
+        let synthesizer = RecordingGatewaySpeechSynthesizer(audio: TalkGatewaySpeechAudio(
+            data: expectedAudio,
+            provider: "xiaomi",
+            outputFormat: "mp3"))
+        let audioPlayer = RecordingBufferedAudioPlayer()
+        let manager = TalkModeManager(
+            allowSimulatorCapture: true,
+            gatewaySpeechSynthesizer: synthesizer)
+        manager.bufferedPlayer = audioPlayer
+        manager._test_applyLoadedTalkConfig(parsed, providerSelection: .gatewayDefault)
+
+        #expect(manager._test_runtimeRoute() == .gatewayTalkSpeak)
+        #expect(manager._test_executionMode() == .native)
+        #expect(!manager.gatewayTalkUsesRealtime)
+        #expect(manager.gatewayTalkTransportLabel == "Native")
+
+        await manager._test_playAssistant(text: "Gateway voice")
+
+        #expect(synthesizer.requests.map(\.text) == ["Gateway voice"])
+        #expect(audioPlayer.payloads == [expectedAudio])
+    }
+
+    @Test func persistedVoiceAndModelOverridesReachLaterGatewayRequests() async {
+        let parsed = Self.parseSpeechProvider("xiaomi")
+        let synthesizer = RecordingGatewaySpeechSynthesizer(audio: TalkGatewaySpeechAudio(
+            data: Data([4, 5, 6]),
+            provider: "xiaomi",
+            outputFormat: "mp3"))
+        let manager = TalkModeManager(
+            allowSimulatorCapture: true,
+            gatewaySpeechSynthesizer: synthesizer)
+        manager.bufferedPlayer = RecordingBufferedAudioPlayer()
+        manager._test_applyLoadedTalkConfig(parsed, providerSelection: .gatewayDefault)
+
+        await manager._test_playAssistant(text: "{\"voice\":\"alloy\",\"model\":\"expressive\"}\nFirst")
+        await manager._test_playAssistant(text: "Second")
+
+        #expect(synthesizer.requests.count == 2)
+        #expect(synthesizer.requests[1].voiceId == "alloy")
+        #expect(synthesizer.requests[1].modelId == "expressive")
+    }
+
+    @Test func omittedGatewayModelDoesNotSendElevenLabsFallback() async {
+        let parsed = Self.parseSpeechProvider("openai", model: nil)
+        let synthesizer = RecordingGatewaySpeechSynthesizer(audio: TalkGatewaySpeechAudio(
+            data: Data([4, 5, 6]),
+            provider: "openai",
+            outputFormat: "mp3"))
+        let manager = TalkModeManager(
+            allowSimulatorCapture: true,
+            gatewaySpeechSynthesizer: synthesizer)
+        manager.bufferedPlayer = RecordingBufferedAudioPlayer()
+        manager._test_applyLoadedTalkConfig(parsed, providerSelection: .gatewayDefault)
+
+        await manager._test_playAssistant(text: "No model override")
+
+        #expect(synthesizer.requests.count == 1)
+        #expect(synthesizer.requests[0].modelId == nil)
+        #expect(manager.gatewayTalkDefaultModelId == nil)
+    }
+
+    @Test func stoppedTalkDoesNotPlayCompletedGatewaySynthesis() async {
+        let parsed = Self.parseSpeechProvider("xiaomi")
+        let synthesizer = SuspendedGatewaySpeechSynthesizer()
+        let audioPlayer = RecordingBufferedAudioPlayer()
+        let manager = TalkModeManager(
+            allowSimulatorCapture: true,
+            gatewaySpeechSynthesizer: synthesizer)
+        manager.bufferedPlayer = audioPlayer
+        manager._test_applyLoadedTalkConfig(parsed, providerSelection: .gatewayDefault)
+
+        let playback = Task { await manager._test_playAssistant(text: "Delayed voice") }
+        while !synthesizer.hasPendingRequest {
+            await Task.yield()
+        }
+        manager.stop()
+        synthesizer.complete()
+        await playback.value
+
+        #expect(audioPlayer.payloads.isEmpty)
+    }
+
+    @Test func interruptedGatewayPlaybackStopsSpeechRecognition() async {
+        let parsed = Self.parseSpeechProvider("xiaomi", interruptOnSpeech: true)
+        let synthesizer = RecordingGatewaySpeechSynthesizer(audio: TalkGatewaySpeechAudio(
+            data: Data([4, 5, 6]),
+            provider: "xiaomi",
+            outputFormat: "mp3"))
+        let audioPlayer = InterruptibleBufferedAudioPlayer()
+        let manager = TalkModeManager(
+            allowSimulatorCapture: true,
+            gatewaySpeechSynthesizer: synthesizer)
+        manager.bufferedPlayer = audioPlayer
+        manager._test_applyLoadedTalkConfig(parsed, providerSelection: .gatewayDefault)
+
+        let playback = Task { await manager._test_playAssistant(text: "Interrupt me") }
+        while !audioPlayer.isPlaying {
+            await Task.yield()
+        }
+        #expect(manager._test_hasRecognitionRequest())
+
+        manager._test_stopSpeaking()
+        await playback.value
+
+        #expect(!manager._test_hasRecognitionRequest())
+    }
+
+    @Test func openAISpeechProviderWithoutRealtimeConfigUsesTalkSpeak() {
+        let parsed = Self.parseSpeechProvider("openai")
+
+        let routing = TalkModeRoutingResolver.resolve(
+            parsed: parsed,
+            providerSelection: .gatewayDefault,
+            defaultProvider: "elevenlabs",
+            defaultRealtimeModelId: "gpt-realtime-2")
+
+        #expect(routing.activeProvider == "openai")
+        #expect(routing.executionMode == .native)
+        #expect(routing.route == .gatewayTalkSpeak)
+    }
+
+    @Test func explicitRealtimeConfigKeepsRealtimeRelay() {
+        let parsed = TalkModeGatewayConfigParser.parse(
+            config: [
+                "talk": [
+                    "provider": "openai",
+                    "providers": [
+                        "openai": [
+                            "mode": "realtime",
+                            "model": "gpt-realtime-2",
+                        ],
+                    ],
+                    "resolved": [
+                        "provider": "openai",
+                        "config": [
+                            "model": "gpt-realtime-2",
+                        ],
+                    ],
+                    "realtime": [
+                        "provider": "openai",
+                        "mode": "realtime",
+                        "transport": "gateway-relay",
+                        "model": "gpt-realtime-2",
+                    ],
+                ],
+            ],
+            defaultProvider: "elevenlabs",
+            defaultModelIdFallback: "eleven_v3",
+            defaultRealtimeModelIdFallback: "gpt-realtime-2",
+            defaultSilenceTimeoutMs: 900)
+
+        let routing = TalkModeRoutingResolver.resolve(
+            parsed: parsed,
+            providerSelection: .gatewayDefault,
+            defaultProvider: "elevenlabs",
+            defaultRealtimeModelId: "gpt-realtime-2")
+
+        #expect(routing.executionMode == .realtimeRelay)
+        #expect(routing.route == .realtimeRelay)
+    }
+
+    private static func parseSpeechProvider(
+        _ provider: String,
+        model: String? = "speech-model",
+        interruptOnSpeech: Bool = false) -> TalkModeGatewayConfigState
+    {
+        let providerConfig: [String: String] = model.map { ["model": $0] } ?? [:]
+        return TalkModeGatewayConfigParser.parse(
+            config: [
+                "talk": [
+                    "provider": provider,
+                    "providers": [provider: providerConfig],
+                    "resolved": [
+                        "provider": provider,
+                        "config": providerConfig,
+                    ],
+                    "interruptOnSpeech": interruptOnSpeech,
+                ],
+            ],
+            defaultProvider: "elevenlabs",
+            defaultModelIdFallback: "eleven_v3",
+            defaultRealtimeModelIdFallback: "gpt-realtime-2",
+            defaultSilenceTimeoutMs: 900)
+    }
+}

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
@@ -47,6 +47,11 @@ public final class OpenClawChatViewModel {
     }
 
     private var pendingLocalUserEchoMessageIDsByRunID: [String: UUID] = [:]
+    // Final chat events and durable session-message rows arrive independently.
+    // Keep each provisional final scoped to the run's user turn so a later identical
+    // answer in the same session does not adopt or suppress the wrong row.
+    private var runMessageScopesByRunID: [String: RunMessageScope] = [:]
+    private var provisionalFinalMessagesByID: [UUID: ProvisionalFinalMessage] = [:]
     private var sessionGeneration: UInt64 = 0
     private var bootstrapGeneration: UInt64 = 0
     // A newer same-session history request only invalidates older responses after it applies.
@@ -109,6 +114,17 @@ public final class OpenClawChatViewModel {
         var refreshKey: String?
         var occurrence: Int
         var timestamp: Double?
+    }
+
+    private struct RunMessageScope {
+        var session: SessionSnapshot
+        var latestUserTurn: LatestUserTurn?
+    }
+
+    private struct ProvisionalFinalMessage {
+        var reconciliationKey: String
+        var runId: String?
+        var scope: RunMessageScope
     }
 
     private var pendingToolCallsById: [String: OpenClawChatPendingToolCall] = [:] {
@@ -359,6 +375,8 @@ public final class OpenClawChatViewModel {
             Self.reconcileMessageIDs(previous: self.messages, incoming: incoming)
         }
         self.prunePendingLocalUserEchoMessageIDs()
+        self.pruneProvisionalFinalMessages()
+        self.pruneRunMessageScopes()
         self.sessionId = payload.sessionId
         // Incomplete refreshes can arrive before durable assistant history.
         // The latest visible user turn must survive answered before it can reject older replies.
@@ -526,6 +544,14 @@ public final class OpenClawChatViewModel {
         }.joined(separator: "\\u{001E}")
     }
 
+    private static func finalMessageContentFingerprint(for message: OpenClawChatMessage) -> String {
+        message.content.map { item in
+            let type = (item.type ?? "text").trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            let text = (item.text ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+            return [type, text].joined(separator: "\\u{001F}")
+        }.joined(separator: "\\u{001E}")
+    }
+
     private static func messageIdentityKey(for message: OpenClawChatMessage) -> String? {
         let role = message.role.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         guard !role.isEmpty else { return nil }
@@ -557,11 +583,129 @@ public final class OpenClawChatViewModel {
         return [role, toolCallId, toolName, contentFingerprint].joined(separator: "|")
     }
 
+    private static func finalMessageReconciliationKey(for message: OpenClawChatMessage) -> String? {
+        let role = message.role.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard role == "assistant" else { return nil }
+
+        // chat.final and session.message can serialize the same final row with
+        // different timestamps/content ids; the run user-turn scope owns safety
+        // for repeated same-text replies across turns.
+        let contentFingerprint = Self.finalMessageContentFingerprint(for: message)
+        let toolCallId = (message.toolCallId ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        let toolName = (message.toolName ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        if contentFingerprint.isEmpty, toolCallId.isEmpty, toolName.isEmpty {
+            return nil
+        }
+        return [role, toolCallId, toolName, contentFingerprint].joined(separator: "|")
+    }
+
+    private static func normalizedRunID(_ runId: String?) -> String? {
+        let trimmed = runId?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private func currentRunMessageScope() -> RunMessageScope {
+        RunMessageScope(
+            session: self.currentSessionSnapshot(),
+            latestUserTurn: Self.latestUserTurn(in: self.messages))
+    }
+
+    private func runMessageScope(for runId: String?) -> RunMessageScope {
+        guard let runId = Self.normalizedRunID(runId),
+              let scope = self.runMessageScopesByRunID[runId],
+              self.isCurrentSession(scope.session)
+        else {
+            return self.currentRunMessageScope()
+        }
+        return scope
+    }
+
+    private static func isSameUserTurnBoundary(_ lhs: LatestUserTurn?, _ rhs: LatestUserTurn?) -> Bool {
+        switch (lhs, rhs) {
+        case (nil, nil):
+            return true
+        case let (lhs?, rhs?):
+            if let lhsKey = lhs.refreshKey, let rhsKey = rhs.refreshKey {
+                return lhsKey == rhsKey && lhs.occurrence == rhs.occurrence
+            }
+            return lhs.refreshKey == nil &&
+                rhs.refreshKey == nil &&
+                lhs.occurrence == rhs.occurrence &&
+                lhs.timestamp == rhs.timestamp
+        default:
+            return false
+        }
+    }
+
+    private static func indexAfterLatestUserTurn(
+        _ latestUserTurn: LatestUserTurn?,
+        in messages: [OpenClawChatMessage])
+        -> [OpenClawChatMessage].Index
+    {
+        guard let latestUserTurn else { return messages.startIndex }
+        if let refreshKey = latestUserTurn.refreshKey {
+            var occurrence = 0
+            for index in messages.indices {
+                guard self.userRefreshIdentityKey(for: messages[index]) == refreshKey else { continue }
+                occurrence += 1
+                if occurrence == latestUserTurn.occurrence {
+                    return messages.index(after: index)
+                }
+            }
+        } else if let timestamp = latestUserTurn.timestamp,
+                  let index = messages.lastIndex(where: { message in
+                      message.role.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "user" &&
+                          message.timestamp == timestamp
+                  })
+        {
+            return messages.index(after: index)
+        }
+
+        return messages.lastIndex(where: { message in
+            message.role.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "user"
+        }).map { messages.index(after: $0) } ?? messages.startIndex
+    }
+
+    private func hasCanonicalFinalMessageMatching(
+        _ message: OpenClawChatMessage,
+        scope: RunMessageScope) -> Bool
+    {
+        guard let key = Self.finalMessageReconciliationKey(for: message) else { return false }
+        guard self.isCurrentSession(scope.session) else { return false }
+        let searchStart = Self.indexAfterLatestUserTurn(scope.latestUserTurn, in: self.messages)
+        guard searchStart < self.messages.endIndex else { return false }
+
+        return self.messages[searchStart...].contains { existing in
+            self.provisionalFinalMessagesByID[existing.id] == nil &&
+                Self.finalMessageReconciliationKey(for: existing) == key
+        }
+    }
+
     private func prunePendingLocalUserEchoMessageIDs() {
         guard !self.pendingLocalUserEchoMessageIDsByRunID.isEmpty else { return }
         let visibleMessageIDs = Set(messages.map(\.id))
         self.pendingLocalUserEchoMessageIDsByRunID = self.pendingLocalUserEchoMessageIDsByRunID.filter {
             self.pendingRuns.contains($0.key) && visibleMessageIDs.contains($0.value)
+        }
+    }
+
+    private func pruneProvisionalFinalMessages() {
+        guard !self.provisionalFinalMessagesByID.isEmpty else { return }
+        let visibleMessageIDs = Set(messages.map(\.id))
+        self.provisionalFinalMessagesByID = self.provisionalFinalMessagesByID.filter { entry in
+            visibleMessageIDs.contains(entry.key) && self.isCurrentSession(entry.value.scope.session)
+        }
+    }
+
+    private func pruneRunMessageScopes() {
+        self.runMessageScopesByRunID = self.runMessageScopesByRunID.filter { entry in
+            self.isCurrentSession(entry.value.session)
+        }
+        guard self.runMessageScopesByRunID.count > 64 else { return }
+        let referencedRunIDs = Set(self.pendingRuns)
+            .union(self.provisionalFinalMessagesByID.values.compactMap(\.runId))
+        self.runMessageScopesByRunID = self.runMessageScopesByRunID.filter { entry in
+            referencedRunIDs.contains(entry.key)
         }
     }
 
@@ -591,6 +735,43 @@ public final class OpenClawChatViewModel {
             errorMessage: incoming.errorMessage)
         self.messages = Self.dedupeMessages(updated)
         self.prunePendingLocalUserEchoMessageIDs()
+        return true
+    }
+
+    private func adoptProvisionalFinalMessage(incoming: OpenClawChatMessage) -> Bool {
+        guard let incomingKey = Self.finalMessageReconciliationKey(for: incoming) else { return false }
+        let canonicalScope = self.currentRunMessageScope()
+        let searchStart = Self.indexAfterLatestUserTurn(canonicalScope.latestUserTurn, in: self.messages)
+        guard searchStart < self.messages.endIndex else { return false }
+
+        guard let matchIndex = messages[searchStart...].lastIndex(where: { existing in
+            guard let provisional = self.provisionalFinalMessagesByID[existing.id] else { return false }
+            return provisional.reconciliationKey == incomingKey &&
+                Self.isSameUserTurnBoundary(provisional.scope.latestUserTurn, canonicalScope.latestUserTurn)
+        }) else {
+            return false
+        }
+
+        let existing = self.messages[matchIndex]
+        let provisional = self.provisionalFinalMessagesByID[existing.id]
+        var updated = self.messages
+        updated[matchIndex] = OpenClawChatMessage(
+            id: existing.id,
+            role: incoming.role,
+            content: incoming.content,
+            timestamp: incoming.timestamp ?? existing.timestamp,
+            toolCallId: incoming.toolCallId,
+            toolName: incoming.toolName,
+            usage: incoming.usage,
+            stopReason: incoming.stopReason,
+            errorMessage: incoming.errorMessage)
+        self.provisionalFinalMessagesByID.removeValue(forKey: existing.id)
+        if let runId = provisional?.runId {
+            self.runMessageScopesByRunID.removeValue(forKey: runId)
+        }
+        self.messages = Self.dedupeMessages(updated)
+        self.pruneProvisionalFinalMessages()
+        self.pruneRunMessageScopes()
         return true
     }
 
@@ -840,6 +1021,7 @@ public final class OpenClawChatViewModel {
                 content: userContent,
                 timestamp: userMessageTimestamp))
         self.pendingLocalUserEchoMessageIDsByRunID[runId] = userMessageID
+        self.runMessageScopesByRunID[runId] = self.currentRunMessageScope()
 
         // Clear input immediately for responsive UX (before network await)
         self.input = ""
@@ -863,9 +1045,11 @@ public final class OpenClawChatViewModel {
                     + "localRunId=\(runId) remoteRunId=\(response.runId)")
             if response.runId != runId {
                 let pendingUserMessageID = self.pendingLocalUserEchoMessageIDsByRunID.removeValue(forKey: runId)
+                let runScope = self.runMessageScopesByRunID.removeValue(forKey: runId)
                 self.clearPendingRun(runId)
                 self.pendingRuns.insert(response.runId)
                 self.pendingLocalUserEchoMessageIDsByRunID[response.runId] = pendingUserMessageID
+                self.runMessageScopesByRunID[response.runId] = runScope
                 self.armPendingRunTimeout(runId: response.runId)
             }
             if response.status == "ok" {
@@ -894,6 +1078,7 @@ public final class OpenClawChatViewModel {
         } catch {
             guard self.isCurrentSession(sessionSnapshot) else { return }
             self.removePendingLocalUserEcho(for: runId)
+            self.runMessageScopesByRunID.removeValue(forKey: runId)
             self.clearPendingRun(runId)
             self.errorText = error.localizedDescription
             self.logDiagnostic(
@@ -955,6 +1140,8 @@ public final class OpenClawChatViewModel {
         self.modelSelectionID = Self.defaultModelSelectionID
         self.messages = []
         self.pendingLocalUserEchoMessageIDsByRunID.removeAll()
+        self.runMessageScopesByRunID.removeAll()
+        self.provisionalFinalMessagesByID.removeAll()
         self.sessionId = nil
         self.pendingToolCallsById = [:]
         self.streamingAssistantText = nil
@@ -989,6 +1176,8 @@ public final class OpenClawChatViewModel {
         self.modelSelectionID = Self.defaultModelSelectionID
         self.messages = []
         self.pendingLocalUserEchoMessageIDsByRunID.removeAll()
+        self.runMessageScopesByRunID.removeAll()
+        self.provisionalFinalMessagesByID.removeAll()
         self.sessionId = nil
         self.pendingToolCallsById = [:]
         self.streamingAssistantText = nil
@@ -1016,6 +1205,8 @@ public final class OpenClawChatViewModel {
             return
         }
 
+        self.runMessageScopesByRunID.removeAll()
+        self.provisionalFinalMessagesByID.removeAll()
         self.startBootstrap()
     }
 
@@ -1519,9 +1710,14 @@ public final class OpenClawChatViewModel {
         if self.adoptPendingLocalUserEcho(incoming: sanitized) {
             return
         }
+        if self.adoptProvisionalFinalMessage(incoming: sanitized) {
+            return
+        }
 
         let reconciled = Self.reconcileMessageIDs(previous: self.messages, incoming: self.messages + [sanitized])
         self.messages = Self.dedupeMessages(reconciled)
+        self.pruneProvisionalFinalMessages()
+        self.pruneRunMessageScopes()
     }
 
     private func handleChatEvent(_ chat: OpenClawChatEventPayload) {
@@ -1608,8 +1804,28 @@ public final class OpenClawChatViewModel {
                 stopReason: "stop")
         }
 
+        let runId = Self.normalizedRunID(chat.runId)
+        let scope = self.runMessageScope(for: runId)
+        guard self.isCurrentSession(scope.session) else { return }
+        guard let reconciliationKey = Self.finalMessageReconciliationKey(for: message) else { return }
+
+        if self.hasCanonicalFinalMessageMatching(message, scope: scope) {
+            if let runId {
+                self.runMessageScopesByRunID.removeValue(forKey: runId)
+            }
+            return
+        }
+
         let reconciled = Self.reconcileMessageIDs(previous: self.messages, incoming: self.messages + [message])
         self.messages = Self.dedupeMessages(reconciled)
+        if self.messages.contains(where: { $0.id == message.id }) {
+            self.provisionalFinalMessagesByID[message.id] = ProvisionalFinalMessage(
+                reconciliationKey: reconciliationKey,
+                runId: runId,
+                scope: scope)
+        }
+        self.pruneProvisionalFinalMessages()
+        self.pruneRunMessageScopes()
     }
 
     private static func isAssistantMessage(_ message: OpenClawChatMessage) -> Bool {
@@ -1761,7 +1977,7 @@ public final class OpenClawChatViewModel {
     }
 
     private func removePendingLocalUserEcho(for runId: String) {
-        guard let messageID = self.pendingLocalUserEchoMessageIDsByRunID[runId] else { return }
+        guard let messageID = pendingLocalUserEchoMessageIDsByRunID[runId] else { return }
         self.messages.removeAll { $0.id == messageID }
         self.pendingLocalUserEchoMessageIDsByRunID[runId] = nil
     }
@@ -1852,7 +2068,7 @@ public final class OpenClawChatViewModel {
         guard let lastUserIndex = messages.lastIndex(where: { $0.role.lowercased() == "user" }) else {
             return nil
         }
-        guard let refreshKey = self.userRefreshIdentityKey(for: messages[lastUserIndex]) else {
+        guard let refreshKey = userRefreshIdentityKey(for: messages[lastUserIndex]) else {
             return LatestUserTurn(
                 refreshKey: nil,
                 occurrence: 0,

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
@@ -3,12 +3,30 @@ import OpenClawKit
 import Testing
 @testable import OpenClawChatUI
 
-private func chatTextMessage(role: String, text: String, timestamp: Double) -> AnyCodable {
-    AnyCodable([
+private func chatTextMessage(role: String, text: String, timestamp: Double, contentId: String? = nil) -> AnyCodable {
+    var content: [String: Any] = ["type": "text", "text": text]
+    if let contentId {
+        content["id"] = contentId
+    }
+    return AnyCodable([
         "role": role,
-        "content": [["type": "text", "text": text]],
+        "content": [content],
         "timestamp": timestamp,
     ])
+}
+
+private func chatTextModelMessage(role: String, text: String, timestamp: Double) -> OpenClawChatMessage {
+    OpenClawChatMessage(
+        role: role,
+        content: [
+            OpenClawChatMessageContent(
+                type: "text",
+                text: text,
+                mimeType: nil,
+                fileName: nil,
+                content: nil),
+        ],
+        timestamp: timestamp)
 }
 
 private func chatErrorMessage(role: String, errorMessage: String, timestamp: Double) -> AnyCodable {
@@ -799,6 +817,175 @@ struct ChatViewModelTests {
         }
     }
 
+    @Test func `session message adopts provisional final event reply`() async throws {
+        let sessionId = "sess-main"
+        let now = Date().timeIntervalSince1970 * 1000
+        let finalRefreshGate = SessionSubscribeGate()
+        let historyCount = AsyncCounter()
+        let history = historyPayload(sessionId: sessionId)
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [history, history],
+            requestHistoryHook: { _ in
+                let count = await historyCount.increment()
+                if count == 2 {
+                    await finalRefreshGate.wait()
+                }
+            })
+        try await loadAndWaitBootstrap(vm: vm, sessionId: sessionId)
+
+        await sendUserMessage(vm, text: "hello")
+        try await waitUntil("pending run starts") { await MainActor.run { vm.pendingRunCount == 1 } }
+        let runId = try await waitForLastSentRunId(transport)
+
+        transport.emit(
+            .chat(
+                OpenClawChatEventPayload(
+                    runId: runId,
+                    sessionKey: "main",
+                    state: "final",
+                    message: chatTextMessage(
+                        role: "assistant",
+                        text: "dedupe me",
+                        timestamp: now + 1,
+                        contentId: "live-final-content"),
+                    errorMessage: nil)))
+
+        try await waitUntil("provisional final visible once") {
+            await MainActor.run {
+                vm.messages.count(where: { msg in
+                    msg.role == "assistant" && msg.content.first?.text == "dedupe me"
+                }) == 1
+            }
+        }
+
+        transport.emit(
+            .sessionMessage(
+                OpenClawSessionMessageEventPayload(
+                    sessionKey: "agent:main:main",
+                    message: chatTextModelMessage(role: "assistant", text: "dedupe me", timestamp: now + 2),
+                    messageId: "msg-assistant-final",
+                    messageSeq: 2)))
+
+        try await waitUntil("canonical session message adopted final event row") {
+            await MainActor.run {
+                let matches = vm.messages.filter { msg in
+                    msg.role == "assistant" && msg.content.first?.text == "dedupe me"
+                }
+                return matches.count == 1 && matches.first?.timestamp == now + 2
+            }
+        }
+
+        await finalRefreshGate.release()
+    }
+
+    @Test func `final event does not duplicate canonical assistant session message`() async throws {
+        let sessionId = "sess-main"
+        let now = Date().timeIntervalSince1970 * 1000
+        let finalRefreshGate = SessionSubscribeGate()
+        let historyCount = AsyncCounter()
+        let history = historyPayload(sessionId: sessionId)
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [history, history],
+            requestHistoryHook: { _ in
+                let count = await historyCount.increment()
+                if count == 2 {
+                    await finalRefreshGate.wait()
+                }
+            })
+        try await loadAndWaitBootstrap(vm: vm, sessionId: sessionId)
+
+        await sendUserMessage(vm, text: "hello")
+        try await waitUntil("pending run starts") { await MainActor.run { vm.pendingRunCount == 1 } }
+        let runId = try await waitForLastSentRunId(transport)
+
+        transport.emit(
+            .sessionMessage(
+                OpenClawSessionMessageEventPayload(
+                    sessionKey: "agent:main:main",
+                    message: chatTextModelMessage(role: "assistant", text: "canonical first", timestamp: now + 2),
+                    messageId: "msg-assistant-first",
+                    messageSeq: 2)))
+
+        try await waitUntil("canonical assistant visible once") {
+            await MainActor.run {
+                vm.messages.count(where: { msg in
+                    msg.role == "assistant" && msg.content.first?.text == "canonical first"
+                }) == 1
+            }
+        }
+
+        transport.emit(
+            .chat(
+                OpenClawChatEventPayload(
+                    runId: runId,
+                    sessionKey: "main",
+                    state: "final",
+                    message: chatTextMessage(role: "assistant", text: "canonical first", timestamp: now + 1),
+                    errorMessage: nil)))
+
+        try await Task.sleep(nanoseconds: 50_000_000)
+        #expect(await MainActor.run {
+            let matches = vm.messages.filter { msg in
+                msg.role == "assistant" && msg.content.first?.text == "canonical first"
+            }
+            return matches.count == 1 && matches.first?.timestamp == now + 2
+        })
+
+        await finalRefreshGate.release()
+    }
+
+    @Test func `later identical session reply does not adopt prior turn provisional final`() async throws {
+        let sessionId = "sess-main"
+        let now = Date().timeIntervalSince1970 * 1000
+        let history = historyPayload(sessionId: sessionId)
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [history, history],
+            sendMessageHook: { runId in
+                OpenClawChatSendResponse(runId: runId, status: "pending")
+            })
+        try await loadAndWaitBootstrap(vm: vm, sessionId: sessionId)
+
+        await sendUserMessage(vm, text: "first turn")
+        try await waitUntil("first pending run starts") { await MainActor.run { vm.pendingRunCount == 1 } }
+        let firstRunId = try await waitForLastSentRunId(transport)
+        transport.emit(
+            .chat(
+                OpenClawChatEventPayload(
+                    runId: firstRunId,
+                    sessionKey: "main",
+                    state: "final",
+                    message: chatTextMessage(role: "assistant", text: "OK", timestamp: now + 1),
+                    errorMessage: nil)))
+
+        try await waitUntil("first provisional final visible") {
+            await MainActor.run {
+                vm.messages.count(where: { msg in
+                    msg.role == "assistant" && msg.content.first?.text == "OK"
+                }) == 1
+            }
+        }
+
+        await sendUserMessage(vm, text: "second turn")
+        try await waitUntil("second pending run starts") { await MainActor.run { vm.pendingRunCount == 1 } }
+
+        transport.emit(
+            .sessionMessage(
+                OpenClawSessionMessageEventPayload(
+                    sessionKey: "agent:main:main",
+                    message: chatTextModelMessage(role: "assistant", text: "OK", timestamp: now + 4),
+                    messageId: "msg-second-assistant",
+                    messageSeq: 4)))
+
+        try await waitUntil("second identical reply appends after second user") {
+            await MainActor.run {
+                let okReplies = vm.messages.filter { msg in
+                    msg.role == "assistant" && msg.content.first?.text == "OK"
+                }
+                return okReplies.count == 2 && vm.messages.last?.timestamp == now + 4
+            }
+        }
+    }
+
     @Test func `completion wait refreshes history and clears pending run`() async throws {
         let sessionId = "sess-main"
         let now = (Date().timeIntervalSince1970 * 1000) + 10000
@@ -1455,7 +1642,11 @@ struct ChatViewModelTests {
     }
 
     @Test func `dedupes gateway echo of local user message`() async throws {
-        let (transport, vm) = await makeViewModel(historyResponses: [historyPayload()])
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [historyPayload()],
+            sendMessageHook: { runId in
+                OpenClawChatSendResponse(runId: runId, status: "pending")
+            })
 
         await MainActor.run { vm.load() }
         try await waitUntil("bootstrap history loaded") { await MainActor.run { vm.messages.isEmpty } }

--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -229,7 +229,7 @@ openclaw gateway stability --json
 
 <AccordionGroup>
   <Accordion title="Privacy and bundle behavior">
-    - Records keep operational metadata: event names, counts, byte sizes, memory readings, queue/session state, channel/plugin names, and redacted session summaries. They do not keep chat text, webhook bodies, tool outputs, raw request or response bodies, tokens, cookies, secret values, hostnames, or raw session ids. Set `diagnostics.enabled: false` to disable the recorder entirely.
+    - Records keep operational metadata: event names, counts, byte sizes, memory readings, queue/session state, approval ids, channel/plugin names, and redacted session summaries. They do not keep chat text, webhook bodies, tool outputs, raw request or response bodies, tokens, cookies, secret values, hostnames, or raw session ids. Set `diagnostics.enabled: false` to disable the recorder entirely.
     - On fatal Gateway exits, shutdown timeouts, and restart startup failures, OpenClaw writes the same diagnostic snapshot to `~/.openclaw/logs/stability/openclaw-stability-*.json` when the recorder has events. Inspect the newest bundle with `openclaw gateway stability --bundle latest`; `--limit`, `--type`, and `--since-seq` also apply to bundle output.
 
   </Accordion>

--- a/docs/gateway/opentelemetry.md
+++ b/docs/gateway/opentelemetry.md
@@ -412,6 +412,10 @@ to them directly without OTLP export.
 - `exec.process.completed` - terminal outcome, duration, target, mode, exit
   code, and failure kind. Command text and working directories are not
   included.
+- `exec.approval.followup_suppressed` - stale approval follow-up dropped after
+  a session rebound. Includes `approvalId`, `reason` (`session_rebound`),
+  `phase` (`direct_delivery` or `gateway_preflight`), and the dispatcher
+  timestamp. Session keys, routes, and command text are not included.
 
 ## Without an exporter
 

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -3823,6 +3823,8 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
             case "exec.process.completed":
               recordExecProcessCompleted(evt);
               return;
+            case "exec.approval.followup_suppressed":
+              return;
             case "log.record":
               recordLogRecord?.(evt, metadata);
               return;

--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -127,7 +127,7 @@ const defaultPublicDeprecatedExportsByEntrypointBudget = Object.freeze({
   "outbound-send-deps": 4,
   "outbound-runtime": 16,
   "file-access-runtime": 2,
-  "infra-runtime": 584,
+  "infra-runtime": 585,
   "ssrf-policy": 1,
   "ssrf-runtime": 1,
   "media-runtime": 2,
@@ -202,11 +202,11 @@ let publicDeprecatedExportsByEntrypointBudget;
 try {
   budgets = {
     publicEntrypoints: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_ENTRYPOINTS", 322),
-    publicExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS", 10401),
+    publicExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS", 10402),
     publicFunctionExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_FUNCTION_EXPORTS", 5220),
     publicDeprecatedExports: readBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_DEPRECATED_EXPORTS",
-      3260,
+      3261,
     ),
     publicWildcardReexports: readBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_WILDCARD_REEXPORTS",

--- a/src/agents/bash-tools.exec-approval-followup.test.ts
+++ b/src/agents/bash-tools.exec-approval-followup.test.ts
@@ -18,6 +18,12 @@ import os from "node:os";
 import path from "node:path";
 import { clearSessionStoreCacheForTest } from "../config/sessions/store.js";
 import { writeSessionStoreForTest } from "../config/sessions/test-helpers.js";
+import {
+  onDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+  waitForDiagnosticEventsDrained,
+  type DiagnosticEventPayload,
+} from "../infra/diagnostic-events.js";
 import { sendMessage } from "../infra/outbound/message.js";
 import {
   buildExecApprovalFollowupPrompt,
@@ -39,6 +45,7 @@ function writeTempSessionStore(entries: Record<string, { sessionId: string }>): 
 
 afterEach(() => {
   vi.resetAllMocks();
+  resetDiagnosticEventsForTest();
   clearSessionStoreCacheForTest();
   while (tempStoreDirs.length > 0) {
     const dir = tempStoreDirs.pop();
@@ -171,6 +178,10 @@ describe("exec approval followup", () => {
     const sessionStore = writeTempSessionStore({
       "agent:main:main": { sessionId: "session-after-reset" },
     });
+    const diagnostics: DiagnosticEventPayload[] = [];
+    onDiagnosticEvent((event) => {
+      diagnostics.push(event);
+    });
 
     const result = await sendExecApprovalFollowup({
       approvalId: "req-denied-rebound",
@@ -184,6 +195,15 @@ describe("exec approval followup", () => {
     });
 
     expect(result).toBe(false);
+    await waitForDiagnosticEventsDrained();
+    expect(diagnostics).toContainEqual(
+      expect.objectContaining({
+        type: "exec.approval.followup_suppressed",
+        approvalId: "req-denied-rebound",
+        reason: "session_rebound",
+        phase: "direct_delivery",
+      }),
+    );
     expect(sendMessage).not.toHaveBeenCalled();
     expect(callGatewayTool).not.toHaveBeenCalled();
   });
@@ -212,6 +232,10 @@ describe("exec approval followup", () => {
     const sessionStore = writeTempSessionStore({
       "agent:main:main": { sessionId: "session-after-reset" },
     });
+    const diagnostics: DiagnosticEventPayload[] = [];
+    onDiagnosticEvent((event) => {
+      diagnostics.push(event);
+    });
 
     const result = await sendExecApprovalFollowup({
       approvalId: "req-finished-rebound",
@@ -225,6 +249,15 @@ describe("exec approval followup", () => {
     });
 
     expect(result).toBe(false);
+    await waitForDiagnosticEventsDrained();
+    expect(diagnostics).toContainEqual(
+      expect.objectContaining({
+        type: "exec.approval.followup_suppressed",
+        approvalId: "req-finished-rebound",
+        reason: "session_rebound",
+        phase: "direct_delivery",
+      }),
+    );
     expect(sendMessage).not.toHaveBeenCalled();
     expect(callGatewayTool).not.toHaveBeenCalled();
   });

--- a/src/agents/bash-tools.exec-approval-followup.ts
+++ b/src/agents/bash-tools.exec-approval-followup.ts
@@ -9,6 +9,7 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import { resolveStorePath } from "../config/sessions/paths.js";
 import { loadSessionStore } from "../config/sessions/store-load.js";
+import { emitDiagnosticEvent } from "../infra/diagnostic-events.js";
 import {
   resolveExternalBestEffortDeliveryTarget,
   type ExternalBestEffortDeliveryTarget,
@@ -394,6 +395,12 @@ export async function sendExecApprovalFollowup(
         sessionStore: params.sessionStore,
       })
     ) {
+      emitDiagnosticEvent({
+        type: "exec.approval.followup_suppressed",
+        approvalId: params.approvalId,
+        reason: "session_rebound",
+        phase: "direct_delivery",
+      });
       log.info(
         `Dropping stale denied exec approval followup ${params.approvalId}: session ${sessionKey ?? ""} was rebound before the approval resolved`,
       );
@@ -423,6 +430,12 @@ export async function sendExecApprovalFollowup(
       sessionStore: params.sessionStore,
     })
   ) {
+    emitDiagnosticEvent({
+      type: "exec.approval.followup_suppressed",
+      approvalId: params.approvalId,
+      reason: "session_rebound",
+      phase: "direct_delivery",
+    });
     log.info(
       `Dropping stale exec approval followup ${params.approvalId} direct fallback: session ${sessionKey ?? ""} was rebound before the approval resolved`,
     );

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -5,6 +5,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ErrorCodes } from "../../../packages/gateway-protocol/src/index.js";
 import type { readAcpSessionMeta } from "../../acp/runtime/session-meta.js";
 import {
+  onDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+  waitForDiagnosticEventsDrained,
+  type DiagnosticEventPayload,
+} from "../../infra/diagnostic-events.js";
+import {
   registerExecApprovalFollowupRuntimeHandoff,
   resetExecApprovalFollowupRuntimeHandoffsForTests,
 } from "../../agents/bash-tools.exec-approval-followup-state.js";
@@ -600,6 +606,7 @@ describe("gateway agent handler", () => {
   afterEach(() => {
     envSnapshot.restore();
     resetDetachedTaskLifecycleRuntimeForTests();
+    resetDiagnosticEventsForTest();
     resetTaskRegistryForTests();
     resetSubagentRegistryForTests({ persist: false });
     subagentRegistryTesting.setDepsForTest();
@@ -3212,6 +3219,10 @@ describe("gateway agent handler", () => {
       lastTo: "123",
     });
     const context = makeContext();
+    const diagnostics: DiagnosticEventPayload[] = [];
+    onDiagnosticEvent((event) => {
+      diagnostics.push(event);
+    });
     const updateSessionStoreCallsBefore = mocks.updateSessionStore.mock.calls.length;
     const agentCommandCallsBefore = mocks.agentCommand.mock.calls.length;
 
@@ -3237,6 +3248,15 @@ describe("gateway agent handler", () => {
       status: "ok",
       summary: expect.stringContaining("exec approval followup dropped"),
     });
+    await waitForDiagnosticEventsDrained();
+    expect(diagnostics).toContainEqual(
+      expect.objectContaining({
+        type: "exec.approval.followup_suppressed",
+        approvalId: "req-rebound-followup",
+        reason: "session_rebound",
+        phase: "gateway_preflight",
+      }),
+    );
     expect(mocks.updateSessionStore.mock.calls.length).toBe(updateSessionStoreCallsBefore);
     expect(mocks.agentCommand.mock.calls.length).toBe(agentCommandCallsBefore);
     const dedupeEntry = context.dedupe.get("agent:exec-approval-followup:req-rebound-followup");

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -77,6 +77,7 @@ import {
 import { hasProviderOwnedSession } from "../../config/sessions/entry-freshness.js";
 import { resolveMaintenanceConfigFromInput } from "../../config/sessions/store-maintenance.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { emitDiagnosticEvent } from "../../infra/diagnostic-events.js";
 import {
   assertAgentRunLifecycleGenerationCurrent,
   claimAgentRunContext,
@@ -1516,6 +1517,12 @@ export const agentHandlers: GatewayRequestHandlers = {
           resolvedSessionId: currentSessionId,
         })
       ) {
+        emitDiagnosticEvent({
+          type: "exec.approval.followup_suppressed",
+          approvalId: execApprovalFollowupApprovalId,
+          reason: "session_rebound",
+          phase: "gateway_preflight",
+        });
         context.logGateway.info(
           `Dropping stale exec approval followup ${execApprovalFollowupApprovalId}: session ${requestedSessionKeyRaw} rebound (expected ${expectedSessionId}, current ${currentSessionId}) before the approval resolved`,
         );

--- a/src/infra/diagnostic-events.test.ts
+++ b/src/infra/diagnostic-events.test.ts
@@ -801,6 +801,32 @@ describe("diagnostic-events", () => {
     expect(internalEvents).toEqual(["log.record"]);
   });
 
+  it("emits exec approval followup suppression events on the public stream", async () => {
+    const events: DiagnosticEventPayload[] = [];
+    onDiagnosticEvent((event) => {
+      events.push(event);
+    });
+
+    emitDiagnosticEvent({
+      type: "exec.approval.followup_suppressed",
+      approvalId: "approval-123",
+      reason: "session_rebound",
+      phase: "gateway_preflight",
+    });
+
+    await waitForDiagnosticEventsDrained();
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "exec.approval.followup_suppressed",
+        approvalId: "approval-123",
+        reason: "session_rebound",
+        phase: "gateway_preflight",
+        ts: expect.any(Number),
+      }),
+    );
+  });
+
   it("keeps trusted private data off shared internal diagnostic listeners", async () => {
     const internalEvents: DiagnosticEventPayload[] = [];
     const trustedEvents: Array<{

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -514,6 +514,13 @@ export type DiagnosticExecProcessCompletedEvent = DiagnosticBaseEvent & {
     | "runtime-error";
 };
 
+export type DiagnosticExecApprovalFollowupSuppressedEvent = DiagnosticBaseEvent & {
+  type: "exec.approval.followup_suppressed";
+  approvalId: string;
+  reason: "session_rebound";
+  phase: "direct_delivery" | "gateway_preflight";
+};
+
 type DiagnosticRunBaseEvent = DiagnosticBaseEvent & {
   runId: string;
   sessionKey?: string;
@@ -769,6 +776,7 @@ export type DiagnosticEventPayload =
   | DiagnosticToolExecutionBlockedEvent
   | DiagnosticSkillUsedEvent
   | DiagnosticExecProcessCompletedEvent
+  | DiagnosticExecApprovalFollowupSuppressedEvent
   | DiagnosticRunStartedEvent
   | DiagnosticRunCompletedEvent
   | DiagnosticHarnessRunStartedEvent
@@ -863,6 +871,7 @@ const ASYNC_DIAGNOSTIC_EVENT_TYPES = new Set<DiagnosticEventPayload["type"]>([
   "tool.execution.blocked",
   "skill.used",
   "exec.process.completed",
+  "exec.approval.followup_suppressed",
   "message.delivery.started",
   "message.delivery.completed",
   "message.delivery.error",

--- a/src/logging/diagnostic-stability-bundle.test.ts
+++ b/src/logging/diagnostic-stability-bundle.test.ts
@@ -281,10 +281,20 @@ describe("diagnostic stability bundles", () => {
           chatId: "chat-id-secret",
           error: "event-error-secret",
         },
+        {
+          seq: 2,
+          ts: 2,
+          type: "exec.approval.followup_suppressed",
+          approvalId: "approval-imported-123",
+          reason: "session_rebound",
+          phase: "gateway_preflight",
+          command: "raw command secret",
+        },
       ],
       summary: {
         byType: {
           "webhook.error": 1,
+          "exec.approval.followup_suppressed": 1,
           "private summary type": 1,
         },
         privateSummary: "summary-secret",
@@ -312,7 +322,18 @@ describe("diagnostic stability bundles", () => {
       type: "webhook.error",
       channel: "telegram",
     });
-    expect(result.bundle.snapshot.summary.byType).toEqual({ "webhook.error": 1 });
+    expect(result.bundle.snapshot.events[1]).toEqual({
+      seq: 2,
+      ts: 2,
+      type: "exec.approval.followup_suppressed",
+      approvalId: "approval-imported-123",
+      reason: "session_rebound",
+      phase: "gateway_preflight",
+    });
+    expect(result.bundle.snapshot.summary.byType).toEqual({
+      "webhook.error": 1,
+      "exec.approval.followup_suppressed": 1,
+    });
     const sanitized = JSON.stringify(result.bundle);
     for (const secret of [
       "private reason",
@@ -327,6 +348,7 @@ describe("diagnostic stability bundles", () => {
       "raw-secret-session",
       "chat-id-secret",
       "event-error-secret",
+      "raw command secret",
       "private summary type",
       "summary-secret",
     ]) {

--- a/src/logging/diagnostic-stability-bundle.ts
+++ b/src/logging/diagnostic-stability-bundle.ts
@@ -696,6 +696,7 @@ function readStabilityEventRecord(
   assignOptionalCodeString(sanitized, "outcome", record.outcome, `${label}.outcome`);
   assignOptionalCodeString(sanitized, "level", record.level, `${label}.level`);
   assignOptionalCodeString(sanitized, "phase", record.phase, `${label}.phase`);
+  assignOptionalCodeString(sanitized, "approvalId", record.approvalId, `${label}.approvalId`);
   assignOptionalCodeString(sanitized, "detector", record.detector, `${label}.detector`);
   assignOptionalCodeString(sanitized, "toolName", record.toolName, `${label}.toolName`);
   assignOptionalCodeString(

--- a/src/logging/diagnostic-stability.test.ts
+++ b/src/logging/diagnostic-stability.test.ts
@@ -144,6 +144,30 @@ describe("diagnostic stability recorder", () => {
     expect(snapshot.events[1]).not.toHaveProperty("reason");
   });
 
+  it("records exec approval followup suppression metadata", async () => {
+    startDiagnosticStabilityRecorder();
+
+    emitDiagnosticEvent({
+      type: "exec.approval.followup_suppressed",
+      approvalId: "approval-123",
+      reason: "session_rebound",
+      phase: "direct_delivery",
+    });
+
+    await waitForDiagnosticEventsDrained();
+
+    const snapshot = getDiagnosticStabilitySnapshot({ limit: 10 });
+    expectFields(snapshot.summary.byType, {
+      "exec.approval.followup_suppressed": 1,
+    });
+    expectFields(snapshot.events[0], {
+      type: "exec.approval.followup_suppressed",
+      approvalId: "approval-123",
+      reason: "session_rebound",
+      phase: "direct_delivery",
+    });
+  });
+
   it("summarizes inbound delivery proof events without message content", () => {
     startDiagnosticStabilityRecorder();
 

--- a/src/logging/diagnostic-stability.ts
+++ b/src/logging/diagnostic-stability.ts
@@ -35,6 +35,7 @@ export type DiagnosticStabilityEventRecord = {
   transport?: string;
   brain?: string;
   toolName?: string;
+  approvalId?: string;
   activeWorkKind?: string;
   pairedToolName?: string;
   provider?: string;
@@ -430,6 +431,11 @@ function sanitizeDiagnosticEvent(event: DiagnosticEventPayload): DiagnosticStabi
       record.timedOut = event.timedOut;
       record.failureKind = event.failureKind;
       assignReasonCode(record, event.failureKind);
+      break;
+    case "exec.approval.followup_suppressed":
+      record.approvalId = event.approvalId;
+      record.phase = event.phase;
+      assignReasonCode(record, event.reason);
       break;
     case "run.started":
       record.provider = event.provider;


### PR DESCRIPTION
Closes #98153

AI-assisted change prepared and reviewed with Codex.

## What Problem This Solves

Fixes an issue where iOS Talk users selecting Gateway Default with a speech provider such as Xiaomi or Microsoft would be routed into an unconfigured realtime session and then hear the iOS system voice instead of their configured Gateway TTS provider.

## Why This Change Was Made

iOS now resolves local ElevenLabs, Gateway `talk.speak`, and explicit realtime configurations as separate runtime routes. Native Gateway speech uses the existing `talk.speak` contract and plays returned PCM or complete audio containers, while preserving the existing local ElevenLabs and explicit realtime behavior. Headerless raw formats without sample-rate metadata continue to fall back safely rather than expanding the Gateway protocol in this fix.

## User Impact

iOS Talk can now use configured Gateway speech providers instead of silently switching to realtime or system speech. Stopping or interrupting synthesis also prevents delayed audio and stale interruption state from leaking into later turns.

## Evidence

- Reporter evidence in #98153 confirms Xiaomi `talk.speak` returns non-empty MP3 audio while current iOS routes the same provider to realtime/system speech.
- Regenerated `apps/ios/OpenClaw.xcodeproj` with XcodeGen 2.45.4.
- `xcodebuild -project apps/ios/OpenClaw.xcodeproj -scheme OpenClaw -destination 'platform=iOS Simulator,name=iPhone 17' build-for-testing` — passed.
- `xcodebuild -project apps/ios/OpenClaw.xcodeproj -scheme OpenClaw -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:OpenClawTests/TalkGatewaySpeechClientTests test-without-building` — 9 tests passed. Xcode 27 beta was terminated only after its known post-test log-finalization hang.
- SwiftFormat lint — 0/4 touched Swift files require formatting.
- `git diff --check` — passed.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean, 0 findings, correctness confidence 0.96.

Live playback with Xiaomi/Microsoft credentials was not available locally; the focused simulator tests cover route selection, Gateway request encoding, audio format selection, credential ownership, delayed synthesis cancellation, and interruption cleanup.
