### PR TITLE
fix: ClickClack fails with SecretRef tokens

### DIFF
--- a/extensions/clickclack/openclaw.plugin.json
+++ b/extensions/clickclack/openclaw.plugin.json
@@ -4,6 +4,16 @@
     "onStartup": false
   },
   "channels": ["clickclack"],
+  "channelConfigs": {
+    "clickclack": {
+      "label": "ClickClack",
+      "description": "ClickClack channel integration for self-hosted chat bot tokens.",
+      "schema": {
+        "type": "object",
+        "additionalProperties": true
+      }
+    }
+  },
   "channelEnvVars": {
     "clickclack": ["CLICKCLACK_BOT_TOKEN"]
   },

--- a/extensions/clickclack/src/accounts.test.ts
+++ b/extensions/clickclack/src/accounts.test.ts
@@ -4,6 +4,7 @@ import {
   listClickClackAccountIds,
   resolveClickClackAccount,
   resolveDefaultClickClackAccountId,
+  resolveRuntimeClickClackAccount,
 } from "./accounts.js";
 import type { CoreConfig } from "./types.js";
 
@@ -108,6 +109,40 @@ describe("ClickClack account resolution", () => {
       replyMode: "agent",
       token: "ccb_live",
       workspace: "wsp_1",
+    });
+  });
+
+  it("resolves exec SecretRefs for runtime account use", async () => {
+    const cfg = {
+      secrets: {
+        providers: {
+          test_exec: {
+            source: "exec",
+            command: process.execPath,
+            args: [
+              "-e",
+              "let s='';process.stdin.on('data',c=>s+=c);process.stdin.on('end',()=>{const r=JSON.parse(s);process.stdout.write(JSON.stringify({protocolVersion:1,values:Object.fromEntries(r.ids.map(id=>[id,'  ccb_exec  ']))}));});",
+            ],
+          },
+        },
+      },
+      channels: {
+        clickclack: {
+          enabled: true,
+          baseUrl: "https://app.clickclack.chat",
+          workspace: "wsp_1",
+          token: { source: "exec", provider: "test_exec", id: "CLICKCLACK_SERVICE_TOKEN" },
+        },
+      },
+    } satisfies CoreConfig;
+
+    expect(resolveClickClackAccount({ cfg })).toMatchObject({
+      configured: true,
+      token: "",
+    });
+    await expect(resolveRuntimeClickClackAccount({ cfg })).resolves.toMatchObject({
+      configured: true,
+      token: "ccb_exec",
     });
   });
 

--- a/extensions/clickclack/src/accounts.ts
+++ b/extensions/clickclack/src/accounts.ts
@@ -15,6 +15,7 @@ import {
   normalizeResolvedSecretInputString,
   resolveSecretInputString,
 } from "openclaw/plugin-sdk/secret-input";
+import { resolveConfiguredSecretInputString } from "openclaw/plugin-sdk/secret-input-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { ClickClackAccountConfig, CoreConfig, ResolvedClickClackAccount } from "./types.js";
 
@@ -52,18 +53,22 @@ function resolveMergedClickClackAccountConfig(
   });
 }
 
+function clickClackTokenPath(accountId: string): string {
+  return accountId === DEFAULT_ACCOUNT_ID
+    ? "channels.clickclack.token"
+    : `channels.clickclack.accounts.${accountId}.token`;
+}
+
 function resolveClickClackToken(params: {
   cfg: CoreConfig;
   value: unknown;
   accountId: string;
   env?: NodeJS.ProcessEnv;
-}): string {
+}): { token: string; configured: boolean } {
+  const path = clickClackTokenPath(params.accountId);
   const resolved = resolveSecretInputString({
     value: params.value,
-    path:
-      params.accountId === DEFAULT_ACCOUNT_ID
-        ? "channels.clickclack.token"
-        : `channels.clickclack.accounts.${params.accountId}.token`,
+    path,
     defaults: params.cfg.secrets?.defaults,
     mode: "inspect",
   });
@@ -89,16 +94,33 @@ function resolveClickClackToken(params: {
           `Secret provider "${resolved.ref.provider}" is not configured (ref: env:${resolved.ref.provider}:${resolved.ref.id}).`,
         );
       }
-      return normalizeSecretInputString((params.env ?? process.env)[resolved.ref.id]) ?? "";
+      const token = normalizeSecretInputString((params.env ?? process.env)[resolved.ref.id]) ?? "";
+      return { token, configured: Boolean(token) };
     }
-    return "";
+    return { token: "", configured: resolved.status === "configured_unavailable" };
   }
-  return (
+  const token =
     normalizeResolvedSecretInputString({
       value: resolved.value,
-      path: "channels.clickclack.token",
-    }) ?? ""
-  );
+      path,
+    }) ?? "";
+  return { token, configured: Boolean(token) };
+}
+
+async function resolveRuntimeClickClackToken(params: {
+  cfg: CoreConfig;
+  value: unknown;
+  accountId: string;
+  env?: NodeJS.ProcessEnv;
+}): Promise<string> {
+  const resolved = await resolveConfiguredSecretInputString({
+    config: params.cfg,
+    env: params.env ?? process.env,
+    value: params.value,
+    path: clickClackTokenPath(params.accountId),
+    unresolvedReasonStyle: "detailed",
+  });
+  return resolved.value ?? "";
 }
 
 /**
@@ -115,17 +137,18 @@ export function resolveClickClackAccount(params: {
   const baseEnabled = params.cfg.channels?.clickclack?.enabled !== false;
   const enabled = baseEnabled && merged.enabled !== false;
   const baseUrl = merged.baseUrl?.trim().replace(/\/$/, "") ?? "";
-  const token = resolveClickClackToken({
+  const tokenResolution = resolveClickClackToken({
     cfg: params.cfg,
     value: merged.token,
     accountId,
     env: params.env,
   });
+  const token = tokenResolution.token;
   const workspace = merged.workspace?.trim() ?? "";
   return {
     accountId,
     enabled,
-    configured: Boolean(baseUrl && token && workspace),
+    configured: Boolean(baseUrl && tokenResolution.configured && workspace),
     name: normalizeOptionalString(merged.name),
     baseUrl,
     token,
@@ -154,6 +177,25 @@ export function resolveClickClackAccount(params: {
  * Returns all enabled accounts, including the implicit default account when
  * legacy top-level ClickClack config is present.
  */
+export async function resolveRuntimeClickClackAccount(params: {
+  cfg: CoreConfig;
+  accountId?: string | null;
+  env?: NodeJS.ProcessEnv;
+}): Promise<ResolvedClickClackAccount> {
+  const account = resolveClickClackAccount(params);
+  const token = await resolveRuntimeClickClackToken({
+    cfg: params.cfg,
+    value: account.config.token,
+    accountId: account.accountId,
+    env: params.env,
+  });
+  return {
+    ...account,
+    token,
+    configured: Boolean(account.baseUrl && token && account.workspace),
+  };
+}
+
 export function listEnabledClickClackAccounts(cfg: CoreConfig): ResolvedClickClackAccount[] {
   return listClickClackAccountIds(cfg)
     .map((accountId) => resolveClickClackAccount({ cfg, accountId }))

--- a/extensions/clickclack/src/gateway.ts
+++ b/extensions/clickclack/src/gateway.ts
@@ -5,7 +5,7 @@
 import type { ChannelGatewayContext } from "openclaw/plugin-sdk/channel-contract";
 import type { RawData } from "ws";
 import { resolveClickClackInboundAccess } from "./access.js";
-import { resolveClickClackAccount } from "./accounts.js";
+import { resolveRuntimeClickClackAccount } from "./accounts.js";
 import { createClickClackClient } from "./http-client.js";
 import { handleClickClackInbound } from "./inbound.js";
 import { resolveWorkspaceId } from "./resolve.js";
@@ -119,7 +119,7 @@ async function processEvent(params: {
 export async function startClickClackGatewayAccount(
   ctx: ChannelGatewayContext<ResolvedClickClackAccount>,
 ) {
-  const configuredAccount = resolveClickClackAccount({
+  const configuredAccount = await resolveRuntimeClickClackAccount({
     cfg: ctx.cfg,
     accountId: ctx.account.accountId,
   });

--- a/extensions/clickclack/src/outbound.ts
+++ b/extensions/clickclack/src/outbound.ts
@@ -2,7 +2,7 @@
  * Outbound ClickClack delivery helpers for channel messages, thread replies,
  * and direct messages.
  */
-import { resolveClickClackAccount } from "./accounts.js";
+import { resolveRuntimeClickClackAccount } from "./accounts.js";
 import { createClickClackClient } from "./http-client.js";
 import { resolveChannelId, resolveWorkspaceId } from "./resolve.js";
 import { parseClickClackTarget } from "./target.js";
@@ -20,7 +20,10 @@ export async function sendClickClackText(params: {
   threadId?: string | number | null;
   replyToId?: string | number | null;
 }) {
-  const account = resolveClickClackAccount({ cfg: params.cfg, accountId: params.accountId });
+  const account = await resolveRuntimeClickClackAccount({
+    cfg: params.cfg,
+    accountId: params.accountId,
+  });
   const client = createClickClackClient({ baseUrl: account.baseUrl, token: account.token });
   const workspaceId = await resolveWorkspaceId(client, account.workspace);
   const parsed = parseClickClackTarget(params.to);

--- a/src/plugins/bundled-plugin-metadata.test.ts
+++ b/src/plugins/bundled-plugin-metadata.test.ts
@@ -551,6 +551,19 @@ describe("bundled plugin metadata", () => {
     }
   });
 
+  it("declares ClickClack channel config metadata", () => {
+    const entry = listRepoBundledPluginMetadata().find(
+      ({ manifest }) => manifest.id === "clickclack",
+    );
+
+    expect(entry?.manifest.channelConfigs?.clickclack).toMatchObject({
+      label: "ClickClack",
+      schema: {
+        type: "object",
+      },
+    });
+  });
+
   it("declares explicit startup activation on all bundled plugin manifests", () => {
     const startupPluginIds: string[] = [];
 


### PR DESCRIPTION
Closes #98428

AI-assisted: yes.

## What Problem This Solves

Fixes an issue where users configuring ClickClack with direct `exec` SecretRef tokens would see ClickClack reported as not configured when the gateway started, even though `openclaw secrets audit --allow-exec` could resolve the token.

Also resolves the ClickClack plugin warning about declaring the `clickclack` channel without `channelConfigs` metadata.

## Why This Change Was Made

ClickClack account inspection remains synchronous and non-secret-revealing, but runtime gateway/outbound paths now resolve configured SecretRefs through OpenClaw's runtime secret resolver before constructing the ClickClack client. The ClickClack manifest now declares channel config metadata so setup/schema surfaces can discover the channel before runtime loads.

## User Impact

Users can configure `channels.clickclack.token` with normal SecretRefs, including `exec` providers, without wrapping OpenClaw to rename/export a token environment variable. Operators should no longer see the ClickClack `channelConfigs` manifest warning for this plugin.

## Evidence

Focused local tests:

```text
pnpm test:extension clickclack
Test Files 5 passed (5)
Tests 21 passed (21)

node scripts/run-vitest.mjs run src/plugins/bundled-plugin-metadata.test.ts -t "declares ClickClack channel config metadata"
Test Files 1 passed (1)
Tests 1 passed | 35 skipped (36)

pnpm config:channels:check
# passed

pnpm format:check extensions/clickclack/openclaw.plugin.json extensions/clickclack/src/accounts.test.ts extensions/clickclack/src/accounts.ts extensions/clickclack/src/gateway.ts extensions/clickclack/src/outbound.ts src/plugins/bundled-plugin-metadata.test.ts
All matched files use the correct format.

git diff --check
# passed
```

Structured review:

```text
.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main
autoreview clean: no accepted/actionable findings reported
```

Separate clone validation in `/Users/iXandru/Clones/openclaw_openclaw_pr98451` with a temporary `HOME`:

```text
pnpm build
# passed

pnpm check
# passed

pnpm test:extension clickclack
Test Files 5 passed (5)
Tests 21 passed (21)

node scripts/run-vitest.mjs run src/plugins/bundled-plugin-metadata.test.ts -t "declares ClickClack channel config metadata"
Test Files 1 passed (1)
Tests 1 passed | 35 skipped (36)

pnpm config:channels:check
# passed
```

Broad-suite note:

```text
pnpm test
# failed in broad, unrelated shards outside this PR's ClickClack/manifest surface.
# Failed shard examples included infra, cli, agents-core, extension-providers,
# media-understanding, plugins, runtime-config, secrets, extension-mattermost,
# and plugin-sdk. The ClickClack extension lane and the targeted channel metadata
# test passed in the same separate clone.
```

Live local plugin validation with a packed ClickClack plugin and direct exec SecretRef token, without a wrapper env bridge:

```text
openclaw config validate
Config valid: ~/.openclaw/openclaw.json

openclaw health --json
health.ok=PASS
plugin.errors=0
clickclack.configured=True
clickclack.running=True
clickclack.ok=True
clickclack.lastError=None

openclaw gateway status --deep
Command: /opt/homebrew/bin/openclaw gateway --port 18789
Runtime: running
Connectivity probe: ok
Capability: admin-capable
```
