### PR TITLE
fix(discord): bound gateway metadata response body reads to prevent OOM

### DIFF
--- a/extensions/discord/src/monitor/gateway-metadata.test.ts
+++ b/extensions/discord/src/monitor/gateway-metadata.test.ts
@@ -6,10 +6,17 @@ import {
   fetchDiscordGatewayMetadataGuarded,
   resolveDiscordGatewayInfoTimeoutMs,
   resolveGatewayInfoWithFallback,
-  testExports,
 } from "./gateway-metadata.js";
 
 const DISCORD_GATEWAY_METADATA_MAX_BYTES = 4 * 1024 * 1024;
+
+const { mockFetchWithSsrFGuard } = vi.hoisted(() => ({
+  mockFetchWithSsrFGuard: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
+  fetchWithSsrFGuard: mockFetchWithSsrFGuard,
+}));
 
 async function listenLoopbackServer(server: Server): Promise<number> {
   return await new Promise((resolve, reject) => {
@@ -29,6 +36,13 @@ async function listenLoopbackServer(server: Server): Promise<number> {
 async function closeServer(server: Server): Promise<void> {
   await new Promise<void>((resolve) => {
     server.close(() => resolve());
+  });
+}
+
+function stubGuardedFetch(response: Response): void {
+  mockFetchWithSsrFGuard.mockResolvedValue({
+    response,
+    release: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
   });
 }
 
@@ -80,9 +94,10 @@ describe("Discord gateway metadata", () => {
   });
 });
 
-describe("materializeGuardedResponse bounded reads", () => {
+describe("fetchDiscordGatewayMetadataGuarded bounded reads", () => {
   beforeEach(() => {
     vi.useRealTimers();
+    mockFetchWithSsrFGuard.mockReset();
   });
 
   afterEach(() => {
@@ -111,7 +126,11 @@ describe("materializeGuardedResponse bounded reads", () => {
 
     try {
       const rawResponse = await fetch(`http://127.0.0.1:${port}`);
-      const response = await testExports.materializeGuardedResponse(rawResponse);
+      stubGuardedFetch(rawResponse);
+
+      const response = await fetchDiscordGatewayMetadataGuarded(
+        "https://discord.com/api/v10/gateway/bot",
+      );
       const text = await response.text();
       expect(JSON.parse(text)).toEqual(JSON.parse(payload));
       console.log(
@@ -150,10 +169,11 @@ describe("materializeGuardedResponse bounded reads", () => {
 
     try {
       const rawResponse = await fetch(`http://127.0.0.1:${port}`);
+      stubGuardedFetch(rawResponse);
 
       let error: unknown;
       try {
-        await testExports.materializeGuardedResponse(rawResponse);
+        await fetchDiscordGatewayMetadataGuarded("https://discord.com/api/v10/gateway/bot");
       } catch (err) {
         error = err;
       }

--- a/extensions/discord/src/monitor/gateway-metadata.test.ts
+++ b/extensions/discord/src/monitor/gateway-metadata.test.ts
@@ -1,10 +1,36 @@
 // Discord tests cover gateway metadata plugin behavior.
-import { describe, expect, it, vi } from "vitest";
+import { createServer, type Server } from "node:http";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   fetchDiscordGatewayInfo,
+  fetchDiscordGatewayMetadataGuarded,
   resolveDiscordGatewayInfoTimeoutMs,
   resolveGatewayInfoWithFallback,
+  testExports,
 } from "./gateway-metadata.js";
+
+const DISCORD_GATEWAY_METADATA_MAX_BYTES = 4 * 1024 * 1024;
+
+async function listenLoopbackServer(server: Server): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("expected loopback TCP address"));
+        return;
+      }
+      resolve(address.port);
+    });
+  });
+}
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve) => {
+    server.close(() => resolve());
+  });
+}
 
 describe("Discord gateway metadata", () => {
   it("resolves gateway info timeouts from strict integer config and env values", () => {
@@ -51,5 +77,95 @@ describe("Discord gateway metadata", () => {
     expect(logs).toBe(
       "discord: gateway metadata lookup failed transiently; using default gateway url (Failed to get gateway information from Discord: fetch failed | Discord API /gateway/bot failed (429): Error 1015 rate limited)",
     );
+  });
+});
+
+describe("materializeGuardedResponse bounded reads", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("returns under-cap response body from a real loopback HTTP server", async () => {
+    const payload = JSON.stringify({
+      url: "wss://gateway.discord.gg/",
+      shards: 1,
+      session_start_limit: {
+        total: 1000,
+        remaining: 999,
+        reset_after: 3600000,
+        max_concurrency: 1,
+      },
+    });
+
+    const server = createServer((req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.write(payload.slice(0, 32));
+      res.end(payload.slice(32));
+    });
+    const port = await listenLoopbackServer(server);
+
+    try {
+      const rawResponse = await fetch(`http://127.0.0.1:${port}`);
+      const response = await testExports.materializeGuardedResponse(rawResponse);
+      const text = await response.text();
+      expect(JSON.parse(text)).toEqual(JSON.parse(payload));
+      console.log(
+        `[discord gateway metadata loopback proof] normal path: returned valid gateway metadata`,
+      );
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it("rejects oversized response body from a real loopback HTTP server", async () => {
+    const oversizedPayloadBytes = DISCORD_GATEWAY_METADATA_MAX_BYTES + 256 * 1024;
+    let streamedBytes = 0;
+
+    const server = createServer((req, res) => {
+      const chunk = Buffer.alloc(64 * 1024, 0x78);
+      res.writeHead(200, { "content-type": "application/json" });
+
+      const writeMore = () => {
+        while (streamedBytes < oversizedPayloadBytes) {
+          if (res.destroyed) {
+            return;
+          }
+          streamedBytes += chunk.byteLength;
+          if (!res.write(chunk)) {
+            res.once("drain", writeMore);
+            return;
+          }
+        }
+        res.end();
+      };
+
+      writeMore();
+    });
+    const port = await listenLoopbackServer(server);
+
+    try {
+      const rawResponse = await fetch(`http://127.0.0.1:${port}`);
+
+      let error: unknown;
+      try {
+        await testExports.materializeGuardedResponse(rawResponse);
+      } catch (err) {
+        error = err;
+      }
+
+      expect(error).toBeInstanceOf(Error);
+      expect(String(error)).toContain("Discord gateway metadata response body too large");
+      expect(String(error)).toContain(`limit: ${DISCORD_GATEWAY_METADATA_MAX_BYTES} bytes`);
+      console.log(
+        `[discord gateway metadata loopback proof] oversized path: cap=${DISCORD_GATEWAY_METADATA_MAX_BYTES} streamed>=${streamedBytes} rejected=${String(error)}`,
+      );
+    } finally {
+      await closeServer(server);
+    }
   });
 });

--- a/extensions/discord/src/monitor/gateway-metadata.test.ts
+++ b/extensions/discord/src/monitor/gateway-metadata.test.ts
@@ -1,6 +1,6 @@
 // Discord tests cover gateway metadata plugin behavior.
 import { createServer, type Server } from "node:http";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   fetchDiscordGatewayInfo,
   fetchDiscordGatewayMetadataGuarded,
@@ -39,11 +39,13 @@ async function closeServer(server: Server): Promise<void> {
   });
 }
 
-function stubGuardedFetch(response: Response): void {
+function stubGuardedFetch(response: Response) {
+  const release = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
   mockFetchWithSsrFGuard.mockResolvedValue({
     response,
-    release: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    release,
   });
+  return release;
 }
 
 describe("Discord gateway metadata", () => {
@@ -100,12 +102,7 @@ describe("fetchDiscordGatewayMetadataGuarded bounded reads", () => {
     mockFetchWithSsrFGuard.mockReset();
   });
 
-  afterEach(() => {
-    vi.restoreAllMocks();
-    vi.unstubAllGlobals();
-  });
-
-  it("returns under-cap response body from a real loopback HTTP server", async () => {
+  it("returns under-cap response bodies and releases the guarded fetch", async () => {
     const payload = JSON.stringify({
       url: "wss://gateway.discord.gg/",
       shards: 1,
@@ -117,35 +114,23 @@ describe("fetchDiscordGatewayMetadataGuarded bounded reads", () => {
       },
     });
 
-    const server = createServer((req, res) => {
-      res.writeHead(200, { "content-type": "application/json" });
-      res.write(payload.slice(0, 32));
-      res.end(payload.slice(32));
-    });
-    const port = await listenLoopbackServer(server);
+    const release = stubGuardedFetch(
+      new Response(payload, { headers: { "content-type": "application/json" } }),
+    );
 
-    try {
-      const rawResponse = await fetch(`http://127.0.0.1:${port}`);
-      stubGuardedFetch(rawResponse);
+    const response = await fetchDiscordGatewayMetadataGuarded(
+      "https://discord.com/api/v10/gateway/bot",
+    );
 
-      const response = await fetchDiscordGatewayMetadataGuarded(
-        "https://discord.com/api/v10/gateway/bot",
-      );
-      const text = await response.text();
-      expect(JSON.parse(text)).toEqual(JSON.parse(payload));
-      console.log(
-        `[discord gateway metadata loopback proof] normal path: returned valid gateway metadata`,
-      );
-    } finally {
-      await closeServer(server);
-    }
+    await expect(response.json()).resolves.toEqual(JSON.parse(payload));
+    expect(release).toHaveBeenCalledOnce();
   });
 
   it("rejects oversized response body from a real loopback HTTP server", async () => {
     const oversizedPayloadBytes = DISCORD_GATEWAY_METADATA_MAX_BYTES + 256 * 1024;
     let streamedBytes = 0;
 
-    const server = createServer((req, res) => {
+    const server = createServer((_request, res) => {
       const chunk = Buffer.alloc(64 * 1024, 0x78);
       res.writeHead(200, { "content-type": "application/json" });
 
@@ -169,21 +154,16 @@ describe("fetchDiscordGatewayMetadataGuarded bounded reads", () => {
 
     try {
       const rawResponse = await fetch(`http://127.0.0.1:${port}`);
-      stubGuardedFetch(rawResponse);
+      const release = stubGuardedFetch(rawResponse);
 
-      let error: unknown;
-      try {
-        await fetchDiscordGatewayMetadataGuarded("https://discord.com/api/v10/gateway/bot");
-      } catch (err) {
-        error = err;
-      }
-
-      expect(error).toBeInstanceOf(Error);
-      expect(String(error)).toContain("Discord gateway metadata response body too large");
-      expect(String(error)).toContain(`limit: ${DISCORD_GATEWAY_METADATA_MAX_BYTES} bytes`);
-      console.log(
-        `[discord gateway metadata loopback proof] oversized path: cap=${DISCORD_GATEWAY_METADATA_MAX_BYTES} streamed>=${streamedBytes} rejected=${String(error)}`,
+      await expect(
+        fetchDiscordGatewayMetadataGuarded("https://discord.com/api/v10/gateway/bot"),
+      ).rejects.toThrow(
+        new RegExp(
+          `Discord gateway metadata response body too large: \\d+ bytes \\(limit: ${DISCORD_GATEWAY_METADATA_MAX_BYTES} bytes\\)`,
+        ),
       );
+      expect(release).toHaveBeenCalledOnce();
     } finally {
       await closeServer(server);
     }

--- a/extensions/discord/src/monitor/gateway-metadata.ts
+++ b/extensions/discord/src/monitor/gateway-metadata.ts
@@ -59,12 +59,14 @@ function resolveFetchInputUrl(input: RequestInfo | URL): string {
 }
 
 async function materializeGuardedResponse(response: Response): Promise<Response> {
-  const body = await readResponseWithLimit(response, DISCORD_GATEWAY_METADATA_MAX_BYTES, {
-    onOverflow: ({ size, maxBytes }) =>
-      new Error(
-        `Discord gateway metadata response body too large: ${size} bytes (limit: ${maxBytes} bytes)`,
-      ),
-  });
+  const body = new Uint8Array(
+    await readResponseWithLimit(response, DISCORD_GATEWAY_METADATA_MAX_BYTES, {
+      onOverflow: ({ size, maxBytes }) =>
+        new Error(
+          `Discord gateway metadata response body too large: ${size} bytes (limit: ${maxBytes} bytes)`,
+        ),
+    }),
+  );
   return new Response(body, {
     status: response.status,
     statusText: response.statusText,
@@ -276,10 +278,6 @@ export function resolveGatewayInfoWithFallback(params: { runtime?: RuntimeEnv; e
     usedFallback: true,
   };
 }
-
-export const testExports = {
-  materializeGuardedResponse,
-};
 
 export async function fetchDiscordGatewayMetadataGuarded(
   input: string,

--- a/extensions/discord/src/monitor/gateway-metadata.ts
+++ b/extensions/discord/src/monitor/gateway-metadata.ts
@@ -3,6 +3,7 @@ import type { APIGatewayBotInfo } from "discord-api-types/v10";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
 import { captureHttpExchange } from "openclaw/plugin-sdk/proxy-capture";
+import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { Type } from "typebox";
@@ -16,6 +17,7 @@ const DEFAULT_DISCORD_GATEWAY_URL = "wss://gateway.discord.gg/";
 const DEFAULT_DISCORD_GATEWAY_INFO_TIMEOUT_MS = 30_000;
 const MAX_DISCORD_GATEWAY_INFO_TIMEOUT_MS = 120_000;
 const DISCORD_GATEWAY_INFO_TIMEOUT_ENV = "OPENCLAW_DISCORD_GATEWAY_INFO_TIMEOUT_MS";
+const DISCORD_GATEWAY_METADATA_MAX_BYTES = 4 * 1024 * 1024;
 const DISCORD_GATEWAY_METADATA_FALLBACK_LOG_INTERVAL_MS = 60_000;
 
 type DiscordGatewayMetadataResponse = Pick<Response, "ok" | "status" | "text">;
@@ -57,7 +59,12 @@ function resolveFetchInputUrl(input: RequestInfo | URL): string {
 }
 
 async function materializeGuardedResponse(response: Response): Promise<Response> {
-  const body = await response.arrayBuffer();
+  const body = await readResponseWithLimit(response, DISCORD_GATEWAY_METADATA_MAX_BYTES, {
+    onOverflow: ({ size, maxBytes }) =>
+      new Error(
+        `Discord gateway metadata response body too large: ${size} bytes (limit: ${maxBytes} bytes)`,
+      ),
+  });
   return new Response(body, {
     status: response.status,
     statusText: response.statusText,
@@ -269,6 +276,10 @@ export function resolveGatewayInfoWithFallback(params: { runtime?: RuntimeEnv; e
     usedFallback: true,
   };
 }
+
+export const testExports = {
+  materializeGuardedResponse,
+};
 
 export async function fetchDiscordGatewayMetadataGuarded(
   input: string,


### PR DESCRIPTION
## What Problem This Solves

The `materializeGuardedResponse` helper in the Discord gateway metadata path buffered the full upstream HTTP response body via `response.arrayBuffer()` without any size cap. A malicious or malfunctioning Discord `/gateway/bot` endpoint that returns an oversized payload could exhaust gateway memory (OOM). The response body is expected to be a small JSON metadata object (~200 bytes), but no size check was enforced before buffering the entire body into memory.

## Why This Change Was Made

Replace the unbounded `response.arrayBuffer()` with `readResponseWithLimit(4 MiB)`, consistent with `DISCORD_API_RESPONSE_BODY_LIMIT_BYTES` already used in `api.ts` for Discord API response reads. Overflow throws an Error with the byte counts, allowing the caller's existing error-handling path to treat it as a transient gateway metadata failure and fall back to the default gateway URL.

## User Impact

Normal behavior remains unchanged: the gateway metadata response is typically ~200 bytes of JSON and reads as before. Abnormal behavior (oversized response from a compromised or malfunctioning upstream) changes from a potential OOM crash to a bounded error — the gateway falls back to the default `wss://gateway.discord.gg/` URL and logs the oversized-body condition.

## Evidence

### Real behavior proof

- **Behavior addressed**: Unbounded `response.arrayBuffer()` → bounded `readResponseWithLimit(4 MiB)`
- **Real environment tested**: Loopback HTTP server (`node:http.createServer`), Node 22
- **Exact steps**:
  1. Start a loopback HTTP server that streams >4 MiB of response body (64 KB chunks, no Content-Length)
  2. Return the real loopback `Response` from the mocked SSRF guard and call `fetchDiscordGatewayMetadataGuarded()`
  3. Assert the function rejects with the expected overflow error and releases the guarded fetch
  4. Positive control: a small valid JSON response still returns correctly and also releases the guarded fetch
- **Observed result**: `Error: Discord gateway metadata response body too large: 4208568 bytes (limit: 4194304 bytes)`
- **What was not tested**: Live Discord traffic or the real SSRF DNS/pinned-dispatcher path; the test exercises the production materialization and release logic with a controlled guard result

### Validation Evidence

```
pnpm test extensions/discord/src/monitor/gateway-metadata.test.ts
✓ 4 tests passed (oversized loopback + valid control + existing ×2)
```

### Security & Privacy / Compatibility

- No new dependencies or APIs
- Cap value (4 MiB) matches existing `DISCORD_API_RESPONSE_BODY_LIMIT_BYTES` in `api.ts`
- Fail-closed: overflow throws, caller falls back to default gateway URL
- No user data or credentials affected

---

_AI-assisted._
