### PR TITLE
fix(nostr): clear per-relay publish timeout timer to prevent dangling handles

### DIFF
--- a/extensions/nostr/src/nostr-profile.test.ts
+++ b/extensions/nostr/src/nostr-profile.test.ts
@@ -1,5 +1,5 @@
 // Nostr tests cover nostr profile plugin behavior.
-import { verifyEvent, getPublicKey } from "nostr-tools";
+import { verifyEvent, getPublicKey, type SimplePool } from "nostr-tools";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { NostrProfile } from "./config-schema.js";
 import {
@@ -8,6 +8,7 @@ import {
   contentToProfile,
   validateProfile,
   sanitizeProfileForDisplay,
+  publishProfile,
   type ProfileContent,
 } from "./nostr-profile.js";
 import { TEST_HEX_PRIVATE_KEY_BYTES } from "./test-fixtures.js";
@@ -412,5 +413,76 @@ describe("edge cases", () => {
 
     const event = createTestProfileEvent(profile);
     expect(verifyEvent(event)).toBe(true);
+  });
+});
+
+// ============================================================================
+// Profile Publishing Tests
+// ============================================================================
+
+describe("publishProfile", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function createFakePool(publishResult: unknown): SimplePool {
+    return {
+      publish: vi.fn(() => [publishResult]),
+    } as unknown as SimplePool;
+  }
+
+  it("clears the per-relay timeout timer after a successful publish", async () => {
+    const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
+    const profile: NostrProfile = { name: "test" };
+    const pool = createFakePool(Promise.resolve());
+
+    const result = await publishProfile(
+      pool,
+      TEST_HEX_PRIVATE_KEY_BYTES,
+      ["wss://relay.example"],
+      profile,
+    );
+
+    expect(result.successes).toEqual(["wss://relay.example"]);
+    expect(clearTimeoutSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears the per-relay timeout timer after a publish timeout", async () => {
+    const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
+    const profile: NostrProfile = { name: "test" };
+    const pool = createFakePool(new Promise(() => {}));
+
+    const promise = publishProfile(
+      pool,
+      TEST_HEX_PRIVATE_KEY_BYTES,
+      ["wss://relay.example"],
+      profile,
+    );
+    vi.advanceTimersByTime(6_000);
+    const result = await promise;
+
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0]?.error).toContain("timeout");
+    expect(clearTimeoutSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not add dangling timers when publishing to multiple relays", async () => {
+    vi.spyOn(globalThis, "setTimeout").mockClear();
+    const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
+    const profile: NostrProfile = { name: "test" };
+    const pool = createFakePool(Promise.resolve());
+
+    await publishProfile(
+      pool,
+      TEST_HEX_PRIVATE_KEY_BYTES,
+      ["wss://relay.a", "wss://relay.b"],
+      profile,
+    );
+
+    expect(clearTimeoutSpy).toHaveBeenCalledTimes(2);
   });
 });

--- a/extensions/nostr/src/nostr-profile.ts
+++ b/extensions/nostr/src/nostr-profile.ts
@@ -98,9 +98,10 @@ async function publishProfileEvent(
 
   // Publish to each relay in parallel with timeout
   const publishPromises = relays.map(async (relay) => {
+    let timer: ReturnType<typeof setTimeout> | undefined;
     try {
       const timeoutPromise = new Promise<never>((_, reject) => {
-        setTimeout(() => reject(new Error("timeout")), RELAY_PUBLISH_TIMEOUT_MS);
+        timer = setTimeout(() => reject(new Error("timeout")), RELAY_PUBLISH_TIMEOUT_MS);
       });
 
       await Promise.race([...pool.publish([relay], event), timeoutPromise]);
@@ -109,6 +110,10 @@ async function publishProfileEvent(
     } catch (err) {
       const errorMessage = formatErrorMessage(err);
       failures.push({ relay, error: errorMessage });
+    } finally {
+      if (timer) {
+        clearTimeout(timer);
+      }
     }
   });
 


### PR DESCRIPTION
## What Problem This Solves

Closes #98463

`publishProfileEvent` in `extensions/nostr/src/nostr-profile.ts` creates a `setTimeout` per relay to enforce `RELAY_PUBLISH_TIMEOUT_MS`, but the returned timer handle was discarded. When a relay accepted the event quickly (the common success path), the timeout callback had already been scheduled and would remain active until it fired 5 seconds later. On busy agents that publish profiles repeatedly, these dangling timers accumulate and increase memory/FD pressure.

## Why This Change Was Made

The fix saves the `setTimeout` handle and clears it in a `finally` block, so the timer is cancelled whether the publish succeeds, times out, or throws. This matches the timer lifecycle already used in sibling Nostr modules (`nostr-bus.ts` and `nostr-profile-import.ts`).

## User Impact

- Nostr profile publishing no longer leaks per-relay timer handles.
- Long-running agents with frequent profile updates see reduced stale timer accumulation.
- No behavioral change for callers: successes/failures/timeouts are still reported the same way.

## Evidence

Unit tests in `extensions/nostr/src/nostr-profile.test.ts`:

```
✓ clears the per-relay timeout timer after a successful publish
✓ clears the per-relay timeout timer after a publish timeout
✓ does not add dangling timers when publishing to multiple relays
```

Run:

```bash
node scripts/run-vitest.mjs extensions/nostr/src/nostr-profile.test.ts --run
```

Result: 34 passed.

Lint: `node scripts/run-oxlint.mjs extensions/nostr/src/nostr-profile.ts extensions/nostr/src/nostr-profile.test.ts` → exit 0.
Typecheck: `pnpm tsgo:extensions:test` → exit 0.
Build: `pnpm build` → exit 0.

## Real behavior proof

I wrote a standalone Node.js script that monkey-patches `setTimeout`/`clearTimeout` to count active "publish timeout" timers after the real exported `publishProfile()` function returns. The script runs against real Node timers (no Vitest fake timers).

**BEFORE (source fix reverted):**

```
--- success path (promise resolves fast) ---
relays: 2
successes: 2
failures: 0
active timers before call: 0
active timers after call: 2
dangling timer age: 2ms
dangling timer age: 1ms

--- timeout path (promise never resolves) ---
relays: 2
successes: 0
failures: 2
active timers before call: 0
active timers after call: 0

=== Summary ===
success path dangling timers: 2
timeout path dangling timers: 0
FAIL: dangling timers detected after publishProfile() returned
```

The leak appears only on the success path: when `pool.publish` resolves before the 5 s timeout, the old code never cleared the timer.

**AFTER (this patch):**

```
--- success path (promise resolves fast) ---
relays: 2
successes: 2
failures: 0
active timers before call: 0
active timers after call: 0

--- timeout path (promise never resolves) ---
relays: 2
successes: 0
failures: 2
active timers before call: 0
active timers after call: 0

=== Summary ===
success path dangling timers: 0
timeout path dangling timers: 0
PASS: no dangling timers detected after publishProfile() returned
```

**Negative control:** reverting only the source change while keeping the new tests makes the success-path test fail to observe a clean timer state, confirming the tests are sensitive to the fix.

- **Behavior addressed:** per-relay `setTimeout` handle created during `publishProfile` is now cleared after the race finishes.
- **Real environment tested:** Linux, Node v22.19+, local source checkout.
- **Exact steps or command run after this patch:** `node scripts/run-vitest.mjs extensions/nostr/src/nostr-profile.test.ts --run`.
- **Evidence after fix:** all 34 tests pass; standalone timer probe shows 0 dangling timers in both success and timeout paths.
- **Observed result after fix:** no active `RELAY_PUBLISH_TIMEOUT_MS` timers remain after `publishProfile` returns.
- **What was not tested:** live relay WebSocket behavior; the fix only touches local timer lifecycle and does not change relay protocol handling.

## Related issues

- #98463
