### PR TITLE
fix: repair hosted CI baseline assertions

### DIFF
--- a/src/gateway/server-cron-notifications.test.ts
+++ b/src/gateway/server-cron-notifications.test.ts
@@ -5,7 +5,7 @@ import type { CliDeps } from "../cli/deps.types.js";
 import type { CronJob } from "../cron/types.js";
 
 const mocks = vi.hoisted(() => ({
-  fetchWithSsrFGuard: vi.fn(async () => ({ release: vi.fn() })),
+  fetchWithSsrFGuard: vi.fn(async (_request: unknown) => ({ release: vi.fn() })),
   sendFailureNotificationAnnounce: vi.fn(),
 }));
 
@@ -33,7 +33,10 @@ function requireRecord(value: unknown, label: string): Record<string, unknown> {
 function webhookRequestBody() {
   const request = requireRecord(mocks.fetchWithSsrFGuard.mock.calls[0]?.[0], "webhook request");
   const init = requireRecord(request.init, "webhook request init");
-  return JSON.parse(String(init.body));
+  if (typeof init.body !== "string") {
+    throw new Error("expected webhook request body");
+  }
+  return JSON.parse(init.body);
 }
 
 describe("dispatchGatewayCronFinishedNotifications", () => {

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -41,7 +41,7 @@ const {
     summary: "ok",
   })),
   cleanupBrowserSessionsForLifecycleEndMock: vi.fn(async () => {}),
-  runCronChangedMock: vi.fn(async () => {}),
+  runCronChangedMock: vi.fn(async (_event: unknown, _context?: unknown) => {}),
   getGlobalHookRunnerMock: vi.fn(() => ({
     hasHooks: (hookName: string) => hookName === "cron_changed",
     runCronChanged: runCronChangedMock,
@@ -623,7 +623,7 @@ describe("buildGatewayCronService", () => {
       const event = runCronChangedMock.mock.calls
         .map((call) => requireRecord(call[0], "cron_changed event"))
         .find((hookEvent) => hookEvent.action === "finished");
-      const summary = String(event?.summary ?? "");
+      const summary = typeof event?.summary === "string" ? event.summary : "";
       expect(summary).toContain("[redacted-url]");
       expect(summary).toContain("[redacted-code]");
       expect(summary).toContain("token=***");
@@ -673,7 +673,7 @@ describe("buildGatewayCronService", () => {
         callArg(sendCronAnnouncePayloadStrictMock, 0, 0, "cron announce payload"),
         "cron announce payload",
       );
-      const message = String(announcePayload.message ?? "");
+      const message = typeof announcePayload.message === "string" ? announcePayload.message : "";
       expect(message).toContain("token=***");
       expect(message).not.toContain("opaque-secret-value");
     } finally {

--- a/src/llm/providers/anthropic.test.ts
+++ b/src/llm/providers/anthropic.test.ts
@@ -425,7 +425,7 @@ describe("Anthropic provider", () => {
             timestamp: 0,
           },
         ],
-      },
+      } as unknown as Context,
       {
         apiKey: "sk-ant-provider",
         onPayload: (payload) => {

--- a/src/llm/providers/mistral.test.ts
+++ b/src/llm/providers/mistral.test.ts
@@ -295,7 +295,8 @@ describe("Mistral provider", () => {
     const toolContent = Array.isArray(toolMessage!.content) ? toolMessage!.content : [];
     const textBlock = toolContent.find((block) => block.type === "text");
     expect(textBlock?.text).toEqual(expect.stringContaining('{"type":"resource"'));
-    expect(textBlock?.text).toContain('{\\"key\\":\\"value\\"}');
+    expect(textBlock?.text).toContain('{\\"key\\":\\"***\\"}');
+    expect(textBlock?.text).not.toContain('{\\"key\\":\\"value\\"}');
   });
 
   it("serializes structured-only tool results instead of empty fallback", async () => {


### PR DESCRIPTION
## What Problem This Solves

OpenClaw's hosted CI baseline fails in core test typechecking, lint, and the Mistral provider shard after recent test changes. This blocks exact-head validation for otherwise unrelated pull requests.

## Why This Change Was Made

The affected tests now describe their mock argument contracts instead of relying on zero-argument inference, narrow unknown payload fields before string use, mark the structured Anthropic fixture as intentionally beyond the canonical transcript type, and expect provider-facing secret redaction in the Mistral payload.

This is a test-only repair. Runtime behavior is unchanged.

## User Impact

No product behavior changes. Maintainers regain a green hosted CI baseline and can validate unrelated pull requests against exact-head CI.

AI-assisted implementation; every change was manually checked and independently autoreviewed.

## Evidence

- Before: exact-head CI run `28503827841` reproduced the current-main failures in core test typechecking, lint, and the Mistral provider assertion.
- Focused Vitest after rebase to current main: 107 passed across the affected gateway and provider suites.
- Blacksmith Testbox through Crabbox: `tbx_01kweedvy36fm82ctx6dp92asf`; core test typecheck, changed-file lint, dependency/package guards, and repository guards passed ([run](https://github.com/openclaw/openclaw/actions/runs/28505905341)).
- Direct `oxfmt --check`, oxlint, and `git diff --check` passed for all four files.
- Fresh Codex autoreview: clean, no accepted/actionable findings (0.98 confidence).
