### PR TITLE
fix: cancel aborted plugin approvals

### DIFF
--- a/extensions/discord/src/approval-handler.runtime.ts
+++ b/extensions/discord/src/approval-handler.runtime.ts
@@ -255,13 +255,17 @@ function createExecResolvedContainer(params: {
       ? "Allowed (once)"
       : params.view.decision === "allow-always"
         ? "Allowed (always)"
-        : "Denied";
+        : params.view.decision === "deny"
+          ? "Denied"
+          : "Cancelled";
   const accentColor =
     params.view.decision === "deny"
       ? "#ED4245"
       : params.view.decision === "allow-always"
         ? "#5865F2"
-        : "#57F287";
+        : params.view.decision === "allow-once"
+          ? "#57F287"
+          : "#99AAB5";
 
   return new ExecApprovalContainer({
     cfg: params.cfg,

--- a/extensions/googlechat/src/approval-handler.runtime.ts
+++ b/extensions/googlechat/src/approval-handler.runtime.ts
@@ -99,12 +99,14 @@ function buildMetadataText(metadata: readonly { label: string; value: string }[]
     .join("<br>");
 }
 
-function formatDecision(decision: ExecApprovalDecision): string {
+function formatDecision(decision: ExecApprovalDecision | null): string {
   return decision === "allow-once"
     ? "Allowed once"
     : decision === "allow-always"
       ? "Allowed always"
-      : "Denied";
+      : decision === "deny"
+        ? "Denied"
+        : "Cancelled";
 }
 
 function buildMainTextWidget(text: string) {

--- a/extensions/slack/src/approval-handler.runtime.ts
+++ b/extensions/slack/src/approval-handler.runtime.ts
@@ -150,13 +150,15 @@ function buildSlackMetadataContextBlocks(metadata: readonly SlackMetadataItem[])
 }
 
 function resolveSlackApprovalDecisionLabel(
-  decision: "allow-once" | "allow-always" | "deny",
+  decision: "allow-once" | "allow-always" | "deny" | null,
 ): string {
   return decision === "allow-once"
     ? "Allowed once"
     : decision === "allow-always"
       ? "Allowed always"
-      : "Denied";
+      : decision === "deny"
+        ? "Denied"
+        : "Cancelled";
 }
 
 function buildSlackPluginMetadata(view: SlackPluginApprovalView): SlackMetadataItem[] {

--- a/packages/gateway-protocol/src/index.ts
+++ b/packages/gateway-protocol/src/index.ts
@@ -209,6 +209,8 @@ import {
   ExecApprovalRequestParamsSchema,
   type ExecApprovalResolveParams,
   ExecApprovalResolveParamsSchema,
+  type PluginApprovalCancelParams,
+  PluginApprovalCancelParamsSchema,
   type PluginApprovalRequestParams,
   PluginApprovalRequestParamsSchema,
   type PluginApprovalResolveParams,
@@ -886,6 +888,9 @@ export const validatePluginApprovalRequestParams = lazyCompile<PluginApprovalReq
 );
 export const validatePluginApprovalResolveParams = lazyCompile<PluginApprovalResolveParams>(
   PluginApprovalResolveParamsSchema,
+);
+export const validatePluginApprovalCancelParams = lazyCompile<PluginApprovalCancelParams>(
+  PluginApprovalCancelParamsSchema,
 );
 export const validatePluginsUiDescriptorsParams = lazyCompile<PluginsUiDescriptorsParams>(
   PluginsUiDescriptorsParamsSchema,

--- a/packages/gateway-protocol/src/schema/plugin-approvals.ts
+++ b/packages/gateway-protocol/src/schema/plugin-approvals.ts
@@ -48,3 +48,11 @@ export const PluginApprovalResolveParamsSchema = Type.Object(
   },
   { additionalProperties: false },
 );
+
+/** Requester-side cancellation for a pending plugin approval. */
+export const PluginApprovalCancelParamsSchema = Type.Object(
+  {
+    id: NonEmptyString,
+  },
+  { additionalProperties: false },
+);

--- a/packages/gateway-protocol/src/schema/protocol-schemas.ts
+++ b/packages/gateway-protocol/src/schema/protocol-schemas.ts
@@ -232,6 +232,7 @@ import {
   NodeRenameParamsSchema,
 } from "./nodes.js";
 import {
+  PluginApprovalCancelParamsSchema,
   PluginApprovalRequestParamsSchema,
   PluginApprovalResolveParamsSchema,
 } from "./plugin-approvals.js";
@@ -564,6 +565,7 @@ export const ProtocolSchemas = {
   ExecApprovalGetParams: ExecApprovalGetParamsSchema,
   ExecApprovalRequestParams: ExecApprovalRequestParamsSchema,
   ExecApprovalResolveParams: ExecApprovalResolveParamsSchema,
+  PluginApprovalCancelParams: PluginApprovalCancelParamsSchema,
   PluginApprovalRequestParams: PluginApprovalRequestParamsSchema,
   PluginApprovalResolveParams: PluginApprovalResolveParamsSchema,
   PluginControlUiDescriptor: PluginControlUiDescriptorSchema,

--- a/packages/gateway-protocol/src/schema/types.ts
+++ b/packages/gateway-protocol/src/schema/types.ts
@@ -275,6 +275,7 @@ export type ExecApprovalsSnapshot = SchemaType<"ExecApprovalsSnapshot">;
 export type ExecApprovalGetParams = SchemaType<"ExecApprovalGetParams">;
 export type ExecApprovalRequestParams = SchemaType<"ExecApprovalRequestParams">;
 export type ExecApprovalResolveParams = SchemaType<"ExecApprovalResolveParams">;
+export type PluginApprovalCancelParams = SchemaType<"PluginApprovalCancelParams">;
 export type PluginApprovalRequestParams = SchemaType<"PluginApprovalRequestParams">;
 export type PluginApprovalResolveParams = SchemaType<"PluginApprovalResolveParams">;
 export type DevicePairListParams = SchemaType<"DevicePairListParams">;

--- a/src/agents/agent-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/agent-tools.before-tool-call.e2e.test.ts
@@ -1611,7 +1611,11 @@ describe("before_tool_call requireApproval handling", () => {
 
     expect(result.blocked).toBe(true);
     expect(result).toHaveProperty("reason", "Approval cancelled (run aborted)");
-    expect(mockCallGateway).toHaveBeenCalledTimes(2);
+    expect(mockCallGateway).toHaveBeenCalledTimes(3);
+    const cancelCall = requireGatewayCall(2);
+    expect(cancelCall[0]).toBe("plugin.approval.cancel");
+    expect(cancelCall[1]).toEqual({ timeoutMs: 5_000 });
+    expect(cancelCall[2]).toEqual({ id: "server-id-abort" });
   });
 
   it("classifies non-Error abort reasons as run abort cancellation", async () => {

--- a/src/agents/agent-tools.before-tool-call.ts
+++ b/src/agents/agent-tools.before-tool-call.ts
@@ -643,6 +643,20 @@ function notifyPluginApprovalResolution(
   }
 }
 
+function cancelPluginToolApprovalRequest(id: string): void {
+  void Promise.resolve(
+    callGatewayTool(
+      "plugin.approval.cancel",
+      { timeoutMs: 5_000 },
+      {
+        id,
+      },
+    ),
+  ).catch((err: unknown) => {
+    log.warn(`plugin approval cancel failed: ${String(err)}`);
+  });
+}
+
 async function requestPluginToolApproval(params: {
   approval: PluginApprovalRequest;
   toolName: string;
@@ -655,6 +669,7 @@ async function requestPluginToolApproval(params: {
   const approval = params.approval;
   const timeoutMs = resolvePluginToolApprovalTimeoutMs(approval);
   const gatewayTimeoutMs = resolvePluginToolApprovalGatewayTimeoutMs(timeoutMs);
+  let approvalId: string | undefined;
   try {
     const requestResult: {
       id?: string;
@@ -695,6 +710,7 @@ async function requestPluginToolApproval(params: {
         params: params.baseParams,
       };
     }
+    approvalId = id;
     const hasImmediateDecision = Object.hasOwn(requestResult ?? {}, "decision");
     let decision: string | null | undefined;
     if (hasImmediateDecision) {
@@ -795,6 +811,9 @@ async function requestPluginToolApproval(params: {
         (err instanceof Error &&
           (err.name === "AbortError" || ("cause" in err && err.cause === signal.reason))));
     if (abortCancelled) {
+      if (approvalId) {
+        cancelPluginToolApprovalRequest(approvalId);
+      }
       log.warn(`plugin approval wait cancelled by run abort: ${String(err)}`);
       return {
         blocked: true,

--- a/src/agents/tools/gateway.test.ts
+++ b/src/agents/tools/gateway.test.ts
@@ -488,6 +488,18 @@ describe("gateway tool defaults", () => {
     expect(call.deviceIdentity).toEqual(mocks.deviceIdentity);
   });
 
+  it("marks local plugin approval cancel calls with runtime and device identity", async () => {
+    mocks.callGateway.mockResolvedValueOnce({ ok: true });
+
+    await callGatewayTool("plugin.approval.cancel", {}, { id: "approval-id" });
+
+    const call = capturedGatewayCall();
+    expect(call.method).toBe("plugin.approval.cancel");
+    expect(call.scopes).toEqual(["operator.approvals"]);
+    expect(call.approvalRuntimeToken).toEqual(expect.any(String));
+    expect(call.deviceIdentity).toEqual(mocks.deviceIdentity);
+  });
+
   it("marks local plugin approval request calls with runtime and device identity", async () => {
     mocks.callGateway.mockResolvedValueOnce({ id: "plugin:approval-id" });
 

--- a/src/agents/tools/gateway.ts
+++ b/src/agents/tools/gateway.ts
@@ -208,6 +208,7 @@ const APPROVAL_RUNTIME_METHODS = new Set<string>([
   "exec.approval.waitDecision",
   "plugin.approval.request",
   "plugin.approval.waitDecision",
+  "plugin.approval.cancel",
 ]);
 
 const AGENT_RUNTIME_IDENTITY_METHODS = new Set<string>([

--- a/src/gateway/method-scopes.test.ts
+++ b/src/gateway/method-scopes.test.ts
@@ -325,6 +325,7 @@ describe("operator scope authorization", () => {
     "plugin.approval.list",
     "plugin.approval.request",
     "plugin.approval.waitDecision",
+    "plugin.approval.cancel",
     "plugin.approval.resolve",
   ])("requires approvals scope for %s", (method) => {
     expect(authorizeOperatorScopesForMethod(method, ["operator.write"])).toEqual({
@@ -361,6 +362,7 @@ describe("plugin approval method registration", () => {
     expect(methods).toContain("plugin.approval.list");
     expect(methods).toContain("plugin.approval.request");
     expect(methods).toContain("plugin.approval.waitDecision");
+    expect(methods).toContain("plugin.approval.cancel");
     expect(methods).toContain("plugin.approval.resolve");
   });
 
@@ -368,6 +370,7 @@ describe("plugin approval method registration", () => {
     expect(isGatewayMethodClassified("plugin.approval.list")).toBe(true);
     expect(isGatewayMethodClassified("plugin.approval.request")).toBe(true);
     expect(isGatewayMethodClassified("plugin.approval.waitDecision")).toBe(true);
+    expect(isGatewayMethodClassified("plugin.approval.cancel")).toBe(true);
     expect(isGatewayMethodClassified("plugin.approval.resolve")).toBe(true);
   });
 });

--- a/src/gateway/methods/core-descriptors.ts
+++ b/src/gateway/methods/core-descriptors.ts
@@ -63,6 +63,7 @@ export const CORE_GATEWAY_METHOD_SPECS: readonly CoreGatewayMethodSpec[] = [
   { name: "plugin.approval.list", scope: "operator.approvals" },
   { name: "plugin.approval.request", scope: "operator.approvals" },
   { name: "plugin.approval.waitDecision", scope: "operator.approvals" },
+  { name: "plugin.approval.cancel", scope: "operator.approvals" },
   { name: "plugin.approval.resolve", scope: "operator.approvals" },
   { name: "plugins.uiDescriptors", scope: "operator.read" },
   { name: "plugins.sessionAction", scope: "dynamic" },

--- a/src/gateway/server-aux-handlers.ts
+++ b/src/gateway/server-aux-handlers.ts
@@ -285,6 +285,10 @@ export function createGatewayAuxHandlers(params: {
         "plugin.approval.waitDecision",
         loadPluginApprovalHandlers,
       ),
+      "plugin.approval.cancel": createLazyHandler(
+        "plugin.approval.cancel",
+        loadPluginApprovalHandlers,
+      ),
       "plugin.approval.resolve": createLazyHandler(
         "plugin.approval.resolve",
         loadPluginApprovalHandlers,

--- a/src/gateway/server-aux-methods.ts
+++ b/src/gateway/server-aux-methods.ts
@@ -10,6 +10,7 @@ export const GATEWAY_AUX_METHODS = [
   "plugin.approval.list",
   "plugin.approval.request",
   "plugin.approval.waitDecision",
+  "plugin.approval.cancel",
   "plugin.approval.resolve",
   "secrets.reload",
   "secrets.resolve",

--- a/src/gateway/server-methods/approval-shared.ts
+++ b/src/gateway/server-methods/approval-shared.ts
@@ -667,3 +667,98 @@ export async function handleApprovalResolve<TPayload, TResolvedEvent extends obj
 
   params.respond(true, { ok: true }, undefined);
 }
+
+/** Cancels a pending approval requested by the caller and broadcasts cleanup. */
+export async function handleApprovalCancel<TPayload, TResolvedEvent extends object>(params: {
+  manager: ExecApprovalManager<TPayload>;
+  inputId: string;
+  respond: RespondFn;
+  context: GatewayRequestContext;
+  client: GatewayClient | null;
+  exposeAmbiguousPrefixError?: boolean;
+  resolvedEventName: string;
+  buildResolvedEvent: (params: {
+    approvalId: string;
+    decision: null;
+    resolvedBy: string | null;
+    snapshot: ExecApprovalRecord<TPayload>;
+    nowMs: number;
+  }) => TResolvedEvent;
+  forwardResolved?: (event: TResolvedEvent) => Promise<void> | void;
+  forwardResolvedErrorLabel?: string;
+}): Promise<void> {
+  const resolved = resolvePendingApprovalRecord({
+    manager: params.manager,
+    inputId: params.inputId,
+    client: params.client,
+    exposeAmbiguousPrefixError: params.exposeAmbiguousPrefixError,
+  });
+  if (!resolved.ok) {
+    const resolvedRepeat = resolveResolvedApprovalRecord({
+      manager: params.manager,
+      inputId: params.inputId,
+      client: params.client,
+      exposeAmbiguousPrefixError: params.exposeAmbiguousPrefixError,
+    });
+    if (resolvedRepeat.ok) {
+      if (resolveRecordedApprovalDecision(resolvedRepeat.snapshot) === undefined) {
+        params.respond(true, { ok: true }, undefined);
+        return;
+      }
+      params.respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, "approval already resolved", {
+          details: APPROVAL_ALREADY_RESOLVED_DETAILS,
+        }),
+      );
+      return;
+    }
+    respondPendingApprovalLookupError({ respond: params.respond, response: resolved.response });
+    return;
+  }
+
+  const resolvedBy =
+    params.client?.connect?.client?.displayName ?? params.client?.connect?.client?.id ?? null;
+  const ok = params.manager.expire(resolved.approvalId, resolvedBy ?? "request-cancelled");
+  if (!ok) {
+    respondUnknownOrExpiredApproval(params.respond);
+    return;
+  }
+
+  const resolvedEvent = params.buildResolvedEvent({
+    approvalId: resolved.approvalId,
+    decision: null,
+    resolvedBy,
+    snapshot: resolved.snapshot,
+    nowMs: Date.now(),
+  });
+  const resolvedEventConnIds = resolveApprovalRequestRecipientConnIds({
+    context: params.context,
+    record: resolved.snapshot,
+  });
+  if (resolvedEventConnIds) {
+    params.context.broadcastToConnIds(
+      params.resolvedEventName,
+      resolvedEvent,
+      resolvedEventConnIds,
+      {
+        dropIfSlow: true,
+      },
+    );
+  } else {
+    params.context.broadcast(params.resolvedEventName, resolvedEvent, { dropIfSlow: true });
+  }
+
+  if (params.forwardResolved) {
+    try {
+      await params.forwardResolved(resolvedEvent);
+    } catch (err) {
+      params.context.logGateway?.error?.(
+        `${params.forwardResolvedErrorLabel ?? "approval cancel follow-up failed"}: ${String(err)}`,
+      );
+    }
+  }
+
+  params.respond(true, { ok: true }, undefined);
+}

--- a/src/gateway/server-methods/plugin-approval.test.ts
+++ b/src/gateway/server-methods/plugin-approval.test.ts
@@ -226,6 +226,7 @@ function broadcastCall(opts: GatewayRequestHandlerOptions, index = 0) {
 
 const invalidParamMethodCases = [
   { method: "plugin.approval.request" },
+  { method: "plugin.approval.cancel" },
   { method: "plugin.approval.resolve" },
 ] as const;
 
@@ -262,6 +263,7 @@ describe("createPluginApprovalHandlers", () => {
   it("returns handlers for every plugin approval method", () => {
     const handlers = createPluginApprovalHandlers(manager);
     expect(Object.keys(handlers).toSorted()).toEqual([
+      "plugin.approval.cancel",
       "plugin.approval.list",
       "plugin.approval.request",
       "plugin.approval.resolve",
@@ -717,6 +719,72 @@ describe("createPluginApprovalHandlers", () => {
       const error = expectResponseRejected(opts.respond);
       expect(error.code).toBe("INVALID_REQUEST");
       expect(error.message).toBe("unknown or expired approval id");
+    });
+  });
+
+  describe("plugin.approval.cancel", () => {
+    it("cancels a pending approval and broadcasts a nullable resolved event", async () => {
+      const handlers = createPluginApprovalHandlers(manager);
+      const record = registerApproval(manager);
+
+      const opts = createMockOptions("plugin.approval.cancel", { id: record.id });
+      await handlers["plugin.approval.cancel"](opts);
+
+      expect(opts.respond).toHaveBeenCalledWith(true, { ok: true }, undefined);
+      expect(manager.listPendingRecords()).toEqual([]);
+      const resolvedBroadcast = broadcastCall(opts);
+      expect(resolvedBroadcast.event).toBe("plugin.approval.resolved");
+      expect(resolvedBroadcast.payload.id).toBe(record.id);
+      expect(resolvedBroadcast.payload.decision).toBeNull();
+      expect(resolvedBroadcast.options).toEqual({ dropIfSlow: true });
+    });
+
+    it("unblocks waitDecision with a null decision when cancelled", async () => {
+      const handlers = createPluginApprovalHandlers(manager);
+      const record = registerApproval(manager);
+      const waitOpts = createMockOptions("plugin.approval.waitDecision", { id: record.id });
+      const waitPromise = handlers["plugin.approval.waitDecision"](waitOpts);
+
+      const cancelOpts = createMockOptions("plugin.approval.cancel", { id: record.id });
+      await handlers["plugin.approval.cancel"](cancelOpts);
+      await waitPromise;
+
+      expect(cancelOpts.respond).toHaveBeenCalledWith(true, { ok: true }, undefined);
+      const waitResult = expectResponseOk(waitOpts.respond);
+      expect(waitResult.id).toBe(record.id);
+      expect(waitResult.decision).toBeNull();
+    });
+
+    it("does not cancel approvals hidden from the caller", async () => {
+      const handlers = createPluginApprovalHandlers(manager);
+      const hidden = registerOwnedApproval(manager, {
+        title: "Hidden",
+        id: "plugin:hidden-cancel",
+        owner: "other",
+      });
+
+      const opts = createMockOptions(
+        "plugin.approval.cancel",
+        { id: hidden.id },
+        {
+          client: createOwnedClient("owner"),
+        },
+      );
+      await handlers["plugin.approval.cancel"](opts);
+
+      expect(expectResponseRejected(opts.respond).message).toContain("unknown or expired");
+      expect(manager.listPendingRecords().map((record) => record.id)).toEqual([hidden.id]);
+    });
+
+    it("rejects cancel after an approval was already decided", async () => {
+      const handlers = createPluginApprovalHandlers(manager);
+      const record = registerApproval(manager);
+      manager.resolve(record.id, "allow-once");
+
+      const opts = createMockOptions("plugin.approval.cancel", { id: record.id });
+      await handlers["plugin.approval.cancel"](opts);
+
+      expect(expectResponseRejected(opts.respond).message).toBe("approval already resolved");
     });
   });
 });

--- a/src/gateway/server-methods/plugin-approval.ts
+++ b/src/gateway/server-methods/plugin-approval.ts
@@ -5,6 +5,7 @@ import {
   ErrorCodes,
   errorShape,
   formatValidationErrors,
+  validatePluginApprovalCancelParams,
   validatePluginApprovalRequestParams,
   validatePluginApprovalResolveParams,
 } from "../../../packages/gateway-protocol/src/index.js";
@@ -18,6 +19,7 @@ import type { ExecApprovalManager } from "../exec-approval-manager.js";
 import {
   bindApprovalRequesterMetadata,
   buildRequestedApprovalEvent,
+  handleApprovalCancel,
   handleApprovalResolve,
   handleApprovalWaitDecision,
   handlePendingApprovalRequest,
@@ -145,6 +147,41 @@ export function createPluginApprovalHandlers(
         inputId: (params as { id?: string }).id,
         client,
         respond,
+      });
+    },
+
+    "plugin.approval.cancel": async ({ params, respond, client, context }) => {
+      if (!validatePluginApprovalCancelParams(params)) {
+        respond(
+          false,
+          undefined,
+          errorShape(
+            ErrorCodes.INVALID_REQUEST,
+            `invalid plugin.approval.cancel params: ${formatValidationErrors(
+              validatePluginApprovalCancelParams.errors,
+            )}`,
+          ),
+        );
+        return;
+      }
+      await handleApprovalCancel({
+        manager,
+        inputId: params.id,
+        respond,
+        context,
+        client,
+        exposeAmbiguousPrefixError: false,
+        resolvedEventName: "plugin.approval.resolved",
+        buildResolvedEvent: ({ approvalId, resolvedBy, snapshot, nowMs }) => ({
+          id: approvalId,
+          decision: null,
+          resolvedBy,
+          ts: nowMs,
+          request: snapshot.request,
+        }),
+        forwardResolved: (resolvedEvent) =>
+          opts?.forwarder?.handlePluginApprovalResolved?.(resolvedEvent),
+        forwardResolvedErrorLabel: "plugin approvals: forward cancel failed",
       });
     },
 

--- a/src/infra/approval-view-model.types.ts
+++ b/src/infra/approval-view-model.types.ts
@@ -89,7 +89,7 @@ export type PluginApprovalPendingView = PluginApprovalViewBase & {
 /** Resolved plugin approval view with the recorded decision. */
 export type PluginApprovalResolvedView = PluginApprovalViewBase & {
   phase: "resolved";
-  decision: ExecApprovalDecision;
+  decision: ExecApprovalDecision | null;
   resolvedBy?: string | null;
 };
 

--- a/src/infra/plugin-approval-forwarder.test.ts
+++ b/src/infra/plugin-approval-forwarder.test.ts
@@ -356,6 +356,19 @@ describe("plugin approval forwarding", () => {
       expect(text).toContain("allowed once");
     });
 
+    it("delivers cancelled message to targets", async () => {
+      const deliver = vi.fn().mockResolvedValue([]);
+      const { forwarder } = createForwarder({ cfg: PLUGIN_TARGETS_CFG, deliver });
+
+      await registerPendingApproval(forwarder, deliver);
+
+      await forwarder.handlePluginApprovalResolved!(makePluginResolved({ decision: null }));
+      expect(deliver).toHaveBeenCalled();
+      const text = firstDeliveredPayload(deliver)?.text ?? "";
+      expect(text).toContain("Plugin approval");
+      expect(text).toContain("cancelled");
+    });
+
     it("reconstructs targets from resolved request snapshot when pending cache is missing", async () => {
       const deliver = vi.fn().mockResolvedValue([]);
       const { forwarder } = createForwarder({ cfg: PLUGIN_TARGETS_CFG, deliver });

--- a/src/infra/plugin-approvals.ts
+++ b/src/infra/plugin-approvals.ts
@@ -41,7 +41,7 @@ export type PluginApprovalRequest = {
 /** Resolved plugin approval decision plus optional request snapshot. */
 export type PluginApprovalResolved = {
   id: string;
-  decision: ExecApprovalDecision;
+  decision: ExecApprovalDecision | null;
   resolvedBy?: string | null;
   ts: number;
   request?: PluginApprovalRequestPayload;
@@ -67,14 +67,17 @@ export function resolvePluginApprovalTimeoutMs(value: unknown): number {
 }
 
 /** Format an approval decision for user-facing messages. */
-export function approvalDecisionLabel(decision: ExecApprovalDecision): string {
+export function approvalDecisionLabel(decision: ExecApprovalDecision | null | undefined): string {
   if (decision === "allow-once") {
     return "allowed once";
   }
   if (decision === "allow-always") {
     return "allowed always";
   }
-  return "denied";
+  if (decision === "deny") {
+    return "denied";
+  }
+  return "cancelled";
 }
 
 /** Resolve explicit plugin approval decisions or fall back to defaults. */

--- a/src/plugin-sdk/approval-renderers.test.ts
+++ b/src/plugin-sdk/approval-renderers.test.ts
@@ -230,6 +230,26 @@ describe("plugin-sdk/approval-renderers", () => {
         },
       },
     },
+    {
+      name: "builds plugin cancelled payloads",
+      payload: buildPluginApprovalResolvedReplyPayload({
+        resolved: {
+          id: "plugin-approval-cancelled",
+          decision: null,
+          resolvedBy: "gateway-client",
+          ts: 2_000,
+        },
+      }),
+      textExpected: (text: string) => expect(text).toContain("Plugin approval cancelled"),
+      presentationExpected: undefined,
+      channelDataExpected: {
+        execApproval: {
+          approvalId: "plugin-approval-cancelled",
+          approvalSlug: "plugin-a",
+          state: "resolved",
+        },
+      },
+    },
   ])("$name", ({ payload, textExpected, presentationExpected, channelDataExpected }) => {
     if (payload.text === undefined) {
       throw new Error("expected rendered approval text");


### PR DESCRIPTION
﻿Fixes #98576.

## Summary
- add `plugin.approval.cancel` as a requester-side terminal RPC for pending plugin approvals
- cancel accepted plugin approval ids when the agent run aborts during `waitDecision`
- broadcast nullable `plugin.approval.resolved` cleanup events and render cancelled plugin approvals safely
- cover cancel routing, runtime identity, forwarder/renderer behavior, and abort cleanup

## Tests
- `node scripts/run-with-env.mjs OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 OPENCLAW_GATEWAY_PROJECT_SHARDS=0 -- node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/server-methods/plugin-approval.test.ts src/gateway/method-scopes.test.ts --testTimeout=30000 --reporter=dot`
- `node scripts/run-with-env.mjs OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 -- node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts src/agents/agent-tools.before-tool-call.e2e.test.ts --testNamePattern="unblocks immediately when abort signal fires during waitDecision" --testTimeout=30000 --reporter=verbose`
- `node scripts/run-with-env.mjs OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 -- node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-tools.config.ts src/agents/tools/gateway.test.ts --testTimeout=30000 --reporter=dot`
- `node scripts/run-with-env.mjs OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 -- node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts src/agents/tools/gateway.test.ts src/plugin-sdk/approval-renderers.test.ts --testTimeout=30000 --reporter=dot` (agents file excluded by this config; renderer file ran)
- `node scripts/run-with-env.mjs OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 -- node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-slack.config.ts extensions/slack/src/approval-handler.runtime.test.ts --testTimeout=30000 --reporter=dot`
- `node scripts/run-with-env.mjs OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 -- node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-messaging.config.ts extensions/googlechat/src/approval-handler.runtime.test.ts --testTimeout=30000 --reporter=dot`
- `node scripts/run-with-env.mjs OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 -- node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-discord.config.ts extensions/discord/src/approval-handler.runtime.test.ts --testTimeout=30000 --reporter=dot`
- `node scripts/run-with-env.mjs OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 -- node scripts/run-vitest.mjs run --config test/vitest/vitest.infra.config.ts src/infra/plugin-approval-forwarder.test.ts --testTimeout=30000 --reporter=dot`
- `git diff --check`
- Attempted: `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo` timed out after 240s on this Windows/OneDrive checkout; lingering tsgo processes were stopped.
