### PR TITLE
improve(web-fetch): speed up provider fallback loading

### DIFF
--- a/extensions/firecrawl/src/firecrawl-client.test.ts
+++ b/extensions/firecrawl/src/firecrawl-client.test.ts
@@ -421,6 +421,7 @@ describe("parseFirecrawlScrapePayload", () => {
     expect(result.extractor).toBe("firecrawl");
     expect(result.extractMode).toBe("markdown");
     expect(result.text).toContain("# Hello");
+    expect(result.wrappedLength).toBe((result.text as string).length);
     expect(result.truncated).toBe(false);
   });
 

--- a/extensions/firecrawl/src/firecrawl-client.ts
+++ b/extensions/firecrawl/src/firecrawl-client.ts
@@ -475,6 +475,10 @@ export function parseFirecrawlScrapePayload(params: {
   }
   const rawText = params.extractMode === "text" ? markdownToText(markdown) : markdown;
   const truncated = truncateText(rawText, params.maxChars);
+  const wrappedText = wrapExternalContent(truncated.text, {
+    source: "web_fetch",
+    includeWarning: false,
+  });
   return {
     url: params.url,
     finalUrl:
@@ -498,14 +502,8 @@ export function parseFirecrawlScrapePayload(params: {
     },
     truncated: truncated.truncated,
     rawLength: rawText.length,
-    wrappedLength: wrapExternalContent(truncated.text, {
-      source: "web_fetch",
-      includeWarning: false,
-    }).length,
-    text: wrapExternalContent(truncated.text, {
-      source: "web_fetch",
-      includeWarning: false,
-    }),
+    wrappedLength: wrappedText.length,
+    text: wrappedText,
     warning:
       typeof params.payload.warning === "string" && params.payload.warning
         ? wrapExternalContent(params.payload.warning, {

--- a/extensions/firecrawl/src/firecrawl-fetch-provider.ts
+++ b/extensions/firecrawl/src/firecrawl-fetch-provider.ts
@@ -1,9 +1,19 @@
 // Firecrawl provider module implements model/runtime integration.
 import { readPositiveIntegerParam } from "openclaw/plugin-sdk/param-readers";
-import type { WebFetchProviderPlugin } from "openclaw/plugin-sdk/provider-web-fetch";
-import { enablePluginInConfig } from "openclaw/plugin-sdk/provider-web-fetch";
-import { runFirecrawlScrape } from "./firecrawl-client.js";
+import {
+  enablePluginInConfig,
+  type WebFetchProviderPlugin,
+} from "openclaw/plugin-sdk/provider-web-fetch-contract";
 import { FIRECRAWL_WEB_FETCH_PROVIDER_SHARED } from "./firecrawl-fetch-provider-shared.js";
+
+type FirecrawlClientModule = typeof import("./firecrawl-client.js");
+
+let firecrawlClientModulePromise: Promise<FirecrawlClientModule> | undefined;
+
+function loadFirecrawlClientModule(): Promise<FirecrawlClientModule> {
+  firecrawlClientModulePromise ??= import("./firecrawl-client.js");
+  return firecrawlClientModulePromise;
+}
 
 export function createFirecrawlWebFetchProvider(): WebFetchProviderPlugin {
   return {
@@ -21,6 +31,7 @@ export function createFirecrawlWebFetchProvider(): WebFetchProviderPlugin {
             ? args.proxy
             : undefined;
         const storeInCache = typeof args.storeInCache === "boolean" ? args.storeInCache : undefined;
+        const { runFirecrawlScrape } = await loadFirecrawlClientModule();
         return await runFirecrawlScrape({
           cfg: config,
           url,

--- a/extensions/web-readability/web-content-extractor.test.ts
+++ b/extensions/web-readability/web-content-extractor.test.ts
@@ -61,4 +61,15 @@ describe("web readability extractor", () => {
     expect(extracted.text).toContain("Main content starts here");
     expect(extracted.title).toBe("Example Article");
   });
+
+  it("does not count void tags toward the nesting limit", async () => {
+    const extractor = createReadabilityWebContentExtractor();
+    const html = SAMPLE_HTML.replace("<article>", `<article>${"<BR>".repeat(3100)}`);
+    const result = await extractor.extract({
+      html,
+      url: "https://example.com/article",
+      extractMode: "markdown",
+    });
+    expect(requireReadabilityResult(result).text).toContain("Main content starts here");
+  });
 });

--- a/extensions/web-readability/web-content-extractor.ts
+++ b/extensions/web-readability/web-content-extractor.ts
@@ -13,6 +13,22 @@ import {
 
 const READABILITY_MAX_HTML_CHARS = 1_000_000;
 const READABILITY_MAX_ESTIMATED_NESTING_DEPTH = 3_000;
+const HTML_VOID_TAGS = new Set([
+  "area",
+  "base",
+  "br",
+  "col",
+  "embed",
+  "hr",
+  "img",
+  "input",
+  "link",
+  "meta",
+  "param",
+  "source",
+  "track",
+  "wbr",
+]);
 
 type ParsedHtml = {
   document: Document;
@@ -79,23 +95,6 @@ function normalizeLowercaseStringOrEmpty(value: string): string {
 }
 
 function exceedsEstimatedHtmlNestingDepth(html: string, maxDepth: number): boolean {
-  const voidTags = new Set([
-    "area",
-    "base",
-    "br",
-    "col",
-    "embed",
-    "hr",
-    "img",
-    "input",
-    "link",
-    "meta",
-    "param",
-    "source",
-    "track",
-    "wbr",
-  ]);
-
   let depth = 0;
   const len = html.length;
   for (let i = 0; i < len; i++) {
@@ -142,7 +141,7 @@ function exceedsEstimatedHtmlNestingDepth(html: string, maxDepth: number): boole
       depth = Math.max(0, depth - 1);
       continue;
     }
-    if (voidTags.has(tagName)) {
+    if (HTML_VOID_TAGS.has(tagName)) {
       continue;
     }
 

--- a/extensions/web-readability/web-content-extractor.ts
+++ b/extensions/web-readability/web-content-extractor.ts
@@ -90,10 +90,6 @@ async function loadReadabilityDeps(): Promise<{
   }
 }
 
-function normalizeLowercaseStringOrEmpty(value: string): string {
-  return value.trim().toLowerCase();
-}
-
 function exceedsEstimatedHtmlNestingDepth(html: string, maxDepth: number): boolean {
   let depth = 0;
   const len = html.length;
@@ -132,15 +128,17 @@ function exceedsEstimatedHtmlNestingDepth(html: string, maxDepth: number): boole
       j += 1;
     }
 
-    const tagName = normalizeLowercaseStringOrEmpty(html.slice(nameStart, j));
-    if (!tagName) {
+    if (j === nameStart) {
       continue;
     }
 
     if (closing) {
-      depth = Math.max(0, depth - 1);
+      if (depth > 0) {
+        depth -= 1;
+      }
       continue;
     }
+    const tagName = html.slice(nameStart, j).toLowerCase();
     if (HTML_VOID_TAGS.has(tagName)) {
       continue;
     }

--- a/package.json
+++ b/package.json
@@ -1692,6 +1692,7 @@
     "openclaw": "node scripts/run-node.mjs",
     "openclaw:rpc": "node scripts/run-node.mjs agent --mode rpc --json",
     "perf:issue-78851": "node --import tsx scripts/perf/issue-78851-model-resolution.ts",
+    "perf:web-fetch": "node --import tsx scripts/bench-web-fetch.ts",
     "perf:kova:summary": "node scripts/kova-ci-summary.mjs",
     "perf:source:summary": "node scripts/openclaw-performance-source-summary.mjs",
     "plugin-sdk:api:check": "node --max-old-space-size=8192 --import tsx scripts/generate-plugin-sdk-api-baseline.ts --check",

--- a/scripts/bench-web-fetch.ts
+++ b/scripts/bench-web-fetch.ts
@@ -107,6 +107,7 @@ const SHELL_HTML = `<!doctype html>
 
 const TEXT_BODY = "OpenClaw web_fetch direct text benchmark body.".repeat(160);
 const MARKDOWN_BODY = "# Web Fetch Benchmark\n\n" + "- markdown list item\n".repeat(220);
+const OFFLINE_PROVIDER_ENV_VARS = ["FIRECRAWL_API_KEY"] as const;
 
 const lookupFn: LookupFn = async () => [{ address: "93.184.216.34", family: 4 }];
 const toolConfig: OpenClawConfig = {
@@ -270,6 +271,25 @@ function installMockFetch(params: { body: string; contentType: string }) {
   globalThis.fetch = fetchImpl;
 }
 
+async function withOfflineProviderEnv<T>(run: () => Promise<T>): Promise<T> {
+  const previous = new Map<string, string | undefined>();
+  for (const name of OFFLINE_PROVIDER_ENV_VARS) {
+    previous.set(name, process.env[name]);
+    process.env[name] = "";
+  }
+  try {
+    return await run();
+  } finally {
+    for (const [name, value] of previous) {
+      if (value === undefined) {
+        delete process.env[name];
+      } else {
+        process.env[name] = value;
+      }
+    }
+  }
+}
+
 function createTool() {
   const tool = createWebFetchTool({
     config: toolConfig,
@@ -387,22 +407,24 @@ async function main(): Promise<void> {
     return;
   }
   const options = parseOptions(args);
-  const casesById = createCases();
-  const cases: CaseReport[] = [];
-  for (const caseId of options.cases) {
-    cases.push(await measureCase(casesById[caseId], options));
-  }
-  const report: BenchmarkReport = {
-    cases,
-    node: process.version,
-    options: {
-      cases: options.cases,
-      output: options.output,
-      runs: options.runs,
-      warmup: options.warmup,
-    },
-    rssMb: Math.round((process.memoryUsage().rss / 1024 / 1024) * 10) / 10,
-  };
+  const report = await withOfflineProviderEnv(async () => {
+    const casesById = createCases();
+    const cases: CaseReport[] = [];
+    for (const caseId of options.cases) {
+      cases.push(await measureCase(casesById[caseId], options));
+    }
+    return {
+      cases,
+      node: process.version,
+      options: {
+        cases: options.cases,
+        output: options.output,
+        runs: options.runs,
+        warmup: options.warmup,
+      },
+      rssMb: Math.round((process.memoryUsage().rss / 1024 / 1024) * 10) / 10,
+    };
+  });
   if (options.output) {
     await mkdir(path.dirname(options.output), { recursive: true });
     await writeFile(options.output, `${JSON.stringify(report, null, 2)}\n`);

--- a/scripts/bench-web-fetch.ts
+++ b/scripts/bench-web-fetch.ts
@@ -1,0 +1,424 @@
+// Web fetch benchmark covers direct response loading, HTML extraction, and fallback cleanup.
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+import { extractBasicHtmlContent } from "../src/agents/tools/web-fetch-utils.js";
+import { createWebFetchTool } from "../src/agents/tools/web-fetch.js";
+import type { OpenClawConfig } from "../src/config/types.openclaw.js";
+import type { LookupFn } from "../src/infra/net/ssrf.js";
+import { extractReadableContent } from "../src/web-fetch/content-extractors.runtime.js";
+
+type BenchmarkCaseId =
+  | "tool-create"
+  | "tool-text"
+  | "tool-markdown"
+  | "tool-html-article"
+  | "tool-html-shell"
+  | "extract-readable-article"
+  | "extract-basic-shell";
+
+type BenchmarkCase = {
+  id: BenchmarkCaseId;
+  label: string;
+  run: () => Promise<void> | void;
+};
+
+type Options = {
+  cases: BenchmarkCaseId[];
+  json: boolean;
+  output?: string;
+  runs: number;
+  warmup: number;
+};
+
+type SummaryStats = {
+  avg: number;
+  max: number;
+  min: number;
+  p50: number;
+  p95: number;
+};
+
+type CaseReport = {
+  id: BenchmarkCaseId;
+  label: string;
+  samplesMs: number[];
+  summaryMs: SummaryStats;
+};
+
+type BenchmarkReport = {
+  cases: CaseReport[];
+  node: string;
+  options: Omit<Options, "json">;
+  rssMb: number;
+};
+
+const ALL_CASE_IDS = [
+  "tool-create",
+  "tool-text",
+  "tool-markdown",
+  "tool-html-article",
+  "tool-html-shell",
+  "extract-readable-article",
+  "extract-basic-shell",
+] as const satisfies readonly BenchmarkCaseId[];
+
+const BOOLEAN_FLAGS = new Set(["--help", "-h", "--json"]);
+const VALUE_FLAGS = new Set(["--case", "--output", "--runs", "--warmup"]);
+
+class CliArgumentError extends Error {
+  override name = "CliArgumentError";
+}
+
+const ARTICLE_HTML = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Web Fetch Benchmark Article</title>
+  </head>
+  <body>
+    <nav>${Array.from({ length: 24 }, (_, index) => `<a href="/nav-${index}">Nav ${index}</a>`).join("")}</nav>
+    <main>
+      <article>
+        <h1>Web Fetch Benchmark Article</h1>
+        ${Array.from(
+          { length: 180 },
+          (_, index) =>
+            `<p>Paragraph ${index} carries readable benchmark content with enough prose for Readability to score it as article body text.</p>`,
+        ).join("\n")}
+      </article>
+    </main>
+    <footer>Repeated footer chrome that should not dominate extracted content.</footer>
+  </body>
+</html>`;
+
+const SHELL_HTML = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Shell App</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script>window.__APP__ = true;</script>
+    <noscript>Enable JavaScript to load this page.</noscript>
+  </body>
+</html>`;
+
+const TEXT_BODY = "OpenClaw web_fetch direct text benchmark body.".repeat(160);
+const MARKDOWN_BODY = "# Web Fetch Benchmark\n\n" + "- markdown list item\n".repeat(220);
+
+const lookupFn: LookupFn = async () => [{ address: "93.184.216.34", family: 4 }];
+const toolConfig: OpenClawConfig = {
+  tools: {
+    web: {
+      fetch: {
+        cacheTtlMinutes: 0,
+        firecrawl: { enabled: false },
+      },
+    },
+  },
+};
+
+function validateArgs(args: string[]): void {
+  const seenSingularValueFlags = new Set<string>();
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index] ?? "";
+    if (BOOLEAN_FLAGS.has(arg)) {
+      continue;
+    }
+    if (VALUE_FLAGS.has(arg)) {
+      if (arg !== "--case") {
+        if (seenSingularValueFlags.has(arg)) {
+          throw new CliArgumentError(`${arg} was provided more than once`);
+        }
+        seenSingularValueFlags.add(arg);
+      }
+      const value = args[index + 1];
+      if (!value || value.startsWith("-")) {
+        throw new CliArgumentError(`${arg} requires a value`);
+      }
+      index += 1;
+      continue;
+    }
+    throw new CliArgumentError(`Unknown argument: ${arg}`);
+  }
+}
+
+function parsePositiveInteger(flag: string, fallback: number, args: string[]): number {
+  const index = args.indexOf(flag);
+  if (index === -1) {
+    return fallback;
+  }
+  const raw = args[index + 1];
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new CliArgumentError(`${flag} must be a positive integer`);
+  }
+  return value;
+}
+
+function parseNonNegativeInteger(flag: string, fallback: number, args: string[]): number {
+  const index = args.indexOf(flag);
+  if (index === -1) {
+    return fallback;
+  }
+  const raw = args[index + 1];
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < 0) {
+    throw new CliArgumentError(`${flag} must be a non-negative integer`);
+  }
+  return value;
+}
+
+function parseCases(args: string[]): BenchmarkCaseId[] {
+  const requested: string[] = [];
+  for (let index = 0; index < args.length; index += 1) {
+    if (args[index] === "--case") {
+      requested.push(args[index + 1] ?? "");
+      index += 1;
+    }
+  }
+  if (requested.length === 0 || requested.includes("all")) {
+    return [...ALL_CASE_IDS];
+  }
+  const valid = new Set<string>(ALL_CASE_IDS);
+  for (const id of requested) {
+    if (!valid.has(id)) {
+      throw new CliArgumentError(
+        `--case must be one of all, ${ALL_CASE_IDS.join(", ")}; got ${JSON.stringify(id)}`,
+      );
+    }
+  }
+  return requested as BenchmarkCaseId[];
+}
+
+function parseFlagValue(flag: string, args: string[]): string | undefined {
+  const index = args.indexOf(flag);
+  return index === -1 ? undefined : args[index + 1];
+}
+
+function parseOptions(args = process.argv.slice(2)): Options {
+  validateArgs(args);
+  return {
+    cases: parseCases(args),
+    json: args.includes("--json"),
+    output: parseFlagValue("--output", args),
+    runs: parsePositiveInteger("--runs", 20, args),
+    warmup: parseNonNegativeInteger("--warmup", 3, args),
+  };
+}
+
+function printUsage(): void {
+  process.stdout.write(`OpenClaw web_fetch benchmark
+
+Usage:
+  pnpm perf:web-fetch -- [options]
+  node --import tsx scripts/bench-web-fetch.ts [options]
+
+Options:
+  --case <id>      Case to run; repeatable. Use "all" for every case.
+  --runs <n>       Measured runs per case (default: 20)
+  --warmup <n>     Warmup runs per case (default: 3)
+  --output <path>  Write JSON report
+  --json           Print JSON report
+  --help, -h       Show this text
+
+Cases:
+  ${ALL_CASE_IDS.join("\n  ")}
+`);
+}
+
+function round(value: number): number {
+  return Math.round(value * 1000) / 1000;
+}
+
+function percentile(values: number[], p: number): number {
+  if (values.length === 0) {
+    return 0;
+  }
+  const sorted = values.toSorted((left, right) => left - right);
+  const index = Math.min(sorted.length - 1, Math.floor((sorted.length - 1) * p));
+  return round(sorted[index] ?? 0);
+}
+
+function stats(values: number[]): SummaryStats {
+  if (values.length === 0) {
+    return { avg: 0, max: 0, min: 0, p50: 0, p95: 0 };
+  }
+  const total = values.reduce((sum, value) => sum + value, 0);
+  return {
+    avg: round(total / values.length),
+    max: round(Math.max(...values)),
+    min: round(Math.min(...values)),
+    p50: percentile(values, 0.5),
+    p95: percentile(values, 0.95),
+  };
+}
+
+function installMockFetch(params: { body: string; contentType: string }) {
+  const fetchImpl = (async () =>
+    new Response(params.body, {
+      status: 200,
+      headers: {
+        "content-type": params.contentType,
+      },
+    })) as typeof globalThis.fetch & { mock: object };
+  // fetchWithSsrFGuard preserves dispatcher support unless global fetch is a
+  // test double. The marker keeps this benchmark offline and deterministic.
+  fetchImpl.mock = {};
+  globalThis.fetch = fetchImpl;
+}
+
+function createTool() {
+  const tool = createWebFetchTool({
+    config: toolConfig,
+    lookupFn,
+    sandboxed: false,
+  });
+  if (!tool?.execute) {
+    throw new Error("web_fetch tool was not created");
+  }
+  return tool;
+}
+
+function createCases(): Record<BenchmarkCaseId, BenchmarkCase> {
+  const textTool = createTool();
+  const markdownTool = createTool();
+  const articleTool = createTool();
+  const shellTool = createTool();
+  return {
+    "tool-create": {
+      id: "tool-create",
+      label: "create web_fetch tool",
+      run: () => {
+        createTool();
+      },
+    },
+    "tool-text": {
+      id: "tool-text",
+      label: "execute text/plain fetch",
+      run: async () => {
+        installMockFetch({ body: TEXT_BODY, contentType: "text/plain; charset=utf-8" });
+        await textTool.execute("bench", { url: "https://example.com/plain" });
+      },
+    },
+    "tool-markdown": {
+      id: "tool-markdown",
+      label: "execute text/markdown fetch",
+      run: async () => {
+        installMockFetch({ body: MARKDOWN_BODY, contentType: "text/markdown; charset=utf-8" });
+        await markdownTool.execute("bench", { url: "https://example.com/markdown" });
+      },
+    },
+    "tool-html-article": {
+      id: "tool-html-article",
+      label: "execute article HTML fetch",
+      run: async () => {
+        installMockFetch({ body: ARTICLE_HTML, contentType: "text/html; charset=utf-8" });
+        await articleTool.execute("bench", { url: "https://example.com/article" });
+      },
+    },
+    "tool-html-shell": {
+      id: "tool-html-shell",
+      label: "execute shell HTML fallback fetch",
+      run: async () => {
+        installMockFetch({ body: SHELL_HTML, contentType: "text/html; charset=utf-8" });
+        await shellTool.execute("bench", { url: "https://example.com/shell" });
+      },
+    },
+    "extract-readable-article": {
+      id: "extract-readable-article",
+      label: "extract readable article HTML",
+      run: async () => {
+        await extractReadableContent({
+          html: ARTICLE_HTML,
+          url: "https://example.com/article",
+          extractMode: "markdown",
+          config: toolConfig,
+        });
+      },
+    },
+    "extract-basic-shell": {
+      id: "extract-basic-shell",
+      label: "extract basic shell HTML",
+      run: async () => {
+        await extractBasicHtmlContent({
+          html: SHELL_HTML,
+          extractMode: "markdown",
+        });
+      },
+    },
+  };
+}
+
+async function measureCase(testCase: BenchmarkCase, options: Options): Promise<CaseReport> {
+  for (let index = 0; index < options.warmup; index += 1) {
+    await testCase.run();
+  }
+  const samplesMs: number[] = [];
+  for (let index = 0; index < options.runs; index += 1) {
+    const started = performance.now();
+    await testCase.run();
+    samplesMs.push(round(performance.now() - started));
+  }
+  return {
+    id: testCase.id,
+    label: testCase.label,
+    samplesMs,
+    summaryMs: stats(samplesMs),
+  };
+}
+
+function printProofLines(report: BenchmarkReport): void {
+  for (const testCase of report.cases) {
+    const summary = testCase.summaryMs;
+    console.log(
+      `WEB_FETCH_BENCH_CASE=${testCase.id} avg_ms=${summary.avg.toFixed(3)} p50_ms=${summary.p50.toFixed(3)} p95_ms=${summary.p95.toFixed(3)} max_ms=${summary.max.toFixed(3)}`,
+    );
+  }
+  console.log(`WEB_FETCH_BENCH_RSS_MB=${report.rssMb.toFixed(1)}`);
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  if (args.includes("--help") || args.includes("-h")) {
+    printUsage();
+    return;
+  }
+  const options = parseOptions(args);
+  const casesById = createCases();
+  const cases: CaseReport[] = [];
+  for (const caseId of options.cases) {
+    cases.push(await measureCase(casesById[caseId], options));
+  }
+  const report: BenchmarkReport = {
+    cases,
+    node: process.version,
+    options: {
+      cases: options.cases,
+      output: options.output,
+      runs: options.runs,
+      warmup: options.warmup,
+    },
+    rssMb: Math.round((process.memoryUsage().rss / 1024 / 1024) * 10) / 10,
+  };
+  if (options.output) {
+    await mkdir(path.dirname(options.output), { recursive: true });
+    await writeFile(options.output, `${JSON.stringify(report, null, 2)}\n`);
+  }
+  if (options.json) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    printProofLines(report);
+  }
+}
+
+main().catch((error: unknown) => {
+  if (error instanceof CliArgumentError) {
+    console.error(error.message);
+    process.exitCode = 2;
+    return;
+  }
+  throw error;
+});

--- a/scripts/bench-web-fetch.ts
+++ b/scripts/bench-web-fetch.ts
@@ -13,8 +13,10 @@ type BenchmarkCaseId =
   | "tool-text"
   | "tool-markdown"
   | "tool-html-article"
+  | "tool-html-article-text"
   | "tool-html-shell"
   | "extract-readable-article"
+  | "extract-readable-article-text"
   | "extract-basic-shell";
 
 type BenchmarkCase = {
@@ -58,8 +60,10 @@ const ALL_CASE_IDS = [
   "tool-text",
   "tool-markdown",
   "tool-html-article",
+  "tool-html-article-text",
   "tool-html-shell",
   "extract-readable-article",
+  "extract-readable-article-text",
   "extract-basic-shell",
 ] as const satisfies readonly BenchmarkCaseId[];
 
@@ -306,6 +310,7 @@ function createCases(): Record<BenchmarkCaseId, BenchmarkCase> {
   const textTool = createTool();
   const markdownTool = createTool();
   const articleTool = createTool();
+  const articleTextTool = createTool();
   const shellTool = createTool();
   return {
     "tool-create": {
@@ -339,6 +344,17 @@ function createCases(): Record<BenchmarkCaseId, BenchmarkCase> {
         await articleTool.execute("bench", { url: "https://example.com/article" });
       },
     },
+    "tool-html-article-text": {
+      id: "tool-html-article-text",
+      label: "execute article HTML fetch as text",
+      run: async () => {
+        installMockFetch({ body: ARTICLE_HTML, contentType: "text/html; charset=utf-8" });
+        await articleTextTool.execute("bench", {
+          url: "https://example.com/article-text",
+          extractMode: "text",
+        });
+      },
+    },
     "tool-html-shell": {
       id: "tool-html-shell",
       label: "execute shell HTML fallback fetch",
@@ -355,6 +371,18 @@ function createCases(): Record<BenchmarkCaseId, BenchmarkCase> {
           html: ARTICLE_HTML,
           url: "https://example.com/article",
           extractMode: "markdown",
+          config: toolConfig,
+        });
+      },
+    },
+    "extract-readable-article-text": {
+      id: "extract-readable-article-text",
+      label: "extract readable article HTML as text",
+      run: async () => {
+        await extractReadableContent({
+          html: ARTICLE_HTML,
+          url: "https://example.com/article-text",
+          extractMode: "text",
           config: toolConfig,
         });
       },

--- a/src/agents/tools/web-fetch-utils.ts
+++ b/src/agents/tools/web-fetch-utils.ts
@@ -9,11 +9,28 @@ import { sanitizeHtml, stripInvisibleUnicode } from "./web-fetch-visibility.js";
 /** Output mode requested by web_fetch extraction. */
 export type ExtractMode = "markdown" | "text";
 
+const HTML_TAG_RE = /<[^>]+>/g;
+const SCRIPT_TAG_BLOCK_RE = /<script[\s\S]*?<\/script>/gi;
+const STYLE_TAG_BLOCK_RE = /<style[\s\S]*?<\/style>/gi;
+const NOSCRIPT_TAG_BLOCK_RE = /<noscript[\s\S]*?<\/noscript>/gi;
+const SCRIPT_STYLE_NOSCRIPT_OPEN_RE = /<(?:script|style|noscript)\b/i;
+const ANCHOR_OPEN_RE = /<a\s/i;
+const ANCHOR_RE = /<a\s+[^>]*href=["']([^"']+)["'][^>]*>([\s\S]*?)<\/a>/gi;
+const HEADING_OPEN_RE = /<h[1-6]\b/i;
+const HEADING_RE = /<h([1-6])[^>]*>([\s\S]*?)<\/h\1>/gi;
+const LIST_ITEM_OPEN_RE = /<li\b/i;
+const LIST_ITEM_RE = /<li[^>]*>([\s\S]*?)<\/li>/gi;
+const BLOCK_BREAK_RE =
+  /<(?:br|hr)\s*\/?>|<\/(?:p|div|section|article|header|footer|table|tr|ul|ol)>/gi;
+
 // Decode entities through the canonical shared decoder (agents/utils/html.ts) so web_fetch and the
 // renderer share one entity contract — the divergent hand-rolled copy here was what truncated astral
 // entities. A single left-to-right pass also avoids double-decoding "&amp;#39;" into "'", because the
 // "&amp;" is consumed before its following "#39;" is ever seen as an entity.
 function decodeEntities(value: string): string {
+  if (!value.includes("&")) {
+    return value;
+  }
   let out = "";
   for (let i = 0; i < value.length; i += 1) {
     if (value[i] === "&") {
@@ -36,7 +53,8 @@ function decodeEntities(value: string): string {
 }
 
 function stripTags(value: string): string {
-  return decodeEntities(value.replace(/<[^>]+>/g, ""));
+  const withoutTags = value.includes("<") ? value.replace(HTML_TAG_RE, "") : value;
+  return decodeEntities(withoutTags);
 }
 
 /** Collapses display whitespace while preserving paragraph breaks. */
@@ -53,30 +71,37 @@ export function normalizeWhitespace(value: string): string {
 export function htmlToMarkdown(html: string): { text: string; title?: string } {
   const titleMatch = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
   const title = titleMatch ? normalizeWhitespace(stripTags(titleMatch[1])) : undefined;
-  let text = html
-    .replace(/<script[\s\S]*?<\/script>/gi, "")
-    .replace(/<style[\s\S]*?<\/style>/gi, "")
-    .replace(/<noscript[\s\S]*?<\/noscript>/gi, "");
-  text = text.replace(/<a\s+[^>]*href=["']([^"']+)["'][^>]*>([\s\S]*?)<\/a>/gi, (_, href, body) => {
-    const label = normalizeWhitespace(stripTags(body));
-    if (!label) {
-      return href;
-    }
-    // Preserve link targets in markdown mode so fetched pages remain source-auditable.
-    return `[${label}](${href})`;
-  });
-  text = text.replace(/<h([1-6])[^>]*>([\s\S]*?)<\/h\1>/gi, (_, level, body) => {
-    const prefix = "#".repeat(Math.max(1, Math.min(6, Number.parseInt(level, 10))));
-    const label = normalizeWhitespace(stripTags(body));
-    return `\n${prefix} ${label}\n`;
-  });
-  text = text.replace(/<li[^>]*>([\s\S]*?)<\/li>/gi, (_, body) => {
-    const label = normalizeWhitespace(stripTags(body));
-    return label ? `\n- ${label}` : "";
-  });
-  text = text
-    .replace(/<(br|hr)\s*\/?>/gi, "\n")
-    .replace(/<\/(p|div|section|article|header|footer|table|tr|ul|ol)>/gi, "\n");
+  let text = html;
+  if (SCRIPT_STYLE_NOSCRIPT_OPEN_RE.test(text)) {
+    text = text
+      .replace(SCRIPT_TAG_BLOCK_RE, "")
+      .replace(STYLE_TAG_BLOCK_RE, "")
+      .replace(NOSCRIPT_TAG_BLOCK_RE, "");
+  }
+  if (ANCHOR_OPEN_RE.test(text)) {
+    text = text.replace(ANCHOR_RE, (_, href, body) => {
+      const label = normalizeWhitespace(stripTags(body));
+      if (!label) {
+        return href;
+      }
+      // Preserve link targets in markdown mode so fetched pages remain source-auditable.
+      return `[${label}](${href})`;
+    });
+  }
+  if (HEADING_OPEN_RE.test(text)) {
+    text = text.replace(HEADING_RE, (_, level, body) => {
+      const prefix = "#".repeat(Math.max(1, Math.min(6, Number.parseInt(level, 10))));
+      const label = normalizeWhitespace(stripTags(body));
+      return `\n${prefix} ${label}\n`;
+    });
+  }
+  if (LIST_ITEM_OPEN_RE.test(text)) {
+    text = text.replace(LIST_ITEM_RE, (_, body) => {
+      const label = normalizeWhitespace(stripTags(body));
+      return label ? `\n- ${label}` : "";
+    });
+  }
+  text = text.replace(BLOCK_BREAK_RE, "\n");
   text = stripTags(text);
   text = normalizeWhitespace(text);
   return { text, title };

--- a/src/plugins/web-fetch-providers.runtime.test.ts
+++ b/src/plugins/web-fetch-providers.runtime.test.ts
@@ -40,12 +40,12 @@ function createFirecrawlAllowConfig() {
   };
 }
 
-function createManifestRegistryFixture() {
+function createManifestRegistryFixture(origin: "bundled" | "global" = "bundled") {
   return {
     plugins: [
       {
         id: "firecrawl",
-        origin: "bundled",
+        origin,
         rootDir: "/tmp/firecrawl",
         source: "/tmp/firecrawl/index.js",
         manifestPath: "/tmp/firecrawl/openclaw.plugin.json",
@@ -56,6 +56,7 @@ function createManifestRegistryFixture() {
         nonSecretAuthMarkers: [],
         skills: [],
         hooks: [],
+        contracts: { webFetchProviders: ["firecrawl"] },
         configUiHints: { "webFetch.apiKey": { label: "key" } },
       },
       {
@@ -149,13 +150,48 @@ describe("resolvePluginWebFetchProviders", () => {
     vi.restoreAllMocks();
   });
 
-  it("falls back to the plugin loader when no compatible active registry exists", () => {
+  it("loads bundled runtime artifacts when no compatible active registry exists", () => {
+    const providers = resolvePluginWebFetchProviders({});
+
+    expect(providers.map((provider) => `${provider.pluginId}:${provider.id}`)).toEqual([
+      "firecrawl:firecrawl",
+    ]);
+    expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the plugin loader for non-bundled provider owners", () => {
+    vi.mocked(manifestRegistryModule.loadPluginManifestRegistry).mockReturnValue(
+      createManifestRegistryFixture(
+        "global",
+      ) as ManifestRegistryModule["loadPluginManifestRegistry"] extends (
+        ...args: unknown[]
+      ) => infer R
+        ? R
+        : never,
+    );
+
     const providers = resolvePluginWebFetchProviders({});
 
     expect(providers.map((provider) => `${provider.pluginId}:${provider.id}`)).toEqual([
       "firecrawl:firecrawl",
     ]);
     expect(loadOpenClawPluginsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    {
+      label: "denylisted",
+      config: { plugins: { deny: ["firecrawl"] } },
+    },
+    {
+      label: "explicitly disabled",
+      config: { plugins: { entries: { firecrawl: { enabled: false } } } },
+    },
+  ])("does not load $label bundled runtime artifacts", ({ config }) => {
+    const providers = resolvePluginWebFetchProviders({ config });
+
+    expect(providers).toStrictEqual([]);
+    expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
   });
 
   it("loads manifest-declared web-fetch providers in setup mode without the plugin loader", () => {
@@ -177,11 +213,19 @@ describe("resolvePluginWebFetchProviders", () => {
     loadOpenClawPluginsMock.mockImplementation(() => {
       throw new Error("resolvePluginWebFetchProviders should not bypass the in-flight guard");
     });
+    const rawConfig = createFirecrawlAllowConfig();
+    const env = createWebFetchEnv();
+    const { config, activationSourceConfig, autoEnabledReasons } =
+      webFetchProvidersSharedModule.resolveBundledWebFetchResolutionConfig({
+        config: rawConfig,
+        workspaceDir: DEFAULT_WORKSPACE,
+        env,
+      });
 
     const providers = resolvePluginWebFetchProviders({
-      config: createFirecrawlAllowConfig(),
+      config: rawConfig,
       workspaceDir: DEFAULT_WORKSPACE,
-      env: createWebFetchEnv(),
+      env,
     });
 
     expect(providers).toStrictEqual([]);
@@ -193,14 +237,16 @@ describe("resolvePluginWebFetchProviders", () => {
       "warn",
     ]);
     expect(inFlightLoadOptions).toEqual({
-      config: createFirecrawlAllowConfig(),
-      activationSourceConfig: createFirecrawlAllowConfig(),
-      autoEnabledReasons: {},
+      config,
+      activationSourceConfig,
+      autoEnabledReasons,
       workspaceDir: DEFAULT_WORKSPACE,
-      env: createWebFetchEnv(),
+      env,
       cache: true,
       activate: false,
       onlyPluginIds: ["firecrawl"],
+      installRecords: undefined,
+      manifestRegistry: undefined,
     });
     expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
   });
@@ -285,6 +331,15 @@ describe("resolvePluginWebFetchProviders", () => {
       "default",
       "/tmp/runtime-workspace",
     );
+    vi.mocked(manifestRegistryModule.loadPluginManifestRegistry).mockReturnValue(
+      createManifestRegistryFixture(
+        "global",
+      ) as ManifestRegistryModule["loadPluginManifestRegistry"] extends (
+        ...args: unknown[]
+      ) => infer R
+        ? R
+        : never,
+    );
 
     resolvePluginWebFetchProviders({
       config: rawConfig,
@@ -315,6 +370,15 @@ describe("resolvePluginWebFetchProviders", () => {
   it("resolves web-fetch providers for each active registry workspace", () => {
     const env = createWebFetchEnv();
     const config = createFirecrawlAllowConfig();
+    vi.mocked(manifestRegistryModule.loadPluginManifestRegistry).mockReturnValue(
+      createManifestRegistryFixture(
+        "global",
+      ) as ManifestRegistryModule["loadPluginManifestRegistry"] extends (
+        ...args: unknown[]
+      ) => infer R
+        ? R
+        : never,
+    );
 
     setActivePluginRegistry(createEmptyPluginRegistry(), undefined, "default", "/tmp/workspace-a");
     resolvePluginWebFetchProviders({

--- a/src/plugins/web-fetch-providers.runtime.ts
+++ b/src/plugins/web-fetch-providers.runtime.ts
@@ -7,7 +7,10 @@ import {
   resolveBundledWebFetchResolutionConfig,
   sortWebFetchProviders,
 } from "./web-fetch-providers.shared.js";
-import { resolveBundledWebFetchProvidersFromPublicArtifacts } from "./web-provider-public-artifacts.js";
+import {
+  resolveBundledRuntimeWebFetchProvidersFromPublicArtifacts,
+  resolveBundledWebFetchProvidersFromPublicArtifacts,
+} from "./web-provider-public-artifacts.js";
 import {
   mapRegistryProviders,
   resolveManifestDeclaredWebProviderCandidatePluginIds,
@@ -65,6 +68,8 @@ export function resolvePluginWebFetchProviders(params: {
     resolveCandidatePluginIds: resolveWebFetchCandidatePluginIds,
     mapRegistryProviders: mapRegistryWebFetchProviders,
     resolveBundledPublicArtifactProviders: resolveBundledWebFetchProvidersFromPublicArtifacts,
+    resolveBundledRuntimeArtifactProviders:
+      resolveBundledRuntimeWebFetchProvidersFromPublicArtifacts,
   });
 }
 
@@ -80,5 +85,7 @@ export function resolveRuntimeWebFetchProviders(params: {
     resolveBundledResolutionConfig: resolveBundledWebFetchResolutionConfig,
     resolveCandidatePluginIds: resolveWebFetchCandidatePluginIds,
     mapRegistryProviders: mapRegistryWebFetchProviders,
+    resolveBundledRuntimeArtifactProviders:
+      resolveBundledRuntimeWebFetchProvidersFromPublicArtifacts,
   });
 }

--- a/src/plugins/web-provider-public-artifacts.explicit-fast-path.test.ts
+++ b/src/plugins/web-provider-public-artifacts.explicit-fast-path.test.ts
@@ -60,6 +60,19 @@ const {
           }),
         };
       }
+      if (dirName === "firecrawl" && artifactBasename === "web-fetch-provider.js") {
+        return {
+          createFirecrawlWebFetchProvider: () => ({
+            ...providerBase,
+            id: "firecrawl",
+            createTool: () => ({
+              description: "runtime firecrawl",
+              parameters: {},
+              execute: async () => ({}),
+            }),
+          }),
+        };
+      }
       throw new Error(
         `Unable to resolve bundled plugin public surface ${dirName}/${artifactBasename}`,
       );
@@ -112,6 +125,7 @@ vi.mock("./public-surface-loader.js", async (importOriginal) => {
   };
 });
 
+import { resolveBundledExplicitRuntimeWebFetchProvidersFromPublicArtifacts } from "./web-provider-public-artifacts.explicit.js";
 import {
   resolveBundledWebFetchProvidersFromPublicArtifacts,
   resolveBundledWebSearchProvidersFromPublicArtifacts,
@@ -194,5 +208,24 @@ describe("web provider public artifacts explicit fast path", () => {
       artifactBasename: "web-fetch-contract-api.js",
     });
     expect(loadPluginManifestRegistryMock).not.toHaveBeenCalled();
+  });
+
+  it("loads executable web fetch runtime artifacts instead of contract-only facades", () => {
+    const provider = expectSingleProvider(
+      resolveBundledExplicitRuntimeWebFetchProvidersFromPublicArtifacts({
+        onlyPluginIds: ["firecrawl"],
+      }),
+    );
+
+    expect(provider.pluginId).toBe("firecrawl");
+    expect(provider.createTool({ config: {} as never })).not.toBeNull();
+    expect(loadBundledPluginPublicArtifactModuleSyncMock).toHaveBeenCalledWith({
+      dirName: "firecrawl",
+      artifactBasename: "web-fetch-provider.js",
+    });
+    expect(loadBundledPluginPublicArtifactModuleSyncMock).not.toHaveBeenCalledWith({
+      dirName: "firecrawl",
+      artifactBasename: "web-fetch-contract-api.js",
+    });
   });
 });

--- a/src/plugins/web-provider-public-artifacts.explicit.ts
+++ b/src/plugins/web-provider-public-artifacts.explicit.ts
@@ -19,6 +19,7 @@ const WEB_FETCH_ARTIFACT_CANDIDATES = [
   "web-fetch-provider.js",
   "web-fetch.js",
 ] as const;
+const WEB_FETCH_RUNTIME_ARTIFACT_CANDIDATES = ["web-fetch-provider.js", "web-fetch.js"] as const;
 
 function isStringArray(value: unknown): value is string[] {
   return Array.isArray(value) && value.every((entry) => typeof entry === "string");
@@ -152,6 +153,19 @@ export function loadBundledWebFetchProviderEntriesFromDir(params: {
   });
 }
 
+export function loadBundledRuntimeWebFetchProviderEntriesFromDir(params: {
+  dirName: string;
+  pluginId: string;
+}): PluginWebFetchProviderEntry[] | null {
+  return loadBundledProviderEntriesFromDir<WebFetchProviderPlugin>({
+    dirName: params.dirName,
+    pluginId: params.pluginId,
+    artifactCandidates: WEB_FETCH_RUNTIME_ARTIFACT_CANDIDATES,
+    suffix: "WebFetchProvider",
+    isProvider: isWebFetchProviderPlugin,
+  });
+}
+
 export function resolveBundledExplicitWebSearchProvidersFromPublicArtifacts(params: {
   onlyPluginIds: readonly string[];
 }): PluginWebSearchProviderEntry[] | null {
@@ -175,6 +189,23 @@ export function resolveBundledExplicitWebFetchProvidersFromPublicArtifacts(param
   const providers: PluginWebFetchProviderEntry[] = [];
   for (const pluginId of normalizeExplicitBundledPluginIds(params.onlyPluginIds)) {
     const loadedProviders = loadBundledWebFetchProviderEntriesFromDir({
+      dirName: pluginId,
+      pluginId,
+    });
+    if (!loadedProviders) {
+      return null;
+    }
+    providers.push(...loadedProviders);
+  }
+  return providers;
+}
+
+export function resolveBundledExplicitRuntimeWebFetchProvidersFromPublicArtifacts(params: {
+  onlyPluginIds: readonly string[];
+}): PluginWebFetchProviderEntry[] | null {
+  const providers: PluginWebFetchProviderEntry[] = [];
+  for (const pluginId of normalizeExplicitBundledPluginIds(params.onlyPluginIds)) {
+    const loadedProviders = loadBundledRuntimeWebFetchProviderEntriesFromDir({
       dirName: pluginId,
       pluginId,
     });

--- a/src/plugins/web-provider-public-artifacts.ts
+++ b/src/plugins/web-provider-public-artifacts.ts
@@ -1,6 +1,7 @@
 // Extracts web provider public artifacts from plugin entrypoints.
 import path from "node:path";
 import { normalizeUniqueStringEntries } from "@openclaw/normalization-core/string-normalization";
+import { resolveEnabledBundledManifestContractPlugins } from "./bundled-manifest-contract-plugins.js";
 import { normalizePluginId } from "./config-state.js";
 import type { PluginLoadOptions } from "./loader.js";
 import { loadManifestMetadataSnapshot } from "./manifest-contract-eligibility.js";
@@ -10,6 +11,7 @@ import { resolveBundledWebFetchResolutionConfig } from "./web-fetch-providers.sh
 import {
   loadBundledWebFetchProviderEntriesFromDir,
   loadBundledWebSearchProviderEntriesFromDir,
+  resolveBundledExplicitRuntimeWebFetchProvidersFromPublicArtifacts,
   resolveBundledExplicitWebFetchProvidersFromPublicArtifacts,
   resolveBundledExplicitWebSearchProvidersFromPublicArtifacts,
 } from "./web-provider-public-artifacts.explicit.js";
@@ -103,6 +105,48 @@ function resolveBundledManifestRecordsByPluginId(params: {
   );
 }
 
+function resolveBundledRuntimeCandidatePluginIds(params: {
+  contract: "webFetchProviders";
+  configKey: "webFetch";
+  config?: PluginLoadOptions["config"];
+  workspaceDir?: string;
+  env?: PluginLoadOptions["env"];
+  onlyPluginIds: readonly string[];
+}): string[] | null {
+  const resolvedConfig = resolveBundledWebFetchResolutionConfig(params).config;
+  const candidates = resolveManifestDeclaredWebProviderCandidates({
+    contract: params.contract,
+    configKey: params.configKey,
+    config: resolvedConfig,
+    workspaceDir: params.workspaceDir,
+    env: params.env,
+    onlyPluginIds: params.onlyPluginIds,
+  });
+  const pluginIds = filterAllowlistedBundledPluginIds(resolvedConfig, candidates.pluginIds ?? []);
+  const recordsByPluginId = new Map(
+    (candidates.manifestRecords ?? [])
+      .filter((record) => pluginIds.includes(record.id))
+      .map((record) => [record.id, record] as const),
+  );
+  if (pluginIds.some((pluginId) => recordsByPluginId.get(pluginId)?.origin !== "bundled")) {
+    return null;
+  }
+  const enabledPluginIds = new Set(
+    resolveEnabledBundledManifestContractPlugins({
+      config: params.config,
+      workspaceDir: params.workspaceDir,
+      env: params.env,
+      onlyPluginIds: pluginIds,
+      contract: params.contract,
+      compatMode: {
+        enablement: "always",
+        vitest: params.config !== undefined,
+      },
+    }).map((plugin) => plugin.id),
+  );
+  return pluginIds.filter((pluginId) => enabledPluginIds.has(pluginId));
+}
+
 export function resolveBundledWebSearchProvidersFromPublicArtifacts(
   params: BundledWebProviderPublicArtifactParams,
 ): PluginWebSearchProviderEntry[] | null {
@@ -191,4 +235,28 @@ export function resolveBundledWebFetchProvidersFromPublicArtifacts(
     providers.push(...loadedProviders);
   }
   return providers;
+}
+
+export function resolveBundledRuntimeWebFetchProvidersFromPublicArtifacts(
+  params: BundledWebProviderPublicArtifactParams & {
+    onlyPluginIds: readonly string[];
+  },
+): PluginWebFetchProviderEntry[] | null {
+  const pluginIds = resolveBundledRuntimeCandidatePluginIds({
+    contract: "webFetchProviders",
+    configKey: "webFetch",
+    config: params.config,
+    workspaceDir: params.workspaceDir,
+    env: params.env,
+    onlyPluginIds: params.onlyPluginIds,
+  });
+  if (!pluginIds) {
+    return null;
+  }
+  if (pluginIds.length === 0) {
+    return [];
+  }
+  return resolveBundledExplicitRuntimeWebFetchProvidersFromPublicArtifacts({
+    onlyPluginIds: pluginIds,
+  });
 }

--- a/src/plugins/web-provider-runtime-shared.test.ts
+++ b/src/plugins/web-provider-runtime-shared.test.ts
@@ -310,6 +310,97 @@ describe("web-provider-runtime-shared", () => {
     expect(mockArg(mocks.loadOpenClawPlugins).onlyPluginIds).toEqual(["brave"]);
   });
 
+  it("uses bundled runtime artifacts before loading a plugin registry", () => {
+    const resolveBundledRuntimeArtifactProviders = vi.fn(() => ["provider"]);
+
+    const providers = resolvePluginWebProviders(
+      {
+        config: {},
+        workspaceDir: "/workspace",
+        env: { FIRECRAWL_API_KEY: "" },
+      },
+      {
+        resolveBundledResolutionConfig: () => ({
+          config: {},
+          activationSourceConfig: {},
+          autoEnabledReasons: {},
+        }),
+        resolveCandidatePluginIds: () => ["firecrawl"],
+        mapRegistryProviders: vi.fn(() => []),
+        resolveBundledRuntimeArtifactProviders,
+      },
+    );
+
+    expect(providers).toEqual(["provider"]);
+    expect(resolveBundledRuntimeArtifactProviders).toHaveBeenCalledWith({
+      config: {},
+      workspaceDir: "/workspace",
+      env: { FIRECRAWL_API_KEY: "" },
+      onlyPluginIds: ["firecrawl"],
+    });
+    expect(mocks.loadOpenClawPlugins).not.toHaveBeenCalled();
+  });
+
+  it("falls back to plugin loading when bundled runtime artifacts do not cover the scope", () => {
+    const fallbackRegistry = { source: "fallback" };
+    const mapRegistryProviders = vi.fn(() => ["provider"]);
+    const resolveBundledRuntimeArtifactProviders = vi.fn(() => null);
+    mocks.loadOpenClawPlugins.mockReturnValue(fallbackRegistry as never);
+
+    const providers = resolvePluginWebProviders(
+      {
+        config: {},
+      },
+      {
+        resolveBundledResolutionConfig: () => ({
+          config: {},
+          activationSourceConfig: {},
+          autoEnabledReasons: {},
+        }),
+        resolveCandidatePluginIds: () => ["external-provider"],
+        mapRegistryProviders,
+        resolveBundledRuntimeArtifactProviders,
+      },
+    );
+
+    expect(providers).toEqual(["provider"]);
+    expect(resolveBundledRuntimeArtifactProviders).toHaveBeenCalledTimes(1);
+    expect(mocks.loadOpenClawPlugins).toHaveBeenCalledTimes(1);
+    expect(mapRegistryProviders).toHaveBeenCalledWith({
+      registry: fallbackRegistry,
+      onlyPluginIds: ["external-provider"],
+    });
+  });
+
+  it("loads the plugin registry when runtime activation is explicitly requested", () => {
+    const fallbackRegistry = { source: "activated" };
+    const mapRegistryProviders = vi.fn(() => ["provider"]);
+    const resolveBundledRuntimeArtifactProviders = vi.fn(() => ["artifact-provider"]);
+    mocks.loadOpenClawPlugins.mockReturnValue(fallbackRegistry as never);
+
+    const providers = resolvePluginWebProviders(
+      {
+        activate: true,
+        config: {},
+      },
+      {
+        resolveBundledResolutionConfig: () => ({
+          config: {},
+          activationSourceConfig: {},
+          autoEnabledReasons: {},
+        }),
+        resolveCandidatePluginIds: () => ["firecrawl"],
+        mapRegistryProviders,
+        resolveBundledRuntimeArtifactProviders,
+      },
+    );
+
+    expect(providers).toEqual(["provider"]);
+    expect(resolveBundledRuntimeArtifactProviders).not.toHaveBeenCalled();
+    expect(mocks.loadOpenClawPlugins).toHaveBeenCalledTimes(1);
+    expect(mockArg(mocks.loadOpenClawPlugins).activate).toBe(true);
+  });
+
   it("falls back to a scoped provider load when the active runtime registry has no web providers", () => {
     const activeRegistry = { source: "active" };
     const fallbackRegistry = { source: "fallback" };

--- a/src/plugins/web-provider-runtime-shared.ts
+++ b/src/plugins/web-provider-runtime-shared.ts
@@ -53,6 +53,12 @@ type ResolveWebProviderRuntimeDeps<TEntry> = {
     env?: PluginLoadOptions["env"];
     onlyPluginIds?: readonly string[];
   }) => TEntry[] | null;
+  resolveBundledRuntimeArtifactProviders?: (params: {
+    config?: PluginLoadOptions["config"];
+    workspaceDir?: string;
+    env?: PluginLoadOptions["env"];
+    onlyPluginIds: readonly string[];
+  }) => TEntry[] | null;
 };
 
 type WebProviderRuntimeContext = {
@@ -236,6 +242,21 @@ export function resolvePluginWebProviders<TEntry>(
   }
   if (hasExplicitEmptyScope) {
     return [];
+  }
+  if (
+    params.activate !== true &&
+    context.loadPluginIds &&
+    deps.resolveBundledRuntimeArtifactProviders
+  ) {
+    const bundledArtifactProviders = deps.resolveBundledRuntimeArtifactProviders({
+      config: context.config,
+      workspaceDir: context.workspaceDir,
+      env: context.env,
+      onlyPluginIds: context.loadPluginIds,
+    });
+    if (bundledArtifactProviders) {
+      return bundledArtifactProviders;
+    }
   }
   const registry = loadOpenClawPlugins(loadOptions);
   return deps.mapRegistryProviders({

--- a/src/web-fetch/runtime.test.ts
+++ b/src/web-fetch/runtime.test.ts
@@ -88,14 +88,17 @@ function requireResolvedWebFetch(
 
 describe("web fetch runtime", () => {
   let resolveWebFetchDefinition: typeof import("./runtime.js").resolveWebFetchDefinition;
+  let clearWebFetchRuntimeCachesForTest: typeof import("./runtime.js").clearWebFetchRuntimeCachesForTest;
   let clearSecretsRuntimeSnapshot: typeof import("../secrets/runtime.js").clearSecretsRuntimeSnapshot;
 
   beforeAll(async () => {
-    ({ resolveWebFetchDefinition } = await import("./runtime.js"));
+    ({ clearWebFetchRuntimeCachesForTest, resolveWebFetchDefinition } =
+      await import("./runtime.js"));
     ({ clearSecretsRuntimeSnapshot } = await import("../secrets/runtime.js"));
   });
 
   beforeEach(() => {
+    clearWebFetchRuntimeCachesForTest();
     resolvePluginWebFetchProvidersMock.mockReset();
     resolveRuntimeWebFetchProvidersMock.mockReset();
     resolvePluginWebFetchProvidersMock.mockReturnValue([]);
@@ -104,6 +107,7 @@ describe("web fetch runtime", () => {
 
   afterEach(() => {
     clearSecretsRuntimeSnapshot();
+    clearWebFetchRuntimeCachesForTest();
   });
 
   it("does not auto-detect providers from plugin-owned env SecretRefs without runtime metadata", () => {
@@ -207,6 +211,82 @@ describe("web fetch runtime", () => {
     resolvePluginWebFetchProvidersMock.mockReturnValue([provider]);
 
     expect(resolveWebFetchDefinition({ config: {} })).toBeNull();
+  });
+
+  it("caches provider resolution misses for the same config snapshot", () => {
+    const config = {
+      tools: {
+        web: {
+          fetch: {
+            cacheTtlMinutes: 0,
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(resolveWebFetchDefinition({ config })).toBeNull();
+    expect(resolveWebFetchDefinition({ config })).toBeNull();
+
+    expect(resolvePluginWebFetchProvidersMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("caches provider definitions for the same config and runtime selection", () => {
+    const createTool = vi.fn(() => ({
+      description: "firecrawl",
+      parameters: {},
+      execute: async () => ({}),
+    }));
+    const provider = createFirecrawlProvider({
+      getConfiguredCredentialValue: () => "firecrawl-key",
+      createTool,
+    });
+    resolvePluginWebFetchProvidersMock.mockReturnValue([provider]);
+    const config = createFirecrawlPluginConfig("firecrawl-key");
+
+    const first = requireResolvedWebFetch(resolveWebFetchDefinition({ config }));
+    const second = requireResolvedWebFetch(resolveWebFetchDefinition({ config }));
+
+    expect(first).toBe(second);
+    expect(resolvePluginWebFetchProvidersMock).toHaveBeenCalledTimes(1);
+    expect(createTool).toHaveBeenCalledTimes(1);
+  });
+
+  it("keys provider definition cache by runtime-selected provider", () => {
+    const firecrawl = createFirecrawlProvider({
+      getConfiguredCredentialValue: () => "firecrawl-key",
+    });
+    const external = createThirdPartyFetchProvider();
+    resolveRuntimeWebFetchProvidersMock.mockReturnValue([firecrawl, external]);
+    const config = {} as OpenClawConfig;
+
+    const first = requireResolvedWebFetch(
+      resolveWebFetchDefinition({
+        config,
+        preferRuntimeProviders: true,
+        runtimeWebFetch: {
+          providerSource: "auto-detect",
+          selectedProvider: "firecrawl",
+          selectedProviderKeySource: "env",
+          diagnostics: [],
+        },
+      }),
+    );
+    const second = requireResolvedWebFetch(
+      resolveWebFetchDefinition({
+        config,
+        preferRuntimeProviders: true,
+        runtimeWebFetch: {
+          providerSource: "configured",
+          selectedProvider: "thirdparty",
+          selectedProviderKeySource: "config",
+          diagnostics: [],
+        },
+      }),
+    );
+
+    expect(first.provider.id).toBe("firecrawl");
+    expect(second.provider.id).toBe("thirdparty");
+    expect(resolveRuntimeWebFetchProvidersMock).toHaveBeenCalledTimes(2);
   });
 
   it("auto-detects providers from configured fallback credentials", () => {

--- a/src/web-fetch/runtime.test.ts
+++ b/src/web-fetch/runtime.test.ts
@@ -286,6 +286,55 @@ describe("web fetch runtime", () => {
     expect(resolvePluginWebFetchProvidersMock).toHaveBeenCalledTimes(2);
   });
 
+  it("invalidates provider discovery when the same config object changes", () => {
+    const firecrawl = createFirecrawlProvider({
+      getConfiguredCredentialValue: () => "firecrawl-key",
+    });
+    const external = createThirdPartyFetchProvider();
+    resolvePluginWebFetchProvidersMock
+      .mockReturnValueOnce([firecrawl])
+      .mockReturnValueOnce([external]);
+    const config = {
+      tools: { web: { fetch: { provider: "firecrawl" } } },
+    } as OpenClawConfig & { tools: { web: { fetch: { provider: string } } } };
+
+    const first = requireResolvedWebFetch(resolveWebFetchDefinition({ config }));
+    config.tools.web.fetch.provider = "thirdparty";
+    const second = requireResolvedWebFetch(resolveWebFetchDefinition({ config }));
+
+    expect(first.provider.id).toBe("firecrawl");
+    expect(second.provider.id).toBe("thirdparty");
+    expect(resolvePluginWebFetchProvidersMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("evicts superseded provider discovery cache entries", () => {
+    const firstFirecrawl = createFirecrawlProvider({
+      getConfiguredCredentialValue: () => "firecrawl-key",
+    });
+    const external = createThirdPartyFetchProvider();
+    const secondFirecrawl = createFirecrawlProvider({
+      getConfiguredCredentialValue: () => "firecrawl-key",
+    });
+    resolvePluginWebFetchProvidersMock
+      .mockReturnValueOnce([firstFirecrawl])
+      .mockReturnValueOnce([external])
+      .mockReturnValueOnce([secondFirecrawl]);
+    getActivePluginRegistryVersionMock
+      .mockReturnValueOnce(10)
+      .mockReturnValueOnce(11)
+      .mockReturnValueOnce(10);
+    const config = createFirecrawlPluginConfig("firecrawl-key");
+
+    const first = requireResolvedWebFetch(resolveWebFetchDefinition({ config }));
+    const second = requireResolvedWebFetch(resolveWebFetchDefinition({ config }));
+    const third = requireResolvedWebFetch(resolveWebFetchDefinition({ config }));
+
+    expect(first.provider).toBe(firstFirecrawl);
+    expect(second.provider.id).toBe("thirdparty");
+    expect(third.provider).toBe(secondFirecrawl);
+    expect(resolvePluginWebFetchProvidersMock).toHaveBeenCalledTimes(3);
+  });
+
   it("reuses runtime provider discovery across runtime-selected providers", () => {
     const firecrawl = createFirecrawlProvider({
       getConfiguredCredentialValue: () => "firecrawl-key",

--- a/src/web-fetch/runtime.test.ts
+++ b/src/web-fetch/runtime.test.ts
@@ -213,24 +213,22 @@ describe("web fetch runtime", () => {
     expect(resolveWebFetchDefinition({ config: {} })).toBeNull();
   });
 
-  it("caches provider resolution misses for the same config snapshot", () => {
-    const config = {
-      tools: {
-        web: {
-          fetch: {
-            cacheTtlMinutes: 0,
-          },
-        },
-      },
-    } as OpenClawConfig;
+  it("retries provider discovery after an empty plugin snapshot", () => {
+    const provider = createFirecrawlProvider({
+      getConfiguredCredentialValue: () => "firecrawl-key",
+    });
+    const config = createFirecrawlPluginConfig("firecrawl-key");
+    resolvePluginWebFetchProvidersMock.mockReturnValueOnce([]).mockReturnValueOnce([provider]);
 
     expect(resolveWebFetchDefinition({ config })).toBeNull();
-    expect(resolveWebFetchDefinition({ config })).toBeNull();
+    expect(requireResolvedWebFetch(resolveWebFetchDefinition({ config })).provider.id).toBe(
+      "firecrawl",
+    );
 
-    expect(resolvePluginWebFetchProvidersMock).toHaveBeenCalledTimes(1);
+    expect(resolvePluginWebFetchProvidersMock).toHaveBeenCalledTimes(2);
   });
 
-  it("caches provider definitions for the same config and runtime selection", () => {
+  it("reuses provider discovery for the same config snapshot", () => {
     const createTool = vi.fn(() => ({
       description: "firecrawl",
       parameters: {},
@@ -246,12 +244,12 @@ describe("web fetch runtime", () => {
     const first = requireResolvedWebFetch(resolveWebFetchDefinition({ config }));
     const second = requireResolvedWebFetch(resolveWebFetchDefinition({ config }));
 
-    expect(first).toBe(second);
+    expect(first.provider).toBe(second.provider);
     expect(resolvePluginWebFetchProvidersMock).toHaveBeenCalledTimes(1);
-    expect(createTool).toHaveBeenCalledTimes(1);
+    expect(createTool).toHaveBeenCalledTimes(2);
   });
 
-  it("keys provider definition cache by runtime-selected provider", () => {
+  it("reuses runtime provider discovery across runtime-selected providers", () => {
     const firecrawl = createFirecrawlProvider({
       getConfiguredCredentialValue: () => "firecrawl-key",
     });
@@ -286,7 +284,7 @@ describe("web fetch runtime", () => {
 
     expect(first.provider.id).toBe("firecrawl");
     expect(second.provider.id).toBe("thirdparty");
-    expect(resolveRuntimeWebFetchProvidersMock).toHaveBeenCalledTimes(2);
+    expect(resolveRuntimeWebFetchProvidersMock).toHaveBeenCalledTimes(1);
   });
 
   it("auto-detects providers from configured fallback credentials", () => {

--- a/src/web-fetch/runtime.test.ts
+++ b/src/web-fetch/runtime.test.ts
@@ -15,12 +15,23 @@ type TestPluginWebFetchConfig = {
   };
 };
 
-const { resolvePluginWebFetchProvidersMock, resolveRuntimeWebFetchProvidersMock } = vi.hoisted(
-  () => ({
-    resolvePluginWebFetchProvidersMock: vi.fn<() => PluginWebFetchProviderEntry[]>(() => []),
-    resolveRuntimeWebFetchProvidersMock: vi.fn<() => PluginWebFetchProviderEntry[]>(() => []),
-  }),
-);
+const {
+  getActivePluginRegistryVersionMock,
+  resolvePluginWebFetchProvidersMock,
+  resolveRuntimeWebFetchProvidersMock,
+} = vi.hoisted(() => ({
+  getActivePluginRegistryVersionMock: vi.fn(() => 1),
+  resolvePluginWebFetchProvidersMock: vi.fn<() => PluginWebFetchProviderEntry[]>(() => []),
+  resolveRuntimeWebFetchProvidersMock: vi.fn<() => PluginWebFetchProviderEntry[]>(() => []),
+}));
+
+vi.mock("../plugins/runtime.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../plugins/runtime.js")>();
+  return {
+    ...actual,
+    getActivePluginRegistryVersion: getActivePluginRegistryVersionMock,
+  };
+});
 
 vi.mock("../plugins/web-fetch-providers.runtime.js", () => ({
   resolvePluginWebFetchProviders: resolvePluginWebFetchProvidersMock,
@@ -99,6 +110,8 @@ describe("web fetch runtime", () => {
 
   beforeEach(() => {
     clearWebFetchRuntimeCachesForTest();
+    getActivePluginRegistryVersionMock.mockReset();
+    getActivePluginRegistryVersionMock.mockReturnValue(1);
     resolvePluginWebFetchProvidersMock.mockReset();
     resolveRuntimeWebFetchProvidersMock.mockReset();
     resolvePluginWebFetchProvidersMock.mockReturnValue([]);
@@ -247,6 +260,30 @@ describe("web fetch runtime", () => {
     expect(first.provider).toBe(second.provider);
     expect(resolvePluginWebFetchProvidersMock).toHaveBeenCalledTimes(1);
     expect(createTool).toHaveBeenCalledTimes(2);
+  });
+
+  it("invalidates provider discovery when the active plugin registry version changes", () => {
+    const firecrawl = createFirecrawlProvider({
+      getConfiguredCredentialValue: () => "firecrawl-key",
+    });
+    const external = createThirdPartyFetchProvider();
+    resolvePluginWebFetchProvidersMock
+      .mockReturnValueOnce([firecrawl])
+      .mockReturnValueOnce([external]);
+    getActivePluginRegistryVersionMock
+      .mockReturnValueOnce(10)
+      .mockReturnValueOnce(10)
+      .mockReturnValueOnce(11);
+    const config = createFirecrawlPluginConfig("firecrawl-key");
+
+    const first = requireResolvedWebFetch(resolveWebFetchDefinition({ config }));
+    const second = requireResolvedWebFetch(resolveWebFetchDefinition({ config }));
+    const third = requireResolvedWebFetch(resolveWebFetchDefinition({ config }));
+
+    expect(first.provider.id).toBe("firecrawl");
+    expect(second.provider.id).toBe("firecrawl");
+    expect(third.provider.id).toBe("thirdparty");
+    expect(resolvePluginWebFetchProvidersMock).toHaveBeenCalledTimes(2);
   });
 
   it("reuses runtime provider discovery across runtime-selected providers", () => {

--- a/src/web-fetch/runtime.ts
+++ b/src/web-fetch/runtime.ts
@@ -9,6 +9,7 @@ import {
 } from "../../packages/web-content-core/src/provider-runtime-shared.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { logVerbose } from "../globals.js";
+import { getActivePluginRegistryVersion } from "../plugins/runtime.js";
 import type {
   PluginWebFetchProviderEntry,
   WebFetchProviderToolDefinition,
@@ -193,7 +194,11 @@ function resolveConfiguredWebFetchProviderId(params: {
 function resolveWebFetchProviderCacheKey(
   options: ResolveWebFetchDefinitionParams | undefined,
 ): string {
-  return JSON.stringify([options?.sandboxed === true, options?.preferRuntimeProviders === true]);
+  return JSON.stringify([
+    getActivePluginRegistryVersion(),
+    options?.sandboxed === true,
+    options?.preferRuntimeProviders === true,
+  ]);
 }
 
 function resolveCachedWebFetchProviders(params: {

--- a/src/web-fetch/runtime.ts
+++ b/src/web-fetch/runtime.ts
@@ -36,6 +36,15 @@ type ResolveWebFetchDefinitionParams = {
   providerId?: string;
   preferRuntimeProviders?: boolean;
 };
+type WebFetchDefinitionResolution = {
+  provider: PluginWebFetchProviderEntry;
+  definition: WebFetchProviderToolDefinition;
+} | null;
+
+let webFetchDefinitionCache = new WeakMap<
+  OpenClawConfig,
+  Map<string, WebFetchDefinitionResolution>
+>();
 
 /** Resolves whether web_fetch is enabled for the current config/sandbox. */
 function resolveWebFetchEnabled(params: { fetch?: WebFetchConfig; sandboxed?: boolean }): boolean {
@@ -181,10 +190,60 @@ function resolveConfiguredWebFetchProviderId(params: {
   return params.providers.find((provider) => provider.id === raw)?.id;
 }
 
+function resolveWebFetchDefinitionCacheKey(
+  options: ResolveWebFetchDefinitionParams | undefined,
+): string {
+  const runtimeWebFetch = options?.runtimeWebFetch;
+  return JSON.stringify([
+    options?.sandboxed === true,
+    options?.preferRuntimeProviders === true,
+    options?.providerId ?? "",
+    runtimeWebFetch?.providerConfigured ?? "",
+    runtimeWebFetch?.providerSource ?? "",
+    runtimeWebFetch?.selectedProvider ?? "",
+    runtimeWebFetch?.selectedProviderKeySource ?? "",
+  ]);
+}
+
+function resolveCachedWebFetchDefinition(params: {
+  cacheKey: string;
+  config: OpenClawConfig;
+  load: () => WebFetchDefinitionResolution;
+}): WebFetchDefinitionResolution {
+  let configCache = webFetchDefinitionCache.get(params.config);
+  if (!configCache) {
+    configCache = new Map();
+    webFetchDefinitionCache.set(params.config, configCache);
+  }
+  if (configCache.has(params.cacheKey)) {
+    return configCache.get(params.cacheKey) ?? null;
+  }
+  const loaded = params.load();
+  configCache.set(params.cacheKey, loaded);
+  return loaded;
+}
+
+export function clearWebFetchRuntimeCachesForTest(): void {
+  webFetchDefinitionCache = new WeakMap();
+}
+
 /** Resolves the executable web_fetch provider tool definition. */
 export function resolveWebFetchDefinition(
   options?: ResolveWebFetchDefinitionParams,
-): { provider: PluginWebFetchProviderEntry; definition: WebFetchProviderToolDefinition } | null {
+): WebFetchDefinitionResolution {
+  if (options?.config) {
+    return resolveCachedWebFetchDefinition({
+      config: options.config,
+      cacheKey: resolveWebFetchDefinitionCacheKey(options),
+      load: () => resolveWebFetchDefinitionUncached(options),
+    });
+  }
+  return resolveWebFetchDefinitionUncached(options);
+}
+
+function resolveWebFetchDefinitionUncached(
+  options?: ResolveWebFetchDefinitionParams,
+): WebFetchDefinitionResolution {
   const fetch = resolveWebProviderConfig(options?.config, "fetch") as
     | NonNullable<WebFetchConfig>
     | undefined;

--- a/src/web-fetch/runtime.ts
+++ b/src/web-fetch/runtime.ts
@@ -41,9 +41,9 @@ type WebFetchDefinitionResolution = {
   definition: WebFetchProviderToolDefinition;
 } | null;
 
-let webFetchDefinitionCache = new WeakMap<
+let webFetchProviderCache = new WeakMap<
   OpenClawConfig,
-  Map<string, WebFetchDefinitionResolution>
+  Map<string, PluginWebFetchProviderEntry[]>
 >();
 
 /** Resolves whether web_fetch is enabled for the current config/sandbox. */
@@ -190,55 +190,70 @@ function resolveConfiguredWebFetchProviderId(params: {
   return params.providers.find((provider) => provider.id === raw)?.id;
 }
 
-function resolveWebFetchDefinitionCacheKey(
+function resolveWebFetchProviderCacheKey(
   options: ResolveWebFetchDefinitionParams | undefined,
 ): string {
-  const runtimeWebFetch = options?.runtimeWebFetch;
-  return JSON.stringify([
-    options?.sandboxed === true,
-    options?.preferRuntimeProviders === true,
-    options?.providerId ?? "",
-    runtimeWebFetch?.providerConfigured ?? "",
-    runtimeWebFetch?.providerSource ?? "",
-    runtimeWebFetch?.selectedProvider ?? "",
-    runtimeWebFetch?.selectedProviderKeySource ?? "",
-  ]);
+  return JSON.stringify([options?.sandboxed === true, options?.preferRuntimeProviders === true]);
 }
 
-function resolveCachedWebFetchDefinition(params: {
+function resolveCachedWebFetchProviders(params: {
   cacheKey: string;
   config: OpenClawConfig;
-  load: () => WebFetchDefinitionResolution;
-}): WebFetchDefinitionResolution {
-  let configCache = webFetchDefinitionCache.get(params.config);
+  load: () => PluginWebFetchProviderEntry[];
+}): PluginWebFetchProviderEntry[] {
+  let configCache = webFetchProviderCache.get(params.config);
   if (!configCache) {
     configCache = new Map();
-    webFetchDefinitionCache.set(params.config, configCache);
+    webFetchProviderCache.set(params.config, configCache);
   }
-  if (configCache.has(params.cacheKey)) {
-    return configCache.get(params.cacheKey) ?? null;
+  const cached = configCache.get(params.cacheKey);
+  if (cached) {
+    return cached;
   }
   const loaded = params.load();
-  configCache.set(params.cacheKey, loaded);
+  if (loaded.length > 0) {
+    configCache.set(params.cacheKey, loaded);
+  }
   return loaded;
 }
 
 export function clearWebFetchRuntimeCachesForTest(): void {
-  webFetchDefinitionCache = new WeakMap();
+  webFetchProviderCache = new WeakMap();
 }
 
 /** Resolves the executable web_fetch provider tool definition. */
 export function resolveWebFetchDefinition(
   options?: ResolveWebFetchDefinitionParams,
 ): WebFetchDefinitionResolution {
+  return resolveWebFetchDefinitionUncached(options);
+}
+
+function resolveWebFetchProvidersForOptions(
+  options?: ResolveWebFetchDefinitionParams,
+): PluginWebFetchProviderEntry[] {
+  const load = () =>
+    sortWebFetchProvidersForAutoDetect(
+      options?.sandboxed
+        ? resolvePluginWebFetchProviders({
+            config: options?.config,
+            sandboxed: true,
+          })
+        : options?.preferRuntimeProviders
+          ? resolveRuntimeWebFetchProviders({
+              config: options?.config,
+            })
+          : resolvePluginWebFetchProviders({
+              config: options?.config,
+            }),
+    );
   if (options?.config) {
-    return resolveCachedWebFetchDefinition({
+    return resolveCachedWebFetchProviders({
       config: options.config,
-      cacheKey: resolveWebFetchDefinitionCacheKey(options),
-      load: () => resolveWebFetchDefinitionUncached(options),
+      cacheKey: resolveWebFetchProviderCacheKey(options),
+      load,
     });
   }
-  return resolveWebFetchDefinitionUncached(options);
+  return load();
 }
 
 function resolveWebFetchDefinitionUncached(
@@ -247,21 +262,11 @@ function resolveWebFetchDefinitionUncached(
   const fetch = resolveWebProviderConfig(options?.config, "fetch") as
     | NonNullable<WebFetchConfig>
     | undefined;
+  if (!resolveWebFetchEnabled({ fetch, sandboxed: options?.sandboxed })) {
+    return null;
+  }
   const runtimeWebFetch = options?.runtimeWebFetch ?? getActiveRuntimeWebToolsMetadata()?.fetch;
-  const providers = sortWebFetchProvidersForAutoDetect(
-    options?.sandboxed
-      ? resolvePluginWebFetchProviders({
-          config: options?.config,
-          sandboxed: true,
-        })
-      : options?.preferRuntimeProviders
-        ? resolveRuntimeWebFetchProviders({
-            config: options?.config,
-          })
-        : resolvePluginWebFetchProviders({
-            config: options?.config,
-          }),
-  );
+  const providers = resolveWebFetchProvidersForOptions(options);
   return resolveWebProviderDefinition({
     config: options?.config,
     toolConfig: fetch as Record<string, unknown> | undefined,

--- a/src/web-fetch/runtime.ts
+++ b/src/web-fetch/runtime.ts
@@ -1,4 +1,5 @@
 /** Runtime provider selection and tool construction for the `web_fetch` tool. */
+import { createHash } from "node:crypto";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import {
   hasWebProviderEntryCredential,
@@ -41,11 +42,13 @@ type WebFetchDefinitionResolution = {
   provider: PluginWebFetchProviderEntry;
   definition: WebFetchProviderToolDefinition;
 } | null;
+type WebFetchProviderCacheEntry = {
+  cacheKey: string;
+  configFingerprint: string;
+  providers: PluginWebFetchProviderEntry[];
+};
 
-let webFetchProviderCache = new WeakMap<
-  OpenClawConfig,
-  Map<string, PluginWebFetchProviderEntry[]>
->();
+let webFetchProviderCache = new WeakMap<OpenClawConfig, WebFetchProviderCacheEntry>();
 
 /** Resolves whether web_fetch is enabled for the current config/sandbox. */
 function resolveWebFetchEnabled(params: { fetch?: WebFetchConfig; sandboxed?: boolean }): boolean {
@@ -201,23 +204,30 @@ function resolveWebFetchProviderCacheKey(
   ]);
 }
 
+function createWebFetchProviderConfigFingerprint(config: OpenClawConfig): string {
+  return createHash("sha256").update(JSON.stringify(config)).digest("hex");
+}
+
 function resolveCachedWebFetchProviders(params: {
   cacheKey: string;
   config: OpenClawConfig;
+  configFingerprint: string;
   load: () => PluginWebFetchProviderEntry[];
 }): PluginWebFetchProviderEntry[] {
-  let configCache = webFetchProviderCache.get(params.config);
-  if (!configCache) {
-    configCache = new Map();
-    webFetchProviderCache.set(params.config, configCache);
-  }
-  const cached = configCache.get(params.cacheKey);
-  if (cached) {
-    return cached;
+  const cached = webFetchProviderCache.get(params.config);
+  if (
+    cached?.cacheKey === params.cacheKey &&
+    cached.configFingerprint === params.configFingerprint
+  ) {
+    return cached.providers;
   }
   const loaded = params.load();
   if (loaded.length > 0) {
-    configCache.set(params.cacheKey, loaded);
+    webFetchProviderCache.set(params.config, {
+      cacheKey: params.cacheKey,
+      configFingerprint: params.configFingerprint,
+      providers: loaded,
+    });
   }
   return loaded;
 }
@@ -255,6 +265,7 @@ function resolveWebFetchProvidersForOptions(
     return resolveCachedWebFetchProviders({
       config: options.config,
       cacheKey: resolveWebFetchProviderCacheKey(options),
+      configFingerprint: createWebFetchProviderConfigFingerprint(options.config),
       load,
     });
   }


### PR DESCRIPTION
## What Problem This Solves

Resolves a performance problem where `web_fetch` shell-like HTML fallback paths loaded the complete bundled Firecrawl plugin graph after direct readability extraction returned no content. In a fresh process, that path spent roughly 6.4-6.9 seconds in plugin discovery/loading before doing useful fetch work.

## Why This Change Was Made

This adds a deterministic `perf:web-fetch` benchmark, caches provider fallback discovery with bounded invalidation, and gives bundled web-fetch providers a narrow runtime-artifact path. The fast path uses the canonical bundled-plugin activation policy, so plugin deny lists, explicit disables, allow lists, and global plugin disablement still apply. Explicit activation and mixed/external provider origins continue through the full loader.

The bundled Firecrawl provider now exposes a narrow runtime artifact and lazily imports its client only when the tool executes. The branch also removes duplicate Firecrawl scrape payload wrapping and trims HTML/readability hot-path work.

## User Impact

Fresh shell-like HTML fallback now resolves in roughly 0.92-1.11 seconds instead of 6.4-6.9 seconds on the same machine, an approximately 83-86% reduction. The first old-path sample reached 13.9 seconds and 811 MB RSS; the new path remained near one second across repeated fresh-process runs.

Provider behavior still updates when plugins load or unload, config changes, credentials appear, or callers explicitly request activation. External and non-bundled providers retain the existing full-loader behavior.

## Evidence

- Fresh-process baseline from the rebased parent: `6933.901ms`, `6658.163ms`, `6417.874ms`, `6476.341ms` after a first-run outlier of `13945.523ms`.
- Fresh-process result on this branch: `1222.835ms`, `1102.780ms`, `1113.427ms`, `949.066ms`, `969.586ms`, `916.912ms`, `988.535ms`.
- Focused validation passed with 178 tests across core, agent, plugin, extension, readability, Firecrawl, and web-fetch runtime shards.
- `pnpm build` passed through Testbox id `tbx_01kwn1evj9cjt8xz43hmj5yahg` in `75.5s`.
- Path-scoped `pnpm check:changed` passed through Crabbox/Testbox id `tbx_01kwn1r744fs714103fns86pr0`, Actions run `28686129791`, exit `0`, total `10m05.984s`. This covered all typecheck lanes, core/extensions/tooling lint, dependency and shrinkwrap guards, runtime import cycles, and repository policy guards.
- Post-rebase branch autoreview passed with no accepted/actionable findings; overall verdict `patch is correct`, confidence `0.90`.
