### PR TITLE
fix(commands): widen isLocalBaseUrl to full 127.0.0.0/8 loopback range

### DIFF
--- a/src/commands/models/list.local-url.ts
+++ b/src/commands/models/list.local-url.ts
@@ -8,7 +8,7 @@ export const isLocalBaseUrl = (baseUrl: string) => {
     const host = normalizeLowercaseStringOrEmpty(url.hostname).replace(/^\[|\]$/g, "");
     return (
       host === "localhost" ||
-      host === "127.0.0.1" ||
+      host.startsWith("127.") ||
       host === "0.0.0.0" ||
       host === "::" ||
       host === "::1" ||


### PR DESCRIPTION
## What Problem This Solves

The `isLocalBaseUrl` function in the model provider status command only matched exact `"127.0.0.1"`, missing model providers bound to other loopback addresses like `127.0.0.2:11434`. This affects how `openclaw status` classifies provider URLs as local or remote.

## Why This Change Was Made

Changed from `host === "127.0.0.1"` to `host.startsWith("127.")`, covering the full 127.0.0.0/8 loopback range. `0.0.0.0` and `::` are intentionally preserved as local-classified wildcard binds (consistent with existing status display contract).

## Evidence

```text
$ node scripts/run-vitest.mjs run src/commands/status.format.test.ts src/commands/status.command-report-data.test.ts 2>&1 | tail -10

 ✓ |unit-fast| src/commands/status.command-report-data.test.ts > ...
 ✓ |unit-fast| src/commands/status.format.test.ts > status cache formatting > ...
 Test Files  2 passed (2)
      Tests  11 passed (11)
   Start at  22:11:29
   Duration  14.03s
```

All 11 status command tests pass. The `isLocalBaseUrl` function is a display classifier for `openclaw status` output — the wider range check means providers on `127.0.0.2`+ are now correctly displayed as local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)