### PR TITLE
fix: accept nullable plugin approval metadata

### DIFF
--- a/packages/gateway-protocol/src/schema/plugin-approvals.ts
+++ b/packages/gateway-protocol/src/schema/plugin-approvals.ts
@@ -12,28 +12,34 @@ import { NonEmptyString } from "./primitives.js";
 const MAX_PLUGIN_APPROVAL_TIMEOUT_MS = 600_000;
 const PLUGIN_APPROVAL_TITLE_MAX_LENGTH = 80;
 const PLUGIN_APPROVAL_DESCRIPTION_MAX_LENGTH = 256;
+const NullableString = Type.Union([Type.String(), Type.Null()]);
 
 /** Approval request raised by a plugin before a sensitive tool action proceeds. */
 export const PluginApprovalRequestParamsSchema = Type.Object(
   {
-    pluginId: Type.Optional(NonEmptyString),
+    pluginId: Type.Optional(Type.Union([NonEmptyString, Type.Null()])),
     title: Type.String({ minLength: 1, maxLength: PLUGIN_APPROVAL_TITLE_MAX_LENGTH }),
     description: Type.String({ minLength: 1, maxLength: PLUGIN_APPROVAL_DESCRIPTION_MAX_LENGTH }),
-    severity: Type.Optional(Type.String({ enum: ["info", "warning", "critical"] })),
-    toolName: Type.Optional(Type.String()),
-    toolCallId: Type.Optional(Type.String()),
-    allowedDecisions: Type.Optional(
-      Type.Array(Type.String({ enum: ["allow-once", "allow-always", "deny"] }), {
-        minItems: 1,
-        maxItems: 3,
-      }),
+    severity: Type.Optional(
+      Type.Union([Type.String({ enum: ["info", "warning", "critical"] }), Type.Null()]),
     ),
-    agentId: Type.Optional(Type.String()),
-    sessionKey: Type.Optional(Type.String()),
-    turnSourceChannel: Type.Optional(Type.String()),
-    turnSourceTo: Type.Optional(Type.String()),
-    turnSourceAccountId: Type.Optional(Type.String()),
-    turnSourceThreadId: Type.Optional(Type.Union([Type.String(), Type.Number()])),
+    toolName: Type.Optional(NullableString),
+    toolCallId: Type.Optional(NullableString),
+    allowedDecisions: Type.Optional(
+      Type.Union([
+        Type.Array(Type.String({ enum: ["allow-once", "allow-always", "deny"] }), {
+          minItems: 1,
+          maxItems: 3,
+        }),
+        Type.Null(),
+      ]),
+    ),
+    agentId: Type.Optional(NullableString),
+    sessionKey: Type.Optional(NullableString),
+    turnSourceChannel: Type.Optional(NullableString),
+    turnSourceTo: Type.Optional(NullableString),
+    turnSourceAccountId: Type.Optional(NullableString),
+    turnSourceThreadId: Type.Optional(Type.Union([Type.String(), Type.Number(), Type.Null()])),
     timeoutMs: Type.Optional(Type.Integer({ minimum: 1, maximum: MAX_PLUGIN_APPROVAL_TIMEOUT_MS })),
     twoPhase: Type.Optional(Type.Boolean()),
   },

--- a/src/gateway/server-methods/plugin-approval.test.ts
+++ b/src/gateway/server-methods/plugin-approval.test.ts
@@ -460,6 +460,52 @@ describe("createPluginApprovalHandlers", () => {
       manager.resolve(approvalId, "deny");
       await handlerPromise;
     });
+
+    it("accepts nullable optional request fields", async () => {
+      const handlers = createPluginApprovalHandlers(manager);
+      const respond = vi.fn();
+      const opts = createMockOptions(
+        "plugin.approval.request",
+        {
+          pluginId: null,
+          title: "Nullable metadata",
+          description: "Optional plugin approval metadata may be null",
+          severity: null,
+          toolName: null,
+          toolCallId: null,
+          allowedDecisions: null,
+          agentId: null,
+          sessionKey: null,
+          turnSourceChannel: null,
+          turnSourceTo: null,
+          turnSourceAccountId: null,
+          turnSourceThreadId: null,
+          twoPhase: true,
+        },
+        { respond },
+      );
+
+      const handlerPromise = handlers["plugin.approval.request"](opts);
+      const approvalId = await waitForAcceptedApproval(respond);
+      expect(manager.getSnapshot(approvalId)?.request).toMatchObject({
+        pluginId: null,
+        title: "Nullable metadata",
+        description: "Optional plugin approval metadata may be null",
+        severity: null,
+        toolName: null,
+        toolCallId: null,
+        agentId: null,
+        sessionKey: null,
+        turnSourceChannel: null,
+        turnSourceTo: null,
+        turnSourceAccountId: null,
+        turnSourceThreadId: null,
+      });
+      expect(manager.getSnapshot(approvalId)?.request.allowedDecisions).toBeUndefined();
+
+      manager.resolve(approvalId, "allow-once");
+      await handlerPromise;
+    });
   });
 
   describe("plugin.approval.list", () => {


### PR DESCRIPTION
## Summary

- allow `plugin.approval.request` optional metadata fields to be explicitly `null`
- treat `allowedDecisions: null` as omitted so default decisions still apply
- add a gateway regression test for nullable plugin approval metadata

Closes #98403.

## Validation

- `node scripts/run-with-env.mjs OPENCLAW_GATEWAY_PROJECT_SHARDS=0 -- node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/server-methods/plugin-approval.test.ts --testTimeout=30000`
- `corepack pnpm --dir packages/gateway-protocol build`
- `git diff --check`