### PR TITLE
fix: show actionable mobile protocol mismatch recovery

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -90,8 +90,13 @@ data class GatewayConnectionProblem(
   val recommendedNextStep: String?,
   val pauseReconnect: Boolean,
   val retryable: Boolean,
+  val clientMinProtocol: Int? = null,
+  val clientMaxProtocol: Int? = null,
+  val expectedProtocol: Int? = null,
+  val minimumProbeProtocol: Int? = null,
 ) {
   val isPairingRequired: Boolean = code == "PAIRING_REQUIRED"
+  val isProtocolMismatch: Boolean = code == "PROTOCOL_MISMATCH"
   val canAutoRetry: Boolean =
     isPairingRequired &&
       (
@@ -765,6 +770,10 @@ class NodeRuntime(
         recommendedNextStep = details?.recommendedNextStep,
         pauseReconnect = pauseReconnect || details?.pauseReconnect == true,
         retryable = details?.retryable == true,
+        clientMinProtocol = details?.clientMinProtocol,
+        clientMaxProtocol = details?.clientMaxProtocol,
+        expectedProtocol = details?.expectedProtocol,
+        minimumProbeProtocol = details?.minimumProbeProtocol,
       )
   }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
@@ -69,7 +69,7 @@ private enum class GatewayConnectAuthSource {
 }
 
 /**
- * Structured auth failure guidance from the gateway, preserved for reconnect and UI decisions.
+ * Structured connect failure guidance from the gateway, preserved for reconnect and UI decisions.
  */
 data class GatewayConnectErrorDetails(
   val code: String?,
@@ -79,6 +79,10 @@ data class GatewayConnectErrorDetails(
   val reason: String? = null,
   val requestId: String? = null,
   val retryable: Boolean = false,
+  val clientMinProtocol: Int? = null,
+  val clientMaxProtocol: Int? = null,
+  val expectedProtocol: Int? = null,
+  val minimumProbeProtocol: Int? = null,
 )
 
 /**
@@ -889,6 +893,10 @@ class GatewaySession(
                 reason = it["reason"].asStringOrNull(),
                 requestId = normalizePairingRequestId(it["requestId"].asStringOrNull()),
                 retryable = it["retryable"].asBooleanOrNull() == true,
+                clientMinProtocol = it["clientMinProtocol"].asIntOrNull(),
+                clientMaxProtocol = it["clientMaxProtocol"].asIntOrNull(),
+                expectedProtocol = it["expectedProtocol"].asIntOrNull(),
+                minimumProbeProtocol = it["minimumProbeProtocol"].asIntOrNull(),
               )
             }
           ErrorShape(code, msg, details)
@@ -1262,6 +1270,7 @@ internal fun shouldPauseGatewayReconnectAfterAuthFailure(
           )
       )
     "AUTH_TOKEN_MISMATCH" -> deviceTokenRetryBudgetUsed && !pendingDeviceTokenRetry
+    "PROTOCOL_MISMATCH" -> true
     else -> false
   }
 
@@ -1313,6 +1322,12 @@ private fun JsonElement?.asBooleanOrNull(): Boolean? =
 private fun JsonElement?.asLongOrNull(): Long? =
   when (this) {
     is JsonPrimitive -> content.toLongOrNull()
+    else -> null
+  }
+
+private fun JsonElement?.asIntOrNull(): Int? =
+  when (this) {
+    is JsonPrimitive -> content.toIntOrNull()
     else -> null
   }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
@@ -1216,31 +1216,32 @@ internal fun recoveryGatewayDetail(
   if (ready) {
     remoteAddress?.takeIf { it.isNotBlank() } ?: "Ready for chat and voice"
   } else if (
-      nodeCapabilityApprovalState == GatewayNodeApprovalState.PendingApproval ||
-      nodeCapabilityApprovalState == GatewayNodeApprovalState.PendingReapproval ||
-      nodeCapabilityApprovalState == GatewayNodeApprovalState.Unapproved
-    ) {
-      "Gateway paired. Waiting for node capability approval."
-    } else if (gatewayConnectionProblem?.isPairingRequired == true && !gatewayConnectionProblem.canAutoRetry) {
-      recoveryGatewayApprovalCommand(gatewayConnectionProblem)
-        ?.let { "Gateway approval is pending. Run this on the gateway host:" }
-        ?: "Gateway approval is pending. Run openclaw devices list on the gateway host, approve this phone, then retry."
-    } else if (gatewayConnectionProblem?.isPairingRequired == true && gatewayConnectionProblem.canAutoRetry) {
-      "Gateway approval is in progress. OpenClaw will retry automatically."
-    } else if (gatewayConnectionProblem != null) {
-      recoveryGatewayAuthDetail(gatewayConnectionProblem)
-    } else if (nodeCapabilityApprovalState == GatewayNodeApprovalState.Loading) {
-      "Gateway paired. Checking node capability approval."
-    } else if (statusText.contains("operator offline", ignoreCase = true)) {
-      "Gateway paired. Waiting for operator access."
-    } else if (gatewayStatusLooksLikePairing(statusText)) {
-      "Gateway approval is in progress. OpenClaw will retry automatically."
-    } else {
-      remoteAddress?.takeIf { it.isNotBlank() } ?: "Gateway unreachable"
-    }
+    nodeCapabilityApprovalState == GatewayNodeApprovalState.PendingApproval ||
+    nodeCapabilityApprovalState == GatewayNodeApprovalState.PendingReapproval ||
+    nodeCapabilityApprovalState == GatewayNodeApprovalState.Unapproved
+  ) {
+    "Gateway paired. Waiting for node capability approval."
+  } else if (gatewayConnectionProblem?.isPairingRequired == true && !gatewayConnectionProblem.canAutoRetry) {
+    recoveryGatewayApprovalCommand(gatewayConnectionProblem)
+      ?.let { "Gateway approval is pending. Run this on the gateway host:" }
+      ?: "Gateway approval is pending. Run openclaw devices list on the gateway host, approve this phone, then retry."
+  } else if (gatewayConnectionProblem?.isPairingRequired == true && gatewayConnectionProblem.canAutoRetry) {
+    "Gateway approval is in progress. OpenClaw will retry automatically."
+  } else if (gatewayConnectionProblem != null) {
+    recoveryGatewayAuthDetail(gatewayConnectionProblem)
+  } else if (nodeCapabilityApprovalState == GatewayNodeApprovalState.Loading) {
+    "Gateway paired. Checking node capability approval."
+  } else if (statusText.contains("operator offline", ignoreCase = true)) {
+    "Gateway paired. Waiting for operator access."
+  } else if (gatewayStatusLooksLikePairing(statusText)) {
+    "Gateway approval is in progress. OpenClaw will retry automatically."
+  } else {
+    remoteAddress?.takeIf { it.isNotBlank() } ?: "Gateway unreachable"
+  }
 
 internal fun recoveryGatewayAuthDetail(gatewayConnectionProblem: GatewayConnectionProblem): String =
   when (gatewayConnectionProblem.code) {
+    "PROTOCOL_MISMATCH" -> recoveryGatewayProtocolMismatchDetail(gatewayConnectionProblem)
     "AUTH_BOOTSTRAP_TOKEN_INVALID" -> "Setup code expired. Scan a fresh setup QR."
     "AUTH_DEVICE_TOKEN_MISMATCH",
     "AUTH_TOKEN_MISMATCH",
@@ -1259,6 +1260,40 @@ internal fun recoveryGatewayAuthDetail(gatewayConnectionProblem: GatewayConnecti
         else -> gatewayConnectionProblem.message.takeIf { it.isNotBlank() } ?: "Gateway authentication needs attention."
       }
   }
+
+private fun recoveryGatewayProtocolMismatchDetail(gatewayConnectionProblem: GatewayConnectionProblem): String {
+  val clientMin = gatewayConnectionProblem.clientMinProtocol
+  val clientMax = gatewayConnectionProblem.clientMaxProtocol
+  val expected = gatewayConnectionProblem.expectedProtocol
+  val summary =
+    when {
+      clientMax != null && expected != null && clientMax < expected ->
+        "This app is older than the gateway. Update OpenClaw on this device, then retry."
+      clientMin != null && expected != null && clientMin > expected ->
+        "The gateway is older than this app. Update OpenClaw on the gateway host, then retry."
+      else -> "The app and gateway use incompatible protocol versions. Update OpenClaw on both, then retry."
+    }
+  return protocolMismatchVersions(clientMin, clientMax, expected)?.let { "$summary $it" } ?: summary
+}
+
+private fun protocolMismatchVersions(
+  clientMin: Int?,
+  clientMax: Int?,
+  expected: Int?,
+): String? {
+  val clientRange =
+    when {
+      clientMin == null && clientMax == null -> null
+      clientMin != null && clientMin == clientMax -> "app protocol v$clientMin"
+      clientMin != null && clientMax != null -> "app protocols v$clientMin-v$clientMax"
+      clientMin != null -> "app protocol min v$clientMin"
+      else -> "app protocol max v$clientMax"
+    }
+  val gatewayVersion = expected?.let { "gateway protocol v$it" }
+  return listOfNotNull(clientRange, gatewayVersion)
+    .takeIf { it.isNotEmpty() }
+    ?.joinToString(prefix = "(", postfix = ").")
+}
 
 private fun recoveryGatewayApprovalCommand(gatewayConnectionProblem: GatewayConnectionProblem?): String? {
   if (gatewayConnectionProblem?.isPairingRequired != true || gatewayConnectionProblem.canAutoRetry) return null

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionReconnectTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionReconnectTest.kt
@@ -208,6 +208,36 @@ class GatewaySessionReconnectTest {
   }
 
   @Test
+  fun protocolMismatchPausesReconnect() {
+    val error =
+      GatewaySession.ErrorShape(
+        code = "INVALID_REQUEST",
+        message = "protocol mismatch",
+        details =
+          GatewayConnectErrorDetails(
+            code = "PROTOCOL_MISMATCH",
+            canRetryWithDeviceToken = false,
+            recommendedNextStep = null,
+            clientMinProtocol = 4,
+            clientMaxProtocol = 4,
+            expectedProtocol = 5,
+            minimumProbeProtocol = 4,
+          ),
+      )
+
+    assertTrue(
+      shouldPauseGatewayReconnectAfterAuthFailure(
+        error = error,
+        hasBootstrapToken = false,
+        role = "node",
+        scopes = emptyList(),
+        deviceTokenRetryBudgetUsed = false,
+        pendingDeviceTokenRetry = false,
+      ),
+    )
+  }
+
+  @Test
   fun bootstrapRoleUpgradeStillPausesReconnect() {
     val error =
       GatewaySession.ErrorShape(
@@ -294,6 +324,41 @@ class GatewaySessionReconnectTest {
         assertEquals("PAIRING_REQUIRED", error.details?.code)
         assertEquals("not-paired", error.details?.reason)
         assertNull(error.details?.requestId)
+        assertTrue(pauseReconnect)
+      } finally {
+        shutdownReconnectHarness(harness, server)
+      }
+    }
+
+  @Test
+  fun protocolMismatchFailurePreservesProtocolDetailsAndPausesReconnect() =
+    runBlocking {
+      val json = Json { ignoreUnknownKeys = true }
+      val connectFailure = CompletableDeferred<Pair<GatewaySession.ErrorShape, Boolean>>()
+      val server =
+        startGatewayServer(json = json) { webSocket, id, method ->
+          if (method == "connect") {
+            webSocket.send(
+              """
+              {"type":"res","id":"$id","ok":false,"error":{"code":"INVALID_REQUEST","message":"protocol mismatch","details":{"code":"PROTOCOL_MISMATCH","clientMinProtocol":4,"clientMaxProtocol":4,"expectedProtocol":5,"minimumProbeProtocol":4}}}
+              """.trimIndent(),
+            )
+          }
+        }
+      val harness =
+        createReconnectHarness { error, pauseReconnect ->
+          connectFailure.complete(error to pauseReconnect)
+        }
+
+      try {
+        connectNodeSession(harness.session, server.port)
+        val (error, pauseReconnect) = withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { connectFailure.await() }
+
+        assertEquals("PROTOCOL_MISMATCH", error.details?.code)
+        assertEquals(4, error.details?.clientMinProtocol)
+        assertEquals(4, error.details?.clientMaxProtocol)
+        assertEquals(5, error.details?.expectedProtocol)
+        assertEquals(4, error.details?.minimumProbeProtocol)
         assertTrue(pauseReconnect)
       } finally {
         shutdownReconnectHarness(harness, server)

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/OnboardingFlowLogicTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/OnboardingFlowLogicTest.kt
@@ -301,6 +301,68 @@ class OnboardingFlowLogicTest {
   }
 
   @Test
+  fun recoveryGatewayAuthDetailIdentifiesOlderAppProtocolMismatch() {
+    assertEquals(
+      "This app is older than the gateway. Update OpenClaw on this device, then retry. (app protocol v4, gateway protocol v5).",
+      recoveryGatewayAuthDetail(
+        GatewayConnectionProblem(
+          code = "PROTOCOL_MISMATCH",
+          message = "protocol mismatch",
+          reason = null,
+          requestId = null,
+          recommendedNextStep = null,
+          pauseReconnect = true,
+          retryable = false,
+          clientMinProtocol = 4,
+          clientMaxProtocol = 4,
+          expectedProtocol = 5,
+          minimumProbeProtocol = 4,
+        ),
+      ),
+    )
+  }
+
+  @Test
+  fun recoveryGatewayAuthDetailIdentifiesOlderGatewayProtocolMismatch() {
+    assertEquals(
+      "The gateway is older than this app. Update OpenClaw on the gateway host, then retry. (app protocol v4, gateway protocol v3).",
+      recoveryGatewayAuthDetail(
+        GatewayConnectionProblem(
+          code = "PROTOCOL_MISMATCH",
+          message = "protocol mismatch",
+          reason = null,
+          requestId = null,
+          recommendedNextStep = null,
+          pauseReconnect = true,
+          retryable = false,
+          clientMinProtocol = 4,
+          clientMaxProtocol = 4,
+          expectedProtocol = 3,
+          minimumProbeProtocol = 3,
+        ),
+      ),
+    )
+  }
+
+  @Test
+  fun recoveryGatewayAuthDetailKeepsProtocolMismatchFallbackActionable() {
+    assertEquals(
+      "The app and gateway use incompatible protocol versions. Update OpenClaw on both, then retry.",
+      recoveryGatewayAuthDetail(
+        GatewayConnectionProblem(
+          code = "PROTOCOL_MISMATCH",
+          message = "protocol mismatch",
+          reason = null,
+          requestId = null,
+          recommendedNextStep = null,
+          pauseReconnect = true,
+          retryable = false,
+        ),
+      ),
+    )
+  }
+
+  @Test
   fun recoveryGatewayAuthDetailUsesRecommendedNextStepFallbacks() {
     assertEquals(
       "Gateway authentication is not configured. Edit this connection and try again.",

--- a/apps/ios/Sources/Design/SettingsProTabActions.swift
+++ b/apps/ios/Sources/Design/SettingsProTabActions.swift
@@ -360,9 +360,11 @@ extension SettingsProTab {
         }
     }
 
-    func gatewayProblemPrimaryActionTitle(_ problem: GatewayConnectionProblem) -> String {
-        if problem.suggestsOnboardingReset { return "Reset onboarding" }
-        return problem.canTrustRotatedCertificate ? "Trust certificate" : "Retry connection"
+    func gatewayProblemPrimaryActionTitle(_ problem: GatewayConnectionProblem) -> String? {
+        GatewayProblemPrimaryAction.title(
+            for: problem,
+            retryTitle: "Retry connection",
+            resetTitle: "Reset onboarding")
     }
 
     func handleGatewayProblemPrimaryAction(_ problem: GatewayConnectionProblem) async {
@@ -374,6 +376,10 @@ extension SettingsProTab {
             _ = await self.gatewayController.trustRotatedGatewayCertificate(from: problem)
             return
         }
+        if GatewayProblemPrimaryAction.openProtocolMismatchHelpIfNeeded(problem) {
+            return
+        }
+        guard problem.retryable else { return }
         await self.retryGatewayConnectionFromProblem()
     }
 

--- a/apps/ios/Sources/Gateway/GatewayProblemPrimaryAction.swift
+++ b/apps/ios/Sources/Gateway/GatewayProblemPrimaryAction.swift
@@ -1,0 +1,34 @@
+import OpenClawKit
+import UIKit
+
+enum GatewayProblemPrimaryAction {
+    static func title(
+        for problem: GatewayConnectionProblem,
+        retryTitle: String,
+        resetTitle: String? = nil,
+        nonRetryableTitle: String? = nil) -> String?
+    {
+        if problem.suggestsOnboardingReset, let resetTitle {
+            return resetTitle
+        }
+        if problem.canTrustRotatedCertificate {
+            return "Trust certificate"
+        }
+        if problem.kind == .protocolMismatch {
+            return problem.actionLabel
+        }
+        if problem.retryable {
+            return problem.actionLabel ?? retryTitle
+        }
+        return nonRetryableTitle
+    }
+
+    @MainActor
+    static func openProtocolMismatchHelpIfNeeded(_ problem: GatewayConnectionProblem) -> Bool {
+        guard problem.kind == .protocolMismatch else { return false }
+        if let url = problem.docsURL {
+            UIApplication.shared.open(url)
+        }
+        return true
+    }
+}

--- a/apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift
+++ b/apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift
@@ -138,8 +138,8 @@ struct GatewayQuickSetupSheet: View {
             }
     }
 
-    private func gatewayProblemPrimaryActionTitle(_ problem: GatewayConnectionProblem) -> String {
-        problem.canTrustRotatedCertificate ? "Trust certificate" : "Connect"
+    private func gatewayProblemPrimaryActionTitle(_ problem: GatewayConnectionProblem) -> String? {
+        GatewayProblemPrimaryAction.title(for: problem, retryTitle: "Connect")
     }
 
     private func handleGatewayProblemPrimaryAction(_ problem: GatewayConnectionProblem) async {
@@ -147,6 +147,10 @@ struct GatewayQuickSetupSheet: View {
             _ = await self.gatewayController.trustRotatedGatewayCertificate(from: problem)
             return
         }
+        if GatewayProblemPrimaryAction.openProtocolMismatchHelpIfNeeded(problem) {
+            return
+        }
+        guard problem.retryable else { return }
         guard let candidate = self.bestCandidate else { return }
         self.connectError = nil
         self.connecting = true

--- a/apps/ios/Sources/Onboarding/OnboardingWizardView.swift
+++ b/apps/ios/Sources/Onboarding/OnboardingWizardView.swift
@@ -1037,9 +1037,11 @@ extension OnboardingWizardView {
         await self.gatewayController.connectLastKnown()
     }
 
-    private func gatewayProblemPrimaryActionTitle(_ problem: GatewayConnectionProblem) -> String {
-        if problem.suggestsOnboardingReset { return "Scan QR again" }
-        return problem.canTrustRotatedCertificate ? "Trust certificate" : "Retry connection"
+    private func gatewayProblemPrimaryActionTitle(_ problem: GatewayConnectionProblem) -> String? {
+        GatewayProblemPrimaryAction.title(
+            for: problem,
+            retryTitle: "Retry connection",
+            resetTitle: "Scan QR again")
     }
 
     private func handleGatewayProblemPrimaryAction(_ problem: GatewayConnectionProblem) async {
@@ -1064,6 +1066,10 @@ extension OnboardingWizardView {
             _ = await self.gatewayController.trustRotatedGatewayCertificate(from: problem)
             return
         }
+        if GatewayProblemPrimaryAction.openProtocolMismatchHelpIfNeeded(problem) {
+            return
+        }
+        guard problem.retryable else { return }
         await self.retryLastAttempt()
     }
 }

--- a/apps/ios/Sources/RootTabs.swift
+++ b/apps/ios/Sources/RootTabs.swift
@@ -1051,14 +1051,18 @@ extension RootTabs {
         return trimmed.isEmpty ? nil : trimmed
     }
 
-    private func gatewayProblemPrimaryActionTitle(_ problem: GatewayConnectionProblem) -> String {
-        if problem.canTrustRotatedCertificate { return "Trust certificate" }
-        return problem.retryable ? "Retry" : "Open Settings"
+    private func gatewayProblemPrimaryActionTitle(_ problem: GatewayConnectionProblem) -> String? {
+        GatewayProblemPrimaryAction.title(
+            for: problem,
+            retryTitle: "Retry",
+            nonRetryableTitle: "Open Settings")
     }
 
     private func handleGatewayProblemPrimaryAction(_ problem: GatewayConnectionProblem) {
         if problem.canTrustRotatedCertificate {
             Task { await self.gatewayController.trustRotatedGatewayCertificate(from: problem) }
+        } else if GatewayProblemPrimaryAction.openProtocolMismatchHelpIfNeeded(problem) {
+            return
         } else if problem.retryable {
             Task { await self.gatewayController.connectLastKnown() }
         } else {

--- a/apps/ios/SwiftSources.input.xcfilelist
+++ b/apps/ios/SwiftSources.input.xcfilelist
@@ -48,6 +48,7 @@ Sources/Gateway/GatewayConnectionIssue.swift
 Sources/Gateway/GatewayDiscoveryDebugLogView.swift
 Sources/Gateway/GatewayDiscoveryModel.swift
 Sources/Gateway/GatewayHealthMonitor.swift
+Sources/Gateway/GatewayProblemPrimaryAction.swift
 Sources/Gateway/GatewayProblemView.swift
 Sources/Gateway/GatewayQuickSetupSheet.swift
 Sources/Gateway/NotificationPermissionGuidanceDialog.swift

--- a/apps/ios/Tests/GatewayProblemPrimaryActionTests.swift
+++ b/apps/ios/Tests/GatewayProblemPrimaryActionTests.swift
@@ -1,0 +1,36 @@
+import Foundation
+import OpenClawKit
+import Testing
+@testable import OpenClaw
+
+struct GatewayProblemPrimaryActionTests {
+    @Test func `protocol mismatch uses update action instead of retry`() {
+        let problem = GatewayConnectionProblem(
+            kind: .protocolMismatch,
+            owner: .iphone,
+            title: "App update required",
+            message: "This app is older than the gateway.",
+            actionLabel: "Update app",
+            retryable: false,
+            pauseReconnect: true)
+
+        let title = GatewayProblemPrimaryAction.title(for: problem, retryTitle: "Retry connection")
+
+        #expect(title == "Update app")
+    }
+
+    @Test func `retryable problem uses mapped action label`() {
+        let problem = GatewayConnectionProblem(
+            kind: .timeout,
+            owner: .network,
+            title: "Connection timed out",
+            message: "Check the gateway network path.",
+            actionLabel: "Try again",
+            retryable: true,
+            pauseReconnect: false)
+
+        let title = GatewayProblemPrimaryAction.title(for: problem, retryTitle: "Retry connection")
+
+        #expect(title == "Try again")
+    }
+}

--- a/apps/ios/Tests/RootTabsSourceGuardTests.swift
+++ b/apps/ios/Tests/RootTabsSourceGuardTests.swift
@@ -625,6 +625,7 @@ struct RootTabsSourceGuardTests {
         #expect(actionsSource.contains("Run /pair approve in your OpenClaw chat"))
         #expect(actionsSource.contains("self.resetOnboarding()"))
         #expect(actionsSource.contains("self.gatewayController.trustRotatedGatewayCertificate(from: problem)"))
+        #expect(actionsSource.contains("GatewayProblemPrimaryAction.openProtocolMismatchHelpIfNeeded(problem)"))
         #expect(actionsSource.contains("await self.retryGatewayConnectionFromProblem()"))
 
         #expect(settingsSource.contains("GatewayProblemDetailsSheet("))

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
@@ -173,6 +173,29 @@ private func gatewayErrorDetails(_ error: ErrorShape?) -> [String: ProtoAnyCodab
     return details
 }
 
+private func gatewayIntValue(_ value: Any?) -> Int? {
+    if let value = value as? Int {
+        return value
+    }
+    if let value = value as? Int64 {
+        return Int(exactly: value)
+    }
+    if let value = value as? Double, value.rounded() == value {
+        return Int(exactly: value)
+    }
+    if let value = value as? NSNumber, CFGetTypeID(value) != CFBooleanGetTypeID() {
+        let doubleValue = value.doubleValue
+        guard doubleValue.rounded() == doubleValue else {
+            return nil
+        }
+        return Int(exactly: doubleValue)
+    }
+    if let value = value as? String {
+        return Int(value.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+    return nil
+}
+
 private enum ConnectChallengeError: Error {
     case timeout
 }
@@ -834,6 +857,10 @@ public actor GatewayChannelActor {
             let docsURLString = details["docsUrl"]?.value as? String
             let retryableOverride = details["retryable"]?.value as? Bool
             let pauseReconnectOverride = details["pauseReconnect"]?.value as? Bool
+            let clientMinProtocol = gatewayIntValue(details["clientMinProtocol"]?.value)
+            let clientMaxProtocol = gatewayIntValue(details["clientMaxProtocol"]?.value)
+            let expectedProtocol = gatewayIntValue(details["expectedProtocol"]?.value)
+            let minimumProbeProtocol = gatewayIntValue(details["minimumProbeProtocol"]?.value)
             throw GatewayConnectAuthError(
                 message: msg,
                 detailCodeRaw: detailCode,
@@ -848,7 +875,11 @@ public actor GatewayChannelActor {
                 actionCommand: actionCommand,
                 docsURLString: docsURLString,
                 retryableOverride: retryableOverride,
-                pauseReconnectOverride: pauseReconnectOverride)
+                pauseReconnectOverride: pauseReconnectOverride,
+                clientMinProtocol: clientMinProtocol,
+                clientMaxProtocol: clientMaxProtocol,
+                expectedProtocol: expectedProtocol,
+                minimumProbeProtocol: minimumProbeProtocol)
         }
         guard let payload = res.payload else {
             throw NSError(

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayConnectionProblem.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayConnectionProblem.swift
@@ -15,6 +15,7 @@ public struct GatewayConnectionProblem: Equatable, Sendable {
         case pairingRoleUpgradeRequired
         case pairingScopeUpgradeRequired
         case pairingMetadataUpgradeRequired
+        case protocolMismatch
         case deviceIdentityRequired
         case deviceSignatureExpired
         case deviceNonceRequired
@@ -128,7 +129,7 @@ public struct GatewayConnectionProblem: Equatable, Sendable {
     public var statusText: String {
         switch self.kind {
         case .pairingRequired, .pairingRoleUpgradeRequired, .pairingScopeUpgradeRequired,
-             .pairingMetadataUpgradeRequired:
+             .pairingMetadataUpgradeRequired, .protocolMismatch:
             if let requestId {
                 return "\(self.title) (request ID: \(requestId))"
             }
@@ -348,6 +349,8 @@ public enum GatewayConnectionProblemMapper {
                 authError: authError)
         case .pairingRequired:
             return self.pairingProblem(for: authError)
+        case .protocolMismatch:
+            return self.protocolMismatchProblem(for: authError)
         case .controlUiDeviceIdentityRequired, .deviceIdentityRequired:
             return self.problem(
                 kind: .deviceIdentityRequired,
@@ -799,6 +802,52 @@ public enum GatewayConnectionProblemMapper {
         }
     }
 
+    private static func protocolMismatchProblem(for authError: GatewayConnectAuthError) -> GatewayConnectionProblem {
+        let title: String
+        let message: String
+        let owner: GatewayConnectionProblem.Owner
+        let actionLabel: String
+        if let clientMax = authError.clientMaxProtocol,
+           let expected = authError.expectedProtocol,
+           clientMax < expected
+        {
+            title = authError.titleOverride ?? "App update required"
+            message = authError.userMessageOverride
+                ?? "This app is older than the gateway. Update OpenClaw on this device, then retry."
+            owner = .iphone
+            actionLabel = authError.actionLabel ?? "Update app"
+        } else if let clientMin = authError.clientMinProtocol,
+                  let expected = authError.expectedProtocol,
+                  clientMin > expected
+        {
+            title = authError.titleOverride ?? "Gateway update required"
+            message = authError.userMessageOverride
+                ?? "The gateway is older than this app. Update OpenClaw on the gateway host, then retry."
+            owner = .gateway
+            actionLabel = authError.actionLabel ?? "Update gateway"
+        } else {
+            title = authError.titleOverride ?? "OpenClaw update required"
+            message = authError.userMessageOverride
+                ?? "The app and gateway use incompatible protocol versions. Update OpenClaw on both, then retry."
+            owner = .both
+            actionLabel = authError.actionLabel ?? "Update OpenClaw"
+        }
+        return self.problem(
+            kind: .protocolMismatch,
+            owner: owner,
+            title: title,
+            message: message,
+            actionLabel: actionLabel,
+            actionCommand: authError.actionCommand,
+            docsURL: self.docsURL(
+                authError.docsURLString,
+                fallback: "https://docs.openclaw.ai/gateway/troubleshooting"),
+            requestId: authError.requestId,
+            retryable: false,
+            pauseReconnect: true,
+            authError: authError)
+    }
+
     private static func problem(
         kind: GatewayConnectionProblem.Kind,
         owner: GatewayConnectionProblem.Owner,
@@ -851,7 +900,31 @@ public enum GatewayConnectionProblemMapper {
         if authError.canRetryWithDeviceToken {
             parts.append("deviceTokenRetry=true")
         }
+        if let clientRange = self.protocolRange(min: authError.clientMinProtocol, max: authError.clientMaxProtocol) {
+            parts.append("clientProtocol=\(clientRange)")
+        }
+        if let expected = authError.expectedProtocol {
+            parts.append("gatewayProtocol=\(expected)")
+        }
+        if let minimumProbe = authError.minimumProbeProtocol {
+            parts.append("probeMin=\(minimumProbe)")
+        }
         return parts.isEmpty ? nil : parts.joined(separator: " · ")
+    }
+
+    private static func protocolRange(min: Int?, max: Int?) -> String? {
+        switch (min, max) {
+        case (nil, nil):
+            nil
+        case let (min?, max?) where min == max:
+            "\(min)"
+        case let (min?, max?):
+            "\(min)-\(max)"
+        case let (min?, nil):
+            "min \(min)"
+        case let (nil, max?):
+            "max \(max)"
+        }
     }
 
     private static func docsURL(_ preferred: String?, fallback: String?) -> URL? {

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayErrors.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayErrors.swift
@@ -19,6 +19,7 @@ public enum GatewayConnectAuthDetailCode: String, Sendable {
     case authTailscaleWhoisFailed = "AUTH_TAILSCALE_WHOIS_FAILED"
     case authTailscaleIdentityMismatch = "AUTH_TAILSCALE_IDENTITY_MISMATCH"
     case pairingRequired = "PAIRING_REQUIRED"
+    case protocolMismatch = "PROTOCOL_MISMATCH"
     case controlUiDeviceIdentityRequired = "CONTROL_UI_DEVICE_IDENTITY_REQUIRED"
     case deviceIdentityRequired = "DEVICE_IDENTITY_REQUIRED"
     case deviceAuthInvalid = "DEVICE_AUTH_INVALID"
@@ -54,6 +55,10 @@ public struct GatewayConnectAuthError: LocalizedError, Sendable {
     public let docsURLString: String?
     public let retryableOverride: Bool?
     public let pauseReconnectOverride: Bool?
+    public let clientMinProtocol: Int?
+    public let clientMaxProtocol: Int?
+    public let expectedProtocol: Int?
+    public let minimumProbeProtocol: Int?
 
     public init(
         message: String,
@@ -69,7 +74,11 @@ public struct GatewayConnectAuthError: LocalizedError, Sendable {
         actionCommand: String? = nil,
         docsURLString: String? = nil,
         retryableOverride: Bool? = nil,
-        pauseReconnectOverride: Bool? = nil)
+        pauseReconnectOverride: Bool? = nil,
+        clientMinProtocol: Int? = nil,
+        clientMaxProtocol: Int? = nil,
+        expectedProtocol: Int? = nil,
+        minimumProbeProtocol: Int? = nil)
     {
         let trimmedMessage = message.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedDetailCode = detailCodeRaw?.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -90,6 +99,10 @@ public struct GatewayConnectAuthError: LocalizedError, Sendable {
         self.docsURLString = Self.trimmedOrNil(docsURLString)
         self.retryableOverride = retryableOverride
         self.pauseReconnectOverride = pauseReconnectOverride
+        self.clientMinProtocol = clientMinProtocol
+        self.clientMaxProtocol = clientMaxProtocol
+        self.expectedProtocol = expectedProtocol
+        self.minimumProbeProtocol = minimumProbeProtocol
     }
 
     public init(
@@ -106,7 +119,11 @@ public struct GatewayConnectAuthError: LocalizedError, Sendable {
         actionCommand: String? = nil,
         docsURLString: String? = nil,
         retryableOverride: Bool? = nil,
-        pauseReconnectOverride: Bool? = nil)
+        pauseReconnectOverride: Bool? = nil,
+        clientMinProtocol: Int? = nil,
+        clientMaxProtocol: Int? = nil,
+        expectedProtocol: Int? = nil,
+        minimumProbeProtocol: Int? = nil)
     {
         self.init(
             message: message,
@@ -122,7 +139,11 @@ public struct GatewayConnectAuthError: LocalizedError, Sendable {
             actionCommand: actionCommand,
             docsURLString: docsURLString,
             retryableOverride: retryableOverride,
-            pauseReconnectOverride: pauseReconnectOverride)
+            pauseReconnectOverride: pauseReconnectOverride,
+            clientMinProtocol: clientMinProtocol,
+            clientMaxProtocol: clientMaxProtocol,
+            expectedProtocol: expectedProtocol,
+            minimumProbeProtocol: minimumProbeProtocol)
     }
 
     private static func trimmedOrNil(_ value: String?) -> String? {
@@ -163,6 +184,7 @@ public struct GatewayConnectAuthError: LocalizedError, Sendable {
              .authRateLimited,
              .authScopeMismatch,
              .pairingRequired,
+             .protocolMismatch,
              .controlUiDeviceIdentityRequired,
              .deviceIdentityRequired:
             true

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayErrorsTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayErrorsTests.swift
@@ -2,8 +2,8 @@ import Foundation
 import OpenClawKit
 import Testing
 
-@Suite struct GatewayErrorsTests {
-    @Test func bootstrapTokenInvalidIsNonRecoverable() {
+struct GatewayErrorsTests {
+    @Test func `bootstrap token invalid is non recoverable`() {
         let error = GatewayConnectAuthError(
             message: "setup code expired",
             detailCode: GatewayConnectAuthDetailCode.authBootstrapTokenInvalid.rawValue,
@@ -13,7 +13,7 @@ import Testing
         #expect(error.detail == .authBootstrapTokenInvalid)
     }
 
-    @Test func connectAuthErrorPreservesStructuredMetadata() {
+    @Test func `connect auth error preserves structured metadata`() {
         let error = GatewayConnectAuthError(
             message: "pairing required",
             detailCode: GatewayConnectAuthDetailCode.pairingRequired.rawValue,
@@ -28,7 +28,11 @@ import Testing
             actionCommand: "openclaw devices approve req-123",
             docsURLString: "https://docs.openclaw.ai/gateway/pairing",
             retryableOverride: false,
-            pauseReconnectOverride: true)
+            pauseReconnectOverride: true,
+            clientMinProtocol: 4,
+            clientMaxProtocol: 4,
+            expectedProtocol: 5,
+            minimumProbeProtocol: 4)
 
         #expect(error.requestId == "req-123")
         #expect(error.detailsReason == "scope-upgrade")
@@ -37,9 +41,74 @@ import Testing
         #expect(error.actionCommand == "openclaw devices approve req-123")
         #expect(error.docsURLString == "https://docs.openclaw.ai/gateway/pairing")
         #expect(error.pauseReconnectOverride == true)
+        #expect(error.clientMinProtocol == 4)
+        #expect(error.clientMaxProtocol == 4)
+        #expect(error.expectedProtocol == 5)
+        #expect(error.minimumProbeProtocol == 4)
     }
 
-    @Test func pairingProblemUsesStructuredRequestMetadata() {
+    @Test func `protocol mismatch maps older app to update problem`() {
+        let error = GatewayConnectAuthError(
+            message: "protocol mismatch",
+            detailCode: GatewayConnectAuthDetailCode.protocolMismatch.rawValue,
+            canRetryWithDeviceToken: false,
+            clientMinProtocol: 4,
+            clientMaxProtocol: 4,
+            expectedProtocol: 5,
+            minimumProbeProtocol: 4)
+
+        let problem = GatewayConnectionProblemMapper.map(error: error)
+
+        #expect(error.detail == .protocolMismatch)
+        #expect(error.isNonRecoverable)
+        #expect(problem?.kind == .protocolMismatch)
+        #expect(problem?.owner == .iphone)
+        #expect(problem?.title == "App update required")
+        #expect(problem?.message == "This app is older than the gateway. Update OpenClaw on this device, then retry.")
+        #expect(problem?.retryable == false)
+        #expect(problem?.pauseReconnect == true)
+        #expect(problem?.technicalDetails?.contains("clientProtocol=4") == true)
+        #expect(problem?.technicalDetails?.contains("gatewayProtocol=5") == true)
+    }
+
+    @Test func `protocol mismatch maps older gateway to update problem`() {
+        let error = GatewayConnectAuthError(
+            message: "protocol mismatch",
+            detailCode: GatewayConnectAuthDetailCode.protocolMismatch.rawValue,
+            canRetryWithDeviceToken: false,
+            clientMinProtocol: 4,
+            clientMaxProtocol: 4,
+            expectedProtocol: 3,
+            minimumProbeProtocol: 3)
+
+        let problem = GatewayConnectionProblemMapper.map(error: error)
+
+        #expect(problem?.kind == .protocolMismatch)
+        #expect(problem?.owner == .gateway)
+        #expect(problem?.title == "Gateway update required")
+        #expect(problem?
+            .message == "The gateway is older than this app. Update OpenClaw on the gateway host, then retry.")
+        #expect(problem?.retryable == false)
+        #expect(problem?.pauseReconnect == true)
+    }
+
+    @Test func `protocol mismatch without versions still gives actionable fallback`() {
+        let error = GatewayConnectAuthError(
+            message: "protocol mismatch",
+            detailCode: GatewayConnectAuthDetailCode.protocolMismatch.rawValue,
+            canRetryWithDeviceToken: false)
+
+        let problem = GatewayConnectionProblemMapper.map(error: error)
+
+        #expect(problem?.kind == .protocolMismatch)
+        #expect(problem?.owner == .both)
+        #expect(problem?
+            .message == "The app and gateway use incompatible protocol versions. Update OpenClaw on both, then retry.")
+        #expect(problem?.retryable == false)
+        #expect(problem?.pauseReconnect == true)
+    }
+
+    @Test func `pairing problem uses structured request metadata`() {
         let error = GatewayConnectAuthError(
             message: "pairing required",
             detailCode: GatewayConnectAuthDetailCode.pairingRequired.rawValue,
@@ -55,7 +124,7 @@ import Testing
         #expect(problem?.actionCommand == "openclaw devices approve req-123")
     }
 
-    @Test func scopeMismatchMapsToPairingOrRepairProblem() {
+    @Test func `scope mismatch maps to pairing or repair problem`() {
         let error = GatewayConnectAuthError(
             message: "device token scope mismatch",
             detailCode: GatewayConnectAuthDetailCode.authScopeMismatch.rawValue,
@@ -70,7 +139,7 @@ import Testing
         #expect(problem?.needsCredentialUpdate == false)
     }
 
-    @Test func tokenMismatchSuggestsOnboardingReset() {
+    @Test func `token mismatch suggests onboarding reset`() {
         let error = GatewayConnectAuthError(
             message: "token mismatch",
             detailCode: GatewayConnectAuthDetailCode.authTokenMismatch.rawValue,
@@ -83,7 +152,7 @@ import Testing
         #expect(problem?.needsCredentialUpdate == true)
     }
 
-    @Test func cancelledTransportDoesNotReplaceStructuredPairingProblem() {
+    @Test func `cancelled transport does not replace structured pairing problem`() {
         let pairing = GatewayConnectAuthError(
             message: "pairing required",
             detailCode: GatewayConnectAuthDetailCode.pairingRequired.rawValue,
@@ -101,7 +170,7 @@ import Testing
         #expect(preserved?.requestId == "req-123")
     }
 
-    @Test func unmappedTransportErrorClearsStaleStructuredProblem() {
+    @Test func `unmapped transport error clears stale structured problem`() {
         let pairing = GatewayConnectAuthError(
             message: "pairing required",
             detailCode: GatewayConnectAuthDetailCode.pairingRequired.rawValue,
@@ -118,7 +187,7 @@ import Testing
         #expect(mapped == nil)
     }
 
-    @Test func tlsPinMismatchMapsToActionableProblem() {
+    @Test func `tls pin mismatch maps to actionable problem`() {
         let error = GatewayTLSValidationError(
             failure: GatewayTLSValidationFailure(
                 kind: .pinMismatch,
@@ -141,7 +210,7 @@ import Testing
         #expect(problem?.tlsObservedFingerprint == "new")
     }
 
-    @Test func untrustedTLSCertificatePausesReconnect() {
+    @Test func `untrusted TLS certificate pauses reconnect`() {
         let error = GatewayTLSValidationError(
             failure: GatewayTLSValidationFailure(
                 kind: .untrustedCertificate,
@@ -159,7 +228,7 @@ import Testing
         #expect(problem?.pauseReconnect == true)
     }
 
-    @Test func untrustedTLSMismatchCannotBeRecoveredInApp() {
+    @Test func `untrusted TLS mismatch cannot be recovered in app`() {
         let error = GatewayTLSValidationError(
             failure: GatewayTLSValidationFailure(
                 kind: .pinMismatch,

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
@@ -52,6 +52,7 @@ private final class DoubleCallbackPingWebSocketTask: WebSocketTasking, @unchecke
 private final class FakeGatewayWebSocketTask: WebSocketTasking, @unchecked Sendable {
     private let lock = NSLock()
     private let helloAuth: [String: Any]?
+    private let connectError: [String: Any]?
     private var _state: URLSessionTask.State = .suspended
     private var connectRequestId: String?
     private var connectAuth: [String: Any]?
@@ -60,8 +61,9 @@ private final class FakeGatewayWebSocketTask: WebSocketTasking, @unchecked Senda
     private var pendingReceiveHandler:
         (@Sendable (Result<URLSessionWebSocketTask.Message, Error>) -> Void)?
 
-    init(helloAuth: [String: Any]? = nil) {
+    init(helloAuth: [String: Any]? = nil, connectError: [String: Any]? = nil) {
         self.helloAuth = helloAuth
+        self.connectError = connectError
     }
 
     var state: URLSessionTask.State {
@@ -133,9 +135,15 @@ private final class FakeGatewayWebSocketTask: WebSocketTasking, @unchecked Senda
         for _ in 0..<50 {
             let id = self.lock.withLock { self.connectRequestId }
             if let id {
+                if let connectError {
+                    return .data(Self.connectErrorData(id: id, error: connectError))
+                }
                 return .data(Self.connectOkData(id: id, auth: self.helloAuth))
             }
             try await Task.sleep(nanoseconds: 1_000_000)
+        }
+        if let connectError {
+            return .data(Self.connectErrorData(id: "connect", error: connectError))
         }
         return .data(Self.connectOkData(id: "connect", auth: self.helloAuth))
     }
@@ -206,16 +214,28 @@ private final class FakeGatewayWebSocketTask: WebSocketTasking, @unchecked Senda
         ]
         return (try? JSONSerialization.data(withJSONObject: frame)) ?? Data()
     }
+
+    private static func connectErrorData(id: String, error: [String: Any]) -> Data {
+        let frame: [String: Any] = [
+            "type": "res",
+            "id": id,
+            "ok": false,
+            "error": error,
+        ]
+        return (try? JSONSerialization.data(withJSONObject: frame)) ?? Data()
+    }
 }
 
 private final class FakeGatewayWebSocketSession: WebSocketSessioning, @unchecked Sendable {
     private let lock = NSLock()
     private let helloAuth: [String: Any]?
+    private let connectError: [String: Any]?
     private var tasks: [FakeGatewayWebSocketTask] = []
     private var makeCount = 0
 
-    init(helloAuth: [String: Any]? = nil) {
+    init(helloAuth: [String: Any]? = nil, connectError: [String: Any]? = nil) {
         self.helloAuth = helloAuth
+        self.connectError = connectError
     }
 
     func snapshotMakeCount() -> Int {
@@ -230,7 +250,7 @@ private final class FakeGatewayWebSocketSession: WebSocketSessioning, @unchecked
         _ = url
         return self.lock.withLock {
             self.makeCount += 1
-            let task = FakeGatewayWebSocketTask(helloAuth: self.helloAuth)
+            let task = FakeGatewayWebSocketTask(helloAuth: self.helloAuth, connectError: self.connectError)
             self.tasks.append(task)
             return WebSocketTaskBox(task: task)
         }
@@ -424,6 +444,66 @@ struct GatewayNodeSessionTests {
         #expect(auth["password"] as? String == "shared-password")
         #expect(auth["bootstrapToken"] == nil)
         #expect(auth["token"] == nil)
+
+        await gateway.disconnect()
+    }
+
+    @Test
+    func `connect failure preserves protocol mismatch details`() async throws {
+        let session = FakeGatewayWebSocketSession(connectError: [
+            "code": "INVALID_REQUEST",
+            "message": "protocol mismatch",
+            "details": [
+                "code": "PROTOCOL_MISMATCH",
+                "clientMinProtocol": 4,
+                "clientMaxProtocol": 4,
+                "expectedProtocol": 5,
+                "minimumProbeProtocol": 4,
+            ],
+        ])
+        let gateway = GatewayNodeSession()
+        let options = GatewayConnectOptions(
+            role: "operator",
+            scopes: ["operator.read"],
+            caps: [],
+            commands: [],
+            permissions: [:],
+            clientId: "openclaw-ios-test",
+            clientMode: "ui",
+            clientDisplayName: "iOS Test",
+            includeDeviceIdentity: false)
+
+        do {
+            try await gateway.connect(
+                url: #require(URL(string: "ws://example.invalid")),
+                token: "shared-token",
+                bootstrapToken: nil,
+                password: nil,
+                connectOptions: options,
+                sessionBox: WebSocketSessionBox(session: session),
+                onConnected: {},
+                onDisconnected: { _ in },
+                onInvoke: { req in
+                    BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil)
+                })
+            Issue.record("connect unexpectedly succeeded")
+        } catch let error as GatewayConnectAuthError {
+            #expect(error.detail == .protocolMismatch)
+            #expect(error.clientMinProtocol == 4)
+            #expect(error.clientMaxProtocol == 4)
+            #expect(error.expectedProtocol == 5)
+            #expect(error.minimumProbeProtocol == 4)
+
+            let problem = GatewayConnectionProblemMapper.map(error: error)
+            #expect(problem?.kind == .protocolMismatch)
+            #expect(problem?.owner == .iphone)
+            #expect(problem?
+                .message == "This app is older than the gateway. Update OpenClaw on this device, then retry.")
+            #expect(problem?.pauseReconnect == true)
+            #expect(problem?.retryable == false)
+        } catch {
+            Issue.record("unexpected error type: \(error)")
+        }
 
         await gateway.disconnect()
     }


### PR DESCRIPTION
Closes #98384
Related: #91569

AI-assisted: yes.

## What Problem This Solves

Fixes an issue where mobile users connecting to a protocol-skewed gateway would see raw `protocol mismatch` transport text when the gateway already returned structured `PROTOCOL_MISMATCH` details. The affected recovery surfaces are Android onboarding/gateway recovery and shared OpenClawKit connection problem mapping.

## Why This Change Was Made

The fix preserves the gateway's structured protocol mismatch fields at the mobile GatewayChannel boundary and maps them into a first-class, non-retryable version-skew recovery state. Android and OpenClawKit now distinguish app-older, gateway-older, and missing-version fallback cases without changing the gateway protocol or adding a compatibility shim.

## User Impact

Users now get actionable update guidance when the app and gateway cannot talk because their protocol versions are incompatible. Android also pauses reconnect attempts for this update-required state instead of treating it like an ordinary transient auth failure.

## Evidence

- Reproduced current-main Android breakage against a live fake Gateway WebSocket: the gateway returned `details.code = "PROTOCOL_MISMATCH"` with protocol fields, while the UI showed only raw `protocol mismatch`.
- Ran `$autoreview` before commit; first pass found an unsafe Swift numeric conversion in the initial implementation, fixed it, then reran clean with no accepted/actionable findings. Reran local autoreview clean after adding the lower-level iOS response test.
- Android focused tests passed: `./gradlew :app:testPlayDebugUnitTest --tests ai.openclaw.app.gateway.GatewaySessionReconnectTest --tests ai.openclaw.app.ui.OnboardingFlowLogicTest --console=plain`.
- Swift focused tests passed: `swift test --filter GatewayErrorsTests`, `swift test --filter "connect failure preserves protocol mismatch details"`, and `swift test --filter GatewayNodeSessionTests --filter GatewayErrorsTests`.
- Formatting/check proof passed: `swiftformat --config config/swiftformat ...` on edited Swift files, Android ktlint formatting for touched files with unrelated formatter drift undone, and `git diff --check`.
- Live Android fix proof passed on `OpenClaw_QA_API35` with fake gateway + `adb reverse`:
  - app older than gateway: rendered `This app is older than the gateway. Update OpenClaw on this device, then retry. (app protocol v4, gateway protocol v5).`
  - gateway older than app: rendered `The gateway is older than this app. Update OpenClaw on the gateway host, then retry. (app protocol v4, gateway protocol v3).`
  - missing version fields: rendered `The app and gateway use incompatible protocol versions. Update OpenClaw on both, then retry.`
  - raw `protocol mismatch` no longer appeared in the recovery UI.
- Lower-level iOS/OpenClawKit fake GatewayChannel proof passed through the real `GatewayNodeSession.connect()` challenge/connect-failure path and verified the mapped owner/copy/retry behavior.

- Follow-up for review comment #4850141839: iOS gateway problem banners now use a shared primary-action helper, protocol mismatch opens update/help instead of retry/connect, and non-protocol non-retryable settings behavior remains scoped through the caller fallback.
- Focused iOS proof passed after the follow-up: `xcodebuild test -project OpenClaw.xcodeproj -scheme OpenClaw -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:OpenClawTests/GatewayProblemPrimaryActionTests -only-testing:OpenClawTests/RootTabsSourceGuardTests`.
- Live iOS Simulator proof for review comment #4850141839 passed on a dedicated `iPhone 17` simulator named `OpenClaw Protocol Proof 20260630234823` with a local fake Gateway WebSocket returning structured `PROTOCOL_MISMATCH`:
  - The app entered first-run onboarding, applied `ws://localhost:19385`, and rendered the real protocol-mismatch recovery banner with `App update required`, `Fix on this device`, and primary action `Update OpenClaw`.
  - The Xcode result bundle kept screenshots named `protocol-mismatch-banner` and `protocol-mismatch-after-update-action`.
  - The proof-only UI harness tapped `Update OpenClaw`; the fake gateway count stayed at `connectRequests: 1` after the tap, proving the action did not call retry/connect.
  - Command shape: `xcodebuild test -project OpenClaw.xcodeproj -scheme OpenClawUITests -destination 'platform=iOS Simulator,id=337BBD56-DF39-48BB-BF64-03DC76452E35' -only-testing:OpenClawUITests/OpenClawSnapshotUITests/testProtocolMismatchPrimaryActionOpensHelpWithoutRetrying`.
