### PR TITLE
fix(model-selection): handle whitespace-only model config gracefully

### DIFF
--- a/src/agents/model-selection-shared.ts
+++ b/src/agents/model-selection-shared.ts
@@ -753,8 +753,8 @@ export function resolveConfiguredModelRef(
   } & ModelManifestNormalizationContext,
 ): ModelRef {
   const rawModel = resolveAgentModelPrimaryValue(params.cfg.agents?.defaults?.model) ?? "";
-  if (rawModel) {
-    const trimmed = rawModel.trim();
+  const trimmed = rawModel.trim();
+  if (trimmed) {
     const { model: modelWithoutProfile } = splitTrailingAuthProfile(trimmed);
     const manifestPluginContext = createModelManifestPluginContext(params);
     const profileStripped = Boolean(modelWithoutProfile && modelWithoutProfile !== trimmed);


### PR DESCRIPTION
## What Problem This Solves

When `agents.defaults.model` is set to a whitespace-only string (e.g. `"   "`), the previous code entered the resolution block because whitespace is truthy in JavaScript. The `trim()` call then produced an empty string, causing the function to return `{ model: "" }` instead of falling through to `params.defaultModel`.

## Why This Change Was Made

Move `trim()` before the truthiness check so `if (trimmed)` catches both empty and whitespace-only values, allowing the correct `defaultModel` fallback.

## User Impact

Fixes model selection silently returning an empty model ID when config contains accidental whitespace in the model field.

## Evidence

- `src/agents/model-selection-resolve.test.ts`: 5/5 passed ✅
- `src/agents/model-selection-display.test.ts`: 9/9 passed ✅