### PR TITLE
fix(macos): preserve profile env in launch agent

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -4835,7 +4835,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 97,
+      "line": 96,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawSurfaces.kt",
       "source": "Needs attention",
       "surface": "android",

--- a/apps/macos/Sources/OpenClaw/LaunchAgentManager.swift
+++ b/apps/macos/Sources/OpenClaw/LaunchAgentManager.swift
@@ -31,33 +31,39 @@ enum LaunchAgentManager {
     }
 
     static func plistContents(bundlePath: String) -> String {
-        """
-        <?xml version="1.0" encoding="UTF-8"?>
-        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-        <plist version="1.0">
-        <dict>
-          <key>Label</key>
-          <string>ai.openclaw.mac</string>
-          <key>ProgramArguments</key>
-          <array>
-            <string>\(bundlePath)/Contents/MacOS/OpenClaw</string>
-          </array>
-          <key>WorkingDirectory</key>
-          <string>\(FileManager().homeDirectoryForCurrentUser.path)</string>
-          <key>RunAtLoad</key>
-          <true/>
-          <key>EnvironmentVariables</key>
-          <dict>
-            <key>PATH</key>
-            <string>\(CommandResolver.preferredPaths().joined(separator: ":"))</string>
-          </dict>
-          <key>StandardOutPath</key>
-          <string>\(LogLocator.launchdLogPath)</string>
-          <key>StandardErrorPath</key>
-          <string>\(LogLocator.launchdLogPath)</string>
-        </dict>
-        </plist>
-        """
+        let plist: [String: Any] = [
+            "Label": "ai.openclaw.mac",
+            "ProgramArguments": [
+                "\(bundlePath)/Contents/MacOS/OpenClaw",
+            ],
+            "WorkingDirectory": FileManager().homeDirectoryForCurrentUser.path,
+            "RunAtLoad": true,
+            "EnvironmentVariables": self.launchEnvironmentVariables(),
+            "StandardOutPath": LogLocator.launchdLogPath,
+            "StandardErrorPath": LogLocator.launchdLogPath,
+        ]
+        guard
+            let data = try? PropertyListSerialization.data(
+                fromPropertyList: plist,
+                format: .xml,
+                options: 0),
+            let contents = String(data: data, encoding: .utf8)
+        else {
+            return ""
+        }
+        return contents
+    }
+
+    private static func launchEnvironmentVariables() -> [String: String] {
+        var environment = [
+            "PATH": CommandResolver.preferredPaths().joined(separator: ":"),
+        ]
+        for key in ["OPENCLAW_CONFIG_PATH", "OPENCLAW_STATE_DIR"] {
+            if let value = OpenClawEnv.path(key) {
+                environment[key] = value
+            }
+        }
+        return environment
     }
 
     @discardableResult

--- a/apps/macos/Tests/OpenClawIPCTests/LaunchAgentManagerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/LaunchAgentManagerTests.swift
@@ -4,15 +4,52 @@ import Testing
 
 struct LaunchAgentManagerTests {
     @Test func `launch at login plist does not keep app alive after manual quit`() throws {
-        let plist = LaunchAgentManager.plistContents(bundlePath: "/Applications/OpenClaw.app")
-        let data = try #require(plist.data(using: .utf8))
-        let object = try #require(
-            PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any])
+        let object = try Self.parsePlist(
+            LaunchAgentManager.plistContents(bundlePath: "/Applications/OpenClaw.app"))
 
         #expect(object["RunAtLoad"] as? Bool == true)
         #expect(object["KeepAlive"] == nil)
 
         let args = try #require(object["ProgramArguments"] as? [String])
         #expect(args == ["/Applications/OpenClaw.app/Contents/MacOS/OpenClaw"])
+    }
+
+    @Test func `launch at login plist preserves profile environment`() async throws {
+        let stateDir = "/tmp/openclaw state & profile"
+        let configPath = "/tmp/openclaw state & profile/custom<profile>.json"
+
+        try await TestIsolation.withEnvValues([
+            "OPENCLAW_CONFIG_PATH": configPath,
+            "OPENCLAW_STATE_DIR": stateDir,
+        ]) {
+            let object = try Self.parsePlist(
+                LaunchAgentManager.plistContents(bundlePath: "/Applications/OpenClaw.app"))
+            let environment = try #require(object["EnvironmentVariables"] as? [String: String])
+
+            #expect(environment["OPENCLAW_CONFIG_PATH"] == configPath)
+            #expect(environment["OPENCLAW_STATE_DIR"] == stateDir)
+            #expect(environment["PATH"]?.isEmpty == false)
+        }
+    }
+
+    @Test func `launch at login plist omits empty profile environment`() async throws {
+        try await TestIsolation.withEnvValues([
+            "OPENCLAW_CONFIG_PATH": "   ",
+            "OPENCLAW_STATE_DIR": "",
+        ]) {
+            let object = try Self.parsePlist(
+                LaunchAgentManager.plistContents(bundlePath: "/Applications/OpenClaw.app"))
+            let environment = try #require(object["EnvironmentVariables"] as? [String: String])
+
+            #expect(environment["OPENCLAW_CONFIG_PATH"] == nil)
+            #expect(environment["OPENCLAW_STATE_DIR"] == nil)
+            #expect(environment["PATH"]?.isEmpty == false)
+        }
+    }
+
+    private static func parsePlist(_ plist: String) throws -> [String: Any] {
+        let data = try #require(plist.data(using: .utf8))
+        return try #require(
+            PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any])
     }
 }


### PR DESCRIPTION
Fixes #98594.

## What Problem This Solves

The macOS app launch-at-login plist only preserved `PATH` in `EnvironmentVariables`. If a user enabled Launch at login while running OpenClaw with a custom profile, the login-launched app lost `OPENCLAW_STATE_DIR` and `OPENCLAW_CONFIG_PATH` and fell back to the default `~/.openclaw/openclaw.json` profile.

## Why This Change Was Made

`OpenClawPaths` already treats `OPENCLAW_STATE_DIR` and `OPENCLAW_CONFIG_PATH` as the supported profile-selection contract. The app LaunchAgent now carries those two non-empty environment variables alongside `PATH` so the next login uses the same profile that was active when autostart was enabled.

The plist is generated through `PropertyListSerialization` instead of a hand-written XML string, so paths containing XML-sensitive characters are escaped by Foundation.

## User Impact

macOS users with custom OpenClaw profiles can enable Launch at login without silently switching back to the default profile on the next login.

## Evidence

- Added focused Swift coverage for:
  - preserving non-empty `OPENCLAW_CONFIG_PATH` and `OPENCLAW_STATE_DIR`
  - omitting blank profile env values
  - parsing the generated plist after XML-sensitive profile paths
- `git diff --cached --check` passed before commit.
- `swiftc -parse apps/macos/Sources/OpenClaw/LaunchAgentManager.swift` passed locally.

## Not Run Locally

- `swift test --package-path apps/macos --filter LaunchAgentManagerTests` could not run on this machine because the available Swift toolchain is 5.7.2 while `apps/macos/Package.swift` requires Swift tools 6.2; the command exits immediately with `XCTest not available`.
- Full Swift typecheck also cannot complete with this local Swift 5.7.2 toolchain because existing project sources use newer Swift syntax.
