### PR TITLE
Allow alternate Zalo Bot API roots

### DIFF
--- a/extensions/zalo/src/api.test.ts
+++ b/extensions/zalo/src/api.test.ts
@@ -12,6 +12,7 @@ vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
 }));
 
 import {
+  callZaloApi,
   deleteWebhook,
   getMe,
   getWebhookInfo,
@@ -68,6 +69,7 @@ async function expectPostJsonRequest(run: (token: string, fetcher: ZaloFetch) =>
 
 describe("Zalo API request methods", () => {
   beforeEach(() => {
+    vi.unstubAllEnvs();
     resolvePinnedHostnameWithPolicyMock.mockReset();
     resolvePinnedHostnameWithPolicyMock.mockResolvedValue({
       hostname: "example.com",
@@ -97,6 +99,75 @@ describe("Zalo API request methods", () => {
       },
     });
   });
+
+  it("uses the production API root by default", async () => {
+    const fetcher = createOkFetcher();
+
+    await callZaloApi("getMe", "test-token", undefined, { fetch: fetcher });
+
+    expect(fetcher).toHaveBeenCalledWith(
+      "https://bot-api.zaloplatforms.com/bottest-token/getMe",
+      expect.any(Object),
+    );
+  });
+
+  it("uses ZALO_API_URL for provider-compatible alternate endpoints", async () => {
+    vi.stubEnv("ZALO_API_URL", " http://127.0.0.1:49152/zalo/ ");
+    const fetcher = createOkFetcher();
+
+    await callZaloApi("getMe", "test-token", undefined, { fetch: fetcher });
+
+    expect(fetcher).toHaveBeenCalledWith(
+      "http://127.0.0.1:49152/zalo/bottest-token/getMe",
+      expect.any(Object),
+    );
+  });
+
+  it("prefers an explicit API URL over ZALO_API_URL", async () => {
+    vi.stubEnv("ZALO_API_URL", "http://127.0.0.1:49152/env");
+    const fetcher = createOkFetcher();
+
+    await callZaloApi("getMe", "test-token", undefined, {
+      apiUrl: "http://127.0.0.1:49153/explicit/",
+      fetch: fetcher,
+    });
+
+    expect(fetcher).toHaveBeenCalledWith(
+      "http://127.0.0.1:49153/explicit/bottest-token/getMe",
+      expect.any(Object),
+    );
+  });
+
+  it("rejects an explicitly empty API URL instead of falling back to ZALO_API_URL", async () => {
+    vi.stubEnv("ZALO_API_URL", "http://127.0.0.1:49152/env");
+
+    await expect(
+      callZaloApi("getMe", "test-token", undefined, {
+        apiUrl: "   ",
+        fetch: createOkFetcher(),
+      }),
+    ).rejects.toThrow("ZALO_API_URL must not be empty.");
+  });
+
+  it("rejects invalid alternate API URLs", async () => {
+    vi.stubEnv("ZALO_API_URL", "file:///tmp/zalo");
+
+    await expect(
+      callZaloApi("getMe", "test-token", undefined, { fetch: createOkFetcher() }),
+    ).rejects.toThrow("ZALO_API_URL must use http:// or https://.");
+  });
+
+  it.each(["https://proxy.example/zalo?tenant=1", "https://proxy.example/zalo#provider"])(
+    "rejects an API root with URL suffix components: %s",
+    async (apiUrl) => {
+      await expect(
+        callZaloApi("getMe", "test-token", undefined, {
+          apiUrl,
+          fetch: createOkFetcher(),
+        }),
+      ).rejects.toThrow("ZALO_API_URL must not include a query string or fragment.");
+    },
+  );
 
   it("uses POST for getWebhookInfo", async () => {
     await expectPostJsonRequest(getWebhookInfo);

--- a/extensions/zalo/src/api.ts
+++ b/extensions/zalo/src/api.ts
@@ -8,6 +8,7 @@ import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import { resolvePinnedHostnameWithPolicy, type SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
 
 const ZALO_API_BASE = "https://bot-api.zaloplatforms.com";
+const ZALO_API_URL_ENV = "ZALO_API_URL";
 const ZALO_MEDIA_SSRF_POLICY: SsrFPolicy = {};
 
 export type ZaloFetch = (input: string, init?: RequestInit) => Promise<Response>;
@@ -104,6 +105,27 @@ export class ZaloApiError extends Error {
   }
 }
 
+function resolveZaloApiUrl(apiUrl?: string): string {
+  const value =
+    apiUrl === undefined ? (process.env[ZALO_API_URL_ENV]?.trim() ?? ZALO_API_BASE) : apiUrl.trim();
+  if (!value) {
+    throw new Error(`${ZALO_API_URL_ENV} must not be empty.`);
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new Error(`${ZALO_API_URL_ENV} must be a valid URL.`);
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error(`${ZALO_API_URL_ENV} must use http:// or https://.`);
+  }
+  if (parsed.search || parsed.hash) {
+    throw new Error(`${ZALO_API_URL_ENV} must not include a query string or fragment.`);
+  }
+  return parsed.href.replace(/\/+$/u, "");
+}
+
 /**
  * Call the Zalo Bot API
  */
@@ -111,9 +133,9 @@ export async function callZaloApi<T = unknown>(
   method: string,
   token: string,
   body?: Record<string, unknown>,
-  options?: { timeoutMs?: number; fetch?: ZaloFetch },
+  options?: { apiUrl?: string; timeoutMs?: number; fetch?: ZaloFetch },
 ): Promise<ZaloApiResponse<T>> {
-  const url = `${ZALO_API_BASE}/bot${token}/${method}`;
+  const url = `${resolveZaloApiUrl(options?.apiUrl)}/bot${token}/${method}`;
   const controller = new AbortController();
   const requestTimeoutMs =
     options?.timeoutMs === undefined ? undefined : resolveTimerTimeoutMs(options.timeoutMs, 1);

--- a/extensions/zalo/src/monitor.image.polling.test.ts
+++ b/extensions/zalo/src/monitor.image.polling.test.ts
@@ -68,6 +68,9 @@ describe("Zalo polling image handling", () => {
       finalizeInboundContextMock,
       recordInboundSessionMock,
     });
+    expect(finalizeInboundContextMock).toHaveBeenCalledWith(
+      expect.objectContaining({ Timestamp: 1774084566880 }),
+    );
 
     abort.abort();
     await run;

--- a/extensions/zalo/src/monitor.ts
+++ b/extensions/zalo/src/monitor.ts
@@ -64,6 +64,7 @@ const ZALO_TEXT_LIMIT = 2000;
 const DEFAULT_MEDIA_MAX_MB = 5;
 const WEBHOOK_CLEANUP_TIMEOUT_MS = 5_000;
 const ZALO_TYPING_TIMEOUT_MS = 5_000;
+const UNIX_MILLISECONDS_THRESHOLD = 1_000_000_000_000;
 
 type ZaloCoreRuntime = ReturnType<typeof getZaloRuntime>;
 type ZaloStatusSink = (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
@@ -92,6 +93,13 @@ type ZaloUpdateProcessingParams = ZaloProcessingContext & {
 
 let zaloWebhookModulePromise: Promise<ZaloWebhookModule> | undefined;
 const hostedMediaRouteRefs = new Map<string, { count: number; unregisters: Array<() => void> }>();
+
+function resolveZaloTimestampMs(date: number | undefined): number | undefined {
+  if (!date) {
+    return undefined;
+  }
+  return date >= UNIX_MILLISECONDS_THRESHOLD ? date : date * 1000;
+}
 
 function loadZaloWebhookModule(): Promise<ZaloWebhookModule> {
   zaloWebhookModulePromise ??= import("./monitor.webhook.js");
@@ -564,10 +572,11 @@ async function processMessageWithPipeline(params: ZaloMessagePipelineParams): Pr
   }
 
   const fromLabel = isGroup ? `group:${chatId}` : senderName || `user:${senderId}`;
+  const timestamp = resolveZaloTimestampMs(date);
   const { storePath, body } = buildEnvelope({
     channel: "Zalo",
     from: fromLabel,
-    timestamp: date ? date * 1000 : undefined,
+    timestamp,
     body: rawBody,
   });
 
@@ -575,7 +584,7 @@ async function processMessageWithPipeline(params: ZaloMessagePipelineParams): Pr
     channel: "zalo",
     accountId: route.accountId,
     messageId: message_id,
-    timestamp: date ? date * 1000 : undefined,
+    timestamp,
     from: isGroup ? `zalo:group:${chatId}` : `zalo:${senderId}`,
     sender: {
       id: senderId,

--- a/src/infra/dotenv.test.ts
+++ b/src/infra/dotenv.test.ts
@@ -287,6 +287,7 @@ describe("loadDotEnv", () => {
             "EXAMPLE_API_HOST=https://evil-api.example.com",
             "MINIMAX_API_HOST=https://evil.example.com",
             "SLACK_API_URL=http://evil-slack.example.com/api/",
+            "ZALO_API_URL=http://evil-zalo.example.com/",
             "HTTP_PROXY=http://evil-proxy:8080",
             "HOMEBREW_BREW_FILE=./evil-brew/bin/brew",
             "HOMEBREW_PREFIX=./evil-brew",
@@ -311,6 +312,7 @@ describe("loadDotEnv", () => {
         delete process.env.EXAMPLE_API_HOST;
         delete process.env.MINIMAX_API_HOST;
         delete process.env.SLACK_API_URL;
+        delete process.env.ZALO_API_URL;
         delete process.env.HTTP_PROXY;
         delete process.env.HOMEBREW_BREW_FILE;
         delete process.env.HOMEBREW_PREFIX;
@@ -335,6 +337,7 @@ describe("loadDotEnv", () => {
         expect(process.env.EXAMPLE_API_HOST).toBeUndefined();
         expect(process.env.MINIMAX_API_HOST).toBeUndefined();
         expect(process.env.SLACK_API_URL).toBeUndefined();
+        expect(process.env.ZALO_API_URL).toBeUndefined();
         expect(process.env.HTTP_PROXY).toBeUndefined();
         expect(process.env.HOMEBREW_BREW_FILE).toBeUndefined();
         expect(process.env.HOMEBREW_PREFIX).toBeUndefined();
@@ -561,6 +564,7 @@ describe("loadDotEnv", () => {
             "OPENCLAW_PINNED_PYTHON=/trusted/python",
             "OPENCLAW_PINNED_WRITE_PYTHON=/trusted/write-python",
             "SLACK_API_URL=http://trusted-slack.example.com/api/",
+            "ZALO_API_URL=http://trusted-zalo.example.com/",
           ].join("\n"),
         );
         vi.spyOn(process, "cwd").mockReturnValue(cwdDir);
@@ -569,6 +573,7 @@ describe("loadDotEnv", () => {
         delete process.env.OPENCLAW_PINNED_PYTHON;
         delete process.env.OPENCLAW_PINNED_WRITE_PYTHON;
         delete process.env.SLACK_API_URL;
+        delete process.env.ZALO_API_URL;
 
         loadDotEnv({ quiet: true });
 
@@ -577,6 +582,7 @@ describe("loadDotEnv", () => {
         expect(process.env.OPENCLAW_PINNED_PYTHON).toBe("/trusted/python");
         expect(process.env.OPENCLAW_PINNED_WRITE_PYTHON).toBe("/trusted/write-python");
         expect(process.env.SLACK_API_URL).toBe("http://trusted-slack.example.com/api/");
+        expect(process.env.ZALO_API_URL).toBe("http://trusted-zalo.example.com/");
       });
     });
   });

--- a/src/infra/dotenv.ts
+++ b/src/infra/dotenv.ts
@@ -168,6 +168,7 @@ const BLOCKED_WORKSPACE_DOTENV_KEYS = new Set([
   "SYNOLOGY_CHAT_INCOMING_URL",
   "SYNOLOGY_NAS_HOST",
   "UV_PYTHON",
+  "ZALO_API_URL",
 ]);
 
 // Block endpoint redirection for any service without overfitting per-provider names.


### PR DESCRIPTION
## Summary

- allow trusted process/CI configuration to point the Zalo Bot client at an alternate HTTP(S) API root
- preserve explicit client-option precedence and the production Zalo endpoint by default
- block `ZALO_API_URL` from workspace dotenv propagation
- preserve provider timestamps that already arrive in milliseconds while continuing to normalize epoch seconds

## Stack

- stacked on #99274, which independently corrects the native Zalo `getMe` identity contract
- this PR no longer changes `ZaloBotInfo` or gateway identity labeling

## Tests

- `node scripts/run-vitest.mjs extensions/zalo/src/api.test.ts extensions/zalo/src/monitor.image.polling.test.ts src/infra/dotenv.test.ts`
- `pnpm format:check extensions/zalo/src/api.ts extensions/zalo/src/api.test.ts extensions/zalo/src/monitor.ts extensions/zalo/src/monitor.image.polling.test.ts src/infra/dotenv.ts src/infra/dotenv.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base 91342b007d --stream-engine-output` (clean, no actionable findings)
