### PR TITLE
test(shared): add unit tests for parseConfigPathArrayIndex

### DIFF
--- a/src/shared/path-array-index.test.ts
+++ b/src/shared/path-array-index.test.ts
@@ -1,0 +1,43 @@
+// Path array index tests cover config-path index segment parsing.
+import { describe, expect, it } from "vitest";
+import { parseConfigPathArrayIndex } from "./path-array-index.js";
+
+describe("parseConfigPathArrayIndex", () => {
+  it("parses zero and positive canonical indexes", () => {
+    expect(parseConfigPathArrayIndex("0")).toBe(0);
+    expect(parseConfigPathArrayIndex("1")).toBe(1);
+    expect(parseConfigPathArrayIndex("42")).toBe(42);
+  });
+
+  it("accepts indexes up to the max bound", () => {
+    expect(parseConfigPathArrayIndex("100000")).toBe(100000);
+  });
+
+  it("rejects indexes exceeding the max bound", () => {
+    expect(parseConfigPathArrayIndex("100001")).toBeUndefined();
+    expect(parseConfigPathArrayIndex("999999")).toBeUndefined();
+  });
+
+  it("rejects leading zero indexes as non-canonical", () => {
+    expect(parseConfigPathArrayIndex("00")).toBeUndefined();
+    expect(parseConfigPathArrayIndex("01")).toBeUndefined();
+    expect(parseConfigPathArrayIndex("000")).toBeUndefined();
+  });
+
+  it("rejects negative indexes", () => {
+    expect(parseConfigPathArrayIndex("-1")).toBeUndefined();
+    expect(parseConfigPathArrayIndex("-0")).toBeUndefined();
+  });
+
+  it("rejects empty or non-numeric segments", () => {
+    expect(parseConfigPathArrayIndex("")).toBeUndefined();
+    expect(parseConfigPathArrayIndex("abc")).toBeUndefined();
+  });
+
+  it("rejects decimals, whitespace, and special characters", () => {
+    expect(parseConfigPathArrayIndex("1.5")).toBeUndefined();
+    expect(parseConfigPathArrayIndex(" 5")).toBeUndefined();
+    expect(parseConfigPathArrayIndex("5 ")).toBeUndefined();
+    expect(parseConfigPathArrayIndex("1e2")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

The `parseConfigPathArrayIndex` utility in `src/shared/path-array-index.ts` is a zero-dependency pure function that validates and parses canonical non-negative integer array index segments used by config and JSON path processing. It enforces a strict format (`/^(0|[1-9]\d*)$/`) with an upper bound of 100,000 to reject impractical sparse writes. Despite being a guard for config path safety, this module had no unit tests.

## Why This Change Was Made

Add unit tests for the `parseConfigPathArrayIndex` function covering:
- Zero and positive canonical indexes (accepts `"0"`, `"42"`)
- Maximum bound acceptance (`100000`)
- Above-bound rejection (`100001`, `999999`)
- Leading zero rejection as non-canonical (`"00"`, `"01"`, `"000"`)
- Negative index rejection (`"-1"`, `"-0"`)
- Empty and non-numeric segment rejection
- Decimal, whitespace, and special character rejection (`"1.5"`, `" 5"`, `"1e2"`)

This improves test coverage and documents the strict parsing contract for config path safety.

## User Impact

No user-visible changes. For developers, the config path array index parsing contract is now documented via tests, preventing regressions in path validation logic.

## Evidence

Reproducibility: not applicable. This PR adds direct coverage for existing utility behavior rather than reporting a user-visible runtime bug. Source inspection confirms the utility behavior the tests target.

Direct behavior probe (no mocks — real functions exercised directly):

```text
$ node --import tsx -e "import('./src/shared/path-array-index.js').then((m) => {
  const r = [];
  r.push({ desc: 'exported function', fn: typeof m.parseConfigPathArrayIndex });
  r.push({ desc: 'zero', result: m.parseConfigPathArrayIndex('0') });
  r.push({ desc: '42', result: m.parseConfigPathArrayIndex('42') });
  r.push({ desc: 'max bound 100000', result: m.parseConfigPathArrayIndex('100000') });
  r.push({ desc: 'exceeds bound 100001', result: m.parseConfigPathArrayIndex('100001') });
  r.push({ desc: 'leading zero 01', result: m.parseConfigPathArrayIndex('01') });
  r.push({ desc: 'negative -1', result: m.parseConfigPathArrayIndex('-1') });
  r.push({ desc: 'empty string', result: m.parseConfigPathArrayIndex('') });
  r.push({ desc: 'non-numeric abc', result: m.parseConfigPathArrayIndex('abc') });
  r.push({ desc: 'decimal 1.5', result: m.parseConfigPathArrayIndex('1.5') });
  r.push({ desc: 'whitespace', result: m.parseConfigPathArrayIndex(' 5') });
  console.log(JSON.stringify(r, null, 2));
})"
[
  { "desc": "exported function", "fn": "function" },
  { "desc": "zero", "result": 0 },
  { "desc": "42", "result": 42 },
  { "desc": "max bound 100000", "result": 100000 },
  { "desc": "exceeds bound 100001" },
  { "desc": "leading zero 01" },
  { "desc": "negative -1" },
  { "desc": "empty string" },
  { "desc": "non-numeric abc" },
  { "desc": "decimal 1.5" },
  { "desc": "whitespace" }
]
```

Targeted test:

```text
$ node scripts/run-vitest.mjs run src/shared/path-array-index.test.ts

 RUN  v4.1.8

 Test Files  1 passed (1)
      Tests  7 passed (7)
   Start at  17:34:18
   Duration  542ms

[test] passed 1 Vitest shard in 11.93s
```

Formatting:

```text
$ npx oxfmt --check src/shared/path-array-index.ts src/shared/path-array-index.test.ts
Checking formatting...

All matched files use the correct format.
```

Whitespace:

```text
$ git diff --check
```
