### PR TITLE
fix(google): bound embedding batch response reads

### DIFF
--- a/extensions/google/embedding-batch.test.ts
+++ b/extensions/google/embedding-batch.test.ts
@@ -58,25 +58,27 @@ function makeGeminiClient(): GeminiEmbeddingClient {
 type GeminiBatchRequest = Parameters<typeof runGeminiEmbeddingBatches>[0]["requests"][number];
 
 function singleRequest(): GeminiBatchRequest[] {
-  return [
-    {
-      custom_id: "r0",
-      request: {
-        model: "models/text-embedding-004",
-        content: { parts: [{ text: "hello" }] },
-        taskType: "RETRIEVAL_DOCUMENT",
-      },
-    },
-  ];
+  return makeRequests(1);
 }
 
-function makeOversizedResponse(): {
+function makeRequests(count: number): GeminiBatchRequest[] {
+  return Array.from({ length: count }, (_, index) => ({
+    custom_id: `r${index}`,
+    request: {
+      model: "models/text-embedding-004",
+      content: { parts: [{ text: `hello-${index}` }] },
+      taskType: "RETRIEVAL_DOCUMENT",
+    },
+  }));
+}
+
+function makeOversizedResponse(init?: ResponseInit): {
   response: Response;
   getReadCount: () => number;
   wasCanceled: () => boolean;
 } {
   const chunkSize = 1024 * 1024;
-  const chunkCount = 20; // 20 MiB — over 16 MiB cap
+  const chunkCount = 20; // 20 MiB, over the 16 MiB provider response cap.
   let readCount = 0;
   let canceled = false;
   return {
@@ -94,7 +96,36 @@ function makeOversizedResponse(): {
           canceled = true;
         },
       }),
-      { status: 200, headers: { "Content-Type": "application/json" } },
+      { status: 200, headers: { "Content-Type": "application/json" }, ...init },
+    ),
+    getReadCount: () => readCount,
+    wasCanceled: () => canceled,
+  };
+}
+
+function makeJsonlLinesResponse(lines: string[]): {
+  response: Response;
+  getReadCount: () => number;
+  wasCanceled: () => boolean;
+} {
+  let readCount = 0;
+  let canceled = false;
+  return {
+    response: new Response(
+      new ReadableStream<Uint8Array>({
+        pull(controller) {
+          if (readCount >= lines.length) {
+            controller.close();
+            return;
+          }
+          controller.enqueue(new TextEncoder().encode(`${lines[readCount]}\n`));
+          readCount += 1;
+        },
+        cancel() {
+          canceled = true;
+        },
+      }),
+      { status: 200, headers: { "Content-Type": "application/jsonl" } },
     ),
     getReadCount: () => readCount,
     wasCanceled: () => canceled,
@@ -102,6 +133,66 @@ function makeOversizedResponse(): {
 }
 
 describe("Google embedding-batch bounded JSON reads", () => {
+  it("bounds oversized file-upload error bodies and cancels the stream", async () => {
+    const streamed = makeOversizedResponse({ status: 500 });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        if (fetchInputUrl(input).includes("/upload/")) {
+          return streamed.response;
+        }
+        return new Response("unexpected", { status: 500 });
+      }),
+    );
+
+    await expect(
+      runGeminiEmbeddingBatches({
+        gemini: makeGeminiClient(),
+        agentId: "main",
+        requests: singleRequest(),
+        wait: true,
+        concurrency: 1,
+        pollIntervalMs: 50,
+        timeoutMs: 5_000,
+      }),
+    ).rejects.toThrow(/gemini batch file upload failed: 500/);
+
+    expect(streamed.wasCanceled()).toBe(true);
+    expect(streamed.getReadCount()).toBeLessThan(20);
+  });
+
+  it("bounds oversized batch-create error bodies and cancels the stream", async () => {
+    const streamed = makeOversizedResponse({ status: 500 });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = fetchInputUrl(input);
+        if (url.includes("/upload/")) {
+          return jsonResponse({ name: "files/f-ok" });
+        }
+        if (url.includes(":asyncBatchEmbedContent")) {
+          return streamed.response;
+        }
+        return new Response("unexpected", { status: 500 });
+      }),
+    );
+
+    await expect(
+      runGeminiEmbeddingBatches({
+        gemini: makeGeminiClient(),
+        agentId: "main",
+        requests: singleRequest(),
+        wait: true,
+        concurrency: 1,
+        pollIntervalMs: 50,
+        timeoutMs: 5_000,
+      }),
+    ).rejects.toThrow(/gemini batch create failed: 500/);
+
+    expect(streamed.wasCanceled()).toBe(true);
+    expect(streamed.getReadCount()).toBeLessThan(20);
+  });
+
   it("bounds oversized file-upload JSON response and cancels the stream", async () => {
     const streamed = makeOversizedResponse();
     vi.stubGlobal(
@@ -242,5 +333,203 @@ describe("Google embedding-batch bounded JSON reads", () => {
     });
 
     expect(result.get("r0")).toEqual([1, 0, 0]);
+  });
+
+  it("streams valid batch output files larger than the provider text cap", async () => {
+    const requestCount = 18;
+    const requests = makeRequests(requestCount);
+    const padding = "x".repeat(1024 * 1024);
+    const output = requests
+      .map((request) =>
+        JSON.stringify({
+          key: request.custom_id,
+          embedding: { values: [1, 0, 0] },
+          padding,
+        }),
+      )
+      .join("\n");
+    expect(new TextEncoder().encode(output).byteLength).toBeGreaterThan(16 * 1024 * 1024);
+
+    let statusCalled = false;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = fetchInputUrl(input);
+        if (url.includes("/upload/")) {
+          return jsonResponse({ name: "files/f-ok" });
+        }
+        if (url.includes(":asyncBatchEmbedContent")) {
+          return jsonResponse({ name: "batches/b-0", state: "PENDING" });
+        }
+        if (url.includes("/batches/") && !statusCalled) {
+          statusCalled = true;
+          return jsonResponse({
+            name: "batches/b-0",
+            state: "SUCCEEDED",
+            outputConfig: { file: "files/out-0" },
+          });
+        }
+        if (url.includes(":download")) {
+          return new Response(output, { status: 200 });
+        }
+        return new Response("unexpected", { status: 500 });
+      }),
+    );
+
+    const result = await runGeminiEmbeddingBatches({
+      gemini: makeGeminiClient(),
+      agentId: "main",
+      requests,
+      wait: true,
+      concurrency: 1,
+      pollIntervalMs: 50,
+      timeoutMs: 5_000,
+    });
+
+    expect(result.size).toBe(requestCount);
+    expect(result.get("r0")).toEqual([1, 0, 0]);
+    expect(result.get("r17")).toEqual([1, 0, 0]);
+  });
+
+  it("bounds oversized batch output downloads and cancels the stream", async () => {
+    const streamed = makeOversizedResponse({ headers: { "Content-Type": "application/jsonl" } });
+    let statusCalled = false;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = fetchInputUrl(input);
+        if (url.includes("/upload/")) {
+          return jsonResponse({ name: "files/f-ok" });
+        }
+        if (url.includes(":asyncBatchEmbedContent")) {
+          return jsonResponse({ name: "batches/b-0", state: "PENDING" });
+        }
+        if (url.includes("/batches/") && !statusCalled) {
+          statusCalled = true;
+          return jsonResponse({
+            name: "batches/b-0",
+            state: "SUCCEEDED",
+            outputConfig: { file: "files/out-0" },
+          });
+        }
+        if (url.includes(":download")) {
+          return streamed.response;
+        }
+        return new Response("unexpected", { status: 500 });
+      }),
+    );
+
+    await expect(
+      runGeminiEmbeddingBatches({
+        gemini: makeGeminiClient(),
+        agentId: "main",
+        requests: singleRequest(),
+        wait: true,
+        concurrency: 1,
+        pollIntervalMs: 50,
+        timeoutMs: 5_000,
+      }),
+    ).rejects.toThrow(/gemini\.batch-file-content: JSONL line exceeds/);
+
+    expect(streamed.wasCanceled()).toBe(true);
+    expect(streamed.getReadCount()).toBeLessThan(20);
+  });
+
+  it("bounds batch output record count to the submitted request group", async () => {
+    const streamed = makeJsonlLinesResponse([
+      JSON.stringify({ key: "r0", embedding: { values: [1, 0, 0] } }),
+      ...Array.from({ length: 19 }, (_, index) =>
+        JSON.stringify({ key: `unexpected-${index}`, embedding: { values: [1, 0, 0] } }),
+      ),
+    ]);
+    let statusCalled = false;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = fetchInputUrl(input);
+        if (url.includes("/upload/")) {
+          return jsonResponse({ name: "files/f-ok" });
+        }
+        if (url.includes(":asyncBatchEmbedContent")) {
+          return jsonResponse({ name: "batches/b-0", state: "PENDING" });
+        }
+        if (url.includes("/batches/") && !statusCalled) {
+          statusCalled = true;
+          return jsonResponse({
+            name: "batches/b-0",
+            state: "SUCCEEDED",
+            outputConfig: { file: "files/out-0" },
+          });
+        }
+        if (url.includes(":download")) {
+          return streamed.response;
+        }
+        return new Response("unexpected", { status: 500 });
+      }),
+    );
+
+    await expect(
+      runGeminiEmbeddingBatches({
+        gemini: makeGeminiClient(),
+        agentId: "main",
+        requests: singleRequest(),
+        wait: true,
+        concurrency: 1,
+        pollIntervalMs: 50,
+        timeoutMs: 5_000,
+      }),
+    ).rejects.toThrow(/gemini\.batch-file-content: JSONL output exceeds 1 records/);
+
+    expect(streamed.wasCanceled()).toBe(true);
+    expect(streamed.getReadCount()).toBeLessThan(20);
+  });
+
+  it("counts blank batch output records against the submitted request group", async () => {
+    const streamed = makeJsonlLinesResponse([
+      JSON.stringify({ key: "r0", embedding: { values: [1, 0, 0] } }),
+      "",
+      "",
+      "",
+    ]);
+    let statusCalled = false;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = fetchInputUrl(input);
+        if (url.includes("/upload/")) {
+          return jsonResponse({ name: "files/f-ok" });
+        }
+        if (url.includes(":asyncBatchEmbedContent")) {
+          return jsonResponse({ name: "batches/b-0", state: "PENDING" });
+        }
+        if (url.includes("/batches/") && !statusCalled) {
+          statusCalled = true;
+          return jsonResponse({
+            name: "batches/b-0",
+            state: "SUCCEEDED",
+            outputConfig: { file: "files/out-0" },
+          });
+        }
+        if (url.includes(":download")) {
+          return streamed.response;
+        }
+        return new Response("unexpected", { status: 500 });
+      }),
+    );
+
+    await expect(
+      runGeminiEmbeddingBatches({
+        gemini: makeGeminiClient(),
+        agentId: "main",
+        requests: singleRequest(),
+        wait: true,
+        concurrency: 1,
+        pollIntervalMs: 50,
+        timeoutMs: 5_000,
+      }),
+    ).rejects.toThrow(/gemini\.batch-file-content: JSONL output exceeds 1 records/);
+
+    expect(streamed.wasCanceled()).toBe(true);
+    expect(streamed.getReadCount()).toBeLessThan(4);
   });
 });

--- a/extensions/google/embedding-batch.ts
+++ b/extensions/google/embedding-batch.ts
@@ -12,8 +12,8 @@ import {
 import {
   createProviderHttpError,
   readProviderJsonResponse,
+  readResponseTextLimited,
 } from "openclaw/plugin-sdk/provider-http";
-import { normalizeStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { GeminiEmbeddingClient, GeminiTextEmbeddingRequest } from "./embedding-provider.js";
 
 type EmbeddingBatchExecutionParams = {
@@ -54,6 +54,7 @@ type GeminiBatchOutputLine = {
 };
 
 const GEMINI_BATCH_MAX_REQUESTS = 50000;
+const GEMINI_BATCH_OUTPUT_LINE_MAX_BYTES = 4 * 1024 * 1024;
 function hashText(text: string): string {
   return crypto.createHash("sha256").update(text).digest("hex");
 }
@@ -126,7 +127,7 @@ async function submitGeminiBatch(params: {
     },
     onResponse: async (fileRes) => {
       if (!fileRes.ok) {
-        const text = await fileRes.text();
+        const text = await readResponseTextLimited(fileRes);
         throw new Error(`gemini batch file upload failed: ${fileRes.status} ${text}`);
       }
       return readProviderJsonResponse<{ name?: string; file?: { name?: string } }>(
@@ -166,7 +167,7 @@ async function submitGeminiBatch(params: {
       if (batchRes.ok) {
         return readProviderJsonResponse<GeminiBatchStatus>(batchRes, "gemini.batch-create");
       }
-      const text = await batchRes.text();
+      const text = await readResponseTextLimited(batchRes);
       if (batchRes.status === 404) {
         throw new Error(
           "gemini batch create failed: 404 (asyncBatchEmbedContent not available for this model/baseUrl). Disable remote.batch.enabled or switch providers.",
@@ -202,10 +203,12 @@ async function fetchGeminiBatchStatus(params: {
   });
 }
 
-async function fetchGeminiFileContent(params: {
+async function readGeminiBatchOutputFile(params: {
   gemini: GeminiEmbeddingClient;
   fileId: string;
-}): Promise<string> {
+  maxLines: number;
+  onLine: (line: GeminiBatchOutputLine) => void;
+}): Promise<void> {
   const baseUrl = normalizeBatchBaseUrl(params.gemini);
   const file = params.fileId.startsWith("files/") ? params.fileId : `files/${params.fileId}`;
   const downloadUrl = `${baseUrl}/${file}:download`;
@@ -220,18 +223,96 @@ async function fetchGeminiFileContent(params: {
       if (!res.ok) {
         throw await createProviderHttpError(res, "gemini batch file content failed");
       }
-      return await res.text();
+      return await readGeminiBatchOutputLines(res, {
+        maxLines: params.maxLines,
+        onLine: params.onLine,
+      });
     },
   });
 }
 
-function parseGeminiBatchOutput(text: string): GeminiBatchOutputLine[] {
-  if (!text.trim()) {
-    return [];
+function parseGeminiBatchOutputLine(line: string): GeminiBatchOutputLine {
+  return JSON.parse(line) as GeminiBatchOutputLine;
+}
+
+async function readGeminiBatchOutputLines(
+  response: Response,
+  params: {
+    maxLines: number;
+    onLine: (line: GeminiBatchOutputLine) => void;
+  },
+): Promise<void> {
+  const reader = response.body?.getReader();
+  if (!reader) {
+    return;
   }
-  return normalizeStringEntries(text.split("\n")).map(
-    (line) => JSON.parse(line) as GeminiBatchOutputLine,
-  );
+
+  const decoder = new TextDecoder();
+  const encoder = new TextEncoder();
+  let lineCount = 0;
+  let line = "";
+  let lineBytes = 0;
+
+  const appendSegment = (segment: string) => {
+    if (!segment) {
+      return;
+    }
+    lineBytes += encoder.encode(segment).byteLength;
+    if (lineBytes > GEMINI_BATCH_OUTPUT_LINE_MAX_BYTES) {
+      throw new Error(
+        `gemini.batch-file-content: JSONL line exceeds ${GEMINI_BATCH_OUTPUT_LINE_MAX_BYTES} bytes`,
+      );
+    }
+    line += segment;
+  };
+
+  const emitLine = () => {
+    lineCount += 1;
+    if (lineCount > params.maxLines) {
+      throw new Error(`gemini.batch-file-content: JSONL output exceeds ${params.maxLines} records`);
+    }
+    const trimmed = line.trim();
+    line = "";
+    lineBytes = 0;
+    if (trimmed) {
+      params.onLine(parseGeminiBatchOutputLine(trimmed));
+    }
+  };
+
+  const consumeText = (text: string) => {
+    let offset = 0;
+    while (true) {
+      const newline = text.indexOf("\n", offset);
+      if (newline === -1) {
+        appendSegment(text.slice(offset));
+        return;
+      }
+      appendSegment(text.slice(offset, newline));
+      emitLine();
+      offset = newline + 1;
+    }
+  };
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      if (value && value.byteLength > 0) {
+        consumeText(decoder.decode(value, { stream: true }));
+      }
+    }
+    consumeText(decoder.decode());
+    if (line.trim()) {
+      emitLine();
+    }
+  } catch (error) {
+    await reader.cancel().catch(() => {});
+    throw error;
+  } finally {
+    reader.releaseLock();
+  }
 }
 
 async function waitForGeminiBatch(params: {
@@ -344,37 +425,37 @@ export async function runGeminiEmbeddingBatches(
         throw new Error(`gemini batch ${batchName} completed without output file`);
       }
 
-      const content = await fetchGeminiFileContent({
-        gemini: params.gemini,
-        fileId: completed.outputFileId,
-      });
-      const outputLines = parseGeminiBatchOutput(content);
       const errors: string[] = [];
       const remaining = new Set(group.map((request) => request.custom_id));
 
-      for (const line of outputLines) {
-        const customId = line.key ?? line.custom_id ?? line.request_id;
-        if (!customId) {
-          continue;
-        }
-        remaining.delete(customId);
-        if (line.error?.message) {
-          errors.push(`${customId}: ${line.error.message}`);
-          continue;
-        }
-        if (line.response?.error?.message) {
-          errors.push(`${customId}: ${line.response.error.message}`);
-          continue;
-        }
-        const embedding = sanitizeAndNormalizeEmbedding(
-          line.embedding?.values ?? line.response?.embedding?.values ?? [],
-        );
-        if (embedding.length === 0) {
-          errors.push(`${customId}: empty embedding`);
-          continue;
-        }
-        byCustomId.set(customId, embedding);
-      }
+      await readGeminiBatchOutputFile({
+        gemini: params.gemini,
+        fileId: completed.outputFileId,
+        maxLines: group.length,
+        onLine: (line) => {
+          const customId = line.key ?? line.custom_id ?? line.request_id;
+          if (!customId || !remaining.has(customId)) {
+            return;
+          }
+          remaining.delete(customId);
+          if (line.error?.message) {
+            errors.push(`${customId}: ${line.error.message}`);
+            return;
+          }
+          if (line.response?.error?.message) {
+            errors.push(`${customId}: ${line.response.error.message}`);
+            return;
+          }
+          const embedding = sanitizeAndNormalizeEmbedding(
+            line.embedding?.values ?? line.response?.embedding?.values ?? [],
+          );
+          if (embedding.length === 0) {
+            errors.push(`${customId}: empty embedding`);
+            return;
+          }
+          byCustomId.set(customId, embedding);
+        },
+      });
 
       if (errors.length > 0) {
         throw new Error(`gemini batch ${batchName} failed: ${errors.join("; ")}`);


### PR DESCRIPTION
## What Problem This Solves

Fixes a sibling OOM risk to #98554 in Gemini/Google embedding batch handling. The Gemini batch upload/create error paths and completed output download path still had raw response body reads. A faulty or hostile Google-compatible endpoint could stream oversized error bodies, an oversized JSONL record, or extra/blank output records after a batch completed.

## Why This Change Was Made

The Google embedding batch code now uses the shared bounded provider HTTP readers for upload/create error bodies, and streams completed JSONL output one record at a time instead of buffering the whole file.

The output reader keeps valid large batch outputs working by allowing files larger than the provider text cap, while bounding the unsafe shapes:

- error response bodies are read with `readResponseTextLimited`
- each JSONL output record is capped at 4 MiB
- the number of output records is capped to the submitted request group size
- blank/whitespace JSONL records count against that record budget
- unknown `custom_id` rows are ignored instead of being stored in the result map

This follows the same invariant as the recent OpenAI embedding batch hardening: large valid JSONL output should stream successfully, but malformed single-record or unbounded provider output must be cancelled early.

## User Impact

Users running large Gemini embedding batches can still process valid large result files, and a bad provider response cannot grow gateway memory through unbounded response buffering or unlimited small output rows.

## Evidence

Loopback transport proof: I ran the production `runGeminiEmbeddingBatches` path against a local HTTP server on `127.0.0.1`. This uses the real `withRemoteHttpResponse` / `fetchWithSsrFGuard` path, real HTTP `Response` streams, and no mocked `fetch`.

```text
$ node --import tsx .automation/openclaw-gemini-loopback-proof.mjs
{
  "proof": "gemini embedding batch loopback",
  "valid": {
    "mode": "valid-jsonl-output-over-loopback",
    "ok": true,
    "vectors": 8,
    "downloadWrites": 8,
    "cancelObserved": false,
    "ms": 56
  },
  "oversized": {
    "mode": "oversized-output-line-cancel-over-loopback",
    "ok": false,
    "error": "gemini.batch-file-content: JSONL line exceeds 4194304 bytes",
    "downloadWrites": 7,
    "cancelObserved": true,
    "ms": 253
  }
}
```

Targeted unit proof: the tests drive `runGeminiEmbeddingBatches` through upload, batch create, status polling, and output download using real `Response` streams passed through the production `withRemoteHttpResponse` callback shape. They cover the large-output and record-budget cases that are cheaper to validate deterministically in-process.

```text
$ node scripts/run-vitest.mjs extensions/google/embedding-batch.test.ts -- --reporter=verbose
 ✓ |extension-providers| extensions/google/embedding-batch.test.ts > Google embedding-batch bounded JSON reads > bounds oversized file-upload error bodies and cancels the stream
 ✓ |extension-providers| extensions/google/embedding-batch.test.ts > Google embedding-batch bounded JSON reads > bounds oversized batch-create error bodies and cancels the stream
 ✓ |extension-providers| extensions/google/embedding-batch.test.ts > Google embedding-batch bounded JSON reads > bounds oversized file-upload JSON response and cancels the stream
 ✓ |extension-providers| extensions/google/embedding-batch.test.ts > Google embedding-batch bounded JSON reads > bounds oversized batch-create JSON response and cancels the stream
 ✓ |extension-providers| extensions/google/embedding-batch.test.ts > Google embedding-batch bounded JSON reads > bounds oversized batch-status poll JSON response and cancels the stream
 ✓ |extension-providers| extensions/google/embedding-batch.test.ts > Google embedding-batch bounded JSON reads > parses small responses on all three JSON paths correctly
 ✓ |extension-providers| extensions/google/embedding-batch.test.ts > Google embedding-batch bounded JSON reads > streams valid batch output files larger than the provider text cap
 ✓ |extension-providers| extensions/google/embedding-batch.test.ts > Google embedding-batch bounded JSON reads > bounds oversized batch output downloads and cancels the stream
 ✓ |extension-providers| extensions/google/embedding-batch.test.ts > Google embedding-batch bounded JSON reads > bounds batch output record count to the submitted request group
 ✓ |extension-providers| extensions/google/embedding-batch.test.ts > Google embedding-batch bounded JSON reads > counts blank batch output records against the submitted request group

 Test Files  1 passed (1)
      Tests  10 passed (10)
[test] passed 1 Vitest shard
```

```text
$ node_modules\.bin\oxfmt --check extensions/google/embedding-batch.ts extensions/google/embedding-batch.test.ts
Checking formatting...

All matched files use the correct format.
```

```text
$ node_modules\.bin\oxlint --tsconfig config/tsconfig/oxlint.core.json extensions/google/embedding-batch.ts extensions/google/embedding-batch.test.ts
# passed
```

```text
$ git diff --check -- extensions/google/embedding-batch.ts extensions/google/embedding-batch.test.ts
# passed
```

```text
$ F:\Program\Python\Python313\python.exe .agents\skills\autoreview\scripts\autoreview --mode local
autoreview clean: no accepted/actionable findings reported
```

Notes for reviewers:

- The 4 MiB per-line cap and submitted-request-count record budget are intentional fail-closed bounds. They match the safety shape of the merged OpenAI sibling hardening in #98554: valid multi-record output can stream, but one malformed record or unlimited extra provider rows cannot grow memory without bound.
- This PR does not add or migrate persistent state. The ClawSweeper stored-data-model warning appears to be a keyword false positive from embedding metadata terminology in `extensions/google/embedding-batch.ts` and its tests.

AI-assisted: built with Codex. I understand the change: it replaces unbounded Gemini batch response reads with bounded error reads plus a streaming JSONL output reader capped by per-record byte size and submitted record count.