### PR TITLE
fix(memory): remove sync-on-miss from memory_search tool handler (fixes #98520)

### DIFF
--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -634,7 +634,13 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
         // A fresh process can receive its first search before background watch/session
         // syncs have built the index. Force one synchronous bootstrap so the first
         // lookup after restart does not fail closed with empty results.
-        await this.sync({ reason: "search", force: true });
+        // Use a bounded timeout so the foreground search is not blocked indefinitely
+        // when the embedding provider is slow or unreachable.
+        const bootstrapTimeout = 15_000;
+        const timeoutPromise = new Promise<void>((_, reject) => {
+          setTimeout(() => reject(new Error("memory sync bootstrap timed out")), bootstrapTimeout);
+        });
+        await Promise.race([this.sync({ reason: "search", force: true }), timeoutPromise]);
       } catch (err) {
         log.warn(`memory sync failed (search-bootstrap): ${String(err)}`);
       }

--- a/extensions/memory-core/src/tools.test.ts
+++ b/extensions/memory-core/src/tools.test.ts
@@ -349,23 +349,11 @@ describe("memory_search unavailable payloads", () => {
     expect(getMemoryCloseMockCalls()).toBe(1);
   });
 
-  it("forces a sync and retries once when the first search has zero hits", async () => {
+  it("returns empty results without forced sync retry when the first search has zero hits", async () => {
     let searchCalls = 0;
     setMemorySearchImpl(async () => {
       searchCalls += 1;
-      if (searchCalls === 1) {
-        return [];
-      }
-      return [
-        {
-          path: "MEMORY.md",
-          startLine: 1,
-          endLine: 1,
-          score: 0.9,
-          snippet: "Thread-hidden codename: ORBIT-22.",
-          source: "memory" as const,
-        },
-      ];
+      return [];
     });
 
     const tool = createMemorySearchToolOrThrow({
@@ -374,47 +362,35 @@ describe("memory_search unavailable payloads", () => {
         memory: { citations: "off" },
       },
     });
-    const result = await tool.execute("zero-hit-retry", { query: "hidden thread codename" });
+    const result = await tool.execute("zero-hit-no-retry", { query: "hidden thread codename" });
 
-    expect((result.details as { results?: Array<{ path: string }> }).results?.[0]?.path).toBe(
-      "MEMORY.md",
-    );
-    expect(searchCalls).toBe(2);
+    expect((result.details as { results?: Array<{ path: string }> }).results).toEqual([]);
+    expect(searchCalls).toBe(1);
   });
 
-  it("merges qmd runtime debug across zero-hit retry attempts", async () => {
+  it("returns qmd runtime debug from a single search call without retry", async () => {
     setMemoryBackend("qmd");
     let searchCalls = 0;
     setMemorySearchImpl(async (opts) => {
       searchCalls += 1;
-      if (searchCalls === 1) {
-        opts?.onDebug?.({
-          backend: "qmd",
-          configuredMode: "search",
-          effectiveMode: "search",
-          qmd: {
-            collectionValidation: {
-              cacheState: "hit",
-              elapsedMs: 2,
-              collectionCount: 2,
-              listCalls: 0,
-              showCalls: 0,
-            },
-            multiCollectionProbe: {
-              cacheState: "hit",
-              elapsedMs: 1,
-              supported: true,
-            },
-          },
-        });
-        return [];
-      }
       opts?.onDebug?.({
         backend: "qmd",
         configuredMode: "search",
         effectiveMode: "query",
         fallback: "unsupported-search-flags",
         qmd: {
+          collectionValidation: {
+            cacheState: "hit",
+            elapsedMs: 2,
+            collectionCount: 2,
+            listCalls: 0,
+            showCalls: 0,
+          },
+          multiCollectionProbe: {
+            cacheState: "hit",
+            elapsedMs: 1,
+            supported: true,
+          },
           searchPlan: {
             command: "query",
             collectionCount: 2,
@@ -423,16 +399,7 @@ describe("memory_search unavailable payloads", () => {
           },
         },
       });
-      return [
-        {
-          path: "MEMORY.md",
-          startLine: 1,
-          endLine: 1,
-          score: 0.9,
-          snippet: "Thread-hidden codename: ORBIT-22.",
-          source: "memory" as const,
-        },
-      ];
+      return [];
     });
 
     const tool = createMemorySearchToolOrThrow({
@@ -441,7 +408,7 @@ describe("memory_search unavailable payloads", () => {
         memory: { backend: "qmd", citations: "off" },
       },
     });
-    const result = await tool.execute("zero-hit-debug-retry", {
+    const result = await tool.execute("zero-hit-debug-single", {
       query: "hidden thread codename",
     });
     const details = result.details as {
@@ -452,7 +419,7 @@ describe("memory_search unavailable payloads", () => {
       };
     };
 
-    expect(searchCalls).toBe(2);
+    expect(searchCalls).toBe(1);
     expect(details.debug?.effectiveMode).toBe("query");
     expect(details.debug?.fallback).toBe("unsupported-search-flags");
     expect(details.debug?.qmd?.collectionValidation).toMatchObject({

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -566,16 +566,7 @@ export function createMemorySearchTool(options: {
                   if (pausedIndexIdentityReason) {
                     return;
                   }
-                  if (rawResults.length === 0 && activeMemory.manager.sync) {
-                    await activeMemory.manager.sync({ reason: "search", force: true });
-                    rawResults = await activeMemory.manager.search(query, searchOptions);
-                    pausedIndexIdentityReason = resolvePausedMemoryIndexIdentityReason(
-                      activeMemory.manager.status(),
-                    );
-                    if (pausedIndexIdentityReason) {
-                      return;
-                    }
-                  }
+
                   rawResults = await filterMemorySearchHitsBySessionVisibility({
                     cfg,
                     agentId,


### PR DESCRIPTION
## What Problem This Solves

`memory_search` blocks the foreground tool call for the full duration of a memory sync when the first search returns zero results. The tool handler in `extensions/memory-core/src/tools.ts` performs a synchronous `manager.sync({ reason: "search", force: true })` on every empty-result search, which can take minutes when the embedding provider is slow or unreachable.

This makes a normal "no results" search miss behave like a full memory indexing/sync operation inside the user-facing tool call deadline.

## Why This Change Was Made

The tool-level sync-on-miss (lines 569-578 in `tools.ts`) is redundant with the manager's bootstrap sync in `manager.ts:631-642`. The manager already handles the "fresh process with no indexed content" case with its own synchronous bootstrap. The tool-level retry adds a second full sync on every empty result — not just the first search after restart.

**Root cause:** The tool handler called `manager.sync({ force: true })` whenever `rawResults.length === 0`, regardless of whether the index was already populated. For queries with no matches, this triggered a full sync cycle (filesystem scan, embedding calls, vector updates) that blocked the foreground search.

**Fix:** Remove the tool-level sync-on-miss block. The manager's bootstrap sync handles the edge case of a fresh process with no indexed content. Additionally, add a 15-second timeout to the bootstrap sync so it does not block indefinitely when the embedding provider is unreachable.

## User Impact

- `memory_search` for queries with no matches returns immediately instead of blocking for minutes
- First search after process restart still bootstraps the index, but with a bounded 15s timeout
- Background syncs continue to keep the index up to date independently

## Evidence

## Real behavior proof

- **Behavior addressed:** memory_search blocks foreground tool call on zero-result queries due to synchronous sync-on-miss
- **Environment tested:** macOS, Node 22, OpenClaw 2026.6.11 (local checkout at `upstream/main`)
- **Steps run after the patch:** Built OpenClaw (`pnpm build`), ran `node openclaw.mjs memory search 'nonexistent_test_query_xyz_12345' --json`
- **Evidence after fix:**

```
$ node openclaw.mjs memory search 'nonexistent_test_query_xyz_12345' --json
[memory] sync failed (search-bootstrap): Error: memory sync bootstrap timed out
{
  "results": []
}
```

- **Observed result after fix:** The search returns empty results. The bootstrap sync times out at 15s (embedding provider unreachable in this environment) instead of blocking indefinitely. The tool-level sync-on-miss that previously re-triggered a full sync on every empty result is no longer present.
- **What was not tested:** Live search with a working embedding provider (OpenAI API unreachable from this environment). The fix's correctness is verified by unit tests (21/21 pass) and source code inspection. The timeout improvement is demonstrated by the bootstrap timeout log message.

## Changes Made

- `extensions/memory-core/src/tools.ts`: Remove the `rawResults.length === 0 && activeMemory.manager.sync` sync-on-miss block (lines 569-578)
- `extensions/memory-core/src/memory/manager.ts`: Add 15-second `Promise.race` timeout to the bootstrap sync in `search()` method
- `extensions/memory-core/src/tools.test.ts`: Update two tests that depended on the retry-on-miss behavior

## How to Test

```bash
pnpm test:extension memory-core
node scripts/run-vitest.mjs run extensions/memory-core/src/tools.test.ts
```

- [x] AI-assisted (Hermes Agent)
