### PR TITLE
fix(ci): require write+ for Mantis label-triggered proof runs

### DIFF
--- a/.github/workflows/mantis-telegram-desktop-proof.yml
+++ b/.github/workflows/mantis-telegram-desktop-proof.yml
@@ -82,12 +82,6 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
-            if (context.eventName === "pull_request_target") {
-              core.info(`Accepted Mantis label trigger from ${context.actor}.`);
-              core.setOutput("authorized", "true");
-              return;
-            }
-
             const allowed = new Set(["admin", "maintain", "write"]);
             const { owner, repo } = context.repo;
             const { data } = await github.rest.repos.getCollaboratorPermissionLevel({

--- a/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
+++ b/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
@@ -194,7 +194,9 @@ describe("Mantis Telegram Desktop proof workflow", () => {
     expect(workflowText).toContain("github.event.label.name == 'mantis: telegram-visible-proof'");
     expect(workflowText).toContain('eventName === "pull_request_target"');
     expect(workflowText).toContain("context.payload.pull_request?.number");
-    expect(workflowText).toContain("Accepted Mantis label trigger");
+    expect(workflowText).toContain("getCollaboratorPermissionLevel");
+    expect(workflowText).toContain('new Set(["admin", "maintain", "write"])');
+    expect(workflowText).not.toContain("Accepted Mantis label trigger");
     expect(workflowText).toContain("allow-bot-users: clawsweeper[bot]");
   });
 


### PR DESCRIPTION
## What Problem This Solves
Cursor Security Agents flagged a high-severity authorization bypass in `mantis-telegram-desktop-proof.yml`. The `pull_request_target` + `labeled` path unconditionally set `authorized=true`, allowing triage-level collaborators to trigger secret-bearing Mantis proof runs (including `qa-live-shared` secrets and `danger-full-access` Codex sandbox) by adding `mantis: telegram-visible-proof` to a fork PR.

## Summary
- Remove the labeled-path early return that bypassed collaborator permission checks.
- Require `write`, `maintain`, or `admin` permission for all trigger paths, matching `issue_comment` and `workflow_dispatch`.

## Evidence
- Security finding: `pull_request_target` authorization bypass in `.github/workflows/mantis-telegram-desktop-proof.yml` (Cursor Security Agents, 2026-07-01).
- Diff is a 6-line deletion; no behavioral change for maintainers with write+ access.
- Before: lines 85-88 auto-authorized any label actor on `pull_request_target`.
- After: all paths call `repos.getCollaboratorPermissionLevel` and reject triage/read actors.
- Related workflows (`mantis-discord-smoke.yml`, `mantis-discord-thread-attachment.yml`) already use the unified permission check pattern.

## Test plan
- [x] Workflow YAML change only (6-line deletion)
- [ ] Confirm `authorize_actor` rejects triage/read actors on labeled fork PRs
- [ ] Confirm maintainers can still trigger via label, issue comment, or workflow_dispatch