### PR TITLE
fix(google): bound OAuth token error body reads to prevent OOM

### DIFF
--- a/extensions/google/oauth.token.test.ts
+++ b/extensions/google/oauth.token.test.ts
@@ -1,0 +1,238 @@
+// Google tests cover oauth.token error body boundary behavior.
+import { createServer, type Server } from "node:http";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { exchangeCodeForTokens, refreshTokensForGeminiCli } from "./oauth.token.js";
+
+const GOOGLE_OAUTH_ERROR_BODY_MAX_BYTES = 8 * 1024;
+const STREAM_CHUNK = Buffer.alloc(4 * 1024, "x");
+const STREAM_BODY_BYTES = 1024 * 1024;
+
+const { mockFetchWithTimeout } = vi.hoisted(() => ({
+  mockFetchWithTimeout: vi.fn(),
+}));
+
+vi.mock("./oauth.http.js", () => ({
+  fetchWithTimeout: mockFetchWithTimeout,
+}));
+
+vi.mock("./oauth.credentials.js", () => ({
+  resolveOAuthClientConfig: () => ({
+    clientId: "test-client-id",
+    clientSecret: "test-client-secret",
+  }),
+}));
+
+vi.mock("./oauth.project.js", () => ({
+  resolveGoogleOAuthIdentity: async () => ({ email: "test@example.com" }),
+  resolveGooglePersonalOAuthIdentity: async () => ({ email: "test@example.com" }),
+}));
+
+async function listenLoopbackServer(server: Server): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("expected loopback TCP address"));
+        return;
+      }
+      resolve(address.port);
+    });
+  });
+}
+
+async function closeServer(server: Server): Promise<void> {
+  server.closeAllConnections();
+  await new Promise<void>((resolve) => {
+    server.close(() => resolve());
+  });
+}
+
+describe("requestTokenGrant bounded error reads", () => {
+  let server: Server;
+  let baseUrl: string;
+  let streamClosed: Promise<void>;
+  let resolveStreamClosed: () => void;
+  let streamCompleted: boolean;
+
+  beforeEach(() => {
+    vi.useRealTimers();
+    mockFetchWithTimeout.mockReset();
+    vi.stubEnv("GOOGLE_CLIENT_ID", "test-client-id");
+    vi.stubEnv("GOOGLE_CLIENT_SECRET", "test-client-secret");
+    for (const key of [
+      "ALL_PROXY",
+      "all_proxy",
+      "HTTP_PROXY",
+      "http_proxy",
+      "HTTPS_PROXY",
+      "https_proxy",
+    ]) {
+      vi.stubEnv(key, "");
+    }
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  describe("error body bounded reads via loopback HTTP server", () => {
+    beforeEach(async () => {
+      streamClosed = new Promise<void>((resolve) => {
+        resolveStreamClosed = resolve;
+      });
+      streamCompleted = false;
+
+      server = createServer((req, res) => {
+        if (req.url === "/small") {
+          res.writeHead(400, {
+            "content-type": "application/json; charset=utf-8",
+          });
+          res.end('{"error":"invalid_grant","error_description":"Bad Request"}');
+          return;
+        }
+
+        // Oversized error response
+        res.writeHead(500, {
+          "content-type": "text/html; charset=utf-8",
+        });
+        let written = 0;
+        let closed = false;
+        res.once("close", () => {
+          closed = true;
+          resolveStreamClosed();
+        });
+        const writeNext = () => {
+          if (closed) return;
+          if (written >= STREAM_BODY_BYTES) {
+            streamCompleted = true;
+            res.end();
+            return;
+          }
+          written += STREAM_CHUNK.byteLength;
+          const writeMore = () => setTimeout(writeNext, 2);
+          if (res.write(STREAM_CHUNK)) {
+            writeMore();
+          } else {
+            res.once("drain", writeMore);
+          }
+        };
+        writeNext();
+      });
+
+      const port = await listenLoopbackServer(server);
+      baseUrl = `http://127.0.0.1:${port}`;
+    });
+
+    afterEach(async () => {
+      await closeServer(server);
+    });
+
+    it("bounds oversized OAuth error body text", async () => {
+      const rawResponse = await fetch(`${baseUrl}/large`);
+      mockFetchWithTimeout.mockResolvedValue(rawResponse);
+
+      const error = await exchangeCodeForTokens("test-code", "test-verifier").catch(
+        (err: unknown) => err,
+      );
+
+      expect(error).toBeInstanceOf(Error);
+      const message = String((error as Error).message);
+      expect(message).toContain("Token exchange failed:");
+
+      // After bounded read, the stream should be cancelled before completion
+      await expect(streamClosed).resolves.toBeUndefined();
+      expect(streamCompleted).toBe(false);
+
+      console.log(
+        `[google oauth.token loopback proof] oversized path: ` +
+          `cap=${GOOGLE_OAUTH_ERROR_BODY_MAX_BYTES} ` +
+          `streamed=${STREAM_BODY_BYTES} ` +
+          `message_length=${message.length}`,
+      );
+    });
+
+    it("preserves complete small error body text within the limit", async () => {
+      const rawResponse = await fetch(`${baseUrl}/small`);
+      mockFetchWithTimeout.mockResolvedValue(rawResponse);
+
+      const error = await exchangeCodeForTokens("test-code", "test-verifier").catch(
+        (err: unknown) => err,
+      );
+
+      expect(error).toBeInstanceOf(Error);
+      const message = String((error as Error).message);
+      expect(message).toBe(
+        'Token exchange failed: {"error":"invalid_grant","error_description":"Bad Request"}',
+      );
+
+      console.log(
+        `[google oauth.token loopback proof] small body path: ` +
+          `message_length=${message.length}`,
+      );
+    });
+  });
+
+  describe("refreshTokensForGeminiCli error body bounded reads", () => {
+    beforeEach(async () => {
+      streamClosed = new Promise<void>((resolve) => {
+        resolveStreamClosed = resolve;
+      });
+      streamCompleted = false;
+
+      server = createServer((req, res) => {
+        // Oversized error response for refresh path
+        res.writeHead(503, {
+          "content-type": "text/html; charset=utf-8",
+        });
+        let written = 0;
+        let closed = false;
+        res.once("close", () => {
+          closed = true;
+          resolveStreamClosed();
+        });
+        const writeNext = () => {
+          if (closed) return;
+          if (written >= STREAM_BODY_BYTES) {
+            streamCompleted = true;
+            res.end();
+            return;
+          }
+          written += STREAM_CHUNK.byteLength;
+          const writeMore = () => setTimeout(writeNext, 2);
+          if (res.write(STREAM_CHUNK)) {
+            writeMore();
+          } else {
+            res.once("drain", writeMore);
+          }
+        };
+        writeNext();
+      });
+
+      const port = await listenLoopbackServer(server);
+      baseUrl = `http://127.0.0.1:${port}`;
+    });
+
+    afterEach(async () => {
+      await closeServer(server);
+    });
+
+    it("bounds oversized OAuth error body text during token refresh", async () => {
+      const rawResponse = await fetch(`${baseUrl}/large`);
+      mockFetchWithTimeout.mockResolvedValue(rawResponse);
+
+      const error = await refreshTokensForGeminiCli({
+        refresh: "test-refresh-token",
+      }).catch((err: unknown) => err);
+
+      expect(error).toBeInstanceOf(Error);
+      const message = String((error as Error).message);
+      expect(message).toContain("Token exchange failed:");
+
+      await expect(streamClosed).resolves.toBeUndefined();
+      expect(streamCompleted).toBe(false);
+    });
+  });
+});

--- a/extensions/google/oauth.token.test.ts
+++ b/extensions/google/oauth.token.test.ts
@@ -105,7 +105,9 @@ describe("requestTokenGrant bounded error reads", () => {
           resolveStreamClosed();
         });
         const writeNext = () => {
-          if (closed) return;
+          if (closed) {
+            return;
+          }
           if (written >= STREAM_BODY_BYTES) {
             streamCompleted = true;
             res.end();
@@ -139,7 +141,7 @@ describe("requestTokenGrant bounded error reads", () => {
       );
 
       expect(error).toBeInstanceOf(Error);
-      const message = String((error as Error).message);
+      const message = (error as Error).message;
       expect(message).toContain("Token exchange failed:");
 
       // After bounded read, the stream should be cancelled before completion
@@ -163,7 +165,7 @@ describe("requestTokenGrant bounded error reads", () => {
       );
 
       expect(error).toBeInstanceOf(Error);
-      const message = String((error as Error).message);
+      const message = (error as Error).message;
       expect(message).toBe(
         'Token exchange failed: {"error":"invalid_grant","error_description":"Bad Request"}',
       );
@@ -194,7 +196,9 @@ describe("requestTokenGrant bounded error reads", () => {
           resolveStreamClosed();
         });
         const writeNext = () => {
-          if (closed) return;
+          if (closed) {
+            return;
+          }
           if (written >= STREAM_BODY_BYTES) {
             streamCompleted = true;
             res.end();
@@ -228,7 +232,7 @@ describe("requestTokenGrant bounded error reads", () => {
       }).catch((err: unknown) => err);
 
       expect(error).toBeInstanceOf(Error);
-      const message = String((error as Error).message);
+      const message = (error as Error).message;
       expect(message).toContain("Token exchange failed:");
 
       await expect(streamClosed).resolves.toBeUndefined();

--- a/extensions/google/oauth.token.ts
+++ b/extensions/google/oauth.token.ts
@@ -3,6 +3,10 @@ import {
   asDateTimestampMs,
   resolveExpiresAtMsFromDurationSeconds,
 } from "openclaw/plugin-sdk/number-runtime";
+import {
+  readProviderJsonResponse,
+  readResponseTextLimited,
+} from "openclaw/plugin-sdk/provider-http";
 import { resolveOAuthClientConfig } from "./oauth.credentials.js";
 import { fetchWithTimeout } from "./oauth.http.js";
 import { resolveGoogleOAuthIdentity, resolveGooglePersonalOAuthIdentity } from "./oauth.project.js";
@@ -10,6 +14,7 @@ import { isGeminiCliPersonalOAuth } from "./oauth.settings.js";
 import { REDIRECT_URI, TOKEN_URL, type GeminiCliOAuthCredentials } from "./oauth.shared.js";
 
 const TOKEN_EXPIRY_BUFFER_MS = 5 * 60 * 1000;
+const GOOGLE_OAUTH_ERROR_BODY_MAX_BYTES = 8 * 1024;
 
 async function requestTokenGrant(body: URLSearchParams): Promise<{
   access_token?: string;
@@ -27,15 +32,15 @@ async function requestTokenGrant(body: URLSearchParams): Promise<{
   });
 
   if (!response.ok) {
-    const errorText = await response.text();
+    const errorText = await readResponseTextLimited(response, GOOGLE_OAUTH_ERROR_BODY_MAX_BYTES);
     throw new Error(`Token exchange failed: ${errorText}`);
   }
 
-  return (await response.json()) as {
+  return await readProviderJsonResponse<{
     access_token?: string;
     refresh_token?: string;
     expires_in?: unknown;
-  };
+  }>(response, "Google OAuth token grant");
 }
 
 function resolveExpiredTokenTimestampMs(nowMs: number): number {


### PR DESCRIPTION
## What Problem This Solves

The `requestTokenGrant` helper in the Google OAuth token exchange path read error response bodies via `response.text()` without any size cap. A misconfigured or malfunctioning Google OAuth endpoint (or intermediate proxy) that returns an oversized error body — e.g. a misrouted HTML page or a proxy error splash — could exhaust gateway memory before the error was surfaced.

The `fetchWithTimeout` wrapper in `oauth.http.ts` already bounds the response at 16 MiB, so the raw body cannot overflow memory. However, an unbounded 16 MiB error body can still be embedded verbatim into the downstream `Error` message, producing excessive log payloads and redundant memory pressure.

## Why This Change Was Made

- **Error path** (`response.status !== 200`): replace `response.text()` with `readResponseTextLimited(response, 8 KiB)`. The cap is generous for a structured OAuth error payload (~100 bytes of JSON) while keeping a runaway HTML page from polluting downstream diagnostics.

- **Success path**: replace the bare `(await response.json()) as {…}` cast with `readProviderJsonResponse<T>(response, …)`. The upstream `fetchWithTimeout` already bounds the body at 16 MiB, so this is defense-in-depth type-safe parsing with a consistent provider error surface.

No new dependencies, APIs, config keys, or protocol changes.

## User Impact

Normal OAuth errors (invalid grant, expired token, etc.) preserve their complete diagnostic payload. Oversized error streams are truncated at 8 KiB — the error message still identifies the failure, and the upstream 16 MiB bound ensures memory safety at the transport layer.

## Evidence

### Real behavior proof

- **Behavior addressed**: unbounded `response.text()` on error path → bounded `readResponseTextLimited(8 KiB)`
- **Real environment tested**: loopback HTTP server (`node:http.createServer`) streaming 1 MiB of chunked body over `127.0.0.1`, driven through the exported `exchangeCodeForTokens` and `refreshTokensForGeminiCli` public APIs with mocked `fetchWithTimeout`
- **Exact steps**:
  1. Start a loopback HTTP server that streams a 1 MiB error body (4 KiB chunks, 2 ms delay, no Content-Length)
  2. Mock `fetchWithTimeout` to return the loopback Response
  3. Call `exchangeCodeForTokens("test-code", "test-verifier")`
  4. Assert the error message is bounded (≈8 KiB text)
  5. Assert the stream was cancelled before the server finished writing (proof the read stopped early)
  6. Positive control: a small valid OAuth error body (`{"error":"invalid_grant"}`) is preserved exactly
  7. Both `exchangeCodeForTokens` (authorization code) and `refreshTokensForGeminiCli` (refresh) paths are covered
- **Observed result**: `[google oauth.token loopback proof] oversized path: cap=8192 streamed=1048576 message_length=8215`
- **What was not tested**: The full end-to-end path through Google's actual OAuth endpoint (SSRF guard + DNS pinning). The `fetchWithTimeout` wrapper already has an independent 16 MiB bound; this PR adds a tighter text cap at the call site.

### Validation Evidence

```
pnpm test extensions/google/oauth.token.test.ts

✓ bounds oversized OAuth error body text
✓ preserves complete small error body text within the limit
✓ bounds oversized OAuth error body text during token refresh

Mutation proof:
  $ git stash      → 2 FAILED (old code buffers full body, stream not cancelled)
  $ git stash pop  → 3 PASSED
```

### Security & Privacy / Compatibility

- Cap value (8 KiB) consistent with existing conventions
- `readResponseTextLimited` reads at most maxBytes from the stream; oversized bodies are truncated, not silently consumed
- OAuth tokens, client secrets, and user credentials are not exposed in the capped error path
- No config, dependency, protocol, or `CHANGELOG.md` changes

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
