### PR TITLE
fix: support Claude Sonnet 5 adaptive thinking requests

### DIFF
--- a/packages/llm-core/src/model-contracts/anthropic.ts
+++ b/packages/llm-core/src/model-contracts/anthropic.ts
@@ -54,7 +54,7 @@ export function resolveClaudeFable5ModelIdentity(ref: ClaudeModelRef): string | 
 /** Return whether a Claude model supports adaptive thinking. */
 export function supportsClaudeAdaptiveThinking(ref: ClaudeModelRef): boolean {
   const modelId = resolveClaudeModelIdentity(ref);
-  return /(?:^|-)claude-(?:fable-5|mythos-preview|opus-4-(?:6|7|8)|sonnet-4-6)(?=$|[^a-z0-9])/.test(
+  return /(?:^|-)claude-(?:fable-5|mythos-preview|opus-4-(?:6|7|8)|sonnet-(?:5|4-6))(?=$|[^a-z0-9])/.test(
     modelId,
   );
 }
@@ -62,13 +62,13 @@ export function supportsClaudeAdaptiveThinking(ref: ClaudeModelRef): boolean {
 /** Return whether a Claude model supports native max effort. */
 export function supportsClaudeNativeMaxEffort(ref: ClaudeModelRef): boolean {
   const modelId = resolveClaudeModelIdentity(ref);
-  return /(?:^|-)claude-(?:fable-5|opus-4-(?:6|7|8)|sonnet-4-6)(?=$|[^a-z0-9])/.test(modelId);
+  return /(?:^|-)claude-(?:fable-5|opus-4-(?:6|7|8)|sonnet-(?:5|4-6))(?=$|[^a-z0-9])/.test(modelId);
 }
 
 /** Return whether a Claude model supports native xhigh effort. */
 export function supportsClaudeNativeXhighEffort(ref: ClaudeModelRef): boolean {
   const modelId = resolveClaudeModelIdentity(ref);
-  return /(?:^|-)claude-(?:fable-5|opus-4-(?:7|8))(?=$|[^a-z0-9])/.test(modelId);
+  return /(?:^|-)claude-(?:fable-5|opus-4-(?:7|8)|sonnet-5)(?=$|[^a-z0-9])/.test(modelId);
 }
 
 /**

--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -517,6 +517,134 @@ describe("anthropic transport stream", () => {
     });
   });
 
+  it("uses adaptive thinking without legacy fields for Claude Sonnet 5 defaults", async () => {
+    const model = makeAnthropicTransportModel({
+      id: "claude-sonnet-5",
+      name: "Claude Sonnet 5",
+      maxTokens: 128000,
+    });
+
+    await runTransportStream(
+      model,
+      {
+        messages: [{ role: "user", content: "hello" }],
+      } as AnthropicStreamContext,
+      {
+        apiKey: "test-api-key",
+        temperature: 0.2,
+        onPayload: (params) => ({
+          ...(params as Record<string, unknown>),
+          top_p: 0.9,
+          top_k: 40,
+          service_tier: "auto",
+        }),
+      } as AnthropicStreamOptions,
+    );
+
+    const payload = latestAnthropicRequest().payload;
+    expect(payload.thinking).toEqual({ type: "adaptive", display: "summarized" });
+    expect(payload).not.toHaveProperty("output_config");
+    expect(payload).not.toHaveProperty("temperature");
+    expect(payload).not.toHaveProperty("top_p");
+    expect(payload).not.toHaveProperty("top_k");
+    expect(payload).not.toHaveProperty("service_tier");
+  });
+
+  it("maps Claude Sonnet 5 low thinking to adaptive effort", async () => {
+    await runTransportStream(
+      makeAnthropicTransportModel({
+        id: "claude-sonnet-5",
+        name: "Claude Sonnet 5",
+        maxTokens: 128000,
+      }),
+      {
+        messages: [{ role: "user", content: "hello" }],
+      } as AnthropicStreamContext,
+      {
+        apiKey: "test-api-key",
+        reasoning: "low",
+      } as AnthropicStreamOptions,
+    );
+
+    const payload = latestAnthropicRequest().payload;
+    expect(payload.thinking).toEqual({ type: "adaptive", display: "summarized" });
+    expect(payload.output_config).toEqual({ effort: "low" });
+  });
+
+  it("preserves explicit adaptive thinking without forcing effort", async () => {
+    await runTransportStream(
+      makeAnthropicTransportModel({
+        id: "claude-sonnet-4-6",
+        name: "Claude Sonnet 4.6",
+        maxTokens: 64000,
+      }),
+      {
+        messages: [{ role: "user", content: "hello" }],
+      } as AnthropicStreamContext,
+      {
+        apiKey: "test-api-key",
+        reasoning: "adaptive",
+      } as unknown as AnthropicStreamOptions,
+    );
+
+    const payload = latestAnthropicRequest().payload;
+    expect(payload.thinking).toEqual({ type: "adaptive", display: "summarized" });
+    expect(payload).not.toHaveProperty("output_config");
+  });
+
+  it("can disable thinking for Claude Sonnet 5", async () => {
+    await runTransportStream(
+      makeAnthropicTransportModel({
+        id: "claude-sonnet-5",
+        name: "Claude Sonnet 5",
+        maxTokens: 128000,
+      }),
+      {
+        messages: [{ role: "user", content: "hello" }],
+      } as AnthropicStreamContext,
+      {
+        apiKey: "test-api-key",
+        reasoning: "off",
+      } as unknown as AnthropicStreamOptions,
+    );
+
+    expect(latestAnthropicRequest().payload.thinking).toEqual({ type: "disabled" });
+  });
+
+  it("preserves forced tool choice when Claude Sonnet 5 thinking is disabled", async () => {
+    await runTransportStream(
+      makeAnthropicTransportModel({
+        id: "claude-sonnet-5",
+        name: "Claude Sonnet 5",
+        maxTokens: 128000,
+      }),
+      {
+        messages: [{ role: "user", content: "Use a tool", timestamp: 0 }],
+        tools: [
+          {
+            name: "lookup",
+            description: "Lookup",
+            parameters: {
+              type: "object",
+              properties: { query: { type: "string" } },
+              required: ["query"],
+            },
+          },
+        ],
+      } as AnthropicStreamContext,
+      {
+        apiKey: "test-api-key",
+        reasoning: "off",
+        toolChoice: "any",
+      } as unknown as AnthropicStreamOptions,
+    );
+
+    expect(latestAnthropicRequest().payload).toMatchObject({
+      thinking: { type: "disabled" },
+      tool_choice: { type: "any" },
+    });
+  });
+
   it("does not add implicit Anthropic beta headers for custom compatible API-key endpoints", async () => {
     const model = makeAnthropicTransportModel({
       provider: "anthropic",
@@ -2979,6 +3107,34 @@ describe("anthropic transport stream", () => {
     const payload = latestAnthropicRequest().payload;
     expect(payload.thinking).toEqual({ type: "adaptive", display: "summarized" });
     expect(payload.output_config).toEqual({ effort: "high" });
+  });
+
+  it("keeps mandatory adaptive thinking for explicit off on canonical Claude Mythos Preview transport aliases", async () => {
+    const model = makeAnthropicTransportModel({
+      id: "prod-mythos-preview",
+      name: "Production Claude",
+      provider: "microsoft-foundry",
+      params: { canonicalModelId: "claude-mythos-preview" },
+      reasoning: false,
+      baseUrl: "https://example.services.ai.azure.com/anthropic",
+      maxTokens: 128_000,
+    });
+
+    guardedFetchMock.mockResolvedValueOnce(createSseResponse());
+    await runTransportStream(
+      model,
+      {
+        messages: [{ role: "user", content: "Think." }],
+      } as AnthropicStreamContext,
+      {
+        apiKey: "test-api-key",
+        reasoning: "off",
+      } as unknown as AnthropicStreamOptions,
+    );
+
+    const payload = latestAnthropicRequest().payload;
+    expect(payload.thinking).toEqual({ type: "adaptive", display: "summarized" });
+    expect(payload.output_config).toEqual({ effort: "low" });
   });
 
   it("maps Claude Fable 5 transport thinking levels to adaptive effort", async () => {

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -22,6 +22,7 @@ import type {
   AssistantMessageDiagnostic,
   Context,
   Model,
+  ModelThinkingLevel,
   SimpleStreamOptions,
   ThinkingLevel,
 } from "../llm/types.js";
@@ -37,6 +38,7 @@ import {
   supportsClaudeNativeMaxEffort,
   supportsClaudeNativeXhighEffort,
   usesClaudeFable5MessagesContract,
+  usesClaudeSonnet5MessagesContract,
 } from "../shared/anthropic-model-contract.js";
 import { applyAnthropicRefusal } from "../shared/anthropic-refusal.js";
 import { MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE } from "../shared/assistant-error-format.js";
@@ -102,8 +104,11 @@ type AnthropicTransportModel = Model<"anthropic-messages"> & {
   provider: string;
 };
 
+type AnthropicReasoningLevel = ModelThinkingLevel | "adaptive";
 type AnthropicTransportOptions = AnthropicOptions &
-  Pick<SimpleStreamOptions, "reasoning" | "thinkingBudgets" | "stop">;
+  Omit<Pick<SimpleStreamOptions, "reasoning" | "thinkingBudgets" | "stop">, "reasoning"> & {
+    reasoning?: AnthropicReasoningLevel;
+  };
 type AnthropicAdaptiveEffort = NonNullable<AnthropicOptions["effort"]> | "xhigh";
 type AnthropicMessagesClient = {
   messages: {
@@ -166,9 +171,11 @@ const EMPTY_ANTHROPIC_MESSAGES_FALLBACK_TEXT = ".";
 function normalizeAnthropicToolChoice(
   model: AnthropicTransportModel,
   toolChoice: NonNullable<AnthropicTransportOptions["toolChoice"]>,
+  thinkingEnabled: boolean | undefined,
 ): AnthropicProjectedToolChoice {
   if (
     requiresClaudeAdaptiveThinking(model) &&
+    !(usesClaudeSonnet5MessagesContract(model) && thinkingEnabled !== true) &&
     (toolChoice === "any" || (typeof toolChoice === "object" && toolChoice.type === "tool"))
   ) {
     return { type: "auto" as const };
@@ -185,9 +192,12 @@ function supportsAdaptiveThinking(model: AnthropicTransportModel): boolean {
 }
 
 function mapThinkingLevelToEffort(
-  level: ThinkingLevel | "off",
+  level: AnthropicReasoningLevel,
   model: AnthropicTransportModel,
-): AnthropicAdaptiveEffort {
+): AnthropicAdaptiveEffort | undefined {
+  if (level === "adaptive") {
+    return undefined;
+  }
   const thinkingLevelMap = resolveClaudeNativeThinkingLevelMap(model);
   const clampModel = {
     ...model,
@@ -217,6 +227,19 @@ function mapThinkingLevelToEffort(
 
 function clampReasoningLevel(level: ThinkingLevel): "minimal" | "low" | "medium" | "high" {
   return level === "xhigh" || level === "max" ? "high" : level;
+}
+
+function applyClaudeSonnet5RequestMigration(
+  params: Record<string, unknown>,
+  model: AnthropicTransportModel,
+): void {
+  if (!usesClaudeSonnet5MessagesContract(model)) {
+    return;
+  }
+  delete params.temperature;
+  delete params.top_p;
+  delete params.top_k;
+  delete params.service_tier;
 }
 
 function resolvePositiveAnthropicMaxTokens(value: unknown): number | undefined {
@@ -1030,7 +1053,11 @@ function buildAnthropicParams(
     params.metadata = { user_id: options.metadata.user_id };
   }
   if (options?.toolChoice) {
-    const normalizedToolChoice = normalizeAnthropicToolChoice(model, options.toolChoice);
+    const normalizedToolChoice = normalizeAnthropicToolChoice(
+      model,
+      options.toolChoice,
+      options.thinkingEnabled,
+    );
     const projectedToolChoice = toolProjection
       ? reconcileAnthropicToolChoice(normalizedToolChoice, toolProjection)
       : normalizedToolChoice;
@@ -1039,6 +1066,7 @@ function buildAnthropicParams(
     }
   }
   applyAnthropicPayloadPolicyToParams(params, payloadPolicy);
+  applyClaudeSonnet5RequestMigration(params, model);
   return { params, toolProjection };
 }
 
@@ -1077,22 +1105,29 @@ function resolveAnthropicTransportOptions(
   };
   if (!options?.reasoning) {
     resolved.thinkingEnabled = requiresClaudeAdaptiveThinking(model);
-    if (resolved.thinkingEnabled) {
+    if (resolved.thinkingEnabled && !usesClaudeSonnet5MessagesContract(model)) {
       resolved.effort = "high";
     }
     return resolved;
   }
-  if (supportsAdaptiveThinking(model)) {
-    resolved.thinkingEnabled = true;
-    resolved.effort = mapThinkingLevelToEffort(options.reasoning, model) as NonNullable<
-      AnthropicOptions["effort"]
-    >;
+  if (
+    options.reasoning === "off" &&
+    (!requiresClaudeAdaptiveThinking(model) || usesClaudeSonnet5MessagesContract(model))
+  ) {
+    resolved.thinkingEnabled = false;
     return resolved;
   }
+  if (supportsAdaptiveThinking(model)) {
+    resolved.thinkingEnabled = true;
+    resolved.effort = mapThinkingLevelToEffort(options.reasoning, model);
+    return resolved;
+  }
+  const tokenReasoningLevel: ThinkingLevel =
+    options.reasoning === "adaptive" || options.reasoning === "off" ? "high" : options.reasoning;
   const adjusted = adjustMaxTokensForThinking({
     baseMaxTokens,
     modelMaxTokens: reasoningModelMaxTokens,
-    reasoningLevel: options.reasoning,
+    reasoningLevel: tokenReasoningLevel,
     customBudgets: options.thinkingBudgets,
   });
   resolved.maxTokens = adjusted.maxTokens;
@@ -1145,6 +1180,7 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
         if (nextParams !== undefined) {
           params = nextParams as Record<string, unknown>;
         }
+        applyClaudeSonnet5RequestMigration(params, model);
         const anthropicStream = client.messages.stream(
           { ...params, stream: true },
           transportOptions.signal ? { signal: transportOptions.signal } : undefined,

--- a/src/llm/providers/anthropic.test.ts
+++ b/src/llm/providers/anthropic.test.ts
@@ -5,12 +5,14 @@ import type { Context, Model, Tool } from "../types.js";
 
 const anthropicMockState = vi.hoisted(() => ({
   configs: [] as unknown[],
+  creates: [] as unknown[],
 }));
 
 vi.mock("@anthropic-ai/sdk", () => ({
   default: class MockAnthropic {
     messages = {
-      create: vi.fn(() => {
+      create: vi.fn((params: unknown) => {
+        anthropicMockState.creates.push(params);
         throw new Error("stop after constructor");
       }),
     };
@@ -52,6 +54,7 @@ function makeAnthropicModel(overrides: Partial<Model<"anthropic-messages">> = {}
 describe("Anthropic provider", () => {
   beforeEach(() => {
     anthropicMockState.configs = [];
+    anthropicMockState.creates = [];
   });
 
   it("keeps Cloudflare AI Gateway upstream provider auth on the Anthropic API key", async () => {
@@ -216,7 +219,7 @@ describe("Anthropic provider", () => {
       {
         apiKey: "sk-ant-provider",
         client: client as never,
-        onPayload: (payload) => {
+        onPayload: (payload: unknown) => {
           capturedPayload = payload;
         },
       },
@@ -366,7 +369,7 @@ describe("Anthropic provider", () => {
       {
         apiKey: "sk-ant-provider",
         thinkingEnabled: false,
-        onPayload: (payload) => {
+        onPayload: (payload: unknown) => {
           capturedPayload = payload;
           throw new Error("stop before network");
         },
@@ -428,7 +431,7 @@ describe("Anthropic provider", () => {
       } as unknown as Context,
       {
         apiKey: "sk-ant-provider",
-        onPayload: (payload) => {
+        onPayload: (payload: unknown) => {
           capturedPayload = payload;
           throw new Error("stop before network");
         },
@@ -666,7 +669,7 @@ describe("Anthropic provider", () => {
       } as Context,
       {
         apiKey: "vertex-token",
-        onPayload: (payload) => {
+        onPayload: (payload: unknown) => {
           capturedPayload = payload;
         },
       },
@@ -696,7 +699,7 @@ describe("Anthropic provider", () => {
       {
         apiKey: "sk-ant-provider",
         reasoning,
-        onPayload: (payload) => {
+        onPayload: (payload: unknown) => {
           capturedPayload = payload;
         },
       },
@@ -767,7 +770,7 @@ describe("Anthropic provider", () => {
       {
         apiKey: "sk-ant-provider",
         temperature: 0.2,
-        onPayload: (payload) => {
+        onPayload: (payload: unknown) => {
           capturedPayload = payload;
         },
       },
@@ -780,6 +783,267 @@ describe("Anthropic provider", () => {
       output_config: { effort: "high" },
     });
     expect(capturedPayload).not.toHaveProperty("temperature");
+  });
+
+  it("uses adaptive thinking without default effort for Claude Sonnet 5", async () => {
+    let capturedPayload: unknown;
+    const stream = streamSimpleAnthropic(
+      makeAnthropicModel({
+        id: "claude-sonnet-5",
+        name: "Claude Sonnet 5",
+        maxTokens: 128_000,
+      }),
+      {
+        messages: [{ role: "user", content: "hello", timestamp: 0 }],
+      },
+      {
+        apiKey: "test-api-key",
+        onPayload: (payload) => {
+          capturedPayload = payload;
+          throw new Error("stop before network");
+        },
+      },
+    );
+
+    await stream.result();
+
+    expect(capturedPayload).toMatchObject({
+      thinking: { type: "adaptive", display: "summarized" },
+    });
+    expect(capturedPayload).not.toHaveProperty("output_config");
+  });
+
+  it("removes Anthropic service tier while removing Sonnet 5 sampling fields", async () => {
+    const stream = streamSimpleAnthropic(
+      makeAnthropicModel({
+        id: "claude-sonnet-5",
+        name: "Claude Sonnet 5",
+        maxTokens: 128_000,
+      }),
+      {
+        messages: [{ role: "user", content: "hello", timestamp: 0 }],
+      },
+      {
+        apiKey: "test-api-key",
+        temperature: 0.2,
+        onPayload: (payload) => ({
+          ...(payload as Record<string, unknown>),
+          top_p: 0.9,
+          top_k: 40,
+          service_tier: "auto",
+        }),
+      },
+    );
+
+    await stream.result();
+
+    const payload = anthropicMockState.creates[0] as Record<string, unknown>;
+    expect(payload).not.toHaveProperty("temperature");
+    expect(payload).not.toHaveProperty("top_p");
+    expect(payload).not.toHaveProperty("top_k");
+    expect(payload).not.toHaveProperty("service_tier");
+  });
+
+  it("preserves explicit adaptive reasoning without forcing effort", async () => {
+    let capturedPayload: unknown;
+    const stream = streamSimpleAnthropic(
+      makeAnthropicModel({
+        id: "claude-sonnet-4-6",
+        name: "Claude Sonnet 4.6",
+        maxTokens: 64_000,
+      }),
+      {
+        messages: [{ role: "user", content: "hello", timestamp: 0 }],
+      },
+      {
+        apiKey: "test-api-key",
+        reasoning: "adaptive",
+        onPayload: (payload: unknown) => {
+          capturedPayload = payload;
+          throw new Error("stop before network");
+        },
+      } as never,
+    );
+
+    await stream.result();
+
+    expect(capturedPayload).toMatchObject({
+      thinking: { type: "adaptive", display: "summarized" },
+    });
+    expect(capturedPayload).not.toHaveProperty("output_config");
+  });
+
+  it("can disable thinking for Claude Sonnet 5 through the direct provider", async () => {
+    let capturedPayload: unknown;
+    const stream = streamSimpleAnthropic(
+      makeAnthropicModel({
+        id: "claude-sonnet-5",
+        name: "Claude Sonnet 5",
+        maxTokens: 128_000,
+      }),
+      {
+        messages: [{ role: "user", content: "hello", timestamp: 0 }],
+      },
+      {
+        apiKey: "test-api-key",
+        reasoning: "off",
+        onPayload: (payload: unknown) => {
+          capturedPayload = payload;
+          throw new Error("stop before network");
+        },
+      } as never,
+    );
+
+    await stream.result();
+
+    expect(capturedPayload).toMatchObject({
+      thinking: { type: "disabled" },
+    });
+  });
+
+  it("preserves forced tool choice when Claude Sonnet 5 thinking is disabled", async () => {
+    let capturedPayload: unknown;
+    const stream = streamAnthropic(
+      makeAnthropicModel({
+        id: "claude-sonnet-5",
+        name: "Claude Sonnet 5",
+        maxTokens: 128_000,
+      }),
+      {
+        messages: [{ role: "user", content: "Use a tool", timestamp: 0 }],
+        tools: [
+          {
+            name: "lookup",
+            description: "Lookup",
+            parameters: {
+              type: "object",
+              properties: { query: { type: "string" } },
+              required: ["query"],
+            },
+          },
+        ],
+      },
+      {
+        apiKey: "test-api-key",
+        thinkingEnabled: false,
+        toolChoice: "any",
+        onPayload: (payload) => {
+          capturedPayload = payload;
+          throw new Error("stop before network");
+        },
+      },
+    );
+
+    await stream.result();
+
+    expect(capturedPayload).toMatchObject({
+      thinking: { type: "disabled" },
+      tool_choice: { type: "any" },
+    });
+  });
+
+  it("preserves forced tool choice when direct Claude Sonnet 5 thinking is unset", async () => {
+    let capturedPayload: unknown;
+    const stream = streamAnthropic(
+      makeAnthropicModel({
+        id: "claude-sonnet-5",
+        name: "Claude Sonnet 5",
+        maxTokens: 128_000,
+      }),
+      {
+        messages: [{ role: "user", content: "Use a tool", timestamp: 0 }],
+        tools: [
+          {
+            name: "lookup",
+            description: "Lookup",
+            parameters: {
+              type: "object",
+              properties: { query: { type: "string" } },
+              required: ["query"],
+            },
+          },
+        ],
+      },
+      {
+        apiKey: "test-api-key",
+        toolChoice: "any",
+        onPayload: (payload) => {
+          capturedPayload = payload;
+          throw new Error("stop before network");
+        },
+      },
+    );
+
+    await stream.result();
+
+    expect(capturedPayload).toMatchObject({
+      tool_choice: { type: "any" },
+    });
+  });
+
+  it("removes Claude Sonnet 5 rejected sampling fields after direct provider payload hooks", async () => {
+    let requestPayload: unknown;
+    const client = {
+      messages: {
+        create: vi.fn((params: unknown) => {
+          requestPayload = params;
+          return {
+            asResponse: () =>
+              Promise.resolve(
+                createSseResponse([
+                  {
+                    type: "message_start",
+                    message: {
+                      id: "msg_1",
+                      model: "claude-sonnet-5",
+                      usage: { input_tokens: 1, output_tokens: 0 },
+                    },
+                  },
+                  {
+                    type: "message_delta",
+                    delta: { stop_reason: "end_turn" },
+                    usage: { output_tokens: 1 },
+                  },
+                  { type: "message_stop" },
+                ]),
+              ),
+          };
+        }),
+      },
+    };
+    const stream = streamAnthropic(
+      makeAnthropicModel({
+        id: "claude-sonnet-5",
+        name: "Claude Sonnet 5",
+        maxTokens: 128_000,
+      }),
+      {
+        messages: [{ role: "user", content: "hello", timestamp: 0 }],
+      },
+      {
+        apiKey: "test-api-key",
+        client: client as never,
+        thinkingEnabled: true,
+        temperature: 0.2,
+        onPayload: (payload) => ({
+          ...(payload as Record<string, unknown>),
+          top_p: 0.9,
+          top_k: 40,
+          service_tier: "auto",
+        }),
+      },
+    );
+
+    await stream.result();
+
+    const payload = requestPayload as Record<string, unknown>;
+    expect(payload).toMatchObject({
+      thinking: { type: "adaptive", display: "summarized" },
+    });
+    expect(payload).not.toHaveProperty("temperature");
+    expect(payload).not.toHaveProperty("top_p");
+    expect(payload).not.toHaveProperty("top_k");
+    expect(payload).not.toHaveProperty("service_tier");
   });
 
   it("preserves native max effort for Claude Mythos Preview", async () => {
@@ -839,6 +1103,37 @@ describe("Anthropic provider", () => {
     expect(capturedPayload).toMatchObject({
       thinking: { type: "adaptive" },
       output_config: { effort: "high" },
+    });
+  });
+
+  it("keeps mandatory adaptive thinking for explicit off on Foundry Mythos Preview", async () => {
+    let capturedPayload: unknown;
+    const stream = streamSimpleAnthropic(
+      makeAnthropicModel({
+        id: "prod-mythos-preview",
+        name: "Production Claude",
+        provider: "microsoft-foundry",
+        params: { canonicalModelId: "claude-mythos-preview" },
+        reasoning: false,
+      }),
+      {
+        messages: [{ role: "user", content: "hello", timestamp: 0 }],
+      },
+      {
+        apiKey: "test-api-key",
+        reasoning: "off",
+        onPayload: (payload: unknown) => {
+          capturedPayload = payload;
+          throw new Error("stop before network");
+        },
+      } as never,
+    );
+
+    await stream.result();
+
+    expect(capturedPayload).toMatchObject({
+      thinking: { type: "adaptive" },
+      output_config: { effort: "low" },
     });
   });
 

--- a/src/llm/providers/anthropic.ts
+++ b/src/llm/providers/anthropic.ts
@@ -30,6 +30,7 @@ import {
   supportsClaudeNativeMaxEffort,
   supportsClaudeNativeXhighEffort,
   usesClaudeFable5MessagesContract,
+  usesClaudeSonnet5MessagesContract,
 } from "../../shared/anthropic-model-contract.js";
 import { applyAnthropicRefusal } from "../../shared/anthropic-refusal.js";
 import { createDeferredEventBuffer } from "../../shared/deferred-event-buffer.js";
@@ -203,6 +204,7 @@ function convertContentBlocks(content: readonly unknown[]):
 export type AnthropicEffort = "low" | "medium" | "high" | "xhigh" | "max";
 
 export type AnthropicThinkingDisplay = "summarized" | "omitted";
+type AnthropicReasoningLevel = SimpleStreamOptions["reasoning"] | "adaptive" | "off";
 
 const FINE_GRAINED_TOOL_STREAMING_BETA = "fine-grained-tool-streaming-2025-05-14";
 const INTERLEAVED_THINKING_BETA = "interleaved-thinking-2025-05-14";
@@ -547,6 +549,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
       if (nextParams !== undefined) {
         params = nextParams as MessageCreateParamsStreaming;
       }
+      applyClaudeSonnet5RequestMigration(params, model);
       const requestOptions = {
         ...(options?.signal ? { signal: options.signal } : {}),
         ...(options?.timeoutMs !== undefined ? { timeout: options.timeoutMs } : {}),
@@ -796,9 +799,11 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
 function normalizeAnthropicToolChoice(
   model: Model<"anthropic-messages">,
   toolChoice: NonNullable<AnthropicOptions["toolChoice"]>,
+  thinkingEnabled: boolean | undefined,
 ): AnthropicProjectedToolChoice {
   if (
     requiresClaudeAdaptiveThinking(model) &&
+    !(usesClaudeSonnet5MessagesContract(model) && thinkingEnabled !== true) &&
     (toolChoice === "any" || (typeof toolChoice === "object" && toolChoice.type === "tool"))
   ) {
     return { type: "auto" as const };
@@ -817,14 +822,31 @@ function supportsNativeXhighEffort(model: Model<"anthropic-messages">): boolean 
   return supportsClaudeNativeXhighEffort(model);
 }
 
+function applyClaudeSonnet5RequestMigration(
+  params: MessageCreateParamsStreaming,
+  model: Model<"anthropic-messages">,
+): void {
+  if (!usesClaudeSonnet5MessagesContract(model)) {
+    return;
+  }
+  const mutableParams = params as unknown as Record<string, unknown>;
+  delete params.temperature;
+  delete mutableParams.top_p;
+  delete mutableParams.top_k;
+  delete mutableParams.service_tier;
+}
+
 /**
  * Map ThinkingLevel to Anthropic effort levels for adaptive thinking.
  * Model metadata owns the provider-specific extended effort mapping.
  */
 function mapThinkingLevelToEffort(
   model: Model<"anthropic-messages">,
-  level: SimpleStreamOptions["reasoning"],
-): AnthropicEffort {
+  level: AnthropicReasoningLevel,
+): AnthropicEffort | undefined {
+  if (level === "adaptive") {
+    return undefined;
+  }
   const requestedLevel = level as ModelThinkingLevel | undefined;
   const hasCanonicalAlias = typeof model.params?.canonicalModelId === "string";
   const thinkingLevelMap = resolveClaudeNativeThinkingLevelMap(model);
@@ -870,19 +892,31 @@ export const streamSimpleAnthropic: StreamFunction<"anthropic-messages", SimpleS
   }
 
   const base = buildBaseOptions(model, options, apiKey);
-  if (!options?.reasoning) {
+  const requestedReasoning = options?.reasoning as AnthropicReasoningLevel | undefined;
+  if (!requestedReasoning) {
     const mandatoryAdaptiveThinking = requiresClaudeAdaptiveThinking(model);
     return streamAnthropic(model, context, {
       ...base,
       thinkingEnabled: mandatoryAdaptiveThinking,
-      ...(mandatoryAdaptiveThinking ? { effort: "high" as const } : {}),
+      ...(mandatoryAdaptiveThinking && !usesClaudeSonnet5MessagesContract(model)
+        ? { effort: "high" as const }
+        : {}),
+    } satisfies AnthropicOptions);
+  }
+  if (
+    requestedReasoning === "off" &&
+    (!requiresClaudeAdaptiveThinking(model) || usesClaudeSonnet5MessagesContract(model))
+  ) {
+    return streamAnthropic(model, context, {
+      ...base,
+      thinkingEnabled: false,
     } satisfies AnthropicOptions);
   }
 
   // For Opus 4.6 and Sonnet 4.6: use adaptive thinking with effort level
   // For older models: use budget-based thinking
   if (supportsAdaptiveThinking(model)) {
-    const effort = mapThinkingLevelToEffort(model, options.reasoning);
+    const effort = mapThinkingLevelToEffort(model, requestedReasoning);
     return streamAnthropic(model, context, {
       ...base,
       thinkingEnabled: true,
@@ -892,11 +926,13 @@ export const streamSimpleAnthropic: StreamFunction<"anthropic-messages", SimpleS
 
   // Undefined means the caller did not request an output cap; let the helper use the model cap.
   // Do not coerce to 0 here, or the thinking budget would become the entire max_tokens value.
+  const tokenReasoningLevel: SimpleStreamOptions["reasoning"] =
+    requestedReasoning === "off" || requestedReasoning === "adaptive" ? "high" : requestedReasoning;
   const adjusted = adjustMaxTokensForThinking(
     base.maxTokens,
     model.maxTokens,
-    options.reasoning,
-    options.thinkingBudgets,
+    tokenReasoningLevel,
+    options?.thinkingBudgets,
   );
 
   return streamAnthropic(model, context, {
@@ -1151,7 +1187,11 @@ function buildParams(
   }
 
   if (options?.toolChoice) {
-    const normalizedToolChoice = normalizeAnthropicToolChoice(model, options.toolChoice);
+    const normalizedToolChoice = normalizeAnthropicToolChoice(
+      model,
+      options.toolChoice,
+      options?.thinkingEnabled,
+    );
     const projectedToolChoice = toolProjection
       ? reconcileAnthropicToolChoice(normalizedToolChoice, toolProjection)
       : normalizedToolChoice;
@@ -1160,6 +1200,7 @@ function buildParams(
     }
   }
 
+  applyClaudeSonnet5RequestMigration(params, model);
   return { params, toolProjection };
 }
 

--- a/src/shared/anthropic-model-contract.ts
+++ b/src/shared/anthropic-model-contract.ts
@@ -1,8 +1,5 @@
 // Model-bound thinking cannot be exposed or replayed after a model switch.
-import {
-  resolveClaudeFable5ModelIdentity,
-  resolveClaudeModelIdentity,
-} from "@openclaw/llm-core";
+import { resolveClaudeFable5ModelIdentity, resolveClaudeModelIdentity } from "@openclaw/llm-core";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 export {
   resolveClaudeFable5ModelIdentity,
@@ -52,6 +49,18 @@ export function usesClaudeFable5MessagesContract(model: {
   );
 }
 
+export function usesClaudeSonnet5MessagesContract(model: {
+  id?: string;
+  params?: Record<string, unknown>;
+  api?: string;
+}): boolean {
+  if (normalizeApi(model.api) !== "anthropic-messages") {
+    return false;
+  }
+  const modelId = resolveClaudeModelIdentity(model);
+  return /(?:^|-)claude-sonnet-5(?=$|[^a-z0-9])/.test(modelId);
+}
+
 export function requiresClaudeAdaptiveThinking(model: {
   id?: string;
   params?: Record<string, unknown>;
@@ -63,6 +72,7 @@ export function requiresClaudeAdaptiveThinking(model: {
   const modelId = resolveClaudeModelIdentity(model);
   return (
     resolveClaudeFable5ModelIdentity(model) !== undefined ||
+    usesClaudeSonnet5MessagesContract(model) ||
     /(?:^|-)claude-mythos-preview(?=$|[^a-z0-9])/.test(modelId)
   );
 }


### PR DESCRIPTION
Closes #98386
Related: #98254

## What Problem This Solves

Claude Sonnet 5 uses Anthropic adaptive thinking semantics. Requests that still look like older manual-thinking payloads, or that include non-default sampling / priority service-tier fields, can fail against the Anthropic API.

This PR keeps the fix scoped to Anthropic-family request paths so OpenClaw can send Claude Sonnet 5 requests with the provider contract Sonnet 5 expects.

## Why This Change Was Made

- Sonnet 5 default and explicit `adaptive` thinking send native adaptive thinking without forcing `output_config.effort`.
- Explicit `low` and other effort levels send adaptive thinking with the requested Anthropic effort.
- Explicit `off` disables thinking for Sonnet 5 where the Anthropic API allows it.
- Sonnet 5 migrated requests strip `temperature`, `top_p`, `top_k`, and `service_tier` after payload hooks.
- The public SDK/session/simple-provider reasoning surface is not widened in this PR; non-Anthropic providers are intentionally left out unless they document the same API shape.

## User Impact

Users can configure Claude Sonnet 5 through the existing OpenClaw thinking controls:

- no explicit setting: Sonnet 5 uses Anthropic adaptive thinking by default
- `adaptive`: sends Anthropic adaptive thinking without an effort override
- `low`: sends Anthropic adaptive thinking with low effort
- `off`: disables Sonnet 5 thinking instead of forcing it back on

## Scope

Current diff is intentionally narrow:

- `packages/llm-core/src/model-contracts/anthropic.ts`
- `src/shared/anthropic-model-contract.ts`
- `src/llm/providers/anthropic.ts`
- `src/llm/providers/anthropic.test.ts`
- `src/agents/anthropic-transport-stream.ts`
- `src/agents/anthropic-transport-stream.test.ts`

## Evidence

- `git diff origin/main...HEAD --stat`: 6 files changed, 569 insertions, 31 deletions
- `git diff --check` passed
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-sonnet5-narrow.tsbuildinfo` passed
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test-sonnet5-narrow.tsbuildinfo` passed
- `./node_modules/.bin/vitest run --config test/vitest/vitest.unit-src.config.ts src/llm/providers/anthropic.test.ts --maxWorkers=1 --reporter=dot` passed, 45 tests
- `./node_modules/.bin/vitest run --config test/vitest/vitest.agents.config.ts src/agents/anthropic-transport-stream.test.ts --maxWorkers=1 --reporter=dot` passed, 88 tests
- Secret-pattern scan over `git diff origin/main` found only dummy test literals: `sk-ant-provider`
- GitHub PR checks passed, including `Real behavior proof`, `QA Smoke CI`, `check-lint`, `check-prod-types`, `check-test-types`, `check-guards`, `check-shrinkwrap`, and the compact shard matrix

Not run in this narrow update:

- Full pnpm test suite
- Local live Anthropic API smoke, because this local worktree has no `ANTHROPIC_API_KEY`; the GitHub `Real behavior proof` check passed

AI-assisted contribution disclosure: this patch and PR text were prepared with AI assistance and verified with the focused tests and checks listed above.
