### PR TITLE
fix(plugins): clear live interactive handlers

### DIFF
--- a/src/plugins/interactive-registry.ts
+++ b/src/plugins/interactive-registry.ts
@@ -104,8 +104,8 @@ export function registerRegistryPluginInteractiveHandler(
   });
 }
 
-/** Clears all active plugin interactive handlers. */
-export function clearPluginInteractiveHandlers(): void {
+/** Clears process-global interactive handler and dedupe state. */
+export function clearPluginInteractiveRuntimeState(): void {
   clearPluginInteractiveHandlersState();
 }
 
@@ -114,8 +114,8 @@ export function clearPluginInteractiveHandlerRegistrations(): void {
   clearPluginInteractiveHandlerRegistrationsState();
 }
 
-/** Clears active interactive handlers owned by one plugin. */
-export function clearPluginInteractiveHandlersForPlugin(pluginId: string): void {
+/** Clears process-global interactive handler state owned by one plugin. */
+export function clearPluginInteractiveRuntimeStateForPlugin(pluginId: string): void {
   const interactiveHandlers = getPluginInteractiveHandlersState();
   for (const [key, value] of interactiveHandlers.entries()) {
     if (value.pluginId === pluginId) {

--- a/src/plugins/interactive.test.ts
+++ b/src/plugins/interactive.test.ts
@@ -13,6 +13,7 @@ import type {
 import { registerRegistryPluginInteractiveHandler } from "./interactive-registry.js";
 import {
   clearPluginInteractiveHandlers,
+  clearPluginInteractiveHandlersForPlugin,
   dispatchPluginInteractiveHandler,
   registerPluginInteractiveHandler,
 } from "./interactive.js";
@@ -707,6 +708,99 @@ describe("plugin interactive handlers", () => {
       ),
     ).resolves.toEqual({ matched: false, handled: false, duplicate: false });
     expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears registry-owned handlers from live registries", async () => {
+    const handler = vi.fn(async () => ({ handled: true }));
+    const registry = createEmptyPluginRegistry();
+    registry.interactiveHandlers = [
+      {
+        channel: "telegram",
+        namespace: "code-agent",
+        pluginId: "openclaw-code-agent",
+        handler: handler as never,
+      },
+    ];
+    expect(
+      registerRegistryPluginInteractiveHandler("openclaw-code-agent", {
+        channel: "telegram",
+        namespace: "code-agent",
+        handler: handler as never,
+      }),
+    ).toEqual({ ok: true });
+    setActivePluginRegistry(registry);
+
+    clearPluginInteractiveHandlers();
+
+    expect(registry.interactiveHandlers).toStrictEqual([]);
+    await expect(
+      dispatchInteractive(
+        createTelegramDispatchParams({
+          data: "code-agent:resume",
+          callbackId: "cb-code-agent-cleared",
+        }),
+      ),
+    ).resolves.toEqual({ matched: false, handled: false, duplicate: false });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("clears one plugin's registry-owned handlers from live registries", async () => {
+    const firstHandler = vi.fn(async () => ({ handled: true }));
+    const secondHandler = vi.fn(async () => ({ handled: true }));
+    const registry = createEmptyPluginRegistry();
+    registry.interactiveHandlers = [
+      {
+        channel: "telegram",
+        namespace: "first",
+        pluginId: "plugin-a",
+        handler: firstHandler as never,
+      },
+      {
+        channel: "telegram",
+        namespace: "second",
+        pluginId: "plugin-b",
+        handler: secondHandler as never,
+      },
+    ];
+    expect(
+      registerRegistryPluginInteractiveHandler("plugin-a", {
+        channel: "telegram",
+        namespace: "first",
+        handler: firstHandler as never,
+      }),
+    ).toEqual({ ok: true });
+    expect(
+      registerRegistryPluginInteractiveHandler("plugin-b", {
+        channel: "telegram",
+        namespace: "second",
+        handler: secondHandler as never,
+      }),
+    ).toEqual({ ok: true });
+    setActivePluginRegistry(registry);
+
+    clearPluginInteractiveHandlersForPlugin("plugin-a");
+
+    expect(registry.interactiveHandlers?.map((registration) => registration.pluginId)).toEqual([
+      "plugin-b",
+    ]);
+    await expect(
+      dispatchInteractive(
+        createTelegramDispatchParams({
+          data: "first:resume",
+          callbackId: "cb-first-cleared",
+        }),
+      ),
+    ).resolves.toEqual({ matched: false, handled: false, duplicate: false });
+    await expect(
+      dispatchInteractive(
+        createTelegramDispatchParams({
+          data: "second:resume",
+          callbackId: "cb-second-active",
+        }),
+      ),
+    ).resolves.toEqual({ matched: true, handled: true, duplicate: false });
+    expect(firstHandler).not.toHaveBeenCalled();
+    expect(secondHandler).toHaveBeenCalledTimes(1);
   });
 
   it("rejects duplicate namespace registrations", () => {

--- a/src/plugins/interactive.ts
+++ b/src/plugins/interactive.ts
@@ -1,5 +1,7 @@
 // Resolves interactive plugin entries from registry metadata.
 import {
+  clearPluginInteractiveRuntimeState,
+  clearPluginInteractiveRuntimeStateForPlugin,
   resolvePluginInteractiveNamespaceMatch,
   resolvePluginInteractiveRegistrationsMatch,
 } from "./interactive-registry.js";
@@ -27,12 +29,30 @@ export type PluginInteractiveMatch<TRegistration extends PluginInteractiveDispat
   payload: string;
 };
 
-export {
-  clearPluginInteractiveHandlers,
-  clearPluginInteractiveHandlersForPlugin,
-  registerPluginInteractiveHandler,
-} from "./interactive-registry.js";
+export { registerPluginInteractiveHandler } from "./interactive-registry.js";
 export type { InteractiveRegistrationResult } from "./interactive-registry.js";
+
+/** Clears all active plugin interactive handlers. */
+export function clearPluginInteractiveHandlers(): void {
+  clearPluginInteractiveRuntimeState();
+  for (const registry of collectLivePluginRegistries()) {
+    registry.interactiveHandlers = [];
+  }
+}
+
+/** Clears active interactive handlers owned by one plugin. */
+export function clearPluginInteractiveHandlersForPlugin(pluginId: string): void {
+  clearPluginInteractiveRuntimeStateForPlugin(pluginId);
+  for (const registry of collectLivePluginRegistries()) {
+    const interactiveHandlers = registry.interactiveHandlers;
+    if (!interactiveHandlers?.some((registration) => registration.pluginId === pluginId)) {
+      continue;
+    }
+    registry.interactiveHandlers = interactiveHandlers.filter(
+      (registration) => registration.pluginId !== pluginId,
+    );
+  }
+}
 
 function resolveLivePluginInteractiveNamespaceMatch(channel: string, data: string) {
   const existing = resolvePluginInteractiveNamespaceMatch(channel, data);

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -48,7 +48,7 @@ import { createHookRunner } from "./hooks.js";
 import { writePersistedInstalledPluginIndexInstallRecordsSync } from "./installed-plugin-index-records.js";
 import {
   clearPluginInteractiveHandlerRegistrations,
-  clearPluginInteractiveHandlers,
+  clearPluginInteractiveRuntimeState,
   resolvePluginInteractiveNamespaceMatch,
 } from "./interactive-registry.js";
 import {
@@ -3185,7 +3185,7 @@ module.exports = { id: "throws-after-import", register() {} };`,
 
     clearInternalHooks();
     clearPluginCommands();
-    clearPluginInteractiveHandlers();
+    clearPluginInteractiveRuntimeState();
 
     const registry = loadOpenClawPlugins({
       cache: false,
@@ -3219,7 +3219,7 @@ module.exports = { id: "throws-after-import", register() {} };`,
 
     clearInternalHooks();
     clearPluginCommands();
-    clearPluginInteractiveHandlers();
+    clearPluginInteractiveRuntimeState();
   });
 
   it("fails plugin registration when a hook is missing its required name", () => {

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -70,7 +70,7 @@ import { initializeGlobalHookRunner } from "./hook-runner-global.js";
 import { collectPluginManifestCompatCodes } from "./installed-plugin-index-record-builder.js";
 import { loadInstalledPluginIndexInstallRecordsSync } from "./installed-plugin-index-records.js";
 import {
-  clearPluginInteractiveHandlers,
+  clearPluginInteractiveRuntimeState,
   listPluginInteractiveHandlers,
   restorePluginInteractiveHandlers,
 } from "./interactive-registry.js";
@@ -432,7 +432,9 @@ export function clearActivatedPluginRuntimeState(): void {
   clearPluginCommands();
   clearCompactionProviders();
   clearDetachedTaskLifecycleRuntimeRegistration();
-  clearPluginInteractiveHandlers();
+  // Clear reload bookkeeping without mutating the still-live registry. Failed
+  // replacement loads must leave its registry-owned handlers executable.
+  clearPluginInteractiveRuntimeState();
   clearEmbeddingProviders();
   clearMemoryEmbeddingProviders();
   clearMemoryPluginState();

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -106,7 +106,7 @@ import {
 import { normalizePluginHttpPath } from "./http-path.js";
 import { findOverlappingPluginHttpRoute } from "./http-route-overlap.js";
 import {
-  clearPluginInteractiveHandlersForPlugin,
+  clearPluginInteractiveRuntimeStateForPlugin,
   registerRegistryPluginInteractiveHandler,
 } from "./interactive-registry.js";
 import type { PluginDiagnostic } from "./manifest-types.js";
@@ -3276,7 +3276,10 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     }
 
     clearPluginCommandsForPlugin(pluginId);
-    clearPluginInteractiveHandlersForPlugin(pluginId);
+    // The loader restores the candidate registry snapshot after this call.
+    // Clear only its global reservation so a live registry with the same
+    // plugin id survives a failed replacement.
+    clearPluginInteractiveRuntimeStateForPlugin(pluginId);
     clearCodeModeNamespacesForPlugin(pluginId);
     clearContextEnginesForOwner(`plugin:${pluginId}`);
 


### PR DESCRIPTION
## Summary

### What Problem This Solves

Registry-owned interactive handlers introduced by #97174 are dispatched from live plugin registries, but the public cleanup helpers still cleared only the process-global reservation map. A handler could therefore remain executable after `clearPluginInteractiveHandlers()` or `clearPluginInteractiveHandlersForPlugin()` returned.

### Why This Change Was Made

The cleanup contract needs to cover every active dispatch source without weakening registry lifecycle ownership. Reload and failed-registration rollback also need a narrower cleanup path so a still-live registry is not mutated while a replacement registry is being built.

### User Impact

Plugin runtimes and test harnesses can reliably deactivate all interactive handlers or one plugin's handlers. Normal callback dispatch and registry retirement behavior are unchanged.

## Changes

- Clear registry-owned handlers from every live plugin registry in both public cleanup functions.
- Separate process-global runtime cleanup for loader reload and registration rollback paths.
- Preserve handlers owned by the current live registry during replacement loading.
- Add regressions for all-handler cleanup and per-plugin cleanup while another plugin remains active.

## Validation

### Evidence

- `node scripts/run-vitest.mjs src/plugins/interactive.test.ts src/plugins/loader.test.ts extensions/telegram/src/bot.create-telegram-bot.test.ts extensions/telegram/src/bot.test.ts` — 383 tests passed.
- `corepack pnpm build` — passed.
- `corepack pnpm format:check -- src/plugins/interactive-registry.ts src/plugins/interactive.ts src/plugins/loader.ts src/plugins/registry.ts src/plugins/interactive.test.ts src/plugins/loader.test.ts` — passed.
- `git diff --check upstream/main...HEAD` — passed.
- All three core/plugin import-boundary inventory scripts returned `[]`.
- Structured Codex autoreview completed with no accepted or actionable findings.

## Notes

- Public export names, parameters, and return types are unchanged.
- No config, environment, CLI, gateway protocol, storage, or migration surface changes.
- The broad changed gate is left to PR CI because delegated Testbox tooling was unavailable in the local environment.
