### PR TITLE
test(hooks): add unit tests for Gmail watcher error classification

### DIFF
--- a/src/hooks/gmail-watcher-errors.test.ts
+++ b/src/hooks/gmail-watcher-errors.test.ts
@@ -1,0 +1,29 @@
+// Tests for Gmail watcher error classification.
+import { describe, expect, it } from "vitest";
+import { isAddressInUseError } from "./gmail-watcher-errors.js";
+
+describe("isAddressInUseError", () => {
+  it("detects address already in use", () => {
+    expect(isAddressInUseError("address already in use")).toBe(true);
+  });
+
+  it("detects EADDRINUSE", () => {
+    expect(isAddressInUseError("EADDRINUSE")).toBe(true);
+  });
+
+  it("detects eaddrinuse case insensitive", () => {
+    expect(isAddressInUseError("eaddrinuse")).toBe(true);
+  });
+
+  it("returns false for unrelated error", () => {
+    expect(isAddressInUseError("connection refused")).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
+    expect(isAddressInUseError("")).toBe(false);
+  });
+
+  it("detects address in use in multi-line log", () => {
+    expect(isAddressInUseError("Error: listen EADDRINUSE 0.0.0.0:3000")).toBe(true);
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

The `isAddressInUseError` function detects watcher startup failures caused by occupied bind ports. Without tests, the regex-based detection could silently break.

## Why This Change Was Made

Add unit tests covering address-in-use messages, EADDRINUSE codes, case insensitivity, and unrelated errors.

## User Impact

Gmail watcher error classification now has comprehensive test coverage.

## Evidence

Direct behavior probe with real function calls:

```text
$ node --import tsx -e "import('./src/hooks/gmail-watcher-errors.js').then(({isAddressInUseError})=>console.log(JSON.stringify([{i:'address already in use',r:isAddressInUseError('address already in use'),e:true},{i:'EADDRINUSE',r:isAddressInUseError('EADDRINUSE'),e:true},{i:'connection refused',r:isAddressInUseError('connection refused'),e:false}])))"
[{"i":"address already in use","r":true,"e":true},{"i":"EADDRINUSE","r":true,"e":true},{"i":"connection refused","r":false,"e":false}]
```

Targeted test:

```text
$ node scripts/run-vitest.mjs run src/hooks/gmail-watcher-errors.test.ts
Test Files  1 passed (1)
     Tests  6 passed (6)
```

Formatting: `npx oxfmt --check` passed. Whitespace: `git diff --check` passed.