### PR TITLE
fix: reload pending approvals after control ui reconnect

### DIFF
--- a/ui/src/ui/app-gateway-chat-load.node.test.ts
+++ b/ui/src/ui/app-gateway-chat-load.node.test.ts
@@ -144,6 +144,7 @@ vi.mock("./controllers/exec-approval.ts", () => ({
   parseExecApprovalResolved: vi.fn(() => null),
   parsePluginApprovalRequested: vi.fn(() => null),
   pruneExecApprovalQueue: vi.fn((queue) => queue),
+  refreshPendingApprovalQueue: vi.fn(async () => undefined),
   removeExecApproval: vi.fn((queue) => queue),
 }));
 

--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -964,6 +964,53 @@ describe("connectGateway", () => {
     expect(host.execApprovalQueue[0]?.id).toBe("approval-1");
   });
 
+  it("loads pending approval requests after reconnect hello", async () => {
+    const now = Date.now();
+    const { host, client } = connectHostGateway();
+    client.request.mockImplementation(async (method: string) => {
+      if (method === "exec.approval.list") {
+        return [
+          {
+            id: "approval-exec-reconnected",
+            request: {
+              command: "pnpm check:changed",
+              host: "gateway",
+            },
+            createdAtMs: now,
+            expiresAtMs: now + 60_000,
+          },
+        ];
+      }
+      if (method === "plugin.approval.list") {
+        return [
+          {
+            id: "approval-plugin-reconnected",
+            request: {
+              title: "Allow plugin action",
+              description: "Plugin action requires confirmation.",
+              pluginId: "calendar",
+            },
+            createdAtMs: now + 1,
+            expiresAtMs: now + 60_000,
+          },
+        ];
+      }
+      return {};
+    });
+
+    client.emitHello();
+
+    await vi.waitFor(() => {
+      expect(host.execApprovalQueue.map((entry) => entry.id)).toEqual([
+        "approval-plugin-reconnected",
+        "approval-exec-reconnected",
+      ]);
+    });
+    expect(client.request).toHaveBeenCalledWith("exec.approval.list", {});
+    expect(client.request).toHaveBeenCalledWith("plugin.approval.list", {});
+    expect(host.execApprovalQueue.map((entry) => entry.kind)).toEqual(["plugin", "exec"]);
+  });
+
   it("maps generic fetch-failed auth errors to actionable token mismatch message", () => {
     const host = createHost();
 

--- a/ui/src/ui/app-gateway.sessions.node.test.ts
+++ b/ui/src/ui/app-gateway.sessions.node.test.ts
@@ -76,6 +76,7 @@ vi.mock("./controllers/exec-approval.ts", () => ({
   parseExecApprovalResolved: vi.fn(() => null),
   parsePluginApprovalRequested: vi.fn(() => null),
   pruneExecApprovalQueue: vi.fn((queue) => queue),
+  refreshPendingApprovalQueue: vi.fn(async () => undefined),
   removeExecApproval: vi.fn(),
 }));
 vi.mock("./controllers/nodes.ts", () => ({

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -63,6 +63,7 @@ import {
   parseExecApprovalResolved,
   parsePluginApprovalRequested,
   pruneExecApprovalQueue,
+  refreshPendingApprovalQueue,
 } from "./controllers/exec-approval.ts";
 import { loadHealthState, type HealthState } from "./controllers/health.ts";
 import {
@@ -848,6 +849,7 @@ export function connectGateway(host: GatewayHost, options?: ConnectGatewayOption
             console.warn("[openclaw] pending abort failed:", err);
           });
       }
+      void refreshPendingApprovalQueue(host);
       // Reset orphaned chat run state from before disconnect.
       // Any in-flight run's final event was lost during the disconnect window.
       const orphanedRunId = host.chatRunId;


### PR DESCRIPTION
Fixes #98523

## Summary
- refresh pending exec/plugin approval lists after a successful Control UI hello/reconnect
- keep existing pending abort processing ahead of the refresh so reconnect abort behavior is unchanged
- cover reconnect hydration with both exec and plugin pending approvals

## Tests
- `node scripts/run-with-env.mjs OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 -- node scripts/run-vitest.mjs run --config test/vitest/vitest.ui.config.ts ui/src/ui/app-gateway.node.test.ts ui/src/ui/app-gateway-chat-load.node.test.ts ui/src/ui/app-gateway.sessions.node.test.ts --testTimeout=30000 --reporter=dot`
- `git diff --check`