### PR TITLE
fix: keep workspace rail file sections scrollable

### DIFF
--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -181,8 +181,10 @@
 
 .chat-workspace-rail__section {
   display: flex;
+  flex: 0 1 auto;
   flex-direction: column;
   min-height: 0;
+  overflow-y: auto;
   padding-top: 8px;
 }
 

--- a/ui/src/ui/e2e/chat-flow.e2e.test.ts
+++ b/ui/src/ui/e2e/chat-flow.e2e.test.ts
@@ -521,6 +521,82 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
     }
   });
 
+  it("keeps long workspace file sections scrollable inside the rail", async () => {
+    const context = await newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 720, width: 1280 },
+    });
+    const page = await context.newPage();
+    const browserEntries = Array.from({ length: 60 }, (_, index) => ({
+      kind: "file" as const,
+      name: `file-${String(index + 1).padStart(2, "0")}.ts`,
+      path: `src/file-${String(index + 1).padStart(2, "0")}.ts`,
+      size: 2048 + index,
+    }));
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "sessions.files.list": {
+          browser: {
+            entries: browserEntries,
+            path: "",
+          },
+          files: [],
+          root: "/workspace",
+          sessionKey: "main",
+        },
+      },
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+      await page.getByRole("button", { name: "Expand session workspace" }).click();
+      await page.locator(".chat-workspace-rail__file-name", { hasText: "file-60.ts" }).waitFor({
+        timeout: 10_000,
+      });
+      expect(await gateway.getRequests("sessions.files.list")).toHaveLength(1);
+
+      const browserSection = page.locator(".chat-workspace-rail__section", {
+        hasText: "Project files",
+      });
+      await expect
+        .poll(
+          () =>
+            browserSection.evaluate((section) => {
+              const element = section as HTMLElement;
+              const scroll = element.closest(".chat-workspace-rail__scroll") as HTMLElement | null;
+              if (!scroll) {
+                throw new Error("Expected workspace rail scroll container");
+              }
+              const sectionRect = element.getBoundingClientRect();
+              const scrollRect = scroll.getBoundingClientRect();
+              const style = getComputedStyle(element);
+              return {
+                bottomWithinRail: Math.ceil(sectionRect.bottom) <= Math.ceil(scrollRect.bottom),
+                clientHeight: element.clientHeight,
+                overflowY: style.overflowY,
+                scrollHeight: element.scrollHeight,
+              };
+            }),
+          { timeout: 10_000 },
+        )
+        .toMatchObject({
+          bottomWithinRail: true,
+          overflowY: "auto",
+        });
+      const sectionMetrics = await browserSection.evaluate((section) => {
+        const element = section as HTMLElement;
+        return {
+          clientHeight: element.clientHeight,
+          scrollHeight: element.scrollHeight,
+        };
+      });
+      expect(sectionMetrics.scrollHeight).toBeGreaterThan(sectionMetrics.clientHeight);
+    } finally {
+      await closeBrowserContext(context);
+    }
+  });
+
   it("renders stable markdown during a streaming chat turn and finalizes the tail", async () => {
     const context = await newBrowserContext({
       locale: "en-US",


### PR DESCRIPTION
Closes #98566

## What Problem This Solves

Fixes an issue where users opening the Control UI chat workspace rail with a long project file list could see the project file section overflow without its own scrollbar.

## Why This Change Was Made

Workspace rail sections now shrink within the rail and become vertical scroll containers when their content is taller than the available rail area. This keeps the fix scoped to Control UI layout; Gateway file listing behavior is unchanged.

## User Impact

Users can browse long workspace file lists in the chat workspace rail without the list leaking past the visible rail area.

## Evidence

Focused verification passed:

- `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/ui/e2e/chat-flow.e2e.test.ts -t "keeps long workspace file sections scrollable inside the rail"`
- `node scripts/run-vitest.mjs ui/src/ui/views/chat.test.ts`
- `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/ui/e2e/chat-flow.e2e.test.ts -t "workspace"`
- `git diff --check`
- `pnpm build`
- `pnpm check`

Real behavior proof:

![Workspace rail long file list after fix](https://litter.catbox.moe/s9x6yu.png)

- Behavior addressed: long Control UI workspace rail project-file sections remain bounded inside the rail and become scrollable.
- Environment: macOS local checkout, mocked Control UI Gateway E2E, Chrome via `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH`.
- Current-main contrast: the new regression test fails before the CSS fix because `.chat-workspace-rail__section` computes `overflowY: "visible"`.
- Exact steps or command run after this patch: opened `/chat`, expanded the session workspace rail, returned 60 mocked project files from `sessions.files.list`, and measured the `Project files` section geometry in Chromium.
- Evidence after fix: section metrics showed `overflowY: "auto"`, `clientHeight: 497`, `scrollHeight: 2479`, and `bottomWithinRail: true`.
- Evidence artifact links: screenshot embedded above; local metrics file captured at `.artifacts/control-ui-e2e/workspace-rail-overflow/after-fix-long-workspace-rail-metrics.json`.
- Control check: existing workspace rail E2E coverage still passes under the `workspace` filter.
- Observed result after fix: the long project file list is internally scrollable and remains within the workspace rail.
- What was not tested: a real Windows npm-global install; this is a CSS/layout fix validated through mocked Control UI browser proof.

Broad-suite note:

- `pnpm test` was run and failed in 24 unrelated shards outside the touched Control UI surface. The touched UI unit and E2E shards passed. Several broad failures were in agents/provider/gateway/plugin/extension areas, and this local environment had `http_proxy`, `https_proxy`, and `all_proxy` set to `127.0.0.1:7897`, which matched multiple gateway HTTP failure traces.

Autoreview:

- `.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main`
- `.agents/skills/autoreview/scripts/autoreview --mode commit --commit HEAD`
- Both reported no accepted/actionable findings.

AI assistance note: This PR was authored with AI assistance. The proof above was run against the local branch after the patch.
