### PR TITLE
fix: Mattermost fails to load after configured plugin repair

### DIFF
--- a/src/config/plugin-auto-enable.channels.test.ts
+++ b/src/config/plugin-auto-enable.channels.test.ts
@@ -173,7 +173,70 @@ describe("applyPluginAutoEnable channels", () => {
     }
   });
 
-  describe("third-party channel plugins (pluginId ≠ channelId)", () => {
+  describe("third-party channel plugins", () => {
+    it("activates external channel plugins under plugins.entries when plugin id matches channel id", () => {
+      const result = materializePluginAutoEnableCandidates({
+        config: {
+          channels: {
+            mattermost: {
+              baseUrl: "http://mattermost:8065",
+            },
+          },
+        },
+        candidates: [
+          {
+            pluginId: "mattermost",
+            kind: "channel-configured",
+            channelId: "mattermost",
+          },
+        ],
+        env: makeIsolatedEnv(),
+        manifestRegistry: makeRegistry([
+          {
+            id: "mattermost",
+            channels: ["mattermost"],
+            origin: "global",
+          },
+        ]),
+      });
+
+      expect(result.config.plugins?.entries?.mattermost?.enabled).toBe(true);
+      expect(result.config.channels?.mattermost?.enabled).toBeUndefined();
+      expect(result.changes).toContain("Mattermost configured, enabled automatically.");
+    });
+
+    it("activates repaired external channel plugins under plugins.entries", () => {
+      const result = materializePluginAutoEnableCandidates({
+        config: {
+          channels: {
+            mattermost: {
+              baseUrl: "http://mattermost:8065",
+            },
+          },
+        },
+        candidates: [
+          {
+            pluginId: "mattermost",
+            kind: "configured-plugin-repaired",
+          },
+        ],
+        env: makeIsolatedEnv(),
+        manifestRegistry: makeRegistry([
+          {
+            id: "mattermost",
+            channels: ["mattermost"],
+            origin: "global",
+          },
+        ]),
+      });
+
+      expect(result.config.plugins?.entries?.mattermost?.enabled).toBe(true);
+      expect(result.config.channels?.mattermost?.enabled).toBeUndefined();
+      expect(result.changes).toContain(
+        "mattermost installed for existing configuration, enabled automatically.",
+      );
+    });
+
     it("uses the plugin manifest id, not the channel id, for plugins.entries", () => {
       const result = applyWithApnChannelConfig();
 
@@ -363,6 +426,7 @@ describe("applyPluginAutoEnable channels", () => {
           {
             id: "discord",
             channels: ["discord"],
+            origin: "bundled",
           },
         ]),
       });

--- a/src/config/plugin-auto-enable.channels.test.ts
+++ b/src/config/plugin-auto-enable.channels.test.ts
@@ -273,6 +273,37 @@ describe("applyPluginAutoEnable channels", () => {
       );
     });
 
+    it("keeps built-in channel enablement when a same-id plugin does not claim the channel", () => {
+      const result = materializePluginAutoEnableCandidates({
+        config: {
+          channels: {
+            telegram: {
+              botToken: "token",
+            },
+          },
+        },
+        candidates: [
+          {
+            pluginId: "telegram",
+            kind: "channel-configured",
+            channelId: "telegram",
+          },
+        ],
+        env: makeIsolatedEnv(),
+        manifestRegistry: makeRegistry([
+          {
+            id: "telegram",
+            channels: ["unrelated-channel"],
+            origin: "global",
+          },
+        ]),
+      });
+
+      expect(result.config.channels?.telegram?.enabled).toBe(true);
+      expect(result.config.plugins?.entries?.telegram).toBeUndefined();
+      expect(result.changes).toContain("Telegram configured, enabled automatically.");
+    });
+
     it("uses the plugin manifest id, not the channel id, for plugins.entries", () => {
       const result = applyWithApnChannelConfig();
 

--- a/src/config/plugin-auto-enable.channels.test.ts
+++ b/src/config/plugin-auto-enable.channels.test.ts
@@ -237,6 +237,42 @@ describe("applyPluginAutoEnable channels", () => {
       );
     });
 
+    it("allowlists repaired external channel plugins under restrictive plugin policy", () => {
+      const result = materializePluginAutoEnableCandidates({
+        config: {
+          channels: {
+            mattermost: {
+              baseUrl: "http://mattermost:8065",
+            },
+          },
+          plugins: {
+            allow: ["telegram"],
+          },
+        },
+        candidates: [
+          {
+            pluginId: "mattermost",
+            kind: "configured-plugin-repaired",
+          },
+        ],
+        env: makeIsolatedEnv(),
+        manifestRegistry: makeRegistry([
+          {
+            id: "mattermost",
+            channels: ["mattermost"],
+            origin: "global",
+          },
+        ]),
+      });
+
+      expect(result.config.plugins?.entries?.mattermost?.enabled).toBe(true);
+      expect(result.config.plugins?.allow).toEqual(["telegram", "mattermost"]);
+      expect(result.config.channels?.mattermost?.enabled).toBeUndefined();
+      expect(result.changes).toContain(
+        "mattermost installed for existing configuration, enabled automatically.",
+      );
+    });
+
     it("uses the plugin manifest id, not the channel id, for plugins.entries", () => {
       const result = applyWithApnChannelConfig();
 

--- a/src/config/plugin-auto-enable.shared.ts
+++ b/src/config/plugin-auto-enable.shared.ts
@@ -861,6 +861,15 @@ function resolveAutoEnableChannelId(params: {
   entry: PluginAutoEnableCandidate;
   manifestRegistry: PluginManifestRegistry;
 }): string | null {
+  if (params.entry.kind === "configured-plugin-repaired") {
+    return null;
+  }
+  const plugin = params.manifestRegistry.plugins.find(
+    (record) => record.id === params.entry.pluginId,
+  );
+  if (plugin && plugin.origin !== "bundled") {
+    return null;
+  }
   const builtInChannelId = normalizeChatChannelId(params.entry.pluginId);
   if (builtInChannelId) {
     return builtInChannelId;
@@ -868,9 +877,6 @@ function resolveAutoEnableChannelId(params: {
   if (params.entry.kind !== "channel-configured") {
     return null;
   }
-  const plugin = params.manifestRegistry.plugins.find(
-    (record) => record.id === params.entry.pluginId,
-  );
   if (plugin?.origin !== "bundled") {
     return null;
   }

--- a/src/config/plugin-auto-enable.shared.ts
+++ b/src/config/plugin-auto-enable.shared.ts
@@ -868,7 +868,13 @@ function resolveAutoEnableChannelId(params: {
     (record) => record.id === params.entry.pluginId,
   );
   if (plugin && plugin.origin !== "bundled") {
-    return null;
+    if (params.entry.kind !== "channel-configured") {
+      return null;
+    }
+    const channelId = normalizeManifestChannelId(params.entry.channelId);
+    if ((plugin.channels ?? []).some((id) => normalizeManifestChannelId(id) === channelId)) {
+      return null;
+    }
   }
   const builtInChannelId = normalizeChatChannelId(params.entry.pluginId);
   if (builtInChannelId) {


### PR DESCRIPTION
Closes #98564

AI-assisted: yes, prepared with Codex.

## What Problem This Solves

Fixes an issue where users upgrading a configured Mattermost deployment from OpenClaw 2026.6.10 to 2026.6.11 could run `openclaw doctor --fix`, see the missing external Mattermost plugin installed, and still have the gateway start without Mattermost loaded.

We proved this locally with the reported container upgrade path: start a 2026.6.10 OpenClaw container with `channels.mattermost.enabled=true`, Mattermost `baseUrl`, and a bot token supplied through a SecretRef; verify Mattermost loads and connects; replace that container with `ghcr.io/openclaw/openclaw:2026.6.11` while preserving the same state/config; run `openclaw doctor --fix --non-interactive`; then restart the 2026.6.11 gateway. After repair, the gateway still started with only the built-in plugin set and omitted Mattermost until `plugins.entries.mattermost.enabled=true` was set manually.

## Why This Change Was Made

Doctor already materializes auto-enable candidates for plugins repaired from existing configuration. The missing piece was that repaired channel plugin IDs such as `mattermost` were treated like built-in channel activation because their plugin ID is also a channel ID. This change keeps repaired plugin activation on the plugin config path so doctor writes `plugins.entries.<id>.enabled=true`, which is the explicit activation contract non-bundled gateway channel plugins require.

## User Impact

Users with configured Mattermost channels can upgrade from the bundled Mattermost release to the externalized Mattermost plugin release, run doctor repair, and have the gateway load Mattermost on restart without manually setting `plugins.entries.mattermost.enabled=true`.

## Evidence

Manual local container proof for the regression:

- 2026.6.10 container baseline loaded Mattermost and connected:
  `http server listening (8 plugins: browser, canvas, device-pair, file-transfer, mattermost, memory-core, phone-control, talk-voice; ...)`
  `[mattermost] connected as @test`
- The same preserved state/config after switching to the 2026.6.11 container and running `openclaw doctor --fix --non-interactive` installed the plugin but the restarted gateway omitted Mattermost:
  `Installed missing configured plugin "mattermost" from @openclaw/mattermost.`
  `http server listening (7 plugins: browser, canvas, device-pair, file-transfer, memory-core, phone-control, talk-voice; ...)`
- Setting `plugins.entries.mattermost.enabled=true` manually and restarting the same 2026.6.11 container made Mattermost load and connect again, proving the repair needed to materialize that activation bit.

Focused local validation for this patch:

- `node scripts/run-vitest.mjs src/config/plugin-auto-enable.channels.test.ts`
- `node scripts/run-vitest.mjs src/commands/doctor/repair-sequencing.test.ts`
- `node scripts/run-vitest.mjs src/config/plugin-auto-enable.core.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
