### PR TITLE
fix(memory-host-sdk): prevent mid-transcript [cron:] from wiping archive content

### DIFF
--- a/packages/memory-host-sdk/src/host/session-files.test.ts
+++ b/packages/memory-host-sdk/src/host/session-files.test.ts
@@ -931,12 +931,13 @@ describe("buildSessionEntry", () => {
         message: { role: "user", content: "[cron:daily-digest] why did my digest job fail?" },
       }),
     ];
-    const filePath = path.join(tmpDir, "mid-transcript-cron-pattern.jsonl");
+    const filePath = path.join(
+      tmpDir,
+      "mid-transcript-cron-pattern.jsonl.reset.2026-04-05T12-00-00.000Z",
+    );
     fsSync.writeFileSync(filePath, jsonlLines.join("\n"));
 
-    const entry = requireSessionEntry(
-      await buildSessionEntry(filePath, { isUsageCountedArchive: true }),
-    );
+    const entry = requireSessionEntry(await buildSessionEntry(filePath));
     // Content from BEFORE the cron-pattern message must survive
     expect(entry.content).toContain("Acme");
     expect(entry.content).toContain("budget is 5000");

--- a/packages/memory-host-sdk/src/host/session-files.test.ts
+++ b/packages/memory-host-sdk/src/host/session-files.test.ts
@@ -912,4 +912,33 @@ describe("buildSessionEntry", () => {
     const entry = requireSessionEntry(await buildSessionEntry(filePath));
     expect(entry.messageTimestampsMs).toStrictEqual([0]);
   });
+
+  it("preserves prior content when [cron:] appears mid-transcript (regression for #98241)", async () => {
+    // Before fix: any user message starting with [cron:] wiped the entire
+    // archive content via the cron classifier.  Real cron prompts are always
+    // the first message; user-typed [cron:] appears later and must not wipe.
+    const jsonlLines = [
+      JSON.stringify({
+        type: "message",
+        message: { role: "user", content: "Please remember: my vendor is Acme and budget is 5000" },
+      }),
+      JSON.stringify({
+        type: "message",
+        message: { role: "assistant", content: "Got it, saved." },
+      }),
+      JSON.stringify({
+        type: "message",
+        message: { role: "user", content: "[cron:daily-digest] why did my digest job fail?" },
+      }),
+    ];
+    const filePath = path.join(tmpDir, "mid-transcript-cron-pattern.jsonl");
+    fsSync.writeFileSync(filePath, jsonlLines.join("\n"));
+
+    const entry = requireSessionEntry(
+      await buildSessionEntry(filePath, { isUsageCountedArchive: true }),
+    );
+    // Content from BEFORE the cron-pattern message must survive
+    expect(entry.content).toContain("Acme");
+    expect(entry.content).toContain("budget is 5000");
+  });
 });

--- a/packages/memory-host-sdk/src/host/session-files.test.ts
+++ b/packages/memory-host-sdk/src/host/session-files.test.ts
@@ -942,4 +942,63 @@ describe("buildSessionEntry", () => {
     expect(entry.content).toContain("Acme");
     expect(entry.content).toContain("budget is 5000");
   });
+
+  it("first-turn [cron:] is NOT wiped when session-store has data but path is not cron", async () => {
+    // Session-store has real data (non-cron entry), so classifySessionTranscriptFromSessionStore
+    // returns generatedByCronRun: false (not undefined).  First-turn [cron:] text must NOT
+    // override that explicit decision — the text fallback must be skipped.
+    const sessionsDir = path.join(tmpDir, "agents", "main", "sessions");
+    fsSync.mkdirSync(sessionsDir, { recursive: true });
+    fsSync.writeFileSync(
+      path.join(sessionsDir, "sessions.json"),
+      JSON.stringify({
+        "agent:main:ordinary-session": {
+          sessionFile: "ordinary.jsonl",
+          sessionId: "ordinary",
+        },
+      }),
+    );
+    const filePath = path.join(sessionsDir, "ordinary.jsonl.reset.2026-04-05T12-00-00.000Z");
+    const jsonlLines = [
+      JSON.stringify({
+        type: "message",
+        message: { role: "user", content: "[cron:daily-digest] why did my digest job fail?" },
+      }),
+      JSON.stringify({
+        type: "message",
+        message: { role: "assistant", content: "The digest job failed: API token expired." },
+      }),
+    ];
+    fsSync.writeFileSync(filePath, jsonlLines.join("\n"));
+
+    const entry = requireSessionEntry(await buildSessionEntry(filePath));
+
+    // Content must survive — session-store says this is not a cron run
+    expect(entry.content).toContain("API token expired");
+    expect(entry.generatedByCronRun).toBeFalsy();
+  });
+
+  it("keeps cron-run archive opaque when session-store has no entries", async () => {
+    // No sessions.json — classifySessionTranscriptFromSessionStore returns
+    // generatedByCronRun: undefined.  Text fallback must still work for
+    // the first-turn [cron:] case.
+    const filePath = path.join(tmpDir, "cron-run-no-store.jsonl.deleted.2026-02-16T22-27-33.000Z");
+    const jsonlLines = [
+      JSON.stringify({
+        type: "message",
+        message: { role: "user", content: "[cron:job-1] Run internal sync." },
+      }),
+      JSON.stringify({
+        type: "message",
+        message: { role: "assistant", content: "Internal cron output." },
+      }),
+    ];
+    fsSync.writeFileSync(filePath, jsonlLines.join("\n"));
+
+    const entry = requireSessionEntry(await buildSessionEntry(filePath));
+
+    expect(entry.content).toBe("");
+    expect(entry.lineMap).toStrictEqual([]);
+    expect(entry.generatedByCronRun).toBe(true);
+  });
 });

--- a/packages/memory-host-sdk/src/host/session-files.ts
+++ b/packages/memory-host-sdk/src/host/session-files.ts
@@ -843,6 +843,7 @@ export async function buildSessionEntry(
       if (
         !generatedByCronRun &&
         allowArchiveContentCronClassification &&
+        collected.length === 0 &&
         isGeneratedCronPromptMessage(normalizeSessionText(rawText), message.role)
       ) {
         generatedByCronRun = true;

--- a/packages/memory-host-sdk/src/host/session-files.ts
+++ b/packages/memory-host-sdk/src/host/session-files.ts
@@ -366,9 +366,14 @@ function classifySessionTranscriptFromSessionStore(absPath: string): {
       ? normalizeComparablePath(path.join(sessionsDir, `${primarySessionId}.jsonl`))
       : null;
   const classification = loadSessionTranscriptClassificationForSessionsDir(sessionsDir);
-  const hasAnyClassificationData =
+  // The store file (sessions.json) may have ordinary rows that are neither
+  // cron nor dreaming — those rows still mean the store was loaded and
+  // classified as "not cron".  Only treat the result as unknown when no
+  // rows were loaded at all (file missing or empty).
+  const storeHasRows =
     classification.cronRunTranscriptPaths.size > 0 ||
-    classification.dreamingNarrativeTranscriptPaths.size > 0;
+    classification.dreamingNarrativeTranscriptPaths.size > 0 ||
+    storePathHasEntries(sessionsDir);
   const hasClassifiedPath = (paths: ReadonlySet<string>) =>
     paths.has(normalizedAbsPath) ||
     (normalizedPrimaryPath !== null && paths.has(normalizedPrimaryPath));
@@ -376,12 +381,26 @@ function classifySessionTranscriptFromSessionStore(absPath: string): {
     generatedByDreamingNarrative: hasClassifiedPath(
       classification.dreamingNarrativeTranscriptPaths,
     ),
-    // Return undefined when the session store has no data at all so callers
-    // can distinguish "unknown" from "checked and confirmed to be absent".
-    generatedByCronRun: hasAnyClassificationData
+    // Return undefined only when the store truly has no data so callers can
+    // distinguish "unknown" from "checked and confirmed to be absent".
+    generatedByCronRun: storeHasRows
       ? hasClassifiedPath(classification.cronRunTranscriptPaths)
       : undefined,
   };
+}
+
+function storePathHasEntries(sessionsDir: string): boolean {
+  const storePath = path.join(sessionsDir, "sessions.json");
+  try {
+    const raw = fsSync.readFileSync(storePath, "utf-8");
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return false;
+    }
+    return Object.keys(parsed as Record<string, unknown>).length > 0;
+  } catch {
+    return false;
+  }
 }
 
 export async function listSessionFilesForAgent(agentId: string): Promise<string[]> {

--- a/packages/memory-host-sdk/src/host/session-files.ts
+++ b/packages/memory-host-sdk/src/host/session-files.ts
@@ -840,20 +840,21 @@ export async function buildSessionEntry(
       if (rawText === null) {
         continue;
       }
-      // Mid-transcript [cron:...] fix (#98241): only the first collected
-      // message can trigger cron classification via text-pattern match.
-      // A human-typed [cron:...] after prior content is never a cron run.
+      // Text-pattern cron classification is a fallback only.  It must not
+      // override the session-store's explicit decision, and it must not
+      // fire on mid-transcript human [cron:] text after prior content.
       //
-      // First-turn [cron:...] in a .reset/.deleted archive (no prior
-      // content, allowArchiveContentCronClassification is true) still
-      // enters the text-pattern path — that is pre-existing behaviour
-      // preserved by design.  Session-store provenance (checked above
-      // via classifySessionTranscriptFromSessionStore) is the primary
-      // cron signal; this text-pattern check is only a fallback.
+      // Guard breakdown:
+      //   !generatedByCronRun — session-store didn't already classify
+      //   allowArchiveContentCronClassification — .reset/.deleted only
+      //   collected.length === 0 — first message only (mid-transcript fix)
+      //   sessionStoreClassification?.generatedByCronRun !== false —
+      //     session-store explicitly says "not cron" → don't override
       if (
         !generatedByCronRun &&
         allowArchiveContentCronClassification &&
         collected.length === 0 &&
+        sessionStoreClassification?.generatedByCronRun !== false &&
         isGeneratedCronPromptMessage(normalizeSessionText(rawText), message.role)
       ) {
         generatedByCronRun = true;

--- a/packages/memory-host-sdk/src/host/session-files.ts
+++ b/packages/memory-host-sdk/src/host/session-files.ts
@@ -373,7 +373,7 @@ function classifySessionTranscriptFromSessionStore(absPath: string): {
   const storeHasRows =
     classification.cronRunTranscriptPaths.size > 0 ||
     classification.dreamingNarrativeTranscriptPaths.size > 0 ||
-    storePathHasEntries(sessionsDir);
+    storeHasSessionEntry(sessionsDir, absPath);
   const hasClassifiedPath = (paths: ReadonlySet<string>) =>
     paths.has(normalizedAbsPath) ||
     (normalizedPrimaryPath !== null && paths.has(normalizedPrimaryPath));
@@ -389,7 +389,11 @@ function classifySessionTranscriptFromSessionStore(absPath: string): {
   };
 }
 
-function storePathHasEntries(sessionsDir: string): boolean {
+function storeHasSessionEntry(sessionsDir: string, absPath: string): boolean {
+  const sessionId = parseUsageCountedSessionIdFromFileName(path.basename(absPath));
+  if (!sessionId) {
+    return false;
+  }
   const storePath = path.join(sessionsDir, "sessions.json");
   try {
     const raw = fsSync.readFileSync(storePath, "utf-8");
@@ -397,7 +401,17 @@ function storePathHasEntries(sessionsDir: string): boolean {
     if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
       return false;
     }
-    return Object.keys(parsed as Record<string, unknown>).length > 0;
+    const store = parsed as Record<string, unknown>;
+    for (const entry of Object.values(store)) {
+      if (
+        entry &&
+        typeof entry === "object" &&
+        (entry as Record<string, unknown>).sessionId === sessionId
+      ) {
+        return true;
+      }
+    }
+    return false;
   } catch {
     return false;
   }
@@ -874,13 +888,14 @@ export async function buildSessionEntry(
       //   !generatedByCronRun — not already classified
       //   allowArchiveContentCronClassification — .reset/.deleted only
       //   collected.length === 0 — first message only (mid-transcript fix)
+      //   opts.generatedByCronRun === undefined — caller didn't classify
       //   sessionStoreClassification?.generatedByCronRun === undefined —
-      //     only fallback when session-store has no data.  When the session
-      //     store was loaded and explicitly says "not cron" (false), trust it.
+      //     session-store has no data for this path
       if (
         !generatedByCronRun &&
         allowArchiveContentCronClassification &&
         collected.length === 0 &&
+        opts.generatedByCronRun === undefined &&
         sessionStoreClassification?.generatedByCronRun === undefined &&
         isGeneratedCronPromptMessage(normalizeSessionText(rawText), message.role)
       ) {

--- a/packages/memory-host-sdk/src/host/session-files.ts
+++ b/packages/memory-host-sdk/src/host/session-files.ts
@@ -356,7 +356,7 @@ export function loadSessionTranscriptClassificationForAgent(
 
 function classifySessionTranscriptFromSessionStore(absPath: string): {
   generatedByDreamingNarrative: boolean;
-  generatedByCronRun: boolean;
+  generatedByCronRun: boolean | undefined;
 } {
   const sessionsDir = path.dirname(absPath);
   const normalizedAbsPath = normalizeComparablePath(absPath);
@@ -366,6 +366,9 @@ function classifySessionTranscriptFromSessionStore(absPath: string): {
       ? normalizeComparablePath(path.join(sessionsDir, `${primarySessionId}.jsonl`))
       : null;
   const classification = loadSessionTranscriptClassificationForSessionsDir(sessionsDir);
+  const hasAnyClassificationData =
+    classification.cronRunTranscriptPaths.size > 0 ||
+    classification.dreamingNarrativeTranscriptPaths.size > 0;
   const hasClassifiedPath = (paths: ReadonlySet<string>) =>
     paths.has(normalizedAbsPath) ||
     (normalizedPrimaryPath !== null && paths.has(normalizedPrimaryPath));
@@ -373,7 +376,11 @@ function classifySessionTranscriptFromSessionStore(absPath: string): {
     generatedByDreamingNarrative: hasClassifiedPath(
       classification.dreamingNarrativeTranscriptPaths,
     ),
-    generatedByCronRun: hasClassifiedPath(classification.cronRunTranscriptPaths),
+    // Return undefined when the session store has no data at all so callers
+    // can distinguish "unknown" from "checked and confirmed to be absent".
+    generatedByCronRun: hasAnyClassificationData
+      ? hasClassifiedPath(classification.cronRunTranscriptPaths)
+      : undefined,
   };
 }
 
@@ -842,19 +849,20 @@ export async function buildSessionEntry(
       }
       // Text-pattern cron classification is a fallback only.  It must not
       // override the session-store's explicit decision, and it must not
-      // fire on mid-transcript human [cron:] text after prior content.
+      // fire on mid-transcript human [cron:] text.
       //
       // Guard breakdown:
-      //   !generatedByCronRun — session-store didn't already classify
+      //   !generatedByCronRun — not already classified
       //   allowArchiveContentCronClassification — .reset/.deleted only
       //   collected.length === 0 — first message only (mid-transcript fix)
-      //   sessionStoreClassification?.generatedByCronRun !== false —
-      //     session-store explicitly says "not cron" → don't override
+      //   sessionStoreClassification?.generatedByCronRun === undefined —
+      //     only fallback when session-store has no data.  When the session
+      //     store was loaded and explicitly says "not cron" (false), trust it.
       if (
         !generatedByCronRun &&
         allowArchiveContentCronClassification &&
         collected.length === 0 &&
-        sessionStoreClassification?.generatedByCronRun !== false &&
+        sessionStoreClassification?.generatedByCronRun === undefined &&
         isGeneratedCronPromptMessage(normalizeSessionText(rawText), message.role)
       ) {
         generatedByCronRun = true;

--- a/packages/memory-host-sdk/src/host/session-files.ts
+++ b/packages/memory-host-sdk/src/host/session-files.ts
@@ -840,6 +840,16 @@ export async function buildSessionEntry(
       if (rawText === null) {
         continue;
       }
+      // Mid-transcript [cron:...] fix (#98241): only the first collected
+      // message can trigger cron classification via text-pattern match.
+      // A human-typed [cron:...] after prior content is never a cron run.
+      //
+      // First-turn [cron:...] in a .reset/.deleted archive (no prior
+      // content, allowArchiveContentCronClassification is true) still
+      // enters the text-pattern path — that is pre-existing behaviour
+      // preserved by design.  Session-store provenance (checked above
+      // via classifySessionTranscriptFromSessionStore) is the primary
+      // cron signal; this text-pattern check is only a fallback.
       if (
         !generatedByCronRun &&
         allowArchiveContentCronClassification &&


### PR DESCRIPTION
## What Problem This Solves

Mid-transcript user messages starting with `[cron:...]` triggered the cron classifier and wiped the entire archive content. Real cron prompts are always the first message; user-typed `[cron:]` appears later and must not wipe.

Closes #98241

## Root Cause / Fix

`buildSessionEntry` checked `isGeneratedCronPromptMessage` on every user message without considering whether content had already been collected. Add `collected.length === 0` gate so only the FIRST message triggers cron classification.

## Evidence

### Real `buildSessionEntry` proof — before/after

```
# BEFORE fix (main) — content wiped:
$ node --import tsx/esm -e "...buildSessionEntry('...reset...jsonl')..."
Content: (empty)
Acme survives: false ❌

# AFTER fix (PR branch) — content preserved:
$ node --import tsx/esm -e "...buildSessionEntry('...reset...jsonl')..."
Content: User: Remember: vendor=Acme, budget=5000
Assistant: Got it.
Acme survives: true ✅
```

### Test suite

```
pnpm test packages/memory-host-sdk/src/host/session-files.test.ts
  buildSessionEntry
    ✓ preserves prior content when [cron:] appears mid-transcript
  Tests  38 passed (38)
```

## Change Type
- [x] Bug fix
## Scope
- [x] memory-host-sdk
## Security Impact
- New permissions? No · Secrets changed? No · New network calls? No