### PR TITLE
fix: bound NPM registry and MiniMax OAuth JSON response reads to prevent OOM

### DIFF
--- a/extensions/minimax/oauth.test.ts
+++ b/extensions/minimax/oauth.test.ts
@@ -81,6 +81,39 @@ describe("loginMiniMaxPortalOAuth", () => {
     expect(textSpy).not.toHaveBeenCalled();
   });
 
+  it("rejects oversized OAuth authorization response bodies and cancels the stream", async () => {
+    let canceled = false;
+    const ONE_MIB = 1024 * 1024;
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (let i = 0; i < 18; i++) controller.enqueue(new Uint8Array(ONE_MIB));
+        controller.close();
+      },
+      cancel() {
+        canceled = true;
+      },
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        return new Response(body, {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }),
+    );
+
+    const error = await loginMiniMaxPortalOAuth({
+      openUrl: vi.fn(async () => undefined),
+      note: vi.fn(async () => undefined),
+      progress: { update: vi.fn(), stop: vi.fn() },
+    }).catch((cause: unknown) => cause);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain("MiniMax OAuth authorization: JSON response exceeds");
+    expect(canceled).toBe(true);
+  });
+
   it("bounds token error bodies without using response.text()", async () => {
     const tracked = cancelTrackedResponse(`${"minimax token unavailable ".repeat(1024)}tail`, {
       status: 503,

--- a/extensions/minimax/oauth.ts
+++ b/extensions/minimax/oauth.ts
@@ -7,7 +7,10 @@ import {
   resolvePositiveTimerTimeoutMs,
 } from "openclaw/plugin-sdk/number-runtime";
 import { generatePkceVerifierChallenge, toFormUrlEncoded } from "openclaw/plugin-sdk/provider-auth";
-import { readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
+import {
+  readProviderJsonResponse,
+  readResponseTextLimited,
+} from "openclaw/plugin-sdk/provider-http";
 import { ensureGlobalUndiciEnvProxyDispatcher } from "openclaw/plugin-sdk/runtime-env";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 
@@ -121,7 +124,9 @@ async function requestOAuthCode(params: {
       throw new Error(`MiniMax OAuth authorization failed: ${text || response.statusText}`);
     }
 
-    const payload = (await response.json()) as MiniMaxOAuthAuthorization & { error?: string };
+    const payload = await readProviderJsonResponse<
+      MiniMaxOAuthAuthorization & { error?: string }
+    >(response, "MiniMax OAuth authorization");
     if (!payload.user_code || !payload.verification_uri) {
       throw new Error(
         payload.error ??

--- a/src/infra/update-check.test.ts
+++ b/src/infra/update-check.test.ts
@@ -196,13 +196,16 @@ describe("resolveNpmChannelTag", () => {
 
   it("uses the public registry when no npm command is available", async () => {
     const fetch = vi.fn(async () => {
-      return {
-        ok: true,
-        json: async () => ({
+      return new Response(
+        JSON.stringify({
           version: "2026.6.8",
           engines: { node: ">=22.19.0" },
         }),
-      } as Response;
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
     });
     vi.stubGlobal("fetch", fetch);
 
@@ -235,6 +238,73 @@ describe("resolveNpmChannelTag", () => {
       error: "HTTP 503",
     });
     expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects oversized NPM registry responses", async () => {
+    const ONE_MIB = 1024 * 1024;
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (let i = 0; i < 5; i++) controller.enqueue(new Uint8Array(ONE_MIB));
+        controller.close();
+      },
+    });
+    const fetch = vi.fn(
+      async () =>
+        new Response(body, {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    vi.stubGlobal("fetch", fetch);
+
+    const result = await fetchNpmPackageTargetStatus({ target: "latest", timeoutMs: 5000 });
+
+    expect(result.error).toContain("NPM registry response exceeds");
+    expect(result.version).toBeNull();
+  });
+
+  it("rejects oversized NPM registry responses from a real HTTP server (behavior proof)", async () => {
+    let socketDestroyed = false;
+    const server = http.createServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      const ONE_MIB = 1024 * 1024;
+      const chunk = Buffer.alloc(ONE_MIB, 0x41);
+      const writeMore = () => {
+        if (socketDestroyed) return;
+        for (let i = 0; i < 4 && !socketDestroyed; i++) {
+          if (!res.write(chunk)) {
+            res.once("drain", writeMore);
+            return;
+          }
+        }
+        if (!socketDestroyed) setImmediate(writeMore);
+      };
+      writeMore();
+    });
+    server.on("connection", (socket) => {
+      socket.on("close", () => {
+        socketDestroyed = true;
+      });
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const port = (server.address() as { port: number }).port;
+
+    try {
+      const realFetch = fetch;
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (_url: string | URL, init?: RequestInit) => {
+          return realFetch(`http://127.0.0.1:${port}`, init);
+        }),
+      );
+
+      const result = await fetchNpmPackageTargetStatus({ target: "latest", timeoutMs: 5000 });
+
+      expect(result.error).toContain("NPM registry response exceeds");
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
   });
 
   it("falls back to latest when beta is older", async () => {

--- a/src/infra/update-check.ts
+++ b/src/infra/update-check.ts
@@ -1,12 +1,15 @@
 // Computes git, dependency, and registry update status for OpenClaw installs.
 import fs from "node:fs/promises";
 import path from "node:path";
+import { readResponseWithLimit } from "@openclaw/media-core/read-response-with-limit";
 import { runCommandWithTimeout } from "../process/exec.js";
 import { fetchWithTimeout } from "../utils/fetch-timeout.js";
 import { detectPackageManager as detectPackageManagerImpl } from "./detect-package-manager.js";
 import { compareOpenClawReleaseVersions } from "./npm-registry-spec.js";
 import { compareComparableSemver, parseComparableSemver } from "./semver-compare.js";
 import { channelToNpmTag, type UpdateChannel } from "./update-channels.js";
+
+const NPM_REGISTRY_RESPONSE_MAX_BYTES = 4 * 1024 * 1024;
 
 export type PackageManager = "pnpm" | "bun" | "npm" | "unknown";
 
@@ -125,7 +128,11 @@ async function fetchPublicNpmPackageTargetStatus(params: {
         error: `HTTP ${res.status}`,
       };
     }
-    const json = (await res.json()) as {
+    const body = await readResponseWithLimit(res, NPM_REGISTRY_RESPONSE_MAX_BYTES, {
+      onOverflow: ({ maxBytes }) =>
+        new Error(`NPM registry response exceeds ${maxBytes} bytes`),
+    });
+    const json = JSON.parse(new TextDecoder().decode(body)) as {
       version?: unknown;
       engines?: { node?: unknown };
     };


### PR DESCRIPTION
## What Problem This Solves

Two unbounded `response.json()` calls can buffer arbitrarily large HTTP responses into memory (OOM risk):

1. **NPM registry** — `openclaw/latest` metadata includes all versions, can be very large
2. **MiniMax OAuth authorization** — success path unbounded while error path already uses `readResponseTextLimited`

## Why This Change Was Made

Each follows the established bounded-reader pattern used in recent OOM fixes.

## User Impact

Oversized NPM registry and MiniMax OAuth responses are cancelled mid-stream instead of fully buffered.

## Evidence: Real Behavior Proof

### 1. NPM registry — Real TCP HTTP Server Test
A local `http.createServer` streams 1 MiB chunks past the 4 MiB cap. The bounded reader cancels the socket mid-flight before the full body is buffered. Verified by: error message contains "NPM registry response exceeds 4194304 bytes".

### 2. MiniMax OAuth — Stream Cancel Proof
18 MiB `ReadableStream` with `cancel()` handler triggers `readProviderJsonResponse` overflow (16 MiB cap). Stream cancel is verified. Error: "MiniMax OAuth authorization: JSON response exceeds 16777216 bytes".

### Test Results
```
update-check.test.ts — 21 passed (mock oversized + real HTTP server proof)
minimax/oauth.test.ts — 13 passed (mock oversized with cancel verification)
```

### Files Changed
| File | Change |
|------|--------|
| `src/infra/update-check.ts` | `readResponseWithLimit` (4 MiB) for NPM registry |
| `extensions/minimax/oauth.ts` | `readProviderJsonResponse` (16 MiB) for authorization |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
