### PR TITLE
fix: consume stale google chat approval clicks

### DIFF
--- a/extensions/googlechat/src/approval-card-click.test.ts
+++ b/extensions/googlechat/src/approval-card-click.test.ts
@@ -9,9 +9,14 @@ import type { WebhookTarget } from "./monitor-types.js";
 import type { GoogleChatEvent } from "./types.js";
 
 const resolveApprovalOverGateway = vi.hoisted(() => vi.fn());
+const isApprovalNotFoundError = vi.hoisted(() => vi.fn(() => false));
 
 vi.mock("openclaw/plugin-sdk/approval-gateway-runtime", () => ({
   resolveApprovalOverGateway,
+}));
+
+vi.mock("openclaw/plugin-sdk/error-runtime", () => ({
+  isApprovalNotFoundError,
 }));
 
 function createTarget(): WebhookTarget {
@@ -55,6 +60,8 @@ describe("maybeHandleGoogleChatApprovalCardClick", () => {
   beforeEach(() => {
     clearGoogleChatApprovalCardBindingsForTest();
     resolveApprovalOverGateway.mockReset();
+    isApprovalNotFoundError.mockReset();
+    isApprovalNotFoundError.mockReturnValue(false);
   });
 
   it("authorizes the Chat actor and resolves the bound approval over the gateway", async () => {
@@ -275,5 +282,46 @@ describe("maybeHandleGoogleChatApprovalCardClick", () => {
     ).resolves.toBe(true);
 
     expect(resolveApprovalOverGateway).toHaveBeenCalledTimes(2);
+  });
+
+  it("consumes stale approval card tokens when gateway reports approval not found", async () => {
+    registerGoogleChatApprovalCardBinding({
+      token: "token-stale",
+      accountId: "default",
+      approvalId: "approval-stale",
+      approvalKind: "exec",
+      decision: "allow-once",
+      allowedDecisions: ["allow-once", "deny"],
+      spaceName: "spaces/AAA",
+      messageName: "spaces/AAA/messages/msg-1",
+      expiresAtMs: Date.now() + 60_000,
+    });
+    resolveApprovalOverGateway.mockRejectedValueOnce(
+      Object.assign(new Error("approval not found"), { gatewayCode: "APPROVAL_NOT_FOUND" }),
+    );
+    isApprovalNotFoundError.mockReturnValueOnce(true);
+    const target = createTarget();
+
+    await expect(
+      maybeHandleGoogleChatApprovalCardClick({
+        event: createCardClickEvent("token-stale"),
+        target,
+      }),
+    ).resolves.toBe(true);
+
+    await expect(
+      maybeHandleGoogleChatApprovalCardClick({
+        event: createCardClickEvent("token-stale"),
+        target,
+      }),
+    ).resolves.toBe(true);
+
+    expect(resolveApprovalOverGateway).toHaveBeenCalledTimes(1);
+    expect(target.runtime.log).toHaveBeenCalledWith(
+      "[default] googlechat approval ignored: expired approval id=approval-stale",
+    );
+    expect(target.runtime.log).toHaveBeenCalledWith(
+      "[default] googlechat approval ignored: unknown or expired card token",
+    );
   });
 });

--- a/extensions/googlechat/src/approval-card-click.ts
+++ b/extensions/googlechat/src/approval-card-click.ts
@@ -1,4 +1,5 @@
 import { resolveApprovalOverGateway } from "openclaw/plugin-sdk/approval-gateway-runtime";
+import { isApprovalNotFoundError } from "openclaw/plugin-sdk/error-runtime";
 import { googleChatApprovalAuth } from "./approval-auth.js";
 import {
   claimGoogleChatApprovalCardBinding,
@@ -83,6 +84,11 @@ export async function maybeHandleGoogleChatApprovalCardClick(params: {
       clientDisplayName: `Google Chat approval (${actor?.trim() || "unknown"})`,
     });
   } catch (error) {
+    if (isApprovalNotFoundError(error)) {
+      completeGoogleChatApprovalCardBinding(token);
+      logIgnored(params.target, `expired approval id=${consumed.approvalId}`);
+      return true;
+    }
     releaseGoogleChatApprovalCardBinding(token);
     throw error;
   }


### PR DESCRIPTION
﻿## Summary

- consume Google Chat approval card tokens when gateway resolution reports `APPROVAL_NOT_FOUND`
- keep generic gateway failures retryable as before
- add regression coverage that stale card clicks are handled once and subsequent clicks do not retry resolution

Closes #98432.

## Validation

- `node scripts/run-with-env.mjs OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 -- node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-messaging.config.ts googlechat/src/approval-card-click.test.ts -t "consumes stale approval card tokens when gateway reports approval not found" --reporter=verbose --testTimeout=30000`
- `node scripts/run-with-env.mjs OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 -- node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-messaging.config.ts googlechat/src/approval-card-click.test.ts -t "keeps the token retryable when gateway resolution fails" --reporter=verbose --testTimeout=30000`
- `node scripts/run-with-env.mjs OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 -- node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-messaging.config.ts googlechat/src/approval-card-click.test.ts --reporter=verbose --testTimeout=30000`
- `git diff --check`
