### PR TITLE
fix(device-pair): remove INADDR_ANY and IPv6 unspecified from isLoopbackHost

### DIFF
--- a/extensions/device-pair/index.test.ts
+++ b/extensions/device-pair/index.test.ts
@@ -813,6 +813,30 @@ describe("device-pair /pair default setup code", () => {
     expect(text).toContain("Gateway: ws://127.0.0.1:18789");
   });
 
+  it.each(["ws://0.0.0.0:18789", "ws://[::]:18789"])(
+    "rejects unspecified cleartext setup url %s before issuing setup codes",
+    async (publicUrl) => {
+      const command = registerPairCommand({
+        pluginConfig: {
+          publicUrl,
+        },
+      });
+      const result = await command.handler(
+        createCommandContext({
+          channel: "webchat",
+          args: "",
+          commandBody: "/pair",
+          gatewayClientScopes: INTERNAL_SETUP_SCOPES,
+        }),
+      );
+
+      expect(pluginApiMocks.issueDeviceBootstrapToken).not.toHaveBeenCalled();
+      expect(requireText(result)).toContain(
+        "Tailscale and public mobile pairing require a secure gateway URL",
+      );
+    },
+  );
+
   it("allows private LAN cleartext setup urls", async () => {
     const command = registerPairCommand({
       pluginConfig: {

--- a/extensions/device-pair/index.ts
+++ b/extensions/device-pair/index.ts
@@ -204,7 +204,7 @@ function isLoopbackHost(host: string): boolean {
   if (!normalized) {
     return false;
   }
-  if (normalized === "localhost" || normalized === "0.0.0.0" || normalized === "::") {
+  if (normalized === "localhost") {
     return true;
   }
   const octets = parseIPv4Octets(normalized);


### PR DESCRIPTION
## What Problem This Solves

The `isLoopbackHost` function in the device-pair extension incorrectly classifies `0.0.0.0` (INADDR_ANY — bind to all interfaces) and `::` (IPv6 unspecified address) as loopback addresses. This causes incorrect behavior in `isMobilePairingCleartextAllowedHost`, which uses `isLoopbackHost` to decide whether cleartext (ws://) setup codes are safe.

## Why This Change Was Made

- `0.0.0.0` is INADDR_ANY, not a loopback address — it means "bind to all interfaces"
- `::` is the IPv6 unspecified address, not a loopback address
- The canonical implementation in `src/gateway/net.ts` `isLoopbackHost` explicitly excludes both
- `packages/net-policy/src/ip.ts` `isLoopbackIpAddress` correctly classifies neither as loopback

## User Impact

`/pair` no longer emits unusable cleartext mobile setup codes for unspecified bind addresses. Real loopback, private LAN, mDNS, and Android-emulator setup URLs remain supported.

## Evidence

```text
$ node scripts/run-vitest.mjs run extensions/device-pair/ 2>&1 | tail -10

 Test Files  4 passed (4)
      Tests  58 passed (58)
   Start at  21:15:36
   Duration  3.19s (transform 1.37s, setup 734ms, import 1.56s, tests 555ms, environment 0ms)
```

The final head also adds a table-driven `/pair` regression for `ws://0.0.0.0:18789` and `ws://[::]:18789`; both cases must reject before `issueDeviceBootstrapToken` is called. The adjacent behavior remains covered because:
- loopback addresses (127.x.x.x, ::1, localhost) are still correctly recognized
- `10.0.2.2` (Android emulator) and private LAN addresses are independent checks
- The canonical `isLoopbackHost` in `src/gateway/net.ts` has 49 test cases explicitly verifying `0.0.0.0` and `::` are NOT loopback

Final reviewed head: `9fdeba53463af274e0df8ddbdca9a59b23efd291`. Fresh exact-head CI is required before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
