### PR TITLE
fix(scripts): retry Docker E2E after rejected resource caps

### DIFF
--- a/scripts/lib/docker-e2e-container.sh
+++ b/scripts/lib/docker-e2e-container.sh
@@ -200,9 +200,12 @@ docker_e2e_resource_limit_error_file() {
   esac
   case "$text" in
     *cgroup*controller* | *cgroup*controllers* | *cgroup*not*supported* | \
+      *cgroup*is*not*mounted* | *cgroup*not*mounted* | \
       *Cgroup*controller* | *Cgroup*controllers* | *Cgroup*not*supported* | \
+      *Cgroup*is*not*mounted* | *Cgroup*not*mounted* | \
       *pids*not*available* | *pids*not*supported* | *cannot*set*pids*limit* | \
       *PIDs*not*available* | *PIDs*not*supported* | *cannot*set*PIDs*limit* | \
+      *NanoCPUs*can*not*be*set* | *CPU*CFS*scheduler* | \
       *cpu*controller* | *CPU*controller* | *memory*controller* | *Memory*controller* | \
       *resource*limit*not*supported* | *Resource*limit*not*supported* | \
       *oci*runtime*cgroup* | *OCI*runtime*cgroup*)

--- a/scripts/lib/docker-e2e-container.sh
+++ b/scripts/lib/docker-e2e-container.sh
@@ -212,6 +212,10 @@ docker_e2e_resource_limit_error_file() {
   return 1
 }
 
+docker_e2e_resource_limit_error_status() {
+  [ "${1:-}" = "125" ]
+}
+
 docker_e2e_resource_limit_stderr_file() {
   local template="${TMPDIR:-/tmp}/openclaw-docker-resource-limits.XXXXXX"
   local stderr_file=""
@@ -242,6 +246,30 @@ docker_e2e_remove_temp_file() {
   elif [ -x /usr/bin/rm ]; then
     /usr/bin/rm -f "$file"
   fi
+}
+
+docker_e2e_docker_run_option_consumes_value() {
+  case "$1" in
+    -a | --attach | --add-host | --annotation | --blkio-weight | --blkio-weight-device | \
+      --cap-add | --cap-drop | --cgroup-parent | --cidfile | --cpu-count | --cpu-percent | \
+      --cpu-period | --cpu-quota | --cpu-rt-period | --cpu-rt-runtime | -c | --cpu-shares | \
+      --cpus | --cpuset-cpus | --cpuset-mems | --device | --device-cgroup-rule | \
+      --device-read-bps | --device-read-iops | --device-write-bps | --device-write-iops | \
+      --dns | --dns-option | --dns-search | --domainname | --entrypoint | -e | --env | \
+      --env-file | --expose | --gpus | --group-add | --health-cmd | --health-interval | \
+      --health-retries | --health-start-interval | --health-start-period | --health-timeout | \
+      -h | --hostname | --ip | --ip6 | --ipc | --isolation | --kernel-memory | -l | --label | \
+      --label-file | --link | --link-local-ip | --log-driver | --log-opt | --mac-address | \
+      -m | --memory | --memory-reservation | --memory-swap | --memory-swappiness | --mount | \
+      --name | --network | --network-alias | --oom-score-adj | --pid | --pids-limit | \
+      --platform | -p | --publish | --pull | --restart | --runtime | --security-opt | \
+      --shm-size | --stop-signal | --stop-timeout | --storage-opt | --sysctl | --tmpfs | \
+      --ulimit | -u | --user | --userns | --uts | -v | --volume | --volume-driver | \
+      --volumes-from | -w | --workdir)
+      return 0
+      ;;
+  esac
+  return 1
 }
 
 docker_e2e_docker_run_created_container_refs() {
@@ -296,6 +324,19 @@ docker_e2e_docker_run_created_container_refs() {
           done <"$value"
         fi
         ;;
+      --)
+        break
+        ;;
+      --*=*)
+        ;;
+      -*)
+        if docker_e2e_docker_run_option_consumes_value "$arg" && [ "$#" -gt 0 ]; then
+          shift
+        fi
+        ;;
+      *)
+        break
+        ;;
     esac
   done
 }
@@ -335,7 +376,7 @@ docker_e2e_docker_run_with_resource_fallback() {
     status="$?"
   fi
   docker_e2e_print_file_stderr "$stderr_file" || true
-  if docker_e2e_resource_limit_error_file "$stderr_file"; then
+  if docker_e2e_resource_limit_error_status "$status" && docker_e2e_resource_limit_error_file "$stderr_file"; then
     export DOCKER_E2E_RESOURCE_LIMITS_RUNTIME_DISABLED=1
     echo "Docker run resource limits were rejected by this daemon; retrying without default --memory/--cpus/--pids-limit flags." >&2
     docker_e2e_cleanup_failed_resource_limited_run "$@"

--- a/scripts/lib/docker-e2e-container.sh
+++ b/scripts/lib/docker-e2e-container.sh
@@ -142,11 +142,7 @@ docker_e2e_docker_cmd() {
   if [ "${1:-}" = "run" ]; then
     shift
     docker_e2e_docker_run_resource_args "$@" || return $?
-    if [ "${#DOCKER_E2E_RUN_RESOURCE_ARGS[@]}" -gt 0 ]; then
-      docker_e2e_timeout_cmd "$timeout_value" docker run "${DOCKER_E2E_RUN_RESOURCE_ARGS[@]}" "$@"
-    else
-      docker_e2e_timeout_cmd "$timeout_value" docker run "$@"
-    fi
+    docker_e2e_docker_run_with_resource_fallback "$timeout_value" "$@"
     return
   fi
   docker_e2e_timeout_cmd "$timeout_value" docker "$@"
@@ -157,11 +153,7 @@ docker_e2e_docker_run_cmd() {
   if [ "${1:-}" = "run" ]; then
     shift
     docker_e2e_docker_run_resource_args "$@" || return $?
-    if [ "${#DOCKER_E2E_RUN_RESOURCE_ARGS[@]}" -gt 0 ]; then
-      docker_e2e_timeout_cmd "$timeout_value" docker run "${DOCKER_E2E_RUN_RESOURCE_ARGS[@]}" "$@"
-    else
-      docker_e2e_timeout_cmd "$timeout_value" docker run "$@"
-    fi
+    docker_e2e_docker_run_with_resource_fallback "$timeout_value" "$@"
     return
   fi
   docker_e2e_timeout_cmd "$timeout_value" docker "$@"
@@ -183,6 +175,176 @@ docker_e2e_resource_value_disabled() {
       ;;
   esac
   return 1
+}
+
+docker_e2e_resource_limits_runtime_disabled() {
+  [ "${DOCKER_E2E_RESOURCE_LIMITS_RUNTIME_DISABLED:-}" = "1" ]
+}
+
+docker_e2e_resource_limit_error_file() {
+  local stderr_file="$1"
+  local text=""
+  while IFS= read -r line || [ -n "$line" ]; do
+    text="${text}${line}
+"
+  done <"$stderr_file"
+  case "$text" in
+    *"OCI runtime create failed"* | *"oci runtime create failed"* | \
+      *"Error response from daemon"* | *"error response from daemon"* | \
+      *"failed to create task"* | *"failed to create shim task"* | \
+      *"runc create failed"* | *"crun:"*)
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+  case "$text" in
+    *cgroup*controller* | *cgroup*controllers* | *cgroup*not*supported* | \
+      *Cgroup*controller* | *Cgroup*controllers* | *Cgroup*not*supported* | \
+      *pids*not*available* | *pids*not*supported* | *cannot*set*pids*limit* | \
+      *PIDs*not*available* | *PIDs*not*supported* | *cannot*set*PIDs*limit* | \
+      *cpu*controller* | *CPU*controller* | *memory*controller* | *Memory*controller* | \
+      *resource*limit*not*supported* | *Resource*limit*not*supported* | \
+      *oci*runtime*cgroup* | *OCI*runtime*cgroup*)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+docker_e2e_resource_limit_stderr_file() {
+  local template="${TMPDIR:-/tmp}/openclaw-docker-resource-limits.XXXXXX"
+  local stderr_file=""
+  if command -v mktemp >/dev/null 2>&1; then
+    stderr_file="$(mktemp "$template")" || return $?
+  elif [ -x /usr/bin/mktemp ]; then
+    stderr_file="$(/usr/bin/mktemp "$template")" || return $?
+  else
+    echo "mktemp command not found; cannot securely capture Docker stderr" >&2
+    return 127
+  fi
+  chmod 600 "$stderr_file" 2>/dev/null || true
+  printf '%s\n' "$stderr_file"
+}
+
+docker_e2e_print_file_stderr() {
+  local file="$1"
+  local line
+  while IFS= read -r line || [ -n "$line" ]; do
+    printf '%s\n' "$line" >&2
+  done <"$file"
+}
+
+docker_e2e_remove_temp_file() {
+  local file="$1"
+  if command -v rm >/dev/null 2>&1; then
+    rm -f "$file"
+  elif [ -x /usr/bin/rm ]; then
+    /usr/bin/rm -f "$file"
+  fi
+}
+
+docker_e2e_docker_run_created_container_refs() {
+  DOCKER_E2E_RUN_CREATED_CONTAINER_REFS=()
+  DOCKER_E2E_RUN_CREATED_CONTAINER_CIDFILES=()
+  local arg
+  local value
+  while [ "$#" -gt 0 ]; do
+    arg="$1"
+    shift
+    case "$arg" in
+      --name)
+        if [ "$#" -gt 0 ]; then
+          DOCKER_E2E_RUN_CREATED_CONTAINER_REFS+=("$1")
+          shift
+        fi
+        ;;
+      --name=*)
+        value="${arg#--name=}"
+        if [ -n "$value" ]; then
+          DOCKER_E2E_RUN_CREATED_CONTAINER_REFS+=("$value")
+        fi
+        ;;
+      --cidfile)
+        if [ "$#" -gt 0 ]; then
+          value="$1"
+          shift
+          if [ -n "$value" ]; then
+            DOCKER_E2E_RUN_CREATED_CONTAINER_CIDFILES+=("$value")
+          fi
+          if [ -f "$value" ]; then
+            while IFS= read -r arg || [ -n "$arg" ]; do
+              if [ -n "$arg" ]; then
+                DOCKER_E2E_RUN_CREATED_CONTAINER_REFS+=("$arg")
+              fi
+              break
+            done <"$value"
+          fi
+        fi
+        ;;
+      --cidfile=*)
+        value="${arg#--cidfile=}"
+        if [ -n "$value" ]; then
+          DOCKER_E2E_RUN_CREATED_CONTAINER_CIDFILES+=("$value")
+        fi
+        if [ -n "$value" ] && [ -f "$value" ]; then
+          while IFS= read -r arg || [ -n "$arg" ]; do
+            if [ -n "$arg" ]; then
+              DOCKER_E2E_RUN_CREATED_CONTAINER_REFS+=("$arg")
+            fi
+            break
+          done <"$value"
+        fi
+        ;;
+    esac
+  done
+}
+
+docker_e2e_cleanup_failed_resource_limited_run() {
+  docker_e2e_docker_run_created_container_refs "$@"
+  local ref
+  for ref in "${DOCKER_E2E_RUN_CREATED_CONTAINER_REFS[@]}"; do
+    if [ -n "$ref" ]; then
+      docker_e2e_timeout_cmd "${OPENCLAW_DOCKER_E2E_CLEANUP_TIMEOUT:-30s}" docker rm -f "$ref" >/dev/null 2>&1 || true
+    fi
+  done
+  local cidfile
+  for cidfile in "${DOCKER_E2E_RUN_CREATED_CONTAINER_CIDFILES[@]}"; do
+    if [ -n "$cidfile" ]; then
+      docker_e2e_remove_temp_file "$cidfile"
+    fi
+  done
+}
+
+docker_e2e_docker_run_with_resource_fallback() {
+  local timeout_value="$1"
+  shift
+  if [ "${#DOCKER_E2E_RUN_RESOURCE_ARGS[@]}" -eq 0 ]; then
+    docker_e2e_timeout_cmd "$timeout_value" docker run "$@"
+    return
+  fi
+
+  local stderr_file=""
+  stderr_file="$(docker_e2e_resource_limit_stderr_file)" || return $?
+  local status=0
+  if docker_e2e_timeout_cmd "$timeout_value" docker run "${DOCKER_E2E_RUN_RESOURCE_ARGS[@]}" "$@" 2>"$stderr_file"; then
+    docker_e2e_print_file_stderr "$stderr_file" || true
+    docker_e2e_remove_temp_file "$stderr_file"
+    return 0
+  else
+    status="$?"
+  fi
+  docker_e2e_print_file_stderr "$stderr_file" || true
+  if docker_e2e_resource_limit_error_file "$stderr_file"; then
+    export DOCKER_E2E_RESOURCE_LIMITS_RUNTIME_DISABLED=1
+    echo "Docker run resource limits were rejected by this daemon; retrying without default --memory/--cpus/--pids-limit flags." >&2
+    docker_e2e_cleanup_failed_resource_limited_run "$@"
+    docker_e2e_remove_temp_file "$stderr_file"
+    docker_e2e_timeout_cmd "$timeout_value" docker run "$@"
+    return
+  fi
+  docker_e2e_remove_temp_file "$stderr_file"
+  return "$status"
 }
 
 docker_e2e_detect_available_cpus() {
@@ -240,7 +402,7 @@ docker_e2e_resolve_pids_limit() {
 
 docker_e2e_docker_run_resource_args() {
   DOCKER_E2E_RUN_RESOURCE_ARGS=()
-  if docker_e2e_resource_limits_disabled; then
+  if docker_e2e_resource_limits_disabled || docker_e2e_resource_limits_runtime_disabled; then
     return 0
   fi
 

--- a/scripts/lib/docker-e2e-package.sh
+++ b/scripts/lib/docker-e2e-package.sh
@@ -55,9 +55,12 @@ if ! declare -F docker_e2e_docker_run_resource_args >/dev/null 2>&1; then
     esac
     case "$text" in
       *cgroup*controller* | *cgroup*controllers* | *cgroup*not*supported* | \
+        *cgroup*is*not*mounted* | *cgroup*not*mounted* | \
         *Cgroup*controller* | *Cgroup*controllers* | *Cgroup*not*supported* | \
+        *Cgroup*is*not*mounted* | *Cgroup*not*mounted* | \
         *pids*not*available* | *pids*not*supported* | *cannot*set*pids*limit* | \
         *PIDs*not*available* | *PIDs*not*supported* | *cannot*set*PIDs*limit* | \
+        *NanoCPUs*can*not*be*set* | *CPU*CFS*scheduler* | \
         *cpu*controller* | *CPU*controller* | *memory*controller* | *Memory*controller* | \
         *resource*limit*not*supported* | *Resource*limit*not*supported* | \
         *oci*runtime*cgroup* | *OCI*runtime*cgroup*)

--- a/scripts/lib/docker-e2e-package.sh
+++ b/scripts/lib/docker-e2e-package.sh
@@ -32,6 +32,176 @@ if ! declare -F docker_e2e_docker_run_resource_args >/dev/null 2>&1; then
     return 1
   }
 
+  docker_e2e_resource_limits_runtime_disabled() {
+    [ "${DOCKER_E2E_RESOURCE_LIMITS_RUNTIME_DISABLED:-}" = "1" ]
+  }
+
+  docker_e2e_resource_limit_error_file() {
+    local stderr_file="$1"
+    local text=""
+    while IFS= read -r line || [ -n "$line" ]; do
+      text="${text}${line}
+"
+    done <"$stderr_file"
+    case "$text" in
+      *"OCI runtime create failed"* | *"oci runtime create failed"* | \
+        *"Error response from daemon"* | *"error response from daemon"* | \
+        *"failed to create task"* | *"failed to create shim task"* | \
+        *"runc create failed"* | *"crun:"*)
+        ;;
+      *)
+        return 1
+        ;;
+    esac
+    case "$text" in
+      *cgroup*controller* | *cgroup*controllers* | *cgroup*not*supported* | \
+        *Cgroup*controller* | *Cgroup*controllers* | *Cgroup*not*supported* | \
+        *pids*not*available* | *pids*not*supported* | *cannot*set*pids*limit* | \
+        *PIDs*not*available* | *PIDs*not*supported* | *cannot*set*PIDs*limit* | \
+        *cpu*controller* | *CPU*controller* | *memory*controller* | *Memory*controller* | \
+        *resource*limit*not*supported* | *Resource*limit*not*supported* | \
+        *oci*runtime*cgroup* | *OCI*runtime*cgroup*)
+        return 0
+        ;;
+    esac
+    return 1
+  }
+
+  docker_e2e_resource_limit_stderr_file() {
+    local template="${TMPDIR:-/tmp}/openclaw-docker-resource-limits.XXXXXX"
+    local stderr_file=""
+    if command -v mktemp >/dev/null 2>&1; then
+      stderr_file="$(mktemp "$template")" || return $?
+    elif [ -x /usr/bin/mktemp ]; then
+      stderr_file="$(/usr/bin/mktemp "$template")" || return $?
+    else
+      echo "mktemp command not found; cannot securely capture Docker stderr" >&2
+      return 127
+    fi
+    chmod 600 "$stderr_file" 2>/dev/null || true
+    printf '%s\n' "$stderr_file"
+  }
+
+  docker_e2e_print_file_stderr() {
+    local file="$1"
+    local line
+    while IFS= read -r line || [ -n "$line" ]; do
+      printf '%s\n' "$line" >&2
+    done <"$file"
+  }
+
+  docker_e2e_remove_temp_file() {
+    local file="$1"
+    if command -v rm >/dev/null 2>&1; then
+      rm -f "$file"
+    elif [ -x /usr/bin/rm ]; then
+      /usr/bin/rm -f "$file"
+    fi
+  }
+
+  docker_e2e_docker_run_created_container_refs() {
+    DOCKER_E2E_RUN_CREATED_CONTAINER_REFS=()
+    DOCKER_E2E_RUN_CREATED_CONTAINER_CIDFILES=()
+    local arg
+    local value
+    while [ "$#" -gt 0 ]; do
+      arg="$1"
+      shift
+      case "$arg" in
+        --name)
+          if [ "$#" -gt 0 ]; then
+            DOCKER_E2E_RUN_CREATED_CONTAINER_REFS+=("$1")
+            shift
+          fi
+          ;;
+        --name=*)
+          value="${arg#--name=}"
+          if [ -n "$value" ]; then
+            DOCKER_E2E_RUN_CREATED_CONTAINER_REFS+=("$value")
+          fi
+          ;;
+        --cidfile)
+          if [ "$#" -gt 0 ]; then
+            value="$1"
+            shift
+            if [ -n "$value" ]; then
+              DOCKER_E2E_RUN_CREATED_CONTAINER_CIDFILES+=("$value")
+            fi
+            if [ -f "$value" ]; then
+              while IFS= read -r arg || [ -n "$arg" ]; do
+                if [ -n "$arg" ]; then
+                  DOCKER_E2E_RUN_CREATED_CONTAINER_REFS+=("$arg")
+                fi
+                break
+              done <"$value"
+            fi
+          fi
+          ;;
+        --cidfile=*)
+          value="${arg#--cidfile=}"
+          if [ -n "$value" ]; then
+            DOCKER_E2E_RUN_CREATED_CONTAINER_CIDFILES+=("$value")
+          fi
+          if [ -n "$value" ] && [ -f "$value" ]; then
+            while IFS= read -r arg || [ -n "$arg" ]; do
+              if [ -n "$arg" ]; then
+                DOCKER_E2E_RUN_CREATED_CONTAINER_REFS+=("$arg")
+              fi
+              break
+            done <"$value"
+          fi
+          ;;
+      esac
+    done
+  }
+
+  docker_e2e_cleanup_failed_resource_limited_run() {
+    docker_e2e_docker_run_created_container_refs "$@"
+    local ref
+    for ref in "${DOCKER_E2E_RUN_CREATED_CONTAINER_REFS[@]}"; do
+      if [ -n "$ref" ]; then
+        docker_e2e_timeout_cmd "${OPENCLAW_DOCKER_E2E_CLEANUP_TIMEOUT:-30s}" docker rm -f "$ref" >/dev/null 2>&1 || true
+      fi
+    done
+    local cidfile
+    for cidfile in "${DOCKER_E2E_RUN_CREATED_CONTAINER_CIDFILES[@]}"; do
+      if [ -n "$cidfile" ]; then
+        docker_e2e_remove_temp_file "$cidfile"
+      fi
+    done
+  }
+
+  docker_e2e_docker_run_with_resource_fallback() {
+    local timeout_value="$1"
+    shift
+    if [ "${#DOCKER_E2E_RUN_RESOURCE_ARGS[@]}" -eq 0 ]; then
+      docker_e2e_timeout_cmd "$timeout_value" docker run "$@"
+      return
+    fi
+
+    local stderr_file=""
+    stderr_file="$(docker_e2e_resource_limit_stderr_file)" || return $?
+    local status=0
+    if docker_e2e_timeout_cmd "$timeout_value" docker run "${DOCKER_E2E_RUN_RESOURCE_ARGS[@]}" "$@" 2>"$stderr_file"; then
+      docker_e2e_print_file_stderr "$stderr_file" || true
+      docker_e2e_remove_temp_file "$stderr_file"
+      return 0
+    else
+      status="$?"
+    fi
+    docker_e2e_print_file_stderr "$stderr_file" || true
+    if docker_e2e_resource_limit_error_file "$stderr_file"; then
+      export DOCKER_E2E_RESOURCE_LIMITS_RUNTIME_DISABLED=1
+      echo "Docker run resource limits were rejected by this daemon; retrying without default --memory/--cpus/--pids-limit flags." >&2
+      docker_e2e_cleanup_failed_resource_limited_run "$@"
+      docker_e2e_remove_temp_file "$stderr_file"
+      docker_e2e_timeout_cmd "$timeout_value" docker run "$@"
+      return
+    fi
+    docker_e2e_remove_temp_file "$stderr_file"
+    return "$status"
+  }
+
   docker_e2e_detect_available_cpus() {
     if [ -n "${OPENCLAW_DOCKER_E2E_AVAILABLE_CPUS:-}" ]; then
       printf '%s\n' "$OPENCLAW_DOCKER_E2E_AVAILABLE_CPUS"
@@ -87,7 +257,7 @@ if ! declare -F docker_e2e_docker_run_resource_args >/dev/null 2>&1; then
 
   docker_e2e_docker_run_resource_args() {
     DOCKER_E2E_RUN_RESOURCE_ARGS=()
-    if docker_e2e_resource_limits_disabled; then
+    if docker_e2e_resource_limits_disabled || docker_e2e_resource_limits_runtime_disabled; then
       return 0
     fi
 
@@ -109,45 +279,38 @@ if ! declare -F docker_e2e_docker_run_resource_args >/dev/null 2>&1; then
   }
 fi
 if ! declare -F docker_e2e_docker_run_cmd >/dev/null 2>&1; then
-  docker_e2e_docker_run_cmd() {
-    if [ "${1:-}" = "run" ]; then
+  if ! declare -F docker_e2e_timeout_cmd >/dev/null 2>&1; then
+    docker_e2e_timeout_cmd() {
+      local timeout_value="$1"
       shift
-      docker_e2e_docker_run_resource_args "$@" || return $?
-      if declare -F docker_e2e_timeout_cmd >/dev/null 2>&1; then
-        if [ "${#DOCKER_E2E_RUN_RESOURCE_ARGS[@]}" -gt 0 ]; then
-          docker_e2e_timeout_cmd "${DOCKER_COMMAND_TIMEOUT:-${OPENCLAW_DOCKER_E2E_RUN_TIMEOUT:-3600s}}" docker run "${DOCKER_E2E_RUN_RESOURCE_ARGS[@]}" "$@"
+      local timeout_bin=""
+      if command -v timeout >/dev/null 2>&1; then
+        timeout_bin="timeout"
+      elif command -v gtimeout >/dev/null 2>&1; then
+        timeout_bin="gtimeout"
+      fi
+      if [ -n "$timeout_bin" ]; then
+        if "$timeout_bin" --kill-after=1s 1s true >/dev/null 2>&1; then
+          "$timeout_bin" --kill-after=30s "$timeout_value" "$@"
         else
-          docker_e2e_timeout_cmd "${DOCKER_COMMAND_TIMEOUT:-${OPENCLAW_DOCKER_E2E_RUN_TIMEOUT:-3600s}}" docker run "$@"
+          "$timeout_bin" "$timeout_value" "$@"
         fi
         return
       fi
-      if [ "${#DOCKER_E2E_RUN_RESOURCE_ARGS[@]}" -gt 0 ]; then
-        set -- run "${DOCKER_E2E_RUN_RESOURCE_ARGS[@]}" "$@"
-      else
-        set -- run "$@"
-      fi
-    fi
-    if declare -F docker_e2e_timeout_cmd >/dev/null 2>&1; then
-      docker_e2e_timeout_cmd "${DOCKER_COMMAND_TIMEOUT:-${OPENCLAW_DOCKER_E2E_RUN_TIMEOUT:-3600s}}" docker "$@"
-      return
-    fi
+      echo "timeout command not found; cannot bound Docker run after ${timeout_value}" >&2
+      return 127
+    }
+  fi
+
+  docker_e2e_docker_run_cmd() {
     local timeout_value="${DOCKER_COMMAND_TIMEOUT:-${OPENCLAW_DOCKER_E2E_RUN_TIMEOUT:-3600s}}"
-    local timeout_bin=""
-    if command -v timeout >/dev/null 2>&1; then
-      timeout_bin="timeout"
-    elif command -v gtimeout >/dev/null 2>&1; then
-      timeout_bin="gtimeout"
-    fi
-    if [ -n "$timeout_bin" ]; then
-      if "$timeout_bin" --kill-after=1s 1s true >/dev/null 2>&1; then
-        "$timeout_bin" --kill-after=30s "$timeout_value" docker "$@"
-      else
-        "$timeout_bin" "$timeout_value" docker "$@"
-      fi
+    if [ "${1:-}" = "run" ]; then
+      shift
+      docker_e2e_docker_run_resource_args "$@" || return $?
+      docker_e2e_docker_run_with_resource_fallback "$timeout_value" "$@"
       return
     fi
-    echo "timeout command not found; cannot bound Docker run after ${timeout_value}" >&2
-    return 127
+    docker_e2e_timeout_cmd "$timeout_value" docker "$@"
   }
 fi
 

--- a/scripts/lib/docker-e2e-package.sh
+++ b/scripts/lib/docker-e2e-package.sh
@@ -67,6 +67,10 @@ if ! declare -F docker_e2e_docker_run_resource_args >/dev/null 2>&1; then
     return 1
   }
 
+  docker_e2e_resource_limit_error_status() {
+    [ "${1:-}" = "125" ]
+  }
+
   docker_e2e_resource_limit_stderr_file() {
     local template="${TMPDIR:-/tmp}/openclaw-docker-resource-limits.XXXXXX"
     local stderr_file=""
@@ -97,6 +101,30 @@ if ! declare -F docker_e2e_docker_run_resource_args >/dev/null 2>&1; then
     elif [ -x /usr/bin/rm ]; then
       /usr/bin/rm -f "$file"
     fi
+  }
+
+  docker_e2e_docker_run_option_consumes_value() {
+    case "$1" in
+      -a | --attach | --add-host | --annotation | --blkio-weight | --blkio-weight-device | \
+        --cap-add | --cap-drop | --cgroup-parent | --cidfile | --cpu-count | --cpu-percent | \
+        --cpu-period | --cpu-quota | --cpu-rt-period | --cpu-rt-runtime | -c | --cpu-shares | \
+        --cpus | --cpuset-cpus | --cpuset-mems | --device | --device-cgroup-rule | \
+        --device-read-bps | --device-read-iops | --device-write-bps | --device-write-iops | \
+        --dns | --dns-option | --dns-search | --domainname | --entrypoint | -e | --env | \
+        --env-file | --expose | --gpus | --group-add | --health-cmd | --health-interval | \
+        --health-retries | --health-start-interval | --health-start-period | --health-timeout | \
+        -h | --hostname | --ip | --ip6 | --ipc | --isolation | --kernel-memory | -l | --label | \
+        --label-file | --link | --link-local-ip | --log-driver | --log-opt | --mac-address | \
+        -m | --memory | --memory-reservation | --memory-swap | --memory-swappiness | --mount | \
+        --name | --network | --network-alias | --oom-score-adj | --pid | --pids-limit | \
+        --platform | -p | --publish | --pull | --restart | --runtime | --security-opt | \
+        --shm-size | --stop-signal | --stop-timeout | --storage-opt | --sysctl | --tmpfs | \
+        --ulimit | -u | --user | --userns | --uts | -v | --volume | --volume-driver | \
+        --volumes-from | -w | --workdir)
+        return 0
+        ;;
+    esac
+    return 1
   }
 
   docker_e2e_docker_run_created_container_refs() {
@@ -151,6 +179,19 @@ if ! declare -F docker_e2e_docker_run_resource_args >/dev/null 2>&1; then
             done <"$value"
           fi
           ;;
+        --)
+          break
+          ;;
+        --*=*)
+          ;;
+        -*)
+          if docker_e2e_docker_run_option_consumes_value "$arg" && [ "$#" -gt 0 ]; then
+            shift
+          fi
+          ;;
+        *)
+          break
+          ;;
       esac
     done
   }
@@ -190,7 +231,7 @@ if ! declare -F docker_e2e_docker_run_resource_args >/dev/null 2>&1; then
       status="$?"
     fi
     docker_e2e_print_file_stderr "$stderr_file" || true
-    if docker_e2e_resource_limit_error_file "$stderr_file"; then
+    if docker_e2e_resource_limit_error_status "$status" && docker_e2e_resource_limit_error_file "$stderr_file"; then
       export DOCKER_E2E_RESOURCE_LIMITS_RUNTIME_DISABLED=1
       echo "Docker run resource limits were rejected by this daemon; retrying without default --memory/--cpus/--pids-limit flags." >&2
       docker_e2e_cleanup_failed_resource_limited_run "$@"

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -1298,6 +1298,62 @@ docker_e2e_docker_cmd run second
     }
   });
 
+  it("retries Docker runs when rootless daemons reject NanoCPUs", () => {
+    const workDir = mkdtempSync(join(tmpdir(), "openclaw-docker-rootless-nanocpus-"));
+
+    try {
+      const binDir = join(workDir, "bin");
+      mkdirSync(binDir);
+      writeFileSync(
+        join(binDir, "timeout"),
+        `#!/bin/bash
+set -euo pipefail
+if [[ "$1" = "--kill-after=1s" ]]; then
+  exit 0
+fi
+shift 2
+"$@"
+`,
+      );
+      chmodSync(join(binDir, "timeout"), 0o755);
+      const rootDir = process.cwd();
+      const script = `
+set -euo pipefail
+ROOT_DIR=${shellQuote(rootDir)}
+TMPDIR=${shellQuote(workDir)}
+export ROOT_DIR TMPDIR
+export PATH="$TMPDIR/bin:$PATH"
+unset OPENCLAW_DOCKER_E2E_DISABLE_RESOURCE_LIMITS
+unset OPENCLAW_DOCKER_E2E_MEMORY OPENCLAW_DOCKER_E2E_CPUS OPENCLAW_DOCKER_E2E_PIDS_LIMIT
+export OPENCLAW_DOCKER_E2E_AVAILABLE_CPUS=32
+
+docker() {
+  printf "%s\\n" "$*" >>"$TMPDIR/docker-seen"
+  if [[ "$*" == *"--cpus"* ]]; then
+    echo "docker: Error response from daemon: NanoCPUs can not be set, as your kernel does not support CPU CFS scheduler or the cgroup is not mounted" >&2
+    return 125
+  fi
+}
+export -f docker
+
+source "$ROOT_DIR/scripts/lib/docker-e2e-container.sh"
+
+docker_e2e_docker_cmd run demo 2>"$TMPDIR/stderr"
+
+mapfile -t docker_seen <"$TMPDIR/docker-seen"
+[[ "\${docker_seen[0]}" = "run --memory 8g --cpus 16 --pids-limit 2048 demo" ]]
+[[ "\${docker_seen[1]}" = "run demo" ]]
+[[ "\${#docker_seen[@]}" = "2" ]]
+grep -Fq "NanoCPUs can not be set" "$TMPDIR/stderr"
+grep -Fq "retrying without default" "$TMPDIR/stderr"
+`;
+
+      execFileSync("bash", ["-lc", script], { encoding: "utf8" });
+    } finally {
+      rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
   it("ignores Docker-like command arguments after the image when cleaning up a resource-limit retry", () => {
     const workDir = mkdtempSync(join(tmpdir(), "openclaw-docker-cgroup-image-boundary-"));
 
@@ -1876,6 +1932,72 @@ mapfile -t docker_seen <"$TMPDIR/docker-seen"
 [[ "\${docker_seen[3]}" = "run --name package-gateway --cidfile $TMPDIR/package.cid demo" ]]
 [[ "\${docker_seen[4]}" = "run second" ]]
 [[ ! -e "$TMPDIR/package.cid" ]]
+`;
+
+      execFileSync("bash", ["-lc", script], { encoding: "utf8" });
+    } finally {
+      rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  it("retries package-backed Docker runs when rootless daemons reject NanoCPUs", () => {
+    const workDir = mkdtempSync(join(tmpdir(), "openclaw-docker-package-rootless-nanocpus-"));
+
+    try {
+      const binDir = join(workDir, "bin");
+      mkdirSync(binDir);
+      writeFileSync(
+        join(binDir, "gtimeout"),
+        `#!/bin/bash
+set -euo pipefail
+if [[ "$1" = "--kill-after=1s" ]]; then
+  exit 0
+fi
+shift 2
+"$@"
+`,
+      );
+      chmodSync(join(binDir, "gtimeout"), 0o755);
+      const rootDir = process.cwd();
+      const script = `
+set -euo pipefail
+ROOT_DIR=${shellQuote(rootDir)}
+TMPDIR=${shellQuote(workDir)}
+export ROOT_DIR TMPDIR
+export PATH="$TMPDIR/bin"
+export OPENCLAW_DOCKER_E2E_RUN_TIMEOUT=15s
+export OPENCLAW_DOCKER_E2E_AVAILABLE_CPUS=8
+unset OPENCLAW_DOCKER_E2E_DISABLE_RESOURCE_LIMITS
+unset OPENCLAW_DOCKER_E2E_MEMORY OPENCLAW_DOCKER_E2E_CPUS OPENCLAW_DOCKER_E2E_PIDS_LIMIT
+
+dirname() {
+  /usr/bin/dirname "$@"
+}
+
+docker_e2e_docker_cmd() {
+  return 0
+}
+
+docker() {
+  printf "%s\\n" "$*" >>"$TMPDIR/docker-seen"
+  if [[ "$*" == *"--cpus"* ]]; then
+    echo "docker: Error response from daemon: NanoCPUs can not be set, as your kernel does not support CPU CFS scheduler or the cgroup is not mounted" >&2
+    return 125
+  fi
+}
+export -f docker_e2e_docker_cmd docker
+
+source "$ROOT_DIR/scripts/lib/docker-e2e-package.sh"
+
+docker_e2e_docker_run_cmd run demo 2>"$TMPDIR/stderr"
+
+mapfile -t docker_seen <"$TMPDIR/docker-seen"
+[[ "\${docker_seen[0]}" = "run --memory 8g --cpus 8 --pids-limit 2048 demo" ]]
+[[ "\${docker_seen[1]}" = "run demo" ]]
+[[ "\${#docker_seen[@]}" = "2" ]]
+stderr="$(<"$TMPDIR/stderr")"
+[[ "$stderr" = *"NanoCPUs can not be set"* ]]
+[[ "$stderr" = *"retrying without default"* ]]
 `;
 
       execFileSync("bash", ["-lc", script], { encoding: "utf8" });

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -1236,6 +1236,124 @@ OPENCLAW_DOCKER_E2E_DISABLE_RESOURCE_LIMITS=1 docker_e2e_docker_cmd run demo
     }
   });
 
+  it("retries Docker runs without default resource limits when cgroups reject them", () => {
+    const workDir = mkdtempSync(join(tmpdir(), "openclaw-docker-cgroup-fallback-"));
+
+    try {
+      const binDir = join(workDir, "bin");
+      mkdirSync(binDir);
+      writeFileSync(
+        join(binDir, "timeout"),
+        `#!/bin/bash
+set -euo pipefail
+if [[ "$1" = "--kill-after=1s" ]]; then
+  exit 0
+fi
+shift 2
+"$@"
+`,
+      );
+      chmodSync(join(binDir, "timeout"), 0o755);
+      const rootDir = process.cwd();
+      const script = `
+set -euo pipefail
+ROOT_DIR=${shellQuote(rootDir)}
+TMPDIR=${shellQuote(workDir)}
+export ROOT_DIR TMPDIR
+export PATH="$TMPDIR/bin:$PATH"
+unset OPENCLAW_DOCKER_E2E_DISABLE_RESOURCE_LIMITS
+unset OPENCLAW_DOCKER_E2E_MEMORY OPENCLAW_DOCKER_E2E_CPUS OPENCLAW_DOCKER_E2E_PIDS_LIMIT
+export OPENCLAW_DOCKER_E2E_AVAILABLE_CPUS=32
+
+docker() {
+  printf "%s\\n" "$*" >>"$TMPDIR/docker-seen"
+  if [[ "$*" == *"--pids-limit"* ]]; then
+    printf 'gateway-cid\\n' >"$TMPDIR/gateway.cid"
+    echo "OCI runtime create failed: crun: controller pids is not available" >&2
+    return 126
+  fi
+  if [[ "$*" == "run --name gateway-test --cidfile $TMPDIR/gateway.cid demo" && -e "$TMPDIR/gateway.cid" ]]; then
+    echo "cidfile exists" >&2
+    return 125
+  fi
+}
+export -f docker
+
+source "$ROOT_DIR/scripts/lib/docker-e2e-container.sh"
+
+docker_e2e_docker_cmd run --name gateway-test --cidfile "$TMPDIR/gateway.cid" demo
+docker_e2e_docker_cmd run second
+
+[[ "$(sed -n '1p' "$TMPDIR/docker-seen")" = "run --memory 8g --cpus 16 --pids-limit 2048 --name gateway-test --cidfile $TMPDIR/gateway.cid demo" ]]
+[[ "$(sed -n '2p' "$TMPDIR/docker-seen")" = "rm -f gateway-test" ]]
+[[ "$(sed -n '3p' "$TMPDIR/docker-seen")" = "rm -f gateway-cid" ]]
+[[ "$(sed -n '4p' "$TMPDIR/docker-seen")" = "run --name gateway-test --cidfile $TMPDIR/gateway.cid demo" ]]
+[[ "$(sed -n '5p' "$TMPDIR/docker-seen")" = "run second" ]]
+[[ ! -e "$TMPDIR/gateway.cid" ]]
+`;
+
+      execFileSync("bash", ["-lc", script], { encoding: "utf8" });
+    } finally {
+      rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns non-resource Docker run failures without retrying", () => {
+    const workDir = mkdtempSync(join(tmpdir(), "openclaw-docker-run-failure-"));
+
+    try {
+      const binDir = join(workDir, "bin");
+      mkdirSync(binDir);
+      writeFileSync(
+        join(binDir, "timeout"),
+        `#!/bin/bash
+set -euo pipefail
+if [[ "$1" = "--kill-after=1s" ]]; then
+  exit 0
+fi
+shift 2
+"$@"
+`,
+      );
+      chmodSync(join(binDir, "timeout"), 0o755);
+      const rootDir = process.cwd();
+      const script = `
+set -euo pipefail
+ROOT_DIR=${shellQuote(rootDir)}
+TMPDIR=${shellQuote(workDir)}
+export ROOT_DIR TMPDIR
+export PATH="$TMPDIR/bin:$PATH"
+unset OPENCLAW_DOCKER_E2E_DISABLE_RESOURCE_LIMITS
+unset OPENCLAW_DOCKER_E2E_MEMORY OPENCLAW_DOCKER_E2E_CPUS OPENCLAW_DOCKER_E2E_PIDS_LIMIT
+export OPENCLAW_DOCKER_E2E_AVAILABLE_CPUS=32
+
+docker() {
+  printf "%s\\n" "$*" >>"$TMPDIR/docker-seen"
+  echo "image not found" >&2
+  return 42
+}
+export -f docker
+
+source "$ROOT_DIR/scripts/lib/docker-e2e-container.sh"
+
+set +e
+docker_e2e_docker_cmd run missing 2>"$TMPDIR/stderr"
+status="$?"
+set -e
+
+mapfile -t docker_seen <"$TMPDIR/docker-seen"
+[[ "$status" = "42" ]]
+[[ "\${docker_seen[0]}" = "run --memory 8g --cpus 16 --pids-limit 2048 missing" ]]
+[[ "\${#docker_seen[@]}" = "1" ]]
+[[ "$(<"$TMPDIR/stderr")" = *"image not found"* ]]
+`;
+
+      execFileSync("bash", ["-lc", script], { encoding: "utf8" });
+    } finally {
+      rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
   it("rejects invalid Docker run pids limits before invoking docker", () => {
     const workDir = mkdtempSync(join(tmpdir(), "openclaw-docker-resource-pids-"));
 
@@ -1572,6 +1690,78 @@ docker_e2e_docker_run_cmd run demo
 
 [[ "$(<"$TMPDIR/timeout-seen")" = "gtimeout:--kill-after=30s 15s|docker run --memory 8g --cpus 8 --pids-limit 2048 demo" ]]
 [[ "$(<"$TMPDIR/docker-seen")" = "run --memory 8g --cpus 8 --pids-limit 2048 demo" ]]
+`;
+
+      execFileSync("bash", ["-lc", script], { encoding: "utf8" });
+    } finally {
+      rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  it("retries package-backed Docker runs without default resource limits when cgroups reject them", () => {
+    const workDir = mkdtempSync(join(tmpdir(), "openclaw-docker-package-cgroup-fallback-"));
+
+    try {
+      const binDir = join(workDir, "bin");
+      mkdirSync(binDir);
+      writeFileSync(
+        join(binDir, "gtimeout"),
+        `#!/bin/bash
+set -euo pipefail
+if [[ "$1" = "--kill-after=1s" ]]; then
+  exit 0
+fi
+shift 2
+"$@"
+`,
+      );
+      chmodSync(join(binDir, "gtimeout"), 0o755);
+      const rootDir = process.cwd();
+      const script = `
+set -euo pipefail
+ROOT_DIR=${shellQuote(rootDir)}
+TMPDIR=${shellQuote(workDir)}
+export ROOT_DIR TMPDIR
+export PATH="$TMPDIR/bin"
+export OPENCLAW_DOCKER_E2E_RUN_TIMEOUT=15s
+export OPENCLAW_DOCKER_E2E_AVAILABLE_CPUS=8
+unset OPENCLAW_DOCKER_E2E_DISABLE_RESOURCE_LIMITS
+unset OPENCLAW_DOCKER_E2E_MEMORY OPENCLAW_DOCKER_E2E_CPUS OPENCLAW_DOCKER_E2E_PIDS_LIMIT
+
+dirname() {
+  /usr/bin/dirname "$@"
+}
+
+docker_e2e_docker_cmd() {
+  return 0
+}
+
+docker() {
+  printf "%s\\n" "$*" >>"$TMPDIR/docker-seen"
+  if [[ "$*" == *"--pids-limit"* ]]; then
+    printf 'package-cid\\n' >"$TMPDIR/package.cid"
+    echo "OCI runtime create failed: crun: cgroup controller pids is not available" >&2
+    return 126
+  fi
+  if [[ "$*" == "run --name package-gateway --cidfile $TMPDIR/package.cid demo" && -e "$TMPDIR/package.cid" ]]; then
+    echo "cidfile exists" >&2
+    return 125
+  fi
+}
+export -f docker_e2e_docker_cmd docker
+
+source "$ROOT_DIR/scripts/lib/docker-e2e-package.sh"
+
+docker_e2e_docker_run_cmd run --name package-gateway --cidfile "$TMPDIR/package.cid" demo
+docker_e2e_docker_run_cmd run second
+
+mapfile -t docker_seen <"$TMPDIR/docker-seen"
+[[ "\${docker_seen[0]}" = "run --memory 8g --cpus 8 --pids-limit 2048 --name package-gateway --cidfile $TMPDIR/package.cid demo" ]]
+[[ "\${docker_seen[1]}" = "rm -f package-gateway" ]]
+[[ "\${docker_seen[2]}" = "rm -f package-cid" ]]
+[[ "\${docker_seen[3]}" = "run --name package-gateway --cidfile $TMPDIR/package.cid demo" ]]
+[[ "\${docker_seen[4]}" = "run second" ]]
+[[ ! -e "$TMPDIR/package.cid" ]]
 `;
 
       execFileSync("bash", ["-lc", script], { encoding: "utf8" });

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -1270,7 +1270,7 @@ docker() {
   if [[ "$*" == *"--pids-limit"* ]]; then
     printf 'gateway-cid\\n' >"$TMPDIR/gateway.cid"
     echo "OCI runtime create failed: crun: controller pids is not available" >&2
-    return 126
+    return 125
   fi
   if [[ "$*" == "run --name gateway-test --cidfile $TMPDIR/gateway.cid demo" && -e "$TMPDIR/gateway.cid" ]]; then
     echo "cidfile exists" >&2
@@ -1290,6 +1290,120 @@ docker_e2e_docker_cmd run second
 [[ "$(sed -n '4p' "$TMPDIR/docker-seen")" = "run --name gateway-test --cidfile $TMPDIR/gateway.cid demo" ]]
 [[ "$(sed -n '5p' "$TMPDIR/docker-seen")" = "run second" ]]
 [[ ! -e "$TMPDIR/gateway.cid" ]]
+`;
+
+      execFileSync("bash", ["-lc", script], { encoding: "utf8" });
+    } finally {
+      rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  it("ignores Docker-like command arguments after the image when cleaning up a resource-limit retry", () => {
+    const workDir = mkdtempSync(join(tmpdir(), "openclaw-docker-cgroup-image-boundary-"));
+
+    try {
+      const binDir = join(workDir, "bin");
+      mkdirSync(binDir);
+      writeFileSync(
+        join(binDir, "timeout"),
+        `#!/bin/bash
+set -euo pipefail
+if [[ "$1" = "--kill-after=1s" ]]; then
+  exit 0
+fi
+shift 2
+"$@"
+`,
+      );
+      chmodSync(join(binDir, "timeout"), 0o755);
+      const rootDir = process.cwd();
+      const script = `
+set -euo pipefail
+ROOT_DIR=${shellQuote(rootDir)}
+TMPDIR=${shellQuote(workDir)}
+export ROOT_DIR TMPDIR
+export PATH="$TMPDIR/bin:$PATH"
+unset OPENCLAW_DOCKER_E2E_DISABLE_RESOURCE_LIMITS
+unset OPENCLAW_DOCKER_E2E_MEMORY OPENCLAW_DOCKER_E2E_CPUS OPENCLAW_DOCKER_E2E_PIDS_LIMIT
+export OPENCLAW_DOCKER_E2E_AVAILABLE_CPUS=32
+
+docker() {
+  printf "%s\\n" "$*" >>"$TMPDIR/docker-seen"
+  if [[ "$*" == *"--pids-limit"* ]]; then
+    echo "OCI runtime create failed: crun: controller pids is not available" >&2
+    return 125
+  fi
+}
+export -f docker
+
+source "$ROOT_DIR/scripts/lib/docker-e2e-container.sh"
+
+docker_e2e_docker_cmd run demo worker --name command-container --cidfile "$TMPDIR/command.cid"
+
+mapfile -t docker_seen <"$TMPDIR/docker-seen"
+[[ "\${docker_seen[0]}" = "run --memory 8g --cpus 16 --pids-limit 2048 demo worker --name command-container --cidfile $TMPDIR/command.cid" ]]
+[[ "\${docker_seen[1]}" = "run demo worker --name command-container --cidfile $TMPDIR/command.cid" ]]
+[[ "\${#docker_seen[@]}" = "2" ]]
+`;
+
+      execFileSync("bash", ["-lc", script], { encoding: "utf8" });
+    } finally {
+      rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not retry container command failures that only print resource-limit text", () => {
+    const workDir = mkdtempSync(join(tmpdir(), "openclaw-docker-cgroup-container-stderr-"));
+
+    try {
+      const binDir = join(workDir, "bin");
+      mkdirSync(binDir);
+      writeFileSync(
+        join(binDir, "timeout"),
+        `#!/bin/bash
+set -euo pipefail
+if [[ "$1" = "--kill-after=1s" ]]; then
+  exit 0
+fi
+shift 2
+"$@"
+`,
+      );
+      chmodSync(join(binDir, "timeout"), 0o755);
+      const rootDir = process.cwd();
+      const script = `
+set -euo pipefail
+ROOT_DIR=${shellQuote(rootDir)}
+TMPDIR=${shellQuote(workDir)}
+export ROOT_DIR TMPDIR
+export PATH="$TMPDIR/bin:$PATH"
+unset OPENCLAW_DOCKER_E2E_DISABLE_RESOURCE_LIMITS
+unset OPENCLAW_DOCKER_E2E_MEMORY OPENCLAW_DOCKER_E2E_CPUS OPENCLAW_DOCKER_E2E_PIDS_LIMIT
+export OPENCLAW_DOCKER_E2E_AVAILABLE_CPUS=32
+
+docker() {
+  printf "%s\\n" "$*" >>"$TMPDIR/docker-seen"
+  echo "OCI runtime create failed: crun: controller pids is not available" >&2
+  return 126
+}
+export -f docker
+
+source "$ROOT_DIR/scripts/lib/docker-e2e-container.sh"
+
+set +e
+docker_e2e_docker_cmd run demo 2>"$TMPDIR/stderr"
+status="$?"
+set -e
+
+mapfile -t docker_seen <"$TMPDIR/docker-seen"
+[[ "$status" = "126" ]]
+[[ "\${docker_seen[0]}" = "run --memory 8g --cpus 16 --pids-limit 2048 demo" ]]
+[[ "\${#docker_seen[@]}" = "1" ]]
+grep -Fq "OCI runtime create failed: crun: controller pids is not available" "$TMPDIR/stderr"
+if grep -Fq "retrying without default" "$TMPDIR/stderr"; then
+  echo "container stderr caused an unsafe retry" >&2
+  exit 1
+fi
 `;
 
       execFileSync("bash", ["-lc", script], { encoding: "utf8" });
@@ -1741,7 +1855,7 @@ docker() {
   if [[ "$*" == *"--pids-limit"* ]]; then
     printf 'package-cid\\n' >"$TMPDIR/package.cid"
     echo "OCI runtime create failed: crun: cgroup controller pids is not available" >&2
-    return 126
+    return 125
   fi
   if [[ "$*" == "run --name package-gateway --cidfile $TMPDIR/package.cid demo" && -e "$TMPDIR/package.cid" ]]; then
     echo "cidfile exists" >&2
@@ -1762,6 +1876,139 @@ mapfile -t docker_seen <"$TMPDIR/docker-seen"
 [[ "\${docker_seen[3]}" = "run --name package-gateway --cidfile $TMPDIR/package.cid demo" ]]
 [[ "\${docker_seen[4]}" = "run second" ]]
 [[ ! -e "$TMPDIR/package.cid" ]]
+`;
+
+      execFileSync("bash", ["-lc", script], { encoding: "utf8" });
+    } finally {
+      rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  it("ignores package-backed Docker-like command arguments after the image when cleaning up a resource-limit retry", () => {
+    const workDir = mkdtempSync(join(tmpdir(), "openclaw-docker-package-image-boundary-"));
+
+    try {
+      const binDir = join(workDir, "bin");
+      mkdirSync(binDir);
+      writeFileSync(
+        join(binDir, "gtimeout"),
+        `#!/bin/bash
+set -euo pipefail
+if [[ "$1" = "--kill-after=1s" ]]; then
+  exit 0
+fi
+shift 2
+"$@"
+`,
+      );
+      chmodSync(join(binDir, "gtimeout"), 0o755);
+      const rootDir = process.cwd();
+      const script = `
+set -euo pipefail
+ROOT_DIR=${shellQuote(rootDir)}
+TMPDIR=${shellQuote(workDir)}
+export ROOT_DIR TMPDIR
+export PATH="$TMPDIR/bin"
+export OPENCLAW_DOCKER_E2E_RUN_TIMEOUT=15s
+export OPENCLAW_DOCKER_E2E_AVAILABLE_CPUS=8
+unset OPENCLAW_DOCKER_E2E_DISABLE_RESOURCE_LIMITS
+unset OPENCLAW_DOCKER_E2E_MEMORY OPENCLAW_DOCKER_E2E_CPUS OPENCLAW_DOCKER_E2E_PIDS_LIMIT
+
+dirname() {
+  /usr/bin/dirname "$@"
+}
+
+docker_e2e_docker_cmd() {
+  return 0
+}
+
+docker() {
+  printf "%s\\n" "$*" >>"$TMPDIR/docker-seen"
+  if [[ "$*" == *"--pids-limit"* ]]; then
+    echo "OCI runtime create failed: crun: cgroup controller pids is not available" >&2
+    return 125
+  fi
+}
+export -f docker_e2e_docker_cmd docker
+
+source "$ROOT_DIR/scripts/lib/docker-e2e-package.sh"
+
+docker_e2e_docker_run_cmd run demo worker --name package-command --cidfile "$TMPDIR/package-command.cid"
+
+mapfile -t docker_seen <"$TMPDIR/docker-seen"
+[[ "\${docker_seen[0]}" = "run --memory 8g --cpus 8 --pids-limit 2048 demo worker --name package-command --cidfile $TMPDIR/package-command.cid" ]]
+[[ "\${docker_seen[1]}" = "run demo worker --name package-command --cidfile $TMPDIR/package-command.cid" ]]
+[[ "\${#docker_seen[@]}" = "2" ]]
+`;
+
+      execFileSync("bash", ["-lc", script], { encoding: "utf8" });
+    } finally {
+      rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not retry package-backed container command failures that only print resource-limit text", () => {
+    const workDir = mkdtempSync(join(tmpdir(), "openclaw-docker-package-container-stderr-"));
+
+    try {
+      const binDir = join(workDir, "bin");
+      mkdirSync(binDir);
+      writeFileSync(
+        join(binDir, "gtimeout"),
+        `#!/bin/bash
+set -euo pipefail
+if [[ "$1" = "--kill-after=1s" ]]; then
+  exit 0
+fi
+shift 2
+"$@"
+`,
+      );
+      chmodSync(join(binDir, "gtimeout"), 0o755);
+      const rootDir = process.cwd();
+      const script = `
+set -euo pipefail
+ROOT_DIR=${shellQuote(rootDir)}
+TMPDIR=${shellQuote(workDir)}
+export ROOT_DIR TMPDIR
+export PATH="$TMPDIR/bin"
+export OPENCLAW_DOCKER_E2E_RUN_TIMEOUT=15s
+export OPENCLAW_DOCKER_E2E_AVAILABLE_CPUS=8
+unset OPENCLAW_DOCKER_E2E_DISABLE_RESOURCE_LIMITS
+unset OPENCLAW_DOCKER_E2E_MEMORY OPENCLAW_DOCKER_E2E_CPUS OPENCLAW_DOCKER_E2E_PIDS_LIMIT
+
+dirname() {
+  /usr/bin/dirname "$@"
+}
+
+docker_e2e_docker_cmd() {
+  return 0
+}
+
+docker() {
+  printf "%s\\n" "$*" >>"$TMPDIR/docker-seen"
+  echo "OCI runtime create failed: crun: cgroup controller pids is not available" >&2
+  return 126
+}
+export -f docker_e2e_docker_cmd docker
+
+source "$ROOT_DIR/scripts/lib/docker-e2e-package.sh"
+
+set +e
+docker_e2e_docker_run_cmd run demo 2>"$TMPDIR/stderr"
+status="$?"
+set -e
+
+mapfile -t docker_seen <"$TMPDIR/docker-seen"
+[[ "$status" = "126" ]]
+[[ "\${docker_seen[0]}" = "run --memory 8g --cpus 8 --pids-limit 2048 demo" ]]
+[[ "\${#docker_seen[@]}" = "1" ]]
+stderr="$(<"$TMPDIR/stderr")"
+[[ "$stderr" = *"OCI runtime create failed: crun: cgroup controller pids is not available"* ]]
+if [[ "$stderr" = *"retrying without default"* ]]; then
+  echo "container stderr caused an unsafe package fallback retry" >&2
+  exit 1
+fi
 `;
 
       execFileSync("bash", ["-lc", script], { encoding: "utf8" });


### PR DESCRIPTION
Fixes #98601

## What Problem This Solves

Docker E2E and package-backed Docker lanes can fail before the test container starts when the local Docker daemon accepts the command but rejects OpenClaw's default `--memory`, `--cpus`, or `--pids-limit` cgroup controls during container create/start.

This can happen on nested, rootless, or otherwise constrained Docker hosts. Before this change, operators had to know to set `OPENCLAW_DOCKER_E2E_DISABLE_RESOURCE_LIMITS=1` manually; failed named-container and `--cidfile` attempts could also leave artifacts that blocked the retry.

## Why This Change Was Made

The Docker run helpers now retry once without OpenClaw-injected default resource caps only when Docker itself reports a daemon/runtime resource-limit create failure. The retry path:

- preserves stderr for the original failure;
- keeps ordinary Docker and container-command failures unchanged;
- caches the runtime resource-cap disable for later runs in the same process;
- cleans failed `--name` / `--cidfile` container artifacts before retrying;
- stops cleanup parsing at Docker's image boundary, so `--name` or `--cidfile` inside the container command cannot trigger cleanup of an unrelated container.

The package fallback helper receives the same behavior because it can run without the shared container helper in package-backed lanes. Explicit user-provided Docker run arguments remain on retry; only OpenClaw's injected default caps are removed.

## User Impact

Developers and CI operators can run Docker E2E lanes on more host configurations without manually disabling resource limits. Normal hosts keep the existing capped Docker runs, and non-resource failures such as missing images or container-command exits still fail immediately without retrying as a different command.

## Evidence

Duplicate search before opening:

- `gh pr list -R openclaw/openclaw --state all --search "Docker cgroup resource limits pids limit fallback" --limit 20` returned only older unrelated sandbox/low-memory PRs (#41437, #39463).
- `gh issue list -R openclaw/openclaw --state all --search "Docker cgroup resource limits pids limit fallback" --limit 20` returned no issues.
- Searching the exact new warning text returned no existing issue or PR for this behavior.

Local checks:

- `bash -n scripts/lib/docker-e2e-container.sh`
- `bash -n scripts/lib/docker-e2e-package.sh`
- `node scripts/check-docker-e2e-boundaries.mjs`
- `node_modules/.bin/oxlint.cmd scripts/lib/docker-e2e-container.sh scripts/lib/docker-e2e-package.sh test/scripts/docker-build-helper.test.ts`
- `node_modules/.bin/oxfmt.cmd --check test/scripts/docker-build-helper.test.ts`
- `git diff --check`
- `python .agents/skills/autoreview/scripts/autoreview --mode local`

Focused local Vitest on Windows with Git Bash and `/tmp` temp paths:

```text
node_modules/.bin/vitest.cmd run --config test/vitest/vitest.tooling-docker.config.ts test/scripts/docker-build-helper.test.ts -t "retries Docker runs without default resource limits when cgroups reject them|retries Docker runs when rootless daemons reject NanoCPUs|ignores Docker-like command arguments after the image|does not retry container command failures that only print resource-limit text|retries package-backed Docker runs without default resource limits when cgroups reject them|retries package-backed Docker runs when rootless daemons reject NanoCPUs|ignores package-backed Docker-like command arguments after the image|does not retry package-backed container command failures that only print resource-limit text"

Test Files  1 passed (1)
Tests  8 passed | 160 skipped (168)
```

Real constrained-daemon proof on 122.51.21.218:

- Host: `VM-0-5-ubuntu`
- Kernel: `Linux 5.15.0-170-generic x86_64`
- System Docker after runtime recovery: `server=29.6.1 cgroup=2 driver=overlayfs cgroupDriver=systemd`
- Method: started a temporary rootless Docker daemon as a systemd user service, built a local `FROM scratch` BusyBox image without pulling from a registry, and ran the helper against that real daemon.
- Control: the system Docker daemon accepted both plain and resource-limited runs, proving the host was otherwise healthy.
- Repro daemon: the temporary rootless Docker daemon accepted the plain run but rejected the resource-limited run with Docker's real `NanoCPUs` cgroup error.

```text
SYSTEMD_ROOTLESS_READY=ok
SYSTEMD_ROOTLESS_INFO=server=29.6.1 rootless=[name=seccomp,profile=builtin name=rootless name=cgroupns] cgroup=2 driver=fuse-overlayfs cgroupDriver=systemd
SYSTEMD_ROOTLESS_PLAIN_STATUS=0
SYSTEMD_ROOTLESS_LIMITED_STATUS=125
SYSTEMD_ROOTLESS_LIMITED_ERR=docker: Error response from daemon: NanoCPUs can not be set, as your kernel does not support CPU CFS scheduler or the cgroup is not mounted
```

Helper proof against the same rootless daemon after this patch:

```text
REMOTE_ENV=host-server=29.6.1 cgroup=2 driver=overlayfs cgroupDriver=systemd
ROOTLESS_ENV=server=29.6.1 rootless=[name=seccomp,profile=builtin name=rootless name=cgroupns] cgroup=2 driver=fuse-overlayfs cgroupDriver=systemd
HELPER_STATUS=0
HELPER_ERR=docker: Error response from daemon: NanoCPUs can not be set, as your kernel does not support CPU CFS scheduler or the cgroup is not mounted
HELPER_ERR=Run 'docker run --help' for more information
HELPER_ERR=Docker run resource limits were rejected by this daemon; retrying without default --memory/--cpus/--pids-limit flags.
```

Cleanup after the remote proof:

```text
DOCKER_STATUS=server=29.6.1 containers=0 running=0 images=0
LEFTOVER_TEST_PROCS=
DISK_ROOT=40G total 16G avail 60% used
```
