### PR TITLE
fix(infra): widen gateway bind address loopback classification to full 127/8

### DIFF
--- a/src/infra/ports-format.ts
+++ b/src/infra/ports-format.ts
@@ -69,7 +69,7 @@ function parseListenerAddress(address: string): { host: string; port: number } |
 // Dual-stack listener output can include IPv4-mapped IPv6 addresses; keep them
 // in the IPv6 family so the benign loopback-pair detection stays conservative.
 function classifyLoopbackAddressFamily(host: string): "ipv4" | "ipv6" | null {
-  if (host === "127.0.0.1" || host === "localhost") {
+  if (host.startsWith("127.") || host === "localhost") {
     return "ipv4";
   }
   if (host === "::1") {
@@ -77,7 +77,7 @@ function classifyLoopbackAddressFamily(host: string): "ipv4" | "ipv6" | null {
   }
   if (host.startsWith("::ffff:")) {
     const mapped = host.slice("::ffff:".length);
-    return mapped === "127.0.0.1" ? "ipv6" : null;
+    return mapped.startsWith("127.") ? "ipv6" : null;
   }
   return null;
 }


### PR DESCRIPTION
## What Problem This Solves

The `classifyLoopbackAddressFamily` function in the ports formatter only matched exact `"127.0.0.1"`, causing gateway listeners bound to other loopback addresses (e.g. `127.0.0.2`) to be misclassified. This function feeds into `isExpectedGatewayBindAddress` and `isDualStackLoopbackGatewayListeners`, which affect gateway state detection.

## Why This Change Was Made

Changed both `"127.0.0.1"` exact matches to `startsWith("127.")` — both the direct IPv4 path and the IPv4-mapped IPv6 path (`::ffff:127.x.x.x`). This follows the canonical implementation in `packages/net-policy/src/ip.ts`.

## Evidence

```text
$ node scripts/run-vitest.mjs run src/infra/ports-format.test.ts 2>&1 | tail -12

 ✓ |unit-fast| src/infra/ports-format.test.ts > ports-format > treats single-process loopback dual-stack gateway listeners as benign
 ✓ |unit-fast| src/infra/ports-format.test.ts > ports-format > treats a single expected Gateway listener on 127.0.0.1:18789 as benign
 ✓ |unit-fast| src/infra/ports-format.test.ts > ports-format > treats a single expected Gateway listener on [::1]:18789 as benign
 ✓ |unit-fast| src/infra/ports-format.test.ts > ports-format > treats a single expected Gateway listener on localhost:18789 as benign
 Test Files  1 passed (1)
      Tests  35 passed (35)
   Start at  21:50:35
   Duration  523ms (transform 142ms, setup 0ms, import 183ms, tests 25ms, environment 0ms)
```

All 35 ports-format tests pass, including gateway listener classification and dual-stack detection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)