### PR TITLE
fix: require explicit inline status requests

### DIFF
--- a/src/auto-reply/reply/get-reply-directives.target-session.test.ts
+++ b/src/auto-reply/reply/get-reply-directives.target-session.test.ts
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   applyInlineDirectiveOverrides: vi.fn(),
   resolveFastModeState: vi.fn(),
   resolveReplyExecOverrides: vi.fn(),
+  shouldHandleTextCommands: vi.fn(),
 }));
 
 function makeSessionEntry(overrides: Partial<SessionEntry> = {}): SessionEntry {
@@ -33,8 +34,41 @@ function makeTypingController() {
   };
 }
 
-function parseInlineDirectivesForTest(body: string) {
+function parseInlineDirectivesForTest(
+  body: string,
+  options?: { allowStatusDirective?: boolean },
+) {
   const normalized = body.trim();
+  if (options?.allowStatusDirective !== false && /(?:^|\s)\/status(?=$|\s|:)/i.test(body)) {
+    const cleaned = body
+      .replace(/(?:^|\s)\/status(?=$|\s|:)(?:\s*:\s*)?/i, " ")
+      .replace(/\s+/g, " ")
+      .trim();
+    return {
+      cleaned,
+      hasThinkDirective: false,
+      hasVerboseDirective: false,
+      hasTraceDirective: false,
+      traceLevel: undefined,
+      rawTraceLevel: undefined,
+      hasFastDirective: false,
+      hasReasoningDirective: false,
+      hasElevatedDirective: false,
+      hasExecDirective: false,
+      hasModelDirective: false,
+      hasQueueDirective: false,
+      hasStatusDirective: true,
+      queueReset: false,
+      thinkLevel: undefined,
+      verboseLevel: undefined,
+      fastMode: undefined,
+      reasoningLevel: undefined,
+      elevatedLevel: undefined,
+      rawElevatedLevel: undefined,
+      rawModelDirective: undefined,
+      execSecurity: undefined,
+    };
+  }
   if (normalized === "/reasoning stream") {
     return {
       cleaned: "",
@@ -152,6 +186,7 @@ async function resolveHelloWithModelDefaults(params: {
   provider?: string;
   model?: string;
   ctx?: Parameters<typeof buildTestCtx>[0];
+  isGroup?: boolean;
   opts?: Parameters<typeof resolveReplyDirectives>[0]["opts"];
 }) {
   const resolveDefaultThinkingLevel = vi.fn(async () => params.defaultThinking);
@@ -190,7 +225,7 @@ async function resolveHelloWithModelDefaults(params: {
     storePath: "/tmp/sessions.json",
     sessionScope: "per-sender",
     groupResolution: undefined,
-    isGroup: false,
+    isGroup: params.isGroup ?? false,
     triggerBodyNormalized: "hello",
     resetTriggered: false,
     commandAuthorized: params.commandAuthorized ?? false,
@@ -211,6 +246,7 @@ async function resolveHelloWithModelDefaults(params: {
 
 vi.mock("../../agents/agent-scope.js", () => ({
   listAgentEntries: vi.fn(() => []),
+  resolveAgentConfig: vi.fn(() => ({})),
 }));
 
 vi.mock("../../agents/defaults.js", () => ({
@@ -230,7 +266,7 @@ vi.mock("../../routing/session-key.js", () => ({
 }));
 
 vi.mock("../commands-text-routing.js", () => ({
-  shouldHandleTextCommands: vi.fn(() => false),
+  shouldHandleTextCommands: (...args: unknown[]) => mocks.shouldHandleTextCommands(...args),
 }));
 
 vi.mock("./commands-context.js", () => ({
@@ -298,7 +334,9 @@ describe("resolveReplyDirectives", () => {
     mocks.applyInlineDirectiveOverrides.mockReset();
     mocks.resolveFastModeState.mockReset();
     mocks.resolveReplyExecOverrides.mockReset();
+    mocks.shouldHandleTextCommands.mockReset();
 
+    mocks.shouldHandleTextCommands.mockReturnValue(false);
     mocks.createModelSelectionState.mockResolvedValue({
       provider: "openai",
       model: "gpt-4o-mini",
@@ -526,6 +564,60 @@ describe("resolveReplyDirectives", () => {
       reply: {
         text: "⚙️ Trace enabled. Warning: trace output may contain sensitive information.",
       },
+    });
+  });
+
+  it("does not treat quoted status text as an inline status request", async () => {
+    mocks.shouldHandleTextCommands.mockReturnValue(true);
+    const body = "请忽略上一条 /status 的内部状态细节，只回复：fresh-turn-ok";
+
+    const { result } = await resolveHelloWithModelDefaults({
+      body,
+      commandAuthorized: true,
+      defaultThinking: "off",
+      defaultReasoning: "on",
+    });
+
+    expectContinueResult(result, {
+      cleanedBody: body,
+      inlineStatusRequested: false,
+    });
+  });
+
+  it("keeps leading status text as an inline status request", async () => {
+    mocks.shouldHandleTextCommands.mockReturnValue(true);
+
+    const { result } = await resolveHelloWithModelDefaults({
+      body: "/status what's next?",
+      commandAuthorized: true,
+      defaultThinking: "off",
+      defaultReasoning: "on",
+    });
+
+    expectContinueResult(result, {
+      cleanedBody: "what's next?",
+      inlineStatusRequested: true,
+    });
+  });
+
+  it("allows mention-prefixed group status text as an inline status request", async () => {
+    mocks.shouldHandleTextCommands.mockReturnValue(true);
+
+    const { result } = await resolveHelloWithModelDefaults({
+      body: "@12345 /status what's next?",
+      commandAuthorized: true,
+      defaultThinking: "off",
+      defaultReasoning: "on",
+      ctx: {
+        ChatType: "channel",
+        WasMentioned: true,
+      },
+      isGroup: true,
+    });
+
+    expectContinueResult(result, {
+      cleanedBody: "@12345 what's next?",
+      inlineStatusRequested: true,
     });
   });
 

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -43,7 +43,7 @@ import {
   resolveContextTokens,
 } from "./model-selection.js";
 import { formatElevatedUnavailableMessage, resolveElevatedPermissions } from "./reply-elevated.js";
-import { stripInlineStatus } from "./reply-inline.js";
+import { isExplicitInlineStatusRequest, stripInlineStatus } from "./reply-inline.js";
 import { resolveRuntimePolicySessionKey } from "./runtime-policy-session-key.js";
 import type { TypingController } from "./typing.js";
 
@@ -104,6 +104,20 @@ function resolveDirectiveCommandText(params: { ctx: MsgContext; sessionCtx: Temp
     promptSource,
     commandText: commandSource || promptSource,
   };
+}
+
+function isExplicitStatusDirectiveText(params: {
+  commandText: string;
+  isGroup: boolean;
+  ctx: MsgContext;
+  cfg: OpenClawConfig;
+  agentId: string;
+}): boolean {
+  const stripped = stripStructuralPrefixes(params.commandText);
+  const commandText = params.isGroup
+    ? stripMentions(stripped, params.ctx, params.cfg, params.agentId)
+    : stripped;
+  return isExplicitInlineStatusRequest(commandText);
 }
 
 type ReplyDirectiveContinuation = {
@@ -283,7 +297,16 @@ export async function resolveReplyDirectives(params: {
   const configuredAliases = rawAliases.filter(
     (alias) => !reservedCommands.has(normalizeLowercaseStringOrEmpty(alias)),
   );
-  const allowStatusDirective = allowTextCommands && command.isAuthorizedSender;
+  const allowStatusDirective =
+    allowTextCommands &&
+    command.isAuthorizedSender &&
+    isExplicitStatusDirectiveText({
+      commandText,
+      isGroup,
+      ctx,
+      cfg,
+      agentId,
+    });
   let parsedDirectives = parseInlineDirectives(commandText, {
     modelAliases: configuredAliases,
     allowStatusDirective,

--- a/src/auto-reply/reply/reply-inline.test.ts
+++ b/src/auto-reply/reply/reply-inline.test.ts
@@ -1,6 +1,10 @@
 // Tests inline reply directive parsing and whitespace-preserving behavior.
 import { describe, expect, it } from "vitest";
-import { extractInlineSimpleCommand, stripInlineStatus } from "./reply-inline.js";
+import {
+  extractInlineSimpleCommand,
+  isExplicitInlineStatusRequest,
+  stripInlineStatus,
+} from "./reply-inline.js";
 
 describe("stripInlineStatus", () => {
   it("strips /status directive from message", () => {
@@ -32,6 +36,19 @@ describe("stripInlineStatus", () => {
     const result = stripInlineStatus("   ");
     expect(result.cleaned).toBe("");
     expect(result.didStrip).toBe(false);
+  });
+});
+
+describe("isExplicitInlineStatusRequest", () => {
+  it("accepts leading inline status directives", () => {
+    expect(isExplicitInlineStatusRequest("/status")).toBe(true);
+    expect(isExplicitInlineStatusRequest(" /status what changed?")).toBe(true);
+    expect(isExplicitInlineStatusRequest("/status: what changed?")).toBe(true);
+  });
+
+  it("rejects quoted or discussed status commands", () => {
+    expect(isExplicitInlineStatusRequest("please ignore /status and answer normally")).toBe(false);
+    expect(isExplicitInlineStatusRequest("The command `/status` shows runtime state.")).toBe(false);
   });
 });
 

--- a/src/auto-reply/reply/reply-inline.ts
+++ b/src/auto-reply/reply/reply-inline.ts
@@ -11,6 +11,7 @@ const INLINE_SIMPLE_COMMAND_ALIASES = new Map<string, string>([
 const INLINE_SIMPLE_COMMAND_RE = /(?:^|\s)\/(help|commands|whoami|id)(?=$|\s|:)/i;
 
 const INLINE_STATUS_RE = /(?:^|\s)\/status(?=$|\s|:)(?:\s*:\s*)?/gi;
+const LEADING_INLINE_STATUS_RE = /^\/status(?=$|\s|:)(?:\s*:\s*)?/i;
 
 export function extractInlineSimpleCommand(body?: string): {
   command: string;
@@ -44,4 +45,8 @@ export function stripInlineStatus(body: string): {
   // preserving newlines so multi-line messages keep their paragraph structure.
   const cleaned = collapseInlineHorizontalWhitespace(trimmed.replace(INLINE_STATUS_RE, " ")).trim();
   return { cleaned, didStrip: cleaned !== trimmed };
+}
+
+export function isExplicitInlineStatusRequest(body: string): boolean {
+  return LEADING_INLINE_STATUS_RE.test(body.trimStart());
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users who mention `/status` inside a normal message can accidentally trigger a status reply instead of getting an answer to the current prompt. This happens when a user quotes, discusses, or asks the assistant to ignore a previous `/status` command and includes more text in the same message.

## Why This Change Was Made

Inline status now requires an explicit leading `/status` directive after structural prefixes and group mentions are stripped. Normal prose that merely contains `/status` remains regular prompt text, while direct `/status`, `/status: ...`, and mention-prefixed group status turns still work.

## User Impact

Users can safely refer to `/status` in ordinary chat without losing the turn to a status card. Operators still keep the intentional inline status shortcut for direct status checks.

AI-assisted: yes.

## Evidence

- `node scripts/run-vitest.mjs src/auto-reply/reply/reply-inline.test.ts src/auto-reply/reply/get-reply-directives.target-session.test.ts`
- `git diff --check`
