### PR TITLE
fix: stop invalid message timeouts from stalling

### DIFF
--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -457,6 +457,7 @@ describe("message tool gateway timeout", () => {
           timeoutMs,
         }),
       ).rejects.toThrow("timeoutMs must be a positive integer");
+      expect(mocks.resolveCommandSecretRefsViaGateway).not.toHaveBeenCalled();
       expect(mocks.runMessageAction).not.toHaveBeenCalled();
     },
   );

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -1348,6 +1348,7 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
         }
       }
 
+      const gatewayOpts = readGatewayCallOptions(params);
       const rawConfig = options?.config ?? loadConfigForTool();
       const scope = resolveMessageSecretScope({
         channel: params.channel,
@@ -1413,7 +1414,7 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
         }
       }
 
-      const gatewayResolved = resolveGatewayOptions(readGatewayCallOptions(params));
+      const gatewayResolved = resolveGatewayOptions(gatewayOpts);
       const gateway = {
         url: gatewayResolved.url,
         token: gatewayResolved.token,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the `agents-tools` CI shard could time out while rejecting an invalid message-tool `timeoutMs` when the shard was under load. The same first `timeoutMs: -1` row failed three times while the other 1,037 tests passed:

- [Pinned main CI, attempt 1](https://github.com/openclaw/openclaw/actions/runs/28511402996/job/84512412726): 153.2s
- [Pinned main CI, attempt 2](https://github.com/openclaw/openclaw/actions/runs/28511402996/job/84514551065): 159.7s
- [Pinned post-repair CI](https://github.com/openclaw/openclaw/actions/runs/28520255425/job/84542334833): 157.2s

## Why This Change Was Made

The message tool now parses shared gateway call options synchronously after visible-payload suppression and explicit-target enforcement, but before config loading, secret scoping, and SecretRef resolution. Gateway URL/token resolution remains at its existing later boundary, so valid-call configuration semantics do not move.

The regression test now also proves malformed timeout input never starts SecretRef resolution, while preserving the existing dispatch-not-called assertion.

## User Impact

Invalid message-tool gateway timeouts fail immediately instead of waiting behind asynchronous secret resolution. This restores stability to the required `agents-tools` main CI shard without raising timeouts, weakening coverage, or changing worker counts.

## Evidence

- Focused invalid-timeout regression: 3/3 passed in 1.03s on final rebased head.
- Gateway/common parsing coverage: 41 gateway tests and 19 common-parameter tests passed.
- Exact `agents-tools` shard on Blacksmith Testbox: 54 files and 1,038 tests passed in [Actions run 28521834006](https://github.com/openclaw/openclaw/actions/runs/28521834006), Testbox `tbx_01kweyg8zhzx8y5fs14qg3739b`.
- Path-scoped core production/test typechecks, two-file lint, import-cycle and guard checks passed in [Actions run 28522068321](https://github.com/openclaw/openclaw/actions/runs/28522068321), Testbox `tbx_01kweyq4s53d6a8k44jt9xwscf`.
- Fresh xhigh Codex autoreview: clean, no accepted/actionable findings.
- Provenance: direct main commit `f8d63f4b248d2641f03cc6819f1401d71e95d872` (`fix: centralize gateway timeout schema`, 2026-05-28); GitHub reports no associated PR.

AI-assisted maintenance repair; implementation and proof were verified against the full message-tool execution path and sibling gateway tools.
