### PR TITLE
fix(proxy-capture): widen local peer detection to full 127.0.0.0/8 range

### DIFF
--- a/src/proxy-capture/store.sqlite.ts
+++ b/src/proxy-capture/store.sqlite.ts
@@ -50,8 +50,7 @@ function isInMemoryDatabasePath(dbPath: string): boolean {
   const fragmentIndex = dbPath.indexOf("#");
   const uriWithoutFragment = fragmentIndex === -1 ? dbPath : dbPath.slice(0, fragmentIndex);
   const queryIndex = uriWithoutFragment.indexOf("?");
-  const uriPath =
-    queryIndex === -1 ? uriWithoutFragment : uriWithoutFragment.slice(0, queryIndex);
+  const uriPath = queryIndex === -1 ? uriWithoutFragment : uriWithoutFragment.slice(0, queryIndex);
   try {
     if (decodeURIComponent(uriPath.slice("file:".length)) === ":memory:") {
       return true;
@@ -462,7 +461,7 @@ class DebugProxyCaptureStoreImpl {
         // debugging why cloud-provider labels are absent.
         if (
           host === "127.0.0.1:11434" ||
-          host.startsWith("127.0.0.1:") ||
+          host.startsWith("127.") ||
           host.startsWith("localhost:")
         ) {
           localPeers.set(host, (localPeers.get(host) ?? 0) + 1);
@@ -743,10 +742,12 @@ class DebugProxyCaptureStoreImpl {
           )
           .get(...sessionIds) as { count: number }
       ).count ?? 0;
-    this.db.prepare(`DELETE FROM capture_events WHERE session_id IN (${placeholders})`).run(
-      ...sessionIds,
-    );
-    this.db.prepare(`DELETE FROM capture_sessions WHERE id IN (${placeholders})`).run(...sessionIds);
+    this.db
+      .prepare(`DELETE FROM capture_events WHERE session_id IN (${placeholders})`)
+      .run(...sessionIds);
+    this.db
+      .prepare(`DELETE FROM capture_sessions WHERE id IN (${placeholders})`)
+      .run(...sessionIds);
     const candidateBlobIds = blobRows
       .map((row) => row.blobId?.trim())
       .filter((blobId): blobId is string => Boolean(blobId));
@@ -783,10 +784,7 @@ class DebugProxyCaptureStoreImpl {
 }
 
 export type DebugProxyCaptureStore = Omit<DebugProxyCaptureStoreImpl, "persistPayload"> & {
-  persistPayload(
-    data: Buffer,
-    contentType?: string,
-  ): CaptureBlobRecord | SharedCaptureBlobRecord;
+  persistPayload(data: Buffer, contentType?: string): CaptureBlobRecord | SharedCaptureBlobRecord;
 };
 
 export type LegacyDebugProxyCaptureStore = Omit<DebugProxyCaptureStoreImpl, "persistPayload"> & {
@@ -860,7 +858,10 @@ export function closeDebugProxyCaptureStore(): void {
 
 // Lease API keeps one cached capture-store wrapper alive across related
 // operations, then releases it without closing the shared state database.
-export function acquireDebugProxyCaptureStore(dbPath: string, blobDir: string): {
+export function acquireDebugProxyCaptureStore(
+  dbPath: string,
+  blobDir: string,
+): {
   store: LegacyDebugProxyCaptureStore;
   release: () => void;
 };
@@ -905,10 +906,7 @@ export function acquireDebugProxyCaptureStore(
 
 export function persistEventPayload(
   store: {
-    persistPayload(
-      data: Buffer,
-      contentType?: string,
-    ): CaptureBlobRecord | SharedCaptureBlobRecord;
+    persistPayload(data: Buffer, contentType?: string): CaptureBlobRecord | SharedCaptureBlobRecord;
   },
   params: { data?: Buffer | string | null; contentType?: string; previewLimit?: number },
 ): { dataText?: string; dataBlobId?: string; dataSha256?: string } {


### PR DESCRIPTION
## What Problem This Solves

The proxy-capture dashboard local peer detection only matched hosts starting with `"127.0.0.1:"`, missing model endpoints bound to other loopback addresses like `127.0.0.2:11434`. This affected the `localPeers` grouping in the proxy-capture debug dashboard.

## Why This Change Was Made

Changed from `host.startsWith("127.0.0.1:")` to `host.startsWith("127.")`, covering all 127.x.x.x loopback addresses. The special-case for `127.0.0.1:11434` (Ollama default) is still preserved as the first check. This is a data-quality/display fix — not a security boundary.

## Evidence

```text
$ node scripts/run-vitest.mjs run src/proxy-capture/store.sqlite.test.ts 2>&1 | tail -12

 ✓ |unit-fast| src/proxy-capture/store.sqlite.test.ts > DebugProxyCaptureStore > tracks and closes cached stores independently across paths
 ✓ |unit-fast| src/proxy-capture/store.sqlite.test.ts > DebugProxyCaptureStore > stores sessions, blobs, and duplicate-send query results
 Test Files  1 passed (1)
      Tests  9 passed (9)
   Start at  21:53:15
   Duration  2.86s (transform 647ms, setup 0ms, import 1.18s, tests 1.47s, environment 0ms)
```

All 9 proxy-capture SQLite store tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)