### PR TITLE
Expose legacy plugin manifest doctor lint findings

### DIFF
--- a/src/commands/doctor-plugin-manifests.test.ts
+++ b/src/commands/doctor-plugin-manifests.test.ts
@@ -9,7 +9,6 @@ import {
   collectLegacyPluginManifestContractMigrations,
   legacyPluginManifestContractMigrationToHealthFinding,
   maybeRepairLegacyPluginManifestContracts,
-  repairLegacyPluginManifestContractFindings,
 } from "./doctor-plugin-manifests.js";
 import type { DoctorPrompter } from "./doctor-prompter.js";
 
@@ -279,63 +278,6 @@ describe("doctor plugin manifest legacy contract repair", () => {
     expect(next.contracts).toEqual({
       tools: ["contract_tool"],
     });
-  });
-
-  it("previews legacy manifest rewrites as file effects and diffs", async () => {
-    const pluginsRoot = await suiteTempDirs.make("preview-capability");
-    const root = path.join(pluginsRoot, "openai");
-    fs.mkdirSync(root, { recursive: true });
-    writePackageJson(root);
-    writeManifest(root, {
-      id: "openai",
-      speechProviders: ["openai"],
-      configSchema: { type: "object" },
-    });
-    const manifestPath = path.join(root, "openclaw.plugin.json");
-
-    const result = await repairLegacyPluginManifestContractFindings({
-      config: configWithPluginLoadPath(pluginsRoot),
-      env: {
-        ...process.env,
-      },
-      manifestRoots: [pluginsRoot],
-      findings: [
-        {
-          checkId: "core/doctor/legacy-plugin-manifests",
-          severity: "warning",
-          message: "Plugin manifest openai uses legacy top-level capability keys.",
-          path: manifestPath,
-          target: "openai",
-          requirement: "contracts-capability-keys",
-        },
-      ],
-      dryRun: true,
-      diff: true,
-    });
-
-    expect(result.changes).toEqual([
-      `- ${manifestPath}: moved speechProviders to contracts.speechProviders`,
-    ]);
-    expect(result.effects).toEqual([
-      {
-        kind: "file",
-        action: "would-rewrite-legacy-plugin-manifest-contracts",
-        target: manifestPath,
-        dryRunSafe: false,
-      },
-    ]);
-    expect(result.diffs).toEqual([
-      expect.objectContaining({
-        kind: "file",
-        path: manifestPath,
-        before: expect.stringContaining('"speechProviders"'),
-        after: expect.stringContaining('"contracts"'),
-      }),
-    ]);
-    const unchanged = JSON.parse(fs.readFileSync(manifestPath, "utf-8")) as {
-      speechProviders?: string[];
-    };
-    expect(unchanged.speechProviders).toEqual(["openai"]);
   });
 
   it("ignores non-object contracts payloads when collecting migrations", async () => {

--- a/src/commands/doctor-plugin-manifests.test.ts
+++ b/src/commands/doctor-plugin-manifests.test.ts
@@ -190,8 +190,10 @@ describe("doctor plugin manifest legacy contract repair", () => {
       manifestRoots: [pluginsRoot],
     });
 
-    expect(migration).toBeDefined();
-    expect(legacyPluginManifestContractMigrationToHealthFinding(migration!)).toStrictEqual({
+    if (migration === undefined) {
+      throw new Error("expected legacy manifest migration");
+    }
+    expect(legacyPluginManifestContractMigrationToHealthFinding(migration)).toStrictEqual({
       checkId: "core/doctor/legacy-plugin-manifests",
       severity: "warning",
       message: "Plugin manifest openai uses legacy top-level capability keys.",

--- a/src/commands/doctor-plugin-manifests.test.ts
+++ b/src/commands/doctor-plugin-manifests.test.ts
@@ -7,6 +7,7 @@ import type { RuntimeEnv } from "../runtime.js";
 import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
 import {
   collectLegacyPluginManifestContractMigrations,
+  legacyPluginManifestContractMigrationToHealthFinding,
   maybeRepairLegacyPluginManifestContracts,
 } from "./doctor-plugin-manifests.js";
 import type { DoctorPrompter } from "./doctor-prompter.js";
@@ -167,6 +168,38 @@ describe("doctor plugin manifest legacy contract repair", () => {
         pluginId: "cortex",
       },
     ]);
+  });
+
+  it("maps legacy manifest migrations to structured health findings", async () => {
+    const pluginsRoot = await suiteTempDirs.make("finding-capability");
+    const root = path.join(pluginsRoot, "openai");
+    fs.mkdirSync(root, { recursive: true });
+    writePackageJson(root);
+    writeManifest(root, {
+      id: "openai",
+      speechProviders: ["openai"],
+      configSchema: { type: "object" },
+    });
+
+    const [migration] = collectLegacyPluginManifestContractMigrations({
+      config: configWithPluginLoadPath(pluginsRoot),
+      env: {
+        ...process.env,
+      },
+      manifestRoots: [pluginsRoot],
+    });
+
+    expect(migration).toBeDefined();
+    expect(legacyPluginManifestContractMigrationToHealthFinding(migration!)).toStrictEqual({
+      checkId: "core/doctor/legacy-plugin-manifests",
+      severity: "warning",
+      message: "Plugin manifest openai uses legacy top-level capability keys.",
+      path: path.join(root, "openclaw.plugin.json"),
+      target: "openai",
+      requirement: "contracts-capability-keys",
+      fixHint:
+        "Run `openclaw doctor --fix` to rewrite legacy plugin manifest capability keys under contracts.*.",
+    });
   });
 
   it("rewrites legacy top-level capability keys into contracts", async () => {

--- a/src/commands/doctor-plugin-manifests.test.ts
+++ b/src/commands/doctor-plugin-manifests.test.ts
@@ -9,6 +9,7 @@ import {
   collectLegacyPluginManifestContractMigrations,
   legacyPluginManifestContractMigrationToHealthFinding,
   maybeRepairLegacyPluginManifestContracts,
+  repairLegacyPluginManifestContractFindings,
 } from "./doctor-plugin-manifests.js";
 import type { DoctorPrompter } from "./doctor-prompter.js";
 
@@ -276,6 +277,63 @@ describe("doctor plugin manifest legacy contract repair", () => {
     expect(next.contracts).toEqual({
       tools: ["contract_tool"],
     });
+  });
+
+  it("previews legacy manifest rewrites as file effects and diffs", async () => {
+    const pluginsRoot = await suiteTempDirs.make("preview-capability");
+    const root = path.join(pluginsRoot, "openai");
+    fs.mkdirSync(root, { recursive: true });
+    writePackageJson(root);
+    writeManifest(root, {
+      id: "openai",
+      speechProviders: ["openai"],
+      configSchema: { type: "object" },
+    });
+    const manifestPath = path.join(root, "openclaw.plugin.json");
+
+    const result = await repairLegacyPluginManifestContractFindings({
+      config: configWithPluginLoadPath(pluginsRoot),
+      env: {
+        ...process.env,
+      },
+      manifestRoots: [pluginsRoot],
+      findings: [
+        {
+          checkId: "core/doctor/legacy-plugin-manifests",
+          severity: "warning",
+          message: "Plugin manifest openai uses legacy top-level capability keys.",
+          path: manifestPath,
+          target: "openai",
+          requirement: "contracts-capability-keys",
+        },
+      ],
+      dryRun: true,
+      diff: true,
+    });
+
+    expect(result.changes).toEqual([
+      `- ${manifestPath}: moved speechProviders to contracts.speechProviders`,
+    ]);
+    expect(result.effects).toEqual([
+      {
+        kind: "file",
+        action: "would-rewrite-legacy-plugin-manifest-contracts",
+        target: manifestPath,
+        dryRunSafe: false,
+      },
+    ]);
+    expect(result.diffs).toEqual([
+      expect.objectContaining({
+        kind: "file",
+        path: manifestPath,
+        before: expect.stringContaining('"speechProviders"'),
+        after: expect.stringContaining('"contracts"'),
+      }),
+    ]);
+    const unchanged = JSON.parse(fs.readFileSync(manifestPath, "utf-8")) as {
+      speechProviders?: string[];
+    };
+    expect(unchanged.speechProviders).toEqual(["openai"]);
   });
 
   it("ignores non-object contracts payloads when collecting migrations", async () => {

--- a/src/commands/doctor-plugin-manifests.ts
+++ b/src/commands/doctor-plugin-manifests.ts
@@ -261,7 +261,7 @@ export async function repairLegacyPluginManifestContractFindings(params: {
     let before: string | undefined;
     if (params.diff === true) {
       try {
-        before = readFile(migration.manifestPath, "utf-8").toString();
+        before = readFile(migration.manifestPath, "utf-8");
         diffs.push(legacyPluginManifestMigrationToRepairDiff(migration, before));
       } catch (error) {
         warnings.push(

--- a/src/commands/doctor-plugin-manifests.ts
+++ b/src/commands/doctor-plugin-manifests.ts
@@ -6,7 +6,12 @@ import { normalizeTrimmedStringList } from "@openclaw/normalization-core/string-
 import { z } from "zod";
 import { note } from "../../packages/terminal-core/src/note.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import type { HealthFinding } from "../flows/health-checks.js";
+import type {
+  HealthFinding,
+  HealthRepairDiff,
+  HealthRepairEffect,
+  HealthRepairResult,
+} from "../flows/health-checks.js";
 import { loadPluginManifestRegistry } from "../plugins/manifest-registry.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { shortenHomePath } from "../utils.js";
@@ -169,6 +174,136 @@ export function legacyPluginManifestContractMigrationToHealthFinding(
   };
 }
 
+function migrationToManifestJson(migration: LegacyManifestContractMigration): string {
+  return `${JSON.stringify(migration.nextRaw, null, 2)}\n`;
+}
+
+function legacyPluginManifestMigrationToRepairEffect(
+  migration: LegacyManifestContractMigration,
+  dryRun: boolean,
+): HealthRepairEffect {
+  return {
+    kind: "file",
+    action: dryRun
+      ? "would-rewrite-legacy-plugin-manifest-contracts"
+      : "rewrite-legacy-plugin-manifest-contracts",
+    target: migration.manifestPath,
+    dryRunSafe: false,
+  };
+}
+
+function legacyPluginManifestMigrationToRepairDiff(
+  migration: LegacyManifestContractMigration,
+  before: string,
+): HealthRepairDiff {
+  return {
+    kind: "file",
+    path: migration.manifestPath,
+    before,
+    after: migrationToManifestJson(migration),
+  };
+}
+
+/** Repairs or previews selected legacy plugin manifest contract migrations. */
+export async function repairLegacyPluginManifestContractFindings(params: {
+  config?: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+  manifestRoots?: string[];
+  workspaceDir?: string;
+  findings: readonly HealthFinding[];
+  dryRun?: boolean;
+  diff?: boolean;
+  deps?: {
+    readFileSync?: typeof fs.readFileSync;
+    writeFileSync?: typeof fs.writeFileSync;
+  };
+}): Promise<HealthRepairResult> {
+  const selectedPaths = new Set(
+    params.findings
+      .filter(
+        (finding) =>
+          finding.checkId === LEGACY_PLUGIN_MANIFESTS_CHECK_ID &&
+          finding.requirement === "contracts-capability-keys" &&
+          typeof finding.path === "string",
+      )
+      .map((finding) => finding.path as string),
+  );
+  if (selectedPaths.size === 0) {
+    return {
+      status: "skipped",
+      reason: "no repairable legacy plugin manifest findings were present",
+      changes: [],
+    };
+  }
+
+  const migrations = collectLegacyPluginManifestContractMigrations({
+    ...(params.config ? { config: params.config } : {}),
+    ...(params.env ? { env: params.env } : {}),
+    ...(params.manifestRoots ? { manifestRoots: params.manifestRoots } : {}),
+    ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
+  }).filter((migration) => selectedPaths.has(migration.manifestPath));
+  if (migrations.length === 0) {
+    return {
+      status: "skipped",
+      reason: "selected legacy plugin manifests no longer need repair",
+      changes: [],
+    };
+  }
+
+  const readFile = params.deps?.readFileSync ?? fs.readFileSync;
+  const writeFile = params.deps?.writeFileSync ?? fs.writeFileSync;
+  const changes: string[] = [];
+  const diffs: HealthRepairDiff[] = [];
+  const effects: HealthRepairEffect[] = [];
+  const warnings: string[] = [];
+
+  for (const migration of migrations) {
+    let before: string | undefined;
+    if (params.diff === true) {
+      try {
+        before = readFile(migration.manifestPath, "utf-8").toString();
+        diffs.push(legacyPluginManifestMigrationToRepairDiff(migration, before));
+      } catch (error) {
+        warnings.push(
+          `Could not read legacy plugin manifest at ${migration.manifestPath}: ${String(error)}`,
+        );
+      }
+    }
+
+    if (params.dryRun !== true) {
+      try {
+        writeFile(migration.manifestPath, migrationToManifestJson(migration), "utf-8");
+      } catch (error) {
+        warnings.push(
+          `Failed to rewrite legacy plugin manifest at ${migration.manifestPath}: ${String(error)}`,
+        );
+        continue;
+      }
+    }
+
+    changes.push(...migration.changeLines);
+    effects.push(legacyPluginManifestMigrationToRepairEffect(migration, params.dryRun === true));
+  }
+
+  if (changes.length === 0 && warnings.length > 0) {
+    return {
+      status: "failed",
+      reason: "could not rewrite selected legacy plugin manifests",
+      changes,
+      warnings,
+      diffs,
+      effects,
+    };
+  }
+
+  return {
+    changes,
+    warnings,
+    diffs,
+    effects,
+  };
+}
+
 /** Prompts and rewrites legacy plugin manifest contract fields when doctor repair is enabled. */
 export async function maybeRepairLegacyPluginManifestContracts(params: {
   config?: OpenClawConfig;
@@ -211,11 +346,7 @@ export async function maybeRepairLegacyPluginManifestContracts(params: {
   const applied: string[] = [];
   for (const migration of migrations) {
     try {
-      fs.writeFileSync(
-        migration.manifestPath,
-        `${JSON.stringify(migration.nextRaw, null, 2)}\n`,
-        "utf-8",
-      );
+      fs.writeFileSync(migration.manifestPath, migrationToManifestJson(migration), "utf-8");
       applied.push(...migration.changeLines);
     } catch (error) {
       params.runtime.error(

--- a/src/commands/doctor-plugin-manifests.ts
+++ b/src/commands/doctor-plugin-manifests.ts
@@ -6,12 +6,7 @@ import { normalizeTrimmedStringList } from "@openclaw/normalization-core/string-
 import { z } from "zod";
 import { note } from "../../packages/terminal-core/src/note.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import type {
-  HealthFinding,
-  HealthRepairDiff,
-  HealthRepairEffect,
-  HealthRepairResult,
-} from "../flows/health-checks.js";
+import type { HealthFinding } from "../flows/health-checks.js";
 import { loadPluginManifestRegistry } from "../plugins/manifest-registry.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { shortenHomePath } from "../utils.js";
@@ -176,132 +171,6 @@ export function legacyPluginManifestContractMigrationToHealthFinding(
 
 function migrationToManifestJson(migration: LegacyManifestContractMigration): string {
   return `${JSON.stringify(migration.nextRaw, null, 2)}\n`;
-}
-
-function legacyPluginManifestMigrationToRepairEffect(
-  migration: LegacyManifestContractMigration,
-  dryRun: boolean,
-): HealthRepairEffect {
-  return {
-    kind: "file",
-    action: dryRun
-      ? "would-rewrite-legacy-plugin-manifest-contracts"
-      : "rewrite-legacy-plugin-manifest-contracts",
-    target: migration.manifestPath,
-    dryRunSafe: false,
-  };
-}
-
-function legacyPluginManifestMigrationToRepairDiff(
-  migration: LegacyManifestContractMigration,
-  before: string,
-): HealthRepairDiff {
-  return {
-    kind: "file",
-    path: migration.manifestPath,
-    before,
-    after: migrationToManifestJson(migration),
-  };
-}
-
-/** Repairs or previews selected legacy plugin manifest contract migrations. */
-export async function repairLegacyPluginManifestContractFindings(params: {
-  config?: OpenClawConfig;
-  env?: NodeJS.ProcessEnv;
-  manifestRoots?: string[];
-  workspaceDir?: string;
-  findings: readonly HealthFinding[];
-  dryRun?: boolean;
-  diff?: boolean;
-  deps?: {
-    readFileSync?: typeof fs.readFileSync;
-    writeFileSync?: typeof fs.writeFileSync;
-  };
-}): Promise<HealthRepairResult> {
-  const selectedPaths = new Set(
-    params.findings
-      .filter(
-        (finding) =>
-          finding.checkId === LEGACY_PLUGIN_MANIFESTS_CHECK_ID &&
-          finding.requirement === "contracts-capability-keys" &&
-          typeof finding.path === "string",
-      )
-      .map((finding) => finding.path as string),
-  );
-  if (selectedPaths.size === 0) {
-    return {
-      status: "skipped",
-      reason: "no repairable legacy plugin manifest findings were present",
-      changes: [],
-    };
-  }
-
-  const migrations = collectLegacyPluginManifestContractMigrations({
-    ...(params.config ? { config: params.config } : {}),
-    ...(params.env ? { env: params.env } : {}),
-    ...(params.manifestRoots ? { manifestRoots: params.manifestRoots } : {}),
-    ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
-  }).filter((migration) => selectedPaths.has(migration.manifestPath));
-  if (migrations.length === 0) {
-    return {
-      status: "skipped",
-      reason: "selected legacy plugin manifests no longer need repair",
-      changes: [],
-    };
-  }
-
-  const readFile = params.deps?.readFileSync ?? fs.readFileSync;
-  const writeFile = params.deps?.writeFileSync ?? fs.writeFileSync;
-  const changes: string[] = [];
-  const diffs: HealthRepairDiff[] = [];
-  const effects: HealthRepairEffect[] = [];
-  const warnings: string[] = [];
-
-  for (const migration of migrations) {
-    let before: string | undefined;
-    if (params.diff === true) {
-      try {
-        before = readFile(migration.manifestPath, "utf-8");
-        diffs.push(legacyPluginManifestMigrationToRepairDiff(migration, before));
-      } catch (error) {
-        warnings.push(
-          `Could not read legacy plugin manifest at ${migration.manifestPath}: ${String(error)}`,
-        );
-      }
-    }
-
-    if (params.dryRun !== true) {
-      try {
-        writeFile(migration.manifestPath, migrationToManifestJson(migration), "utf-8");
-      } catch (error) {
-        warnings.push(
-          `Failed to rewrite legacy plugin manifest at ${migration.manifestPath}: ${String(error)}`,
-        );
-        continue;
-      }
-    }
-
-    changes.push(...migration.changeLines);
-    effects.push(legacyPluginManifestMigrationToRepairEffect(migration, params.dryRun === true));
-  }
-
-  if (changes.length === 0 && warnings.length > 0) {
-    return {
-      status: "failed",
-      reason: "could not rewrite selected legacy plugin manifests",
-      changes,
-      warnings,
-      diffs,
-      effects,
-    };
-  }
-
-  return {
-    changes,
-    warnings,
-    diffs,
-    effects,
-  };
 }
 
 /** Prompts and rewrites legacy plugin manifest contract fields when doctor repair is enabled. */

--- a/src/commands/doctor-plugin-manifests.ts
+++ b/src/commands/doctor-plugin-manifests.ts
@@ -6,6 +6,7 @@ import { normalizeTrimmedStringList } from "@openclaw/normalization-core/string-
 import { z } from "zod";
 import { note } from "../../packages/terminal-core/src/note.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { HealthFinding } from "../flows/health-checks.js";
 import { loadPluginManifestRegistry } from "../plugins/manifest-registry.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { shortenHomePath } from "../utils.js";
@@ -18,6 +19,7 @@ const LEGACY_MANIFEST_CONTRACT_KEYS = [
   "imageGenerationProviders",
   "tools",
 ] as const;
+const LEGACY_PLUGIN_MANIFESTS_CHECK_ID = "core/doctor/legacy-plugin-manifests";
 
 type LegacyManifestContractMigration = {
   manifestPath: string;
@@ -150,6 +152,21 @@ export function collectLegacyPluginManifestContractMigrations(params?: {
   }
 
   return migrations.toSorted((left, right) => left.manifestPath.localeCompare(right.manifestPath));
+}
+
+export function legacyPluginManifestContractMigrationToHealthFinding(
+  migration: LegacyManifestContractMigration,
+): HealthFinding {
+  return {
+    checkId: LEGACY_PLUGIN_MANIFESTS_CHECK_ID,
+    severity: "warning",
+    message: `Plugin manifest ${migration.pluginId} uses legacy top-level capability keys.`,
+    path: migration.manifestPath,
+    target: migration.pluginId,
+    requirement: "contracts-capability-keys",
+    fixHint:
+      "Run `openclaw doctor --fix` to rewrite legacy plugin manifest capability keys under contracts.*.",
+  };
 }
 
 /** Prompts and rewrites legacy plugin manifest contract fields when doctor repair is enabled. */

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -69,10 +69,6 @@ const mocks = vi.hoisted(() => ({
     }),
   ),
   maybeRepairLegacyPluginManifestContracts: vi.fn().mockResolvedValue(undefined),
-  repairLegacyPluginManifestContractFindings: vi.fn(async () => ({
-    changes: [] as string[],
-    effects: [] as unknown[],
-  })),
   detectLegacyClawdBrowserProfileResidue: vi.fn(),
   maybeArchiveLegacyClawdBrowserProfileResidue: vi.fn(),
   resolveAgentWorkspaceDir: vi.fn(() => "/tmp/openclaw-workspace"),
@@ -179,7 +175,6 @@ vi.mock("../commands/doctor-plugin-manifests.js", () => ({
   legacyPluginManifestContractMigrationToHealthFinding:
     mocks.legacyPluginManifestContractMigrationToHealthFinding,
   maybeRepairLegacyPluginManifestContracts: mocks.maybeRepairLegacyPluginManifestContracts,
-  repairLegacyPluginManifestContractFindings: mocks.repairLegacyPluginManifestContractFindings,
 }));
 
 vi.mock("../commands/doctor-auth-oauth-sidecar.js", () => ({
@@ -390,11 +385,6 @@ describe("doctor health contributions", () => {
     mocks.legacyPluginManifestContractMigrationToHealthFinding.mockClear();
     mocks.maybeRepairLegacyPluginManifestContracts.mockClear();
     mocks.maybeRepairLegacyPluginManifestContracts.mockResolvedValue(undefined);
-    mocks.repairLegacyPluginManifestContractFindings.mockClear();
-    mocks.repairLegacyPluginManifestContractFindings.mockResolvedValue({
-      changes: [],
-      effects: [],
-    });
     mocks.maybeRepairLegacyOAuthSidecarProfiles.mockClear();
     mocks.maybeRepairLegacyOAuthSidecarProfiles.mockResolvedValue(undefined);
     mocks.collectAuthProfileHealthFindings.mockClear();
@@ -563,56 +553,6 @@ describe("doctor health contributions", () => {
       migration,
       expect.any(Number),
       expect.any(Array),
-    );
-  });
-
-  it("threads dry-run legacy plugin manifest repairs through the structured check", async () => {
-    const contribution = requireDoctorContribution("doctor:legacy-plugin-manifests");
-    const check = contribution.healthChecks[0] as HealthCheck;
-    const findings = [
-      {
-        checkId: "core/doctor/legacy-plugin-manifests",
-        severity: "warning" as const,
-        message: "Plugin manifest legacy-plugin uses legacy top-level capability keys.",
-        path: "/tmp/openclaw-plugin/openclaw.plugin.json",
-        target: "legacy-plugin",
-        requirement: "contracts-capability-keys",
-      },
-    ];
-    mocks.repairLegacyPluginManifestContractFindings.mockResolvedValueOnce({
-      changes: ["Would rewrite legacy manifest."],
-      effects: [
-        {
-          kind: "file",
-          action: "would-rewrite-legacy-plugin-manifest-contracts",
-          target: "/tmp/openclaw-plugin/openclaw.plugin.json",
-          dryRunSafe: false,
-        },
-      ],
-    });
-
-    const result = await check.repair?.(
-      {
-        cfg: { plugins: { load: { paths: ["/tmp/openclaw-plugin"] } } },
-        mode: "fix",
-        dryRun: true,
-        diff: true,
-        runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-      },
-      findings,
-    );
-
-    expect(mocks.repairLegacyPluginManifestContractFindings).toHaveBeenCalledWith({
-      config: { plugins: { load: { paths: ["/tmp/openclaw-plugin"] } } },
-      env: process.env,
-      findings,
-      dryRun: true,
-      diff: true,
-    });
-    expect(result?.effects).toContainEqual(
-      expect.objectContaining({
-        action: "would-rewrite-legacy-plugin-manifest-contracts",
-      }),
     );
   });
 

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -57,7 +57,7 @@ const mocks = vi.hoisted(() => ({
   noteChromeMcpBrowserReadiness: vi.fn(),
   detectLegacyStateMigrations: vi.fn(),
   runLegacyStateMigrations: vi.fn(),
-  collectLegacyPluginManifestContractMigrations: vi.fn(() => []),
+  collectLegacyPluginManifestContractMigrations: vi.fn(() => [] as unknown[]),
   legacyPluginManifestContractMigrationToHealthFinding: vi.fn(
     (migration: { pluginId: string }) => ({
       checkId: "core/doctor/legacy-plugin-manifests",
@@ -69,6 +69,10 @@ const mocks = vi.hoisted(() => ({
     }),
   ),
   maybeRepairLegacyPluginManifestContracts: vi.fn().mockResolvedValue(undefined),
+  repairLegacyPluginManifestContractFindings: vi.fn(async () => ({
+    changes: [] as string[],
+    effects: [] as unknown[],
+  })),
   detectLegacyClawdBrowserProfileResidue: vi.fn(),
   maybeArchiveLegacyClawdBrowserProfileResidue: vi.fn(),
   resolveAgentWorkspaceDir: vi.fn(() => "/tmp/openclaw-workspace"),
@@ -175,6 +179,7 @@ vi.mock("../commands/doctor-plugin-manifests.js", () => ({
   legacyPluginManifestContractMigrationToHealthFinding:
     mocks.legacyPluginManifestContractMigrationToHealthFinding,
   maybeRepairLegacyPluginManifestContracts: mocks.maybeRepairLegacyPluginManifestContracts,
+  repairLegacyPluginManifestContractFindings: mocks.repairLegacyPluginManifestContractFindings,
 }));
 
 vi.mock("../commands/doctor-auth-oauth-sidecar.js", () => ({
@@ -385,6 +390,11 @@ describe("doctor health contributions", () => {
     mocks.legacyPluginManifestContractMigrationToHealthFinding.mockClear();
     mocks.maybeRepairLegacyPluginManifestContracts.mockClear();
     mocks.maybeRepairLegacyPluginManifestContracts.mockResolvedValue(undefined);
+    mocks.repairLegacyPluginManifestContractFindings.mockClear();
+    mocks.repairLegacyPluginManifestContractFindings.mockResolvedValue({
+      changes: [],
+      effects: [],
+    });
     mocks.maybeRepairLegacyOAuthSidecarProfiles.mockClear();
     mocks.maybeRepairLegacyOAuthSidecarProfiles.mockResolvedValue(undefined);
     mocks.collectAuthProfileHealthFindings.mockClear();
@@ -519,9 +529,9 @@ describe("doctor health contributions", () => {
     mocks.collectLegacyPluginManifestContractMigrations.mockReturnValueOnce([migration]);
     const ctx = {
       cfg: { plugins: { load: { paths: ["/tmp/openclaw-plugin"] } } },
-      mode: "lint",
+      mode: "lint" as const,
       runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-    } as const;
+    };
 
     await expect(runDoctorLintChecks(ctx, { checks: [check] })).resolves.toMatchObject({
       checksRun: 0,
@@ -553,6 +563,56 @@ describe("doctor health contributions", () => {
       migration,
       expect.any(Number),
       expect.any(Array),
+    );
+  });
+
+  it("threads dry-run legacy plugin manifest repairs through the structured check", async () => {
+    const contribution = requireDoctorContribution("doctor:legacy-plugin-manifests");
+    const check = contribution.healthChecks[0] as HealthCheck;
+    const findings = [
+      {
+        checkId: "core/doctor/legacy-plugin-manifests",
+        severity: "warning" as const,
+        message: "Plugin manifest legacy-plugin uses legacy top-level capability keys.",
+        path: "/tmp/openclaw-plugin/openclaw.plugin.json",
+        target: "legacy-plugin",
+        requirement: "contracts-capability-keys",
+      },
+    ];
+    mocks.repairLegacyPluginManifestContractFindings.mockResolvedValueOnce({
+      changes: ["Would rewrite legacy manifest."],
+      effects: [
+        {
+          kind: "file",
+          action: "would-rewrite-legacy-plugin-manifest-contracts",
+          target: "/tmp/openclaw-plugin/openclaw.plugin.json",
+          dryRunSafe: false,
+        },
+      ],
+    });
+
+    const result = await check.repair?.(
+      {
+        cfg: { plugins: { load: { paths: ["/tmp/openclaw-plugin"] } } },
+        mode: "fix",
+        dryRun: true,
+        diff: true,
+        runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      },
+      findings,
+    );
+
+    expect(mocks.repairLegacyPluginManifestContractFindings).toHaveBeenCalledWith({
+      config: { plugins: { load: { paths: ["/tmp/openclaw-plugin"] } } },
+      env: process.env,
+      findings,
+      dryRun: true,
+      diff: true,
+    });
+    expect(result?.effects).toContainEqual(
+      expect.objectContaining({
+        action: "would-rewrite-legacy-plugin-manifest-contracts",
+      }),
     );
   });
 

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -57,6 +57,18 @@ const mocks = vi.hoisted(() => ({
   noteChromeMcpBrowserReadiness: vi.fn(),
   detectLegacyStateMigrations: vi.fn(),
   runLegacyStateMigrations: vi.fn(),
+  collectLegacyPluginManifestContractMigrations: vi.fn(() => []),
+  legacyPluginManifestContractMigrationToHealthFinding: vi.fn(
+    (migration: { pluginId: string }) => ({
+      checkId: "core/doctor/legacy-plugin-manifests",
+      severity: "warning" as const,
+      message: `Plugin manifest ${migration.pluginId} uses legacy top-level capability keys.`,
+      path: "/tmp/openclaw-plugin/openclaw.plugin.json",
+      target: migration.pluginId,
+      requirement: "contracts-capability-keys",
+    }),
+  ),
+  maybeRepairLegacyPluginManifestContracts: vi.fn().mockResolvedValue(undefined),
   detectLegacyClawdBrowserProfileResidue: vi.fn(),
   maybeArchiveLegacyClawdBrowserProfileResidue: vi.fn(),
   resolveAgentWorkspaceDir: vi.fn(() => "/tmp/openclaw-workspace"),
@@ -155,6 +167,14 @@ vi.mock("../commands/doctor-auth-legacy-oauth.js", () => ({
 vi.mock("../commands/doctor-state-migrations.js", () => ({
   detectLegacyStateMigrations: mocks.detectLegacyStateMigrations,
   runLegacyStateMigrations: mocks.runLegacyStateMigrations,
+}));
+
+vi.mock("../commands/doctor-plugin-manifests.js", () => ({
+  collectLegacyPluginManifestContractMigrations:
+    mocks.collectLegacyPluginManifestContractMigrations,
+  legacyPluginManifestContractMigrationToHealthFinding:
+    mocks.legacyPluginManifestContractMigrationToHealthFinding,
+  maybeRepairLegacyPluginManifestContracts: mocks.maybeRepairLegacyPluginManifestContracts,
 }));
 
 vi.mock("../commands/doctor-auth-oauth-sidecar.js", () => ({
@@ -360,6 +380,11 @@ describe("doctor health contributions", () => {
     mocks.maybeRepairGatewayDaemon.mockResolvedValue(undefined);
     mocks.maybeRepairLegacyOAuthProfileIds.mockClear();
     mocks.maybeRepairLegacyOAuthProfileIds.mockImplementation(async (cfg: unknown) => cfg);
+    mocks.collectLegacyPluginManifestContractMigrations.mockReset();
+    mocks.collectLegacyPluginManifestContractMigrations.mockReturnValue([]);
+    mocks.legacyPluginManifestContractMigrationToHealthFinding.mockClear();
+    mocks.maybeRepairLegacyPluginManifestContracts.mockClear();
+    mocks.maybeRepairLegacyPluginManifestContracts.mockResolvedValue(undefined);
     mocks.maybeRepairLegacyOAuthSidecarProfiles.mockClear();
     mocks.maybeRepairLegacyOAuthSidecarProfiles.mockResolvedValue(undefined);
     mocks.collectAuthProfileHealthFindings.mockClear();
@@ -477,6 +502,58 @@ describe("doctor health contributions", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  it("keeps legacy plugin manifest lint opt-in for structured findings", async () => {
+    const contribution = requireDoctorContribution("doctor:legacy-plugin-manifests");
+    const check = contribution.healthChecks[0] as HealthCheck & { defaultEnabled?: boolean };
+    expect(contribution.healthCheckIds).toEqual(["core/doctor/legacy-plugin-manifests"]);
+    expect(check.defaultEnabled).toBe(false);
+
+    const migration = {
+      manifestPath: "/tmp/openclaw-plugin/openclaw.plugin.json",
+      pluginId: "legacy-plugin",
+      nextRaw: {},
+      changeLines: ["- moved tools to contracts.tools"],
+    };
+    mocks.collectLegacyPluginManifestContractMigrations.mockReturnValueOnce([migration]);
+    const ctx = {
+      cfg: { plugins: { load: { paths: ["/tmp/openclaw-plugin"] } } },
+      mode: "lint",
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+    } as const;
+
+    await expect(runDoctorLintChecks(ctx, { checks: [check] })).resolves.toMatchObject({
+      checksRun: 0,
+      checksSkipped: 1,
+    });
+    expect(mocks.collectLegacyPluginManifestContractMigrations).not.toHaveBeenCalled();
+
+    await expect(
+      runDoctorLintChecks(ctx, {
+        checks: [check],
+        onlyIds: ["core/doctor/legacy-plugin-manifests"],
+      }),
+    ).resolves.toMatchObject({
+      checksRun: 1,
+      checksSkipped: 0,
+      findings: [
+        expect.objectContaining({
+          checkId: "core/doctor/legacy-plugin-manifests",
+          target: "legacy-plugin",
+          requirement: "contracts-capability-keys",
+        }),
+      ],
+    });
+    expect(mocks.collectLegacyPluginManifestContractMigrations).toHaveBeenCalledWith({
+      config: ctx.cfg,
+      env: process.env,
+    });
+    expect(mocks.legacyPluginManifestContractMigrationToHealthFinding).toHaveBeenCalledWith(
+      migration,
+      expect.any(Number),
+      expect.any(Array),
+    );
   });
 
   it("runs release configured plugin install repair before plugin registry and final config writes", () => {

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -1353,6 +1353,17 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
             env: process.env,
           }).map(legacyPluginManifestContractMigrationToHealthFinding);
         },
+        async repair(ctx, findings) {
+          const { repairLegacyPluginManifestContractFindings } =
+            await import("../commands/doctor-plugin-manifests.js");
+          return await repairLegacyPluginManifestContractFindings({
+            config: ctx.cfg,
+            env: process.env,
+            findings,
+            dryRun: ctx.dryRun,
+            diff: ctx.diff,
+          });
+        },
       },
       run: runLegacyPluginManifestHealth,
     }),

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -1353,17 +1353,6 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
             env: process.env,
           }).map(legacyPluginManifestContractMigrationToHealthFinding);
         },
-        async repair(ctx, findings) {
-          const { repairLegacyPluginManifestContractFindings } =
-            await import("../commands/doctor-plugin-manifests.js");
-          return await repairLegacyPluginManifestContractFindings({
-            config: ctx.cfg,
-            env: process.env,
-            findings,
-            dryRun: ctx.dryRun,
-            diff: ctx.diff,
-          });
-        },
       },
       run: runLegacyPluginManifestHealth,
     }),

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -1339,6 +1339,21 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
     createDoctorHealthContribution({
       id: "doctor:legacy-plugin-manifests",
       label: "Legacy plugin manifests",
+      healthChecks: {
+        id: "core/doctor/legacy-plugin-manifests",
+        description: "Legacy plugin manifest capability keys are reported as findings.",
+        defaultEnabled: false,
+        async detect(ctx) {
+          const {
+            collectLegacyPluginManifestContractMigrations,
+            legacyPluginManifestContractMigrationToHealthFinding,
+          } = await import("../commands/doctor-plugin-manifests.js");
+          return collectLegacyPluginManifestContractMigrations({
+            config: ctx.cfg,
+            env: process.env,
+          }).map(legacyPluginManifestContractMigrationToHealthFinding);
+        },
+      },
       run: runLegacyPluginManifestHealth,
     }),
     createDoctorHealthContribution({


### PR DESCRIPTION
## Summary
- expose legacy plugin manifest contract migrations as default-disabled `core/doctor/legacy-plugin-manifests` lint findings
- keep default `doctor --lint` behavior unchanged
- leave real manifest rewriting in the existing legacy `openclaw doctor --fix` repair path; this PR is lint-only and does not add a structured repair/dry-run hook

## Contract / compatibility notes
No public config, plugin manifest, SDK, persisted data-model, or repair-path contract changes. This PR only maps already-detected legacy manifest state into `HealthFinding` output for explicit lint selection / `--all`.

## Real behavior proof
Source CLI proof with isolated state/config and a temp plugin manifest containing top-level `tools` showed:
- default `doctor --lint --json` emitted zero `core/doctor/legacy-plugin-manifests` findings
- `doctor --lint --json --only core/doctor/legacy-plugin-manifests` ran one selected check and reported the legacy manifest warning for `legacy-plugin`

## Validation after Omar fix
- `node scripts/run-vitest.mjs src/commands/doctor-plugin-manifests.test.ts src/flows/doctor-health-contributions.test.ts` (63 tests)
- changed-file `pnpm exec oxfmt --check`
- changed-file `pnpm exec oxlint`
- `node scripts/plugin-sdk-surface-report.mjs --check`
- `git diff --check`