### PR TITLE
fix: inject only shared auth into macos dashboard

### DIFF
--- a/apps/macos/Sources/OpenClaw/DashboardManager.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardManager.swift
@@ -17,17 +17,20 @@ final class DashboardManager {
     @discardableResult
     func showConfiguredWindowIfPossible() -> Bool {
         let mode = AppStateStore.shared.connectionMode
-        guard let config = self.immediateDashboardConfig(mode: mode),
-              let url = try? GatewayEndpointStore.dashboardURL(
-                  for: config,
-                  mode: mode,
-                  authToken: config.token)
+        guard let config = self.immediateDashboardConfig(mode: mode) else {
+            return false
+        }
+        let token = GatewayConnection.controlUiSharedAuthToken(config: config)
+        guard let url = try? GatewayEndpointStore.dashboardURL(
+            for: config,
+            mode: mode,
+            authToken: token)
         else {
             return false
         }
         let auth = DashboardWindowAuth(
             gatewayUrl: Self.websocketURLString(for: url),
-            token: config.token,
+            token: token,
             password: config.password?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty)
         guard auth.hasCredential else {
             return false
@@ -48,7 +51,7 @@ final class DashboardManager {
         dashboardManagerLogger.info("dashboard show requested mode=\(String(describing: mode), privacy: .public)")
         let config = try await self.dashboardConfig(mode: mode)
         dashboardManagerLogger.info("dashboard config url=\(config.url.absoluteString, privacy: .public)")
-        let token = await GatewayConnection.shared.controlUiAutoAuthToken(config: config)
+        let token = GatewayConnection.controlUiSharedAuthToken(config: config)
         let url = try GatewayEndpointStore.dashboardURL(for: config, mode: mode, authToken: token)
         let auth = DashboardWindowAuth(
             gatewayUrl: Self.websocketURLString(for: url),

--- a/apps/macos/Sources/OpenClaw/GatewayConnection.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnection.swift
@@ -318,24 +318,12 @@ actor GatewayConnection {
         return trimmed.isEmpty ? nil : trimmed
     }
 
-    func controlUiAutoAuthToken(config: Config) async -> String? {
+    /// Token safe to inject into browser Control UI. Native device tokens stay on native websocket clients.
+    static func controlUiSharedAuthToken(config: Config) -> String? {
         if let token = config.token?.trimmingCharacters(in: .whitespacesAndNewlines),
            !token.isEmpty
         {
             return token
-        }
-        if let deviceToken = self.lastSnapshot?.auth["deviceToken"]?.value as? String {
-            let trimmed = deviceToken.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !trimmed.isEmpty {
-                return trimmed
-            }
-        }
-        let identity = DeviceIdentityStore.loadOrCreate()
-        if let entry = DeviceAuthStore.loadToken(deviceId: identity.deviceId, role: "operator") {
-            let trimmed = entry.token.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !trimmed.isEmpty {
-                return trimmed
-            }
         }
         return nil
     }

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardAuthTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardAuthTests.swift
@@ -1,0 +1,50 @@
+import Foundation
+import OpenClawKit
+import Testing
+@testable import OpenClaw
+
+@Suite(.serialized)
+struct DashboardAuthTests {
+    @Test func `dashboard browser auth uses configured shared token only`() throws {
+        let config: GatewayConnection.Config = try (
+            url: #require(URL(string: "ws://127.0.0.1:18789")),
+            token: " shared-token ",
+            password: nil)
+
+        #expect(GatewayConnection.controlUiSharedAuthToken(config: config) == "shared-token")
+    }
+
+    @Test func `dashboard browser auth ignores stored native device token`() async throws {
+        try await self.withTemporaryStateDir {
+            let identity = DeviceIdentityStore.loadOrCreate()
+            _ = DeviceAuthStore.storeToken(
+                deviceId: identity.deviceId,
+                role: "operator",
+                token: "native-device-token",
+                scopes: ["operator.read"])
+            let config: GatewayConnection.Config = try (
+                url: #require(URL(string: "ws://100.64.1.8:18789")),
+                token: nil,
+                password: nil)
+
+            #expect(GatewayConnection.controlUiSharedAuthToken(config: config) == nil)
+        }
+    }
+
+    private func withTemporaryStateDir<T>(_ operation: () async throws -> T) async throws -> T {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let previousStateDir = ProcessInfo.processInfo.environment["OPENCLAW_STATE_DIR"]
+        setenv("OPENCLAW_STATE_DIR", tempDir.path, 1)
+        defer {
+            if let previousStateDir {
+                setenv("OPENCLAW_STATE_DIR", previousStateDir, 1)
+            } else {
+                unsetenv("OPENCLAW_STATE_DIR")
+            }
+            try? FileManager.default.removeItem(at: tempDir)
+        }
+        return try await operation()
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayEndpointStoreTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayEndpointStoreTests.swift
@@ -284,7 +284,7 @@ struct GatewayEndpointStoreTests {
         #expect(url.query == nil)
     }
 
-    @Test func `dashboard URL can use native auth token override`() throws {
+    @Test func `dashboard URL can use shared auth token override`() throws {
         let config: GatewayConnection.Config = try (
             url: #require(URL(string: "ws://127.0.0.1:18789")),
             token: nil,
@@ -294,8 +294,8 @@ struct GatewayEndpointStoreTests {
             for: config,
             mode: .local,
             localBasePath: "/control",
-            authToken: "device-token")
-        #expect(url.absoluteString == "http://127.0.0.1:18789/control/#token=device-token")
+            authToken: "shared-token")
+        #expect(url.absoluteString == "http://127.0.0.1:18789/control/#token=shared-token")
         #expect(url.query == nil)
     }
 


### PR DESCRIPTION
## Summary
- limit macOS Dashboard browser auth injection to configured shared gateway tokens
- stop falling back to cached/native device tokens for browser Control UI token injection
- add tests covering shared-token trimming and stored native device token exclusion

Fixes #98486

## Test plan
- `git diff --check`
- `swift --version` (fails on this Windows environment: `swift` is not installed)