### PR TITLE
Align openclaw-mac config path resolution

### DIFF
--- a/apps/macos/Sources/OpenClawMacCLI/ConfigureRemoteCommand.swift
+++ b/apps/macos/Sources/OpenClawMacCLI/ConfigureRemoteCommand.swift
@@ -128,7 +128,7 @@ private func configureSSHRemote(_ opts: ConfigureRemoteOptions) throws -> Config
             userInfo: [NSLocalizedDescriptionKey: "SSH target must look like user@host[:port]"])
     }
 
-    let configURL = openClawConfigURL()
+    let configURL = OpenClawMacCLIPaths.configURL
     var root = try loadConfigRoot(from: configURL)
     var gateway = root["gateway"] as? [String: Any] ?? [:]
     var remote = gateway["remote"] as? [String: Any] ?? [:]
@@ -174,7 +174,7 @@ private func configureDirectRemote(
             ])
     }
 
-    let configURL = openClawConfigURL()
+    let configURL = OpenClawMacCLIPaths.configURL
     var root = try loadConfigRoot(from: configURL)
     var gateway = root["gateway"] as? [String: Any] ?? [:]
     var remote = gateway["remote"] as? [String: Any] ?? [:]
@@ -203,15 +203,6 @@ private func configureDirectRemote(
         remoteUrl: directURL.absoluteString,
         remotePort: defaultPort(for: directURL) ?? opts.remotePort,
         onboardingSkipped: true)
-}
-
-private func openClawConfigURL() -> URL {
-    if let raw = ProcessInfo.processInfo.environment["OPENCLAW_CONFIG_PATH"],
-       !raw.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-    {
-        return URL(fileURLWithPath: NSString(string: raw).expandingTildeInPath)
-    }
-    return FileManager().homeDirectoryForCurrentUser.appendingPathComponent(".openclaw/openclaw.json")
 }
 
 private func loadConfigRoot(from url: URL) throws -> [String: Any] {

--- a/apps/macos/Sources/OpenClawMacCLI/GatewayConfig.swift
+++ b/apps/macos/Sources/OpenClawMacCLI/GatewayConfig.swift
@@ -19,12 +19,34 @@ struct GatewayEndpoint {
     let mode: String
 }
 
+enum OpenClawMacCLIPaths {
+    private static func envPath(_ key: String) -> String? {
+        guard let raw = getenv(key) else { return nil }
+        let value = String(cString: raw).trimmingCharacters(in: .whitespacesAndNewlines)
+        return value.isEmpty ? nil : value
+    }
+
+    private static func fileURL(path: String, isDirectory: Bool = false) -> URL {
+        URL(fileURLWithPath: NSString(string: path).expandingTildeInPath, isDirectory: isDirectory)
+    }
+
+    static var stateDirURL: URL {
+        if let raw = self.envPath("OPENCLAW_STATE_DIR") {
+            return self.fileURL(path: raw, isDirectory: true)
+        }
+        return FileManager().homeDirectoryForCurrentUser.appendingPathComponent(".openclaw", isDirectory: true)
+    }
+
+    static var configURL: URL {
+        if let raw = self.envPath("OPENCLAW_CONFIG_PATH") {
+            return self.fileURL(path: raw)
+        }
+        return self.stateDirURL.appendingPathComponent("openclaw.json")
+    }
+}
+
 func loadGatewayConfig() -> GatewayConfig {
-    let home = FileManager().homeDirectoryForCurrentUser
-    let candidates = [
-        home.appendingPathComponent(".openclaw/openclaw.json"),
-    ]
-    let url = candidates.first { FileManager().isReadableFile(atPath: $0.path) } ?? candidates[0]
+    let url = OpenClawMacCLIPaths.configURL
     guard let data = try? Data(contentsOf: url) else { return GatewayConfig() }
     guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
         return GatewayConfig()

--- a/apps/macos/Tests/OpenClawIPCTests/ConfigureRemoteCommandTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ConfigureRemoteCommandTests.swift
@@ -100,6 +100,59 @@ struct ConfigureRemoteCommandTests {
         }
     }
 
+    @Test @MainActor func `configure remote writes config under state dir when config path is unset`() async throws {
+        let stateDir = FileManager().temporaryDirectory
+            .appendingPathComponent("openclaw-configure-state-\(UUID().uuidString)", isDirectory: true)
+        let configURL = stateDir.appendingPathComponent("openclaw.json")
+        defer { try? FileManager().removeItem(at: stateDir) }
+
+        try await TestIsolation.withIsolatedState(env: [
+            "OPENCLAW_CONFIG_PATH": nil,
+            "OPENCLAW_STATE_DIR": stateDir.path,
+        ]) {
+            let output = try configureRemote(.init(
+                directUrl: "ws://192.168.0.202:18789",
+                token: "state-token")) // pragma: allowlist secret
+
+            #expect(output.configPath == configURL.path)
+            let data = try Data(contentsOf: configURL)
+            let root = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+            let gateway = try #require(root["gateway"] as? [String: Any])
+            let remote = try #require(gateway["remote"] as? [String: Any])
+            #expect(gateway["mode"] as? String == "remote")
+            #expect(remote["transport"] as? String == "direct")
+            #expect(remote["url"] as? String == "ws://192.168.0.202:18789")
+            #expect(remote["token"] as? String == "state-token") // pragma: allowlist secret
+        }
+    }
+
+    @Test @MainActor func `configure ssh remote writes config under state dir when config path is unset`() async throws {
+        let stateDir = FileManager().temporaryDirectory
+            .appendingPathComponent("openclaw-configure-ssh-state-\(UUID().uuidString)", isDirectory: true)
+        let configURL = stateDir.appendingPathComponent("openclaw.json")
+        defer { try? FileManager().removeItem(at: stateDir) }
+
+        try await TestIsolation.withIsolatedState(env: [
+            "OPENCLAW_CONFIG_PATH": nil,
+            "OPENCLAW_STATE_DIR": stateDir.path,
+        ]) {
+            let output = try configureRemote(.init(
+                sshTarget: "alice@gateway.example",
+                localPort: 19089,
+                remotePort: 18789))
+
+            #expect(output.configPath == configURL.path)
+            let data = try Data(contentsOf: configURL)
+            let root = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+            let gateway = try #require(root["gateway"] as? [String: Any])
+            let remote = try #require(gateway["remote"] as? [String: Any])
+            #expect(gateway["mode"] as? String == "remote")
+            #expect(gateway["port"] as? Int == 19089)
+            #expect(remote["transport"] as? String == "ssh")
+            #expect(remote["sshTarget"] as? String == "alice@gateway.example")
+        }
+    }
+
     @Test func `configure remote rejects invalid explicit ports`() throws {
         #expect(throws: Error.self) {
             _ = try ConfigureRemoteOptions.parse(["--ssh-target", "alice@gateway.example", "--remote-port", "99999"])

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayConfigTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayConfigTests.swift
@@ -1,0 +1,74 @@
+import Foundation
+import Testing
+@testable import OpenClawMacCLI
+
+@Suite(.serialized)
+struct GatewayConfigTests {
+    @Test @MainActor func `load gateway config reads state dir config`() async throws {
+        let stateDir = FileManager().temporaryDirectory
+            .appendingPathComponent("openclaw-cli-state-\(UUID().uuidString)", isDirectory: true)
+        try FileManager().createDirectory(at: stateDir, withIntermediateDirectories: true)
+        defer { try? FileManager().removeItem(at: stateDir) }
+
+        let configURL = stateDir.appendingPathComponent("openclaw.json")
+        try self.writeGatewayConfig(
+            to: configURL,
+            remoteURL: "ws://state-dir.example:18789",
+            token: "state-token")
+
+        try await TestIsolation.withIsolatedState(env: [
+            "OPENCLAW_CONFIG_PATH": nil,
+            "OPENCLAW_STATE_DIR": stateDir.path,
+        ]) {
+            let config = loadGatewayConfig()
+
+            #expect(config.mode == "remote")
+            #expect(config.remoteUrl == "ws://state-dir.example:18789")
+            #expect(config.remoteToken == "state-token")
+        }
+    }
+
+    @Test @MainActor func `load gateway config prefers explicit config path over state dir`() async throws {
+        let dir = FileManager().temporaryDirectory
+            .appendingPathComponent("openclaw-cli-config-precedence-\(UUID().uuidString)", isDirectory: true)
+        let stateDir = dir.appendingPathComponent("state", isDirectory: true)
+        try FileManager().createDirectory(at: stateDir, withIntermediateDirectories: true)
+        defer { try? FileManager().removeItem(at: dir) }
+
+        let explicitConfigURL = dir.appendingPathComponent("explicit.json")
+        let stateConfigURL = stateDir.appendingPathComponent("openclaw.json")
+        try self.writeGatewayConfig(
+            to: explicitConfigURL,
+            remoteURL: "ws://explicit.example:18789",
+            token: "explicit-token")
+        try self.writeGatewayConfig(
+            to: stateConfigURL,
+            remoteURL: "ws://state.example:18789",
+            token: "state-token")
+
+        try await TestIsolation.withIsolatedState(env: [
+            "OPENCLAW_CONFIG_PATH": explicitConfigURL.path,
+            "OPENCLAW_STATE_DIR": stateDir.path,
+        ]) {
+            let config = loadGatewayConfig()
+
+            #expect(config.remoteUrl == "ws://explicit.example:18789")
+            #expect(config.remoteToken == "explicit-token")
+        }
+    }
+
+    private func writeGatewayConfig(to url: URL, remoteURL: String, token: String) throws {
+        let root: [String: Any] = [
+            "gateway": [
+                "mode": "remote",
+                "remote": [
+                    "url": remoteURL,
+                    "token": token,
+                ],
+            ],
+        ]
+        try FileManager().createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let data = try JSONSerialization.data(withJSONObject: root, options: [.prettyPrinted])
+        try data.write(to: url, options: [.atomic])
+    }
+}


### PR DESCRIPTION
﻿Fixes #98591.

## Summary
- Add a shared `OpenClawMacCLIPaths` resolver for the standalone macOS CLI.
- Resolve config paths as `OPENCLAW_CONFIG_PATH`, then `OPENCLAW_STATE_DIR/openclaw.json`, then `~/.openclaw/openclaw.json`.
- Use the resolver for `loadGatewayConfig()` and both `configure-remote` write paths.
- Add regression coverage for state-dir reads, explicit path precedence, and state-dir writes for direct and SSH remote config.

## Testing
- `git diff --check HEAD~1..HEAD`
- residual Node process check for vitest/tsgo/pnpm/prettier processes
- Not run: `swift test` because `swift` is not installed on this Windows host.
