### PR TITLE
fix(ui): prevent cross-turn tool-error banner suppression (#97849)

### DIFF
--- a/ui/src/ui/chat/build-chat-items.test.ts
+++ b/ui/src/ui/chat/build-chat-items.test.ts
@@ -1253,4 +1253,19 @@ describe("tool turn outcome annotation (#89683)", () => {
     ]);
     expect(tools.map((group) => group.turnSucceeded)).toEqual([true, false]);
   });
+
+  it("does not let a later agent-initiated turn reply collapse an earlier failed turn (#97849)", () => {
+    const tools = toolGroups([
+      failedTool(1),
+      {
+        role: "assistant",
+        content: [],
+        senderLabel: "cron-turn-1",
+        timestamp: 2,
+      },
+      failedTool(3),
+      assistantReply("Recovered on the next cron run.", 4),
+    ]);
+    expect(tools.map((group) => group.turnSucceeded)).toEqual([false, true]);
+  });
 });

--- a/ui/src/ui/chat/build-chat-items.ts
+++ b/ui/src/ui/chat/build-chat-items.ts
@@ -370,6 +370,10 @@ function annotateToolTurnOutcome(
     } else if (role === "assistant") {
       if (assistantGroupHasReplyText(item)) {
         sawAssistantReply = true;
+      } else {
+        // Agent-initiated turns have no user boundary; an empty assistant group
+        // marks the end of a failed turn so a later turn's reply cannot leak backward.
+        sawAssistantReply = false;
       }
     } else if (role === "tool") {
       item.turnSucceeded = sawAssistantReply;


### PR DESCRIPTION
## What Problem This Solves

When a cron/scheduled agent turn fails with a tool error and a later autonomous turn succeeds without a user message in between, the Control UI collapses the earlier Tool error banner. Operators lose visibility into the failed turn because `sawAssistantReply` was only reset at user-message boundaries, not at agent-initiated turn boundaries.

Fixes #97849

## Evidence

- Added regression coverage in the tool-turn outcome annotation path for back-to-back assistant groups without intervening user messages.
- `node scripts/run-vitest.mjs` on the affected UI/agent-runner tests passes locally.
- CI lint/type/guard checks pass on the PR head.

## Summary

- Reset `sawAssistantReply` when an assistant group has no reply text, marking agent-initiated turn boundaries that lack a user message.
- Keeps failed cron/scheduled turns showing their Tool error banner instead of collapsing it when a later autonomous turn succeeds.
