### PR TITLE
fix(models): render model context window in decimal K

### DIFF
--- a/src/commands/models/list.table.test.ts
+++ b/src/commands/models/list.table.test.ts
@@ -22,9 +22,10 @@ describe("printModelTable", () => {
 
     printModelTable(rows, runtime as never);
 
+    // Decimal windows render in decimal K: 272000 -> "272k", 400000 -> "400k".
     expect(runtime.log.mock.calls).toEqual([
       ["Model                                      Input      Ctx         Local Auth  Tags"],
-      ["openai/gpt-5.5                             text+image 266k/391k   no    yes   "],
+      ["openai/gpt-5.5                             text+image 272k/400k   no    yes   "],
     ]);
   });
 });

--- a/src/commands/models/shared.test.ts
+++ b/src/commands/models/shared.test.ts
@@ -1,7 +1,7 @@
 // Model command shared tests cover shared config and provider helper behavior.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
-import { loadValidConfigOrThrow, updateConfig } from "./shared.js";
+import { formatTokenK, loadValidConfigOrThrow, updateConfig } from "./shared.js";
 
 const mocks = vi.hoisted(() => ({
   readConfigFileSnapshot: vi.fn(),
@@ -93,5 +93,28 @@ describe("models/shared", () => {
     const [replaceParams] = mocks.replaceConfigFile.mock.calls[0] ?? [];
     expect(replaceParams?.nextConfig).toEqual(sourceConfig);
     expect(replaceParams?.baseHash).toBe("config-2");
+  });
+
+  describe("formatTokenK", () => {
+    // Token context windows are decimal, so round windows must not shrink
+    // (regression: /1024 rendered 200000 as "195k" instead of "200k").
+    it("renders round token context windows in decimal K", () => {
+      expect(formatTokenK(200_000)).toBe("200k");
+      expect(formatTokenK(128_000)).toBe("128k");
+      expect(formatTokenK(1_000_000)).toBe("1000k");
+      expect(formatTokenK(195_000)).toBe("195k");
+    });
+
+    it("passes small counts through and switches to K at 1000", () => {
+      expect(formatTokenK(999)).toBe("999");
+      expect(formatTokenK(1_000)).toBe("1k");
+    });
+
+    it("returns a dash for missing or non-finite values", () => {
+      expect(formatTokenK(undefined)).toBe("-");
+      expect(formatTokenK(null)).toBe("-");
+      expect(formatTokenK(0)).toBe("-");
+      expect(formatTokenK(Number.NaN)).toBe("-");
+    });
   });
 });

--- a/src/commands/models/shared.ts
+++ b/src/commands/models/shared.ts
@@ -31,10 +31,12 @@ export const formatTokenK = (value?: number | null) => {
   if (!value || !Number.isFinite(value)) {
     return "-";
   }
-  if (value < 1024) {
+  // Token counts use decimal-K (/1000), matching formatTokenCount and how
+  // providers advertise context windows (e.g. 200000 -> "200k", not "195k").
+  if (value < 1000) {
     return `${Math.round(value)}`;
   }
-  return `${Math.round(value / 1024)}k`;
+  return `${Math.round(value / 1000)}k`;
 };
 
 /** Formats millisecond durations for model command output. */


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `openclaw models list`, `openclaw models scan`, and the interactive model picker display the wrong context-window size. A model with a 200,000-token window shows **"195k"** in the `Ctx` column — contradicting `openclaw models list --json` (`"contextWindow": 200000`) and how providers advertise windows ("200k"). Other round windows are under-reported too: 128000 → "125k", 1000000 → "977k".

## Why This Change Was Made

`formatTokenK` (`src/commands/models/shared.ts`) divided token counts by **1024** (binary) before adding the `k` suffix. Token context windows are decimal, so the fix divides by **1000**, matching the repo's canonical token formatter `formatTokenCount` (`src/utils/token-format.ts`).

Scope / non-goals: a repo-wide grep found exactly one other binary-`k` token formatter — `formatContextWindowLabel` in `src/auto-reply/reply/agent-runner-execution.ts` — intentionally left as-is. It renders the heartbeat model-bleed hint for heartbeat models, which are frequently binary-round (e.g. `qwen3.5-9b-32k` = 32768 tokens, where `/1024` correctly yields "32k" and existing tests assert `(32k context)`). The model catalog this PR touches is dominated by decimal flagship windows (200000, 400000, 1000000). I also did not swap in `formatTokenCount` directly, since it differs (adds `1.0m`, decimals under 10k, `"0"` for missing) and would regress the table's `-` sentinel for unknown windows.

## User Impact

`openclaw models list` / `models scan` / the model picker now show context windows that match `--json` and provider convention — a 200k model reads "200k", not "195k". Display only; no config or behavior changes.

## Evidence

Real environment: local OpenClaw CLI, macOS, Node 22.22.3, built from source at `upstream/main` `44e88f550b`, with a forced-rebuild negative control.

Before (unfixed `main`):
```
$ OPENCLAW_FORCE_BUILD=1 pnpm openclaw models list
Model                                      Input      Ctx         Local Auth  Tags
openai/gpt-5.5                             text       195k        no    no    default
```
After (this patch):
```
$ OPENCLAW_FORCE_BUILD=1 pnpm openclaw models list
Model                                      Input      Ctx         Local Auth  Tags
openai/gpt-5.5                             text       200k        no    no    default
```
Ground truth unchanged: `pnpm openclaw models list --json` → `"contextWindow": 200000`.

Tests: `node scripts/run-vitest.mjs src/commands/models/shared.test.ts src/commands/models/list.table.test.ts src/commands/models/scan.test.ts` → all pass. New `formatTokenK` regression (200000→"200k", 128000→"128k", 1000000→"1000k", 999→"999", 1000→"1k", missing/NaN→"-"); `list.table.test.ts` corrected from the pre-fix binary rendering of a decimal 400000-token window ("391k"→"400k"). `oxfmt --check` + `oxlint` on changed files → clean. `codex review --base upstream/main` → no regressions.

_AI-assisted: implemented with Claude Code (Opus 4.8), reviewed with `codex review` (cross-model); human-run before/after captured above._
