### PR TITLE
fix: keep approval prompts open for pending items

### DIFF
--- a/apps/macos/Sources/OpenClaw/ExecApprovals.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovals.swift
@@ -85,7 +85,7 @@ enum ExecAsk: String, CaseIterable, Codable, Identifiable {
     }
 }
 
-enum ExecApprovalDecision: String, Codable, Equatable {
+enum ExecApprovalDecision: String, Codable, Equatable, Sendable {
     case allowOnce = "allow-once"
     case allowAlways = "allow-always"
     case deny

--- a/apps/macos/Sources/OpenClaw/ExecApprovalsGatewayPrompter.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovalsGatewayPrompter.swift
@@ -70,7 +70,7 @@ final class ExecApprovalsGatewayPrompter {
                     timeoutMs: 10000)
                 return
             }
-            guard let decision = ExecApprovalsPromptPresenter.prompt(request.request) else {
+            guard let decision = await ExecApprovalsPromptPresenter.prompt(request.request) else {
                 return
             }
             try await GatewayConnection.shared.requestVoid(

--- a/apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift
@@ -5,7 +5,7 @@ import Foundation
 import OpenClawKit
 import OSLog
 
-struct ExecApprovalPromptRequest: Codable {
+struct ExecApprovalPromptRequest: Codable, Sendable {
     var command: String
     var cwd: String?
     var host: String?
@@ -300,7 +300,12 @@ final class ExecApprovalsPromptServer {
 
 enum ExecApprovalsPromptPresenter {
     @MainActor
-    static func prompt(_ request: ExecApprovalPromptRequest) -> ExecApprovalDecision? {
+    static func prompt(_ request: ExecApprovalPromptRequest) async -> ExecApprovalDecision? {
+        await ExecApprovalsPromptQueue.prompt(request)
+    }
+
+    @MainActor
+    fileprivate static func presentNow(_ request: ExecApprovalPromptRequest) -> ExecApprovalDecision? {
         NSApp.activate(ignoringOtherApps: true)
         let alert = NSAlert()
         alert.alertStyle = .warning
@@ -466,6 +471,73 @@ enum ExecApprovalsPromptPresenter {
 }
 
 @MainActor
+private enum ExecApprovalsPromptQueue {
+    typealias Presenter = @MainActor (ExecApprovalPromptRequest) async -> ExecApprovalDecision?
+
+    private struct PendingPrompt {
+        let request: ExecApprovalPromptRequest
+        let continuation: CheckedContinuation<ExecApprovalDecision?, Never>
+    }
+
+    private static var pending: [PendingPrompt] = []
+    private static var isPresenting = false
+    private static var presenter: Presenter = { request in
+        ExecApprovalsPromptPresenter.presentNow(request)
+    }
+
+    static func prompt(_ request: ExecApprovalPromptRequest) async -> ExecApprovalDecision? {
+        await withCheckedContinuation { continuation in
+            self.pending.append(PendingPrompt(request: request, continuation: continuation))
+            self.presentNextIfNeeded()
+        }
+    }
+
+    private static func presentNextIfNeeded() {
+        guard !self.isPresenting else { return }
+        guard !self.pending.isEmpty else { return }
+
+        self.isPresenting = true
+        let next = self.pending.removeFirst()
+        Task { @MainActor in
+            let decision = await self.presenter(next.request)
+            next.continuation.resume(returning: decision)
+            self.isPresenting = false
+            self.presentNextIfNeeded()
+        }
+    }
+
+    #if DEBUG
+    static func withPresenter(
+        _ presenter: @escaping Presenter,
+        run body: @MainActor () async -> Void) async
+    {
+        let previousPresenter = self.presenter
+        self.pending.removeAll(keepingCapacity: false)
+        self.isPresenting = false
+        self.presenter = presenter
+        defer {
+            self.presenter = previousPresenter
+            self.pending.removeAll(keepingCapacity: false)
+            self.isPresenting = false
+        }
+        await body()
+    }
+    #endif
+}
+
+#if DEBUG
+extension ExecApprovalsPromptPresenter {
+    @MainActor
+    static func _testWithPresenter(
+        _ presenter: @escaping @MainActor (ExecApprovalPromptRequest) async -> ExecApprovalDecision?,
+        run body: @MainActor () async -> Void) async
+    {
+        await ExecApprovalsPromptQueue.withPresenter(presenter, run: body)
+    }
+}
+#endif
+
+@MainActor
 private enum ExecHostExecutor {
     private typealias ExecApprovalContext = ExecApprovalEvaluation
 
@@ -492,7 +564,7 @@ private enum ExecHostExecutor {
         case .allow:
             break
         case .requiresPrompt:
-            guard let decision = ExecApprovalsPromptPresenter.prompt(
+            guard let decision = await ExecApprovalsPromptPresenter.prompt(
                 ExecApprovalPromptRequest(
                     command: context.displayCommand,
                     cwd: request.cwd,

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
@@ -754,20 +754,18 @@ actor MacNodeRuntime {
         }
 
         if requiresAsk, !approvedByAsk {
-            let promptDecision = await MainActor.run {
-                ExecApprovalsPromptPresenter.prompt(
-                    ExecApprovalPromptRequest(
-                        command: context.displayCommand,
-                        cwd: params.cwd,
-                        host: "node",
-                        security: context.security.rawValue,
-                        ask: context.ask.rawValue,
-                        agentId: context.agentId,
-                        resolvedPath: context.resolution?.resolvedPath,
-                        sessionKey: context.sessionKey,
-                        allowedDecisions: ExecApprovalPromptRequest.allowedDecisions(
-                            forAsk: context.ask.rawValue)))
-            }
+            let promptDecision = await ExecApprovalsPromptPresenter.prompt(
+                ExecApprovalPromptRequest(
+                    command: context.displayCommand,
+                    cwd: params.cwd,
+                    host: "node",
+                    security: context.security.rawValue,
+                    ask: context.ask.rawValue,
+                    agentId: context.agentId,
+                    resolvedPath: context.resolution?.resolvedPath,
+                    sessionKey: context.sessionKey,
+                    allowedDecisions: ExecApprovalPromptRequest.allowedDecisions(
+                        forAsk: context.ask.rawValue)))
             guard let decision = promptDecision else {
                 await self.emitExecEvent(
                     "exec.denied",

--- a/apps/macos/Tests/OpenClawIPCTests/ExecApprovalPromptLayoutTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecApprovalPromptLayoutTests.swift
@@ -122,6 +122,41 @@ struct ExecApprovalPromptLayoutTests {
         #expect(withDeny == .deny)
     }
 
+    @Test func `exec approval prompts are serialized while a prompt is active`() async {
+        var presentedCommands: [String] = []
+        var firstContinuation: CheckedContinuation<ExecApprovalDecision?, Never>?
+
+        await ExecApprovalsPromptPresenter._testWithPresenter({ request in
+            presentedCommands.append(request.command)
+            if request.command == "first" {
+                return await withCheckedContinuation { continuation in
+                    firstContinuation = continuation
+                }
+            }
+            return .deny
+        }, run: {
+            let firstTask = Task { @MainActor in
+                await ExecApprovalsPromptPresenter.prompt(ExecApprovalPromptRequest(command: "first"))
+            }
+            await Task.yield()
+
+            let secondTask = Task { @MainActor in
+                await ExecApprovalsPromptPresenter.prompt(ExecApprovalPromptRequest(command: "second"))
+            }
+            await Task.yield()
+
+            #expect(presentedCommands == ["first"])
+
+            firstContinuation?.resume(returning: .allowOnce)
+            let firstDecision = await firstTask.value
+            let secondDecision = await secondTask.value
+
+            #expect(firstDecision == .allowOnce)
+            #expect(secondDecision == .deny)
+            #expect(presentedCommands == ["first", "second"])
+        })
+    }
+
     @Test func `accessory view reserves nonzero alert layout space`() {
         let accessory = ExecApprovalsPromptPresenter.buildAccessoryView(
             ExecApprovalPromptRequest(

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -518,7 +518,10 @@ export type AppViewState = {
     handleNostrProfileSave: () => Promise<void>;
     handleNostrProfileImport: () => Promise<void>;
     handleNostrProfileToggleAdvanced: () => void;
-    handleExecApprovalDecision: (decision: "allow-once" | "allow-always" | "deny") => Promise<void>;
+    handleExecApprovalDecision: (
+      decision: "allow-once" | "allow-always" | "deny",
+      approvalId?: string,
+    ) => Promise<void>;
     handleGatewayUrlConfirm: () => void;
     handleGatewayUrlCancel: () => void;
     handleConfigLoad: () => Promise<void>;

--- a/ui/src/ui/app.exec-approval.test.ts
+++ b/ui/src/ui/app.exec-approval.test.ts
@@ -56,7 +56,12 @@ describe("OpenClawApp exec approval decisions", () => {
   });
 
   it("dismisses the active approval after same-decision idempotent success", async () => {
-    const request = vi.fn<RequestFn>(async () => ({ ok: true }));
+    const request = vi.fn<RequestFn>(async (method) => {
+      if (method === "exec.approval.list" || method === "plugin.approval.list") {
+        return [];
+      }
+      return { ok: true };
+    });
     const app = await createApp(request);
 
     await app.handleExecApprovalDecision("allow-once");
@@ -68,6 +73,64 @@ describe("OpenClawApp exec approval decisions", () => {
     expect(app.execApprovalQueue).toEqual([]);
     expect(app.execApprovalError).toBeNull();
     expect(app.execApprovalBusy).toBe(false);
+  });
+
+  it("keeps the approval window backed by the remaining queue after approving the active item", async () => {
+    const request = vi.fn<RequestFn>(async () => ({ ok: true }));
+    const active = createExecApproval({ id: "approval-active", createdAtMs: 2000 });
+    const queued = createExecApproval({ id: "approval-queued", createdAtMs: 1000 });
+    const app = await createApp(request, [active, queued]);
+
+    await app.handleExecApprovalDecision("allow-once", "approval-active");
+
+    expect(request).toHaveBeenCalledWith("exec.approval.resolve", {
+      id: "approval-active",
+      decision: "allow-once",
+    });
+    expect(app.execApprovalQueue).toEqual([queued]);
+    expect(app.execApprovalError).toBeNull();
+    expect(app.execApprovalBusy).toBe(false);
+  });
+
+  it("resolves the requested approval id instead of assuming the queue head", async () => {
+    const request = vi.fn<RequestFn>(async () => ({ ok: true }));
+    const active = createExecApproval({ id: "approval-active", createdAtMs: 2000 });
+    const queued = createExecApproval({ id: "approval-queued", createdAtMs: 1000 });
+    const app = await createApp(request, [active, queued]);
+
+    await app.handleExecApprovalDecision("deny", "approval-queued");
+
+    expect(request).toHaveBeenCalledWith("exec.approval.resolve", {
+      id: "approval-queued",
+      decision: "deny",
+    });
+    expect(app.execApprovalQueue).toEqual([active]);
+    expect(app.execApprovalBusy).toBe(false);
+  });
+
+  it("refreshes pending approvals after the last local approval is dismissed", async () => {
+    const active = createExecApproval({ id: "approval-active", createdAtMs: 3000 });
+    const queued = createExecApproval({ id: "approval-queued", createdAtMs: 2000 });
+    const request = vi.fn<RequestFn>(async (method) => {
+      if (method === "exec.approval.resolve") {
+        return { ok: true };
+      }
+      if (method === "exec.approval.list") {
+        return [active, queued];
+      }
+      if (method === "plugin.approval.list") {
+        return [];
+      }
+      return {};
+    });
+    const app = await createApp(request, [active]);
+
+    await app.handleExecApprovalDecision("allow-once", "approval-active");
+
+    expect(app.execApprovalQueue.map((entry) => entry.id)).toEqual(["approval-queued"]);
+    expect(app.execApprovalBusy).toBe(false);
+    expect(request).toHaveBeenCalledWith("exec.approval.list", {});
+    expect(request).toHaveBeenCalledWith("plugin.approval.list", {});
   });
 
   it("dismisses and refreshes when the backend reports an already resolved approval", async () => {

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -1411,8 +1411,13 @@ export class OpenClawApp extends LitElement {
     handleNostrProfileToggleAdvancedInternal(this);
   }
 
-  async handleExecApprovalDecision(decision: "allow-once" | "allow-always" | "deny") {
-    const active = this.execApprovalQueue[0];
+  async handleExecApprovalDecision(
+    decision: "allow-once" | "allow-always" | "deny",
+    approvalId?: string,
+  ) {
+    const active = approvalId
+      ? this.execApprovalQueue.find((entry) => entry.id === approvalId)
+      : this.execApprovalQueue[0];
     if (!active || !this.client || this.execApprovalBusy) {
       return;
     }
@@ -1425,6 +1430,9 @@ export class OpenClawApp extends LitElement {
         decision,
       });
       dismissExecApprovalPrompt(this, active.id);
+      if (this.execApprovalQueue.length === 0) {
+        await refreshPendingApprovalQueue(this, { suppressIds: [active.id] });
+      }
     } catch (err) {
       if (isStaleApprovalResolutionError(err)) {
         dismissExecApprovalPrompt(this, active.id);

--- a/ui/src/ui/controllers/exec-approval.ts
+++ b/ui/src/ui/controllers/exec-approval.ts
@@ -324,12 +324,18 @@ export function enqueueExecApprovalPrompt(
   scheduleApprovalExpiryPrune(state, entry);
 }
 
-export async function refreshPendingApprovalQueue(state: ExecApprovalPromptState): Promise<void> {
+export async function refreshPendingApprovalQueue(
+  state: ExecApprovalPromptState,
+  options?: { suppressIds?: Iterable<string> },
+): Promise<void> {
   const client = state.client;
   if (!client) {
     return;
   }
   const removedDuringRefresh = state.execApprovalRefreshRemovedIds ?? new Set<string>();
+  for (const id of options?.suppressIds ?? []) {
+    removedDuringRefresh.add(id);
+  }
   const ownsRemovedSet = !state.execApprovalRefreshRemovedIds;
   if (ownsRemovedSet) {
     state.execApprovalRefreshRemovedIds = removedDuringRefresh;

--- a/ui/src/ui/views/exec-approval.test.ts
+++ b/ui/src/ui/views/exec-approval.test.ts
@@ -223,7 +223,30 @@ describe("approval and confirmation modals", () => {
 
     dispatchEscape(dialog);
 
-    expect(handleExecApprovalDecision).toHaveBeenCalledWith("deny");
+    expect(handleExecApprovalDecision).toHaveBeenCalledWith("deny", "approval-1");
+  });
+
+  it("sends the active approval id with button decisions", async () => {
+    const handleExecApprovalDecision = vi.fn(async () => undefined);
+    const active = createExecRequest();
+    const queued = createExecRequest();
+    queued.id = "approval-2";
+    queued.request.command = "pnpm test";
+    render(
+      renderExecApprovalPrompt(
+        createExecState({
+          execApprovalQueue: [active, queued],
+          handleExecApprovalDecision,
+        }),
+      ),
+      container,
+    );
+
+    await getRenderedDialog();
+
+    container.querySelector<HTMLButtonElement>(".exec-approval-actions button")?.click();
+
+    expect(handleExecApprovalDecision).toHaveBeenCalledWith("allow-once", "approval-1");
   });
 
   it("does not dispatch an extra exec decision from Escape while busy", async () => {

--- a/ui/src/ui/views/exec-approval.ts
+++ b/ui/src/ui/views/exec-approval.ts
@@ -179,7 +179,7 @@ export function renderExecApprovalPrompt(state: AppViewState) {
   const decisions = resolveApprovalDecisions(active);
   const handleCancel = () => {
     if (!state.execApprovalBusy && decisions.includes("deny")) {
-      void state.handleExecApprovalDecision("deny");
+      void state.handleExecApprovalDecision("deny", active.id);
     }
   };
   return html`
@@ -207,7 +207,7 @@ export function renderExecApprovalPrompt(state: AppViewState) {
               <button
                 class=${approvalDecisionClass(decision)}
                 ?disabled=${state.execApprovalBusy}
-                @click=${() => state.handleExecApprovalDecision(decision)}
+                @click=${() => state.handleExecApprovalDecision(decision, active.id)}
               >
                 ${approvalDecisionLabel(decision)}
               </button>


### PR DESCRIPTION
﻿Fixes #98585.

## Summary
- make Control UI approval decisions resolve a specific approval id instead of implicitly using the current queue head
- refresh the pending approval lists after the final local item is dismissed, while suppressing the just-resolved id so stale list responses do not requeue it
- serialize macOS native exec approval prompts so a second pending prompt waits for the active prompt to finish instead of competing with/closing alongside it

## Tests
- `node scripts/run-with-env.mjs OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 -- node scripts/run-vitest.mjs run --config test/vitest/vitest.ui.config.ts ui/src/ui/app.exec-approval.test.ts ui/src/ui/views/exec-approval.test.ts ui/src/ui/controllers/exec-approval.test.ts --pool forks --testTimeout=30000 --reporter=dot`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.ui.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-ui-approval-window.tsbuildinfo`
- `git diff --check`

## Not run
- `swift test` (Swift toolchain is not installed in this Windows environment)
