### PR TITLE
fix: ignore stale approval entry removals

### DIFF
--- a/ui/src/ui/app.exec-approval.test.ts
+++ b/ui/src/ui/app.exec-approval.test.ts
@@ -70,6 +70,40 @@ describe("OpenClawApp exec approval decisions", () => {
     expect(app.execApprovalBusy).toBe(false);
   });
 
+  it("keeps a newer same-id approval when an older resolve finishes", async () => {
+    let resolveApproval!: (value: unknown) => void;
+    const resolvePromise = new Promise<unknown>((resolve) => {
+      resolveApproval = resolve;
+    });
+    const request = vi.fn<RequestFn>(async (method) => {
+      if (method === "exec.approval.resolve") {
+        return resolvePromise;
+      }
+      return {};
+    });
+    const active = createExecApproval({
+      id: "approval-reused",
+      createdAtMs: 1000,
+      expiresAtMs: Date.now() + 1_000,
+    });
+    const replacement = createExecApproval({
+      id: "approval-reused",
+      createdAtMs: 2000,
+      expiresAtMs: Date.now() + 60_000,
+    });
+    const app = await createApp(request, [active]);
+
+    const decisionPromise = app.handleExecApprovalDecision("allow-once");
+    app.execApprovalQueue = [replacement];
+    app.execApprovalError = "Approval failed: replacement still active";
+    resolveApproval({ ok: true });
+    await decisionPromise;
+
+    expect(app.execApprovalQueue).toEqual([replacement]);
+    expect(app.execApprovalError).toBe("Approval failed: replacement still active");
+    expect(app.execApprovalBusy).toBe(false);
+  });
+
   it("dismisses and refreshes when the backend reports an already resolved approval", async () => {
     const request = vi.fn<RequestFn>(async (method) => {
       if (method === "exec.approval.resolve") {

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -108,7 +108,7 @@ import type {
   WikiMemoryPalace,
 } from "./controllers/dreaming.ts";
 import {
-  dismissExecApprovalPrompt,
+  dismissExecApprovalEntryPrompt,
   isStaleApprovalResolutionError,
   refreshPendingApprovalQueue,
   type ExecApprovalRequest,
@@ -1424,10 +1424,10 @@ export class OpenClawApp extends LitElement {
         id: active.id,
         decision,
       });
-      dismissExecApprovalPrompt(this, active.id);
+      dismissExecApprovalEntryPrompt(this, active);
     } catch (err) {
       if (isStaleApprovalResolutionError(err)) {
-        dismissExecApprovalPrompt(this, active.id);
+        dismissExecApprovalEntryPrompt(this, active);
         await refreshPendingApprovalQueue(this);
         return;
       }

--- a/ui/src/ui/controllers/exec-approval.test.ts
+++ b/ui/src/ui/controllers/exec-approval.test.ts
@@ -6,6 +6,7 @@ import {
   parseExecApprovalRequested,
   parsePluginApprovalRequested,
   clearResolvedExecApprovalPrompt,
+  enqueueExecApprovalPrompt,
   refreshPendingApprovalQueue,
   type ExecApprovalPromptState,
   type ExecApprovalRequest,
@@ -261,6 +262,42 @@ describe("clearResolvedExecApprovalPrompt", () => {
 
     expect(state.execApprovalQueue).toEqual([]);
     expect(state.execApprovalError).toBeNull();
+  });
+});
+
+describe("enqueueExecApprovalPrompt", () => {
+  it("does not let an old expiry timer remove a newer approval with the same id", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-25T00:00:00.000Z"));
+    try {
+      const oldApproval = createExecApproval({
+        id: "approval-reused",
+        createdAtMs: Date.now(),
+        expiresAtMs: Date.now() + 1_000,
+      });
+      const newerApproval = createExecApproval({
+        id: "approval-reused",
+        createdAtMs: Date.now() + 2_000,
+        expiresAtMs: Date.now() + 60_000,
+      });
+      const state = createPromptState(
+        vi.fn<RequestFn>(async () => ({})),
+        [],
+      );
+
+      enqueueExecApprovalPrompt(state, oldApproval);
+      enqueueExecApprovalPrompt(state, newerApproval);
+
+      vi.advanceTimersByTime(1_500);
+
+      expect(state.execApprovalQueue).toEqual([newerApproval]);
+
+      vi.advanceTimersByTime(59_000);
+
+      expect(state.execApprovalQueue).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/ui/src/ui/controllers/exec-approval.ts
+++ b/ui/src/ui/controllers/exec-approval.ts
@@ -303,16 +303,41 @@ function scheduleApprovalExpiryPrune(
 ): void {
   const delay = Math.max(0, entry.expiresAtMs - Date.now() + 500);
   globalThis.setTimeout(() => {
-    removeExecApprovalFromState(state, entry.id);
+    removeExecApprovalEntryFromState(state, entry);
   }, delay);
 }
 
-function removeExecApprovalFromState(state: ExecApprovalPromptState, id: string): void {
+function isSamePendingApprovalEntry(
+  left: ExecApprovalRequest,
+  right: ExecApprovalRequest,
+): boolean {
+  return (
+    left.id === right.id &&
+    left.kind === right.kind &&
+    left.createdAtMs === right.createdAtMs &&
+    left.expiresAtMs === right.expiresAtMs
+  );
+}
+
+function removeExecApprovalFromState(state: ExecApprovalPromptState, id: string): boolean {
   const activeId = state.execApprovalQueue[0]?.id ?? null;
+  const hadEntry = state.execApprovalQueue.some((entry) => entry.id === id);
   state.execApprovalQueue = removeExecApproval(state.execApprovalQueue, id);
   if (activeId !== (state.execApprovalQueue[0]?.id ?? null)) {
     state.execApprovalError = null;
   }
+  return hadEntry;
+}
+
+function removeExecApprovalEntryFromState(
+  state: ExecApprovalPromptState,
+  entry: ExecApprovalRequest,
+): boolean {
+  const currentEntry = state.execApprovalQueue.find((candidate) => candidate.id === entry.id);
+  if (!currentEntry || !isSamePendingApprovalEntry(currentEntry, entry)) {
+    return false;
+  }
+  return removeExecApprovalFromState(state, entry.id);
 }
 
 export function enqueueExecApprovalPrompt(
@@ -368,6 +393,17 @@ export async function refreshPendingApprovalQueue(state: ExecApprovalPromptState
 export function dismissExecApprovalPrompt(state: ExecApprovalPromptState, id: string): void {
   removeExecApprovalFromState(state, id);
   state.execApprovalRefreshRemovedIds?.add(id);
+  state.execApprovalError = null;
+}
+
+export function dismissExecApprovalEntryPrompt(
+  state: ExecApprovalPromptState,
+  entry: ExecApprovalRequest,
+): void {
+  if (!removeExecApprovalEntryFromState(state, entry)) {
+    return;
+  }
+  state.execApprovalRefreshRemovedIds?.add(entry.id);
   state.execApprovalError = null;
 }
 


### PR DESCRIPTION
Fixes #98529

## Summary
- make approval expiry timers remove only the exact pending entry they scheduled for
- add an entry-aware dismiss path for local resolve completion so slow resolves cannot dismiss a newer same-id prompt
- cover same-id replacement for both expiry timers and async resolve completion

## Tests
- `node scripts/run-with-env.mjs OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 -- node scripts/run-vitest.mjs run --config test/vitest/vitest.ui.config.ts ui/src/ui/controllers/exec-approval.test.ts --testTimeout=30000 --reporter=dot`
- `node scripts/run-with-env.mjs OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 -- node scripts/run-vitest.mjs run --config test/vitest/vitest.ui.config.ts ui/src/ui/app.exec-approval.test.ts --testTimeout=30000 --reporter=dot`
- `git diff --check`