### PR TITLE
fix(huggingface): bound model discovery response reads

### DIFF
--- a/extensions/huggingface/models.test.ts
+++ b/extensions/huggingface/models.test.ts
@@ -25,6 +25,37 @@ function stubAbortSignalTimeout() {
   return vi.spyOn(AbortSignal, "timeout").mockReturnValue(controller.signal);
 }
 
+function makeOversizedJsonResponse(): {
+  response: Response;
+  getReadCount: () => number;
+  wasCanceled: () => boolean;
+} {
+  const chunkSize = 1024 * 1024;
+  const chunkCount = 20;
+  let readCount = 0;
+  let canceled = false;
+  return {
+    response: new Response(
+      new ReadableStream<Uint8Array>({
+        pull(controller) {
+          if (readCount >= chunkCount) {
+            controller.close();
+            return;
+          }
+          readCount += 1;
+          controller.enqueue(new Uint8Array(chunkSize));
+        },
+        cancel() {
+          canceled = true;
+        },
+      }),
+      { headers: { "Content-Type": "application/json" } },
+    ),
+    getReadCount: () => readCount,
+    wasCanceled: () => canceled,
+  };
+}
+
 afterEach(() => {
   restoreEnv("VITEST", ORIGINAL_VITEST);
   restoreEnv("NODE_ENV", ORIGINAL_NODE_ENV);
@@ -106,6 +137,23 @@ describe("huggingface models", () => {
     await discoverHuggingfaceModels("hf_test_token", Number.MAX_SAFE_INTEGER);
 
     expect(timeoutSpy).toHaveBeenCalledWith(MAX_TIMER_TIMEOUT_MS);
+  });
+
+  it("bounds oversized live discovery responses and falls back to the static catalog", async () => {
+    process.env.VITEST = "false";
+    process.env.NODE_ENV = "development";
+    stubAbortSignalTimeout();
+    const streamed = makeOversizedJsonResponse();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => streamed.response),
+    );
+
+    const models = await discoverHuggingfaceModels("hf_test_token");
+
+    expect(models.map((m) => m.id)).toEqual(HUGGINGFACE_MODEL_CATALOG.map((m) => m.id));
+    expect(streamed.wasCanceled()).toBe(true);
+    expect(streamed.getReadCount()).toBeLessThan(20);
   });
 
   describe("isHuggingfacePolicyLocked", () => {

--- a/extensions/huggingface/models.ts
+++ b/extensions/huggingface/models.ts
@@ -1,5 +1,6 @@
 // Huggingface plugin module implements models behavior.
 import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-types";
 import {
   fetchWithSsrFGuard,
@@ -165,7 +166,10 @@ export async function discoverHuggingfaceModels(
         return HUGGINGFACE_MODEL_CATALOG.map(buildHuggingfaceModelDefinition);
       }
 
-      const body = (await response.json()) as OpenAIListModelsResponse;
+      const body = await readProviderJsonResponse<OpenAIListModelsResponse>(
+        response,
+        "huggingface.model-discovery",
+      );
       const data = body?.data;
       if (!Array.isArray(data) || data.length === 0) {
         return HUGGINGFACE_MODEL_CATALOG.map(buildHuggingfaceModelDefinition);


### PR DESCRIPTION
﻿## What Problem This Solves

Fixes an issue where Hugging Face model discovery could buffer an oversized `/models` JSON response in memory when a faulty or hostile Hugging Face-compatible endpoint returned an unexpectedly large successful response body.

## Why This Change Was Made

The Hugging Face provider now reads model discovery JSON through the shared bounded provider response reader instead of calling `response.json()` directly. Overflow or malformed discovery responses still fall back to the bundled static catalog, preserving existing availability behavior while cancelling oversized response streams early.

## User Impact

Users with Hugging Face credentials keep the same model discovery behavior for normal responses. If discovery receives a bad oversized response, OpenClaw falls back to the static Hugging Face catalog instead of continuing to read the whole body into memory.

## Evidence

Before-fix proof: the new regression test failed on current implementation because `response.json()` read the oversized stream without cancelling it.

```text
$ node scripts/run-vitest.mjs extensions/huggingface/models.test.ts -- --reporter=verbose
× huggingface models > bounds oversized live discovery responses and falls back to the static catalog
  expected false to be true
```

After-fix proof:

```text
$ node scripts/run-vitest.mjs extensions/huggingface/models.test.ts -- --reporter=verbose
 Test Files  1 passed (1)
      Tests  9 passed (9)
[test] passed 1 Vitest shard
```

```text
$ node_modules\.bin\oxfmt --check extensions/huggingface/models.ts extensions/huggingface/models.test.ts
Checking formatting...

All matched files use the correct format.
```

```text
$ node_modules\.bin\oxlint --tsconfig config/tsconfig/oxlint.core.json extensions/huggingface/models.ts extensions/huggingface/models.test.ts
# passed
```

```text
$ git diff --check -- extensions/huggingface/models.ts extensions/huggingface/models.test.ts
# passed
```

```text
$ python .agents\skills\autoreview\scripts\autoreview --mode local
autoreview clean: no accepted/actionable findings reported
```

Attempted broader extension lane:

```text
$ pnpm test:extension huggingface
# timed out locally after 184s with no result; residual test-extension/vitest child processes were identified as this command and stopped.
```

AI-assisted: built with Codex. I understand the change: it replaces Hugging Face model discovery's unbounded successful JSON response read with the shared bounded provider JSON reader, while preserving the existing fallback-to-static-catalog behavior on discovery failures.
