### PR TITLE
fix: avoid duplicate macos launchd enable

### DIFF
--- a/apps/macos/Sources/OpenClaw/ConnectionModeCoordinator.swift
+++ b/apps/macos/Sources/OpenClaw/ConnectionModeCoordinator.swift
@@ -35,12 +35,6 @@ final class ConnectionModeCoordinator {
             let shouldStart = GatewayAutostartPolicy.shouldStartGateway(mode: .local, paused: paused)
             if shouldStart {
                 GatewayProcessManager.shared.setActive(true)
-                if GatewayAutostartPolicy.shouldEnsureLaunchAgent(
-                    mode: .local,
-                    paused: paused)
-                {
-                    Task { await GatewayProcessManager.shared.ensureLaunchAgentEnabledIfNeeded() }
-                }
                 _ = await GatewayProcessManager.shared.waitForGatewayReady()
             } else {
                 GatewayProcessManager.shared.stop()

--- a/apps/macos/Sources/OpenClaw/GatewayProcessManager.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayProcessManager.swift
@@ -118,6 +118,9 @@ final class GatewayProcessManager {
         Task { [weak self] in
             guard let self else { return }
             if await self.attachExistingGatewayIfAvailable() {
+                if case .attachedExisting = self.status {
+                    await self.ensureLaunchAgentEnabledIfNeeded()
+                }
                 return
             }
             await self.enableLaunchdGateway()
@@ -437,6 +440,10 @@ extension GatewayProcessManager {
 
     func setTestingLastFailureReason(_ reason: String?) {
         self.lastFailureReason = reason
+    }
+
+    func setTestingStatus(_ status: Status) {
+        self.status = status
     }
 
     func _testAttachExistingGatewayIfAvailable() async -> Bool {

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayProcessManagerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayProcessManagerTests.swift
@@ -29,6 +29,7 @@ struct GatewayProcessManagerTests {
             manager.setTestingConnection(nil)
             manager.setTestingDesiredActive(false)
             manager.setTestingLastFailureReason(nil)
+            manager.setTestingStatus(.stopped)
         }
 
         let ready = await manager.waitForGatewayReady(timeout: 0.5)
@@ -102,6 +103,7 @@ struct GatewayProcessManagerTests {
                 manager.setTestingSkipControlChannelRefresh(false)
                 manager.setTestingDesiredActive(false)
                 manager.setTestingLastFailureReason(nil)
+                manager.setTestingStatus(.stopped)
                 await PortGuardian.shared.setTestingDescriptor(nil, forPort: port)
             }
 
@@ -125,5 +127,96 @@ struct GatewayProcessManagerTests {
                 throw error
             }
         }
+    }
+
+    @Test func `start ensures launch agent after attaching existing gateway`() async throws {
+        let port = 19098
+        try await TestIsolation.withEnvValues(["OPENCLAW_GATEWAY_PORT": "\(port)"]) {
+            let healthData = Data(
+                """
+                {
+                  "ok": true,
+                  "ts": 1,
+                  "durationMs": 0,
+                  "channels": {},
+                  "channelOrder": [],
+                  "channelLabels": {},
+                  "heartbeatSeconds": 30,
+                  "sessions": {
+                    "path": "/tmp/sessions",
+                    "count": 0,
+                    "recent": []
+                  }
+                }
+                """.utf8)
+            let session = GatewayTestWebSocketSession(
+                taskFactory: {
+                    GatewayTestWebSocketTask(
+                        sendHook: { task, message, sendIndex in
+                            guard sendIndex > 0 else { return }
+                            guard let id = GatewayWebSocketTestSupport.requestID(from: message) else { return }
+                            let json = """
+                            {
+                              "type": "res",
+                              "id": "\(id)",
+                              "ok": true,
+                              "payload": \(String(decoding: healthData, as: UTF8.self))
+                            }
+                            """
+                            task.emitReceiveSuccess(.data(Data(json.utf8)))
+                        })
+                })
+            let url = try #require(URL(string: "ws://example.invalid"))
+            let connection = GatewayConnection(
+                configProvider: { (url: url, token: nil, password: nil) },
+                sessionBox: WebSocketSessionBox(session: session))
+            let descriptor = PortGuardian.Descriptor(
+                pid: 4243,
+                command: "openclaw-gateway",
+                executablePath: "/tmp/openclaw-gateway")
+
+            let manager = GatewayProcessManager.shared
+            await PortGuardian.shared.setTestingDescriptor(descriptor, forPort: port)
+            GatewayLaunchAgentManager.setTestingInterceptDaemonCommands(true)
+            GatewayLaunchAgentManager.clearTestingDaemonCommandCalls()
+            manager.setTestingStatus(.stopped)
+            manager.setTestingConnection(connection)
+            manager.setTestingSkipControlChannelRefresh(true)
+            manager.setTestingDesiredActive(true)
+
+            @MainActor
+            func cleanup() async {
+                manager.setTestingConnection(nil)
+                manager.setTestingSkipControlChannelRefresh(false)
+                manager.setTestingDesiredActive(false)
+                manager.setTestingStatus(.stopped)
+                GatewayLaunchAgentManager.setTestingInterceptDaemonCommands(false)
+                GatewayLaunchAgentManager.clearTestingDaemonCommandCalls()
+                await PortGuardian.shared.setTestingDescriptor(nil, forPort: port)
+            }
+
+            manager.startIfNeeded()
+            let calls = await self.waitForLaunchdInstallCall()
+            let installCalls = calls.filter { $0.first == "install" }
+
+            #expect(installCalls.count == 1)
+            #expect(calls.contains { $0.first == "status" })
+            guard case .attachedExisting = manager.status else {
+                Issue.record("expected attachedExisting status")
+                await cleanup()
+                return
+            }
+            await cleanup()
+        }
+    }
+
+    private func waitForLaunchdInstallCall(timeout: TimeInterval = 1) async -> [[String]] {
+        let deadline = Date().addingTimeInterval(timeout)
+        var calls = GatewayLaunchAgentManager.testingDaemonCommandCallsSnapshot()
+        while !calls.contains(where: { $0.first == "install" }), Date() < deadline {
+            try? await Task.sleep(nanoseconds: 20_000_000)
+            calls = GatewayLaunchAgentManager.testingDaemonCommandCallsSnapshot()
+        }
+        return calls
     }
 }


### PR DESCRIPTION
## Summary
- make `GatewayProcessManager` the single launchd-enable owner during macOS local startup
- remove the coordinator's parallel `ensureLaunchAgentEnabledIfNeeded()` task
- preserve launchd ensure after successfully attaching to an existing Gateway
- add a process-manager regression test that records launchd status/install calls and expects one install

Fixes #98491

## Test plan
- `git diff --check`
- `swift --version` (fails on this Windows environment: `swift` is not installed)