### PR TITLE
fix: restore daemon install test typecheck

### DIFF
--- a/src/commands/daemon-install-helpers.test.ts
+++ b/src/commands/daemon-install-helpers.test.ts
@@ -485,6 +485,7 @@ describe("buildGatewayInstallPlan", () => {
         models: {
           providers: {
             openai: {
+              baseUrl: "https://api.openai.com/v1",
               apiKey: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
               models: [],
             },
@@ -1263,7 +1264,7 @@ describe("buildGatewayInstallPlan — dotenv merge", () => {
     const plan = await buildGatewayInstallPlan({
       env: {
         HOME: tmpDir,
-        TELEGRAM_DEFAULT_BOTTOKEN: "telegram-shell-token",
+        DISCORD_BOT_TOKEN: "discord-shell-token",
       },
       port: 3000,
       runtime: "node",
@@ -1271,27 +1272,19 @@ describe("buildGatewayInstallPlan — dotenv merge", () => {
       config: {
         env: {
           vars: {
-            TELEGRAM_DEFAULT_BOTTOKEN: "your-real-telegram-default-token-here",
+            DISCORD_BOT_TOKEN: "your-real-discord-token-here",
           },
         },
         channels: {
-          telegram: {
-            accounts: {
-              default: {
-                botToken: {
-                  source: "env",
-                  provider: "default",
-                  id: "TELEGRAM_DEFAULT_BOTTOKEN",
-                },
-              },
-            },
+          discord: {
+            token: { source: "env", provider: "default", id: "DISCORD_BOT_TOKEN" },
           },
         },
       },
     });
 
-    expect(plan.environment.TELEGRAM_DEFAULT_BOTTOKEN).toBe("telegram-shell-token");
-    expect(plan.environment.OPENCLAW_SERVICE_MANAGED_ENV_KEYS).toBe("TELEGRAM_DEFAULT_BOTTOKEN");
+    expect(plan.environment.DISCORD_BOT_TOKEN).toBe("discord-shell-token");
+    expect(plan.environment.OPENCLAW_SERVICE_MANAGED_ENV_KEYS).toBe("DISCORD_BOT_TOKEN");
   });
 
   it("retains .env values when config env has an unresolved self reference", async () => {


### PR DESCRIPTION
Related: #96065

## What Problem This Solves

Resolves a problem where the repository's test-type gate fails deterministically after the daemon-install SecretRef fix landed, blocking otherwise unrelated pull requests and `main` CI.

## Why This Change Was Made

The test fixtures now satisfy their existing config contracts: the OpenAI provider fixture includes its required `baseUrl`, and the macOS managed-environment test uses Discord's typed `SecretInput` token surface. Production daemon-install behavior is unchanged.

## User Impact

There is no runtime behavior change. Maintainers and contributors regain a green `check:test-types` gate for the daemon-install test module.

## Provenance

This is a test-only follow-up to #96065, authored by @Darren2030 and squash-merged by @obviyus as `e79865569c5022db95f4707415ab28f537e07c5f`. It preserves that PR's production behavior and changes only the two invalid fixtures introduced in `src/commands/daemon-install-helpers.test.ts`.

## Evidence

- Current-main failure: `check-test-types` on `eb417fa206e6ec76df12c500d08f8fd8691298e9` reports the same TS2741 and TS2322 errors: https://github.com/openclaw/openclaw/actions/runs/28548720110/job/84640797600
- Blacksmith Testbox-through-Crabbox `tbx_01kwfsb498kd0p6hxs3xebffpr`: `corepack pnpm check:test-types` passed.
- Same Testbox: `corepack pnpm test src/commands/daemon-install-helpers.test.ts -- --reporter=verbose` passed, 47/47 tests.
- Same Testbox: focused oxfmt and type-aware oxlint passed with zero warnings or errors.
- Fresh autoreview: `gpt-5.6-sol`, `xhigh`, no findings, 0.99 confidence.
- Exact reviewed commit: `5a669644e53f08f0ccb0f60251f70dbd9ff9f81c` (tree `439d59d9d19f601d210a8319aa70d0a7cc5b274f`; one file, +7/-14).

AI-assisted: yes.
