### PR TITLE
fix: use copyToClipboard helper in copyChatWorkspacePath (fixes #98759)

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -37,6 +37,7 @@ import {
   resolvePreferredSessionForAgent,
 } from "./chat/session-controls.ts";
 import { clearChatMessagesFromCache } from "./chat/session-message-cache.ts";
+import { copyToClipboard } from "./chat/clipboard.ts";
 import {
   controlUiNowMs,
   recordControlUiRenderTiming,
@@ -2247,7 +2248,7 @@ export function renderApp(state: AppViewState) {
     }, 160);
   };
   const copyChatWorkspacePath = (filePath: string) => {
-    void globalThis.navigator?.clipboard?.writeText?.(filePath);
+    void copyToClipboard(filePath);
   };
   function loadChatWorkspaceFiles(opts?: { force?: boolean }) {
     if (!state.client || !state.connected) {


### PR DESCRIPTION
## Summary

Fixes the workspace files panel "Copy Path" button doing nothing on plain-HTTP deployments.

Closes #98759

## Root cause

`copyChatWorkspacePath` called `globalThis.navigator?.clipboard?.writeText?.(filePath)` directly. This silently fails in two scenarios:

1. **Non-secure HTTP contexts** (e.g. `http://openclaw.local` via nginx-proxy-manager) — `navigator.clipboard` is `undefined` and the optional chain swallows the no-op silently.
2. **Minifier symbol collision** — in the production bundle the function was compiled to call `wN(p)` (the token-counter helper) instead of the clipboard writer (`zN`), because the minifier resolved the function-name mangling to the wrong symbol.

## Fix

Replace the bare `navigator.clipboard.writeText` call with the shared `copyToClipboard` helper that already exists in `ui/src/ui/chat/clipboard.ts`. The helper:

- Tries `navigator.clipboard.writeText` first (works in HTTPS / localhost)
- Falls back to `document.execCommand('copy')` via a temporary off-screen textarea (works over plain HTTP)
- Has a stable export name that the minifier cannot collide with

### Changes

**`ui/src/ui/app-render.ts`**

```ts
// Before
import { clearChatMessagesFromCache } from "./chat/session-message-cache.ts";

const copyChatWorkspacePath = (filePath: string) => {
  void globalThis.navigator?.clipboard?.writeText?.(filePath);
};

// After
import { clearChatMessagesFromCache } from "./chat/session-message-cache.ts";
import { copyToClipboard } from "./chat/clipboard.ts";

const copyChatWorkspacePath = (filePath: string) => {
  void copyToClipboard(filePath);
};
```

## Testing

- Verified the "Copy Path" button works correctly on an `http://openclaw.local` deployment (nginx-proxy-manager, no HTTPS) after applying this fix.
- The local bundle patch (`wN→zN`) that was the prior workaround is no longer needed once this source fix is rebuilt.

## Related

- Issue: #98759
- The same pattern could be applied to `copyDreamingArchivePath` in `controllers/dreaming.ts` (also uses bare `navigator.clipboard.writeText`) but that is a separate issue and not changed here to keep this PR focused.