### PR TITLE
fix(memory-core): guard qmd mcporter JSON.parse against non-JSON stdout

### DIFF
--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -4184,6 +4184,41 @@ describe("QmdMemoryManager", () => {
     await manager.close();
   });
 
+  it("wraps non-JSON mcporter stdout as a typed error instead of a raw SyntaxError", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          searchMode: "query",
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+          mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
+        },
+      },
+    } as OpenClawConfig;
+
+    spawnMock.mockImplementation((cmd: string, args: string[]) => {
+      const child = createMockChild({ autoClose: false });
+      if (isMcporterCommand(cmd) && args[0] === "call") {
+        // mcporter exits 0 but prints non-JSON to stdout (daemon warning, truncated
+        // output, or CLI flag mismatch). Without the guard this throws a raw
+        // SyntaxError out of runQmdSearchViaMcporter; the guard wraps it.
+        emitAndClose(child, "stdout", "mcporter: daemon warning: connection unstable\n");
+        return child;
+      }
+      emitAndClose(child, "stdout", "[]");
+      return child;
+    });
+
+    const { manager } = await createManager();
+    await expect(
+      manager.search("hello", { sessionKey: "agent:main:slack:dm:u123" }),
+    ).rejects.toThrow(/non-JSON stdout/i);
+    await manager.close();
+  });
+
   it("falls back to QMD <1.1 tool names when query tool is not found", async () => {
     // qmdMcpToolVersion is an instance field — each createManager() starts fresh.
 

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -2726,12 +2726,11 @@ export class QmdMemoryManager implements MemorySearchManager {
       // mcporter (subprocess) can emit non-JSON stdout when output is truncated
       // by maxOutputChars, a daemon warning bleeds onto stdout, or the CLI is
       // killed early. Wrap the SyntaxError so callers get a typed domain error.
-      // Do NOT embed raw stdout in the message: it is surfaced before session
-      // visibility filtering and could leak sensitive content; the original
-      // SyntaxError is preserved as `cause` for diagnostics.
-      throw new Error(`qmd mcporter returned non-JSON stdout: ${(err as Error).message}`, {
-        cause: err,
-      });
+      // The message stays generic on purpose: JSON.parse's SyntaxError message
+      // embeds a snippet of the raw input, which is surfaced before session
+      // visibility filtering and could leak sensitive content. The original
+      // error is preserved as `cause` for developer diagnostics only.
+      throw new Error("qmd mcporter returned non-JSON stdout", { cause: err });
     }
     const parsedRecord = asRecord(parsedUnknown);
     const structuredContent = parsedRecord ? asRecord(parsedRecord.structuredContent) : null;

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -2719,7 +2719,18 @@ export class QmdMemoryManager implements MemorySearchManager {
       throw err;
     }
 
-    const parsedUnknown: unknown = JSON.parse(result.stdout);
+    let parsedUnknown: unknown;
+    try {
+      parsedUnknown = JSON.parse(result.stdout);
+    } catch (err) {
+      // mcporter (subprocess) can emit non-JSON stdout when output is truncated
+      // by maxOutputChars, a daemon warning bleeds onto stdout, or the CLI is
+      // killed early. Wrap the SyntaxError so callers get a typed domain error
+      // with a stdout snippet instead of a raw SyntaxError with no context.
+      throw new Error(
+        `qmd mcporter returned non-JSON stdout: ${(err as Error).message}; first 200 chars: ${result.stdout.slice(0, 200)}`,
+      );
+    }
     const parsedRecord = asRecord(parsedUnknown);
     const structuredContent = parsedRecord ? asRecord(parsedRecord.structuredContent) : null;
     const structured: unknown = structuredContent ?? parsedUnknown;

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -2722,15 +2722,17 @@ export class QmdMemoryManager implements MemorySearchManager {
     let parsedUnknown: unknown;
     try {
       parsedUnknown = JSON.parse(result.stdout);
-    } catch (err) {
+    } catch {
       // mcporter (subprocess) can emit non-JSON stdout when output is truncated
       // by maxOutputChars, a daemon warning bleeds onto stdout, or the CLI is
-      // killed early. Wrap the SyntaxError so callers get a typed domain error.
-      // The message stays generic on purpose: JSON.parse's SyntaxError message
-      // embeds a snippet of the raw input, which is surfaced before session
-      // visibility filtering and could leak sensitive content. The original
-      // error is preserved as `cause` for developer diagnostics only.
-      throw new Error("qmd mcporter returned non-JSON stdout", { cause: err });
+      // killed early. Wrap the failure so callers get a typed domain error.
+      // The thrown Error and its cause both carry generic messages on purpose:
+      // errors.ts formatErrorMessage walks the .cause chain into the user-visible
+      // path, so the JSON.parse SyntaxError (whose message embeds a raw stdout
+      // snippet) must not sit on .cause, or that snippet leaks to the user.
+      throw new Error("qmd mcporter returned non-JSON stdout", {
+        cause: new Error("mcporter stdout was not valid JSON"),
+      });
     }
     const parsedRecord = asRecord(parsedUnknown);
     const structuredContent = parsedRecord ? asRecord(parsedRecord.structuredContent) : null;

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -2725,12 +2725,13 @@ export class QmdMemoryManager implements MemorySearchManager {
     } catch (err) {
       // mcporter (subprocess) can emit non-JSON stdout when output is truncated
       // by maxOutputChars, a daemon warning bleeds onto stdout, or the CLI is
-      // killed early. Wrap the SyntaxError so callers get a typed domain error
-      // with a stdout snippet instead of a raw SyntaxError with no context.
-      throw new Error(
-        `qmd mcporter returned non-JSON stdout: ${(err as Error).message}; first 200 chars: ${result.stdout.slice(0, 200)}`,
-        { cause: err },
-      );
+      // killed early. Wrap the SyntaxError so callers get a typed domain error.
+      // Do NOT embed raw stdout in the message: it is surfaced before session
+      // visibility filtering and could leak sensitive content; the original
+      // SyntaxError is preserved as `cause` for diagnostics.
+      throw new Error(`qmd mcporter returned non-JSON stdout: ${(err as Error).message}`, {
+        cause: err,
+      });
     }
     const parsedRecord = asRecord(parsedUnknown);
     const structuredContent = parsedRecord ? asRecord(parsedRecord.structuredContent) : null;

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -2729,6 +2729,7 @@ export class QmdMemoryManager implements MemorySearchManager {
       // with a stdout snippet instead of a raw SyntaxError with no context.
       throw new Error(
         `qmd mcporter returned non-JSON stdout: ${(err as Error).message}; first 200 chars: ${result.stdout.slice(0, 200)}`,
+        { cause: err },
       );
     }
     const parsedRecord = asRecord(parsedUnknown);


### PR DESCRIPTION
## What Problem This Solves

`runQmdSearchViaMcporter` in `extensions/memory-core/src/memory/qmd-manager.ts` parsed the mcporter subprocess stdout with `JSON.parse` outside the `runMcporter` try/catch. When mcporter exits 0 but prints non-JSON to stdout (daemon warning, output truncated by `maxOutputChars`, CLI killed early, flag mismatch), the `SyntaxError` propagated uncaught. Wrapping it is not enough on its own: `errors.ts formatErrorMessage` walks the `.cause` chain into the user-visible path, so keeping the raw `SyntaxError` on `Error.cause` (whose message embeds a raw stdout snippet) still leaked that snippet through `formatErrorMessage` even when the thrown message was generic.

## Why This Change Was Made

Same JSON.parse guard pattern shipped this week across matrix (#97973), sms (#97999), signal (#98073), plugin-sdk (#98125), and telegram ingress (#98372); `parseListedCollections` in this same file already guards its `JSON.parse`.

The thrown Error message **and its `.cause`** are both deliberately generic. `JSON.parse`'s `SyntaxError` message embeds a snippet of the raw input (e.g. `Unexpected token '<', "<html>..."`), which is surfaced before session visibility filtering and could leak sensitive content. Placing that SyntaxError on `.cause` is unsafe because `formatErrorMessage` traverses `.cause` to build the user-visible message — so the cause now carries only `mcporter stdout was not valid JSON`, and the raw parse detail is not placed on the cause chain at all.

## User Impact

A memory recall that hits a malformed mcporter response fails with a typed, diagnosable Error whose user-visible formatted message is generic — no raw subprocess stdout reaches the user through `formatErrorMessage`. Legitimate JSON, the v1/v2 tool fallback, and the happy path are unchanged.

## Real behavior proof

- **Behavior addressed:** A non-JSON mcporter stdout leaked raw input: first as an uncaught `SyntaxError`, and (after the initial wrap) through `formatErrorMessage` walking `.cause` into the SyntaxError's raw-input snippet.
- **Real environment tested:** Linux x86_64, Node v24.14.0, commit `ecfe4d38d1` on branch `fix/qmd-mcporter-json-parse-guard` (current head, after the cause-chain fix).
- **Exact steps or command run after this patch:** `node --import tsx verify-qmd-cause.mjs` — imports the real `formatErrorMessage` from `openclaw/plugin-sdk/error-runtime`, runs a real `JSON.parse` on a sensitive non-JSON stdout, then compares `formatErrorMessage` over the current-head Error shape (generic cause) vs the pre-fix shape (SyntaxError on cause). The real `QmdMemoryManager` class path is covered by the vitest suite (148 tests, incl. `wraps non-JSON mcporter stdout as a typed error` driving `createManager() -> manager.search() -> runQmdSearchViaMcporter -> guard` with a mocked non-JSON mcporter stdout).
- **Evidence after fix:** Terminal capture of `node` runtime verification (live stdout, copied verbatim):

  ```text
  $ node --import tsx verify-qmd-cause.mjs
  imports the real formatErrorMessage from openclaw/plugin-sdk/error-runtime

  [step 1] JSON.parse(maliciousStdout) -> SyntaxError.message = "Unexpected token '<', \"<html><bod\"... is not valid JSON"

  [step 2] current-head error -> formatErrorMessage (user-visible path):
    "qmd mcporter returned non-JSON stdout | mcporter stdout was not valid JSON"
    leaks raw stdout? NO (generic, safe)

  [step 3] pre-fix error -> same formatErrorMessage:
    "qmd mcporter returned non-JSON stdout | Unexpected *** '<', \"<html><bod\"... is not valid JSON"
    leaks raw stdout? YES (the cause-chain leak this PR closes)

  [step 4] cause chain still present for developer diagnostics:
    fixedErr.cause.message = "mcporter stdout was not valid JSON"

  Verdict: current head surfaces a generic message via formatErrorMessage;
          the .cause chain no longer carries the raw stdout snippet to the user.
  ```

- **Observed result after fix:** `formatErrorMessage(current-head error)` returns `qmd mcporter returned non-JSON stdout | mcporter stdout was not valid JSON` — no raw stdout, no `<html>` snippet, no sensitive bytes from the simulated stdout. The pre-fix shape under the same `formatErrorMessage` includes the SyntaxError's raw snippet (the leak this PR closes). The cause chain is still present for diagnostics, carrying only a generic message.
- **What was not tested:** Live end-to-end against a real mcporter subprocess emitting a daemon warning over an actual QMD collection (the mcporter CLI is not available in CI/local; the patched class path is exercised by the 148-test vitest suite through the real `QmdMemoryManager`, and the formatErrorMessage cause-chain invariant is proven by the node runtime check above).

## Tests and validation

```text
$ pnpm test extensions/memory-core/src/memory/qmd-manager.test.ts
 Test Files  1 passed (1)
      Tests  148 passed (148)

$ pnpm tsgo:extensions:test
EXIT=0 (type check passed)
```

Regression case `wraps non-JSON mcporter stdout as a typed error instead of a raw SyntaxError` drives the real `QmdMemoryManager` via `createManager() -> manager.search()` with a mocked non-JSON mcporter stdout (0-exit) and asserts the rejection matches `/non-JSON stdout/`. The cause-chain redaction invariant (no raw stdout through `formatErrorMessage`) is proven by the node runtime check above.

## Risk checklist

- User-visible behavior: Yes (intended, bounded) - a malformed mcporter stdout now fails recall with a typed Error whose formatted message is generic; valid JSON and the happy path unchanged.
- Config/env/migration behavior: No - no config or env surface touched.
- Security/auth/secrets/network/tool execution: Yes (addressed) - neither the thrown message nor the `.cause` message embeds raw mcporter stdout or the SyntaxError raw-input snippet; `formatErrorMessage` (which walks `.cause`) can no longer surface it. Verified by the node runtime check across the cause chain.
- Plugins/providers/channels/SDK: No - internal to the memory-core plugin; `runQmdSearchViaMcporter` keeps its return type.
- Highest-risk area: raw subprocess stdout leaking into a surfaced error message via the `.cause` chain - resolved by giving both the message and the cause generic text (verified by formatErrorMessage over the current-head error shape).
- Mitigation: 148 qmd-manager tests (incl. the malformed-stdout regression case asserting `/non-JSON stdout/`) + node runtime verification proving `formatErrorMessage` does not leak the raw snippet over the cause chain + tsgo green.

Closes: N/A (no existing issue)
