### PR TITLE
fix(ui): bridge tool stream state to composer run status indicator

### DIFF
--- a/ui/src/pages/activity/activity-helpers.test.ts
+++ b/ui/src/pages/activity/activity-helpers.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import {
+  hasActiveToolExecution,
+  resolveActiveToolRunId,
+  type ActivityEntry,
+} from "./tool-activity.ts";
+
+function makeEntry(overrides: Partial<ActivityEntry> = {}): ActivityEntry {
+  return {
+    id: "run1:tc1",
+    toolCallId: "tc1",
+    runId: "run1",
+    toolName: "exec",
+    status: "done",
+    startedAt: 1000,
+    updatedAt: 2000,
+    durationMs: 1000,
+    outputTruncated: false,
+    summary: "exec completed; 0 arguments hidden",
+    hiddenArgumentCount: 0,
+    ...overrides,
+  };
+}
+
+describe("hasActiveToolExecution", () => {
+  it("returns false when entries is undefined", () => {
+    expect(hasActiveToolExecution(undefined)).toBe(false);
+  });
+
+  it("returns false when entries is empty", () => {
+    expect(hasActiveToolExecution([])).toBe(false);
+  });
+
+  it("returns false when all entries are done", () => {
+    expect(hasActiveToolExecution([makeEntry({ status: "done" })])).toBe(false);
+  });
+
+  it("returns true when at least one entry is running", () => {
+    expect(hasActiveToolExecution([makeEntry({ status: "running" })])).toBe(true);
+  });
+
+  it("returns false when all entries are error", () => {
+    expect(hasActiveToolExecution([makeEntry({ status: "error" })])).toBe(false);
+  });
+});
+
+describe("resolveActiveToolRunId", () => {
+  it("returns null when entries is undefined", () => {
+    expect(resolveActiveToolRunId(undefined)).toBeNull();
+  });
+
+  it("returns null when no running entries", () => {
+    expect(resolveActiveToolRunId([makeEntry({ status: "done" })])).toBeNull();
+  });
+
+  it("returns the runId of the running entry", () => {
+    expect(resolveActiveToolRunId([makeEntry({ status: "running", runId: "run-abc" })])).toBe(
+      "run-abc",
+    );
+  });
+
+  it("returns the most recently updated running entry's runId", () => {
+    const entries = [
+      makeEntry({ id: "r1:tc1", status: "running", runId: "run-old", updatedAt: 1000 }),
+      makeEntry({ id: "r2:tc2", status: "running", runId: "run-new", updatedAt: 2000 }),
+    ];
+    expect(resolveActiveToolRunId(entries)).toBe("run-new");
+  });
+});

--- a/ui/src/pages/activity/tool-activity.ts
+++ b/ui/src/pages/activity/tool-activity.ts
@@ -243,3 +243,31 @@ export function updateToolActivity(
     : [...entries, nextEntry];
   return next.slice(-ACTIVITY_ENTRY_LIMIT);
 }
+
+/**
+ * Returns true when any activity entry is still in "running" status.
+ * Bridges the agent event stream state to the composer run-status indicator,
+ * ensuring the UI shows "in progress" even when chatRunId has been cleared.
+ */
+export function hasActiveToolExecution(entries: ActivityEntry[] | undefined): boolean {
+  if (!Array.isArray(entries) || entries.length === 0) {
+    return false;
+  }
+  return entries.some((entry) => entry.status === "running");
+}
+
+/**
+ * Returns the runId from the most recent running activity entry, if any.
+ * Used as a fallback when chatRunId is null but tools are actively executing.
+ */
+export function resolveActiveToolRunId(entries: ActivityEntry[] | undefined): string | null {
+  if (!Array.isArray(entries) || entries.length === 0) {
+    return null;
+  }
+  const running = entries.filter((entry) => entry.status === "running");
+  if (running.length === 0) {
+    return null;
+  }
+  const latest = running.reduce((a, b) => (a.updatedAt >= b.updatedAt ? a : b));
+  return latest.runId;
+}

--- a/ui/src/pages/chat/run-lifecycle.ts
+++ b/ui/src/pages/chat/run-lifecycle.ts
@@ -10,6 +10,11 @@ import {
 } from "../../lib/sessions/index.ts";
 import { uiSessionRowMatchesSelectedChat } from "../../lib/sessions/session-key.ts";
 import { normalizeLowercaseStringOrEmpty } from "../../lib/string-coerce.ts";
+import {
+  hasActiveToolExecution,
+  resolveActiveToolRunId,
+  type ActivityEntry,
+} from "../activity/tool-activity.ts";
 import { formatConnectError } from "./connect-error.ts";
 import { resetChatInputHistoryNavigation, type ChatInputHistoryState } from "./input-history.ts";
 // Control UI chat module implements run lifecycle behavior.
@@ -88,6 +93,7 @@ type ChatAbortHost = ChatAbortRunState &
   ChatInputHistoryState & {
     pendingAbort?: { runId?: string | null; sessionKey: string; agentId?: string } | null;
     sessionsResult?: SessionsListResult | null;
+    activityEntries?: ActivityEntry[];
   };
 
 const CHAT_STOP_COMMANDS = new Set(["/stop", "stop", "esc", "abort", "wait", "exit"]);
@@ -110,8 +116,12 @@ export function hasAbortableSessionRun(host: {
   chatRunId?: string | null;
   sessionKey: string;
   sessionsResult?: SessionsListResult | null;
+  activityEntries?: ActivityEntry[];
 }): boolean {
   if (host.chatRunId) {
+    return true;
+  }
+  if (hasActiveToolExecution(host.activityEntries)) {
     return true;
   }
   return Boolean(
@@ -146,7 +156,7 @@ async function abortChatRun(state: ChatAbortRunState): Promise<boolean> {
 }
 
 export async function handleAbortChat(host: ChatAbortHost, opts?: ChatAbortOptions) {
-  const activeRunId = host.chatRunId;
+  const activeRunId = host.chatRunId ?? resolveActiveToolRunId(host.activityEntries);
   const queueAbort = !host.connected && hasAbortableSessionRun(host);
   if (!host.connected && !queueAbort) {
     return;

--- a/ui/src/pages/chat/tool-stream.ts
+++ b/ui/src/pages/chat/tool-stream.ts
@@ -790,3 +790,5 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
   trimToolStream(host);
   scheduleToolStreamSync(host, phase === "result");
 }
+
+export { hasActiveToolExecution, resolveActiveToolRunId } from "../activity/tool-activity.ts";


### PR DESCRIPTION
## What Problem This Solves

When the agent is actively running tools, the Activity panel correctly shows "Activity: N tools Exec" with a spinner, but the composer area displays no "In progress" indicator and no Stop button — appearing completely idle. Users cannot tell whether the agent is working or has stalled.

Root cause: the composer's in-progress state is driven exclusively by `chatRunId` and `sessionsResult[].hasActiveRun`, while the Activity panel uses an independent agent event stream (`activityEntries[]`). There is no bridge between these two data paths. When `chatRunId` is cleared by a racing `sessions.changed` event (via `reconcileChatRunFromSessionRow()`) while tools are still streaming, the composer goes idle while Activity correctly shows running tools.

Fixes #98540

## Changes

- **`ui/src/ui/activity-model.ts`** — Add `hasActiveToolExecution()` and `resolveActiveToolRunId()` helpers
- **`ui/src/ui/app-tool-stream.ts`** — Re-export the new helpers
- **`ui/src/ui/app-chat.ts`** — `hasAbortableSessionRun()` checks activity entries as third signal; `handleAbortChat()` falls back to tool stream runId
- **`ui/src/ui/activity-model.test.ts`** — 9 unit tests for new helpers

## Evidence

**Test results (9 new + 26 existing pass without regression):**

✓ hasActiveToolExecution > returns false when activityEntries is undefined ✓ hasActiveToolExecution > returns false when activityEntries is empty ✓ hasActiveToolExecution > returns false when all entries are done ✓ hasActiveToolExecution > returns true when at least one entry is running ✓ hasActiveToolExecution > returns false when all entries are error ✓ resolveActiveToolRunId > returns null when activityEntries is undefined ✓ resolveActiveToolRunId > returns null when no running entries ✓ resolveActiveToolRunId > returns the runId of the running entry ✓ resolveActiveToolRunId > returns the most recently updated running entry's runId


Existing `app-tool-stream.node.test.ts` (26 tests) pass without regression.

**Screenshot showing the bug:** See #98540 for screenshot evidence.