### PR TITLE
fix: tool summaries preserve emoji truncation boundaries

### DIFF
--- a/src/agents/tool-description-summary.test.ts
+++ b/src/agents/tool-description-summary.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import {
+  describeToolForVerbose,
+  summarizeToolDescriptionText,
+} from "./tool-description-summary.js";
+
+function hasDanglingSurrogate(value: string): boolean {
+  return /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/u.test(value);
+}
+
+describe("tool description summaries", () => {
+  it("keeps compact summaries UTF-16 safe at truncation boundaries", () => {
+    const summary = summarizeToolDescriptionText({
+      displaySummary: "abcd😀 efgh",
+      maxLen: 8,
+    });
+
+    expect(summary).toBe("abcd...");
+    expect(hasDanglingSurrogate(summary)).toBe(false);
+  });
+
+  it("keeps verbose descriptions UTF-16 safe at truncation boundaries", () => {
+    const description = describeToolForVerbose({
+      rawDescription: "abcd😀 efgh",
+      fallback: "Tool",
+      maxLen: 8,
+    });
+
+    expect(description).toBe("abcd...");
+    expect(hasDanglingSurrogate(description)).toBe(false);
+  });
+});

--- a/src/agents/tool-description-summary.ts
+++ b/src/agents/tool-description-summary.ts
@@ -5,6 +5,7 @@
  */
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
+import { truncateUtf16Safe } from "../shared/utf16-slice.js";
 
 function normalizeSummaryWhitespace(value: string): string {
   return value.replace(/\s+/g, " ").trim();
@@ -14,7 +15,7 @@ function truncateSummary(value: string, maxLen = 120): string {
   if (value.length <= maxLen) {
     return value;
   }
-  const sliced = value.slice(0, maxLen - 3);
+  const sliced = truncateUtf16Safe(value, maxLen - 3);
   const boundary = sliced.lastIndexOf(" ");
   const trimmed = (boundary >= 48 ? sliced.slice(0, boundary) : sliced).trimEnd();
   return `${trimmed}...`;
@@ -136,7 +137,7 @@ export function describeToolForVerbose(params: {
   if (normalized.length <= maxLen) {
     return normalized;
   }
-  const sliced = normalized.slice(0, maxLen - 3);
+  const sliced = truncateUtf16Safe(normalized, maxLen - 3);
   const boundary = sliced.lastIndexOf(" ");
   return `${(boundary >= Math.floor(maxLen / 2) ? sliced.slice(0, boundary) : sliced).trimEnd()}...`;
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users viewing tool catalogs or `/tools verbose` output could see a replacement character when a tool description was truncated at the middle of an emoji or other UTF-16 surrogate pair.

This affects compact tool summaries in the effective tool inventory and Gateway tools catalog, plus verbose tool descriptions shown in `/tools verbose`.

## Why This Change Was Made

The tool description summary helper now uses the existing UTF-16-safe truncation helper before appending ellipses. This keeps the existing whitespace and word-boundary behavior while avoiding dangling surrogate halves in user-visible tool text.

AI-assisted.

## User Impact

Tool descriptions that contain emoji or other astral Unicode characters now truncate cleanly instead of rendering broken replacement characters in tool inventory surfaces.

## Evidence

Before/premise:

The current raw `slice(0, maxLen - 3)` behavior can split a surrogate pair. A negative-control run temporarily restored raw `slice` in `src/agents/tool-description-summary.ts` and ran the new regression test:

```text
FAIL src/agents/tool-description-summary.test.ts > keeps compact summaries UTF-16 safe at truncation boundaries
Expected: "abcd..."
Received: "abcd�..."

FAIL src/agents/tool-description-summary.test.ts > keeps verbose descriptions UTF-16 safe at truncation boundaries
Expected: "abcd..."
Received: "abcd�..."
```

After fix, I also ran a local OpenClaw tool-catalog proof with temporary plugin-style tool entries whose descriptions place `😀` exactly on the default truncation boundaries used by Gateway `tools.catalog` summaries and `/tools verbose` descriptions:

```text
node --import tsx --input-type=module <<'EOF'
import { buildToolsMessage } from './src/auto-reply/status.ts';
import { summarizeToolDescriptionText } from './src/agents/tool-description-summary.ts';

const hasDanglingSurrogate = (value) => /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/u.test(value);
const catalogRawDescription = `${'a'.repeat(116)}😀${'b'.repeat(20)}`;
const verboseRawDescription = `${'a'.repeat(316)}😀${'b'.repeat(20)}`;
const catalogDescription = summarizeToolDescriptionText({ rawDescription: catalogRawDescription });
const toolsVerbose = buildToolsMessage({
  profile: 'full',
  groups: [
    {
      id: 'proof',
      label: 'Proof tools',
      source: 'plugin',
      tools: [
        {
          id: 'emoji_catalog_boundary_tool',
          label: 'Emoji Catalog Boundary Tool',
          description: catalogDescription,
          rawDescription: catalogRawDescription,
          source: 'plugin',
          pluginId: 'proof-tools',
        },
        {
          id: 'emoji_verbose_boundary_tool',
          label: 'Emoji Verbose Boundary Tool',
          description: 'Verbose proof tool',
          rawDescription: verboseRawDescription,
          source: 'plugin',
          pluginId: 'proof-tools',
        },
      ],
    },
  ],
}, { verbose: true });
const verboseLine = toolsVerbose.split('\n').find((line) => line.includes('Emoji Verbose Boundary Tool')) ?? '';

console.log('Gateway tools.catalog description projection:');
console.log(JSON.stringify({ id: 'emoji_catalog_boundary_tool', description: catalogDescription }, null, 2));
console.log(`catalog contains replacement char: ${catalogDescription.includes('�')}`);
console.log(`catalog contains dangling surrogate: ${hasDanglingSurrogate(catalogDescription)}`);
console.log('\n/tools verbose output excerpt:');
console.log(verboseLine);
console.log(`verbose contains replacement char: ${verboseLine.includes('�')}`);
console.log(`verbose contains dangling surrogate: ${hasDanglingSurrogate(verboseLine)}`);
EOF

Gateway tools.catalog description projection:
{
  "id": "emoji_catalog_boundary_tool",
  "description": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa..."
}
catalog contains replacement char: false
catalog contains dangling surrogate: false

/tools verbose output excerpt:
  Emoji Verbose Boundary Tool - aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa...
verbose contains replacement char: false
verbose contains dangling surrogate: false
```

Focused tests and checks:

```text
node scripts/run-vitest.mjs src/agents/tool-description-summary.test.ts src/auto-reply/status.tools.test.ts src/gateway/server-methods/tools-catalog.test.ts

Test Files  1 passed (1)
Tests  2 passed (2)
Test Files  2 passed (2)
Tests  14 passed (14)
Test Files  1 passed (1)
Tests  6 passed (6)
```

Additional checks:

```text
pnpm format:check -- src/agents/tool-description-summary.ts src/agents/tool-description-summary.test.ts
All matched files use the correct format.

OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs src/agents/tool-description-summary.ts src/agents/tool-description-summary.test.ts
passed

.agents/skills/autoreview/scripts/autoreview --mode local --base upstream/main
autoreview clean: no accepted/actionable findings reported
```

The standard oxlint wrapper without `OPENCLAW_OXLINT_SKIP_PREPARE=1` was also attempted, but current `upstream/main` failed while preparing unrelated extension package-boundary artifacts before linting these files (`plugin-sdk boundary root shims` / rolldown `TypeError: Cannot convert undefined or null to object`). The scoped wrapper lint above still ran against the changed files.
