### PR TITLE
fix(gateway): show pending node approval diagnostics

### DIFF
--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -277,6 +277,34 @@ The export contains a manifest, a Markdown summary, config shape, sanitized conf
 
 It is meant to be shared. It keeps operational details that help debugging, such as safe OpenClaw log fields, subsystem names, status codes, durations, configured modes, ports, plugin ids, provider ids, non-secret feature settings, and redacted operational log messages. It omits or redacts chat text, webhook bodies, tool outputs, credentials, cookies, account/message identifiers, prompt/instruction text, hostnames, and secret values. When a LogTape-style message looks like user/chat/tool payload text, the export keeps only that a message was omitted plus its byte count.
 
+### `gateway diagnostics node-approvals`
+
+Show pending node approval requests from a running Gateway and print the matching approval command.
+
+```bash
+openclaw gateway diagnostics node-approvals
+openclaw gateway diagnostics node-approvals --url ws://127.0.0.1:18789 --token <token>
+openclaw gateway diagnostics node-approvals --json
+```
+
+<ParamField path="--url <url>" type="string">
+  Gateway WebSocket URL.
+</ParamField>
+<ParamField path="--token <token>" type="string">
+  Gateway token.
+</ParamField>
+<ParamField path="--password <password>" type="string">
+  Gateway password.
+</ParamField>
+<ParamField path="--timeout <ms>" type="number" default="3000">
+  Node diagnostics timeout.
+</ParamField>
+<ParamField path="--json" type="boolean">
+  Print pending approvals as JSON.
+</ParamField>
+
+When you pass explicit connection options, reuse the same `--url`, `--token`, or `--password` values with the printed `openclaw nodes approve <requestId>` command.
+
 ### `gateway status`
 
 `gateway status` shows the Gateway service (launchd/systemd/schtasks) plus an optional probe of connectivity/auth capability.

--- a/docs/cli/nodes.md
+++ b/docs/cli/nodes.md
@@ -18,7 +18,9 @@ Related:
 
 Common options:
 
-- `--url`, `--token`, `--timeout`, `--json`
+- `--url`, `--token`, `--password`, `--timeout`, `--json`
+
+When you set `--url`, pass `--token` or `--password` explicitly if the Gateway requires auth. Reuse the same connection options with `nodes approve` or `nodes reject` when a diagnostics command prints a pending approval request id.
 
 ## Common commands
 

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -1498,6 +1498,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H3: gateway usage-cost
   - H3: gateway stability
   - H3: gateway diagnostics export
+  - H3: gateway diagnostics node-approvals
   - H3: gateway status
   - H3: gateway probe
   - H4: Remote over SSH (Mac app parity)

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -2208,6 +2208,7 @@ process.stdin.on("end", () => {
       const slowServerPath = path.join(tempDir, "slow-server.mjs");
       const slowLogPath = path.join(tempDir, "slow.log");
       const firstConnectMarkerPath = path.join(tempDir, "first-connect.marker");
+      const sessionId = `session-timeout-retire-test-${path.basename(tempDir)}`;
 
       await writeExecutable(
         triggerServerPath,
@@ -2368,8 +2369,8 @@ process.on("SIGINT", shutdown);`,
       );
 
       const runtime = await getOrCreateSessionMcpRuntime({
-        sessionId: "session-timeout-retire-test",
-        sessionKey: "agent:test:session-timeout-retire-test",
+        sessionId,
+        sessionKey: `agent:test:${sessionId}`,
         workspaceDir: "/workspace",
         cfg: {
           mcp: {

--- a/src/cli/gateway-cli.coverage.test.ts
+++ b/src/cli/gateway-cli.coverage.test.ts
@@ -12,7 +12,7 @@ type DiscoveredBeacon = Awaited<
   ReturnType<typeof import("../infra/bonjour-discovery.js").discoverGatewayBeacons>
 >[number];
 
-const callGateway = vi.fn<(opts: unknown) => Promise<{ ok: true }>>(async () => ({ ok: true }));
+const callGateway = vi.fn<(opts: unknown) => Promise<unknown>>(async () => ({ ok: true }));
 const formatGatewayClientRequestErrorJson = vi.fn();
 const formatGatewayTransportErrorJson = vi.fn();
 const startGatewayServer = vi.fn<
@@ -33,6 +33,9 @@ const discoverGatewayBeacons = vi.fn<(opts: unknown) => Promise<DiscoveredBeacon
   async () => [],
 );
 const gatewayStatusCommand = vi.fn<(opts: unknown) => Promise<void>>(async () => {});
+const callNodeDiagnosticsGatewayCli = vi.fn<
+  (method: string, opts: unknown, params?: unknown, callOpts?: unknown) => Promise<unknown>
+>(async () => ({ nodes: [] }));
 const inspectPortUsage = vi.fn(async (_port: number) => ({ status: "free" as const }));
 const formatPortDiagnostics = vi.fn((_diagnostics: unknown) => [] as string[]);
 
@@ -116,6 +119,15 @@ vi.mock("../commands/gateway-status.js", () => ({
   gatewayStatusCommand: (opts: unknown) => gatewayStatusCommand(opts),
 }));
 
+vi.mock("./nodes-cli/rpc.js", () => ({
+  callNodeDiagnosticsGatewayCli: (
+    method: string,
+    opts: unknown,
+    params?: unknown,
+    callOpts?: unknown,
+  ) => callNodeDiagnosticsGatewayCli(method, opts, params, callOpts),
+}));
+
 vi.mock("../infra/ports.js", () => ({
   inspectPortUsage: (port: number) => inspectPortUsage(port),
   formatPortDiagnostics: (diagnostics: unknown) => formatPortDiagnostics(diagnostics),
@@ -157,6 +169,8 @@ describe("gateway-cli coverage", () => {
     defaultRuntime.writeJson.mockClear();
     defaultRuntime.exit.mockClear();
     startGatewayServer.mockClear();
+    callNodeDiagnosticsGatewayCli.mockClear();
+    callNodeDiagnosticsGatewayCli.mockResolvedValue({ nodes: [] });
     inspectPortUsage.mockClear();
     formatPortDiagnostics.mockClear();
     formatGatewayClientRequestErrorJson.mockReset();
@@ -453,6 +467,113 @@ describe("gateway-cli coverage", () => {
     } finally {
       fs.rmSync(tempDir, { recursive: true, force: true });
     }
+  });
+
+  it("prints pending node approval ids and exact approve commands", async () => {
+    callGateway.mockClear();
+    callNodeDiagnosticsGatewayCli.mockResolvedValueOnce({
+      nodes: [
+        {
+          nodeId: "android-node",
+          displayName: "Colin's S25",
+          approvalState: "pending-reapproval",
+          pendingRequestId: "node-req-1",
+        },
+        {
+          nodeId: "approved-node",
+          displayName: "Already Approved",
+          approvalState: "approved",
+        },
+      ],
+    });
+
+    await runGatewayCommand([
+      "gateway",
+      "diagnostics",
+      "node-approvals",
+      "--url",
+      "ws://gateway-user:url-secret@gateway.example:18789/openclaw?cluster=qa",
+      "--token",
+      "secret-token",
+      "--password",
+      "node-approval-password",
+    ]);
+
+    expect(callNodeDiagnosticsGatewayCli).toHaveBeenCalledTimes(1);
+    expect(callNodeDiagnosticsGatewayCli).toHaveBeenCalledWith(
+      "node.list",
+      expect.objectContaining({ json: false, password: "node-approval-password" }),
+      {},
+      { requirePairingScope: true },
+    );
+    expect(callGateway).not.toHaveBeenCalled();
+    const output = runtimeLogs.join("\n");
+    expect(output).toContain("Pending Node Approvals");
+    expect(output).toContain("Node reapproval pending for Colin's S25 (node-req-1)");
+    expect(output).toContain("openclaw nodes approve node-req-1");
+    expect(output).toContain(
+      "Reuse the same connection options when rerunning: --url, --token, --password.",
+    );
+    expect(output).not.toContain("approved-node");
+    expect(output).not.toContain("gateway-user");
+    expect(output).not.toContain("url-secret");
+    expect(output).not.toContain("gateway.example");
+    expect(output).not.toContain("secret-token");
+    expect(output).not.toContain("node-approval-password");
+  });
+
+  it("writes pending node approval diagnostics as JSON", async () => {
+    callGateway.mockClear();
+    callNodeDiagnosticsGatewayCli.mockResolvedValueOnce({
+      nodes: [
+        {
+          nodeId: "android-node",
+          displayName: "Colin's S25",
+          approvalState: "pending-approval",
+          pendingRequestId: "node req 1",
+        },
+      ],
+    });
+
+    await runGatewayCommand([
+      "gateway",
+      "diagnostics",
+      "node-approvals",
+      "--url",
+      "ws://gateway.example.test/openclaw",
+      "--timeout",
+      "3000",
+      "--json",
+    ]);
+
+    expect(defaultRuntime.writeJson).toHaveBeenCalledWith({
+      pending: [
+        {
+          nodeId: "android-node",
+          displayName: "Colin's S25",
+          approvalState: "pending-approval",
+          requestId: "node req 1",
+          approveCommand: "openclaw nodes approve 'node req 1' --timeout 3000",
+          connectionReminder: "Reuse the same connection option when rerunning: --url.",
+        },
+      ],
+    });
+  });
+
+  it("prints an empty pending node approval diagnostic", async () => {
+    callGateway.mockClear();
+    callNodeDiagnosticsGatewayCli.mockResolvedValueOnce({
+      nodes: [
+        {
+          nodeId: "android-node",
+          approvalState: "pending-reapproval",
+        },
+      ],
+    });
+
+    await runGatewayCommand(["gateway", "diagnostics", "node-approvals"]);
+
+    expect(runtimeLogs.join("\n")).toContain("No pending node approvals.");
   });
 
   it.each([

--- a/src/cli/gateway-cli/register.ts
+++ b/src/cli/gateway-cli/register.ts
@@ -275,10 +275,11 @@ function renderPendingNodeApprovalDiagnostic(node: NodeListNode, opts: GatewayRp
   const requestId = normalizeNonEmptyString(node.pendingRequestId);
   const label = sanitizeForLog(normalizeNonEmptyString(node.displayName) ?? node.nodeId);
   const action = node.approvalState === "pending-reapproval" ? "reapproval" : "approval";
-  const command = requestId ? formatNodeApprovalCommand(requestId, opts) : null;
-  return command
-    ? `Node ${action} pending for ${label} (${sanitizeForLog(requestId)}). Run ${sanitizeForLog(command)}`
-    : `Node ${action} pending for ${label}.`;
+  if (!requestId) {
+    return `Node ${action} pending for ${label}.`;
+  }
+  const command = formatNodeApprovalCommand(requestId, opts);
+  return `Node ${action} pending for ${label} (${sanitizeForLog(requestId)}). Run ${sanitizeForLog(command)}`;
 }
 
 function formatStabilityEvent(record: DiagnosticStabilityEventRecord): string {

--- a/src/cli/gateway-cli/register.ts
+++ b/src/cli/gateway-cli/register.ts
@@ -1,5 +1,6 @@
 // Commander registration for gateway status, health, diagnostics, discovery, and run commands.
 import type { Command } from "commander";
+import { sanitizeForLog } from "../../../packages/terminal-core/src/ansi.js";
 import { formatDocsLink } from "../../../packages/terminal-core/src/links.js";
 import { colorize, isRich, theme } from "../../../packages/terminal-core/src/theme.js";
 import type { HealthSummary } from "../../commands/health.js";
@@ -16,10 +17,16 @@ import type {
 import type { WriteDiagnosticSupportExportResult } from "../../logging/diagnostic-support-export.js";
 import { defaultRuntime } from "../../runtime.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
+import { parseNodeList } from "../../shared/node-list-parse.js";
+import type { NodeListNode } from "../../shared/node-list-types.js";
+import { formatCliCommand } from "../command-format.js";
 import { inheritOptionFromParent } from "../command-options.js";
 import { addGatewayServiceCommands } from "../daemon-cli/register-service-commands.js";
 import { parseGatewayPortOption } from "../gateway-port-option.js";
 import { formatHelpExamples } from "../help-format.js";
+import { formatConnectionFlagReminder } from "../nodes-cli/cli-utils.js";
+import { callNodeDiagnosticsGatewayCli } from "../nodes-cli/rpc.js";
+import { quoteCliArg } from "../quote-cli-arg.js";
 import type { GatewayRpcOpts } from "./call.js";
 import type { GatewayDiscoverOpts } from "./discover.js";
 import { addGatewayRunCommand } from "./run-command.js";
@@ -48,6 +55,7 @@ const supportExportModuleLoader = createLazyImportLoader(
 const daemonStatusGatherModuleLoader = createLazyImportLoader(
   () => import("../daemon-cli/status.gather.js"),
 );
+const DEFAULT_GATEWAY_RPC_TIMEOUT_MS = 10_000;
 
 function loadConfigModule() {
   return configModuleLoader.load();
@@ -241,6 +249,36 @@ function formatBytes(value: number | undefined): string {
   }
   const digits = unitIndex === 0 || amount >= 100 ? 0 : 1;
   return `${amount.toFixed(digits)} ${units[unitIndex]}`;
+}
+
+function normalizeNonEmptyString(raw: unknown): string | null {
+  return typeof raw === "string" && raw.trim().length > 0 ? raw.trim() : null;
+}
+
+function isPendingNodeApproval(node: NodeListNode): boolean {
+  return (
+    (node.approvalState === "pending-approval" || node.approvalState === "pending-reapproval") &&
+    normalizeNonEmptyString(node.pendingRequestId) !== null
+  );
+}
+
+function formatNodeApprovalCommand(requestId: string, opts: GatewayRpcOpts): string {
+  const args = ["openclaw", "nodes", "approve", requestId];
+  const timeout = normalizeNonEmptyString(opts.timeout);
+  if (timeout && timeout !== String(DEFAULT_GATEWAY_RPC_TIMEOUT_MS)) {
+    args.push("--timeout", timeout);
+  }
+  return formatCliCommand(args.map(quoteCliArg).join(" "));
+}
+
+function renderPendingNodeApprovalDiagnostic(node: NodeListNode, opts: GatewayRpcOpts): string {
+  const requestId = normalizeNonEmptyString(node.pendingRequestId);
+  const label = sanitizeForLog(normalizeNonEmptyString(node.displayName) ?? node.nodeId);
+  const action = node.approvalState === "pending-reapproval" ? "reapproval" : "approval";
+  const command = requestId ? formatNodeApprovalCommand(requestId, opts) : null;
+  return command
+    ? `Node ${action} pending for ${label} (${sanitizeForLog(requestId)}). Run ${sanitizeForLog(command)}`
+    : `Node ${action} pending for ${label}.`;
 }
 
 function formatStabilityEvent(record: DiagnosticStabilityEventRecord): string {
@@ -764,6 +802,58 @@ export function registerGatewayCli(program: Command) {
         });
       }, "Gateway diagnostics export failed");
     });
+  gatewayCallOpts(
+    diagnostics
+      .command("node-approvals")
+      .description("Show pending node approval request IDs and approve commands")
+      .action(async (opts, command) => {
+        await runGatewayCommand(
+          async () => {
+            const rpcOpts = resolveGatewayRpcOptions(opts, command);
+            const pending = parseNodeList(
+              await callNodeDiagnosticsGatewayCli(
+                "node.list",
+                rpcOpts,
+                {},
+                {
+                  requirePairingScope: true,
+                },
+              ),
+            ).filter(isPendingNodeApproval);
+            const connectionReminder = formatConnectionFlagReminder(rpcOpts);
+            if (rpcOpts.json) {
+              defaultRuntime.writeJson({
+                pending: pending.map((node) => {
+                  const requestId = normalizeNonEmptyString(node.pendingRequestId) ?? "";
+                  return {
+                    nodeId: node.nodeId,
+                    displayName: node.displayName,
+                    approvalState: node.approvalState,
+                    requestId,
+                    approveCommand: formatNodeApprovalCommand(requestId, rpcOpts),
+                    ...(connectionReminder ? { connectionReminder } : {}),
+                  };
+                }),
+              });
+              return;
+            }
+            if (pending.length === 0) {
+              defaultRuntime.log(theme.muted("No pending node approvals."));
+              return;
+            }
+            defaultRuntime.log(theme.heading("Pending Node Approvals"));
+            for (const node of pending) {
+              defaultRuntime.log(theme.warn(renderPendingNodeApprovalDiagnostic(node, rpcOpts)));
+            }
+            if (connectionReminder) {
+              defaultRuntime.log(theme.warn(connectionReminder));
+            }
+          },
+          "Gateway node approval diagnostics failed",
+          { json: Boolean(opts.json) },
+        );
+      }),
+  );
 
   gateway
     .command("probe")

--- a/src/cli/nodes-cli.coverage.test.ts
+++ b/src/cli/nodes-cli.coverage.test.ts
@@ -139,6 +139,8 @@ describe("nodes-cli coverage", () => {
           "wss://gateway.example.test",
           "--token",
           "secret-token",
+          "--password",
+          "secret-password",
         ],
         { from: "user" },
       ),
@@ -148,9 +150,12 @@ describe("nodes-cli coverage", () => {
     expect(output).toContain("Unknown node pairing requestId: stale-request");
     expect(output).toContain("Pending requestIds: current-request");
     expect(output).toContain("openclaw nodes pending");
-    expect(output).toContain("Reuse the same connection options when rerunning: --url, --token.");
+    expect(output).toContain(
+      "Reuse the same connection options when rerunning: --url, --token, --password.",
+    );
     expect(output).not.toContain("gateway.example.test");
     expect(output).not.toContain("secret-token");
+    expect(output).not.toContain("secret-password");
     expect(output).not.toContain("nodes approve failed: Error:");
     expect(output).not.toContain("GatewayClientRequestError: unknown requestId");
     expect(callGateway.mock.calls.map(([call]) => call.method)).toEqual(["node.pair.list"]);

--- a/src/cli/nodes-cli/cli-utils.ts
+++ b/src/cli/nodes-cli/cli-utils.ts
@@ -25,6 +25,7 @@ export function formatConnectionFlagReminder(opts: NodesRpcOpts): string | null 
   const flags = [
     normalizeOptionalString(opts.url) ? "--url" : null,
     normalizeOptionalString(opts.token) ? "--token" : null,
+    normalizeOptionalString(opts.password) ? "--password" : null,
   ].filter((flag) => flag !== null);
   return flags.length > 0
     ? `Reuse the same connection option${flags.length === 1 ? "" : "s"} when rerunning: ${flags.join(", ")}.`

--- a/src/cli/nodes-cli/rpc.runtime.ts
+++ b/src/cli/nodes-cli/rpc.runtime.ts
@@ -39,6 +39,7 @@ export async function callGatewayCliRuntime(
       await callGateway({
         url: opts.url,
         token: opts.token,
+        password: opts.password,
         method,
         params,
         scopes: callOpts?.scopes,
@@ -77,6 +78,7 @@ export async function callNodePairApprovalGatewayCliRuntime(
       await callGateway({
         url: opts.url,
         token: opts.token,
+        password: opts.password,
         method,
         params,
         timeoutMs: resolveNodesTransportTimeoutMs(opts, callOpts.transportTimeoutMs),

--- a/src/cli/nodes-cli/rpc.ts
+++ b/src/cli/nodes-cli/rpc.ts
@@ -130,7 +130,12 @@ export const callNodeDiagnosticsGatewayCli = async (
       throw error;
     }
   }
-  return await callGatewayCli(method, opts, params, { scopes: fallbackScopes });
+  return await callGatewayCli(
+    method,
+    opts,
+    params,
+    fallbackScopes ? { scopes: fallbackScopes } : undefined,
+  );
 };
 
 /** Call pairing approval methods with explicit operator scopes. */

--- a/src/cli/nodes-cli/rpc.ts
+++ b/src/cli/nodes-cli/rpc.ts
@@ -79,6 +79,7 @@ export const nodesCallOpts = (cmd: Command, defaults?: { timeoutMs?: number }) =
   cmd
     .option("--url <url>", "Gateway WebSocket URL (defaults to gateway.remote.url when configured)")
     .option("--token <token>", "Gateway token (if required)")
+    .option("--password <password>", "Gateway password (password auth)")
     .option("--timeout <ms>", "Timeout in ms", String(defaults?.timeoutMs ?? 10_000))
     .option("--json", "Output JSON", false);
 
@@ -104,7 +105,11 @@ export const callNodeDiagnosticsGatewayCli = async (
   method: "node.list" | "node.describe",
   opts: NodesRpcOpts,
   params?: unknown,
+  callOpts?: { requirePairingScope?: boolean },
 ) => {
+  const fallbackScopes: OperatorScope[] | undefined = callOpts?.requirePairingScope
+    ? ["operator.read", "operator.pairing"]
+    : undefined;
   try {
     return await callGatewayCli(method, opts, params, {
       useStoredDeviceAuth: true,
@@ -125,7 +130,7 @@ export const callNodeDiagnosticsGatewayCli = async (
       throw error;
     }
   }
-  return await callGatewayCli(method, opts, params);
+  return await callGatewayCli(method, opts, params, { scopes: fallbackScopes });
 };
 
 /** Call pairing approval methods with explicit operator scopes. */

--- a/src/cli/nodes-cli/types.ts
+++ b/src/cli/nodes-cli/types.ts
@@ -3,6 +3,7 @@
 export type NodesRpcOpts = {
   url?: string;
   token?: string;
+  password?: string;
   timeout?: string;
   json?: boolean;
   node?: string;


### PR DESCRIPTION
Closes #98045

AI-assisted by Codex. Agent transcript logs were not included because transcript insertion needs explicit approval.

## What Problem This Solves

Fixes an issue where users diagnosing Android/node reconnect approval could see that approval was pending but still not discover the exact node approval request id or the `openclaw nodes approve <requestId>` command from Gateway diagnostics.

## Why This Change Was Made

This adds a focused Gateway diagnostics command, `openclaw gateway diagnostics node-approvals`, that uses the existing pairing-aware node diagnostics path and renders only pending node approval/reapproval entries with the exact approve command. It preserves safe connection guidance for explicit `--url`, `--token`, and `--password` use without printing credential values, and threads password auth through the node CLI RPC path so the follow-up `nodes approve` command can reuse the same auth mode.

## User Impact

Operators can now run a Gateway diagnostics command and copy the exact node approval command instead of guessing `openclaw devices approve <ip>` or hunting through node status output.

## Evidence

- Current head under review: `fd4c14b4321685f50c412b618c8515de98ff1d46`.
- Claim proved: the new diagnostics command renders pending node approval IDs and exact approve commands, requests the pairing-aware node diagnostics path needed for pending request IDs, preserves non-leaking connection/auth guidance for explicit remote credentials, and the public CLI docs/docs map now include the new command and node `--password` option.
- ClawSweeper's earlier `[P1] Narrow requestId before sanitizing it` finding was fixed by commit `1a21756ad2c6cb70fdc80976d8dde8e9925a5031`: `renderPendingNodeApprovalDiagnostic` now returns before formatting/sanitizing when `pendingRequestId` is absent, so `requestId` is narrowed to `string` before `sanitizeForLog(requestId)`.
- ClawSweeper's July 3 docs finding was fixed by:
  - `0d2e43e270b01f0cab55d62c696e2eda639c6e4f`: documents `openclaw gateway diagnostics node-approvals` and the `openclaw nodes` `--password` option.
  - `fd4c14b4321685f50c412b618c8515de98ff1d46`: refreshes `docs/docs_map.md` so `pnpm check:docs` no longer fails with an out-of-date docs map.
- Real behavior proof, local loopback Gateway with temporary `OPENCLAW_STATE_DIR` and a real pending node pairing request: `node --import tsx src/entry.ts gateway diagnostics node-approvals --url ws://127.0.0.1:<port> --token <redacted> --timeout 3000` exited 0 and produced:

```text
Pending Node Approvals
Node approval pending for Proof Android Node (<requestId>). Run openclaw nodes approve <requestId> --timeout 3000
Reuse the same connection options when rerunning: --url, --token.
```

- Real behavior proof details: `pendingRequestIdMatched=true`, `approveCommandMatched=true`, `connectionReminderMatched=true`; Gateway log for the proof showed a successful real `node.list` RPC on the loopback server. The request id, token, and port were redacted from the pasted output.
- GitHub checks:
  - Current-head `check-docs`: passed after the docs map commit, https://github.com/openclaw/openclaw/actions/runs/28645802202/job/84952044124
  - Current-head `check-prod-types`: passed, https://github.com/openclaw/openclaw/actions/runs/28645802202/job/84952044227
  - Current-head `check-test-types`: passed, https://github.com/openclaw/openclaw/actions/runs/28645802202/job/84952044220
  - Earlier current-branch `Real behavior proof`: passed, https://github.com/openclaw/openclaw/actions/runs/28615937652/job/84859675315
- Focused local checks after docs/doc-map repair:
  - `node scripts/check-docs-mdx.mjs docs/cli/gateway.md docs/cli/nodes.md` - passed.
  - `node_modules\.bin\oxfmt.cmd --check --threads=1 --config .oxfmtrc.jsonc docs\cli\gateway.md docs\cli\nodes.md docs\docs_map.md` - passed.
  - `node scripts/generate-docs-map.mjs --check` - passed.
  - `git diff --check -- docs/cli/gateway.md docs/cli/nodes.md docs/docs_map.md` - passed.
- Earlier focused local checks:
  - `git diff --check` - passed.
  - `node scripts/run-vitest.mjs src/cli/gateway-cli.coverage.test.ts src/cli/nodes-cli.coverage.test.ts --reporter=verbose` - passed, 52 tests.
  - `node scripts/run-vitest.mjs src/agents/agent-bundle-mcp-runtime.test.ts --reporter=verbose -t "retires timed-out shared MCP sessions before later catalog retries"` - passed after commit `7667479a8831e3e996b1c477abe50d24cc0ba358` isolated the shared-session retry test.
- Not tested / proof gaps:
  - Password auth pass-through is covered by source inspection and mocked CLI coverage; the live loopback command used token auth.
  - `node scripts/format-docs.mjs --check docs/cli/gateway.md docs/cli/nodes.md` was attempted on Windows, but that script still formats all docs and hit a command-line-length limitation locally. CI's Linux `pnpm check:docs` now passed the docs formatter, markdownlint, MDX, links, and docs-map checks for the current head.
  - Attempted closeout review: `python .agents\skills\autoreview\scripts\autoreview --mode local` did not complete before the 30 minute command timeout; no autoreview result is claimed.