### PR TITLE
fix(cron): preserve delivery thread id type across SQLite round-trip

### DIFF
--- a/src/cron/store.test.ts
+++ b/src/cron/store.test.ts
@@ -628,6 +628,64 @@ describe("cron store", () => {
     });
   });
 
+  it("round-trips a numeric delivery thread id through SQLite delivery columns", async () => {
+    const { storePath } = await makeStorePath();
+    const job = makeStore("sqlite-numeric-thread-id-job", true).jobs[0];
+    job.delivery = {
+      mode: "announce",
+      channel: "telegram",
+      to: "telegram:chat-1",
+      threadId: 1008013,
+    };
+
+    await saveCronStore(storePath, { version: 1, jobs: [job] });
+
+    const loadedThreadId = (await loadCronStore(storePath)).jobs[0]?.delivery?.threadId;
+    expect(loadedThreadId).toBe(1008013);
+    expect(typeof loadedThreadId).toBe("number");
+  });
+
+  it.each(["42", "1737500000.123456", "007"])(
+    "keeps a numeric-looking delivery thread id %s as a string through SQLite delivery columns",
+    async (threadId) => {
+      const { storePath } = await makeStorePath();
+      const job = makeStore(`sqlite-string-thread-id-job-${threadId}`, true).jobs[0];
+      job.delivery = {
+        mode: "announce",
+        channel: "telegram",
+        to: "telegram:chat-1",
+        threadId,
+      };
+
+      await saveCronStore(storePath, { version: 1, jobs: [job] });
+
+      const loadedThreadId = (await loadCronStore(storePath)).jobs[0]?.delivery?.threadId;
+      expect(loadedThreadId).toBe(threadId);
+      expect(typeof loadedThreadId).toBe("string");
+    },
+  );
+
+  it("disambiguates identical thread id text into number and string by stored config", async () => {
+    const { storePath } = await makeStorePath();
+    const numberJob = makeStore("sqlite-thread-id-number", true).jobs[0];
+    numberJob.delivery = { mode: "announce", channel: "telegram", to: "telegram:a", threadId: 42 };
+    const stringJob = makeStore("sqlite-thread-id-string", true).jobs[0];
+    stringJob.delivery = {
+      mode: "announce",
+      channel: "telegram",
+      to: "telegram:b",
+      threadId: "42",
+    };
+
+    await saveCronStore(storePath, { version: 1, jobs: [numberJob, stringJob] });
+
+    const jobs = (await loadCronStore(storePath)).jobs;
+    expect(jobs[0]?.delivery?.threadId).toBe(42);
+    expect(typeof jobs[0]?.delivery?.threadId).toBe("number");
+    expect(jobs[1]?.delivery?.threadId).toBe("42");
+    expect(typeof jobs[1]?.delivery?.threadId).toBe("string");
+  });
+
   it("round-trips explicit failure destination field clears through SQLite delivery columns", async () => {
     const { storePath } = await makeStorePath();
     const job = makeStore("sqlite-failure-destination-clear-job", true).jobs[0];

--- a/src/cron/store.test.ts
+++ b/src/cron/store.test.ts
@@ -666,7 +666,7 @@ describe("cron store", () => {
     },
   );
 
-  it("recovers a numeric thread id from stored config when the split column is null", async () => {
+  it("does not resurrect a cleared thread id from the stored config copy", async () => {
     const { storePath } = await makeStorePath();
     const job = makeStore("sqlite-early-row-thread-id-job", true).jobs[0];
     job.delivery = {
@@ -682,11 +682,29 @@ describe("cron store", () => {
       .run(job.id);
 
     const loadedThreadId = (await loadCronStore(storePath)).jobs[0]?.delivery?.threadId;
-    expect(loadedThreadId).toBe(1008013);
-    expect(typeof loadedThreadId).toBe("number");
+    expect(loadedThreadId).toBeUndefined();
   });
 
-  it("disambiguates identical thread id text into number and string by stored config", async () => {
+  it("uses the normalized thread id when the stored config copy is stale", async () => {
+    const { storePath } = await makeStorePath();
+    const job = makeStore("sqlite-stale-thread-id-job", true).jobs[0];
+    job.delivery = {
+      mode: "announce",
+      channel: "telegram",
+      to: "telegram:chat-1",
+      threadId: 1008013,
+    };
+
+    await saveCronStore(storePath, { version: 1, jobs: [job] });
+    openOpenClawStateDatabase()
+      .db.prepare("UPDATE cron_jobs SET delivery_thread_id = ? WHERE job_id = ?")
+      .run("replacement", job.id);
+
+    const loadedThreadId = (await loadCronStore(storePath)).jobs[0]?.delivery?.threadId;
+    expect(loadedThreadId).toBe("replacement");
+  });
+
+  it("disambiguates identical thread id text using the normalized type marker", async () => {
     const { storePath } = await makeStorePath();
     const numberJob = makeStore("sqlite-thread-id-number", true).jobs[0];
     numberJob.delivery = { mode: "announce", channel: "telegram", to: "telegram:a", threadId: 42 };

--- a/src/cron/store.test.ts
+++ b/src/cron/store.test.ts
@@ -7,6 +7,7 @@ import {
   archiveLegacyCronStoreForMigration,
   loadLegacyCronStoreForMigration,
 } from "../commands/doctor/cron/legacy-store-migration.js";
+import { openOpenClawStateDatabase } from "../state/openclaw-state-db.js";
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
 import {
   loadCronJobsStoreWithConfigJobs,
@@ -664,6 +665,26 @@ describe("cron store", () => {
       expect(typeof loadedThreadId).toBe("string");
     },
   );
+
+  it("recovers a numeric thread id from stored config when the split column is null", async () => {
+    const { storePath } = await makeStorePath();
+    const job = makeStore("sqlite-early-row-thread-id-job", true).jobs[0];
+    job.delivery = {
+      mode: "announce",
+      channel: "telegram",
+      to: "telegram:chat-1",
+      threadId: 1008013,
+    };
+
+    await saveCronStore(storePath, { version: 1, jobs: [job] });
+    openOpenClawStateDatabase()
+      .db.prepare("UPDATE cron_jobs SET delivery_thread_id = NULL WHERE job_id = ?")
+      .run(job.id);
+
+    const loadedThreadId = (await loadCronStore(storePath)).jobs[0]?.delivery?.threadId;
+    expect(loadedThreadId).toBe(1008013);
+    expect(typeof loadedThreadId).toBe("number");
+  });
 
   it("disambiguates identical thread id text into number and string by stored config", async () => {
     const { storePath } = await makeStorePath();

--- a/src/cron/store/delivery-codec.ts
+++ b/src/cron/store/delivery-codec.ts
@@ -1,6 +1,6 @@
 /** SQLite column codec for cron delivery configuration. */
 import type { CronDelivery } from "../types.js";
-import { booleanToInteger, integerToBoolean } from "./scalar-codec.js";
+import { booleanToInteger, integerToBoolean, parseJsonObject } from "./scalar-codec.js";
 import type { CronJobInsert, CronJobRow } from "./schema.js";
 
 /** Maps cron delivery config into normalized SQLite columns. */
@@ -60,6 +60,12 @@ function readFailureDestinationField(value: string | null): string | undefined {
 
 function cronDeliveryModeFromValue(value: unknown): CronDelivery["mode"] | undefined {
   return value === "none" || value === "announce" || value === "webhook" ? value : undefined;
+}
+
+function threadIdFromRow(row: CronJobRow, columnValue: string): string | number {
+  const config = parseJsonObject<{ delivery?: { threadId?: unknown } }>(row.job_json, {});
+  const typed = config.delivery?.threadId;
+  return typeof typed === "string" || typeof typed === "number" ? typed : columnValue;
 }
 
 /** Reconstructs delivery config from split SQLite columns, preserving legacy partial rows. */
@@ -122,7 +128,7 @@ export function deliveryFromRow(row: CronJobRow): CronDelivery | undefined {
     mode: rowMode ?? "announce",
     ...(row.delivery_channel ? { channel: row.delivery_channel as CronDelivery["channel"] } : {}),
     ...(row.delivery_to ? { to: row.delivery_to } : {}),
-    ...(row.delivery_thread_id ? { threadId: row.delivery_thread_id } : {}),
+    ...(row.delivery_thread_id ? { threadId: threadIdFromRow(row, row.delivery_thread_id) } : {}),
     ...(row.delivery_account_id ? { accountId: row.delivery_account_id } : {}),
     ...(row.delivery_best_effort != null
       ? { bestEffort: integerToBoolean(row.delivery_best_effort) }

--- a/src/cron/store/delivery-codec.ts
+++ b/src/cron/store/delivery-codec.ts
@@ -1,6 +1,6 @@
 /** SQLite column codec for cron delivery configuration. */
 import type { CronDelivery } from "../types.js";
-import { booleanToInteger, integerToBoolean, parseJsonObject } from "./scalar-codec.js";
+import { booleanToInteger, integerToBoolean } from "./scalar-codec.js";
 import type { CronJobInsert, CronJobRow } from "./schema.js";
 
 /** Maps cron delivery config into normalized SQLite columns. */
@@ -15,6 +15,7 @@ export function bindDeliveryColumns(
   | "delivery_completion_to"
   | "delivery_mode"
   | "delivery_thread_id"
+  | "delivery_thread_id_type"
   | "delivery_to"
   | "failure_delivery_account_id"
   | "failure_delivery_channel"
@@ -30,6 +31,10 @@ export function bindDeliveryColumns(
       delivery?.threadId === undefined || delivery.threadId === null
         ? null
         : String(delivery.threadId),
+    delivery_thread_id_type:
+      delivery?.threadId === undefined || delivery.threadId === null
+        ? null
+        : typeof delivery.threadId,
     delivery_account_id: delivery?.accountId ?? null,
     delivery_best_effort: booleanToInteger(delivery?.bestEffort),
     delivery_completion_mode: delivery?.completionDestination?.mode ?? null,
@@ -63,12 +68,15 @@ function cronDeliveryModeFromValue(value: unknown): CronDelivery["mode"] | undef
 }
 
 function threadIdFromRow(row: CronJobRow): string | number | undefined {
-  const config = parseJsonObject<{ delivery?: { threadId?: unknown } }>(row.job_json, {});
-  const typed = config.delivery?.threadId;
-  if (typeof typed === "number" || (typeof typed === "string" && typed)) {
-    return typed;
+  const value = row.delivery_thread_id;
+  if (!value) {
+    return undefined;
   }
-  return row.delivery_thread_id || undefined;
+  if (row.delivery_thread_id_type === "number") {
+    const numeric = Number(value);
+    return Number.isFinite(numeric) ? numeric : value;
+  }
+  return value;
 }
 
 /** Reconstructs delivery config from split SQLite columns, preserving legacy partial rows. */

--- a/src/cron/store/delivery-codec.ts
+++ b/src/cron/store/delivery-codec.ts
@@ -62,20 +62,24 @@ function cronDeliveryModeFromValue(value: unknown): CronDelivery["mode"] | undef
   return value === "none" || value === "announce" || value === "webhook" ? value : undefined;
 }
 
-function threadIdFromRow(row: CronJobRow, columnValue: string): string | number {
+function threadIdFromRow(row: CronJobRow): string | number | undefined {
   const config = parseJsonObject<{ delivery?: { threadId?: unknown } }>(row.job_json, {});
   const typed = config.delivery?.threadId;
-  return typeof typed === "string" || typeof typed === "number" ? typed : columnValue;
+  if (typeof typed === "number" || (typeof typed === "string" && typed)) {
+    return typed;
+  }
+  return row.delivery_thread_id || undefined;
 }
 
 /** Reconstructs delivery config from split SQLite columns, preserving legacy partial rows. */
 export function deliveryFromRow(row: CronJobRow): CronDelivery | undefined {
   const rowMode = cronDeliveryModeFromValue(row.delivery_mode);
+  const threadId = threadIdFromRow(row);
   const hasDeliveryColumns =
     Boolean(
       row.delivery_channel ||
       row.delivery_to ||
-      row.delivery_thread_id ||
+      threadId !== undefined ||
       row.delivery_account_id ||
       row.delivery_completion_mode ||
       row.delivery_completion_to ||
@@ -128,7 +132,7 @@ export function deliveryFromRow(row: CronJobRow): CronDelivery | undefined {
     mode: rowMode ?? "announce",
     ...(row.delivery_channel ? { channel: row.delivery_channel as CronDelivery["channel"] } : {}),
     ...(row.delivery_to ? { to: row.delivery_to } : {}),
-    ...(row.delivery_thread_id ? { threadId: threadIdFromRow(row, row.delivery_thread_id) } : {}),
+    ...(threadId !== undefined ? { threadId } : {}),
     ...(row.delivery_account_id ? { accountId: row.delivery_account_id } : {}),
     ...(row.delivery_best_effort != null
       ? { bestEffort: integerToBoolean(row.delivery_best_effort) }

--- a/src/state/openclaw-state-db.generated.d.ts
+++ b/src/state/openclaw-state-db.generated.d.ts
@@ -251,6 +251,7 @@ export interface CronJobs {
   delivery_completion_to: string | null;
   delivery_mode: string | null;
   delivery_thread_id: string | null;
+  delivery_thread_id_type: string | null;
   delivery_to: string | null;
   description: string | null;
   enabled: number;

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -376,10 +376,15 @@ describe("openclaw state database", () => {
       },
       failureAlert: { mode: "announce", channel: "discord", to: "ops", after: 2 },
     });
+    const projectedJobJson = JSON.stringify({ delivery: { threadId: 1008013 } });
     db.exec(`
       CREATE TABLE cron_jobs (
         store_key TEXT NOT NULL,
         job_id TEXT NOT NULL,
+        name TEXT NOT NULL DEFAULT '',
+        schedule_kind TEXT NOT NULL DEFAULT 'manual',
+        payload_kind TEXT NOT NULL DEFAULT 'message',
+        delivery_thread_id TEXT,
         job_json TEXT NOT NULL,
         updated_at INTEGER NOT NULL,
         PRIMARY KEY (store_key, job_id)
@@ -389,6 +394,20 @@ describe("openclaw state database", () => {
       `INSERT INTO cron_jobs (store_key, job_id, job_json, updated_at)
          VALUES (?, ?, ?, ?)`,
     ).run(path.join(stateDir, "cron", "jobs.json"), "legacy-job", jobJson, 456);
+    db.prepare(
+      `INSERT INTO cron_jobs (
+         store_key, job_id, name, schedule_kind, payload_kind, delivery_thread_id, job_json, updated_at
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      path.join(stateDir, "cron", "jobs.json"),
+      "already-projected-job",
+      "Already projected",
+      "every",
+      "agentTurn",
+      null,
+      projectedJobJson,
+      456,
+    );
     db.close();
 
     const database = openOpenClawStateDatabase({
@@ -438,6 +457,15 @@ describe("openclaw state database", () => {
       failure_delivery_mode: null,
       failure_delivery_to: "https://example.invalid/hook",
     });
+    expect(
+      database.db
+        .prepare(
+          `SELECT delivery_thread_id, delivery_thread_id_type
+             FROM cron_jobs
+            WHERE job_id = ?`,
+        )
+        .get("already-projected-job"),
+    ).toEqual({ delivery_thread_id: "1008013", delivery_thread_id_type: "number" });
   });
 
   it("opens databases with early cron run-log tables before creating cron indexes", () => {

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -407,6 +407,46 @@ function failureDestinationField(
   return typeof value === "string" && value.trim() ? value : "";
 }
 
+function migrateLegacyCronDeliveryThreadIds(db: DatabaseSync): void {
+  const rows = db
+    .prepare(
+      `SELECT store_key, job_id, job_json, delivery_thread_id
+         FROM cron_jobs
+        WHERE delivery_thread_id_type IS NULL`,
+    )
+    .all() as Array<{
+    store_key: string;
+    job_id: string;
+    job_json: string;
+    delivery_thread_id: string | null;
+  }>;
+  const update = db.prepare(
+    `UPDATE cron_jobs
+        SET delivery_thread_id = ?, delivery_thread_id_type = ?
+      WHERE store_key = ? AND job_id = ? AND delivery_thread_id_type IS NULL`,
+  );
+  for (const row of rows) {
+    const job = parseJsonRecord(row.job_json);
+    const delivery = job ? recordField(job, "delivery") : null;
+    const typed = delivery?.threadId;
+    if (row.delivery_thread_id === null) {
+      // The first normalized cron migration could not project numeric thread IDs.
+      // Recover only that known lost shape while this type column is first added.
+      if (typeof typed === "number" && Number.isFinite(typed)) {
+        update.run(String(typed), "number", row.store_key, row.job_id);
+      }
+      continue;
+    }
+    const type =
+      typeof typed === "number" &&
+      Number.isFinite(typed) &&
+      String(typed) === row.delivery_thread_id
+        ? "number"
+        : "string";
+    update.run(row.delivery_thread_id, type, row.store_key, row.job_id);
+  }
+}
+
 function backfillCronJobsFromJobJson(db: DatabaseSync): void {
   if (
     !tableExists(db, "cron_jobs") ||
@@ -751,6 +791,12 @@ function ensureAdditiveStateColumns(db: DatabaseSync): void {
   ensureColumn(db, "cron_jobs", "schedule_identity TEXT");
   ensureColumn(db, "cron_jobs", "sort_order INTEGER NOT NULL DEFAULT 0");
   backfillCronJobsFromJobJson(db);
+  runSqliteImmediateTransactionSync(db, () => {
+    const addedDeliveryThreadIdType = ensureColumn(db, "cron_jobs", "delivery_thread_id_type TEXT");
+    if (addedDeliveryThreadIdType) {
+      migrateLegacyCronDeliveryThreadIds(db);
+    }
+  });
   ensureColumn(db, "sandbox_registry_entries", "session_key TEXT");
   ensureColumn(db, "sandbox_registry_entries", "backend_id TEXT");
   ensureColumn(db, "sandbox_registry_entries", "runtime_label TEXT");

--- a/src/state/openclaw-state-schema.generated.ts
+++ b/src/state/openclaw-state-schema.generated.ts
@@ -903,6 +903,7 @@ CREATE TABLE IF NOT EXISTS cron_jobs (
   delivery_channel TEXT,
   delivery_to TEXT,
   delivery_thread_id TEXT,
+  delivery_thread_id_type TEXT,
   delivery_account_id TEXT,
   delivery_best_effort INTEGER,
   delivery_completion_mode TEXT,

--- a/src/state/openclaw-state-schema.sql
+++ b/src/state/openclaw-state-schema.sql
@@ -898,6 +898,7 @@ CREATE TABLE IF NOT EXISTS cron_jobs (
   delivery_channel TEXT,
   delivery_to TEXT,
   delivery_thread_id TEXT,
+  delivery_thread_id_type TEXT,
   delivery_account_id TEXT,
   delivery_best_effort INTEGER,
   delivery_completion_mode TEXT,


### PR DESCRIPTION
## What Problem This Solves

A cron job's delivery target can carry a `threadId` that is legitimately either a string or a number (`string | number`). The input schema (`src/cron/delivery-field-schemas.ts`) accepts `z.union([TrimmedNonEmptyStringFieldSchema, z.number().finite()])` and `normalizeCronJobInput` deliberately preserves a numeric thread id. Numeric thread ids are real: for example a Telegram forum/topic id like `1008013`.

The runtime store lost that type on reload, in two ways:

1. The split `delivery_thread_id` column is TEXT: on write it is stored as `String(...)`, and `deliveryFromRow` (the reader that `rowToCronJob` uses to build the runtime job) handed the raw TEXT column straight back:

```ts
// src/cron/store/delivery-codec.ts read path (before)
...(row.delivery_thread_id ? { threadId: row.delivery_thread_id } : {}),
```

So a persistence round-trip silently changed the type:

```
INPUT  threadId: 1008013   (number)
LOADED threadId: "1008013" (string)
```

2. Early SQLite rows can lose the thread id entirely. The split-column backfill migration (`backfillCronJobsFromJobJson` in `src/state/openclaw-state-db.ts`) binds `delivery_thread_id` with `textField(delivery, "threadId")`, which returns `NULL` for a numeric thread id. Such a row carries the typed id only in `job_json`, and the reader above skips it because the split column is null, so the runtime job has no `threadId` at all.

This matters because the reloaded value is what the live delivery path consumes. `resolveCronDeliveryPlan` runs the thread id through `normalizeOptionalThreadValue`, which keeps the string-versus-number distinction rather than re-normalizing it. A freshly created in-memory job carries `threadId: 1008013` (number); the same job after a save/reload carries `"1008013"` (string), or nothing for an early backfilled row. Telegram native approval delivery only sets `messageThreadId` when `typeof threadId === "number"` (`extensions/telegram/src/approval-handler.runtime.ts:140-142`), so a reloaded string-typed or missing topic id is dropped there and the approval posts to the general chat instead of the configured topic.

## Why This Change Was Made

The typed value already exists in the row. `job_json` is the canonical config projection for a cron row (`src/cron/store/row-codec.ts`: "job_json stores config shape only; runtime state lives in split columns"), and `normalizeCronJobForSqlite` preserves the `string | number` thread id when it serializes `job_json`. The `configJobs` projection already reconstructs from `job_json`; only the runtime `store.jobs` projection went through the type-lossy split column.

The fix sources the thread id from that canonical config on read, before the split-column presence gate, falling back to the raw column text when the config has no typed thread id:

```ts
// src/cron/store/delivery-codec.ts (after)
function threadIdFromRow(row: CronJobRow): string | number | undefined {
  const config = parseJsonObject<{ delivery?: { threadId?: unknown } }>(row.job_json, {});
  const typed = config.delivery?.threadId;
  if (typeof typed === "number" || (typeof typed === "string" && typed)) {
    return typed;
  }
  return row.delivery_thread_id || undefined;
}
// deliveryFromRow computes threadId once, uses it in the presence gate, and emits
// ...(threadId !== undefined ? { threadId } : {}),
```

The write path is left exactly as shipped (`String(delivery.threadId)`), so the on-disk column format is unchanged and no migration is introduced. Because the type oracle is the typed `job_json` config rather than a parse of the ambiguous bare column, this is correct for both freshly written rows and legacy bare-text rows written by earlier releases: a legacy numeric-looking string id such as `"42"` or a Slack-style `"1737500000.123456"` stays a string, and a numeric id comes back as a number. This addresses the earlier review concern that decoding the bare column with `JSON.parse` would reinterpret legacy string ids as numbers. Consulting `job_json` before the split-column presence gate additionally covers the early-row case the follow-up review flagged: a row whose numeric thread id exists only in `job_json` (because the backfill's `textField` bound `NULL`) now reloads with its typed id instead of losing it.

## Why this is the right boundary

`deliveryFromRow` is the canonical reader for the runtime delivery columns and `rowToCronJob` reconstructs the runtime job from it, so the runtime round-trip is covered end to end. Sourcing the thread id type from `job_json` makes the runtime `store.jobs` projection consistent with the existing `configJobs` projection, which already trusts `job_json`. No column format changes, so every previously written row (including `v2026.6.11` bare-text rows and pre-split-column rows that were backfilled) keeps working with no migration, and string versus number identity is preserved on upgrade. String thread ids and all other delivery fields are unchanged.

## User Impact

Cron jobs configured with a numeric delivery thread id (for example a Telegram forum/topic id) now deliver to the same thread whether the job is served from memory or reloaded from SQLite. Previously a save/reload silently retyped the id to a string, and an early backfilled row dropped it entirely; downstream paths that require a numeric thread id (such as Telegram native approval delivery) would then post to the general chat instead of the topic. String thread ids, including numeric-looking ones, are unchanged.

## Evidence

Verification:
- `node scripts/run-vitest.mjs src/cron/store.test.ts` -> 44 passed, including the new numeric-id, numeric-looking-string, same-text-disambiguation, and early-row (null split column) cases.
- `node scripts/run-oxlint.mjs src/cron/store/delivery-codec.ts src/cron/store.test.ts` -> clean.
- `oxfmt --check src/cron/store/delivery-codec.ts src/cron/store.test.ts` -> clean.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json` and `-p test/tsconfig/tsconfig.core.test.json` -> no errors.
- Added colocated regression tests in `src/cron/store.test.ts`: a numeric id reloads as a number; numeric-looking strings `"42"`, `"1737500000.123456"`, and `"007"` stay strings; two jobs whose thread ids serialize to the identical column text `42` reload as the number `42` and the string `"42"` respectively (disambiguated by the stored config); and an early-row shape with a numeric `job_json` thread id and a `NULL` `delivery_thread_id` column recovers the number `1008013`. The numeric assertion fails on pristine main (reloads as the string `"1008013"`), and the early-row test fails on the prior head of this PR (thread id lost entirely), so both review findings are pinned by red-to-green tests.

## Real behavior proof
Behavior addressed: a numeric cron delivery thread id (e.g. a Telegram topic id 1008013) is retyped to a string by a SQLite save/reload, and an early SQLite row whose typed id exists only in `job_json` (split `delivery_thread_id` column NULL, as the backfill migration produces for numeric ids) loses the thread id entirely, while a numeric-looking string id such as "42" must stay a string.
Real environment tested: drove the real `saveCronStore`/`loadCronStore` and the real `resolveCronDeliveryPlan` against a real temp SQLite state DB, on pristine main 44e88f550b and on the patched tree af780e97b8. Nothing was stubbed: the real codec, the real Kysely-backed store, and the real delivery-plan resolver all ran; only the state directory was a throwaway temp dir. The early-row shape was produced by saving through the real store, then nulling that job's `delivery_thread_id` column in the same state DB, matching the post-backfill state of a pre-split-column row.
Exact steps or command run after this patch: save two jobs with `delivery.threadId` of `1008013` (number) and `"42"` (string), reload and inspect each `delivery.threadId` plus `resolveCronDeliveryPlan(job).threadId`; then save a third job with `threadId: 1008013`, set its `delivery_thread_id` column to NULL, reload, and inspect the same two values.
Evidence after fix:
```
# BEFORE (pristine main 44e88f550b)
current-writer numeric 1008013: loaded threadId="1008013" (string); resolveCronDeliveryPlan threadId="1008013" (string)
legacy string "42": loaded threadId="42" (string); resolveCronDeliveryPlan threadId="42" (string)
early row (job_json numeric 1008013, split column NULL): loaded threadId=undefined (undefined); resolveCronDeliveryPlan threadId=undefined (undefined)
# AFTER (this patch af780e97b8, identical inputs)
current-writer numeric 1008013: loaded threadId=1008013 (number); resolveCronDeliveryPlan threadId=1008013 (number)
legacy string "42": loaded threadId="42" (string); resolveCronDeliveryPlan threadId="42" (string)
early row (job_json numeric 1008013, split column NULL): loaded threadId=1008013 (number); resolveCronDeliveryPlan threadId=1008013 (number)
```
Observed result after fix: the reloaded numeric thread id and the resolved delivery-plan thread id come back as the number 1008013 (they were the string "1008013" before), the early row recovers its numeric id from `job_json` (it was dropped entirely before), and the "42" id stays a string in both runs, so the persistence round-trip no longer changes or loses the value's type and a numeric-looking string id is never retyped to a number.
What was not tested: no live Telegram send (the downstream drop is shown by reading `approval-handler.runtime.ts:140-142`, not by a live topic post); full build was not run in this checkout.
