### PR TITLE
fix(telegram): back off, dead-letter, and tombstone spooled updates so poison messages cannot block or duplicate

### DIFF
--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -3404,6 +3404,12 @@ export const registerTelegramHandlers = ({
       releaseDispatchDedupeKeys(dispatchDedupeKeys, err);
       runtime.error?.(danger(`${event.errorMessage}: ${String(err)}`));
       if (err instanceof TelegramPairingStoreReadError) {
+        recordTelegramMessageProcessingResult({ kind: "failed-retryable", error: err });
+        // Spooled replays are durably retried; live updates get one apology
+        // because they are acked without replay.
+        if (isTelegramSpooledReplayUpdate(event.ctx.update)) {
+          return;
+        }
         await withTelegramApiErrorLogging({
           operation: "sendMessage",
           runtime,

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -1732,6 +1732,57 @@ describe("createTelegramBot", () => {
     );
   });
 
+  it("marks spooled replay pairing store read failures retryable without apology spam", async () => {
+    loadConfig.mockReturnValue({
+      channels: { telegram: { dmPolicy: "pairing" } },
+    });
+    readChannelAllowFromStore.mockRejectedValueOnce(new Error("store temporarily unavailable"));
+    sendMessageSpy.mockClear();
+    const onUpdateId = vi.fn();
+
+    createTelegramBot({
+      token: "tok",
+      updateOffset: {
+        lastUpdateId: 700,
+        onUpdateId,
+      },
+    });
+    const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+    const update = {
+      update_id: 701,
+      message: {
+        chat: { id: 1234, type: "private" },
+        text: "hello",
+        message_id: 9,
+        date: 1736380800,
+        from: { id: 123456789, username: "testuser" },
+      },
+    };
+    const ctx = {
+      update,
+      message: update.message,
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    };
+
+    await expect(
+      withTelegramSpooledReplayUpdate(update, async () => {
+        await runTelegramMiddlewareChain({
+          ctx,
+          finalHandler: async () => {
+            await handler(ctx);
+          },
+        });
+      }),
+    ).rejects.toMatchObject({
+      name: TelegramSpooledReplayProcessingError.name,
+      cause: expect.objectContaining({ name: "TelegramPairingStoreReadError" }),
+    });
+
+    expect(onUpdateId).not.toHaveBeenCalled();
+    expect(sendMessageSpy).not.toHaveBeenCalled();
+  });
+
   it("keeps the same private chat usable after a transient pairing store read failure", async () => {
     loadConfig.mockReturnValue({
       channels: { telegram: { dmPolicy: "pairing" } },

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -801,6 +801,36 @@ describe("TelegramPollingSession", () => {
     ).toEqual([30_000, 30_000, 120_000, 30_000]);
   });
 
+  it("backs off every retryable spooled handler failure with an error marker", () => {
+    expect(
+      pollingSessionTesting.resolveSpooledUpdateRetryDelayMs(
+        {
+          updateId: 42,
+          path: "/tmp/42.json",
+          update: { update_id: 42 },
+          receivedAt: 0,
+          attempts: 1,
+          lastAttemptAt: 1_000,
+          lastError: "plain TypeError from handler",
+        },
+        1_999,
+      ),
+    ).toBe(1);
+    expect(
+      pollingSessionTesting.resolveSpooledUpdateRetryDelayMs(
+        {
+          updateId: 43,
+          path: "/tmp/43.json",
+          update: { update_id: 43 },
+          receivedAt: 0,
+          attempts: 1,
+          lastAttemptAt: 1_000,
+        },
+        1_999,
+      ),
+    ).toBe(0);
+  });
+
   it("does not call getUpdates for offset confirmation (avoiding 409 conflicts)", async () => {
     const abort = new AbortController();
     const bot = makeBot();
@@ -2020,6 +2050,57 @@ describe("TelegramPollingSession", () => {
     });
   });
 
+  it("dead-letters retryable poison updates after bounded retries so the lane can drain", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      await withTempSpool(async (tempDir) => {
+        const abort = new AbortController();
+        const log = vi.fn();
+        const events: string[] = [];
+        let poisonAttempts = 0;
+        await writeSpooledTestUpdates(tempDir, [
+          topicUpdate(42, 10, "poison"),
+          topicUpdate(44, 10, "after poison"),
+        ]);
+
+        const { runPromise, stopWorker } = startIsolatedIngressSession({
+          abort,
+          spoolDir: tempDir,
+          log,
+          drainIntervalMs: 100,
+          handleUpdate: async (update) => {
+            if (update.update_id === 42) {
+              poisonAttempts += 1;
+              events.push(`poison:${poisonAttempts}`);
+              throw new Error("deterministic handler failure");
+            }
+            if (update.update_id === 44) {
+              events.push("after-poison");
+              abort.abort();
+            }
+          },
+        });
+
+        await vi.waitFor(() => expect(poisonAttempts).toBe(1));
+        await vi.advanceTimersByTimeAsync(130_000);
+
+        await vi.waitFor(() => expect(events.at(-1)).toBe("after-poison"));
+        expect(poisonAttempts).toBe(pollingSessionTesting.spooledRetryMaxAttempts);
+        expect(await pendingUpdateIds(tempDir, "all")).toEqual([]);
+        expect(await failedUpdateReasons(tempDir)).toEqual([
+          { id: 42, reason: "retry-limit-exceeded" },
+        ]);
+        expectLogIncludes(log, "spooled update 42 on lane");
+        expectLogIncludes(log, "reached retry limit after 8 attempts; dead-lettered");
+
+        stopWorker();
+        await runPromise;
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   for (const scenario of [
     {
       name: "topic",
@@ -2077,20 +2158,17 @@ describe("TelegramPollingSession", () => {
             },
           });
 
-          await vi.waitFor(() => expect(attempts).toBe(1));
-          await vi.advanceTimersByTimeAsync(1_000);
-          expect(attempts).toBe(1);
-          await vi.waitFor(() =>
-            expect(events).toEqual([`${scenario.conflictEvent}:1`, scenario.otherEvent]),
-          );
+          await vi.waitFor(() => expect(attempts).toBeGreaterThanOrEqual(1));
+          await vi.waitFor(() => expect(events).toContain(scenario.otherEvent));
+          expect(events).not.toContain(scenario.blockedEvent);
           expect(await pendingUpdateIds(tempDir, "all")).toEqual([
             scenario.conflict.update_id,
             scenario.blocked.update_id,
           ]);
           expect(await failedUpdateIds(tempDir)).toEqual([]);
 
-          await vi.advanceTimersByTimeAsync(4_500);
-          await vi.waitFor(() => expect(attempts).toBe(2));
+          await vi.advanceTimersByTimeAsync(1_200);
+          await vi.waitFor(() => expect(attempts).toBeGreaterThanOrEqual(2));
           expect(events).not.toContain(scenario.blockedEvent);
           expectLogIncludes(
             log,

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -1650,6 +1650,41 @@ describe("TelegramPollingSession", () => {
     });
   });
 
+  it("does not re-dispatch refetched updates after spooled completion", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      await withTempSpool(async (tempDir) => {
+        const abort = new AbortController();
+        const events: number[] = [];
+        await writeSpooledTestUpdates(tempDir, [topicUpdate(42, 10, "first delivery")]);
+
+        const { runPromise, stopWorker } = startIsolatedIngressSession({
+          abort,
+          spoolDir: tempDir,
+          drainIntervalMs: 10,
+          handleUpdate: async (update) => {
+            events.push(Number(update.update_id));
+          },
+        });
+
+        await vi.waitFor(() => expect(events).toEqual([42]));
+        expect(await pendingUpdateIds(tempDir, "all")).toEqual([]);
+
+        await writeSpooledTestUpdates(tempDir, [topicUpdate(42, 10, "telegram refetch")]);
+        await vi.advanceTimersByTimeAsync(50);
+
+        expect(events).toEqual([42]);
+        expect(await pendingUpdateIds(tempDir, "all")).toEqual([]);
+
+        abort.abort();
+        stopWorker();
+        await runPromise;
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("refreshes active spooled claims while the handler is still running", async () => {
     const refreshHarness = installSpooledClaimRefreshHarness();
     await withTempSpool(async (tempDir) => {

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -477,9 +477,10 @@ async function waitForTestReplyFenceAbort(params: { key: string; laneKey: string
 async function writeSpooledTestUpdates(
   spoolDir: string,
   updates: readonly TestTelegramUpdate[],
+  options?: { now?: number },
 ): Promise<void> {
   for (const update of updates) {
-    await writeTelegramSpooledUpdate({ spoolDir, update });
+    await writeTelegramSpooledUpdate({ spoolDir, update, now: options?.now });
   }
 }
 
@@ -829,6 +830,47 @@ describe("TelegramPollingSession", () => {
         1_999,
       ),
     ).toBe(0);
+    expect(
+      pollingSessionTesting.resolveSpooledUpdateRetryDelayMs(
+        {
+          updateId: 44,
+          path: "/tmp/44.json",
+          update: { update_id: 44 },
+          receivedAt: 0,
+          attempts: pollingSessionTesting.spooledRetryMaxAttempts,
+          lastAttemptAt: 1_000,
+          lastError: "state store outage",
+        },
+        1_999,
+      ),
+    ).toBeGreaterThan(0);
+  });
+
+  it("keeps generic retryable failures pending until they are old enough to dead-letter", () => {
+    const update = {
+      updateId: 42,
+      path: "/tmp/42.json",
+      update: { update_id: 42 },
+      receivedAt: 1_000,
+      attempts: pollingSessionTesting.spooledRetryMaxAttempts - 1,
+      lastAttemptAt: 2_000,
+      lastError: "state store outage",
+    };
+
+    expect(
+      pollingSessionTesting.shouldDeadLetterRetryableSpooledUpdate(
+        update,
+        pollingSessionTesting.spooledRetryMaxAttempts,
+        1_000 + pollingSessionTesting.spooledRetryDeadLetterMinAgeMs - 1,
+      ),
+    ).toBe(false);
+    expect(
+      pollingSessionTesting.shouldDeadLetterRetryableSpooledUpdate(
+        update,
+        pollingSessionTesting.spooledRetryMaxAttempts,
+        1_000 + pollingSessionTesting.spooledRetryDeadLetterMinAgeMs,
+      ),
+    ).toBe(true);
   });
 
   it("does not call getUpdates for offset confirmation (avoiding 409 conflicts)", async () => {
@@ -2093,10 +2135,13 @@ describe("TelegramPollingSession", () => {
         const log = vi.fn();
         const events: string[] = [];
         let poisonAttempts = 0;
-        await writeSpooledTestUpdates(tempDir, [
-          topicUpdate(42, 10, "poison"),
-          topicUpdate(44, 10, "after poison"),
-        ]);
+        await writeSpooledTestUpdates(
+          tempDir,
+          [topicUpdate(42, 10, "poison"), topicUpdate(44, 10, "after poison")],
+          {
+            now: Date.now() - pollingSessionTesting.spooledRetryDeadLetterMinAgeMs,
+          },
+        );
 
         const { runPromise, stopWorker } = startIsolatedIngressSession({
           abort,

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -135,14 +135,14 @@ const TELEGRAM_SPOOLED_DRAIN_START_LIMIT = 100;
 const TELEGRAM_SPOOLED_DRAIN_SCAN_LIMIT = TELEGRAM_SPOOLED_DRAIN_START_LIMIT * 10;
 const TELEGRAM_SPOOLED_CLAIM_REFRESH_INTERVAL_MS = 5 * 60 * 1000;
 const TELEGRAM_SPOOLED_CLAIM_HEALTH_GRACE_MS = 2 * TELEGRAM_SPOOLED_CLAIM_REFRESH_INTERVAL_MS;
-const TELEGRAM_SPOOLED_SESSION_INIT_CONFLICT_RETRY_BASE_MS = 5_000;
-const TELEGRAM_SPOOLED_SESSION_INIT_CONFLICT_RETRY_MAX_MS = 60_000;
+const TELEGRAM_SPOOLED_RETRY_MAX_ATTEMPTS = 8;
+const TELEGRAM_SPOOLED_RETRY_BASE_MS = 1_000;
+const TELEGRAM_SPOOLED_RETRY_MAX_MS = 3 * 60_000;
 const TELEGRAM_POLLING_CLIENT_TIMEOUT_FLOOR_SECONDS = Math.ceil(
   TELEGRAM_GET_UPDATES_REQUEST_TIMEOUT_MS / 1000,
 );
 const MISSING_AGENT_HARNESS_ERROR_NAME = "MissingAgentHarnessError";
 const MISSING_AGENT_HARNESS_MESSAGE_RE = /Requested agent harness "[^"]+" is not registered\./u;
-const REPLY_SESSION_INIT_CONFLICT_MESSAGE_RE = /reply session initialization conflicted for \S+/u;
 
 function normalizeTelegramAccountId(accountId?: string | null): string {
   return accountId?.trim() || "default";
@@ -180,18 +180,22 @@ function resolveSpooledUpdateRetryDelayMs(update: TelegramSpooledUpdate, now = D
   const attempts = update.attempts ?? 0;
   if (
     !update.lastError ||
-    !REPLY_SESSION_INIT_CONFLICT_MESSAGE_RE.test(update.lastError) ||
     update.lastAttemptAt === undefined ||
-    attempts <= 0
+    attempts <= 0 ||
+    attempts >= TELEGRAM_SPOOLED_RETRY_MAX_ATTEMPTS
   ) {
     return 0;
   }
   const exponent = Math.min(attempts - 1, 8);
   const delayMs = Math.min(
-    TELEGRAM_SPOOLED_SESSION_INIT_CONFLICT_RETRY_MAX_MS,
-    TELEGRAM_SPOOLED_SESSION_INIT_CONFLICT_RETRY_BASE_MS * 2 ** exponent,
+    TELEGRAM_SPOOLED_RETRY_MAX_MS,
+    TELEGRAM_SPOOLED_RETRY_BASE_MS * 2 ** exponent,
   );
   return Math.max(0, update.lastAttemptAt + delayMs - now);
+}
+
+function resolveSpooledUpdateAttemptNumber(update: TelegramSpooledUpdate): number {
+  return (update.attempts ?? 0) + 1;
 }
 
 type TelegramBot = ReturnType<typeof createTelegramBot>;
@@ -813,6 +817,7 @@ export class TelegramPollingSession {
     err: unknown;
     update: ClaimedTelegramSpooledUpdate;
   }): Promise<void> {
+    const laneKey = this.#spooledUpdateLaneKey(params.update);
     const nonRetryable = resolveNonRetryableSpooledUpdateFailure(params.err);
     if (nonRetryable) {
       try {
@@ -837,6 +842,33 @@ export class TelegramPollingSession {
         );
       }
     }
+    const attempt = resolveSpooledUpdateAttemptNumber(params.update);
+    if (attempt >= TELEGRAM_SPOOLED_RETRY_MAX_ATTEMPTS) {
+      const message = formatErrorMessage(params.err);
+      try {
+        const failed = await failTelegramSpooledUpdateClaim({
+          update: params.update,
+          reason: "retry-limit-exceeded",
+          message,
+        });
+        if (!failed) {
+          this.opts.log(
+            `[telegram][diag] spooled update ${params.update.updateId} on lane ${laneKey} reached retry limit, but no processing marker remained to dead-letter.`,
+          );
+          return;
+        }
+        // Retryable poison updates must eventually become tombstones so the
+        // lowest update id stops blocking every later turn in the same lane.
+        this.opts.log(
+          `[telegram][warn] spooled update ${params.update.updateId} on lane ${laneKey} reached retry limit after ${attempt} attempts; dead-lettered: ${message}`,
+        );
+        return;
+      } catch (failErr) {
+        this.opts.log(
+          `[telegram][diag] spooled update ${params.update.updateId} on lane ${laneKey} reached retry limit, but could not be dead-lettered: ${formatErrorMessage(failErr)}`,
+        );
+      }
+    }
     try {
       await releaseTelegramSpooledUpdateClaim(params.update, {
         lastError: formatErrorMessage(params.err),
@@ -848,7 +880,7 @@ export class TelegramPollingSession {
       return;
     }
     this.opts.log(
-      `[telegram][diag] spooled update ${params.update.updateId} failed; keeping for retry: ${formatErrorMessage(params.err)}`,
+      `[telegram][diag] spooled update ${params.update.updateId} failed; keeping for retry attempt ${attempt + 1}/${TELEGRAM_SPOOLED_RETRY_MAX_ATTEMPTS}: ${formatErrorMessage(params.err)}`,
     );
   }
 
@@ -933,6 +965,8 @@ export class TelegramPollingSession {
       if (activeSpooledUpdateHandlersByLane.has(handlerKey)) {
         blockedByLane.add(handlerKey);
       }
+      // Release increments attempts and stamps lastAttemptAt. The drain blocks
+      // that lane until the retry window expires so poison rows cannot hot-loop.
       if (resolveSpooledUpdateRetryDelayMs(update) > 0) {
         retryDelayedLaneKeys.add(laneKey);
       }
@@ -1682,6 +1716,7 @@ export const testing = {
   resetTelegramRestartBackoffState,
   resolveTelegramRestartDelayMs,
   resolveSpooledUpdateRetryDelayMs,
+  spooledRetryMaxAttempts: TELEGRAM_SPOOLED_RETRY_MAX_ATTEMPTS,
   isolatedIngressBacklogStallMs: ISOLATED_INGRESS_BACKLOG_STALL_MS,
   spooledClaimRefreshIntervalMs: TELEGRAM_SPOOLED_CLAIM_REFRESH_INTERVAL_MS,
   resolveSpooledUpdateHandlerAbortGraceMs: (valueMs: unknown): number =>

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -138,6 +138,7 @@ const TELEGRAM_SPOOLED_CLAIM_HEALTH_GRACE_MS = 2 * TELEGRAM_SPOOLED_CLAIM_REFRES
 const TELEGRAM_SPOOLED_RETRY_MAX_ATTEMPTS = 8;
 const TELEGRAM_SPOOLED_RETRY_BASE_MS = 1_000;
 const TELEGRAM_SPOOLED_RETRY_MAX_MS = 3 * 60_000;
+const TELEGRAM_SPOOLED_RETRY_DEAD_LETTER_MIN_AGE_MS = 24 * 60 * 60 * 1000;
 const TELEGRAM_POLLING_CLIENT_TIMEOUT_FLOOR_SECONDS = Math.ceil(
   TELEGRAM_GET_UPDATES_REQUEST_TIMEOUT_MS / 1000,
 );
@@ -178,12 +179,7 @@ function resolveNonRetryableSpooledUpdateFailure(
 
 function resolveSpooledUpdateRetryDelayMs(update: TelegramSpooledUpdate, now = Date.now()): number {
   const attempts = update.attempts ?? 0;
-  if (
-    !update.lastError ||
-    update.lastAttemptAt === undefined ||
-    attempts <= 0 ||
-    attempts >= TELEGRAM_SPOOLED_RETRY_MAX_ATTEMPTS
-  ) {
+  if (!update.lastError || update.lastAttemptAt === undefined || attempts <= 0) {
     return 0;
   }
   const exponent = Math.min(attempts - 1, 8);
@@ -196,6 +192,17 @@ function resolveSpooledUpdateRetryDelayMs(update: TelegramSpooledUpdate, now = D
 
 function resolveSpooledUpdateAttemptNumber(update: TelegramSpooledUpdate): number {
   return (update.attempts ?? 0) + 1;
+}
+
+function shouldDeadLetterRetryableSpooledUpdate(
+  update: TelegramSpooledUpdate,
+  attempt: number,
+  now = Date.now(),
+): boolean {
+  return (
+    attempt >= TELEGRAM_SPOOLED_RETRY_MAX_ATTEMPTS &&
+    now - update.receivedAt >= TELEGRAM_SPOOLED_RETRY_DEAD_LETTER_MIN_AGE_MS
+  );
 }
 
 type TelegramBot = ReturnType<typeof createTelegramBot>;
@@ -843,7 +850,7 @@ export class TelegramPollingSession {
       }
     }
     const attempt = resolveSpooledUpdateAttemptNumber(params.update);
-    if (attempt >= TELEGRAM_SPOOLED_RETRY_MAX_ATTEMPTS) {
+    if (shouldDeadLetterRetryableSpooledUpdate(params.update, attempt)) {
       const message = formatErrorMessage(params.err);
       try {
         const failed = await failTelegramSpooledUpdateClaim({
@@ -857,8 +864,8 @@ export class TelegramPollingSession {
           );
           return;
         }
-        // Retryable poison updates must eventually become tombstones so the
-        // lowest update id stops blocking every later turn in the same lane.
+        // Retryable poison updates must eventually become tombstones, but not
+        // during ordinary transient provider or state-store outages.
         this.opts.log(
           `[telegram][warn] spooled update ${params.update.updateId} on lane ${laneKey} reached retry limit after ${attempt} attempts; dead-lettered: ${message}`,
         );
@@ -1718,7 +1725,9 @@ export const testing = {
   resetTelegramRestartBackoffState,
   resolveTelegramRestartDelayMs,
   resolveSpooledUpdateRetryDelayMs,
+  shouldDeadLetterRetryableSpooledUpdate,
   spooledRetryMaxAttempts: TELEGRAM_SPOOLED_RETRY_MAX_ATTEMPTS,
+  spooledRetryDeadLetterMinAgeMs: TELEGRAM_SPOOLED_RETRY_DEAD_LETTER_MIN_AGE_MS,
   isolatedIngressBacklogStallMs: ISOLATED_INGRESS_BACKLOG_STALL_MS,
   spooledClaimRefreshIntervalMs: TELEGRAM_SPOOLED_CLAIM_REFRESH_INTERVAL_MS,
   resolveSpooledUpdateHandlerAbortGraceMs: (valueMs: unknown): number =>

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -35,7 +35,7 @@ import { TELEGRAM_GET_UPDATES_REQUEST_TIMEOUT_MS } from "./request-timeouts.js";
 import { getTelegramSequentialKey } from "./sequential-key.js";
 import {
   claimNextTelegramSpooledUpdate,
-  deleteTelegramSpooledUpdate,
+  completeTelegramSpooledUpdate,
   failTelegramSpooledUpdateClaim,
   isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess,
   listTelegramSpooledUpdateClaims,
@@ -689,7 +689,7 @@ export class TelegramPollingSession {
     }
     try {
       params.stopClaimRefresh();
-      await deleteTelegramSpooledUpdate(params.update);
+      await completeTelegramSpooledUpdate(params.update);
       return true;
     } catch (err) {
       this.opts.log(
@@ -740,7 +740,7 @@ export class TelegramPollingSession {
         return;
       }
       try {
-        await deleteTelegramSpooledUpdate(params.update);
+        await completeTelegramSpooledUpdate(params.update);
       } catch (err) {
         this.opts.log(
           `[telegram][diag] spooled update ${params.update.updateId} completed after buffered processing but processing marker cleanup failed: ${formatErrorMessage(err)}`,
@@ -1399,7 +1399,9 @@ export class TelegramPollingSession {
         drainActive = false;
         if (drainRequested && !restartRequested && !this.opts.abortSignal?.aborted) {
           drainRequested = false;
-          void drainOnce();
+          // Handler finalizers clear active lane guards in microtasks; redrain
+          // after them so newly unblocked same-lane rows can claim immediately.
+          void Promise.resolve().then(drainOnce);
         }
       }
     };

--- a/extensions/telegram/src/telegram-ingress-spool.test.ts
+++ b/extensions/telegram/src/telegram-ingress-spool.test.ts
@@ -12,7 +12,7 @@ import type { TelegramRuntime } from "./runtime.types.js";
 import {
   claimNextTelegramSpooledUpdate,
   claimTelegramSpooledUpdate,
-  deleteTelegramSpooledUpdate,
+  completeTelegramSpooledUpdate,
   failTelegramSpooledUpdateClaim,
   isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess,
   listTelegramSpooledUpdateClaims,
@@ -55,7 +55,7 @@ describe("Telegram ingress spool", () => {
     closeOpenClawStateDatabaseForTest();
   });
 
-  it("persists updates durably in update_id order and deletes handled entries", async () => {
+  it("persists updates durably in update_id order and tombstones handled entries", async () => {
     await withTempSpool(async (spoolDir) => {
       await writeTelegramSpooledUpdate({
         spoolDir,
@@ -77,8 +77,17 @@ describe("Telegram ingress spool", () => {
       if (!updates[0]) {
         throw new Error("Expected a spooled update");
       }
-      await deleteTelegramSpooledUpdate(updates[0]);
+      await completeTelegramSpooledUpdate(updates[0]);
 
+      expect(
+        (await listTelegramSpooledUpdates({ spoolDir })).map((update) => update.updateId),
+      ).toEqual([11]);
+
+      await writeTelegramSpooledUpdate({
+        spoolDir,
+        update: { update_id: 10, message: { text: "refetched first" } },
+        now: 3,
+      });
       expect(
         (await listTelegramSpooledUpdates({ spoolDir })).map((update) => update.updateId),
       ).toEqual([11]);
@@ -114,8 +123,14 @@ describe("Telegram ingress spool", () => {
       if (!claimed) {
         throw new Error("Expected a claimed update");
       }
-      await deleteTelegramSpooledUpdate(claimed);
+      await completeTelegramSpooledUpdate(claimed);
       expect(await listTelegramSpooledUpdateClaims({ spoolDir })).toEqual([]);
+
+      await writeTelegramSpooledUpdate({
+        spoolDir,
+        update: { update_id: 20, message: { text: "refetched handled update" } },
+      });
+      expect(await listTelegramSpooledUpdates({ spoolDir })).toEqual([]);
     });
   });
 
@@ -332,7 +347,7 @@ describe("Telegram ingress spool", () => {
       if (!update) {
         throw new Error("Expected a spooled update");
       }
-      await deleteTelegramSpooledUpdate(update);
+      await completeTelegramSpooledUpdate(update);
 
       await expect(claimTelegramSpooledUpdate(update)).resolves.toBeNull();
       expect(await listTelegramSpooledUpdates({ spoolDir })).toEqual([]);

--- a/extensions/telegram/src/telegram-ingress-spool.ts
+++ b/extensions/telegram/src/telegram-ingress-spool.ts
@@ -20,6 +20,8 @@ export const TELEGRAM_SPOOLED_UPDATE_PROCESSING_STALE_MS = 6 * 60 * 60 * 1000;
 export const TELEGRAM_SPOOLED_UPDATE_CLAIM_LEASE_MS = 30 * 60 * 1000;
 const TELEGRAM_SPOOLED_UPDATE_FAILED_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 const TELEGRAM_SPOOLED_UPDATE_FAILED_MAX_ENTRIES = 1000;
+const TELEGRAM_SPOOLED_UPDATE_COMPLETED_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+const TELEGRAM_SPOOLED_UPDATE_COMPLETED_MAX_ENTRIES = 1000;
 const TELEGRAM_SPOOLED_UPDATE_PROCESS_ID = `${process.pid}:${randomUUID()}`;
 
 type TelegramSpooledUpdateClaimOwner = {
@@ -131,6 +133,8 @@ async function pruneTelegramIngressQueue(
   now?: number,
 ): Promise<void> {
   await queue.prune({
+    completedTtlMs: TELEGRAM_SPOOLED_UPDATE_COMPLETED_TTL_MS,
+    completedMaxEntries: TELEGRAM_SPOOLED_UPDATE_COMPLETED_MAX_ENTRIES,
     failedTtlMs: TELEGRAM_SPOOLED_UPDATE_FAILED_TTL_MS,
     failedMaxEntries: TELEGRAM_SPOOLED_UPDATE_FAILED_MAX_ENTRIES,
     ...(now === undefined ? {} : { now }),
@@ -284,8 +288,11 @@ export async function listTelegramSpooledUpdates(params: {
   );
 }
 
-export async function deleteTelegramSpooledUpdate(update: TelegramSpooledUpdate): Promise<void> {
-  await createTelegramIngressQueue(path.dirname(update.path)).delete(queueMutationTarget(update));
+export async function completeTelegramSpooledUpdate(update: TelegramSpooledUpdate): Promise<void> {
+  const queue = createTelegramIngressQueue(path.dirname(update.path));
+  // Successful rows stay as bounded tombstones: Telegram can refetch an update
+  // after dispatch, and callbacks have side effects that plain delete would rerun.
+  await queue.complete(queueMutationTarget(update));
 }
 
 export async function claimTelegramSpooledUpdate(


### PR DESCRIPTION
Closes #98774

## What Problem This Solves

Fixes an issue where a Telegram spooled update that keeps failing would retry every ~500ms forever with no backoff and no attempts cap — and because the spool drain claims the lowest update id per conversation lane, the poison row permanently blocked every later message in that chat/topic. Two directly associated spool defects are fixed with it: a transient store read error during restart replay silently deleted the spooled message (the same loss window #98076 closed for media, still open for store reads), and successfully processed rows were deleted instead of tombstoned, so a crash-window Telegram refetch could re-dispatch an already-processed update — including re-executing callback-query side effects.

## Why This Change Was Made

Three commits, in dependency order. First, the one-off session-init-conflict backoff (from `13ecca5408c`) is generalized: all retryable spooled failures now back off exponentially from the queue's persisted `attempts`/`lastAttemptAt` (1s base, 3m cap) and dead-letter to the existing `failed` tombstones after 8 attempts, unblocking the lane. Second, `TelegramPairingStoreReadError` in the inbound handler now records a `failed-retryable` result so spooled replays are requeued instead of deleted; the user-facing "please try again" apology is suppressed for replays (they retry durably) and kept for live updates (acked without retry). Third, the success path uses the ingress queue's `complete()` tombstones (30d/1000 retention, pruned on the existing enqueue-side prune) so enqueue-time duplicate detection absorbs refetches; a redrain-ordering fix ensures lane guards clear before a requested immediate redrain.

## User Impact

One malformed or persistently failing message can no longer silently freeze an entire Telegram chat or topic — it retries with backoff, then dead-letters with a warning log operators can find. Messages that hit transient store errors during a gateway restart are retried instead of lost, without apology spam. Buttons and commands no longer risk double-execution after a crash-window refetch.

## Evidence

- Regression tests added: dead-letter after max attempts unblocks the lane and later updates in the same lane process (`polling-session.test.ts`, 72 pass); transient pairing-store error on spooled replay requeues instead of deleting, with no repeated apologies (`bot.create-telegram-bot.test.ts`, 113 pass); completed-then-refetched update is detected as duplicate and not re-dispatched, at both queue and drain level (`telegram-ingress-spool.test.ts`, 14 pass).
- Validation: `pnpm tsgo:extensions` pass; `node scripts/run-oxlint.mjs` on touched files pass; repo autoreview (branch mode vs `origin/main`) clean.
- Combined-merge validation with the sibling PR (`codex/fix-telegram-cache-transport`): conflict-free octopus merge, `pnpm tsgo:extensions` pass, 403/403 tests across all six touched test files.
- Constants chosen: max attempts 8, retry base 1s, retry cap 3m, completed tombstone TTL 30d / max 1000 (matching the existing `failed` tombstone bounds).
