### PR TITLE
fix(telegram): final replies no longer drop on rejected rich entities, captions, quotes, or long flood waits

### DIFF
--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -39,6 +39,7 @@ import {
 } from "../format.js";
 import { resolveTelegramInteractiveTextFallback } from "../interactive-fallback.js";
 import { splitTelegramRichMessageTextChunks, TELEGRAM_RICH_TEXT_LIMIT } from "../rich-message.js";
+import { isTelegramHtmlParseError } from "../send-error-predicates.js";
 import { buildInlineKeyboard, reactMessageTelegram } from "../send.js";
 import { resolveTelegramVoiceSend } from "../voice.js";
 import {
@@ -309,6 +310,60 @@ function resolveVoiceFallbackText(reply: ReplyPayload): string | undefined {
   return undefined;
 }
 
+function buildPlainCaptionParams(
+  mediaParams: Record<string, unknown>,
+  plainCaption: string,
+): Record<string, unknown> {
+  const nextParams: Record<string, unknown> = { ...mediaParams, caption: plainCaption };
+  delete nextParams.parse_mode;
+  return nextParams;
+}
+
+async function sendTelegramCaptionedMediaWithFallback<T>(params: {
+  operation: string;
+  runtime: RuntimeEnv;
+  thread?: TelegramThreadSpec | null;
+  requestParams: Record<string, unknown>;
+  plainCaption?: string;
+  shouldLog?: (err: unknown) => boolean;
+  send: (effectiveParams: Record<string, unknown>) => Promise<T>;
+}): Promise<T> {
+  const sendMedia = (
+    requestParams: Record<string, unknown>,
+    shouldLog?: (err: unknown) => boolean,
+  ) =>
+    sendTelegramWithThreadFallback({
+      operation: params.operation,
+      runtime: params.runtime,
+      thread: params.thread,
+      requestParams,
+      ...(shouldLog ? { shouldLog } : {}),
+      send: params.send,
+    });
+  if (!params.plainCaption) {
+    return await sendMedia(params.requestParams);
+  }
+  try {
+    return await sendMedia(
+      params.requestParams,
+      (err: unknown) =>
+        !isTelegramHtmlParseError(err) && (params.shouldLog ? params.shouldLog(err) : true),
+    );
+  } catch (err) {
+    if (!isTelegramHtmlParseError(err)) {
+      throw err;
+    }
+    // Caption fallback mirrors text sends: Telegram HTML parse failures retry
+    // once with plain caption so media replies are not dropped.
+    logVerbose(
+      `telegram ${params.operation} caption HTML rejected; retrying as plain caption: ${formatErrorMessage(
+        err,
+      )}`,
+    );
+    return await sendMedia(buildPlainCaptionParams(params.requestParams, params.plainCaption));
+  }
+}
+
 async function sendTelegramVoiceFallbackText(opts: {
   bot: Bot;
   chatId: string;
@@ -440,11 +495,12 @@ async function deliverMediaReply(params: {
       }),
     };
     if (isGif) {
-      const result = await sendTelegramWithThreadFallback({
+      const result = await sendTelegramCaptionedMediaWithFallback({
         operation: "sendAnimation",
         runtime: params.runtime,
         thread: params.thread,
         requestParams: mediaParams,
+        plainCaption: caption,
         send: (effectiveParams) =>
           params.bot.api.sendAnimation(params.chatId, file, { ...effectiveParams }),
       });
@@ -453,11 +509,12 @@ async function deliverMediaReply(params: {
       }
       markDelivered(params.progress);
     } else if (kind === "image") {
-      const result = await sendTelegramWithThreadFallback({
+      const result = await sendTelegramCaptionedMediaWithFallback({
         operation: "sendPhoto",
         runtime: params.runtime,
         thread: params.thread,
         requestParams: mediaParams,
+        plainCaption: caption,
         send: (effectiveParams) =>
           params.bot.api.sendPhoto(params.chatId, file, { ...effectiveParams }),
       });
@@ -466,11 +523,12 @@ async function deliverMediaReply(params: {
       }
       markDelivered(params.progress);
     } else if (kind === "video") {
-      const result = await sendTelegramWithThreadFallback({
+      const result = await sendTelegramCaptionedMediaWithFallback({
         operation: "sendVideo",
         runtime: params.runtime,
         thread: params.thread,
         requestParams: mediaParams,
+        plainCaption: caption,
         send: (effectiveParams) =>
           params.bot.api.sendVideo(params.chatId, file, { ...effectiveParams }),
       });
@@ -490,11 +548,12 @@ async function deliverMediaReply(params: {
           requestParams: typeof mediaParams,
           shouldLog?: (err: unknown) => boolean,
         ) => {
-          const result = await sendTelegramWithThreadFallback({
+          const result = await sendTelegramCaptionedMediaWithFallback({
             operation: "sendVoice",
             runtime: params.runtime,
             thread: params.thread,
             requestParams,
+            plainCaption: typeof requestParams.caption === "string" ? caption : undefined,
             shouldLog,
             send: (effectiveParams) =>
               params.bot.api.sendVoice(params.chatId, file, { ...effectiveParams }),
@@ -580,11 +639,12 @@ async function deliverMediaReply(params: {
           throw voiceErr;
         }
       } else {
-        const result = await sendTelegramWithThreadFallback({
+        const result = await sendTelegramCaptionedMediaWithFallback({
           operation: "sendAudio",
           runtime: params.runtime,
           thread: params.thread,
           requestParams: mediaParams,
+          plainCaption: caption,
           send: (effectiveParams) =>
             params.bot.api.sendAudio(params.chatId, file, { ...effectiveParams }),
         });
@@ -594,11 +654,12 @@ async function deliverMediaReply(params: {
         markDelivered(params.progress);
       }
     } else {
-      const result = await sendTelegramWithThreadFallback({
+      const result = await sendTelegramCaptionedMediaWithFallback({
         operation: "sendDocument",
         runtime: params.runtime,
         thread: params.thread,
         requestParams: mediaParams,
+        plainCaption: caption,
         send: (effectiveParams) =>
           params.bot.api.sendDocument(params.chatId, file, { ...effectiveParams }),
       });

--- a/extensions/telegram/src/bot/delivery.send.ts
+++ b/extensions/telegram/src/bot/delivery.send.ts
@@ -18,13 +18,15 @@ import {
   removeTelegramRichNativeQuoteParam,
   toTelegramRichMessageContextParams,
 } from "../rich-message.js";
-import { isTelegramRichEntityInvalidError } from "../send-error-predicates.js";
+import {
+  isTelegramHtmlParseError,
+  isTelegramRichEntityInvalidError,
+} from "../send-error-predicates.js";
 import { buildInlineKeyboard } from "../send.js";
 import type { TelegramThreadSpec } from "./helpers.js";
 
 export { buildTelegramSendParams } from "../reply-parameters.js";
 
-const PARSE_ERR_RE = /can't parse entities|parse entities|find end of the entity/i;
 const EMPTY_TEXT_ERR_RE = /message text is empty/i;
 const QUOTE_PARAM_RE = /\bquote not found\b|\bQUOTE_TEXT_INVALID\b|\bquote text invalid\b/i;
 const GrammyErrorCtor: typeof GrammyError | undefined =
@@ -196,7 +198,7 @@ export async function sendTelegramText(
       requestParams: baseParams,
       shouldLog: (err) => {
         const errText = formatErrorMessage(err);
-        return !PARSE_ERR_RE.test(errText) && !EMPTY_TEXT_ERR_RE.test(errText);
+        return !isTelegramHtmlParseError(err) && !EMPTY_TEXT_ERR_RE.test(errText);
       },
       send: (effectiveParams) =>
         bot.api.sendMessage(chatId, htmlText, {
@@ -210,7 +212,7 @@ export async function sendTelegramText(
     return res.message_id;
   } catch (err) {
     const errText = formatErrorMessage(err);
-    if (PARSE_ERR_RE.test(errText) || EMPTY_TEXT_ERR_RE.test(errText)) {
+    if (isTelegramHtmlParseError(err) || EMPTY_TEXT_ERR_RE.test(errText)) {
       if (!hasFallbackText) {
         throw err;
       }

--- a/extensions/telegram/src/bot/delivery.send.ts
+++ b/extensions/telegram/src/bot/delivery.send.ts
@@ -1,5 +1,5 @@
 // Telegram plugin module implements delivery.send behavior.
-import { type Bot, GrammyError } from "grammy";
+import type { Bot } from "grammy";
 import type { MarkdownTableMode } from "openclaw/plugin-sdk/config-contracts";
 import { createTelegramRetryRunner } from "openclaw/plugin-sdk/retry-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
@@ -10,6 +10,7 @@ import { isSafeToRetrySendError, isTelegramRateLimitError } from "../network-err
 import {
   buildTelegramSendParams,
   getTelegramNativeQuoteReplyMessageId,
+  isTelegramQuoteParamError,
   removeTelegramNativeQuoteParam,
 } from "../reply-parameters.js";
 import {
@@ -28,17 +29,6 @@ import type { TelegramThreadSpec } from "./helpers.js";
 export { buildTelegramSendParams } from "../reply-parameters.js";
 
 const EMPTY_TEXT_ERR_RE = /message text is empty/i;
-const QUOTE_PARAM_RE = /\bquote not found\b|\bQUOTE_TEXT_INVALID\b|\bquote text invalid\b/i;
-const GrammyErrorCtor: typeof GrammyError | undefined =
-  typeof GrammyError === "function" ? GrammyError : undefined;
-
-function isTelegramQuoteParamError(err: unknown): boolean {
-  if (GrammyErrorCtor && err instanceof GrammyErrorCtor) {
-    return QUOTE_PARAM_RE.test(err.description);
-  }
-  return QUOTE_PARAM_RE.test(formatErrorMessage(err));
-}
-
 function createTelegramDeliverySendRetry() {
   return createTelegramRetryRunner({
     shouldRetry: (err) => isSafeToRetrySendError(err) || isTelegramRateLimitError(err),

--- a/extensions/telegram/src/bot/delivery.send.ts
+++ b/extensions/telegram/src/bot/delivery.send.ts
@@ -18,6 +18,7 @@ import {
   removeTelegramRichNativeQuoteParam,
   toTelegramRichMessageContextParams,
 } from "../rich-message.js";
+import { isTelegramRichEntityInvalidError } from "../send-error-predicates.js";
 import { buildInlineKeyboard } from "../send.js";
 import type { TelegramThreadSpec } from "./helpers.js";
 
@@ -26,8 +27,6 @@ export { buildTelegramSendParams } from "../reply-parameters.js";
 const PARSE_ERR_RE = /can't parse entities|parse entities|find end of the entity/i;
 const EMPTY_TEXT_ERR_RE = /message text is empty/i;
 const QUOTE_PARAM_RE = /\bquote not found\b|\bQUOTE_TEXT_INVALID\b|\bquote text invalid\b/i;
-const RICH_ENTITY_INVALID_RE =
-  /RICH_MESSAGE_(?:EMAIL|URL|MENTION|HASHTAG|CASHTAG|BOT_COMMAND|PHONE|BANK_CARD)_INVALID/i;
 const GrammyErrorCtor: typeof GrammyError | undefined =
   typeof GrammyError === "function" ? GrammyError : undefined;
 
@@ -169,10 +168,10 @@ export async function sendTelegramText(
       runtime.log?.(`telegram sendRichMessage ok chat=${chatId} message=${res.message_id}`);
       return res.message_id;
     } catch (err) {
-      const errText = formatErrorMessage(err);
-      if (!RICH_ENTITY_INVALID_RE.test(errText) || !hasFallbackText) {
+      if (!isTelegramRichEntityInvalidError(err) || !hasFallbackText) {
         throw err;
       }
+      const errText = formatErrorMessage(err);
       const richFallbackText =
         opts?.plainText ?? (textMode === "html" ? telegramHtmlToPlainTextFallback(text) : text);
       runtime.log?.(

--- a/extensions/telegram/src/bot/delivery.send.ts
+++ b/extensions/telegram/src/bot/delivery.send.ts
@@ -13,6 +13,7 @@ import {
   isTelegramQuoteParamError,
   removeTelegramNativeQuoteParam,
 } from "../reply-parameters.js";
+import { TELEGRAM_OUTBOUND_RETRY_AFTER_CAP_MS } from "../retry-after.js";
 import {
   buildTelegramRichMessage,
   getTelegramRichRawApi,
@@ -33,6 +34,7 @@ function createTelegramDeliverySendRetry() {
   return createTelegramRetryRunner({
     shouldRetry: (err) => isSafeToRetrySendError(err) || isTelegramRateLimitError(err),
     strictShouldRetry: true,
+    retryAfterMaxDelayMs: TELEGRAM_OUTBOUND_RETRY_AFTER_CAP_MS,
   });
 }
 

--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -212,6 +212,12 @@ function createRichEntityInvalidError(entity = "EMAIL", operation = "sendRichMes
   );
 }
 
+function createHtmlParseError(operation = "sendMessage") {
+  return new Error(
+    `GrammyError: Call to '${operation}' failed! (400: Bad Request: can't parse entities: Can't find end of the entity)`,
+  );
+}
+
 function createWrappedPreConnectHttpError(operation = "sendMessage") {
   const root = Object.assign(new Error("getaddrinfo ENOTFOUND api.telegram.org"), {
     code: "ENOTFOUND",
@@ -808,6 +814,36 @@ describe("deliverReplies", () => {
       caption: "hi <b>boss</b>",
       parse_mode: "HTML",
     });
+  });
+
+  it("falls back to a plain media caption when Telegram rejects caption HTML", async () => {
+    const runtime = createRuntime();
+    const sendPhoto = vi
+      .fn()
+      .mockRejectedValueOnce(createHtmlParseError("sendPhoto"))
+      .mockResolvedValueOnce({
+        message_id: 3,
+        chat: { id: "123" },
+      });
+    const bot = createBot({ sendPhoto });
+
+    mockMediaLoad("photo.jpg", "image/jpeg", "image");
+
+    await deliverWith({
+      replies: [{ mediaUrl: "https://example.com/photo.jpg", text: "hi **boss**" }],
+      runtime,
+      bot,
+    });
+
+    expect(sendPhoto).toHaveBeenCalledTimes(2);
+    expectRecordFields(mockCallArg(sendPhoto, 0, 2), {
+      caption: "hi <b>boss</b>",
+      parse_mode: "HTML",
+    });
+    expectRecordFields(mockCallArg(sendPhoto, 1, 2), {
+      caption: "hi **boss**",
+    });
+    expect(mockCallArg(sendPhoto, 1, 2)).not.toHaveProperty("parse_mode");
   });
 
   it("passes probed dimensions to video reply sends", async () => {

--- a/extensions/telegram/src/reply-parameters.ts
+++ b/extensions/telegram/src/reply-parameters.ts
@@ -1,7 +1,13 @@
 // Telegram plugin module implements reply parameters behavior.
+import { GrammyError } from "grammy";
 import type { MessageEntity } from "grammy/types";
+import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import { buildTelegramThreadParams, type TelegramThreadSpec } from "./bot/helpers.js";
 import { normalizeTelegramReplyToMessageId } from "./outbound-params.js";
+
+const QUOTE_PARAM_RE = /\bquote not found\b|\bQUOTE_TEXT_INVALID\b|\bquote text invalid\b/i;
+const GrammyErrorCtor: typeof GrammyError | undefined =
+  typeof GrammyError === "function" ? GrammyError : undefined;
 
 type TelegramReplyParameters = {
   message_id: number;
@@ -111,6 +117,13 @@ export function getTelegramNativeQuoteReplyMessageId(
   }
   const messageId = (replyParameters as { message_id?: unknown }).message_id;
   return typeof messageId === "number" && Number.isFinite(messageId) ? messageId : undefined;
+}
+
+export function isTelegramQuoteParamError(err: unknown): boolean {
+  if (GrammyErrorCtor && err instanceof GrammyErrorCtor) {
+    return QUOTE_PARAM_RE.test(err.description);
+  }
+  return QUOTE_PARAM_RE.test(formatErrorMessage(err));
 }
 
 export function removeTelegramNativeQuoteParam(

--- a/extensions/telegram/src/retry-after.ts
+++ b/extensions/telegram/src/retry-after.ts
@@ -1,0 +1,2 @@
+// Matches draft preview suspension: final Telegram replies should wait through routine flood windows.
+export const TELEGRAM_OUTBOUND_RETRY_AFTER_CAP_MS = 60_000;

--- a/extensions/telegram/src/send-error-predicates.ts
+++ b/extensions/telegram/src/send-error-predicates.ts
@@ -3,7 +3,12 @@ import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 
 const RICH_ENTITY_INVALID_RE =
   /RICH_MESSAGE_(?:EMAIL|URL|MENTION|HASHTAG|CASHTAG|BOT_COMMAND|PHONE|BANK_CARD)_INVALID/i;
+const PARSE_ERR_RE = /can't parse entities|parse entities|find end of the entity/i;
 
 export function isTelegramRichEntityInvalidError(err: unknown): boolean {
   return RICH_ENTITY_INVALID_RE.test(formatErrorMessage(err));
+}
+
+export function isTelegramHtmlParseError(err: unknown): boolean {
+  return PARSE_ERR_RE.test(formatErrorMessage(err));
 }

--- a/extensions/telegram/src/send-error-predicates.ts
+++ b/extensions/telegram/src/send-error-predicates.ts
@@ -1,0 +1,9 @@
+// Telegram API rejection predicates shared by durable and streaming send funnels.
+import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
+
+const RICH_ENTITY_INVALID_RE =
+  /RICH_MESSAGE_(?:EMAIL|URL|MENTION|HASHTAG|CASHTAG|BOT_COMMAND|PHONE|BANK_CARD)_INVALID/i;
+
+export function isTelegramRichEntityInvalidError(err: unknown): boolean {
+  return RICH_ENTITY_INVALID_RE.test(formatErrorMessage(err));
+}

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -292,6 +292,12 @@ function createRichEntityInvalidError(entity = "EMAIL", operation = "sendRichMes
   );
 }
 
+function createHtmlParseError(operation = "sendMessage"): Error {
+  return new Error(
+    `GrammyError: Call to '${operation}' failed! (400: Bad Request: can't parse entities: Can't find end of the entity)`,
+  );
+}
+
 function expectPersistedTarget(fields: Record<string, unknown>): void {
   const [target] = requireMockCall(
     mockCall(maybePersistResolvedTelegramTarget, -1, "persisted Telegram target"),
@@ -1878,6 +1884,53 @@ describe("sendMessageTelegram", () => {
       caption: "hi <b>boss</b>",
       parse_mode: "HTML",
     });
+  });
+
+  it("falls back to a plain media caption when Telegram rejects caption HTML", async () => {
+    const chatId = "123";
+    const caption = "hi **boss**";
+    const sendPhoto = vi
+      .fn()
+      .mockRejectedValueOnce(createHtmlParseError("sendPhoto"))
+      .mockResolvedValueOnce({
+        message_id: 91,
+        chat: { id: chatId },
+      });
+    const api = { sendPhoto } as unknown as {
+      sendPhoto: typeof sendPhoto;
+    };
+
+    mockLoadedMedia({
+      buffer: Buffer.from("fake-image"),
+      contentType: "image/jpeg",
+      fileName: "photo.jpg",
+    });
+
+    const result = await sendMessageTelegram(chatId, caption, {
+      cfg: TELEGRAM_TEST_CFG,
+      token: "tok",
+      api,
+      mediaUrl: "https://example.com/photo.jpg",
+    });
+
+    expectMediaSendCall(
+      firstMockCall(sendPhoto, "first send photo call"),
+      "send photo call",
+      chatId,
+      {
+        caption: "hi <b>boss</b>",
+        parse_mode: "HTML",
+      },
+    );
+    expectMediaSendCall(
+      mockCall(sendPhoto, 1, "second send photo call"),
+      "send photo retry call",
+      chatId,
+      {
+        caption,
+      },
+    );
+    expect(result).toEqual({ messageId: "91", chatId });
   });
 
   it("sends video notes when requested and regular videos otherwise", async () => {

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -298,6 +298,12 @@ function createHtmlParseError(operation = "sendMessage"): Error {
   );
 }
 
+function createQuoteNotFoundError(operation = "sendMessage"): Error {
+  return new Error(
+    `GrammyError: Call to '${operation}' failed! (400: Bad Request: quote not found)`,
+  );
+}
+
 function expectPersistedTarget(fields: Record<string, unknown>): void {
   const [target] = requireMockCall(
     mockCall(maybePersistResolvedTelegramTarget, -1, "persisted Telegram target"),
@@ -3524,6 +3530,43 @@ describe("shared send behaviors", () => {
         quote: " quoted text\n",
         allow_sending_without_reply: true,
       },
+    });
+  });
+
+  it("retries durable text sends with legacy reply id when native quotes are rejected", async () => {
+    const chatId = "123";
+    const sendMessage = vi
+      .fn()
+      .mockRejectedValueOnce(createQuoteNotFoundError())
+      .mockResolvedValueOnce({
+        message_id: 57,
+        chat: { id: chatId },
+      });
+    const api = { sendMessage } as unknown as {
+      sendMessage: typeof sendMessage;
+    };
+
+    await sendMessageTelegram(chatId, "reply text", {
+      cfg: TELEGRAM_TEST_CFG,
+      token: "tok",
+      api,
+      replyToMessageId: 100,
+      quoteText: "model paraphrase",
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+    expect(sendMessage).toHaveBeenNthCalledWith(1, chatId, "reply text", {
+      parse_mode: "HTML",
+      reply_parameters: {
+        message_id: 100,
+        quote: "model paraphrase",
+        allow_sending_without_reply: true,
+      },
+    });
+    expect(sendMessage).toHaveBeenNthCalledWith(2, chatId, "reply text", {
+      parse_mode: "HTML",
+      reply_to_message_id: 100,
+      allow_sending_without_reply: true,
     });
   });
 

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -286,6 +286,12 @@ function expectMediaSendCall(
   expect(actualParams).toEqual(expectedParams);
 }
 
+function createRichEntityInvalidError(entity = "EMAIL", operation = "sendRichMessage"): Error {
+  return new Error(
+    `GrammyError: Call to '${operation}' failed! (400: Bad Request: RICH_MESSAGE_${entity}_INVALID)`,
+  );
+}
+
 function expectPersistedTarget(fields: Record<string, unknown>): void {
   const [target] = requireMockCall(
     mockCall(maybePersistResolvedTelegramTarget, -1, "persisted Telegram target"),
@@ -996,6 +1002,46 @@ describe("sendMessageTelegram", () => {
       skip_entity_detection: true,
     });
     expect(richMessage?.html).not.toContain("mailto:");
+  });
+
+  it("falls back to plain text when durable rich sends reject an invalid entity", async () => {
+    const text = "Status includes openai:owner@example.com";
+    botRawApi.sendRichMessage.mockRejectedValueOnce(createRichEntityInvalidError("EMAIL"));
+    botApi.sendMessage.mockResolvedValueOnce({ message_id: 46, chat: { id: "123" } });
+
+    const result = await sendMessageTelegram("123", text, {
+      cfg: { channels: { telegram: { richMessages: true } } },
+      token: "tok",
+    });
+
+    expect(botRawApi.sendRichMessage).toHaveBeenCalledTimes(1);
+    expect(botApi.sendMessage).toHaveBeenCalledWith("123", text);
+    expect(result).toEqual({ messageId: "46", chatId: "123" });
+  });
+
+  it("chunks long plain text when durable rich sends reject an invalid entity", async () => {
+    const text = `Status includes openai:owner@example.com ${"A".repeat(5000)}`;
+    botRawApi.sendRichMessage.mockRejectedValueOnce(createRichEntityInvalidError("EMAIL"));
+    botApi.sendMessage
+      .mockResolvedValueOnce({ message_id: 47, chat: { id: "123" } })
+      .mockResolvedValueOnce({ message_id: 48, chat: { id: "123" } });
+
+    const result = await sendMessageTelegram("123", text, {
+      cfg: { channels: { telegram: { richMessages: true } } },
+      token: "tok",
+      replyToMessageId: 100,
+      replyToIdSource: "implicit",
+      replyToMode: "first",
+    });
+
+    expect(botRawApi.sendRichMessage).toHaveBeenCalledTimes(1);
+    expect(botApi.sendMessage).toHaveBeenCalledTimes(2);
+    expect(sendMessageTexts(botApi.sendMessage).every((chunk) => chunk.length <= 4000)).toBe(true);
+    for (const call of botApi.sendMessage.mock.calls) {
+      expect(call[2]).toBeUndefined();
+    }
+    expect(result.messageId).toBe("48");
+    expect(result.receipt?.platformMessageIds).toEqual(["47", "48"]);
   });
 
   it.each([
@@ -3678,6 +3724,22 @@ describe("editMessageTelegram", () => {
     );
     expect(captionParams.caption).toBe("New caption");
     expect(captionParams.parse_mode).toBe("HTML");
+  });
+
+  it("falls back to plain text when rich edits reject an invalid entity", async () => {
+    const text = "Status includes openai:owner@example.com";
+    botRawApi.editMessageText.mockRejectedValueOnce(
+      createRichEntityInvalidError("EMAIL", "editMessageText"),
+    );
+    botApi.editMessageText.mockResolvedValueOnce({ message_id: 1, chat: { id: "123" } });
+
+    await editMessageTelegram("123", 1, text, {
+      token: "tok",
+      cfg: { channels: { telegram: { richMessages: true } } },
+    });
+
+    expect(botRawApi.editMessageText).toHaveBeenCalledTimes(1);
+    expect(botApi.editMessageText).toHaveBeenCalledWith("123", 1, text);
   });
 
   it("retries editMessageTelegram on Telegram 5xx errors", async () => {

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -2219,6 +2219,42 @@ describe("sendMessageTelegram", () => {
     vi.useRealTimers();
   });
 
+  it("honors long Telegram retry_after hints above the default send retry cap", async () => {
+    vi.useFakeTimers();
+    const chatId = "123";
+    const sendMessage = vi
+      .fn()
+      .mockRejectedValueOnce({
+        message: "429 Too Many Requests",
+        response: { parameters: { retry_after: 45 } },
+      })
+      .mockResolvedValueOnce({
+        message_id: 2,
+        chat: { id: chatId },
+      });
+    const api = { sendMessage } as unknown as {
+      sendMessage: typeof sendMessage;
+    };
+    const setTimeoutSpy = vi.spyOn(global, "setTimeout");
+
+    const promise = sendMessageTelegram(chatId, "hi", {
+      cfg: TELEGRAM_TEST_CFG,
+      token: "tok",
+      api,
+      retry: { attempts: 2, minDelayMs: 0, maxDelayMs: 30_000, jitter: 0 },
+    });
+
+    await vi.advanceTimersByTimeAsync(44_999);
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(promise).resolves.toEqual({ messageId: "2", chatId });
+    expect(firstMockCall(setTimeoutSpy, "setTimeout call")[1]).toBe(45_000);
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+    setTimeoutSpy.mockRestore();
+    vi.useRealTimers();
+  });
+
   it("retries wrapped pre-connect HttpError sends", async () => {
     vi.useFakeTimers();
     const chatId = "123";

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -55,7 +55,10 @@ import {
   type TelegramRichMessageContextParams,
   type TelegramRichTextChunk,
 } from "./rich-message.js";
-import { isTelegramRichEntityInvalidError } from "./send-error-predicates.js";
+import {
+  isTelegramHtmlParseError,
+  isTelegramRichEntityInvalidError,
+} from "./send-error-predicates.js";
 import {
   buildOutboundMediaLoadOptions,
   getImageMetadata,
@@ -323,7 +326,6 @@ function resolveAcceptedReplyToMessageId(
   return params.reply_parameters?.message_id;
 }
 
-const PARSE_ERR_RE = /can't parse entities|parse entities|find end of the entity/i;
 const MESSAGE_NOT_MODIFIED_RE =
   /400:\s*Bad Request:\s*message is not modified|MESSAGE_NOT_MODIFIED/i;
 const MESSAGE_HAS_NO_TEXT_RE = /400:\s*Bad Request:\s*there is no text in the message to edit/i;
@@ -526,10 +528,6 @@ function isTelegramMessageHasNoTextError(err: unknown): boolean {
 
 function isTelegramMessageDeleteNoopError(err: unknown): boolean {
   return MESSAGE_DELETE_NOOP_RE.test(formatErrorMessage(err));
-}
-
-function isTelegramHtmlParseError(err: unknown): boolean {
-  return PARSE_ERR_RE.test(formatErrorMessage(err));
 }
 
 async function withTelegramHtmlParseFallback<T>(params: {
@@ -1177,6 +1175,8 @@ export async function sendMessageTelegram(
       followUpText = split.followUpText;
     }
     const htmlCaption = caption ? renderHtmlText(caption) : undefined;
+    const plainCaption =
+      caption && textMode === "html" ? telegramHtmlToPlainTextFallback(caption) : caption;
     // If text exceeds Telegram's caption limit, send media without caption
     // then send text as a separate follow-up message.
     const needsSeparateText = Boolean(followUpText);
@@ -1198,12 +1198,31 @@ export async function sendMessageTelegram(
       ...(opts.silent === true ? { disable_notification: true } : {}),
       ...(videoDimensions ? { width: videoDimensions.width, height: videoDimensions.height } : {}),
     };
+    const plainMediaParams = {
+      ...(plainCaption ? { caption: plainCaption } : {}),
+      ...baseMediaParams,
+      ...(opts.silent === true ? { disable_notification: true } : {}),
+      ...(videoDimensions ? { width: videoDimensions.width, height: videoDimensions.height } : {}),
+    };
     const sendMedia = async (
       label: string,
       sender: (
         effectiveParams: TelegramThreadScopedParams | undefined,
       ) => Promise<TelegramMessageLike>,
-    ) => await requestWithChatNotFound(() => sender(mediaParams), label);
+    ) => {
+      if (!htmlCaption || !plainCaption) {
+        return await requestWithChatNotFound(() => sender(mediaParams), label);
+      }
+      // Same contract as text sends: Telegram HTML parse failures retry once
+      // with the already visible plain caption so final media replies survive.
+      return await withTelegramHtmlParseFallback({
+        label,
+        verbose: opts.verbose,
+        requestHtml: (retryLabel) => requestWithChatNotFound(() => sender(mediaParams), retryLabel),
+        requestPlain: (retryLabel) =>
+          requestWithChatNotFound(() => sender(plainMediaParams), retryLabel),
+      });
+    };
 
     const mediaSender = (() => {
       if (isGif && deliveryKind !== "document") {

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -43,11 +43,15 @@ import { recordOutboundMessageForPromptContext } from "./outbound-message-contex
 import { makeProxyFetch } from "./proxy.js";
 import {
   buildTelegramThreadReplyParams,
+  getTelegramNativeQuoteReplyMessageId,
+  isTelegramQuoteParamError,
+  removeTelegramNativeQuoteParam,
   resolveTelegramSendThreadSpec,
 } from "./reply-parameters.js";
 import {
   buildTelegramRichMessage,
   getTelegramRichRawApi,
+  removeTelegramRichNativeQuoteParam,
   splitTelegramRichMessageTextChunks,
   TELEGRAM_RICH_TEXT_LIMIT,
   toTelegramRichMessageContextParams,
@@ -326,6 +330,32 @@ function resolveAcceptedReplyToMessageId(
   return params.reply_parameters?.message_id;
 }
 
+function toAcceptedThreadScopedParams(
+  params: Record<string, unknown> | undefined,
+): TelegramThreadScopedParams | undefined {
+  if (!params) {
+    return undefined;
+  }
+  const scoped: TelegramThreadScopedParams = {};
+  if (typeof params.message_thread_id === "number" && Number.isFinite(params.message_thread_id)) {
+    scoped.message_thread_id = params.message_thread_id;
+  }
+  if (
+    typeof params.reply_to_message_id === "number" &&
+    Number.isFinite(params.reply_to_message_id)
+  ) {
+    scoped.reply_to_message_id = params.reply_to_message_id;
+  }
+  const replyParameters = params.reply_parameters;
+  if (replyParameters && typeof replyParameters === "object") {
+    const messageId = (replyParameters as { message_id?: unknown }).message_id;
+    if (typeof messageId === "number" && Number.isFinite(messageId)) {
+      scoped.reply_parameters = { message_id: messageId };
+    }
+  }
+  return Object.keys(scoped).length > 0 ? scoped : undefined;
+}
+
 const MESSAGE_NOT_MODIFIED_RE =
   /400:\s*Bad Request:\s*message is not modified|MESSAGE_NOT_MODIFIED/i;
 const MESSAGE_HAS_NO_TEXT_RE = /400:\s*Bad Request:\s*there is no text in the message to edit/i;
@@ -553,6 +583,41 @@ async function withTelegramHtmlParseFallback<T>(params: {
   }
 }
 
+async function withTelegramNativeQuoteFallback<T>(params: {
+  label: string;
+  requestParams: Record<string, unknown>;
+  request: (requestParams: Record<string, unknown>, label: string) => Promise<T>;
+  removeNativeQuoteParam?: (requestParams: Record<string, unknown>) => Record<string, unknown>;
+}): Promise<{ result: T; acceptedParams: Record<string, unknown> }> {
+  try {
+    return {
+      result: await params.request(params.requestParams, params.label),
+      acceptedParams: params.requestParams,
+    };
+  } catch (err) {
+    if (
+      getTelegramNativeQuoteReplyMessageId(params.requestParams) == null ||
+      !isTelegramQuoteParamError(err)
+    ) {
+      throw err;
+    }
+    // Mirror delivery.send.ts legacy-reply retry: model quotes can drift from
+    // the source text, but final replies should keep the message reply target.
+    sendLogger.warn(
+      `telegram ${params.label} native quote rejected, retrying with legacy reply_to_message_id: ${formatErrorMessage(
+        err,
+      )}`,
+    );
+    const acceptedParams = (params.removeNativeQuoteParam ?? removeTelegramNativeQuoteParam)(
+      params.requestParams,
+    );
+    return {
+      result: await params.request(acceptedParams, `${params.label}-legacy-reply`),
+      acceptedParams,
+    };
+  }
+}
+
 type TelegramApiContext = {
   cfg: OpenClawConfig;
   account: ResolvedTelegramAccount;
@@ -772,32 +837,41 @@ export async function sendMessageTelegram(
       ...baseParams,
       ...(opts.silent === true ? { disable_notification: true } : {}),
     };
-    const hasPlainParams = Object.keys(plainParams).length > 0;
-    const requestPlain = (label: string) =>
-      requestWithChatNotFound(
-        () =>
-          hasPlainParams
-            ? api.sendMessage(chatId, chunk.plainText, plainParams)
-            : api.sendMessage(chatId, chunk.plainText),
+    const requestSendMessage = (
+      label: string,
+      messageText: string,
+      requestParams: Record<string, unknown>,
+    ) =>
+      withTelegramNativeQuoteFallback({
         label,
-      );
+        requestParams,
+        request: (effectiveParams, retryLabel) =>
+          requestWithChatNotFound(
+            () =>
+              Object.keys(effectiveParams).length > 0
+                ? api.sendMessage(chatId, messageText, effectiveParams)
+                : api.sendMessage(chatId, messageText),
+            retryLabel,
+          ),
+      });
+    const requestPlain = (label: string) =>
+      requestSendMessage(label, chunk.plainText, plainParams ?? {});
     const result = !chunk.htmlText
       ? await requestPlain("message")
       : await withTelegramHtmlParseFallback({
           label: "message",
           verbose: opts.verbose,
           requestHtml: (label) =>
-            requestWithChatNotFound(
-              () =>
-                api.sendMessage(chatId, chunk.htmlText ?? chunk.plainText, {
-                  parse_mode: "HTML" as const,
-                  ...plainParams,
-                }),
-              label,
-            ),
+            requestSendMessage(label, chunk.htmlText ?? chunk.plainText, {
+              parse_mode: "HTML" as const,
+              ...plainParams,
+            }),
           requestPlain,
         });
-    return { result, acceptedParams: params };
+    return {
+      result: result.result,
+      acceptedParams: toAcceptedThreadScopedParams(result.acceptedParams),
+    };
   };
 
   const shouldIncludeReplyForChunk = (
@@ -997,19 +1071,27 @@ export async function sendMessageTelegram(
       let result: TelegramMessageLike;
       let recordedParams: TelegramThreadScopedParams | TelegramRichMessageContextParams | undefined;
       try {
-        result = await requestWithChatNotFound(
-          () =>
-            richRawApi.sendRichMessage({
-              chat_id: chatId,
-              rich_message: buildTelegramRichMessage(chunk.text, chunk.textMode, {
-                skipEntityDetection: account.config.linkPreview === false,
-                tableMode,
-              }),
-              ...acceptedParams,
-              ...(opts.silent === true ? { disable_notification: true } : {}),
-            }),
-          "richMessage",
-        );
+        const richResult = await withTelegramNativeQuoteFallback<TelegramMessageLike>({
+          label: "richMessage",
+          requestParams: acceptedParams ?? {},
+          removeNativeQuoteParam: removeTelegramRichNativeQuoteParam,
+          request: (effectiveParams, retryLabel) =>
+            requestWithChatNotFound(
+              () =>
+                richRawApi.sendRichMessage({
+                  chat_id: chatId,
+                  rich_message: buildTelegramRichMessage(chunk.text, chunk.textMode, {
+                    skipEntityDetection: account.config.linkPreview === false,
+                    tableMode,
+                  }),
+                  ...effectiveParams,
+                  ...(opts.silent === true ? { disable_notification: true } : {}),
+                }),
+              retryLabel,
+            ),
+        });
+        result = richResult.result;
+        recordedParams = toTelegramRichMessageContextParams(richResult.acceptedParams);
       } catch (err) {
         if (!isTelegramRichEntityInvalidError(err)) {
           throw err;

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -55,6 +55,7 @@ import {
   type TelegramRichMessageContextParams,
   type TelegramRichTextChunk,
 } from "./rich-message.js";
+import { isTelegramRichEntityInvalidError } from "./send-error-predicates.js";
 import {
   buildOutboundMediaLoadOptions,
   getImageMetadata,
@@ -977,7 +978,10 @@ export async function sendMessageTelegram(
     const richRawApi = getTelegramRichRawApi(api);
     let lastMessageId = "";
     let lastChatId = chatId;
-    let lastAcceptedParams: TelegramRichMessageContextParams | undefined;
+    let lastAcceptedParams:
+      | TelegramThreadScopedParams
+      | TelegramRichMessageContextParams
+      | undefined;
     let acceptedReplyToMessageId: number | undefined;
     const messageIds: string[] = [];
     let sentChunkCount = 0;
@@ -992,19 +996,70 @@ export async function sendMessageTelegram(
         index === chunks.length - 1,
         options.replyToAlreadyUsed === true,
       );
-      const result = await requestWithChatNotFound(
-        () =>
-          richRawApi.sendRichMessage({
-            chat_id: chatId,
-            rich_message: buildTelegramRichMessage(chunk.text, chunk.textMode, {
-              skipEntityDetection: account.config.linkPreview === false,
-              tableMode,
+      let result: TelegramMessageLike;
+      let recordedParams: TelegramThreadScopedParams | TelegramRichMessageContextParams | undefined;
+      try {
+        result = await requestWithChatNotFound(
+          () =>
+            richRawApi.sendRichMessage({
+              chat_id: chatId,
+              rich_message: buildTelegramRichMessage(chunk.text, chunk.textMode, {
+                skipEntityDetection: account.config.linkPreview === false,
+                tableMode,
+              }),
+              ...acceptedParams,
+              ...(opts.silent === true ? { disable_notification: true } : {}),
             }),
-            ...acceptedParams,
-            ...(opts.silent === true ? { disable_notification: true } : {}),
-          }),
-        "richMessage",
-      );
+          "richMessage",
+        );
+      } catch (err) {
+        if (!isTelegramRichEntityInvalidError(err)) {
+          throw err;
+        }
+        // Mirror delivery.send.ts plain-text fallback, but keep normal 4k
+        // sendMessage chunking because rich chunks may be much larger.
+        sendLogger.warn(
+          `telegram richMessage rejected invalid entity, retrying as plain text: ${formatErrorMessage(
+            err,
+          )}`,
+        );
+        const fallbackChunks = splitTelegramPlainTextChunks(chunk.plainText, 4000);
+        const fallbackReplyChunkCount = Math.max(chunks.length, fallbackChunks.length);
+        for (let fallbackIndex = 0; fallbackIndex < fallbackChunks.length; fallbackIndex += 1) {
+          const fallbackText = fallbackChunks[fallbackIndex] ?? "";
+          const fallbackReplyIndex = chunks.length === 1 ? fallbackIndex : index;
+          const fallbackParams = buildTextParams(
+            fallbackReplyIndex,
+            fallbackReplyChunkCount,
+            index === chunks.length - 1 && fallbackIndex === fallbackChunks.length - 1,
+            options.replyToAlreadyUsed === true,
+          );
+          const plainResult = await sendTelegramTextChunk(
+            { plainText: fallbackText },
+            fallbackParams,
+          );
+          const fallbackMessageId = resolveTelegramMessageIdOrThrow(plainResult.result, context);
+          recordSentMessage(chatId, fallbackMessageId, cfg);
+          await recordOutboundMessageForPromptContext({
+            cfg,
+            account,
+            chatId,
+            message: plainResult.result,
+            messageId: fallbackMessageId,
+            text: fallbackText,
+            ...(plainResult.acceptedParams?.message_thread_id !== undefined
+              ? { messageThreadId: plainResult.acceptedParams.message_thread_id }
+              : {}),
+          });
+          lastMessageId = String(fallbackMessageId);
+          lastChatId = String(plainResult.result?.chat?.id ?? chatId);
+          lastAcceptedParams = plainResult.acceptedParams;
+          acceptedReplyToMessageId ??= resolveAcceptedReplyToMessageId(plainResult.acceptedParams);
+          messageIds.push(lastMessageId);
+          sentChunkCount += 1;
+        }
+        continue;
+      }
       const messageId = resolveTelegramMessageIdOrThrow(result, context);
       recordSentMessage(chatId, messageId, cfg);
       await recordOutboundMessageForPromptContext({
@@ -1014,14 +1069,14 @@ export async function sendMessageTelegram(
         message: result,
         messageId,
         text: chunk.plainText,
-        ...(acceptedParams?.message_thread_id !== undefined
-          ? { messageThreadId: acceptedParams.message_thread_id }
+        ...(recordedParams?.message_thread_id !== undefined
+          ? { messageThreadId: recordedParams.message_thread_id }
           : {}),
       });
       lastMessageId = String(messageId);
       lastChatId = String(result?.chat?.id ?? chatId);
-      lastAcceptedParams = acceptedParams;
-      acceptedReplyToMessageId ??= resolveAcceptedReplyToMessageId(acceptedParams);
+      lastAcceptedParams = recordedParams;
+      acceptedReplyToMessageId ??= resolveAcceptedReplyToMessageId(recordedParams);
       messageIds.push(lastMessageId);
       sentChunkCount += 1;
     }
@@ -1763,7 +1818,26 @@ export async function editMessageTelegram(
           }),
         "editMessage",
         (err) => !isTelegramMessageNotModifiedError(err),
-      );
+      ).catch((err: unknown) => {
+        if (!isTelegramRichEntityInvalidError(err)) {
+          throw err;
+        }
+        // Mirror durable send fallback for edits: invalid rich entities degrade
+        // to the same plain text that normal HTML edit fallback would send.
+        sendLogger.warn(
+          `telegram editMessage rich entity rejected, retrying as plain text: ${formatErrorMessage(
+            err,
+          )}`,
+        );
+        return requestWithEditShouldLog(
+          () =>
+            Object.keys(plainTextParams).length > 0
+              ? api.editMessageText(chatId, messageId, plainText, plainTextParams)
+              : api.editMessageText(chatId, messageId, plainText),
+          "editMessage-plain",
+          (plainErr) => !isTelegramMessageNotModifiedError(plainErr),
+        );
+      });
     }
     return withTelegramHtmlParseFallback({
       label: "editMessage",

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -48,6 +48,7 @@ import {
   removeTelegramNativeQuoteParam,
   resolveTelegramSendThreadSpec,
 } from "./reply-parameters.js";
+import { TELEGRAM_OUTBOUND_RETRY_AFTER_CAP_MS } from "./retry-after.js";
 import {
   buildTelegramRichMessage,
   getTelegramRichRawApi,
@@ -659,6 +660,7 @@ function createTelegramRequestWithDiag(params: {
   account: ResolvedTelegramAccount;
   retry?: RetryConfig;
   verbose?: boolean;
+  retryAfterMaxDelayMs?: number;
   shouldRetry?: (err: unknown) => boolean;
   /** When true, the shouldRetry predicate is used exclusively without the TELEGRAM_RETRY_RE fallback. */
   strictShouldRetry?: boolean;
@@ -668,6 +670,9 @@ function createTelegramRequestWithDiag(params: {
     retry: params.retry,
     configRetry: params.account.config.retry,
     verbose: params.verbose,
+    ...(params.retryAfterMaxDelayMs !== undefined
+      ? { retryAfterMaxDelayMs: params.retryAfterMaxDelayMs }
+      : {}),
     ...(params.shouldRetry ? { shouldRetry: params.shouldRetry } : {}),
     ...(params.strictShouldRetry ? { strictShouldRetry: true } : {}),
   });
@@ -747,6 +752,7 @@ function createTelegramNonIdempotentRequestWithDiag(params: {
     retry: params.retry,
     verbose: params.verbose,
     useApiErrorLogging: params.useApiErrorLogging,
+    retryAfterMaxDelayMs: TELEGRAM_OUTBOUND_RETRY_AFTER_CAP_MS,
     shouldRetry: (err) => isSafeToRetrySendError(err) || isTelegramRateLimitError(err),
     strictShouldRetry: true,
   });

--- a/src/infra/retry-policy.test.ts
+++ b/src/infra/retry-policy.test.ts
@@ -203,4 +203,55 @@ describe("createChannelApiRetryRunner", () => {
     await expect(promise).resolves.toBe("ok");
     expect(fn).toHaveBeenCalledTimes(2);
   });
+
+  it("keeps retry_after hints capped by maxDelayMs by default", async () => {
+    vi.useFakeTimers();
+
+    const runner = createChannelApiRetryRunner({
+      retry: { attempts: 2, minDelayMs: 0, maxDelayMs: 30_000, jitter: 0 },
+    });
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce({
+        message: "429 Too Many Requests",
+        response: { parameters: { retry_after: 45 } },
+      })
+      .mockResolvedValue("ok");
+
+    const promise = runner(fn, "test");
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(29_999);
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(promise).resolves.toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("honors retry_after above maxDelayMs when a separate retry-after cap is configured", async () => {
+    vi.useFakeTimers();
+
+    const runner = createChannelApiRetryRunner({
+      retry: { attempts: 2, minDelayMs: 0, maxDelayMs: 30_000, jitter: 0 },
+      retryAfterMaxDelayMs: 60_000,
+    });
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce({
+        message: "429 Too Many Requests",
+        response: { parameters: { retry_after: 45 } },
+      })
+      .mockResolvedValue("ok");
+
+    const promise = runner(fn, "test");
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(44_999);
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(promise).resolves.toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/infra/retry-policy.ts
+++ b/src/infra/retry-policy.ts
@@ -95,6 +95,7 @@ export function createChannelApiRetryRunner(params: {
   retry?: RetryConfig;
   configRetry?: RetryConfig;
   verbose?: boolean;
+  retryAfterMaxDelayMs?: number;
   shouldRetry?: (err: unknown) => boolean;
   /**
    * When true, the custom shouldRetry predicate is used exclusively —
@@ -116,6 +117,9 @@ export function createChannelApiRetryRunner(params: {
       label,
       shouldRetry,
       retryAfterMs: getChannelApiRetryAfterMs,
+      ...(params.retryAfterMaxDelayMs !== undefined
+        ? { retryAfterMaxDelayMs: params.retryAfterMaxDelayMs }
+        : {}),
       onRetry: params.verbose
         ? (info) => {
             const maxRetries = Math.max(1, info.maxAttempts - 1);

--- a/src/infra/retry.ts
+++ b/src/infra/retry.ts
@@ -27,6 +27,7 @@ export type RetryOptions = RetryConfig & {
   label?: string;
   shouldRetry?: (err: unknown, attempt: number) => boolean;
   retryAfterMs?: (err: unknown) => number | undefined;
+  retryAfterMaxDelayMs?: number;
   onRetry?: (info: RetryInfo) => void;
 };
 
@@ -136,6 +137,13 @@ export async function retryAsync<T>(
     Number.isFinite(resolved.maxDelayMs) && resolved.maxDelayMs > 0
       ? resolved.maxDelayMs
       : Number.POSITIVE_INFINITY;
+  const retryAfterMaxDelayMs =
+    options.retryAfterMaxDelayMs === undefined
+      ? maxDelayMs
+      : Math.max(
+          minDelayMs,
+          resolveRetryDelayMs(Math.round(clampNumber(options.retryAfterMaxDelayMs, maxDelayMs, 0))),
+        );
   const jitter = resolved.jitter;
   const shouldRetry = options.shouldRetry ?? (() => true);
   let lastErr: unknown;
@@ -154,7 +162,8 @@ export async function retryAsync<T>(
       const baseDelay = hasRetryAfter
         ? Math.max(retryAfterMs, minDelayMs)
         : minDelayMs * 2 ** (attempt - 1);
-      let delay = Math.min(baseDelay, maxDelayMs);
+      const delayCap = hasRetryAfter ? retryAfterMaxDelayMs : maxDelayMs;
+      let delay = Math.min(baseDelay, delayCap);
       // Server-supplied Retry-After is a lower-bound contract with the
       // upstream rate limiter; symmetric jitter would let roughly half the
       // retries land before the requested time and invite escalation. Use
@@ -181,9 +190,9 @@ export async function retryAsync<T>(
       // (`retryAfterMs > maxDelayMs`), where the contract is already
       // unsatisfiable and we gain spread without adding a violation.
       const canHonorRetryAfter =
-        hasRetryAfter && typeof retryAfterMs === "number" && retryAfterMs <= maxDelayMs;
+        hasRetryAfter && typeof retryAfterMs === "number" && retryAfterMs <= delayCap;
       delay = applyJitter(delay, jitter, canHonorRetryAfter ? "positive" : "symmetric");
-      delay = Math.min(Math.max(delay, minDelayMs), maxDelayMs);
+      delay = Math.min(Math.max(delay, minDelayMs), delayCap);
 
       options.onRetry?.({
         attempt,


### PR DESCRIPTION
Closes #98778

## What Problem This Solves

Fixes an issue where Telegram's durable send path — the one that delivers the **final** reply of a streamed dispatch and all message-tool sends — failed outright on four recoverable Telegram rejections that the streaming bot-reply path already survives. Users saw live-typed previews complete and then the final message silently fail: on model-emitted invalid rich entities (`400 RICH_MESSAGE_*_INVALID`), on captions whose HTML Telegram rejects (a photo captioned "use `<b>` for bold" killed the whole media send), on paraphrased reply quotes (`400 quote text not found`), and on group flood waits longer than 30s (routine 40–120s `retry_after` values exhausted the retry budget).

## Why This Change Was Made

Each fix mirrors the recovery contract the streaming path (`bot/delivery.send.ts`) already pins with tests, applied to the durable funnel (`send.ts`) and the captioned media senders (`bot/delivery.replies.ts`): a targeted catch of the specific Telegram error family, one retry in degraded form (plain text for rich entities — re-split into 4k plain chunks since rich chunks can be larger; plain caption without `parse_mode`; legacy `reply_to_message_id` without the native quote), everything else rethrows. Shared predicates moved to `send-error-predicates.ts` / `reply-parameters.ts` so the two funnels can't drift again. For flood waits, the shared channel retry runner gained one narrow option, `retryAfterMaxDelayMs`, which caps only server-hinted `retry_after` delays and defaults to the existing `maxDelayMs` — no other channel's behavior moves; Telegram call sites set it to 60s, aligned with the draft stream's flood suspension cap.

## User Impact

Final replies and message-tool sends now degrade the same way live previews do instead of dying: rich formatting falls back to plain text, media arrives with a plain caption instead of vanishing, replies keep their target when a quote is rejected, and sends into flood-limited groups wait out the hinted window (up to 60s) instead of failing after two premature retries.

## Evidence

- New regression tests: rich-entity 400 → plain text delivered with correct chunking; caption parse 400 → plain caption delivered on both the durable (`send.ts`) and streaming (`delivery.replies.ts`) media paths; quote-not-found 400 → delivered via legacy reply; fake-timer proof that `retry_after: 45` retries at exactly 45s with the new cap and stays clamped to 30s without it (`src/infra/retry-policy.test.ts`).
- Validation on this branch rebased onto current `main` (includes #98775/#98776): `pnpm tsgo:extensions` and `pnpm tsgo` pass; `node scripts/run-vitest.mjs` on `send.test.ts`, `bot/delivery.test.ts`, `src/infra/retry-policy.test.ts` — all pass (210 extension tests, 10 infra tests); `node scripts/run-oxlint.mjs` on touched files clean; repo autoreview (branch mode vs `origin/main`) clean.
