### PR TITLE
fix(browser): bound error body read in fetchHttpJson to prevent OOM

### DIFF
--- a/extensions/browser/src/browser/client-fetch.error-body-boundary.test.ts
+++ b/extensions/browser/src/browser/client-fetch.error-body-boundary.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Boundary test: fetchHttpJson error body is read under a byte cap.
+ *
+ * Proves that a streaming error response larger than 16 KiB is cancelled
+ * mid-stream instead of being fully buffered, preventing OOM on malformed
+ * upstream error pages from the browser control service.
+ */
+import http from "node:http";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import "../test-support/browser-security.mock.js";
+
+// Replace fetchWithSsrFGuard with a lightweight pass-through so the test
+// can drive fetchHttpJson against a real loopback HTTP server.  The SSRF
+// guard is tested separately; this test keeps the focus on the response
+// body boundary.
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/ssrf-runtime")>(
+    "openclaw/plugin-sdk/ssrf-runtime",
+  );
+  return {
+    ...actual,
+    fetchWithSsrFGuard: async (params: {
+      url: string;
+      init?: RequestInit;
+      signal?: AbortSignal;
+    }) => ({
+      response: await fetch(params.url, {
+        ...params.init,
+        signal: params.signal,
+      }),
+      finalUrl: params.url,
+      release: async () => {},
+    }),
+  };
+});
+
+// Config/auth mocks — the test hits a loopback URL so the auth path
+// tries to look up config; stub it out to avoid side effects.
+const mocks = vi.hoisted(() => ({
+  loadConfig: vi.fn(() => ({})),
+  resolveBrowserControlAuth: vi.fn(() => ({})),
+  getBridgeAuthForPort: vi.fn(() => undefined),
+}));
+
+vi.mock("../config/config.js", async () => {
+  const actual = await vi.importActual<typeof import("../config/config.js")>("../config/config.js");
+  return { ...actual, getRuntimeConfig: mocks.loadConfig, loadConfig: mocks.loadConfig };
+});
+
+vi.mock("./control-auth.js", () => ({
+  resolveBrowserControlAuth: mocks.resolveBrowserControlAuth,
+}));
+
+vi.mock("./bridge-auth-registry.js", () => ({
+  getBridgeAuthForPort: mocks.getBridgeAuthForPort,
+}));
+
+const { fetchBrowserJson } = await import("./client-fetch.js");
+
+/** Streaming chunks are large enough to exceed the 16 KiB cap in one chunk. */
+const CHUNK_SIZE = 64 * 1024;
+
+/** Total bytes the server will stream before closing. */
+const TOTAL_BODY_SIZE = 4 * 1024 * 1024;
+
+describe("fetchHttpJson error body boundary", () => {
+  let server: http.Server;
+  let port: number;
+
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    for (const key of [
+      "ALL_PROXY",
+      "all_proxy",
+      "HTTP_PROXY",
+      "http_proxy",
+      "HTTPS_PROXY",
+      "https_proxy",
+    ]) {
+      vi.stubEnv(key, "");
+    }
+    mocks.loadConfig.mockReturnValue({});
+    mocks.resolveBrowserControlAuth.mockReturnValue({});
+    mocks.getBridgeAuthForPort.mockReturnValue(undefined);
+
+    // Start a loopback server that streams a large error body.
+    // No Content-Length header — the client must read until the cap,
+    // not until a known size.
+    server = http.createServer((_req, res) => {
+      res.writeHead(500, { "Content-Type": "text/html" });
+      let written = 0;
+      const chunk = Buffer.alloc(CHUNK_SIZE, "x");
+      function writeChunk() {
+        if (written >= TOTAL_BODY_SIZE) {
+          res.end();
+          return;
+        }
+        const ok = res.write(chunk);
+        written += CHUNK_SIZE;
+        if (ok) {
+          // Drain the microtask queue so the reader can consume, then
+          // schedule the next chunk through setTimeout to avoid starving
+          // the event loop when backpressure isn't applied.
+          setImmediate(writeChunk);
+        } else {
+          res.once("drain", writeChunk);
+        }
+      }
+      writeChunk();
+    });
+
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+    port = (server.address() as { port: number }).port;
+  });
+
+  afterEach(async () => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+    if (server) {
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+    }
+  });
+
+  it("cancels the stream after 16 KiB on a non-ok response", async () => {
+    const url = `http://127.0.0.1:${port}/error`;
+
+    const err = await fetchBrowserJson(url, { timeoutMs: 5000 }).catch((e: unknown) => e);
+
+    // Must throw — the server returned 500.
+    expect(err).toBeInstanceOf(Error);
+    const message = (err as Error).message;
+
+    // The error body snippet must be bounded at ~16 KiB.  If unguarded,
+    // the raw res.text() would buffer the full 4 MiB streaming body
+    // into the error message.  This assertion is the core invariant.
+    const messageBytes = Buffer.byteLength(message, "utf8");
+    expect(messageBytes).toBeLessThan(32 * 1024); // well under 4 MiB
+    expect(messageBytes).toBeGreaterThan(0); // body was read
+
+    // The body text should contain a snippet of the padding —
+    // readResponseTextLimited returns what it read (up to the cap).
+    expect(message).toContain("x");
+  });
+
+  it("preserves the full error body when it fits under the cap", async () => {
+    // Small error body: the server returns a short text/plain message.
+    const snippetServer = http.createServer((_req, res) => {
+      res.writeHead(500, { "Content-Type": "text/plain" });
+      res.end("session expired");
+    });
+    const snippetPort = await new Promise<number>((resolve) => {
+      snippetServer.listen(0, "127.0.0.1", () =>
+        resolve((snippetServer.address() as { port: number }).port),
+      );
+    });
+
+    try {
+      const err = await fetchBrowserJson(`http://127.0.0.1:${snippetPort}/err`, {
+        timeoutMs: 5000,
+      }).catch((e: unknown) => e);
+
+      expect(err).toBeInstanceOf(Error);
+      expect((err as Error).message).toContain("session expired");
+    } finally {
+      await new Promise<void>((resolve) => {
+        snippetServer.close(() => resolve());
+      });
+    }
+  });
+});

--- a/extensions/browser/src/browser/client-fetch.error-body-boundary.test.ts
+++ b/extensions/browser/src/browser/client-fetch.error-body-boundary.test.ts
@@ -1,42 +1,7 @@
-/**
- * Boundary test: fetchHttpJson error body is read under a byte cap.
- *
- * Proves that a streaming error response larger than 16 KiB is cancelled
- * mid-stream instead of being fully buffered, preventing OOM on malformed
- * upstream error pages from the browser control service.
- */
 import http from "node:http";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import "../test-support/browser-security.mock.js";
 
-// Replace fetchWithSsrFGuard with a lightweight pass-through so the test
-// can drive fetchHttpJson against a real loopback HTTP server.  The SSRF
-// guard is tested separately; this test keeps the focus on the response
-// body boundary.
-vi.mock("openclaw/plugin-sdk/ssrf-runtime", async () => {
-  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/ssrf-runtime")>(
-    "openclaw/plugin-sdk/ssrf-runtime",
-  );
-  return {
-    ...actual,
-    fetchWithSsrFGuard: async (params: {
-      url: string;
-      init?: RequestInit;
-      signal?: AbortSignal;
-    }) => ({
-      response: await fetch(params.url, {
-        ...params.init,
-        signal: params.signal,
-      }),
-      finalUrl: params.url,
-      release: async () => {},
-    }),
-  };
-});
-
-// Config/auth mocks — the test hits a loopback URL so the auth path
-// tries to look up config; stub it out to avoid side effects.
-const mocks = vi.hoisted(() => ({
+const authMocks = vi.hoisted(() => ({
   loadConfig: vi.fn(() => ({})),
   resolveBrowserControlAuth: vi.fn(() => ({})),
   getBridgeAuthForPort: vi.fn(() => undefined),
@@ -44,31 +9,30 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("../config/config.js", async () => {
   const actual = await vi.importActual<typeof import("../config/config.js")>("../config/config.js");
-  return { ...actual, getRuntimeConfig: mocks.loadConfig, loadConfig: mocks.loadConfig };
+  return { ...actual, getRuntimeConfig: authMocks.loadConfig, loadConfig: authMocks.loadConfig };
 });
-
 vi.mock("./control-auth.js", () => ({
-  resolveBrowserControlAuth: mocks.resolveBrowserControlAuth,
+  resolveBrowserControlAuth: authMocks.resolveBrowserControlAuth,
 }));
-
 vi.mock("./bridge-auth-registry.js", () => ({
-  getBridgeAuthForPort: mocks.getBridgeAuthForPort,
+  getBridgeAuthForPort: authMocks.getBridgeAuthForPort,
 }));
 
 const { fetchBrowserJson } = await import("./client-fetch.js");
 
-/** Streaming chunks are large enough to exceed the 16 KiB cap in one chunk. */
-const CHUNK_SIZE = 64 * 1024;
-
-/** Total bytes the server will stream before closing. */
-const TOTAL_BODY_SIZE = 4 * 1024 * 1024;
+const STREAM_CHUNK = Buffer.alloc(4 * 1024, "x");
+const STREAM_BODY_BYTES = 1024 * 1024;
 
 describe("fetchHttpJson error body boundary", () => {
   let server: http.Server;
-  let port: number;
+  let baseUrl: string;
+  let streamClosed: Promise<void>;
+  let resolveStreamClosed: () => void;
+  let smallConnectionClosed: Promise<void>;
+  let resolveSmallConnectionClosed: () => void;
+  let streamCompleted: boolean;
 
   beforeEach(async () => {
-    vi.restoreAllMocks();
     for (const key of [
       "ALL_PROXY",
       "all_proxy",
@@ -79,96 +43,81 @@ describe("fetchHttpJson error body boundary", () => {
     ]) {
       vi.stubEnv(key, "");
     }
-    mocks.loadConfig.mockReturnValue({});
-    mocks.resolveBrowserControlAuth.mockReturnValue({});
-    mocks.getBridgeAuthForPort.mockReturnValue(undefined);
 
-    // Start a loopback server that streams a large error body.
-    // No Content-Length header — the client must read until the cap,
-    // not until a known size.
-    server = http.createServer((_req, res) => {
-      res.writeHead(500, { "Content-Type": "text/html" });
+    streamClosed = new Promise<void>((resolve) => {
+      resolveStreamClosed = resolve;
+    });
+    smallConnectionClosed = new Promise<void>((resolve) => {
+      resolveSmallConnectionClosed = resolve;
+    });
+    streamCompleted = false;
+    server = http.createServer((req, res) => {
+      if (req.url === "/small") {
+        req.socket.once("close", () => resolveSmallConnectionClosed());
+        res.writeHead(500, { "Content-Type": "text/plain" });
+        res.end("session expired");
+        return;
+      }
+
+      res.writeHead(500, { "Content-Type": "text/plain" });
       let written = 0;
-      const chunk = Buffer.alloc(CHUNK_SIZE, "x");
-      function writeChunk() {
-        if (written >= TOTAL_BODY_SIZE) {
+      let closed = false;
+      res.once("close", () => {
+        closed = true;
+        resolveStreamClosed();
+      });
+      const writeNext = () => {
+        if (closed) {
+          return;
+        }
+        if (written >= STREAM_BODY_BYTES) {
+          streamCompleted = true;
           res.end();
           return;
         }
-        const ok = res.write(chunk);
-        written += CHUNK_SIZE;
-        if (ok) {
-          // Drain the microtask queue so the reader can consume, then
-          // schedule the next chunk through setTimeout to avoid starving
-          // the event loop when backpressure isn't applied.
-          setImmediate(writeChunk);
+        written += STREAM_CHUNK.byteLength;
+        const writeMore = () => setTimeout(writeNext, 2);
+        if (res.write(STREAM_CHUNK)) {
+          writeMore();
         } else {
-          res.once("drain", writeChunk);
+          res.once("drain", writeMore);
         }
-      }
-      writeChunk();
+      };
+      writeNext();
     });
-
     await new Promise<void>((resolve) => {
-      server.listen(0, "127.0.0.1", () => resolve());
+      server.listen(0, "127.0.0.1", resolve);
     });
-    port = (server.address() as { port: number }).port;
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("expected loopback server address");
+    }
+    baseUrl = `http://127.0.0.1:${address.port}`;
   });
 
   afterEach(async () => {
-    vi.unstubAllGlobals();
     vi.unstubAllEnvs();
-    if (server) {
-      await new Promise<void>((resolve) => {
-        server.close(() => resolve());
-      });
-    }
+    server.closeAllConnections();
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
   });
 
-  it("cancels the stream after 16 KiB on a non-ok response", async () => {
-    const url = `http://127.0.0.1:${port}/error`;
+  it("cancels an overflowing stream and releases the guarded fetch", async () => {
+    const error = await fetchBrowserJson(`${baseUrl}/large`).catch((err: unknown) => err);
 
-    const err = await fetchBrowserJson(url, { timeoutMs: 5000 }).catch((e: unknown) => e);
-
-    // Must throw — the server returned 500.
-    expect(err).toBeInstanceOf(Error);
-    const message = (err as Error).message;
-
-    // The error body snippet must be bounded at ~16 KiB.  If unguarded,
-    // the raw res.text() would buffer the full 4 MiB streaming body
-    // into the error message.  This assertion is the core invariant.
-    const messageBytes = Buffer.byteLength(message, "utf8");
-    expect(messageBytes).toBeLessThan(32 * 1024); // well under 4 MiB
-    expect(messageBytes).toBeGreaterThan(0); // body was read
-
-    // The body text should contain a snippet of the padding —
-    // readResponseTextLimited returns what it read (up to the cap).
-    expect(message).toContain("x");
+    expect(error).toMatchObject({ name: "BrowserServiceError", message: "HTTP 500" });
+    await expect(streamClosed).resolves.toBeUndefined();
+    expect(streamCompleted).toBe(false);
   });
 
-  it("preserves the full error body when it fits under the cap", async () => {
-    // Small error body: the server returns a short text/plain message.
-    const snippetServer = http.createServer((_req, res) => {
-      res.writeHead(500, { "Content-Type": "text/plain" });
-      res.end("session expired");
-    });
-    const snippetPort = await new Promise<number>((resolve) => {
-      snippetServer.listen(0, "127.0.0.1", () =>
-        resolve((snippetServer.address() as { port: number }).port),
-      );
-    });
+  it("preserves a complete diagnostic body within the limit", async () => {
+    const error = await fetchBrowserJson(`${baseUrl}/small`).catch((err: unknown) => err);
 
-    try {
-      const err = await fetchBrowserJson(`http://127.0.0.1:${snippetPort}/err`, {
-        timeoutMs: 5000,
-      }).catch((e: unknown) => e);
-
-      expect(err).toBeInstanceOf(Error);
-      expect((err as Error).message).toContain("session expired");
-    } finally {
-      await new Promise<void>((resolve) => {
-        snippetServer.close(() => resolve());
-      });
-    }
+    expect(error).toMatchObject({
+      name: "BrowserServiceError",
+      message: "session expired",
+    });
+    await expect(smallConnectionClosed).resolves.toBeUndefined();
   });
 });

--- a/extensions/browser/src/browser/client-fetch.ts
+++ b/extensions/browser/src/browser/client-fetch.ts
@@ -6,6 +6,7 @@
  */
 import { parseBrowserHttpUrl } from "openclaw/plugin-sdk/browser-config";
 import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
+import { readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -103,6 +104,11 @@ function withLoopbackBrowserAuth(
 const BROWSER_TOOL_MODEL_HINT =
   "Do NOT retry the browser tool — it will keep failing. " +
   "Use an alternative approach or inform the user that the browser is currently unavailable.";
+
+/** Max bytes to read from a non-ok browser-control error body before cancelling the stream.
+ *  Kept small to avoid OOM on malformed upstream error pages while preserving a
+ *  useful diagnostic snippet. */
+const BROWSER_ERROR_BODY_LIMIT_BYTES = 16 * 1024;
 
 function isRateLimitStatus(status: number): boolean {
   return status === 429;
@@ -267,7 +273,9 @@ async function fetchHttpJson<T>(
           `${resolveBrowserRateLimitMessage(url)} ${BROWSER_TOOL_MODEL_HINT}`,
         );
       }
-      const text = await res.text().catch(() => "");
+      const text = await readResponseTextLimited(res, BROWSER_ERROR_BODY_LIMIT_BYTES).catch(
+        () => "",
+      );
       throw new BrowserServiceError(text || `HTTP ${res.status}`);
     }
     return (await res.json()) as T;

--- a/extensions/browser/src/browser/client-fetch.ts
+++ b/extensions/browser/src/browser/client-fetch.ts
@@ -6,7 +6,7 @@
  */
 import { parseBrowserHttpUrl } from "openclaw/plugin-sdk/browser-config";
 import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
-import { readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
+import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -105,9 +105,6 @@ const BROWSER_TOOL_MODEL_HINT =
   "Do NOT retry the browser tool — it will keep failing. " +
   "Use an alternative approach or inform the user that the browser is currently unavailable.";
 
-/** Max bytes to read from a non-ok browser-control error body before cancelling the stream.
- *  Kept small to avoid OOM on malformed upstream error pages while preserving a
- *  useful diagnostic snippet. */
 const BROWSER_ERROR_BODY_LIMIT_BYTES = 16 * 1024;
 
 function isRateLimitStatus(status: number): boolean {
@@ -273,9 +270,11 @@ async function fetchHttpJson<T>(
           `${resolveBrowserRateLimitMessage(url)} ${BROWSER_TOOL_MODEL_HINT}`,
         );
       }
-      const text = await readResponseTextLimited(res, BROWSER_ERROR_BODY_LIMIT_BYTES).catch(
-        () => "",
+      // Overflow cancels the stream and releases its reader lock before the guarded fetch below.
+      const body = await readResponseWithLimit(res, BROWSER_ERROR_BODY_LIMIT_BYTES).catch(
+        () => undefined,
       );
+      const text = body ? new TextDecoder().decode(body) : "";
       throw new BrowserServiceError(text || `HTTP ${res.status}`);
     }
     return (await res.json()) as T;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where browser-control requests could buffer an arbitrarily large streaming HTTP error body when the service returned a non-429 failure. A malformed or hostile upstream response could exhaust Gateway memory before `BrowserServiceError` was created.

## Why This Change Was Made

Non-success browser HTTP responses now use OpenClaw's shared strict response-limit contract with a 16 KiB boundary. Complete bodies within the limit remain useful diagnostics; true overflow cancels the stream, releases the reader lock, discards the partial body, and falls back to `HTTP <status>`. Existing 429 body suppression and the in-process dispatcher path remain unchanged.

## User Impact

Normal browser-control errors keep their complete small diagnostic messages. Oversized error streams can no longer be materialized into the Gateway error surface; they are cancelled and reported by HTTP status instead.

## Evidence

- Real loopback `node:http` server streams a 1 MiB chunked HTTP 500 response through the actual browser SSRF guard and Undici dispatcher.
- The candidate returns `BrowserServiceError: HTTP 500`, closes the response before the server completes, and releases the guarded connection.
- A normal `session expired` HTTP 500 body remains exact.
- Mutation proof: restoring current `main`'s bare `Response.text()` makes the streaming test fail while the small-body test still passes.
- Focused local proof: 3 files, 57 tests passed.
- Azure Crabbox `cbx_4489d89218a0`, run `run_4aaf7511d588`, Node 24.18: loopback regression passed; extension production/test typecheck, lint, boundary guards, and import-cycle check passed.
- Final Codex autoreview: no accepted/actionable findings (0.98 confidence).

No config, dependency, protocol, or `CHANGELOG.md` changes.

---

_AI-assisted._
