### PR TITLE
refactor(shared): consolidate provider and utility lazy loaders

### DIFF
--- a/extensions/acpx/register.runtime.ts
+++ b/extensions/acpx/register.runtime.ts
@@ -9,6 +9,7 @@ import {
   type AcpRuntime,
 } from "openclaw/plugin-sdk/acp-runtime-backend";
 import type { OpenClawPluginService, OpenClawPluginServiceContext } from "openclaw/plugin-sdk/core";
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { createLazyAcpRuntimeProxy } from "./src/runtime-proxy.js";
 
 const ACPX_BACKEND_ID = "acpx";
@@ -26,12 +27,7 @@ type DeferredServiceState = {
   startPromise: Promise<AcpRuntime> | null;
 };
 
-let serviceModulePromise: Promise<RealAcpxServiceModule> | null = null;
-
-function loadServiceModule(): Promise<RealAcpxServiceModule> {
-  serviceModulePromise ??= import("./src/service.js");
-  return serviceModulePromise;
-}
+const loadServiceModule = createLazyRuntimeModule(() => import("./src/service.js"));
 
 async function startRealService(state: DeferredServiceState): Promise<AcpRuntime> {
   if (state.realRuntime) {

--- a/extensions/acpx/src/service.ts
+++ b/extensions/acpx/src/service.ts
@@ -7,6 +7,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { inspect } from "node:util";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { finiteSecondsToTimerSafeMilliseconds } from "openclaw/plugin-sdk/number-runtime";
 import type {
   OpenKeyedStoreOptions,
@@ -58,9 +59,6 @@ const ENABLE_STARTUP_PROBE_ENV = "OPENCLAW_ACPX_RUNTIME_STARTUP_PROBE";
 const SKIP_RUNTIME_PROBE_ENV = "OPENCLAW_SKIP_ACPX_RUNTIME_PROBE";
 const ACPX_BACKEND_ID = "acpx";
 
-type AcpxRuntimeModule = typeof import("./runtime.js");
-let runtimeModulePromise: Promise<AcpxRuntimeModule> | null = null;
-
 type AcpxRuntimeFactoryParams = {
   pluginConfig: ResolvedAcpxPluginConfig;
   gatewayInstanceId: string;
@@ -76,10 +74,7 @@ type CreateAcpxRuntimeServiceParams = {
   processCleanupDeps?: AcpxProcessCleanupDeps;
 };
 
-function loadRuntimeModule(): Promise<AcpxRuntimeModule> {
-  runtimeModulePromise ??= import("./runtime.js");
-  return runtimeModulePromise;
-}
+const loadRuntimeModule = createLazyRuntimeModule(() => import("./runtime.js"));
 
 /** Convert ACPX timeout seconds into timer-safe milliseconds. */
 export function resolveAcpxTimerTimeoutMs(timeoutSeconds: number | undefined): number | undefined {

--- a/extensions/anthropic-vertex/api.ts
+++ b/extensions/anthropic-vertex/api.ts
@@ -3,6 +3,7 @@
  * and lazy stream factories without eagerly importing the Vertex SDK runtime.
  */
 import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import type { AnthropicVertexStreamDeps } from "./stream-runtime.js";
 
 export {
@@ -21,12 +22,7 @@ export {
 import { buildAnthropicVertexProvider } from "./provider-catalog.js";
 import { hasAnthropicVertexAvailableAuth } from "./region.js";
 
-let streamRuntimeModulePromise: Promise<typeof import("./stream-runtime.js")> | null = null;
-
-const loadStreamRuntimeModule = async () => {
-  streamRuntimeModulePromise ??= import("./stream-runtime.js");
-  return await streamRuntimeModulePromise;
-};
+const loadStreamRuntimeModule = createLazyRuntimeModule(() => import("./stream-runtime.js"));
 
 /** Merge an implicit Anthropic Vertex provider with explicit user config. */
 export function mergeImplicitAnthropicVertexProvider(params: {

--- a/extensions/bonjour/src/advertiser.ts
+++ b/extensions/bonjour/src/advertiser.ts
@@ -6,6 +6,7 @@ import type { ChildProcess } from "node:child_process";
 import fs from "node:fs";
 import { createRequire } from "node:module";
 import os from "node:os";
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import type { PluginLogger } from "openclaw/plugin-sdk/plugin-entry";
 import { isTruthyEnvValue } from "openclaw/plugin-sdk/runtime-env";
 import { classifyCiaoProcessError, type CiaoProcessErrorClassification } from "./ciao.js";
@@ -113,14 +114,10 @@ const defaultLogger = {
 
 const CIAO_MODULE_ID = "@homebridge/ciao";
 const CIAO_WINDOWS_SHELL_COMMANDS = new Set(['arp -a | findstr /C:"---"']);
-let ciaoModulePromise: Promise<CiaoModule> | null = null;
 let ciaoExecHidePatchDepth = 0;
 let restoreCiaoExecHidePatchOnce: (() => void) | null = null;
 
-async function loadCiaoModule(): Promise<CiaoModule> {
-  ciaoModulePromise ??= import(CIAO_MODULE_ID) as Promise<CiaoModule>;
-  return ciaoModulePromise;
-}
+const loadCiaoModule = createLazyRuntimeModule(() => import(CIAO_MODULE_ID) as Promise<CiaoModule>);
 
 function readBonjourDisableOverride(): boolean | null {
   const raw = process.env.OPENCLAW_DISABLE_BONJOUR;

--- a/extensions/brave/src/brave-web-search-provider.ts
+++ b/extensions/brave/src/brave-web-search-provider.ts
@@ -3,6 +3,7 @@
  * lazy-loads HTTP execution only when a search is run.
  */
 import { isDiagnosticFlagEnabled } from "openclaw/plugin-sdk/diagnostic-runtime";
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import type {
   SearchConfigRecord,
   WebSearchProviderPlugin,
@@ -15,14 +16,9 @@ import {
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { buildBraveWebSearchProviderBase } from "../web-search-shared.js";
 
-type BraveWebSearchRuntime = typeof import("./brave-web-search-provider.runtime.js");
-
-let braveWebSearchRuntimePromise: Promise<BraveWebSearchRuntime> | undefined;
-
-function loadBraveWebSearchRuntime(): Promise<BraveWebSearchRuntime> {
-  braveWebSearchRuntimePromise ??= import("./brave-web-search-provider.runtime.js");
-  return braveWebSearchRuntimePromise;
-}
+const loadBraveWebSearchRuntime = createLazyRuntimeModule(
+  () => import("./brave-web-search-provider.runtime.js"),
+);
 
 const BraveSearchSchema = {
   type: "object",

--- a/extensions/browser/plugin-registration.ts
+++ b/extensions/browser/plugin-registration.ts
@@ -1,3 +1,4 @@
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 /**
  * Browser plugin registration helpers. This file keeps registration lazy while
  * advertising Browser tools, services, node-host commands, and audits.
@@ -19,14 +20,9 @@ import { BrowserToolSchema } from "./src/browser-tool.schema.js";
 
 const EAGER_BROWSER_CONTROL_SERVICE_ENV = "OPENCLAW_EAGER_BROWSER_CONTROL_SERVER";
 
-let browserRegistrationRuntimeModulePromise: Promise<
-  typeof import("./register.runtime.js")
-> | null = null;
-
-const loadBrowserRegistrationRuntimeModule = async () => {
-  browserRegistrationRuntimeModulePromise ??= import("./register.runtime.js");
-  return await browserRegistrationRuntimeModulePromise;
-};
+const loadBrowserRegistrationRuntimeModule = createLazyRuntimeModule(
+  () => import("./register.runtime.js"),
+);
 
 function isTruthyEnvValue(value: string | undefined): boolean {
   return /^(?:1|true|yes|on)$/iu.test(value?.trim() ?? "");

--- a/extensions/browser/src/browser/server-context.remote-profile-tab-ops.test-helpers.ts
+++ b/extensions/browser/src/browser/server-context.remote-profile-tab-ops.test-helpers.ts
@@ -1,3 +1,4 @@
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 /**
  * Lazy-loaded dependency bundle for remote-profile tab operation tests.
  */
@@ -19,11 +20,9 @@ export type RemoteProfileTestDeps = {
   originalFetch: typeof import("./server-context.remote-tab-ops.harness.js").originalFetch;
 };
 
-let remoteProfileTestDepsPromise: Promise<RemoteProfileTestDeps> | undefined;
-
 /** Loads remote-profile tab operation dependencies after Chrome mocks are installed. */
-export async function loadRemoteProfileTestDeps(): Promise<RemoteProfileTestDeps> {
-  remoteProfileTestDepsPromise ??= (async () => {
+const loadRemoteProfileTestDepsOnce = createLazyRuntimeModule(() =>
+  (async () => {
     await import("./server-context.chrome-test-harness.js");
     const cdpModule = await import("./cdp.js");
     const chromeModule = await import("./chrome.js");
@@ -53,9 +52,10 @@ export async function loadRemoteProfileTestDeps(): Promise<RemoteProfileTestDeps
       makeState,
       originalFetch,
     };
-  })();
-  return await remoteProfileTestDepsPromise;
-}
+  })(),
+);
+
+export const loadRemoteProfileTestDeps = loadRemoteProfileTestDepsOnce;
 
 /** Installs per-test mock reset and Playwright connection cleanup. */
 export function installRemoteProfileTestLifecycle(deps: RemoteProfileTestDeps): void {

--- a/extensions/browser/src/browser/server.control-server.test-harness.ts
+++ b/extensions/browser/src/browser/server.control-server.test-harness.ts
@@ -1,3 +1,4 @@
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 /**
  * Shared Browser control-server test harness with mocked Chrome, CDP,
  * Playwright, Chrome MCP, config, and media dependencies.
@@ -534,12 +535,7 @@ vi.mock("./screenshot.js", () => ({
   })),
 }));
 
-let browserServerModulePromise: Promise<typeof import("../server.js")> | undefined;
-
-async function loadBrowserServerModule() {
-  browserServerModulePromise ??= import("../server.js");
-  return await browserServerModulePromise;
-}
+const loadBrowserServerModule = createLazyRuntimeModule(() => import("../server.js"));
 
 /** Starts the Browser control server from the mocked config module. */
 export async function startBrowserControlServerFromConfig() {

--- a/extensions/canvas/index.ts
+++ b/extensions/canvas/index.ts
@@ -5,6 +5,7 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { Duplex } from "node:stream";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { definePluginEntry, type AnyAgentTool } from "openclaw/plugin-sdk/plugin-entry";
 import { canvasConfigSchema, isCanvasHostEnabled } from "./src/config.js";
 import { A2UI_PATH, CANVAS_HOST_PATH, CANVAS_WS_PATH } from "./src/host/a2ui-shared.js";
@@ -25,16 +26,14 @@ function createLazyCanvasTool(params: {
   config?: OpenClawConfig;
   workspaceDir?: string;
 }): AnyAgentTool {
-  let toolPromise: Promise<AnyAgentTool> | undefined;
-  const loadTool = async () => {
-    toolPromise ??= import("./src/tool.js").then(({ createCanvasTool }) =>
+  const loadTool = createLazyRuntimeModule(() =>
+    import("./src/tool.js").then(({ createCanvasTool }) =>
       createCanvasTool({
         config: params.config,
         workspaceDir: params.workspaceDir,
       }),
-    );
-    return await toolPromise;
-  };
+    ),
+  );
   return {
     label: "Canvas",
     name: "canvas",
@@ -56,28 +55,22 @@ export default definePluginEntry({
   },
   register(api) {
     if (isCanvasHostEnabled(api.config)) {
-      let httpRouteHandlerPromise:
-        | Promise<
-            ReturnType<(typeof import("./src/http-route.js"))["createCanvasHttpRouteHandler"]>
-          >
-        | undefined;
-      const loadHttpRouteHandler = async () => {
-        httpRouteHandlerPromise ??= import("./src/http-route.js").then(
-          ({ createCanvasHttpRouteHandler }) =>
-            createCanvasHttpRouteHandler({
-              config: api.config,
-              pluginConfig: api.pluginConfig,
-              runtime: {
-                log: (...args) => api.logger.info(args.map(String).join(" ")),
-                error: (...args) => api.logger.error(args.map(String).join(" ")),
-                exit: (code) => {
-                  throw new Error(`canvas host requested process exit ${code}`);
-                },
+      const httpRouteHandlerLoader = createLazyRuntimeModule(() =>
+        import("./src/http-route.js").then(({ createCanvasHttpRouteHandler }) =>
+          createCanvasHttpRouteHandler({
+            config: api.config,
+            pluginConfig: api.pluginConfig,
+            runtime: {
+              log: (...args) => api.logger.info(args.map(String).join(" ")),
+              error: (...args) => api.logger.error(args.map(String).join(" ")),
+              exit: (code) => {
+                throw new Error(`canvas host requested process exit ${code}`);
               },
-            }),
-        );
-        return await httpRouteHandlerPromise;
-      };
+            },
+          }),
+        ),
+      );
+      const loadHttpRouteHandler = httpRouteHandlerLoader;
       const handleHttpRequest = async (req: IncomingMessage, res: ServerResponse) =>
         await (await loadHttpRouteHandler()).handleHttpRequest(req, res);
       const handleUpgrade = async (req: IncomingMessage, socket: Duplex, head: Buffer) =>
@@ -109,18 +102,17 @@ export default definePluginEntry({
         id: "canvas-host",
         start: () => {},
         stop: async () => {
-          const httpRouteHandler = httpRouteHandlerPromise ? await httpRouteHandlerPromise : null;
+          const httpRouteHandler = await httpRouteHandlerLoader.peek();
           await httpRouteHandler?.close();
         },
       });
-      let resolveCanvasHttpPathToLocalPathPromise:
-        | Promise<(typeof import("./src/documents.js"))["resolveCanvasHttpPathToLocalPath"]>
-        | undefined;
-      api.registerHostedMediaResolver(async (mediaUrl) => {
-        resolveCanvasHttpPathToLocalPathPromise ??= import("./src/documents.js").then(
+      const loadResolveCanvasHttpPathToLocalPath = createLazyRuntimeModule(() =>
+        import("./src/documents.js").then(
           ({ resolveCanvasHttpPathToLocalPath }) => resolveCanvasHttpPathToLocalPath,
-        );
-        return (await resolveCanvasHttpPathToLocalPathPromise)(mediaUrl);
+        ),
+      );
+      api.registerHostedMediaResolver(async (mediaUrl) => {
+        return (await loadResolveCanvasHttpPathToLocalPath())(mediaUrl);
       });
     }
     api.registerNodeInvokePolicy({

--- a/extensions/codex/src/app-server/client-factory.ts
+++ b/extensions/codex/src/app-server/client-factory.ts
@@ -1,3 +1,4 @@
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 /**
  * Lazy factories for shared and leased Codex app-server clients.
  */
@@ -22,12 +23,7 @@ export type CodexAppServerClientFactory = (
   },
 ) => Promise<CodexAppServerClient>;
 
-let sharedClientModulePromise: Promise<typeof import("./shared-client.js")> | null = null;
-
-const loadSharedClientModule = async () => {
-  sharedClientModulePromise ??= import("./shared-client.js");
-  return await sharedClientModulePromise;
-};
+const loadSharedClientModule = createLazyRuntimeModule(() => import("./shared-client.js"));
 
 /** Returns a leased shared client so startup can release ownership explicitly. */
 export const defaultLeasedCodexAppServerClientFactory: CodexAppServerClientFactory = (

--- a/extensions/codex/src/web-search-provider.ts
+++ b/extensions/codex/src/web-search-provider.ts
@@ -1,16 +1,12 @@
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { resolvePluginConfigObject } from "openclaw/plugin-sdk/plugin-config-runtime";
 import type { WebSearchProviderPlugin } from "openclaw/plugin-sdk/provider-web-search-contract";
 import type { CodexAppServerClientFactory } from "./app-server/client-factory.js";
 import { createCodexWebSearchProviderBase } from "./web-search-provider.shared.js";
 
-type CodexWebSearchRuntime = typeof import("./web-search-provider.runtime.js");
-
-let codexWebSearchRuntimePromise: Promise<CodexWebSearchRuntime> | undefined;
-
-function loadCodexWebSearchRuntime(): Promise<CodexWebSearchRuntime> {
-  codexWebSearchRuntimePromise ??= import("./web-search-provider.runtime.js");
-  return codexWebSearchRuntimePromise;
-}
+const loadCodexWebSearchRuntime = createLazyRuntimeModule(
+  () => import("./web-search-provider.runtime.js"),
+);
 
 const CodexWebSearchSchema = {
   type: "object",

--- a/extensions/duckduckgo/src/ddg-search-provider.ts
+++ b/extensions/duckduckgo/src/ddg-search-provider.ts
@@ -1,16 +1,10 @@
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 // Duckduckgo provider module implements model/runtime integration.
 import { readPositiveIntegerParam, readStringParam } from "openclaw/plugin-sdk/param-readers";
 import type { WebSearchProviderPlugin } from "openclaw/plugin-sdk/provider-web-search-contract";
 import { createDuckDuckGoWebSearchProviderBase } from "./ddg-search-provider.shared.js";
 
-type DuckDuckGoClientModule = typeof import("./ddg-client.js");
-
-let duckDuckGoClientModulePromise: Promise<DuckDuckGoClientModule> | undefined;
-
-function loadDuckDuckGoClientModule(): Promise<DuckDuckGoClientModule> {
-  duckDuckGoClientModulePromise ??= import("./ddg-client.js");
-  return duckDuckGoClientModulePromise;
-}
+const loadDuckDuckGoClientModule = createLazyRuntimeModule(() => import("./ddg-client.js"));
 
 const DuckDuckGoSearchSchema = {
   type: "object",

--- a/extensions/exa/src/exa-web-search-provider.ts
+++ b/extensions/exa/src/exa-web-search-provider.ts
@@ -1,3 +1,4 @@
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 // Exa provider module implements model/runtime integration.
 import type { WebSearchProviderPlugin } from "openclaw/plugin-sdk/provider-web-search-contract";
 import { createExaWebSearchProviderBase } from "./exa-web-search-provider.shared.js";
@@ -6,14 +7,9 @@ const EXA_SEARCH_TYPES = ["auto", "neural", "fast", "deep", "deep-reasoning", "i
 const EXA_FRESHNESS_VALUES = ["day", "week", "month", "year"] as const;
 const EXA_MAX_SEARCH_COUNT = 100;
 
-type ExaWebSearchRuntime = typeof import("./exa-web-search-provider.runtime.js");
-
-let exaWebSearchRuntimePromise: Promise<ExaWebSearchRuntime> | undefined;
-
-function loadExaWebSearchRuntime(): Promise<ExaWebSearchRuntime> {
-  exaWebSearchRuntimePromise ??= import("./exa-web-search-provider.runtime.js");
-  return exaWebSearchRuntimePromise;
-}
+const loadExaWebSearchRuntime = createLazyRuntimeModule(
+  () => import("./exa-web-search-provider.runtime.js"),
+);
 
 const ExaSearchSchema = {
   type: "object",

--- a/extensions/firecrawl/src/firecrawl-search-provider.ts
+++ b/extensions/firecrawl/src/firecrawl-search-provider.ts
@@ -1,16 +1,10 @@
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 // Firecrawl provider module implements model/runtime integration.
 import { readPositiveIntegerParam } from "openclaw/plugin-sdk/param-readers";
 import type { WebSearchProviderPlugin } from "openclaw/plugin-sdk/provider-web-search-contract";
 import { buildFirecrawlWebSearchProviderBase } from "../web-search-shared.js";
 
-type FirecrawlClientModule = typeof import("./firecrawl-client.js");
-
-let firecrawlClientModulePromise: Promise<FirecrawlClientModule> | undefined;
-
-function loadFirecrawlClientModule(): Promise<FirecrawlClientModule> {
-  firecrawlClientModulePromise ??= import("./firecrawl-client.js");
-  return firecrawlClientModulePromise;
-}
+const loadFirecrawlClientModule = createLazyRuntimeModule(() => import("./firecrawl-client.js"));
 
 const GenericFirecrawlSearchSchema = {
   type: "object",

--- a/extensions/google/gemini-cli-provider.ts
+++ b/extensions/google/gemini-cli-provider.ts
@@ -1,3 +1,4 @@
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 // Google provider module implements model/runtime integration.
 import type {
   OpenClawPluginApi,
@@ -22,12 +23,7 @@ const ENV_VARS = [
   "GEMINI_CLI_OAUTH_CLIENT_SECRET",
 ] as const;
 
-let oauthRuntimeModulePromise: Promise<typeof import("./oauth.runtime.js")> | null = null;
-
-const loadOauthRuntimeModule = async () => {
-  oauthRuntimeModulePromise ??= import("./oauth.runtime.js");
-  return await oauthRuntimeModulePromise;
-};
+const loadOauthRuntimeModule = createLazyRuntimeModule(() => import("./oauth.runtime.js"));
 
 async function fetchGeminiCliUsage(ctx: ProviderFetchUsageSnapshotContext) {
   return await fetchGeminiUsage(ctx.token, ctx.timeoutMs, ctx.fetchFn, PROVIDER_ID);

--- a/extensions/google/src/gemini-web-search-provider.ts
+++ b/extensions/google/src/gemini-web-search-provider.ts
@@ -1,5 +1,6 @@
 // Google provider module implements model/runtime integration.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import {
   createWebSearchProviderContractFields,
   mergeScopedSearchConfig,
@@ -17,14 +18,9 @@ import {
 const GEMINI_CREDENTIAL_PATH = "plugins.entries.google.config.webSearch.apiKey";
 const GOOGLE_PROVIDER_CREDENTIAL_PATH = "models.providers.google.apiKey";
 
-type GeminiWebSearchRuntime = typeof import("./gemini-web-search-provider.runtime.js");
-
-let geminiWebSearchRuntimePromise: Promise<GeminiWebSearchRuntime> | undefined;
-
-function loadGeminiWebSearchRuntime(): Promise<GeminiWebSearchRuntime> {
-  geminiWebSearchRuntimePromise ??= import("./gemini-web-search-provider.runtime.js");
-  return geminiWebSearchRuntimePromise;
-}
+const loadGeminiWebSearchRuntime = createLazyRuntimeModule(
+  () => import("./gemini-web-search-provider.runtime.js"),
+);
 
 const GEMINI_TOOL_PARAMETERS = {
   type: "object",

--- a/extensions/memory-core/index.ts
+++ b/extensions/memory-core/index.ts
@@ -1,3 +1,4 @@
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 // Memory Core plugin entrypoint registers its OpenClaw integration.
 import {
   jsonResult,
@@ -20,7 +21,6 @@ import { buildMemoryFlushPlan } from "./src/flush-plan.js";
 import { buildPromptSection } from "./src/prompt-section.js";
 
 type MemoryToolsModule = typeof import("./src/tools.js");
-type RuntimeProviderModule = typeof import("./src/runtime-provider.js");
 
 type MemoryToolOptions = {
   config?: OpenClawConfig;
@@ -31,18 +31,11 @@ type MemoryToolOptions = {
   oneShotCliRun?: boolean;
 };
 
-let memoryToolsModulePromise: Promise<MemoryToolsModule> | undefined;
-let runtimeProviderModulePromise: Promise<RuntimeProviderModule> | undefined;
+const loadMemoryToolsModule = createLazyRuntimeModule(() => import("./src/tools.js"));
 
-function loadMemoryToolsModule(): Promise<MemoryToolsModule> {
-  memoryToolsModulePromise ??= import("./src/tools.js");
-  return memoryToolsModulePromise;
-}
-
-function loadRuntimeProviderModule(): Promise<RuntimeProviderModule> {
-  runtimeProviderModulePromise ??= import("./src/runtime-provider.js");
-  return runtimeProviderModulePromise;
-}
+const loadRuntimeProviderModule = createLazyRuntimeModule(
+  () => import("./src/runtime-provider.js"),
+);
 
 function getToolConfig(options: MemoryToolOptions): OpenClawConfig | undefined {
   return options.getConfig?.() ?? options.config;

--- a/extensions/memory-core/src/cli.ts
+++ b/extensions/memory-core/src/cli.ts
@@ -1,5 +1,6 @@
 // Memory Core plugin module implements cli behavior.
 import type { Command } from "commander";
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import {
   formatDocsLink,
   formatHelpExamples,
@@ -23,14 +24,7 @@ import {
   DEFAULT_PROMOTION_MIN_UNIQUE_QUERIES,
 } from "./short-term-promotion.js";
 
-type MemoryCliRuntime = typeof import("./cli.runtime.js");
-
-let memoryCliRuntimePromise: Promise<MemoryCliRuntime> | null = null;
-
-async function loadMemoryCliRuntime(): Promise<MemoryCliRuntime> {
-  memoryCliRuntimePromise ??= import("./cli.runtime.js");
-  return await memoryCliRuntimePromise;
-}
+const loadMemoryCliRuntime = createLazyRuntimeModule(() => import("./cli.runtime.js"));
 
 const DECIMAL_NUMBER_RE = /^[+-]?(?:\d+(?:\.\d+)?|\.\d+)$/;
 

--- a/extensions/memory-core/src/memory/search-manager.ts
+++ b/extensions/memory-core/src/memory/search-manager.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 // Memory Core plugin module implements search manager behavior.
 import fs from "node:fs/promises";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import {
   createSubsystemLogger,
   resolveAgentContextLimits,
@@ -112,18 +113,10 @@ const {
   pendingQmdManagerCreates: PENDING_QMD_MANAGER_CREATES,
   qmdManagerOpenFailures: QMD_MANAGER_OPEN_FAILURES,
 } = getMemorySearchManagerCacheStore();
-let managerRuntimePromise: Promise<typeof import("../../manager-runtime.js")> | null = null;
-let qmdManagerModulePromise: Promise<typeof import("./qmd-manager.js")> | null = null;
+const managerRuntimeLoader = createLazyRuntimeModule(() => import("../../manager-runtime.js"));
+const loadManagerRuntime = managerRuntimeLoader;
 
-function loadManagerRuntime() {
-  managerRuntimePromise ??= import("../../manager-runtime.js");
-  return managerRuntimePromise;
-}
-
-function loadQmdManagerModule() {
-  qmdManagerModulePromise ??= import("./qmd-manager.js");
-  return qmdManagerModulePromise;
-}
+const loadQmdManagerModule = createLazyRuntimeModule(() => import("./qmd-manager.js"));
 
 export type MemorySearchManagerResult = {
   manager: Maybe<MemorySearchManager>;
@@ -522,7 +515,7 @@ export async function closeAllMemorySearchManagers(): Promise<void> {
       log.warn(`failed to close qmd memory manager: ${String(err)}`);
     }
   }
-  if (managerRuntimePromise !== null) {
+  if (managerRuntimeLoader.peek()) {
     const { closeAllMemoryIndexManagers } = await loadManagerRuntime();
     await closeAllMemoryIndexManagers();
   }
@@ -548,7 +541,7 @@ export async function closeMemorySearchManager(params: {
       log.warn(`failed to close qmd memory manager for agent ${normalizedAgentId}: ${String(err)}`);
     }
   }
-  if (managerRuntimePromise !== null) {
+  if (managerRuntimeLoader.peek()) {
     const { closeMemoryIndexManagersForAgent } = await loadManagerRuntime();
     await closeMemoryIndexManagersForAgent({ cfg: params.cfg, agentId: normalizedAgentId });
   }

--- a/extensions/memory-core/src/memory/test-manager-helpers.ts
+++ b/extensions/memory-core/src/memory/test-manager-helpers.ts
@@ -1,22 +1,15 @@
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 // Memory Core helper module supports test manager helpers behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
 import type { MemoryIndexManager } from "./index.js";
 
-type MemoryIndexModule = typeof import("./index.js");
+const ensureEmbeddingMocksLoaded = createLazyRuntimeModule(() =>
+  import("./embedding.test-mocks.js").then(() => undefined),
+);
 
-let ensureEmbeddingMocksLoadedPromise: Promise<void> | null = null;
-let getMemorySearchManagerPromise: Promise<MemoryIndexModule["getMemorySearchManager"]> | null =
-  null;
-
-async function ensureEmbeddingMocksLoaded(): Promise<void> {
-  ensureEmbeddingMocksLoadedPromise ??= import("./embedding.test-mocks.js").then(() => undefined);
-  await ensureEmbeddingMocksLoadedPromise;
-}
-
-async function loadGetMemorySearchManager(): Promise<MemoryIndexModule["getMemorySearchManager"]> {
-  getMemorySearchManagerPromise ??= import("./index.js").then((mod) => mod.getMemorySearchManager);
-  return await getMemorySearchManagerPromise;
-}
+const loadGetMemorySearchManager = createLazyRuntimeModule(() =>
+  import("./index.js").then((mod) => mod.getMemorySearchManager),
+);
 
 export async function getRequiredMemoryIndexManager(params: {
   cfg: OpenClawConfig;

--- a/extensions/memory-core/src/tools.shared.ts
+++ b/extensions/memory-core/src/tools.shared.ts
@@ -1,5 +1,6 @@
 // Memory Core plugin module implements tools.shared behavior.
 import { optionalFiniteNumberSchema, stringEnum } from "openclaw/plugin-sdk/channel-actions";
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import {
   listMemoryCorpusSupplements,
   resolveMemorySearchConfig,
@@ -10,8 +11,6 @@ import {
 } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { Type } from "typebox";
-
-type MemoryToolRuntime = typeof import("./tools.runtime.js");
 type MemorySearchManagerResult = Awaited<
   ReturnType<(typeof import("./memory/index.js"))["getMemorySearchManager"]>
 >;
@@ -23,12 +22,7 @@ type MemoryToolOptions = {
   oneShotCliRun?: boolean;
 };
 
-let memoryToolRuntimePromise: Promise<MemoryToolRuntime> | null = null;
-
-export async function loadMemoryToolRuntime(): Promise<MemoryToolRuntime> {
-  memoryToolRuntimePromise ??= import("./tools.runtime.js");
-  return await memoryToolRuntimePromise;
-}
+export const loadMemoryToolRuntime = createLazyRuntimeModule(() => import("./tools.runtime.js"));
 
 export const MemorySearchSchema = Type.Object({
   query: Type.String(),

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -16,6 +16,7 @@ import {
 } from "openclaw/plugin-sdk/channel-actions";
 import { BUNDLED_CHAT_CHANNEL_ENVELOPE_PREFIXES } from "openclaw/plugin-sdk/chat-channel-ids";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import type { MemoryEmbeddingProvider } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
 import { MESSAGE_TOOL_DELIVERY_HINTS } from "openclaw/plugin-sdk/message-tool-delivery-hints";
 import {
@@ -78,33 +79,13 @@ type OpenAiEmbeddingClient = {
     options: { body: unknown; timeout?: number; maxRetries?: number },
   ): Promise<T>;
 };
-
-let openAiModulePromise: Promise<typeof import("openai")> | undefined;
-function loadOpenAiModule(): Promise<typeof import("openai")> {
-  openAiModulePromise ??= import("openai");
-  return openAiModulePromise;
-}
-
-let memoryEmbeddingProviderModulePromise:
-  | Promise<typeof import("openclaw/plugin-sdk/memory-core-host-engine-embeddings")>
-  | undefined;
-function loadMemoryEmbeddingProviderModule(): Promise<
-  typeof import("openclaw/plugin-sdk/memory-core-host-engine-embeddings")
-> {
-  memoryEmbeddingProviderModulePromise ??=
-    import("openclaw/plugin-sdk/memory-core-host-engine-embeddings");
-  return memoryEmbeddingProviderModulePromise;
-}
-
-let memoryHostCoreModulePromise:
-  | Promise<typeof import("openclaw/plugin-sdk/memory-host-core")>
-  | undefined;
-function loadMemoryHostCoreModule(): Promise<
-  typeof import("openclaw/plugin-sdk/memory-host-core")
-> {
-  memoryHostCoreModulePromise ??= import("openclaw/plugin-sdk/memory-host-core");
-  return memoryHostCoreModulePromise;
-}
+const loadOpenAiModule = createLazyRuntimeModule(() => import("openai"));
+const loadMemoryEmbeddingProviderModule = createLazyRuntimeModule(
+  () => import("openclaw/plugin-sdk/memory-core-host-engine-embeddings"),
+);
+const loadMemoryHostCoreModule = createLazyRuntimeModule(
+  () => import("openclaw/plugin-sdk/memory-host-core"),
+);
 
 function extractUserTextContent(message: unknown): string[] {
   const msgObj = asRecord(message);

--- a/extensions/minimax/src/minimax-web-search-provider.ts
+++ b/extensions/minimax/src/minimax-web-search-provider.ts
@@ -1,3 +1,4 @@
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 // Minimax provider module implements model/runtime integration.
 import {
   createWebSearchProviderContractFields,
@@ -12,14 +13,9 @@ const MINIMAX_TOKEN_PLAN_ENV_VARS = [
 ] as const;
 const MINIMAX_WEB_SEARCH_ENV_VARS = [...MINIMAX_TOKEN_PLAN_ENV_VARS, "MINIMAX_API_KEY"] as const;
 
-type MiniMaxWebSearchRuntime = typeof import("./minimax-web-search-provider.runtime.js");
-
-let miniMaxWebSearchRuntimePromise: Promise<MiniMaxWebSearchRuntime> | undefined;
-
-function loadMiniMaxWebSearchRuntime(): Promise<MiniMaxWebSearchRuntime> {
-  miniMaxWebSearchRuntimePromise ??= import("./minimax-web-search-provider.runtime.js");
-  return miniMaxWebSearchRuntimePromise;
-}
+const loadMiniMaxWebSearchRuntime = createLazyRuntimeModule(
+  () => import("./minimax-web-search-provider.runtime.js"),
+);
 
 const MiniMaxSearchSchema = {
   type: "object",

--- a/extensions/moonshot/src/kimi-web-search-provider.ts
+++ b/extensions/moonshot/src/kimi-web-search-provider.ts
@@ -1,3 +1,4 @@
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 // Moonshot provider module implements model/runtime integration.
 import {
   createWebSearchProviderContractFields,
@@ -6,14 +7,10 @@ import {
 } from "openclaw/plugin-sdk/provider-web-search-config-contract";
 
 const KIMI_CREDENTIAL_PATH = "plugins.entries.moonshot.config.webSearch.apiKey";
-type KimiWebSearchProviderRuntime = typeof import("./kimi-web-search-provider.runtime.js");
 
-let kimiWebSearchProviderRuntimePromise: Promise<KimiWebSearchProviderRuntime> | undefined;
-
-function loadKimiWebSearchProviderRuntime(): Promise<KimiWebSearchProviderRuntime> {
-  kimiWebSearchProviderRuntimePromise ??= import("./kimi-web-search-provider.runtime.js");
-  return kimiWebSearchProviderRuntimePromise;
-}
+const loadKimiWebSearchProviderRuntime = createLazyRuntimeModule(
+  () => import("./kimi-web-search-provider.runtime.js"),
+);
 
 const KimiSearchSchema = {
   type: "object",

--- a/extensions/openai/openai-chatgpt-oauth-flow.runtime.ts
+++ b/extensions/openai/openai-chatgpt-oauth-flow.runtime.ts
@@ -5,6 +5,7 @@
  * It is only intended for CLI use, not browser environments.
  */
 
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import {
   parseOAuthAuthorizationInput,
   resolveOAuthTokenExpiresAt,
@@ -56,7 +57,12 @@ type TokenRequestOptions = {
   timeoutMs?: number;
 };
 
-let nodeOAuthRuntimePromise: Promise<NodeOAuthRuntime> | null = null;
+const loadNodeOAuthModules = createLazyRuntimeModule(() =>
+  Promise.all([import("node:crypto"), import("node:http")]).then(([cryptoModule, httpModule]) => ({
+    randomBytes: cryptoModule.randomBytes,
+    http: httpModule,
+  })),
+);
 
 function loadNodeOAuthRuntime(): Promise<NodeOAuthRuntime> {
   if (typeof process === "undefined" || (!process.versions?.node && !process.versions?.bun)) {
@@ -64,13 +70,7 @@ function loadNodeOAuthRuntime(): Promise<NodeOAuthRuntime> {
       new Error("OpenAI Codex OAuth is only available in Node.js environments"),
     );
   }
-  nodeOAuthRuntimePromise ??= Promise.all([import("node:crypto"), import("node:http")]).then(
-    ([cryptoModule, httpModule]) => ({
-      randomBytes: cryptoModule.randomBytes,
-      http: httpModule,
-    }),
-  );
-  return nodeOAuthRuntimePromise;
+  return loadNodeOAuthModules();
 }
 
 function resolveCallbackHost(env: NodeJS.ProcessEnv = process.env): string {

--- a/extensions/parallel/src/parallel-free-web-search-provider.ts
+++ b/extensions/parallel/src/parallel-free-web-search-provider.ts
@@ -1,3 +1,4 @@
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import type { WebSearchProviderPlugin } from "openclaw/plugin-sdk/provider-web-search-contract";
 import { createParallelFreeWebSearchProviderBase } from "./parallel-free-web-search-provider.shared.js";
 import { PARALLEL_FREE_SESSION_ID_MAX_LENGTH } from "./parallel-search-normalize.js";
@@ -18,14 +19,9 @@ const ParallelFreeSearchSchema = {
   },
 } satisfies Record<string, unknown>;
 
-type ParallelFreeWebSearchRuntime = typeof import("./parallel-free-web-search-provider.runtime.js");
-
-let parallelFreeWebSearchRuntimePromise: Promise<ParallelFreeWebSearchRuntime> | undefined;
-
-function loadParallelFreeWebSearchRuntime(): Promise<ParallelFreeWebSearchRuntime> {
-  parallelFreeWebSearchRuntimePromise ??= import("./parallel-free-web-search-provider.runtime.js");
-  return parallelFreeWebSearchRuntimePromise;
-}
+const loadParallelFreeWebSearchRuntime = createLazyRuntimeModule(
+  () => import("./parallel-free-web-search-provider.runtime.js"),
+);
 
 export function createParallelFreeWebSearchProvider(): WebSearchProviderPlugin {
   return {

--- a/extensions/parallel/src/parallel-web-search-provider.ts
+++ b/extensions/parallel/src/parallel-web-search-provider.ts
@@ -1,3 +1,4 @@
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import type { WebSearchProviderPlugin } from "openclaw/plugin-sdk/provider-web-search-contract";
 import { createParallelWebSearchProviderBase } from "./parallel-web-search-provider.shared.js";
 
@@ -8,14 +9,9 @@ const PARALLEL_MAX_OBJECTIVE_CHARS = 5000;
 const PARALLEL_MAX_SESSION_ID_CHARS = 1000;
 const PARALLEL_MAX_CLIENT_MODEL_CHARS = 100;
 
-type ParallelWebSearchRuntime = typeof import("./parallel-web-search-provider.runtime.js");
-
-let parallelWebSearchRuntimePromise: Promise<ParallelWebSearchRuntime> | undefined;
-
-function loadParallelWebSearchRuntime(): Promise<ParallelWebSearchRuntime> {
-  parallelWebSearchRuntimePromise ??= import("./parallel-web-search-provider.runtime.js");
-  return parallelWebSearchRuntimePromise;
-}
+const loadParallelWebSearchRuntime = createLazyRuntimeModule(
+  () => import("./parallel-web-search-provider.runtime.js"),
+);
 
 // Mirrors Parallel's recommended search tool schema:
 // https://docs.parallel.ai/search/best-practices#search-tool-definition

--- a/extensions/perplexity/src/perplexity-web-search-provider.ts
+++ b/extensions/perplexity/src/perplexity-web-search-provider.ts
@@ -1,3 +1,4 @@
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 // Perplexity provider module implements model/runtime integration.
 import {
   mergeScopedSearchConfig,
@@ -11,14 +12,9 @@ import {
   resolvePerplexityWebSearchRuntimeMetadata,
 } from "./perplexity-web-search-provider.shared.js";
 
-type PerplexityWebSearchRuntime = typeof import("./perplexity-web-search-provider.runtime.js");
-
-let perplexityWebSearchRuntimePromise: Promise<PerplexityWebSearchRuntime> | undefined;
-
-function loadPerplexityWebSearchRuntime(): Promise<PerplexityWebSearchRuntime> {
-  perplexityWebSearchRuntimePromise ??= import("./perplexity-web-search-provider.runtime.js");
-  return perplexityWebSearchRuntimePromise;
-}
+const loadPerplexityWebSearchRuntime = createLazyRuntimeModule(
+  () => import("./perplexity-web-search-provider.runtime.js"),
+);
 
 function createPerplexityParameters(transport?: string): Record<string, unknown> {
   const properties: Record<string, unknown> = {

--- a/extensions/policy/src/doctor/register.ts
+++ b/extensions/policy/src/doctor/register.ts
@@ -8,6 +8,7 @@ import {
   type HealthCheckContext,
   type HealthFinding,
 } from "openclaw/plugin-sdk/health";
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
 import { isRecord, uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
@@ -25,12 +26,7 @@ import {
 } from "../policy-state.js";
 import { POLICY_TOOL_GROUPS } from "../tool-policy-conformance.js";
 
-let fsPromisesModulePromise: Promise<typeof import("node:fs/promises")> | null = null;
-
-const loadFsPromisesModule = async () => {
-  fsPromisesModulePromise ??= import("node:fs/promises");
-  return await fsPromisesModulePromise;
-};
+const loadFsPromisesModule = createLazyRuntimeModule(() => import("node:fs/promises"));
 
 import { createPolicyDoctorChecks } from "./checks.js";
 import {

--- a/extensions/qa-lab/src/cli.ts
+++ b/extensions/qa-lab/src/cli.ts
@@ -1,5 +1,6 @@
 // Qa Lab plugin module implements cli behavior.
 import type { Command } from "commander";
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
 import { collectString } from "./cli-options.js";
 import type {
@@ -20,8 +21,6 @@ import {
 } from "./providers/live-frontier/parity.js";
 import type { QaProviderMode, QaProviderModeInput } from "./run-config.js";
 import { hasQaScenarioPack } from "./scenario-catalog.js";
-
-type QaLabCliRuntime = typeof import("./cli.runtime.js");
 
 type QaScenarioRunCliOptions = {
   repoRoot?: QaSuiteCommandOptions["repoRoot"];
@@ -83,12 +82,7 @@ type QaSuiteCliOptions = QaScenarioRunCliOptions & {
   runtimeParityTier?: QaSuiteCommandOptions["runtimeParityTier"];
 };
 
-let qaLabCliRuntimePromise: Promise<QaLabCliRuntime> | null = null;
-
-async function loadQaLabCliRuntime(): Promise<QaLabCliRuntime> {
-  qaLabCliRuntimePromise ??= import("./cli.runtime.js");
-  return await qaLabCliRuntimePromise;
-}
+const loadQaLabCliRuntime = createLazyRuntimeModule(() => import("./cli.runtime.js"));
 
 function invalidQaCliArgument(message: string): Error & { code: string; exitCode: number } {
   const error = new Error(message) as Error & { code: string; exitCode: number };

--- a/extensions/searxng/src/searxng-search-provider.ts
+++ b/extensions/searxng/src/searxng-search-provider.ts
@@ -1,3 +1,4 @@
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 // Searxng provider module implements model/runtime integration.
 import { readPositiveIntegerParam, readStringParam } from "openclaw/plugin-sdk/param-readers";
 import {
@@ -7,14 +8,7 @@ import {
 
 const SEARXNG_CREDENTIAL_PATH = "plugins.entries.searxng.config.webSearch.baseUrl";
 
-type SearxngClientModule = typeof import("./searxng-client.js");
-
-let searxngClientModulePromise: Promise<SearxngClientModule> | undefined;
-
-function loadSearxngClientModule(): Promise<SearxngClientModule> {
-  searxngClientModulePromise ??= import("./searxng-client.js");
-  return searxngClientModulePromise;
-}
+const loadSearxngClientModule = createLazyRuntimeModule(() => import("./searxng-client.js"));
 
 const SearxngSearchSchema = {
   type: "object",

--- a/extensions/tavily/src/tavily-search-provider.ts
+++ b/extensions/tavily/src/tavily-search-provider.ts
@@ -1,3 +1,4 @@
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 // Tavily provider module implements model/runtime integration.
 import { readPositiveIntegerParam } from "openclaw/plugin-sdk/param-readers";
 import type { WebSearchProviderPlugin } from "openclaw/plugin-sdk/provider-web-search-contract";
@@ -7,14 +8,7 @@ import {
   TAVILY_GENERIC_SEARCH_SCHEMA,
 } from "../web-search-shared.js";
 
-type TavilyClientModule = typeof import("./tavily-client.js");
-
-let tavilyClientModulePromise: Promise<TavilyClientModule> | undefined;
-
-function loadTavilyClientModule(): Promise<TavilyClientModule> {
-  tavilyClientModulePromise ??= import("./tavily-client.js");
-  return tavilyClientModulePromise;
-}
+const loadTavilyClientModule = createLazyRuntimeModule(() => import("./tavily-client.js"));
 
 export function createTavilyWebSearchProvider(): WebSearchProviderPlugin {
   return {

--- a/extensions/tavily/web-search-contract-api.ts
+++ b/extensions/tavily/web-search-contract-api.ts
@@ -1,3 +1,4 @@
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 // Tavily API module exposes the plugin public contract.
 import type { WebSearchProviderPlugin } from "openclaw/plugin-sdk/provider-web-search-config-contract";
 import {
@@ -6,14 +7,9 @@ import {
   TAVILY_GENERIC_SEARCH_SCHEMA,
 } from "./web-search-shared.js";
 
-type TavilySearchProviderModule = typeof import("./src/tavily-search-provider.js");
-
-let tavilySearchProviderModulePromise: Promise<TavilySearchProviderModule> | undefined;
-
-function loadTavilySearchProviderModule(): Promise<TavilySearchProviderModule> {
-  tavilySearchProviderModulePromise ??= import("./src/tavily-search-provider.js");
-  return tavilySearchProviderModulePromise;
-}
+const loadTavilySearchProviderModule = createLazyRuntimeModule(
+  () => import("./src/tavily-search-provider.js"),
+);
 
 export function createTavilyWebSearchProvider(): WebSearchProviderPlugin {
   return {

--- a/extensions/xai/index.ts
+++ b/extensions/xai/index.ts
@@ -1,3 +1,4 @@
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 // Xai plugin entrypoint registers its OpenClaw integration.
 import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
 import { OPENAI_COMPATIBLE_REPLAY_HOOKS } from "openclaw/plugin-sdk/provider-model-shared";
@@ -48,25 +49,14 @@ import {
 } from "./xai-oauth.js";
 
 const PROVIDER_ID = "xai";
-type CodeExecutionModule = typeof import("./code-execution.js");
-type XSearchModule = typeof import("./x-search.js");
 
 const XAI_CREDIT_OR_SPENDING_LIMIT_RE =
   /\b(?:used all available credits|monthly spending limit|purchase more credits|raise your spending limit)\b/i;
 const XAI_RATE_LIMIT_RE = /\b(?:rate limit exceeded|too many requests)\b/i;
 
-let codeExecutionModulePromise: Promise<CodeExecutionModule> | undefined;
-let xSearchModulePromise: Promise<XSearchModule> | undefined;
+const loadCodeExecutionModule = createLazyRuntimeModule(() => import("./code-execution.js"));
 
-function loadCodeExecutionModule(): Promise<CodeExecutionModule> {
-  codeExecutionModulePromise ??= import("./code-execution.js");
-  return codeExecutionModulePromise;
-}
-
-function loadXSearchModule(): Promise<XSearchModule> {
-  xSearchModulePromise ??= import("./x-search.js");
-  return xSearchModulePromise;
-}
+const loadXSearchModule = createLazyRuntimeModule(() => import("./x-search.js"));
 
 function classifyXaiFailoverReason(errorMessage: string) {
   if (XAI_CREDIT_OR_SPENDING_LIMIT_RE.test(errorMessage)) {

--- a/extensions/xai/web-search.ts
+++ b/extensions/xai/web-search.ts
@@ -1,3 +1,4 @@
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 // Xai plugin module implements web search behavior.
 import type {
   WebSearchProviderPlugin,
@@ -5,14 +6,9 @@ import type {
 } from "openclaw/plugin-sdk/provider-web-search-config-contract";
 import { buildXaiWebSearchProviderBase } from "./web-search-provider-shared.js";
 
-type XaiWebSearchProviderRuntime = typeof import("./src/web-search-provider.runtime.js");
-
-let xaiWebSearchProviderRuntimePromise: Promise<XaiWebSearchProviderRuntime> | undefined;
-
-function loadXaiWebSearchProviderRuntime(): Promise<XaiWebSearchProviderRuntime> {
-  xaiWebSearchProviderRuntimePromise ??= import("./src/web-search-provider.runtime.js");
-  return xaiWebSearchProviderRuntimePromise;
-}
+const loadXaiWebSearchProviderRuntime = createLazyRuntimeModule(
+  () => import("./src/web-search-provider.runtime.js"),
+);
 
 const GenericXaiSearchSchema = {
   type: "object",

--- a/scripts/check-dynamic-import-warts.mjs
+++ b/scripts/check-dynamic-import-warts.mjs
@@ -74,41 +74,6 @@ function readDeclarationName(node) {
   return null;
 }
 
-function unwrapExpression(node) {
-  let current = node;
-  while (
-    ts.isParenthesizedExpression(current) ||
-    ts.isAsExpression(current) ||
-    ts.isTypeAssertionExpression(current) ||
-    ts.isSatisfiesExpression(current)
-  ) {
-    current = current.expression;
-  }
-  return current;
-}
-
-function isCanonicalLazyLoaderExpression(node) {
-  const expression = unwrapExpression(node);
-  return (
-    ts.isCallExpression(expression) &&
-    ts.isIdentifier(expression.expression) &&
-    expression.expression.text.startsWith("createLazy")
-  );
-}
-
-function containsDynamicImport(node) {
-  let found = false;
-  const visit = (current) => {
-    if (ts.isCallExpression(current) && current.expression.kind === ts.SyntaxKind.ImportKeyword) {
-      found = true;
-      return;
-    }
-    ts.forEachChild(current, visit);
-  };
-  visit(node);
-  return found;
-}
-
 function isIgnoredTestHelperContent(content) {
   return /\bfrom\s+["']vitest["']/.test(content) || /\bfrom\s+["']@vitest\//.test(content);
 }
@@ -134,7 +99,6 @@ export function findDynamicImportAdvisories(content, fileName = "source.ts") {
   const staticRuntimeImports = new Map();
   const dynamicImports = new Map();
   const directExecuteImports = [];
-  const manualMemoizers = [];
   const declarationStack = [];
 
   const addLine = (map, specifier, line) => {
@@ -184,19 +148,6 @@ export function findDynamicImportAdvisories(content, fileName = "source.ts") {
       }
     }
 
-    if (
-      ts.isBinaryExpression(node) &&
-      node.operatorToken.kind === ts.SyntaxKind.QuestionQuestionEqualsToken &&
-      containsDynamicImport(node.right) &&
-      !isCanonicalLazyLoaderExpression(node.right)
-    ) {
-      manualMemoizers.push({
-        line: toLine(sourceFile, node),
-        reason:
-          "hand-written dynamic import memoizer; use createLazyPromise or createLazyRuntimeModule",
-      });
-    }
-
     ts.forEachChild(node, visit);
     if (declarationName) {
       declarationStack.pop();
@@ -205,7 +156,7 @@ export function findDynamicImportAdvisories(content, fileName = "source.ts") {
 
   visit(sourceFile);
 
-  const advisories = [...directExecuteImports, ...manualMemoizers];
+  const advisories = [...directExecuteImports];
   for (const [specifier, dynamicLines] of dynamicImports) {
     const staticLines = staticRuntimeImports.get(specifier);
     if (staticLines?.length) {
@@ -256,7 +207,6 @@ export async function collectDynamicImportAdvisories(options = {}) {
  */
 export async function main(argv = process.argv.slice(2)) {
   const fail = argv.includes("--fail");
-  const failManualMemoizers = argv.includes("--fail-manual-memoizers");
   const json = argv.includes("--json");
   const advisories = await collectDynamicImportAdvisories();
 
@@ -273,14 +223,6 @@ export async function main(argv = process.argv.slice(2)) {
   }
 
   if (fail && advisories.length > 0) {
-    process.exit(1);
-  }
-  if (
-    failManualMemoizers &&
-    advisories.some((advisory) =>
-      advisory.reason.startsWith("hand-written dynamic import memoizer"),
-    )
-  ) {
     process.exit(1);
   }
 }

--- a/scripts/check-dynamic-import-warts.mjs
+++ b/scripts/check-dynamic-import-warts.mjs
@@ -74,6 +74,41 @@ function readDeclarationName(node) {
   return null;
 }
 
+function unwrapExpression(node) {
+  let current = node;
+  while (
+    ts.isParenthesizedExpression(current) ||
+    ts.isAsExpression(current) ||
+    ts.isTypeAssertionExpression(current) ||
+    ts.isSatisfiesExpression(current)
+  ) {
+    current = current.expression;
+  }
+  return current;
+}
+
+function isCanonicalLazyLoaderExpression(node) {
+  const expression = unwrapExpression(node);
+  return (
+    ts.isCallExpression(expression) &&
+    ts.isIdentifier(expression.expression) &&
+    expression.expression.text.startsWith("createLazy")
+  );
+}
+
+function containsDynamicImport(node) {
+  let found = false;
+  const visit = (current) => {
+    if (ts.isCallExpression(current) && current.expression.kind === ts.SyntaxKind.ImportKeyword) {
+      found = true;
+      return;
+    }
+    ts.forEachChild(current, visit);
+  };
+  visit(node);
+  return found;
+}
+
 function isIgnoredTestHelperContent(content) {
   return /\bfrom\s+["']vitest["']/.test(content) || /\bfrom\s+["']@vitest\//.test(content);
 }
@@ -99,6 +134,7 @@ export function findDynamicImportAdvisories(content, fileName = "source.ts") {
   const staticRuntimeImports = new Map();
   const dynamicImports = new Map();
   const directExecuteImports = [];
+  const manualMemoizers = [];
   const declarationStack = [];
 
   const addLine = (map, specifier, line) => {
@@ -148,6 +184,19 @@ export function findDynamicImportAdvisories(content, fileName = "source.ts") {
       }
     }
 
+    if (
+      ts.isBinaryExpression(node) &&
+      node.operatorToken.kind === ts.SyntaxKind.QuestionQuestionEqualsToken &&
+      containsDynamicImport(node.right) &&
+      !isCanonicalLazyLoaderExpression(node.right)
+    ) {
+      manualMemoizers.push({
+        line: toLine(sourceFile, node),
+        reason:
+          "hand-written dynamic import memoizer; use createLazyPromise or createLazyRuntimeModule",
+      });
+    }
+
     ts.forEachChild(node, visit);
     if (declarationName) {
       declarationStack.pop();
@@ -156,7 +205,7 @@ export function findDynamicImportAdvisories(content, fileName = "source.ts") {
 
   visit(sourceFile);
 
-  const advisories = [...directExecuteImports];
+  const advisories = [...directExecuteImports, ...manualMemoizers];
   for (const [specifier, dynamicLines] of dynamicImports) {
     const staticLines = staticRuntimeImports.get(specifier);
     if (staticLines?.length) {
@@ -207,6 +256,7 @@ export async function collectDynamicImportAdvisories(options = {}) {
  */
 export async function main(argv = process.argv.slice(2)) {
   const fail = argv.includes("--fail");
+  const failManualMemoizers = argv.includes("--fail-manual-memoizers");
   const json = argv.includes("--json");
   const advisories = await collectDynamicImportAdvisories();
 
@@ -223,6 +273,14 @@ export async function main(argv = process.argv.slice(2)) {
   }
 
   if (fail && advisories.length > 0) {
+    process.exit(1);
+  }
+  if (
+    failManualMemoizers &&
+    advisories.some((advisory) =>
+      advisory.reason.startsWith("hand-written dynamic import memoizer"),
+    )
+  ) {
     process.exit(1);
   }
 }

--- a/test/scripts/check-dynamic-import-warts.test.ts
+++ b/test/scripts/check-dynamic-import-warts.test.ts
@@ -37,12 +37,10 @@ describe("check-dynamic-import-warts", () => {
       }
       export { run } from "./runtime.js";
     `;
-    expect(findDynamicImportAdvisories(source)).toEqual([
-      {
-        line: 4,
-        reason: 'runtime static + dynamic import of "./runtime.js" (static line 7)',
-      },
-    ]);
+    expect(findDynamicImportAdvisories(source)).toContainEqual({
+      line: 4,
+      reason: 'runtime static + dynamic import of "./runtime.js" (static line 7)',
+    });
   });
 
   it("ignores type-only static re-exports", () => {
@@ -74,12 +72,10 @@ describe("check-dynamic-import-warts", () => {
       }
       export { type Runtime, createRuntime } from "./runtime.js";
     `;
-    expect(findDynamicImportAdvisories(source)).toEqual([
-      {
-        line: 4,
-        reason: 'runtime static + dynamic import of "./runtime.js" (static line 7)',
-      },
-    ]);
+    expect(findDynamicImportAdvisories(source)).toContainEqual({
+      line: 4,
+      reason: 'runtime static + dynamic import of "./runtime.js" (static line 7)',
+    });
   });
 
   it("ignores local export declarations without module specifiers", () => {
@@ -110,13 +106,42 @@ describe("check-dynamic-import-warts", () => {
     ]);
   });
 
-  it("ignores cached loader patterns", () => {
+  it("flags hand-written dynamic import memoizers", () => {
     const source = `
       let runtimePromise: Promise<typeof import("./runtime.js")> | undefined;
       function loadRuntime() {
         runtimePromise ??= import("./runtime.js");
         return runtimePromise;
       }
+    `;
+    expect(findDynamicImportAdvisories(source)).toContainEqual({
+      line: 4,
+      reason:
+        "hand-written dynamic import memoizer; use createLazyPromise or createLazyRuntimeModule",
+    });
+  });
+
+  it("flags transformed and multi-import memoizers", () => {
+    const source = `
+      let runtimePromise: Promise<unknown> | undefined;
+      function loadRuntime() {
+        runtimePromise ??= Promise.all([
+          import("./one.js"),
+          import("./two.js"),
+        ]).then(([one, two]) => ({ one, two }));
+        return runtimePromise;
+      }
+    `;
+    expect(findDynamicImportAdvisories(source)).toContainEqual({
+      line: 4,
+      reason:
+        "hand-written dynamic import memoizer; use createLazyPromise or createLazyRuntimeModule",
+    });
+  });
+
+  it("allows canonical lazy loader assignment", () => {
+    const source = `
+      state.loader ??= createLazyImportLoader(() => import("./runtime.js"));
     `;
     expect(findDynamicImportAdvisories(source)).toStrictEqual([]);
   });
@@ -142,11 +167,7 @@ describe("check-dynamic-import-warts", () => {
 
   it("allows execute paths that call cached loaders", () => {
     const source = `
-      let runtimePromise: Promise<typeof import("./runtime.js")> | undefined;
-      function loadRuntime() {
-        runtimePromise ??= import("./runtime.js");
-        return runtimePromise;
-      }
+      const loadRuntime = createLazyRuntimeModule(() => import("./runtime.js"));
       export function createTool() {
         return {
           execute: async () => await loadRuntime(),

--- a/test/scripts/check-dynamic-import-warts.test.ts
+++ b/test/scripts/check-dynamic-import-warts.test.ts
@@ -37,10 +37,12 @@ describe("check-dynamic-import-warts", () => {
       }
       export { run } from "./runtime.js";
     `;
-    expect(findDynamicImportAdvisories(source)).toContainEqual({
-      line: 4,
-      reason: 'runtime static + dynamic import of "./runtime.js" (static line 7)',
-    });
+    expect(findDynamicImportAdvisories(source)).toEqual([
+      {
+        line: 4,
+        reason: 'runtime static + dynamic import of "./runtime.js" (static line 7)',
+      },
+    ]);
   });
 
   it("ignores type-only static re-exports", () => {
@@ -72,10 +74,12 @@ describe("check-dynamic-import-warts", () => {
       }
       export { type Runtime, createRuntime } from "./runtime.js";
     `;
-    expect(findDynamicImportAdvisories(source)).toContainEqual({
-      line: 4,
-      reason: 'runtime static + dynamic import of "./runtime.js" (static line 7)',
-    });
+    expect(findDynamicImportAdvisories(source)).toEqual([
+      {
+        line: 4,
+        reason: 'runtime static + dynamic import of "./runtime.js" (static line 7)',
+      },
+    ]);
   });
 
   it("ignores local export declarations without module specifiers", () => {
@@ -106,42 +110,13 @@ describe("check-dynamic-import-warts", () => {
     ]);
   });
 
-  it("flags hand-written dynamic import memoizers", () => {
+  it("ignores cached loader patterns", () => {
     const source = `
       let runtimePromise: Promise<typeof import("./runtime.js")> | undefined;
       function loadRuntime() {
         runtimePromise ??= import("./runtime.js");
         return runtimePromise;
       }
-    `;
-    expect(findDynamicImportAdvisories(source)).toContainEqual({
-      line: 4,
-      reason:
-        "hand-written dynamic import memoizer; use createLazyPromise or createLazyRuntimeModule",
-    });
-  });
-
-  it("flags transformed and multi-import memoizers", () => {
-    const source = `
-      let runtimePromise: Promise<unknown> | undefined;
-      function loadRuntime() {
-        runtimePromise ??= Promise.all([
-          import("./one.js"),
-          import("./two.js"),
-        ]).then(([one, two]) => ({ one, two }));
-        return runtimePromise;
-      }
-    `;
-    expect(findDynamicImportAdvisories(source)).toContainEqual({
-      line: 4,
-      reason:
-        "hand-written dynamic import memoizer; use createLazyPromise or createLazyRuntimeModule",
-    });
-  });
-
-  it("allows canonical lazy loader assignment", () => {
-    const source = `
-      state.loader ??= createLazyImportLoader(() => import("./runtime.js"));
     `;
     expect(findDynamicImportAdvisories(source)).toStrictEqual([]);
   });
@@ -167,7 +142,11 @@ describe("check-dynamic-import-warts", () => {
 
   it("allows execute paths that call cached loaders", () => {
     const source = `
-      const loadRuntime = createLazyRuntimeModule(() => import("./runtime.js"));
+      let runtimePromise: Promise<typeof import("./runtime.js")> | undefined;
+      function loadRuntime() {
+        runtimePromise ??= import("./runtime.js");
+        return runtimePromise;
+      }
       export function createTool() {
         return {
           execute: async () => await loadRuntime(),


### PR DESCRIPTION
Related: #98748

## What Problem This Solves

Resolves the final provider and utility portion of a maintainability problem where bundled plugins and provider adapters repeatedly implement their own dynamic-import promise caches. This is PR 6 of 6 in the lazy-runtime consolidation series.

The shared foundation and core leaf batches are already merged:

- #99261 — lazy runtime loader foundation
- #99278 — core leaf lazy loaders

## Why This Change Was Made

Migrates provider and utility plugin loaders to the public `openclaw/plugin-sdk/lazy-runtime` helper while preserving each existing sticky-rejection, retry, reset, and inspection contract. The memory-lancedb provider path retains retry-after-failure behavior; other runtime imports retain sticky rejection caching.

## User Impact

No intended user-visible behavior change. Maintainers get one canonical lazy runtime loader across provider and utility plugins, reducing repeated cache variables and loader functions without changing provider behavior.

## Evidence

- Exact scope: 35 loader files, `+149/-328`.
- Focused loader proof: 307 tests passed across 8 Vitest shards, covering shared lazy helpers, ACPX, Codex, browser remote-profile loaders, memory-core/lancedb, OpenAI OAuth, Parallel, and XAI.
- Format: `oxfmt --check` passed on all 35 files.
- Existing broader proof for the same loader changes: Testbox-through-Crabbox `check:changed` and `pnpm build` passed.
- Fresh Codex autoreview: clean with no accepted/actionable findings, confidence 0.98.
