### PR TITLE
fix(ui): scope agent detail actions

### DIFF
--- a/ui/src/ui/views/agents-panels-overview.ts
+++ b/ui/src/ui/views/agents-panels-overview.ts
@@ -28,6 +28,7 @@ export function renderAgentOverview(params: {
   onModelChange: (agentId: string, modelId: string | null) => void;
   onModelFallbacksChange: (agentId: string, fallbacks: string[]) => void;
   onSelectPanel: (panel: AgentsPanel) => void;
+  onSetDefault: (agentId: string) => void;
 }) {
   const {
     agent,
@@ -41,6 +42,7 @@ export function renderAgentOverview(params: {
     onModelChange,
     onModelFallbacksChange,
     onSelectPanel,
+    onSetDefault,
   } = params;
   const config = resolveAgentConfig(configForm, agent.id);
   const workspaceFromFiles =
@@ -105,6 +107,28 @@ export function renderAgentOverview(params: {
           <div class="label">Skills Filter</div>
           <div>${skillFilter ? `${skillCount} selected` : "all skills"}</div>
         </div>
+      </div>
+
+      <div class="agent-detail-actions" style="margin-top: 16px;">
+        <button
+          type="button"
+          class="btn btn--sm"
+          @click=${() => {
+            if (navigator.clipboard) {
+              void navigator.clipboard.writeText(agent.id);
+            }
+          }}
+        >
+          Copy agent ID
+        </button>
+        <button
+          type="button"
+          class="btn btn--sm"
+          ?disabled=${isDefault}
+          @click=${() => onSetDefault(agent.id)}
+        >
+          ${isDefault ? "Already default" : "Set as default"}
+        </button>
       </div>
 
       ${

--- a/ui/src/ui/views/agents.test.ts
+++ b/ui/src/ui/views/agents.test.ts
@@ -171,4 +171,25 @@ describe("renderAgents", () => {
 
     expect(skillsTab?.textContent?.trim()).toContain("1");
   });
+
+  it("renders agent actions inside the selected agent overview instead of the toolbar", async () => {
+    const container = document.createElement("div");
+    render(renderAgents(createProps()), container);
+    await Promise.resolve();
+
+    expect(container.querySelector(".agent-actions-toggle")).toBeNull();
+    expect(container.querySelector(".agents-control-actions")?.textContent?.trim()).toBe("Refresh");
+
+    const overview = container.querySelector(".agents-main");
+    const defaultButtons = Array.from(
+      overview?.querySelectorAll<HTMLButtonElement>("button") ?? [],
+    ).filter((button) => button.textContent?.trim() === "Set as default");
+    const copyButtons = Array.from(
+      overview?.querySelectorAll<HTMLButtonElement>("button") ?? [],
+    ).filter((button) => button.textContent?.trim() === "Copy agent ID");
+
+    expect(defaultButtons).toHaveLength(1);
+    expect(copyButtons).toHaveLength(1);
+    expect(defaultButtons[0]?.disabled).toBe(false);
+  });
 });

--- a/ui/src/ui/views/agents.ts
+++ b/ui/src/ui/views/agents.ts
@@ -160,43 +160,6 @@ export function renderAgents(props: AgentsProps) {
               </select>
             </div>
             <div class="agents-control-actions">
-              ${
-                selectedAgent
-                  ? html`
-                      <div class="agent-actions-wrap">
-                        <button
-                          class="agent-actions-toggle"
-                          type="button"
-                          @click=${() => {
-                            actionsMenuOpen = !actionsMenuOpen;
-                          }}
-                        >⋯</button>
-                        ${
-                          actionsMenuOpen
-                            ? html`
-                                <div class="agent-actions-menu">
-                                  <button type="button" @click=${() => {
-                                    void navigator.clipboard.writeText(selectedAgent.id);
-                                    actionsMenuOpen = false;
-                                  }}>Copy agent ID</button>
-                                  <button
-                                    type="button"
-                                    ?disabled=${Boolean(defaultId && selectedAgent.id === defaultId)}
-                                    @click=${() => {
-                                      props.onSetDefault(selectedAgent.id);
-                                      actionsMenuOpen = false;
-                                    }}
-                                  >
-                                    ${defaultId && selectedAgent.id === defaultId ? "Already default" : "Set as default"}
-                                  </button>
-                                </div>
-                              `
-                            : nothing
-                        }
-                      </div>
-                    `
-                  : nothing
-              }
               <button class="btn btn--sm agents-refresh-btn" ?disabled=${props.loading} @click=${props.onRefresh}>
                 ${props.loading ? "Loading…" : "Refresh"}
               </button>
@@ -239,6 +202,7 @@ export function renderAgents(props: AgentsProps) {
                         onModelChange: props.onModelChange,
                         onModelFallbacksChange: props.onModelFallbacksChange,
                         onSelectPanel: props.onSelectPanel,
+                        onSetDefault: props.onSetDefault,
                       })
                     : nothing
                 }
@@ -347,8 +311,6 @@ export function renderAgents(props: AgentsProps) {
     </div>
   `;
 }
-
-let actionsMenuOpen = false;
 
 function renderAgentTabs(
   active: AgentsPanel,


### PR DESCRIPTION
Problem\nAgent detail actions were rendered in the global agents toolbar, while the selected-agent details lived below. The action dropdown also used module-level state, so menu state was not scoped to an agent render.\n\nRoot cause\nThe agents view kept actionsMenuOpen as a file-level boolean and rendered Copy agent ID / Set as default beside the selector.\n\nFix\nMove Copy agent ID and Set as default into the selected agent Overview card, remove the toolbar dropdown, and remove the module-level menu state.\n\nValidation\n- pnpm --dir ui exec vitest run src/ui/views/agents.test.ts\n- pnpm exec oxfmt --check ui/src/ui/views/agents.ts ui/src/ui/views/agents-panels-overview.ts ui/src/ui/views/agents.test.ts\n\nKnown gaps/blockers\nFull dependency install emitted unrelated prepare-time TypeScript errors from a nested optional package before completing, but the focused UI test and formatting check passed.\n\nProduction expectation\nAgent detail actions should now be scoped to the selected agent details panel, with no duplicated toolbar action controls or cross-agent dropdown state.