### PR TITLE
fix: keep queued approval prompts visible

### DIFF
--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -371,6 +371,42 @@ describe("connectGateway", () => {
     expect(host.chatComposerProvisionalRestore).toBeNull();
   });
 
+  it("loads pending plugin approvals from approval lists on hello", async () => {
+    const { host, client } = connectHostGateway();
+    client.request.mockImplementation(async (method: string) => {
+      if (method === "exec.approval.list") {
+        return [];
+      }
+      if (method === "plugin.approval.list") {
+        return [
+          {
+            id: "plugin-approval-from-list",
+            createdAtMs: Date.now(),
+            expiresAtMs: Date.now() + 120_000,
+            request: {
+              title: "Review plugin action",
+              description: "The plugin wants to run a sensitive action.",
+              severity: "high",
+              pluginId: "sage",
+              agentId: "agent-1",
+              sessionKey: "main",
+            },
+          },
+        ];
+      }
+      return {};
+    });
+
+    client.emitHello();
+
+    await vi.waitFor(() => {
+      expect(client.request).toHaveBeenCalledWith("exec.approval.list", {});
+      expect(client.request).toHaveBeenCalledWith("plugin.approval.list", {});
+      expect(host.execApprovalQueue[0]?.id).toBe("plugin-approval-from-list");
+    });
+    expect(host.execApprovalQueue[0]?.kind).toBe("plugin");
+  });
+
   it("ignores stale client onEvent callbacks after reconnect", () => {
     const host = createHost();
 

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -63,6 +63,7 @@ import {
   parseExecApprovalResolved,
   parsePluginApprovalRequested,
   pruneExecApprovalQueue,
+  refreshPendingApprovalQueue,
 } from "./controllers/exec-approval.ts";
 import { loadHealthState, type HealthState } from "./controllers/health.ts";
 import {
@@ -889,6 +890,7 @@ export function connectGateway(host: GatewayHost, options?: ConnectGatewayOption
         host as unknown as SessionsState & { sessionKey: string },
         { force: true },
       );
+      void refreshPendingApprovalQueue(host);
       void loadAgentsThenRefreshActiveTabForClient(host, client);
       scheduleDeferredStartupWork(() => {
         if (host.client !== client) {

--- a/ui/src/ui/app.exec-approval.test.ts
+++ b/ui/src/ui/app.exec-approval.test.ts
@@ -1,10 +1,11 @@
 /* @vitest-environment jsdom */
 
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createStorageMock } from "../test-helpers/storage.ts";
 import type { ExecApprovalRequest } from "./controllers/exec-approval.ts";
 
 type RequestFn = (method: string, params?: unknown) => Promise<unknown>;
+let OpenClawApp: typeof import("./app.ts").OpenClawApp;
 
 function createExecApproval(overrides: Partial<ExecApprovalRequest> = {}): ExecApprovalRequest {
   return {
@@ -34,7 +35,6 @@ async function createApp(
   request: RequestFn,
   queue: ExecApprovalRequest[] = [createExecApproval()],
 ) {
-  const { OpenClawApp } = await import("./app.ts");
   const app = Object.create(OpenClawApp.prototype) as InstanceType<typeof OpenClawApp>;
   Object.defineProperties(app, {
     client: { value: { request }, writable: true },
@@ -46,6 +46,10 @@ async function createApp(
 }
 
 describe("OpenClawApp exec approval decisions", () => {
+  beforeAll(async () => {
+    ({ OpenClawApp } = await import("./app.ts"));
+  }, 60_000);
+
   beforeEach(() => {
     vi.stubGlobal("localStorage", createStorageMock());
   });
@@ -68,6 +72,46 @@ describe("OpenClawApp exec approval decisions", () => {
     expect(app.execApprovalQueue).toEqual([]);
     expect(app.execApprovalError).toBeNull();
     expect(app.execApprovalBusy).toBe(false);
+  });
+
+  it("keeps the approval prompt on the next queued item after resolving the active item", async () => {
+    const request = vi.fn<RequestFn>(async () => ({ ok: true }));
+    const active = createExecApproval({ id: "approval-active", createdAtMs: 2000 });
+    const queued = createExecApproval({
+      id: "approval-queued",
+      request: { command: "pnpm test:changed" },
+      createdAtMs: 1000,
+    });
+    const app = await createApp(request, [active, queued]);
+
+    await app.handleExecApprovalDecision("allow-once");
+
+    expect(request).toHaveBeenCalledWith("exec.approval.resolve", {
+      id: "approval-active",
+      decision: "allow-once",
+    });
+    expect(app.execApprovalQueue).toEqual([queued]);
+    expect(app.execApprovalError).toBeNull();
+    expect(app.execApprovalBusy).toBe(false);
+  });
+
+  it("resolves plugin approvals through the plugin approval method", async () => {
+    const request = vi.fn<RequestFn>(async () => ({ ok: true }));
+    const pluginApproval = createExecApproval({
+      id: "plugin-approval-1",
+      kind: "plugin",
+      pluginTitle: "Plugin approval",
+      request: { command: "Plugin approval" },
+    });
+    const app = await createApp(request, [pluginApproval]);
+
+    await app.handleExecApprovalDecision("allow-once");
+
+    expect(request).toHaveBeenCalledWith("plugin.approval.resolve", {
+      id: "plugin-approval-1",
+      decision: "allow-once",
+    });
+    expect(app.execApprovalQueue).toEqual([]);
   });
 
   it("dismisses and refreshes when the backend reports an already resolved approval", async () => {

--- a/ui/src/ui/components/modal-dialog.test.ts
+++ b/ui/src/ui/components/modal-dialog.test.ts
@@ -13,18 +13,24 @@ import "./modal-dialog.ts";
 let container: HTMLDivElement;
 let restoreDialogPolyfill: () => void;
 
-async function renderModal() {
+async function renderModal(
+  options: {
+    label?: string;
+    description?: string;
+    firstAction?: string;
+    lastAction?: string;
+  } = {},
+) {
+  const label = options.label ?? "Confirm action";
+  const description = options.description ?? "Review the operation before continuing.";
   render(
     html`
-      <openclaw-modal-dialog
-        label="Confirm action"
-        description="Review the operation before continuing."
-      >
+      <openclaw-modal-dialog label=${label} description=${description}>
         <section>
-          <h2 id="modal-title">Confirm action</h2>
-          <p id="modal-description">Review the operation before continuing.</p>
-          <button id="first-action">First</button>
-          <button id="last-action">Last</button>
+          <h2 id="modal-title">${label}</h2>
+          <p id="modal-description">${description}</p>
+          <button id="first-action">${options.firstAction ?? "First"}</button>
+          <button id="last-action">${options.lastAction ?? "Last"}</button>
         </section>
       </openclaw-modal-dialog>
     `,
@@ -132,6 +138,23 @@ describe("openclaw-modal-dialog", () => {
     );
 
     expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("reopens the same dialog instance after content changes while closed", async () => {
+    const { modal, dialog } = await renderModal();
+    dialog.close();
+    expect(dialog.open).toBe(false);
+
+    await renderModal({
+      label: "Next approval",
+      description: "Another item is pending.",
+      firstAction: "Next",
+    });
+
+    const { modal: updatedModal, dialog: updatedDialog } = await getRenderedModalDialog(container);
+    expect(updatedModal).toBe(modal);
+    expect(updatedDialog).toBe(dialog);
+    expect(dialog.open).toBe(true);
   });
 
   it("restores focus when closed and removed", async () => {

--- a/ui/src/ui/components/modal-dialog.ts
+++ b/ui/src/ui/components/modal-dialog.ts
@@ -91,6 +91,10 @@ export class OpenClawModalDialog extends LitElement {
     this.openDialog();
   }
 
+  override updated() {
+    this.openDialog();
+  }
+
   override disconnectedCallback() {
     this.closeDialog();
     this.restoreFocus();
@@ -122,11 +126,11 @@ export class OpenClawModalDialog extends LitElement {
   }
 
   private openDialog() {
-    if (this.opened) {
-      return;
-    }
     const dialog = this.dialogElement;
     if (!dialog) {
+      return;
+    }
+    if (this.opened && dialog.open) {
       return;
     }
     this.opened = true;

--- a/ui/src/ui/views/exec-approval.ts
+++ b/ui/src/ui/views/exec-approval.ts
@@ -205,6 +205,7 @@ export function renderExecApprovalPrompt(state: AppViewState) {
           ${decisions.map(
             (decision) => html`
               <button
+                type="button"
                 class=${approvalDecisionClass(decision)}
                 ?disabled=${state.execApprovalBusy}
                 @click=${() => state.handleExecApprovalDecision(decision)}


### PR DESCRIPTION
﻿Closes #98379

AI-assisted: Yes (Codex)

## What Problem This Solves

Fixes an issue where users resolving one Control UI approval could lose the approval window when another exec/plugin approval was still queued. The remaining approval could stay pending but no longer be visible in the active modal flow.

## Why This Change Was Made

The shared modal primitive now reopens its underlying `<dialog>` when the same custom element instance is reused after the dialog was closed, so queued approval content remains modal-visible after the active item changes. The approval action buttons are explicitly non-submit buttons, and the gateway hello path refreshes pending exec/plugin approval lists so reconnects recover missed approval events.

## User Impact

Users can approve or deny a stack of pending Control UI approvals without the prompt disappearing after the first decision. Reconnects also repopulate pending plugin approvals from the authoritative gateway lists.

## Evidence

Rebased on `origin/main` at `21d1e1f0f` and revalidated:

- `corepack pnpm exec vitest run --config vitest.config.ts --project unit src/ui/components/modal-dialog.test.ts src/ui/app.exec-approval.test.ts src/ui/views/exec-approval.test.ts --reporter=verbose`
- `corepack pnpm exec vitest run --config vitest.config.ts --project unit-node src/ui/app-gateway.node.test.ts --reporter=verbose`
- `git diff --check`
- `corepack pnpm ui:build`
- `codex review --base origin/main` was attempted but could not run in this environment because `codex.exe` returned `Access is denied`.
