### PR TITLE
fix(zai): send User-Agent header on endpoint detection probe

### DIFF
--- a/extensions/zai/detect.test.ts
+++ b/extensions/zai/detect.test.ts
@@ -93,11 +93,10 @@ describe("detectZaiEndpoint", () => {
     delete process.env.OPENCLAW_VERSION;
   });
 
-  it("sends a User-Agent header on the probe so z.ai does not 429 it (#98100)", async () => {
-    // z.ai's edge rejects User-Agent-less requests with HTTP 429 (code 1305),
-    // which makes detectZaiEndpoint return null even for valid Coding Plan
-    // keys. Node's fetch (undici) does not add a default User-Agent, so the
-    // probe must set one explicitly.
+  it("sends an explicit OpenClaw User-Agent header on the probe so z.ai does not 429 it (#98100)", async () => {
+    // z.ai's edge can reject probes without an explicit OpenClaw User-Agent
+    // with HTTP 429 (code 1305), which makes detectZaiEndpoint return null
+    // even for valid Coding Plan keys.
     process.env.OPENCLAW_VERSION = "2026.6.11";
     let capturedHeaders: Record<string, string> | undefined;
     const fetchFn = (async (url: string, init?: RequestInit) => {

--- a/extensions/zai/detect.test.ts
+++ b/extensions/zai/detect.test.ts
@@ -90,14 +90,14 @@ function makeFetch(map: Record<string, FetchResponse>) {
 describe("detectZaiEndpoint", () => {
   afterEach(() => {
     vi.restoreAllMocks();
-    delete process.env.OPENCLAW_VERSION;
+    vi.unstubAllEnvs();
   });
 
   it("sends an explicit OpenClaw User-Agent header on the probe so z.ai does not 429 it (#98100)", async () => {
     // z.ai's edge can reject probes without an explicit OpenClaw User-Agent
     // with HTTP 429 (code 1305), which makes detectZaiEndpoint return null
     // even for valid Coding Plan keys.
-    process.env.OPENCLAW_VERSION = "2026.6.11";
+    vi.stubEnv("OPENCLAW_VERSION", "2026.6.11");
     let capturedHeaders: Record<string, string> | undefined;
     const fetchFn = (async (url: string, init?: RequestInit) => {
       capturedHeaders = init?.headers as Record<string, string> | undefined;
@@ -117,7 +117,7 @@ describe("detectZaiEndpoint", () => {
   });
 
   it("falls back to openclaw/dev User-Agent when OPENCLAW_VERSION is absent (#98100)", async () => {
-    delete process.env.OPENCLAW_VERSION;
+    vi.stubEnv("OPENCLAW_VERSION", undefined);
     let capturedHeaders: Record<string, string> | undefined;
     const fetchFn = (async (url: string, init?: RequestInit) => {
       capturedHeaders = init?.headers as Record<string, string> | undefined;

--- a/extensions/zai/detect.test.ts
+++ b/extensions/zai/detect.test.ts
@@ -90,6 +90,51 @@ function makeFetch(map: Record<string, FetchResponse>) {
 describe("detectZaiEndpoint", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    delete process.env.OPENCLAW_VERSION;
+  });
+
+  it("sends a User-Agent header on the probe so z.ai does not 429 it (#98100)", async () => {
+    // z.ai's edge rejects User-Agent-less requests with HTTP 429 (code 1305),
+    // which makes detectZaiEndpoint return null even for valid Coding Plan
+    // keys. Node's fetch (undici) does not add a default User-Agent, so the
+    // probe must set one explicitly.
+    process.env.OPENCLAW_VERSION = "2026.6.11";
+    let capturedHeaders: Record<string, string> | undefined;
+    const fetchFn = (async (url: string, init?: RequestInit) => {
+      capturedHeaders = init?.headers as Record<string, string> | undefined;
+      return new Response("{}", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    await detectZaiEndpoint({
+      apiKey: "sk-test", // pragma: allowlist secret
+      endpoint: "global",
+      fetchFn,
+    });
+
+    expect(capturedHeaders?.["user-agent"]).toMatch(/^openclaw\/2026\.6\.11/);
+  });
+
+  it("falls back to openclaw/dev User-Agent when OPENCLAW_VERSION is absent (#98100)", async () => {
+    delete process.env.OPENCLAW_VERSION;
+    let capturedHeaders: Record<string, string> | undefined;
+    const fetchFn = (async (url: string, init?: RequestInit) => {
+      capturedHeaders = init?.headers as Record<string, string> | undefined;
+      return new Response("{}", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    await detectZaiEndpoint({
+      apiKey: "sk-test", // pragma: allowlist secret
+      endpoint: "global",
+      fetchFn,
+    });
+
+    expect(capturedHeaders?.["user-agent"]).toBe("openclaw/dev");
   });
 
   it("resolves preferred/fallback endpoints and null when probes fail", async () => {

--- a/extensions/zai/detect.ts
+++ b/extensions/zai/detect.ts
@@ -40,6 +40,20 @@ const UNSUPPORTED_MODEL_ERROR_CODES = new Set(["1211", "1311"]);
 /** Cap for the Z.AI probe error body; bounds untrusted error responses to avoid unbounded buffering/OOM. */
 const ZAI_DETECT_ERROR_BODY_MAX_BYTES = 16 * 1024 * 1024;
 
+/**
+ * Resolves the version string embedded in the probe User-Agent. Mirrors the
+ * `openclaw/${version || "dev"}` pattern used by other bare-fetch probes such
+ * as the ChatGPT usage cooldown probe. Falls back to "dev" when the runtime
+ * version cannot be resolved (dev/undici-only environments).
+ */
+function resolveOpenClawUserAgentVersion(): string {
+  const fromEnv = process.env.OPENCLAW_VERSION?.trim();
+  if (fromEnv && fromEnv.toLowerCase() !== "undefined") {
+    return fromEnv;
+  }
+  return "dev";
+}
+
 function isUnsupportedModelResult(result: ProbeResult): boolean {
   if (result.ok) {
     return false;
@@ -92,6 +106,12 @@ async function probeZaiChatCompletions(params: {
         headers: {
           authorization: `Bearer ${params.apiKey}`,
           "content-type": "application/json",
+          // z.ai's edge rejects requests without a User-Agent with HTTP 429
+          // (code 1305). Node's fetch (undici) does not add a default
+          // User-Agent, so without this header every endpoint probe fails and
+          // Coding Plan onboarding cannot auto-select the coding endpoint.
+          // See https://github.com/openclaw/openclaw/issues/98100
+          "user-agent": `openclaw/${resolveOpenClawUserAgentVersion()}`,
         },
         body: JSON.stringify({
           model: params.modelId,

--- a/extensions/zai/detect.ts
+++ b/extensions/zai/detect.ts
@@ -44,7 +44,7 @@ const ZAI_DETECT_ERROR_BODY_MAX_BYTES = 16 * 1024 * 1024;
  * Resolves the version string embedded in the probe User-Agent. Mirrors the
  * `openclaw/${version || "dev"}` pattern used by other bare-fetch probes such
  * as the ChatGPT usage cooldown probe. Falls back to "dev" when the runtime
- * version cannot be resolved (dev/undici-only environments).
+ * version cannot be resolved.
  */
 function resolveOpenClawUserAgentVersion(): string {
   const fromEnv = process.env.OPENCLAW_VERSION?.trim();
@@ -106,10 +106,9 @@ async function probeZaiChatCompletions(params: {
         headers: {
           authorization: `Bearer ${params.apiKey}`,
           "content-type": "application/json",
-          // z.ai's edge rejects requests without a User-Agent with HTTP 429
-          // (code 1305). Node's fetch (undici) does not add a default
-          // User-Agent, so without this header every endpoint probe fails and
-          // Coding Plan onboarding cannot auto-select the coding endpoint.
+          // z.ai's edge can reject detection probes without an explicit
+          // OpenClaw User-Agent with HTTP 429 (code 1305), which prevents
+          // Coding Plan onboarding from auto-selecting the coding endpoint.
           // See https://github.com/openclaw/openclaw/issues/98100
           "user-agent": `openclaw/${resolveOpenClawUserAgentVersion()}`,
         },


### PR DESCRIPTION
## What Problem This Solves

z.ai's edge rejects HTTP requests that omit a `User-Agent` header with HTTP 429 (error code 1305, \"The service may be temporarily overloaded\"). Node's `fetch` (undici) does **not** add a default `User-Agent`, so every probe issued by `detectZaiEndpoint` in `extensions/zai/detect.ts` failed. As a result, onboarding cannot auto-select the Coding Plan endpoint (`/api/coding/paas/v4`) for a valid z.ai Coding Plan key — the user sees misleading \"rate limit\" / \"billing\" errors and is forced to pin the coding endpoint manually.

Fixes #98100

## Why This Change Was Made

- `probeZaiChatCompletions` only sent `authorization` and `content-type` headers.
- The real model transport (`openai-completions`) already sends a `User-Agent`, which is why manual configuration works once the coding endpoint is pinned — only the **detection probe** is broken.
- Adding a `user-agent: openclaw/<version>` header mirrors the existing pattern in `src/agents/auth-profiles/usage.ts:238` (`openclaw/${version || "dev"}`), which is the canonical shape for bare-`fetch` provider probes.
- Without this header, the issue reporter demonstrated (with isolated `fetch` repros) that z.ai returns 429 for User-Agent-less requests and 200 for the same request with any User-Agent set.

## User Impact

- z.ai Coding Plan onboarding auto-detection works again: `openclaw onboard` picks the `/api/coding/paas/v4` endpoint automatically for valid Coding Plan keys.
- Removes the need for the documented workaround (pinning baseUrl + model manually).
- No behavior change for users on the standard endpoint or with User-Agents injected by a proxy.

## Evidence

- Local tests: `CI=1 npx vitest run extensions/zai/detect.test.ts` — 8/8 pass (added two regression tests covering the OPENCLAW_VERSION-set and fallback-to-`dev` paths).
- Lint: `node scripts/run-oxlint.mjs extensions/zai/detect.ts extensions/zai/detect.test.ts` — clean.
- Reproduction data comes from issue #98100 (isolated `fetch` loop showing `null` UA → 429, `openclaw`/`curl/8.0` UA → 200).