### PR TITLE
feat(ios): support reverse-proxy Basic auth on the gateway WebSocket

### DIFF
--- a/apps/ios/Sources/Design/SettingsProTab.swift
+++ b/apps/ios/Sources/Design/SettingsProTab.swift
@@ -41,6 +41,8 @@ struct SettingsProTab: View {
     @State var selectedAgentPickerId = ""
     @State var gatewayToken = ""
     @State var gatewayPassword = ""
+    @State var gatewayProxyUsername = ""
+    @State var gatewayProxyPassword = ""
     @State var manualGatewayPortText = ""
     @State var setupStatusText: String?
     @State var stagedGatewaySetupLink: GatewayConnectDeepLink?
@@ -165,6 +167,12 @@ struct SettingsProTab: View {
             }
             .onChange(of: self.gatewayPassword) { _, newValue in
                 self.persistGatewayPassword(newValue)
+            }
+            .onChange(of: self.gatewayProxyUsername) { _, _ in
+                self.persistGatewayProxyBasicAuth()
+            }
+            .onChange(of: self.gatewayProxyPassword) { _, _ in
+                self.persistGatewayProxyBasicAuth()
             }
             .onChange(of: self.setupCode) { _, newValue in
                 if !newValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {

--- a/apps/ios/Sources/Design/SettingsProTabActions.swift
+++ b/apps/ios/Sources/Design/SettingsProTabActions.swift
@@ -171,6 +171,8 @@ extension SettingsProTab {
         guard !trimmedInstanceId.isEmpty else { return }
         self.gatewayToken = GatewaySettingsStore.loadGatewayToken(instanceId: trimmedInstanceId) ?? ""
         self.gatewayPassword = GatewaySettingsStore.loadGatewayPassword(instanceId: trimmedInstanceId) ?? ""
+        self.gatewayProxyUsername = GatewaySettingsStore.loadGatewayProxyUsername(instanceId: trimmedInstanceId) ?? ""
+        self.gatewayProxyPassword = GatewaySettingsStore.loadGatewayProxyPassword(instanceId: trimmedInstanceId) ?? ""
     }
 
     func connect(_ gateway: GatewayDiscoveryModel.DiscoveredGateway) async {
@@ -339,6 +341,8 @@ extension SettingsProTab {
         defer { self.suppressCredentialPersist = false }
         self.gatewayToken = ""
         self.gatewayPassword = ""
+        self.gatewayProxyUsername = ""
+        self.gatewayProxyPassword = ""
         GatewayOnboardingReset.reset(appModel: self.appModel, instanceId: self.instanceId)
         self.onboardingComplete = false
         self.hasConnectedOnce = false
@@ -486,6 +490,18 @@ extension SettingsProTab {
         guard !instanceId.isEmpty else { return }
         GatewaySettingsStore.saveGatewayPassword(
             value.trimmingCharacters(in: .whitespacesAndNewlines),
+            instanceId: instanceId)
+    }
+
+    /// Persist reverse-proxy Basic auth credentials together, so username and password
+    /// can never drift apart in the Keychain.
+    func persistGatewayProxyBasicAuth() {
+        guard !self.suppressCredentialPersist else { return }
+        let instanceId = self.instanceId.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !instanceId.isEmpty else { return }
+        GatewaySettingsStore.saveGatewayProxyBasicAuth(
+            username: self.gatewayProxyUsername,
+            password: self.gatewayProxyPassword,
             instanceId: instanceId)
     }
 

--- a/apps/ios/Sources/Design/SettingsProTabSections.swift
+++ b/apps/ios/Sources/Design/SettingsProTabSections.swift
@@ -840,6 +840,15 @@ extension SettingsProTab {
                     .textFieldStyle(.roundedBorder)
                 SecureField("Gateway Password", text: self.$gatewayPassword)
                     .textFieldStyle(.roundedBorder)
+                Text("Reverse proxy (optional)")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                TextField("Proxy Username", text: self.$gatewayProxyUsername)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .textFieldStyle(.roundedBorder)
+                SecureField("Proxy Password", text: self.$gatewayProxyPassword)
+                    .textFieldStyle(.roundedBorder)
                 Button(role: .destructive) {
                     self.showResetOnboardingAlert = true
                 } label: {

--- a/apps/ios/Sources/Gateway/GatewayConnectConfig.swift
+++ b/apps/ios/Sources/Gateway/GatewayConnectConfig.swift
@@ -16,6 +16,15 @@ struct GatewayConnectConfig {
     let token: String?
     let bootstrapToken: String?
     let password: String?
+    /// Extra HTTP headers for the WebSocket upgrade, used to satisfy a reverse proxy
+    /// that fronts the gateway (for example HTTP Basic auth). Empty for direct
+    /// connections. Distinct from `token`/`password`, which are gateway auth carried
+    /// inside the connect protocol message.
+    ///
+    /// Declared `var` (with a default) so the synthesized memberwise initializer keeps
+    /// this parameter optional; existing call sites that don't use a reverse proxy stay
+    /// unchanged. Instances are still treated as immutable configuration.
+    var additionalHeaders: [String: String] = [:]
     let nodeOptions: GatewayConnectOptions
 
     /// Stable, non-empty identifier used for gateway-scoped persistence keys.
@@ -33,6 +42,7 @@ struct GatewayConnectConfig {
             self.token == other.token &&
             self.bootstrapToken == other.bootstrapToken &&
             self.password == other.password &&
+            self.additionalHeaders == other.additionalHeaders &&
             Self.sameOptions(self.nodeOptions, other.nodeOptions)
     }
 

--- a/apps/ios/Sources/Gateway/GatewayConnectionController.swift
+++ b/apps/ios/Sources/Gateway/GatewayConnectionController.swift
@@ -484,6 +484,7 @@ final class GatewayConnectionController {
             token: cfg.token,
             bootstrapToken: cfg.bootstrapToken,
             password: cfg.password,
+            additionalHeaders: cfg.additionalHeaders,
             nodeOptions: nodeOptions)
         appModel.applyGatewayConnectConfig(refreshedConfig)
     }
@@ -574,6 +575,7 @@ final class GatewayConnectionController {
                 token: cfg.token,
                 bootstrapToken: cfg.bootstrapToken,
                 password: cfg.password,
+                additionalHeaders: cfg.additionalHeaders,
                 nodeOptions: cfg.nodeOptions)
             appModel.applyGatewayConnectConfig(refreshedConfig)
         } else {
@@ -816,6 +818,12 @@ final class GatewayConnectionController {
     {
         guard let appModel else { return }
         appModel.gatewayStatusText = "Connecting…"
+        // Reverse-proxy Basic auth (if configured) is applied to every connect path
+        // through here, so all callers pick it up without threading it individually.
+        let proxyInstanceId = GatewaySettingsStore.currentInstanceID()
+        let additionalHeaders = GatewayProxyAuth.basicAuthHeaders(
+            username: GatewaySettingsStore.loadGatewayProxyUsername(instanceId: proxyInstanceId),
+            password: GatewaySettingsStore.loadGatewayProxyPassword(instanceId: proxyInstanceId))
         Task { [weak self, weak appModel] in
             guard let self, let appModel else { return }
             if forceReconnect {
@@ -829,6 +837,7 @@ final class GatewayConnectionController {
                 token: token,
                 bootstrapToken: bootstrapToken,
                 password: password,
+                additionalHeaders: additionalHeaders,
                 nodeOptions: nodeOptions)
             appModel.applyGatewayConnectConfig(cfg, forceReconnect: forceReconnect)
         }

--- a/apps/ios/Sources/Gateway/GatewaySettingsStore.swift
+++ b/apps/ios/Sources/Gateway/GatewaySettingsStore.swift
@@ -176,6 +176,54 @@ enum GatewaySettingsStore {
             account: self.gatewayPasswordAccount(instanceId: instanceId))
     }
 
+    /// Reverse-proxy HTTP Basic auth credentials. Used only to traverse a proxy that
+    /// fronts the gateway (e.g. Caddy/nginx); this is separate from the gateway's own
+    /// token/password auth, which travels inside the connect protocol message.
+    static func loadGatewayProxyUsername(instanceId: String) -> String? {
+        let value = KeychainStore.loadString(
+            service: self.gatewayService,
+            account: self.gatewayProxyUsernameAccount(instanceId: instanceId))?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return value?.isEmpty == false ? value : nil
+    }
+
+    static func loadGatewayProxyPassword(instanceId: String) -> String? {
+        // The password is intentionally not trimmed: HTTP Basic secrets may contain
+        // leading/trailing whitespace.
+        let value = KeychainStore.loadString(
+            service: self.gatewayService,
+            account: self.gatewayProxyPasswordAccount(instanceId: instanceId))
+        return (value?.isEmpty == false) ? value : nil
+    }
+
+    static func saveGatewayProxyBasicAuth(username: String, password: String, instanceId: String) {
+        let trimmedUser = username.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmedUser.isEmpty {
+            // No username means no proxy auth; clear both so a partial secret never lingers.
+            _ = KeychainStore.delete(
+                service: self.gatewayService,
+                account: self.gatewayProxyUsernameAccount(instanceId: instanceId))
+            _ = KeychainStore.delete(
+                service: self.gatewayService,
+                account: self.gatewayProxyPasswordAccount(instanceId: instanceId))
+            return
+        }
+        _ = KeychainStore.saveString(
+            trimmedUser,
+            service: self.gatewayService,
+            account: self.gatewayProxyUsernameAccount(instanceId: instanceId))
+        if password.isEmpty {
+            _ = KeychainStore.delete(
+                service: self.gatewayService,
+                account: self.gatewayProxyPasswordAccount(instanceId: instanceId))
+        } else {
+            _ = KeychainStore.saveString(
+                password,
+                service: self.gatewayService,
+                account: self.gatewayProxyPasswordAccount(instanceId: instanceId))
+        }
+    }
+
     enum LastGatewayConnection: Equatable {
         case manual(host: String, port: Int, useTLS: Bool, stableID: String)
         case discovered(stableID: String, useTLS: Bool)
@@ -315,6 +363,12 @@ enum GatewaySettingsStore {
         _ = KeychainStore.delete(
             service: self.gatewayService,
             account: self.gatewayPasswordAccount(instanceId: trimmed))
+        _ = KeychainStore.delete(
+            service: self.gatewayService,
+            account: self.gatewayProxyUsernameAccount(instanceId: trimmed))
+        _ = KeychainStore.delete(
+            service: self.gatewayService,
+            account: self.gatewayProxyPasswordAccount(instanceId: trimmed))
     }
 
     static func loadGatewayClientIdOverride(stableID: String) -> String? {
@@ -371,6 +425,14 @@ enum GatewaySettingsStore {
 
     private static func gatewayPasswordAccount(instanceId: String) -> String {
         "gateway-password.\(instanceId)"
+    }
+
+    private static func gatewayProxyUsernameAccount(instanceId: String) -> String {
+        "gateway-proxy-username.\(instanceId)"
+    }
+
+    private static func gatewayProxyPasswordAccount(instanceId: String) -> String {
+        "gateway-proxy-password.\(instanceId)"
     }
 
     private static func talkProviderApiKeyAccount(providerId: String) -> String {

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -2028,6 +2028,7 @@ extension NodeAppModel {
         token: String?,
         bootstrapToken: String?,
         password: String?,
+        additionalHeaders: [String: String] = [:],
         connectOptions: GatewayConnectOptions,
         forceReconnect: Bool = false)
     {
@@ -2041,6 +2042,7 @@ extension NodeAppModel {
             token: token,
             bootstrapToken: bootstrapToken,
             password: password,
+            additionalHeaders: additionalHeaders,
             nodeOptions: connectOptions)
         let operatorLoopRequired = self.shouldStartOperatorGatewayLoop(
             token: token,
@@ -2095,6 +2097,7 @@ extension NodeAppModel {
             token: cfg.token,
             bootstrapToken: cfg.bootstrapToken,
             password: cfg.password,
+            additionalHeaders: cfg.additionalHeaders,
             connectOptions: cfg.nodeOptions,
             forceReconnect: forceReconnect)
     }
@@ -2334,6 +2337,7 @@ extension NodeAppModel {
             token: config.token,
             bootstrapToken: nil,
             password: config.password,
+            additionalHeaders: config.additionalHeaders,
             nodeOptions: config.nodeOptions)
     }
 
@@ -2468,6 +2472,7 @@ extension NodeAppModel {
                         token: reconnectAuth.token,
                         bootstrapToken: reconnectAuth.bootstrapToken,
                         password: reconnectAuth.password,
+                        additionalHeaders: self.activeGatewayConnectConfig?.additionalHeaders ?? [:],
                         connectOptions: operatorOptions,
                         sessionBox: sessionBox,
                         onConnected: { [weak self] in
@@ -2609,6 +2614,7 @@ extension NodeAppModel {
                         token: reconnectAuth.token,
                         bootstrapToken: reconnectAuth.bootstrapToken,
                         password: reconnectAuth.password,
+                        additionalHeaders: self.activeGatewayConnectConfig?.additionalHeaders ?? [:],
                         connectOptions: connectedOptions,
                         sessionBox: sessionBox,
                         onConnected: { [weak self] in

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
@@ -78,11 +78,39 @@ public struct WebSocketTaskBox: @unchecked Sendable {
 
 public protocol WebSocketSessioning: AnyObject {
     func makeWebSocketTask(url: URL) -> WebSocketTaskBox
+    /// Create the upgrade task with extra HTTP headers on the handshake request.
+    ///
+    /// Used to satisfy an identity-aware reverse proxy that fronts the gateway (for
+    /// example one enforcing HTTP Basic auth). Gateway auth (token/password) travels
+    /// inside the `connect` protocol message, so it never collides with a proxy
+    /// `Authorization` header set here.
+    ///
+    /// The default implementation ignores `headers` and falls back to the URL-only
+    /// task, so existing conformers (including test doubles) keep working unchanged.
+    func makeWebSocketTask(url: URL, headers: [String: String]) -> WebSocketTaskBox
+}
+
+extension WebSocketSessioning {
+    public func makeWebSocketTask(url: URL, headers _: [String: String]) -> WebSocketTaskBox {
+        self.makeWebSocketTask(url: url)
+    }
 }
 
 extension URLSession: WebSocketSessioning {
     public func makeWebSocketTask(url: URL) -> WebSocketTaskBox {
-        let task = self.webSocketTask(with: url)
+        Self.boxed(self.webSocketTask(with: url))
+    }
+
+    public func makeWebSocketTask(url: URL, headers: [String: String]) -> WebSocketTaskBox {
+        guard !headers.isEmpty else { return self.makeWebSocketTask(url: url) }
+        var request = URLRequest(url: url)
+        for (field, value) in headers {
+            request.setValue(value, forHTTPHeaderField: field)
+        }
+        return Self.boxed(self.webSocketTask(with: request))
+    }
+
+    private static func boxed(_ task: URLSessionWebSocketTask) -> WebSocketTaskBox {
         // Avoid "Message too long" receive errors for large snapshots / history payloads.
         task.maximumMessageSize = 16 * 1024 * 1024 // 16 MB
         return WebSocketTaskBox(task: task)
@@ -251,6 +279,9 @@ public actor GatewayChannelActor {
     private var token: String?
     private var bootstrapToken: String?
     private var password: String?
+    /// Extra HTTP headers applied to the WebSocket upgrade request (for example a
+    /// reverse-proxy `Authorization: Basic …`). Empty for direct gateway connections.
+    private let additionalHeaders: [String: String]
     private let session: WebSocketSessioning
     private var backoffMs: Double = 500
     private var shouldReconnect = true
@@ -283,6 +314,7 @@ public actor GatewayChannelActor {
         token: String?,
         bootstrapToken: String? = nil,
         password: String? = nil,
+        additionalHeaders: [String: String] = [:],
         session: WebSocketSessionBox? = nil,
         pushHandler: (@Sendable (GatewayPush) async -> Void)? = nil,
         connectOptions: GatewayConnectOptions? = nil,
@@ -292,6 +324,7 @@ public actor GatewayChannelActor {
         self.token = token
         self.bootstrapToken = bootstrapToken
         self.password = password
+        self.additionalHeaders = additionalHeaders
         self.session = session?.session ?? URLSession(configuration: .default)
         self.pushHandler = pushHandler
         self.connectOptions = connectOptions
@@ -378,7 +411,7 @@ public actor GatewayChannelActor {
         defer { self.isConnecting = false }
 
         self.task?.cancel(with: .goingAway, reason: nil)
-        self.task = self.session.makeWebSocketTask(url: self.url)
+        self.task = self.session.makeWebSocketTask(url: self.url, headers: self.additionalHeaders)
         self.task?.resume()
         do {
             try await AsyncTimeout.withTimeout(

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
@@ -52,6 +52,7 @@ public actor GatewayNodeSession {
     private var activeToken: String?
     private var activeBootstrapToken: String?
     private var activePassword: String?
+    private var activeAdditionalHeaders: [String: String] = [:]
     private var activeConnectOptionsKey: String?
     private var activeSessionIdentity: ObjectIdentifier?
     private var connectOptions: GatewayConnectOptions?
@@ -191,6 +192,7 @@ public actor GatewayNodeSession {
         token: String?,
         bootstrapToken: String?,
         password: String?,
+        additionalHeaders: [String: String] = [:],
         connectOptions: GatewayConnectOptions,
         sessionBox: WebSocketSessionBox?,
         onConnected: @escaping @Sendable () async -> Void,
@@ -203,6 +205,7 @@ public actor GatewayNodeSession {
             self.activeToken != token ||
             self.activeBootstrapToken != bootstrapToken ||
             self.activePassword != password ||
+            self.activeAdditionalHeaders != additionalHeaders ||
             self.activeConnectOptionsKey != nextOptionsKey ||
             self.activeSessionIdentity != nextSessionIdentity ||
             self.channel == nil
@@ -222,6 +225,7 @@ public actor GatewayNodeSession {
                 token: token,
                 bootstrapToken: bootstrapToken,
                 password: password,
+                additionalHeaders: additionalHeaders,
                 session: sessionBox,
                 pushHandler: { [weak self] push in
                     await self?.handlePush(push)
@@ -235,6 +239,7 @@ public actor GatewayNodeSession {
             self.activeToken = token
             self.activeBootstrapToken = bootstrapToken
             self.activePassword = password
+            self.activeAdditionalHeaders = additionalHeaders
             self.activeConnectOptionsKey = nextOptionsKey
             self.activeSessionIdentity = nextSessionIdentity
         }

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayProxyAuth.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayProxyAuth.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// Helpers for traversing an identity-aware reverse proxy that fronts the gateway.
+///
+/// A gateway is commonly published behind a proxy (Caddy, nginx, …) that enforces
+/// HTTP Basic auth at the edge. The gateway's own auth (device token / shared token /
+/// password) travels inside the `connect` protocol message, so a proxy `Authorization`
+/// header never collides with it. These headers are applied to the WebSocket upgrade
+/// request via `WebSocketSessioning.makeWebSocketTask(url:headers:)`.
+public enum GatewayProxyAuth {
+    /// HTTP header name carrying the reverse-proxy credentials.
+    public static let authorizationHeader = "Authorization"
+
+    /// Returns `["Authorization": "Basic …"]` for the supplied credentials, or an empty
+    /// dictionary when no username is configured. An empty password is allowed
+    /// (RFC 7617 permits `user:` with an empty secret).
+    public static func basicAuthHeaders(username: String?, password: String?) -> [String: String] {
+        let user = (username ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !user.isEmpty else { return [:] }
+        let secret = password ?? ""
+        let encoded = Data("\(user):\(secret)".utf8).base64EncodedString()
+        return [self.authorizationHeader: "Basic \(encoded)"]
+    }
+}

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayTLSPinning.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayTLSPinning.swift
@@ -206,7 +206,19 @@ GatewayTLSFailureProviding, GatewayDeviceTokenRetryTrustProviding, @unchecked Se
     }
 
     public func makeWebSocketTask(url: URL) -> WebSocketTaskBox {
-        let task = self.session.webSocketTask(with: url)
+        Self.boxed(self.session.webSocketTask(with: url))
+    }
+
+    public func makeWebSocketTask(url: URL, headers: [String: String]) -> WebSocketTaskBox {
+        guard !headers.isEmpty else { return self.makeWebSocketTask(url: url) }
+        var request = URLRequest(url: url)
+        for (field, value) in headers {
+            request.setValue(value, forHTTPHeaderField: field)
+        }
+        return Self.boxed(self.session.webSocketTask(with: request))
+    }
+
+    private static func boxed(_ task: URLSessionWebSocketTask) -> WebSocketTaskBox {
         task.maximumMessageSize = 16 * 1024 * 1024
         return WebSocketTaskBox(task: task)
     }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayReverseProxyAuthTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayReverseProxyAuthTests.swift
@@ -1,0 +1,118 @@
+import Foundation
+import Testing
+@testable import OpenClawKit
+
+private final class NonRespondingWebSocketTask: WebSocketTasking, @unchecked Sendable {
+    var state: URLSessionTask.State { .running }
+    func resume() {}
+    func cancel(with closeCode: URLSessionWebSocketTask.CloseCode, reason: Data?) {
+        _ = (closeCode, reason)
+    }
+
+    func send(_ message: URLSessionWebSocketTask.Message) async throws {
+        _ = message
+    }
+
+    func sendPing(pongReceiveHandler: @escaping @Sendable (Error?) -> Void) {
+        pongReceiveHandler(nil)
+    }
+
+    func receive() async throws -> URLSessionWebSocketTask.Message {
+        // Fail the handshake fast; the upgrade task has already been created by then.
+        throw URLError(.badServerResponse)
+    }
+
+    func receive(
+        completionHandler: @escaping @Sendable (Result<URLSessionWebSocketTask.Message, Error>) -> Void)
+    {
+        completionHandler(.failure(URLError(.badServerResponse)))
+    }
+}
+
+private final class HeaderCapturingSession: WebSocketSessioning, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _capturedHeaders: [String: String] = [:]
+    private var _headerVariantCalls = 0
+
+    var capturedHeaders: [String: String] {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        return self._capturedHeaders
+    }
+
+    var headerVariantCalls: Int {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        return self._headerVariantCalls
+    }
+
+    func makeWebSocketTask(url _: URL) -> WebSocketTaskBox {
+        WebSocketTaskBox(task: NonRespondingWebSocketTask())
+    }
+
+    func makeWebSocketTask(url _: URL, headers: [String: String]) -> WebSocketTaskBox {
+        self.lock.lock()
+        self._capturedHeaders = headers
+        self._headerVariantCalls += 1
+        self.lock.unlock()
+        return WebSocketTaskBox(task: NonRespondingWebSocketTask())
+    }
+}
+
+@Suite(.serialized)
+struct GatewayReverseProxyAuthTests {
+    @Test
+    func `basic auth headers encode credentials`() {
+        let headers = GatewayProxyAuth.basicAuthHeaders(username: "admin", password: "s3cr3t")
+        let expected = "Basic " + Data("admin:s3cr3t".utf8).base64EncodedString()
+        #expect(headers["Authorization"] == expected)
+    }
+
+    @Test
+    func `basic auth headers allow an empty password`() {
+        let headers = GatewayProxyAuth.basicAuthHeaders(username: "admin", password: "")
+        let expected = "Basic " + Data("admin:".utf8).base64EncodedString()
+        #expect(headers["Authorization"] == expected)
+    }
+
+    @Test
+    func `basic auth headers are empty without a username`() {
+        #expect(GatewayProxyAuth.basicAuthHeaders(username: nil, password: "x").isEmpty)
+        #expect(GatewayProxyAuth.basicAuthHeaders(username: "   ", password: "x").isEmpty)
+    }
+
+    @Test
+    func `channel forwards proxy authorization on the upgrade request`() async throws {
+        let session = HeaderCapturingSession()
+        let url = try #require(URL(string: "wss://gateway.example.test/openclaw"))
+        let channel = GatewayChannelActor(
+            url: url,
+            token: nil,
+            additionalHeaders: GatewayProxyAuth.basicAuthHeaders(username: "admin", password: "s3cr3t"),
+            session: WebSocketSessionBox(session: session))
+
+        // The fake task never completes the handshake; we only require the upgrade
+        // task to be created, which happens synchronously before the handshake.
+        _ = try? await channel.connect()
+        await channel.shutdown()
+
+        let expected = "Basic " + Data("admin:s3cr3t".utf8).base64EncodedString()
+        #expect(session.headerVariantCalls >= 1)
+        #expect(session.capturedHeaders["Authorization"] == expected)
+    }
+
+    @Test
+    func `channel without proxy auth sends no authorization header`() async throws {
+        let session = HeaderCapturingSession()
+        let url = try #require(URL(string: "wss://gateway.example.test/openclaw"))
+        let channel = GatewayChannelActor(
+            url: url,
+            token: nil,
+            session: WebSocketSessionBox(session: session))
+
+        _ = try? await channel.connect()
+        await channel.shutdown()
+
+        #expect(session.capturedHeaders["Authorization"] == nil)
+    }
+}


### PR DESCRIPTION
Closes #98708

## What Problem This Solves

Resolves a problem where the iOS/macOS apps cannot connect to a gateway that is
published behind an identity-aware reverse proxy enforcing HTTP Basic auth (e.g.
Caddy or nginx). The node and operator sessions open a WebSocket to the gateway, but
the upgrade request carried no HTTP headers, so the proxy rejected it with
`401 Unauthorized` before the gateway was ever reached. There was no field in the
manual-gateway setup (or in `GatewayConnectConfig`) to supply reverse-proxy
credentials.

This affects the "Manual Host" connection flow in Settings when the gateway is not
reachable directly (loopback/LAN/tailnet) but only through an authenticating proxy.

## Why This Change Was Made

Adds an optional set of extra HTTP headers to the shared gateway WebSocket channel,
plus an iOS UI to enter reverse-proxy Basic credentials. Gateway auth
(device/shared token or password) travels inside the `connect` protocol message, so a
proxy `Authorization: Basic` header on the upgrade request never collides with it.
Direct connections are unchanged: headers default to empty and the existing
URL-only task path is preserved.

Key points:
- `WebSocketSessioning` gains `makeWebSocketTask(url:headers:)` with a default that
  falls back to the URL-only task, so existing conformers (incl. test doubles) are
  untouched. `URLSession` and `GatewayTLSPinningSession` honor the headers via a
  `URLRequest`.
- `GatewayChannelActor` / `GatewayNodeSession.connect` thread `additionalHeaders`;
  changing them triggers a reconnect.
- iOS stores optional proxy username/password in the Keychain (per instance, like the
  existing gateway token/password) and preserves them across every config rebuild
  (token refresh, TLS-fingerprint refresh, bootstrap-token clear).

Non-goal: no macOS UI in this PR (the shared core already benefits macOS; a settings
surface can follow).

## User Impact

Users can connect the app to a gateway behind a Basic-auth reverse proxy by entering
a **Proxy Username / Proxy Password** in Settings → gateway advanced. Users who
connect directly (loopback/LAN/tailnet/SSH) see no change.

## Evidence

Validated on macOS CI (Xcode 26.5, Swift 6.3):

**1. `OpenClawKit` builds and the new unit tests pass**
([run](https://github.com/nayrosk/openclaw/actions/runs/28526906992)):

```
Build complete! (81.03s)
✔ Test "basic auth headers encode credentials" passed
✔ Test "basic auth headers allow an empty password" passed
✔ Test "basic auth headers are empty without a username" passed
✔ Test "channel forwards proxy authorization on the upgrade request" passed
✔ Test "channel without proxy auth sends no authorization header" passed
✔ Test run with 5 tests in 1 suite passed
```

The 5 cases (`GatewayReverseProxyAuthTests`) cover: the Basic header encodes as
`Basic base64(user:pass)` (empty password allowed, empty when no username); the
channel forwards the `Authorization` header on the upgrade task; and no header is sent
when no proxy auth is configured.

**2. The full iOS app compiles** (`pnpm ios:build`, xcodegen + xcodebuild for the iOS
simulator) ([run](https://github.com/nayrosk/openclaw/actions/runs/28527335077)):

```
xcodebuild -project OpenClaw.xcodeproj -scheme OpenClaw \
  -destination "generic/platform=iOS Simulator" -configuration Debug build
** BUILD SUCCEEDED **
```

**3. End-to-end path** against a real Caddy `basic_auth` + private-CA TLS front (the
motivating deployment): TLS handshake succeeds, an unauthenticated request returns
`401 WWW-Authenticate: Basic`, and the gateway accepts the WebSocket upgrade at the
root path (`101 Switching Protocols`).

Every construction/rebuild site of `GatewayConnectConfig` and both
`GatewayNodeSession.connect` call sites keep the header threaded; the new protocol
requirement is source-compatible via a default, so existing conformers are unchanged.
