### PR TITLE
fix(process): resolve Gemini CLI Windows shim

### DIFF
--- a/src/process/supervisor/adapters/child.test.ts
+++ b/src/process/supervisor/adapters/child.test.ts
@@ -424,6 +424,28 @@ describe("createChildAdapter", () => {
     expect(spawnArgs.fallbacks).toStrictEqual([]);
   });
 
+  it("wraps Gemini CLI Windows shims through trusted cmd.exe", async () => {
+    setPlatform("win32");
+
+    await createAdapterHarness({
+      pid: 3336,
+      argv: ["gemini", "--help"],
+    });
+
+    const spawnArgs = firstSpawnWithFallbackParams();
+    expect(spawnArgs.argv).toEqual([
+      expectedTrustedCmdExe(),
+      "/d",
+      "/s",
+      "/c",
+      "gemini.cmd --help",
+    ]);
+    expect(spawnArgs.options?.detached).toBe(false);
+    expect(spawnArgs.options?.windowsHide).toBe(true);
+    expect(spawnArgs.options?.windowsVerbatimArguments).toBe(true);
+    expect(spawnArgs.fallbacks).toStrictEqual([]);
+  });
+
   it("wraps Linux child spawns and strips shell-init env", async () => {
     const originalBashEnv = process.env.BASH_ENV;
     const originalEnv = process.env.ENV;

--- a/src/process/supervisor/adapters/child.ts
+++ b/src/process/supervisor/adapters/child.ts
@@ -20,7 +20,7 @@ const WINDOWS_CLOSE_STATE_SETTLE_TIMEOUT_MS = 250;
 function resolveCommand(command: string): string {
   return resolveWindowsCommandShim({
     command,
-    cmdCommands: ["npm", "pnpm", "yarn", "npx"],
+    cmdCommands: ["npm", "pnpm", "yarn", "npx", "gemini"],
   });
 }
 

--- a/src/process/windows-command.test.ts
+++ b/src/process/windows-command.test.ts
@@ -33,6 +33,16 @@ describe("resolveWindowsCommandShim", () => {
     ).toBe("corepack.cmd");
   });
 
+  it("appends .cmd for Gemini CLI on Windows when configured", () => {
+    expect(
+      resolveWindowsCommandShim({
+        command: "gemini",
+        cmdCommands: ["gemini"],
+        platform: "win32",
+      }),
+    ).toBe("gemini.cmd");
+  });
+
   it("keeps explicit extensions on Windows", () => {
     expect(
       resolveWindowsCommandShim({


### PR DESCRIPTION
## Summary

Fix Windows Gemini CLI launches by resolving the npm-installed `gemini` shim to `gemini.cmd` before the supervisor spawns child processes.

## Issue/Motivation

Fixes #98573.

On Windows, npm global binaries such as Gemini CLI are exposed through `.cmd` shims. The child supervisor already resolves npm/pnpm/yarn/npx through the trusted `cmd.exe` wrapper, but `google-gemini-cli` ultimately spawns bare `gemini`, which can fail with `spawn gemini ENOENT` even when `gemini --help` works in a terminal.

## Changes

- Add `gemini` to the Windows command shim allowlist used by the child process adapter.
- Add regression coverage for the low-level shim resolver.
- Add child-adapter coverage proving Windows `gemini --help` is invoked through trusted `cmd.exe /d /s /c gemini.cmd --help`.

## Testing

- `pnpm exec oxfmt --check --threads=1 src/process/supervisor/adapters/child.ts src/process/supervisor/adapters/child.test.ts src/process/windows-command.test.ts`
- `pnpm exec vitest run src/process/windows-command.test.ts src/process/supervisor/adapters/child.test.ts` — 2 files passed, 24 tests passed
- `git diff --check`
- Diff secret scan over added lines — no matches

Note: `pnpm lint:core` and a direct `node scripts/run-oxlint.mjs ...` attempt were stopped locally because type-aware oxlint/tsgolint hung for several minutes on unrelated broad shards/files in this low-disk watchdog environment. The focused formatter and regression tests above passed.

## What Problem This Solves

Windows users who install Gemini CLI through npm can have `gemini` available in their terminal while Node child-process spawning still fails with `spawn gemini ENOENT`, because the runnable target is the npm `.cmd` shim. This prevents OpenClaw's `google-gemini-cli` backend from starting on Windows.

## Evidence

- The Google CLI backend uses `command: "gemini"`.
- Before this change, the supervisor Windows shim allowlist only included `npm`, `pnpm`, `yarn`, and `npx`.
- The new tests prove:
  - `resolveWindowsCommandShim({ command: "gemini", cmdCommands: ["gemini"], platform: "win32" })` returns `gemini.cmd`.
  - The child adapter wraps `gemini --help` as trusted `cmd.exe /d /s /c gemini.cmd --help` on Windows.
- Local validation passed:
  - `pnpm exec oxfmt --check --threads=1 src/process/supervisor/adapters/child.ts src/process/supervisor/adapters/child.test.ts src/process/windows-command.test.ts`
  - `pnpm exec vitest run src/process/windows-command.test.ts src/process/supervisor/adapters/child.test.ts` — 24 tests passed
  - `git diff --check`
  - Diff secret scan over added lines — no matches
