### PR TITLE
fix: omit synthesized maxTokens fallback for custom Xiaomi models

### DIFF
--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -1243,6 +1243,36 @@ describe("resolveModel", () => {
     });
   });
 
+  it("leaves maxTokens undefined when no configured or catalog value is available (regression: #98295)", () => {
+    // Regression for https://github.com/openclaw/openclaw/issues/98295.
+    // A custom provider row without maxTokens must not synthesize an
+    // unrelated output cap from DEFAULT_CONTEXT_TOKENS. Leaving maxTokens
+    // undefined lets the transport omit `max_completion_tokens` entirely.
+    resolveBundledStaticCatalogModelMock.mockReturnValueOnce(undefined);
+    const cfg = {
+      models: {
+        providers: {
+          xiaomi: {
+            baseUrl: "https://api.xiaomimimo.com/v1",
+            models: [
+              {
+                id: "mimo-v2.5-pro",
+                name: "mimo-v2.5-pro",
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveModelForTest("xiaomi", "mimo-v2.5-pro", "/tmp/agent", cfg);
+    const model = expectResolvedModel(result);
+
+    expect(model.id).toBe("mimo-v2.5-pro");
+    expect(model.baseUrl).toBe("https://api.xiaomimimo.com/v1");
+    expect(model.maxTokens).toBeUndefined();
+  });
+
   it("inherits bundled static transport for configured provider fallback models", () => {
     resolveBundledStaticCatalogModelMock.mockReturnValueOnce({
       provider: "deepseek",

--- a/src/agents/embedded-agent-runner/model.ts
+++ b/src/agents/embedded-agent-runner/model.ts
@@ -1330,6 +1330,11 @@ function resolveConfiguredFallbackModel(params: {
     compat: fallbackCompat,
     reasoning: metadataModel?.reasoning,
   });
+  const resolvedFallbackMaxTokens =
+    configuredModel?.maxTokens ??
+    providerConfig?.maxTokens ??
+    providerConfig?.models?.[0]?.maxTokens ??
+    staticCatalogModel?.maxTokens;
   return normalizeResolvedModel({
     provider,
     cfg,
@@ -1365,12 +1370,9 @@ function resolveConfiguredFallbackModel(params: {
             providerConfig?.contextTokens ??
             providerConfig?.models?.[0]?.contextTokens ??
             staticCatalogModel?.contextTokens,
-          maxTokens:
-            configuredModel?.maxTokens ??
-            providerConfig?.maxTokens ??
-            providerConfig?.models?.[0]?.maxTokens ??
-            staticCatalogModel?.maxTokens ??
-            DEFAULT_CONTEXT_TOKENS,
+          ...(resolvedFallbackMaxTokens !== undefined
+            ? { maxTokens: resolvedFallbackMaxTokens }
+            : {}),
           ...(resolvedParams ? { params: resolvedParams } : {}),
           ...(requestTimeoutMs !== undefined ? { requestTimeoutMs } : {}),
           headers: requestConfig.headers,

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -7507,6 +7507,31 @@ describe("openai transport stream", () => {
     expect(params).not.toHaveProperty("max_tokens");
   });
 
+  it("omits max_completion_tokens when model maxTokens is not configured (regression: #98295)", () => {
+    const params = buildOpenAICompletionsParams(
+      {
+        id: "mimo-v2.5-pro",
+        name: "MiMo V2.5 Pro",
+        api: "openai-completions",
+        provider: "xiaomi",
+        baseUrl: "https://api.xiaomimimo.com/v1",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 1_048_576,
+      } as never,
+      {
+        systemPrompt: "system",
+        messages: [],
+        tools: [],
+      } as never,
+      undefined,
+    );
+
+    expect(params).not.toHaveProperty("max_completion_tokens");
+    expect(params).not.toHaveProperty("max_tokens");
+  });
+
   it("uses model params max_completion_tokens for OpenAI completions before model maxTokens", () => {
     const params = buildOpenAICompletionsParams(
       {


### PR DESCRIPTION
Fixes #98295

## What Problem This Solves

Custom Xiaomi MiMo models could resolve with a synthesized `max_completion_tokens` value even when `maxTokens` was not configured. That produced an invalid OpenAI completions payload for this model family.

## Why This Change Was Made

Stop inventing a token-limit fallback during model resolution. Only forward `maxTokens` when the configured model or provider metadata actually defines one.

## User Impact

Xiaomi MiMo completions requests no longer emit an invalid token-limit field when the user did not configure one. Existing configured token limits still flow through normally.

## Evidence

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/model.test.ts`
- `node scripts/run-vitest.mjs src/agents/openai-transport-stream.test.ts -t "regression: #98295"`
- `pnpm build`
- `pnpm check`
- `git diff --check`

## Real Behavior Proof

- **Behavior addressed:** Xiaomi MiMo model resolution no longer synthesizes a token limit when `maxTokens` is absent.
- **Environment:** local macOS OpenClaw checkout on branch `codex/issue-98295-xiaomi-max-tokens`.
- **Current-main contrast:** current `main` can synthesize `DEFAULT_CONTEXT_TOKENS` into `model.maxTokens` for configured fallback models; the fixed branch resolves the Xiaomi MiMo model with `maxTokens` unset and emits no completion-token cap fields.
- **Exact steps or command run after this patch:**

```bash
node --import tsx -e '...runtime probe...'
```

- **Evidence after fix:**

```json
{
  "branch": "codex/issue-98295-xiaomi-max-tokens",
  "commit": "a17ff435",
  "model": {
    "id": "mimo-v2.5-pro",
    "provider": "xiaomi",
    "api": "openai-completions",
    "baseUrl": "https://api.xiaomimimo.com/v1",
    "contextWindow": 1048576,
    "maxTokens": null
  },
  "transport": {
    "hasMaxCompletionTokens": false,
    "hasMaxTokens": false,
    "keys": []
  }
}
```

- **Evidence artifact links:** `.artifacts/proof/issue-98295/current-branch-proof.json`, `.artifacts/proof/issue-98295/proof-summary.md`
- **Control check:** focused Vitest coverage passed for the model-resolution regression and the transport regression target.
- **Observed result after fix:** the request payload no longer includes a synthesized completion-token limit.
- **What was not tested:** live remote Xiaomi API traffic; validation was done against the local runtime and transport path.

## Focused Production Fix

The fix stays in the model-resolution path that assembles the resolved fallback model and removes the synthesized `DEFAULT_CONTEXT_TOKENS` max-token fallback for configured Xiaomi fallback models that do not define a token limit.

## Regression Test

The regression coverage is focused on the two affected surfaces:

- `src/agents/embedded-agent-runner/model.test.ts` now checks that the resolved model leaves `maxTokens` undefined when no configured or catalog value exists.
- `src/agents/openai-transport-stream.test.ts` now checks that the OpenAI completions payload omits `max_completion_tokens` when the model has no configured `maxTokens`.

## AI Disclosure

This PR was prepared with AI assistance. The code change, tests, and proof were reviewed and verified locally before submission.