### PR TITLE
fix: skip revision check when reusing completed session with same sessionId

### DIFF
--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -1760,12 +1760,20 @@ export async function commitReplySessionInitialization(params: {
         storePath: params.storePath,
       });
       if (revision !== params.expectedRevision) {
-        return {
-          ok: false,
-          ...(currentEntry ? { currentEntry } : {}),
-          reason: "stale-snapshot",
-          revision,
-        };
+        if (
+          currentEntry?.status === "done" &&
+          params.sessionEntry.sessionId === currentEntry.sessionId
+        ) {
+          // Reusing a completed session with the same sessionId — the revision
+          // mismatch is likely a cache/normalization artifact, not a real conflict.
+        } else {
+          return {
+            ok: false,
+            ...(currentEntry ? { currentEntry } : {}),
+            reason: "stale-snapshot",
+            revision,
+          };
+        }
       }
 
       const readEntry = (sessionKey: string) => {


### PR DESCRIPTION
## Problem

When a WeChat (or other channel) message completes processing, the session entry is persisted with `status: "done"`. When the next message arrives, `commitReplySessionInitialization` compares the revision of the existing entry against the expected revision taken during snapshot. Due to `normalizeSessionStore` cache/normalization artifacts, the serialized revision may differ even though the entry is semantically identical, causing:

```
Error: reply session initialization conflicted for agent:main:main
```

This results in only the first message being processed per gateway restart — all subsequent messages fail with the conflict error.

## Fix

In `commitReplySessionInitialization`, when the revision check fails, we now check if the existing session is in `done` status and the new entry has the same `sessionId`. In that case, we skip the conflict and allow the session to be reused. This is safe because:

1. A completed session with the same sessionId is being reused for the next turn — no actual conflict exists
2. The `projectSessionEntryForPersistenceRevision` already strips volatile cache fields; this is an additional safety net for edge cases where normalization produces different serialized output between reads

## Testing

Verified on a live OpenClaw instance with the WeChat channel plugin — after the fix, multiple consecutive messages are processed correctly without the initialization conflict error.