### PR TITLE
test(telegram): lock rich table presentation attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **WeChat account routing:** `startAccount` preserves session routing by resolving manifest channel account config from raw account keys with opaque provider ids, while still ignoring manifest account keys that normalize to blocked object keys. (#93686) Thanks @zhangguiping-xydt.
+- **Telegram rich tables:** Markdown tables sent through `richMessages` keep Telegram's native `bordered` and `striped` table presentation so clients show grid lines and alternating rows instead of bare, unstyled tables.
 
 ## 2026.6.11
 

--- a/extensions/telegram/src/format.test.ts
+++ b/extensions/telegram/src/format.test.ts
@@ -265,6 +265,13 @@ describe("markdownToTelegramHtml", () => {
     expect(markdownToTelegramRichHtml(table(2), { tableMode: "code" })).not.toContain("<table>");
   });
 
+  it("marks rich markdown tables as bordered and striped for visible Telegram styling", () => {
+    const html = markdownToTelegramRichHtml("| Name | Score |\n| --- | ---: |\n| Alice | 10 |");
+
+    expect(html).toContain("<table bordered striped>");
+    expect(html).not.toContain("<table><thead>");
+  });
+
   it("falls back over-wide raw rich HTML tables", () => {
     const cells = Array.from({ length: 21 }, (_, index) => `<td>C${index + 1}</td>`).join("");
     const html = `<table><caption>Wide</caption><tbody><tr>${cells}</tr></tbody></table>`;


### PR DESCRIPTION
## Summary

Lock the Telegram rich Markdown-table presentation regression with explicit coverage and an Unreleased changelog note.

OpenClaw `v2026.6.11` renders rich Markdown tables as bare `<table>...`, which Telegram clients show without visible borders or striped rows. Current `main` already emits `<table bordered striped>...`; this PR adds a focused regression test so that presentation attribute does not silently regress again.

## Evidence

Release-tag check from `v2026.6.11`:

```text
renderTelegramRichHtmlTable(...) -> <table>${head}${body}</table>
```

Current `main` source check:

```text
renderTelegramRichHtmlTable(...) -> <table bordered striped>${head}${body}</table>
```

Local lightweight checks:

```text
git diff --check
rich-table-output-present
regression-test-present
```

## Validation note

I attempted the targeted test:

```text
pnpm test extensions/telegram/src/format.test.ts
```

The host ran out of disk during dependency installation (`ERR_PNPM_ENOSPC`) while downloading large native packages. I stopped the install and removed only the generated `/tmp/openclaw-rich-tables/node_modules` tree. The code change is test/changelog only, and the added test directly asserts the missing `bordered striped` rich-table marker.
