### PR TITLE
fix(agents): Anthropic replay fails after boundaryless compaction

### DIFF
--- a/src/agents/embedded-agent-runner/replay-history.ts
+++ b/src/agents/embedded-agent-runner/replay-history.ts
@@ -1,6 +1,8 @@
 /**
  * Sanitizes and validates replayed session history before model calls.
  */
+import { createReadStream, statSync } from "node:fs";
+import { createInterface } from "node:readline";
 import { stripInternalMetadataForDisplay } from "../../auto-reply/reply/display-text-sanitize.js";
 import { isSilentReplyPayloadText, SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -66,6 +68,8 @@ import {
 } from "./thinking.js";
 
 const MODEL_SNAPSHOT_CUSTOM_TYPE = "model-snapshot";
+const PARENT_COMPACTION_SCAN_MAX_BYTES = 64 * 1024 * 1024;
+const MAX_PARENT_COMPACTION_SCAN_CACHE_ENTRIES = 8;
 type CustomEntryLike = { type?: unknown; customType?: unknown; data?: unknown };
 type ModelSnapshotEntry = {
   timestamp: number;
@@ -74,6 +78,17 @@ type ModelSnapshotEntry = {
   modelId?: string;
 };
 type AssistantReplayMessage = Extract<AgentMessage, { role: "assistant" }>;
+type ParentCompactionCandidate = {
+  firstKeptEntryId: string;
+  timestampMs: number;
+};
+type ParentCompactionScanCacheEntry = {
+  snapshotKey: string;
+  parentIdById: ReadonlyMap<string, string | null>;
+  compactions: readonly ParentCompactionCandidate[];
+};
+
+const parentCompactionScanCache = new Map<string, ParentCompactionScanCacheEntry>();
 
 type ProviderReplayHookParams = {
   config?: OpenClawConfig;
@@ -685,6 +700,223 @@ function assertOpenAIResponsesToolUseResultInvariant(messages: AgentMessage[]): 
   return messages;
 }
 
+function parseReplayTimestampMs(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string") {
+    const parsed = Date.parse(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return null;
+}
+
+function hasCompactionSummaryMessage(messages: AgentMessage[]): boolean {
+  return messages.some((message) => (message as { role?: unknown })?.role === "compactionSummary");
+}
+
+function latestAssistantPredatesTimestamp(
+  messages: AgentMessage[],
+  timestampMs: number | null,
+): boolean {
+  if (timestampMs === null) {
+    return false;
+  }
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if ((message as { role?: unknown })?.role !== "assistant") {
+      continue;
+    }
+    const messageTimestampMs = parseReplayTimestampMs(
+      (message as { timestamp?: unknown }).timestamp,
+    );
+    return messageTimestampMs !== null && messageTimestampMs < timestampMs;
+  }
+  return false;
+}
+
+function hasMissingParentAncestor(params: {
+  entryId: string;
+  parentIdById: ReadonlyMap<string, string | null>;
+  childEntryIds: ReadonlySet<string>;
+}): boolean {
+  const seen = new Set<string>();
+  let parentId = params.parentIdById.get(params.entryId);
+  while (typeof parentId === "string" && parentId.length > 0 && !seen.has(parentId)) {
+    seen.add(parentId);
+    if (!params.childEntryIds.has(parentId)) {
+      return true;
+    }
+    parentId = params.parentIdById.get(parentId);
+  }
+  return false;
+}
+
+function readParentSessionSnapshotKey(parentSessionFile: string): string | null {
+  let stats: ReturnType<typeof statSync>;
+  try {
+    stats = statSync(parentSessionFile);
+  } catch {
+    return null;
+  }
+  if (!stats.isFile() || stats.size > PARENT_COMPACTION_SCAN_MAX_BYTES) {
+    return null;
+  }
+  return `${stats.dev}:${stats.ino}:${stats.size}:${stats.mtimeMs}:${stats.ctimeMs}`;
+}
+
+function rememberParentCompactionScan(
+  parentSessionFile: string,
+  entry: ParentCompactionScanCacheEntry,
+): ParentCompactionScanCacheEntry {
+  parentCompactionScanCache.delete(parentSessionFile);
+  parentCompactionScanCache.set(parentSessionFile, entry);
+  while (parentCompactionScanCache.size > MAX_PARENT_COMPACTION_SCAN_CACHE_ENTRIES) {
+    const oldestKey = parentCompactionScanCache.keys().next().value;
+    if (oldestKey === undefined) {
+      break;
+    }
+    parentCompactionScanCache.delete(oldestKey);
+  }
+  return entry;
+}
+
+async function readParentCompactionScan(
+  parentSessionFile: string,
+): Promise<ParentCompactionScanCacheEntry | null> {
+  const snapshotKey = readParentSessionSnapshotKey(parentSessionFile);
+  if (snapshotKey === null) {
+    parentCompactionScanCache.delete(parentSessionFile);
+    return null;
+  }
+  const cached = parentCompactionScanCache.get(parentSessionFile);
+  if (cached?.snapshotKey === snapshotKey) {
+    return cached;
+  }
+  const parentIdById = new Map<string, string | null>();
+  const compactions: ParentCompactionCandidate[] = [];
+  const input = createReadStream(parentSessionFile, { encoding: "utf8" });
+  const lines = createInterface({ input, crlfDelay: Infinity });
+  try {
+    for await (const line of lines) {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      const record = parsed as { id?: unknown; parentId?: unknown; type?: unknown };
+      if (typeof record.id === "string") {
+        parentIdById.set(
+          record.id,
+          typeof record.parentId === "string" || record.parentId === null ? record.parentId : null,
+        );
+      }
+      if (record.type !== "compaction") {
+        continue;
+      }
+      const firstKeptEntryId = (parsed as { firstKeptEntryId?: unknown }).firstKeptEntryId;
+      if (typeof firstKeptEntryId !== "string") {
+        continue;
+      }
+      const ts = parseReplayTimestampMs((parsed as { timestamp?: unknown }).timestamp);
+      if (ts !== null) {
+        compactions.push({ firstKeptEntryId, timestampMs: ts });
+      }
+    }
+  } catch {
+    return null;
+  } finally {
+    input.destroy();
+  }
+  return rememberParentCompactionScan(parentSessionFile, {
+    snapshotKey,
+    parentIdById,
+    compactions,
+  });
+}
+
+async function readLatestParentCompactionTimestampMs(
+  parentSessionFile: string,
+  maxTimestampMs: number,
+  childEntryIds: ReadonlySet<string>,
+): Promise<number | null> {
+  const parentScan = await readParentCompactionScan(parentSessionFile);
+  if (parentScan === null) {
+    return null;
+  }
+  let latestCompactionTimestamp: number | null = null;
+  for (const compaction of parentScan.compactions) {
+    if (!childEntryIds.has(compaction.firstKeptEntryId)) {
+      continue;
+    }
+    if (
+      !hasMissingParentAncestor({
+        entryId: compaction.firstKeptEntryId,
+        parentIdById: parentScan.parentIdById,
+        childEntryIds,
+      })
+    ) {
+      continue;
+    }
+    if (compaction.timestampMs <= maxTimestampMs) {
+      latestCompactionTimestamp =
+        latestCompactionTimestamp === null
+          ? compaction.timestampMs
+          : Math.max(latestCompactionTimestamp, compaction.timestampMs);
+    }
+  }
+  return latestCompactionTimestamp;
+}
+
+async function resolveBoundarylessCompactionTimestampMs(params: {
+  sessionManager: SessionManager;
+  messages: AgentMessage[];
+}): Promise<number | null> {
+  if (hasCompactionSummaryMessage(params.messages)) {
+    return null;
+  }
+  const getHeader = (
+    params.sessionManager as {
+      getHeader?: () => { parentSession?: unknown; timestamp?: unknown } | null;
+    }
+  ).getHeader;
+  const header = typeof getHeader === "function" ? getHeader.call(params.sessionManager) : null;
+  const parentSession = header?.parentSession;
+  if (typeof parentSession !== "string" || parentSession.trim().length === 0) {
+    return null;
+  }
+  const successorTimestampMs = parseReplayTimestampMs(header?.timestamp);
+  if (successorTimestampMs === null) {
+    return null;
+  }
+  let activeBranchEntryIds: Set<string>;
+  try {
+    activeBranchEntryIds = new Set(
+      params.sessionManager
+        .getBranch()
+        .map((entry: { id?: unknown }) => (typeof entry.id === "string" ? entry.id : undefined))
+        .filter((id): id is string => id !== undefined),
+    );
+  } catch {
+    return null;
+  }
+  if (activeBranchEntryIds.size === 0) {
+    return null;
+  }
+  const compactionTimestampMs = await readLatestParentCompactionTimestampMs(
+    parentSession.trim(),
+    successorTimestampMs,
+    activeBranchEntryIds,
+  );
+  if (compactionTimestampMs === null) {
+    return null;
+  }
+  return compactionTimestampMs;
+}
+
 /**
  * Applies the generic replay-history cleanup pipeline before provider-owned
  * replay hooks run.
@@ -760,11 +992,27 @@ export async function sanitizeSessionHistory(params: {
   // stripInvalidThinkingSignatures runs. Pre-compaction kept messages carry signatures
   // bound to the original prefix; after compaction the prefix changes and Anthropic
   // rejects them. Timestamp comparison with the latest compaction summary identifies
-  // the affected messages regardless of path (standard or truncateAfterCompaction).
+  // the affected messages. For legacy successor files that lost the summary boundary,
+  // recover the timestamp from the parent transcript before stripping.
+  const boundarylessCompactionTimestampMs =
+    signedThinkingProvider || policy.preserveSignatures
+      ? await resolveBoundarylessCompactionTimestampMs({
+          sessionManager: params.sessionManager,
+          messages: sanitizedImages,
+        })
+      : null;
   const compactionStaleStripped =
     signedThinkingProvider || policy.preserveSignatures
-      ? stripStaleThinkingSignaturesForCompactionReplay(sanitizedImages)
+      ? stripStaleThinkingSignaturesForCompactionReplay(sanitizedImages, {
+          compactionTimestampMs: boundarylessCompactionTimestampMs,
+        })
       : sanitizedImages;
+  const preserveLatestAssistantForInvalidThinking = latestAssistantPredatesTimestamp(
+    compactionStaleStripped,
+    boundarylessCompactionTimestampMs,
+  )
+    ? false
+    : preserveLatestAssistantThinking;
   // Some recovery paths supply a narrow policy with preserveSignatures disabled.
   // Native signed-thinking providers still cannot replay missing/blank
   // signatures once the assistant turn is no longer latest in the outbound
@@ -772,7 +1020,7 @@ export async function sanitizeSessionHistory(params: {
   const validatedThinkingSignatures =
     signedThinkingProvider || policy.preserveSignatures
       ? stripInvalidThinkingSignatures(compactionStaleStripped, {
-          preserveLatestAssistant: preserveLatestAssistantThinking,
+          preserveLatestAssistant: preserveLatestAssistantForInvalidThinking,
         })
       : compactionStaleStripped;
   const droppedReasoning = policy.dropReasoningFromHistory

--- a/src/agents/embedded-agent-runner/sanitize-session-history.tool-result-details.test.ts
+++ b/src/agents/embedded-agent-runner/sanitize-session-history.tool-result-details.test.ts
@@ -1,10 +1,14 @@
 // Session-history sanitization tests ensure replay strips tool-result internals
 // before provider validation sees transcript messages.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
 import { SessionManager } from "openclaw/plugin-sdk/agent-sessions";
-import type { ToolResultMessage, UserMessage } from "openclaw/plugin-sdk/llm";
+import type { AssistantMessage, ToolResultMessage, UserMessage } from "openclaw/plugin-sdk/llm";
 import { describe, expect, it, vi } from "vitest";
 import { makeAgentAssistantMessage } from "../test-helpers/agent-message-fixtures.js";
+import type { TranscriptPolicy } from "../transcript-policy.js";
 import { sanitizeSessionHistory } from "./replay-history.js";
 
 vi.mock("../../plugins/provider-runtime.js", () => ({
@@ -18,6 +22,78 @@ vi.mock("../../plugins/provider-runtime.js", () => ({
 vi.mock("../../plugins/provider-hook-runtime.js", () => ({
   resolveProviderRuntimePlugin: () => undefined,
 }));
+
+const nativeAnthropicPolicy: TranscriptPolicy = {
+  sanitizeMode: "full",
+  sanitizeToolCallIds: true,
+  toolCallIdMode: "strict",
+  preserveNativeAnthropicToolUseIds: true,
+  repairToolUseResultPairing: true,
+  preserveSignatures: true,
+  sanitizeThinkingSignatures: false,
+  dropThinkingBlocks: false,
+  dropReasoningFromHistory: false,
+  applyGoogleTurnOrdering: false,
+  validateGeminiTurns: false,
+  validateAnthropicTurns: true,
+  allowSyntheticToolResults: true,
+};
+
+function sessionHeader(params: {
+  id: string;
+  timestamp: string;
+  cwd: string;
+  parentSession?: string;
+}) {
+  return {
+    type: "session",
+    version: 3,
+    id: params.id,
+    timestamp: params.timestamp,
+    cwd: params.cwd,
+    ...(params.parentSession ? { parentSession: params.parentSession } : {}),
+  };
+}
+
+function messageEntry(params: {
+  id: string;
+  parentId: string | null;
+  message: AgentMessage;
+  timestamp: string;
+}) {
+  return {
+    type: "message",
+    id: params.id,
+    parentId: params.parentId,
+    timestamp: params.timestamp,
+    message: params.message,
+  };
+}
+
+function compactionEntry(params: {
+  id: string;
+  parentId: string | null;
+  timestamp: number | string;
+  firstKeptEntryId: string;
+}) {
+  return {
+    type: "compaction",
+    id: params.id,
+    parentId: params.parentId,
+    timestamp: params.timestamp,
+    firstKeptEntryId: params.firstKeptEntryId,
+    summary: "summary",
+    tokensBefore: 100,
+  };
+}
+
+async function writeJsonl(file: string, records: unknown[]): Promise<void> {
+  await fs.writeFile(
+    file,
+    `${records.map((record) => JSON.stringify(record)).join("\n")}\n`,
+    "utf-8",
+  );
+}
 
 describe("sanitizeSessionHistory toolResult details stripping", () => {
   it("strips toolResult.details so untrusted payloads are not fed back to the model", async () => {
@@ -89,5 +165,883 @@ describe("sanitizeSessionHistory toolResult details stripping", () => {
       throw new Error("Expected sanitized first message to be an assistant message");
     }
     expect(assistant?.content).toEqual([{ type: "text", text: "plain reply" }]);
+  });
+
+  it("preserves boundaryless signed-thinking replay without a successor header", async () => {
+    const sm = SessionManager.inMemory();
+
+    const sanitized = await sanitizeSessionHistory({
+      messages: [
+        {
+          role: "user",
+          content: "old question",
+          timestamp: 1,
+        } satisfies UserMessage,
+        makeAgentAssistantMessage({
+          api: "anthropic-messages",
+          provider: "anthropic",
+          model: "claude-opus-4-6",
+          content: [
+            { type: "thinking", thinking: "old reasoning", thinkingSignature: "stale_sig" },
+            { type: "text", text: "old answer" },
+          ] as AssistantMessage["content"],
+          timestamp: 2,
+        }),
+        {
+          role: "user",
+          content: "new question",
+          timestamp: 3,
+        } satisfies UserMessage,
+        makeAgentAssistantMessage({
+          api: "anthropic-messages",
+          provider: "anthropic",
+          model: "claude-opus-4-6",
+          content: [
+            { type: "thinking", thinking: "latest reasoning", thinkingSignature: "latest_sig" },
+            { type: "text", text: "latest answer" },
+          ] as AssistantMessage["content"],
+          timestamp: 4,
+        }),
+      ],
+      modelApi: "anthropic-messages",
+      provider: "anthropic",
+      modelId: "claude-opus-4-6",
+      sessionManager: sm,
+      sessionId: "test",
+      policy: nativeAnthropicPolicy,
+    });
+
+    const assistants = sanitized.filter((message): message is AssistantMessage => {
+      return message?.role === "assistant";
+    });
+
+    expect(assistants[0]?.content).toEqual([
+      { type: "thinking", thinking: "old reasoning", thinkingSignature: "stale_sig" },
+      { type: "text", text: "old answer" },
+    ]);
+    expect(assistants[1]?.content).toEqual([
+      { type: "thinking", thinking: "latest reasoning", thinkingSignature: "latest_sig" },
+      { type: "text", text: "latest answer" },
+    ]);
+  });
+
+  it("preserves parented signed-thinking replay when the parent has no compaction boundary", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-parented-replay-"));
+    const parentSessionFile = path.join(dir, "parent.jsonl");
+    await fs.writeFile(
+      parentSessionFile,
+      [
+        JSON.stringify({
+          type: "session",
+          id: "parent",
+          timestamp: "2026-07-01T00:00:00.000Z",
+          cwd: dir,
+        }),
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+    const sm = SessionManager.inMemory();
+    sm.newSession({ parentSession: parentSessionFile });
+
+    const sanitized = await sanitizeSessionHistory({
+      messages: [
+        {
+          role: "user",
+          content: "old question",
+          timestamp: 1,
+        } satisfies UserMessage,
+        makeAgentAssistantMessage({
+          api: "anthropic-messages",
+          provider: "anthropic",
+          model: "claude-opus-4-6",
+          content: [
+            { type: "thinking", thinking: "old reasoning", thinkingSignature: "valid_sig" },
+            { type: "text", text: "old answer" },
+          ] as AssistantMessage["content"],
+          timestamp: 2,
+        }),
+        {
+          role: "user",
+          content: "new question",
+          timestamp: 3,
+        } satisfies UserMessage,
+        makeAgentAssistantMessage({
+          api: "anthropic-messages",
+          provider: "anthropic",
+          model: "claude-opus-4-6",
+          content: [
+            { type: "thinking", thinking: "latest reasoning", thinkingSignature: "latest_sig" },
+            { type: "text", text: "latest answer" },
+          ] as AssistantMessage["content"],
+          timestamp: 4,
+        }),
+      ],
+      modelApi: "anthropic-messages",
+      provider: "anthropic",
+      modelId: "claude-opus-4-6",
+      sessionManager: sm,
+      sessionId: "test",
+      policy: nativeAnthropicPolicy,
+    });
+
+    const assistants = sanitized.filter((message): message is AssistantMessage => {
+      return message?.role === "assistant";
+    });
+
+    expect(assistants[0]?.content).toEqual([
+      { type: "thinking", thinking: "old reasoning", thinkingSignature: "valid_sig" },
+      { type: "text", text: "old answer" },
+    ]);
+    expect(assistants[1]?.content).toEqual([
+      { type: "thinking", thinking: "latest reasoning", thinkingSignature: "latest_sig" },
+      { type: "text", text: "latest answer" },
+    ]);
+  });
+
+  it("recovers successor-header signed-thinking replay by stripping historical signatures", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-legacy-successor-"));
+    const parentSessionFile = path.join(dir, "parent.jsonl");
+    const childSessionFile = path.join(dir, "child.jsonl");
+    const oldUser = {
+      role: "user",
+      content: "old question",
+      timestamp: 1,
+    } satisfies UserMessage;
+    const staleAssistant = makeAgentAssistantMessage({
+      api: "anthropic-messages",
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      content: [
+        { type: "thinking", thinking: "old reasoning", thinkingSignature: "stale_sig" },
+        { type: "text", text: "old answer" },
+      ] as AssistantMessage["content"],
+      timestamp: 2,
+    });
+    const firstKept = {
+      role: "user",
+      content: "new question",
+      timestamp: 3,
+    } satisfies UserMessage;
+    const latestAssistant = makeAgentAssistantMessage({
+      api: "anthropic-messages",
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      content: [
+        { type: "thinking", thinking: "latest reasoning", thinkingSignature: "latest_sig" },
+        { type: "text", text: "latest answer" },
+      ] as AssistantMessage["content"],
+      timestamp: 4,
+    });
+    await writeJsonl(parentSessionFile, [
+      sessionHeader({
+        id: "parent",
+        timestamp: "2026-07-01T00:00:00.000Z",
+        cwd: dir,
+      }),
+      messageEntry({
+        id: "old-user",
+        parentId: null,
+        message: oldUser,
+        timestamp: "1970-01-01T00:00:00.001Z",
+      }),
+      messageEntry({
+        id: "stale-assistant",
+        parentId: "old-user",
+        message: staleAssistant,
+        timestamp: "1970-01-01T00:00:00.002Z",
+      }),
+      messageEntry({
+        id: "first-kept",
+        parentId: "stale-assistant",
+        message: firstKept,
+        timestamp: "1970-01-01T00:00:00.003Z",
+      }),
+      compactionEntry({
+        id: "compact",
+        parentId: "first-kept",
+        timestamp: 3,
+        firstKeptEntryId: "first-kept",
+      }),
+    ]);
+    await writeJsonl(childSessionFile, [
+      sessionHeader({
+        id: "child",
+        timestamp: "2026-07-01T00:00:01.000Z",
+        cwd: dir,
+        parentSession: parentSessionFile,
+      }),
+      messageEntry({
+        id: "stale-assistant",
+        parentId: null,
+        message: staleAssistant,
+        timestamp: "1970-01-01T00:00:00.002Z",
+      }),
+      messageEntry({
+        id: "first-kept",
+        parentId: "stale-assistant",
+        message: firstKept,
+        timestamp: "1970-01-01T00:00:00.003Z",
+      }),
+      messageEntry({
+        id: "latest-assistant",
+        parentId: "first-kept",
+        message: latestAssistant,
+        timestamp: "1970-01-01T00:00:00.004Z",
+      }),
+    ]);
+    const sm = SessionManager.open(childSessionFile, dir);
+
+    const sanitized = await sanitizeSessionHistory({
+      messages: sm.buildSessionContext().messages,
+      modelApi: "anthropic-messages",
+      provider: "anthropic",
+      modelId: "claude-opus-4-6",
+      sessionManager: sm,
+      sessionId: "test",
+      policy: nativeAnthropicPolicy,
+    });
+
+    const assistants = sanitized.filter((message): message is AssistantMessage => {
+      return message?.role === "assistant";
+    });
+
+    expect(JSON.stringify(assistants[0]?.content)).not.toContain("stale_sig");
+    expect(assistants[0]?.content).toEqual([{ type: "text", text: "old answer" }]);
+    expect(assistants[1]?.content).toEqual([
+      { type: "thinking", thinking: "latest reasoning", thinkingSignature: "latest_sig" },
+      { type: "text", text: "latest answer" },
+    ]);
+  });
+
+  it("preserves forked signed-thinking replay when parent compaction kept id is absent", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-forked-parent-compaction-"));
+    const parentSessionFile = path.join(dir, "parent.jsonl");
+    await fs.writeFile(
+      parentSessionFile,
+      [
+        JSON.stringify({
+          type: "session",
+          id: "parent",
+          timestamp: "2026-07-01T00:00:00.000Z",
+          cwd: dir,
+        }),
+        JSON.stringify({
+          type: "compaction",
+          id: "compact",
+          parentId: null,
+          timestamp: 3000,
+          firstKeptEntryId: "unrelated-kept-entry",
+          summary: "summary",
+          tokensBefore: 100,
+        }),
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+    const sm = SessionManager.inMemory();
+    sm.newSession({ parentSession: parentSessionFile });
+    sm.appendMessage({
+      role: "user",
+      content: "fork question",
+      timestamp: 1000,
+    } satisfies UserMessage);
+    sm.appendMessage(
+      makeAgentAssistantMessage({
+        api: "anthropic-messages",
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+        content: [
+          { type: "thinking", thinking: "fork reasoning", thinkingSignature: "valid_sig" },
+          { type: "text", text: "fork answer" },
+        ] as AssistantMessage["content"],
+        timestamp: 2000,
+      }),
+    );
+
+    const sanitized = await sanitizeSessionHistory({
+      messages: sm.buildSessionContext().messages,
+      modelApi: "anthropic-messages",
+      provider: "anthropic",
+      modelId: "claude-opus-4-6",
+      sessionManager: sm,
+      sessionId: "test",
+      policy: nativeAnthropicPolicy,
+    });
+
+    const assistant = sanitized.find((message): message is AssistantMessage => {
+      return message?.role === "assistant";
+    });
+
+    expect(assistant?.content).toEqual([
+      { type: "thinking", thinking: "fork reasoning", thinkingSignature: "valid_sig" },
+      { type: "text", text: "fork answer" },
+    ]);
+  });
+
+  it("preserves forked signed-thinking replay when parent compaction ancestry is intact", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-forked-intact-compaction-"));
+    const parentSessionFile = path.join(dir, "parent.jsonl");
+    const childSessionFile = path.join(dir, "child.jsonl");
+    const rootUser = {
+      role: "user",
+      content: "root question",
+      timestamp: 1000,
+    } satisfies UserMessage;
+    const forkAssistant = makeAgentAssistantMessage({
+      api: "anthropic-messages",
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      content: [
+        { type: "thinking", thinking: "fork reasoning", thinkingSignature: "valid_sig" },
+        { type: "text", text: "fork answer" },
+      ] as AssistantMessage["content"],
+      timestamp: 2000,
+    });
+    const firstKept = {
+      role: "user",
+      content: "kept question",
+      timestamp: 2500,
+    } satisfies UserMessage;
+    await writeJsonl(parentSessionFile, [
+      sessionHeader({
+        id: "parent",
+        timestamp: "2026-07-01T00:00:00.000Z",
+        cwd: dir,
+      }),
+      messageEntry({
+        id: "root-user",
+        parentId: null,
+        message: rootUser,
+        timestamp: "1970-01-01T00:00:01.000Z",
+      }),
+      messageEntry({
+        id: "fork-assistant",
+        parentId: "root-user",
+        message: forkAssistant,
+        timestamp: "1970-01-01T00:00:02.000Z",
+      }),
+      messageEntry({
+        id: "first-kept",
+        parentId: "fork-assistant",
+        message: firstKept,
+        timestamp: "1970-01-01T00:00:02.500Z",
+      }),
+      compactionEntry({
+        id: "compact",
+        parentId: "first-kept",
+        timestamp: 3000,
+        firstKeptEntryId: "first-kept",
+      }),
+    ]);
+    await writeJsonl(childSessionFile, [
+      sessionHeader({
+        id: "child",
+        timestamp: "2026-07-01T00:00:01.000Z",
+        cwd: dir,
+        parentSession: parentSessionFile,
+      }),
+      messageEntry({
+        id: "root-user",
+        parentId: null,
+        message: rootUser,
+        timestamp: "1970-01-01T00:00:01.000Z",
+      }),
+      messageEntry({
+        id: "fork-assistant",
+        parentId: "root-user",
+        message: forkAssistant,
+        timestamp: "1970-01-01T00:00:02.000Z",
+      }),
+      messageEntry({
+        id: "first-kept",
+        parentId: "fork-assistant",
+        message: firstKept,
+        timestamp: "1970-01-01T00:00:02.500Z",
+      }),
+    ]);
+    const sm = SessionManager.open(childSessionFile, dir);
+
+    const sanitized = await sanitizeSessionHistory({
+      messages: sm.buildSessionContext().messages,
+      modelApi: "anthropic-messages",
+      provider: "anthropic",
+      modelId: "claude-opus-4-6",
+      sessionManager: sm,
+      sessionId: "test",
+      policy: nativeAnthropicPolicy,
+    });
+
+    const assistant = sanitized.find((message): message is AssistantMessage => {
+      return message?.role === "assistant";
+    });
+
+    expect(assistant?.content).toEqual([
+      { type: "thinking", thinking: "fork reasoning", thinkingSignature: "valid_sig" },
+      { type: "text", text: "fork answer" },
+    ]);
+  });
+
+  it("preserves active branch replay when only an inactive branch matches parent compaction", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-inactive-branch-compaction-"));
+    const parentSessionFile = path.join(dir, "parent.jsonl");
+    const childSessionFile = path.join(dir, "child.jsonl");
+    const oldUser = {
+      role: "user",
+      content: "old inactive question",
+      timestamp: 500,
+    } satisfies UserMessage;
+    const inactiveKept = {
+      role: "user",
+      content: "inactive kept question",
+      timestamp: 1000,
+    } satisfies UserMessage;
+    const activeUser = {
+      role: "user",
+      content: "active question",
+      timestamp: 1500,
+    } satisfies UserMessage;
+    const activeAssistant = makeAgentAssistantMessage({
+      api: "anthropic-messages",
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      content: [
+        { type: "thinking", thinking: "active reasoning", thinkingSignature: "active_sig" },
+        { type: "text", text: "active answer" },
+      ] as AssistantMessage["content"],
+      timestamp: 2000,
+    });
+    await writeJsonl(parentSessionFile, [
+      sessionHeader({
+        id: "parent",
+        timestamp: "1970-01-01T00:00:00.000Z",
+        cwd: dir,
+      }),
+      messageEntry({
+        id: "old-user",
+        parentId: null,
+        message: oldUser,
+        timestamp: "1970-01-01T00:00:00.500Z",
+      }),
+      messageEntry({
+        id: "inactive-kept",
+        parentId: "old-user",
+        message: inactiveKept,
+        timestamp: "1970-01-01T00:00:01.000Z",
+      }),
+      compactionEntry({
+        id: "compact",
+        parentId: "inactive-kept",
+        timestamp: 3000,
+        firstKeptEntryId: "inactive-kept",
+      }),
+    ]);
+    await writeJsonl(childSessionFile, [
+      sessionHeader({
+        id: "child",
+        timestamp: "1970-01-01T00:00:05.000Z",
+        cwd: dir,
+        parentSession: parentSessionFile,
+      }),
+      messageEntry({
+        id: "inactive-kept",
+        parentId: null,
+        message: inactiveKept,
+        timestamp: "1970-01-01T00:00:01.000Z",
+      }),
+      messageEntry({
+        id: "active-user",
+        parentId: null,
+        message: activeUser,
+        timestamp: "1970-01-01T00:00:01.500Z",
+      }),
+      messageEntry({
+        id: "active-assistant",
+        parentId: "active-user",
+        message: activeAssistant,
+        timestamp: "1970-01-01T00:00:02.000Z",
+      }),
+    ]);
+    const sm = SessionManager.open(childSessionFile, dir);
+
+    const sanitized = await sanitizeSessionHistory({
+      messages: sm.buildSessionContext().messages,
+      modelApi: "anthropic-messages",
+      provider: "anthropic",
+      modelId: "claude-opus-4-6",
+      sessionManager: sm,
+      sessionId: "test",
+      policy: nativeAnthropicPolicy,
+    });
+
+    expect(sanitized).toHaveLength(2);
+    const assistant = sanitized.find((message): message is AssistantMessage => {
+      return message?.role === "assistant";
+    });
+    expect(assistant?.content).toEqual([
+      { type: "thinking", thinking: "active reasoning", thinkingSignature: "active_sig" },
+      { type: "text", text: "active answer" },
+    ]);
+  });
+
+  it("ignores parent compactions written after the successor session was created", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-later-parent-compaction-"));
+    const parentSessionFile = path.join(dir, "parent.jsonl");
+    const childSessionFile = path.join(dir, "child.jsonl");
+    const rootUser = {
+      role: "user",
+      content: "root question",
+      timestamp: 500,
+    } satisfies UserMessage;
+    const oldQuestion = {
+      role: "user",
+      content: "old question",
+      timestamp: 1000,
+    } satisfies UserMessage;
+    const oldAssistant = makeAgentAssistantMessage({
+      api: "anthropic-messages",
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      content: [
+        { type: "thinking", thinking: "old reasoning", thinkingSignature: "stale_sig" },
+        { type: "text", text: "old answer" },
+      ] as AssistantMessage["content"],
+      timestamp: 2000,
+    });
+    const successorQuestion = {
+      role: "user",
+      content: "successor question",
+      timestamp: 3500,
+    } satisfies UserMessage;
+    const successorAssistant = makeAgentAssistantMessage({
+      api: "anthropic-messages",
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      content: [
+        {
+          type: "thinking",
+          thinking: "successor reasoning",
+          thinkingSignature: "valid_successor_sig",
+        },
+        { type: "text", text: "successor answer" },
+      ] as AssistantMessage["content"],
+      timestamp: 4000,
+    });
+    await writeJsonl(parentSessionFile, [
+      sessionHeader({
+        id: "parent",
+        timestamp: "1970-01-01T00:00:00.000Z",
+        cwd: dir,
+      }),
+      messageEntry({
+        id: "root-user",
+        parentId: null,
+        message: rootUser,
+        timestamp: "1970-01-01T00:00:00.500Z",
+      }),
+      messageEntry({
+        id: "old-question",
+        parentId: "root-user",
+        message: oldQuestion,
+        timestamp: "1970-01-01T00:00:01.000Z",
+      }),
+      messageEntry({
+        id: "old-assistant",
+        parentId: "old-question",
+        message: oldAssistant,
+        timestamp: "1970-01-01T00:00:02.000Z",
+      }),
+      compactionEntry({
+        id: "compact-before-successor",
+        parentId: "old-assistant",
+        timestamp: 3000,
+        firstKeptEntryId: "old-question",
+      }),
+      compactionEntry({
+        id: "compact-after-successor",
+        parentId: "compact-before-successor",
+        timestamp: 9000,
+        firstKeptEntryId: "later-kept",
+      }),
+    ]);
+    await writeJsonl(childSessionFile, [
+      sessionHeader({
+        id: "child",
+        timestamp: "1970-01-01T00:00:05.000Z",
+        cwd: dir,
+        parentSession: parentSessionFile,
+      }),
+      messageEntry({
+        id: "old-question",
+        parentId: null,
+        message: oldQuestion,
+        timestamp: "1970-01-01T00:00:01.000Z",
+      }),
+      messageEntry({
+        id: "old-assistant",
+        parentId: "old-question",
+        message: oldAssistant,
+        timestamp: "1970-01-01T00:00:02.000Z",
+      }),
+      messageEntry({
+        id: "successor-question",
+        parentId: "old-assistant",
+        message: successorQuestion,
+        timestamp: "1970-01-01T00:00:03.500Z",
+      }),
+      messageEntry({
+        id: "successor-assistant",
+        parentId: "successor-question",
+        message: successorAssistant,
+        timestamp: "1970-01-01T00:00:04.000Z",
+      }),
+    ]);
+    const sm = SessionManager.open(childSessionFile, dir);
+
+    const sanitized = await sanitizeSessionHistory({
+      messages: sm.buildSessionContext().messages,
+      modelApi: "anthropic-messages",
+      provider: "anthropic",
+      modelId: "claude-opus-4-6",
+      sessionManager: sm,
+      sessionId: "test",
+      policy: nativeAnthropicPolicy,
+    });
+
+    const assistants = sanitized.filter((message): message is AssistantMessage => {
+      return message?.role === "assistant";
+    });
+
+    expect(JSON.stringify(assistants[0]?.content)).not.toContain("stale_sig");
+    expect(assistants[0]?.content).toEqual([{ type: "text", text: "old answer" }]);
+    expect(assistants[1]?.content).toEqual([
+      {
+        type: "thinking",
+        thinking: "successor reasoning",
+        thinkingSignature: "valid_successor_sig",
+      },
+      { type: "text", text: "successor answer" },
+    ]);
+  });
+
+  it("preserves unsigned latest post-compaction thinking for provider recovery", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-post-compaction-latest-"));
+    const parentSessionFile = path.join(dir, "parent.jsonl");
+    const childSessionFile = path.join(dir, "child.jsonl");
+    const rootUser = {
+      role: "user",
+      content: "root question",
+      timestamp: 500,
+    } satisfies UserMessage;
+    const oldQuestion = {
+      role: "user",
+      content: "old question",
+      timestamp: 1000,
+    } satisfies UserMessage;
+    const oldAssistant = makeAgentAssistantMessage({
+      api: "anthropic-messages",
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      content: [
+        { type: "thinking", thinking: "old reasoning", thinkingSignature: "stale_sig" },
+        { type: "text", text: "old answer" },
+      ] as AssistantMessage["content"],
+      timestamp: 2000,
+    });
+    const successorQuestion = {
+      role: "user",
+      content: "successor question",
+      timestamp: 3500,
+    } satisfies UserMessage;
+    const interruptedLatestAssistant = makeAgentAssistantMessage({
+      api: "anthropic-messages",
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      content: [
+        { type: "thinking", thinking: "latest interrupted reasoning" },
+        { type: "text", text: "latest interrupted answer" },
+      ] as AssistantMessage["content"],
+      timestamp: 4000,
+    });
+    await writeJsonl(parentSessionFile, [
+      sessionHeader({
+        id: "parent",
+        timestamp: "1970-01-01T00:00:00.000Z",
+        cwd: dir,
+      }),
+      messageEntry({
+        id: "root-user",
+        parentId: null,
+        message: rootUser,
+        timestamp: "1970-01-01T00:00:00.500Z",
+      }),
+      messageEntry({
+        id: "old-question",
+        parentId: "root-user",
+        message: oldQuestion,
+        timestamp: "1970-01-01T00:00:01.000Z",
+      }),
+      messageEntry({
+        id: "old-assistant",
+        parentId: "old-question",
+        message: oldAssistant,
+        timestamp: "1970-01-01T00:00:02.000Z",
+      }),
+      compactionEntry({
+        id: "compact",
+        parentId: "old-assistant",
+        timestamp: 3000,
+        firstKeptEntryId: "old-question",
+      }),
+    ]);
+    await writeJsonl(childSessionFile, [
+      sessionHeader({
+        id: "child",
+        timestamp: "1970-01-01T00:00:05.000Z",
+        cwd: dir,
+        parentSession: parentSessionFile,
+      }),
+      messageEntry({
+        id: "old-question",
+        parentId: null,
+        message: oldQuestion,
+        timestamp: "1970-01-01T00:00:01.000Z",
+      }),
+      messageEntry({
+        id: "old-assistant",
+        parentId: "old-question",
+        message: oldAssistant,
+        timestamp: "1970-01-01T00:00:02.000Z",
+      }),
+      messageEntry({
+        id: "successor-question",
+        parentId: "old-assistant",
+        message: successorQuestion,
+        timestamp: "1970-01-01T00:00:03.500Z",
+      }),
+      messageEntry({
+        id: "interrupted-latest-assistant",
+        parentId: "successor-question",
+        message: interruptedLatestAssistant,
+        timestamp: "1970-01-01T00:00:04.000Z",
+      }),
+    ]);
+    const sm = SessionManager.open(childSessionFile, dir);
+
+    const sanitized = await sanitizeSessionHistory({
+      messages: sm.buildSessionContext().messages,
+      modelApi: "anthropic-messages",
+      provider: "anthropic",
+      modelId: "claude-opus-4-6",
+      sessionManager: sm,
+      sessionId: "test",
+      policy: nativeAnthropicPolicy,
+    });
+
+    const assistants = sanitized.filter((message): message is AssistantMessage => {
+      return message?.role === "assistant";
+    });
+
+    expect(JSON.stringify(assistants[0]?.content)).not.toContain("stale_sig");
+    expect(assistants[0]?.content).toEqual([{ type: "text", text: "old answer" }]);
+    expect(assistants[1]?.content).toEqual([
+      { type: "thinking", thinking: "latest interrupted reasoning" },
+      { type: "text", text: "latest interrupted answer" },
+    ]);
+  });
+
+  it("recovers boundaryless successor replay before any post-compaction turn exists", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-legacy-successor-first-"));
+    const parentSessionFile = path.join(dir, "parent.jsonl");
+    const childSessionFile = path.join(dir, "child.jsonl");
+    const rootUser = {
+      role: "user",
+      content: "root question",
+      timestamp: 500,
+    } satisfies UserMessage;
+    const retainedQuestion = {
+      role: "user",
+      content: "retained question",
+      timestamp: 1000,
+    } satisfies UserMessage;
+    const retainedAssistant = makeAgentAssistantMessage({
+      api: "anthropic-messages",
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      content: [
+        { type: "thinking", thinking: "retained reasoning", thinkingSignature: "stale_sig" },
+        { type: "text", text: "retained answer" },
+      ] as AssistantMessage["content"],
+      timestamp: 2000,
+    });
+    await writeJsonl(parentSessionFile, [
+      sessionHeader({
+        id: "parent",
+        timestamp: "2026-07-01T00:00:00.000Z",
+        cwd: dir,
+      }),
+      messageEntry({
+        id: "root-user",
+        parentId: null,
+        message: rootUser,
+        timestamp: "1970-01-01T00:00:00.500Z",
+      }),
+      messageEntry({
+        id: "retained-question",
+        parentId: "root-user",
+        message: retainedQuestion,
+        timestamp: "1970-01-01T00:00:01.000Z",
+      }),
+      messageEntry({
+        id: "retained-assistant",
+        parentId: "retained-question",
+        message: retainedAssistant,
+        timestamp: "1970-01-01T00:00:02.000Z",
+      }),
+      compactionEntry({
+        id: "compact",
+        parentId: "retained-assistant",
+        timestamp: 3000,
+        firstKeptEntryId: "retained-question",
+      }),
+    ]);
+    await writeJsonl(childSessionFile, [
+      sessionHeader({
+        id: "child",
+        timestamp: "2026-07-01T00:00:01.000Z",
+        cwd: dir,
+        parentSession: parentSessionFile,
+      }),
+      messageEntry({
+        id: "retained-question",
+        parentId: null,
+        message: retainedQuestion,
+        timestamp: "1970-01-01T00:00:01.000Z",
+      }),
+      messageEntry({
+        id: "retained-assistant",
+        parentId: "retained-question",
+        message: retainedAssistant,
+        timestamp: "1970-01-01T00:00:02.000Z",
+      }),
+    ]);
+    const sm = SessionManager.open(childSessionFile, dir);
+
+    const sanitized = await sanitizeSessionHistory({
+      messages: sm.buildSessionContext().messages,
+      modelApi: "anthropic-messages",
+      provider: "anthropic",
+      modelId: "claude-opus-4-6",
+      sessionManager: sm,
+      sessionId: "test",
+      policy: nativeAnthropicPolicy,
+    });
+
+    const assistant = sanitized.find((message): message is AssistantMessage => {
+      return message?.role === "assistant";
+    });
+
+    expect(JSON.stringify(assistant?.content)).not.toContain("stale_sig");
+    expect(assistant?.content).toEqual([{ type: "text", text: "retained answer" }]);
   });
 });

--- a/src/agents/embedded-agent-runner/thinking.test.ts
+++ b/src/agents/embedded-agent-runner/thinking.test.ts
@@ -1094,6 +1094,70 @@ describe("stripStaleThinkingSignaturesForCompactionReplay", () => {
     expect(stripStaleThinkingSignaturesForCompactionReplay(messages)).toBe(messages);
   });
 
+  it("recovers boundaryless transcripts when callers provide the compaction timestamp", () => {
+    const messages: AgentMessage[] = [
+      castAgentMessage({ role: "user", content: "old q" }),
+      castAgentMessage({
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "old think", thinkingSignature: "stale_sig" },
+          { type: "text", text: "old answer" },
+        ],
+        timestamp: 1000,
+      }),
+      castAgentMessage({ role: "user", content: "new q" }),
+      castAgentMessage({
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "latest think", thinkingSignature: "latest_sig" },
+          { type: "text", text: "latest answer" },
+        ],
+        timestamp: 3000,
+      }),
+    ];
+
+    const result = stripStaleThinkingSignaturesForCompactionReplay(messages, {
+      compactionTimestampMs: 2000,
+    });
+
+    expect(result).not.toBe(messages);
+    const historical = result[1] as AssistantMessage;
+    const latest = result[3] as AssistantMessage;
+    expect(historical.content).toEqual([
+      { type: "thinking", thinking: "old think" },
+      { type: "text", text: "old answer" },
+    ]);
+    expect(latest.content).toEqual([
+      { type: "thinking", thinking: "latest think", thinkingSignature: "latest_sig" },
+      { type: "text", text: "latest answer" },
+    ]);
+  });
+
+  it("strips boundaryless redacted thinking before a recovered compaction timestamp", () => {
+    const messages: AgentMessage[] = [
+      castAgentMessage({ role: "user", content: "old q" }),
+      castAgentMessage({
+        role: "assistant",
+        content: [
+          { type: "redacted_thinking", data: "stale_redacted" },
+          { type: "text", text: "old answer" },
+        ],
+        timestamp: 1000,
+      }),
+    ];
+
+    const result = stripStaleThinkingSignaturesForCompactionReplay(messages, {
+      compactionTimestampMs: 2000,
+    });
+
+    expect(result).not.toBe(messages);
+    const assistant = result[1] as AssistantMessage;
+    expect(assistant.content).toEqual([
+      { type: "redacted_thinking" },
+      { type: "text", text: "old answer" },
+    ]);
+  });
+
   it("strips thinking signatures from assistant messages at or before the compaction timestamp", () => {
     const compactionSummary = castAgentMessage({
       role: "compactionSummary",

--- a/src/agents/embedded-agent-runner/thinking.ts
+++ b/src/agents/embedded-agent-runner/thinking.ts
@@ -180,12 +180,23 @@ export function stripThinkingSignaturesFromMessage(message: AgentMessage): Agent
  * in the new context and retain their signatures. Messages with no parseable timestamp are
  * left unchanged.
  *
+ * Some older successor transcripts were already written without a compaction summary
+ * boundary. Callers can pass a recovered compaction timestamp for those transcripts so
+ * the same timestamp-based stale stripping applies without broadening normal replay.
+ *
  * Returns the original array reference when nothing was changed.
  */
 export function stripStaleThinkingSignaturesForCompactionReplay(
   messages: AgentMessage[],
+  options: {
+    compactionTimestampMs?: number | null;
+  } = {},
 ): AgentMessage[] {
-  let latestCompactionTimestamp: number | null = null;
+  let latestCompactionTimestamp: number | null =
+    typeof options.compactionTimestampMs === "number" &&
+    Number.isFinite(options.compactionTimestampMs)
+      ? options.compactionTimestampMs
+      : null;
   for (const message of messages) {
     if ((message as { role?: unknown }).role !== "compactionSummary") {
       continue;


### PR DESCRIPTION
Related: #30157

## Related PR Matrix

- #99383: canonical no-compaction completed-turn Anthropic replay fix. That PR owns the SDK and managed transport replay policy for ordinary non-compacted sessions.
- #98527: this PR, legacy boundaryless compaction successor repair. It recovers a missing compaction boundary before replay sanitization.
- #98441: config-surface pruning alternative, not chosen here because this repair should not add or change public replay config/defaults.
- #94493 / #98831 / #99437: superseded or partial-overlap attempts in the same signed-thinking replay cluster.

## Maintainer Decision Requested

Please decide whether the bounded parent-boundary inference is acceptable for legacy successor transcripts that lost their in-transcript `compactionSummary` boundary.

What is proven:

- current `main` can replay stale pre-compaction signed thinking when the successor transcript has no `compactionSummary`,
- unsanitized Anthropic replay rejects that stale signature,
- sanitized OpenClaw replay succeeds at PR head `9d2565bc03519e02e63a1017b2ac8a67019651be`, and
- the source delta is small; the `size: XL` label is mostly focused regression coverage.

What this PR does not claim:

- it does not close the broader completed-turn signed-thinking replay cluster; #99383 is the canonical no-compaction branch,
- it does not add a public replay config/default surface, and
- it does not provide separate Bedrock/Vertex live proof, although those routes share the signed-thinking sanitizer path covered here.

## What Problem This Solves

Anthropic/Bedrock signed-thinking replay can fail after a compacted session is rotated into a successor transcript that no longer carries a `compactionSummary` message. Those successor transcripts may still replay pre-compaction assistant thinking signatures, but the signatures are bound to the old context prefix and can be rejected by the provider.

## Why This Change Was Made

The existing stale-signature cleanup only had the in-transcript compaction summary timestamp available. This change recovers a conservative compaction timestamp for legacy boundaryless successor transcripts by looking at the parent session metadata when:

- the current replay has no `compactionSummary`,
- the session header points at a parent transcript,
- the parent compaction predates the successor session,
- the active child branch contains the parent compaction's `firstKeptEntryId`, and
- the child branch is missing an ancestor before that kept entry, which distinguishes rotated compacted successors from ordinary forks.

The parent transcript scan is bounded to files up to 64 MiB and cached by file snapshot, so normal parented sessions do not rescan large parents on every replay. If the boundary cannot be proven, replay behavior stays unchanged.

## Scope

This is a narrow boundaryless-successor repair under the broader signed-thinking replay cluster. It does not claim to close every Anthropic/Bedrock signed-thinking replay failure path; it only handles legacy successor transcripts whose compaction boundary can be proven from the parent transcript.

## User Impact

Users can continue affected legacy compacted Anthropic/Bedrock sessions without manually disabling truncation, resetting the session, or losing the visible replay tail. Normal forks, sessions without parent compaction, post-compaction signed thinking, and latest interrupted assistant recovery remain preserved.

## Real behavior proof

Live Anthropic replay proof was run against PR head `9d2565bc03519e02e63a1017b2ac8a67019651be` with `ANTHROPIC_API_KEY` loaded from a local `.env`; the key was not printed. The proof builds a boundaryless successor transcript with a stale pre-compaction thinking signature, confirms the unsanitized replay is rejected by Anthropic, then sends the sanitized OpenClaw replay through the real Anthropic transport.

Command:

```shell
OPENCLAW_PROOF_HEAD=9d2565bc03519e02e63a1017b2ac8a67019651be ./node_modules/.bin/tsx /tmp/openclaw-boundaryless-live-proof.ts
```

Redacted output:

```text
model=claude-sonnet-4-6
head=9d2565bc03519e02e63a1017b2ac8a67019651be
fixture=boundaryless-successor parent=proof-parent child=proof-child
before_stale_signature_present=true
after_stale_signature_present=false
sanitized_assistant_content=[{"type":"text","text":"retained answer"}]
negative_unsanitized_replay_http=400
negative_unsanitized_replay_ok=false
negative_unsanitized_error_redacted={"type":"error","error":{"type":"invalid_request_error","message":"messages.1.content.0: Invalid `signature` in `thinking` block"},"request_id":"<redacted>"}
[provider-transport-fetch] [model-fetch] start provider=anthropic api=anthropic-messages model=claude-sonnet-4-6 method=POST url=https://api.anthropic.com/v1/messages timeoutMs=undefined proxy=none policy=custom
[provider-transport-fetch] [model-fetch] response provider=anthropic api=anthropic-messages model=claude-sonnet-4-6 status=200 elapsedMs=<redacted> contentType=text/event-stream; charset=utf-8
positive_openclaw_transport_text="BOUNDARYLESS_PROOF_OK"
positive_openclaw_transport_ok=true
BOUNDARYLESS_LIVE_PROOF=PASS
```

## Evidence

- AI-assisted: Implemented with Codex. I reviewed the code, tests, review findings, and final diff and understand the change.
- `./node_modules/.bin/oxfmt --check --threads=1 src/agents/embedded-agent-runner/thinking.ts src/agents/embedded-agent-runner/replay-history.ts src/agents/embedded-agent-runner/thinking.test.ts src/agents/embedded-agent-runner/sanitize-session-history.tool-result-details.test.ts` passed.
- `node scripts/run-oxlint.mjs src/agents/embedded-agent-runner/thinking.ts src/agents/embedded-agent-runner/replay-history.ts src/agents/embedded-agent-runner/thinking.test.ts src/agents/embedded-agent-runner/sanitize-session-history.tool-result-details.test.ts` passed.
- `env CI=true pnpm tsgo:core` passed.
- `env CI=true pnpm check:test-types` passed after rebasing onto upstream main.
- `./node_modules/.bin/vitest run --config test/vitest/vitest.agents-embedded-agent.config.ts src/agents/embedded-agent-runner/thinking.test.ts src/agents/embedded-agent-runner/sanitize-session-history.tool-result-details.test.ts --reporter verbose` passed: 2 files, 60 tests.
- `./node_modules/.bin/vitest run --config test/vitest/vitest.agents.config.ts src/agents/embedded-agent-runner.sanitize-session-history.test.ts --reporter verbose` passed: 1 file, 76 tests.
- `git diff --check` passed.
- `codex review --base origin/main` passed with no actionable regression found.
