### PR TITLE
fix(codex): classify get_goal read statuses as successful dynamic tool calls

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.test.ts
@@ -402,6 +402,53 @@ describe("createCodexDynamicToolBridge", () => {
     expect(updatedResult.success).toBe(true);
   });
 
+  it("treats get_goal read statuses (found / missing) as successful dynamic tool calls", async () => {
+    const onFoundResult = vi.fn();
+    const foundBridge = createBridgeWithToolResult(
+      "get_goal",
+      textToolResult('{\n  "status": "found"\n}', {
+        status: "found",
+        goal: { objective: "ship the fix", status: "active" },
+      }),
+    );
+    const foundResult = await foundBridge.handleToolCall(
+      {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        callId: "call-found",
+        namespace: null,
+        tool: "get_goal",
+        arguments: {},
+      },
+      { onAgentToolResult: onFoundResult },
+    );
+    expect(foundResult.success).toBe(true);
+    expect(onFoundResult).toHaveBeenCalledWith(
+      expect.objectContaining({ toolName: "get_goal", isError: false }),
+    );
+
+    const onMissingResult = vi.fn();
+    const missingBridge = createBridgeWithToolResult(
+      "get_goal",
+      textToolResult('{\n  "status": "missing"\n}', { status: "missing" }),
+    );
+    const missingResult = await missingBridge.handleToolCall(
+      {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        callId: "call-missing",
+        namespace: null,
+        tool: "get_goal",
+        arguments: {},
+      },
+      { onAgentToolResult: onMissingResult },
+    );
+    expect(missingResult.success).toBe(true);
+    expect(onMissingResult).toHaveBeenCalledWith(
+      expect.objectContaining({ toolName: "get_goal", isError: false }),
+    );
+  });
+
   it("keeps available and registered schemas paired with their tools", () => {
     const bridge = createCodexDynamicToolBridge({
       tools: [

--- a/extensions/codex/src/app-server/dynamic-tools.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.ts
@@ -1187,6 +1187,8 @@ function isCodexToolResultError(result: AgentToolResult<unknown>): boolean {
     status !== "created" &&
     status !== "updated" &&
     status !== "accepted" &&
+    status !== "found" &&
+    status !== "missing" &&
     status !== "pending" &&
     status !== "started" &&
     status !== "running" &&


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running the Codex harness with thread goals enabled would see every `get_goal` call reported to the model as a failed tool call, even though the read succeeded. On every call the tool ran and returned the current goal (or reported that no goal was set), yet the model was told the read failed. The failure was also persisted on the transcript with `isError: true` and drove the diagnostic terminal type to `error`, so it polluted session history, diagnostics, and any error-gated heuristics.

## Why This Change Was Made

Root cause: `isCodexToolResultError` (`extensions/codex/src/app-server/dynamic-tools.ts:1159`) fail-closes. Any dynamic-tool result whose `details.status` is not in its non-error allowlist is classified as an error.

```ts
// before
  const status = details.status.trim().toLowerCase();
  return (
    status !== "" &&
    status !== "0" &&
    status !== "ok" &&
    status !== "success" &&
    status !== "completed" &&
    status !== "recorded" &&
    status !== "created" &&
    status !== "updated" &&
    status !== "accepted" &&
    status !== "pending" &&
    status !== "started" &&
    status !== "running" &&
    status !== "yielded"
  );
```

`get_goal` returns `jsonResult(snapshot)` (`src/agents/tools/goal-tools.ts:87`), and `getSessionGoal` sets `details.status` to `"found"` (a goal exists) or `"missing"` (no goal) (`src/config/sessions/goals.ts:170`, `:189`). Neither value is in the allowlist, so the classifier returns `true`, the bridge sends `success: false` to Codex, and the result is persisted with `isError: true`.

The fix adds the two read-side statuses to the same non-error allowlist, next to the write-side statuses their sibling added:

```ts
// after
    status !== "created" &&
    status !== "updated" &&
    status !== "accepted" &&
    status !== "found" &&
    status !== "missing" &&
    status !== "pending" &&
```

`found`/`missing` are the only two statuses `get_goal` can emit, and both represent a successful read. Genuinely failed statuses (`error`, `forbidden`, and the rest) remain fail-closed.

This is the right boundary: `isCodexToolResultError` is the single owner of the Codex dynamic-tool error/success classification, and this matches the boundary that merged sibling #96856 (`b3ff64145e`) already chose for the write-side goal statuses. That PR added `created`/`updated` (goal writes) and `accepted` (spawn) but missed the read-side `get_goal` statuses, so current `main` still carries the defect. The Codex contract confirms `success` is load-bearing: OpenClaw's `DynamicToolResponse.success` is consumed by Codex at `codex-rs/core/src/tools/handlers/dynamic.rs:124` and mapped into `FunctionToolOutput::from_content(body, Some(success))`, which becomes `FunctionCallOutputPayload.success` (`codex-rs/protocol/src/models.rs:1384`) and the `DynamicToolCallResponse` event, so `success: false` marks the tool call failed to the model.

## User Impact

Codex-harness users with goals enabled now get an accurate signal: reading the thread goal is reported to the model as a successful tool call instead of a failure on every call. This stops false failures from polluting session history and diagnostics and from feeding error-gated heuristics. Genuinely failed goal reads are unaffected.

## Evidence

Real runtime, before and after. Drove the real Codex dynamic-tool bridge (`createCodexDynamicToolBridge().handleToolCall`) with the real `get_goal` tool (`createGetGoalTool`) against a real on-disk session store, on pristine main f936c6b495 vs the patched tree, identical inputs. The classifier, the goal tool, the session store read/write, and the persisted-result callback all stayed real; nothing external was mocked.

Steps: seed a temp `sessions.json`, invoke the bridge once with no goal present, create a real goal via `createSessionGoal`, then invoke the bridge again; print `details.status`, the response `success`, and the persisted `isError` for each call.

```
# BEFORE (pristine main f936c6b495)
missing-goal: details.status=missing success=false persisted.isError=true
found-goal: details.status=found success=false persisted.isError=true
# AFTER (this patch, identical inputs)
missing-goal: details.status=missing success=true persisted.isError=false
found-goal: details.status=found success=true persisted.isError=false
```

Both a present goal and an absent goal now return the read as a successful tool call to the harness instead of a failure, and the persisted result flag flips from failed to ok. Genuinely failed statuses are unchanged.

Checks:
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/dynamic-tools.test.ts`: 81 passed with the patch; the new `get_goal` case fails on pristine main and passes with the fix.
- `node scripts/run-oxlint.mjs` and `oxfmt --check` on both changed files: clean.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json` and `-p test/tsconfig/tsconfig.core.test.json`: clean.

Not covered: no live Codex subprocess round-trip or live OpenAI provider request; the Codex-side mapping of `success` to the failed item status is established from the pinned `codex-rs` contract rather than a live run. Full build not run.

### Real behavior proof
Behavior addressed: under the Codex harness with goals enabled, every successful get_goal read is reported to the model as a failed tool call (success false, persisted isError true).
Real environment tested: the real Codex dynamic-tool bridge (createCodexDynamicToolBridge().handleToolCall) driving the real get_goal tool (createGetGoalTool) against a real on-disk session store, on pristine main f936c6b495 and on the patched tree; the classifier, goal tool, session store, and persisted-result callback stayed real, nothing external mocked.
Exact steps or command run after this patch: seed a temp sessions.json, invoke the bridge with no goal present, create a real goal via createSessionGoal, invoke the bridge again, print details.status plus response success plus persisted isError.
Evidence after fix:
```
# BEFORE (pristine main f936c6b495)
missing-goal: details.status=missing success=false persisted.isError=true
found-goal: details.status=found success=false persisted.isError=true
# AFTER (this patch, identical inputs)
missing-goal: details.status=missing success=true persisted.isError=false
found-goal: details.status=found success=true persisted.isError=false
```
Observed result after fix: both a present goal and an absent goal now return the read as a successful tool call to the harness instead of a failure, with the persisted result flag flipped from failed to ok; genuinely failed statuses are unchanged.
What was not tested: no live Codex subprocess round-trip or live provider request; the Codex-side mapping of success to the failed item status comes from the pinned codex-rs contract rather than a live run; full build not run.
