### PR TITLE
improve(gateway): add auth token resolution regression coverage

### DIFF
--- a/src/gateway/auth-token-resolution.test.ts
+++ b/src/gateway/auth-token-resolution.test.ts
@@ -1,0 +1,124 @@
+// Focused regression coverage for gateway auth token precedence and SecretRef fallback.
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { SecretRef } from "../config/types.secrets.js";
+import { resolveGatewayAuthToken } from "./auth-token-resolution.js";
+
+function envSecretRef(id: string): SecretRef {
+  return {
+    source: "env",
+    provider: "default",
+    id,
+  };
+}
+
+function makeConfig(token?: OpenClawConfig["gateway"]["auth"]["token"]): OpenClawConfig {
+  return {
+    gateway: {
+      auth: token === undefined ? {} : { token },
+    },
+    secrets: {
+      providers: {
+        default: { source: "env" },
+      },
+    },
+  } as OpenClawConfig;
+}
+
+describe("resolveGatewayAuthToken", () => {
+  it("prefers explicitToken over config and env", async () => {
+    await expect(
+      resolveGatewayAuthToken({
+        cfg: makeConfig("config-token"),
+        env: {
+          OPENCLAW_GATEWAY_TOKEN: "env-token",
+        },
+        explicitToken: "explicit-token",
+      }),
+    ).resolves.toEqual({
+      token: "explicit-token",
+      source: "explicit",
+      secretRefConfigured: false,
+    });
+  });
+
+  it("uses plain config token when no SecretRef is configured", async () => {
+    await expect(
+      resolveGatewayAuthToken({
+        cfg: makeConfig("config-token"),
+        env: {
+          OPENCLAW_GATEWAY_TOKEN: "env-token",
+        },
+      }),
+    ).resolves.toEqual({
+      token: "config-token",
+      source: "config",
+      secretRefConfigured: false,
+    });
+  });
+
+  it("resolves an env-backed SecretRef before the fallback env token", async () => {
+    await expect(
+      resolveGatewayAuthToken({
+        cfg: makeConfig(envSecretRef("MY_GATEWAY_TOKEN")),
+        env: {
+          MY_GATEWAY_TOKEN: "secret-ref-token",
+          OPENCLAW_GATEWAY_TOKEN: "env-token",
+        },
+      }),
+    ).resolves.toEqual({
+      token: "secret-ref-token",
+      source: "secretRef",
+      secretRefConfigured: true,
+    });
+  });
+
+  it("falls back to OPENCLAW_GATEWAY_TOKEN only when envFallback=always", async () => {
+    await expect(
+      resolveGatewayAuthToken({
+        cfg: makeConfig(envSecretRef("MISSING_GATEWAY_TOKEN")),
+        env: {
+          OPENCLAW_GATEWAY_TOKEN: "env-token",
+        },
+        envFallback: "always",
+      }),
+    ).resolves.toEqual({
+      token: "env-token",
+      source: "env",
+      secretRefConfigured: true,
+    });
+  });
+
+  it("keeps an unresolved SecretRef fail-closed when envFallback=no-secret-ref", async () => {
+    const result = await resolveGatewayAuthToken({
+      cfg: makeConfig(envSecretRef("MISSING_GATEWAY_TOKEN")),
+      env: {
+        OPENCLAW_GATEWAY_TOKEN: "env-token",
+      },
+      envFallback: "no-secret-ref",
+      unresolvedReasonStyle: "detailed",
+    });
+
+    expect(result).toEqual({
+      token: undefined,
+      source: undefined,
+      secretRefConfigured: true,
+      unresolvedRefReason:
+        "gateway.auth.token SecretRef is unresolved (env:default:MISSING_GATEWAY_TOKEN).",
+    });
+  });
+
+  it("does not use env when no SecretRef exists and envFallback=never", async () => {
+    await expect(
+      resolveGatewayAuthToken({
+        cfg: makeConfig(undefined),
+        env: {
+          OPENCLAW_GATEWAY_TOKEN: "env-token",
+        },
+        envFallback: "never",
+      }),
+    ).resolves.toEqual({
+      secretRefConfigured: false,
+    });
+  });
+});

--- a/src/gateway/auth-token-resolution.test.ts
+++ b/src/gateway/auth-token-resolution.test.ts
@@ -4,6 +4,8 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { SecretRef } from "../config/types.secrets.js";
 import { resolveGatewayAuthToken } from "./auth-token-resolution.js";
 
+type GatewayAuthTokenInput = NonNullable<NonNullable<OpenClawConfig["gateway"]>["auth"]>["token"];
+
 function envSecretRef(id: string): SecretRef {
   return {
     source: "env",
@@ -12,7 +14,7 @@ function envSecretRef(id: string): SecretRef {
   };
 }
 
-function makeConfig(token?: OpenClawConfig["gateway"]["auth"]["token"]): OpenClawConfig {
+function makeConfig(token?: GatewayAuthTokenInput): OpenClawConfig {
   return {
     gateway: {
       auth: token === undefined ? {} : { token },


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where gateway auth token precedence around explicit values, config values, SecretRef resolution, and env fallback is only covered indirectly by higher-level tests. That makes auth fallback behavior easier to change accidentally without a focused signal.

## Why This Change Was Made

This adds focused unit coverage for `resolveGatewayAuthToken()` so the intended precedence and fail-closed/fail-open behavior stay explicit. The new tests lock the most sensitive cases around unresolved SecretRef handling and env fallback.

## User Impact

Developers and maintainers now get direct regression coverage for gateway auth token resolution. This reduces the risk of silent auth behavior drift during future gateway auth refactors.

## Evidence

- Added focused Vitest coverage in `src/gateway/auth-token-resolution.test.ts`
- Ran:
  - `pnpm test src/gateway/auth-token-resolution.test.ts`
- Result:
  - `Test Files 4 passed (4)`
  - `Tests 24 passed (24)`

- Real local OpenClaw behavior proof:
  - `pnpm openclaw setup`
    - `Wrote ~\.openclaw\openclaw.json`
    - `Workspace OK: ~\.openclaw\workspace`
    - `Sessions OK: ~\.openclaw\agents\main\sessions`
  - `pnpm openclaw gateway run --verbose`
    - gateway reached ready state locally
    - startup logs showed plugin loading and local bind on `127.0.0.1:18789`
  - `pnpm openclaw gateway status`
    - reported dashboard URL `http://127.0.0.1:18789/`
    - reported `Port 18789 is already in use`
    - showed the local OpenClaw gateway process listening on `127.0.0.1:18789`
  
<img width="1061" height="601" alt="image" src="https://github.com/user-attachments/assets/aff71901-8c6b-406e-a080-7c4c990fbbc1" />
