### PR TITLE
improve(ios): clarify Control and Talk visual hierarchy

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -90,8 +90,13 @@ data class GatewayConnectionProblem(
   val recommendedNextStep: String?,
   val pauseReconnect: Boolean,
   val retryable: Boolean,
+  val clientMinProtocol: Int? = null,
+  val clientMaxProtocol: Int? = null,
+  val expectedProtocol: Int? = null,
+  val minimumProbeProtocol: Int? = null,
 ) {
   val isPairingRequired: Boolean = code == "PAIRING_REQUIRED"
+  val isProtocolMismatch: Boolean = code == "PROTOCOL_MISMATCH"
   val canAutoRetry: Boolean =
     isPairingRequired &&
       (
@@ -765,6 +770,10 @@ class NodeRuntime(
         recommendedNextStep = details?.recommendedNextStep,
         pauseReconnect = pauseReconnect || details?.pauseReconnect == true,
         retryable = details?.retryable == true,
+        clientMinProtocol = details?.clientMinProtocol,
+        clientMaxProtocol = details?.clientMaxProtocol,
+        expectedProtocol = details?.expectedProtocol,
+        minimumProbeProtocol = details?.minimumProbeProtocol,
       )
   }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
@@ -69,7 +69,7 @@ private enum class GatewayConnectAuthSource {
 }
 
 /**
- * Structured auth failure guidance from the gateway, preserved for reconnect and UI decisions.
+ * Structured connect failure guidance from the gateway, preserved for reconnect and UI decisions.
  */
 data class GatewayConnectErrorDetails(
   val code: String?,
@@ -79,6 +79,10 @@ data class GatewayConnectErrorDetails(
   val reason: String? = null,
   val requestId: String? = null,
   val retryable: Boolean = false,
+  val clientMinProtocol: Int? = null,
+  val clientMaxProtocol: Int? = null,
+  val expectedProtocol: Int? = null,
+  val minimumProbeProtocol: Int? = null,
 )
 
 /**
@@ -889,6 +893,10 @@ class GatewaySession(
                 reason = it["reason"].asStringOrNull(),
                 requestId = normalizePairingRequestId(it["requestId"].asStringOrNull()),
                 retryable = it["retryable"].asBooleanOrNull() == true,
+                clientMinProtocol = it["clientMinProtocol"].asIntOrNull(),
+                clientMaxProtocol = it["clientMaxProtocol"].asIntOrNull(),
+                expectedProtocol = it["expectedProtocol"].asIntOrNull(),
+                minimumProbeProtocol = it["minimumProbeProtocol"].asIntOrNull(),
               )
             }
           ErrorShape(code, msg, details)
@@ -1262,6 +1270,7 @@ internal fun shouldPauseGatewayReconnectAfterAuthFailure(
           )
       )
     "AUTH_TOKEN_MISMATCH" -> deviceTokenRetryBudgetUsed && !pendingDeviceTokenRetry
+    "PROTOCOL_MISMATCH" -> true
     else -> false
   }
 
@@ -1313,6 +1322,12 @@ private fun JsonElement?.asBooleanOrNull(): Boolean? =
 private fun JsonElement?.asLongOrNull(): Long? =
   when (this) {
     is JsonPrimitive -> content.toLongOrNull()
+    else -> null
+  }
+
+private fun JsonElement?.asIntOrNull(): Int? =
+  when (this) {
+    is JsonPrimitive -> content.toIntOrNull()
     else -> null
   }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
@@ -1216,31 +1216,32 @@ internal fun recoveryGatewayDetail(
   if (ready) {
     remoteAddress?.takeIf { it.isNotBlank() } ?: "Ready for chat and voice"
   } else if (
-      nodeCapabilityApprovalState == GatewayNodeApprovalState.PendingApproval ||
-      nodeCapabilityApprovalState == GatewayNodeApprovalState.PendingReapproval ||
-      nodeCapabilityApprovalState == GatewayNodeApprovalState.Unapproved
-    ) {
-      "Gateway paired. Waiting for node capability approval."
-    } else if (gatewayConnectionProblem?.isPairingRequired == true && !gatewayConnectionProblem.canAutoRetry) {
-      recoveryGatewayApprovalCommand(gatewayConnectionProblem)
-        ?.let { "Gateway approval is pending. Run this on the gateway host:" }
-        ?: "Gateway approval is pending. Run openclaw devices list on the gateway host, approve this phone, then retry."
-    } else if (gatewayConnectionProblem?.isPairingRequired == true && gatewayConnectionProblem.canAutoRetry) {
-      "Gateway approval is in progress. OpenClaw will retry automatically."
-    } else if (gatewayConnectionProblem != null) {
-      recoveryGatewayAuthDetail(gatewayConnectionProblem)
-    } else if (nodeCapabilityApprovalState == GatewayNodeApprovalState.Loading) {
-      "Gateway paired. Checking node capability approval."
-    } else if (statusText.contains("operator offline", ignoreCase = true)) {
-      "Gateway paired. Waiting for operator access."
-    } else if (gatewayStatusLooksLikePairing(statusText)) {
-      "Gateway approval is in progress. OpenClaw will retry automatically."
-    } else {
-      remoteAddress?.takeIf { it.isNotBlank() } ?: "Gateway unreachable"
-    }
+    nodeCapabilityApprovalState == GatewayNodeApprovalState.PendingApproval ||
+    nodeCapabilityApprovalState == GatewayNodeApprovalState.PendingReapproval ||
+    nodeCapabilityApprovalState == GatewayNodeApprovalState.Unapproved
+  ) {
+    "Gateway paired. Waiting for node capability approval."
+  } else if (gatewayConnectionProblem?.isPairingRequired == true && !gatewayConnectionProblem.canAutoRetry) {
+    recoveryGatewayApprovalCommand(gatewayConnectionProblem)
+      ?.let { "Gateway approval is pending. Run this on the gateway host:" }
+      ?: "Gateway approval is pending. Run openclaw devices list on the gateway host, approve this phone, then retry."
+  } else if (gatewayConnectionProblem?.isPairingRequired == true && gatewayConnectionProblem.canAutoRetry) {
+    "Gateway approval is in progress. OpenClaw will retry automatically."
+  } else if (gatewayConnectionProblem != null) {
+    recoveryGatewayAuthDetail(gatewayConnectionProblem)
+  } else if (nodeCapabilityApprovalState == GatewayNodeApprovalState.Loading) {
+    "Gateway paired. Checking node capability approval."
+  } else if (statusText.contains("operator offline", ignoreCase = true)) {
+    "Gateway paired. Waiting for operator access."
+  } else if (gatewayStatusLooksLikePairing(statusText)) {
+    "Gateway approval is in progress. OpenClaw will retry automatically."
+  } else {
+    remoteAddress?.takeIf { it.isNotBlank() } ?: "Gateway unreachable"
+  }
 
 internal fun recoveryGatewayAuthDetail(gatewayConnectionProblem: GatewayConnectionProblem): String =
   when (gatewayConnectionProblem.code) {
+    "PROTOCOL_MISMATCH" -> recoveryGatewayProtocolMismatchDetail(gatewayConnectionProblem)
     "AUTH_BOOTSTRAP_TOKEN_INVALID" -> "Setup code expired. Scan a fresh setup QR."
     "AUTH_DEVICE_TOKEN_MISMATCH",
     "AUTH_TOKEN_MISMATCH",
@@ -1259,6 +1260,40 @@ internal fun recoveryGatewayAuthDetail(gatewayConnectionProblem: GatewayConnecti
         else -> gatewayConnectionProblem.message.takeIf { it.isNotBlank() } ?: "Gateway authentication needs attention."
       }
   }
+
+private fun recoveryGatewayProtocolMismatchDetail(gatewayConnectionProblem: GatewayConnectionProblem): String {
+  val clientMin = gatewayConnectionProblem.clientMinProtocol
+  val clientMax = gatewayConnectionProblem.clientMaxProtocol
+  val expected = gatewayConnectionProblem.expectedProtocol
+  val summary =
+    when {
+      clientMax != null && expected != null && clientMax < expected ->
+        "This app is older than the gateway. Update OpenClaw on this device, then retry."
+      clientMin != null && expected != null && clientMin > expected ->
+        "The gateway is older than this app. Update OpenClaw on the gateway host, then retry."
+      else -> "The app and gateway use incompatible protocol versions. Update OpenClaw on both, then retry."
+    }
+  return protocolMismatchVersions(clientMin, clientMax, expected)?.let { "$summary $it" } ?: summary
+}
+
+private fun protocolMismatchVersions(
+  clientMin: Int?,
+  clientMax: Int?,
+  expected: Int?,
+): String? {
+  val clientRange =
+    when {
+      clientMin == null && clientMax == null -> null
+      clientMin != null && clientMin == clientMax -> "app protocol v$clientMin"
+      clientMin != null && clientMax != null -> "app protocols v$clientMin-v$clientMax"
+      clientMin != null -> "app protocol min v$clientMin"
+      else -> "app protocol max v$clientMax"
+    }
+  val gatewayVersion = expected?.let { "gateway protocol v$it" }
+  return listOfNotNull(clientRange, gatewayVersion)
+    .takeIf { it.isNotEmpty() }
+    ?.joinToString(prefix = "(", postfix = ").")
+}
 
 private fun recoveryGatewayApprovalCommand(gatewayConnectionProblem: GatewayConnectionProblem?): String? {
   if (gatewayConnectionProblem?.isPairingRequired != true || gatewayConnectionProblem.canAutoRetry) return null

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionReconnectTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionReconnectTest.kt
@@ -208,6 +208,36 @@ class GatewaySessionReconnectTest {
   }
 
   @Test
+  fun protocolMismatchPausesReconnect() {
+    val error =
+      GatewaySession.ErrorShape(
+        code = "INVALID_REQUEST",
+        message = "protocol mismatch",
+        details =
+          GatewayConnectErrorDetails(
+            code = "PROTOCOL_MISMATCH",
+            canRetryWithDeviceToken = false,
+            recommendedNextStep = null,
+            clientMinProtocol = 4,
+            clientMaxProtocol = 4,
+            expectedProtocol = 5,
+            minimumProbeProtocol = 4,
+          ),
+      )
+
+    assertTrue(
+      shouldPauseGatewayReconnectAfterAuthFailure(
+        error = error,
+        hasBootstrapToken = false,
+        role = "node",
+        scopes = emptyList(),
+        deviceTokenRetryBudgetUsed = false,
+        pendingDeviceTokenRetry = false,
+      ),
+    )
+  }
+
+  @Test
   fun bootstrapRoleUpgradeStillPausesReconnect() {
     val error =
       GatewaySession.ErrorShape(
@@ -294,6 +324,41 @@ class GatewaySessionReconnectTest {
         assertEquals("PAIRING_REQUIRED", error.details?.code)
         assertEquals("not-paired", error.details?.reason)
         assertNull(error.details?.requestId)
+        assertTrue(pauseReconnect)
+      } finally {
+        shutdownReconnectHarness(harness, server)
+      }
+    }
+
+  @Test
+  fun protocolMismatchFailurePreservesProtocolDetailsAndPausesReconnect() =
+    runBlocking {
+      val json = Json { ignoreUnknownKeys = true }
+      val connectFailure = CompletableDeferred<Pair<GatewaySession.ErrorShape, Boolean>>()
+      val server =
+        startGatewayServer(json = json) { webSocket, id, method ->
+          if (method == "connect") {
+            webSocket.send(
+              """
+              {"type":"res","id":"$id","ok":false,"error":{"code":"INVALID_REQUEST","message":"protocol mismatch","details":{"code":"PROTOCOL_MISMATCH","clientMinProtocol":4,"clientMaxProtocol":4,"expectedProtocol":5,"minimumProbeProtocol":4}}}
+              """.trimIndent(),
+            )
+          }
+        }
+      val harness =
+        createReconnectHarness { error, pauseReconnect ->
+          connectFailure.complete(error to pauseReconnect)
+        }
+
+      try {
+        connectNodeSession(harness.session, server.port)
+        val (error, pauseReconnect) = withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { connectFailure.await() }
+
+        assertEquals("PROTOCOL_MISMATCH", error.details?.code)
+        assertEquals(4, error.details?.clientMinProtocol)
+        assertEquals(4, error.details?.clientMaxProtocol)
+        assertEquals(5, error.details?.expectedProtocol)
+        assertEquals(4, error.details?.minimumProbeProtocol)
         assertTrue(pauseReconnect)
       } finally {
         shutdownReconnectHarness(harness, server)

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/OnboardingFlowLogicTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/OnboardingFlowLogicTest.kt
@@ -301,6 +301,68 @@ class OnboardingFlowLogicTest {
   }
 
   @Test
+  fun recoveryGatewayAuthDetailIdentifiesOlderAppProtocolMismatch() {
+    assertEquals(
+      "This app is older than the gateway. Update OpenClaw on this device, then retry. (app protocol v4, gateway protocol v5).",
+      recoveryGatewayAuthDetail(
+        GatewayConnectionProblem(
+          code = "PROTOCOL_MISMATCH",
+          message = "protocol mismatch",
+          reason = null,
+          requestId = null,
+          recommendedNextStep = null,
+          pauseReconnect = true,
+          retryable = false,
+          clientMinProtocol = 4,
+          clientMaxProtocol = 4,
+          expectedProtocol = 5,
+          minimumProbeProtocol = 4,
+        ),
+      ),
+    )
+  }
+
+  @Test
+  fun recoveryGatewayAuthDetailIdentifiesOlderGatewayProtocolMismatch() {
+    assertEquals(
+      "The gateway is older than this app. Update OpenClaw on the gateway host, then retry. (app protocol v4, gateway protocol v3).",
+      recoveryGatewayAuthDetail(
+        GatewayConnectionProblem(
+          code = "PROTOCOL_MISMATCH",
+          message = "protocol mismatch",
+          reason = null,
+          requestId = null,
+          recommendedNextStep = null,
+          pauseReconnect = true,
+          retryable = false,
+          clientMinProtocol = 4,
+          clientMaxProtocol = 4,
+          expectedProtocol = 3,
+          minimumProbeProtocol = 3,
+        ),
+      ),
+    )
+  }
+
+  @Test
+  fun recoveryGatewayAuthDetailKeepsProtocolMismatchFallbackActionable() {
+    assertEquals(
+      "The app and gateway use incompatible protocol versions. Update OpenClaw on both, then retry.",
+      recoveryGatewayAuthDetail(
+        GatewayConnectionProblem(
+          code = "PROTOCOL_MISMATCH",
+          message = "protocol mismatch",
+          reason = null,
+          requestId = null,
+          recommendedNextStep = null,
+          pauseReconnect = true,
+          retryable = false,
+        ),
+      ),
+    )
+  }
+
+  @Test
   fun recoveryGatewayAuthDetailUsesRecommendedNextStepFallbacks() {
     assertEquals(
       "Gateway authentication is not configured. Edit this connection and try again.",

--- a/apps/ios/Sources/Design/OpenClawProComponents.swift
+++ b/apps/ios/Sources/Design/OpenClawProComponents.swift
@@ -32,18 +32,18 @@ struct ProSectionHeader: View {
     var body: some View {
         HStack {
             Text(self.title)
-                .font(.caption.weight(.medium))
+                .font(.footnote.weight(.medium))
                 .foregroundStyle(.secondary)
                 .textCase(self.uppercase ? .uppercase : nil)
             Spacer()
             if let actionTitle {
                 if let action {
                     Button(actionTitle, action: action)
-                        .font(.caption.weight(.medium))
+                        .font(.footnote.weight(.medium))
                         .foregroundStyle(OpenClawBrand.accent)
                 } else {
                     Text(actionTitle)
-                        .font(.caption.weight(.medium))
+                        .font(.footnote.weight(.medium))
                         .foregroundStyle(.secondary)
                 }
             }
@@ -377,7 +377,7 @@ struct ProValuePill: View {
 
     var body: some View {
         Text(self.value)
-            .font(.caption.weight(.semibold))
+            .font(.footnote.weight(.semibold))
             .foregroundStyle(self.color)
             .lineLimit(1)
             .padding(.horizontal, 8)

--- a/apps/ios/Sources/Design/RootTabsPhoneControlHub.swift
+++ b/apps/ios/Sources/Design/RootTabsPhoneControlHub.swift
@@ -21,7 +21,6 @@ struct RootTabsPhoneControlHub: View {
                         ForEach(self.groups) { group in
                             self.groupSection(group)
                         }
-                        self.versionFooter
                     }
                     .padding(.vertical, self.isCompactHeight ? 10 : 16)
                 }
@@ -51,7 +50,7 @@ struct RootTabsPhoneControlHub: View {
                             .font(.subheadline.weight(.semibold))
                             .lineLimit(1)
                         Text(self.gatewayDisplayLabel)
-                            .font(.caption)
+                            .font(.footnote)
                             .foregroundStyle(.secondary)
                             .lineLimit(1)
                             .truncationMode(.middle)
@@ -71,7 +70,7 @@ struct RootTabsPhoneControlHub: View {
                                 .font(.headline)
                                 .lineLimit(1)
                             Text(self.gatewayDisplayLabel)
-                                .font(.caption)
+                                .font(.footnote)
                                 .foregroundStyle(.secondary)
                                 .lineLimit(1)
                                 .truncationMode(.middle)
@@ -98,14 +97,14 @@ struct RootTabsPhoneControlHub: View {
                         .font(.subheadline.weight(.semibold))
                         .foregroundStyle(.primary)
                     Text(self.gatewayDisplayLabel)
-                        .font(.caption)
+                        .font(.footnote)
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
                         .truncationMode(.middle)
                 }
                 Spacer(minLength: 8)
                 Text(self.gatewayActionTitle)
-                    .font(.caption.weight(.semibold))
+                    .font(.footnote.weight(.semibold))
                     .foregroundStyle(OpenClawBrand.accent)
                 Image(systemName: "chevron.right")
                     .font(.caption2.weight(.bold))
@@ -157,13 +156,13 @@ struct RootTabsPhoneControlHub: View {
 
     private func rowLabel(_ destination: RootTabs.SidebarDestination) -> some View {
         HStack(alignment: .center, spacing: 12) {
-            ProIconBadge(systemName: destination.systemImage, color: self.color(for: destination))
+            ProIconBadge(systemName: destination.systemImage, color: .secondary)
             VStack(alignment: .leading, spacing: 3) {
                 Text(destination.title)
                     .font(.subheadline.weight(.semibold))
                     .foregroundStyle(.primary)
                 Text(destination.subtitle)
-                    .font(.caption)
+                    .font(.footnote)
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
             }
@@ -175,20 +174,6 @@ struct RootTabsPhoneControlHub: View {
         .padding(.vertical, self.isCompactHeight ? 8 : 10)
         .padding(.horizontal, 14)
         .contentShape(Rectangle())
-    }
-
-    private var versionFooter: some View {
-        ProCard(radius: OpenClawProMetric.cardRadius) {
-            HStack {
-                Spacer()
-                Text("v\(DeviceInfoHelper.openClawVersionString())")
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-                Spacer()
-            }
-        }
-        .padding(.horizontal, OpenClawProMetric.pagePadding)
     }
 
     @ViewBuilder
@@ -348,19 +333,6 @@ struct RootTabsPhoneControlHub: View {
 
     static func bottomScrollInset(verticalSizeClass: UserInterfaceSizeClass?) -> CGFloat {
         verticalSizeClass == .compact ? 72 : 112
-    }
-
-    private func color(for destination: RootTabs.SidebarDestination) -> Color {
-        switch destination {
-        case .chat, .talk, .overview, .gateway:
-            OpenClawBrand.accent
-        case .instances:
-            Color.secondary
-        case .activity, .usage, .docs:
-            OpenClawBrand.accentHot
-        case .agents, .workboard, .skillWorkshop, .sessions, .dreaming, .cron, .settings:
-            OpenClawBrand.ok
-        }
     }
 
     private func resolveDefaultAgentID() -> String {

--- a/apps/ios/Sources/Design/SettingsProTab.swift
+++ b/apps/ios/Sources/Design/SettingsProTab.swift
@@ -222,6 +222,11 @@ struct SettingsProTab: View {
                         }
                 }
             }
+            .sheet(isPresented: self.$showNotificationRelayDisclosure) {
+                HostedPushRelayDisclosureSheet(
+                    message: self.notificationRelayDisclosureMessage,
+                    onContinue: self.requestNotificationAuthorizationFromSettings)
+            }
             .alert("Reset Onboarding?", isPresented: self.$showResetOnboardingAlert) {
                 Button("Reset", role: .destructive) {
                     self.resetOnboarding()
@@ -240,14 +245,6 @@ struct SettingsProTab: View {
             } message: {
                 Text(self.scannerError ?? "")
             }
-            .alert("Enable OpenClaw Hosted Push Relay?", isPresented: self.$showNotificationRelayDisclosure) {
-                    Button("Continue") {
-                        self.requestNotificationAuthorizationFromSettings()
-                    }
-                    Button("Not Now", role: .cancel) {}
-                } message: {
-                    Text(self.notificationRelayDisclosureMessage)
-                }
     }
 
     func openNotificationsRouteFromApprovals() {
@@ -272,5 +269,47 @@ struct SettingsProTab: View {
             return
         }
         self.onRouteChange?(self.navigationPath.last)
+    }
+}
+
+struct HostedPushRelayDisclosureSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    let message: String
+    let onContinue: () -> Void
+
+    var body: some View {
+        VStack(spacing: 18) {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 18) {
+                    Image(systemName: "network")
+                        .font(.title2.weight(.semibold))
+                        .foregroundStyle(Color(uiColor: .systemBlue))
+                    Text("Enable OpenClaw Hosted Push Relay?")
+                        .font(.title3.weight(.semibold))
+                    Text(self.message)
+                        .font(.body)
+                        .foregroundStyle(.secondary)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            VStack(spacing: 10) {
+                Button {
+                    self.dismiss()
+                    self.onContinue()
+                } label: {
+                    Text("Continue").frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                Button("Not Now", role: .cancel) {
+                    self.dismiss()
+                }
+                .buttonStyle(.bordered)
+                .frame(maxWidth: .infinity)
+            }
+        }
+        .tint(Color(uiColor: .systemBlue))
+        .padding(24)
+        .presentationDetents([.medium, .large])
+        .presentationDragIndicator(.visible)
     }
 }

--- a/apps/ios/Sources/Design/SettingsProTabActions.swift
+++ b/apps/ios/Sources/Design/SettingsProTabActions.swift
@@ -360,9 +360,11 @@ extension SettingsProTab {
         }
     }
 
-    func gatewayProblemPrimaryActionTitle(_ problem: GatewayConnectionProblem) -> String {
-        if problem.suggestsOnboardingReset { return "Reset onboarding" }
-        return problem.canTrustRotatedCertificate ? "Trust certificate" : "Retry connection"
+    func gatewayProblemPrimaryActionTitle(_ problem: GatewayConnectionProblem) -> String? {
+        GatewayProblemPrimaryAction.title(
+            for: problem,
+            retryTitle: "Retry connection",
+            resetTitle: "Reset onboarding")
     }
 
     func handleGatewayProblemPrimaryAction(_ problem: GatewayConnectionProblem) async {
@@ -374,6 +376,10 @@ extension SettingsProTab {
             _ = await self.gatewayController.trustRotatedGatewayCertificate(from: problem)
             return
         }
+        if GatewayProblemPrimaryAction.openProtocolMismatchHelpIfNeeded(problem) {
+            return
+        }
+        guard problem.retryable else { return }
         await self.retryGatewayConnectionFromProblem()
     }
 

--- a/apps/ios/Sources/Design/SettingsProTabSections.swift
+++ b/apps/ios/Sources/Design/SettingsProTabSections.swift
@@ -190,7 +190,7 @@ extension SettingsProTab {
                     Text(title)
                         .font(.subheadline.weight(.semibold))
                     Text(detail)
-                        .font(.caption2)
+                        .font(.footnote)
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
                 }

--- a/apps/ios/Sources/Design/TalkProTab.swift
+++ b/apps/ios/Sources/Design/TalkProTab.swift
@@ -175,7 +175,7 @@ struct TalkProTab: View {
                         .background {
                             RoundedRectangle(cornerRadius: 14, style: .continuous)
                                 .fill(self.state.primaryButtonFill)
-                                .shadow(color: self.state.color.opacity(0.28), radius: 18, y: 8)
+                                .shadow(color: self.state.primaryButtonFill.opacity(0.22), radius: 18, y: 8)
                         }
                 }
                 .buttonStyle(.plain)
@@ -607,17 +607,14 @@ struct TalkProState: Equatable {
         }
     }
 
-    var primaryButtonFill: AnyShapeStyle {
+    var primaryButtonFill: Color {
         switch self.primaryAction {
         case .stop:
-            AnyShapeStyle(OpenClawBrand.danger)
+            OpenClawBrand.danger
         case .waiting:
-            AnyShapeStyle(OpenClawBrand.warn.opacity(0.72))
+            OpenClawBrand.warn.opacity(0.72)
         default:
-            AnyShapeStyle(LinearGradient(
-                colors: [self.color.opacity(0.95), OpenClawBrand.accent],
-                startPoint: .topLeading,
-                endPoint: .bottomTrailing))
+            Color(uiColor: .systemBlue)
         }
     }
 
@@ -662,7 +659,7 @@ private struct TalkProOrb: View {
     var body: some View {
         TimelineView(.periodic(from: .now, by: 1.0 / 24.0)) { timeline in
             ZStack {
-                ForEach(0..<3, id: \.self) { ring in
+                ForEach(0..<self.ringCount, id: \.self) { ring in
                     Circle()
                         .strokeBorder(self.color.opacity(self.ringOpacity(ring)), lineWidth: 1.4)
                         .scaleEffect(self.ringScale(ring, date: timeline.date))
@@ -676,14 +673,23 @@ private struct TalkProOrb: View {
                     }
                 TalkProWaveform(mode: self.mode, tint: self.color, barCount: 18)
                     .frame(width: 116, height: 52)
-                    .opacity(self.systemImage == "waveform" || self.systemImage == "mic.fill" ? 1 : 0.34)
+                    .opacity(self.showsWaveform ? 1 : 0)
                 Image(systemName: self.systemImage)
                     .font(.system(size: 34, weight: .bold))
                     .foregroundStyle(self.color)
-                    .opacity(self.systemImage == "waveform" || self.systemImage == "mic.fill" ? 0.20 : 1)
+                    .opacity(self.showsWaveform ? 0.20 : 1)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .clipped()
         }
+    }
+
+    private var ringCount: Int {
+        self.mode == .still ? 0 : 3
+    }
+
+    private var showsWaveform: Bool {
+        self.systemImage == "waveform" || self.systemImage == "mic.fill"
     }
 
     private func ringScale(_ ring: Int, date: Date) -> CGFloat {

--- a/apps/ios/Sources/Gateway/GatewayProblemPrimaryAction.swift
+++ b/apps/ios/Sources/Gateway/GatewayProblemPrimaryAction.swift
@@ -1,0 +1,34 @@
+import OpenClawKit
+import UIKit
+
+enum GatewayProblemPrimaryAction {
+    static func title(
+        for problem: GatewayConnectionProblem,
+        retryTitle: String,
+        resetTitle: String? = nil,
+        nonRetryableTitle: String? = nil) -> String?
+    {
+        if problem.suggestsOnboardingReset, let resetTitle {
+            return resetTitle
+        }
+        if problem.canTrustRotatedCertificate {
+            return "Trust certificate"
+        }
+        if problem.kind == .protocolMismatch {
+            return problem.actionLabel
+        }
+        if problem.retryable {
+            return problem.actionLabel ?? retryTitle
+        }
+        return nonRetryableTitle
+    }
+
+    @MainActor
+    static func openProtocolMismatchHelpIfNeeded(_ problem: GatewayConnectionProblem) -> Bool {
+        guard problem.kind == .protocolMismatch else { return false }
+        if let url = problem.docsURL {
+            UIApplication.shared.open(url)
+        }
+        return true
+    }
+}

--- a/apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift
+++ b/apps/ios/Sources/Gateway/GatewayQuickSetupSheet.swift
@@ -138,8 +138,8 @@ struct GatewayQuickSetupSheet: View {
             }
     }
 
-    private func gatewayProblemPrimaryActionTitle(_ problem: GatewayConnectionProblem) -> String {
-        problem.canTrustRotatedCertificate ? "Trust certificate" : "Connect"
+    private func gatewayProblemPrimaryActionTitle(_ problem: GatewayConnectionProblem) -> String? {
+        GatewayProblemPrimaryAction.title(for: problem, retryTitle: "Connect")
     }
 
     private func handleGatewayProblemPrimaryAction(_ problem: GatewayConnectionProblem) async {
@@ -147,6 +147,10 @@ struct GatewayQuickSetupSheet: View {
             _ = await self.gatewayController.trustRotatedGatewayCertificate(from: problem)
             return
         }
+        if GatewayProblemPrimaryAction.openProtocolMismatchHelpIfNeeded(problem) {
+            return
+        }
+        guard problem.retryable else { return }
         guard let candidate = self.bestCandidate else { return }
         self.connectError = nil
         self.connecting = true

--- a/apps/ios/Sources/Onboarding/OnboardingWizardView.swift
+++ b/apps/ios/Sources/Onboarding/OnboardingWizardView.swift
@@ -1037,9 +1037,11 @@ extension OnboardingWizardView {
         await self.gatewayController.connectLastKnown()
     }
 
-    private func gatewayProblemPrimaryActionTitle(_ problem: GatewayConnectionProblem) -> String {
-        if problem.suggestsOnboardingReset { return "Scan QR again" }
-        return problem.canTrustRotatedCertificate ? "Trust certificate" : "Retry connection"
+    private func gatewayProblemPrimaryActionTitle(_ problem: GatewayConnectionProblem) -> String? {
+        GatewayProblemPrimaryAction.title(
+            for: problem,
+            retryTitle: "Retry connection",
+            resetTitle: "Scan QR again")
     }
 
     private func handleGatewayProblemPrimaryAction(_ problem: GatewayConnectionProblem) async {
@@ -1064,6 +1066,10 @@ extension OnboardingWizardView {
             _ = await self.gatewayController.trustRotatedGatewayCertificate(from: problem)
             return
         }
+        if GatewayProblemPrimaryAction.openProtocolMismatchHelpIfNeeded(problem) {
+            return
+        }
+        guard problem.retryable else { return }
         await self.retryLastAttempt()
     }
 }

--- a/apps/ios/Sources/OpenClawApp.swift
+++ b/apps/ios/Sources/OpenClawApp.swift
@@ -630,6 +630,10 @@ struct OpenClawApp: App {
         GatewaySettingsStore.bootstrapPersistence()
         let appModel = NodeAppModel()
         #if DEBUG
+        if ProcessInfo.processInfo.arguments.contains("--openclaw-reset-onboarding") {
+            // Reruns must exercise onboarding instead of saved pairing state.
+            GatewayOnboardingReset.reset(appModel: appModel, instanceId: GatewaySettingsStore.currentInstanceID())
+        }
         if Self.screenshotModeEnabled {
             UIView.setAnimationsEnabled(false)
             UserDefaults.standard.set(true, forKey: "gateway.onboardingComplete")

--- a/apps/ios/Sources/RootTabs.swift
+++ b/apps/ios/Sources/RootTabs.swift
@@ -269,7 +269,6 @@ struct RootTabs: View {
         VStack(spacing: 0) {
             self.sidebarIdentityHeader
             self.sidebarList
-            self.sidebarFooter
         }
         .safeAreaPadding(.top, 8)
         .safeAreaPadding(.bottom, 8)
@@ -342,26 +341,6 @@ struct RootTabs: View {
         .tint(OpenClawBrand.accent)
         .scrollContentBackground(.hidden)
         .background(Color(uiColor: .systemBackground))
-    }
-
-    private var sidebarFooter: some View {
-        VStack(spacing: 0) {
-            self.sidebarHorizontalSeparator
-            HStack(spacing: 10) {
-                Text("VERSION")
-                    .font(.caption2.weight(.semibold))
-                    .foregroundStyle(.secondary)
-                Spacer(minLength: 8)
-                Text("v\(DeviceInfoHelper.openClawVersionString())")
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(.primary)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.72)
-                ProStatusDot(color: self.sidebarGatewayStatusColor)
-            }
-            .padding(.horizontal, 18)
-            .padding(.vertical, 12)
-        }
     }
 
     private var sidebarHorizontalSeparator: some View {

--- a/apps/ios/Sources/RootTabs.swift
+++ b/apps/ios/Sources/RootTabs.swift
@@ -1042,14 +1042,18 @@ extension RootTabs {
         return trimmed.isEmpty ? nil : trimmed
     }
 
-    private func gatewayProblemPrimaryActionTitle(_ problem: GatewayConnectionProblem) -> String {
-        if problem.canTrustRotatedCertificate { return "Trust certificate" }
-        return problem.retryable ? "Retry" : "Open Settings"
+    private func gatewayProblemPrimaryActionTitle(_ problem: GatewayConnectionProblem) -> String? {
+        GatewayProblemPrimaryAction.title(
+            for: problem,
+            retryTitle: "Retry",
+            nonRetryableTitle: "Open Settings")
     }
 
     private func handleGatewayProblemPrimaryAction(_ problem: GatewayConnectionProblem) {
         if problem.canTrustRotatedCertificate {
             Task { await self.gatewayController.trustRotatedGatewayCertificate(from: problem) }
+        } else if GatewayProblemPrimaryAction.openProtocolMismatchHelpIfNeeded(problem) {
+            return
         } else if problem.retryable {
             Task { await self.gatewayController.connectLastKnown() }
         } else {

--- a/apps/ios/Sources/Voice/TalkGatewaySpeechClient.swift
+++ b/apps/ios/Sources/Voice/TalkGatewaySpeechClient.swift
@@ -1,0 +1,279 @@
+import AVFoundation
+import Foundation
+import OpenClawKit
+import OpenClawProtocol
+import OSLog
+
+struct TalkGatewaySpeechAudio: Equatable {
+    enum PlaybackMode: Equatable {
+        case pcm(sampleRate: Double)
+        case buffered
+        case unsupportedRaw(codec: String)
+    }
+
+    let data: Data
+    let provider: String
+    let outputFormat: String?
+
+    var playbackMode: PlaybackMode {
+        if let sampleRate = TalkTTSValidation.pcmSampleRate(from: self.outputFormat) {
+            return .pcm(sampleRate: sampleRate)
+        }
+        let outputFormat = self.outputFormat?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        let isHeaderlessAudio = if let outputFormat {
+            outputFormat.hasPrefix("raw-") ||
+                outputFormat.hasPrefix("raw_") ||
+                outputFormat == "pcm" ||
+                outputFormat == "mulaw" ||
+                outputFormat == "alaw" ||
+                outputFormat.hasPrefix("mulaw_") ||
+                outputFormat.hasPrefix("ulaw_") ||
+                outputFormat.hasPrefix("alaw_")
+        } else {
+            false
+        }
+        if let outputFormat, isHeaderlessAudio {
+            // talk.speak does not expose the sample rate needed to play headerless audio.
+            // Keep these codecs out of AVAudioPlayer until that protocol metadata exists.
+            return .unsupportedRaw(codec: outputFormat)
+        }
+        // Gateway providers return complete audio files (for example MP3, WAV, or FLAC).
+        // AVAudioPlayer performs container detection; raw PCM keeps its sample-rate path above.
+        return .buffered
+    }
+}
+
+struct TalkGatewaySpeechRequest {
+    let text: String
+    // These are talk.speak protocol inputs; each Gateway speech provider owns which overrides it honors.
+    let voiceId: String?
+    let modelId: String?
+    let outputFormat: String?
+    let directive: TalkDirective?
+}
+
+@MainActor
+protocol TalkGatewaySpeechSynthesizing {
+    func synthesize(_ request: TalkGatewaySpeechRequest) async throws -> TalkGatewaySpeechAudio
+}
+
+@MainActor
+final class TalkGatewaySpeechClient: TalkGatewaySpeechSynthesizing {
+    typealias Request = (_ method: String, _ paramsJSON: String?, _ timeoutSeconds: Int) async throws -> Data
+    private static let requestTimeoutSeconds = 125
+
+    private let request: Request
+
+    init(gateway: GatewayNodeSession) {
+        self.request = { method, paramsJSON, timeoutSeconds in
+            try await gateway.request(
+                method: method,
+                paramsJSON: paramsJSON,
+                timeoutSeconds: timeoutSeconds)
+        }
+    }
+
+    init(request: @escaping Request) {
+        self.request = request
+    }
+
+    func synthesize(_ speechRequest: TalkGatewaySpeechRequest) async throws -> TalkGatewaySpeechAudio {
+        let directive = speechRequest.directive
+        let params = TalkSpeakParams(
+            text: speechRequest.text,
+            voiceid: speechRequest.voiceId,
+            modelid: speechRequest.modelId,
+            outputformat: speechRequest.outputFormat,
+            speed: directive?.speed,
+            ratewpm: directive?.rateWPM,
+            stability: directive?.stability,
+            similarity: directive?.similarity,
+            style: directive?.style,
+            speakerboost: directive?.speakerBoost,
+            seed: directive?.seed,
+            normalize: directive?.normalize,
+            language: directive?.language,
+            latencytier: directive?.latencyTier)
+        let paramsData = try JSONEncoder().encode(params)
+        guard let paramsJSON = String(data: paramsData, encoding: .utf8) else {
+            throw TalkGatewaySpeechError.invalidRequest
+        }
+        let responseData = try await request(
+            "talk.speak",
+            paramsJSON,
+            Self.requestTimeoutSeconds)
+        let response = try JSONDecoder().decode(TalkSpeakResult.self, from: responseData)
+        guard let audioData = Data(base64Encoded: response.audiobase64), !audioData.isEmpty else {
+            throw TalkGatewaySpeechError.emptyAudio
+        }
+        return TalkGatewaySpeechAudio(
+            data: audioData,
+            provider: response.provider,
+            outputFormat: response.outputformat)
+    }
+}
+
+@MainActor
+protocol TalkBufferedAudioPlaying {
+    func play(data: Data) async -> StreamingPlaybackResult
+    func stop() -> Double?
+}
+
+@MainActor
+final class TalkBufferedAudioPlayer: NSObject, TalkBufferedAudioPlaying, @preconcurrency AVAudioPlayerDelegate {
+    static let shared = TalkBufferedAudioPlayer()
+
+    private final class Playback: @unchecked Sendable {
+        private let lock = NSLock()
+        private var finished = false
+        private var continuation: CheckedContinuation<StreamingPlaybackResult, Never>?
+        private var watchdog: Task<Void, Never>?
+
+        func setContinuation(_ continuation: CheckedContinuation<StreamingPlaybackResult, Never>) {
+            self.lock.lock()
+            defer { self.lock.unlock() }
+            self.continuation = continuation
+        }
+
+        func setWatchdog(_ task: Task<Void, Never>?) {
+            self.lock.lock()
+            let old = self.watchdog
+            self.watchdog = task
+            self.lock.unlock()
+            old?.cancel()
+        }
+
+        func finish(_ result: StreamingPlaybackResult) {
+            let continuation: CheckedContinuation<StreamingPlaybackResult, Never>?
+            self.lock.lock()
+            if self.finished {
+                continuation = nil
+            } else {
+                self.finished = true
+                continuation = self.continuation
+                self.continuation = nil
+            }
+            self.lock.unlock()
+            continuation?.resume(returning: result)
+        }
+    }
+
+    private let logger = Logger(subsystem: "ai.openclaw", category: "talk.tts")
+    private var player: AVAudioPlayer?
+    private var playback: Playback?
+
+    func play(data: Data) async -> StreamingPlaybackResult {
+        self.stopInternal()
+
+        let playback = Playback()
+        self.playback = playback
+        return await withCheckedContinuation { continuation in
+            playback.setContinuation(continuation)
+            do {
+                let player = try AVAudioPlayer(data: data)
+                self.player = player
+                player.delegate = self
+                player.prepareToPlay()
+                self.armWatchdog(playback: playback)
+                if !player.play() {
+                    self.logger.error("talk buffered audio player refused to play")
+                    self.finish(playback: playback, result: .init(finished: false, interruptedAt: nil))
+                }
+            } catch {
+                self.logger.error("talk buffered audio player failed: \(error.localizedDescription, privacy: .public)")
+                self.finish(playback: playback, result: .init(finished: false, interruptedAt: nil))
+            }
+        }
+    }
+
+    func stop() -> Double? {
+        guard let player else { return nil }
+        let interruptedAt = player.currentTime
+        self.finish(
+            playback: self.playback,
+            result: .init(finished: false, interruptedAt: interruptedAt))
+        return interruptedAt
+    }
+
+    func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
+        self.finish(
+            playback: self.activePlayback(for: player),
+            result: .init(finished: flag, interruptedAt: nil))
+    }
+
+    func audioPlayerDecodeErrorDidOccur(_ player: AVAudioPlayer, error: (any Error)?) {
+        let message = error?.localizedDescription ?? "unknown decode error"
+        self.logger.error("talk buffered audio decode failed: \(message, privacy: .public)")
+        self.finish(
+            playback: self.activePlayback(for: player),
+            result: .init(finished: false, interruptedAt: nil))
+    }
+
+    private func activePlayback(for player: AVAudioPlayer) -> Playback? {
+        // AVAudioPlayer can deliver callbacks after stop/replacement. Keep a stale
+        // player from completing the current reply's continuation.
+        guard self.player === player else { return nil }
+        return self.playback
+    }
+
+    private func stopInternal() {
+        if let player, let playback {
+            self.finish(
+                playback: playback,
+                result: .init(finished: false, interruptedAt: player.currentTime))
+            return
+        }
+        self.player?.stop()
+        self.player = nil
+    }
+
+    private func finish(playback: Playback?, result: StreamingPlaybackResult) {
+        guard let playback else { return }
+        playback.setWatchdog(nil)
+        playback.finish(result)
+
+        guard self.playback === playback else { return }
+        self.playback = nil
+        self.player?.stop()
+        self.player = nil
+    }
+
+    private func armWatchdog(playback: Playback) {
+        playback.setWatchdog(Task { @MainActor [weak self] in
+            guard let self else { return }
+            try? await Task.sleep(nanoseconds: 650_000_000)
+            guard !Task.isCancelled, self.playback === playback else { return }
+            guard self.player?.isPlaying == true else {
+                self.finish(
+                    playback: playback,
+                    result: .init(finished: false, interruptedAt: nil))
+                return
+            }
+
+            let duration = self.player?.duration ?? 0
+            let timeoutSeconds = min(max(2.0, duration + 2.0), 5 * 60.0)
+            try? await Task.sleep(nanoseconds: UInt64(timeoutSeconds * 1_000_000_000))
+            guard !Task.isCancelled, self.playback === playback else { return }
+            self.logger.error("talk buffered audio player watchdog completed unresolved playback")
+            self.finish(
+                playback: playback,
+                result: .init(finished: false, interruptedAt: nil))
+        })
+    }
+}
+
+private enum TalkGatewaySpeechError: LocalizedError {
+    case invalidRequest
+    case emptyAudio
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidRequest:
+            "Failed to encode talk.speak request"
+        case .emptyAudio:
+            "Gateway talk.speak returned empty audio"
+        }
+    }
+}

--- a/apps/ios/Sources/Voice/TalkModeGatewayConfig.swift
+++ b/apps/ios/Sources/Voice/TalkModeGatewayConfig.swift
@@ -1,7 +1,7 @@
 import Foundation
 import OpenClawKit
 
-enum TalkModeExecutionMode {
+enum TalkModeExecutionMode: Equatable {
     case native
     case realtimeRelay
 }
@@ -60,7 +60,7 @@ struct TalkRuntimeIssue: Equatable {
 
     var technicalDetails: String {
         var lines = [
-            "code: \(self.code.rawValue)",
+            "code: \(code.rawValue)",
             "message: \(self.displayMessage)",
         ]
         if let provider, !provider.isEmpty { lines.append("provider: \(provider)") }
@@ -71,7 +71,7 @@ struct TalkRuntimeIssue: Equatable {
     }
 
     var diagnosticSummary: String {
-        var parts = [self.displayMessage]
+        var parts = [displayMessage]
         if let provider, !provider.isEmpty { parts.append("provider: \(provider)") }
         if let model, !model.isEmpty { parts.append("model: \(model)") }
         if let transport, !transport.isEmpty { parts.append("transport: \(transport)") }
@@ -201,7 +201,7 @@ enum TalkModeProviderSelection: String, CaseIterable, Identifiable {
     static let storageKey = "talk.providerSelection"
 
     var id: String {
-        self.rawValue
+        rawValue
     }
 
     var label: String {
@@ -218,6 +218,79 @@ enum TalkModeProviderSelection: String, CaseIterable, Identifiable {
     static func resolved(_ raw: String?) -> TalkModeProviderSelection {
         let trimmed = (raw ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
         return TalkModeProviderSelection(rawValue: trimmed) ?? .gatewayDefault
+    }
+}
+
+enum TalkModeRuntimeRoute: Equatable {
+    case localElevenLabs
+    case gatewayTalkSpeak
+    case realtimeRelay
+
+    var usesRealtime: Bool {
+        self == .realtimeRelay
+    }
+
+    var usesGatewayTalkSpeak: Bool {
+        self == .gatewayTalkSpeak
+    }
+
+    var gatewayOwnsCredentials: Bool {
+        self != .localElevenLabs
+    }
+}
+
+struct TalkModeResolvedRouting: Equatable {
+    let activeProvider: String
+    let executionMode: TalkModeExecutionMode
+    let realtimeProvider: String?
+    let realtimeModelId: String?
+    let route: TalkModeRuntimeRoute
+}
+
+enum TalkModeRoutingResolver {
+    static func resolve(
+        parsed: TalkModeGatewayConfigState,
+        providerSelection: TalkModeProviderSelection,
+        defaultProvider: String,
+        defaultRealtimeModelId: String) -> TalkModeResolvedRouting
+    {
+        var activeProvider = parsed.activeProvider
+        var realtimeProvider = parsed.realtimeProvider
+        var realtimeModelId = parsed.realtimeModelId
+        let route: TalkModeRuntimeRoute
+
+        switch providerSelection {
+        case .gatewayDefault:
+            // Only an explicit realtime config selects the realtime transport. Other Gateway
+            // speech providers stay native and synthesize through talk.speak.
+            if parsed.executionMode == .realtimeRelay {
+                route = .realtimeRelay
+            } else if Self.normalized(activeProvider) == Self.normalized(defaultProvider) {
+                // Preserve the shipped local ElevenLabs path, including its streaming playback.
+                route = .localElevenLabs
+            } else {
+                route = .gatewayTalkSpeak
+            }
+        case .nativeElevenLabs:
+            activeProvider = defaultProvider
+            route = .localElevenLabs
+        case .openAIRealtime:
+            activeProvider = "openai"
+            realtimeProvider = realtimeProvider ?? "openai"
+            realtimeModelId = realtimeModelId ?? defaultRealtimeModelId
+            route = .realtimeRelay
+        }
+
+        return TalkModeResolvedRouting(
+            activeProvider: activeProvider,
+            executionMode: route.usesRealtime ? .realtimeRelay : .native,
+            realtimeProvider: realtimeProvider,
+            realtimeModelId: realtimeModelId,
+            route: route)
+    }
+
+    private static func normalized(_ value: String) -> String {
+        value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     }
 }
 
@@ -254,6 +327,7 @@ struct TalkModeGatewayConfigState {
     let executionMode: TalkModeExecutionMode
     let defaultVoiceId: String?
     let voiceAliases: [String: String]
+    let configuredModelId: String?
     let defaultModelId: String
     let defaultOutputFormat: String?
     let realtimeProvider: String?
@@ -325,6 +399,7 @@ enum TalkModeGatewayConfigParser {
             executionMode: executionMode,
             defaultVoiceId: defaultVoiceId,
             voiceAliases: voiceAliases,
+            configuredModelId: model,
             defaultModelId: defaultModelId,
             defaultOutputFormat: defaultOutputFormat,
             realtimeProvider: realtimeProvider,

--- a/apps/ios/Sources/Voice/TalkModeManager.swift
+++ b/apps/ios/Sources/Voice/TalkModeManager.swift
@@ -93,6 +93,7 @@ final class TalkModeManager: NSObject {
     private var pttTimeoutTask: Task<Void, Never>?
 
     private let allowSimulatorCapture: Bool
+    private let gatewaySpeechSynthesizerOverride: (any TalkGatewaySpeechSynthesizing)?
 
     private let audioEngine = AVAudioEngine()
     private var inputTapInstalled = false
@@ -117,12 +118,13 @@ final class TalkModeManager: NSObject {
     private var currentVoiceId: String?
     private var defaultModelId: String?
     private var currentModelId: String?
+    private var configuredProviderModelId: String?
     private var voiceOverrideActive = false
     private var modelOverrideActive = false
     private var defaultOutputFormat: String?
     private var activeTalkProvider: String = TalkModeManager.defaultTalkProvider
     private var executionMode: TalkModeExecutionMode = .native
-    private var realtimeWebRTCEnabled: Bool = false
+    private var runtimeRoute: TalkModeRuntimeRoute = .localElevenLabs
     private var realtimeProvider: String?
     private var realtimeModelId: String?
     private var realtimeVoiceId: String?
@@ -143,11 +145,13 @@ final class TalkModeManager: NSObject {
     private var mainSessionKey: String = "main"
     private var fallbackVoiceId: String?
     private var lastPlaybackWasPCM: Bool = false
+    private var speechGeneration = 0
     /// Set when the ElevenLabs API rejects PCM format (e.g. 403 subscription_required).
     /// Once set, all subsequent requests in this session use MP3 instead of re-trying PCM.
     private var pcmFormatUnavailable: Bool = false
     var pcmPlayer: PCMStreamingAudioPlaying = PCMStreamingAudioPlayer.shared
     var mp3Player: StreamingAudioPlaying = StreamingAudioPlayer.shared
+    var bufferedPlayer: TalkBufferedAudioPlaying = TalkBufferedAudioPlayer.shared
 
     private var gateway: GatewayNodeSession?
     private var gatewayConnected = false
@@ -180,8 +184,12 @@ final class TalkModeManager: NSObject {
         max(0, Int((self.nowSeconds() - start) * 1000))
     }
 
-    init(allowSimulatorCapture: Bool = false) {
+    init(
+        allowSimulatorCapture: Bool = false,
+        gatewaySpeechSynthesizer: (any TalkGatewaySpeechSynthesizing)? = nil)
+    {
         self.allowSimulatorCapture = allowSimulatorCapture
+        self.gatewaySpeechSynthesizerOverride = gatewaySpeechSynthesizer
         super.init()
     }
 
@@ -328,14 +336,14 @@ final class TalkModeManager: NSObject {
             return
         }
         guard self.isCurrentStartAttempt(attemptID) else { return }
-        await self.ensureTalkConfigLoadedForStart()
+        await ensureTalkConfigLoadedForStart()
         guard self.isCurrentStartAttempt(attemptID) else { return }
         if self.gatewayTalkPermissionState.requiresTalkPermissionAction {
             self.statusText = "Gateway permission required"
             GatewayDiagnostics.log("talk.timeline manager start blocked gateway permission")
             return
         }
-        if self.realtimeWebRTCEnabled {
+        if self.runtimeRoute.usesRealtime {
             let realtimeStart = self.executionMode == .realtimeRelay
                 ? await self.startRealtimeRelayIfAvailable()
                 : await self.startRealtimeIfAvailable()
@@ -365,10 +373,10 @@ final class TalkModeManager: NSObject {
             self.captureMode = .continuous
             try self.startRecognition()
             self.isListening = true
-            if let issue = self.pendingRealtimeIssue {
-                self.markNativeFallbackActive(after: issue)
+            if let issue = pendingRealtimeIssue {
+                markNativeFallbackActive(after: issue)
             } else {
-                self.markNativeTalkActive()
+                markNativeTalkActive()
             }
             self.startSilenceMonitor()
             await self.subscribeChatIfNeeded(sessionKey: self.mainSessionKey)
@@ -401,7 +409,7 @@ final class TalkModeManager: NSObject {
     private func applyOpenAIRealtimeSelectionDefaults() {
         self.activeTalkProvider = "openai"
         self.executionMode = .realtimeRelay
-        self.realtimeWebRTCEnabled = true
+        self.runtimeRoute = .realtimeRelay
         self.realtimeProvider = self.realtimeProvider ?? "openai"
         self.realtimeModelId = self.realtimeModelId ?? Self.defaultRealtimeModelIdFallback
         self.gatewayTalkProviderLabel = TalkModeProviderSelection.openAIRealtime.label
@@ -1008,7 +1016,7 @@ final class TalkModeManager: NSObject {
             self.logger.info(
                 "chat.send start sessionKey=\(sessionKey, privacy: .public) chars=\(prompt.count, privacy: .public)")
             GatewayDiagnostics.log("talk: chat.send start sessionKey=\(sessionKey) chars=\(prompt.count)")
-            let ack = try await self.sendChat(prompt, gateway: gateway)
+            let ack = try await sendChat(prompt, gateway: gateway)
             let runId = ack.runId
             let normalizedStatus = Self.normalizedChatSendStatus(ack.status)
             self.logger.info(
@@ -1107,10 +1115,10 @@ final class TalkModeManager: NSObject {
 
     private func startRealtimeIfAvailable() async -> RealtimeStartResult {
         guard let gateway else {
-            return .unavailable(self.realtimeIssue(message: "Gateway not connected", phase: "start"))
+            return .unavailable(realtimeIssue(message: "Gateway not connected", phase: "start"))
         }
         let startedAt = Self.nowSeconds()
-        if self.prefetchedRealtimeSession == nil, let prefetchTask = self.realtimePrefetchTask {
+        if self.prefetchedRealtimeSession == nil, let prefetchTask = realtimePrefetchTask {
             GatewayDiagnostics.log("talk.timeline realtime awaiting in-flight prefetch")
             await prefetchTask.value
         }
@@ -1133,7 +1141,7 @@ final class TalkModeManager: NSObject {
             }
             self.isListening = true
             self.captureMode = .continuous
-            self.markRealtimeActive()
+            markRealtimeActive()
             GatewayDiagnostics.log(
                 "talk.timeline realtime start ready elapsedMs=\(Self.elapsedMs(since: startedAt))")
             GatewayDiagnostics.log("talk realtime: started direct OpenAI WebRTC session")
@@ -1144,7 +1152,7 @@ final class TalkModeManager: NSObject {
                 return .ignored
             }
             self.stopRealtimeSession()
-            let issue = self.realtimeIssue(from: error, phase: "start")
+            let issue = realtimeIssue(from: error, phase: "start")
             GatewayDiagnostics
                 .log("talk realtime: unavailable; falling back to speech pipeline error=\(error.localizedDescription)")
             GatewayDiagnostics.log(
@@ -1156,7 +1164,7 @@ final class TalkModeManager: NSObject {
 
     private func startRealtimeRelayIfAvailable() async -> RealtimeStartResult {
         guard let gateway else {
-            return .unavailable(self.realtimeIssue(message: "Gateway not connected", phase: "start"))
+            return .unavailable(realtimeIssue(message: "Gateway not connected", phase: "start"))
         }
         guard self.foregroundAudioCaptureAllowed else {
             self.statusText = "Paused"
@@ -1175,7 +1183,7 @@ final class TalkModeManager: NSObject {
         }
         self.realtimeRelayStartInFlight = true
         defer { self.realtimeRelayStartInFlight = false }
-        self.prepareRealtimeRelayStart()
+        prepareRealtimeRelayStart()
         GatewayDiagnostics.log("talk.timeline realtime relay start attempt sessionKey=\(self.mainSessionKey)")
         let startedAt = Self.nowSeconds()
         let relaySession = RealtimeTalkRelaySession(
@@ -1213,7 +1221,7 @@ final class TalkModeManager: NSObject {
                 relaySession.stop()
                 return .ignored
             }
-            if let issue = self.realtimeRelayStartIssue {
+            if let issue = realtimeRelayStartIssue {
                 self.realtimeRelaySession = nil
                 relaySession.stop()
                 GatewayDiagnostics.log(
@@ -1234,7 +1242,7 @@ final class TalkModeManager: NSObject {
             }
             self.realtimeRelaySession = nil
             let issue = self.realtimeRelayStartIssue
-                ?? self.realtimeIssue(from: error, phase: "start")
+                ?? realtimeIssue(from: error, phase: "start")
             self.realtimeRelayStartIssue = nil
             GatewayDiagnostics.log(
                 "talk.timeline realtime relay start failed elapsedMs=\(Self.elapsedMs(since: startedAt)) "
@@ -1249,7 +1257,7 @@ final class TalkModeManager: NSObject {
               self.realtimeRelaySession == nil,
               !self.isEnabled
         else { return }
-        guard self.realtimeWebRTCEnabled, self.executionMode != .realtimeRelay else { return }
+        guard self.runtimeRoute.usesRealtime, self.executionMode != .realtimeRelay else { return }
         guard self.gatewayTalkPermissionState == .ready else { return }
         guard self.consumePrefetchedRealtimeSession(peekOnly: true) == nil else { return }
         guard self.realtimePrefetchTask == nil else { return }
@@ -1296,7 +1304,7 @@ final class TalkModeManager: NSObject {
     }
 
     private func consumePrefetchedRealtimeSession(peekOnly: Bool = false) -> TalkRealtimeClientSession? {
-        guard let session = self.prefetchedRealtimeSession else { return nil }
+        guard let session = prefetchedRealtimeSession else { return nil }
         if let expiresAt = session.expiresAt {
             let usableUntil = expiresAt - Self.realtimePrefetchExpiryLeewaySeconds
             if Date().timeIntervalSince1970 >= usableUntil {
@@ -1520,14 +1528,45 @@ final class TalkModeManager: NSObject {
         let cleaned = parsed.stripped.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !cleaned.isEmpty else { return }
         self.applyDirective(directive)
+        self.speechGeneration += 1
+        let speechGeneration = self.speechGeneration
 
         self.statusText = "Generating voice…"
         self.isSpeaking = true
         self.lastSpokenText = cleaned
+        defer {
+            if self.speechGeneration == speechGeneration {
+                self.stopRecognition()
+                self.isSpeaking = false
+                self.restoreConfiguredVoiceModeDescriptor()
+            }
+        }
+
+        let language = ElevenLabsTTSClient.validatedLanguage(directive?.language)
+        if self.runtimeRoute.usesGatewayTalkSpeak {
+            do {
+                try await self.playGatewayTalkSpeak(
+                    text: cleaned,
+                    directive: directive,
+                    generation: speechGeneration)
+            } catch {
+                guard self.speechGeneration == speechGeneration else { return }
+                let errorMessage = error.localizedDescription
+                self.logger.error("gateway TTS failed: \(errorMessage, privacy: .public); falling back to system voice")
+                GatewayDiagnostics.log("talk tts: provider=system (gateway error) msg=\(error.localizedDescription)")
+                do {
+                    try await self.playSystemVoice(text: cleaned, language: language)
+                } catch {
+                    guard self.speechGeneration == speechGeneration else { return }
+                    self.statusText = "Speak failed: \(error.localizedDescription)"
+                    self.logger.error("system voice failed: \(error.localizedDescription, privacy: .public)")
+                }
+            }
+            return
+        }
 
         do {
             let started = Date()
-            let language = ElevenLabsTTSClient.validatedLanguage(directive?.language)
             let requestedVoice = directive?.voiceId?.trimmingCharacters(in: .whitespacesAndNewlines)
             let resolvedVoice = resolveVoiceAlias(requestedVoice)
             if requestedVoice?.isEmpty == false, resolvedVoice == nil {
@@ -1546,7 +1585,7 @@ final class TalkModeManager: NSObject {
             if canUseElevenLabs, let voiceId, let apiKey {
                 GatewayDiagnostics.log("talk tts: provider=elevenlabs voiceId=\(voiceId)")
                 let modelId = directive?.modelId ?? self.currentModelId ?? self.defaultModelId
-                self.applyVoiceModeDescriptor(TalkVoiceModeDescriptorBuilder.build(
+                applyVoiceModeDescriptor(TalkVoiceModeDescriptorBuilder.build(
                     providerId: "elevenlabs",
                     providerLabel: Self.displayName(forProvider: "elevenlabs"),
                     modelId: modelId,
@@ -1618,42 +1657,102 @@ final class TalkModeManager: NSObject {
             } else {
                 self.logger.warning("tts unavailable; falling back to system voice (missing key or voiceId)")
                 GatewayDiagnostics.log("talk tts: provider=system (missing key or voiceId)")
-                self.applyVoiceModeDescriptor(TalkVoiceModeDescriptorBuilder.build(
-                    providerId: "system",
-                    providerLabel: Self.displayName(forProvider: "system"),
-                    modelId: nil,
-                    voiceId: language,
-                    transport: "native",
-                    isRealtime: false))
-                self.startSpeechInterruptionRecognitionIfNeeded()
-                self.statusText = "Speaking (System)…"
-                try await TalkSystemSpeechSynthesizer.shared.speak(text: cleaned, language: language)
+                try await self.playSystemVoice(text: cleaned, language: language)
             }
         } catch {
+            guard self.speechGeneration == speechGeneration else { return }
             self.logger.error(
                 "tts failed: \(error.localizedDescription, privacy: .public); falling back to system voice")
             GatewayDiagnostics.log("talk tts: provider=system (error) msg=\(error.localizedDescription)")
             do {
-                let language = ElevenLabsTTSClient.validatedLanguage(directive?.language)
-                self.applyVoiceModeDescriptor(TalkVoiceModeDescriptorBuilder.build(
-                    providerId: "system",
-                    providerLabel: Self.displayName(forProvider: "system"),
-                    modelId: nil,
-                    voiceId: language,
-                    transport: "native",
-                    isRealtime: false))
-                self.startSpeechInterruptionRecognitionIfNeeded()
-                self.statusText = "Speaking (System)…"
-                try await TalkSystemSpeechSynthesizer.shared.speak(text: cleaned, language: language)
+                try await self.playSystemVoice(text: cleaned, language: language)
             } catch {
+                guard self.speechGeneration == speechGeneration else { return }
                 self.statusText = "Speak failed: \(error.localizedDescription)"
                 self.logger.error("system voice failed: \(error.localizedDescription, privacy: .public)")
             }
         }
+    }
 
-        self.stopRecognition()
-        self.isSpeaking = false
-        self.restoreConfiguredVoiceModeDescriptor()
+    private func playGatewayTalkSpeak(
+        text: String,
+        directive: TalkDirective?,
+        generation: Int) async throws
+    {
+        let synthesizer: any TalkGatewaySpeechSynthesizing
+        if let gatewaySpeechSynthesizerOverride {
+            synthesizer = gatewaySpeechSynthesizerOverride
+        } else if let gateway {
+            synthesizer = TalkGatewaySpeechClient(gateway: gateway)
+        } else {
+            throw NSError(domain: "TalkGatewaySpeech", code: 1, userInfo: [
+                NSLocalizedDescriptionKey: "Gateway not connected",
+            ])
+        }
+
+        let requestedVoice = directive?.voiceId?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let voiceId = requestedVoice?.isEmpty == false
+            ? requestedVoice
+            : (self.currentVoiceId ?? self.defaultVoiceId)
+        let modelId = directive?.modelId ?? (self.modelOverrideActive
+            ? self.currentModelId
+            : self.configuredProviderModelId)
+        let outputFormat = directive?.outputFormat ?? self.defaultOutputFormat
+        let audio = try await synthesizer.synthesize(TalkGatewaySpeechRequest(
+            text: text,
+            voiceId: voiceId,
+            modelId: modelId,
+            outputFormat: outputFormat,
+            directive: directive))
+        guard generation == self.speechGeneration, self.isSpeaking else { return }
+
+        applyVoiceModeDescriptor(TalkVoiceModeDescriptorBuilder.build(
+            providerId: audio.provider,
+            providerLabel: Self.displayName(forProvider: audio.provider),
+            modelId: modelId,
+            voiceId: voiceId,
+            transport: "native",
+            isRealtime: false))
+        self.startSpeechInterruptionRecognitionIfNeeded()
+        self.statusText = "Speaking…"
+        let result: StreamingPlaybackResult
+        switch audio.playbackMode {
+        case let .pcm(sampleRate):
+            self.lastPlaybackWasPCM = true
+            let stream = Self.makeBufferedAudioStream(chunks: [audio.data])
+            result = await self.pcmPlayer.play(stream: stream, sampleRate: sampleRate)
+        case .buffered:
+            self.lastPlaybackWasPCM = false
+            result = await self.bufferedPlayer.play(data: audio.data)
+        case let .unsupportedRaw(codec):
+            throw NSError(domain: "TalkGatewaySpeech", code: 2, userInfo: [
+                NSLocalizedDescriptionKey: "Gateway talk.speak returned unsupported raw audio codec '\(codec)'",
+            ])
+        }
+        guard generation == self.speechGeneration, self.isSpeaking else { return }
+        GatewayDiagnostics.log(
+            "talk tts: provider=\(audio.provider) outputFormat=\(audio.outputFormat ?? "unknown") " +
+                "finished=\(result.finished)")
+        if !result.finished, let interruptedAt = result.interruptedAt {
+            self.lastInterruptedAtSeconds = interruptedAt
+        } else if !result.finished {
+            throw NSError(domain: "TalkGatewaySpeech", code: 3, userInfo: [
+                NSLocalizedDescriptionKey: "Gateway talk.speak audio playback failed",
+            ])
+        }
+    }
+
+    private func playSystemVoice(text: String, language: String?) async throws {
+        applyVoiceModeDescriptor(TalkVoiceModeDescriptorBuilder.build(
+            providerId: "system",
+            providerLabel: Self.displayName(forProvider: "system"),
+            modelId: nil,
+            voiceId: language,
+            transport: "native",
+            isRealtime: false))
+        self.startSpeechInterruptionRecognitionIfNeeded()
+        self.statusText = "Speaking (System)…"
+        try await TalkSystemSpeechSynthesizer.shared.speak(text: text, language: language)
     }
 
     private func resolvedElevenLabsAPIKey() -> String? {
@@ -1700,15 +1799,18 @@ final class TalkModeManager: NSObject {
     }
 
     private func stopSpeaking(storeInterruption: Bool = true) {
+        self.speechGeneration += 1
         let hasIncremental = self.incrementalSpeechActive ||
             self.incrementalSpeechTask != nil ||
             !self.incrementalSpeechQueue.isEmpty
         if self.isSpeaking {
-            let interruptedAt = self.lastPlaybackWasPCM
+            let streamedInterruptedAt = self.lastPlaybackWasPCM
                 ? self.pcmPlayer.stop()
                 : self.mp3Player.stop()
             if storeInterruption {
-                self.lastInterruptedAtSeconds = interruptedAt
+                self.lastInterruptedAtSeconds = self.bufferedPlayer.stop() ?? streamedInterruptedAt
+            } else {
+                _ = self.bufferedPlayer.stop()
             }
             _ = self.lastPlaybackWasPCM
                 ? self.mp3Player.stop()
@@ -1716,10 +1818,11 @@ final class TalkModeManager: NSObject {
         } else if !hasIncremental {
             return
         }
+        self.stopRecognition()
         TalkSystemSpeechSynthesizer.shared.stop()
         self.cancelIncrementalSpeech()
         self.isSpeaking = false
-        self.restoreConfiguredVoiceModeDescriptor()
+        restoreConfiguredVoiceModeDescriptor()
     }
 
     private func shouldInterrupt(with transcript: String) -> Bool {
@@ -1747,7 +1850,7 @@ final class TalkModeManager: NSObject {
     }
 
     private func shouldUseIncrementalTTS() -> Bool {
-        true
+        !self.runtimeRoute.usesGatewayTalkSpeak
     }
 
     private var isSpeechOutputActive: Bool {
@@ -1759,8 +1862,9 @@ final class TalkModeManager: NSObject {
 
     private func applyDirective(_ directive: TalkDirective?) {
         let requestedVoice = directive?.voiceId?.trimmingCharacters(in: .whitespacesAndNewlines)
-        let resolvedVoice = resolveVoiceAlias(requestedVoice)
-        if requestedVoice?.isEmpty == false, resolvedVoice == nil {
+        let usesGatewayVoiceIds = self.runtimeRoute.usesGatewayTalkSpeak
+        let resolvedVoice = usesGatewayVoiceIds ? requestedVoice : resolveVoiceAlias(requestedVoice)
+        if !usesGatewayVoiceIds, requestedVoice?.isEmpty == false, resolvedVoice == nil {
             self.logger.warning("unknown voice alias \(requestedVoice ?? "?", privacy: .public)")
         }
         if let voice = resolvedVoice {
@@ -2525,9 +2629,9 @@ extension TalkModeManager {
         if let gatewayError = error as? GatewayResponseError,
            let issue = Self.talkRuntimeIssue(
                from: gatewayError,
-               fallbackProvider: self.realtimeProvider,
-               fallbackModel: self.realtimeModelId,
-               fallbackTransport: self.executionMode == .realtimeRelay ? "gateway-relay" : "webrtc",
+               fallbackProvider: realtimeProvider,
+               fallbackModel: realtimeModelId,
+               fallbackTransport: executionMode == .realtimeRelay ? "gateway-relay" : "webrtc",
                fallbackPhase: phase)
         {
             return issue
@@ -2597,7 +2701,7 @@ extension TalkModeManager {
         self.pcmFormatUnavailable = false
         self.prefetchedRealtimeSession = nil
         do {
-            guard let loaded = try await self.loadTalkConfig(from: gateway) else { return }
+            guard let loaded = try await loadTalkConfig(from: gateway) else { return }
             let parsed = TalkModeGatewayConfigParser.parse(
                 config: loaded.config,
                 defaultProvider: Self.defaultTalkProvider,
@@ -2649,40 +2753,23 @@ extension TalkModeManager {
 
     private func applyLoadedTalkConfig(
         _ parsed: TalkModeGatewayConfigState,
-        redactedFallbackMissingScope: String?)
+        redactedFallbackMissingScope: String?,
+        providerSelection providerSelectionOverride: TalkModeProviderSelection? = nil)
     {
-        let providerSelection = self.talkProviderSelection
-        var activeProvider = parsed.activeProvider
-        var executionMode = parsed.executionMode
-        var realtimeProvider = parsed.realtimeProvider
-        var realtimeModelId = parsed.realtimeModelId
+        let providerSelection = providerSelectionOverride ?? self.talkProviderSelection
+        let routing = TalkModeRoutingResolver.resolve(
+            parsed: parsed,
+            providerSelection: providerSelection,
+            defaultProvider: Self.defaultTalkProvider,
+            defaultRealtimeModelId: Self.defaultRealtimeModelIdFallback)
         let realtimeVoiceOverride = TalkModeRealtimeVoiceSelection.resolvedOverride(
             UserDefaults.standard.string(forKey: TalkModeRealtimeVoiceSelection.storageKey))
         let realtimeVoiceId = realtimeVoiceOverride ?? parsed.realtimeVoiceId
-        switch providerSelection {
-        case .gatewayDefault:
-            break
-        case .nativeElevenLabs:
-            activeProvider = Self.defaultTalkProvider
-            executionMode = .native
-        case .openAIRealtime:
-            activeProvider = "openai"
-            executionMode = .realtimeRelay
-            realtimeProvider = realtimeProvider ?? "openai"
-            realtimeModelId = realtimeModelId ?? Self.defaultRealtimeModelIdFallback
-        }
-        if activeProvider.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "openai" {
-            executionMode = .realtimeRelay
-            realtimeProvider = realtimeProvider ?? "openai"
-            realtimeModelId = realtimeModelId ?? Self.defaultRealtimeModelIdFallback
-        }
-
-        let usesRealtimeConfig = activeProvider != Self.defaultTalkProvider || executionMode != .native
-        self.activeTalkProvider = activeProvider
-        self.executionMode = executionMode
-        self.realtimeWebRTCEnabled = usesRealtimeConfig
-        self.realtimeProvider = realtimeProvider
-        self.realtimeModelId = realtimeModelId
+        self.activeTalkProvider = routing.activeProvider
+        self.executionMode = routing.executionMode
+        self.runtimeRoute = routing.route
+        self.realtimeProvider = routing.realtimeProvider
+        self.realtimeModelId = routing.realtimeModelId
         self.realtimeVoiceId = realtimeVoiceId
         self.defaultVoiceId = parsed.defaultVoiceId
         self.voiceAliases = parsed.voiceAliases
@@ -2690,23 +2777,26 @@ extension TalkModeManager {
             self.currentVoiceId = self.defaultVoiceId
         }
         self.defaultModelId = parsed.defaultModelId
+        self.configuredProviderModelId = parsed.configuredModelId
         if !self.modelOverrideActive {
             self.currentModelId = self.defaultModelId
         }
         self.defaultOutputFormat = parsed.defaultOutputFormat
 
+        let credentialProvider = routing.route.usesRealtime
+            ? (routing.realtimeProvider ?? routing.activeProvider)
+            : routing.activeProvider
         let gatewayOwnedVoiceProvider = self.applyTalkConfigCredentials(
             parsed: parsed,
-            activeProvider: activeProvider,
-            usesRealtimeConfig: usesRealtimeConfig,
-            realtimeProvider: realtimeProvider)
+            activeProvider: routing.activeProvider,
+            gatewayOwnsCredentials: routing.route.gatewayOwnsCredentials,
+            credentialProvider: credentialProvider)
         self.applyTalkModeDescriptor(
-            activeProvider: activeProvider,
+            routing: routing,
             providerSelection: providerSelection,
-            usesRealtimeConfig: usesRealtimeConfig,
-            usesRealtimeRelay: executionMode == .realtimeRelay,
-            realtimeProvider: realtimeProvider,
-            realtimeModelId: realtimeModelId,
+            nativeModelId: routing.route == .localElevenLabs
+                ? self.defaultModelId
+                : self.configuredProviderModelId,
             realtimeVoiceId: realtimeVoiceId)
         self.applyTalkPermissionState(
             redactedFallbackMissingScope: redactedFallbackMissingScope,
@@ -2718,15 +2808,16 @@ extension TalkModeManager {
         self.gatewaySpeechLocaleID = parsed.speechLocaleID
         self.silenceWindow = TimeInterval(parsed.silenceTimeoutMs) / 1000
         if parsed.normalizedPayload || parsed.defaultVoiceId != nil || parsed.rawConfigApiKey != nil {
-            GatewayDiagnostics.log("talk config provider=\(activeProvider) silenceTimeoutMs=\(parsed.silenceTimeoutMs)")
+            GatewayDiagnostics.log(
+                "talk config provider=\(routing.activeProvider) silenceTimeoutMs=\(parsed.silenceTimeoutMs)")
         }
     }
 
     private func applyTalkConfigCredentials(
         parsed: TalkModeGatewayConfigState,
         activeProvider: String,
-        usesRealtimeConfig: Bool,
-        realtimeProvider: String?) -> Bool
+        gatewayOwnsCredentials: Bool,
+        credentialProvider: String) -> Bool
     {
         let rawConfigApiKey = parsed.rawConfigApiKey
         let configApiKey = Self.normalizedTalkApiKey(rawConfigApiKey)
@@ -2738,28 +2829,25 @@ extension TalkModeManager {
         } else {
             self.apiKey = (localApiKey?.isEmpty == false) ? localApiKey : configApiKey
         }
-        let gatewayOwnedVoiceProvider = usesRealtimeConfig
-        if gatewayOwnedVoiceProvider {
+        if gatewayOwnsCredentials {
             self.apiKey = nil
-            let credentialProvider = realtimeProvider ?? activeProvider
-            GatewayDiagnostics.log("talk realtime provider '\(credentialProvider)' uses gateway-owned credentials")
+            GatewayDiagnostics.log("talk provider '\(credentialProvider)' uses gateway-owned credentials")
         }
-        return gatewayOwnedVoiceProvider
+        return gatewayOwnsCredentials
     }
 
     private func applyTalkModeDescriptor(
-        activeProvider: String,
+        routing: TalkModeResolvedRouting,
         providerSelection: TalkModeProviderSelection,
-        usesRealtimeConfig: Bool,
-        usesRealtimeRelay: Bool,
-        realtimeProvider: String?,
-        realtimeModelId: String?,
+        nativeModelId: String?,
         realtimeVoiceId: String?)
     {
+        let usesRealtimeConfig = routing.route.usesRealtime
+        let usesRealtimeRelay = routing.executionMode == .realtimeRelay
         self.gatewayTalkDefaultVoiceId = usesRealtimeConfig ? realtimeVoiceId : self.defaultVoiceId
-        self.gatewayTalkDefaultModelId = usesRealtimeConfig ? realtimeModelId : self.defaultModelId
+        self.gatewayTalkDefaultModelId = usesRealtimeConfig ? routing.realtimeModelId : nativeModelId
         let providerLabel = providerSelection == .gatewayDefault
-            ? Self.displayName(forProvider: activeProvider)
+            ? Self.displayName(forProvider: routing.activeProvider)
             : providerSelection.label
         let transport = usesRealtimeConfig ? (usesRealtimeRelay ? "gateway-relay" : "webrtc") : "native"
         let transportLabel = usesRealtimeRelay ? "Gateway Relay" : (usesRealtimeConfig ? "Native WebRTC" : "Native")
@@ -2767,17 +2855,19 @@ extension TalkModeManager {
         self.gatewayTalkUsesRealtime = usesRealtimeConfig
         self.gatewayTalkUsesRealtimeRelay = usesRealtimeRelay
         self.gatewayTalkTransportLabel = transportLabel
-        self.gatewayTalkRealtimeProviderLabel = realtimeProvider.map { Self.displayName(forProvider: $0) }
-        self.gatewayTalkRealtimeModelId = realtimeModelId
+        self.gatewayTalkRealtimeProviderLabel = routing.realtimeProvider.map { Self.displayName(forProvider: $0) }
+        self.gatewayTalkRealtimeModelId = routing.realtimeModelId
         self.gatewayTalkRealtimeVoiceId = realtimeVoiceId
-        let voiceModeProvider = usesRealtimeConfig ? (realtimeProvider ?? "realtime") : activeProvider
+        let voiceModeProvider = usesRealtimeConfig
+            ? (routing.realtimeProvider ?? "realtime")
+            : routing.activeProvider
         let voiceModeLabel = usesRealtimeConfig
             ? Self.displayName(forProvider: voiceModeProvider)
-            : Self.displayName(forProvider: activeProvider)
+            : Self.displayName(forProvider: routing.activeProvider)
         let voiceModeDescriptor = self.buildConfiguredVoiceModeDescriptor(
             provider: voiceModeProvider,
             providerLabel: voiceModeLabel,
-            modelId: usesRealtimeConfig ? realtimeModelId : self.defaultModelId,
+            modelId: usesRealtimeConfig ? routing.realtimeModelId : nativeModelId,
             voiceId: usesRealtimeConfig ? realtimeVoiceId : self.defaultVoiceId,
             transport: transport,
             isRealtime: usesRealtimeConfig)
@@ -2792,7 +2882,7 @@ extension TalkModeManager {
         self.gatewayTalkConfigLoaded = true
         self.talkConfigLoadedAt = Date()
         if let missingScope = redactedFallbackMissingScope,
-           gatewayOwnedVoiceProvider || self.apiKey == nil
+           gatewayOwnedVoiceProvider || apiKey == nil
         {
             self.gatewayTalkPermissionState = .missingScope(missingScope)
             GatewayDiagnostics.log("talk config missing gateway scope=\(missingScope)")
@@ -2804,6 +2894,7 @@ extension TalkModeManager {
     }
 
     private func applyTalkConfigLoadFailure(_ error: Error) {
+        self.configuredProviderModelId = nil
         if self.shouldForceRealtimeRelayFromSelection {
             self.applyOpenAIRealtimeSelectionDefaults()
             GatewayDiagnostics.log("talk config unavailable; keeping openai realtime selection")
@@ -2830,10 +2921,11 @@ extension TalkModeManager {
     private func applyTalkConfigLoadFailureFallback() {
         self.activeTalkProvider = Self.defaultTalkProvider
         self.executionMode = .native
-        self.realtimeWebRTCEnabled = false
+        self.runtimeRoute = .localElevenLabs
         self.realtimeProvider = nil
         self.realtimeModelId = nil
         self.realtimeVoiceId = nil
+        self.configuredProviderModelId = nil
         self.gatewayTalkProviderLabel = "Not loaded"
         self.gatewayTalkTransportLabel = "Not loaded"
         self.gatewayTalkUsesRealtime = false
@@ -3090,6 +3182,36 @@ extension TalkModeManager {
 
     func _test_applyOpenAIRealtimeSelectionDefaults() {
         self.applyOpenAIRealtimeSelectionDefaults()
+    }
+
+    func _test_applyLoadedTalkConfig(
+        _ parsed: TalkModeGatewayConfigState,
+        providerSelection: TalkModeProviderSelection)
+    {
+        self.applyLoadedTalkConfig(
+            parsed,
+            redactedFallbackMissingScope: nil,
+            providerSelection: providerSelection)
+    }
+
+    func _test_runtimeRoute() -> TalkModeRuntimeRoute {
+        self.runtimeRoute
+    }
+
+    func _test_playAssistant(text: String) async {
+        await self.playAssistant(text: text)
+    }
+
+    func _test_stopSpeaking(storeInterruption: Bool = true) {
+        self.stopSpeaking(storeInterruption: storeInterruption)
+    }
+
+    func _test_lastInterruptedAtSeconds() -> Double? {
+        self.lastInterruptedAtSeconds
+    }
+
+    func _test_hasRecognitionRequest() -> Bool {
+        self.recognitionRequest != nil
     }
 
     func _test_executionMode() -> TalkModeExecutionMode {

--- a/apps/ios/SwiftSources.input.xcfilelist
+++ b/apps/ios/SwiftSources.input.xcfilelist
@@ -48,6 +48,7 @@ Sources/Gateway/GatewayConnectionIssue.swift
 Sources/Gateway/GatewayDiscoveryDebugLogView.swift
 Sources/Gateway/GatewayDiscoveryModel.swift
 Sources/Gateway/GatewayHealthMonitor.swift
+Sources/Gateway/GatewayProblemPrimaryAction.swift
 Sources/Gateway/GatewayProblemView.swift
 Sources/Gateway/GatewayQuickSetupSheet.swift
 Sources/Gateway/NotificationPermissionGuidanceDialog.swift

--- a/apps/ios/SwiftSources.input.xcfilelist
+++ b/apps/ios/SwiftSources.input.xcfilelist
@@ -99,6 +99,7 @@ Sources/Status/VoiceWakeToast.swift
 Sources/Voice/TalkGatewayPermissionState.swift
 Sources/Voice/TalkDefaults.swift
 Sources/Voice/RealtimeTalkRelaySession.swift
+Sources/Voice/TalkGatewaySpeechClient.swift
 Sources/Voice/TalkModeGatewayConfig.swift
 Sources/Voice/TalkModeManager.swift
 Sources/Voice/TalkModeManager+Permissions.swift

--- a/apps/ios/Tests/GatewayProblemPrimaryActionTests.swift
+++ b/apps/ios/Tests/GatewayProblemPrimaryActionTests.swift
@@ -1,0 +1,36 @@
+import Foundation
+import OpenClawKit
+import Testing
+@testable import OpenClaw
+
+struct GatewayProblemPrimaryActionTests {
+    @Test func `protocol mismatch uses update action instead of retry`() {
+        let problem = GatewayConnectionProblem(
+            kind: .protocolMismatch,
+            owner: .iphone,
+            title: "App update required",
+            message: "This app is older than the gateway.",
+            actionLabel: "Update app",
+            retryable: false,
+            pauseReconnect: true)
+
+        let title = GatewayProblemPrimaryAction.title(for: problem, retryTitle: "Retry connection")
+
+        #expect(title == "Update app")
+    }
+
+    @Test func `retryable problem uses mapped action label`() {
+        let problem = GatewayConnectionProblem(
+            kind: .timeout,
+            owner: .network,
+            title: "Connection timed out",
+            message: "Check the gateway network path.",
+            actionLabel: "Try again",
+            retryable: true,
+            pauseReconnect: false)
+
+        let title = GatewayProblemPrimaryAction.title(for: problem, retryTitle: "Retry connection")
+
+        #expect(title == "Try again")
+    }
+}

--- a/apps/ios/Tests/RootTabsSourceGuardTests.swift
+++ b/apps/ios/Tests/RootTabsSourceGuardTests.swift
@@ -118,7 +118,7 @@ struct RootTabsSourceGuardTests {
         #expect(source.contains(".listRowSeparator(.hidden, edges: .all)"))
         #expect(source.contains(".listSectionSeparator(.hidden, edges: .all)"))
         #expect(source.contains("if self.isSidebarDrawerLayout {"))
-        #expect(source.contains("private var sidebarFooter: some View"))
+        #expect(!source.contains("private var sidebarFooter: some View"))
         #expect(!source.contains("LabeledContent(\"Version\""))
         #expect(navigationSource.contains("SidebarGroup(title: \"CHAT\", destinations: [.chat, .talk])"))
         #expect(!navigationSource.contains("title: \"AGENT\""))

--- a/apps/ios/Tests/RootTabsSourceGuardTests.swift
+++ b/apps/ios/Tests/RootTabsSourceGuardTests.swift
@@ -645,6 +645,7 @@ struct RootTabsSourceGuardTests {
         #expect(actionsSource.contains("Run /pair approve in your OpenClaw chat"))
         #expect(actionsSource.contains("self.resetOnboarding()"))
         #expect(actionsSource.contains("self.gatewayController.trustRotatedGatewayCertificate(from: problem)"))
+        #expect(actionsSource.contains("GatewayProblemPrimaryAction.openProtocolMismatchHelpIfNeeded(problem)"))
         #expect(actionsSource.contains("await self.retryGatewayConnectionFromProblem()"))
 
         #expect(settingsSource.contains("GatewayProblemDetailsSheet("))

--- a/apps/ios/Tests/SwiftUIRenderSmokeTests.swift
+++ b/apps/ios/Tests/SwiftUIRenderSmokeTests.swift
@@ -42,6 +42,17 @@ import UIKit
         }
     }
 
+    @Test @MainActor func hostedPushRelayDisclosureBuildsAViewHierarchy() {
+        for typeSize in [DynamicTypeSize.large, .accessibility5] {
+            let root = HostedPushRelayDisclosureSheet(
+                message: "Enabling this sends delivery data through OpenClaw's hosted push relay.",
+                onContinue: {})
+                .environment(\.dynamicTypeSize, typeSize)
+
+            _ = Self.host(root, size: CGSize(width: 402, height: 450))
+        }
+    }
+
     @Test @MainActor func rootTabsBuildsDeviceOrientationShellMatrix() {
         for scenario in Self.rootTabsShellScenarios() {
             let appModel = NodeAppModel()

--- a/apps/ios/Tests/TalkGatewaySpeechClientTests.swift
+++ b/apps/ios/Tests/TalkGatewaySpeechClientTests.swift
@@ -1,0 +1,422 @@
+import AVFoundation
+import Foundation
+import OpenClawKit
+import OpenClawProtocol
+import Testing
+@testable import OpenClaw
+
+@MainActor
+private final class RecordingGatewaySpeechSynthesizer: TalkGatewaySpeechSynthesizing {
+    let audio: TalkGatewaySpeechAudio
+    private(set) var requests: [TalkGatewaySpeechRequest] = []
+
+    init(audio: TalkGatewaySpeechAudio) {
+        self.audio = audio
+    }
+
+    func synthesize(_ request: TalkGatewaySpeechRequest) async throws -> TalkGatewaySpeechAudio {
+        self.requests.append(request)
+        return self.audio
+    }
+}
+
+@MainActor
+private final class SuspendedGatewaySpeechSynthesizer: TalkGatewaySpeechSynthesizing {
+    private var continuation: CheckedContinuation<TalkGatewaySpeechAudio, Never>?
+
+    var hasPendingRequest: Bool {
+        self.continuation != nil
+    }
+
+    func synthesize(_: TalkGatewaySpeechRequest) async throws -> TalkGatewaySpeechAudio {
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func complete() {
+        self.continuation?.resume(returning: TalkGatewaySpeechAudio(
+            data: Data([1, 2, 3]),
+            provider: "xiaomi",
+            outputFormat: "mp3"))
+        self.continuation = nil
+    }
+}
+
+@MainActor
+private final class RecordingBufferedAudioPlayer: TalkBufferedAudioPlaying {
+    private(set) var payloads: [Data] = []
+
+    func play(data: Data) async -> StreamingPlaybackResult {
+        self.payloads.append(data)
+        return StreamingPlaybackResult(finished: true, interruptedAt: nil)
+    }
+
+    func stop() -> Double? {
+        nil
+    }
+}
+
+@MainActor
+private final class InterruptibleBufferedAudioPlayer: TalkBufferedAudioPlaying {
+    private var continuation: CheckedContinuation<StreamingPlaybackResult, Never>?
+
+    var isPlaying: Bool {
+        self.continuation != nil
+    }
+
+    func play(data _: Data) async -> StreamingPlaybackResult {
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func stop() -> Double? {
+        self.continuation?.resume(returning: StreamingPlaybackResult(
+            finished: false,
+            interruptedAt: 0))
+        self.continuation = nil
+        return 0
+    }
+}
+
+@MainActor
+struct TalkGatewaySpeechClientTests {
+    @Test func `forwards talk directives and decodes audio`() async throws {
+        let expectedAudio = Data([1, 2, 3])
+        var requestedMethod: String?
+        var requestedParams: TalkSpeakParams?
+        var requestedTimeout: Int?
+        let client = TalkGatewaySpeechClient { method, paramsJSON, timeoutSeconds in
+            requestedMethod = method
+            requestedTimeout = timeoutSeconds
+            requestedParams = try JSONDecoder().decode(
+                TalkSpeakParams.self,
+                from: Data((paramsJSON ?? "").utf8))
+            return try JSONEncoder().encode(TalkSpeakResult(
+                audiobase64: expectedAudio.base64EncodedString(),
+                provider: "xiaomi",
+                outputformat: "mp3",
+                voicecompatible: false,
+                mimetype: "audio/mpeg",
+                fileextension: ".mp3"))
+        }
+        let directive = TalkDirective(
+            voiceId: "mimo_default",
+            modelId: "mimo-v2.5-tts",
+            speed: 1.1,
+            language: "zh-CN",
+            outputFormat: "mp3")
+
+        let audio = try await client.synthesize(TalkGatewaySpeechRequest(
+            text: "hello",
+            voiceId: "resolved-voice",
+            modelId: "resolved-model",
+            outputFormat: "mp3",
+            directive: directive))
+
+        #expect(requestedMethod == "talk.speak")
+        #expect(requestedTimeout == 125)
+        #expect(requestedParams?.text == "hello")
+        #expect(requestedParams?.voiceid == "resolved-voice")
+        #expect(requestedParams?.modelid == "resolved-model")
+        #expect(requestedParams?.speed == 1.1)
+        #expect(requestedParams?.language == "zh-CN")
+        #expect(requestedParams?.outputformat == "mp3")
+        #expect(audio.data == expectedAudio)
+        #expect(audio.provider == "xiaomi")
+        #expect(audio.playbackMode == .buffered)
+    }
+
+    @Test func `resolves gateway audio playback metadata`() {
+        let pcm = TalkGatewaySpeechAudio(
+            data: Data([0, 1]),
+            provider: "elevenlabs",
+            outputFormat: "pcm_24000")
+        let mimeOnlyMP3 = TalkGatewaySpeechAudio(
+            data: Data([0, 1]),
+            provider: "xiaomi",
+            outputFormat: nil)
+        let wav = TalkGatewaySpeechAudio(
+            data: Data([0, 1]),
+            provider: "xiaomi",
+            outputFormat: "wav")
+        let rawPCM = TalkGatewaySpeechAudio(
+            data: Data([0, 1]),
+            provider: "xai",
+            outputFormat: "pcm")
+        let microsoftRawPCM = TalkGatewaySpeechAudio(
+            data: Data([0, 1]),
+            provider: "microsoft",
+            outputFormat: "raw-24khz-16bit-mono-pcm")
+        let rawULaw = TalkGatewaySpeechAudio(
+            data: Data([0, 1]),
+            provider: "microsoft",
+            outputFormat: "ulaw_8000")
+        let microsoftRIFF = TalkGatewaySpeechAudio(
+            data: Data([0, 1]),
+            provider: "microsoft",
+            outputFormat: "riff-24khz-16bit-mono-pcm")
+
+        #expect(pcm.playbackMode == .pcm(sampleRate: 24000))
+        #expect(mimeOnlyMP3.playbackMode == .buffered)
+        #expect(wav.playbackMode == .buffered)
+        #expect(rawPCM.playbackMode == .unsupportedRaw(codec: "pcm"))
+        #expect(microsoftRawPCM.playbackMode == .unsupportedRaw(codec: "raw-24khz-16bit-mono-pcm"))
+        #expect(rawULaw.playbackMode == .unsupportedRaw(codec: "ulaw_8000"))
+        #expect(microsoftRIFF.playbackMode == .buffered)
+    }
+
+    @Test func `gateway speech provider stays native and uses talk speak`() async {
+        let parsed = Self.parseSpeechProvider("xiaomi")
+        let routing = TalkModeRoutingResolver.resolve(
+            parsed: parsed,
+            providerSelection: .gatewayDefault,
+            defaultProvider: "elevenlabs",
+            defaultRealtimeModelId: "gpt-realtime-2")
+        #expect(routing.activeProvider == "xiaomi")
+        #expect(routing.executionMode == .native)
+        #expect(routing.route == .gatewayTalkSpeak)
+
+        let expectedAudio = Data([4, 5, 6])
+        let synthesizer = RecordingGatewaySpeechSynthesizer(audio: TalkGatewaySpeechAudio(
+            data: expectedAudio,
+            provider: "xiaomi",
+            outputFormat: "mp3"))
+        let audioPlayer = RecordingBufferedAudioPlayer()
+        let manager = TalkModeManager(
+            allowSimulatorCapture: true,
+            gatewaySpeechSynthesizer: synthesizer)
+        manager.bufferedPlayer = audioPlayer
+        manager._test_applyLoadedTalkConfig(parsed, providerSelection: .gatewayDefault)
+
+        #expect(manager._test_runtimeRoute() == .gatewayTalkSpeak)
+        #expect(manager._test_executionMode() == .native)
+        #expect(!manager.gatewayTalkUsesRealtime)
+        #expect(manager.gatewayTalkTransportLabel == "Native")
+
+        await manager._test_playAssistant(text: "Gateway voice")
+
+        #expect(synthesizer.requests.map(\.text) == ["Gateway voice"])
+        #expect(audioPlayer.payloads == [expectedAudio])
+    }
+
+    @Test func `persisted voice and model overrides reach later gateway requests`() async {
+        let parsed = Self.parseSpeechProvider("xiaomi")
+        let synthesizer = RecordingGatewaySpeechSynthesizer(audio: TalkGatewaySpeechAudio(
+            data: Data([4, 5, 6]),
+            provider: "xiaomi",
+            outputFormat: "mp3"))
+        let manager = TalkModeManager(
+            allowSimulatorCapture: true,
+            gatewaySpeechSynthesizer: synthesizer)
+        manager.bufferedPlayer = RecordingBufferedAudioPlayer()
+        manager._test_applyLoadedTalkConfig(parsed, providerSelection: .gatewayDefault)
+
+        await manager._test_playAssistant(text: "{\"voice\":\"alloy\",\"model\":\"expressive\"}\nFirst")
+        await manager._test_playAssistant(text: "Second")
+
+        #expect(synthesizer.requests.count == 2)
+        #expect(synthesizer.requests[1].voiceId == "alloy")
+        #expect(synthesizer.requests[1].modelId == "expressive")
+    }
+
+    @Test func `omitted gateway model does not send eleven labs fallback`() async {
+        let parsed = Self.parseSpeechProvider("openai", model: nil)
+        let synthesizer = RecordingGatewaySpeechSynthesizer(audio: TalkGatewaySpeechAudio(
+            data: Data([4, 5, 6]),
+            provider: "openai",
+            outputFormat: "mp3"))
+        let manager = TalkModeManager(
+            allowSimulatorCapture: true,
+            gatewaySpeechSynthesizer: synthesizer)
+        manager.bufferedPlayer = RecordingBufferedAudioPlayer()
+        manager._test_applyLoadedTalkConfig(parsed, providerSelection: .gatewayDefault)
+
+        await manager._test_playAssistant(text: "No model override")
+
+        #expect(synthesizer.requests.count == 1)
+        #expect(synthesizer.requests[0].modelId == nil)
+        #expect(manager.gatewayTalkDefaultModelId == nil)
+    }
+
+    @Test func `stopped talk does not play completed gateway synthesis`() async {
+        let parsed = Self.parseSpeechProvider("xiaomi")
+        let synthesizer = SuspendedGatewaySpeechSynthesizer()
+        let audioPlayer = RecordingBufferedAudioPlayer()
+        let manager = TalkModeManager(
+            allowSimulatorCapture: true,
+            gatewaySpeechSynthesizer: synthesizer)
+        manager.bufferedPlayer = audioPlayer
+        manager._test_applyLoadedTalkConfig(parsed, providerSelection: .gatewayDefault)
+
+        let playback = Task { await manager._test_playAssistant(text: "Delayed voice") }
+        while !synthesizer.hasPendingRequest {
+            await Task.yield()
+        }
+        manager.stop()
+        synthesizer.complete()
+        await playback.value
+
+        #expect(audioPlayer.payloads.isEmpty)
+    }
+
+    @Test func `stale buffered player callback does not finish replacement`() async throws {
+        let player = TalkBufferedAudioPlayer()
+        let wav = makeWav16Mono(sampleRate: 8000, samples: 8000)
+        let stalePlayer = try AVAudioPlayer(data: wav)
+        let stopAfterStaleCallback = Task { @MainActor in
+            player.audioPlayerDidFinishPlaying(stalePlayer, successfully: true)
+            return player.stop()
+        }
+
+        let result = await player.play(data: wav)
+        let interruptedAt = await stopAfterStaleCallback.value
+
+        #expect(interruptedAt != nil)
+        #expect(!result.finished)
+    }
+
+    @Test func `interrupted gateway playback stops speech recognition`() async {
+        let parsed = Self.parseSpeechProvider("xiaomi", interruptOnSpeech: true)
+        let synthesizer = RecordingGatewaySpeechSynthesizer(audio: TalkGatewaySpeechAudio(
+            data: Data([4, 5, 6]),
+            provider: "xiaomi",
+            outputFormat: "mp3"))
+        let audioPlayer = InterruptibleBufferedAudioPlayer()
+        let manager = TalkModeManager(
+            allowSimulatorCapture: true,
+            gatewaySpeechSynthesizer: synthesizer)
+        manager.bufferedPlayer = audioPlayer
+        manager._test_applyLoadedTalkConfig(parsed, providerSelection: .gatewayDefault)
+
+        let playback = Task { await manager._test_playAssistant(text: "Interrupt me") }
+        while !audioPlayer.isPlaying {
+            await Task.yield()
+        }
+        #expect(manager._test_hasRecognitionRequest())
+
+        manager._test_stopSpeaking(storeInterruption: false)
+        await playback.value
+
+        #expect(!manager._test_hasRecognitionRequest())
+        #expect(manager._test_lastInterruptedAtSeconds() == nil)
+    }
+
+    @Test func `open AI speech provider without realtime config uses talk speak`() {
+        let parsed = Self.parseSpeechProvider("openai")
+
+        let routing = TalkModeRoutingResolver.resolve(
+            parsed: parsed,
+            providerSelection: .gatewayDefault,
+            defaultProvider: "elevenlabs",
+            defaultRealtimeModelId: "gpt-realtime-2")
+
+        #expect(routing.activeProvider == "openai")
+        #expect(routing.executionMode == .native)
+        #expect(routing.route == .gatewayTalkSpeak)
+    }
+
+    @Test func `explicit realtime config keeps realtime relay`() {
+        let parsed = TalkModeGatewayConfigParser.parse(
+            config: [
+                "talk": [
+                    "provider": "openai",
+                    "providers": [
+                        "openai": [
+                            "mode": "realtime",
+                            "model": "gpt-realtime-2",
+                        ],
+                    ],
+                    "resolved": [
+                        "provider": "openai",
+                        "config": [
+                            "model": "gpt-realtime-2",
+                        ],
+                    ],
+                    "realtime": [
+                        "provider": "openai",
+                        "mode": "realtime",
+                        "transport": "gateway-relay",
+                        "model": "gpt-realtime-2",
+                    ],
+                ],
+            ],
+            defaultProvider: "elevenlabs",
+            defaultModelIdFallback: "eleven_v3",
+            defaultRealtimeModelIdFallback: "gpt-realtime-2",
+            defaultSilenceTimeoutMs: 900)
+
+        let routing = TalkModeRoutingResolver.resolve(
+            parsed: parsed,
+            providerSelection: .gatewayDefault,
+            defaultProvider: "elevenlabs",
+            defaultRealtimeModelId: "gpt-realtime-2")
+
+        #expect(routing.executionMode == .realtimeRelay)
+        #expect(routing.route == .realtimeRelay)
+        #expect(!routing.route.usesGatewayTalkSpeak)
+        #expect(routing.route.gatewayOwnsCredentials)
+    }
+
+    private static func parseSpeechProvider(
+        _ provider: String,
+        model: String? = "speech-model",
+        interruptOnSpeech: Bool = false) -> TalkModeGatewayConfigState
+    {
+        let providerConfig: [String: String] = model.map { ["model": $0] } ?? [:]
+        return TalkModeGatewayConfigParser.parse(
+            config: [
+                "talk": [
+                    "provider": provider,
+                    "providers": [provider: providerConfig],
+                    "resolved": [
+                        "provider": provider,
+                        "config": providerConfig,
+                    ],
+                    "interruptOnSpeech": interruptOnSpeech,
+                ],
+            ],
+            defaultProvider: "elevenlabs",
+            defaultModelIdFallback: "eleven_v3",
+            defaultRealtimeModelIdFallback: "gpt-realtime-2",
+            defaultSilenceTimeoutMs: 900)
+    }
+}
+
+private func makeWav16Mono(sampleRate: UInt32, samples: Int) -> Data {
+    let channels: UInt16 = 1
+    let bitsPerSample: UInt16 = 16
+    let blockAlign = channels * (bitsPerSample / 8)
+    let byteRate = sampleRate * UInt32(blockAlign)
+    let dataSize = UInt32(samples) * UInt32(blockAlign)
+
+    var data = Data()
+    data.append(contentsOf: [0x52, 0x49, 0x46, 0x46])
+    data.appendTestLEUInt32(36 + dataSize)
+    data.append(contentsOf: [0x57, 0x41, 0x56, 0x45])
+    data.append(contentsOf: [0x66, 0x6D, 0x74, 0x20])
+    data.appendTestLEUInt32(16)
+    data.appendTestLEUInt16(1)
+    data.appendTestLEUInt16(channels)
+    data.appendTestLEUInt32(sampleRate)
+    data.appendTestLEUInt32(byteRate)
+    data.appendTestLEUInt16(blockAlign)
+    data.appendTestLEUInt16(bitsPerSample)
+    data.append(contentsOf: [0x64, 0x61, 0x74, 0x61])
+    data.appendTestLEUInt32(dataSize)
+    data.append(Data(repeating: 0, count: Int(dataSize)))
+    return data
+}
+
+extension Data {
+    fileprivate mutating func appendTestLEUInt16(_ value: UInt16) {
+        var value = value.littleEndian
+        Swift.withUnsafeBytes(of: &value) { self.append(contentsOf: $0) }
+    }
+
+    fileprivate mutating func appendTestLEUInt32(_ value: UInt32) {
+        var value = value.littleEndian
+        Swift.withUnsafeBytes(of: &value) { self.append(contentsOf: $0) }
+    }
+}

--- a/apps/ios/UITests/OpenClawSnapshotUITests.swift
+++ b/apps/ios/UITests/OpenClawSnapshotUITests.swift
@@ -1,3 +1,4 @@
+import UIKit
 import XCTest
 
 @MainActor
@@ -20,20 +21,86 @@ final class OpenClawSnapshotUITests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        self.continueAfterFailure = false
+        continueAfterFailure = false
     }
 
     override func tearDownWithError() throws {
-        self.app?.terminate()
-        self.app = nil
+        app?.terminate()
+        app = nil
         try super.tearDownWithError()
     }
 
     func testConnectedGatewayTabs() {
         for target in Self.screenshotTargets {
-            self.launchApp(for: target)
+            launchApp(for: target)
             snapshot(target.name, timeWaitingForIdle: 5)
         }
+    }
+
+    func testControlOverviewNavigation() throws {
+        try XCTSkipIf(UIDevice.current.userInterfaceIdiom != .phone, "Phone control hub only")
+        launchApp(for: ScreenshotTarget(
+            initialTab: "control",
+            initialDestination: "control",
+            name: "control-overview-navigation"
+        ))
+
+        let overview = app?.buttons.containing(.staticText, identifier: "Overview").firstMatch
+        XCTAssertTrue(overview?.waitForExistence(timeout: 5) == true)
+        overview?.tap()
+
+        XCTAssertTrue(app?.buttons["Back to Control"].waitForExistence(timeout: 5) == true)
+        XCTAssertEqual(app?.state, .runningForeground)
+    }
+
+    func testLiveGatewayControlOverviewNavigation() throws {
+        try XCTSkipIf(UIDevice.current.userInterfaceIdiom != .phone, "Phone control hub only")
+        try XCTSkipUnless(
+            ProcessInfo.processInfo.environment["OPENCLAW_IOS_LIVE_GATEWAY"] == "1",
+            "Set OPENCLAW_IOS_LIVE_GATEWAY=1 and copy a fresh setup code to the simulator pasteboard"
+        )
+
+        let app = XCUIApplication()
+        addUIInterruptionMonitor(withDescription: "Local network access") { alert in
+            guard alert.buttons["Allow"].exists else { return false }
+            alert.buttons["Allow"].tap()
+            return true
+        }
+        app.launchArguments += [
+            "--openclaw-reset-onboarding",
+            "--openclaw-initial-tab",
+            "control",
+            "--openclaw-initial-destination",
+            "control",
+        ]
+        app.launch()
+        self.app = app
+
+        XCTAssertTrue(app.buttons["Continue"].waitForExistence(timeout: 8))
+        app.buttons["Continue"].tap()
+        app.tap()
+        XCTAssertTrue(app.buttons["Set Up Manually"].waitForExistence(timeout: 8))
+        app.buttons["Set Up Manually"].tap()
+
+        let setupCodeField = app.textFields["Paste setup code"]
+        XCTAssertTrue(setupCodeField.waitForExistence(timeout: 5))
+        setupCodeField.tap()
+        setupCodeField.press(forDuration: 1)
+        XCTAssertTrue(app.menuItems["Paste"].waitForExistence(timeout: 3))
+        app.menuItems["Paste"].tap()
+        app.buttons["Done"].tap()
+        app.buttons["Apply Setup Code"].tap()
+
+        XCTAssertTrue(app.staticTexts["Connected"].waitForExistence(timeout: 45))
+        app.buttons["Open OpenClaw"].tap()
+
+        let overview = app.buttons.containing(.staticText, identifier: "Overview").firstMatch
+        XCTAssertTrue(overview.waitForExistence(timeout: 8))
+        attachScreenshot(named: "live-gateway-control")
+        overview.tap()
+        XCTAssertTrue(app.buttons["Back to Control"].waitForExistence(timeout: 8))
+        attachScreenshot(named: "live-gateway-overview")
+        XCTAssertEqual(app.state, .runningForeground)
     }
 
     private func launchApp(for target: ScreenshotTarget) {
@@ -54,5 +121,13 @@ final class OpenClawSnapshotUITests: XCTestCase {
         self.app = app
 
         XCTAssertTrue(app.wait(for: .runningForeground, timeout: 8))
+    }
+
+    private func attachScreenshot(named name: String) {
+        guard let app = app else { return }
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = name
+        attachment.lifetime = .keepAlways
+        add(attachment)
     }
 }

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
@@ -173,6 +173,29 @@ private func gatewayErrorDetails(_ error: ErrorShape?) -> [String: ProtoAnyCodab
     return details
 }
 
+private func gatewayIntValue(_ value: Any?) -> Int? {
+    if let value = value as? Int {
+        return value
+    }
+    if let value = value as? Int64 {
+        return Int(exactly: value)
+    }
+    if let value = value as? Double, value.rounded() == value {
+        return Int(exactly: value)
+    }
+    if let value = value as? NSNumber, CFGetTypeID(value) != CFBooleanGetTypeID() {
+        let doubleValue = value.doubleValue
+        guard doubleValue.rounded() == doubleValue else {
+            return nil
+        }
+        return Int(exactly: doubleValue)
+    }
+    if let value = value as? String {
+        return Int(value.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+    return nil
+}
+
 private enum ConnectChallengeError: Error {
     case timeout
 }
@@ -834,6 +857,10 @@ public actor GatewayChannelActor {
             let docsURLString = details["docsUrl"]?.value as? String
             let retryableOverride = details["retryable"]?.value as? Bool
             let pauseReconnectOverride = details["pauseReconnect"]?.value as? Bool
+            let clientMinProtocol = gatewayIntValue(details["clientMinProtocol"]?.value)
+            let clientMaxProtocol = gatewayIntValue(details["clientMaxProtocol"]?.value)
+            let expectedProtocol = gatewayIntValue(details["expectedProtocol"]?.value)
+            let minimumProbeProtocol = gatewayIntValue(details["minimumProbeProtocol"]?.value)
             throw GatewayConnectAuthError(
                 message: msg,
                 detailCodeRaw: detailCode,
@@ -848,7 +875,11 @@ public actor GatewayChannelActor {
                 actionCommand: actionCommand,
                 docsURLString: docsURLString,
                 retryableOverride: retryableOverride,
-                pauseReconnectOverride: pauseReconnectOverride)
+                pauseReconnectOverride: pauseReconnectOverride,
+                clientMinProtocol: clientMinProtocol,
+                clientMaxProtocol: clientMaxProtocol,
+                expectedProtocol: expectedProtocol,
+                minimumProbeProtocol: minimumProbeProtocol)
         }
         guard let payload = res.payload else {
             throw NSError(

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayConnectionProblem.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayConnectionProblem.swift
@@ -15,6 +15,7 @@ public struct GatewayConnectionProblem: Equatable, Sendable {
         case pairingRoleUpgradeRequired
         case pairingScopeUpgradeRequired
         case pairingMetadataUpgradeRequired
+        case protocolMismatch
         case deviceIdentityRequired
         case deviceSignatureExpired
         case deviceNonceRequired
@@ -128,7 +129,7 @@ public struct GatewayConnectionProblem: Equatable, Sendable {
     public var statusText: String {
         switch self.kind {
         case .pairingRequired, .pairingRoleUpgradeRequired, .pairingScopeUpgradeRequired,
-             .pairingMetadataUpgradeRequired:
+             .pairingMetadataUpgradeRequired, .protocolMismatch:
             if let requestId {
                 return "\(self.title) (request ID: \(requestId))"
             }
@@ -348,6 +349,8 @@ public enum GatewayConnectionProblemMapper {
                 authError: authError)
         case .pairingRequired:
             return self.pairingProblem(for: authError)
+        case .protocolMismatch:
+            return self.protocolMismatchProblem(for: authError)
         case .controlUiDeviceIdentityRequired, .deviceIdentityRequired:
             return self.problem(
                 kind: .deviceIdentityRequired,
@@ -799,6 +802,52 @@ public enum GatewayConnectionProblemMapper {
         }
     }
 
+    private static func protocolMismatchProblem(for authError: GatewayConnectAuthError) -> GatewayConnectionProblem {
+        let title: String
+        let message: String
+        let owner: GatewayConnectionProblem.Owner
+        let actionLabel: String
+        if let clientMax = authError.clientMaxProtocol,
+           let expected = authError.expectedProtocol,
+           clientMax < expected
+        {
+            title = authError.titleOverride ?? "App update required"
+            message = authError.userMessageOverride
+                ?? "This app is older than the gateway. Update OpenClaw on this device, then retry."
+            owner = .iphone
+            actionLabel = authError.actionLabel ?? "Update app"
+        } else if let clientMin = authError.clientMinProtocol,
+                  let expected = authError.expectedProtocol,
+                  clientMin > expected
+        {
+            title = authError.titleOverride ?? "Gateway update required"
+            message = authError.userMessageOverride
+                ?? "The gateway is older than this app. Update OpenClaw on the gateway host, then retry."
+            owner = .gateway
+            actionLabel = authError.actionLabel ?? "Update gateway"
+        } else {
+            title = authError.titleOverride ?? "OpenClaw update required"
+            message = authError.userMessageOverride
+                ?? "The app and gateway use incompatible protocol versions. Update OpenClaw on both, then retry."
+            owner = .both
+            actionLabel = authError.actionLabel ?? "Update OpenClaw"
+        }
+        return self.problem(
+            kind: .protocolMismatch,
+            owner: owner,
+            title: title,
+            message: message,
+            actionLabel: actionLabel,
+            actionCommand: authError.actionCommand,
+            docsURL: self.docsURL(
+                authError.docsURLString,
+                fallback: "https://docs.openclaw.ai/gateway/troubleshooting"),
+            requestId: authError.requestId,
+            retryable: false,
+            pauseReconnect: true,
+            authError: authError)
+    }
+
     private static func problem(
         kind: GatewayConnectionProblem.Kind,
         owner: GatewayConnectionProblem.Owner,
@@ -851,7 +900,31 @@ public enum GatewayConnectionProblemMapper {
         if authError.canRetryWithDeviceToken {
             parts.append("deviceTokenRetry=true")
         }
+        if let clientRange = self.protocolRange(min: authError.clientMinProtocol, max: authError.clientMaxProtocol) {
+            parts.append("clientProtocol=\(clientRange)")
+        }
+        if let expected = authError.expectedProtocol {
+            parts.append("gatewayProtocol=\(expected)")
+        }
+        if let minimumProbe = authError.minimumProbeProtocol {
+            parts.append("probeMin=\(minimumProbe)")
+        }
         return parts.isEmpty ? nil : parts.joined(separator: " · ")
+    }
+
+    private static func protocolRange(min: Int?, max: Int?) -> String? {
+        switch (min, max) {
+        case (nil, nil):
+            nil
+        case let (min?, max?) where min == max:
+            "\(min)"
+        case let (min?, max?):
+            "\(min)-\(max)"
+        case let (min?, nil):
+            "min \(min)"
+        case let (nil, max?):
+            "max \(max)"
+        }
     }
 
     private static func docsURL(_ preferred: String?, fallback: String?) -> URL? {

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayErrors.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayErrors.swift
@@ -19,6 +19,7 @@ public enum GatewayConnectAuthDetailCode: String, Sendable {
     case authTailscaleWhoisFailed = "AUTH_TAILSCALE_WHOIS_FAILED"
     case authTailscaleIdentityMismatch = "AUTH_TAILSCALE_IDENTITY_MISMATCH"
     case pairingRequired = "PAIRING_REQUIRED"
+    case protocolMismatch = "PROTOCOL_MISMATCH"
     case controlUiDeviceIdentityRequired = "CONTROL_UI_DEVICE_IDENTITY_REQUIRED"
     case deviceIdentityRequired = "DEVICE_IDENTITY_REQUIRED"
     case deviceAuthInvalid = "DEVICE_AUTH_INVALID"
@@ -54,6 +55,10 @@ public struct GatewayConnectAuthError: LocalizedError, Sendable {
     public let docsURLString: String?
     public let retryableOverride: Bool?
     public let pauseReconnectOverride: Bool?
+    public let clientMinProtocol: Int?
+    public let clientMaxProtocol: Int?
+    public let expectedProtocol: Int?
+    public let minimumProbeProtocol: Int?
 
     public init(
         message: String,
@@ -69,7 +74,11 @@ public struct GatewayConnectAuthError: LocalizedError, Sendable {
         actionCommand: String? = nil,
         docsURLString: String? = nil,
         retryableOverride: Bool? = nil,
-        pauseReconnectOverride: Bool? = nil)
+        pauseReconnectOverride: Bool? = nil,
+        clientMinProtocol: Int? = nil,
+        clientMaxProtocol: Int? = nil,
+        expectedProtocol: Int? = nil,
+        minimumProbeProtocol: Int? = nil)
     {
         let trimmedMessage = message.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedDetailCode = detailCodeRaw?.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -90,6 +99,10 @@ public struct GatewayConnectAuthError: LocalizedError, Sendable {
         self.docsURLString = Self.trimmedOrNil(docsURLString)
         self.retryableOverride = retryableOverride
         self.pauseReconnectOverride = pauseReconnectOverride
+        self.clientMinProtocol = clientMinProtocol
+        self.clientMaxProtocol = clientMaxProtocol
+        self.expectedProtocol = expectedProtocol
+        self.minimumProbeProtocol = minimumProbeProtocol
     }
 
     public init(
@@ -106,7 +119,11 @@ public struct GatewayConnectAuthError: LocalizedError, Sendable {
         actionCommand: String? = nil,
         docsURLString: String? = nil,
         retryableOverride: Bool? = nil,
-        pauseReconnectOverride: Bool? = nil)
+        pauseReconnectOverride: Bool? = nil,
+        clientMinProtocol: Int? = nil,
+        clientMaxProtocol: Int? = nil,
+        expectedProtocol: Int? = nil,
+        minimumProbeProtocol: Int? = nil)
     {
         self.init(
             message: message,
@@ -122,7 +139,11 @@ public struct GatewayConnectAuthError: LocalizedError, Sendable {
             actionCommand: actionCommand,
             docsURLString: docsURLString,
             retryableOverride: retryableOverride,
-            pauseReconnectOverride: pauseReconnectOverride)
+            pauseReconnectOverride: pauseReconnectOverride,
+            clientMinProtocol: clientMinProtocol,
+            clientMaxProtocol: clientMaxProtocol,
+            expectedProtocol: expectedProtocol,
+            minimumProbeProtocol: minimumProbeProtocol)
     }
 
     private static func trimmedOrNil(_ value: String?) -> String? {
@@ -163,6 +184,7 @@ public struct GatewayConnectAuthError: LocalizedError, Sendable {
              .authRateLimited,
              .authScopeMismatch,
              .pairingRequired,
+             .protocolMismatch,
              .controlUiDeviceIdentityRequired,
              .deviceIdentityRequired:
             true

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayErrorsTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayErrorsTests.swift
@@ -2,8 +2,8 @@ import Foundation
 import OpenClawKit
 import Testing
 
-@Suite struct GatewayErrorsTests {
-    @Test func bootstrapTokenInvalidIsNonRecoverable() {
+struct GatewayErrorsTests {
+    @Test func `bootstrap token invalid is non recoverable`() {
         let error = GatewayConnectAuthError(
             message: "setup code expired",
             detailCode: GatewayConnectAuthDetailCode.authBootstrapTokenInvalid.rawValue,
@@ -13,7 +13,7 @@ import Testing
         #expect(error.detail == .authBootstrapTokenInvalid)
     }
 
-    @Test func connectAuthErrorPreservesStructuredMetadata() {
+    @Test func `connect auth error preserves structured metadata`() {
         let error = GatewayConnectAuthError(
             message: "pairing required",
             detailCode: GatewayConnectAuthDetailCode.pairingRequired.rawValue,
@@ -28,7 +28,11 @@ import Testing
             actionCommand: "openclaw devices approve req-123",
             docsURLString: "https://docs.openclaw.ai/gateway/pairing",
             retryableOverride: false,
-            pauseReconnectOverride: true)
+            pauseReconnectOverride: true,
+            clientMinProtocol: 4,
+            clientMaxProtocol: 4,
+            expectedProtocol: 5,
+            minimumProbeProtocol: 4)
 
         #expect(error.requestId == "req-123")
         #expect(error.detailsReason == "scope-upgrade")
@@ -37,9 +41,74 @@ import Testing
         #expect(error.actionCommand == "openclaw devices approve req-123")
         #expect(error.docsURLString == "https://docs.openclaw.ai/gateway/pairing")
         #expect(error.pauseReconnectOverride == true)
+        #expect(error.clientMinProtocol == 4)
+        #expect(error.clientMaxProtocol == 4)
+        #expect(error.expectedProtocol == 5)
+        #expect(error.minimumProbeProtocol == 4)
     }
 
-    @Test func pairingProblemUsesStructuredRequestMetadata() {
+    @Test func `protocol mismatch maps older app to update problem`() {
+        let error = GatewayConnectAuthError(
+            message: "protocol mismatch",
+            detailCode: GatewayConnectAuthDetailCode.protocolMismatch.rawValue,
+            canRetryWithDeviceToken: false,
+            clientMinProtocol: 4,
+            clientMaxProtocol: 4,
+            expectedProtocol: 5,
+            minimumProbeProtocol: 4)
+
+        let problem = GatewayConnectionProblemMapper.map(error: error)
+
+        #expect(error.detail == .protocolMismatch)
+        #expect(error.isNonRecoverable)
+        #expect(problem?.kind == .protocolMismatch)
+        #expect(problem?.owner == .iphone)
+        #expect(problem?.title == "App update required")
+        #expect(problem?.message == "This app is older than the gateway. Update OpenClaw on this device, then retry.")
+        #expect(problem?.retryable == false)
+        #expect(problem?.pauseReconnect == true)
+        #expect(problem?.technicalDetails?.contains("clientProtocol=4") == true)
+        #expect(problem?.technicalDetails?.contains("gatewayProtocol=5") == true)
+    }
+
+    @Test func `protocol mismatch maps older gateway to update problem`() {
+        let error = GatewayConnectAuthError(
+            message: "protocol mismatch",
+            detailCode: GatewayConnectAuthDetailCode.protocolMismatch.rawValue,
+            canRetryWithDeviceToken: false,
+            clientMinProtocol: 4,
+            clientMaxProtocol: 4,
+            expectedProtocol: 3,
+            minimumProbeProtocol: 3)
+
+        let problem = GatewayConnectionProblemMapper.map(error: error)
+
+        #expect(problem?.kind == .protocolMismatch)
+        #expect(problem?.owner == .gateway)
+        #expect(problem?.title == "Gateway update required")
+        #expect(problem?
+            .message == "The gateway is older than this app. Update OpenClaw on the gateway host, then retry.")
+        #expect(problem?.retryable == false)
+        #expect(problem?.pauseReconnect == true)
+    }
+
+    @Test func `protocol mismatch without versions still gives actionable fallback`() {
+        let error = GatewayConnectAuthError(
+            message: "protocol mismatch",
+            detailCode: GatewayConnectAuthDetailCode.protocolMismatch.rawValue,
+            canRetryWithDeviceToken: false)
+
+        let problem = GatewayConnectionProblemMapper.map(error: error)
+
+        #expect(problem?.kind == .protocolMismatch)
+        #expect(problem?.owner == .both)
+        #expect(problem?
+            .message == "The app and gateway use incompatible protocol versions. Update OpenClaw on both, then retry.")
+        #expect(problem?.retryable == false)
+        #expect(problem?.pauseReconnect == true)
+    }
+
+    @Test func `pairing problem uses structured request metadata`() {
         let error = GatewayConnectAuthError(
             message: "pairing required",
             detailCode: GatewayConnectAuthDetailCode.pairingRequired.rawValue,
@@ -55,7 +124,7 @@ import Testing
         #expect(problem?.actionCommand == "openclaw devices approve req-123")
     }
 
-    @Test func scopeMismatchMapsToPairingOrRepairProblem() {
+    @Test func `scope mismatch maps to pairing or repair problem`() {
         let error = GatewayConnectAuthError(
             message: "device token scope mismatch",
             detailCode: GatewayConnectAuthDetailCode.authScopeMismatch.rawValue,
@@ -70,7 +139,7 @@ import Testing
         #expect(problem?.needsCredentialUpdate == false)
     }
 
-    @Test func tokenMismatchSuggestsOnboardingReset() {
+    @Test func `token mismatch suggests onboarding reset`() {
         let error = GatewayConnectAuthError(
             message: "token mismatch",
             detailCode: GatewayConnectAuthDetailCode.authTokenMismatch.rawValue,
@@ -83,7 +152,7 @@ import Testing
         #expect(problem?.needsCredentialUpdate == true)
     }
 
-    @Test func cancelledTransportDoesNotReplaceStructuredPairingProblem() {
+    @Test func `cancelled transport does not replace structured pairing problem`() {
         let pairing = GatewayConnectAuthError(
             message: "pairing required",
             detailCode: GatewayConnectAuthDetailCode.pairingRequired.rawValue,
@@ -101,7 +170,7 @@ import Testing
         #expect(preserved?.requestId == "req-123")
     }
 
-    @Test func unmappedTransportErrorClearsStaleStructuredProblem() {
+    @Test func `unmapped transport error clears stale structured problem`() {
         let pairing = GatewayConnectAuthError(
             message: "pairing required",
             detailCode: GatewayConnectAuthDetailCode.pairingRequired.rawValue,
@@ -118,7 +187,7 @@ import Testing
         #expect(mapped == nil)
     }
 
-    @Test func tlsPinMismatchMapsToActionableProblem() {
+    @Test func `tls pin mismatch maps to actionable problem`() {
         let error = GatewayTLSValidationError(
             failure: GatewayTLSValidationFailure(
                 kind: .pinMismatch,
@@ -141,7 +210,7 @@ import Testing
         #expect(problem?.tlsObservedFingerprint == "new")
     }
 
-    @Test func untrustedTLSCertificatePausesReconnect() {
+    @Test func `untrusted TLS certificate pauses reconnect`() {
         let error = GatewayTLSValidationError(
             failure: GatewayTLSValidationFailure(
                 kind: .untrustedCertificate,
@@ -159,7 +228,7 @@ import Testing
         #expect(problem?.pauseReconnect == true)
     }
 
-    @Test func untrustedTLSMismatchCannotBeRecoveredInApp() {
+    @Test func `untrusted TLS mismatch cannot be recovered in app`() {
         let error = GatewayTLSValidationError(
             failure: GatewayTLSValidationFailure(
                 kind: .pinMismatch,

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
@@ -52,6 +52,7 @@ private final class DoubleCallbackPingWebSocketTask: WebSocketTasking, @unchecke
 private final class FakeGatewayWebSocketTask: WebSocketTasking, @unchecked Sendable {
     private let lock = NSLock()
     private let helloAuth: [String: Any]?
+    private let connectError: [String: Any]?
     private var _state: URLSessionTask.State = .suspended
     private var connectRequestId: String?
     private var connectAuth: [String: Any]?
@@ -60,8 +61,9 @@ private final class FakeGatewayWebSocketTask: WebSocketTasking, @unchecked Senda
     private var pendingReceiveHandler:
         (@Sendable (Result<URLSessionWebSocketTask.Message, Error>) -> Void)?
 
-    init(helloAuth: [String: Any]? = nil) {
+    init(helloAuth: [String: Any]? = nil, connectError: [String: Any]? = nil) {
         self.helloAuth = helloAuth
+        self.connectError = connectError
     }
 
     var state: URLSessionTask.State {
@@ -133,9 +135,15 @@ private final class FakeGatewayWebSocketTask: WebSocketTasking, @unchecked Senda
         for _ in 0..<50 {
             let id = self.lock.withLock { self.connectRequestId }
             if let id {
+                if let connectError {
+                    return .data(Self.connectErrorData(id: id, error: connectError))
+                }
                 return .data(Self.connectOkData(id: id, auth: self.helloAuth))
             }
             try await Task.sleep(nanoseconds: 1_000_000)
+        }
+        if let connectError {
+            return .data(Self.connectErrorData(id: "connect", error: connectError))
         }
         return .data(Self.connectOkData(id: "connect", auth: self.helloAuth))
     }
@@ -206,16 +214,28 @@ private final class FakeGatewayWebSocketTask: WebSocketTasking, @unchecked Senda
         ]
         return (try? JSONSerialization.data(withJSONObject: frame)) ?? Data()
     }
+
+    private static func connectErrorData(id: String, error: [String: Any]) -> Data {
+        let frame: [String: Any] = [
+            "type": "res",
+            "id": id,
+            "ok": false,
+            "error": error,
+        ]
+        return (try? JSONSerialization.data(withJSONObject: frame)) ?? Data()
+    }
 }
 
 private final class FakeGatewayWebSocketSession: WebSocketSessioning, @unchecked Sendable {
     private let lock = NSLock()
     private let helloAuth: [String: Any]?
+    private let connectError: [String: Any]?
     private var tasks: [FakeGatewayWebSocketTask] = []
     private var makeCount = 0
 
-    init(helloAuth: [String: Any]? = nil) {
+    init(helloAuth: [String: Any]? = nil, connectError: [String: Any]? = nil) {
         self.helloAuth = helloAuth
+        self.connectError = connectError
     }
 
     func snapshotMakeCount() -> Int {
@@ -230,7 +250,7 @@ private final class FakeGatewayWebSocketSession: WebSocketSessioning, @unchecked
         _ = url
         return self.lock.withLock {
             self.makeCount += 1
-            let task = FakeGatewayWebSocketTask(helloAuth: self.helloAuth)
+            let task = FakeGatewayWebSocketTask(helloAuth: self.helloAuth, connectError: self.connectError)
             self.tasks.append(task)
             return WebSocketTaskBox(task: task)
         }
@@ -424,6 +444,66 @@ struct GatewayNodeSessionTests {
         #expect(auth["password"] as? String == "shared-password")
         #expect(auth["bootstrapToken"] == nil)
         #expect(auth["token"] == nil)
+
+        await gateway.disconnect()
+    }
+
+    @Test
+    func `connect failure preserves protocol mismatch details`() async throws {
+        let session = FakeGatewayWebSocketSession(connectError: [
+            "code": "INVALID_REQUEST",
+            "message": "protocol mismatch",
+            "details": [
+                "code": "PROTOCOL_MISMATCH",
+                "clientMinProtocol": 4,
+                "clientMaxProtocol": 4,
+                "expectedProtocol": 5,
+                "minimumProbeProtocol": 4,
+            ],
+        ])
+        let gateway = GatewayNodeSession()
+        let options = GatewayConnectOptions(
+            role: "operator",
+            scopes: ["operator.read"],
+            caps: [],
+            commands: [],
+            permissions: [:],
+            clientId: "openclaw-ios-test",
+            clientMode: "ui",
+            clientDisplayName: "iOS Test",
+            includeDeviceIdentity: false)
+
+        do {
+            try await gateway.connect(
+                url: #require(URL(string: "ws://example.invalid")),
+                token: "shared-token",
+                bootstrapToken: nil,
+                password: nil,
+                connectOptions: options,
+                sessionBox: WebSocketSessionBox(session: session),
+                onConnected: {},
+                onDisconnected: { _ in },
+                onInvoke: { req in
+                    BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil)
+                })
+            Issue.record("connect unexpectedly succeeded")
+        } catch let error as GatewayConnectAuthError {
+            #expect(error.detail == .protocolMismatch)
+            #expect(error.clientMinProtocol == 4)
+            #expect(error.clientMaxProtocol == 4)
+            #expect(error.expectedProtocol == 5)
+            #expect(error.minimumProbeProtocol == 4)
+
+            let problem = GatewayConnectionProblemMapper.map(error: error)
+            #expect(problem?.kind == .protocolMismatch)
+            #expect(problem?.owner == .iphone)
+            #expect(problem?
+                .message == "This app is older than the gateway. Update OpenClaw on this device, then retry.")
+            #expect(problem?.pauseReconnect == true)
+            #expect(problem?.retryable == false)
+        } catch {
+            Issue.record("unexpected error type: \(error)")
+        }
 
         await gateway.disconnect()
     }

--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -229,7 +229,7 @@ openclaw gateway stability --json
 
 <AccordionGroup>
   <Accordion title="Privacy and bundle behavior">
-    - Records keep operational metadata: event names, counts, byte sizes, memory readings, queue/session state, channel/plugin names, and redacted session summaries. They do not keep chat text, webhook bodies, tool outputs, raw request or response bodies, tokens, cookies, secret values, hostnames, or raw session ids. Set `diagnostics.enabled: false` to disable the recorder entirely.
+    - Records keep operational metadata: event names, counts, byte sizes, memory readings, queue/session state, approval ids, channel/plugin names, and redacted session summaries. They do not keep chat text, webhook bodies, tool outputs, raw request or response bodies, tokens, cookies, secret values, hostnames, or raw session ids. Set `diagnostics.enabled: false` to disable the recorder entirely.
     - On fatal Gateway exits, shutdown timeouts, and restart startup failures, OpenClaw writes the same diagnostic snapshot to `~/.openclaw/logs/stability/openclaw-stability-*.json` when the recorder has events. Inspect the newest bundle with `openclaw gateway stability --bundle latest`; `--limit`, `--type`, and `--since-seq` also apply to bundle output.
 
   </Accordion>

--- a/docs/gateway/opentelemetry.md
+++ b/docs/gateway/opentelemetry.md
@@ -412,6 +412,10 @@ to them directly without OTLP export.
 - `exec.process.completed` - terminal outcome, duration, target, mode, exit
   code, and failure kind. Command text and working directories are not
   included.
+- `exec.approval.followup_suppressed` - stale approval follow-up dropped after
+  a session rebound. Includes `approvalId`, `reason` (`session_rebound`),
+  `phase` (`direct_delivery` or `gateway_preflight`), and the dispatcher
+  timestamp. Session keys, routes, and command text are not included.
 
 ## Without an exporter
 

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -3823,6 +3823,8 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
             case "exec.process.completed":
               recordExecProcessCompleted(evt);
               return;
+            case "exec.approval.followup_suppressed":
+              return;
             case "log.record":
               recordLogRecord?.(evt, metadata);
               return;

--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -127,7 +127,7 @@ const defaultPublicDeprecatedExportsByEntrypointBudget = Object.freeze({
   "outbound-send-deps": 4,
   "outbound-runtime": 16,
   "file-access-runtime": 2,
-  "infra-runtime": 584,
+  "infra-runtime": 585,
   "ssrf-policy": 1,
   "ssrf-runtime": 1,
   "media-runtime": 2,
@@ -202,11 +202,11 @@ let publicDeprecatedExportsByEntrypointBudget;
 try {
   budgets = {
     publicEntrypoints: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_ENTRYPOINTS", 322),
-    publicExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS", 10401),
+    publicExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_EXPORTS", 10402),
     publicFunctionExports: readBudgetEnv("OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_FUNCTION_EXPORTS", 5220),
     publicDeprecatedExports: readBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_DEPRECATED_EXPORTS",
-      3260,
+      3261,
     ),
     publicWildcardReexports: readBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_WILDCARD_REEXPORTS",

--- a/src/agents/bash-tools.exec-approval-followup.test.ts
+++ b/src/agents/bash-tools.exec-approval-followup.test.ts
@@ -18,6 +18,12 @@ import os from "node:os";
 import path from "node:path";
 import { clearSessionStoreCacheForTest } from "../config/sessions/store.js";
 import { writeSessionStoreForTest } from "../config/sessions/test-helpers.js";
+import {
+  onDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+  waitForDiagnosticEventsDrained,
+  type DiagnosticEventPayload,
+} from "../infra/diagnostic-events.js";
 import { sendMessage } from "../infra/outbound/message.js";
 import {
   buildExecApprovalFollowupPrompt,
@@ -39,6 +45,7 @@ function writeTempSessionStore(entries: Record<string, { sessionId: string }>): 
 
 afterEach(() => {
   vi.resetAllMocks();
+  resetDiagnosticEventsForTest();
   clearSessionStoreCacheForTest();
   while (tempStoreDirs.length > 0) {
     const dir = tempStoreDirs.pop();
@@ -171,6 +178,10 @@ describe("exec approval followup", () => {
     const sessionStore = writeTempSessionStore({
       "agent:main:main": { sessionId: "session-after-reset" },
     });
+    const diagnostics: DiagnosticEventPayload[] = [];
+    onDiagnosticEvent((event) => {
+      diagnostics.push(event);
+    });
 
     const result = await sendExecApprovalFollowup({
       approvalId: "req-denied-rebound",
@@ -184,6 +195,15 @@ describe("exec approval followup", () => {
     });
 
     expect(result).toBe(false);
+    await waitForDiagnosticEventsDrained();
+    expect(diagnostics).toContainEqual(
+      expect.objectContaining({
+        type: "exec.approval.followup_suppressed",
+        approvalId: "req-denied-rebound",
+        reason: "session_rebound",
+        phase: "direct_delivery",
+      }),
+    );
     expect(sendMessage).not.toHaveBeenCalled();
     expect(callGatewayTool).not.toHaveBeenCalled();
   });
@@ -212,6 +232,10 @@ describe("exec approval followup", () => {
     const sessionStore = writeTempSessionStore({
       "agent:main:main": { sessionId: "session-after-reset" },
     });
+    const diagnostics: DiagnosticEventPayload[] = [];
+    onDiagnosticEvent((event) => {
+      diagnostics.push(event);
+    });
 
     const result = await sendExecApprovalFollowup({
       approvalId: "req-finished-rebound",
@@ -225,6 +249,15 @@ describe("exec approval followup", () => {
     });
 
     expect(result).toBe(false);
+    await waitForDiagnosticEventsDrained();
+    expect(diagnostics).toContainEqual(
+      expect.objectContaining({
+        type: "exec.approval.followup_suppressed",
+        approvalId: "req-finished-rebound",
+        reason: "session_rebound",
+        phase: "direct_delivery",
+      }),
+    );
     expect(sendMessage).not.toHaveBeenCalled();
     expect(callGatewayTool).not.toHaveBeenCalled();
   });

--- a/src/agents/bash-tools.exec-approval-followup.ts
+++ b/src/agents/bash-tools.exec-approval-followup.ts
@@ -9,6 +9,7 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import { resolveStorePath } from "../config/sessions/paths.js";
 import { loadSessionStore } from "../config/sessions/store-load.js";
+import { emitDiagnosticEvent } from "../infra/diagnostic-events.js";
 import {
   resolveExternalBestEffortDeliveryTarget,
   type ExternalBestEffortDeliveryTarget,
@@ -394,6 +395,12 @@ export async function sendExecApprovalFollowup(
         sessionStore: params.sessionStore,
       })
     ) {
+      emitDiagnosticEvent({
+        type: "exec.approval.followup_suppressed",
+        approvalId: params.approvalId,
+        reason: "session_rebound",
+        phase: "direct_delivery",
+      });
       log.info(
         `Dropping stale denied exec approval followup ${params.approvalId}: session ${sessionKey ?? ""} was rebound before the approval resolved`,
       );
@@ -423,6 +430,12 @@ export async function sendExecApprovalFollowup(
       sessionStore: params.sessionStore,
     })
   ) {
+    emitDiagnosticEvent({
+      type: "exec.approval.followup_suppressed",
+      approvalId: params.approvalId,
+      reason: "session_rebound",
+      phase: "direct_delivery",
+    });
     log.info(
       `Dropping stale exec approval followup ${params.approvalId} direct fallback: session ${sessionKey ?? ""} was rebound before the approval resolved`,
     );

--- a/src/agents/bash-tools.exec-host-shared.test.ts
+++ b/src/agents/bash-tools.exec-host-shared.test.ts
@@ -167,6 +167,39 @@ describe("sendExecApprovalFollowupResult", () => {
     );
   });
 
+  it.each([
+    {
+      name: "direct gateway code",
+      error: Object.assign(new Error("approval not found"), {
+        gatewayCode: "APPROVAL_NOT_FOUND",
+      }),
+    },
+    {
+      name: "structured invalid-request details",
+      error: Object.assign(new Error("approval not found"), {
+        gatewayCode: "INVALID_REQUEST",
+        details: { reason: "APPROVAL_NOT_FOUND" },
+      }),
+    },
+    {
+      name: "legacy message-only error",
+      error: new Error("unknown or expired approval id"),
+    },
+  ])("suppresses approval-not-found followup dispatch failures ($name)", async ({ error }) => {
+    sendExecApprovalFollowup.mockRejectedValue(error);
+
+    await sendExecApprovalFollowupResult(
+      {
+        approvalId: "approval-expired",
+        sessionKey: "agent:main:main",
+      },
+      "Exec finished",
+      { sendExecApprovalFollowup, logWarn },
+    );
+
+    expect(logWarn).not.toHaveBeenCalled();
+  });
+
   it("evicts oldest followup failure dedupe keys after reaching the cap", async () => {
     sendExecApprovalFollowup.mockRejectedValue(new Error("Channel is required"));
     const deps = { sendExecApprovalFollowup, logWarn };

--- a/src/agents/bash-tools.exec-host-shared.ts
+++ b/src/agents/bash-tools.exec-host-shared.ts
@@ -5,6 +5,7 @@
  */
 import crypto from "node:crypto";
 import { resolveExpiresAtMsFromDurationMs } from "@openclaw/normalization-core/number-coercion";
+import { isApprovalNotFoundError } from "../infra/approval-errors.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { buildExecApprovalUnavailableReplyPayload } from "../infra/exec-approval-reply.js";
 import {
@@ -481,6 +482,9 @@ export async function sendExecApprovalFollowupResult(
         }
       : {}),
   }).catch((error: unknown) => {
+    if (isApprovalNotFoundError(error)) {
+      return;
+    }
     const message = formatErrorMessage(error);
     const key = `${target.approvalId}:${message}`;
     if (!rememberExecApprovalFollowupFailureKey(key)) {

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -5,6 +5,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ErrorCodes } from "../../../packages/gateway-protocol/src/index.js";
 import type { readAcpSessionMeta } from "../../acp/runtime/session-meta.js";
 import {
+  onDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+  waitForDiagnosticEventsDrained,
+  type DiagnosticEventPayload,
+} from "../../infra/diagnostic-events.js";
+import {
   registerExecApprovalFollowupRuntimeHandoff,
   resetExecApprovalFollowupRuntimeHandoffsForTests,
 } from "../../agents/bash-tools.exec-approval-followup-state.js";
@@ -600,6 +606,7 @@ describe("gateway agent handler", () => {
   afterEach(() => {
     envSnapshot.restore();
     resetDetachedTaskLifecycleRuntimeForTests();
+    resetDiagnosticEventsForTest();
     resetTaskRegistryForTests();
     resetSubagentRegistryForTests({ persist: false });
     subagentRegistryTesting.setDepsForTest();
@@ -3212,6 +3219,10 @@ describe("gateway agent handler", () => {
       lastTo: "123",
     });
     const context = makeContext();
+    const diagnostics: DiagnosticEventPayload[] = [];
+    onDiagnosticEvent((event) => {
+      diagnostics.push(event);
+    });
     const updateSessionStoreCallsBefore = mocks.updateSessionStore.mock.calls.length;
     const agentCommandCallsBefore = mocks.agentCommand.mock.calls.length;
 
@@ -3237,6 +3248,15 @@ describe("gateway agent handler", () => {
       status: "ok",
       summary: expect.stringContaining("exec approval followup dropped"),
     });
+    await waitForDiagnosticEventsDrained();
+    expect(diagnostics).toContainEqual(
+      expect.objectContaining({
+        type: "exec.approval.followup_suppressed",
+        approvalId: "req-rebound-followup",
+        reason: "session_rebound",
+        phase: "gateway_preflight",
+      }),
+    );
     expect(mocks.updateSessionStore.mock.calls.length).toBe(updateSessionStoreCallsBefore);
     expect(mocks.agentCommand.mock.calls.length).toBe(agentCommandCallsBefore);
     const dedupeEntry = context.dedupe.get("agent:exec-approval-followup:req-rebound-followup");

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -77,6 +77,7 @@ import {
 import { hasProviderOwnedSession } from "../../config/sessions/entry-freshness.js";
 import { resolveMaintenanceConfigFromInput } from "../../config/sessions/store-maintenance.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { emitDiagnosticEvent } from "../../infra/diagnostic-events.js";
 import {
   assertAgentRunLifecycleGenerationCurrent,
   claimAgentRunContext,
@@ -1516,6 +1517,12 @@ export const agentHandlers: GatewayRequestHandlers = {
           resolvedSessionId: currentSessionId,
         })
       ) {
+        emitDiagnosticEvent({
+          type: "exec.approval.followup_suppressed",
+          approvalId: execApprovalFollowupApprovalId,
+          reason: "session_rebound",
+          phase: "gateway_preflight",
+        });
         context.logGateway.info(
           `Dropping stale exec approval followup ${execApprovalFollowupApprovalId}: session ${requestedSessionKeyRaw} rebound (expected ${expectedSessionId}, current ${currentSessionId}) before the approval resolved`,
         );

--- a/src/infra/diagnostic-events.test.ts
+++ b/src/infra/diagnostic-events.test.ts
@@ -801,6 +801,32 @@ describe("diagnostic-events", () => {
     expect(internalEvents).toEqual(["log.record"]);
   });
 
+  it("emits exec approval followup suppression events on the public stream", async () => {
+    const events: DiagnosticEventPayload[] = [];
+    onDiagnosticEvent((event) => {
+      events.push(event);
+    });
+
+    emitDiagnosticEvent({
+      type: "exec.approval.followup_suppressed",
+      approvalId: "approval-123",
+      reason: "session_rebound",
+      phase: "gateway_preflight",
+    });
+
+    await waitForDiagnosticEventsDrained();
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "exec.approval.followup_suppressed",
+        approvalId: "approval-123",
+        reason: "session_rebound",
+        phase: "gateway_preflight",
+        ts: expect.any(Number),
+      }),
+    );
+  });
+
   it("keeps trusted private data off shared internal diagnostic listeners", async () => {
     const internalEvents: DiagnosticEventPayload[] = [];
     const trustedEvents: Array<{

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -514,6 +514,13 @@ export type DiagnosticExecProcessCompletedEvent = DiagnosticBaseEvent & {
     | "runtime-error";
 };
 
+export type DiagnosticExecApprovalFollowupSuppressedEvent = DiagnosticBaseEvent & {
+  type: "exec.approval.followup_suppressed";
+  approvalId: string;
+  reason: "session_rebound";
+  phase: "direct_delivery" | "gateway_preflight";
+};
+
 type DiagnosticRunBaseEvent = DiagnosticBaseEvent & {
   runId: string;
   sessionKey?: string;
@@ -769,6 +776,7 @@ export type DiagnosticEventPayload =
   | DiagnosticToolExecutionBlockedEvent
   | DiagnosticSkillUsedEvent
   | DiagnosticExecProcessCompletedEvent
+  | DiagnosticExecApprovalFollowupSuppressedEvent
   | DiagnosticRunStartedEvent
   | DiagnosticRunCompletedEvent
   | DiagnosticHarnessRunStartedEvent
@@ -863,6 +871,7 @@ const ASYNC_DIAGNOSTIC_EVENT_TYPES = new Set<DiagnosticEventPayload["type"]>([
   "tool.execution.blocked",
   "skill.used",
   "exec.process.completed",
+  "exec.approval.followup_suppressed",
   "message.delivery.started",
   "message.delivery.completed",
   "message.delivery.error",

--- a/src/logging/diagnostic-stability-bundle.test.ts
+++ b/src/logging/diagnostic-stability-bundle.test.ts
@@ -281,10 +281,20 @@ describe("diagnostic stability bundles", () => {
           chatId: "chat-id-secret",
           error: "event-error-secret",
         },
+        {
+          seq: 2,
+          ts: 2,
+          type: "exec.approval.followup_suppressed",
+          approvalId: "approval-imported-123",
+          reason: "session_rebound",
+          phase: "gateway_preflight",
+          command: "raw command secret",
+        },
       ],
       summary: {
         byType: {
           "webhook.error": 1,
+          "exec.approval.followup_suppressed": 1,
           "private summary type": 1,
         },
         privateSummary: "summary-secret",
@@ -312,7 +322,18 @@ describe("diagnostic stability bundles", () => {
       type: "webhook.error",
       channel: "telegram",
     });
-    expect(result.bundle.snapshot.summary.byType).toEqual({ "webhook.error": 1 });
+    expect(result.bundle.snapshot.events[1]).toEqual({
+      seq: 2,
+      ts: 2,
+      type: "exec.approval.followup_suppressed",
+      approvalId: "approval-imported-123",
+      reason: "session_rebound",
+      phase: "gateway_preflight",
+    });
+    expect(result.bundle.snapshot.summary.byType).toEqual({
+      "webhook.error": 1,
+      "exec.approval.followup_suppressed": 1,
+    });
     const sanitized = JSON.stringify(result.bundle);
     for (const secret of [
       "private reason",
@@ -327,6 +348,7 @@ describe("diagnostic stability bundles", () => {
       "raw-secret-session",
       "chat-id-secret",
       "event-error-secret",
+      "raw command secret",
       "private summary type",
       "summary-secret",
     ]) {

--- a/src/logging/diagnostic-stability-bundle.ts
+++ b/src/logging/diagnostic-stability-bundle.ts
@@ -696,6 +696,7 @@ function readStabilityEventRecord(
   assignOptionalCodeString(sanitized, "outcome", record.outcome, `${label}.outcome`);
   assignOptionalCodeString(sanitized, "level", record.level, `${label}.level`);
   assignOptionalCodeString(sanitized, "phase", record.phase, `${label}.phase`);
+  assignOptionalCodeString(sanitized, "approvalId", record.approvalId, `${label}.approvalId`);
   assignOptionalCodeString(sanitized, "detector", record.detector, `${label}.detector`);
   assignOptionalCodeString(sanitized, "toolName", record.toolName, `${label}.toolName`);
   assignOptionalCodeString(

--- a/src/logging/diagnostic-stability.test.ts
+++ b/src/logging/diagnostic-stability.test.ts
@@ -144,6 +144,30 @@ describe("diagnostic stability recorder", () => {
     expect(snapshot.events[1]).not.toHaveProperty("reason");
   });
 
+  it("records exec approval followup suppression metadata", async () => {
+    startDiagnosticStabilityRecorder();
+
+    emitDiagnosticEvent({
+      type: "exec.approval.followup_suppressed",
+      approvalId: "approval-123",
+      reason: "session_rebound",
+      phase: "direct_delivery",
+    });
+
+    await waitForDiagnosticEventsDrained();
+
+    const snapshot = getDiagnosticStabilitySnapshot({ limit: 10 });
+    expectFields(snapshot.summary.byType, {
+      "exec.approval.followup_suppressed": 1,
+    });
+    expectFields(snapshot.events[0], {
+      type: "exec.approval.followup_suppressed",
+      approvalId: "approval-123",
+      reason: "session_rebound",
+      phase: "direct_delivery",
+    });
+  });
+
   it("summarizes inbound delivery proof events without message content", () => {
     startDiagnosticStabilityRecorder();
 

--- a/src/logging/diagnostic-stability.ts
+++ b/src/logging/diagnostic-stability.ts
@@ -35,6 +35,7 @@ export type DiagnosticStabilityEventRecord = {
   transport?: string;
   brain?: string;
   toolName?: string;
+  approvalId?: string;
   activeWorkKind?: string;
   pairedToolName?: string;
   provider?: string;
@@ -430,6 +431,11 @@ function sanitizeDiagnosticEvent(event: DiagnosticEventPayload): DiagnosticStabi
       record.timedOut = event.timedOut;
       record.failureKind = event.failureKind;
       assignReasonCode(record, event.failureKind);
+      break;
+    case "exec.approval.followup_suppressed":
+      record.approvalId = event.approvalId;
+      record.phase = event.phase;
+      assignReasonCode(record, event.reason);
       break;
     case "run.started":
       record.provider = event.provider;


### PR DESCRIPTION
Closes #98397

Feedback context: https://x.com/Kerroudjm/status/2071998995753279540

## What Problem This Solves

The iOS Control and Talk surfaces use competing icon colors, small supporting text, an always-active idle animation, destructive styling for constructive actions, and a redundant version footer. The hosted push relay consent also presents both safe choices as destructive.

## Why This Change Was Made

This aligns ordinary destinations with the neutral Settings treatment, reserves semantic colors for status and destructive actions, increases shared supporting typography, removes the duplicate version block, clips Talk visuals, and replaces the relay alert with a scroll-safe disclosure sheet. It also adds deterministic fixture and opt-in live Gateway coverage for the reported Overview crash; current main did not reproduce the crash, so this prevents regression without claiming an unverified fix.

## User Impact

Control and Settings are easier to scan, Talk is quieter while idle, Start Talk is clearly constructive, hosted relay consent no longer looks destructive, and version information remains available in Settings > About. Overview continues to open normally and now has simulator regression coverage against both fixture and real Gateway states.

## Evidence

### Before / after

All comparison captures use the same iPhone 17 Simulator at 1206 × 2622.

#### Control hierarchy

| Before | After |
| --- | --- |
| ![Control before: mixed red, green, and gray destination badges plus a dedicated version footer](https://github.com/user-attachments/assets/f2ccc30f-b014-4f75-aab1-ff5abab099eb) | ![Control after: neutral destination badges, larger supporting type, semantic status color only, and no duplicate version footer](https://github.com/user-attachments/assets/c55cbc73-ef14-4fc9-a9cc-82461d91ccb8) |

The revised screen removes competing destination colors, promotes supporting labels from caption sizes to footnote, and removes the redundant version card while preserving the version in Settings > About.

#### Talk idle state

| Before | After |
| --- | --- |
| ![Talk before: gray-to-red action gradient, persistent idle rings, and background waveform noise](https://github.com/user-attachments/assets/e98cc03d-bb33-4f54-9591-e53d6e2c8a7e) | ![Talk after: system-blue constructive action, quiet idle orb, clipped animation, and no waveform beneath the status icon](https://github.com/user-attachments/assets/d560029e-cbfa-473b-85f2-199f04c12831) |

The primary action is now blue for the constructive path, red only for Stop, and warning-colored only while waiting. Idle rings and the obscured waveform are suppressed; active animation remains clipped to the orb.

#### Settings typography and relay consent

| Before | After |
| --- | --- |
| ![Settings before: smaller caption-sized supporting copy](https://github.com/user-attachments/assets/e1e5880d-2993-476a-808f-9b53ff312187) | ![Settings after: footnote-sized supporting copy with improved scanability](https://github.com/user-attachments/assets/b4adc69d-fac4-4b4c-813a-10d7a6cef4ff) |

Shared row details now use footnote sizing. The hosted relay confirmation is a scroll-safe disclosure sheet with blue safe actions instead of a destructive-looking alert; render coverage exercises both `.large` and `.accessibility5` Dynamic Type.

### Live Gateway E2E

| Connected Control | Opened Overview |
| --- | --- |
| ![Live Gateway connected Control screen showing Online status at 127.0.0.1](https://github.com/user-attachments/assets/13b4b708-0e1d-46f4-8865-6eeaff2ebb32) | ![Live Gateway Overview screen showing Healthy status and 127.0.0.1:19001](https://github.com/user-attachments/assets/03ccff76-f8ee-4ffb-8eea-6e48f646e8f9) |

The simulator completed real setup-code onboarding against a locally running OpenClaw Gateway, reached Online, opened Overview, and remained foreground. A second run reused the onboarded simulator container to cover persisted state.

### Validation

- iPhone 17 Simulator, iOS 26.5: `pnpm ios:build` — passed.
- Focused state/source/render suites: 47 tests in 3 suites — passed.
- Dynamic Type relay disclosure renders at `.large` and `.accessibility5`: 11 render smoke tests — passed.
- Deterministic Overview navigation: `testControlOverviewNavigation` — passed in 8.259s.
- Real Gateway E2E on `127.0.0.1:19001`: fresh setup-code onboarding, connected Control, Overview navigation, foreground assertion, named screenshots — passed in 22.415s.
- Persistence rerun: same live test against an already-onboarded simulator container — passed in 24.785s.
- Codex autoreview: clean; no accepted/actionable findings.
