### PR TITLE
fix(cli): show exit code when plugin npm install returns empty output

### DIFF
--- a/src/infra/install-package-dir.test.ts
+++ b/src/infra/install-package-dir.test.ts
@@ -3,7 +3,7 @@ import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { runCommandWithTimeout, type CommandOptions } from "../process/exec.js";
+import { runCommandWithTimeout, type CommandOptions, type SpawnResult } from "../process/exec.js";
 import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
 import { installPackageDir } from "./install-package-dir.js";
 
@@ -179,6 +179,66 @@ describe("installPackageDir", () => {
   const fixtureRootTracker = createSuiteTempRootTracker({
     prefix: "openclaw-install-package-dir-",
   });
+  const emptyNpmFailureCases = [
+    {
+      label: "exit code",
+      npmResult: {
+        stdout: "",
+        stderr: "",
+        code: 1,
+        signal: null,
+        killed: false,
+        termination: "exit",
+      },
+      expectedDetail: "exit code 1",
+    },
+    {
+      label: "signal",
+      npmResult: {
+        stdout: "",
+        stderr: "",
+        code: null,
+        signal: "SIGKILL",
+        killed: true,
+        termination: "signal",
+      },
+      expectedDetail: "signal SIGKILL",
+    },
+  ] satisfies Array<{
+    label: string;
+    npmResult: SpawnResult;
+    expectedDetail: string;
+  }>;
+
+  async function installWithNpmResult(npmResult: SpawnResult) {
+    await fixtureRootTracker.setup();
+    const fixtureRoot = await fixtureRootTracker.make("case");
+    const sourceDir = path.join(fixtureRoot, "source");
+    const targetDir = path.join(fixtureRoot, "plugins", "demo");
+    await fs.mkdir(sourceDir, { recursive: true });
+    await fs.writeFile(
+      path.join(sourceDir, "package.json"),
+      JSON.stringify({
+        name: "demo-plugin",
+        version: "1.0.0",
+        dependencies: {
+          zod: "^4.0.0",
+        },
+      }),
+      "utf-8",
+    );
+    vi.mocked(runCommandWithTimeout).mockResolvedValue(npmResult);
+
+    return await installPackageDir({
+      sourceDir,
+      targetDir,
+      mode: "install",
+      timeoutMs: 1_000,
+      copyErrorPrefix: "failed to copy plugin",
+      hasDeps: true,
+      depsLogMessage: "Installing deps…",
+    });
+  }
 
   afterEach(async () => {
     vi.restoreAllMocks();
@@ -745,97 +805,17 @@ describe("installPackageDir", () => {
     }
   });
 
-  it("includes exit code when npm dependency install fails with empty stdout and stderr", async () => {
-    // Regression for #98484: `openclaw plugins install @openclaw/acpx` surfaced
-    // `npm install failed:` with no trailing detail when npm exited non-zero but
-    // produced no output on either stream. Without an exit code, users get zero
-    // actionable signal (and the hook-pack fallback "missing openclaw.hooks"
-    // message becomes the only visible error, which is misleading for plugins).
-    await fixtureRootTracker.setup();
-    const fixtureRoot = await fixtureRootTracker.make("case");
-    const sourceDir = path.join(fixtureRoot, "source");
-    const targetDir = path.join(fixtureRoot, "plugins", "demo");
-    await fs.mkdir(sourceDir, { recursive: true });
-    await fs.writeFile(
-      path.join(sourceDir, "package.json"),
-      JSON.stringify({
-        name: "demo-plugin",
-        version: "1.0.0",
-        dependencies: {
-          zod: "^4.0.0",
-        },
-      }),
-      "utf-8",
-    );
+  it.each(emptyNpmFailureCases)(
+    "includes $label when npm dependency install fails without output",
+    async ({ npmResult, expectedDetail }) => {
+      const result = await installWithNpmResult(npmResult);
 
-    vi.mocked(runCommandWithTimeout).mockResolvedValue({
-      stdout: "",
-      stderr: "",
-      code: 1,
-      signal: null,
-      killed: false,
-      termination: "exit",
-    });
-
-    const result = await installPackageDir({
-      sourceDir,
-      targetDir,
-      mode: "install",
-      timeoutMs: 1_000,
-      copyErrorPrefix: "failed to copy plugin",
-      hasDeps: true,
-      depsLogMessage: "Installing deps…",
-    });
-
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.error).toContain("npm install failed:");
-      expect(result.error).toContain("exit code 1");
-      expect(result.error.replace(/\s+/g, " ").trim()).not.toMatch(/npm install failed:\s*$/);
-    }
-  });
-
-  it("includes signal detail when npm dependency install is killed by a signal", async () => {
-    await fixtureRootTracker.setup();
-    const fixtureRoot = await fixtureRootTracker.make("case");
-    const sourceDir = path.join(fixtureRoot, "source");
-    const targetDir = path.join(fixtureRoot, "plugins", "demo");
-    await fs.mkdir(sourceDir, { recursive: true });
-    await fs.writeFile(
-      path.join(sourceDir, "package.json"),
-      JSON.stringify({
-        name: "demo-plugin",
-        version: "1.0.0",
-        dependencies: {
-          zod: "^4.0.0",
-        },
-      }),
-      "utf-8",
-    );
-
-    vi.mocked(runCommandWithTimeout).mockResolvedValue({
-      stdout: "",
-      stderr: "",
-      code: null,
-      signal: "SIGKILL",
-      killed: true,
-      termination: "signal",
-    });
-
-    const result = await installPackageDir({
-      sourceDir,
-      targetDir,
-      mode: "install",
-      timeoutMs: 1_000,
-      copyErrorPrefix: "failed to copy plugin",
-      hasDeps: true,
-      depsLogMessage: "Installing deps…",
-    });
-
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.error).toContain("npm install failed:");
-      expect(result.error).toContain("SIGKILL");
-    }
-  });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toContain("npm install failed:");
+        expect(result.error).toContain(expectedDetail);
+        expect(result.error.replace(/\s+/g, " ").trim()).not.toMatch(/npm install failed:\s*$/);
+      }
+    },
+  );
 });

--- a/src/infra/install-package-dir.test.ts
+++ b/src/infra/install-package-dir.test.ts
@@ -744,4 +744,98 @@ describe("installPackageDir", () => {
       expect(result.error).toContain("workspace:");
     }
   });
+
+  it("includes exit code when npm dependency install fails with empty stdout and stderr", async () => {
+    // Regression for #98484: `openclaw plugins install @openclaw/acpx` surfaced
+    // `npm install failed:` with no trailing detail when npm exited non-zero but
+    // produced no output on either stream. Without an exit code, users get zero
+    // actionable signal (and the hook-pack fallback "missing openclaw.hooks"
+    // message becomes the only visible error, which is misleading for plugins).
+    await fixtureRootTracker.setup();
+    const fixtureRoot = await fixtureRootTracker.make("case");
+    const sourceDir = path.join(fixtureRoot, "source");
+    const targetDir = path.join(fixtureRoot, "plugins", "demo");
+    await fs.mkdir(sourceDir, { recursive: true });
+    await fs.writeFile(
+      path.join(sourceDir, "package.json"),
+      JSON.stringify({
+        name: "demo-plugin",
+        version: "1.0.0",
+        dependencies: {
+          zod: "^4.0.0",
+        },
+      }),
+      "utf-8",
+    );
+
+    vi.mocked(runCommandWithTimeout).mockResolvedValue({
+      stdout: "",
+      stderr: "",
+      code: 1,
+      signal: null,
+      killed: false,
+      termination: "exit",
+    });
+
+    const result = await installPackageDir({
+      sourceDir,
+      targetDir,
+      mode: "install",
+      timeoutMs: 1_000,
+      copyErrorPrefix: "failed to copy plugin",
+      hasDeps: true,
+      depsLogMessage: "Installing deps…",
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("npm install failed:");
+      expect(result.error).toContain("exit code 1");
+      expect(result.error.replace(/\s+/g, " ").trim()).not.toMatch(/npm install failed:\s*$/);
+    }
+  });
+
+  it("includes signal detail when npm dependency install is killed by a signal", async () => {
+    await fixtureRootTracker.setup();
+    const fixtureRoot = await fixtureRootTracker.make("case");
+    const sourceDir = path.join(fixtureRoot, "source");
+    const targetDir = path.join(fixtureRoot, "plugins", "demo");
+    await fs.mkdir(sourceDir, { recursive: true });
+    await fs.writeFile(
+      path.join(sourceDir, "package.json"),
+      JSON.stringify({
+        name: "demo-plugin",
+        version: "1.0.0",
+        dependencies: {
+          zod: "^4.0.0",
+        },
+      }),
+      "utf-8",
+    );
+
+    vi.mocked(runCommandWithTimeout).mockResolvedValue({
+      stdout: "",
+      stderr: "",
+      code: null,
+      signal: "SIGKILL",
+      killed: true,
+      termination: "signal",
+    });
+
+    const result = await installPackageDir({
+      sourceDir,
+      targetDir,
+      mode: "install",
+      timeoutMs: 1_000,
+      copyErrorPrefix: "failed to copy plugin",
+      hasDeps: true,
+      depsLogMessage: "Installing deps…",
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("npm install failed:");
+      expect(result.error).toContain("SIGKILL");
+    }
+  });
 });

--- a/src/infra/install-package-dir.ts
+++ b/src/infra/install-package-dir.ts
@@ -2,7 +2,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { isRecord as isObjectRecord } from "@openclaw/normalization-core/record-coerce";
-import { runCommandWithTimeout } from "../process/exec.js";
+import { runCommandWithTimeout, type SpawnResult } from "../process/exec.js";
 import { pathExists } from "./fs-safe.js";
 import { assertCanonicalPathWithinBase } from "./install-safe-path.js";
 import { tryReadJson, writeJson } from "./json-files.js";
@@ -55,40 +55,18 @@ async function sanitizeManifestForNpmInstall(targetDir: string): Promise<void> {
   await writeJson(manifestPath, manifest, { trailingNewline: true });
 }
 
-/**
- * Formats the failure suffix for `npm install failed:` messages when npm exits
- * with a non-zero status. Prefers npm's own stderr/stdout when either is
- * populated, but falls back to the exit code / signal / termination reason so
- * users still get an actionable signal when npm returns empty output (observed
- * on some npm 11 combinations for @openclaw/acpx installs, #98484).
- */
-function formatNpmDependencyInstallFailure(result: {
-  stdout: string;
-  stderr: string;
-  code: number | null;
-  signal: NodeJS.Signals | null;
-  termination?: "exit" | "timeout" | "no-output-timeout" | "signal";
-}): string {
+function formatNpmDependencyInstallFailure(result: SpawnResult): string {
   const detail = result.stderr.trim() || result.stdout.trim();
   if (detail) {
     return detail;
   }
-  const parts: string[] = [];
-  if (result.termination === "timeout") {
-    parts.push("timed out");
-  } else if (result.termination === "no-output-timeout") {
-    parts.push("exceeded no-output timeout");
-  }
-  if (typeof result.code === "number") {
-    parts.push(`exit code ${result.code}`);
+  if (result.code !== null) {
+    return `exit code ${result.code} (no output from npm)`;
   }
   if (result.signal) {
-    parts.push(`signal ${result.signal}`);
+    return `signal ${result.signal} (no output from npm)`;
   }
-  if (parts.length === 0) {
-    return "npm exited with no output";
-  }
-  return `${parts.join(", ")} (no output from npm)`;
+  return `termination ${result.termination} (no output from npm)`;
 }
 
 async function hideProjectNpmConfigForInstall(targetDir: string): Promise<HiddenProjectConfigFile> {

--- a/src/infra/install-package-dir.ts
+++ b/src/infra/install-package-dir.ts
@@ -55,6 +55,42 @@ async function sanitizeManifestForNpmInstall(targetDir: string): Promise<void> {
   await writeJson(manifestPath, manifest, { trailingNewline: true });
 }
 
+/**
+ * Formats the failure suffix for `npm install failed:` messages when npm exits
+ * with a non-zero status. Prefers npm's own stderr/stdout when either is
+ * populated, but falls back to the exit code / signal / termination reason so
+ * users still get an actionable signal when npm returns empty output (observed
+ * on some npm 11 combinations for @openclaw/acpx installs, #98484).
+ */
+function formatNpmDependencyInstallFailure(result: {
+  stdout: string;
+  stderr: string;
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  termination?: "exit" | "timeout" | "no-output-timeout" | "signal";
+}): string {
+  const detail = result.stderr.trim() || result.stdout.trim();
+  if (detail) {
+    return detail;
+  }
+  const parts: string[] = [];
+  if (result.termination === "timeout") {
+    parts.push("timed out");
+  } else if (result.termination === "no-output-timeout") {
+    parts.push("exceeded no-output timeout");
+  }
+  if (typeof result.code === "number") {
+    parts.push(`exit code ${result.code}`);
+  }
+  if (result.signal) {
+    parts.push(`signal ${result.signal}`);
+  }
+  if (parts.length === 0) {
+    return "npm exited with no output";
+  }
+  return `${parts.join(", ")} (no output from npm)`;
+}
+
 async function hideProjectNpmConfigForInstall(targetDir: string): Promise<HiddenProjectConfigFile> {
   const originalPath = path.join(targetDir, STAGED_NPM_PROJECT_CONFIG_NAME);
   let hiddenDir = "";
@@ -281,7 +317,7 @@ export async function installPackageDir(params: {
         }
       })();
       if (npmRes.code !== 0) {
-        return await fail(`npm install failed: ${npmRes.stderr.trim() || npmRes.stdout.trim()}`);
+        return await fail(`npm install failed: ${formatNpmDependencyInstallFailure(npmRes)}`);
       }
     } catch (error) {
       return await fail(`npm install failed: ${String(error)}`, error);


### PR DESCRIPTION
Refs #98484.

## What Problem This Solves

When npm exits nonzero without writing stdout or stderr, `installPackageDir` currently reports only:

```text
npm install failed:
```

That blank primary error makes the later hook-pack fallback look like the root cause even for a valid plugin package such as `@openclaw/acpx`.

## Why This Change Was Made

`runCommandWithTimeout` already returns a typed `SpawnResult` with exit code, signal, and termination metadata. The failure formatter now:

1. preserves npm stderr or stdout when either is present;
2. otherwise reports the exit code;
3. otherwise reports the signal;
4. otherwise reports the termination reason.

Install behavior, cleanup, and the existing exception path are unchanged.

## User Impact

Silent npm failures now produce actionable diagnostics such as:

- `npm install failed: exit code 1 (no output from npm)`
- `npm install failed: signal SIGKILL (no output from npm)`
- `npm install failed: termination timeout (no output from npm)`

This PR improves the diagnostic only. It does not claim to fix the underlying ACPX 6.11 update/install failure tracked in #98484.

## Evidence

- `node scripts/run-vitest.mjs src/infra/install-package-dir.test.ts` - 15 passed
- Blacksmith Testbox `tbx_01kwephxx24d6v6bsqwpdsc907` - `corepack pnpm check:changed` passed
- Fresh autoreview on the final local diff - no accepted/actionable findings
- `git diff --check origin/main...HEAD` - clean

Focused tests retain the existing non-empty stderr behavior and table-drive empty-stream exit-code and signal failures.

Hosted CI is required on the pushed exact head before merge.

## AI Disclosure

This change was written with AI assistance. The contributor and maintainers reviewed the diff and tests.