### PR TITLE
fix: prevent agents-tools message test timeouts

### DIFF
--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -111,6 +111,19 @@ const mocks = vi.hoisted(() => ({
   ),
 }));
 
+vi.mock("../../channels/plugins/bundled.js", async () => {
+  const actual = await vi.importActual<typeof import("../../channels/plugins/bundled.js")>(
+    "../../channels/plugins/bundled.js",
+  );
+  // This unit suite installs minimal loaded plugins when it exercises channel actions.
+  // Bundled source entry loading belongs to the loader integration suites.
+  return {
+    ...actual,
+    getBundledChannelPlugin: vi.fn(() => undefined),
+    getBundledChannelSetupPlugin: vi.fn(() => undefined),
+  };
+});
+
 type RunMessageActionInput = {
   agentId?: string;
   cfg?: unknown;


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the serialized `agents-tools` CI shard could time out in `message-tool.test.ts` when its first asynchronous send cold-loaded bundled channel source entries after the heavyweight image-tool tests.

## Why This Change Was Made

The message-tool unit suite now disables bundled runtime/setup entry fallback while retaining the real loaded-plugin registry and alias-resolution paths. Tests that need channel behavior already install explicit minimal test plugins, so this keeps integration loading in its dedicated loader suites without changing production code, runner allocation, worker counts, timeouts, or coverage.

## User Impact

There is no product/runtime behavior change. Maintainers can expect the main `agents-tools` shard to complete without the deterministic 2–3 minute message-tool stall that was blocking green-main leases.

## Evidence

Root-cause reproduction:

- Main jobs [84514551065](https://github.com/openclaw/openclaw/actions/runs/28511402996/job/84514551065), [84542334833](https://github.com/openclaw/openclaw/actions/runs/28520255425/job/84542334833), and [84560888446](https://github.com/openclaw/openclaw/actions/runs/28525531094/job/84560888446) all stalled the first asynchronous message-tool row for 157–181 seconds after the image-tool family.
- Fresh Blacksmith Testbox `tbx_01kwf4f5e6dcm6qrw9h2kswchs` (Node 24.13) reproduced the exact valid string-timeout row at 132,998 ms.
- Direct AWS Crabbox `cbx_370910f4757b` / `c7a.8xlarge` (Node 24.18, 32 CPUs) reproduced it at 172,451 ms, excluding a Blacksmith-only platform defect.
- A worker CPU profile attributed 79.945 seconds of self time to Jiti and showed the inclusive path `message-tool execute -> resolvePollVoteEchoRoute -> getChannelPlugin -> getBundledChannelPlugin -> source entry loader`. The Vitest worker held one CPU while the async resolver awaited its next line.

Exact-head candidate proof:

- Fresh Blacksmith Testbox `tbx_01kwf65hyk9camrztpa05p40qt`, [Actions run 28530354474](https://github.com/openclaw/openclaw/actions/runs/28530354474), Node 24.13, 8 CPUs: exact row 10 ms; final full message-tool file 111/111 passed in 2.38 seconds.
- Same Testbox, real serialized agents-tools config/process: `image-tool.test.ts` ran first in 34.889 seconds, then `message-tool.test.ts` passed 111/111 in 547 ms; entire shard passed 54 files / 1,040 tests in 70.18 seconds.
- Direct AWS Crabbox `cbx_370910f4757b`: exact row 10 ms ([run `run_29422e57dc4b`](https://crabbox.openclaw.ai/portal/runs/run_29422e57dc4b)); full message-tool file passed 111/111 in 3.19 seconds with all formerly displaced fallback rows at 0–2 ms ([run `run_94e471588c26`](https://crabbox.openclaw.ai/portal/runs/run_94e471588c26)).
- `corepack pnpm check:changed -- src/agents/tools/message-tool.test.ts`: passed conflict, attribution, dependency/patch guards, core-test typecheck, and changed-file lint (0 warnings/errors) on the fresh Testbox.
- Genuine `gpt-5.6-sol` xhigh autoreview: no findings; patch correct at 0.97 confidence.

The exact hosted/Testbox/direct-AWS executions are the live boundary for this test-only change; no external product service is involved.
