### PR TITLE
fix(google,discord): bound response body reads to prevent OOM

### DIFF
--- a/extensions/discord/src/monitor/gateway-metadata.test.ts
+++ b/extensions/discord/src/monitor/gateway-metadata.test.ts
@@ -6,10 +6,17 @@ import {
   fetchDiscordGatewayMetadataGuarded,
   resolveDiscordGatewayInfoTimeoutMs,
   resolveGatewayInfoWithFallback,
-  testExports,
 } from "./gateway-metadata.js";
 
 const DISCORD_GATEWAY_METADATA_MAX_BYTES = 4 * 1024 * 1024;
+
+const { mockFetchWithSsrFGuard } = vi.hoisted(() => ({
+  mockFetchWithSsrFGuard: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
+  fetchWithSsrFGuard: mockFetchWithSsrFGuard,
+}));
 
 async function listenLoopbackServer(server: Server): Promise<number> {
   return await new Promise((resolve, reject) => {
@@ -29,6 +36,13 @@ async function listenLoopbackServer(server: Server): Promise<number> {
 async function closeServer(server: Server): Promise<void> {
   await new Promise<void>((resolve) => {
     server.close(() => resolve());
+  });
+}
+
+function stubGuardedFetch(response: Response): void {
+  mockFetchWithSsrFGuard.mockResolvedValue({
+    response,
+    release: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
   });
 }
 
@@ -80,9 +94,10 @@ describe("Discord gateway metadata", () => {
   });
 });
 
-describe("materializeGuardedResponse bounded reads", () => {
+describe("fetchDiscordGatewayMetadataGuarded bounded reads", () => {
   beforeEach(() => {
     vi.useRealTimers();
+    mockFetchWithSsrFGuard.mockReset();
   });
 
   afterEach(() => {
@@ -111,7 +126,11 @@ describe("materializeGuardedResponse bounded reads", () => {
 
     try {
       const rawResponse = await fetch(`http://127.0.0.1:${port}`);
-      const response = await testExports.materializeGuardedResponse(rawResponse);
+      stubGuardedFetch(rawResponse);
+
+      const response = await fetchDiscordGatewayMetadataGuarded(
+        "https://discord.com/api/v10/gateway/bot",
+      );
       const text = await response.text();
       expect(JSON.parse(text)).toEqual(JSON.parse(payload));
       console.log(
@@ -150,10 +169,11 @@ describe("materializeGuardedResponse bounded reads", () => {
 
     try {
       const rawResponse = await fetch(`http://127.0.0.1:${port}`);
+      stubGuardedFetch(rawResponse);
 
       let error: unknown;
       try {
-        await testExports.materializeGuardedResponse(rawResponse);
+        await fetchDiscordGatewayMetadataGuarded("https://discord.com/api/v10/gateway/bot");
       } catch (err) {
         error = err;
       }

--- a/extensions/discord/src/monitor/gateway-metadata.test.ts
+++ b/extensions/discord/src/monitor/gateway-metadata.test.ts
@@ -1,10 +1,36 @@
 // Discord tests cover gateway metadata plugin behavior.
-import { describe, expect, it, vi } from "vitest";
+import { createServer, type Server } from "node:http";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   fetchDiscordGatewayInfo,
+  fetchDiscordGatewayMetadataGuarded,
   resolveDiscordGatewayInfoTimeoutMs,
   resolveGatewayInfoWithFallback,
+  testExports,
 } from "./gateway-metadata.js";
+
+const DISCORD_GATEWAY_METADATA_MAX_BYTES = 4 * 1024 * 1024;
+
+async function listenLoopbackServer(server: Server): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("expected loopback TCP address"));
+        return;
+      }
+      resolve(address.port);
+    });
+  });
+}
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve) => {
+    server.close(() => resolve());
+  });
+}
 
 describe("Discord gateway metadata", () => {
   it("resolves gateway info timeouts from strict integer config and env values", () => {
@@ -51,5 +77,95 @@ describe("Discord gateway metadata", () => {
     expect(logs).toBe(
       "discord: gateway metadata lookup failed transiently; using default gateway url (Failed to get gateway information from Discord: fetch failed | Discord API /gateway/bot failed (429): Error 1015 rate limited)",
     );
+  });
+});
+
+describe("materializeGuardedResponse bounded reads", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("returns under-cap response body from a real loopback HTTP server", async () => {
+    const payload = JSON.stringify({
+      url: "wss://gateway.discord.gg/",
+      shards: 1,
+      session_start_limit: {
+        total: 1000,
+        remaining: 999,
+        reset_after: 3600000,
+        max_concurrency: 1,
+      },
+    });
+
+    const server = createServer((req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.write(payload.slice(0, 32));
+      res.end(payload.slice(32));
+    });
+    const port = await listenLoopbackServer(server);
+
+    try {
+      const rawResponse = await fetch(`http://127.0.0.1:${port}`);
+      const response = await testExports.materializeGuardedResponse(rawResponse);
+      const text = await response.text();
+      expect(JSON.parse(text)).toEqual(JSON.parse(payload));
+      console.log(
+        `[discord gateway metadata loopback proof] normal path: returned valid gateway metadata`,
+      );
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it("rejects oversized response body from a real loopback HTTP server", async () => {
+    const oversizedPayloadBytes = DISCORD_GATEWAY_METADATA_MAX_BYTES + 256 * 1024;
+    let streamedBytes = 0;
+
+    const server = createServer((req, res) => {
+      const chunk = Buffer.alloc(64 * 1024, 0x78);
+      res.writeHead(200, { "content-type": "application/json" });
+
+      const writeMore = () => {
+        while (streamedBytes < oversizedPayloadBytes) {
+          if (res.destroyed) {
+            return;
+          }
+          streamedBytes += chunk.byteLength;
+          if (!res.write(chunk)) {
+            res.once("drain", writeMore);
+            return;
+          }
+        }
+        res.end();
+      };
+
+      writeMore();
+    });
+    const port = await listenLoopbackServer(server);
+
+    try {
+      const rawResponse = await fetch(`http://127.0.0.1:${port}`);
+
+      let error: unknown;
+      try {
+        await testExports.materializeGuardedResponse(rawResponse);
+      } catch (err) {
+        error = err;
+      }
+
+      expect(error).toBeInstanceOf(Error);
+      expect(String(error)).toContain("Discord gateway metadata response body too large");
+      expect(String(error)).toContain(`limit: ${DISCORD_GATEWAY_METADATA_MAX_BYTES} bytes`);
+      console.log(
+        `[discord gateway metadata loopback proof] oversized path: cap=${DISCORD_GATEWAY_METADATA_MAX_BYTES} streamed>=${streamedBytes} rejected=${String(error)}`,
+      );
+    } finally {
+      await closeServer(server);
+    }
   });
 });

--- a/extensions/discord/src/monitor/gateway-metadata.ts
+++ b/extensions/discord/src/monitor/gateway-metadata.ts
@@ -59,12 +59,14 @@ function resolveFetchInputUrl(input: RequestInfo | URL): string {
 }
 
 async function materializeGuardedResponse(response: Response): Promise<Response> {
-  const body = await readResponseWithLimit(response, DISCORD_GATEWAY_METADATA_MAX_BYTES, {
-    onOverflow: ({ size, maxBytes }) =>
-      new Error(
-        `Discord gateway metadata response body too large: ${size} bytes (limit: ${maxBytes} bytes)`,
-      ),
-  });
+  const body = new Uint8Array(
+    await readResponseWithLimit(response, DISCORD_GATEWAY_METADATA_MAX_BYTES, {
+      onOverflow: ({ size, maxBytes }) =>
+        new Error(
+          `Discord gateway metadata response body too large: ${size} bytes (limit: ${maxBytes} bytes)`,
+        ),
+    }),
+  );
   return new Response(body, {
     status: response.status,
     statusText: response.statusText,
@@ -276,10 +278,6 @@ export function resolveGatewayInfoWithFallback(params: { runtime?: RuntimeEnv; e
     usedFallback: true,
   };
 }
-
-export const testExports = {
-  materializeGuardedResponse,
-};
 
 export async function fetchDiscordGatewayMetadataGuarded(
   input: string,

--- a/extensions/discord/src/monitor/gateway-metadata.ts
+++ b/extensions/discord/src/monitor/gateway-metadata.ts
@@ -3,6 +3,7 @@ import type { APIGatewayBotInfo } from "discord-api-types/v10";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
 import { captureHttpExchange } from "openclaw/plugin-sdk/proxy-capture";
+import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { Type } from "typebox";
@@ -16,6 +17,7 @@ const DEFAULT_DISCORD_GATEWAY_URL = "wss://gateway.discord.gg/";
 const DEFAULT_DISCORD_GATEWAY_INFO_TIMEOUT_MS = 30_000;
 const MAX_DISCORD_GATEWAY_INFO_TIMEOUT_MS = 120_000;
 const DISCORD_GATEWAY_INFO_TIMEOUT_ENV = "OPENCLAW_DISCORD_GATEWAY_INFO_TIMEOUT_MS";
+const DISCORD_GATEWAY_METADATA_MAX_BYTES = 4 * 1024 * 1024;
 const DISCORD_GATEWAY_METADATA_FALLBACK_LOG_INTERVAL_MS = 60_000;
 
 type DiscordGatewayMetadataResponse = Pick<Response, "ok" | "status" | "text">;
@@ -57,7 +59,12 @@ function resolveFetchInputUrl(input: RequestInfo | URL): string {
 }
 
 async function materializeGuardedResponse(response: Response): Promise<Response> {
-  const body = await response.arrayBuffer();
+  const body = await readResponseWithLimit(response, DISCORD_GATEWAY_METADATA_MAX_BYTES, {
+    onOverflow: ({ size, maxBytes }) =>
+      new Error(
+        `Discord gateway metadata response body too large: ${size} bytes (limit: ${maxBytes} bytes)`,
+      ),
+  });
   return new Response(body, {
     status: response.status,
     statusText: response.statusText,
@@ -269,6 +276,10 @@ export function resolveGatewayInfoWithFallback(params: { runtime?: RuntimeEnv; e
     usedFallback: true,
   };
 }
+
+export const testExports = {
+  materializeGuardedResponse,
+};
 
 export async function fetchDiscordGatewayMetadataGuarded(
   input: string,

--- a/extensions/google/oauth.token.test.ts
+++ b/extensions/google/oauth.token.test.ts
@@ -1,0 +1,238 @@
+// Google tests cover oauth.token error body boundary behavior.
+import { createServer, type Server } from "node:http";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { exchangeCodeForTokens, refreshTokensForGeminiCli } from "./oauth.token.js";
+
+const GOOGLE_OAUTH_ERROR_BODY_MAX_BYTES = 8 * 1024;
+const STREAM_CHUNK = Buffer.alloc(4 * 1024, "x");
+const STREAM_BODY_BYTES = 1024 * 1024;
+
+const { mockFetchWithTimeout } = vi.hoisted(() => ({
+  mockFetchWithTimeout: vi.fn(),
+}));
+
+vi.mock("./oauth.http.js", () => ({
+  fetchWithTimeout: mockFetchWithTimeout,
+}));
+
+vi.mock("./oauth.credentials.js", () => ({
+  resolveOAuthClientConfig: () => ({
+    clientId: "test-client-id",
+    clientSecret: "test-client-secret",
+  }),
+}));
+
+vi.mock("./oauth.project.js", () => ({
+  resolveGoogleOAuthIdentity: async () => ({ email: "test@example.com" }),
+  resolveGooglePersonalOAuthIdentity: async () => ({ email: "test@example.com" }),
+}));
+
+async function listenLoopbackServer(server: Server): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("expected loopback TCP address"));
+        return;
+      }
+      resolve(address.port);
+    });
+  });
+}
+
+async function closeServer(server: Server): Promise<void> {
+  server.closeAllConnections();
+  await new Promise<void>((resolve) => {
+    server.close(() => resolve());
+  });
+}
+
+describe("requestTokenGrant bounded error reads", () => {
+  let server: Server;
+  let baseUrl: string;
+  let streamClosed: Promise<void>;
+  let resolveStreamClosed: () => void;
+  let streamCompleted: boolean;
+
+  beforeEach(() => {
+    vi.useRealTimers();
+    mockFetchWithTimeout.mockReset();
+    vi.stubEnv("GOOGLE_CLIENT_ID", "test-client-id");
+    vi.stubEnv("GOOGLE_CLIENT_SECRET", "test-client-secret");
+    for (const key of [
+      "ALL_PROXY",
+      "all_proxy",
+      "HTTP_PROXY",
+      "http_proxy",
+      "HTTPS_PROXY",
+      "https_proxy",
+    ]) {
+      vi.stubEnv(key, "");
+    }
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  describe("error body bounded reads via loopback HTTP server", () => {
+    beforeEach(async () => {
+      streamClosed = new Promise<void>((resolve) => {
+        resolveStreamClosed = resolve;
+      });
+      streamCompleted = false;
+
+      server = createServer((req, res) => {
+        if (req.url === "/small") {
+          res.writeHead(400, {
+            "content-type": "application/json; charset=utf-8",
+          });
+          res.end('{"error":"invalid_grant","error_description":"Bad Request"}');
+          return;
+        }
+
+        // Oversized error response
+        res.writeHead(500, {
+          "content-type": "text/html; charset=utf-8",
+        });
+        let written = 0;
+        let closed = false;
+        res.once("close", () => {
+          closed = true;
+          resolveStreamClosed();
+        });
+        const writeNext = () => {
+          if (closed) return;
+          if (written >= STREAM_BODY_BYTES) {
+            streamCompleted = true;
+            res.end();
+            return;
+          }
+          written += STREAM_CHUNK.byteLength;
+          const writeMore = () => setTimeout(writeNext, 2);
+          if (res.write(STREAM_CHUNK)) {
+            writeMore();
+          } else {
+            res.once("drain", writeMore);
+          }
+        };
+        writeNext();
+      });
+
+      const port = await listenLoopbackServer(server);
+      baseUrl = `http://127.0.0.1:${port}`;
+    });
+
+    afterEach(async () => {
+      await closeServer(server);
+    });
+
+    it("bounds oversized OAuth error body text", async () => {
+      const rawResponse = await fetch(`${baseUrl}/large`);
+      mockFetchWithTimeout.mockResolvedValue(rawResponse);
+
+      const error = await exchangeCodeForTokens("test-code", "test-verifier").catch(
+        (err: unknown) => err,
+      );
+
+      expect(error).toBeInstanceOf(Error);
+      const message = String((error as Error).message);
+      expect(message).toContain("Token exchange failed:");
+
+      // After bounded read, the stream should be cancelled before completion
+      await expect(streamClosed).resolves.toBeUndefined();
+      expect(streamCompleted).toBe(false);
+
+      console.log(
+        `[google oauth.token loopback proof] oversized path: ` +
+          `cap=${GOOGLE_OAUTH_ERROR_BODY_MAX_BYTES} ` +
+          `streamed=${STREAM_BODY_BYTES} ` +
+          `message_length=${message.length}`,
+      );
+    });
+
+    it("preserves complete small error body text within the limit", async () => {
+      const rawResponse = await fetch(`${baseUrl}/small`);
+      mockFetchWithTimeout.mockResolvedValue(rawResponse);
+
+      const error = await exchangeCodeForTokens("test-code", "test-verifier").catch(
+        (err: unknown) => err,
+      );
+
+      expect(error).toBeInstanceOf(Error);
+      const message = String((error as Error).message);
+      expect(message).toBe(
+        'Token exchange failed: {"error":"invalid_grant","error_description":"Bad Request"}',
+      );
+
+      console.log(
+        `[google oauth.token loopback proof] small body path: ` +
+          `message_length=${message.length}`,
+      );
+    });
+  });
+
+  describe("refreshTokensForGeminiCli error body bounded reads", () => {
+    beforeEach(async () => {
+      streamClosed = new Promise<void>((resolve) => {
+        resolveStreamClosed = resolve;
+      });
+      streamCompleted = false;
+
+      server = createServer((req, res) => {
+        // Oversized error response for refresh path
+        res.writeHead(503, {
+          "content-type": "text/html; charset=utf-8",
+        });
+        let written = 0;
+        let closed = false;
+        res.once("close", () => {
+          closed = true;
+          resolveStreamClosed();
+        });
+        const writeNext = () => {
+          if (closed) return;
+          if (written >= STREAM_BODY_BYTES) {
+            streamCompleted = true;
+            res.end();
+            return;
+          }
+          written += STREAM_CHUNK.byteLength;
+          const writeMore = () => setTimeout(writeNext, 2);
+          if (res.write(STREAM_CHUNK)) {
+            writeMore();
+          } else {
+            res.once("drain", writeMore);
+          }
+        };
+        writeNext();
+      });
+
+      const port = await listenLoopbackServer(server);
+      baseUrl = `http://127.0.0.1:${port}`;
+    });
+
+    afterEach(async () => {
+      await closeServer(server);
+    });
+
+    it("bounds oversized OAuth error body text during token refresh", async () => {
+      const rawResponse = await fetch(`${baseUrl}/large`);
+      mockFetchWithTimeout.mockResolvedValue(rawResponse);
+
+      const error = await refreshTokensForGeminiCli({
+        refresh: "test-refresh-token",
+      }).catch((err: unknown) => err);
+
+      expect(error).toBeInstanceOf(Error);
+      const message = String((error as Error).message);
+      expect(message).toContain("Token exchange failed:");
+
+      await expect(streamClosed).resolves.toBeUndefined();
+      expect(streamCompleted).toBe(false);
+    });
+  });
+});

--- a/extensions/google/oauth.token.test.ts
+++ b/extensions/google/oauth.token.test.ts
@@ -105,7 +105,9 @@ describe("requestTokenGrant bounded error reads", () => {
           resolveStreamClosed();
         });
         const writeNext = () => {
-          if (closed) return;
+          if (closed) {
+            return;
+          }
           if (written >= STREAM_BODY_BYTES) {
             streamCompleted = true;
             res.end();
@@ -139,7 +141,7 @@ describe("requestTokenGrant bounded error reads", () => {
       );
 
       expect(error).toBeInstanceOf(Error);
-      const message = String((error as Error).message);
+      const message = (error as Error).message;
       expect(message).toContain("Token exchange failed:");
 
       // After bounded read, the stream should be cancelled before completion
@@ -163,7 +165,7 @@ describe("requestTokenGrant bounded error reads", () => {
       );
 
       expect(error).toBeInstanceOf(Error);
-      const message = String((error as Error).message);
+      const message = (error as Error).message;
       expect(message).toBe(
         'Token exchange failed: {"error":"invalid_grant","error_description":"Bad Request"}',
       );
@@ -194,7 +196,9 @@ describe("requestTokenGrant bounded error reads", () => {
           resolveStreamClosed();
         });
         const writeNext = () => {
-          if (closed) return;
+          if (closed) {
+            return;
+          }
           if (written >= STREAM_BODY_BYTES) {
             streamCompleted = true;
             res.end();
@@ -228,7 +232,7 @@ describe("requestTokenGrant bounded error reads", () => {
       }).catch((err: unknown) => err);
 
       expect(error).toBeInstanceOf(Error);
-      const message = String((error as Error).message);
+      const message = (error as Error).message;
       expect(message).toContain("Token exchange failed:");
 
       await expect(streamClosed).resolves.toBeUndefined();

--- a/extensions/google/oauth.token.ts
+++ b/extensions/google/oauth.token.ts
@@ -3,6 +3,10 @@ import {
   asDateTimestampMs,
   resolveExpiresAtMsFromDurationSeconds,
 } from "openclaw/plugin-sdk/number-runtime";
+import {
+  readProviderJsonResponse,
+  readResponseTextLimited,
+} from "openclaw/plugin-sdk/provider-http";
 import { resolveOAuthClientConfig } from "./oauth.credentials.js";
 import { fetchWithTimeout } from "./oauth.http.js";
 import { resolveGoogleOAuthIdentity, resolveGooglePersonalOAuthIdentity } from "./oauth.project.js";
@@ -10,6 +14,7 @@ import { isGeminiCliPersonalOAuth } from "./oauth.settings.js";
 import { REDIRECT_URI, TOKEN_URL, type GeminiCliOAuthCredentials } from "./oauth.shared.js";
 
 const TOKEN_EXPIRY_BUFFER_MS = 5 * 60 * 1000;
+const GOOGLE_OAUTH_ERROR_BODY_MAX_BYTES = 8 * 1024;
 
 async function requestTokenGrant(body: URLSearchParams): Promise<{
   access_token?: string;
@@ -27,15 +32,15 @@ async function requestTokenGrant(body: URLSearchParams): Promise<{
   });
 
   if (!response.ok) {
-    const errorText = await response.text();
+    const errorText = await readResponseTextLimited(response, GOOGLE_OAUTH_ERROR_BODY_MAX_BYTES);
     throw new Error(`Token exchange failed: ${errorText}`);
   }
 
-  return (await response.json()) as {
+  return await readProviderJsonResponse<{
     access_token?: string;
     refresh_token?: string;
     expires_in?: unknown;
-  };
+  }>(response, "Google OAuth token grant");
 }
 
 function resolveExpiredTokenTimestampMs(nowMs: number): number {


### PR DESCRIPTION
## What Problem This Solves

The `requestTokenGrant` helper in the Google OAuth token exchange path read error response bodies via `response.text()` without any size cap. A misconfigured or malfunctioning Google OAuth endpoint (or intermediate proxy) that returns an oversized error body — e.g. a misrouted HTML page or a proxy error splash — could exhaust gateway memory before the error was surfaced.

The `fetchWithTimeout` wrapper in `oauth.http.ts` already bounds the response at 16 MiB, so the raw body cannot overflow memory. However, an unbounded 16 MiB error body can still be embedded verbatim into the downstream `Error` message, producing excessive log payloads and redundant memory pressure.

## Why This Change Was Made

- **Error path** (`response.status !== 200`): replace `response.text()` with `readResponseTextLimited(response, 8 KiB)`. Consistent with `DISCORD_API_ERROR_BODY_LIMIT_BYTES` in `extensions/discord/src/api.ts`. The cap is generous for a structured OAuth error payload (~100 bytes of JSON) while keeping a runaway HTML page from polluting downstream diagnostics.

- **Success path**: replace the bare `(await response.json()) as {…}` cast with `readProviderJsonResponse<T>(response, …)`. The upstream `fetchWithTimeout` already bounds the body at 16 MiB, so this is defense-in-depth type-safe parsing with a consistent provider error surface.

No new dependencies, APIs, config keys, or protocol changes.

## User Impact

Normal OAuth errors (invalid grant, expired token, etc.) preserve their complete diagnostic payload. Oversized error streams are truncated at 8 KiB — the error message still identifies the failure, and the upstream 16 MiB bound ensures memory safety at the transport layer.

## Evidence

### Real behavior proof

- **Behavior addressed**: unbounded `response.text()` on error path → bounded `readResponseTextLimited(8 KiB)`
- **Real environment tested**: loopback HTTP server (`node:http.createServer`) streaming 1 MiB of chunked body over `127.0.0.1`, driven through the exported `exchangeCodeForTokens` and `refreshTokensForGeminiCli` public APIs with mocked `fetchWithTimeout`
- **Exact steps**:
  1. Start a loopback HTTP server that streams a 1 MiB error body (4 KiB chunks, 2 ms delay, no Content-Length)
  2. Mock `fetchWithTimeout` to return the loopback Response
  3. Call `exchangeCodeForTokens("test-code", "test-verifier")`
  4. Assert the error message is bounded (≈8 KiB text)
  5. Assert the stream was cancelled before the server finished writing (proof the read stopped early)
  6. Positive control: a small valid OAuth error body (`{"error":"invalid_grant"}`) is preserved exactly
  7. Both `exchangeCodeForTokens` (authorization code) and `refreshTokensForGeminiCli` (refresh) paths are covered
- **Observed result**: `[google oauth.token loopback proof] oversized path: cap=8192 streamed=1048576 message_length=8215`
- **What was not tested**: The full end-to-end path through Google's actual OAuth endpoint (SSRF guard + DNS pinning). The `fetchWithTimeout` wrapper already has an independent 16 MiB bound; this PR adds a tighter text cap at the call site.

### Validation Evidence

```
pnpm test extensions/google/oauth.token.test.ts

✓ bounds oversized OAuth error body text
✓ preserves complete small error body text within the limit
✓ bounds oversized OAuth error body text during token refresh

Mutation proof:
  $ git stash      → 2 FAILED (old code buffers full body, stream not cancelled)
  $ git stash pop  → 3 PASSED
```

### Security & Privacy / Compatibility

- Cap value (8 KiB) matches existing `DISCORD_API_ERROR_BODY_LIMIT_BYTES` convention
- `readResponseTextLimited` reads at most maxBytes from the stream; oversized bodies are truncated, not silently consumed
- OAuth tokens, client secrets, and user credentials are not exposed in the capped error path
- No config, dependency, protocol, or `CHANGELOG.md` changes

---

_AI-assisted._
