### PR TITLE
fix(tools-manager): bound GitHub releases response body to prevent unbounded read

### DIFF
--- a/src/agents/utils/tools-manager.test.ts
+++ b/src/agents/utils/tools-manager.test.ts
@@ -1,5 +1,4 @@
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { createServer, type Server } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -8,7 +7,6 @@ import { deleteTestEnvValue, setTestEnvValue } from "../../test-utils/env.js";
 const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
 const spawnSyncMock = vi.hoisted(() => vi.fn());
 const extractArchiveMock = vi.hoisted(() => vi.fn());
-const GITHUB_RELEASE_JSON_MAX_BYTES = 1024 * 1024;
 
 vi.mock("../../infra/net/fetch-guard.js", () => ({
   fetchWithSsrFGuard: fetchWithSsrFGuardMock,
@@ -25,27 +23,6 @@ vi.mock("../../infra/archive.js", () => ({
 
 let originalAgentDir: string | undefined;
 let tempAgentDir: string | undefined;
-
-async function listenLoopbackServer(server: Server): Promise<number> {
-  return await new Promise((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(0, "127.0.0.1", () => {
-      server.off("error", reject);
-      const address = server.address();
-      if (!address || typeof address === "string") {
-        reject(new Error("expected loopback TCP address"));
-        return;
-      }
-      resolve(address.port);
-    });
-  });
-}
-
-async function closeServer(server: Server): Promise<void> {
-  await new Promise<void>((resolve) => {
-    server.close(() => resolve());
-  });
-}
 
 beforeEach(() => {
   originalAgentDir = process.env.OPENCLAW_AGENT_DIR;
@@ -87,7 +64,7 @@ describe("ensureTool", () => {
       finalUrl: "https://api.github.com/repos/sharkdp/fd/releases/latest",
     });
 
-    await expect(ensureTool("fd", true)).rejects.toThrow("GitHub API error: 503");
+    await expect(ensureTool("fd", true)).resolves.toBeUndefined();
 
     expect(cancel).toHaveBeenCalledOnce();
     expect(release).toHaveBeenCalledOnce();
@@ -111,7 +88,7 @@ describe("ensureTool", () => {
         finalUrl: "https://github.com/BurntSushi/ripgrep/releases/download/14.1.1/archive",
       });
 
-    await expect(ensureTool("rg", true)).rejects.toThrow("Failed to download: 404");
+    await expect(ensureTool("rg", true)).resolves.toBeUndefined();
 
     expect(cancel).toHaveBeenCalledOnce();
     expect(releaseCheckRelease).toHaveBeenCalledOnce();
@@ -232,131 +209,38 @@ describe("ensureTool", () => {
     expect(readFileSync(destination)).toEqual(Buffer.from(body));
   });
 
-  it.each([
-    { body: "{not json", error: "GitHub release response is malformed JSON" },
-    {
-      body: JSON.stringify({ tag_name: 42 }),
-      error: "GitHub release response has no valid tag_name",
-    },
-  ])("rejects corrupt release metadata: $error", async ({ body, error }) => {
-    const { ensureTool } = await import("./tools-manager.js");
-    const release = vi.fn(async () => {});
-    fetchWithSsrFGuardMock.mockResolvedValueOnce({
-      response: new Response(body, { status: 200 }),
-      release,
-      finalUrl: "https://api.github.com/repos/sharkdp/fd/releases/latest",
-    });
-
-    await expect(ensureTool("fd", true)).rejects.toThrow(error);
-    expect(fetchWithSsrFGuardMock).toHaveBeenCalledOnce();
-    expect(release).toHaveBeenCalledOnce();
-  });
-
-  it("releases the guarded response when the release stream aborts", async () => {
-    const { ensureTool } = await import("./tools-manager.js");
-    const release = vi.fn(async () => {});
-    const body = new ReadableStream<Uint8Array>({
-      pull(controller) {
-        const error = new Error("release lookup aborted");
-        error.name = "AbortError";
-        controller.error(error);
-      },
-    });
-    fetchWithSsrFGuardMock.mockResolvedValueOnce({
-      response: new Response(body, { status: 200 }),
-      release,
-      finalUrl: "https://api.github.com/repos/sharkdp/fd/releases/latest",
-    });
-
-    await expect(ensureTool("fd", true)).rejects.toThrow("release lookup aborted");
-    expect(fetchWithSsrFGuardMock).toHaveBeenCalledOnce();
-    expect(release).toHaveBeenCalledOnce();
-  });
-
-  it("surfaces download failures through non-silent logging", async () => {
-    const { ensureTool } = await import("./tools-manager.js");
-    const release = vi.fn(async () => {});
-    const log = vi.spyOn(console, "log").mockImplementation(() => {});
-    fetchWithSsrFGuardMock.mockResolvedValueOnce({
-      response: new Response("server error", { status: 503 }),
-      release,
-      finalUrl: "https://api.github.com/repos/sharkdp/fd/releases/latest",
-    });
-
-    try {
-      await expect(ensureTool("fd")).resolves.toBeUndefined();
-      expect(log).toHaveBeenCalledWith(expect.stringContaining("GitHub API error: 503"));
-      expect(release).toHaveBeenCalledOnce();
-    } finally {
-      log.mockRestore();
-    }
-  });
-
-  it("uses the fdfind system fallback without starting a download", async () => {
-    const { ensureTool } = await import("./tools-manager.js");
-    spawnSyncMock
-      .mockReturnValueOnce({
-        error: new Error("ENOENT"),
-        status: null,
-        stderr: Buffer.alloc(0),
-        stdout: Buffer.alloc(0),
-      })
-      .mockReturnValueOnce({
-        error: undefined,
-        status: 0,
-        stderr: Buffer.alloc(0),
-        stdout: Buffer.from("fd 10.4.2"),
-      });
-
-    await expect(ensureTool("fd", true)).resolves.toBe("fdfind");
-    expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
-  });
-
-  it("bounds the real tool-resolution path against streamed HTTP release metadata", async () => {
-    const totalBytes = 16 * 1024 * 1024;
-    const chunk = Buffer.alloc(64 * 1024, 0x78);
-    let streamedBytes = 0;
-    let requestUrl: string | undefined;
-    const server = createServer((req, res) => {
-      requestUrl = req.url;
-      res.writeHead(200, { "content-type": "application/json" });
-      res.write('{"tag_name":"v');
-
-      const writeMore = () => {
-        while (streamedBytes < totalBytes && !res.destroyed) {
-          streamedBytes += chunk.byteLength;
-          if (!res.write(chunk)) {
-            res.once("drain", writeMore);
+  it("bounds GitHub release metadata reads", async () => {
+    let reads = 0;
+    let canceled = false;
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        pull(controller) {
+          if (reads >= 20) {
+            controller.close();
             return;
           }
-        }
-        if (!res.destroyed) {
-          res.end('"}');
-        }
-      };
-      writeMore();
-    });
-    const port = await listenLoopbackServer(server);
+          reads += 1;
+          controller.enqueue(new Uint8Array(512 * 1024));
+        },
+        cancel() {
+          canceled = true;
+        },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
     const release = vi.fn(async () => {});
-    fetchWithSsrFGuardMock.mockImplementationOnce(async () => ({
-      response: await fetch(`http://127.0.0.1:${port}/release/latest`),
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response,
       release,
-      finalUrl: `http://127.0.0.1:${port}/release/latest`,
-    }));
+      finalUrl: "https://api.github.com/repos/sharkdp/fd/releases/latest",
+    });
 
-    try {
-      const { ensureTool } = await import("./tools-manager.js");
-      await expect(ensureTool("fd", true)).rejects.toThrow(
-        `GitHub release response exceeds ${GITHUB_RELEASE_JSON_MAX_BYTES} bytes`,
-      );
+    const { ensureTool } = await import("./tools-manager.js");
+    await expect(ensureTool("fd", true)).resolves.toBeUndefined();
 
-      expect(requestUrl).toBe("/release/latest");
-      expect(streamedBytes).toBeLessThan(totalBytes);
-      expect(fetchWithSsrFGuardMock).toHaveBeenCalledOnce();
-      expect(release).toHaveBeenCalledOnce();
-    } finally {
-      await closeServer(server);
-    }
+    expect(reads).toBeLessThan(20);
+    expect(canceled).toBe(true);
+    expect(release).toHaveBeenCalledOnce();
   });
 });
 

--- a/src/agents/utils/tools-manager.test.ts
+++ b/src/agents/utils/tools-manager.test.ts
@@ -1,4 +1,5 @@
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createServer, type Server } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -7,6 +8,7 @@ import { deleteTestEnvValue, setTestEnvValue } from "../../test-utils/env.js";
 const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
 const spawnSyncMock = vi.hoisted(() => vi.fn());
 const extractArchiveMock = vi.hoisted(() => vi.fn());
+const GITHUB_RELEASE_JSON_MAX_BYTES = 1024 * 1024;
 
 vi.mock("../../infra/net/fetch-guard.js", () => ({
   fetchWithSsrFGuard: fetchWithSsrFGuardMock,
@@ -23,6 +25,27 @@ vi.mock("../../infra/archive.js", () => ({
 
 let originalAgentDir: string | undefined;
 let tempAgentDir: string | undefined;
+
+async function listenLoopbackServer(server: Server): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("expected loopback TCP address"));
+        return;
+      }
+      resolve(address.port);
+    });
+  });
+}
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve) => {
+    server.close(() => resolve());
+  });
+}
 
 beforeEach(() => {
   originalAgentDir = process.env.OPENCLAW_AGENT_DIR;
@@ -64,7 +87,7 @@ describe("ensureTool", () => {
       finalUrl: "https://api.github.com/repos/sharkdp/fd/releases/latest",
     });
 
-    await expect(ensureTool("fd", true)).resolves.toBeUndefined();
+    await expect(ensureTool("fd", true)).rejects.toThrow("GitHub API error: 503");
 
     expect(cancel).toHaveBeenCalledOnce();
     expect(release).toHaveBeenCalledOnce();
@@ -88,7 +111,7 @@ describe("ensureTool", () => {
         finalUrl: "https://github.com/BurntSushi/ripgrep/releases/download/14.1.1/archive",
       });
 
-    await expect(ensureTool("rg", true)).resolves.toBeUndefined();
+    await expect(ensureTool("rg", true)).rejects.toThrow("Failed to download: 404");
 
     expect(cancel).toHaveBeenCalledOnce();
     expect(releaseCheckRelease).toHaveBeenCalledOnce();
@@ -207,6 +230,133 @@ describe("ensureTool", () => {
 
     expect(release).toHaveBeenCalledOnce();
     expect(readFileSync(destination)).toEqual(Buffer.from(body));
+  });
+
+  it.each([
+    { body: "{not json", error: "GitHub release response is malformed JSON" },
+    {
+      body: JSON.stringify({ tag_name: 42 }),
+      error: "GitHub release response has no valid tag_name",
+    },
+  ])("rejects corrupt release metadata: $error", async ({ body, error }) => {
+    const { ensureTool } = await import("./tools-manager.js");
+    const release = vi.fn(async () => {});
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: new Response(body, { status: 200 }),
+      release,
+      finalUrl: "https://api.github.com/repos/sharkdp/fd/releases/latest",
+    });
+
+    await expect(ensureTool("fd", true)).rejects.toThrow(error);
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledOnce();
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it("releases the guarded response when the release stream aborts", async () => {
+    const { ensureTool } = await import("./tools-manager.js");
+    const release = vi.fn(async () => {});
+    const body = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        const error = new Error("release lookup aborted");
+        error.name = "AbortError";
+        controller.error(error);
+      },
+    });
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: new Response(body, { status: 200 }),
+      release,
+      finalUrl: "https://api.github.com/repos/sharkdp/fd/releases/latest",
+    });
+
+    await expect(ensureTool("fd", true)).rejects.toThrow("release lookup aborted");
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledOnce();
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it("surfaces download failures through non-silent logging", async () => {
+    const { ensureTool } = await import("./tools-manager.js");
+    const release = vi.fn(async () => {});
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: new Response("server error", { status: 503 }),
+      release,
+      finalUrl: "https://api.github.com/repos/sharkdp/fd/releases/latest",
+    });
+
+    try {
+      await expect(ensureTool("fd")).resolves.toBeUndefined();
+      expect(log).toHaveBeenCalledWith(expect.stringContaining("GitHub API error: 503"));
+      expect(release).toHaveBeenCalledOnce();
+    } finally {
+      log.mockRestore();
+    }
+  });
+
+  it("uses the fdfind system fallback without starting a download", async () => {
+    const { ensureTool } = await import("./tools-manager.js");
+    spawnSyncMock
+      .mockReturnValueOnce({
+        error: new Error("ENOENT"),
+        status: null,
+        stderr: Buffer.alloc(0),
+        stdout: Buffer.alloc(0),
+      })
+      .mockReturnValueOnce({
+        error: undefined,
+        status: 0,
+        stderr: Buffer.alloc(0),
+        stdout: Buffer.from("fd 10.4.2"),
+      });
+
+    await expect(ensureTool("fd", true)).resolves.toBe("fdfind");
+    expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
+  });
+
+  it("bounds the real tool-resolution path against streamed HTTP release metadata", async () => {
+    const totalBytes = 16 * 1024 * 1024;
+    const chunk = Buffer.alloc(64 * 1024, 0x78);
+    let streamedBytes = 0;
+    let requestUrl: string | undefined;
+    const server = createServer((req, res) => {
+      requestUrl = req.url;
+      res.writeHead(200, { "content-type": "application/json" });
+      res.write('{"tag_name":"v');
+
+      const writeMore = () => {
+        while (streamedBytes < totalBytes && !res.destroyed) {
+          streamedBytes += chunk.byteLength;
+          if (!res.write(chunk)) {
+            res.once("drain", writeMore);
+            return;
+          }
+        }
+        if (!res.destroyed) {
+          res.end('"}');
+        }
+      };
+      writeMore();
+    });
+    const port = await listenLoopbackServer(server);
+    const release = vi.fn(async () => {});
+    fetchWithSsrFGuardMock.mockImplementationOnce(async () => ({
+      response: await fetch(`http://127.0.0.1:${port}/release/latest`),
+      release,
+      finalUrl: `http://127.0.0.1:${port}/release/latest`,
+    }));
+
+    try {
+      const { ensureTool } = await import("./tools-manager.js");
+      await expect(ensureTool("fd", true)).rejects.toThrow(
+        `GitHub release response exceeds ${GITHUB_RELEASE_JSON_MAX_BYTES} bytes`,
+      );
+
+      expect(requestUrl).toBe("/release/latest");
+      expect(streamedBytes).toBeLessThan(totalBytes);
+      expect(fetchWithSsrFGuardMock).toHaveBeenCalledOnce();
+      expect(release).toHaveBeenCalledOnce();
+    } finally {
+      await closeServer(server);
+    }
   });
 });
 

--- a/src/agents/utils/tools-manager.ts
+++ b/src/agents/utils/tools-manager.ts
@@ -19,11 +19,11 @@ import { join } from "node:path";
 import { Readable, Transform } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import type { ReadableStream as NodeReadableStream } from "node:stream/web";
-import { readResponseWithLimit } from "@openclaw/media-core/read-response-with-limit";
 import chalk from "chalk";
 import { extractArchive } from "../../infra/archive.js";
 import { fetchWithSsrFGuard } from "../../infra/net/fetch-guard.js";
 import { APP_NAME, getBinDir } from "../config.js";
+import { readProviderJsonResponse } from "../provider-http-errors.js";
 
 const TOOLS_DIR = getBinDir();
 const NETWORK_TIMEOUT_MS = 10_000;
@@ -162,22 +162,10 @@ async function getLatestVersion(repo: string): Promise<string> {
       throw new Error(`GitHub API error: ${response.status}`);
     }
 
-    const bytes = await readResponseWithLimit(response, GITHUB_RELEASE_JSON_MAX_BYTES, {
-      onOverflow: ({ size, maxBytes }) =>
-        new Error(`GitHub release response exceeds ${maxBytes} bytes (got ${size})`),
+    const data = await readProviderJsonResponse<{ tag_name: string }>(response, "GitHub release", {
+      maxBytes: GITHUB_RELEASE_JSON_MAX_BYTES,
     });
-    let data: unknown;
-    try {
-      data = JSON.parse(bytes.toString("utf8")) as unknown;
-    } catch (cause) {
-      throw new Error("GitHub release response is malformed JSON", { cause });
-    }
-    const tagName =
-      data && typeof data === "object" && "tag_name" in data ? data.tag_name : undefined;
-    if (typeof tagName !== "string" || !tagName.trim()) {
-      throw new Error("GitHub release response has no valid tag_name");
-    }
-    return tagName.replace(/^v/, "");
+    return data.tag_name.replace(/^v/, "");
   } finally {
     await guarded.release();
   }
@@ -426,13 +414,13 @@ export async function ensureTool(tool: "fd" | "rg", silent = false): Promise<str
     }
     return path;
   } catch (e) {
-    const error = e instanceof Error ? e : new Error(String(e));
-    // Silent callers surface the failure through their tool result instead of
-    // replacing actionable release/download corruption with a generic message.
-    if (silent) {
-      throw error;
+    if (!silent) {
+      console.log(
+        chalk.yellow(
+          `Failed to download ${config.name}: ${e instanceof Error ? e.message : String(e)}`,
+        ),
+      );
     }
-    console.log(chalk.yellow(`Failed to download ${config.name}: ${error.message}`));
     return undefined;
   }
 }

--- a/src/agents/utils/tools-manager.ts
+++ b/src/agents/utils/tools-manager.ts
@@ -19,6 +19,7 @@ import { join } from "node:path";
 import { Readable, Transform } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import type { ReadableStream as NodeReadableStream } from "node:stream/web";
+import { readResponseWithLimit } from "@openclaw/media-core/read-response-with-limit";
 import chalk from "chalk";
 import { extractArchive } from "../../infra/archive.js";
 import { fetchWithSsrFGuard } from "../../infra/net/fetch-guard.js";
@@ -32,6 +33,7 @@ const MAX_EXTRACTED_BYTES = 500 * 1024 * 1024;
 const MAX_ARCHIVE_ENTRIES = 1_000;
 const ARCHIVE_EXTRACT_TIMEOUT_MS = 60_000;
 const CONTENT_LENGTH_RE = /^\d+$/;
+const GITHUB_RELEASE_JSON_MAX_BYTES = 1024 * 1024;
 
 async function cancelUnreadResponseBody(response: Response): Promise<void> {
   if (!response.bodyUsed) {
@@ -160,8 +162,22 @@ async function getLatestVersion(repo: string): Promise<string> {
       throw new Error(`GitHub API error: ${response.status}`);
     }
 
-    const data = (await response.json()) as { tag_name: string };
-    return data.tag_name.replace(/^v/, "");
+    const bytes = await readResponseWithLimit(response, GITHUB_RELEASE_JSON_MAX_BYTES, {
+      onOverflow: ({ size, maxBytes }) =>
+        new Error(`GitHub release response exceeds ${maxBytes} bytes (got ${size})`),
+    });
+    let data: unknown;
+    try {
+      data = JSON.parse(bytes.toString("utf8")) as unknown;
+    } catch (cause) {
+      throw new Error("GitHub release response is malformed JSON", { cause });
+    }
+    const tagName =
+      data && typeof data === "object" && "tag_name" in data ? data.tag_name : undefined;
+    if (typeof tagName !== "string" || !tagName.trim()) {
+      throw new Error("GitHub release response has no valid tag_name");
+    }
+    return tagName.replace(/^v/, "");
   } finally {
     await guarded.release();
   }
@@ -410,13 +426,13 @@ export async function ensureTool(tool: "fd" | "rg", silent = false): Promise<str
     }
     return path;
   } catch (e) {
-    if (!silent) {
-      console.log(
-        chalk.yellow(
-          `Failed to download ${config.name}: ${e instanceof Error ? e.message : String(e)}`,
-        ),
-      );
+    const error = e instanceof Error ? e : new Error(String(e));
+    // Silent callers surface the failure through their tool result instead of
+    // replacing actionable release/download corruption with a generic message.
+    if (silent) {
+      throw error;
     }
+    console.log(chalk.yellow(`Failed to download ${config.name}: ${error.message}`));
     return undefined;
   }
 }


### PR DESCRIPTION
## What Problem This Solves

The agent helper-tool fallback for `fd` and `ripgrep` read GitHub's latest-release response with `Response.json()`. That consumes the complete remote body before parsing it, so a faulty or compromised response could grow agent memory without a bound.

The affected path is `ensureTool`, reached by the agent `find` and `grep` tools when no suitable local binary is available.

## Why This Change Was Made

The maintainer rewrite uses the existing `readProviderJsonResponse` bounded JSON reader with an owner-local 1 MiB cap. It keeps the current error, logging, silent-mode, and download behavior unchanged. An oversized streaming response is canceled before its full body is consumed, and the guarded response is still released by the existing `finally` block.

The two current public GitHub responses checked during review were about 37 KiB and 51 KiB, leaving ample headroom. A `Content-Length` check alone would not protect chunked responses.

## User Impact

Oversized release metadata can no longer be buffered without limit. Normal release lookup and fallback behavior is unchanged. No public API, configuration, schema, UI, or documentation surface changes.

## Evidence

Exact candidate: `58c5e33e4970593ce5547d36eaf31a3e1f962162`

- Focused proof: `node scripts/run-vitest.mjs src/agents/utils/tools-manager.test.ts` — 1 file, 9 tests passed.
- Streaming regression: oversized chunked metadata stops before all chunks are read, cancels the body, releases the guarded response once, and preserves silent fallback behavior.
- Live public API proof: latest-release responses for `sharkdp/fd` and `BurntSushi/ripgrep` returned 200 with valid `tag_name` values at 36,756 and 51,002 bytes.
- Fresh branch autoreview: no accepted/actionable findings.
- No `CHANGELOG.md` edit.

Original report and starting patch by @sheyanmin. Maintainer rewrite preserves contributor credit.

<details>
<summary>Security and Privacy</summary>

- Removes an unbounded read from an external response.
- Keeps the existing SSRF/guarded-fetch boundary.
- Logs no response content and adds no persistence or dependency.
- Stream cancellation and response release are covered.

</details>

---

AI-assisted. The original proposal was authored with Claude Code. The maintainer rewrite, deep review, tests, and verification were performed with OpenAI Codex and the repository autoreview workflow.
