### PR TITLE
fix(followup): honor suppressToolErrors for queued tool progress

### DIFF
--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -2353,6 +2353,88 @@ describe("createFollowupRunner progress forwarding", () => {
     );
   });
 
+  it("suppresses queued follow-up tool error progress in full verbose when suppressToolErrors is enabled", async () => {
+    const queued = createQueuedRun({
+      originatingChannel: "discord",
+      originatingTo: "channel:C1",
+      originatingAccountId: "acct-1",
+      originatingThreadId: "thread-1",
+      run: {
+        config: {
+          messages: {
+            suppressToolErrors: true,
+          },
+        },
+        messageProvider: "discord",
+        verboseLevel: "full",
+      },
+    });
+
+    runEmbeddedAgentMock.mockImplementationOnce(
+      async (args: {
+        onToolResult?: (payload: { text: string; isError?: boolean }) => Promise<void>;
+      }) => {
+        await args.onToolResult?.({ text: "warning: command failed", isError: true });
+        return { payloads: [{ text: "handled failure" }], meta: { agentMeta: {} } };
+      },
+    );
+
+    const runner = createFollowupRunner({
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      defaultModel: "claude",
+    });
+
+    await runner(queued);
+
+    expect(routeReplyMock).toHaveBeenCalledTimes(1);
+    expect(requireMockCallArg(routeReplyMock, 0).payload).toEqual(
+      expect.objectContaining({ text: "handled failure" }),
+    );
+    expect(requireMockCallArg(routeReplyMock, 0).replyKind).toBe("final");
+  });
+
+  it("keeps queued full-verbose tool error progress visible without suppressToolErrors", async () => {
+    const queued = createQueuedRun({
+      originatingChannel: "discord",
+      originatingTo: "channel:C1",
+      originatingAccountId: "acct-1",
+      originatingThreadId: "thread-1",
+      run: {
+        messageProvider: "discord",
+        verboseLevel: "full",
+      },
+    });
+
+    runEmbeddedAgentMock.mockImplementationOnce(
+      async (args: {
+        onToolResult?: (payload: { text: string; isError?: boolean }) => Promise<void>;
+      }) => {
+        await args.onToolResult?.({ text: "warning: command failed", isError: true });
+        return { payloads: [{ text: "handled failure" }], meta: { agentMeta: {} } };
+      },
+    );
+
+    const runner = createFollowupRunner({
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      defaultModel: "claude",
+    });
+
+    await runner(queued);
+
+    expect(routeReplyMock).toHaveBeenCalledTimes(2);
+    expect(requireMockCallArg(routeReplyMock, 0).payload).toEqual(
+      expect.objectContaining({ text: "warning: command failed", isError: true }),
+    );
+    expect(requireMockCallArg(routeReplyMock, 0).replyKind).toBe("tool");
+    expect(requireMockCallArg(routeReplyMock, 0).mirror).toBe(false);
+    expect(requireMockCallArg(routeReplyMock, 1).payload).toEqual(
+      expect.objectContaining({ text: "handled failure" }),
+    );
+    expect(requireMockCallArg(routeReplyMock, 1).replyKind).toBe("final");
+  });
+
   it("drains fire-and-forget queued tool progress before final delivery", async () => {
     const queued = createQueuedRun({
       originatingChannel: "discord",

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -932,6 +932,14 @@ export function createFollowupRunner(params: {
             // summary tracker so both runners deliver identical durable summaries.
             const deliverFollowupToolSummary = (payload: ReplyPayload) =>
               enqueueProgressDelivery(async () => {
+                // Match direct dispatch: suppressToolErrors hides tool-error
+                // summaries from channel progress, while final failure handling remains intact.
+                if (
+                  payload.isError === true &&
+                  runtimeConfig.messages?.suppressToolErrors === true
+                ) {
+                  return;
+                }
                 if (
                   run.sourceReplyDeliveryMode === "message_tool_only" &&
                   !shouldEmitToolResultProgress()


### PR DESCRIPTION
Related: pattern sweep ledger 2026-07-01 suppressToolErrors followup sibling
Related PR: #97135

## What Problem This Solves

Fixes an issue where queued follow-up turns could still send failed tool-result progress to the originating channel when `messages.suppressToolErrors` was enabled.

The direct reply path already treats `messages.suppressToolErrors` as an explicit operator opt-out for visible tool-error progress. The queued follow-up runner used a separate tool-summary delivery path, so a queued follow-up could still route an `isError: true` tool payload even in a config that requested suppression.

## Why This Change Was Made

The follow-up runner now applies the same `messages.suppressToolErrors` guard at the shared queued tool-summary delivery seam used by embedded follow-ups and CLI tool summaries. Final failure handling and non-error tool progress are left unchanged.

This is narrower than #97135's recovered-progress policy: #97135 preserves full-verbose failed diagnostics when the operator has not opted out, while this PR makes the explicit `messages.suppressToolErrors` config win even in full verbose queued follow-ups.

Risk note: this touches a config-sensitive reply path, so the regression tests cover both the enabled suppression case and the normal unsuppressed full-verbose case, including final reply delivery in both cases.

## User Impact

Users who opt into `messages.suppressToolErrors` no longer see failed tool progress leak from queued follow-up replies. Users without that setting keep the existing full-verbose failed-tool progress behavior.

## Evidence

Head: `e9859a34b9b8`

Real queued follow-up runtime proof, no Vitest mocks:

- Command shape: `PROOF_SUPPRESS=<0|1> node --import tsx /tmp/tmp.hPhEcjgcTG.mjs`
- What it drives: the real exported `createFollowupRunner`, real `runEmbeddedAgent`, and a local OpenAI-compatible mock provider. The provider returns an `exec` tool call with `{ "command": "false" }`, then a final assistant message after receiving the tool output.
- Why this is scoped proof: it exercises the queued follow-up delivery seam before channel transport, records the routed `onBlockReply` payloads, and avoids real API spend.

Suppressed runtime proof (`messages.suppressToolErrors: true`), exit 0:

```text
[provider-transport-fetch] [model-fetch] start provider=openai api=openai-responses model=gpt-5.5 method=POST url=http://127.0.0.1:45555/v1/responses
[provider-transport-fetch] [model-fetch] response provider=openai api=openai-responses model=gpt-5.5 status=200 elapsedMs=19 contentType=text/event-stream; charset=utf-8
[provider-transport-fetch] [model-fetch] start provider=openai api=openai-responses model=gpt-5.5 method=POST url=http://127.0.0.1:45555/v1/responses
[provider-transport-fetch] [model-fetch] response provider=openai api=openai-responses model=gpt-5.5 status=200 elapsedMs=11 contentType=text/event-stream; charset=utf-8
SUPPRESSED_DELIVERIES=[{"text":"🛠️ `false`","isError":false},{"text":"🛠️ `false`\n```txt\n(Command exited with code 1)\n```","isError":false},{"text":"FINAL_AFTER_FAILED_TOOL","isError":false}]
SUPPRESSED_REQUESTS=[{"names":["agents_list","apply_patch","create_goal","cron","edit","exec","gateway","get_goal"],"sawToolOutput":false},{"names":["agents_list","apply_patch","create_goal","cron","edit","exec","gateway","get_goal"],"sawToolOutput":true}]
```

Unsuppressed runtime control (`messages.suppressToolErrors` unset), exit 0:

```text
[provider-transport-fetch] [model-fetch] start provider=openai api=openai-responses model=gpt-5.5 method=POST url=http://127.0.0.1:35291/v1/responses
[provider-transport-fetch] [model-fetch] response provider=openai api=openai-responses model=gpt-5.5 status=200 elapsedMs=19 contentType=text/event-stream; charset=utf-8
[provider-transport-fetch] [model-fetch] start provider=openai api=openai-responses model=gpt-5.5 method=POST url=http://127.0.0.1:35291/v1/responses
[provider-transport-fetch] [model-fetch] response provider=openai api=openai-responses model=gpt-5.5 status=200 elapsedMs=6 contentType=text/event-stream; charset=utf-8
UNSUPPRESSED_DELIVERIES=[{"text":"🛠️ `false`","isError":false},{"text":"🛠️ `false`\n```txt\n(Command exited with code 1)\n```","isError":false},{"text":"FINAL_AFTER_FAILED_TOOL","isError":false},{"text":"⚠️ 🛠️ Exec failed: `false`: (Command exited with code 1)","isError":true}]
UNSUPPRESSED_REQUESTS=[{"names":["agents_list","apply_patch","create_goal","cron","edit","exec","gateway","get_goal"],"sawToolOutput":false},{"names":["agents_list","apply_patch","create_goal","cron","edit","exec","gateway","get_goal"],"sawToolOutput":true}]
```

Unit-level negative control, with the production guard temporarily removed and the current regression tests retained:

```text
node scripts/run-vitest.mjs src/auto-reply/reply/followup-runner.test.ts

FAIL  |auto-reply| src/auto-reply/reply/followup-runner.test.ts > createFollowupRunner progress forwarding > suppresses queued follow-up tool error progress in full verbose when suppressToolErrors is enabled
AssertionError: expected "vi.fn()" to be called 1 times, but got 2 times
src/auto-reply/reply/followup-runner.test.ts:2390:28
[negative-control] exit 1
```

After fix on head `e9859a34b9b8`:

```text
node scripts/run-vitest.mjs src/auto-reply/reply/followup-runner.test.ts

Test Files  1 passed (1)
Tests  88 passed (88)
[test] passed 1 Vitest shard in 6.69s
```

Additional local checks:

```text
pnpm exec oxfmt --write src/auto-reply/reply/followup-runner.ts src/auto-reply/reply/followup-runner.test.ts
git diff --check
.agents/skills/autoreview/scripts/autoreview --mode local

autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.67)
```

No external Discord/Telegram round trip was run; the runtime proof drives the queued follow-up seam directly with real runtime code and a local mock provider.

AI-assisted: Codex implemented the patch; the proof above was run locally in this checkout.
