### PR TITLE
test(dispatch-wrapper): preserve utility operand boundaries

### DIFF
--- a/src/infra/dispatch-wrapper-resolution.ts
+++ b/src/infra/dispatch-wrapper-resolution.ts
@@ -284,7 +284,11 @@ function unwrapFlockInvocation(argv: string[]): string[] | null {
     adjustCommandIndex: (commandIndex, currentArgv) => {
       // The first non-option token is the lock target; only the next token can be
       // the wrapped executable. Shell-string and fd-only forms stay blocked.
-      const wrappedCommandIndex = commandIndex + 1;
+      let wrappedCommandIndex = commandIndex + 1;
+      // Skip past `--` separator between lock target and command.
+      if (currentArgv[wrappedCommandIndex]?.trim() === "--") {
+        wrappedCommandIndex += 1;
+      }
       const wrappedCommand = currentArgv[wrappedCommandIndex]?.trim() ?? "";
       return wrappedCommand && (!wrappedCommand.startsWith("-") || wrappedCommand === "-")
         ? wrappedCommandIndex
@@ -349,19 +353,20 @@ function unwrapScriptInvocation(
       return "invalid";
     },
     adjustCommandIndex: (commandIndex, currentArgv) => {
-      let sawTranscript = false;
-      for (let idx = commandIndex; idx < currentArgv.length; idx += 1) {
-        const token = currentArgv[idx]?.trim() ?? "";
-        if (!token) {
-          continue;
-        }
-        if (!sawTranscript) {
-          sawTranscript = true;
-          continue;
-        }
-        return idx;
+      // When -- separator was consumed, there is no transcript file —
+      // all remaining tokens are the command.
+      if (currentArgv[commandIndex - 1] === "--") {
+        return commandIndex < currentArgv.length ? commandIndex : null;
       }
-      return null;
+      // Transcript form: first remaining token is the transcript file,
+      // second is the command. Transcript-only invocations stay blocked.
+      let remaining = 0;
+      for (let idx = commandIndex; idx < currentArgv.length; idx += 1) {
+        if (currentArgv[idx]?.trim()) {
+          remaining += 1;
+        }
+      }
+      return remaining >= 2 ? commandIndex + 1 : null;
     },
   });
 }

--- a/src/infra/exec-wrapper-resolution.test.ts
+++ b/src/infra/exec-wrapper-resolution.test.ts
@@ -367,6 +367,18 @@ describe("resolveDispatchWrapperTrustPlan", () => {
       effectiveArgv: ["bash", "-lc", "echo hi"],
     },
     {
+      argv: ["flock", "/tmp/openclaw.lock", "--", "bash", "-lc", "echo hi"],
+      wrapper: "flock",
+      effectiveArgv: ["bash", "-lc", "echo hi"],
+    },
+    {
+      argv: ["flock", "-n", "/tmp/openclaw.lock", "--", "bash", "-lc", "echo hi"],
+      wrapper: "flock",
+      effectiveArgv: ["bash", "-lc", "echo hi"],
+    },
+    // script -- echo hello is tested in unwrapKnownDispatchWrapperInvocation
+    // (not here — script.transparentUsage is always false).,
+    {
       argv: ["timeout", "--signal=TERM", "5s", "bash", "-lc", "echo hi"],
       wrapper: "timeout",
       effectiveArgv: ["bash", "-lc", "echo hi"],

--- a/src/infra/exec-wrapper-resolution.test.ts
+++ b/src/infra/exec-wrapper-resolution.test.ts
@@ -263,6 +263,10 @@ describe("unwrapKnownDispatchWrapperInvocation", () => {
       expected: { kind: "blocked", wrapper: "flock" },
     },
     {
+      argv: ["flock", "/tmp/openclaw.lock", "--", "bash", "-lc", "echo hi"],
+      expected: { kind: "blocked", wrapper: "flock" },
+    },
+    {
       argv: ["flock", "-un", "/tmp/openclaw.lock", "bash", "-lc", "echo hi"],
       expected: { kind: "blocked", wrapper: "flock" },
     },
@@ -284,6 +288,15 @@ describe("unwrapKnownDispatchWrapperInvocation", () => {
     },
   ])("unwraps known dispatch wrappers for %j", ({ argv, expected }) => {
     expect(unwrapKnownDispatchWrapperInvocation(argv)).toEqual(expected);
+  });
+
+  test("keeps the transcript operand after the script option separator", () => {
+    expect(
+      unwrapKnownDispatchWrapperInvocation(
+        ["script", "--", "/tmp/session.log", "bash", "-lc", "echo hi"],
+        "darwin",
+      ),
+    ).toEqual({ kind: "unwrapped", wrapper: "script", argv: ["bash", "-lc", "echo hi"] });
   });
 
   test("blocks arch dispatch unwrapping outside macOS", () => {
@@ -393,6 +406,11 @@ describe("resolveDispatchWrapperTrustPlan", () => {
     },
     {
       argv: ["flock", "--no-fork", "/tmp/openclaw.lock", "bash", "-lc", "echo hi"],
+      wrapper: "flock",
+      effectiveArgv: ["bash", "-lc", "echo hi"],
+    },
+    {
+      argv: ["flock", "--", "/tmp/openclaw.lock", "bash", "-lc", "echo hi"],
       wrapper: "flock",
       effectiveArgv: ["bash", "-lc", "echo hi"],
     },


### PR DESCRIPTION
Related: #98964

## What Problem This Solves

The original patch treated unsupported post-lock `flock --` syntax as a transparent command and treated BSD `script --` as if it removed the transcript-file operand. Both assumptions could make approval analysis inspect a process that the utility does not execute.

## Root cause

The candidate inferred wrapper grammar from `--` alone. The utilities keep positional operand rules after option parsing ends.

## Fix

- Remove both production parser changes from the candidate.
- Prove the valid `flock -- <lock> <command>` form still resolves and persists the inner executable.
- Prove `flock <lock> -- <command>` remains blocked because util-linux executes `--` as its command.
- Prove BSD `script -- <transcript> <command>` keeps the transcript operand before the command.

## Evidence

- util-linux 2.41 runs `flock -- <lock> /usr/bin/printf ...` and prints the inner marker.
- The same runtime rejects `flock <lock> -- /usr/bin/touch <marker>` with exit 69; the marker remains absent.
- The production approval pipeline resolves the valid form to `/usr/bin/printf` and emits that persistent pattern.
- The same pipeline blocks the invalid post-lock form and emits no persistent pattern.
- [util-linux 2.41 source](https://github.com/util-linux/util-linux/blob/v2.41/sys-utils/flock.c#L305-L325) sets the command vector to the first token after the lock operand.
- [FreeBSD 15 `script(1)`](https://man.freebsd.org/cgi/man.cgi?query=script&sektion=1&manpath=FreeBSD+15.0-RELEASE) defines `[file [command ...]]` and says a command cannot be specified without a script file.
- Focused tests: 162 wrapper tests passed.
- Sibling tests: 130 allow-always tests passed.

```text
valid-flock-inner
invalid-post-lock-status=69 marker-exists=false
valid: execution=/usr/bin/printf policyBlocked=false persistedPatterns=[/usr/bin/printf]
invalid: execution=flock policyBlocked=true persistedPatterns=[]
```

## Change size

- Production: no change.
- Tests: +18 lines across the existing table and owner boundary.
