### PR TITLE
test(cron): add unit tests for assertCronDeliveryInputNonBlankFields

### DIFF
--- a/src/cron/delivery-target-validation.test.ts
+++ b/src/cron/delivery-target-validation.test.ts
@@ -1,0 +1,66 @@
+// Delivery target validation tests cover cron input field blank-check guards.
+import { describe, expect, it } from "vitest";
+import { assertCronDeliveryInputNonBlankFields } from "./delivery-target-validation.js";
+
+describe("assertCronDeliveryInputNonBlankFields", () => {
+  it("does not throw for null, undefined, or non-object delivery", () => {
+    expect(() => assertCronDeliveryInputNonBlankFields(null)).not.toThrow();
+    expect(() => assertCronDeliveryInputNonBlankFields(undefined)).not.toThrow();
+    expect(() => assertCronDeliveryInputNonBlankFields("string")).not.toThrow();
+  });
+
+  it("does not throw when channel and to are non-blank strings", () => {
+    expect(() =>
+      assertCronDeliveryInputNonBlankFields({ channel: "slack", to: "#general" }),
+    ).not.toThrow();
+  });
+
+  it("throws when channel is a blank string", () => {
+    expect(() => assertCronDeliveryInputNonBlankFields({ channel: "", to: "#general" })).toThrow(
+      "delivery.channel must be a non-empty string",
+    );
+  });
+
+  it("throws when to is a whitespace-only string", () => {
+    expect(() => assertCronDeliveryInputNonBlankFields({ channel: "slack", to: "   " })).toThrow(
+      "delivery.to must be a non-empty string",
+    );
+  });
+
+  it("throws when failureDestination channel is blank", () => {
+    expect(() =>
+      assertCronDeliveryInputNonBlankFields({
+        channel: "slack",
+        to: "#general",
+        failureDestination: { channel: "" },
+      }),
+    ).toThrow("delivery.failureDestination.channel must be a non-empty string");
+  });
+
+  it("throws when completionDestination to is blank", () => {
+    expect(() =>
+      assertCronDeliveryInputNonBlankFields({
+        channel: "slack",
+        to: "#general",
+        completionDestination: { to: "   " },
+      }),
+    ).toThrow("delivery.completionDestination.to must be a non-empty string");
+  });
+
+  it("does not throw when nested destinations have valid fields", () => {
+    expect(() =>
+      assertCronDeliveryInputNonBlankFields({
+        channel: "slack",
+        to: "#general",
+        failureDestination: { channel: "email", to: "admin@example.com" },
+        completionDestination: { to: "done" },
+      }),
+    ).not.toThrow();
+  });
+
+  it("uses custom field prefix in error messages", () => {
+    expect(() => assertCronDeliveryInputNonBlankFields({ channel: "" }, "input")).toThrow(
+      "input.channel must be a non-empty string",
+    );
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

`assertCronDeliveryInputNonBlankFields` in `src/cron/delivery-target-validation.ts` is a zero-dependency validation guard that checks cron delivery input fields are non-blank before jobs enter runtime dispatch. It validates channel/to fields and nested failureDestination/completionDestination objects, throwing descriptive errors for blank strings. Despite being a safety guard on the cron dispatch path, it had no unit tests.

## Why This Change Was Made

Add 8 tests covering the validation contract:
- No-op for null, undefined, and non-object delivery values
- No-op when channel and to are valid non-blank strings
- Throws when channel is blank or to is whitespace-only
- Throws for blank fields in nested failureDestination and completionDestination
- No-op when nested destinations have valid fields
- Custom fieldPrefix propagates into error messages

## User Impact

No user-visible changes. The cron delivery input validation contract is now tested.

## Evidence

Reproducibility: not applicable.

Direct behavior probe (no mocks):

```text
$ node --import tsx -e "import('./src/cron/delivery-target-validation.js').then((m)=>{
  const r=[];
  r.push({fn:typeof m.assertCronDeliveryInputNonBlankFields});
  let ok=true;
  try{m.assertCronDeliveryInputNonBlankFields(null)}catch{ok=false}
  r.push({null_noop:ok});
  try{m.assertCronDeliveryInputNonBlankFields({channel:''})}catch(e){r.push({blank_channel:e.message})}
  try{m.assertCronDeliveryInputNonBlankFields({channel:'x',to:'  '})}catch(e){r.push({blank_to:e.message})}
  try{m.assertCronDeliveryInputNonBlankFields({channel:'x',to:'y',failureDestination:{channel:''}})}catch(e){r.push({blank_failure:e.message})}
  try{m.assertCronDeliveryInputNonBlankFields({channel:''},'input')}catch(e){r.push({custom_prefix:e.message})}
  console.log(JSON.stringify(r,null,2));
})"
[
  {"fn":"function"},
  {"null_noop":true},
  {"blank_channel":"delivery.channel must be a non-empty string"},
  {"blank_to":"delivery.to must be a non-empty string"},
  {"blank_failure":"delivery.failureDestination.channel must be a non-empty string"},
  {"custom_prefix":"input.channel must be a non-empty string"}
]
```

Targeted test:

```text
$ node scripts/run-vitest.mjs run src/cron/delivery-target-validation.test.ts
 Test Files  1 passed (1)
      Tests  8 passed (8)
```

Formatting:

```text
$ npx oxfmt --check src/cron/delivery-target-validation.ts src/cron/delivery-target-validation.test.ts
All matched files use the correct format.
```

Whitespace:

```text
$ git diff --check
```