### PR TITLE
fix(cli): resolve gemini.cmd on Windows supervisor spawn

### DIFF
--- a/src/process/supervisor/adapters/child.test.ts
+++ b/src/process/supervisor/adapters/child.test.ts
@@ -424,6 +424,24 @@ describe("createChildAdapter", () => {
     expect(spawnArgs.fallbacks).toStrictEqual([]);
   });
 
+  it("wraps Windows npm-global CLI backends (gemini) through trusted cmd.exe", async () => {
+    setPlatform("win32");
+
+    await createAdapterHarness({
+      pid: 3336,
+      argv: ["gemini", "--help"],
+    });
+
+    const spawnArgs = firstSpawnWithFallbackParams();
+    expect(spawnArgs.argv).toEqual([
+      expectedTrustedCmdExe(),
+      "/d",
+      "/s",
+      "/c",
+      "gemini.cmd --help",
+    ]);
+  });
+
   it("wraps Linux child spawns and strips shell-init env", async () => {
     const originalBashEnv = process.env.BASH_ENV;
     const originalEnv = process.env.ENV;

--- a/src/process/supervisor/adapters/child.ts
+++ b/src/process/supervisor/adapters/child.ts
@@ -20,7 +20,8 @@ const WINDOWS_CLOSE_STATE_SETTLE_TIMEOUT_MS = 250;
 function resolveCommand(command: string): string {
   return resolveWindowsCommandShim({
     command,
-    cmdCommands: ["npm", "pnpm", "yarn", "npx"],
+    // npm global CLIs (gemini, claude, codex, etc.) are exposed as .cmd shims on Windows.
+    cmdCommands: ["npm", "pnpm", "yarn", "npx", "gemini", "claude", "codex"],
   });
 }
 


### PR DESCRIPTION
## What Problem This Solves

On Windows, globally installed npm CLIs such as `@google/gemini-cli` are exposed as `gemini.cmd`, not a bare `gemini` executable. The supervisor child spawn path did not append `.cmd`, so `google-gemini-cli` failed immediately with `spawn gemini ENOENT`.

Fixes #98573

## Evidence

- Regression test in `src/process/supervisor/adapters/child.test.ts` asserts `gemini` resolves through `cmd.exe` as `gemini.cmd --help` on Windows.
- `node scripts/run-vitest.mjs src/process/supervisor/adapters/child.test.ts` — new case passes; existing shim coverage unchanged.
- CI `checks-windows-node-test` passes on the PR head.

## Summary

- Extend supervisor child adapter `.cmd` shim list to npm-global agent CLIs (`gemini`, `claude`, `codex`).
- Reuses the existing trusted `cmd.exe` wrapper already used for `npm`/`pnpm`/`yarn`.
