### PR TITLE
fix: disable local gateway launchd in remote mode

### DIFF
--- a/apps/macos/Sources/OpenClaw/GatewayLaunchAgentManager.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayLaunchAgentManager.swift
@@ -61,16 +61,16 @@ enum GatewayLaunchAgentManager {
 
     static func set(enabled: Bool, bundlePath: String, port: Int) async -> String? {
         _ = bundlePath
-        guard !CommandResolver.connectionModeIsRemote() else {
-            self.logger.info("launchd change skipped (remote mode)")
-            return nil
-        }
         if enabled, self.isLaunchAgentWriteDisabled() {
             self.logger.info("launchd enable skipped (disable marker set)")
             return nil
         }
 
         if enabled {
+            guard !CommandResolver.connectionModeIsRemote() else {
+                self.logger.info("launchd enable skipped (remote mode)")
+                return nil
+            }
             self.logger.info("launchd enable requested via CLI port=\(port)")
             return await self.runDaemonCommand([
                 "install",

--- a/apps/macos/Sources/OpenClaw/GatewayProcessManager.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayProcessManager.swift
@@ -130,9 +130,6 @@ final class GatewayProcessManager {
         self.lastFailureReason = nil
         self.status = .stopped
         self.logger.info("gateway stop requested")
-        if CommandResolver.connectionModeIsRemote() {
-            return
-        }
         let bundlePath = Bundle.main.bundleURL.path
         Task {
             _ = await GatewayLaunchAgentManager.set(

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayLaunchAgentManagerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayLaunchAgentManagerTests.swift
@@ -3,6 +3,30 @@ import Testing
 @testable import OpenClaw
 
 struct GatewayLaunchAgentManagerTests {
+    @Test func `remote mode still allows disabling gateway launch agent`() async {
+        let configPath = TestIsolation.tempConfigPath()
+        await TestIsolation.withIsolatedState(
+            env: ["OPENCLAW_CONFIG_PATH": configPath],
+            defaults: [connectionModeKey: AppState.ConnectionMode.remote.rawValue])
+        {
+            defer {
+                GatewayLaunchAgentManager.setTestingInterceptDaemonCommands(false)
+                GatewayLaunchAgentManager.clearTestingDaemonCommandCalls()
+            }
+            GatewayLaunchAgentManager.setTestingInterceptDaemonCommands(true)
+            GatewayLaunchAgentManager.clearTestingDaemonCommandCalls()
+
+            let error = await GatewayLaunchAgentManager.set(
+                enabled: false,
+                bundlePath: "/Applications/OpenClaw.app",
+                port: 18789)
+
+            #expect(error == nil)
+            #expect(
+                GatewayLaunchAgentManager.testingDaemonCommandCallsSnapshot() == [["uninstall"]])
+        }
+    }
+
     @Test func `attach only runtime override does not uninstall gateway launch agent`() throws {
         let dir = FileManager().temporaryDirectory
             .appendingPathComponent("openclaw-attach-only-\(UUID().uuidString)", isDirectory: true)

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayProcessManagerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayProcessManagerTests.swift
@@ -6,6 +6,36 @@ import Testing
 @Suite(.serialized)
 @MainActor
 struct GatewayProcessManagerTests {
+    @Test func `stop disables launch agent even when remote mode is active`() async {
+        let configPath = TestIsolation.tempConfigPath()
+        await TestIsolation.withIsolatedState(
+            env: ["OPENCLAW_CONFIG_PATH": configPath],
+            defaults: [connectionModeKey: AppState.ConnectionMode.remote.rawValue])
+        {
+            defer {
+                GatewayLaunchAgentManager.setTestingInterceptDaemonCommands(false)
+                GatewayLaunchAgentManager.clearTestingDaemonCommandCalls()
+                GatewayProcessManager.shared.setTestingDesiredActive(false)
+            }
+            GatewayLaunchAgentManager.setTestingInterceptDaemonCommands(true)
+            GatewayLaunchAgentManager.clearTestingDaemonCommandCalls()
+
+            GatewayProcessManager.shared.stop()
+
+            for _ in 0..<20 {
+                let calls = GatewayLaunchAgentManager.testingDaemonCommandCallsSnapshot()
+                if calls.contains(["uninstall"]) {
+                    break
+                }
+                try? await Task.sleep(nanoseconds: 25_000_000)
+            }
+
+            #expect(
+                GatewayLaunchAgentManager.testingDaemonCommandCallsSnapshot()
+                    .contains(["uninstall"]))
+        }
+    }
+
     @Test func `clears last failure when health succeeds`() async throws {
         let session = GatewayTestWebSocketSession(
             taskFactory: {


### PR DESCRIPTION
﻿Fixes #98537

## Summary
- allow `GatewayLaunchAgentManager.set(enabled: false)` to run in Remote mode while still skipping enables
- remove the Remote-mode early return from `GatewayProcessManager.stop()` so switching to Remote uninstalls the local gateway launchd job
- add Swift regression coverage for direct launch-agent disable and process-manager stop in Remote mode

## Tests
- `git diff --check`

Not run: Swift tests. This Windows environment does not have `swift` on PATH, so the new macOS tests could not be executed here.
