### PR TITLE
fix: media tools skip env-key provider plugins when auto-selecting models

### DIFF
--- a/src/agents/tools/model-config.helpers.test.ts
+++ b/src/agents/tools/model-config.helpers.test.ts
@@ -1,6 +1,6 @@
 // Model config helper tests cover provider auth detection across config and
 // stored agent auth profiles for reusable media tools.
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { AuthProfileCredential, AuthProfileStore } from "../auth-profiles/types.js";
 import {
@@ -12,6 +12,17 @@ import {
 vi.mock("../auth-profiles/external-cli-sync.js", () => ({
   resolveExternalCliAuthProfiles: () => [],
 }));
+
+// Env-key candidates for plugin providers are resolved from the metadata
+// snapshot keyed by config/workspace. Stub the env resolver so a provider is
+// only "env-authed" when config/workspaceDir actually reach it, mirroring a
+// config-scoped (non-bundled) provider plugin without loading plugin runtime.
+const authMocks = vi.hoisted(() => ({ resolveEnvApiKey: vi.fn() }));
+
+vi.mock("../model-auth.js", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, resolveEnvApiKey: authMocks.resolveEnvApiKey };
+});
 
 const AGENT_DIR = "/tmp/openclaw-model-config-helper";
 const MODEL = "gpt-5.5";
@@ -83,11 +94,41 @@ const hasDirectOpenAiKey = (
     ...overrides,
   });
 
+beforeEach(() => {
+  authMocks.resolveEnvApiKey.mockReset();
+  authMocks.resolveEnvApiKey.mockImplementation(
+    (provider: string, _env?: unknown, options?: { config?: unknown }) =>
+      provider === "acme" && options?.config
+        ? { apiKey: "sk-acme-env", source: "env: ACME_API_KEY" }
+        : null,
+  );
+});
+
 afterEach(() => {
   vi.unstubAllEnvs();
 });
 
 describe("hasProviderAuthForTool", () => {
+  it("threads cfg/workspaceDir into config-aware env-key resolution", () => {
+    // Regression: hasProviderAuthForTool used to call the env resolver without
+    // cfg/workspaceDir, so config-scoped (non-bundled) provider plugins whose
+    // env candidates are only visible with config were reported as unauthed.
+    const cfg = { models: { providers: {} } } as OpenClawConfig;
+    hasProviderAuthForTool({ provider: "acme", cfg, workspaceDir: "/ws" });
+    expect(authMocks.resolveEnvApiKey).toHaveBeenCalledWith("acme", undefined, {
+      config: cfg,
+      workspaceDir: "/ws",
+    });
+  });
+
+  it("accepts env-key plugin provider auth only when config reaches env resolution", () => {
+    // "acme" is not in models.json, so custom-provider auth is false; the only
+    // path to true is the config-aware env lookup.
+    const cfg = { models: { providers: {} } } as OpenClawConfig;
+    expect(hasProviderAuthForTool({ provider: "acme", cfg })).toBe(true);
+    expect(hasProviderAuthForTool({ provider: "acme" })).toBe(false);
+  });
+
   it("accepts config-backed custom provider auth", () => {
     const cfg = {
       models: {

--- a/src/agents/tools/model-config.helpers.ts
+++ b/src/agents/tools/model-config.helpers.ts
@@ -66,13 +66,29 @@ export function resolveDefaultModelRef(cfg?: OpenClawConfig): { provider: string
 /** Returns whether a provider has env, profile, or external CLI auth available. */
 export function hasAuthForProvider(params: {
   provider: string;
+  cfg?: OpenClawConfig;
+  workspaceDir?: string;
   agentDir?: string;
   authStore?: AuthProfileStore;
 }): boolean {
-  if (resolveEnvApiKey(params.provider)?.apiKey) {
+  // Env-key resolution is config/workspace aware: plugin-provider env candidates
+  // come from the metadata snapshot resolved for this config. Non-bundled or
+  // config-scoped provider plugins are invisible without it, so a config-blind
+  // lookup would wrongly report "no auth" for env-key providers.
+  if (
+    resolveEnvApiKey(params.provider, undefined, {
+      config: params.cfg,
+      workspaceDir: params.workspaceDir,
+    })?.apiKey
+  ) {
     return true;
   }
-  return hasAuthProfileForProvider({ ...params, includeExternalCli: true });
+  return hasAuthProfileForProvider({
+    provider: params.provider,
+    agentDir: params.agentDir,
+    authStore: params.authStore,
+    includeExternalCli: true,
+  });
 }
 
 /** Returns whether an auth profile exists for a provider, optionally filtered by type. */
@@ -120,6 +136,8 @@ export function hasProviderAuthForTool(params: {
   if (
     hasAuthForProvider({
       provider: params.provider,
+      cfg: params.cfg,
+      workspaceDir: params.workspaceDir,
       agentDir: params.agentDir,
       authStore: params.authStore,
     })

--- a/src/agents/tools/video-generate-tool.ts
+++ b/src/agents/tools/video-generate-tool.ts
@@ -270,6 +270,7 @@ function collectVideoGenerationModelProviderIds(params: {
 function isVideoGenerationProviderConfigured(params: {
   snapshot: Pick<PluginMetadataSnapshot, "index" | "plugins">;
   cfg: OpenClawConfig;
+  workspaceDir?: string;
   agentDir?: string;
   authStore?: AuthProfileStore;
   providerId: string;
@@ -285,6 +286,8 @@ function isVideoGenerationProviderConfigured(params: {
     }) ||
     hasAuthForProvider({
       provider: params.providerId,
+      cfg: params.cfg,
+      workspaceDir: params.workspaceDir,
       agentDir: params.agentDir,
       authStore: params.authStore,
     })
@@ -347,6 +350,7 @@ function shouldExposeVideoReferenceAudioParams(params: {
       isVideoGenerationProviderConfigured({
         snapshot,
         cfg: params.cfg,
+        workspaceDir: params.workspaceDir,
         agentDir: params.agentDir,
         authStore: params.authStore,
         providerId,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a provider plugin that authenticates through an environment variable was treated as "not configured" by model-backed tools. When such a provider was the only route to a capability, the image and video tools would skip it during automatic model selection and could report that no model is configured, even though valid environment credentials were present.

This affected provider plugins that are only discoverable with the active configuration (for example, an installed or workspace-scoped provider plugin). Bundled providers were not affected, because they stay discoverable under default discovery.

## Why This Change Was Made

The tool-side auth check resolved environment API keys without the active config/workspace context. Environment-variable candidates for provider plugins are sourced from the config-scoped plugin metadata snapshot, so a context-free lookup could not see non-bundled, config-scoped providers and reported them as unauthenticated. Even when callers already passed the config into `hasProviderAuthForTool`, it was dropped before the environment lookup.

This change forwards `cfg`/`workspaceDir` through `hasProviderAuthForTool` -> `hasAuthForProvider` -> `resolveEnvApiKey`, matching the existing config-aware sibling path already used for direct API-key detection, and applies the same fix to the video tool's provider check. There are no configuration, default, or public API changes; the new parameters are optional and backward compatible.

## User Impact

Users whose provider plugin authenticates via an environment variable now get that provider's image and video models offered during automatic model selection, and the related tools become available, instead of the provider being silently dropped or the tool reporting that no model is configured. No configuration change or migration is required.

## Evidence

### Regression coverage

Added regression tests in `model-config.helpers.test.ts` that assert the config/workspace context is forwarded into environment-key resolution, and that an env-key provider plugin is recognized only when that context reaches the resolver:

```
$ node scripts/run-vitest.mjs src/agents/tools/model-config.helpers.test.ts
 Test Files  1 passed (1)
      Tests  17 passed (17)
```

Related tool suites that exercise the same auth path:

```
$ node scripts/run-vitest.mjs \
    src/agents/tools/image-tool.custom-provider-auth.regression.test.ts \
    src/agents/tools/video-generate-tool.test.ts
 Test Files  2 passed (2)
      Tests  42 passed (42)
```

Lint on the three changed files reported no errors.

### Real behavior proof (real plugin discovery + real environment)

To validate against a real setup rather than unit mocks, I created an on-disk provider plugin that authenticates via an environment variable and is only discoverable through the active config/workspace (a workspace-scoped plugin, i.e. non-bundled), then drove the real image tool entry point with real plugin discovery and a real key in the environment, comparing current `main` against this change.

Setup:
- Real `openclaw.plugin.json` on disk declaring `providers: ["acme"]`, `setup.providers: [{ id: "acme", envVars: ["ACME_API_KEY"] }]`, and an image capability; discovered via the workspace scope (`plugins.allow`).
- Bundled-plugin discovery isolated to an empty directory so `acme` is the only provider present; ambient core-provider keys cleared.
- `ACME_API_KEY` set in the environment; the provider has no auth profile and no `models.json` API key, so auth can only come from the env-var candidate.

Result matrix (identical setup; `resolveEnvApiKey` called directly with explicit arguments as a control):

| Signal | Before (`main`) | After (this PR) |
| --- | --- | --- |
| `resolveEnvApiKey("acme", { config })` (no workspace) | `null` | `null` |
| `resolveEnvApiKey("acme", { config, workspaceDir })` (control) | `sk-acme-...` | `sk-acme-...` |
| `hasProviderAuthForTool({ provider: "acme", cfg, workspaceDir })` | `false` | `true` |
| `buildToolModelConfigFromCandidates(["acme/acme-vision-1"])` | `null` | `{ primary: "acme/acme-vision-1" }` |
| `resolveImageModelConfigForTool({ cfg, agentDir, workspaceDir })` | `null` | `{ primary: "acme/acme-vision-1" }` |

The control row shows the resolver itself already honors config/workspace context; the regression was that the tool auth path dropped that context before calling it. On `main`, the image tool entry point resolves no model for an env-key provider plugin (surfacing as "no image model configured"); with this change, the plugin's model is selected. The same context is now also forwarded on the video tool's provider path.
