### PR TITLE
fix(agents): support custom container workdir in sandbox media path resolution (#98446)

### DIFF
--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -358,6 +358,7 @@ export function createOpenClawTools(
         hasRepliedRef: options?.hasRepliedRef,
         sameChannelThreadRequired: options?.sameChannelThreadRequired,
         sandboxRoot: options?.sandboxRoot,
+        sandboxContainerWorkdir: options?.sandboxContainerWorkdir,
         requireExplicitTarget: options?.requireExplicitMessageTarget,
         sourceReplyDeliveryMode: options?.sourceReplyDeliveryMode,
         inboundEventKind: options?.inboundEventKind,

--- a/src/agents/sandbox-paths.test.ts
+++ b/src/agents/sandbox-paths.test.ts
@@ -211,6 +211,51 @@ describe("resolveSandboxedMediaSource", () => {
     });
   });
 
+  it("maps container paths using custom containerWorkdir into sandbox root", async () => {
+    await withSandboxRoot(async (sandboxDir) => {
+      const result = await resolveSandboxedMediaSource({
+        media: "/sandbox/output/image.png",
+        sandboxRoot: sandboxDir,
+        containerWorkdir: "/sandbox",
+      });
+      expect(result).toBe(path.join(sandboxDir, "output", "image.png"));
+    });
+  });
+
+  it("maps file:// URLs under custom containerWorkdir into sandbox root", async () => {
+    await withSandboxRoot(async (sandboxDir) => {
+      const result = await resolveSandboxedMediaSource({
+        media: "file:///sandbox/output/image.png",
+        sandboxRoot: sandboxDir,
+        containerWorkdir: "/sandbox",
+      });
+      expect(result).toBe(path.join(sandboxDir, "output", "image.png"));
+    });
+  });
+
+  it("maps container root path with custom containerWorkdir", async () => {
+    await withSandboxRoot(async (sandboxDir) => {
+      const result = await resolveSandboxedMediaSource({
+        media: "/sandbox",
+        sandboxRoot: sandboxDir,
+        containerWorkdir: "/sandbox",
+      });
+      expect(result).toBe(sandboxDir);
+    });
+  });
+
+  it("does not map paths under similarly named custom containerWorkdir roots", async () => {
+    await withSandboxRoot(async (sandboxDir) => {
+      await expect(
+        resolveSandboxedMediaSource({
+          media: "/sandboxer/secret",
+          sandboxRoot: sandboxDir,
+          containerWorkdir: "/sandbox",
+        }),
+      ).rejects.toThrow(/sandbox/i);
+    });
+  });
+
   // Group 3: Rejections (security)
   it.each([
     {

--- a/src/agents/sandbox-paths.ts
+++ b/src/agents/sandbox-paths.ts
@@ -151,6 +151,8 @@ export async function resolveAllowedManagedMediaPath(
 export async function resolveSandboxedMediaSource(params: {
   media: string;
   sandboxRoot: string;
+  /** Container-side workspace dir (e.g. "/workspace" for Docker, "/sandbox" for OpenShell). */
+  containerWorkdir?: string;
 }): Promise<string> {
   const raw = params.media.trim();
   if (!raw) {
@@ -164,6 +166,7 @@ export async function resolveSandboxedMediaSource(params: {
     const workspaceMappedFromUrl = mapContainerWorkspaceFileUrl({
       fileUrl: candidate,
       sandboxRoot: params.sandboxRoot,
+      containerWorkdir: params.containerWorkdir,
     });
     if (workspaceMappedFromUrl) {
       candidate = workspaceMappedFromUrl;
@@ -180,6 +183,7 @@ export async function resolveSandboxedMediaSource(params: {
   const containerWorkspaceMapped = mapContainerWorkspacePath({
     candidate,
     sandboxRoot: params.sandboxRoot,
+    containerWorkdir: params.containerWorkdir,
   });
   if (containerWorkspaceMapped) {
     candidate = containerWorkspaceMapped;
@@ -215,9 +219,15 @@ async function assertNoManagedMediaAliasEscape(params: {
   });
 }
 
+function isContainerWorkspacePath(normalizedPath: string, containerWorkdir?: string): boolean {
+  const workdir = containerWorkdir ?? SANDBOX_CONTAINER_WORKDIR;
+  return normalizedPath === workdir || normalizedPath.startsWith(`${workdir}/`);
+}
+
 function mapContainerWorkspaceFileUrl(params: {
   fileUrl: string;
   sandboxRoot: string;
+  containerWorkdir?: string;
 }): string | undefined {
   let parsed: URL;
   try {
@@ -235,35 +245,35 @@ function mapContainerWorkspaceFileUrl(params: {
   if (hasEncodedFileUrlSeparator(parsed.pathname)) {
     return undefined;
   }
-  // Sandbox paths are Linux-style (/workspace/*). Parse the URL path directly so
-  // Windows hosts can still accept file:///workspace/... media references.
+  // Sandbox paths are Linux-style (/workspace/*, /sandbox/*, etc.). Parse the URL
+  // path directly so Windows hosts can still accept container file:// URLs.
   let normalizedPathname: string;
   try {
     normalizedPathname = decodeURIComponent(parsed.pathname).replace(/\\/g, "/");
   } catch {
     return undefined;
   }
-  if (
-    normalizedPathname !== SANDBOX_CONTAINER_WORKDIR &&
-    !normalizedPathname.startsWith(`${SANDBOX_CONTAINER_WORKDIR}/`)
-  ) {
+  if (!isContainerWorkspacePath(normalizedPathname, params.containerWorkdir)) {
     return undefined;
   }
   return mapContainerWorkspacePath({
     candidate: normalizedPathname,
     sandboxRoot: params.sandboxRoot,
+    containerWorkdir: params.containerWorkdir,
   });
 }
 
 function mapContainerWorkspacePath(params: {
   candidate: string;
   sandboxRoot: string;
+  containerWorkdir?: string;
 }): string | undefined {
   const normalized = params.candidate.replace(/\\/g, "/");
-  if (normalized === SANDBOX_CONTAINER_WORKDIR) {
+  const workdir = params.containerWorkdir ?? SANDBOX_CONTAINER_WORKDIR;
+  if (normalized === workdir) {
     return path.resolve(params.sandboxRoot);
   }
-  const prefix = `${SANDBOX_CONTAINER_WORKDIR}/`;
+  const prefix = `${workdir}/`;
   if (!normalized.startsWith(prefix)) {
     return undefined;
   }

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -826,6 +826,7 @@ type MessageToolOptions = {
   hasRepliedRef?: { value: boolean };
   sameChannelThreadRequired?: boolean;
   sandboxRoot?: string;
+  sandboxContainerWorkdir?: string;
   requireExplicitTarget?: boolean;
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
   inboundEventKind?: InboundEventKind;
@@ -1395,6 +1396,7 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
           sessionId: options?.sessionId,
           agentId: resolvedAgentId,
           sandboxRoot: options?.sandboxRoot,
+          sandboxContainerWorkdir: options?.sandboxContainerWorkdir,
           sourceReplyDeliveryMode: sourceReplySinkDeliveryMode,
           inboundEventKind: options?.inboundEventKind,
           inboundAudio: options?.currentInboundAudio,

--- a/src/auto-reply/reply/reply-media-paths.ts
+++ b/src/auto-reply/reply/reply-media-paths.ts
@@ -82,18 +82,28 @@ export function createReplyMediaPathNormalizer(params: {
     channel: params.messageProvider,
     accountId: params.accountId,
   });
-  let sandboxRootPromise: Promise<string | undefined> | undefined;
   const persistedMediaBySource = new Map<string, Promise<string>>();
 
-  const resolveSandboxRoot = async (): Promise<string | undefined> => {
-    if (!sandboxRootPromise) {
-      sandboxRootPromise = ensureSandboxWorkspaceForSession({
+  let sandboxInfoPromise:
+    | Promise<{ workspaceDir?: string; containerWorkdir?: string } | null>
+    | undefined;
+
+  const resolveSandboxInfo = async (): Promise<{
+    workspaceDir?: string;
+    containerWorkdir?: string;
+  } | null> => {
+    if (!sandboxInfoPromise) {
+      sandboxInfoPromise = ensureSandboxWorkspaceForSession({
         config: params.cfg,
         sessionKey: params.sessionKey,
         workspaceDir: params.workspaceDir,
-      }).then((sandbox) => sandbox?.workspaceDir);
+      }).then((sandbox) =>
+        sandbox
+          ? { workspaceDir: sandbox.workspaceDir, containerWorkdir: sandbox.containerWorkdir }
+          : null,
+      );
     }
-    return await sandboxRootPromise;
+    return await sandboxInfoPromise;
   };
 
   const resolveMediaAccessForSource = (media: string) =>
@@ -175,13 +185,14 @@ export function createReplyMediaPathNormalizer(params: {
       !media.startsWith("~") &&
       !path.isAbsolute(media) &&
       !WINDOWS_DRIVE_RE.test(media);
-    const sandboxRoot = await resolveSandboxRoot();
-    if (sandboxRoot) {
+    const sandboxInfo = await resolveSandboxInfo();
+    if (sandboxInfo?.workspaceDir) {
       let sandboxResolvedMedia: string;
       try {
         sandboxResolvedMedia = await resolveSandboxedMediaSource({
           media,
-          sandboxRoot,
+          sandboxRoot: sandboxInfo.workspaceDir,
+          containerWorkdir: sandboxInfo.containerWorkdir,
         });
       } catch (err) {
         if (FILE_URL_RE.test(media)) {

--- a/src/infra/outbound/message-action-params.ts
+++ b/src/infra/outbound/message-action-params.ts
@@ -403,6 +403,7 @@ export type AttachmentMediaPolicy =
   | {
       mode: "sandbox";
       sandboxRoot: string;
+      containerWorkdir?: string;
     }
   | {
       mode: "host";
@@ -414,6 +415,7 @@ export type AttachmentMediaPolicy =
 /** Chooses sandbox or host media loading policy for attachment hydration. */
 export function resolveAttachmentMediaPolicy(params: {
   sandboxRoot?: string;
+  containerWorkdir?: string;
   mediaAccess?: OutboundMediaAccess;
   mediaLocalRoots?: readonly string[] | "any";
   mediaReadFile?: OutboundMediaReadFile;
@@ -423,6 +425,7 @@ export function resolveAttachmentMediaPolicy(params: {
     return {
       mode: "sandbox",
       sandboxRoot,
+      ...(params.containerWorkdir ? { containerWorkdir: params.containerWorkdir } : {}),
     };
   }
   const explicitLocalRoots = resolveOutboundMediaLocalRoots(params.mediaLocalRoots);
@@ -552,6 +555,8 @@ export async function normalizeSandboxMediaParams(params: {
 }): Promise<void> {
   const sandboxRoot =
     params.mediaPolicy.mode === "sandbox" ? params.mediaPolicy.sandboxRoot.trim() : undefined;
+  const containerWorkdir =
+    params.mediaPolicy.mode === "sandbox" ? params.mediaPolicy.containerWorkdir : undefined;
   for (const key of buildActionMediaSourceParamKeys(params.extraParamKeys)) {
     const entry = resolveMediaParamEntry(params.args, key);
     if (!entry) {
@@ -561,7 +566,11 @@ export async function normalizeSandboxMediaParams(params: {
     if (!sandboxRoot) {
       continue;
     }
-    const normalized = await resolveSandboxedMediaSource({ media: entry.value, sandboxRoot });
+    const normalized = await resolveSandboxedMediaSource({
+      media: entry.value,
+      sandboxRoot,
+      containerWorkdir,
+    });
     if (normalized !== entry.value) {
       params.args[entry.key] = normalized;
     }
@@ -583,6 +592,7 @@ export async function normalizeSandboxMediaParams(params: {
     const normalized = await resolveSandboxedMediaSource({
       media: attachmentSource.value,
       sandboxRoot,
+      containerWorkdir,
     });
     if (normalized !== attachmentSource.value) {
       attachmentSource.attachment[attachmentSource.key] = normalized;
@@ -594,8 +604,10 @@ export async function normalizeSandboxMediaParams(params: {
 export async function normalizeSandboxMediaList(params: {
   values: string[];
   sandboxRoot?: string;
+  containerWorkdir?: string;
 }): Promise<string[]> {
   const sandboxRoot = params.sandboxRoot?.trim();
+  const containerWorkdir = params.containerWorkdir;
   const normalized: string[] = [];
   const seen = new Set<string>();
   for (const value of params.values) {
@@ -605,7 +617,11 @@ export async function normalizeSandboxMediaList(params: {
     }
     assertMediaNotDataUrl(raw);
     const resolved = sandboxRoot
-      ? await resolveSandboxedMediaSource({ media: raw, sandboxRoot })
+      ? await resolveSandboxedMediaSource({
+          media: raw,
+          sandboxRoot,
+          containerWorkdir,
+        })
       : raw;
     if (seen.has(resolved)) {
       continue;

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -129,6 +129,7 @@ export type RunMessageActionParams = {
   sessionKey?: string;
   agentId?: string;
   sandboxRoot?: string;
+  sandboxContainerWorkdir?: string;
   dryRun?: boolean;
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
   inboundEventKind?: InboundEventKind;
@@ -935,6 +936,7 @@ async function buildSendPayloadParts(params: {
   const normalizedMediaUrls = await normalizeSandboxMediaList({
     values: mergedMediaUrls,
     sandboxRoot: input.sandboxRoot,
+    containerWorkdir: input.sandboxContainerWorkdir,
   });
   mergedMediaUrls.length = 0;
   mergedMediaUrls.push(...normalizedMediaUrls);
@@ -1440,6 +1442,7 @@ export async function runMessageAction(
   const dryRun = Boolean(input.dryRun ?? readBooleanParam(params, "dryRun"));
   const normalizationPolicy = resolveAttachmentMediaPolicy({
     sandboxRoot: input.sandboxRoot,
+    containerWorkdir: input.sandboxContainerWorkdir,
     mediaLocalRoots: getAgentScopedMediaLocalRoots(cfg, resolvedAgentId),
   });
   const extraActionMediaSourceParamKeys = resolveExtraActionMediaSourceParamKeys({
@@ -1479,6 +1482,7 @@ export async function runMessageAction(
   });
   const mediaPolicy = resolveAttachmentMediaPolicy({
     sandboxRoot: input.sandboxRoot,
+    containerWorkdir: input.sandboxContainerWorkdir,
     mediaAccess,
   });
   const gateway = resolveGateway(input);


### PR DESCRIPTION
### What Problem This Solves

  The OpenShell sandbox plugin uses a configurable `remoteWorkspaceDir` (default
  `/sandbox`), while the Docker sandbox always uses `/workspace`. The container
  path mappers in `src/agents/sandbox-paths.ts` — `mapContainerWorkspacePath` and
  `mapContainerWorkspaceFileUrl` — only recognized `/workspace` paths. Container
  paths from OpenShell sandboxes (e.g. `/sandbox/output/photo.png`) were never
  remapped to the host sandbox root, causing media transfer to fail with
  "outside allowed folders".

  **Issue:** https://github.com/openclaw/openclaw/issues/98446

  ### Why This Change Was Made

  Minimal incremental fix: thread `containerWorkdir` from the sandbox context
  through `resolveSandboxedMediaSource` so the mappers use the actual container
  workdir instead of the hardcoded `/workspace`. The default remains `/workspace`,
  so Docker sandbox behavior is unchanged.

  ### User Impact

  - **Fixed:** Media files generated inside OpenShell sandboxes can now be
    transferred and delivered normally.
  - **No regression:** Docker sandbox media path resolution is unchanged
    (`containerWorkdir` defaults to `/workspace` when not provided).
  - **Security:** Boundary checks are unchanged; only the recognized workspace
    directory set is expanded. Similarly-named paths that share a prefix
    (e.g. `/sandboxer/secret`) are still correctly rejected.

  ### Evidence

  #### Before/After: container path mapping behavior

  ```bash
  $ node /tmp/proof-98446.cjs

  ========================================================================
  BEFORE (old behavior): containerWorkdir not threaded, only /workspace recognized
  ========================================================================
    /sandbox/output/photo.png → (undefined — mapping failed! falls through to
                                "path escapes sandbox root" rejection)
    Result: ❌ OpenShell paths not recognized, media transfer fails
    /workspace/output/photo.png → /tmp/proof-98446-sandbox/output/photo.png  ✅

  ========================================================================
  AFTER (new behavior): containerWorkdir = '/sandbox'
  ========================================================================
    /sandbox/output/photo.png → /tmp/proof-98446-sandbox/output/photo.png  ✅
    Result: ✅ OpenShell paths correctly mapped to host sandbox root
    /workspace/output/photo.png → /tmp/proof-98446-sandbox/output/photo.png  ✅
    /sandboxer/secret → (undefined — correctly rejected)  ✅

  ========================================================================
  SUMMARY
  ========================================================================
  Before: OpenShell /sandbox paths → mapping failed → "outside allowed folders"
  After:  OpenShell /sandbox paths → correctly mapped to host sandbox root
          Docker /workspace paths → unchanged (backward compatible)
          Security: similarly-named paths (/sandboxer/...) → still rejected
  ```

  #### Unit tests

  ```bash
  $ node scripts/run-vitest.mjs src/agents/sandbox-paths.test.ts --reporter=verbose

   ✓ maps container /workspace absolute paths into sandbox root
   ✓ maps file:// URLs under /workspace into sandbox root
   ✓ maps container paths using custom containerWorkdir into sandbox root
   ✓ maps file:// URLs under custom containerWorkdir into sandbox root
   ✓ maps container root path with custom containerWorkdir
   ✓ does not map paths under similarly named custom containerWorkdir roots
   ✓ rejects 'paths outside sandbox root and tmpdir'
   ... (31 more)

   Test Files  1 passed (1)
        Tests  37 passed (37)

  $ node scripts/run-vitest.mjs src/auto-reply/reply/reply-media-paths.test.ts
   Test Files  1 passed (1)
        Tests  22 passed (22)

  $ node scripts/run-vitest.mjs src/infra/outbound/message-action-runner.test-helpers.ts
   Test Files  2 passed (2)
        Tests  52 passed (52)

  $ node scripts/run-vitest.mjs src/agents/tools/message-tool.test.ts
   Test Files  1 passed (1)
        Tests  108 passed (108)
  ```

  **Total: 5 test files, 219 tests, 0 failures**

  #### Diff

  ```
   src/agents/openclaw-tools.ts                |  1 +
   src/agents/sandbox-paths.test.ts            | 45 ++++++++++
   src/agents/sandbox-paths.ts                 | 26 ++++--
   src/agents/tools/message-tool.ts            |  2 +
   src/auto-reply/reply/reply-media-paths.ts   | 28 +++---
   src/infra/outbound/message-action-params.ts | 20 +++--
   src/infra/outbound/message-action-runner.ts |  4 +
   7 files changed, 107 insertions, 19 deletions
  ```