### PR TITLE
fix(cli): clear stale Claude CLI session bindings after failover

### DIFF
--- a/src/auto-reply/reply/agent-runner-cli-dispatch.test.ts
+++ b/src/auto-reply/reply/agent-runner-cli-dispatch.test.ts
@@ -1,7 +1,12 @@
 // Tests CLI dispatch arguments and runtime selection for agent runner turns.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { EmbeddedAgentRunResult } from "../../agents/embedded-agent-runner/types.js";
+import { FailoverError } from "../../agents/failover-error.js";
 import { createAgentRunRestartAbortError } from "../../agents/run-termination.js";
+import type { SessionEntry } from "../../config/sessions.js";
 import {
   emitAgentEvent,
   getAgentEventLifecycleGeneration,
@@ -9,6 +14,7 @@ import {
   resetAgentEventsForTest,
 } from "../../infra/agent-events.js";
 import {
+  clearFailedReusedCliSessionBinding,
   createCliToolSummaryTracker,
   keepCliSessionBindingOnlyWhenReused,
   runCliAgentWithLifecycle,
@@ -214,6 +220,54 @@ describe("keepCliSessionBindingOnlyWhenReused", () => {
     expect(onDroppedReplacement).toHaveBeenCalledOnce();
     expect(result.meta.agentMeta?.sessionId).toBe("");
     expect(result.meta.agentMeta?.cliSessionBinding).toBeUndefined();
+  });
+});
+
+describe("clearFailedReusedCliSessionBinding", () => {
+  it("clears reused Claude CLI session state from memory and sessions.json after failover", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cli-dispatch-"));
+    const storePath = path.join(tmpDir, "sessions.json");
+    const sessionKey = "agent:main:telegram:direct:user";
+    const sessionEntry: SessionEntry = {
+      sessionId: "openclaw-session",
+      updatedAt: 1,
+      cliSessionBindings: {
+        "claude-cli": { sessionId: "stale-claude-session" },
+      },
+      cliSessionIds: { "claude-cli": "stale-claude-session" },
+      claudeCliSessionId: "stale-claude-session",
+    };
+    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
+    await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2), "utf-8");
+
+    try {
+      await clearFailedReusedCliSessionBinding({
+        provider: "claude-cli",
+        error: new FailoverError("Not logged in", {
+          reason: "auth",
+          provider: "claude-cli",
+          model: "claude-opus-4-6",
+        }),
+        cliSessionBinding: { sessionId: "stale-claude-session" },
+        sessionKey,
+        sessionStore,
+        storePath,
+        activeSessionEntry: sessionEntry,
+      });
+
+      expect(sessionStore[sessionKey]?.cliSessionBindings).toBeUndefined();
+      expect(sessionStore[sessionKey]?.cliSessionIds).toBeUndefined();
+      expect(sessionStore[sessionKey]?.claudeCliSessionId).toBeUndefined();
+      const persisted = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+        string,
+        SessionEntry
+      >;
+      expect(persisted[sessionKey]?.cliSessionBindings).toBeUndefined();
+      expect(persisted[sessionKey]?.cliSessionIds).toBeUndefined();
+      expect(persisted[sessionKey]?.claudeCliSessionId).toBeUndefined();
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/auto-reply/reply/agent-runner-cli-dispatch.ts
+++ b/src/auto-reply/reply/agent-runner-cli-dispatch.ts
@@ -6,10 +6,11 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import { runCliAgent } from "../../agents/cli-runner.js";
 import type { RunCliAgentParams } from "../../agents/cli-runner/types.js";
-import { clearCliSession } from "../../agents/cli-session.js";
+import { clearCliSession, getCliSessionBinding } from "../../agents/cli-session.js";
 import { extractToolResultText } from "../../agents/embedded-agent-subscribe.tools.js";
 import { inferToolMetaFromArgs } from "../../agents/embedded-agent-utils.js";
 import type { EmbeddedAgentRunResult } from "../../agents/embedded-agent.js";
+import { FailoverError } from "../../agents/failover-error.js";
 import {
   DEFAULT_FAST_MODE_AUTO_ON_SECONDS,
   formatFastModeAutoProgressText,
@@ -28,6 +29,7 @@ import {
   onAgentEvent,
   withAgentRunLifecycleGeneration,
 } from "../../infra/agent-events.js";
+import { readErrorName } from "../../infra/errors.js";
 import { FAST_MODE_AUTO_PROGRESS_KIND, type ReplyPayload } from "../reply-payload.js";
 import { formatToolAggregate } from "../tool-meta.js";
 import { resolveAgentLifecycleTerminalMetadata } from "./agent-lifecycle-terminal.js";
@@ -187,10 +189,17 @@ export async function clearDroppedCliSessionBinding(params: {
   sessionStore?: Record<string, SessionEntry>;
   storePath?: string;
   activeSessionEntry?: SessionEntry;
+  expectedSessionId?: string;
 }): Promise<void> {
   const updatedAt = Date.now();
   const clearEntry = (entry: SessionEntry | undefined) => {
     if (!entry) {
+      return;
+    }
+    if (
+      params.expectedSessionId &&
+      getCliSessionBinding(entry, params.provider)?.sessionId !== params.expectedSessionId
+    ) {
       return;
     }
     clearCliSession(entry, params.provider);
@@ -208,6 +217,32 @@ export async function clearDroppedCliSessionBinding(params: {
       return entry;
     },
   );
+}
+
+export async function clearFailedReusedCliSessionBinding(params: {
+  provider: string;
+  error: unknown;
+  cliSessionBinding?: { sessionId?: string };
+  sessionKey?: string;
+  sessionStore?: Record<string, SessionEntry>;
+  storePath?: string;
+  activeSessionEntry?: SessionEntry;
+}): Promise<void> {
+  const sessionId = normalizeOptionalString(params.cliSessionBinding?.sessionId);
+  if (!sessionId || !isClaudeCliProvider(params.provider)) {
+    return;
+  }
+  if (!(params.error instanceof FailoverError) && readErrorName(params.error) !== "AbortError") {
+    return;
+  }
+  await clearDroppedCliSessionBinding({
+    provider: params.provider,
+    sessionKey: params.sessionKey,
+    sessionStore: params.sessionStore,
+    storePath: params.storePath,
+    activeSessionEntry: params.activeSessionEntry,
+    expectedSessionId: sessionId,
+  });
 }
 
 function createToolEventBridge(params: {

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -2596,6 +2596,59 @@ describe("runAgentTurnWithFallback", () => {
     });
   });
 
+  it("clears reused Claude CLI bindings after channel FailoverError", async () => {
+    state.isCliProviderMock.mockImplementation((provider: unknown) => provider === "claude-cli");
+    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
+      result: await params.run("claude-cli", "claude-opus-4-6"),
+      provider: "claude-cli",
+      model: "claude-opus-4-6",
+      attempts: [],
+    }));
+    state.runCliAgentMock.mockRejectedValueOnce(
+      new FailoverError("Not logged in", {
+        reason: "auth",
+        provider: "claude-cli",
+        model: "claude-opus-4-6",
+      }),
+    );
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const followupRun = createFollowupRun();
+    followupRun.run.provider = "claude-cli";
+    followupRun.run.model = "claude-opus-4-6";
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      sessionFile: "/tmp/session.jsonl",
+      updatedAt: 1,
+      cliSessionBindings: {
+        "claude-cli": { sessionId: "stale-claude-session" },
+      },
+      cliSessionIds: { "claude-cli": "stale-claude-session" },
+      claudeCliSessionId: "stale-claude-session",
+    };
+    const activeSessionStore = { main: sessionEntry };
+    const { replyOperation, failMock } = createMockReplyOperation();
+
+    const result = await runAgentTurnWithFallback({
+      ...createMinimalRunAgentTurnParams({ followupRun, replyOperation }),
+      activeSessionStore,
+      getActiveSessionEntry: () => activeSessionStore.main,
+    });
+
+    expect(result.kind).toBe("final");
+    expect(failMock).toHaveBeenCalledWith("run_failed", expect.any(FailoverError));
+    expect(state.runCliAgentMock).toHaveBeenCalledOnce();
+    expectMockCallArgFields(state.runCliAgentMock, 0, "CLI run params", {
+      cliSessionId: "stale-claude-session",
+      cliSessionBinding: {
+        sessionId: "stale-claude-session",
+      },
+    });
+    expect(activeSessionStore.main.cliSessionBindings).toBeUndefined();
+    expect(activeSessionStore.main.cliSessionIds).toBeUndefined();
+    expect(activeSessionStore.main.claudeCliSessionId).toBeUndefined();
+  });
+
   it("keeps the first CLI session created by a room-event turn", async () => {
     state.isCliProviderMock.mockReturnValue(true);
     state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -116,6 +116,7 @@ import {
 import { resolveRunAuthProfile } from "./agent-runner-auth-profile.js";
 import {
   clearDroppedCliSessionBinding,
+  clearFailedReusedCliSessionBinding,
   createCliToolSummaryTracker,
   keepCliSessionBindingOnlyWhenReused,
   runCliAgentWithLifecycle,
@@ -2362,7 +2363,22 @@ export async function runAgentTurnWithFallback(params: {
                   onFastModeAutoProgress: async (payload) => {
                     await params.opts?.onToolResult?.(payload);
                   },
-                  onErrorBeforeLifecycle: async () => {
+                  onErrorBeforeLifecycle: async (error) => {
+                    try {
+                      await clearFailedReusedCliSessionBinding({
+                        provider: cliExecutionProvider,
+                        error,
+                        cliSessionBinding,
+                        sessionKey: params.sessionKey,
+                        sessionStore: params.activeSessionStore,
+                        storePath: params.storePath,
+                        activeSessionEntry: params.getActiveSessionEntry(),
+                      });
+                    } catch (clearError) {
+                      logVerbose(
+                        `failed to clear failed CLI session binding (non-fatal): ${String(clearError)}`,
+                      );
+                    }
                     if (!rollbackFallbackCandidateSelection) {
                       return;
                     }

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -53,6 +53,7 @@ import {
 } from "./agent-lifecycle-terminal.js";
 import {
   clearDroppedCliSessionBinding,
+  clearFailedReusedCliSessionBinding,
   createCliToolSummaryTracker,
   keepCliSessionBindingOnlyWhenReused,
   runCliAgentWithLifecycle,
@@ -1023,6 +1024,23 @@ export function createFollowupRunner(params: {
                         { kind: "tool", mirror: false, runId },
                       );
                     });
+                  },
+                  onErrorBeforeLifecycle: async (error) => {
+                    try {
+                      await clearFailedReusedCliSessionBinding({
+                        provider: cliExecutionProvider,
+                        error,
+                        cliSessionBinding,
+                        sessionKey: replySessionKey,
+                        sessionStore,
+                        storePath,
+                        activeSessionEntry,
+                      });
+                    } catch (clearError) {
+                      logVerbose(
+                        `failed to clear failed followup CLI session binding (non-fatal): ${String(clearError)}`,
+                      );
+                    }
                   },
                   transformResult:
                     queued.currentInboundEventKind === "room_event"


### PR DESCRIPTION
## What Problem This Solves

After model failover or abort on a reused Claude CLI session, stale `cliSessionBindings` / `cliSessionIds` remained in session state. The next turn attempted to resume a dead CLI session instead of starting fresh, causing confusing failures on recovery.

Fixes #97887

## Evidence

- Added `clearFailedReusedCliSessionBinding()` and wired it through CLI lifecycle `onErrorBeforeLifecycle` for main agent turns and followup queue runs.
- Regression tests: `node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-cli-dispatch.test.ts` — 13/13 pass.
- Targeted execution-path tests for failover/abort cleanup pass locally.

## Summary

- Add `clearFailedReusedCliSessionBinding()` to drop stale bindings when a reused **claude-cli** session fails with `FailoverError` or `AbortError`.
- Guard `clearDroppedCliSessionBinding` with `expectedSessionId` to avoid clearing a newer binding for the same key.
