### PR TITLE
Expose disk space doctor lint findings

### DIFF
--- a/src/commands/doctor-disk-space.test.ts
+++ b/src/commands/doctor-disk-space.test.ts
@@ -1,6 +1,11 @@
 // Doctor disk-space tests cover byte formatting, warning generation, and note rendering.
 import { describe, expect, it, vi } from "vitest";
-import { buildDiskSpaceWarnings, formatBytes, noteDiskSpace } from "./doctor-disk-space.js";
+import {
+  buildDiskSpaceWarnings,
+  collectDiskSpaceHealthFindings,
+  formatBytes,
+  noteDiskSpace,
+} from "./doctor-disk-space.js";
 
 vi.mock("../../packages/terminal-core/src/note.js", () => ({
   note: vi.fn(),
@@ -162,5 +167,63 @@ describe("noteDiskSpace", () => {
     });
 
     expect(mockNote).not.toHaveBeenCalled();
+  });
+});
+
+describe("collectDiskSpaceHealthFindings", () => {
+  it("returns a low-space warning finding", () => {
+    const findings = collectDiskSpaceHealthFindings({ gateway: { mode: "local" } } as never, {
+      env: { HOME: "/home/test" },
+      readDiskSpace: () => ({ availableBytes: 300 * 1024 * 1024 }),
+    });
+
+    expect(findings).toEqual([
+      expect.objectContaining({
+        checkId: "core/doctor/disk-space",
+        severity: "warning",
+        message: "Low disk space: 300 MB free on the partition containing /home/test/.openclaw.",
+        path: "/home/test/.openclaw",
+        target: "300 MB",
+        requirement: "low-free-space",
+        fixHint: expect.stringContaining("prevent future config/session write failures"),
+      }),
+    ]);
+  });
+
+  it("returns a critical-space warning finding", () => {
+    const findings = collectDiskSpaceHealthFindings({ gateway: { mode: "local" } } as never, {
+      env: { HOME: "/home/test" },
+      readDiskSpace: () => ({ availableBytes: 50 * 1024 * 1024 }),
+    });
+
+    expect(findings).toEqual([
+      expect.objectContaining({
+        checkId: "core/doctor/disk-space",
+        severity: "warning",
+        message: "CRITICAL: only 50 MB free on the partition containing /home/test/.openclaw.",
+        path: "/home/test/.openclaw",
+        target: "50 MB",
+        requirement: "critical-free-space",
+        fixHint: expect.stringContaining("avoid data loss"),
+      }),
+    ]);
+  });
+
+  it("returns no finding when space is sufficient", () => {
+    const findings = collectDiskSpaceHealthFindings({ gateway: { mode: "local" } } as never, {
+      env: { HOME: "/home/test" },
+      readDiskSpace: () => ({ availableBytes: 10 * 1024 * 1024 * 1024 }),
+    });
+
+    expect(findings).toEqual([]);
+  });
+
+  it("returns no finding when disk space cannot be read", () => {
+    const findings = collectDiskSpaceHealthFindings({ gateway: { mode: "local" } } as never, {
+      env: { HOME: "/home/test" },
+      readDiskSpace: () => null,
+    });
+
+    expect(findings).toEqual([]);
   });
 });

--- a/src/commands/doctor-disk-space.ts
+++ b/src/commands/doctor-disk-space.ts
@@ -3,9 +3,12 @@ import os from "node:os";
 import { note } from "../../packages/terminal-core/src/note.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";
+import type { HealthFinding } from "../flows/health-checks.js";
 import { tryReadDiskSpace } from "../infra/disk-space.js";
 import { resolveRequiredHomeDir } from "../infra/home-dir.js";
 import { shortenHomePath } from "../utils.js";
+
+const DISK_SPACE_CHECK_ID = "core/doctor/disk-space";
 
 // 100 MB — below this, config writes and session transcripts are likely to
 // fail silently, causing data loss.
@@ -65,6 +68,67 @@ export function buildDiskSpaceWarnings(params: {
   return warnings;
 }
 
+function collectDiskSpaceWarnings(params: {
+  env?: NodeJS.ProcessEnv;
+  readDiskSpace?: (targetPath: string) => { availableBytes: number } | null;
+}): { availableBytes: number; stateDir: string; warnings: readonly string[] } | null {
+  const env = params.env ?? process.env;
+  const homedir = () => resolveRequiredHomeDir(env, os.homedir);
+  const stateDir = resolveStateDir(env, homedir);
+
+  const readDiskSpace = params.readDiskSpace ?? tryReadDiskSpace;
+  const snapshot = readDiskSpace(stateDir);
+  // If we cannot determine free space (no existing ancestor, unsupported FS,
+  // or permission error), skip silently — other contributions already
+  // handle missing directories.
+  if (!snapshot) {
+    return null;
+  }
+
+  const displayStateDir = shortenHomePath(stateDir);
+  const warnings = buildDiskSpaceWarnings({
+    availableBytes: snapshot.availableBytes,
+    displayStateDir,
+  });
+
+  return {
+    availableBytes: snapshot.availableBytes,
+    stateDir,
+    warnings,
+  };
+}
+
+/** Collects read-only structured findings for low disk space around the state directory. */
+export function collectDiskSpaceHealthFindings(
+  _cfg: OpenClawConfig, // reserved for API consistency with other Doctor contributions
+  deps?: {
+    env?: NodeJS.ProcessEnv;
+    readDiskSpace?: (targetPath: string) => { availableBytes: number } | null;
+  },
+): readonly HealthFinding[] {
+  const result = collectDiskSpaceWarnings({
+    env: deps?.env,
+    readDiskSpace: deps?.readDiskSpace,
+  });
+  if (!result || result.warnings.length === 0) {
+    return [];
+  }
+
+  const [message, ...details] = result.warnings;
+  return [
+    {
+      checkId: DISK_SPACE_CHECK_ID,
+      severity: "warning",
+      message: message.replace(/^- /, ""),
+      path: result.stateDir,
+      target: formatBytes(result.availableBytes),
+      requirement:
+        result.availableBytes < CRITICAL_BYTES ? "critical-free-space" : "low-free-space",
+      fixHint: details.map((line) => line.replace(/^- /, "")).join(" "),
+    },
+  ];
+}
+
 /**
  * Doctor health contribution: check free disk space on the partition that
  * holds the state directory and warn when it drops below safe thresholds.
@@ -85,26 +149,13 @@ export function noteDiskSpace(
     readDiskSpace?: (targetPath: string) => { availableBytes: number } | null;
   },
 ): void {
-  const env = deps?.env ?? process.env;
-  const homedir = () => resolveRequiredHomeDir(env, os.homedir);
-  const stateDir = resolveStateDir(env, homedir);
-
-  const readDiskSpace = deps?.readDiskSpace ?? tryReadDiskSpace;
-  const snapshot = readDiskSpace(stateDir);
-  // If we cannot determine free space (no existing ancestor, unsupported FS,
-  // or permission error), skip silently — other contributions already
-  // handle missing directories.
-  if (!snapshot) {
+  const result = collectDiskSpaceWarnings({
+    env: deps?.env,
+    readDiskSpace: deps?.readDiskSpace,
+  });
+  if (!result || result.warnings.length === 0) {
     return;
   }
 
-  const displayStateDir = shortenHomePath(stateDir);
-  const warnings = buildDiskSpaceWarnings({
-    availableBytes: snapshot.availableBytes,
-    displayStateDir,
-  });
-
-  if (warnings.length > 0) {
-    note(warnings.join("\n"), "Disk space");
-  }
+  note(result.warnings.join("\n"), "Disk space");
 }

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -10,7 +10,7 @@ import {
   shouldSkipLegacyUpdateDoctorConfigWrite,
 } from "./doctor-health-contributions.js";
 import { runDoctorLintChecks } from "./doctor-lint-flow.js";
-import type { HealthCheck } from "./health-checks.js";
+import type { HealthCheck, HealthFinding } from "./health-checks.js";
 
 const mocks = vi.hoisted(() => ({
   maybeRunConfiguredPluginInstallReleaseStep: vi.fn(),
@@ -83,7 +83,7 @@ const mocks = vi.hoisted(() => ({
   gatherDaemonStatus: vi.fn(),
   noteWorkspaceStatus: vi.fn(),
   collectWorkspaceStatusHealthFindings: vi.fn().mockResolvedValue([]),
-  collectDiskSpaceHealthFindings: vi.fn(() => []),
+  collectDiskSpaceHealthFindings: vi.fn((): readonly HealthFinding[] => []),
   collectDevicePairingHealthFindings: vi.fn(async () => []),
   scanConfiguredChannelPluginBlockers: vi.fn(
     (): Array<{ channelId: string; pluginId: string; reason: string }> => [],

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -83,6 +83,7 @@ const mocks = vi.hoisted(() => ({
   gatherDaemonStatus: vi.fn(),
   noteWorkspaceStatus: vi.fn(),
   collectWorkspaceStatusHealthFindings: vi.fn().mockResolvedValue([]),
+  collectDiskSpaceHealthFindings: vi.fn(() => []),
   collectDevicePairingHealthFindings: vi.fn(async () => []),
   scanConfiguredChannelPluginBlockers: vi.fn(
     (): Array<{ channelId: string; pluginId: string; reason: string }> => [],
@@ -297,6 +298,11 @@ vi.mock("../commands/doctor-workspace-status.js", () => ({
   collectWorkspaceStatusHealthFindings: mocks.collectWorkspaceStatusHealthFindings,
 }));
 
+vi.mock("../commands/doctor-disk-space.js", () => ({
+  noteDiskSpace: vi.fn(),
+  collectDiskSpaceHealthFindings: mocks.collectDiskSpaceHealthFindings,
+}));
+
 vi.mock("../commands/doctor-device-pairing.js", () => ({
   collectDevicePairingHealthFindings: mocks.collectDevicePairingHealthFindings,
   noteDevicePairingHealth: vi.fn().mockResolvedValue(undefined),
@@ -490,6 +496,8 @@ describe("doctor health contributions", () => {
     mocks.noteWorkspaceStatus.mockReset();
     mocks.collectWorkspaceStatusHealthFindings.mockReset();
     mocks.collectWorkspaceStatusHealthFindings.mockResolvedValue([]);
+    mocks.collectDiskSpaceHealthFindings.mockReset();
+    mocks.collectDiskSpaceHealthFindings.mockReturnValue([]);
     mocks.collectDevicePairingHealthFindings.mockReset();
     mocks.collectDevicePairingHealthFindings.mockResolvedValue([]);
     mocks.scanConfiguredChannelPluginBlockers.mockReset();
@@ -1211,6 +1219,7 @@ describe("doctor health contributions", () => {
     expect(contributionIds).toContain("core/doctor/session-snapshots");
     expect(contributionIds).toContain("core/doctor/plugin-registry");
     expect(contributionIds).toContain("core/doctor/configured-plugin-installs");
+    expect(contributionIds).toContain("core/doctor/disk-space");
     expect(contributionIds).toContain("core/doctor/device-pairing");
     expect(contributionIds).toContain("core/doctor/channel-plugin-blockers");
     expect(contributionIds).toContain("core/doctor/tool-result-cap");
@@ -1401,6 +1410,47 @@ describe("doctor health contributions", () => {
     });
 
     expect(findings).toEqual([]);
+  });
+
+  it("keeps disk space opt-in for default lint selection", async () => {
+    const contributionChecks = await resolveDoctorContributionHealthChecks();
+    const diskSpaceCheck = contributionChecks.find(
+      (check) => check.id === "core/doctor/disk-space",
+    );
+    expect(diskSpaceCheck).toMatchObject({ defaultEnabled: false });
+    expect(diskSpaceCheck).toBeDefined();
+
+    const ctx = {
+      cfg: {},
+      mode: "lint",
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+    } as const;
+    const checks = [diskSpaceCheck!];
+
+    await expect(runDoctorLintChecks(ctx, { checks })).resolves.toMatchObject({
+      checksRun: 0,
+      checksSkipped: 1,
+    });
+    expect(mocks.collectDiskSpaceHealthFindings).not.toHaveBeenCalled();
+
+    mocks.collectDiskSpaceHealthFindings.mockReturnValueOnce([
+      {
+        checkId: "core/doctor/disk-space",
+        severity: "warning",
+        message: "Low disk space: 300 MB free on the partition containing ~/.openclaw.",
+        path: "/home/test/.openclaw",
+        requirement: "low-free-space",
+      },
+    ]);
+
+    await expect(
+      runDoctorLintChecks(ctx, { checks, onlyIds: ["core/doctor/disk-space"] }),
+    ).resolves.toMatchObject({
+      checksRun: 1,
+      checksSkipped: 0,
+      findings: [expect.objectContaining({ checkId: "core/doctor/disk-space" })],
+    });
+    expect(mocks.collectDiskSpaceHealthFindings).toHaveBeenCalledWith(ctx.cfg);
   });
 
   it("keeps device pairing opt-in for default lint selection", async () => {

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -1521,6 +1521,16 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
     createDoctorHealthContribution({
       id: "doctor:disk-space",
       label: "Disk space",
+      healthChecks: {
+        id: "core/doctor/disk-space",
+        description: "Low disk space around the OpenClaw state directory is a finding.",
+        defaultEnabled: false,
+        async detect(ctx) {
+          const { collectDiskSpaceHealthFindings } =
+            await import("../commands/doctor-disk-space.js");
+          return collectDiskSpaceHealthFindings(ctx.cfg);
+        },
+      },
       run: runDiskSpaceHealth,
     }),
     createDoctorHealthContribution({


### PR DESCRIPTION
## Summary
- add a default-disabled `core/doctor/disk-space` structured health check for low free space around `OPENCLAW_STATE_DIR`
- reuse the existing Doctor disk-space warning builder so legacy `doctor` note output and structured lint findings share thresholds/messages
- keep real behavior read-only: no config, plugin, SDK, or persisted data contract changes

## Real behavior proof
- Source CLI with isolated `OPENCLAW_CONFIG_PATH` and `OPENCLAW_STATE_DIR`:
  - `node scripts/run-node.mjs doctor --lint --json` ran broad default lint with `disk=0`, proving default lint skips the new default-disabled check
  - `node scripts/run-node.mjs doctor --lint --json --only core/doctor/disk-space` ran `checksRun=1`, `checksSkipped=36`, `disk=0`, exit 0 on a healthy temp state partition
- Focused source harness proves positive low/critical findings by injecting disk-space snapshots for 300 MB and 50 MB free.

## Validation
- Rebased onto current `main` after #97500 merged and fixed the CI `check-test-types` failure by typing the disk-space health-finding mock.
- `node scripts/run-vitest.mjs src/commands/doctor-disk-space.test.ts src/flows/doctor-health-contributions.test.ts`
- `./node_modules/.bin/oxfmt --check src/commands/doctor-disk-space.test.ts src/commands/doctor-disk-space.ts src/flows/doctor-health-contributions.test.ts src/flows/doctor-health-contributions.ts`
- `./node_modules/.bin/oxlint src/commands/doctor-disk-space.test.ts src/commands/doctor-disk-space.ts src/flows/doctor-health-contributions.test.ts src/flows/doctor-health-contributions.ts`
- `pnpm tsgo:core:test`
- `pnpm tsgo:core`
- `node scripts/plugin-sdk-surface-report.mjs --check`
- `git diff --check origin/main...HEAD`
