### PR TITLE
fix(audit): widen isLoopbackPublishHost to full 127.0.0.0/8 loopback range

### DIFF
--- a/src/security/audit-extra.async.ts
+++ b/src/security/audit-extra.async.ts
@@ -408,7 +408,11 @@ function parsePublishedHostFromDockerPortLine(line: string): string | null {
 
 function isLoopbackPublishHost(host: string): boolean {
   const normalized = normalizeOptionalLowercaseString(host);
-  return normalized === "127.0.0.1" || normalized === "::1" || normalized === "localhost";
+  return (
+    normalized === "::1" ||
+    normalized === "localhost" ||
+    (normalized !== undefined && normalized.startsWith("127."))
+  );
 }
 
 async function readSandboxBrowserPortMappings(params: {


### PR DESCRIPTION
## What Problem This Solves

The `isLoopbackPublishHost` function in the security audit module only checks for exact `"127.0.0.1"`, missing the full 127.0.0.0/8 loopback range. Docker containers and sandbox environments commonly publish ports on other loopback addresses like `127.0.0.2`.

## Why This Change Was Made

Changed from `normalized === "127.0.0.1"` to `normalized.startsWith("127.")`, covering all 127.x.x.x loopback addresses. This matches the canonical implementation in `packages/net-policy/src/ip.ts`.

## Evidence

```text
$ node scripts/run-vitest.mjs run src/security/audit-extra.async.test.ts 2>&1 | tail -12

 ✓ |unit-fast| src/security/audit-extra.async.test.ts > audit-extra async code safety > ...
 Test Files  1 passed (1)
      Tests  6 passed (6)
   Start at  21:30:19
   Duration  971ms (transform 361ms, setup 0ms, import 693ms, tests 92ms, environment 0ms)
```

All 6 audit-extra tests pass. The `isLoopbackPublishHost` function is used in sandbox browser port mapping validation to detect loopback-published docker ports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)