### PR TITLE
fix(feishu): strip internal tool-trace banners from outbound text

### DIFF
--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -33,6 +33,7 @@ import { createLazyRuntimeNamedExport } from "openclaw/plugin-sdk/lazy-runtime";
 import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
 import { createComputedAccountStatusAdapter } from "openclaw/plugin-sdk/status-helpers";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking";
 import type { PluginRuntime } from "../runtime-api.js";
 import {
   inspectFeishuCredentials,
@@ -1367,6 +1368,7 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
       chunker: chunkTextForOutbound,
       chunkerMode: "markdown",
       textChunkLimit: 4000,
+      sanitizeText: ({ text }) => sanitizeAssistantVisibleText(text),
       presentationCapabilities: {
         supported: true,
         buttons: true,

--- a/extensions/feishu/src/outbound-tool-trace-sanitize.test.ts
+++ b/extensions/feishu/src/outbound-tool-trace-sanitize.test.ts
@@ -1,0 +1,20 @@
+// Feishu outbound must strip assistant internal tool-trace scaffolding, matching
+// the sibling channel fixes tracked under #90684 (Slack / Signal / Matrix /
+// Telegram / Google Chat / QQBot / IRC / SMS). sanitizeAssistantVisibleText
+// keeps markdown formatting suitable for Feishu card rendering.
+import { describe, expect, it } from "vitest";
+import { feishuPlugin } from "./channel.js";
+
+describe("feishu outbound sanitizeText", () => {
+  it("strips internal tool-trace banners before outbound delivery", () => {
+    const text = "Done.\n⚠️ 🛠️ `search repos (agent)` failed";
+
+    expect(feishuPlugin.outbound?.sanitizeText?.({ text, payload: { text } })).toBe("Done.");
+  });
+
+  it("preserves ordinary assistant prose while sanitizing", () => {
+    const text = "The pipeline has 3 open deals.";
+
+    expect(feishuPlugin.outbound?.sanitizeText?.({ text, payload: { text } })).toBe(text);
+  });
+});


### PR DESCRIPTION
Part of #90684

## What Problem This Solves

Fixes an issue where Feishu users receiving bot replies would see internal assistant tool-trace scaffolding lines (e.g. `⚠️ 🛠️ \`search repos (agent)\` failed`) leaked into outbound messages. These banners are internal runtime diagnostics that should not reach end users.

## Why This Change Was Made

The Feishu outbound adapter lacked a `sanitizeText` hook, so core `stripInternalRuntimeScaffolding` was the only sanitization layer — and it does not remove tool-trace failure banners. Adding `sanitizeAssistantVisibleText` on the outbound `sanitizeText` hook matches the accepted sibling pattern already shipped for Slack, Signal, Matrix, Telegram, Google Chat, QQBot, IRC, and SMS.

## User Impact

Feishu users no longer see internal tool-trace failure banners in bot replies. Normal assistant prose and markdown formatting are preserved.

## Evidence

**Negative control — core strip keeps banner (pre-fix behavior):**

```
$ node --import tsx -e '
import { stripInternalRuntimeScaffolding } from "./src/infra/outbound/sanitize-text.js";
const text = "Done.\n⚠️ 🛠️ \`search repos (agent)\` failed";
console.log("Output:", JSON.stringify(stripInternalRuntimeScaffolding(text)));
console.log("Banner survives:", stripInternalRuntimeScaffolding(text).includes("⚠️"));'

Output: "Done.\n⚠️ 🛠️ `search repos (agent)` failed"
Banner survives: true
```

**After fix — feishuPlugin.outbound.sanitizeText strips banner:**

```
$ node --import tsx -e '
import { feishuPlugin } from "./extensions/feishu/src/channel.js";
const text = "Done.\n⚠️ 🛠️ \`search repos (agent)\` failed";
const result = feishuPlugin.outbound?.sanitizeText?.({ text, payload: { text } });
console.log("Output:", JSON.stringify(result));
console.log("Banner stripped:", !result?.includes("⚠️"));'

Output: "Done."
Banner stripped: true
```

**Focused test:**

```
$ node scripts/run-vitest.mjs run extensions/feishu/src/outbound-tool-trace-sanitize.test.ts

 ✓ feishu outbound sanitizeText
   ✓ strips internal tool-trace banners before outbound delivery
   ✓ preserves ordinary assistant prose while sanitizing

 Test Files  1 passed (1)
      Tests  2 passed (2)
```

**What was not tested:** No live Feishu round-trip — credentials were not available in this checkout. The bug is in the sanitization layer before network delivery, so the proof above covers the affected boundary without a live channel.

AI-assisted: Cursor (Claude). Proof run manually.

Made with [Cursor](https://cursor.com)