### PR TITLE
fix: Android setup codes accept local mDNS gateway hosts

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayHostSecurity.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayHostSecurity.kt
@@ -48,7 +48,7 @@ internal fun isLoopbackGatewayHost(
   return isMappedIpv4 && address[12] == 127.toByte()
 }
 
-/** Allows cleartext only for loopback and private/link-local network ranges. */
+/** Allows cleartext only for loopback, `.local`, and private/link-local network ranges. */
 internal fun isLocalCleartextGatewayHost(
   rawHost: String?,
   allowEmulatorBridgeAlias: Boolean = isAndroidEmulatorRuntime(),
@@ -62,6 +62,10 @@ internal fun isLocalCleartextGatewayHost(
   if (host.endsWith(".")) {
     host = host.dropLast(1)
   }
+  if (host.isEmpty()) return false
+  if (isLoopbackGatewayHost(host, allowEmulatorBridgeAlias = allowEmulatorBridgeAlias)) return true
+  if (isMdnsLocalHostname(host)) return true
+
   val zoneIndex = host.indexOf('%')
   if (zoneIndex >= 0) {
     // Link-local cleartext policy is about the address range; strip the
@@ -69,7 +73,6 @@ internal fun isLocalCleartextGatewayHost(
     host = host.substring(0, zoneIndex)
   }
   if (host.isEmpty()) return false
-  if (isLoopbackGatewayHost(host, allowEmulatorBridgeAlias = allowEmulatorBridgeAlias)) return true
 
   parseIpv4Address(host)?.let { ipv4 ->
     val first = ipv4[0].toInt() and 0xff
@@ -125,6 +128,20 @@ private fun parseIpv4Address(host: String): ByteArray? {
     bytes[index] = value.toByte()
   }
   return bytes
+}
+
+private fun isMdnsLocalHostname(host: String): Boolean {
+  if (host.length > 253) return false
+  if (!host.endsWith(".local")) return false
+  val labels = host.split('.')
+  if (labels.size < 2 || labels.last() != "local") return false
+  return labels.dropLast(1).all(::isDnsHostnameLabel)
+}
+
+private fun isDnsHostnameLabel(label: String): Boolean {
+  if (label.isEmpty() || label.length > 63) return false
+  if (label.first() == '-' || label.last() == '-') return false
+  return label.all { it in 'a'..'z' || it in '0'..'9' || it == '-' }
 }
 
 /** Cheap prefilter before handing potential IPv6 literals to InetAddress. */

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt
@@ -63,7 +63,7 @@ internal data class GatewayScannedSetupCodeResult(
 
 private val gatewaySetupJson = Json { ignoreUnknownKeys = true }
 private const val remoteGatewaySecurityRule =
-  "Public gateways require wss:// or Tailscale Serve. ws:// is allowed for localhost, the Android emulator, and private LAN IPs."
+  "Public gateways require wss:// or Tailscale Serve. ws:// is allowed for localhost, .local hosts, the Android emulator, and private LAN IPs."
 private const val remoteGatewaySecurityFix =
   "Use a private LAN IP for local setup, or enable Tailscale Serve / expose a wss:// gateway URL for remote access."
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayDiagnostics.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayDiagnostics.kt
@@ -56,7 +56,7 @@ internal fun buildGatewayDiagnosticsReport(
     Please:
     - pick one route only: same machine, same LAN, Tailscale, or public URL
     - classify this as pairing/auth, TLS trust, wrong advertised route, wrong address/port, or gateway down
-    - remember: public routes require wss:// or Tailscale Serve; ws:// is allowed for localhost, the Android emulator, and private LAN IPs
+    - remember: public routes require wss:// or Tailscale Serve; ws:// is allowed for localhost, .local hosts, the Android emulator, and private LAN IPs
     - quote the exact app status/error below
     - tell me whether `openclaw devices list` should show a pending pairing request
     - if more signal is needed, ask for `openclaw qr --json`, `openclaw devices list`, and `openclaw nodes status`

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/ConnectionManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/ConnectionManagerTest.kt
@@ -124,6 +124,20 @@ class ConnectionManagerTest {
   }
 
   @Test
+  fun resolveTlsParamsForEndpoint_manualMdnsRespectsManualTlsToggle() {
+    val endpoint = GatewayEndpoint.manual(host = "gateway.local", port = 18789)
+
+    val params =
+      ConnectionManager.resolveTlsParamsForEndpoint(
+        endpoint,
+        storedFingerprint = null,
+        manualTlsEnabled = false,
+      )
+
+    assertNull(params)
+  }
+
+  @Test
   fun resolveTlsParamsForEndpoint_manualPrivateLanCleartextCanOverrideStoredPin() {
     val endpoint = GatewayEndpoint.manual(host = "192.168.1.20", port = 18789)
 
@@ -168,6 +182,30 @@ class ConnectionManagerTest {
         stableId = "_openclaw-gw._tcp.|local.|Test",
         name = "Test",
         host = "192.168.1.20",
+        port = 18789,
+        tlsEnabled = false,
+        tlsFingerprintSha256 = null,
+      )
+
+    val params =
+      ConnectionManager.resolveTlsParamsForEndpoint(
+        endpoint,
+        storedFingerprint = null,
+        manualTlsEnabled = false,
+      )
+
+    assertEquals(true, params?.required)
+    assertNull(params?.expectedFingerprint)
+    assertEquals(false, params?.allowTOFU)
+  }
+
+  @Test
+  fun resolveTlsParamsForEndpoint_discoveryMdnsWithoutHintsStillRequiresTls() {
+    val endpoint =
+      GatewayEndpoint(
+        stableId = "_openclaw-gw._tcp.|local.|Test",
+        name = "Test",
+        host = "gateway.local",
         port = 18789,
         tlsEnabled = false,
         tlsFingerprintSha256 = null,
@@ -258,9 +296,16 @@ class ConnectionManagerTest {
   }
 
   @Test
-  fun isLocalCleartextGatewayHost_acceptsLanIpsButRejectsMdnsAndTailnetHosts() {
+  fun isLocalCleartextGatewayHost_acceptsLanIpsAndMdnsButRejectsRemoteHosts() {
     assertTrue(isLocalCleartextGatewayHost("192.168.1.20"))
-    assertFalse(isLocalCleartextGatewayHost("gateway.local"))
+    assertTrue(isLocalCleartextGatewayHost("gateway.local"))
+    assertTrue(isLocalCleartextGatewayHost("GATEWAY.LOCAL."))
+    assertFalse(isLocalCleartextGatewayHost("gateway.local.evil.com"))
+    assertFalse(isLocalCleartextGatewayHost("gatewaylocal"))
+    assertFalse(isLocalCleartextGatewayHost("local"))
+    assertFalse(isLocalCleartextGatewayHost(".local"))
+    assertFalse(isLocalCleartextGatewayHost("gateway..local"))
+    assertFalse(isLocalCleartextGatewayHost("gateway.local%25wlan0"))
     assertFalse(isLocalCleartextGatewayHost("100.64.0.9"))
     assertFalse(isLocalCleartextGatewayHost("gateway.tailnet.ts.net"))
   }

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt
@@ -114,10 +114,44 @@ class GatewayConfigResolverTest {
   }
 
   @Test
-  fun parseGatewayEndpointRejectsMdnsCleartextWsUrls() {
+  fun parseGatewayEndpointAllowsMdnsCleartextWsUrls() {
     val parsed = parseGatewayEndpoint("ws://gateway.local:18789")
 
-    assertNull(parsed)
+    assertEquals(
+      GatewayEndpointConfig(
+        host = "gateway.local",
+        port = 18789,
+        tls = false,
+        displayUrl = "http://gateway.local:18789",
+      ),
+      parsed,
+    )
+  }
+
+  @Test
+  fun parseGatewayEndpointAllowsNormalizedMdnsCleartextWsUrls() {
+    val parsed = parseGatewayEndpoint("ws://GATEWAY.LOCAL.:18789")
+
+    assertEquals("GATEWAY.LOCAL.", parsed?.host)
+    assertEquals(18789, parsed?.port)
+    assertEquals(false, parsed?.tls)
+  }
+
+  @Test
+  fun parseGatewayEndpointRejectsMdnsSuffixAndLabelBypasses() {
+    val rejected =
+      listOf(
+        "ws://gateway.local.evil.com:18789",
+        "ws://gatewaylocal:18789",
+        "ws://local:18789",
+        "ws://.local:18789",
+        "ws://gateway..local:18789",
+        "ws://gateway.local%25wlan0:18789",
+      )
+
+    for (url in rejected) {
+      assertNull(url, parseGatewayEndpoint(url))
+    }
   }
 
   @Test
@@ -280,6 +314,17 @@ class GatewayConfigResolverTest {
   }
 
   @Test
+  fun resolveScannedSetupCodeResultAcceptsMdnsCleartextGateway() {
+    val setupCode =
+      encodeSetupCode("""{"url":"ws://gateway.local:18789","bootstrapToken":"bootstrap-1"}""")
+
+    val resolved = resolveScannedSetupCodeResult(setupCode)
+
+    assertEquals(setupCode, resolved.setupCode)
+    assertNull(resolved.error)
+  }
+
+  @Test
   fun resolveScannedSetupCodeResultFlagsInsecureRemoteGateway() {
     val setupCode =
       encodeSetupCode("""{"url":"ws://attacker.example:18789","bootstrapToken":"bootstrap-1"}""")
@@ -316,6 +361,22 @@ class GatewayConfigResolverTest {
         port = 18789,
         tls = false,
         displayUrl = "http://192.168.1.20:18789",
+      ),
+      parsed.config,
+    )
+    assertNull(parsed.error)
+  }
+
+  @Test
+  fun parseGatewayEndpointResultAllowsMdnsCleartextGateway() {
+    val parsed = parseGatewayEndpointResult("ws://gateway.local:18789")
+
+    assertEquals(
+      GatewayEndpointConfig(
+        host = "gateway.local",
+        port = 18789,
+        tls = false,
+        displayUrl = "http://gateway.local:18789",
       ),
       parsed.config,
     )
@@ -386,6 +447,34 @@ class GatewayConfigResolverTest {
     assertEquals("gateway.example", resolved?.host)
     assertEquals(443, resolved?.port)
     assertEquals(true, resolved?.tls)
+    assertEquals("bootstrap-1", resolved?.bootstrapToken)
+    assertNull(resolved?.token?.takeIf { it.isNotEmpty() })
+    assertNull(resolved?.password?.takeIf { it.isNotEmpty() })
+  }
+
+  @Test
+  fun resolveGatewayConnectConfigAllowsMdnsCleartextSetupCode() {
+    val setupCode =
+      encodeSetupCode("""{"url":"ws://gateway.local:18789","bootstrapToken":"bootstrap-1"}""")
+
+    val resolved =
+      resolveGatewayConnectConfig(
+        useSetupCode = true,
+        setupCode = setupCode,
+        savedManualHost = "",
+        savedManualPort = "",
+        savedManualTls = false,
+        manualHostInput = "",
+        manualPortInput = "",
+        manualTlsInput = false,
+        fallbackBootstrapToken = "",
+        fallbackToken = "shared-token",
+        fallbackPassword = "shared-password",
+      )
+
+    assertEquals("gateway.local", resolved?.host)
+    assertEquals(18789, resolved?.port)
+    assertEquals(false, resolved?.tls)
     assertEquals("bootstrap-1", resolved?.bootstrapToken)
     assertNull(resolved?.token?.takeIf { it.isNotEmpty() })
     assertNull(resolved?.password?.takeIf { it.isNotEmpty() })
@@ -477,6 +566,28 @@ class GatewayConfigResolverTest {
       )
 
     assertEquals("192.168.31.100", resolved?.host)
+    assertEquals(18789, resolved?.port)
+    assertEquals(false, resolved?.tls)
+  }
+
+  @Test
+  fun resolveGatewayConnectConfigAllowsMdnsManualCleartextEndpoint() {
+    val resolved =
+      resolveGatewayConnectConfig(
+        useSetupCode = false,
+        setupCode = "",
+        savedManualHost = "",
+        savedManualPort = "",
+        savedManualTls = false,
+        manualHostInput = "gateway.local",
+        manualPortInput = "18789",
+        manualTlsInput = false,
+        fallbackBootstrapToken = "bootstrap-1",
+        fallbackToken = "",
+        fallbackPassword = "",
+      )
+
+    assertEquals("gateway.local", resolved?.host)
     assertEquals(18789, resolved?.port)
     assertEquals(false, resolved?.tls)
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Android users pairing with a local Gateway through a setup code would be rejected when the setup code used a cleartext `ws://...local:<port>` mDNS hostname.

The affected workflow is Android Gateway setup/pairing from QR/setup-code or manual endpoint entry. The app already allowed loopback/LAN cleartext addresses, but treated `.local` mDNS hosts as remote and failed setup-code validation before the connection layer could try the local Gateway.

AI-assisted: yes.

## Why This Change Was Made

The Android cleartext allowlist now treats syntactically valid `.local` hostnames as local mDNS endpoints for explicit setup-code/manual Gateway input. The check is intentionally syntax-based rather than DNS-resolution-based: it classifies the user-provided mDNS namespace without trusting a resolved address, avoiding DNS side effects and TOCTOU behavior.

The security boundary stays narrow: suffix/lookalike/malformed hosts such as `gateway.local.evil.com`, `gateway..local`, and `gateway.local%25wlan0` remain rejected, CGNAT/tailnet-style cleartext hosts remain rejected, and discovered non-loopback endpoints still require TLS unless they carry the existing local-cleartext hint.

## User Impact

Android users can pair with a Gateway advertised through normal `.local` mDNS setup codes on a local network without switching to an IP address or TLS endpoint.

Remote or ambiguous cleartext hosts continue to fail closed, so this does not broaden Android setup-code handling into a general remote-cleartext bypass.

## Evidence

- Focused Android unit proof passed:
  `./gradlew testPlayDebugUnitTest --tests ai.openclaw.app.ui.GatewayConfigResolverTest --tests ai.openclaw.app.node.ConnectionManagerTest --console=plain`
- Android CI-equivalent lane passed:
  `./gradlew testPlayDebugUnitTest testThirdPartyDebugUnitTest assemblePlayDebug --console=plain`
- Remote changed gate passed through Testbox-through-Crabbox:
  - provider: `blacksmith-testbox`
  - Testbox id: `tbx_01kwe3ff7mx6xzgmjc0h4623aq`
  - Actions run: `28496485353`
  - command: `corepack pnpm check:changed`
  - result: `exitCode: 0`
- `$autoreview` passed clean:
  `.agents/skills/autoreview/scripts/autoreview --mode local`
- Live Android E2E fix proof passed:
  - Installed the patched Play debug APK on an Android emulator.
  - Entered a setup code whose payload URL was `ws://gateway.local:18789`.
  - The app advanced past setup-code validation into Gateway recovery/connection handling.
- Live Android regression proof passed:
  - Entered a setup code whose payload URL was `ws://100.64.0.9:18789`.
  - The app stayed on Gateway Setup and showed `Setup code issue`, preserving the fail-closed behavior for CGNAT/tailnet cleartext hosts.
