### PR TITLE
fix(huggingface): bound model discovery JSON response read to prevent OOM

### DIFF
--- a/extensions/huggingface/models.test.ts
+++ b/extensions/huggingface/models.test.ts
@@ -91,6 +91,39 @@ describe("huggingface models", () => {
     expect(timeoutSpy).toHaveBeenCalledWith(25_000);
   });
 
+  it("rejects oversized model discovery responses and falls back to static catalog", async () => {
+    process.env.VITEST = "false";
+    process.env.NODE_ENV = "development";
+    stubAbortSignalTimeout();
+    let canceled = false;
+    const ONE_MIB = 1024 * 1024;
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (let i = 0; i < 18; i++) controller.enqueue(new Uint8Array(ONE_MIB));
+        controller.close();
+      },
+      cancel() {
+        canceled = true;
+      },
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(body, {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+      ),
+    );
+
+    const models = await discoverHuggingfaceModels("hf_test_token");
+
+    // Oversized response should be cancelled mid-stream and fall back to the static catalog.
+    expect(canceled).toBe(true);
+    expect(models).toHaveLength(HUGGINGFACE_MODEL_CATALOG.length);
+  });
+
   it("caps oversized live discovery timeout overrides", async () => {
     process.env.VITEST = "false";
     process.env.NODE_ENV = "development";

--- a/extensions/huggingface/models.ts
+++ b/extensions/huggingface/models.ts
@@ -1,5 +1,6 @@
 // Huggingface plugin module implements models behavior.
 import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-types";
 import {
   fetchWithSsrFGuard,
@@ -165,7 +166,10 @@ export async function discoverHuggingfaceModels(
         return HUGGINGFACE_MODEL_CATALOG.map(buildHuggingfaceModelDefinition);
       }
 
-      const body = (await response.json()) as OpenAIListModelsResponse;
+      const body = await readProviderJsonResponse<OpenAIListModelsResponse>(
+        response,
+        "HuggingFace model discovery",
+      );
       const data = body?.data;
       if (!Array.isArray(data) || data.length === 0) {
         return HUGGINGFACE_MODEL_CATALOG.map(buildHuggingfaceModelDefinition);


### PR DESCRIPTION
## What Problem This Solves

`discoverHuggingfaceModels` in `extensions/huggingface/models.ts` uses unbounded `response.json()` when fetching the model list from `router.huggingface.co/v1/models`. A large or malicious response could cause OOM.

## Why This Change Was Made

The established pattern (`readProviderJsonResponse` with 16 MiB cap) is already used across similar OAuth and provider response reads (see #98191, #98454). The error path in the same function already falls back gracefully to a static catalog — this change ensures the success path does too when an oversized response is rejected.

## User Impact

Oversized HuggingFace model discovery responses are cancelled mid-stream and fall back to the built-in static catalog. No breaking change — the catch at the outer scope already handles `readProviderJsonResponse` errors.

## Evidence

### Source fix
```diff
-const body = (await response.json()) as OpenAIListModelsResponse;
+const body = await readProviderJsonResponse<OpenAIListModelsResponse>(
+  response,
+  "HuggingFace model discovery",
+);
```

### Test: oversized response falls back to static catalog
```ts
// 18 MiB ReadableStream triggers 16 MiB cap → reader.cancel() → catch → static catalog
const models = await discoverHuggingfaceModels("hf_test_token");
expect(canceled).toBe(true);
expect(models).toHaveLength(HUGGINGFACE_MODEL_CATALOG.length);
```

### Test Results
```
extensions/huggingface/models.test.ts — 9 passed (1 new oversized test)
```

### Files Changed
| File | Change |
|------|--------|
| `extensions/huggingface/models.ts` | `readProviderJsonResponse` for model discovery |
| `extensions/huggingface/models.test.ts` | Oversized response fallback test |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
