### PR TITLE
test(shared): add unit tests for numeric coercion helper

### DIFF
--- a/src/shared/number-coercion.test.ts
+++ b/src/shared/number-coercion.test.ts
@@ -1,27 +1,18 @@
-// Tests for numeric coercion helpers.
 import { describe, expect, it } from "vitest";
 import { resolveNonNegativeNumber } from "./number-coercion.js";
 
 describe("resolveNonNegativeNumber", () => {
-  it("returns number for positive value", () => {
-    expect(resolveNonNegativeNumber(5)).toBe(5);
-  });
-  it("returns number for zero", () => {
-    expect(resolveNonNegativeNumber(0)).toBe(0);
-  });
-  it("returns undefined for negative value", () => {
-    expect(resolveNonNegativeNumber(-1)).toBeUndefined();
-  });
-  it("returns undefined for null", () => {
-    expect(resolveNonNegativeNumber(null)).toBeUndefined();
-  });
-  it("returns undefined for undefined", () => {
-    expect(resolveNonNegativeNumber(undefined)).toBeUndefined();
-  });
-  it("returns undefined for NaN", () => {
-    expect(resolveNonNegativeNumber(Number.NaN)).toBeUndefined();
-  });
-  it("returns undefined for Infinity", () => {
-    expect(resolveNonNegativeNumber(Infinity)).toBeUndefined();
-  });
+  it.each([0, -0, 1.25, Number.MIN_VALUE, Number.MAX_VALUE])(
+    "preserves finite non-negative value %s",
+    (value) => {
+      expect(resolveNonNegativeNumber(value)).toBe(value);
+    },
+  );
+
+  it.each([-1, -0.1, Number.NaN, Infinity, -Infinity, null, undefined])(
+    "rejects invalid value %s",
+    (value) => {
+      expect(resolveNonNegativeNumber(value)).toBeUndefined();
+    },
+  );
 });

--- a/src/shared/number-coercion.test.ts
+++ b/src/shared/number-coercion.test.ts
@@ -1,0 +1,27 @@
+// Tests for numeric coercion helpers.
+import { describe, expect, it } from "vitest";
+import { resolveNonNegativeNumber } from "./number-coercion.js";
+
+describe("resolveNonNegativeNumber", () => {
+  it("returns number for positive value", () => {
+    expect(resolveNonNegativeNumber(5)).toBe(5);
+  });
+  it("returns number for zero", () => {
+    expect(resolveNonNegativeNumber(0)).toBe(0);
+  });
+  it("returns undefined for negative value", () => {
+    expect(resolveNonNegativeNumber(-1)).toBeUndefined();
+  });
+  it("returns undefined for null", () => {
+    expect(resolveNonNegativeNumber(null)).toBeUndefined();
+  });
+  it("returns undefined for undefined", () => {
+    expect(resolveNonNegativeNumber(undefined)).toBeUndefined();
+  });
+  it("returns undefined for NaN", () => {
+    expect(resolveNonNegativeNumber(Number.NaN)).toBeUndefined();
+  });
+  it("returns undefined for Infinity", () => {
+    expect(resolveNonNegativeNumber(Infinity)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

The `resolveNonNegativeNumber` function handles numeric type boundaries by returning the value only when it is a finite non-negative number, otherwise returning undefined. Without tests, the type guard logic could silently regress.

## Why This Change Was Made

Add unit tests covering positive numbers, zero, negative numbers, null, undefined, NaN, and Infinity.

## User Impact

Numeric coercion now has comprehensive test coverage at the type boundary, reducing regression risk.

## Evidence

Direct behavior probe with real function calls:

```text
$ node --import tsx -e "import(./src/shared/number-coercion.js).then(({resolveNonNegativeNumber})=>console.log(JSON.stringify([{v:5,r:resolveNonNegativeNumber(5)},{v:0,r:resolveNonNegativeNumber(0)},{v:-1,r:resolveNonNegativeNumber(-1)},{v:null,r:resolveNonNegativeNumber(null)}])))"
[{"v":5,"r":5},{"v":0,"r":0},{"v":-1},{"v":null}]
```

Targeted test:

```text
$ node scripts/run-vitest.mjs run src/shared/number-coercion.test.ts

Test Files  1 passed (1)
     Tests  7 passed (7)
  Duration  397ms
```

Formatting:

```text
$ npx oxfmt --check src/shared/number-coercion.ts src/shared/number-coercion.test.ts
Checking formatting...

All matched files use the correct format.
Finished in 72ms on 2 files using 8 threads.
```

Whitespace:

```text
$ git diff --check
```