### PR TITLE
fix: restore main lint after timer repairs

### DIFF
--- a/extensions/feishu/src/async.ts
+++ b/extensions/feishu/src/async.ts
@@ -75,7 +75,7 @@ export function waitForAbortableDelay(
 
   return new Promise((resolve) => {
     let settled = false;
-    let timer: ReturnType<typeof setTimeout> | undefined;
+    let timer: ReturnType<typeof setTimeout> | undefined = undefined;
 
     const finish = (value: boolean) => {
       if (settled) {

--- a/src/infra/tailscale.ts
+++ b/src/infra/tailscale.ts
@@ -49,7 +49,9 @@ export async function findTailscaleBinary(): Promise<string | null> {
           }),
         ]);
       } finally {
-        if (timer) clearTimeout(timer);
+        if (timer) {
+          clearTimeout(timer);
+        }
       }
       return true;
     } catch {


### PR DESCRIPTION
Related: #98134
Related: #98137
Closes #98462
Closes #98464

## What Problem This Solves

Resolves a problem where the `main` CI lint gates fail deterministically after the Tailscale timer-cleanup and Feishu timer-TDZ fixes merged, blocking the green-main landing queue.

## Why This Change Was Made

Keep both runtime fixes unchanged while making their new timer code satisfy the repository's lint contracts: add braces to the Tailscale cleanup guard and explicitly initialize the hoisted Feishu timer binding before its later assignment. The original fixes and diagnosis were authored by @zhangLei99586 in #98134 and #98137; this repair preserves that work and credit.

## User Impact

No runtime behavior changes. Users retain the Tailscale dangling-timer cleanup and Feishu early-abort TDZ protection, while maintainers regain green lint gates for `main` and the queued PR landing path.

## Evidence

- Failed `main` run: https://github.com/openclaw/openclaw/actions/runs/28513527783 (`check-lint` and `check-additional-extension-bundled`).
- Before-fix Testbox-through-Crabbox proof: `tbx_01kweq3fxgepssyeygn0jv0sne`, https://github.com/openclaw/openclaw/actions/runs/28514318773. Both `pnpm lint --threads=8` and `pnpm lint:extensions:bundled` reproduced the exact failures.
- After-fix Testbox-through-Crabbox proof: `tbx_01kweqa18tn8g5yz836jttdjmv`, https://github.com/openclaw/openclaw/actions/runs/28514507632. Both exact lint lanes passed.
- Focused tests: `node scripts/run-vitest.mjs src/infra/tailscale.test.ts extensions/feishu/src/async.test.ts` — 35/35 passed across 2 files.
- `git diff --check` passed.
- Fresh Auto Review: Codex `gpt-5.6-sol`, `xhigh` — no accepted/actionable findings; patch correct at 0.99 confidence.
- Rebased once onto `origin/main` at `1b0b8c294a`; stable patch ID was unchanged.

AI-assisted maintainer repair. The diff and validation evidence were reviewed before publication.
