### PR TITLE
fix(transcripts): close readline interface and destroy read stream on error exit

### DIFF
--- a/src/transcripts/store.test.ts
+++ b/src/transcripts/store.test.ts
@@ -1,0 +1,108 @@
+// Tests TranscriptsStore stream cleanup and transcript reading behavior.
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { listOpenFileDescriptorsForPath } from "../../src/infra/open-file-descriptors.test-support.js";
+import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
+import { TranscriptsStore } from "./store.js";
+
+const tempRoots: string[] = [];
+
+describe("TranscriptsStore.readUtterancesFromSessionDir", () => {
+  afterEach(() => {
+    cleanupTempDirs(tempRoots);
+  });
+
+  it("returns an empty array when transcript.jsonl is missing", () => {
+    const tmpDir = makeTempDir(tempRoots, "openclaw-transcript-test-");
+    const store = new TranscriptsStore(tmpDir);
+    const sessionDir = path.join(tmpDir, "2026-07-01", "missing");
+    fs.mkdirSync(sessionDir, { recursive: true });
+
+    const result = store.readUtterancesFromSessionDir(sessionDir, { maxUtterances: 10 });
+
+    return expect(result).resolves.toEqual([]);
+  });
+
+  it("reads utterances from transcript.jsonl", () => {
+    const tmpDir = makeTempDir(tempRoots, "openclaw-transcript-test-");
+    const store = new TranscriptsStore(tmpDir);
+    const sessionDir = path.join(tmpDir, "2026-07-01", "session-1");
+    fs.mkdirSync(sessionDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(sessionDir, "transcript.jsonl"),
+      [
+        JSON.stringify({ text: "hello", sessionId: "session-1" }),
+        JSON.stringify({ text: "world", sessionId: "session-1" }),
+      ].join("\n") + "\n",
+    );
+
+    const result = store.readUtterancesFromSessionDir(sessionDir, { maxUtterances: 10 });
+
+    return expect(result).resolves.toEqual([
+      expect.objectContaining({ text: "hello" }),
+      expect.objectContaining({ text: "world" }),
+    ]);
+  });
+
+  it("keeps only the tail when utterances exceed maxUtterances", () => {
+    const tmpDir = makeTempDir(tempRoots, "openclaw-transcript-test-");
+    const store = new TranscriptsStore(tmpDir);
+    const sessionDir = path.join(tmpDir, "2026-07-01", "session-1");
+    fs.mkdirSync(sessionDir, { recursive: true });
+    const lines = Array.from({ length: 5 }, (_, i) =>
+      JSON.stringify({ text: `line-${i}`, sessionId: "session-1" }),
+    );
+    fs.writeFileSync(path.join(sessionDir, "transcript.jsonl"), lines.join("\n") + "\n");
+
+    const result = store.readUtterancesFromSessionDir(sessionDir, { maxUtterances: 2 });
+
+    return expect(result).resolves.toEqual([
+      expect.objectContaining({ text: "line-3" }),
+      expect.objectContaining({ text: "line-4" }),
+    ]);
+  });
+
+  it.runIf(process.platform === "linux")(
+    "does not leak file descriptors when JSON.parse throws",
+    async () => {
+      const tmpDir = makeTempDir(tempRoots, "openclaw-transcript-test-");
+      const store = new TranscriptsStore(tmpDir);
+      const sessionDir = path.join(tmpDir, "2026-07-01", "session-1");
+      fs.mkdirSync(sessionDir, { recursive: true });
+      const transcriptPath = path.join(sessionDir, "transcript.jsonl");
+      fs.writeFileSync(transcriptPath, "not valid json\n");
+
+      const fdsBefore = listOpenFileDescriptorsForPath(sessionDir);
+      await expect(
+        store.readUtterancesFromSessionDir(sessionDir, { maxUtterances: 10 }),
+      ).rejects.toThrow();
+      const fdsAfter = listOpenFileDescriptorsForPath(sessionDir);
+
+      const leaked = fdsAfter.filter((p) => !fdsBefore.includes(p));
+      expect(leaked).toHaveLength(0);
+    },
+  );
+
+  it.runIf(process.platform === "linux")(
+    "does not leak file descriptors in the happy path",
+    async () => {
+      const tmpDir = makeTempDir(tempRoots, "openclaw-transcript-test-");
+      const store = new TranscriptsStore(tmpDir);
+      const sessionDir = path.join(tmpDir, "2026-07-01", "session-1");
+      fs.mkdirSync(sessionDir, { recursive: true });
+      const transcriptPath = path.join(sessionDir, "transcript.jsonl");
+      fs.writeFileSync(
+        transcriptPath,
+        JSON.stringify({ text: "hello", sessionId: "session-1" }) + "\n",
+      );
+
+      const fdsBefore = listOpenFileDescriptorsForPath(sessionDir);
+      await store.readUtterancesFromSessionDir(sessionDir, { maxUtterances: 10 });
+      const fdsAfter = listOpenFileDescriptorsForPath(sessionDir);
+
+      const leaked = fdsAfter.filter((p) => !fdsBefore.includes(p));
+      expect(leaked).toHaveLength(0);
+    },
+  );
+});

--- a/src/transcripts/store.ts
+++ b/src/transcripts/store.ts
@@ -196,18 +196,29 @@ export class TranscriptsStore {
     if (maxUtterances !== undefined) {
       const utterances: TranscriptUtterance[] = [];
       try {
+        const stream = createReadStream(transcriptPath, { encoding: "utf8" });
         const lines = createInterface({
-          input: createReadStream(transcriptPath, { encoding: "utf8" }),
+          input: stream,
           crlfDelay: Infinity,
         });
-        for await (const line of lines) {
-          if (!line) {
-            continue;
+        try {
+          for await (const line of lines) {
+            if (!line) {
+              continue;
+            }
+            utterances.push(JSON.parse(line) as TranscriptUtterance);
+            if (utterances.length > maxUtterances) {
+              // Stream and keep only the tail so large transcripts do not require full-file memory.
+              utterances.shift();
+            }
           }
-          utterances.push(JSON.parse(line) as TranscriptUtterance);
-          if (utterances.length > maxUtterances) {
-            // Stream and keep only the tail so large transcripts do not require full-file memory.
-            utterances.shift();
+        } finally {
+          lines.close();
+          stream.destroy();
+          if (!stream.closed) {
+            await new Promise<void>((resolve) => {
+              stream.once("close", () => resolve());
+            });
           }
         }
       } catch (err) {


### PR DESCRIPTION
## What Problem This Solves

`TranscriptsStore.readUtterancesFromDir` (`src/transcripts/store.ts:199-218`) streams `transcript.jsonl` through a `createReadStream` + `readline.createInterface` pair when `maxUtterances` is set, but it never closes the interface or destroys the stream. If `JSON.parse` throws inside the `for await` loop, the function propagates the error while leaving the underlying file descriptor open. Over time this leaks fds in long-running gateway processes.

## Changes

- `src/transcripts/store.ts`: extract the `createReadStream` result into a named `stream`, wrap the `for await` loop in `try/finally`, and call `lines.close()` and `stream.destroy()` in `finally`. When `stream.destroy()` does not immediately close the fs handle, await the stream's `close` event before returning.
- `src/transcripts/store.test.ts`: add regression tests for missing-file handling, normal JSONL reads, tail truncation, and fd-leak-free behavior on both the malformed-JSON error path and the happy path.

## Real behavior proof

**BEFORE (current `main`, no fix applied)**  
Driving the real `TranscriptsStore.readUtterancesFromSessionDir` against a malformed JSONL file leaks the transcript fd:

```text
threw as expected: SyntaxError
transcript path: /tmp/openclaw-repro-98467-i9zShq/2026-07-01/session-1/transcript.jsonl
threw on malformed JSON: true
open fds before call: 25
open fds after call: 26
leaked transcript.jsonl fds: 1
  leaked fd: /tmp/openclaw-repro-98467-i9zShq/2026-07-01/session-1/transcript.jsonl
FAIL: file descriptor leak detected
```

**NEGATIVE CONTROL**  
Reverting only the source change in `src/transcripts/store.ts` while keeping the new tests makes the fd-leak regression test fail:

```text
× src/transcripts/store.test.ts > ... > does not leak file descriptors when JSON.parse throws
  → expected [ Array(1) ] to have a length of +0 but got 1
 Test Files  1 failed (1)
      Tests  1 failed | 4 passed (5)
```

**AFTER (this branch)**  
The same local fd-count repro and the new unit tests pass with zero leaked fds:

```text
threw as expected: SyntaxError
transcript path: /tmp/openclaw-repro-98467-TDJkNx/2026-07-01/session-1/transcript.jsonl
threw on malformed JSON: true
open fds before call: 25
open fds after call: 25
leaked transcript.jsonl fds: 0
PASS: no file descriptor leak after malformed JSON read
```

## Evidence

- **Behavior addressed**: `TranscriptsStore.readUtterancesFromDir` now closes the readline interface and destroys the read stream (awaiting close) when the streaming JSONL parser exits, fixing a file descriptor leak on malformed lines.
- **Real environment tested**: Linux x86_64, Node v22.22.0, repo checkout `/home/0668000666/0668000666/AI/OpenClaw/new_open_claw`, branch `fix/transcripts-store-fd-leak`, base `openclaw/main @ f55abc0606`, live HEAD `68749382de`.
- **Exact steps or command run after this patch**:
  ```bash
  node scripts/run-vitest.mjs run src/transcripts/store.test.ts --reporter=verbose
  # → Test Files  1 passed (1)
  #      Tests  5 passed (5)

  # Local-only fd-count repro (not committed):
  # node --import tsx /tmp/issue-98467-fd-leak.mts
  # → leaked transcript.jsonl fds: 0
  # → PASS: no file descriptor leak after malformed JSON read

  node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.scripts.json \
    src/transcripts/store.ts src/transcripts/store.test.ts
  # → exit 0

  pnpm tsgo:core
  # → silent (no type errors)
  ```
- **Evidence after fix**: 5/5 new regression tests pass; the local fd-count repro reports `leaked transcript.jsonl fds: 0` after a malformed-line parse error; source change is 1 file, ~10 net LoC.
- **Observed result after fix**: The streaming read path no longer leaks file descriptors when `JSON.parse` throws or when the loop exits normally.
- **What was not tested**: Live long-running gateway telemetry under production load; the fix relies on local fd counting and unit tests. Windows/macOS fd behavior was not explicitly measured, but the cleanup calls (`lines.close()`, `stream.destroy()`, awaiting `close`) are platform-agnostic Node.js APIs.

## Tests and validation

- Added `src/transcripts/store.test.ts` with 5 tests covering:
  - missing `transcript.jsonl` returns `[]`
  - normal JSONL read returns utterances
  - `maxUtterances` keeps only the tail
  - malformed JSON does not leak fds
  - happy path does not leak fds
- Revert-line gate verified: reverting the `try/finally` cleanup makes the fd-leak test fail.

## Risk checklist

- **Scope**: 1 source file (`src/transcripts/store.ts`), 1 new test file.
- **Behavior change**: only the cleanup path; happy-path output unchanged.
- **API/signature changes**: none.
- **Type check**: `pnpm tsgo:core` passes. `pnpm tsgo:core:test` fails on pre-existing errors in `src/gateway/server-cron-notifications.test.ts`, `src/gateway/server-cron.test.ts`, and `src/llm/providers/anthropic.test.ts` that are unrelated to this change (verified on `openclaw/main @ f55abc0606`).
- **No config/env/migration changes**.
- **No security/auth/secrets/tool-execution changes**.

## CI status

The latest CI run on this PR shows three failing checks. All three failures are in files this PR does **not** touch:

- `check-lint`: `typescript(no-base-to-string)` in `src/gateway/server-cron.test.ts:626,676`.
- `check-test-types`: tuple-length and type mismatch errors in `src/gateway/server-cron-notifications.test.ts`, `src/gateway/server-cron.test.ts`, and `src/llm/providers/anthropic.test.ts`.
- `checks-node-compact-small-whole-3`: assertion failure in `src/llm/providers/mistral.test.ts:298`.

I rebased the branch onto the latest `openclaw/main @ f55abc0606`; these same failures persist on main. They appear to be pre-existing CI failures unrelated to the transcript store cleanup change, so I have not expanded this PR's scope to address them.

## Related

- Closes #98467.
- PR #98140 is a competing fix with the same source shape but no tests and no real-behavior proof.
