### PR TITLE
fix: stop reconnecting on protocol mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Docs: https://docs.openclaw.ai
 - **Plugin install diagnostics:** suppress the misleading hook-pack fallback after plugin install failures only when the hook manifest is absent, while preserving actionable malformed hook-pack errors. (#100554) Thanks @vincentkoc.
 - **Config validation diagnostics:** emit each unchanged sanitized validation-warning payload once per config path, reset deduplication after a clean validation, and preserve the warning fingerprint across transient invalid reads and failed refreshes. (#100569, #25574) Thanks @vincentkoc.
 - **Config size-drop guard:** compare writes against canonical bytes for parseable object configs instead of raw BOM and indentation overhead, while preserving raw audit telemetry and the conservative malformed-input fallback. (#100591, #71865) Thanks @vincentkoc.
+- **Control UI protocol mismatches:** stop automatic reconnect loops after incompatible Gateway and Control UI versions while preserving the actionable mismatch error. (#98414) Thanks @haruaiclone-droid.
 - **Control UI coalesced updates:** show a clear queued-restart completion banner when an update joins an already-running Gateway restart. (#93082) Thanks @goutamadwant.
 - **Control UI connection errors:** preserve structured pairing and authentication failures for pending RPC callers while keeping generic disconnect behavior unchanged. (#54758) Thanks @ruanrrn.
 - **TUI startup status:** show `starting up` during post-connect initialization without overwriting active-run or reconnect state. (#93999) Thanks @ml12580.

--- a/src/gateway/reconnect-gating.test.ts
+++ b/src/gateway/reconnect-gating.test.ts
@@ -14,9 +14,7 @@ describe("isNonRecoverableConnectError", () => {
   });
 
   it("returns false for errors without detail codes (network issues)", () => {
-    expect(isNonRecoverableConnectError({ code: "connect_failed", message: "timeout" })).toBe(
-      false,
-    );
+    expect(isNonRecoverableConnectError({})).toBe(false);
   });
 
   it("blocks reconnect for AUTH_TOKEN_MISSING (misconfigured client)", () => {

--- a/src/gateway/reconnect-gating.test.ts
+++ b/src/gateway/reconnect-gating.test.ts
@@ -68,8 +68,6 @@ describe("isNonRecoverableConnectError", () => {
   it("allows reconnect for PAIRING_REQUIRED when retry hints keep reconnect active", () => {
     expect(
       isNonRecoverableConnectError({
-        code: "connect_failed",
-        message: "auth failed",
         details: {
           code: ConnectErrorDetailCodes.PAIRING_REQUIRED,
           reason: "not-paired",

--- a/src/gateway/reconnect-gating.test.ts
+++ b/src/gateway/reconnect-gating.test.ts
@@ -1,73 +1,75 @@
 // Reconnect gating tests keep UI reconnect policy aligned with gateway protocol
-// auth error details that cannot recover by retrying.
+// failures that cannot recover by retrying.
 import { describe, expect, it } from "vitest";
 import { ConnectErrorDetailCodes } from "../../packages/gateway-protocol/src/connect-error-details.js";
-import { type GatewayErrorInfo, isNonRecoverableAuthError } from "../../ui/src/api/gateway.ts";
+import { type GatewayErrorInfo, isNonRecoverableConnectError } from "../../ui/src/api/gateway.ts";
 
 function makeError(detailCode: string): GatewayErrorInfo {
   return { code: "connect_failed", message: "auth failed", details: { code: detailCode } };
 }
 
-describe("isNonRecoverableAuthError", () => {
+describe("isNonRecoverableConnectError", () => {
   it("returns false for undefined error (normal disconnect)", () => {
-    expect(isNonRecoverableAuthError(undefined)).toBe(false);
+    expect(isNonRecoverableConnectError(undefined)).toBe(false);
   });
 
   it("returns false for errors without detail codes (network issues)", () => {
-    expect(isNonRecoverableAuthError({ code: "connect_failed", message: "timeout" })).toBe(false);
+    expect(isNonRecoverableConnectError({ code: "connect_failed", message: "timeout" })).toBe(
+      false,
+    );
   });
 
   it("blocks reconnect for AUTH_TOKEN_MISSING (misconfigured client)", () => {
-    expect(isNonRecoverableAuthError(makeError(ConnectErrorDetailCodes.AUTH_TOKEN_MISSING))).toBe(
-      true,
-    );
+    expect(
+      isNonRecoverableConnectError(makeError(ConnectErrorDetailCodes.AUTH_TOKEN_MISSING)),
+    ).toBe(true);
   });
 
   it("blocks reconnect for AUTH_BOOTSTRAP_TOKEN_INVALID", () => {
     expect(
-      isNonRecoverableAuthError(makeError(ConnectErrorDetailCodes.AUTH_BOOTSTRAP_TOKEN_INVALID)),
+      isNonRecoverableConnectError(makeError(ConnectErrorDetailCodes.AUTH_BOOTSTRAP_TOKEN_INVALID)),
     ).toBe(true);
   });
 
   it("blocks reconnect for AUTH_PASSWORD_MISSING", () => {
     expect(
-      isNonRecoverableAuthError(makeError(ConnectErrorDetailCodes.AUTH_PASSWORD_MISSING)),
+      isNonRecoverableConnectError(makeError(ConnectErrorDetailCodes.AUTH_PASSWORD_MISSING)),
     ).toBe(true);
   });
 
   it("blocks reconnect for AUTH_PASSWORD_MISMATCH (wrong password won't self-correct)", () => {
     expect(
-      isNonRecoverableAuthError(makeError(ConnectErrorDetailCodes.AUTH_PASSWORD_MISMATCH)),
+      isNonRecoverableConnectError(makeError(ConnectErrorDetailCodes.AUTH_PASSWORD_MISMATCH)),
     ).toBe(true);
   });
 
   it("blocks reconnect for AUTH_RATE_LIMITED (reconnecting burns more slots)", () => {
-    expect(isNonRecoverableAuthError(makeError(ConnectErrorDetailCodes.AUTH_RATE_LIMITED))).toBe(
+    expect(isNonRecoverableConnectError(makeError(ConnectErrorDetailCodes.AUTH_RATE_LIMITED))).toBe(
       true,
     );
   });
 
   it("blocks reconnect for AUTH_DEVICE_TOKEN_MISMATCH", () => {
     expect(
-      isNonRecoverableAuthError(makeError(ConnectErrorDetailCodes.AUTH_DEVICE_TOKEN_MISMATCH)),
+      isNonRecoverableConnectError(makeError(ConnectErrorDetailCodes.AUTH_DEVICE_TOKEN_MISMATCH)),
     ).toBe(true);
   });
 
   it("blocks reconnect for AUTH_SCOPE_MISMATCH", () => {
-    expect(isNonRecoverableAuthError(makeError(ConnectErrorDetailCodes.AUTH_SCOPE_MISMATCH))).toBe(
-      true,
-    );
+    expect(
+      isNonRecoverableConnectError(makeError(ConnectErrorDetailCodes.AUTH_SCOPE_MISMATCH)),
+    ).toBe(true);
   });
 
   it("blocks reconnect for PAIRING_REQUIRED", () => {
-    expect(isNonRecoverableAuthError(makeError(ConnectErrorDetailCodes.PAIRING_REQUIRED))).toBe(
+    expect(isNonRecoverableConnectError(makeError(ConnectErrorDetailCodes.PAIRING_REQUIRED))).toBe(
       true,
     );
   });
 
   it("allows reconnect for PAIRING_REQUIRED when retry hints keep reconnect active", () => {
     expect(
-      isNonRecoverableAuthError({
+      isNonRecoverableConnectError({
         code: "connect_failed",
         message: "auth failed",
         details: {
@@ -83,12 +85,18 @@ describe("isNonRecoverableAuthError", () => {
   it("allows reconnect for AUTH_TOKEN_MISMATCH (device-token fallback flow)", () => {
     // Browser client can queue a single trusted-device retry after shared token mismatch.
     // Blocking reconnect on mismatch here would skip that bounded recovery attempt.
-    expect(isNonRecoverableAuthError(makeError(ConnectErrorDetailCodes.AUTH_TOKEN_MISMATCH))).toBe(
-      false,
+    expect(
+      isNonRecoverableConnectError(makeError(ConnectErrorDetailCodes.AUTH_TOKEN_MISMATCH)),
+    ).toBe(false);
+  });
+
+  it("blocks reconnect for PROTOCOL_MISMATCH", () => {
+    expect(isNonRecoverableConnectError(makeError(ConnectErrorDetailCodes.PROTOCOL_MISMATCH))).toBe(
+      true,
     );
   });
 
   it("allows reconnect for unrecognized detail codes (future-proof)", () => {
-    expect(isNonRecoverableAuthError(makeError("SOME_FUTURE_CODE"))).toBe(false);
+    expect(isNonRecoverableConnectError(makeError("SOME_FUTURE_CODE"))).toBe(false);
   });
 });

--- a/ui/src/api/gateway.node.test.ts
+++ b/ui/src/api/gateway.node.test.ts
@@ -104,6 +104,7 @@ const {
   CONTROL_UI_OPERATOR_SCOPES,
   GatewayBrowserClient,
   GatewayRequestError,
+  isNonRecoverableConnectError,
   resolveGatewayErrorDetailCode,
   shouldRetryWithDeviceToken,
 } = await import("./gateway.ts");
@@ -391,6 +392,7 @@ describe("GatewayBrowserClient", () => {
 
     expect(error.message).toBe(`protocol mismatch: Control UI v${PROTOCOL_VERSION}`);
     expect(resolveGatewayErrorDetailCode(error)).toBe(ConnectErrorDetailCodes.PROTOCOL_MISMATCH);
+    expect(isNonRecoverableConnectError(error)).toBe(true);
   });
 
   it("reuses cached device token scopes when connecting from bootstrap handoff", async () => {

--- a/ui/src/api/gateway.node.test.ts
+++ b/ui/src/api/gateway.node.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ConnectErrorDetailCodes } from "../../../packages/gateway-protocol/src/connect-error-details.js";
 import {
   MIN_CLIENT_PROTOCOL_VERSION,
   PROTOCOL_VERSION,
@@ -103,6 +104,7 @@ const {
   CONTROL_UI_OPERATOR_SCOPES,
   GatewayBrowserClient,
   GatewayRequestError,
+  resolveGatewayErrorDetailCode,
   shouldRetryWithDeviceToken,
 } = await import("./gateway.ts");
 
@@ -388,6 +390,7 @@ describe("GatewayBrowserClient", () => {
     });
 
     expect(error.message).toBe(`protocol mismatch: Control UI v${PROTOCOL_VERSION}`);
+    expect(resolveGatewayErrorDetailCode(error)).toBe(ConnectErrorDetailCodes.PROTOCOL_MISMATCH);
   });
 
   it("reuses cached device token scopes when connecting from bootstrap handoff", async () => {
@@ -1256,6 +1259,35 @@ describe("GatewayBrowserClient", () => {
         code: "INVALID_REQUEST",
         message: "unauthorized",
         details: { code: "AUTH_TOKEN_MISSING" },
+      },
+    });
+    await expectSocketClosed(ws1);
+    ws1.emitClose(4008, "connect failed");
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(wsInstances).toHaveLength(1);
+
+    vi.useRealTimers();
+  });
+
+  it("does not auto-reconnect on PROTOCOL_MISMATCH", async () => {
+    useNodeFakeTimers();
+
+    const client = new GatewayBrowserClient({
+      url: "ws://127.0.0.1:18789",
+      token: "shared-auth-token",
+    });
+
+    const { ws: ws1, connectFrame: connect } = await startConnect(client);
+
+    ws1.emitMessage({
+      type: "res",
+      id: connect.id,
+      ok: false,
+      error: {
+        code: "INVALID_REQUEST",
+        message: "protocol mismatch",
+        details: { code: "PROTOCOL_MISMATCH" },
       },
     });
     await expectSocketClosed(ws1);

--- a/ui/src/api/gateway.ts
+++ b/ui/src/api/gateway.ts
@@ -67,15 +67,16 @@ export class GatewayRequestError extends Error {
   readonly retryAfterMs?: number;
 
   constructor(error: GatewayErrorInfo) {
+    const details = enrichProtocolMismatchDetails(error.message, error.details);
     super(
       formatConnectErrorMessage({
         message: error.message,
-        details: enrichProtocolMismatchDetails(error.message, error.details),
+        details,
       }),
     );
     this.name = "GatewayRequestError";
     this.gatewayCode = error.code;
-    this.details = error.details;
+    this.details = details;
     this.retryable = error.retryable === true;
     this.retryAfterMs = error.retryAfterMs;
   }
@@ -137,6 +138,7 @@ export function isNonRecoverableAuthError(error: GatewayErrorInfo | undefined): 
     code === ConnectErrorDetailCodes.AUTH_RATE_LIMITED ||
     code === ConnectErrorDetailCodes.AUTH_DEVICE_TOKEN_MISMATCH ||
     code === ConnectErrorDetailCodes.AUTH_SCOPE_MISMATCH ||
+    code === ConnectErrorDetailCodes.PROTOCOL_MISMATCH ||
     code === ConnectErrorDetailCodes.PAIRING_REQUIRED ||
     code === ConnectErrorDetailCodes.CONTROL_UI_DEVICE_IDENTITY_REQUIRED ||
     code === ConnectErrorDetailCodes.DEVICE_IDENTITY_REQUIRED

--- a/ui/src/api/gateway.ts
+++ b/ui/src/api/gateway.ts
@@ -112,14 +112,10 @@ function shouldContinueReconnectForPairingRequired(details: unknown): boolean {
 }
 
 /**
- * Auth errors that won't resolve without user action — don't auto-reconnect.
- *
- * NOTE: AUTH_TOKEN_MISMATCH is intentionally NOT included here because the
- * browser client supports a bounded one-time retry with a cached device token
- * when the endpoint is trusted. Reconnect suppression for mismatch is handled
- * with client state (after retry budget is exhausted).
+ * Connect failures that cannot recover while client and server state stay unchanged.
+ * AUTH_TOKEN_MISMATCH stays out: the close handler owns its bounded cached-token retry.
  */
-export function isNonRecoverableAuthError(error: GatewayErrorInfo | undefined): boolean {
+export function isNonRecoverableConnectError(error: { details?: unknown } | undefined): boolean {
   if (!error) {
     return false;
   }
@@ -599,7 +595,7 @@ export class GatewayBrowserClient {
         !this.closed &&
         (connectErrorCode === ConnectErrorDetailCodes.AUTH_TOKEN_MISMATCH
           ? this.pendingDeviceTokenRetry
-          : !isNonRecoverableAuthError(connectError));
+          : !isNonRecoverableConnectError(connectError));
       this.notifyClose({ code: ev.code, reason, error: connectError, willRetry });
       if (willRetry) {
         this.scheduleReconnect();

--- a/ui/src/e2e/login-gate.e2e.test.ts
+++ b/ui/src/e2e/login-gate.e2e.test.ts
@@ -100,7 +100,7 @@ describeControlUiE2e("Control UI responsive login gate E2E", () => {
         "supported connection protocol",
       );
       await page.waitForTimeout(1_600);
-      expect(await gateway.getSocketCount()).toBe(1);
+      expect(await gateway.getRequests("connect")).toHaveLength(1);
     } finally {
       await closeContext(context);
     }

--- a/ui/src/e2e/login-gate.e2e.test.ts
+++ b/ui/src/e2e/login-gate.e2e.test.ts
@@ -96,7 +96,9 @@ describeControlUiE2e("Control UI responsive login gate E2E", () => {
 
       const failure = page.locator(".login-gate__failure-summary");
       await failure.waitFor({ timeout: 10_000 });
-      expect((await failure.textContent())?.toLowerCase()).toContain("protocol mismatch");
+      expect((await failure.textContent())?.toLowerCase()).toContain(
+        "supported connection protocol",
+      );
       await page.waitForTimeout(1_600);
       expect(await gateway.getSocketCount()).toBe(1);
     } finally {

--- a/ui/src/e2e/login-gate.e2e.test.ts
+++ b/ui/src/e2e/login-gate.e2e.test.ts
@@ -1,8 +1,10 @@
 // Control UI tests cover the responsive disconnected login gate.
 import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { ConnectErrorDetailCodes } from "../../../packages/gateway-protocol/src/connect-error-details.js";
 import {
   canRunPlaywrightChromium,
+  installMockGateway,
   resolvePlaywrightChromiumExecutablePath,
   startControlUiE2eServer,
   type ControlUiE2eServer,
@@ -76,6 +78,30 @@ describeControlUiE2e("Control UI responsive login gate E2E", () => {
   afterAll(async () => {
     await browser?.close();
     await server?.close();
+  });
+
+  it("shows a protocol mismatch without reconnecting", async () => {
+    const context = await browser.newContext({ viewport: { height: 900, width: 1280 } });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, { deferredMethods: ["connect"] });
+
+    try {
+      await page.goto(server.baseUrl);
+      await gateway.waitForRequest("connect");
+      await gateway.rejectDeferred("connect", {
+        code: "INVALID_REQUEST",
+        message: "protocol mismatch",
+        details: { code: ConnectErrorDetailCodes.PROTOCOL_MISMATCH },
+      });
+
+      const failure = page.locator(".login-gate__failure-summary");
+      await failure.waitFor({ timeout: 10_000 });
+      expect((await failure.textContent())?.toLowerCase()).toContain("protocol mismatch");
+      await page.waitForTimeout(1_600);
+      expect(await gateway.getSocketCount()).toBe(1);
+    } finally {
+      await closeContext(context);
+    }
   });
 
   it("keeps mobile controls compact, touchable, and keyboard-friendly", async () => {


### PR DESCRIPTION
Closes #98413.

## What Problem This Solves

When the Control UI and Gateway disagree on the connection protocol, the Gateway returns `PROTOCOL_MISMATCH`. The browser surfaced the failure but treated it like a retryable disconnect, opening another WebSocket every retry interval and repeating a connection that cannot succeed.

## Why This Change Was Made

The fix keeps normalized protocol-mismatch details on `GatewayRequestError` and classifies that structured error as a non-recoverable connect failure. This extends the existing authentication/pairing reconnect gate instead of adding a second retry policy. Ordinary transient closes and explicitly retryable pairing flows keep their existing reconnect behavior.

## User Impact

Users now get the existing actionable protocol guidance once, without a reconnect loop. Updating the mismatched client or Gateway remains the supported recovery path.

## Evidence

- Added focused reconnect-gating coverage for protocol mismatch plus the existing authentication, pairing, and transient-close cases.
- Added Control UI Gateway unit coverage that preserves normalized mismatch details and suppresses reconnect.
- Added a real-Chromium Control UI E2E that injects `PROTOCOL_MISMATCH`, verifies the rendered guidance, waits beyond the retry window, and asserts that only one Gateway `connect` request was sent.
- Exact-head sanitized AWS Crabbox run `run_04a548fbf6ec` passed `pnpm tsgo:test:src`, all 42 reconnect-gating assertions, all 38 Gateway unit assertions, and all 4 `login-gate.e2e.test.ts` real-Chromium scenarios on `87f41b7c1a06fb8bf6cef8428a2baea8c82b0956`.
- The browser proof renders the protocol guidance, waits beyond the initial retry backoff, and confirms only one Gateway `connect` request; unrelated Vite HMR sockets are deliberately excluded from that assertion.
- Fresh autoreview found no accepted/actionable defects.
