### PR TITLE
fix: route node policy plugin approvals

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -1896,19 +1896,31 @@ public struct NodeInvokeParams: Codable, Sendable {
     public let params: AnyCodable?
     public let timeoutms: Int?
     public let idempotencykey: String
+    public let turnsourcechannel: String?
+    public let turnsourceto: String?
+    public let turnsourceaccountid: String?
+    public let turnsourcethreadid: AnyCodable?
 
     public init(
         nodeid: String,
         command: String,
         params: AnyCodable? = nil,
         timeoutms: Int? = nil,
-        idempotencykey: String)
+        idempotencykey: String,
+        turnsourcechannel: String? = nil,
+        turnsourceto: String? = nil,
+        turnsourceaccountid: String? = nil,
+        turnsourcethreadid: AnyCodable? = nil)
     {
         self.nodeid = nodeid
         self.command = command
         self.params = params
         self.timeoutms = timeoutms
         self.idempotencykey = idempotencykey
+        self.turnsourcechannel = turnsourcechannel
+        self.turnsourceto = turnsourceto
+        self.turnsourceaccountid = turnsourceaccountid
+        self.turnsourcethreadid = turnsourcethreadid
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -1917,6 +1929,10 @@ public struct NodeInvokeParams: Codable, Sendable {
         case params
         case timeoutms = "timeoutMs"
         case idempotencykey = "idempotencyKey"
+        case turnsourcechannel = "turnSourceChannel"
+        case turnsourceto = "turnSourceTo"
+        case turnsourceaccountid = "turnSourceAccountId"
+        case turnsourcethreadid = "turnSourceThreadId"
     }
 }
 

--- a/packages/gateway-protocol/src/schema/nodes.ts
+++ b/packages/gateway-protocol/src/schema/nodes.ts
@@ -102,6 +102,11 @@ export const NodeInvokeParamsSchema = Type.Object(
     params: Type.Optional(Type.Unknown()),
     timeoutMs: Type.Optional(Type.Integer({ minimum: 0 })),
     idempotencyKey: NonEmptyString,
+    // Gateway-only approval routing metadata. Node forwarding strips these fields.
+    turnSourceChannel: Type.Optional(Type.String()),
+    turnSourceTo: Type.Optional(Type.String()),
+    turnSourceAccountId: Type.Optional(Type.String()),
+    turnSourceThreadId: Type.Optional(Type.Union([Type.String(), Type.Number()])),
   },
   { additionalProperties: false },
 );

--- a/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
+++ b/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
@@ -32,6 +32,7 @@ import { createHostSandboxFsBridge } from "./test-helpers/host-sandbox-fs-bridge
 import { buildEmptyExplicitToolAllowlistError } from "./tool-allowlist-guard.js";
 import { DEFAULT_PLUGIN_TOOLS_ALLOWLIST_ENTRY, normalizeToolName } from "./tool-policy.js";
 import { replaceWithEffectiveCronCreatorToolAllowlist } from "./tools/cron-tool.js";
+import { getGatewayToolCallerIdentity } from "./tools/gateway-caller-context.js";
 
 const tinyPngBuffer = Buffer.from(
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO2f7z8AAAAASUVORK5CYII=",
@@ -733,6 +734,58 @@ describe("createOpenClawCodingTools", () => {
       expect(pluginToolOptions?.modelProvider).toBe("openrouter");
       expect(pluginToolOptions?.modelId).toBe("openrouter/auto");
       expect(pluginToolOptions?.nativeChannelId).toBe("oc_native_chat");
+    } finally {
+      resolvePluginToolsSpy.mockRestore();
+    }
+  });
+
+  it("wraps plugin-only tools with trusted caller routing context", async () => {
+    let observedIdentity: unknown;
+    const resolvePluginToolsSpy = vi
+      .spyOn(openClawPluginTools, "resolveOpenClawPluginToolsForOptions")
+      .mockReturnValue([
+        {
+          name: "file_fetch",
+          label: "File fetch",
+          description: "Fetch a file",
+          parameters: { type: "object", properties: {} },
+          execute: async () => {
+            observedIdentity = getGatewayToolCallerIdentity();
+            return { content: [{ type: "text" as const, text: "ok" }], details: {} };
+          },
+        },
+      ]);
+
+    try {
+      const tools = createOpenClawCodingTools({
+        config: testConfig,
+        agentId: "main",
+        sessionKey: "agent:main:telegram:direct:alice",
+        messageProvider: "discord-voice",
+        messageChannel: "discord",
+        messageTo: "channel:123",
+        agentAccountId: "work",
+        messageThreadId: "42",
+        includeCoreTools: false,
+        runtimeToolAllowlist: ["file_fetch"],
+        toolConstructionPlan: {
+          includeBaseCodingTools: false,
+          includeShellTools: false,
+          includeChannelTools: false,
+          includeOpenClawTools: false,
+          includePluginTools: true,
+        },
+      });
+
+      await requireTool(tools, "file_fetch").execute?.("tool-call-1", {});
+      expect(observedIdentity).toEqual({
+        agentId: "main",
+        sessionKey: "agent:main:telegram:direct:alice",
+        turnSourceChannel: "discord",
+        turnSourceTo: "channel:123",
+        turnSourceAccountId: "work",
+        turnSourceThreadId: "42",
+      });
     } finally {
       resolvePluginToolsSpy.mockRestore();
     }

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -108,6 +108,7 @@ import {
   replaceWithEffectiveCronCreatorToolAllowlist,
   type CronCreatorToolAllowlistEntry,
 } from "./tools/cron-tool.js";
+import { wrapToolWithGatewayCallerIdentity } from "./tools/gateway-caller-context.js";
 
 const MEMORY_FLUSH_ALLOWED_TOOL_NAMES = new Set(["read", "write"]);
 
@@ -839,13 +840,29 @@ export function createOpenClawCodingTools(options?: {
   );
   // Plugin-only plans bypass createOpenClawTools, so the capability gate must
   // apply here too or narrow allowlists leak gated tools onto capless surfaces.
+  const pluginToolCallerIdentity =
+    agentId && options?.sessionKey?.trim()
+      ? {
+          agentId,
+          sessionKey: options.sessionKey.trim(),
+          turnSourceChannel: resolveGatewayMessageChannel(
+            options.messageChannel ?? options.messageProvider,
+          ),
+          turnSourceTo:
+            options.currentMessagingTarget ?? options.currentChannelId ?? options.messageTo,
+          turnSourceAccountId: options.agentAccountId,
+          turnSourceThreadId: options.currentThreadTs ?? options.messageThreadId,
+        }
+      : undefined;
   const pluginToolsOnly = filterToolsByClientCaps(
     includeOpenClawTools || !includePluginTools
       ? []
       : resolveOpenClawPluginToolsForOptions({
           options: {
             agentSessionKey: options?.sessionKey,
-            agentChannel: resolveGatewayMessageChannel(options?.messageProvider),
+            agentChannel: resolveGatewayMessageChannel(
+              options?.messageChannel ?? options?.messageProvider,
+            ),
             agentAccountId: options?.agentAccountId,
             agentTo: options?.messageTo,
             agentThreadId: options?.messageThreadId,
@@ -879,7 +896,7 @@ export function createOpenClawCodingTools(options?: {
           resolvedConfig: options?.config,
         }),
     options?.clientCaps,
-  );
+  ).map((tool) => wrapToolWithGatewayCallerIdentity(tool, pluginToolCallerIdentity));
   const toolSearchTools = toolSearchControlsEnabled
     ? createToolSearchTools({
         config: options?.config,
@@ -932,7 +949,9 @@ export function createOpenClawCodingTools(options?: {
           agentSessionKey: options?.sessionKey,
           runId: options?.runId,
           runSessionKey: options?.runSessionKey,
-          agentChannel: resolveGatewayMessageChannel(options?.messageProvider),
+          agentChannel: resolveGatewayMessageChannel(
+            options?.messageChannel ?? options?.messageProvider,
+          ),
           agentAccountId: options?.agentAccountId,
           agentTo: options?.messageTo,
           agentThreadId: options?.messageThreadId,

--- a/src/agents/openclaw-tools.gateway-caller-identity.test.ts
+++ b/src/agents/openclaw-tools.gateway-caller-identity.test.ts
@@ -23,13 +23,14 @@ vi.mock("./openclaw-plugin-tools.js", () => ({
 
 import { createOpenClawTools } from "./openclaw-tools.js";
 
-function requireTool(name: string) {
+function requireTool(name: string, overrides?: Parameters<typeof createOpenClawTools>[0]) {
   const tool = createOpenClawTools({
     agentSessionKey: "agent:main:discord:channel:123",
     disableMessageTool: true,
     pluginToolAllowlist: [name],
     requesterAgentIdOverride: "main",
     wrapBeforeToolCallHook: false,
+    ...overrides,
   }).find((candidate) => candidate.name === name);
   if (!tool?.execute) {
     throw new Error(`Expected executable tool ${name}`);
@@ -48,6 +49,29 @@ describe("createOpenClawTools Gateway caller identity", () => {
       {
         agentId: "main",
         sessionKey: "agent:main:discord:channel:123",
+      },
+    ]);
+  });
+
+  it("carries trusted turn-source routing with the agent identity", async () => {
+    mocks.observedIdentities.length = 0;
+
+    const tool = requireTool("synthetic_direct_cron_plugin", {
+      agentChannel: "discord",
+      agentTo: "channel:123",
+      agentAccountId: "work",
+      agentThreadId: "thread-7",
+    });
+    await tool.execute("tool-call-2", {});
+
+    expect(mocks.observedIdentities).toEqual([
+      {
+        agentId: "main",
+        sessionKey: "agent:main:discord:channel:123",
+        turnSourceChannel: "discord",
+        turnSourceTo: "channel:123",
+        turnSourceAccountId: "work",
+        turnSourceThreadId: "thread-7",
       },
     ]);
   });

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -660,7 +660,15 @@ export function createOpenClawTools(
   const hookAgentId = options?.requesterAgentIdOverride ?? sessionAgentId;
   const gatewayCallerIdentity =
     hookAgentId && options?.agentSessionKey?.trim()
-      ? { agentId: hookAgentId, sessionKey: options.agentSessionKey.trim() }
+      ? {
+          agentId: hookAgentId,
+          sessionKey: options.agentSessionKey.trim(),
+          turnSourceChannel: options.agentChannel,
+          turnSourceTo:
+            options.currentMessagingTarget ?? options.currentChannelId ?? options.agentTo,
+          turnSourceAccountId: options.agentAccountId,
+          turnSourceThreadId: options.currentThreadTs ?? options.agentThreadId,
+        }
       : undefined;
   const wrapGatewayCallerIdentity = (tool: AnyAgentTool) =>
     wrapToolWithGatewayCallerIdentity(tool, gatewayCallerIdentity);

--- a/src/agents/tools/gateway-caller-context.ts
+++ b/src/agents/tools/gateway-caller-context.ts
@@ -9,6 +9,11 @@ import type { AnyAgentTool } from "./common.js";
 type GatewayToolCallerIdentity = {
   agentId: string;
   sessionKey: string;
+  // Trusted run context, carried separately from model-authored tool arguments.
+  turnSourceChannel?: string;
+  turnSourceTo?: string;
+  turnSourceAccountId?: string;
+  turnSourceThreadId?: string | number;
 };
 
 const gatewayToolCallerStorage = new AsyncLocalStorage<GatewayToolCallerIdentity>();
@@ -28,6 +33,16 @@ export async function withGatewayToolCallerIdentity<T>(
     {
       agentId: identity.agentId.trim(),
       sessionKey: identity.sessionKey.trim(),
+      ...(identity.turnSourceChannel?.trim()
+        ? { turnSourceChannel: identity.turnSourceChannel.trim() }
+        : {}),
+      ...(identity.turnSourceTo?.trim() ? { turnSourceTo: identity.turnSourceTo.trim() } : {}),
+      ...(identity.turnSourceAccountId?.trim()
+        ? { turnSourceAccountId: identity.turnSourceAccountId.trim() }
+        : {}),
+      ...(identity.turnSourceThreadId !== undefined
+        ? { turnSourceThreadId: identity.turnSourceThreadId }
+        : {}),
     },
     run,
   );

--- a/src/agents/tools/gateway.test.ts
+++ b/src/agents/tools/gateway.test.ts
@@ -663,6 +663,171 @@ describe("gateway tool defaults", () => {
     expect(call.deviceIdentity).toEqual(mocks.deviceIdentity);
   });
 
+  it("attaches trusted turn-source metadata to node invokes", async () => {
+    mocks.callGateway.mockResolvedValueOnce({ ok: true });
+
+    await withGatewayToolCallerIdentity(
+      {
+        agentId: "ops",
+        sessionKey: "agent:ops:telegram:direct:alice",
+        turnSourceChannel: "telegram",
+        turnSourceTo: "chat:123",
+        turnSourceAccountId: "work",
+        turnSourceThreadId: 42,
+      },
+      async () => {
+        await callGatewayTool(
+          "node.invoke",
+          {},
+          {
+            nodeId: "node-1",
+            command: "file.fetch",
+            params: { path: "/tmp/a" },
+            idempotencyKey: "invoke-1",
+            turnSourceChannel: "attacker-channel",
+            turnSourceTo: "attacker-target",
+            turnSourceAccountId: "attacker-account",
+            turnSourceThreadId: "attacker-thread",
+          },
+        );
+      },
+    );
+
+    const call = capturedGatewayCall();
+    expect(call.params).toEqual({
+      nodeId: "node-1",
+      command: "file.fetch",
+      params: { path: "/tmp/a" },
+      idempotencyKey: "invoke-1",
+      turnSourceChannel: "telegram",
+      turnSourceTo: "chat:123",
+      turnSourceAccountId: "work",
+      turnSourceThreadId: 42,
+    });
+    expect(verifyAgentRuntimeIdentityToken(call.agentRuntimeIdentityToken ?? "")).toMatchObject({
+      agentId: "ops",
+      sessionKey: "agent:ops:telegram:direct:alice",
+    });
+  });
+
+  it("retries node invokes without optional identity against an older gateway", async () => {
+    mocks.callGateway
+      .mockRejectedValueOnce(
+        new Error(
+          "invalid connect params: at /auth: unexpected property 'agentRuntimeIdentityToken'",
+        ),
+      )
+      .mockResolvedValueOnce({ ok: true });
+
+    await withGatewayToolCallerIdentity(
+      {
+        agentId: "ops",
+        sessionKey: "agent:ops:main",
+        turnSourceChannel: "telegram",
+        turnSourceTo: "chat:123",
+      },
+      async () => {
+        await callGatewayTool(
+          "node.invoke",
+          {},
+          {
+            nodeId: "node-1",
+            command: "device.info",
+            idempotencyKey: "invoke-legacy",
+          },
+        );
+      },
+    );
+
+    expect(mocks.callGateway).toHaveBeenCalledTimes(2);
+    expect(mocks.callGateway.mock.calls[0]?.[0]).toHaveProperty(
+      "agentRuntimeIdentityToken",
+      expect.any(String),
+    );
+    expect(mocks.callGateway.mock.calls[1]?.[0].agentRuntimeIdentityToken).toBeUndefined();
+    expect(mocks.callGateway.mock.calls[1]?.[0].params).toEqual({
+      nodeId: "node-1",
+      command: "device.info",
+      idempotencyKey: "invoke-legacy",
+    });
+  });
+
+  it("strips turn-source fields for gateways with the preceding node schema", async () => {
+    const schemaError = Object.assign(
+      new Error("invalid node.invoke params: at root: unexpected property 'turnSourceChannel'"),
+      {
+        name: "GatewayClientRequestError",
+        gatewayCode: "INVALID_REQUEST",
+      },
+    );
+    mocks.callGateway.mockRejectedValueOnce(schemaError).mockResolvedValueOnce({ ok: true });
+
+    await withGatewayToolCallerIdentity(
+      {
+        agentId: "ops",
+        sessionKey: "agent:ops:main",
+        turnSourceChannel: "telegram",
+        turnSourceTo: "chat:123",
+      },
+      async () => {
+        await callGatewayTool(
+          "node.invoke",
+          {},
+          {
+            nodeId: "node-1",
+            command: "device.info",
+            idempotencyKey: "invoke-preceding-schema",
+          },
+        );
+      },
+    );
+
+    expect(mocks.callGateway).toHaveBeenCalledTimes(2);
+    expect(mocks.callGateway.mock.calls[1]?.[0].params).toEqual({
+      nodeId: "node-1",
+      command: "device.info",
+      idempotencyKey: "invoke-preceding-schema",
+    });
+    expect(mocks.callGateway.mock.calls[1]?.[0]).toHaveProperty(
+      "agentRuntimeIdentityToken",
+      expect.any(String),
+    );
+  });
+
+  it("does not retry a dispatched node invoke whose error resembles schema rejection", async () => {
+    const dispatchedError = Object.assign(
+      new Error("invalid node.invoke params: at root: unexpected property 'turnSourceChannel'"),
+      {
+        name: "GatewayClientRequestError",
+        gatewayCode: "INVALID_REQUEST",
+        details: { nodeCommandDispatched: true },
+      },
+    );
+    mocks.callGateway.mockRejectedValueOnce(dispatchedError);
+
+    await expect(
+      withGatewayToolCallerIdentity(
+        {
+          agentId: "ops",
+          sessionKey: "agent:ops:main",
+          turnSourceChannel: "telegram",
+          turnSourceTo: "chat:123",
+        },
+        async () =>
+          await callGatewayTool(
+            "node.invoke",
+            {},
+            {
+              nodeId: "node-1",
+              command: "device.info",
+              idempotencyKey: "invoke-dispatched",
+            },
+          ),
+      ),
+    ).rejects.toBe(dispatchedError);
+    expect(mocks.callGateway).toHaveBeenCalledTimes(1);
+  });
+
   it("marks local plugin approval request calls with runtime and device identity", async () => {
     mocks.callGateway.mockResolvedValueOnce({ id: "plugin:approval-id" });
 

--- a/src/agents/tools/gateway.ts
+++ b/src/agents/tools/gateway.ts
@@ -12,6 +12,7 @@ import {
   GATEWAY_CLIENT_MODES,
   GATEWAY_CLIENT_NAMES,
 } from "../../../packages/gateway-protocol/src/client-info.js";
+import { ErrorCodes } from "../../../packages/gateway-protocol/src/schema/error-codes.js";
 import { getRuntimeConfig, resolveGatewayPort } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { mintAgentRuntimeIdentityToken } from "../../gateway/agent-runtime-identity-token.js";
@@ -223,6 +224,8 @@ const AGENT_RUNTIME_IDENTITY_METHODS = new Set<string>([
   "cron.runs",
 ]);
 
+const OPTIONAL_LOCAL_AGENT_RUNTIME_IDENTITY_METHODS = new Set<string>(["node.invoke"]);
+
 function resolveApprovalRuntimeTokenForGatewayTool(params: {
   method: string;
   opts: GatewayCallOptions;
@@ -247,6 +250,40 @@ function isApprovalReplayNodeSystemRun(method: string, callParams: unknown): boo
   const run = invoke?.command === "system.run" ? asNullableRecord(invoke.params) : null;
   const decision = normalizeOptionalString(run?.approvalDecision);
   return run?.approved === true || decision === "allow-once" || decision === "allow-always";
+}
+
+function attachNodeInvokeTurnSource(method: string, params: unknown): unknown {
+  if (method !== "node.invoke") {
+    return params;
+  }
+  const invoke = asNullableRecord(params);
+  const caller = getGatewayToolCallerIdentity();
+  if (!invoke || !caller) {
+    return params;
+  }
+  return {
+    ...omitNodeInvokeTurnSource(invoke),
+    ...(caller.turnSourceChannel ? { turnSourceChannel: caller.turnSourceChannel } : {}),
+    ...(caller.turnSourceTo ? { turnSourceTo: caller.turnSourceTo } : {}),
+    ...(caller.turnSourceAccountId ? { turnSourceAccountId: caller.turnSourceAccountId } : {}),
+    ...(caller.turnSourceThreadId !== undefined
+      ? { turnSourceThreadId: caller.turnSourceThreadId }
+      : {}),
+  };
+}
+
+function omitNodeInvokeTurnSource(invoke: Record<string, unknown>): Record<string, unknown> {
+  const legacyParams = { ...invoke };
+  delete legacyParams.turnSourceChannel;
+  delete legacyParams.turnSourceTo;
+  delete legacyParams.turnSourceAccountId;
+  delete legacyParams.turnSourceThreadId;
+  return legacyParams;
+}
+
+function stripNodeInvokeTurnSource(params: unknown): unknown {
+  const invoke = asNullableRecord(params);
+  return invoke ? omitNodeInvokeTurnSource(invoke) : params;
 }
 
 function resolveApprovalRequesterDeviceIdentityForGatewayTool(params: {
@@ -310,7 +347,12 @@ async function resolveAgentRuntimeIdentityTokenForGatewayTool(params: {
   target: GatewayOverrideTarget;
   required?: boolean;
 }): Promise<string | undefined> {
-  if (!params.required && !AGENT_RUNTIME_IDENTITY_METHODS.has(params.method)) {
+  const optionalLocalIdentity = OPTIONAL_LOCAL_AGENT_RUNTIME_IDENTITY_METHODS.has(params.method);
+  if (
+    !params.required &&
+    !AGENT_RUNTIME_IDENTITY_METHODS.has(params.method) &&
+    !optionalLocalIdentity
+  ) {
     return undefined;
   }
   const identity = getGatewayToolCallerIdentity();
@@ -323,9 +365,20 @@ async function resolveAgentRuntimeIdentityTokenForGatewayTool(params: {
   const hasGatewayUrlOverride = trimToUndefined(params.opts.gatewayUrl) !== undefined;
   const hasGatewayTokenOverride = trimToUndefined(params.opts.gatewayToken) !== undefined;
   if (hasGatewayUrlOverride || hasGatewayTokenOverride || params.target !== "local") {
+    // Optional provenance must never turn a supported remote node call into an auth failure.
+    if (optionalLocalIdentity && !params.required) {
+      return undefined;
+    }
     throw new Error("agent gateway calls require the trusted local gateway context");
   }
-  return await mintAgentRuntimeIdentityToken(identity);
+  try {
+    return await mintAgentRuntimeIdentityToken(identity);
+  } catch (error) {
+    if (optionalLocalIdentity && !params.required) {
+      return undefined;
+    }
+    throw error;
+  }
 }
 
 export async function resolveMessageActionAgentRuntimeIdentityToken(params: {
@@ -376,6 +429,29 @@ function isStaleGatewayAgentRuntimeIdentityRejection(error: unknown): boolean {
   );
 }
 
+function isStaleGatewayNodeInvokeTurnSourceRejection(error: unknown): boolean {
+  if (!(error instanceof Error) || error.name !== "GatewayClientRequestError") {
+    return false;
+  }
+  const requestError = error as Error & { gatewayCode?: unknown; details?: unknown };
+  if (requestError.gatewayCode !== ErrorCodes.INVALID_REQUEST) {
+    return false;
+  }
+  const details = asNullableRecord(requestError.details);
+  // A dispatched command may have acted before returning an error. Never turn
+  // version fallback into a duplicate invocation when the Gateway says so.
+  if (details?.nodeCommandDispatched === true) {
+    return false;
+  }
+  const message = formatErrorMessage(error);
+  if (!message.includes("invalid node.invoke params:")) {
+    return false;
+  }
+  return ["turnSourceChannel", "turnSourceTo", "turnSourceAccountId", "turnSourceThreadId"].some(
+    (field) => message.includes(`unexpected property '${field}'`),
+  );
+}
+
 function staleGatewayAgentRuntimeIdentityError(cause: unknown): Error {
   return new Error(
     [
@@ -401,9 +477,10 @@ export async function callGatewayTool<T = Record<string, unknown>>(
   },
 ) {
   const gateway = resolveGatewayOptions(opts);
+  const callParams = attachNodeInvokeTurnSource(method, params);
   const scopes = Array.isArray(extra?.scopes)
     ? extra.scopes
-    : resolveLeastPrivilegeOperatorScopesForMethod(method, params);
+    : resolveLeastPrivilegeOperatorScopesForMethod(method, callParams);
   const approvalRuntimeToken = resolveApprovalRuntimeTokenForGatewayTool({
     method,
     opts,
@@ -417,29 +494,43 @@ export async function callGatewayTool<T = Record<string, unknown>>(
   });
   const deviceIdentity = resolveApprovalRequesterDeviceIdentityForGatewayTool({
     method,
-    callParams: params,
+    callParams,
     opts,
     target: gateway.target,
   });
+  const callOptions = {
+    url: gateway.url,
+    token: gateway.token,
+    method,
+    params: callParams,
+    timeoutMs: gateway.timeoutMs,
+    signal: extra?.signal,
+    expectFinal: extra?.expectFinal,
+    clientName: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
+    clientDisplayName: "agent",
+    mode: GATEWAY_CLIENT_MODES.BACKEND,
+    ...(approvalRuntimeToken ? { approvalRuntimeToken } : {}),
+    ...(agentRuntimeIdentityToken ? { agentRuntimeIdentityToken } : {}),
+    ...(deviceIdentity ? { deviceIdentity } : {}),
+    scopes,
+  };
   try {
-    return await callGateway<T>({
-      url: gateway.url,
-      token: gateway.token,
-      method,
-      params,
-      timeoutMs: gateway.timeoutMs,
-      signal: extra?.signal,
-      expectFinal: extra?.expectFinal,
-      clientName: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
-      clientDisplayName: "agent",
-      mode: GATEWAY_CLIENT_MODES.BACKEND,
-      ...(approvalRuntimeToken ? { approvalRuntimeToken } : {}),
-      ...(agentRuntimeIdentityToken ? { agentRuntimeIdentityToken } : {}),
-      ...(deviceIdentity ? { deviceIdentity } : {}),
-      scopes,
-    });
+    return await callGateway<T>(callOptions);
   } catch (error) {
+    if (method === "node.invoke" && isStaleGatewayNodeInvokeTurnSourceRejection(error)) {
+      return await callGateway<T>({
+        ...callOptions,
+        params: stripNodeInvokeTurnSource(callOptions.params),
+      });
+    }
     if (agentRuntimeIdentityToken && isStaleGatewayAgentRuntimeIdentityRejection(error)) {
+      if (method === "node.invoke" && extra?.requireAgentRuntimeIdentity !== true) {
+        return await callGateway<T>({
+          ...callOptions,
+          params: stripNodeInvokeTurnSource(callOptions.params),
+          agentRuntimeIdentityToken: undefined,
+        });
+      }
       throw staleGatewayAgentRuntimeIdentityError(error);
     }
     throw error;

--- a/src/gateway/node-invoke-plugin-policy.test.ts
+++ b/src/gateway/node-invoke-plugin-policy.test.ts
@@ -52,6 +52,7 @@ function createContext(opts?: {
   getRuntimeConfig?: GatewayRequestContext["getRuntimeConfig"];
   nodeSession?: NodeSession;
   hasExecApprovalClients?: GatewayRequestContext["hasExecApprovalClients"];
+  forwardPluginApprovalRequest?: GatewayRequestContext["forwardPluginApprovalRequest"];
 }) {
   const nodeSession = opts?.nodeSession ?? createNodeSession();
   const invoke = vi.fn(async () => ({
@@ -71,6 +72,7 @@ function createContext(opts?: {
       pluginApprovalManager: opts?.pluginApprovalManager,
       getApprovalClientConnIds: opts?.getApprovalClientConnIds,
       hasExecApprovalClients: opts?.hasExecApprovalClients,
+      forwardPluginApprovalRequest: opts?.forwardPluginApprovalRequest,
     } as unknown as GatewayRequestContext,
     invoke,
   };
@@ -384,27 +386,37 @@ describe("applyPluginNodeInvokePolicy", () => {
     await expectApprovalResolution(resultPromise, manager, record);
   });
 
-  it("keeps plugin policy approvals pending when only the originating turn source can approve", async () => {
+  it("forwards plugin policy approvals to the originating turn source", async () => {
     const manager = new ExecApprovalManager<PluginApprovalRequestPayload>();
     const getApprovalClientConnIds = vi.fn(() => new Set<string>());
+    const handlePluginApprovalRequested = vi.fn(async () => true);
     setDangerousDemoCommandRegistry([createApprovalRequestPolicy()]);
     const { context } = createContext({
       pluginApprovalManager: manager,
       getApprovalClientConnIds,
       hasExecApprovalClients: vi.fn(() => false),
+      forwardPluginApprovalRequest: handlePluginApprovalRequested,
     });
     const resultPromise = applyPluginNodeInvokePolicy({
       context,
-      client: createOperatorClient(),
+      client: {
+        ...createOperatorClient(),
+        internal: {
+          agentRuntimeIdentity: {
+            kind: "agentRuntime",
+            agentId: "main",
+            sessionKey: "agent:main:telegram:direct:alice",
+          },
+        },
+      },
       nodeSession: createNodeSession(),
       command: DEMO_COMMAND,
       params: DEMO_PARAMS,
-      rawParams: {
-        ...DEMO_PARAMS,
-        turnSourceChannel: "tui",
-        turnSourceTo: "terminal",
-        turnSourceAccountId: "default",
-        turnSourceThreadId: 7,
+      turnSource: {
+        channel: "tui",
+        to: "terminal",
+        accountId: "default",
+        threadId: 7,
       },
     });
 
@@ -420,13 +432,61 @@ describe("applyPluginNodeInvokePolicy", () => {
       new Set<string>(),
       { dropIfSlow: true },
     );
-    expect(hasApprovalTurnSourceRouteMock).toHaveBeenCalledWith({
-      turnSourceChannel: "tui",
-      turnSourceAccountId: "default",
-      approvalKind: "plugin",
-    });
+    expect(handlePluginApprovalRequested).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: record.id,
+        request: expect.objectContaining({
+          turnSourceChannel: "tui",
+          turnSourceTo: "terminal",
+          turnSourceAccountId: "default",
+          turnSourceThreadId: 7,
+          agentId: "main",
+          sessionKey: "agent:main:telegram:direct:alice",
+        }),
+      }),
+    );
 
     await expectApprovalResolution(resultPromise, manager, record);
+  });
+
+  it("ignores approval routes from unsigned node.invoke clients", async () => {
+    const manager = new ExecApprovalManager<PluginApprovalRequestPayload>();
+    const forwardPluginApprovalRequest = vi.fn(async () => false);
+    setDangerousDemoCommandRegistry([createApprovalRequestPolicy()]);
+    const { context } = createContext({
+      pluginApprovalManager: manager,
+      getApprovalClientConnIds: vi.fn(() => new Set<string>()),
+      hasExecApprovalClients: vi.fn(() => false),
+      forwardPluginApprovalRequest,
+    });
+
+    const result = await applyPluginNodeInvokePolicy({
+      context,
+      client: createOperatorClient(),
+      nodeSession: createNodeSession(),
+      command: DEMO_COMMAND,
+      params: DEMO_PARAMS,
+      turnSource: {
+        channel: "telegram",
+        to: "chat:other",
+        accountId: "work",
+        threadId: 9,
+      },
+    });
+
+    expect(result).toMatchObject({ ok: true, payload: { decision: null } });
+    expect(forwardPluginApprovalRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        request: expect.objectContaining({
+          agentId: null,
+          sessionKey: null,
+          turnSourceChannel: null,
+          turnSourceTo: null,
+          turnSourceAccountId: null,
+          turnSourceThreadId: null,
+        }),
+      }),
+    );
   });
 
   it("caps plugin policy approval timeouts through the shared approval policy", async () => {

--- a/src/gateway/node-invoke-plugin-policy.test.ts
+++ b/src/gateway/node-invoke-plugin-policy.test.ts
@@ -23,6 +23,16 @@ const DEMO_PLUGIN_ID = "demo";
 const DEMO_COMMAND = "demo.read";
 const DEMO_PARAMS = { path: "/tmp/x" };
 
+const hasApprovalTurnSourceRouteMock = vi.hoisted(() =>
+  vi.fn(
+    (params: { turnSourceChannel?: string | null; approvalKind?: "exec" | "plugin" }) =>
+      params.approvalKind === "plugin" && params.turnSourceChannel === "tui",
+  ),
+);
+
+vi.mock("../infra/approval-turn-source.js", () => ({
+  hasApprovalTurnSourceRoute: hasApprovalTurnSourceRouteMock,
+}));
 function createNodeSession(): NodeSession {
   return {
     nodeId: "node-1",
@@ -41,6 +51,7 @@ function createContext(opts?: {
   getApprovalClientConnIds?: GatewayRequestContext["getApprovalClientConnIds"];
   getRuntimeConfig?: GatewayRequestContext["getRuntimeConfig"];
   nodeSession?: NodeSession;
+  hasExecApprovalClients?: GatewayRequestContext["hasExecApprovalClients"];
 }) {
   const nodeSession = opts?.nodeSession ?? createNodeSession();
   const invoke = vi.fn(async () => ({
@@ -59,6 +70,7 @@ function createContext(opts?: {
       broadcastToConnIds: vi.fn(),
       pluginApprovalManager: opts?.pluginApprovalManager,
       getApprovalClientConnIds: opts?.getApprovalClientConnIds,
+      hasExecApprovalClients: opts?.hasExecApprovalClients,
     } as unknown as GatewayRequestContext,
     invoke,
   };
@@ -198,6 +210,7 @@ async function expectApprovalResolution(
 describe("applyPluginNodeInvokePolicy", () => {
   beforeEach(() => {
     resetPluginRuntimeStateForTest();
+    hasApprovalTurnSourceRouteMock.mockClear();
   });
 
   afterEach(() => {
@@ -367,6 +380,51 @@ describe("applyPluginNodeInvokePolicy", () => {
       visibleConnIds,
       { dropIfSlow: true },
     );
+
+    await expectApprovalResolution(resultPromise, manager, record);
+  });
+
+  it("keeps plugin policy approvals pending when only the originating turn source can approve", async () => {
+    const manager = new ExecApprovalManager<PluginApprovalRequestPayload>();
+    const getApprovalClientConnIds = vi.fn(() => new Set<string>());
+    setDangerousDemoCommandRegistry([createApprovalRequestPolicy()]);
+    const { context } = createContext({
+      pluginApprovalManager: manager,
+      getApprovalClientConnIds,
+      hasExecApprovalClients: vi.fn(() => false),
+    });
+    const resultPromise = applyPluginNodeInvokePolicy({
+      context,
+      client: createOperatorClient(),
+      nodeSession: createNodeSession(),
+      command: DEMO_COMMAND,
+      params: DEMO_PARAMS,
+      rawParams: {
+        ...DEMO_PARAMS,
+        turnSourceChannel: "tui",
+        turnSourceTo: "terminal",
+        turnSourceAccountId: "default",
+        turnSourceThreadId: 7,
+      },
+    });
+
+    const record = await expectSinglePendingApproval(manager);
+    expect(record.request.turnSourceChannel).toBe("tui");
+    expect(record.request.turnSourceTo).toBe("terminal");
+    expect(record.request.turnSourceAccountId).toBe("default");
+    expect(record.request.turnSourceThreadId).toBe(7);
+    expect(context.broadcast).not.toHaveBeenCalled();
+    expect(context.broadcastToConnIds).toHaveBeenCalledWith(
+      "plugin.approval.requested",
+      expect.objectContaining({ id: record.id }),
+      new Set<string>(),
+      { dropIfSlow: true },
+    );
+    expect(hasApprovalTurnSourceRouteMock).toHaveBeenCalledWith({
+      turnSourceChannel: "tui",
+      turnSourceAccountId: "default",
+      approvalKind: "plugin",
+    });
 
     await expectApprovalResolution(resultPromise, manager, record);
   });

--- a/src/gateway/node-invoke-plugin-policy.ts
+++ b/src/gateway/node-invoke-plugin-policy.ts
@@ -1,7 +1,6 @@
 // Plugin-provided node.invoke policy adapter.
 // Lets plugin policies gate dangerous node commands before transport dispatch.
 import { randomUUID } from "node:crypto";
-import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { PluginApprovalRequestPayload } from "../infra/plugin-approvals.js";
@@ -50,17 +49,23 @@ function normalizeRouteThreadId(value: unknown): string | number | null {
 }
 
 function resolveNodeInvokeTurnSourceFields(
-  rawParams: unknown,
+  turnSource:
+    | {
+        channel?: unknown;
+        to?: unknown;
+        accountId?: unknown;
+        threadId?: unknown;
+      }
+    | undefined,
 ): Pick<
   PluginApprovalRequestPayload,
   "turnSourceChannel" | "turnSourceTo" | "turnSourceAccountId" | "turnSourceThreadId"
 > {
-  const params = asNullableRecord(rawParams);
   return {
-    turnSourceChannel: normalizeOptionalString(params?.turnSourceChannel) ?? null,
-    turnSourceTo: normalizeOptionalString(params?.turnSourceTo) ?? null,
-    turnSourceAccountId: normalizeOptionalString(params?.turnSourceAccountId) ?? null,
-    turnSourceThreadId: normalizeRouteThreadId(params?.turnSourceThreadId),
+    turnSourceChannel: normalizeOptionalString(turnSource?.channel) ?? null,
+    turnSourceTo: normalizeOptionalString(turnSource?.to) ?? null,
+    turnSourceAccountId: normalizeOptionalString(turnSource?.accountId) ?? null,
+    turnSourceThreadId: normalizeRouteThreadId(turnSource?.threadId),
   };
 }
 
@@ -83,7 +88,7 @@ function createApprovalRuntime(params: {
   context: GatewayRequestContext;
   client: GatewayClient | null;
   pluginId: string;
-  rawParams: unknown;
+  turnSource: Parameters<typeof resolveNodeInvokeTurnSourceFields>[0];
 }): OpenClawPluginNodeInvokePolicyContext["approvals"] | undefined {
   const manager = params.context.pluginApprovalManager;
   if (!manager) {
@@ -92,7 +97,8 @@ function createApprovalRuntime(params: {
   return {
     async request(input) {
       const timeoutMs = resolvePluginApprovalTimeoutMs(input.timeoutMs);
-      const turnSource = resolveNodeInvokeTurnSourceFields(params.rawParams);
+      const turnSource = resolveNodeInvokeTurnSourceFields(params.turnSource);
+      const callerIdentity = params.client?.internal?.agentRuntimeIdentity;
       const request: PluginApprovalRequestPayload = {
         pluginId: params.pluginId,
         title: truncateUtf16Safe(input.title, 80),
@@ -100,8 +106,8 @@ function createApprovalRuntime(params: {
         severity: input.severity ?? "warning",
         toolName: normalizeOptionalString(input.toolName) ?? null,
         toolCallId: normalizeOptionalString(input.toolCallId) ?? null,
-        agentId: normalizeOptionalString(input.agentId) ?? null,
-        sessionKey: normalizeOptionalString(input.sessionKey) ?? null,
+        agentId: callerIdentity?.agentId ?? normalizeOptionalString(input.agentId) ?? null,
+        sessionKey: callerIdentity?.sessionKey ?? normalizeOptionalString(input.sessionKey) ?? null,
         turnSourceChannel: turnSource.turnSourceChannel,
         turnSourceTo: turnSource.turnSourceTo,
         turnSourceAccountId: turnSource.turnSourceAccountId,
@@ -131,7 +137,18 @@ function createApprovalRuntime(params: {
         requestEvent,
         twoPhase: false,
         approvalKind: "plugin",
-        deliverRequest: () => false,
+        deliverRequest: () => {
+          const forward = params.context.forwardPluginApprovalRequest;
+          if (!forward) {
+            return false;
+          }
+          return forward(requestEvent).catch((err: unknown) => {
+            params.context.logGateway?.error?.(
+              `plugin approvals: forward node policy request failed: ${String(err)}`,
+            );
+            return false;
+          });
+        },
       });
       return { id: record.id, decision: await decisionPromise };
     },
@@ -145,11 +162,20 @@ export async function applyPluginNodeInvokePolicy(params: {
   nodeSession: NodeSession;
   command: string;
   params: unknown;
-  rawParams?: unknown;
+  turnSource?: {
+    channel?: unknown;
+    to?: unknown;
+    accountId?: unknown;
+    threadId?: unknown;
+  };
   timeoutMs?: number;
   idempotencyKey?: string;
 }): Promise<OpenClawPluginNodeInvokePolicyResult | null> {
   const registry = getActivePluginGatewayNodePolicyRegistry();
+  // Route metadata is authority-bearing: only a signed agent-runtime caller may nominate it.
+  const trustedTurnSource = params.client?.internal?.agentRuntimeIdentity
+    ? params.turnSource
+    : undefined;
   const entry = registry?.nodeInvokePolicies?.find((candidate) =>
     candidate.policy.commands.includes(params.command),
   );
@@ -249,7 +275,7 @@ export async function applyPluginNodeInvokePolicy(params: {
       context: params.context,
       client: params.client,
       pluginId: entry.pluginId,
-      rawParams: params.rawParams ?? params.params,
+      turnSource: trustedTurnSource,
     }),
     invokeNode,
   });

--- a/src/gateway/node-invoke-plugin-policy.ts
+++ b/src/gateway/node-invoke-plugin-policy.ts
@@ -1,6 +1,7 @@
 // Plugin-provided node.invoke policy adapter.
 // Lets plugin policies gate dangerous node commands before transport dispatch.
 import { randomUUID } from "node:crypto";
+import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { PluginApprovalRequestPayload } from "../infra/plugin-approvals.js";
@@ -8,7 +9,6 @@ import { resolvePluginApprovalTimeoutMs } from "../infra/plugin-approvals.js";
 import type { PluginRegistry } from "../plugins/registry-types.js";
 import { getActivePluginGatewayNodePolicyRegistry } from "../plugins/runtime.js";
 import type {
-  OpenClawPluginNodeInvokeApprovalDecision,
   OpenClawPluginNodeInvokePolicyContext,
   OpenClawPluginNodeInvokePolicyResult,
   OpenClawPluginNodeInvokeTransportResult,
@@ -42,16 +42,6 @@ function parsePayload(payloadJSON: string | null | undefined, payload: unknown):
   }
 }
 
-function readObject(value: unknown): Record<string, unknown> | null {
-  return typeof value === "object" && value !== null && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : null;
-}
-
-function normalizeRouteString(value: unknown): string | null {
-  return normalizeOptionalString(value) ?? null;
-}
-
 function normalizeRouteThreadId(value: unknown): string | number | null {
   if (typeof value === "number" && Number.isFinite(value)) {
     return value;
@@ -65,29 +55,12 @@ function resolveNodeInvokeTurnSourceFields(
   PluginApprovalRequestPayload,
   "turnSourceChannel" | "turnSourceTo" | "turnSourceAccountId" | "turnSourceThreadId"
 > {
-  const params = readObject(rawParams);
+  const params = asNullableRecord(rawParams);
   return {
-    turnSourceChannel: normalizeRouteString(params?.turnSourceChannel),
-    turnSourceTo: normalizeRouteString(params?.turnSourceTo),
-    turnSourceAccountId: normalizeRouteString(params?.turnSourceAccountId),
+    turnSourceChannel: normalizeOptionalString(params?.turnSourceChannel) ?? null,
+    turnSourceTo: normalizeOptionalString(params?.turnSourceTo) ?? null,
+    turnSourceAccountId: normalizeOptionalString(params?.turnSourceAccountId) ?? null,
     turnSourceThreadId: normalizeRouteThreadId(params?.turnSourceThreadId),
-  };
-}
-
-function readApprovalResponse(
-  recordId: string,
-  response: { ok: boolean; payload?: unknown } | null,
-): { id: string; decision: OpenClawPluginNodeInvokeApprovalDecision | null } {
-  if (!response?.ok || !response.payload || typeof response.payload !== "object") {
-    return { id: recordId, decision: null };
-  }
-  const payload = response.payload as {
-    id?: unknown;
-    decision?: OpenClawPluginNodeInvokeApprovalDecision | null;
-  };
-  return {
-    id: normalizeOptionalString(payload.id) ?? recordId,
-    decision: payload.decision ?? null,
   };
 }
 
@@ -136,10 +109,7 @@ function createApprovalRuntime(params: {
       };
       const record = manager.create(request, timeoutMs, `plugin:${randomUUID()}`);
       bindApprovalRequesterMetadata({ record, client: params.client });
-      let response: { ok: boolean; payload?: unknown } | null = null;
-      const respond: RespondFn = (ok, payload) => {
-        response = { ok, payload };
-      };
+      const respond: RespondFn = () => {};
       const decisionPromise = registerPendingApprovalRecord({
         manager,
         record,
@@ -163,7 +133,7 @@ function createApprovalRuntime(params: {
         approvalKind: "plugin",
         deliverRequest: () => false,
       });
-      return readApprovalResponse(record.id, response);
+      return { id: record.id, decision: await decisionPromise };
     },
   };
 }

--- a/src/gateway/node-invoke-plugin-policy.ts
+++ b/src/gateway/node-invoke-plugin-policy.ts
@@ -8,14 +8,20 @@ import { resolvePluginApprovalTimeoutMs } from "../infra/plugin-approvals.js";
 import type { PluginRegistry } from "../plugins/registry-types.js";
 import { getActivePluginGatewayNodePolicyRegistry } from "../plugins/runtime.js";
 import type {
+  OpenClawPluginNodeInvokeApprovalDecision,
   OpenClawPluginNodeInvokePolicyContext,
   OpenClawPluginNodeInvokePolicyResult,
   OpenClawPluginNodeInvokeTransportResult,
 } from "../plugins/types.js";
 import { isNodeCommandAllowed, resolveNodeCommandAllowlist } from "./node-command-policy.js";
 import type { NodeSession } from "./node-registry.js";
-import { resolveApprovalRequestRecipientConnIds } from "./server-methods/approval-shared.js";
-import type { GatewayClient, GatewayRequestContext } from "./server-methods/types.js";
+import {
+  bindApprovalRequesterMetadata,
+  buildRequestedApprovalEvent,
+  handlePendingApprovalRequest,
+  registerPendingApprovalRecord,
+} from "./server-methods/approval-shared.js";
+import type { GatewayClient, GatewayRequestContext, RespondFn } from "./server-methods/types.js";
 
 // Plugin node.invoke policies are the last gateway-side guard before a
 // plugin-declared dangerous node command reaches the node transport.
@@ -34,6 +40,55 @@ function parsePayload(payloadJSON: string | null | undefined, payload: unknown):
   } catch {
     return payload;
   }
+}
+
+function readObject(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function normalizeRouteString(value: unknown): string | null {
+  return normalizeOptionalString(value) ?? null;
+}
+
+function normalizeRouteThreadId(value: unknown): string | number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  return normalizeOptionalString(value) ?? null;
+}
+
+function resolveNodeInvokeTurnSourceFields(
+  rawParams: unknown,
+): Pick<
+  PluginApprovalRequestPayload,
+  "turnSourceChannel" | "turnSourceTo" | "turnSourceAccountId" | "turnSourceThreadId"
+> {
+  const params = readObject(rawParams);
+  return {
+    turnSourceChannel: normalizeRouteString(params?.turnSourceChannel),
+    turnSourceTo: normalizeRouteString(params?.turnSourceTo),
+    turnSourceAccountId: normalizeRouteString(params?.turnSourceAccountId),
+    turnSourceThreadId: normalizeRouteThreadId(params?.turnSourceThreadId),
+  };
+}
+
+function readApprovalResponse(
+  recordId: string,
+  response: { ok: boolean; payload?: unknown } | null,
+): { id: string; decision: OpenClawPluginNodeInvokeApprovalDecision | null } {
+  if (!response?.ok || !response.payload || typeof response.payload !== "object") {
+    return { id: recordId, decision: null };
+  }
+  const payload = response.payload as {
+    id?: unknown;
+    decision?: OpenClawPluginNodeInvokeApprovalDecision | null;
+  };
+  return {
+    id: normalizeOptionalString(payload.id) ?? recordId,
+    decision: payload.decision ?? null,
+  };
 }
 
 // Dangerous commands must have an explicit policy. Without this check, a plugin
@@ -55,6 +110,7 @@ function createApprovalRuntime(params: {
   context: GatewayRequestContext;
   client: GatewayClient | null;
   pluginId: string;
+  rawParams: unknown;
 }): OpenClawPluginNodeInvokePolicyContext["approvals"] | undefined {
   const manager = params.context.pluginApprovalManager;
   if (!manager) {
@@ -63,6 +119,7 @@ function createApprovalRuntime(params: {
   return {
     async request(input) {
       const timeoutMs = resolvePluginApprovalTimeoutMs(input.timeoutMs);
+      const turnSource = resolveNodeInvokeTurnSourceFields(params.rawParams);
       const request: PluginApprovalRequestPayload = {
         pluginId: params.pluginId,
         title: truncateUtf16Safe(input.title, 80),
@@ -72,50 +129,41 @@ function createApprovalRuntime(params: {
         toolCallId: normalizeOptionalString(input.toolCallId) ?? null,
         agentId: normalizeOptionalString(input.agentId) ?? null,
         sessionKey: normalizeOptionalString(input.sessionKey) ?? null,
+        turnSourceChannel: turnSource.turnSourceChannel,
+        turnSourceTo: turnSource.turnSourceTo,
+        turnSourceAccountId: turnSource.turnSourceAccountId,
+        turnSourceThreadId: turnSource.turnSourceThreadId,
       };
       const record = manager.create(request, timeoutMs, `plugin:${randomUUID()}`);
-      record.requestedByConnId = params.client?.connId ?? null;
-      record.requestedByDeviceId = params.client?.connect?.device?.id ?? null;
-      record.requestedByClientId = params.client?.connect?.client?.id ?? null;
-      record.requestedByDeviceTokenAuth = params.client?.isDeviceTokenAuth === true;
-      const decisionPromise = manager.register(record, timeoutMs);
-      const requestEvent = {
-        id: record.id,
-        request: record.request,
-        createdAtMs: record.createdAtMs,
-        expiresAtMs: record.expiresAtMs,
+      bindApprovalRequesterMetadata({ record, client: params.client });
+      let response: { ok: boolean; payload?: unknown } | null = null;
+      const respond: RespondFn = (ok, payload) => {
+        response = { ok, payload };
       };
-      const approvalClientConnIds = resolveApprovalRequestRecipientConnIds({
-        context: params.context,
+      const decisionPromise = registerPendingApprovalRecord({
+        manager,
         record,
-        excludeConnId: params.client?.connId,
+        timeoutMs,
+        respond,
       });
-      // Approval requests are routed to eligible operator clients only. Falling
-      // back to broadcast is safe because the event payload carries no secret.
-      if (approvalClientConnIds) {
-        params.context.broadcastToConnIds(
-          "plugin.approval.requested",
-          requestEvent,
-          approvalClientConnIds,
-          {
-            dropIfSlow: true,
-          },
-        );
-      } else {
-        params.context.broadcast("plugin.approval.requested", requestEvent, {
-          dropIfSlow: true,
-        });
-      }
-      const hasApprovalClients =
-        approvalClientConnIds !== null
-          ? approvalClientConnIds.size > 0
-          : (params.context.hasExecApprovalClients?.(params.client?.connId) ?? false);
-      if (!hasApprovalClients) {
-        manager.expire(record.id, "no-approval-route");
+      if (!decisionPromise) {
         return { id: record.id, decision: null };
       }
-      const decision = await decisionPromise;
-      return { id: record.id, decision };
+      const requestEvent = buildRequestedApprovalEvent(record);
+      await handlePendingApprovalRequest({
+        manager,
+        record,
+        decisionPromise,
+        respond,
+        context: params.context,
+        clientConnId: params.client?.connId,
+        requestEventName: "plugin.approval.requested",
+        requestEvent,
+        twoPhase: false,
+        approvalKind: "plugin",
+        deliverRequest: () => false,
+      });
+      return readApprovalResponse(record.id, response);
     },
   };
 }
@@ -127,6 +175,7 @@ export async function applyPluginNodeInvokePolicy(params: {
   nodeSession: NodeSession;
   command: string;
   params: unknown;
+  rawParams?: unknown;
   timeoutMs?: number;
   idempotencyKey?: string;
 }): Promise<OpenClawPluginNodeInvokePolicyResult | null> {
@@ -230,6 +279,7 @@ export async function applyPluginNodeInvokePolicy(params: {
       context: params.context,
       client: params.client,
       pluginId: entry.pluginId,
+      rawParams: params.rawParams ?? params.params,
     }),
     invokeNode,
   });

--- a/src/gateway/server-aux-handlers.ts
+++ b/src/gateway/server-aux-handlers.ts
@@ -277,6 +277,7 @@ export function createGatewayAuxHandlers(params: {
 
   return {
     execApprovalManager,
+    forwardPluginApprovalRequest: execApprovalForwarder.handlePluginApprovalRequested,
     pluginApprovalManager,
     extraHandlers: {
       "exec.approval.get": createLazyHandler("exec.approval.get", loadExecApprovalHandlers),

--- a/src/gateway/server-methods/nodes.ts
+++ b/src/gateway/server-methods/nodes.ts
@@ -1404,6 +1404,7 @@ export const nodeHandlers: GatewayRequestHandlers = {
         nodeSession,
         command,
         params: forwardedParams.params,
+        rawParams: p.params,
         timeoutMs: p.timeoutMs,
         idempotencyKey: p.idempotencyKey,
       });

--- a/src/gateway/server-methods/nodes.ts
+++ b/src/gateway/server-methods/nodes.ts
@@ -1225,6 +1225,10 @@ export const nodeHandlers: GatewayRequestHandlers = {
       params?: unknown;
       timeoutMs?: number;
       idempotencyKey: string;
+      turnSourceChannel?: string;
+      turnSourceTo?: string;
+      turnSourceAccountId?: string;
+      turnSourceThreadId?: string | number;
     };
     const nodeId = normalizeOptionalString(p.nodeId) ?? "";
     const command = normalizeOptionalString(p.command) ?? "";
@@ -1404,7 +1408,12 @@ export const nodeHandlers: GatewayRequestHandlers = {
         nodeSession,
         command,
         params: forwardedParams.params,
-        rawParams: p.params,
+        turnSource: {
+          channel: p.turnSourceChannel,
+          to: p.turnSourceTo,
+          accountId: p.turnSourceAccountId,
+          threadId: p.turnSourceThreadId,
+        },
         timeoutMs: p.timeoutMs,
         idempotencyKey: p.idempotencyKey,
       });

--- a/src/gateway/server-methods/shared-types.ts
+++ b/src/gateway/server-methods/shared-types.ts
@@ -9,7 +9,10 @@ import type { ModelCatalogEntry } from "../../agents/model-catalog.types.js";
 import type { CliDeps } from "../../cli/deps.types.js";
 import type { HealthSummary } from "../../commands/health.types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import type { PluginApprovalRequestPayload } from "../../infra/plugin-approvals.js";
+import type {
+  PluginApprovalRequest,
+  PluginApprovalRequestPayload,
+} from "../../infra/plugin-approvals.js";
 import type { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { WizardSession } from "../../wizard/session.js";
 import type { AgentRuntimeIdentity } from "../agent-runtime-identity-token.js";
@@ -76,6 +79,7 @@ export type GatewayRequestContext = {
   isTerminalEnabled: () => boolean;
   execApprovalManager?: ExecApprovalManager;
   pluginApprovalManager?: ExecApprovalManager<PluginApprovalRequestPayload>;
+  forwardPluginApprovalRequest?: (request: PluginApprovalRequest) => Promise<boolean>;
   loadGatewayModelCatalog: (params?: { readOnly?: boolean }) => Promise<ModelCatalogEntry[]>;
   getHealthCache: () => HealthSummary | null;
   refreshHealthSnapshot: (opts?: {

--- a/src/gateway/server-request-context.ts
+++ b/src/gateway/server-request-context.ts
@@ -19,6 +19,7 @@ export type GatewayRequestContextParams = {
   resolveTerminalLaunchPolicy: GatewayRequestContext["resolveTerminalLaunchPolicy"];
   isTerminalEnabled: GatewayRequestContext["isTerminalEnabled"];
   execApprovalManager: GatewayRequestContext["execApprovalManager"];
+  forwardPluginApprovalRequest?: GatewayRequestContext["forwardPluginApprovalRequest"];
   pluginApprovalManager: GatewayRequestContext["pluginApprovalManager"];
   loadGatewayModelCatalog: GatewayRequestContext["loadGatewayModelCatalog"];
   getHealthCache: GatewayRequestContext["getHealthCache"];
@@ -103,6 +104,7 @@ export function createGatewayRequestContext(
     resolveTerminalLaunchPolicy: params.resolveTerminalLaunchPolicy,
     isTerminalEnabled: params.isTerminalEnabled,
     execApprovalManager: params.execApprovalManager,
+    forwardPluginApprovalRequest: params.forwardPluginApprovalRequest,
     pluginApprovalManager: params.pluginApprovalManager,
     loadGatewayModelCatalog: params.loadGatewayModelCatalog,
     getHealthCache: params.getHealthCache,

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -1306,25 +1306,30 @@ export async function startGatewayServer(
     );
     Object.assign(runtimeState, runtimeServices);
 
-    const { execApprovalManager, pluginApprovalManager, extraHandlers, coreGatewayHandlers } =
-      await startupTrace.measure("gateway.handlers", async () => {
-        const [{ createGatewayAuxHandlers }, { coreGatewayHandlers: coreGatewayHandlersLocal }] =
-          await Promise.all([import("./server-aux-handlers.js"), import("./server-methods.js")]);
-        return {
-          ...createGatewayAuxHandlers({
-            log,
-            activateRuntimeSecrets,
-            sharedGatewaySessionGenerationState,
-            resolveSharedGatewaySessionGenerationForConfig,
-            clients,
-            startChannel,
-            stopChannel,
-            getChannelAutostartSuppression: channelManager.getAutostartSuppression,
-            logChannels,
-          }),
-          coreGatewayHandlers: coreGatewayHandlersLocal,
-        };
-      });
+    const {
+      execApprovalManager,
+      forwardPluginApprovalRequest,
+      pluginApprovalManager,
+      extraHandlers,
+      coreGatewayHandlers,
+    } = await startupTrace.measure("gateway.handlers", async () => {
+      const [{ createGatewayAuxHandlers }, { coreGatewayHandlers: coreGatewayHandlersLocal }] =
+        await Promise.all([import("./server-aux-handlers.js"), import("./server-methods.js")]);
+      return {
+        ...createGatewayAuxHandlers({
+          log,
+          activateRuntimeSecrets,
+          sharedGatewaySessionGenerationState,
+          resolveSharedGatewaySessionGenerationForConfig,
+          clients,
+          startChannel,
+          stopChannel,
+          getChannelAutostartSuppression: channelManager.getAutostartSuppression,
+          logChannels,
+        }),
+        coreGatewayHandlers: coreGatewayHandlersLocal,
+      };
+    });
     const attachedGatewayExtraHandlers: GatewayRequestHandlers = {
       ...pluginRegistry.gatewayHandlers,
       ...extraHandlers,
@@ -1559,6 +1564,7 @@ export async function startGatewayServer(
           resolveTerminalLaunchPolicy: terminalLaunchPolicy.resolve,
           isTerminalEnabled: terminalLaunchPolicy.isEnabled,
           execApprovalManager,
+          forwardPluginApprovalRequest,
           pluginApprovalManager,
           loadGatewayModelCatalog,
           getHealthCache,


### PR DESCRIPTION
﻿Fixes #98560.

## Summary
- copy turn-source fields from raw `node.invoke` params into plugin policy approval records
- route plugin node policy approvals through the shared pending approval helper with `approvalKind: "plugin"`
- keep approvals pending for routable chat/TUI origins even when no live approval client is connected

## Tests
- `node scripts/run-with-env.mjs OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 OPENCLAW_GATEWAY_PROJECT_SHARDS=0 -- node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/node-invoke-plugin-policy.test.ts --testTimeout=10000 --reporter=verbose`
- `git diff --check`
- Attempted: `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.src.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-src.tsbuildinfo` timed out after 240s on this Windows/OneDrive checkout; lingering tsgo processes were stopped.
