### PR TITLE
fix(ui): keep landscape composer compact

### DIFF
--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -1540,6 +1540,24 @@
   }
 }
 
+@media (max-width: 932px) and (max-height: 500px) and (orientation: landscape) {
+  .chat-thread {
+    min-height: 40vh;
+  }
+
+  .agent-chat__input {
+    max-height: min(36vh, 164px);
+    overflow-x: hidden;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+  }
+
+  .agent-chat__composer-combobox > textarea {
+    max-height: 56px;
+    overflow-y: auto;
+  }
+}
+
 .chat-queue__item--steered {
   border-color: color-mix(in srgb, var(--accent) 30%, var(--border));
 }

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -1556,6 +1556,15 @@
     max-height: 56px;
     overflow-y: auto;
   }
+
+  .agent-chat__input > .slash-menu {
+    flex: 0 0 auto;
+    position: sticky;
+    top: 0;
+    bottom: auto;
+    max-height: min(28vh, 88px);
+    margin-bottom: 6px;
+  }
 }
 
 .chat-queue__item--steered {

--- a/ui/src/ui/chat/chat-responsive.browser.test.ts
+++ b/ui/src/ui/chat/chat-responsive.browser.test.ts
@@ -622,6 +622,8 @@ describeBrowserLayout("chat responsive browser layout", () => {
           };
           return {
             input: rectFor(".agent-chat__input"),
+            thread: rectFor(".chat-thread"),
+            textarea: rectFor(".agent-chat__composer-combobox > textarea"),
             left: rectFor(".agent-chat__toolbar-left"),
             model: rectFor(".chat-composer-model-control"),
             settings: rectFor(".chat-settings-chip"),
@@ -631,6 +633,8 @@ describeBrowserLayout("chat responsive browser layout", () => {
         });
 
         const input = expectControlRect(controls.input, "composer");
+        const thread = expectControlRect(controls.thread, "chat thread");
+        const textarea = expectControlRect(controls.textarea, "composer textarea");
         const left = expectControlRect(controls.left, "composer left controls");
         const model = expectControlRect(controls.model, "composer model control");
         const settings = expectControlRect(controls.settings, "composer settings control");
@@ -647,6 +651,12 @@ describeBrowserLayout("chat responsive browser layout", () => {
         expect(settings.width).toBeGreaterThanOrEqual(TOUCH_TARGET_MIN_PX);
         expect(settings.height).toBeGreaterThanOrEqual(TOUCH_TARGET_MIN_PX);
         expect(settingsLabel.display).toBe("none");
+
+        if (width > height && height <= 500) {
+          expect(input.height).toBeLessThanOrEqual(height * 0.38);
+          expect(thread.height).toBeGreaterThanOrEqual(height * 0.4);
+          expect(textarea.height).toBeLessThanOrEqual(56);
+        }
       } finally {
         await closeBrowserPage(page);
       }

--- a/ui/src/ui/chat/chat-responsive.browser.test.ts
+++ b/ui/src/ui/chat/chat-responsive.browser.test.ts
@@ -29,6 +29,9 @@ type ControlRect = {
   y: number;
   width: number;
   height: number;
+  clientHeight?: number;
+  scrollHeight?: number;
+  scrollTop?: number;
   text?: string;
   display?: string;
 };
@@ -183,7 +186,14 @@ function chatHeaderControlsHtml(hidden = false) {
   `;
 }
 
-function chatHtml(opts: { sideResult?: boolean; singleAgent?: boolean } = {}) {
+function chatHtml(
+  opts: {
+    composerAttachment?: boolean;
+    sideResult?: boolean;
+    singleAgent?: boolean;
+    slashMenu?: boolean;
+  } = {},
+) {
   return `
     <div class="shell shell--chat" data-chat-responsive-fixture>
       <header class="topbar">
@@ -235,6 +245,43 @@ function chatHtml(opts: { sideResult?: boolean; singleAgent?: boolean } = {}) {
               : ""
           }
           <div class="agent-chat__input">
+            ${
+              opts.slashMenu
+                ? `<div class="slash-menu" role="listbox" aria-label="Command suggestions">
+                    <div class="slash-menu-group">
+                      <div class="slash-menu-group__label">Commands</div>
+                      <div class="slash-menu-item slash-menu-item--active" role="option" aria-selected="true">
+                        <span class="slash-menu-icon">${iconSvg()}</span>
+                        <span class="slash-menu-name">/plan</span>
+                        <span class="slash-menu-desc">Create a plan</span>
+                      </div>
+                      <div class="slash-menu-item" role="option">
+                        <span class="slash-menu-icon">${iconSvg()}</span>
+                        <span class="slash-menu-name">/review</span>
+                        <span class="slash-menu-desc">Review changes</span>
+                      </div>
+                      <div class="slash-menu-item" role="option">
+                        <span class="slash-menu-icon">${iconSvg()}</span>
+                        <span class="slash-menu-name">/fix</span>
+                        <span class="slash-menu-desc">Fix current issue</span>
+                      </div>
+                    </div>
+                  </div>`
+                : ""
+            }
+            ${
+              opts.composerAttachment
+                ? `<div class="chat-attachments-preview">
+                    <div class="chat-attachment-thumb chat-attachment-thumb--file">
+                      <div class="chat-attachment-file">
+                        <span class="chat-attachment-file__icon">${iconSvg()}</span>
+                        <span class="chat-attachment-file__name">landscape-proof-attachment.txt</span>
+                      </div>
+                      <button class="chat-attachment-remove" type="button" aria-label="Remove attachment">&times;</button>
+                    </div>
+                  </div>`
+                : ""
+            }
             <div class="agent-chat__composer-combobox">
               <textarea rows="1">Queued follow-up for the active operator session</textarea>
             </div>
@@ -260,7 +307,12 @@ function chatHtml(opts: { sideResult?: boolean; singleAgent?: boolean } = {}) {
 async function openFixture(
   width: number,
   height: number,
-  opts: { sideResult?: boolean; singleAgent?: boolean } = {},
+  opts: {
+    composerAttachment?: boolean;
+    sideResult?: boolean;
+    singleAgent?: boolean;
+    slashMenu?: boolean;
+  } = {},
 ) {
   const page = await openBrowserPage(width, height);
   try {
@@ -654,7 +706,7 @@ describeBrowserLayout("chat responsive browser layout", () => {
 
         if (width > height && height <= 500) {
           expect(input.height).toBeLessThanOrEqual(height * 0.38);
-          expect(thread.height).toBeGreaterThanOrEqual(height * 0.4);
+          expect(thread.height).toBeGreaterThanOrEqual(height * 0.4 - 1);
           expect(textarea.height).toBeLessThanOrEqual(56);
         }
       } finally {
@@ -662,6 +714,176 @@ describeBrowserLayout("chat responsive browser layout", () => {
       }
     },
   );
+
+  it("keeps short-landscape composer adjunct rows scroll-reachable", async () => {
+    const page = await openFixture(568, 320, { composerAttachment: true });
+    try {
+      await page
+        .locator(".agent-chat__composer-combobox > textarea")
+        .fill(
+          Array.from(
+            { length: 10 },
+            (_value, index) =>
+              `Landscape proof line ${index + 1}: keep transcript visible while this long draft scrolls inside the bounded composer.`,
+          ).join("\n"),
+        );
+
+      const initial = await page.evaluate(() => {
+        const rectFor = (selector: string) => {
+          const node = document.querySelector(selector) as HTMLElement | null;
+          if (!node) {
+            return null;
+          }
+          const rect = node.getBoundingClientRect();
+          return {
+            x: rect.x,
+            y: rect.y,
+            width: rect.width,
+            height: rect.height,
+            clientHeight: node.clientHeight,
+            scrollHeight: node.scrollHeight,
+            scrollTop: node.scrollTop,
+          };
+        };
+        return {
+          input: rectFor(".agent-chat__input"),
+          thread: rectFor(".chat-thread"),
+          textarea: rectFor(".agent-chat__composer-combobox > textarea"),
+        };
+      });
+
+      const input = expectControlRect(initial.input, "composer");
+      const thread = expectControlRect(initial.thread, "chat thread");
+      const textarea = expectControlRect(initial.textarea, "composer textarea");
+      expect(input.height).toBeLessThanOrEqual(320 * 0.38);
+      expect(thread.height).toBeGreaterThanOrEqual(320 * 0.4 - 1);
+      if (
+        input.scrollHeight === undefined ||
+        input.clientHeight === undefined ||
+        textarea.scrollHeight === undefined ||
+        textarea.clientHeight === undefined
+      ) {
+        throw new Error("Expected scroll metrics for short-landscape composer");
+      }
+      expect(input.scrollHeight).toBeGreaterThan(input.clientHeight);
+      expect(textarea.scrollHeight).toBeGreaterThan(textarea.clientHeight);
+
+      const scrolled = await page.evaluate(() => {
+        const composer = document.querySelector(".agent-chat__input") as HTMLElement | null;
+        if (composer) {
+          composer.scrollTop = composer.scrollHeight;
+        }
+        const rectFor = (selector: string) => {
+          const node = document.querySelector(selector) as HTMLElement | null;
+          if (!node) {
+            return null;
+          }
+          const rect = node.getBoundingClientRect();
+          return { x: rect.x, y: rect.y, width: rect.width, height: rect.height };
+        };
+        return {
+          input: rectFor(".agent-chat__input"),
+          left: rectFor(".agent-chat__toolbar-left"),
+          model: rectFor(".chat-composer-model-control"),
+          settings: rectFor(".chat-settings-chip"),
+          send: rectFor(".chat-send-btn"),
+        };
+      });
+
+      const scrolledInput = expectControlRect(scrolled.input, "scrolled composer");
+      for (const [label, control] of [
+        ["composer left controls", scrolled.left],
+        ["composer model control", scrolled.model],
+        ["composer settings control", scrolled.settings],
+        ["composer send control", scrolled.send],
+      ] as const) {
+        const rect = expectControlRect(control, label);
+        expect(rect.y).toBeGreaterThanOrEqual(scrolledInput.y - 1);
+        expect(rect.y + rect.height).toBeLessThanOrEqual(
+          scrolledInput.y + scrolledInput.height + 1,
+        );
+      }
+    } finally {
+      await closeBrowserPage(page);
+    }
+  });
+
+  it("keeps short-landscape slash menu visible inside the bounded composer", async () => {
+    const page = await openFixture(568, 320, {
+      composerAttachment: true,
+      slashMenu: true,
+    });
+    try {
+      await page.locator(".agent-chat__composer-combobox > textarea").fill("/review");
+
+      const initial = await page.evaluate(() => {
+        const rectFor = (selector: string) => {
+          const node = document.querySelector(selector) as HTMLElement | null;
+          if (!node) {
+            return null;
+          }
+          const rect = node.getBoundingClientRect();
+          return {
+            x: rect.x,
+            y: rect.y,
+            width: rect.width,
+            height: rect.height,
+            clientHeight: node.clientHeight,
+            scrollHeight: node.scrollHeight,
+            scrollTop: node.scrollTop,
+          };
+        };
+        return {
+          input: rectFor(".agent-chat__input"),
+          menu: rectFor(".slash-menu"),
+          textarea: rectFor(".agent-chat__composer-combobox > textarea"),
+          toolbar: rectFor(".agent-chat__toolbar"),
+        };
+      });
+
+      const input = expectControlRect(initial.input, "composer");
+      const menu = expectControlRect(initial.menu, "slash menu");
+      const textarea = expectControlRect(initial.textarea, "composer textarea");
+      expect(input.height).toBeLessThanOrEqual(320 * 0.38);
+      if (input.scrollHeight === undefined || input.clientHeight === undefined) {
+        throw new Error("Expected scroll metrics for slash-menu composer");
+      }
+      expect(input.scrollHeight).toBeGreaterThan(input.clientHeight);
+      expect(menu.y).toBeGreaterThanOrEqual(input.y - 1);
+      expect(menu.y + menu.height).toBeLessThanOrEqual(input.y + input.height + 1);
+      expect(menu.height).toBeGreaterThanOrEqual(48);
+      expect(menu.height).toBeLessThanOrEqual(89);
+      expect(textarea.y).toBeGreaterThan(menu.y);
+
+      const scrolled = await page.evaluate(() => {
+        const composer = document.querySelector(".agent-chat__input") as HTMLElement | null;
+        if (composer) {
+          composer.scrollTop = composer.scrollHeight;
+        }
+        const rectFor = (selector: string) => {
+          const node = document.querySelector(selector) as HTMLElement | null;
+          if (!node) {
+            return null;
+          }
+          const rect = node.getBoundingClientRect();
+          return { x: rect.x, y: rect.y, width: rect.width, height: rect.height };
+        };
+        return {
+          input: rectFor(".agent-chat__input"),
+          toolbar: rectFor(".agent-chat__toolbar"),
+        };
+      });
+
+      const scrolledInput = expectControlRect(scrolled.input, "scrolled composer");
+      const toolbar = expectControlRect(scrolled.toolbar, "composer toolbar");
+      expect(toolbar.y).toBeGreaterThanOrEqual(scrolledInput.y - 1);
+      expect(toolbar.y + toolbar.height).toBeLessThanOrEqual(
+        scrolledInput.y + scrolledInput.height + 1,
+      );
+    } finally {
+      await closeBrowserPage(page);
+    }
+  });
 
   it("uses the compact mobile grid when the agent filter is not rendered", async () => {
     const page = await openFixture(320, 568, { singleAgent: true });

--- a/ui/src/ui/chat/chat-responsive.browser.test.ts
+++ b/ui/src/ui/chat/chat-responsive.browser.test.ts
@@ -1,10 +1,13 @@
 // Control UI tests cover chat responsive behavior.
 import { chromium, type Browser, type Page } from "playwright";
-import { describe, expect, it } from "vitest";
+import { afterAll, describe, expect, it } from "vitest";
 import { readStyleSheet } from "../../../../test/helpers/ui-style-fixtures.js";
 import {
   canRunPlaywrightChromium,
+  installMockGateway,
   resolvePlaywrightChromiumExecutablePath,
+  startControlUiE2eServer,
+  type ControlUiE2eServer,
 } from "../../test-helpers/control-ui-e2e.ts";
 
 const VIEWPORTS = [
@@ -23,6 +26,7 @@ const describeBrowserLayout = canRunPlaywrightChromium(chromiumExecutablePath)
   : describe.skip;
 
 const pageBrowsers = new WeakMap<Page, Browser>();
+let realChatServer: ControlUiE2eServer | null = null;
 
 type ControlRect = {
   x: number;
@@ -418,6 +422,11 @@ async function expectNoHorizontalOverflow(page: Page) {
 }
 
 describeBrowserLayout("chat responsive browser layout", () => {
+  afterAll(async () => {
+    await realChatServer?.close();
+    realChatServer = null;
+  });
+
   it.each([
     [1120, 740],
     [1366, 900],
@@ -880,6 +889,104 @@ describeBrowserLayout("chat responsive browser layout", () => {
       expect(toolbar.y + toolbar.height).toBeLessThanOrEqual(
         scrolledInput.y + scrolledInput.height + 1,
       );
+    } finally {
+      await closeBrowserPage(page);
+    }
+  });
+
+  it("scrolls the keyboard-active slash option into view in short landscape", async () => {
+    realChatServer ??= await startControlUiE2eServer();
+    const page = await openBrowserPage(568, 320);
+    await installMockGateway(page, {
+      historyMessages: [
+        {
+          content: [
+            {
+              text: "Short landscape slash command keyboard regression fixture.",
+              type: "text",
+            },
+          ],
+          role: "assistant",
+          timestamp: Date.now(),
+        },
+      ],
+    });
+    try {
+      await page.goto(`${realChatServer.baseUrl}chat`);
+      await page
+        .getByText("Short landscape slash command keyboard regression fixture.")
+        .waitFor({ timeout: 10_000 });
+      const textarea = page.locator(".agent-chat__composer-combobox > textarea");
+      await textarea.fill("/");
+      await textarea.focus();
+
+      const initiallyHidden = await page.evaluate(() => {
+        const menu = document.querySelector<HTMLElement>(".slash-menu");
+        const options = Array.from(
+          document.querySelectorAll<HTMLElement>(".slash-menu-item[role='option']"),
+        );
+        const hiddenOption = options.find((option) => {
+          const menuRect = menu?.getBoundingClientRect();
+          const optionRect = option.getBoundingClientRect();
+          return Boolean(menuRect && optionRect.bottom > menuRect.bottom + 1);
+        });
+        if (!menu || !hiddenOption) {
+          throw new Error("Expected an initially hidden slash option");
+        }
+        menu.scrollTop = 0;
+        const menuRect = menu.getBoundingClientRect();
+        const itemRect = hiddenOption.getBoundingClientRect();
+        return {
+          id: hiddenOption.id,
+          index: options.indexOf(hiddenOption),
+          visible: itemRect.top >= menuRect.top - 1 && itemRect.bottom <= menuRect.bottom + 1,
+        };
+      });
+      expect(initiallyHidden.visible).toBe(false);
+
+      for (let index = 0; index < initiallyHidden.index; index += 1) {
+        await page.keyboard.press("ArrowDown");
+      }
+      await page.waitForFunction((expectedId) => {
+        const input = document.querySelector<HTMLTextAreaElement>(
+          ".agent-chat__composer-combobox > textarea",
+        );
+        return input?.getAttribute("aria-activedescendant") === expectedId;
+      }, initiallyHidden.id);
+      await page.waitForFunction((expectedId) => {
+        const active = document.getElementById(expectedId);
+        const menu = active?.closest<HTMLElement>(".slash-menu");
+        if (!active || !menu) {
+          return false;
+        }
+        const menuRect = menu.getBoundingClientRect();
+        const activeRect = active.getBoundingClientRect();
+        return activeRect.top >= menuRect.top - 1 && activeRect.bottom <= menuRect.bottom + 1;
+      }, initiallyHidden.id);
+
+      const result = await page.evaluate(() => {
+        const input = document.querySelector<HTMLTextAreaElement>(
+          ".agent-chat__composer-combobox > textarea",
+        );
+        const menu = document.querySelector<HTMLElement>(".slash-menu");
+        const active = document.querySelector<HTMLElement>(".slash-menu-item--active");
+        if (!input || !menu || !active) {
+          throw new Error("Expected active slash option after keyboard navigation");
+        }
+        const menuRect = menu.getBoundingClientRect();
+        const activeRect = active.getBoundingClientRect();
+        return {
+          activeDescendant: input.getAttribute("aria-activedescendant"),
+          focusedTag: document.activeElement?.tagName,
+          scrollTop: menu.scrollTop,
+          visible: activeRect.top >= menuRect.top - 1 && activeRect.bottom <= menuRect.bottom + 1,
+        };
+      });
+
+      expect(result.focusedTag).toBe("TEXTAREA");
+      expect(result.activeDescendant).toBe(initiallyHidden.id);
+      expect(result.scrollTop).toBeGreaterThan(0);
+      expect(result.visible).toBe(true);
     } finally {
       await closeBrowserPage(page);
     }

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -1826,7 +1826,15 @@ function scrollActiveSlashMenuOptionIntoView(): void {
     if (!activeOption || !menu) {
       return;
     }
-    activeOption.scrollIntoView({ block: "nearest" });
+    const menuBounds = menu.getBoundingClientRect();
+    const optionBounds = activeOption.getBoundingClientRect();
+    // scrollIntoView also moves the short-landscape composer and page. Keep
+    // keyboard navigation owned by the menu so textarea focus stays stable.
+    if (optionBounds.top < menuBounds.top) {
+      menu.scrollTop -= menuBounds.top - optionBounds.top;
+    } else if (optionBounds.bottom > menuBounds.bottom) {
+      menu.scrollTop += optionBounds.bottom - menuBounds.bottom;
+    }
   });
 }
 

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -1815,6 +1815,21 @@ function getActiveSlashMenuOptionLabel(): string {
   return `${command} ${cmd.description}`;
 }
 
+function scrollActiveSlashMenuOptionIntoView(): void {
+  const activeId = getActiveSlashMenuOptionId();
+  if (!activeId) {
+    return;
+  }
+  requestAnimationFrame(() => {
+    const activeOption = document.getElementById(activeId);
+    const menu = activeOption?.closest<HTMLElement>(".slash-menu");
+    if (!activeOption || !menu) {
+      return;
+    }
+    activeOption.scrollIntoView({ block: "nearest" });
+  });
+}
+
 function tokenEstimate(draft: string): string | null {
   if (draft.length < 100) {
     return null;
@@ -2507,11 +2522,13 @@ export function renderChat(props: ChatProps) {
           e.preventDefault();
           vs.slashMenuIndex = (vs.slashMenuIndex + 1) % len;
           requestUpdate();
+          scrollActiveSlashMenuOptionIntoView();
           return;
         case "ArrowUp":
           e.preventDefault();
           vs.slashMenuIndex = (vs.slashMenuIndex - 1 + len) % len;
           requestUpdate();
+          scrollActiveSlashMenuOptionIntoView();
           return;
         case "Tab":
           e.preventDefault();
@@ -2538,11 +2555,13 @@ export function renderChat(props: ChatProps) {
           e.preventDefault();
           vs.slashMenuIndex = (vs.slashMenuIndex + 1) % len;
           requestUpdate();
+          scrollActiveSlashMenuOptionIntoView();
           return;
         case "ArrowUp":
           e.preventDefault();
           vs.slashMenuIndex = (vs.slashMenuIndex - 1 + len) % len;
           requestUpdate();
+          scrollActiveSlashMenuOptionIntoView();
           return;
         case "Tab":
           e.preventDefault();


### PR DESCRIPTION
Closes #98615

AI-assisted by Codex. Agent transcript logs were not included because transcript insertion needs explicit approval.

## What Problem This Solves

Fixes an issue where Android Chrome PWA users in landscape orientation could have the Control UI composer occupy nearly the full screen, leaving too little chat history visible while composing.

## Why This Change Was Made

The short-landscape chat layout now bounds the composer height and keeps overflow inside the composer and textarea scroll areas, while reserving visible vertical space for the chat thread. The slash command menu is kept inside the bounded short-landscape composer as a sticky scrollable panel so the new composer scrollport does not clip the existing command UI.

## User Impact

Users on short landscape viewports, including Android PWA users, can keep the composer controls and slash command menu available while still seeing meaningful chat history above the input bar.

## Evidence

- Current head: `fcf3793cd46f5779b9208263bed8e5cefd761c58`.
- Maintainer rewrite: keyboard navigation now adjusts only the slash menu's own `scrollTop`; the prior `scrollIntoView()` implementation could also move the bounded composer or page on short landscape viewports.
- Claim proved: the 568x320 short-landscape browser fixture keeps the composer bounded, leaves 40% of the viewport for the chat thread, keeps the textarea compact and scrollable, keeps attachment/toolbar rows scroll-reachable, and keeps the slash command menu visible inside the bounded composer without clipping.
- Added regression coverage: `ui/src/ui/chat/chat-responsive.browser.test.ts` now covers a short-landscape composer with an attachment row plus a long draft, verifies composer overflow, verifies model/settings/send controls after composer scroll, and verifies a slash menu remains visible and scrollable inside the bounded composer.
- Current-head keyboard-scroll proof: `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH='C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe' node scripts/run-vitest.mjs ui/src/ui/chat/chat-responsive.browser.test.ts --reporter=verbose -t "scrolls the keyboard-active slash option into view in short landscape"` - passed on `daa7f6eeeb6c5d5ded6d9e0a7a307bcc291b3653` with 1 test passed and 25 skipped, proving ArrowDown scrolls the initially hidden slash command option into view in the 568x320 short-landscape browser fixture.
- Visual proof gist: https://gist.github.com/qingminglong/72855897728f4d1cc262494109c20a3c.
- Visual proof screenshots: slash menu visible at 568x320 (`short-landscape-slash-menu-top.svg` raw: https://gist.githubusercontent.com/qingminglong/72855897728f4d1cc262494109c20a3c/raw/4c076c87a04c7acb8487e017abae30da3ef5c2b8/short-landscape-slash-menu-top.svg) and controls reachable after composer scroll (`short-landscape-controls-scrolled.svg` raw: https://gist.githubusercontent.com/qingminglong/72855897728f4d1cc262494109c20a3c/raw/834d90aee0658f17335361c7f383c537ca9b0698/short-landscape-controls-scrolled.svg).
- Visual proof metrics JSON: https://gist.githubusercontent.com/qingminglong/72855897728f4d1cc262494109c20a3c/raw/a616148412674e77e635cad322add4ce76358636/short-landscape-slash-menu-metrics.json. Key metrics: viewport 568x320, composer 115.1875px, chat thread 128px, slash menu 88px with `scrollHeight` 138 > `clientHeight` 86, composer `scrollHeight` 313 > `clientHeight` 113, and after composer scroll the model/settings/send controls remain inside `.agent-chat__input`.
- `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH='C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe' node scripts/run-vitest.mjs ui/src/ui/chat/chat-responsive.browser.test.ts --reporter=verbose` - passed, 25 tests.
- Exact-head macOS Chrome proof: `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH='/Applications/Google Chrome.app/Contents/MacOS/Google Chrome' node scripts/run-vitest.mjs ui/src/ui/chat/chat-responsive.browser.test.ts --reporter=verbose` - passed, 26 tests on `fcf3793cd46f5779b9208263bed8e5cefd761c58`.
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.ui.json --incremental false --pretty false` - passed.
- `./node_modules/.bin/oxlint.CMD ui/src/styles/chat/layout.css ui/src/ui/chat/chat-responsive.browser.test.ts` - passed.
- `./node_modules/.bin/oxfmt.CMD --check --threads=1 ui/src/styles/chat/layout.css ui/src/ui/chat/chat-responsive.browser.test.ts` - passed.
- `git diff --check` - passed.
- Fresh maintainer autoreview of the bounded menu-scroll rewrite - clean, no accepted/actionable findings; correct (0.95).
- Hosted exact-head CI run `28658753206` passed, including QA smoke, build, lint, type, security, and all selected Node shards.
- Existing-profile Chrome capture was attempted through the configured browser bridge, but that bridge exposed no pages. The contributor's 568x320 visual artifact remains applicable because the maintainer rewrite changes only keyboard scroll ownership, not the rendered layout.
- Not tested: physical Android Chrome PWA device capture; the closest available proof is the 568x320 Edge/Playwright short-landscape visual capture above.
