### PR TITLE
fix(minimax): bound OAuth authorization JSON response to prevent unbounded read

### DIFF
--- a/extensions/minimax/oauth.test.ts
+++ b/extensions/minimax/oauth.test.ts
@@ -399,4 +399,24 @@ describe("loginMiniMaxPortalOAuth", () => {
     await vi.advanceTimersByTimeAsync(2_000);
     await expect(result).resolves.toMatchObject({ access: "access", refresh: "refresh" });
   });
+
+  it("fails closed when the OAuth authorization response exceeds the size cap", async () => {
+    // 300 KiB body — well above the 256 KiB cap.
+    const fetchMock = vi.fn(async () => {
+      return new Response('{"a":"' + "x".repeat(300 * 1024) + '"}', {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const error = await loginMiniMaxPortalOAuth({
+      openUrl: vi.fn(async () => undefined),
+      note: vi.fn(async () => undefined),
+      progress: { update: vi.fn(), stop: vi.fn() },
+    }).catch((cause: unknown) => cause);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain("exceeds");
+  });
 });

--- a/extensions/minimax/oauth.ts
+++ b/extensions/minimax/oauth.ts
@@ -8,6 +8,7 @@ import {
 } from "openclaw/plugin-sdk/number-runtime";
 import { generatePkceVerifierChallenge, toFormUrlEncoded } from "openclaw/plugin-sdk/provider-auth";
 import { readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
+import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import { ensureGlobalUndiciEnvProxyDispatcher } from "openclaw/plugin-sdk/runtime-env";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 
@@ -31,6 +32,7 @@ const MINIMAX_OAUTH_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:user_code";
 const MINIMAX_RELATIVE_EXPIRY_SECONDS_THRESHOLD = 1_000_000_000;
 const MINIMAX_ABSOLUTE_EXPIRY_MS_THRESHOLD = 1_000_000_000_000;
 const MINIMAX_OAUTH_ERROR_BODY_LIMIT_BYTES = 8 * 1024;
+const MINIMAX_OAUTH_JSON_MAX_BYTES = 256 * 1024; // 256 KiB — OAuth authorization responses are tiny
 
 function getOAuthEndpoints(region: MiniMaxRegion) {
   const config = MINIMAX_OAUTH_CONFIG[region];
@@ -121,7 +123,13 @@ async function requestOAuthCode(params: {
       throw new Error(`MiniMax OAuth authorization failed: ${text || response.statusText}`);
     }
 
-    const payload = (await response.json()) as MiniMaxOAuthAuthorization & { error?: string };
+    const bytes = await readResponseWithLimit(response, MINIMAX_OAUTH_JSON_MAX_BYTES, {
+      onOverflow: ({ size, maxBytes }) =>
+        new Error(`MiniMax OAuth authorization response exceeds ${maxBytes} bytes (got ${size})`),
+    });
+    const payload = JSON.parse(new TextDecoder().decode(bytes)) as MiniMaxOAuthAuthorization & {
+      error?: string;
+    };
     if (!payload.user_code || !payload.verification_uri) {
       throw new Error(
         payload.error ??


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the MiniMax OAuth authorization path (`requestOAuthCode`) reads the MiniMax device-code endpoint response with `await response.json()`, which has no size limit. The authorization endpoint is expected to return a tiny JSON object (under 1 KiB with `user_code`, `verification_uri`, `expired_in`, and `state`), but a misconfigured proxy, compromised endpoint, or MITM could stream an arbitrarily large body and exhaust the gateway process memory.

The affected surface is the MiniMax OAuth login flow, reached via `loginMiniMaxPortalOAuth` (the main OAuth entry point for MiniMax provider setup).

## Why This Change Was Made

Read the OAuth authorization response through the shared `readResponseWithLimit` helper (`openclaw/plugin-sdk/response-limit-runtime`) under a 256 KiB cap, then `JSON.parse` the resulting buffer. This mirrors the existing bounded-read precedent already used across the codebase (response-limit campaign — same helper, same decode shape).

The error-path reads (`readResponseTextLimited`) were already bounded for both the authorization and token endpoints, so this change only narrows the success-path read.

**Cap sizing:** 256 KiB is ~250× larger than any legitimate MiniMax device-code response (typically < 1 KiB). This is proportionate to the expected response size, matching the per-use-case sizing precedent.

**Design (fail-closed):** the bounded read is placed inside the existing `try/finally` in `requestOAuthCode`. On overflow the error propagates through `loginMiniMaxPortalOAuth` to the caller. Normal, in-bounds responses parse unchanged; the existing `user_code` / `verification_uri` / state validation is untouched.

**Non-goal:** this PR does not change the OAuth flow, token polling, PKCE challenge, or any public API signature.

## User Impact

MiniMax OAuth authorization exchanges are now protected from an OOM crash triggered by an oversized device-code endpoint response. On overflow the authorization fails with a clear error message. There is no user-visible change for normal OAuth responses. No config, API, or schema changes — purely an internal robustness improvement.

## Evidence

### Focused tests

```
node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-providers.config.ts extensions/minimax/oauth.test.ts

 Test Files  1 passed (1)
      Tests  13 passed (13)
```

New test:
- **fails closed when the OAuth authorization response exceeds the size cap** — creates a 300 KiB body (> 256 KiB cap) via a real `Response` object, drives the real `readResponseWithLimit` path through stubbed global `fetch`, verifies the error message contains "exceeds".

All 12 existing tests pass unchanged (authorization error body bounding, token error body bounding, HTTP 200 malformed token body, global/CN endpoint routing, expired_in normalization, token polling expiry, etc.), confirming the bounded read does not regress any OAuth flow.

### Lint

`oxlint --quiet` is clean (exit 0) on both changed files.

### Mutation check (test is load-bearing)

Temporarily removing the bounded read (restoring `await response.json()`) makes the oversized-body test pass because `response.json()` would buffer the full 300 KiB body without throwing — confirming the cap is load-bearing and the test guards the boundary.

<details>
<summary>Security and Privacy</summary>

- Hardening fix: removes an unbounded-memory read of an external (MiniMax OAuth) response, closing a DoS/OOM vector reachable via a compromised or MITM'd endpoint.
- No new data is logged, persisted, or transmitted; the error message contains only the byte limit, no response content.
- No new dependency — reuses the existing `openclaw/plugin-sdk/response-limit-runtime` helper.
- Fail-closed: oversized input is rejected rather than partially processed.

</details>

<details>
<summary>Compatibility</summary>

- Backwards compatible for all normal-size responses: the `user_code`, `verification_uri`, `expired_in`, and `state` extraction and validation are unchanged.
- Only oversized (>256 KiB) responses change outcome (now fail closed). 256 KiB is ~250× larger than any legitimate MiniMax device-code JSON response.
- No API, config, or schema changes. Blast radius is low: a single source file plus its self-contained test, no shared infra/mocks touched.

</details>

---

AI-assisted (Claude Code). Implementation and tests were authored with Claude Code (Anthropic). Degree of assistance: the helper-reuse pattern, the per-use-case cap sizing, and the focused tests were drafted by Claude Code, then reviewed and validated locally by the author (focused vitest run + oxlint). The author can explain the technical rationale: the bug is an unbounded `response.json()` buffer in the OAuth authorization path; the fix swaps in the shared bounded reader under a 256 KiB cap so an oversized body can never OOM the gateway process.
