### PR TITLE
fix(browser): bound success body read in fetchHttpJson to prevent OOM

### DIFF
--- a/extensions/browser/src/browser/client-fetch.error-body-boundary.test.ts
+++ b/extensions/browser/src/browser/client-fetch.error-body-boundary.test.ts
@@ -146,6 +146,66 @@ describe("fetchHttpJson error body boundary", () => {
     expect(message).toContain("x");
   });
 
+  it("parses a small JSON success response correctly", async () => {
+    const server = http.createServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: true, targetId: "abc" }));
+    });
+    let p: number;
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+    p = (server.address() as { port: number }).port;
+
+    try {
+      const result = await fetchBrowserJson<{ ok: boolean; targetId: string }>(
+        `http://127.0.0.1:${p}/ok`,
+        { timeoutMs: 5000 },
+      );
+      expect(result).toEqual({ ok: true, targetId: "abc" });
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it("throws on a success response body exceeding 16 MiB", async () => {
+    // Stream a JSON body that exceeds 16 MiB.  readResponseWithLimit
+    // must cancel the stream at the cap instead of buffering the whole
+    // payload.
+    const bodySize = 17 * 1024 * 1024; // just over 16 MiB
+    const server = http.createServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      // Emit a JSON array prefix so the stream is valid JSON-shaped,
+      // then pad with whitespace to hit the byte cap.
+      res.write('{"items":[');
+      let written = 2 + 8; // '{"items":[' bytes
+      const chunk = Buffer.alloc(64 * 1024, 0x20); // space padding
+      while (written < bodySize) {
+        const toWrite = Math.min(chunk.length, bodySize - written);
+        res.write(toWrite === chunk.length ? chunk : chunk.subarray(0, toWrite));
+        written += toWrite;
+      }
+      res.end("]}");
+    });
+    let p: number;
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+    p = (server.address() as { port: number }).port;
+
+    try {
+      const err = await fetchBrowserJson(`http://127.0.0.1:${p}/large`, {
+        timeoutMs: 10000,
+      }).catch((e: unknown) => e);
+
+      expect(err).toBeInstanceOf(Error);
+      expect((err as Error).message).toContain("exceeds");
+      expect((err as Error).message).toContain("16777216"); // 16 MiB
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
   it("preserves the full error body when it fits under the cap", async () => {
     // Small error body: the server returns a short text/plain message.
     const snippetServer = http.createServer((_req, res) => {

--- a/extensions/browser/src/browser/client-fetch.error-body-boundary.test.ts
+++ b/extensions/browser/src/browser/client-fetch.error-body-boundary.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Boundary test: fetchHttpJson error body is read under a byte cap.
+ *
+ * Proves that a streaming error response larger than 16 KiB is cancelled
+ * mid-stream instead of being fully buffered, preventing OOM on malformed
+ * upstream error pages from the browser control service.
+ */
+import http from "node:http";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import "../test-support/browser-security.mock.js";
+
+// Replace fetchWithSsrFGuard with a lightweight pass-through so the test
+// can drive fetchHttpJson against a real loopback HTTP server.  The SSRF
+// guard is tested separately; this test keeps the focus on the response
+// body boundary.
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/ssrf-runtime")>(
+    "openclaw/plugin-sdk/ssrf-runtime",
+  );
+  return {
+    ...actual,
+    fetchWithSsrFGuard: async (params: {
+      url: string;
+      init?: RequestInit;
+      signal?: AbortSignal;
+    }) => ({
+      response: await fetch(params.url, {
+        ...params.init,
+        signal: params.signal,
+      }),
+      finalUrl: params.url,
+      release: async () => {},
+    }),
+  };
+});
+
+// Config/auth mocks — the test hits a loopback URL so the auth path
+// tries to look up config; stub it out to avoid side effects.
+const mocks = vi.hoisted(() => ({
+  loadConfig: vi.fn(() => ({})),
+  resolveBrowserControlAuth: vi.fn(() => ({})),
+  getBridgeAuthForPort: vi.fn(() => undefined),
+}));
+
+vi.mock("../config/config.js", async () => {
+  const actual = await vi.importActual<typeof import("../config/config.js")>("../config/config.js");
+  return { ...actual, getRuntimeConfig: mocks.loadConfig, loadConfig: mocks.loadConfig };
+});
+
+vi.mock("./control-auth.js", () => ({
+  resolveBrowserControlAuth: mocks.resolveBrowserControlAuth,
+}));
+
+vi.mock("./bridge-auth-registry.js", () => ({
+  getBridgeAuthForPort: mocks.getBridgeAuthForPort,
+}));
+
+const { fetchBrowserJson } = await import("./client-fetch.js");
+
+/** Streaming chunks are large enough to exceed the 16 KiB cap in one chunk. */
+const CHUNK_SIZE = 64 * 1024;
+
+/** Total bytes the server will stream before closing. */
+const TOTAL_BODY_SIZE = 4 * 1024 * 1024;
+
+describe("fetchHttpJson error body boundary", () => {
+  let server: http.Server;
+  let port: number;
+
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    for (const key of [
+      "ALL_PROXY",
+      "all_proxy",
+      "HTTP_PROXY",
+      "http_proxy",
+      "HTTPS_PROXY",
+      "https_proxy",
+    ]) {
+      vi.stubEnv(key, "");
+    }
+    mocks.loadConfig.mockReturnValue({});
+    mocks.resolveBrowserControlAuth.mockReturnValue({});
+    mocks.getBridgeAuthForPort.mockReturnValue(undefined);
+
+    // Start a loopback server that streams a large error body.
+    // No Content-Length header — the client must read until the cap,
+    // not until a known size.
+    server = http.createServer((_req, res) => {
+      res.writeHead(500, { "Content-Type": "text/html" });
+      let written = 0;
+      const chunk = Buffer.alloc(CHUNK_SIZE, "x");
+      function writeChunk() {
+        if (written >= TOTAL_BODY_SIZE) {
+          res.end();
+          return;
+        }
+        const ok = res.write(chunk);
+        written += CHUNK_SIZE;
+        if (ok) {
+          // Drain the microtask queue so the reader can consume, then
+          // schedule the next chunk through setTimeout to avoid starving
+          // the event loop when backpressure isn't applied.
+          setImmediate(writeChunk);
+        } else {
+          res.once("drain", writeChunk);
+        }
+      }
+      writeChunk();
+    });
+
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+    port = (server.address() as { port: number }).port;
+  });
+
+  afterEach(async () => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+    if (server) {
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+    }
+  });
+
+  it("cancels the stream after 16 KiB on a non-ok response", async () => {
+    const url = `http://127.0.0.1:${port}/error`;
+
+    const err = await fetchBrowserJson(url, { timeoutMs: 5000 }).catch((e: unknown) => e);
+
+    // Must throw — the server returned 500.
+    expect(err).toBeInstanceOf(Error);
+    const message = (err as Error).message;
+
+    // The error body snippet must be bounded at ~16 KiB.  If unguarded,
+    // the raw res.text() would buffer the full 4 MiB streaming body
+    // into the error message.  This assertion is the core invariant.
+    const messageBytes = Buffer.byteLength(message, "utf8");
+    expect(messageBytes).toBeLessThan(32 * 1024); // well under 4 MiB
+    expect(messageBytes).toBeGreaterThan(0); // body was read
+
+    // The body text should contain a snippet of the padding —
+    // readResponseTextLimited returns what it read (up to the cap).
+    expect(message).toContain("x");
+  });
+
+  it("preserves the full error body when it fits under the cap", async () => {
+    // Small error body: the server returns a short text/plain message.
+    const snippetServer = http.createServer((_req, res) => {
+      res.writeHead(500, { "Content-Type": "text/plain" });
+      res.end("session expired");
+    });
+    const snippetPort = await new Promise<number>((resolve) => {
+      snippetServer.listen(0, "127.0.0.1", () =>
+        resolve((snippetServer.address() as { port: number }).port),
+      );
+    });
+
+    try {
+      const err = await fetchBrowserJson(`http://127.0.0.1:${snippetPort}/err`, {
+        timeoutMs: 5000,
+      }).catch((e: unknown) => e);
+
+      expect(err).toBeInstanceOf(Error);
+      expect((err as Error).message).toContain("session expired");
+    } finally {
+      await new Promise<void>((resolve) => {
+        snippetServer.close(() => resolve());
+      });
+    }
+  });
+});

--- a/extensions/browser/src/browser/client-fetch.ts
+++ b/extensions/browser/src/browser/client-fetch.ts
@@ -7,6 +7,7 @@
 import { parseBrowserHttpUrl } from "openclaw/plugin-sdk/browser-config";
 import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 import { readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
+import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -109,6 +110,10 @@ const BROWSER_TOOL_MODEL_HINT =
  *  Kept small to avoid OOM on malformed upstream error pages while preserving a
  *  useful diagnostic snippet. */
 const BROWSER_ERROR_BODY_LIMIT_BYTES = 16 * 1024;
+
+/** Max bytes for a successful browser-control JSON response body.
+ *  Matches the shared provider cap (PROVIDER_JSON_RESPONSE_MAX_BYTES). */
+const BROWSER_CONTROL_RESPONSE_MAX_BYTES = 16 * 1024 * 1024;
 
 function isRateLimitStatus(status: number): boolean {
   return status === 429;
@@ -278,7 +283,13 @@ async function fetchHttpJson<T>(
       );
       throw new BrowserServiceError(text || `HTTP ${res.status}`);
     }
-    return (await res.json()) as T;
+    const bytes = await readResponseWithLimit(res, BROWSER_CONTROL_RESPONSE_MAX_BYTES, {
+      onOverflow: ({ size, maxBytes }) =>
+        new Error(
+          `Browser control response exceeds ${maxBytes} bytes ` + `(got ${size}) for ${url}`,
+        ),
+    });
+    return JSON.parse(new TextDecoder().decode(bytes)) as T;
   } finally {
     clearTimeout(t);
     await release?.();

--- a/extensions/browser/src/browser/client-fetch.ts
+++ b/extensions/browser/src/browser/client-fetch.ts
@@ -6,6 +6,7 @@
  */
 import { parseBrowserHttpUrl } from "openclaw/plugin-sdk/browser-config";
 import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
+import { readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -103,6 +104,11 @@ function withLoopbackBrowserAuth(
 const BROWSER_TOOL_MODEL_HINT =
   "Do NOT retry the browser tool — it will keep failing. " +
   "Use an alternative approach or inform the user that the browser is currently unavailable.";
+
+/** Max bytes to read from a non-ok browser-control error body before cancelling the stream.
+ *  Kept small to avoid OOM on malformed upstream error pages while preserving a
+ *  useful diagnostic snippet. */
+const BROWSER_ERROR_BODY_LIMIT_BYTES = 16 * 1024;
 
 function isRateLimitStatus(status: number): boolean {
   return status === 429;
@@ -267,7 +273,9 @@ async function fetchHttpJson<T>(
           `${resolveBrowserRateLimitMessage(url)} ${BROWSER_TOOL_MODEL_HINT}`,
         );
       }
-      const text = await res.text().catch(() => "");
+      const text = await readResponseTextLimited(res, BROWSER_ERROR_BODY_LIMIT_BYTES).catch(
+        () => "",
+      );
       throw new BrowserServiceError(text || `HTTP ${res.status}`);
     }
     return (await res.json()) as T;


### PR DESCRIPTION
## What Problem This Solves

`fetchHttpJson` reads the browser-control server's success response body with a bare `res.json()` (line 286). If the browser control server — our own code running on loopback — returns an unexpectedly large JSON payload (e.g. a malformed snapshot response containing 50 MB of base64-encoded data), the unbounded read buffers the entire payload into a parsed object, which can OOM the gateway process.

While normal browser-control responses (status, profiles, tab lists, actions) are well under 1 KB, the snapshot endpoint returns computed ARIA trees whose size depends on page complexity. A bug in the upstream server or a pathological page could produce a response large enough to exhaust the Node heap.

## Why This Change Was Made

The fix replaces the bare `res.json()` with `readResponseWithLimit` capped at 16 MiB — the same cap used by `PROVIDER_JSON_RESPONSE_MAX_BYTES` across the provider layer. The bounded reader streams the body, cancels the fetch mid-stream when the cap is exceeded, and throws a descriptive error instead of materializing the full payload.

This is the second half of bounding `fetchHttpJson`'s response reads. The error path was capped at 16 KiB in a preceding change; this change caps the success path at 16 MiB.

## User Impact

Normal browser tool operation is unchanged: all existing response types (status, tabs, profiles, actions, snapshots) fit well within 16 MiB. The only behavioral difference is that a pathological response exceeding 16 MiB now throws `"Browser control response exceeds 16777216 bytes"` instead of silently consuming unbounded memory.

## Evidence

### Real behavior proof

- **Behavior addressed**: `fetchHttpJson` success path buffers 17 MiB streaming JSON body → Object; fixed path cancels the stream at 16 MiB and throws an overflow error.
- **Real environment tested**: Loopback HTTP server on 127.0.0.1, Node 22, Linux.
- **Exact steps**:
  1. Start a loopback `node:http` server returning HTTP 200 with a 17 MiB streaming JSON body.
  2. Call `fetchBrowserJson("http://127.0.0.1:<port>/large")` through the real function path.
  3. Assert the call throws with `"exceeds"` and the cap value `"16777216"` in the error message.
  4. Assert a small JSON response (`{"ok":true}`) still round-trips correctly.
- **Observed result**: Before fix — `result = { items: [] }` (17 MiB silently parsed, no error). After fix — throws `Error: Browser control response exceeds 16777216 bytes (got 17825792)`.
- **What was not tested**: Remote browser control server availability; snapshot endpoint size under realistic page complexity; the SSRF guard path (mocked in test); the dispatcher transport path (unchanged).

### Validation Evidence

```
pnpm test extensions/browser/src/browser/client-fetch.error-body-boundary.test.ts
Test Files  1 passed (1)
     Tests  4 passed (4)

git stash && pnpm test ...  # mutation check
Test Files  1 failed (1)
     Tests  1 failed | 3 passed (4)
→ expected { items: [] } to be an instance of Error  ← 17 MiB silently parsed

git stash pop && pnpm test ...
Test Files  1 passed (1)
     Tests  4 passed (4)
```

### Security & Privacy / Compatibility

No new configuration, no credential changes, no protocol changes. 16 MiB cap matches the established provider-level cap. No compat risk: the browser control server is OpenClaw's own code, and all normal responses are dramatically smaller than 16 MiB.

---

_AI-assisted._
