### PR TITLE
fix(agents): add additionalProperties:false to Anthropic tool inputSchema for Opus 4.8 compat

### DIFF
--- a/src/agents/anthropic-schema-normalizer.test.ts
+++ b/src/agents/anthropic-schema-normalizer.test.ts
@@ -1,0 +1,260 @@
+import { describe, expect, it } from "vitest";
+import { normalizeAnthropicSchema } from "./anthropic-schema-normalizer.js";
+
+describe("normalizeAnthropicSchema", () => {
+  it("returns the same reference when no changes are needed", () => {
+    const schema = {
+      type: "object",
+      properties: { name: { type: "string" } },
+    };
+    expect(normalizeAnthropicSchema(schema)).toBe(schema);
+  });
+
+  it("returns non-object values unchanged", () => {
+    expect(normalizeAnthropicSchema(null)).toBe(null);
+    expect(normalizeAnthropicSchema(false)).toBe(false);
+    expect(normalizeAnthropicSchema(42)).toBe(42);
+    expect(normalizeAnthropicSchema("string")).toBe("string");
+  });
+
+  it("passes through arrays of non-schema values unchanged", () => {
+    const arr = [1, "two", false];
+    expect(normalizeAnthropicSchema(arr)).toBe(arr);
+  });
+
+  describe("items → prefixItems conversion", () => {
+    it("converts items array (tuple) to prefixItems", () => {
+      const schema = {
+        type: "array",
+        items: [{ type: "number" }, { type: "string" }],
+      };
+      expect(normalizeAnthropicSchema(schema)).toEqual({
+        type: "array",
+        prefixItems: [{ type: "number" }, { type: "string" }],
+      });
+    });
+
+    it("does not change single-schema items (object)", () => {
+      const schema = {
+        type: "array",
+        items: { type: "number" },
+      };
+      expect(normalizeAnthropicSchema(schema)).toBe(schema);
+    });
+
+    it("does not change items: false", () => {
+      const schema = {
+        type: "array",
+        items: false,
+      };
+      expect(normalizeAnthropicSchema(schema)).toBe(schema);
+    });
+
+    it("does not overwrite existing prefixItems", () => {
+      const schema = {
+        type: "array",
+        items: [{ type: "string" }],
+        prefixItems: [{ type: "number" }],
+      };
+      expect(normalizeAnthropicSchema(schema)).toEqual({
+        type: "array",
+        prefixItems: [{ type: "number" }],
+      });
+    });
+
+    it("converts empty items array to empty prefixItems", () => {
+      const schema = {
+        type: "array",
+        items: [] as Array<Record<string, unknown>>,
+      };
+      expect(normalizeAnthropicSchema(schema)).toEqual({
+        type: "array",
+        prefixItems: [],
+      });
+    });
+  });
+
+  describe("additionalItems → items conversion", () => {
+    it("converts additionalItems: false to items: false", () => {
+      const schema = {
+        type: "array",
+        additionalItems: false,
+      };
+      expect(normalizeAnthropicSchema(schema)).toEqual({
+        type: "array",
+        items: false,
+      });
+    });
+
+    it("converts additionalItems schema to items", () => {
+      const schema = {
+        type: "array",
+        additionalItems: { type: "string" },
+      };
+      expect(normalizeAnthropicSchema(schema)).toEqual({
+        type: "array",
+        items: { type: "string" },
+      });
+    });
+
+    it("does not overwrite existing items when converting additionalItems", () => {
+      const schema = {
+        type: "array",
+        items: { type: "number" },
+        additionalItems: { type: "string" },
+      };
+      expect(normalizeAnthropicSchema(schema)).toEqual({
+        type: "array",
+        items: { type: "number" },
+      });
+    });
+
+    it("converts both items tuple and additionalItems together", () => {
+      const schema = {
+        type: "array",
+        items: [{ type: "number" }, { type: "number" }],
+        additionalItems: false,
+      };
+      expect(normalizeAnthropicSchema(schema)).toEqual({
+        type: "array",
+        prefixItems: [{ type: "number" }, { type: "number" }],
+        items: false,
+      });
+    });
+  });
+
+  describe("nested schema recursion", () => {
+    it("normalizes tuple items deeply nested in properties", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          coords: {
+            type: "array",
+            items: [{ type: "number" }, { type: "number" }],
+            additionalItems: false,
+          },
+        },
+      };
+      expect(normalizeAnthropicSchema(schema)).toEqual({
+        type: "object",
+        properties: {
+          coords: {
+            type: "array",
+            prefixItems: [{ type: "number" }, { type: "number" }],
+            items: false,
+          },
+        },
+      });
+    });
+
+    it("normalizes tuple items inside anyOf", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          value: {
+            anyOf: [{ type: "array", items: [{ type: "number" }] }, { type: "string" }],
+          },
+        },
+      };
+      expect(normalizeAnthropicSchema(schema)).toEqual({
+        type: "object",
+        properties: {
+          value: {
+            anyOf: [{ type: "array", prefixItems: [{ type: "number" }] }, { type: "string" }],
+          },
+        },
+      });
+    });
+
+    it("normalizes tuple items inside oneOf and allOf", () => {
+      const schema = {
+        oneOf: [{ type: "array", items: [{ type: "number" }], additionalItems: false }],
+        allOf: [
+          { type: "object", properties: { arr: { type: "array", items: [{ type: "string" }] } } },
+        ],
+      };
+      expect(normalizeAnthropicSchema(schema)).toEqual({
+        oneOf: [{ type: "array", prefixItems: [{ type: "number" }], items: false }],
+        allOf: [
+          {
+            type: "object",
+            properties: { arr: { type: "array", prefixItems: [{ type: "string" }] } },
+          },
+        ],
+      });
+    });
+
+    it("normalizes tuple items inside $defs", () => {
+      const schema = {
+        $defs: {
+          point: {
+            type: "array",
+            items: [{ type: "number" }, { type: "number" }],
+            additionalItems: false,
+          },
+        },
+      };
+      expect(normalizeAnthropicSchema(schema)).toEqual({
+        $defs: {
+          point: {
+            type: "array",
+            prefixItems: [{ type: "number" }, { type: "number" }],
+            items: false,
+          },
+        },
+      });
+    });
+
+    it("normalizes additionalItems inside properties map values", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          arr: { type: "array", additionalItems: { type: "number" } },
+        },
+      };
+      expect(normalizeAnthropicSchema(schema)).toEqual({
+        type: "object",
+        properties: {
+          arr: { type: "array", items: { type: "number" } },
+        },
+      });
+    });
+
+    it("handles deep nesting through multiple schema constructs", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          outer: {
+            anyOf: [
+              {
+                properties: {
+                  inner: {
+                    type: "array",
+                    items: [{ type: "number" }, { type: "string" }],
+                  },
+                },
+              },
+            ],
+          },
+        },
+      };
+      expect(normalizeAnthropicSchema(schema)).toEqual({
+        type: "object",
+        properties: {
+          outer: {
+            anyOf: [
+              {
+                properties: {
+                  inner: {
+                    type: "array",
+                    prefixItems: [{ type: "number" }, { type: "string" }],
+                  },
+                },
+              },
+            ],
+          },
+        },
+      });
+    });
+  });
+});

--- a/src/agents/anthropic-schema-normalizer.test.ts
+++ b/src/agents/anthropic-schema-normalizer.test.ts
@@ -75,25 +75,25 @@ describe("normalizeAnthropicSchema", () => {
   });
 
   describe("additionalItems → items conversion", () => {
-    it("converts additionalItems: false to items: false", () => {
+    it("drops standalone additionalItems (ignored in draft-07 without tuple items)", () => {
+      // draft-07 §9.3.1.2: additionalItems is only meaningful alongside
+      // tuple-form items; standalone additionalItems must be ignored.
       const schema = {
         type: "array",
         additionalItems: false,
       };
       expect(normalizeAnthropicSchema(schema)).toEqual({
         type: "array",
-        items: false,
       });
     });
 
-    it("converts additionalItems schema to items", () => {
+    it("drops standalone additionalItems schema (ignored in draft-07 without tuple items)", () => {
       const schema = {
         type: "array",
         additionalItems: { type: "string" },
       };
       expect(normalizeAnthropicSchema(schema)).toEqual({
         type: "array",
-        items: { type: "string" },
       });
     });
 
@@ -205,7 +205,8 @@ describe("normalizeAnthropicSchema", () => {
       });
     });
 
-    it("normalizes additionalItems inside properties map values", () => {
+    it("drops standalone additionalItems in properties values", () => {
+      // standalone additionalItems without tuple items is ignored in draft-07.
       const schema = {
         type: "object",
         properties: {
@@ -215,7 +216,7 @@ describe("normalizeAnthropicSchema", () => {
       expect(normalizeAnthropicSchema(schema)).toEqual({
         type: "object",
         properties: {
-          arr: { type: "array", items: { type: "number" } },
+          arr: { type: "array" },
         },
       });
     });

--- a/src/agents/anthropic-schema-normalizer.ts
+++ b/src/agents/anthropic-schema-normalizer.ts
@@ -1,0 +1,104 @@
+const SCHEMA_MAP_KEYS = new Set([
+  "$defs",
+  "definitions",
+  "dependentSchemas",
+  "patternProperties",
+  "properties",
+]);
+
+const SCHEMA_NESTED_KEYS = new Set([
+  "additionalItems",
+  "additionalProperties",
+  "allOf",
+  "anyOf",
+  "contains",
+  "else",
+  "if",
+  "items",
+  "not",
+  "oneOf",
+  "prefixItems",
+  "propertyNames",
+  "then",
+  "unevaluatedItems",
+  "unevaluatedProperties",
+]);
+
+function normalizeSchemaMap(schema: unknown): unknown {
+  if (!schema || typeof schema !== "object" || Array.isArray(schema)) {
+    return schema;
+  }
+  let changed = false;
+  const normalized: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(schema as Record<string, unknown>)) {
+    const next = normalizeDraft2020_12Recursive(value);
+    normalized[key] = next;
+    changed ||= next !== value;
+  }
+  return changed ? normalized : schema;
+}
+
+function normalizeDraft2020_12Recursive(schema: unknown): unknown {
+  if (Array.isArray(schema)) {
+    let changed = false;
+    const normalized = schema.map((entry) => {
+      const next = normalizeDraft2020_12Recursive(entry);
+      changed ||= next !== entry;
+      return next;
+    });
+    return changed ? normalized : schema;
+  }
+  if (!schema || typeof schema !== "object") {
+    return schema;
+  }
+
+  const record = schema as Record<string, unknown>;
+  let changed = false;
+  const normalized: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(record)) {
+    const next = SCHEMA_MAP_KEYS.has(key)
+      ? normalizeSchemaMap(value)
+      : SCHEMA_NESTED_KEYS.has(key)
+        ? normalizeDraft2020_12Recursive(value)
+        : value;
+    normalized[key] = next;
+    changed ||= next !== value;
+  }
+
+  // Convert draft-07 tuple items: [A, B] → draft 2020-12 prefixItems: [A, B]
+  if (Array.isArray(normalized.items)) {
+    if (!("prefixItems" in normalized)) {
+      normalized.prefixItems = normalized.items;
+    }
+    delete normalized.items;
+    changed = true;
+  }
+
+  // Convert draft-07 additionalItems → draft 2020-12 items
+  if ("additionalItems" in normalized) {
+    if (!("items" in normalized)) {
+      normalized.items = normalized.additionalItems;
+    }
+    delete normalized.additionalItems;
+    changed = true;
+  }
+
+  return changed ? normalized : schema;
+}
+
+/**
+ * Recursively normalizes a JSON Schema from draft-07 tuple syntax to draft
+ * 2020-12 so it is accepted by Anthropic models (opus-4-8+) that enforce
+ * draft 2020-12 compliance on tool input_schema.
+ *
+ * Conversions:
+ * - `items: [A, B, C]` → `prefixItems: [A, B, C]` (tuple arrays only)
+ * - `additionalItems: X`  → `items: X`
+ *
+ * Single-schema `items: {…}` and `items: false` are left unchanged.
+ * Returns the original object reference when no changes are needed.
+ */
+export function normalizeAnthropicSchema(schema: unknown): unknown {
+  return normalizeDraft2020_12Recursive(schema);
+}

--- a/src/agents/anthropic-schema-normalizer.ts
+++ b/src/agents/anthropic-schema-normalizer.ts
@@ -66,8 +66,11 @@ function normalizeDraft2020_12Recursive(schema: unknown): unknown {
     changed ||= next !== value;
   }
 
-  // Convert draft-07 tuple items: [A, B] → draft 2020-12 prefixItems: [A, B]
-  if (Array.isArray(normalized.items)) {
+  // Convert draft-07 tuple items: [A, B] → draft 2020-12 prefixItems: [A, B].
+  // Track whether the original items was a tuple so we only transfer
+  // additionalItems when it was semantically active (draft-07 §9.3.1.1).
+  const hadTupleItems = Array.isArray(normalized.items);
+  if (hadTupleItems) {
     if (!("prefixItems" in normalized)) {
       normalized.prefixItems = normalized.items;
     }
@@ -75,9 +78,11 @@ function normalizeDraft2020_12Recursive(schema: unknown): unknown {
     changed = true;
   }
 
-  // Convert draft-07 additionalItems → draft 2020-12 items
+  // Convert draft-07 additionalItems → draft 2020-12 items.
+  // additionalItems is only meaningful alongside tuple items in draft-07;
+  // standalone additionalItems must be ignored (draft-07 §9.3.1.2).
   if ("additionalItems" in normalized) {
-    if (!("items" in normalized)) {
+    if (hadTupleItems && !("items" in normalized)) {
       normalized.items = normalized.additionalItems;
     }
     delete normalized.additionalItems;
@@ -94,7 +99,8 @@ function normalizeDraft2020_12Recursive(schema: unknown): unknown {
  *
  * Conversions:
  * - `items: [A, B, C]` → `prefixItems: [A, B, C]` (tuple arrays only)
- * - `additionalItems: X`  → `items: X`
+ * - `additionalItems: X`  → `items: X` (only when tuple items was present;
+ *   standalone additionalItems is ignored in draft-07 and is dropped)
  *
  * Single-schema `items: {…}` and `items: false` are left unchanged.
  * Returns the original object reference when no changes are needed.

--- a/src/agents/anthropic-tool-projection.test.ts
+++ b/src/agents/anthropic-tool-projection.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import { projectAnthropicTools } from "./anthropic-tool-projection.js";
+
+describe("projectAnthropicTools", () => {
+  const toWireName = (name: string) => name;
+
+  it("converts draft-07 tuple items to draft 2020-12 prefixItems in projected input_schema", () => {
+    const projection = projectAnthropicTools(
+      [
+        {
+          name: "tuple_tool",
+          description: "tool with tuple schema",
+          parameters: {
+            type: "object",
+            properties: {
+              coords: {
+                type: "array",
+                items: [{ type: "number" }, { type: "number" }],
+                additionalItems: false,
+              },
+            },
+            required: ["coords"],
+          },
+        },
+      ],
+      toWireName,
+    );
+
+    expect(projection.tools).toHaveLength(1);
+    const schema = projection.tools[0].inputSchema;
+    expect(schema.additionalProperties).toBe(false);
+    const coords = schema.properties.coords as Record<string, unknown>;
+    expect(coords.prefixItems).toEqual([{ type: "number" }, { type: "number" }]);
+    expect(coords.items).toBe(false); // from additionalItems: false
+    expect(coords).not.toHaveProperty("additionalItems");
+  });
+
+  it("converts deep nested tuple items through anyOf in projected input_schema", () => {
+    const projection = projectAnthropicTools(
+      [
+        {
+          name: "nested_tool",
+          description: "tool with nested tuple in anyOf",
+          parameters: {
+            type: "object",
+            properties: {
+              value: {
+                anyOf: [
+                  { type: "array", items: [{ type: "number" }, { type: "string" }] },
+                  { type: "string" },
+                ],
+              },
+            },
+          },
+        },
+      ],
+      toWireName,
+    );
+
+    expect(projection.tools).toHaveLength(1);
+    const value = projection.tools[0].inputSchema.properties.value as Record<string, unknown>;
+    const options = value.anyOf as Array<Record<string, unknown>>;
+    expect(options[0].prefixItems).toEqual([{ type: "number" }, { type: "string" }]);
+    expect(options[0]).not.toHaveProperty("items");
+  });
+
+  it("returns identity for single-schema items (no conversion)", () => {
+    const projection = projectAnthropicTools(
+      [
+        {
+          name: "simple_array_tool",
+          description: "tool with simple array",
+          parameters: {
+            type: "object",
+            properties: {
+              tags: {
+                type: "array",
+                items: { type: "string" },
+              },
+            },
+          },
+        },
+      ],
+      toWireName,
+    );
+
+    expect(projection.tools).toHaveLength(1);
+    const tags = projection.tools[0].inputSchema.properties.tags as Record<string, unknown>;
+    expect(tags.items).toEqual({ type: "string" });
+    expect(tags).not.toHaveProperty("prefixItems");
+  });
+
+  it("preserves additionalProperties: false on top-level inputSchema", () => {
+    const projection = projectAnthropicTools(
+      [
+        {
+          name: "basic_tool",
+          description: "basic tool",
+          parameters: {
+            type: "object",
+            properties: {
+              query: { type: "string" },
+            },
+            required: ["query"],
+          },
+        },
+      ],
+      toWireName,
+    );
+
+    expect(projection.tools).toHaveLength(1);
+    expect(projection.tools[0].inputSchema.additionalProperties).toBe(false);
+    expect(projection.tools[0].inputSchema.type).toBe("object");
+    expect(projection.tools[0].inputSchema.properties).toEqual({
+      query: { type: "string" },
+    });
+    expect(projection.tools[0].inputSchema.required).toEqual(["query"]);
+  });
+});

--- a/src/agents/anthropic-tool-projection.ts
+++ b/src/agents/anthropic-tool-projection.ts
@@ -15,6 +15,7 @@ type AnthropicProjectedTool = {
     readonly type: "object";
     readonly properties: Record<string, unknown>;
     readonly required: string[];
+    readonly additionalProperties: false;
   };
 };
 
@@ -88,6 +89,7 @@ export function projectAnthropicTools(
           type: "object",
           properties: (properties ?? {}) as Record<string, unknown>,
           required: (required ?? []) as string[],
+          additionalProperties: false,
         },
       };
     } catch {

--- a/src/agents/anthropic-tool-projection.ts
+++ b/src/agents/anthropic-tool-projection.ts
@@ -1,4 +1,5 @@
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { normalizeAnthropicSchema } from "./anthropic-schema-normalizer.js";
 import { projectRuntimeToolInputSchema } from "./tool-schema-json-projection.js";
 
 type AnthropicToolDescriptor = {
@@ -81,15 +82,21 @@ export function projectAnthropicTools(
         // Description is optional; keep the usable tool schema.
       }
       const wireName = toWireName(name);
+      const inputSchema = {
+        type: "object" as const,
+        properties: (properties ?? {}) as Record<string, unknown>,
+        required: (required ?? []) as string[],
+        additionalProperties: false as const,
+      };
       projectedTool = {
         originalName: name,
         wireName,
         ...(description ? { description } : {}),
-        inputSchema: {
-          type: "object",
-          properties: (properties ?? {}) as Record<string, unknown>,
-          required: (required ?? []) as string[],
-          additionalProperties: false,
+        inputSchema: normalizeAnthropicSchema(inputSchema) as {
+          type: "object";
+          properties: Record<string, unknown>;
+          required: string[];
+          additionalProperties: false;
         },
       };
     } catch {

--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -1731,7 +1731,7 @@ describe("anthropic transport stream", () => {
     expect(requireRecord(tool.input_schema, "input schema").properties).toEqual({
       query: { type: "string" },
     });
-    expect(tool.input_schema.additionalProperties).toBe(false);
+    expect(requireRecord(tool.input_schema, "input schema").additionalProperties).toBe(false);
   });
 
   it("omits automatic Anthropic tool choice when every provided schema is unreadable", async () => {

--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -1731,6 +1731,7 @@ describe("anthropic transport stream", () => {
     expect(requireRecord(tool.input_schema, "input schema").properties).toEqual({
       query: { type: "string" },
     });
+    expect(tool.input_schema.additionalProperties).toBe(false);
   });
 
   it("omits automatic Anthropic tool choice when every provided schema is unreadable", async () => {

--- a/src/agents/tool-schema-json-projection.ts
+++ b/src/agents/tool-schema-json-projection.ts
@@ -1,3 +1,5 @@
+import { normalizeAnthropicSchema } from "./anthropic-schema-normalizer.js";
+
 /** JSON-safe schema value used when projecting runtime tool parameters. */
 export type RuntimeToolInputSchemaJson =
   | null
@@ -124,8 +126,9 @@ export function projectRuntimeToolInputSchema(
     violations.push(`${path}.type must be "object"`);
   }
   violations.push(...findDynamicSchemaKeywordViolations(projection.schema, path));
+  const normalized = normalizeAnthropicSchema(projection.schema);
   return {
-    schema: projection.schema,
+    schema: normalized as RuntimeToolInputSchemaJson,
     violations,
   };
 }

--- a/src/agents/tool-schema-json-projection.ts
+++ b/src/agents/tool-schema-json-projection.ts
@@ -1,5 +1,3 @@
-import { normalizeAnthropicSchema } from "./anthropic-schema-normalizer.js";
-
 /** JSON-safe schema value used when projecting runtime tool parameters. */
 export type RuntimeToolInputSchemaJson =
   | null
@@ -126,9 +124,8 @@ export function projectRuntimeToolInputSchema(
     violations.push(`${path}.type must be "object"`);
   }
   violations.push(...findDynamicSchemaKeywordViolations(projection.schema, path));
-  const normalized = normalizeAnthropicSchema(projection.schema);
   return {
-    schema: normalized as RuntimeToolInputSchemaJson,
+    schema: projection.schema,
     violations,
   };
 }

--- a/src/llm/providers/anthropic.test.ts
+++ b/src/llm/providers/anthropic.test.ts
@@ -1191,6 +1191,7 @@ describe("Anthropic provider", () => {
     expect(payload.tools?.[0]?.input_schema).toMatchObject({
       properties: { query: { type: "string" } },
       required: ["query"],
+      additionalProperties: false,
     });
   });
 


### PR DESCRIPTION
## What Problem This Solves

`tools.profile=coding` + `anthropic/claude-opus-4-8` returns HTTP 400 because opus-4-8 enforces **JSON Schema draft 2020-12** validation on tool `input_schema` (opus-4-7 was lenient). When tool parameters contain draft-07 tuple syntax, the Anthropic API rejects the request.

**Root cause**: draft-07 tuple `items: [...]` and `additionalItems` syntax was replaced by `prefixItems` in draft 2020-12. opus-4-8 rejects schemas containing these legacy constructs with:

```
400 tools.0.custom.input_schema: JSON schema is invalid.
It must match JSON Schema draft 2020-12
```

**Fix**: Add `normalizeAnthropicSchema`, a recursive normalizer applied at the Anthropic-specific choke point (`projectAnthropicTools`).

## Conversion Rules (semantics-preserving)

| draft-07 | draft 2020-12 |
|----------|---------------|
| `items: [A, B, C]` | `prefixItems: [A, B, C]` (delete `items`) |
| `items: [A, B]` + `additionalItems: X` | `prefixItems: [A, B]` + `items: X` (delete `additionalItems`) |
| standalone `additionalItems: X` (no tuple) | **dropped** — ignored keyword in draft-07 §9.3.1.2 |
| `items: {...}` (single schema) | unchanged |
| `items: false` | unchanged |

Identity-preserving: returns the original object reference when no changes are needed. Recursively traverses all JSON Schema nesting keywords.

## Architecture

The fix applies at the **single Anthropic-specific choke point**, keeping the shared `projectRuntimeToolInputSchema()` provider-agnostic:

```
All upstream schema sources (Zod / TypeBox / MCP / Plugin SDK / user-defined)
         ↓
  projectRuntimeToolInputSchema()  ← shared: JSON-ifies schema, checks violations (no provider logic)
         ↓
  projectAnthropicTools()          ← Anthropic-specific choke point
    └─ normalizeAnthropicSchema()  ← recursive draft 2020-12 normalization (Anthropic only)
         ↓
  input_schema                     ← sent to Anthropic API
```

Both Anthropic API consumers share the same path:
- [anthropic-transport-stream.ts:562](src/agents/anthropic-transport-stream.ts#L562) — agent transport
- [anthropic.ts:1489](src/llm/providers/anthropic.ts#L1489) — provider path

## Files Changed

| File | Change |
|------|--------|
| `src/agents/anthropic-schema-normalizer.ts` | **New** — recursive draft 2020-12 normalizer |
| `src/agents/anthropic-schema-normalizer.test.ts` | **New** — unit tests including regression for standalone `additionalItems` |
| `src/agents/anthropic-tool-projection.test.ts` | **New** — consumer-path pipeline tests |
| `src/agents/anthropic-tool-projection.ts` | **Modified** — `additionalProperties: false` + `normalizeAnthropicSchema()` call |
| `src/agents/anthropic-transport-stream.test.ts` | **Modified** — regression assertion for `additionalProperties: false` |
| `src/llm/providers/anthropic.test.ts` | **Modified** — regression assertion for `additionalProperties: false` |

## Evidence

### Tests: 162/162 passing

```
$ pnpm test src/agents/anthropic-tool-projection.test.ts \
  src/agents/anthropic-schema-normalizer.test.ts \
  src/agents/tool-schema-projection.test.ts \
  src/agents/anthropic-transport-stream.test.ts \
  src/agents/anthropic-payload-policy.test.ts \
  src/llm/providers/anthropic.test.ts

 Test Files  6 passed (6)
      Tests  162 passed (162)
```

### Normalizer tests (18 cases)

| Scenario | Assertion |
|----------|-----------|
| No-change identity-preserving | `expect(normalize(s)).toBe(s)` |
| `items: [A, B]` → `prefixItems` | `{ prefixItems: [...] }`, `items` deleted |
| `items: {...}` single schema unchanged | `toBe(s)` |
| `items: false` unchanged | `toBe(s)` |
| Existing `prefixItems` not overwritten | preserves existing `prefixItems` |
| Empty `items: []` → empty `prefixItems` | `{ prefixItems: [] }` |
| Standalone `additionalItems: false` dropped | `{}` (was ignored in draft-07) |
| Standalone `additionalItems: {...}` dropped | `{}` (was ignored in draft-07) |
| `additionalItems` with tuple items → `items` | `prefixItems` + `items` |
| Does not overwrite existing `items` when tuple+additionalItems | preserves existing `items` |
| Deep nesting in `properties` | recursive conversion |
| Tuple inside `anyOf` | recursive conversion |
| `oneOf` + `allOf` combination | recursive conversion |
| Tuple inside `$defs` | recursive conversion |
| Standalone `additionalItems` in `properties` values | dropped (ignored) |
| Multi-level deep nesting | through anyOf→properties→array |

### Consumer-path projection tests (4 cases)

| Scenario | Assertion |
|----------|-----------|
| Tuple `items` + `additionalItems` → `prefixItems` + `items` | Full pipeline verified |
| Deep nested tuple through `anyOf` | Inner tuple converted to `prefixItems` |
| Single-schema `items` identity | `items: { type: "string" }` unchanged |
| `additionalProperties: false` preserved | Top-level `inputSchema.additionalProperties` === `false` |

### Live API verification (credit: @brandencho)

Verified against real opus-4-8 API:

| tool input_schema | result |
|-------------------|--------|
| tuple `items: [...]` (draft-07) | ❌ 400 "must match JSON Schema draft 2020-12" |
| `prefixItems: [...]` (draft 2020-12) | ✅ 200 |
| `additionalProperties: false` | ✅ 200 |

### Lint / Format

| Check | Result |
|-------|--------|
| oxlint | zero errors, zero warnings |
| oxfmt | correct formatting |

## Linked Issue/PR

- Fixes #98588

## Change Type

- [x] Bug fix

## Compatibility

- [x] Backward compatible — semantics-preserving conversions
- [x] opus-4-7 compatible — `prefixItems` + `items` are also valid in draft-07
- [x] Config/env changes? No
- [x] Migration needed? No
- [x] Provider isolation — normalization is Anthropic-only

## AI Assistance

- **AI-assisted**: Yes
- **Co-Authored-By**: claude-opus-4-8 <noreply@anthropic.com>
- **Human confirmed understanding of code changes**: Yes
