### PR TITLE
fix(agents): default missing static-catalog maxTokens to 8192, not a context-window-sized value

### DIFF
--- a/src/agents/defaults.ts
+++ b/src/agents/defaults.ts
@@ -4,3 +4,9 @@ export const DEFAULT_PROVIDER = "openai";
 export const DEFAULT_MODEL = "gpt-5.5";
 // Conservative fallback used when model metadata is unavailable.
 export const DEFAULT_CONTEXT_TOKENS = 200_000;
+// Conservative fallback for the per-request output token cap when model
+// metadata omits it. Mirrors DEFAULT_MODEL_MAX_TOKENS in config/defaults.ts.
+// Using a context-window-sized value here lets request budget clamps hand
+// providers a `max_completion_tokens` larger than the model's real output cap,
+// which they reject with HTTP 400 (see #98295).
+export const DEFAULT_MODEL_MAX_TOKENS = 8192;

--- a/src/agents/embedded-agent-runner/model.static-catalog.test.ts
+++ b/src/agents/embedded-agent-runner/model.static-catalog.test.ts
@@ -468,6 +468,41 @@ describe("resolveBundledProviderStaticCatalogModel", () => {
     expect(providerMocks.runProviderStaticCatalog).not.toHaveBeenCalled();
   });
 
+  it("defaults missing maxTokens to a per-request output cap, not a context-window-sized value (#98295)", async () => {
+    const provider = {
+      id: "google",
+      pluginId: "google",
+      label: "Google",
+      auth: [],
+      staticCatalog: { run: vi.fn() },
+    };
+    providerMocks.resolveOwningPluginIdsForProviderRef.mockReturnValue(["google"]);
+    providerMocks.resolveBundledProviderCompatPluginIds.mockReturnValue(["google"]);
+    providerMocks.resolveRuntimePluginDiscoveryProviders.mockResolvedValue([provider]);
+    providerMocks.runProviderStaticCatalog.mockResolvedValue({ marker: "static-result" });
+    providerMocks.normalizePluginDiscoveryResult.mockReturnValue({
+      google: {
+        models: [
+          {
+            id: "custom-without-max-tokens",
+            name: "Custom Without Max Tokens",
+            contextWindow: 1_048_576,
+          },
+        ],
+      },
+    });
+
+    const resolveModel = createBundledProviderStaticCatalogModelResolver();
+    const resolved = await resolveModel({
+      provider: "google",
+      modelId: "custom-without-max-tokens",
+    });
+    expect(resolved).toMatchObject({
+      contextWindow: 1_048_576,
+      maxTokens: 8192,
+    });
+  });
+
   it("runs each prepared provider static catalog once", async () => {
     const provider = {
       id: "google",

--- a/src/agents/embedded-agent-runner/model.static-catalog.ts
+++ b/src/agents/embedded-agent-runner/model.static-catalog.ts
@@ -23,7 +23,7 @@ import {
   resolveBundledProviderCompatPluginIds,
   resolveOwningPluginIdsForProviderRef,
 } from "../../plugins/providers.js";
-import { DEFAULT_CONTEXT_TOKENS } from "../defaults.js";
+import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL_MAX_TOKENS } from "../defaults.js";
 import { normalizeStaticProviderModelId } from "../model-ref-shared.js";
 import { buildInlineProviderModels } from "./model.inline-provider.js";
 
@@ -92,7 +92,7 @@ function modelFromStaticCatalogRow(row: NormalizedModelCatalogRow): ProviderRunt
     cost: normalizeStaticCatalogCost(row.cost),
     contextWindow: row.contextWindow ?? DEFAULT_CONTEXT_TOKENS,
     contextTokens: row.contextTokens,
-    maxTokens: row.maxTokens ?? DEFAULT_CONTEXT_TOKENS,
+    maxTokens: row.maxTokens ?? DEFAULT_MODEL_MAX_TOKENS,
     thinkingLevelMap: row.thinkingLevelMap ? { ...row.thinkingLevelMap } : undefined,
     headers: row.headers,
     compat: row.compat,
@@ -129,7 +129,7 @@ function modelFromProviderStaticCatalog(params: {
       model?.maxTokens ??
       params.model.maxTokens ??
       params.providerConfig.maxTokens ??
-      DEFAULT_CONTEXT_TOKENS,
+      DEFAULT_MODEL_MAX_TOKENS,
     ...(params.providerConfig.authHeader !== undefined
       ? { authHeader: params.providerConfig.authHeader }
       : {}),

--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -2586,6 +2586,41 @@ describe("resolveModel", () => {
     expect(result.model?.input).toEqual(["text", "image"]);
   });
 
+  it("defaults missing maxTokens to a per-request output cap in configured fallback (#98295)", () => {
+    // Reproduces the reporter's scenario: a custom Xiaomi MiMo row without
+    // maxTokens, no matching static catalog row, and no provider-level
+    // maxTokens. Without the fix, resolveConfiguredFallbackModel fell through
+    // to DEFAULT_CONTEXT_TOKENS (200_000), producing an oversized
+    // max_completion_tokens that Xiaomi rejects with HTTP 400.
+    const cfg = {
+      models: {
+        providers: {
+          xiaomi: {
+            baseUrl: "https://api.xiaomi.com/v1",
+            models: [
+              {
+                id: "mimo-v2.5-pro",
+                name: "mimo-v2.5-pro",
+                reasoning: false,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 128_000,
+                // intentionally no maxTokens
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveModelForTest("xiaomi", "mimo-v2.5-pro", "/tmp/agent", cfg);
+
+    expect(result.error).toBeUndefined();
+    // Per-request output cap stays at the agent default, not the context window.
+    expect(result.model?.maxTokens).toBe(8192);
+    expect(result.model?.contextWindow).toBe(128_000);
+  });
+
   it("propagates image input when configured model ids include the provider prefix", () => {
     const cfg = {
       models: {

--- a/src/agents/embedded-agent-runner/model.ts
+++ b/src/agents/embedded-agent-runner/model.ts
@@ -21,7 +21,7 @@ import { discoverAuthStorage, discoverModels } from "../agent-model-discovery.js
 import { resolveDefaultAgentDir } from "../agent-scope.js";
 import { ensureAuthProfileStore, resolveAuthProfileOrder } from "../auth-profiles.js";
 import type { AuthProfileCredential } from "../auth-profiles/types.js";
-import { DEFAULT_CONTEXT_TOKENS } from "../defaults.js";
+import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL_MAX_TOKENS } from "../defaults.js";
 import { resolveAgentHarnessPolicy } from "../harness/policy.js";
 import { resolveModelWorkspaceDir } from "../model-discovery-context.js";
 import { modelKey, normalizeStaticProviderModelId } from "../model-ref-shared.js";
@@ -1370,7 +1370,7 @@ function resolveConfiguredFallbackModel(params: {
             providerConfig?.maxTokens ??
             providerConfig?.models?.[0]?.maxTokens ??
             staticCatalogModel?.maxTokens ??
-            DEFAULT_CONTEXT_TOKENS,
+            DEFAULT_MODEL_MAX_TOKENS,
           ...(resolvedParams ? { params: resolvedParams } : {}),
           ...(requestTimeoutMs !== undefined ? { requestTimeoutMs } : {}),
           headers: requestConfig.headers,


### PR DESCRIPTION
## What Problem This Solves

Fixes #98295.

Custom Xiaomi MiMo models registered without `maxTokens` produced `max_completion_tokens=186281`, which the Xiaomi API rejects with HTTP 400 "Param Incorrect" (the model's real cap is 131072). The agent fails on every request with only a generic "Something went wrong", making root-cause analysis difficult.

## Why This Change Was Made

Root cause is in `src/agents/embedded-agent-runner/model.static-catalog.ts`. When a catalog row or provider config omits `maxTokens`, both `modelFromStaticCatalogRow` and `modelFromProviderStaticCatalog` fell back to `DEFAULT_CONTEXT_TOKENS` (200_000) — a value sized for a context window, not a per-request output cap. Downstream, `resolveOpenAICompletionsMaxTokens` returned that value, and the proxy-like endpoint context clamp subtracted the estimated input tokens, yielding an effective `max_completion_tokens` larger than the model's true output cap. With `contextWindow=200_000` and a small prompt the arithmetic resolves to ~186281, matching the report.

Fix: introduce `DEFAULT_MODEL_MAX_TOKENS = 8192` in `src/agents/defaults.ts` (mirroring the existing `DEFAULT_MODEL_MAX_TOKENS` already used in `src/config/defaults.ts`) and use it for the two `maxTokens` fallbacks. The `contextWindow` fallback stays at `DEFAULT_CONTEXT_TOKENS` as intended.

## User Impact

- Custom models registered without `maxTokens` now send a conservative output cap (8192) instead of a context-window-sized value. Providers no longer 400-reject the request over an over-large `max_completion_tokens`.
- Operators who want a larger cap can still set `maxTokens` explicitly per model or provider; existing explicit values are unchanged.
- Context-window fallback behavior is preserved — only the maxTokens fallback changes.

## Evidence

- New test in `src/agents/embedded-agent-runner/model.static-catalog.test.ts`: "defaults missing maxTokens to a per-request output cap, not a context-window-sized value (#98295)". It registers a catalog row with `contextWindow` but no `maxTokens`, resolves the model, and asserts `maxTokens === 8192`.
- Local tests: `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/model.static-catalog.test.ts` exits 0.
- Local typecheck: `node scripts/run-tsgo.mjs -p tsconfig.core.json` exits 0.
- Local lint: `oxlint` on touched files exits 0.
