### PR TITLE
fix: allow config.patch with defaulted provider baseUrl

### DIFF
--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -498,7 +498,7 @@ function parseValidateConfigFromRawOrRespond(
     : restored.result;
   const validationCandidate = stripBundledProviderRuntimeDefaults({
     candidate: projectedValidationCandidate,
-    sourceConfig: snapshot.parsed,
+    sourceConfig: snapshot.sourceConfig,
   });
   const sourceValidated = validateConfigObjectRawWithPlugins(validationCandidate);
   if (!sourceValidated.ok) {
@@ -859,7 +859,27 @@ export const configHandlers: GatewayRequestHandlers = {
       });
       return;
     }
-    const validated = validateConfigObjectWithPlugins(restoredMerge.result);
+    const validationCandidate = stripBundledProviderRuntimeDefaults({
+      candidate: restoredMerge.result,
+      sourceConfig: snapshot.sourceConfig,
+    });
+    const sourceValidated = validateConfigObjectRawWithPlugins(validationCandidate);
+    if (!sourceValidated.ok) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          summarizeConfigValidationIssues(sourceValidated.issues),
+          {
+            details: { issues: sourceValidated.issues },
+          },
+        ),
+      );
+      return;
+    }
+    const writeConfig = validationCandidate as OpenClawConfig;
+    const validated = validateConfigObjectWithPlugins(validationCandidate);
     if (!validated.ok) {
       respond(
         false,
@@ -908,7 +928,7 @@ export const configHandlers: GatewayRequestHandlers = {
     const writeResult = await commitGatewayConfigWrite({
       snapshot,
       writeOptions,
-      nextConfig: validated.config,
+      nextConfig: writeConfig,
       context,
       disconnectSharedAuthClients,
     });

--- a/src/gateway/server.config-patch.test.ts
+++ b/src/gateway/server.config-patch.test.ts
@@ -280,6 +280,82 @@ describe("gateway config methods", () => {
     }
   });
 
+  it("accepts config.patch when bundled provider baseUrl was only defaulted", async () => {
+    const { createConfigIO, resetConfigRuntimeState } = await import("../config/config.js");
+    const configPath = createConfigIO().configPath;
+    try {
+      await writeJsonFile(configPath, {
+        models: {
+          providers: {
+            openai: {
+              agentRuntime: { id: "openclaw" },
+            },
+          },
+        },
+      });
+      resetConfigRuntimeState();
+
+      const current = await getCurrentConfigObject();
+
+      const res = await rpcReq<{
+        ok?: boolean;
+        error?: { message?: string };
+      }>(requireWs(), "config.patch", {
+        raw: JSON.stringify({ gateway: { port: 19003 } }),
+        baseHash: current.hash,
+      });
+
+      expect(res.error).toBeUndefined();
+      expect(res.ok).toBe(true);
+      const persisted = await fs.readFile(configPath, "utf-8");
+      expect(persisted).toContain('"port": 19003');
+      expect(persisted).not.toContain('"baseUrl"');
+      expect(persisted).not.toContain('"models": []');
+    } finally {
+      await fs.rm(configPath, { force: true });
+      resetConfigRuntimeState();
+    }
+  });
+
+  it("preserves authored empty bundled provider models during config.patch", async () => {
+    const { createConfigIO, resetConfigRuntimeState } = await import("../config/config.js");
+    const configPath = createConfigIO().configPath;
+    try {
+      await writeJsonFile(configPath, {
+        models: {
+          providers: {
+            openai: {
+              agentRuntime: { id: "openclaw" },
+              models: [],
+            },
+          },
+        },
+      });
+      resetConfigRuntimeState();
+
+      const current = await getCurrentConfigObject();
+
+      const res = await rpcReq<{
+        ok?: boolean;
+        error?: { message?: string };
+      }>(requireWs(), "config.patch", {
+        raw: JSON.stringify({ gateway: { port: 19004 } }),
+        baseHash: current.hash,
+      });
+
+      expect(res.error).toBeUndefined();
+      expect(res.ok).toBe(true);
+      const persisted = JSON.parse(await fs.readFile(configPath, "utf-8")) as {
+        models?: { providers?: { openai?: { baseUrl?: unknown; models?: unknown } } };
+      };
+      expect(persisted.models?.providers?.openai?.baseUrl).toBeUndefined();
+      expect(persisted.models?.providers?.openai?.models).toEqual([]);
+    } finally {
+      await fs.rm(configPath, { force: true });
+      resetConfigRuntimeState();
+    }
+  });
+
   it("redacts browser cdpUrl credentials from config.get responses", async () => {
     const { createConfigIO, resetConfigRuntimeState } = await import("../config/config.js");
     const configPath = createConfigIO().configPath;


### PR DESCRIPTION
Closes #98270

## What Problem This Solves

Fixes an issue where users calling gateway `config.patch` would get an invalid config error when a bundled model provider overlay, such as `openai`, had runtime-defaulted empty `baseUrl` / `models` values.

## Why This Change Was Made

`config.patch` now uses the same source-shaped validation/write split as the full config write path: strip bundled-provider runtime defaults, raw-validate the source-shaped candidate, runtime-validate the resulting config, then persist the source-shaped candidate so runtime-only defaults do not get written back to `openclaw.json`.

The source-presence check uses the resolved source config, so authored fields that arrive through include/env resolution are still treated as authored values. This keeps explicit provider fields such as `models: []` while still removing runtime-only defaults.

This version intentionally keeps the stricter provider schema; it applies the existing write-normalization invariant to the missing `config.patch` RPC surface rather than weakening `baseUrl` validation.

## User Impact

Users can patch unrelated config fields without explicitly adding SDK default provider endpoints just to satisfy `baseUrl` validation. The patch response and persisted config no longer leak runtime-only empty bundled provider defaults, while explicitly authored empty provider model lists remain preserved.

AI-assisted: yes.

## Evidence

Current PR head: `68fbf67640f7abe2d6e78ee935dddaa0caae0a27`, rebased onto `origin/main` at `5113fbf4cc6a664a84bf38ccb555a6ab3ed40bea`.

Current-head local verification:

- `node scripts/run-vitest.mjs src/gateway/server.config-patch.test.ts` — 72 passed
- `pnpm check:test-types`
- `pnpm lint --threads=8`
- `git diff --check origin/main...HEAD`

Additional verification run earlier on the same config.patch production change before the final rebase/squash:

- `node scripts/run-vitest.mjs src/gateway/server-cron-notifications.test.ts src/gateway/server-cron.test.ts src/llm/providers/mistral.test.ts src/llm/providers/anthropic.test.ts` — 107 passed
- `codex review --base origin/main` — no actionable correctness issues after upgrading the patch/test coverage

Live Gateway proof from a temporary auth-none loopback gateway on an equivalent pre-rebase config-fix commit. Current head only rebases/squashes the same production `config.patch` change and removes unrelated current-main test-fixture commits from the PR diff. The source config had `models.providers.openai.agentRuntime` only; it intentionally omitted `models.providers.openai.baseUrl` and `models.providers.openai.models`.

```text
gateway connect ok=true error=none
gateway config.get ok
source openai has baseUrl=false models=false
runtime openai provider baseUrl="" modelsLength=0
base hash 34048451eca21a7283ea8eb1752d3b15f34885cd5656b24b8cf1c4f26507dac9
gateway log: res ✓ config.patch 585ms
persisted auth.cooldowns.billingBackoffHours=7
persisted openai has baseUrl=false models=false
post-restart connect ok=true
post-restart config.get valid=true issues=0
post-restart source openai has baseUrl=false models=false
post-restart runtime openai provider baseUrl="" modelsLength=0
post-restart auth.cooldowns.billingBackoffHours=7
```

Live proof command shape: start `openclaw gateway run --port 19183 --bind loopback --auth none --allow-unconfigured` with `OPENCLAW_SKIP_CHANNELS=1 OPENCLAW_SKIP_PROVIDERS=1`, connect over `ws://127.0.0.1:19183`, call `config.get`, call `config.patch` with `{ "auth": { "cooldowns": { "billingBackoffHours": 7 } } }`, then read the persisted temporary config and reconnect after the gateway restart.

Coverage added:

- `config.patch` succeeds when an unrelated patch is applied while a bundled provider only has runtime-defaulted `baseUrl` / `models`.
- Authored empty bundled provider `models: []` survives an unrelated `config.patch`.
- The patch path raw-validates the source-shaped candidate before runtime validation, matching `config.set` / `config.apply` behavior.
