### PR TITLE
fix(mcp): proactively refresh OAuth tokens for long-lived MCP servers

### DIFF
--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -35,6 +35,7 @@ import type {
 } from "./agent-bundle-mcp-types.js";
 import { loadEmbeddedAgentMcpConfig } from "./embedded-agent-mcp.js";
 import { isMcpConfigRecord } from "./mcp-config-shared.js";
+import { ensureMcpOAuthTokenFresh, startMcpOAuthProactiveRefresh } from "./mcp-oauth.js";
 import { resolveMcpTransport } from "./mcp-transport.js";
 
 type BundleMcpSession = {
@@ -50,6 +51,7 @@ type BundleMcpSession = {
   sharedAcrossCatalogGenerations: boolean;
   connectPromise?: Promise<void>;
   detachStderr?: () => void;
+  stopRefresh?: () => void;
 };
 
 type LoadedMcpConfig = ReturnType<typeof loadEmbeddedAgentMcpConfig>;
@@ -389,6 +391,7 @@ function summarizeServerCapabilities(capabilities: ServerCapabilities | undefine
 const DISPOSE_TIMEOUT_MS = 5_000;
 
 async function disposeSession(session: BundleMcpSession) {
+  session.stopRefresh?.();
   session.detachStderr?.();
   let timer: ReturnType<typeof setTimeout> | undefined;
   let timedOut = false;
@@ -670,6 +673,17 @@ export function createSessionMcpRuntime(params: {
                     },
                   },
                 );
+                // Keep the OAuth access token fresh for the life of this
+                // persistent session; cleared in disposeSession so the timer
+                // never dangles.
+                const stopRefresh =
+                  resolved.authProvider && resolved.serverUrl
+                    ? startMcpOAuthProactiveRefresh({
+                        serverName,
+                        serverUrl: resolved.serverUrl,
+                        authProvider: resolved.authProvider,
+                      })
+                    : undefined;
                 session = {
                   serverName,
                   client,
@@ -682,6 +696,7 @@ export function createSessionMcpRuntime(params: {
                   catalogUseCount: 0,
                   sharedAcrossCatalogGenerations: false,
                   detachStderr: resolved.detachStderr,
+                  stopRefresh,
                 };
                 sessions.set(serverName, session);
               }
@@ -696,6 +711,17 @@ export function createSessionMcpRuntime(params: {
               let connectedForCatalog = false;
               try {
                 failIfDisposed();
+                if (resolved.authProvider && resolved.serverUrl) {
+                  // Refresh a stale OAuth token before connecting: rarely-used
+                  // servers are idle-disposed before the background timer fires,
+                  // so the token expires during idle and reconnect would present
+                  // a dead token. Runs each catalog use; no-op when still fresh.
+                  await ensureMcpOAuthTokenFresh({
+                    serverName,
+                    serverUrl: resolved.serverUrl,
+                    authProvider: resolved.authProvider,
+                  });
+                }
                 await ensureSessionConnected(session, resolved.connectionTimeoutMs);
                 connectedForCatalog = true;
                 failIfDisposed();

--- a/src/agents/mcp-oauth.ts
+++ b/src/agents/mcp-oauth.ts
@@ -19,11 +19,12 @@ import type {
 import type { FetchLike } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { resolveStateDir } from "../config/paths.js";
+import { logWarn } from "../logger.js";
 import { sanitizeServerName } from "./agent-bundle-mcp-names.js";
 
 type McpOAuthStore = {
   clientInformation?: OAuthClientInformationMixed;
-  tokens?: OAuthTokens;
+  tokens?: OAuthTokens & { expires_at?: number };
   codeVerifier?: string;
   discoveryState?: OAuthDiscoveryState;
   lastAuthorizationUrl?: string;
@@ -155,7 +156,13 @@ export function createMcpOAuthClientProvider(params: {
     },
     async saveTokens(tokens) {
       const store = await readStore(filePath);
-      await writeStore(filePath, { ...store, tokens });
+      // Persist an absolute expiry so a long-lived session schedules proactive
+      // refresh from the remaining lifetime; expires_in alone is only the
+      // original lifetime and is wrong after a gateway restart.
+      const expiresIn = typeof tokens.expires_in === "number" ? tokens.expires_in : undefined;
+      const stored =
+        expiresIn === undefined ? tokens : { ...tokens, expires_at: Date.now() + expiresIn * 1000 };
+      await writeStore(filePath, { ...store, tokens: stored });
     },
     async redirectToAuthorization(authorizationUrl) {
       assertAuthorizationRedirectAllowed();
@@ -200,6 +207,124 @@ export function createMcpOAuthClientProvider(params: {
       return (await readStore(filePath)).discoveryState;
     },
   };
+}
+
+// Refresh this far ahead of expiry so a persistent connection never presents an
+// expired access token. The reactive 401->refresh path is unreliable on a
+// long-lived gateway connection (openclaw/openclaw#98377); the SDK transport
+// reads tokens() from disk every request, so keeping the stored token fresh is
+// sufficient.
+const OAUTH_PROACTIVE_REFRESH_SKEW_MS = 5 * 60_000;
+const OAUTH_PROACTIVE_REFRESH_MIN_DELAY_MS = 30_000;
+const OAUTH_PROACTIVE_REFRESH_FALLBACK_MS = 50 * 60_000;
+
+/**
+ * Keep a long-lived MCP OAuth access token fresh on disk by refreshing shortly
+ * before it expires (via the SDK auth() refresh_token path). Returns a stop
+ * function; the session owner MUST call it on dispose so the timer never
+ * dangles. Stops quietly if there is no refresh token or a refresh needs
+ * interactive re-login.
+ */
+export function startMcpOAuthProactiveRefresh(params: {
+  serverName: string;
+  serverUrl: string;
+  authProvider: OAuthClientProvider;
+}): () => void {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let stopped = false;
+
+  const nextDelayMs = async (): Promise<number | null> => {
+    const tokens = await params.authProvider.tokens();
+    if (!tokens?.refresh_token) {
+      return null; // nothing to refresh with; leave (re)auth to the login flow
+    }
+    const expiresAt = (tokens as { expires_at?: number }).expires_at;
+    const remainingMs =
+      typeof expiresAt === "number" ? expiresAt - Date.now() : OAUTH_PROACTIVE_REFRESH_FALLBACK_MS;
+    return Math.max(
+      OAUTH_PROACTIVE_REFRESH_MIN_DELAY_MS,
+      remainingMs - OAUTH_PROACTIVE_REFRESH_SKEW_MS,
+    );
+  };
+
+  const arm = async () => {
+    if (stopped) {
+      return;
+    }
+    const delay = await nextDelayMs();
+    if (delay === null || stopped) {
+      return;
+    }
+    timer = setTimeout(() => void refreshAndRearm(), delay);
+    timer.unref?.();
+  };
+
+  const refreshAndRearm = async () => {
+    if (stopped) {
+      return;
+    }
+    try {
+      const result = await auth(params.authProvider, { serverUrl: params.serverUrl });
+      if (result !== "AUTHORIZED") {
+        logWarn(
+          `mcp-oauth: proactive refresh for "${params.serverName}" needs interactive login (openclaw mcp login ${params.serverName}).`,
+        );
+        return;
+      }
+    } catch (error) {
+      logWarn(`mcp-oauth: proactive refresh failed for "${params.serverName}": ${String(error)}`);
+      return;
+    }
+    await arm();
+  };
+
+  void arm();
+
+  return () => {
+    stopped = true;
+    if (timer) {
+      clearTimeout(timer);
+      timer = undefined;
+    }
+  };
+}
+
+// Refresh at connect if the token expires within this window. Must exceed the
+// session idle-TTL (~10 min) so a token refreshed at connect outlives the reuse
+// window. A background timer alone is insufficient: rarely-used sessions are
+// idle-disposed (clearing the timer) long before it fires, so the token expires
+// during idle and the next use hits a stale token (openclaw/openclaw#98377).
+const OAUTH_ENSURE_FRESH_SKEW_MS = 15 * 60_000;
+
+/**
+ * Refresh the stored MCP OAuth token *now* if it lacks an expiry, is expired, or
+ * expires within OAUTH_ENSURE_FRESH_SKEW_MS. Call (awaited) before connecting a
+ * session so the connection never starts with a stale token. Safe no-op when
+ * there is no refresh token (leaves auth to the login flow).
+ */
+export async function ensureMcpOAuthTokenFresh(params: {
+  serverName: string;
+  serverUrl: string;
+  authProvider: OAuthClientProvider;
+}): Promise<void> {
+  const tokens = await params.authProvider.tokens();
+  if (!tokens?.refresh_token) {
+    return;
+  }
+  const expiresAt = (tokens as { expires_at?: number }).expires_at;
+  if (typeof expiresAt === "number" && expiresAt - Date.now() > OAUTH_ENSURE_FRESH_SKEW_MS) {
+    return;
+  }
+  try {
+    const result = await auth(params.authProvider, { serverUrl: params.serverUrl });
+    if (result !== "AUTHORIZED") {
+      logWarn(
+        `mcp-oauth: token refresh for "${params.serverName}" needs interactive login (openclaw mcp login ${params.serverName}).`,
+      );
+    }
+  } catch (error) {
+    logWarn(`mcp-oauth: token refresh failed for "${params.serverName}": ${String(error)}`);
+  }
 }
 
 /** Deletes stored OAuth credentials for one MCP server. */

--- a/src/agents/mcp-transport.ts
+++ b/src/agents/mcp-transport.ts
@@ -1,3 +1,4 @@
+import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
 /**
  * MCP client transport factory.
  *
@@ -29,6 +30,8 @@ type ResolvedMcpTransport = {
   requestTimeoutMs: number;
   supportsParallelToolCalls: boolean;
   detachStderr?: () => void;
+  authProvider?: OAuthClientProvider;
+  serverUrl?: string;
 };
 
 function attachStderrLogging(serverName: string, transport: OpenClawStdioClientTransport) {
@@ -148,6 +151,8 @@ export function resolveMcpTransport(
       connectionTimeoutMs: resolved.connectionTimeoutMs,
       requestTimeoutMs: resolved.requestTimeoutMs,
       supportsParallelToolCalls: resolved.supportsParallelToolCalls,
+      authProvider,
+      serverUrl: resolved.url,
     };
   }
   const sseHeaders: Record<string, string> = { ...headers };
@@ -166,5 +171,7 @@ export function resolveMcpTransport(
     connectionTimeoutMs: resolved.connectionTimeoutMs,
     requestTimeoutMs: resolved.requestTimeoutMs,
     supportsParallelToolCalls: resolved.supportsParallelToolCalls,
+    authProvider,
+    serverUrl: resolved.url,
   };
 }


### PR DESCRIPTION
## Summary

Remote MCP servers configured with `auth: "oauth"` (the MCP SDK OAuth provider path — authorized via `openclaw mcp login`, **no** `oauth.authProfileId`) stop working in the long-running **gateway** once the OAuth access token expires (~1h): the server is reported as needing authorization even though a valid **refresh token** is stored, and a fresh `openclaw mcp probe <server>` refreshes fine. So the capability works on a freshly-constructed client but not on the persistent gateway.

### Why keep the stored token fresh

`StreamableHTTPClientTransport._commonHeaders` reads `authProvider.tokens()` from disk on **every** request, so keeping the on-disk token fresh is sufficient — the transport picks it up on the next request.

### Fix — two complementary refreshes

- **`ensureMcpOAuthTokenFresh()` — refresh at session connect (primary).** In `getCatalog`, before connecting, refresh synchronously if the token lacks an expiry / is expired / expires within 15 min (> the ~10-min session idle-TTL, so a refreshed token outlives the reuse window). This fires **whenever the server is actually used**, so a rarely-used server whose token expired during idle reconnects with a fresh token.
  - A background timer *alone* is insufficient: MCP sessions are **idle-disposed after ~10 min**, which clears the timer long before its ~55-min fire — so for a rarely-used server it never runs.
- **`startMcpOAuthProactiveRefresh()` — session-lifetime timer (defense).** Refreshes ahead of expiry to cover continuously-active sessions that outlive a single token.
- **`saveTokens()` persists an absolute `expires_at`** so the refresh timing is correct across gateway restarts.

`mcp-transport.ts` also returns the `authProvider` + `serverUrl` it already builds, so the session can reuse that exact (disk-backed) provider. `auth: "oauth"` + `oauth.authProfileId` (the #96120 path) and static-header / no-auth servers are unaffected.

## Real behavior proof

- **Behavior addressed**: an `auth: "oauth"` remote MCP server (no `authProfileId`) on a 24/7 gateway no longer needs a manual `openclaw mcp login` after the ~1h access-token TTL — the token is refreshed at connect whenever the server is used.
- **Real environment tested**: Linux, a `2026.6.11`-based build with this patch, gateway running as a systemd service, against a self-hosted OAuth 2.1 (authorization_code + PKCE + DCR + refresh_token, ~3600s TTL) streamable-http MCP server.
- **Exact steps or command run after this patch**: `pnpm build`, restart gateway, force the stored token's `expires_at` to the past, then exercise the `getCatalog`+`ensureMcpOAuthTokenFresh` path (`openclaw mcp probe`).
- **Evidence after fix** (server access log; note `/token` fires *before* any `/mcp`, i.e. refresh-before-connect, no 401):
  ```
  POST /token 200 OK        ← ensureMcpOAuthTokenFresh, before connect
  POST /mcp   200 OK
  ```
  Contrast with the prior (timer-only) build, where the daemon ran for ~2 days and made **zero** `/token` refreshes (repeated `401 invalid_token`) because the timer was always cleared by idle-dispose before firing.
- **Observed result after fix**: connect refreshes the expired token with no 401; the server lists all tools.
- **What was not tested**: an automated Vitest for the connect-time refresh path (live proof only); one OAuth server, not a provider matrix. Authored on `2026.6.11` and applied onto `main` (the connect choke-point is `ensureSessionConnected`).

Fixes #98377

🤖 Generated with [Claude Code](https://claude.com/claude-code)
