### PR TITLE
fix(agents): traverse errorBody and provider detail fields in Anthropic thinking-block recovery

### DIFF
--- a/src/agents/embedded-agent-runner/thinking.test.ts
+++ b/src/agents/embedded-agent-runner/thinking.test.ts
@@ -1136,6 +1136,81 @@ describe("wrapAnthropicStreamWithRecovery", () => {
     );
     expect(callCount).toBe(1);
   });
+
+  it("fires the onRecoveredAnthropicThinking hook when errorBody-based recovery succeeds", async () => {
+    // The recovery notification hook must fire after a successful retry so
+    // callers (session manager, telemetry) can observe the self-heal event.
+    const providerError = new ProviderHttpError(
+      "LLM request failed: provider rejected the request schema or tool payload.",
+      {
+        status: 400,
+        body: '{"error":{"message":"Invalid `signature` in `thinking` block"}}',
+      },
+    );
+    const hookCalls: Array<{
+      originalCount: number;
+      cleanedCount: number;
+    }> = [];
+    let callCount = 0;
+    const wrapped = wrapAnthropicStreamWithRecovery(
+      (() => {
+        callCount += 1;
+        if (callCount === 1) {
+          return Promise.reject(providerError);
+        }
+        const stream = createAssistantMessageEventStream();
+        const finalMessage = createTestAssistantMessage({
+          content: [{ type: "text", text: "recovered response" }],
+          stopReason: "stop",
+        }) as AssistantMessage;
+        queueMicrotask(() => {
+          stream.push({ type: "start", partial: finalMessage });
+          stream.push({ type: "done", reason: "stop", message: finalMessage });
+          stream.end();
+        });
+        return stream;
+      }) as Parameters<typeof wrapAnthropicStreamWithRecovery>[0],
+      {
+        id: "test-session",
+        onRecoveredAnthropicThinking: (recovery) => {
+          hookCalls.push({
+            originalCount: recovery.originalMessages.length,
+            cleanedCount: recovery.cleanedMessages.length,
+          });
+        },
+      },
+    );
+
+    // The wrapper returns a Promise (first call rejected) that resolves to
+    // the retry stream.  Drain events and await result() so the recovery
+    // notification hook fires, then verify the hook payload.
+    const response = (await wrapped(
+      {} as never,
+      {
+        messages: castAgentMessages([
+          {
+            role: "assistant",
+            content: [{ type: "thinking", thinking: "secret", thinkingSignature: "sig" }],
+          },
+        ]),
+      } as never,
+      {} as never,
+    )) as { result: () => Promise<unknown> } & AsyncIterable<unknown>;
+
+    const events: unknown[] = [];
+    for await (const event of response) {
+      events.push(event);
+    }
+    const result = await response.result();
+
+    expect(callCount).toBe(2);
+    expect(result).toBeDefined();
+    expect(hookCalls).toHaveLength(1);
+    expect(hookCalls[0].originalCount).toBe(1);
+    // Retry strips thinking blocks: 1 original assistant → 1 cleaned message.
+    expect(hookCalls[0].cleanedCount).toBe(1);
+    expect(events.some((e) => (e as { type?: string }).type === "done")).toBe(true);
+  });
 });
 
 describe("stripStaleThinkingSignaturesForCompactionReplay", () => {

--- a/src/agents/embedded-agent-runner/thinking.test.ts
+++ b/src/agents/embedded-agent-runner/thinking.test.ts
@@ -3,6 +3,7 @@
 import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
 import { createAssistantMessageEventStream } from "openclaw/plugin-sdk/llm";
 import { describe, expect, it, vi } from "vitest";
+import { ProviderHttpError } from "../provider-http-errors.js";
 import { castAgentMessage, castAgentMessages } from "../test-helpers/agent-message-fixtures.js";
 import {
   OMITTED_ASSISTANT_REASONING_TEXT,
@@ -1008,6 +1009,132 @@ describe("wrapAnthropicStreamWithRecovery", () => {
 
     await expect(response.result()).resolves.toEqual(finalMessage);
     expect(events).toHaveLength(2);
+  });
+
+  it("recovers when ProviderHttpError.errorBody contains a thinking signature error", async () => {
+    // ProviderHttpError stores the actionable Anthropic rejection detail on
+    // errorBody while .message carries a generic human-facing string.
+    // Recovery must traverse errorBody to detect the thinking-block failure.
+    const providerError = new ProviderHttpError(
+      "LLM request failed: provider rejected the request schema or tool payload.",
+      {
+        status: 400,
+        body: '{"error":{"message":"Invalid `signature` in `thinking` block"}}',
+      },
+    );
+    let callCount = 0;
+    const wrapped = wrapAnthropicStreamWithRecovery(
+      (() => {
+        callCount += 1;
+        return Promise.reject(providerError);
+      }) as Parameters<typeof wrapAnthropicStreamWithRecovery>[0],
+      { id: "test-session" },
+    );
+
+    await expect(
+      wrapped(
+        {} as never,
+        {
+          messages: castAgentMessages([
+            {
+              role: "assistant",
+              content: [{ type: "thinking", thinking: "secret", thinkingSignature: "sig" }],
+            },
+          ]),
+        } as never,
+        {} as never,
+      ),
+    ).rejects.toBe(providerError);
+    expect(callCount).toBe(2);
+  });
+
+  it("recovers when a thinking signature error is nested inside errorBody in a cause chain", async () => {
+    // Some error wrappers nest the ProviderHttpError inside .cause.
+    // Recovery must traverse the cause chain and still find errorBody.
+    const providerError = new ProviderHttpError(
+      "LLM request failed: provider rejected the request schema or tool payload.",
+      {
+        status: 400,
+        body: '{"error":{"message":"Invalid `signature` in `thinking` block"}}',
+      },
+    );
+    const outerError = new Error("failover: all providers exhausted");
+    Object.defineProperty(outerError, "cause", {
+      value: providerError,
+      enumerable: true,
+      configurable: true,
+    });
+    let callCount = 0;
+    const wrapped = wrapAnthropicStreamWithRecovery(
+      (() => {
+        callCount += 1;
+        return Promise.reject(outerError);
+      }) as Parameters<typeof wrapAnthropicStreamWithRecovery>[0],
+      { id: "test-session" },
+    );
+
+    await expect(
+      wrapped(
+        {} as never,
+        {
+          messages: castAgentMessages([
+            {
+              role: "assistant",
+              content: [{ type: "thinking", thinking: "secret", thinkingSignature: "sig" }],
+            },
+          ]),
+        } as never,
+        {} as never,
+      ),
+    ).rejects.toBe(outerError);
+    expect(callCount).toBe(2);
+  });
+
+  it("does not recover when ProviderHttpError.errorBody is a non-thinking error", async () => {
+    // errorBody traversal must not false-positive on unrelated provider errors
+    // (rate limits, auth failures, context overflow, etc.).
+    const rateLimitError = new ProviderHttpError("Anthropic (429): rate limit exceeded", {
+      status: 429,
+      body: '{"error":{"message":"Rate limit exceeded. Please try again later."}}',
+    });
+    let callCount = 0;
+    const wrapped = wrapAnthropicStreamWithRecovery(
+      (() => {
+        callCount += 1;
+        return Promise.reject(rateLimitError);
+      }) as Parameters<typeof wrapAnthropicStreamWithRecovery>[0],
+      { id: "test-session" },
+    );
+
+    await expect(wrapped({} as never, { messages: [] } as never, {} as never)).rejects.toBe(
+      rateLimitError,
+    );
+    expect(callCount).toBe(1);
+  });
+
+  it("does not recover when ProviderHttpError has a generic schema rejection without thinking detail", async () => {
+    // Generic schema rejections (missing required fields, type mismatches, etc.)
+    // must not trigger thinking-block recovery.
+    const genericError = new ProviderHttpError(
+      "LLM request failed: provider rejected the request schema or tool payload.",
+      {
+        status: 400,
+        body: '{"error":{"message":"`messages.5.content.1`: unknown field `tool_call`"}}',
+      },
+    );
+    let callCount = 0;
+    const wrapped = wrapAnthropicStreamWithRecovery(
+      (() => {
+        callCount += 1;
+        return Promise.reject(genericError);
+      }) as Parameters<typeof wrapAnthropicStreamWithRecovery>[0],
+      { id: "test-session" },
+    );
+
+    await expect(wrapped({} as never, { messages: [] } as never, {} as never)).rejects.toBe(
+      genericError,
+    );
+    expect(callCount).toBe(1);
   });
 });
 

--- a/src/agents/embedded-agent-runner/thinking.ts
+++ b/src/agents/embedded-agent-runner/thinking.ts
@@ -546,13 +546,46 @@ function shouldRecoverAnthropicThinkingError(
     current.rawError,
     current.errorMessage,
     current.message,
+    // ProviderHttpError stores the raw response body on errorBody, not on any
+    // field traversed above.  Also cover common aliases so recovery works
+    // regardless of which error wrapper carried the rejection.
+    current.errorBody,
+    current.body,
+    current.detail,
+    current.responseBody,
+    current.data,
   ]);
   for (const candidate of candidates) {
-    if (
-      typeof candidate === "string" &&
-      shouldRecoverAnthropicThinkingErrorMessage(candidate, sessionMeta)
-    ) {
-      return true;
+    if (typeof candidate === "string") {
+      if (shouldRecoverAnthropicThinkingErrorMessage(candidate, sessionMeta)) {
+        return true;
+      }
+      continue;
+    }
+    // Some providers store the rejection detail as a parsed object (e.g. a
+    // JSON-decoded error payload on errorBody).  Serialize only these
+    // provider-detail objects under a bounded char cap before testing against
+    // the thinking-block error pattern.  Skip arrays and opaque carrier
+    // objects (AgentMessage, etc.) whose content fields may coincidentally
+    // match the pattern without carrying an actionable provider rejection.
+    if (candidate && typeof candidate === "object" && !Array.isArray(candidate)) {
+      const record = candidate as Record<string, unknown>;
+      // Provider-detail objects are small and error-shaped; carrier objects
+      // like AgentMessage carry a role / content / stopReason signature.
+      if (record.role !== undefined || record.content !== undefined) {
+        continue;
+      }
+      try {
+        const serialized = JSON.stringify(candidate);
+        if (
+          serialized.length <= 20_000 &&
+          shouldRecoverAnthropicThinkingErrorMessage(serialized, sessionMeta)
+        ) {
+          return true;
+        }
+      } catch {
+        // Circular or non-serializable object; skip.
+      }
     }
   }
   return false;


### PR DESCRIPTION
Fixes #98308

  ## What Problem This Solves

  `shouldRecoverAnthropicThinkingError` fails to detect the production error shape for invalid Anthropic thinking-block signatures. `ProviderHttpError` stores the raw provider rejection
  on `errorBody` (e.g. `Invalid signature in thinking block`), but the detector only traverses `cause`, `error`, `rawError`, `errorMessage`, and `message`. The `.message` carries a
  generic human-facing string, so the detector silently returns `false` and the session stays permanently bricked — even though the non-destructive
  `repairRejectedThinkingReplayInSessionManager` path already exists.

  Every later turn fails with HTTP 400 `Invalid signature in thinking block` until a destructive `openclaw sessions compact` is run.

  ## Why This Change Was Made

  Broaden the error-graph traversal in `shouldRecoverAnthropicThinkingError` to include provider detail fields (`errorBody`, `body`, `detail`, `responseBody`, `data`) so string-valued
  rejection detail is tested against `THINKING_BLOCK_ERROR_PATTERN`.

  Object-typed provider detail (e.g. parsed JSON error payloads) is also covered: the detector serializes candidate objects that are not AgentMessage carriers (skipping objects with
  `role` / `content` properties), bounded at 20,000 chars.

  The change is additive — no existing detection paths are narrowed or removed.

  ## User Impact

  Users running native extended thinking on Claude models (`opus-4.x`, `sonnet-4.x`, `haiku-4.x`, `claude-5+`) whose sessions encounter a stale or invalid thinking-block signature will
  now get automatic one-shot recovery instead of being permanently bricked.

  ## Evidence

  ### Test run

  ```bash
  $ node scripts/run-vitest.mjs src/agents/embedded-agent-runner/thinking.test.ts
  [test] starting test/vitest/vitest.agents.config.ts

   RUN  v4.1.8 /home/0668001086/文档/OpenClaw/openclaw

   ✓ |agents| src/agents/embedded-agent-runner/thinking.test.ts (51 tests) 207ms

   Test Files  1 passed (1)
        Tests  51 passed (51)
     Start at  13:58:35
     Duration  1.65s

  [test] passed 1 Vitest shard in 12.77s

  Before (current main) — recovery does not fire

  # ProviderHttpError with thinking-block error in errorBody
  # .message = generic human-facing string, errorBody = raw Anthropic rejection
  #
  # collectErrorGraphCandidates traverses: cause, error, rawError, errorMessage, message
  # errorBody is NOT traversed → detector returns false → session stays bricked

  $ node -e "
  const { ProviderHttpError } = require('./src/agents/provider-http-errors.js');
  const err = new ProviderHttpError(
    'LLM request failed: provider rejected the request schema or tool payload.',
    { status: 400, body: '{\"error\":{\"message\":\"Invalid \`signature\` in \`thinking\` block\"}}' }
  );
  console.log('message:', err.message);
  console.log('errorBody:', err.errorBody);
  "
  message: LLM request failed: provider rejected the request schema or tool payload.
  errorBody: {"error":{"message":"Invalid `signature` in `thinking` block"}}

  # → shouldRecoverAnthropicThinkingError returns false
  # → No [session-recovery] log emitted
  # → Every subsequent turn fails with HTTP 400

  After (this PR) — recovery fires

  # Same error now traverses errorBody, body, detail, responseBody, data
  # errorBody is a string → tested against THINKING_BLOCK_ERROR_PATTERN → match

  $ node scripts/run-vitest.mjs src/agents/embedded-agent-runner/thinking.test.ts \
    -t "recovers when ProviderHttpError.errorBody"

   ✓ recovers when ProviderHttpError.errorBody contains a thinking signature error
   ✓ recovers when a thinking signature error is nested inside errorBody in a cause chain
   ✓ fires the onRecoveredAnthropicThinking hook when errorBody-based recovery succeeds

  # → shouldRecoverAnthropicThinkingError returns true
  # → [session-recovery] Anthropic thinking request rejected; retrying once without thinking blocks
  # → onRecoveredAnthropicThinking hook fires with { originalMessages, cleanedMessages }
  # → Session recovered without data loss

  New tests (5 added)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┬────────────────────────────────────────────────────────────────────────────┐
  │                                              Test                                              │                               What it proves                               │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────┤
  │ recovers when ProviderHttpError.errorBody contains a thinking signature error                  │ errorBody string traversal fires recovery (retry count 1→2)                │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────┤
  │ recovers when a thinking signature error is nested inside errorBody in a cause chain           │ Traversal reaches errorBody through .cause nesting                         │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────┤
  │ does not recover when ProviderHttpError.errorBody is a non-thinking error                      │ Rate-limit body (HTTP 429) is not false-positive matched                   │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────┤
  │ does not recover when ProviderHttpError has a generic schema rejection without thinking detail │ Generic schema rejections (unknown field) are not matched                  │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────┤
  │ fires the onRecoveredAnthropicThinking hook when errorBody-based recovery succeeds             │ Full recovery pipeline: detector → retry → hook fires with correct payload │
  └────────────────────────────────────────────────────────────────────────────────────────────────┴────────────────────────────────────────────────────────────────────────────┘

  ---