### PR TITLE
fix(media): guard ffprobe JSON parse against malformed output

### DIFF
--- a/src/media/video-dimensions.test.ts
+++ b/src/media/video-dimensions.test.ts
@@ -26,6 +26,12 @@ describe("parseFfprobeVideoDimensions", () => {
       parseFfprobeVideoDimensions(JSON.stringify({ streams: [{ width: 720.5, height: 1280 }] })),
     ).toBeUndefined();
   });
+
+  it("returns undefined for malformed JSON instead of throwing", () => {
+    expect(parseFfprobeVideoDimensions("{")).toBeUndefined();
+    expect(parseFfprobeVideoDimensions("")).toBeUndefined();
+    expect(parseFfprobeVideoDimensions("not json")).toBeUndefined();
+  });
 });
 
 describe("probeVideoDimensions", () => {

--- a/src/media/video-dimensions.test.ts
+++ b/src/media/video-dimensions.test.ts
@@ -28,9 +28,9 @@ describe("parseFfprobeVideoDimensions", () => {
   });
 
   it("returns undefined for malformed JSON instead of throwing", () => {
-    expect(parseFfprobeVideoDimensions("{")).toBeUndefined();
-    expect(parseFfprobeVideoDimensions("")).toBeUndefined();
-    expect(parseFfprobeVideoDimensions("not json")).toBeUndefined();
+    for (const stdout of ["{", "", "not json", "null", "42", '"text"', '{"streams":{}}']) {
+      expect(parseFfprobeVideoDimensions(stdout)).toBeUndefined();
+    }
   });
 });
 

--- a/src/media/video-dimensions.ts
+++ b/src/media/video-dimensions.ts
@@ -16,7 +16,12 @@ function parsePositiveDimension(value: unknown): number | undefined {
 
 /** Parses ffprobe JSON output, accepting only positive integer first-stream dimensions. */
 export function parseFfprobeVideoDimensions(stdout: string): VideoDimensions | undefined {
-  const parsed = JSON.parse(stdout) as { streams?: Array<{ width?: unknown; height?: unknown }> };
+  let parsed: { streams?: Array<{ width?: unknown; height?: unknown }> };
+  try {
+    parsed = JSON.parse(stdout) as { streams?: Array<{ width?: unknown; height?: unknown }> };
+  } catch {
+    return undefined;
+  }
   const stream = parsed.streams?.[0];
   const width = parsePositiveDimension(stream?.width);
   const height = parsePositiveDimension(stream?.height);

--- a/src/media/video-dimensions.ts
+++ b/src/media/video-dimensions.ts
@@ -16,15 +16,23 @@ function parsePositiveDimension(value: unknown): number | undefined {
 
 /** Parses ffprobe JSON output, accepting only positive integer first-stream dimensions. */
 export function parseFfprobeVideoDimensions(stdout: string): VideoDimensions | undefined {
-  let parsed: { streams?: Array<{ width?: unknown; height?: unknown }> };
+  let parsed: unknown;
   try {
-    parsed = JSON.parse(stdout) as { streams?: Array<{ width?: unknown; height?: unknown }> };
+    parsed = JSON.parse(stdout);
   } catch {
     return undefined;
   }
-  const stream = parsed.streams?.[0];
-  const width = parsePositiveDimension(stream?.width);
-  const height = parsePositiveDimension(stream?.height);
+  if (!parsed || typeof parsed !== "object") {
+    return undefined;
+  }
+  const streams = (parsed as { streams?: unknown }).streams;
+  const stream = Array.isArray(streams) ? streams[0] : undefined;
+  if (!stream || typeof stream !== "object") {
+    return undefined;
+  }
+  const record = stream as Record<string, unknown>;
+  const width = parsePositiveDimension(record.width);
+  const height = parsePositiveDimension(record.height);
   return width && height ? { width, height } : undefined;
 }
 


### PR DESCRIPTION
## What Problem This Solves
Fixes an issue where `parseFfprobeVideoDimensions` — an exported public function in the plugin SDK — would throw an unhandled `SyntaxError` when ffprobe produces malformed or truncated JSON output. The function is called by external plugins through `openclaw/plugin-sdk`, and callers may not expect a JSON parse crash from a parsing helper.

## Why This Change Was Made
Added a try-catch around `JSON.parse` inside `parseFfprobeVideoDimensions` so malformed stdout returns `undefined` instead of throwing. This matches the function's existing contract (it already returns `undefined` for missing/invalid dimensions) and keeps the fix at the earliest chokepoint — the parser itself — rather than pushing error handling to every caller.

## User Impact
Malformed ffprobe output no longer crashes callers with an unhandled `SyntaxError`. The function now gracefully returns `undefined`, consistent with how it handles other invalid input (zero dimensions, non-integer values, missing streams).

## Real behavior proof

**Behavior addressed:** `parseFfprobeVideoDimensions` must return `undefined` for malformed JSON instead of throwing `SyntaxError`.

**Real environment tested:** Linux 4.19, Node 22, `node --import tsx proof.mts` importing the real production export from `src/media/video-dimensions.js` (no vitest, no mock).

**Evidence after fix (terminal output):**
```
[case 1] parseFfprobeVideoDimensions: valid ffprobe JSON
  ok: returns width=720, height=1280
[case 2] parseFfprobeVideoDimensions: malformed JSON
  ok: truncated '{' returns undefined
  ok: empty string returns undefined
  ok: garbage text returns undefined
  ok: unclosed object returns undefined
[case 3] parseFfprobeVideoDimensions: valid JSON, invalid dimensions
  ok: zero width returns undefined
  ok: non-integer width returns undefined
  ok: empty streams returns undefined
  ok: missing streams key returns undefined
[case 4] parseFfprobeVideoDimensions: large valid JSON (5 MiB)
  ok: handles 5 MiB payload (first stream extracted)

=== Summary ===
ALL PROOF ASSERTIONS: 10 passed, 0 failed
```

**Negative control — pre-fix behavior reproduced (same script, same environment):**
```
[case 2] parseFfprobeVideoDimensions: malformed JSON
  FAIL: truncated '{' returns undefined
  FAIL: empty string returns undefined — Unexpected end of JSON input
  FAIL: garbage text returns undefined — Unexpected token 'o', "not json" is not valid JSON
  FAIL: unclosed object returns undefined — Unexpected end of JSON input

=== Summary ===
ALL PROOF ASSERTIONS: 6 passed, 4 failed
```
4 malformed JSON cases consistently throw `SyntaxError` on current main. The fix makes all 4 return `undefined` and all 10 assertions pass.

**What was not tested:** Live ffprobe invocation (requires ffprobe binary). The proof covers the parse function boundary with 4 categories: valid JSON, 4 malformed variants, 4 invalid-dimension variants, and a 5 MiB large payload.

## Evidence
- `pnpm test src/media/video-dimensions.test.ts` — 5 passed, 0 failed
- Standalone proof: `node --import tsx proof.mts` — 10 passed, 0 failed (4 malformed JSON, 4 invalid dimensions, 1 valid, 1 5 MiB)
- Negative control (main): 6 passed, 4 failed (all malformed JSON crash with SyntaxError)
- No competing open PRs

