### PR TITLE
fix: add missing compat schema keys and session-affinity header injection to transport adapter

### DIFF
--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -2669,8 +2669,9 @@ function createOpenAICompletionsClient(
   context: Context,
   apiKey: string,
   optionHeaders?: Record<string, string>,
+  sessionId?: string,
 ) {
-  const clientConfig = buildOpenAICompletionsClientConfig(model, context, optionHeaders);
+  const clientConfig = buildOpenAICompletionsClientConfig(model, context, optionHeaders, sessionId);
   return new OpenAI({
     apiKey,
     baseURL: clientConfig.baseURL,
@@ -2709,12 +2710,18 @@ function buildOpenAICompletionsClientConfig(
   model: Model,
   context: Context,
   optionHeaders?: Record<string, string>,
+  sessionId?: string,
 ): {
   baseURL: string;
   defaultHeaders: Record<string, string>;
   defaultQuery?: Record<string, string>;
 } {
   const headers = buildOpenAIClientHeaders(model, context, optionHeaders);
+  if (sessionId && model.compat?.sendSessionAffinityHeaders) {
+    headers.session_id = sessionId;
+    headers["x-client-request-id"] = sessionId;
+    headers["x-session-affinity"] = sessionId;
+  }
   const defaultQuery: Record<string, string> = {};
   let baseURL = model.baseUrl;
   let isAzureHost = false;
@@ -2777,7 +2784,13 @@ export function createOpenAICompletionsTransportStreamFn(): StreamFn {
       };
       try {
         const apiKey = options?.apiKey || getEnvApiKey(model.provider) || "";
-        const client = createOpenAICompletionsClient(model, context, apiKey, options?.headers);
+        const client = createOpenAICompletionsClient(
+          model,
+          context,
+          apiKey,
+          options?.headers,
+          options?.sessionId,
+        );
         let params = buildOpenAICompletionsParams(
           model as OpenAIModeModel,
           context,

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -246,6 +246,75 @@ const ModelCompatSchema = z
     toolCallArgumentsEncoding: z.string().optional(),
     requiresMistralToolIds: z.boolean().optional(),
     requiresOpenAiAnthropicToolPayload: z.boolean().optional(),
+    // Keys below close schema drift: they are runtime-supported compat fields
+    // that were present in ModelCompatConfig and model-registry.ts but missing
+    // from this Zod schema. Because the schema uses .strict(), any key not
+    // declared here is silently rejected during config validation.
+    sendSessionAffinityHeaders: z.boolean().optional(),
+    sendSessionIdHeader: z.boolean().optional(),
+    supportsEagerToolInputStreaming: z.boolean().optional(),
+    supportsLongCacheRetention: z.boolean().optional(),
+    cacheControlFormat: z.union([z.literal("anthropic")]).optional(),
+    zaiToolStream: z.boolean().optional(),
+    openRouterRouting: z
+      .object({
+        allow_fallbacks: z.boolean().optional(),
+        require_parameters: z.boolean().optional(),
+        data_collection: z.union([z.literal("deny"), z.literal("allow")]).optional(),
+        zdr: z.boolean().optional(),
+        enforce_distillable_text: z.boolean().optional(),
+        order: z.array(z.string()).optional(),
+        only: z.array(z.string()).optional(),
+        ignore: z.array(z.string()).optional(),
+        quantizations: z.array(z.string()).optional(),
+        sort: z
+          .union([
+            z.string(),
+            z.object({
+              by: z.string().optional(),
+              partition: z.union([z.string(), z.null()]).optional(),
+            }),
+          ])
+          .optional(),
+        max_price: z
+          .object({
+            prompt: z.union([z.number(), z.string()]).optional(),
+            completion: z.union([z.number(), z.string()]).optional(),
+            image: z.union([z.number(), z.string()]).optional(),
+            audio: z.union([z.number(), z.string()]).optional(),
+            request: z.union([z.number(), z.string()]).optional(),
+          })
+          .optional(),
+        preferred_min_throughput: z
+          .union([
+            z.number(),
+            z.object({
+              p50: z.number().optional(),
+              p75: z.number().optional(),
+              p90: z.number().optional(),
+              p99: z.number().optional(),
+            }),
+          ])
+          .optional(),
+        preferred_max_latency: z
+          .union([
+            z.number(),
+            z.object({
+              p50: z.number().optional(),
+              p75: z.number().optional(),
+              p90: z.number().optional(),
+              p99: z.number().optional(),
+            }),
+          ])
+          .optional(),
+      })
+      .optional(),
+    vercelGatewayRouting: z
+      .object({
+        only: z.array(z.string()).optional(),
+        order: z.array(z.string()).optional(),
+      })
+      .optional(),
   })
   .strict()
   .optional();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users configuring model `compat` fields like `sendSessionAffinityHeaders`, `openRouterRouting`, `vercelGatewayRouting`, `zaiToolStream`, `cacheControlFormat`, `sendSessionIdHeader`, `supportsEagerToolInputStreaming`, or `supportsLongCacheRetention` in their OpenClaw config would have these settings silently dropped during validation. The `ModelCompatSchema` in `zod-schema.core.ts` uses `.strict()`, so any compat key not explicitly declared is rejected even though all 8 are defined in `ModelCompatConfig`, used throughout the runtime, and present in the TypeBox schema in `model-registry.ts`.

The `sendSessionAffinityHeaders` compat flag was effectively dead code for real conversations. The boundary-aware transport adapter (`openai-transport-stream.ts`), which handles all embedded-agent chat turns, never injected session-affinity headers, even when the flag was enabled. Only the direct adapter had this support.

## Why This Change Was Made

Added all 8 missing compat keys to `ModelCompatSchema` with types matching their declarations in `ModelCompatConfig` and the TypeBox schemas in `model-registry.ts`. This closes the schema drift caused by the Zod schema and the TypeScript/TypeBox types being maintained separately.

For session-affinity, added a `sessionId` parameter through the transport adapter call chain (`createOpenAICompletionsClient` → `buildOpenAICompletionsClientConfig`) and pass `options?.sessionId` from the `createOpenAICompletionsTransportStreamFn` call site. The header injection (`session_id`, `x-client-request-id`, `x-session-affinity`) is gated on `model.compat?.sendSessionAffinityHeaders`, matching the existing direct adapter behavior.

Non-goal: the schema and TypeScript types are still maintained separately. A coverage test or shared derivation would prevent future drift, but that's out of scope for this fix.

## User Impact

Users can now configure `sendSessionAffinityHeaders`, `openRouterRouting`, `vercelGatewayRouting`, `zaiToolStream`, and the other 4 compat fields in their `openclaw.json` and have them survive config validation. Providers that rely on session-affinity headers for request routing or caching will now actually receive them during real chat turns, improving cache hit rates and session stickiness when `sendSessionAffinityHeaders` is enabled.

## Evidence

Verified the added schema keys and transport adapter changes match the equivalent patches already running in a production OpenClaw deployment (2026.6.9). Side-by-side comparison of all 8 schema entries and all 3 transport adapter changes confirms identical logic, types, and header values. The changes are a schema/transport parity fix, not new functionality.
