### PR TITLE
docs(gateway): fix Telegram streaming default in config-channels.md

### DIFF
--- a/docs/gateway/config-channels.md
+++ b/docs/gateway/config-channels.md
@@ -203,7 +203,7 @@ WhatsApp runs through the gateway's web channel (Baileys Web). It starts automat
       historyLimit: 50,
       replyToMode: "first", // off | first | all | batched
       linkPreview: true,
-      streaming: "partial", // off | partial | block | progress (default: off; opt in explicitly to avoid preview-edit rate limits)
+      streaming: "partial", // off | partial | block | progress (default: partial)
       actions: { reactions: true, sendMessage: true },
       reactionNotifications: "own", // off | own | all
       mediaMaxMb: 100,


### PR DESCRIPTION
## What Problem This Solves

The Telegram config example in `docs/gateway/config-channels.md` lists the streaming default as `"off"`, but the actual runtime default is `"partial"`. Users reading the config reference would expect streaming to be off by default, while it is actually enabled. This contradicts the channel-specific docs at `docs/channels/telegram.md` which correctly document `"partial"` as the default.

## Evidence

### Runtime default

`extensions/telegram/src/preview-streaming.ts:15` — `resolveChannelPreviewStreamMode` is called with `"partial"` as the fallback default:

```ts
return resolveChannelPreviewStreamMode(params, "partial");
```

`src/channels/streaming.ts:890` — when no streaming config is provided, the function returns the `defaultMode` argument:

```ts
return defaultMode;
```

### Test coverage

`extensions/telegram/src/bot.helpers.test.ts:9-10` — confirms that unconfigured streaming resolves to `"partial"`:

```ts
expect(resolveTelegramStreamMode(undefined)).toBe("partial");
expect(resolveTelegramStreamMode({})).toBe("partial");
```

### The channel-specific docs already have the correct value

`docs/channels/telegram.md:338` — Telegram channel docs correctly state `(default: partial)`:

```
channels.telegram.streaming is off | partial | block | progress (default: partial)
```

### This fix

`docs/gateway/config-channels.md:206` — corrected the inline comment from `(default: off)` to `(default: partial)`.

## User Impact

Docs-only change, no behavioral impact. Resolves the contradiction between the two documentation files about the Telegram streaming default.