### PR TITLE
fix: resolve scheduled live and e2e CI failures on main

### DIFF
--- a/src/agents/model-fallback.run-embedded.e2e.test.ts
+++ b/src/agents/model-fallback.run-embedded.e2e.test.ts
@@ -245,6 +245,7 @@ async function runEmbeddedFallback(params: {
     sessionId: params.sessionId,
     lane: params.lane,
     agentDir: params.agentDir,
+    abortSignal: params.abortSignal,
     run: (provider, model, options) =>
       runEmbeddedAgent({
         sessionId,

--- a/src/gateway/gateway-models.profiles.live.test.ts
+++ b/src/gateway/gateway-models.profiles.live.test.ts
@@ -2744,9 +2744,10 @@ function buildLiveGatewayConfig(params: {
     ...params.cfg,
     agents: {
       ...params.cfg.agents,
-      list: (params.cfg.agents?.list ?? []).map((entry) =>
-        Object.assign({}, entry, { sandbox: { mode: `off` } }),
-      ),
+      list: (params.cfg.agents?.list?.length
+        ? params.cfg.agents.list
+        : [{ id: "dev", default: true }]
+      ).map((entry) => Object.assign({}, entry, { sandbox: { mode: `off` } })),
       defaults: {
         ...params.cfg.agents?.defaults,
         // Live tests should avoid Docker sandboxing so tool probes can

--- a/src/gateway/gateway.test.ts
+++ b/src/gateway/gateway.test.ts
@@ -206,6 +206,7 @@ describe("gateway e2e", () => {
               },
             },
           },
+          list: [{ id: "dev", default: true }],
         },
         models: {
           mode: "replace",


### PR DESCRIPTION
## What Problem This Solves

The nightly "OpenClaw Scheduled Live And E2E Checks" workflow has been failing consistently since 2026-06-28, causing CI emails for every scheduled run. Two distinct regressions were found.

## Why This Change Was Made

### Issue 1: model-fallback e2e test — `FallbackSummaryError` instead of `AbortError`

Commit 98ed83f848 replaced the `shouldRethrowAbort(err)` guard in `runFallbackCandidate` with `isCallerAbortSignal(params.abortSignal)`. The new guard checks whether the abort signal object passed to `runWithModelFallback` is aborted, rather than checking the error name. However, the test helper `runEmbeddedFallback` only forwarded `abortSignal` to `runEmbeddedAgent` via the `run` callback closure — it never passed it to `runWithModelFallback` itself. With the signal absent, `isCallerAbortSignal` always returned false, and the AbortError fell through to the fallback loop where it was eventually wrapped as a `FallbackSummaryError`.

**Fix:** Add `abortSignal: params.abortSignal` to the `runWithModelFallback` call in `runEmbeddedFallback`.

### Issue 2: gateway tests — `Agent "dev" no longer exists in configuration`

A new deleted-agent validation check now rejects gateway requests whose session key references an agent not in the config list. Several test configs used `agent:dev` session keys without including a "dev" entry in `agents.list`.

**Fix:**
- Added `agents.list: [{ id: "dev", default: true }]` to the `gateway.test.ts` e2e config
- Made `buildLiveGatewayConfig` default to a "dev" agent when the input config has no agents configured, fixing the `gateway-models.profiles.live.test.ts` live suites

## User Impact

Scheduled CI checks return to green. No production code changes.

## Evidence

- `pnpm test src/agents/model-fallback.run-embedded.e2e.test.ts` — 20/20 passed (was 19/20)
- `pnpm test src/gateway/gateway.test.ts` — 4/4 passed (was 3/4)
- `pnpm format:check` — all modified files pass
- The `buildLiveGatewayConfig` change is purely additive (only kicks in when agents list is empty) and all existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)