### PR TITLE
fix: suppress google chat plugin approval fallbacks

### DIFF
--- a/extensions/googlechat/src/approval-card-actions.test.ts
+++ b/extensions/googlechat/src/approval-card-actions.test.ts
@@ -11,8 +11,9 @@ const approvalId = "12345678-1234-1234-1234-123456789012";
 type TestExecApprovalDecision = "allow-once" | "allow-always" | "deny";
 let tokenCounter = 0;
 
-function registerExecApprovalCard(overrides?: {
+function registerApprovalCard(overrides?: {
   approvalId?: string;
+  approvalKind?: "exec" | "plugin";
   expiresAtMs?: number;
   allowedDecisions?: readonly TestExecApprovalDecision[];
 }): void {
@@ -20,7 +21,7 @@ function registerExecApprovalCard(overrides?: {
     token: `token-${tokenCounter++}`,
     accountId: "default",
     approvalId: overrides?.approvalId ?? approvalId,
-    approvalKind: "exec",
+    approvalKind: overrides?.approvalKind ?? "exec",
     decision: "allow-once",
     allowedDecisions: overrides?.allowedDecisions ?? ["allow-once", "deny"],
     spaceName: "spaces/AAA",
@@ -36,7 +37,7 @@ describe("Google Chat approval card action registry", () => {
   });
 
   it("suppresses manual exec approval follow-up text for an active native card", () => {
-    registerExecApprovalCard();
+    registerApprovalCard();
 
     expect(
       shouldSuppressGoogleChatManualExecApprovalFollowupText(
@@ -65,8 +66,35 @@ describe("Google Chat approval card action registry", () => {
     ).toBe(true);
   });
 
+  it("suppresses manual plugin approval follow-up text for native delivery", () => {
+    const pluginApprovalId = "plugin:12345678-1234-1234-1234-123456789012";
+
+    registerApprovalCard({
+      approvalId: pluginApprovalId,
+      approvalKind: "plugin",
+    });
+    expect(
+      shouldSuppressGoogleChatManualExecApprovalFollowupText(
+        `Run this if needed: \`/approve ${pluginApprovalId} deny\``,
+      ),
+    ).toBe(true);
+
+    clearGoogleChatApprovalCardBindingsForTest();
+    registerGoogleChatManualApprovalFollowupSuppression({
+      approvalId: pluginApprovalId,
+      approvalKind: "plugin",
+      allowedDecisions: ["allow-once", "deny"],
+      expiresAtMs: Date.now() + 60_000,
+    });
+    expect(
+      shouldSuppressGoogleChatManualExecApprovalFollowupText(
+        `Please reply with:\n/approve ${pluginApprovalId} allow-once`,
+      ),
+    ).toBe(true);
+  });
+
   it("keeps unrelated, expired, and non-sendable approval text visible", () => {
-    registerExecApprovalCard({ expiresAtMs: Date.now() - 1 });
+    registerApprovalCard({ expiresAtMs: Date.now() - 1 });
     expect(
       shouldSuppressGoogleChatManualExecApprovalFollowupText(
         `/approve ${approvalId.slice(0, 8)} allow-once`,
@@ -74,7 +102,7 @@ describe("Google Chat approval card action registry", () => {
     ).toBe(false);
 
     clearGoogleChatApprovalCardBindingsForTest();
-    registerExecApprovalCard();
+    registerApprovalCard();
     expect(
       shouldSuppressGoogleChatManualExecApprovalFollowupText("/approve deadbeef allow-once"),
     ).toBe(false);
@@ -84,7 +112,7 @@ describe("Google Chat approval card action registry", () => {
   });
 
   it("suppresses only text-only manual approval follow-up payloads", () => {
-    registerExecApprovalCard();
+    registerApprovalCard();
 
     expect(
       shouldSuppressGoogleChatManualExecApprovalFollowupPayload({

--- a/extensions/googlechat/src/approval-card-actions.ts
+++ b/extensions/googlechat/src/approval-card-actions.ts
@@ -7,7 +7,7 @@ export const GOOGLECHAT_APPROVAL_ACTION = "openclaw.approval";
 const GOOGLECHAT_APPROVAL_ACTION_PARAM = "openclaw_action";
 const GOOGLECHAT_APPROVAL_TOKEN_PARAM = "token";
 const GOOGLECHAT_APPROVAL_ACTION_VALUE = "approval";
-const MANUAL_EXEC_APPROVAL_COMMAND_RE =
+const MANUAL_APPROVAL_COMMAND_RE =
   /(?:^|[\s`])\/approve[ \t]+([^ \t\r\n`|]+)[ \t]+(allow-once|allow-always|deny)(?=$|[\s`|.,;:!?])/giu;
 
 export type GoogleChatApprovalCardBinding = {
@@ -193,7 +193,7 @@ function pruneExpiredGoogleChatApprovalCardBindings(nowMs: number): void {
   }
 }
 
-function hasActiveGoogleChatExecApprovalCardForManualCommand(params: {
+function hasActiveGoogleChatApprovalCardForManualCommand(params: {
   approvalRef: string;
   decision: ExecApprovalDecision;
   nowMs: number;
@@ -201,7 +201,6 @@ function hasActiveGoogleChatExecApprovalCardForManualCommand(params: {
   pruneExpiredGoogleChatApprovalCardBindings(params.nowMs);
   for (const binding of approvalCardBindings.values()) {
     if (
-      binding.approvalKind === "exec" &&
       binding.allowedDecisions.includes(params.decision) &&
       approvalRefMatches(binding.approvalId, params.approvalRef)
     ) {
@@ -210,7 +209,6 @@ function hasActiveGoogleChatExecApprovalCardForManualCommand(params: {
   }
   for (const suppression of manualApprovalFollowupSuppressions.values()) {
     if (
-      suppression.approvalKind === "exec" &&
       suppression.allowedDecisions.includes(params.decision) &&
       approvalRefMatches(suppression.approvalId, params.approvalRef)
     ) {
@@ -224,13 +222,13 @@ export function shouldSuppressGoogleChatManualExecApprovalFollowupText(
   text: string,
   nowMs = Date.now(),
 ): boolean {
-  for (const match of text.matchAll(MANUAL_EXEC_APPROVAL_COMMAND_RE)) {
+  for (const match of text.matchAll(MANUAL_APPROVAL_COMMAND_RE)) {
     const approvalRef = match[1];
     const decision = match[2]?.toLowerCase() as ExecApprovalDecision | undefined;
     if (
       approvalRef &&
       decision &&
-      hasActiveGoogleChatExecApprovalCardForManualCommand({ approvalRef, decision, nowMs })
+      hasActiveGoogleChatApprovalCardForManualCommand({ approvalRef, decision, nowMs })
     ) {
       return true;
     }

--- a/extensions/googlechat/src/approval-native.test.ts
+++ b/extensions/googlechat/src/approval-native.test.ts
@@ -330,6 +330,31 @@ describe("googleChatApprovalCapability", () => {
     ).toBe(true);
   });
 
+  it("suppresses the local plugin prompt when a Google Chat native route is active", () => {
+    expect(
+      shouldSuppressLocalGoogleChatExecApprovalPrompt({
+        cfg: {
+          approvals: { plugin: { enabled: true } },
+          channels: { googlechat: GOOGLE_CHAT_APPROVAL_ACCOUNT },
+        },
+        payload: {
+          channelData: {
+            execApproval: {
+              approvalId: "plugin:12345678-1234-1234-1234-123456789012",
+              approvalSlug: "plugin:12345678",
+              approvalKind: "plugin",
+            },
+          },
+        },
+        hint: {
+          kind: "approval-pending",
+          approvalKind: "plugin",
+          nativeRouteActive: true,
+        },
+      }),
+    ).toBe(true);
+  });
+
   it("keeps the local exec prompt when native Google Chat delivery cannot own it", () => {
     expect(
       shouldSuppressLocalGoogleChatExecApprovalPrompt({

--- a/extensions/googlechat/src/channel-config.test.ts
+++ b/extensions/googlechat/src/channel-config.test.ts
@@ -61,9 +61,9 @@ describe("googlechatPlugin config adapter", () => {
     );
   });
 
-  it("wires native exec approval suppression through the outbound adapter", () => {
+  it("wires native approval suppression through the outbound adapter", () => {
     const cfg = {
-      approvals: { exec: { enabled: true } },
+      approvals: { exec: { enabled: true }, plugin: { enabled: true } },
       channels: {
         googlechat: {
           serviceAccount: {
@@ -100,6 +100,28 @@ describe("googlechatPlugin config adapter", () => {
         cfg,
         payload,
         hint,
+      }),
+    ).toBe(true);
+
+    expect(
+      googlechatPlugin.outbound?.shouldSuppressLocalPayloadPrompt?.({
+        cfg,
+        payload: {
+          channelData: {
+            execApproval: {
+              approvalId: "plugin:12345678-1234-1234-1234-123456789012",
+              approvalSlug: "plugin:12345678",
+              approvalKind: "plugin",
+              agentId: "dev",
+              sessionKey: "agent:dev:main",
+            },
+          },
+        },
+        hint: {
+          kind: "approval-pending",
+          approvalKind: "plugin",
+          nativeRouteActive: true,
+        },
       }),
     ).toBe(true);
   });

--- a/src/plugin-sdk/approval-native-helpers.test.ts
+++ b/src/plugin-sdk/approval-native-helpers.test.ts
@@ -590,6 +590,23 @@ describe("shouldSuppressLocalNativeExecApprovalPrompt", () => {
     approvalKind: "exec",
     nativeRouteActive: true,
   } as const;
+  const pluginPayload = {
+    text: "Approval required.",
+    channelData: {
+      execApproval: {
+        approvalId: "plugin:12345678-1234-1234-1234-123456789012",
+        approvalSlug: "plugin:12345678",
+        approvalKind: "plugin",
+        agentId: "main",
+        sessionKey: "agent:main:discord:direct:123",
+      },
+    },
+  };
+  const activePluginHint = {
+    kind: "approval-pending",
+    approvalKind: "plugin",
+    nativeRouteActive: true,
+  } as const;
 
   it("supports strict top-level native exec suppression", () => {
     expect(
@@ -653,6 +670,56 @@ describe("shouldSuppressLocalNativeExecApprovalPrompt", () => {
         }),
         enforceForwardingMode: false,
         fallbackAgentIdFromSessionKey: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("supports strict top-level native plugin suppression", () => {
+    expect(
+      shouldSuppressLocalNativeExecApprovalPrompt({
+        cfg: {
+          approvals: {
+            plugin: {
+              enabled: true,
+              agentFilter: ["main"],
+            },
+          },
+        },
+        payload: pluginPayload,
+        hint: activePluginHint,
+        isTransportEnabled: () => true,
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldSuppressLocalNativeExecApprovalPrompt({
+        cfg: {
+          approvals: {
+            exec: {
+              enabled: true,
+              agentFilter: ["main"],
+            },
+          },
+        },
+        payload: pluginPayload,
+        hint: activePluginHint,
+        isTransportEnabled: () => true,
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldSuppressLocalNativeExecApprovalPrompt({
+        cfg: {
+          approvals: {
+            plugin: {
+              enabled: true,
+              agentFilter: ["main"],
+            },
+          },
+        },
+        payload: pluginPayload,
+        hint: activeExecHint,
+        isTransportEnabled: () => true,
       }),
     ).toBe(false);
   });

--- a/src/plugin-sdk/approval-native-helpers.ts
+++ b/src/plugin-sdk/approval-native-helpers.ts
@@ -271,15 +271,15 @@ export function nativeApprovalTargetsMatch(params: {
   });
 }
 
-/** Decide whether a channel-native exec approval route replaces the local text prompt. */
+/** Decide whether a channel-native approval route replaces the local text prompt. */
 export function shouldSuppressLocalNativeExecApprovalPrompt(params: {
   /** Full config containing top-level or channel-specific approval settings. */
   cfg: OpenClawConfig;
   /** Optional channel account id for account-scoped native delivery checks. */
   accountId?: string | null;
-  /** Reply payload that may already contain exec approval metadata. */
+  /** Reply payload that may already contain approval metadata. */
   payload: ReplyPayload;
-  /** Outbound payload hint proving an active native exec approval route. */
+  /** Outbound payload hint proving an active native approval route. */
   hint?: ChannelOutboundPayloadHint;
   /** Legacy transport gate for native delivery. */
   isTransportEnabled?: (params: { cfg: OpenClawConfig; accountId?: string | null }) => boolean;
@@ -306,14 +306,14 @@ export function shouldSuppressLocalNativeExecApprovalPrompt(params: {
   /** Whether agent filters may fall back to the agent segment in sessionKey. */
   fallbackAgentIdFromSessionKey?: boolean;
 }): boolean {
-  if (params.hint?.kind !== "approval-pending" || params.hint.approvalKind !== "exec") {
+  if (params.hint?.kind !== "approval-pending") {
     return false;
   }
   if (params.hint.nativeRouteActive !== true) {
     return false;
   }
   const metadata = getExecApprovalReplyMetadata(params.payload);
-  if (!metadata || metadata.approvalKind !== "exec") {
+  if (!metadata || metadata.approvalKind !== params.hint.approvalKind) {
     return false;
   }
   const isDeliveryEnabled = params.isNativeDeliveryEnabled ?? params.isTransportEnabled;
@@ -325,7 +325,10 @@ export function shouldSuppressLocalNativeExecApprovalPrompt(params: {
       cfg: params.cfg,
       accountId: params.accountId,
       metadata,
-    }) ?? params.cfg.approvals?.exec;
+    }) ??
+    (metadata.approvalKind === "plugin"
+      ? params.cfg.approvals?.plugin
+      : params.cfg.approvals?.exec);
   const requireConfigEnabled =
     params.requireApprovalConfigEnabled ?? params.resolveApprovalConfig === undefined;
   if (requireConfigEnabled && !config?.enabled) {


### PR DESCRIPTION
Fixes #98518

## Summary
- allow the shared native approval prompt suppression helper to suppress plugin approvals when the payload metadata and outbound hint both identify a plugin approval
- make Google Chat manual approval follow-up suppression honor active plugin approval card bindings and pre-binding suppressions
- add regression coverage for plugin approval suppression in the shared helper and Google Chat outbound/native card paths

## Tests
- `node scripts/run-with-env.mjs OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 -- node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts src/plugin-sdk/approval-native-helpers.test.ts --testTimeout=30000 --reporter=dot`
- `node scripts/run-with-env.mjs OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 -- node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-messaging.config.ts googlechat/src/approval-card-actions.test.ts --testTimeout=30000 --reporter=dot`
- `node scripts/run-with-env.mjs OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 -- node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-messaging.config.ts googlechat/src/channel-config.test.ts --testTimeout=30000 --reporter=dot`
- `node scripts/run-with-env.mjs OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 -- node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-messaging.config.ts googlechat/src/approval-native.test.ts --testTimeout=30000 --reporter=dot`
- `git diff --check`