### PR TITLE
fix: normalize plugin policy approval copy

### DIFF
--- a/src/gateway/node-invoke-plugin-policy.test.ts
+++ b/src/gateway/node-invoke-plugin-policy.test.ts
@@ -287,6 +287,36 @@ describe("applyPluginNodeInvokePolicy", () => {
     await expectApprovalResolution(resultPromise, manager, record);
   });
 
+  it("normalizes blank plugin policy approval copy before storing pending records", async () => {
+    const manager = new ExecApprovalManager<PluginApprovalRequestPayload>();
+    setDangerousDemoCommandRegistry([
+      createDemoPolicy(async (ctx: OpenClawPluginNodeInvokePolicyContext) => {
+        const approval = await ctx.approvals?.request({
+          title: "   ",
+          description: "\t",
+        });
+        return { ok: true, payload: approval ?? null };
+      }),
+    ]);
+    const { context } = createContext({
+      pluginApprovalManager: manager,
+      getApprovalClientConnIds: createApprovalClientLookup([
+        createApprovalClient({
+          connId: "conn-owner-approval",
+          clientId: "client-owner",
+          deviceId: "device-owner",
+        }),
+      ]),
+    });
+    const resultPromise = invokeDemoPolicy(context, createOperatorClient());
+
+    const record = await expectSinglePendingApproval(manager);
+    expect(record.request.title).toBe("Plugin approval required");
+    expect(record.request.description).toBe(`Plugin policy for ${DEMO_COMMAND} requires approval.`);
+
+    await expectApprovalResolution(resultPromise, manager, record);
+  });
+
   it("leaves commands without a dangerous plugin registration to normal allowlist handling", async () => {
     registryState.current = {
       nodeHostCommands: [],

--- a/src/gateway/node-invoke-plugin-policy.ts
+++ b/src/gateway/node-invoke-plugin-policy.ts
@@ -3,7 +3,11 @@
 import { randomUUID } from "node:crypto";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { PluginApprovalRequestPayload } from "../infra/plugin-approvals.js";
-import { resolvePluginApprovalTimeoutMs } from "../infra/plugin-approvals.js";
+import {
+  PLUGIN_APPROVAL_DESCRIPTION_MAX_LENGTH,
+  PLUGIN_APPROVAL_TITLE_MAX_LENGTH,
+  resolvePluginApprovalTimeoutMs,
+} from "../infra/plugin-approvals.js";
 import { getActiveRuntimePluginRegistry } from "../plugins/active-runtime-registry.js";
 import type { PluginRegistry } from "../plugins/registry-types.js";
 import type {
@@ -49,10 +53,15 @@ function findDangerousPluginNodeCommand(registry: PluginRegistry | null, command
   );
 }
 
+function normalizePolicyApprovalText(value: string, maxLength: number, fallback: string): string {
+  return (normalizeOptionalString(value) ?? fallback).slice(0, maxLength);
+}
+
 function createApprovalRuntime(params: {
   context: GatewayRequestContext;
   client: GatewayClient | null;
   pluginId: string;
+  command: string;
 }): OpenClawPluginNodeInvokePolicyContext["approvals"] | undefined {
   const manager = params.context.pluginApprovalManager;
   if (!manager) {
@@ -63,8 +72,16 @@ function createApprovalRuntime(params: {
       const timeoutMs = resolvePluginApprovalTimeoutMs(input.timeoutMs);
       const request: PluginApprovalRequestPayload = {
         pluginId: params.pluginId,
-        title: input.title.slice(0, 80),
-        description: input.description.slice(0, 256),
+        title: normalizePolicyApprovalText(
+          input.title,
+          PLUGIN_APPROVAL_TITLE_MAX_LENGTH,
+          "Plugin approval required",
+        ),
+        description: normalizePolicyApprovalText(
+          input.description,
+          PLUGIN_APPROVAL_DESCRIPTION_MAX_LENGTH,
+          `Plugin policy for ${params.command} requires approval.`,
+        ),
         severity: input.severity ?? "warning",
         toolName: normalizeOptionalString(input.toolName) ?? null,
         toolCallId: normalizeOptionalString(input.toolCallId) ?? null,
@@ -196,6 +213,7 @@ export async function applyPluginNodeInvokePolicy(params: {
       context: params.context,
       client: params.client,
       pluginId: entry.pluginId,
+      command: params.command,
     }),
     invokeNode,
   });


### PR DESCRIPTION
﻿Fixes #98534

## Summary
- normalize plugin node.invoke policy approval title/description before storing pending approval records
- fall back to non-empty copy when policy-provided approval text is whitespace-only
- add regression coverage for blank policy approval copy

## Tests
- `node scripts/run-with-env.mjs OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 OPENCLAW_GATEWAY_PROJECT_SHARDS=0 -- node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/node-invoke-plugin-policy.test.ts --testTimeout=30000 --reporter=dot`
- `git diff --check`

Note: the same single-file command with `OPENCLAW_GATEWAY_PROJECT_SHARDS=1` stalled before running tests; the scoped gateway config with `OPENCLAW_GATEWAY_PROJECT_SHARDS=0` completed and passed.
