### PR TITLE
fix: preserve streaming tool_calls when provider omits finish_reason

### DIFF
--- a/src/llm/providers/openai-completions.test.ts
+++ b/src/llm/providers/openai-completions.test.ts
@@ -1156,6 +1156,29 @@ describe("openai-completions stop-reason tool-call guard", () => {
     expect(toolCalls).toHaveLength(1);
   });
 
+  it("preserves toolCall blocks when stream ends without finish_reason (data: [DONE])", async () => {
+    // Some OpenAI-compatible providers (e.g., Evolink deepseek-v4-pro) send
+    // valid delta.tool_calls chunks but end with `data: [DONE]` without a
+    // final `finish_reason` chunk.  The tool calls should still be preserved.
+    mockChunksRef.chunks = [
+      makeToolCallChunk("call_1", "read", '{"path":"/tmp/foo.txt"}'),
+      // No finishChunk — stream ends naturally like `data: [DONE]`
+    ];
+
+    const stream = streamOpenAICompletions(model, context, {
+      apiKey: "***",
+    });
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("toolUse");
+    const toolCalls = result.content.filter((b) => b.type === "toolCall");
+    expect(toolCalls).toHaveLength(1);
+    expect(toolCalls[0]).toMatchObject({
+      id: "call_1",
+      name: "read",
+    });
+  });
+
   it("keeps buffered visible text before following tool calls", async () => {
     mockChunksRef.chunks = [
       makeTextChunk("Use <"),

--- a/src/llm/providers/openai-completions.ts
+++ b/src/llm/providers/openai-completions.ts
@@ -499,14 +499,25 @@ export const streamOpenAICompletions: StreamFunction<
       if (output.stopReason === "error") {
         throw new Error(output.errorMessage || "Provider returned an error stop reason");
       }
-      if (!hasFinishReason) {
-        throw new Error("Stream ended without finish_reason");
-      }
-
       const hasToolCalls = output.content.some((block) => block.type === "toolCall");
       const hasVisibleText = output.content.some(
         (block) => block.type === "text" && block.text.trim().length > 0,
       );
+
+      // Some OpenAI-compatible providers end the stream with `data: [DONE]`
+      // without emitting a final `finish_reason`.  When that happens we still
+      // have the accumulated content blocks, so we can infer the stop reason
+      // instead of discarding everything with an error.
+      if (!hasFinishReason) {
+        if (hasToolCalls) {
+          output.stopReason = "toolUse";
+        } else if (hasVisibleText) {
+          output.stopReason = "stop";
+        } else {
+          output.stopReason = "stop";
+        }
+      }
+
       if (output.stopReason === "toolUse" && !hasToolCalls) {
         output.stopReason = "stop";
       }


### PR DESCRIPTION
Some OpenAI-compatible providers (e.g., Evolink deepseek-v4-pro) send valid delta.tool_calls chunks but end the stream with data: [DONE] without a final finish_reason chunk. Previously, this caused an error that discarded all accumulated tool call blocks, making tool-using agent workflows silently fail.

Now we infer the stop reason from the accumulated content: toolUse if tool calls were parsed, stop otherwise. This matches the existing fallback logic that already promotes stop -> toolUse when tool calls are present.

Fixes #97994

### Changes
- src/llm/providers/openai-completions.ts: Instead of throwing when stream ends without finish_reason, infer stopReason from accumulated content blocks (toolUse if has tool calls, stop otherwise)
- src/llm/providers/openai-completions.test.ts: Added test for stream ending without finish_reason but with valid tool_calls

### Testing
All 36 existing tests pass plus the new test case.