### PR TITLE
fix(ios): improve light and dark appearance contrast

### DIFF
--- a/apps/ios/Sources/Design/OpenClawBrand.swift
+++ b/apps/ios/Sources/Design/OpenClawBrand.swift
@@ -29,6 +29,14 @@ enum AppAppearancePreference: String, CaseIterable, Identifiable {
         }
     }
 
+    var detail: String {
+        switch self {
+        case .system: "Matches the system appearance."
+        case .light: "Always uses light appearance."
+        case .dark: "Always uses dark appearance."
+        }
+    }
+
     var colorScheme: ColorScheme? {
         switch self {
         case .system: nil
@@ -47,36 +55,19 @@ enum AppAppearancePreference: String, CaseIterable, Identifiable {
 }
 
 enum OpenClawBrand {
-    static let uiAccent = UIColor { traits in
-        traits.userInterfaceStyle == .dark
-            ? UIColor(red: 198 / 255.0, green: 62 / 255.0, blue: 56 / 255.0, alpha: 1)
-            : UIColor(red: 183 / 255.0, green: 56 / 255.0, blue: 51 / 255.0, alpha: 1)
-    }
+    static let uiAccent = adaptiveUIColor(light: (183, 56, 51), dark: (198, 62, 56))
+    static let uiOK = adaptiveUIColor(light: (19, 122, 62), dark: (48, 209, 88))
+    static let uiWarn = adaptiveUIColor(light: (154, 87, 0), dark: (255, 214, 10))
+    static let uiInfo = adaptiveUIColor(light: (0, 91, 196), dark: (100, 168, 255))
 
     static let accent = Color(uiColor: Self.uiAccent)
-    static let accentHot = Color(uiColor: UIColor { traits in
-        traits.userInterfaceStyle == .dark
-            ? UIColor(red: 232 / 255.0, green: 92 / 255.0, blue: 86 / 255.0, alpha: 1)
-            : UIColor(red: 204 / 255.0, green: 75 / 255.0, blue: 69 / 255.0, alpha: 1)
-    })
-    static let danger = Color(uiColor: UIColor { traits in
-        traits.userInterfaceStyle == .dark
-            ? UIColor(red: 252 / 255.0, green: 165 / 255.0, blue: 165 / 255.0, alpha: 1)
-            : UIColor(red: 185 / 255.0, green: 28 / 255.0, blue: 28 / 255.0, alpha: 1)
-    })
-    static let ok = Color(red: 34 / 255.0, green: 197 / 255.0, blue: 94 / 255.0)
-    static let warn = Color(red: 245 / 255.0, green: 158 / 255.0, blue: 11 / 255.0)
-    static let info = Color(red: 0 / 255.0, green: 122 / 255.0, blue: 255 / 255.0)
-    static let graphite = Color(uiColor: UIColor { traits in
-        traits.userInterfaceStyle == .dark
-            ? UIColor(red: 20 / 255.0, green: 22 / 255.0, blue: 24 / 255.0, alpha: 1)
-            : UIColor(red: 246 / 255.0, green: 247 / 255.0, blue: 249 / 255.0, alpha: 1)
-    })
-    static let graphiteElevated = Color(uiColor: UIColor { traits in
-        traits.userInterfaceStyle == .dark
-            ? UIColor(red: 34 / 255.0, green: 36 / 255.0, blue: 39 / 255.0, alpha: 1)
-            : UIColor.white
-    })
+    static let accentHot = Color(uiColor: adaptiveUIColor(light: (204, 75, 69), dark: (232, 92, 86)))
+    static let danger = Color(uiColor: adaptiveUIColor(light: (185, 28, 28), dark: (252, 165, 165)))
+    static let ok = Color(uiColor: Self.uiOK)
+    static let warn = Color(uiColor: Self.uiWarn)
+    static let info = Color(uiColor: Self.uiInfo)
+    static let graphite = Color(uiColor: adaptiveUIColor(light: (246, 247, 249), dark: (20, 22, 24)))
+    static let graphiteElevated = Color(uiColor: adaptiveUIColor(light: (255, 255, 255), dark: (34, 36, 39)))
 
     static var sheetBackground: LinearGradient {
         LinearGradient(
@@ -87,6 +78,20 @@ enum OpenClawBrand {
             ],
             startPoint: .topLeading,
             endPoint: .bottomTrailing)
+    }
+
+    private static func adaptiveUIColor(
+        light: (red: CGFloat, green: CGFloat, blue: CGFloat),
+        dark: (red: CGFloat, green: CGFloat, blue: CGFloat)) -> UIColor
+    {
+        UIColor { traits in
+            let components = traits.userInterfaceStyle == .dark ? dark : light
+            return UIColor(
+                red: components.red / 255,
+                green: components.green / 255,
+                blue: components.blue / 255,
+                alpha: 1)
+        }
     }
 }
 

--- a/apps/ios/Sources/Design/SettingsProTab.swift
+++ b/apps/ios/Sources/Design/SettingsProTab.swift
@@ -89,6 +89,10 @@ struct SettingsProTab: View {
                 self.settingsContent))
     }
 
+    var appearancePreference: AppAppearancePreference {
+        AppAppearancePreference(rawValue: self.appearancePreferenceRaw) ?? .system
+    }
+
     @ViewBuilder
     private var settingsContent: some View {
         if let directRoute {

--- a/apps/ios/Sources/Design/SettingsProTabSections.swift
+++ b/apps/ios/Sources/Design/SettingsProTabSections.swift
@@ -30,7 +30,7 @@ extension SettingsProTab {
                         }
                     }
                     .pickerStyle(.segmented)
-                    Text("Follows iOS appearance.")
+                    Text(self.appearancePreference.detail)
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }

--- a/apps/ios/Tests/OpenClawBrandTests.swift
+++ b/apps/ios/Tests/OpenClawBrandTests.swift
@@ -1,0 +1,54 @@
+import Testing
+import UIKit
+@testable import OpenClaw
+
+struct OpenClawBrandTests {
+    @Test func `appearance preference details match selection`() {
+        #expect(AppAppearancePreference.system.detail == "Matches the system appearance.")
+        #expect(AppAppearancePreference.light.detail == "Always uses light appearance.")
+        #expect(AppAppearancePreference.dark.detail == "Always uses dark appearance.")
+    }
+
+    @Test func `semantic colors meet text contrast in both appearances`() {
+        let colors = [OpenClawBrand.uiOK, OpenClawBrand.uiWarn, OpenClawBrand.uiInfo]
+        let backgrounds = [UIColor.systemBackground, UIColor.secondarySystemBackground]
+
+        for style in [UIUserInterfaceStyle.light, .dark] {
+            let traits = UITraitCollection(userInterfaceStyle: style)
+            for color in colors {
+                for background in backgrounds {
+                    #expect(Self.contrastRatio(color, background, traits: traits) >= 4.5)
+                }
+            }
+        }
+    }
+
+    private static func contrastRatio(
+        _ foreground: UIColor,
+        _ background: UIColor,
+        traits: UITraitCollection) -> CGFloat
+    {
+        let foregroundLuminance = Self.relativeLuminance(foreground, traits: traits)
+        let backgroundLuminance = Self.relativeLuminance(background, traits: traits)
+        let lighter = max(foregroundLuminance, backgroundLuminance)
+        let darker = min(foregroundLuminance, backgroundLuminance)
+        return (lighter + 0.05) / (darker + 0.05)
+    }
+
+    private static func relativeLuminance(_ color: UIColor, traits: UITraitCollection) -> CGFloat {
+        let resolved = color.resolvedColor(with: traits)
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+        guard resolved.getRed(&red, green: &green, blue: &blue, alpha: &alpha) else { return 0 }
+
+        func linearize(_ component: CGFloat) -> CGFloat {
+            component <= 0.04045
+                ? component / 12.92
+                : pow((component + 0.055) / 1.055, 2.4)
+        }
+
+        return 0.2126 * linearize(red) + 0.7152 * linearize(green) + 0.0722 * linearize(blue)
+    }
+}

--- a/apps/ios/UITests/OpenClawSnapshotUITests.swift
+++ b/apps/ios/UITests/OpenClawSnapshotUITests.swift
@@ -3,6 +3,11 @@ import XCTest
 
 @MainActor
 final class OpenClawSnapshotUITests: XCTestCase {
+    private enum ScreenshotAppearance: String, CaseIterable {
+        case light
+        case dark
+    }
+
     private struct ScreenshotTarget {
         let initialTab: String
         let initialDestination: String
@@ -31,9 +36,12 @@ final class OpenClawSnapshotUITests: XCTestCase {
     }
 
     func testConnectedGatewayTabs() {
-        for target in Self.screenshotTargets {
-            launchApp(for: target)
-            snapshot(target.name, timeWaitingForIdle: 5)
+        for appearance in ScreenshotAppearance.allCases {
+            for target in Self.screenshotTargets {
+                launchApp(for: target, appearance: appearance)
+                let name = appearance == .light ? target.name : "\(target.name)-dark"
+                snapshot(name, timeWaitingForIdle: 5)
+            }
         }
     }
 
@@ -103,13 +111,18 @@ final class OpenClawSnapshotUITests: XCTestCase {
         XCTAssertEqual(app.state, .runningForeground)
     }
 
-    private func launchApp(for target: ScreenshotTarget) {
+    private func launchApp(
+        for target: ScreenshotTarget,
+        appearance: ScreenshotAppearance = .light)
+    {
         self.app?.terminate()
 
         let app = XCUIApplication()
         setupSnapshot(app, waitForAnimations: false)
         app.launchArguments += [
             "--openclaw-screenshot-mode",
+            "--openclaw-appearance",
+            appearance.rawValue,
             "--openclaw-initial-tab",
             target.initialTab,
             "--openclaw-initial-destination",


### PR DESCRIPTION
Closes #98440

## What Problem This Solves

Fixes an issue where iOS users in light appearance would see low-contrast connected, warning, and informational status text. The Appearance setting also described every selection as following iOS, even when Light or Dark was explicitly selected.

## Why This Change Was Made

Semantic status colors now resolve to separate WCAG-compliant light and dark palettes while preserving the existing brand palette and appearance override behavior. The settings helper follows the selected mode, and the deterministic screenshot lane now exercises all five primary screens in both appearances.

## User Impact

Connection state and actions remain legible in light and dark mode. System, Light, and Dark selections now explain their actual behavior.

## Evidence

- iPhone 17 simulator, iOS 26.5; Xcode 26.6.
- `OpenClawBrandTests`: adaptive status colors meet a 4.5:1 contrast floor against primary and card backgrounds in both appearances; appearance descriptions match all selections.
- `OpenClawSnapshotUITests/testConnectedGatewayTabs`: 10/10 deterministic launches passed (Control, Chat, Talk, Agent, Settings × Light/Dark).
- Focused Xcode build, SwiftFormat lint, SwiftLint build phase, and `git diff --check` passed. Five pre-existing SwiftLint warnings remain outside the touched files.
- Fresh branch autoreview: clean; no accepted/actionable findings (0.92 confidence).
- Before/after simulator captures below; deterministic fixture data, identical device and status-bar state.

### Light appearance

| Control — before | Control — after |
| --- | --- |
| <img width="375" alt="Light Control before: low-contrast Online status" src="https://github.com/user-attachments/assets/dde6d765-b709-4d34-9f3c-fe2c1bb80ad8" /> | <img width="375" alt="Light Control after: accessible Online status contrast" src="https://github.com/user-attachments/assets/f52594de-2543-4f6e-b421-87cff59c699c" /> |

| Settings — before | Settings — after |
| --- | --- |
| <img width="375" alt="Light Settings before: static appearance helper and low-contrast actions" src="https://github.com/user-attachments/assets/d5575a25-1a04-4650-87af-67df95b20fc3" /> | <img width="375" alt="Light Settings after: selection-specific helper and accessible action contrast" src="https://github.com/user-attachments/assets/3e47068d-3621-4acc-af6c-190066279735" /> |

### Dark appearance

| Control — before | Control — after |
| --- | --- |
| <img width="375" alt="Dark Control before" src="https://github.com/user-attachments/assets/d41919b6-77b0-4bb1-b049-2640e292cdf6" /> | <img width="375" alt="Dark Control after: vivid semantic status colors retained" src="https://github.com/user-attachments/assets/e4021982-d1f7-4f9b-a5dc-44a9613a858a" /> |

| Settings — before | Settings — after |
| --- | --- |
| <img width="375" alt="Dark Settings before: static appearance helper" src="https://github.com/user-attachments/assets/1ef04f0e-d56a-4c1e-89d1-6e9b80e83313" /> | <img width="375" alt="Dark Settings after: selection-specific helper and vivid action contrast" src="https://github.com/user-attachments/assets/85b593cd-f9dd-4900-809f-d0d736da9b8b" /> |
