### PR TITLE
fix(compaction): skip no-op compaction when there is nothing to summarize

### DIFF
--- a/src/agents/sessions/agent-session.ts
+++ b/src/agents/sessions/agent-session.ts
@@ -1933,9 +1933,20 @@ export class AgentSession {
       return { status: "skipped" };
     }
 
+    const hasBeforeCompactHandler =
+      this.currentExtensionRunner.hasHandlers("session_before_compact");
+    const nothingToSummarize =
+      preparation.messagesToSummarize.length === 0 && preparation.turnPrefixMessages.length === 0;
+    if (nothingToSummarize && !hasBeforeCompactHandler) {
+      if (isManual) {
+        throw new Error("Nothing to compact (session too small)");
+      }
+      return { status: "skipped" };
+    }
+
     let compactionResult: CompactionResult | undefined;
     let fromExtension = false;
-    if (this.currentExtensionRunner.hasHandlers("session_before_compact")) {
+    if (hasBeforeCompactHandler) {
       const extensionResult = await this.currentExtensionRunner.emit({
         type: "session_before_compact",
         preparation,

--- a/src/agents/sessions/compaction-skip-empty.test.ts
+++ b/src/agents/sessions/compaction-skip-empty.test.ts
@@ -1,0 +1,206 @@
+import { createAssistantMessageEventStream } from "openclaw/plugin-sdk/llm";
+import { describe, expect, it } from "vitest";
+import type { AssistantMessage, Context, Model, SimpleStreamOptions } from "../../llm/types.js";
+import { AuthStorage } from "./auth-storage.js";
+import { createExtensionRuntime } from "./extensions/loader.js";
+import type { LoadExtensionsResult } from "./extensions/types.js";
+import { ModelRegistry } from "./model-registry.js";
+import type { ResourceLoader } from "./resource-loader.js";
+import { createAgentSession } from "./sdk.js";
+import { SessionManager } from "./session-manager.js";
+import { SettingsManager } from "./settings-manager.js";
+import { createSyntheticSourceInfo } from "./source-info.js";
+
+const smallModel: Model = {
+  id: "small-context",
+  name: "Small Context",
+  api: "anthropic-messages",
+  provider: "anthropic",
+  baseUrl: "https://example.test",
+  reasoning: false,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 16000,
+  maxTokens: 4000,
+};
+
+function resourceLoaderWith(
+  handlers: Map<string, Array<(...args: unknown[]) => Promise<unknown>>>,
+): ResourceLoader {
+  const extensionsResult: LoadExtensionsResult = {
+    extensions:
+      handlers.size > 0
+        ? [
+            {
+              path: "<test-extension>",
+              resolvedPath: "<test-extension>",
+              sourceInfo: createSyntheticSourceInfo("<test-extension>", { source: "temporary" }),
+              handlers,
+              tools: new Map(),
+              messageRenderers: new Map(),
+              commands: new Map(),
+              flags: new Map(),
+              shortcuts: new Map(),
+            },
+          ]
+        : [],
+    errors: [],
+    runtime: createExtensionRuntime(),
+  };
+  return {
+    getExtensions: () => extensionsResult,
+    getSkills: () => ({ skills: [], diagnostics: [] }),
+    getPrompts: () => ({ prompts: [], diagnostics: [] }),
+    getThemes: () => ({ themes: [], diagnostics: [] }),
+    getAgentsFiles: () => ({ agentsFiles: [] }),
+    getSystemPrompt: () => undefined,
+    getAppendSystemPrompt: () => [],
+    extendResources: () => {},
+    reload: async () => {},
+  };
+}
+
+function keepAllSessionManager(): SessionManager {
+  const sessionManager = SessionManager.inMemory();
+  sessionManager.appendMessage({
+    role: "user",
+    content: [{ type: "text", text: "hi there" }],
+    timestamp: Date.now(),
+  } as Parameters<SessionManager["appendMessage"]>[0]);
+  sessionManager.appendMessage({
+    role: "assistant",
+    content: [{ type: "text", text: "hello, how can I help?" }],
+    api: "anthropic-messages",
+    provider: "anthropic",
+    model: smallModel.id,
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "stop",
+    timestamp: Date.now(),
+  } as Parameters<SessionManager["appendMessage"]>[0]);
+  return sessionManager;
+}
+
+async function buildSession(params: {
+  sessionManager: SessionManager;
+  resourceLoader: ResourceLoader;
+}): Promise<{
+  session: Awaited<ReturnType<typeof createAgentSession>>["session"];
+  calls: () => number;
+}> {
+  const { session } = await createAgentSession({
+    model: smallModel,
+    resourceLoader: params.resourceLoader,
+    sessionManager: params.sessionManager,
+    settingsManager: SettingsManager.inMemory(),
+    modelRegistry: ModelRegistry.inMemory(AuthStorage.inMemory()),
+  });
+
+  let summarizationCalls = 0;
+  session.agent.streamFn = ((_model: Model, _context: Context, _options?: SimpleStreamOptions) => {
+    summarizationCalls += 1;
+    const summaryMessage: AssistantMessage = {
+      role: "assistant",
+      content: [{ type: "text", text: "SUMMARY-OF-NOTHING" }],
+      api: smallModel.api,
+      provider: smallModel.provider,
+      model: smallModel.id,
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "stop",
+      timestamp: Date.now(),
+    };
+    const stream = createAssistantMessageEventStream();
+    stream.push({ type: "done", reason: "stop", message: summaryMessage });
+    stream.end();
+    return stream;
+  }) as typeof session.agent.streamFn;
+
+  return { session, calls: () => summarizationCalls };
+}
+
+function runCompaction(session: unknown, settings: unknown) {
+  return (
+    session as {
+      runCompactionWork: (options: {
+        settings: unknown;
+        signal: AbortSignal;
+        mode: "manual" | "auto";
+      }) => Promise<{ status: string }>;
+    }
+  ).runCompactionWork({ settings, signal: new AbortController().signal, mode: "auto" });
+}
+
+describe("runCompactionWork with nothing to summarize", () => {
+  it("skips the no-op compaction when no session_before_compact handler is registered", async () => {
+    const sessionManager = keepAllSessionManager();
+    const { session, calls } = await buildSession({
+      sessionManager,
+      resourceLoader: resourceLoaderWith(new Map()),
+    });
+    const settings = SettingsManager.inMemory().getCompactionSettings();
+
+    const outcome = await runCompaction(session, settings);
+
+    expect(outcome.status).toBe("skipped");
+    expect(calls()).toBe(0);
+    expect(sessionManager.getEntries().some((entry) => entry.type === "compaction")).toBe(false);
+  });
+
+  it("still delivers the empty preparation to a registered session_before_compact handler", async () => {
+    let deliveredMessages = -1;
+    let deliveredTurnPrefix = -1;
+    const handlers = new Map<string, Array<(...args: unknown[]) => Promise<unknown>>>([
+      [
+        "session_before_compact",
+        [
+          async (event: unknown) => {
+            const typed = event as {
+              preparation: {
+                messagesToSummarize: unknown[];
+                turnPrefixMessages: unknown[];
+                firstKeptEntryId: string;
+                tokensBefore: number;
+              };
+            };
+            deliveredMessages = typed.preparation.messagesToSummarize.length;
+            deliveredTurnPrefix = typed.preparation.turnPrefixMessages.length;
+            return {
+              compaction: {
+                summary: "from-handler",
+                firstKeptEntryId: typed.preparation.firstKeptEntryId,
+                tokensBefore: typed.preparation.tokensBefore,
+              },
+            };
+          },
+        ],
+      ],
+    ]);
+    const sessionManager = keepAllSessionManager();
+    const { session, calls } = await buildSession({
+      sessionManager,
+      resourceLoader: resourceLoaderWith(handlers),
+    });
+    const settings = SettingsManager.inMemory().getCompactionSettings();
+
+    const outcome = await runCompaction(session, settings);
+
+    expect(deliveredMessages).toBe(0);
+    expect(deliveredTurnPrefix).toBe(0);
+    expect(outcome.status).toBe("compacted");
+    expect(calls()).toBe(0);
+    expect(sessionManager.getEntries().some((entry) => entry.type === "compaction")).toBe(true);
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

On the default compaction path, a triggered compaction that has nothing to trim still spends a summarization request on an empty conversation and appends a keep-all compaction entry that trims nothing.

`prepareCompaction` (`packages/agent-core/src/harness/compaction/compaction.ts`) returns a preparation whose `messagesToSummarize` and `turnPrefixMessages` are both empty whenever `findCutPoint` keeps the whole summarizable window (`firstKeptEntryIndex === boundaryStart`, not a split turn). This keep-all case is reachable when the window is smaller than `keepRecentTokens` (default 20000), i.e. on small-context models or young/small sessions that trip a threshold or overflow compaction. `AgentSession.runCompactionWork` then falls into `compact()`'s non-split branch, which calls `generateSummary([])` unconditionally and appends a compaction entry pinned at the first entry (keeps everything, summary of nothing).

## Why This Change Was Made

This is a correctness and efficiency fix: one wasted summarization round trip plus a junk keep-all compaction entry per triggered compaction on that path. It is not a data-loss defect; the live small-context overflow situation is separately handled by preemptive compaction and by the adjacent budget-cap work in open PR #87927.

The fix is placed at the session boundary rather than in `prepareCompaction` on purpose. In `mode: "safeguard"` a `session_before_compact` extension handler intercepts the empty preparation and does real work (branch-fallback summarization, plus the #41981 re-trigger-suppression boundary write). Returning `undefined` from `prepareCompaction` would bypass that handler. `runCompactionWork` is the layer that knows whether an extension will consume the preparation, so the skip decision belongs there.

## Root cause

`src/agents/sessions/agent-session.ts`, `runCompactionWork`, after `prepareCompaction` returns a preparation (before this change):

```ts
let compactionResult: CompactionResult | undefined;
let fromExtension = false;
if (this.currentExtensionRunner.hasHandlers("session_before_compact")) {
  // ...extension path...
}

compactionResult ??= unwrapCoreResult(
  await compact(preparation, this.model, /* ... */),
);
```

When the preparation is empty and no `session_before_compact` handler is registered, `compact()` runs a summarization on an empty conversation and returns a keep-all entry that is then appended.

## Fix

```ts
const hasBeforeCompactHandler =
  this.currentExtensionRunner.hasHandlers("session_before_compact");
const nothingToSummarize =
  preparation.messagesToSummarize.length === 0 && preparation.turnPrefixMessages.length === 0;
if (nothingToSummarize && !hasBeforeCompactHandler) {
  if (isManual) {
    throw new Error("Nothing to compact (session too small)");
  }
  return { status: "skipped" };
}
```

Auto compaction returns the existing `{ status: "skipped" }`; manual `/compact` throws the existing "Nothing to compact (session too small)" message, matching the current undefined-preparation behavior. When a handler is present, execution falls through to the unchanged emit/compact path.

## Why this is the right boundary

- `prepareCompaction` in `packages/agent-core` is left untouched, so `mode: "safeguard"` still receives the empty preparation and its `session_before_compact` path (`src/agents/agent-hooks/compaction-safeguard.ts`, including the #41981 re-trigger-suppression fix) is fully preserved.
- The skip only engages when nothing will consume the empty preparation (no handler), which is exactly the default path where the summarization and appended entry are pure waste.
- Adjacent, not overlapping: open PR #87927 caps `reserveTokens`/`keepRecentTokens` for small contexts in `src/agents/agent-settings.ts` and `src/agents/agent-compaction-constants.ts`; it does not add an empty-summarize guard. Closed PR #95748 touched the safeguard and cron surfaces, which this change deliberately does not modify.

## Verification

- `node scripts/run-vitest.mjs src/agents/sessions/compaction-skip-empty.test.ts`: 2 passing (fails on pristine main: the no-handler case returns "compacted" instead of "skipped").
- `node scripts/run-oxlint.mjs` on both changed files: clean.
- `oxfmt --check` on both changed files: clean.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json`: clean (includes the changed `src/agents/sessions/agent-session.ts`).
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.agents.json`: clean (includes the new colocated regression file).

## Evidence

The regression is colocated in `src/agents/sessions/compaction-skip-empty.test.ts`. It drives the real `AgentSession.runCompactionWork` with a real `SessionManager`, real `prepareCompaction`/`findCutPoint`/`compact` routing, and controls only whether a `session_before_compact` handler is registered. Live before/after captured below.

## Real behavior proof
Behavior addressed: a triggered compaction with a keep-all cut (nothing to trim) and no session_before_compact handler runs one summarization request on an empty conversation and appends a keep-all compaction entry.
Real environment tested: pristine main (68bfa42b9b) versus the patched tree, both driving the real AgentSession.runCompactionWork with a real in-memory SessionManager holding a small keep-all session; real prepareCompaction, findCutPoint, and compact routing stay in play; the only substituted seam is the summarization completion stream, instrumented to count invocations.
Exact steps or command run after this patch: build a two-message keep-all session (user + assistant, well under keepRecentTokens), then call AgentSession.runCompactionWork in auto mode, first with no session_before_compact handler and then with one registered.
Evidence after fix:
```
# BEFORE (pristine main 68bfa42b9b)
[default: no session_before_compact handler]
status=compacted
summarizationCalls=1
compactionEntryAppended=true
[safeguard: session_before_compact handler registered]
handlerReceivedPreparation=true
handler.preparation.messagesToSummarize.len=0
status=compacted

# AFTER (this patch, identical inputs)
[default: no session_before_compact handler]
status=skipped
summarizationCalls=0
compactionEntryAppended=false
[safeguard: session_before_compact handler registered]
handlerReceivedPreparation=true
handler.preparation.messagesToSummarize.len=0
status=compacted
```
Observed result after fix: on the default path the empty compaction is skipped with zero summarization calls and no appended entry, while the safeguard path still receives the empty preparation and proceeds unchanged.
What was not tested: no live provider summarization request was issued; the full build was not run (scoped runners only). The safeguard-mode empty-preparation behavior is intentionally unchanged and not modified here.
