### PR TITLE
fix(telegram): survive transient getUpdates errors and stop per-send cache rewrites

### DIFF
--- a/extensions/telegram/src/network-errors.test.ts
+++ b/extensions/telegram/src/network-errors.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   getTelegramNetworkErrorOrigin,
   isRecoverableTelegramNetworkError,
+  isRetryableTelegramApiError,
   isTelegramRateLimitError,
   isSafeToRetrySendError,
   isTelegramClientRejection,
@@ -319,6 +320,19 @@ describe("isTelegramRateLimitError", () => {
       response: { parameters: { retry_after: 1 } },
     };
     expect(isTelegramRateLimitError(wrapped)).toBe(true);
+  });
+});
+
+describe("isRetryableTelegramApiError", () => {
+  it.each([
+    ["Too Many Requests", 429, true],
+    ["Internal Server Error", 500, true],
+    ["Bad Gateway", 502, true],
+    ["Conflict", 409, false],
+    ["Unauthorized", 401, false],
+    ["Not Found", 404, false],
+  ])("returns %s for error_code %s", (message, errorCode, expected) => {
+    expect(isRetryableTelegramApiError(errorWithTelegramCode(message, errorCode))).toBe(expected);
   });
 });
 

--- a/extensions/telegram/src/network-errors.ts
+++ b/extensions/telegram/src/network-errors.ts
@@ -341,3 +341,14 @@ export function isRecoverableTelegramNetworkError(
 
   return false;
 }
+
+export function isRetryableTelegramApiError(
+  err: unknown,
+  options: { context?: TelegramNetworkErrorContext; allowMessageMatch?: boolean } = {},
+): boolean {
+  return (
+    isRecoverableTelegramNetworkError(err, options) ||
+    isTelegramServerError(err) ||
+    isTelegramRateLimitError(err)
+  );
+}

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -368,7 +368,24 @@ describe("sent-message-cache", () => {
     expect(wasSentByBot(123, 1)).toBe(true);
   });
 
-  it("persists sent-message rows with their remaining logical ttl", () => {
+  it("persists only the newly recorded sent-message row", () => {
+    const persistedMessageIds: string[] = [];
+    setTelegramSentMessageStoreForTest({
+      ...sentMessageStore,
+      register(key, value, options) {
+        sentMessageStore.register(key, value, options);
+        persistedMessageIds.push(value.messageId);
+      },
+    });
+
+    recordSentMessage(123, 1);
+    recordSentMessage(123, 2);
+    recordSentMessage(456, 10);
+
+    expect(persistedMessageIds).toEqual(["1", "2", "10"]);
+  });
+
+  it("persists sent-message rows with a per-entry ttl", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-01-26T12:00:00.000Z"));
     const ttlByMessageId = new Map<string, number>();
@@ -384,7 +401,7 @@ describe("sent-message-cache", () => {
     vi.advanceTimersByTime(60 * 60 * 1000);
     recordSentMessage(123, 2);
 
-    expect(ttlByMessageId.get("1")).toBe(23 * 60 * 60 * 1000);
+    expect(ttlByMessageId.get("1")).toBe(24 * 60 * 60 * 1000);
     expect(ttlByMessageId.get("2")).toBe(24 * 60 * 60 * 1000);
   });
 

--- a/extensions/telegram/src/sent-message-cache.ts
+++ b/extensions/telegram/src/sent-message-cache.ts
@@ -105,6 +105,12 @@ function cleanupExpired(
   }
 }
 
+function cleanupExpiredSentMessages(store: SentMessageStore, now: number): void {
+  for (const [scopeKey, entry] of store) {
+    cleanupExpired(store, scopeKey, entry, now);
+  }
+}
+
 function readLegacySentMessages(filePath: string): SentMessageStore {
   try {
     const raw = fs.readFileSync(filePath, "utf-8");
@@ -173,23 +179,17 @@ function getSentMessages(cfg?: Pick<OpenClawConfig, "session">): SentMessageStor
   return getSentMessageBucket(cfg).store;
 }
 
-function persistSentMessages(bucket: SentMessageBucket): void {
-  const { store, scopeKey } = bucket;
-  const now = Date.now();
-  for (const [chatId, entry] of store) {
-    cleanupExpired(store, chatId, entry, now);
-    for (const [messageId, timestamp] of entry) {
-      const ttlMs = TTL_MS - Math.max(0, now - timestamp);
-      if (ttlMs <= 0) {
-        continue;
-      }
-      openSentMessageStore().register(
-        sentMessageEntryKey(scopeKey, chatId, messageId),
-        { scopeKey, chatId, messageId, timestamp },
-        { ttlMs },
-      );
-    }
-  }
+function persistSentMessage(
+  bucket: SentMessageBucket,
+  chatId: string,
+  messageId: string,
+  timestamp: number,
+): void {
+  openSentMessageStore().register(
+    sentMessageEntryKey(bucket.scopeKey, chatId, messageId),
+    { scopeKey: bucket.scopeKey, chatId, messageId, timestamp },
+    { ttlMs: TTL_MS },
+  );
 }
 
 export function recordSentMessage(
@@ -208,11 +208,9 @@ export function recordSentMessage(
     store.set(scopeKey, entry);
   }
   entry.set(idKey, now);
-  if (entry.size > 100) {
-    cleanupExpired(store, scopeKey, entry, now);
-  }
+  cleanupExpiredSentMessages(store, now);
   try {
-    persistSentMessages(bucket);
+    persistSentMessage(bucket, scopeKey, idKey, now);
   } catch (error) {
     logVerbose(`telegram: failed to persist sent-message cache: ${String(error)}`);
   }

--- a/extensions/telegram/src/telegram-ingress-worker.runtime.test.ts
+++ b/extensions/telegram/src/telegram-ingress-worker.runtime.test.ts
@@ -1,0 +1,177 @@
+// Telegram tests cover ingress worker runtime behavior.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type {
+  TelegramIngressWorkerCommand,
+  TelegramIngressWorkerMessage,
+} from "./telegram-ingress-worker.js";
+import { runTelegramIngressWorkerRuntime } from "./telegram-ingress-worker.runtime.js";
+
+type RuntimePort = Parameters<typeof runTelegramIngressWorkerRuntime>[0]["port"];
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function htmlResponse(status: number, body: string): Response {
+  return new Response(body, {
+    status,
+    headers: { "content-type": "text/html" },
+  });
+}
+
+function createRuntime(responses: Response[]): {
+  calls: number[];
+  messages: TelegramIngressWorkerMessage[];
+  done: Promise<void>;
+} {
+  const calls: number[] = [];
+  const messages: TelegramIngressWorkerMessage[] = [];
+  const listeners = new Set<(message: TelegramIngressWorkerCommand) => void>();
+  const sendCommand = (message: TelegramIngressWorkerCommand) => {
+    for (const listener of listeners) {
+      listener(message);
+    }
+  };
+  const port: RuntimePort = {
+    postMessage(message) {
+      messages.push(message);
+      if (message.type === "poll-success") {
+        sendCommand({ type: "stop" });
+      }
+    },
+    onMessage(listener) {
+      listeners.add(listener);
+    },
+    close() {},
+  };
+  const fetchImpl: typeof fetch = async () => {
+    calls.push(Date.now());
+    return responses[Math.min(calls.length - 1, responses.length - 1)];
+  };
+  const done = runTelegramIngressWorkerRuntime({
+    options: {
+      token: "TEST:TOKEN",
+      accountId: "acct",
+      initialUpdateId: null,
+      spoolDir: "/tmp/openclaw-telegram-ingress-worker-test",
+      apiRoot: "https://api.telegram.test",
+      timeoutSeconds: 1,
+    },
+    port,
+    deps: {
+      fetch: fetchImpl,
+      closeTransport: async () => {},
+    },
+  });
+  return { calls, messages, done };
+}
+
+async function flushRuntime(): Promise<void> {
+  await vi.advanceTimersByTimeAsync(0);
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("telegram ingress worker retry policy", () => {
+  it("honors Telegram retry_after for getUpdates 429 responses", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-01T12:00:00.000Z"));
+    const runtime = createRuntime([
+      jsonResponse(429, {
+        ok: false,
+        error_code: 429,
+        description: "Too Many Requests: retry after 0.05",
+        parameters: { retry_after: 0.05 },
+      }),
+      jsonResponse(200, { ok: true, result: [] }),
+    ]);
+
+    expect(runtime.calls).toHaveLength(1);
+    await flushRuntime();
+    expect(runtime.messages).toContainEqual(
+      expect.objectContaining({ type: "poll-error", errorCode: 429 }),
+    );
+    await vi.advanceTimersByTimeAsync(49);
+    expect(runtime.calls).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(1);
+    await runtime.done;
+
+    expect(runtime.calls).toHaveLength(2);
+    expect(runtime.calls[1] - runtime.calls[0]).toBe(50);
+    expect(runtime.messages).toContainEqual(
+      expect.objectContaining({ type: "poll-success", count: 0 }),
+    );
+  });
+
+  it.each([500, 502])("retries getUpdates %s responses with backoff", async (status) => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-01T12:00:00.000Z"));
+    const runtime = createRuntime([
+      jsonResponse(status, {
+        ok: false,
+        error_code: status,
+        description: status === 500 ? "Internal Server Error" : "Bad Gateway",
+      }),
+      jsonResponse(200, { ok: true, result: [] }),
+    ]);
+
+    expect(runtime.calls).toHaveLength(1);
+    await flushRuntime();
+    expect(runtime.messages).toContainEqual(
+      expect.objectContaining({ type: "poll-error", errorCode: status }),
+    );
+    await vi.advanceTimersByTimeAsync(999);
+    expect(runtime.calls).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(1);
+    await runtime.done;
+
+    expect(runtime.calls).toHaveLength(2);
+    expect(runtime.calls[1] - runtime.calls[0]).toBe(1000);
+  });
+
+  it("retries a non-json getUpdates 502 response as a server error", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-01T12:00:00.000Z"));
+    const runtime = createRuntime([
+      htmlResponse(502, "<html>Bad Gateway</html>"),
+      jsonResponse(200, { ok: true, result: [] }),
+    ]);
+
+    expect(runtime.calls).toHaveLength(1);
+    await flushRuntime();
+    expect(runtime.messages).toContainEqual(
+      expect.objectContaining({
+        type: "poll-error",
+        errorCode: 502,
+        message: "Telegram getUpdates failed with HTTP 502",
+      }),
+    );
+    await vi.advanceTimersByTimeAsync(1000);
+    await runtime.done;
+
+    expect(runtime.calls).toHaveLength(2);
+  });
+
+  it.each([401, 409])("propagates getUpdates %s responses to the parent", async (status) => {
+    const runtime = createRuntime([
+      jsonResponse(status, {
+        ok: false,
+        error_code: status,
+        description:
+          status === 401 ? "Unauthorized" : "Conflict: terminated by other getUpdates request",
+      }),
+    ]);
+
+    await expect(runtime.done).rejects.toThrow(
+      status === 401 ? "Unauthorized" : "Conflict: terminated by other getUpdates request",
+    );
+    expect(runtime.messages).toContainEqual(
+      expect.objectContaining({ type: "poll-error", errorCode: status }),
+    );
+  });
+});

--- a/extensions/telegram/src/telegram-ingress-worker.runtime.ts
+++ b/extensions/telegram/src/telegram-ingress-worker.runtime.ts
@@ -4,7 +4,7 @@ import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtim
 import { resolveTelegramAllowedUpdates } from "./allowed-updates.js";
 import { normalizeTelegramApiRoot } from "./api-root.js";
 import { resolveTelegramTransport } from "./fetch.js";
-import { isRecoverableTelegramNetworkError } from "./network-errors.js";
+import { isRetryableTelegramApiError, readTelegramRetryAfterMs } from "./network-errors.js";
 import { makeProxyFetch } from "./proxy.js";
 import {
   TELEGRAM_GET_UPDATES_REQUEST_TIMEOUT_MS,
@@ -15,36 +15,59 @@ import type {
   TelegramIngressWorkerMessage,
   TelegramIngressWorkerOptions,
 } from "./telegram-ingress-worker.js";
+import { TELEGRAM_INGRESS_WORKER_RUNTIME_MARKER } from "./telegram-ingress-worker.js";
 
-const options = workerData as TelegramIngressWorkerOptions;
 const pollLimit = 100;
 // getUpdates can return up to 100 updates; 4 MiB is a generous bound that no legitimate
 // Telegram Bot API response will reach, guarding against misbehaving/hostile endpoints.
 const TELEGRAM_GET_UPDATES_MAX_RESPONSE_BYTES = 4 * 1024 * 1024;
 const retryInitialMs = 1000;
 const retryMaxMs = 30_000;
-let stopped = false;
-let activeController: AbortController | undefined;
-let nextSpoolRequestId = 0;
-const pendingSpoolRequests = new Map<
+
+type TelegramGetUpdatesJson = {
+  ok?: unknown;
+  error_code?: unknown;
+  result?: unknown;
+  description?: unknown;
+  parameters?: unknown;
+};
+
+type PendingSpoolRequests = Map<
   string,
   {
     resolve(updateId: number): void;
     reject(err: Error): void;
   }
->();
+>;
 
-function post(message: TelegramIngressWorkerMessage): void {
-  if (parentPort) {
-    Reflect.apply(Reflect.get(parentPort, "postMessage") as (value: unknown) => void, parentPort, [
-      message,
-    ]);
+export type TelegramIngressRuntimePort = {
+  postMessage(message: TelegramIngressWorkerMessage): void;
+  onMessage(listener: (message: TelegramIngressWorkerCommand) => void): void;
+  close(): void;
+};
+
+export type TelegramIngressRuntimeDeps = {
+  fetch?: typeof fetch;
+  closeTransport?: () => Promise<void>;
+};
+
+type TelegramIngressWorkerRuntimeData = TelegramIngressWorkerOptions & {
+  runtime: typeof TELEGRAM_INGRESS_WORKER_RUNTIME_MARKER;
+};
+
+function sleep(ms: number, signal: AbortSignal): Promise<void> {
+  if (signal.aborted) {
+    return Promise.resolve();
   }
-}
-
-function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => {
-    setTimeout(resolve, ms);
+    const done = () => {
+      clearTimeout(timeout);
+      signal.removeEventListener("abort", done);
+      resolve();
+    };
+    const timeout = setTimeout(done, ms);
+    timeout.unref?.();
+    signal.addEventListener("abort", done, { once: true });
   });
 }
 
@@ -65,9 +88,9 @@ function readTelegramErrorCode(err: unknown): number | undefined {
   return undefined;
 }
 
-function postPollError(err: unknown): void {
+function postPollError(port: TelegramIngressRuntimePort, err: unknown): void {
   const errorCode = readTelegramErrorCode(err);
-  post({
+  port.postMessage({
     type: "poll-error",
     message: formatErrorMessage(err),
     ...(errorCode === undefined ? {} : { errorCode }),
@@ -79,60 +102,33 @@ function resolveBackoff(attempt: number): number {
   return Math.min(retryMaxMs, retryInitialMs * 2 ** Math.max(0, attempt - 1));
 }
 
-function rejectPendingSpoolRequests(err: Error): void {
+function createTelegramGetUpdatesError(params: {
+  message: string;
+  errorCode?: number;
+  parameters?: unknown;
+}): Error {
+  return Object.assign(
+    new Error(params.message),
+    params.errorCode === undefined ? {} : { error_code: params.errorCode },
+    params.parameters === undefined ? {} : { parameters: params.parameters },
+  );
+}
+
+function rejectPendingSpoolRequests(pendingSpoolRequests: PendingSpoolRequests, err: Error): void {
   for (const pending of pendingSpoolRequests.values()) {
     pending.reject(err);
   }
   pendingSpoolRequests.clear();
 }
 
-parentPort?.on("message", (message: TelegramIngressWorkerCommand) => {
-  if (message?.type === "stop") {
-    stopped = true;
-    const err = new Error("telegram ingress worker stopped");
-    activeController?.abort(err);
-    rejectPendingSpoolRequests(err);
-    return;
-  }
-  if (message?.type !== "spool-ack") {
-    return;
-  }
-  const pending = pendingSpoolRequests.get(message.requestId);
-  if (!pending) {
-    return;
-  }
-  pendingSpoolRequests.delete(message.requestId);
-  if (message.result.ok) {
-    pending.resolve(message.result.updateId);
-    return;
-  }
-  pending.reject(new Error(message.result.message));
-});
-
-async function requestSpoolUpdate(params: { update: unknown; queued: number }): Promise<number> {
-  if (!parentPort) {
-    throw new Error("Telegram ingress worker missing parent port.");
-  }
-  const requestId = String(++nextSpoolRequestId);
-  const updateId = await new Promise<number>((resolve, reject) => {
-    pendingSpoolRequests.set(requestId, { resolve, reject });
-    post({
-      type: "update",
-      requestId,
-      update: params.update,
-      queued: params.queued,
-    });
-  });
-  return updateId;
-}
-
 async function fetchJson(params: {
   fetch: typeof fetch;
   url: string;
   body: unknown;
+  setActiveController(controller: AbortController | undefined): void;
 }): Promise<unknown> {
   const controller = new AbortController();
-  activeController = controller;
+  params.setActiveController(controller);
   const timeout = setTimeout(() => {
     controller.abort(new Error("Telegram getUpdates timed out"));
   }, TELEGRAM_GET_UPDATES_REQUEST_TIMEOUT_MS);
@@ -144,16 +140,21 @@ async function fetchJson(params: {
       body: JSON.stringify(params.body),
       signal: controller.signal,
     });
-    const json = JSON.parse(
-      (await readResponseWithLimit(response, TELEGRAM_GET_UPDATES_MAX_RESPONSE_BYTES)).toString(
-        "utf8",
-      ),
-    ) as {
-      ok?: unknown;
-      error_code?: unknown;
-      result?: unknown;
-      description?: unknown;
-    };
+    const raw = (
+      await readResponseWithLimit(response, TELEGRAM_GET_UPDATES_MAX_RESPONSE_BYTES)
+    ).toString("utf8");
+    let json: TelegramGetUpdatesJson;
+    try {
+      json = JSON.parse(raw) as TelegramGetUpdatesJson;
+    } catch (err) {
+      if (!response.ok) {
+        throw createTelegramGetUpdatesError({
+          message: `Telegram getUpdates failed with HTTP ${response.status}`,
+          errorCode: response.status,
+        });
+      }
+      throw err;
+    }
     if (!response.ok || json.ok !== true) {
       const message =
         typeof json.description === "string"
@@ -162,28 +163,84 @@ async function fetchJson(params: {
       // Preserve the Bot API error_code across the worker boundary so the
       // parent session can distinguish getUpdates conflicts (409) from fatal
       // errors (401) without parsing description strings.
-      throw typeof json.error_code === "number"
-        ? Object.assign(new Error(message), { error_code: json.error_code })
-        : new Error(message);
+      throw createTelegramGetUpdatesError({
+        message,
+        errorCode: typeof json.error_code === "number" ? json.error_code : response.status,
+        parameters: json.parameters,
+      });
     }
     return json.result;
   } finally {
     clearTimeout(timeout);
-    if (activeController === controller) {
-      activeController = undefined;
-    }
+    params.setActiveController(undefined);
   }
 }
 
-async function main(): Promise<void> {
+export async function runTelegramIngressWorkerRuntime(params: {
+  options: TelegramIngressWorkerOptions;
+  port: TelegramIngressRuntimePort;
+  deps?: TelegramIngressRuntimeDeps;
+}): Promise<void> {
+  const { options, port } = params;
+  const stopController = new AbortController();
+  let stopped = false;
+  let activeController: AbortController | undefined;
+  let nextSpoolRequestId = 0;
+  const pendingSpoolRequests: PendingSpoolRequests = new Map();
   const proxyFetch = options.proxy ? makeProxyFetch(options.proxy) : undefined;
-  const transport = resolveTelegramTransport(proxyFetch, { network: options.network });
-  const fetchImpl = transport.fetch ?? globalThis.fetch;
+  const transport =
+    params.deps?.fetch === undefined
+      ? resolveTelegramTransport(proxyFetch, { network: options.network })
+      : undefined;
+  const fetchImpl = params.deps?.fetch ?? transport?.fetch ?? globalThis.fetch;
+  const closeTransport =
+    params.deps?.closeTransport ?? (() => transport?.close() ?? Promise.resolve());
   const apiRoot = normalizeTelegramApiRoot(options.apiRoot ?? "https://api.telegram.org");
   const getUpdatesUrl = `${apiRoot}/bot${options.token}/getUpdates`;
   const pollTimeoutSeconds = resolveTelegramLongPollTimeoutSeconds(options.timeoutSeconds);
   let lastUpdateId = options.initialUpdateId;
   let failures = 0;
+
+  port.onMessage((message) => {
+    if (message?.type === "stop") {
+      stopped = true;
+      const err = new Error("telegram ingress worker stopped");
+      stopController.abort(err);
+      activeController?.abort(err);
+      rejectPendingSpoolRequests(pendingSpoolRequests, err);
+      return;
+    }
+    if (message?.type !== "spool-ack") {
+      return;
+    }
+    const pending = pendingSpoolRequests.get(message.requestId);
+    if (!pending) {
+      return;
+    }
+    pendingSpoolRequests.delete(message.requestId);
+    if (message.result.ok) {
+      pending.resolve(message.result.updateId);
+      return;
+    }
+    pending.reject(new Error(message.result.message));
+  });
+
+  const requestSpoolUpdate = async (requestParams: {
+    update: unknown;
+    queued: number;
+  }): Promise<number> => {
+    const requestId = String(++nextSpoolRequestId);
+    const updateId = await new Promise<number>((resolve, reject) => {
+      pendingSpoolRequests.set(requestId, { resolve, reject });
+      port.postMessage({
+        type: "update",
+        requestId,
+        update: requestParams.update,
+        queued: requestParams.queued,
+      });
+    });
+    return updateId;
+  };
 
   try {
     for (;;) {
@@ -192,7 +249,7 @@ async function main(): Promise<void> {
       }
       const offset = lastUpdateId === null ? null : lastUpdateId + 1;
       const startedAt = Date.now();
-      post({ type: "poll-start", offset, startedAt });
+      port.postMessage({ type: "poll-start", offset, startedAt });
       try {
         const result = await fetchJson({
           fetch: fetchImpl,
@@ -202,6 +259,9 @@ async function main(): Promise<void> {
             limit: pollLimit,
             allowed_updates: resolveTelegramAllowedUpdates(),
             ...(offset === null ? {} : { offset }),
+          },
+          setActiveController(controller) {
+            activeController = controller;
           },
         });
         if (!Array.isArray(result)) {
@@ -215,10 +275,10 @@ async function main(): Promise<void> {
           if (lastUpdateId === null || updateId > lastUpdateId) {
             lastUpdateId = updateId;
           }
-          post({ type: "spooled", updateId, queued: result.length });
+          port.postMessage({ type: "spooled", updateId, queued: result.length });
         }
         failures = 0;
-        post({
+        port.postMessage({
           type: "poll-success",
           offset,
           count: result.length,
@@ -229,24 +289,67 @@ async function main(): Promise<void> {
           break;
         }
         failures += 1;
-        postPollError(err);
-        if (!isRecoverableTelegramNetworkError(err, { context: "polling" })) {
+        postPollError(port, err);
+        // 409 must propagate to the parent: it owns duplicate-poller/webhook
+        // conflict recovery. Transient Bot API errors stay local to this worker.
+        if (!isRetryableTelegramApiError(err, { context: "polling" })) {
           throw err;
         }
-        await sleep(resolveBackoff(failures));
+        await sleep(
+          readTelegramRetryAfterMs(err) ?? resolveBackoff(failures),
+          stopController.signal,
+        );
       }
     }
   } finally {
-    await transport.close();
+    await closeTransport();
   }
 }
 
-main()
-  .then(() => {
-    parentPort?.close();
-  })
-  .catch((err: unknown) => {
-    postPollError(err);
-    parentPort?.close();
-    process.exitCode = stopped ? 0 : 1;
+const workerPort = parentPort;
+const runtimePort =
+  workerPort === null
+    ? null
+    : ({
+        postMessage(message) {
+          Reflect.apply(
+            Reflect.get(workerPort, "postMessage") as (value: unknown) => void,
+            workerPort,
+            [message],
+          );
+        },
+        onMessage(listener) {
+          workerPort.on("message", listener);
+        },
+        close() {
+          workerPort.close();
+        },
+      } satisfies TelegramIngressRuntimePort);
+const runtimeOptions =
+  workerData &&
+  typeof workerData === "object" &&
+  "runtime" in workerData &&
+  workerData.runtime === TELEGRAM_INGRESS_WORKER_RUNTIME_MARKER
+    ? (workerData as TelegramIngressWorkerRuntimeData)
+    : null;
+
+if (runtimePort && runtimeOptions) {
+  let exitedAfterStop = false;
+  runtimePort.onMessage((message) => {
+    if (message?.type === "stop") {
+      exitedAfterStop = true;
+    }
   });
+  runTelegramIngressWorkerRuntime({
+    options: runtimeOptions,
+    port: runtimePort,
+  })
+    .then(() => {
+      runtimePort.close();
+    })
+    .catch((err: unknown) => {
+      postPollError(runtimePort, err);
+      runtimePort.close();
+      process.exitCode = exitedAfterStop ? 0 : 1;
+    });
+}

--- a/extensions/telegram/src/telegram-ingress-worker.ts
+++ b/extensions/telegram/src/telegram-ingress-worker.ts
@@ -2,6 +2,8 @@
 import { Worker } from "node:worker_threads";
 import type { TelegramNetworkConfig } from "openclaw/plugin-sdk/config-contracts";
 
+export const TELEGRAM_INGRESS_WORKER_RUNTIME_MARKER = "openclaw.telegram-ingress-worker";
+
 export type TelegramIngressWorkerMessage =
   | {
       type: "poll-start";
@@ -87,7 +89,7 @@ export type TelegramIngressWorkerFactory = (
 export const createTelegramIngressWorker: TelegramIngressWorkerFactory = (options) => {
   const listeners = new Set<(message: TelegramIngressWorkerMessage) => void>();
   const worker = new Worker(new URL("./telegram-ingress-worker.runtime.js", import.meta.url), {
-    workerData: options,
+    workerData: { ...options, runtime: TELEGRAM_INGRESS_WORKER_RUNTIME_MARKER },
   });
   const taskPromise = new Promise<void>((resolve, reject) => {
     worker.once("error", reject);

--- a/extensions/telegram/src/webhook.ts
+++ b/extensions/telegram/src/webhook.ts
@@ -33,11 +33,7 @@ import { readJsonBodyWithLimit } from "openclaw/plugin-sdk/webhook-request-guard
 import { resolveTelegramAllowedUpdates } from "./allowed-updates.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { createTelegramBot } from "./bot.js";
-import {
-  isRecoverableTelegramNetworkError,
-  isTelegramRateLimitError,
-  isTelegramServerError,
-} from "./network-errors.js";
+import { isRetryableTelegramApiError } from "./network-errors.js";
 import { createTelegramWebhookStatusPublisher } from "./webhook-status.js";
 
 const TELEGRAM_WEBHOOK_MAX_BODY_BYTES = 1024 * 1024;
@@ -455,9 +451,7 @@ export async function startTelegramWebhook(opts: {
     runtime.log?.(`webhook advertised to telegram on ${publicUrl}`);
   };
   const shouldRetryWebhookRegistration = (err: unknown): boolean =>
-    isRecoverableTelegramNetworkError(err, { context: "webhook" }) ||
-    isTelegramServerError(err) ||
-    isTelegramRateLimitError(err);
+    isRetryableTelegramApiError(err, { context: "webhook" });
   const retryWebhookRegistration = async (firstAttempt: number): Promise<void> => {
     let attempt = firstAttempt;
     while (true) {


### PR DESCRIPTION
Closes #98772
Closes #98773

## What Problem This Solves

Fixes two Telegram channel stability defects found in a full subsystem audit:

1. Resolves a problem where any transient Telegram Bot API error on `getUpdates` (429, 500, 502 — including 502s with HTML bodies) crashed the account's polling session. Because the gateway supervisor counts restart attempts cumulatively, routine Telegram degradations eventually disabled the channel permanently until a manual restart. This was a regression from the isolated-ingress migration: the retired grammY polling path retried these errors internally for up to an hour.
2. Fixes an issue where every outbound Telegram message rewrote the entire sent-message cache (up to 10,000 entries) to SQLite as individual synchronous transactions. On busy bots this stalled the gateway event loop, showing up as spurious "polling stall detected" restarts and lock contention with the ingress spool on the shared state DB.

## Why This Change Was Made

The ingress worker now classifies Bot API server errors (5xx) and rate limits (429) as retryable, honoring `parameters.retry_after` before falling back to the existing exponential backoff, and parses non-2xx bodies defensively so a 502 HTML page becomes a status-bearing retryable error instead of a fatal `JSON.parse` crash. 401/404 stay fatal (bad token) and 409 still propagates to the parent session, which owns webhook-conflict recovery. The classifier is shared with the webhook registration path, which already had this behavior (pure refactor there, no behavior change). The sent-message cache now persists only the newly recorded entry — keys were already content-addressed — relying on per-entry TTL and store-side caps for expiry.

The worker runtime was extracted into an injectable function (module-level side effects gated behind a workerData marker) so the retry behavior is directly testable.

## User Impact

Telegram accounts survive Telegram-side outages and rate limiting instead of dying permanently, and 429 `retry_after` hints are respected on the polling path. Busy bots no longer degrade the whole gateway as their daily send volume grows; spurious stall-watchdog restarts from event-loop blocking disappear.

Known bound, not a bug: an extreme `retry_after` (e.g. 3600s) makes the worker sleep past the parent stall watchdog, which restarts the session — an acceptable upper bound that converges.

## Evidence

- New regression tests in `extensions/telegram/src/telegram-ingress-worker.runtime.test.ts`: 429-with-`retry_after` retries after the hinted delay; 500/502 retry with backoff; 502 HTML body (JSON parse failure) retries; 401 and 409 still propagate to the parent.
- `extensions/telegram/src/send.test.ts` now asserts exactly one persisted entry per recorded sent message.
- Validation: `pnpm tsgo:extensions` pass; `node scripts/run-vitest.mjs` on all touched test files — 204 tests pass (send, network-errors, ingress-worker runtime); repo autoreview clean.
- Combined-merge validation with the sibling spool PR (`codex/fix-telegram-spool`): conflict-free octopus merge, `pnpm tsgo:extensions` pass, 403/403 tests across all six touched test files.
