### PR TITLE
fix(pr): stop rebased syncs from losing ancestry

### DIFF
--- a/scripts/pr
+++ b/scripts/pr
@@ -40,7 +40,7 @@ Usage:
   scripts/pr prepare-init <PR>
   scripts/pr prepare-validate-commit <PR>
   scripts/pr prepare-gates <PR>
-  scripts/pr prepare-push <PR>
+  scripts/pr prepare-push [--repair-ancestry] <PR>
   scripts/pr prepare-sync-head <PR>
   scripts/pr prepare-run <PR>
   scripts/pr merge-verify <PR>
@@ -168,9 +168,18 @@ main() {
       prepare_gates "$pr"
       ;;
     prepare-push)
+      local repair_ancestry=false
+      if [ "${1-}" = "--repair-ancestry" ]; then
+        repair_ancestry=true
+        shift || true
+      fi
       local pr="${1-}"
       [ -n "$pr" ] || { usage; exit 2; }
-      prepare_push "$pr"
+      if [ "$repair_ancestry" = "true" ]; then
+        prepare_push_ancestry_repair "$pr"
+      else
+        prepare_push "$pr"
+      fi
       ;;
     prepare-sync-head)
       local pr="${1-}"

--- a/scripts/pr-lib/common.sh
+++ b/scripts/pr-lib/common.sh
@@ -1,5 +1,22 @@
+artifact_path_is_tracked() {
+  local path="$1"
+  git ls-files --error-unmatch -- ":(icase,literal)$path" >/dev/null 2>&1
+}
+
 require_artifact() {
   local path="$1"
+  case "$path" in
+    .local/*)
+      if [ -L .local ] || [ ! -d .local ]; then
+        echo "Refusing untrusted local artifact directory: .local"
+        exit 1
+      fi
+      if [ -L "$path" ] || { [ -e "$path" ] && [ ! -f "$path" ]; } || artifact_path_is_tracked "$path"; then
+        echo "Refusing untrusted local artifact: $path"
+        exit 1
+      fi
+      ;;
+  esac
   if [ ! -s "$path" ]; then
     echo "Missing required artifact: $path"
     exit 1

--- a/scripts/pr-lib/prepare-core.sh
+++ b/scripts/pr-lib/prepare-core.sh
@@ -605,6 +605,26 @@ prepare_sync_head() {
     return 1
   fi
 
+  if [ "${OPENCLAW_TESTBOX:-}" != "1" ] && [ "$prep_head_sha" != "$lease_sha" ]; then
+    local gates_cover_prep=false
+    if [ -e .local/gates.env ] || [ -L .local/gates.env ]; then
+      require_artifact .local/gates.env
+      # shellcheck disable=SC1091
+      source .local/gates.env
+      if [ "${LAST_VERIFIED_HEAD_SHA:-}" = "$prep_head_sha" ]; then
+        gates_cover_prep=true
+      fi
+    fi
+    if [ "$gates_cover_prep" != "true" ]; then
+      prepare_gates "$pr"
+      checkout_prep_branch "$pr"
+      if [ "$(git rev-parse HEAD)" != "$prep_head_sha" ]; then
+        echo "Prepare gates changed the synced head; restart prepare-sync-head."
+        return 1
+      fi
+    fi
+  fi
+
   if [ "${OPENCLAW_PR_PUSH_MODE:-graphql}" != "git" ] && ! require_graphql_push_preserves_ancestry "$lease_sha" "$prep_head_sha"; then
     echo "Retry prepare-sync-head with the explicit git/unsigned overrides for this content-changing head."
     return 1

--- a/scripts/pr-lib/prepare-core.sh
+++ b/scripts/pr-lib/prepare-core.sh
@@ -47,9 +47,121 @@ verify_prep_branch_matches_prepared_head() {
   exit 1
 }
 
+write_prep_sync_artifact() {
+  local pr="$1"
+  local pr_head="$2"
+  local remote_lease_sha="$3"
+  local local_head_sha="$4"
+  local mainline_base_sha="$5"
+  local published_head_sha="${6:-}"
+  local sync_tree
+  sync_tree=$(git rev-parse "${local_head_sha}^{tree}")
+  local artifact_path=".local/prep-sync.env"
+  if [ -L .local ] || [ ! -d .local ]; then
+    echo "Refusing untrusted local artifact directory: .local"
+    exit 1
+  fi
+  if artifact_path_is_tracked "$artifact_path"; then
+    echo "Refusing tracked local artifact destination: $artifact_path"
+    exit 1
+  fi
+  if [ -e "$artifact_path" ] || [ -L "$artifact_path" ]; then
+    if [ -L "$artifact_path" ] || [ ! -f "$artifact_path" ]; then
+      echo "Refusing untrusted local artifact destination: $artifact_path"
+      exit 1
+    fi
+  fi
+  local artifact_tmp
+  artifact_tmp=$(mktemp .local/prep-sync.env.XXXXXX)
+
+  # Security: shell-escape values before the repair flow sources this artifact.
+  printf '%s=%q\n' \
+    PREP_SYNC_PR_NUMBER "$pr" \
+    PREP_SYNC_BRANCH "$pr_head" \
+    PREP_SYNC_REMOTE_LEASE_SHA "$remote_lease_sha" \
+    PREP_SYNC_LOCAL_HEAD_SHA "$local_head_sha" \
+    PREP_SYNC_MAINLINE_BASE_SHA "$mainline_base_sha" \
+    PREP_SYNC_TREE "$sync_tree" \
+    PREP_SYNC_PUBLISHED_HEAD_SHA "$published_head_sha" \
+    PREP_SYNC_MODE ancestry_repair \
+    PREP_SYNC_REQUIRES_HOSTED_GATES 1 \
+    PREP_SYNC_RECORDED_AT "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    > "$artifact_tmp"
+  mv -f "$artifact_tmp" "$artifact_path"
+  if [ -L "$artifact_path" ] || [ ! -f "$artifact_path" ]; then
+    echo "Failed to create regular sync artifact: $artifact_path"
+    exit 1
+  fi
+  if artifact_path_is_tracked "$artifact_path"; then
+    echo "Created sync artifact unexpectedly became tracked: $artifact_path"
+    exit 1
+  fi
+}
+
+require_exact_prepare_gates() {
+  local prep_head_sha="$1"
+  require_artifact .local/gates.env
+  # shellcheck disable=SC1091
+  source .local/gates.env
+
+  if [ "${LAST_VERIFIED_HEAD_SHA:-}" != "$prep_head_sha" ]; then
+    echo "Prepare gates do not cover the current local head (expected $prep_head_sha, got ${LAST_VERIFIED_HEAD_SHA:-missing})."
+    exit 1
+  fi
+  if [ ! -e .local/prep-sync.env ] && [ ! -L .local/prep-sync.env ]; then
+    return 0
+  fi
+  require_artifact .local/prep-sync.env
+
+  # shellcheck disable=SC1091
+  source .local/prep-sync.env
+  if [ "${PREP_SYNC_MODE:-}" != "ancestry_repair" ]; then
+    echo "Prepared sync artifact has an unsupported mode; restart prepare from a clean worktree."
+    exit 1
+  fi
+  if [ "${PREP_SYNC_REQUIRES_HOSTED_GATES:-}" != "1" ]; then
+    echo "Ancestry-repair artifact is stale or invalid. Re-run prepare-sync-head."
+    exit 1
+  fi
+  if [ "${PREP_SYNC_PUBLISHED_HEAD_SHA:-}" != "$prep_head_sha" ]; then
+    echo "Prepared synced head has not been published by the ancestry-repair flow."
+    exit 1
+  fi
+  if [ "${GATES_MODE:-}" != "hosted_exact_head" ] || [ "${HOSTED_GATES_HEAD_SHA:-}" != "$prep_head_sha" ]; then
+    echo "Ancestry-repaired head requires exact published-head hosted gates before prepare-push."
+    exit 1
+  fi
+}
+
+guard_active_prep_sync() {
+  if [ ! -e .local/prep-sync.env ] && [ ! -L .local/prep-sync.env ]; then
+    return 0
+  fi
+  require_artifact .local/prep-sync.env
+  # shellcheck disable=SC1091
+  source .local/prep-sync.env
+  if [ "${PREP_SYNC_MODE:-}" != "ancestry_repair" ]; then
+    echo "Active sync artifact has an unsupported mode; restart prepare from a clean worktree."
+    return 1
+  fi
+  if [ "${PREP_SYNC_REQUIRES_HOSTED_GATES:-}" != "1" ]; then
+    echo "Active sync artifact is legacy or invalid; remove it and re-run prepare-sync-head."
+    return 1
+  fi
+  if [ -n "${PREP_SYNC_PUBLISHED_HEAD_SHA:-}" ]; then
+    echo "Published synced head $PREP_SYNC_PUBLISHED_HEAD_SHA still requires exact hosted gates."
+    echo "Run OPENCLAW_TESTBOX=1 scripts/pr prepare-run <PR>; prepare-init and prepare-sync-head cannot replace it."
+  else
+    echo "An active sync artifact requires its explicit publication mode; normal prepare cannot replace it."
+  fi
+  return 1
+}
+
 prepare_init() {
   local pr="$1"
   enter_worktree "$pr" true
+
+  guard_active_prep_sync || exit 1
 
   require_artifact .local/pr-meta.env
   require_artifact .local/review.md
@@ -133,7 +245,6 @@ prepare_push() {
 
   require_artifact .local/pr-meta.env
   require_artifact .local/prep-context.env
-  require_artifact .local/gates.env
 
   checkout_prep_branch "$pr"
 
@@ -141,11 +252,10 @@ prepare_push() {
   source .local/pr-meta.env
   # shellcheck disable=SC1091
   source .local/prep-context.env
-  # shellcheck disable=SC1091
-  source .local/gates.env
 
   local prep_head_sha
   prep_head_sha=$(git rev-parse HEAD)
+  require_exact_prepare_gates "$prep_head_sha"
   local local_prep_head_sha
 
   local lease_sha
@@ -153,7 +263,30 @@ prepare_push() {
   local push_result_env=".local/prepare-push-result.env"
 
   verify_pr_head_branch_matches_expected "$pr" "$PR_HEAD"
-  push_prep_head_to_pr_branch "$pr" "$PR_HEAD" "$prep_head_sha" "$lease_sha" true "${DOCS_ONLY:-false}" "$push_result_env"
+  if [ "${PREP_SYNC_MODE:-}" != "ancestry_repair" ] && [ "${OPENCLAW_PR_PUSH_MODE:-graphql}" != "git" ]; then
+    require_graphql_push_preserves_ancestry "$lease_sha" "$prep_head_sha" || exit 1
+  fi
+  if [ "${PREP_SYNC_MODE:-}" = "ancestry_repair" ]; then
+    if [ "$lease_sha" != "$PREP_SYNC_PUBLISHED_HEAD_SHA" ]; then
+      echo "Repaired PR head changed after exact hosted gates; refusing to republish it."
+      exit 1
+    fi
+    setup_prhead_remote
+    local final_remote_sha
+    final_remote_sha=$(resolve_prhead_remote_sha "$PR_HEAD")
+    if [ "$final_remote_sha" != "$PREP_SYNC_PUBLISHED_HEAD_SHA" ]; then
+      echo "Repaired remote branch changed after exact hosted gates; refusing to republish it."
+      exit 1
+    fi
+    printf '%s=%q\n' \
+      PUSH_PREP_HEAD_SHA "$prep_head_sha" \
+      PUSH_LOCAL_PREP_HEAD_SHA "$prep_head_sha" \
+      PUSHED_FROM_SHA "$final_remote_sha" \
+      PR_HEAD_SHA_AFTER_PUSH "$final_remote_sha" \
+      > "$push_result_env"
+  else
+    push_prep_head_to_pr_branch "$pr" "$PR_HEAD" "$prep_head_sha" "$lease_sha" true "${DOCS_ONLY:-false}" "$push_result_env"
+  fi
   # shellcheck disable=SC1090
   source "$push_result_env"
   prep_head_sha="$PUSH_PREP_HEAD_SHA"
@@ -173,7 +306,9 @@ prepare_push() {
       exit 1
     fi
     mainline_base_sha="$PREP_SYNC_MAINLINE_BASE_SHA"
-    rm -f .local/prep-sync.env
+    local remove_prep_sync_after_finalize=true
+  else
+    local remove_prep_sync_after_finalize=false
   fi
   local pushed_from_sha="$PUSHED_FROM_SHA"
   local pr_head_sha_after="$PR_HEAD_SHA_AFTER_PUSH"
@@ -209,6 +344,9 @@ EOF_PREP
     > .local/prep.env
 
   ls -la .local/prep.md .local/prep.env >/dev/null
+  if [ "$remove_prep_sync_after_finalize" = "true" ]; then
+    rm -f .local/prep-sync.env
+  fi
 
   echo "prepare-push complete"
   echo "pr_url=${PR_URL:-}"
@@ -216,6 +354,167 @@ EOF_PREP
   echo "prep_head_sha=$prep_head_sha"
   echo "pr_head_sha=$pr_head_sha_after"
   echo "artifacts=.local/prep.md .local/prep.env"
+}
+
+prepare_push_ancestry_repair() {
+  local pr="$1"
+  enter_worktree "$pr" false
+
+  require_artifact .local/pr-meta.env
+  require_artifact .local/prep-context.env
+  require_artifact .local/prep.md
+  require_artifact .local/prep-sync.env
+  checkout_prep_branch "$pr"
+
+  # shellcheck disable=SC1091
+  source .local/pr-meta.env
+  # shellcheck disable=SC1091
+  source .local/prep-context.env
+  # shellcheck disable=SC1091
+  source .local/prep-sync.env
+
+  local required_sync_field
+  for required_sync_field in \
+    PREP_SYNC_PR_NUMBER \
+    PREP_SYNC_BRANCH \
+    PREP_SYNC_REMOTE_LEASE_SHA \
+    PREP_SYNC_LOCAL_HEAD_SHA \
+    PREP_SYNC_MAINLINE_BASE_SHA \
+    PREP_SYNC_TREE
+  do
+    if [ -z "${!required_sync_field:-}" ]; then
+      echo "Ancestry repair artifact is missing $required_sync_field. Re-run prepare-sync-head."
+      exit 1
+    fi
+  done
+
+  if [ "${OPENCLAW_PR_PUSH_MODE:-}" != "git" ] || [ "${OPENCLAW_ALLOW_UNSIGNED_GIT_PUSH:-}" != "1" ]; then
+    echo "Ancestry repair requires OPENCLAW_PR_PUSH_MODE=git and OPENCLAW_ALLOW_UNSIGNED_GIT_PUSH=1."
+    exit 1
+  fi
+  if [ "${PREP_SYNC_PR_NUMBER:-}" != "$pr" ] || [ "${PREP_SYNC_BRANCH:-}" != "$PR_HEAD" ]; then
+    echo "Ancestry repair artifact does not match PR #$pr branch $PR_HEAD."
+    exit 1
+  fi
+  if [ "${PREP_SYNC_REQUIRES_HOSTED_GATES:-}" != "1" ]; then
+    echo "Ancestry repair artifact does not require the hosted-gates publication flow."
+    exit 1
+  fi
+  if [ "${PREP_SYNC_MODE:-}" != "ancestry_repair" ]; then
+    echo "Ancestry repair requires an ancestry_repair sync artifact."
+    exit 1
+  fi
+
+  local repo_nwo
+  local live_head_repo
+  repo_nwo=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
+  live_head_repo=$(gh pr view "$pr" --json headRepository --jq .headRepository.nameWithOwner)
+  if [ "$PR_HEAD_REPO" != "$repo_nwo" ] || [ "$live_head_repo" != "$repo_nwo" ]; then
+    echo "Ancestry repair is restricted to same-repository maintainer branches."
+    exit 1
+  fi
+  verify_pr_head_branch_matches_expected "$pr" "$PR_HEAD"
+
+  local local_head_sha
+  local_head_sha=$(git rev-parse HEAD)
+  if [ "$local_head_sha" != "${PREP_SYNC_LOCAL_HEAD_SHA:-}" ]; then
+    echo "Ancestry repair refused: local prep head differs from the verified sync artifact."
+    exit 1
+  fi
+  local local_tree
+  local_tree=$(git rev-parse "${local_head_sha}^{tree}")
+  if [ "$local_tree" != "${PREP_SYNC_TREE:-}" ]; then
+    echo "Ancestry repair refused: local prep tree differs from the verified sync artifact."
+    exit 1
+  fi
+  if ! git merge-base --is-ancestor "$PREP_SYNC_MAINLINE_BASE_SHA" "$local_head_sha" 2>/dev/null; then
+    echo "Ancestry repair refused: verified mainline base is not an ancestor of the local prep head."
+    exit 1
+  fi
+  local current_merge_base
+  current_merge_base=$(git merge-base "$local_head_sha" origin/main)
+  if [ "$current_merge_base" != "$PREP_SYNC_MAINLINE_BASE_SHA" ]; then
+    echo "Ancestry repair refused: local prep head no longer has the verified mainline merge-base."
+    exit 1
+  fi
+
+  local live_lease_sha
+  live_lease_sha=$(gh pr view "$pr" --json headRefOid --jq .headRefOid)
+  local recovering_published_head=false
+  if [ "$live_lease_sha" != "$PREP_SYNC_REMOTE_LEASE_SHA" ]; then
+    if [ "$live_lease_sha" = "$local_head_sha" ]; then
+      recovering_published_head=true
+    else
+      echo "Ancestry repair refused: PR head changed after the sync artifact was written."
+      exit 1
+    fi
+  fi
+  setup_prhead_remote
+  local remote_lease_sha
+  remote_lease_sha=$(resolve_prhead_remote_sha "$PR_HEAD")
+  if [ "$recovering_published_head" = "true" ] && [ "$remote_lease_sha" != "$local_head_sha" ]; then
+    echo "Ancestry repair recovery refused: PR metadata and remote branch disagree."
+    exit 1
+  fi
+  if [ "$recovering_published_head" = "false" ] && [ "$remote_lease_sha" != "$PREP_SYNC_REMOTE_LEASE_SHA" ]; then
+    echo "Ancestry repair refused: remote branch changed after the sync artifact was written."
+    exit 1
+  fi
+
+  # Stale gate/prepare artifacts must never survive a topology-only publish.
+  rm -f .local/gates.env .local/prep.env .local/prepare-push-result.env
+  local published_head_sha
+  if [ "$recovering_published_head" = "true" ]; then
+    published_head_sha="$local_head_sha"
+  else
+    published_head_sha=$(repair_synced_ancestry_ref \
+      "$PR_HEAD" \
+      "$PREP_SYNC_REMOTE_LEASE_SHA" \
+      "$local_head_sha" \
+      "$PREP_SYNC_MAINLINE_BASE_SHA" \
+      "$PREP_SYNC_TREE")
+  fi
+
+  if ! wait_for_pr_head_sha "$pr" "$published_head_sha" 8 3; then
+    echo "Ancestry repair published the ref, but the PR head did not converge to $published_head_sha."
+    exit 1
+  fi
+  git fetch origin "pull/$pr/head:pr-$pr-ancestry-repair-verify" --force
+  local verified_sha
+  verified_sha=$(git rev-parse "pr-$pr-ancestry-repair-verify")
+  local verified_tree
+  verified_tree=$(git rev-parse "${verified_sha}^{tree}")
+  local verified_merge_base
+  verified_merge_base=$(git merge-base "$verified_sha" origin/main)
+  git branch -D "pr-$pr-ancestry-repair-verify" >/dev/null 2>&1 || true
+  if [ "$verified_sha" != "$local_head_sha" ] || [ "$verified_tree" != "$PREP_SYNC_TREE" ]; then
+    echo "Ancestry repair verification failed: PR ref SHA or tree differs from the verified local sync."
+    exit 1
+  fi
+  if [ "$verified_merge_base" != "$PREP_SYNC_MAINLINE_BASE_SHA" ]; then
+    echo "Ancestry repair verification failed: PR ref merge-base differs from the verified mainline base."
+    exit 1
+  fi
+  if ! git diff --quiet "$PREP_SYNC_REMOTE_LEASE_SHA" "$verified_sha"; then
+    echo "Ancestry repair verification failed: PR ref publication changed file content."
+    exit 1
+  fi
+
+  write_prep_sync_artifact \
+    "$pr" \
+    "$PR_HEAD" \
+    "$PREP_SYNC_REMOTE_LEASE_SHA" \
+    "$local_head_sha" \
+    "$PREP_SYNC_MAINLINE_BASE_SHA" \
+    "$published_head_sha"
+  cat >> .local/prep.md <<EOF_PREP
+- Published the verified synced commit topology to branch $PR_HEAD without changing its tree.
+- Cleared stale prepare/gate artifacts; exact hosted gates are required for $published_head_sha.
+EOF_PREP
+
+  echo "prepare-push ancestry repair complete"
+  echo "published_head_sha=$published_head_sha"
+  echo "Run OPENCLAW_TESTBOX=1 scripts/pr prepare-gates $pr, then scripts/pr prepare-push $pr."
 }
 
 prepare_sync_head() {
@@ -231,6 +530,7 @@ prepare_sync_head() {
   source .local/pr-meta.env
   # shellcheck disable=SC1091
   source .local/prep-context.env
+  guard_active_prep_sync || exit 1
 
   local rebased=false
   git fetch origin main
@@ -255,12 +555,66 @@ prepare_sync_head() {
   local push_result_env=".local/prepare-sync-result.env"
 
   verify_pr_head_branch_matches_expected "$pr" "$PR_HEAD"
+  git fetch origin "pull/$pr/head:pr-$pr-sync-lease" --force
+  local fetched_lease_sha
+  fetched_lease_sha=$(git rev-parse "pr-$pr-sync-lease")
+  git branch -D "pr-$pr-sync-lease" >/dev/null 2>&1 || true
+  if [ "$fetched_lease_sha" != "$lease_sha" ]; then
+    echo "PR head changed while preparing the sync artifact. Re-run prepare-sync-head."
+    exit 1
+  fi
+
+  local mainline_base_sha
+  mainline_base_sha=$(git merge-base "$prep_head_sha" origin/main) || {
+    echo "Unable to resolve the prepared mainline base."
+    exit 1
+  }
+  local topology_requires_rewrite=false
+  if ! git merge-base --is-ancestor "$lease_sha" "$prep_head_sha" 2>/dev/null; then
+    topology_requires_rewrite=true
+  fi
+  local lease_tree
+  local prep_tree
+  lease_tree=$(git rev-parse "${lease_sha}^{tree}")
+  prep_tree=$(git rev-parse "${prep_head_sha}^{tree}")
+  if [ "$topology_requires_rewrite" = "true" ] && [ "$lease_tree" = "$prep_tree" ]; then
+    local repo_nwo
+    local live_head_repo
+    repo_nwo=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
+    live_head_repo=$(gh pr view "$pr" --json headRepository --jq .headRepository.nameWithOwner)
+    if [ "${PR_HEAD_REPO:-}" != "$repo_nwo" ] || [ "$live_head_repo" != "$repo_nwo" ]; then
+      echo "Equal-tree ancestry repair is restricted to same-repository maintainer branches."
+      return 1
+    fi
+    rm -f .local/gates.env .local/prep.env
+    write_prep_sync_artifact \
+      "$pr" \
+      "$PR_HEAD" \
+      "$lease_sha" \
+      "$prep_head_sha" \
+      "$mainline_base_sha" \
+      ""
+    echo "wrote=.local/prep-sync.env"
+    echo "Equal-tree topology repair requires prepare-push --repair-ancestry; normal sync will not publish it."
+    return 1
+  fi
+
+  if [ "${OPENCLAW_TESTBOX:-}" = "1" ] && [ "$prep_head_sha" != "$lease_sha" ]; then
+    echo "Testbox changed-head publication is restricted to the equal-tree ancestry-repair mode."
+    echo "Use the normal prepare flow for content-changing publication."
+    return 1
+  fi
+
+  if [ "${OPENCLAW_PR_PUSH_MODE:-graphql}" != "git" ] && ! require_graphql_push_preserves_ancestry "$lease_sha" "$prep_head_sha"; then
+    echo "Retry prepare-sync-head with the explicit git/unsigned overrides for this content-changing head."
+    return 1
+  fi
+
   push_prep_head_to_pr_branch "$pr" "$PR_HEAD" "$prep_head_sha" "$lease_sha" false false "$push_result_env"
   # shellcheck disable=SC1090
   source "$push_result_env"
   prep_head_sha="$PUSH_PREP_HEAD_SHA"
   local_prep_head_sha="$PUSH_LOCAL_PREP_HEAD_SHA"
-  local mainline_base_sha
   mainline_base_sha=$(git merge-base "$local_prep_head_sha" origin/main) || {
     echo "Unable to resolve the prepared mainline base."
     exit 1
@@ -284,24 +638,6 @@ prepare_sync_head() {
 - Rebased onto origin/main: $rebased.
 - Verified the remote PR head tree matches the local prep head.
 EOF_PREP
-
-  if [ "$rebased" = "true" ] && [ "${OPENCLAW_TESTBOX:-}" = "1" ]; then
-    local prep_sync_tree
-    prep_sync_tree=$(git rev-parse "${local_prep_head_sha}^{tree}")
-    # Preserve the verified local lineage because GraphQL creates a remote
-    # commit with the same tree but the old branch parent.
-    printf '%s=%q\n' \
-      PREP_SYNC_MAINLINE_BASE_SHA "$mainline_base_sha" \
-      PREP_SYNC_TREE "$prep_sync_tree" \
-      > .local/prep-sync.env
-    cat >> .local/prep.md <<EOF_PREP
-- Cleared stale prepare artifacts. Wait for hosted CI/Testbox on $prep_head_sha, then run prepare-run again.
-EOF_PREP
-    echo "prepare-sync-head complete"
-    echo "prep_head_sha=$prep_head_sha"
-    echo "Hosted CI/Testbox must pass for this exact head before prepare-run can continue."
-    return
-  fi
 
   cat >> .local/prep.md <<EOF_PREP
 - Prepare gates reran automatically when the sync rebase changed the prep head.
@@ -332,6 +668,30 @@ EOF_PREP
 
 prepare_run() {
   local pr="$1"
+
+  enter_worktree "$pr" false
+
+  if [ -e .local/prep-sync.env ] || [ -L .local/prep-sync.env ]; then
+    require_artifact .local/prep-sync.env
+    # shellcheck disable=SC1091
+    source .local/prep-sync.env
+    if [ "${PREP_SYNC_MODE:-}" = "ancestry_repair" ] && [ -n "${PREP_SYNC_PUBLISHED_HEAD_SHA:-}" ]; then
+      if [ "${OPENCLAW_TESTBOX:-}" != "1" ]; then
+        echo "Published synced head $PREP_SYNC_PUBLISHED_HEAD_SHA requires OPENCLAW_TESTBOX=1 scripts/pr prepare-run $pr."
+        return 1
+      fi
+      prepare_gates "$pr"
+      prepare_push "$pr"
+      echo "prepare-run complete for PR #$pr"
+      echo "pr_url=${PR_URL:-}"
+      return
+    fi
+    if [ "${PREP_SYNC_MODE:-}" = "ancestry_repair" ]; then
+      echo "Unpublished ancestry repair requires scripts/pr prepare-push --repair-ancestry $pr."
+      return 1
+    fi
+  fi
+
   prepare_init "$pr"
   prepare_gates "$pr"
   prepare_push "$pr"

--- a/scripts/pr-lib/push.sh
+++ b/scripts/pr-lib/push.sh
@@ -21,15 +21,52 @@ resolve_head_push_url() {
 # Push to a fork PR branch via GitHub GraphQL createCommitOnBranch.
 # This uses the same permission model as the GitHub web editor, bypassing
 # the git-protocol 403 that occurs even when maintainer_can_modify is true.
-# Usage: graphql_push_to_fork <owner/repo> <branch> <expected_head_oid>
+# Usage: graphql_push_to_fork <owner/repo> <branch> <expected_head_oid> [mainline_ref]
 # Pushes the diff between expected_head_oid and local HEAD as file additions/deletions.
 # File bytes are read from git objects (not the working tree) to avoid
 # symlink/special-file dereference risks from untrusted fork content.
+require_graphql_push_preserves_ancestry() {
+  local expected_oid="$1"
+  local prepared_oid="$2"
+  local mainline_ref="${3:-origin/main}"
+
+  if ! git cat-file -e "${expected_oid}^{commit}" 2>/dev/null; then
+    echo "GraphQL push refused before mutation: remote lease $expected_oid is not available locally." >&2
+    echo "Refresh the PR head and retry so commit ancestry can be verified." >&2
+    return 1
+  fi
+  if ! git merge-base --is-ancestor "$expected_oid" "$prepared_oid" 2>/dev/null; then
+    echo "GraphQL push refused before mutation: prepared head $prepared_oid is not a descendant of remote lease $expected_oid." >&2
+    echo "createCommitOnBranch always parents the new commit to the remote branch head, so this push would discard the prepared topology." >&2
+    return 1
+  fi
+  local expected_mainline_base
+  local prepared_mainline_base
+  expected_mainline_base=$(git merge-base "$expected_oid" "$mainline_ref") || {
+    echo "GraphQL push refused before mutation: unable to resolve the remote lease mainline base." >&2
+    return 1
+  }
+  prepared_mainline_base=$(git merge-base "$prepared_oid" "$mainline_ref") || {
+    echo "GraphQL push refused before mutation: unable to resolve the prepared mainline base." >&2
+    return 1
+  }
+  if [ "$expected_mainline_base" != "$prepared_mainline_base" ]; then
+    echo "GraphQL push refused before mutation: publication would discard the prepared mainline merge-base." >&2
+    echo "createCommitOnBranch gives the published commit only the remote branch head as its parent." >&2
+    return 1
+  fi
+}
+
 graphql_push_to_fork() {
   local repo_nwo="$1"
   local branch="$2"
   local expected_oid="$3"
+  local mainline_ref="${4:-origin/main}"
   local max_blob_bytes=$((5 * 1024 * 1024))
+
+  # GitHub creates the commit on the remote branch head, not with the local
+  # commit's parents. Only a descendant local head can preserve that lineage.
+  require_graphql_push_preserves_ancestry "$expected_oid" HEAD "$mainline_ref" || return 1
 
   local additions="[]"
   local deletions="[]"
@@ -239,6 +276,113 @@ push_prep_head_once() {
   printf '%s\n' "$prep_head_sha"
 }
 
+repair_synced_ancestry_ref() {
+  local pr_head="$1"
+  local lease_sha="$2"
+  local prepared_head_sha="$3"
+  local synced_base_sha="$4"
+  local synced_tree="$5"
+  local verify_ref="refs/remotes/prhead/ancestry-repair"
+
+  local remote_sha
+  remote_sha=$(resolve_prhead_remote_sha "$pr_head")
+  if [ "$remote_sha" != "$lease_sha" ]; then
+    echo "Ancestry repair refused: remote lease changed (expected $lease_sha, got $remote_sha)." >&2
+    return 1
+  fi
+
+  if ! git fetch --no-tags prhead "+refs/heads/$pr_head:$verify_ref" >/dev/null 2>&1; then
+    echo "Ancestry repair refused: unable to fetch the remote lease for verification." >&2
+    return 1
+  fi
+  local fetched_sha
+  fetched_sha=$(git rev-parse "$verify_ref")
+  if [ "$fetched_sha" != "$lease_sha" ]; then
+    echo "Ancestry repair refused: fetched branch head differs from the verified lease." >&2
+    return 1
+  fi
+  if [ "$lease_sha" = "$prepared_head_sha" ] || git merge-base --is-ancestor "$lease_sha" "$prepared_head_sha" 2>/dev/null; then
+    echo "Ancestry repair refused: normal publication already preserves this topology." >&2
+    return 1
+  fi
+
+  local prepared_tree
+  local lease_tree
+  prepared_tree=$(git rev-parse "${prepared_head_sha}^{tree}")
+  lease_tree=$(git rev-parse "${lease_sha}^{tree}")
+  if [ "$prepared_tree" != "$synced_tree" ]; then
+    echo "Ancestry repair refused: local prepared tree no longer matches the verified sync artifact." >&2
+    return 1
+  fi
+  if [ "$lease_tree" != "$synced_tree" ]; then
+    echo "Ancestry repair refused: remote lease tree differs from the local prepared tree." >&2
+    return 1
+  fi
+  if ! git merge-base --is-ancestor "$synced_base_sha" "$prepared_head_sha" 2>/dev/null; then
+    echo "Ancestry repair refused: synced base is not an ancestor of the prepared head." >&2
+    return 1
+  fi
+  if ! git diff --quiet "$lease_sha" "$prepared_head_sha"; then
+    echo "Ancestry repair refused: lease and prepared commits contain different file changes." >&2
+    return 1
+  fi
+
+  # This mode is topology-only. The dry run proves git-protocol permission,
+  # and the second lease read closes the race before the only mutating command.
+  if ! git push --dry-run \
+    --force-with-lease="refs/heads/$pr_head:$lease_sha" \
+    prhead "$prepared_head_sha:refs/heads/$pr_head" >&2
+  then
+    echo "Ancestry repair refused: force-with-lease permission dry run failed." >&2
+    return 1
+  fi
+  remote_sha=$(resolve_prhead_remote_sha "$pr_head")
+  if [ "$remote_sha" != "$lease_sha" ]; then
+    echo "Ancestry repair refused: remote lease changed after the permission dry run." >&2
+    return 1
+  fi
+  if ! git push \
+    --force-with-lease="refs/heads/$pr_head:$lease_sha" \
+    prhead "$prepared_head_sha:refs/heads/$pr_head" >&2
+  then
+    echo "Ancestry repair publication failed." >&2
+    return 1
+  fi
+
+  remote_sha=$(resolve_prhead_remote_sha "$pr_head")
+  if [ "$remote_sha" != "$prepared_head_sha" ]; then
+    echo "Ancestry repair verification failed: expected remote $prepared_head_sha, got $remote_sha." >&2
+    return 1
+  fi
+  if ! git fetch --no-tags prhead "+refs/heads/$pr_head:$verify_ref" >/dev/null 2>&1; then
+    echo "Ancestry repair verification failed: unable to fetch the published ref." >&2
+    return 1
+  fi
+  fetched_sha=$(git rev-parse "$verify_ref")
+  local published_tree
+  published_tree=$(git rev-parse "${fetched_sha}^{tree}")
+  if [ "$fetched_sha" != "$prepared_head_sha" ] || [ "$published_tree" != "$synced_tree" ]; then
+    echo "Ancestry repair verification failed: published SHA or tree differs from the verified sync." >&2
+    return 1
+  fi
+  if ! git merge-base --is-ancestor "$synced_base_sha" "$fetched_sha" 2>/dev/null; then
+    echo "Ancestry repair verification failed: published head lost the synced base ancestry." >&2
+    return 1
+  fi
+  local published_merge_base
+  published_merge_base=$(git merge-base "$synced_base_sha" "$fetched_sha")
+  if [ "$published_merge_base" != "$synced_base_sha" ]; then
+    echo "Ancestry repair verification failed: published merge-base differs from the synced base." >&2
+    return 1
+  fi
+  if ! git diff --quiet "$lease_sha" "$fetched_sha"; then
+    echo "Ancestry repair verification failed: publication changed file content." >&2
+    return 1
+  fi
+
+  printf '%s\n' "$fetched_sha"
+}
+
 push_prep_head_to_pr_branch() {
   local pr="$1"
   local pr_head="$2"
@@ -259,8 +403,8 @@ push_prep_head_to_pr_branch() {
     echo "Remote branch already at local prep HEAD; skipping push."
   else
     if [ "$remote_sha" != "$lease_sha" ]; then
-      echo "Remote SHA $remote_sha differs from PR head SHA $lease_sha. Refreshing lease SHA from remote."
-      lease_sha="$remote_sha"
+      echo "Remote SHA $remote_sha differs from PR head lease $lease_sha. Re-run prepare from the refreshed head."
+      exit 1
     fi
     pushed_from_sha="$lease_sha"
     local push_output
@@ -268,6 +412,10 @@ push_prep_head_to_pr_branch() {
       echo "Push failed: $push_output"
 
       if printf '%s' "$push_output" | grep -qiE '(permission|denied|403|forbidden)'; then
+        if [ "${OPENCLAW_PR_PUSH_MODE:-graphql}" = "git" ]; then
+          echo "Explicit git push permission failed; refusing GraphQL fallback."
+          exit 1
+        fi
         echo "Permission denied on git push; trying GraphQL createCommitOnBranch fallback..."
         if [ -n "${PR_HEAD_OWNER:-}" ] && [ -n "${PR_HEAD_REPO_NAME:-}" ]; then
           local graphql_oid
@@ -296,6 +444,10 @@ push_prep_head_to_pr_branch() {
 
         if ! push_output=$(push_prep_head_once "$pr_head" "$lease_sha" "$prep_head_sha" 2>&1); then
           echo "Retry push failed: $push_output"
+          if [ "${OPENCLAW_PR_PUSH_MODE:-graphql}" = "git" ]; then
+            echo "Explicit git retry failed; refusing GraphQL fallback."
+            exit 1
+          fi
           if [ -n "${PR_HEAD_OWNER:-}" ] && [ -n "${PR_HEAD_REPO_NAME:-}" ]; then
             echo "Retry failed; trying GraphQL createCommitOnBranch fallback..."
             local graphql_oid

--- a/test/scripts/pr-push-topology.test.ts
+++ b/test/scripts/pr-push-topology.test.ts
@@ -1,0 +1,499 @@
+// PR push topology tests exercise real temporary Git repositories and refs.
+import { execFileSync, spawnSync } from "node:child_process";
+import { chmodSync, existsSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { createScriptTestHarness } from "./test-helpers.js";
+
+const repoRoot = process.cwd();
+const pushScript = path.join(repoRoot, "scripts", "pr-lib", "push.sh");
+const commonScript = path.join(repoRoot, "scripts", "pr-lib", "common.sh");
+const prepareScript = path.join(repoRoot, "scripts", "pr-lib", "prepare-core.sh");
+const { createTempDir } = createScriptTestHarness();
+const realGit = execFileSync("which", ["git"], { encoding: "utf8" }).trim();
+const gitEnv = {
+  ...process.env,
+  GIT_AUTHOR_DATE: "2026-01-01T00:00:00Z",
+  GIT_COMMITTER_DATE: "2026-01-01T00:00:00Z",
+};
+
+interface TopologyFixture {
+  base: string;
+  broken: string;
+  lease: string;
+  mainline: string;
+  prepared: string;
+  preparedTree: string;
+  remote: string;
+  repo: string;
+}
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync("git", args, { cwd, encoding: "utf8", env: gitEnv }).trim();
+}
+
+function runBash(cwd: string, script: string, env: Record<string, string> = {}) {
+  const result = spawnSync("bash", ["-c", script], {
+    cwd,
+    encoding: "utf8",
+    env: {
+      ...gitEnv,
+      ...env,
+      COMMON_SCRIPT: commonScript,
+      PREPARE_SCRIPT: prepareScript,
+      PUSH_SCRIPT: pushScript,
+    },
+  });
+  return {
+    output: `${result.stdout}${result.stderr}`,
+    status: result.status,
+  };
+}
+
+function commitTree(repo: string, tree: string, parent: string, message: string): string {
+  return git(repo, "commit-tree", tree, "-p", parent, "-m", message);
+}
+
+function createTopologyFixture(): TopologyFixture {
+  const root = createTempDir("openclaw-pr-topology-");
+  const repo = path.join(root, "repo");
+  const remote = path.join(root, "remote.git");
+  mkdirSync(repo);
+  git(repo, "init", "-q", "--initial-branch=main");
+  git(repo, "config", "user.email", "maintainer@example.com");
+  git(repo, "config", "user.name", "Maintainer");
+
+  writeFileSync(path.join(repo, "base.txt"), "base\n");
+  git(repo, "add", "base.txt");
+  git(repo, "commit", "-qm", "base");
+  const base = git(repo, "rev-parse", "HEAD");
+
+  git(repo, "checkout", "-qb", "topic");
+  writeFileSync(path.join(repo, "feature.txt"), "feature\n");
+  git(repo, "add", "feature.txt");
+  git(repo, "commit", "-qm", "feature");
+  const lease = git(repo, "rev-parse", "HEAD");
+
+  git(repo, "checkout", "-qB", "main", base);
+  git(repo, "commit", "--allow-empty", "-qm", "mainline");
+  const mainline = git(repo, "rev-parse", "HEAD");
+  const preparedTree = git(repo, "rev-parse", `${lease}^{tree}`);
+  const prepared = commitTree(repo, preparedTree, mainline, "prepared");
+  const broken = commitTree(repo, preparedTree, lease, "graphql publication");
+
+  mkdirSync(remote);
+  git(remote, "init", "--bare", "-q");
+  git(repo, "remote", "add", "origin", remote);
+  git(repo, "remote", "add", "prhead", remote);
+  git(repo, "push", "-q", "origin", `${mainline}:refs/heads/main`);
+  git(repo, "push", "-q", "prhead", `${broken}:refs/heads/topic`);
+  git(repo, "checkout", "-q", "--detach", prepared);
+
+  return { base, broken, lease, mainline, prepared, preparedTree, remote, repo };
+}
+
+function runRepair(fixture: TopologyFixture, lease = fixture.broken, tree = fixture.preparedTree) {
+  return runBash(
+    fixture.repo,
+    `gh() { printf called > "$GRAPHQL_MARKER"; return 99; }
+    source "$PUSH_SCRIPT"
+    repair_synced_ancestry_ref topic "$LEASE" "$PREPARED" "$BASE" "$TREE"`,
+    {
+      BASE: fixture.mainline,
+      GRAPHQL_MARKER: path.join(fixture.repo, "graphql-called"),
+      LEASE: lease,
+      PREPARED: fixture.prepared,
+      TREE: tree,
+    },
+  );
+}
+
+describe("PR push topology", () => {
+  it("allows descendant GraphQL publication", () => {
+    const fixture = createTopologyFixture();
+    const descendant = commitTree(fixture.repo, fixture.preparedTree, fixture.broken, "descendant");
+    git(fixture.repo, "checkout", "-q", "--detach", descendant);
+    const marker = path.join(fixture.repo, "graphql-called");
+
+    const result = runBash(
+      fixture.repo,
+      `gh() {
+        printf called > "$MARKER"
+        printf '{"data":{"createCommitOnBranch":{"commit":{"oid":"%s"}}}}\\n' "$PREPARED"
+      }
+      source "$PUSH_SCRIPT"
+      graphql_push_to_fork owner/repo topic "$LEASE"`,
+      { LEASE: fixture.broken, MARKER: marker, PREPARED: descendant },
+    );
+
+    expect(result.status).toBe(0);
+    expect(existsSync(marker)).toBe(true);
+  });
+
+  it("refuses non-descendant GraphQL publication before mutation", () => {
+    const fixture = createTopologyFixture();
+    const marker = path.join(fixture.repo, "graphql-called");
+
+    const result = runBash(
+      fixture.repo,
+      `gh() { printf called > "$MARKER"; }
+      source "$PUSH_SCRIPT"
+      graphql_push_to_fork owner/repo topic "$LEASE"`,
+      { LEASE: fixture.broken, MARKER: marker },
+    );
+
+    expect(result.status).not.toBe(0);
+    expect(result.output).toContain("GraphQL push refused before mutation");
+    expect(existsSync(marker)).toBe(false);
+    expect(git(fixture.remote, "rev-parse", "refs/heads/topic")).toBe(fixture.broken);
+  });
+
+  it("refuses GraphQL publication that would drop a prepared mainline merge parent", () => {
+    const fixture = createTopologyFixture();
+    const merged = git(
+      fixture.repo,
+      "commit-tree",
+      fixture.preparedTree,
+      "-p",
+      fixture.broken,
+      "-p",
+      fixture.mainline,
+      "-m",
+      "merged",
+    );
+    git(fixture.repo, "checkout", "-q", "--detach", merged);
+    const marker = path.join(fixture.repo, "graphql-called");
+
+    const result = runBash(
+      fixture.repo,
+      `gh() { printf called > "$MARKER"; }
+      source "$PUSH_SCRIPT"
+      graphql_push_to_fork owner/repo topic "$LEASE"`,
+      { LEASE: fixture.broken, MARKER: marker },
+    );
+
+    expect(result.status).not.toBe(0);
+    expect(result.output).toContain("discard the prepared mainline merge-base");
+    expect(existsSync(marker)).toBe(false);
+    expect(git(fixture.remote, "rev-parse", "refs/heads/topic")).toBe(fixture.broken);
+  });
+
+  it("keeps explicit git-mode rebased publication available", () => {
+    const fixture = createTopologyFixture();
+
+    const result = runBash(
+      fixture.repo,
+      'source "$PUSH_SCRIPT"; push_prep_head_once topic "$LEASE" "$PREPARED"',
+      {
+        LEASE: fixture.broken,
+        OPENCLAW_ALLOW_UNSIGNED_GIT_PUSH: "1",
+        OPENCLAW_PR_PUSH_MODE: "git",
+        PREPARED: fixture.prepared,
+      },
+    );
+
+    expect(result.status).toBe(0);
+    expect(git(fixture.remote, "rev-parse", "refs/heads/topic")).toBe(fixture.prepared);
+  });
+
+  it("repairs only same-tree ancestry with a force-with-lease ref move", () => {
+    const fixture = createTopologyFixture();
+
+    const result = runRepair(fixture);
+
+    expect(result.status).toBe(0);
+    expect(result.output).toContain(fixture.prepared);
+    expect(git(fixture.remote, "rev-parse", "refs/heads/topic")).toBe(fixture.prepared);
+    expect(git(fixture.remote, "rev-parse", "refs/heads/topic^{tree}")).toBe(fixture.preparedTree);
+    expect(git(fixture.repo, "merge-base", fixture.mainline, fixture.prepared)).toBe(
+      fixture.mainline,
+    );
+    expect(existsSync(path.join(fixture.repo, "graphql-called"))).toBe(false);
+  });
+
+  it("refuses ancestry repair after a lease mismatch", () => {
+    const fixture = createTopologyFixture();
+    const moved = commitTree(fixture.repo, fixture.preparedTree, fixture.broken, "remote moved");
+    git(fixture.repo, "push", "-q", "--force", "prhead", `${moved}:refs/heads/topic`);
+
+    const result = runRepair(fixture);
+
+    expect(result.status).not.toBe(0);
+    expect(result.output).toContain("remote lease changed");
+    expect(git(fixture.remote, "rev-parse", "refs/heads/topic")).toBe(moved);
+  });
+
+  it("refuses ancestry repair when the remote tree differs", () => {
+    const fixture = createTopologyFixture();
+    const differentTree = git(fixture.repo, "rev-parse", `${fixture.mainline}^{tree}`);
+    const different = commitTree(fixture.repo, differentTree, fixture.broken, "different tree");
+    git(fixture.repo, "push", "-q", "--force", "prhead", `${different}:refs/heads/topic`);
+
+    const result = runRepair(fixture, different);
+
+    expect(result.status).not.toBe(0);
+    expect(result.output).toContain("remote lease tree differs");
+    expect(git(fixture.remote, "rev-parse", "refs/heads/topic")).toBe(different);
+  });
+
+  it("does not publish when the force-with-lease dry run fails", () => {
+    const fixture = createTopologyFixture();
+    const binDir = path.join(fixture.repo, "fake-bin");
+    const actualPushMarker = path.join(fixture.repo, "actual-push");
+    mkdirSync(binDir);
+    const fakeGit = path.join(binDir, "git");
+    writeFileSync(
+      fakeGit,
+      `#!/bin/sh
+if [ "$1" = "push" ]; then
+  case " $* " in
+    *" --dry-run "*) exit 77 ;;
+    *) printf called > "$ACTUAL_PUSH_MARKER" ;;
+  esac
+fi
+exec "$REAL_GIT" "$@"
+`,
+    );
+    chmodSync(fakeGit, 0o755);
+
+    const result = runBash(
+      fixture.repo,
+      'source "$PUSH_SCRIPT"; repair_synced_ancestry_ref topic "$LEASE" "$PREPARED" "$BASE" "$TREE"',
+      {
+        ACTUAL_PUSH_MARKER: actualPushMarker,
+        BASE: fixture.mainline,
+        LEASE: fixture.broken,
+        PATH: `${binDir}:${process.env.PATH}`,
+        PREPARED: fixture.prepared,
+        REAL_GIT: realGit,
+        TREE: fixture.preparedTree,
+      },
+    );
+
+    expect(result.status).not.toBe(0);
+    expect(result.output).toContain("permission dry run failed");
+    expect(existsSync(actualPushMarker)).toBe(false);
+    expect(git(fixture.remote, "rev-parse", "refs/heads/topic")).toBe(fixture.broken);
+  });
+
+  it("requires exact published-head hosted gates after ancestry repair", () => {
+    const fixture = createTopologyFixture();
+    expect(runRepair(fixture).status).toBe(0);
+    const localDir = path.join(fixture.repo, ".local");
+    mkdirSync(localDir);
+    writeFileSync(
+      path.join(localDir, "prep-sync.env"),
+      "PREP_SYNC_MODE=ancestry_repair\nPREP_SYNC_PUBLISHED_HEAD_SHA=\nPREP_SYNC_REQUIRES_HOSTED_GATES=1\n",
+    );
+    const activeSyncReentry = runBash(
+      fixture.repo,
+      'source "$COMMON_SCRIPT"; source "$PREPARE_SCRIPT"; guard_active_prep_sync',
+    );
+    expect(activeSyncReentry.status).not.toBe(0);
+    expect(activeSyncReentry.output).toContain("active sync artifact");
+
+    writeFileSync(
+      path.join(localDir, "prep-sync.env"),
+      [
+        `PREP_SYNC_PUBLISHED_HEAD_SHA=${fixture.prepared}`,
+        "PREP_SYNC_REQUIRES_HOSTED_GATES=1",
+        "PREP_SYNC_MODE=ancestry_repair",
+      ].join("\n"),
+    );
+
+    const gateCheck =
+      'source "$COMMON_SCRIPT"; source "$PREPARE_SCRIPT"; require_exact_prepare_gates "$PREPARED"';
+    const missing = runBash(fixture.repo, gateCheck, { PREPARED: fixture.prepared });
+    expect(missing.status).not.toBe(0);
+    expect(missing.output).toContain("Missing required artifact: .local/gates.env");
+
+    const syncReentry = runBash(
+      fixture.repo,
+      'source "$COMMON_SCRIPT"; source "$PREPARE_SCRIPT"; guard_active_prep_sync',
+    );
+    expect(syncReentry.status).not.toBe(0);
+    expect(syncReentry.output).toContain("OPENCLAW_TESTBOX=1 scripts/pr prepare-run");
+
+    writeFileSync(
+      path.join(localDir, "gates.env"),
+      [
+        "GATES_MODE=hosted_exact_head",
+        `LAST_VERIFIED_HEAD_SHA=${fixture.prepared}`,
+        `HOSTED_GATES_HEAD_SHA=${fixture.prepared}`,
+      ].join("\n"),
+    );
+    const exact = runBash(fixture.repo, gateCheck, { PREPARED: fixture.prepared });
+    expect(exact.status).toBe(0);
+  });
+
+  it("resumes a published sync through exact hosted gates without prepare-init", () => {
+    const fixture = createTopologyFixture();
+    const localDir = path.join(fixture.repo, ".local");
+    mkdirSync(localDir);
+    writeFileSync(
+      path.join(localDir, "prep-sync.env"),
+      [
+        `PREP_SYNC_PUBLISHED_HEAD_SHA=${fixture.prepared}`,
+        "PREP_SYNC_REQUIRES_HOSTED_GATES=1",
+        "PREP_SYNC_MODE=ancestry_repair",
+      ].join("\n"),
+    );
+
+    const callerDir = path.join(fixture.repo, "caller");
+    mkdirSync(callerDir);
+    const result = runBash(
+      callerDir,
+      `source "$COMMON_SCRIPT"
+      source "$PREPARE_SCRIPT"
+      enter_worktree() { cd "$TARGET"; }
+      prepare_init() { printf init; return 99; }
+      prepare_gates() { printf gates; }
+      prepare_push() { printf push; }
+      prepare_run 1`,
+      { OPENCLAW_TESTBOX: "1", TARGET: fixture.repo },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.output).toContain("gatespush");
+    expect(result.output).not.toContain("init");
+  });
+
+  it("detects case-folded tracked artifact aliases", () => {
+    const fixture = createTopologyFixture();
+    const artifact = path.join(fixture.repo, ".LOCAL", "PREP-SYNC.ENV");
+    mkdirSync(path.dirname(artifact));
+    writeFileSync(artifact, "tracked\n");
+    git(fixture.repo, "add", "-f", ".LOCAL/PREP-SYNC.ENV");
+
+    const result = runBash(
+      fixture.repo,
+      'source "$COMMON_SCRIPT"; artifact_path_is_tracked .local/prep-sync.env',
+    );
+
+    expect(result.status).toBe(0);
+  });
+
+  it("fails closed on legacy sync artifacts", () => {
+    const fixture = createTopologyFixture();
+    const localDir = path.join(fixture.repo, ".local");
+    mkdirSync(localDir);
+    writeFileSync(
+      path.join(localDir, "prep-sync.env"),
+      `PREP_SYNC_MAINLINE_BASE_SHA=${fixture.mainline}\nPREP_SYNC_TREE=${fixture.preparedTree}\n`,
+    );
+
+    const result = runBash(
+      fixture.repo,
+      'source "$COMMON_SCRIPT"; source "$PREPARE_SCRIPT"; guard_active_prep_sync',
+    );
+
+    expect(result.status).not.toBe(0);
+    expect(result.output).toContain("unsupported mode");
+  });
+
+  it("rejects tracked sync artifacts without executing them", () => {
+    const fixture = createTopologyFixture();
+    const localDir = path.join(fixture.repo, ".local");
+    const marker = path.join(fixture.repo, "artifact-executed");
+    mkdirSync(localDir);
+    writeFileSync(
+      path.join(localDir, "prep-sync.env"),
+      `touch "$MARKER"\nPREP_SYNC_REQUIRES_HOSTED_GATES=1\n`,
+    );
+    git(fixture.repo, "add", "-f", ".local/prep-sync.env");
+
+    const result = runBash(
+      fixture.repo,
+      'source "$COMMON_SCRIPT"; source "$PREPARE_SCRIPT"; guard_active_prep_sync',
+      { MARKER: marker },
+    );
+
+    expect(result.status).not.toBe(0);
+    expect(result.output).toContain("Refusing untrusted local artifact");
+    expect(existsSync(marker)).toBe(false);
+  });
+
+  it("refuses to write a sync artifact through a broken symlink", () => {
+    const fixture = createTopologyFixture();
+    const localDir = path.join(fixture.repo, ".local");
+    const target = path.join(fixture.repo, "outside-artifact");
+    mkdirSync(localDir);
+    symlinkSync(target, path.join(localDir, "prep-sync.env"));
+
+    const result = runBash(
+      fixture.repo,
+      'source "$COMMON_SCRIPT"; source "$PREPARE_SCRIPT"; write_prep_sync_artifact 1 topic "$LEASE" "$PREPARED" "$BASE"',
+      {
+        BASE: fixture.mainline,
+        LEASE: fixture.broken,
+        PREPARED: fixture.prepared,
+      },
+    );
+
+    expect(result.status).not.toBe(0);
+    expect(result.output).toContain("Refusing untrusted local artifact destination");
+    expect(existsSync(target)).toBe(false);
+  });
+
+  it("refuses to replace a sync artifact directory", () => {
+    const fixture = createTopologyFixture();
+    mkdirSync(path.join(fixture.repo, ".local", "prep-sync.env"), { recursive: true });
+
+    const result = runBash(
+      fixture.repo,
+      'source "$COMMON_SCRIPT"; source "$PREPARE_SCRIPT"; write_prep_sync_artifact 1 topic "$LEASE" "$PREPARED" "$BASE"',
+      {
+        BASE: fixture.mainline,
+        LEASE: fixture.broken,
+        PREPARED: fixture.prepared,
+      },
+    );
+
+    expect(result.status).not.toBe(0);
+    expect(result.output).toContain("Refusing untrusted local artifact destination");
+  });
+
+  it("refuses a symlinked local artifact directory", () => {
+    const fixture = createTopologyFixture();
+    const outside = path.join(fixture.repo, "outside-local");
+    mkdirSync(outside);
+    symlinkSync(outside, path.join(fixture.repo, ".local"));
+
+    const result = runBash(
+      fixture.repo,
+      'source "$COMMON_SCRIPT"; source "$PREPARE_SCRIPT"; write_prep_sync_artifact 1 topic "$LEASE" "$PREPARED" "$BASE"',
+      {
+        BASE: fixture.mainline,
+        LEASE: fixture.broken,
+        PREPARED: fixture.prepared,
+      },
+    );
+
+    expect(result.status).not.toBe(0);
+    expect(result.output).toContain("Refusing untrusted local artifact directory");
+    expect(existsSync(path.join(outside, "prep-sync.env"))).toBe(false);
+  });
+
+  it("refuses a tracked but missing sync artifact destination", () => {
+    const fixture = createTopologyFixture();
+    const artifact = path.join(fixture.repo, ".local", "prep-sync.env");
+    mkdirSync(path.dirname(artifact));
+    writeFileSync(artifact, "tracked\n");
+    git(fixture.repo, "add", "-f", ".local/prep-sync.env");
+    rmSync(artifact);
+
+    const result = runBash(
+      fixture.repo,
+      'source "$COMMON_SCRIPT"; source "$PREPARE_SCRIPT"; write_prep_sync_artifact 1 topic "$LEASE" "$PREPARED" "$BASE"',
+      {
+        BASE: fixture.mainline,
+        LEASE: fixture.broken,
+        PREPARED: fixture.prepared,
+      },
+    );
+
+    expect(result.status).not.toBe(0);
+    expect(result.output).toContain("Refusing tracked local artifact destination");
+    expect(existsSync(artifact)).toBe(false);
+  });
+});

--- a/test/scripts/pr-wrappers.test.ts
+++ b/test/scripts/pr-wrappers.test.ts
@@ -16,10 +16,12 @@ describe("scripts/pr wrappers", () => {
     expect(script).toContain("OPENCLAW_GH_BIN=");
     expect(script).toContain("gh_plain");
     expect(script).toContain("scripts/pr review-init <PR>");
+    expect(script).toContain("scripts/pr prepare-push [--repair-ancestry] <PR>");
     expect(script).toContain("scripts/pr prepare-run <PR>");
     expect(script).toContain("scripts/pr merge-run <PR>");
     expect(script).toContain('review_init "$pr"');
     expect(script).toContain('prepare_run "$pr"');
+    expect(script).toContain('prepare_push_ancestry_repair "$pr"');
     expect(script).toContain('merge_run "$pr"');
   });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where maintainers syncing a rebased PR preparation head could publish the intended tree on the old branch ancestry, leaving the prepared topology and merge-gate evidence inconsistent.

## Why This Change Was Made

The default GitHub GraphQL publication path now refuses before mutation unless the prepared head preserves both the remote lease ancestry and mainline merge base. A new explicit `prepare-push --repair-ancestry` mode may move only a same-repository branch ref when the verified local and remote trees are identical; it requires the recorded sync artifact, an unchanged lease, explicit git/unsigned overrides, a successful force-with-lease dry run, and post-publication SHA/tree/base/content verification. It never falls back to GraphQL.

The repair clears stale preparation evidence and cannot finalize until normal hosted gates pass for the exact published SHA. Other Testbox changed-head publication remains refused and the normal content-changing path proves or reruns local gates before publication.

## User Impact

Maintainers can repair same-tree ancestry after a rebase without fabricating gate artifacts or weakening `prepare-run` or `merge-run`. Unsafe or ambiguous publication states fail closed before the branch is mutated.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/pr-push-topology.test.ts test/scripts/pr-wrappers.test.ts` — 22 tests passed.
- `bash -n` and ShellCheck on the touched shell wrappers passed.
- Oxfmt, oxlint, and `git diff --check` passed.
- Blacksmith Testbox changed-file gate passed: `tbx_01kwfrjn5xkx6q8vbxf6yxvdj3` ([Actions run](https://github.com/openclaw/openclaw/actions/runs/28548267451)).
- Fresh `gpt-5.6-sol` xhigh autoreview reported no actionable findings on the rebased current-main diff.
