### PR TITLE
fix(telegram): index-based callback_data fallback for long model names

### DIFF
--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -2945,7 +2945,7 @@ export const registerTelegramHandlers = ({
           return;
         }
 
-        if (modelCallback.type === "select") {
+        if (modelCallback.type === "select" || modelCallback.type === "select-index") {
           const selection = resolveModelSelection({
             callback: modelCallback,
             providers,

--- a/extensions/telegram/src/model-buttons.test.ts
+++ b/extensions/telegram/src/model-buttons.test.ts
@@ -33,6 +33,8 @@ describe("parseModelCallbackData", () => {
         "mdl_sel/anthropic/claude-3-7-sonnet",
         { type: "select", model: "anthropic/claude-3-7-sonnet" },
       ],
+      ["mdl_idx_openai_0", { type: "select-index", provider: "openai", index: 0 }],
+      ["mdl_idx_anthropic_42", { type: "select-index", provider: "anthropic", index: 42 }],
       ["  mdl_prov  ", { type: "providers" }],
     ] as const;
     for (const [input, expected] of cases) {
@@ -50,6 +52,9 @@ describe("parseModelCallbackData", () => {
       "mdl_list_openai_9007199254740993",
       "mdl_sel_noslash",
       "mdl_sel/",
+      "mdl_idx_openai",
+      "mdl_idx_openai_-1",
+      "mdl_idx_openai_abc",
     ];
     for (const input of invalid) {
       expect(parseModelCallbackData(input), input).toBeNull();
@@ -111,6 +116,45 @@ describe("resolveModelSelection", () => {
       matchingProviders: [],
     });
   });
+
+  it("resolves select-index callbacks via sorted-list position", () => {
+    const result = resolveModelSelection({
+      callback: { type: "select-index", provider: "openai", index: 1 },
+      providers: ["openai", "anthropic"],
+      byProvider: new Map([
+        ["openai", new Set(["zeta", "alpha", "mid"])],
+        ["anthropic", new Set(["claude-sonnet-4-5"])],
+      ]),
+    });
+    // Sorted list is ["alpha", "mid", "zeta"]; index 1 -> "mid"
+    expect(result).toEqual({ kind: "resolved", provider: "openai", model: "mid" });
+  });
+
+  it("returns ambiguous when select-index targets an unknown provider", () => {
+    const result = resolveModelSelection({
+      callback: { type: "select-index", provider: "missing", index: 0 },
+      providers: ["openai"],
+      byProvider: new Map([["openai", new Set(["gpt-4.1"])]]),
+    });
+    expect(result).toEqual({
+      kind: "ambiguous",
+      model: "<index:0>",
+      matchingProviders: [],
+    });
+  });
+
+  it("returns ambiguous when select-index is out of range", () => {
+    const result = resolveModelSelection({
+      callback: { type: "select-index", provider: "openai", index: 99 },
+      providers: ["openai"],
+      byProvider: new Map([["openai", new Set(["gpt-4.1"])]]),
+    });
+    expect(result).toEqual({
+      kind: "ambiguous",
+      model: "<index:99>",
+      matchingProviders: [],
+    });
+  });
 });
 
 describe("buildModelSelectionCallbackData", () => {
@@ -127,6 +171,29 @@ describe("buildModelSelectionCallbackData", () => {
   it("returns null when even compact callback exceeds Telegram limit", () => {
     const tooLongModel = "x".repeat(80);
     expect(buildModelSelectionCallbackData({ provider: "openai", model: tooLongModel })).toBeNull();
+  });
+
+  it("falls back to index-based callback when compact form still exceeds the limit", () => {
+    const tooLongModel = "x".repeat(80);
+    expect(
+      buildModelSelectionCallbackData({
+        provider: "openai",
+        model: tooLongModel,
+        sortedIndex: 5,
+      }),
+    ).toBe("mdl_idx_openai_5");
+  });
+
+  it("returns null when every encoding exceeds the limit", () => {
+    const tooLongModel = "x".repeat(80);
+    const tooLongProvider = "p".repeat(60);
+    expect(
+      buildModelSelectionCallbackData({
+        provider: tooLongProvider,
+        model: tooLongModel,
+        sortedIndex: 999999,
+      }),
+    ).toBeNull();
   });
 });
 
@@ -495,11 +562,13 @@ describe("large model lists (OpenRouter-scale)", () => {
     }
   });
 
-  it("skips models that would exceed callback_data limit", () => {
+  it("falls back to index-based callback when model name overflows every text encoding", () => {
+    // Caller-sorted list (the keyboard contract requires the caller to sort
+    // alphabetically before paginating, matching resolveModelSelection's sort).
     const models = [
+      "another-short",
       "short-model",
       "this-is-an-extremely-long-model-name-that-definitely-exceeds-the-sixty-four-byte-limit",
-      "another-short",
     ];
     const result = buildModelsKeyboard({
       provider: "openrouter",
@@ -508,10 +577,14 @@ describe("large model lists (OpenRouter-scale)", () => {
       totalPages: 1,
     });
 
-    // Should have 2 model buttons (skipping the long one) + back
+    // All three models render (no skip); the long one gets an index callback.
     const modelButtons = result.filter((row) => !row[0]?.callback_data.startsWith("mdl_back"));
-    expect(modelButtons.length).toBe(2);
-    expect(modelButtons[0]?.[0]?.text).toBe("short-model");
-    expect(modelButtons[1]?.[0]?.text).toBe("another-short");
+    expect(modelButtons.length).toBe(3);
+    expect(modelButtons[0]?.[0]?.text).toBe("another-short");
+    expect(modelButtons[0]?.[0]?.callback_data).toBe("mdl_sel_openrouter/another-short");
+    expect(modelButtons[1]?.[0]?.text).toBe("short-model");
+    expect(modelButtons[1]?.[0]?.callback_data).toBe("mdl_sel_openrouter/short-model");
+    // Index 2 in the sorted list -> the long model
+    expect(modelButtons[2]?.[0]?.callback_data).toBe("mdl_idx_openrouter_2");
   });
 });

--- a/extensions/telegram/src/model-buttons.ts
+++ b/extensions/telegram/src/model-buttons.ts
@@ -154,49 +154,50 @@ export function resolveModelSelection(params: {
   providers: readonly string[];
   byProvider: ReadonlyMap<string, ReadonlySet<string>>;
 }): ResolveModelSelectionResult {
-  if (params.callback.type === "select-index") {
-    const modelSet = params.byProvider.get(params.callback.provider);
+  const { callback } = params;
+  if (callback.type === "select-index") {
+    const modelSet = params.byProvider.get(callback.provider);
     if (!modelSet || modelSet.size === 0) {
       return {
         kind: "ambiguous",
-        model: `<index:${params.callback.index}>`,
+        model: `<index:${callback.index}>`,
         matchingProviders: [],
       };
     }
     // The keyboard sorts the provider's models alphabetically before paginating,
     // so the index in the callback maps directly to the sorted list position.
     const sortedModels = [...modelSet].toSorted((left, right) => left.localeCompare(right));
-    const model = sortedModels[params.callback.index];
+    const model = sortedModels[callback.index];
     if (!model) {
       return {
         kind: "ambiguous",
-        model: `<index:${params.callback.index}>`,
+        model: `<index:${callback.index}>`,
         matchingProviders: [],
       };
     }
-    return { kind: "resolved", provider: params.callback.provider, model };
+    return { kind: "resolved", provider: callback.provider, model };
   }
 
-  if (params.callback.provider) {
+  if (callback.provider) {
     return {
       kind: "resolved",
-      provider: params.callback.provider,
-      model: params.callback.model,
+      provider: callback.provider,
+      model: callback.model,
     };
   }
   const matchingProviders = params.providers.filter((id) =>
-    params.byProvider.get(id)?.has(params.callback.model),
+    params.byProvider.get(id)?.has(callback.model),
   );
   if (matchingProviders.length === 1) {
     return {
       kind: "resolved",
       provider: matchingProviders[0],
-      model: params.callback.model,
+      model: callback.model,
     };
   }
   return {
     kind: "ambiguous",
-    model: params.callback.model,
+    model: callback.model,
     matchingProviders,
   };
 }

--- a/extensions/telegram/src/model-buttons.ts
+++ b/extensions/telegram/src/model-buttons.ts
@@ -6,6 +6,9 @@
  * - mdl_list_{prov}_{pg}  - show models for provider (page N, 1-indexed)
  * - mdl_sel_{provider/id} - select model (standard)
  * - mdl_sel/{model}       - select model (compact fallback when standard is >64 bytes)
+ * - mdl_idx_{provider}_{i}- select model by sorted-list index (final fallback
+ *                           when even the compact encoding exceeds 64 bytes,
+ *                          e.g. long Ollama namespaced names)
  * - mdl_back              - back to providers list
  */
 import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
@@ -17,6 +20,7 @@ export type ParsedModelCallback =
   | { type: "providers" }
   | { type: "list"; provider: string; page: number }
   | { type: "select"; provider?: string; model: string }
+  | { type: "select-index"; provider: string; index: number }
   | { type: "back" };
 
 export type ProviderInfo = {
@@ -47,6 +51,7 @@ const CALLBACK_PREFIX = {
   list: "mdl_list_",
   selectStandard: "mdl_sel_",
   selectCompact: "mdl_sel/",
+  selectIndex: "mdl_idx_",
 } as const;
 
 /**
@@ -85,6 +90,18 @@ export function parseModelCallbackData(data: string): ParsedModelCallback | null
     }
   }
 
+  // mdl_idx_{provider}_{index} (index-based fallback for names that exceed the
+  // 64-byte limit even in compact form). The resolver looks the index up in
+  // the provider's alphabetically sorted model list.
+  const indexSelMatch = trimmed.match(/^mdl_idx_([a-z0-9_.-]+)_(\d+)$/i);
+  if (indexSelMatch) {
+    const [, provider, indexStr] = indexSelMatch;
+    const index = Number(indexStr);
+    if (provider && Number.isSafeInteger(index) && index >= 0) {
+      return { type: "select-index", provider, index };
+    }
+  }
+
   // mdl_sel_{provider/model}
   const selMatch = trimmed.match(/^mdl_sel_(.+)$/);
   if (selMatch) {
@@ -107,20 +124,59 @@ export function parseModelCallbackData(data: string): ParsedModelCallback | null
 export function buildModelSelectionCallbackData(params: {
   provider: string;
   model: string;
+  /**
+   * Optional position of this model in the provider's alphabetically sorted
+   * model list. When provided, used as the final fallback for names that
+   * exceed Telegram's 64-byte callback_data limit even in compact form,
+   * instead of silently dropping the model.
+   */
+  sortedIndex?: number;
 }): string | null {
   const fullCallbackData = `${CALLBACK_PREFIX.selectStandard}${params.provider}/${params.model}`;
   if (fitsTelegramCallbackData(fullCallbackData)) {
     return fullCallbackData;
   }
   const compactCallbackData = `${CALLBACK_PREFIX.selectCompact}${params.model}`;
-  return fitsTelegramCallbackData(compactCallbackData) ? compactCallbackData : null;
+  if (fitsTelegramCallbackData(compactCallbackData)) {
+    return compactCallbackData;
+  }
+  if (params.sortedIndex !== undefined && params.sortedIndex >= 0) {
+    const indexCallbackData = `${CALLBACK_PREFIX.selectIndex}${params.provider}_${params.sortedIndex}`;
+    if (fitsTelegramCallbackData(indexCallbackData)) {
+      return indexCallbackData;
+    }
+  }
+  return null;
 }
 
 export function resolveModelSelection(params: {
-  callback: Extract<ParsedModelCallback, { type: "select" }>;
+  callback: Extract<ParsedModelCallback, { type: "select" | "select-index" }>;
   providers: readonly string[];
   byProvider: ReadonlyMap<string, ReadonlySet<string>>;
 }): ResolveModelSelectionResult {
+  if (params.callback.type === "select-index") {
+    const modelSet = params.byProvider.get(params.callback.provider);
+    if (!modelSet || modelSet.size === 0) {
+      return {
+        kind: "ambiguous",
+        model: `<index:${params.callback.index}>`,
+        matchingProviders: [],
+      };
+    }
+    // The keyboard sorts the provider's models alphabetically before paginating,
+    // so the index in the callback maps directly to the sorted list position.
+    const sortedModels = [...modelSet].toSorted((left, right) => left.localeCompare(right));
+    const model = sortedModels[params.callback.index];
+    if (!model) {
+      return {
+        kind: "ambiguous",
+        model: `<index:${params.callback.index}>`,
+        matchingProviders: [],
+      };
+    }
+    return { kind: "resolved", provider: params.callback.provider, model };
+  }
+
   if (params.callback.provider) {
     return {
       kind: "resolved",
@@ -210,9 +266,25 @@ export function buildModelsKeyboard(params: ModelsKeyboardParams): ButtonRow[] {
   const endIndex = Math.min(startIndex + pageSize, models.length);
   const pageModels = models.slice(startIndex, endIndex);
 
-  for (const model of pageModels) {
-    const callbackData = buildModelSelectionCallbackData({ provider, model });
-    // Skip models that still exceed Telegram's callback_data limit.
+  // `models` is the provider's full alphabetically-sorted list (the caller
+  // sorts before paginating), so the global index of each model is its
+  // position in `models`. We pass that index as a final callback_data fallback
+  // so models whose names overflow Telegram's 64-byte limit (even in compact
+  // form) still get a usable button instead of being silently dropped.
+  for (let pageOffset = 0; pageOffset < pageModels.length; pageOffset += 1) {
+    const model = pageModels[pageOffset];
+    if (model === undefined) {
+      continue;
+    }
+    const sortedIndex = startIndex + pageOffset;
+    const callbackData = buildModelSelectionCallbackData({
+      provider,
+      model,
+      sortedIndex,
+    });
+    // Skip only if every encoding (standard, compact, index) exceeds the
+    // 64-byte limit. In practice the index encoding fits for any reasonable
+    // provider id, so models are no longer dropped for long names.
     if (!callbackData) {
       continue;
     }


### PR DESCRIPTION
## What Problem This Solves

Closes #98221.

Telegram's inline `callback_data` field has a hard 64-byte limit. The `/models` picker currently has two encodings:

- Standard: `mdl_sel_{provider}/{model}` — used when it fits.
- Compact: `mdl_sel/{model}` — used as a fallback.

When **both** exceed 64 bytes (e.g. long Ollama namespaced names like `llama3.1:70b-instruct-q6_K-xlarge-accelerated-release-candidate`), `buildModelSelectionCallbackData` returns `null` and `buildModelsKeyboard` silently drops the model from the picker. Users on providers with long IDs see an incomplete model list with no indication that models are missing.

## Why This Change Was Made

Adds a third fallback encoding: `mdl_idx_{provider}_{index}`, where `index` is the model's position in the provider's alphabetically sorted model list. The resolver looks the index up in the sorted list to recover the original model ID.

- **Index encoding is compact.** For any reasonable provider id, `mdl_idx_<provider>_<N>` is far under 64 bytes — `mdl_idx_openrouter_999` is 23 bytes — so this fallback covers virtually every real-world case where the compact form overflows.
- **The sort order is already a runtime invariant.** `bot-handlers.runtime.ts` already sorts the provider's models alphabetically before paginating, and `resolveModelSelection` now performs the same sort on the `byProvider` set, so the index in the callback lines up with the model the user clicked.
- **No behavior change for short names.** Standard and compact encodings remain the first two choices; index encoding only kicks in when both would overflow.

## User Impact

Users on providers with long model IDs (Ollama namespaced names, some OpenRouter aliases, Bedrock inference profile ARNs) will now see all models in the `/models` picker instead of a silently truncated list. Selecting a previously-dropped model now works and sets the session override as expected.

## Evidence

- New unit tests in `extensions/telegram/src/model-buttons.test.ts`:
  - `parseModelCallbackData` accepts `mdl_idx_openai_0` and `mdl_idx_anthropic_42`, rejects malformed variants (`mdl_idx_openai`, `mdl_idx_openai_-1`, `mdl_idx_openai_abc`).
  - `buildModelSelectionCallbackData` returns `mdl_idx_openai_5` when standard and compact both overflow, and returns `null` only when the index encoding also overflows.
  - `buildModelsKeyboard` no longer drops long models — they get an index-based callback (`mdl_idx_openrouter_2`).
  - `resolveModelSelection` resolves `select-index` callbacks via sorted-list position and returns an ambiguous result for unknown provider or out-of-range index.
- Caller updated: `extensions/telegram/src/bot-handlers.runtime.ts` now handles `select-index` callbacks alongside `select`.
- Local vitest run: `extensions/telegram/src/model-buttons.test.ts` — 31 passed.
- `oxlint` clean on all three changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)