### PR TITLE
fix(telegram): preserve rich forwarded message text

### DIFF
--- a/extensions/telegram/src/bot-message-context.body.test.ts
+++ b/extensions/telegram/src/bot-message-context.body.test.ts
@@ -98,6 +98,76 @@ describe("resolveTelegramInboundBody", () => {
     expect(result?.bodyText).toBe("[unsupported Telegram rich_message received]");
   });
 
+  it("extracts text from rich-message-only updates", async () => {
+    const result = await resolveTelegramBody({
+      msg: {
+        message_id: 0,
+        date: 1_700_000_000,
+        chat: { id: 42, type: "private", first_name: "Pat" },
+        from: { id: 42, first_name: "Pat" },
+        rich_message: {
+          blocks: [
+            {
+              type: "paragraph",
+              text: [{ type: "plain", text: "Forwarded rich text" }],
+            },
+          ],
+        },
+      } as never,
+    });
+
+    expect(result?.rawBody).toBe("Forwarded rich text");
+    expect(result?.bodyText).toBe("Forwarded rich text");
+  });
+
+  it("preserves whitespace across rich-message inline text spans", async () => {
+    const result = await resolveTelegramBody({
+      msg: {
+        message_id: 0,
+        date: 1_700_000_000,
+        chat: { id: 42, type: "private", first_name: "Pat" },
+        from: { id: 42, first_name: "Pat" },
+        rich_message: {
+          blocks: [
+            {
+              type: "paragraph",
+              text: [
+                { type: "plain", text: "Forwarded " },
+                { type: "bold", text: "rich text" },
+              ],
+            },
+          ],
+        },
+      } as never,
+    });
+
+    expect(result?.rawBody).toBe("Forwarded rich text");
+  });
+
+  it("extracts markdown and html rich-message text", async () => {
+    const markdownResult = await resolveTelegramBody({
+      msg: {
+        message_id: 0,
+        date: 1_700_000_000,
+        chat: { id: 42, type: "private", first_name: "Pat" },
+        from: { id: 42, first_name: "Pat" },
+        rich_message: { markdown: "Forwarded **markdown**" },
+      } as never,
+    });
+    const htmlResult = await resolveTelegramBody({
+      msg: {
+        message_id: 0,
+        date: 1_700_000_000,
+        chat: { id: 42, type: "private", first_name: "Pat" },
+        from: { id: 42, first_name: "Pat" },
+        rich_message: { html: "<p>Forwarded html</p>" },
+      } as never,
+    });
+
+    expect(markdownResult?.rawBody).toBe("Forwarded **markdown**");
+    expect(htmlResult?.rawBody).toBe("Forwarded html");
+  });
+
   it("keeps rich-message placeholders quiet in requireMention groups", async () => {
     const logger = { info: vi.fn() };
     const result = await resolveTelegramBody({
@@ -125,6 +195,76 @@ describe("resolveTelegramInboundBody", () => {
       "skipping group message",
     );
     expect(result).toBeNull();
+  });
+
+  it("routes rich-message-only updates that match group mention patterns", async () => {
+    const logger = { info: vi.fn() };
+    const result = await resolveTelegramBody({
+      cfg: {
+        channels: { telegram: {} },
+        messages: { groupChat: { mentionPatterns: ["\\btelegram\\b"] } },
+      } as never,
+      msg: {
+        message_id: 1,
+        date: 1_700_000_001,
+        chat: { id: -1001234567890, type: "supergroup", title: "Test Group" },
+        from: { id: 42, first_name: "Pat" },
+        rich_message: {
+          blocks: [
+            {
+              type: "paragraph",
+              text: [{ type: "plain", text: "telegram please read this" }],
+            },
+          ],
+        },
+      } as never,
+      isGroup: true,
+      chatId: -1001234567890,
+      senderId: "42",
+      groupConfig: { requireMention: true } as never,
+      requireMention: true,
+      logger,
+    });
+
+    expect(logger.info).not.toHaveBeenCalledWith(
+      { chatId: -1001234567890, reason: "no-mention" },
+      "skipping group message",
+    );
+    expect(result?.rawBody).toBe("telegram please read this");
+    expect(result?.effectiveWasMentioned).toBe(true);
+  });
+
+  it("routes rich-message-only updates that mention the bot username", async () => {
+    const logger = { info: vi.fn() };
+    const result = await resolveTelegramBody({
+      msg: {
+        message_id: 1,
+        date: 1_700_000_001,
+        chat: { id: -1001234567890, type: "supergroup", title: "Test Group" },
+        from: { id: 42, first_name: "Pat" },
+        rich_message: {
+          blocks: [
+            {
+              type: "paragraph",
+              text: [{ type: "plain", text: "@bot please read this" }],
+            },
+          ],
+        },
+      } as never,
+      isGroup: true,
+      chatId: -1001234567890,
+      senderId: "42",
+      groupConfig: { requireMention: true } as never,
+      requireMention: true,
+      logger,
+    });
+
+    expect(logger.info).not.toHaveBeenCalledWith(
+      { chatId: -1001234567890, reason: "no-mention" },
+      "skipping group message",
+    );
+    expect(result?.rawBody).toBe("@bot please read this");
+    expect(result?.effectiveWasMentioned).toBe(true);
   });
 
   it("renders Telegram text entities before building the agent body", async () => {

--- a/extensions/telegram/src/bot-message-context.body.ts
+++ b/extensions/telegram/src/bot-message-context.body.ts
@@ -39,10 +39,12 @@ import {
   buildSenderName,
   extractTelegramLocation,
   getTelegramTextParts,
+  hasBotMentionInText,
   hasBotMention,
   renderTelegramTextEntities,
   resolveTelegramPrimaryMedia,
-  resolveTelegramRichMessagePlaceholder,
+  resolveTelegramRichMessageBody,
+  resolveTelegramRichMessageText,
 } from "./bot/body-helpers.js";
 import { buildTelegramGroupPeerId, buildTelegramInboundOriginTarget } from "./bot/helpers.js";
 import type { TelegramContext } from "./bot/types.js";
@@ -275,10 +277,11 @@ export async function resolveTelegramInboundBody(params: {
     messageTextParts.text,
     messageTextParts.entities,
   ).trim();
+  const richText = resolveTelegramRichMessageText(msg);
   const hasUserText = Boolean(rawText || locationText);
   let rawBody = [rawText, locationText].filter(Boolean).join("\n").trim();
   if (!rawBody) {
-    rawBody = resolveTelegramRichMessagePlaceholder(msg) ?? placeholder;
+    rawBody = resolveTelegramRichMessageBody(msg) ?? placeholder;
   }
   if (!rawBody && allMedia.length === 0) {
     return null;
@@ -366,9 +369,12 @@ export async function resolveTelegramInboundBody(params: {
   }
 
   const hasAnyMention = messageTextParts.entities.some((ent) => ent.type === "mention");
-  const explicitlyMentioned = botUsername ? hasBotMention(msg, botUsername) : false;
+  const explicitlyMentioned = botUsername
+    ? hasBotMention(msg, botUsername) ||
+      (richText ? hasBotMentionInText(richText, botUsername) : false)
+    : false;
   const computedWasMentioned = matchesMentionWithExplicit({
-    text: messageTextParts.text,
+    text: messageTextParts.text || richText || "",
     mentionRegexes,
     explicit: {
       hasAnyMention,

--- a/extensions/telegram/src/bot-message-context.body.ts
+++ b/extensions/telegram/src/bot-message-context.body.ts
@@ -43,7 +43,7 @@ import {
   hasBotMention,
   renderTelegramTextEntities,
   resolveTelegramPrimaryMedia,
-  resolveTelegramRichMessageBody,
+  resolveTelegramRichMessagePlaceholder,
   resolveTelegramRichMessageText,
 } from "./bot/body-helpers.js";
 import { buildTelegramGroupPeerId, buildTelegramInboundOriginTarget } from "./bot/helpers.js";
@@ -281,7 +281,7 @@ export async function resolveTelegramInboundBody(params: {
   const hasUserText = Boolean(rawText || locationText);
   let rawBody = [rawText, locationText].filter(Boolean).join("\n").trim();
   if (!rawBody) {
-    rawBody = resolveTelegramRichMessageBody(msg) ?? placeholder;
+    rawBody = richText ?? resolveTelegramRichMessagePlaceholder(msg) ?? placeholder;
   }
   if (!rawBody && allMedia.length === 0) {
     return null;

--- a/extensions/telegram/src/bot/body-helpers.ts
+++ b/extensions/telegram/src/bot/body-helpers.ts
@@ -5,6 +5,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { telegramHtmlToPlainTextFallback } from "../format.js";
 
 type TelegramMediaMessage = Pick<
   Message,
@@ -103,10 +104,83 @@ function hasTelegramRichMessage(value: unknown): boolean {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function compactRichText(value: string): string {
+  return value
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .join("\n");
+}
+
+function joinRichText(parts: string[], separator: string): string {
+  return parts.map(compactRichText).filter(Boolean).join(separator);
+}
+
+function renderRichInlineText(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map(renderRichInlineText).filter(Boolean).join("");
+  }
+  if (!isRecord(value)) {
+    return "";
+  }
+  const directText = value.text;
+  if (directText !== undefined) {
+    return renderRichInlineText(directText);
+  }
+  for (const key of ["alternative_text", "expression"] as const) {
+    const text = value[key];
+    if (typeof text === "string") {
+      return text;
+    }
+  }
+  return "";
+}
+
+function renderRichBlocks(value: unknown): string {
+  if (Array.isArray(value)) {
+    return joinRichText(value.map(renderRichBlocks), "\n");
+  }
+  if (!isRecord(value)) {
+    return renderRichInlineText(value);
+  }
+  if (typeof value.markdown === "string") {
+    return value.markdown;
+  }
+  if (typeof value.html === "string") {
+    return telegramHtmlToPlainTextFallback(value.html);
+  }
+  const parts: string[] = [];
+  for (const key of ["text", "title", "subtitle", "caption", "credit"] as const) {
+    parts.push(renderRichInlineText(value[key]));
+  }
+  for (const key of ["blocks", "items", "rows", "cells", "headers", "children"] as const) {
+    parts.push(renderRichBlocks(value[key]));
+  }
+  return joinRichText(parts, "\n");
+}
+
 export function resolveTelegramRichMessagePlaceholder(
   msg: TelegramTextMessage,
 ): string | undefined {
   return hasTelegramRichMessage(msg.rich_message) ? TELEGRAM_RICH_MESSAGE_PLACEHOLDER : undefined;
+}
+
+export function resolveTelegramRichMessageText(msg: TelegramTextMessage): string | undefined {
+  if (!hasTelegramRichMessage(msg.rich_message)) {
+    return undefined;
+  }
+  return compactRichText(renderRichBlocks(msg.rich_message)) || undefined;
+}
+
+export function resolveTelegramRichMessageBody(msg: TelegramTextMessage): string | undefined {
+  return resolveTelegramRichMessageText(msg) ?? resolveTelegramRichMessagePlaceholder(msg);
 }
 
 export function isBinaryContent(text: string): boolean {
@@ -179,6 +253,13 @@ export function hasBotMention(msg: Message, botUsername: string) {
     }
   }
   return false;
+}
+
+export function hasBotMentionInText(text: string, botUsername: string): boolean {
+  return hasStandaloneTelegramMention(
+    normalizeLowercaseStringOrEmpty(text),
+    normalizeLowercaseStringOrEmpty(`@${botUsername}`),
+  );
 }
 
 type TelegramMarkdownEntity = {

--- a/extensions/telegram/src/bot/helpers.test.ts
+++ b/extensions/telegram/src/bot/helpers.test.ts
@@ -525,6 +525,31 @@ describe("describeReplyTarget", () => {
     expect(result?.quoteSourceText).toBeUndefined();
   });
 
+  it("describes rich-message-only reply targets with rich text", () => {
+    const result = describeReplyTarget({
+      message_id: 2,
+      date: 1000,
+      chat: { id: 1, type: "private" },
+      reply_to_message: {
+        message_id: 1,
+        date: 900,
+        chat: { id: 1, type: "private" },
+        rich_message: {
+          blocks: [
+            {
+              type: "paragraph",
+              text: [{ type: "plain", text: "Forwarded reply text" }],
+            },
+          ],
+        },
+        from: { id: 42, first_name: "Alice", is_bot: false },
+      },
+    } as never);
+
+    expect(result?.body).toBe("Forwarded reply text");
+    expect(result?.quoteSourceText).toBeUndefined();
+  });
+
   it("drops binary reply captions with no safe fallback", () => {
     const result = describeReplyTarget({
       message_id: 2,

--- a/extensions/telegram/src/bot/helpers.ts
+++ b/extensions/telegram/src/bot/helpers.ts
@@ -34,13 +34,16 @@ import {
   buildSenderName,
   extractTelegramLocation,
   getTelegramTextParts,
+  hasBotMentionInText,
   hasBotMention,
   isBinaryContent,
   normalizeForwardedContext,
   renderTelegramTextEntities,
   resolveTelegramTextContent,
   resolveTelegramMediaPlaceholder,
+  resolveTelegramRichMessageBody,
   resolveTelegramRichMessagePlaceholder,
+  resolveTelegramRichMessageText,
   type TelegramForwardedContext,
   type TelegramTextEntity,
 } from "./body-helpers.js";
@@ -52,12 +55,15 @@ export {
   buildSenderName,
   extractTelegramLocation,
   getTelegramTextParts,
+  hasBotMentionInText,
   hasBotMention,
   isBinaryContent,
   normalizeForwardedContext,
   renderTelegramTextEntities,
   resolveTelegramMediaPlaceholder,
+  resolveTelegramRichMessageBody,
   resolveTelegramRichMessagePlaceholder,
+  resolveTelegramRichMessageText,
 };
 
 const TELEGRAM_GENERAL_TOPIC_ID = 1;
@@ -629,8 +635,7 @@ export function describeReplyTarget(msg: Message): TelegramReplyTarget | null {
   const safeReplyText = replyTextParts?.text ?? "";
   let filteredReplyText = false;
   if (!body && replyLike) {
-    const replyBody =
-      safeReplyText.trim() || resolveTelegramRichMessagePlaceholder(replyLike) || "";
+    const replyBody = safeReplyText.trim() || resolveTelegramRichMessageBody(replyLike) || "";
     filteredReplyText = hadUnsafeTelegramText(rawReplyText, replyBody);
     body = replyBody;
     if (!body) {

--- a/extensions/telegram/src/message-cache.test.ts
+++ b/extensions/telegram/src/message-cache.test.ts
@@ -600,6 +600,56 @@ describe("telegram message cache", () => {
     });
   });
 
+  it("preserves rich-message text in subsequent conversation context", async () => {
+    const cache = createTelegramMessageCache();
+    const chat = { id: 7, type: "private", first_name: "Nora" } as const;
+    await cache.record({
+      accountId: "default",
+      chatId: 7,
+      msg: {
+        chat,
+        message_id: 45,
+        date: 1736380745,
+        rich_message: {
+          blocks: [
+            {
+              type: "paragraph",
+              text: [{ type: "plain", text: "Forwarded cache text" }],
+            },
+          ],
+        },
+        from: { id: 1, is_bot: false, first_name: "Nora" },
+      } as Message,
+    });
+    await cache.record({
+      accountId: "default",
+      chatId: 7,
+      msg: {
+        chat,
+        message_id: 46,
+        date: 1736380746,
+        text: "What did I just send?",
+        from: { id: 1, is_bot: false, first_name: "Nora" },
+      } as Message,
+    });
+
+    const context = await buildTelegramConversationContext({
+      cache,
+      accountId: "default",
+      chatId: 7,
+      messageId: "46",
+      replyChainNodes: [],
+      recentLimit: 10,
+      replyTargetWindowSize: 2,
+    });
+
+    expect(context).toHaveLength(1);
+    expect(context[0]?.node).toMatchObject({
+      messageId: "45",
+      body: "Forwarded cache text",
+    });
+  });
+
   it("returns nearby messages around a stale reply target", async () => {
     const cache = createTelegramMessageCache();
     for (const id of [100, 101, 102, 200, 201]) {

--- a/extensions/telegram/src/message-cache.ts
+++ b/extensions/telegram/src/message-cache.ts
@@ -7,10 +7,7 @@ import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
 import type { MsgContext } from "openclaw/plugin-sdk/reply-runtime";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
-import {
-  resolveTelegramPrimaryMedia,
-  resolveTelegramRichMessagePlaceholder,
-} from "./bot/body-helpers.js";
+import { resolveTelegramPrimaryMedia, resolveTelegramRichMessageBody } from "./bot/body-helpers.js";
 import {
   buildSenderName,
   extractTelegramLocation,
@@ -155,9 +152,7 @@ function resolveMessageBody(msg: Message): string | undefined {
   if (location) {
     return formatLocationText(location);
   }
-  return (
-    resolveTelegramRichMessagePlaceholder(msg) ?? resolveTelegramPrimaryMedia(msg)?.placeholder
-  );
+  return resolveTelegramRichMessageBody(msg) ?? resolveTelegramPrimaryMedia(msg)?.placeholder;
 }
 
 function resolveMediaType(placeholder?: string): string | undefined {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Telegram messages delivered as rich messages could reach the agent as `[unsupported Telegram rich_message received]` instead of the visible message text.

This affected rich-message-only Telegram updates, including forwarded messages from clients where Telegram leaves `text` and `caption` empty but populates `rich_message`.

## Why This Change Was Made

Telegram inbound body resolution now extracts visible text from `rich_message.markdown`, `rich_message.html`, and nested rich message blocks before falling back to the existing unsupported placeholder.

The same extraction path is used for the main inbound body, reply-target descriptions, and cached conversation context so rich-message text does not disappear in follow-up turns. Unsupported rich message shapes still keep the loud placeholder.

AI-assisted.

## User Impact

Users can forward or send Telegram rich messages to the bot and have the agent see the actual message body. In `requireMention` groups, rich-message-only updates also participate in mention detection when the extracted rich text mentions the bot or matches configured mention patterns.

## Evidence

Before-fix live repro on `origin/main` at `8d9a7ab2cab`:

```text
sent rich message 41658: RICH_FORWARD_MAIN_mr2d52u7 forwarded rich body text
observed SUT reply 41659
mock request promptHasRichText=false
mock request promptHasPlaceholder=true
excerpt: [unsupported Telegram rich_message received]
```

Focused tests after the fix:

```text
node scripts/run-vitest.mjs extensions/telegram/src/bot-message-context.body.test.ts extensions/telegram/src/message-cache.test.ts extensions/telegram/src/bot/helpers.test.ts
Test Files  3 passed (3)
Tests       129 passed (129)
```

Other checks:

```text
git diff --check
.agents/skills/autoreview/scripts/autoreview --mode local
autoreview clean: no accepted/actionable findings reported
```

After-fix live Telegram rerun was attempted, but the shared SUT bot token was being polled elsewhere:

```text
Telegram getUpdates conflict: terminated by other getUpdates request
```
