### PR TITLE
fix: support macos remote password auth ui

### DIFF
--- a/apps/macos/Sources/OpenClaw/AppState.swift
+++ b/apps/macos/Sources/OpenClaw/AppState.swift
@@ -13,6 +13,7 @@ final class AppState {
     private let isPreview: Bool
     private var isInitializing = true
     private var isApplyingRemoteTokenConfig = false
+    private var isApplyingRemotePasswordConfig = false
     private var configWatcher: ConfigFileWatcher?
     private var suppressVoiceWakeGlobalSync = false
     private var voiceWakeGlobalSyncTask: Task<Void, Never>?
@@ -41,6 +42,30 @@ final class AppState {
         var remoteIdentity: String
         var remoteToken: String
         var remoteTokenDirty: Bool
+        var remotePassword: String
+        var remotePasswordDirty: Bool
+
+        init(
+            transport: RemoteTransport,
+            remoteUrl: String,
+            remoteHost: String?,
+            remoteTarget: String,
+            remoteIdentity: String,
+            remoteToken: String,
+            remoteTokenDirty: Bool,
+            remotePassword: String = "",
+            remotePasswordDirty: Bool = false)
+        {
+            self.transport = transport
+            self.remoteUrl = remoteUrl
+            self.remoteHost = remoteHost
+            self.remoteTarget = remoteTarget
+            self.remoteIdentity = remoteIdentity
+            self.remoteToken = remoteToken
+            self.remoteTokenDirty = remoteTokenDirty
+            self.remotePassword = remotePassword
+            self.remotePasswordDirty = remotePasswordDirty
+        }
     }
 
     struct GatewayConfigSyncDraft {
@@ -51,6 +76,30 @@ final class AppState {
         var remoteUrl: String
         var remoteToken: String
         var remoteTokenDirty: Bool
+        var remotePassword: String
+        var remotePasswordDirty: Bool
+
+        init(
+            connectionMode: ConnectionMode,
+            remoteTransport: RemoteTransport,
+            remoteTarget: String,
+            remoteIdentity: String,
+            remoteUrl: String,
+            remoteToken: String,
+            remoteTokenDirty: Bool,
+            remotePassword: String = "",
+            remotePasswordDirty: Bool = false)
+        {
+            self.connectionMode = connectionMode
+            self.remoteTransport = remoteTransport
+            self.remoteTarget = remoteTarget
+            self.remoteIdentity = remoteIdentity
+            self.remoteUrl = remoteUrl
+            self.remoteToken = remoteToken
+            self.remoteTokenDirty = remoteTokenDirty
+            self.remotePassword = remotePassword
+            self.remotePasswordDirty = remotePasswordDirty
+        }
     }
 
     var isPaused: Bool {
@@ -279,6 +328,16 @@ final class AppState {
     private(set) var remoteTokenDirty = false
     private(set) var remoteTokenUnsupported = false
 
+    var remotePassword: String {
+        didSet {
+            guard !self.isApplyingRemotePasswordConfig else { return }
+            self.remotePasswordDirty = true
+            self.syncGatewayConfigIfNeeded()
+        }
+    }
+
+    private(set) var remotePasswordDirty = false
+
     var remoteIdentity: String {
         didSet { self.ifNotPreview { UserDefaults.standard.set(self.remoteIdentity, forKey: remoteIdentityKey) } }
     }
@@ -366,6 +425,7 @@ final class AppState {
 
         let configRoot = OpenClawConfigFile.loadDict()
         let configRemoteToken = GatewayRemoteConfig.resolveTokenValue(root: configRoot)
+        let configRemotePassword = GatewayRemoteConfig.resolvePasswordString(root: configRoot)
         let configRemoteResolution = GatewayRemoteConfig.resolveTransportResolution(root: configRoot)
         let configRemoteTransport = configRemoteResolution.transport
         let configRemoteUrl = configRemoteResolution.directURL?.absoluteString
@@ -397,6 +457,8 @@ final class AppState {
         self.remoteToken = configRemoteToken.textFieldValue
         self.remoteTokenDirty = false
         self.remoteTokenUnsupported = configRemoteToken.isUnsupportedNonString
+        self.remotePassword = configRemotePassword ?? ""
+        self.remotePasswordDirty = false
         self.remoteIdentity = UserDefaults.standard.string(forKey: remoteIdentityKey)?.nonEmpty
             ?? configRemote?["sshIdentity"] as? String
             ?? ""
@@ -514,6 +576,17 @@ final class AppState {
         self.remoteTokenUnsupported = unsupported
     }
 
+    private func applyRemotePasswordState(_ password: String?) {
+        let nextPassword = password ?? ""
+        guard self.remotePassword != nextPassword || self.remotePasswordDirty else {
+            return
+        }
+        self.isApplyingRemotePasswordConfig = true
+        self.remotePassword = nextPassword
+        self.isApplyingRemotePasswordConfig = false
+        self.remotePasswordDirty = false
+    }
+
     private static func updatedRemoteGatewayConfig(
         current: [String: Any],
         draft: RemoteGatewayConfigDraft) -> (remote: [String: Any], changed: Bool)
@@ -556,6 +629,9 @@ final class AppState {
         if draft.remoteTokenDirty {
             changed = Self.updateGatewayString(&remote, key: "token", value: draft.remoteToken) || changed
         }
+        if draft.remotePasswordDirty {
+            changed = Self.updateGatewayString(&remote, key: "password", value: draft.remotePassword) || changed
+        }
 
         return (remote, changed)
     }
@@ -580,6 +656,7 @@ final class AppState {
         let modeRaw = (gateway?["mode"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
         let remoteUrl = GatewayRemoteConfig.resolveUrlString(root: root)
         let remoteToken = GatewayRemoteConfig.resolveTokenValue(root: root)
+        let remotePassword = GatewayRemoteConfig.resolvePasswordString(root: root)
         let hasRemoteUrl = !(remoteUrl?
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .isEmpty ?? true)
@@ -613,6 +690,7 @@ final class AppState {
             self.remoteUrl = remoteUrlText
         }
         self.applyRemoteTokenState(remoteToken)
+        self.applyRemotePasswordState(remotePassword)
 
         let targetMode = desiredMode ?? self.connectionMode
         if targetMode == .remote,
@@ -680,7 +758,9 @@ final class AppState {
                     remoteTarget: draft.remoteTarget,
                     remoteIdentity: draft.remoteIdentity,
                     remoteToken: draft.remoteToken,
-                    remoteTokenDirty: draft.remoteTokenDirty))
+                    remoteTokenDirty: draft.remoteTokenDirty,
+                    remotePassword: draft.remotePassword,
+                    remotePasswordDirty: draft.remotePasswordDirty))
             if updated.changed {
                 gateway["remote"] = updated.remote
                 changed = true
@@ -719,7 +799,9 @@ final class AppState {
                 remoteIdentity: self.remoteIdentity,
                 remoteUrl: self.remoteUrl,
                 remoteToken: self.remoteToken,
-                remoteTokenDirty: self.remoteTokenDirty))
+                remoteTokenDirty: self.remoteTokenDirty,
+                remotePassword: self.remotePassword,
+                remotePasswordDirty: self.remotePasswordDirty))
         guard synced.changed else { return }
         guard OpenClawConfigFile.saveDict(synced.root) else {
             Self.logger.warning("gateway config sync rejected to protect persisted gateway auth/mode")
@@ -869,6 +951,7 @@ extension AppState {
         state.remoteTarget = "user@example.com"
         state.remoteUrl = "wss://gateway.example.ts.net"
         state.remoteToken = "example-token"
+        state.remotePassword = "example-password"
         state.remoteIdentity = "~/.ssh/id_ed25519"
         state.remoteProjectRoot = "~/Projects/openclaw"
         state.remoteCliPath = ""

--- a/apps/macos/Sources/OpenClaw/GeneralSettings.swift
+++ b/apps/macos/Sources/OpenClaw/GeneralSettings.swift
@@ -355,6 +355,7 @@ struct GeneralSettings: View {
                     self.remoteDirectRow
                 }
                 self.remoteTokenRow
+                self.remotePasswordRow
             }
 
             SettingsCardGroup("Discovery & Status") {
@@ -536,8 +537,7 @@ struct GeneralSettings: View {
         VStack(alignment: .leading, spacing: 0) {
             SettingsCardRow(
                 title: "Gateway token",
-                subtitle: "Used when the remote gateway requires token auth.",
-                showsDivider: false)
+                subtitle: "Used when the remote gateway requires token auth.")
             {
                 SecureField("remote gateway auth token (gateway.remote.token)", text: self.$state.remoteToken)
                     .textFieldStyle(.roundedBorder)
@@ -553,6 +553,18 @@ struct GeneralSettings: View {
                     .padding(.horizontal, 14)
                     .padding(.bottom, 10)
             }
+        }
+    }
+
+    private var remotePasswordRow: some View {
+        SettingsCardRow(
+            title: "Gateway password",
+            subtitle: "Used when the remote gateway requires password auth.",
+            showsDivider: false)
+        {
+            SecureField("remote gateway password (gateway.remote.password)", text: self.$state.remotePassword)
+                .textFieldStyle(.roundedBorder)
+                .frame(width: Self.remoteSecretFieldWidth)
         }
     }
 

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
@@ -301,6 +301,10 @@ extension OnboardingView {
                 showAdvancedConnection: self.showAdvancedConnection,
                 remoteToken: self.state.remoteToken,
                 remoteTokenUnsupported: self.state.remoteTokenUnsupported,
+                authIssue: self.remoteAuthIssue) ||
+            Self.shouldShowRemotePasswordField(
+                showAdvancedConnection: self.showAdvancedConnection,
+                remotePassword: self.state.remotePassword,
                 authIssue: self.remoteAuthIssue)
     }
 
@@ -310,6 +314,14 @@ extension OnboardingView {
             showAdvancedConnection: self.showAdvancedConnection,
             remoteToken: self.state.remoteToken,
             remoteTokenUnsupported: self.state.remoteTokenUnsupported,
+            authIssue: self.remoteAuthIssue)
+    }
+
+    private var shouldShowRemotePasswordField: Bool {
+        guard self.shouldShowRemoteConnectionSection else { return false }
+        return Self.shouldShowRemotePasswordField(
+            showAdvancedConnection: self.showAdvancedConnection,
+            remotePassword: self.state.remotePassword,
             authIssue: self.remoteAuthIssue)
     }
 
@@ -368,6 +380,10 @@ extension OnboardingView {
                 self.remoteTokenField()
             }
 
+            if self.shouldShowRemotePasswordField {
+                self.remotePasswordField()
+            }
+
             if let message = self.remoteProbePreflightMessage, self.remoteProbeState != .checking {
                 Text(message)
                     .font(.caption)
@@ -380,6 +396,22 @@ extension OnboardingView {
             if let issue = self.remoteAuthIssue {
                 self.remoteAuthPromptView(issue: issue)
             }
+        }
+    }
+
+    private func remotePasswordField() -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .center, spacing: 12) {
+                Text("Gateway password")
+                    .font(.callout.weight(.semibold))
+                    .frame(width: 110, alignment: .leading)
+                SecureField("remote gateway password (gateway.remote.password)", text: self.$state.remotePassword)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(maxWidth: 320)
+            }
+            Text("Used when the remote gateway requires password auth.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
         }
     }
 
@@ -512,7 +544,7 @@ extension OnboardingView {
         case .setupCodeExpired:
             ("qrcode.viewfinder", .orange)
         case .passwordRequired:
-            ("lock.slash.fill", .orange)
+            ("lock.fill", .orange)
         case .pairingRequired:
             ("link.badge.plus", .orange)
         }
@@ -528,6 +560,16 @@ extension OnboardingView {
             remoteTokenUnsupported ||
             !remoteToken.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ||
             authIssue?.showsTokenField == true
+    }
+
+    static func shouldShowRemotePasswordField(
+        showAdvancedConnection: Bool,
+        remotePassword: String,
+        authIssue: RemoteGatewayAuthIssue?) -> Bool
+    {
+        showAdvancedConnection ||
+            !remotePassword.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ||
+            authIssue?.showsPasswordField == true
     }
 
     static func shouldResetRemoteProbeFeedback(

--- a/apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift
+++ b/apps/macos/Sources/OpenClaw/RemoteGatewayProbe.swift
@@ -41,6 +41,15 @@ enum RemoteGatewayAuthIssue: Equatable {
         }
     }
 
+    var showsPasswordField: Bool {
+        switch self {
+        case .passwordRequired:
+            true
+        case .tokenRequired, .tokenMismatch, .gatewayTokenNotConfigured, .setupCodeExpired, .pairingRequired:
+            false
+        }
+    }
+
     var title: String {
         switch self {
         case .tokenRequired:
@@ -52,7 +61,7 @@ enum RemoteGatewayAuthIssue: Equatable {
         case .setupCodeExpired:
             "This setup code is no longer valid"
         case .passwordRequired:
-            "This gateway is using unsupported auth"
+            "This gateway requires a password"
         case .pairingRequired:
             "This device needs pairing approval"
         }
@@ -73,8 +82,7 @@ enum RemoteGatewayAuthIssue: Equatable {
         case .setupCodeExpired:
             "Scan or paste a fresh setup code from an already-paired OpenClaw client, then try again."
         case .passwordRequired:
-            "This onboarding flow does not support password auth yet. "
-                + "Reconfigure the gateway to use token auth, then retry."
+            "Enter the password configured as `gateway.remote.password` for this remote gateway, then try again."
         case .pairingRequired:
             "Approve this device from an already-paired OpenClaw client. "
                 + "In your OpenClaw chat, run `/pair approve`, then click **Check connection** again."
@@ -107,7 +115,7 @@ enum RemoteGatewayAuthIssue: Equatable {
         case .setupCodeExpired:
             "Setup code expired or already used. Scan a fresh setup code, then try again."
         case .passwordRequired:
-            "This gateway uses password auth. Remote onboarding on macOS cannot collect gateway passwords yet."
+            "This gateway requires gateway.remote.password. Enter the password, then check the connection again."
         case .pairingRequired:
             "Pairing required. In an already-paired OpenClaw client, "
                 + "run /pair approve, then check the connection again."

--- a/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
@@ -38,6 +38,44 @@ struct AppStateRemoteConfigTests {
     }
 
     @Test
+    func `updated remote gateway config sets trimmed password`() {
+        let remote = AppState._testUpdatedRemoteGatewayConfig(
+            current: [:],
+            draft: .init(
+                transport: .direct,
+                remoteUrl: "wss://gateway.example",
+                remoteHost: nil,
+                remoteTarget: "",
+                remoteIdentity: "",
+                remoteToken: "",
+                remoteTokenDirty: false,
+                remotePassword: "  gateway-password  ", // pragma: allowlist secret
+                remotePasswordDirty: true))
+
+        #expect(remote["password"] as? String == "gateway-password") // pragma: allowlist secret
+    }
+
+    @Test
+    func `updated remote gateway config clears password when blank`() {
+        let remote = AppState._testUpdatedRemoteGatewayConfig(
+            current: [
+                "password": "old-password", // pragma: allowlist secret
+            ],
+            draft: .init(
+                transport: .direct,
+                remoteUrl: "wss://gateway.example",
+                remoteHost: nil,
+                remoteTarget: "",
+                remoteIdentity: "",
+                remoteToken: "",
+                remoteTokenDirty: false,
+                remotePassword: "   ",
+                remotePasswordDirty: true))
+
+        #expect((remote["password"] as? String) == nil)
+    }
+
+    @Test
     func `updated remote gateway config pins loopback url for ssh transport`() {
         let remote = AppState._testUpdatedRemoteGatewayConfig(
             current: ["url": "ws://gateway.example:18789"],
@@ -195,6 +233,9 @@ struct AppStateRemoteConfigTests {
                     "token": [
                         "$secretRef": "gateway-token", // pragma: allowlist secret
                     ],
+                    "password": [
+                        "$secretRef": "gateway-password", // pragma: allowlist secret
+                    ],
                 ],
             ],
         ]
@@ -212,6 +253,8 @@ struct AppStateRemoteConfigTests {
         let sshRemote = (sshRoot["gateway"] as? [String: Any])?["remote"] as? [String: Any]
         #expect((sshRemote?["token"] as? [String: String])?["$secretRef"] ==
             "gateway-token") // pragma: allowlist secret
+        #expect((sshRemote?["password"] as? [String: String])?["$secretRef"] ==
+            "gateway-password") // pragma: allowlist secret
 
         let localRoot = AppState._testSyncedGatewayRoot(
             currentRoot: sshRoot,
@@ -228,6 +271,8 @@ struct AppStateRemoteConfigTests {
         #expect(localGateway?["mode"] as? String == "local")
         #expect((localRemote?["token"] as? [String: String])?["$secretRef"] ==
             "gateway-token") // pragma: allowlist secret
+        #expect((localRemote?["password"] as? [String: String])?["$secretRef"] ==
+            "gateway-password") // pragma: allowlist secret
     }
 
     @Test
@@ -281,6 +326,66 @@ struct AppStateRemoteConfigTests {
                 remoteToken: "   ",
                 remoteTokenDirty: true))
         #expect((cleared["token"] as? String) == nil)
+    }
+
+    @Test
+    func `updated remote gateway config replaces object password when user enters plaintext`() {
+        let remote = AppState._testUpdatedRemoteGatewayConfig(
+            current: [
+                "password": [
+                    "$secretRef": "gateway-password", // pragma: allowlist secret
+                ],
+            ],
+            draft: .init(
+                transport: .direct,
+                remoteUrl: "wss://gateway.example",
+                remoteHost: nil,
+                remoteTarget: "",
+                remoteIdentity: "",
+                remoteToken: "",
+                remoteTokenDirty: false,
+                remotePassword: "  fresh-password  ", // pragma: allowlist secret
+                remotePasswordDirty: true))
+
+        #expect(remote["password"] as? String == "fresh-password") // pragma: allowlist secret
+    }
+
+    @Test
+    func `updated remote gateway config clears object password only after explicit edit`() {
+        let current: [String: Any] = [
+            "password": [
+                "$secretRef": "gateway-password", // pragma: allowlist secret
+            ],
+        ]
+
+        let preserved = AppState._testUpdatedRemoteGatewayConfig(
+            current: current,
+            draft: .init(
+                transport: .direct,
+                remoteUrl: "wss://gateway.example",
+                remoteHost: nil,
+                remoteTarget: "",
+                remoteIdentity: "",
+                remoteToken: "",
+                remoteTokenDirty: false,
+                remotePassword: "",
+                remotePasswordDirty: false))
+        #expect((preserved["password"] as? [String: String])?["$secretRef"] ==
+            "gateway-password") // pragma: allowlist secret
+
+        let cleared = AppState._testUpdatedRemoteGatewayConfig(
+            current: current,
+            draft: .init(
+                transport: .direct,
+                remoteUrl: "wss://gateway.example",
+                remoteHost: nil,
+                remoteTarget: "",
+                remoteIdentity: "",
+                remoteToken: "",
+                remoteTokenDirty: false,
+                remotePassword: "   ",
+                remotePasswordDirty: true))
+        #expect((cleared["password"] as? String) == nil)
     }
 
     @Test

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingRemoteAuthPromptTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingRemoteAuthPromptTests.swift
@@ -102,7 +102,49 @@ struct OnboardingRemoteAuthPromptTests {
             showAdvancedConnection: false,
             remoteToken: "",
             remoteTokenUnsupported: false,
+            authIssue: .passwordRequired) == false)
+        #expect(OnboardingView.shouldShowRemoteTokenField(
+            showAdvancedConnection: false,
+            remoteToken: "",
+            remoteTokenUnsupported: false,
             authIssue: .pairingRequired) == false)
+    }
+
+    @Test func `password field visibility follows onboarding rules`() {
+        #expect(OnboardingView.shouldShowRemotePasswordField(
+            showAdvancedConnection: false,
+            remotePassword: "",
+            authIssue: nil) == false)
+        #expect(OnboardingView.shouldShowRemotePasswordField(
+            showAdvancedConnection: true,
+            remotePassword: "",
+            authIssue: nil))
+        #expect(OnboardingView.shouldShowRemotePasswordField(
+            showAdvancedConnection: false,
+            remotePassword: "secret",
+            authIssue: nil))
+        #expect(OnboardingView.shouldShowRemotePasswordField(
+            showAdvancedConnection: false,
+            remotePassword: "",
+            authIssue: .passwordRequired))
+        #expect(OnboardingView.shouldShowRemotePasswordField(
+            showAdvancedConnection: false,
+            remotePassword: "",
+            authIssue: .tokenRequired) == false)
+        #expect(OnboardingView.shouldShowRemotePasswordField(
+            showAdvancedConnection: false,
+            remotePassword: "",
+            authIssue: .pairingRequired) == false)
+    }
+
+    @Test func `password required copy asks for remote gateway password`() {
+        let issue = RemoteGatewayAuthIssue.passwordRequired
+
+        #expect(issue.showsPasswordField)
+        #expect(issue.title == "This gateway requires a password")
+        #expect(issue.body.contains("`gateway.remote.password`"))
+        #expect(issue.statusMessage.contains("gateway.remote.password"))
+        #expect(issue.body.contains("does not support password auth yet") == false)
     }
 
     @Test func `pairing required copy points users to pair approve`() {
@@ -118,6 +160,7 @@ struct OnboardingRemoteAuthPromptTests {
         let pairedDevice = RemoteGatewayProbeSuccess(authSource: .deviceToken)
         let bootstrap = RemoteGatewayProbeSuccess(authSource: .bootstrapToken)
         let sharedToken = RemoteGatewayProbeSuccess(authSource: .sharedToken)
+        let password = RemoteGatewayProbeSuccess(authSource: .password)
         let noAuth = RemoteGatewayProbeSuccess(authSource: GatewayAuthSource.none)
 
         #expect(pairedDevice.title == "Connected via paired device")
@@ -129,6 +172,8 @@ struct OnboardingRemoteAuthPromptTests {
             "This Mac is still using the temporary setup code. Approve pairing to finish provisioning device-scoped auth.")
         #expect(sharedToken.title == "Connected with gateway token")
         #expect(sharedToken.detail == nil)
+        #expect(password.title == "Connected with password")
+        #expect(password.detail == nil)
         #expect(noAuth.title == "Remote gateway ready")
         #expect(noAuth.detail == nil)
     }


### PR DESCRIPTION
Fixes #98552.

## Summary
- add gateway.remote.password state, dirty tracking, and config sync to macOS AppState
- expose a secure Gateway password field in Settings and onboarding
- change password-auth onboarding failures from unsupported-copy to an actionable password prompt
- preserve existing non-plaintext password config unless the user explicitly edits the field

## Tests
- git diff --check
- Not run: swift test --filter AppStateRemoteConfigTests (swift is not installed on this Windows host)