### PR TITLE
fix(ui): keep landscape composer compact

### DIFF
--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -984,6 +984,12 @@
   min-width: 0;
 }
 
+.agent-chat__token-count {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .agent-chat__input-btn,
 .agent-chat__toolbar .btn--ghost {
   display: inline-flex;
@@ -1558,6 +1564,29 @@
   .chat-settings-chip__text,
   .chat-settings-chip__chevron {
     display: none;
+  }
+}
+
+@media (max-width: 932px) and (max-height: 500px) and (orientation: landscape) {
+  .chat-thread {
+    min-height: 45vh;
+  }
+
+  .agent-chat__input {
+    max-height: min(34vh, 156px);
+    overflow: hidden;
+  }
+
+  .agent-chat__composer-combobox > textarea {
+    max-height: 56px;
+    padding-top: 8px;
+    padding-bottom: 6px;
+    overflow-y: auto;
+  }
+
+  .agent-chat__toolbar {
+    padding-top: 4px;
+    padding-bottom: 4px;
   }
 }
 

--- a/ui/src/ui/chat/chat-responsive.browser.test.ts
+++ b/ui/src/ui/chat/chat-responsive.browser.test.ts
@@ -622,6 +622,7 @@ describeBrowserLayout("chat responsive browser layout", () => {
           };
           return {
             input: rectFor(".agent-chat__input"),
+            thread: rectFor(".chat-thread"),
             left: rectFor(".agent-chat__toolbar-left"),
             model: rectFor(".chat-composer-model-control"),
             settings: rectFor(".chat-settings-chip"),
@@ -631,6 +632,7 @@ describeBrowserLayout("chat responsive browser layout", () => {
         });
 
         const input = expectControlRect(controls.input, "composer");
+        const thread = expectControlRect(controls.thread, "chat thread");
         const left = expectControlRect(controls.left, "composer left controls");
         const model = expectControlRect(controls.model, "composer model control");
         const settings = expectControlRect(controls.settings, "composer settings control");
@@ -647,6 +649,11 @@ describeBrowserLayout("chat responsive browser layout", () => {
         expect(settings.width).toBeGreaterThanOrEqual(TOUCH_TARGET_MIN_PX);
         expect(settings.height).toBeGreaterThanOrEqual(TOUCH_TARGET_MIN_PX);
         expect(settingsLabel.display).toBe("none");
+
+        if (height < width && height <= 500) {
+          expect(input.height).toBeLessThanOrEqual(height * 0.36);
+          expect(thread.height).toBeGreaterThanOrEqual(height * 0.4);
+        }
       } finally {
         await closeBrowserPage(page);
       }


### PR DESCRIPTION
Closes #98615

## What Problem This Solves

Fixes an issue where Android PWA users in landscape orientation could have the Control UI composer occupy nearly the full viewport, leaving too little chat history visible while composing.

## Why This Change Was Made

The short-landscape responsive layout now caps the composer height, lets long draft text scroll inside the textarea, and preserves a minimum transcript area instead of allowing the input stack to consume the screen. The change stays within the existing compact composer layout rather than adding a new collapse/hide interaction.

## User Impact

Users on short landscape viewports, including Android Chrome PWAs, can keep the model/settings/send controls available while still seeing meaningful chat history above the composer.

## Evidence

- `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/root/.cache/ms-playwright/chromium-1223/chrome-linux64/chrome node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-ui.config.ts ui/src/ui/chat/chat-responsive.browser.test.ts --reporter=verbose` — 1 file passed, 23 tests passed. The 568x320 landscape case now asserts composer height stays under 36% of viewport height and chat thread height stays at least 40%.
- `pnpm exec oxfmt --check --threads=1 ui/src/ui/chat/chat-responsive.browser.test.ts`
- `git diff --check`
- Added-line secret scan over the diff — no matches
