### PR TITLE
fix:  #98101 [Bug]: HTTP 429 + 'overloaded' body (e.g. z.ai code 1…

### DIFF
--- a/src/agents/embedded-agent-helpers/errors.ts
+++ b/src/agents/embedded-agent-helpers/errors.ts
@@ -1052,11 +1052,15 @@ function classifyFailoverClassificationFromMessage(
   if (isPeriodicUsageLimitErrorMessage(raw)) {
     return toReasonClassification(isBillingErrorMessage(raw) ? "billing" : "rate_limit");
   }
-  if (isRateLimitErrorMessage(raw)) {
-    return toReasonClassification("rate_limit");
-  }
+  // Overloaded errors take precedence over rate-limit because providers may
+  // return HTTP 429 with an overload message (e.g., z.ai error code 1305:
+  // "The service may be temporarily overloaded"). Classifying these as
+  // rate_limit would show the wrong user-facing copy (#98101).
   if (isOverloadedErrorMessage(raw)) {
     return toReasonClassification("overloaded");
+  }
+  if (isRateLimitErrorMessage(raw)) {
+    return toReasonClassification("rate_limit");
   }
   if (
     isStructuredServerErrorMessage(raw) &&

--- a/src/agents/embedded-agent-helpers/failover-matches.test.ts
+++ b/src/agents/embedded-agent-helpers/failover-matches.test.ts
@@ -117,6 +117,38 @@ describe("Chinese provider overload messages", () => {
   });
 });
 
+describe("z.ai HTTP 429 with overload message (#98101)", () => {
+  // z.ai returns HTTP 429 with error code 1305 and message:
+  // "The service may be temporarily overloaded, please try again later"
+  // This should be classified as "overloaded", not "rate_limit".
+  const ZAI_429_OVERLOAD_JSON =
+    '{"error":{"code":"1305","message":"The service may be temporarily overloaded, please try again later"}}';
+
+  it("classifies z.ai 429+overload JSON body as overloaded", () => {
+    expect(isOverloadedErrorMessage(ZAI_429_OVERLOAD_JSON)).toBe(true);
+  });
+
+  it("does not misclassify z.ai 429+overload as rate limit", () => {
+    expect(isRateLimitErrorMessage(ZAI_429_OVERLOAD_JSON)).toBe(false);
+  });
+
+  it("classifies z.ai 429+overload with classifyFailoverReason as overloaded", () => {
+    expect(classifyFailoverReason(ZAI_429_OVERLOAD_JSON)).toBe("overloaded");
+  });
+
+  it("still classifies plain 429 without overload wording as rate limit", () => {
+    const plain429 = "Error 429: Too many requests";
+    expect(isRateLimitErrorMessage(plain429)).toBe(true);
+    expect(isOverloadedErrorMessage(plain429)).toBe(false);
+  });
+
+  it("still classifies rate limit messages correctly", () => {
+    expect(isRateLimitErrorMessage("rate limit exceeded")).toBe(true);
+    expect(isRateLimitErrorMessage("too many requests")).toBe(true);
+    expect(isRateLimitErrorMessage("throttled")).toBe(true);
+  });
+});
+
 describe("Volcengine Coding Plan subscription errors", () => {
   it("classifies InvalidSubscription JSON body as billing", () => {
     const raw =

--- a/src/agents/embedded-agent-helpers/failover-matches.ts
+++ b/src/agents/embedded-agent-helpers/failover-matches.ts
@@ -69,7 +69,12 @@ const ZAI_AUTH_ERROR_PATTERNS = [
 
 const ERROR_PATTERNS = {
   rateLimit: [
-    /rate[_ ]limit|too many requests|429/,
+    // Match 429 status codes, but exclude explicit overload messages which
+    // should be classified as "overloaded" instead (#98101). The negative
+    // lookahead prevents matching when "overload" or "capacity" appears nearby.
+    /429(?!.*(?:overload|capacity))/i,
+    /rate[_ ]limit/i,
+    /too many requests/i,
     /too many (?:concurrent )?requests/i,
     /throttling(?:exception)?/i,
     "model_cooldown",


### PR DESCRIPTION
fix: HTTP 429 + 'overloaded' body (e.g. z.ai code 1305) misclassified as rate_limit → false 'API rate limit reached' instead of overloaded

Closes #98101

## What Problem This Solves

Fixes an issue where users calling AI providers that return HTTP 429 with an explicit "overloaded" error message (such as z.ai error code 1305: "The service may be temporarily overloaded, please try again later") would see the incorrect user-facing message "⚠️ API rate limit reached. Please try again later." instead of the appropriate transient overload notification.

This particularly impacts scenarios where providers implement concurrency-based throttling mechanisms that are distinct from traditional quota/rate limiting systems, such as z.ai Coding Plan environments which have low per-key concurrent request ceilings leading to these types of transient failures during parallel usage attempts while sequential operations succeed without issues.

## Why This Change Was Made

The root cause was a classification order issue in `classifyFailoverClassificationFromMessage` within `src/agents/embedded-agent-helpers/errors.ts`: the function checked `isRateLimitErrorMessage(raw)` before `isOverloadedErrorMessage(raw)`. Since the rate-limit pattern included a bare `|429|` match, all non-billing/auth related 429 responses got classified as rate limits even when their content clearly indicated a temporary overload condition.

The fix involves two changes:
1. **Reordered classification**: `isOverloadedErrorMessage` now runs before `isRateLimitErrorMessage`, ensuring explicit overload messages take precedence.
2. **Refined rate-limit pattern**: Changed `/rate[_ ]limit|too many requests|429/` to `/429(?!.*(?:overload|capacity))/i` — using a negative lookahead to exclude 429 responses that contain "overload" or "capacity" wording.

These changes preserve existing behavior for genuine rate-limit errors while correctly routing provider overload signals to the "overloaded" classification, which triggers the appropriate user-facing copy and retry semantics.

## User Impact

Users will now see the correct error message when providers return overload conditions:
- **Before**: "⚠️ API rate limit reached. Please try again later." (incorrectly suggests quota exhaustion)
- **After**: "The AI service is temporarily overloaded. Please try again in a moment." (correctly indicates transient capacity issue)

This distinction matters because:
- Rate limits imply the user has hit a quota boundary and should wait for a reset window
- Overload indicates a temporary provider capacity issue that typically resolves within seconds to minutes

The fix also ensures failover/retry logic treats these errors appropriately — overload errors are more likely to succeed on immediate retry compared to hard rate limits.

## Evidence

**Pattern matching verification:**
```bash
# Test case: z.ai 429+overload JSON
echo '{"error":{"code":"1305","message":"The service may be temporarily overloaded, please try again later"}}' | \
  node -e "const msg = require('fs').readFileSync(0, 'utf8'); console.log('isOverloaded:', /overloaded/i.test(msg)); console.log('isRateLimit:', /429(?!.*(overload|capacity))/i.test(msg));"
# Output: isOverloaded: true, isRateLimit: false ✅
Added test coverage (src/agents/embedded-agent-helpers/failover-matches.test.ts):

classifies z.ai 429+overload JSON body as overloaded ✅
does not misclassify z.ai 429+overload as rate limit ✅
classifies z.ai 429+overload with classifyFailoverReason as overloaded ✅
still classifies plain 429 without overload wording as rate limit ✅
still classifies rate limit messages correctly ✅
Existing tests remain green:

Chinese provider overload messages (Zhipu GLM code 1305) continue to classify as overloaded
OpenAI model-capacity and OpenRouter high-load messages continue to classify as overloaded
Standard rate-limit patterns ("rate limit exceeded", "too many requests", "throttled") continue to classify as rate_limit
Files changed:

src/agents/embedded-agent-helpers/errors.ts — classification order fix (+6 lines comment)
src/agents/embedded-agent-helpers/failover-matches.ts — refined rate-limit regex (+4 lines comment)
src/agents/embedded-agent-helpers/failover-matches.test.ts — comprehensive test suite (+32 lines)


