### PR TITLE
fix(claude-cli): return updatedInput in can_use_tool allow response for Claude Code 2.1

### DIFF
--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -1960,7 +1960,7 @@ ${JSON.stringify({
       response: {
         subtype: string;
         request_id: string;
-        response: { behavior: string; toolUseID?: string };
+        response: { behavior: string; toolUseID?: string; updatedInput?: unknown };
       };
     };
     expect(parsed.type).toBe("control_response");
@@ -1968,6 +1968,7 @@ ${JSON.stringify({
     expect(parsed.response.request_id).toBe("req-allow");
     expect(parsed.response.response.behavior).toBe("allow");
     expect(parsed.response.response.toolUseID).toBe("tool-allow-1");
+    expect(parsed.response.response.updatedInput).toEqual({ command: "ls" });
   });
 
   it("reports Claude live stream progress and keeps native tools fresh while they are running", async () => {
@@ -2329,11 +2330,12 @@ ${JSON.stringify({
       response: {
         subtype: string;
         request_id: string;
-        response: { behavior: string; toolUseID?: string };
+        response: { behavior: string; toolUseID?: string; updatedInput?: unknown };
       };
     };
     expect(parsed.response.response.behavior).toBe("allow");
     expect(parsed.response.response.toolUseID).toBe("tool-default-allow-1");
+    expect(parsed.response.response.updatedInput).toEqual({ command: "echo hi" });
   });
 
   it("answers Claude live control_request can_use_tool with deny when approval defaults are restrictive", async () => {

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -866,6 +866,7 @@ function handleClaudeLiveControlRequest(
     return;
   }
   const toolUseId = typeof request.tool_use_id === "string" ? request.tool_use_id : undefined;
+  const toolInput = isRecord(request.input) ? request.input : {};
   const allowed = turn.execPermission.security === "full" && turn.execPermission.ask === "off";
   writeClaudeLiveControlResponse(session, {
     type: "control_response",
@@ -875,6 +876,7 @@ function handleClaudeLiveControlRequest(
       response: allowed
         ? {
             behavior: "allow",
+            updatedInput: toolInput,
             ...(toolUseId ? { toolUseID: toolUseId } : {}),
           }
         : {


### PR DESCRIPTION
## What Problem This Solves

In a `claude-cli`-backed session, every native tool call that Claude Code routes through its permission flow (`control_request` / `can_use_tool`) fails against `@anthropic-ai/claude-code >= 2.1.156`. OpenClaw answers an approved request with the deprecated `{ behavior: "allow" }` shape, but Claude Code 2.1 tightened its `PermissionResult` schema so the allow branch now requires an `updatedInput` record. The CLI rejects the response with a `ZodError` (`invalid_union` on `updatedInput`) before the tool runs, so the turn stalls.

This is the underlying failure behind issue #81099 (the `AskUserQuestion` variant that surfaces as `invalid_union on updatedInput`) and is reported directly in issue #95171 (all approval-gated tools: Bash, WebFetch, Grep with `path`, Glob outside cwd). Pinning Claude Code to `2.0.77` restores tool calls, confirming the break is on the OpenClaw bridge side.

## Why This Change Was Made

`handleClaudeLiveControlRequest` in `src/agents/cli-runner/claude-live-session.ts` builds the `control_response`. On main the allow branch is:

```ts
response: allowed
  ? {
      behavior: "allow",
      ...(toolUseId ? { toolUseID: toolUseId } : {}),
    }
  : { behavior: "deny", ... }
```

The allow object omits `updatedInput`. Claude Code >= 2.1 validates the response against a union whose allow branch is `{ behavior: "allow", updatedInput: <record>, ... }`; a missing `updatedInput` matches neither branch, so validation throws before the tool executes.

The fix echoes the tool input back unchanged as `updatedInput` (OpenClaw does not modify the tool input, so the original input is the correct value):

```ts
const toolInput = isRecord(request.input) ? request.input : {};
...
response: allowed
  ? {
      behavior: "allow",
      updatedInput: toolInput,
      ...(toolUseId ? { toolUseID: toolUseId } : {}),
    }
  : { behavior: "deny", ... }
```

Boundary: this is the only Claude live-session surface that answers `can_use_tool`. The other `behavior: "allow"` site, `src/agents/harness/native-hook-relay.ts`, is the `codex`-only provider adapter (`NATIVE_HOOK_RELAY_PROVIDERS = ["codex"]`) emitting the settings-hook `hookSpecificOutput` schema, a different provider contract that Claude does not route through; it is intentionally untouched. The deny branch is unchanged.

Dependency contract: the installed `claude` 2.1.197 binary emits the allow decision internally as `behavior:"allow",updatedInput:<input>` and logs `returned updatedInput that failed schema validation` on mismatch, matching the `ZodError` in #95171.

## User Impact

`claude-cli` sessions on Claude Code >= 2.1.156 can once again use native tools through the approval flow. `AskUserQuestion` and every other approval-gated tool stop failing with a `ZodError` and the assistant turn proceeds. No config or migration is required; the deny path and existing behavior are unchanged.

## Evidence

## Real behavior proof
Behavior addressed: on a `claude-cli` backend, an approved `can_use_tool` request was answered with a shape Claude Code >= 2.1.156 rejects (`invalid_union` on `updatedInput`), stalling every native tool call including `AskUserQuestion`.
Real environment tested: drove the real prepared-run entry point `executePreparedCliRun` with `backend.liveSession = "claude-stdio"` on pristine `origin/main` (ce4a259485) and on the patched tree, feeding a real `control_request` / `can_use_tool` line for the `AskUserQuestion` payload from issue #81099. The real live-session dispatcher, the real `handleClaudeLiveControlRequest`, and the real `writeClaudeLiveControlResponse` stay in play; only the spawned CLI OS process is stubbed, and the verbatim bytes OpenClaw writes to the CLI stdin are captured. The dependency contract is the installed `claude` 2.1.197 binary, whose allow shape is `behavior:"allow",updatedInput:<input>`.
Exact steps or command run after this patch: fed the `AskUserQuestion` `can_use_tool` request through `executePreparedCliRun` and captured the `control_response.response` object OpenClaw emits to the CLI.
Evidence after fix:
```
# BEFORE (pristine main ce4a259485) - emitted allow control_response.response
{"behavior":"allow","toolUseID":"tool-ask-1"}
# AFTER (this patch, identical AskUserQuestion request) - emitted allow control_response.response
{"behavior":"allow","updatedInput":{"questions":[{"question":"How do you want to watch these issues?","header":"Watch style","multiSelect":false,"options":[{"label":"Scheduled daily digest","description":"Cron job once a day."},{"label":"GitHub subscribe + notify","description":"Subscribe via API."}]}]},"toolUseID":"tool-ask-1"}
```
Observed result after fix: before the change OpenClaw emits an allow decision with no updatedInput, the exact shape Claude Code 2.1 rejects; after the change it emits updatedInput carrying the unmodified tool input, matching the shape the 2.1.197 binary expects, so the approved tool proceeds.
What was not tested: no live network round-trip against Anthropic was run (that requires an authenticated model turn to emit a real tool call); full build not run.

### Verification
- `node scripts/run-vitest.mjs src/agents/cli-runner.spawn.test.ts`: the two allow control_response cases now assert `updatedInput` round-trips the tool input; both pass with the patch and the added assertion fails on pristine main.
- `oxfmt --check` and `run-oxlint.mjs` on the changed files: clean.
- `run-tsgo.mjs -p tsconfig.core.json` and the core-test tsconfig: clean.

Related: #95171 (canonical report of this regression). Adjacent open PR #91544 targets the separate `AskUserQuestion` picker/answer bridge and does not change this line.
