### PR TITLE
fix(active-memory): keep recall summaries UTF-16 safe at truncation boundary

### DIFF
--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -5363,6 +5363,44 @@ describe("active-memory plugin", () => {
     expect(prependContext).not.toContain("zetalongword");
   });
 
+  it("truncates recall summaries on a UTF-16 boundary without leaking a lone surrogate", async () => {
+    const hasDanglingSurrogate = (value: string): boolean =>
+      /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/u.test(value);
+    api.pluginConfig = {
+      agents: ["main"],
+      // Minimum accepted value; contentMaxChars becomes 39, placing the emoji's
+      // surrogate pair across the cut so a raw slice would keep only its high half.
+      maxSummaryChars: 40,
+    };
+    plugin.register(api as unknown as OpenClawPluginApi);
+    const head = "a".repeat(38);
+    runEmbeddedAgent.mockImplementationOnce(async (params: { sessionFile: string }) => {
+      await writeUsableMemoryTranscript(params.sessionFile, head);
+      return {
+        payloads: [
+          {
+            text: `${head}🎉TAILWORD`,
+          },
+        ],
+      };
+    });
+
+    const result = await hooks.before_prompt_build(
+      { prompt: "recall the emoji note utf16-boundary-check", messages: [] },
+      {
+        agentId: "main",
+        trigger: "user",
+        sessionKey: "agent:main:main",
+        messageProvider: "webchat",
+      },
+    );
+
+    const prependContext = requirePrependContext(result);
+    expect(hasDanglingSurrogate(prependContext)).toBe(false);
+    expect(prependContext).toContain(`${head}…`);
+    expect(prependContext).not.toContain("TAILWORD");
+  });
+
   it("asks recall subagents to mark mutable operational facts stale unless source status is current", async () => {
     await hooks.before_prompt_build(
       { prompt: "is autonomous pickup running?", messages: [] },

--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -5401,6 +5401,40 @@ describe("active-memory plugin", () => {
     expect(prependContext).not.toContain("TAILWORD");
   });
 
+  it("keeps the old word boundary when an emoji follows whitespace at the cut", async () => {
+    api.pluginConfig = {
+      agents: ["main"],
+      maxSummaryChars: 40,
+    };
+    plugin.register(api as unknown as OpenClawPluginApi);
+    const retainedWords = `alpha beta ${"c".repeat(26)}`;
+    runEmbeddedAgent.mockImplementationOnce(async (params: { sessionFile: string }) => {
+      await writeUsableMemoryTranscript(params.sessionFile, "alpha beta");
+      return {
+        payloads: [
+          {
+            text: `${retainedWords} 🎉TAILWORD`,
+          },
+        ],
+      };
+    });
+
+    const result = await hooks.before_prompt_build(
+      { prompt: "recall the emoji note whitespace-boundary-check", messages: [] },
+      {
+        agentId: "main",
+        trigger: "user",
+        sessionKey: "agent:main:main",
+        messageProvider: "webchat",
+      },
+    );
+
+    const prependContext = requirePrependContext(result);
+    expect(prependContext).toContain(`${retainedWords}…`);
+    expect(prependContext).not.toContain("alpha beta…");
+    expect(prependContext).not.toContain("TAILWORD");
+  });
+
   it("asks recall subagents to mark mutable operational facts stale unless source status is current", async () => {
     await hooks.before_prompt_build(
       { prompt: "is autonomous pickup running?", messages: [] },

--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -37,6 +37,7 @@ import {
   uniqueStrings,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { tempWorkspace, resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
+import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 
 const DEFAULT_TIMEOUT_MS = 15_000;
 const DEFAULT_AGENT_ID = "main";
@@ -2570,7 +2571,7 @@ function truncateSummary(summary: string, maxSummaryChars: number): string {
     return ellipsis.slice(0, Math.max(0, maxSummaryChars));
   }
   const contentMaxChars = maxSummaryChars - ellipsis.length;
-  const bounded = trimmed.slice(0, contentMaxChars).trimEnd();
+  const bounded = sliceUtf16Safe(trimmed, 0, contentMaxChars).trimEnd();
   const nextChar = trimmed.charAt(contentMaxChars);
   if (!nextChar || /\s/.test(nextChar)) {
     return `${bounded}${ellipsis}`;

--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -2571,18 +2571,20 @@ function truncateSummary(summary: string, maxSummaryChars: number): string {
     return ellipsis.slice(0, Math.max(0, maxSummaryChars));
   }
   const contentMaxChars = maxSummaryChars - ellipsis.length;
-  const bounded = sliceUtf16Safe(trimmed, 0, contentMaxChars).trimEnd();
+  const bounded = trimmed.slice(0, contentMaxChars).trimEnd();
+  const safeBounded = sliceUtf16Safe(trimmed, 0, contentMaxChars).trimEnd();
   const nextChar = trimmed.charAt(contentMaxChars);
   if (!nextChar || /\s/.test(nextChar)) {
-    return `${bounded}${ellipsis}`;
+    return `${safeBounded}${ellipsis}`;
   }
 
   const lastBoundary = bounded.search(/\s\S*$/);
   if (lastBoundary > 0) {
-    return `${bounded.slice(0, lastBoundary).trimEnd()}${ellipsis}`;
+    const wordBounded = bounded.slice(0, lastBoundary).trimEnd();
+    return `${sliceUtf16Safe(wordBounded, 0).trimEnd()}${ellipsis}`;
   }
 
-  return `${bounded}${ellipsis}`;
+  return `${safeBounded}${ellipsis}`;
 }
 
 function buildMetadata(summary: string | null): string | undefined {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the active-memory recall summary that gets prepended to the agent prompt could contain a lone UTF-16 surrogate half when the summary was long enough to be truncated and an emoji (or other astral character) sat exactly on the truncation boundary. The broken half renders as a replacement character in the injected `<active_memory_plugin>` context.

## Why This Change Was Made

`truncateSummary` now preserves the old whitespace/word-boundary decision from the raw cut, but uses the existing surrogate-safe `sliceUtf16Safe` helper for the returned text. That keeps the previous word-boundary behavior while ensuring the reserved-ellipsis cut can no longer split a surrogate pair. This mirrors the recently merged tool-summary fix (#98644), which applied the same helper to the same class of user-visible truncation.

## User Impact

Recall summaries containing emoji or other astral Unicode now truncate cleanly before the split character instead of leaking a broken half-character into prompt context. Existing word-boundary truncation is preserved, including the whitespace-before-emoji boundary case raised in review.

## Evidence

Premise: `String.prototype.slice` operates on UTF-16 code units, so `slice(0, n)` where index `n` falls inside a surrogate pair keeps a dangling high surrogate. `sliceUtf16Safe` (`openclaw/plugin-sdk/text-utility-runtime`) is the existing accepted helper for this exact case and is already used by the merged tool-summary fix (#98644) and by sibling channels (Discord model picker, Feishu streaming card).

Review finding fixed: added coverage for the whitespace-before-emoji boundary. The regression drives the real `before_prompt_build` active-memory hook and verifies `alpha beta cccccccccccccccccccccccccc…` is kept instead of falling back to `alpha beta…`, while `TAILWORD` is not included.

```text
node scripts/run-vitest.mjs run extensions/active-memory/index.test.ts -t "truncates recall summaries|keeps the old word boundary"
Test Files  1 passed (1)
Tests  2 passed | 154 skipped (156)
```

Full focused active-memory test file after the revision:

```text
node scripts/run-vitest.mjs run extensions/active-memory/index.test.ts
Test Files  1 passed (1)
Tests  156 passed (156)
```

Real OpenClaw run proof: ran `pnpm openclaw agent --local --session-key agent:main:direct:proof3 --channel webchat --message "what should I remember about the emoji boundary?" --verbose on --json --timeout 60` with an isolated temporary `OPENCLAW_STATE_DIR`, active-memory enabled, `maxSummaryChars: 40`, and a local mock OpenAI-compatible provider. The recall subagent made a real `memory_get` tool call against a temporary `MEMORY.md`; the mock provider then returned the emoji-bearing recall summary `alpha beta cccccccccccccccccccccccccc 🎉TAILWORD`. The main model request contained the hidden active-memory prompt prefix after truncation:

```text
request entries: 3
recall tool call requested memory_get: true
recall tool output present: true
main prompt prefix: alpha beta cccccccccccccccccccccccccc…
main prefix has TAILWORD: false
main prefix has replacement char: false
main prefix length: 38
```

Type-check, format, and lint on the changed files:

```text
pnpm format:check -- extensions/active-memory/index.ts extensions/active-memory/index.test.ts
All matched files use the correct format.

OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs extensions/active-memory/index.ts extensions/active-memory/index.test.ts
exit 0

pnpm tsgo:extensions:test
exit 0
```

What was not tested: no external live provider credentials were used. The after-fix proof used OpenClaw's real local agent runtime, real active-memory plugin loading, a real active-memory recall subagent turn, and a local OpenAI-compatible test provider so the prompt injection behavior could be captured without sending private proof data to an external model.

AI-assisted: implemented with Cursor; all proof commands were run manually.