### PR TITLE
docs(telegram): add missing batched replyToMode value

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -639,10 +639,12 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
     - `off` (default)
     - `first`
     - `all`
+    - `batched`
 
     When reply threading is enabled and the original Telegram text or caption is available, OpenClaw includes a native Telegram quote excerpt automatically. Telegram caps native quote text at 1024 UTF-16 code units, so longer messages are quoted from the start and fall back to a plain reply if Telegram rejects the quote.
 
     Note: `off` disables implicit reply threading. Explicit `[[reply_to_*]]` tags are still honored.
+    `batched` only attaches the native reply reference when the inbound event was a debounced batch of multiple messages. Useful when you want native replies mainly for bursty multi-message chats without attaching one to every single-message turn.
 
   </Accordion>
 


### PR DESCRIPTION
## What Problem This Solves

The `replyToMode` options list in `docs/channels/telegram.md` only documents `off`, `first`, and `all`, but the schema and runtime also support `batched`. Users are not aware of the `batched` option from the Telegram channel docs.

## Evidence

### Shared type definition includes `batched`

`src/config/types.base.ts:13`:
```ts
export type ReplyToMode = "off" | "first" | "all" | "batched";
```

### Telegram runtime uses `batched` via shared SDK helper

`extensions/telegram/src/send.ts:719-720` — `batched` is handled through `isSingleUseReplyToMode()` alongside `first`:
```ts
isSingleUseReplyToMode(opts.replyToMode);
```

`src/auto-reply/reply/reply-reference.ts:7`:
```ts
export function isSingleUseReplyToMode(mode: ReplyToMode): boolean {
  return mode === "first" || mode === "batched";
}
```

### Sibling channel docs already list `batched`

- `docs/channels/discord.md:654-657` — lists `off`, `first`, `all`, `batched`
- `docs/channels/slack.md:1064` — lists `off|first|all|batched`
- `docs/gateway/config-channels.md:204` — example shows `// off | first | all | batched`

### Tests confirm `batched` is valid

`extensions/telegram/src/doctor.test.ts:533-537` — tests `replyToMode: "batched"` explicitly.

### This fix

Added `- batched` to the options list and described its behavior: only attaches the native reply reference for debounced batch messages, useful for bursty multi-message chats.

## User Impact

Docs-only change. Users can now discover the `batched` option from the Telegram channel documentation.