### PR TITLE
fix(openai): widen local image endpoint loopback check to full 127.0.0.0/8 range

### DIFF
--- a/extensions/openai/image-generation-provider.ts
+++ b/extensions/openai/image-generation-provider.ts
@@ -292,7 +292,7 @@ function shouldAllowPrivateImageEndpoint(req: {
     return true;
   }
   const baseUrl = resolveConfiguredOpenAIBaseUrl(req.cfg);
-  if (!baseUrl.startsWith("http://127.0.0.1:") && !baseUrl.startsWith("http://localhost:")) {
+  if (!baseUrl.startsWith("http://127.") && !baseUrl.startsWith("http://localhost:")) {
     return false;
   }
   return process.env.OPENCLAW_QA_ALLOW_LOCAL_IMAGE_PROVIDER === "1";


### PR DESCRIPTION
## What Problem This Solves

The `shouldAllowPrivateImageEndpoint` check in the OpenAI image generation provider only matched `http://127.0.0.1:`, missing containerized providers bound to other loopback addresses. This is a QA-only code path (`OPENCLAW_QA_ALLOW_LOCAL_IMAGE_PROVIDER=1`) but the detection logic should still be correct.

## Why This Change Was Made

Changed from `baseUrl.startsWith("http://127.0.0.1:")` to `baseUrl.startsWith("http://127.")`, covering all 127.x.x.x addresses. The `https://` path is already excluded (only HTTP is checked). This matches the canonical `isLoopbackIpAddress` in `packages/net-policy/src/ip.ts`.

## Evidence

Single-line change in a QA-only guard path. The function is only active when `OPENCLAW_QA_ALLOW_LOCAL_IMAGE_PROVIDER=1` is set. The `https://` exclusion + `localhost:` check are unchanged.

```text
$ git show --stat
 extensions/openai/image-generation-provider.ts | 1 +, 1 -
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)