### PR TITLE
fix(ui): copy workspace file paths over plain HTTP

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -29,6 +29,7 @@ import {
 } from "./app-render.helpers.ts";
 import { hasOperatorAdminAccess, hasOperatorWriteAccess, warnQueryToken } from "./app-settings.ts";
 import type { AppViewState } from "./app-view-state.ts";
+import { copyToClipboard } from "./chat/clipboard.ts";
 import { reconcileChatRunLifecycle } from "./chat/run-lifecycle.ts";
 import {
   renderChatQuotaPill,
@@ -2341,7 +2342,7 @@ export function renderApp(state: AppViewState) {
     }, 160);
   };
   const copyChatWorkspacePath = (filePath: string) => {
-    void globalThis.navigator?.clipboard?.writeText?.(filePath);
+    void copyToClipboard(filePath);
   };
   function loadChatWorkspaceFiles(opts?: { force?: boolean }) {
     if (!state.client || !state.connected) {

--- a/ui/src/ui/e2e/chat-flow.e2e.test.ts
+++ b/ui/src/ui/e2e/chat-flow.e2e.test.ts
@@ -51,6 +51,29 @@ async function waitForRequests(
   throw new Error(`Timed out waiting for ${count} ${method} requests`);
 }
 
+async function installPlainHttpClipboardCapture(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    Object.defineProperty(navigator, "clipboard", { configurable: true, value: undefined });
+    (globalThis as unknown as { copiedViaExec: string[] }).copiedViaExec = [];
+    document.execCommand = ((command: string) => {
+      if (command !== "copy") {
+        return false;
+      }
+      // execCommand("copy") copies the active selection; the fallback selects
+      // its off-screen scratch textarea, so the focused element holds the text.
+      const active = document.activeElement as HTMLTextAreaElement | null;
+      (globalThis as unknown as { copiedViaExec: string[] }).copiedViaExec.push(
+        active?.value ?? "",
+      );
+      return true;
+    }) as typeof document.execCommand;
+  });
+}
+
+async function copiedViaExec(page: Page): Promise<string[]> {
+  return page.evaluate(() => (globalThis as unknown as { copiedViaExec: string[] }).copiedViaExec);
+}
+
 async function chatThreadDistanceFromBottom(page: Page): Promise<number> {
   return page.locator(".chat-thread").evaluate((element) => {
     const thread = element as HTMLElement;
@@ -373,25 +396,8 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
       viewport: { height: 900, width: 1280 },
     });
     const page = await context.newPage();
-    // Simulate a plain-HTTP (non-secure) deployment: navigator.clipboard is
-    // undefined there, so the Clipboard API path throws. Capture the legacy
-    // execCommand copy the fallback should use instead.
-    await page.addInitScript(() => {
-      Object.defineProperty(navigator, "clipboard", { configurable: true, value: undefined });
-      (globalThis as unknown as { copiedViaExec: string[] }).copiedViaExec = [];
-      document.execCommand = ((command: string) => {
-        if (command !== "copy") {
-          return false;
-        }
-        // execCommand("copy") copies the active selection; the fallback selects
-        // its off-screen scratch textarea, so the focused element holds the text.
-        const active = document.activeElement as HTMLTextAreaElement | null;
-        (globalThis as unknown as { copiedViaExec: string[] }).copiedViaExec.push(
-          active?.value ?? "",
-        );
-        return true;
-      }) as typeof document.execCommand;
-    });
+    // Simulate a plain-HTTP deployment where navigator.clipboard is unavailable.
+    await installPlainHttpClipboardCapture(page);
     const code = "const hello = 1;";
     const gateway = await installMockGateway(page, {
       historyMessages: [
@@ -414,10 +420,50 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
           timeout: 10_000,
         })
         .toBe(true);
-      const copied = await page.evaluate(
-        () => (globalThis as unknown as { copiedViaExec: string[] }).copiedViaExec,
-      );
-      expect(copied).toContain(code);
+      expect(await copiedViaExec(page)).toContain(code);
+      expect(await gateway.getRequests("chat.send")).toHaveLength(0);
+    } finally {
+      await closeBrowserContext(context);
+    }
+  });
+
+  it("copies a workspace file path over a non-secure context via the execCommand fallback", async () => {
+    const context = await newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    await installPlainHttpClipboardCapture(page);
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "artifacts.list": { artifacts: [] },
+        "sessions.files.list": {
+          browser: { entries: [], path: "" },
+          files: [
+            {
+              kind: "modified",
+              missing: false,
+              name: "AGENTS.md",
+              path: "/workspace/AGENTS.md",
+              size: 2048,
+            },
+          ],
+          root: "/workspace",
+          sessionKey: "main",
+        },
+      },
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+      await page.getByRole("button", { name: "Expand session workspace" }).click();
+      await page.getByText("AGENTS.md").waitFor({ timeout: 10_000 });
+
+      await page.getByRole("button", { name: "Copy path" }).click();
+
+      expect(await copiedViaExec(page)).toContain("/workspace/AGENTS.md");
+      expect(await gateway.getRequests("sessions.files.list")).toHaveLength(1);
       expect(await gateway.getRequests("chat.send")).toHaveLength(0);
     } finally {
       await closeBrowserContext(context);


### PR DESCRIPTION
Closes #98759

## What Problem This Solves

Fixes an issue where users clicking **Copy path** in the Chat tab's Session Workspace files panel would get no copied path when the Control UI is served from a plain-HTTP context where `navigator.clipboard` is unavailable.

The workspace file row already routed the click back to the app-level workspace callback, but that callback used only the secure-context Clipboard API path. The existing Control UI clipboard helper already supports the legacy `execCommand("copy")` fallback used by other chat copy affordances.

## Why This Change Was Made

This routes workspace path copying through the shared `copyToClipboard` helper instead of directly calling `navigator.clipboard.writeText`, keeping the workspace panel behavior aligned with the existing code-block copy fallback.

The E2E coverage now shares a plain-HTTP clipboard capture helper and adds a browser-level regression for the workspace Copy path button. This is a narrow Control UI fix; it does not change workspace file listing, file opening, Gateway RPCs, or clipboard UI state.

AI-assisted.

## User Impact

Users can copy Session Workspace file paths from the Chat tab even when accessing the Control UI over plain HTTP or another context where the async Clipboard API is not exposed.

Secure-context clipboard behavior remains unchanged because `copyToClipboard` still tries `navigator.clipboard.writeText` first.

## Evidence

Before source proof on current `upstream/main`: `ui/src/ui/app-render.ts` wired `copyChatWorkspacePath` to `globalThis.navigator?.clipboard?.writeText?.(filePath)`, so a missing Clipboard API made the Copy path click a no-op. The workspace rail was introduced in #92856; the reusable plain-HTTP clipboard fallback was added later in #93666 for code-block copying.

After browser proof:

```sh
PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=<local chromium> node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts ui/src/ui/e2e/chat-flow.e2e.test.ts -t "copies a workspace file path"
```

Result: 1 test file passed; 1 test passed, 18 skipped. The E2E opened the mocked Control UI chat page, expanded Session Workspace, clicked the file row **Copy path** button with `navigator.clipboard` unset, and observed `/workspace/AGENTS.md` copied through the `execCommand` fallback with no `chat.send` request.

Additional validation:

```sh
node scripts/run-vitest.mjs ui/src/ui/chat/clipboard.test.ts
PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=<local chromium> node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts ui/src/ui/e2e/chat-flow.e2e.test.ts -t "copies a code block over a non-secure context"
node_modules/.bin/oxfmt --check --threads=1 ui/src/ui/app-render.ts ui/src/ui/e2e/chat-flow.e2e.test.ts
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.ui.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-ui.tsbuildinfo
node scripts/ui.js build
git diff --check
```

Results: all passed. `node scripts/ui.js build` completed with the existing large chunk warning only.

Local embedded model smoke using the configured DeepSeek environment also completed: provider `deepseek`, model `deepseek-v4-pro`, stop reason `stop`, final visible text `workspace-copy-proof`.

Closeout review:

```sh
.agents/skills/autoreview/scripts/autoreview --mode local
```

Result: clean; no accepted/actionable findings.

Broad `pnpm check` and full `pnpm test` were not run locally in this linked worktree; the PR CI should cover the wider repository gates.
