### PR TITLE
fix(wizard): reject loose gateway port input

### DIFF
--- a/src/wizard/setup.gateway-config.test.ts
+++ b/src/wizard/setup.gateway-config.test.ts
@@ -39,7 +39,14 @@ describe("configureGatewayForSetup", () => {
 
     return buildWizardPrompter({
       select,
-      text: vi.fn(async () => textQueue.shift() as string),
+      text: vi.fn(async (paramsLocal) => {
+        const value = textQueue.shift() as string;
+        const error = typeof value === "string" ? paramsLocal.validate?.(value) : undefined;
+        if (error) {
+          throw new Error(error);
+        }
+        return value;
+      }),
     });
   }
 
@@ -98,6 +105,14 @@ describe("configureGatewayForSetup", () => {
     expect(result.nextConfig.gateway?.nodes?.denyCommands).toEqual(DEFAULT_DANGEROUS_NODE_COMMANDS);
     expect(result.nextConfig.gateway?.nodes?.denyCommands).not.toContain("screen.snapshot");
     expect(result.nextConfig.gateway?.nodes?.denyCommands).toContain("screen.record");
+  });
+
+  it.each(["1e3", "0x1000"])("rejects loose gateway port input: %s", async (port) => {
+    mocks.randomToken.mockReturnValue("generated-token");
+
+    await expect(runGatewayConfig({ textQueue: [port] })).rejects.toThrow(
+      "Use a port number from 1 to 65535",
+    );
   });
 
   it("prefers OPENCLAW_GATEWAY_TOKEN during quickstart token setup", async () => {

--- a/src/wizard/setup.gateway-config.ts
+++ b/src/wizard/setup.gateway-config.ts
@@ -1,5 +1,6 @@
 // Setup gateway config helpers build gateway config from onboarding answers.
 import { validateIPv4AddressInput } from "@openclaw/net-policy/ipv4";
+import { parseStrictInteger } from "@openclaw/normalization-core/number-coercion";
 import { formatPortRangeHint } from "../cli/error-format.js";
 import {
   normalizeGatewayTokenInput,
@@ -62,11 +63,15 @@ function normalizeWizardTextInput(value: unknown): string {
 }
 
 function validateGatewayPortInput(value: unknown): string | undefined {
-  const port = Number(normalizeWizardTextInput(value));
-  if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+  if (parseGatewayPortInput(value) === undefined) {
     return formatPortRangeHint();
   }
   return undefined;
+}
+
+function parseGatewayPortInput(value: unknown): number | undefined {
+  const port = parseStrictInteger(normalizeWizardTextInput(value));
+  return port !== undefined && port >= 1 && port <= 65_535 ? port : undefined;
 }
 
 export async function configureGatewayForSetup(
@@ -78,16 +83,16 @@ export async function configureGatewayForSetup(
   const port =
     flow === "quickstart"
       ? quickstartGateway.port
-      : Number.parseInt(
-          normalizeWizardTextInput(
-            await prompter.text({
-              message: t("wizard.gateway.port"),
-              initialValue: String(localPort),
-              validate: validateGatewayPortInput,
-            }),
-          ),
-          10,
+      : parseGatewayPortInput(
+          await prompter.text({
+            message: t("wizard.gateway.port"),
+            initialValue: String(localPort),
+            validate: validateGatewayPortInput,
+          }),
         );
+  if (port === undefined) {
+    throw new Error(formatPortRangeHint());
+  }
 
   let bind: GatewayWizardSettings["bind"] =
     flow === "quickstart"

--- a/src/wizard/setup.gateway-config.ts
+++ b/src/wizard/setup.gateway-config.ts
@@ -1,7 +1,7 @@
 // Setup gateway config helpers build gateway config from onboarding answers.
 import { validateIPv4AddressInput } from "@openclaw/net-policy/ipv4";
-import { parseStrictInteger } from "@openclaw/normalization-core/number-coercion";
 import { formatPortRangeHint } from "../cli/error-format.js";
+import { parsePort } from "../cli/shared/parse-port.js";
 import {
   normalizeGatewayTokenInput,
   randomToken,
@@ -63,15 +63,10 @@ function normalizeWizardTextInput(value: unknown): string {
 }
 
 function validateGatewayPortInput(value: unknown): string | undefined {
-  if (parseGatewayPortInput(value) === undefined) {
+  if (parsePort(value) === null) {
     return formatPortRangeHint();
   }
   return undefined;
-}
-
-function parseGatewayPortInput(value: unknown): number | undefined {
-  const port = parseStrictInteger(normalizeWizardTextInput(value));
-  return port !== undefined && port >= 1 && port <= 65_535 ? port : undefined;
 }
 
 export async function configureGatewayForSetup(
@@ -83,14 +78,14 @@ export async function configureGatewayForSetup(
   const port =
     flow === "quickstart"
       ? quickstartGateway.port
-      : parseGatewayPortInput(
+      : parsePort(
           await prompter.text({
             message: t("wizard.gateway.port"),
             initialValue: String(localPort),
             validate: validateGatewayPortInput,
           }),
         );
-  if (port === undefined) {
+  if (port === null) {
     throw new Error(formatPortRangeHint());
   }
 


### PR DESCRIPTION
Closes #98681

## What Problem This Solves

Fixes an issue where users running manual setup could enter a gateway port such as `1e3` or `0x1000` and have the wizard accept it but persist a different port.

## Why This Change Was Made

The setup wizard now uses the existing shared TCP port parser for both gateway port validation and persistence. This keeps the manual setup path aligned with the sibling configure flow and avoids a second setup-only parser drifting from the canonical TCP port contract.

## User Impact

Manual setup users now get the existing port-range validation message for loose numeric port input instead of silently saving an unintended gateway port.

## Evidence

- Claim proved: manual gateway setup rejects loose numeric port input instead of saving a truncated value, and the setup path now uses the shared TCP port parser.
- Target head SHA: `e4e72b1db3696b3e60fbacbc4cef1fb26da883ce`.
- Commands / artifacts:
  - `node scripts/run-vitest.mjs src/wizard/setup.gateway-config.test.ts src/cli/shared/parse-port.test.ts src/infra/tcp-port.test.ts -- --reporter=verbose`
  - `node .artifacts\proof-gateway-port-pty.mjs`
  - `git diff --check`
  - `python .agents\skills\autoreview\scripts\autoreview --mode local`
- Observed result:
  - Focused Vitest passed: 3 files / 20 tests passed, including `rejects loose gateway port input: 1e3`, `rejects loose gateway port input: 0x1000`, and the shared `parsePort` loose-input cases.
  - Real manual setup proof passed through the source CLI with an isolated temp state dir:
    - Command under proof: `node --import tsx src/entry.ts onboard --flow manual --mode local --auth-choice skip --workspace <temp>\workspace --skip-channels --skip-skills --skip-search --skip-health --skip-ui --skip-daemon --skip-bootstrap --accept-risk`
    - `sawGatewayPortPrompt: true`
    - `sawPortValidationError: true`
    - `configWritten: false`
    - Terminal transcript included `Gateway port`, entered value `1e3`, and `Use a port number from 1 to 65535, for example 18789.`
  - `git diff --check` passed with no output.
  - Autoreview reported `autoreview clean: no accepted/actionable findings reported` and `overall: patch is correct (0.89)`.
- Not tested / proof gaps:
  - Did not run full repository checks or broad typecheck, per scoped small-change validation.
  - The PTY proof script lived under ignored `.artifacts/` and was not committed.

