### PR TITLE
feat(plugins): add scoped credential broker

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-729181bf726ea51bebfa51c760eff8d5016933c21815e47197b5d05db8d549d5  plugin-sdk-api-baseline.json
-d8add92c9c5445e8bdd8a8361cdd5a42e1ab5baa45cd16ea640152d6f577f1bf  plugin-sdk-api-baseline.jsonl
+514fe16ee8a94751eed8754ad25835e94b3d6806d64859fbee7d975d3529ff50  plugin-sdk-api-baseline.json
+e612119458d317fe8272517b4374276983d7d4bee105d52b9de6427a787ee4bd  plugin-sdk-api-baseline.jsonl

--- a/docs/gateway/secrets.md
+++ b/docs/gateway/secrets.md
@@ -56,6 +56,34 @@ SecretRef migration as complete only when all of these are true:
 This is why the audit/configure/apply workflow is a security migration gate, not
 just a convenience helper.
 
+### Brokered plugin tool operations
+
+Plugin manifests can declare narrow credentialed JSON operations for agent
+tools. When the configured credential is a structured SecretRef, OpenClaw keeps
+the resolved runtime value inside a conversation-scoped request broker and
+removes that credential path from the owning tool factory's config snapshots.
+The tool-discovery plugin API receives only the opaque SecretRef before
+registration, and the tool receives a short-lived opaque request handle, not
+the SecretRef or plaintext value.
+
+The broker reads the resolved runtime snapshot paired with the prepared run, so
+startup/reload fail-fast, atomic swap, and last-known-good behavior remain
+unchanged. It does not invoke env, file, or exec secret providers on the request
+path.
+
+Brokered operations require prepared agent, conversation, channel, and sender
+identity plus an explicit existing tool-policy grant. Missing scope denies the
+request. Existing sender, group, agent, sandbox, and inherited deny policies
+still win. Requests use guarded HTTPS/SSRF handling, no redirects, fixed
+manifest-declared methods and paths, and declared body, response, and timeout
+limits. Handles are single-use, expire after 30 seconds, and are invalid after a
+Gateway restart.
+
+This is a data-flow boundary against accidental secret propagation into tool
+arguments, events, logs, errors, transcripts, and audit records. It is not
+process isolation from installed plugin code or a modified OpenClaw runtime.
+See [Plugin manifest: credentialBroker](/plugins/manifest#credentialbroker-reference).
+
 <Warning>
 SecretRefs do not make arbitrary readable files safe. Backups, copied configs,
 old generated model catalogs, and unsupported credential classes must be treated

--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -187,6 +187,7 @@ or npm install metadata. Those belong in your plugin code and `package.json`.
 | `videoGenerationProviderMetadata`    | No       | `Record<string, object>`         | Cheap video-generation auth metadata for provider ids declared in `contracts.videoGenerationProviders`, including provider-owned auth aliases and base-url guards.                                                                              |
 | `musicGenerationProviderMetadata`    | No       | `Record<string, object>`         | Cheap music-generation auth metadata for provider ids declared in `contracts.musicGenerationProviders`, including provider-owned auth aliases and base-url guards.                                                                              |
 | `toolMetadata`                       | No       | `Record<string, object>`         | Cheap availability metadata for plugin-owned tools declared in `contracts.tools`. Use it when a tool should not load runtime unless config, env, or auth evidence exists.                                                                       |
+| `credentialBroker`                   | No       | `object`                         | Narrow manifest-declared credentialed operations for plugin tools. Structured SecretRefs stay host-owned and execute through conversation-scoped opaque request handles.                                                                        |
 | `channelConfigs`                     | No       | `Record<string, object>`         | Manifest-owned channel config metadata merged into discovery and validation surfaces before runtime loads.                                                                                                                                      |
 | `skills`                             | No       | `string[]`                       | Skill directories to load, relative to the plugin root.                                                                                                                                                                                         |
 | `name`                               | No       | `string`                         | Human-readable plugin name.                                                                                                                                                                                                                     |
@@ -335,6 +336,109 @@ If a tool has no `toolMetadata`, OpenClaw preserves the existing behavior and
 loads the owning plugin when the tool contract matches policy. For hot-path
 tools whose factory depends on auth/config, plugin authors should declare
 `toolMetadata` instead of making core import runtime to ask.
+
+## credentialBroker reference
+
+Use `credentialBroker` when a plugin tool must make one fixed credentialed
+JSON request without receiving the resolved credential. This is a narrow host
+request boundary, not a general HTTP client or process isolation from installed
+plugin code.
+
+```json
+{
+  "contracts": {
+    "tools": ["team_operation_run"]
+  },
+  "configContracts": {
+    "secretInputs": {
+      "paths": [{ "path": "service.apiKey", "expected": "string" }]
+    }
+  },
+  "credentialBroker": {
+    "operations": [
+      {
+        "id": "run",
+        "tool": "team_operation_run",
+        "secretInputPath": "service.apiKey",
+        "baseUrlConfigPath": "service.baseUrl",
+        "baseUrlEnv": "SERVICE_BASE_URL",
+        "defaultBaseUrl": "https://api.example.com",
+        "path": "/v1/run",
+        "method": "POST",
+        "credentialHeader": "Authorization",
+        "credentialScheme": "Bearer",
+        "headers": {
+          "X-Client-Source": "openclaw"
+        },
+        "maxRequestBodyBytes": 131072,
+        "maxResponseBodyBytes": 16777216,
+        "timeoutMs": 30000
+      }
+    ]
+  }
+}
+```
+
+| Operation field        | Required | Meaning                                                                                                                                                             |
+| ---------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`                   | Yes      | Stable operation id passed to the plugin's broker client.                                                                                                           |
+| `tool`                 | Yes      | Owning tool name. It must match the plugin's runtime registration and `contracts.tools`.                                                                            |
+| `secretInputPath`      | Yes      | Dot path relative to `plugins.entries.<id>.config`. It must match a `configContracts.secretInputs.paths` entry; only a canonical structured SecretRef activates it. |
+| `baseUrlConfigPath`    | No       | Optional dot path for an operator-configured HTTPS base URL.                                                                                                        |
+| `baseUrlEnv`           | No       | Optional existing environment variable for the HTTPS base URL. Config takes precedence.                                                                             |
+| `defaultBaseUrl`       | Yes      | Credential-free HTTPS base URL. Userinfo, query strings, and fragments are rejected.                                                                                |
+| `path`                 | Yes      | Fixed request path appended to the base URL.                                                                                                                        |
+| `method`               | Yes      | `POST`. Other methods are rejected.                                                                                                                                 |
+| `credentialHeader`     | Yes      | `Authorization` or `X-Api-Key`.                                                                                                                                     |
+| `credentialScheme`     | No       | Optional scheme such as `Bearer`.                                                                                                                                   |
+| `headers`              | No       | Static, non-credential request headers. Only `Accept`, `Accept-Language`, `User-Agent`, `X-Client-Source`, and `X-Client-Version` are accepted.                     |
+| `maxRequestBodyBytes`  | Yes      | Positive JSON request-body limit, at most 1 MiB.                                                                                                                    |
+| `maxResponseBodyBytes` | Yes      | Positive JSON response-body limit, at most 64 MiB.                                                                                                                  |
+| `timeoutMs`            | Yes      | Positive request timeout, at most 120 seconds.                                                                                                                      |
+
+When a structured SecretRef activates an operation, OpenClaw restores that
+opaque reference before loading the owning tool-discovery plugin, then removes
+the credential path from the tool factory's `config`, `runtimeConfig`, and live
+config getter. The factory receives `credentialBroker` instead:
+
+```typescript
+const handle = context.credentialBroker?.createRequest({
+  operationId: "run",
+  body: { taskId },
+});
+const result = await handle?.execute({ signal });
+```
+
+The handle exposes only an id, operation id, expiry, and lifecycle state. It is
+single-use, expires after 30 seconds, supports pre-execution revocation, and is
+invalid after process restart. It never serializes the request body, SecretRef,
+or resolved value.
+
+Broker authorization reuses the prepared conversation capability profile and
+existing layered tool policy. The profile must contain agent, conversation,
+channel, and sender identity; the normal default-plugin selection or an active
+policy must allow the tool, plugin id, or `group:plugins`; and every active
+deny/narrowing policy still wins. Missing scope, an optional tool without an
+explicit grant, or a tool excluded by a narrowing policy fails closed.
+Scope-less MCP and control-plane catalogs omit tools activated by structured
+SecretRefs instead of advertising an operation they cannot authorize.
+
+Execution materializes the value from the resolved runtime snapshot paired with
+the prepared run, only inside the broker closure; it does not rerun file or exec
+secret providers on the request path. The request uses the existing guarded
+trusted-endpoint path, pins the declared hostname while honoring standard proxy
+routing, requires HTTPS, disables redirects and debug request capture, and
+enforces the declared timeout and size limits. Returned JSON is redacted for the
+exact credential value before it crosses back to plugin code. Errors contain
+stable broker text or an HTTP status only, never provider response bodies or
+resolver details.
+
+Literal string credentials and environment-variable fallback do not activate
+the broker. A consumer may retain those existing paths for compatibility, but
+must not fall back from a configured structured SecretRef to plaintext.
+Invalid, duplicate, empty, or over-limit broker declarations invalidate the
+plugin manifest so a rejected operation can never fall through to resolved
+plugin config.
 
 ## providerAuthChoices reference
 

--- a/docs/tools/tavily.md
+++ b/docs/tools/tavily.md
@@ -134,15 +134,61 @@ The generic `web_search` tool with Tavily as provider supports `query` and `coun
   <Accordion title="API key resolution order">
     The Tavily client looks up its API key in this order:
 
-    1. `plugins.entries.tavily.config.webSearch.apiKey` (resolved through SecretRefs).
+    1. `plugins.entries.tavily.config.webSearch.apiKey`.
     2. `TAVILY_API_KEY` from the gateway environment.
 
     `tavily_extract` raises a setup error if neither is present.
 
   </Accordion>
 
+  <Accordion title="Broker a SecretRef for Tavily tools">
+    `tavily_search` and `tavily_extract` can execute with an opaque,
+    conversation-scoped request handle when `apiKey` is a structured SecretRef.
+    The resolved value stays inside the host broker and is removed from the
+    plugin tool factory's config snapshots.
+
+    Tavily's default-enabled tools preserve their normal access when the active
+    profile has no restrictive allowlist. If a profile narrows tool access, use
+    `alsoAllow` to preserve that profile while adding the two tools:
+
+    ```json5
+    {
+      plugins: {
+        entries: {
+          tavily: {
+            enabled: true,
+            config: {
+              webSearch: {
+                apiKey: {
+                  source: "env",
+                  provider: "default",
+                  id: "TAVILY_API_KEY",
+                },
+              },
+            },
+          },
+        },
+      },
+      tools: {
+        alsoAllow: ["tavily_search", "tavily_extract"],
+      },
+    }
+    ```
+
+    The prepared run must include agent, conversation, channel, and sender
+    identity. Sender, group, agent, sandbox, and inherited deny policies still
+    win. Handles are single-use, expire after 30 seconds, and do not survive a
+    Gateway restart.
+
+    This broker path applies to the explicit plugin tools. Generic `web_search`,
+    literal config values, and the environment fallback keep their existing
+    client path. OpenClaw never falls back from a configured structured
+    SecretRef to a plaintext value for a brokered operation.
+
+  </Accordion>
+
   <Accordion title="Custom base URL">
-    Override `plugins.entries.tavily.config.webSearch.baseUrl` if you front Tavily through a proxy. The default is `https://api.tavily.com`.
+    Override `plugins.entries.tavily.config.webSearch.baseUrl` if you front Tavily through a proxy. Existing `TAVILY_BASE_URL` deployments remain supported as a fallback. The default is `https://api.tavily.com`.
   </Accordion>
 
   <Accordion title="`chunks_per_source` requires `query`">

--- a/extensions/tavily/openclaw.plugin.json
+++ b/extensions/tavily/openclaw.plugin.json
@@ -15,7 +15,7 @@
   "uiHints": {
     "webSearch.apiKey": {
       "label": "Tavily API Key",
-      "help": "Tavily API key for web search and extraction (fallback: TAVILY_API_KEY env var).",
+      "help": "Tavily API key for web search and extraction. Structured SecretRefs use the scoped broker for explicit Tavily tools; fallback: TAVILY_API_KEY.",
       "sensitive": true,
       "placeholder": "tvly-..."
     },
@@ -28,8 +28,47 @@
     "webSearchProviders": ["tavily"],
     "tools": ["tavily_search", "tavily_extract"]
   },
+  "credentialBroker": {
+    "operations": [
+      {
+        "id": "search",
+        "tool": "tavily_search",
+        "secretInputPath": "webSearch.apiKey",
+        "baseUrlConfigPath": "webSearch.baseUrl",
+        "baseUrlEnv": "TAVILY_BASE_URL",
+        "defaultBaseUrl": "https://api.tavily.com",
+        "path": "/search",
+        "method": "POST",
+        "credentialHeader": "Authorization",
+        "credentialScheme": "Bearer",
+        "headers": { "X-Client-Source": "openclaw" },
+        "maxRequestBodyBytes": 131072,
+        "maxResponseBodyBytes": 16777216,
+        "timeoutMs": 30000
+      },
+      {
+        "id": "extract",
+        "tool": "tavily_extract",
+        "secretInputPath": "webSearch.apiKey",
+        "baseUrlConfigPath": "webSearch.baseUrl",
+        "baseUrlEnv": "TAVILY_BASE_URL",
+        "defaultBaseUrl": "https://api.tavily.com",
+        "path": "/extract",
+        "method": "POST",
+        "credentialHeader": "Authorization",
+        "credentialScheme": "Bearer",
+        "headers": { "X-Client-Source": "openclaw" },
+        "maxRequestBodyBytes": 131072,
+        "maxResponseBodyBytes": 67108864,
+        "timeoutMs": 60000
+      }
+    ]
+  },
   "configContracts": {
-    "compatibilityRuntimePaths": ["tools.web.search.apiKey"]
+    "compatibilityRuntimePaths": ["tools.web.search.apiKey"],
+    "secretInputs": {
+      "paths": [{ "path": "webSearch.apiKey", "expected": "string" }]
+    }
   },
   "configSchema": {
     "type": "object",

--- a/extensions/tavily/src/tavily-client.test.ts
+++ b/extensions/tavily/src/tavily-client.test.ts
@@ -1,15 +1,24 @@
+import type { OpenClawCredentialBroker } from "openclaw/plugin-sdk/plugin-entry";
 // Tavily tests cover tavily client plugin behavior.
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createStreamingResponse } from "../../test-support/streaming-error-response.js";
 
 // Capture every call to postTrustedWebToolsJson so we can assert on extraHeaders.
 const postTrustedWebToolsJson = vi.fn();
+const resolveTavilyApiKey = vi.fn(() => "test-key");
+const readCache = vi.fn<() => { value: Record<string, unknown> } | undefined>(() => undefined);
+const deniedBroker: OpenClawCredentialBroker = {
+  isConfigured: () => true,
+  createRequest: () => {
+    throw new Error("denied by scope");
+  },
+};
 
 vi.mock("openclaw/plugin-sdk/provider-web-search", () => ({
   DEFAULT_CACHE_TTL_MINUTES: 5,
   normalizeCacheKey: (k: string) => k,
   postTrustedWebToolsJson,
-  readCache: () => undefined,
+  readCache,
   resolveCacheTtlMs: () => 300_000,
   writeCache: vi.fn(),
 }));
@@ -21,7 +30,7 @@ vi.mock("openclaw/plugin-sdk/security-runtime", () => ({
 
 vi.mock("./config.js", () => ({
   DEFAULT_TAVILY_BASE_URL: "https://api.tavily.com",
-  resolveTavilyApiKey: () => "test-key",
+  resolveTavilyApiKey,
   resolveTavilyBaseUrl: () => "https://api.tavily.com",
   resolveTavilySearchTimeoutSeconds: () => 30,
   resolveTavilyExtractTimeoutSeconds: () => 60,
@@ -37,6 +46,9 @@ describe("tavily client X-Client-Source header", () => {
 
   beforeEach(() => {
     postTrustedWebToolsJson.mockReset();
+    readCache.mockReset();
+    readCache.mockReturnValue(undefined);
+    resolveTavilyApiKey.mockClear();
     postTrustedWebToolsJson.mockImplementation(
       async (_params: unknown, parse: (r: Response) => Promise<unknown>) =>
         parse(Response.json({ results: [] })),
@@ -44,11 +56,75 @@ describe("tavily client X-Client-Source header", () => {
   });
 
   it("runTavilySearch sends X-Client-Source: openclaw", async () => {
-    await runTavilySearch({ query: "test query" });
+    const signal = new AbortController().signal;
+    await runTavilySearch({ query: "test query", signal });
 
     expect(postTrustedWebToolsJson).toHaveBeenCalledOnce();
     const params = postTrustedWebToolsJson.mock.calls[0]?.[0];
     expect(params.extraHeaders).toEqual({ "X-Client-Source": "openclaw" });
+    expect(params.signal).toBe(signal);
+  });
+
+  it("routes a configured SecretRef operation through the credential broker", async () => {
+    const execute = vi.fn(async () => ({ status: 200, body: { results: [] } }));
+    const credentialBroker: OpenClawCredentialBroker = {
+      isConfigured: (operationId) => operationId === "search",
+      createRequest: vi.fn(({ operationId }: { operationId: string }) => ({
+        id: "opaque-request",
+        operationId,
+        expiresAtMs: 30_000,
+        execute,
+        revoke: vi.fn(),
+        toJSON: () => ({
+          id: "opaque-request",
+          operationId,
+          expiresAtMs: 30_000,
+          state: "pending" as const,
+        }),
+      })),
+    };
+
+    const signal = new AbortController().signal;
+    await runTavilySearch({ query: "test query", credentialBroker, signal });
+
+    expect(credentialBroker.createRequest).toHaveBeenCalledWith({
+      operationId: "search",
+      body: {
+        query: "test query",
+        max_results: 5,
+      },
+    });
+    expect(execute).toHaveBeenCalledWith({ signal });
+    expect(resolveTavilyApiKey).not.toHaveBeenCalled();
+    expect(postTrustedWebToolsJson).not.toHaveBeenCalled();
+  });
+
+  it("does not fall back to resolved plaintext when a SecretRef requires the broker", async () => {
+    await expect(
+      runTavilySearch({ query: "test query", requiresCredentialBroker: true }),
+    ).rejects.toThrow("requires a conversation-scoped credential broker");
+
+    expect(resolveTavilyApiKey).not.toHaveBeenCalled();
+    expect(postTrustedWebToolsJson).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      operationId: "search",
+      run: () => runTavilySearch({ query: "cached", credentialBroker: deniedBroker }),
+    },
+    {
+      operationId: "extract",
+      run: () =>
+        runTavilyExtract({ urls: ["https://example.com/cached"], credentialBroker: deniedBroker }),
+    },
+  ])("authorizes brokered $operationId operations before cache reads", async ({ run }) => {
+    readCache.mockReturnValueOnce({ value: { results: [] } });
+
+    await expect(run()).rejects.toThrow("denied by scope");
+
+    expect(readCache).not.toHaveBeenCalled();
+    expect(postTrustedWebToolsJson).not.toHaveBeenCalled();
   });
 
   it("runTavilySearch reports malformed JSON with a stable provider error", async () => {

--- a/extensions/tavily/src/tavily-client.ts
+++ b/extensions/tavily/src/tavily-client.ts
@@ -1,5 +1,9 @@
 // Tavily plugin module implements tavily client behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import type {
+  BrokeredCredentialRequestHandle,
+  OpenClawCredentialBroker,
+} from "openclaw/plugin-sdk/plugin-entry";
 import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import {
   DEFAULT_CACHE_TTL_MINUTES,
@@ -40,6 +44,9 @@ export type TavilySearchParams = {
   includeDomains?: string[];
   excludeDomains?: string[];
   timeoutSeconds?: number;
+  credentialBroker?: OpenClawCredentialBroker;
+  requiresCredentialBroker?: boolean;
+  signal?: AbortSignal;
 };
 
 export type TavilyExtractParams = {
@@ -50,6 +57,9 @@ export type TavilyExtractParams = {
   chunksPerSource?: number;
   includeImages?: boolean;
   timeoutSeconds?: number;
+  credentialBroker?: OpenClawCredentialBroker;
+  requiresCredentialBroker?: boolean;
+  signal?: AbortSignal;
 };
 
 function resolveEndpoint(baseUrl: string, pathname: string): string {
@@ -72,11 +82,23 @@ async function postTavilyJson(params: {
   baseUrl: string;
   pathname: "/extract" | "/search";
   timeoutSeconds: number;
-  apiKey: string;
+  apiKey?: string;
+  credentialRequest?: BrokeredCredentialRequestHandle;
+  signal?: AbortSignal;
   body: Record<string, unknown>;
   errorLabel: string;
   responseMaxBytes?: number;
 }): Promise<Record<string, unknown>> {
+  if (params.credentialRequest) {
+    const result = await params.credentialRequest.execute({ signal: params.signal });
+    if (!result.body || typeof result.body !== "object" || Array.isArray(result.body)) {
+      throw new Error(`${params.errorLabel}: malformed JSON response`);
+    }
+    return result.body as Record<string, unknown>;
+  }
+  if (!params.apiKey) {
+    throw new Error(`${params.errorLabel}: missing API key`);
+  }
   return postTrustedWebToolsJson(
     {
       url: resolveEndpoint(params.baseUrl, params.pathname),
@@ -85,6 +107,7 @@ async function postTavilyJson(params: {
       body: params.body,
       errorLabel: params.errorLabel,
       extraHeaders: { "X-Client-Source": "openclaw" },
+      signal: params.signal,
     },
     async (response) =>
       readTavilyJsonResponse(response, params.errorLabel, {
@@ -104,8 +127,12 @@ async function readTavilyJsonResponse(
 export async function runTavilySearch(
   params: TavilySearchParams,
 ): Promise<Record<string, unknown>> {
-  const apiKey = resolveTavilyApiKey(params.cfg);
-  if (!apiKey) {
+  const usesCredentialBroker = params.credentialBroker?.isConfigured("search") === true;
+  if (params.requiresCredentialBroker && !usesCredentialBroker) {
+    throw new Error("web_search (tavily) requires a conversation-scoped credential broker.");
+  }
+  const apiKey = usesCredentialBroker ? undefined : resolveTavilyApiKey(params.cfg);
+  if (!usesCredentialBroker && !apiKey) {
     throw new Error(
       "web_search (tavily) needs a Tavily API key. Set TAVILY_API_KEY in the Gateway environment, or configure plugins.entries.tavily.config.webSearch.apiKey.",
     );
@@ -116,25 +143,6 @@ export async function runTavilySearch(
       : DEFAULT_SEARCH_COUNT;
   const timeoutSeconds = resolveTavilySearchTimeoutSeconds(params.timeoutSeconds);
   const baseUrl = resolveTavilyBaseUrl(params.cfg);
-
-  const cacheKey = normalizeCacheKey(
-    JSON.stringify({
-      type: "tavily-search",
-      q: params.query,
-      count,
-      baseUrl,
-      searchDepth: params.searchDepth,
-      topic: params.topic,
-      includeAnswer: params.includeAnswer,
-      timeRange: params.timeRange,
-      includeDomains: params.includeDomains,
-      excludeDomains: params.excludeDomains,
-    }),
-  );
-  const cached = readCache(SEARCH_CACHE, cacheKey);
-  if (cached) {
-    return { ...cached.value, cached: true };
-  }
 
   const body: Record<string, unknown> = {
     query: params.query,
@@ -158,6 +166,29 @@ export async function runTavilySearch(
   if (params.excludeDomains?.length) {
     body.exclude_domains = params.excludeDomains;
   }
+  const credentialRequest = usesCredentialBroker
+    ? params.credentialBroker!.createRequest({ operationId: "search", body })
+    : undefined;
+
+  const cacheKey = normalizeCacheKey(
+    JSON.stringify({
+      type: "tavily-search",
+      q: params.query,
+      count,
+      baseUrl,
+      searchDepth: params.searchDepth,
+      topic: params.topic,
+      includeAnswer: params.includeAnswer,
+      timeRange: params.timeRange,
+      includeDomains: params.includeDomains,
+      excludeDomains: params.excludeDomains,
+    }),
+  );
+  const cached = readCache(SEARCH_CACHE, cacheKey);
+  if (cached) {
+    credentialRequest?.revoke();
+    return { ...cached.value, cached: true };
+  }
 
   const start = Date.now();
   const payload = await postTavilyJson({
@@ -167,6 +198,8 @@ export async function runTavilySearch(
     apiKey,
     body,
     errorLabel: "Tavily Search",
+    credentialRequest,
+    signal: params.signal,
   });
 
   const rawResults = Array.isArray(payload.results) ? payload.results : [];
@@ -211,30 +244,18 @@ export async function runTavilySearch(
 export async function runTavilyExtract(
   params: TavilyExtractParams,
 ): Promise<Record<string, unknown>> {
-  const apiKey = resolveTavilyApiKey(params.cfg);
-  if (!apiKey) {
+  const usesCredentialBroker = params.credentialBroker?.isConfigured("extract") === true;
+  if (params.requiresCredentialBroker && !usesCredentialBroker) {
+    throw new Error("tavily_extract requires a conversation-scoped credential broker.");
+  }
+  const apiKey = usesCredentialBroker ? undefined : resolveTavilyApiKey(params.cfg);
+  if (!usesCredentialBroker && !apiKey) {
     throw new Error(
       "tavily_extract needs a Tavily API key. Set TAVILY_API_KEY in the Gateway environment, or configure plugins.entries.tavily.config.webSearch.apiKey.",
     );
   }
   const baseUrl = resolveTavilyBaseUrl(params.cfg);
   const timeoutSeconds = resolveTavilyExtractTimeoutSeconds(params.timeoutSeconds);
-
-  const cacheKey = normalizeCacheKey(
-    JSON.stringify({
-      type: "tavily-extract",
-      urls: params.urls,
-      baseUrl,
-      query: params.query,
-      extractDepth: params.extractDepth,
-      chunksPerSource: params.chunksPerSource,
-      includeImages: params.includeImages,
-    }),
-  );
-  const cached = readCache(EXTRACT_CACHE, cacheKey);
-  if (cached) {
-    return { ...cached.value, cached: true };
-  }
 
   const body: Record<string, unknown> = { urls: params.urls };
   if (params.query) {
@@ -249,6 +270,26 @@ export async function runTavilyExtract(
   if (params.includeImages) {
     body.include_images = true;
   }
+  const credentialRequest = usesCredentialBroker
+    ? params.credentialBroker!.createRequest({ operationId: "extract", body })
+    : undefined;
+
+  const cacheKey = normalizeCacheKey(
+    JSON.stringify({
+      type: "tavily-extract",
+      urls: params.urls,
+      baseUrl,
+      query: params.query,
+      extractDepth: params.extractDepth,
+      chunksPerSource: params.chunksPerSource,
+      includeImages: params.includeImages,
+    }),
+  );
+  const cached = readCache(EXTRACT_CACHE, cacheKey);
+  if (cached) {
+    credentialRequest?.revoke();
+    return { ...cached.value, cached: true };
+  }
 
   const start = Date.now();
   const payload = await postTavilyJson({
@@ -260,6 +301,8 @@ export async function runTavilyExtract(
     errorLabel: "Tavily Extract",
     // Extract can include raw page content and image lists, unlike search metadata.
     responseMaxBytes: TAVILY_EXTRACT_RESPONSE_MAX_BYTES,
+    credentialRequest,
+    signal: params.signal,
   });
 
   const rawResults = Array.isArray(payload.results) ? payload.results : [];

--- a/extensions/tavily/src/tavily-extract-tool.ts
+++ b/extensions/tavily/src/tavily-extract-tool.ts
@@ -7,7 +7,11 @@ import {
 } from "openclaw/plugin-sdk/provider-web-search";
 import { Type } from "typebox";
 import { runTavilyExtract } from "./tavily-client.js";
-import { resolveTavilyToolConfig, type TavilyToolConfigContext } from "./tavily-tool-config.js";
+import {
+  resolveTavilyToolConfig,
+  tavilyToolRequiresCredentialBroker,
+  type TavilyToolConfigContext,
+} from "./tavily-tool-config.js";
 import { optionalStringEnum } from "./tavily-tool-schema.js";
 
 const TavilyExtractToolSchema = Type.Object(
@@ -48,7 +52,11 @@ export function createTavilyExtractTool(api: OpenClawPluginApi, ctx?: TavilyTool
     description:
       "Extract clean content from one or more URLs using Tavily. Handles JS-rendered pages. Supports query-focused chunking.",
     parameters: TavilyExtractToolSchema,
-    execute: async (_toolCallId: string, rawParams: Record<string, unknown>) => {
+    execute: async (
+      _toolCallId: string,
+      rawParams: Record<string, unknown>,
+      signal?: AbortSignal,
+    ) => {
       const urls = Array.isArray(rawParams.urls)
         ? (rawParams.urls as string[]).filter(Boolean)
         : [];
@@ -74,6 +82,9 @@ export function createTavilyExtractTool(api: OpenClawPluginApi, ctx?: TavilyTool
           extractDepth,
           chunksPerSource,
           includeImages,
+          ...(ctx?.credentialBroker ? { credentialBroker: ctx.credentialBroker } : {}),
+          ...(tavilyToolRequiresCredentialBroker(ctx) ? { requiresCredentialBroker: true } : {}),
+          ...(signal ? { signal } : {}),
         }),
       );
     },

--- a/extensions/tavily/src/tavily-search-tool.ts
+++ b/extensions/tavily/src/tavily-search-tool.ts
@@ -7,7 +7,11 @@ import {
 } from "openclaw/plugin-sdk/provider-web-search";
 import { Type } from "typebox";
 import { runTavilySearch } from "./tavily-client.js";
-import { resolveTavilyToolConfig, type TavilyToolConfigContext } from "./tavily-tool-config.js";
+import {
+  resolveTavilyToolConfig,
+  tavilyToolRequiresCredentialBroker,
+  type TavilyToolConfigContext,
+} from "./tavily-tool-config.js";
 import { optionalStringEnum } from "./tavily-tool-schema.js";
 
 const TavilySearchToolSchema = Type.Object(
@@ -55,7 +59,11 @@ export function createTavilySearchTool(api: OpenClawPluginApi, ctx?: TavilyToolC
     description:
       "Search the web using Tavily Search API. Supports search depth, topic filtering, domain filters, time ranges, and AI answer summaries.",
     parameters: TavilySearchToolSchema,
-    execute: async (_toolCallId: string, rawParams: Record<string, unknown>) => {
+    execute: async (
+      _toolCallId: string,
+      rawParams: Record<string, unknown>,
+      signal?: AbortSignal,
+    ) => {
       const query = readStringParam(rawParams, "query", { required: true });
       const searchDepth = readStringParam(rawParams, "search_depth") || undefined;
       const topic = readStringParam(rawParams, "topic") || undefined;
@@ -83,6 +91,9 @@ export function createTavilySearchTool(api: OpenClawPluginApi, ctx?: TavilyToolC
           timeRange,
           includeDomains: includeDomains?.length ? includeDomains : undefined,
           excludeDomains: excludeDomains?.length ? excludeDomains : undefined,
+          ...(ctx?.credentialBroker ? { credentialBroker: ctx.credentialBroker } : {}),
+          ...(tavilyToolRequiresCredentialBroker(ctx) ? { requiresCredentialBroker: true } : {}),
+          ...(signal ? { signal } : {}),
         }),
       );
     },

--- a/extensions/tavily/src/tavily-tool-config.ts
+++ b/extensions/tavily/src/tavily-tool-config.ts
@@ -2,10 +2,12 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { OpenClawPluginToolContext } from "openclaw/plugin-sdk/plugin-entry";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-runtime";
+import { isSecretRef } from "openclaw/plugin-sdk/secret-input";
+import { resolveTavilySearchConfig } from "./config.js";
 
 export type TavilyToolConfigContext = Pick<
   OpenClawPluginToolContext,
-  "config" | "runtimeConfig" | "getRuntimeConfig"
+  "config" | "runtimeConfig" | "getRuntimeConfig" | "credentialBroker"
 >;
 
 export function resolveTavilyToolConfig(
@@ -13,4 +15,8 @@ export function resolveTavilyToolConfig(
   ctx?: TavilyToolConfigContext,
 ): OpenClawConfig {
   return ctx?.getRuntimeConfig?.() ?? ctx?.runtimeConfig ?? ctx?.config ?? api.config;
+}
+
+export function tavilyToolRequiresCredentialBroker(ctx?: TavilyToolConfigContext): boolean {
+  return isSecretRef(resolveTavilySearchConfig(ctx?.config)?.apiKey);
 }

--- a/extensions/tavily/src/tavily-tools.test.ts
+++ b/extensions/tavily/src/tavily-tools.test.ts
@@ -24,6 +24,7 @@ type TavilyExtractParams = {
   urls?: string[];
   query?: string;
   chunksPerSource?: number;
+  requiresCredentialBroker?: boolean;
 };
 
 vi.mock("./tavily-client.js", () => ({
@@ -288,12 +289,14 @@ describe("tavily tools", () => {
     >;
     expect(searchParams.cfg).toBe(runtimeConfig);
     expect(searchParams.query).toBe("openclaw");
+    expect(searchParams.requiresCredentialBroker).toBe(true);
     const extractParams = requireFirstMockArg(
       runTavilyExtract,
       "Tavily extract params",
     ) as TavilyExtractParams;
     expect(extractParams.cfg).toBe(runtimeConfig);
     expect(extractParams.urls).toEqual(["https://example.com"]);
+    expect(extractParams.requiresCredentialBroker).toBe(true);
   });
 
   it("drops empty domain arrays and forwards query-scoped chunking", async () => {

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -924,6 +924,7 @@ export function createOpenClawCodingTools(options?: {
             requesterAgentIdOverride: agentId,
             allowGatewaySubagentBinding: options?.allowGatewaySubagentBinding,
             authProfileStore: options?.authProfileStore,
+            conversationCapabilityProfile: capabilityProfile,
           },
           resolvedConfig: options?.config,
         });
@@ -1022,6 +1023,7 @@ export function createOpenClawCodingTools(options?: {
           requesterSenderId: options?.senderId,
           senderIsOwner: options?.senderIsOwner,
           authProfileStore: options?.authProfileStore,
+          conversationCapabilityProfile: capabilityProfile,
           sessionId: options?.sessionId,
           oneShotCliRun: options?.oneShotCliRun,
           inheritedToolAllowlist,

--- a/src/agents/local-model-lean.test.ts
+++ b/src/agents/local-model-lean.test.ts
@@ -2,8 +2,13 @@
  * Regression coverage for local-model lean tool filtering.
  * Verifies agent scope, default flags, preserve lists, and message-tool overrides.
  */
-import { describe, expect, it } from "vitest";
-import type { OpenClawConfig } from "../config/config.js";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  resetConfigRuntimeState,
+  setRuntimeConfigSnapshot,
+  type OpenClawConfig,
+} from "../config/config.js";
+import { getRuntimeConfigSourcePair } from "../config/runtime-snapshot.js";
 import type { AnyAgentTool } from "./agent-tools.types.js";
 import {
   applyLocalModelLeanToolSearchDefaults,
@@ -17,6 +22,10 @@ function tools(names: string[]): AnyAgentTool[] {
 }
 
 describe("local model lean tool filtering", () => {
+  afterEach(() => {
+    resetConfigRuntimeState();
+  });
+
   it("filters heavyweight tools for one configured agent", () => {
     const cfg: OpenClawConfig = {
       agents: {
@@ -252,6 +261,30 @@ describe("local model lean tool filtering", () => {
       maxSearchLimit: 10,
     });
     expect(cfg.tools?.toolSearch).toBeUndefined();
+  });
+
+  it("retains explicit SecretRef provenance when deriving lean config", () => {
+    const secretRef = { source: "env", provider: "default", id: "LEAN_BROKER_TOKEN" } as const;
+    const sourceConfig = {
+      agents: { defaults: { experimental: { localModelLean: true } } },
+      plugins: {
+        entries: { brokered: { config: { service: { token: secretRef } } } },
+      },
+    } as OpenClawConfig;
+    const runtimeConfig = structuredClone(sourceConfig);
+    const runtimePluginConfig = runtimeConfig.plugins?.entries?.brokered?.config as {
+      service: { token: unknown };
+    };
+    runtimePluginConfig.service.token = "resolved-lean-credential";
+    setRuntimeConfigSnapshot(runtimeConfig, sourceConfig);
+
+    const resolved = applyLocalModelLeanToolSearchDefaults({
+      config: runtimeConfig,
+      agentId: "main",
+    });
+
+    expect(resolved).not.toBe(runtimeConfig);
+    expect(getRuntimeConfigSourcePair(resolved!)).toMatchObject(sourceConfig);
   });
 
   it("preserves explicit Tool Search operator config", () => {

--- a/src/agents/local-model-lean.ts
+++ b/src/agents/local-model-lean.ts
@@ -3,6 +3,7 @@
  * Removes high-latency or channel-dependent tools for local models while
  * preserving explicitly required delivery tools.
  */
+import { applyMergePatchToPairedRuntimeConfig } from "../config/runtime-source-projection.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
 import { resolveAgentConfig, resolveDefaultAgentId } from "./agent-scope-config.js";
@@ -109,11 +110,8 @@ export function applyLocalModelLeanToolSearchDefaults(params: {
   if (params.config.tools?.toolSearch !== undefined) {
     return params.config;
   }
-  return {
-    ...params.config,
-    tools: {
-      ...params.config.tools,
-      toolSearch: LOCAL_MODEL_LEAN_TOOL_SEARCH_DEFAULTS,
-    },
-  };
+  return applyMergePatchToPairedRuntimeConfig({
+    runtimeConfig: params.config,
+    patch: { tools: { toolSearch: LOCAL_MODEL_LEAN_TOOL_SEARCH_DEFAULTS } },
+  });
 }

--- a/src/agents/openclaw-plugin-tools.ts
+++ b/src/agents/openclaw-plugin-tools.ts
@@ -6,10 +6,12 @@
  */
 import { selectApplicableRuntimeConfig } from "../config/config.js";
 import {
+  getRuntimeConfigSourcePair,
   getRuntimeConfigSnapshot,
   getRuntimeConfigSourceSnapshot,
 } from "../config/runtime-snapshot.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { hasPreparedCredentialBrokerScope } from "../plugins/credential-broker.js";
 import { resolvePluginTools } from "../plugins/tools.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.js";
 import { resolveApiKeyForProfile, resolveAuthProfileOrder } from "./auth-profiles.js";
@@ -92,6 +94,22 @@ export function resolveOpenClawPluginToolsForOptions(params: {
           provider: providerId,
         })
     : undefined;
+  const credentialBrokerRuntimeConfig = resolveCurrentRuntimeConfig();
+  const pairedCredentialBrokerSourceConfig = credentialBrokerRuntimeConfig
+    ? getRuntimeConfigSourcePair(credentialBrokerRuntimeConfig)
+    : undefined;
+  // A process-global source snapshot is credential metadata only for its paired runtime.
+  // Unrelated explicit configs keep their own literal/env semantics.
+  const credentialBrokerSourceConfig =
+    pairedCredentialBrokerSourceConfig ?? credentialBrokerRuntimeConfig;
+  const pairedCredentialBrokerRuntimeConfig = pairedCredentialBrokerSourceConfig
+    ? credentialBrokerRuntimeConfig
+    : undefined;
+  const conversationCapabilityProfile = params.options?.conversationCapabilityProfile;
+  const hasPreparedBrokerScope = Boolean(
+    conversationCapabilityProfile &&
+    hasPreparedCredentialBrokerScope(conversationCapabilityProfile),
+  );
   const hasAuthForProvider = authProfileStore
     ? (providerId: string) => (resolveAuthProfileIdsForProvider?.(providerId) ?? []).length > 0
     : undefined;
@@ -129,6 +147,19 @@ export function resolveOpenClawPluginToolsForOptions(params: {
     toolDenylist: params.options?.pluginToolDenylist,
     allowGatewaySubagentBinding: params.options?.allowGatewaySubagentBinding,
     ...(hasAuthForProvider ? { hasAuthForProvider } : {}),
+    ...(credentialBrokerSourceConfig ? { credentialBrokerSourceConfig } : {}),
+    ...(hasPreparedBrokerScope && conversationCapabilityProfile && credentialBrokerSourceConfig
+      ? {
+          credentialBrokerContext: {
+            profile: conversationCapabilityProfile,
+            sourceConfig: credentialBrokerSourceConfig,
+            ...(pairedCredentialBrokerRuntimeConfig
+              ? { runtimeConfig: pairedCredentialBrokerRuntimeConfig }
+              : {}),
+          },
+        }
+      : {}),
+    omitCredentialBrokerToolsWithoutContext: true,
   });
 
   return applyPluginToolDeliveryDefaults({

--- a/src/agents/openclaw-tools.browser-plugin.integration.test.ts
+++ b/src/agents/openclaw-tools.browser-plugin.integration.test.ts
@@ -1,15 +1,28 @@
 // Verifies OpenClaw plugin tools are resolved with browser/runtime context.
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { OpenClawConfig } from "../config/config.js";
-import { resetConfigRuntimeState, setRuntimeConfigSnapshot } from "../config/config.js";
+import {
+  applyMergePatchToPairedRuntimeConfig,
+  resetConfigRuntimeState,
+  setRuntimeConfigSnapshot,
+  type OpenClawConfig,
+} from "../config/config.js";
 import { activateSecretsRuntimeSnapshot, clearSecretsRuntimeSnapshot } from "../secrets/runtime.js";
 import { resolveOpenClawPluginToolsForOptions } from "./openclaw-plugin-tools.js";
+import { createOpenClawTools } from "./openclaw-tools.js";
 
 const hoisted = vi.hoisted(() => ({
   resolvePluginTools: vi.fn(),
 }));
 
+const BROKER_CAPABILITY_PROFILE = {
+  serviceIdentity: { agentId: "main" },
+  conversation: { sessionKey: "agent:main:discord:direct:alice", messageChannel: "discord" },
+  sender: { id: "alice" },
+};
+
 vi.mock("../plugins/tools.js", () => ({
+  copyPluginToolMeta: vi.fn(),
+  getPluginToolMeta: vi.fn(),
   resolvePluginTools: (...args: unknown[]) => hoisted.resolvePluginTools(...args),
 }));
 
@@ -277,6 +290,237 @@ describe("createOpenClawTools browser plugin integration", () => {
     });
 
     expect(capturedRuntimeConfig).toBe(resolvedRunConfig);
+  });
+
+  it("pairs scoped resolved config with its authored SecretRef for the credential broker", () => {
+    const secretRef = { source: "env", provider: "default", id: "TAVILY_API_KEY" } as const;
+    const sourceConfig = {
+      plugins: {
+        entries: { tavily: { config: { webSearch: { apiKey: secretRef } } } },
+      },
+      tools: { alsoAllow: ["tavily_search"] },
+    } as OpenClawConfig;
+    const runtimeConfig = {
+      plugins: {
+        entries: { tavily: { config: { webSearch: { apiKey: "resolved-value" } } } },
+      },
+      tools: { alsoAllow: ["tavily_search"] },
+    } as OpenClawConfig;
+    setRuntimeConfigSnapshot(runtimeConfig, sourceConfig);
+    const scopedRuntimeConfig = applyMergePatchToPairedRuntimeConfig({
+      runtimeConfig,
+      patch: { tools: { alsoAllow: ["tavily_search", "tavily_extract"] } },
+    });
+
+    resolveOpenClawPluginToolsForOptions({
+      options: {
+        config: scopedRuntimeConfig,
+        conversationCapabilityProfile: BROKER_CAPABILITY_PROFILE as never,
+      },
+      resolvedConfig: scopedRuntimeConfig,
+    });
+
+    const brokerContext = firstResolvePluginToolsParams().credentialBrokerContext as {
+      sourceConfig: OpenClawConfig;
+      runtimeConfig: OpenClawConfig;
+    };
+    expect(
+      (
+        brokerContext.sourceConfig.plugins?.entries?.tavily?.config as {
+          webSearch?: { apiKey?: unknown };
+        }
+      ).webSearch?.apiKey,
+    ).toEqual(secretRef);
+    expect(
+      (
+        brokerContext.runtimeConfig.plugins?.entries?.tavily?.config as {
+          webSearch?: { apiKey?: unknown };
+        }
+      ).webSearch?.apiKey,
+    ).toBe("resolved-value");
+    expect(brokerContext.sourceConfig.tools?.alsoAllow).toEqual([
+      "tavily_search",
+      "tavily_extract",
+    ]);
+  });
+
+  it("retains a prepared config's SecretRef pairing across a runtime snapshot refresh", () => {
+    const firstSecretRef = {
+      source: "env",
+      provider: "default",
+      id: "FIRST_TAVILY_API_KEY",
+    } as const;
+    const firstSourceConfig = {
+      plugins: {
+        entries: { tavily: { config: { webSearch: { apiKey: firstSecretRef } } } },
+      },
+    } as OpenClawConfig;
+    const firstRuntimeConfig = {
+      plugins: {
+        entries: { tavily: { config: { webSearch: { apiKey: "first-resolved-value" } } } },
+      },
+    } as OpenClawConfig;
+    setRuntimeConfigSnapshot(firstRuntimeConfig, firstSourceConfig);
+
+    const nextSourceConfig = {
+      plugins: {
+        entries: {
+          tavily: {
+            config: {
+              webSearch: {
+                apiKey: { source: "env", provider: "default", id: "NEXT_TAVILY_API_KEY" },
+              },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const nextRuntimeConfig = {
+      plugins: {
+        entries: { tavily: { config: { webSearch: { apiKey: "next-resolved-value" } } } },
+      },
+    } as OpenClawConfig;
+    setRuntimeConfigSnapshot(nextRuntimeConfig, nextSourceConfig);
+
+    resolveOpenClawPluginToolsForOptions({
+      options: {
+        config: firstRuntimeConfig,
+        conversationCapabilityProfile: BROKER_CAPABILITY_PROFILE as never,
+      },
+      resolvedConfig: firstRuntimeConfig,
+    });
+
+    const brokerContext = firstResolvePluginToolsParams().credentialBrokerContext as {
+      sourceConfig: OpenClawConfig;
+      runtimeConfig: OpenClawConfig;
+    };
+    expect(
+      (
+        brokerContext.sourceConfig.plugins?.entries?.tavily?.config as {
+          webSearch?: { apiKey?: unknown };
+        }
+      ).webSearch?.apiKey,
+    ).toEqual(firstSecretRef);
+    expect(brokerContext.runtimeConfig).toBe(firstRuntimeConfig);
+  });
+
+  it("does not associate an unrelated literal config with the active SecretRef snapshot", () => {
+    const secretRef = { source: "env", provider: "default", id: "TAVILY_API_KEY" } as const;
+    const sourceConfig = {
+      plugins: {
+        entries: { tavily: { config: { webSearch: { apiKey: secretRef } } } },
+      },
+    } as OpenClawConfig;
+    const runtimeConfig = {
+      plugins: {
+        entries: { tavily: { config: { webSearch: { apiKey: "active-resolved-value" } } } },
+      },
+    } as OpenClawConfig;
+    const explicitConfig = {
+      plugins: {
+        entries: { tavily: { config: { webSearch: { apiKey: "explicit-literal-value" } } } },
+      },
+    } as OpenClawConfig;
+    setRuntimeConfigSnapshot(runtimeConfig, sourceConfig);
+
+    resolveOpenClawPluginToolsForOptions({
+      options: {
+        config: explicitConfig,
+        conversationCapabilityProfile: BROKER_CAPABILITY_PROFILE as never,
+      },
+      resolvedConfig: explicitConfig,
+    });
+
+    const brokerContext = firstResolvePluginToolsParams().credentialBrokerContext as {
+      sourceConfig: OpenClawConfig;
+      runtimeConfig?: OpenClawConfig;
+    };
+    expect(brokerContext.runtimeConfig).toBeUndefined();
+    expect(
+      (
+        brokerContext.sourceConfig.plugins?.entries?.tavily?.config as {
+          webSearch?: { apiKey?: unknown };
+        }
+      ).webSearch?.apiKey,
+    ).toBe("explicit-literal-value");
+  });
+
+  it("omits brokered tools when the prepared profile lacks sender scope", () => {
+    const secretRef = { source: "env", provider: "default", id: "TAVILY_API_KEY" } as const;
+    const sourceConfig = {
+      plugins: {
+        entries: { tavily: { config: { webSearch: { apiKey: secretRef } } } },
+      },
+    } as OpenClawConfig;
+    const runtimeConfig = {
+      plugins: {
+        entries: { tavily: { config: { webSearch: { apiKey: "resolved-value" } } } },
+      },
+    } as OpenClawConfig;
+    setRuntimeConfigSnapshot(runtimeConfig, sourceConfig);
+
+    resolveOpenClawPluginToolsForOptions({
+      options: {
+        config: runtimeConfig,
+        conversationCapabilityProfile: {
+          ...BROKER_CAPABILITY_PROFILE,
+          sender: {},
+        } as never,
+      },
+      resolvedConfig: runtimeConfig,
+    });
+
+    const params = firstResolvePluginToolsParams();
+    expect(params.credentialBrokerContext).toBeUndefined();
+    expect(params.omitCredentialBrokerToolsWithoutContext).toBe(true);
+  });
+
+  it("prepares a fail-closed capability profile for direct tool assembly", () => {
+    hoisted.resolvePluginTools.mockReturnValue([]);
+    const secretRef = { source: "env", provider: "default", id: "TAVILY_API_KEY" } as const;
+    const sourceConfig = {
+      plugins: {
+        entries: { tavily: { config: { webSearch: { apiKey: secretRef } } } },
+      },
+      tools: { alsoAllow: ["tavily_search"] },
+    } as OpenClawConfig;
+    const runtimeConfig = {
+      plugins: {
+        entries: { tavily: { config: { webSearch: { apiKey: "resolved-value" } } } },
+      },
+      tools: { alsoAllow: ["tavily_search"] },
+    } as OpenClawConfig;
+    setRuntimeConfigSnapshot(runtimeConfig, sourceConfig);
+
+    createOpenClawTools({
+      config: runtimeConfig,
+      agentSessionKey: "agent:main:discord:direct:alice",
+      agentChannel: "discord",
+      requesterAgentIdOverride: "main",
+      requesterSenderId: "alice",
+      pluginToolAllowlist: ["tavily_search"],
+      wrapBeforeToolCallHook: false,
+    });
+
+    const brokerContext = firstResolvePluginToolsParams().credentialBrokerContext as {
+      profile: {
+        conversation: { sessionKey?: string; messageChannel?: string };
+        sender: { id?: string | null };
+      };
+      sourceConfig: OpenClawConfig;
+    };
+    expect(brokerContext.profile.conversation).toMatchObject({
+      sessionKey: "agent:main:discord:direct:alice",
+      messageChannel: "discord",
+    });
+    expect(brokerContext.profile.sender.id).toBe("alice");
+    expect(
+      (
+        brokerContext.sourceConfig.plugins?.entries?.tavily?.config as {
+          webSearch?: { apiKey?: unknown };
+        }
+      ).webSearch?.apiKey,
+    ).toEqual(secretRef);
   });
 
   it("does not let a source-less pinned config snapshot override explicit plugin tool config", () => {

--- a/src/agents/openclaw-tools.plugin-context.ts
+++ b/src/agents/openclaw-tools.plugin-context.ts
@@ -7,6 +7,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.js";
 import type { GatewayMessageChannel } from "../utils/message-channel.js";
 import { resolveAgentWorkspaceDir, resolveSessionAgentIds } from "./agent-scope.js";
+import type { ResolvedConversationCapabilityProfile } from "./conversation-capability-profile.js";
 import { modelKey } from "./model-ref-shared.js";
 import type { ToolFsPolicy } from "./tool-fs-policy.js";
 import { resolveWorkspaceRoot } from "./workspace-dir.js";
@@ -28,6 +29,8 @@ export type OpenClawPluginToolOptions = {
   senderIsOwner?: boolean;
   requesterAgentIdOverride?: string;
   sessionId?: string;
+  /** Prepared conversation-scoped facts used by host-owned security boundaries. */
+  conversationCapabilityProfile?: ResolvedConversationCapabilityProfile;
   /**
    * Explicit one-shot local CLI runs should not keep plugin-owned process
    * resources alive after emitting their result.

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -23,6 +23,10 @@ import {
   wrapToolWithBeforeToolCallHook,
 } from "./agent-tools.before-tool-call.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
+import {
+  resolveConversationCapabilityProfile,
+  type ResolvedConversationCapabilityProfile,
+} from "./conversation-capability-profile.js";
 import { resolveOpenClawPluginToolsForOptions } from "./openclaw-plugin-tools.js";
 import {
   isToolExplicitlyAllowedByFactoryPolicy,
@@ -169,6 +173,8 @@ export function createOpenClawTools(
     authProfileStore?: AuthProfileStore;
     /** Ephemeral session UUID — regenerated on /new and /reset. */
     sessionId?: string;
+    /** Prepared conversation-scoped facts for host-owned security boundaries. */
+    conversationCapabilityProfile?: ResolvedConversationCapabilityProfile;
     /**
      * Explicit one-shot local CLI runs should not keep plugin-owned process
      * resources alive after emitting their result.
@@ -209,6 +215,38 @@ export function createOpenClawTools(
   const spawnWorkspaceDir = resolveWorkspaceRoot(
     options?.spawnWorkspaceDir ?? options?.workspaceDir ?? inferredWorkspaceDir,
   );
+  const conversationCapabilityProfile =
+    options?.conversationCapabilityProfile ??
+    resolveConversationCapabilityProfile({
+      config: resolvedConfig,
+      sessionKey: options?.agentSessionKey,
+      runSessionKey: options?.runSessionKey,
+      sessionId: options?.sessionId,
+      runId: options?.runId,
+      agentId: options?.requesterAgentIdOverride ?? sessionAgentId,
+      agentDir: options?.agentDir,
+      agentAccountId: options?.agentAccountId,
+      messageProvider: options?.agentChannel,
+      messageChannel: options?.agentChannel,
+      messageTo: options?.agentTo,
+      messageThreadId: options?.agentThreadId,
+      currentChannelId: options?.currentChannelId,
+      currentMessagingTarget: options?.currentMessagingTarget,
+      currentThreadTs: options?.currentThreadTs,
+      currentMessageId: options?.currentMessageId,
+      groupId: options?.agentGroupId,
+      groupChannel: options?.agentGroupChannel,
+      groupSpace: options?.agentGroupSpace,
+      memberRoleIds: options?.agentMemberRoleIds,
+      senderId: options?.requesterSenderId,
+      senderIsOwner: options?.senderIsOwner,
+      modelProvider: options?.modelProvider,
+      modelId: options?.modelId,
+      modelHasVision: options?.modelHasVision,
+      workspaceDir,
+      spawnWorkspaceDir,
+      runtimeToolAllowlist: options?.pluginToolAllowlist,
+    });
   options?.recordToolPrepStage?.("openclaw-tools:session-workspace");
   const deliveryContext = normalizeDeliveryContext({
     channel: options?.agentChannel,
@@ -569,7 +607,7 @@ export function createOpenClawTools(
     allTools = [
       ...tools,
       ...resolveOpenClawPluginToolsForOptions({
-        options,
+        options: { ...options, conversationCapabilityProfile },
         resolvedConfig,
         existingToolNames,
       }),

--- a/src/auto-reply/reply/agent-runner-utils.secret-resolution.test.ts
+++ b/src/auto-reply/reply/agent-runner-utils.secret-resolution.test.ts
@@ -22,6 +22,7 @@ const { resolveQueuedReplyExecutionConfig, resolveQueuedReplyRuntimeConfig } =
   await import("./agent-runner-utils.js");
 const { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } =
   await import("../../config/config.js");
+const { getRuntimeConfigSourcePair } = await import("../../config/runtime-snapshot.js");
 
 type ResolveCommandSecretRefsCall = {
   config: OpenClawConfig;
@@ -63,8 +64,10 @@ describe("resolveQueuedReplyExecutionConfig channel scope", () => {
 
   it("resolves base runtime targets, then active channel/account targets from originating context", async () => {
     const sourceConfig = { source: true } as unknown as OpenClawConfig;
+    const runtimeConfig = { runtime: true } as unknown as OpenClawConfig;
     const baseResolved = { baseResolved: true } as unknown as OpenClawConfig;
     const scopedResolved = { scopedResolved: true } as unknown as OpenClawConfig;
+    setRuntimeConfigSnapshot(runtimeConfig, sourceConfig);
     hoisted.resolveCommandSecretRefsViaGatewayMock
       .mockResolvedValueOnce({
         resolvedConfig: baseResolved,
@@ -89,7 +92,7 @@ describe("resolveQueuedReplyExecutionConfig channel scope", () => {
     expect(resolved).toBe(scopedResolved);
     expect(hoisted.resolveCommandSecretRefsViaGatewayMock).toHaveBeenCalledTimes(2);
     const baseCall = resolveCommandSecretRefsCall();
-    expect(baseCall.config).toBe(sourceConfig);
+    expect(baseCall.config).toBe(runtimeConfig);
     expect(baseCall.commandName).toBe("reply");
     expect(baseCall.targetIds).toEqual(new Set(["skills.entries.*.apiKey"]));
     expect(hoisted.getScopedChannelsCommandSecretTargetsMock).toHaveBeenCalledWith({
@@ -104,6 +107,8 @@ describe("resolveQueuedReplyExecutionConfig channel scope", () => {
     expect(scopedCall.allowedPaths).toEqual(
       new Set(["channels.discord.token", "channels.discord.accounts.work.token"]),
     );
+    expect(getRuntimeConfigSourcePair(baseResolved)).toBe(sourceConfig);
+    expect(getRuntimeConfigSourcePair(scopedResolved)).toBe(sourceConfig);
   });
 
   it("falls back to messageProvider and agentAccountId when originating values are missing", async () => {
@@ -119,6 +124,45 @@ describe("resolveQueuedReplyExecutionConfig channel scope", () => {
       channel: "discord",
       accountId: "ops",
     });
+  });
+
+  it("does not bless an unpaired stale runtime credential as authored config", async () => {
+    const sourceConfig = {
+      plugins: {
+        entries: {
+          tavily: {
+            config: {
+              webSearch: {
+                apiKey: { source: "env", provider: "default", id: "CURRENT_TAVILY_API_KEY" },
+              },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const currentRuntimeConfig = {
+      plugins: {
+        entries: { tavily: { config: { webSearch: { apiKey: "current-resolved-value" } } } },
+      },
+    } as OpenClawConfig;
+    const staleRuntimeConfig = {
+      plugins: {
+        entries: { tavily: { config: { webSearch: { apiKey: "stale-resolved-value" } } } },
+      },
+    } as OpenClawConfig;
+    const preparedConfig = structuredClone(staleRuntimeConfig);
+    setRuntimeConfigSnapshot(currentRuntimeConfig, sourceConfig);
+    hoisted.resolveCommandSecretRefsViaGatewayMock.mockResolvedValueOnce({
+      resolvedConfig: preparedConfig,
+      diagnostics: [],
+      targetStatesByPath: {},
+      hadUnresolvedTargets: false,
+    });
+
+    const resolved = await resolveQueuedReplyExecutionConfig(staleRuntimeConfig);
+
+    expect(resolved).toBe(preparedConfig);
+    expect(getRuntimeConfigSourcePair(preparedConfig)).toBeUndefined();
   });
 
   it("skips scoped channel resolution when no active channel can be resolved", async () => {

--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -23,7 +23,12 @@ import {
   selectApplicableRuntimeConfig,
   type OpenClawConfig,
 } from "../../config/config.js";
+import {
+  getRuntimeConfigSourcePair,
+  registerRuntimeConfigSourcePair,
+} from "../../config/runtime-snapshot.js";
 import type { SessionEntry } from "../../config/sessions.js";
+import { hasSecretRefCandidate } from "../../secrets/runtime-secret-scan.js";
 import { isReasoningTagProvider } from "../../utils/provider-utils.js";
 import type { TemplateContext } from "../templating.js";
 import {
@@ -74,12 +79,20 @@ export async function resolveQueuedReplyExecutionConfig(
   },
 ): Promise<OpenClawConfig> {
   const runtimeConfig = resolveQueuedReplyRuntimeConfig(config);
+  const sourceConfig =
+    getRuntimeConfigSourcePair(runtimeConfig) ??
+    (hasSecretRefCandidate(runtimeConfig, undefined) ? runtimeConfig : undefined);
   const { resolvedConfig } = await resolveCommandSecretRefsViaGateway({
     config: runtimeConfig,
     commandName: "reply",
     targetIds: getAgentRuntimeCommandSecretTargetIds(),
   });
   const baseResolvedConfig = resolvedConfig ?? runtimeConfig;
+  // Derived prepared configs must retain their authored SecretRefs across snapshot refreshes.
+  // Otherwise a later tool assembly could mistake resolved credentials for literal plugin config.
+  if (sourceConfig) {
+    registerRuntimeConfigSourcePair(baseResolvedConfig, sourceConfig);
+  }
 
   const scope = resolveMessageSecretScope({
     channel: params?.originatingChannel,
@@ -106,7 +119,11 @@ export async function resolveQueuedReplyExecutionConfig(
     targetIds: scopedTargets.targetIds,
     ...(scopedTargets.allowedPaths ? { allowedPaths: scopedTargets.allowedPaths } : {}),
   });
-  return scopedResolved.resolvedConfig ?? baseResolvedConfig;
+  const scopedResolvedConfig = scopedResolved.resolvedConfig ?? baseResolvedConfig;
+  if (sourceConfig) {
+    registerRuntimeConfigSourcePair(scopedResolvedConfig, sourceConfig);
+  }
+  return scopedResolvedConfig;
 }
 
 /**

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -2,7 +2,12 @@
 import { beforeAll, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import { clearAgentHarnesses, registerAgentHarness } from "../../agents/harness/registry.js";
 import type { ChannelMessagingAdapter } from "../../channels/plugins/types.core.js";
-import type { OpenClawConfig } from "../../config/config.js";
+import {
+  resetConfigRuntimeState,
+  setRuntimeConfigSnapshot,
+  type OpenClawConfig,
+} from "../../config/config.js";
+import { getRuntimeConfigSourcePair } from "../../config/runtime-snapshot.js";
 import {
   clearApprovalNativeRouteStateForTest,
   createApprovalNativeRouteReporter,
@@ -8074,7 +8079,40 @@ describe("dispatchReplyFromConfig", () => {
 
   it("passes the loaded config plus configOverride patch to replyResolver when provided", async () => {
     setNoAbort();
-    const cfg = emptyConfig;
+    const secretRef = { source: "env", provider: "default", id: "TAVILY_API_KEY" } as const;
+    const sourceConfig = {
+      plugins: {
+        entries: { tavily: { config: { webSearch: { apiKey: secretRef } } } },
+      },
+    } as OpenClawConfig;
+    const cfg = {
+      plugins: {
+        entries: { tavily: { config: { webSearch: { apiKey: "resolved-value" } } } },
+      },
+    } as OpenClawConfig;
+    setRuntimeConfigSnapshot(cfg, sourceConfig);
+    setRuntimeConfigSnapshot(
+      {
+        plugins: {
+          entries: {
+            tavily: { config: { webSearch: { apiKey: "next-resolved-value" } } },
+          },
+        },
+      } as OpenClawConfig,
+      {
+        plugins: {
+          entries: {
+            tavily: {
+              config: {
+                webSearch: {
+                  apiKey: { source: "env", provider: "default", id: "NEXT_TAVILY_API_KEY" },
+                },
+              },
+            },
+          },
+        },
+      } as OpenClawConfig,
+    );
     const dispatcher = createDispatcher();
     const ctx = buildTestCtx({ Provider: "msteams", Surface: "msteams" });
 
@@ -8092,17 +8130,28 @@ describe("dispatchReplyFromConfig", () => {
       return { text: "hi" } satisfies ReplyPayload;
     };
 
-    await dispatchReplyFromConfig({
-      ctx,
-      cfg,
-      dispatcher,
-      replyResolver,
-      configOverride: overrideCfg,
-    });
+    try {
+      await dispatchReplyFromConfig({
+        ctx,
+        cfg,
+        dispatcher,
+        replyResolver,
+        configOverride: overrideCfg,
+      });
 
-    expect(receivedCfg).not.toBe(cfg);
-    expect(receivedCfg).not.toBe(overrideCfg);
-    expect(receivedCfg).toEqual(overrideCfg);
+      expect(receivedCfg).not.toBe(cfg);
+      expect(receivedCfg).not.toBe(overrideCfg);
+      expect(receivedCfg).toMatchObject(overrideCfg);
+      expect(
+        (
+          getRuntimeConfigSourcePair(receivedCfg!)?.plugins?.entries?.tavily?.config as {
+            webSearch?: { apiKey?: unknown };
+          }
+        ).webSearch?.apiKey,
+      ).toEqual(secretRef);
+    } finally {
+      resetConfigRuntimeState();
+    }
   });
 
   it("passes the already loaded config to replyResolver when configOverride is not provided", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -43,7 +43,7 @@ import {
 import { normalizeChatType } from "../../channels/chat-type.js";
 import { resolveChannelModelOverride } from "../../channels/model-overrides.js";
 import { shouldSuppressLocalExecApprovalPrompt } from "../../channels/plugins/exec-approval-local.js";
-import { applyMergePatch } from "../../config/merge-patch.js";
+import { applyMergePatchToPairedRuntimeConfig } from "../../config/config.js";
 import { normalizeExplicitSessionKey } from "../../config/sessions/explicit-session-key-normalization.js";
 import { resolveGroupSessionKey } from "../../config/sessions/group.js";
 import {
@@ -3069,9 +3069,13 @@ export async function dispatchReplyFromConfig(
       params.replyResolver ??
       (await traceReplyPhase("reply.load_reply_resolver", () => loadGetReplyFromConfigRuntime()))
         .getReplyFromConfig;
-    const replyConfig = withFullRuntimeReplyConfig(
-      params.configOverride ? (applyMergePatch(cfg, params.configOverride) as OpenClawConfig) : cfg,
-    );
+    const mergedReplyConfig = params.configOverride
+      ? applyMergePatchToPairedRuntimeConfig({
+          runtimeConfig: cfg,
+          patch: params.configOverride,
+        })
+      : cfg;
+    const replyConfig = withFullRuntimeReplyConfig(mergedReplyConfig);
     recordAgentDispatchStarted();
     const replyResult = await runWithDispatchAbortSignal(getDispatchAbortSignal(), () =>
       traceReplyPhase("reply.run_reply_resolver", () =>

--- a/src/auto-reply/reply/get-reply-fast-path.ts
+++ b/src/auto-reply/reply/get-reply-fast-path.ts
@@ -6,7 +6,8 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import { normalizeChatType } from "../../channels/chat-type.js";
 import { normalizeAnyChannelId } from "../../channels/registry.js";
-import { applyMergePatch } from "../../config/merge-patch.js";
+import { getRuntimeConfigSourcePair } from "../../config/runtime-snapshot.js";
+import { applyMergePatchToPairedRuntimeConfig } from "../../config/runtime-source-projection.js";
 import { resolveSessionTranscriptPath, resolveStorePath } from "../../config/sessions/paths.js";
 import { resolveSessionKey } from "../../config/sessions/session-key.js";
 import { loadSessionStore } from "../../config/sessions/store.js";
@@ -117,7 +118,17 @@ export function resolveGetReplyConfig(params: {
   if (isCompleteReplyConfig(configOverride)) {
     return configOverride;
   }
-  return applyMergePatch(params.getRuntimeConfig(), configOverride) as OpenClawConfig;
+  const runtimeConfig = params.getRuntimeConfig();
+  if (
+    configOverride === runtimeConfig ||
+    getRuntimeConfigSourcePair(configOverride) !== undefined
+  ) {
+    return configOverride;
+  }
+  return applyMergePatchToPairedRuntimeConfig({
+    runtimeConfig,
+    patch: configOverride,
+  });
 }
 
 export function shouldUseReplyFastTestBootstrap(params: {

--- a/src/auto-reply/reply/get-reply.config-override.test.ts
+++ b/src/auto-reply/reply/get-reply.config-override.test.ts
@@ -1,6 +1,11 @@
 // Tests get-reply config override handling for a single inbound turn.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { OpenClawConfig } from "../../config/config.js";
+import {
+  resetConfigRuntimeState,
+  setRuntimeConfigSnapshot,
+  type OpenClawConfig,
+} from "../../config/config.js";
+import { getRuntimeConfigSourcePair } from "../../config/runtime-snapshot.js";
 import {
   buildGetReplyCtx,
   createGetReplySessionState,
@@ -39,6 +44,7 @@ describe("getReplyFromConfig configOverride", () => {
 
   afterEach(() => {
     vi.unstubAllEnvs();
+    resetConfigRuntimeState();
   });
 
   it("merges configOverride over fresh getRuntimeConfig()", async () => {
@@ -91,5 +97,59 @@ describe("getReplyFromConfig configOverride", () => {
 
     expect(loadConfigMock).not.toHaveBeenCalled();
     expectResolvedTelegramTimezone(mocks.resolveReplyDirectives);
+  });
+
+  it("preserves a paired full runtime override without reconstructing it", async () => {
+    const secretRef = { source: "env", provider: "default", id: "REPLY_BROKER_TOKEN" } as const;
+    const sourceConfig = {
+      plugins: { entries: { brokered: { config: { service: { token: secretRef } } } } },
+    } as OpenClawConfig;
+    const runtimeConfig = {
+      plugins: {
+        entries: { brokered: { config: { service: { token: "resolved-reply-credential" } } } },
+      },
+    } as OpenClawConfig;
+    setRuntimeConfigSnapshot(runtimeConfig, sourceConfig);
+    vi.mocked(loadConfigMock).mockReturnValue(runtimeConfig);
+
+    await getReplyFromConfig(buildGetReplyCtx(), undefined, runtimeConfig);
+
+    const call = mocks.resolveReplyDirectives.mock.calls[0]?.[0] as
+      | { cfg?: OpenClawConfig }
+      | undefined;
+    expect(call?.cfg).toBe(runtimeConfig);
+    expect(getRuntimeConfigSourcePair(call!.cfg!)).toBe(sourceConfig);
+  });
+
+  it("preserves provenance when merging a partial reply override", async () => {
+    const secretRef = { source: "env", provider: "default", id: "REPLY_BROKER_TOKEN" } as const;
+    const sourceConfig = {
+      agents: { defaults: { userTimezone: "UTC" } },
+      plugins: { entries: { brokered: { config: { service: { token: secretRef } } } } },
+    } as OpenClawConfig;
+    const runtimeConfig = structuredClone(sourceConfig);
+    const runtimePluginConfig = runtimeConfig.plugins?.entries?.brokered?.config as {
+      service: { token: unknown };
+    };
+    runtimePluginConfig.service.token = "resolved-reply-credential";
+    setRuntimeConfigSnapshot(runtimeConfig, sourceConfig);
+    vi.mocked(loadConfigMock).mockReturnValue(runtimeConfig);
+
+    await getReplyFromConfig(buildGetReplyCtx(), undefined, {
+      agents: { defaults: { userTimezone: "America/New_York" } },
+    });
+
+    const call = mocks.resolveReplyDirectives.mock.calls[0]?.[0] as
+      | { cfg?: OpenClawConfig }
+      | undefined;
+    const pairedSource = getRuntimeConfigSourcePair(call!.cfg!);
+    expect(pairedSource?.agents?.defaults?.userTimezone).toBe("America/New_York");
+    expect(
+      (
+        pairedSource?.plugins?.entries?.brokered?.config as {
+          service?: { token?: unknown };
+        }
+      ).service?.token,
+    ).toEqual(secretRef);
   });
 });

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -9,6 +9,7 @@ export {
   getRuntimeConfigSnapshotMetadata,
   getRuntimeConfigSnapshot,
   getRuntimeConfigSourceSnapshot,
+  applyMergePatchToPairedRuntimeConfig,
   projectConfigOntoRuntimeSourceSnapshot,
   loadConfig,
   readBestEffortConfig,

--- a/src/config/io.runtime-snapshot-write.test.ts
+++ b/src/config/io.runtime-snapshot-write.test.ts
@@ -1,11 +1,13 @@
 // Covers runtime snapshot writes produced by config IO.
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  applyMergePatchToPairedRuntimeConfig,
   projectConfigOntoRuntimeSourceSnapshot,
   resetConfigRuntimeState,
   setRuntimeConfigSnapshotRefreshHandler,
   setRuntimeConfigSnapshot,
 } from "./io.js";
+import { getRuntimeConfigSourcePair } from "./runtime-snapshot.js";
 import type { OpenClawConfig } from "./types.js";
 
 function createSourceConfig(): OpenClawConfig {
@@ -82,5 +84,106 @@ describe("runtime config snapshot writes", () => {
     setRuntimeConfigSnapshot(runtimeConfig, sourceConfig);
     const projected = projectConfigOntoRuntimeSourceSnapshot(independentConfig);
     expect(projected).toBe(independentConfig);
+  });
+
+  it("does not pair a same-shape literal config with the active SecretRef source", () => {
+    const sourceConfig = createSourceConfig();
+    const runtimeConfig = createRuntimeConfig();
+    const independentConfig = createRuntimeConfig();
+
+    setRuntimeConfigSnapshot(runtimeConfig, sourceConfig);
+
+    expect(projectConfigOntoRuntimeSourceSnapshot(independentConfig)).toBe(independentConfig);
+    expect(getRuntimeConfigSourcePair(independentConfig)).toBeUndefined();
+  });
+
+  it("pairs a known scoped merge but rejects changed SecretRef values", () => {
+    const sourceConfig = createSourceConfig();
+    const runtimeConfig = createRuntimeConfig();
+    setRuntimeConfigSnapshot(runtimeConfig, sourceConfig);
+
+    const scopedConfig = applyMergePatchToPairedRuntimeConfig({
+      runtimeConfig,
+      patch: { tools: { alsoAllow: ["brokered_action"] } },
+    });
+    expect(scopedConfig).toEqual({
+      ...runtimeConfig,
+      tools: { alsoAllow: ["brokered_action"] },
+    });
+    expect(getRuntimeConfigSourcePair(scopedConfig)).toEqual({
+      ...sourceConfig,
+      tools: { alsoAllow: ["brokered_action"] },
+    });
+
+    expect(() =>
+      applyMergePatchToPairedRuntimeConfig({
+        runtimeConfig,
+        patch: {
+          models: {
+            providers: {
+              openai: {
+                apiKey: "sk-stale-runtime", // pragma: allowlist secret
+                models: [],
+              },
+            },
+          },
+        },
+      }),
+    ).toThrow("Cannot override a resolved SecretRef");
+  });
+
+  it("preserves SecretRefs when an unrelated top-level branch is removed", () => {
+    const sourceConfig = { ...createSourceConfig(), tools: { allow: ["brokered_action"] } };
+    const runtimeConfig = { ...createRuntimeConfig(), tools: { allow: ["brokered_action"] } };
+    setRuntimeConfigSnapshot(runtimeConfig, sourceConfig);
+
+    const scopedConfig = applyMergePatchToPairedRuntimeConfig({
+      runtimeConfig,
+      patch: { tools: null } as unknown as OpenClawConfig,
+    });
+
+    expect(getRuntimeConfigSourcePair(scopedConfig)).toEqual(createSourceConfig());
+  });
+
+  it("preserves SecretRefs when a scoped patch carries an unchanged array credential", () => {
+    const secretRef = { source: "env", provider: "default", id: "ACCOUNT_API_KEY" } as const;
+    const sourceConfig = {
+      plugins: {
+        entries: {
+          brokered: {
+            config: { accounts: [{ apiKey: secretRef, label: "primary" }] },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const runtimeConfig = structuredClone(sourceConfig);
+    const runtimeAccounts = (
+      runtimeConfig.plugins?.entries?.brokered?.config as {
+        accounts: Array<{ apiKey: unknown; label: string }>;
+      }
+    ).accounts;
+    runtimeAccounts[0]!.apiKey = "resolved-secret";
+    setRuntimeConfigSnapshot(runtimeConfig, sourceConfig);
+
+    const scopedConfig = applyMergePatchToPairedRuntimeConfig({
+      runtimeConfig,
+      patch: {
+        plugins: {
+          entries: {
+            brokered: {
+              config: { accounts: [{ apiKey: "resolved-secret", label: "scoped" }] },
+            },
+          },
+        },
+      },
+    });
+
+    expect(
+      (
+        getRuntimeConfigSourcePair(scopedConfig)?.plugins?.entries?.brokered?.config as {
+          accounts: Array<{ apiKey: unknown; label: string }>;
+        }
+      ).accounts[0],
+    ).toEqual({ apiKey: secretRef, label: "scoped" });
   });
 });

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -125,7 +125,10 @@ import {
   type RuntimeConfigSnapshotRefreshOptions,
   type RuntimeConfigWriteNotification,
 } from "./runtime-snapshot.js";
-export { projectConfigOntoRuntimeSourceSnapshot } from "./runtime-source-projection.js";
+export {
+  applyMergePatchToPairedRuntimeConfig,
+  projectConfigOntoRuntimeSourceSnapshot,
+} from "./runtime-source-projection.js";
 import { resolveShellEnvExpectedKeys } from "./shell-env-expected-keys.js";
 import type { OpenClawConfig, ConfigFileSnapshot, LegacyConfigIssue } from "./types.js";
 import {

--- a/src/config/runtime-snapshot.ts
+++ b/src/config/runtime-snapshot.ts
@@ -90,6 +90,7 @@ export type RuntimeConfigSnapshotMetadata = {
 
 let runtimeConfigSnapshot: OpenClawConfig | null = null;
 let runtimeConfigSourceSnapshot: OpenClawConfig | null = null;
+let runtimeConfigSourcePairs = new WeakMap<OpenClawConfig, OpenClawConfig>();
 let runtimeConfigSnapshotMetadata: RuntimeConfigSnapshotMetadata | null = null;
 let runtimeConfigSnapshotRevision = 0;
 let runtimeConfigSnapshotRefreshHandler: RuntimeConfigSnapshotRefreshHandler | null = null;
@@ -143,12 +144,28 @@ export function setRuntimeConfigSnapshot(
 ): void {
   runtimeConfigSnapshot = config;
   runtimeConfigSourceSnapshot = sourceConfig ?? null;
+  if (sourceConfig) {
+    registerRuntimeConfigSourcePair(config, sourceConfig);
+  }
   runtimeConfigSnapshotMetadata = createRuntimeConfigSnapshotMetadata(config, sourceConfig);
+}
+
+/** Retains the authored source paired with a prepared runtime config for its object lifetime. */
+export function registerRuntimeConfigSourcePair(
+  config: OpenClawConfig,
+  sourceConfig: OpenClawConfig,
+): void {
+  runtimeConfigSourcePairs.set(config, sourceConfig);
+}
+
+export function getRuntimeConfigSourcePair(config: OpenClawConfig): OpenClawConfig | undefined {
+  return runtimeConfigSourcePairs.get(config);
 }
 
 export function resetConfigRuntimeState(): void {
   runtimeConfigSnapshot = null;
   runtimeConfigSourceSnapshot = null;
+  runtimeConfigSourcePairs = new WeakMap<OpenClawConfig, OpenClawConfig>();
   runtimeConfigSnapshotMetadata = null;
   runtimeConfigSnapshotRevision = 0;
 }

--- a/src/config/runtime-source-projection.ts
+++ b/src/config/runtime-source-projection.ts
@@ -1,59 +1,92 @@
-import { createMergePatch, projectSourceOntoRuntimeShape } from "./io.write-prepare.js";
+import { isDeepStrictEqual } from "node:util";
+import { isRecord } from "../utils.js";
+import { projectSourceOntoRuntimeShape } from "./io.write-prepare.js";
 import { applyMergePatch } from "./merge-patch.js";
-import { getRuntimeConfigSnapshot, getRuntimeConfigSourceSnapshot } from "./runtime-snapshot.js";
+import { getRuntimeConfigSourcePair, registerRuntimeConfigSourcePair } from "./runtime-snapshot.js";
 import type { OpenClawConfig } from "./types.js";
+import { isSecretRef } from "./types.secrets.js";
 
-function isCompatibleTopLevelRuntimeProjectionShape(params: {
-  runtimeSnapshot: OpenClawConfig;
-  candidate: OpenClawConfig;
-}): boolean {
-  const runtime = params.runtimeSnapshot as Record<string, unknown>;
-  const candidate = params.candidate as Record<string, unknown>;
-  for (const key of Object.keys(runtime)) {
-    if (!Object.hasOwn(candidate, key)) {
-      return false;
-    }
-    const runtimeValue = runtime[key];
-    const candidateValue = candidate[key];
-    const runtimeType = Array.isArray(runtimeValue)
-      ? "array"
-      : runtimeValue === null
-        ? "null"
-        : typeof runtimeValue;
-    const candidateType = Array.isArray(candidateValue)
-      ? "array"
-      : candidateValue === null
-        ? "null"
-        : typeof candidateValue;
-    if (runtimeType !== candidateType) {
-      return false;
-    }
+function containsSecretRef(value: unknown): boolean {
+  if (isSecretRef(value)) {
+    return true;
   }
-  return true;
+  if (Array.isArray(value)) {
+    return value.some(containsSecretRef);
+  }
+  return isRecord(value) && Object.values(value).some(containsSecretRef);
 }
 
-/** Projects a runtime-derived config back onto the active authored source snapshot. */
-export function projectConfigOntoRuntimeSourceSnapshot(config: OpenClawConfig): OpenClawConfig {
-  const runtimeConfigSnapshot = getRuntimeConfigSnapshot();
-  const runtimeConfigSourceSnapshot = getRuntimeConfigSourceSnapshot();
-  if (!runtimeConfigSnapshot || !runtimeConfigSourceSnapshot) {
+function restoreSecretRefs(source: unknown, target: unknown): unknown {
+  if (isSecretRef(source)) {
+    return source;
+  }
+  if (Array.isArray(source) && Array.isArray(target)) {
+    return target.map((value, index) => restoreSecretRefs(source[index], value));
+  }
+  if (!isRecord(source) || !isRecord(target)) {
+    return target;
+  }
+  const restored = { ...target };
+  for (const [key, sourceValue] of Object.entries(source)) {
+    if (containsSecretRef(sourceValue) && Object.hasOwn(restored, key)) {
+      restored[key] = restoreSecretRefs(sourceValue, restored[key]);
+    }
+  }
+  return restored;
+}
+
+function hasSecretRefRuntimeMismatch(
+  source: unknown,
+  runtime: unknown,
+  candidate: unknown,
+): boolean {
+  if (isSecretRef(source)) {
+    return !isDeepStrictEqual(runtime, candidate);
+  }
+  if (Array.isArray(source)) {
+    if (!Array.isArray(runtime) || !Array.isArray(candidate)) {
+      return containsSecretRef(source);
+    }
+    return source.some((value, index) =>
+      hasSecretRefRuntimeMismatch(value, runtime[index], candidate[index]),
+    );
+  }
+  if (!isRecord(source)) {
+    return false;
+  }
+  if (!isRecord(runtime) || !isRecord(candidate)) {
+    return containsSecretRef(source);
+  }
+  return Object.entries(source).some(([key, value]) =>
+    hasSecretRefRuntimeMismatch(value, runtime[key], candidate[key]),
+  );
+}
+
+/** Applies a scoped merge while retaining only explicit runtime-to-source provenance. */
+export function applyMergePatchToPairedRuntimeConfig(params: {
+  runtimeConfig: OpenClawConfig;
+  patch: OpenClawConfig;
+}): OpenClawConfig {
+  const config = applyMergePatch(params.runtimeConfig, params.patch) as OpenClawConfig;
+  const sourceConfig = getRuntimeConfigSourcePair(params.runtimeConfig);
+  if (!sourceConfig) {
     return config;
   }
-  if (config === runtimeConfigSnapshot) {
-    return runtimeConfigSourceSnapshot;
-  }
-  if (
-    !isCompatibleTopLevelRuntimeProjectionShape({
-      runtimeSnapshot: runtimeConfigSnapshot,
-      candidate: config,
-    })
-  ) {
-    return config;
+  if (hasSecretRefRuntimeMismatch(sourceConfig, params.runtimeConfig, config)) {
+    throw new Error("Cannot override a resolved SecretRef through a runtime config merge.");
   }
   const projectedSource = projectSourceOntoRuntimeShape(
-    runtimeConfigSourceSnapshot,
-    runtimeConfigSnapshot,
+    sourceConfig,
+    params.runtimeConfig,
   ) as OpenClawConfig;
-  const runtimePatch = createMergePatch(runtimeConfigSnapshot, config);
-  return applyMergePatch(projectedSource, runtimePatch) as OpenClawConfig;
+  const patchedSource = applyMergePatch(projectedSource, params.patch) as OpenClawConfig;
+  // Merge patches replace arrays atomically, so restore authored refs after scoped changes.
+  const pairedSource = restoreSecretRefs(projectedSource, patchedSource) as OpenClawConfig;
+  registerRuntimeConfigSourcePair(config, pairedSource);
+  return config;
+}
+
+/** Returns authored config only for a runtime object with an explicit source pairing. */
+export function projectConfigOntoRuntimeSourceSnapshot(config: OpenClawConfig): OpenClawConfig {
+  return getRuntimeConfigSourcePair(config) ?? config;
 }

--- a/src/gateway/server-methods/tools-catalog.test.ts
+++ b/src/gateway/server-methods/tools-catalog.test.ts
@@ -3,6 +3,8 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ErrorCodes } from "../../../packages/gateway-protocol/src/index.js";
+import { getRuntimeConfigSourceSnapshot } from "../../config/config.js";
+import { loadManifestContractSnapshot } from "../../plugins/manifest-contract-eligibility.js";
 import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
 import {
   ensureStandalonePluginToolRegistryLoaded,
@@ -19,6 +21,11 @@ vi.mock("../../agents/agent-scope.js", () => ({
 
 vi.mock("../../config/config.js", () => ({
   getRuntimeConfig: vi.fn(() => ({})),
+  getRuntimeConfigSourceSnapshot: vi.fn(() => undefined),
+}));
+
+vi.mock("../../plugins/manifest-contract-eligibility.js", () => ({
+  loadManifestContractSnapshot: vi.fn(() => ({ index: {}, plugins: [] })),
 }));
 
 const pluginToolMetaState = new Map<string, { pluginId: string; optional: boolean }>();
@@ -124,6 +131,8 @@ describe("tools.catalog handler", () => {
     pluginToolMetaState.set("matrix_room", { pluginId: "matrix", optional: false });
     getActivePluginRegistryMock.mockReturnValue(null);
     vi.mocked(ensureStandalonePluginToolRegistryLoaded).mockReturnValue(undefined);
+    vi.mocked(getRuntimeConfigSourceSnapshot).mockReturnValue(undefined);
+    vi.mocked(loadManifestContractSnapshot).mockReturnValue({ index: {}, plugins: [] } as never);
   });
 
   it("rejects invalid params", async () => {
@@ -189,6 +198,7 @@ describe("tools.catalog handler", () => {
 
     const resolveArgs = firstMockArg(vi.mocked(resolvePluginTools), "resolvePluginTools args") as {
       allowGatewaySubagentBinding?: boolean;
+      omitCredentialBrokerToolsWithoutContext?: boolean;
       suppressNameConflicts?: boolean;
       toolAllowlist?: string[];
       context?: {
@@ -199,6 +209,7 @@ describe("tools.catalog handler", () => {
       existingToolNames?: Set<string>;
     };
     expect(resolveArgs.allowGatewaySubagentBinding).toBe(true);
+    expect(resolveArgs.omitCredentialBrokerToolsWithoutContext).toBe(true);
     expect(resolveArgs.suppressNameConflicts).toBe(true);
     expect(resolveArgs.toolAllowlist).toEqual(["group:plugins"]);
     expect(resolveArgs.context?.agentId).toBe("main");
@@ -223,10 +234,66 @@ describe("tools.catalog handler", () => {
     expect(registryArgs.toolAllowlist).toEqual(["group:plugins"]);
     expect(registryArgs.context).toEqual({
       config: {},
+      runtimeConfig: {},
       workspaceDir: "/tmp/workspace-main",
       agentDir: "/tmp/agents/main/agent",
       agentId: "main",
     });
+  });
+
+  it("omits declared brokered tools when the catalog has no prepared conversation scope", async () => {
+    const sourceConfig = {
+      plugins: {
+        entries: {
+          tavily: {
+            config: {
+              webSearch: {
+                apiKey: { source: "env", provider: "default", id: "TAVILY_API_KEY" },
+              },
+            },
+          },
+        },
+      },
+    };
+    vi.mocked(getRuntimeConfigSourceSnapshot).mockReturnValue(sourceConfig as never);
+    vi.mocked(loadManifestContractSnapshot).mockReturnValue({
+      index: {},
+      plugins: [
+        {
+          id: "tavily",
+          credentialBroker: {
+            operations: [
+              {
+                id: "search",
+                tool: "tavily_search",
+                secretInputPath: "webSearch.apiKey",
+              },
+            ],
+          },
+        },
+      ],
+    } as never);
+    const toolRegistry = createEmptyPluginRegistry();
+    toolRegistry.tools.push({
+      pluginId: "tavily",
+      pluginName: "Tavily",
+      factory: vi.fn(),
+      names: [],
+      declaredNames: ["tavily_search"],
+      optional: true,
+      source: "test",
+    });
+    vi.mocked(ensureStandalonePluginToolRegistryLoaded).mockReturnValue(toolRegistry);
+    vi.mocked(resolvePluginTools).mockReturnValueOnce([]);
+
+    const { respond, invoke } = createInvokeParams({});
+    await invoke();
+
+    const payload = expectCatalogPayload(respond);
+    const pluginToolIds = payload.groups
+      .filter((group) => group.source === "plugin")
+      .flatMap((group) => group.tools.map((tool) => tool.id));
+    expect(pluginToolIds).not.toContain("tavily_search");
   });
 
   it("projects metadata from the exact tool-discovery registry", async () => {

--- a/src/gateway/server-methods/tools-catalog.ts
+++ b/src/gateway/server-methods/tools-catalog.ts
@@ -18,7 +18,10 @@ import {
   resolveCoreToolProfiles,
 } from "../../agents/tool-catalog.js";
 import { summarizeToolDescriptionText } from "../../agents/tool-description-summary.js";
+import { getRuntimeConfigSourceSnapshot } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { listConfiguredBrokeredToolNames } from "../../plugins/credential-broker.js";
+import { loadManifestContractSnapshot } from "../../plugins/manifest-contract-eligibility.js";
 import type { PluginRegistry } from "../../plugins/registry-types.js";
 import { getActivePluginRegistry } from "../../plugins/runtime.js";
 import {
@@ -74,8 +77,22 @@ function buildPluginGroups(params: {
 }): ToolCatalogGroup[] {
   const workspaceDir = resolveAgentWorkspaceDir(params.cfg, params.agentId);
   const agentDir = resolveAgentDir(params.cfg, params.agentId);
+  const credentialBrokerSourceConfig = getRuntimeConfigSourceSnapshot() ?? params.cfg;
+  const manifestSnapshot = loadManifestContractSnapshot({
+    config: params.cfg,
+    workspaceDir,
+  });
+  const unscopedBrokeredToolKeys = new Set(
+    manifestSnapshot.plugins.flatMap((plugin) =>
+      listConfiguredBrokeredToolNames({
+        sourceConfig: credentialBrokerSourceConfig,
+        plugin,
+      }).map((toolName) => buildPluginToolMetadataKey(plugin.id, toolName)),
+    ),
+  );
   const toolContext = {
     config: params.cfg,
+    runtimeConfig: params.cfg,
     workspaceDir,
     agentDir,
     agentId: params.agentId,
@@ -84,6 +101,7 @@ function buildPluginGroups(params: {
     context: toolContext,
     toolAllowlist: ["group:plugins"],
     allowGatewaySubagentBinding: true,
+    credentialBrokerSourceConfig,
   });
   // Resolve tools through the same plugin registry path used at runtime so the
   // catalog respects conflicts, optional tools, and subagent binding rules.
@@ -94,6 +112,8 @@ function buildPluginGroups(params: {
     suppressNameConflicts: true,
     allowGatewaySubagentBinding: true,
     runtimeRegistry: toolRegistry,
+    credentialBrokerSourceConfig,
+    omitCredentialBrokerToolsWithoutContext: true,
   });
   const catalogRegistry = toolRegistry ?? getActivePluginRegistry();
   const groups = new Map<string, ToolCatalogGroup>();
@@ -153,7 +173,12 @@ function buildPluginGroups(params: {
   for (const entry of catalogRegistry?.tools ?? []) {
     const names = entry.names.length > 0 ? entry.names : (entry.declaredNames ?? []);
     for (const name of names) {
-      if (seenToolIds.has(name) || params.existingToolNames.has(name)) {
+      const toolKey = buildPluginToolMetadataKey(entry.pluginId, name);
+      if (
+        seenToolIds.has(name) ||
+        params.existingToolNames.has(name) ||
+        unscopedBrokeredToolKeys.has(toolKey)
+      ) {
         continue;
       }
       const groupId = `plugin:${entry.pluginId}`;

--- a/src/mcp/plugin-tools-serve.test.ts
+++ b/src/mcp/plugin-tools-serve.test.ts
@@ -20,6 +20,7 @@ const callGatewayTool = vi.hoisted(() => vi.fn());
 const connectToolsMcpServerToStdioMock = vi.hoisted(() => vi.fn());
 const createToolsMcpServerMock = vi.hoisted(() => vi.fn(() => ({ close: vi.fn() })));
 const getRuntimeConfigMock = vi.hoisted(() => vi.fn(() => ({ plugins: { enabled: true } })));
+const getRuntimeConfigSourceSnapshotMock = vi.hoisted(() => vi.fn(() => null));
 const ensureStandalonePluginToolRegistryLoadedMock = vi.hoisted(() => vi.fn());
 const resolvePluginToolsMock = vi.hoisted(() => vi.fn<() => AnyAgentTool[]>(() => []));
 const routeLogsToStderrMock = vi.hoisted(() => vi.fn());
@@ -30,6 +31,7 @@ vi.mock("../agents/tools/gateway.js", () => ({
 
 vi.mock("../config/config.js", () => ({
   getRuntimeConfig: getRuntimeConfigMock,
+  getRuntimeConfigSourceSnapshot: getRuntimeConfigSourceSnapshotMock,
 }));
 
 vi.mock("../logging/console.js", async (importOriginal) => {
@@ -61,6 +63,8 @@ afterEach(() => {
   createToolsMcpServerMock.mockClear();
   ensureStandalonePluginToolRegistryLoadedMock.mockReset();
   getRuntimeConfigMock.mockClear();
+  getRuntimeConfigSourceSnapshotMock.mockReset();
+  getRuntimeConfigSourceSnapshotMock.mockReturnValue(null);
   resolvePluginToolsMock.mockReset();
   resolvePluginToolsMock.mockReturnValue([]);
   routeLogsToStderrMock.mockReset();
@@ -104,11 +108,18 @@ describe("plugin tools MCP server", () => {
 
     expect(routeLogsToStderrMock).toHaveBeenCalledTimes(1);
     expect(ensureStandalonePluginToolRegistryLoadedMock).toHaveBeenCalledWith({
-      context: { config: { plugins: { enabled: true } } },
+      context: {
+        config: { plugins: { enabled: true } },
+        runtimeConfig: { plugins: { enabled: true } },
+      },
+      credentialBrokerSourceConfig: { plugins: { enabled: true } },
     });
     expect(resolvePluginToolsMock).toHaveBeenCalledTimes(1);
     expect(resolvePluginToolsMock).toHaveBeenCalledWith(
-      expect.objectContaining({ runtimeRegistry }),
+      expect.objectContaining({
+        runtimeRegistry,
+        omitCredentialBrokerToolsWithoutContext: true,
+      }),
     );
     expect(ensureStandalonePluginToolRegistryLoadedMock.mock.invocationCallOrder[0]).toBeLessThan(
       resolvePluginToolsMock.mock.invocationCallOrder[0] ?? 0,
@@ -117,6 +128,38 @@ describe("plugin tools MCP server", () => {
       resolvePluginToolsMock.mock.invocationCallOrder[0] ?? 0,
     );
     expect(connectToolsMcpServerToStdioMock).toHaveBeenCalledOnce();
+  });
+
+  it("keeps source SecretRefs separate from the resolved plugin tool config", async () => {
+    const sourceConfig = {
+      plugins: {
+        enabled: true,
+        entries: {
+          tavily: {
+            config: {
+              webSearch: {
+                apiKey: { source: "env", provider: "default", id: "TAVILY_API_KEY" },
+              },
+            },
+          },
+        },
+      },
+    };
+    const runtimeConfig = structuredClone(sourceConfig);
+    runtimeConfig.plugins.entries.tavily.config.webSearch.apiKey = "resolved-value" as never;
+    getRuntimeConfigMock.mockReturnValueOnce(runtimeConfig as never);
+    getRuntimeConfigSourceSnapshotMock.mockReturnValueOnce(sourceConfig as never);
+    const { servePluginToolsMcp } = await import("./plugin-tools-serve.js");
+
+    await servePluginToolsMcp();
+
+    expect(resolvePluginToolsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: { config: runtimeConfig, runtimeConfig },
+        credentialBrokerSourceConfig: sourceConfig,
+        omitCredentialBrokerToolsWithoutContext: true,
+      }),
+    );
   });
 
   it("threads global plugin tool policy into plugin resolution", async () => {

--- a/src/mcp/plugin-tools-serve.ts
+++ b/src/mcp/plugin-tools-serve.ts
@@ -16,7 +16,7 @@ import {
   resolveToolProfilePolicy,
 } from "../agents/tool-policy.js";
 import type { AnyAgentTool } from "../agents/tools/common.js";
-import { getRuntimeConfig } from "../config/config.js";
+import { getRuntimeConfig, getRuntimeConfigSourceSnapshot } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { routeLogsToStderr } from "../logging/console.js";
@@ -40,17 +40,24 @@ function resolvePluginToolPolicy(config: OpenClawConfig): {
   };
 }
 
-function resolveTools(config: OpenClawConfig): AnyAgentTool[] {
+function resolveTools(config: OpenClawConfig, sourceConfig: OpenClawConfig): AnyAgentTool[] {
   const pluginToolPolicy = resolvePluginToolPolicy(config);
+  const context = {
+    config,
+    runtimeConfig: config,
+  };
   const runtimeRegistry = ensureStandalonePluginToolRegistryLoaded({
-    context: { config },
+    context,
     ...pluginToolPolicy,
+    credentialBrokerSourceConfig: sourceConfig,
   });
   return resolvePluginTools({
-    context: { config },
+    context,
     ...pluginToolPolicy,
     suppressNameConflicts: true,
     runtimeRegistry,
+    credentialBrokerSourceConfig: sourceConfig,
+    omitCredentialBrokerToolsWithoutContext: true,
   });
 }
 
@@ -61,7 +68,8 @@ export function createPluginToolsMcpServer(
   } = {},
 ): Server {
   const cfg = params.config ?? getRuntimeConfig();
-  const tools = params.tools ?? resolveTools(cfg);
+  const sourceConfig = params.config ? params.config : (getRuntimeConfigSourceSnapshot() ?? cfg);
+  const tools = params.tools ?? resolveTools(cfg, sourceConfig);
   return createToolsMcpServer({ name: "openclaw-plugin-tools", tools });
 }
 
@@ -71,7 +79,7 @@ export async function servePluginToolsMcp(): Promise<void> {
   routeLogsToStderr();
 
   const config = getRuntimeConfig();
-  const tools = resolveTools(config);
+  const tools = resolveTools(config, getRuntimeConfigSourceSnapshot() ?? config);
   const server = createPluginToolsMcpServer({ config, tools });
   if (tools.length === 0) {
     process.stderr.write("plugin-tools-serve: no plugin tools found\n");

--- a/src/plugin-sdk/plugin-entry.ts
+++ b/src/plugin-sdk/plugin-entry.ts
@@ -44,6 +44,12 @@ export type OpenClawPluginServiceContext =
   import("../plugins/types.js").OpenClawPluginServiceContext;
 export type OpenClawPluginToolContext = import("../plugins/types.js").OpenClawPluginToolContext;
 export type OpenClawPluginToolFactory = import("../plugins/types.js").OpenClawPluginToolFactory;
+export type {
+  BrokeredCredentialJsonResponse,
+  BrokeredCredentialRequestHandle,
+  BrokeredCredentialRequestHandleSnapshot,
+  OpenClawCredentialBroker,
+} from "../plugins/credential-broker-types.js";
 export type PluginLogger = import("../plugins/types.js").PluginLogger;
 export type ProviderAugmentModelCatalogContext =
   import("../plugins/types.js").ProviderAugmentModelCatalogContext;

--- a/src/plugins/credential-broker-types.ts
+++ b/src/plugins/credential-broker-types.ts
@@ -1,0 +1,27 @@
+/** Public, secret-free request handle exposed to plugin-owned agent tools. */
+export type BrokeredCredentialRequestHandle = {
+  readonly id: string;
+  readonly operationId: string;
+  readonly expiresAtMs: number;
+  execute(options?: { signal?: AbortSignal }): Promise<BrokeredCredentialJsonResponse>;
+  revoke(): void;
+  toJSON(): BrokeredCredentialRequestHandleSnapshot;
+};
+
+export type BrokeredCredentialRequestHandleSnapshot = {
+  id: string;
+  operationId: string;
+  expiresAtMs: number;
+  state: "pending" | "running" | "consumed" | "revoked";
+};
+
+export type BrokeredCredentialJsonResponse = {
+  status: number;
+  body: unknown;
+};
+
+/** Conversation-bound broker surface. Secret values never cross this boundary. */
+export type OpenClawCredentialBroker = {
+  isConfigured(operationId: string): boolean;
+  createRequest(params: { operationId: string; body: unknown }): BrokeredCredentialRequestHandle;
+};

--- a/src/plugins/credential-broker.test.ts
+++ b/src/plugins/credential-broker.test.ts
@@ -1,0 +1,490 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveConversationCapabilityProfile } from "../agents/conversation-capability-profile.js";
+import type { withTrustedWebToolsEndpoint } from "../agents/tools/web-guarded-fetch.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { SecretRef } from "../config/types.secrets.js";
+import {
+  createCredentialBrokerSafeConfigGetter,
+  createCredentialBrokerClient,
+  hasConfiguredBrokeredSecretInputs,
+  omitConfiguredBrokeredSecretInputs,
+  projectConfiguredBrokeredSecretInputs,
+} from "./credential-broker.js";
+import type { PluginManifestCredentialBrokerOperation } from "./manifest.js";
+
+const SECRET = "broker-test-secret-value";
+const SECRET_REF: SecretRef = {
+  source: "env",
+  provider: "default",
+  id: "BROKER_TEST_TOKEN",
+};
+const OPERATION: PluginManifestCredentialBrokerOperation = {
+  id: "search",
+  tool: "tavily_search",
+  secretInputPath: "webSearch.apiKey",
+  baseUrlConfigPath: "webSearch.baseUrl",
+  baseUrlEnv: "TAVILY_BASE_URL",
+  defaultBaseUrl: "https://api.example.test",
+  path: "/search",
+  method: "POST",
+  credentialHeader: "Authorization",
+  credentialScheme: "Bearer",
+  headers: { "X-Client-Source": "openclaw" },
+  maxRequestBodyBytes: 1024,
+  maxResponseBodyBytes: 4096,
+  timeoutMs: 5000,
+};
+
+function createConfig(params?: {
+  allow?: string[];
+  alsoAllow?: string[];
+  deny?: string[];
+  profile?: "coding";
+  baseUrl?: string | null;
+  senderDeny?: string[];
+}): OpenClawConfig {
+  return {
+    tools: {
+      allow: params?.allow,
+      alsoAllow: params?.alsoAllow,
+      deny: params?.deny,
+      profile: params?.profile,
+      ...(params?.senderDeny ? { toolsBySender: { "id:alice": { deny: params.senderDeny } } } : {}),
+    },
+    plugins: {
+      entries: {
+        tavily: {
+          config: {
+            webSearch: {
+              apiKey: SECRET_REF,
+              baseUrl:
+                params?.baseUrl === null
+                  ? undefined
+                  : (params?.baseUrl ?? "https://api.example.test/v1"),
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
+function createProfile(config: OpenClawConfig) {
+  return resolveConversationCapabilityProfile({
+    config,
+    sessionKey: "agent:main:discord:direct:alice",
+    agentId: "main",
+    messageProvider: "discord",
+    messageChannel: "discord",
+    chatType: "direct",
+    senderId: "alice",
+    workspaceDir: "/tmp/openclaw-broker-test",
+  });
+}
+
+function createRuntimeConfig(sourceConfig: OpenClawConfig, credential: unknown = SECRET) {
+  const runtimeConfig = structuredClone(sourceConfig);
+  const pluginConfig = runtimeConfig.plugins?.entries?.tavily?.config as {
+    webSearch?: { apiKey?: unknown };
+  };
+  if (pluginConfig.webSearch) {
+    pluginConfig.webSearch.apiKey = credential;
+  }
+  return runtimeConfig;
+}
+
+function createFixture(params?: {
+  allow?: string[];
+  alsoAllow?: string[];
+  deny?: string[];
+  profile?: "coding";
+  baseUrl?: string | null;
+  senderDeny?: string[];
+  now?: () => number;
+  response?: Response;
+  runtimeCredential?: unknown;
+  fetchError?: unknown;
+  env?: NodeJS.ProcessEnv;
+  defaultEnabled?: boolean;
+}) {
+  const config = createConfig(params);
+  const runtimeConfig = createRuntimeConfig(config, params?.runtimeCredential ?? SECRET);
+  const release = vi.fn(async () => {});
+  const fetchGuard = vi.fn(
+    async (
+      options: Parameters<typeof withTrustedWebToolsEndpoint>[0],
+      run: (result: { response: Response; finalUrl: string }) => Promise<unknown>,
+    ) => {
+      if (params?.fetchError) {
+        throw params.fetchError;
+      }
+      try {
+        const response =
+          params?.response ??
+          Response.json({
+            echo: `prefix ${SECRET} suffix`,
+            results: [],
+          });
+        return await run({ response, finalUrl: options.url });
+      } finally {
+        await release();
+      }
+    },
+  );
+  const broker = createCredentialBrokerClient({
+    pluginId: "tavily",
+    operations: [OPERATION],
+    registrationToolNames: ["tavily_search"],
+    defaultToolNames: params?.defaultEnabled === false ? [] : ["tavily_search"],
+    context: {
+      profile: createProfile(config),
+      sourceConfig: config,
+      runtimeConfig,
+    },
+    deps: {
+      now: params?.now ?? (() => 0),
+      randomUUID: () => "request-id",
+      withTrustedWebToolsEndpoint: fetchGuard as typeof withTrustedWebToolsEndpoint,
+      env: params?.env ?? {},
+    },
+  });
+  return { broker, fetchGuard, release };
+}
+
+describe("credential broker", () => {
+  it("handles array-index secret paths without exposing resolved values", () => {
+    const operation = { ...OPERATION, secretInputPath: "accounts.0.apiKey" };
+    const plugin = { id: "tavily", credentialBroker: { operations: [operation] } };
+    const sourceConfig = {
+      plugins: {
+        entries: {
+          tavily: { config: { accounts: [{ apiKey: SECRET_REF, label: "primary" }] } },
+        },
+      },
+    } as OpenClawConfig;
+    const runtimeConfig = structuredClone(sourceConfig);
+    const runtimeAccounts = (
+      runtimeConfig.plugins?.entries?.tavily?.config as {
+        accounts: Array<{ apiKey?: unknown }>;
+      }
+    ).accounts;
+    runtimeAccounts[0]!.apiKey = SECRET;
+
+    expect(hasConfiguredBrokeredSecretInputs({ sourceConfig, plugins: [plugin] })).toBe(true);
+    expect(
+      JSON.stringify(
+        omitConfiguredBrokeredSecretInputs({
+          config: runtimeConfig,
+          sourceConfig,
+          plugins: [plugin],
+        }),
+      ),
+    ).not.toContain(SECRET);
+    const projected = projectConfiguredBrokeredSecretInputs({
+      config: runtimeConfig,
+      sourceConfig,
+      plugins: [plugin],
+    });
+    const projectedCredential = (
+      projected.plugins?.entries?.tavily?.config as {
+        accounts: Array<{ apiKey?: unknown }>;
+      }
+    ).accounts[0]?.apiKey as SecretRef;
+    expect(projectedCredential).toEqual(SECRET_REF);
+    expect(projectedCredential).not.toBe(SECRET_REF);
+    projectedCredential.id = "PLUGIN_MUTATED_TOKEN";
+    expect(hasConfiguredBrokeredSecretInputs({ sourceConfig, plugins: [plugin] })).toBe(true);
+
+    const getSafeConfig = createCredentialBrokerSafeConfigGetter({
+      getRuntimeConfig: () => runtimeConfig,
+      preparedConfig: sourceConfig,
+      plugins: [plugin],
+    });
+    const safeCredential = (
+      getSafeConfig().plugins?.entries?.tavily?.config as {
+        accounts: Array<{ apiKey?: unknown }>;
+      }
+    ).accounts[0]?.apiKey as SecretRef;
+    expect(safeCredential).toEqual(SECRET_REF);
+    expect(safeCredential).not.toBe(SECRET_REF);
+    safeCredential.id = "PLUGIN_MUTATED_AGAIN";
+    expect(
+      (
+        getSafeConfig().plugins?.entries?.tavily?.config as {
+          accounts: Array<{ apiKey?: unknown }>;
+        }
+      ).accounts[0]?.apiKey,
+    ).toEqual(SECRET_REF);
+    expect(hasConfiguredBrokeredSecretInputs({ sourceConfig, plugins: [plugin] })).toBe(true);
+  });
+
+  it("keeps credentials inside a scoped, single-use request", async () => {
+    const fixture = createFixture({ allow: ["tavily_search"] });
+
+    const handle = fixture.broker.createRequest({
+      operationId: "search",
+      body: { query: "team status" },
+    });
+
+    expect(JSON.stringify(fixture.broker)).not.toContain(SECRET);
+    expect(JSON.stringify(handle)).toBe(
+      '{"id":"request-id","operationId":"search","expiresAtMs":30000,"state":"pending"}',
+    );
+
+    await expect(handle.execute()).resolves.toEqual({
+      status: 200,
+      body: { echo: "prefix [REDACTED] suffix", results: [] },
+    });
+    expect(fixture.fetchGuard).toHaveBeenCalledOnce();
+    const request = fixture.fetchGuard.mock.calls[0]?.[0];
+    expect(request).toMatchObject({
+      url: "https://api.example.test/v1/search",
+      requireHttps: true,
+      maxRedirects: 0,
+      capture: false,
+      timeoutMs: 5000,
+      auditContext: "credential-broker:tavily:search",
+      init: {
+        method: "POST",
+        body: '{"query":"team status"}',
+      },
+    });
+    const headers = new Headers(request?.init?.headers);
+    expect(headers.get("authorization")).toBe(`Bearer ${SECRET}`);
+    expect(headers.get("x-client-source")).toBe("openclaw");
+    expect(fixture.release).toHaveBeenCalledOnce();
+    await expect(handle.execute()).rejects.toThrow("already consumed");
+  });
+
+  it("preserves default tool access while denying absent, conflicting, and sender grants", () => {
+    expect(() =>
+      createFixture().broker.createRequest({ operationId: "search", body: {} }),
+    ).not.toThrow();
+    for (const fixture of [
+      createFixture({ defaultEnabled: false }),
+      createFixture({ allow: ["tavily_search"], deny: ["tavily"] }),
+      createFixture({ allow: ["tavily"], senderDeny: ["group:plugins"] }),
+    ]) {
+      expect(() => fixture.broker.createRequest({ operationId: "search", body: {} })).toThrow(
+        "denied this conversation capability profile",
+      );
+      expect(fixture.fetchGuard).not.toHaveBeenCalled();
+    }
+  });
+
+  it("uses the effective profile policy after alsoAllow is merged", async () => {
+    const fixture = createFixture({ profile: "coding", alsoAllow: ["tavily_search"] });
+    const handle = fixture.broker.createRequest({ operationId: "search", body: {} });
+
+    await expect(handle.execute()).resolves.toMatchObject({ status: 200 });
+  });
+
+  it.each([
+    ["agent", { serviceIdentity: { agentId: undefined } }],
+    ["conversation", { conversation: { sessionKey: undefined } }],
+    ["channel", { conversation: { messageChannel: undefined, messageProvider: undefined } }],
+    ["sender", { sender: { id: undefined } }],
+  ])("requires prepared %s scope", (_label, profilePatch) => {
+    const config = createConfig({ allow: ["tavily_search"] });
+    const profile = createProfile(config);
+    const patchedProfile = {
+      ...profile,
+      ...profilePatch,
+      serviceIdentity: {
+        ...profile.serviceIdentity,
+        ...("serviceIdentity" in profilePatch ? profilePatch.serviceIdentity : {}),
+      },
+      conversation: {
+        ...profile.conversation,
+        ...("conversation" in profilePatch ? profilePatch.conversation : {}),
+      },
+      sender: { ...profile.sender, ...("sender" in profilePatch ? profilePatch.sender : {}) },
+    };
+    const broker = createCredentialBrokerClient({
+      pluginId: "tavily",
+      operations: [OPERATION],
+      registrationToolNames: ["tavily_search"],
+      defaultToolNames: ["tavily_search"],
+      context: {
+        profile: patchedProfile,
+        sourceConfig: config,
+        runtimeConfig: createRuntimeConfig(config),
+      },
+    });
+
+    expect(() => broker.createRequest({ operationId: "search", body: {} })).toThrow(
+      "requires prepared agent, conversation, channel, and sender scope",
+    );
+  });
+
+  it("validates destination before resolving credentials", async () => {
+    const fixture = createFixture({
+      allow: ["tavily_search"],
+      baseUrl: "http://api.example.test",
+    });
+
+    const handle = fixture.broker.createRequest({ operationId: "search", body: {} });
+    await expect(handle.execute()).rejects.toThrow(
+      "destination must be a credential-free HTTPS base URL",
+    );
+    expect(fixture.fetchGuard).not.toHaveBeenCalled();
+  });
+
+  it("fails closed without the runtime snapshot paired to the SecretRef", () => {
+    const config = createConfig({ allow: ["tavily_search"] });
+    const broker = createCredentialBrokerClient({
+      pluginId: "tavily",
+      operations: [OPERATION],
+      registrationToolNames: ["tavily_search"],
+      defaultToolNames: ["tavily_search"],
+      context: {
+        profile: createProfile(config),
+        sourceConfig: config,
+      },
+    });
+
+    expect(() => broker.createRequest({ operationId: "search", body: {} })).toThrow(
+      "requires a paired runtime credential snapshot",
+    );
+  });
+
+  it("uses the declared destination environment fallback after config", async () => {
+    const fixture = createFixture({
+      allow: ["tavily_search"],
+      baseUrl: null,
+      env: { TAVILY_BASE_URL: "https://proxy.example.test/tavily" },
+    });
+    const handle = fixture.broker.createRequest({ operationId: "search", body: {} });
+
+    await handle.execute();
+
+    expect(fixture.fetchGuard.mock.calls[0]?.[0].url).toBe(
+      "https://proxy.example.test/tavily/search",
+    );
+  });
+
+  it("expires and revokes handles deterministically", async () => {
+    let now = 100;
+    const expired = createFixture({ allow: ["tavily_search"], now: () => now });
+    const expiredHandle = expired.broker.createRequest({ operationId: "search", body: {} });
+    now = expiredHandle.expiresAtMs;
+    await expect(expiredHandle.execute()).rejects.toThrow("handle expired");
+    expect(expired.fetchGuard).not.toHaveBeenCalled();
+    expect(expiredHandle.toJSON().state).toBe("revoked");
+
+    const revoked = createFixture({ allow: ["tavily_search"] });
+    const revokedHandle = revoked.broker.createRequest({ operationId: "search", body: {} });
+    revokedHandle.revoke();
+    await expect(revokedHandle.execute()).rejects.toThrow("handle was revoked");
+    expect(revoked.fetchGuard).not.toHaveBeenCalled();
+  });
+
+  it("rejects oversized and non-serializable bodies without retaining them", () => {
+    const fixture = createFixture({ allow: ["tavily_search"] });
+    expect(() =>
+      fixture.broker.createRequest({ operationId: "search", body: "x".repeat(1024) }),
+    ).toThrow("request body exceeds its declared limit");
+
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    expect(() => fixture.broker.createRequest({ operationId: "search", body: circular })).toThrow(
+      "request body must be JSON serializable",
+    );
+    expect(fixture.fetchGuard).not.toHaveBeenCalled();
+  });
+
+  it("does not expose credential lookup or network failure details", async () => {
+    const config = createConfig({ allow: ["tavily_search"] });
+    const broker = createCredentialBrokerClient({
+      pluginId: "tavily",
+      operations: [OPERATION],
+      registrationToolNames: ["tavily_search"],
+      defaultToolNames: ["tavily_search"],
+      context: {
+        profile: createProfile(config),
+        sourceConfig: config,
+        runtimeConfig: createRuntimeConfig(config, SECRET_REF),
+      },
+    });
+
+    const handle = broker.createRequest({ operationId: "search", body: {} });
+    let message = "";
+    try {
+      await handle.execute();
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+    expect(message).toBe("Credential broker could not resolve operation credentials.");
+    expect(message).not.toContain(SECRET);
+
+    const failedRequest = createFixture({
+      allow: ["tavily_search"],
+      fetchError: new Error(SECRET),
+    });
+    const failedHandle = failedRequest.broker.createRequest({ operationId: "search", body: {} });
+    await expect(failedHandle.execute()).rejects.toThrow(
+      "Credential broker request failed before receiving a response.",
+    );
+  });
+
+  it("contains header validation failures without exposing the credential", async () => {
+    const invalidCredential = `${SECRET}\nsecond-line`;
+    const fixture = createFixture({
+      allow: ["tavily_search"],
+      runtimeCredential: invalidCredential,
+    });
+    const handle = fixture.broker.createRequest({ operationId: "search", body: {} });
+
+    let message = "";
+    try {
+      await handle.execute();
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+    expect(message).toBe("Credential broker could not prepare operation credentials.");
+    expect(message).not.toContain(invalidCredential);
+    expect(fixture.fetchGuard).not.toHaveBeenCalled();
+  });
+
+  it("redacts credentials from response property names", async () => {
+    const fixture = createFixture({
+      allow: ["tavily_search"],
+      response: new Response(`{"prefix-${SECRET}":"value","__proto__":{"nested":"${SECRET}"}}`, {
+        status: 200,
+      }),
+    });
+    const handle = fixture.broker.createRequest({ operationId: "search", body: {} });
+
+    const result = await handle.execute();
+
+    expect(JSON.stringify(result.body)).not.toContain(SECRET);
+    expect(Object.keys(result.body as object)).toContain("prefix-[REDACTED]");
+  });
+
+  it.each([
+    { credential: "1234", responseBody: '{"echo":1234}' },
+    { credential: "1e3", responseBody: '{"echo":1e3}' },
+    { credential: "1.0", responseBody: '{"echo":1.0}' },
+    { credential: "-0", responseBody: '{"echo":-0}' },
+    { credential: "true", responseBody: '{"echo":true}' },
+    { credential: "null", responseBody: '{"echo":null}' },
+    { credential: '"json-string-secret"', responseBody: '{"echo":"json-string-secret"}' },
+    {
+      credential: '{"token":"json-object-secret"}',
+      responseBody: '{"echo":{"token":"json-object-secret"}}',
+    },
+    { credential: '["json-array-secret",1]', responseBody: '{"echo":["json-array-secret",1]}' },
+  ])("redacts a credential echoed as a parsed JSON value", async ({ credential, responseBody }) => {
+    const fixture = createFixture({
+      allow: ["tavily_search"],
+      runtimeCredential: credential,
+      response: new Response(responseBody, { status: 200 }),
+    });
+    const handle = fixture.broker.createRequest({ operationId: "search", body: {} });
+
+    await expect(handle.execute()).resolves.toEqual({
+      status: 200,
+      body: { echo: "[REDACTED]" },
+    });
+  });
+});

--- a/src/plugins/credential-broker.ts
+++ b/src/plugins/credential-broker.ts
@@ -1,0 +1,720 @@
+/** Executes manifest-declared credentialed requests without exposing resolved secrets to plugins. */
+import { randomUUID } from "node:crypto";
+import { isDeepStrictEqual } from "node:util";
+import { readResponseWithLimit } from "@openclaw/media-core/read-response-with-limit";
+import type { ResolvedConversationCapabilityProfile } from "../agents/conversation-capability-profile.js";
+import { isToolAllowedByPolicies, isToolAllowedByPolicyName } from "../agents/tool-policy-match.js";
+import {
+  DEFAULT_PLUGIN_TOOLS_ALLOWLIST_ENTRY,
+  expandPolicyWithPluginGroups,
+  mergeAlsoAllowPolicy,
+  normalizeToolName,
+  type PluginToolGroups,
+} from "../agents/tool-policy.js";
+import { withTrustedWebToolsEndpoint } from "../agents/tools/web-guarded-fetch.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { isSecretRef } from "../config/types.secrets.js";
+import { isValidSecretRef } from "../secrets/ref-contract.js";
+import { isRecord } from "../utils.js";
+import type {
+  BrokeredCredentialJsonResponse,
+  BrokeredCredentialRequestHandle,
+  BrokeredCredentialRequestHandleSnapshot,
+  OpenClawCredentialBroker,
+} from "./credential-broker-types.js";
+import type { PluginManifestCredentialBrokerOperation } from "./manifest.js";
+import type { OpenClawPluginToolContext } from "./tool-types.js";
+
+const REQUEST_HANDLE_TTL_MS = 30_000;
+const REDACTED_VALUE = "[REDACTED]";
+
+type CredentialBrokerDeps = {
+  now: () => number;
+  randomUUID: () => string;
+  withTrustedWebToolsEndpoint: typeof withTrustedWebToolsEndpoint;
+  env: NodeJS.ProcessEnv;
+};
+
+const defaultDeps: CredentialBrokerDeps = {
+  now: Date.now,
+  randomUUID,
+  withTrustedWebToolsEndpoint,
+  env: process.env,
+};
+
+class CredentialBrokerOperationError extends Error {}
+
+export type CredentialBrokerContext = {
+  profile: ResolvedConversationCapabilityProfile;
+  sourceConfig: OpenClawConfig;
+  runtimeConfig?: OpenClawConfig;
+};
+
+function readPath(root: unknown, path: string): unknown {
+  let current = root;
+  for (const segment of path.split(".")) {
+    const key = segment.trim();
+    if (!key || (!Array.isArray(current) && !isRecord(current)) || !Object.hasOwn(current, key)) {
+      return undefined;
+    }
+    current = (current as Record<string, unknown>)[key];
+  }
+  return current;
+}
+
+function readPluginConfig(config: OpenClawConfig, pluginId: string): unknown {
+  return config.plugins?.entries?.[pluginId]?.config;
+}
+
+function omitPath(root: unknown, path: readonly string[]): unknown {
+  const [key, ...rest] = path;
+  if (!key || (!Array.isArray(root) && !isRecord(root)) || !Object.hasOwn(root, key)) {
+    return root;
+  }
+  const copy = Array.isArray(root) ? [...root] : { ...root };
+  if (rest.length === 0) {
+    delete (copy as Record<string, unknown>)[key];
+  } else {
+    (copy as Record<string, unknown>)[key] = omitPath((copy as Record<string, unknown>)[key], rest);
+  }
+  return copy;
+}
+
+function replacePath(root: unknown, path: readonly string[], value: unknown): unknown {
+  const [key, ...rest] = path;
+  if (!key || (!Array.isArray(root) && !isRecord(root)) || !Object.hasOwn(root, key)) {
+    return root;
+  }
+  const copy = Array.isArray(root) ? [...root] : { ...root };
+  const record = copy as Record<string, unknown>;
+  record[key] = rest.length === 0 ? value : replacePath(record[key], rest, value);
+  return copy;
+}
+
+function cloneCredentialInput(value: unknown): unknown {
+  return isSecretRef(value) ? { ...value } : value;
+}
+
+function omitBrokeredSecrets(
+  config: OpenClawConfig | undefined,
+  pluginId: string,
+  paths: readonly string[],
+): OpenClawConfig | undefined {
+  let safeConfig: unknown = config;
+  for (const path of paths) {
+    safeConfig = omitPath(safeConfig, [
+      "plugins",
+      "entries",
+      pluginId,
+      "config",
+      ...path.split("."),
+    ]);
+  }
+  return safeConfig as OpenClawConfig | undefined;
+}
+
+type CredentialBrokerManifestPlugin = {
+  id: string;
+  credentialBroker?: {
+    operations: readonly PluginManifestCredentialBrokerOperation[];
+  };
+};
+
+export function hasConfiguredBrokeredSecretInputs(params: {
+  sourceConfig: OpenClawConfig;
+  plugins: readonly CredentialBrokerManifestPlugin[];
+}): boolean {
+  return params.plugins.some((plugin) =>
+    plugin.credentialBroker?.operations.some((operation) =>
+      hasOperationSecretRef({
+        config: params.sourceConfig,
+        pluginId: plugin.id,
+        operation,
+      }),
+    ),
+  );
+}
+
+/** Lists manifest tools whose credential input is an active structured SecretRef. */
+export function listConfiguredBrokeredToolNames(params: {
+  sourceConfig: OpenClawConfig;
+  plugin: CredentialBrokerManifestPlugin;
+}): string[] {
+  return (params.plugin.credentialBroker?.operations ?? [])
+    .filter((operation) =>
+      hasOperationSecretRef({
+        config: params.sourceConfig,
+        pluginId: params.plugin.id,
+        operation,
+      }),
+    )
+    .map((operation) => operation.tool);
+}
+
+/** Removes every configured broker-owned secret before a plugin API can capture config. */
+export function omitConfiguredBrokeredSecretInputs(params: {
+  config: OpenClawConfig;
+  sourceConfig: OpenClawConfig;
+  plugins: readonly CredentialBrokerManifestPlugin[];
+}): OpenClawConfig {
+  let safeConfig: OpenClawConfig | undefined = params.config;
+  for (const plugin of params.plugins) {
+    const paths = (plugin.credentialBroker?.operations ?? [])
+      .filter((operation) =>
+        hasOperationSecretRef({
+          config: params.sourceConfig,
+          pluginId: plugin.id,
+          operation,
+        }),
+      )
+      .map((operation) => operation.secretInputPath);
+    safeConfig = omitBrokeredSecrets(safeConfig, plugin.id, paths);
+  }
+  return safeConfig ?? params.config;
+}
+
+/** Restores opaque SecretRefs before tool-discovery plugin APIs capture resolved config. */
+export function projectConfiguredBrokeredSecretInputs(params: {
+  config: OpenClawConfig;
+  sourceConfig: OpenClawConfig;
+  plugins: readonly CredentialBrokerManifestPlugin[];
+}): OpenClawConfig {
+  let safeConfig: unknown = params.config;
+  for (const plugin of params.plugins) {
+    for (const operation of plugin.credentialBroker?.operations ?? []) {
+      if (
+        !hasOperationSecretRef({
+          config: params.sourceConfig,
+          pluginId: plugin.id,
+          operation,
+        })
+      ) {
+        continue;
+      }
+      const sourceValue = readPath(
+        readPluginConfig(params.sourceConfig, plugin.id),
+        operation.secretInputPath,
+      );
+      safeConfig = replacePath(
+        safeConfig,
+        ["plugins", "entries", plugin.id, "config", ...operation.secretInputPath.split(".")],
+        cloneCredentialInput(sourceValue),
+      );
+    }
+  }
+  return safeConfig as OpenClawConfig;
+}
+
+/** Keeps broker-owned credential inputs on their prepared view while other config stays live. */
+export function createCredentialBrokerSafeConfigGetter(params: {
+  getRuntimeConfig?: () => OpenClawConfig | undefined;
+  preparedConfig: OpenClawConfig;
+  plugins: readonly CredentialBrokerManifestPlugin[];
+}): () => OpenClawConfig {
+  return () => {
+    let safeConfig: unknown = params.getRuntimeConfig?.() ?? params.preparedConfig;
+    for (const plugin of params.plugins) {
+      for (const operation of plugin.credentialBroker?.operations ?? []) {
+        const path = [
+          "plugins",
+          "entries",
+          plugin.id,
+          "config",
+          ...operation.secretInputPath.split("."),
+        ];
+        const preparedValue = readPath(
+          readPluginConfig(params.preparedConfig, plugin.id),
+          operation.secretInputPath,
+        );
+        safeConfig =
+          preparedValue === undefined
+            ? omitPath(safeConfig, path)
+            : replacePath(safeConfig, path, cloneCredentialInput(preparedValue));
+      }
+    }
+    return safeConfig as OpenClawConfig;
+  };
+}
+
+function hasOperationSecretRef(params: {
+  config: OpenClawConfig;
+  pluginId: string;
+  operation: PluginManifestCredentialBrokerOperation;
+}): boolean {
+  const value = readPath(
+    readPluginConfig(params.config, params.pluginId),
+    params.operation.secretInputPath,
+  );
+  return isSecretRef(value) && isValidSecretRef(value);
+}
+
+function readOperationCredential(params: {
+  config: OpenClawConfig;
+  pluginId: string;
+  operation: PluginManifestCredentialBrokerOperation;
+}): string | undefined {
+  const value = readPath(
+    readPluginConfig(params.config, params.pluginId),
+    params.operation.secretInputPath,
+  );
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function hasExplicitScopedGrant(params: {
+  pluginId: string;
+  tool: string;
+  defaultToolNames: readonly string[];
+  profile: ResolvedConversationCapabilityProfile;
+}): boolean {
+  const explicitAllowlist = params.profile.policy.explicitToolAllowlist;
+  const isDefaultTool = params.defaultToolNames.some(
+    (toolName) => normalizeToolName(toolName) === normalizeToolName(params.tool),
+  );
+  const selectsDefaultPluginTools =
+    explicitAllowlist.length === 0 ||
+    explicitAllowlist.some(
+      (entry) => normalizeToolName(entry) === DEFAULT_PLUGIN_TOOLS_ALLOWLIST_ENTRY,
+    );
+  // The normal tool pipeline includes non-optional plugin tools when no
+  // restrictive allowlist applies. Preserve that prepared, scoped selection.
+  if (isDefaultTool && selectsDefaultPluginTools) {
+    return true;
+  }
+  const raw = explicitAllowlist.filter(
+    (entry) => normalizeToolName(entry) !== DEFAULT_PLUGIN_TOOLS_ALLOWLIST_ENTRY,
+  );
+  raw.push(
+    ...(params.profile.policy.profileAlsoAllow ?? []),
+    ...(params.profile.policy.providerProfileAlsoAllow ?? []),
+  );
+  if (raw.length === 0) {
+    return false;
+  }
+  const tool = normalizeToolName(params.tool);
+  return isToolAllowedByPolicyName(
+    tool,
+    expandPolicyWithPluginGroups({ allow: raw }, buildOperationToolGroups(params.pluginId, tool)),
+  );
+}
+
+function buildOperationToolGroups(pluginId: string, tool: string): PluginToolGroups {
+  return {
+    all: [tool],
+    byPlugin: new Map([[normalizeToolName(pluginId), [tool]]]),
+  };
+}
+
+function isAllowedByScopedPolicies(params: {
+  pluginId: string;
+  tool: string;
+  profile: ResolvedConversationCapabilityProfile;
+}): boolean {
+  const tool = normalizeToolName(params.tool);
+  const groups = buildOperationToolGroups(params.pluginId, tool);
+  const [profilePolicy, providerProfilePolicy, ...remainingPolicies] =
+    params.profile.policy.inheritancePolicies;
+  const policies = [
+    mergeAlsoAllowPolicy(profilePolicy, params.profile.policy.profileAlsoAllow),
+    mergeAlsoAllowPolicy(providerProfilePolicy, params.profile.policy.providerProfileAlsoAllow),
+    ...remainingPolicies,
+  ].map((policy) => expandPolicyWithPluginGroups(policy, groups));
+  return isToolAllowedByPolicies(tool, policies);
+}
+
+export function hasPreparedCredentialBrokerScope(
+  profile: ResolvedConversationCapabilityProfile,
+): boolean {
+  return Boolean(
+    profile.serviceIdentity?.agentId &&
+    profile.conversation?.sessionKey &&
+    (profile.conversation.messageChannel ?? profile.conversation.messageProvider) &&
+    profile.sender?.id,
+  );
+}
+
+function assertPreparedScope(params: {
+  pluginId: string;
+  operation: PluginManifestCredentialBrokerOperation;
+  registrationToolNames: readonly string[];
+  defaultToolNames: readonly string[];
+  profile: ResolvedConversationCapabilityProfile;
+}): void {
+  const { profile, operation } = params;
+  const registered = params.registrationToolNames.some(
+    (name) => normalizeToolName(name) === normalizeToolName(operation.tool),
+  );
+  if (!registered) {
+    throw new Error("Credential broker denied an undeclared tool operation.");
+  }
+  if (!hasPreparedCredentialBrokerScope(profile)) {
+    throw new Error(
+      "Credential broker requires prepared agent, conversation, channel, and sender scope.",
+    );
+  }
+  if (
+    !hasExplicitScopedGrant({
+      pluginId: params.pluginId,
+      tool: operation.tool,
+      defaultToolNames: params.defaultToolNames,
+      profile,
+    }) ||
+    !isAllowedByScopedPolicies({
+      pluginId: params.pluginId,
+      tool: operation.tool,
+      profile,
+    })
+  ) {
+    throw new Error("Credential broker denied this conversation capability profile.");
+  }
+}
+
+function resolveDestination(params: {
+  config: OpenClawConfig;
+  pluginId: string;
+  operation: PluginManifestCredentialBrokerOperation;
+  env: NodeJS.ProcessEnv;
+}): string {
+  const pluginConfig = readPluginConfig(params.config, params.pluginId);
+  const configuredBaseUrl = params.operation.baseUrlConfigPath
+    ? readPath(pluginConfig, params.operation.baseUrlConfigPath)
+    : undefined;
+  const configuredBaseUrlValue =
+    typeof configuredBaseUrl === "string" && configuredBaseUrl.trim()
+      ? configuredBaseUrl.trim()
+      : undefined;
+  const environmentBaseUrl = params.operation.baseUrlEnv
+    ? params.env[params.operation.baseUrlEnv]?.trim()
+    : undefined;
+  const baseUrl = configuredBaseUrlValue || environmentBaseUrl || params.operation.defaultBaseUrl;
+  let url: URL;
+  try {
+    url = new URL(baseUrl);
+  } catch {
+    throw new Error("Credential broker destination is invalid.");
+  }
+  if (url.protocol !== "https:" || url.username || url.password || url.search || url.hash) {
+    throw new Error("Credential broker destination must be a credential-free HTTPS base URL.");
+  }
+  url.pathname = `${url.pathname.replace(/\/$/u, "")}${params.operation.path}`;
+  return url.toString();
+}
+
+function parseJsonSecret(secret: string): { value: unknown } | undefined {
+  try {
+    return { value: JSON.parse(secret) as unknown };
+  } catch {
+    return undefined;
+  }
+}
+
+function replaceExactSecret(value: unknown, secret: string): unknown {
+  return replaceExactSecretValue(value, secret, parseJsonSecret(secret), new WeakSet());
+}
+
+function replaceExactSecretValue(
+  value: unknown,
+  secret: string,
+  jsonSecret: { value: unknown } | undefined,
+  seen: WeakSet<object>,
+): unknown {
+  if (jsonSecret && isDeepStrictEqual(value, jsonSecret.value)) {
+    return REDACTED_VALUE;
+  }
+  if (typeof value === "string") {
+    return value.includes(secret) ? value.replaceAll(secret, REDACTED_VALUE) : value;
+  }
+  const matchesScalar = (value === null || typeof value === "boolean") && String(value) === secret;
+  const matchesNumber = typeof value === "number" && String(value) === secret;
+  if (matchesScalar || matchesNumber) {
+    return REDACTED_VALUE;
+  }
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+  if (seen.has(value)) {
+    return "[Circular]";
+  }
+  seen.add(value);
+  if (Array.isArray(value)) {
+    const result = value.map((entry) => replaceExactSecretValue(entry, secret, jsonSecret, seen));
+    seen.delete(value);
+    return result;
+  }
+  if (!isRecord(value)) {
+    seen.delete(value);
+    return value;
+  }
+  const result: Record<string, unknown> = Object.create(null);
+  for (const [key, entry] of Object.entries(value)) {
+    const redactedKey = key.includes(secret) ? key.replaceAll(secret, REDACTED_VALUE) : key;
+    result[redactedKey] = replaceExactSecretValue(entry, secret, jsonSecret, seen);
+  }
+  seen.delete(value);
+  return result;
+}
+
+async function executeOperation(params: {
+  pluginId: string;
+  operation: PluginManifestCredentialBrokerOperation;
+  sourceConfig: OpenClawConfig;
+  runtimeConfig: OpenClawConfig;
+  body: string;
+  signal?: AbortSignal;
+  deps: CredentialBrokerDeps;
+}): Promise<BrokeredCredentialJsonResponse> {
+  const destination = resolveDestination({
+    config: params.sourceConfig,
+    pluginId: params.pluginId,
+    operation: params.operation,
+    env: params.deps.env,
+  });
+  const credential = readOperationCredential({
+    config: params.runtimeConfig,
+    pluginId: params.pluginId,
+    operation: params.operation,
+  });
+  if (!credential) {
+    throw new Error("Credential broker could not resolve operation credentials.");
+  }
+
+  let headers: Headers;
+  try {
+    headers = new Headers(params.operation.headers);
+    headers.set("Content-Type", "application/json");
+    headers.set(
+      params.operation.credentialHeader,
+      params.operation.credentialScheme
+        ? `${params.operation.credentialScheme} ${credential}`
+        : credential,
+    );
+  } catch {
+    throw new Error("Credential broker could not prepare operation credentials.");
+  }
+
+  try {
+    return await params.deps.withTrustedWebToolsEndpoint(
+      {
+        url: destination,
+        requireHttps: true,
+        maxRedirects: 0,
+        capture: false,
+        auditContext: `credential-broker:${params.pluginId}:${params.operation.id}`,
+        timeoutMs: params.operation.timeoutMs,
+        signal: params.signal,
+        init: {
+          method: params.operation.method,
+          headers,
+          body: params.body,
+        },
+      },
+      async ({ response }) => {
+        if (!response.ok) {
+          void response.body?.cancel();
+          throw new CredentialBrokerOperationError(
+            `Credential broker request failed with status ${response.status}.`,
+          );
+        }
+        let bytes: Buffer;
+        try {
+          bytes = await readResponseWithLimit(response, params.operation.maxResponseBodyBytes);
+        } catch {
+          throw new CredentialBrokerOperationError(
+            "Credential broker response exceeded its declared limit.",
+          );
+        }
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(new TextDecoder().decode(bytes)) as unknown;
+        } catch {
+          throw new CredentialBrokerOperationError("Credential broker received malformed JSON.");
+        }
+        return {
+          status: response.status,
+          body: replaceExactSecret(parsed, credential),
+        };
+      },
+    );
+  } catch (error) {
+    if (error instanceof CredentialBrokerOperationError) {
+      throw error;
+    }
+    throw new Error("Credential broker request failed before receiving a response.");
+  }
+}
+
+export function createCredentialBrokerClient(params: {
+  pluginId: string;
+  operations: readonly PluginManifestCredentialBrokerOperation[];
+  registrationToolNames: readonly string[];
+  defaultToolNames: readonly string[];
+  context: CredentialBrokerContext;
+  deps?: Partial<CredentialBrokerDeps>;
+}): OpenClawCredentialBroker {
+  const deps = { ...defaultDeps, ...params.deps };
+  const operations = new Map(params.operations.map((operation) => [operation.id, operation]));
+
+  return {
+    isConfigured(operationId) {
+      const operation = operations.get(operationId);
+      return Boolean(
+        operation &&
+        hasOperationSecretRef({
+          config: params.context.sourceConfig,
+          pluginId: params.pluginId,
+          operation,
+        }),
+      );
+    },
+    createRequest({ operationId, body }) {
+      const operation = operations.get(operationId);
+      if (!operation) {
+        throw new Error("Credential broker operation is not declared.");
+      }
+      assertPreparedScope({
+        pluginId: params.pluginId,
+        operation,
+        registrationToolNames: params.registrationToolNames,
+        defaultToolNames: params.defaultToolNames,
+        profile: params.context.profile,
+      });
+      const hasSecretRef = hasOperationSecretRef({
+        config: params.context.sourceConfig,
+        pluginId: params.pluginId,
+        operation,
+      });
+      if (!hasSecretRef) {
+        throw new Error("Credential broker operation has no configured SecretRef.");
+      }
+      const runtimeConfig = params.context.runtimeConfig;
+      if (!runtimeConfig) {
+        throw new Error("Credential broker requires a paired runtime credential snapshot.");
+      }
+      let serializedBody: string | undefined;
+      try {
+        serializedBody = JSON.stringify(body);
+      } catch {
+        throw new Error("Credential broker request body must be JSON serializable.");
+      }
+      if (typeof serializedBody !== "string") {
+        throw new Error("Credential broker request body must be JSON serializable.");
+      }
+      if (Buffer.byteLength(serializedBody) > operation.maxRequestBodyBytes) {
+        throw new Error("Credential broker request body exceeds its declared limit.");
+      }
+
+      const id = deps.randomUUID();
+      const expiresAtMs = deps.now() + REQUEST_HANDLE_TTL_MS;
+      let state: BrokeredCredentialRequestHandleSnapshot["state"] = "pending";
+      const snapshot = (): BrokeredCredentialRequestHandleSnapshot => ({
+        id,
+        operationId,
+        expiresAtMs,
+        state,
+      });
+      const handle: BrokeredCredentialRequestHandle = {
+        id,
+        operationId,
+        expiresAtMs,
+        async execute(options) {
+          if (state === "revoked") {
+            throw new Error("Credential broker request handle was revoked.");
+          }
+          if (state !== "pending") {
+            throw new Error("Credential broker request handle was already consumed.");
+          }
+          if (deps.now() >= expiresAtMs) {
+            state = "revoked";
+            throw new Error("Credential broker request handle expired.");
+          }
+          state = "running";
+          try {
+            return await executeOperation({
+              pluginId: params.pluginId,
+              operation,
+              sourceConfig: params.context.sourceConfig,
+              runtimeConfig,
+              body: serializedBody,
+              signal: options?.signal,
+              deps,
+            });
+          } finally {
+            state = "consumed";
+          }
+        },
+        revoke() {
+          if (state === "pending") {
+            state = "revoked";
+          }
+        },
+        toJSON: snapshot,
+      };
+      return handle;
+    },
+  };
+}
+
+/** Removes broker-owned credential inputs from the plugin-visible config snapshots. */
+export function bindCredentialBrokerToToolContext(params: {
+  context: OpenClawPluginToolContext;
+  broker?: OpenClawCredentialBroker;
+  sourceConfig: OpenClawConfig;
+  pluginId: string;
+  operations: readonly PluginManifestCredentialBrokerOperation[];
+}): OpenClawPluginToolContext {
+  const secretInputPaths = params.operations
+    .filter((operation) =>
+      hasOperationSecretRef({
+        config: params.sourceConfig,
+        pluginId: params.pluginId,
+        operation,
+      }),
+    )
+    .map((operation) => operation.secretInputPath);
+  const configuredOperationIds = new Set(
+    params.operations
+      .filter((operation) => secretInputPaths.includes(operation.secretInputPath))
+      .map((operation) => operation.id),
+  );
+  // Preserve the configured-broker signal on control-plane paths that lack conversation scope.
+  // Otherwise a plugin could mistake the scrubbed config for literal/env fallback authorization.
+  const credentialBroker: OpenClawCredentialBroker | undefined =
+    params.broker ??
+    (configuredOperationIds.size > 0
+      ? {
+          isConfigured: (operationId) => configuredOperationIds.has(operationId),
+          createRequest: () => {
+            throw new Error(
+              "Credential broker requires a prepared conversation capability profile.",
+            );
+          },
+        }
+      : undefined);
+  const getRuntimeConfig = params.context.getRuntimeConfig;
+  const config = omitBrokeredSecrets(params.context.config, params.pluginId, secretInputPaths);
+  const runtimeConfig = omitBrokeredSecrets(
+    params.context.runtimeConfig,
+    params.pluginId,
+    secretInputPaths,
+  );
+  const preparedConfig = runtimeConfig ?? config;
+  const safeConfigGetter =
+    getRuntimeConfig && preparedConfig
+      ? createCredentialBrokerSafeConfigGetter({
+          getRuntimeConfig,
+          preparedConfig,
+          plugins: [
+            {
+              id: params.pluginId,
+              credentialBroker: { operations: params.operations },
+            },
+          ],
+        })
+      : undefined;
+  return {
+    ...params.context,
+    config,
+    runtimeConfig,
+    ...(safeConfigGetter ? { getRuntimeConfig: safeConfigGetter } : {}),
+    ...(credentialBroker ? { credentialBroker } : {}),
+  };
+}

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -35,6 +35,7 @@ import {
   type OpenClawPackageManifest,
   type PluginManifestActivation,
   type PluginManifestConfigContracts,
+  type PluginManifestCredentialBroker,
   type PluginManifest,
   type PluginManifestCapabilityProviderMetadata,
   type PluginManifestChannelCommandDefaults,
@@ -263,6 +264,7 @@ export type PluginManifestRecord = {
   videoGenerationProviderMetadata?: Record<string, PluginManifestCapabilityProviderMetadata>;
   musicGenerationProviderMetadata?: Record<string, PluginManifestCapabilityProviderMetadata>;
   toolMetadata?: Record<string, PluginManifestToolMetadata>;
+  credentialBroker?: PluginManifestCredentialBroker;
   configContracts?: PluginManifestConfigContracts;
   channelConfigs?: Record<string, PluginManifestChannelConfig>;
   channelCatalogMeta?: {
@@ -561,6 +563,7 @@ function buildRecord(params: {
     videoGenerationProviderMetadata: params.manifest.videoGenerationProviderMetadata,
     musicGenerationProviderMetadata: params.manifest.musicGenerationProviderMetadata,
     toolMetadata: params.manifest.toolMetadata,
+    credentialBroker: params.manifest.credentialBroker,
     configContracts: params.manifest.configContracts,
     channelConfigs,
     ...(params.candidate.packageManifest?.channel?.id

--- a/src/plugins/manifest.json5-tolerance.test.ts
+++ b/src/plugins/manifest.json5-tolerance.test.ts
@@ -200,6 +200,126 @@ describe("loadPluginManifest JSON5 tolerance", () => {
     }
   });
 
+  it("normalizes bounded credential broker operations", () => {
+    const dir = makeTempDir();
+    fs.writeFileSync(
+      path.join(dir, "openclaw.plugin.json"),
+      JSON.stringify({
+        id: "brokered-plugin",
+        contracts: { tools: ["brokered_action"] },
+        configContracts: {
+          secretInputs: { paths: [{ path: "service.token", expected: "string" }] },
+        },
+        credentialBroker: {
+          operations: [
+            {
+              id: "action",
+              tool: "brokered_action",
+              secretInputPath: "service.token",
+              baseUrlConfigPath: "service.baseUrl",
+              baseUrlEnv: "SERVICE_BASE_URL",
+              defaultBaseUrl: "https://api.example.test/v1",
+              path: "/action",
+              method: "POST",
+              credentialHeader: "authorization",
+              credentialScheme: "Bearer",
+              headers: {
+                "X-Client-Source": "openclaw",
+              },
+              maxRequestBodyBytes: 4096,
+              maxResponseBodyBytes: 8192,
+              timeoutMs: 5000,
+            },
+          ],
+        },
+        configSchema: { type: "object" },
+      }),
+      "utf-8",
+    );
+
+    const result = loadPluginManifest(dir, false);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.manifest.credentialBroker).toEqual({
+        operations: [
+          {
+            id: "action",
+            tool: "brokered_action",
+            secretInputPath: "service.token",
+            baseUrlConfigPath: "service.baseUrl",
+            baseUrlEnv: "SERVICE_BASE_URL",
+            defaultBaseUrl: "https://api.example.test/v1",
+            path: "/action",
+            method: "POST",
+            credentialHeader: "Authorization",
+            credentialScheme: "Bearer",
+            headers: { "X-Client-Source": "openclaw" },
+            maxRequestBodyBytes: 4096,
+            maxResponseBodyBytes: 8192,
+            timeoutMs: 5000,
+          },
+        ],
+      });
+    }
+  });
+
+  it("rejects the manifest when any credential broker operation is unsafe", () => {
+    const dir = makeTempDir();
+    const operation = {
+      id: "action",
+      tool: "brokered_action",
+      secretInputPath: "service.token",
+      defaultBaseUrl: "https://api.example.test",
+      path: "/action",
+      method: "POST",
+      credentialHeader: "Authorization",
+      maxRequestBodyBytes: 4096,
+      maxResponseBodyBytes: 8192,
+      timeoutMs: 5000,
+    };
+    fs.writeFileSync(
+      path.join(dir, "openclaw.plugin.json"),
+      JSON.stringify({
+        id: "unsafe-brokered-plugin",
+        contracts: { tools: ["brokered_action"] },
+        configContracts: {
+          secretInputs: { paths: [{ path: "service.token", expected: "string" }] },
+        },
+        credentialBroker: {
+          operations: [
+            operation,
+            { ...operation, id: "insecure", defaultBaseUrl: "http://api.example.test" },
+            { ...operation, id: "read", method: "GET" },
+            { ...operation, id: "cookie", credentialHeader: "Cookie" },
+            { ...operation, id: "traversal", secretInputPath: "service..token" },
+            { ...operation, id: "environment", baseUrlEnv: "unsafe-env-name" },
+            { ...operation, id: "header", headers: { Authorization: "static-secret" } },
+            {
+              ...operation,
+              id: "routing-header",
+              headers: { "X-Original-URL": "/admin" },
+            },
+            {
+              ...operation,
+              id: "method-header",
+              headers: { "X-HTTP-Method-Override": "GET" },
+            },
+          ],
+        },
+        configSchema: { type: "object" },
+      }),
+      "utf-8",
+    );
+
+    const result = loadPluginManifest(dir, false);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe("plugin manifest credentialBroker is invalid");
+    }
+  });
+
   it("still rejects completely invalid syntax", () => {
     const dir = makeTempDir();
     fs.writeFileSync(path.join(dir, "openclaw.plugin.json"), "not json at all {{{}}", "utf-8");

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -32,7 +32,23 @@ const MAX_SECRET_PROVIDER_EXEC_ARG_BYTES = 1024;
 const MAX_SECRET_PROVIDER_EXEC_TIMEOUT_MS = 120_000;
 const MAX_SECRET_PROVIDER_EXEC_OUTPUT_BYTES = 20 * 1024 * 1024;
 const MAX_SECRET_PROVIDER_EXEC_PASS_ENV = 128;
+const MAX_CREDENTIAL_BROKER_OPERATIONS = 64;
+const MAX_CREDENTIAL_BROKER_REQUEST_BYTES = 1024 * 1024;
+const MAX_CREDENTIAL_BROKER_RESPONSE_BYTES = 64 * 1024 * 1024;
+const MAX_CREDENTIAL_BROKER_TIMEOUT_MS = 120_000;
 const SECRET_PROVIDER_NODE_COMMAND_PLACEHOLDER = "${node}";
+const CREDENTIAL_BROKER_CONFIG_PATH_PATTERN = /^[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]+)*$/;
+const CREDENTIAL_BROKER_ENV_NAME_PATTERN = /^[A-Z][A-Z0-9_]{0,127}$/;
+const CREDENTIAL_BROKER_OPERATION_ID_PATTERN = /^[a-z][a-z0-9_-]{0,63}$/;
+const CREDENTIAL_BROKER_HEADER_NAME_PATTERN = /^[A-Za-z][A-Za-z0-9-]{0,63}$/;
+const CREDENTIAL_BROKER_SCHEME_PATTERN = /^[A-Za-z][A-Za-z0-9_-]{0,31}$/;
+const CREDENTIAL_BROKER_SAFE_STATIC_HEADERS = new Set([
+  "accept",
+  "accept-language",
+  "user-agent",
+  "x-client-source",
+  "x-client-version",
+]);
 
 type PluginManifestLoadCacheEntry = {
   result: PluginManifestLoadResult;
@@ -294,6 +310,27 @@ export type PluginManifestConfigContracts = {
   secretInputs?: PluginManifestSecretInputContracts;
 };
 
+export type PluginManifestCredentialBrokerOperation = {
+  id: string;
+  tool: string;
+  secretInputPath: string;
+  baseUrlConfigPath?: string;
+  baseUrlEnv?: string;
+  defaultBaseUrl: string;
+  path: string;
+  method: "POST";
+  credentialHeader: "Authorization" | "X-Api-Key";
+  credentialScheme?: string;
+  headers?: Record<string, string>;
+  maxRequestBodyBytes: number;
+  maxResponseBodyBytes: number;
+  timeoutMs: number;
+};
+
+export type PluginManifestCredentialBroker = {
+  operations: PluginManifestCredentialBrokerOperation[];
+};
+
 export type PluginManifest = {
   id: string;
   configSchema: JsonSchemaObject;
@@ -398,6 +435,8 @@ export type PluginManifest = {
   musicGenerationProviderMetadata?: Record<string, PluginManifestCapabilityProviderMetadata>;
   /** Cheap plugin-tool availability metadata without importing plugin runtime. */
   toolMetadata?: Record<string, PluginManifestToolMetadata>;
+  /** Manifest-declared credentialed operations available only through the scoped broker. */
+  credentialBroker?: PluginManifestCredentialBroker;
   /** Manifest-owned config behavior consumed by generic core helpers. */
   configContracts?: PluginManifestConfigContracts;
   channelConfigs?: Record<string, PluginManifestChannelConfig>;
@@ -839,6 +878,143 @@ function normalizePluginToolMetadata(
     }
   }
   return Object.keys(normalized).length > 0 ? normalized : undefined;
+}
+
+type CredentialBrokerHeadersNormalizationResult =
+  | { ok: true; value?: Record<string, string> }
+  | { ok: false };
+
+function normalizeCredentialBrokerHeaders(
+  value: unknown,
+): CredentialBrokerHeadersNormalizationResult {
+  if (value === undefined) {
+    return { ok: true };
+  }
+  if (!isRecord(value)) {
+    return { ok: false };
+  }
+  const headers: Record<string, string> = {};
+  for (const [rawName, rawValue] of Object.entries(value)) {
+    const name = rawName.trim();
+    if (
+      !CREDENTIAL_BROKER_HEADER_NAME_PATTERN.test(name) ||
+      !CREDENTIAL_BROKER_SAFE_STATIC_HEADERS.has(name.toLowerCase()) ||
+      typeof rawValue !== "string" ||
+      rawValue.length > 512 ||
+      /[\r\n]/u.test(rawValue)
+    ) {
+      return { ok: false };
+    }
+    headers[name] = rawValue;
+  }
+  return Object.keys(headers).length > 0 ? { ok: true, value: headers } : { ok: true };
+}
+
+type CredentialBrokerNormalizationResult =
+  | { ok: true; value?: PluginManifestCredentialBroker }
+  | { ok: false };
+
+function normalizeManifestCredentialBroker(
+  value: unknown,
+  declaredTools: ReadonlySet<string>,
+  declaredSecretInputs: ReadonlySet<string>,
+): CredentialBrokerNormalizationResult {
+  if (value === undefined) {
+    return { ok: true };
+  }
+  if (
+    !isRecord(value) ||
+    !Array.isArray(value.operations) ||
+    value.operations.length === 0 ||
+    value.operations.length > MAX_CREDENTIAL_BROKER_OPERATIONS
+  ) {
+    return { ok: false };
+  }
+  const operations: PluginManifestCredentialBrokerOperation[] = [];
+  const seen = new Set<string>();
+  for (const rawOperation of value.operations) {
+    if (!isRecord(rawOperation)) {
+      return { ok: false };
+    }
+    const id = normalizeOptionalString(rawOperation.id) ?? "";
+    const tool = normalizeOptionalString(rawOperation.tool) ?? "";
+    const secretInputPath = normalizeOptionalString(rawOperation.secretInputPath) ?? "";
+    const baseUrlConfigPath = normalizeOptionalString(rawOperation.baseUrlConfigPath);
+    const baseUrlEnv = normalizeOptionalString(rawOperation.baseUrlEnv);
+    const defaultBaseUrl = normalizeOptionalString(rawOperation.defaultBaseUrl) ?? "";
+    const pathLocal = normalizeOptionalString(rawOperation.path) ?? "";
+    const credentialHeaderRaw = normalizeOptionalString(rawOperation.credentialHeader) ?? "";
+    const credentialHeader =
+      credentialHeaderRaw.toLowerCase() === "authorization"
+        ? "Authorization"
+        : credentialHeaderRaw.toLowerCase() === "x-api-key"
+          ? "X-Api-Key"
+          : undefined;
+    const credentialScheme = normalizeOptionalString(rawOperation.credentialScheme);
+    const maxRequestBodyBytes = normalizeManifestPositiveInteger(
+      rawOperation.maxRequestBodyBytes,
+      MAX_CREDENTIAL_BROKER_REQUEST_BYTES,
+    );
+    const maxResponseBodyBytes = normalizeManifestPositiveInteger(
+      rawOperation.maxResponseBodyBytes,
+      MAX_CREDENTIAL_BROKER_RESPONSE_BYTES,
+    );
+    const timeoutMs = normalizeManifestPositiveInteger(
+      rawOperation.timeoutMs,
+      MAX_CREDENTIAL_BROKER_TIMEOUT_MS,
+    );
+    let parsedDefaultBaseUrl: URL | undefined;
+    try {
+      parsedDefaultBaseUrl = new URL(defaultBaseUrl);
+    } catch {}
+    if (
+      !CREDENTIAL_BROKER_OPERATION_ID_PATTERN.test(id) ||
+      seen.has(id) ||
+      !declaredTools.has(tool) ||
+      !declaredSecretInputs.has(secretInputPath) ||
+      !CREDENTIAL_BROKER_CONFIG_PATH_PATTERN.test(secretInputPath) ||
+      (baseUrlConfigPath && !CREDENTIAL_BROKER_CONFIG_PATH_PATTERN.test(baseUrlConfigPath)) ||
+      (baseUrlEnv && !CREDENTIAL_BROKER_ENV_NAME_PATTERN.test(baseUrlEnv)) ||
+      rawOperation.method !== "POST" ||
+      !credentialHeader ||
+      (credentialScheme && !CREDENTIAL_BROKER_SCHEME_PATTERN.test(credentialScheme)) ||
+      !parsedDefaultBaseUrl ||
+      parsedDefaultBaseUrl.protocol !== "https:" ||
+      parsedDefaultBaseUrl.username ||
+      parsedDefaultBaseUrl.password ||
+      parsedDefaultBaseUrl.search ||
+      parsedDefaultBaseUrl.hash ||
+      !pathLocal.startsWith("/") ||
+      pathLocal.startsWith("//") ||
+      !maxRequestBodyBytes ||
+      !maxResponseBodyBytes ||
+      !timeoutMs
+    ) {
+      return { ok: false };
+    }
+    seen.add(id);
+    const headers = normalizeCredentialBrokerHeaders(rawOperation.headers);
+    if (!headers.ok) {
+      return { ok: false };
+    }
+    operations.push({
+      id,
+      tool,
+      secretInputPath,
+      ...(baseUrlConfigPath ? { baseUrlConfigPath } : {}),
+      ...(baseUrlEnv ? { baseUrlEnv } : {}),
+      defaultBaseUrl: parsedDefaultBaseUrl.toString(),
+      path: pathLocal,
+      method: "POST",
+      credentialHeader,
+      ...(credentialScheme ? { credentialScheme } : {}),
+      ...(headers.value ? { headers: headers.value } : {}),
+      maxRequestBodyBytes,
+      maxResponseBodyBytes,
+      timeoutMs,
+    });
+  }
+  return { ok: true, value: { operations } };
 }
 
 function normalizeManifestContracts(value: unknown): PluginManifestContracts | undefined {
@@ -1815,6 +1991,19 @@ export function loadPluginManifest(
   );
   const toolMetadata = normalizePluginToolMetadata(raw.toolMetadata);
   const configContracts = normalizeManifestConfigContracts(raw.configContracts);
+  const credentialBrokerResult = normalizeManifestCredentialBroker(
+    raw.credentialBroker,
+    new Set(contracts?.tools ?? []),
+    new Set(configContracts?.secretInputs?.paths.map((entry) => entry.path) ?? []),
+  );
+  if (!credentialBrokerResult.ok) {
+    return cacheResult({
+      ok: false,
+      error: "plugin manifest credentialBroker is invalid",
+      manifestPath,
+    });
+  }
+  const credentialBroker = credentialBrokerResult.value;
   const channelConfigs = normalizeChannelConfigs(raw.channelConfigs);
 
   let uiHints: Record<string, PluginConfigUiHint> | undefined;
@@ -1868,6 +2057,7 @@ export function loadPluginManifest(
       videoGenerationProviderMetadata,
       musicGenerationProviderMetadata,
       toolMetadata,
+      credentialBroker,
       configContracts,
       channelConfigs,
     },

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -233,7 +233,7 @@ export function createPluginRuntime(_options: CreatePluginRuntimeOptions = {}): 
     // Sourced from the shared OpenClaw version resolver (#52899) so plugins
     // always see the same version the CLI reports, avoiding API-version drift.
     version: VERSION,
-    config: createRuntimeConfig(),
+    config: createRuntimeConfig(_options.getConfig),
     agent: createRuntimeAgent(),
     subagent: createLateBindingSubagent(
       _options.subagent,

--- a/src/plugins/runtime/runtime-config.test.ts
+++ b/src/plugins/runtime/runtime-config.test.ts
@@ -53,6 +53,25 @@ describe("createRuntimeConfig", () => {
     );
   });
 
+  it("uses a host-prepared getter for an isolated discovery runtime", () => {
+    const configSnapshot = {
+      plugins: {
+        entries: {
+          brokered: {
+            config: {
+              token: { source: "env", provider: "default", id: "BROKERED_TOKEN" },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const configApi = createRuntimeConfig(() => configSnapshot);
+
+    expect(configApi.current()).toBe(configSnapshot);
+    expect(configApi.loadConfig()).toBe(configSnapshot);
+    expect(getRuntimeConfigMock).not.toHaveBeenCalled();
+  });
+
   it("attributes deprecated loadConfig warnings to the active plugin scope", () => {
     const runtimeConfig = { plugins: { entries: {} } };
     getRuntimeConfigMock.mockReturnValue(runtimeConfig);

--- a/src/plugins/runtime/runtime-config.ts
+++ b/src/plugins/runtime/runtime-config.ts
@@ -4,6 +4,7 @@ import {
   mutateConfigFile as mutateConfigFileInternal,
   replaceConfigFile as replaceConfigFileInternal,
 } from "../../config/mutate.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logWarn } from "../../logger.js";
 import { getPluginRuntimeGatewayRequestScope } from "./gateway-request-scope.js";
 import type { PluginRuntime } from "./types.js";
@@ -49,9 +50,11 @@ export function resetRuntimeConfigDeprecationWarningStateForTest(): void {
   warnedDeprecatedConfigApis.clear();
 }
 
-export function createRuntimeConfig(): PluginRuntime["config"] {
+export function createRuntimeConfig(
+  getConfig: () => OpenClawConfig = getRuntimeConfig,
+): PluginRuntime["config"] {
   return {
-    current: getRuntimeConfig,
+    current: getConfig,
     mutateConfigFile: async (params) =>
       await mutateConfigFileInternal({
         ...params,
@@ -64,7 +67,7 @@ export function createRuntimeConfig(): PluginRuntime["config"] {
       }),
     loadConfig: () => {
       warnDeprecatedConfigApiOnce("loadConfig", "config.current()");
-      return getRuntimeConfig();
+      return getConfig();
     },
     writeConfigFile: async (cfg, options) => {
       warnDeprecatedConfigApiOnce(

--- a/src/plugins/runtime/types.ts
+++ b/src/plugins/runtime/types.ts
@@ -1,4 +1,5 @@
 // Plugin runtime types describe activated plugin capabilities exposed to core execution.
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { OperatorScope } from "../../gateway/operator-scopes.js";
 import type { PluginRuntimeCore, RuntimeLogger } from "./types-core.js";
 
@@ -102,4 +103,6 @@ export type CreatePluginRuntimeOptions = {
   subagent?: PluginRuntime["subagent"];
   nodes?: PluginRuntime["nodes"];
   allowGatewaySubagentBinding?: boolean;
+  /** Host-prepared live config view for an isolated plugin discovery runtime. */
+  getConfig?: () => OpenClawConfig;
 };

--- a/src/plugins/tool-types.ts
+++ b/src/plugins/tool-types.ts
@@ -4,6 +4,7 @@ import type { AnyAgentTool } from "../agents/tools/common.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { HookEntry } from "../hooks/types.js";
 import type { DeliveryContext } from "../utils/delivery-context.types.js";
+import type { OpenClawCredentialBroker } from "./credential-broker-types.js";
 
 export type OpenClawPluginActiveModelContext = {
   provider?: string;
@@ -48,6 +49,8 @@ export type OpenClawPluginToolContext = {
   requesterSenderId?: string;
   /** Trusted owner bit from inbound context (runtime-provided, not tool args). */
   senderIsOwner?: boolean;
+  /** Brokered operations whose declared secret inputs are removed from plugin-visible config. */
+  credentialBroker?: OpenClawCredentialBroker;
   sandboxed?: boolean;
   /**
    * True for explicit one-shot local CLI runs that must release plugin-owned

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -1,8 +1,11 @@
 // Verifies optional plugin tool registration and absence handling.
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveConversationCapabilityProfile } from "../agents/conversation-capability-profile.js";
 import { DEFAULT_PLUGIN_TOOLS_ALLOWLIST_ENTRY } from "../agents/tool-policy.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resetLogger, setLoggerOverride } from "../logging/logger.js";
 import { loggingState } from "../logging/state.js";
+import type { OpenClawCredentialBroker } from "./credential-broker-types.js";
 import { resolveInstalledPluginIndexPolicyHash } from "./installed-plugin-index-policy.js";
 
 type MockRegistryToolEntry = {
@@ -98,6 +101,11 @@ function createToolRegistry(entries: MockRegistryToolEntry[]) {
       pluginId: string;
       source: string;
       message: string;
+    }>,
+    toolMetadata: [] as Array<{
+      pluginId: string;
+      source: string;
+      metadata: { toolName: string; displayName?: string };
     }>,
   };
 }
@@ -1349,6 +1357,491 @@ describe("resolvePluginTools optional tools", () => {
     const tools = resolveOptionalDemoTools();
 
     expect(tools).toHaveLength(0);
+  });
+
+  it("injects a manifest-declared credential broker into its owning tool factory", () => {
+    const sourceConfig = {
+      ...createContext().config,
+      tools: { allow: ["brokered_action"] },
+      plugins: {
+        ...createContext().config.plugins,
+        allow: [...createContext().config.plugins.allow, "broker-demo"],
+        entries: {
+          "broker-demo": {
+            config: {
+              service: {
+                token: { source: "env", provider: "default", id: "BROKER_DEMO_TOKEN" },
+              },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const runtimeConfig = structuredClone(sourceConfig);
+    const runtimeEntry = runtimeConfig.plugins?.entries?.["broker-demo"]?.config as {
+      service?: { token?: unknown };
+    };
+    if (runtimeEntry.service) {
+      runtimeEntry.service.token = "resolved-secret-must-not-cross";
+    }
+    let credentialBroker: OpenClawCredentialBroker | undefined;
+    let factoryContext: {
+      config?: OpenClawConfig;
+      runtimeConfig?: OpenClawConfig;
+      getRuntimeConfig?: () => OpenClawConfig | undefined;
+    } = {};
+    const factory = vi.fn((rawContext: unknown) => {
+      factoryContext = rawContext as typeof factoryContext;
+      credentialBroker = (rawContext as { credentialBroker?: OpenClawCredentialBroker })
+        .credentialBroker;
+      return makeTool("brokered_action");
+    });
+    const registry = createToolRegistry([
+      {
+        pluginId: "broker-demo",
+        optional: false,
+        source: "/tmp/broker-demo.js",
+        names: ["brokered_action"],
+        factory,
+      },
+    ]);
+    const manifestPlugin = {
+      id: "broker-demo",
+      origin: "bundled",
+      enabledByDefault: true,
+      channels: [],
+      providers: [],
+      contracts: { tools: ["brokered_action"] },
+      credentialBroker: {
+        operations: [
+          {
+            id: "action",
+            tool: "brokered_action",
+            secretInputPath: "service.token",
+            defaultBaseUrl: "https://api.example.test",
+            path: "/action",
+            method: "POST",
+            credentialHeader: "Authorization",
+            maxRequestBodyBytes: 1024,
+            maxResponseBodyBytes: 1024,
+            timeoutMs: 1000,
+          },
+        ],
+      },
+    };
+    installToolManifestSnapshot({
+      config: sourceConfig as never,
+      compatibleConfigs: [runtimeConfig as never],
+      plugin: manifestPlugin,
+    });
+    const profile = resolveConversationCapabilityProfile({
+      config: sourceConfig,
+      sessionKey: "agent:main:discord:direct:alice",
+      agentId: "main",
+      messageProvider: "discord",
+      messageChannel: "discord",
+      chatType: "direct",
+      senderId: "alice",
+      workspaceDir: "/tmp",
+    });
+    loadOpenClawPluginsMock.mockReturnValue(registry);
+
+    const tools = resolvePluginTools({
+      context: {
+        ...createContext(),
+        config: runtimeConfig,
+        runtimeConfig,
+        getRuntimeConfig: () => runtimeConfig,
+      } as never,
+      runtimeRegistry: registry as never,
+      toolAllowlist: ["brokered_action"],
+      credentialBrokerContext: {
+        profile,
+        sourceConfig,
+        runtimeConfig,
+      },
+    });
+
+    expectResolvedToolNames(tools, ["brokered_action"]);
+    expect(factory).toHaveBeenCalledOnce();
+    expect(credentialBroker?.isConfigured("action")).toBe(true);
+    expect(JSON.stringify(factoryContext.config)).not.toContain("BROKER_DEMO_TOKEN");
+    expect(JSON.stringify(factoryContext.runtimeConfig)).not.toContain(
+      "resolved-secret-must-not-cross",
+    );
+    expect(JSON.stringify(factoryContext.getRuntimeConfig?.())).not.toContain(
+      "resolved-secret-must-not-cross",
+    );
+    const loaderParams = mockCallParams(loadOpenClawPluginsMock) as {
+      cache?: boolean;
+      config?: OpenClawConfig;
+      activationSourceConfig?: OpenClawConfig;
+      runtimeOptions?: { getConfig?: () => OpenClawConfig };
+    };
+    expect(loaderParams.cache).toBe(false);
+    expect(JSON.stringify(loaderParams.config)).not.toContain("resolved-secret-must-not-cross");
+    expect(JSON.stringify(loaderParams.activationSourceConfig)).not.toContain(
+      "resolved-secret-must-not-cross",
+    );
+    expect(JSON.stringify(loaderParams.runtimeOptions?.getConfig?.())).not.toContain(
+      "resolved-secret-must-not-cross",
+    );
+    expect(JSON.stringify(loaderParams.runtimeOptions?.getConfig?.())).toContain(
+      "BROKER_DEMO_TOKEN",
+    );
+
+    factory.mockClear();
+    credentialBroker = undefined;
+    resetPluginToolFactoryCache();
+    resolvePluginTools({
+      context: {
+        ...createContext(),
+        config: runtimeConfig,
+        runtimeConfig,
+      } as never,
+      toolAllowlist: ["brokered_action"],
+      credentialBrokerSourceConfig: sourceConfig,
+    });
+
+    expect(factory).toHaveBeenCalledOnce();
+    const unavailableBroker = credentialBroker as OpenClawCredentialBroker | undefined;
+    expect(unavailableBroker?.isConfigured("action")).toBe(true);
+    expect(() => unavailableBroker?.createRequest({ operationId: "action", body: {} })).toThrow(
+      "Credential broker requires a prepared conversation capability profile.",
+    );
+    expect(JSON.stringify(factoryContext.config)).not.toContain("resolved-secret-must-not-cross");
+
+    resetPluginToolFactoryCache();
+    const unscopedTools = resolvePluginTools({
+      context: {
+        ...createContext(),
+        config: runtimeConfig,
+        runtimeConfig,
+      } as never,
+      toolAllowlist: ["brokered_action"],
+      credentialBrokerSourceConfig: sourceConfig,
+      omitCredentialBrokerToolsWithoutContext: true,
+    });
+
+    expect(unscopedTools).toEqual([]);
+
+    const literalSourceConfig = structuredClone(sourceConfig);
+    const literalEntry = literalSourceConfig.plugins?.entries?.["broker-demo"]?.config as {
+      service?: { token?: unknown };
+    };
+    if (literalEntry.service) {
+      literalEntry.service.token = "literal-before-secret-ref";
+    }
+    let liveRuntimeConfig = literalSourceConfig;
+    factory.mockClear();
+    loadOpenClawPluginsMock.mockClear();
+    resetPluginToolFactoryCache();
+    installToolManifestSnapshot({
+      config: literalSourceConfig as never,
+      plugin: manifestPlugin,
+    });
+
+    resolvePluginTools({
+      context: {
+        ...createContext(),
+        config: literalSourceConfig,
+        runtimeConfig: literalSourceConfig,
+        getRuntimeConfig: () => liveRuntimeConfig,
+      } as never,
+      runtimeRegistry: registry as never,
+      toolAllowlist: ["brokered_action"],
+      credentialBrokerSourceConfig: literalSourceConfig,
+    });
+
+    const literalLoaderParams = mockCallParams(loadOpenClawPluginsMock) as {
+      cache?: boolean;
+      runtimeOptions?: { getConfig?: () => OpenClawConfig };
+    };
+    expect(literalLoaderParams.cache).toBe(false);
+    expect(JSON.stringify(literalLoaderParams.runtimeOptions?.getConfig?.())).toContain(
+      "literal-before-secret-ref",
+    );
+    const transitionedRuntimeConfig = structuredClone(runtimeConfig);
+    const transitionedEntry = transitionedRuntimeConfig.plugins?.entries?.["broker-demo"]
+      ?.config as {
+      service?: { baseUrl?: string; token?: unknown };
+    };
+    if (transitionedEntry.service) {
+      transitionedEntry.service.baseUrl = "https://next.example.test";
+    }
+    liveRuntimeConfig = transitionedRuntimeConfig;
+    expect(JSON.stringify(factoryContext.getRuntimeConfig?.())).not.toContain(
+      "resolved-secret-must-not-cross",
+    );
+    expect(JSON.stringify(factoryContext.getRuntimeConfig?.())).toContain(
+      "literal-before-secret-ref",
+    );
+    expect(JSON.stringify(factoryContext.getRuntimeConfig?.())).toContain(
+      "https://next.example.test",
+    );
+    expect(JSON.stringify(literalLoaderParams.runtimeOptions?.getConfig?.())).not.toContain(
+      "resolved-secret-must-not-cross",
+    );
+    expect(JSON.stringify(literalLoaderParams.runtimeOptions?.getConfig?.())).toContain(
+      "literal-before-secret-ref",
+    );
+    expect(JSON.stringify(literalLoaderParams.runtimeOptions?.getConfig?.())).toContain(
+      "https://next.example.test",
+    );
+  });
+
+  it("does not reuse descriptors captured before a credential becomes brokered", () => {
+    const marker = "descriptor-credential-marker";
+    const createBrokerConfig = (token: unknown) =>
+      ({
+        ...createContext().config,
+        tools: { allow: ["brokered_action"] },
+        plugins: {
+          ...createContext().config.plugins,
+          allow: [...createContext().config.plugins.allow, "broker-demo"],
+          entries: {
+            "broker-demo": { config: { service: { token } } },
+          },
+        },
+      }) as OpenClawConfig;
+    const runtimeConfig = createBrokerConfig(marker);
+    const sourceConfig = createBrokerConfig({
+      source: "env",
+      provider: "default",
+      id: "BROKER_DESCRIPTOR_TOKEN",
+    });
+    const manifestPlugin = {
+      id: "broker-demo",
+      origin: "bundled",
+      enabledByDefault: true,
+      channels: [],
+      providers: [],
+      contracts: { tools: ["brokered_action"] },
+      credentialBroker: {
+        operations: [
+          {
+            id: "action",
+            tool: "brokered_action",
+            secretInputPath: "service.token",
+            defaultBaseUrl: "https://api.example.test",
+            path: "/action",
+            method: "POST",
+            credentialHeader: "Authorization",
+            maxRequestBodyBytes: 1024,
+            maxResponseBodyBytes: 1024,
+            timeoutMs: 1000,
+          },
+        ],
+      },
+    };
+    const factory = vi.fn((rawContext: unknown) => {
+      const config = (rawContext as { config?: OpenClawConfig }).config;
+      return {
+        ...makeTool("brokered_action"),
+        description: JSON.stringify(config).includes(marker)
+          ? `brokered action ${marker}`
+          : "brokered action safe",
+      };
+    });
+    const registry = createToolRegistry([
+      {
+        pluginId: "broker-demo",
+        optional: false,
+        source: "/tmp/broker-demo.js",
+        names: ["brokered_action"],
+        factory,
+      },
+    ]);
+    loadOpenClawPluginsMock.mockReturnValue(registry);
+    installToolManifestSnapshot({ config: runtimeConfig as never, plugin: manifestPlugin });
+
+    const literalTools = resolvePluginTools({
+      context: {
+        ...createContext(),
+        config: runtimeConfig,
+        runtimeConfig,
+      } as never,
+      runtimeRegistry: registry as never,
+      toolAllowlist: ["brokered_action"],
+      credentialBrokerSourceConfig: runtimeConfig,
+    });
+    expect(literalTools[0]?.description).toContain(marker);
+    expect(factory).toHaveBeenCalledOnce();
+
+    factory.mockClear();
+    installToolManifestSnapshot({
+      config: sourceConfig as never,
+      compatibleConfigs: [runtimeConfig as never],
+      plugin: manifestPlugin,
+    });
+    const profile = resolveConversationCapabilityProfile({
+      config: sourceConfig,
+      sessionKey: "agent:main:discord:direct:alice",
+      agentId: "main",
+      messageProvider: "discord",
+      messageChannel: "discord",
+      chatType: "direct",
+      senderId: "alice",
+      workspaceDir: "/tmp",
+    });
+    const brokeredTools = resolvePluginTools({
+      context: {
+        ...createContext(),
+        config: runtimeConfig,
+        runtimeConfig,
+      } as never,
+      runtimeRegistry: registry as never,
+      toolAllowlist: ["brokered_action"],
+      credentialBrokerContext: { profile, sourceConfig, runtimeConfig },
+    });
+
+    expect(brokeredTools[0]?.description).toBe("brokered action safe");
+    expect(factory).toHaveBeenCalledOnce();
+  });
+
+  it("isolates broker owners without reloading unrelated plugin tools", () => {
+    const sourceConfig = {
+      ...createContext().config,
+      plugins: {
+        ...createContext().config.plugins,
+        allow: [...createContext().config.plugins.allow, "broker-demo", "regular-demo"],
+        entries: {
+          "broker-demo": {
+            config: {
+              service: {
+                token: { source: "env", provider: "default", id: "BROKER_DEMO_TOKEN" },
+              },
+            },
+          },
+          "regular-demo": { config: {} },
+        },
+      },
+    } as OpenClawConfig;
+    const runtimeConfig = structuredClone(sourceConfig);
+    const runtimeEntry = runtimeConfig.plugins?.entries?.["broker-demo"]?.config as {
+      service?: { token?: unknown };
+    };
+    if (runtimeEntry.service) {
+      runtimeEntry.service.token = "resolved-secret-must-not-cross";
+    }
+    const brokerManifest = {
+      id: "broker-demo",
+      origin: "bundled",
+      enabledByDefault: true,
+      channels: [],
+      providers: [],
+      contracts: { tools: ["brokered_action"] },
+      credentialBroker: {
+        operations: [
+          {
+            id: "action",
+            tool: "brokered_action",
+            secretInputPath: "service.token",
+            defaultBaseUrl: "https://api.example.test",
+            path: "/action",
+            method: "POST",
+            credentialHeader: "Authorization",
+            maxRequestBodyBytes: 1024,
+            maxResponseBodyBytes: 1024,
+            timeoutMs: 1000,
+          },
+        ],
+      },
+    };
+    installToolManifestSnapshots({
+      config: sourceConfig as never,
+      compatibleConfigs: [runtimeConfig as never],
+      plugins: [
+        brokerManifest,
+        {
+          id: "regular-demo",
+          origin: "bundled",
+          enabledByDefault: true,
+          channels: [],
+          providers: [],
+          contracts: { tools: ["regular_action"] },
+        },
+      ],
+    });
+    const activeBrokerFactory = vi.fn(() => makeTool("brokered_action"));
+    const regularFactory = vi.fn(() => makeTool("regular_action"));
+    const isolatedBrokerFactory = vi.fn(() => makeTool("brokered_action"));
+    const runtimeRegistry = createToolRegistry([
+      {
+        pluginId: "broker-demo",
+        optional: false,
+        source: "/tmp/active-broker.js",
+        names: ["brokered_action"],
+        factory: activeBrokerFactory,
+      },
+      {
+        pluginId: "regular-demo",
+        optional: false,
+        source: "/tmp/regular.js",
+        names: ["regular_action"],
+        factory: regularFactory,
+      },
+    ]);
+    runtimeRegistry.toolMetadata = [
+      {
+        pluginId: "regular-demo",
+        source: "/tmp/regular.js",
+        metadata: { toolName: "regular_action", displayName: "Regular action" },
+      },
+    ];
+    const isolatedRegistry = createToolRegistry([
+      {
+        pluginId: "broker-demo",
+        optional: false,
+        source: "/tmp/isolated-broker.js",
+        names: ["brokered_action"],
+        factory: isolatedBrokerFactory,
+      },
+    ]);
+    isolatedRegistry.toolMetadata = [
+      {
+        pluginId: "broker-demo",
+        source: "/tmp/isolated-broker.js",
+        metadata: { toolName: "brokered_action", displayName: "Brokered action" },
+      },
+    ];
+    loadOpenClawPluginsMock.mockReturnValue(isolatedRegistry);
+    setActivePluginRegistry(
+      runtimeRegistry as never,
+      "test-tool-registry",
+      "gateway-bindable",
+      "/tmp",
+    );
+    const context = {
+      ...createContext(),
+      config: runtimeConfig,
+      runtimeConfig,
+      getRuntimeConfig: () => runtimeConfig,
+    } as never;
+    const catalogRegistry = ensureStandalonePluginToolRegistryLoaded({
+      context,
+      toolAllowlist: ["brokered_action", "regular_action"],
+      credentialBrokerSourceConfig: sourceConfig,
+    });
+
+    expect(catalogRegistry?.toolMetadata?.map((entry) => entry.metadata.displayName)).toEqual([
+      "Regular action",
+      "Brokered action",
+    ]);
+    loadOpenClawPluginsMock.mockClear();
+
+    const tools = resolvePluginTools({
+      context,
+      runtimeRegistry: runtimeRegistry as never,
+      toolAllowlist: ["brokered_action", "regular_action"],
+      credentialBrokerSourceConfig: sourceConfig,
+    });
+
+    expectResolvedToolNames(tools, ["regular_action", "brokered_action"]);
+    expect(regularFactory).toHaveBeenCalledOnce();
+    expect(activeBrokerFactory).not.toHaveBeenCalled();
+    expect(isolatedBrokerFactory).toHaveBeenCalledOnce();
+    expectLoaderSelectedOnlyPluginIds(["broker-demo"]);
   });
 
   it("does not invoke named optional tool factories without a matching allowlist", () => {

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -7,9 +7,19 @@ import {
 import { compileGlobPatterns, matchesAnyGlobPattern } from "../agents/glob-pattern.js";
 import { DEFAULT_PLUGIN_TOOLS_ALLOWLIST_ENTRY, normalizeToolName } from "../agents/tool-policy.js";
 import type { AnyAgentTool } from "../agents/tools/common.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { getLoadedRuntimePluginRegistry } from "./active-runtime-registry.js";
 import { applyTestPluginDefaults, normalizePluginsConfig } from "./config-state.js";
+import {
+  bindCredentialBrokerToToolContext,
+  createCredentialBrokerSafeConfigGetter,
+  createCredentialBrokerClient,
+  hasConfiguredBrokeredSecretInputs,
+  listConfiguredBrokeredToolNames,
+  projectConfiguredBrokeredSecretInputs,
+  type CredentialBrokerContext,
+} from "./credential-broker.js";
 import type { PluginLoadOptions } from "./loader.js";
 import {
   isManifestPluginAvailableForControlPlane,
@@ -201,9 +211,39 @@ function wrapPluginToolFactoryResult(
   return isAgentTool(result) ? wrapPluginToolCallbacks(entry, result) : result;
 }
 
-function resolvePluginToolFactory(entry: PluginToolRegistration, ctx: OpenClawPluginToolContext) {
+function resolvePluginToolFactory(
+  entry: PluginToolRegistration,
+  ctx: OpenClawPluginToolContext,
+  manifestPlugin?: PluginManifestRecord,
+  credentialBrokerContext?: CredentialBrokerContext,
+  credentialBrokerSourceConfig?: OpenClawConfig,
+) {
+  const operations = manifestPlugin?.credentialBroker?.operations;
+  const credentialBroker =
+    operations && credentialBrokerContext
+      ? createCredentialBrokerClient({
+          pluginId: entry.pluginId,
+          operations,
+          registrationToolNames: entry.names.length > 0 ? entry.names : (entry.declaredNames ?? []),
+          defaultToolNames: operations
+            .map((operation) => operation.tool)
+            .filter((toolName) => !isPluginToolOptional({ entry, manifestPlugin, toolName })),
+          context: credentialBrokerContext,
+        })
+      : undefined;
+  const brokerSourceConfig = credentialBrokerSourceConfig ?? credentialBrokerContext?.sourceConfig;
+  const factoryContext =
+    operations && brokerSourceConfig
+      ? bindCredentialBrokerToToolContext({
+          context: ctx,
+          broker: credentialBroker,
+          sourceConfig: brokerSourceConfig,
+          pluginId: entry.pluginId,
+          operations,
+        })
+      : ctx;
   return runWithPluginToolScope(entry, () =>
-    wrapPluginToolFactoryResult(entry, entry.factory(ctx)),
+    wrapPluginToolFactoryResult(entry, entry.factory(factoryContext)),
   );
 }
 
@@ -382,6 +422,9 @@ function createPluginToolFactoryTiming(params: {
 function resolvePluginToolFactoryEntry(params: {
   entry: PluginToolRegistration;
   ctx: OpenClawPluginToolContext;
+  manifestPlugin?: PluginManifestRecord;
+  credentialBrokerContext?: CredentialBrokerContext;
+  credentialBrokerSourceConfig?: OpenClawConfig;
   declaredNames: string[];
   factoryTimingStartedAt: number;
   logError: (message: string) => void;
@@ -395,7 +438,13 @@ function resolvePluginToolFactoryEntry(params: {
   const factoryStartedAt = Date.now();
 
   try {
-    resolved = resolvePluginToolFactory(params.entry, params.ctx);
+    resolved = resolvePluginToolFactory(
+      params.entry,
+      params.ctx,
+      params.manifestPlugin,
+      params.credentialBrokerContext,
+      params.credentialBrokerSourceConfig,
+    );
   } catch (err) {
     failed = true;
     params.logError(`plugin tool failed (${params.entry.pluginId}): ${String(err)}`);
@@ -678,6 +727,8 @@ function createCachedDescriptorPluginTool(params: {
   ctx: OpenClawPluginToolContext;
   loadContext: ReturnType<typeof resolvePluginRuntimeLoadContext>;
   runtimeOptions: PluginLoadOptions["runtimeOptions"];
+  credentialBrokerContext?: CredentialBrokerContext;
+  credentialBrokerSourceConfig?: OpenClawConfig;
 }): AnyAgentTool {
   const { descriptor } = params.descriptor;
   const pluginId = descriptor.owner.kind === "plugin" ? descriptor.owner.pluginId : "";
@@ -697,6 +748,7 @@ function createCachedDescriptorPluginTool(params: {
       const registry = resolvePluginToolRegistry({
         loadOptions,
         onlyPluginIds: [pluginId],
+        forceStandaloneLoad: (params.plugin.credentialBroker?.operations.length ?? 0) > 0,
         retainedRegistry: cachedDescriptorRuntimeRegistries.get(params.descriptor),
         onRetainRegistry: (retainedRegistry) => {
           cachedDescriptorRuntimeRegistries.set(params.descriptor, retainedRegistry);
@@ -721,7 +773,13 @@ function createCachedDescriptorPluginTool(params: {
       const resolveCandidateTool = (
         candidate: PluginToolRegistration,
       ): AnyAgentTool | undefined => {
-        const resolved = resolvePluginToolFactory(candidate, params.ctx);
+        const resolved = resolvePluginToolFactory(
+          candidate,
+          params.ctx,
+          params.plugin,
+          params.credentialBrokerContext,
+          params.credentialBrokerSourceConfig,
+        );
         const listRaw: unknown[] = Array.isArray(resolved) ? resolved : resolved ? [resolved] : [];
         for (const toolRaw of listRaw) {
           const malformedReason = describeMalformedPluginTool(toolRaw);
@@ -781,8 +839,11 @@ function resolveCachedPluginTools(params: {
   ctx: OpenClawPluginToolContext;
   loadContext: ReturnType<typeof resolvePluginRuntimeLoadContext>;
   runtimeOptions: PluginLoadOptions["runtimeOptions"];
+  brokerRuntimeOptions: PluginLoadOptions["runtimeOptions"];
   currentRuntimeConfig?: PluginLoadOptions["config"] | null;
   configCacheKeyMemo: PluginToolDescriptorConfigCacheKeyMemo;
+  credentialBrokerContext?: CredentialBrokerContext;
+  credentialBrokerSourceConfig?: OpenClawConfig;
 }): { tools: AnyAgentTool[]; handledPluginIds: Set<string> } {
   const tools: AnyAgentTool[] = [];
   const handledPluginIds = new Set<string>();
@@ -828,6 +889,15 @@ function resolveCachedPluginTools(params: {
       continue;
     }
     if (params.existingNormalized.has(normalizeToolName(plugin.id))) {
+      continue;
+    }
+    if (
+      params.credentialBrokerSourceConfig &&
+      listConfiguredBrokeredToolNames({
+        sourceConfig: params.credentialBrokerSourceConfig,
+        plugin,
+      }).length > 0
+    ) {
       continue;
     }
     const cached = readCachedPluginToolDescriptors(
@@ -893,7 +963,12 @@ function resolveCachedPluginTools(params: {
           plugin,
           ctx: params.ctx,
           loadContext: params.loadContext,
-          runtimeOptions: params.runtimeOptions,
+          runtimeOptions:
+            (plugin.credentialBroker?.operations.length ?? 0) > 0
+              ? params.brokerRuntimeOptions
+              : params.runtimeOptions,
+          credentialBrokerContext: params.credentialBrokerContext,
+          credentialBrokerSourceConfig: params.credentialBrokerSourceConfig,
         }),
       );
     }
@@ -913,9 +988,19 @@ function resolveCachedPluginTools(params: {
 function resolvePluginToolRegistry(params: {
   loadOptions: PluginLoadOptions;
   onlyPluginIds?: readonly string[];
+  forceStandaloneLoad?: boolean;
   retainedRegistry?: PluginRegistry;
   onRetainRegistry?: (registry: PluginRegistry) => void;
 }) {
+  if (params.forceStandaloneLoad) {
+    return ensureStandaloneRuntimePluginRegistryLoaded({
+      surface: "active",
+      forceLoad: true,
+      installRegistry: false,
+      requiredPluginIds: params.onlyPluginIds,
+      loadOptions: params.loadOptions,
+    });
+  }
   const lookup = {
     env: params.loadOptions.env,
     loadOptions: params.loadOptions,
@@ -991,19 +1076,22 @@ function resolvePluginToolLoadState(params: {
   allowGatewaySubagentBinding?: boolean;
   hasAuthForProvider?: (providerId: string) => boolean;
   env?: NodeJS.ProcessEnv;
+  credentialBrokerContext?: CredentialBrokerContext;
+  credentialBrokerSourceConfig?: OpenClawConfig;
 }):
   | {
       context: ReturnType<typeof resolvePluginRuntimeLoadContext>;
       env: NodeJS.ProcessEnv;
-      loadOptions: PluginLoadOptions;
       onlyPluginIds: string[];
       runtimeOptions: PluginLoadOptions["runtimeOptions"];
+      brokerRuntimeOptions: PluginLoadOptions["runtimeOptions"];
+      brokerPluginIds: Set<string>;
       snapshot: PluginMetadataManifestView;
     }
   | undefined {
   const env = params.env ?? process.env;
   const baseConfig = applyTestPluginDefaults(params.context.config ?? {}, env);
-  const context = resolvePluginRuntimeLoadContext({
+  let context = resolvePluginRuntimeLoadContext({
     config: baseConfig,
     env,
     workspaceDir: params.context.workspaceDir,
@@ -1013,7 +1101,7 @@ function resolvePluginToolLoadState(params: {
     return undefined;
   }
 
-  const runtimeOptions = params.allowGatewaySubagentBinding
+  const baseRuntimeOptions = params.allowGatewaySubagentBinding
     ? { allowGatewaySubagentBinding: true as const }
     : undefined;
   const snapshot = loadManifestContractSnapshot({
@@ -1031,13 +1119,55 @@ function resolvePluginToolLoadState(params: {
     hasAuthForProvider: params.hasAuthForProvider,
     snapshot,
   });
-  const loadOptions = buildPluginRuntimeLoadOptions(context, {
-    activate: false,
-    toolDiscovery: true,
+  const selectedPluginIds = new Set(onlyPluginIds);
+  const selectedPlugins = snapshot.plugins.filter((plugin) => selectedPluginIds.has(plugin.id));
+  const brokerSourceConfig =
+    params.credentialBrokerSourceConfig ?? params.credentialBrokerContext?.sourceConfig;
+  const hasBrokeredSecretInputs = Boolean(
+    brokerSourceConfig &&
+    hasConfiguredBrokeredSecretInputs({
+      sourceConfig: brokerSourceConfig,
+      plugins: selectedPlugins,
+    }),
+  );
+  const brokerPlugins = selectedPlugins.filter(
+    (plugin) => (plugin.credentialBroker?.operations.length ?? 0) > 0,
+  );
+  const brokerPluginIds = new Set(brokerPlugins.map((plugin) => plugin.id));
+  if (hasBrokeredSecretInputs && brokerSourceConfig) {
+    const scrub = (config: OpenClawConfig) =>
+      projectConfiguredBrokeredSecretInputs({
+        config,
+        sourceConfig: brokerSourceConfig,
+        plugins: selectedPlugins,
+      });
+    context = {
+      ...context,
+      rawConfig: scrub(context.rawConfig),
+      config: scrub(context.config),
+      activationSourceConfig: scrub(context.activationSourceConfig),
+    };
+  }
+  const runtimeOptions = baseRuntimeOptions;
+  const brokerRuntimeOptions = brokerPlugins.length
+    ? {
+        ...baseRuntimeOptions,
+        getConfig: createCredentialBrokerSafeConfigGetter({
+          getRuntimeConfig: params.context.getRuntimeConfig,
+          preparedConfig: context.config,
+          plugins: brokerPlugins,
+        }),
+      }
+    : baseRuntimeOptions;
+  return {
+    context,
+    env,
     onlyPluginIds,
     runtimeOptions,
-  });
-  return { context, env, loadOptions, onlyPluginIds, runtimeOptions, snapshot };
+    brokerRuntimeOptions,
+    brokerPluginIds,
+    snapshot,
+  };
 }
 
 export function ensureStandalonePluginToolRegistryLoaded(params: {
@@ -1047,23 +1177,73 @@ export function ensureStandalonePluginToolRegistryLoaded(params: {
   allowGatewaySubagentBinding?: boolean;
   hasAuthForProvider?: (providerId: string) => boolean;
   env?: NodeJS.ProcessEnv;
+  credentialBrokerSourceConfig?: OpenClawConfig;
 }): PluginRegistry | undefined {
   const loadState = resolvePluginToolLoadState(params);
   if (!loadState) {
     return undefined;
   }
-  const registry = ensureStandaloneRuntimePluginRegistryLoaded({
-    surface: "channel",
-    requiredPluginIds: loadState.onlyPluginIds,
-    loadOptions: loadState.loadOptions,
-  });
-  if (registryHasScopedPluginTools(registry, loadState.onlyPluginIds)) {
-    return registry;
+  const regularPluginIds = loadState.onlyPluginIds.filter(
+    (pluginId) => !loadState.brokerPluginIds.has(pluginId),
+  );
+  const registries: Array<{ pluginIds: string[]; registry: PluginRegistry }> = [];
+  if (regularPluginIds.length > 0) {
+    const loadOptions = buildPluginRuntimeLoadOptions(loadState.context, {
+      activate: false,
+      toolDiscovery: true,
+      onlyPluginIds: regularPluginIds,
+      runtimeOptions: loadState.runtimeOptions,
+    });
+    const registry = ensureStandaloneRuntimePluginRegistryLoaded({
+      surface: "channel",
+      requiredPluginIds: regularPluginIds,
+      loadOptions,
+    });
+    const resolved = registryHasScopedPluginTools(registry, regularPluginIds)
+      ? registry
+      : resolvePluginToolRegistry({ loadOptions, onlyPluginIds: regularPluginIds });
+    if (resolved) {
+      registries.push({ pluginIds: regularPluginIds, registry: resolved });
+    }
   }
-  return resolvePluginToolRegistry({
-    loadOptions: loadState.loadOptions,
-    onlyPluginIds: loadState.onlyPluginIds,
-  });
+  const brokerPluginIds = loadState.onlyPluginIds.filter((pluginId) =>
+    loadState.brokerPluginIds.has(pluginId),
+  );
+  if (brokerPluginIds.length > 0) {
+    const loadOptions = buildPluginRuntimeLoadOptions(loadState.context, {
+      activate: false,
+      toolDiscovery: true,
+      onlyPluginIds: brokerPluginIds,
+      runtimeOptions: loadState.brokerRuntimeOptions,
+    });
+    const registry = resolvePluginToolRegistry({
+      loadOptions,
+      onlyPluginIds: brokerPluginIds,
+      forceStandaloneLoad: true,
+    });
+    if (registry) {
+      registries.push({ pluginIds: brokerPluginIds, registry });
+    }
+  }
+  if (registries.length === 0) {
+    return undefined;
+  }
+  if (registries.length === 1) {
+    return registries[0]?.registry;
+  }
+  const first = registries[0]!.registry;
+  return {
+    ...first,
+    tools: registries.flatMap(({ pluginIds, registry }) => {
+      const selected = new Set(pluginIds);
+      return registry.tools.filter((entry) => selected.has(entry.pluginId));
+    }),
+    toolMetadata: registries.flatMap(({ pluginIds, registry }) => {
+      const selected = new Set(pluginIds);
+      return (registry.toolMetadata ?? []).filter((entry) => selected.has(entry.pluginId));
+    }),
+    diagnostics: registries.flatMap(({ registry }) => registry.diagnostics),
+  };
 }
 
 export function resolvePluginTools(params: {
@@ -1076,6 +1256,9 @@ export function resolvePluginTools(params: {
   hasAuthForProvider?: (providerId: string) => boolean;
   env?: NodeJS.ProcessEnv;
   runtimeRegistry?: PluginRegistry;
+  credentialBrokerContext?: CredentialBrokerContext;
+  credentialBrokerSourceConfig?: OpenClawConfig;
+  omitCredentialBrokerToolsWithoutContext?: boolean;
 }): AnyAgentTool[] {
   // Fast path: when plugins are effectively disabled, avoid discovery/jiti entirely.
   // This matters a lot for unit tests and for tool construction hot paths.
@@ -1083,8 +1266,42 @@ export function resolvePluginTools(params: {
   if (!loadState) {
     return [];
   }
-  const { context, env, onlyPluginIds, runtimeOptions, snapshot } = loadState;
+  const {
+    context,
+    env,
+    onlyPluginIds,
+    runtimeOptions,
+    brokerRuntimeOptions,
+    brokerPluginIds,
+    snapshot,
+  } = loadState;
+  const credentialBrokerSourceConfig =
+    params.credentialBrokerSourceConfig ?? params.credentialBrokerContext?.sourceConfig;
   const tools: AnyAgentTool[] = [];
+  const finishTools = (): AnyAgentTool[] => {
+    if (
+      !params.omitCredentialBrokerToolsWithoutContext ||
+      params.credentialBrokerContext ||
+      !credentialBrokerSourceConfig
+    ) {
+      return tools;
+    }
+    const sourceConfig = credentialBrokerSourceConfig;
+    const blocked = new Set(
+      snapshot.plugins.flatMap((plugin) =>
+        listConfiguredBrokeredToolNames({ sourceConfig, plugin }).map((toolName) =>
+          buildPluginToolMetadataKey(plugin.id, normalizeToolName(toolName)),
+        ),
+      ),
+    );
+    return tools.filter((tool) => {
+      const meta = pluginToolMeta.get(tool);
+      return (
+        !meta ||
+        !blocked.has(buildPluginToolMetadataKey(meta.pluginId, normalizeToolName(tool.name)))
+      );
+    });
+  };
   const existing = params.existingToolNames ?? new Set<string>();
   const existingNormalized = new Set(Array.from(existing, (tool) => normalizeToolName(tool)));
   const allowlist = normalizeAllowlist(params.toolAllowlist);
@@ -1113,86 +1330,111 @@ export function resolvePluginTools(params: {
     ctx: params.context,
     loadContext: context,
     runtimeOptions,
+    brokerRuntimeOptions,
     currentRuntimeConfig: currentRuntimeConfigForDescriptorCache,
     configCacheKeyMemo,
+    credentialBrokerContext: params.credentialBrokerContext,
+    credentialBrokerSourceConfig,
   });
   tools.push(...cached.tools);
   const runtimePluginIds = onlyPluginIds.filter(
     (pluginId) => !cached.handledPluginIds.has(pluginId),
   );
   if (runtimePluginIds.length === 0) {
-    return tools;
+    return finishTools();
   }
-  const loadOptions = buildPluginRuntimeLoadOptions(context, {
-    activate: false,
-    toolDiscovery: true,
-    onlyPluginIds: runtimePluginIds,
-    runtimeOptions,
-  });
-  let registry = registryHasScopedPluginTools(params.runtimeRegistry, runtimePluginIds)
-    ? params.runtimeRegistry
-    : undefined;
-  if (!registry) {
-    registry = resolvePluginToolRegistry({
-      loadOptions,
-      onlyPluginIds: runtimePluginIds,
-    });
-  }
-  if (!registry) {
-    // Cold registry: path-based plugins (origin "config") registered via plugins.load.paths
-    // are not pinned to any active channel/surface registry until explicitly loaded.
-    // Trigger a standalone load so their tool factories become available, then retry.
-    try {
-      ensureStandaloneRuntimePluginRegistryLoaded({
-        surface: "channel",
-        requiredPluginIds: runtimePluginIds,
-        loadOptions,
-      });
-    } catch (error) {
-      context.logger.error(
-        `failed to cold-load plugin tool registry for plugin ids [${runtimePluginIds.join(", ")}]: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
-      );
-      throw error;
+  const regularRuntimePluginIds = runtimePluginIds.filter(
+    (pluginId) => !brokerPluginIds.has(pluginId),
+  );
+  const brokerRuntimePluginIds = runtimePluginIds.filter((pluginId) =>
+    brokerPluginIds.has(pluginId),
+  );
+  const registryScopes: Array<{ pluginIds: string[]; registry: PluginRegistry }> = [];
+  for (const scope of [
+    {
+      pluginIds: regularRuntimePluginIds,
+      runtimeOptions,
+      forceStandaloneLoad: false,
+    },
+    {
+      pluginIds: brokerRuntimePluginIds,
+      runtimeOptions: brokerRuntimeOptions,
+      forceStandaloneLoad: true,
+    },
+  ]) {
+    if (scope.pluginIds.length === 0) {
+      continue;
     }
-    registry = resolvePluginToolRegistry({
-      loadOptions,
-      onlyPluginIds: runtimePluginIds,
+    const loadOptions = buildPluginRuntimeLoadOptions(context, {
+      activate: false,
+      toolDiscovery: true,
+      onlyPluginIds: scope.pluginIds,
+      runtimeOptions: scope.runtimeOptions,
     });
+    let registry =
+      !scope.forceStandaloneLoad &&
+      registryHasScopedPluginTools(params.runtimeRegistry, scope.pluginIds)
+        ? params.runtimeRegistry
+        : resolvePluginToolRegistry({
+            loadOptions,
+            onlyPluginIds: scope.pluginIds,
+            forceStandaloneLoad: scope.forceStandaloneLoad,
+          });
+    if (!registry && !scope.forceStandaloneLoad) {
+      // Path-based plugins are not pinned until their first standalone load.
+      try {
+        ensureStandaloneRuntimePluginRegistryLoaded({
+          surface: "channel",
+          requiredPluginIds: scope.pluginIds,
+          loadOptions,
+        });
+      } catch (error) {
+        context.logger.error(
+          `failed to cold-load plugin tool registry for plugin ids [${scope.pluginIds.join(", ")}]: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+        throw error;
+      }
+      registry = resolvePluginToolRegistry({ loadOptions, onlyPluginIds: scope.pluginIds });
+    }
     if (!registry) {
       context.logger.warn(
-        `plugin tool registry still unavailable after cold load for plugin ids [${runtimePluginIds.join(
-          ", ",
-        )}]`,
+        `plugin tool registry unavailable for plugin ids [${scope.pluginIds.join(", ")}]`,
       );
-      return tools;
+      continue;
     }
+    const registryToolPluginIds = new Set(registry.tools.map((entry) => entry.pluginId));
+    for (const pluginId of scope.pluginIds) {
+      if (registryToolPluginIds.has(pluginId)) {
+        continue;
+      }
+      registry.diagnostics.push({
+        level: "warn",
+        pluginId,
+        source: "plugin-tools",
+        message: `plugin tool registry did not include selected plugin tools after cold load (${pluginId})`,
+      });
+    }
+    registryScopes.push({ pluginIds: scope.pluginIds, registry });
+  }
+  if (registryScopes.length === 0) {
+    return finishTools();
   }
 
-  const scopedPluginIds = new Set(runtimePluginIds);
-  const registryToolPluginIds = new Set(registry.tools.map((entry) => entry.pluginId));
-  const missingRegistryToolPluginIds = runtimePluginIds.filter(
-    (pluginId) => !registryToolPluginIds.has(pluginId),
-  );
-  for (const pluginId of missingRegistryToolPluginIds) {
-    registry.diagnostics.push({
-      level: "warn",
-      pluginId,
-      source: "plugin-tools",
-      message: `plugin tool registry did not include selected plugin tools after cold load (${pluginId})`,
-    });
-  }
   const blockedPlugins = new Set<string>();
   const factoryTimingStartedAt = Date.now();
   const factoryTimings: PluginToolFactoryTiming[] = [];
   const capturedDescriptorsByPluginId = new Map<string, CachedPluginToolDescriptor[]>();
   const manifestPluginsById = new Map(snapshot.plugins.map((plugin) => [plugin.id, plugin]));
 
-  for (const entry of registry.tools) {
-    if (!scopedPluginIds.has(entry.pluginId)) {
-      continue;
-    }
+  const registryEntries = registryScopes.flatMap(({ pluginIds, registry }) => {
+    const selected = new Set(pluginIds);
+    return registry.tools
+      .filter((entry) => selected.has(entry.pluginId))
+      .map((entry) => ({ entry, registry }));
+  });
+  for (const { entry, registry } of registryEntries) {
     if (denylistBlocksPlugin({ pluginId: entry.pluginId, denylist })) {
       continue;
     }
@@ -1250,6 +1492,9 @@ export function resolvePluginTools(params: {
     const factoryResult = resolvePluginToolFactoryEntry({
       entry,
       ctx: params.context,
+      manifestPlugin,
+      credentialBrokerContext: params.credentialBrokerContext,
+      credentialBrokerSourceConfig,
       declaredNames,
       factoryTimingStartedAt,
       logError: (message) => context.logger.error(message),
@@ -1414,6 +1659,15 @@ export function resolvePluginTools(params: {
     if (!manifestPlugin) {
       continue;
     }
+    if (
+      credentialBrokerSourceConfig &&
+      listConfiguredBrokeredToolNames({
+        sourceConfig: credentialBrokerSourceConfig,
+        plugin: manifestPlugin,
+      }).length > 0
+    ) {
+      continue;
+    }
     const availableToolNames = listManifestToolNamesForAvailability({
       plugin: manifestPlugin,
       toolNames: manifestPlugin.contracts?.tools ?? [],
@@ -1456,5 +1710,5 @@ export function resolvePluginTools(params: {
     }
   }
 
-  return tools;
+  return finishTools();
 }


### PR DESCRIPTION
Depends on #98536.

Closes #98549.

## What Problem This Solves

OpenClaw plugins currently need plaintext credentials in plugin-visible runtime configuration before they can perform credentialed operations. For team digital employees, that makes it difficult to grant one approved operation without also exposing the underlying secret to plugin code, tool arguments, logs, errors, events, or transcripts.

## Why This Change Was Made

This adds one manifest-declared credential broker boundary. The broker resolves a structured SecretRef only inside core, authorizes the request against the prepared agent, conversation/channel, sender, and capability profile from #98536, validates the fixed destination and request limits through the existing guarded network path, and returns a single-use opaque request handle to the owning plugin tool.

The first end-to-end consumer is the existing Tavily search/extract plugin path. Structured SecretRefs use the broker; existing literal and environment-backed configuration remains unchanged. Handles are process-local, expire after 30 seconds, are deterministically revocable and single-use, and do not survive restart. Missing scope or grant denies by default, with no plaintext fallback.

This intentionally does not add a second generic HTTP client, global environment injection, broad RBAC, a general egress policy system, or an admin UI. Those are deferred to later focused changes.

## User Impact

Operators can configure supported plugin credentials as SecretRefs and allow an approved plugin operation without delivering the plaintext credential to the model or plugin tool. Plugin authors receive a narrow opaque broker API rather than secret-resolution access.

Security-owner review remains required for the secrets documentation and broker boundary.

## Evidence

- Exact stacked base verified unchanged: `4445ec01edf2d6e7fbcfe897536b0fe131e7911d`; dependent merge-base matches.
- Final head: `d3195d00523a7bf90a3b17df0edb8c326cd6eaa8`.
- Focused local proof:
  - `node scripts/run-vitest.mjs src/auto-reply/reply/get-reply.config-override.test.ts src/agents/local-model-lean.test.ts src/agents/openclaw-tools.browser-plugin.integration.test.ts src/config/io.runtime-snapshot-write.test.ts src/auto-reply/reply/agent-runner-utils.secret-resolution.test.ts src/plugins/tools.optional.test.ts src/plugins/credential-broker.test.ts`
  - `node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.test.ts -t 'passes the loaded config plus configOverride patch to replyResolver when provided'`
  - `node scripts/run-vitest.mjs src/plugins/credential-broker.test.ts extensions/tavily/src/tavily-client.test.ts`
  - `node scripts/run-tsgo.mjs -p tsconfig.core.json --pretty false`
- Full Linux build and API proof through Crabbox on provider `blacksmith-testbox`: lease `tbx_01kwf5d3mw6wdcd94sc8prad2s`, [Actions run 28529540096](https://github.com/openclaw/openclaw/actions/runs/28529540096). Passed `pnpm build`, `plugin-sdk:api:check`, core typecheck, and 170 focused tests.
- Exact-final-head Linux proof through Crabbox on provider `blacksmith-testbox`: lease `tbx_01kwf6fzq3yzstjv4km7cj07cn`, [Actions run 28530699649](https://github.com/openclaw/openclaw/actions/runs/28530699649). Passed core typecheck and 173 focused tests, including structured JSON credential redaction.
- Fresh whole-branch autoreview against `origin/codex/scoped-access-profiles`: `gpt-5.6-sol`, xhigh, no accepted/actionable findings.
- `git diff --check` passed. No persistent runtime state, UI changes, screenshots, release changes, version bump, or changelog edit.

AI disclosure: implementation, tests, and review were assisted by Codex.

