### PR TITLE
fix(model-selection): warn on duplicate model aliases

### DIFF
--- a/src/agents/model-selection-shared.ts
+++ b/src/agents/model-selection-shared.ts
@@ -141,7 +141,15 @@ function findModelAliasCandidate(
   let match: ModelAliasCandidate | undefined;
   for (const candidate of listModelAliasCandidates(cfg)) {
     if (normalizeLowercaseStringOrEmpty(candidate.alias) === aliasKey) {
-      match = candidate;
+      if (match) {
+        // Duplicate alias — keep first match but warn so operators can find and fix.
+        const safe = sanitizeForLog(aliasKey);
+        getLog().warn(
+          `Duplicate model alias "${safe}" (targets "${sanitizeForLog(candidate.keyRaw)}" and "${sanitizeForLog(match.keyRaw)}"); using the first match.`,
+        );
+      } else {
+        match = candidate;
+      }
     }
   }
   return match;


### PR DESCRIPTION
Related: #98962

## What Problem This Solves
Duplicate model aliases silently overwrite (last Object.entries wins).

## Why This Change Was Made
Keep first match + log warning with both conflicting targets.

## User Impact
Operators see warning instead of unpredictable last-wins behavior.

## Evidence
![proof](https://raw.githubusercontent.com/zhangLei99586/openclaw/proof-screenshots/pr-4-proof.png)

- Source: `Duplicate model alias` warning in `findModelAliasCandidate` (line 148)
- `model-selection-resolve.test.ts`: 3/3 passed ✅