### PR TITLE
fix(agents): fail fast with attributable reason after MCP stdio session dies mid-run

### DIFF
--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -1036,6 +1036,136 @@ process.on("SIGINT", shutdown);`,
     }
   });
 
+  it("marks the MCP session disconnected and fails tool calls fast after the child process is killed mid-session", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "bundle-mcp-kill-mid-session-"));
+    const serverPath = path.join(tempDir, "kill-mid-session.mjs");
+    const pidPath = path.join(tempDir, "server.pid");
+    await writeExecutable(
+      serverPath,
+      `#!/usr/bin/env node
+import fs from "node:fs/promises";
+
+const pidPath = ${JSON.stringify(pidPath)};
+await fs.writeFile(pidPath, String(process.pid), "utf8");
+
+let buffer = "";
+function send(message) {
+  process.stdout.write(JSON.stringify(message) + "\\n");
+}
+function handle(message) {
+  if (!message || typeof message !== "object") {
+    return;
+  }
+  if (message.method === "initialize") {
+    send({
+      jsonrpc: "2.0",
+      id: message.id,
+      result: {
+        protocolVersion: message.params?.protocolVersion ?? "2025-03-26",
+        capabilities: { tools: {} },
+        serverInfo: { name: "kill-mid-session", version: "1.0.0" },
+      },
+    });
+    return;
+  }
+  if (message.method === "notifications/initialized") {
+    return;
+  }
+  if (message.method === "tools/list") {
+    send({
+      jsonrpc: "2.0",
+      id: message.id,
+      result: { tools: [{ name: "ok_tool", inputSchema: { type: "object", properties: {} } }] },
+    });
+    return;
+  }
+  if (message.method === "tools/call") {
+    send({
+      jsonrpc: "2.0",
+      id: message.id,
+      result: { isError: false, content: [{ type: "text", text: "still connected" }] },
+    });
+  }
+}
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => {
+  buffer += chunk;
+  while (true) {
+    const newline = buffer.indexOf("\\n");
+    if (newline < 0) {
+      return;
+    }
+    const line = buffer.slice(0, newline).replace(/\\r$/, "");
+    buffer = buffer.slice(newline + 1);
+    if (line.trim()) {
+      handle(JSON.parse(line));
+    }
+  }
+});`,
+    );
+
+    const runtime = await getOrCreateSessionMcpRuntime({
+      sessionId: "session-kill-mid-session",
+      sessionKey: "agent:test:session-kill-mid-session",
+      workspaceDir: "/workspace",
+      cfg: {
+        mcp: {
+          servers: {
+            killable: {
+              command: process.execPath,
+              args: [serverPath],
+            },
+          },
+        },
+      },
+    });
+
+    try {
+      const firstCatalog = await runtime.getCatalog();
+      expect(firstCatalog.tools.map((tool) => tool.toolName)).toEqual(["ok_tool"]);
+
+      const firstResult = await runtime.callTool("killable", "ok_tool", {});
+      expect(firstResult.content[0]).toEqual({ type: "text", text: "still connected" });
+
+      await waitForFileText(pidPath, "", LIST_TOOLS_SERVER_LOG_TIMEOUT_MS);
+      const pid = Number.parseInt((await fs.readFile(pidPath, "utf8")).trim(), 10);
+      expect(Number.isInteger(pid)).toBe(true);
+      process.kill(pid, "SIGKILL");
+
+      // Poll instead of a fixed delay: the child's close event races the test.
+      // Once it lands, `connected` flips and every subsequent call fails fast
+      // with the attributable reason instead of a generic/timeout error.
+      let sawDisconnectedMessage = "";
+      const deadline = Date.now() + LIST_TOOLS_SERVER_LOG_TIMEOUT_MS;
+      while (Date.now() < deadline && !sawDisconnectedMessage) {
+        try {
+          await runtime.callTool("killable", "ok_tool", {});
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          if (message.includes("is disconnected")) {
+            sawDisconnectedMessage = message;
+            break;
+          }
+        }
+        await new Promise((resolve) => {
+          setTimeout(resolve, 10);
+        });
+      }
+      expect(sawDisconnectedMessage).toBe(
+        `bundle-mcp server "killable" is disconnected: mcp transport closed`,
+      );
+
+      const start = Date.now();
+      await expect(runtime.callTool("killable", "ok_tool", {})).rejects.toThrow(
+        `bundle-mcp server "killable" is disconnected: mcp transport closed`,
+      );
+      expect(Date.now() - start).toBeLessThan(200);
+    } finally {
+      await runtime.dispose();
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("does not cache a catalog invalidated while discovery is in flight", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "bundle-mcp-inflight-invalidated-"));
     const serverPath = path.join(tempDir, "inflight-invalidated.mjs");

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -1166,6 +1166,139 @@ process.stdin.on("data", (chunk) => {
     }
   });
 
+  it("retires a reused session that dies mid-refresh instead of leaving it reachable", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "bundle-mcp-die-mid-refresh-"));
+    const serverPath = path.join(tempDir, "die-mid-refresh.mjs");
+    const logPath = path.join(tempDir, "server.log");
+    await writeExecutable(
+      serverPath,
+      `#!/usr/bin/env node
+import fs from "node:fs/promises";
+
+const logPath = ${JSON.stringify(logPath)};
+let buffer = "";
+let listCount = 0;
+function log(line) {
+  void fs.appendFile(logPath, line + "\\n", "utf8").catch(() => {});
+}
+function send(message) {
+  process.stdout.write(JSON.stringify(message) + "\\n");
+}
+function handle(message) {
+  if (!message || typeof message !== "object") {
+    return;
+  }
+  if (message.method === "initialize") {
+    send({
+      jsonrpc: "2.0",
+      id: message.id,
+      result: {
+        protocolVersion: message.params?.protocolVersion ?? "2025-03-26",
+        capabilities: { tools: { listChanged: true } },
+        serverInfo: { name: "die-mid-refresh", version: "1.0.0" },
+      },
+    });
+    return;
+  }
+  if (message.method === "notifications/initialized") {
+    return;
+  }
+  if (message.method === "tools/list") {
+    listCount += 1;
+    if (listCount === 1) {
+      send({
+        jsonrpc: "2.0",
+        id: message.id,
+        result: {
+          tools: [{ name: "ok_tool", inputSchema: { type: "object", properties: {} } }],
+        },
+      });
+      setTimeout(() => {
+        send({ jsonrpc: "2.0", method: "notifications/tools/list_changed" });
+        log("sent tools/list_changed");
+      }, 10);
+      return;
+    }
+    // Second tools/list: die without responding, simulating the child
+    // process crashing mid-refresh (after the reused session was already
+    // marked connected, before this catalog pass finishes).
+    log("dying mid tools/list");
+    process.exit(1);
+  }
+  if (message.method === "tools/call") {
+    send({
+      jsonrpc: "2.0",
+      id: message.id,
+      result: { isError: false, content: [{ type: "text", text: "still connected" }] },
+    });
+  }
+}
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => {
+  buffer += chunk;
+  while (true) {
+    const newline = buffer.indexOf("\\n");
+    if (newline < 0) {
+      return;
+    }
+    const line = buffer.slice(0, newline).replace(/\\r$/, "");
+    buffer = buffer.slice(newline + 1);
+    if (line.trim()) {
+      handle(JSON.parse(line));
+    }
+  }
+});`,
+    );
+
+    const runtime = await getOrCreateSessionMcpRuntime({
+      sessionId: "session-die-mid-refresh",
+      sessionKey: "agent:test:session-die-mid-refresh",
+      workspaceDir: "/workspace",
+      cfg: {
+        mcp: {
+          servers: {
+            volatile: {
+              command: process.execPath,
+              args: [serverPath],
+            },
+          },
+        },
+      },
+    });
+
+    try {
+      const firstCatalog = await runtime.getCatalog();
+      expect(firstCatalog.tools.map((tool) => tool.toolName)).toEqual(["ok_tool"]);
+
+      await waitForFileText(logPath, "sent tools/list_changed", LIST_TOOLS_SERVER_LOG_TIMEOUT_MS);
+      await waitForPredicate(
+        () => runtime.peekCatalog() === null,
+        "list_changed to invalidate the catalog",
+        LIST_TOOLS_SERVER_LOG_TIMEOUT_MS,
+      );
+
+      // Refresh reuses the still-"connected" session; the child dies mid
+      // tools/list, flipping session.connected via onclose before this
+      // refresh's catch block runs.
+      const refreshedCatalog = await runtime.getCatalog();
+      expect(refreshedCatalog.tools).toEqual([]);
+      expect(refreshedCatalog.diagnostics?.[0]?.serverName).toBe("volatile");
+
+      // The dead session must be retired within this same refresh, not left
+      // dangling for a future rebuild to notice. If it were left dangling,
+      // callTool would find the stale session object and throw "is
+      // disconnected: mcp transport closed"; a properly retired session is
+      // simply absent, so callTool throws the plain "not connected" message
+      // (a fresh session gets created on the next successful catalog build).
+      await expect(runtime.callTool("volatile", "ok_tool", {})).rejects.toThrow(
+        'bundle-mcp server "volatile" is not connected',
+      );
+    } finally {
+      await runtime.dispose();
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("does not cache a catalog invalidated while discovery is in flight", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "bundle-mcp-inflight-invalidated-"));
     const serverPath = path.join(tempDir, "inflight-invalidated.mjs");

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -46,7 +46,10 @@ async function writeListToolsMcpServer(params: {
   inputSchema?: unknown;
   tools?: Array<{ name: string; description?: string; inputSchema?: unknown }>;
   capabilities?: Record<string, unknown>;
+  pidPath?: string;
   notifyListChangedOnInitialized?: boolean;
+  notifyListChangedAfterFirstList?: boolean;
+  exitOnListCall?: number;
   listToolsMethodNotFound?: boolean;
   callToolIsError?: boolean;
   callToolJsonRpcError?: boolean;
@@ -62,7 +65,10 @@ const delayMs = ${params.delayMs ?? 0};
 const initializeDelayMs = ${params.initializeDelayMs ?? 0};
 const hang = ${params.hang === true};
 const capabilities = ${JSON.stringify(params.capabilities ?? { tools: {} })};
+const pidPath = ${JSON.stringify(params.pidPath)};
 const notifyListChangedOnInitialized = ${params.notifyListChangedOnInitialized === true};
+const notifyListChangedAfterFirstList = ${params.notifyListChangedAfterFirstList === true};
+const exitOnListCall = ${params.exitOnListCall ?? 0};
 const listToolsMethodNotFound = ${params.listToolsMethodNotFound === true};
 const tools = ${JSON.stringify(
       params.tools ?? [
@@ -78,8 +84,12 @@ const callToolJsonRpcError = ${params.callToolJsonRpcError === true};
 const resourceListJsonRpcError = ${params.resourceListJsonRpcError === true};
 
 let buffer = "";
+let listCount = 0;
 let pendingTimer;
 let keepAlive;
+if (pidPath) {
+  await fs.writeFile(pidPath, String(process.pid), "utf8");
+}
 function log(line) {
   void fs.appendFile(logPath, line + "\\n", "utf8").catch(() => {});
 }
@@ -116,6 +126,11 @@ function handle(message) {
     return;
   }
   if (message.method === "tools/list") {
+    listCount += 1;
+    if (listCount === exitOnListCall) {
+      log("exit tools/list " + listCount);
+      process.exit(1);
+    }
     if (listToolsMethodNotFound) {
       log("reject tools/list method not found");
       send({
@@ -130,6 +145,7 @@ function handle(message) {
       keepAlive = setInterval(() => {}, 1000);
       return;
     }
+    const currentListCount = listCount;
     log("delay tools/list " + delayMs);
     pendingTimer = setTimeout(() => {
       send({
@@ -139,6 +155,10 @@ function handle(message) {
           tools,
         },
       });
+      if (notifyListChangedAfterFirstList && currentListCount === 1) {
+        log("notify tools/list_changed");
+        send({ jsonrpc: "2.0", method: "notifications/tools/list_changed" });
+      }
     }, delayMs);
   }
   if (message.method === "tools/call") {
@@ -245,6 +265,29 @@ async function waitForPredicate(
     });
   }
   throw new Error(`Timed out waiting for ${description}`);
+}
+
+async function waitForErrorMessage(
+  action: () => Promise<unknown>,
+  expectedText: string,
+  timeoutMs: number,
+): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+  let lastMessage = "";
+  while (Date.now() < deadline) {
+    try {
+      await action();
+    } catch (error) {
+      lastMessage = error instanceof Error ? error.message : String(error);
+      if (lastMessage.includes(expectedText)) {
+        return lastMessage;
+      }
+    }
+    await new Promise((resolve) => {
+      setTimeout(resolve, 10);
+    });
+  }
+  throw new Error(`Timed out waiting for ${expectedText}; saw ${JSON.stringify(lastMessage)}`);
 }
 
 function makeRuntime(
@@ -1036,262 +1079,85 @@ process.on("SIGINT", shutdown);`,
     }
   });
 
-  it("marks the MCP session disconnected and fails tool calls fast after the child process is killed mid-session", async () => {
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "bundle-mcp-kill-mid-session-"));
-    const serverPath = path.join(tempDir, "kill-mid-session.mjs");
+  it("fails fast with an attributable error after an MCP child process exits", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "bundle-mcp-child-exit-"));
+    const serverPath = path.join(tempDir, "server.mjs");
+    const logPath = path.join(tempDir, "server.log");
     const pidPath = path.join(tempDir, "server.pid");
-    await writeExecutable(
-      serverPath,
-      `#!/usr/bin/env node
-import fs from "node:fs/promises";
-
-const pidPath = ${JSON.stringify(pidPath)};
-await fs.writeFile(pidPath, String(process.pid), "utf8");
-
-let buffer = "";
-function send(message) {
-  process.stdout.write(JSON.stringify(message) + "\\n");
-}
-function handle(message) {
-  if (!message || typeof message !== "object") {
-    return;
-  }
-  if (message.method === "initialize") {
-    send({
-      jsonrpc: "2.0",
-      id: message.id,
-      result: {
-        protocolVersion: message.params?.protocolVersion ?? "2025-03-26",
-        capabilities: { tools: {} },
-        serverInfo: { name: "kill-mid-session", version: "1.0.0" },
-      },
-    });
-    return;
-  }
-  if (message.method === "notifications/initialized") {
-    return;
-  }
-  if (message.method === "tools/list") {
-    send({
-      jsonrpc: "2.0",
-      id: message.id,
-      result: { tools: [{ name: "ok_tool", inputSchema: { type: "object", properties: {} } }] },
-    });
-    return;
-  }
-  if (message.method === "tools/call") {
-    send({
-      jsonrpc: "2.0",
-      id: message.id,
-      result: { isError: false, content: [{ type: "text", text: "still connected" }] },
-    });
-  }
-}
-process.stdin.setEncoding("utf8");
-process.stdin.on("data", (chunk) => {
-  buffer += chunk;
-  while (true) {
-    const newline = buffer.indexOf("\\n");
-    if (newline < 0) {
-      return;
-    }
-    const line = buffer.slice(0, newline).replace(/\\r$/, "");
-    buffer = buffer.slice(newline + 1);
-    if (line.trim()) {
-      handle(JSON.parse(line));
-    }
-  }
-});`,
-    );
+    await writeListToolsMcpServer({ filePath: serverPath, logPath, pidPath });
 
     const runtime = await getOrCreateSessionMcpRuntime({
-      sessionId: "session-kill-mid-session",
-      sessionKey: "agent:test:session-kill-mid-session",
+      sessionId: "session-child-exit",
+      sessionKey: "agent:test:session-child-exit",
       workspaceDir: "/workspace",
       cfg: {
         mcp: {
           servers: {
-            killable: {
-              command: process.execPath,
-              args: [serverPath],
-            },
+            child: { command: process.execPath, args: [serverPath] },
           },
         },
       },
     });
 
     try {
-      const firstCatalog = await runtime.getCatalog();
-      expect(firstCatalog.tools.map((tool) => tool.toolName)).toEqual(["ok_tool"]);
-
-      const firstResult = await runtime.callTool("killable", "ok_tool", {});
-      expect(firstResult.content[0]).toEqual({ type: "text", text: "still connected" });
-
+      await expect(runtime.callTool("child", "slow_tool", {})).resolves.toMatchObject({
+        isError: false,
+      });
       await waitForFileText(pidPath, "", LIST_TOOLS_SERVER_LOG_TIMEOUT_MS);
       const pid = Number.parseInt((await fs.readFile(pidPath, "utf8")).trim(), 10);
-      expect(Number.isInteger(pid)).toBe(true);
-      process.kill(pid, "SIGKILL");
+      process.kill(pid);
 
-      // Poll instead of a fixed delay: the child's close event races the test.
-      // Once it lands, `connected` flips and every subsequent call fails fast
-      // with the attributable reason instead of a generic/timeout error.
-      let sawDisconnectedMessage = "";
-      const deadline = Date.now() + LIST_TOOLS_SERVER_LOG_TIMEOUT_MS;
-      while (Date.now() < deadline && !sawDisconnectedMessage) {
-        try {
-          await runtime.callTool("killable", "ok_tool", {});
-        } catch (error) {
-          const message = error instanceof Error ? error.message : String(error);
-          if (message.includes("is disconnected")) {
-            sawDisconnectedMessage = message;
-            break;
-          }
-        }
-        await new Promise((resolve) => {
-          setTimeout(resolve, 10);
-        });
-      }
-      expect(sawDisconnectedMessage).toBe(
-        `bundle-mcp server "killable" is disconnected: mcp transport closed`,
+      const message = await waitForErrorMessage(
+        () => runtime.callTool("child", "slow_tool", {}),
+        "is disconnected",
+        LIST_TOOLS_SERVER_LOG_TIMEOUT_MS,
       );
-
-      const start = Date.now();
-      await expect(runtime.callTool("killable", "ok_tool", {})).rejects.toThrow(
-        `bundle-mcp server "killable" is disconnected: mcp transport closed`,
-      );
-      expect(Date.now() - start).toBeLessThan(200);
+      expect(message).toBe('bundle-mcp server "child" is disconnected: mcp transport closed');
     } finally {
       await runtime.dispose();
       await fs.rm(tempDir, { recursive: true, force: true });
     }
   });
 
-  it("retires a reused session that dies mid-refresh instead of leaving it reachable", async () => {
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "bundle-mcp-die-mid-refresh-"));
-    const serverPath = path.join(tempDir, "die-mid-refresh.mjs");
+  it("retires a reused MCP session that exits during catalog refresh", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "bundle-mcp-refresh-exit-"));
+    const serverPath = path.join(tempDir, "server.mjs");
     const logPath = path.join(tempDir, "server.log");
-    await writeExecutable(
-      serverPath,
-      `#!/usr/bin/env node
-import fs from "node:fs/promises";
-
-const logPath = ${JSON.stringify(logPath)};
-let buffer = "";
-let listCount = 0;
-function log(line) {
-  void fs.appendFile(logPath, line + "\\n", "utf8").catch(() => {});
-}
-function send(message) {
-  process.stdout.write(JSON.stringify(message) + "\\n");
-}
-function handle(message) {
-  if (!message || typeof message !== "object") {
-    return;
-  }
-  if (message.method === "initialize") {
-    send({
-      jsonrpc: "2.0",
-      id: message.id,
-      result: {
-        protocolVersion: message.params?.protocolVersion ?? "2025-03-26",
-        capabilities: { tools: { listChanged: true } },
-        serverInfo: { name: "die-mid-refresh", version: "1.0.0" },
-      },
+    await writeListToolsMcpServer({
+      filePath: serverPath,
+      logPath,
+      capabilities: { tools: { listChanged: true } },
+      notifyListChangedAfterFirstList: true,
+      exitOnListCall: 2,
     });
-    return;
-  }
-  if (message.method === "notifications/initialized") {
-    return;
-  }
-  if (message.method === "tools/list") {
-    listCount += 1;
-    if (listCount === 1) {
-      send({
-        jsonrpc: "2.0",
-        id: message.id,
-        result: {
-          tools: [{ name: "ok_tool", inputSchema: { type: "object", properties: {} } }],
-        },
-      });
-      setTimeout(() => {
-        send({ jsonrpc: "2.0", method: "notifications/tools/list_changed" });
-        log("sent tools/list_changed");
-      }, 10);
-      return;
-    }
-    // Second tools/list: die without responding, simulating the child
-    // process crashing mid-refresh (after the reused session was already
-    // marked connected, before this catalog pass finishes).
-    log("dying mid tools/list");
-    process.exit(1);
-  }
-  if (message.method === "tools/call") {
-    send({
-      jsonrpc: "2.0",
-      id: message.id,
-      result: { isError: false, content: [{ type: "text", text: "still connected" }] },
-    });
-  }
-}
-process.stdin.setEncoding("utf8");
-process.stdin.on("data", (chunk) => {
-  buffer += chunk;
-  while (true) {
-    const newline = buffer.indexOf("\\n");
-    if (newline < 0) {
-      return;
-    }
-    const line = buffer.slice(0, newline).replace(/\\r$/, "");
-    buffer = buffer.slice(newline + 1);
-    if (line.trim()) {
-      handle(JSON.parse(line));
-    }
-  }
-});`,
-    );
 
     const runtime = await getOrCreateSessionMcpRuntime({
-      sessionId: "session-die-mid-refresh",
-      sessionKey: "agent:test:session-die-mid-refresh",
+      sessionId: "session-refresh-exit",
+      sessionKey: "agent:test:session-refresh-exit",
       workspaceDir: "/workspace",
       cfg: {
         mcp: {
           servers: {
-            volatile: {
-              command: process.execPath,
-              args: [serverPath],
-            },
+            child: { command: process.execPath, args: [serverPath] },
           },
         },
       },
     });
 
     try {
-      const firstCatalog = await runtime.getCatalog();
-      expect(firstCatalog.tools.map((tool) => tool.toolName)).toEqual(["ok_tool"]);
-
-      await waitForFileText(logPath, "sent tools/list_changed", LIST_TOOLS_SERVER_LOG_TIMEOUT_MS);
+      expect((await runtime.getCatalog()).tools).toHaveLength(1);
+      await waitForFileText(logPath, "notify tools/list_changed", LIST_TOOLS_SERVER_LOG_TIMEOUT_MS);
       await waitForPredicate(
         () => runtime.peekCatalog() === null,
         "list_changed to invalidate the catalog",
         LIST_TOOLS_SERVER_LOG_TIMEOUT_MS,
       );
 
-      // Refresh reuses the still-"connected" session; the child dies mid
-      // tools/list, flipping session.connected via onclose before this
-      // refresh's catch block runs.
       const refreshedCatalog = await runtime.getCatalog();
       expect(refreshedCatalog.tools).toEqual([]);
-      expect(refreshedCatalog.diagnostics?.[0]?.serverName).toBe("volatile");
-
-      // The dead session must be retired within this same refresh, not left
-      // dangling for a future rebuild to notice. If it were left dangling,
-      // callTool would find the stale session object and throw "is
-      // disconnected: mcp transport closed"; a properly retired session is
-      // simply absent, so callTool throws the plain "not connected" message
-      // (a fresh session gets created on the next successful catalog build).
-      await expect(runtime.callTool("volatile", "ok_tool", {})).rejects.toThrow(
-        'bundle-mcp server "volatile" is not connected',
+      expect(refreshedCatalog.diagnostics?.[0]?.serverName).toBe("child");
+      await expect(runtime.callTool("child", "slow_tool", {})).rejects.toThrow(
+        'bundle-mcp server "child" is not connected',
       );
     } finally {
       await runtime.dispose();

--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -45,6 +45,7 @@ type BundleMcpSession = {
   requestTimeoutMs: number;
   supportsParallelToolCalls: boolean;
   connected: boolean;
+  disconnectReason?: string;
   retiring: boolean;
   catalogUseCount: number;
   sharedAcrossCatalogGenerations: boolean;
@@ -542,6 +543,17 @@ export function createSessionMcpRuntime(params: {
       throw createDisposedError(params.sessionId);
     }
   };
+  const requireConnectedSession = (serverName: string): BundleMcpSession => {
+    const session = sessions.get(serverName);
+    if (!session || !session.connected) {
+      throw new Error(
+        session?.disconnectReason
+          ? `bundle-mcp server "${serverName}" is disconnected: ${session.disconnectReason}`
+          : `bundle-mcp server "${serverName}" is not connected`,
+      );
+    }
+    return session;
+  };
   const ensureSessionConnected = async (
     session: BundleMcpSession,
     connectionTimeoutMs: number,
@@ -642,6 +654,12 @@ export function createSessionMcpRuntime(params: {
               let session = sessions.get(serverName);
               if (session?.retiring) {
                 session = undefined;
+              } else if (session && !session.connected && !session.connectPromise) {
+                // Transport closed/errored out-of-band (e.g. child process crash);
+                // the SDK client can't cleanly reconnect on the same instance
+                // (stale read buffer, chained onclose/onerror), so rebuild fresh.
+                await retireSessionIfCurrent(serverName, session);
+                session = undefined;
               }
               const reusedSession = Boolean(session);
               if (!session) {
@@ -670,7 +688,7 @@ export function createSessionMcpRuntime(params: {
                     },
                   },
                 );
-                session = {
+                const createdSession: BundleMcpSession = {
                   serverName,
                   client,
                   transport: resolved.transport,
@@ -683,6 +701,23 @@ export function createSessionMcpRuntime(params: {
                   sharedAcrossCatalogGenerations: false,
                   detachStderr: resolved.detachStderr,
                 };
+                // The SDK chains any transport-level onclose/onerror set before
+                // connect() runs; client.onclose is the authoritative "the
+                // transport is gone" signal (fires for every transport kind).
+                // onerror also fires for non-fatal protocol issues, so it only
+                // logs and must not flip `connected`.
+                // oxlint-disable-next-line unicorn/prefer-add-event-listener -- MCP SDK Client exposes onclose/onerror as plain settable callback properties, not an EventTarget.
+                client.onclose = () => {
+                  createdSession.connected = false;
+                  createdSession.disconnectReason = "mcp transport closed";
+                };
+                // oxlint-disable-next-line unicorn/prefer-add-event-listener -- see onclose above.
+                client.onerror = (error) => {
+                  logWarn(
+                    `bundle-mcp: transport error for server "${serverName}": ${redactErrorUrls(error)}`,
+                  );
+                };
+                session = createdSession;
                 sessions.set(serverName, session);
               }
 
@@ -894,10 +929,7 @@ export function createSessionMcpRuntime(params: {
     async callTool(serverName, toolName, input) {
       failIfDisposed();
       await getCatalog();
-      const session = sessions.get(serverName);
-      if (!session) {
-        throw new Error(`bundle-mcp server "${serverName}" is not connected`);
-      }
+      const session = requireConnectedSession(serverName);
       return await runGuardedServerRequest(
         serverName,
         async () =>
@@ -914,10 +946,7 @@ export function createSessionMcpRuntime(params: {
     async listResources(serverName) {
       failIfDisposed();
       await getCatalog();
-      const session = sessions.get(serverName);
-      if (!session) {
-        throw new Error(`bundle-mcp server "${serverName}" is not connected`);
-      }
+      const session = requireConnectedSession(serverName);
       return await runGuardedServerRequest(serverName, async () =>
         listAllResources(session.client, session.requestTimeoutMs),
       );
@@ -925,10 +954,7 @@ export function createSessionMcpRuntime(params: {
     async readResource(serverName, uri) {
       failIfDisposed();
       await getCatalog();
-      const session = sessions.get(serverName);
-      if (!session) {
-        throw new Error(`bundle-mcp server "${serverName}" is not connected`);
-      }
+      const session = requireConnectedSession(serverName);
       return await runGuardedServerRequest(
         serverName,
         async () =>
@@ -938,10 +964,7 @@ export function createSessionMcpRuntime(params: {
     async listPrompts(serverName) {
       failIfDisposed();
       await getCatalog();
-      const session = sessions.get(serverName);
-      if (!session) {
-        throw new Error(`bundle-mcp server "${serverName}" is not connected`);
-      }
+      const session = requireConnectedSession(serverName);
       return await runGuardedServerRequest(serverName, async () =>
         listAllPrompts(session.client, session.requestTimeoutMs),
       );
@@ -949,10 +972,7 @@ export function createSessionMcpRuntime(params: {
     async getPrompt(serverName, name, args) {
       failIfDisposed();
       await getCatalog();
-      const session = sessions.get(serverName);
-      if (!session) {
-        throw new Error(`bundle-mcp server "${serverName}" is not connected`);
-      }
+      const session = requireConnectedSession(serverName);
       return await runGuardedServerRequest(
         serverName,
         async () =>

--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -821,6 +821,14 @@ export function createSessionMcpRuntime(params: {
                   // Timed-out connects can still leave the SDK client bound to a
                   // transport. Delete before async close so future catalogs start fresh.
                   await retireSessionIfCurrent(serverName, session);
+                } else if (reusedSession && !session.connected && !sharedWithNewerGeneration) {
+                  // A reused, previously-connected session died mid-refresh (e.g. the
+                  // child process was killed between ensureSessionConnected() returning
+                  // and listAllToolsBestEffort() finishing) — client.onclose already
+                  // flipped session.connected. Retire now instead of waiting for the
+                  // next catalog pass to notice, so a disconnected session is never
+                  // left reachable to a future reuse check.
+                  await retireSessionIfCurrent(serverName, session);
                 } else if (!reusedSession && !sharedWithNewerGeneration) {
                   // Catalog invalidation can overlap generations; an older failed
                   // generation must not dispose a session a newer one already reused.

--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -652,13 +652,19 @@ export function createSessionMcpRuntime(params: {
               failIfDisposed();
 
               let session = sessions.get(serverName);
-              if (session?.retiring) {
-                session = undefined;
-              } else if (session && !session.connected && !session.connectPromise) {
-                // Transport closed/errored out-of-band (e.g. child process crash);
-                // the SDK client can't cleanly reconnect on the same instance
-                // (stale read buffer, chained onclose/onerror), so rebuild fresh.
+              while (
+                session &&
+                !session.retiring &&
+                !session.connected &&
+                !session.connectPromise
+              ) {
+                // A closed SDK client cannot reconnect cleanly on the same transport.
                 await retireSessionIfCurrent(serverName, session);
+                // Retirement yields while closing. Preserve any replacement that a
+                // newer catalog generation installed during that await.
+                session = sessions.get(serverName);
+              }
+              if (session?.retiring) {
                 session = undefined;
               }
               const reusedSession = Boolean(session);
@@ -701,21 +707,12 @@ export function createSessionMcpRuntime(params: {
                   sharedAcrossCatalogGenerations: false,
                   detachStderr: resolved.detachStderr,
                 };
-                // The SDK chains any transport-level onclose/onerror set before
-                // connect() runs; client.onclose is the authoritative "the
-                // transport is gone" signal (fires for every transport kind).
-                // onerror also fires for non-fatal protocol issues, so it only
-                // logs and must not flip `connected`.
-                // oxlint-disable-next-line unicorn/prefer-add-event-listener -- MCP SDK Client exposes onclose/onerror as plain settable callback properties, not an EventTarget.
+                // The SDK exposes lifecycle hooks as callback properties. A close is
+                // terminal for this client/transport pair.
+                // oxlint-disable-next-line unicorn/prefer-add-event-listener -- MCP Client is not an EventTarget.
                 client.onclose = () => {
                   createdSession.connected = false;
                   createdSession.disconnectReason = "mcp transport closed";
-                };
-                // oxlint-disable-next-line unicorn/prefer-add-event-listener -- see onclose above.
-                client.onerror = (error) => {
-                  logWarn(
-                    `bundle-mcp: transport error for server "${serverName}": ${redactErrorUrls(error)}`,
-                  );
                 };
                 session = createdSession;
                 sessions.set(serverName, session);
@@ -816,20 +813,10 @@ export function createSessionMcpRuntime(params: {
                 const sharedWithNewerGeneration =
                   session.sharedAcrossCatalogGenerations || session.catalogUseCount > 1;
                 if (!session.connected) {
-                  // The session ended up disconnected in this pass — either it never
-                  // connected (fresh session's connect failed, or a timed-out connect
-                  // still left the SDK client bound to a transport) or it was a reused,
-                  // previously-healthy session that died mid-refresh (e.g. the child
-                  // process was killed between ensureSessionConnected() returning and
-                  // listAllToolsBestEffort() finishing) — client.onclose already flipped
-                  // session.connected. Retiring is safe here regardless of
-                  // sharedWithNewerGeneration: that guard exists to protect a still-alive
-                  // session another generation is actively using, and a disconnected
-                  // transport isn't alive for any generation sharing it.
+                  // A close is terminal for every catalog generation sharing this
+                  // session. The identity guard preserves any newer replacement.
                   await retireSessionIfCurrent(serverName, session);
                 } else if (!reusedSession && !sharedWithNewerGeneration) {
-                  // Still connected, but this catalog build attempt itself failed for an
-                  // unrelated reason (e.g. a listTools timeout) on a brand-new session.
                   // Catalog invalidation can overlap generations; an older failed
                   // generation must not dispose a session a newer one already reused.
                   await retireSessionIfCurrent(serverName, session);

--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -728,11 +728,9 @@ export function createSessionMcpRuntime(params: {
                 session.sharedAcrossCatalogGenerations = true;
               }
               session.catalogUseCount += 1;
-              let connectedForCatalog = false;
               try {
                 failIfDisposed();
                 await ensureSessionConnected(session, resolved.connectionTimeoutMs);
-                connectedForCatalog = true;
                 failIfDisposed();
                 const capabilities = summarizeServerCapabilities(
                   session.client.getServerCapabilities(),
@@ -817,19 +815,21 @@ export function createSessionMcpRuntime(params: {
                 ];
                 const sharedWithNewerGeneration =
                   session.sharedAcrossCatalogGenerations || session.catalogUseCount > 1;
-                if (!connectedForCatalog && !session.connected) {
-                  // Timed-out connects can still leave the SDK client bound to a
-                  // transport. Delete before async close so future catalogs start fresh.
-                  await retireSessionIfCurrent(serverName, session);
-                } else if (reusedSession && !session.connected && !sharedWithNewerGeneration) {
-                  // A reused, previously-connected session died mid-refresh (e.g. the
-                  // child process was killed between ensureSessionConnected() returning
-                  // and listAllToolsBestEffort() finishing) — client.onclose already
-                  // flipped session.connected. Retire now instead of waiting for the
-                  // next catalog pass to notice, so a disconnected session is never
-                  // left reachable to a future reuse check.
+                if (!session.connected) {
+                  // The session ended up disconnected in this pass — either it never
+                  // connected (fresh session's connect failed, or a timed-out connect
+                  // still left the SDK client bound to a transport) or it was a reused,
+                  // previously-healthy session that died mid-refresh (e.g. the child
+                  // process was killed between ensureSessionConnected() returning and
+                  // listAllToolsBestEffort() finishing) — client.onclose already flipped
+                  // session.connected. Retiring is safe here regardless of
+                  // sharedWithNewerGeneration: that guard exists to protect a still-alive
+                  // session another generation is actively using, and a disconnected
+                  // transport isn't alive for any generation sharing it.
                   await retireSessionIfCurrent(serverName, session);
                 } else if (!reusedSession && !sharedWithNewerGeneration) {
+                  // Still connected, but this catalog build attempt itself failed for an
+                  // unrelated reason (e.g. a listTools timeout) on a brand-new session.
                   // Catalog invalidation can overlap generations; an older failed
                   // generation must not dispose a session a newer one already reused.
                   await retireSessionIfCurrent(serverName, session);

--- a/test/scripts/lint-suppressions.test.ts
+++ b/test/scripts/lint-suppressions.test.ts
@@ -193,6 +193,7 @@ describe("production lint suppressions", () => {
         "extensions/feishu/src/bitable.ts|typescript/no-unnecessary-type-parameters|1",
         "extensions/matrix/src/onboarding.test-harness.ts|typescript/no-unnecessary-type-parameters|1",
         "extensions/slack/src/monitor/provider-support.ts|typescript/no-unnecessary-type-parameters|1",
+        "src/agents/agent-bundle-mcp-runtime.ts|unicorn/prefer-add-event-listener|2",
         "src/channels/plugins/channel-runtime-surface.types.ts|typescript/no-unnecessary-type-parameters|1",
         "src/channels/plugins/contracts/test-helpers.ts|typescript/no-unnecessary-type-parameters|1",
         "src/channels/plugins/types.plugin.ts|typescript/no-explicit-any|1",

--- a/test/scripts/lint-suppressions.test.ts
+++ b/test/scripts/lint-suppressions.test.ts
@@ -193,7 +193,7 @@ describe("production lint suppressions", () => {
         "extensions/feishu/src/bitable.ts|typescript/no-unnecessary-type-parameters|1",
         "extensions/matrix/src/onboarding.test-harness.ts|typescript/no-unnecessary-type-parameters|1",
         "extensions/slack/src/monitor/provider-support.ts|typescript/no-unnecessary-type-parameters|1",
-        "src/agents/agent-bundle-mcp-runtime.ts|unicorn/prefer-add-event-listener|2",
+        "src/agents/agent-bundle-mcp-runtime.ts|unicorn/prefer-add-event-listener|1",
         "src/channels/plugins/channel-runtime-surface.types.ts|typescript/no-unnecessary-type-parameters|1",
         "src/channels/plugins/contracts/test-helpers.ts|typescript/no-unnecessary-type-parameters|1",
         "src/channels/plugins/types.plugin.ts|typescript/no-explicit-any|1",


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where, when a bundled MCP server's child process exits or
its transport errors out mid-session, OpenClaw keeps treating that server as
connected. The next tool/resource/prompt call against that server either
surfaces the MCP SDK's generic `"Not connected"` error with no indication of
which server died or why, or — if a catalog refresh happens to run first
(e.g. after a `tools/list_changed` notification) — silently reuses the dead
session forever, so the server never recovers until the whole session's MCP
runtime is torn down (idle sweep or explicit disposal).

## Why This Change Was Made

Wires the MCP SDK `Client`'s `onclose`/`onerror` callbacks (public settable
properties on `Protocol`, not an `EventTarget`) when a bundle-mcp session is
created. `onclose` is the authoritative "this transport is gone" signal for
every transport kind (stdio/SSE/streamable-http) and flips the existing
`session.connected` flag plus a small bounded `disconnectReason` string.
`onerror` only logs — it also fires for non-fatal protocol issues (e.g. an
unrelated malformed message), so it must not mark a still-healthy session
dead. `callTool`/`listResources`/`readResource`/`listPrompts`/`getPrompt` now
share one `requireConnectedSession` check (replacing five copies of the same
`if (!session) throw` guard) that also rejects a disconnected session with an
attributable message. Session reuse in the catalog-build path now retires a
disconnected session instead of trying to reconnect it in place: the SDK
chains `onclose`/`onerror` cumulatively on repeat `connect()` calls on the
same `Client`, and the stdio transport never clears its read buffer on an
unexpected exit, so reconnecting the same instance is not safe. Retirement
now hinges on one signal — `!session.connected` — regardless of when the
disconnect happened (before this catalog refresh started, or mid-refresh,
e.g. the child process crashes between `ensureSessionConnected()` returning
and `listAllToolsBestEffort()` finishing) or whether the same session
object is shared with an overlapping catalog generation: a dead transport
is dead for every generation sharing it, so the existing
`sharedWithNewerGeneration` guard (which protects a still-*healthy* shared
session from being disposed by an older generation's unrelated failure)
correctly does not apply once the session is confirmed disconnected.
`retireSessionIfCurrent` already no-ops safely if a newer generation
already replaced the map entry. Non-goals: no gateway protocol change, no
persisted history, no new config surface.

## User Impact

Anyone using bundled MCP servers gets a clear, specific error
(`bundle-mcp server "<name>" is disconnected: mcp transport closed`) the
moment they try to use a server whose process died, instead of a generic
`"Not connected"` message or an indefinitely-stuck integration that silently
never recovers until the agent session restarts.

## Evidence

- Two new focused tests in `agent-bundle-mcp-runtime.test.ts`:
  - Spawns a real fake stdio MCP child process, confirms a normal tool call
    succeeds, `SIGKILL`s the child mid-session, then asserts the next tool
    call fails within 200ms with the new attributable message (not a
    timeout, not the SDK's generic message).
  - Spawns a fake server that invalidates its own catalog via
    `tools/list_changed`, then dies without responding during the resulting
    refresh's `tools/list` call on the still-"connected" reused session;
    asserts the dead session is purged from the runtime's session map
    within that same refresh (a subsequent `callTool` gets the "not
    connected" — session missing — message, not the "is disconnected"
    message a lingering dead session object would produce).
- `node scripts/run-vitest.mjs src/agents/agent-bundle-mcp-runtime.test.ts src/agents/mcp-stdio-transport.test.ts` → 46/46 passed (3 repeat runs, no flakiness). The overlapping-catalog-generation sub-case (a dead session shared with `sharedWithNewerGeneration === true`) isn't covered by a dedicated test — reproducing it deterministically needs a genuinely concurrent (non-sequential) `getCatalog()` race, which adds disproportionate complexity/flakiness risk for this narrow additional branch; it's covered by code reasoning (`retireSessionIfCurrent`'s own safe no-op-if-superseded identity check) plus the existing "in-flight invalidated" test proving the overlapping-generation catalog mechanics themselves are unaffected.
- `node scripts/run-vitest.mjs test/scripts/lint-suppressions.test.ts` → 3/3
  passed (covers the one-line suppression-allowlist addition below).
- `pnpm tsgo:core` (core prod typecheck) and the core test-types lane → clean; verified the checker genuinely inspects the touched file by injecting then reverting a deliberate type error.
- `pnpm exec oxfmt --check` → clean. `node scripts/run-oxlint.mjs` → clean after two justified `oxlint-disable-next-line unicorn/prefer-add-event-listener` comments (the MCP SDK `Client` exposes these as plain callback properties, not an `EventTarget`). The matching one-line entry in `test/scripts/lint-suppressions.test.ts` adds those two suppressions to the repo's intentional-suppression allowlist for the same reason: `addEventListener` does not exist on the SDK `Client`, so the rule's suggested rewrite is impossible there.
- `git diff --check` (upstream/main...HEAD) → clean.

### Real behavior proof (redacted terminal output)

Production runtime paths end to end: `loadConfig()` reads a real
`openclaw.json`, `getOrCreateSessionMcpRuntime()` builds the real session
runtime, `getCatalog()` spawns and connects a real local stdio MCP server
child process (a tiny standalone script speaking MCP JSON-RPC over stdio),
and `callTool()` calls run over that live child, which is then killed with
a real `SIGKILL`. No unit-test doubles of any runtime code are involved,
and no live external API is used.

````
$ git rev-parse --abbrev-ref HEAD && git rev-parse HEAD
fix/mcp-stdio-close-lifecycle
9784aa512d248327f94914ea574c13c240e52967
$ node --import tsx .proof-98738.ts   # production-path proof driver

[1. Real stdio MCP child started via production runtime]
catalog tools: proof-demo/proof_echo, proof-demo/proof_time
child PID: 1814660 (alive: true)

[2. First tool call succeeds (live child)]
callTool(proof-demo, proof_echo) -> [{"type":"text","text":"echo:hello"}] in 0ms

[3. Child killed]
process.kill(1814660, "SIGKILL") sent

[4. Next tool call after kill fails fast with attributable reason]
duration: 0ms
error: bundle-mcp server "proof-demo" is disconnected: mcp transport closed

PROOF OK: all assertions passed
EXIT=0
````

The driver polls briefly after the `SIGKILL` until the SDK's `onclose`
lands (the close event races the kill), then times one clean call: it
fails in under a millisecond with the exact server-specific message this
PR introduces, and the driver asserts the exact message text and the
<200ms bound, exiting non-zero on any mismatch.

Note on stored data: there is no persistent data-model change in this PR.
The runtime change is in-memory session lifecycle state (the existing
`connected` flag plus one bounded `disconnectReason` string on the
in-memory session object); nothing is serialized, written to disk, or
migrated. The "serialized state" pattern match in automated review points
at fixture code inside `agent-bundle-mcp-runtime.test.ts`, not stored user
data.
