### PR TITLE
Expose heartbeat template doctor lint findings

### DIFF
--- a/src/commands/doctor-heartbeat-template-repair.test.ts
+++ b/src/commands/doctor-heartbeat-template-repair.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   analyzeHeartbeatTemplateForRepair,
+  collectHeartbeatTemplateHealthFindings,
   maybeRepairHeartbeatTemplate,
 } from "./doctor-heartbeat-template-repair.js";
 
@@ -187,6 +188,71 @@ Add short tasks below the comments only when you want the agent to check somethi
       expect.stringContaining("custom or unrecognized content"),
       "Heartbeat template",
     );
+  });
+
+  it("collects a finding for pure dirty templates", async () => {
+    const { workspaceDir, heartbeatPath } = await makeWorkspaceWithHeartbeat(`\`\`\`markdown
+# Keep this file empty (or with only comments) to skip heartbeat API calls.
+
+# Add tasks below when you want the agent to check something periodically.
+\`\`\`
+`);
+
+    const findings = await collectHeartbeatTemplateHealthFindings({
+      agents: { defaults: { workspace: workspaceDir } },
+    });
+
+    expect(findings).toEqual([
+      expect.objectContaining({
+        checkId: "core/doctor/heartbeat-template",
+        severity: "warning",
+        path: heartbeatPath,
+        requirement: "legacy-template",
+        fixHint: expect.stringContaining("openclaw doctor --fix"),
+      }),
+    ]);
+  });
+
+  it("collects a manual finding when dirty templates include user content", async () => {
+    const { workspaceDir, heartbeatPath } = await makeWorkspaceWithHeartbeat(`\`\`\`markdown
+# Keep this file empty (or with only comments) to skip heartbeat API calls.
+
+# Add tasks below when you want the agent to check something periodically.
+\`\`\`
+
+- Check email
+`);
+
+    const findings = await collectHeartbeatTemplateHealthFindings({
+      agents: { defaults: { workspace: workspaceDir } },
+    });
+
+    expect(findings).toEqual([
+      expect.objectContaining({
+        checkId: "core/doctor/heartbeat-template",
+        severity: "warning",
+        path: heartbeatPath,
+        requirement: "legacy-template-with-custom-content",
+        fixHint: expect.stringContaining("Remove the fenced template"),
+      }),
+    ]);
+  });
+
+  it("returns no findings for clean templates or missing heartbeat files", async () => {
+    const { workspaceDir } = await makeWorkspaceWithHeartbeat(`# Keep this file empty.
+`);
+    const missingWorkspaceDir = await makeTempRoot();
+
+    await expect(
+      collectHeartbeatTemplateHealthFindings({
+        agents: { defaults: { workspace: workspaceDir } },
+      }),
+    ).resolves.toEqual([]);
+    await expect(
+      collectHeartbeatTemplateHealthFindings({
+        agents: { defaults: { workspace: missingWorkspaceDir } },
+      }),
+    ).resolves.toEqual([]);
   });
 
   it("rewrites pure dirty templates to the clean runtime template", async () => {

--- a/src/commands/doctor-heartbeat-template-repair.test.ts
+++ b/src/commands/doctor-heartbeat-template-repair.test.ts
@@ -6,7 +6,6 @@ import {
   analyzeHeartbeatTemplateForRepair,
   collectHeartbeatTemplateHealthFindings,
   maybeRepairHeartbeatTemplate,
-  repairHeartbeatTemplateHealthFindings,
 } from "./doctor-heartbeat-template-repair.js";
 
 const mocks = vi.hoisted(() => ({
@@ -282,79 +281,5 @@ Add short tasks below the comments only when you want the agent to check somethi
       expect.stringContaining("clean heartbeat template"),
       "Doctor changes",
     );
-  });
-
-  it("previews pure dirty template repair as a file effect and diff", async () => {
-    const { workspaceDir, heartbeatPath } = await makeWorkspaceWithHeartbeat(`\`\`\`markdown
-# Keep this file empty (or with only comments) to skip heartbeat API calls.
-
-# Add tasks below when you want the agent to check something periodically.
-\`\`\`
-`);
-    const cleanTemplate = "# clean heartbeat\n";
-    const writeTextAtomic = vi.fn();
-
-    const result = await repairHeartbeatTemplateHealthFindings({
-      cfg: { agents: { defaults: { workspace: workspaceDir } } },
-      findings: [
-        {
-          checkId: "core/doctor/heartbeat-template",
-          severity: "warning",
-          message: "legacy template",
-          path: heartbeatPath,
-          requirement: "legacy-template",
-        },
-      ],
-      dryRun: true,
-      diff: true,
-      deps: {
-        readCleanHeartbeatTemplate: async () => cleanTemplate,
-        writeTextAtomic,
-      },
-    });
-
-    expect(writeTextAtomic).not.toHaveBeenCalled();
-    expect(result.changes).toEqual([
-      `Would replace ${heartbeatPath} with the clean heartbeat template.`,
-    ]);
-    expect(result.effects).toEqual([
-      {
-        kind: "file",
-        action: "would-replace-heartbeat-template",
-        target: heartbeatPath,
-        dryRunSafe: false,
-      },
-    ]);
-    expect(result.diffs).toEqual([
-      expect.objectContaining({
-        kind: "file",
-        path: heartbeatPath,
-        before: expect.stringContaining("```markdown"),
-        after: cleanTemplate,
-      }),
-    ]);
-    await expect(fs.readFile(heartbeatPath, "utf-8")).resolves.toContain("```markdown");
-  });
-
-  it("skips structured repair when only manual heartbeat findings are present", async () => {
-    const result = await repairHeartbeatTemplateHealthFindings({
-      cfg: {},
-      findings: [
-        {
-          checkId: "core/doctor/heartbeat-template",
-          severity: "warning",
-          message: "custom content",
-          path: "/tmp/HEARTBEAT.md",
-          requirement: "legacy-template-with-custom-content",
-        },
-      ],
-      dryRun: true,
-    });
-
-    expect(result).toEqual({
-      status: "skipped",
-      reason: "only manual heartbeat template findings were present",
-      changes: [],
-    });
   });
 });

--- a/src/commands/doctor-heartbeat-template-repair.test.ts
+++ b/src/commands/doctor-heartbeat-template-repair.test.ts
@@ -6,6 +6,7 @@ import {
   analyzeHeartbeatTemplateForRepair,
   collectHeartbeatTemplateHealthFindings,
   maybeRepairHeartbeatTemplate,
+  repairHeartbeatTemplateHealthFindings,
 } from "./doctor-heartbeat-template-repair.js";
 
 const mocks = vi.hoisted(() => ({
@@ -281,5 +282,79 @@ Add short tasks below the comments only when you want the agent to check somethi
       expect.stringContaining("clean heartbeat template"),
       "Doctor changes",
     );
+  });
+
+  it("previews pure dirty template repair as a file effect and diff", async () => {
+    const { workspaceDir, heartbeatPath } = await makeWorkspaceWithHeartbeat(`\`\`\`markdown
+# Keep this file empty (or with only comments) to skip heartbeat API calls.
+
+# Add tasks below when you want the agent to check something periodically.
+\`\`\`
+`);
+    const cleanTemplate = "# clean heartbeat\n";
+    const writeTextAtomic = vi.fn();
+
+    const result = await repairHeartbeatTemplateHealthFindings({
+      cfg: { agents: { defaults: { workspace: workspaceDir } } },
+      findings: [
+        {
+          checkId: "core/doctor/heartbeat-template",
+          severity: "warning",
+          message: "legacy template",
+          path: heartbeatPath,
+          requirement: "legacy-template",
+        },
+      ],
+      dryRun: true,
+      diff: true,
+      deps: {
+        readCleanHeartbeatTemplate: async () => cleanTemplate,
+        writeTextAtomic,
+      },
+    });
+
+    expect(writeTextAtomic).not.toHaveBeenCalled();
+    expect(result.changes).toEqual([
+      `Would replace ${heartbeatPath} with the clean heartbeat template.`,
+    ]);
+    expect(result.effects).toEqual([
+      {
+        kind: "file",
+        action: "would-replace-heartbeat-template",
+        target: heartbeatPath,
+        dryRunSafe: false,
+      },
+    ]);
+    expect(result.diffs).toEqual([
+      expect.objectContaining({
+        kind: "file",
+        path: heartbeatPath,
+        before: expect.stringContaining("```markdown"),
+        after: cleanTemplate,
+      }),
+    ]);
+    await expect(fs.readFile(heartbeatPath, "utf-8")).resolves.toContain("```markdown");
+  });
+
+  it("skips structured repair when only manual heartbeat findings are present", async () => {
+    const result = await repairHeartbeatTemplateHealthFindings({
+      cfg: {},
+      findings: [
+        {
+          checkId: "core/doctor/heartbeat-template",
+          severity: "warning",
+          message: "custom content",
+          path: "/tmp/HEARTBEAT.md",
+          requirement: "legacy-template-with-custom-content",
+        },
+      ],
+      dryRun: true,
+    });
+
+    expect(result).toEqual({
+      status: "skipped",
+      reason: "only manual heartbeat template findings were present",
+      changes: [],
+    });
   });
 });

--- a/src/commands/doctor-heartbeat-template-repair.ts
+++ b/src/commands/doctor-heartbeat-template-repair.ts
@@ -6,9 +6,12 @@ import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent
 import { resolveWorkspaceTemplateDir } from "../agents/workspace-templates.js";
 import { DEFAULT_HEARTBEAT_FILENAME } from "../agents/workspace.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { HealthFinding } from "../flows/health-checks.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { writeTextAtomic } from "../infra/json-files.js";
 import { shortenHomePath } from "../utils.js";
+
+const HEARTBEAT_TEMPLATE_CHECK_ID = "core/doctor/heartbeat-template";
 
 const LEGACY_HEARTBEAT_PROSE_TEMPLATE = [
   "# HEARTBEAT.md",
@@ -124,6 +127,67 @@ async function readCleanHeartbeatTemplate(): Promise<string> {
   const templateDir = await resolveWorkspaceTemplateDir();
   const templatePath = path.join(templateDir, DEFAULT_HEARTBEAT_FILENAME);
   return await fs.readFile(templatePath, "utf-8");
+}
+
+function heartbeatTemplateAnalysisToHealthFinding(
+  heartbeatPath: string,
+  analysis: Exclude<HeartbeatTemplateRepairAnalysis, { status: "clean" }>,
+): HealthFinding {
+  if (analysis.status === "dirty-template-with-custom-content") {
+    return {
+      checkId: HEARTBEAT_TEMPLATE_CHECK_ID,
+      severity: "warning",
+      message:
+        "HEARTBEAT.md contains an older heartbeat template wrapper plus custom or unrecognized content.",
+      path: heartbeatPath,
+      requirement: "legacy-template-with-custom-content",
+      fixHint: "Remove the fenced template and Related lines manually if they are not intentional.",
+    };
+  }
+  return {
+    checkId: HEARTBEAT_TEMPLATE_CHECK_ID,
+    severity: "warning",
+    message: "HEARTBEAT.md contains an older heartbeat documentation template.",
+    path: heartbeatPath,
+    requirement: "legacy-template",
+    fixHint: 'Run "openclaw doctor --fix" to replace it with the clean heartbeat template.',
+  };
+}
+
+/** Collects read-only structured findings for legacy HEARTBEAT.md template wrappers. */
+export async function collectHeartbeatTemplateHealthFindings(
+  cfg: OpenClawConfig,
+  deps?: {
+    readFile?: (filePath: string) => Promise<string>;
+  },
+): Promise<readonly HealthFinding[]> {
+  const workspaceDir = resolveAgentWorkspaceDir(cfg, resolveDefaultAgentId(cfg));
+  const heartbeatPath = path.join(workspaceDir, DEFAULT_HEARTBEAT_FILENAME);
+  const readFile = deps?.readFile ?? ((filePath: string) => fs.readFile(filePath, "utf-8"));
+  let content: string;
+  try {
+    content = await readFile(heartbeatPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException | undefined)?.code === "ENOENT") {
+      return [];
+    }
+    return [
+      {
+        checkId: HEARTBEAT_TEMPLATE_CHECK_ID,
+        severity: "warning",
+        message: `Could not inspect HEARTBEAT.md: ${formatErrorMessage(error)}`,
+        path: heartbeatPath,
+        requirement: "inspect-failed",
+        fixHint: "Check file permissions, then rerun doctor.",
+      },
+    ];
+  }
+
+  const analysis = analyzeHeartbeatTemplateForRepair(content);
+  if (analysis.status === "clean") {
+    return [];
+  }
+  return [heartbeatTemplateAnalysisToHealthFinding(heartbeatPath, analysis)];
 }
 
 /** Replaces known dirty heartbeat templates with the clean runtime template when repair is enabled. */

--- a/src/commands/doctor-heartbeat-template-repair.ts
+++ b/src/commands/doctor-heartbeat-template-repair.ts
@@ -6,12 +6,7 @@ import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent
 import { resolveWorkspaceTemplateDir } from "../agents/workspace-templates.js";
 import { DEFAULT_HEARTBEAT_FILENAME } from "../agents/workspace.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import type {
-  HealthFinding,
-  HealthRepairDiff,
-  HealthRepairEffect,
-  HealthRepairResult,
-} from "../flows/health-checks.js";
+import type { HealthFinding } from "../flows/health-checks.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { writeTextAtomic } from "../infra/json-files.js";
 import { shortenHomePath } from "../utils.js";
@@ -193,115 +188,6 @@ export async function collectHeartbeatTemplateHealthFindings(
     return [];
   }
   return [heartbeatTemplateAnalysisToHealthFinding(heartbeatPath, analysis)];
-}
-
-function heartbeatTemplateReplacementEffect(
-  heartbeatPath: string,
-  dryRun: boolean,
-): HealthRepairEffect {
-  return {
-    kind: "file",
-    action: dryRun ? "would-replace-heartbeat-template" : "replace-heartbeat-template",
-    target: heartbeatPath,
-    dryRunSafe: false,
-  };
-}
-
-function heartbeatTemplateReplacementDiff(
-  heartbeatPath: string,
-  before: string,
-  after: string,
-): HealthRepairDiff {
-  return {
-    kind: "file",
-    path: heartbeatPath,
-    before,
-    after,
-  };
-}
-
-/** Repairs or previews known legacy HEARTBEAT.md template rewrites for structured Doctor repair. */
-export async function repairHeartbeatTemplateHealthFindings(params: {
-  cfg: OpenClawConfig;
-  findings: readonly HealthFinding[];
-  dryRun?: boolean;
-  diff?: boolean;
-  deps?: {
-    readFile?: (filePath: string) => Promise<string>;
-    writeTextAtomic?: typeof writeTextAtomic;
-    readCleanHeartbeatTemplate?: () => Promise<string>;
-  };
-}): Promise<HealthRepairResult> {
-  const repairableFinding = params.findings.find(
-    (finding) =>
-      finding.checkId === HEARTBEAT_TEMPLATE_CHECK_ID &&
-      finding.requirement === "legacy-template" &&
-      typeof finding.path === "string",
-  );
-  if (repairableFinding === undefined) {
-    return {
-      status: "skipped",
-      reason: "only manual heartbeat template findings were present",
-      changes: [],
-    };
-  }
-
-  const heartbeatPath = repairableFinding.path;
-  if (typeof heartbeatPath !== "string") {
-    return {
-      status: "skipped",
-      reason: "heartbeat template finding did not include a file path",
-      changes: [],
-    };
-  }
-  const readFile = params.deps?.readFile ?? ((filePath: string) => fs.readFile(filePath, "utf-8"));
-  const writeFile = params.deps?.writeTextAtomic ?? writeTextAtomic;
-  const readTemplate = params.deps?.readCleanHeartbeatTemplate ?? readCleanHeartbeatTemplate;
-  let content: string;
-  let cleanTemplate: string;
-  try {
-    [content, cleanTemplate] = await Promise.all([readFile(heartbeatPath), readTemplate()]);
-  } catch (error) {
-    return {
-      status: "failed",
-      reason: `could not prepare heartbeat template repair: ${formatErrorMessage(error)}`,
-      changes: [],
-    };
-  }
-
-  if (analyzeHeartbeatTemplateForRepair(content).status !== "dirty-template") {
-    return {
-      status: "skipped",
-      reason: "heartbeat file is not a pure legacy template",
-      changes: [],
-    };
-  }
-
-  if (params.dryRun !== true) {
-    try {
-      await writeFile(heartbeatPath, cleanTemplate, { mode: 0o600 });
-    } catch (error) {
-      return {
-        status: "failed",
-        reason: `could not repair heartbeat template: ${formatErrorMessage(error)}`,
-        changes: [],
-      };
-    }
-  }
-
-  const shortPath = shortenHomePath(heartbeatPath);
-  return {
-    changes: [
-      params.dryRun === true
-        ? `Would replace ${shortPath} with the clean heartbeat template.`
-        : `Replaced ${shortPath} with the clean heartbeat template.`,
-    ],
-    diffs:
-      params.diff === true
-        ? [heartbeatTemplateReplacementDiff(heartbeatPath, content, cleanTemplate)]
-        : [],
-    effects: [heartbeatTemplateReplacementEffect(heartbeatPath, params.dryRun === true)],
-  };
 }
 
 /** Replaces known dirty heartbeat templates with the clean runtime template when repair is enabled. */

--- a/src/commands/doctor-heartbeat-template-repair.ts
+++ b/src/commands/doctor-heartbeat-template-repair.ts
@@ -6,7 +6,12 @@ import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent
 import { resolveWorkspaceTemplateDir } from "../agents/workspace-templates.js";
 import { DEFAULT_HEARTBEAT_FILENAME } from "../agents/workspace.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import type { HealthFinding } from "../flows/health-checks.js";
+import type {
+  HealthFinding,
+  HealthRepairDiff,
+  HealthRepairEffect,
+  HealthRepairResult,
+} from "../flows/health-checks.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { writeTextAtomic } from "../infra/json-files.js";
 import { shortenHomePath } from "../utils.js";
@@ -188,6 +193,115 @@ export async function collectHeartbeatTemplateHealthFindings(
     return [];
   }
   return [heartbeatTemplateAnalysisToHealthFinding(heartbeatPath, analysis)];
+}
+
+function heartbeatTemplateReplacementEffect(
+  heartbeatPath: string,
+  dryRun: boolean,
+): HealthRepairEffect {
+  return {
+    kind: "file",
+    action: dryRun ? "would-replace-heartbeat-template" : "replace-heartbeat-template",
+    target: heartbeatPath,
+    dryRunSafe: false,
+  };
+}
+
+function heartbeatTemplateReplacementDiff(
+  heartbeatPath: string,
+  before: string,
+  after: string,
+): HealthRepairDiff {
+  return {
+    kind: "file",
+    path: heartbeatPath,
+    before,
+    after,
+  };
+}
+
+/** Repairs or previews known legacy HEARTBEAT.md template rewrites for structured Doctor repair. */
+export async function repairHeartbeatTemplateHealthFindings(params: {
+  cfg: OpenClawConfig;
+  findings: readonly HealthFinding[];
+  dryRun?: boolean;
+  diff?: boolean;
+  deps?: {
+    readFile?: (filePath: string) => Promise<string>;
+    writeTextAtomic?: typeof writeTextAtomic;
+    readCleanHeartbeatTemplate?: () => Promise<string>;
+  };
+}): Promise<HealthRepairResult> {
+  const repairableFinding = params.findings.find(
+    (finding) =>
+      finding.checkId === HEARTBEAT_TEMPLATE_CHECK_ID &&
+      finding.requirement === "legacy-template" &&
+      typeof finding.path === "string",
+  );
+  if (repairableFinding === undefined) {
+    return {
+      status: "skipped",
+      reason: "only manual heartbeat template findings were present",
+      changes: [],
+    };
+  }
+
+  const heartbeatPath = repairableFinding.path;
+  if (typeof heartbeatPath !== "string") {
+    return {
+      status: "skipped",
+      reason: "heartbeat template finding did not include a file path",
+      changes: [],
+    };
+  }
+  const readFile = params.deps?.readFile ?? ((filePath: string) => fs.readFile(filePath, "utf-8"));
+  const writeFile = params.deps?.writeTextAtomic ?? writeTextAtomic;
+  const readTemplate = params.deps?.readCleanHeartbeatTemplate ?? readCleanHeartbeatTemplate;
+  let content: string;
+  let cleanTemplate: string;
+  try {
+    [content, cleanTemplate] = await Promise.all([readFile(heartbeatPath), readTemplate()]);
+  } catch (error) {
+    return {
+      status: "failed",
+      reason: `could not prepare heartbeat template repair: ${formatErrorMessage(error)}`,
+      changes: [],
+    };
+  }
+
+  if (analyzeHeartbeatTemplateForRepair(content).status !== "dirty-template") {
+    return {
+      status: "skipped",
+      reason: "heartbeat file is not a pure legacy template",
+      changes: [],
+    };
+  }
+
+  if (params.dryRun !== true) {
+    try {
+      await writeFile(heartbeatPath, cleanTemplate, { mode: 0o600 });
+    } catch (error) {
+      return {
+        status: "failed",
+        reason: `could not repair heartbeat template: ${formatErrorMessage(error)}`,
+        changes: [],
+      };
+    }
+  }
+
+  const shortPath = shortenHomePath(heartbeatPath);
+  return {
+    changes: [
+      params.dryRun === true
+        ? `Would replace ${shortPath} with the clean heartbeat template.`
+        : `Replaced ${shortPath} with the clean heartbeat template.`,
+    ],
+    diffs:
+      params.diff === true
+        ? [heartbeatTemplateReplacementDiff(heartbeatPath, content, cleanTemplate)]
+        : [],
+    effects: [heartbeatTemplateReplacementEffect(heartbeatPath, params.dryRun === true)],
+  };
 }
 
 /** Replaces known dirty heartbeat templates with the clean runtime template when repair is enabled. */

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -86,10 +86,6 @@ const mocks = vi.hoisted(() => ({
   collectDiskSpaceHealthFindings: vi.fn((): readonly HealthFinding[] => []),
   collectHeartbeatTemplateHealthFindings: vi.fn(async () => [] as unknown[]),
   maybeRepairHeartbeatTemplate: vi.fn().mockResolvedValue(undefined),
-  repairHeartbeatTemplateHealthFindings: vi.fn(async () => ({
-    changes: [] as string[],
-    effects: [] as unknown[],
-  })),
   collectDevicePairingHealthFindings: vi.fn(async () => []),
   scanConfiguredChannelPluginBlockers: vi.fn(
     (): Array<{ channelId: string; pluginId: string; reason: string }> => [],
@@ -312,7 +308,6 @@ vi.mock("../commands/doctor-disk-space.js", () => ({
 vi.mock("../commands/doctor-heartbeat-template-repair.js", () => ({
   collectHeartbeatTemplateHealthFindings: mocks.collectHeartbeatTemplateHealthFindings,
   maybeRepairHeartbeatTemplate: mocks.maybeRepairHeartbeatTemplate,
-  repairHeartbeatTemplateHealthFindings: mocks.repairHeartbeatTemplateHealthFindings,
 }));
 
 vi.mock("../commands/doctor-device-pairing.js", () => ({
@@ -514,8 +509,6 @@ describe("doctor health contributions", () => {
     mocks.collectHeartbeatTemplateHealthFindings.mockResolvedValue([]);
     mocks.maybeRepairHeartbeatTemplate.mockReset();
     mocks.maybeRepairHeartbeatTemplate.mockResolvedValue(undefined);
-    mocks.repairHeartbeatTemplateHealthFindings.mockReset();
-    mocks.repairHeartbeatTemplateHealthFindings.mockResolvedValue({ changes: [], effects: [] });
     mocks.collectDevicePairingHealthFindings.mockReset();
     mocks.collectDevicePairingHealthFindings.mockResolvedValue([]);
     mocks.scanConfiguredChannelPluginBlockers.mockReset();
@@ -1075,57 +1068,6 @@ describe("doctor health contributions", () => {
       findings: [expect.objectContaining({ checkId: "core/doctor/heartbeat-template" })],
     });
     expect(mocks.collectHeartbeatTemplateHealthFindings).toHaveBeenCalledWith(ctx.cfg);
-  });
-
-  it("threads dry-run heartbeat template repairs through the structured check", async () => {
-    const contributionChecks = await resolveDoctorContributionHealthChecks();
-    const heartbeatTemplateCheck = contributionChecks.find(
-      (check) => check.id === "core/doctor/heartbeat-template",
-    );
-    expect(heartbeatTemplateCheck).toBeDefined();
-    const findings = [
-      {
-        checkId: "core/doctor/heartbeat-template",
-        severity: "warning" as const,
-        message: "HEARTBEAT.md contains an older heartbeat documentation template.",
-        path: "/tmp/openclaw-workspace/HEARTBEAT.md",
-        requirement: "legacy-template",
-      },
-    ];
-    mocks.repairHeartbeatTemplateHealthFindings.mockResolvedValueOnce({
-      changes: ["Would replace heartbeat template."],
-      effects: [
-        {
-          kind: "file",
-          action: "would-replace-heartbeat-template",
-          target: "/tmp/openclaw-workspace/HEARTBEAT.md",
-          dryRunSafe: false,
-        },
-      ],
-    });
-
-    const result = await heartbeatTemplateCheck!.repair?.(
-      {
-        cfg: { agents: { defaults: { workspace: "/tmp/openclaw-workspace" } } },
-        mode: "fix",
-        dryRun: true,
-        diff: true,
-        runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-      },
-      findings,
-    );
-
-    expect(mocks.repairHeartbeatTemplateHealthFindings).toHaveBeenCalledWith({
-      cfg: { agents: { defaults: { workspace: "/tmp/openclaw-workspace" } } },
-      findings,
-      dryRun: true,
-      diff: true,
-    });
-    expect(result?.effects).toContainEqual(
-      expect.objectContaining({
-        action: "would-replace-heartbeat-template",
-      }),
-    );
   });
 
   it("preserves allow-exec Gateway SecretRef resolution in auth health", async () => {

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -84,6 +84,8 @@ const mocks = vi.hoisted(() => ({
   noteWorkspaceStatus: vi.fn(),
   collectWorkspaceStatusHealthFindings: vi.fn().mockResolvedValue([]),
   collectDiskSpaceHealthFindings: vi.fn((): readonly HealthFinding[] => []),
+  collectHeartbeatTemplateHealthFindings: vi.fn(async () => []),
+  maybeRepairHeartbeatTemplate: vi.fn().mockResolvedValue(undefined),
   collectDevicePairingHealthFindings: vi.fn(async () => []),
   scanConfiguredChannelPluginBlockers: vi.fn(
     (): Array<{ channelId: string; pluginId: string; reason: string }> => [],
@@ -303,6 +305,11 @@ vi.mock("../commands/doctor-disk-space.js", () => ({
   collectDiskSpaceHealthFindings: mocks.collectDiskSpaceHealthFindings,
 }));
 
+vi.mock("../commands/doctor-heartbeat-template-repair.js", () => ({
+  collectHeartbeatTemplateHealthFindings: mocks.collectHeartbeatTemplateHealthFindings,
+  maybeRepairHeartbeatTemplate: mocks.maybeRepairHeartbeatTemplate,
+}));
+
 vi.mock("../commands/doctor-device-pairing.js", () => ({
   collectDevicePairingHealthFindings: mocks.collectDevicePairingHealthFindings,
   noteDevicePairingHealth: vi.fn().mockResolvedValue(undefined),
@@ -498,6 +505,10 @@ describe("doctor health contributions", () => {
     mocks.collectWorkspaceStatusHealthFindings.mockResolvedValue([]);
     mocks.collectDiskSpaceHealthFindings.mockReset();
     mocks.collectDiskSpaceHealthFindings.mockReturnValue([]);
+    mocks.collectHeartbeatTemplateHealthFindings.mockReset();
+    mocks.collectHeartbeatTemplateHealthFindings.mockResolvedValue([]);
+    mocks.maybeRepairHeartbeatTemplate.mockReset();
+    mocks.maybeRepairHeartbeatTemplate.mockResolvedValue(undefined);
     mocks.collectDevicePairingHealthFindings.mockReset();
     mocks.collectDevicePairingHealthFindings.mockResolvedValue([]);
     mocks.scanConfiguredChannelPluginBlockers.mockReset();
@@ -1018,6 +1029,47 @@ describe("doctor health contributions", () => {
     );
   });
 
+  it("keeps heartbeat template lint opt-in for default lint selection", async () => {
+    const contributionChecks = await resolveDoctorContributionHealthChecks();
+    const heartbeatTemplateCheck = contributionChecks.find(
+      (check) => check.id === "core/doctor/heartbeat-template",
+    );
+    expect(heartbeatTemplateCheck).toMatchObject({ defaultEnabled: false });
+    expect(heartbeatTemplateCheck).toBeDefined();
+
+    const ctx = {
+      cfg: { agents: { defaults: { workspace: "/tmp/openclaw-workspace" } } },
+      mode: "lint",
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+    } as const;
+    const checks = [heartbeatTemplateCheck!];
+
+    await expect(runDoctorLintChecks(ctx, { checks })).resolves.toMatchObject({
+      checksRun: 0,
+      checksSkipped: 1,
+    });
+    expect(mocks.collectHeartbeatTemplateHealthFindings).not.toHaveBeenCalled();
+
+    mocks.collectHeartbeatTemplateHealthFindings.mockResolvedValueOnce([
+      {
+        checkId: "core/doctor/heartbeat-template",
+        severity: "warning",
+        message: "HEARTBEAT.md contains an older heartbeat documentation template.",
+        path: "/tmp/openclaw-workspace/HEARTBEAT.md",
+        requirement: "legacy-template",
+      },
+    ]);
+
+    await expect(
+      runDoctorLintChecks(ctx, { checks, onlyIds: ["core/doctor/heartbeat-template"] }),
+    ).resolves.toMatchObject({
+      checksRun: 1,
+      checksSkipped: 0,
+      findings: [expect.objectContaining({ checkId: "core/doctor/heartbeat-template" })],
+    });
+    expect(mocks.collectHeartbeatTemplateHealthFindings).toHaveBeenCalledWith(ctx.cfg);
+  });
+
   it("preserves allow-exec Gateway SecretRef resolution in auth health", async () => {
     const contribution = requireDoctorContribution("doctor:gateway-auth");
     const ctx = {
@@ -1219,6 +1271,8 @@ describe("doctor health contributions", () => {
     expect(contributionIds).toContain("core/doctor/session-snapshots");
     expect(contributionIds).toContain("core/doctor/plugin-registry");
     expect(contributionIds).toContain("core/doctor/configured-plugin-installs");
+    expect(contributionIds).toContain("core/doctor/disk-space");
+    expect(contributionIds).toContain("core/doctor/heartbeat-template");
     expect(contributionIds).toContain("core/doctor/disk-space");
     expect(contributionIds).toContain("core/doctor/device-pairing");
     expect(contributionIds).toContain("core/doctor/channel-plugin-blockers");

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -84,8 +84,12 @@ const mocks = vi.hoisted(() => ({
   noteWorkspaceStatus: vi.fn(),
   collectWorkspaceStatusHealthFindings: vi.fn().mockResolvedValue([]),
   collectDiskSpaceHealthFindings: vi.fn((): readonly HealthFinding[] => []),
-  collectHeartbeatTemplateHealthFindings: vi.fn(async () => []),
+  collectHeartbeatTemplateHealthFindings: vi.fn(async () => [] as unknown[]),
   maybeRepairHeartbeatTemplate: vi.fn().mockResolvedValue(undefined),
+  repairHeartbeatTemplateHealthFindings: vi.fn(async () => ({
+    changes: [] as string[],
+    effects: [] as unknown[],
+  })),
   collectDevicePairingHealthFindings: vi.fn(async () => []),
   scanConfiguredChannelPluginBlockers: vi.fn(
     (): Array<{ channelId: string; pluginId: string; reason: string }> => [],
@@ -308,6 +312,7 @@ vi.mock("../commands/doctor-disk-space.js", () => ({
 vi.mock("../commands/doctor-heartbeat-template-repair.js", () => ({
   collectHeartbeatTemplateHealthFindings: mocks.collectHeartbeatTemplateHealthFindings,
   maybeRepairHeartbeatTemplate: mocks.maybeRepairHeartbeatTemplate,
+  repairHeartbeatTemplateHealthFindings: mocks.repairHeartbeatTemplateHealthFindings,
 }));
 
 vi.mock("../commands/doctor-device-pairing.js", () => ({
@@ -509,6 +514,8 @@ describe("doctor health contributions", () => {
     mocks.collectHeartbeatTemplateHealthFindings.mockResolvedValue([]);
     mocks.maybeRepairHeartbeatTemplate.mockReset();
     mocks.maybeRepairHeartbeatTemplate.mockResolvedValue(undefined);
+    mocks.repairHeartbeatTemplateHealthFindings.mockReset();
+    mocks.repairHeartbeatTemplateHealthFindings.mockResolvedValue({ changes: [], effects: [] });
     mocks.collectDevicePairingHealthFindings.mockReset();
     mocks.collectDevicePairingHealthFindings.mockResolvedValue([]);
     mocks.scanConfiguredChannelPluginBlockers.mockReset();
@@ -1068,6 +1075,57 @@ describe("doctor health contributions", () => {
       findings: [expect.objectContaining({ checkId: "core/doctor/heartbeat-template" })],
     });
     expect(mocks.collectHeartbeatTemplateHealthFindings).toHaveBeenCalledWith(ctx.cfg);
+  });
+
+  it("threads dry-run heartbeat template repairs through the structured check", async () => {
+    const contributionChecks = await resolveDoctorContributionHealthChecks();
+    const heartbeatTemplateCheck = contributionChecks.find(
+      (check) => check.id === "core/doctor/heartbeat-template",
+    );
+    expect(heartbeatTemplateCheck).toBeDefined();
+    const findings = [
+      {
+        checkId: "core/doctor/heartbeat-template",
+        severity: "warning" as const,
+        message: "HEARTBEAT.md contains an older heartbeat documentation template.",
+        path: "/tmp/openclaw-workspace/HEARTBEAT.md",
+        requirement: "legacy-template",
+      },
+    ];
+    mocks.repairHeartbeatTemplateHealthFindings.mockResolvedValueOnce({
+      changes: ["Would replace heartbeat template."],
+      effects: [
+        {
+          kind: "file",
+          action: "would-replace-heartbeat-template",
+          target: "/tmp/openclaw-workspace/HEARTBEAT.md",
+          dryRunSafe: false,
+        },
+      ],
+    });
+
+    const result = await heartbeatTemplateCheck!.repair?.(
+      {
+        cfg: { agents: { defaults: { workspace: "/tmp/openclaw-workspace" } } },
+        mode: "fix",
+        dryRun: true,
+        diff: true,
+        runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      },
+      findings,
+    );
+
+    expect(mocks.repairHeartbeatTemplateHealthFindings).toHaveBeenCalledWith({
+      cfg: { agents: { defaults: { workspace: "/tmp/openclaw-workspace" } } },
+      findings,
+      dryRun: true,
+      diff: true,
+    });
+    expect(result?.effects).toContainEqual(
+      expect.objectContaining({
+        action: "would-replace-heartbeat-template",
+      }),
+    );
   });
 
   it("preserves allow-exec Gateway SecretRef resolution in auth health", async () => {

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -1839,6 +1839,16 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
     createDoctorHealthContribution({
       id: "doctor:heartbeat-template-repair",
       label: "Heartbeat template repair",
+      healthChecks: {
+        id: "core/doctor/heartbeat-template",
+        description: "Legacy HEARTBEAT.md documentation templates are findings.",
+        defaultEnabled: false,
+        async detect(ctx) {
+          const { collectHeartbeatTemplateHealthFindings } =
+            await import("../commands/doctor-heartbeat-template-repair.js");
+          return await collectHeartbeatTemplateHealthFindings(ctx.cfg);
+        },
+      },
       run: runHeartbeatTemplateRepairHealth,
     }),
     createDoctorHealthContribution({

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -1848,16 +1848,6 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
             await import("../commands/doctor-heartbeat-template-repair.js");
           return await collectHeartbeatTemplateHealthFindings(ctx.cfg);
         },
-        async repair(ctx, findings) {
-          const { repairHeartbeatTemplateHealthFindings } =
-            await import("../commands/doctor-heartbeat-template-repair.js");
-          return await repairHeartbeatTemplateHealthFindings({
-            cfg: ctx.cfg,
-            findings,
-            dryRun: ctx.dryRun,
-            diff: ctx.diff,
-          });
-        },
       },
       run: runHeartbeatTemplateRepairHealth,
     }),

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -1848,6 +1848,16 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
             await import("../commands/doctor-heartbeat-template-repair.js");
           return await collectHeartbeatTemplateHealthFindings(ctx.cfg);
         },
+        async repair(ctx, findings) {
+          const { repairHeartbeatTemplateHealthFindings } =
+            await import("../commands/doctor-heartbeat-template-repair.js");
+          return await repairHeartbeatTemplateHealthFindings({
+            cfg: ctx.cfg,
+            findings,
+            dryRun: ctx.dryRun,
+            diff: ctx.diff,
+          });
+        },
       },
       run: runHeartbeatTemplateRepairHealth,
     }),


### PR DESCRIPTION
## Summary
- add a default-disabled `core/doctor/heartbeat-template` structured health check for legacy `HEARTBEAT.md` documentation-template wrappers
- reuse the existing heartbeat template analyzer so lint and legacy Doctor repair classify the same file shapes
- keep actual replacement in the existing legacy `doctor --fix` path; this PR is lint-only and does not add a structured repair/dry-run hook
- no config, plugin, SDK, persisted data, or repair-path contract changes

## Public surface
- Default `doctor --lint` is unchanged.
- The check runs only with `--only core/doctor/heartbeat-template` or `--all`.

## Real behavior proof
- Source CLI with isolated `OPENCLAW_CONFIG_PATH`, `OPENCLAW_STATE_DIR`, and workspace containing a legacy fenced `HEARTBEAT.md` template:
  - `doctor --lint --json` ran broad default lint with `heartbeat=0`, proving default lint skips the new default-disabled check.
  - `doctor --lint --json --only core/doctor/heartbeat-template` ran one selected check, emitted one `core/doctor/heartbeat-template` warning with `requirement: "legacy-template"`, and exited 1.

## Validation after Omar fix
- `node scripts/run-vitest.mjs src/commands/doctor-heartbeat-template-repair.test.ts src/flows/doctor-health-contributions.test.ts` (73 tests)
- changed-file `pnpm exec oxfmt --check`
- changed-file `pnpm exec oxlint`
- `node scripts/plugin-sdk-surface-report.mjs --check`
- `git diff --check`