### PR TITLE
fix(memory): allow relaxed promote inspection

### DIFF
--- a/extensions/memory-core/src/cli.runtime.ts
+++ b/extensions/memory-core/src/cli.runtime.ts
@@ -3,6 +3,7 @@ import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { isUsageCountedSessionTranscriptFileName } from "openclaw/plugin-sdk/memory-core-host-engine-qmd";
 import type { MemoryEmbeddingProbeResult } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import {
   resolveMemoryDreamingConfig,
@@ -10,7 +11,6 @@ import {
   resolveMemoryRemDreamingConfig,
 } from "openclaw/plugin-sdk/memory-core-host-status";
 import { buildAgentSessionKey } from "openclaw/plugin-sdk/routing";
-import { isUsageCountedSessionTranscriptFileName } from "openclaw/plugin-sdk/memory-core-host-engine-qmd";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import {
   colorize,
@@ -1357,6 +1357,11 @@ export async function runMemoryPromote(opts: MemoryPromoteCommandOptions) {
         return;
       }
 
+      const relaxedInspectionMode =
+        opts.apply !== true &&
+        opts.minScore === 0 &&
+        opts.minRecallCount === 1 &&
+        opts.minUniqueQueries === 1;
       let candidates: Awaited<ReturnType<typeof rankShortTermPromotionCandidates>>;
       try {
         candidates = await rankShortTermPromotionCandidates({
@@ -1366,7 +1371,7 @@ export async function runMemoryPromote(opts: MemoryPromoteCommandOptions) {
           minRecallCount: opts.minRecallCount ?? dreaming.minRecallCount,
           minUniqueQueries: opts.minUniqueQueries ?? dreaming.minUniqueQueries,
           recencyHalfLifeDays: dreaming.recencyHalfLifeDays,
-          maxAgeDays: dreaming.maxAgeDays,
+          ...(relaxedInspectionMode ? {} : { maxAgeDays: dreaming.maxAgeDays }),
           includePromoted: Boolean(opts.includePromoted),
         });
       } catch (err) {

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -1527,6 +1527,114 @@ describe("memory cli", () => {
     });
   });
 
+  it("relaxes promote maxAgeDays only for explicit non-apply inspection", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      const oldRecallMs = Date.now() - 45 * 24 * 60 * 60 * 1000;
+      await recordShortTermRecalls({
+        workspaceDir,
+        query: "router notes",
+        nowMs: oldRecallMs,
+        results: [
+          {
+            path: "memory/2026-04-03.md",
+            startLine: 4,
+            endLine: 8,
+            score: 0.86,
+            snippet: "Configured VLAN 10 for IoT on router",
+            source: "memory",
+          },
+        ],
+      });
+
+      getRuntimeConfig.mockReturnValue({
+        plugins: {
+          entries: {
+            "memory-core": {
+              config: {
+                dreaming: {
+                  phases: {
+                    deep: {
+                      maxAgeDays: 7,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+
+      const conservativeClose = vi.fn(async () => {});
+      mockManager({
+        status: () => makeMemoryStatus({ workspaceDir }),
+        close: conservativeClose,
+      });
+      const conservativeJson = spyRuntimeJson(defaultRuntime);
+      await runMemoryCli([
+        "promote",
+        "--json",
+        "--limit",
+        "10",
+        "--min-score",
+        "0",
+        "--min-recall-count",
+        "0",
+        "--min-unique-queries",
+        "1",
+      ]);
+      const conservativePayload = firstWrittenJsonArg<{ candidates: unknown[] }>(conservativeJson);
+      expect(conservativePayload?.candidates).toHaveLength(0);
+      conservativeJson.mockRestore();
+
+      const inspectionClose = vi.fn(async () => {});
+      mockManager({
+        status: () => makeMemoryStatus({ workspaceDir }),
+        close: inspectionClose,
+      });
+      const inspectionJson = spyRuntimeJson(defaultRuntime);
+      await runMemoryCli([
+        "promote",
+        "--json",
+        "--limit",
+        "10",
+        "--min-score",
+        "0",
+        "--min-recall-count",
+        "1",
+        "--min-unique-queries",
+        "1",
+      ]);
+      const inspectionPayload = firstWrittenJsonArg<{ candidates: unknown[] }>(inspectionJson);
+      expect(inspectionPayload?.candidates).toHaveLength(1);
+      inspectionJson.mockRestore();
+
+      const applyClose = vi.fn(async () => {});
+      mockManager({
+        status: () => makeMemoryStatus({ workspaceDir }),
+        close: applyClose,
+      });
+      const applyJson = spyRuntimeJson(defaultRuntime);
+      await runMemoryCli([
+        "promote",
+        "--json",
+        "--apply",
+        "--limit",
+        "10",
+        "--min-score",
+        "0",
+        "--min-recall-count",
+        "1",
+        "--min-unique-queries",
+        "1",
+      ]);
+      const applyPayload = firstWrittenJsonArg<{ candidates: unknown[] }>(applyJson);
+      expect(applyPayload?.candidates).toHaveLength(0);
+      expect(conservativeClose).toHaveBeenCalled();
+      expect(inspectionClose).toHaveBeenCalled();
+      expect(applyClose).toHaveBeenCalled();
+    });
+  });
+
   it("explains a specific promote candidate as json", async () => {
     await withTempWorkspace(async (workspaceDir) => {
       await recordShortTermRecalls({


### PR DESCRIPTION
## What Problem This Solves

`openclaw memory promote` uses the configured deep-dreaming `maxAgeDays` gate for review as well as apply. That is safe for automatic promotion, but it also prevents operators from inspecting older short-term recall rows during manual memory repair.

This change adds one explicit, non-apply inspection mode:

```sh
openclaw memory promote --json --limit 20 --min-score 0 --min-recall-count 1 --min-unique-queries 1
```

Only that command shape omits `maxAgeDays` from ranking. Default review and `--apply` remain conservative and continue to honor `dreaming.maxAgeDays`.

## Summary

- Adds a guarded relaxed inspection mode for `openclaw memory promote` when all review thresholds are explicitly loosened: `--min-score 0 --min-recall-count 1 --min-unique-queries 1`.
- Omits `maxAgeDays` only for that non-apply inspection mode so older recall candidates can be reviewed manually.
- Keeps default review and `--apply` conservative by continuing to pass `dreaming.maxAgeDays` outside that exact inspection shape.
- Adds a regression test covering conservative, relaxed inspection, and `--apply` behavior for an old recall row.

## Evidence

Local focused verification in a fresh clone:

```sh
pnpm exec oxfmt --check extensions/memory-core/src/cli.runtime.ts extensions/memory-core/src/cli.test.ts
pnpm exec vitest run extensions/memory-core/src/cli.test.ts --config vitest.config.ts
```

Result:

```text
Test Files  1 passed (1)
Tests       74 passed (74)
```

Local installed-runtime behavior, using the existing patched OpenClaw package and not running `--apply`:

```text
openclaw memory promote --json --limit 20
=> candidates: 0, applied: null

openclaw memory promote --json --limit 20 --min-recall-count 1 --min-unique-queries 1 --min-score 0
=> candidates: 20, applied: null
```

## Notes

- `pnpm install --frozen-lockfile` failed in a fresh clone because pnpm reported an overrides/lockfile config mismatch. I used `pnpm install --no-frozen-lockfile` for local verification and reverted the lockfile noise before committing.
- Broad `pnpm tsgo:test:extensions` and direct `tsc -p extensions/memory-core/tsconfig.json --noEmit` are blocked in this fresh clone by missing/generated SDK and optional extension type packages unrelated to this diff (for example `@github/copilot-sdk`, AWS SDK packages, `discord-api-types`, `baileys`, and `openclaw/plugin-sdk/*` generated subpaths).
