### PR TITLE
fix(fal): route grok-imagine and nano-banana-2-lite edits to correct endpoints

### DIFF
--- a/extensions/fal/image-generation-provider.test.ts
+++ b/extensions/fal/image-generation-provider.test.ts
@@ -44,6 +44,23 @@ describe("fal image-generation provider", () => {
     vi.restoreAllMocks();
   });
 
+  it("publishes model-specific Grok and Nano Banana 2 Lite geometry", () => {
+    const geometry = buildFalImageGenerationProvider().capabilities.geometry;
+    const grokRatios = geometry?.aspectRatiosByModel?.["xai/grok-imagine-image"];
+    const grokResolutions = geometry?.resolutionsByModel?.["xai/grok-imagine-image"];
+    const nanoResolutions = geometry?.resolutionsByModel?.["google/nano-banana-2-lite"];
+
+    expect(grokRatios).toContain("2:1");
+    expect(grokRatios).toContain("20:9");
+    expect(grokResolutions).toEqual(["1K", "2K"]);
+    expect(geometry?.aspectRatiosByModel?.["xai/grok-imagine-image/edit"]).toEqual(grokRatios);
+    expect(geometry?.resolutionsByModel?.["xai/grok-imagine-image/quality/edit"]).toEqual(
+      grokResolutions,
+    );
+    expect(nanoResolutions).toEqual([]);
+    expect(geometry?.resolutionsByModel?.["google/nano-banana-2-lite/edit"]).toEqual([]);
+  });
+
   it("generates image buffers from the fal sync API", async () => {
     vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
       apiKey: "fal-test-key",

--- a/extensions/fal/image-generation-provider.test.ts
+++ b/extensions/fal/image-generation-provider.test.ts
@@ -53,6 +53,8 @@ describe("fal image-generation provider", () => {
 
     expect(grokRatios).toContain("2:1");
     expect(grokRatios).toContain("20:9");
+    expect(geometry?.aspectRatiosByModel?.["fal-ai/nano-banana"]).toContain("21:9");
+    expect(geometry?.aspectRatiosByModel?.["fal-ai/nano-banana"]).not.toContain("4:1");
     expect(grokResolutions).toEqual(["1K", "2K"]);
     expect(geometry?.aspectRatiosByModel?.["xai/grok-imagine-image/edit"]).toEqual(grokRatios);
     expect(geometry?.resolutionsByModel?.["xai/grok-imagine-image/quality/edit"]).toEqual(
@@ -61,10 +63,11 @@ describe("fal image-generation provider", () => {
     expect(nanoResolutions).toEqual([]);
     expect(geometry?.resolutionsByModel?.["google/nano-banana-2-lite/edit"]).toEqual([]);
     expect(edit.maxInputImages).toBe(1);
-    expect(edit.maxInputImagesByModel?.["google/nano-banana-2-lite"]).toBe(14);
-    expect(edit.maxInputImagesByModel?.["xai/grok-imagine-image"]).toBe(3);
-    expect(edit.maxInputImagesByModel?.["xai/grok-imagine-image/quality"]).toBe(3);
-    expect(edit.maxInputImagesByModel?.["openai/gpt-image-2/edit"]).toBe(10);
+    expect(edit.maxInputImagesByModel?.["fal-ai/nano-banana"]).toBe(3);
+    expect(edit.maxInputImagesByModelPrefix?.["fal-ai/nano-banana-"]).toBe(14);
+    expect(edit.maxInputImagesByModelPrefix?.["google/nano-banana-2-lite"]).toBe(14);
+    expect(edit.maxInputImagesByModelPrefix?.["xai/grok-imagine-image"]).toBe(3);
+    expect(edit.maxInputImagesByModelPrefix?.["openai/gpt-image-"]).toBe(10);
     expect(geometry?.resolutionsByModel?.["xai/grok-imagine-image/quality"]).toEqual(
       grokResolutions,
     );
@@ -505,7 +508,10 @@ describe("fal image-generation provider", () => {
     });
   });
 
-  it("routes Nano Banana 2 edits through /edit with NB2 geometry", async () => {
+  it.each([
+    { model: "fal-ai/nano-banana", resolution: undefined },
+    { model: "fal-ai/nano-banana-2", resolution: "2K" as const },
+  ])("routes $model edits through /edit with model geometry", async ({ model, resolution }) => {
     vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
       apiKey: "fal-test-key",
       source: "env",
@@ -536,11 +542,11 @@ describe("fal image-generation provider", () => {
     const provider = buildFalImageGenerationProvider();
     await provider.generateImage({
       provider: "fal",
-      model: "fal-ai/nano-banana-2",
+      model,
       prompt: "blend these references",
       cfg: {},
       aspectRatio: "9:16",
-      resolution: "2K",
+      ...(resolution ? { resolution } : {}),
       inputImages: [
         { buffer: Buffer.from("first"), mimeType: "image/png" },
         { buffer: Buffer.from("second"), mimeType: "image/png" },
@@ -549,11 +555,11 @@ describe("fal image-generation provider", () => {
 
     expectFalJsonPost({
       call: 1,
-      url: "https://fal.run/fal-ai/nano-banana-2/edit",
+      url: `https://fal.run/${model}/edit`,
       body: {
         prompt: "blend these references",
         aspect_ratio: "9:16",
-        resolution: "2K",
+        ...(resolution ? { resolution } : {}),
         num_images: 1,
         output_format: "png",
         image_urls: [
@@ -564,7 +570,18 @@ describe("fal image-generation provider", () => {
     });
   });
 
-  it("rejects Nano Banana 2 edits above 14 reference images", async () => {
+  it.each([
+    {
+      model: "fal-ai/nano-banana",
+      inputCount: 4,
+      error: "fal Nano Banana supports at most 3 reference images",
+    },
+    {
+      model: "fal-ai/nano-banana-2",
+      inputCount: 15,
+      error: "fal Nano Banana 2 supports at most 14 reference images",
+    },
+  ])("rejects $model edits above its reference limit", async ({ model, inputCount, error }) => {
     vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
       apiKey: "fal-test-key",
       source: "env",
@@ -576,15 +593,15 @@ describe("fal image-generation provider", () => {
     await expect(
       provider.generateImage({
         provider: "fal",
-        model: "fal-ai/nano-banana-2",
+        model,
         prompt: "too many references",
         cfg: {},
-        inputImages: Array.from({ length: 15 }, () => ({
+        inputImages: Array.from({ length: inputCount }, () => ({
           buffer: Buffer.from("ref"),
           mimeType: "image/png",
         })),
       }),
-    ).rejects.toThrow("fal Nano Banana 2 supports at most 14 reference images");
+    ).rejects.toThrow(error);
     expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
   });
 

--- a/extensions/fal/image-generation-provider.test.ts
+++ b/extensions/fal/image-generation-provider.test.ts
@@ -661,81 +661,31 @@ describe("fal image-generation provider", () => {
     expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
   });
 
-  it("forwards the 1K resolution for Nano Banana 2 Lite edits", async () => {
-    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
-      apiKey: "fal-test-key",
-      source: "env",
-      mode: "api-key",
-    });
-    setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
-    fetchWithSsrFGuardMock
-      .mockResolvedValueOnce({
-        response: new Response(
-          JSON.stringify({
-            images: [{ url: "https://v3.fal.media/files/example/nb2-lite-1k.png" }],
-          }),
-          {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          },
-        ),
-        release: vi.fn(async () => {}),
-      })
-      .mockResolvedValueOnce({
-        response: new Response(Buffer.from("nb2-lite-1k-data"), {
-          status: 200,
-          headers: { "content-type": "image/png" },
-        }),
-        release: vi.fn(async () => {}),
+  it.each(["1K", "2K", "4K"] as const)(
+    "rejects %s resolution overrides for Nano Banana 2 Lite",
+    async (resolution) => {
+      vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
+        apiKey: "fal-test-key",
+        source: "env",
+        mode: "api-key",
       });
+      setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
 
-    const provider = buildFalImageGenerationProvider();
-    await provider.generateImage({
-      provider: "fal",
-      model: "google/nano-banana-2-lite",
-      prompt: "1K resolution",
-      cfg: {},
-      aspectRatio: "1:1",
-      resolution: "1K",
-      inputImages: [{ buffer: Buffer.from("src"), mimeType: "image/png" }],
-    });
-
-    expectFalJsonPost({
-      call: 1,
-      url: "https://fal.run/google/nano-banana-2-lite/edit",
-      body: {
-        prompt: "1K resolution",
-        aspect_ratio: "1:1",
-        resolution: "1K",
-        num_images: 1,
-        output_format: "png",
-        image_urls: [`data:image/png;base64,${Buffer.from("src").toString("base64")}`],
-      },
-    });
-  });
-
-  it("rejects 2K/4K resolution overrides for Nano Banana 2 Lite edits", async () => {
-    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
-      apiKey: "fal-test-key",
-      source: "env",
-      mode: "api-key",
-    });
-    setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
-
-    const provider = buildFalImageGenerationProvider();
-    await expect(
-      provider.generateImage({
-        provider: "fal",
-        model: "google/nano-banana-2-lite",
-        prompt: "resolution too high",
-        cfg: {},
-        aspectRatio: "1:1",
-        resolution: "2K",
-        inputImages: [{ buffer: Buffer.from("src"), mimeType: "image/png" }],
-      }),
-    ).rejects.toThrow("fal Nano Banana 2 Lite supports resolution values: 1K");
-    expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
-  });
+      const provider = buildFalImageGenerationProvider();
+      await expect(
+        provider.generateImage({
+          provider: "fal",
+          model: "google/nano-banana-2-lite",
+          prompt: "unsupported resolution",
+          cfg: {},
+          aspectRatio: "1:1",
+          resolution,
+          inputImages: [{ buffer: Buffer.from("src"), mimeType: "image/png" }],
+        }),
+      ).rejects.toThrow("fal Nano Banana 2 Lite does not support resolution overrides");
+      expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
+    },
+  );
 
   it("rejects Nano Banana 2 Lite edits above 14 reference images", async () => {
     vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
@@ -761,7 +711,78 @@ describe("fal image-generation provider", () => {
     expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
   });
 
-  it("routes Grok Imagine edits through /quality/edit with lowercase resolution", async () => {
+  it.each([
+    {
+      label: "Nano Banana 2 Lite",
+      model: "google/nano-banana-2-lite",
+      aspectRatio: "3:2",
+      resolution: undefined,
+      expectedBody: {
+        prompt: "generate without references",
+        aspect_ratio: "3:2",
+        num_images: 1,
+        output_format: "png",
+      },
+    },
+    {
+      label: "Grok Imagine",
+      model: "xai/grok-imagine-image",
+      aspectRatio: "16:9",
+      resolution: "2K" as const,
+      expectedBody: {
+        prompt: "generate without references",
+        aspect_ratio: "16:9",
+        resolution: "2k",
+        num_images: 1,
+        output_format: "png",
+      },
+    },
+  ])("keeps $label text-to-image on its base endpoint", async (testCase) => {
+    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
+      apiKey: "fal-test-key",
+      source: "env",
+      mode: "api-key",
+    });
+    setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
+    fetchWithSsrFGuardMock
+      .mockResolvedValueOnce({
+        response: new Response(
+          JSON.stringify({
+            images: [{ url: "https://v3.fal.media/files/example/generated.png" }],
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+        release: vi.fn(async () => {}),
+      })
+      .mockResolvedValueOnce({
+        response: new Response(Buffer.from("generated-data"), {
+          status: 200,
+          headers: { "content-type": "image/png" },
+        }),
+        release: vi.fn(async () => {}),
+      });
+
+    const provider = buildFalImageGenerationProvider();
+    await provider.generateImage({
+      provider: "fal",
+      model: testCase.model,
+      prompt: "generate without references",
+      cfg: {},
+      aspectRatio: testCase.aspectRatio,
+      resolution: testCase.resolution,
+    });
+
+    expectFalJsonPost({
+      call: 1,
+      url: `https://fal.run/${testCase.model}`,
+      body: testCase.expectedBody,
+    });
+  });
+
+  it("routes Grok Imagine edits through /edit with lowercase resolution", async () => {
     vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
       apiKey: "fal-test-key",
       source: "env",
@@ -802,7 +823,7 @@ describe("fal image-generation provider", () => {
 
     expectFalJsonPost({
       call: 1,
-      url: "https://fal.run/xai/grok-imagine-image/quality/edit",
+      url: "https://fal.run/xai/grok-imagine-image/edit",
       body: {
         prompt: "make it more realistic",
         aspect_ratio: "16:9",

--- a/extensions/fal/image-generation-provider.test.ts
+++ b/extensions/fal/image-generation-provider.test.ts
@@ -60,7 +60,14 @@ describe("fal image-generation provider", () => {
     );
     expect(nanoResolutions).toEqual([]);
     expect(geometry?.resolutionsByModel?.["google/nano-banana-2-lite/edit"]).toEqual([]);
-    expect(edit.maxInputImages).toBe(14);
+    expect(edit.maxInputImages).toBe(1);
+    expect(edit.maxInputImagesByModel?.["google/nano-banana-2-lite"]).toBe(14);
+    expect(edit.maxInputImagesByModel?.["xai/grok-imagine-image"]).toBe(3);
+    expect(edit.maxInputImagesByModel?.["xai/grok-imagine-image/quality"]).toBe(3);
+    expect(edit.maxInputImagesByModel?.["openai/gpt-image-2/edit"]).toBe(10);
+    expect(geometry?.resolutionsByModel?.["xai/grok-imagine-image/quality"]).toEqual(
+      grokResolutions,
+    );
   });
 
   it("generates image buffers from the fal sync API", async () => {

--- a/extensions/fal/image-generation-provider.test.ts
+++ b/extensions/fal/image-generation-provider.test.ts
@@ -46,6 +46,7 @@ describe("fal image-generation provider", () => {
 
   it("publishes model-specific Grok and Nano Banana 2 Lite geometry", () => {
     const geometry = buildFalImageGenerationProvider().capabilities.geometry;
+    const edit = buildFalImageGenerationProvider().capabilities.edit;
     const grokRatios = geometry?.aspectRatiosByModel?.["xai/grok-imagine-image"];
     const grokResolutions = geometry?.resolutionsByModel?.["xai/grok-imagine-image"];
     const nanoResolutions = geometry?.resolutionsByModel?.["google/nano-banana-2-lite"];
@@ -59,6 +60,7 @@ describe("fal image-generation provider", () => {
     );
     expect(nanoResolutions).toEqual([]);
     expect(geometry?.resolutionsByModel?.["google/nano-banana-2-lite/edit"]).toEqual([]);
+    expect(edit.maxInputImages).toBe(14);
   });
 
   it("generates image buffers from the fal sync API", async () => {

--- a/extensions/fal/image-generation-provider.test.ts
+++ b/extensions/fal/image-generation-provider.test.ts
@@ -583,6 +583,354 @@ describe("fal image-generation provider", () => {
     expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
   });
 
+  it("routes Nano Banana 2 Lite edits through /edit with image_urls", async () => {
+    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
+      apiKey: "fal-test-key",
+      source: "env",
+      mode: "api-key",
+    });
+    setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
+    fetchWithSsrFGuardMock
+      .mockResolvedValueOnce({
+        response: new Response(
+          JSON.stringify({
+            images: [{ url: "https://v3.fal.media/files/example/nb2-lite-edited.png" }],
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+        release: vi.fn(async () => {}),
+      })
+      .mockResolvedValueOnce({
+        response: new Response(Buffer.from("nb2-lite-edited-data"), {
+          status: 200,
+          headers: { "content-type": "image/png" },
+        }),
+        release: vi.fn(async () => {}),
+      });
+
+    const provider = buildFalImageGenerationProvider();
+    await provider.generateImage({
+      provider: "fal",
+      model: "google/nano-banana-2-lite",
+      prompt: "drive the man down the coastline",
+      cfg: {},
+      aspectRatio: "3:2",
+      inputImages: [
+        { buffer: Buffer.from("first"), mimeType: "image/png" },
+        { buffer: Buffer.from("second"), mimeType: "image/png" },
+      ],
+    });
+
+    expectFalJsonPost({
+      call: 1,
+      url: "https://fal.run/google/nano-banana-2-lite/edit",
+      body: {
+        prompt: "drive the man down the coastline",
+        aspect_ratio: "3:2",
+        num_images: 1,
+        output_format: "png",
+        image_urls: [
+          `data:image/png;base64,${Buffer.from("first").toString("base64")}`,
+          `data:image/png;base64,${Buffer.from("second").toString("base64")}`,
+        ],
+      },
+    });
+  });
+
+  it("rejects Krea-only aspect ratios for Nano Banana 2 Lite", async () => {
+    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
+      apiKey: "fal-test-key",
+      source: "env",
+      mode: "api-key",
+    });
+    setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
+
+    const provider = buildFalImageGenerationProvider();
+    await expect(
+      provider.generateImage({
+        provider: "fal",
+        model: "google/nano-banana-2-lite",
+        prompt: "unsupported ratio",
+        cfg: {},
+        aspectRatio: "2.35:1",
+      }),
+    ).rejects.toThrow("fal Nano Banana 2 Lite supports aspectRatio values");
+    expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
+  });
+
+  it("forwards the 1K resolution for Nano Banana 2 Lite edits", async () => {
+    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
+      apiKey: "fal-test-key",
+      source: "env",
+      mode: "api-key",
+    });
+    setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
+    fetchWithSsrFGuardMock
+      .mockResolvedValueOnce({
+        response: new Response(
+          JSON.stringify({
+            images: [{ url: "https://v3.fal.media/files/example/nb2-lite-1k.png" }],
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+        release: vi.fn(async () => {}),
+      })
+      .mockResolvedValueOnce({
+        response: new Response(Buffer.from("nb2-lite-1k-data"), {
+          status: 200,
+          headers: { "content-type": "image/png" },
+        }),
+        release: vi.fn(async () => {}),
+      });
+
+    const provider = buildFalImageGenerationProvider();
+    await provider.generateImage({
+      provider: "fal",
+      model: "google/nano-banana-2-lite",
+      prompt: "1K resolution",
+      cfg: {},
+      aspectRatio: "1:1",
+      resolution: "1K",
+      inputImages: [{ buffer: Buffer.from("src"), mimeType: "image/png" }],
+    });
+
+    expectFalJsonPost({
+      call: 1,
+      url: "https://fal.run/google/nano-banana-2-lite/edit",
+      body: {
+        prompt: "1K resolution",
+        aspect_ratio: "1:1",
+        resolution: "1K",
+        num_images: 1,
+        output_format: "png",
+        image_urls: [`data:image/png;base64,${Buffer.from("src").toString("base64")}`],
+      },
+    });
+  });
+
+  it("rejects 2K/4K resolution overrides for Nano Banana 2 Lite edits", async () => {
+    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
+      apiKey: "fal-test-key",
+      source: "env",
+      mode: "api-key",
+    });
+    setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
+
+    const provider = buildFalImageGenerationProvider();
+    await expect(
+      provider.generateImage({
+        provider: "fal",
+        model: "google/nano-banana-2-lite",
+        prompt: "resolution too high",
+        cfg: {},
+        aspectRatio: "1:1",
+        resolution: "2K",
+        inputImages: [{ buffer: Buffer.from("src"), mimeType: "image/png" }],
+      }),
+    ).rejects.toThrow("fal Nano Banana 2 Lite supports resolution values: 1K");
+    expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects Nano Banana 2 Lite edits above 14 reference images", async () => {
+    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
+      apiKey: "fal-test-key",
+      source: "env",
+      mode: "api-key",
+    });
+    setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
+
+    const provider = buildFalImageGenerationProvider();
+    await expect(
+      provider.generateImage({
+        provider: "fal",
+        model: "google/nano-banana-2-lite",
+        prompt: "too many references",
+        cfg: {},
+        inputImages: Array.from({ length: 15 }, () => ({
+          buffer: Buffer.from("ref"),
+          mimeType: "image/png",
+        })),
+      }),
+    ).rejects.toThrow("fal Nano Banana 2 Lite supports at most 14 reference images");
+    expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
+  });
+
+  it("routes Grok Imagine edits through /quality/edit with lowercase resolution", async () => {
+    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
+      apiKey: "fal-test-key",
+      source: "env",
+      mode: "api-key",
+    });
+    setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
+    fetchWithSsrFGuardMock
+      .mockResolvedValueOnce({
+        response: new Response(
+          JSON.stringify({
+            images: [{ url: "https://v3.fal.media/files/example/grok-edited.png" }],
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+        release: vi.fn(async () => {}),
+      })
+      .mockResolvedValueOnce({
+        response: new Response(Buffer.from("grok-edited-data"), {
+          status: 200,
+          headers: { "content-type": "image/png" },
+        }),
+        release: vi.fn(async () => {}),
+      });
+
+    const provider = buildFalImageGenerationProvider();
+    await provider.generateImage({
+      provider: "fal",
+      model: "xai/grok-imagine-image",
+      prompt: "make it more realistic",
+      cfg: {},
+      aspectRatio: "16:9",
+      resolution: "2K",
+      inputImages: [{ buffer: Buffer.from("source"), mimeType: "image/jpeg" }],
+    });
+
+    expectFalJsonPost({
+      call: 1,
+      url: "https://fal.run/xai/grok-imagine-image/quality/edit",
+      body: {
+        prompt: "make it more realistic",
+        aspect_ratio: "16:9",
+        resolution: "2k",
+        num_images: 1,
+        output_format: "png",
+        image_urls: [`data:image/jpeg;base64,${Buffer.from("source").toString("base64")}`],
+      },
+    });
+  });
+
+  it("rejects 4K resolution for Grok Imagine edits", async () => {
+    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
+      apiKey: "fal-test-key",
+      source: "env",
+      mode: "api-key",
+    });
+    setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
+
+    const provider = buildFalImageGenerationProvider();
+    await expect(
+      provider.generateImage({
+        provider: "fal",
+        model: "xai/grok-imagine-image",
+        prompt: "too big",
+        cfg: {},
+        aspectRatio: "1:1",
+        resolution: "4K",
+        inputImages: [{ buffer: Buffer.from("src"), mimeType: "image/png" }],
+      }),
+    ).rejects.toThrow("fal Grok Imagine supports resolution values: 1K, 2K");
+    expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects Nano Banana ratios for Grok Imagine", async () => {
+    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
+      apiKey: "fal-test-key",
+      source: "env",
+      mode: "api-key",
+    });
+    setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
+
+    const provider = buildFalImageGenerationProvider();
+    await expect(
+      provider.generateImage({
+        provider: "fal",
+        model: "xai/grok-imagine-image",
+        prompt: "unsupported ratio",
+        cfg: {},
+        aspectRatio: "21:9",
+      }),
+    ).rejects.toThrow("fal Grok Imagine supports aspectRatio values");
+    expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects Grok Imagine edits above 3 reference images", async () => {
+    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
+      apiKey: "fal-test-key",
+      source: "env",
+      mode: "api-key",
+    });
+    setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
+
+    const provider = buildFalImageGenerationProvider();
+    await expect(
+      provider.generateImage({
+        provider: "fal",
+        model: "xai/grok-imagine-image",
+        prompt: "too many references",
+        cfg: {},
+        inputImages: Array.from({ length: 4 }, () => ({
+          buffer: Buffer.from("ref"),
+          mimeType: "image/png",
+        })),
+      }),
+    ).rejects.toThrow("fal Grok Imagine supports at most 3 reference images");
+    expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
+  });
+
+  it("preserves an explicit Grok Imagine /quality/edit model path", async () => {
+    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
+      apiKey: "fal-test-key",
+      source: "env",
+      mode: "api-key",
+    });
+    setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
+    fetchWithSsrFGuardMock
+      .mockResolvedValueOnce({
+        response: new Response(
+          JSON.stringify({
+            images: [{ url: "https://v3.fal.media/files/example/grok-explicit.png" }],
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+        release: vi.fn(async () => {}),
+      })
+      .mockResolvedValueOnce({
+        response: new Response(Buffer.from("grok-explicit-data"), {
+          status: 200,
+          headers: { "content-type": "image/png" },
+        }),
+        release: vi.fn(async () => {}),
+      });
+
+    const provider = buildFalImageGenerationProvider();
+    await provider.generateImage({
+      provider: "fal",
+      model: "xai/grok-imagine-image/quality/edit",
+      prompt: "explicit edit endpoint",
+      cfg: {},
+      inputImages: [{ buffer: Buffer.from("source"), mimeType: "image/png" }],
+    });
+
+    expectFalJsonPost({
+      call: 1,
+      url: "https://fal.run/xai/grok-imagine-image/quality/edit",
+      body: {
+        prompt: "explicit edit endpoint",
+        num_images: 1,
+        output_format: "png",
+        image_urls: [`data:image/png;base64,${Buffer.from("source").toString("base64")}`],
+      },
+    });
+  });
+
   it("preserves exact custom Fal edit endpoints", async () => {
     vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
       apiKey: "fal-test-key",

--- a/extensions/fal/image-generation-provider.ts
+++ b/extensions/fal/image-generation-provider.ts
@@ -34,11 +34,12 @@ const DEFAULT_FAL_EDIT_SUBPATH = "image-to-image";
 const FAL_KREA_2_MODEL_PREFIX = "krea/v2/";
 const FAL_KREA_2_MEDIUM_MODEL = "krea/v2/medium/text-to-image";
 const FAL_KREA_2_LARGE_MODEL = "krea/v2/large/text-to-image";
-const FAL_NANO_BANANA_2_MODEL = "fal-ai/nano-banana-2";
+const FAL_NANO_BANANA_MODEL = "fal-ai/nano-banana";
 const FAL_NANO_BANANA_2_LITE_MODEL = "google/nano-banana-2-lite";
 const FAL_GROK_IMAGINE_MODEL = "xai/grok-imagine-image";
 const DEFAULT_OUTPUT_FORMAT = "png";
 const GPT_IMAGE_EDIT_MAX_INPUT_IMAGES = 10;
+const NANO_BANANA_LEGACY_EDIT_MAX_INPUT_IMAGES = 3;
 const NANO_BANANA_EDIT_MAX_INPUT_IMAGES = 14;
 const GROK_IMAGINE_EDIT_MAX_INPUT_IMAGES = 3;
 const KREA_STYLE_REFERENCE_MAX_INPUT_IMAGES = 10;
@@ -74,6 +75,18 @@ const KREA_SUPPORTED_ASPECT_RATIOS = [
   "16:9",
   "2.35:1",
   "4:5",
+  "2:3",
+  "9:16",
+] as const;
+const NANO_BANANA_LEGACY_SUPPORTED_ASPECT_RATIOS = [
+  "21:9",
+  "16:9",
+  "3:2",
+  "4:3",
+  "5:4",
+  "1:1",
+  "4:5",
+  "3:4",
   "2:3",
   "9:16",
 ] as const;
@@ -230,8 +243,22 @@ function resolveFalImageModelSchema(model: string): FalImageModelSchema {
       defaultBody: { creativity: "medium" },
     };
   }
-  if (model.startsWith("openai/gpt-image-") || model.startsWith("fal-ai/nano-banana-")) {
-    const isNanoBanana = model.startsWith("fal-ai/nano-banana-");
+  if (model === FAL_NANO_BANANA_MODEL || model.startsWith(`${FAL_NANO_BANANA_MODEL}/`)) {
+    return {
+      geometry: "native_aspect_ratio",
+      aspectRatios: NANO_BANANA_LEGACY_SUPPORTED_ASPECT_RATIOS,
+      resolutions: [],
+      referenceImages: "image_urls",
+      maxInputImages: NANO_BANANA_LEGACY_EDIT_MAX_INPUT_IMAGES,
+      referenceLimitLabel: "fal Nano Banana",
+      referenceLimitNoun: "reference image",
+      appendEditPath: "edit",
+      supportsCount: true,
+      supportsOutputFormat: true,
+    };
+  }
+  if (model.startsWith("openai/gpt-image-") || model.startsWith(`${FAL_NANO_BANANA_MODEL}-`)) {
+    const isNanoBanana = model.startsWith(`${FAL_NANO_BANANA_MODEL}-`);
     return {
       geometry: isNanoBanana ? "native_aspect_ratio" : "image_size",
       ...(isNanoBanana ? { aspectRatios: NANO_BANANA_SUPPORTED_ASPECT_RATIOS } : {}),
@@ -628,24 +655,15 @@ export function buildFalImageGenerationProvider(): ImageGenerationProvider {
         maxCount: 4,
         maxInputImages: 1,
         maxInputImagesByModel: {
-          "openai/gpt-image-1": GPT_IMAGE_EDIT_MAX_INPUT_IMAGES,
-          "openai/gpt-image-1/edit": GPT_IMAGE_EDIT_MAX_INPUT_IMAGES,
-          "openai/gpt-image-1-mini": GPT_IMAGE_EDIT_MAX_INPUT_IMAGES,
-          "openai/gpt-image-1-mini/edit": GPT_IMAGE_EDIT_MAX_INPUT_IMAGES,
-          "openai/gpt-image-1.5": GPT_IMAGE_EDIT_MAX_INPUT_IMAGES,
-          "openai/gpt-image-1.5/edit": GPT_IMAGE_EDIT_MAX_INPUT_IMAGES,
-          "openai/gpt-image-2": GPT_IMAGE_EDIT_MAX_INPUT_IMAGES,
-          "openai/gpt-image-2/edit": GPT_IMAGE_EDIT_MAX_INPUT_IMAGES,
-          [FAL_KREA_2_MEDIUM_MODEL]: KREA_STYLE_REFERENCE_MAX_INPUT_IMAGES,
-          [FAL_KREA_2_LARGE_MODEL]: KREA_STYLE_REFERENCE_MAX_INPUT_IMAGES,
-          [FAL_NANO_BANANA_2_MODEL]: NANO_BANANA_EDIT_MAX_INPUT_IMAGES,
-          [`${FAL_NANO_BANANA_2_MODEL}/edit`]: NANO_BANANA_EDIT_MAX_INPUT_IMAGES,
+          [FAL_NANO_BANANA_MODEL]: NANO_BANANA_LEGACY_EDIT_MAX_INPUT_IMAGES,
+          [`${FAL_NANO_BANANA_MODEL}/edit`]: NANO_BANANA_LEGACY_EDIT_MAX_INPUT_IMAGES,
+        },
+        maxInputImagesByModelPrefix: {
+          "openai/gpt-image-": GPT_IMAGE_EDIT_MAX_INPUT_IMAGES,
+          [FAL_KREA_2_MODEL_PREFIX]: KREA_STYLE_REFERENCE_MAX_INPUT_IMAGES,
+          [`${FAL_NANO_BANANA_MODEL}-`]: NANO_BANANA_EDIT_MAX_INPUT_IMAGES,
           [FAL_NANO_BANANA_2_LITE_MODEL]: NANO_BANANA_EDIT_MAX_INPUT_IMAGES,
-          [`${FAL_NANO_BANANA_2_LITE_MODEL}/edit`]: NANO_BANANA_EDIT_MAX_INPUT_IMAGES,
           [FAL_GROK_IMAGINE_MODEL]: GROK_IMAGINE_EDIT_MAX_INPUT_IMAGES,
-          [`${FAL_GROK_IMAGINE_MODEL}/edit`]: GROK_IMAGINE_EDIT_MAX_INPUT_IMAGES,
-          [`${FAL_GROK_IMAGINE_MODEL}/quality`]: GROK_IMAGINE_EDIT_MAX_INPUT_IMAGES,
-          [`${FAL_GROK_IMAGINE_MODEL}/quality/edit`]: GROK_IMAGINE_EDIT_MAX_INPUT_IMAGES,
         },
         supportsSize: true,
         supportsAspectRatio: true,
@@ -659,6 +677,8 @@ export function buildFalImageGenerationProvider(): ImageGenerationProvider {
         },
         aspectRatios: [...FAL_SUPPORTED_ASPECT_RATIOS],
         aspectRatiosByModel: {
+          [FAL_NANO_BANANA_MODEL]: [...NANO_BANANA_LEGACY_SUPPORTED_ASPECT_RATIOS],
+          [`${FAL_NANO_BANANA_MODEL}/edit`]: [...NANO_BANANA_LEGACY_SUPPORTED_ASPECT_RATIOS],
           [FAL_NANO_BANANA_2_LITE_MODEL]: [...NANO_BANANA_SUPPORTED_ASPECT_RATIOS],
           [`${FAL_NANO_BANANA_2_LITE_MODEL}/edit`]: [...NANO_BANANA_SUPPORTED_ASPECT_RATIOS],
           [FAL_GROK_IMAGINE_MODEL]: [...GROK_IMAGINE_SUPPORTED_ASPECT_RATIOS],
@@ -670,6 +690,8 @@ export function buildFalImageGenerationProvider(): ImageGenerationProvider {
         resolutionsByModel: {
           [FAL_KREA_2_MEDIUM_MODEL]: [],
           [FAL_KREA_2_LARGE_MODEL]: [],
+          [FAL_NANO_BANANA_MODEL]: [],
+          [`${FAL_NANO_BANANA_MODEL}/edit`]: [],
           [FAL_NANO_BANANA_2_LITE_MODEL]: [],
           [`${FAL_NANO_BANANA_2_LITE_MODEL}/edit`]: [],
           [FAL_GROK_IMAGINE_MODEL]: [...GROK_IMAGINE_SUPPORTED_RESOLUTIONS],

--- a/extensions/fal/image-generation-provider.ts
+++ b/extensions/fal/image-generation-provider.ts
@@ -37,6 +37,7 @@ const FAL_KREA_2_LARGE_MODEL = "krea/v2/large/text-to-image";
 const DEFAULT_OUTPUT_FORMAT = "png";
 const GPT_IMAGE_EDIT_MAX_INPUT_IMAGES = 10;
 const NANO_BANANA_EDIT_MAX_INPUT_IMAGES = 14;
+const GROK_IMAGINE_EDIT_MAX_INPUT_IMAGES = 3;
 const KREA_STYLE_REFERENCE_MAX_INPUT_IMAGES = 10;
 const FAL_OUTPUT_FORMATS = ["png", "jpeg"] as const;
 const FAL_SUPPORTED_SIZES = [
@@ -89,20 +90,39 @@ const NANO_BANANA_SUPPORTED_ASPECT_RATIOS = [
   "8:1",
   "1:8",
 ] as const;
+const GROK_IMAGINE_SUPPORTED_ASPECT_RATIOS = [
+  "2:1",
+  "20:9",
+  "19.5:9",
+  "16:9",
+  "4:3",
+  "3:2",
+  "1:1",
+  "2:3",
+  "3:4",
+  "9:16",
+  "9:19.5",
+  "9:20",
+  "1:2",
+] as const;
+const GROK_IMAGINE_SUPPORTED_RESOLUTIONS: readonly ("1K" | "2K" | "4K")[] = ["1K", "2K"] as const;
 const KREA_CREATIVITY_LEVELS = ["raw", "low", "medium", "high"] as const;
 
 const FAL_IMAGE_MALFORMED_RESPONSE = "fal image generation response malformed";
 const DEFAULT_GENERATED_IMAGE_MAX_BYTES = 6 * 1024 * 1024;
 
 type FalImageSize = string | { width: number; height: number };
+type FalEditEndpointSuffix = "edit" | "image-to-image" | "quality/edit";
 type FalImageModelSchema = {
   geometry: "image_size" | "native_aspect_ratio";
   aspectRatios?: readonly string[];
+  resolutions?: readonly ("1K" | "2K" | "4K")[];
+  resolutionCase?: "lower";
   referenceImages: "image_url" | "image_urls" | "image_style_references";
   maxInputImages: number;
   referenceLimitLabel: string;
   referenceLimitNoun: "reference image" | "style reference";
-  appendEditPath: false | "edit" | "image-to-image";
+  appendEditPath: false | FalEditEndpointSuffix;
   supportsCount: boolean;
   supportsOutputFormat: boolean;
   defaultBody?: Record<string, unknown>;
@@ -178,24 +198,18 @@ function resolveFalNetworkPolicy(params: {
 function ensureFalModelPath(model: string | undefined, hasInputImages: boolean): string {
   const trimmed = model?.trim() || DEFAULT_FAL_IMAGE_MODEL;
   const schema = resolveFalImageModelSchema(trimmed);
-  if (hasInputImages && schema.appendEditPath === false) {
-    return trimmed;
-  }
-  if (!hasInputImages) {
+  if (!hasInputImages || schema.appendEditPath === false) {
     return trimmed;
   }
   if (
+    trimmed.endsWith(`/${schema.appendEditPath}`) ||
     trimmed.endsWith("/edit") ||
     trimmed.endsWith(`/${DEFAULT_FAL_EDIT_SUBPATH}`) ||
     trimmed.includes("/image-to-image/")
   ) {
     return trimmed;
   }
-  // GPT Image 2 and Nano Banana 2 use /edit; Flux uses /image-to-image.
-  if (trimmed.startsWith("openai/gpt-image-") || trimmed.startsWith("fal-ai/nano-banana-")) {
-    return `${trimmed}/edit`;
-  }
-  return `${trimmed}/${DEFAULT_FAL_EDIT_SUBPATH}`;
+  return `${trimmed}/${schema.appendEditPath}`;
 }
 
 function resolveFalImageModelSchema(model: string): FalImageModelSchema {
@@ -225,6 +239,42 @@ function resolveFalImageModelSchema(model: string): FalImageModelSchema {
       referenceLimitLabel: isNanoBanana ? "fal Nano Banana 2" : "fal GPT Image edit",
       referenceLimitNoun: "reference image",
       appendEditPath: "edit",
+      supportsCount: true,
+      supportsOutputFormat: true,
+    };
+  }
+  // Nano Banana 2 Lite (Gemini 3.1 Flash Lite Image) — same aspect_ratio contract
+  // and image_urls reference contract as Nano Banana 2, but the fal endpoint suffix
+  // is /edit (not /image-to-image), and the /edit endpoint accepts only a single
+  // `resolution` value ("1K") — verified against the live fal API on 2026-07-01.
+  if (model.startsWith("google/nano-banana-2-lite")) {
+    return {
+      geometry: "native_aspect_ratio",
+      aspectRatios: NANO_BANANA_SUPPORTED_ASPECT_RATIOS,
+      resolutions: ["1K"],
+      referenceImages: "image_urls",
+      maxInputImages: NANO_BANANA_EDIT_MAX_INPUT_IMAGES,
+      referenceLimitLabel: "fal Nano Banana 2 Lite",
+      referenceLimitNoun: "reference image",
+      appendEditPath: "edit",
+      supportsCount: true,
+      supportsOutputFormat: true,
+    };
+  }
+  // Grok Imagine (xAI) — text-to-image at /xai/grok-imagine-image, edit at
+  // /xai/grok-imagine-image/quality/edit. Accepts up to 3 reference images via
+  // image_urls, aspect_ratio enum, and lowercase resolution enum (1k/2k only).
+  if (model.startsWith("xai/grok-imagine-image")) {
+    return {
+      geometry: "native_aspect_ratio",
+      aspectRatios: GROK_IMAGINE_SUPPORTED_ASPECT_RATIOS,
+      resolutions: GROK_IMAGINE_SUPPORTED_RESOLUTIONS,
+      resolutionCase: "lower",
+      referenceImages: "image_urls",
+      maxInputImages: GROK_IMAGINE_EDIT_MAX_INPUT_IMAGES,
+      referenceLimitLabel: "fal Grok Imagine",
+      referenceLimitNoun: "reference image",
+      appendEditPath: "quality/edit",
       supportsCount: true,
       supportsOutputFormat: true,
     };
@@ -434,7 +484,33 @@ function applyFalImageGeometry(params: {
       params.requestBody.aspect_ratio = nativeAspectRatio;
     }
     if (params.resolution && params.schema.referenceImages === "image_urls") {
-      params.requestBody.resolution = params.resolution;
+      // Schemas may opt in to resolution validation by declaring `resolutions`.
+      // - `resolutions: undefined` (default, e.g. Nano Banana 2): forward the
+      //   uppercase value unchanged, matching legacy behaviour.
+      // - `resolutions: ["1K", "2K"]` with `resolutionCase: "lower"` (Grok
+      //   Imagine): validate against the allowlist and lowercase before
+      //   sending.
+      // - `resolutions: ["1K"]` (Nano Banana 2 Lite): the fal endpoint
+      //   exposes a `resolution` field but only accepts the literal `"1K"`;
+      //   anything else (including `"1k"`, `"2K"`, `"4K"`) returns 422.
+      // - `resolutions: []` (reserved): reject any override entirely.
+      const allowedResolutions = params.schema.resolutions;
+      if (allowedResolutions === undefined) {
+        params.requestBody.resolution = params.resolution;
+      } else if (allowedResolutions.length === 0) {
+        throw new Error(
+          `${params.schema.referenceLimitLabel} does not support resolution overrides`,
+        );
+      } else if (!allowedResolutions.includes(params.resolution)) {
+        throw new Error(
+          `${params.schema.referenceLimitLabel} supports resolution values: ${allowedResolutions.join(", ")}`,
+        );
+      } else {
+        params.requestBody.resolution =
+          params.schema.resolutionCase === "lower"
+            ? params.resolution.toLowerCase()
+            : params.resolution;
+      }
     }
     return;
   }

--- a/extensions/fal/image-generation-provider.ts
+++ b/extensions/fal/image-generation-provider.ts
@@ -112,7 +112,7 @@ const FAL_IMAGE_MALFORMED_RESPONSE = "fal image generation response malformed";
 const DEFAULT_GENERATED_IMAGE_MAX_BYTES = 6 * 1024 * 1024;
 
 type FalImageSize = string | { width: number; height: number };
-type FalEditEndpointSuffix = "edit" | "image-to-image" | "quality/edit";
+type FalEditEndpointSuffix = "edit" | "image-to-image";
 type FalImageModelSchema = {
   geometry: "image_size" | "native_aspect_ratio";
   aspectRatios?: readonly string[];
@@ -243,15 +243,14 @@ function resolveFalImageModelSchema(model: string): FalImageModelSchema {
       supportsOutputFormat: true,
     };
   }
-  // Nano Banana 2 Lite (Gemini 3.1 Flash Lite Image) — same aspect_ratio contract
-  // and image_urls reference contract as Nano Banana 2, but the fal endpoint suffix
-  // is /edit (not /image-to-image), and the /edit endpoint accepts only a single
-  // `resolution` value ("1K") — verified against the live fal API on 2026-07-01.
+  // Nano Banana 2 Lite (Gemini 3.1 Flash Lite Image) uses /edit and the same
+  // aspect_ratio/image_urls contracts as Nano Banana 2. Its published schema
+  // has no resolution field, so explicit resolution overrides fail locally.
   if (model.startsWith("google/nano-banana-2-lite")) {
     return {
       geometry: "native_aspect_ratio",
       aspectRatios: NANO_BANANA_SUPPORTED_ASPECT_RATIOS,
-      resolutions: ["1K"],
+      resolutions: [],
       referenceImages: "image_urls",
       maxInputImages: NANO_BANANA_EDIT_MAX_INPUT_IMAGES,
       referenceLimitLabel: "fal Nano Banana 2 Lite",
@@ -261,9 +260,9 @@ function resolveFalImageModelSchema(model: string): FalImageModelSchema {
       supportsOutputFormat: true,
     };
   }
-  // Grok Imagine (xAI) — text-to-image at /xai/grok-imagine-image, edit at
-  // /xai/grok-imagine-image/quality/edit. Accepts up to 3 reference images via
-  // image_urls, aspect_ratio enum, and lowercase resolution enum (1k/2k only).
+  // Grok Imagine (xAI) — text-to-image at /xai/grok-imagine-image, standard
+  // edits at /xai/grok-imagine-image/edit. Explicit quality/edit model paths
+  // remain unchanged. Accepts up to 3 reference images via image_urls.
   if (model.startsWith("xai/grok-imagine-image")) {
     return {
       geometry: "native_aspect_ratio",
@@ -274,7 +273,7 @@ function resolveFalImageModelSchema(model: string): FalImageModelSchema {
       maxInputImages: GROK_IMAGINE_EDIT_MAX_INPUT_IMAGES,
       referenceLimitLabel: "fal Grok Imagine",
       referenceLimitNoun: "reference image",
-      appendEditPath: "quality/edit",
+      appendEditPath: "edit",
       supportsCount: true,
       supportsOutputFormat: true,
     };
@@ -490,10 +489,8 @@ function applyFalImageGeometry(params: {
       // - `resolutions: ["1K", "2K"]` with `resolutionCase: "lower"` (Grok
       //   Imagine): validate against the allowlist and lowercase before
       //   sending.
-      // - `resolutions: ["1K"]` (Nano Banana 2 Lite): the fal endpoint
-      //   exposes a `resolution` field but only accepts the literal `"1K"`;
-      //   anything else (including `"1k"`, `"2K"`, `"4K"`) returns 422.
-      // - `resolutions: []` (reserved): reject any override entirely.
+      // - `resolutions: []` (Nano Banana 2 Lite): reject overrides when the
+      //   published endpoint schema has no resolution field.
       const allowedResolutions = params.schema.resolutions;
       if (allowedResolutions === undefined) {
         params.requestBody.resolution = params.resolution;

--- a/extensions/fal/image-generation-provider.ts
+++ b/extensions/fal/image-generation-provider.ts
@@ -34,6 +34,7 @@ const DEFAULT_FAL_EDIT_SUBPATH = "image-to-image";
 const FAL_KREA_2_MODEL_PREFIX = "krea/v2/";
 const FAL_KREA_2_MEDIUM_MODEL = "krea/v2/medium/text-to-image";
 const FAL_KREA_2_LARGE_MODEL = "krea/v2/large/text-to-image";
+const FAL_NANO_BANANA_2_MODEL = "fal-ai/nano-banana-2";
 const FAL_NANO_BANANA_2_LITE_MODEL = "google/nano-banana-2-lite";
 const FAL_GROK_IMAGINE_MODEL = "xai/grok-imagine-image";
 const DEFAULT_OUTPUT_FORMAT = "png";
@@ -625,7 +626,27 @@ export function buildFalImageGenerationProvider(): ImageGenerationProvider {
       edit: {
         enabled: true,
         maxCount: 4,
-        maxInputImages: NANO_BANANA_EDIT_MAX_INPUT_IMAGES,
+        maxInputImages: 1,
+        maxInputImagesByModel: {
+          "openai/gpt-image-1": GPT_IMAGE_EDIT_MAX_INPUT_IMAGES,
+          "openai/gpt-image-1/edit": GPT_IMAGE_EDIT_MAX_INPUT_IMAGES,
+          "openai/gpt-image-1-mini": GPT_IMAGE_EDIT_MAX_INPUT_IMAGES,
+          "openai/gpt-image-1-mini/edit": GPT_IMAGE_EDIT_MAX_INPUT_IMAGES,
+          "openai/gpt-image-1.5": GPT_IMAGE_EDIT_MAX_INPUT_IMAGES,
+          "openai/gpt-image-1.5/edit": GPT_IMAGE_EDIT_MAX_INPUT_IMAGES,
+          "openai/gpt-image-2": GPT_IMAGE_EDIT_MAX_INPUT_IMAGES,
+          "openai/gpt-image-2/edit": GPT_IMAGE_EDIT_MAX_INPUT_IMAGES,
+          [FAL_KREA_2_MEDIUM_MODEL]: KREA_STYLE_REFERENCE_MAX_INPUT_IMAGES,
+          [FAL_KREA_2_LARGE_MODEL]: KREA_STYLE_REFERENCE_MAX_INPUT_IMAGES,
+          [FAL_NANO_BANANA_2_MODEL]: NANO_BANANA_EDIT_MAX_INPUT_IMAGES,
+          [`${FAL_NANO_BANANA_2_MODEL}/edit`]: NANO_BANANA_EDIT_MAX_INPUT_IMAGES,
+          [FAL_NANO_BANANA_2_LITE_MODEL]: NANO_BANANA_EDIT_MAX_INPUT_IMAGES,
+          [`${FAL_NANO_BANANA_2_LITE_MODEL}/edit`]: NANO_BANANA_EDIT_MAX_INPUT_IMAGES,
+          [FAL_GROK_IMAGINE_MODEL]: GROK_IMAGINE_EDIT_MAX_INPUT_IMAGES,
+          [`${FAL_GROK_IMAGINE_MODEL}/edit`]: GROK_IMAGINE_EDIT_MAX_INPUT_IMAGES,
+          [`${FAL_GROK_IMAGINE_MODEL}/quality`]: GROK_IMAGINE_EDIT_MAX_INPUT_IMAGES,
+          [`${FAL_GROK_IMAGINE_MODEL}/quality/edit`]: GROK_IMAGINE_EDIT_MAX_INPUT_IMAGES,
+        },
         supportsSize: true,
         supportsAspectRatio: true,
         supportsResolution: true,
@@ -642,6 +663,7 @@ export function buildFalImageGenerationProvider(): ImageGenerationProvider {
           [`${FAL_NANO_BANANA_2_LITE_MODEL}/edit`]: [...NANO_BANANA_SUPPORTED_ASPECT_RATIOS],
           [FAL_GROK_IMAGINE_MODEL]: [...GROK_IMAGINE_SUPPORTED_ASPECT_RATIOS],
           [`${FAL_GROK_IMAGINE_MODEL}/edit`]: [...GROK_IMAGINE_SUPPORTED_ASPECT_RATIOS],
+          [`${FAL_GROK_IMAGINE_MODEL}/quality`]: [...GROK_IMAGINE_SUPPORTED_ASPECT_RATIOS],
           [`${FAL_GROK_IMAGINE_MODEL}/quality/edit`]: [...GROK_IMAGINE_SUPPORTED_ASPECT_RATIOS],
         },
         resolutions: ["1K", "2K", "4K"],
@@ -652,6 +674,7 @@ export function buildFalImageGenerationProvider(): ImageGenerationProvider {
           [`${FAL_NANO_BANANA_2_LITE_MODEL}/edit`]: [],
           [FAL_GROK_IMAGINE_MODEL]: [...GROK_IMAGINE_SUPPORTED_RESOLUTIONS],
           [`${FAL_GROK_IMAGINE_MODEL}/edit`]: [...GROK_IMAGINE_SUPPORTED_RESOLUTIONS],
+          [`${FAL_GROK_IMAGINE_MODEL}/quality`]: [...GROK_IMAGINE_SUPPORTED_RESOLUTIONS],
           [`${FAL_GROK_IMAGINE_MODEL}/quality/edit`]: [...GROK_IMAGINE_SUPPORTED_RESOLUTIONS],
         },
       },

--- a/extensions/fal/image-generation-provider.ts
+++ b/extensions/fal/image-generation-provider.ts
@@ -34,6 +34,8 @@ const DEFAULT_FAL_EDIT_SUBPATH = "image-to-image";
 const FAL_KREA_2_MODEL_PREFIX = "krea/v2/";
 const FAL_KREA_2_MEDIUM_MODEL = "krea/v2/medium/text-to-image";
 const FAL_KREA_2_LARGE_MODEL = "krea/v2/large/text-to-image";
+const FAL_NANO_BANANA_2_LITE_MODEL = "google/nano-banana-2-lite";
+const FAL_GROK_IMAGINE_MODEL = "xai/grok-imagine-image";
 const DEFAULT_OUTPUT_FORMAT = "png";
 const GPT_IMAGE_EDIT_MAX_INPUT_IMAGES = 10;
 const NANO_BANANA_EDIT_MAX_INPUT_IMAGES = 14;
@@ -246,7 +248,7 @@ function resolveFalImageModelSchema(model: string): FalImageModelSchema {
   // Nano Banana 2 Lite (Gemini 3.1 Flash Lite Image) uses /edit and the same
   // aspect_ratio/image_urls contracts as Nano Banana 2. Its published schema
   // has no resolution field, so explicit resolution overrides fail locally.
-  if (model.startsWith("google/nano-banana-2-lite")) {
+  if (model.startsWith(FAL_NANO_BANANA_2_LITE_MODEL)) {
     return {
       geometry: "native_aspect_ratio",
       aspectRatios: NANO_BANANA_SUPPORTED_ASPECT_RATIOS,
@@ -263,7 +265,7 @@ function resolveFalImageModelSchema(model: string): FalImageModelSchema {
   // Grok Imagine (xAI) — text-to-image at /xai/grok-imagine-image, standard
   // edits at /xai/grok-imagine-image/edit. Explicit quality/edit model paths
   // remain unchanged. Accepts up to 3 reference images via image_urls.
-  if (model.startsWith("xai/grok-imagine-image")) {
+  if (model.startsWith(FAL_GROK_IMAGINE_MODEL)) {
     return {
       geometry: "native_aspect_ratio",
       aspectRatios: GROK_IMAGINE_SUPPORTED_ASPECT_RATIOS,
@@ -635,7 +637,23 @@ export function buildFalImageGenerationProvider(): ImageGenerationProvider {
           [FAL_KREA_2_LARGE_MODEL]: [],
         },
         aspectRatios: [...FAL_SUPPORTED_ASPECT_RATIOS],
+        aspectRatiosByModel: {
+          [FAL_NANO_BANANA_2_LITE_MODEL]: [...NANO_BANANA_SUPPORTED_ASPECT_RATIOS],
+          [`${FAL_NANO_BANANA_2_LITE_MODEL}/edit`]: [...NANO_BANANA_SUPPORTED_ASPECT_RATIOS],
+          [FAL_GROK_IMAGINE_MODEL]: [...GROK_IMAGINE_SUPPORTED_ASPECT_RATIOS],
+          [`${FAL_GROK_IMAGINE_MODEL}/edit`]: [...GROK_IMAGINE_SUPPORTED_ASPECT_RATIOS],
+          [`${FAL_GROK_IMAGINE_MODEL}/quality/edit`]: [...GROK_IMAGINE_SUPPORTED_ASPECT_RATIOS],
+        },
         resolutions: ["1K", "2K", "4K"],
+        resolutionsByModel: {
+          [FAL_KREA_2_MEDIUM_MODEL]: [],
+          [FAL_KREA_2_LARGE_MODEL]: [],
+          [FAL_NANO_BANANA_2_LITE_MODEL]: [],
+          [`${FAL_NANO_BANANA_2_LITE_MODEL}/edit`]: [],
+          [FAL_GROK_IMAGINE_MODEL]: [...GROK_IMAGINE_SUPPORTED_RESOLUTIONS],
+          [`${FAL_GROK_IMAGINE_MODEL}/edit`]: [...GROK_IMAGINE_SUPPORTED_RESOLUTIONS],
+          [`${FAL_GROK_IMAGINE_MODEL}/quality/edit`]: [...GROK_IMAGINE_SUPPORTED_RESOLUTIONS],
+        },
       },
       output: {
         formats: [...FAL_OUTPUT_FORMATS],

--- a/extensions/fal/image-generation-provider.ts
+++ b/extensions/fal/image-generation-provider.ts
@@ -625,7 +625,7 @@ export function buildFalImageGenerationProvider(): ImageGenerationProvider {
       edit: {
         enabled: true,
         maxCount: 4,
-        maxInputImages: GPT_IMAGE_EDIT_MAX_INPUT_IMAGES,
+        maxInputImages: NANO_BANANA_EDIT_MAX_INPUT_IMAGES,
         supportsSize: true,
         supportsAspectRatio: true,
         supportsResolution: true,

--- a/src/agents/tools/image-generate-tool.actions.ts
+++ b/src/agents/tools/image-generate-tool.actions.ts
@@ -48,9 +48,9 @@ function listSupportedImageGenerationModes(provider: ImageGenerationProvider): s
 function summarizeImageGenerationCapabilities(provider: ImageGenerationProvider): string {
   const caps: string[] = [];
   if (provider.capabilities.edit.enabled) {
-    const modelLimits = Object.values(
-      provider.capabilities.edit.maxInputImagesByModel ?? {},
-    ).filter((value) => Number.isFinite(value));
+    const modelLimits = Object.values(provider.capabilities.edit.maxInputImagesByModel ?? {})
+      .concat(Object.values(provider.capabilities.edit.maxInputImagesByModelPrefix ?? {}))
+      .filter((value) => Number.isFinite(value));
     const declaredLimits = [
       ...(typeof provider.capabilities.edit.maxInputImages === "number"
         ? [provider.capabilities.edit.maxInputImages]

--- a/src/agents/tools/image-generate-tool.actions.ts
+++ b/src/agents/tools/image-generate-tool.actions.ts
@@ -48,9 +48,18 @@ function listSupportedImageGenerationModes(provider: ImageGenerationProvider): s
 function summarizeImageGenerationCapabilities(provider: ImageGenerationProvider): string {
   const caps: string[] = [];
   if (provider.capabilities.edit.enabled) {
-    const maxRefs = provider.capabilities.edit.maxInputImages;
+    const modelLimits = Object.values(
+      provider.capabilities.edit.maxInputImagesByModel ?? {},
+    ).filter((value) => Number.isFinite(value));
+    const declaredLimits = [
+      ...(typeof provider.capabilities.edit.maxInputImages === "number"
+        ? [provider.capabilities.edit.maxInputImages]
+        : []),
+      ...modelLimits,
+    ];
+    const maxRefs = declaredLimits.length > 0 ? Math.max(...declaredLimits) : undefined;
     caps.push(
-      `editing${typeof maxRefs === "number" ? ` up to ${maxRefs} ref${maxRefs === 1 ? "" : "s"}` : ""}`,
+      `editing${typeof maxRefs === "number" ? ` up to ${maxRefs} ref${maxRefs === 1 ? "" : "s"}` : ""}${modelLimits.length > 0 ? " depending on model" : ""}`,
     );
   }
   if ((provider.capabilities.geometry?.resolutions?.length ?? 0) > 0) {

--- a/src/agents/tools/image-generate-tool.test.ts
+++ b/src/agents/tools/image-generate-tool.test.ts
@@ -260,6 +260,7 @@ function stubEditedImageFlow(params?: { width?: number; height?: number }) {
 function createFalEditProvider(params?: {
   defaultModel?: string;
   maxInputImages?: number;
+  maxInputImagesByModel?: Readonly<Record<string, number>>;
   omitMaxInputImages?: boolean;
   models?: string[];
   supportsAspectRatio?: boolean;
@@ -280,6 +281,9 @@ function createFalEditProvider(params?: {
       edit: {
         enabled: true,
         ...(!params?.omitMaxInputImages ? { maxInputImages: params?.maxInputImages ?? 1 } : {}),
+        ...(params?.maxInputImagesByModel
+          ? { maxInputImagesByModel: params.maxInputImagesByModel }
+          : {}),
         supportsSize: true,
         supportsAspectRatio: params?.supportsAspectRatio ?? false,
         supportsResolution: true,
@@ -1559,15 +1563,32 @@ describe("createImageGenerateTool", () => {
   );
 
   it.each([
-    { model: "fal-ai/nano-banana-2", disablesResolution: false },
-    { model: "google/nano-banana-2-lite", disablesResolution: true },
-  ])("accepts $model edits with up to 14 reference images", async (testCase) => {
-    const { model } = testCase;
+    {
+      model: "fal-ai/nano-banana-2",
+      primaryRef: "fal/fal-ai/nano-banana-2",
+      maxInputImages: 14,
+      disablesResolution: false,
+    },
+    {
+      model: "google/nano-banana-2-lite",
+      primaryRef: "fal/google/nano-banana-2-lite",
+      maxInputImages: 14,
+      disablesResolution: true,
+    },
+    {
+      model: "openai/gpt-image-2/edit",
+      primaryRef: "FAL/openai/gpt-image-2/edit",
+      maxInputImages: 10,
+      disablesResolution: false,
+    },
+  ])("accepts $model edits up to its reference limit", async (testCase) => {
+    const { model, primaryRef, maxInputImages } = testCase;
     vi.spyOn(imageGenerationRuntime, "listRuntimeImageGenerationProviders").mockReturnValue([
       createFalEditProvider({
         defaultModel: model,
         models: [model],
-        maxInputImages: 14,
+        maxInputImages: 1,
+        maxInputImagesByModel: { [model]: maxInputImages },
         ...(testCase.disablesResolution ? { resolutionsByModel: { [model]: [] } } : {}),
       }),
     ]);
@@ -1594,15 +1615,18 @@ describe("createImageGenerateTool", () => {
       contentType: "image/png",
     });
 
-    const tool = createToolWithPrimaryImageModel(`fal/${model}`, {
+    const tool = createToolWithPrimaryImageModel(primaryRef, {
       workspaceDir: process.cwd(),
     });
-    await tool.execute("call-nano-14-references", {
+    await tool.execute("call-model-reference-limit", {
       prompt: "combine references",
-      images: Array.from({ length: 14 }, (_, index) => `./fixtures/ref-${index + 1}.png`),
+      images: Array.from(
+        { length: maxInputImages },
+        (_, index) => `./fixtures/ref-${index + 1}.png`,
+      ),
     });
 
-    expect(mockCallArg(generateImage, 0, "generateImage").inputImages).toHaveLength(14);
+    expect(mockCallArg(generateImage, 0, "generateImage").inputImages).toHaveLength(maxInputImages);
   });
 
   it("keeps the default edit limit at 10 for providers without limit metadata", async () => {
@@ -1623,6 +1647,81 @@ describe("createImageGenerateTool", () => {
     ).rejects.toThrow("fal edit supports at most 10 reference images");
     expect(loadWebMedia).not.toHaveBeenCalled();
     expect(generateImage).not.toHaveBeenCalled();
+  });
+
+  it("rejects model-specific reference limits before loading inputs", async () => {
+    const model = "xai/grok-imagine-image";
+    vi.spyOn(imageGenerationRuntime, "listRuntimeImageGenerationProviders").mockReturnValue([
+      createFalEditProvider({
+        defaultModel: model,
+        models: [model],
+        maxInputImages: 1,
+        maxInputImagesByModel: { [model]: 3 },
+      }),
+    ]);
+    const generateImage = vi.spyOn(imageGenerationRuntime, "generateImage");
+    const loadWebMedia = vi.spyOn(webMedia, "loadWebMedia");
+    const tool = createToolWithPrimaryImageModel(`fal/${model}`, {
+      workspaceDir: process.cwd(),
+    });
+
+    await expect(
+      tool.execute("call-grok-too-many-references", {
+        prompt: "combine references",
+        images: Array.from({ length: 4 }, (_, index) => `./fixtures/ref-${index + 1}.png`),
+      }),
+    ).rejects.toThrow("fal edit supports at most 3 reference images");
+    expect(loadWebMedia).not.toHaveBeenCalled();
+    expect(generateImage).not.toHaveBeenCalled();
+  });
+
+  it("accepts the highest reference limit across configured fallbacks", async () => {
+    const primaryModel = "xai/grok-imagine-image";
+    const fallbackModel = "google/nano-banana-2-lite";
+    vi.spyOn(imageGenerationRuntime, "listRuntimeImageGenerationProviders").mockReturnValue([
+      createFalEditProvider({
+        defaultModel: primaryModel,
+        models: [primaryModel, fallbackModel],
+        maxInputImages: 1,
+        maxInputImagesByModel: {
+          [primaryModel]: 3,
+          [fallbackModel]: 14,
+        },
+      }),
+    ]);
+    const generateImage = vi.spyOn(imageGenerationRuntime, "generateImage").mockResolvedValue({
+      provider: "fal",
+      model: fallbackModel,
+      attempts: [],
+      ignoredOverrides: [],
+      images: [{ buffer: Buffer.from("edited"), mimeType: "image/png" }],
+    });
+    vi.spyOn(webMedia, "loadWebMedia").mockResolvedValue({
+      kind: "image",
+      buffer: Buffer.from("reference"),
+      contentType: "image/png",
+    });
+    vi.spyOn(imageOps, "getImageMetadata").mockResolvedValue({
+      width: 1024,
+      height: 1024,
+    });
+    vi.spyOn(mediaStore, "saveMediaBuffer").mockResolvedValue({
+      path: "/tmp/edited.png",
+      id: "edited.png",
+      size: 6,
+      contentType: "image/png",
+    });
+    const tool = createToolWithPrimaryImageModel(`fal/${primaryModel}`, {
+      workspaceDir: process.cwd(),
+      fallbacks: [`fal/${fallbackModel}`],
+    });
+
+    await tool.execute("call-fallback-reference-limit", {
+      prompt: "combine references",
+      images: Array.from({ length: 14 }, (_, index) => `./fixtures/ref-${index + 1}.png`),
+    });
+
+    expect(mockCallArg(generateImage, 0, "generateImage").inputImages).toHaveLength(14);
   });
 
   it("passes inferred resolution separately when fallbacks have different capabilities", async () => {
@@ -2452,6 +2551,25 @@ describe("createImageGenerateTool", () => {
       supportsResolution: true,
     });
     expect(openaiProvider.authEnvVars).toEqual(["OPENAI_API_KEY"]);
+  });
+
+  it("reports model-specific edit limits in provider listings", async () => {
+    vi.spyOn(imageGenerationRuntime, "listRuntimeImageGenerationProviders").mockReturnValue([
+      createFalEditProvider({
+        defaultModel: "fal-ai/flux/dev",
+        models: ["fal-ai/flux/dev", "google/nano-banana-2-lite"],
+        maxInputImages: 1,
+        maxInputImagesByModel: {
+          "fal-ai/flux/dev": 1,
+          "google/nano-banana-2-lite": 14,
+        },
+      }),
+    ]);
+    const tool = createToolWithPrimaryImageModel("fal/fal-ai/flux/dev");
+
+    const result = await tool.execute("call-list-model-limits", { action: "list" });
+
+    expect(resultText(result)).toContain("editing up to 14 refs depending on model");
   });
 
   it("skips auth hints for prototype-like provider ids", async () => {

--- a/src/agents/tools/image-generate-tool.test.ts
+++ b/src/agents/tools/image-generate-tool.test.ts
@@ -260,6 +260,7 @@ function stubEditedImageFlow(params?: { width?: number; height?: number }) {
 function createFalEditProvider(params?: {
   defaultModel?: string;
   maxInputImages?: number;
+  omitMaxInputImages?: boolean;
   models?: string[];
   supportsAspectRatio?: boolean;
   aspectRatios?: string[];
@@ -278,7 +279,7 @@ function createFalEditProvider(params?: {
       },
       edit: {
         enabled: true,
-        maxInputImages: params?.maxInputImages ?? 1,
+        ...(!params?.omitMaxInputImages ? { maxInputImages: params?.maxInputImages ?? 1 } : {}),
         supportsSize: true,
         supportsAspectRatio: params?.supportsAspectRatio ?? false,
         supportsResolution: true,
@@ -1556,6 +1557,73 @@ describe("createImageGenerateTool", () => {
       expect(generateArgs.inputImages).toHaveLength(1);
     },
   );
+
+  it.each([
+    { model: "fal-ai/nano-banana-2", disablesResolution: false },
+    { model: "google/nano-banana-2-lite", disablesResolution: true },
+  ])("accepts $model edits with up to 14 reference images", async (testCase) => {
+    const { model } = testCase;
+    vi.spyOn(imageGenerationRuntime, "listRuntimeImageGenerationProviders").mockReturnValue([
+      createFalEditProvider({
+        defaultModel: model,
+        models: [model],
+        maxInputImages: 14,
+        ...(testCase.disablesResolution ? { resolutionsByModel: { [model]: [] } } : {}),
+      }),
+    ]);
+    const generateImage = vi.spyOn(imageGenerationRuntime, "generateImage").mockResolvedValue({
+      provider: "fal",
+      model,
+      attempts: [],
+      ignoredOverrides: [],
+      images: [{ buffer: Buffer.from("edited"), mimeType: "image/png" }],
+    });
+    vi.spyOn(webMedia, "loadWebMedia").mockResolvedValue({
+      kind: "image",
+      buffer: Buffer.from("reference"),
+      contentType: "image/png",
+    });
+    vi.spyOn(imageOps, "getImageMetadata").mockResolvedValue({
+      width: 1024,
+      height: 1024,
+    });
+    vi.spyOn(mediaStore, "saveMediaBuffer").mockResolvedValue({
+      path: "/tmp/edited.png",
+      id: "edited.png",
+      size: 6,
+      contentType: "image/png",
+    });
+
+    const tool = createToolWithPrimaryImageModel(`fal/${model}`, {
+      workspaceDir: process.cwd(),
+    });
+    await tool.execute("call-nano-14-references", {
+      prompt: "combine references",
+      images: Array.from({ length: 14 }, (_, index) => `./fixtures/ref-${index + 1}.png`),
+    });
+
+    expect(mockCallArg(generateImage, 0, "generateImage").inputImages).toHaveLength(14);
+  });
+
+  it("keeps the default edit limit at 10 for providers without limit metadata", async () => {
+    vi.spyOn(imageGenerationRuntime, "listRuntimeImageGenerationProviders").mockReturnValue([
+      createFalEditProvider({ omitMaxInputImages: true }),
+    ]);
+    const generateImage = vi.spyOn(imageGenerationRuntime, "generateImage");
+    const loadWebMedia = vi.spyOn(webMedia, "loadWebMedia");
+    const tool = createToolWithPrimaryImageModel("fal/fal-ai/flux/dev", {
+      workspaceDir: process.cwd(),
+    });
+
+    await expect(
+      tool.execute("call-default-reference-limit", {
+        prompt: "combine references",
+        images: Array.from({ length: 11 }, (_, index) => `./fixtures/ref-${index + 1}.png`),
+      }),
+    ).rejects.toThrow("fal edit supports at most 10 reference images");
+    expect(loadWebMedia).not.toHaveBeenCalled();
+    expect(generateImage).not.toHaveBeenCalled();
+  });
 
   it("passes inferred resolution separately when fallbacks have different capabilities", async () => {
     const fallbackModel = "google/nano-banana-2-lite";

--- a/src/agents/tools/image-generate-tool.test.ts
+++ b/src/agents/tools/image-generate-tool.test.ts
@@ -195,9 +195,11 @@ function createToolWithPrimaryImageModel(
   extra?: {
     agentDir?: string;
     workspaceDir?: string;
+    fallbacks?: string[];
   },
 ) {
   ensureDefaultImageGenerationProvidersStubbed();
+  const { fallbacks, ...toolOptions } = extra ?? {};
   return requireImageGenerateTool(
     createImageGenerateTool({
       config: {
@@ -205,16 +207,20 @@ function createToolWithPrimaryImageModel(
           defaults: {
             imageGenerationModel: {
               primary,
+              ...(fallbacks ? { fallbacks } : {}),
             },
           },
         },
       },
-      ...extra,
+      ...toolOptions,
     }),
   );
 }
 
 function stubEditedImageFlow(params?: { width?: number; height?: number }) {
+  const maxDimension = Math.max(params?.width ?? 0, params?.height ?? 0);
+  const appliedResolution =
+    maxDimension >= 3000 ? "4K" : maxDimension >= 1500 ? "2K" : maxDimension > 0 ? "1K" : undefined;
   // Edit tests stub the whole media pipeline so assertions focus on tool input
   // shaping, provider choice, and saved-media metadata.
   const generateImage = vi.spyOn(imageGenerationRuntime, "generateImage").mockResolvedValue({
@@ -222,6 +228,7 @@ function stubEditedImageFlow(params?: { width?: number; height?: number }) {
     model: "gemini-3-pro-image-preview",
     attempts: [],
     ignoredOverrides: [],
+    ...(appliedResolution ? { appliedResolution } : {}),
     images: [
       {
         buffer: Buffer.from("png-out"),
@@ -256,6 +263,7 @@ function createFalEditProvider(params?: {
   models?: string[];
   supportsAspectRatio?: boolean;
   aspectRatios?: string[];
+  resolutionsByModel?: Record<string, ("1K" | "2K" | "4K")[]>;
 }) {
   return {
     id: "fal",
@@ -275,10 +283,13 @@ function createFalEditProvider(params?: {
         supportsAspectRatio: params?.supportsAspectRatio ?? false,
         supportsResolution: true,
       },
-      ...(params?.aspectRatios
+      ...(params?.aspectRatios || params?.resolutionsByModel
         ? {
             geometry: {
-              aspectRatios: params.aspectRatios,
+              ...(params.aspectRatios ? { aspectRatios: params.aspectRatios } : {}),
+              ...(params.resolutionsByModel
+                ? { resolutionsByModel: params.resolutionsByModel }
+                : {}),
             },
           }
         : {}),
@@ -1490,31 +1501,94 @@ describe("createImageGenerateTool", () => {
     expect(generateArgs.aspectRatio).toBe("2.35:1");
   });
 
-  it("does not infer edit resolution for fal Krea style references", async () => {
+  it.each(["krea/v2/medium/text-to-image", "google/nano-banana-2-lite"])(
+    "does not infer edit resolution when %s declares no resolution options",
+    async (model) => {
+      vi.spyOn(imageGenerationRuntime, "listRuntimeImageGenerationProviders").mockReturnValue([
+        createFalEditProvider({
+          defaultModel: model,
+          models: [model],
+          maxInputImages: 10,
+          supportsAspectRatio: true,
+          resolutionsByModel: { [model]: [] },
+        }),
+      ]);
+      const generateImage = vi.spyOn(imageGenerationRuntime, "generateImage").mockResolvedValue({
+        provider: "fal",
+        model,
+        attempts: [],
+        ignoredOverrides: [],
+        images: [
+          {
+            buffer: Buffer.from("krea-style-out"),
+            mimeType: "image/png",
+            fileName: "krea-style.png",
+          },
+        ],
+      });
+      vi.spyOn(webMedia, "loadWebMedia").mockResolvedValue({
+        kind: "image",
+        buffer: Buffer.from("style-ref"),
+        contentType: "image/png",
+      });
+      vi.spyOn(imageOps, "getImageMetadata").mockResolvedValue({
+        width: 2048,
+        height: 2048,
+      });
+      vi.spyOn(mediaStore, "saveMediaBuffer").mockResolvedValue({
+        path: "/tmp/krea-style.png",
+        id: "krea-style.png",
+        size: 14,
+        contentType: "image/png",
+      });
+
+      const tool = createToolWithPrimaryImageModel(`fal/${model}`, {
+        workspaceDir: process.cwd(),
+      });
+      await tool.execute("call-fal-krea-style", {
+        prompt: "Style-directed portrait",
+        image: "./fixtures/style.png",
+      });
+
+      const generateArgs = mockCallArg(generateImage, 0, "generateImage");
+      expect(generateArgs.resolution).toBeUndefined();
+      expect(generateArgs.inferredResolution).toBe("2K");
+      expect(generateArgs.inputImages).toHaveLength(1);
+    },
+  );
+
+  it("passes inferred resolution separately when fallbacks have different capabilities", async () => {
+    const fallbackModel = "google/nano-banana-2-lite";
     vi.spyOn(imageGenerationRuntime, "listRuntimeImageGenerationProviders").mockReturnValue([
+      {
+        id: "google",
+        defaultModel: "gemini-3-pro-image-preview",
+        models: ["gemini-3-pro-image-preview"],
+        capabilities: {
+          generate: { supportsResolution: true },
+          edit: { enabled: true, maxInputImages: 5, supportsResolution: true },
+          geometry: { resolutions: ["1K", "2K", "4K"] },
+        },
+        generateImage: vi.fn(async () => {
+          throw new Error("not used");
+        }),
+      },
       createFalEditProvider({
-        defaultModel: "krea/v2/medium/text-to-image",
-        models: ["krea/v2/medium/text-to-image"],
-        maxInputImages: 10,
-        supportsAspectRatio: true,
+        defaultModel: fallbackModel,
+        models: [fallbackModel],
+        resolutionsByModel: { [fallbackModel]: [] },
       }),
     ]);
     const generateImage = vi.spyOn(imageGenerationRuntime, "generateImage").mockResolvedValue({
-      provider: "fal",
-      model: "krea/v2/medium/text-to-image",
+      provider: "google",
+      model: "gemini-3-pro-image-preview",
       attempts: [],
       ignoredOverrides: [],
-      images: [
-        {
-          buffer: Buffer.from("krea-style-out"),
-          mimeType: "image/png",
-          fileName: "krea-style.png",
-        },
-      ],
+      images: [{ buffer: Buffer.from("edited"), mimeType: "image/png" }],
     });
     vi.spyOn(webMedia, "loadWebMedia").mockResolvedValue({
       kind: "image",
-      buffer: Buffer.from("style-ref"),
+      buffer: Buffer.from("reference"),
       contentType: "image/png",
     });
     vi.spyOn(imageOps, "getImageMetadata").mockResolvedValue({
@@ -1522,23 +1596,57 @@ describe("createImageGenerateTool", () => {
       height: 2048,
     });
     vi.spyOn(mediaStore, "saveMediaBuffer").mockResolvedValue({
-      path: "/tmp/krea-style.png",
-      id: "krea-style.png",
-      size: 14,
+      path: "/tmp/edited.png",
+      id: "edited.png",
+      size: 6,
       contentType: "image/png",
     });
 
-    const tool = createToolWithPrimaryImageModel("fal/krea/v2/medium/text-to-image", {
+    const tool = createToolWithPrimaryImageModel("google/gemini-3-pro-image-preview", {
       workspaceDir: process.cwd(),
+      fallbacks: [`fal/${fallbackModel}`],
     });
-    await tool.execute("call-fal-krea-style", {
-      prompt: "Style-directed portrait",
-      image: "./fixtures/style.png",
+    await tool.execute("call-edit-with-resolutionless-fallback", {
+      prompt: "edit safely across fallbacks",
+      image: "./fixtures/reference.png",
     });
 
     const generateArgs = mockCallArg(generateImage, 0, "generateImage");
     expect(generateArgs.resolution).toBeUndefined();
-    expect(generateArgs.inputImages).toHaveLength(1);
+    expect(generateArgs.inferredResolution).toBe("2K");
+  });
+
+  it("accepts Grok-specific aspect ratios through image_generate", async () => {
+    const model = "xai/grok-imagine-image";
+    vi.spyOn(imageGenerationRuntime, "listRuntimeImageGenerationProviders").mockReturnValue([
+      createFalEditProvider({
+        defaultModel: model,
+        models: [model],
+        supportsAspectRatio: true,
+        aspectRatios: ["1:1", "20:9"],
+      }),
+    ]);
+    const generateImage = vi.spyOn(imageGenerationRuntime, "generateImage").mockResolvedValue({
+      provider: "fal",
+      model,
+      attempts: [],
+      ignoredOverrides: [],
+      images: [{ buffer: Buffer.from("grok-out"), mimeType: "image/png" }],
+    });
+    vi.spyOn(mediaStore, "saveMediaBuffer").mockResolvedValue({
+      path: "/tmp/grok.png",
+      id: "grok.png",
+      size: 8,
+      contentType: "image/png",
+    });
+
+    const tool = createToolWithPrimaryImageModel(`fal/${model}`);
+    await tool.execute("call-fal-grok-aspect", {
+      prompt: "wide landscape",
+      aspectRatio: "20:9",
+    });
+
+    expect(mockCallArg(generateImage, 0, "generateImage").aspectRatio).toBe("20:9");
   });
 
   it.each([60.5, "60px", null])("rejects malformed OpenAI output compression %s", async (value) => {
@@ -1779,14 +1887,16 @@ describe("createImageGenerateTool", () => {
       workspaceDir: process.cwd(),
     });
 
-    await tool.execute("call-edit", {
+    const result = await tool.execute("call-edit", {
       prompt: "Add a dramatic stormy sky but keep everything else identical.",
       image: "./fixtures/reference.png",
     });
 
     const generateArgs = mockCallArg(generateImage, 0, "generateImage");
     expect(generateArgs.aspectRatio).toBeUndefined();
-    expect(generateArgs.resolution).toBe("4K");
+    expect(generateArgs.resolution).toBeUndefined();
+    expect(generateArgs.inferredResolution).toBe("4K");
+    expect(resultDetails(result).resolution).toBe("4K");
     expect(generateArgs.inputImages).toEqual([
       {
         buffer: Buffer.from("input-image"),
@@ -1977,6 +2087,7 @@ describe("createImageGenerateTool", () => {
     const generateArgs = mockCallArg(generateImage, 0, "generateImage");
     expect(generateArgs.modelOverride).toBeUndefined();
     expect(generateArgs.resolution).toBeUndefined();
+    expect(generateArgs.inferredResolution).toBe("4K");
     expect(generateArgs.inputImages).toEqual([
       {
         buffer: Buffer.from("input-image"),
@@ -2219,7 +2330,7 @@ describe("createImageGenerateTool", () => {
     await expect(
       tool.execute("call-bad-aspect", { prompt: "portrait", aspectRatio: "7:5" }),
     ).rejects.toThrow(
-      "aspectRatio must be one of 1:1, 2:3, 3:2, 2.35:1, 3:4, 4:3, 4:5, 5:4, 9:16, 16:9, 21:9, 4:1, 1:4, 8:1, or 1:8",
+      "aspectRatio must be one of 1:1, 2:1, 20:9, 19.5:9, 2:3, 3:2, 2.35:1, 3:4, 4:3, 4:5, 5:4, 9:16, 9:19.5, 9:20, 16:9, 21:9, 1:2, 4:1, 1:4, 8:1, or 1:8",
     );
   });
 

--- a/src/agents/tools/image-generate-tool.test.ts
+++ b/src/agents/tools/image-generate-tool.test.ts
@@ -261,6 +261,7 @@ function createFalEditProvider(params?: {
   defaultModel?: string;
   maxInputImages?: number;
   maxInputImagesByModel?: Readonly<Record<string, number>>;
+  maxInputImagesByModelPrefix?: Readonly<Record<string, number>>;
   omitMaxInputImages?: boolean;
   models?: string[];
   supportsAspectRatio?: boolean;
@@ -283,6 +284,9 @@ function createFalEditProvider(params?: {
         ...(!params?.omitMaxInputImages ? { maxInputImages: params?.maxInputImages ?? 1 } : {}),
         ...(params?.maxInputImagesByModel
           ? { maxInputImagesByModel: params.maxInputImagesByModel }
+          : {}),
+        ...(params?.maxInputImagesByModelPrefix
+          ? { maxInputImagesByModelPrefix: params.maxInputImagesByModelPrefix }
           : {}),
         supportsSize: true,
         supportsAspectRatio: params?.supportsAspectRatio ?? false,
@@ -1579,6 +1583,7 @@ describe("createImageGenerateTool", () => {
       model: "openai/gpt-image-2/edit",
       primaryRef: "FAL/openai/gpt-image-2/edit",
       maxInputImages: 10,
+      limitPrefix: "openai/gpt-image-",
       disablesResolution: false,
     },
   ])("accepts $model edits up to its reference limit", async (testCase) => {
@@ -1588,7 +1593,9 @@ describe("createImageGenerateTool", () => {
         defaultModel: model,
         models: [model],
         maxInputImages: 1,
-        maxInputImagesByModel: { [model]: maxInputImages },
+        ...(testCase.limitPrefix
+          ? { maxInputImagesByModelPrefix: { [testCase.limitPrefix]: maxInputImages } }
+          : { maxInputImagesByModel: { [model]: maxInputImages } }),
         ...(testCase.disablesResolution ? { resolutionsByModel: { [model]: [] } } : {}),
       }),
     ]);
@@ -2559,9 +2566,9 @@ describe("createImageGenerateTool", () => {
         defaultModel: "fal-ai/flux/dev",
         models: ["fal-ai/flux/dev", "google/nano-banana-2-lite"],
         maxInputImages: 1,
-        maxInputImagesByModel: {
+        maxInputImagesByModelPrefix: {
           "fal-ai/flux/dev": 1,
-          "google/nano-banana-2-lite": 14,
+          "google/nano-banana": 14,
         },
       }),
     ]);

--- a/src/agents/tools/image-generate-tool.ts
+++ b/src/agents/tools/image-generate-tool.ts
@@ -118,6 +118,9 @@ const SUPPORTED_FAL_CREATIVITY = ["raw", "low", "medium", "high"] as const;
 type FalCreativity = (typeof SUPPORTED_FAL_CREATIVITY)[number];
 const SUPPORTED_ASPECT_RATIOS = new Set([
   "1:1",
+  "2:1",
+  "20:9",
+  "19.5:9",
   "2:3",
   "3:2",
   "2.35:1",
@@ -126,8 +129,11 @@ const SUPPORTED_ASPECT_RATIOS = new Set([
   "4:5",
   "5:4",
   "9:16",
+  "9:19.5",
+  "9:20",
   "16:9",
   "21:9",
+  "1:2",
   "4:1",
   "1:4",
   "8:1",
@@ -172,7 +178,7 @@ const ImageGenerateToolSchema = Type.Object({
   aspectRatio: Type.Optional(
     Type.String({
       description:
-        "Aspect ratio: 1:1, 2:3, 3:2, 2.35:1, 3:4, 4:3, 4:5, 5:4, 9:16, 16:9, 21:9, 4:1, 1:4, 8:1, 1:8.",
+        "Aspect ratio: 1:1, 2:1, 20:9, 19.5:9, 2:3, 3:2, 2.35:1, 3:4, 4:3, 4:5, 5:4, 9:16, 9:19.5, 9:20, 16:9, 21:9, 1:2, 4:1, 1:4, 8:1, 1:8.",
     }),
   ),
   resolution: Type.Optional(
@@ -298,7 +304,7 @@ function normalizeAspectRatio(raw: string | undefined): string | undefined {
     return normalized;
   }
   throw new ToolInputError(
-    "aspectRatio must be one of 1:1, 2:3, 3:2, 2.35:1, 3:4, 4:3, 4:5, 5:4, 9:16, 16:9, 21:9, 4:1, 1:4, 8:1, or 1:8",
+    "aspectRatio must be one of 1:1, 2:1, 20:9, 19.5:9, 2:3, 3:2, 2.35:1, 3:4, 4:3, 4:5, 5:4, 9:16, 9:19.5, 9:20, 16:9, 21:9, 1:2, 4:1, 1:4, 8:1, or 1:8",
   );
 }
 
@@ -424,12 +430,12 @@ function normalizeReferenceImages(args: Record<string, unknown>): string[] {
 }
 
 function resolveSelectedImageGenerationProvider(params: {
-  config?: OpenClawConfig;
+  providers: ImageGenerationProvider[];
   imageGenerationModelConfig: ToolModelConfig;
   modelOverride?: string;
 }): ImageGenerationProvider | undefined {
   return resolveSelectedCapabilityProvider({
-    providers: listRuntimeImageGenerationProviders({ config: params.config }),
+    providers: params.providers,
     modelConfig: params.imageGenerationModelConfig,
     modelOverride: params.modelOverride,
     parseModelRef: parseImageGenerationModelRef,
@@ -461,8 +467,14 @@ function resolveSelectedImageGenerationModelId(params: {
   return params.imageGenerationModelConfig.primary ?? params.selectedProvider?.defaultModel;
 }
 
-function isFalKreaImageModel(provider: ImageGenerationProvider | undefined, modelId?: string) {
-  return provider?.id === "fal" && modelId?.startsWith("krea/v2/") === true;
+function modelDisablesImageResolution(
+  provider: ImageGenerationProvider | undefined,
+  modelId?: string,
+) {
+  if (!provider || !modelId) {
+    return false;
+  }
+  return provider.capabilities.geometry?.resolutionsByModel?.[modelId]?.length === 0;
 }
 
 function formatIgnoredImageGenerationOverride(override: ImageGenerationIgnoredOverride): string {
@@ -508,6 +520,7 @@ function validateImageGenerationCapabilities(params: {
   size?: string;
   aspectRatio?: string;
   resolution?: ImageGenerationResolution;
+  inferredResolution?: ImageGenerationResolution;
   explicitResolution?: boolean;
 }) {
   const provider = params.provider;
@@ -693,6 +706,7 @@ async function executeImageGenerationJob(params: {
   size?: string;
   aspectRatio?: string;
   resolution?: ImageGenerationResolution;
+  inferredResolution?: ImageGenerationResolution;
   quality?: ImageGenerationQuality;
   outputFormat?: ImageGenerationOutputFormat;
   background?: ImageGenerationBackground;
@@ -721,6 +735,7 @@ async function executeImageGenerationJob(params: {
     size: params.size,
     aspectRatio: params.aspectRatio,
     resolution: params.resolution,
+    inferredResolution: params.inferredResolution,
     quality: params.quality,
     outputFormat: params.outputFormat,
     background: params.background,
@@ -760,6 +775,7 @@ async function executeImageGenerationJob(params: {
     result.metadata.normalizedResolution.trim()
       ? result.metadata.normalizedResolution
       : undefined);
+  const appliedResolution = result.appliedResolution ?? normalizedResolution;
   const sizeTranslatedToAspectRatio =
     result.normalization?.aspectRatio?.derivedFrom === "size" ||
     (!normalizedSize &&
@@ -820,9 +836,7 @@ async function executeImageGenerationJob(params: {
         pluralKey: "images",
         getResolvedInput: (entry) => entry.resolvedImage,
       }),
-      ...(normalizedResolution || params.resolution
-        ? { resolution: normalizedResolution ?? params.resolution }
-        : {}),
+      ...(appliedResolution ? { resolution: appliedResolution } : {}),
       ...(normalizedSize || (params.size && !sizeTranslatedToAspectRatio)
         ? { size: normalizedSize ?? params.size }
         : {}),
@@ -939,8 +953,11 @@ export function createImageGenerateTool(options?: {
       const outputFormat = normalizeOutputFormat(readStringParam(params, "outputFormat"));
       const background = normalizeBackground(readStringParam(params, "background"));
       const providerOptions = normalizeProviderOptions(params);
-      const selectedProvider = resolveSelectedImageGenerationProvider({
+      const imageGenerationProviders = listRuntimeImageGenerationProviders({
         config: effectiveCfg,
+      });
+      const selectedProvider = resolveSelectedImageGenerationProvider({
+        providers: imageGenerationProviders,
         imageGenerationModelConfig,
         modelOverride: model,
       });
@@ -1004,17 +1021,18 @@ export function createImageGenerateTool(options?: {
         inputImages.length > 0
           ? selectedProvider?.capabilities.edit
           : selectedProvider?.capabilities.generate;
-      const suppressInferredResolution =
-        inputImages.length > 0 &&
-        !explicitResolution &&
-        isFalKreaImageModel(selectedProvider, selectedModelId);
-      const resolution =
-        explicitResolution ??
-        (size || suppressInferredResolution || modeCaps?.supportsResolution === false
+      const inferredResolution =
+        size || explicitResolution
           ? undefined
           : inputImages.length > 0
             ? await inferResolutionFromInputImages(inputImages)
-            : undefined);
+            : undefined;
+      const resolution =
+        explicitResolution ??
+        (modeCaps?.supportsResolution === false ||
+        modelDisablesImageResolution(selectedProvider, selectedModelId)
+          ? undefined
+          : inferredResolution);
       validateImageGenerationCapabilities({
         provider: selectedProvider,
         count,
@@ -1062,7 +1080,8 @@ export function createImageGenerateTool(options?: {
               model,
               size,
               aspectRatio,
-              resolution,
+              resolution: explicitResolution,
+              inferredResolution,
               quality,
               outputFormat,
               background,
@@ -1119,7 +1138,8 @@ export function createImageGenerateTool(options?: {
           model,
           size,
           aspectRatio,
-          resolution,
+          resolution: explicitResolution,
+          inferredResolution,
           quality,
           outputFormat,
           background,

--- a/src/agents/tools/image-generate-tool.ts
+++ b/src/agents/tools/image-generate-tool.ts
@@ -108,7 +108,8 @@ import {
 
 const DEFAULT_COUNT = 1;
 const MAX_COUNT = 4;
-const MAX_INPUT_IMAGES = 10;
+const DEFAULT_MAX_INPUT_IMAGES = 10;
+const MAX_REFERENCE_IMAGE_INPUTS = 14;
 const DEFAULT_RESOLUTION: ImageGenerationResolution = "1K";
 const SUPPORTED_QUALITIES = ["low", "medium", "high", "auto"] as const;
 const SUPPORTED_OUTPUT_FORMATS = ["png", "jpeg", "webp"] as const;
@@ -156,7 +157,7 @@ const ImageGenerateToolSchema = Type.Object({
   ),
   images: Type.Optional(
     Type.Array(Type.String(), {
-      description: `Reference images for edit or style reference; max ${MAX_INPUT_IMAGES}.`,
+      description: `Reference images for edit or style reference; max ${MAX_REFERENCE_IMAGE_INPUTS}.`,
     }),
   ),
   model: Type.Optional(
@@ -424,7 +425,7 @@ function normalizeReferenceImages(args: Record<string, unknown>): string[] {
     args,
     singularKey: "image",
     pluralKey: "images",
-    maxCount: MAX_INPUT_IMAGES,
+    maxCount: MAX_REFERENCE_IMAGE_INPUTS,
     label: "reference images",
   });
 }
@@ -520,7 +521,6 @@ function validateImageGenerationCapabilities(params: {
   size?: string;
   aspectRatio?: string;
   resolution?: ImageGenerationResolution;
-  inferredResolution?: ImageGenerationResolution;
   explicitResolution?: boolean;
 }) {
   const provider = params.provider;
@@ -540,7 +540,7 @@ function validateImageGenerationCapabilities(params: {
     if (!provider.capabilities.edit.enabled) {
       throw new ToolInputError(`${provider.id} does not support reference-image edits.`);
     }
-    const maxInputImages = provider.capabilities.edit.maxInputImages ?? MAX_INPUT_IMAGES;
+    const maxInputImages = provider.capabilities.edit.maxInputImages ?? DEFAULT_MAX_INPUT_IMAGES;
     if (params.inputImageCount > maxInputImages) {
       throw new ToolInputError(
         `${provider.id} edit supports at most ${maxInputImages} reference image${maxInputImages === 1 ? "" : "s"}.`,

--- a/src/agents/tools/image-generate-tool.ts
+++ b/src/agents/tools/image-generate-tool.ts
@@ -3,9 +3,12 @@
  *
  * Loads references, resolves providers/options, saves generated images, and supports detached background runs.
  */
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { Type } from "typebox";
+import { findCapabilityProviderById } from "../../../packages/media-generation-core/src/capability-model-ref.js";
 import { getRuntimeConfig } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resolveImageGenerationMaxInputImages } from "../../image-generation/capabilities.js";
 import { parseImageGenerationModelRef } from "../../image-generation/model-ref.js";
 import {
   generateImage,
@@ -26,6 +29,7 @@ import type {
 } from "../../image-generation/types.js";
 import type { SsrFPolicy } from "../../infra/net/ssrf.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { resolveCapabilityModelCandidates } from "../../media-generation/runtime-shared.js";
 import {
   resolveConfiguredMediaMaxBytes,
   resolveGeneratedMediaMaxBytes,
@@ -468,6 +472,29 @@ function resolveSelectedImageGenerationModelId(params: {
   return params.imageGenerationModelConfig.primary ?? params.selectedProvider?.defaultModel;
 }
 
+function resolveReachableImageGenerationMaxInputImages(params: {
+  providers: ImageGenerationProvider[];
+  candidates: readonly { provider: string; model: string }[];
+}): number | undefined {
+  const limits = params.candidates.flatMap((candidate) => {
+    const provider = findCapabilityProviderById({
+      providers: params.providers,
+      providerId: candidate.provider,
+      normalizeProviderId,
+    });
+    if (!provider?.capabilities.edit.enabled) {
+      return [];
+    }
+    return [
+      resolveImageGenerationMaxInputImages({
+        provider,
+        model: candidate.model,
+      }) ?? DEFAULT_MAX_INPUT_IMAGES,
+    ];
+  });
+  return limits.length > 0 ? Math.max(...limits) : undefined;
+}
+
 function modelDisablesImageResolution(
   provider: ImageGenerationProvider | undefined,
   modelId?: string,
@@ -518,6 +545,7 @@ function validateImageGenerationCapabilities(params: {
   provider: ImageGenerationProvider | undefined;
   count: number;
   inputImageCount: number;
+  maxInputImages?: number;
   size?: string;
   aspectRatio?: string;
   resolution?: ImageGenerationResolution;
@@ -540,7 +568,10 @@ function validateImageGenerationCapabilities(params: {
     if (!provider.capabilities.edit.enabled) {
       throw new ToolInputError(`${provider.id} does not support reference-image edits.`);
     }
-    const maxInputImages = provider.capabilities.edit.maxInputImages ?? DEFAULT_MAX_INPUT_IMAGES;
+    const maxInputImages =
+      params.maxInputImages ??
+      provider.capabilities.edit.maxInputImages ??
+      DEFAULT_MAX_INPUT_IMAGES;
     if (params.inputImageCount > maxInputImages) {
       throw new ToolInputError(
         `${provider.id} edit supports at most ${maxInputImages} reference image${maxInputImages === 1 ? "" : "s"}.`,
@@ -970,6 +1001,19 @@ export function createImageGenerateTool(options?: {
         explicitModelRef,
         primaryModelRef,
       });
+      const imageGenerationCandidates = resolveCapabilityModelCandidates({
+        cfg: effectiveCfg,
+        modelConfig: effectiveCfg.agents?.defaults?.imageGenerationModel,
+        modelOverride: model,
+        parseModelRef: parseImageGenerationModelRef,
+        agentDir: options?.agentDir,
+        listProviders: () => imageGenerationProviders,
+        autoProviderFallback: explicitModelConfig ? false : undefined,
+      });
+      const maxInputImages = resolveReachableImageGenerationMaxInputImages({
+        providers: imageGenerationProviders,
+        candidates: imageGenerationCandidates,
+      });
       const count = resolveRequestedCount(params);
       const requestKey = buildMediaGenerationRequestKey({
         tool: "image_generate",
@@ -1003,6 +1047,7 @@ export function createImageGenerateTool(options?: {
         provider: selectedProvider,
         count,
         inputImageCount: imageInputs.length,
+        maxInputImages,
         size,
         aspectRatio,
         resolution: explicitResolution,
@@ -1037,6 +1082,7 @@ export function createImageGenerateTool(options?: {
         provider: selectedProvider,
         count,
         inputImageCount: inputImages.length,
+        maxInputImages,
         size,
         aspectRatio,
         resolution,

--- a/src/image-generation/capabilities.test.ts
+++ b/src/image-generation/capabilities.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { resolveImageGenerationMaxInputImages } from "./capabilities.js";
+import type { ImageGenerationProvider } from "./types.js";
+
+function createProvider(): ImageGenerationProvider {
+  return {
+    id: "test",
+    capabilities: {
+      generate: {},
+      edit: {
+        enabled: true,
+        maxInputImages: 1,
+        maxInputImagesByModel: {
+          "family/pro/edit": 12,
+        },
+        maxInputImagesByModelPrefix: {
+          family: 5,
+          "family/pro": 10,
+        },
+      },
+    },
+    async generateImage() {
+      throw new Error("not used");
+    },
+  };
+}
+
+describe("resolveImageGenerationMaxInputImages", () => {
+  it("prefers exact limits, then the longest prefix, then the provider default", () => {
+    const provider = createProvider();
+
+    expect(resolveImageGenerationMaxInputImages({ provider, model: "family/pro/edit" })).toBe(12);
+    expect(resolveImageGenerationMaxInputImages({ provider, model: "family/pro/v2" })).toBe(10);
+    expect(resolveImageGenerationMaxInputImages({ provider, model: "family/basic" })).toBe(5);
+    expect(resolveImageGenerationMaxInputImages({ provider, model: "other" })).toBe(1);
+  });
+});

--- a/src/image-generation/capabilities.ts
+++ b/src/image-generation/capabilities.ts
@@ -1,0 +1,12 @@
+import type { ImageGenerationProvider } from "./types.js";
+
+export function resolveImageGenerationMaxInputImages(params: {
+  provider: Pick<ImageGenerationProvider, "capabilities">;
+  model?: string;
+}): number | undefined {
+  const model = params.model?.trim();
+  return (
+    (model ? params.provider.capabilities.edit.maxInputImagesByModel?.[model] : undefined) ??
+    params.provider.capabilities.edit.maxInputImages
+  );
+}

--- a/src/image-generation/capabilities.ts
+++ b/src/image-generation/capabilities.ts
@@ -5,8 +5,21 @@ export function resolveImageGenerationMaxInputImages(params: {
   model?: string;
 }): number | undefined {
   const model = params.model?.trim();
+  let prefixLimit: number | undefined;
+  let prefixLength = -1;
+  if (model) {
+    for (const [prefix, limit] of Object.entries(
+      params.provider.capabilities.edit.maxInputImagesByModelPrefix ?? {},
+    )) {
+      if (prefix.length > prefixLength && model.startsWith(prefix)) {
+        prefixLimit = limit;
+        prefixLength = prefix.length;
+      }
+    }
+  }
   return (
     (model ? params.provider.capabilities.edit.maxInputImagesByModel?.[model] : undefined) ??
+    prefixLimit ??
     params.provider.capabilities.edit.maxInputImages
   );
 }

--- a/src/image-generation/runtime-types.ts
+++ b/src/image-generation/runtime-types.ts
@@ -26,6 +26,8 @@ export type GenerateImageParams = {
   size?: string;
   aspectRatio?: string;
   resolution?: ImageGenerationResolution;
+  /** Resolution inferred from reference images; omitted for incompatible fallback models. */
+  inferredResolution?: ImageGenerationResolution;
   quality?: ImageGenerationQuality;
   outputFormat?: ImageGenerationOutputFormat;
   background?: ImageGenerationBackground;
@@ -43,6 +45,7 @@ export type GenerateImageRuntimeResult = {
   provider: string;
   model: string;
   attempts: FallbackAttempt[];
+  appliedResolution?: ImageGenerationResolution;
   normalization?: ImageGenerationNormalization;
   metadata?: Record<string, unknown>;
   ignoredOverrides: ImageGenerationIgnoredOverride[];

--- a/src/image-generation/runtime.test.ts
+++ b/src/image-generation/runtime.test.ts
@@ -270,6 +270,149 @@ describe("image-generation runtime", () => {
     );
   });
 
+  it("applies inferred resolution only to compatible fallback candidates", async () => {
+    const seenResolutions: Array<string | undefined> = [];
+    let unavailableProvider = "google";
+    const inputImages = [{ buffer: Buffer.from("reference"), mimeType: "image/png" }];
+    providers = [
+      {
+        id: "openai",
+        capabilities: {
+          generate: { supportsResolution: false },
+          edit: { enabled: true, supportsResolution: false },
+        },
+        async generateImage(req) {
+          seenResolutions.push(req.resolution);
+          if (unavailableProvider === "openai") {
+            throw new Error("openai unavailable");
+          }
+          return {
+            images: [{ buffer: Buffer.from("png-bytes"), mimeType: "image/png" }],
+          };
+        },
+      },
+      {
+        id: "google",
+        capabilities: {
+          generate: { supportsResolution: true },
+          edit: { enabled: true, supportsResolution: true },
+          geometry: { resolutions: ["1K", "2K", "4K"] },
+        },
+        async generateImage(req) {
+          seenResolutions.push(req.resolution);
+          if (unavailableProvider === "google") {
+            throw new Error("google unavailable");
+          }
+          return {
+            images: [{ buffer: Buffer.from("png-bytes"), mimeType: "image/png" }],
+          };
+        },
+      },
+      {
+        id: "fal",
+        capabilities: {
+          generate: { supportsResolution: true },
+          edit: { enabled: true, supportsResolution: true },
+          geometry: {
+            resolutions: ["1K", "2K", "4K"],
+            resolutionsByModel: { "google/nano-banana-2-lite": [] },
+          },
+        },
+        async generateImage(req) {
+          seenResolutions.push(req.resolution);
+          if (unavailableProvider === "fal") {
+            throw new Error("fal unavailable");
+          }
+          return {
+            images: [{ buffer: Buffer.from("png-bytes"), mimeType: "image/png" }],
+          };
+        },
+      },
+    ];
+
+    const result = await runGenerateImage({
+      cfg: {
+        agents: {
+          defaults: {
+            imageGenerationModel: {
+              primary: "google/gemini-3-pro-image-preview",
+              fallbacks: ["fal/google/nano-banana-2-lite"],
+            },
+          },
+        },
+      } as OpenClawConfig,
+      prompt: "edit this image",
+      inferredResolution: "2K",
+      inputImages,
+    });
+
+    expect(result.provider).toBe("fal");
+    expect(seenResolutions).toEqual(["2K", undefined]);
+
+    unavailableProvider = "fal";
+    seenResolutions.length = 0;
+    const inverseResult = await runGenerateImage({
+      cfg: {
+        agents: {
+          defaults: {
+            imageGenerationModel: {
+              primary: "fal/google/nano-banana-2-lite",
+              fallbacks: ["google/gemini-3-pro-image-preview"],
+            },
+          },
+        },
+      } as OpenClawConfig,
+      prompt: "edit this image",
+      inferredResolution: "2K",
+      inputImages,
+    });
+
+    expect(inverseResult.provider).toBe("google");
+    expect(seenResolutions).toEqual([undefined, "2K"]);
+
+    unavailableProvider = "openai";
+    seenResolutions.length = 0;
+    const providerDisabledResult = await runGenerateImage({
+      cfg: {
+        agents: {
+          defaults: {
+            imageGenerationModel: {
+              primary: "openai/gpt-image-1",
+              fallbacks: ["google/gemini-3-pro-image-preview"],
+            },
+          },
+        },
+      } as OpenClawConfig,
+      prompt: "edit this image",
+      inferredResolution: "2K",
+      inputImages,
+    });
+
+    expect(providerDisabledResult.provider).toBe("google");
+    expect(seenResolutions).toEqual([undefined, "2K"]);
+
+    unavailableProvider = "";
+    seenResolutions.length = 0;
+    const providerDisabledSuccess = await runGenerateImage({
+      cfg: {
+        agents: {
+          defaults: {
+            imageGenerationModel: {
+              primary: "openai/gpt-image-1",
+            },
+          },
+        },
+      } as OpenClawConfig,
+      prompt: "edit this image",
+      inferredResolution: "2K",
+      inputImages,
+    });
+
+    expect(providerDisabledSuccess.provider).toBe("openai");
+    expect(providerDisabledSuccess.ignoredOverrides).toEqual([]);
+    expect(seenResolutions).toEqual([undefined]);
+  });
+
   it("drops unsupported provider geometry overrides and reports them", async () => {
     let seenRequest:
       | {
@@ -543,6 +686,7 @@ describe("image-generation runtime", () => {
       | {
           size?: string;
           aspectRatio?: string;
+          resolution?: "1K" | "2K" | "4K";
         }
       | undefined;
     providers = [
@@ -552,11 +696,13 @@ describe("image-generation runtime", () => {
           generate: {
             supportsSize: true,
             supportsAspectRatio: true,
+            supportsResolution: true,
           },
           edit: {
             enabled: true,
             supportsSize: true,
             supportsAspectRatio: true,
+            supportsResolution: true,
           },
           geometry: {
             sizes: ["1024x1024", "1536x1024", "1024x1536"],
@@ -564,12 +710,20 @@ describe("image-generation runtime", () => {
               "krea/v2/medium/text-to-image": [],
             },
             aspectRatios: ["1:1", "4:3", "3:2", "16:9"],
+            aspectRatiosByModel: {
+              "krea/v2/medium/text-to-image": ["1:1", "2:1", "20:9"],
+            },
+            resolutions: ["1K", "2K", "4K"],
+            resolutionsByModel: {
+              "krea/v2/medium/text-to-image": ["1K", "2K"],
+            },
           },
         },
         async generateImage(req) {
           seenRequest = {
             size: req.size,
             aspectRatio: req.aspectRatio,
+            resolution: req.resolution,
           };
           return {
             images: [{ buffer: Buffer.from("png-bytes"), mimeType: "image/png" }],
@@ -588,11 +742,14 @@ describe("image-generation runtime", () => {
       } as OpenClawConfig,
       prompt: "draw a cat",
       size: "1024x768",
+      aspectRatio: "20:9",
+      resolution: "4K",
     });
 
     expect(seenRequest).toEqual({
       size: "1024x768",
-      aspectRatio: undefined,
+      aspectRatio: "20:9",
+      resolution: "2K",
     });
   });
 

--- a/src/image-generation/runtime.test.ts
+++ b/src/image-generation/runtime.test.ts
@@ -413,6 +413,60 @@ describe("image-generation runtime", () => {
     expect(seenResolutions).toEqual([undefined]);
   });
 
+  it("skips candidates whose model-specific reference limit is too low", async () => {
+    const attemptedModels: string[] = [];
+    providers = [
+      {
+        id: "fal",
+        capabilities: {
+          generate: {},
+          edit: {
+            enabled: true,
+            maxInputImages: 1,
+            maxInputImagesByModel: {
+              "xai/grok-imagine-image": 3,
+              "google/nano-banana-2-lite": 14,
+            },
+          },
+        },
+        async generateImage(req) {
+          attemptedModels.push(req.model);
+          return {
+            images: [{ buffer: Buffer.from("png-bytes"), mimeType: "image/png" }],
+          };
+        },
+      },
+    ];
+
+    const result = await runGenerateImage({
+      cfg: {
+        agents: {
+          defaults: {
+            imageGenerationModel: {
+              primary: "fal/xai/grok-imagine-image",
+              fallbacks: ["fal/google/nano-banana-2-lite"],
+            },
+          },
+        },
+      } as OpenClawConfig,
+      prompt: "combine references",
+      inputImages: Array.from({ length: 14 }, () => ({
+        buffer: Buffer.from("reference"),
+        mimeType: "image/png",
+      })),
+    });
+
+    expect(result.model).toBe("google/nano-banana-2-lite");
+    expect(attemptedModels).toEqual(["google/nano-banana-2-lite"]);
+    expect(result.attempts).toEqual([
+      {
+        provider: "fal",
+        model: "xai/grok-imagine-image",
+        error: "fal/xai/grok-imagine-image supports at most 3 reference images, 14 requested",
+      },
+    ]);
+  });
+
   it("drops unsupported provider geometry overrides and reports them", async () => {
     let seenRequest:
       | {

--- a/src/image-generation/runtime.ts
+++ b/src/image-generation/runtime.ts
@@ -103,12 +103,21 @@ export async function generateImage(
         timeoutMs: requestedTimeoutMs,
         providerDefaultTimeoutMs: provider.defaultTimeoutMs,
       });
+      const modelResolutions =
+        provider.capabilities.geometry?.resolutionsByModel?.[candidate.model];
+      const modeCapabilities = params.inputImages?.length
+        ? provider.capabilities.edit
+        : provider.capabilities.generate;
+      const inferredResolution =
+        modeCapabilities.supportsResolution === false || modelResolutions?.length === 0
+          ? undefined
+          : params.inferredResolution;
       const sanitized = resolveImageGenerationOverrides({
         provider,
         model: candidate.model,
         size: params.size,
         aspectRatio: params.aspectRatio,
-        resolution: params.resolution,
+        resolution: params.resolution ?? inferredResolution,
         quality: params.quality,
         outputFormat: params.outputFormat,
         background: params.background,
@@ -143,6 +152,7 @@ export async function generateImage(
         provider: candidate.provider,
         model: result.model ?? candidate.model,
         attempts,
+        ...(sanitized.resolution ? { appliedResolution: sanitized.resolution } : {}),
         normalization: sanitized.normalization,
         metadata: {
           ...result.metadata,

--- a/src/image-generation/runtime.ts
+++ b/src/image-generation/runtime.ts
@@ -13,6 +13,7 @@ import {
   throwCapabilityGenerationFailure,
 } from "../media-generation/runtime-shared.js";
 import { getProviderEnvVars } from "../secrets/provider-env-vars.js";
+import { resolveImageGenerationMaxInputImages } from "./capabilities.js";
 import { parseImageGenerationModelRef } from "./model-ref.js";
 import { resolveImageGenerationOverrides } from "./normalization.js";
 import { getImageGenerationProvider, listImageGenerationProviders } from "./provider-registry.js";
@@ -95,6 +96,23 @@ export async function generateImage(
       logger.warn(
         `image-generation candidate failed: ${candidate.provider}/${candidate.model}: ${error}`,
       );
+      continue;
+    }
+
+    const inputImageCount = params.inputImages?.length ?? 0;
+    const maxInputImages = resolveImageGenerationMaxInputImages({
+      provider,
+      model: candidate.model,
+    });
+    if (maxInputImages !== undefined && inputImageCount > maxInputImages) {
+      const error = `${candidate.provider}/${candidate.model} supports at most ${maxInputImages} reference image${maxInputImages === 1 ? "" : "s"}, ${inputImageCount} requested`;
+      attempts.push({
+        provider: candidate.provider,
+        model: candidate.model,
+        error,
+      });
+      lastError = new Error(error);
+      logger.warn(`image-generation candidate skipped: ${error}`);
       continue;
     }
 

--- a/src/image-generation/types.ts
+++ b/src/image-generation/types.ts
@@ -99,6 +99,7 @@ type ImageGenerationEditCapabilities = ImageGenerationModeCapabilities & {
   enabled: boolean;
   maxInputImages?: number;
   maxInputImagesByModel?: Readonly<Record<string, number>>;
+  maxInputImagesByModelPrefix?: Readonly<Record<string, number>>;
 };
 
 type ImageGenerationGeometryCapabilities = {

--- a/src/image-generation/types.ts
+++ b/src/image-generation/types.ts
@@ -98,6 +98,7 @@ type ImageGenerationModeCapabilities = {
 type ImageGenerationEditCapabilities = ImageGenerationModeCapabilities & {
   enabled: boolean;
   maxInputImages?: number;
+  maxInputImagesByModel?: Readonly<Record<string, number>>;
 };
 
 type ImageGenerationGeometryCapabilities = {

--- a/test/scripts/ios-run.test.ts
+++ b/test/scripts/ios-run.test.ts
@@ -53,6 +53,16 @@ if [[ -n "\${OPENCLAW_SIMULATOR_PUSH_PROOF_SECRET:-}" || -n "\${CUSTOM_SIMULATOR
 fi
 `,
   );
+  writeFileSync(
+    path.join(scriptsDir, "ios-write-swift-filelist.mjs"),
+    `import { appendFileSync } from "node:fs";
+if (process.env.OPENCLAW_SIMULATOR_PUSH_PROOF_SECRET || process.env.CUSTOM_SIMULATOR_PUSH_PROOF_SECRET) {
+  appendFileSync(${JSON.stringify(logFile)}, "write-swift-filelist-proof-env leaked\\n");
+}
+appendFileSync(${JSON.stringify(logFile)}, "write-swift-filelist\\n");
+`,
+    "utf8",
+  );
   writeExecutable(
     path.join(binDir, "xcodegen"),
     `#!/usr/bin/env bash


### PR DESCRIPTION
## What Problem This Solves

Reference-image calls for these Fal-hosted models fell through to `/image-to-image`, which Fal does not expose:

- `xai/grok-imagine-image`
- `google/nano-banana-2-lite`

Both models expose standard edits at `/edit`. Grok also has a separate, explicitly selectable `/quality/edit` tier.

The original fix exposed two shared-runtime gaps: inferred resolution was applied before fallback selection, and reference-image limits were represented only at provider level even though Fal models accept between 1 and 14 inputs.

## Why This Change Was Made

The Fal plugin keeps endpoint and request-shape behavior in its existing model schema:

- Base Grok edits append `/edit`; explicit `/quality` and `/quality/edit` model paths retain the quality tier.
- Nano Banana 2 Lite edits append `/edit`.
- Grok uses its published aspect-ratio set, lowercase `1k`/`2k` wire values, and three-reference-image limit.
- Nano Banana 2 and Nano Banana 2 Lite use their published aspect-ratio set and 14-reference-image limit.
- Nano Banana 2 Lite resolution overrides are rejected because the published base and edit schemas do not expose a `resolution` field.

The shared runtime now carries inferred resolution separately and applies it only after selecting each candidate model. A fallback that does not support resolution receives no stale override, while a capable fallback still receives the inferred default.

Image edit capabilities now support model-specific reference limits, matching the existing video-generation capability pattern. Tool preflight accepts the highest limit among reachable fallback candidates, while runtime skips candidates whose concrete model limit is too low before provider or network work. Provider listings report the maximum and mark it as model-dependent.

The generic endpoint fallback remains `/image-to-image`, while existing GPT Image, Nano Banana 2, Flux, and Krea routing is unchanged.

## User Impact

Reference-image calls for the affected model IDs now reach their valid Fal edit endpoints instead of failing with a 404. Mixed-capability fallback chains no longer leak resolution overrides or reject a valid higher-capacity fallback. Invalid direct Grok, Flux, GPT Image, or Krea reference counts fail before input loading or detached-task start.

## Evidence

- Contributor live probes reproduced 404s from the old `/image-to-image` routes and 200 responses from valid Fal routes.
- Fal's current OpenAPI publishes distinct `xai/grok-imagine-image/edit` and `xai/grok-imagine-image/quality/edit` endpoints.
- Fal's current OpenAPI publishes `google/nano-banana-2-lite/edit` and omits `resolution` from both Nano Banana 2 Lite base and edit input schemas.
- `node scripts/run-vitest.mjs src/image-generation/capabilities.test.ts extensions/fal/image-generation-provider.test.ts extensions/fal/music-generation-provider.test.ts extensions/fal/video-generation-provider.test.ts src/agents/tools/image-generate-tool.test.ts src/image-generation/runtime.test.ts test/scripts/render-maturity-docs.test.ts test/scripts/ios-run.test.ts` - 146/146 passed.
- `git diff --check` - passed.
- Blacksmith Testbox `tbx_01kwgc9dg5fnmwfatayh3n58es`: `check:changed` passed on the exact rebased head.
- Final whole-PR structured autoreview - clean, no actionable findings, confidence 0.90.
- Final iOS fixture repair autoreview - clean, no actionable findings, confidence 0.98.
- Exact-head GitHub CI - 65 passed, 27 skipped, 1 neutral, 0 failed.

Fixes the broken edit routing described in this PR.
