### PR TITLE
fix: Telegram durable sends recover from API fallback errors

### DIFF
--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -57,6 +57,7 @@ import {
 
 const VOICE_FORBIDDEN_MARKER = "VOICE_MESSAGES_FORBIDDEN";
 const CAPTION_TOO_LONG_RE = /caption is too long/i;
+const PARSE_ERR_RE = /can't parse entities|parse entities|find end of the entity/i;
 const GrammyErrorCtor: typeof GrammyError | undefined =
   typeof GrammyError === "function" ? GrammyError : undefined;
 
@@ -299,6 +300,10 @@ function isCaptionTooLong(err: unknown): boolean {
   return CAPTION_TOO_LONG_RE.test(formatErrorMessage(err));
 }
 
+function isTelegramHtmlParseError(err: unknown): boolean {
+  return PARSE_ERR_RE.test(formatErrorMessage(err));
+}
+
 function resolveVoiceFallbackText(reply: ReplyPayload): string | undefined {
   if (reply.text?.trim()) {
     return reply.text;
@@ -439,41 +444,64 @@ async function deliverMediaReply(params: {
         silent: params.silent,
       }),
     };
+    const plainMediaParams: Record<string, unknown> = {
+      ...mediaParams,
+      ...(caption ? { caption } : {}),
+    };
+    delete plainMediaParams.parse_mode;
+    const sendMediaWithCaptionFallback = async (
+      operation: string,
+      send: (effectiveParams: Record<string, unknown>) => Promise<{ message_id: number }>,
+      requestParams: Record<string, unknown> = mediaParams,
+      shouldLog?: (err: unknown) => boolean,
+    ) => {
+      const request = (
+        effectiveRequestParams: Record<string, unknown>,
+        requestOperation = operation,
+      ) =>
+        sendTelegramWithThreadFallback({
+          operation: requestOperation,
+          runtime: params.runtime,
+          thread: params.thread,
+          requestParams: effectiveRequestParams,
+          ...(shouldLog ? { shouldLog } : {}),
+          send,
+        });
+      try {
+        return await request(requestParams);
+      } catch (err) {
+        if (
+          requestParams !== mediaParams ||
+          !htmlCaption ||
+          !caption ||
+          !isTelegramHtmlParseError(err)
+        ) {
+          throw err;
+        }
+        logVerbose(`telegram ${operation} caption parse failed; retrying caption as plain text`);
+        return await request(plainMediaParams, `${operation} (plain caption retry)`);
+      }
+    };
     if (isGif) {
-      const result = await sendTelegramWithThreadFallback({
-        operation: "sendAnimation",
-        runtime: params.runtime,
-        thread: params.thread,
-        requestParams: mediaParams,
-        send: (effectiveParams) =>
-          params.bot.api.sendAnimation(params.chatId, file, { ...effectiveParams }),
-      });
+      const result = await sendMediaWithCaptionFallback("sendAnimation", (effectiveParams) =>
+        params.bot.api.sendAnimation(params.chatId, file, { ...effectiveParams }),
+      );
       if (firstDeliveredMessageId == null) {
         firstDeliveredMessageId = result.message_id;
       }
       markDelivered(params.progress);
     } else if (kind === "image") {
-      const result = await sendTelegramWithThreadFallback({
-        operation: "sendPhoto",
-        runtime: params.runtime,
-        thread: params.thread,
-        requestParams: mediaParams,
-        send: (effectiveParams) =>
-          params.bot.api.sendPhoto(params.chatId, file, { ...effectiveParams }),
-      });
+      const result = await sendMediaWithCaptionFallback("sendPhoto", (effectiveParams) =>
+        params.bot.api.sendPhoto(params.chatId, file, { ...effectiveParams }),
+      );
       if (firstDeliveredMessageId == null) {
         firstDeliveredMessageId = result.message_id;
       }
       markDelivered(params.progress);
     } else if (kind === "video") {
-      const result = await sendTelegramWithThreadFallback({
-        operation: "sendVideo",
-        runtime: params.runtime,
-        thread: params.thread,
-        requestParams: mediaParams,
-        send: (effectiveParams) =>
-          params.bot.api.sendVideo(params.chatId, file, { ...effectiveParams }),
-      });
+      const result = await sendMediaWithCaptionFallback("sendVideo", (effectiveParams) =>
+        params.bot.api.sendVideo(params.chatId, file, { ...effectiveParams }),
+      );
       if (firstDeliveredMessageId == null) {
         firstDeliveredMessageId = result.message_id;
       }
@@ -490,15 +518,13 @@ async function deliverMediaReply(params: {
           requestParams: typeof mediaParams,
           shouldLog?: (err: unknown) => boolean,
         ) => {
-          const result = await sendTelegramWithThreadFallback({
-            operation: "sendVoice",
-            runtime: params.runtime,
-            thread: params.thread,
+          const result = await sendMediaWithCaptionFallback(
+            "sendVoice",
+            (effectiveParams) =>
+              params.bot.api.sendVoice(params.chatId, file, { ...effectiveParams }),
             requestParams,
             shouldLog,
-            send: (effectiveParams) =>
-              params.bot.api.sendVoice(params.chatId, file, { ...effectiveParams }),
-          });
+          );
           if (firstDeliveredMessageId == null) {
             firstDeliveredMessageId = result.message_id;
           }
@@ -580,28 +606,18 @@ async function deliverMediaReply(params: {
           throw voiceErr;
         }
       } else {
-        const result = await sendTelegramWithThreadFallback({
-          operation: "sendAudio",
-          runtime: params.runtime,
-          thread: params.thread,
-          requestParams: mediaParams,
-          send: (effectiveParams) =>
-            params.bot.api.sendAudio(params.chatId, file, { ...effectiveParams }),
-        });
+        const result = await sendMediaWithCaptionFallback("sendAudio", (effectiveParams) =>
+          params.bot.api.sendAudio(params.chatId, file, { ...effectiveParams }),
+        );
         if (firstDeliveredMessageId == null) {
           firstDeliveredMessageId = result.message_id;
         }
         markDelivered(params.progress);
       }
     } else {
-      const result = await sendTelegramWithThreadFallback({
-        operation: "sendDocument",
-        runtime: params.runtime,
-        thread: params.thread,
-        requestParams: mediaParams,
-        send: (effectiveParams) =>
-          params.bot.api.sendDocument(params.chatId, file, { ...effectiveParams }),
-      });
+      const result = await sendMediaWithCaptionFallback("sendDocument", (effectiveParams) =>
+        params.bot.api.sendDocument(params.chatId, file, { ...effectiveParams }),
+      );
       if (firstDeliveredMessageId == null) {
         firstDeliveredMessageId = result.message_id;
       }

--- a/extensions/telegram/src/bot/delivery.send.ts
+++ b/extensions/telegram/src/bot/delivery.send.ts
@@ -1,12 +1,17 @@
 // Telegram plugin module implements delivery.send behavior.
 import { type Bot, GrammyError } from "grammy";
 import type { MarkdownTableMode } from "openclaw/plugin-sdk/config-contracts";
-import { createTelegramRetryRunner } from "openclaw/plugin-sdk/retry-runtime";
+import { createRateLimitRetryRunner } from "openclaw/plugin-sdk/retry-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import { withTelegramApiErrorLogging } from "../api-logging.js";
 import { markdownToTelegramHtml, telegramHtmlToPlainTextFallback } from "../format.js";
-import { isSafeToRetrySendError, isTelegramRateLimitError } from "../network-errors.js";
+import {
+  isSafeToRetrySendError,
+  isTelegramRateLimitError,
+  readTelegramRetryAfterMs,
+  TELEGRAM_SEND_RETRY_DEFAULTS,
+} from "../network-errors.js";
 import {
   buildTelegramSendParams,
   getTelegramNativeQuoteReplyMessageId,
@@ -25,7 +30,8 @@ export { buildTelegramSendParams } from "../reply-parameters.js";
 
 const PARSE_ERR_RE = /can't parse entities|parse entities|find end of the entity/i;
 const EMPTY_TEXT_ERR_RE = /message text is empty/i;
-const QUOTE_PARAM_RE = /\bquote not found\b|\bQUOTE_TEXT_INVALID\b|\bquote text invalid\b/i;
+const QUOTE_PARAM_RE =
+  /\bquote not found\b|\bquote text not found\b|\bQUOTE_TEXT_INVALID\b|\bquote text invalid\b/i;
 const RICH_ENTITY_INVALID_RE =
   /RICH_MESSAGE_(?:EMAIL|URL|MENTION|HASHTAG|CASHTAG|BOT_COMMAND|PHONE|BANK_CARD)_INVALID/i;
 const GrammyErrorCtor: typeof GrammyError | undefined =
@@ -39,9 +45,11 @@ function isTelegramQuoteParamError(err: unknown): boolean {
 }
 
 function createTelegramDeliverySendRetry() {
-  return createTelegramRetryRunner({
+  return createRateLimitRetryRunner({
+    defaults: TELEGRAM_SEND_RETRY_DEFAULTS,
+    logLabel: "telegram send",
     shouldRetry: (err) => isSafeToRetrySendError(err) || isTelegramRateLimitError(err),
-    strictShouldRetry: true,
+    retryAfterMs: readTelegramRetryAfterMs,
   });
 }
 

--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -212,6 +212,12 @@ function createRichEntityInvalidError(entity = "EMAIL", operation = "sendRichMes
   );
 }
 
+function createTelegramParseError(operation: string) {
+  return new Error(
+    `GrammyError: Call to '${operation}' failed! (400: Bad Request: can't parse entities: Can't find end of the entity)`,
+  );
+}
+
 function createWrappedPreConnectHttpError(operation = "sendMessage") {
   const root = Object.assign(new Error("getaddrinfo ENOTFOUND api.telegram.org"), {
     code: "ENOTFOUND",
@@ -807,6 +813,35 @@ describe("deliverReplies", () => {
     expectRecordFields(mockCallArg(sendPhoto, 0, 2), {
       caption: "hi <b>boss</b>",
       parse_mode: "HTML",
+    });
+  });
+
+  it("retries media reply captions as plain text when Telegram rejects caption HTML", async () => {
+    const runtime = createRuntime();
+    const sendPhoto = vi
+      .fn()
+      .mockRejectedValueOnce(createTelegramParseError("sendPhoto"))
+      .mockResolvedValueOnce({
+        message_id: 3,
+        chat: { id: "123" },
+      });
+    const bot = createBot({ sendPhoto });
+
+    mockMediaLoad("photo.jpg", "image/jpeg", "image");
+
+    await deliverWith({
+      replies: [{ mediaUrl: "https://example.com/photo.jpg", text: "use `<b>` for bold" }],
+      runtime,
+      bot,
+    });
+
+    expect(sendPhoto).toHaveBeenCalledTimes(2);
+    expectRecordFields(mockCallArg(sendPhoto, 0, 2), {
+      caption: "use <code>&lt;b&gt;</code> for bold",
+      parse_mode: "HTML",
+    });
+    expectRecordFields(mockCallArg(sendPhoto, 1, 2), {
+      caption: "use `<b>` for bold",
     });
   });
 

--- a/extensions/telegram/src/network-errors.ts
+++ b/extensions/telegram/src/network-errors.ts
@@ -9,6 +9,12 @@ import { parseStrictNonNegativeInteger } from "openclaw/plugin-sdk/number-runtim
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 
 const TELEGRAM_NETWORK_ORIGIN = Symbol("openclaw.telegram.network-origin");
+export const TELEGRAM_SEND_RETRY_DEFAULTS = {
+  attempts: 3,
+  minDelayMs: 400,
+  maxDelayMs: 60_000,
+  jitter: 0.1,
+} as const;
 
 const RECOVERABLE_ERROR_CODES = new Set([
   "ECONNRESET",

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -241,6 +241,24 @@ function mockLoadedMedia({
   });
 }
 
+function createTelegramParseError(operation: string): Error {
+  return new Error(
+    `GrammyError: Call to '${operation}' failed! (400: Bad Request: can't parse entities: Can't find end of the entity)`,
+  );
+}
+
+function createTelegramQuoteError(operation: string): Error {
+  return new Error(
+    `GrammyError: Call to '${operation}' failed! (400: Bad Request: quote text not found)`,
+  );
+}
+
+function createTelegramRichEntityInvalidError(entity = "URL"): Error {
+  return new Error(
+    `GrammyError: Call to 'sendRichMessage' failed! (400: Bad Request: RICH_MESSAGE_${entity}_INVALID)`,
+  );
+}
+
 function requireMockCall<T extends unknown[]>(call: T | undefined, label: string): T {
   if (!call) {
     throw new Error(`expected ${label}`);
@@ -996,6 +1014,26 @@ describe("sendMessageTelegram", () => {
       skip_entity_detection: true,
     });
     expect(richMessage?.html).not.toContain("mailto:");
+  });
+
+  it("falls back to plain text when durable rich messages reject invalid entities", async () => {
+    botRawApi.sendRichMessage.mockRejectedValueOnce(createTelegramRichEntityInvalidError("URL"));
+    botApi.sendMessage.mockResolvedValueOnce({ message_id: 46, chat: { id: "123" } });
+    const text = "Status includes https://example.invalid/path";
+
+    await sendMessageTelegram("123", text, {
+      cfg: {
+        channels: {
+          telegram: {
+            richMessages: true,
+          },
+        },
+      },
+      token: "tok",
+    });
+
+    expect(botRawApi.sendRichMessage).toHaveBeenCalledTimes(1);
+    expect(botApi.sendMessage).toHaveBeenCalledWith("123", text);
   });
 
   it.each([
@@ -1834,6 +1872,52 @@ describe("sendMessageTelegram", () => {
     });
   });
 
+  it("retries media captions as plain text when Telegram rejects caption HTML", async () => {
+    const chatId = "123";
+    const caption = "use `<b>` for bold";
+    const sendPhoto = vi
+      .fn()
+      .mockRejectedValueOnce(createTelegramParseError("sendPhoto"))
+      .mockResolvedValueOnce({
+        message_id: 91,
+        chat: { id: chatId },
+      });
+    const api = { sendPhoto } as unknown as {
+      sendPhoto: typeof sendPhoto;
+    };
+
+    mockLoadedMedia({
+      buffer: Buffer.from("fake-image"),
+      contentType: "image/jpeg",
+      fileName: "photo.jpg",
+    });
+
+    await sendMessageTelegram(chatId, caption, {
+      cfg: TELEGRAM_TEST_CFG,
+      token: "tok",
+      api,
+      mediaUrl: "https://example.com/photo.jpg",
+    });
+
+    expectMediaSendCall(
+      firstMockCall(sendPhoto, "send photo html call"),
+      "send photo html call",
+      chatId,
+      {
+        caption: "use <code>&lt;b&gt;</code> for bold",
+        parse_mode: "HTML",
+      },
+    );
+    expectMediaSendCall(
+      mockCall(sendPhoto, 1, "send photo plain call"),
+      "send photo plain call",
+      chatId,
+      {
+        caption,
+      },
+    );
+  });
+
   it("sends video notes when requested and regular videos otherwise", async () => {
     const chatId = "123";
 
@@ -2110,6 +2194,39 @@ describe("sendMessageTelegram", () => {
     await vi.runAllTimersAsync();
     await expect(promise).resolves.toEqual({ messageId: "1", chatId });
     expect(firstMockCall(setTimeoutSpy, "setTimeout call")[1]).toBe(500);
+    setTimeoutSpy.mockRestore();
+    vi.useRealTimers();
+  });
+
+  it("honors Telegram retry_after hints above the generic channel cap", async () => {
+    vi.useFakeTimers();
+    const chatId = "123";
+    const err = Object.assign(new Error("Too Many Requests: retry later"), {
+      error_code: 429,
+      response: { parameters: { retry_after: 45 } },
+    });
+    const sendMessage = vi
+      .fn()
+      .mockRejectedValueOnce(err)
+      .mockResolvedValueOnce({
+        message_id: 1,
+        chat: { id: chatId },
+      });
+    const api = { sendMessage } as unknown as {
+      sendMessage: typeof sendMessage;
+    };
+    const setTimeoutSpy = vi.spyOn(global, "setTimeout");
+
+    const promise = sendMessageTelegram(chatId, "hi", {
+      cfg: TELEGRAM_TEST_CFG,
+      token: "tok",
+      api,
+      retry: { attempts: 2, minDelayMs: 0, jitter: 0 },
+    });
+
+    await vi.runAllTimersAsync();
+    await expect(promise).resolves.toEqual({ messageId: "1", chatId });
+    expect(firstMockCall(setTimeoutSpy, "setTimeout call")[1]).toBe(45_000);
     setTimeoutSpy.mockRestore();
     vi.useRealTimers();
   });
@@ -3425,6 +3542,43 @@ describe("shared send behaviors", () => {
         quote: " quoted text\n",
         allow_sending_without_reply: true,
       },
+    });
+  });
+
+  it("retries durable direct quote sends with legacy reply id when Telegram rejects the quote", async () => {
+    const chatId = "123";
+    const sendMessage = vi
+      .fn()
+      .mockRejectedValueOnce(createTelegramQuoteError("sendMessage"))
+      .mockResolvedValueOnce({
+        message_id: 57,
+        chat: { id: chatId },
+      });
+    const api = { sendMessage } as unknown as {
+      sendMessage: typeof sendMessage;
+    };
+
+    await sendMessageTelegram(chatId, "reply text", {
+      cfg: TELEGRAM_TEST_CFG,
+      token: "tok",
+      api,
+      replyToMessageId: 100,
+      quoteText: "paraphrased quote",
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+    expect(sendMessage).toHaveBeenNthCalledWith(1, chatId, "reply text", {
+      parse_mode: "HTML",
+      reply_parameters: {
+        message_id: 100,
+        quote: "paraphrased quote",
+        allow_sending_without_reply: true,
+      },
+    });
+    expect(sendMessage).toHaveBeenNthCalledWith(2, chatId, "reply text", {
+      parse_mode: "HTML",
+      reply_to_message_id: 100,
+      allow_sending_without_reply: true,
     });
   });
 

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -14,7 +14,11 @@ import { redactSensitiveText } from "openclaw/plugin-sdk/logging-core";
 import { parseStrictInteger } from "openclaw/plugin-sdk/number-runtime";
 import { resolveChunkMode, resolveTextChunkLimit } from "openclaw/plugin-sdk/reply-chunking";
 import { isSingleUseReplyToMode } from "openclaw/plugin-sdk/reply-reference";
-import { createTelegramRetryRunner, type RetryConfig } from "openclaw/plugin-sdk/retry-runtime";
+import {
+  createRateLimitRetryRunner,
+  createTelegramRetryRunner,
+  type RetryConfig,
+} from "openclaw/plugin-sdk/retry-runtime";
 import { createSubsystemLogger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -38,16 +42,21 @@ import {
   isSafeToRetrySendError,
   isTelegramRateLimitError,
   isTelegramServerError,
+  readTelegramRetryAfterMs,
+  TELEGRAM_SEND_RETRY_DEFAULTS,
 } from "./network-errors.js";
 import { recordOutboundMessageForPromptContext } from "./outbound-message-context.js";
 import { makeProxyFetch } from "./proxy.js";
 import {
   buildTelegramThreadReplyParams,
+  getTelegramNativeQuoteReplyMessageId,
+  removeTelegramNativeQuoteParam,
   resolveTelegramSendThreadSpec,
 } from "./reply-parameters.js";
 import {
   buildTelegramRichMessage,
   getTelegramRichRawApi,
+  removeTelegramRichNativeQuoteParam,
   splitTelegramRichMessageTextChunks,
   TELEGRAM_RICH_TEXT_LIMIT,
   toTelegramRichMessageContextParams,
@@ -323,6 +332,10 @@ function resolveAcceptedReplyToMessageId(
 }
 
 const PARSE_ERR_RE = /can't parse entities|parse entities|find end of the entity/i;
+const QUOTE_PARAM_RE =
+  /\bquote not found\b|\bquote text not found\b|\bQUOTE_TEXT_INVALID\b|\bquote text invalid\b/i;
+const RICH_ENTITY_INVALID_RE =
+  /RICH_MESSAGE_(?:EMAIL|URL|MENTION|HASHTAG|CASHTAG|BOT_COMMAND|PHONE|BANK_CARD)_INVALID/i;
 const MESSAGE_NOT_MODIFIED_RE =
   /400:\s*Bad Request:\s*message is not modified|MESSAGE_NOT_MODIFIED/i;
 const MESSAGE_HAS_NO_TEXT_RE = /400:\s*Bad Request:\s*there is no text in the message to edit/i;
@@ -531,6 +544,14 @@ function isTelegramHtmlParseError(err: unknown): boolean {
   return PARSE_ERR_RE.test(formatErrorMessage(err));
 }
 
+function isTelegramQuoteParamError(err: unknown): boolean {
+  return QUOTE_PARAM_RE.test(formatErrorMessage(err));
+}
+
+function isTelegramRichEntityInvalidError(err: unknown): boolean {
+  return RICH_ENTITY_INVALID_RE.test(formatErrorMessage(err));
+}
+
 async function withTelegramHtmlParseFallback<T>(params: {
   label: string;
   verbose?: boolean;
@@ -677,15 +698,35 @@ function createTelegramNonIdempotentRequestWithDiag(params: {
   verbose?: boolean;
   useApiErrorLogging?: boolean;
 }): TelegramRequestWithDiag {
-  return createTelegramRequestWithDiag({
-    cfg: params.cfg,
-    account: params.account,
+  const request = createRateLimitRetryRunner({
     retry: params.retry,
+    configRetry: params.account.config.retry,
     verbose: params.verbose,
-    useApiErrorLogging: params.useApiErrorLogging,
+    defaults: TELEGRAM_SEND_RETRY_DEFAULTS,
+    logLabel: "telegram send",
+    retryAfterMs: readTelegramRetryAfterMs,
     shouldRetry: (err) => isSafeToRetrySendError(err) || isTelegramRateLimitError(err),
-    strictShouldRetry: true,
   });
+  const logHttpError = createTelegramHttpLogger(params.cfg);
+  return <T>(
+    fn: () => Promise<T>,
+    label?: string,
+    options?: { shouldLog?: (err: unknown) => boolean },
+  ) => {
+    const runRequest = () => request(fn, label);
+    const call =
+      params.useApiErrorLogging === false
+        ? runRequest()
+        : withTelegramApiErrorLogging({
+            operation: label ?? "request",
+            fn: runRequest,
+            ...(options?.shouldLog ? { shouldLog: options.shouldLog } : {}),
+          });
+    return call.catch((err: unknown) => {
+      logHttpError(label ?? "request", err);
+      throw err;
+    });
+  };
 }
 
 export async function sendMessageTelegram(
@@ -740,6 +781,41 @@ export async function sendMessageTelegram(
     chatId,
     input: to,
   });
+  const requestWithNativeQuoteFallback = async <
+    T,
+    P extends Record<string, unknown> | undefined,
+  >(params: {
+    label: string;
+    requestParams: P;
+    send: (effectiveParams: P) => Promise<T>;
+    removeNativeQuoteParam?: (requestParams: Record<string, unknown> | undefined) => P;
+  }): Promise<{ result: T; acceptedParams: P }> => {
+    const hasNativeQuote = getTelegramNativeQuoteReplyMessageId(params.requestParams) != null;
+    try {
+      const result = await requestWithChatNotFound(
+        () => params.send(params.requestParams),
+        params.label,
+      );
+      return { result, acceptedParams: params.requestParams };
+    } catch (err) {
+      if (!hasNativeQuote || !isTelegramQuoteParamError(err)) {
+        throw err;
+      }
+      if (opts.verbose) {
+        sendLogger.warn(
+          `telegram ${params.label} native quote rejected; retrying with legacy reply_to_message_id`,
+        );
+      }
+      const retryParams = params.removeNativeQuoteParam
+        ? params.removeNativeQuoteParam(params.requestParams)
+        : (removeTelegramNativeQuoteParam(params.requestParams) as P);
+      const result = await requestWithChatNotFound(
+        () => params.send(retryParams),
+        `${params.label}-legacy-reply`,
+      );
+      return { result, acceptedParams: retryParams };
+    }
+  };
 
   const textMode = opts.textMode ?? "markdown";
   const useRichMessages = account.config.richMessages === true;
@@ -774,31 +850,34 @@ export async function sendMessageTelegram(
       ...(opts.silent === true ? { disable_notification: true } : {}),
     };
     const hasPlainParams = Object.keys(plainParams).length > 0;
+    const effectivePlainParams = hasPlainParams ? plainParams : undefined;
     const requestPlain = (label: string) =>
-      requestWithChatNotFound(
-        () =>
-          hasPlainParams
-            ? api.sendMessage(chatId, chunk.plainText, plainParams)
-            : api.sendMessage(chatId, chunk.plainText),
+      requestWithNativeQuoteFallback({
         label,
-      );
+        requestParams: effectivePlainParams,
+        send: (effectiveParams) =>
+          effectiveParams
+            ? api.sendMessage(chatId, chunk.plainText, effectiveParams)
+            : api.sendMessage(chatId, chunk.plainText),
+      });
     const result = !chunk.htmlText
       ? await requestPlain("message")
       : await withTelegramHtmlParseFallback({
           label: "message",
           verbose: opts.verbose,
           requestHtml: (label) =>
-            requestWithChatNotFound(
-              () =>
+            requestWithNativeQuoteFallback({
+              label,
+              requestParams: plainParams,
+              send: (effectiveParams) =>
                 api.sendMessage(chatId, chunk.htmlText ?? chunk.plainText, {
                   parse_mode: "HTML" as const,
-                  ...plainParams,
+                  ...effectiveParams,
                 }),
-              label,
-            ),
+            }),
           requestPlain,
         });
-    return { result, acceptedParams: params };
+    return result;
   };
 
   const shouldIncludeReplyForChunk = (
@@ -992,19 +1071,41 @@ export async function sendMessageTelegram(
         index === chunks.length - 1,
         options.replyToAlreadyUsed === true,
       );
-      const result = await requestWithChatNotFound(
-        () =>
-          richRawApi.sendRichMessage({
-            chat_id: chatId,
-            rich_message: buildTelegramRichMessage(chunk.text, chunk.textMode, {
-              skipEntityDetection: account.config.linkPreview === false,
-              tableMode,
+      let sendResult: {
+        result: TelegramMessageLike;
+        acceptedParams: TelegramRichMessageContextParams | undefined;
+      };
+      try {
+        sendResult = await requestWithNativeQuoteFallback({
+          label: "richMessage",
+          requestParams: acceptedParams,
+          removeNativeQuoteParam: (requestParams) =>
+            removeTelegramRichNativeQuoteParam(requestParams) as typeof acceptedParams,
+          send: (effectiveParams) =>
+            richRawApi.sendRichMessage({
+              chat_id: chatId,
+              rich_message: buildTelegramRichMessage(chunk.text, chunk.textMode, {
+                skipEntityDetection: account.config.linkPreview === false,
+                tableMode,
+              }),
+              ...effectiveParams,
+              ...(opts.silent === true ? { disable_notification: true } : {}),
             }),
-            ...acceptedParams,
-            ...(opts.silent === true ? { disable_notification: true } : {}),
-          }),
-        "richMessage",
-      );
+        });
+      } catch (err) {
+        if (!isTelegramRichEntityInvalidError(err) || !chunk.plainText.trim()) {
+          throw err;
+        }
+        if (opts.verbose) {
+          sendLogger.warn(
+            `telegram richMessage rejected invalid entity; retrying as plain text: ${formatErrorMessage(
+              err,
+            )}`,
+          );
+        }
+        sendResult = await sendTelegramTextChunk({ plainText: chunk.plainText }, acceptedParams);
+      }
+      const { result, acceptedParams: finalAcceptedParams } = sendResult;
       const messageId = resolveTelegramMessageIdOrThrow(result, context);
       recordSentMessage(chatId, messageId, cfg);
       await recordOutboundMessageForPromptContext({
@@ -1014,14 +1115,14 @@ export async function sendMessageTelegram(
         message: result,
         messageId,
         text: chunk.plainText,
-        ...(acceptedParams?.message_thread_id !== undefined
-          ? { messageThreadId: acceptedParams.message_thread_id }
+        ...(finalAcceptedParams?.message_thread_id !== undefined
+          ? { messageThreadId: finalAcceptedParams.message_thread_id }
           : {}),
       });
       lastMessageId = String(messageId);
       lastChatId = String(result?.chat?.id ?? chatId);
-      lastAcceptedParams = acceptedParams;
-      acceptedReplyToMessageId ??= resolveAcceptedReplyToMessageId(acceptedParams);
+      lastAcceptedParams = finalAcceptedParams;
+      acceptedReplyToMessageId ??= resolveAcceptedReplyToMessageId(finalAcceptedParams);
       messageIds.push(lastMessageId);
       sentChunkCount += 1;
     }
@@ -1122,6 +1223,10 @@ export async function sendMessageTelegram(
       followUpText = split.followUpText;
     }
     const htmlCaption = caption ? renderHtmlText(caption) : undefined;
+    const plainCaption =
+      caption && textMode === "html" && htmlCaption
+        ? telegramHtmlToPlainTextFallback(htmlCaption)
+        : caption;
     // If text exceeds Telegram's caption limit, send media without caption
     // then send text as a separate follow-up message.
     const needsSeparateText = Boolean(followUpText);
@@ -1143,18 +1248,30 @@ export async function sendMessageTelegram(
       ...(opts.silent === true ? { disable_notification: true } : {}),
       ...(videoDimensions ? { width: videoDimensions.width, height: videoDimensions.height } : {}),
     };
+    const plainMediaParams = {
+      ...(plainCaption ? { caption: plainCaption } : {}),
+      ...baseMediaParams,
+      ...(opts.silent === true ? { disable_notification: true } : {}),
+      ...(videoDimensions ? { width: videoDimensions.width, height: videoDimensions.height } : {}),
+    };
     const sendMedia = async (
       label: string,
       sender: (
-        effectiveParams: TelegramThreadScopedParams | undefined,
+        effectiveParams: Record<string, unknown> | undefined,
       ) => Promise<TelegramMessageLike>,
-    ) => await requestWithChatNotFound(() => sender(mediaParams), label);
+      requestParams: Record<string, unknown>,
+    ) =>
+      await requestWithNativeQuoteFallback({
+        label,
+        requestParams,
+        send: sender,
+      });
 
     const mediaSender = (() => {
       if (isGif && deliveryKind !== "document") {
         return {
           label: "animation",
-          sender: (effectiveParams: TelegramThreadScopedParams | undefined) =>
+          sender: (effectiveParams: Record<string, unknown> | undefined) =>
             api.sendAnimation(
               chatId,
               file,
@@ -1165,7 +1282,7 @@ export async function sendMessageTelegram(
       if (deliveryKind === "image" && !isGif && sendImageAsPhoto) {
         return {
           label: "photo",
-          sender: (effectiveParams: TelegramThreadScopedParams | undefined) =>
+          sender: (effectiveParams: Record<string, unknown> | undefined) =>
             api.sendPhoto(
               chatId,
               file,
@@ -1177,7 +1294,7 @@ export async function sendMessageTelegram(
         if (isVideoNote) {
           return {
             label: "video_note",
-            sender: (effectiveParams: TelegramThreadScopedParams | undefined) =>
+            sender: (effectiveParams: Record<string, unknown> | undefined) =>
               api.sendVideoNote(
                 chatId,
                 file,
@@ -1187,7 +1304,7 @@ export async function sendMessageTelegram(
         }
         return {
           label: "video",
-          sender: (effectiveParams: TelegramThreadScopedParams | undefined) =>
+          sender: (effectiveParams: Record<string, unknown> | undefined) =>
             api.sendVideo(
               chatId,
               file,
@@ -1205,7 +1322,7 @@ export async function sendMessageTelegram(
         if (useVoice) {
           return {
             label: "voice",
-            sender: (effectiveParams: TelegramThreadScopedParams | undefined) =>
+            sender: (effectiveParams: Record<string, unknown> | undefined) =>
               api.sendVoice(
                 chatId,
                 file,
@@ -1215,7 +1332,7 @@ export async function sendMessageTelegram(
         }
         return {
           label: "audio",
-          sender: (effectiveParams: TelegramThreadScopedParams | undefined) =>
+          sender: (effectiveParams: Record<string, unknown> | undefined) =>
             api.sendAudio(
               chatId,
               file,
@@ -1225,7 +1342,7 @@ export async function sendMessageTelegram(
       }
       return {
         label: "document",
-        sender: (effectiveParams: TelegramThreadScopedParams | undefined) =>
+        sender: (effectiveParams: Record<string, unknown> | undefined) =>
           api.sendDocument(
             chatId,
             file,
@@ -1236,9 +1353,21 @@ export async function sendMessageTelegram(
       };
     })();
 
-    const result = await sendMedia(mediaSender.label, mediaSender.sender);
+    const mediaSend = htmlCaption
+      ? await withTelegramHtmlParseFallback({
+          label: mediaSender.label,
+          verbose: opts.verbose,
+          requestHtml: (label) => sendMedia(label, mediaSender.sender, mediaParams),
+          requestPlain: (label) => sendMedia(label, mediaSender.sender, plainMediaParams),
+        })
+      : await sendMedia(mediaSender.label, mediaSender.sender, mediaParams);
+    const { result, acceptedParams: acceptedMediaParams } = mediaSend;
     const mediaMessageId = resolveTelegramMessageIdOrThrow(result, "media send");
     const resolvedChatId = String(result?.chat?.id ?? chatId);
+    const acceptedMediaThreadId =
+      typeof acceptedMediaParams.message_thread_id === "number"
+        ? acceptedMediaParams.message_thread_id
+        : undefined;
     recordSentMessage(chatId, mediaMessageId, cfg);
     await recordOutboundMessageForPromptContext({
       cfg,
@@ -1247,9 +1376,7 @@ export async function sendMessageTelegram(
       message: result,
       messageId: mediaMessageId,
       ...(caption ? { text: caption } : {}),
-      ...(mediaParams.message_thread_id !== undefined
-        ? { messageThreadId: mediaParams.message_thread_id }
-        : {}),
+      ...(acceptedMediaThreadId !== undefined ? { messageThreadId: acceptedMediaThreadId } : {}),
     });
     logTelegramOutboundSendOk({
       accountId: account.accountId,
@@ -1260,7 +1387,7 @@ export async function sendMessageTelegram(
         .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
         .join("")}`,
       deliveryKind: mediaSender.label,
-      messageThreadId: mediaParams.message_thread_id,
+      messageThreadId: acceptedMediaThreadId,
       replyToMessageId: opts.replyToMessageId,
       silent: opts.silent,
     });


### PR DESCRIPTION
Closes #98778

## What Problem This Solves

Fixes an issue where Telegram users could lose durable outbound replies when Telegram rejected otherwise recoverable send parameters, such as native quote text, HTML media captions, rich-message entity detection, or rate-limit responses that require waiting longer than the generic channel retry cap.

## Why This Change Was Made

Telegram durable sends now use Telegram send-specific retry defaults, honor Telegram `retry_after` hints, and share the bot delivery fallbacks for native quote rejection and media caption parse failures. Rich-message sends also retry invalid Telegram rich entities as plain text, keeping the fallback inside the Telegram plugin instead of widening core channel behavior.

AI-assisted.

## User Impact

Telegram replies that previously failed at the API boundary now have a bounded recovery path: quote failures retry with legacy reply IDs, malformed caption HTML retries as plain text, invalid rich entities retry as plain text, and Telegram rate-limit hints are respected before the final failure. Users should see fewer dropped Telegram responses in groups, threads, and media replies.

## Evidence

- `node scripts/run-vitest.mjs extensions/telegram/src/send.test.ts extensions/telegram/src/bot/delivery.test.ts` (208 tests passed)
- `node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/telegram`
- `/home/wen/projects/openclaw/node_modules/.bin/oxfmt --write --threads=1 extensions/telegram/src/send.ts`
- `OPENCLAW_BUILD_ALL_NO_PNPM=1 node scripts/build-all.mjs`
- Real local agent turn through the built CLI using `deepseek/deepseek-v4-pro` returned the expected response text (`telegram fallback proof ok`).

Live Telegram round-trip proof was not run because this checkout does not have Telegram bot/chat credentials. The Telegram API rejection cases are covered by focused regression tests at the Telegram send boundaries.

Remaining live proof runbook:

1. Configure a real Telegram bot account and a test chat/thread.
2. Send an agent reply that uses a native quote whose quote text Telegram rejects, and confirm the message still posts using the legacy reply fallback.
3. Send a media reply with caption text that renders invalid Telegram HTML, and confirm the media still posts with a plain caption.
4. Send a rich-message reply containing an entity Telegram rejects, and confirm the visible text still posts as plain text.
5. Attach redacted Telegram/send logs and the posted message screenshots or recording to this PR.

Current CI note: after rebasing onto `6df7db9f`, `check-test-types` fails in `src/cli/attach-cli.action.test.ts`, and the same core test type lane reproduces locally on the rebased branch. This PR's diff against `upstream/main` only touches Telegram files.
