### PR TITLE
fix(wizard): use strict setup gateway port parsing

### DIFF
--- a/src/wizard/setup.gateway-config.test.ts
+++ b/src/wizard/setup.gateway-config.test.ts
@@ -100,6 +100,42 @@ describe("configureGatewayForSetup", () => {
     expect(result.nextConfig.gateway?.nodes?.denyCommands).toContain("screen.record");
   });
 
+  it("rejects loose numeric gateway port syntax without storing a partial parse", async () => {
+    mocks.randomToken.mockReturnValue("generated-token");
+    const selectQueue = ["loopback", "token", "off"];
+    const textQueue: Array<string | undefined> = ["1e3", undefined];
+    const validationMessages: Array<string | undefined> = [];
+    const select = vi.fn(async (params: WizardSelectParams<unknown>) => {
+      const next = selectQueue.shift();
+      if (next !== undefined) {
+        return next;
+      }
+      return params.initialValue ?? params.options[0]?.value;
+    }) as unknown as WizardPrompter["select"];
+    const text = vi.fn(async (params: Parameters<WizardPrompter["text"]>[0]) => {
+      const next = textQueue.shift();
+      if (next === "1e3") {
+        validationMessages.push(params.validate?.(next));
+      }
+      return next as string;
+    }) as unknown as WizardPrompter["text"];
+    const prompter = buildWizardPrompter({ select, text });
+
+    const result = await configureGatewayForSetup({
+      flow: "advanced",
+      baseConfig: {},
+      nextConfig: {},
+      localPort: 18789,
+      quickstartGateway: createQuickstartGateway("token"),
+      prompter,
+      runtime: createRuntime(),
+    });
+
+    expect(validationMessages).toEqual(["Use a port number from 1 to 65535, for example 18789."]);
+    expect(result.nextConfig.gateway?.port).toBe(18789);
+    expect(result.nextConfig.gateway?.port).not.toBe(1);
+  });
+
   it("prefers OPENCLAW_GATEWAY_TOKEN during quickstart token setup", async () => {
     const prevToken = process.env.OPENCLAW_GATEWAY_TOKEN;
     process.env.OPENCLAW_GATEWAY_TOKEN = "token-from-env";

--- a/src/wizard/setup.gateway-config.ts
+++ b/src/wizard/setup.gateway-config.ts
@@ -20,6 +20,7 @@ import {
 } from "../gateway/gateway-config-prompts.shared.js";
 import { DEFAULT_DANGEROUS_NODE_COMMANDS } from "../gateway/node-command-policy.js";
 import { findTailscaleBinary } from "../infra/tailscale.js";
+import { parseTcpPort } from "../infra/tcp-port.js";
 import { resolveSecretInputModeForEnvSelection } from "../plugins/provider-auth-mode.js";
 import { promptSecretRefForSetup } from "../plugins/provider-auth-ref.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -62,8 +63,7 @@ function normalizeWizardTextInput(value: unknown): string {
 }
 
 function validateGatewayPortInput(value: unknown): string | undefined {
-  const port = Number(normalizeWizardTextInput(value));
-  if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+  if (parseTcpPort(value) === null) {
     return formatPortRangeHint();
   }
   return undefined;
@@ -75,19 +75,16 @@ export async function configureGatewayForSetup(
   const { flow, localPort, quickstartGateway, prompter } = opts;
   let { nextConfig } = opts;
 
-  const port =
+  const portInput =
     flow === "quickstart"
-      ? quickstartGateway.port
-      : Number.parseInt(
-          normalizeWizardTextInput(
-            await prompter.text({
-              message: t("wizard.gateway.port"),
-              initialValue: String(localPort),
-              validate: validateGatewayPortInput,
-            }),
-          ),
-          10,
-        );
+      ? undefined
+      : await prompter.text({
+          message: t("wizard.gateway.port"),
+          initialValue: String(localPort),
+          validate: validateGatewayPortInput,
+        });
+  const port =
+    flow === "quickstart" ? quickstartGateway.port : (parseTcpPort(portInput) ?? localPort);
 
   let bind: GatewayWizardSettings["bind"] =
     flow === "quickstart"


### PR DESCRIPTION
## What Problem This Solves

Manual setup accepted loose numeric gateway port syntax such as `1e3` during validation, but then persisted the prompt value with decimal `parseInt`. That combination could store `gateway.port: 1` even though the prompt had accepted the input as numeric `1000`.

Closes #98681

## Why This Change Was Made

The setup wizard now uses the existing strict TCP port parser for both validation and persistence. This keeps the manual setup path aligned with the rest of the port parsing code and removes the partial-parse behavior instead of adding another local parsing rule.

## User Impact

Users entering non-decimal or loose numeric syntax at the manual gateway port prompt now get the normal port range validation message, and the setup flow keeps the resolved local port instead of saving a truncated value.

## Summary

- Reused `parseTcpPort` in `configureGatewayForSetup` so validation and persistence share the same strict parser.
- Removed the `Number(...)` plus `parseInt(..., 10)` split that allowed `1e3` to validate but store `1`.
- Added a regression test for the exact loose numeric syntax scenario.

## Evidence

- `node_modules/.bin/oxfmt src/wizard/setup.gateway-config.ts src/wizard/setup.gateway-config.test.ts` -> finished on 2 files.
- `git diff --check` -> passed.
- `node scripts/run-vitest.mjs src/wizard/setup.gateway-config.test.ts -t "rejects loose numeric gateway port syntax" --config test/vitest/vitest.wizard.config.ts` -> passed.
- `node scripts/run-vitest.mjs src/infra/tcp-port.test.ts src/cli/shared/parse-port.test.ts src/infra/parse-finite-number.test.ts --reporter=dot` -> passed 1 Vitest shard.

## Impact Assessment

- Scope: setup wizard gateway port prompt only; production change is limited to `src/wizard/setup.gateway-config.ts`.
- Downstream: the advanced setup flow still stores a number in the existing `gateway.port` config field; quickstart keeps using `quickstartGateway.port`.
- Edge cases: absent/empty prompt returns fall back to `localPort`; malformed, decimal, exponential, zero, and out-of-range values are rejected by `parseTcpPort`.
- Hard-coded values: no new hard-coded defaults; the fallback remains the runtime-provided `localPort`.
- Existing fixes: checked for open PRs covering #98681 or the reported parser mismatch before implementing.

## Real behavior proof

**Behavior addressed:** Manual setup rejects loose numeric gateway port syntax and avoids persisting a decimal partial parse.
**Environment tested:** Local checkout on Linux with Node via `node --import tsx`.
**Steps run after the patch:** Called the actual `configureGatewayForSetup` production function from source with the reported `1e3` port prompt input.
**Evidence after fix:**

```bash
node --import tsx --no-warnings -e "import { configureGatewayForSetup } from './src/wizard/setup.gateway-config.ts'; const validationMessages = []; const quickstartGateway = { hasExisting: false, port: 18789, bind: 'loopback', authMode: 'token', tailscaleMode: 'off', tailscaleResetOnExit: false }; const prompter = { text: async (params) => { if (params.message === 'Gateway port') { validationMessages.push(params.validate?.('1e3')); return undefined; } return undefined; }, select: async (params) => params.initialValue ?? params.options[0]?.value, multiselect: async () => [], confirm: async (params) => params.initialValue ?? false, note: async () => {}, intro: async () => {}, outro: async () => {}, plain: async () => {}, progress: () => ({ update: () => {}, stop: () => {} }) }; const runtime = { log: () => {}, warn: () => {}, error: () => {}, info: () => {} }; const result = await configureGatewayForSetup({ flow: 'advanced', baseConfig: {}, nextConfig: {}, localPort: 18789, quickstartGateway, prompter, runtime }); console.log(JSON.stringify({ validationMessages, storedPort: result.nextConfig.gateway?.port, partialParseAvoided: result.nextConfig.gateway?.port !== 1 }, null, 2));"
```

Output:

```json
{
  "validationMessages": [
    "Use a port number from 1 to 65535, for example 18789."
  ],
  "storedPort": 18789,
  "partialParseAvoided": true
}
```

**Observed result:** The invalid `1e3` input produces the expected validation message, and the stored gateway port remains `18789` instead of `1`.
**Not tested:** A live terminal keypress session was not exercised; the verification directly invoked the setup production function with the same prompt value.
