### PR TITLE
docs(skills): support variable landable sweep batches

### DIFF
--- a/.agents/skills/openclaw-landable-bug-sweep/SKILL.md
+++ b/.agents/skills/openclaw-landable-bug-sweep/SKILL.md
@@ -1,17 +1,18 @@
 ---
 name: openclaw-landable-bug-sweep
-description: "Find or repair small high-confidence non-SDK-boundary OpenClaw bugfix PRs until five are landable."
+description: "Find or repair a requested batch of small high-confidence non-SDK-boundary OpenClaw bugfix PRs until they are landable."
 ---
 
 # OpenClaw Landable Bug Sweep
 
-Autonomous maintainer workflow for producing five landable OpenClaw bugfix PR URLs.
+Autonomous maintainer workflow for producing a requested batch of landable OpenClaw bugfix PR URLs.
 Use for broad issue/PR sweeps where the bar is high and the output is PRs, not notes.
 Do not use for plugin SDK/API boundary work; those need separate architecture review.
 
 ## Target
 
-Return exactly five PR URLs, each with:
+Use `batch_size` from the request, defaulting to `5` and capped at `20`.
+Return up to that many qualified PR URLs, each with:
 
 - bug summary
 - why the fix is low-risk
@@ -20,9 +21,18 @@ Return exactly five PR URLs, each with:
 - CI green on the exact pushed PR head
 - issue/duplicate cleanup done or still pending
 
-The five URLs may be existing PRs that were reviewed/fixed, or new PRs created from issues/clusters.
+The URLs may be existing PRs that were reviewed/fixed, or new PRs created from issues/clusters.
 Do not present a PR URL to the maintainer until it has been refreshed on current `main`, left-tested, autoreviewed clean, pushed, and verified green in live GitHub CI.
 If code, tests, changelog, PR body, or branch base changes after autoreview, rerun autoreview before showing the URL.
+Do not pad a batch when the bounded search yields fewer qualified PRs.
+
+## Inputs
+
+- `batch_size`: requested number of landable PRs; default `5`, maximum `20`.
+- `source_mode`: `discovery` or `provided-prs`; default `discovery`.
+- `provided_prs`: explicit PR refs when `source_mode=provided-prs`.
+
+In `provided-prs` mode, inspect only the supplied PRs plus directly linked duplicate/canonical refs unless broader discovery is required to prove the best fix.
 
 ## Companion Skills
 
@@ -103,7 +113,7 @@ Reject:
    - close duplicates and fixed-on-main issues/PRs with proof as soon as you notice them during the sweep
    - never mutate more than five associated items in one cluster without explicit confirmation
    - comments must be kind, concrete, and include proof/PR/commit links
-8. Repeat until five landable PR URLs are ready.
+8. Repeat until `batch_size` landable PR URLs are ready or the bounded qualified queue is exhausted.
 
 ## PR Body Proof
 
@@ -151,7 +161,7 @@ closed:
 
 Final answer:
 
-- exactly five accepted PR URLs
+- the requested number of accepted PR URLs, or the smaller qualified count with the exhausted-search reason
 - 2-4 sentence explainer per PR
 - proof/CI state per PR
 - closed duplicates/fixed-on-main refs


### PR DESCRIPTION
## What Problem This Solves

Resolves a workflow limitation where the landable bug sweep always targeted exactly five pull requests, even when the operator requested a different batch size or supplied a fixed PR list.

## Why This Change Was Made

The skill now accepts a requested batch size up to 20, supports discovery and provided-PR modes, and returns the smaller qualified set when the bounded search is exhausted instead of padding the result.

## User Impact

Maintainers can reuse the existing proof and landing workflow for `next 20` and explicit PR batches without duplicating the skill or lowering its qualification bar.

## Evidence

- Fresh autoreview completed with no findings before the rebase.
- `git diff --check origin/main...HEAD`
- One scoped documentation-only commit; no runtime, config, security, or UI behavior changes.
