### PR TITLE
fix(telegram): strip model-generated parameter XML wrappers from rich HTML

### DIFF
--- a/extensions/telegram/src/format.test.ts
+++ b/extensions/telegram/src/format.test.ts
@@ -619,6 +619,13 @@ it("strips model-generated parameter XML wrappers from rich HTML (regression for
   expect(result).toContain("<summary>");
 });
 
+it("preserves escaped parameter tags inside code blocks (regression for #98557)", () => {
+  const input = '<pre><code>&lt;parameter name="x"&gt;val&lt;/parameter&gt;</code></pre>';
+  const result = sanitizeTelegramRichHtml(input);
+  expect(result).toContain("parameter");
+  expect(result).toContain("<pre><code>");
+});
+
 function containsLoneSurrogate(text: string): boolean {
   for (let index = 0; index < text.length; index += 1) {
     const code = text.charCodeAt(index);

--- a/extensions/telegram/src/format.test.ts
+++ b/extensions/telegram/src/format.test.ts
@@ -610,6 +610,15 @@ describe("markdownToTelegramHtml", () => {
   });
 });
 
+it("strips model-generated parameter XML wrappers from rich HTML (regression for #98557)", () => {
+  const input = '<details><summary>Test</summary><parameter name="x">content</parameter></details>';
+  const result = sanitizeTelegramRichHtml(input);
+  expect(result).not.toContain("parameter");
+  expect(result).toContain("content");
+  expect(result).toContain("<details>");
+  expect(result).toContain("<summary>");
+});
+
 function containsLoneSurrogate(text: string): boolean {
   for (let index = 0; index < text.length; index += 1) {
     const code = text.charCodeAt(index);

--- a/extensions/telegram/src/format.ts
+++ b/extensions/telegram/src/format.ts
@@ -431,16 +431,16 @@ function escapeUnsupportedTelegramHtml(
 ): string {
   // Strip model-generated tool-call XML wrappers before any tag processing
   // so they do not appear as escaped text in either rich or legacy output.
-  text = stripModelParameterWrappers(text);
+  const sanitized = stripModelParameterWrappers(text);
   let result = "";
   let index = 0;
   const openTags: string[] = [];
-  while (index < text.length) {
-    const char = text[index];
+  while (index < sanitized.length) {
+    const char = sanitized[index];
     if (char === "&") {
-      const entityEnd = findTelegramHtmlEntityEnd(text, index);
+      const entityEnd = findTelegramHtmlEntityEnd(sanitized, index);
       if (entityEnd !== -1) {
-        result += text.slice(index, entityEnd + 1);
+        result += sanitized.slice(index, entityEnd + 1);
         index = entityEnd + 1;
       } else {
         result += "&amp;";

--- a/extensions/telegram/src/format.ts
+++ b/extensions/telegram/src/format.ts
@@ -429,6 +429,9 @@ function escapeUnsupportedTelegramHtml(
   text: string,
   support: TelegramHtmlTagSupport = TELEGRAM_LEGACY_HTML_TAG_SUPPORT,
 ): string {
+  // Strip model-generated tool-call XML wrappers before any tag processing
+  // so they do not appear as escaped text in either rich or legacy output.
+  text = stripModelParameterWrappers(text);
   let result = "";
   let index = 0;
   const openTags: string[] = [];
@@ -728,6 +731,15 @@ export function renderTelegramHtmlText(
   }
   // markdownToTelegramHtml already wraps file references by default
   return markdownToTelegramHtml(text, { tableMode: options.tableMode });
+}
+
+// Model-generated tool-call XML wrappers leak into rich HTML output as
+// escaped &lt;parameter&gt;...&lt;/parameter&gt; text.  Strip the wrapper tags
+// while preserving inner content so only the payload text is visible.
+const MODEL_PARAMETER_WRAPPER_RE = /<\/?parameter\b[^>]*>/gi;
+
+function stripModelParameterWrappers(html: string): string {
+  return html.replace(MODEL_PARAMETER_WRAPPER_RE, "");
 }
 
 export function sanitizeTelegramRichHtml(html: string): string {


### PR DESCRIPTION
## What Problem This Solves

When `richMessages: true` is enabled, model-generated `<parameter name="...">content</parameter>` XML wrappers leak into Telegram output as visible escaped HTML text. The wrapper tags are tool-call artifacts that should be stripped entirely.

Closes #98557

## Fix

Add `stripModelParameterWrappers` inside `escapeUnsupportedTelegramHtml` — a regex replacement that strips raw `<parameter>` XML wrapper tags while preserving inner content. Applied BEFORE HTML escaping so both rich and legacy paths are covered.

**Code blocks are NOT affected**: the markdown parser already escapes `<parameter>` inside code fences to `&lt;parameter&gt;`. Our regex only matches raw unescaped tags, so literal XML examples inside `<pre>` / `<code>` remain visible.

**2 files, ~24 lines**

## Evidence

### Real behavior proof

```
Raw <parameter> in details → stripped ✅
Escaped &lt;parameter&gt; in <pre><code> → preserved ✅
```

### Before/after

| Scenario | Before | After |
|----------|--------|-------|
| `<parameter>` in details | `&lt;parameter...&gt;` visible | **stripped**, content preserved |
| `<parameter>` in code block | preserved by markdown parser | **preserved** (no change) |
| Legacy path (`textMode: html`) | escaped to text | **stripped** (both paths) |

### Test suite

```
pnpm test extensions/telegram/src/format.test.ts
  Test Files  1 passed (1)    Tests  all passed
```

Proof test covers: details strip ✅ + code block preserve ✅

### Formatting

```
pnpm exec oxfmt --check ...  (pass)
git diff --check  (clean)
```

## Change Type

- [x] Bug fix

## Scope

- [x] Telegram channel (format/sanitization)

## Security Impact

- New permissions? No
- Secrets handling changed? No
- New network calls? No