### PR TITLE
fix: Android QR scan starts gateway pairing

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
@@ -182,6 +182,36 @@ fun OnboardingFlow(
 
     val permissionState = rememberPermissionState(context = context, viewModel = viewModel)
 
+    fun connectToGatewayConfig(
+      config: GatewayConnectConfig,
+      resetSetupAuth: Boolean,
+    ) {
+      setupError = null
+      attemptedGatewayName = null
+      attemptedConnect = true
+      connectAttemptStartedAtMs = SystemClock.elapsedRealtime()
+      viewModel.saveGatewayConfigAndConnect(
+        host = config.host,
+        port = config.port,
+        tls = config.tls,
+        token = config.token,
+        bootstrapToken = config.bootstrapToken,
+        password = config.password,
+        resetSetupAuth = resetSetupAuth,
+      )
+      step = OnboardingStep.Recovery
+    }
+
+    fun resolveCurrentGatewayConfig(setupCodeValue: String = setupCode): GatewayConnectConfig? =
+      resolveOnboardingGatewayConnectConfig(
+        setupCode = setupCodeValue,
+        manualHost = manualHost,
+        manualPort = manualPort,
+        manualTls = manualTls,
+        token = token,
+        password = password,
+      )
+
     LaunchedEffect(startAtGatewaySetup) {
       if (startAtGatewaySetup) {
         step = OnboardingStep.Gateway
@@ -261,15 +291,26 @@ fun OnboardingFlow(
               .startScan()
               .addOnSuccessListener { barcode ->
                 val scanned = resolveScannedSetupCodeResult(barcode.rawValue.orEmpty())
-                if (scanned.setupCode == null) {
+                val scannedSetupCode = scanned.setupCode
+                if (scannedSetupCode == null) {
                   setupError =
                     gatewayEndpointValidationMessage(
                       scanned.error ?: GatewayEndpointValidationError.INVALID_URL,
                       GatewayEndpointInputSource.QR_SCAN,
+                  )
+                  return@addOnSuccessListener
+                }
+                val config = resolveCurrentGatewayConfig(setupCodeValue = scannedSetupCode)
+                if (config == null) {
+                  setupError =
+                    gatewayEndpointValidationMessage(
+                      GatewayEndpointValidationError.INVALID_URL,
+                      GatewayEndpointInputSource.QR_SCAN,
                     )
                   return@addOnSuccessListener
                 }
-                setupCode = scanned.setupCode
+                setupCode = scannedSetupCode
+                connectToGatewayConfig(config, resetSetupAuth = true)
               }.addOnFailureListener { setupError = "Could not open the scanner." }
           },
           onSetupCodeChange = {
@@ -296,34 +337,12 @@ fun OnboardingFlow(
             step = OnboardingStep.Recovery
           },
           onPair = {
-            val config =
-              resolveGatewayConfig(
-                setupCode = setupCode,
-                manualHost = manualHost,
-                manualPort = manualPort,
-                manualTls = manualTls,
-                token = token,
-                password = password,
-              )
+            val config = resolveCurrentGatewayConfig()
             if (config == null) {
               setupError = "Enter a setup code or a valid gateway URL."
               return@GatewaySetupScreen
             }
-
-            setupError = null
-            attemptedGatewayName = null
-            attemptedConnect = true
-            connectAttemptStartedAtMs = SystemClock.elapsedRealtime()
-            viewModel.saveGatewayConfigAndConnect(
-              host = config.host,
-              port = config.port,
-              tls = config.tls,
-              token = config.token,
-              bootstrapToken = config.bootstrapToken,
-              password = config.password,
-              resetSetupAuth = true,
-            )
-            step = OnboardingStep.Recovery
+            connectToGatewayConfig(config, resetSetupAuth = true)
           },
         )
       OnboardingStep.Recovery ->
@@ -339,26 +358,8 @@ fun OnboardingFlow(
           connectSettling = recoveryNowMs - connectAttemptStartedAtMs < GATEWAY_CONNECT_SETTLING_MS,
           onBack = { step = OnboardingStep.Gateway },
           onRetry = {
-            attemptedConnect = true
-            connectAttemptStartedAtMs = SystemClock.elapsedRealtime()
-            val config =
-              resolveGatewayConfig(
-                setupCode = setupCode,
-                manualHost = manualHost,
-                manualPort = manualPort,
-                manualTls = manualTls,
-                token = token,
-                password = password,
-              ) ?: return@GatewayRecoveryScreen
-            viewModel.saveGatewayConfigAndConnect(
-              host = config.host,
-              port = config.port,
-              tls = config.tls,
-              token = config.token,
-              bootstrapToken = config.bootstrapToken,
-              password = config.password,
-              resetSetupAuth = false,
-            )
+            val config = resolveCurrentGatewayConfig() ?: return@GatewayRecoveryScreen
+            connectToGatewayConfig(config, resetSetupAuth = false)
           },
           onEdit = { step = OnboardingStep.Gateway },
           onContinue = { step = OnboardingStep.Permissions },
@@ -1151,59 +1152,28 @@ internal fun recoveryGatewayName(
       ?.takeIf { it.isNotEmpty() }
     ?: "Home Gateway"
 
-private data class GatewayConfig(
-  val host: String,
-  val port: Int,
-  val tls: Boolean,
-  val bootstrapToken: String,
-  val token: String,
-  val password: String,
-)
-
-/** Resolves setup-code or manual fields into the gateway config used for first connect. */
-private fun resolveGatewayConfig(
+/** Resolves onboarding setup-code or manual fields into the gateway config used for connect. */
+internal fun resolveOnboardingGatewayConnectConfig(
   setupCode: String,
   manualHost: String,
   manualPort: String,
   manualTls: Boolean,
   token: String,
   password: String,
-): GatewayConfig? {
-  val setup = setupCode.takeIf { it.isNotBlank() }?.let(::decodeGatewaySetupCode)
-  if (setup != null) {
-    val endpoint = parseGatewayEndpointResult(setup.url).config ?: return null
-    val bootstrapToken = setup.bootstrapToken?.trim().orEmpty()
-    // Bootstrap setup codes own first-pairing auth; fall back to typed token or
-    // password only for non-bootstrap setup payloads.
-    return GatewayConfig(
-      host = endpoint.host,
-      port = endpoint.port,
-      tls = endpoint.tls,
-      bootstrapToken = bootstrapToken,
-      token =
-        setup.token
-          ?.trim()
-          .orEmpty()
-          .ifEmpty { if (bootstrapToken.isEmpty()) token.trim() else "" },
-      password =
-        setup.password
-          ?.trim()
-          .orEmpty()
-          .ifEmpty { if (bootstrapToken.isEmpty()) password.trim() else "" },
-    )
-  }
-
-  val manualUrl = composeGatewayManualUrl(manualHost, manualPort, manualTls) ?: return null
-  val endpoint = parseGatewayEndpointResult(manualUrl).config ?: return null
-  return GatewayConfig(
-    host = endpoint.host,
-    port = endpoint.port,
-    tls = endpoint.tls,
-    bootstrapToken = "",
-    token = token.trim(),
-    password = password.trim(),
+): GatewayConnectConfig? =
+  resolveGatewayConnectConfig(
+    useSetupCode = setupCode.isNotBlank(),
+    setupCode = setupCode,
+    savedManualHost = manualHost,
+    savedManualPort = manualPort,
+    savedManualTls = manualTls,
+    manualHostInput = manualHost,
+    manualPortInput = manualPort,
+    manualTlsInput = manualTls,
+    fallbackBootstrapToken = "",
+    fallbackToken = token,
+    fallbackPassword = password,
   )
-}
 
 /** Selects the recovery detail line from endpoint metadata and transient gateway status. */
 internal fun recoveryGatewayDetail(

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/OnboardingFlowLogicTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/OnboardingFlowLogicTest.kt
@@ -7,8 +7,10 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.util.Base64
 
 class OnboardingFlowLogicTest {
   @Test
@@ -432,4 +434,51 @@ class OnboardingFlowLogicTest {
       ),
     )
   }
+
+  @Test
+  fun resolvesOnboardingSetupCodeConnectConfigForScannedQr() {
+    val setupCode =
+      encodeSetupCode("""{"url":"ws://10.0.2.2:18789","bootstrapToken":"bootstrap-1"}""")
+    val scanned = resolveScannedSetupCodeResult(setupCode)
+
+    val resolved =
+      resolveOnboardingGatewayConnectConfig(
+        setupCode = requireNotNull(scanned.setupCode),
+        manualHost = "127.0.0.1",
+        manualPort = "18789",
+        manualTls = false,
+        token = "stale-shared-token",
+        password = "stale-shared-password",
+      )
+
+    assertEquals("10.0.2.2", resolved?.host)
+    assertEquals(18789, resolved?.port)
+    assertEquals(false, resolved?.tls)
+    assertEquals("bootstrap-1", resolved?.bootstrapToken)
+    assertEquals("", resolved?.token)
+    assertEquals("", resolved?.password)
+    assertNull(scanned.error)
+  }
+
+  @Test
+  fun resolvesOnboardingManualConnectConfigWhenSetupCodeIsBlank() {
+    val resolved =
+      resolveOnboardingGatewayConnectConfig(
+        setupCode = "",
+        manualHost = "127.0.0.1",
+        manualPort = "18789",
+        manualTls = false,
+        token = "shared-token",
+        password = "shared-password",
+      )
+
+    assertEquals("127.0.0.1", resolved?.host)
+    assertEquals(18789, resolved?.port)
+    assertEquals(false, resolved?.tls)
+    assertEquals("", resolved?.bootstrapToken)
+    assertEquals("shared-token", resolved?.token)
+    assertEquals("shared-password", resolved?.password)
+  }
+
+  private fun encodeSetupCode(payloadJson: String): String = Base64.getUrlEncoder().withoutPadding().encodeToString(payloadJson.toByteArray(Charsets.UTF_8))
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Android users scanning a valid Gateway setup QR code would return to Gateway Setup without starting the pairing connection.

The scanner accepted the QR code, but the app only copied the setup code into local UI state. Users then had to know to press Pair manually, so a successful scan appeared to do nothing.

## Why This Change Was Made

The scanner success path now resolves the scanned setup code into the same gateway connection config used by the Pair action, then starts the normal setup-auth connection flow and moves to Gateway Recovery. Onboarding now delegates setup/manual config resolution to the shared Android gateway config resolver instead of keeping a duplicate private resolver.

## User Impact

Android QR setup behaves like users expect: scanning a valid setup QR immediately starts gateway pairing and shows the recovery/approval state instead of silently staying on setup.

## Evidence

- Focused Android tests passed:
  - `./gradlew testPlayDebugUnitTest --tests ai.openclaw.app.ui.OnboardingFlowLogicTest --tests ai.openclaw.app.ui.GatewayConfigResolverTest --tests ai.openclaw.app.gateway.GatewaySessionInvokeTest --console=plain`
- Pre-commit autoreview passed clean:
  - `.agents/skills/autoreview/scripts/autoreview --mode local`
- Live E2E proof after commit:
  - Installed committed Play debug APK into a Play-enabled Android emulator.
  - Started an isolated live OpenClaw gateway.
  - Scanned a real setup QR with Google Code Scanner.
  - App returned to `Gateway Recovery` with `Node Approval Pending` instead of remaining on `Gateway Setup`.
  - Gateway logs showed Android node connect with `auth=bootstrap-token`, followed by Android UI connect with `auth=device-token`.

AI-assisted: yes. I understand the code change and verified the user-facing QR pairing path live.
