### PR TITLE
fix: reject unsafe Mattermost API path segments

### DIFF
--- a/extensions/mattermost/src/mattermost/client.test.ts
+++ b/extensions/mattermost/src/mattermost/client.test.ts
@@ -368,6 +368,45 @@ describe("createMattermostClient", () => {
     );
   });
 
+  it("rejects relative API path segments before fetch", async () => {
+    const { client, calls } = createTestClient();
+
+    await expect(client.request("/posts/../users/me")).rejects.toThrow(
+      "Mattermost API path must not contain unsafe path segments",
+    );
+
+    expect(calls).toEqual([]);
+  });
+
+  it("rejects encoded relative API path segments before fetch", async () => {
+    const { client, calls } = createTestClient();
+
+    await expect(client.request("/posts/%2e%2e/users/me")).rejects.toThrow(
+      "Mattermost API path must not contain unsafe path segments",
+    );
+
+    expect(calls).toEqual([]);
+  });
+
+  it("rejects URL-normalized relative API path bypasses before fetch", async () => {
+    const { client, calls } = createTestClient();
+
+    for (const path of [
+      "/posts/..?x=1",
+      "/posts/%2e%2e?x=1",
+      "/posts\\..\\users/me",
+      "/posts/.\n./users/me",
+      "/posts/.%0a./users/me",
+      "/posts/%2e%2e%2fusers%80%2f..%2fme",
+    ]) {
+      await expect(client.request(path)).rejects.toThrow(
+        "Mattermost API path must not contain unsafe path segments",
+      );
+    }
+
+    expect(calls).toEqual([]);
+  });
+
   it("sends Authorization header with Bearer token", async () => {
     const { mockFetch, calls } = createMockFetch({ body: { id: "u1" } });
     const client = createMattermostClient({

--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -91,10 +91,48 @@ export function normalizeMattermostBaseUrl(raw?: string | null): string | undefi
   return withoutTrailing.replace(/\/api\/v4$/i, "");
 }
 
+function decodeMattermostPathSegment(segment: string): string | undefined {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return undefined;
+  }
+}
+
+function stripMattermostUrlIgnoredPathControls(value: string): string {
+  return value.replace(/[\t\r\n]/g, "");
+}
+
+function mattermostPathnameForSegmentValidation(path: string): string {
+  const withoutQueryOrFragment = path.split(/[?#]/, 1)[0] ?? "";
+  return stripMattermostUrlIgnoredPathControls(withoutQueryOrFragment).replace(/\\/g, "/");
+}
+
+function containsMattermostUnsafePathSegment(path: string): boolean {
+  const pathname = mattermostPathnameForSegmentValidation(path);
+  const suffix = pathname.startsWith("/") ? pathname : `/${pathname}`;
+  return suffix.split("/").some((segment) => {
+    if (segment === "." || segment === "..") {
+      return true;
+    }
+    const decodedSegment = decodeMattermostPathSegment(segment);
+    if (decodedSegment == null) {
+      return true;
+    }
+    const decoded = stripMattermostUrlIgnoredPathControls(decodedSegment);
+    return decoded.split(/[\\/]/).some((decodedComponent) => {
+      return decodedComponent === "." || decodedComponent === "..";
+    });
+  });
+}
+
 function buildMattermostApiUrl(baseUrl: string, path: string): string {
   const normalized = normalizeMattermostBaseUrl(baseUrl);
   if (!normalized) {
     throw new Error("Mattermost baseUrl is required");
+  }
+  if (containsMattermostUnsafePathSegment(path)) {
+    throw new Error("Mattermost API path must not contain unsafe path segments");
   }
   const suffix = path.startsWith("/") ? path : `/${path}`;
   return `${normalized}/api/v4${suffix}`;

--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -91,48 +91,22 @@ export function normalizeMattermostBaseUrl(raw?: string | null): string | undefi
   return withoutTrailing.replace(/\/api\/v4$/i, "");
 }
 
-function decodeMattermostPathSegment(segment: string): string | undefined {
-  try {
-    return decodeURIComponent(segment);
-  } catch {
-    return undefined;
-  }
-}
-
-function stripMattermostUrlIgnoredPathControls(value: string): string {
-  return value.replace(/[\t\r\n]/g, "");
-}
-
-function mattermostPathnameForSegmentValidation(path: string): string {
-  const withoutQueryOrFragment = path.split(/[?#]/, 1)[0] ?? "";
-  return stripMattermostUrlIgnoredPathControls(withoutQueryOrFragment).replace(/\\/g, "/");
-}
-
-function containsMattermostUnsafePathSegment(path: string): boolean {
-  const pathname = mattermostPathnameForSegmentValidation(path);
-  const suffix = pathname.startsWith("/") ? pathname : `/${pathname}`;
-  return suffix.split("/").some((segment) => {
-    if (segment === "." || segment === "..") {
-      return true;
-    }
-    const decodedSegment = decodeMattermostPathSegment(segment);
-    if (decodedSegment == null) {
-      return true;
-    }
-    const decoded = stripMattermostUrlIgnoredPathControls(decodedSegment);
-    return decoded.split(/[\\/]/).some((decodedComponent) => {
-      return decodedComponent === "." || decodedComponent === "..";
-    });
-  });
-}
-
 export function buildMattermostApiUrl(baseUrl: string, path: string): string {
   const normalized = normalizeMattermostBaseUrl(baseUrl);
   if (!normalized) {
     throw new Error("Mattermost baseUrl is required");
   }
-  if (containsMattermostUnsafePathSegment(path)) {
-    throw new Error("Mattermost API path must not contain unsafe path segments");
+  const pathname = (path.split(/[?#]/, 1)[0] ?? "").replace(/[\t\r\n]/g, "").replace(/\\/g, "/");
+  for (const segment of pathname.split("/")) {
+    let decoded: string;
+    try {
+      decoded = decodeURIComponent(segment).replace(/[\t\r\n]/g, "");
+    } catch {
+      throw new Error("Mattermost API path must not contain unsafe path segments");
+    }
+    if (decoded.split(/[\\/]/).some((part) => part === "." || part === "..")) {
+      throw new Error("Mattermost API path must not contain unsafe path segments");
+    }
   }
   const suffix = path.startsWith("/") ? path : `/${path}`;
   return `${normalized}/api/v4${suffix}`;

--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -126,7 +126,7 @@ function containsMattermostUnsafePathSegment(path: string): boolean {
   });
 }
 
-function buildMattermostApiUrl(baseUrl: string, path: string): string {
+export function buildMattermostApiUrl(baseUrl: string, path: string): string {
   const normalized = normalizeMattermostBaseUrl(baseUrl);
   if (!normalized) {
     throw new Error("Mattermost baseUrl is required");

--- a/extensions/mattermost/src/mattermost/monitor-resources.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-resources.test.ts
@@ -7,12 +7,16 @@ const sendMattermostTyping = vi.hoisted(() => vi.fn());
 const updateMattermostPost = vi.hoisted(() => vi.fn());
 const buildButtonProps = vi.hoisted(() => vi.fn());
 
-vi.mock("./client.js", () => ({
-  fetchMattermostChannel,
-  fetchMattermostUser,
-  sendMattermostTyping,
-  updateMattermostPost,
-}));
+vi.mock("./client.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./client.js")>();
+  return {
+    ...actual,
+    fetchMattermostChannel,
+    fetchMattermostUser,
+    sendMattermostTyping,
+    updateMattermostPost,
+  };
+});
 
 vi.mock("./interactions.js", () => ({
   buildButtonProps,
@@ -102,6 +106,35 @@ describe("mattermost monitor resources", () => {
       responseHeaderTimeoutMs: 120_000,
       readIdleTimeoutMs: 30_000,
     });
+  });
+
+  it("rejects unsafe file paths before media download", async () => {
+    const saveRemoteMedia = vi.fn();
+    const resources = createMattermostMonitorResources({
+      accountId: "default",
+      callbackUrl: "https://openclaw.test/callback",
+      client: {
+        apiBaseUrl: "https://chat.example.com/api/v4",
+        baseUrl: "https://chat.example.com",
+        token: "test-token",
+      } as never,
+      logger: {},
+      mediaMaxBytes: 1024,
+      saveRemoteMedia,
+      mediaKindFromMime: () => "document",
+    });
+
+    await expect(
+      resources.resolveMattermostMedia([
+        "../users/me",
+        "%2e%2e/users/me",
+        "..\\users\\me",
+        ".%0a./users/me",
+        "%",
+      ]),
+    ).resolves.toEqual([]);
+
+    expect(saveRemoteMedia).not.toHaveBeenCalled();
   });
 
   it("times out inbound media downloads when response headers never arrive", async () => {

--- a/extensions/mattermost/src/mattermost/monitor-resources.ts
+++ b/extensions/mattermost/src/mattermost/monitor-resources.ts
@@ -7,6 +7,7 @@ import {
 } from "openclaw/plugin-sdk/number-runtime";
 import { normalizeStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
+  buildMattermostApiUrl,
   fetchMattermostChannel,
   fetchMattermostUser,
   sendMattermostTyping,
@@ -124,7 +125,7 @@ export function createMattermostMonitorResources(params: {
     for (const fileId of ids) {
       try {
         const saved = await saveRemoteMedia({
-          url: `${client.apiBaseUrl}/files/${fileId}`,
+          url: buildMattermostApiUrl(client.baseUrl, `/files/${fileId}`),
           requestInit: {
             headers: {
               Authorization: `Bearer ${client.token}`,


### PR DESCRIPTION
Closes #98389

## What Problem This Solves

Fixes an issue where Mattermost plugin REST calls could reach a different bearer-token endpoint when a dynamic path component contained relative, URL-normalized, or malformed percent-encoded segments.

The affected workflow is Mattermost channel operation through the plugin REST client. Operators expect post, user, and channel ids to select the intended Mattermost endpoint; unsafe path-shaped values should fail before the client attaches the bot token and calls fetch.

## Why This Change Was Made

The Mattermost client now rejects unsafe API path segments at one shared URL-builder boundary before preparing authorization headers. The direct authenticated media-file download path reuses the same builder. The guard handles raw `.` / `..`, encoded dot segments, backslash separator normalization, URL parser TAB/CR/LF normalization, and malformed percent encoding.

Normal Mattermost paths and request bodies are unchanged. This PR does not alter token storage, account resolution, or Mattermost response handling.

## User Impact

Mattermost users and operators get safer fail-closed behavior for malformed or unexpected REST path inputs. Legitimate Mattermost plugin requests continue to use the same `/api/v4` endpoints.

## Evidence

Before/source proof:

- On current `main`, `buildMattermostApiUrl` appended the requested suffix to `/api/v4` without rejecting dot segments first.
- WHATWG URL parsing normalizes examples like `http://localhost:8065/api/v4/posts/../users/me` to `/api/v4/users/me`, so a path-shaped id can change the endpoint selected under the Mattermost bot token.

After-fix proof on this branch:

- `node scripts/run-vitest.mjs extensions/mattermost/src/mattermost/client.test.ts extensions/mattermost/src/mattermost/monitor-resources.test.ts` — 44 tests passed.
- The media regression supplies raw, encoded, backslash, URL-control, and malformed paths and proves `saveRemoteMedia` receives no request.
- Type-aware targeted oxlint passed for the four touched files.
- `git diff --check` passed.
- Fresh uncommitted and full-branch autoreview passes reported no accepted/actionable findings.

No live Mattermost credentials were used. The requested mocked transport proof exercises the production shared URL builder before either authenticated transport boundary.
