### PR TITLE
fix: unify macos dashboard auth startup

### DIFF
--- a/apps/macos/Sources/OpenClaw/AppNavigationActions.swift
+++ b/apps/macos/Sources/OpenClaw/AppNavigationActions.swift
@@ -4,11 +4,8 @@ import AppKit
 enum AppNavigationActions {
     static func openDashboard() {
         NSApp.activate(ignoringOtherApps: true)
-        if DashboardManager.shared.showConfiguredWindowIfPossible() {
-            return
-        }
         Task { @MainActor in
-            if DashboardManager.shared.showConfiguredWindowIfPossible() {
+            if await DashboardManager.shared.showConfiguredWindowIfPossible() {
                 return
             }
             do {

--- a/apps/macos/Sources/OpenClaw/DashboardManager.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardManager.swift
@@ -15,32 +15,33 @@ final class DashboardManager {
     private init() {}
 
     @discardableResult
-    func showConfiguredWindowIfPossible() -> Bool {
+    func showConfiguredWindowIfPossible() async -> Bool {
         let mode = AppStateStore.shared.connectionMode
-        guard let config = self.immediateDashboardConfig(mode: mode),
-              let url = try? GatewayEndpointStore.dashboardURL(
-                  for: config,
-                  mode: mode,
-                  authToken: config.token)
+        guard let config = self.immediateDashboardConfig(mode: mode) else {
+            return false
+        }
+        let token = await GatewayConnection.shared.controlUiAutoAuthToken(config: config)
+        guard let presentation = try? Self.makeDashboardPresentation(
+            config: config,
+            mode: mode,
+            authToken: token),
+            presentation.auth.hasCredential
         else {
             return false
         }
-        let auth = DashboardWindowAuth(
-            gatewayUrl: Self.websocketURLString(for: url),
-            token: config.token,
-            password: config.password?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty)
-        guard auth.hasCredential else {
-            return false
-        }
-        if let controller {
-            controller.show(url: url, auth: auth)
-        } else {
-            let controller = DashboardWindowController(url: url, auth: auth)
-            self.controller = controller
-            controller.show(url: url, auth: auth)
-        }
+        self.show(presentation: presentation)
         Task { _ = try? await ControlChannel.shared.health(timeout: 3) }
         return true
+    }
+
+    private func show(presentation: (url: URL, auth: DashboardWindowAuth)) {
+        if let controller {
+            controller.show(url: presentation.url, auth: presentation.auth)
+        } else {
+            let controller = DashboardWindowController(url: presentation.url, auth: presentation.auth)
+            self.controller = controller
+            controller.show(url: presentation.url, auth: presentation.auth)
+        }
     }
 
     func show() async throws {
@@ -49,22 +50,18 @@ final class DashboardManager {
         let config = try await self.dashboardConfig(mode: mode)
         dashboardManagerLogger.info("dashboard config url=\(config.url.absoluteString, privacy: .public)")
         let token = await GatewayConnection.shared.controlUiAutoAuthToken(config: config)
-        let url = try GatewayEndpointStore.dashboardURL(for: config, mode: mode, authToken: token)
-        let auth = DashboardWindowAuth(
-            gatewayUrl: Self.websocketURLString(for: url),
-            token: token,
-            password: config.password?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty)
+        let presentation = try Self.makeDashboardPresentation(config: config, mode: mode, authToken: token)
 
         if let controller {
-            dashboardManagerLogger.info("dashboard reuse window url=\(url.absoluteString, privacy: .public)")
-            controller.show(url: url, auth: auth)
+            dashboardManagerLogger.info("dashboard reuse window url=\(presentation.url.absoluteString, privacy: .public)")
+            controller.show(url: presentation.url, auth: presentation.auth)
             return
         }
 
-        dashboardManagerLogger.info("dashboard create window url=\(url.absoluteString, privacy: .public)")
-        let controller = DashboardWindowController(url: url, auth: auth)
+        dashboardManagerLogger.info("dashboard create window url=\(presentation.url.absoluteString, privacy: .public)")
+        let controller = DashboardWindowController(url: presentation.url, auth: presentation.auth)
         self.controller = controller
-        controller.show(url: url, auth: auth)
+        controller.show(url: presentation.url, auth: presentation.auth)
 
         // Refresh the cached hello payload without blocking window creation.
         Task { _ = try? await ControlChannel.shared.health(timeout: 3) }
@@ -100,6 +97,25 @@ final class DashboardManager {
         components.queryItems = nil
         components.fragment = nil
         return components.url?.absoluteString ?? dashboardURL.absoluteString
+    }
+
+    static func makeDashboardPresentation(
+        config: GatewayConnection.Config,
+        mode: AppState.ConnectionMode,
+        authToken: String?,
+        localBasePath: String? = nil) throws -> (url: URL, auth: DashboardWindowAuth)
+    {
+        let url = try GatewayEndpointStore.dashboardURL(
+            for: config,
+            mode: mode,
+            localBasePath: localBasePath,
+            authToken: authToken)
+        return (
+            url,
+            DashboardWindowAuth(
+                gatewayUrl: Self.websocketURLString(for: url),
+                token: authToken,
+                password: config.password?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty))
     }
 
     private func dashboardConfig(mode: AppState.ConnectionMode) async throws -> GatewayConnection.Config {

--- a/apps/macos/Sources/OpenClaw/MenuBar.swift
+++ b/apps/macos/Sources/OpenClaw/MenuBar.swift
@@ -388,7 +388,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if CommandLine.arguments.contains("--dashboard") {
             self.webChatAutoLogger.info("Auto-opening dashboard via CLI flag")
             Task { @MainActor in
-                if DashboardManager.shared.showConfiguredWindowIfPossible() {
+                if await DashboardManager.shared.showConfiguredWindowIfPossible() {
                     return
                 }
                 do {

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardManagerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardManagerTests.swift
@@ -1,0 +1,26 @@
+import Foundation
+import Testing
+@testable import OpenClaw
+
+@MainActor
+struct DashboardManagerTests {
+    @Test func `dashboard presentation uses resolved auth token consistently`() throws {
+        let config: GatewayConnection.Config = try (
+            url: #require(URL(string: "ws://127.0.0.1:18789")),
+            token: "stale-config-token",
+            password: "  shared-password  ")
+
+        let presentation = try DashboardManager.makeDashboardPresentation(
+            config: config,
+            mode: .local,
+            authToken: "resolved-native-token",
+            localBasePath: "/control")
+
+        #expect(
+            presentation.url.absoluteString ==
+                "http://127.0.0.1:18789/control/#token=resolved-native-token")
+        #expect(presentation.auth.gatewayUrl == "ws://127.0.0.1:18789/control/")
+        #expect(presentation.auth.token == "resolved-native-token")
+        #expect(presentation.auth.password == "shared-password")
+    }
+}


### PR DESCRIPTION
﻿## Summary
- make the macOS Dashboard fast path resolve Control UI auth through `controlUiAutoAuthToken(config:)`
- share Dashboard URL/auth payload construction so the URL fragment and WKWebView native auth use the same resolved token
- update Dashboard callers to use the async fast path and add a presentation regression test

Closes #98472

## Testing
- `git diff --check`
- Not run: Swift tests (`swift --version` fails on this Windows environment: Swift toolchain is not installed)

## Suggested Swift validation
- `cd apps/macos && swift test --filter DashboardManagerTests`
