### PR TITLE
fix: treat macos protocol mismatch as terminal

### DIFF
--- a/apps/macos/Tests/OpenClawIPCTests/GatewayChannelConnectTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayChannelConnectTests.swift
@@ -332,6 +332,29 @@ struct GatewayChannelConnectTests {
         }
     }
 
+    @Test func `protocol mismatch connect failure is terminal`() async throws {
+        let session = self.makeSession(response: .authFailed(
+            delayMs: 0,
+            detailCode: GatewayConnectAuthDetailCode.protocolMismatch.rawValue,
+            canRetryWithDeviceToken: false,
+            recommendedNextStep: nil))
+        let channel = try GatewayChannelActor(
+            url: #require(URL(string: "ws://example.invalid")),
+            token: nil,
+            session: WebSocketSessionBox(session: session))
+
+        do {
+            try await channel.connect()
+            Issue.record("expected GatewayConnectAuthError")
+        } catch let error as GatewayConnectAuthError {
+            #expect(error.detail == .protocolMismatch)
+            #expect(error.detailCode == GatewayConnectAuthDetailCode.protocolMismatch.rawValue)
+            #expect(error.isNonRecoverable)
+        } catch {
+            Issue.record("unexpected error: \(error)")
+        }
+    }
+
     @Test func `connect maps user cancelled authentication with cached TLS failure`() async throws {
         let failure = GatewayTLSValidationFailure(
             kind: .pinMismatch,

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayErrors.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayErrors.swift
@@ -18,6 +18,7 @@ public enum GatewayConnectAuthDetailCode: String, Sendable {
     case authTailscaleProxyMissing = "AUTH_TAILSCALE_PROXY_MISSING"
     case authTailscaleWhoisFailed = "AUTH_TAILSCALE_WHOIS_FAILED"
     case authTailscaleIdentityMismatch = "AUTH_TAILSCALE_IDENTITY_MISMATCH"
+    case protocolMismatch = "PROTOCOL_MISMATCH"
     case pairingRequired = "PAIRING_REQUIRED"
     case controlUiDeviceIdentityRequired = "CONTROL_UI_DEVICE_IDENTITY_REQUIRED"
     case deviceIdentityRequired = "DEVICE_IDENTITY_REQUIRED"
@@ -162,6 +163,7 @@ public struct GatewayConnectAuthError: LocalizedError, Sendable {
              .authPasswordNotConfigured,
              .authRateLimited,
              .authScopeMismatch,
+             .protocolMismatch,
              .pairingRequired,
              .controlUiDeviceIdentityRequired,
              .deviceIdentityRequired:


### PR DESCRIPTION
﻿## Summary
- add the Swift `PROTOCOL_MISMATCH` auth detail code
- classify protocol mismatch connect failures as non-recoverable so macOS stops reconnecting
- add a GatewayChannel regression test for terminal protocol mismatch failures

Closes #98442

## Testing
- `git diff --check`
- Not run: Swift tests (`swift --version` fails on this Windows environment: Swift toolchain is not installed)
