### PR TITLE
fix(agents): recover thinking errors from provider body

### DIFF
--- a/src/agents/embedded-agent-runner/thinking.test.ts
+++ b/src/agents/embedded-agent-runner/thinking.test.ts
@@ -738,6 +738,18 @@ describe("wrapAnthropicStreamWithRecovery", () => {
         }),
     },
     {
+      name: "ProviderHttpError errorBody",
+      createError: () =>
+        Object.assign(new Error(genericizedProviderError), {
+          errorBody: JSON.stringify({
+            error: {
+              message: terminalThinkingSignatureError,
+              type: "invalid_request_error",
+            },
+          }),
+        }),
+    },
+    {
       name: "cyclic cause graph",
       createError: () => {
         const root = new Error(genericizedProviderError) as Error & { cause?: unknown };

--- a/src/agents/embedded-agent-runner/thinking.ts
+++ b/src/agents/embedded-agent-runner/thinking.ts
@@ -545,6 +545,7 @@ function shouldRecoverAnthropicThinkingError(
     current.error,
     current.rawError,
     current.errorMessage,
+    current.errorBody,
     current.message,
   ]);
   for (const candidate of candidates) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Claude native-thinking sessions could stay stuck after Anthropic rejected a replayed thinking block signature. The recovery wrapper already knows how to retry without thinking blocks, but the production `ProviderHttpError` shape kept the provider detail in `errorBody`, which the detector did not inspect.

Fixes #98308

## Why This Change Was Made

The recovery detector now includes the existing `ProviderHttpError.errorBody` carrier in its error graph traversal. The result shape, retry count, and existing recovery behavior are unchanged.

## User Impact

Users on affected Claude native-thinking models can recover from this provider rejection path without destructive manual session compaction.

## Evidence

`node scripts/run-vitest.mjs src/agents/embedded-agent-runner/thinking.test.ts`

```text
Test Files  1 passed (1)
Tests       47 passed (47)
[test] passed 1 Vitest shard in 3.55s
```

`node scripts/run-vitest.mjs src/agents/embedded-agent-runner/thinking.test.ts src/agents/embedded-agent-runner/thinking-replay-repair.test.ts`

```text
Test Files  1 passed (1)
Tests       4 passed (4)
Test Files  1 passed (1)
Tests       47 passed (47)
[test] passed 2 Vitest shards in 6.16s
```

`pnpm exec oxfmt --check --threads=1 src/agents/embedded-agent-runner/thinking.ts src/agents/embedded-agent-runner/thinking.test.ts`

```text
Checking formatting...
All matched files use the correct format.
Finished in 6ms on 2 files using 1 threads.
```

`node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.scripts.json src/agents/embedded-agent-runner/thinking.ts src/agents/embedded-agent-runner/thinking.test.ts`

```text
oxlint_exit=0
```

`node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo`

```text
exit=0
```

`git diff --check`

```text
exit=0
```

Live proof: a local runtime script constructed a real `ProviderHttpError` with generic `.message` and matching Anthropic JSON in `.errorBody`, then passed it through `wrapAnthropicStreamWithRecovery`.

```text
[agent/embedded] [session-recovery] Anthropic thinking request rejected; retrying once without thinking blocks: sessionId=proof-session
{
  "errorName": "ProviderHttpError",
  "errorBodyCarriesDetail": true,
  "calls": 2,
  "resultContent": [
    {
      "type": "text",
      "text": "recovered"
    }
  ],
  "retryContent": [
    {
      "type": "text",
      "text": "visible answer"
    }
  ],
  "recovered": true,
  "recoveredCleanedContent": [
    {
      "type": "text",
      "text": "visible answer"
    }
  ]
}
```

No secrets or external services were used.

AI-assisted: built with Codex
