### PR TITLE
test(shared): add unit tests for createDeferredEventBuffer

### DIFF
--- a/src/shared/deferred-event-buffer.test.ts
+++ b/src/shared/deferred-event-buffer.test.ts
@@ -1,0 +1,61 @@
+// Deferred event buffer tests cover buffered event dispatch with flush/discard.
+import { describe, expect, it, vi } from "vitest";
+import { createDeferredEventBuffer } from "./deferred-event-buffer.js";
+
+describe("createDeferredEventBuffer", () => {
+  it("buffers events on push and delivers on flush", () => {
+    const sink = { push: vi.fn() };
+    const buffer = createDeferredEventBuffer(sink);
+    buffer.push("a");
+    buffer.push("b");
+    expect(sink.push).not.toHaveBeenCalled();
+    buffer.flush();
+    expect(sink.push).toHaveBeenCalledTimes(2);
+    expect(sink.push).toHaveBeenNthCalledWith(1, "a");
+    expect(sink.push).toHaveBeenNthCalledWith(2, "b");
+  });
+
+  it("discards buffered events without delivering to sink", () => {
+    const sink = { push: vi.fn() };
+    const buffer = createDeferredEventBuffer(sink);
+    buffer.push("a");
+    buffer.discard();
+    buffer.flush();
+    expect(sink.push).not.toHaveBeenCalled();
+  });
+
+  it("calls onBufferedEvent callback on each push", () => {
+    const onEvent = vi.fn();
+    const buffer = createDeferredEventBuffer({ push() {} }, onEvent);
+    buffer.push("a");
+    buffer.push("b");
+    expect(onEvent).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not throw when onBufferedEvent is not provided", () => {
+    const buffer = createDeferredEventBuffer({ push() {} });
+    expect(() => buffer.push("a")).not.toThrow();
+  });
+
+  it("allows push after flush to start a new buffer", () => {
+    const sink = { push: vi.fn() };
+    const buffer = createDeferredEventBuffer(sink);
+    buffer.push("a");
+    buffer.flush();
+    expect(sink.push).toHaveBeenCalledTimes(1);
+    buffer.push("b");
+    buffer.flush();
+    expect(sink.push).toHaveBeenCalledTimes(2);
+  });
+
+  it("allows push after discard to start fresh", () => {
+    const sink = { push: vi.fn() };
+    const buffer = createDeferredEventBuffer(sink);
+    buffer.push("a");
+    buffer.discard();
+    buffer.push("b");
+    buffer.flush();
+    expect(sink.push).toHaveBeenCalledTimes(1);
+    expect(sink.push).toHaveBeenCalledWith("b");
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

`createDeferredEventBuffer` in `src/shared/deferred-event-buffer.ts` is a zero-dependency pure factory that provides buffered event dispatch with deferred flush and discard semantics. It is used to decouple event production from delivery. Despite being a reusable concurrency primitive, it had no unit tests.

## Why This Change Was Made

Add 6 tests covering the buffer contract:
- Events are buffered on `push` and only delivered on `flush`
- `discard` drops buffered events without delivering to sink
- Optional `onBufferedEvent` callback fires on each push
- No-op when `onBufferedEvent` is not provided
- Push after flush starts a fresh buffer cycle
- Push after discard starts fresh (prior events not leaked)

## User Impact

No user-visible changes. The deferred event buffer contract is now tested.

## Evidence

Reproducibility: not applicable.

Direct behavior probe (no mocks — real functions, real sink):

```text
$ node --import tsx -e "import('./src/shared/deferred-event-buffer.js').then((m)=>{
  const delivered=[];
  const buf=m.createDeferredEventBuffer({push(v){delivered.push(v)}});
  const r=[];
  buf.push('a'); buf.push('b');
  r.push({before_flush:[...delivered]});
  buf.flush();
  r.push({after_flush:[...delivered]});
  buf.push('c');
  r.push({after_push:[...delivered]});
  buf.discard(); buf.flush();
  r.push({after_discard_flush:[...delivered]});
  console.log(JSON.stringify(r,null,2));
})"
[
  {"before_flush":[]},
  {"after_flush":["a","b"]},
  {"after_push":["a","b"]},
  {"after_discard_flush":["a","b"]}
]
```

Targeted test:

```text
$ node scripts/run-vitest.mjs run src/shared/deferred-event-buffer.test.ts
 Test Files  1 passed (1)
      Tests  6 passed (6)
```

Formatting:

```text
$ npx oxfmt --check src/shared/deferred-event-buffer.ts src/shared/deferred-event-buffer.test.ts
All matched files use the correct format.
```

Whitespace:

```text
$ git diff --check
```