### PR TITLE
fix: Telegram replies duplicate recent context after sent replies

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -1621,6 +1621,38 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expectDraftStreamParams({ maxChars: 800 });
   });
 
+  it("marks durable non-preview finals with the transcript prompt-context timestamp", async () => {
+    const transcriptTimestamp = Date.now() + 1_000;
+    const context = createContext();
+    context.ctxPayload.SessionKey = "agent:default:telegram:direct:123";
+    mockDefaultSessionEntry();
+    readLatestAssistantTextByIdentity.mockResolvedValue({
+      text: "Final answer",
+      timestamp: transcriptTimestamp,
+    });
+    deliverInboundReplyWithMessageSendContext.mockResolvedValue({
+      status: "handled_visible",
+      delivery: {
+        messageIds: ["2001"],
+        visibleReplySent: true,
+      },
+    });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({ text: "Final answer" }, { kind: "final" });
+      return { queuedFinal: true };
+    });
+
+    await dispatchWithContext({ context, streamMode: "off" });
+
+    const outbound = expectRecordFields(mockCallArg(deliverInboundReplyWithMessageSendContext), {
+      payload: expect.objectContaining({ text: "Final answer" }),
+    });
+    expectRecordFields(expectRecordFields(outbound.payload, {}).channelData, {
+      telegram: { promptContextTimestampMs: transcriptTimestamp },
+    });
+    expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
   it("keeps the Telegram edit cap for non-block previews regardless of chunk config", async () => {
     const draftStream = createDraftStream();
     createTelegramDraftStream.mockReturnValue(draftStream);
@@ -1644,12 +1676,20 @@ describe("dispatchTelegramMessage draft streaming", () => {
 
   it("streams text-only finals into the answer message", async () => {
     const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    const transcriptTimestamp = Date.now() + 1_000;
+    const context = createContext();
+    context.ctxPayload.SessionKey = "agent:default:telegram:direct:123";
+    mockDefaultSessionEntry();
+    readLatestAssistantTextByIdentity.mockResolvedValue({
+      text: "Final answer",
+      timestamp: transcriptTimestamp,
+    });
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
       await dispatcherOptions.deliver({ text: "Final answer" }, { kind: "final" });
       return { queuedFinal: true };
     });
 
-    await dispatchWithContext({ context: createContext() });
+    await dispatchWithContext({ context });
 
     expect(answerDraftStream.update).toHaveBeenCalledWith("Final answer");
     expect(answerDraftStream.stop).toHaveBeenCalled();
@@ -1664,11 +1704,20 @@ describe("dispatchTelegramMessage draft streaming", () => {
       messageId: 2001,
       text: "Final answer",
       messageThreadId: 777,
+      promptContextTimestampMs: transcriptTimestamp,
     });
   });
 
   it("records streamed final replies into the prompt context cache", async () => {
     const storePath = `/tmp/openclaw-telegram-stream-context-${process.pid}-${Date.now()}.json`;
+    const transcriptTimestamp = Date.now() + 1_000;
+    const context = createContext();
+    context.ctxPayload.SessionKey = "agent:default:telegram:direct:123";
+    mockDefaultSessionEntry();
+    readLatestAssistantTextByIdentity.mockResolvedValue({
+      text: "Done already: timeoutSeconds is now 7200s.",
+      timestamp: transcriptTimestamp,
+    });
     setupDraftStreams({ answerMessageId: 1497 });
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
       await dispatcherOptions.deliver(
@@ -1679,7 +1728,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     });
 
     await dispatchWithContext({
-      context: createContext(),
+      context,
       cfg: { session: { store: storePath } },
       telegramDeps: {
         ...telegramDepsForTest,
@@ -1704,7 +1753,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
       },
     });
 
-    const context = await buildTelegramConversationContext({
+    const conversationContext = await buildTelegramConversationContext({
       cache,
       accountId: "default",
       chatId: "123",
@@ -1715,10 +1764,13 @@ describe("dispatchTelegramMessage draft streaming", () => {
       replyTargetWindowSize: 2,
     });
 
-    expect(context.map((entry) => entry.node.messageId)).toContain("1497");
-    expect(context.map((entry) => entry.node.body)).toContain(
+    expect(conversationContext.map((entry) => entry.node.messageId)).toContain("1497");
+    expect(conversationContext.map((entry) => entry.node.body)).toContain(
       "Done already: timeoutSeconds is now 7200s.",
     );
+    expect(
+      conversationContext.find((entry) => entry.node.messageId === "1497")?.node.timestamp,
+    ).toBe(transcriptTimestamp);
   });
 
   it("suppresses text-only tool payloads delivered after the final answer", async () => {

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -117,7 +117,10 @@ import {
   type LaneName,
 } from "./lane-delivery.js";
 import { TELEGRAM_TEXT_CHUNK_LIMIT } from "./outbound-adapter.js";
-import { recordOutboundMessageForPromptContext } from "./outbound-message-context.js";
+import {
+  recordOutboundMessageForPromptContext,
+  withTelegramPromptContextTimestampMs,
+} from "./outbound-message-context.js";
 import {
   createTelegramReasoningStepState,
   splitTelegramReasoningText,
@@ -244,6 +247,7 @@ export type TelegramDispatchResult =
 type TelegramReasoningLevel = "off" | "on" | "stream";
 
 type TelegramTranscriptMirrorPayload = { text?: string; mediaUrls?: string[] };
+type CurrentTurnTranscriptFinal = { text: string; timestamp: number };
 type TelegramScopedTranscriptSession = { sessionId: string; storePath: string };
 type FreshTelegramSessionEntryLoader = ((
   agentId: string,
@@ -1459,9 +1463,15 @@ export const dispatchTelegramMessage = async ({
   const sessionKey = ctxPayload.SessionKey;
   let transcriptMirrorSequence = 0;
   const transcriptMirrorTurnId = `${chatId}:${ctxPayload.MessageSid ?? msg.message_id ?? dispatchStartedAt}`;
-  const resolveCurrentTurnTranscriptFinalText = async (): Promise<string | undefined> => {
+  let currentTurnTranscriptFinal: CurrentTurnTranscriptFinal | undefined;
+  const resolveCurrentTurnTranscriptFinal = async (): Promise<
+    CurrentTurnTranscriptFinal | undefined
+  > => {
     if (!sessionKey) {
       return undefined;
+    }
+    if (currentTurnTranscriptFinal) {
+      return currentTurnTranscriptFinal;
     }
     try {
       const { entry: sessionEntry, storePath } = loadFreshSessionEntry(route.agentId, sessionKey);
@@ -1477,11 +1487,24 @@ export const dispatchTelegramMessage = async ({
       if (!latest?.timestamp || latest.timestamp < dispatchStartedAt) {
         return undefined;
       }
-      return latest.text;
+      currentTurnTranscriptFinal = {
+        text: latest.text,
+        timestamp: latest.timestamp,
+      };
+      return currentTurnTranscriptFinal;
     } catch (err) {
       logVerbose(`telegram transcript final candidate lookup failed: ${formatErrorMessage(err)}`);
       return undefined;
     }
+  };
+  const resolveCurrentTurnTranscriptFinalText = async (): Promise<string | undefined> =>
+    (await resolveCurrentTurnTranscriptFinal())?.text;
+  const resolvePromptContextTimestampMs = async (text: string): Promise<number | undefined> => {
+    const final = await resolveCurrentTurnTranscriptFinal();
+    if (final?.text.trim() !== text.trim()) {
+      return undefined;
+    }
+    return final.timestamp;
   };
   const deliveryBaseOptions = {
     chatId: String(chatId),
@@ -1631,6 +1654,14 @@ export const dispatchTelegramMessage = async ({
         return false;
       }
       const deliverablePayload = applyQuoteReplyTarget(payload);
+      const promptContextTimestampMs =
+        options?.durable && deliverablePayload.text
+          ? await resolvePromptContextTimestampMs(deliverablePayload.text)
+          : undefined;
+      const effectivePayload = withTelegramPromptContextTimestampMs(
+        deliverablePayload,
+        promptContextTimestampMs,
+      );
       const silent = options?.silent ?? (silentErrorReplies && payload.isError === true);
       const durableDelivery = telegramDeps.deliverInboundReplyWithMessageSendContext;
       if (options?.durable && durableDelivery) {
@@ -1641,7 +1672,7 @@ export const dispatchTelegramMessage = async ({
           accountId: route.accountId,
           agentId: route.agentId,
           ctxPayload,
-          payload: deliverablePayload,
+          payload: effectivePayload,
           info: { kind: "final" },
           replyToMode,
           threadId: threadSpec.id,
@@ -1652,13 +1683,13 @@ export const dispatchTelegramMessage = async ({
           },
           silent,
           requiredCapabilities: deriveDurableFinalDeliveryRequirements({
-            payload: deliverablePayload,
-            replyToId: deliverablePayload.replyToId,
+            payload: effectivePayload,
+            replyToId: effectivePayload.replyToId,
             threadId: threadSpec.id,
             silent,
             payloadTransport: true,
             extraCapabilities: {
-              nativeQuote: usesNativeTelegramQuote(deliverablePayload),
+              nativeQuote: usesNativeTelegramQuote(effectivePayload),
             },
           }),
         });
@@ -1676,7 +1707,7 @@ export const dispatchTelegramMessage = async ({
       const result = await (telegramDeps.deliverReplies ?? deliverReplies)({
         ...deliveryBaseOptions,
         transcriptMirror: options?.durable ? deliveryBaseOptions.transcriptMirror : undefined,
-        replies: [deliverablePayload],
+        replies: [effectivePayload],
         onVoiceRecording: sendRecordVoice,
         silent,
         mediaLoader: telegramDeps.loadWebMedia,
@@ -1701,6 +1732,10 @@ export const dispatchTelegramMessage = async ({
         groupId: deliveryBaseOptions.mirrorGroupId,
       });
       try {
+        const promptContextContent =
+          result.delivery.promptContextContent ?? result.delivery.content;
+        const promptContextTimestampMs =
+          await resolvePromptContextTimestampMs(promptContextContent);
         await (
           telegramDeps.recordOutboundMessageForPromptContext ??
           recordOutboundMessageForPromptContext
@@ -1710,7 +1745,8 @@ export const dispatchTelegramMessage = async ({
           chatId: deliveryBaseOptions.chatId,
           message: { message_id: result.delivery.messageId },
           messageId: result.delivery.messageId,
-          text: result.delivery.promptContextContent ?? result.delivery.content,
+          text: promptContextContent,
+          ...(promptContextTimestampMs !== undefined ? { promptContextTimestampMs } : {}),
           ...(threadSpec.id !== undefined ? { messageThreadId: threadSpec.id } : {}),
         });
       } catch (error) {
@@ -1868,11 +1904,13 @@ export const dispatchTelegramMessage = async ({
       markProgressFinalDelivered();
       return { kind: "sent" };
     };
-    const resolveTranscriptBackedFinalText = async (text: string): Promise<string> =>
-      await resolveTranscriptBackedChannelFinalText({
+    const resolveTranscriptBackedFinalText = async (text: string): Promise<string> => {
+      const candidate = await resolveCurrentTurnTranscriptFinal();
+      return await resolveTranscriptBackedChannelFinalText({
         finalText: text,
-        resolveCandidateText: resolveCurrentTurnTranscriptFinalText,
+        resolveCandidateText: async () => candidate?.text,
       });
+    };
 
     if (isDmTopic) {
       try {

--- a/extensions/telegram/src/message-cache.ts
+++ b/extensions/telegram/src/message-cache.ts
@@ -66,6 +66,9 @@ export type TelegramMessageCache = {
 };
 
 type MessageWithExternalReply = Message & { external_reply?: Message };
+type MessageWithPromptContextTimestamp = Message & {
+  openclaw_prompt_context_timestamp_ms?: unknown;
+};
 
 type TelegramMessageCacheBucket = {
   messages: Map<string, TelegramCachedMessageNode>;
@@ -159,6 +162,15 @@ function resolveMediaType(placeholder?: string): string | undefined {
   return placeholder?.match(/^<media:([^>]+)>$/)?.[1];
 }
 
+function resolveMessageTimestamp(msg: Message): number | undefined {
+  const promptContextTimestamp = (msg as MessageWithPromptContextTimestamp)
+    .openclaw_prompt_context_timestamp_ms;
+  if (typeof promptContextTimestamp === "number" && Number.isFinite(promptContextTimestamp)) {
+    return promptContextTimestamp;
+  }
+  return msg.date ? msg.date * 1000 : undefined;
+}
+
 function normalizeMessageNode(
   msg: Message,
   params: { threadId?: number },
@@ -172,13 +184,14 @@ function normalizeMessageNode(
   const replyMessage = resolveReplyMessage(msg);
   const body = resolveMessageBody(msg);
   const threadId = normalizeTelegramCacheThreadId(params.threadId);
+  const timestamp = resolveMessageTimestamp(msg);
   return {
     sourceMessage: msg,
     messageId: String(msg.message_id),
     sender: buildSenderName(msg) ?? "unknown sender",
     ...(msg.from?.id != null ? { senderId: String(msg.from.id) } : {}),
     ...(msg.from?.username ? { senderUsername: msg.from.username } : {}),
-    ...(msg.date ? { timestamp: msg.date * 1000 } : {}),
+    ...(timestamp !== undefined ? { timestamp } : {}),
     ...(body ? { body } : {}),
     ...(media ? { mediaType: resolveMediaType(media.placeholder) ?? media.placeholder } : {}),
     ...(fileId ? { mediaRef: `telegram:file/${fileId}` } : {}),

--- a/extensions/telegram/src/outbound-adapter.test.ts
+++ b/extensions/telegram/src/outbound-adapter.test.ts
@@ -158,6 +158,29 @@ describe("telegramOutbound", () => {
     expect(result).toEqual({ channel: "telegram", messageId: "tg-buttons", chatId: "12345" });
   });
 
+  it("forwards prompt-context timestamps on durable payload sends", async () => {
+    sendMessageTelegramMock.mockResolvedValueOnce({ messageId: "tg-final", chatId: "12345" });
+
+    const result = await telegramOutbound.sendPayload!({
+      cfg: {} as never,
+      to: "12345",
+      text: "",
+      payload: {
+        text: "Final answer",
+        channelData: {
+          telegram: {
+            promptContextTimestampMs: 1_779_394_740_123,
+          },
+        },
+      },
+      deps: { sendTelegram: sendMessageTelegramMock },
+    });
+
+    const options = callOptionsAt(sendMessageTelegramMock, 0, "12345", "Final answer");
+    expect(options.promptContextTimestampMs).toBe(1_779_394_740_123);
+    expect(result).toEqual({ channel: "telegram", messageId: "tg-final", chatId: "12345" });
+  });
+
   it("applies reaction-only payloads without sending empty Telegram text", async () => {
     reactMessageTelegramMock.mockResolvedValueOnce({ ok: true });
 

--- a/extensions/telegram/src/outbound-adapter.ts
+++ b/extensions/telegram/src/outbound-adapter.ts
@@ -26,6 +26,7 @@ import type { TelegramInlineButtons } from "./button-types.js";
 import { resolveTelegramInlineButtons } from "./button-types.js";
 import { splitTelegramHtmlChunks } from "./format.js";
 import { resolveTelegramInteractiveTextFallback } from "./interactive-fallback.js";
+import { resolveTelegramPromptContextTimestampMs } from "./outbound-message-context.js";
 import { parseTelegramReplyToMessageId, parseTelegramThreadId } from "./outbound-params.js";
 import { loadTelegramSendModule, type TelegramSendModule } from "./send-runtime.js";
 import { normalizeTelegramOutboundTarget, parseTelegramTarget } from "./targets.js";
@@ -156,6 +157,7 @@ export async function sendTelegramPayloadMessages(params: {
   const payloadOpts = {
     ...params.baseOpts,
     quoteText,
+    promptContextTimestampMs: resolveTelegramPromptContextTimestampMs(params.payload),
     ...(params.payload.audioAsVoice === true ? { asVoice: true } : {}),
   };
   const shouldConsumeImplicitReplyTarget =

--- a/extensions/telegram/src/outbound-message-context.ts
+++ b/extensions/telegram/src/outbound-message-context.ts
@@ -1,15 +1,21 @@
 // Telegram plugin module implements outbound message context behavior.
 import type { Message } from "grammy/types";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import type { ReplyPayload } from "openclaw/plugin-sdk/reply-payload";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
 import { createTelegramMessageCache, resolveTelegramMessageCacheScope } from "./message-cache.js";
+
+type TelegramPromptContextChannelData = {
+  promptContextTimestampMs?: unknown;
+};
 
 export type TelegramOutboundPromptContextMessage = {
   message_id?: number;
   chat?: { id?: string | number; type?: string; title?: string; username?: string };
   date?: number;
   from?: { id?: number; is_bot?: boolean; first_name?: string; username?: string };
+  openclaw_prompt_context_timestamp_ms?: number;
   text?: string;
   caption?: string;
   message_thread_id?: number;
@@ -19,6 +25,38 @@ type TelegramOutboundPromptContextAccount = {
   accountId: string;
   name?: string;
 };
+
+export function resolveTelegramPromptContextTimestampMs(
+  payload: Pick<ReplyPayload, "channelData">,
+): number | undefined {
+  const telegramData = payload.channelData?.telegram as
+    | TelegramPromptContextChannelData
+    | undefined;
+  const timestamp = telegramData?.promptContextTimestampMs;
+  return typeof timestamp === "number" && Number.isFinite(timestamp) ? timestamp : undefined;
+}
+
+export function withTelegramPromptContextTimestampMs(
+  payload: ReplyPayload,
+  timestampMs: number | undefined,
+): ReplyPayload {
+  if (timestampMs === undefined) {
+    return payload;
+  }
+  const telegramData = payload.channelData?.telegram as
+    | TelegramPromptContextChannelData
+    | undefined;
+  return {
+    ...payload,
+    channelData: {
+      ...payload.channelData,
+      telegram: {
+        ...telegramData,
+        promptContextTimestampMs: timestampMs,
+      },
+    },
+  };
+}
 
 function inferTelegramChatType(chatId: string | number): "private" | "supergroup" {
   return String(chatId).startsWith("-") ? "supergroup" : "private";
@@ -31,12 +69,16 @@ function buildOutboundCacheMessage(params: {
   messageId: number;
   text?: string;
   messageThreadId?: number;
+  promptContextTimestampMs?: number;
 }): TelegramOutboundPromptContextMessage {
   const chat = params.message.chat ?? {};
   const text = params.message.text ?? params.message.caption ?? params.text;
   return {
     ...params.message,
     message_id: params.messageId,
+    ...(params.promptContextTimestampMs !== undefined
+      ? { openclaw_prompt_context_timestamp_ms: params.promptContextTimestampMs }
+      : {}),
     date:
       typeof params.message.date === "number" && Number.isFinite(params.message.date)
         ? params.message.date
@@ -65,6 +107,7 @@ export async function recordOutboundMessageForPromptContext(params: {
   messageId: number;
   text?: string;
   messageThreadId?: number;
+  promptContextTimestampMs?: number;
 }): Promise<void> {
   try {
     const cache = createTelegramMessageCache({

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -900,6 +900,36 @@ describe("sendMessageTelegram", () => {
     );
   });
 
+  it("records prompt-context text messages with a transcript timestamp override", async () => {
+    const storePath = `/tmp/openclaw-telegram-send-context-override-${process.pid}-${Date.now()}.json`;
+    const cfg = { session: { store: storePath } };
+    const transcriptTimestamp = 1_779_394_740_123;
+    botApi.sendMessage.mockResolvedValueOnce({
+      message_id: 1497,
+      date: 1_779_394_745,
+      chat: { id: "123", type: "private" },
+      from: { id: 42, is_bot: true, first_name: "Kelaw" },
+      text: "Final answer",
+    });
+
+    await sendMessageTelegram("123", "Final answer", {
+      cfg,
+      token: "tok",
+      promptContextTimestampMs: transcriptTimestamp,
+    });
+
+    const cache = createTelegramMessageCache({
+      scope: resolveTelegramMessageCacheScope(storePath),
+    });
+    const node = await cache.get({
+      accountId: "default",
+      chatId: "123",
+      messageId: "1497",
+    });
+
+    expect(node?.timestamp).toBe(transcriptTimestamp);
+  });
+
   it("normalizes raw code language HTML before sending", async () => {
     const chatId = "123";
     const text = [

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -125,6 +125,8 @@ type TelegramSendOpts = {
   asVideoNote?: boolean;
   /** Send message silently (no notification). Defaults to false. */
   silent?: boolean;
+  /** Override the prompt-context cache timestamp for transcript-aligned sends. */
+  promptContextTimestampMs?: number;
   /** Message ID to reply to (for threading) */
   replyToMessageId?: number;
   /** Whether replyToMessageId came from ambient context or explicit payload/action input. */
@@ -957,6 +959,7 @@ export async function sendMessageTelegram(
         message: res,
         messageId,
         text: chunk.plainText,
+        promptContextTimestampMs: opts.promptContextTimestampMs,
         ...(acceptedParams?.message_thread_id !== undefined
           ? { messageThreadId: acceptedParams.message_thread_id }
           : {}),
@@ -1133,6 +1136,7 @@ export async function sendMessageTelegram(
             message: plainResult.result,
             messageId: fallbackMessageId,
             text: fallbackText,
+            promptContextTimestampMs: opts.promptContextTimestampMs,
             ...(plainResult.acceptedParams?.message_thread_id !== undefined
               ? { messageThreadId: plainResult.acceptedParams.message_thread_id }
               : {}),
@@ -1155,6 +1159,7 @@ export async function sendMessageTelegram(
         message: result,
         messageId,
         text: chunk.plainText,
+        promptContextTimestampMs: opts.promptContextTimestampMs,
         ...(recordedParams?.message_thread_id !== undefined
           ? { messageThreadId: recordedParams.message_thread_id }
           : {}),
@@ -1409,6 +1414,7 @@ export async function sendMessageTelegram(
       message: result,
       messageId: mediaMessageId,
       ...(caption ? { text: caption } : {}),
+      promptContextTimestampMs: opts.promptContextTimestampMs,
       ...(mediaParams.message_thread_id !== undefined
         ? { messageThreadId: mediaParams.message_thread_id }
         : {}),


### PR DESCRIPTION
Closes #98767

## What Problem This Solves

Fixes an issue where Telegram direct-message users could receive duplicated recent prompt context after a visible assistant reply was sent back to Telegram.

## Why This Change Was Made

Telegram already reads the current turn transcript when recovering the final assistant text for delivery. This change keeps that same transcript timestamp on the Telegram prompt-context cache entry when the cached outbound text matches the transcript final text, instead of deriving prompt-context order from Telegram send completion time. It does not add new per-message IDs, change delivery behavior, or broaden the prompt-context cache policy.

## User Impact

Telegram DM sessions keep cleaner prompt context after sent replies. The shared session transcript and Telegram prompt-context cache no longer describe the same assistant reply with different ordering timestamps, which reduces duplicate recent-context rows and token waste.

## Live Proof

Captured on the PR branch in a local Telegram DM using TomServoBotBot. Before the proof run, iMessage and WhatsApp were disabled in the local OpenClaw config and the proof gateway reported both as unavailable/unknown channels; Telegram remained running.

Proof sequence:

1. User sent Telegram DM marker: `oc proof one 2026-07-01-1508: reply with exactly alpha proof`
2. Assistant produced final text: `alpha proof`
3. User sent Telegram DM marker: `oc proof two 2026-07-01-1508: report whether the immediately prior assistant reply appears once or more than once in the conversation context for this turn`
4. Runtime trajectory for the second turn's submitted prompt contained exactly one prior assistant context row for the first turn's assistant reply.

Redacted trajectory extract:

```json
{
  "sessionKey": "agent:main:direct:<redacted>",
  "currentMessageId": "29737",
  "previousAssistantMessageId": "29736",
  "previousAssistantContextRows": 1,
  "redactedContextRows": [
    "#29736 <timestamp> OpenClaw: alpha proof"
  ],
  "assistantTexts": [
    "Once."
  ]
}
```

The live proof was captured before the branch was narrowed and rebased onto current `main`; the rebased head contains the same Telegram runtime/test change and no non-Telegram cleanup.

## Evidence

- `pnpm docs:list`
- `pnpm test extensions/telegram/src/bot-message-dispatch.test.ts --reporter=dot`
- `pnpm test extensions/telegram/src/outbound-adapter.test.ts --reporter=dot`
- `pnpm test extensions/telegram/src/send.test.ts --reporter=dot`
- `pnpm check:test-types`
- `pnpm exec oxfmt --check extensions/telegram/src/bot-message-dispatch.ts extensions/telegram/src/bot-message-dispatch.test.ts extensions/telegram/src/outbound-adapter.ts extensions/telegram/src/outbound-adapter.test.ts extensions/telegram/src/send.ts extensions/telegram/src/send.test.ts extensions/telegram/src/outbound-message-context.ts`
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 pnpm check:changed --base openclaw/main --head HEAD`
- `git diff --check openclaw/main...HEAD`
