### PR TITLE
fix(llm): add zai thinking handler to transport stream for GLM-4.5+ models

### DIFF
--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -6844,6 +6844,51 @@ describe("openai transport stream", () => {
     expect(disabled.reasoning_effort).toBe("none");
   });
 
+  it("maps zai thinking format to thinking.type and reasoning_effort for GLM-4.5+", () => {
+    const baseModel = {
+      id: "glm-5.2",
+      name: "GLM 5.2",
+      api: "openai-completions",
+      provider: "zai",
+      baseUrl: "https://open.bigmodel.cn/api/paas/v4",
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 131072,
+      maxTokens: 8192,
+      compat: {
+        thinkingFormat: "zai",
+      },
+    } as unknown as Model<"openai-completions">;
+    const context = {
+      systemPrompt: "system",
+      messages: [],
+      tools: [],
+    } as never;
+
+    const enabled = buildOpenAICompletionsParams(baseModel, context, {
+      reasoning: "medium",
+    } as never) as {
+      thinking?: { type: string };
+      reasoning_effort?: unknown;
+      enable_thinking?: unknown;
+    };
+    const disabled = buildOpenAICompletionsParams(baseModel, context, {
+      reasoning: "off",
+    } as never) as {
+      thinking?: { type: string };
+      reasoning_effort?: unknown;
+      enable_thinking?: unknown;
+    };
+
+    expect(enabled.thinking).toEqual({ type: "enabled" });
+    expect(enabled.reasoning_effort).toBe("medium");
+    expect(enabled).not.toHaveProperty("enable_thinking");
+    expect(disabled.thinking).toEqual({ type: "disabled" });
+    expect(disabled).not.toHaveProperty("reasoning_effort");
+    expect(disabled).not.toHaveProperty("enable_thinking");
+  });
+
   it("maps qwen thinking format to top-level enable_thinking", () => {
     const baseModel = {
       id: "qwen3.5-32b",

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -3882,6 +3882,27 @@ function applyTogetherOpenAICompletionsThinkingParams(params: {
   return true;
 }
 
+function applyZaiOpenAICompletionsThinkingParams(params: {
+  compatThinkingFormat: string;
+  modelReasoning: boolean;
+  payload: Record<string, unknown>;
+  requestedEffort: OpenAIReasoningEffort;
+  resolvedEffort?: string;
+  thinkingLevelMap?: Record<string, string>;
+}): boolean {
+  if (!params.modelReasoning || params.compatThinkingFormat !== "zai") {
+    return false;
+  }
+  params.payload.thinking = {
+    type: isOpenAICompletionsThinkingEnabled(params.requestedEffort) ? "enabled" : "disabled",
+  };
+  if (params.resolvedEffort) {
+    params.payload.reasoning_effort =
+      params.thinkingLevelMap?.[params.resolvedEffort] ?? params.resolvedEffort;
+  }
+  return true;
+}
+
 function convertTools(
   tools: NonNullable<Context["tools"]>,
   compat: ReturnType<typeof getCompat>,
@@ -4431,6 +4452,14 @@ export function buildOpenAICompletionsParams(
     modelReasoning: model.reasoning,
     payload: params,
     requestedEffort: completionsReasoningEffort,
+  });
+  applyZaiOpenAICompletionsThinkingParams({
+    compatThinkingFormat: compat.thinkingFormat,
+    modelReasoning: model.reasoning,
+    payload: params,
+    requestedEffort: completionsReasoningEffort,
+    resolvedEffort: resolvedCompletionsReasoningEffort,
+    thinkingLevelMap: model.thinkingLevelMap as Record<string, string> | undefined,
   });
   if (
     compat.thinkingFormat === "openrouter" &&

--- a/src/llm/providers/openai-completions.ts
+++ b/src/llm/providers/openai-completions.ts
@@ -724,7 +724,15 @@ function buildParams(
   }
 
   if (compat.thinkingFormat === "zai" && model.reasoning) {
-    params.enable_thinking = Boolean(options?.reasoningEffort);
+    // ZAI/Zhipu GLM-4.5+ (including GLM-5.2) dropped the legacy `enable_thinking`
+    // top-level boolean in favor of `thinking: { type: "enabled" | "disabled" }`,
+    // matching the DeepSeek thinking contract. The legacy param was silently ignored,
+    // so `/reasoning on` produced no `reasoning_content` in responses.
+    params.thinking = { type: options?.reasoningEffort ? "enabled" : "disabled" };
+    if (options?.reasoningEffort) {
+      params.reasoning_effort =
+        model.thinkingLevelMap?.[options.reasoningEffort] ?? options.reasoningEffort;
+    }
   } else if (compat.thinkingFormat === "qwen" && model.reasoning) {
     params.enable_thinking = Boolean(options?.reasoningEffort);
   } else if (compat.thinkingFormat === "qwen-chat-template" && model.reasoning) {


### PR DESCRIPTION
## What Problem This Solves

The original PR #98030 fixed zai thinking format in `openai-completions.ts` `buildParams`, but the transport stream s `buildOpenAICompletionsParams` is a separate code path used by active agent sessions and was missing the fix. The test added in that PR imports from the transport stream and failed until now.

ZAI/Zhipu GLM-4.5+ dropped the legacy `enable_thinking` boolean in favor of `thinking: { type: "enabled" | "disabled" }` matching DeepSeek.

## Why This Change Was Made

Add `applyZaiOpenAICompletionsThinkingParams` to the transport stream with the same logic:
- `thinking: { type: "enabled" | "disabled" }`
- `reasoning_effort` via `model.thinkingLevelMap`

## User Impact

Fixes `/reasoning on` producing no `reasoning_content` in responses for ZAI models via the streaming transport path.

## Evidence

- All 284 transport stream tests pass
- New test covers zai thinking params in transport stream