### PR TITLE
fix: route iOS OpenAI realtime Talk through WebRTC

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -11347,7 +11347,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2864,
+      "line": 2866,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Native",
       "surface": "apple",
@@ -11355,7 +11355,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2864,
+      "line": 2866,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Native WebRTC",
       "surface": "apple",
@@ -11363,7 +11363,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3183,
+      "line": 3174,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Offline",
       "surface": "apple",
@@ -11371,7 +11371,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3183,
+      "line": 3174,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Ready",
       "surface": "apple",
@@ -11475,7 +11475,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 484,
+      "line": 503,
       "path": "apps/ios/Sources/Voice/TalkRealtimeWebRTCSession.swift",
       "source": "Asking OpenClaw",
       "surface": "apple",
@@ -11483,7 +11483,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 484,
+      "line": 503,
       "path": "apps/ios/Sources/Voice/TalkRealtimeWebRTCSession.swift",
       "source": "Updating OpenClaw",
       "surface": "apple",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -11291,7 +11291,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 209,
+      "line": 210,
       "path": "apps/ios/Sources/Voice/TalkModeGatewayConfig.swift",
       "source": "Gateway Default",
       "surface": "apple",
@@ -11299,7 +11299,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 211,
+      "line": 212,
       "path": "apps/ios/Sources/Voice/TalkModeGatewayConfig.swift",
       "source": "ElevenLabs",
       "surface": "apple",
@@ -11307,7 +11307,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 213,
+      "line": 214,
       "path": "apps/ios/Sources/Voice/TalkModeGatewayConfig.swift",
       "source": "Realtime-2 (OpenAI)",
       "surface": "apple",
@@ -11315,7 +11315,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 825,
+      "line": 830,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Listening",
       "surface": "apple",
@@ -11323,7 +11323,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 825,
+      "line": 830,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Speech error: \\(msg)",
       "surface": "apple",
@@ -11331,7 +11331,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1026,
+      "line": 1031,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Aborted",
       "surface": "apple",
@@ -11339,7 +11339,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1026,
+      "line": 1031,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Chat error",
       "surface": "apple",
@@ -11347,7 +11347,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2853,
+      "line": 2864,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Native",
       "surface": "apple",
@@ -11355,7 +11355,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2853,
+      "line": 2864,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Native WebRTC",
       "surface": "apple",
@@ -11363,7 +11363,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3172,
+      "line": 3183,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Offline",
       "surface": "apple",
@@ -11371,7 +11371,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3172,
+      "line": 3183,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Ready",
       "surface": "apple",
@@ -11475,7 +11475,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 479,
+      "line": 484,
       "path": "apps/ios/Sources/Voice/TalkRealtimeWebRTCSession.swift",
       "source": "Asking OpenClaw",
       "surface": "apple",
@@ -11483,7 +11483,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 479,
+      "line": 484,
       "path": "apps/ios/Sources/Voice/TalkRealtimeWebRTCSession.swift",
       "source": "Updating OpenClaw",
       "surface": "apple",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -11475,7 +11475,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 503,
+      "line": 508,
       "path": "apps/ios/Sources/Voice/TalkRealtimeWebRTCSession.swift",
       "source": "Asking OpenClaw",
       "surface": "apple",
@@ -11483,7 +11483,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 503,
+      "line": 508,
       "path": "apps/ios/Sources/Voice/TalkRealtimeWebRTCSession.swift",
       "source": "Updating OpenClaw",
       "surface": "apple",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -11315,55 +11315,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 830,
-      "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
-      "source": "Listening",
-      "surface": "apple",
-      "id": "native.apple.794c5c98f3a4238d"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 830,
-      "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
-      "source": "Speech error: \\(msg)",
-      "surface": "apple",
-      "id": "native.apple.0b35fc3b0b221098"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 1031,
-      "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
-      "source": "Aborted",
-      "surface": "apple",
-      "id": "native.apple.96c7457cafa7dd47"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 1031,
-      "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
-      "source": "Chat error",
-      "surface": "apple",
-      "id": "native.apple.7c027ae095940485"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 2866,
-      "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
-      "source": "Native",
-      "surface": "apple",
-      "id": "native.apple.c48dc51b49089432"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 2866,
-      "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
-      "source": "Native WebRTC",
-      "surface": "apple",
-      "id": "native.apple.b0eb8a8cad908166"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 3174,
+      "line": 284,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Offline",
       "surface": "apple",
@@ -11371,11 +11323,59 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3174,
+      "line": 284,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Ready",
       "surface": "apple",
       "id": "native.apple.5839cdb826c12c71"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 957,
+      "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
+      "source": "Listening",
+      "surface": "apple",
+      "id": "native.apple.794c5c98f3a4238d"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 957,
+      "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
+      "source": "Speech error: \\(msg)",
+      "surface": "apple",
+      "id": "native.apple.0b35fc3b0b221098"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 1158,
+      "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
+      "source": "Aborted",
+      "surface": "apple",
+      "id": "native.apple.96c7457cafa7dd47"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 1158,
+      "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
+      "source": "Chat error",
+      "surface": "apple",
+      "id": "native.apple.7c027ae095940485"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 2988,
+      "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
+      "source": "Native",
+      "surface": "apple",
+      "id": "native.apple.c48dc51b49089432"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 2988,
+      "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
+      "source": "Native WebRTC",
+      "surface": "apple",
+      "id": "native.apple.b0eb8a8cad908166"
     },
     {
       "kind": "ui-call",

--- a/apps/ios/Sources/Voice/TalkDefaults.swift
+++ b/apps/ios/Sources/Voice/TalkDefaults.swift
@@ -15,6 +15,14 @@ enum TalkDefaults {
 }
 
 enum TalkAudioRoute {
+    static func categoryOptions(speakerphoneEnabled: Bool) -> AVAudioSession.CategoryOptions {
+        var options: AVAudioSession.CategoryOptions = [.allowBluetoothHFP, .allowBluetoothA2DP, .allowAirPlay]
+        if speakerphoneEnabled {
+            options.insert(.defaultToSpeaker)
+        }
+        return options
+    }
+
     static func shouldForceSpeaker(
         preferenceEnabled: Bool,
         outputPortTypes: [AVAudioSession.Port]) -> Bool

--- a/apps/ios/Sources/Voice/TalkDefaults.swift
+++ b/apps/ios/Sources/Voice/TalkDefaults.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import Foundation
 
 enum TalkDefaults {
@@ -10,5 +11,16 @@ enum TalkDefaults {
             return self.speakerphoneEnabledByDefault
         }
         return defaults.bool(forKey: self.speakerphoneEnabledKey)
+    }
+}
+
+enum TalkAudioRoute {
+    static func shouldForceSpeaker(
+        preferenceEnabled: Bool,
+        outputPortTypes: [AVAudioSession.Port]) -> Bool
+    {
+        guard preferenceEnabled else { return false }
+        guard !outputPortTypes.isEmpty else { return false }
+        return outputPortTypes.allSatisfy { $0 == .builtInReceiver || $0 == .builtInSpeaker }
     }
 }

--- a/apps/ios/Sources/Voice/TalkModeGatewayConfig.swift
+++ b/apps/ios/Sources/Voice/TalkModeGatewayConfig.swift
@@ -284,7 +284,7 @@ enum TalkModeRoutingResolver {
             realtimeModelId = defaultRealtimeModelId
             // Provider selection can replace provider details, but an explicit Gateway-owned
             // realtime route must remain on the Gateway (for example, Azure-backed OpenAI).
-            route = parsed.usesExplicitGatewayRealtimeTransport ? .realtimeRelay : .realtimeWebRTC
+            route = parsed.requiresGatewayRealtimeTransport ? .realtimeRelay : .realtimeWebRTC
         }
 
         return TalkModeResolvedRouting(
@@ -342,7 +342,7 @@ struct TalkModeGatewayConfigState {
     let normalizedPayload: Bool
     let missingResolvedPayload: Bool
     let executionMode: TalkModeExecutionMode
-    let usesExplicitGatewayRealtimeTransport: Bool
+    let requiresGatewayRealtimeTransport: Bool
     let defaultVoiceId: String?
     let voiceAliases: [String: String]
     let configuredModelId: String?
@@ -403,7 +403,12 @@ enum TalkModeGatewayConfigParser {
         let realtimeVoiceId = Self.firstString(realtime, keys: ["voice"])
             ?? Self.firstString(realtimeProviderConfig, keys: ["voice"])
         let realtimeTransport = Self.firstString(realtime, keys: ["transport"])?.lowercased()
-        let executionMode = Self.resolvedExecutionMode(realtime)
+        let requiresGatewayRealtimeTransport = realtimeTransport == "gateway-relay"
+            || realtimeTransport == "provider-websocket"
+            || Self.usesAzureOpenAI(provider: realtimeProvider, config: realtimeProviderConfig)
+        let executionMode = Self.resolvedExecutionMode(
+            realtime,
+            requiresGatewayRealtimeTransport: requiresGatewayRealtimeTransport)
         let rawConfigApiKey = activeConfig?["apiKey"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines)
         let interruptOnSpeech = talk?["interruptOnSpeech"]?.boolValue
         let silenceTimeoutMs = TalkConfigParsing.resolvedSilenceTimeoutMs(
@@ -416,8 +421,7 @@ enum TalkModeGatewayConfigParser {
             normalizedPayload: selection?.normalizedPayload == true,
             missingResolvedPayload: talk != nil && selection == nil,
             executionMode: executionMode,
-            usesExplicitGatewayRealtimeTransport: realtimeTransport == "gateway-relay"
-                || realtimeTransport == "provider-websocket",
+            requiresGatewayRealtimeTransport: requiresGatewayRealtimeTransport,
             defaultVoiceId: defaultVoiceId,
             voiceAliases: voiceAliases,
             configuredModelId: model,
@@ -443,7 +447,10 @@ enum TalkModeGatewayConfigParser {
         return nil
     }
 
-    private static func resolvedExecutionMode(_ realtime: [String: AnyCodable]?) -> TalkModeExecutionMode {
+    private static func resolvedExecutionMode(
+        _ realtime: [String: AnyCodable]?,
+        requiresGatewayRealtimeTransport: Bool) -> TalkModeExecutionMode
+    {
         guard let realtime else { return .native }
         let mode = Self.firstString(realtime, keys: ["mode"])?.lowercased()
         let transport = Self.firstString(realtime, keys: ["transport"])?.lowercased()
@@ -455,6 +462,9 @@ enum TalkModeGatewayConfigParser {
         }
         if brain != nil, brain != "agent-consult" {
             return .native
+        }
+        if requiresGatewayRealtimeTransport {
+            return .realtimeRelay
         }
         switch transport {
         case "managed-room":
@@ -475,6 +485,14 @@ enum TalkModeGatewayConfigParser {
             return .realtimeRelay
         }
         return .realtimeWebRTC
+    }
+
+    private static func usesAzureOpenAI(
+        provider: String?,
+        config: [String: AnyCodable]?) -> Bool
+    {
+        guard provider?.caseInsensitiveCompare("openai") == .orderedSame else { return false }
+        return self.firstString(config, keys: ["azureEndpoint", "azureDeployment"]) != nil
     }
 
     private static func singleRealtimeProviderId(_ providers: [String: AnyCodable]?) -> String? {

--- a/apps/ios/Sources/Voice/TalkModeGatewayConfig.swift
+++ b/apps/ios/Sources/Voice/TalkModeGatewayConfig.swift
@@ -282,7 +282,9 @@ enum TalkModeRoutingResolver {
             activeProvider = "openai"
             realtimeProvider = "openai"
             realtimeModelId = defaultRealtimeModelId
-            route = .realtimeWebRTC
+            // Provider selection can replace provider details, but an explicit Gateway-owned
+            // realtime route must remain on the Gateway (for example, Azure-backed OpenAI).
+            route = parsed.usesExplicitGatewayRealtimeTransport ? .realtimeRelay : .realtimeWebRTC
         }
 
         return TalkModeResolvedRouting(
@@ -340,6 +342,7 @@ struct TalkModeGatewayConfigState {
     let normalizedPayload: Bool
     let missingResolvedPayload: Bool
     let executionMode: TalkModeExecutionMode
+    let usesExplicitGatewayRealtimeTransport: Bool
     let defaultVoiceId: String?
     let voiceAliases: [String: String]
     let configuredModelId: String?
@@ -399,6 +402,7 @@ enum TalkModeGatewayConfigParser {
         let realtimeModelId = realtimeModel ?? defaultRealtimeModelIdFallback
         let realtimeVoiceId = Self.firstString(realtime, keys: ["voice"])
             ?? Self.firstString(realtimeProviderConfig, keys: ["voice"])
+        let realtimeTransport = Self.firstString(realtime, keys: ["transport"])?.lowercased()
         let executionMode = Self.resolvedExecutionMode(realtime)
         let rawConfigApiKey = activeConfig?["apiKey"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines)
         let interruptOnSpeech = talk?["interruptOnSpeech"]?.boolValue
@@ -412,6 +416,8 @@ enum TalkModeGatewayConfigParser {
             normalizedPayload: selection?.normalizedPayload == true,
             missingResolvedPayload: talk != nil && selection == nil,
             executionMode: executionMode,
+            usesExplicitGatewayRealtimeTransport: realtimeTransport == "gateway-relay"
+                || realtimeTransport == "provider-websocket",
             defaultVoiceId: defaultVoiceId,
             voiceAliases: voiceAliases,
             configuredModelId: model,

--- a/apps/ios/Sources/Voice/TalkModeGatewayConfig.swift
+++ b/apps/ios/Sources/Voice/TalkModeGatewayConfig.swift
@@ -3,6 +3,7 @@ import OpenClawKit
 
 enum TalkModeExecutionMode: Equatable {
     case native
+    case realtimeWebRTC
     case realtimeRelay
 }
 
@@ -224,10 +225,11 @@ enum TalkModeProviderSelection: String, CaseIterable, Identifiable {
 enum TalkModeRuntimeRoute: Equatable {
     case localElevenLabs
     case gatewayTalkSpeak
+    case realtimeWebRTC
     case realtimeRelay
 
     var usesRealtime: Bool {
-        self == .realtimeRelay
+        self == .realtimeRelay || self == .realtimeWebRTC
     }
 
     var usesGatewayTalkSpeak: Bool {
@@ -263,7 +265,9 @@ enum TalkModeRoutingResolver {
         case .gatewayDefault:
             // Only an explicit realtime config selects the realtime transport. Other Gateway
             // speech providers stay native and synthesize through talk.speak.
-            if parsed.executionMode == .realtimeRelay {
+            if parsed.executionMode == .realtimeWebRTC {
+                route = .realtimeWebRTC
+            } else if parsed.executionMode == .realtimeRelay {
                 route = .realtimeRelay
             } else if Self.normalized(activeProvider) == Self.normalized(defaultProvider) {
                 // Preserve the shipped local ElevenLabs path, including its streaming playback.
@@ -276,17 +280,28 @@ enum TalkModeRoutingResolver {
             route = .localElevenLabs
         case .openAIRealtime:
             activeProvider = "openai"
-            realtimeProvider = realtimeProvider ?? "openai"
-            realtimeModelId = realtimeModelId ?? defaultRealtimeModelId
-            route = .realtimeRelay
+            realtimeProvider = "openai"
+            realtimeModelId = defaultRealtimeModelId
+            route = .realtimeWebRTC
         }
 
         return TalkModeResolvedRouting(
             activeProvider: activeProvider,
-            executionMode: route.usesRealtime ? .realtimeRelay : .native,
+            executionMode: Self.executionMode(for: route),
             realtimeProvider: realtimeProvider,
             realtimeModelId: realtimeModelId,
             route: route)
+    }
+
+    private static func executionMode(for route: TalkModeRuntimeRoute) -> TalkModeExecutionMode {
+        switch route {
+        case .localElevenLabs, .gatewayTalkSpeak:
+            .native
+        case .realtimeWebRTC:
+            .realtimeWebRTC
+        case .realtimeRelay:
+            .realtimeRelay
+        }
     }
 
     private static func normalized(_ value: String) -> String {
@@ -426,17 +441,34 @@ enum TalkModeGatewayConfigParser {
         guard let realtime else { return .native }
         let mode = Self.firstString(realtime, keys: ["mode"])?.lowercased()
         let transport = Self.firstString(realtime, keys: ["transport"])?.lowercased()
+        let provider = Self.firstString(realtime, keys: ["provider"])?.lowercased()
+            ?? Self.singleRealtimeProviderId(realtime["providers"]?.dictionaryValue)?.lowercased()
         let brain = Self.firstString(realtime, keys: ["brain"])?.lowercased()
         guard mode == "realtime" else {
-            return .native
-        }
-        if transport == "managed-room" {
             return .native
         }
         if brain != nil, brain != "agent-consult" {
             return .native
         }
-        return .realtimeRelay
+        switch transport {
+        case "managed-room":
+            return .native
+        case "gateway-relay":
+            return .realtimeRelay
+        case "provider-websocket":
+            return .realtimeRelay
+        case "webrtc":
+            if provider != "openai" {
+                return .realtimeRelay
+            }
+        case nil:
+            if provider != "openai" {
+                return .realtimeRelay
+            }
+        default:
+            return .realtimeRelay
+        }
+        return .realtimeWebRTC
     }
 
     private static func singleRealtimeProviderId(_ providers: [String: AnyCodable]?) -> String? {

--- a/apps/ios/Sources/Voice/TalkModeGatewayConfig.swift
+++ b/apps/ios/Sources/Voice/TalkModeGatewayConfig.swift
@@ -284,7 +284,7 @@ enum TalkModeRoutingResolver {
             realtimeModelId = defaultRealtimeModelId
             // Provider selection can replace provider details, but an explicit Gateway-owned
             // realtime route must remain on the Gateway (for example, Azure-backed OpenAI).
-            route = parsed.requiresGatewayRealtimeTransport ? .realtimeRelay : .realtimeWebRTC
+            route = parsed.openAIRequiresGatewayRealtimeTransport ? .realtimeRelay : .realtimeWebRTC
         }
 
         return TalkModeResolvedRouting(
@@ -343,6 +343,7 @@ struct TalkModeGatewayConfigState {
     let missingResolvedPayload: Bool
     let executionMode: TalkModeExecutionMode
     let requiresGatewayRealtimeTransport: Bool
+    let openAIRequiresGatewayRealtimeTransport: Bool
     let defaultVoiceId: String?
     let voiceAliases: [String: String]
     let configuredModelId: String?
@@ -406,6 +407,12 @@ enum TalkModeGatewayConfigParser {
         let requiresGatewayRealtimeTransport = realtimeTransport == "gateway-relay"
             || realtimeTransport == "provider-websocket"
             || Self.usesAzureOpenAI(provider: realtimeProvider, config: realtimeProviderConfig)
+        let openAIProviderConfig = Self.realtimeProviderConfig(
+            providers: realtimeProviders,
+            provider: "openai")
+        let openAIRequiresGatewayRealtimeTransport = realtimeTransport == "gateway-relay"
+            || realtimeTransport == "provider-websocket"
+            || Self.usesAzureOpenAI(provider: "openai", config: openAIProviderConfig)
         let executionMode = Self.resolvedExecutionMode(
             realtime,
             requiresGatewayRealtimeTransport: requiresGatewayRealtimeTransport)
@@ -422,6 +429,7 @@ enum TalkModeGatewayConfigParser {
             missingResolvedPayload: talk != nil && selection == nil,
             executionMode: executionMode,
             requiresGatewayRealtimeTransport: requiresGatewayRealtimeTransport,
+            openAIRequiresGatewayRealtimeTransport: openAIRequiresGatewayRealtimeTransport,
             defaultVoiceId: defaultVoiceId,
             voiceAliases: voiceAliases,
             configuredModelId: model,
@@ -507,7 +515,13 @@ enum TalkModeGatewayConfigParser {
     {
         guard let providers else { return nil }
         if let provider {
-            return providers[provider]?.dictionaryValue
+            if let exact = providers[provider]?.dictionaryValue {
+                return exact
+            }
+            return providers.first { key, _ in
+                key.trimmingCharacters(in: .whitespacesAndNewlines)
+                    .caseInsensitiveCompare(provider) == .orderedSame
+            }?.value.dictionaryValue
         }
         if providers.count == 1 {
             return providers.values.first?.dictionaryValue

--- a/apps/ios/Sources/Voice/TalkModeManager.swift
+++ b/apps/ios/Sources/Voice/TalkModeManager.swift
@@ -2772,7 +2772,9 @@ extension TalkModeManager {
             defaultRealtimeModelId: Self.defaultRealtimeModelIdFallback)
         let realtimeVoiceOverride = TalkModeRealtimeVoiceSelection.resolvedOverride(
             UserDefaults.standard.string(forKey: TalkModeRealtimeVoiceSelection.storageKey))
-        let parsedRealtimeVoiceId = providerSelection == .openAIRealtime && parsed.realtimeProvider != "openai"
+        let parsedRealtimeProviderIsOpenAI =
+            parsed.realtimeProvider?.caseInsensitiveCompare("openai") == .orderedSame
+        let parsedRealtimeVoiceId = providerSelection == .openAIRealtime && !parsedRealtimeProviderIsOpenAI
             ? nil
             : parsed.realtimeVoiceId
         let realtimeVoiceId = realtimeVoiceOverride ?? parsedRealtimeVoiceId

--- a/apps/ios/Sources/Voice/TalkModeManager.swift
+++ b/apps/ios/Sources/Voice/TalkModeManager.swift
@@ -2994,10 +2994,7 @@ extension TalkModeManager {
     static func configureAudioSession() throws {
         let session = AVAudioSession.sharedInstance()
         let forceSpeaker = TalkDefaults.speakerphoneEnabled()
-        var options: AVAudioSession.CategoryOptions = [.allowBluetoothHFP]
-        if forceSpeaker {
-            options.insert(.defaultToSpeaker)
-        }
+        let options = TalkAudioRoute.categoryOptions(speakerphoneEnabled: forceSpeaker)
         // Prefer `.spokenAudio` for STT; it tends to preserve speech energy better than `.voiceChat`.
         try session.setCategory(.playAndRecord, mode: .spokenAudio, options: options)
         try? session.setPreferredSampleRate(48000)
@@ -3017,10 +3014,7 @@ extension TalkModeManager {
     static func configureRealtimeAudioSession() throws {
         let session = AVAudioSession.sharedInstance()
         let forceSpeaker = TalkDefaults.speakerphoneEnabled()
-        var options: AVAudioSession.CategoryOptions = [.allowBluetoothHFP]
-        if forceSpeaker {
-            options.insert(.defaultToSpeaker)
-        }
+        let options = TalkAudioRoute.categoryOptions(speakerphoneEnabled: forceSpeaker)
         // Realtime Talk is full duplex. `.voiceChat` enables iOS voice processing so speaker
         // output is less likely to be captured as fresh microphone input.
         try session.setCategory(.playAndRecord, mode: .voiceChat, options: options)

--- a/apps/ios/Sources/Voice/TalkModeManager.swift
+++ b/apps/ios/Sources/Voice/TalkModeManager.swift
@@ -3003,7 +3003,10 @@ extension TalkModeManager {
         try? session.setPreferredSampleRate(48000)
         try? session.setPreferredIOBufferDuration(0.02)
         try session.setActive(true, options: [])
-        if forceSpeaker, !Self.hasExternalAudioOutput(session.currentRoute) {
+        if TalkAudioRoute.shouldForceSpeaker(
+            preferenceEnabled: forceSpeaker,
+            outputPortTypes: session.currentRoute.outputs.map(\.portType))
+        {
             try? session.overrideOutputAudioPort(.speaker)
         } else {
             try? session.overrideOutputAudioPort(.none)
@@ -3024,7 +3027,10 @@ extension TalkModeManager {
         try? session.setPreferredSampleRate(48000)
         try? session.setPreferredIOBufferDuration(0.02)
         try session.setActive(true, options: [])
-        if forceSpeaker, !Self.hasExternalAudioOutput(session.currentRoute) {
+        if TalkAudioRoute.shouldForceSpeaker(
+            preferenceEnabled: forceSpeaker,
+            outputPortTypes: session.currentRoute.outputs.map(\.portType))
+        {
             try? session.overrideOutputAudioPort(.speaker)
         } else {
             try? session.overrideOutputAudioPort(.none)
@@ -3047,17 +3053,6 @@ extension TalkModeManager {
         return "category=\(session.category.rawValue) mode=\(session.mode.rawValue) "
             + "opts=\(session.categoryOptions.rawValue) inputAvail=\(session.isInputAvailable) "
             + "routeIn=[\(inputs)] routeOut=[\(outputs)] availIn=[\(available)]"
-    }
-
-    private static func hasExternalAudioOutput(_ route: AVAudioSessionRouteDescription) -> Bool {
-        route.outputs.contains(where: { output in
-            switch output.portType {
-            case .airPlay, .bluetoothA2DP, .bluetoothHFP, .bluetoothLE, .carAudio, .headphones, .usbAudio:
-                true
-            default:
-                false
-            }
-        })
     }
 }
 

--- a/apps/ios/Sources/Voice/TalkModeManager.swift
+++ b/apps/ios/Sources/Voice/TalkModeManager.swift
@@ -283,7 +283,9 @@ final class TalkModeManager: NSObject {
     func applyAudioRoutePreferenceChanged() {
         guard self.isEnabled || self.isListening || self.isSpeaking else { return }
         do {
-            if self.realtimeRelaySession != nil {
+            if let realtimeSession {
+                try realtimeSession.applyAudioRoutePreferenceChanged()
+            } else if self.realtimeRelaySession != nil {
                 try Self.configureRealtimeAudioSession()
             } else {
                 try Self.configureAudioSession()
@@ -402,20 +404,23 @@ final class TalkModeManager: NSObject {
             UserDefaults.standard.string(forKey: TalkModeProviderSelection.storageKey))
     }
 
-    private var shouldForceRealtimeRelayFromSelection: Bool {
+    private var shouldUseOpenAIRealtimeSelectionFallback: Bool {
         self.talkProviderSelection == .openAIRealtime
     }
 
     private func applyOpenAIRealtimeSelectionDefaults() {
+        let realtimeVoiceOverride = TalkModeRealtimeVoiceSelection.resolvedOverride(
+            UserDefaults.standard.string(forKey: TalkModeRealtimeVoiceSelection.storageKey))
         self.activeTalkProvider = "openai"
-        self.executionMode = .realtimeRelay
-        self.runtimeRoute = .realtimeRelay
-        self.realtimeProvider = self.realtimeProvider ?? "openai"
-        self.realtimeModelId = self.realtimeModelId ?? Self.defaultRealtimeModelIdFallback
+        self.executionMode = .realtimeWebRTC
+        self.runtimeRoute = .realtimeWebRTC
+        self.realtimeProvider = "openai"
+        self.realtimeModelId = Self.defaultRealtimeModelIdFallback
+        self.realtimeVoiceId = realtimeVoiceOverride
         self.gatewayTalkProviderLabel = TalkModeProviderSelection.openAIRealtime.label
         self.gatewayTalkUsesRealtime = true
-        self.gatewayTalkUsesRealtimeRelay = true
-        self.gatewayTalkTransportLabel = "Gateway Relay"
+        self.gatewayTalkUsesRealtimeRelay = false
+        self.gatewayTalkTransportLabel = "Native WebRTC"
         self.gatewayTalkRealtimeProviderLabel = Self.displayName(forProvider: self.realtimeProvider ?? "openai")
         self.gatewayTalkRealtimeModelId = self.realtimeModelId
         self.gatewayTalkRealtimeVoiceId = self.realtimeVoiceId
@@ -1025,7 +1030,10 @@ final class TalkModeManager: NSObject {
             if Self.isTerminalChatSendFailure(ack.status) {
                 self.statusText = normalizedStatus == "error" ? "Chat error" : "Aborted"
                 self.logger.warning(
-                    "chat.send terminal ack runId=\(runId, privacy: .public) status=\(normalizedStatus, privacy: .public)")
+                    """
+                    chat.send terminal ack runId=\(runId, privacy: .public) \
+                    status=\(normalizedStatus, privacy: .public)
+                    """)
                 GatewayDiagnostics.log(
                     "talk: chat.send terminal ack runId=\(runId) status=\(normalizedStatus)")
                 if restartAfter {
@@ -2764,7 +2772,10 @@ extension TalkModeManager {
             defaultRealtimeModelId: Self.defaultRealtimeModelIdFallback)
         let realtimeVoiceOverride = TalkModeRealtimeVoiceSelection.resolvedOverride(
             UserDefaults.standard.string(forKey: TalkModeRealtimeVoiceSelection.storageKey))
-        let realtimeVoiceId = realtimeVoiceOverride ?? parsed.realtimeVoiceId
+        let parsedRealtimeVoiceId = providerSelection == .openAIRealtime && parsed.realtimeProvider != "openai"
+            ? nil
+            : parsed.realtimeVoiceId
+        let realtimeVoiceId = realtimeVoiceOverride ?? parsedRealtimeVoiceId
         self.activeTalkProvider = routing.activeProvider
         self.executionMode = routing.executionMode
         self.runtimeRoute = routing.route
@@ -2895,7 +2906,7 @@ extension TalkModeManager {
 
     private func applyTalkConfigLoadFailure(_ error: Error) {
         self.configuredProviderModelId = nil
-        if self.shouldForceRealtimeRelayFromSelection {
+        if self.shouldUseOpenAIRealtimeSelectionFallback {
             self.applyOpenAIRealtimeSelectionDefaults()
             GatewayDiagnostics.log("talk config unavailable; keeping openai realtime selection")
         } else {

--- a/apps/ios/Sources/Voice/TalkModeManager.swift
+++ b/apps/ios/Sources/Voice/TalkModeManager.swift
@@ -82,6 +82,9 @@ final class TalkModeManager: NSObject {
         case ignored
     }
 
+    private static let realtimeStableSessionSeconds: TimeInterval = 30
+    private static let realtimeRestartDelaysNanoseconds: [UInt64] = [500_000_000, 2_000_000_000]
+
     private var isStarting = false
     private var startAttemptID = 0
     private var captureMode: CaptureMode = .idle
@@ -103,6 +106,10 @@ final class TalkModeManager: NSObject {
     private var recognitionTask: SFSpeechRecognitionTask?
     private var silenceTask: Task<Void, Never>?
     private var realtimeSession: TalkRealtimeWebRTCSession?
+    private var realtimeSessionReadyAt: Date?
+    private var rapidRealtimeRestartCount = 0
+    private var bypassRealtimeOnNextStart = false
+    private var realtimeRestartGeneration = 0
     private var realtimeRelaySession: RealtimeTalkRelaySession?
     private var realtimeRelayStartInFlight = false
     private var prefetchedRealtimeSession: TalkRealtimeClientSession?
@@ -184,6 +191,121 @@ final class TalkModeManager: NSObject {
         max(0, Int((self.nowSeconds() - start) * 1000))
     }
 
+    private static func shouldRestartRealtimeSession(
+        isEnabled: Bool,
+        gatewayConnected: Bool,
+        captureIsContinuous: Bool) -> Bool
+    {
+        isEnabled && gatewayConnected && captureIsContinuous
+    }
+
+    private static func realtimeRestartAttempt(
+        previousRapidRestarts: Int,
+        activeDuration: TimeInterval) -> Int
+    {
+        activeDuration >= self.realtimeStableSessionSeconds ? 1 : previousRapidRestarts + 1
+    }
+
+    private static func realtimeRestartDelayNanoseconds(attempt: Int) -> UInt64? {
+        guard attempt > 0, attempt <= self.realtimeRestartDelaysNanoseconds.count else { return nil }
+        return self.realtimeRestartDelaysNanoseconds[attempt - 1]
+    }
+
+    private func resetRealtimeRestartState() {
+        self.realtimeRestartGeneration += 1
+        self.realtimeSessionReadyAt = nil
+        self.rapidRealtimeRestartCount = 0
+        self.bypassRealtimeOnNextStart = false
+    }
+
+    private func markRealtimeSessionReady() {
+        self.isListening = true
+        if self.captureMode != .pushToTalk {
+            self.captureMode = .continuous
+        }
+        if self.realtimeSessionReadyAt == nil {
+            self.realtimeSessionReadyAt = Date()
+        }
+        self.markRealtimeActive()
+    }
+
+    private func scheduleRealtimeRestart(after delayNanoseconds: UInt64?, generation: Int) {
+        Task { [weak self] in
+            if let delayNanoseconds {
+                do {
+                    try await Task.sleep(nanoseconds: delayNanoseconds)
+                } catch {
+                    return
+                }
+            }
+            // A ready/close pair can arrive before the current start() unwinds. Wait for that
+            // attempt instead of letting its isStarting guard consume the only recovery task.
+            while self?.isStarting == true {
+                do {
+                    try await Task.sleep(nanoseconds: 50_000_000)
+                } catch {
+                    return
+                }
+                guard let self,
+                      self.realtimeRestartGeneration == generation,
+                      Self.shouldRestartRealtimeSession(
+                          isEnabled: self.isEnabled,
+                          gatewayConnected: self.gatewayConnected,
+                          captureIsContinuous: self.captureMode == .continuous)
+                else { return }
+            }
+            guard let self,
+                  self.realtimeRestartGeneration == generation,
+                  Self.shouldRestartRealtimeSession(
+                      isEnabled: self.isEnabled,
+                      gatewayConnected: self.gatewayConnected,
+                      captureIsContinuous: self.captureMode == .continuous)
+            else { return }
+            await self.start()
+        }
+    }
+
+    private func handleRealtimeSessionFinish() {
+        // Provider sessions expire or disconnect while continuous Talk remains enabled. Explicit
+        // stop/background paths clear one of these guards before closing either session type.
+        let shouldRestart = Self.shouldRestartRealtimeSession(
+            isEnabled: self.isEnabled,
+            gatewayConnected: self.gatewayConnected,
+            captureIsContinuous: self.captureMode == .continuous)
+        let activeDuration = self.realtimeSessionReadyAt.map { Date().timeIntervalSince($0) } ?? 0
+        self.realtimeSessionReadyAt = nil
+        self.isListening = false
+        self.isSpeaking = false
+        self.isUserSpeechDetected = false
+        self.gatewayTalkActiveModeTitle = "Not active"
+        self.gatewayTalkActiveModeSubtitle = nil
+        guard shouldRestart else {
+            if self.isEnabled {
+                self.statusText = self.gatewayConnected ? "Ready" : "Offline"
+            }
+            return
+        }
+
+        self.realtimeRestartGeneration += 1
+        let restartGeneration = self.realtimeRestartGeneration
+        let attempt = Self.realtimeRestartAttempt(
+            previousRapidRestarts: self.rapidRealtimeRestartCount,
+            activeDuration: activeDuration)
+        self.rapidRealtimeRestartCount = attempt
+        guard let delay = Self.realtimeRestartDelayNanoseconds(attempt: attempt) else {
+            let issue = self.realtimeIssue(
+                message: "Realtime disconnected repeatedly.",
+                phase: "reconnect")
+            self.pendingRealtimeIssue = issue
+            self.gatewayTalkLastIssueText = issue.diagnosticSummary
+            self.bypassRealtimeOnNextStart = true
+            self.scheduleRealtimeRestart(after: nil, generation: restartGeneration)
+            return
+        }
+        self.statusText = "Reconnecting"
+        self.scheduleRealtimeRestart(after: delay, generation: restartGeneration)
+    }
+
     init(
         allowSimulatorCapture: Bool = false,
         gatewaySpeechSynthesizer: (any TalkGatewaySpeechSynthesizing)? = nil)
@@ -206,6 +328,7 @@ final class TalkModeManager: NSObject {
                 Task { await self.start() }
             }
         } else {
+            self.resetRealtimeRestartState()
             self.stopRealtimeSession()
             self.gatewayTalkActiveModeTitle = "Not active"
             self.gatewayTalkActiveModeSubtitle = nil
@@ -345,7 +468,9 @@ final class TalkModeManager: NSObject {
             GatewayDiagnostics.log("talk.timeline manager start blocked gateway permission")
             return
         }
-        if self.runtimeRoute.usesRealtime {
+        let bypassRealtime = self.bypassRealtimeOnNextStart
+        self.bypassRealtimeOnNextStart = false
+        if self.runtimeRoute.usesRealtime, !bypassRealtime {
             let realtimeStart = self.executionMode == .realtimeRelay
                 ? await self.startRealtimeRelayIfAvailable()
                 : await self.startRealtimeIfAvailable()
@@ -446,6 +571,7 @@ final class TalkModeManager: NSObject {
         self.lastHeard = nil
         self.silenceTask?.cancel()
         self.silenceTask = nil
+        self.resetRealtimeRestartState()
         self.stopRealtimeSession()
         self.stopRecognition()
         self.stopSpeaking()
@@ -495,6 +621,7 @@ final class TalkModeManager: NSObject {
         self.silenceTask?.cancel()
         self.silenceTask = nil
 
+        self.resetRealtimeRestartState()
         self.stopRealtimeSession()
         self.stopRecognition()
         self.stopSpeaking()
@@ -1147,9 +1274,7 @@ final class TalkModeManager: NSObject {
                 session.stop()
                 return .ignored
             }
-            self.isListening = true
-            self.captureMode = .continuous
-            markRealtimeActive()
+            self.markRealtimeSessionReady()
             GatewayDiagnostics.log(
                 "talk.timeline realtime start ready elapsedMs=\(Self.elapsedMs(since: startedAt))")
             GatewayDiagnostics.log("talk realtime: started direct OpenAI WebRTC session")
@@ -1237,8 +1362,7 @@ final class TalkModeManager: NSObject {
                         + "issue=\(issue.code.rawValue)")
                 return .unavailable(issue)
             }
-            self.isListening = true
-            self.captureMode = .continuous
+            self.markRealtimeSessionReady()
             self.realtimeRelayStartIssue = nil
             GatewayDiagnostics.log(
                 "talk.timeline realtime relay start ready elapsedMs=\(Self.elapsedMs(since: startedAt))")
@@ -2582,16 +2706,14 @@ extension TalkModeManager {
 
     private func handleRealtimeRelayStatus(_ status: String) {
         if status == "Listening (Realtime)" {
-            self.markRealtimeActive()
+            // Ready can be followed by a buffered close before start() resumes. Commit continuous
+            // state here so the close still enters bounded recovery.
+            self.markRealtimeSessionReady()
         } else {
             self.statusText = status
             if status == "Ready" {
                 self.realtimeRelaySession = nil
-                self.gatewayTalkActiveModeTitle = "Not active"
-                self.gatewayTalkActiveModeSubtitle = nil
-                self.isListening = false
-                self.isSpeaking = false
-                self.isUserSpeechDetected = false
+                self.handleRealtimeSessionFinish()
             }
         }
         self.isListening = status.localizedCaseInsensitiveContains("listening")
@@ -3124,7 +3246,7 @@ extension TalkModeManager: TalkRealtimeWebRTCSessionDelegate {
         guard session === self.realtimeSession else { return }
         GatewayDiagnostics.log("talk.timeline realtime status=\(status)")
         if status == "Listening" {
-            self.markRealtimeActive()
+            self.markRealtimeSessionReady()
         } else {
             self.statusText = status
         }
@@ -3165,19 +3287,36 @@ extension TalkModeManager: TalkRealtimeWebRTCSessionDelegate {
     func realtimeSessionDidFinish(_ session: TalkRealtimeWebRTCSession) {
         guard session === self.realtimeSession else { return }
         self.realtimeSession = nil
-        self.isListening = false
-        self.isSpeaking = false
-        self.isUserSpeechDetected = false
-        self.gatewayTalkActiveModeTitle = "Not active"
-        self.gatewayTalkActiveModeSubtitle = nil
-        if self.isEnabled {
-            self.statusText = self.gatewayConnected ? "Ready" : "Offline"
-        }
+        self.handleRealtimeSessionFinish()
     }
 }
 
 #if DEBUG
 extension TalkModeManager {
+    static func _test_shouldRestartRealtimeSession(
+        isEnabled: Bool,
+        gatewayConnected: Bool,
+        captureIsContinuous: Bool) -> Bool
+    {
+        self.shouldRestartRealtimeSession(
+            isEnabled: isEnabled,
+            gatewayConnected: gatewayConnected,
+            captureIsContinuous: captureIsContinuous)
+    }
+
+    static func _test_realtimeRestartAttempt(
+        previousRapidRestarts: Int,
+        activeDuration: TimeInterval) -> Int
+    {
+        self.realtimeRestartAttempt(
+            previousRapidRestarts: previousRapidRestarts,
+            activeDuration: activeDuration)
+    }
+
+    static func _test_realtimeRestartDelayNanoseconds(attempt: Int) -> UInt64? {
+        self.realtimeRestartDelayNanoseconds(attempt: attempt)
+    }
+
     static func _test_isPCMFormatRejectedByAPI(_ error: Error?) -> Bool {
         self.isPCMFormatRejectedByAPI(error)
     }
@@ -3245,6 +3384,23 @@ extension TalkModeManager {
 
     func _test_handleRealtimeRelayStatus(_ status: String) {
         self.handleRealtimeRelayStatus(status)
+    }
+
+    func _test_prepareEnabledRealtimeSessionForClose() {
+        self.isEnabled = true
+        self.gatewayConnected = true
+        self.captureMode = .idle
+        self.realtimeSessionReadyAt = nil
+    }
+
+    func _test_rapidRealtimeRestartCount() -> Int {
+        self.rapidRealtimeRestartCount
+    }
+
+    func _test_realtimeStatusPreservesPushToTalkCapture() -> Bool {
+        self.captureMode = .pushToTalk
+        self.handleRealtimeRelayStatus("Listening (Realtime)")
+        return self.captureMode == .pushToTalk
     }
 
     func _test_prepareRealtimeRelayStart() {

--- a/apps/ios/Sources/Voice/TalkRealtimeClientSession.swift
+++ b/apps/ios/Sources/Voice/TalkRealtimeClientSession.swift
@@ -31,6 +31,7 @@ struct TalkRealtimeToolCallResponse: Decodable {
 
 struct TalkRealtimeServerEvent: Decodable {
     let type: String
+    let error: TalkRealtimeServerError?
     let itemId: String?
     let item: TalkRealtimeServerItem?
     let callId: String?
@@ -42,6 +43,7 @@ struct TalkRealtimeServerEvent: Decodable {
 
     enum CodingKeys: String, CodingKey {
         case type
+        case error
         case itemId = "item_id"
         case item
         case callId = "call_id"
@@ -67,6 +69,15 @@ struct TalkRealtimeServerEvent: Decodable {
     var resolvedArguments: String? {
         self.arguments ?? self.item?.arguments
     }
+
+    var isMaximumDurationError: Bool {
+        guard self.type == "error", let message = self.error?.message?.lowercased() else { return false }
+        return message.contains("session") && message.contains("maximum duration")
+    }
+}
+
+struct TalkRealtimeServerError: Decodable {
+    let message: String?
 }
 
 struct TalkRealtimeServerItem: Decodable {

--- a/apps/ios/Sources/Voice/TalkRealtimeWebRTCSession.swift
+++ b/apps/ios/Sources/Voice/TalkRealtimeWebRTCSession.swift
@@ -180,6 +180,11 @@ final class TalkRealtimeWebRTCSession: NSObject {
         }
     }
 
+    func applyAudioRoutePreferenceChanged() throws {
+        try Self.configureAudioSession()
+        self.trace("audio route preference reapplied")
+    }
+
     private func checkNotStopped() throws {
         if self.stopped {
             throw CancellationError()
@@ -895,13 +900,15 @@ final class TalkRealtimeWebRTCSession: NSObject {
     }
 
     private static func configureAudioSession() throws {
+        let forceSpeaker = TalkDefaults.speakerphoneEnabled()
         let config = RTCAudioSessionConfiguration.webRTC()
         config.category = AVAudioSession.Category.playAndRecord.rawValue
         config.mode = AVAudioSession.Mode.default.rawValue
-        config.categoryOptions = [
-            .allowBluetoothHFP,
-            .defaultToSpeaker,
-        ]
+        var options: AVAudioSession.CategoryOptions = [.allowBluetoothHFP]
+        if forceSpeaker {
+            options.insert(.defaultToSpeaker)
+        }
+        config.categoryOptions = options
         config.sampleRate = 48000
         config.ioBufferDuration = 0.01
         RTCAudioSessionConfiguration.setWebRTC(config)
@@ -912,7 +919,7 @@ final class TalkRealtimeWebRTCSession: NSObject {
 
         session.ignoresPreferredAttributeConfigurationErrors = true
         try session.setConfiguration(config, active: true)
-        try? session.overrideOutputAudioPort(.speaker)
+        try? session.overrideOutputAudioPort(forceSpeaker ? .speaker : .none)
     }
 }
 

--- a/apps/ios/Sources/Voice/TalkRealtimeWebRTCSession.swift
+++ b/apps/ios/Sources/Voice/TalkRealtimeWebRTCSession.swift
@@ -919,7 +919,10 @@ final class TalkRealtimeWebRTCSession: NSObject {
 
         session.ignoresPreferredAttributeConfigurationErrors = true
         try session.setConfiguration(config, active: true)
-        try? session.overrideOutputAudioPort(forceSpeaker ? .speaker : .none)
+        let shouldForceSpeaker = TalkAudioRoute.shouldForceSpeaker(
+            preferenceEnabled: forceSpeaker,
+            outputPortTypes: AVAudioSession.sharedInstance().currentRoute.outputs.map(\.portType))
+        try? session.overrideOutputAudioPort(shouldForceSpeaker ? .speaker : .none)
     }
 }
 

--- a/apps/ios/Sources/Voice/TalkRealtimeWebRTCSession.swift
+++ b/apps/ios/Sources/Voice/TalkRealtimeWebRTCSession.swift
@@ -50,6 +50,7 @@ final class TalkRealtimeWebRTCSession: NSObject {
     private var loggedFirstAssistantSignal = false
     private var assistantAudioActive = false
     private var assistantAudioFinishTask: Task<Void, Never>?
+    private var ownsAudioSessionActivation = false
 
     private struct ToolBuffer {
         var name: String
@@ -117,7 +118,8 @@ final class TalkRealtimeWebRTCSession: NSObject {
         self.session = session
 
         self.trace("configure audio session start")
-        try Self.configureAudioSession()
+        try Self.configureAudioSession(activate: true)
+        self.ownsAudioSessionActivation = true
         self.trace("configure audio session done")
         RTCInitializeSSL()
         let factory = RTCPeerConnectionFactory(
@@ -171,6 +173,7 @@ final class TalkRealtimeWebRTCSession: NSObject {
         self.peerConnection?.close()
         self.peerConnection = nil
         self.factory = nil
+        self.releaseAudioSessionActivation()
         self.session = nil
         self.assistantAudioActive = false
         self.assistantAudioFinishTask?.cancel()
@@ -181,8 +184,24 @@ final class TalkRealtimeWebRTCSession: NSObject {
     }
 
     func applyAudioRoutePreferenceChanged() throws {
-        try Self.configureAudioSession()
+        try Self.configureAudioSession(activate: false)
         self.trace("audio route preference reapplied")
+    }
+
+    private func releaseAudioSessionActivation() {
+        guard self.ownsAudioSessionActivation else { return }
+        self.ownsAudioSessionActivation = false
+
+        // Balance only the activation this session owns. WebRTC may hold its own
+        // activation while the peer connection is alive.
+        let session = RTCAudioSession.sharedInstance()
+        session.lockForConfiguration()
+        defer { session.unlockForConfiguration() }
+        do {
+            try session.setActive(false)
+        } catch {
+            self.trace("audio session deactivate failed error=\(error.localizedDescription)")
+        }
     }
 
     private func checkNotStopped() throws {
@@ -899,16 +918,12 @@ final class TalkRealtimeWebRTCSession: NSObject {
         }
     }
 
-    private static func configureAudioSession() throws {
+    private static func configureAudioSession(activate: Bool) throws {
         let forceSpeaker = TalkDefaults.speakerphoneEnabled()
         let config = RTCAudioSessionConfiguration.webRTC()
         config.category = AVAudioSession.Category.playAndRecord.rawValue
         config.mode = AVAudioSession.Mode.default.rawValue
-        var options: AVAudioSession.CategoryOptions = [.allowBluetoothHFP]
-        if forceSpeaker {
-            options.insert(.defaultToSpeaker)
-        }
-        config.categoryOptions = options
+        config.categoryOptions = TalkAudioRoute.categoryOptions(speakerphoneEnabled: forceSpeaker)
         config.sampleRate = 48000
         config.ioBufferDuration = 0.01
         RTCAudioSessionConfiguration.setWebRTC(config)
@@ -918,10 +933,14 @@ final class TalkRealtimeWebRTCSession: NSObject {
         defer { session.unlockForConfiguration() }
 
         session.ignoresPreferredAttributeConfigurationErrors = true
-        try session.setConfiguration(config, active: true)
+        if activate {
+            try session.setConfiguration(config, active: true)
+        } else {
+            try session.setConfiguration(config)
+        }
         let shouldForceSpeaker = TalkAudioRoute.shouldForceSpeaker(
             preferenceEnabled: forceSpeaker,
-            outputPortTypes: AVAudioSession.sharedInstance().currentRoute.outputs.map(\.portType))
+            outputPortTypes: session.currentRoute.outputs.map(\.portType))
         try? session.overrideOutputAudioPort(shouldForceSpeaker ? .speaker : .none)
     }
 }

--- a/apps/ios/Sources/Voice/TalkRealtimeWebRTCSession.swift
+++ b/apps/ios/Sources/Voice/TalkRealtimeWebRTCSession.swift
@@ -397,6 +397,11 @@ final class TalkRealtimeWebRTCSession: NSObject {
             self.handleToolDone(event)
         case "error":
             self.delegate?.realtimeSession(self, didChangeStatus: "Realtime error")
+            if event.isMaximumDurationError {
+                // The provider's hard limit is terminal before transport state catches up.
+                // Finish explicitly so TalkModeManager rotates the session exactly once.
+                self.stop()
+            }
         default:
             break
         }
@@ -992,10 +997,16 @@ extension TalkRealtimeWebRTCSession: RTCDataChannelDelegate {
     nonisolated func dataChannelDidChangeState(_ dataChannel: RTCDataChannel) {
         Task { @MainActor in
             guard !self.stopped else { return }
-            if dataChannel.readyState == .open {
+            switch dataChannel.readyState {
+            case .open:
                 if !self.assistantAudioActive {
                     self.delegate?.realtimeSession(self, didChangeStatus: "Listening")
                 }
+            case .closed:
+                self.delegate?.realtimeSession(self, didChangeStatus: "Realtime disconnected")
+                self.stop()
+            default:
+                break
             }
         }
     }

--- a/apps/ios/Tests/TalkModeConfigParsingTests.swift
+++ b/apps/ios/Tests/TalkModeConfigParsingTests.swift
@@ -6,6 +6,23 @@ import Testing
 
 @MainActor
 struct TalkModeManagerTests {
+    @Test func `recognizes open AI maximum duration errors as terminal`() throws {
+        let event = try JSONDecoder().decode(
+            TalkRealtimeServerEvent.self,
+            from: Data(#"{"type":"error","error":{"message":"Your session hit the maximum duration of 60 minutes."}}"#
+                .utf8))
+
+        #expect(event.isMaximumDurationError)
+    }
+
+    @Test func `keeps recoverable open AI errors in the current session`() throws {
+        let event = try JSONDecoder().decode(
+            TalkRealtimeServerEvent.self,
+            from: Data(#"{"type":"error","error":{"message":"Cancellation failed: no active response found"}}"#.utf8))
+
+        #expect(!event.isMaximumDurationError)
+    }
+
     @Test func `parses open AI realtime provider model and voice`() {
         let config: [String: Any] = [
             "talk": [

--- a/apps/ios/Tests/TalkModeConfigParsingTests.swift
+++ b/apps/ios/Tests/TalkModeConfigParsingTests.swift
@@ -4,8 +4,8 @@ import Testing
 @testable import OpenClaw
 
 @MainActor
-@Suite struct TalkModeManagerTests {
-    @Test func parsesOpenAIRealtimeProviderModelAndVoice() {
+struct TalkModeManagerTests {
+    @Test func `parses open AI realtime provider model and voice`() {
         let config: [String: Any] = [
             "talk": [
                 "provider": "elevenlabs",
@@ -49,7 +49,7 @@ import Testing
         #expect(parsed.realtimeVoiceId == "marin")
     }
 
-    @Test func infersRealtimeProviderWhenProviderMapHasSingleEntry() {
+    @Test func `infers realtime provider when provider map has single entry`() {
         let config: [String: Any] = [
             "talk": [
                 "realtime": [
@@ -71,12 +71,12 @@ import Testing
             defaultRealtimeModelIdFallback: "gpt-realtime-2",
             defaultSilenceTimeoutMs: 900)
 
-        #expect(parsed.executionMode == .realtimeRelay)
+        #expect(parsed.executionMode == .realtimeWebRTC)
         #expect(parsed.realtimeProvider == "openai")
         #expect(parsed.realtimeModelId == "gpt-realtime-2")
     }
 
-    @Test func formatsGenericRealtimeVoiceModeWithoutNativeProviderFallback() {
+    @Test func `formats generic realtime voice mode without native provider fallback`() {
         let descriptor = TalkVoiceModeDescriptorBuilder.build(
             providerId: "realtime",
             providerLabel: "Realtime Voice",
@@ -89,7 +89,7 @@ import Testing
         #expect(descriptor.subtitle == "Native WebRTC • gpt-realtime-2")
     }
 
-    @Test func defaultsOpenAIRealtimeModelWhenProviderOmitsModel() {
+    @Test func `defaults open AI realtime model when provider omits model`() {
         let config: [String: Any] = [
             "talk": [
                 "realtime": [
@@ -113,14 +113,14 @@ import Testing
         #expect(parsed.realtimeVoiceId == nil)
     }
 
-    @Test func resolvesRealtimeVoicePickerOverrides() {
+    @Test func `resolves realtime voice picker overrides`() {
         #expect(TalkModeRealtimeVoiceSelection.resolvedOverride(nil) == nil)
         #expect(TalkModeRealtimeVoiceSelection.resolvedOverride("") == nil)
         #expect(TalkModeRealtimeVoiceSelection.resolvedOverride(" Cedar ") == "cedar")
         #expect(TalkModeRealtimeVoiceSelection.resolvedOverride("unknown") == nil)
     }
 
-    @Test func formatsOpenAIRealtimeVoiceMode() {
+    @Test func `formats open AI realtime voice mode`() {
         let descriptor = TalkVoiceModeDescriptorBuilder.build(
             providerId: "openai",
             providerLabel: "OpenAI",
@@ -134,7 +134,7 @@ import Testing
         #expect(descriptor.accessibilityValue == "GPT Realtime 2.0, Native WebRTC • Marin")
     }
 
-    @Test func formatsGatewayRelayRealtimeVoiceMode() {
+    @Test func `formats gateway relay realtime voice mode`() {
         let descriptor = TalkVoiceModeDescriptorBuilder.build(
             providerId: "google",
             providerLabel: "Google Live Voice",
@@ -147,7 +147,7 @@ import Testing
         #expect(descriptor.subtitle == "Gateway Relay • gemini-live-2.5-flash-preview")
     }
 
-    @Test func formatsElevenLabsVoiceMode() {
+    @Test func `formats eleven labs voice mode`() {
         let descriptor = TalkVoiceModeDescriptorBuilder.build(
             providerId: "elevenlabs",
             providerLabel: "ElevenLabs",
@@ -160,7 +160,7 @@ import Testing
         #expect(descriptor.subtitle == "Native • eleven_v3 • voice-id")
     }
 
-    @Test func formatsSystemVoiceFallbackMode() {
+    @Test func `formats system voice fallback mode`() {
         let descriptor = TalkVoiceModeDescriptorBuilder.build(
             providerId: "system",
             providerLabel: "iOS System Voice",
@@ -173,18 +173,80 @@ import Testing
         #expect(descriptor.subtitle == "Native • en-US")
     }
 
-    @Test func openAIRealtimeSelectionFallbackKeepsGatewayRelayDefaults() {
+    @Test func `open AI realtime selection defaults to native web RTC`() {
         let manager = TalkModeManager(allowSimulatorCapture: true)
 
         manager._test_applyOpenAIRealtimeSelectionDefaults()
 
-        #expect(manager._test_executionMode() == .realtimeRelay)
+        #expect(manager._test_executionMode() == .realtimeWebRTC)
         #expect(manager._test_realtimeProvider() == "openai")
         #expect(manager._test_realtimeModelId() == "gpt-realtime-2")
-        #expect(manager._test_gatewayTalkUsesRealtimeRelay())
+        #expect(!manager._test_gatewayTalkUsesRealtimeRelay())
     }
 
-    @Test func buildsGenericRealtimeFallbackIssueForDisplay() {
+    @Test func `open AI realtime selection clears stale realtime config`() {
+        let manager = TalkModeManager(allowSimulatorCapture: true)
+        let config: [String: Any] = [
+            "talk": [
+                "realtime": [
+                    "provider": "google",
+                    "model": "gemini-live-2.5-flash-preview",
+                    "voice": "puck",
+                    "mode": "realtime",
+                    "transport": "gateway-relay",
+                    "brain": "agent-consult",
+                ],
+            ],
+        ]
+        let parsed = TalkModeGatewayConfigParser.parse(
+            config: config,
+            defaultProvider: "elevenlabs",
+            defaultModelIdFallback: "eleven_v3",
+            defaultRealtimeModelIdFallback: "gpt-realtime-2",
+            defaultSilenceTimeoutMs: 900)
+
+        manager._test_applyLoadedTalkConfig(parsed, providerSelection: .gatewayDefault)
+        manager._test_applyOpenAIRealtimeSelectionDefaults()
+
+        #expect(manager._test_executionMode() == .realtimeWebRTC)
+        #expect(manager._test_realtimeProvider() == "openai")
+        #expect(manager._test_realtimeModelId() == "gpt-realtime-2")
+        #expect(manager.gatewayTalkRealtimeVoiceId == nil)
+        #expect(!manager._test_gatewayTalkUsesRealtimeRelay())
+    }
+
+    @Test func `open AI realtime selection keeps explicit open AI voice override`() {
+        let manager = TalkModeManager(allowSimulatorCapture: true)
+        let defaults = UserDefaults.standard
+        defaults.set(" Cedar ", forKey: TalkModeRealtimeVoiceSelection.storageKey)
+        defer { defaults.removeObject(forKey: TalkModeRealtimeVoiceSelection.storageKey) }
+        let config: [String: Any] = [
+            "talk": [
+                "realtime": [
+                    "provider": "google",
+                    "model": "gemini-live-2.5-flash-preview",
+                    "voice": "puck",
+                    "mode": "realtime",
+                    "transport": "gateway-relay",
+                    "brain": "agent-consult",
+                ],
+            ],
+        ]
+        let parsed = TalkModeGatewayConfigParser.parse(
+            config: config,
+            defaultProvider: "elevenlabs",
+            defaultModelIdFallback: "eleven_v3",
+            defaultRealtimeModelIdFallback: "gpt-realtime-2",
+            defaultSilenceTimeoutMs: 900)
+
+        manager._test_applyLoadedTalkConfig(parsed, providerSelection: .openAIRealtime)
+
+        #expect(manager._test_realtimeProvider() == "openai")
+        #expect(manager._test_realtimeModelId() == "gpt-realtime-2")
+        #expect(manager.gatewayTalkRealtimeVoiceId == "cedar")
+    }
+
+    @Test func `builds generic realtime fallback issue for display`() {
         let issue = TalkRuntimeIssue.realtimeUnavailable(
             message: "OpenAI API key rejected with 401",
             provider: "openai",
@@ -205,7 +267,7 @@ import Testing
         #expect(issue.technicalDetails.contains("code: realtime_unavailable"))
     }
 
-    @Test func nativeFallbackKeepsRealtimeIssueVisible() {
+    @Test func `native fallback keeps realtime issue visible`() {
         let manager = TalkModeManager(allowSimulatorCapture: true)
         let issue = TalkRuntimeIssue(
             code: .realtimeUnavailable,
@@ -224,7 +286,7 @@ import Testing
         #expect(manager._test_gatewayTalkCurrentFallbackIssue() == issue)
     }
 
-    @Test func gatewayTalkIssueDetailsDriveRealtimeFailureDisplay() {
+    @Test func `gateway talk issue details drive realtime failure display`() {
         let manager = TalkModeManager(allowSimulatorCapture: true)
         let error = GatewayResponseError(
             method: "talk.session.create",
@@ -251,7 +313,7 @@ import Testing
         #expect(issue.phase == "request")
     }
 
-    @Test func relayStartupIssueSurvivesUntilReadyStatus() {
+    @Test func `relay startup issue survives until ready status`() {
         let manager = TalkModeManager(allowSimulatorCapture: true)
         let issue = TalkRuntimeIssue(
             code: .realtimeUnavailable,
@@ -274,7 +336,7 @@ import Testing
         #expect(manager._test_gatewayTalkCurrentFallbackIssue() == nil)
     }
 
-    @Test func relayCloseClearsActiveRealtimeMode() {
+    @Test func `relay close clears active realtime mode`() {
         let manager = TalkModeManager(allowSimulatorCapture: true)
 
         manager._test_handleRealtimeRelayStatus("Listening (Realtime)")
@@ -288,7 +350,7 @@ import Testing
         #expect(manager._test_gatewayTalkActiveModeSubtitle() == nil)
     }
 
-    @Test func relayRetryClearsStaleFallbackTriggerButKeepsLastIssueVisible() {
+    @Test func `relay retry clears stale fallback trigger but keeps last issue visible`() {
         let manager = TalkModeManager(allowSimulatorCapture: true)
         let issue = TalkRuntimeIssue(
             code: .realtimeUnavailable,
@@ -310,7 +372,7 @@ import Testing
         #expect(manager._test_gatewayTalkLastIssueText()?.contains("Realtime closed before") == true)
     }
 
-    @Test func mapsWebRTCRealtimeTransportToGatewayRelayOnIOS() {
+    @Test func `maps web RTC realtime transport to native web RTC on IOS`() {
         let config: [String: Any] = [
             "talk": [
                 "realtime": [
@@ -328,10 +390,150 @@ import Testing
             defaultRealtimeModelIdFallback: "gpt-realtime-2",
             defaultSilenceTimeoutMs: 900)
 
+        #expect(parsed.executionMode == .realtimeWebRTC)
+    }
+
+    @Test func `keeps provider web socket realtime transport on gateway relay`() {
+        let config: [String: Any] = [
+            "talk": [
+                "realtime": [
+                    "provider": "google",
+                    "mode": "realtime",
+                    "transport": "provider-websocket",
+                    "brain": "agent-consult",
+                ],
+            ],
+        ]
+
+        let parsed = TalkModeGatewayConfigParser.parse(
+            config: config,
+            defaultProvider: "elevenlabs",
+            defaultModelIdFallback: "eleven_v3",
+            defaultRealtimeModelIdFallback: "gpt-realtime-2",
+            defaultSilenceTimeoutMs: 900)
+
         #expect(parsed.executionMode == .realtimeRelay)
     }
 
-    @Test func parsesRedactedGatewayRealtimeConfig() {
+    @Test func `leaves native mode for unsupported realtime brain`() {
+        let config: [String: Any] = [
+            "talk": [
+                "realtime": [
+                    "provider": "google",
+                    "mode": "realtime",
+                    "transport": "gateway-relay",
+                    "brain": "direct-tools",
+                ],
+            ],
+        ]
+
+        let parsed = TalkModeGatewayConfigParser.parse(
+            config: config,
+            defaultProvider: "elevenlabs",
+            defaultModelIdFallback: "eleven_v3",
+            defaultRealtimeModelIdFallback: "gpt-realtime-2",
+            defaultSilenceTimeoutMs: 900)
+
+        #expect(parsed.executionMode == .native)
+    }
+
+    @Test func `keeps non open AI realtime default transport on gateway relay`() {
+        let config: [String: Any] = [
+            "talk": [
+                "realtime": [
+                    "provider": "google",
+                    "mode": "realtime",
+                    "brain": "agent-consult",
+                ],
+            ],
+        ]
+
+        let parsed = TalkModeGatewayConfigParser.parse(
+            config: config,
+            defaultProvider: "elevenlabs",
+            defaultModelIdFallback: "eleven_v3",
+            defaultRealtimeModelIdFallback: "gpt-realtime-2",
+            defaultSilenceTimeoutMs: 900)
+
+        #expect(parsed.executionMode == .realtimeRelay)
+    }
+
+    @Test func `keeps non open AI web RTC transport on gateway relay`() {
+        let config: [String: Any] = [
+            "talk": [
+                "realtime": [
+                    "provider": "google",
+                    "model": "gemini-live-2.5-flash-preview",
+                    "mode": "realtime",
+                    "transport": "webrtc",
+                    "brain": "agent-consult",
+                ],
+            ],
+        ]
+
+        let parsed = TalkModeGatewayConfigParser.parse(
+            config: config,
+            defaultProvider: "elevenlabs",
+            defaultModelIdFallback: "eleven_v3",
+            defaultRealtimeModelIdFallback: "gpt-realtime-2",
+            defaultSilenceTimeoutMs: 900)
+
+        #expect(parsed.executionMode == .realtimeRelay)
+    }
+
+    @Test func `open AI selection overrides non open AI realtime provider`() {
+        let config: [String: Any] = [
+            "talk": [
+                "realtime": [
+                    "provider": "google",
+                    "mode": "realtime",
+                    "transport": "webrtc",
+                    "brain": "agent-consult",
+                ],
+            ],
+        ]
+
+        let parsed = TalkModeGatewayConfigParser.parse(
+            config: config,
+            defaultProvider: "elevenlabs",
+            defaultModelIdFallback: "eleven_v3",
+            defaultRealtimeModelIdFallback: "gpt-realtime-2",
+            defaultSilenceTimeoutMs: 900)
+        let routing = TalkModeRoutingResolver.resolve(
+            parsed: parsed,
+            providerSelection: .openAIRealtime,
+            defaultProvider: "elevenlabs",
+            defaultRealtimeModelId: "gpt-realtime-2")
+
+        #expect(routing.activeProvider == "openai")
+        #expect(routing.realtimeProvider == "openai")
+        #expect(routing.realtimeModelId == "gpt-realtime-2")
+        #expect(routing.executionMode == .realtimeWebRTC)
+        #expect(routing.route == .realtimeWebRTC)
+    }
+
+    @Test func `maps open AI realtime default transport to native web RTC`() {
+        let config: [String: Any] = [
+            "talk": [
+                "realtime": [
+                    "provider": "openai",
+                    "mode": "realtime",
+                    "brain": "agent-consult",
+                ],
+            ],
+        ]
+
+        let parsed = TalkModeGatewayConfigParser.parse(
+            config: config,
+            defaultProvider: "elevenlabs",
+            defaultModelIdFallback: "eleven_v3",
+            defaultRealtimeModelIdFallback: "gpt-realtime-2",
+            defaultSilenceTimeoutMs: 900)
+
+        #expect(parsed.executionMode == .realtimeWebRTC)
+    }
+
+    @Test func `parses redacted gateway realtime config`() {
         let config: [String: Any] = [
             "talk": [
                 "providers": [
@@ -372,14 +574,14 @@ import Testing
             defaultSilenceTimeoutMs: 900)
 
         #expect(parsed.activeProvider == "elevenlabs")
-        #expect(parsed.executionMode == .realtimeRelay)
+        #expect(parsed.executionMode == .realtimeWebRTC)
         #expect(parsed.realtimeProvider == "openai")
         #expect(parsed.realtimeModelId == "gpt-realtime-2")
         #expect(parsed.realtimeVoiceId == "cedar")
         #expect(parsed.rawConfigApiKey == "__OPENCLAW_REDACTED__")
     }
 
-    @Test func leavesNativeModeForManagedRoomRealtimeTransport() {
+    @Test func `leaves native mode for managed room realtime transport`() {
         let config: [String: Any] = [
             "talk": [
                 "realtime": [
@@ -400,7 +602,7 @@ import Testing
         #expect(parsed.executionMode == .native)
     }
 
-    @Test func detectsPCMFormatRejectionFromElevenLabsError() {
+    @Test func `detects PCM format rejection from eleven labs error`() {
         let error = NSError(
             domain: "ElevenLabsTTS",
             code: 403,
@@ -410,7 +612,7 @@ import Testing
         #expect(TalkModeManager._test_isPCMFormatRejectedByAPI(error))
     }
 
-    @Test func ignoresGenericPlaybackFailuresForPCMFormatRejection() {
+    @Test func `ignores generic playback failures for PCM format rejection`() {
         let error = NSError(
             domain: "StreamingAudio",
             code: -1,

--- a/apps/ios/Tests/TalkModeConfigParsingTests.swift
+++ b/apps/ios/Tests/TalkModeConfigParsingTests.swift
@@ -377,6 +377,24 @@ struct TalkModeManagerTests {
         #expect(manager._test_gatewayTalkActiveModeSubtitle() == nil)
     }
 
+    @Test func `relay close restarts enabled continuous realtime`() {
+        let manager = TalkModeManager(allowSimulatorCapture: true)
+        manager._test_prepareEnabledRealtimeSessionForClose()
+
+        manager._test_handleRealtimeRelayStatus("Listening (Realtime)")
+        manager._test_handleRealtimeRelayStatus("Ready")
+
+        #expect(manager.statusText == "Reconnecting")
+        #expect(manager._test_rapidRealtimeRestartCount() == 1)
+        manager.isEnabled = false
+    }
+
+    @Test func `recurring realtime ready status preserves push to talk capture`() {
+        let manager = TalkModeManager(allowSimulatorCapture: true)
+
+        #expect(manager._test_realtimeStatusPreservesPushToTalkCapture())
+    }
+
     @Test func `relay retry clears stale fallback trigger but keeps last issue visible`() {
         let manager = TalkModeManager(allowSimulatorCapture: true)
         let issue = TalkRuntimeIssue(
@@ -451,6 +469,35 @@ struct TalkModeManagerTests {
             #expect(parsed.executionMode == .realtimeRelay)
             #expect(routing.route == .realtimeRelay)
         }
+    }
+
+    @Test func `restarts an enabled continuous realtime session after provider close`() {
+        #expect(TalkModeManager._test_shouldRestartRealtimeSession(
+            isEnabled: true,
+            gatewayConnected: true,
+            captureIsContinuous: true))
+        #expect(!TalkModeManager._test_shouldRestartRealtimeSession(
+            isEnabled: false,
+            gatewayConnected: true,
+            captureIsContinuous: true))
+        #expect(!TalkModeManager._test_shouldRestartRealtimeSession(
+            isEnabled: true,
+            gatewayConnected: false,
+            captureIsContinuous: true))
+        #expect(!TalkModeManager._test_shouldRestartRealtimeSession(
+            isEnabled: true,
+            gatewayConnected: true,
+            captureIsContinuous: false))
+
+        #expect(TalkModeManager._test_realtimeRestartAttempt(
+            previousRapidRestarts: 1,
+            activeDuration: 5) == 2)
+        #expect(TalkModeManager._test_realtimeRestartAttempt(
+            previousRapidRestarts: 2,
+            activeDuration: 31) == 1)
+        #expect(TalkModeManager._test_realtimeRestartDelayNanoseconds(attempt: 1) == 500_000_000)
+        #expect(TalkModeManager._test_realtimeRestartDelayNanoseconds(attempt: 2) == 2_000_000_000)
+        #expect(TalkModeManager._test_realtimeRestartDelayNanoseconds(attempt: 3) == nil)
     }
 
     @Test func `keeps provider web socket realtime transport on gateway relay`() {

--- a/apps/ios/Tests/TalkModeConfigParsingTests.swift
+++ b/apps/ios/Tests/TalkModeConfigParsingTests.swift
@@ -420,6 +420,39 @@ struct TalkModeManagerTests {
         #expect(parsed.executionMode == .realtimeWebRTC)
     }
 
+    @Test func `keeps Azure open AI realtime on gateway relay`() {
+        for providerConfig in [
+            ["azureEndpoint": "https://example.openai.azure.com"],
+            ["azureDeployment": "realtime-prod"],
+        ] {
+            let config: [String: Any] = [
+                "talk": [
+                    "realtime": [
+                        "provider": "openai",
+                        "providers": ["openai": providerConfig],
+                        "mode": "realtime",
+                        "transport": "webrtc",
+                        "brain": "agent-consult",
+                    ],
+                ],
+            ]
+            let parsed = TalkModeGatewayConfigParser.parse(
+                config: config,
+                defaultProvider: "elevenlabs",
+                defaultModelIdFallback: "eleven_v3",
+                defaultRealtimeModelIdFallback: "gpt-realtime-2",
+                defaultSilenceTimeoutMs: 900)
+            let routing = TalkModeRoutingResolver.resolve(
+                parsed: parsed,
+                providerSelection: .openAIRealtime,
+                defaultProvider: "elevenlabs",
+                defaultRealtimeModelId: "gpt-realtime-2")
+
+            #expect(parsed.executionMode == .realtimeRelay)
+            #expect(routing.route == .realtimeRelay)
+        }
+    }
+
     @Test func `keeps provider web socket realtime transport on gateway relay`() {
         let config: [String: Any] = [
             "talk": [

--- a/apps/ios/Tests/TalkModeConfigParsingTests.swift
+++ b/apps/ios/Tests/TalkModeConfigParsingTests.swift
@@ -246,6 +246,32 @@ struct TalkModeManagerTests {
         #expect(manager.gatewayTalkRealtimeVoiceId == "cedar")
     }
 
+    @Test func `open AI selection preserves configured voice for case insensitive provider`() {
+        let manager = TalkModeManager(allowSimulatorCapture: true)
+        let config: [String: Any] = [
+            "talk": [
+                "realtime": [
+                    "provider": " OpenAI ",
+                    "voice": "marin",
+                    "mode": "realtime",
+                    "transport": "webrtc",
+                    "brain": "agent-consult",
+                ],
+            ],
+        ]
+        let parsed = TalkModeGatewayConfigParser.parse(
+            config: config,
+            defaultProvider: "elevenlabs",
+            defaultModelIdFallback: "eleven_v3",
+            defaultRealtimeModelIdFallback: "gpt-realtime-2",
+            defaultSilenceTimeoutMs: 900)
+
+        manager._test_applyLoadedTalkConfig(parsed, providerSelection: .openAIRealtime)
+
+        #expect(manager._test_realtimeProvider() == "openai")
+        #expect(manager.gatewayTalkRealtimeVoiceId == "marin")
+    }
+
     @Test func `builds generic realtime fallback issue for display`() {
         let issue = TalkRuntimeIssue.realtimeUnavailable(
             message: "OpenAI API key rejected with 401",

--- a/apps/ios/Tests/TalkModeConfigParsingTests.swift
+++ b/apps/ios/Tests/TalkModeConfigParsingTests.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import Foundation
 import OpenClawKit
 import Testing
@@ -507,7 +508,7 @@ struct TalkModeManagerTests {
         #expect(parsed.executionMode == .realtimeRelay)
     }
 
-    @Test func `open AI selection overrides non open AI realtime provider`() {
+    @Test func `open AI selection overrides non open AI web RTC provider`() {
         let config: [String: Any] = [
             "talk": [
                 "realtime": [
@@ -536,6 +537,68 @@ struct TalkModeManagerTests {
         #expect(routing.realtimeModelId == "gpt-realtime-2")
         #expect(routing.executionMode == .realtimeWebRTC)
         #expect(routing.route == .realtimeWebRTC)
+    }
+
+    @Test func `open AI selection preserves explicit gateway owned transport`() {
+        for transport in ["gateway-relay", "provider-websocket"] {
+            let config: [String: Any] = [
+                "talk": [
+                    "realtime": [
+                        "provider": "google",
+                        "mode": "realtime",
+                        "transport": transport,
+                        "brain": "agent-consult",
+                    ],
+                ],
+            ]
+            let parsed = TalkModeGatewayConfigParser.parse(
+                config: config,
+                defaultProvider: "elevenlabs",
+                defaultModelIdFallback: "eleven_v3",
+                defaultRealtimeModelIdFallback: "gpt-realtime-2",
+                defaultSilenceTimeoutMs: 900)
+            let routing = TalkModeRoutingResolver.resolve(
+                parsed: parsed,
+                providerSelection: .openAIRealtime,
+                defaultProvider: "elevenlabs",
+                defaultRealtimeModelId: "gpt-realtime-2")
+
+            #expect(routing.realtimeProvider == "openai")
+            #expect(routing.executionMode == .realtimeRelay)
+            #expect(routing.route == .realtimeRelay)
+        }
+    }
+
+    @Test func `speaker preference preserves external audio routes`() {
+        #expect(TalkAudioRoute.shouldForceSpeaker(
+            preferenceEnabled: true,
+            outputPortTypes: [.builtInReceiver]))
+        #expect(TalkAudioRoute.shouldForceSpeaker(
+            preferenceEnabled: true,
+            outputPortTypes: [.builtInSpeaker]))
+        #expect(!TalkAudioRoute.shouldForceSpeaker(
+            preferenceEnabled: false,
+            outputPortTypes: [.builtInReceiver]))
+        #expect(!TalkAudioRoute.shouldForceSpeaker(
+            preferenceEnabled: true,
+            outputPortTypes: []))
+
+        let externalOutputs: [AVAudioSession.Port] = [
+            .airPlay,
+            .bluetoothA2DP,
+            .bluetoothHFP,
+            .bluetoothLE,
+            .carAudio,
+            .headphones,
+            .HDMI,
+            .lineOut,
+            .usbAudio,
+        ]
+        for output in externalOutputs {
+            #expect(!TalkAudioRoute.shouldForceSpeaker(
+                preferenceEnabled: true,
+                outputPortTypes: [output]))
+        }
     }
 
     @Test func `maps open AI realtime default transport to native web RTC`() {

--- a/apps/ios/Tests/TalkModeConfigParsingTests.swift
+++ b/apps/ios/Tests/TalkModeConfigParsingTests.swift
@@ -570,6 +570,13 @@ struct TalkModeManagerTests {
     }
 
     @Test func `speaker preference preserves external audio routes`() {
+        let externalRouteOptions = TalkAudioRoute.categoryOptions(speakerphoneEnabled: false)
+        #expect(externalRouteOptions.contains(.allowBluetoothHFP))
+        #expect(externalRouteOptions.contains(.allowBluetoothA2DP))
+        #expect(externalRouteOptions.contains(.allowAirPlay))
+        #expect(!externalRouteOptions.contains(.defaultToSpeaker))
+        #expect(TalkAudioRoute.categoryOptions(speakerphoneEnabled: true).contains(.defaultToSpeaker))
+
         #expect(TalkAudioRoute.shouldForceSpeaker(
             preferenceEnabled: true,
             outputPortTypes: [.builtInReceiver]))

--- a/apps/ios/Tests/TalkModeConfigParsingTests.swift
+++ b/apps/ios/Tests/TalkModeConfigParsingTests.swift
@@ -471,6 +471,37 @@ struct TalkModeManagerTests {
         }
     }
 
+    @Test func `open AI selection keeps its Azure config on gateway relay`() {
+        let config: [String: Any] = [
+            "talk": [
+                "realtime": [
+                    "provider": "google",
+                    "providers": [
+                        "google": ["model": "gemini-live"],
+                        "OpenAI": ["azureDeployment": "realtime-prod"],
+                    ],
+                    "mode": "realtime",
+                    "transport": "webrtc",
+                    "brain": "agent-consult",
+                ],
+            ],
+        ]
+        let parsed = TalkModeGatewayConfigParser.parse(
+            config: config,
+            defaultProvider: "elevenlabs",
+            defaultModelIdFallback: "eleven_v3",
+            defaultRealtimeModelIdFallback: "gpt-realtime-2",
+            defaultSilenceTimeoutMs: 900)
+        let routing = TalkModeRoutingResolver.resolve(
+            parsed: parsed,
+            providerSelection: .openAIRealtime,
+            defaultProvider: "elevenlabs",
+            defaultRealtimeModelId: "gpt-realtime-2")
+
+        #expect(parsed.realtimeProvider == "google")
+        #expect(routing.route == .realtimeRelay)
+    }
+
     @Test func `restarts an enabled continuous realtime session after provider close`() {
         #expect(TalkModeManager._test_shouldRestartRealtimeSession(
             isEnabled: true,

--- a/docs/nodes/talk.md
+++ b/docs/nodes/talk.md
@@ -9,6 +9,7 @@ title: "Talk mode"
 Talk mode has two runtime shapes:
 
 - Native macOS/iOS/Android Talk uses local speech recognition, Gateway chat, and `talk.speak` TTS. Nodes advertise the `talk` capability and declare the `talk.*` commands they support.
+- iOS Talk uses client-owned WebRTC for OpenAI realtime configurations that select `webrtc` or omit the transport. Explicit `gateway-relay`, `provider-websocket`, and non-OpenAI realtime configurations stay on the Gateway-owned relay; non-realtime configurations use the native speech loop.
 - Browser Talk uses `talk.client.create` for client-owned `webrtc` and `provider-websocket` sessions, or `talk.session.create` for Gateway-owned `gateway-relay` sessions. `managed-room` is reserved for Gateway handoff and walkie-talkie rooms.
 - Android Talk can opt into Gateway-owned realtime relay sessions with `talk.realtime.mode: "realtime"` and `talk.realtime.transport: "gateway-relay"`. Otherwise it stays on native speech recognition, Gateway chat, and `talk.speak`.
 - Transcription-only clients use `talk.session.create({ mode: "transcription", transport: "gateway-relay", brain: "none" })`, then `talk.session.appendAudio`, `talk.session.cancelTurn`, and `talk.session.close` when they need captions or dictation without an assistant voice response.
@@ -20,7 +21,7 @@ Native Talk is a continuous voice conversation loop:
 3. Wait for the response
 4. Speak it via the configured Talk provider (`talk.speak`)
 
-Browser realtime Talk forwards provider tool calls through `talk.client.toolCall`; browser clients do not call `chat.send` directly for realtime consults.
+Client-owned realtime Talk forwards provider tool calls through `talk.client.toolCall`; those clients do not call `chat.send` directly for realtime consults.
 While a realtime consult is active, Talk clients can use `talk.client.steer` or
 `talk.session.steer` to classify spoken input as `status`, `steer`, `cancel`, or
 `followup`. Accepted steering is queued into the active embedded run; rejected
@@ -111,10 +112,10 @@ Defaults:
 - `providers.elevenlabs.apiKey`: falls back to `ELEVENLABS_API_KEY` (or gateway shell profile if available).
 - `consultThinkingLevel`: optional thinking level override for the full OpenClaw agent run behind realtime `openclaw_agent_consult` calls.
 - `consultFastMode`: optional fast-mode override for realtime `openclaw_agent_consult` calls.
-- `realtime.provider`: selects the active browser/server realtime voice provider. Use `openai` for WebRTC, `google` for provider WebSocket, or a bridge-only provider through Gateway relay.
+- `realtime.provider`: selects the active realtime voice provider. Use `openai` for WebRTC, `google` for provider WebSocket, or a bridge-only provider through Gateway relay.
 - `realtime.providers.<provider>` stores provider-owned realtime config. The browser receives only ephemeral or constrained session credentials, never a standard API key.
 - `realtime.providers.openai.voice`: built-in OpenAI Realtime voice id. Current `gpt-realtime-2` voices are `alloy`, `ash`, `ballad`, `coral`, `echo`, `sage`, `shimmer`, `verse`, `marin`, and `cedar`; `marin` and `cedar` are recommended for best quality.
-- `realtime.transport`: `webrtc` and `provider-websocket` are browser realtime transports. Android uses realtime relay only when this is `gateway-relay`; otherwise Android Talk uses its native STT/TTS loop.
+- `realtime.transport`: `webrtc` uses client-owned OpenAI WebRTC on iOS and in the browser. `provider-websocket` is browser-owned but stays on the Gateway relay on iOS. `gateway-relay` keeps provider audio on the Gateway; Android uses realtime only for this transport and otherwise keeps its native STT/TTS loop.
 - `realtime.brain`: `agent-consult` routes realtime tool calls through Gateway policy; `direct-tools` is legacy direct-tool compatibility behavior; `none` is for transcription or external orchestration.
 - `realtime.consultRouting`: `provider-direct` preserves the provider's direct reply when it skips `openclaw_agent_consult`; `force-agent-consult` makes Gateway relay route finalized user transcripts through OpenClaw instead.
 - `realtime.instructions`: appends provider-facing system instructions to OpenClaw's built-in realtime prompt. Use it for voice style and tone; OpenClaw keeps the default `openclaw_agent_consult` guidance.
@@ -145,7 +146,7 @@ Defaults:
 
 - Requires Speech + Microphone permissions.
 - Native Talk uses the active Gateway session and only falls back to history polling when response events are unavailable.
-- Browser realtime Talk uses `talk.client.toolCall` for `openclaw_agent_consult` instead of exposing `chat.send` to provider-owned browser sessions.
+- Client-owned realtime Talk uses `talk.client.toolCall` for `openclaw_agent_consult` instead of exposing `chat.send` to provider-owned sessions.
 - Transcription-only Talk uses `talk.session.create`, `talk.session.appendAudio`, `talk.session.cancelTurn`, and `talk.session.close`; clients subscribe to `talk.event` for partial/final transcript updates.
 - The gateway resolves Talk playback through `talk.speak` using the active Talk provider. Android falls back to local system TTS only when that RPC is unavailable.
 - macOS local MLX playback uses the bundled `openclaw-mlx-tts` helper when present, or an executable on `PATH`. Set `OPENCLAW_MLX_TTS_BIN` to point at a custom helper binary during development.

--- a/docs/platforms/ios.md
+++ b/docs/platforms/ios.md
@@ -267,6 +267,7 @@ openclaw nodes invoke --node "iOS Node" --command canvas.snapshot --params '{"ma
 ## Voice wake + talk mode
 
 - Voice wake and talk mode are available in Settings.
+- OpenAI realtime Talk uses client-owned WebRTC when `talk.realtime.transport` is `webrtc`; an explicit `gateway-relay` configuration remains Gateway-owned. See [Talk mode](/nodes/talk).
 - Talk-capable iOS nodes advertise the `talk` capability and can declare
   `talk.ptt.start`, `talk.ptt.stop`, `talk.ptt.cancel`, and `talk.ptt.once`;
   the Gateway allows those push-to-talk commands by default for trusted

--- a/src/gateway/server-methods/talk.test.ts
+++ b/src/gateway/server-methods/talk.test.ts
@@ -16,7 +16,9 @@ const mocks = vi.hoisted(() => ({
   getResolvedSpeechProviderConfig: vi.fn(() => ({})),
   resolveTtsConfig: vi.fn(() => ({ timeoutMs: 30_000 })),
   synthesizeSpeech: vi.fn(),
-  canonicalizeRealtimeVoiceProviderId: vi.fn((providerId: string | undefined) => providerId),
+  canonicalizeRealtimeVoiceProviderId: vi.fn((providerId: string | undefined) =>
+    providerId?.trim().toLowerCase(),
+  ),
   listRealtimeVoiceProviders: vi.fn(() => []),
   listRealtimeTranscriptionProviders: vi.fn(() => []),
   resolveConfiguredRealtimeVoiceProvider: vi.fn(),
@@ -417,6 +419,119 @@ describe("talk.speak handler", () => {
 describe("talk.config handler", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it("projects effective legacy realtime provider config for native routing", async () => {
+    const resolveConfig = vi.fn(
+      ({ rawConfig }: { rawConfig: Record<string, unknown> }): Record<string, unknown> => ({
+        ...rawConfig,
+        apiKey: normalizeResolvedSecretInputString({
+          value: rawConfig.apiKey,
+          path: "plugins.entries.voice-call.config.realtime.providers.openai.apiKey",
+        }),
+      }),
+    );
+    mocks.listRealtimeVoiceProviders.mockReturnValue([
+      {
+        id: "openai",
+        label: "OpenAI Realtime",
+        models: ["gpt-realtime"],
+        resolveConfig,
+        isConfigured: ({ providerConfig }: { providerConfig: Record<string, unknown> }) =>
+          providerConfig.apiKey === "runtime-azure-secret",
+      },
+    ] as never);
+    const sourceConfig = {
+      agents: {
+        defaults: {
+          voiceModel: { primary: "openai/gpt-realtime" },
+        },
+      },
+      talk: {
+        realtime: {
+          speakerVoice: "marin",
+          speakerVoiceId: "voice-id",
+        },
+      },
+      plugins: {
+        entries: {
+          "voice-call": {
+            config: {
+              realtime: {
+                providers: {
+                  " OpenAI ": {
+                    apiKey: {
+                      source: "env",
+                      provider: "default",
+                      id: "AZURE_OPENAI_API_KEY",
+                    },
+                    azureEndpoint: "https://example.openai.azure.com",
+                    azureDeployment: "realtime-prod",
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const runtimeConfig = {
+      ...sourceConfig,
+      plugins: {
+        entries: {
+          "voice-call": {
+            config: {
+              realtime: {
+                providers: {
+                  " OpenAI ": {
+                    apiKey: "runtime-azure-secret",
+                    azureEndpoint: "https://example.openai.azure.com",
+                    azureDeployment: "realtime-prod",
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    mocks.readConfigFileSnapshot.mockResolvedValue({
+      path: "/tmp/openclaw.json",
+      hash: "test-hash",
+      valid: true,
+      config: sourceConfig,
+    });
+
+    const respond = vi.fn();
+    await talkHandlers["talk.config"]({
+      req: { type: "req", id: "1", method: "talk.config" },
+      params: {},
+      client: { connect: { scopes: ["operator.read"] } } as never,
+      isWebchatConnect: () => false,
+      respond: respond as never,
+      context: { getRuntimeConfig: () => runtimeConfig } as never,
+    });
+
+    const response = expectRespondOk(respond) as { config?: { talk?: Record<string, unknown> } };
+    const realtime = expectRecordFields(response.config?.talk?.realtime, {
+      provider: "openai",
+      model: "gpt-realtime",
+      speakerVoice: "marin",
+      speakerVoiceId: "voice-id",
+    });
+    const providers = realtime.providers as Record<string, unknown> | undefined;
+    expectRecordFields(providers?.openai, {
+      apiKey: {
+        source: "__OPENCLAW_REDACTED__",
+        provider: "__OPENCLAW_REDACTED__",
+        id: "__OPENCLAW_REDACTED__",
+      },
+      azureEndpoint: "https://example.openai.azure.com",
+      azureDeployment: "realtime-prod",
+    });
+    expect(resolveConfig).toHaveBeenCalledOnce();
+    expect(JSON.stringify(mockCallArg(resolveConfig))).toContain("runtime-azure-secret");
+    expect(JSON.stringify(response)).not.toContain("runtime-azure-secret");
   });
 
   it("passes runtime-resolved messages.tts provider secrets to strict provider resolvers", async () => {

--- a/src/gateway/server-methods/talk.ts
+++ b/src/gateway/server-methods/talk.ts
@@ -407,14 +407,44 @@ async function resolveTalkResponseFromConfig(params: {
   runtimeConfig: OpenClawConfig;
 }): Promise<TalkConfigResponse | undefined> {
   const normalizedTalk = normalizeTalkSection(params.sourceConfig.talk);
-  if (!normalizedTalk) {
+  const configuredPayload = normalizedTalk ? buildTalkConfigResponse(normalizedTalk) : undefined;
+  // Resolve provider selection from materialized config, but project provider-owned fields from
+  // source config so SecretRefs stay redacted. The requested provider also avoids re-resolving them.
+  const runtimeRealtime = buildTalkRealtimeConfig(params.runtimeConfig);
+  const effectiveProvider = canonicalizeRealtimeVoiceProviderId(
+    runtimeRealtime.provider,
+    params.runtimeConfig,
+  );
+  const sourceRealtime = buildTalkRealtimeConfig(params.sourceConfig, effectiveProvider);
+  const sourceProviders: Record<string, TalkProviderConfig> = {};
+  for (const [providerId, providerConfig] of Object.entries(sourceRealtime.providers)) {
+    const canonicalProviderId =
+      canonicalizeRealtimeVoiceProviderId(providerId, params.runtimeConfig) ?? providerId;
+    sourceProviders[canonicalProviderId] = {
+      ...sourceProviders[canonicalProviderId],
+      ...providerConfig,
+    };
+  }
+  const effectiveRealtime = normalizeTalkSection({
+    realtime: {
+      ...(effectiveProvider ? { provider: effectiveProvider } : {}),
+      ...(runtimeRealtime.model ? { model: runtimeRealtime.model } : {}),
+      ...(Object.keys(sourceProviders).length > 0 ? { providers: sourceProviders } : {}),
+    },
+  })?.realtime;
+  if (!configuredPayload && !effectiveRealtime) {
     return undefined;
   }
-
-  const sourcePayload = buildTalkConfigResponse(normalizedTalk);
-  if (!sourcePayload) {
-    return undefined;
-  }
+  const realtime: TalkRealtimeConfig | undefined = effectiveRealtime
+    ? {
+        ...configuredPayload?.realtime,
+        ...effectiveRealtime,
+      }
+    : configuredPayload?.realtime;
+  const sourcePayload: TalkConfigResponse = {
+    ...configuredPayload,
+    ...(realtime ? { realtime } : {}),
+  };
   const payload = params.includeSecrets
     ? projectTalkSourcePayloadForSecrets(sourcePayload)
     : sourcePayload;


### PR DESCRIPTION
Related: #91007

## What Problem This Solves

Fixes an issue where iOS users trying to use OpenAI Realtime Talk could see the app enter the Gateway Relay path even though the Gateway advertised a WebRTC realtime configuration.

## Why This Change Was Made

The Gateway already carries the requested realtime transport. This change makes the iOS Talk route honor OpenAI Realtime configs with `transport: "webrtc"` by using the existing native WebRTC session path instead of mapping them to Gateway Relay.

## User Impact

iOS Talk can use the intended Native WebRTC path for OpenAI Realtime configurations that request WebRTC, while existing relay/provider-websocket behavior remains available for configurations that explicitly need it.

## Evidence

- External screenshot/video proof media was removed after merge for privacy.
- Physical iPhone proof before merge showed GPT Realtime 2.0 on Native WebRTC, Talk Ready -> Listening on Native WebRTC, and a completed user prompt plus app response.
- Maintainer repair landed on exact head `059023e7800350bd59d922b81465c5004f90509d`; branch-wide review and hosted/local validation were completed before merge.
- `TalkModeManagerTests`: 32 passed.
- `TalkConfigParsingTests`: 7 passed.
- iOS simulator build passed.
- SwiftFormat, SwiftLint, `git diff --check`, `pnpm native:i18n:check`, docs formatting, MDX syntax check, and docs link audit passed.

AI-assisted: yes. The implementation and review were done with Codex, with local review findings addressed before publication.