### PR TITLE
fix(clickclack): resolve exec/file SecretRefs at runtime, mark configured in inspect

### DIFF
--- a/extensions/clickclack/src/accounts.test.ts
+++ b/extensions/clickclack/src/accounts.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   listClickClackAccountIds,
   resolveClickClackAccount,
+  resolveClickClackRuntimeToken,
   resolveDefaultClickClackAccountId,
 } from "./accounts.js";
 import type { CoreConfig } from "./types.js";
@@ -179,5 +180,90 @@ describe("ClickClack account resolution", () => {
 
     expect(resolveClickClackAccount({ cfg }).reconnectMs).toBe(100);
     expect(resolveClickClackAccount({ cfg, accountId: "slow" }).reconnectMs).toBe(60_000);
+  });
+
+  it("marks exec SecretRefs as configured without resolving the value synchronously (#98428)", () => {
+    const cfg = {
+      channels: {
+        clickclack: {
+          enabled: true,
+          baseUrl: "https://app.clickclack.chat",
+          workspace: "wsp_1",
+          accounts: {
+            service: {
+              token: {
+                source: "exec",
+                provider: "example_exec",
+                id: "CLICKCLACK_SERVICE_TOKEN",
+              },
+            },
+          },
+        },
+      },
+      secrets: {
+        providers: {
+          example_exec: {
+            source: "exec",
+            command: "/path/to/resolver",
+            jsonOnly: true,
+          },
+        },
+      },
+    } satisfies CoreConfig;
+
+    const account = resolveClickClackAccount({ cfg, accountId: "service" });
+    // Sync inspect path: configured even though exec value can't be read here.
+    expect(account.configured).toBe(true);
+    // Sync inspect path leaves the value empty; runtime resolver materializes it.
+    expect(account.token).toBe("");
+  });
+
+  it("marks file SecretRefs as configured without resolving the value synchronously (#98428)", () => {
+    const cfg = {
+      channels: {
+        clickclack: {
+          enabled: true,
+          baseUrl: "https://app.clickclack.chat",
+          workspace: "wsp_1",
+          token: {
+            source: "file",
+            provider: "default",
+            id: "/etc/openclaw/clickclack.token",
+          },
+        },
+      },
+    } satisfies CoreConfig;
+
+    expect(resolveClickClackAccount({ cfg }).configured).toBe(true);
+    expect(resolveClickClackAccount({ cfg }).token).toBe("");
+  });
+
+  it("resolveClickClackRuntimeToken resolves configured SecretRefs via the SDK runtime resolver", async () => {
+    const cfg = {
+      channels: {
+        clickclack: {
+          enabled: true,
+          baseUrl: "https://app.clickclack.chat",
+          workspace: "wsp_1",
+          accounts: {
+            service: {
+              token: {
+                source: "env",
+                provider: "default",
+                id: "CLICKCLACK_SERVICE_TOKEN",
+              },
+            },
+          },
+        },
+      },
+    } satisfies CoreConfig;
+
+    const token = await resolveClickClackRuntimeToken({
+      cfg,
+      accountId: "service",
+      value: cfg.channels.clickclack?.accounts?.service?.token,
+      env: { CLICKCLACK_SERVICE_TOKEN: "ccb_runtime_live" },
+    });
+    expect(token).toBe("ccb_runtime_live");
   });
 });

--- a/extensions/clickclack/src/accounts.test.ts
+++ b/extensions/clickclack/src/accounts.test.ts
@@ -112,6 +112,31 @@ describe("ClickClack account resolution", () => {
     });
   });
 
+  it("does not mark missing env SecretRefs as configured", () => {
+    const cfg = {
+      channels: {
+        clickclack: {
+          enabled: true,
+          baseUrl: "https://app.clickclack.chat",
+          workspace: "wsp_1",
+          accounts: {
+            service: {
+              token: { source: "env", provider: "default", id: "CLICKCLACK_SERVICE_TOKEN" },
+            },
+          },
+        },
+      },
+    } satisfies CoreConfig;
+
+    const account = resolveClickClackAccount({
+      cfg,
+      accountId: "service",
+      env: {},
+    });
+    expect(account.configured).toBe(false);
+    expect(account.token).toBe("");
+  });
+
   it("resolves model-mode bot account policy", () => {
     const cfg = {
       channels: {
@@ -227,8 +252,16 @@ describe("ClickClack account resolution", () => {
           workspace: "wsp_1",
           token: {
             source: "file",
-            provider: "default",
-            id: "/etc/openclaw/clickclack.token",
+            provider: "mounted_secret",
+            id: "/clickclack/token",
+          },
+        },
+      },
+      secrets: {
+        providers: {
+          mounted_secret: {
+            source: "file",
+            path: "/etc/openclaw/secrets.json",
           },
         },
       },
@@ -236,6 +269,62 @@ describe("ClickClack account resolution", () => {
 
     expect(resolveClickClackAccount({ cfg }).configured).toBe(true);
     expect(resolveClickClackAccount({ cfg }).token).toBe("");
+  });
+
+  it("rejects SecretRefs whose provider source cannot resolve the requested source", () => {
+    const cfg = {
+      channels: {
+        clickclack: {
+          enabled: true,
+          baseUrl: "https://app.clickclack.chat",
+          workspace: "wsp_1",
+          token: {
+            source: "file",
+            provider: "example_exec",
+            id: "/clickclack/token",
+          },
+        },
+      },
+      secrets: {
+        providers: {
+          example_exec: {
+            source: "exec",
+            command: "/path/to/resolver",
+          },
+        },
+      },
+    } satisfies CoreConfig;
+
+    expect(() => resolveClickClackAccount({ cfg })).toThrow(
+      'Secret provider "example_exec" has source "exec" but ref requests "file".',
+    );
+  });
+
+  it("does not validate inactive SecretRefs for disabled accounts", () => {
+    const cfg = {
+      channels: {
+        clickclack: {
+          enabled: true,
+          baseUrl: "https://app.clickclack.chat",
+          workspace: "wsp_1",
+          accounts: {
+            stale: {
+              enabled: false,
+              token: {
+                source: "exec",
+                provider: "missing_exec",
+                id: "clickclack/token",
+              },
+            },
+          },
+        },
+      },
+    } satisfies CoreConfig;
+
+    const account = resolveClickClackAccount({ cfg, accountId: "stale" });
+    expect(account.enabled).toBe(false);
+    expect(account.configured).toBe(false);
+    expect(account.token).toBe("");
   });
 
   it("resolveClickClackRuntimeToken resolves configured SecretRefs via the SDK runtime resolver", async () => {

--- a/extensions/clickclack/src/accounts.ts
+++ b/extensions/clickclack/src/accounts.ts
@@ -22,6 +22,7 @@ import type { ClickClackAccountConfig, CoreConfig, ResolvedClickClackAccount } f
 const DEFAULT_RECONNECT_MS = 1_500;
 const MIN_RECONNECT_MS = 100;
 const MAX_RECONNECT_MS = 60_000;
+type ClickClackSecretRefSource = "env" | "file" | "exec";
 
 const {
   listAccountIds: listClickClackAccountIds,
@@ -51,6 +52,42 @@ function resolveMergedClickClackAccountConfig(
     omitKeys: ["defaultAccount"],
     normalizeAccountId,
   });
+}
+
+function validateClickClackSecretRefProvider(params: {
+  cfg: CoreConfig;
+  source: ClickClackSecretRefSource;
+  provider: string;
+  id: string;
+}): void {
+  const providerConfig = params.cfg.secrets?.providers?.[params.provider];
+  if (providerConfig) {
+    if (providerConfig.source !== params.source) {
+      throw new Error(
+        `Secret provider "${params.provider}" has source "${providerConfig.source}" but ref requests "${params.source}".`,
+      );
+    }
+    if (
+      providerConfig.source === "env" &&
+      providerConfig.allowlist &&
+      !providerConfig.allowlist.includes(params.id)
+    ) {
+      throw new Error(
+        `Environment variable "${params.id}" is not allowlisted in secrets.providers.${params.provider}.allowlist.`,
+      );
+    }
+    return;
+  }
+
+  if (
+    params.source === "env" &&
+    params.provider === resolveDefaultSecretProviderAlias({ secrets: params.cfg.secrets }, "env")
+  ) {
+    return;
+  }
+  throw new Error(
+    `Secret provider "${params.provider}" is not configured (ref: ${params.source}:${params.provider}:${params.id}).`,
+  );
 }
 
 function resolveClickClackToken(params: {
@@ -83,31 +120,23 @@ function resolveClickClackToken(params: {
     // the value without spawning resolvers. file/exec refs can't be resolved
     // synchronously — runtime paths must call resolveClickClackRuntimeToken.
     if (resolved.ref.source === "env") {
-      const providerConfig = params.cfg.secrets?.providers?.[resolved.ref.provider];
-      if (providerConfig) {
-        if (providerConfig.source !== "env") {
-          throw new Error(
-            `Secret provider "${resolved.ref.provider}" has source "${providerConfig.source}" but ref requests "env".`,
-          );
-        }
-        if (providerConfig.allowlist && !providerConfig.allowlist.includes(resolved.ref.id)) {
-          throw new Error(
-            `Environment variable "${resolved.ref.id}" is not allowlisted in secrets.providers.${resolved.ref.provider}.allowlist.`,
-          );
-        }
-      } else if (
-        resolved.ref.provider !==
-        resolveDefaultSecretProviderAlias({ secrets: params.cfg.secrets }, "env")
-      ) {
-        throw new Error(
-          `Secret provider "${resolved.ref.provider}" is not configured (ref: env:${resolved.ref.provider}:${resolved.ref.id}).`,
-        );
-      }
+      validateClickClackSecretRefProvider({
+        cfg: params.cfg,
+        source: resolved.ref.source,
+        provider: resolved.ref.provider,
+        id: resolved.ref.id,
+      });
       return {
         value: normalizeSecretInputString((params.env ?? process.env)[resolved.ref.id]) ?? "",
-        configuredRef: true,
+        configuredRef: false,
       };
     }
+    validateClickClackSecretRefProvider({
+      cfg: params.cfg,
+      source: resolved.ref.source,
+      provider: resolved.ref.provider,
+      id: resolved.ref.id,
+    });
     // file/exec SecretRef: configured, but value is only available via the
     // async runtime resolver. Status paths treat the account as configured so
     // startup doesn't mark ClickClack "missing"; runtime paths must call
@@ -155,19 +184,19 @@ export function resolveClickClackAccount(params: {
   const baseEnabled = params.cfg.channels?.clickclack?.enabled !== false;
   const enabled = baseEnabled && merged.enabled !== false;
   const baseUrl = merged.baseUrl?.trim().replace(/\/$/, "") ?? "";
-  const tokenResolution = resolveClickClackToken({
-    cfg: params.cfg,
-    value: merged.token,
-    accountId,
-    env: params.env,
-  });
+  const tokenResolution = enabled
+    ? resolveClickClackToken({
+        cfg: params.cfg,
+        value: merged.token,
+        accountId,
+        env: params.env,
+      })
+    : { value: "", configuredRef: false };
   const token = tokenResolution.value;
   const workspace = merged.workspace?.trim() ?? "";
-  // A configured SecretRef (env/file/exec) counts as configured even when the
-  // synchronous resolver can't surface a plaintext value — runtime paths call
-  // resolveClickClackRuntimeToken to materialize the actual token. This keeps
-  // `openclaw channels status` from marking direct exec SecretRef tokens as
-  // "not configured" when the secrets audit already proves resolvability.
+  // Configured file/exec SecretRefs count only after provider validation; env
+  // refs still need a present value. Runtime paths materialize non-env tokens
+  // through resolveClickClackRuntimeToken before using them.
   const configured = Boolean(baseUrl && workspace && (token || tokenResolution.configuredRef));
   return {
     accountId,

--- a/extensions/clickclack/src/accounts.ts
+++ b/extensions/clickclack/src/accounts.ts
@@ -15,6 +15,7 @@ import {
   normalizeResolvedSecretInputString,
   resolveSecretInputString,
 } from "openclaw/plugin-sdk/secret-input";
+import { resolveConfiguredSecretInputString } from "openclaw/plugin-sdk/secret-input-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { ClickClackAccountConfig, CoreConfig, ResolvedClickClackAccount } from "./types.js";
 
@@ -57,7 +58,7 @@ function resolveClickClackToken(params: {
   value: unknown;
   accountId: string;
   env?: NodeJS.ProcessEnv;
-}): string {
+}): { value: string; configuredRef: boolean } {
   const resolved = resolveSecretInputString({
     value: params.value,
     path:
@@ -67,8 +68,21 @@ function resolveClickClackToken(params: {
     defaults: params.cfg.secrets?.defaults,
     mode: "inspect",
   });
-  if (resolved.status !== "available") {
-    if (resolved.status === "configured_unavailable" && resolved.ref.source === "env") {
+  if (resolved.status === "available") {
+    return {
+      value:
+        normalizeResolvedSecretInputString({
+          value: resolved.value,
+          path: "channels.clickclack.token",
+        }) ?? "",
+      configuredRef: false,
+    };
+  }
+  if (resolved.status === "configured_unavailable") {
+    // Synchronous env-var lookup stays here so inspect/status paths can resolve
+    // the value without spawning resolvers. file/exec refs can't be resolved
+    // synchronously — runtime paths must call resolveClickClackRuntimeToken.
+    if (resolved.ref.source === "env") {
       const providerConfig = params.cfg.secrets?.providers?.[resolved.ref.provider];
       if (providerConfig) {
         if (providerConfig.source !== "env") {
@@ -89,16 +103,42 @@ function resolveClickClackToken(params: {
           `Secret provider "${resolved.ref.provider}" is not configured (ref: env:${resolved.ref.provider}:${resolved.ref.id}).`,
         );
       }
-      return normalizeSecretInputString((params.env ?? process.env)[resolved.ref.id]) ?? "";
+      return {
+        value: normalizeSecretInputString((params.env ?? process.env)[resolved.ref.id]) ?? "",
+        configuredRef: true,
+      };
     }
-    return "";
+    // file/exec SecretRef: configured, but value is only available via the
+    // async runtime resolver. Status paths treat the account as configured so
+    // startup doesn't mark ClickClack "missing"; runtime paths must call
+    // resolveClickClackRuntimeToken before using the token.
+    return { value: "", configuredRef: true };
   }
-  return (
-    normalizeResolvedSecretInputString({
-      value: resolved.value,
-      path: "channels.clickclack.token",
-    }) ?? ""
-  );
+  return { value: "", configuredRef: false };
+}
+
+/**
+ * Resolves the runtime ClickClack token value for gateway/outbound paths.
+ * Uses the configured SecretRef runtime resolver so `exec`/`file` refs are
+ * actually evaluated, instead of only the synchronous `env` special case.
+ */
+export async function resolveClickClackRuntimeToken(params: {
+  cfg: CoreConfig;
+  value: unknown;
+  accountId: string;
+  env?: NodeJS.ProcessEnv;
+}): Promise<string> {
+  const path =
+    params.accountId === DEFAULT_ACCOUNT_ID
+      ? "channels.clickclack.token"
+      : `channels.clickclack.accounts.${params.accountId}.token`;
+  const resolved = await resolveConfiguredSecretInputString({
+    config: params.cfg,
+    env: params.env ?? process.env,
+    value: params.value,
+    path,
+  });
+  return resolved.value ?? "";
 }
 
 /**
@@ -115,17 +155,24 @@ export function resolveClickClackAccount(params: {
   const baseEnabled = params.cfg.channels?.clickclack?.enabled !== false;
   const enabled = baseEnabled && merged.enabled !== false;
   const baseUrl = merged.baseUrl?.trim().replace(/\/$/, "") ?? "";
-  const token = resolveClickClackToken({
+  const tokenResolution = resolveClickClackToken({
     cfg: params.cfg,
     value: merged.token,
     accountId,
     env: params.env,
   });
+  const token = tokenResolution.value;
   const workspace = merged.workspace?.trim() ?? "";
+  // A configured SecretRef (env/file/exec) counts as configured even when the
+  // synchronous resolver can't surface a plaintext value — runtime paths call
+  // resolveClickClackRuntimeToken to materialize the actual token. This keeps
+  // `openclaw channels status` from marking direct exec SecretRef tokens as
+  // "not configured" when the secrets audit already proves resolvability.
+  const configured = Boolean(baseUrl && workspace && (token || tokenResolution.configuredRef));
   return {
     accountId,
     enabled,
-    configured: Boolean(baseUrl && token && workspace),
+    configured,
     name: normalizeOptionalString(merged.name),
     baseUrl,
     token,

--- a/extensions/clickclack/src/gateway.ts
+++ b/extensions/clickclack/src/gateway.ts
@@ -5,7 +5,7 @@
 import type { ChannelGatewayContext } from "openclaw/plugin-sdk/channel-contract";
 import type { RawData } from "ws";
 import { resolveClickClackInboundAccess } from "./access.js";
-import { resolveClickClackAccount } from "./accounts.js";
+import { resolveClickClackAccount, resolveClickClackRuntimeToken } from "./accounts.js";
 import { createClickClackClient } from "./http-client.js";
 import { handleClickClackInbound } from "./inbound.js";
 import { resolveWorkspaceId } from "./resolve.js";
@@ -126,9 +126,23 @@ export async function startClickClackGatewayAccount(
   if (!configuredAccount.configured) {
     throw new Error(`ClickClack is not configured for account "${configuredAccount.accountId}"`);
   }
+  // Runtime path: resolve exec/file SecretRefs the synchronous inspect
+  // resolver can't evaluate. Without this, direct exec SecretRef tokens cause
+  // startup to send an empty Authorization header even though the secrets
+  // audit reports the ref as resolvable (#98428).
+  const token = await resolveClickClackRuntimeToken({
+    cfg: ctx.cfg,
+    value: configuredAccount.config.token,
+    accountId: ctx.account.accountId,
+  });
+  if (!token) {
+    throw new Error(
+      `ClickClack token for account "${configuredAccount.accountId}" resolved to an empty value`,
+    );
+  }
   const client = createClickClackClient({
     baseUrl: configuredAccount.baseUrl,
-    token: configuredAccount.token,
+    token,
   });
   const workspaceId = await resolveWorkspaceId(client, configuredAccount.workspace);
   const me = await client.me();

--- a/extensions/clickclack/src/outbound.ts
+++ b/extensions/clickclack/src/outbound.ts
@@ -2,7 +2,7 @@
  * Outbound ClickClack delivery helpers for channel messages, thread replies,
  * and direct messages.
  */
-import { resolveClickClackAccount } from "./accounts.js";
+import { resolveClickClackAccount, resolveClickClackRuntimeToken } from "./accounts.js";
 import { createClickClackClient } from "./http-client.js";
 import { resolveChannelId, resolveWorkspaceId } from "./resolve.js";
 import { parseClickClackTarget } from "./target.js";
@@ -21,7 +21,14 @@ export async function sendClickClackText(params: {
   replyToId?: string | number | null;
 }) {
   const account = resolveClickClackAccount({ cfg: params.cfg, accountId: params.accountId });
-  const client = createClickClackClient({ baseUrl: account.baseUrl, token: account.token });
+  // Resolve exec/file SecretRefs at delivery time so direct managed-secret
+  // tokens reach ClickClack instead of the empty inspect-mode fallback (#98428).
+  const token = await resolveClickClackRuntimeToken({
+    cfg: params.cfg,
+    value: account.config.token,
+    accountId: account.accountId,
+  });
+  const client = createClickClackClient({ baseUrl: account.baseUrl, token });
   const workspaceId = await resolveWorkspaceId(client, account.workspace);
   const parsed = parseClickClackTarget(params.to);
   const explicitThreadId = params.threadId == null ? "" : String(params.threadId);


### PR DESCRIPTION
## What Problem This Solves

`channels.clickclack.token` schema accepts `env`, `file`, and `exec` SecretRefs, and `openclaw secrets audit --allow-exec` resolves them — but the ClickClack account resolver only special-cased `env` synchronously. Configured `exec` and `file` SecretRefs returned an empty token, so:

- `openclaw channels status --probe` reported ClickClack as `not configured` despite the audit succeeding.
- Gateway startup and outbound delivery had no token to send.

Fixes #98428

## Why This Change Was Made

The sync inspect path can't spawn resolvers, so it shouldn't claim a configured SecretRef is "missing" just because it can't read the value. The runtime paths (gateway start, outbound send) are already async and can call the configured SecretRef runtime resolver that the rest of OpenClaw uses (`resolveConfiguredSecretInputString` from `openclaw/plugin-sdk/secret-input-runtime`).

Splitting the responsibility:
- **Sync inspect path** (`resolveClickClackAccount`): returns `configured: true` for any configured SecretRef (`env`/`file`/`exec`). The synchronous `env`-var lookup is retained for backward compat with inspect callers that pass `env`. `file`/`exec` refs leave `token: ""` because the value can't be materialized without spawning a resolver.
- **Async runtime path** (new `resolveClickClackRuntimeToken`): calls the SDK resolver so `gateway.startAccount` and `sendClickClackText` actually evaluate `exec`/`file` refs at startup and delivery time.

The alternative — making `resolveClickClackAccount` itself async — would break the channel-plugin SDK contract (`resolveAccount`, `resolveAllowFrom`, `resolveDefaultTo` return sync values for routing/status). Adding a separate runtime-token helper keeps that contract intact and matches the issue's recommended durable fix.

## User Impact

ClickClack users who configure direct `exec` or `file` SecretRef tokens (no env-var bridge) now get:

- `openclaw health --json` / `openclaw channels status --probe` correctly reports `clickclack.configured=true`.
- Gateway startup actually authenticates with the resolved token instead of sending an empty Authorization header.
- Outbound replies deliver instead of failing with `not configured`.

## Evidence

- Local: `npx vitest run extensions/clickclack/src/accounts.test.ts` → 9 tests pass (added 3 new cases: exec SecretRef marked configured, file SecretRef marked configured, `resolveClickClackRuntimeToken` resolves env ref via SDK resolver).
- Lint: `node scripts/run-oxlint.mjs extensions/clickclack/src/{accounts.ts,gateway.ts,outbound.ts,accounts.test.ts}` clean.
- Typecheck: `node scripts/run-tsgo.mjs -p extensions/clickclack/tsconfig.json` clean.