### PR TITLE
fix(telegram): use index-based callback_data to avoid silent model drops in /model picker (fixes #98221)

### DIFF
--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -2359,8 +2359,18 @@ describe("createTelegramBot", () => {
       ).reply_markup?.inline_keyboard;
 
       expect(inlineKeyboard).toStrictEqual([
-        [{ text: "GPT 4.1 Bridge", callback_data: "mdl_sel_openai/gpt-4.1" }],
-        [{ text: "GPT Five Bridge ✓", callback_data: "mdl_sel_openai/gpt-5" }],
+        [
+          {
+            text: "GPT 4.1 Bridge",
+            callback_data: expect.stringMatching(/^mdl_sel_openai_\d+_\d+_\d+_[a-f0-9]{4}$/),
+          },
+        ],
+        [
+          {
+            text: "GPT Five Bridge ✓",
+            callback_data: expect.stringMatching(/^mdl_sel_openai_\d+_\d+_\d+_[a-f0-9]{4}$/),
+          },
+        ],
         [{ text: "<< Back", callback_data: "mdl_back" }],
       ]);
       expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-model-display-names-1");

--- a/extensions/telegram/src/model-buttons.test.ts
+++ b/extensions/telegram/src/model-buttons.test.ts
@@ -20,18 +20,18 @@ describe("parseModelCallbackData", () => {
       ["mdl_list_anthropic_2", { type: "list", provider: "anthropic", page: 2 }],
       ["mdl_list_open-ai_1", { type: "list", provider: "open-ai", page: 1 }],
       ["mdl_list_hf.co_1", { type: "list", provider: "hf.co", page: 1 }],
+      // Index-based select format (#98221)
       [
-        "mdl_sel_anthropic/claude-sonnet-4-5",
-        { type: "select", provider: "anthropic", model: "claude-sonnet-4-5" },
-      ],
-      ["mdl_sel_openai/gpt-4/turbo", { type: "select", provider: "openai", model: "gpt-4/turbo" }],
-      [
-        "mdl_sel/us.anthropic.claude-3-5-sonnet-20240620-v1:0",
-        { type: "select", model: "us.anthropic.claude-3-5-sonnet-20240620-v1:0" },
+        "mdl_sel_anthropic_1_1_2",
+        { type: "select", provider: "anthropic", page: 1, modelIndex: 1, totalCount: 2 },
       ],
       [
-        "mdl_sel/anthropic/claude-3-7-sonnet",
-        { type: "select", model: "anthropic/claude-3-7-sonnet" },
+        "mdl_sel_openai_2_5_8",
+        { type: "select", provider: "openai", page: 2, modelIndex: 5, totalCount: 8 },
+      ],
+      [
+        "mdl_sel_hf.co_1_12_42",
+        { type: "select", provider: "hf.co", page: 1, modelIndex: 12, totalCount: 42 },
       ],
       ["  mdl_prov  ", { type: "providers" }],
     ] as const;
@@ -49,7 +49,7 @@ describe("parseModelCallbackData", () => {
       "mdl_list_",
       "mdl_list_openai_9007199254740993",
       "mdl_sel_noslash",
-      "mdl_sel/",
+      "mdl_sel_",
     ];
     for (const input of invalid) {
       expect(parseModelCallbackData(input), input).toBeNull();
@@ -58,9 +58,9 @@ describe("parseModelCallbackData", () => {
 });
 
 describe("resolveModelSelection", () => {
-  it("returns explicit provider selections unchanged", () => {
+  it("resolves by provider and modelIndex from sorted models", () => {
     const result = resolveModelSelection({
-      callback: { type: "select", provider: "openai", model: "gpt-4.1" },
+      callback: { type: "select", provider: "openai", page: 1, modelIndex: 1, totalCount: 1 },
       providers: ["openai", "anthropic"],
       byProvider: new Map([
         ["openai", new Set(["gpt-4.1"])],
@@ -70,63 +70,121 @@ describe("resolveModelSelection", () => {
     expect(result).toEqual({ kind: "resolved", provider: "openai", model: "gpt-4.1" });
   });
 
-  it("resolves compact callbacks when exactly one provider matches", () => {
+  it("resolves by index into correctly sorted models", () => {
+    // Models are sorted alphabetically: claude-opus-4, claude-sonnet-4
     const result = resolveModelSelection({
-      callback: { type: "select", model: "shared" },
-      providers: ["openai", "anthropic"],
-      byProvider: new Map([
-        ["openai", new Set(["shared"])],
-        ["anthropic", new Set(["other"])],
-      ]),
+      callback: { type: "select", provider: "anthropic", page: 1, modelIndex: 2, totalCount: 2 },
+      providers: ["anthropic"],
+      byProvider: new Map([["anthropic", new Set(["claude-sonnet-4", "claude-opus-4"])]]),
     });
-    expect(result).toEqual({ kind: "resolved", provider: "openai", model: "shared" });
+    expect(result).toEqual({ kind: "resolved", provider: "anthropic", model: "claude-sonnet-4" });
   });
 
-  it("returns ambiguous result when zero or multiple providers match", () => {
-    const sharedByBoth = resolveModelSelection({
-      callback: { type: "select", model: "shared" },
-      providers: ["openai", "anthropic"],
-      byProvider: new Map([
-        ["openai", new Set(["shared"])],
-        ["anthropic", new Set(["shared"])],
-      ]),
+  it("returns ambiguous when totalCount differs (stale button guard)", () => {
+    const result = resolveModelSelection({
+      callback: { type: "select", provider: "openai", page: 1, modelIndex: 1, totalCount: 5 },
+      providers: ["openai"],
+      byProvider: new Map([["openai", new Set(["gpt-4.1"])]]),
     });
-    expect(sharedByBoth).toEqual({
-      kind: "ambiguous",
-      model: "shared",
-      matchingProviders: ["openai", "anthropic"],
-    });
+    expect(result.kind).toBe("ambiguous");
+  });
 
-    const missingEverywhere = resolveModelSelection({
-      callback: { type: "select", model: "missing" },
+  it("rejects stale fingerprinted callback on same-count different-model list (#98221)", () => {
+    // ["a", "bc"] and ["ab", "c"] have the same concatenated character
+    // stream but different models. The delimiter in the fingerprint must
+    // distinguish them so a button from the first list is rejected when
+    // the provider's models change to the second list.
+    const modelsA = new Set(["a", "bc"]);
+    const result = resolveModelSelection({
+      callback: {
+        type: "select",
+        provider: "p",
+        page: 1,
+        modelIndex: 1,
+        totalCount: 2,
+        fingerprint: "dead",
+      },
+      providers: ["p"],
+      byProvider: new Map([["p", modelsA]]),
+    });
+    // Real fingerprint of modelsA ≠ "dead" → rejected as stale
+    expect(result.kind).toBe("ambiguous");
+  });
+
+  it("returns ambiguous result when provider has no models", () => {
+    const result = resolveModelSelection({
+      callback: { type: "select", provider: "missing", page: 1, modelIndex: 1, totalCount: 0 },
       providers: ["openai", "anthropic"],
-      byProvider: new Map([
-        ["openai", new Set(["gpt-4.1"])],
-        ["anthropic", new Set(["claude-sonnet-4-5"])],
-      ]),
+      byProvider: new Map([["openai", new Set(["gpt-4.1"])]]),
     });
-    expect(missingEverywhere).toEqual({
-      kind: "ambiguous",
-      model: "missing",
-      matchingProviders: [],
+    expect(result).toMatchObject({ kind: "ambiguous", matchingProviders: ["openai", "anthropic"] });
+  });
+
+  it("returns ambiguous result when modelIndex is out of range", () => {
+    const result = resolveModelSelection({
+      callback: { type: "select", provider: "openai", page: 1, modelIndex: 99, totalCount: 1 },
+      providers: ["openai", "anthropic"],
+      byProvider: new Map([["openai", new Set(["gpt-4.1"])]]),
     });
+    expect(result.kind).toBe("ambiguous");
   });
 });
 
 describe("buildModelSelectionCallbackData", () => {
-  it("uses standard callback when under limit and compact callback when needed", () => {
-    expect(buildModelSelectionCallbackData({ provider: "openai", model: "gpt-4.1" })).toBe(
-      "mdl_sel_openai/gpt-4.1",
-    );
-    const longModel = "us.anthropic.claude-3-5-sonnet-20240620-v1:0";
-    expect(buildModelSelectionCallbackData({ provider: "amazon-bedrock", model: longModel })).toBe(
-      `mdl_sel/${longModel}`,
-    );
+  it("builds fixed-length index-based callback with fingerprint (#98221)", () => {
+    const models5 = ["gpt-4", "gpt-4.1", "gpt-5", "claude-3", "gemini-2"];
+    const cb1 = buildModelSelectionCallbackData({
+      provider: "openai",
+      page: 1,
+      modelIndex: 1,
+      totalCount: 5,
+      models: models5,
+    });
+    expect(cb1).toMatch(/^mdl_sel_openai_1_1_5_[a-f0-9]{4}$/);
+    const models42 = Array.from({ length: 42 }, (_, i) => `model-${i}`);
+    const cb2 = buildModelSelectionCallbackData({
+      provider: "anthropic",
+      page: 3,
+      modelIndex: 12,
+      totalCount: 42,
+      models: models42,
+    });
+    expect(cb2).toMatch(/^mdl_sel_anthropic_3_12_42_[a-f0-9]{4}$/);
+    // Never embeds model name — always fits 64 bytes
+    const cb3 = buildModelSelectionCallbackData({
+      provider: "a",
+      page: 1,
+      modelIndex: 1,
+      totalCount: 1,
+      models: ["x"],
+    });
+    expect(cb3.length).toBeLessThan(64);
   });
+});
 
-  it("returns null when even compact callback exceeds Telegram limit", () => {
-    const tooLongModel = "x".repeat(80);
-    expect(buildModelSelectionCallbackData({ provider: "openai", model: tooLongModel })).toBeNull();
+describe("fingerprint delimiter disambiguation (#98221)", () => {
+  it("produces different callback_data for same-character-stream model lists", () => {
+    // ["a", "bc"] and ["ab", "c"] both concatenate to "abc" but represent
+    // different model sets. The delimiter in computeModelListFingerprint
+    // must produce different fingerprints for these two lists.
+    const cb1 = buildModelSelectionCallbackData({
+      provider: "p",
+      page: 1,
+      modelIndex: 1,
+      totalCount: 2,
+      models: ["a", "bc"],
+    });
+    const cb2 = buildModelSelectionCallbackData({
+      provider: "p",
+      page: 1,
+      modelIndex: 1,
+      totalCount: 2,
+      models: ["ab", "c"],
+    });
+    expect(cb1).not.toBe(cb2);
+    // Both still under 64 bytes
+    expect(Buffer.byteLength(cb1, "utf8")).toBeLessThanOrEqual(64);
+    expect(Buffer.byteLength(cb2, "utf8")).toBeLessThanOrEqual(64);
   });
 });
 
@@ -225,8 +283,9 @@ describe("buildModelsKeyboard", () => {
       // 2 model rows + back button
       expect(result, testCase.name).toHaveLength(3);
       expect(result[0]?.[0]?.text).toBe(testCase.firstText);
-      expect(result[0]?.[0]?.callback_data).toBe("mdl_sel_anthropic/claude-sonnet-4");
+      expect(result[0]?.[0]?.callback_data).toMatch(/^mdl_sel_anthropic_1_1_2_[a-f0-9]{4}$/);
       expect(result[1]?.[0]?.text).toBe("claude-opus-4");
+      expect(result[1]?.[0]?.callback_data).toMatch(/^mdl_sel_anthropic_1_2_2_[a-f0-9]{4}$/);
       expect(result[2]?.[0]?.text).toBe("<< Back");
     }
   });
@@ -247,10 +306,8 @@ describe("buildModelsKeyboard", () => {
     expect(result).toHaveLength(3);
     expect(result[0]?.[0]?.text).toBe("Claude Sonnet 4");
     expect(result[1]?.[0]?.text).toBe("Claude Opus 4");
-    // callback_data still uses the raw model ID, not the display name
-    expect(result[0]?.[0]?.callback_data).toBe(
-      "mdl_sel_nexos/a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-    );
+    // callback_data uses index format, not model ID (#98221)
+    expect(result[0]?.[0]?.callback_data).toMatch(/^mdl_sel_nexos_1_1_2_[a-f0-9]{4}$/);
   });
 
   it("falls back to model ID when modelNames does not contain an entry", () => {
@@ -423,18 +480,6 @@ describe("buildModelsKeyboard", () => {
       expect(result[0]?.[0]?.text, testCase.name).toBe(`…${"b".repeat(36)}`);
     }
   });
-
-  it("uses compact selection callback when provider/model callback exceeds 64 bytes", () => {
-    const model = "us.anthropic.claude-3-5-sonnet-20240620-v1:0";
-    const result = buildModelsKeyboard({
-      provider: "amazon-bedrock",
-      models: [model],
-      currentPage: 1,
-      totalPages: 1,
-    });
-
-    expect(result[0]?.[0]?.callback_data).toBe(`mdl_sel/${model}`);
-  });
 });
 
 describe("buildBrowseProvidersButton", () => {
@@ -473,9 +518,8 @@ describe("large model lists (OpenRouter-scale)", () => {
   it("handles 100+ models with pagination", () => {
     const models = Array.from({ length: 150 }, (_, i) => `model-${i}`);
     const totalPages = calculateTotalPages(models.length);
-    expect(totalPages).toBe(19); // 150 / 8 = 18.75 -> 19 pages
+    expect(totalPages).toBe(19);
 
-    // Test first page
     const firstPage = buildModelsKeyboard({
       provider: "openrouter",
       models,
@@ -486,20 +530,18 @@ describe("large model lists (OpenRouter-scale)", () => {
     expect(firstPage[0]?.[0]?.text).toBe("model-0");
     expect(firstPage[7]?.[0]?.text).toBe("model-7");
 
-    // Test last page
     const lastPage = buildModelsKeyboard({
       provider: "openrouter",
       models,
       currentPage: 19,
       totalPages,
     });
-    // Last page has 150 - (18 * 8) = 6 models
     expect(lastPage.length).toBe(8); // 6 models + pagination + back
     expect(lastPage[0]?.[0]?.text).toBe("model-144");
   });
 
-  it("all callback_data stays within 64-byte limit", () => {
-    // Realistic OpenRouter model IDs
+  it("all callback_data stays within 64-byte limit (#98221)", () => {
+    // Realistic model IDs — all should create valid callbacks now
     const models = [
       "anthropic/claude-3-5-sonnet-20241022",
       "google/gemini-2.0-flash-thinking-exp:free",
@@ -522,23 +564,29 @@ describe("large model lists (OpenRouter-scale)", () => {
     }
   });
 
-  it("skips models that would exceed callback_data limit", () => {
-    const models = [
-      "short-model",
-      "this-is-an-extremely-long-model-name-that-definitely-exceeds-the-sixty-four-byte-limit",
-      "another-short",
-    ];
+  it("never drops models due to callback_data limit (#98221)", () => {
+    // The exact scenario from the bug report
+    const longModel = "xentriom/gemma-4-12B-agentic-fable5-composer2.5-v2:latest";
+    const models = ["short-model-1", longModel, "short-model-2"];
     const result = buildModelsKeyboard({
-      provider: "openrouter",
+      provider: "ollama",
       models,
       currentPage: 1,
       totalPages: 1,
     });
 
-    // Should have 2 model buttons (skipping the long one) + back
+    // All 3 models should appear (no silent drops)
     const modelButtons = result.filter((row) => !row[0]?.callback_data.startsWith("mdl_back"));
-    expect(modelButtons.length).toBe(2);
-    expect(modelButtons[0]?.[0]?.text).toBe("short-model");
-    expect(modelButtons[1]?.[0]?.text).toBe("another-short");
+    expect(modelButtons.length).toBe(3);
+    expect(modelButtons[0]?.[0]?.text).toBe("short-model-1");
+    expect(modelButtons[1]?.[0]?.text).toBe("…-agentic-fable5-composer2.5-v2:latest");
+    expect(modelButtons[2]?.[0]?.text).toBe("short-model-2");
+
+    // All callback_data is under 64 bytes
+    for (const row of result) {
+      for (const button of row) {
+        expect(Buffer.byteLength(button.callback_data, "utf8")).toBeLessThanOrEqual(64);
+      }
+    }
   });
 });

--- a/extensions/telegram/src/model-buttons.ts
+++ b/extensions/telegram/src/model-buttons.ts
@@ -2,23 +2,32 @@
  * Telegram inline button utilities for model selection.
  *
  * Callback data patterns (max 64 bytes for Telegram):
- * - mdl_prov              - show providers list
- * - mdl_list_{prov}_{pg}  - show models for provider (page N, 1-indexed)
- * - mdl_sel_{provider/id} - select model (standard)
- * - mdl_sel/{model}       - select model (compact fallback when standard is >64 bytes)
- * - mdl_back              - back to providers list
+ * - mdl_prov                      - show providers list
+ * - mdl_list_{prov}_{pg}          - show models for provider (page N, 1-indexed)
+ * - mdl_sel_{prov}_{pg}_{idx}     - select model by page + absolute index
+ * - mdl_back                      - back to providers list
+ *
+ * The index-based select format avoids the 64-byte callback_data limit:
+ * model names are never embedded in the button data (#98221).
  */
 import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
 import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
 import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
-import { fitsTelegramCallbackData } from "./approval-callback-data.js";
 
 export type ButtonRow = Array<{ text: string; callback_data: string }>;
 
 export type ParsedModelCallback =
   | { type: "providers" }
   | { type: "list"; provider: string; page: number }
-  | { type: "select"; provider?: string; model: string }
+  | {
+      type: "select";
+      provider?: string;
+      page: number;
+      modelIndex: number;
+      totalCount: number;
+      fingerprint?: string;
+      model?: string;
+    }
   | { type: "back" };
 
 export type ProviderInfo = {
@@ -48,8 +57,7 @@ const CALLBACK_PREFIX = {
   providers: "mdl_prov",
   back: "mdl_back",
   list: "mdl_list_",
-  selectStandard: "mdl_sel_",
-  selectCompact: "mdl_sel/",
+  select: "mdl_sel_",
 } as const;
 
 /**
@@ -76,19 +84,36 @@ export function parseModelCallbackData(data: string): ParsedModelCallback | null
     }
   }
 
-  // mdl_sel/{model} (compact fallback)
-  const compactSelMatch = trimmed.match(/^mdl_sel\/(.+)$/);
-  if (compactSelMatch) {
-    const modelRef = compactSelMatch[1];
-    if (modelRef) {
+  // mdl_sel_{provider}_{page}_{modelIndex}_{totalCount}[_{fingerprint}]  (1-based)
+  const idxMatch = trimmed.match(/^mdl_sel_([a-z0-9_.-]+)_(\d+)_(\d+)_(\d+)(?:_([a-f0-9]{4}))?$/i);
+  if (idxMatch) {
+    const [, provider, pageStr, idxStr, totalStr, fingerprint] = idxMatch;
+    const page = parseStrictPositiveInteger(pageStr);
+    const modelIndex = parseStrictPositiveInteger(idxStr);
+    const totalCount = parseStrictPositiveInteger(totalStr);
+    if (provider && page !== undefined && modelIndex !== undefined && totalCount !== undefined) {
       return {
         type: "select",
-        model: modelRef,
+        provider,
+        page,
+        modelIndex,
+        totalCount,
+        fingerprint: fingerprint || undefined,
       };
     }
   }
 
-  // mdl_sel_{provider/model}
+  // Legacy formats (backward compat for in-flight buttons rendered before the index scheme):
+  // mdl_sel/{model} (compact)
+  const compactMatch = trimmed.match(/^mdl_sel\/(.+)$/);
+  if (compactMatch) {
+    const modelRef = compactMatch[1];
+    if (modelRef) {
+      return { type: "select", page: 1, modelIndex: 0, totalCount: 0, model: modelRef };
+    }
+  }
+
+  // mdl_sel_{provider/model} (standard)
   const selMatch = trimmed.match(/^mdl_sel_(.+)$/);
   if (selMatch) {
     const modelRef = selMatch[1];
@@ -98,6 +123,9 @@ export function parseModelCallbackData(data: string): ParsedModelCallback | null
         return {
           type: "select",
           provider: modelRef.slice(0, slashIndex),
+          page: 1,
+          modelIndex: 0,
+          totalCount: 0,
           model: modelRef.slice(slashIndex + 1),
         };
       }
@@ -107,16 +135,39 @@ export function parseModelCallbackData(data: string): ParsedModelCallback | null
   return null;
 }
 
+/**
+ * Compute a short fingerprint of the model list for stale-button detection.
+ * Catches same-count-but-different-content changes that totalCount alone misses.
+ */
+function computeModelListFingerprint(sortedModels: readonly string[]): string {
+  // Rolling hash over model names separated by a delimiter so that
+  // ["ab","c"] and ["a","bc"] produce different fingerprints.
+  let hash = 0;
+  for (const name of sortedModels) {
+    for (let i = 0; i < name.length; i++) {
+      hash = (hash << 5) - hash + name.charCodeAt(i);
+      hash |= 0;
+    }
+    // Delimiter between model names prevents concatenation ambiguity
+    hash = (hash << 5) - hash + 0x7c; // '|'
+    hash |= 0;
+  }
+  return (hash >>> 0).toString(16).slice(0, 4);
+}
+
 export function buildModelSelectionCallbackData(params: {
   provider: string;
-  model: string;
-}): string | null {
-  const fullCallbackData = `${CALLBACK_PREFIX.selectStandard}${params.provider}/${params.model}`;
-  if (fitsTelegramCallbackData(fullCallbackData)) {
-    return fullCallbackData;
-  }
-  const compactCallbackData = `${CALLBACK_PREFIX.selectCompact}${params.model}`;
-  return fitsTelegramCallbackData(compactCallbackData) ? compactCallbackData : null;
+  page: number;
+  modelIndex: number;
+  totalCount: number;
+  models: readonly string[];
+}): string {
+  // Fixed-length callback (page, modelIndex, totalCount are 1-based).
+  // Never embeds model names, always fits in 64 bytes (#98221).
+  // totalCount + fingerprint guard against stale buttons: if the provider's
+  // model list changes between render and click, the mismatch is detected.
+  const snapshot = computeModelListFingerprint(params.models);
+  return `${CALLBACK_PREFIX.select}${params.provider}_${params.page}_${params.modelIndex}_${params.totalCount}_${snapshot}`;
 }
 
 export function resolveModelSelection(params: {
@@ -124,28 +175,53 @@ export function resolveModelSelection(params: {
   providers: readonly string[];
   byProvider: ReadonlyMap<string, ReadonlySet<string>>;
 }): ResolveModelSelectionResult {
-  if (params.callback.provider) {
-    return {
-      kind: "resolved",
-      provider: params.callback.provider,
-      model: params.callback.model,
-    };
+  const { provider, modelIndex, totalCount, model: legacyModel } = params.callback;
+
+  // Legacy callback (pre-index format): resolve by model name across providers.
+  if (legacyModel) {
+    if (provider) {
+      return { kind: "resolved", provider, model: legacyModel };
+    }
+    const matchingProviders = params.providers.filter((id) =>
+      params.byProvider.get(id)?.has(legacyModel),
+    );
+    if (matchingProviders.length === 1) {
+      return {
+        kind: "resolved",
+        provider: expectDefined(matchingProviders.at(0), "single matching model provider"),
+        model: legacyModel,
+      };
+    }
+    return { kind: "ambiguous", model: legacyModel, matchingProviders };
   }
-  const matchingProviders = params.providers.filter((id) =>
-    params.byProvider.get(id)?.has(params.callback.model),
-  );
-  if (matchingProviders.length === 1) {
-    return {
-      kind: "resolved",
-      provider: expectDefined(matchingProviders.at(0), "single matching model provider"),
-      model: params.callback.model,
-    };
+
+  // Index-based callback: resolve by provider + index, with stale guards.
+  if (!provider) {
+    return { kind: "ambiguous", model: "", matchingProviders: [...params.providers] };
   }
-  return {
-    kind: "ambiguous",
-    model: params.callback.model,
-    matchingProviders,
-  };
+  const models = params.byProvider.get(provider);
+  if (!models || models.size === 0) {
+    return { kind: "ambiguous", model: "", matchingProviders: [...params.providers] };
+  }
+  if (totalCount > 0) {
+    // Reject stale buttons via count mismatch (add/remove detected).
+    if (models.size !== totalCount) {
+      return { kind: "ambiguous", model: "", matchingProviders: [...params.providers] };
+    }
+    // Reject stale buttons via fingerprint mismatch (same-count-different-content).
+    const sorted = [...models].toSorted((a, b) => a.localeCompare(b));
+    const expectedFingerprint = computeModelListFingerprint(sorted);
+    if (params.callback.fingerprint && params.callback.fingerprint !== expectedFingerprint) {
+      return { kind: "ambiguous", model: "", matchingProviders: [...params.providers] };
+    }
+    const model = sorted[modelIndex - 1]; // modelIndex is 1-based
+    if (!model) {
+      return { kind: "ambiguous", model: "", matchingProviders: [...params.providers] };
+    }
+    return { kind: "resolved", provider, model };
+  }
+  // totalCount === 0 means legacy callback with model name — handled above.
+  return { kind: "ambiguous", model: "", matchingProviders: [...params.providers] };
 }
 
 function isCurrentModelSelection(params: {
@@ -213,12 +289,15 @@ export function buildModelsKeyboard(params: ModelsKeyboardParams): ButtonRow[] {
   const endIndex = Math.min(startIndex + pageSize, models.length);
   const pageModels = models.slice(startIndex, endIndex);
 
-  for (const model of pageModels) {
-    const callbackData = buildModelSelectionCallbackData({ provider, model });
-    // Skip models that still exceed Telegram's callback_data limit.
-    if (!callbackData) {
-      continue;
-    }
+  for (const [pageIdx, model] of pageModels.entries()) {
+    const modelIndex = startIndex + pageIdx + 1; // 1-based absolute index in sorted models (#98221)
+    const callbackData = buildModelSelectionCallbackData({
+      provider,
+      page: currentPage,
+      modelIndex,
+      totalCount: models.length,
+      models, // snapshot for stale-button detection
+    });
 
     const isCurrentModel = isCurrentModelSelection({ currentModel, provider, model });
     const fallbackLabel = model.includes("/") ? `${provider}/${model}` : model;


### PR DESCRIPTION
## What Problem This Solves

Fixes #98221.

When a model ID is long enough that even the compact callback encoding exceeds Telegram's 64-byte limit, `buildModelSelectionCallbackData` returns `null` and the model is silently skipped from the button list. The header says "7 available" but only 6 buttons render, with no indication a model was dropped.

## Changes Made

- `extensions/telegram/src/model-buttons.ts`: Replaced embed-model-name callback format with a fixed-length index-based format (`mdl_sel_{provider}_{page}_{index}`) that never embeds model names. The resolver looks up the actual model from the sorted provider model list by 1-based index.
- `extensions/telegram/src/model-buttons.test.ts`: Updated tests for the new format, including a regression test for the exact long-model-name scenario from the bug report.

## Evidence

### Production code test output
```
$ node scripts/run-vitest.mjs run extensions/telegram/src/model-buttons.test.ts
 ✓ |extension-telegram| extensions/telegram/src/model-buttons.test.ts > buildProviderKeyboard > lays out providers in two-column rows 1ms
 ✓ |extension-telegram| extensions/telegram/src/model-buttons.test.ts > buildModelsKeyboard > shows back button for empty models 2ms
 ✓ |extension-telegram| extensions/telegram/src/model-buttons.test.ts > buildModelsKeyboard > renders model rows and optional current-model indicator 2ms
 ✓ |extension-telegram| extensions/telegram/src/model-buttons.test.ts > buildModelsKeyboard > uses modelNames for display text when provided 1ms
 ✓ |extension-telegram| extensions/telegram/src/model-buttons.test.ts > buildModelsKeyboard > falls back to model ID when modelNames does not contain an entry 0ms
 ✓ |extension-telegram| extensions/telegram/src/model-buttons.test.ts > buildModelsKeyboard > prefixes provider in fallback label for nested provider-local ids (OpenRouter) 0ms
 ✓ |extension-telegram| extensions/telegram/src/model-buttons.test.ts > buildModelsKeyboard > marks nested provider-local id as current when full ref matches 0ms
 ✓ |extension-telegram| extensions/telegram/src/model-buttons.test.ts > buildModelsKeyboard > uses provider-scoped modelNames keys to avoid cross-provider collisions 0ms
 ✓ |extension-telegram| extensions/telegram/src/model-buttons.test.ts > buildModelsKeyboard > does not mark same-id models from other providers as current 1ms
 ✓ |extension-telegram| extensions/telegram/src/model-buttons.test.ts > buildModelsKeyboard > renders pagination controls for first, middle, and last pages 1ms
 ✓ |extension-telegram| extensions/telegram/src/model-buttons.test.ts > buildModelsKeyboard > keeps short display IDs untouched and truncates overly long IDs 1ms
 ✓ |extension-telegram| extensions/telegram/src/model-buttons.test.ts > buildBrowseProvidersButton > returns browse providers button 1ms
 ✓ |extension-telegram| extensions/telegram/src/model-buttons.test.ts > getModelsPageSize > returns default page size 0ms
 ✓ |extension-telegram| extensions/telegram/src/model-buttons.test.ts > calculateTotalPages > calculates pages correctly 0ms
 ✓ |extension-telegram| extensions/telegram/src/model-buttons.test.ts > calculateTotalPages > uses custom page size 0ms
 ✓ |extension-telegram| extensions/telegram/src/model-buttons.test.ts > large model lists (OpenRouter-scale) > handles 100+ models with pagination 1ms
 ✓ |extension-telegram| extensions/telegram/src/model-buttons.test.ts > large model lists (OpenRouter-scale) > all callback_data stays within 64-byte limit (#98221) 1ms
 ✓ |extension-telegram| extensions/telegram/src/model-buttons.test.ts > large model lists (OpenRouter-scale) > never drops models due to callback_data limit (#98221) 1ms
 Test Files  1 passed (1)
      Tests  25 passed (25)
```

### Before vs After

**Before:** A model named `xentriom/gemma-4-12B-agentic-fable5-composer2.5-v2:latest` was silently dropped because both standard (72 bytes) and compact (65 bytes) encodings exceed Telegram's 64-byte limit.

**After:** All callback_data values are under 64 bytes regardless of model name length. Even a very long model name never blocks selection.

### Tests (25/25 passed)
- ✓ never drops models due to callback_data limit (#98221)
- ✓ all callback_data stays within 64-byte limit
- ✓ resolves by provider and modelIndex from sorted models
- ✓ handles 100+ models with pagination
- ✓ 25 passed

## AI Assistance 🤖

- **AI-assisted**: Yes
- **Co-Authored-By**: Claude <noreply@anthropic.com>
- **Human confirmed understanding**: Yes