### PR TITLE
fix: guard runtimeModelForCard against non-string model values

### DIFF
--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -783,7 +783,7 @@ export function createSessionStatusTool(opts?: {
         (resolved.entry.providerOverride?.trim() || resolved.entry.modelOverride?.trim()),
       );
       const runtimeProviderForCard = runtimeModelIdentity.provider?.trim();
-      const runtimeModelForCard = runtimeModelIdentity.model.trim();
+      const runtimeModelForCard = typeof runtimeModelIdentity.model === "string" ? runtimeModelIdentity.model.trim() : "";
       const defaultProviderForCard = hasExplicitModelOverride
         ? configured.provider
         : (runtimeProviderForCard ?? "");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `openclaw status` crashes with a TypeError when a session entry's `model` field is a non-string value (e.g., object or number) parsed from session JSON storage.

## Why This Change Was Made

The problematic call `runtimeModelIdentity.model.trim()` assumes `model` is always a string, but at runtime it can be any JSON-deserialized type. A `typeof` guard prevents the crash and safely falls back to an empty string, matching the behaviour of the adjacent `provider?.trim()` call.

## User Impact

Users with session entries that have non-string `model` values (e.g., after upgrading from an older version or restoring from backup with malformed data) will no longer see a crash in `openclaw status`.

## Evidence

- [x] AI-assisted (Claude Code)
- [x] TypeScript `typeof` guard pattern matches existing codebase conventions (see `session-utils.ts:1736` which uses `?.trim()` but only guards null/undefined, not non-string types)

Fixes a class of bug similar to the one described in this codebase where `?.trim()` only guards against null/undefined but not against non-string runtime types.