### PR TITLE
fix(ios): classify TLS fingerprint timeouts

### DIFF
--- a/apps/ios/Sources/Design/SettingsProTabActions.swift
+++ b/apps/ios/Sources/Design/SettingsProTabActions.swift
@@ -188,11 +188,11 @@ extension SettingsProTab {
         self.setupStatusText = nil
         guard self.applySetupCode() else { return }
         let host = self.manualGatewayHost.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard let port = self.resolvedManualPort(host: host) else {
+        guard self.resolvedManualPort(host: host) != nil else {
             self.setupStatusText = "Failed: invalid port"
             return
         }
-        guard await self.preflightGateway(host: host, port: port) else { return }
+        guard await self.preflightGateway(host: host) else { return }
         self.setupStatusText = "Setup code applied. Connecting..."
         await self.connectManual()
     }
@@ -286,11 +286,11 @@ extension SettingsProTab {
 
     func connectAfterScannedGatewayLink() async {
         let host = self.manualGatewayHost.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard let port = self.resolvedManualPort(host: host) else {
+        guard self.resolvedManualPort(host: host) != nil else {
             self.setupStatusText = "Failed: invalid port"
             return
         }
-        guard await self.preflightGateway(host: host, port: port) else { return }
+        guard await self.preflightGateway(host: host) else { return }
         await self.connectManual()
     }
 
@@ -319,7 +319,7 @@ extension SettingsProTab {
             authOverride: authOverride)
     }
 
-    func preflightGateway(host: String, port: Int) async -> Bool {
+    func preflightGateway(host: String) async -> Bool {
         let trimmed = host.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return false }
         if Self.isTailnetHostOrIP(trimmed), !Self.hasTailnetIPv4() {
@@ -327,12 +327,7 @@ extension SettingsProTab {
             return false
         }
         self.gatewayController.requestLocalNetworkAccess(reason: "settings_preflight")
-        self.setupStatusText = "Checking gateway reachability..."
-        let ok = await TCPProbe.probe(host: trimmed, port: port, timeoutSeconds: 3, queueLabel: "gateway.preflight")
-        if !ok {
-            self.setupStatusText = "Can't reach gateway at \(trimmed):\(port). Check Tailscale or LAN."
-        }
-        return ok
+        return true
     }
 
     func resetOnboarding() {
@@ -562,6 +557,12 @@ extension SettingsProTab {
         let gatewayStatus = self.appModel.gatewayStatusText.trimmingCharacters(in: .whitespacesAndNewlines)
         if let friendly = self.friendlyGatewayMessage(from: gatewayStatus) { return friendly }
         if let friendly = self.friendlyGatewayMessage(from: trimmedSetup) { return friendly }
+        if self.isTransientSetupStatus(trimmedSetup),
+           !gatewayStatus.isEmpty,
+           gatewayStatus != "Offline"
+        {
+            return gatewayStatus
+        }
         if !trimmedSetup.isEmpty { return trimmedSetup }
         if gatewayStatus.isEmpty || gatewayStatus == "Offline" { return nil }
         return gatewayStatus
@@ -586,6 +587,11 @@ extension SettingsProTab {
         if lower.contains("device nonce required") || lower.contains("device nonce mismatch") {
             return "Secure handshake failed. Check Tailscale, then connect again."
         }
+        if lower.contains("tls fingerprint verification timed out")
+            || lower.contains("no tls endpoint detected")
+        {
+            return raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
         if lower.contains("timed out") {
             return "Connection timed out. Make sure Tailscale is connected, then try again."
         }
@@ -593,6 +599,13 @@ extension SettingsProTab {
             return "Connected, but some controls are restricted for nodes. This is expected."
         }
         return nil
+    }
+
+    func isTransientSetupStatus(_ raw: String) -> Bool {
+        let lower = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return lower == "setup code applied. connecting..."
+            || lower.hasPrefix("qr loaded. connecting to ")
+            || lower == "checking gateway reachability..."
     }
 
     var shouldShowRealtimeVoicePicker: Bool {

--- a/apps/ios/Sources/Gateway/GatewayConnectionController.swift
+++ b/apps/ios/Sources/Gateway/GatewayConnectionController.swift
@@ -16,6 +16,47 @@ import Speech
 import SwiftUI
 import UIKit
 
+enum GatewayTLSFingerprintProbeFailure: Equatable {
+    case endpointUnreachable
+    case tlsHandshakeTimeout
+    case tlsUnavailable
+    case certificateUnavailable
+}
+
+enum GatewayTLSFingerprintProbeResult: Equatable {
+    case fingerprint(String)
+    case failure(GatewayTLSFingerprintProbeFailure)
+}
+
+typealias GatewayTCPReachabilityProbe = @Sendable (String, Int, Double, String) async -> Bool
+typealias GatewayTLSFingerprintProbeFunction = @Sendable (URL) async -> GatewayTLSFingerprintProbeResult
+
+private enum GatewayTLSFingerprintProbeBudget {
+    static let tcpConnectTimeoutSeconds = 3.0
+    static let tlsHandshakeTimeoutSeconds = 10.0
+}
+
+private func defaultGatewayTCPReachabilityProbe(
+    host: String,
+    port: Int,
+    timeoutSeconds: Double,
+    queueLabel: String) async -> Bool
+{
+    await TCPProbe.probe(host: host, port: port, timeoutSeconds: timeoutSeconds, queueLabel: queueLabel)
+}
+
+private func defaultGatewayTLSFingerprintProbe(url: URL) async -> GatewayTLSFingerprintProbeResult {
+    await withCheckedContinuation { continuation in
+        let probe = GatewayTLSFingerprintProbe(
+            url: url,
+            timeoutSeconds: GatewayTLSFingerprintProbeBudget.tlsHandshakeTimeoutSeconds)
+        { result in
+            continuation.resume(returning: result)
+        }
+        probe.start()
+    }
+}
+
 @MainActor
 @Observable
 final class GatewayConnectionController {
@@ -132,6 +173,8 @@ final class GatewayConnectionController {
     private var didAutoConnect = false
     private var pendingServiceResolvers: [String: GatewayServiceResolver] = [:]
     private var pendingTrustConnect: PendingTrustConnect?
+    private let tcpReachabilityProbe: GatewayTCPReachabilityProbe
+    private let tlsFingerprintProbe: GatewayTLSFingerprintProbeFunction
 
     private struct SavedManualEndpoint: Equatable {
         let host: String
@@ -142,11 +185,15 @@ final class GatewayConnectionController {
     init(
         appModel: NodeAppModel,
         startDiscovery: Bool = true,
-        deferDiscoveryUntilLocalNetworkRequest: Bool = false)
+        deferDiscoveryUntilLocalNetworkRequest: Bool = false,
+        tcpReachabilityProbe: @escaping GatewayTCPReachabilityProbe = defaultGatewayTCPReachabilityProbe,
+        tlsFingerprintProbe: @escaping GatewayTLSFingerprintProbeFunction = defaultGatewayTLSFingerprintProbe)
     {
         self.discoveryEnabled = startDiscovery
         self.appModel = appModel
         self.localNetworkAccessRequested = !deferDiscoveryUntilLocalNetworkRequest
+        self.tcpReachabilityProbe = tcpReachabilityProbe
+        self.tlsFingerprintProbe = tlsFingerprintProbe
 
         GatewaySettingsStore.bootstrapPersistence()
         let defaults = UserDefaults.standard
@@ -253,23 +300,36 @@ final class GatewayConnectionController {
         if tlsRequired, stored == nil {
             guard let url = self.buildGatewayURL(host: target.host, port: target.port, useTLS: true)
             else { return "Failed to build TLS URL for trust verification." }
-            guard let fp = await self.probeTLSFingerprint(url: url) else {
-                return "Failed to read TLS fingerprint from discovered gateway."
-            }
-            self.pendingTrustConnect = PendingTrustConnect(
-                url: url,
-                stableID: stableID,
-                isManual: false,
-                authOverride: nil)
-            self.pendingTrustPrompt = TrustPrompt(
-                stableID: stableID,
-                gatewayName: gateway.name,
+            self.appModel?.beginGatewayPreconnectVerification(statusText: "Verifying gateway TLS fingerprint…")
+            switch await self.probeTLSFingerprint(
                 host: target.host,
                 port: target.port,
-                fingerprintSha256: fp,
-                isManual: false)
-            self.appModel?.gatewayStatusText = "Verify gateway TLS fingerprint"
-            return nil
+                url: url,
+                queueLabel: "gateway.tls.discovered")
+            {
+            case let .fingerprint(fp):
+                self.pendingTrustConnect = PendingTrustConnect(
+                    url: url,
+                    stableID: stableID,
+                    isManual: false,
+                    authOverride: nil)
+                self.pendingTrustPrompt = TrustPrompt(
+                    stableID: stableID,
+                    gatewayName: gateway.name,
+                    host: target.host,
+                    port: target.port,
+                    fingerprintSha256: fp,
+                    isManual: false)
+                self.appModel?.gatewayStatusText = "Verify gateway TLS fingerprint"
+                return nil
+            case let .failure(failure):
+                let message = self.tlsProbeFailureMessage(
+                    failure,
+                    host: target.host,
+                    port: target.port)
+                self.appModel?.gatewayStatusText = message
+                return message
+            }
         }
 
         let tlsParams = stored.map { fp in
@@ -324,26 +384,35 @@ final class GatewayConnectionController {
         let stored = GatewayTLSStore.loadFingerprint(stableID: stableID)
         if resolvedUseTLS, stored == nil {
             guard let url = self.buildGatewayURL(host: host, port: resolvedPort, useTLS: true) else { return }
-            guard let fp = await self.probeTLSFingerprint(url: url) else {
-                self.appModel?.gatewayStatusText =
-                    "TLS handshake failed for \(host):\(resolvedPort). "
-                        + "Remote gateways must use HTTPS/WSS."
-                return
-            }
-            self.pendingTrustConnect = PendingTrustConnect(
-                url: url,
-                stableID: stableID,
-                isManual: true,
-                authOverride: pendingAuthOverride)
-            self.pendingTrustPrompt = TrustPrompt(
-                stableID: stableID,
-                gatewayName: "\(host):\(resolvedPort)",
+            self.appModel?.beginGatewayPreconnectVerification(statusText: "Verifying gateway TLS fingerprint…")
+            switch await self.probeTLSFingerprint(
                 host: host,
                 port: resolvedPort,
-                fingerprintSha256: fp,
-                isManual: true)
-            self.appModel?.gatewayStatusText = "Verify gateway TLS fingerprint"
-            return
+                url: url,
+                queueLabel: "gateway.tls.manual")
+            {
+            case let .fingerprint(fp):
+                self.pendingTrustConnect = PendingTrustConnect(
+                    url: url,
+                    stableID: stableID,
+                    isManual: true,
+                    authOverride: pendingAuthOverride)
+                self.pendingTrustPrompt = TrustPrompt(
+                    stableID: stableID,
+                    gatewayName: "\(host):\(resolvedPort)",
+                    host: host,
+                    port: resolvedPort,
+                    fingerprintSha256: fp,
+                    isManual: true)
+                self.appModel?.gatewayStatusText = "Verify gateway TLS fingerprint"
+                return
+            case let .failure(failure):
+                self.appModel?.gatewayStatusText = self.tlsProbeFailureMessage(
+                    failure,
+                    host: host,
+                    port: resolvedPort)
+                return
+            }
         }
 
         let tlsParams = stored.map { fp in
@@ -798,12 +867,40 @@ final class GatewayConnectionController {
         return nil
     }
 
-    private func probeTLSFingerprint(url: URL) async -> String? {
-        await withCheckedContinuation { continuation in
-            let probe = GatewayTLSFingerprintProbe(url: url, timeoutSeconds: 3) { fp in
-                continuation.resume(returning: fp)
-            }
-            probe.start()
+    private func probeTLSFingerprint(
+        host: String,
+        port: Int,
+        url: URL,
+        queueLabel: String) async -> GatewayTLSFingerprintProbeResult
+    {
+        self.pendingTrustConnect = nil
+        self.pendingTrustPrompt = nil
+        let reachable = await self.tcpReachabilityProbe(
+            host,
+            port,
+            GatewayTLSFingerprintProbeBudget.tcpConnectTimeoutSeconds,
+            queueLabel)
+        guard reachable else {
+            return .failure(.endpointUnreachable)
+        }
+        return await self.tlsFingerprintProbe(url)
+    }
+
+    private func tlsProbeFailureMessage(
+        _ failure: GatewayTLSFingerprintProbeFailure,
+        host: String,
+        port: Int) -> String
+    {
+        switch failure {
+        case .endpointUnreachable:
+            "Can't reach gateway at \(host):\(port). Check Tailscale or LAN."
+        case .tlsHandshakeTimeout:
+            "TLS fingerprint verification timed out for \(host):\(port). "
+                + "Secure endpoint was reached, but TLS did not finish in time."
+        case .tlsUnavailable:
+            "No TLS endpoint detected at \(host):\(port). Remote gateways must use HTTPS/WSS."
+        case .certificateUnavailable:
+            "Could not read the TLS certificate from \(host):\(port)."
         }
     }
 
@@ -1118,7 +1215,9 @@ extension GatewayConnectionController {
 }
 #endif
 
-private final class GatewayTLSFingerprintProbe: NSObject, URLSessionDelegate, @unchecked Sendable {
+private final class GatewayTLSFingerprintProbe: NSObject, URLSessionDelegate, URLSessionTaskDelegate,
+    @unchecked Sendable
+{
     private struct ProbeState {
         var didFinish = false
         var session: URLSession?
@@ -1127,10 +1226,14 @@ private final class GatewayTLSFingerprintProbe: NSObject, URLSessionDelegate, @u
 
     private let url: URL
     private let timeoutSeconds: Double
-    private let onComplete: (String?) -> Void
+    private let onComplete: (GatewayTLSFingerprintProbeResult) -> Void
     private let state = OSAllocatedUnfairLock(initialState: ProbeState())
 
-    init(url: URL, timeoutSeconds: Double, onComplete: @escaping (String?) -> Void) {
+    init(
+        url: URL,
+        timeoutSeconds: Double,
+        onComplete: @escaping (GatewayTLSFingerprintProbeResult) -> Void)
+    {
         self.url = url
         self.timeoutSeconds = timeoutSeconds
         self.onComplete = onComplete
@@ -1149,7 +1252,7 @@ private final class GatewayTLSFingerprintProbe: NSObject, URLSessionDelegate, @u
         task.resume()
 
         DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + self.timeoutSeconds) { [weak self] in
-            self?.finish(nil)
+            self?.finish(.failure(.tlsHandshakeTimeout))
         }
     }
 
@@ -1167,10 +1270,22 @@ private final class GatewayTLSFingerprintProbe: NSObject, URLSessionDelegate, @u
 
         let fp = GatewayTLSFingerprintProbe.certificateFingerprint(trust)
         completionHandler(.cancelAuthenticationChallenge, nil)
-        self.finish(fp)
+        if let fp {
+            self.finish(.fingerprint(fp))
+        } else {
+            self.finish(.failure(.certificateUnavailable))
+        }
     }
 
-    private func finish(_ fingerprint: String?) {
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        guard let error else {
+            self.finish(.failure(.tlsUnavailable))
+            return
+        }
+        self.finish(.failure(Self.failure(for: error)))
+    }
+
+    private func finish(_ result: GatewayTLSFingerprintProbeResult) {
         typealias FinishState = (Bool, URLSessionWebSocketTask?, URLSession?)
         let (shouldComplete, taskToCancel, sessionToInvalidate) = self.state.withLock { s -> FinishState in
             guard !s.didFinish else { return (false, nil, nil) }
@@ -1184,7 +1299,34 @@ private final class GatewayTLSFingerprintProbe: NSObject, URLSessionDelegate, @u
         guard shouldComplete else { return }
         taskToCancel?.cancel(with: .goingAway, reason: nil)
         sessionToInvalidate?.invalidateAndCancel()
-        self.onComplete(fingerprint)
+        self.onComplete(result)
+    }
+
+    private static func failure(for error: Error) -> GatewayTLSFingerprintProbeFailure {
+        let nsError = error as NSError
+        guard nsError.domain == URLError.errorDomain else {
+            return .tlsUnavailable
+        }
+
+        switch URLError.Code(rawValue: nsError.code) {
+        case .timedOut:
+            return .tlsHandshakeTimeout
+        case .cannotFindHost,
+             .dnsLookupFailed,
+             .cannotConnectToHost,
+             .notConnectedToInternet,
+             .internationalRoamingOff,
+             .callIsActive,
+             .dataNotAllowed:
+            return .endpointUnreachable
+        case .networkConnectionLost,
+             .secureConnectionFailed,
+             .cannotParseResponse,
+             .badServerResponse:
+            return .tlsUnavailable
+        default:
+            return .tlsUnavailable
+        }
     }
 
     private static func certificateFingerprint(_ trust: SecTrust) -> String? {

--- a/apps/ios/Sources/Gateway/GatewayConnectionController.swift
+++ b/apps/ios/Sources/Gateway/GatewayConnectionController.swift
@@ -30,6 +30,7 @@ enum GatewayTLSFingerprintProbeResult: Equatable {
 
 typealias GatewayTCPReachabilityProbe = @Sendable (String, Int, Double, String) async -> Bool
 typealias GatewayTLSFingerprintProbeFunction = @Sendable (URL) async -> GatewayTLSFingerprintProbeResult
+typealias GatewayServiceEndpointResolver = @Sendable (NWEndpoint) async -> (host: String, port: Int)?
 
 private enum GatewayTLSFingerprintProbeBudget {
     static let tcpConnectTimeoutSeconds = 3.0
@@ -175,6 +176,7 @@ final class GatewayConnectionController {
     private var pendingTrustConnect: PendingTrustConnect?
     private let tcpReachabilityProbe: GatewayTCPReachabilityProbe
     private let tlsFingerprintProbe: GatewayTLSFingerprintProbeFunction
+    private let serviceEndpointResolver: GatewayServiceEndpointResolver?
 
     private struct SavedManualEndpoint: Equatable {
         let host: String
@@ -187,13 +189,15 @@ final class GatewayConnectionController {
         startDiscovery: Bool = true,
         deferDiscoveryUntilLocalNetworkRequest: Bool = false,
         tcpReachabilityProbe: @escaping GatewayTCPReachabilityProbe = defaultGatewayTCPReachabilityProbe,
-        tlsFingerprintProbe: @escaping GatewayTLSFingerprintProbeFunction = defaultGatewayTLSFingerprintProbe)
+        tlsFingerprintProbe: @escaping GatewayTLSFingerprintProbeFunction = defaultGatewayTLSFingerprintProbe,
+        serviceEndpointResolver: GatewayServiceEndpointResolver? = nil)
     {
         self.discoveryEnabled = startDiscovery
         self.appModel = appModel
         self.localNetworkAccessRequested = !deferDiscoveryUntilLocalNetworkRequest
         self.tcpReachabilityProbe = tcpReachabilityProbe
         self.tlsFingerprintProbe = tlsFingerprintProbe
+        self.serviceEndpointResolver = serviceEndpointResolver
 
         GatewaySettingsStore.bootstrapPersistence()
         let defaults = UserDefaults.standard
@@ -284,7 +288,12 @@ final class GatewayConnectionController {
         let password = GatewaySettingsStore.loadGatewayPassword(instanceId: instanceId)
 
         // Resolve the service endpoint (SRV/A/AAAA). TXT is unauthenticated; do not route via TXT.
-        guard let target = await self.resolveServiceEndpoint(gateway.endpoint) else {
+        let target = if let serviceEndpointResolver {
+            await serviceEndpointResolver(gateway.endpoint)
+        } else {
+            await self.resolveServiceEndpoint(gateway.endpoint)
+        }
+        guard let target else {
             return "Failed to resolve the discovered gateway endpoint."
         }
 

--- a/apps/ios/Sources/Gateway/GatewayTrustPromptAlert.swift
+++ b/apps/ios/Sources/Gateway/GatewayTrustPromptAlert.swift
@@ -3,33 +3,32 @@ import SwiftUI
 struct GatewayTrustPromptAlert: ViewModifier {
     @Environment(GatewayConnectionController.self) private var gatewayController: GatewayConnectionController
 
-    private var promptBinding: Binding<GatewayConnectionController.TrustPrompt?> {
-        Binding(
-            get: { self.gatewayController.pendingTrustPrompt },
-            set: { _ in
-                // Keep pending trust state until explicit user action.
-                // `alert(item:)` may set the binding to nil during dismissal, which can race with
-                // the button handler and cause accept to no-op.
-            })
-    }
-
     func body(content: Content) -> some View {
-        content.alert(item: self.promptBinding) { prompt in
-            Alert(
-                title: Text("Trust this gateway?"),
-                message: Text(
-                    """
-                    First-time TLS connection.
+        content.alert(
+            "Trust this gateway?",
+            isPresented: Binding(
+                get: { self.gatewayController.pendingTrustPrompt != nil },
+                set: { _ in
+                    // Keep pending trust state until explicit user action.
+                    // SwiftUI may set presentation bindings during dismissal; clearing here can
+                    // race with the trust button and make accept no-op.
+                }),
+            presenting: self.gatewayController.pendingTrustPrompt)
+        { _ in
+            Button("Cancel", role: .cancel) {
+                self.gatewayController.declinePendingTrustPrompt()
+            }
+            Button("Trust and connect") {
+                Task { await self.gatewayController.acceptPendingTrustPrompt() }
+            }
+        } message: { prompt in
+            Text(
+                """
+                First-time TLS connection.
 
-                    Verify this SHA-256 fingerprint out-of-band before trusting:
-                    \(prompt.fingerprintSha256)
-                    """),
-                primaryButton: .cancel(Text("Cancel")) {
-                    self.gatewayController.declinePendingTrustPrompt()
-                },
-                secondaryButton: .default(Text("Trust and connect")) {
-                    Task { await self.gatewayController.acceptPendingTrustPrompt() }
-                })
+                Verify this SHA-256 fingerprint out-of-band before trusting:
+                \(prompt.fingerprintSha256)
+                """)
         }
     }
 }

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -2209,6 +2209,14 @@ extension NodeAppModel {
         self.gatewayPairingRequestId = nil
     }
 
+    func beginGatewayPreconnectVerification(statusText: String) {
+        self.lastGatewayProblem = nil
+        self.operatorGatewayProblem = nil
+        self.gatewayPairingPaused = false
+        self.gatewayPairingRequestId = nil
+        self.gatewayStatusText = statusText
+    }
+
     private func applyGatewayConnectionProblem(_ problem: GatewayConnectionProblem) {
         guard !self.isLocalGatewayFixtureEnabled else { return }
         self.lastGatewayProblem = problem

--- a/apps/ios/Tests/GatewayConnectionSecurityTests.swift
+++ b/apps/ios/Tests/GatewayConnectionSecurityTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import Network
 import OpenClawKit
 import Testing
+import os
 @testable import OpenClaw
 
 @Suite(.serialized) struct GatewayConnectionSecurityTests {
@@ -137,6 +138,84 @@ import Testing
         #expect(controller._test_resolveManualPort(host: "device.sample.ts.net", port: 0, useTLS: true) == 443)
         #expect(controller._test_resolveManualPort(host: "device.sample.ts.net.", port: 0, useTLS: true) == 443)
         #expect(controller._test_resolveManualPort(host: "device.sample.ts.net", port: 18789, useTLS: true) == 18789)
+    }
+
+    @Test @MainActor func manualFirstUseTLSProbeShowsTrustPromptAfterFingerprintCapture() async {
+        let host = "gateway-\(UUID().uuidString).example.com"
+        let port = 18789
+        let stableID = "manual|\(host.lowercased())|\(port)"
+        defer { clearTLSFingerprint(stableID: stableID) }
+        self.clearTLSFingerprint(stableID: stableID)
+
+        let appModel = NodeAppModel()
+        let controller = GatewayConnectionController(
+            appModel: appModel,
+            startDiscovery: false,
+            tcpReachabilityProbe: { _, _, _, _ in true },
+            tlsFingerprintProbe: { _ in .fingerprint("abc123") })
+
+        await controller.connectManual(host: host, port: port, useTLS: true)
+
+        #expect(controller.pendingTrustPrompt?.fingerprintSha256 == "abc123")
+        #expect(controller.pendingTrustPrompt?.host == host)
+        #expect(controller.pendingTrustPrompt?.port == port)
+        #expect(appModel.gatewayStatusText == "Verify gateway TLS fingerprint")
+    }
+
+    @Test @MainActor func manualFirstUseTLSProbeSkipsTLSWhenTCPIsUnreachable() async {
+        let host = "gateway-\(UUID().uuidString).example.com"
+        let port = 18789
+        let stableID = "manual|\(host.lowercased())|\(port)"
+        let tlsProbeCalls = OSAllocatedUnfairLock(initialState: 0)
+        defer { clearTLSFingerprint(stableID: stableID) }
+        self.clearTLSFingerprint(stableID: stableID)
+
+        let appModel = NodeAppModel()
+        let controller = GatewayConnectionController(
+            appModel: appModel,
+            startDiscovery: false,
+            tcpReachabilityProbe: { _, _, _, _ in false },
+            tlsFingerprintProbe: { _ in
+                tlsProbeCalls.withLock { $0 += 1 }
+                return .fingerprint("abc123")
+            })
+
+        await controller.connectManual(host: host, port: port, useTLS: true)
+
+        #expect(tlsProbeCalls.withLock { $0 } == 0)
+        #expect(controller.pendingTrustPrompt == nil)
+        #expect(appModel.gatewayStatusText == "Can't reach gateway at \(host):\(port). Check Tailscale or LAN.")
+    }
+
+    @Test @MainActor func manualFirstUseTLSProbeReportsHandshakeTimeoutWithoutTrustPrompt() async {
+        let host = "gateway-\(UUID().uuidString).example.com"
+        let port = 18789
+        let stableID = "manual|\(host.lowercased())|\(port)"
+        defer { clearTLSFingerprint(stableID: stableID) }
+        self.clearTLSFingerprint(stableID: stableID)
+
+        let appModel = NodeAppModel()
+        let staleProblem = GatewayConnectionProblem(
+            kind: .pairingRequired,
+            owner: .gateway,
+            title: "Pairing required",
+            message: "Approve an old request.",
+            requestId: "stale-request",
+            retryable: true,
+            pauseReconnect: true)
+        appModel._test_applyOperatorGatewayConnectionProblem(staleProblem)
+        let controller = GatewayConnectionController(
+            appModel: appModel,
+            startDiscovery: false,
+            tcpReachabilityProbe: { _, _, _, _ in true },
+            tlsFingerprintProbe: { _ in .failure(.tlsHandshakeTimeout) })
+
+        await controller.connectManual(host: host, port: port, useTLS: true)
+
+        #expect(controller.pendingTrustPrompt == nil)
+        #expect(appModel.lastGatewayProblem == nil)
+        #expect(appModel.gatewayStatusText.contains("TLS fingerprint verification timed out"))
+        #expect(appModel.gatewayStatusText.contains("\(host):\(port)"))
     }
 
     @Test @MainActor func clearAllTLSFingerprints_removesStoredPins() async {

--- a/apps/ios/Tests/GatewayConnectionSecurityTests.swift
+++ b/apps/ios/Tests/GatewayConnectionSecurityTests.swift
@@ -218,6 +218,49 @@ import os
         #expect(appModel.gatewayStatusText.contains("\(host):\(port)"))
     }
 
+    @Test @MainActor func discoveredFirstUseTLSProbeFailureClearsStaleTrustPrompt() async {
+        let staleHost = "stale-\(UUID().uuidString).example.com"
+        let stalePort = 18789
+        let staleStableID = "manual|\(staleHost.lowercased())|\(stalePort)"
+        let discoveredStableID = "discovered|\(UUID().uuidString)"
+        let discoveredHost = "gateway.tailnet.ts.net"
+        let discoveredPort = 443
+        defer {
+            clearTLSFingerprint(stableID: staleStableID)
+            clearTLSFingerprint(stableID: discoveredStableID)
+        }
+        self.clearTLSFingerprint(stableID: staleStableID)
+        self.clearTLSFingerprint(stableID: discoveredStableID)
+
+        let tlsResults = OSAllocatedUnfairLock(initialState: [
+            GatewayTLSFingerprintProbeResult.fingerprint("abc123"),
+            .failure(.tlsHandshakeTimeout),
+        ])
+        let appModel = NodeAppModel()
+        let controller = GatewayConnectionController(
+            appModel: appModel,
+            startDiscovery: false,
+            tcpReachabilityProbe: { _, _, _, _ in true },
+            tlsFingerprintProbe: { _ in tlsResults.withLock { $0.removeFirst() } },
+            serviceEndpointResolver: { _ in (host: discoveredHost, port: discoveredPort) })
+
+        await controller.connectManual(host: staleHost, port: stalePort, useTLS: true)
+        #expect(controller.pendingTrustPrompt?.fingerprintSha256 == "abc123")
+
+        let gateway = self.makeDiscoveredGateway(
+            stableID: discoveredStableID,
+            lanHost: nil,
+            tailnetDns: discoveredHost,
+            gatewayPort: discoveredPort,
+            fingerprint: nil)
+        let message = await controller.connectWithDiagnostics(gateway)
+
+        #expect(controller.pendingTrustPrompt == nil)
+        #expect(message?.contains("TLS fingerprint verification timed out") == true)
+        #expect(message?.contains("\(discoveredHost):\(discoveredPort)") == true)
+        #expect(appModel.gatewayStatusText == message)
+    }
+
     @Test @MainActor func clearAllTLSFingerprints_removesStoredPins() async {
         let stableID1 = "test|\(UUID().uuidString)"
         let stableID2 = "test|\(UUID().uuidString)"

--- a/apps/ios/Tests/RootTabsSourceGuardTests.swift
+++ b/apps/ios/Tests/RootTabsSourceGuardTests.swift
@@ -637,10 +637,9 @@ struct RootTabsSourceGuardTests {
         #expect(actionsSource.contains("self.gatewayController.refreshActiveGatewayRegistrationFromSettings()"))
         #expect(actionsSource.contains("self.gatewayController.restartDiscovery()"))
         #expect(actionsSource.contains("await self.appModel.refreshGatewayOverviewIfConnected()"))
-        #expect(actionsSource
-            .contains("self.gatewayController.requestLocalNetworkAccess(reason: \"settings_preflight\")"))
-        #expect(actionsSource.contains("await TCPProbe.probe(host: trimmed, port: port"))
-        #expect(actionsSource.contains("Check Tailscale or LAN."))
+        #expect(actionsSource.contains("self.gatewayController.requestLocalNetworkAccess(reason: \"settings_preflight\")"))
+        #expect(controllerSource.contains("await self.tcpReachabilityProbe("))
+        #expect(controllerSource.contains("Check Tailscale or LAN."))
         #expect(actionsSource.contains("Tailscale is off on this device. Turn it on, then try again."))
         #expect(actionsSource.contains("Run /pair approve in your OpenClaw chat"))
         #expect(actionsSource.contains("self.resetOnboarding()"))

--- a/apps/ios/Tests/SwiftUIRenderSmokeTests.swift
+++ b/apps/ios/Tests/SwiftUIRenderSmokeTests.swift
@@ -72,6 +72,74 @@ import UIKit
         }
     }
 
+    @Test @MainActor func gatewayTrustPromptAlertPresentsWhenPromptAppearsAfterInitialRender() async {
+        let appModel = NodeAppModel()
+        let gatewayController = Self.gatewayControllerWithCapturedTLSFingerprint(appModel: appModel)
+        let root = Color.clear
+            .gatewayTrustPromptAlert()
+            .environment(gatewayController)
+
+        let window = Self.host(root)
+        await Self.triggerGatewayTrustPrompt(controller: gatewayController)
+        await Self.waitForPresentedAlert(in: window)
+
+        #expect(window.rootViewController?.presentedViewController is UIAlertController)
+    }
+
+    @Test @MainActor func rootPromptAlertStackPresentsGatewayTrustPrompt() async {
+        let appModel = NodeAppModel()
+        let gatewayController = Self.gatewayControllerWithCapturedTLSFingerprint(appModel: appModel)
+        let root = Color.clear
+            .gatewayTrustPromptAlert()
+            .deepLinkAgentPromptAlert()
+            .environment(appModel)
+            .environment(gatewayController)
+
+        let window = Self.host(root)
+        await Self.triggerGatewayTrustPrompt(controller: gatewayController)
+        await Self.waitForPresentedAlert(in: window)
+
+        #expect(window.rootViewController?.presentedViewController is UIAlertController)
+    }
+
+    @Test @MainActor func rootPromptAlertStackStillPresentsDeepLinkPrompt() async throws {
+        let appModel = NodeAppModel()
+        appModel._test_setGatewayConnected(true)
+        let gatewayController = Self.gatewayControllerWithCapturedTLSFingerprint(appModel: appModel)
+        let root = Color.clear
+            .gatewayTrustPromptAlert()
+            .deepLinkAgentPromptAlert()
+            .environment(appModel)
+            .environment(gatewayController)
+
+        let window = Self.host(root)
+        let url = try #require(URL(string: "openclaw://agent?message=hello%20from%20deep%20link"))
+        await appModel.handleDeepLink(url: url)
+        await Self.waitForPresentedAlert(in: window)
+
+        #expect(window.rootViewController?.presentedViewController is UIAlertController)
+    }
+
+    @MainActor private static func gatewayControllerWithCapturedTLSFingerprint(
+        appModel: NodeAppModel)
+        -> GatewayConnectionController
+    {
+        GatewayConnectionController(
+            appModel: appModel,
+            startDiscovery: false,
+            tcpReachabilityProbe: { _, _, _, _ in true },
+            tlsFingerprintProbe: { _ in .fingerprint("abc123") })
+    }
+
+    @MainActor private static func triggerGatewayTrustPrompt(controller: GatewayConnectionController) async {
+        let host = "gateway-\(UUID().uuidString).example.com"
+        let port = 18789
+        let stableID = "manual|\(host.lowercased())|\(port)"
+        defer { GatewayTLSStore.clearFingerprint(stableID: stableID) }
+        GatewayTLSStore.clearFingerprint(stableID: stableID)
+        await controller.connectManual(host: host, port: port, useTLS: true)
+    }
+
     @Test @MainActor func phoneControlHubBuildsGatewayStateViewHierarchies() {
         for appModel in Self.rootTabsGatewayStateModels() {
             let root = RootTabsPhoneControlHub(
@@ -147,6 +215,14 @@ import UIKit
     @Test @MainActor func voiceWakeToastBuildsAViewHierarchy() {
         let root = VoiceWakeToast(command: "openclaw: do something")
         _ = Self.host(root)
+    }
+
+    @MainActor private static func waitForPresentedAlert(in window: UIWindow) async {
+        for _ in 0 ..< 10 {
+            if window.rootViewController?.presentedViewController != nil { return }
+            await Task.yield()
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
     }
 
     @MainActor private static func rootTabsGatewayStateModels() -> [NodeAppModel] {


### PR DESCRIPTION
Related: OpenClaw claim report ACTIONABLE-003-C2

## What Problem This Solves

Fixes an issue where iOS users connecting to a manual HTTPS gateway could get stuck behind generic connection failure behavior when the gateway accepts TCP but never completes enough TLS handshake work to produce a certificate fingerprint.

This also fixes the root alert-stack breakage where the gateway trust prompt could be prepared but not presented from the app's main root UI.

## Why This Change Was Made

The iOS gateway connector now classifies TLS fingerprint probing outcomes separately from plain TCP reachability, including a bounded TLS fingerprint timeout for secure endpoints that stall after TCP connect. The trust prompt presentation was also moved to SwiftUI's current `alert(_:isPresented:presenting:actions:message:)` API so it survives the root prompt stack alongside deep-link prompts.

The change keeps the timeout decision inside the gateway connection controller instead of adding settings-screen heuristics or widening generic connection fallbacks.

## User Impact

Users now see a specific TLS fingerprint timeout message when a secure gateway endpoint is reachable but does not complete fingerprint verification in time. First-time TLS connections can again present the trust prompt from the main iOS app shell, so users can inspect and trust the gateway fingerprint instead of seeing a silent or misleading connection failure.

## Evidence

AI-assisted PR.

- `.agents/skills/autoreview/scripts/autoreview --mode local` reported no accepted/actionable findings before commit.
- Focused XCTest before rebasing onto current `origin/main`: `xcodebuild test -project apps/ios/OpenClaw.xcodeproj -scheme OpenClaw -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' -only-testing:OpenClawTests/SwiftUIRenderSmokeTests -only-testing:OpenClawTests/RootTabsSourceGuardTests -only-testing:OpenClawTests/GatewayConnectionSecurityTests` passed 55 tests.
- Live simulator proof before rebasing: a local self-signed TLS endpoint on `127.0.0.1:29664` produced the `Trust this gateway?` prompt with SHA-256 fingerprint and `Trust and connect` / `Cancel` actions.
- Live simulator regression proof before rebasing: a local stalled TCP endpoint on `127.0.0.1:29664` produced `TLS fingerprint verification timed out for 127.0.0.1:29664. Secure endpoint was reached, but TLS did not finish in time.`
- After rebasing onto current `origin/main`, regenerated the ignored local Xcode project with `xcodegen generate` and confirmed the branch builds with `xcodebuild build -project apps/ios/OpenClaw.xcodeproj -scheme OpenClaw -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5'`.
- Post-reset focused XCTest on the amended branch: `xcodebuild test -project OpenClaw.xcodeproj -scheme OpenClaw -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5' -only-testing:OpenClawTests/GatewayConnectionSecurityTests` passed 12 tests.
- A later combined local focused run rebuilt successfully, launched the simulator app, then hung in Xcode/CoreSimulator before materializing the test worker (`waiting for workers to materialize`, `Waiting for -runningDidFinish call`). No test assertions failed in that run.
- `swiftlint lint Sources/Design/SettingsProTabActions.swift` passed with 0 violations.
- PR CI on `f2a72a02ef295a2c60990b49086c9264974e8703`: `ios-build`, `macos-swift`, and `Scan iOS dead code` passed.
