### PR TITLE
feat: prepare scoped conversation capability profiles

### DIFF
--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -10,6 +10,7 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import type { SourceReplyDeliveryMode } from "../auto-reply/get-reply-options.types.js";
 import { HEARTBEAT_RESPONSE_TOOL_NAME } from "../auto-reply/heartbeat-tool-response.js";
+import type { ChatType } from "../channels/chat-type.js";
 import type { InboundEventKind } from "../channels/inbound-event/kind.js";
 import { resolveExecCommandHighlighting } from "../config/exec-command-highlighting.js";
 import type { ModelCompatConfig } from "../config/types.models.js";
@@ -35,12 +36,6 @@ import {
 import { applyDeferredFollowupToolDescriptions } from "./agent-tools.deferred-followup.js";
 import { filterToolsByMessageProvider } from "./agent-tools.message-provider-policy.js";
 import {
-  resolveEffectiveToolPolicy,
-  resolveGroupToolPolicy,
-  resolveInheritedToolPolicyForSession,
-  resolveSubagentToolPolicyForSession,
-} from "./agent-tools.policy.js";
-import {
   assertRequiredParams,
   createHostWorkspaceEditTool,
   createHostWorkspaceWriteTool,
@@ -64,6 +59,10 @@ import type { ProcessToolDefaults } from "./bash-tools.process.js";
 import { execSchema, processSchema } from "./bash-tools.schemas.js";
 import { listChannelAgentTools } from "./channel-tools.js";
 import { shouldSuppressManagedWebSearchTool } from "./codex-native-web-search.js";
+import {
+  resolveConversationCapabilityProfile,
+  type ResolvedConversationCapabilityProfile,
+} from "./conversation-capability-profile.js";
 import { resolveImageSanitizationLimits } from "./image-sanitization.js";
 import {
   filterLocalModelLeanTools,
@@ -75,12 +74,7 @@ import { createOpenClawTools } from "./openclaw-tools.js";
 import type { SandboxContext } from "./sandbox.js";
 import { SANDBOX_AGENT_WORKSPACE_MOUNT } from "./sandbox/constants.js";
 import { resolveReadOnlyWorkspaceSkillMounts } from "./sandbox/workspace-mounts.js";
-import { resolveSenderToolPolicy } from "./sender-tool-policy.js";
 import { createCodingTools, createReadTool } from "./sessions/index.js";
-import {
-  isSubagentEnvelopeSession,
-  resolveSubagentCapabilityStore,
-} from "./subagent-capabilities.js";
 import {
   EXEC_TOOL_DISPLAY_SUMMARY,
   PROCESS_TOOL_DISPLAY_SUMMARY,
@@ -94,14 +88,11 @@ import {
   buildDefaultToolPolicyPipelineSteps,
 } from "./tool-policy-pipeline.js";
 import {
-  collectExplicitAllowlist,
-  collectExplicitDenylist,
   expandToolGroups,
   hasRestrictiveAllowPolicy,
   mergeAlsoAllowPolicy,
   normalizeToolName,
   replaceWithEffectiveToolAllowlist,
-  resolveToolProfilePolicy,
 } from "./tool-policy.js";
 import {
   createToolSearchTools,
@@ -117,7 +108,6 @@ import {
   replaceWithEffectiveCronCreatorToolAllowlist,
   type CronCreatorToolAllowlistEntry,
 } from "./tools/cron-tool.js";
-import { resolveWorkspaceRoot } from "./workspace-dir.js";
 
 const MEMORY_FLUSH_ALLOWED_TOOL_NAMES = new Set(["read", "write"]);
 
@@ -397,6 +387,8 @@ export function createOpenClawCodingTools(options?: {
   messageProvider?: string;
   /** Canonical transport channel when tool-policy provider differs from delivery channel. */
   messageChannel?: string;
+  /** Normalized conversation kind when the caller already has channel metadata. */
+  chatType?: ChatType;
   /** Specific ingress provider used only for transport tool availability. */
   toolPolicyMessageProvider?: string;
   agentAccountId?: string;
@@ -543,6 +535,8 @@ export function createOpenClawCodingTools(options?: {
   allocateToolOutcomeOrdinal?: (toolCallId?: string) => number;
   /** Runtime-only resolved skill paths that the read tool may load under workspaceOnly. */
   skillsSnapshot?: SkillSnapshot;
+  /** Prepared conversation-scoped facts for callers that already resolved this run context. */
+  conversationCapabilityProfile?: ResolvedConversationCapabilityProfile;
 }): AnyAgentTool[] {
   const execToolName = "exec";
   const sandbox = options?.sandbox?.enabled ? options.sandbox : undefined;
@@ -553,6 +547,52 @@ export function createOpenClawCodingTools(options?: {
   const memoryFlushWritePath = isMemoryFlushRun ? options.memoryFlushWritePath : undefined;
   const cronSelfRemoveOnlyJobId =
     options?.trigger === "cron" && options.jobId?.trim() ? options.jobId.trim() : undefined;
+  // Prefer the already-resolved sandbox context policy. Recomputing from
+  // sessionKey/config can lose the real sandbox agent when callers pass a
+  // legacy alias like `main` instead of an agent session key.
+  const sandboxToolPolicy = sandbox?.tools;
+  const capabilityProfile =
+    options?.conversationCapabilityProfile ??
+    resolveConversationCapabilityProfile({
+      config: options?.config,
+      sessionKey: options?.sessionKey,
+      runSessionKey: options?.runSessionKey,
+      sessionId: options?.sessionId,
+      runId: options?.runId,
+      agentId: options?.agentId,
+      agentDir: options?.agentDir,
+      agentAccountId: options?.agentAccountId,
+      messageProvider: options?.messageProvider,
+      messageChannel: options?.messageChannel,
+      chatType: options?.chatType,
+      messageTo: options?.messageTo,
+      messageThreadId: options?.messageThreadId,
+      currentChannelId: options?.currentChannelId,
+      currentMessagingTarget: options?.currentMessagingTarget,
+      currentThreadTs: options?.currentThreadTs,
+      currentMessageId: options?.currentMessageId,
+      groupId: options?.groupId,
+      groupChannel: options?.groupChannel,
+      groupSpace: options?.groupSpace,
+      memberRoleIds: options?.memberRoleIds,
+      spawnedBy: options?.spawnedBy,
+      senderId: options?.senderId,
+      senderName: options?.senderName,
+      senderUsername: options?.senderUsername,
+      senderE164: options?.senderE164,
+      senderIsOwner: options?.senderIsOwner,
+      modelProvider: options?.modelProvider,
+      modelId: options?.modelId,
+      modelApi: options?.modelApi,
+      modelContextWindowTokens: options?.modelContextWindowTokens,
+      modelHasVision: options?.modelHasVision,
+      workspaceDir: options?.workspaceDir,
+      cwd: options?.cwd,
+      spawnWorkspaceDir: options?.spawnWorkspaceDir,
+      skillsSnapshot: options?.skillsSnapshot,
+      sandboxToolPolicy,
+      runtimeToolAllowlist: options?.runtimeToolAllowlist,
+    });
   const {
     agentId,
     globalPolicy,
@@ -561,44 +601,15 @@ export function createOpenClawCodingTools(options?: {
     agentProviderPolicy,
     profile,
     providerProfile,
+    profilePolicy,
+    providerProfilePolicy,
     profileAlsoAllow,
     providerProfileAlsoAllow,
-  } = resolveEffectiveToolPolicy({
-    config: options?.config,
-    sessionKey: options?.sessionKey,
-    agentId: options?.agentId,
-    modelProvider: options?.modelProvider,
-    modelId: options?.modelId,
-  });
-  // Prefer the already-resolved sandbox context policy. Recomputing from
-  // sessionKey/config can lose the real sandbox agent when callers pass a
-  // legacy alias like `main` instead of an agent session key.
-  const sandboxToolPolicy = sandbox?.tools;
-  const groupPolicy = resolveGroupToolPolicy({
-    config: options?.config,
-    sessionKey: options?.sessionKey,
-    spawnedBy: options?.spawnedBy,
-    messageProvider: options?.messageProvider,
-    groupId: options?.groupId,
-    groupChannel: options?.groupChannel,
-    groupSpace: options?.groupSpace,
-    accountId: options?.agentAccountId,
-    senderId: options?.senderId,
-    senderName: options?.senderName,
-    senderUsername: options?.senderUsername,
-    senderE164: options?.senderE164,
-  });
-  const senderPolicy = resolveSenderToolPolicy({
-    config: options?.config,
-    agentId,
-    messageProvider: options?.messageProvider,
-    senderId: options?.senderId,
-    senderName: options?.senderName,
-    senderUsername: options?.senderUsername,
-    senderE164: options?.senderE164,
-  });
-  const profilePolicy = resolveToolProfilePolicy(profile);
-  const providerProfilePolicy = resolveToolProfilePolicy(providerProfile);
+    groupPolicy,
+    senderPolicy,
+    subagentPolicy,
+    inheritedToolPolicy,
+  } = capabilityProfile.policy;
 
   const enableHeartbeatTool =
     options?.enableHeartbeatTool === true ||
@@ -654,26 +665,6 @@ export function createOpenClawCodingTools(options?: {
     sessionId: options?.sessionId,
     agentId,
   });
-  const subagentStore = resolveSubagentCapabilityStore(options?.sessionKey, {
-    cfg: options?.config,
-  });
-  const subagentPolicy =
-    options?.sessionKey &&
-    isSubagentEnvelopeSession(options.sessionKey, {
-      cfg: options.config,
-      store: subagentStore,
-    })
-      ? resolveSubagentToolPolicyForSession(options.config, options.sessionKey, {
-          store: subagentStore,
-        })
-      : undefined;
-  const inheritedToolPolicy = resolveInheritedToolPolicyForSession(
-    options?.config,
-    options?.sessionKey,
-    {
-      store: subagentStore,
-    },
-  );
   const globalPolicyWithToolSearchControls = mergeToolSearchControlAllowlist(globalPolicy);
   const globalProviderPolicyWithToolSearchControls =
     mergeToolSearchControlAllowlist(globalProviderPolicy);
@@ -707,8 +698,8 @@ export function createOpenClawCodingTools(options?: {
   const sandboxRoot = sandbox?.workspaceDir;
   const sandboxFsBridge = sandbox?.fsBridge;
   const allowWorkspaceWrites = sandbox?.workspaceAccess !== "ro";
-  const workspaceRoot = resolveWorkspaceRoot(options?.workspaceDir);
-  const runtimeRoot = resolveWorkspaceRoot(options?.cwd ?? options?.workspaceDir);
+  const workspaceRoot = capabilityProfile.workspace.workspaceRoot;
+  const runtimeRoot = capabilityProfile.workspace.runtimeRoot;
   const codingRoot = sandboxRoot ?? runtimeRoot;
   const memoryFlushWriteRoot = sandboxRoot ?? workspaceRoot;
   const includeCoreTools = options?.includeCoreTools !== false;
@@ -885,51 +876,13 @@ export function createOpenClawCodingTools(options?: {
           workspaceOnly: applyPatchWorkspaceOnly,
         });
   options?.recordToolPrepStage?.("shell-tools");
-  const pluginToolAllowlist = collectExplicitAllowlist([
-    profilePolicy,
-    providerProfilePolicy,
-    globalPolicy,
-    globalProviderPolicy,
-    agentPolicy,
-    agentProviderPolicy,
-    groupPolicy,
-    senderPolicy,
-    sandboxToolPolicy,
-    subagentPolicy,
-    inheritedToolPolicy,
-    options?.runtimeToolAllowlist ? { allow: options.runtimeToolAllowlist } : undefined,
-  ]);
-  const pluginToolDenylist = collectExplicitDenylist([
-    profilePolicy,
-    providerProfilePolicy,
-    globalPolicy,
-    globalProviderPolicy,
-    agentPolicy,
-    agentProviderPolicy,
-    groupPolicy,
-    senderPolicy,
-    sandboxToolPolicy,
-    subagentPolicy,
-    inheritedToolPolicy,
-  ]);
+  const pluginToolAllowlist = capabilityProfile.policy.explicitToolAllowlist;
+  const pluginToolDenylist = capabilityProfile.policy.explicitToolDenylist;
   const inheritedToolDenylist = [...pluginToolDenylist];
   // Passed by reference to sessions_spawn and populated after the final policy
   // pass so child sessions inherit the actual parent tool surface.
   const inheritedToolAllowlist: string[] = [];
-  const toolPolicyInheritanceSources = [
-    profilePolicy,
-    providerProfilePolicy,
-    globalPolicy,
-    globalProviderPolicy,
-    agentPolicy,
-    agentProviderPolicy,
-    groupPolicy,
-    senderPolicy,
-    sandboxToolPolicy,
-    subagentPolicy,
-    inheritedToolPolicy,
-    options?.runtimeToolAllowlist ? { allow: options.runtimeToolAllowlist } : undefined,
-  ];
+  const toolPolicyInheritanceSources = capabilityProfile.policy.inheritancePolicies;
   const shouldInheritEffectiveToolAllowlist =
     toolPolicyInheritanceSources.some(hasRestrictiveAllowPolicy);
   const cronCreatorToolAllowlist = options?.cronCreatorToolAllowlistRef ?? [];
@@ -1038,9 +991,7 @@ export function createOpenClawCodingTools(options?: {
           sandboxFsBridge,
           fsPolicy,
           workspaceDir: workspaceRoot,
-          spawnWorkspaceDir: options?.spawnWorkspaceDir
-            ? resolveWorkspaceRoot(options.spawnWorkspaceDir)
-            : undefined,
+          spawnWorkspaceDir: capabilityProfile.workspace.spawnWorkspaceRoot,
           sandboxed: Boolean(sandbox),
           config: options?.config,
           pluginToolAllowlist,

--- a/src/agents/conversation-capability-profile.test.ts
+++ b/src/agents/conversation-capability-profile.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveConversationCapabilityProfile } from "./conversation-capability-profile.js";
+
+describe("resolveConversationCapabilityProfile", () => {
+  it("prepares a direct conversation profile with sender tool restrictions", () => {
+    const cfg: OpenClawConfig = {
+      tools: {
+        toolsBySender: {
+          "id:guest": { deny: ["exec", "process"] },
+        },
+      },
+    };
+
+    const profile = resolveConversationCapabilityProfile({
+      config: cfg,
+      sessionKey: "agent:main:discord:dm:guest",
+      agentId: "main",
+      messageProvider: "discord",
+      chatType: "direct",
+      senderId: "guest",
+      modelProvider: "openai",
+      modelId: "gpt-5.5",
+      modelApi: "responses",
+      workspaceDir: "/tmp/openclaw-direct-profile",
+      cwd: "/tmp/openclaw-direct-profile/task",
+      agentDir: "/tmp/openclaw-agent-direct-profile",
+      skillsSnapshot: {
+        prompt: "",
+        skills: [{ name: "ops" }],
+      },
+    });
+
+    expect(profile.conversation.scope).toBe("direct");
+    expect(profile.policy.senderPolicy).toEqual({ deny: ["exec", "process"] });
+    expect(profile.policy.explicitToolDenylist).toEqual(["exec", "process"]);
+    expect(profile.model).toMatchObject({
+      provider: "openai",
+      id: "gpt-5.5",
+      api: "responses",
+    });
+    expect(profile.workspace).toMatchObject({
+      workspaceRoot: "/tmp/openclaw-direct-profile",
+      runtimeRoot: "/tmp/openclaw-direct-profile/task",
+      instructionRoot: "/tmp/openclaw-agent-direct-profile",
+    });
+    expect(profile.skills.snapshot?.skills).toEqual([{ name: "ops" }]);
+  });
+
+  it("prepares a shared conversation profile with group per-sender restrictions", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        whatsapp: {
+          groups: {
+            team: {
+              tools: { allow: ["read"] },
+              toolsBySender: {
+                "id:alice": { allow: ["read", "exec"] },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const profile = resolveConversationCapabilityProfile({
+      config: cfg,
+      sessionKey: "agent:main:whatsapp:group:team",
+      agentId: "main",
+      messageProvider: "whatsapp",
+      chatType: "group",
+      groupId: "team",
+      senderId: "alice",
+      modelProvider: "openai",
+      modelId: "gpt-5.5",
+      workspaceDir: "/tmp/openclaw-shared-profile",
+    });
+
+    expect(profile.conversation.scope).toBe("shared");
+    expect(profile.policy.trustedGroup).toEqual({ groupId: "team", dropped: false });
+    expect(profile.policy.groupPolicy).toEqual({ allow: ["read", "exec"] });
+    expect(profile.policy.explicitToolAllowlist).toEqual(["read", "exec"]);
+  });
+});

--- a/src/agents/conversation-capability-profile.ts
+++ b/src/agents/conversation-capability-profile.ts
@@ -1,0 +1,357 @@
+/**
+ * Resolves the conversation-scoped runtime facts that tool and harness policy
+ * hot paths share. Keep this internal: it prepares existing config/state, not a
+ * new public access-profile config surface.
+ */
+import type { ChatType } from "../channels/chat-type.js";
+import { normalizeChatType } from "../channels/chat-type.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { SkillSnapshot } from "../skills/types.js";
+import {
+  resolveEffectiveToolPolicy,
+  resolveGroupToolPolicy,
+  resolveInheritedToolPolicyForSession,
+  resolveSubagentToolPolicyForSession,
+  resolveTrustedGroupId,
+} from "./agent-tools.policy.js";
+import type { SandboxToolPolicy } from "./sandbox/types.js";
+import { resolveSenderToolPolicy } from "./sender-tool-policy.js";
+import {
+  isSubagentEnvelopeSession,
+  resolveSubagentCapabilityStore,
+} from "./subagent-capabilities.js";
+import type { PromptMode } from "./system-prompt.types.js";
+import {
+  collectExplicitAllowlist,
+  collectExplicitDenylist,
+  resolveToolProfilePolicy,
+  type ToolPolicyLike,
+} from "./tool-policy.js";
+import { resolveWorkspaceRoot } from "./workspace-dir.js";
+
+export type ConversationCapabilityScope = "direct" | "shared" | "unknown";
+
+export type ConversationCapabilityProfileParams = {
+  config?: OpenClawConfig;
+  sessionKey?: string;
+  /** Live conversation key when a sandbox/policy key is used for tool filtering. */
+  runSessionKey?: string;
+  /** Session key used for subagent capability inheritance when it differs from sessionKey. */
+  sandboxSessionKey?: string;
+  sessionId?: string;
+  runId?: string;
+  agentId?: string;
+  agentDir?: string;
+  agentAccountId?: string | null;
+  messageProvider?: string | null;
+  messageChannel?: string | null;
+  chatType?: ChatType | string;
+  messageTo?: string | null;
+  messageThreadId?: string | number | null;
+  currentChannelId?: string | null;
+  currentMessagingTarget?: string | null;
+  currentThreadTs?: string | null;
+  currentMessageId?: string | number | null;
+  groupId?: string | null;
+  groupChannel?: string | null;
+  groupSpace?: string | null;
+  memberRoleIds?: readonly string[];
+  spawnedBy?: string | null;
+  senderId?: string | null;
+  senderName?: string | null;
+  senderUsername?: string | null;
+  senderE164?: string | null;
+  senderIsOwner?: boolean;
+  modelProvider?: string;
+  modelId?: string;
+  modelApi?: string;
+  modelContextWindowTokens?: number;
+  modelHasVision?: boolean;
+  workspaceDir?: string;
+  cwd?: string;
+  spawnWorkspaceDir?: string;
+  isCanonicalWorkspace?: boolean;
+  promptMode?: PromptMode;
+  skillsSnapshot?: SkillSnapshot;
+  sandboxToolPolicy?: SandboxToolPolicy;
+  runtimeToolAllowlist?: string[];
+};
+
+export type ResolvedConversationCapabilityProfile = {
+  agentId?: string;
+  serviceIdentity: {
+    agentId?: string;
+    agentDir?: string;
+    accountId?: string | null;
+    runId?: string;
+    sessionId?: string;
+  };
+  model: {
+    provider?: string;
+    id?: string;
+    api?: string;
+    contextWindowTokens?: number;
+    hasVision?: boolean;
+  };
+  conversation: {
+    scope: ConversationCapabilityScope;
+    chatType?: ChatType;
+    sessionKey?: string;
+    policySessionKey?: string;
+    runSessionKey?: string;
+    sessionId?: string;
+    messageProvider?: string | null;
+    messageChannel?: string | null;
+    messageTo?: string | null;
+    messageThreadId?: string | number | null;
+    currentChannelId?: string | null;
+    currentMessagingTarget?: string | null;
+    currentThreadTs?: string | null;
+    currentMessageId?: string | number | null;
+    groupId?: string | null;
+    groupChannel?: string | null;
+    groupSpace?: string | null;
+    memberRoleIds?: readonly string[];
+    spawnedBy?: string | null;
+  };
+  sender: {
+    id?: string | null;
+    name?: string | null;
+    username?: string | null;
+    e164?: string | null;
+    isOwner?: boolean;
+  };
+  workspace: {
+    workspaceDir?: string;
+    cwd?: string;
+    spawnWorkspaceDir?: string;
+    workspaceRoot: string;
+    runtimeRoot: string;
+    spawnWorkspaceRoot?: string;
+    instructionRoot?: string;
+    isCanonicalWorkspace?: boolean;
+  };
+  instructions: {
+    agentDir?: string;
+    workspaceDir?: string;
+    promptMode?: PromptMode;
+    isCanonicalWorkspace?: boolean;
+  };
+  skills: {
+    snapshot?: SkillSnapshot;
+  };
+  policy: {
+    agentId?: string;
+    sessionKey?: string;
+    subagentSessionKey?: string;
+    trustedGroup: {
+      groupId: string | null | undefined;
+      dropped: boolean;
+    };
+    profile?: string;
+    providerProfile?: string;
+    profilePolicy?: ToolPolicyLike;
+    providerProfilePolicy?: ToolPolicyLike;
+    profileAlsoAllow?: string[];
+    providerProfileAlsoAllow?: string[];
+    globalPolicy?: SandboxToolPolicy;
+    globalProviderPolicy?: SandboxToolPolicy;
+    agentPolicy?: SandboxToolPolicy;
+    agentProviderPolicy?: SandboxToolPolicy;
+    groupPolicy?: SandboxToolPolicy;
+    senderPolicy?: SandboxToolPolicy;
+    sandboxPolicy?: SandboxToolPolicy;
+    subagentPolicy?: SandboxToolPolicy;
+    inheritedToolPolicy?: SandboxToolPolicy;
+    inheritancePolicies: Array<ToolPolicyLike | undefined>;
+    explicitToolAllowlist: string[];
+    explicitToolDenylist: string[];
+  };
+};
+
+export function resolveConversationCapabilityProfile(
+  params: ConversationCapabilityProfileParams,
+): ResolvedConversationCapabilityProfile {
+  const messageProvider = params.messageProvider;
+  const effective = resolveEffectiveToolPolicy({
+    config: params.config,
+    sessionKey: params.sessionKey,
+    agentId: params.agentId,
+    modelProvider: params.modelProvider,
+    modelId: params.modelId,
+  });
+  const trustedGroup = resolveTrustedGroupId({
+    sessionKey: params.sessionKey,
+    spawnedBy: params.spawnedBy,
+    groupId: params.groupId,
+  });
+  const groupPolicy = resolveGroupToolPolicy({
+    config: params.config,
+    sessionKey: params.sessionKey,
+    spawnedBy: params.spawnedBy,
+    messageProvider: messageProvider ?? undefined,
+    groupId: trustedGroup.groupId,
+    groupChannel: trustedGroup.dropped ? null : params.groupChannel,
+    groupSpace: trustedGroup.dropped ? null : params.groupSpace,
+    accountId: params.agentAccountId,
+    senderId: params.senderId,
+    senderName: params.senderName,
+    senderUsername: params.senderUsername,
+    senderE164: params.senderE164,
+  });
+  const senderPolicy = resolveSenderToolPolicy({
+    config: params.config,
+    agentId: effective.agentId,
+    messageProvider,
+    senderId: params.senderId,
+    senderName: params.senderName,
+    senderUsername: params.senderUsername,
+    senderE164: params.senderE164,
+  });
+  const profilePolicy = resolveToolProfilePolicy(effective.profile);
+  const providerProfilePolicy = resolveToolProfilePolicy(effective.providerProfile);
+  const subagentSessionKey = params.sandboxSessionKey ?? params.sessionKey;
+  const subagentStore = resolveSubagentCapabilityStore(subagentSessionKey, {
+    cfg: params.config,
+  });
+  const subagentPolicy =
+    subagentSessionKey &&
+    isSubagentEnvelopeSession(subagentSessionKey, {
+      cfg: params.config,
+      store: subagentStore,
+    })
+      ? resolveSubagentToolPolicyForSession(params.config, subagentSessionKey, {
+          store: subagentStore,
+        })
+      : undefined;
+  const inheritedToolPolicy = resolveInheritedToolPolicyForSession(
+    params.config,
+    subagentSessionKey,
+    {
+      store: subagentStore,
+    },
+  );
+  const inheritancePolicies = [
+    profilePolicy,
+    providerProfilePolicy,
+    effective.globalPolicy,
+    effective.globalProviderPolicy,
+    effective.agentPolicy,
+    effective.agentProviderPolicy,
+    groupPolicy,
+    senderPolicy,
+    params.sandboxToolPolicy,
+    subagentPolicy,
+    inheritedToolPolicy,
+    params.runtimeToolAllowlist ? { allow: params.runtimeToolAllowlist } : undefined,
+  ];
+
+  return {
+    agentId: effective.agentId,
+    serviceIdentity: {
+      agentId: effective.agentId,
+      agentDir: params.agentDir,
+      accountId: params.agentAccountId,
+      runId: params.runId,
+      sessionId: params.sessionId,
+    },
+    model: {
+      provider: params.modelProvider,
+      id: params.modelId,
+      api: params.modelApi,
+      contextWindowTokens: params.modelContextWindowTokens,
+      hasVision: params.modelHasVision,
+    },
+    conversation: {
+      scope: resolveConversationScope(params),
+      chatType: normalizeChatType(params.chatType),
+      sessionKey: params.runSessionKey ?? params.sessionKey,
+      policySessionKey: params.sessionKey,
+      runSessionKey: params.runSessionKey,
+      sessionId: params.sessionId,
+      messageProvider,
+      messageChannel: params.messageChannel,
+      messageTo: params.messageTo,
+      messageThreadId: params.messageThreadId,
+      currentChannelId: params.currentChannelId,
+      currentMessagingTarget: params.currentMessagingTarget,
+      currentThreadTs: params.currentThreadTs,
+      currentMessageId: params.currentMessageId,
+      groupId: trustedGroup.groupId,
+      groupChannel: trustedGroup.dropped ? null : params.groupChannel,
+      groupSpace: trustedGroup.dropped ? null : params.groupSpace,
+      memberRoleIds: params.memberRoleIds,
+      spawnedBy: params.spawnedBy,
+    },
+    sender: {
+      id: params.senderId,
+      name: params.senderName,
+      username: params.senderUsername,
+      e164: params.senderE164,
+      isOwner: params.senderIsOwner,
+    },
+    workspace: {
+      workspaceDir: params.workspaceDir,
+      cwd: params.cwd,
+      spawnWorkspaceDir: params.spawnWorkspaceDir,
+      workspaceRoot: resolveWorkspaceRoot(params.workspaceDir),
+      runtimeRoot: resolveWorkspaceRoot(params.cwd ?? params.workspaceDir),
+      spawnWorkspaceRoot: params.spawnWorkspaceDir
+        ? resolveWorkspaceRoot(params.spawnWorkspaceDir)
+        : undefined,
+      instructionRoot: params.agentDir ?? params.workspaceDir,
+      isCanonicalWorkspace: params.isCanonicalWorkspace,
+    },
+    instructions: {
+      agentDir: params.agentDir,
+      workspaceDir: params.workspaceDir,
+      promptMode: params.promptMode,
+      isCanonicalWorkspace: params.isCanonicalWorkspace,
+    },
+    skills: {
+      snapshot: params.skillsSnapshot,
+    },
+    policy: {
+      agentId: effective.agentId,
+      sessionKey: params.sessionKey,
+      subagentSessionKey,
+      trustedGroup,
+      profile: effective.profile,
+      providerProfile: effective.providerProfile,
+      profilePolicy,
+      providerProfilePolicy,
+      profileAlsoAllow: effective.profileAlsoAllow,
+      providerProfileAlsoAllow: effective.providerProfileAlsoAllow,
+      globalPolicy: effective.globalPolicy,
+      globalProviderPolicy: effective.globalProviderPolicy,
+      agentPolicy: effective.agentPolicy,
+      agentProviderPolicy: effective.agentProviderPolicy,
+      groupPolicy,
+      senderPolicy,
+      sandboxPolicy: params.sandboxToolPolicy,
+      subagentPolicy,
+      inheritedToolPolicy,
+      inheritancePolicies,
+      explicitToolAllowlist: collectExplicitAllowlist(inheritancePolicies),
+      explicitToolDenylist: collectExplicitDenylist(inheritancePolicies),
+    },
+  };
+}
+
+function resolveConversationScope(
+  params: Pick<
+    ConversationCapabilityProfileParams,
+    "chatType" | "groupId" | "groupChannel" | "groupSpace"
+  >,
+): ConversationCapabilityScope {
+  const chatType = normalizeChatType(params.chatType);
+  if (chatType === "direct") {
+    return "direct";
+  }
+  if (chatType === "group" || chatType === "channel") {
+    return "shared";
+  }
+  return params.groupId?.trim() || params.groupChannel?.trim() || params.groupSpace?.trim()
+    ? "shared"
+    : "unknown";
+}

--- a/src/agents/conversation-capability-profile.ts
+++ b/src/agents/conversation-capability-profile.ts
@@ -45,7 +45,7 @@ export type ConversationCapabilityProfileParams = {
   agentAccountId?: string | null;
   messageProvider?: string | null;
   messageChannel?: string | null;
-  chatType?: ChatType | string;
+  chatType?: string;
   messageTo?: string | null;
   messageThreadId?: string | number | null;
   currentChannelId?: string | null;

--- a/src/agents/embedded-agent-runner/compact.hooks.harness.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.harness.ts
@@ -777,6 +777,9 @@ export async function loadCompactHooksHarness(): Promise<{
     resolveAgentDir: vi.fn((_cfg: unknown, agentId: string) => `/tmp/agents/${agentId}/agent`),
     resolveDefaultAgentDir: vi.fn(() => "/tmp/agents/main/agent"),
     resolveDefaultAgentId: vi.fn(() => "main"),
+    resolveAgentIdFromSessionKey: vi.fn(
+      (sessionKey: string) => sessionKey.match(/^agent:([^:]+)/)?.[1] ?? "main",
+    ),
     resolveRunModelFallbacksOverride: vi.fn(() => undefined),
     resolveSessionAgentId: resolveSessionAgentIdMock,
     resolveSessionAgentIds: resolveSessionAgentIdsMock,

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -83,6 +83,7 @@ import {
   isRealConversationMessage,
 } from "../compaction-real-conversation.js";
 import { resolveContextWindowInfo } from "../context-window-guard.js";
+import { resolveConversationCapabilityProfile } from "../conversation-capability-profile.js";
 import { formatUserTime, resolveUserTimeFormat, resolveUserTimezone } from "../date-time.js";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../defaults.js";
 import { resolveOpenClawReferencePaths } from "../docs-path.js";
@@ -867,6 +868,45 @@ async function compactEmbeddedAgentSessionDirectOnce(
       });
 
     const runAbortController = new AbortController();
+    const spawnWorkspaceDir =
+      effectiveCwd !== effectiveWorkspace
+        ? resolvedWorkspace
+        : resolveAttemptSpawnWorkspaceDir({
+            sandbox,
+            resolvedWorkspace,
+          });
+    const runtimeCapabilityProfile = resolveConversationCapabilityProfile({
+      config: params.config,
+      sessionKey: sandboxSessionKey,
+      runSessionKey:
+        params.sessionKey && params.sessionKey !== sandboxSessionKey
+          ? params.sessionKey
+          : undefined,
+      sessionId: params.sessionId,
+      runId: params.runId,
+      agentDir,
+      agentAccountId: params.agentAccountId,
+      messageProvider: resolvedMessageProvider,
+      chatType: params.chatType,
+      groupId: params.groupId,
+      groupChannel: params.groupChannel,
+      groupSpace: params.groupSpace,
+      spawnedBy: params.spawnedBy,
+      senderId: params.senderId,
+      senderName: params.senderName,
+      senderUsername: params.senderUsername,
+      senderE164: params.senderE164,
+      senderIsOwner: params.senderIsOwner,
+      modelProvider: model.provider,
+      modelId,
+      modelApi: model.api,
+      modelContextWindowTokens: contextTokenBudget,
+      workspaceDir: effectiveWorkspace,
+      cwd: effectiveCwd,
+      spawnWorkspaceDir,
+      skillsSnapshot: skillsSnapshotForRun,
+      sandboxToolPolicy: sandbox?.tools,
+    });
     const toolsRaw = createOpenClawCodingTools({
       exec: {
         ...params.execOverrides,
@@ -875,6 +915,7 @@ async function compactEmbeddedAgentSessionDirectOnce(
       },
       sandbox,
       messageProvider: resolvedMessageProvider,
+      chatType: params.chatType,
       agentAccountId: params.agentAccountId,
       sessionKey: sandboxSessionKey,
       runSessionKey:
@@ -896,13 +937,7 @@ async function compactEmbeddedAgentSessionDirectOnce(
       agentDir,
       cwd: effectiveCwd,
       workspaceDir: effectiveWorkspace,
-      spawnWorkspaceDir:
-        effectiveCwd !== effectiveWorkspace
-          ? resolvedWorkspace
-          : resolveAttemptSpawnWorkspaceDir({
-              sandbox,
-              resolvedWorkspace,
-            }),
+      spawnWorkspaceDir,
       config: params.config,
       abortSignal: runAbortController.signal,
       sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
@@ -912,6 +947,7 @@ async function compactEmbeddedAgentSessionDirectOnce(
       modelApi: model.api,
       modelContextWindowTokens: contextTokenBudget,
       skillsSnapshot: skillsSnapshotForRun,
+      conversationCapabilityProfile: runtimeCapabilityProfile,
       modelAuthMode: resolveModelAuthMode(model.provider, params.config, undefined, {
         workspaceDir: effectiveWorkspace,
       }),
@@ -976,6 +1012,8 @@ async function compactEmbeddedAgentSessionDirectOnce(
       senderName: params.senderName,
       senderUsername: params.senderUsername,
       senderE164: params.senderE164,
+      senderIsOwner: params.senderIsOwner,
+      conversationCapabilityProfile: runtimeCapabilityProfile,
       warn: (message) => log.warn(message),
     });
     const normalizableBundledToolProjection = filterProviderNormalizableTools(filteredBundledTools);

--- a/src/agents/embedded-agent-runner/effective-tool-policy.ts
+++ b/src/agents/embedded-agent-runner/effective-tool-policy.ts
@@ -4,28 +4,16 @@
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { getPluginToolMeta } from "../../plugins/tools.js";
 import {
-  resolveEffectiveToolPolicy,
-  resolveGroupToolPolicy,
-  resolveInheritedToolPolicyForSession,
-  resolveTrustedGroupId,
-  resolveSubagentToolPolicyForSession,
-} from "../agent-tools.policy.js";
-import { resolveSenderToolPolicy } from "../sender-tool-policy.js";
-import {
-  isSubagentEnvelopeSession,
-  resolveSubagentCapabilityStore,
-} from "../subagent-capabilities.js";
+  resolveConversationCapabilityProfile,
+  type ResolvedConversationCapabilityProfile,
+} from "../conversation-capability-profile.js";
 import { buildDeclaredToolAllowlistContext } from "../tool-policy-declared-context.js";
 import {
   applyToolPolicyPipeline,
   buildDefaultToolPolicyPipelineSteps,
   type ToolPolicyPipelineStep,
 } from "../tool-policy-pipeline.js";
-import {
-  collectExplicitDenylist,
-  mergeAlsoAllowPolicy,
-  resolveToolProfilePolicy,
-} from "../tool-policy.js";
+import { collectExplicitDenylist, mergeAlsoAllowPolicy } from "../tool-policy.js";
 import type { AnyAgentTool } from "../tools/common.js";
 
 /**
@@ -61,6 +49,8 @@ type FinalEffectiveToolPolicyParams = {
   senderName?: string | null;
   senderUsername?: string | null;
   senderE164?: string | null;
+  senderIsOwner?: boolean;
+  conversationCapabilityProfile?: ResolvedConversationCapabilityProfile;
   warn: (message: string) => void;
   toolPolicyAuditLogLevel?: "info" | "debug";
 };
@@ -71,7 +61,28 @@ export function applyFinalEffectiveToolPolicy(
   if (params.bundledTools.length === 0) {
     return params.bundledTools;
   }
-  const trustedGroup = resolveTrustedGroupId(params);
+  const capabilityProfile =
+    params.conversationCapabilityProfile ??
+    resolveConversationCapabilityProfile({
+      config: params.config,
+      sessionKey: params.sessionKey,
+      agentId: params.agentId,
+      agentAccountId: params.agentAccountId,
+      messageProvider: params.messageProvider,
+      groupId: params.groupId,
+      groupChannel: params.groupChannel,
+      groupSpace: params.groupSpace,
+      spawnedBy: params.spawnedBy,
+      senderId: params.senderId,
+      senderName: params.senderName,
+      senderUsername: params.senderUsername,
+      senderE164: params.senderE164,
+      senderIsOwner: params.senderIsOwner,
+      modelProvider: params.modelProvider,
+      modelId: params.modelId,
+      sandboxToolPolicy: params.sandboxToolPolicy,
+    });
+  const { trustedGroup } = capabilityProfile.policy;
   // Resolve here for warnings and to strip caller-only group metadata before
   // this pass; resolveGroupToolPolicy re-checks internally for all callers.
   if (trustedGroup.dropped) {
@@ -87,65 +98,19 @@ export function applyFinalEffectiveToolPolicy(
     agentProviderPolicy,
     profile,
     providerProfile,
+    profilePolicy,
+    providerProfilePolicy,
     profileAlsoAllow,
     providerProfileAlsoAllow,
-  } = resolveEffectiveToolPolicy({
-    config: params.config,
-    sessionKey: params.sessionKey,
-    agentId: params.agentId,
-    modelProvider: params.modelProvider,
-    modelId: params.modelId,
-  });
-
-  const groupPolicy = resolveGroupToolPolicy({
-    config: params.config,
-    sessionKey: params.sessionKey,
-    spawnedBy: params.spawnedBy,
-    messageProvider: params.messageProvider,
-    groupId: trustedGroup.groupId,
-    groupChannel: trustedGroup.dropped ? null : params.groupChannel,
-    groupSpace: trustedGroup.dropped ? null : params.groupSpace,
-    accountId: params.agentAccountId,
-    senderId: params.senderId,
-    senderName: params.senderName,
-    senderUsername: params.senderUsername,
-    senderE164: params.senderE164,
-  });
-  const senderPolicy = resolveSenderToolPolicy({
-    config: params.config,
-    agentId,
-    messageProvider: params.messageProvider,
-    senderId: params.senderId,
-    senderName: params.senderName,
-    senderUsername: params.senderUsername,
-    senderE164: params.senderE164,
-  });
-  const profilePolicy = resolveToolProfilePolicy(profile);
-  const providerProfilePolicy = resolveToolProfilePolicy(providerProfile);
+    groupPolicy,
+    senderPolicy,
+    subagentPolicy,
+    inheritedToolPolicy,
+  } = capabilityProfile.policy;
   const profilePolicyWithAlsoAllow = mergeAlsoAllowPolicy(profilePolicy, profileAlsoAllow);
   const providerProfilePolicyWithAlsoAllow = mergeAlsoAllowPolicy(
     providerProfilePolicy,
     providerProfileAlsoAllow,
-  );
-  const subagentStore = resolveSubagentCapabilityStore(params.sessionKey, {
-    cfg: params.config,
-  });
-  const subagentPolicy =
-    params.sessionKey &&
-    isSubagentEnvelopeSession(params.sessionKey, {
-      cfg: params.config,
-      store: subagentStore,
-    })
-      ? resolveSubagentToolPolicyForSession(params.config, params.sessionKey, {
-          store: subagentStore,
-        })
-      : undefined;
-  const inheritedToolPolicy = resolveInheritedToolPolicyForSession(
-    params.config,
-    params.sessionKey,
-    {
-      store: subagentStore,
-    },
   );
   // Suppress unavailable-core-tool warnings on every step of this pass.
   // `applyToolPolicyPipeline` infers `coreToolNames` from the `tools` array

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -116,12 +116,6 @@ import {
   resolveProcessToolScopeKey,
   resolveToolLoopDetectionConfig,
 } from "../../agent-tools.js";
-import {
-  resolveEffectiveToolPolicy,
-  resolveGroupToolPolicy,
-  resolveInheritedToolPolicyForSession,
-  resolveSubagentToolPolicyForSession,
-} from "../../agent-tools.policy.js";
 import { createAnthropicPayloadLogger } from "../../anthropic-payload-log.js";
 import { listActiveProcessSessionReferences } from "../../bash-process-references.js";
 import {
@@ -155,6 +149,10 @@ import {
   createCodeModeTools,
   resolveCodeModeConfig,
 } from "../../code-mode.js";
+import {
+  resolveConversationCapabilityProfile,
+  type ResolvedConversationCapabilityProfile,
+} from "../../conversation-capability-profile.js";
 import { resolveUserTimezone } from "../../date-time.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../defaults.js";
 import { resolveOpenClawReferencePaths } from "../../docs-path.js";
@@ -208,10 +206,6 @@ import { createAgentSession, SessionManager } from "../../sessions/index.js";
 import { wrapToolDefinition } from "../../sessions/tools/tool-definition-wrapper.js";
 import { detectRuntimeShell } from "../../shell-utils.js";
 import { buildActiveSubagentSystemPromptAddition } from "../../subagent-active-context.js";
-import {
-  isSubagentEnvelopeSession,
-  resolveSubagentCapabilityStore,
-} from "../../subagent-capabilities.js";
 import {
   ackPendingAgentSteeringItems,
   leasePendingAgentSteeringItems,
@@ -743,49 +737,40 @@ function collectAttemptExplicitToolAllowlistSources(params: {
   senderE164?: string | null;
   sandboxToolPolicy?: { allow?: string[]; deny?: string[] };
   toolsAllow?: string[];
+  conversationCapabilityProfile?: ResolvedConversationCapabilityProfile;
 }) {
-  const { agentId, globalPolicy, globalProviderPolicy, agentPolicy, agentProviderPolicy } =
-    resolveEffectiveToolPolicy({
+  const capabilityProfile =
+    params.conversationCapabilityProfile ??
+    resolveConversationCapabilityProfile({
       config: params.config,
       sessionKey: params.sessionKey,
+      sandboxSessionKey: params.sandboxSessionKey,
       agentId: params.agentId,
       modelProvider: params.modelProvider,
       modelId: params.modelId,
+      messageProvider: params.messageProvider,
+      agentAccountId: params.agentAccountId,
+      groupId: params.groupId,
+      groupChannel: params.groupChannel,
+      groupSpace: params.groupSpace,
+      spawnedBy: params.spawnedBy,
+      senderId: params.senderId,
+      senderName: params.senderName,
+      senderUsername: params.senderUsername,
+      senderE164: params.senderE164,
+      sandboxToolPolicy: params.sandboxToolPolicy,
+      runtimeToolAllowlist: params.toolsAllow,
     });
-  const groupPolicy = resolveGroupToolPolicy({
-    config: params.config,
-    sessionKey: params.sessionKey,
-    spawnedBy: params.spawnedBy,
-    messageProvider: params.messageProvider,
-    groupId: params.groupId,
-    groupChannel: params.groupChannel,
-    groupSpace: params.groupSpace,
-    accountId: params.agentAccountId,
-    senderId: params.senderId,
-    senderName: params.senderName,
-    senderUsername: params.senderUsername,
-    senderE164: params.senderE164,
-  });
-  const subagentStore = resolveSubagentCapabilityStore(params.sandboxSessionKey, {
-    cfg: params.config,
-  });
-  const subagentPolicy =
-    params.sandboxSessionKey &&
-    isSubagentEnvelopeSession(params.sandboxSessionKey, {
-      cfg: params.config,
-      store: subagentStore,
-    })
-      ? resolveSubagentToolPolicyForSession(params.config, params.sandboxSessionKey, {
-          store: subagentStore,
-        })
-      : undefined;
-  const inheritedToolPolicy = resolveInheritedToolPolicyForSession(
-    params.config,
-    params.sandboxSessionKey,
-    {
-      store: subagentStore,
-    },
-  );
+  const {
+    agentId,
+    globalPolicy,
+    globalProviderPolicy,
+    agentPolicy,
+    agentProviderPolicy,
+    groupPolicy,
+    subagentPolicy,
+    inheritedToolPolicy,
+  } = capabilityProfile.policy;
   return collectExplicitToolAllowlistSources([
     { label: "tools.allow", allow: globalPolicy?.allow },
     { label: "tools.byProvider.allow", allow: globalProviderPolicy?.allow },
@@ -1254,6 +1239,58 @@ export async function runEmbeddedAttempt(
         : undefined;
     const toolSearchTargetTranscriptProjections: ToolSearchTargetTranscriptProjection[] = [];
     const cronCreatorToolAllowlist: CronCreatorToolAllowlistEntry[] = [];
+    const spawnWorkspaceDir =
+      effectiveCwd !== effectiveWorkspace
+        ? resolvedWorkspace
+        : resolveAttemptSpawnWorkspaceDir({
+            sandbox,
+            resolvedWorkspace,
+          });
+    const runtimeCapabilityProfile = resolveConversationCapabilityProfile({
+      config: toolSearchRuntimeConfig,
+      sessionKey: sandboxSessionKey,
+      runSessionKey:
+        params.sessionKey && params.sessionKey !== sandboxSessionKey
+          ? params.sessionKey
+          : undefined,
+      sessionId: params.sessionId,
+      runId: params.runId,
+      agentId: sessionAgentId,
+      agentDir,
+      agentAccountId: params.agentAccountId,
+      messageProvider: resolveAttemptToolPolicyMessageProvider(params),
+      messageChannel: params.messageChannel,
+      chatType: params.chatType,
+      messageTo: params.messageTo,
+      messageThreadId: params.messageThreadId,
+      currentChannelId: params.currentChannelId,
+      currentMessagingTarget: params.currentMessagingTarget,
+      currentThreadTs: params.currentThreadTs,
+      currentMessageId: params.currentMessageId,
+      groupId: params.groupId,
+      groupChannel: params.groupChannel,
+      groupSpace: params.groupSpace,
+      memberRoleIds: params.memberRoleIds,
+      spawnedBy: params.spawnedBy,
+      senderId: params.senderId,
+      senderName: params.senderName,
+      senderUsername: params.senderUsername,
+      senderE164: params.senderE164,
+      senderIsOwner: params.senderIsOwner,
+      modelProvider: params.provider,
+      modelId: params.modelId,
+      modelApi: params.model.api,
+      modelContextWindowTokens: params.model.contextWindow,
+      modelHasVision: params.model.input?.includes("image") ?? false,
+      workspaceDir: effectiveWorkspace,
+      cwd: effectiveCwd,
+      spawnWorkspaceDir,
+      isCanonicalWorkspace: params.isCanonicalWorkspace,
+      promptMode: params.promptMode,
+      skillsSnapshot: skillsSnapshotForRun,
+      sandboxToolPolicy: sandbox?.tools,
+      runtimeToolAllowlist: effectiveToolsAllow,
+    });
     const toolsRaw = !shouldConstructTools
       ? []
       : (() => {
@@ -1261,6 +1298,7 @@ export async function runEmbeddedAttempt(
             agentId: sessionAgentId,
             ...buildEmbeddedAttemptToolRunContext({ ...params, trace: runTrace }),
             messageChannel: params.messageChannel,
+            chatType: params.chatType,
             exec: {
               ...params.execOverrides,
               config: params.config,
@@ -1301,13 +1339,7 @@ export async function runEmbeddedAttempt(
             workspaceDir: effectiveWorkspace,
             // Runtime cwd can point at a task repo while bootstrap/persona files stay in the
             // agent workspace. Spawned subagents inherit the real agent workspace, not task cwd.
-            spawnWorkspaceDir:
-              effectiveCwd !== effectiveWorkspace
-                ? resolvedWorkspace
-                : resolveAttemptSpawnWorkspaceDir({
-                    sandbox,
-                    resolvedWorkspace,
-                  }),
+            spawnWorkspaceDir,
             config: toolSearchRuntimeConfig,
             abortSignal: runAbortController.signal,
             modelProvider: params.provider,
@@ -1350,6 +1382,7 @@ export async function runEmbeddedAttempt(
             onToolOutcome: params.onToolOutcome,
             allocateToolOutcomeOrdinal: params.allocateToolOutcomeOrdinal,
             skillsSnapshot: skillsSnapshotForRun,
+            conversationCapabilityProfile: runtimeCapabilityProfile,
             onYield: (message) => {
               yieldDetected = true;
               yieldMessage = message;
@@ -1608,6 +1641,8 @@ export async function runEmbeddedAttempt(
       senderName: params.senderName,
       senderUsername: params.senderUsername,
       senderE164: params.senderE164,
+      senderIsOwner: params.senderIsOwner,
+      conversationCapabilityProfile: runtimeCapabilityProfile,
       warn: (message) => log.warn(message),
     });
     const normalizedBundledTools =

--- a/src/agents/harness/selection.ts
+++ b/src/agents/harness/selection.ts
@@ -14,29 +14,15 @@ import { formatErrorMessage } from "../../infra/errors.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { resolveProviderRefOwnership } from "../../plugins/providers.js";
 import { isDefaultAgentRuntimeId, normalizeOptionalAgentRuntimeId } from "../agent-runtime-id.js";
-import {
-  resolveEffectiveToolPolicy,
-  resolveGroupToolPolicy,
-  resolveInheritedToolPolicyForSession,
-  resolveSubagentToolPolicyForSession,
-} from "../agent-tools.policy.js";
+import { resolveGroupToolPolicy } from "../agent-tools.policy.js";
+import { resolveConversationCapabilityProfile } from "../conversation-capability-profile.js";
 import type {
   EmbeddedRunAttemptParams,
   EmbeddedRunAttemptResult,
 } from "../embedded-agent-runner/run/types.js";
 import { isCliRuntimeAliasForProvider } from "../model-runtime-aliases.js";
 import { resolveSandboxRuntimeStatus } from "../sandbox/runtime-status.js";
-import { resolveSenderToolPolicy } from "../sender-tool-policy.js";
-import {
-  isSubagentEnvelopeSession,
-  resolveSubagentCapabilityStore,
-} from "../subagent-capabilities.js";
-import {
-  expandToolGroups,
-  mergeAlsoAllowPolicy,
-  normalizeToolName,
-  resolveToolProfilePolicy,
-} from "../tool-policy.js";
+import { expandToolGroups, mergeAlsoAllowPolicy, normalizeToolName } from "../tool-policy.js";
 import { createOpenClawAgentHarness } from "./builtin-openclaw.js";
 import { MissingAgentHarnessError } from "./errors.js";
 import { runAgentHarnessLifecycleAttempt } from "./lifecycle.js";
@@ -447,23 +433,27 @@ function resolvePluginHarnessDenyAllToolPolicyPrompt(
 function resolvePluginHarnessToolPolicies(
   params: PluginHarnessToolPolicyContext,
 ): ResolvedPluginHarnessToolPolicies {
-  const {
-    globalPolicy,
-    globalProviderPolicy,
-    agentPolicy,
-    agentProviderPolicy,
-    profile,
-    providerProfile,
-    profileAlsoAllow,
-    providerProfileAlsoAllow,
-  } = resolveEffectiveToolPolicy({
+  const messageProvider = params.messageProvider ?? params.messageChannel;
+  const sandboxSessionKey = params.sandboxSessionKey ?? params.sessionKey;
+  const capabilityProfile = resolveConversationCapabilityProfile({
     config: params.config,
     sessionKey: params.sessionKey,
+    sandboxSessionKey,
     agentId: params.agentId,
     modelProvider: params.provider,
     modelId: params.modelId,
+    messageProvider,
+    messageChannel: params.messageChannel,
+    agentAccountId: params.agentAccountId,
+    groupId: params.groupId,
+    groupChannel: params.groupChannel,
+    groupSpace: params.groupSpace,
+    spawnedBy: params.spawnedBy,
+    senderId: params.senderId,
+    senderName: params.senderName,
+    senderUsername: params.senderUsername,
+    senderE164: params.senderE164,
   });
-  const messageProvider = params.messageProvider ?? params.messageChannel;
   const groupPolicyParams = {
     config: params.config,
     sessionKey: params.sessionKey,
@@ -478,58 +468,30 @@ function resolvePluginHarnessToolPolicies(
     senderUsername: params.senderUsername,
     senderE164: params.senderE164,
   };
-  const groupPolicy = resolveGroupToolPolicy(groupPolicyParams);
-  const senderPolicy = resolveSenderToolPolicy({
-    config: params.config,
-    agentId: params.agentId,
-    messageProvider,
-    senderId: params.senderId,
-    senderName: params.senderName,
-    senderUsername: params.senderUsername,
-    senderE164: params.senderE164,
-  });
-  const sandboxSessionKey = params.sandboxSessionKey ?? params.sessionKey;
+  const { policy } = capabilityProfile;
   const sandboxRuntime = resolveSandboxRuntimeStatus({
     cfg: params.config,
     sessionKey: sandboxSessionKey,
   });
   const sandboxPolicy = sandboxRuntime.sandboxed ? sandboxRuntime.toolPolicy : undefined;
-  const subagentStore = resolveSubagentCapabilityStore(sandboxSessionKey, { cfg: params.config });
-  const subagentPolicy =
-    sandboxSessionKey &&
-    isSubagentEnvelopeSession(sandboxSessionKey, {
-      cfg: params.config,
-      store: subagentStore,
-    })
-      ? resolveSubagentToolPolicyForSession(params.config, sandboxSessionKey, {
-          store: subagentStore,
-        })
-      : undefined;
-  const inheritedToolPolicy = resolveInheritedToolPolicyForSession(
-    params.config,
-    sandboxSessionKey,
-    {
-      store: subagentStore,
-    },
-  );
   return {
-    senderPolicy,
+    senderPolicy: policy.senderPolicy,
     senderScopedGroupPolicy: resolveSenderScopedGroupToolPolicy(
       params,
       groupPolicyParams,
-      groupPolicy,
+      policy.groupPolicy,
     ),
-    groupPolicy,
+    groupPolicy: policy.groupPolicy,
     runtimePolicies: [
-      mergeAlsoAllowPolicy(resolveToolProfilePolicy(profile), profileAlsoAllow),
-      mergeAlsoAllowPolicy(resolveToolProfilePolicy(providerProfile), providerProfileAlsoAllow),
-      globalPolicy,
-      globalProviderPolicy,
-      agentPolicy,
-      agentProviderPolicy,
+      mergeAlsoAllowPolicy(policy.profilePolicy, policy.profileAlsoAllow),
+      mergeAlsoAllowPolicy(policy.providerProfilePolicy, policy.providerProfileAlsoAllow),
+      policy.globalPolicy,
+      policy.globalProviderPolicy,
+      policy.agentPolicy,
+      policy.agentProviderPolicy,
       sandboxPolicy,
-      subagentPolicy,
-      inheritedToolPolicy,
+      policy.subagentPolicy,
+      policy.inheritedToolPolicy,
     ],
   };
 }


### PR DESCRIPTION
Related: #98512

## What Problem This Solves

OpenClaw currently resolves the same agent, conversation, sender, workspace, model, and tool-policy facts in several hot paths during a single agent turn. That makes it harder to add scoped access behavior for digital-employee and team-operations workflows because future dependent features have to choose between redoing the same lookups or inventing another partial context shape.

This PR creates one canonical internal resolved conversation capability profile for a specific agent + conversation/channel + sender context, then wires existing tool/harness consumers to use that prepared result.

## Why This Change Was Made

The new internal resolver combines the existing service identity, model choice, channel/conversation metadata, sender identity, workspace roots, instruction/skill source, and layered tool-policy inputs without adding public config. The embedded run and compaction paths now prepare the profile once for core tool construction and appended bundled-tool filtering, while the plugin harness policy guard and direct callers can use the same resolver without changing policy order or trust checks.

Non-goals: no credential values, egress behavior, new public access-profile config, version changes, or changelog entry.

## User Impact

Operators and developers get a safer foundation for scoped access profiles: direct conversations, shared conversations, and per-sender tool restrictions are represented by one typed runtime result instead of repeated rediscovery. Existing tool availability behavior should remain unchanged.

## Evidence

AI-assisted change. No transcript attached.

Focused local proof on head `147b25a92790047d5c5dc1ec7d3aa8cae2a8be9d`:
- `pnpm exec oxfmt --check --threads=1 src/agents/conversation-capability-profile.ts src/agents/conversation-capability-profile.test.ts src/agents/agent-tools.ts src/agents/embedded-agent-runner/effective-tool-policy.ts src/agents/embedded-agent-runner/run/attempt.ts src/agents/embedded-agent-runner/compact.ts src/agents/embedded-agent-runner/compact.hooks.harness.ts src/agents/harness/selection.ts` passed.
- `git diff --check` passed.
- `node scripts/run-oxlint.mjs --tsconfig tsconfig.core.json src/agents/conversation-capability-profile.ts src/agents/conversation-capability-profile.test.ts src/agents/agent-tools.ts src/agents/embedded-agent-runner/effective-tool-policy.ts src/agents/embedded-agent-runner/run/attempt.ts src/agents/embedded-agent-runner/compact.ts src/agents/embedded-agent-runner/compact.hooks.harness.ts src/agents/harness/selection.ts` passed.
- `pnpm tsgo:core` passed.
- `node scripts/run-vitest.mjs src/agents/conversation-capability-profile.test.ts src/agents/embedded-agent-runner/effective-tool-policy.test.ts src/agents/harness/selection.test.ts src/agents/agent-tools-agent-config.test.ts src/agents/embedded-agent-runner/compact.hooks.test.ts` passed: 5 files, 162 tests.

Remote changed-gate proof:
- Crabbox provider `blacksmith-testbox`, id `tbx_01kwfhn9n7graz8rdd5n2kerxk`, linked Actions run https://github.com/openclaw/openclaw/actions/runs/28541646842.
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` passed for lanes `core, coreTests`.

Autoreview:
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --engine codex --model gpt-5.6-sol --thinking xhigh` passed with no accepted/actionable findings after the final patch shape.

