### PR TITLE
fix(codex): preserve allowlisted fallback tools

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -227,6 +227,23 @@ describe("Codex app-server dynamic tool build", () => {
     ]);
   });
 
+  it("preserves explicitly allowlisted OpenClaw fallback tools when Codex native tools are unavailable", () => {
+    const tools = ["read", "write", "exec", "process", "update_plan", "tool_search", "message"].map(
+      (name) => ({ name }),
+    );
+
+    expect(
+      filterCodexDynamicTools(tools, {}, process.env, {
+        preserveExplicitFallbackToolNames: ["exec", "read", "update_plan", "tool_search"],
+      }).map((tool) => tool.name),
+    ).toEqual(["read", "exec", "update_plan", "message"]);
+    expect(
+      filterCodexDynamicTools(tools, { codexDynamicToolsExclude: ["exec"] }, process.env, {
+        preserveExplicitFallbackToolNames: ["exec", "read"],
+      }).map((tool) => tool.name),
+    ).toEqual(["read", "message"]);
+  });
+
   it("removes managed web_search when domain-restricted Codex hosted search is active", async () => {
     const workspaceDir = path.join(tempDir, "workspace");
     const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
@@ -815,6 +832,28 @@ describe("Codex app-server dynamic tool build", () => {
     expect(tools.find((tool) => tool.name === "sandbox_exec")?.description).toContain(
       "Docker container-path bind layout",
     );
+  });
+
+  it("exposes explicitly allowlisted OpenClaw shell and file tools when Codex native surface is disabled", async () => {
+    setOpenClawCodingToolsFactoryForTests(() => [
+      createRuntimeDynamicTool("exec"),
+      createRuntimeDynamicTool("read"),
+      createRuntimeDynamicTool("write"),
+      createRuntimeDynamicTool("web_search"),
+      createRuntimeDynamicTool("message"),
+    ]);
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(sessionFile, workspaceDir);
+    params.disableTools = false;
+    params.runtimePlan = createCodexRuntimePlanFixture();
+    params.toolsAllow = ["exec", "read", "write"];
+
+    const tools = await buildDynamicToolsForTest(params, workspaceDir, {
+      nativeToolSurfaceEnabled: false,
+    });
+
+    expect(tools.map((tool) => tool.name)).toEqual(["exec", "read", "write"]);
   });
 
   it("does not expose sandbox shell tools when sandbox routing is disabled", async () => {

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -328,11 +328,16 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
     nativeProviderWebSearchSupport: input.nativeProviderWebSearchSupport,
   });
   const readableAllTools = [...readableAllToolProjection.tools];
+  const toolsAllow = includeForcedCodexDynamicToolAllow(params.toolsAllow, messagePolicyParams);
+  const preserveExplicitFallbackToolNames =
+    input.nativeToolSurfaceEnabled === false ? toolsAllow : undefined;
   const codexFilteredTools = addNodeShellDynamicToolsIfNeeded(
     addSandboxShellDynamicToolsIfAvailable(
       isCodexMemoryFlushRun(params)
         ? filterCodexMemoryFlushDynamicTools(readableAllTools)
-        : filterCodexDynamicTools(readableAllTools, input.pluginConfig),
+        : filterCodexDynamicTools(readableAllTools, input.pluginConfig, process.env, {
+            preserveExplicitFallbackToolNames,
+          }),
       readableAllTools,
       input,
     ),
@@ -380,7 +385,6 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
         transientWebSearchRestriction &&
         webSearchPolicy.persistentAllowed),
   );
-  const toolsAllow = includeForcedCodexDynamicToolAllow(params.toolsAllow, messagePolicyParams);
   const filteredTools = filterCodexDynamicToolsForAllowlist(visionFilteredTools, toolsAllow);
   toolBuildStages.mark("allowlist-filter");
   const normalizedTools = normalizeAgentRuntimeTools({

--- a/extensions/codex/src/app-server/dynamic-tool-profile.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-profile.ts
@@ -22,6 +22,16 @@ export const CODEX_APP_SERVER_OWNED_DYNAMIC_TOOL_EXCLUDES = [
   "tool_search_code",
 ] as const;
 
+const CODEX_DYNAMIC_OPENCLAW_FALLBACK_TOOL_NAMES = new Set<string>([
+  "read",
+  "write",
+  "edit",
+  "apply_patch",
+  "exec",
+  "process",
+  "update_plan",
+]);
+
 const DYNAMIC_TOOL_NAME_ALIASES: Record<string, string> = {
   bash: "exec",
   "apply-patch": "apply_patch",
@@ -104,20 +114,36 @@ export function filterCodexDynamicTools<T extends { name: string }>(
   tools: T[],
   config: Pick<CodexPluginConfig, "codexDynamicToolsExclude">,
   env: CodexDynamicToolProfileEnv = process.env,
+  options: { preserveExplicitFallbackToolNames?: readonly string[] } = {},
 ): T[] {
-  const excludes = new Set<string>();
+  const defaultExcludes = new Set<string>();
   if (!isForcedPrivateQaCodexRuntime(env)) {
     for (const name of CODEX_APP_SERVER_OWNED_DYNAMIC_TOOL_EXCLUDES) {
-      excludes.add(name);
+      defaultExcludes.add(name);
     }
   }
+  const explicitExcludes = new Set<string>();
   for (const name of config.codexDynamicToolsExclude ?? []) {
     const trimmed = normalizeCodexDynamicToolName(name);
     if (trimmed) {
-      excludes.add(trimmed);
+      explicitExcludes.add(trimmed);
     }
   }
-  return excludes.size === 0
+  const preservedFallbackTools = new Set(
+    (options.preserveExplicitFallbackToolNames ?? [])
+      .map((name) => normalizeCodexDynamicToolName(name))
+      .filter((name) => CODEX_DYNAMIC_OPENCLAW_FALLBACK_TOOL_NAMES.has(name)),
+  );
+  return defaultExcludes.size === 0 && explicitExcludes.size === 0
     ? tools
-    : tools.filter((tool) => !excludes.has(normalizeCodexDynamicToolName(tool.name)));
+    : tools.filter((tool) => {
+        const normalized = normalizeCodexDynamicToolName(tool.name);
+        if (explicitExcludes.has(normalized)) {
+          return false;
+        }
+        if (preservedFallbackTools.has(normalized)) {
+          return true;
+        }
+        return !defaultExcludes.has(normalized);
+      });
 }


### PR DESCRIPTION
## Summary

Fixes the restricted `toolsAllow` gap for Codex app-server dynamic tools.

When a run uses a narrow `toolsAllow`, the Codex native tool surface is disabled fail-closed. However, the dynamic tool profile still filtered OpenClaw fallback tools such as `exec`, `read`, and `write` as app-server-owned names. The combination can leave the run without either native or fallback shell/file tools.

This patch preserves a limited set of explicitly allowlisted OpenClaw fallback tools only when the Codex native tool surface is unavailable. Explicit `codexDynamicToolsExclude` entries still win.

## Scope boundary

This PR is intentionally the narrow fallback-preservation slice for explicit allowlists where the Codex native tool surface is unavailable but OpenClaw fallback dynamic tools were also filtered out.

It is not intended to be the umbrella fix for every cron/watchdog tool-surface failure. Adjacent work already covers those lanes:
- #84709 covers fail-closed behavior when cron declares required tools but they are unavailable.
- #92294 covers the direct/no-Codex-environment shell branch where OpenClaw `exec` needs to remain available.

Keeping this PR scoped to fallback preservation should avoid duplicating those review surfaces while still fixing the explicit-allowlist gap this patch changes.

## Related issues

Addresses the root cause described in #86423. It also matches the failure shape reported in #84141, #86033, and #86236.

## Behavior addressed

Restricted Codex runs with `toolsAllow` containing shell/file tool names can compile without those requested tools because:

1. narrow `toolsAllow` disables the native Codex app-server tool surface, and
2. the dynamic tool filter still removes same-named OpenClaw fallback tools as native-owned names.

After this patch, if native tools are disabled, explicitly allowed fallback tool names from a small allow-preserve set can survive the native-owned-name filter and then pass through the existing allowlist filter.

## Real setup tested

Local source checkout based on current upstream `main`.

## Exact steps or command run after this patch

```bash
git diff --check
pnpm install --frozen-lockfile
pnpm exec vitest run extensions/codex/src/app-server/dynamic-tool-build.test.ts
```

## Evidence after fix

- `git diff --check` passed.
- The focused test file now includes coverage for:
  - direct dynamic-tool filtering with preserved fallback names;
  - explicit `codexDynamicToolsExclude` still overriding preservation;
  - full dynamic-tool build exposing `exec/read/write` when native surface is disabled and those tools are explicitly allowed.

## Observed result after fix

The local focused Vitest command did not complete under this runner; it repeatedly stopped at build/plugin timing output without a test summary. I stopped the hanging worker processes and am not claiming a local Vitest pass. The added regression tests are included for CI to execute.

## What was not tested

- Full repository test suite was not run locally.
- Focused Vitest did not produce a local pass/fail summary in this environment.
- No production/private deployment details are needed for this PR; the change is covered by the generic source-level regression tests added here.
