### PR TITLE
Expose legacy plugin dependency doctor lint findings

### DIFF
--- a/src/commands/doctor/shared/plugin-dependency-cleanup.test.ts
+++ b/src/commands/doctor/shared/plugin-dependency-cleanup.test.ts
@@ -3,7 +3,11 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { testing, cleanupLegacyPluginDependencyState } from "./plugin-dependency-cleanup.js";
+import {
+  testing,
+  cleanupLegacyPluginDependencyState,
+  repairLegacyPluginDependencyStateFindings,
+} from "./plugin-dependency-cleanup.js";
 
 async function expectPathMissing(targetPath: string): Promise<void> {
   try {
@@ -171,6 +175,63 @@ describe("cleanupLegacyPluginDependencyState", () => {
       requirement: "legacy-plugin-dependency-state-removed",
       fixHint: "Run `openclaw doctor --fix` to remove legacy plugin dependency state.",
     });
+    await expectDirectoryPresent(legacyRuntimeRoot);
+  });
+
+  it("previews selected legacy plugin dependency cleanup as dry-run effects", async () => {
+    const stateDir = path.join(tempDir, "state");
+    const packageRoot = path.join(tempDir, "prefix", "lib", "node_modules", "openclaw");
+    const nodeModulesRoot = path.dirname(packageRoot);
+    const legacyRuntimeRoot = path.join(stateDir, "plugin-runtime-deps");
+    const legacyTarget = path.join(
+      legacyRuntimeRoot,
+      "openclaw-2026.4.29-slack",
+      "node_modules",
+      "@slack",
+      "web-api",
+    );
+    const slackScope = path.join(nodeModulesRoot, "@slack");
+    const slackLink = path.join(slackScope, "web-api");
+
+    await fs.mkdir(legacyTarget, { recursive: true });
+    await fs.writeFile(path.join(legacyTarget, "package.json"), "{}\n");
+    await fs.mkdir(slackScope, { recursive: true });
+    await fs.mkdir(packageRoot, { recursive: true });
+    await fs.symlink(legacyTarget, slackLink, "dir");
+
+    const result = await repairLegacyPluginDependencyStateFindings({
+      env: { OPENCLAW_STATE_DIR: stateDir },
+      packageRoot,
+      dryRun: true,
+      findings: [
+        {
+          checkId: "core/doctor/legacy-plugin-dependencies",
+          severity: "warning",
+          message: `Legacy plugin dependency state remains at ${legacyRuntimeRoot}.`,
+          target: legacyRuntimeRoot,
+          path: legacyRuntimeRoot,
+          requirement: "legacy-plugin-dependency-state-removed",
+        },
+      ],
+    });
+
+    expect(result.changes).toStrictEqual([
+      `Would remove stale plugin-runtime symlink: ${slackLink}`,
+      `Would remove legacy plugin dependency state: ${legacyRuntimeRoot}`,
+    ]);
+    expect(result.effects).toContainEqual({
+      kind: "file",
+      action: "would-remove-stale-plugin-runtime-symlink",
+      target: slackLink,
+      dryRunSafe: false,
+    });
+    expect(result.effects).toContainEqual({
+      kind: "state",
+      action: "would-remove-legacy-plugin-dependency-state",
+      target: legacyRuntimeRoot,
+      dryRunSafe: false,
+    });
+    expect((await fs.lstat(slackLink)).isSymbolicLink()).toBe(true);
     await expectDirectoryPresent(legacyRuntimeRoot);
   });
 

--- a/src/commands/doctor/shared/plugin-dependency-cleanup.test.ts
+++ b/src/commands/doctor/shared/plugin-dependency-cleanup.test.ts
@@ -3,11 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import {
-  testing,
-  cleanupLegacyPluginDependencyState,
-  repairLegacyPluginDependencyStateFindings,
-} from "./plugin-dependency-cleanup.js";
+import { testing, cleanupLegacyPluginDependencyState } from "./plugin-dependency-cleanup.js";
 
 async function expectPathMissing(targetPath: string): Promise<void> {
   try {
@@ -166,7 +162,7 @@ describe("cleanupLegacyPluginDependencyState", () => {
       kind: "legacy-plugin-dependency-state",
       path: legacyRuntimeRoot,
     });
-    expect(testing.legacyPluginDependencyStateIssueToHealthFinding(issue!)).toEqual({
+    expect(testing.legacyPluginDependencyStateIssueToHealthFinding(issue)).toEqual({
       checkId: "core/doctor/legacy-plugin-dependencies",
       severity: "warning",
       message: `Legacy plugin dependency state remains at ${legacyRuntimeRoot}.`,
@@ -175,63 +171,6 @@ describe("cleanupLegacyPluginDependencyState", () => {
       requirement: "legacy-plugin-dependency-state-removed",
       fixHint: "Run `openclaw doctor --fix` to remove legacy plugin dependency state.",
     });
-    await expectDirectoryPresent(legacyRuntimeRoot);
-  });
-
-  it("previews selected legacy plugin dependency cleanup as dry-run effects", async () => {
-    const stateDir = path.join(tempDir, "state");
-    const packageRoot = path.join(tempDir, "prefix", "lib", "node_modules", "openclaw");
-    const nodeModulesRoot = path.dirname(packageRoot);
-    const legacyRuntimeRoot = path.join(stateDir, "plugin-runtime-deps");
-    const legacyTarget = path.join(
-      legacyRuntimeRoot,
-      "openclaw-2026.4.29-slack",
-      "node_modules",
-      "@slack",
-      "web-api",
-    );
-    const slackScope = path.join(nodeModulesRoot, "@slack");
-    const slackLink = path.join(slackScope, "web-api");
-
-    await fs.mkdir(legacyTarget, { recursive: true });
-    await fs.writeFile(path.join(legacyTarget, "package.json"), "{}\n");
-    await fs.mkdir(slackScope, { recursive: true });
-    await fs.mkdir(packageRoot, { recursive: true });
-    await fs.symlink(legacyTarget, slackLink, "dir");
-
-    const result = await repairLegacyPluginDependencyStateFindings({
-      env: { OPENCLAW_STATE_DIR: stateDir },
-      packageRoot,
-      dryRun: true,
-      findings: [
-        {
-          checkId: "core/doctor/legacy-plugin-dependencies",
-          severity: "warning",
-          message: `Legacy plugin dependency state remains at ${legacyRuntimeRoot}.`,
-          target: legacyRuntimeRoot,
-          path: legacyRuntimeRoot,
-          requirement: "legacy-plugin-dependency-state-removed",
-        },
-      ],
-    });
-
-    expect(result.changes).toStrictEqual([
-      `Would remove stale plugin-runtime symlink: ${slackLink}`,
-      `Would remove legacy plugin dependency state: ${legacyRuntimeRoot}`,
-    ]);
-    expect(result.effects).toContainEqual({
-      kind: "file",
-      action: "would-remove-stale-plugin-runtime-symlink",
-      target: slackLink,
-      dryRunSafe: false,
-    });
-    expect(result.effects).toContainEqual({
-      kind: "state",
-      action: "would-remove-legacy-plugin-dependency-state",
-      target: legacyRuntimeRoot,
-      dryRunSafe: false,
-    });
-    expect((await fs.lstat(slackLink)).isSymbolicLink()).toBe(true);
     await expectDirectoryPresent(legacyRuntimeRoot);
   });
 

--- a/src/commands/doctor/shared/plugin-dependency-cleanup.test.ts
+++ b/src/commands/doctor/shared/plugin-dependency-cleanup.test.ts
@@ -89,6 +89,22 @@ describe("cleanupLegacyPluginDependencyState", () => {
     expect(targets).toContain(path.join(stateDirectory, "plugin-runtime-deps"));
     expect(targets).not.toContain(thirdPartyNodeModules);
 
+    const issues = await testing.detectLegacyPluginDependencyStateIssues({ env, packageRoot });
+    expect(issues).toContainEqual({
+      kind: "legacy-plugin-dependency-state",
+      path: legacyRuntimeRoot,
+    });
+    expect(issues).toContainEqual({
+      kind: "legacy-plugin-dependency-state",
+      path: legacyLocalRoot,
+    });
+    expect(issues).toContainEqual({
+      kind: "legacy-plugin-dependency-state",
+      path: explicitStageDir,
+    });
+    expect(issues.some((issue) => issue.path === thirdPartyNodeModules)).toBe(false);
+    await expectDirectoryPresent(legacyRuntimeRoot);
+
     const result = await cleanupLegacyPluginDependencyState({ env, packageRoot });
 
     expect(result.warnings).toStrictEqual([]);
@@ -127,6 +143,35 @@ describe("cleanupLegacyPluginDependencyState", () => {
     expect(result.warnings).toStrictEqual([]);
     expect(result.changes).toContain(`Removed legacy plugin dependency state: ${stageRoot}`);
     await expectPathMissing(stageRoot);
+  });
+
+  it("maps legacy dependency state issues to lint findings", async () => {
+    const stateDir = path.join(tempDir, "state");
+    const packageRoot = path.join(tempDir, "package");
+    const legacyRuntimeRoot = path.join(stateDir, "plugin-runtime-deps");
+
+    await fs.mkdir(legacyRuntimeRoot, { recursive: true });
+    await fs.mkdir(packageRoot, { recursive: true });
+
+    const [issue] = await testing.detectLegacyPluginDependencyStateIssues({
+      env: { OPENCLAW_STATE_DIR: stateDir },
+      packageRoot,
+    });
+
+    expect(issue).toEqual({
+      kind: "legacy-plugin-dependency-state",
+      path: legacyRuntimeRoot,
+    });
+    expect(testing.legacyPluginDependencyStateIssueToHealthFinding(issue!)).toEqual({
+      checkId: "core/doctor/legacy-plugin-dependencies",
+      severity: "warning",
+      message: `Legacy plugin dependency state remains at ${legacyRuntimeRoot}.`,
+      target: legacyRuntimeRoot,
+      path: legacyRuntimeRoot,
+      requirement: "legacy-plugin-dependency-state-removed",
+      fixHint: "Run `openclaw doctor --fix` to remove legacy plugin dependency state.",
+    });
+    await expectDirectoryPresent(legacyRuntimeRoot);
   });
 
   it("refuses arbitrary explicit plugin stage roots outside OpenClaw roots", async () => {

--- a/src/commands/doctor/shared/plugin-dependency-cleanup.ts
+++ b/src/commands/doctor/shared/plugin-dependency-cleanup.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { resolveStateDir } from "../../../config/paths.js";
+import type { HealthFinding } from "../../../flows/health-checks.js";
 import { resolveOpenClawPackageRootSync } from "../../../infra/openclaw-root.js";
 import { resolveConfigDir, resolveUserPath } from "../../../utils.js";
 import { removeStalePluginRuntimeSymlinks } from "./plugin-runtime-symlinks.js";
@@ -16,6 +17,11 @@ interface CleanupTarget {
   readonly kind: "explicit-stage" | "legacy";
   readonly path: string;
   readonly rawPath?: string;
+}
+
+export interface LegacyPluginDependencyStateIssue {
+  readonly kind: "legacy-plugin-dependency-state";
+  readonly path: string;
 }
 
 function uniqueSorted(values: Iterable<string | null | undefined>): string[] {
@@ -385,6 +391,50 @@ async function collectLegacyPluginDependencyTargets(
   );
 }
 
+/** Find stale legacy plugin dependency state that doctor --fix can remove. */
+export async function detectLegacyPluginDependencyStateIssues(
+  params: {
+    env?: NodeJS.ProcessEnv;
+    packageRoot?: string | null;
+  } = {},
+): Promise<LegacyPluginDependencyStateIssue[]> {
+  const env = params.env ?? process.env;
+  const packageRoot =
+    params.packageRoot ??
+    resolveOpenClawPackageRootSync({
+      argv1: process.argv[1],
+      moduleUrl: import.meta.url,
+      cwd: process.cwd(),
+    });
+  const targets = await collectLegacyPluginDependencyTargetEntries(env, {
+    packageRoot,
+  });
+  const cleanupRootPaths = collectCleanupRootPaths(env, packageRoot);
+  const cleanupRoots = await collectExistingCleanupRoots(cleanupRootPaths);
+  const staleRootCandidates = filterLegacyStaleRootCandidates(targets, cleanupRootPaths);
+  const preparedTargets = await prepareCleanupTargets(staleRootCandidates.targets, cleanupRoots);
+  return preparedTargets.removalTargets.map(
+    (target): LegacyPluginDependencyStateIssue => ({
+      kind: "legacy-plugin-dependency-state",
+      path: target,
+    }),
+  );
+}
+
+export function legacyPluginDependencyStateIssueToHealthFinding(
+  issue: LegacyPluginDependencyStateIssue,
+): HealthFinding {
+  return {
+    checkId: "core/doctor/legacy-plugin-dependencies",
+    severity: "warning",
+    message: `Legacy plugin dependency state remains at ${issue.path}.`,
+    target: issue.path,
+    path: issue.path,
+    requirement: "legacy-plugin-dependency-state-removed",
+    fixHint: "Run `openclaw doctor --fix` to remove legacy plugin dependency state.",
+  };
+}
+
 /** Remove legacy plugin dependency state under trusted OpenClaw cleanup roots. */
 export async function cleanupLegacyPluginDependencyState(params: {
   env?: NodeJS.ProcessEnv;
@@ -427,5 +477,7 @@ export async function cleanupLegacyPluginDependencyState(params: {
 
 export const testing = {
   collectLegacyPluginDependencyTargets,
+  detectLegacyPluginDependencyStateIssues,
+  legacyPluginDependencyStateIssueToHealthFinding,
 };
 export { testing as __testing };

--- a/src/commands/doctor/shared/plugin-dependency-cleanup.ts
+++ b/src/commands/doctor/shared/plugin-dependency-cleanup.ts
@@ -2,17 +2,10 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { resolveStateDir } from "../../../config/paths.js";
-import type {
-  HealthFinding,
-  HealthRepairEffect,
-  HealthRepairResult,
-} from "../../../flows/health-checks.js";
+import type { HealthFinding } from "../../../flows/health-checks.js";
 import { resolveOpenClawPackageRootSync } from "../../../infra/openclaw-root.js";
 import { resolveConfigDir, resolveUserPath } from "../../../utils.js";
-import {
-  collectStalePluginRuntimeSymlinks,
-  removeStalePluginRuntimeSymlinks,
-} from "./plugin-runtime-symlinks.js";
+import { removeStalePluginRuntimeSymlinks } from "./plugin-runtime-symlinks.js";
 
 const LEGACY_DIRECT_CHILD_NAMES = new Set(["plugin-runtime-deps", "bundled-plugin-runtime-deps"]);
 
@@ -440,138 +433,6 @@ export function legacyPluginDependencyStateIssueToHealthFinding(
     requirement: "legacy-plugin-dependency-state-removed",
     fixHint: "Run `openclaw doctor --fix` to remove legacy plugin dependency state.",
   };
-}
-
-function legacyPluginDependencyRemovalEffect(target: string, dryRun: boolean): HealthRepairEffect {
-  return {
-    kind: "state",
-    action: dryRun
-      ? "would-remove-legacy-plugin-dependency-state"
-      : "remove-legacy-plugin-dependency-state",
-    target,
-    dryRunSafe: false,
-  };
-}
-
-function stalePluginRuntimeSymlinkRemovalEffect(
-  target: string,
-  dryRun: boolean,
-): HealthRepairEffect {
-  return {
-    kind: "file",
-    action: dryRun
-      ? "would-remove-stale-plugin-runtime-symlink"
-      : "remove-stale-plugin-runtime-symlink",
-    target,
-    dryRunSafe: false,
-  };
-}
-
-async function prepareLegacyPluginDependencyRemovals(params: {
-  env: NodeJS.ProcessEnv;
-  packageRoot: string | null | undefined;
-}): Promise<{ removalTargets: string[]; staleRoots: string[]; warnings: string[] }> {
-  const targets = await collectLegacyPluginDependencyTargetEntries(params.env, {
-    packageRoot: params.packageRoot,
-  });
-  const cleanupRootPaths = collectCleanupRootPaths(params.env, params.packageRoot);
-  const cleanupRoots = await collectExistingCleanupRoots(cleanupRootPaths);
-  const staleRootCandidates = filterLegacyStaleRootCandidates(targets, cleanupRootPaths);
-  const preparedTargets = await prepareCleanupTargets(staleRootCandidates.targets, cleanupRoots);
-  return {
-    removalTargets: preparedTargets.removalTargets,
-    staleRoots: preparedTargets.staleRoots,
-    warnings: [...staleRootCandidates.warnings, ...preparedTargets.warnings],
-  };
-}
-
-/** Repairs or previews selected legacy plugin dependency state findings. */
-export async function repairLegacyPluginDependencyStateFindings(params: {
-  env?: NodeJS.ProcessEnv;
-  packageRoot?: string | null;
-  findings: readonly HealthFinding[];
-  dryRun?: boolean;
-}): Promise<HealthRepairResult> {
-  const selectedPaths = new Set(
-    params.findings
-      .filter(
-        (finding) =>
-          finding.checkId === "core/doctor/legacy-plugin-dependencies" &&
-          finding.requirement === "legacy-plugin-dependency-state-removed" &&
-          typeof finding.path === "string",
-      )
-      .map((finding) => path.resolve(finding.path as string)),
-  );
-  if (selectedPaths.size === 0) {
-    return {
-      status: "skipped",
-      reason: "no repairable legacy plugin dependency findings were present",
-      changes: [],
-    };
-  }
-
-  const env = params.env ?? process.env;
-  const packageRoot =
-    params.packageRoot ??
-    resolveOpenClawPackageRootSync({
-      argv1: process.argv[1],
-      moduleUrl: import.meta.url,
-      cwd: process.cwd(),
-    });
-  const preparedTargets = await prepareLegacyPluginDependencyRemovals({ env, packageRoot });
-  const removalTargets = preparedTargets.removalTargets.filter((target) =>
-    selectedPaths.has(path.resolve(target)),
-  );
-  if (removalTargets.length === 0) {
-    return {
-      status: "skipped",
-      reason: "selected legacy plugin dependency state no longer needs repair",
-      changes: [],
-      warnings: preparedTargets.warnings,
-    };
-  }
-
-  const changes: string[] = [];
-  const warnings = [...preparedTargets.warnings];
-  const effects: HealthRepairEffect[] = [];
-  const staleSymlinks = await collectStalePluginRuntimeSymlinks(packageRoot, {
-    staleRoots: removalTargets,
-  });
-  for (const symlink of staleSymlinks) {
-    if (params.dryRun === true) {
-      changes.push(`Would remove stale plugin-runtime symlink: ${symlink.path}`);
-    } else {
-      try {
-        await fs.unlink(symlink.path);
-        changes.push(`Removed stale plugin-runtime symlink: ${symlink.path}`);
-      } catch (error) {
-        warnings.push(
-          `Failed to remove stale plugin-runtime symlink ${symlink.path}: ${String(error)}`,
-        );
-        continue;
-      }
-    }
-    effects.push(stalePluginRuntimeSymlinkRemovalEffect(symlink.path, params.dryRun === true));
-  }
-
-  for (const target of removalTargets) {
-    if (params.dryRun === true) {
-      changes.push(`Would remove legacy plugin dependency state: ${target}`);
-    } else {
-      try {
-        await fs.rm(target, { recursive: true, force: true });
-        changes.push(`Removed legacy plugin dependency state: ${target}`);
-      } catch (error) {
-        warnings.push(
-          `Failed to remove legacy plugin dependency state ${target}: ${String(error)}`,
-        );
-        continue;
-      }
-    }
-    effects.push(legacyPluginDependencyRemovalEffect(target, params.dryRun === true));
-  }
-
-  return { changes, warnings, effects };
 }
 
 /** Remove legacy plugin dependency state under trusted OpenClaw cleanup roots. */

--- a/src/commands/doctor/shared/plugin-dependency-cleanup.ts
+++ b/src/commands/doctor/shared/plugin-dependency-cleanup.ts
@@ -2,10 +2,17 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { resolveStateDir } from "../../../config/paths.js";
-import type { HealthFinding } from "../../../flows/health-checks.js";
+import type {
+  HealthFinding,
+  HealthRepairEffect,
+  HealthRepairResult,
+} from "../../../flows/health-checks.js";
 import { resolveOpenClawPackageRootSync } from "../../../infra/openclaw-root.js";
 import { resolveConfigDir, resolveUserPath } from "../../../utils.js";
-import { removeStalePluginRuntimeSymlinks } from "./plugin-runtime-symlinks.js";
+import {
+  collectStalePluginRuntimeSymlinks,
+  removeStalePluginRuntimeSymlinks,
+} from "./plugin-runtime-symlinks.js";
 
 const LEGACY_DIRECT_CHILD_NAMES = new Set(["plugin-runtime-deps", "bundled-plugin-runtime-deps"]);
 
@@ -433,6 +440,138 @@ export function legacyPluginDependencyStateIssueToHealthFinding(
     requirement: "legacy-plugin-dependency-state-removed",
     fixHint: "Run `openclaw doctor --fix` to remove legacy plugin dependency state.",
   };
+}
+
+function legacyPluginDependencyRemovalEffect(target: string, dryRun: boolean): HealthRepairEffect {
+  return {
+    kind: "state",
+    action: dryRun
+      ? "would-remove-legacy-plugin-dependency-state"
+      : "remove-legacy-plugin-dependency-state",
+    target,
+    dryRunSafe: false,
+  };
+}
+
+function stalePluginRuntimeSymlinkRemovalEffect(
+  target: string,
+  dryRun: boolean,
+): HealthRepairEffect {
+  return {
+    kind: "file",
+    action: dryRun
+      ? "would-remove-stale-plugin-runtime-symlink"
+      : "remove-stale-plugin-runtime-symlink",
+    target,
+    dryRunSafe: false,
+  };
+}
+
+async function prepareLegacyPluginDependencyRemovals(params: {
+  env: NodeJS.ProcessEnv;
+  packageRoot: string | null | undefined;
+}): Promise<{ removalTargets: string[]; staleRoots: string[]; warnings: string[] }> {
+  const targets = await collectLegacyPluginDependencyTargetEntries(params.env, {
+    packageRoot: params.packageRoot,
+  });
+  const cleanupRootPaths = collectCleanupRootPaths(params.env, params.packageRoot);
+  const cleanupRoots = await collectExistingCleanupRoots(cleanupRootPaths);
+  const staleRootCandidates = filterLegacyStaleRootCandidates(targets, cleanupRootPaths);
+  const preparedTargets = await prepareCleanupTargets(staleRootCandidates.targets, cleanupRoots);
+  return {
+    removalTargets: preparedTargets.removalTargets,
+    staleRoots: preparedTargets.staleRoots,
+    warnings: [...staleRootCandidates.warnings, ...preparedTargets.warnings],
+  };
+}
+
+/** Repairs or previews selected legacy plugin dependency state findings. */
+export async function repairLegacyPluginDependencyStateFindings(params: {
+  env?: NodeJS.ProcessEnv;
+  packageRoot?: string | null;
+  findings: readonly HealthFinding[];
+  dryRun?: boolean;
+}): Promise<HealthRepairResult> {
+  const selectedPaths = new Set(
+    params.findings
+      .filter(
+        (finding) =>
+          finding.checkId === "core/doctor/legacy-plugin-dependencies" &&
+          finding.requirement === "legacy-plugin-dependency-state-removed" &&
+          typeof finding.path === "string",
+      )
+      .map((finding) => path.resolve(finding.path as string)),
+  );
+  if (selectedPaths.size === 0) {
+    return {
+      status: "skipped",
+      reason: "no repairable legacy plugin dependency findings were present",
+      changes: [],
+    };
+  }
+
+  const env = params.env ?? process.env;
+  const packageRoot =
+    params.packageRoot ??
+    resolveOpenClawPackageRootSync({
+      argv1: process.argv[1],
+      moduleUrl: import.meta.url,
+      cwd: process.cwd(),
+    });
+  const preparedTargets = await prepareLegacyPluginDependencyRemovals({ env, packageRoot });
+  const removalTargets = preparedTargets.removalTargets.filter((target) =>
+    selectedPaths.has(path.resolve(target)),
+  );
+  if (removalTargets.length === 0) {
+    return {
+      status: "skipped",
+      reason: "selected legacy plugin dependency state no longer needs repair",
+      changes: [],
+      warnings: preparedTargets.warnings,
+    };
+  }
+
+  const changes: string[] = [];
+  const warnings = [...preparedTargets.warnings];
+  const effects: HealthRepairEffect[] = [];
+  const staleSymlinks = await collectStalePluginRuntimeSymlinks(packageRoot, {
+    staleRoots: removalTargets,
+  });
+  for (const symlink of staleSymlinks) {
+    if (params.dryRun === true) {
+      changes.push(`Would remove stale plugin-runtime symlink: ${symlink.path}`);
+    } else {
+      try {
+        await fs.unlink(symlink.path);
+        changes.push(`Removed stale plugin-runtime symlink: ${symlink.path}`);
+      } catch (error) {
+        warnings.push(
+          `Failed to remove stale plugin-runtime symlink ${symlink.path}: ${String(error)}`,
+        );
+        continue;
+      }
+    }
+    effects.push(stalePluginRuntimeSymlinkRemovalEffect(symlink.path, params.dryRun === true));
+  }
+
+  for (const target of removalTargets) {
+    if (params.dryRun === true) {
+      changes.push(`Would remove legacy plugin dependency state: ${target}`);
+    } else {
+      try {
+        await fs.rm(target, { recursive: true, force: true });
+        changes.push(`Removed legacy plugin dependency state: ${target}`);
+      } catch (error) {
+        warnings.push(
+          `Failed to remove legacy plugin dependency state ${target}: ${String(error)}`,
+        );
+        continue;
+      }
+    }
+    effects.push(legacyPluginDependencyRemovalEffect(target, params.dryRun === true));
+  }
+
+  return { changes, warnings, effects };
 }
 
 /** Remove legacy plugin dependency state under trusted OpenClaw cleanup roots. */

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -1348,6 +1348,7 @@ describe("doctor health contributions", () => {
     expect(contributionIds).toContain("core/doctor/session-snapshots");
     expect(contributionIds).toContain("core/doctor/plugin-registry");
     expect(contributionIds).toContain("core/doctor/configured-plugin-installs");
+    expect(contributionIds).toContain("core/doctor/legacy-plugin-dependencies");
     expect(contributionIds).toContain("core/doctor/disk-space");
     expect(contributionIds).toContain("core/doctor/heartbeat-template");
     expect(contributionIds).toContain("core/doctor/disk-space");
@@ -1448,6 +1449,58 @@ describe("doctor health contributions", () => {
         }),
       ]),
     });
+  });
+
+  it("keeps legacy plugin dependency lint opt-in and read-only", async () => {
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    const tempDir = fs.mkdtempSync("/tmp/openclaw-legacy-plugin-deps-lint-");
+    const stateDir = `${tempDir}/state`;
+    const legacyRuntimeRoot = `${stateDir}/plugin-runtime-deps`;
+    fs.mkdirSync(legacyRuntimeRoot, { recursive: true });
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    try {
+      const contributionChecks = await resolveDoctorContributionHealthChecks();
+      const check = contributionChecks.find(
+        (entry) => entry.id === "core/doctor/legacy-plugin-dependencies",
+      );
+      expect(check).toMatchObject({ defaultEnabled: false });
+      expect(check).toBeDefined();
+
+      const ctx = {
+        cfg: {},
+        mode: "lint",
+        runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      } as const;
+
+      await expect(runDoctorLintChecks(ctx, { checks: [check!] })).resolves.toMatchObject({
+        checksRun: 0,
+        checksSkipped: 1,
+      });
+      await expect(
+        runDoctorLintChecks(ctx, {
+          checks: [check!],
+          onlyIds: ["core/doctor/legacy-plugin-dependencies"],
+        }),
+      ).resolves.toMatchObject({
+        checksRun: 1,
+        checksSkipped: 0,
+        findings: [
+          expect.objectContaining({
+            checkId: "core/doctor/legacy-plugin-dependencies",
+            severity: "warning",
+            path: legacyRuntimeRoot,
+          }),
+        ],
+      });
+      expect(fs.existsSync(legacyRuntimeRoot)).toBe(true);
+    } finally {
+      if (previousStateDir === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 
   it("keeps state integrity opt-in for default lint selection", async () => {

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -1,5 +1,7 @@
 // Doctor health contribution tests cover plugin-provided health checks.
 import fs from "node:fs";
+import os from "node:os";
+import nodePath from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { DoctorPrompter } from "../commands/doctor-prompter.js";
 import { CORE_HEALTH_CHECKS } from "./doctor-core-checks.js";
@@ -1453,9 +1455,9 @@ describe("doctor health contributions", () => {
 
   it("keeps legacy plugin dependency lint opt-in and read-only", async () => {
     const previousStateDir = process.env.OPENCLAW_STATE_DIR;
-    const tempDir = fs.mkdtempSync("/tmp/openclaw-legacy-plugin-deps-lint-");
-    const stateDir = `${tempDir}/state`;
-    const legacyRuntimeRoot = `${stateDir}/plugin-runtime-deps`;
+    const tempDir = fs.mkdtempSync(nodePath.join(os.tmpdir(), "openclaw-legacy-plugin-deps-lint-"));
+    const stateDir = nodePath.join(tempDir, "state");
+    const legacyRuntimeRoot = nodePath.join(stateDir, "plugin-runtime-deps");
     fs.mkdirSync(legacyRuntimeRoot, { recursive: true });
     process.env.OPENCLAW_STATE_DIR = stateDir;
     try {
@@ -1491,56 +1493,6 @@ describe("doctor health contributions", () => {
             path: legacyRuntimeRoot,
           }),
         ],
-      });
-      expect(fs.existsSync(legacyRuntimeRoot)).toBe(true);
-    } finally {
-      if (previousStateDir === undefined) {
-        delete process.env.OPENCLAW_STATE_DIR;
-      } else {
-        process.env.OPENCLAW_STATE_DIR = previousStateDir;
-      }
-      fs.rmSync(tempDir, { recursive: true, force: true });
-    }
-  });
-
-  it("threads dry-run legacy plugin dependency cleanup through the structured check", async () => {
-    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
-    const tempDir = fs.mkdtempSync("/tmp/openclaw-legacy-plugin-deps-repair-");
-    const stateDir = `${tempDir}/state`;
-    const legacyRuntimeRoot = `${stateDir}/plugin-runtime-deps`;
-    fs.mkdirSync(legacyRuntimeRoot, { recursive: true });
-    process.env.OPENCLAW_STATE_DIR = stateDir;
-    try {
-      const contributionChecks = await resolveDoctorContributionHealthChecks();
-      const check = contributionChecks.find(
-        (entry) => entry.id === "core/doctor/legacy-plugin-dependencies",
-      );
-      expect(check?.repair).toBeDefined();
-
-      const result = await check!.repair!(
-        {
-          cfg: {},
-          mode: "fix",
-          dryRun: true,
-          runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-        },
-        [
-          {
-            checkId: "core/doctor/legacy-plugin-dependencies",
-            severity: "warning",
-            message: `Legacy plugin dependency state remains at ${legacyRuntimeRoot}.`,
-            target: legacyRuntimeRoot,
-            path: legacyRuntimeRoot,
-            requirement: "legacy-plugin-dependency-state-removed",
-          },
-        ],
-      );
-
-      expect(result.effects).toContainEqual({
-        kind: "state",
-        action: "would-remove-legacy-plugin-dependency-state",
-        target: legacyRuntimeRoot,
-        dryRunSafe: false,
       });
       expect(fs.existsSync(legacyRuntimeRoot)).toBe(true);
     } finally {

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -1503,6 +1503,56 @@ describe("doctor health contributions", () => {
     }
   });
 
+  it("threads dry-run legacy plugin dependency cleanup through the structured check", async () => {
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    const tempDir = fs.mkdtempSync("/tmp/openclaw-legacy-plugin-deps-repair-");
+    const stateDir = `${tempDir}/state`;
+    const legacyRuntimeRoot = `${stateDir}/plugin-runtime-deps`;
+    fs.mkdirSync(legacyRuntimeRoot, { recursive: true });
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    try {
+      const contributionChecks = await resolveDoctorContributionHealthChecks();
+      const check = contributionChecks.find(
+        (entry) => entry.id === "core/doctor/legacy-plugin-dependencies",
+      );
+      expect(check?.repair).toBeDefined();
+
+      const result = await check!.repair!(
+        {
+          cfg: {},
+          mode: "fix",
+          dryRun: true,
+          runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+        },
+        [
+          {
+            checkId: "core/doctor/legacy-plugin-dependencies",
+            severity: "warning",
+            message: `Legacy plugin dependency state remains at ${legacyRuntimeRoot}.`,
+            target: legacyRuntimeRoot,
+            path: legacyRuntimeRoot,
+            requirement: "legacy-plugin-dependency-state-removed",
+          },
+        ],
+      );
+
+      expect(result.effects).toContainEqual({
+        kind: "state",
+        action: "would-remove-legacy-plugin-dependency-state",
+        target: legacyRuntimeRoot,
+        dryRunSafe: false,
+      });
+      expect(fs.existsSync(legacyRuntimeRoot)).toBe(true);
+    } finally {
+      if (previousStateDir === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("keeps state integrity opt-in for default lint selection", async () => {
     const contributionChecks = await resolveDoctorContributionHealthChecks();
     const stateIntegrityCheck = contributionChecks.find(

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -1444,6 +1444,25 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
       run: runLegacyPluginManifestHealth,
     }),
     createDoctorHealthContribution({
+      id: "doctor:legacy-plugin-dependencies",
+      label: "Legacy plugin dependencies",
+      healthChecks: {
+        id: "core/doctor/legacy-plugin-dependencies",
+        description: "Legacy plugin dependency state roots are represented as findings.",
+        defaultEnabled: false,
+        async detect() {
+          const {
+            detectLegacyPluginDependencyStateIssues,
+            legacyPluginDependencyStateIssueToHealthFinding,
+          } = await import("../commands/doctor/shared/plugin-dependency-cleanup.js");
+          return (await detectLegacyPluginDependencyStateIssues({ env: process.env })).map(
+            legacyPluginDependencyStateIssueToHealthFinding,
+          );
+        },
+      },
+      run: async () => {},
+    }),
+    createDoctorHealthContribution({
       id: "doctor:release-configured-plugin-installs",
       label: "Configured plugin repair",
       healthChecks: {

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -1459,6 +1459,15 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
             legacyPluginDependencyStateIssueToHealthFinding,
           );
         },
+        async repair(ctx, findings) {
+          const { repairLegacyPluginDependencyStateFindings } =
+            await import("../commands/doctor/shared/plugin-dependency-cleanup.js");
+          return await repairLegacyPluginDependencyStateFindings({
+            env: process.env,
+            findings,
+            dryRun: ctx.dryRun,
+          });
+        },
       },
       run: async () => {},
     }),

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -1459,15 +1459,6 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
             legacyPluginDependencyStateIssueToHealthFinding,
           );
         },
-        async repair(ctx, findings) {
-          const { repairLegacyPluginDependencyStateFindings } =
-            await import("../commands/doctor/shared/plugin-dependency-cleanup.js");
-          return await repairLegacyPluginDependencyStateFindings({
-            env: process.env,
-            findings,
-            dryRun: ctx.dryRun,
-          });
-        },
       },
       run: async () => {},
     }),


### PR DESCRIPTION
## Summary
- expose stale legacy plugin dependency state roots as default-disabled `core/doctor/legacy-plugin-dependencies` lint findings
- reuse the existing safe cleanup target preparation so lint reports only roots already considered removable by the legacy `doctor --fix` cleanup path
- keep all real deletion in the existing repair sequence; this PR is lint-only and does not add a structured repair/dry-run hook

## Contract / compatibility
- No public SDK, plugin manifest, config schema, persisted data-model, or plugin contract changes.
- Default `doctor --lint` behavior is unchanged; `--only core/doctor/legacy-plugin-dependencies` and `--all` can select it.
- `doctor --fix` remains the mutation owner for removing legacy plugin dependency state.

## Real behavior proof
Selected source CLI lint with isolated state/config and a temp `state/plugin-runtime-deps` root emitted one `core/doctor/legacy-plugin-dependencies` warning and left the legacy root in place. Focused regression proof verifies default lint skips this default-disabled check and explicit `--only` runs it.

## Validation after refresh
- Rebased onto current `origin/main` and pushed head `9fb731ebe6d506c2810173cb7834247fa17d38fe`.
- `node scripts/run-vitest.mjs src/flows/doctor-health-contributions.test.ts` (62 tests)
- changed-file `.\node_modules\.bin\oxfmt.cmd --check`
- changed-file `.\node_modules\.bin\oxlint.cmd`
- `node scripts/plugin-sdk-surface-report.mjs --check`
- `git diff --check`

Note: the broader cleanup helper test still hits Windows symlink creation `EPERM` in existing symlink safety cases on this host; that is environment-sensitive and not a regression from the lint-only correction. `pnpm exec oxlint` also hit a local node_modules install/rename `EPERM`, so refreshed-head changed-file format/lint used the existing local bin shims.