### PR TITLE
fix(auto-reply): stop treating wait as abort trigger

### DIFF
--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -1535,7 +1535,7 @@ Model Q&A - defaults, selection, aliases, switching, failover, auth profiles - l
   </Accordion>
 
   <Accordion title="How do I stop/cancel a running task?">
-    Send any of these **as a standalone message** (no slash) to trigger an abort: `stop`, `stop action`, `stop current action`, `stop run`, `stop current run`, `stop agent`, `stop the agent`, `stop openclaw`, `openclaw stop`, `stop don't do anything`, `stop do not do anything`, `stop doing anything`, `do not do that`, `please stop`, `stop please`, `abort`, `esc`, `wait`, `exit`, `interrupt`, `halt`. Common non-English triggers (French, German, Spanish, Chinese, Japanese, Hindi, Arabic, Russian) also work.
+    Send any of these **as a standalone message** (no slash) to trigger an abort: `stop`, `stop action`, `stop current action`, `stop run`, `stop current run`, `stop agent`, `stop the agent`, `stop openclaw`, `openclaw stop`, `stop don't do anything`, `stop do not do anything`, `stop doing anything`, `do not do that`, `please stop`, `stop please`, `abort`, `esc`, `exit`, `interrupt`, `halt`. Common non-English triggers (French, German, Spanish, Chinese, Japanese, Hindi, Arabic, Russian) also work.
 
     For background processes started by the exec tool, ask the agent to run:
 

--- a/src/auto-reply/reply/abort-primitives.ts
+++ b/src/auto-reply/reply/abort-primitives.ts
@@ -7,7 +7,6 @@ const ABORT_TRIGGERS = new Set([
   "stop",
   "esc",
   "abort",
-  "wait",
   "exit",
   "interrupt",
   "detente",

--- a/src/auto-reply/reply/abort.test.ts
+++ b/src/auto-reply/reply/abort.test.ts
@@ -238,7 +238,6 @@ describe("abort detection", () => {
       "stop",
       "esc",
       "abort",
-      "wait",
       "exit",
       "interrupt",
       "stop openclaw",
@@ -287,6 +286,8 @@ describe("abort detection", () => {
     }
 
     expect(isAbortTrigger("hello")).toBe(false);
+    expect(isAbortTrigger("wait")).toBe(false);
+    expect(isAbortTrigger("please wait")).toBe(false);
     expect(isAbortTrigger("please do not do that")).toBe(false);
     // /stop is NOT matched by isAbortTrigger - it's handled separately.
     expect(isAbortTrigger("/stop")).toBe(false);
@@ -314,6 +315,8 @@ describe("abort detection", () => {
     expect(isAbortRequestText("/Stop@openclaw_bot", { botUsername: "openclaw_bot" })).toBe(true);
 
     expect(isAbortRequestText("/status")).toBe(false);
+    expect(isAbortRequestText("wait")).toBe(false);
+    expect(isAbortRequestText("please wait")).toBe(false);
     expect(isAbortRequestText("do not do that")).toBe(true);
     expect(isAbortRequestText("please do not do that")).toBe(false);
     expect(isAbortRequestText("/abort")).toBe(false);

--- a/src/channels/inbound-debounce-policy.test.ts
+++ b/src/channels/inbound-debounce-policy.test.ts
@@ -15,12 +15,12 @@ describe("shouldDebounceTextInbound", () => {
     expect(shouldDebounceTextInbound({ text: "/status plugins", cfg })).toBe(false);
     expect(shouldDebounceTextInbound({ text: "stop", cfg })).toBe(false);
     expect(shouldDebounceTextInbound({ text: "abort", cfg })).toBe(false);
-    expect(shouldDebounceTextInbound({ text: "wait", cfg })).toBe(false);
   });
 
   it("accepts normal text when debounce is allowed", () => {
     const cfg = {} as Parameters<typeof shouldDebounceTextInbound>[0]["cfg"];
     expect(shouldDebounceTextInbound({ text: "hello there", cfg })).toBe(true);
+    expect(shouldDebounceTextInbound({ text: "wait", cfg })).toBe(true);
     expect(shouldDebounceTextInbound({ text: "hello there", cfg, allowDebounce: false })).toBe(
       false,
     );


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Telegram group users sending the normal coordination word `wait` could cause OpenClaw to treat the message as an abort request and reply `⚙️ Agent was aborted.` instead of continuing the upstream workflow.

## Why This Change Was Made

`wait` is no longer part of the shared natural-language abort trigger set. Explicit stop commands such as `stop`, `abort`, and `interrupt` still dispatch immediately, while `wait` now follows the normal inbound text path, including channel debounce handling.

## User Impact

Operators can use `wait` in Telegram coordination threads without accidentally cancelling an active OpenClaw run. Existing explicit abort/stop controls continue to work.

## Evidence

- Focused tests: `pnpm test src/auto-reply/reply/abort.test.ts src/channels/inbound-debounce-policy.test.ts`
  - `src/auto-reply/reply/abort.test.ts`: 30 tests passed.
  - `src/channels/inbound-debounce-policy.test.ts`: 3 tests passed.
- Regression coverage verifies `isAbortTrigger("wait")`, `isAbortRequestText("wait")`, and `isAbortRequestText("please wait")` are false.
- Channel debounce coverage now verifies `wait` is treated as normal debounced text, while `stop` and `abort` still bypass debounce as control messages.
- Pre-fix operational observation: a redacted Telegram upstream message containing `wait` was followed by the visible OpenClaw reply `⚙️ Agent was aborted.` on 2026-07-01 around 20:57 Asia/Taipei.
- Not deployed from this PR yet, so there is intentionally no post-deploy live Telegram proof in production.
