### PR TITLE
test: fix stale core test type failures

### DIFF
--- a/src/gateway/server-cron-notifications.test.ts
+++ b/src/gateway/server-cron-notifications.test.ts
@@ -31,7 +31,11 @@ function requireRecord(value: unknown, label: string): Record<string, unknown> {
 }
 
 function webhookRequestBody() {
-  const request = requireRecord(mocks.fetchWithSsrFGuard.mock.calls[0]?.[0], "webhook request");
+  const call = (mocks.fetchWithSsrFGuard.mock.calls as unknown[][])[0];
+  if (!call) {
+    throw new Error("expected webhook request call");
+  }
+  const request = requireRecord(call[0], "webhook request");
   const init = requireRecord(request.init, "webhook request init");
   return JSON.parse(String(init.body));
 }

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -621,7 +621,12 @@ describe("buildGatewayCronService", () => {
       await state.cron.run(job.id, "force");
 
       const event = runCronChangedMock.mock.calls
-        .map((call) => requireRecord(call[0], "cron_changed event"))
+        .map((_, index) =>
+          requireRecord(
+            callArg(runCronChangedMock, index, 0, "cron_changed event"),
+            "cron_changed event",
+          ),
+        )
         .find((hookEvent) => hookEvent.action === "finished");
       const summary = String(event?.summary ?? "");
       expect(summary).toContain("[redacted-url]");
@@ -714,7 +719,12 @@ describe("buildGatewayCronService", () => {
       expect(sendCronAnnouncePayloadStrictMock).not.toHaveBeenCalled();
 
       const event = runCronChangedMock.mock.calls
-        .map((call) => requireRecord(call[0], "cron_changed event"))
+        .map((_, index) =>
+          requireRecord(
+            callArg(runCronChangedMock, index, 0, "cron_changed event"),
+            "cron_changed event",
+          ),
+        )
         .find((hookEvent) => hookEvent.action === "finished");
       expect(event?.summary).toBe(summary);
     } finally {

--- a/src/llm/providers/anthropic.test.ts
+++ b/src/llm/providers/anthropic.test.ts
@@ -425,7 +425,7 @@ describe("Anthropic provider", () => {
             timestamp: 0,
           },
         ],
-      },
+      } as unknown as Context,
       {
         apiKey: "sk-ant-provider",
         onPayload: (payload) => {


### PR DESCRIPTION
## What Problem This Solves

Resolves stale core test type failures that caused `check-test-types` to fail even though the affected gateway cron and Anthropic provider tests were behaviorally valid.

## Why This Change Was Made

Vitest inferred zero-argument mock tuples for loosely typed test doubles, so direct `mock.calls[index][arg]` access failed the test typecheck. The gateway tests now use checked mock-call access, while the Anthropic test explicitly marks its intentionally non-canonical structured `resource` fixture at the `Context` boundary. Production behavior and production types are unchanged.

## User Impact

No user-visible runtime change. Core test typechecking is green again, preserving CI signal for unrelated PRs.

## Evidence

- `node scripts/run-vitest.mjs src/gateway/server-cron-notifications.test.ts src/gateway/server-cron.test.ts src/llm/providers/anthropic.test.ts` — 5 files, 99 tests passed.
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo` — passed.
- Autoreview passed with no accepted/actionable findings.
- Reproduced from the stale failures observed on PR #97962; unrelated Mistral and cron lint failures were already fixed on `main` and are not duplicated here.
