### PR TITLE
fix(status): redact channel base URLs in status-all

### DIFF
--- a/src/commands/status-all/channels.test.ts
+++ b/src/commands/status-all/channels.test.ts
@@ -122,6 +122,38 @@ describe("buildChannelsTable", () => {
     expect(detailRow?.Notes).toContain("credential not checked");
   });
 
+  it("redacts sensitive channel base URL material in account notes", async () => {
+    mocks.listReadOnlyChannelPluginsForConfig.mockReturnValue([
+      {
+        ...discordPlugin,
+        config: {
+          ...discordPlugin.config,
+          describeAccount: () => ({
+            baseUrl:
+              "https://oc-user:oc-pass@mm.example.com/hooks?token=oc-token-raw&keep=1&api_key=oc-api-key-raw",
+          }),
+        },
+      },
+    ]);
+    mocks.resolveInspectedChannelAccount.mockResolvedValue({
+      account: {
+        tokenStatus: "available",
+        tokenSource: "config",
+      },
+      enabled: true,
+      configured: true,
+    });
+
+    const table = await buildChannelsTable({ channels: { discord: { enabled: true } } });
+
+    const notes = table.details[0]?.rows[0]?.Notes;
+    expect(notes).toContain("https://***:***@mm.example.com/hooks?token=***&keep=1&api_key=***");
+    expect(notes).not.toContain("oc-user");
+    expect(notes).not.toContain("oc-pass");
+    expect(notes).not.toContain("oc-token-raw");
+    expect(notes).not.toContain("oc-api-key-raw");
+  });
+
   it("shows configured official external channels when the plugin is missing", async () => {
     mocks.listReadOnlyChannelPluginsForConfig.mockReturnValue([]);
     mocks.missingOfficialExternalChannels.add("feishu");

--- a/src/commands/status-all/channels.ts
+++ b/src/commands/status-all/channels.ts
@@ -4,6 +4,7 @@
 import fs from "node:fs";
 import { asRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { redactSensitiveUrlLikeString } from "../../../packages/net-policy/src/redact-sensitive-url.js";
 import { sanitizeForLog } from "../../../packages/terminal-core/src/ansi.js";
 import { resolveInspectedChannelAccount } from "../../channels/account-inspection.js";
 import { hasConfiguredUnavailableCredentialStatus } from "../../channels/account-snapshot-fields.js";
@@ -137,7 +138,7 @@ const buildAccountNotes = (params: {
     notes.push("secret unavailable in this command path");
   }
   if (snapshot.baseUrl) {
-    notes.push(snapshot.baseUrl);
+    notes.push(redactSensitiveUrlLikeString(snapshot.baseUrl));
   }
   if (snapshot.port != null) {
     notes.push(`port:${snapshot.port}`);


### PR DESCRIPTION
Fixes #98633

## What Problem This Solves
`openclaw status --all` builds a pasteable support report, but channel account notes printed `snapshot.baseUrl` verbatim. If a channel plugin or account summary includes credentials in URL userinfo or auth-like query params, those values can appear in the status report even though token fields are summarized safely.

## Why This Change Was Made
This redacts URL userinfo and sensitive query params before channel base URLs are added to status notes, while keeping ordinary URLs readable.

## User Impact
Operators can paste `openclaw status --all` output without leaking credentials hidden inside channel base URLs.

## Evidence
- `node scripts/run-vitest.mjs src/commands/status-all/channels.test.ts`
- `pnpm exec oxlint src/commands/status-all/channels.ts src/commands/status-all/channels.test.ts`
- `pnpm exec oxfmt --check src/commands/status-all/channels.ts src/commands/status-all/channels.test.ts`
- `git diff --check`
- `node scripts/build-all.mjs cliStartup`
- `OPENCLAW_CONFIG_PATH=<synthetic config> NO_COLOR=1 FORCE_COLOR=0 OPENCLAW_TEST_FAST=1 node openclaw.mjs status --all --timeout 1`
- `python .agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main`

CLI proof excerpt from the synthetic Mattermost `baseUrl`:

```text
Mattermost accounts
+----------+----------+------------------------------------------------------------------------------------------------+
| Account  | Status   | Notes                                                                                          |
+----------+----------+------------------------------------------------------------------------------------------------+
| default  | OK       | bot:config - https://***:***@mm.example.com/hooks?token=***&keep=1&api_key=***                 |
+----------+----------+------------------------------------------------------------------------------------------------+
```

The proof config used synthetic values `oc-user`, `oc-pass`, `oc-token-raw`, and `oc-api-key-raw`; none appeared in the `status --all` output.
