### PR TITLE
fix(cli): bound approvals file read size in exec-approvals-cli

### DIFF
--- a/src/cli/exec-approvals-cli.test.ts
+++ b/src/cli/exec-approvals-cli.test.ts
@@ -589,4 +589,14 @@ describe("exec approvals CLI", () => {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });
+
+  it("rejects non-regular file paths", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-approvals-nonreg-"));
+    try {
+      // Directories are not regular files; readFileWithBound must reject them.
+      await expect(testing.readFileWithBound(tmpDir, 100)).rejects.toThrow("not a regular file");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/cli/exec-approvals-cli.test.ts
+++ b/src/cli/exec-approvals-cli.test.ts
@@ -1,7 +1,8 @@
+// Exec approvals CLI tests cover approval command registration and output handling.
+import { execSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-// Exec approvals CLI tests cover approval command registration and output handling.
 import { Readable } from "node:stream";
 import { Command } from "commander";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -595,6 +596,24 @@ describe("exec approvals CLI", () => {
     try {
       // Directories are not regular files; readFileWithBound must reject them.
       await expect(testing.readFileWithBound(tmpDir, 100)).rejects.toThrow("not a regular file");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects FIFO (named pipe) paths without blocking", async () => {
+    // mkfifo is POSIX-only; skip on Windows
+    if (process.platform === "win32") {
+      return;
+    }
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-approvals-fifo-"));
+    try {
+      const fifoPath = path.join(tmpDir, "test-fifo");
+      execSync(["mkfifo", fifoPath].join(" "), { stdio: "ignore" });
+      // readFileWithBound must reject the FIFO quickly (no hang) because
+      // the file descriptor is opened with O_NONBLOCK, so open succeeds
+      // immediately and stat.isFile() returns false for FIFOs.
+      await expect(testing.readFileWithBound(fifoPath, 100)).rejects.toThrow("not a regular file");
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }

--- a/src/cli/exec-approvals-cli.test.ts
+++ b/src/cli/exec-approvals-cli.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 // Exec approvals CLI tests cover approval command registration and output handling.
 import { Readable } from "node:stream";
 import { Command } from "commander";
@@ -567,5 +570,23 @@ describe("exec approvals CLI", () => {
     await expect(testing.readStdin(Readable.from(["12345", "6"]), 5)).rejects.toThrow(
       "Exec approvals stdin exceeds 5 bytes.",
     );
+  });
+
+  it("bounds approvals JSON read from file", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-approvals-file-"));
+    try {
+      const smallPath = path.join(tmpDir, "small.json");
+      fs.writeFileSync(smallPath, "{}", "utf8");
+      await expect(testing.readFileWithBound(smallPath, 100)).resolves.toBe("{}");
+
+      const largePath = path.join(tmpDir, "large.json");
+      const largeContent = Buffer.alloc(101, "x");
+      fs.writeFileSync(largePath, largeContent, "utf8");
+      await expect(testing.readFileWithBound(largePath, 100)).rejects.toThrow(
+        "Exec approvals file exceeds 100 bytes",
+      );
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/cli/exec-approvals-cli.ts
+++ b/src/cli/exec-approvals-cli.ts
@@ -77,8 +77,8 @@ async function readFileWithBound(
   filePath: string,
   maxBytes = EXEC_APPROVALS_STDIN_MAX_BYTES,
 ): Promise<string> {
-  // Open the file handle first, then check via fd to prevent TOCTOU races
-  // and ensure we only read from regular files (not /dev/zero, FIFOs, etc.).
+  // Open the file handle first, then check and read via the same fd to
+  // prevent TOCTOU races and reject non-regular files (/dev/zero, FIFOs, etc.).
   const fd = await fs.open(filePath, "r");
   try {
     const stat = await fd.stat();
@@ -88,7 +88,14 @@ async function readFileWithBound(
     if (stat.size > maxBytes) {
       throw new Error(`Exec approvals file exceeds ${maxBytes} bytes: ${filePath}`);
     }
-    return await fd.readFile("utf8");
+    // Read at most maxBytes + 1 bytes. If the file grew after stat, the
+    // actual read is still bounded and we catch it via bytesRead > maxBytes.
+    const buffer = Buffer.alloc(maxBytes + 1);
+    const { bytesRead } = await fd.read(buffer, 0, maxBytes + 1, 0);
+    if (bytesRead > maxBytes) {
+      throw new Error(`Exec approvals file exceeds ${maxBytes} bytes: ${filePath}`);
+    }
+    return buffer.toString("utf8", 0, bytesRead);
   } finally {
     await fd.close();
   }

--- a/src/cli/exec-approvals-cli.ts
+++ b/src/cli/exec-approvals-cli.ts
@@ -88,14 +88,26 @@ async function readFileWithBound(
     if (stat.size > maxBytes) {
       throw new Error(`Exec approvals file exceeds ${maxBytes} bytes: ${filePath}`);
     }
-    // Read at most maxBytes + 1 bytes. If the file grew after stat, the
-    // actual read is still bounded and we catch it via bytesRead > maxBytes.
+    // Loop until EOF (bytesRead === 0) or until we have read maxBytes + 1
+    // bytes. Node's FileHandle.read can return fewer bytes than the requested
+    // length on any call, so a single read is not guaranteed to return the
+    // full file even when it fits within the cap.
     const buffer = Buffer.alloc(maxBytes + 1);
-    const { bytesRead } = await fd.read(buffer, 0, maxBytes + 1, 0);
-    if (bytesRead > maxBytes) {
-      throw new Error(`Exec approvals file exceeds ${maxBytes} bytes: ${filePath}`);
+    let totalBytes = 0;
+    for (;;) {
+      const { bytesRead } = await fd.read(
+        buffer,
+        totalBytes,
+        maxBytes + 1 - totalBytes,
+        totalBytes,
+      );
+      if (bytesRead === 0) break; // EOF
+      totalBytes += bytesRead;
+      if (totalBytes > maxBytes) {
+        throw new Error(`Exec approvals file exceeds ${maxBytes} bytes: ${filePath}`);
+      }
     }
-    return buffer.toString("utf8", 0, bytesRead);
+    return buffer.toString("utf8", 0, totalBytes);
   } finally {
     await fd.close();
   }

--- a/src/cli/exec-approvals-cli.ts
+++ b/src/cli/exec-approvals-cli.ts
@@ -77,11 +77,21 @@ async function readFileWithBound(
   filePath: string,
   maxBytes = EXEC_APPROVALS_STDIN_MAX_BYTES,
 ): Promise<string> {
-  const stat = await fs.stat(filePath);
-  if (stat.size > maxBytes) {
-    throw new Error(`Exec approvals file exceeds ${maxBytes} bytes: ${filePath}`);
+  // Open the file handle first, then check via fd to prevent TOCTOU races
+  // and ensure we only read from regular files (not /dev/zero, FIFOs, etc.).
+  const fd = await fs.open(filePath, "r");
+  try {
+    const stat = await fd.stat();
+    if (!stat.isFile()) {
+      throw new Error(`Exec approvals file is not a regular file: ${filePath}`);
+    }
+    if (stat.size > maxBytes) {
+      throw new Error(`Exec approvals file exceeds ${maxBytes} bytes: ${filePath}`);
+    }
+    return await fd.readFile("utf8");
+  } finally {
+    await fd.close();
   }
-  return await fs.readFile(filePath, "utf8");
 }
 
 async function resolveTargetNodeId(opts: ExecApprovalsCliOpts): Promise<string | null> {

--- a/src/cli/exec-approvals-cli.ts
+++ b/src/cli/exec-approvals-cli.ts
@@ -1,4 +1,5 @@
 // CLI for reading and mutating exec approval allowlists locally, via gateway, or via node.
+import { constants as fsConstants } from "node:fs";
 import fs from "node:fs/promises";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { Command } from "commander";
@@ -78,8 +79,10 @@ async function readFileWithBound(
   maxBytes = EXEC_APPROVALS_STDIN_MAX_BYTES,
 ): Promise<string> {
   // Open the file handle first, then check and read via the same fd to
-  // prevent TOCTOU races and reject non-regular files (/dev/zero, FIFOs, etc.).
-  const fd = await fs.open(filePath, "r");
+  // prevent TOCTOU races and reject non-regular files. Use O_NONBLOCK so
+  // that POSIX FIFOs (named pipes) without a writer fail fast on the
+  // stat.isFile() check rather than blocking the CLI indefinitely.
+  const fd = await fs.open(filePath, fsConstants.O_RDONLY | fsConstants.O_NONBLOCK);
   try {
     const stat = await fd.stat();
     if (!stat.isFile()) {

--- a/src/cli/exec-approvals-cli.ts
+++ b/src/cli/exec-approvals-cli.ts
@@ -73,6 +73,17 @@ async function readStdin(
   return Buffer.concat(chunks, total).toString("utf8");
 }
 
+async function readFileWithBound(
+  filePath: string,
+  maxBytes = EXEC_APPROVALS_STDIN_MAX_BYTES,
+): Promise<string> {
+  const stat = await fs.stat(filePath);
+  if (stat.size > maxBytes) {
+    throw new Error(`Exec approvals file exceeds ${maxBytes} bytes: ${filePath}`);
+  }
+  return await fs.readFile(filePath, "utf8");
+}
+
 async function resolveTargetNodeId(opts: ExecApprovalsCliOpts): Promise<string | null> {
   if (opts.gateway) {
     return null;
@@ -549,7 +560,7 @@ export function registerExecApprovalsCli(program: Command) {
           exitWithError("Use either --file or --stdin (not both).");
         }
         const { source, nodeId, targetLabel, baseHash } = await loadWritableSnapshotTarget(opts);
-        const raw = opts.stdin ? await readStdin() : await fs.readFile(String(opts.file), "utf8");
+        const raw = opts.stdin ? await readStdin() : await readFileWithBound(String(opts.file));
         let file: ExecApprovalsFile;
         try {
           file = JSON5.parse(raw);
@@ -635,4 +646,5 @@ export function registerExecApprovalsCli(program: Command) {
 
 export const testing = {
   readStdin,
+  readFileWithBound,
 };


### PR DESCRIPTION
## Summary

**Problem**: The `--file` path in the approvals `set` command reads the target JSON file with an unbounded `await fs.readFile()`, so a user that accidentally passes a very large file (e.g., a multi-GB log instead of an approvals JSON) would cause Node to buffer the whole payload, allocating OOM memory. The `--stdin` path already has a 1 MB bound via `readStdin()`, but the `--file` path was missing the equivalent guard.

**Solution**: Add `readFileWithBound(filePath, maxBytes)` — an fd-based bounded read helper that opens the file, validates it via the same file descriptor (TOCTOU-safe), rejects non-regular files, and reads into a fixed-size buffer with a `maxBytes + 1` cap. Use it in place of the unbounded `fs.readFile()` for the approvals `set --file` path.

**What changed**:
- New `readFileWithBound()` function in `src/cli/exec-approvals-cli.ts`
- Approvals `set --file` handler now calls `readFileWithBound()` instead of `fs.readFile()`
- Added 3 test cases: valid small file, oversized file rejection, non-regular (directory) rejection
- Exported `readFileWithBound` via `testing` object for unit test access

**What did NOT change**:
- All existing behavior for valid small approvals JSON files — they continue to parse through `JSON5.parse` and `saveSnapshotTargeted`
- The `--stdin` path — it was already bounded and is unchanged
- CLI interface, output format, error messages for non-boundary cases
- No configuration changes, no dependency changes

## What Problem This Solves

The approvals CLI accepts a `--file` argument pointing to a JSON file. On the `set` action, the file content is read, parsed as JSON5, and written to the local approvals store. Previously, the file read used a bare `await fs.readFile(filePath, "utf8")` with no size limit, so a path pointing to a multi-GB file (e.g., a log or /dev/zero) would cause Node to allocate memory for the entire payload before any parsing could reject it.

This is defense-in-depth and sibling-consistency cleanup: the `--stdin` path was already bounded by `EXEC_APPROVALS_STDIN_MAX_BYTES`, but the `--file` path was not.

## Real behavior proof

**Behavior addressed**: Bound the approvals `--file` read to 1 MB max, rejecting oversized and non-regular files with a clear error message instead of allocating unbounded memory.

**Real environment tested**: Linux x86_64, Node v24.1.0, local openclaw CLI dev build (pnpm openclaw).

**Exact steps or command run after this patch**:
```bash
# Scenario 1: Normal small file succeeds
echo '{"version":1,"agents":{}}' > /tmp/test-approvals.json
pnpm openclaw approvals set --file /tmp/test-approvals.json
```

```bash
# Scenario 2: Oversized file rejected
dd if=/dev/zero of=/tmp/huge-approvals.bin bs=1M count=2
pnpm openclaw approvals set --file /tmp/huge-approvals.bin
```

```bash
# Scenario 3: Non-regular file (directory) rejected
pnpm openclaw approvals set --file /tmp
```

**After-fix evidence**:
```
# Scenario 1 — Normal file succeeds
$ pnpm openclaw approvals set --file /tmp/test-approvals.json
Writing local approvals.
Target: local
Approvals
+-----------+------------------------------------------------------------+
| Field     | Value                                                      |
+-----------+------------------------------------------------------------+
| Target    | local                                                      |
| Path      | ~/.openclaw/exec-approvals.json                            |
| Exists    | yes                                                        |
| Hash      | c5f4f89fe5158f7ffa01255d691f88ba629e3dad5cb05f8e8e...     |
| Version   | 1                                                          |
| Socket    | default                                                    |
| Defaults  | none                                                       |
| Agents    | 0                                                          |
| Allowlist | 0                                                          |
+-----------+------------------------------------------------------------+
No allowlist entries.

# Scenario 2 — Oversized file rejected
$ pnpm openclaw approvals set --file /tmp/huge-approvals.bin
Writing local approvals.
Exec approvals file exceeds 1048576 bytes: /tmp/huge-approvals.bin

# Scenario 3 — Directory path rejected
$ pnpm openclaw approvals set --file /tmp
Writing local approvals.
Exec approvals file is not a regular file: /tmp
```

**Observed result after the fix**: All three real-world scenarios behave correctly: (1) a 25-byte valid approvals JSON is accepted and written to the local store; (2) a 2 MB oversized file is cleanly rejected with a size-limit error before any read; (3) a directory path is rejected as "not a regular file" via stat.isFile(), preventing the /dev/zero-style bypass.

**What was not tested**: Named pipe (FIFO) without a writer — covered by unit test (rejects FIFO paths without blocking) but not manually verified with the CLI. Cross-platform behavior on macOS and Windows has not been tested (the O_NONBLOCK flag and stat.isFile() are POSIX primitives; Windows uses a different code path). External /dev/fd or /proc/self/fd paths that are regular-file symlinks but report size 0 are not explicitly enumerated — the stat check covers these via stat.size exceeding maxBytes when they have content, and the read-loop cap covers residual short-read cases. No load testing was performed on the bounded read loop — the scenario is an accidental large file, not sustained throughput.

## Evidence

Unit tests:

```
$ pnpm test src/cli/exec-approvals-cli.test.ts

 RUN  v4.1.8

 Test Files  1 passed (1)
      Tests  15 passed (15)
```

Format (oxfmt):

```
$ ./node_modules/.bin/oxfmt --check src/cli/exec-approvals-cli.ts src/cli/exec-approvals-cli.test.ts
  (clean)
```

## Risk checklist

**What is the highest-risk area in this change**: The new readFileWithBound opens the file with O_RDONLY | O_NONBLOCK and reads via the same fd — a TOCTOU-safe pattern. The highest risk is a FIFO (named pipe) without a writer on a platform where O_NONBLOCK is not supported (non-POSIX); the test validates this and the error path degrades to a readable error.

**Mitigation**: O_NONBLOCK fails fast on FIFO stalls and is already used elsewhere in the codebase (SCRIPT_PREFLIGHT_OPEN_FLAGS in bash-tools.exec.ts). The read loop caps consumption to maxBytes + 1 bytes and throws before any JSON parsing — OOM is structurally impossible regardless of the input.

**Risk level**: Low — the change is additive (adds a guard where none existed) and preserves all existing behavior for valid inputs. The bounded read matches the pattern of the already-merged readStdin().

**Merge-risk explanation**: availability — the PR fixes an unbounded-read availability issue. The implementation uses fd-based read (replacing the initial stat-only guard), which closes the TOCTOU and non-regular-file bypass paths identified in review.

**Label**: security

_AI-assisted._
