### PR TITLE
fix(telegram): add mdl_idx callback fallback for long model names

### DIFF
--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -2795,7 +2795,7 @@ export const registerTelegramHandlers = ({
       }
 
       // Model selection callback handler (mdl_prov, mdl_list_*, mdl_sel_*, mdl_back)
-      const modelCallback = parseModelCallbackData(data);
+      let modelCallback = parseModelCallbackData(data);
       if (modelCallback) {
         if (
           !(await isTelegramModelCallbackAuthorized({
@@ -2935,6 +2935,34 @@ export const registerTelegramHandlers = ({
             throw new TelegramRetryableCallbackError(err);
           }
           return;
+        }
+
+        // mdl_idx/{provider}/{i} — fallback when the model name plus the
+        // mdl_sel encoding exceeds Telegram's 64-byte callback_data limit.
+        // Re-derive the same locale-sorted list buildModelsKeyboard uses so
+        // the 0-based index points at the same row the user pressed.
+        if (modelCallback.type === "select-index") {
+          const modelSet = byProvider.get(modelCallback.provider);
+          const sorted = modelSet
+            ? [...modelSet].toSorted((left, right) => left.localeCompare(right))
+            : [];
+          const resolvedModel = sorted[modelCallback.index];
+          if (!resolvedModel) {
+            try {
+              await editMessageWithButtons(
+                `❌ Model index ${modelCallback.index + 1} for "${modelCallback.provider}" is no longer available.`,
+                [],
+              );
+            } catch (err) {
+              throw new TelegramRetryableCallbackError(err);
+            }
+            return;
+          }
+          modelCallback = {
+            type: "select",
+            provider: modelCallback.provider,
+            model: resolvedModel,
+          };
         }
 
         if (modelCallback.type === "select") {

--- a/extensions/telegram/src/model-buttons.test.ts
+++ b/extensions/telegram/src/model-buttons.test.ts
@@ -33,6 +33,7 @@ describe("parseModelCallbackData", () => {
         "mdl_sel/anthropic/claude-3-7-sonnet",
         { type: "select", model: "anthropic/claude-3-7-sonnet" },
       ],
+      ["mdl_idx/ollama/3", { type: "select-index", provider: "ollama", index: 2 }],
       ["  mdl_prov  ", { type: "providers" }],
     ] as const;
     for (const [input, expected] of cases) {
@@ -50,6 +51,10 @@ describe("parseModelCallbackData", () => {
       "mdl_list_openai_9007199254740993",
       "mdl_sel_noslash",
       "mdl_sel/",
+      "mdl_idx/openai",
+      "mdl_idx/openai/abc",
+      "mdl_idx//3",
+      "mdl_idx/openai/0",
     ];
     for (const input of invalid) {
       expect(parseModelCallbackData(input), input).toBeNull();
@@ -127,6 +132,30 @@ describe("buildModelSelectionCallbackData", () => {
   it("returns null when even compact callback exceeds Telegram limit", () => {
     const tooLongModel = "x".repeat(80);
     expect(buildModelSelectionCallbackData({ provider: "openai", model: tooLongModel })).toBeNull();
+  });
+
+  it("falls back to index encoding when standard and compact callbacks exceed the limit", () => {
+    const tooLongModel = "x".repeat(80);
+    expect(
+      buildModelSelectionCallbackData({
+        provider: "openai",
+        model: tooLongModel,
+        sortedIndex: 4,
+      }),
+    ).toBe("mdl_idx/openai/5");
+  });
+
+  it("returns null when no encoding fits even with an index", () => {
+    // Provider name alone is so long that even the index callback overflows.
+    const tooLongProvider = "p".repeat(80);
+    const tooLongModel = "x".repeat(80);
+    expect(
+      buildModelSelectionCallbackData({
+        provider: tooLongProvider,
+        model: tooLongModel,
+        sortedIndex: 0,
+      }),
+    ).toBeNull();
   });
 });
 
@@ -495,12 +524,10 @@ describe("large model lists (OpenRouter-scale)", () => {
     }
   });
 
-  it("skips models that would exceed callback_data limit", () => {
-    const models = [
-      "short-model",
-      "this-is-an-extremely-long-model-name-that-definitely-exceeds-the-sixty-four-byte-limit",
-      "another-short",
-    ];
+  it("uses index fallback when a model name exceeds callback_data limit", () => {
+    const longModel =
+      "this-is-an-extremely-long-model-name-that-definitely-exceeds-the-sixty-four-byte-limit";
+    const models = ["short-model", longModel, "another-short"];
     const result = buildModelsKeyboard({
       provider: "openrouter",
       models,
@@ -508,10 +535,32 @@ describe("large model lists (OpenRouter-scale)", () => {
       totalPages: 1,
     });
 
-    // Should have 2 model buttons (skipping the long one) + back
+    // All three models render. The middle model falls back to a
+    // mdl_idx/{provider}/{sortedIndex+1} callback because the standard
+    // (mdl_sel_) and compact (mdl_sel/) encodings both exceed 64 bytes.
     const modelButtons = result.filter((row) => !row[0]?.callback_data.startsWith("mdl_back"));
-    expect(modelButtons.length).toBe(2);
+    expect(modelButtons.length).toBe(3);
     expect(modelButtons[0]?.[0]?.text).toBe("short-model");
-    expect(modelButtons[1]?.[0]?.text).toBe("another-short");
+    expect(modelButtons[0]?.[0]?.callback_data).toBe("mdl_sel_openrouter/short-model");
+    expect(modelButtons[1]?.[0]?.callback_data).toBe("mdl_idx/openrouter/2");
+    expect(modelButtons[2]?.[0]?.text).toBe("another-short");
+    expect(modelButtons[2]?.[0]?.callback_data).toBe("mdl_sel_openrouter/another-short");
+  });
+
+  it("drops a model only when every encoding (standard, compact, index) overflows", () => {
+    const tooLongProvider = "p".repeat(80);
+    const longModel = "x".repeat(80);
+    const result = buildModelsKeyboard({
+      provider: tooLongProvider,
+      models: ["short", longModel],
+      currentPage: 1,
+      totalPages: 1,
+    });
+
+    // Only "short" survives: index fallback still overflows because the
+    // provider name alone is longer than 64 bytes.
+    const modelButtons = result.filter((row) => !row[0]?.callback_data.startsWith("mdl_back"));
+    expect(modelButtons.length).toBe(1);
+    expect(modelButtons[0]?.[0]?.text).toBe("short");
   });
 });

--- a/extensions/telegram/src/model-buttons.ts
+++ b/extensions/telegram/src/model-buttons.ts
@@ -6,6 +6,9 @@
  * - mdl_list_{prov}_{pg}  - show models for provider (page N, 1-indexed)
  * - mdl_sel_{provider/id} - select model (standard)
  * - mdl_sel/{model}       - select model (compact fallback when standard is >64 bytes)
+ * - mdl_idx/{provider}/{i}- select model by sorted-list index (fallback when
+ *                          even the compact encoding exceeds 64 bytes; the
+ *                          handler re-derives the same sort order)
  * - mdl_back              - back to providers list
  */
 import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
@@ -17,6 +20,7 @@ export type ParsedModelCallback =
   | { type: "providers" }
   | { type: "list"; provider: string; page: number }
   | { type: "select"; provider?: string; model: string }
+  | { type: "select-index"; provider: string; index: number }
   | { type: "back" };
 
 export type ProviderInfo = {
@@ -47,6 +51,7 @@ const CALLBACK_PREFIX = {
   list: "mdl_list_",
   selectStandard: "mdl_sel_",
   selectCompact: "mdl_sel/",
+  selectedIndex: "mdl_idx/",
 } as const;
 
 /**
@@ -85,6 +90,16 @@ export function parseModelCallbackData(data: string): ParsedModelCallback | null
     }
   }
 
+  // mdl_idx/{provider}/{index} (index fallback for names too long to fit)
+  const indexSelMatch = trimmed.match(/^mdl_idx\/([^/]+)\/(\d+)$/);
+  if (indexSelMatch) {
+    const [, provider, indexStr] = indexSelMatch;
+    const index = parseStrictPositiveInteger(indexStr);
+    if (provider && index !== undefined) {
+      return { type: "select-index", provider, index: index - 1 };
+    }
+  }
+
   // mdl_sel_{provider/model}
   const selMatch = trimmed.match(/^mdl_sel_(.+)$/);
   if (selMatch) {
@@ -107,13 +122,29 @@ export function parseModelCallbackData(data: string): ParsedModelCallback | null
 export function buildModelSelectionCallbackData(params: {
   provider: string;
   model: string;
+  /**
+   * 0-based index of the model within the provider's locale-sorted model list.
+   * When the standard and compact encodings both exceed Telegram's 64-byte
+   * callback_data limit, an index-based fallback is emitted so the model is
+   * still selectable. The caller re-derives the same sort order on resolution.
+   */
+  sortedIndex?: number;
 }): string | null {
   const fullCallbackData = `${CALLBACK_PREFIX.selectStandard}${params.provider}/${params.model}`;
   if (fitsTelegramCallbackData(fullCallbackData)) {
     return fullCallbackData;
   }
   const compactCallbackData = `${CALLBACK_PREFIX.selectCompact}${params.model}`;
-  return fitsTelegramCallbackData(compactCallbackData) ? compactCallbackData : null;
+  if (fitsTelegramCallbackData(compactCallbackData)) {
+    return compactCallbackData;
+  }
+  if (params.sortedIndex !== undefined && params.sortedIndex >= 0) {
+    const indexCallbackData = `${CALLBACK_PREFIX.selectedIndex}${params.provider}/${params.sortedIndex + 1}`;
+    if (fitsTelegramCallbackData(indexCallbackData)) {
+      return indexCallbackData;
+    }
+  }
+  return null;
 }
 
 export function resolveModelSelection(params: {
@@ -210,9 +241,20 @@ export function buildModelsKeyboard(params: ModelsKeyboardParams): ButtonRow[] {
   const endIndex = Math.min(startIndex + pageSize, models.length);
   const pageModels = models.slice(startIndex, endIndex);
 
-  for (const model of pageModels) {
-    const callbackData = buildModelSelectionCallbackData({ provider, model });
-    // Skip models that still exceed Telegram's callback_data limit.
+  for (let pageOffset = 0; pageOffset < pageModels.length; pageOffset++) {
+    const model = pageModels[pageOffset];
+    // pageModels is a slice of the sorted `models` list, so the global index
+    // is startIndex + pageOffset. Used as a 64-byte-safe callback fallback so
+    // long model names (e.g. namespaced Ollama tags) stay selectable.
+    const sortedIndex = startIndex + pageOffset;
+    const callbackData = buildModelSelectionCallbackData({
+      provider,
+      model,
+      sortedIndex,
+    });
+    // Only drop if every encoding (standard, compact, index) exceeds the
+    // Telegram callback_data limit. In practice the index fallback always
+    // fits, so this branch now only guards against pathological providers.
     if (!callbackData) {
       continue;
     }


### PR DESCRIPTION
## What Problem This Solves

Telegram inline button `callback_data` is capped at 64 bytes. Namespaced Ollama tags (e.g. `xentriom/gemma-4-12B-agentic-fable5-composer2.5-v2:latest`) plus the `mdl_sel_` or `mdl_sel/` prefix overflow that cap, so `buildModelsKeyboard` silently dropped those rows from the /model picker. The user saw a model count that did not match the buttons, and could never select the long-named model.

Fixes #98221

## Why This Change Was Made

The existing fallback stack (standard → compact) handled real-world IDs from OpenRouter / Bedrock but still failed for Ollama tags with provider namespacing (e.g. `xentriom/...:latest`). Dropping the button was the wrong default: every row in the picker should be selectable. A 1-indexed position in the locale-sorted model list fits in 64 bytes for any realistic provider name and total model count, and the handler can re-derive the same sort order (`[...modelSet].toSorted(localeCompare)`) to map the index back to the exact model the user pressed.

## User Impact

Ollama / OpenRouter models with long, namespaced tags now appear and are selectable in the Telegram `/model` picker. Previously the count said "12 models" but only 11 buttons rendered, and the missing one was often the one the user wanted.

## Evidence

- Local: `npx vitest run extensions/telegram/src/model-buttons.test.ts` → 29 tests pass (added 4 new cases for `mdl_idx` parser + index fallback in `buildModelSelectionCallbackData` / `buildModelsKeyboard`; updated the prior "skips models that would exceed callback_data limit" test which now asserts the index fallback instead).
- Lint: `node scripts/run-oxlint.mjs extensions/telegram/src/{model-buttons.ts,bot-handlers.runtime.ts,model-buttons.test.ts}` clean.
- Typecheck: `node scripts/run-tsgo.mjs -p extensions/telegram/tsconfig.json` shows no new errors (the two reported errors in `bot-message-dispatch.ts` are pre-existing on `main` and unrelated to this change).