### PR TITLE
Expose WhatsApp responsiveness doctor lint findings

### DIFF
--- a/src/commands/doctor-whatsapp-responsiveness.test.ts
+++ b/src/commands/doctor-whatsapp-responsiveness.test.ts
@@ -16,8 +16,12 @@ vi.mock("../../packages/terminal-core/src/note.js", () => ({
   note: noteMock,
 }));
 
-const { listLocalTuiProcesses, noteWhatsappResponsivenessHealth, terminateLocalTuiProcesses } =
-  await import("./doctor-whatsapp-responsiveness.js");
+const {
+  collectWhatsappResponsivenessHealthFindings,
+  listLocalTuiProcesses,
+  noteWhatsappResponsivenessHealth,
+  terminateLocalTuiProcesses,
+} = await import("./doctor-whatsapp-responsiveness.js");
 
 describe("doctor WhatsApp responsiveness", () => {
   beforeEach(() => {
@@ -116,6 +120,93 @@ describe("doctor WhatsApp responsiveness", () => {
       ].join("\n"),
       "WhatsApp responsiveness",
     );
+  });
+
+  it("collects a warning finding for local TUI pressure when WhatsApp is enabled", () => {
+    const cfg = { channels: { whatsapp: { enabled: true } } } as OpenClawConfig;
+
+    const findings = collectWhatsappResponsivenessHealthFindings({
+      cfg,
+      status: {
+        eventLoop: {
+          degraded: true,
+          reasons: ["event_loop_delay"],
+          intervalMs: 30_000,
+          delayP99Ms: 42,
+          delayMaxMs: 12_000,
+          utilization: 0.3,
+          cpuCoreRatio: 0.4,
+        },
+      },
+      listLocalTuiProcesses: () => [{ pid: 101, command: "openclaw-tui" }],
+    });
+
+    expect(findings).toEqual([
+      expect.objectContaining({
+        checkId: "core/doctor/whatsapp-responsiveness",
+        severity: "warning",
+        path: "channels.whatsapp",
+        target: "101",
+        requirement: "local-tui-event-loop-pressure",
+        fixHint: expect.stringContaining("openclaw doctor --fix"),
+      }),
+    ]);
+  });
+
+  it("keeps WhatsApp responsiveness findings quiet without the exact pressure signal", () => {
+    const cfg = { channels: { whatsapp: { enabled: true } } } as OpenClawConfig;
+
+    expect(
+      collectWhatsappResponsivenessHealthFindings({
+        cfg,
+        status: {
+          eventLoop: {
+            degraded: false,
+            reasons: [],
+            intervalMs: 1,
+            delayP99Ms: 0,
+            delayMaxMs: 0,
+            utilization: 0,
+            cpuCoreRatio: 0,
+          },
+        },
+        listLocalTuiProcesses: () => [{ pid: 101, command: "openclaw-tui" }],
+      }),
+    ).toEqual([]);
+    expect(
+      collectWhatsappResponsivenessHealthFindings({
+        cfg,
+        status: {
+          eventLoop: {
+            degraded: true,
+            reasons: ["event_loop_delay"],
+            intervalMs: 30_000,
+            delayP99Ms: 42,
+            delayMaxMs: 12_000,
+            utilization: 0.3,
+            cpuCoreRatio: 0.4,
+          },
+        },
+        listLocalTuiProcesses: () => [],
+      }),
+    ).toEqual([]);
+    expect(
+      collectWhatsappResponsivenessHealthFindings({
+        cfg: { channels: { whatsapp: { enabled: false } } } as OpenClawConfig,
+        status: {
+          eventLoop: {
+            degraded: true,
+            reasons: ["event_loop_delay"],
+            intervalMs: 30_000,
+            delayP99Ms: 42,
+            delayMaxMs: 12_000,
+            utilization: 0.3,
+            cpuCoreRatio: 0.4,
+          },
+        },
+        listLocalTuiProcesses: () => [{ pid: 101, command: "openclaw-tui" }],
+      }),
+    ).toEqual([]);
   });
 
   it("does not treat generic model routing as a WhatsApp-only issue", async () => {

--- a/src/commands/doctor-whatsapp-responsiveness.test.ts
+++ b/src/commands/doctor-whatsapp-responsiveness.test.ts
@@ -43,11 +43,16 @@ describe("doctor WhatsApp responsiveness", () => {
       ].join("\n"),
     });
 
-    expect(listLocalTuiProcesses()).toEqual([
-      { pid: 101, command: "openclaw-tui" },
-      { pid: 104, command: "openclaw tui --local" },
-      { pid: 105, command: "/usr/bin/openclaw chat" },
-    ]);
+    if (process.platform === "win32") {
+      expect(listLocalTuiProcesses()).toEqual([]);
+      expect(spawnSyncMock).not.toHaveBeenCalled();
+    } else {
+      expect(listLocalTuiProcesses()).toEqual([
+        { pid: 101, command: "openclaw-tui" },
+        { pid: 104, command: "openclaw tui --local" },
+        { pid: 105, command: "/usr/bin/openclaw chat" },
+      ]);
+    }
   });
 
   it("terminates stale local TUI processes with a kill fallback", async () => {

--- a/src/commands/doctor-whatsapp-responsiveness.ts
+++ b/src/commands/doctor-whatsapp-responsiveness.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { note } from "../../packages/terminal-core/src/note.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { HealthFinding } from "../flows/health-checks.js";
 import type { StatusSummary } from "./status.types.js";
 
 type LocalTuiProcess = {
@@ -18,6 +19,7 @@ type ProcessController = {
 };
 
 const LOCAL_TUI_SUBCOMMANDS = new Set(["chat", "terminal", "tui"]);
+const WHATSAPP_RESPONSIVENESS_CHECK_ID = "core/doctor/whatsapp-responsiveness";
 
 function tokenizeCommandLine(command: string): string[] {
   return command.trim().split(/\s+/u).filter(Boolean);
@@ -91,6 +93,43 @@ function hasWhatsappEnabled(cfg: OpenClawConfig): boolean {
 
 function formatPidList(processes: LocalTuiProcess[]): string {
   return processes.map((proc) => String(proc.pid)).join(", ");
+}
+
+/** Collects read-only structured findings for WhatsApp responsiveness pressure. */
+export function collectWhatsappResponsivenessHealthFindings(params: {
+  cfg: OpenClawConfig;
+  status?: Pick<StatusSummary, "eventLoop"> | null;
+  listLocalTuiProcesses?: () => LocalTuiProcess[];
+}): readonly HealthFinding[] {
+  if (!hasWhatsappEnabled(params.cfg)) {
+    return [];
+  }
+
+  const eventLoop = params.status?.eventLoop;
+  if (eventLoop?.degraded !== true) {
+    return [];
+  }
+
+  const tuiProcesses = (params.listLocalTuiProcesses ?? listLocalTuiProcesses)();
+  if (tuiProcesses.length === 0) {
+    return [];
+  }
+
+  const pids = formatPidList(tuiProcesses);
+  return [
+    {
+      checkId: WHATSAPP_RESPONSIVENESS_CHECK_ID,
+      severity: "warning",
+      message:
+        "Gateway event loop is degraded while local TUI clients are running; WhatsApp replies can queue behind TUI startup/session refresh work.",
+      path: "channels.whatsapp",
+      target: pids,
+      requirement: "local-tui-event-loop-pressure",
+      fixHint: `Close local TUI sessions (${pids}), or run ${formatCliCommand(
+        "openclaw doctor --fix",
+      )}.`,
+    },
+  ];
 }
 
 function isProcessAlive(controller: ProcessController, pid: number): boolean {

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -100,6 +100,8 @@ const mocks = vi.hoisted(() => ({
   collectDiskSpaceHealthFindings: vi.fn((): readonly HealthFinding[] => []),
   collectHeartbeatTemplateHealthFindings: vi.fn(async () => [] as unknown[]),
   maybeRepairHeartbeatTemplate: vi.fn().mockResolvedValue(undefined),
+  collectWhatsappResponsivenessHealthFindings: vi.fn(() => []),
+  noteWhatsappResponsivenessHealth: vi.fn().mockResolvedValue(undefined),
   collectDevicePairingHealthFindings: vi.fn(async () => []),
   scanConfiguredChannelPluginBlockers: vi.fn(
     (): Array<{ channelId: string; pluginId: string; reason: string }> => [],
@@ -338,6 +340,11 @@ vi.mock("../commands/doctor-heartbeat-template-repair.js", () => ({
   maybeRepairHeartbeatTemplate: mocks.maybeRepairHeartbeatTemplate,
 }));
 
+vi.mock("../commands/doctor-whatsapp-responsiveness.js", () => ({
+  collectWhatsappResponsivenessHealthFindings: mocks.collectWhatsappResponsivenessHealthFindings,
+  noteWhatsappResponsivenessHealth: mocks.noteWhatsappResponsivenessHealth,
+}));
+
 vi.mock("../commands/doctor-device-pairing.js", () => ({
   collectDevicePairingHealthFindings: mocks.collectDevicePairingHealthFindings,
   noteDevicePairingHealth: vi.fn().mockResolvedValue(undefined),
@@ -542,6 +549,10 @@ describe("doctor health contributions", () => {
     mocks.collectHeartbeatTemplateHealthFindings.mockResolvedValue([]);
     mocks.maybeRepairHeartbeatTemplate.mockReset();
     mocks.maybeRepairHeartbeatTemplate.mockResolvedValue(undefined);
+    mocks.collectWhatsappResponsivenessHealthFindings.mockReset();
+    mocks.collectWhatsappResponsivenessHealthFindings.mockReturnValue([]);
+    mocks.noteWhatsappResponsivenessHealth.mockReset();
+    mocks.noteWhatsappResponsivenessHealth.mockResolvedValue(undefined);
     mocks.collectDevicePairingHealthFindings.mockReset();
     mocks.collectDevicePairingHealthFindings.mockResolvedValue([]);
     mocks.scanConfiguredChannelPluginBlockers.mockReset();
@@ -1362,6 +1373,7 @@ describe("doctor health contributions", () => {
     expect(contributionIds).toContain("core/doctor/stale-plugin-runtime-symlinks");
     expect(contributionIds).toContain("core/doctor/disk-space");
     expect(contributionIds).toContain("core/doctor/heartbeat-template");
+    expect(contributionIds).toContain("core/doctor/whatsapp-responsiveness");
     expect(contributionIds).toContain("core/doctor/device-pairing");
     expect(contributionIds).toContain("core/doctor/channel-plugin-blockers");
     expect(contributionIds).toContain("core/doctor/tool-result-cap");
@@ -1692,6 +1704,77 @@ describe("doctor health contributions", () => {
       findings: [expect.objectContaining({ checkId: "core/doctor/disk-space" })],
     });
     expect(mocks.collectDiskSpaceHealthFindings).toHaveBeenCalledWith(ctx.cfg);
+  });
+
+  it("keeps WhatsApp responsiveness opt-in for default lint selection", async () => {
+    const contributionChecks = await resolveDoctorContributionHealthChecks();
+    const whatsappCheck = contributionChecks.find(
+      (check) => check.id === "core/doctor/whatsapp-responsiveness",
+    );
+    expect(whatsappCheck).toMatchObject({ defaultEnabled: false });
+    expect(whatsappCheck).toBeDefined();
+
+    const ctx = {
+      cfg: { channels: { whatsapp: { enabled: true } } },
+      mode: "lint",
+      allowExecSecretRefs: true,
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+    } as const;
+    const checks = [whatsappCheck!];
+
+    await expect(runDoctorLintChecks(ctx, { checks })).resolves.toMatchObject({
+      checksRun: 0,
+      checksSkipped: 1,
+    });
+    expect(mocks.checkGatewayHealth).not.toHaveBeenCalled();
+    expect(mocks.callGateway).not.toHaveBeenCalled();
+    expect(mocks.collectWhatsappResponsivenessHealthFindings).not.toHaveBeenCalled();
+
+    const status = {
+      eventLoop: {
+        degraded: true,
+        reasons: ["event_loop_delay"],
+        intervalMs: 30_000,
+        delayP99Ms: 42,
+        delayMaxMs: 12_000,
+        utilization: 0.3,
+        cpuCoreRatio: 0.4,
+      },
+    };
+    mocks.checkGatewayHealth.mockResolvedValueOnce({
+      authenticated: true,
+      healthOk: true,
+      status,
+    });
+    mocks.collectWhatsappResponsivenessHealthFindings.mockReturnValueOnce([
+      {
+        checkId: "core/doctor/whatsapp-responsiveness",
+        severity: "warning",
+        message: "Gateway event loop is degraded while local TUI clients are running.",
+        path: "channels.whatsapp",
+        requirement: "local-tui-event-loop-pressure",
+      },
+    ]);
+    mocks.callGateway.mockResolvedValueOnce(status);
+
+    await expect(
+      runDoctorLintChecks(ctx, { checks, onlyIds: ["core/doctor/whatsapp-responsiveness"] }),
+    ).resolves.toMatchObject({
+      checksRun: 1,
+      checksSkipped: 0,
+      findings: [expect.objectContaining({ checkId: "core/doctor/whatsapp-responsiveness" })],
+    });
+    expect(mocks.checkGatewayHealth).not.toHaveBeenCalled();
+    expect(mocks.callGateway).toHaveBeenCalledWith({
+      method: "status",
+      params: { includeChannelSummary: false },
+      timeoutMs: 3000,
+      config: ctx.cfg,
+    });
+    expect(mocks.collectWhatsappResponsivenessHealthFindings).toHaveBeenCalledWith({
+      cfg: ctx.cfg,
+      status,
+    });
   });
 
   it("keeps device pairing opt-in for default lint selection", async () => {

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -28,6 +28,7 @@ const mocks = vi.hoisted(() => ({
   noteLegacyCodexProviderOverride: vi.fn(),
   noteMemorySearchHealth: vi.fn().mockResolvedValue(undefined),
   buildGatewayConnectionDetails: vi.fn(() => ({ message: "gateway details" })),
+  callGateway: vi.fn(),
   resolveSecretInputRef: vi.fn((params: { value?: unknown }) => ({
     ref:
       params.value === "exec-token"
@@ -215,6 +216,7 @@ vi.mock("../commands/doctor-memory-search.js", () => ({
 
 vi.mock("../gateway/call.js", () => ({
   buildGatewayConnectionDetails: mocks.buildGatewayConnectionDetails,
+  callGateway: mocks.callGateway,
 }));
 
 vi.mock("../commands/doctor-platform-notes.js", () => ({
@@ -435,6 +437,8 @@ describe("doctor health contributions", () => {
     mocks.noteMemorySearchHealth.mockResolvedValue(undefined);
     mocks.buildGatewayConnectionDetails.mockClear();
     mocks.buildGatewayConnectionDetails.mockReturnValue({ message: "gateway details" });
+    mocks.callGateway.mockReset();
+    mocks.callGateway.mockResolvedValue({});
     mocks.resolveSecretInputRef.mockClear();
     mocks.resolveGatewayAuth.mockClear();
     mocks.resolveGatewayAuth.mockReturnValue({ mode: "token", token: undefined });
@@ -1741,11 +1745,7 @@ describe("doctor health contributions", () => {
         cpuCoreRatio: 0.4,
       },
     };
-    mocks.checkGatewayHealth.mockResolvedValueOnce({
-      authenticated: true,
-      healthOk: true,
-      status,
-    });
+    mocks.callGateway.mockResolvedValueOnce(status);
     mocks.collectWhatsappResponsivenessHealthFindings.mockReturnValueOnce([
       {
         checkId: "core/doctor/whatsapp-responsiveness",
@@ -1774,6 +1774,28 @@ describe("doctor health contributions", () => {
     expect(mocks.collectWhatsappResponsivenessHealthFindings).toHaveBeenCalledWith({
       cfg: ctx.cfg,
       status,
+    });
+
+    mocks.callGateway.mockRejectedValueOnce(new Error("gateway unavailable"));
+    mocks.collectWhatsappResponsivenessHealthFindings.mockReturnValueOnce([]);
+    const error = vi.fn();
+    await expect(
+      runDoctorLintChecks(
+        {
+          ...ctx,
+          runtime: { log: vi.fn(), error, exit: vi.fn() },
+        },
+        { checks, onlyIds: ["core/doctor/whatsapp-responsiveness"] },
+      ),
+    ).resolves.toMatchObject({
+      checksRun: 1,
+      checksSkipped: 0,
+      findings: [],
+    });
+    expect(error).not.toHaveBeenCalled();
+    expect(mocks.collectWhatsappResponsivenessHealthFindings).toHaveBeenLastCalledWith({
+      cfg: ctx.cfg,
+      status: undefined,
     });
   });
 

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -101,7 +101,7 @@ const mocks = vi.hoisted(() => ({
   collectDiskSpaceHealthFindings: vi.fn((): readonly HealthFinding[] => []),
   collectHeartbeatTemplateHealthFindings: vi.fn(async () => [] as unknown[]),
   maybeRepairHeartbeatTemplate: vi.fn().mockResolvedValue(undefined),
-  collectWhatsappResponsivenessHealthFindings: vi.fn(() => []),
+  collectWhatsappResponsivenessHealthFindings: vi.fn((): readonly HealthFinding[] => []),
   noteWhatsappResponsivenessHealth: vi.fn().mockResolvedValue(undefined),
   collectDevicePairingHealthFindings: vi.fn(async () => []),
   scanConfiguredChannelPluginBlockers: vi.fn(
@@ -1755,7 +1755,6 @@ describe("doctor health contributions", () => {
         requirement: "local-tui-event-loop-pressure",
       },
     ]);
-    mocks.callGateway.mockResolvedValueOnce(status);
 
     await expect(
       runDoctorLintChecks(ctx, { checks, onlyIds: ["core/doctor/whatsapp-responsiveness"] }),
@@ -1770,6 +1769,7 @@ describe("doctor health contributions", () => {
       params: { includeChannelSummary: false },
       timeoutMs: 3000,
       config: ctx.cfg,
+      deviceIdentity: null,
     });
     expect(mocks.collectWhatsappResponsivenessHealthFindings).toHaveBeenCalledWith({
       cfg: ctx.cfg,
@@ -1794,6 +1794,36 @@ describe("doctor health contributions", () => {
     });
     expect(error).not.toHaveBeenCalled();
     expect(mocks.collectWhatsappResponsivenessHealthFindings).toHaveBeenLastCalledWith({
+      cfg: ctx.cfg,
+      status: undefined,
+    });
+  });
+
+  it("skips WhatsApp responsiveness Gateway status probes for exec SecretRefs without allow-exec", async () => {
+    const contributionChecks = await resolveDoctorContributionHealthChecks();
+    const whatsappCheck = contributionChecks.find(
+      (check) => check.id === "core/doctor/whatsapp-responsiveness",
+    );
+    expect(whatsappCheck).toBeDefined();
+    mocks.gatewaySecretInputPathCanWin.mockReturnValue(true);
+    mocks.readGatewaySecretInputValue.mockReturnValue("exec-token");
+
+    const ctx = {
+      cfg: { channels: { whatsapp: { enabled: true } } },
+      mode: "lint",
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+    } as const;
+    const checks = [whatsappCheck!];
+
+    await expect(
+      runDoctorLintChecks(ctx, { checks, onlyIds: ["core/doctor/whatsapp-responsiveness"] }),
+    ).resolves.toMatchObject({
+      checksRun: 1,
+      checksSkipped: 0,
+      findings: [],
+    });
+    expect(mocks.callGateway).not.toHaveBeenCalled();
+    expect(mocks.collectWhatsappResponsivenessHealthFindings).toHaveBeenCalledWith({
       cfg: ctx.cfg,
       status: undefined,
     });

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -1915,6 +1915,23 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
     createDoctorHealthContribution({
       id: "doctor:whatsapp-responsiveness",
       label: "WhatsApp responsiveness",
+      healthChecks: {
+        id: "core/doctor/whatsapp-responsiveness",
+        description:
+          "WhatsApp responsiveness pressure from degraded Gateway and local TUI clients.",
+        defaultEnabled: false,
+        async detect(ctx) {
+          const { checkGatewayHealth } = await import("../commands/doctor-gateway-health.js");
+          const { collectWhatsappResponsivenessHealthFindings } =
+            await import("../commands/doctor-whatsapp-responsiveness.js");
+          const { status } = await checkGatewayHealth({
+            runtime: ctx.runtime,
+            cfg: ctx.cfg,
+            timeoutMs: 3000,
+          });
+          return collectWhatsappResponsivenessHealthFindings({ cfg: ctx.cfg, status });
+        },
+      },
       run: runWhatsappResponsivenessHealth,
     }),
     createDoctorHealthContribution({

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -1921,14 +1921,15 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
           "WhatsApp responsiveness pressure from degraded Gateway and local TUI clients.",
         defaultEnabled: false,
         async detect(ctx) {
-          const { checkGatewayHealth } = await import("../commands/doctor-gateway-health.js");
+          const { callGateway } = await import("../gateway/call.js");
           const { collectWhatsappResponsivenessHealthFindings } =
             await import("../commands/doctor-whatsapp-responsiveness.js");
-          const { status } = await checkGatewayHealth({
-            runtime: ctx.runtime,
-            cfg: ctx.cfg,
+          const status = await callGateway<import("../commands/status.types.js").StatusSummary>({
+            method: "status",
+            params: { includeChannelSummary: false },
             timeoutMs: 3000,
-          });
+            config: ctx.cfg,
+          }).catch(() => undefined);
           return collectWhatsappResponsivenessHealthFindings({ cfg: ctx.cfg, status });
         },
       },

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -980,7 +980,7 @@ async function runSystemdLingerHealth(ctx: DoctorHealthFlowContext): Promise<voi
 }
 
 async function hasActiveGatewayExecCredential(
-  ctx: DoctorHealthFlowContext,
+  ctx: Pick<DoctorHealthFlowContext, "cfg">,
   mode: DoctorFlowMode = resolveDoctorMode(ctx.cfg),
 ): Promise<boolean> {
   const { resolveSecretInputRef } = await loadSecretTypesModule();
@@ -1921,15 +1921,24 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
           "WhatsApp responsiveness pressure from degraded Gateway and local TUI clients.",
         defaultEnabled: false,
         async detect(ctx) {
-          const { callGateway } = await import("../gateway/call.js");
           const { collectWhatsappResponsivenessHealthFindings } =
             await import("../commands/doctor-whatsapp-responsiveness.js");
-          const status = await callGateway<import("../commands/status.types.js").StatusSummary>({
-            method: "status",
-            params: { includeChannelSummary: false },
-            timeoutMs: 3000,
-            config: ctx.cfg,
-          }).catch(() => undefined);
+          let status: import("../commands/status.types.js").StatusSummary | undefined;
+          if (
+            !(
+              (await hasActiveGatewayExecCredential({ cfg: ctx.cfg })) &&
+              ctx.allowExecSecretRefs !== true
+            )
+          ) {
+            const { callGateway } = await import("../gateway/call.js");
+            status = await callGateway<import("../commands/status.types.js").StatusSummary>({
+              method: "status",
+              params: { includeChannelSummary: false },
+              timeoutMs: 3000,
+              config: ctx.cfg,
+              deviceIdentity: null,
+            }).catch(() => undefined);
+          }
           return collectWhatsappResponsivenessHealthFindings({ cfg: ctx.cfg, status });
         },
       },


### PR DESCRIPTION
## Summary
- add default-disabled `core/doctor/whatsapp-responsiveness` structured lint findings
- reuse the existing WhatsApp responsiveness signal: WhatsApp enabled + degraded Gateway event loop + local TUI clients
- keep real cleanup in the existing `doctor --fix` path; lint only reports the actionable pressure state
- keep selected lint side-effect-free: skip exec SecretRefs unless allowed, use a quiet Gateway `status` RPC, and pass `deviceIdentity: null` so lint cannot create Gateway identity state

## Public contract
- No config schema, plugin manifest, SDK export, persisted data-model, or public plugin contract changes.
- The new check is opt-in for broad lint via `defaultEnabled: false`; default `doctor --lint` remains unchanged.

## Validation
- `node scripts/run-vitest.mjs src/commands/doctor-whatsapp-responsiveness.test.ts src/flows/doctor-health-contributions.test.ts` (71 tests)
- `.\node_modules\.bin\oxfmt.cmd --check src/commands/doctor-whatsapp-responsiveness.ts src/commands/doctor-whatsapp-responsiveness.test.ts src/flows/doctor-health-contributions.ts src/flows/doctor-health-contributions.test.ts`
- `.\node_modules\.bin\oxlint.cmd --tsconfig config/tsconfig/oxlint.core.json src/commands/doctor-whatsapp-responsiveness.ts src/commands/doctor-whatsapp-responsiveness.test.ts src/flows/doctor-health-contributions.ts src/flows/doctor-health-contributions.test.ts`
- `node scripts/plugin-sdk-surface-report.mjs --check`
- `node scripts/sync-plugin-sdk-exports.mjs --check`
- `git diff --check origin/main...HEAD`

Not completed: `pnpm tsgo:core` timed out on this Windows linked worktree without diagnostics after 180s.

## Real behavior proof
- Source CLI with isolated `OPENCLAW_STATE_DIR` and `OPENCLAW_CONFIG_PATH`, WhatsApp enabled, selected check only:
  - `node scripts/run-node.mjs doctor --lint --json --only core/doctor/whatsapp-responsiveness`
  - exited 0, ran 1 check, emitted 0 findings because Gateway did not provide degraded event-loop status
  - verified `<temp-state>/identity/device.json` was not created (`IdentityExists: false`), proving the selected lint probe did not create Gateway device identity state
- Focused source tests prove the positive selected-lint signal: WhatsApp enabled + `eventLoop.degraded === true` + local TUI process emits a warning finding with `requirement: "local-tui-event-loop-pressure"` and a `doctor --fix` hint.
- Focused contribution tests prove the selected lint path uses quiet `callGateway({ method: "status", params: { includeChannelSummary: false }, deviceIdentity: null })`, does not call `checkGatewayHealth`, returns no finding without calling `runtime.error` when Gateway status is unavailable, and does not call Gateway at all for exec SecretRefs unless exec refs are allowed.

## ClawSweeper follow-up
- Addressed P2 “Avoid creating device identity during lint probes” by passing `deviceIdentity: null` to the selected lint Gateway status call and asserting that in the contribution regression.
- Addressed Omar's exec SecretRef concern by skipping selected lint Gateway status probes unless exec refs are allowed.
- Addressed the Windows-only WhatsApp process-list test mismatch by asserting the intentional Windows skip instead of POSIX `ps` parsing on Windows.