### PR TITLE
fix(clickclack): resolve exec/file SecretRefs at runtime instead of silently returning empty

### DIFF
--- a/extensions/clickclack/index.ts
+++ b/extensions/clickclack/index.ts
@@ -16,4 +16,8 @@ export default defineBundledChannelEntry({
     specifier: "./api.js",
     exportName: "setClickClackRuntime",
   },
+  secrets: {
+    specifier: "./secret-contract-api.js",
+    exportName: "channelSecrets",
+  },
 });

--- a/extensions/clickclack/secret-contract-api.ts
+++ b/extensions/clickclack/secret-contract-api.ts
@@ -1,0 +1,6 @@
+// ClickClack API module exposes the plugin public contract.
+export {
+  channelSecrets,
+  collectRuntimeConfigAssignments,
+  secretTargetRegistryEntries,
+} from "./src/secret-contract.js";

--- a/extensions/clickclack/src/channel.ts
+++ b/extensions/clickclack/src/channel.ts
@@ -26,6 +26,7 @@ import {
 import { clickClackConfigSchema } from "./config-schema.js";
 import { startClickClackGatewayAccount } from "./gateway.js";
 import { sendClickClackText } from "./outbound.js";
+import { collectRuntimeConfigAssignments, secretTargetRegistryEntries } from "./secret-contract.js";
 import {
   buildClickClackTarget,
   looksLikeClickClackTarget,
@@ -166,6 +167,10 @@ export const clickClackPlugin: ChannelPlugin<ResolvedClickClackAccount> = create
     }),
     gateway: {
       startAccount: startClickClackGatewayAccount,
+    },
+    secrets: {
+      secretTargetRegistryEntries,
+      collectRuntimeConfigAssignments,
     },
     message: clickClackMessageAdapter,
   },

--- a/extensions/clickclack/src/secret-contract.ts
+++ b/extensions/clickclack/src/secret-contract.ts
@@ -1,0 +1,92 @@
+// ClickClack plugin module implements secret contract behavior.
+import {
+  hasConfiguredSecretInputValue,
+  hasOwnProperty,
+  isBaseFieldActiveForChannelSurface,
+  normalizeSecretStringValue,
+  type ResolverContext,
+  type SecretDefaults,
+} from "openclaw/plugin-sdk/channel-secret-basic-runtime";
+import { collectSecretInputAssignment } from "openclaw/plugin-sdk/channel-secret-basic-runtime";
+import { getChannelSurface } from "openclaw/plugin-sdk/channel-secret-basic-runtime";
+import type { SecretTargetRegistryEntry } from "openclaw/plugin-sdk/channel-secret-basic-runtime";
+
+export const secretTargetRegistryEntries: SecretTargetRegistryEntry[] = [
+  {
+    id: "channels.clickclack.token",
+    targetType: "channels.clickclack.token",
+    configFile: "openclaw.json",
+    pathPattern: "channels.clickclack.token",
+    secretShape: "secret_input",
+    expectedResolvedValue: "string",
+    includeInPlan: true,
+    includeInConfigure: true,
+    includeInAudit: true,
+  },
+  {
+    id: "channels.clickclack.accounts.*.token",
+    targetType: "channels.clickclack.accounts.*.token",
+    configFile: "openclaw.json",
+    pathPattern: "channels.clickclack.accounts.*.token",
+    secretShape: "secret_input",
+    expectedResolvedValue: "string",
+    includeInPlan: true,
+    includeInConfigure: true,
+    includeInAudit: true,
+  },
+];
+
+export function collectRuntimeConfigAssignments(params: {
+  config: { channels?: Record<string, unknown> };
+  defaults?: SecretDefaults;
+  context: ResolverContext;
+}): void {
+  const resolved = getChannelSurface(params.config, "clickclack");
+  if (!resolved) {
+    return;
+  }
+  const { channel: clickclack, surface } = resolved;
+  const hasImplicitDefaultAccount =
+    surface.channelEnabled &&
+    typeof normalizeSecretStringValue(clickclack.workspace) === "string" &&
+    typeof normalizeSecretStringValue(clickclack.baseUrl) === "string" &&
+    hasConfiguredSecretInputValue(clickclack.token, params.defaults);
+  const topLevelTokenActive =
+    hasImplicitDefaultAccount || isBaseFieldActiveForChannelSurface(surface, "token");
+  collectSecretInputAssignment({
+    value: clickclack.token,
+    path: "channels.clickclack.token",
+    expected: "string",
+    defaults: params.defaults,
+    context: params.context,
+    active: topLevelTokenActive,
+    inactiveReason: "no enabled account inherits this top-level ClickClack token.",
+    apply: (value) => {
+      clickclack.token = value;
+    },
+  });
+  if (surface.hasExplicitAccounts) {
+    for (const { accountId, account, enabled } of surface.accounts) {
+      if (!hasOwnProperty(account, "token")) {
+        continue;
+      }
+      collectSecretInputAssignment({
+        value: account.token,
+        path: `channels.clickclack.accounts.${accountId}.token`,
+        expected: "string",
+        defaults: params.defaults,
+        context: params.context,
+        active: enabled,
+        inactiveReason: "ClickClack account is disabled.",
+        apply: (value) => {
+          account.token = value;
+        },
+      });
+    }
+  }
+}
+
+export const channelSecrets = {
+  secretTargetRegistryEntries,
+  collectRuntimeConfigAssignments,
+};


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where ClickClack channel token `exec` or `file` SecretRefs are treated as "not configured" at runtime, despite being valid and resolvable via `openclaw secrets audit --allow-exec`. Users with managed exec/file secret providers are forced to use wrapper scripts or env-var bridges.

Closes #98428

## Why This Change Was Made

ClickClack was missing a secret contract. Other channels (Feishu, Telegram, Discord, Slack) register their secret fields via `secretTargetRegistryEntries` + `collectRuntimeConfigAssignments` so the gateway startup pipeline resolves SecretRefs to plaintext before the channel's runtime account resolver runs. ClickClack had no such contract, so `resolveClickClackToken` could only resolve `env` SecretRefs by manually reading `process.env` — `exec`/`file` refs silently returned `""`, causing "not configured".

The fix adds the missing `secret-contract.ts` and wires it into the channel plugin definition. No change to `accounts.ts` was needed — once the gateway pipeline resolves the SecretRef, `resolveClickClackToken` sees the already-resolved plaintext value.

## User Impact

ClickClack users with `exec` or `file` SecretRef tokens can now start the channel without wrapper scripts or env-var bridges. `env` SecretRefs are unaffected. Gateway startup behavior is identical for plaintext tokens.

## Evidence

### New file — `extensions/clickclack/src/secret-contract.ts`

```ts
export const secretTargetRegistryEntries: SecretTargetRegistryEntry[] = [
  {
    id: "channels.clickclack.token",
    targetType: "channels.clickclack.token",
    configFile: "openclaw.json",
    pathPattern: "channels.clickclack.token",
    secretShape: "secret_input",
    expectedResolvedValue: "string",
    includeInPlan: true,
    includeInConfigure: true,
    includeInAudit: true,
  },
  {
    id: "channels.clickclack.accounts.*.token",
    targetType: "channels.clickclack.accounts.*.token",
    configFile: "openclaw.json",
    pathPattern: "channels.clickclack.accounts.*.token",
    secretShape: "secret_input",
    expectedResolvedValue: "string",
    includeInPlan: true,
    includeInConfigure: true,
    includeInAudit: true,
  },
];
```

`collectRuntimeConfigAssignments` resolves `channels.clickclack.token` and `channels.clickclack.accounts.<id>.token` through the configured SecretRef provider (env, exec, file) and replaces the ref with the resolved plaintext value in the config snapshot before runtime account resolution runs.

### Model — same pattern as Feishu

Feishu at `extensions/feishu/src/secret-contract.ts` (same `secretTargetRegistryEntries` + `collectRuntimeConfigAssignments` + `channelSecrets` export pattern, wired via `channel.ts:755-757`). This change follows the identical contract.

### Wiring — `extensions/clickclack/src/channel.ts` (+5 lines)

```ts
import { collectRuntimeConfigAssignments, secretTargetRegistryEntries } from "./secret-contract.js";

// In plugin definition:
secrets: {
  secretTargetRegistryEntries,
  collectRuntimeConfigAssignments,
},
```

### Resolution flow

```
Gateway startup
  → collectRuntimeConfigAssignments()
  → detects channels.clickclack.token is an exec/file SecretRef
  → runs the configured secret provider
  → writes resolved plaintext value back into config

resolveClickClackToken() at runtime
  → resolveSecretInputString({ mode: "inspect" })
  → status === "available" (already resolved by gateway pipeline)
  → returns the token value
```
