### PR TITLE
fix(minimax-vlm): bound VLM API response reads

### DIFF
--- a/src/agents/minimax-vlm.normalizes-api-key.test.ts
+++ b/src/agents/minimax-vlm.normalizes-api-key.test.ts
@@ -1,4 +1,6 @@
-// Covers MiniMax VLM auth/header normalization and provider-specific routing.
+// Covers MiniMax VLM auth/header normalization, provider-specific routing,
+// and bounded JSON response enforcement including oversized-response rejection.
+import * as http from "node:http";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { withFetchPreconnect } from "../test-utils/fetch-mock.js";
@@ -204,6 +206,78 @@ describe("minimaxUnderstandImage apiKey normalization", () => {
 
     expect(timeoutSpy).toHaveBeenCalledOnce();
     expect(timeoutSpy).toHaveBeenCalledWith(MAX_TIMER_TIMEOUT_MS);
+  });
+
+  it("rejects oversized VLM response bodies, preserves Trace-Id, and cancels the stream", async () => {
+    let canceled = false;
+    const ONE_MIB = 1024 * 1024;
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (let i = 0; i < 18; i++) controller.enqueue(new Uint8Array(ONE_MIB));
+        controller.close();
+      },
+      cancel() {
+        canceled = true;
+      },
+    });
+    const fetchSpy = vi.fn(
+      async () =>
+        new Response(body, {
+          status: 200,
+          headers: { "Content-Type": "application/json", "Trace-Id": "trace-abc" },
+        }),
+    );
+    global.fetch = withFetchPreconnect(fetchSpy);
+
+    await expect(
+      minimaxUnderstandImage({
+        apiKey: "minimax-test-key",
+        prompt: "hi",
+        imageDataUrl: "data:image/png;base64,AAAA",
+        apiHost: "https://api.minimax.io",
+      }),
+    ).rejects.toThrow("MiniMax VLM: JSON response exceeds 16777216 bytes. Trace-Id: trace-abc");
+
+    expect(canceled).toBe(true);
+  });
+
+  it("rejects oversized VLM responses from a real HTTP server (behavior proof)", async () => {
+    let socketDestroyed = false;
+    const server = http.createServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      const chunk = Buffer.alloc(1024 * 1024, 0x41);
+      const writeMore = () => {
+        if (socketDestroyed) return;
+        for (let i = 0; i < 4 && !socketDestroyed; i++) {
+          if (!res.write(chunk)) {
+            res.once("drain", writeMore);
+            return;
+          }
+        }
+        if (!socketDestroyed) setImmediate(writeMore);
+      };
+      writeMore();
+    });
+    server.on("connection", (s) => {
+      s.on("close", () => {
+        socketDestroyed = true;
+      });
+    });
+    await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+    const port = (server.address() as { port: number }).port;
+
+    try {
+      await expect(
+        minimaxUnderstandImage({
+          apiKey: "test-key",
+          prompt: "hi",
+          imageDataUrl: "data:image/png;base64,AAAA",
+          apiHost: `http://127.0.0.1:${port}`,
+        }),
+      ).rejects.toThrow("MiniMax VLM: JSON response exceeds");
+    } finally {
+      await new Promise<void>((r) => server.close(() => r()));
+    }
   });
 
   it("bounds large provider error response bodies", async () => {

--- a/src/agents/minimax-vlm.ts
+++ b/src/agents/minimax-vlm.ts
@@ -6,6 +6,7 @@ import { ensureGlobalUndiciEnvProxyDispatcher } from "../infra/net/undici-global
 import { resolvePositiveTimerTimeoutMs } from "../shared/number-coercion.js";
 import { isRecord } from "../utils.js";
 import { normalizeSecretInput } from "../utils/normalize-secret-input.js";
+import { readProviderJsonResponse } from "./provider-http-errors.js";
 
 type MinimaxBaseResp = {
   status_code?: number;
@@ -142,7 +143,14 @@ export async function minimaxUnderstandImage(params: {
     );
   }
 
-  const json = (await res.json().catch(() => null)) as unknown;
+  let json: Record<string, unknown>;
+  try {
+    json = await readProviderJsonResponse<Record<string, unknown>>(res, "MiniMax VLM");
+  } catch (err) {
+    const trace = traceId ? ` Trace-Id: ${traceId}` : "";
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`${msg}${trace ? `.${trace}` : ""}`, { cause: err });
+  }
   if (!isRecord(json)) {
     const trace = traceId ? ` Trace-Id: ${traceId}` : "";
     throw new Error(`MiniMax VLM response was not JSON.${trace}`);


### PR DESCRIPTION
## What Problem This Solves

`minimaxUnderstandImage` calls `await res.json()` on the MiniMax VLM API response without a read limit. An oversized response could buffer arbitrarily large payloads before parsing, risking OOM.

## Why This Change Was Made

All provider response reads should use `readProviderJsonResponse` (16 MiB cap). Trace-Id diagnostics are preserved through the error chain.

## User Impact

MiniMax VLM image understanding is now protected against oversized JSON responses. Normal responses work identically. Oversized responses fail with a clear error including the Trace-Id.

## Evidence

### Real HTTP server loopback proof (committed test)

The test creates a real `http.createServer` that writes an oversized JSON stream. The bounded reader cancels the socket mid-flight — proves the 16 MiB cap is enforced against a real TCP connection, not just a mock:

```ts
it("rejects oversized VLM responses from a real HTTP server (behavior proof)", async () => {
  let socketDestroyed = false;
  const server = http.createServer((_req, res) => {
    res.writeHead(200, { "Content-Type": "application/json" });
    const chunk = Buffer.alloc(1024 * 1024, 0x41);
    const writeMore = () => {
      if (socketDestroyed) return;
      for (let i = 0; i < 4 && !socketDestroyed; i++) {
        if (!res.write(chunk)) { res.once("drain", writeMore); return; }
      }
      if (!socketDestroyed) setImmediate(writeMore);
    };
    writeMore();
  });
  server.on("connection", (s) => { s.on("close", () => { socketDestroyed = true; }); });
  await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
  const port = (server.address() as { port: number }).port;

  try {
    await expect(
      minimaxUnderstandImage({
        apiKey: "test-key", prompt: "hi",
        imageDataUrl: "data:image/png;base64,AAAA",
        apiHost: `http://127.0.0.1:${port}`,
      }),
    ).rejects.toThrow("MiniMax VLM: JSON response exceeds");
  } finally {
    await new Promise<void>((r) => server.close(() => r()));
  }
});
```

### ReadableStream cancellation proof (committed test)

```ts
it("rejects oversized VLM response bodies, preserves Trace-Id, and cancels the stream", async () => {
  let canceled = false;
  const ONE_MIB = 1024 * 1024;
  const body = new ReadableStream<Uint8Array>({
    start(controller) {
      for (let i = 0; i < 18; i++) controller.enqueue(new Uint8Array(ONE_MIB));
      controller.close();
    },
    cancel() { canceled = true; },
  });
  // ...
  await expect(
    minimaxUnderstandImage({ apiKey: "minimax-test-key", prompt: "hi", ... }),
  ).rejects.toThrow("MiniMax VLM: JSON response exceeds 16777216 bytes. Trace-Id: trace-abc");
  expect(canceled).toBe(true);
});
```

### Local test run — 14/14 passed

```
pnpm test src/agents/minimax-vlm.normalizes-api-key.test.ts

 ✓ minimaxUnderstandImage apiKey normalization > strips embedded CR/LF before sending Authorization header 236ms
 ✓ minimaxUnderstandImage apiKey normalization > drops non-Latin1 characters from apiKey 3ms
 ✓ minimaxUnderstandImage apiKey normalization > keeps trusted MINIMAX_API_HOST env fallback for VLM routing 4ms
 ✓ minimaxUnderstandImage apiKey normalization > routes minimax-cn to the CN VLM host by default 3ms
 ✓ minimaxUnderstandImage apiKey normalization > routes minimax-portal-cn to the CN VLM host by default 2ms
 ✓ minimaxUnderstandImage apiKey normalization > keeps minimax-cn on the CN VLM host when the configured host is malformed 3ms
 ✓ minimaxUnderstandImage apiKey normalization > keeps minimax-portal-cn on the CN VLM host when the configured host is malformed 2ms
 ✓ minimaxUnderstandImage apiKey normalization > uses the caller-provided request timeout 5ms
 ✓ minimaxUnderstandImage apiKey normalization > uses the default request timeout for non-positive caller timeouts 3ms
 ✓ minimaxUnderstandImage apiKey normalization > clamps oversized caller request timeouts before creating the abort signal 3ms
 ✓ minimaxUnderstandImage apiKey normalization > rejects oversized VLM response bodies, preserves Trace-Id, and cancels the stream 60ms
 ✓ minimaxUnderstandImage apiKey normalization > rejects oversized VLM responses from a real HTTP server (behavior proof) 210ms
 ✓ minimaxUnderstandImage apiKey normalization > bounds large provider error response bodies 9ms
 ✓ isMinimaxVlmModel > only matches the canonical MiniMax VLM model id 1ms

 Test Files  1 passed (1)
      Tests  14 passed (14)
```

### What changed

- `minimax-vlm.ts`: replaced `res.json()` with `readProviderJsonResponse` (16 MiB cap), preserves Trace-Id in error messages
- `minimax-vlm.normalizes-api-key.test.ts`: added real HTTP server loopback proof + ReadableStream cancellation proof

## Risk

Low. 16 MiB cap is generous for MiniMax VLM API responses. Same `readProviderJsonResponse` helper used across all provider JSON reads.