### PR TITLE
fix(sessions): log warning when parseJsonlEntries skips malformed JSONL lines

### DIFF
--- a/src/agents/sessions/session-manager.test.ts
+++ b/src/agents/sessions/session-manager.test.ts
@@ -6,6 +6,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { withOwnedSessionTranscriptWrites } from "../../config/sessions/transcript-write-context.js";
+import * as Logger from "../../logger.js";
 import { isTranscriptOnlyOpenClawAssistantMessage } from "../../shared/transcript-only-openclaw-assistant.js";
 import { prepareSessionManagerForRun } from "../embedded-agent-runner/session-manager-init.js";
 import { repairSessionFileIfNeeded } from "../session-file-repair.js";
@@ -13,6 +14,7 @@ import {
   CURRENT_SESSION_VERSION,
   findMostRecentSession,
   loadEntriesFromFile,
+  parseSessionEntries,
   SessionManager,
   type SessionEntry,
 } from "./session-manager.js";
@@ -2455,6 +2457,76 @@ describe("SessionManager.open", () => {
 
     const after = await fs.stat(sessionFile);
     expect(after.mtimeMs).toBe(before.mtimeMs);
+  });
+});
+
+describe("parseSessionEntries", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("parses valid JSONL lines without logging warnings", () => {
+    const warnSpy = vi.spyOn(Logger, "logWarn").mockImplementation(() => {});
+    const content = [
+      JSON.stringify({ type: "session", id: "s1" }),
+      JSON.stringify({ type: "message", id: "m1" }),
+    ].join("\n");
+
+    const entries = parseSessionEntries(content);
+
+    expect(entries).toHaveLength(2);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("logs a warning and skips malformed JSONL lines while preserving valid entries", () => {
+    const warnSpy = vi.spyOn(Logger, "logWarn").mockImplementation(() => {});
+    const content = [
+      JSON.stringify({ type: "session", id: "s1" }),
+      "not valid json {{{",
+      JSON.stringify({ type: "message", id: "m1" }),
+    ].join("\n");
+
+    const entries = parseSessionEntries(content);
+
+    expect(entries).toHaveLength(2);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("parseSessionEntries: skipped 1 malformed JSONL line"),
+    );
+  });
+
+  it("reports the correct skip count for multiple malformed lines", () => {
+    const warnSpy = vi.spyOn(Logger, "logWarn").mockImplementation(() => {});
+    const content = [
+      "bad line 1",
+      JSON.stringify({ type: "session", id: "s1" }),
+      "bad line 2",
+      "bad line 3",
+    ].join("\n");
+
+    const entries = parseSessionEntries(content);
+
+    expect(entries).toHaveLength(1);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("parseSessionEntries: skipped 3 malformed JSONL line"),
+    );
+  });
+
+  it("skips empty lines without counting them as malformed", () => {
+    const warnSpy = vi.spyOn(Logger, "logWarn").mockImplementation(() => {});
+    const content = [
+      "",
+      JSON.stringify({ type: "session", id: "s1" }),
+      "",
+      JSON.stringify({ type: "message", id: "m1" }),
+      "",
+    ].join("\n");
+
+    const entries = parseSessionEntries(content);
+
+    expect(entries).toHaveLength(2);
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/src/agents/sessions/session-manager.ts
+++ b/src/agents/sessions/session-manager.ts
@@ -967,10 +967,9 @@ function parseJsonlEntries(content: string): FileEntry[] {
     }
   }
 
-  // PR #97356 hardened the write side to never emit non-JSON lines, but
-  // transcripts written by older code or repaired externally may still
-  // contain malformed entries. Warn once so the operator knows data was
-  // skipped instead of silently dropping entries.
+  // Transcripts written by older code or repaired externally may contain
+  // malformed entries that JSON.parse cannot deserialize. Warn once so the
+  // operator knows data was skipped instead of silently dropping entries.
   if (skipped > 0) {
     logWarn(
       `parseJsonlEntries: skipped ${skipped} malformed JSONL line(s) — ` +
@@ -1282,6 +1281,7 @@ async function buildSessionInfo(filePath: string): Promise<SessionInfo | null> {
     const content = await readFile(filePath, "utf8");
     const entries: FileEntry[] = [];
     const lines = content.trim().split("\n");
+    let skipped = 0;
 
     for (const line of lines) {
       if (!line.trim()) {
@@ -1290,8 +1290,15 @@ async function buildSessionInfo(filePath: string): Promise<SessionInfo | null> {
       try {
         entries.push(JSON.parse(line) as FileEntry);
       } catch {
-        // Skip malformed lines
+        skipped++;
       }
+    }
+
+    if (skipped > 0) {
+      logWarn(
+        `buildSessionInfo: skipped ${skipped} malformed JSONL line(s) in ${filePath} — ` +
+          `${entries.length} valid entries were loaded`,
+      );
     }
 
     if (entries.length === 0) {

--- a/src/agents/sessions/session-manager.ts
+++ b/src/agents/sessions/session-manager.ts
@@ -46,6 +46,7 @@ import {
   uuidv7,
 } from "../runtime/index.js";
 import { invalidateSessionFileRepairCache } from "../session-file-repair.js";
+import { logWarn } from "../../logger.js";
 import type { BashExecutionMessage, CustomMessage } from "./messages.js";
 
 export { CURRENT_SESSION_VERSION };
@@ -952,6 +953,7 @@ function freezeJsonLikeValue(value: unknown, seen = new WeakSet<object>()): void
 function parseJsonlEntries(content: string): FileEntry[] {
   const entries: FileEntry[] = [];
   const lines = content.trim().split("\n");
+  let skipped = 0;
 
   for (const line of lines) {
     if (!line.trim()) {
@@ -961,8 +963,19 @@ function parseJsonlEntries(content: string): FileEntry[] {
       const entry = JSON.parse(line) as FileEntry;
       entries.push(entry);
     } catch {
-      // Skip malformed lines
+      skipped++;
     }
+  }
+
+  // PR #97356 hardened the write side to never emit non-JSON lines, but
+  // transcripts written by older code or repaired externally may still
+  // contain malformed entries. Warn once so the operator knows data was
+  // skipped instead of silently dropping entries.
+  if (skipped > 0) {
+    logWarn(
+      `parseJsonlEntries: skipped ${skipped} malformed JSONL line(s) — ` +
+        `${entries.length} valid entries were loaded`,
+    );
   }
 
   return entries;

--- a/src/agents/sessions/session-manager.ts
+++ b/src/agents/sessions/session-manager.ts
@@ -38,6 +38,7 @@ import {
 } from "../../config/sessions/transcript-write-context.js";
 import { CURRENT_SESSION_VERSION } from "../../config/sessions/version.js";
 import type { ImageContent, Message, TextContent } from "../../llm/types.js";
+import { logWarn } from "../../logger.js";
 import { getAgentDir as getDefaultAgentDir, getSessionsDir } from "../config.js";
 import {
   type AgentMessage,
@@ -46,7 +47,6 @@ import {
   uuidv7,
 } from "../runtime/index.js";
 import { invalidateSessionFileRepairCache } from "../session-file-repair.js";
-import { logWarn } from "../../logger.js";
 import type { BashExecutionMessage, CustomMessage } from "./messages.js";
 
 export { CURRENT_SESSION_VERSION };
@@ -351,6 +351,7 @@ export function migrateSessionEntries(entries: FileEntry[]): void {
 export function parseSessionEntries(content: string): FileEntry[] {
   const entries: FileEntry[] = [];
   const lines = content.trim().split("\n");
+  let skipped = 0;
 
   for (const line of lines) {
     if (!line.trim()) {
@@ -360,8 +361,15 @@ export function parseSessionEntries(content: string): FileEntry[] {
       const entry = JSON.parse(line) as FileEntry;
       entries.push(entry);
     } catch {
-      // Skip malformed lines
+      skipped++;
     }
+  }
+
+  if (skipped > 0) {
+    logWarn(
+      `parseSessionEntries: skipped ${skipped} malformed JSONL line(s) — ` +
+        `${entries.length} valid entries were loaded`,
+    );
   }
 
   return entries;


### PR DESCRIPTION
## What Problem This Solves

Three JSONL reader functions in `session-manager.ts` silently skip malformed transcript lines with bare `catch {}` blocks and zero diagnostic output. When a transcript file is corrupted, entries vanish with no operator visibility — no log, no warning, no metric.

This adds counted malformed-line detection and a single `logWarn` summary to all three readers so operators know data was dropped instead of silently losing entries forever.

## Why This Change Was Made

Data loss without observability is the worst failure mode. PR #97356 hardened the write side (`serializeJsonLine` now throws on non-serializable roots), but transcripts already on disk from older code remain vulnerable. This adds the reader-side counterpart: count skipped lines and warn.

## User Impact

Operators running `openclaw doctor` or loading sessions from older transcript files will now see warnings like:

```
parseJsonlEntries: skipped 3 malformed JSONL line(s) — 142 valid entries were loaded
buildSessionInfo: skipped 1 malformed JSONL line(s) in /path/to/session — 99 valid entries were loaded
parseSessionEntries: skipped 2 malformed JSONL line(s) — 50 valid entries were loaded
```

Clean transcripts produce zero extra log output. All three JSONL reader paths are covered: `parseJsonlEntries` (session load), `buildSessionInfo` (session listing), and `parseSessionEntries` (CLI history, BTW continuation, fork-source, embedded file state).

## Evidence

**Environment**: Linux, Node 22, OpenClaw main

**47/47 tests pass with no regression**:
```
$ pnpm test src/agents/sessions/session-manager.test.ts
 Test Files  1 passed (1)
      Tests  47 passed (47)

$ pnpm test src/config/sessions/transcript-jsonl.test.ts
 Test Files  1 passed (1)
      Tests  10 passed (10)
```

## Risk

Low. One `logWarn` call added per reader function. Import is lightweight (`logWarn` from `../../logger.js`). No behavior change to entry loading — malformed lines are still skipped, valid entries still loaded. The only addition is observability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)