### PR TITLE
fix(gateway): skip secrets.resolve for active exec target SecretRefs (#96653)

### DIFF
--- a/src/cli/command-secret-gateway.test.ts
+++ b/src/cli/command-secret-gateway.test.ts
@@ -623,7 +623,6 @@ describe("resolveCommandSecretRefsViaGateway", () => {
 
   it("keeps local exec SecretRef fallback enabled by default", async () => {
     const { config, markerPath } = await createExecProviderConfig("talk/providers/api-key");
-    callGateway.mockRejectedValueOnce(new Error("gateway closed"));
 
     const result = await resolveCommandSecretRefsViaGateway({
       config,
@@ -632,10 +631,17 @@ describe("resolveCommandSecretRefsViaGateway", () => {
       mode: "read_only_status",
     });
 
+    expect(callGateway).not.toHaveBeenCalled();
     expect(await markerExists(markerPath)).toBe(true);
     expect(readTalkProviderApiKey(result.resolvedConfig)).toBe("exec-local-key");
     expect(result.targetStatesByPath[TALK_TEST_PROVIDER_API_KEY_PATH]).toBe("resolved_local");
-    expectGatewayUnavailableLocalFallbackDiagnostics(result);
+    expect(
+      result.diagnostics.some((entry) =>
+        entry.includes(
+          `memory status: skipped gateway secrets.resolve because SecretRefs use exec providers at ${TALK_TEST_PROVIDER_API_KEY_PATH}`,
+        ),
+      ),
+    ).toBe(true);
   });
 
   it("skips local exec SecretRef fallback when the caller disallows exec providers", async () => {
@@ -691,6 +697,74 @@ describe("resolveCommandSecretRefsViaGateway", () => {
     });
     expect(result.targetStatesByPath[TALK_TEST_PROVIDER_API_KEY_PATH]).toBe("unresolved");
     expect(result.hadUnresolvedTargets).toBe(true);
+  });
+
+  it("skips gateway resolution when active target SecretRefs use exec providers", async () => {
+    const { config, markerPath } = await createExecProviderConfig("talk/providers/api-key");
+
+    const result = await resolveCommandSecretRefsViaGateway({
+      config,
+      commandName: "talk reply",
+      targetIds: new Set(["talk.providers.*.apiKey"]),
+      mode: "read_only_status",
+    });
+
+    expect(callGateway).not.toHaveBeenCalled();
+    expect(await markerExists(markerPath)).toBe(true);
+    expect(readTalkProviderApiKey(result.resolvedConfig)).toBe("exec-local-key");
+    expect(result.targetStatesByPath[TALK_TEST_PROVIDER_API_KEY_PATH]).toBe("resolved_local");
+    expect(
+      result.diagnostics.some((entry) =>
+        entry.includes(
+          `talk reply: skipped gateway secrets.resolve because SecretRefs use exec providers at ${TALK_TEST_PROVIDER_API_KEY_PATH}`,
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not skip gateway resolution when only inactive targets use exec SecretRefs", async () => {
+    const { config: execBackedConfig } = await createExecProviderConfig("agent/memory/api-key");
+    callGateway.mockResolvedValueOnce({
+      assignments: [
+        {
+          path: TALK_TEST_PROVIDER_API_KEY_PATH,
+          pathSegments: [...TALK_TEST_PROVIDER_API_KEY_PATH_SEGMENTS],
+          value: "sk-live",
+        },
+      ],
+      diagnostics: [],
+    });
+
+    const result = await resolveCommandSecretRefsViaGateway({
+      config: {
+        ...buildTalkTestProviderConfig({
+          source: "env",
+          provider: "default",
+          id: "TALK_API_KEY",
+        }),
+        agents: {
+          list: [
+            {
+              id: "main",
+              memorySearch: {
+                enabled: false,
+                remote: {
+                  apiKey: { source: "exec", provider: "default", id: "agent/memory/api-key" },
+                },
+              },
+            },
+          ],
+        },
+        secrets: execBackedConfig.secrets,
+      } as OpenClawConfig,
+      commandName: "memory status",
+      targetIds: new Set(["talk.providers.*.apiKey", "agents.list[].memorySearch.remote.apiKey"]),
+      mode: "read_only_status",
+    });
+
+    expect(callGateway).toHaveBeenCalled();
+    expect(readTalkProviderApiKey(result.resolvedConfig)).toBe("sk-live");
+    expect(result.targetStatesByPath[TALK_TEST_PROVIDER_API_KEY_PATH]).toBe("resolved_gateway");
   });
 
   it("skips gateway resolution when gateway credentials would execute exec SecretRefs", async () => {

--- a/src/cli/command-secret-gateway.ts
+++ b/src/cli/command-secret-gateway.ts
@@ -358,12 +358,14 @@ function classifyConfiguredTargetRefs(params: {
 }): {
   hasActiveConfiguredRef: boolean;
   hasUnknownConfiguredRef: boolean;
+  activeConfiguredRefPaths: Set<string>;
   diagnostics: string[];
 } {
   if (params.configuredTargetRefPaths.size === 0) {
     return {
       hasActiveConfiguredRef: false,
       hasUnknownConfiguredRef: false,
+      activeConfiguredRefPaths: new Set(),
       diagnostics: [],
     };
   }
@@ -388,6 +390,7 @@ function classifyConfiguredTargetRefs(params: {
   const diagnostics = new Set<string>();
   let hasActiveConfiguredRef = false;
   let hasUnknownConfiguredRef = false;
+  const activeConfiguredRefPaths = new Set<string>();
 
   for (const path of params.configuredTargetRefPaths) {
     if (
@@ -396,6 +399,7 @@ function classifyConfiguredTargetRefs(params: {
       params.optionalActivePaths?.has(path)
     ) {
       hasActiveConfiguredRef = true;
+      activeConfiguredRefPaths.add(path);
       continue;
     }
     const inactiveWarning = inactiveWarningsByPath.get(path);
@@ -409,6 +413,7 @@ function classifyConfiguredTargetRefs(params: {
   return {
     hasActiveConfiguredRef,
     hasUnknownConfiguredRef,
+    activeConfiguredRefPaths,
     diagnostics: [...diagnostics],
   };
 }
@@ -520,6 +525,36 @@ function collectActiveGatewayExecSecretRefCredentialPaths(
       })
     );
   });
+}
+
+function collectActiveExecTargetRefPaths(params: {
+  config: OpenClawConfig;
+  targetIds: Set<string>;
+  configuredTargetRefPaths: Set<string>;
+  activeConfiguredRefPaths: ReadonlySet<string>;
+}): string[] {
+  const defaults = params.config.secrets?.defaults;
+  const execPaths: string[] = [];
+  for (const target of commandSecretGatewayDeps.discoverConfigSecretTargetsByIds(
+    params.config,
+    params.targetIds,
+  )) {
+    if (
+      !params.configuredTargetRefPaths.has(target.path) ||
+      !params.activeConfiguredRefPaths.has(target.path)
+    ) {
+      continue;
+    }
+    const { ref } = resolveSecretInputRef({
+      value: target.value,
+      refValue: target.refValue,
+      defaults,
+    });
+    if (ref?.source === "exec") {
+      execPaths.push(target.path);
+    }
+  }
+  return execPaths;
 }
 
 async function resolveCommandSecretRefsWithoutGateway(params: {
@@ -938,7 +973,23 @@ export async function resolveCommandSecretRefsViaGateway(params: {
   const gatewayExecSecretRefCredentialPaths = resolutionPolicy.allowExecSecretRefs
     ? []
     : collectActiveGatewayExecSecretRefCredentialPaths(params.config);
-  if (gatewayExecSecretRefCredentialPaths.length > 0) {
+  const targetExecSecretRefPaths = resolutionPolicy.allowExecSecretRefs
+    ? collectActiveExecTargetRefPaths({
+        config: params.config,
+        targetIds: params.targetIds,
+        configuredTargetRefPaths,
+        activeConfiguredRefPaths: preflight.activeConfiguredRefPaths,
+      })
+    : [];
+  const skipGatewayExecPaths = [
+    ...gatewayExecSecretRefCredentialPaths,
+    ...targetExecSecretRefPaths,
+  ];
+  if (skipGatewayExecPaths.length > 0) {
+    const reasonDiagnostic =
+      gatewayExecSecretRefCredentialPaths.length > 0
+        ? `${params.commandName}: skipped gateway secrets.resolve because gateway credentials use exec SecretRefs at ${gatewayExecSecretRefCredentialPaths.join(", ")}; rerun with --allow-exec to execute configured exec providers.`
+        : `${params.commandName}: skipped gateway secrets.resolve because SecretRefs use exec providers at ${targetExecSecretRefPaths.join(", ")}; rerun with --allow-exec to execute configured exec providers.`;
     return await resolveCommandSecretRefsWithoutGateway({
       config: params.config,
       commandName: params.commandName,
@@ -949,7 +1000,7 @@ export async function resolveCommandSecretRefsViaGateway(params: {
       forcedActivePaths: params.forcedActivePaths,
       optionalActivePaths: params.optionalActivePaths,
       resolutionPolicy,
-      reasonDiagnostic: `${params.commandName}: skipped gateway secrets.resolve because gateway credentials use exec SecretRefs at ${gatewayExecSecretRefCredentialPaths.join(", ")}; rerun with --allow-exec to execute configured exec providers.`,
+      reasonDiagnostic,
     });
   }
 


### PR DESCRIPTION
## What Problem This Solves

When exec tool targets use SecretRef providers backed by local exec credentials, OpenClaw still routed active-target resolution through the gateway `secrets.resolve` RPC. That produced repeated `UNAVAILABLE` gateway log noise even though the refs could be resolved locally on the agent side.

Fixes #96653

## Evidence

- Unit tests cover skipping gateway RPC for active exec-target SecretRefs while preserving gateway resolution for other ref kinds.
- `node scripts/run-vitest.mjs` on the gateway/exec secret resolution tests passes locally.
- CI security/guard checks pass on the PR head.

## Summary

- Skip `secrets.resolve` when **active** command target SecretRefs use `exec` providers, resolving them locally instead.
- Stops per-reply gateway `UNAVAILABLE` log noise when model-provider credentials are exec-backed but gateway credentials are plaintext.
