### PR TITLE
Preserve profile env for macOS launch at login

### DIFF
--- a/apps/macos/Sources/OpenClaw/LaunchAgentManager.swift
+++ b/apps/macos/Sources/OpenClaw/LaunchAgentManager.swift
@@ -31,6 +31,7 @@ enum LaunchAgentManager {
     }
 
     static func plistContents(bundlePath: String) -> String {
+        let environmentXML = self.environmentVariablesXML()
         """
         <?xml version="1.0" encoding="UTF-8"?>
         <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -40,24 +41,47 @@ enum LaunchAgentManager {
           <string>ai.openclaw.mac</string>
           <key>ProgramArguments</key>
           <array>
-            <string>\(bundlePath)/Contents/MacOS/OpenClaw</string>
+            <string>\(self.plistEscaped("\(bundlePath)/Contents/MacOS/OpenClaw"))</string>
           </array>
           <key>WorkingDirectory</key>
-          <string>\(FileManager().homeDirectoryForCurrentUser.path)</string>
+          <string>\(self.plistEscaped(FileManager().homeDirectoryForCurrentUser.path))</string>
           <key>RunAtLoad</key>
           <true/>
           <key>EnvironmentVariables</key>
-          <dict>
-            <key>PATH</key>
-            <string>\(CommandResolver.preferredPaths().joined(separator: ":"))</string>
+          <dict>\(environmentXML)
           </dict>
           <key>StandardOutPath</key>
-          <string>\(LogLocator.launchdLogPath)</string>
+          <string>\(self.plistEscaped(LogLocator.launchdLogPath))</string>
           <key>StandardErrorPath</key>
-          <string>\(LogLocator.launchdLogPath)</string>
+          <string>\(self.plistEscaped(LogLocator.launchdLogPath))</string>
         </dict>
         </plist>
         """
+    }
+
+    private static func environmentVariablesXML() -> String {
+        var env: [(String, String)] = [
+            ("PATH", CommandResolver.preferredPaths().joined(separator: ":")),
+        ]
+        for key in ["OPENCLAW_CONFIG_PATH", "OPENCLAW_STATE_DIR"] {
+            if let value = OpenClawEnv.path(key) {
+                env.append((key, value))
+            }
+        }
+        return env
+            .map { key, value in
+                "\n            <key>\(self.plistEscaped(key))</key>\n            <string>\(self.plistEscaped(value))</string>"
+            }
+            .joined()
+    }
+
+    private static func plistEscaped(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+            .replacingOccurrences(of: "'", with: "&apos;")
     }
 
     @discardableResult

--- a/apps/macos/Tests/OpenClawIPCTests/LaunchAgentManagerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/LaunchAgentManagerTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import Testing
 @testable import OpenClaw
 
+@Suite(.serialized)
 struct LaunchAgentManagerTests {
     @Test func `launch at login plist does not keep app alive after manual quit`() throws {
         let plist = LaunchAgentManager.plistContents(bundlePath: "/Applications/OpenClaw.app")
@@ -14,5 +15,48 @@ struct LaunchAgentManagerTests {
 
         let args = try #require(object["ProgramArguments"] as? [String])
         #expect(args == ["/Applications/OpenClaw.app/Contents/MacOS/OpenClaw"])
+    }
+
+    @Test @MainActor func `launch at login plist preserves config path environment`() async throws {
+        let root = FileManager().temporaryDirectory
+            .appendingPathComponent("openclaw-login-agent-\(UUID().uuidString)", isDirectory: true)
+        let configPath = root.appendingPathComponent("custom & config.json").path
+        let stateDir = root.appendingPathComponent("state & dir", isDirectory: true).path
+        defer { try? FileManager().removeItem(at: root) }
+
+        try await TestIsolation.withIsolatedState(env: [
+            "OPENCLAW_CONFIG_PATH": configPath,
+            "OPENCLAW_STATE_DIR": stateDir,
+        ]) {
+            let plist = LaunchAgentManager.plistContents(bundlePath: "/Applications/Open&Claw.app")
+            let data = try #require(plist.data(using: .utf8))
+            let object = try #require(
+                PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any])
+
+            let args = try #require(object["ProgramArguments"] as? [String])
+            #expect(args == ["/Applications/Open&Claw.app/Contents/MacOS/OpenClaw"])
+
+            let env = try #require(object["EnvironmentVariables"] as? [String: String])
+            #expect(env["OPENCLAW_CONFIG_PATH"] == configPath)
+            #expect(env["OPENCLAW_STATE_DIR"] == stateDir)
+            #expect(env["PATH"]?.isEmpty == false)
+        }
+    }
+
+    @Test @MainActor func `launch at login plist omits empty config path environment`() async throws {
+        try await TestIsolation.withIsolatedState(env: [
+            "OPENCLAW_CONFIG_PATH": "   ",
+            "OPENCLAW_STATE_DIR": "",
+        ]) {
+            let plist = LaunchAgentManager.plistContents(bundlePath: "/Applications/OpenClaw.app")
+            let data = try #require(plist.data(using: .utf8))
+            let object = try #require(
+                PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any])
+            let env = try #require(object["EnvironmentVariables"] as? [String: String])
+
+            #expect(env["OPENCLAW_CONFIG_PATH"] == nil)
+            #expect(env["OPENCLAW_STATE_DIR"] == nil)
+            #expect(env["PATH"]?.isEmpty == false)
+        }
     }
 }


### PR DESCRIPTION
﻿Fixes #98594.

## Summary
- Preserve non-empty `OPENCLAW_CONFIG_PATH` and `OPENCLAW_STATE_DIR` in the macOS app launch-at-login plist.
- XML-escape generated plist values so custom paths or app paths containing special characters remain valid plist XML.
- Add launch-agent plist tests for profile env preservation and empty env omission.

## Testing
- `git diff --check HEAD~1..HEAD`
- residual Node process check for vitest/tsgo/pnpm/prettier processes
- Not run: `swift test` because `swift` is not installed on this Windows host.
