### PR TITLE
fix(agents): sanitize OpenAI composite tool ids on cross-provider replay

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.tool-call-normalization.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.tool-call-normalization.test.ts
@@ -972,6 +972,46 @@ describe("sanitizeReplayToolCallIdsForStream", () => {
     });
   });
 
+  it("sanitizes failover-introduced composite ids when signed-thinking preservation is enabled", () => {
+    const compositeId = "call_AbCdEf0123456789|fc_01a7abc";
+    const out = sanitizeReplayToolCallIdsForStream({
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: "internal", thinkingSignature: "sig_1" },
+            { type: "toolUse", id: compositeId, name: "read", input: { path: "." } },
+          ],
+        } as never,
+        {
+          role: "toolResult",
+          toolCallId: compositeId,
+          toolUseId: compositeId,
+          toolName: "read",
+          content: [{ type: "text", text: "ok" }],
+          isError: false,
+        } as never,
+      ],
+      mode: "strict",
+      preserveNativeAnthropicToolUseIds: true,
+      preserveReplaySafeThinkingToolCallIds: true,
+      repairToolUseResultPairing: true,
+    });
+
+    expect(requireAssistantMessage(out[0]).content[1]).toMatchObject({
+      type: "toolUse",
+      id: "callAbCdEf0123456789fc01a7abc",
+      name: "read",
+    });
+    expect(toolResultSummary(out[1])).toEqual({
+      role: "toolResult",
+      toolCallId: "callAbCdEf0123456789fc01a7abc",
+      toolUseId: "callAbCdEf0123456789fc01a7abc",
+      toolName: "read",
+      isError: false,
+    });
+  });
+
   it("synthesizes missing tool results after strict id sanitization", () => {
     const rawId = "call_function_av7cbkigmk7x1";
     const out = sanitizeReplayToolCallIdsForStream({

--- a/src/agents/tool-call-id.test.ts
+++ b/src/agents/tool-call-id.test.ts
@@ -389,6 +389,39 @@ describe("sanitizeToolCallIdsForCloudCodeAssist", () => {
       expect((out[1] as Extract<AgentMessage, { role: "toolResult" }>).toolCallId).toBe("call_1");
     });
 
+    it("sanitizes OpenAI Responses composite ids in replay-safe signed-thinking turns", () => {
+      const compositeId = "call_123|fc_123";
+      const input = castAgentMessages([
+        {
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: "internal", thinkingSignature: "sig_1" },
+            { type: "toolCall", id: compositeId, name: "read", arguments: {} },
+          ],
+        },
+        {
+          role: "toolResult",
+          toolCallId: compositeId,
+          toolName: "read",
+          content: [{ type: "text", text: "ok" }],
+        },
+      ]);
+
+      const out = sanitizeToolCallIdsForCloudCodeAssist(input, "strict", {
+        preserveReplaySafeThinkingToolCallIds: true,
+        preserveNativeAnthropicToolUseIds: true,
+        allowedToolNames: ["read"],
+      });
+
+      expect(out).not.toBe(input);
+      expect(
+        ((out[0] as Extract<AgentMessage, { role: "assistant" }>).content[1] as { id?: string }).id,
+      ).toBe("call123fc123");
+      expect((out[1] as Extract<AgentMessage, { role: "toolResult" }>).toolCallId).toBe(
+        "call123fc123",
+      );
+    });
+
     it("rewrites earlier mutable ids away from later preserved signed ids", () => {
       const input = castAgentMessages([
         {

--- a/src/agents/tool-call-id.ts
+++ b/src/agents/tool-call-id.ts
@@ -178,6 +178,11 @@ function isReplaySafeThinkingAssistantMessage(
   return sawThinking && sawToolCall;
 }
 
+/** OpenAI Responses pairs persist as `call_*|fc_*`; invalid on strict Anthropic/Mistral replay. */
+function isOpenAIResponsesCompositeToolCallId(id: string): boolean {
+  return id.includes("|");
+}
+
 function collectReplaySafeThinkingToolIds(
   messages: AgentMessage[],
   allowedToolNames: Set<string> | null,
@@ -195,6 +200,9 @@ function collectReplaySafeThinkingToolIds(
     }
     const toolCalls = extractToolCallsFromAssistant(assistant);
     if (toolCalls.some((toolCall) => reserved.has(toolCall.id))) {
+      continue;
+    }
+    if (toolCalls.some((toolCall) => isOpenAIResponsesCompositeToolCallId(toolCall.id))) {
       continue;
     }
     preservedIndexes.add(index);
@@ -526,10 +534,13 @@ export function sanitizeToolCallIdsForCloudCodeAssist(
     if (role === "assistant") {
       const assistant = msg as Extract<AgentMessage, { role: "assistant" }>;
       if (replaySafeThinking?.preservedIndexes.has(index)) {
-        for (const toolCall of extractToolCallsFromAssistant(assistant)) {
-          preserveAssistantId(toolCall.id);
+        const toolCalls = extractToolCallsFromAssistant(assistant);
+        if (!toolCalls.some((toolCall) => isOpenAIResponsesCompositeToolCallId(toolCall.id))) {
+          for (const toolCall of toolCalls) {
+            preserveAssistantId(toolCall.id);
+          }
+          return msg;
         }
-        return msg;
       }
       const next = rewriteAssistantToolCallIds({
         message: assistant,


### PR DESCRIPTION
## What Problem This Solves

After cross-provider failover to OpenAI Responses, history can contain composite tool ids (`call_XXX|fc_YYY`). When replaying back to Anthropic, `preserveReplaySafeThinkingToolCallIds` skipped sanitization for signed-thinking turns, letting `|` characters reach Anthropic validation and permanently bricking the session with HTTP 400.

Fixes #95623

## Evidence

- Regression tests in `src/agents/tool-call-id.test.ts` and `src/agents/embedded-agent-runner/run/attempt.tool-call-normalization.test.ts` cover composite id sanitization under signed-thinking preservation.
- `node scripts/run-vitest.mjs src/agents/tool-call-id.test.ts` — 27/27 pass.
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt.tool-call-normalization.test.ts` — 29/29 pass.

## Summary

- Exclude OpenAI Responses composite ids (`|`) from replay-safe thinking preservation.
- Foreign failover-introduced ids are sanitized to strict alphanumeric form before Anthropic replay.
