### PR TITLE
fix: ignore stale approval resolve errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI approval prompts:** keep stale resolve failures and busy-state cleanup from leaking across newer approvals or Gateway reconnects. (#98394) Thanks @haruaiclone-droid.
 - **Agent empty replies:** surface a visible failure when a completed interactive turn has no deliverable reply, including queued follow-ups, while preserving explicit silence, pending continuations, and committed side effects. (#100456) Thanks @mushuiyu886.
 - **Child process output safety:** prevent stdout/stderr pipe failures from crashing agent exec sessions, local TUI shell commands, and bounded process execution. (#100407, #100406, #100410) Thanks @cxbAsDev.
 - **Background refresh isolation:** keep remote skill-bin refreshes running when one node fails, and contain periodic subagent-sweeper failures without hiding errors from direct callers. (#100393, #100390) Thanks @cxbAsDev.

--- a/ui/src/app/overlays.test.ts
+++ b/ui/src/app/overlays.test.ts
@@ -1,0 +1,144 @@
+// Control UI tests cover application-owned overlay races.
+import { describe, expect, it, vi } from "vitest";
+import type { GatewayBrowserClient, GatewayEventFrame } from "../api/gateway.ts";
+import type { ApplicationGateway, ApplicationGatewaySnapshot } from "./gateway.ts";
+import { createApplicationOverlays } from "./overlays.ts";
+
+type RequestFn = (method: string, params?: unknown) => Promise<unknown>;
+
+function deferred<T = unknown>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}
+
+function approval(id: string, createdAtMs: number) {
+  return {
+    id,
+    createdAtMs,
+    expiresAtMs: Date.now() + 60_000,
+    request: { command: `echo ${id}` },
+  };
+}
+
+function createGatewayHarness(initialClient: GatewayBrowserClient) {
+  let snapshot: ApplicationGatewaySnapshot = {
+    assistantAgentId: "main",
+    client: initialClient,
+    connected: true,
+    hello: null,
+    lastError: null,
+    lastErrorCode: null,
+    sessionKey: "main",
+  };
+  const snapshotListeners = new Set<(next: ApplicationGatewaySnapshot) => void>();
+  const eventListeners = new Set<(event: GatewayEventFrame) => void>();
+  const gateway = {
+    get snapshot() {
+      return snapshot;
+    },
+    connection: { gatewayUrl: "ws://gateway.test", password: "", token: "" },
+    eventLog: [],
+    connect() {},
+    setSessionKey() {},
+    start() {},
+    stop() {},
+    subscribe(listener: (next: ApplicationGatewaySnapshot) => void) {
+      snapshotListeners.add(listener);
+      return () => snapshotListeners.delete(listener);
+    },
+    subscribeEventLog() {
+      return () => {};
+    },
+    subscribeEvents(listener: (event: GatewayEventFrame) => void) {
+      eventListeners.add(listener);
+      return () => eventListeners.delete(listener);
+    },
+  } satisfies ApplicationGateway;
+  return {
+    emitApproval(id: string, createdAtMs: number) {
+      const event: GatewayEventFrame = {
+        event: "exec.approval.requested",
+        payload: approval(id, createdAtMs),
+        type: "event",
+      };
+      for (const listener of eventListeners) {
+        listener(event);
+      }
+    },
+    gateway,
+    update(next: Partial<ApplicationGatewaySnapshot>) {
+      snapshot = { ...snapshot, ...next };
+      for (const listener of snapshotListeners) {
+        listener(snapshot);
+      }
+    },
+  };
+}
+
+function client(request: RequestFn): GatewayBrowserClient {
+  return { request } as unknown as GatewayBrowserClient;
+}
+
+describe("application approval overlays", () => {
+  it("does not attach an older resolve failure to a newer approval", async () => {
+    const resolveAttempt = deferred();
+    const request = vi.fn<RequestFn>((method) =>
+      method.endsWith(".list") ? Promise.resolve([]) : resolveAttempt.promise,
+    );
+    const harness = createGatewayHarness(client(request));
+    const overlays = createApplicationOverlays(harness.gateway);
+
+    harness.emitApproval("approval-active", 1_000);
+    const decision = overlays.decideApproval("allow-once");
+    harness.emitApproval("approval-newer", 2_000);
+    resolveAttempt.reject(new Error("gateway unavailable"));
+    await decision;
+
+    expect(overlays.snapshot.approvalQueue.map((entry) => entry.id)).toEqual([
+      "approval-newer",
+      "approval-active",
+    ]);
+    expect(overlays.snapshot.approvalError).toBeNull();
+    expect(overlays.snapshot.approvalBusy).toBe(false);
+    overlays.dispose();
+  });
+
+  it("does not release a new client's busy state when an old resolve settles", async () => {
+    const oldResolve = deferred();
+    const oldRequest = vi.fn<RequestFn>((method) =>
+      method.endsWith(".list") ? Promise.resolve([]) : oldResolve.promise,
+    );
+    const harness = createGatewayHarness(client(oldRequest));
+    const overlays = createApplicationOverlays(harness.gateway);
+
+    harness.emitApproval("approval-old", 1_000);
+    const oldDecision = overlays.decideApproval("allow-once");
+    harness.update({ client: null, connected: false });
+
+    const newResolve = deferred();
+    const newClient = client((method) =>
+      method.endsWith(".list") ? Promise.resolve([]) : newResolve.promise,
+    );
+    harness.update({ client: newClient, connected: true });
+    await Promise.resolve();
+    harness.emitApproval("approval-new", 2_000);
+    const newDecision = overlays.decideApproval("deny");
+    expect(overlays.snapshot.approvalBusy).toBe(true);
+
+    oldResolve.reject(new Error("gateway client stopped"));
+    await oldDecision;
+    expect(overlays.snapshot.approvalBusy).toBe(true);
+    expect(overlays.snapshot.approvalError).toBeNull();
+
+    newResolve.resolve({ ok: true });
+    await newDecision;
+    expect(overlays.snapshot.approvalBusy).toBe(false);
+    expect(overlays.snapshot.approvalQueue).toEqual([]);
+    overlays.dispose();
+  });
+});

--- a/ui/src/app/overlays.ts
+++ b/ui/src/app/overlays.ts
@@ -216,6 +216,7 @@ export function createApplicationOverlays(gateway: ApplicationGateway): Applicat
   let updateVerificationGeneration = 0;
   let updateVerificationTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
   let devicePairPendingCountGeneration = 0;
+  let approvalDecision: { client: NonNullable<typeof activeClient>; id: string } | null = null;
   const devicePairSetupState: DevicePairSetupState & { pendingCount: number } = {
     client: gateway.snapshot.client,
     connected: gateway.snapshot.connected,
@@ -253,6 +254,12 @@ export function createApplicationOverlays(gateway: ApplicationGateway): Applicat
   };
   promptState.execApprovalExpired = publish;
 
+  const isCurrentClient = (client: NonNullable<typeof activeClient>) =>
+    !disposed &&
+    activeClient === client &&
+    gateway.snapshot.client === client &&
+    gateway.snapshot.connected;
+
   const refreshDevicePairPendingCount = async () => {
     const client = gateway.snapshot.client;
     if (
@@ -285,12 +292,7 @@ export function createApplicationOverlays(gateway: ApplicationGateway): Applicat
 
   const refreshApprovals = async (client: NonNullable<typeof activeClient>) => {
     const applied = await refreshPendingApprovalQueue(promptState, {
-      isCurrentClient: (requestClient) =>
-        !disposed &&
-        requestClient === client &&
-        activeClient === client &&
-        gateway.snapshot.client === client &&
-        gateway.snapshot.connected,
+      isCurrentClient: (requestClient) => requestClient === client && isCurrentClient(client),
     });
     if (applied && !disposed) {
       publish();
@@ -411,6 +413,7 @@ export function createApplicationOverlays(gateway: ApplicationGateway): Applicat
     devicePairSetupState.client = next.client;
     devicePairSetupState.connected = next.connected;
     if (previousClient !== next.client || !next.connected) {
+      approvalDecision = null;
       devicePairPendingCountGeneration += 1;
       closeDevicePairSetupState(devicePairSetupState);
       devicePairSetupState.pendingCount = 0;
@@ -571,47 +574,40 @@ export function createApplicationOverlays(gateway: ApplicationGateway): Applicat
       }
       promptState.execApprovalBusy = true;
       promptState.execApprovalError = null;
+      const operation = { client, id: active.id };
+      approvalDecision = operation;
       publish();
       try {
         const method =
           active.kind === "plugin" ? "plugin.approval.resolve" : "exec.approval.resolve";
         await client.request(method, { id: active.id, decision });
-        if (
-          disposed ||
-          activeClient !== client ||
-          gateway.snapshot.client !== client ||
-          !gateway.snapshot.connected
-        ) {
+        if (!isCurrentClient(client)) {
           return;
         }
         dismissExecApprovalPrompt(promptState, active.id);
       } catch (error) {
         if (isStaleApprovalResolutionError(error)) {
-          if (
-            disposed ||
-            activeClient !== client ||
-            gateway.snapshot.client !== client ||
-            !gateway.snapshot.connected
-          ) {
+          if (!isCurrentClient(client)) {
             return;
           }
           dismissExecApprovalPrompt(promptState, active.id);
           const currentClient = activeClient;
-          if (
-            currentClient &&
-            gateway.snapshot.client === currentClient &&
-            gateway.snapshot.connected
-          ) {
+          if (currentClient && isCurrentClient(currentClient)) {
             await refreshApprovals(currentClient);
           }
           return;
         }
-        if (promptState.execApprovalQueue.some((entry) => entry.id === active.id)) {
+        if (isCurrentClient(client) && promptState.execApprovalQueue[0]?.id === active.id) {
           promptState.execApprovalError = `Approval failed: ${error instanceof Error ? error.message : String(error)}`;
         }
       } finally {
-        promptState.execApprovalBusy = false;
-        publish();
+        // Reconnect can admit a new decision while this request is still settling.
+        // Only the operation that owns the busy state may release it.
+        if (approvalDecision === operation) {
+          approvalDecision = null;
+          promptState.execApprovalBusy = false;
+          publish();
+        }
       }
     },
     async openDevicePairSetup() {

--- a/ui/src/e2e/approval-flow.e2e.test.ts
+++ b/ui/src/e2e/approval-flow.e2e.test.ts
@@ -1,0 +1,81 @@
+// Control UI E2E tests cover approval queue behavior through the Gateway WebSocket.
+import { chromium, type Browser, type Page } from "playwright";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  canRunPlaywrightChromium,
+  installMockGateway,
+  resolvePlaywrightChromiumExecutablePath,
+  startControlUiE2eServer,
+  type ControlUiE2eServer,
+} from "../test-helpers/control-ui-e2e.ts";
+
+const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
+const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
+const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
+const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+
+let browser: Browser | undefined;
+let page: Page | undefined;
+let server: ControlUiE2eServer | undefined;
+
+function approval(id: string, command: string, createdAtMs: number) {
+  return {
+    id,
+    createdAtMs,
+    expiresAtMs: Date.now() + 60_000,
+    request: { command },
+  };
+}
+
+describeControlUiE2e("Control UI approval flow", () => {
+  beforeAll(async () => {
+    server = await startControlUiE2eServer();
+  });
+
+  afterEach(async () => {
+    await page
+      ?.context()
+      .close()
+      .catch(() => {});
+    await browser?.close().catch(() => {});
+    page = undefined;
+    browser = undefined;
+  });
+
+  afterAll(async () => {
+    await server?.close();
+  });
+
+  it("keeps an older resolve failure off the newly active approval", async () => {
+    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+    const context = await browser.newContext({ viewport: { height: 800, width: 1200 } });
+    const currentPage = await context.newPage();
+    page = currentPage;
+    const gateway = await installMockGateway(currentPage);
+
+    await currentPage.goto(`${server?.baseUrl ?? ""}chat`);
+    await gateway.waitForRequest("sessions.list");
+    await gateway.deferNext("exec.approval.resolve");
+    await gateway.emitGatewayEvent(
+      "exec.approval.requested",
+      approval("approval-active", "echo active", 1_000),
+    );
+    await currentPage.getByText("echo active", { exact: true }).waitFor();
+    await currentPage.getByRole("button", { name: "Allow once" }).click();
+
+    await gateway.emitGatewayEvent(
+      "exec.approval.requested",
+      approval("approval-newer", "echo newer", 2_000),
+    );
+    await currentPage.getByText("echo newer", { exact: true }).waitFor();
+    await gateway.rejectDeferred("exec.approval.resolve", {
+      code: "UNAVAILABLE",
+      message: "gateway unavailable",
+    });
+
+    await expect.poll(() => currentPage.locator(".exec-approval-error").count()).toBe(0);
+    await expect
+      .poll(() => currentPage.getByRole("button", { name: "Deny" }).isEnabled())
+      .toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #98392

AI-assisted: Yes (Codex)

## What Problem This Solves

An approval resolve can finish after a newer approval becomes active or after the Control UI reconnects. The older completion could attach its error to the wrong prompt, or clear the busy state owned by a newer decision.

## Why This Change Was Made

Approval decisions now have an explicit operation owner: the exact Gateway client and approval id that started the request. Only that operation may release the busy state. Non-stale failures are shown only while the same client and approval remain active. This keeps reconnect and queue transitions on one canonical ownership path instead of adding error-specific fallbacks.

## User Impact

Operators no longer see a stale approval error on a newer prompt, and an older request cannot re-enable controls while a newer approval decision is still in flight.

## Evidence

- Blacksmith Testbox `tbx_01kwt3gy25f6vrxsven71k22mz`: `corepack pnpm test ui/src/app/overlays.test.ts` (2/2 pass).
- Same Testbox: `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/approval-flow.e2e.test.ts` (Chromium, 1/1 pass).
- Same Testbox: `corepack pnpm check:changed` (pass).
- In-app browser live run with a mocked Gateway WebSocket: rejected the older deferred resolve after activating a newer approval; the newer command remained visible, its actions remained enabled, and no approval error rendered.
- Fresh branch autoreview against `origin/main`: no accepted/actionable findings.
- `git diff --check` (pass).
