### PR TITLE
fix(cli): bound batch-file read size in config-set-input

### DIFF
--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -172,6 +172,8 @@ SecretRef assignments are rejected on unsupported runtime-mutable surfaces (for 
 
 Batch parsing always uses the batch payload (`--batch-json`/`--batch-file`) as the source of truth. `--strict-json` / `--json` do not change batch parsing behavior.
 
+`--batch-file` payloads are limited to 50 MB. Files exceeding this limit are rejected with a "Batch file too large" error before parsing.
+
 ## `config patch`
 
 Use `config patch` when you want to paste or pipe a config-shaped patch instead of running many path-based `config set` commands. The input is a JSON5 object. Objects merge recursively, arrays and scalar values replace the target value, and `null` deletes the target path.

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -2749,7 +2749,7 @@ export function registerConfigCli(program: Command) {
     .option("--batch-json <json>", "Batch mode: JSON array of set operations")
     .option(
       "--batch-file <path>",
-      "Batch mode: read JSON array of set operations from file (max 1 MB)",
+      "Batch mode: read JSON array of set operations from file (max 50 MB)",
     )
     .action(async (path: string | undefined, value: string | undefined, opts: ConfigSetOptions) => {
       await runConfigSet({

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -2747,7 +2747,10 @@ export function registerConfigCli(program: Command) {
       false,
     )
     .option("--batch-json <json>", "Batch mode: JSON array of set operations")
-    .option("--batch-file <path>", "Batch mode: read JSON array of set operations from file")
+    .option(
+      "--batch-file <path>",
+      "Batch mode: read JSON array of set operations from file (max 1 MB)",
+    )
     .action(async (path: string | undefined, value: string | undefined, opts: ConfigSetOptions) => {
       await runConfigSet({
         path,

--- a/src/cli/config-set-input.test.ts
+++ b/src/cli/config-set-input.test.ts
@@ -112,4 +112,22 @@ describe("config set input parsing", () => {
       expect(() => parseBatchSource({ batchFile: batchPath })).toThrow("Batch file too large");
     });
   });
+
+  it("accepts --batch-file payload at the exact size limit", () => {
+    const content = `[${"x".repeat(MAX_BATCH_FILE_BYTES - 2)}]`; // just under limit
+    withBatchFile("openclaw-config-set-input-at-limit-", content, (batchPath) => {
+      // Should not throw — at exactly the limit (minus closing bracket room)
+      expect(() => parseBatchSource({ batchFile: batchPath })).not.toThrow("Batch file too large");
+    });
+  });
+
+  it("rejects zero-size batch files with parse error, not size error", () => {
+    // A zero-size / empty file (stat.size === 0) should fail because it's
+    // not valid JSON, not because of a size check.  Special files such as
+    // /dev/zero present the same surface: stat appears small but read is
+    // unbounded if not capped at the read call itself.
+    withBatchFile("openclaw-config-set-input-empty-", "", (batchPath) => {
+      expect(() => parseBatchSource({ batchFile: batchPath })).toThrow("Failed to parse");
+    });
+  });
 });

--- a/src/cli/config-set-input.test.ts
+++ b/src/cli/config-set-input.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { parseBatchSource } from "./config-set-input.js";
+import { MAX_BATCH_FILE_BYTES, parseBatchSource } from "./config-set-input.js";
 
 function withBatchFile<T>(prefix: string, contents: string, run: (batchPath: string) => T): T {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
@@ -103,6 +103,13 @@ describe("config set input parsing", () => {
           batchFile: batchPath,
         }),
       ).toThrow("--batch-file must be a JSON array.");
+    });
+  });
+
+  it("rejects oversized --batch-file payloads", () => {
+    const largeContent = Buffer.alloc(MAX_BATCH_FILE_BYTES + 1, "x");
+    withBatchFile("openclaw-config-set-input-large-", largeContent.toString(), (batchPath) => {
+      expect(() => parseBatchSource({ batchFile: batchPath })).toThrow("Batch file too large");
     });
   });
 });

--- a/src/cli/config-set-input.test.ts
+++ b/src/cli/config-set-input.test.ts
@@ -114,10 +114,18 @@ describe("config set input parsing", () => {
   });
 
   it("accepts --batch-file payload at the exact size limit", () => {
-    const content = `[${"x".repeat(MAX_BATCH_FILE_BYTES - 2)}]`; // just under limit
+    // Build a valid entry at exactly MAX_BATCH_FILE_BYTES
+    // Template: [{"path":"p","value":"PAD"}]
+    // Prefix: 22 bytes, suffix: 3 bytes, so PAD = MAX - 25 = 1,048,551 bytes
+    const padLen = MAX_BATCH_FILE_BYTES - 25;
+    const content = `[{"path":"p","value":"${"x".repeat(padLen)}"}]`;
+    expect(content.length).toBe(MAX_BATCH_FILE_BYTES);
     withBatchFile("openclaw-config-set-input-at-limit-", content, (batchPath) => {
-      // Should not throw — at exactly the limit (minus closing bracket room)
-      expect(() => parseBatchSource({ batchFile: batchPath })).not.toThrow("Batch file too large");
+      const parsed = parseBatchSource({ batchFile: batchPath });
+      expect(parsed).toHaveLength(1);
+      expect(parsed![0].path).toBe("p");
+      expect(typeof parsed![0].value).toBe("string");
+      expect((parsed![0].value as string).length).toBe(padLen);
     });
   });
 

--- a/src/cli/config-set-input.test.ts
+++ b/src/cli/config-set-input.test.ts
@@ -1,4 +1,5 @@
 // Config set input tests cover config value parsing from CLI input and files.
+import { execSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -138,4 +139,22 @@ describe("config set input parsing", () => {
       expect(() => parseBatchSource({ batchFile: batchPath })).toThrow("Failed to parse");
     });
   });
+
+  it("rejects FIFO (named pipe) --batch-file paths without blocking", () => {
+    // POSIX-only: verify that O_NONBLOCK prevents the CLI from hanging when
+    // a user supplies a FIFO path with no writer. Without O_NONBLOCK the
+    // openSync call blocks indefinitely before fstat can check the file type.
+    if (process.platform === "win32") return;
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-set-input-fifo-"));
+    try {
+      const fifoPath = path.join(tempDir, "batch.fifo");
+      execSync(`mkfifo "${fifoPath}"`);
+      // Must throw (not hang).  The O_NONBLOCK open lets fstat identify the
+      // FIFO, then the zero-byte read falls through to parseBatchEntries
+      // which rejects the empty input.
+      expect(() => parseBatchSource({ batchFile: fifoPath })).toThrow("Failed to parse");
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  }, 5_000);
 });

--- a/src/cli/config-set-input.ts
+++ b/src/cli/config-set-input.ts
@@ -138,12 +138,20 @@ export function parseBatchSource(opts: ConfigSetOptions): ConfigSetBatchEntry[] 
   if (!pathname) {
     throw new Error("--batch-file must not be empty.");
   }
-  const stat = fs.statSync(pathname);
-  if (stat.size > MAX_BATCH_FILE_BYTES) {
-    throw new Error(
-      `Batch file too large: ${pathname} (${stat.size} bytes, max ${MAX_BATCH_FILE_BYTES} bytes)`,
-    );
+  // Bounded read: allocate a buffer of MAX+1 so a full buffer means the
+  // file exceeds the limit.  This caps memory even for special files like
+  // /dev/zero whose stat.size is 0 but produce unbounded reads.
+  const fd = fs.openSync(pathname, "r");
+  const buf = Buffer.alloc(MAX_BATCH_FILE_BYTES + 1);
+  let bytesRead = 0;
+  try {
+    bytesRead = fs.readSync(fd, buf, 0, MAX_BATCH_FILE_BYTES + 1, 0);
+  } finally {
+    fs.closeSync(fd);
   }
-  const raw = fs.readFileSync(pathname, "utf8");
+  if (bytesRead > MAX_BATCH_FILE_BYTES) {
+    throw new Error(`Batch file too large: ${pathname} (max ${MAX_BATCH_FILE_BYTES} bytes)`);
+  }
+  const raw = buf.toString("utf8", 0, bytesRead);
   return parseBatchEntries(raw, "--batch-file");
 }

--- a/src/cli/config-set-input.ts
+++ b/src/cli/config-set-input.ts
@@ -6,6 +6,8 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import JSON5 from "json5";
 
+export const MAX_BATCH_FILE_BYTES = 1_048_576; // 1 MB
+
 export type ConfigSetOptions = {
   strictJson?: boolean;
   /** @deprecated Use strictJson. */
@@ -135,6 +137,12 @@ export function parseBatchSource(opts: ConfigSetOptions): ConfigSetBatchEntry[] 
   const pathname = normalizeStringifiedOptionalString(opts.batchFile) ?? "";
   if (!pathname) {
     throw new Error("--batch-file must not be empty.");
+  }
+  const stat = fs.statSync(pathname);
+  if (stat.size > MAX_BATCH_FILE_BYTES) {
+    throw new Error(
+      `Batch file too large: ${pathname} (${stat.size} bytes, max ${MAX_BATCH_FILE_BYTES} bytes)`,
+    );
   }
   const raw = fs.readFileSync(pathname, "utf8");
   return parseBatchEntries(raw, "--batch-file");

--- a/src/cli/config-set-input.ts
+++ b/src/cli/config-set-input.ts
@@ -138,13 +138,18 @@ export function parseBatchSource(opts: ConfigSetOptions): ConfigSetBatchEntry[] 
   if (!pathname) {
     throw new Error("--batch-file must not be empty.");
   }
-  // Bounded read: allocate a buffer of MAX+1 so a full buffer means the
-  // file exceeds the limit.  This caps memory even for special files like
-  // /dev/zero whose stat.size is 0 but produce unbounded reads.
+  const fd = fs.openSync(pathname, "r");
+  // Bounded read: for regular files, use fstat to determine actual size
+  // and allocate only what's needed, so small batch files don't pay the
+  // full 50 MB memory cost.  For special files like /dev/zero whose
+  // stat.size is 0 but produce unbounded reads, use the full cap (MAX+1).
   // Loop because fs.readSync may return a short read (fewer bytes than
   // requested) on some filesystems; a single read would silently truncate.
-  const fd = fs.openSync(pathname, "r");
-  const buf = Buffer.alloc(MAX_BATCH_FILE_BYTES + 1);
+  const fstat = fs.fstatSync(fd);
+  const allocSize = fstat.isFile()
+    ? Math.min(fstat.size, MAX_BATCH_FILE_BYTES) + 1
+    : MAX_BATCH_FILE_BYTES + 1;
+  const buf = Buffer.alloc(allocSize);
   let bytesRead = 0;
   try {
     while (bytesRead < buf.length) {

--- a/src/cli/config-set-input.ts
+++ b/src/cli/config-set-input.ts
@@ -141,11 +141,17 @@ export function parseBatchSource(opts: ConfigSetOptions): ConfigSetBatchEntry[] 
   // Bounded read: allocate a buffer of MAX+1 so a full buffer means the
   // file exceeds the limit.  This caps memory even for special files like
   // /dev/zero whose stat.size is 0 but produce unbounded reads.
+  // Loop because fs.readSync may return a short read (fewer bytes than
+  // requested) on some filesystems; a single read would silently truncate.
   const fd = fs.openSync(pathname, "r");
   const buf = Buffer.alloc(MAX_BATCH_FILE_BYTES + 1);
   let bytesRead = 0;
   try {
-    bytesRead = fs.readSync(fd, buf, 0, MAX_BATCH_FILE_BYTES + 1, 0);
+    while (bytesRead < buf.length) {
+      const result = fs.readSync(fd, buf, bytesRead, buf.length - bytesRead, null);
+      if (result === 0) break; // EOF
+      bytesRead += result;
+    }
   } finally {
     fs.closeSync(fd);
   }

--- a/src/cli/config-set-input.ts
+++ b/src/cli/config-set-input.ts
@@ -6,7 +6,7 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import JSON5 from "json5";
 
-export const MAX_BATCH_FILE_BYTES = 1_048_576; // 1 MB
+export const MAX_BATCH_FILE_BYTES = 52_428_800; // 50 MB
 
 export type ConfigSetOptions = {
   strictJson?: boolean;
@@ -157,7 +157,7 @@ export function parseBatchSource(opts: ConfigSetOptions): ConfigSetBatchEntry[] 
   }
   if (bytesRead > MAX_BATCH_FILE_BYTES) {
     throw new Error(
-      `Batch file too large: ${pathname} (max ${MAX_BATCH_FILE_BYTES.toLocaleString("en-US")} bytes / 1 MB)`,
+      `Batch file too large: ${pathname} (max ${MAX_BATCH_FILE_BYTES.toLocaleString("en-US")} bytes / 50 MB)`,
     );
   }
   const raw = buf.toString("utf8", 0, bytesRead);

--- a/src/cli/config-set-input.ts
+++ b/src/cli/config-set-input.ts
@@ -150,7 +150,9 @@ export function parseBatchSource(opts: ConfigSetOptions): ConfigSetBatchEntry[] 
     fs.closeSync(fd);
   }
   if (bytesRead > MAX_BATCH_FILE_BYTES) {
-    throw new Error(`Batch file too large: ${pathname} (max ${MAX_BATCH_FILE_BYTES} bytes)`);
+    throw new Error(
+      `Batch file too large: ${pathname} (max ${MAX_BATCH_FILE_BYTES.toLocaleString("en-US")} bytes / 1 MB)`,
+    );
   }
   const raw = buf.toString("utf8", 0, bytesRead);
   return parseBatchEntries(raw, "--batch-file");

--- a/src/cli/config-set-input.ts
+++ b/src/cli/config-set-input.ts
@@ -138,7 +138,13 @@ export function parseBatchSource(opts: ConfigSetOptions): ConfigSetBatchEntry[] 
   if (!pathname) {
     throw new Error("--batch-file must not be empty.");
   }
-  const fd = fs.openSync(pathname, "r");
+  // Open with O_NONBLOCK on POSIX so that FIFOs (named pipes) without a
+  // writer are discovered by the fstat isFile check below rather than
+  // blocking the CLI indefinitely at open time.  On Windows O_NONBLOCK is
+  // not available; the ?? 0 fallback keeps the default O_RDONLY semantics.
+  const openFlags =
+    fs.constants.O_RDONLY | ((fs.constants as { O_NONBLOCK?: number }).O_NONBLOCK ?? 0);
+  const fd = fs.openSync(pathname, openFlags);
   // Bounded read: for regular files, use fstat to determine actual size
   // and allocate only what's needed, so small batch files don't pay the
   // full 50 MB memory cost.  For special files like /dev/zero whose


### PR DESCRIPTION
## What Problem This Solves

The `--batch-file` path in `parseBatchSource()` at `src/cli/config-set-input.ts` reads an unbounded `fs.readFileSync()` when processing user-specified batch files. A user that accidentally passes a very large file (e.g., a multi-GB log instead of a config batch JSON) will trigger Node to buffer the entire payload, causing OOM pressure. The `--stdin` path in `config-cli.ts` and `exec-approvals-cli.ts` already have 1 MB bounds (`CONFIG_PATCH_STDIN_MAX_BYTES`, `EXEC_APPROVALS_STDIN_MAX_BYTES`), but the `--batch-file` path had no equivalent guard.

This is a defense-in-depth fix: in practice batch files for `openclaw config set --batch-file` are small JSON arrays of config entries, but an unbounded disk read from a user-specified path is a standard OOM surface.

## Changes

- Define `MAX_BATCH_FILE_BYTES = 52_428_800` (50 MB) in `config-set-input.ts`. This is deliberately higher than the 1 MB stdin limits because batch files on disk can be larger than typed piped input, while 50 MB still safely prevents OOM from accidentally reading multi-GB files. No real `--batch-file` workload produces a 50 MB JSON config array.
- Replace the unbounded `fs.readFileSync()` with a bounded `fs.openSync()` + `fs.readSync()` that allocates a buffer of `MAX_BATCH_FILE_BYTES + 1` and reads at most that many bytes. If the read fills the buffer beyond the limit, a descriptive error is thrown. This caps memory for all inputs, including special files like `/dev/zero` whose `stat.size` is 0 but produce unbounded reads.
- Open the batch file with `O_RDONLY | O_NONBLOCK` on POSIX so that FIFOs (named pipes) without a writer are discovered by the `fstat.isFile()` check rather than blocking the CLI indefinitely at `openSync`. On Windows `O_NONBLOCK` is not available and the open falls back to `O_RDONLY` with no behavioral change.
- Add focused regression tests: oversized rejection, exact-limit boundary acceptance with valid parsed assertion, empty-file parse error, FIFO (named pipe) rejection without blocking.
- Preserve all existing behavior: valid files under the limit continue to parse through the same `parseBatchEntries()` path.
- Update CLI `--help` text to advertise the cap.

## Why 50 MB, not 1 MB

The `--stdin` paths are capped at 1 MB because stdin input is typed directly and has no reason to exceed that. Batch files on disk (`--batch-file`) are a different surface: a config batch with thousands of entries can legitimately be larger than 1 MB. Setting the same tight cap would break existing users. 50 MB is a safe defense-in-depth ceiling — a JSON config array of that size (~500K individual entries) far exceeds any real use case — while eliminating the compatibility concern.

## Real behavior proof

- **Behavior addressed**: An oversized `--batch-file` must be rejected before parsing with a `Batch file too large` error. A normal-sized (valid) batch file must continue to parse as before. A FIFO (named pipe) path must not block the CLI and must be rejected with a parse error.
- **Real environment tested**: Local Vitest run on Node v22.22.0, exercising real `fs.openSync`/`readSync`/`closeSync` against real temp files on an ext4 filesystem, **plus** a real `openclaw config set --batch-file` CLI invocation against actual batch files, **plus** a real POSIX FIFO proving the nonblocking open prevents indefinite blocking.
- **Exact steps**: 
  1. `pnpm test src/cli/config-set-input.test.ts` — 13 tests pass including the new oversized-file regression, the exact-limit boundary test with valid payload assertion, and the FIFO nonblocking-open regression.
  2. `node openclaw.mjs config set --batch-file <file> --dry-run` — three scenarios (valid, oversized, empty).
- **Observed result**: All 13 tests pass. Real CLI behavior confirms the bounded read works end-to-end:

  ```
  $ node openclaw.mjs config set --batch-file batch-valid.json --dry-run
  Dry run successful: 3 update(s) validated against $OPENCLAW_HOME/.openclaw/openclaw.json.

  $ node openclaw.mjs config set --batch-file batch-oversized.json --dry-run
  Error: Batch file too large: /tmp/batch-oversized.json (max 52,428,800 bytes / 50 MB)

  $ node openclaw.mjs config set --batch-file batch-empty.json --dry-run
  Error: Failed to parse --batch-file: SyntaxError: JSON5: invalid end of input at 1:1
  ```

## Evidence

Focused Vitest:

```
$ pnpm test src/cli/config-set-input.test.ts

 RUN  v4.1.8

 Test Files  1 passed (1)
     Tests  13 passed (13)
```

Type checks (tsgo, only our file — pre-existing @openclaw/* module-resolution errors elsewhere):

```
$ node scripts/run-tsgo.mjs -p src/cli/config-set-input.ts
(no errors from config-set-input.ts)
```

Lint (oxlint):

```
$ node scripts/run-oxlint.mjs src/cli/config-set-input.ts src/cli/config-set-input.test.ts
(no output — no issues)
```

Format (oxfmt):

```
$ ./node_modules/.bin/oxfmt --check src/cli/config-set-input.ts src/cli/config-set-input.test.ts
All matched files use the correct format.
```



**Label**: security

_AI-assisted._
