### PR TITLE
fix(openai): widen OAuth callback loopback check to full 127.0.0.0/8 range

### DIFF
--- a/extensions/openai/openai-chatgpt-oauth-flow.runtime.ts
+++ b/extensions/openai/openai-chatgpt-oauth-flow.runtime.ts
@@ -32,7 +32,9 @@ const TOKEN_URL = "https://auth.openai.com/oauth/token";
 const CALLBACK_PORT = 1455;
 const CALLBACK_PATH = "/auth/callback";
 const DEFAULT_CALLBACK_HOST = "localhost";
-const LOOPBACK_CALLBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1"]);
+function isLoopbackCallbackHost(host: string): boolean {
+  return host === "localhost" || host === "::1" || host.startsWith("127.");
+}
 const CALLBACK_HOST = resolveCallbackHost();
 const REDIRECT_URI = resolveRedirectUri(CALLBACK_HOST);
 const MANUAL_PROMPT_FALLBACK_MS = 15_000;
@@ -75,8 +77,10 @@ function loadNodeOAuthRuntime(): Promise<NodeOAuthRuntime> {
 
 function resolveCallbackHost(env: NodeJS.ProcessEnv = process.env): string {
   const host = env.OPENCLAW_OAUTH_CALLBACK_HOST?.trim() || DEFAULT_CALLBACK_HOST;
-  if (!LOOPBACK_CALLBACK_HOSTS.has(host)) {
-    throw new Error("OpenAI Codex OAuth callback host must be localhost, 127.0.0.1, or ::1");
+  if (!isLoopbackCallbackHost(host)) {
+    throw new Error(
+      "OpenAI Codex OAuth callback host must be a loopback address (localhost, ::1, or 127.x.x.x)",
+    );
   }
   return host;
 }


### PR DESCRIPTION
## What Problem This Solves

The OpenAI Codex OAuth callback host validation only accepted exact `"127.0.0.1"`, rejecting other valid loopback addresses like `127.0.0.2`. Container and sandbox environments commonly bind OAuth callbacks to addresses throughout the 127/8 range.

## Why This Change Was Made

Replaced the `LOOPBACK_CALLBACK_HOSTS` Set with `isLoopbackCallbackHost()` that checks `host.startsWith("127.")` for the full 127/8 range, plus `localhost` and `::1`. This follows the canonical `isLoopbackIpAddress` in `packages/net-policy/src/ip.ts`. The error message was also updated to accurately describe valid loopback addresses.

## Evidence

The `resolveCallbackHost` function is a guard used during OAuth callback setup. The change is a pure string-match widening — from exact `"127.0.0.1"` to `startsWith("127.")`. The `resolveRedirectUri` function already handles arbitrary hostnames correctly (bracket-wrapping `::1`, port appending). TypeScript compilation confirms no callers reference the removed `LOOPBACK_CALLBACK_HOSTS` Set.

```text
$ git diff --check && tsc --noEmit --project tsconfig.json 2>&1 | head -5
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)