### PR TITLE
feat(commands): surface live MCP session state in /mcp show

### DIFF
--- a/src/auto-reply/reply/commands-mcp.test.ts
+++ b/src/auto-reply/reply/commands-mcp.test.ts
@@ -22,7 +22,7 @@ const mcpRuntimeMocks = vi.hoisted(() => ({
   })),
 }));
 
-vi.mock("../../agents/agent-bundle-mcp-runtime.js", () => mcpRuntimeMocks);
+vi.mock("../../agents/agent-bundle-mcp-tools.js", () => mcpRuntimeMocks);
 
 vi.mock("../../config/mcp-config.js", () => ({
   listConfiguredMcpServers: vi.fn(async () => ({
@@ -116,6 +116,32 @@ describe("handleCommands /mcp", () => {
       const result = expectMcpResult(await handleMcpCommand(showParams, true));
       expect(result.reply?.text).toContain("🩺 Live state (session):");
       expect(result.reply?.text).toContain("context7: ✅ connected (3 tools)");
+    });
+  });
+
+  it('uses singular "tool" for a server with exactly one tool', async () => {
+    await withTempHome("openclaw-command-mcp-home-", async () => {
+      const workspaceDir = await workspaceHarness.createWorkspace();
+      mcpServers.set("context7", { command: "uvx", args: ["context7-mcp"] });
+      const catalog = makeCatalog({
+        servers: { context7: { serverName: "context7", launchSummary: "uvx", toolCount: 1 } },
+      });
+      mcpRuntimeMocks.peekSessionMcpRuntime.mockReturnValue({
+        configFingerprint: "mcp:1",
+        workspaceDir,
+        peekCatalog: () => catalog,
+      });
+      mcpRuntimeMocks.resolveSessionMcpConfigSummary.mockReturnValue({
+        fingerprint: "mcp:1",
+        serverNames: ["context7"],
+      });
+
+      const showParams = buildCommandTestParams("/mcp show", buildCfg(), undefined, {
+        workspaceDir,
+      });
+      showParams.command.senderIsOwner = true;
+      const result = expectMcpResult(await handleMcpCommand(showParams, true));
+      expect(result.reply?.text).toContain("context7: ✅ connected (1 tool)");
     });
   });
 
@@ -258,17 +284,27 @@ describe("handleCommands /mcp", () => {
     });
   });
 
-  it("omits the live-state section when no session runtime exists yet", async () => {
+  it("renders byte-identical output to the pre-live-state baseline when no session runtime exists yet", async () => {
     await withTempHome("openclaw-command-mcp-home-", async () => {
       const workspaceDir = await workspaceHarness.createWorkspace();
-      mcpServers.set("context7", { command: "uvx", args: ["context7-mcp"] });
+      const server = { command: "uvx", args: ["context7-mcp"] };
+      mcpServers.set("context7", server);
 
       const showParams = buildCommandTestParams("/mcp show", buildCfg(), undefined, {
         workspaceDir,
       });
       showParams.command.senderIsOwner = true;
       const result = expectMcpResult(await handleMcpCommand(showParams, true));
-      expect(result.reply?.text).not.toContain("Live state");
+      // Exact match against what /mcp show rendered before this PR (a single
+      // JSON block, no live-state block appended) — not just a substring
+      // check — so a future regression that always appends a live-state
+      // section (even an empty one) would be caught.
+      const expectedLegacyText = `🔌 MCP servers (/tmp/openclaw.json)\n\`\`\`json\n${JSON.stringify(
+        { context7: server },
+        null,
+        2,
+      )}\n\`\`\``;
+      expect(result.reply?.text).toBe(expectedLegacyText);
     });
   });
 

--- a/src/auto-reply/reply/commands-mcp.test.ts
+++ b/src/auto-reply/reply/commands-mcp.test.ts
@@ -237,6 +237,43 @@ describe("handleCommands /mcp", () => {
     });
   });
 
+  it("computes staleness against the runtime's own workspaceDir, not the command's raw workspaceDir", async () => {
+    await withTempHome("openclaw-command-mcp-home-", async () => {
+      const commandWorkspaceDir = await workspaceHarness.createWorkspace();
+      const runtimeWorkspaceDir = await workspaceHarness.createWorkspace();
+      mcpServers.set("context7", { command: "uvx", args: ["context7-mcp"] });
+      const catalog = makeCatalog({
+        servers: { context7: { serverName: "context7", launchSummary: "uvx", toolCount: 3 } },
+      });
+      // Simulates a sandboxed session: the runtime was built from a different
+      // effective workspace than the raw command workspaceDir threaded
+      // through get-reply.ts. Regression guard for the sandbox-fingerprint
+      // fix — staleness must compare against runtime.workspaceDir.
+      mcpRuntimeMocks.peekSessionMcpRuntime.mockReturnValue({
+        configFingerprint: "mcp:1",
+        workspaceDir: runtimeWorkspaceDir,
+        peekCatalog: () => catalog,
+      });
+      mcpRuntimeMocks.resolveSessionMcpConfigSummary.mockReturnValue({
+        fingerprint: "mcp:1",
+        serverNames: ["context7"],
+      });
+
+      const showParams = buildCommandTestParams("/mcp show", buildCfg(), undefined, {
+        workspaceDir: commandWorkspaceDir,
+      });
+      showParams.command.senderIsOwner = true;
+      const result = expectMcpResult(await handleMcpCommand(showParams, true));
+      expect(mcpRuntimeMocks.resolveSessionMcpConfigSummary).toHaveBeenCalledWith(
+        expect.objectContaining({ workspaceDir: runtimeWorkspaceDir }),
+      );
+      expect(mcpRuntimeMocks.resolveSessionMcpConfigSummary).not.toHaveBeenCalledWith(
+        expect.objectContaining({ workspaceDir: commandWorkspaceDir }),
+      );
+      expect(result.reply?.text).toContain("context7: ✅ connected (3 tools)");
+    });
+  });
+
   it("shows a not-yet-discovered note when the session runtime has no catalog yet", async () => {
     await withTempHome("openclaw-command-mcp-home-", async () => {
       const workspaceDir = await workspaceHarness.createWorkspace();

--- a/src/auto-reply/reply/commands-mcp.test.ts
+++ b/src/auto-reply/reply/commands-mcp.test.ts
@@ -1,5 +1,6 @@
 // Tests MCP command configuration, listing, and enablement behavior.
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { McpToolCatalog, SessionMcpRuntime } from "../../agents/agent-bundle-mcp-types.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { withTempHome } from "../../config/home-env.test-harness.js";
 import { createCommandWorkspaceHarness } from "./commands-filesystem.test-support.js";
@@ -7,6 +8,21 @@ import { handleMcpCommand } from "./commands-mcp.js";
 import { buildCommandTestParams } from "./commands.test-harness.js";
 
 const mcpServers = vi.hoisted(() => new Map<string, Record<string, unknown>>());
+
+const mcpRuntimeMocks = vi.hoisted(() => ({
+  peekSessionMcpRuntime: vi.fn<
+    (params: {
+      sessionId?: string | null;
+      sessionKey?: string | null;
+    }) => Pick<SessionMcpRuntime, "configFingerprint" | "peekCatalog"> | undefined
+  >(() => undefined),
+  resolveSessionMcpConfigSummary: vi.fn(() => ({
+    fingerprint: "mcp:0",
+    serverNames: [] as string[],
+  })),
+}));
+
+vi.mock("../../agents/agent-bundle-mcp-runtime.js", () => mcpRuntimeMocks);
 
 vi.mock("../../config/mcp-config.js", () => ({
   listConfiguredMcpServers: vi.fn(async () => ({
@@ -54,10 +70,146 @@ function buildCfg(): OpenClawConfig {
   };
 }
 
+function makeCatalog(
+  overrides: Partial<McpToolCatalog> & Pick<McpToolCatalog, "servers"> = { servers: {} },
+): McpToolCatalog {
+  return {
+    version: 1,
+    generatedAt: 0,
+    tools: [],
+    ...overrides,
+  };
+}
+
 describe("handleCommands /mcp", () => {
   afterEach(async () => {
     mcpServers.clear();
     await workspaceHarness.cleanupWorkspaces();
+    mcpRuntimeMocks.peekSessionMcpRuntime.mockReset().mockReturnValue(undefined);
+    mcpRuntimeMocks.resolveSessionMcpConfigSummary.mockReset().mockReturnValue({
+      fingerprint: "mcp:0",
+      serverNames: [],
+    });
+  });
+
+  it("shows connected live state for a server with a warm catalog", async () => {
+    await withTempHome("openclaw-command-mcp-home-", async () => {
+      const workspaceDir = await workspaceHarness.createWorkspace();
+      mcpServers.set("context7", { command: "uvx", args: ["context7-mcp"] });
+      const catalog = makeCatalog({
+        servers: { context7: { serverName: "context7", launchSummary: "uvx", toolCount: 3 } },
+      });
+      mcpRuntimeMocks.peekSessionMcpRuntime.mockReturnValue({
+        configFingerprint: "mcp:1",
+        peekCatalog: () => catalog,
+      });
+      mcpRuntimeMocks.resolveSessionMcpConfigSummary.mockReturnValue({
+        fingerprint: "mcp:1",
+        serverNames: ["context7"],
+      });
+
+      const showParams = buildCommandTestParams("/mcp show", buildCfg(), undefined, {
+        workspaceDir,
+      });
+      showParams.command.senderIsOwner = true;
+      const result = expectMcpResult(await handleMcpCommand(showParams, true));
+      expect(result.reply?.text).toContain("🩺 Live state (session):");
+      expect(result.reply?.text).toContain("context7: ✅ connected (3 tools)");
+    });
+  });
+
+  it("shows a diagnostic live-state line for a server that failed to connect", async () => {
+    await withTempHome("openclaw-command-mcp-home-", async () => {
+      const workspaceDir = await workspaceHarness.createWorkspace();
+      mcpServers.set("context7", { command: "uvx", args: ["context7-mcp"] });
+      const catalog = makeCatalog({
+        servers: {},
+        diagnostics: [
+          {
+            serverName: "context7",
+            safeServerName: "context7",
+            launchSummary: "uvx",
+            message: "connect ECONNREFUSED",
+          },
+        ],
+      });
+      mcpRuntimeMocks.peekSessionMcpRuntime.mockReturnValue({
+        configFingerprint: "mcp:1",
+        peekCatalog: () => catalog,
+      });
+      mcpRuntimeMocks.resolveSessionMcpConfigSummary.mockReturnValue({
+        fingerprint: "mcp:1",
+        serverNames: ["context7"],
+      });
+
+      const showParams = buildCommandTestParams("/mcp show context7", buildCfg(), undefined, {
+        workspaceDir,
+      });
+      showParams.command.senderIsOwner = true;
+      const result = expectMcpResult(await handleMcpCommand(showParams, true));
+      expect(result.reply?.text).toContain("context7: ⚠️ connect ECONNREFUSED");
+    });
+  });
+
+  it("marks live state stale when the session catalog predates the current config", async () => {
+    await withTempHome("openclaw-command-mcp-home-", async () => {
+      const workspaceDir = await workspaceHarness.createWorkspace();
+      mcpServers.set("context7", { command: "uvx", args: ["context7-mcp"] });
+      const catalog = makeCatalog({
+        servers: { context7: { serverName: "context7", launchSummary: "uvx", toolCount: 3 } },
+      });
+      mcpRuntimeMocks.peekSessionMcpRuntime.mockReturnValue({
+        configFingerprint: "mcp:old",
+        peekCatalog: () => catalog,
+      });
+      mcpRuntimeMocks.resolveSessionMcpConfigSummary.mockReturnValue({
+        fingerprint: "mcp:new",
+        serverNames: ["context7"],
+      });
+
+      const showParams = buildCommandTestParams("/mcp show", buildCfg(), undefined, {
+        workspaceDir,
+      });
+      showParams.command.senderIsOwner = true;
+      const result = expectMcpResult(await handleMcpCommand(showParams, true));
+      expect(result.reply?.text).toContain(
+        "context7: ♻️ config changed since last connect (stale)",
+      );
+    });
+  });
+
+  it("shows a not-yet-discovered note when the session runtime has no catalog yet", async () => {
+    await withTempHome("openclaw-command-mcp-home-", async () => {
+      const workspaceDir = await workspaceHarness.createWorkspace();
+      mcpServers.set("context7", { command: "uvx", args: ["context7-mcp"] });
+      mcpRuntimeMocks.peekSessionMcpRuntime.mockReturnValue({
+        configFingerprint: "mcp:1",
+        peekCatalog: () => null,
+      });
+
+      const showParams = buildCommandTestParams("/mcp show", buildCfg(), undefined, {
+        workspaceDir,
+      });
+      showParams.command.senderIsOwner = true;
+      const result = expectMcpResult(await handleMcpCommand(showParams, true));
+      expect(result.reply?.text).toContain(
+        "🩺 Live state (session): not yet discovered — connects on next agent MCP tool use.",
+      );
+    });
+  });
+
+  it("omits the live-state section when no session runtime exists yet", async () => {
+    await withTempHome("openclaw-command-mcp-home-", async () => {
+      const workspaceDir = await workspaceHarness.createWorkspace();
+      mcpServers.set("context7", { command: "uvx", args: ["context7-mcp"] });
+
+      const showParams = buildCommandTestParams("/mcp show", buildCfg(), undefined, {
+        workspaceDir,
+      });
+      showParams.command.senderIsOwner = true;
+      const result = expectMcpResult(await handleMcpCommand(showParams, true));
+      expect(result.reply?.text).not.toContain("Live state");
+    });
   });
 
   it("writes MCP config and shows it back", async () => {

--- a/src/auto-reply/reply/commands-mcp.test.ts
+++ b/src/auto-reply/reply/commands-mcp.test.ts
@@ -226,9 +226,35 @@ describe("handleCommands /mcp", () => {
       });
       showParams.command.senderIsOwner = true;
       const result = expectMcpResult(await handleMcpCommand(showParams, true));
+      expect(result.reply?.text).toContain("🩺 Live state (session):");
       expect(result.reply?.text).toContain(
-        "🩺 Live state (session): not yet discovered — connects on next agent MCP tool use.",
+        "context7: ⏳ not yet discovered — connects on next agent MCP tool use.",
       );
+    });
+  });
+
+  it("shows disabled (not not-yet-discovered) for enabled:false servers even before the session catalog is built", async () => {
+    await withTempHome("openclaw-command-mcp-home-", async () => {
+      const workspaceDir = await workspaceHarness.createWorkspace();
+      mcpServers.set("context7", { command: "uvx", args: ["context7-mcp"], enabled: false });
+      // Session runtime exists but hasn't built a catalog yet (cold path) —
+      // the disabled check must still win over the generic "connects on next
+      // agent MCP tool use" fallback, since a disabled server never connects.
+      mcpRuntimeMocks.peekSessionMcpRuntime.mockReturnValue({
+        configFingerprint: "mcp:1",
+        workspaceDir,
+        peekCatalog: () => null,
+      });
+
+      const showParams = buildCommandTestParams("/mcp show", buildCfg(), undefined, {
+        workspaceDir,
+      });
+      showParams.command.senderIsOwner = true;
+      const result = expectMcpResult(await handleMcpCommand(showParams, true));
+      expect(result.reply?.text).toContain(
+        "context7: 🚫 disabled (enabled: false, excluded from runtime)",
+      );
+      expect(result.reply?.text).not.toContain("not yet discovered");
     });
   });
 

--- a/src/auto-reply/reply/commands-mcp.test.ts
+++ b/src/auto-reply/reply/commands-mcp.test.ts
@@ -14,7 +14,7 @@ const mcpRuntimeMocks = vi.hoisted(() => ({
     (params: {
       sessionId?: string | null;
       sessionKey?: string | null;
-    }) => Pick<SessionMcpRuntime, "configFingerprint" | "peekCatalog"> | undefined
+    }) => Pick<SessionMcpRuntime, "configFingerprint" | "peekCatalog" | "workspaceDir"> | undefined
   >(() => undefined),
   resolveSessionMcpConfigSummary: vi.fn(() => ({
     fingerprint: "mcp:0",
@@ -101,6 +101,7 @@ describe("handleCommands /mcp", () => {
       });
       mcpRuntimeMocks.peekSessionMcpRuntime.mockReturnValue({
         configFingerprint: "mcp:1",
+        workspaceDir,
         peekCatalog: () => catalog,
       });
       mcpRuntimeMocks.resolveSessionMcpConfigSummary.mockReturnValue({
@@ -135,6 +136,7 @@ describe("handleCommands /mcp", () => {
       });
       mcpRuntimeMocks.peekSessionMcpRuntime.mockReturnValue({
         configFingerprint: "mcp:1",
+        workspaceDir,
         peekCatalog: () => catalog,
       });
       mcpRuntimeMocks.resolveSessionMcpConfigSummary.mockReturnValue({
@@ -151,6 +153,36 @@ describe("handleCommands /mcp", () => {
     });
   });
 
+  it("shows a disabled live-state line instead of not-yet-discovered for enabled:false servers", async () => {
+    await withTempHome("openclaw-command-mcp-home-", async () => {
+      const workspaceDir = await workspaceHarness.createWorkspace();
+      mcpServers.set("context7", { command: "uvx", args: ["context7-mcp"], enabled: false });
+      // The bundle-MCP runtime excludes enabled:false servers entirely, so the
+      // warm catalog it built never mentions "context7" — not in servers, not
+      // in diagnostics. That absence must read as "disabled", not "pending".
+      const catalog = makeCatalog({ servers: {} });
+      mcpRuntimeMocks.peekSessionMcpRuntime.mockReturnValue({
+        configFingerprint: "mcp:1",
+        workspaceDir,
+        peekCatalog: () => catalog,
+      });
+      mcpRuntimeMocks.resolveSessionMcpConfigSummary.mockReturnValue({
+        fingerprint: "mcp:1",
+        serverNames: [],
+      });
+
+      const showParams = buildCommandTestParams("/mcp show", buildCfg(), undefined, {
+        workspaceDir,
+      });
+      showParams.command.senderIsOwner = true;
+      const result = expectMcpResult(await handleMcpCommand(showParams, true));
+      expect(result.reply?.text).toContain(
+        "context7: 🚫 disabled (enabled: false, excluded from runtime)",
+      );
+      expect(result.reply?.text).not.toContain("not yet discovered");
+    });
+  });
+
   it("marks live state stale when the session catalog predates the current config", async () => {
     await withTempHome("openclaw-command-mcp-home-", async () => {
       const workspaceDir = await workspaceHarness.createWorkspace();
@@ -160,6 +192,7 @@ describe("handleCommands /mcp", () => {
       });
       mcpRuntimeMocks.peekSessionMcpRuntime.mockReturnValue({
         configFingerprint: "mcp:old",
+        workspaceDir,
         peekCatalog: () => catalog,
       });
       mcpRuntimeMocks.resolveSessionMcpConfigSummary.mockReturnValue({
@@ -184,6 +217,7 @@ describe("handleCommands /mcp", () => {
       mcpServers.set("context7", { command: "uvx", args: ["context7-mcp"] });
       mcpRuntimeMocks.peekSessionMcpRuntime.mockReturnValue({
         configFingerprint: "mcp:1",
+        workspaceDir,
         peekCatalog: () => null,
       });
 

--- a/src/auto-reply/reply/commands-mcp.test.ts
+++ b/src/auto-reply/reply/commands-mcp.test.ts
@@ -17,7 +17,7 @@ const mcpRuntimeMocks = vi.hoisted(() => ({
     }) => Pick<SessionMcpRuntime, "configFingerprint" | "peekCatalog" | "workspaceDir"> | undefined
   >(() => undefined),
   resolveSessionMcpConfigSummary: vi.fn(() => ({
-    fingerprint: "mcp:0",
+    fingerprint: "mcp:1",
     serverNames: [] as string[],
   })),
 }));
@@ -87,7 +87,7 @@ describe("handleCommands /mcp", () => {
     await workspaceHarness.cleanupWorkspaces();
     mcpRuntimeMocks.peekSessionMcpRuntime.mockReset().mockReturnValue(undefined);
     mcpRuntimeMocks.resolveSessionMcpConfigSummary.mockReset().mockReturnValue({
-      fingerprint: "mcp:0",
+      fingerprint: "mcp:1",
       serverNames: [],
     });
   });
@@ -183,9 +183,6 @@ describe("handleCommands /mcp", () => {
     await withTempHome("openclaw-command-mcp-home-", async () => {
       const workspaceDir = await workspaceHarness.createWorkspace();
       mcpServers.set("context7", { command: "uvx", args: ["context7-mcp"], enabled: false });
-      // The bundle-MCP runtime excludes enabled:false servers entirely, so the
-      // warm catalog it built never mentions "context7" — not in servers, not
-      // in diagnostics. That absence must read as "disabled", not "pending".
       const catalog = makeCatalog({ servers: {} });
       mcpRuntimeMocks.peekSessionMcpRuntime.mockReturnValue({
         configFingerprint: "mcp:1",
@@ -237,6 +234,58 @@ describe("handleCommands /mcp", () => {
     });
   });
 
+  it("marks cold live state stale when the session runtime predates the current config", async () => {
+    await withTempHome("openclaw-command-mcp-home-", async () => {
+      const workspaceDir = await workspaceHarness.createWorkspace();
+      mcpServers.set("context7", { command: "uvx", args: ["context7-mcp"] });
+      mcpRuntimeMocks.peekSessionMcpRuntime.mockReturnValue({
+        configFingerprint: "mcp:old",
+        workspaceDir,
+        peekCatalog: () => null,
+      });
+      mcpRuntimeMocks.resolveSessionMcpConfigSummary.mockReturnValue({
+        fingerprint: "mcp:new",
+        serverNames: ["context7"],
+      });
+
+      const showParams = buildCommandTestParams("/mcp show", buildCfg(), undefined, {
+        workspaceDir,
+      });
+      showParams.command.senderIsOwner = true;
+      const result = expectMcpResult(await handleMcpCommand(showParams, true));
+      expect(result.reply?.text).toContain(
+        "context7: ♻️ config changed since last connect (stale)",
+      );
+      expect(result.reply?.text).not.toContain("not yet discovered");
+    });
+  });
+
+  it("marks disabled current config stale when an existing runtime predates the edit", async () => {
+    await withTempHome("openclaw-command-mcp-home-", async () => {
+      const workspaceDir = await workspaceHarness.createWorkspace();
+      mcpServers.set("context7", { command: "uvx", args: ["context7-mcp"], enabled: false });
+      mcpRuntimeMocks.peekSessionMcpRuntime.mockReturnValue({
+        configFingerprint: "mcp:old",
+        workspaceDir,
+        peekCatalog: () => null,
+      });
+      mcpRuntimeMocks.resolveSessionMcpConfigSummary.mockReturnValue({
+        fingerprint: "mcp:new",
+        serverNames: [],
+      });
+
+      const showParams = buildCommandTestParams("/mcp show", buildCfg(), undefined, {
+        workspaceDir,
+      });
+      showParams.command.senderIsOwner = true;
+      const result = expectMcpResult(await handleMcpCommand(showParams, true));
+      expect(result.reply?.text).toContain(
+        "context7: ♻️ config changed since last connect (stale)",
+      );
+      expect(result.reply?.text).not.toContain("disabled (enabled: false");
+    });
+  });
+
   it("computes staleness against the runtime's own workspaceDir, not the command's raw workspaceDir", async () => {
     await withTempHome("openclaw-command-mcp-home-", async () => {
       const commandWorkspaceDir = await workspaceHarness.createWorkspace();
@@ -245,10 +294,6 @@ describe("handleCommands /mcp", () => {
       const catalog = makeCatalog({
         servers: { context7: { serverName: "context7", launchSummary: "uvx", toolCount: 3 } },
       });
-      // Simulates a sandboxed session: the runtime was built from a different
-      // effective workspace than the raw command workspaceDir threaded
-      // through get-reply.ts. Regression guard for the sandbox-fingerprint
-      // fix — staleness must compare against runtime.workspaceDir.
       mcpRuntimeMocks.peekSessionMcpRuntime.mockReturnValue({
         configFingerprint: "mcp:1",
         workspaceDir: runtimeWorkspaceDir,
@@ -283,6 +328,10 @@ describe("handleCommands /mcp", () => {
         workspaceDir,
         peekCatalog: () => null,
       });
+      mcpRuntimeMocks.resolveSessionMcpConfigSummary.mockReturnValue({
+        fingerprint: "mcp:1",
+        serverNames: ["context7"],
+      });
 
       const showParams = buildCommandTestParams("/mcp show", buildCfg(), undefined, {
         workspaceDir,
@@ -300,13 +349,14 @@ describe("handleCommands /mcp", () => {
     await withTempHome("openclaw-command-mcp-home-", async () => {
       const workspaceDir = await workspaceHarness.createWorkspace();
       mcpServers.set("context7", { command: "uvx", args: ["context7-mcp"], enabled: false });
-      // Session runtime exists but hasn't built a catalog yet (cold path) —
-      // the disabled check must still win over the generic "connects on next
-      // agent MCP tool use" fallback, since a disabled server never connects.
       mcpRuntimeMocks.peekSessionMcpRuntime.mockReturnValue({
         configFingerprint: "mcp:1",
         workspaceDir,
         peekCatalog: () => null,
+      });
+      mcpRuntimeMocks.resolveSessionMcpConfigSummary.mockReturnValue({
+        fingerprint: "mcp:1",
+        serverNames: [],
       });
 
       const showParams = buildCommandTestParams("/mcp show", buildCfg(), undefined, {
@@ -332,10 +382,6 @@ describe("handleCommands /mcp", () => {
       });
       showParams.command.senderIsOwner = true;
       const result = expectMcpResult(await handleMcpCommand(showParams, true));
-      // Exact match against what /mcp show rendered before this PR (a single
-      // JSON block, no live-state block appended) — not just a substring
-      // check — so a future regression that always appends a live-state
-      // section (even an empty one) would be caught.
       const expectedLegacyText = `🔌 MCP servers (/tmp/openclaw.json)\n\`\`\`json\n${JSON.stringify(
         { context7: server },
         null,

--- a/src/auto-reply/reply/commands-mcp.ts
+++ b/src/auto-reply/reply/commands-mcp.ts
@@ -2,7 +2,7 @@
 import {
   peekSessionMcpRuntime,
   resolveSessionMcpConfigSummary,
-} from "../../agents/agent-bundle-mcp-runtime.js";
+} from "../../agents/agent-bundle-mcp-tools.js";
 import type { McpToolCatalog } from "../../agents/agent-bundle-mcp-types.js";
 import {
   listConfiguredMcpServers,

--- a/src/auto-reply/reply/commands-mcp.ts
+++ b/src/auto-reply/reply/commands-mcp.ts
@@ -30,17 +30,14 @@ function renderMcpServerLiveLine(params: {
   stale: boolean;
 }): string {
   const { serverName, disabled, catalog, stale } = params;
-  // Disabled state always wins: enabled:false servers never attempt a
-  // connection, so they must not be labeled "warming up"/"stale" even when
-  // the session catalog itself isn't built yet (catalog === null).
+  if (stale) {
+    return `- ${serverName}: ♻️ config changed since last connect (stale)`;
+  }
   if (disabled) {
     return `- ${serverName}: 🚫 disabled (enabled: false, excluded from runtime)`;
   }
   if (!catalog) {
     return `- ${serverName}: ⏳ not yet discovered — connects on next agent MCP tool use.`;
-  }
-  if (stale) {
-    return `- ${serverName}: ♻️ config changed since last connect (stale)`;
   }
   const server = catalog.servers[serverName];
   if (server) {
@@ -75,11 +72,11 @@ function renderMcpLiveStateSection(params: {
   // sandboxed sessions resolve MCP config from a different effective
   // workspace, so comparing against the command's own workspaceDir would
   // misreport every server as stale. Mirrors tools-effective.ts.
-  const stale = catalog
-    ? runtime.configFingerprint !==
-      resolveSessionMcpConfigSummary({ workspaceDir: runtime.workspaceDir, cfg: params.cfg })
-        .fingerprint
-    : false;
+  const currentSummary = resolveSessionMcpConfigSummary({
+    workspaceDir: runtime.workspaceDir,
+    cfg: params.cfg,
+  });
+  const stale = runtime.configFingerprint !== currentSummary.fingerprint;
   const lines = Object.entries(params.servers).map(([serverName, server]) => {
     const disabled = Boolean(
       server && typeof server === "object" && (server as { enabled?: unknown }).enabled === false,

--- a/src/auto-reply/reply/commands-mcp.ts
+++ b/src/auto-reply/reply/commands-mcp.ts
@@ -26,12 +26,18 @@ function renderJsonBlock(label: string, value: unknown): string {
 function renderMcpServerLiveLine(params: {
   serverName: string;
   disabled: boolean;
-  catalog: McpToolCatalog;
+  catalog: McpToolCatalog | null;
   stale: boolean;
 }): string {
   const { serverName, disabled, catalog, stale } = params;
+  // Disabled state always wins: enabled:false servers never attempt a
+  // connection, so they must not be labeled "warming up"/"stale" even when
+  // the session catalog itself isn't built yet (catalog === null).
   if (disabled) {
     return `- ${serverName}: 🚫 disabled (enabled: false, excluded from runtime)`;
+  }
+  if (!catalog) {
+    return `- ${serverName}: ⏳ not yet discovered — connects on next agent MCP tool use.`;
   }
   if (stale) {
     return `- ${serverName}: ♻️ config changed since last connect (stale)`;
@@ -64,19 +70,16 @@ function renderMcpLiveStateSection(params: {
     return undefined;
   }
   const catalog = runtime.peekCatalog();
-  if (!catalog) {
-    return "🩺 Live state (session): not yet discovered — connects on next agent MCP tool use.";
-  }
   // Compare against the same workspace-derived fingerprint the runtime was
   // built from (runtime.workspaceDir), not the command's raw workspaceDir:
   // sandboxed sessions resolve MCP config from a different effective
   // workspace, so comparing against the command's own workspaceDir would
   // misreport every server as stale. Mirrors tools-effective.ts.
-  const configSummary = resolveSessionMcpConfigSummary({
-    workspaceDir: runtime.workspaceDir,
-    cfg: params.cfg,
-  });
-  const stale = runtime.configFingerprint !== configSummary.fingerprint;
+  const stale = catalog
+    ? runtime.configFingerprint !==
+      resolveSessionMcpConfigSummary({ workspaceDir: runtime.workspaceDir, cfg: params.cfg })
+        .fingerprint
+    : false;
   const lines = Object.entries(params.servers).map(([serverName, server]) => {
     const disabled = Boolean(
       server && typeof server === "object" && (server as { enabled?: unknown }).enabled === false,

--- a/src/auto-reply/reply/commands-mcp.ts
+++ b/src/auto-reply/reply/commands-mcp.ts
@@ -25,10 +25,14 @@ function renderJsonBlock(label: string, value: unknown): string {
 
 function renderMcpServerLiveLine(params: {
   serverName: string;
+  disabled: boolean;
   catalog: McpToolCatalog;
   stale: boolean;
 }): string {
-  const { serverName, catalog, stale } = params;
+  const { serverName, disabled, catalog, stale } = params;
+  if (disabled) {
+    return `- ${serverName}: 🚫 disabled (enabled: false, excluded from runtime)`;
+  }
   if (stale) {
     return `- ${serverName}: ♻️ config changed since last connect (stale)`;
   }
@@ -51,9 +55,8 @@ function renderMcpServerLiveLine(params: {
  * session runtime exists yet, preserving prior /mcp show output.
  */
 function renderMcpLiveStateSection(params: {
-  serverNames: string[];
+  servers: Record<string, unknown>;
   sessionKey: string;
-  workspaceDir: string;
   cfg: OpenClawConfig;
 }): string | undefined {
   const runtime = peekSessionMcpRuntime({ sessionKey: params.sessionKey });
@@ -64,14 +67,22 @@ function renderMcpLiveStateSection(params: {
   if (!catalog) {
     return "🩺 Live state (session): not yet discovered — connects on next agent MCP tool use.";
   }
+  // Compare against the same workspace-derived fingerprint the runtime was
+  // built from (runtime.workspaceDir), not the command's raw workspaceDir:
+  // sandboxed sessions resolve MCP config from a different effective
+  // workspace, so comparing against the command's own workspaceDir would
+  // misreport every server as stale. Mirrors tools-effective.ts.
   const configSummary = resolveSessionMcpConfigSummary({
-    workspaceDir: params.workspaceDir,
+    workspaceDir: runtime.workspaceDir,
     cfg: params.cfg,
   });
   const stale = runtime.configFingerprint !== configSummary.fingerprint;
-  const lines = params.serverNames.map((serverName) =>
-    renderMcpServerLiveLine({ serverName, catalog, stale }),
-  );
+  const lines = Object.entries(params.servers).map(([serverName, server]) => {
+    const disabled = Boolean(
+      server && typeof server === "object" && (server as { enabled?: unknown }).enabled === false,
+    );
+    return renderMcpServerLiveLine({ serverName, disabled, catalog, stale });
+  });
   return ["🩺 Live state (session):", ...lines].join("\n");
 }
 
@@ -123,9 +134,8 @@ export const handleMcpCommand: CommandHandler = async (params, allowTextCommands
         };
       }
       const liveState = renderMcpLiveStateSection({
-        serverNames: [mcpCommand.name],
+        servers: { [mcpCommand.name]: server },
         sessionKey: params.sessionKey,
-        workspaceDir: params.workspaceDir,
         cfg: params.cfg,
       });
       const text = renderJsonBlock(`🔌 MCP server "${mcpCommand.name}" (${loaded.path})`, server);
@@ -141,9 +151,8 @@ export const handleMcpCommand: CommandHandler = async (params, allowTextCommands
       };
     }
     const liveState = renderMcpLiveStateSection({
-      serverNames: Object.keys(loaded.mcpServers),
+      servers: loaded.mcpServers,
       sessionKey: params.sessionKey,
-      workspaceDir: params.workspaceDir,
       cfg: params.cfg,
     });
     const text = renderJsonBlock(`🔌 MCP servers (${loaded.path})`, loaded.mcpServers);

--- a/src/auto-reply/reply/commands-mcp.ts
+++ b/src/auto-reply/reply/commands-mcp.ts
@@ -1,9 +1,15 @@
 /** Handles /mcp commands for showing and mutating configured MCP servers. */
 import {
+  peekSessionMcpRuntime,
+  resolveSessionMcpConfigSummary,
+} from "../../agents/agent-bundle-mcp-runtime.js";
+import type { McpToolCatalog } from "../../agents/agent-bundle-mcp-types.js";
+import {
   listConfiguredMcpServers,
   setConfiguredMcpServer,
   unsetConfiguredMcpServer,
 } from "../../config/mcp-config.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
   rejectNonOwnerCommand,
   rejectUnauthorizedCommand,
@@ -15,6 +21,58 @@ import { parseMcpCommand } from "./mcp-commands.js";
 
 function renderJsonBlock(label: string, value: unknown): string {
   return `${label}\n\`\`\`json\n${JSON.stringify(value, null, 2)}\n\`\`\``;
+}
+
+function renderMcpServerLiveLine(params: {
+  serverName: string;
+  catalog: McpToolCatalog;
+  stale: boolean;
+}): string {
+  const { serverName, catalog, stale } = params;
+  if (stale) {
+    return `- ${serverName}: ♻️ config changed since last connect (stale)`;
+  }
+  const server = catalog.servers[serverName];
+  if (server) {
+    const toolLabel = server.toolCount === 1 ? "tool" : "tools";
+    return `- ${serverName}: ✅ connected (${server.toolCount} ${toolLabel})`;
+  }
+  const diagnostic = catalog.diagnostics?.find((entry) => entry.serverName === serverName);
+  if (diagnostic) {
+    return `- ${serverName}: ⚠️ ${diagnostic.message}`;
+  }
+  return `- ${serverName}: ⏳ not yet discovered`;
+}
+
+/**
+ * Renders observed session-runtime state alongside static /mcp show config.
+ * Read-only: uses peekSessionMcpRuntime/peekCatalog, which must not create
+ * runtimes or connect transports. Returns undefined (no section) when no
+ * session runtime exists yet, preserving prior /mcp show output.
+ */
+function renderMcpLiveStateSection(params: {
+  serverNames: string[];
+  sessionKey: string;
+  workspaceDir: string;
+  cfg: OpenClawConfig;
+}): string | undefined {
+  const runtime = peekSessionMcpRuntime({ sessionKey: params.sessionKey });
+  if (!runtime) {
+    return undefined;
+  }
+  const catalog = runtime.peekCatalog();
+  if (!catalog) {
+    return "🩺 Live state (session): not yet discovered — connects on next agent MCP tool use.";
+  }
+  const configSummary = resolveSessionMcpConfigSummary({
+    workspaceDir: params.workspaceDir,
+    cfg: params.cfg,
+  });
+  const stale = runtime.configFingerprint !== configSummary.fingerprint;
+  const lines = params.serverNames.map((serverName) =>
+    renderMcpServerLiveLine({ serverName, catalog, stale }),
+  );
+  return ["🩺 Live state (session):", ...lines].join("\n");
 }
 
 /** Command handler for /mcp show/set/unset operations. */
@@ -64,11 +122,16 @@ export const handleMcpCommand: CommandHandler = async (params, allowTextCommands
           reply: { text: `🔌 No MCP server named "${mcpCommand.name}" in ${loaded.path}.` },
         };
       }
+      const liveState = renderMcpLiveStateSection({
+        serverNames: [mcpCommand.name],
+        sessionKey: params.sessionKey,
+        workspaceDir: params.workspaceDir,
+        cfg: params.cfg,
+      });
+      const text = renderJsonBlock(`🔌 MCP server "${mcpCommand.name}" (${loaded.path})`, server);
       return {
         shouldContinue: false,
-        reply: {
-          text: renderJsonBlock(`🔌 MCP server "${mcpCommand.name}" (${loaded.path})`, server),
-        },
+        reply: { text: liveState ? `${text}\n\n${liveState}` : text },
       };
     }
     if (Object.keys(loaded.mcpServers).length === 0) {
@@ -77,11 +140,16 @@ export const handleMcpCommand: CommandHandler = async (params, allowTextCommands
         reply: { text: `🔌 No MCP servers configured in ${loaded.path}.` },
       };
     }
+    const liveState = renderMcpLiveStateSection({
+      serverNames: Object.keys(loaded.mcpServers),
+      sessionKey: params.sessionKey,
+      workspaceDir: params.workspaceDir,
+      cfg: params.cfg,
+    });
+    const text = renderJsonBlock(`🔌 MCP servers (${loaded.path})`, loaded.mcpServers);
     return {
       shouldContinue: false,
-      reply: {
-        text: renderJsonBlock(`🔌 MCP servers (${loaded.path})`, loaded.mcpServers),
-      },
+      reply: { text: liveState ? `${text}\n\n${liveState}` : text },
     };
   }
 


### PR DESCRIPTION
## What Problem This Solves

`/mcp show` only ever prints the static `mcp.servers` config. When an MCP
server fails to connect, or connected but the session's config changed
since, the command gives no signal of that: the static config was never
wrong, so users end up debugging config that's fine while the actual
problem — a broken MCP runtime — stays invisible.

## Why This Change Was Made

The embedded-agent MCP runtime already tracks per-session connect/catalog/
failure state through `peekSessionMcpRuntime()` + `SessionMcpRuntime
.peekCatalog()` + `resolveSessionMcpConfigSummary()` — all three read-only
and session-scoped, never creating a runtime, connecting a transport, or
issuing an MCP request. This is the same primitives and peek-without-
connecting pattern the `tools.effective` gateway method already uses
(`src/gateway/server-methods/tools-effective.ts`), imported through the
same existing public facade (`agents/agent-bundle-mcp-tools.js`) that
method and `session.ts` already use — no new module, no new access path,
and no new load-time cost (that facade is already resident on every
message via `get-reply.ts` → `session.ts`).

This PR threads that already-reachable state into `/mcp show`'s reply as a
separate "🩺 Live state (session)" block, one line per configured server:
`♻️ config changed since last connect (stale)`, `🚫 disabled (enabled:
false, excluded from runtime)`, `✅ connected (N tools)`, `⚠️ <last connect
diagnostic>`, or `⏳ not yet discovered` — in that precedence order, so a
config edit is reported as staleness even for servers whose catalog entry
is still cold. "Stale" compares against the full merged session MCP config
fingerprint (static `mcp.servers` plus any plugin/bundle-contributed
servers), not a per-server diff, so one config edit anywhere in that set
marks every displayed server stale together.

It is purely observational: no daemon/protocol surface was added, no new
persistent state, and no change to `/mcp set|unset` behavior or MCP config
semantics. When no `SessionMcpRuntime` exists yet for the current chat
session, `/mcp show`'s output is byte-identical to before this PR —
verified with an exact-text assertion, not just a substring check.

Non-goals:
- The tool-call failure backoff/pause counter (`serverBackoff` inside
  `createSessionMcpRuntime`) is private closure state not exposed on the
  `SessionMcpRuntime` type; surfacing it needs a new accessor on that core
  runtime file, out of scope for this display-only change.
- A server whose static config can't resolve to any transport is skipped
  before the session catalog even attempts it, so it still renders `⏳ not
  yet discovered` rather than a specific "invalid config" message. This PR
  only surfaces outcomes the session runtime already recorded.

`docs/tools/slash-commands.md` already lists `/mcp show`'s existence and
syntax; it doesn't specify exact reply text, so it didn't need updating.

## User Impact

Once an embedded agent has run in the current chat session with bundled
MCP enabled, `/mcp show` now shows, right next to the static config,
whether each server is actually connected this session and how many tools
it exposed, or why it isn't — without needing to correlate logs or guess.
Before that runtime exists, `/mcp show` looks exactly as it did before this
PR.

## Evidence

- `node scripts/run-vitest.mjs src/auto-reply/reply/commands-mcp.test.ts` →
  16/16 passed: connected (plural/singular tool count), connect-diagnostic,
  disabled (warm- and cold-catalog paths), stale config (warm catalog, plus
  stale reported ahead of the cold-catalog "not yet discovered"/"disabled"
  labels), staleness computed from the runtime's own `workspaceDir` (not
  the command's raw `workspaceDir` — regression guard for sandboxed
  sessions), no-catalog-yet, no-runtime-yet (exact-text baseline match).
- `pnpm tsgo:core`, `pnpm tsgo:core:test` → clean
- `pnpm exec oxfmt --check`, `node scripts/run-oxlint.mjs` on touched files
  → clean
- `git diff --check` (upstream/main...HEAD) → clean

### Real behavior proof (redacted terminal output)

Production command/runtime paths end to end: `loadConfig()` reads a real
`openclaw.json`, `getOrCreateSessionMcpRuntime()` + `getCatalog()` connect a
real local stdio MCP server child process (a tiny standalone script speaking
MCP JSON-RPC over stdio), and the reply below comes from the production
`handleMcpCommand` `/mcp show` handler. No unit-test doubles of any MCP,
config, or command code are involved, and no live external API is used.

````
$ git rev-parse --abbrev-ref HEAD && git rev-parse HEAD
fix/mcp-show-live-state
a8854226e784cba2697f1b5c7cb304dad1c19623
$ node --import tsx .proof-98730.ts   # production-path proof driver

[1. /mcp show BEFORE any session MCP runtime exists (baseline)]
🔌 MCP servers (<state-dir>/openclaw.json)
```json
{
  "proof-demo": {
    "command": "node",
    "args": [
      "<proof-dir>/fake-mcp-server.mjs"
    ]
  }
}
```

[2. Warm real SessionMcpRuntime via getOrCreateSessionMcpRuntime + getCatalog()]
sessionKey=agent:main:whatsapp:proof-owner
catalog servers: {"proof-demo":{"serverName":"proof-demo","safeServerName":"proof-demo","launchSummary":"node <proof-dir>/fake-mcp-server.mjs","toolCount":2,"requestTimeoutMs":60000,"supportsParallelToolCalls":false,"tools":{"listChanged":false}}}
catalog tools: proof-demo/proof_echo, proof-demo/proof_time

[3. /mcp show AFTER warm-up, same sessionKey]
🔌 MCP servers (<state-dir>/openclaw.json)
[static config block identical to step 1]

🩺 Live state (session):
- proof-demo: ✅ connected (2 tools)

[4. /mcp show for a DIFFERENT sessionKey (proves session-bound)]
🔌 MCP servers (<state-dir>/openclaw.json)
[static config block identical to step 1 — no live-state section]

PROOF OK: all assertions passed
EXIT=0
````

Step 4 shows the same `/mcp show` for a different `sessionKey` returning
only the static config block, byte-identical to the pre-warm baseline of
step 1 — the live-state block is bound to the session that actually warmed
MCP, not global. (`[static config block identical to step 1]` marks blocks
elided here for brevity; the driver also asserts each step's expectation
and exits non-zero on any mismatch.)
