### PR TITLE
fix(diffs): widen isLoopbackClientIp to full 127.0.0.0/8 loopback range

### DIFF
--- a/extensions/diffs/src/http.ts
+++ b/extensions/diffs/src/http.ts
@@ -190,7 +190,7 @@ function normalizeRemoteClientKey(remoteAddress: string | undefined): string {
 }
 
 function isLoopbackClientIp(clientIp: string): boolean {
-  return clientIp === "127.0.0.1" || clientIp === "::1";
+  return clientIp.startsWith("127.") || clientIp === "::1";
 }
 
 function hasProxyForwardingHints(req: IncomingMessage): boolean {


### PR DESCRIPTION
## What Problem This Solves

The `isLoopbackClientIp` function in the diffs extension only checks for exact `"127.0.0.1"`, missing the full 127.0.0.0/8 loopback range. Container and sandbox environments commonly use other loopback addresses like `127.0.0.2`.

## Why This Change Was Made

Changed from `clientIp === "127.0.0.1"` to `clientIp.startsWith("127.")`, covering all 127.x.x.x loopback addresses. This follows the same pattern as the canonical implementation in `packages/net-policy/src/ip.ts` which uses `ipaddr.js` range check for the full 127/8 range.

## Evidence

```text
$ node scripts/run-vitest.mjs run extensions/diffs/ 2>&1 | tail -12

 ✓ |extension-diffs| ../../extensions/diffs/src/viewer-client.test.ts > ...
 Test Files  10 passed (10)
      Tests  135 passed (135)
   Start at  21:23:05
   Duration  27.76s (transform 18.23s, setup 2.08s, import 18.87s, tests 4.16s, environment 1.98s)
```

All 135 tests across 10 test files pass. The `isLoopbackClientIp` function is called from `resolveViewerAccess` which determines whether a request is local — the wider range check means containers and sandboxes on `127.0.0.2`+ are now correctly classified as local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)