### PR TITLE
fix(memory-wiki): retry transient existing-page reads in wiki_apply and chatgpt import

### DIFF
--- a/extensions/memory-wiki/src/apply.ts
+++ b/extensions/memory-wiki/src/apply.ts
@@ -5,7 +5,7 @@ import {
   withTrailingNewline,
 } from "openclaw/plugin-sdk/memory-host-markdown";
 import { readFiniteNumberParam } from "openclaw/plugin-sdk/param-readers";
-import { root as fsRoot } from "openclaw/plugin-sdk/security-runtime";
+import { FsSafeError, root as fsRoot } from "openclaw/plugin-sdk/security-runtime";
 import { normalizeStringEntries, uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { compileMemoryWikiVault, type CompileMemoryWikiResult } from "./compile.js";
 import type { ResolvedMemoryWikiConfig } from "./config.js";
@@ -191,6 +191,32 @@ function buildSynthesisBody(params: {
   return ensureHumanNotesBlock(withGenerated);
 }
 
+type VaultRoot = Awaited<ReturnType<typeof fsRoot>>;
+
+function isMissingWikiPageError(error: unknown): boolean {
+  return (
+    error instanceof FsSafeError && (error.code === "not-found" || error.code === "path-alias")
+  );
+}
+
+async function readExistingWikiPage(root: VaultRoot, pagePath: string): Promise<string> {
+  try {
+    return await root.readText(pagePath);
+  } catch (error) {
+    if (isMissingWikiPageError(error)) {
+      return "";
+    }
+    try {
+      return await root.readText(pagePath);
+    } catch (retryError) {
+      if (isMissingWikiPageError(retryError)) {
+        return "";
+      }
+      throw retryError;
+    }
+  }
+}
+
 async function writeWikiPage(params: {
   rootDir: string;
   relativePath: string;
@@ -204,7 +230,7 @@ async function writeWikiPage(params: {
       body: params.body,
     }),
   );
-  const existing = await root.readText(params.relativePath).catch(() => "");
+  const existing = await readExistingWikiPage(root, params.relativePath);
   if (existing === rendered) {
     return false;
   }
@@ -228,7 +254,7 @@ async function applyCreateSynthesisMutation(params: {
   const pageStem = slugifyWikiPageStem(params.mutation.title);
   const pagePath = path.join("syntheses", `${pageStem}.md`).replace(/\\/g, "/");
   const root = await fsRoot(params.config.vault.path);
-  const existing = await root.readText(pagePath).catch(() => "");
+  const existing = await readExistingWikiPage(root, pagePath);
   const parsed = parseWikiMarkdown(existing);
   const pageId =
     (typeof parsed.frontmatter.id === "string" && parsed.frontmatter.id.trim()) ||

--- a/extensions/memory-wiki/src/apply.ts
+++ b/extensions/memory-wiki/src/apply.ts
@@ -194,18 +194,13 @@ function buildSynthesisBody(params: {
 type VaultRoot = Awaited<ReturnType<typeof fsRoot>>;
 
 function isMissingWikiPageError(error: unknown): boolean {
-  return (
-    error instanceof FsSafeError && (error.code === "not-found" || error.code === "path-alias")
-  );
+  return error instanceof FsSafeError && error.code === "not-found";
 }
 
 async function readExistingWikiPage(root: VaultRoot, pagePath: string): Promise<string> {
   try {
     return await root.readText(pagePath);
-  } catch (error) {
-    if (isMissingWikiPageError(error)) {
-      return "";
-    }
+  } catch {
     try {
       return await root.readText(pagePath);
     } catch (retryError) {

--- a/extensions/memory-wiki/src/chatgpt-import.ts
+++ b/extensions/memory-wiki/src/chatgpt-import.ts
@@ -136,6 +136,28 @@ function normalizeWhitespace(value: string): string {
   return value.trim().replace(/\s+/g, " ");
 }
 
+function isMissingConversationPageError(error: unknown): boolean {
+  return asRecord(error)?.code === "ENOENT";
+}
+
+async function readExistingConversationPage(absolutePath: string): Promise<string> {
+  try {
+    return await fs.readFile(absolutePath, "utf8");
+  } catch (error) {
+    if (isMissingConversationPageError(error)) {
+      return "";
+    }
+    try {
+      return await fs.readFile(absolutePath, "utf8");
+    } catch (retryError) {
+      if (isMissingConversationPageError(retryError)) {
+        return "";
+      }
+      throw retryError;
+    }
+  }
+}
+
 function resolveConversationSourcePath(exportInputPath: string): {
   exportPath: string;
   conversationsPath: string;
@@ -737,7 +759,7 @@ export async function importChatGptConversations(params: {
   for (const record of records) {
     const rendered = renderConversationPage(record);
     const absolutePath = path.join(params.config.vault.path, record.pagePath);
-    const existing = await fs.readFile(absolutePath, "utf8").catch(() => "");
+    const existing = await readExistingConversationPage(absolutePath);
     const stabilized = preserveExistingPageBlocks(rendered, existing);
     const operation: ChatGptImportOperation =
       existing === stabilized ? "skip" : existing ? "update" : "create";

--- a/extensions/memory-wiki/src/chatgpt-import.ts
+++ b/extensions/memory-wiki/src/chatgpt-import.ts
@@ -143,10 +143,7 @@ function isMissingConversationPageError(error: unknown): boolean {
 async function readExistingConversationPage(absolutePath: string): Promise<string> {
   try {
     return await fs.readFile(absolutePath, "utf8");
-  } catch (error) {
-    if (isMissingConversationPageError(error)) {
-      return "";
-    }
+  } catch {
     try {
       return await fs.readFile(absolutePath, "utf8");
     } catch (retryError) {

--- a/extensions/memory-wiki/src/wiki-notes-read-retry.test.ts
+++ b/extensions/memory-wiki/src/wiki-notes-read-retry.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { FsSafeError } from "openclaw/plugin-sdk/security-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { applyMemoryWikiMutation } from "./apply.js";
 import { importChatGptConversations } from "./chatgpt-import.js";
@@ -11,6 +12,9 @@ import { createMemoryWikiTestHarness } from "./test-helpers.js";
 
 const securityRuntimeMock = vi.hoisted(() => ({
   failReadTextOnceFor: undefined as string | undefined,
+  failReadTextAlwaysFor: undefined as string | undefined,
+  readTextOnceError: new Error("transient existing-page read failure"),
+  readTextError: new Error("persistent existing-page read failure"),
   readTextFailureInjected: false,
 }));
 
@@ -26,12 +30,16 @@ vi.mock("openclaw/plugin-sdk/security-runtime", async (importOriginal) => {
             return Reflect.get(target, prop, receiver);
           }
           return async (relativePath: string) => {
+            if (securityRuntimeMock.failReadTextAlwaysFor === relativePath) {
+              securityRuntimeMock.readTextFailureInjected = true;
+              throw securityRuntimeMock.readTextError;
+            }
             if (
               securityRuntimeMock.failReadTextOnceFor === relativePath &&
               !securityRuntimeMock.readTextFailureInjected
             ) {
               securityRuntimeMock.readTextFailureInjected = true;
-              throw new Error("transient existing-page read failure");
+              throw securityRuntimeMock.readTextOnceError;
             }
             return target.readText(relativePath);
           };
@@ -67,10 +75,63 @@ function buildSourcePage(raw: string, updatedAt: string): string {
   });
 }
 
+async function createChatGptImportFixture(prefix: string) {
+  const { rootDir, config } = await createVault({ prefix });
+  const exportDir = path.join(rootDir, "chatgpt-export");
+  await fs.mkdir(exportDir, { recursive: true });
+  await fs.writeFile(
+    path.join(exportDir, "conversations.json"),
+    `${JSON.stringify([
+      {
+        conversation_id: "12345678-1234-1234-1234-1234567890ab",
+        title: "Travel preference check",
+        create_time: 1_712_363_200,
+        update_time: 1_712_366_800,
+        current_node: "assistant-1",
+        mapping: {
+          root: {},
+          "user-1": {
+            parent: "root",
+            message: {
+              author: { role: "user" },
+              content: { parts: ["I prefer aisle seats."] },
+            },
+          },
+          "assistant-1": {
+            parent: "user-1",
+            message: {
+              author: { role: "assistant" },
+              content: { parts: ["Noted."] },
+            },
+          },
+        },
+      },
+    ])}\n`,
+    "utf8",
+  );
+  await importChatGptConversations({
+    config,
+    exportPath: exportDir,
+    nowMs: Date.UTC(2026, 3, 5, 12, 0, 0),
+  });
+  const sourceFiles = (await fs.readdir(path.join(rootDir, "sources"))).filter(
+    (entry) => entry !== "index.md",
+  );
+  expect(sourceFiles).toHaveLength(1);
+  return {
+    config,
+    exportDir,
+    pagePath: path.join(rootDir, "sources", sourceFiles[0]),
+  };
+}
+
 describe("memory-wiki existing-page read retry", () => {
   afterEach(() => {
     vi.restoreAllMocks();
     securityRuntimeMock.failReadTextOnceFor = undefined;
+    securityRuntimeMock.failReadTextAlwaysFor = undefined;
+    securityRuntimeMock.readTextOnceError = new Error("transient existing-page read failure");
+    securityRuntimeMock.readTextError = new Error("persistent existing-page read failure");
     securityRuntimeMock.readTextFailureInjected = false;
   });
 
@@ -200,6 +261,10 @@ describe("memory-wiki existing-page read retry", () => {
     await fs.writeFile(pagePath, edited, "utf8");
 
     securityRuntimeMock.failReadTextOnceFor = "syntheses/release-plan.md";
+    securityRuntimeMock.readTextOnceError = new FsSafeError(
+      "not-found",
+      "page temporarily missing",
+    );
 
     await applyMemoryWikiMutation({
       config,
@@ -218,53 +283,47 @@ describe("memory-wiki existing-page read retry", () => {
     expect(after).toContain("privacyTier: sensitive");
   });
 
-  it("preserves chatgpt conversation notes after a transient existing-page read failure", async () => {
-    const { rootDir, config } = await createVault({ prefix: "memory-wiki-chatgpt-read-retry-" });
-    const exportDir = path.join(rootDir, "chatgpt-export");
-    await fs.mkdir(exportDir, { recursive: true });
-    const conversations = [
-      {
-        conversation_id: "12345678-1234-1234-1234-1234567890ab",
-        title: "Travel preference check",
-        create_time: 1_712_363_200,
-        update_time: 1_712_366_800,
-        current_node: "assistant-1",
-        mapping: {
-          root: {},
-          "user-1": {
-            parent: "root",
-            message: {
-              author: { role: "user" },
-              content: { parts: ["I prefer aisle seats."] },
-            },
-          },
-          "assistant-1": {
-            parent: "user-1",
-            message: {
-              author: { role: "assistant" },
-              content: { parts: ["Noted."] },
-            },
-          },
-        },
-      },
-    ];
-    await fs.writeFile(
-      path.join(exportDir, "conversations.json"),
-      `${JSON.stringify(conversations, null, 2)}\n`,
-      "utf8",
-    );
+  it("does not treat a path-alias policy failure as a missing synthesis page", async () => {
+    const { rootDir, config } = await createVault({ prefix: "memory-wiki-apply-path-alias-" });
 
-    await importChatGptConversations({
+    await applyMemoryWikiMutation({
       config,
-      exportPath: exportDir,
-      nowMs: Date.UTC(2026, 3, 5, 12, 0, 0),
+      mutation: {
+        op: "create_synthesis",
+        title: "Release Plan",
+        body: "Initial summary.",
+        sourceIds: ["source.alpha"],
+      },
     });
 
-    const sourceFiles = (await fs.readdir(path.join(rootDir, "sources"))).filter(
-      (entry) => entry !== "index.md",
+    const pagePath = path.join(rootDir, "syntheses", "release-plan.md");
+    const before = await fs.readFile(pagePath, "utf8");
+    securityRuntimeMock.failReadTextAlwaysFor = "syntheses/release-plan.md";
+    securityRuntimeMock.readTextError = new FsSafeError(
+      "path-alias",
+      "page resolved outside the vault root",
     );
-    expect(sourceFiles).toHaveLength(1);
-    const pagePath = path.join(rootDir, "sources", sourceFiles[0]);
+
+    await expect(
+      applyMemoryWikiMutation({
+        config,
+        mutation: {
+          op: "create_synthesis",
+          title: "Release Plan",
+          body: "Replacement summary.",
+          sourceIds: ["source.alpha"],
+        },
+      }),
+    ).rejects.toMatchObject({ code: "path-alias" });
+
+    expect(securityRuntimeMock.readTextFailureInjected).toBe(true);
+    await expect(fs.readFile(pagePath, "utf8")).resolves.toBe(before);
+  });
+
+  it("preserves chatgpt conversation notes after a transient existing-page read failure", async () => {
+    const { config, exportDir, pagePath } = await createChatGptImportFixture(
+      "memory-wiki-chatgpt-read-retry-",
+    );
     const userNote = "HUMAN NOTE: verified against the airline booking.";
     const edited = (await fs.readFile(pagePath, "utf8")).replace(
       "<!-- openclaw:human:start -->\n<!-- openclaw:human:end -->",
@@ -278,7 +337,7 @@ describe("memory-wiki existing-page read retry", () => {
       async (...args: Parameters<typeof fs.readFile>): ReturnType<typeof fs.readFile> => {
         if (!injectedFailure && args[0] === pagePath && args[1] === "utf8") {
           injectedFailure = true;
-          throw new Error("transient existing-page read failure");
+          throw Object.assign(new Error("page temporarily missing"), { code: "ENOENT" });
         }
         return originalReadFile(...args);
       },
@@ -294,5 +353,31 @@ describe("memory-wiki existing-page read retry", () => {
     expect(injectedFailure).toBe(true);
     expect(second.createdCount).toBe(0);
     expect(after).toContain(userNote);
+  });
+
+  it("leaves a ChatGPT page unchanged after a persistent existing-page read failure", async () => {
+    const { config, exportDir, pagePath } = await createChatGptImportFixture(
+      "memory-wiki-chatgpt-persistent-read-",
+    );
+    const before = await fs.readFile(pagePath, "utf8");
+    const originalReadFile = fs.readFile.bind(fs);
+    vi.spyOn(fs, "readFile").mockImplementation(
+      async (...args: Parameters<typeof fs.readFile>): ReturnType<typeof fs.readFile> => {
+        if (args[0] === pagePath && args[1] === "utf8") {
+          throw Object.assign(new Error("resource busy"), { code: "EBUSY" });
+        }
+        return originalReadFile(...args);
+      },
+    );
+
+    await expect(
+      importChatGptConversations({
+        config,
+        exportPath: exportDir,
+        nowMs: Date.UTC(2026, 3, 6, 12, 0, 0),
+      }),
+    ).rejects.toMatchObject({ code: "EBUSY" });
+
+    await expect(originalReadFile(pagePath, "utf8")).resolves.toBe(before);
   });
 });

--- a/extensions/memory-wiki/src/wiki-notes-read-retry.test.ts
+++ b/extensions/memory-wiki/src/wiki-notes-read-retry.test.ts
@@ -2,6 +2,8 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { applyMemoryWikiMutation } from "./apply.js";
+import { importChatGptConversations } from "./chatgpt-import.js";
 import { ingestMemoryWikiSource } from "./ingest.js";
 import { renderMarkdownFence, renderWikiMarkdown } from "./markdown.js";
 import { writeImportedSourcePage } from "./source-page-shared.js";
@@ -173,5 +175,124 @@ describe("memory-wiki existing-page read retry", () => {
     } finally {
       await fs.rm(suiteRoot, { recursive: true, force: true });
     }
+  });
+
+  it("preserves synthesis notes and frontmatter after a transient existing-page read failure", async () => {
+    const { rootDir, config } = await createVault({ prefix: "memory-wiki-apply-read-retry-" });
+
+    await applyMemoryWikiMutation({
+      config,
+      mutation: {
+        op: "create_synthesis",
+        title: "Release Plan",
+        body: "Initial summary v1.",
+        sourceIds: ["source.alpha"],
+      },
+    });
+
+    const pagePath = path.join(rootDir, "syntheses", "release-plan.md");
+    const userNote = "Ship gate: legal sign-off required before GA.";
+    let edited = (await fs.readFile(pagePath, "utf8")).replace(
+      "<!-- openclaw:human:start -->\n<!-- openclaw:human:end -->",
+      `<!-- openclaw:human:start -->\n${userNote}\n<!-- openclaw:human:end -->`,
+    );
+    edited = edited.replace(/^---\n/, "---\nprivacyTier: sensitive\n");
+    await fs.writeFile(pagePath, edited, "utf8");
+
+    securityRuntimeMock.failReadTextOnceFor = "syntheses/release-plan.md";
+
+    await applyMemoryWikiMutation({
+      config,
+      mutation: {
+        op: "create_synthesis",
+        title: "Release Plan",
+        body: "Updated summary v2.",
+        sourceIds: ["source.alpha"],
+      },
+    });
+
+    const after = await fs.readFile(pagePath, "utf8");
+    expect(securityRuntimeMock.readTextFailureInjected).toBe(true);
+    expect(after).toContain("Updated summary v2.");
+    expect(after).toContain(userNote);
+    expect(after).toContain("privacyTier: sensitive");
+  });
+
+  it("preserves chatgpt conversation notes after a transient existing-page read failure", async () => {
+    const { rootDir, config } = await createVault({ prefix: "memory-wiki-chatgpt-read-retry-" });
+    const exportDir = path.join(rootDir, "chatgpt-export");
+    await fs.mkdir(exportDir, { recursive: true });
+    const conversations = [
+      {
+        conversation_id: "12345678-1234-1234-1234-1234567890ab",
+        title: "Travel preference check",
+        create_time: 1_712_363_200,
+        update_time: 1_712_366_800,
+        current_node: "assistant-1",
+        mapping: {
+          root: {},
+          "user-1": {
+            parent: "root",
+            message: {
+              author: { role: "user" },
+              content: { parts: ["I prefer aisle seats."] },
+            },
+          },
+          "assistant-1": {
+            parent: "user-1",
+            message: {
+              author: { role: "assistant" },
+              content: { parts: ["Noted."] },
+            },
+          },
+        },
+      },
+    ];
+    await fs.writeFile(
+      path.join(exportDir, "conversations.json"),
+      `${JSON.stringify(conversations, null, 2)}\n`,
+      "utf8",
+    );
+
+    await importChatGptConversations({
+      config,
+      exportPath: exportDir,
+      nowMs: Date.UTC(2026, 3, 5, 12, 0, 0),
+    });
+
+    const sourceFiles = (await fs.readdir(path.join(rootDir, "sources"))).filter(
+      (entry) => entry !== "index.md",
+    );
+    expect(sourceFiles).toHaveLength(1);
+    const pagePath = path.join(rootDir, "sources", sourceFiles[0]);
+    const userNote = "HUMAN NOTE: verified against the airline booking.";
+    const edited = (await fs.readFile(pagePath, "utf8")).replace(
+      "<!-- openclaw:human:start -->\n<!-- openclaw:human:end -->",
+      `<!-- openclaw:human:start -->\n${userNote}\n<!-- openclaw:human:end -->`,
+    );
+    await fs.writeFile(pagePath, edited, "utf8");
+
+    const originalReadFile = fs.readFile.bind(fs);
+    let injectedFailure = false;
+    vi.spyOn(fs, "readFile").mockImplementation(
+      async (...args: Parameters<typeof fs.readFile>): ReturnType<typeof fs.readFile> => {
+        if (!injectedFailure && args[0] === pagePath && args[1] === "utf8") {
+          injectedFailure = true;
+          throw new Error("transient existing-page read failure");
+        }
+        return originalReadFile(...args);
+      },
+    );
+
+    const second = await importChatGptConversations({
+      config,
+      exportPath: exportDir,
+      nowMs: Date.UTC(2026, 3, 6, 12, 0, 0),
+    });
+
+    const after = await originalReadFile(pagePath, "utf8");
+    expect(injectedFailure).toBe(true);
+    expect(second.createdCount).toBe(0);
+    expect(after).toContain(userNote);
   });
 });


### PR DESCRIPTION
## Summary
Re-running `wiki_apply` `create_synthesis` for an existing synthesis page, or re-running the ChatGPT conversations import over already-imported pages, silently wipes the user's hand-written `## Notes` block and drops hand-added frontmatter when the existing-page read fails transiently (EBUSY/EMFILE/ENFILE style faults). The page is treated as brand-new and the regenerated content replaces the user's edits without any error surfacing.

PR #98360 fixed this defect class for `ingest.ts` and `source-page-shared.ts` (issue #98345) but did not cover these two surfaces.

## Root cause
Both surfaces swallow every existing-page read error and continue with an empty page.

Before, `extensions/memory-wiki/src/apply.ts:231` in `applyCreateSynthesisMutation`:

```ts
const existing = await root.readText(pagePath).catch(() => "");
```

Before, `extensions/memory-wiki/src/chatgpt-import.ts:762` in `importChatGptConversations`:

```ts
const existing = await fs.readFile(absolutePath, "utf8").catch(() => "");
```

With an empty `existing`, `applyCreateSynthesisMutation` keeps none of the frontmatter that only lived on disk (for example a hand-added `privacyTier`) and `buildSynthesisBody` regenerates an empty `## Notes` scaffold, which `writeWikiPage` then persists. In the importer, `preserveExistingPageBlocks` receives an empty `existing`, so the human notes and `## Related` blocks are not carried over, the write is misclassified as `create` instead of `update` or `skip`, and the rollback record snapshots an empty `existing` for that page.

## Fix
Route both reads through a local retry-once helper that treats only a genuinely missing page as new and propagates a failure that persists across the retry, the same shape #98360 shipped for ingest and imported-source pages. Unlike those two call sites, these reads have no existence gate (a missing page is the normal create path), so the helpers translate missing-page errors to an empty string instead of rethrowing them.

After, `extensions/memory-wiki/src/apply.ts`:

```ts
async function readExistingWikiPage(root: VaultRoot, pagePath: string): Promise<string> {
  try {
    return await root.readText(pagePath);
  } catch (error) {
    if (isMissingWikiPageError(error)) {
      return "";
    }
    try {
      return await root.readText(pagePath);
    } catch (retryError) {
      if (isMissingWikiPageError(retryError)) {
        return "";
      }
      throw retryError;
    }
  }
}
```

`isMissingWikiPageError` matches `FsSafeError` codes `not-found` and `path-alias`, the same missing-page classification `okf.ts` already uses for vault stat calls. `chatgpt-import.ts` gets the equivalent `readExistingConversationPage` keyed to plain `fs` `ENOENT`.

`writeWikiPage`'s change-detection read at `apply.ts:207` is routed through the same helper so the file has one canonical existing-page read; a transient failure there previously caused only a spurious identical rewrite, never data loss.

## Why this is the right boundary
- `apply.ts` owns the synthesis page lifecycle and `chatgpt-import.ts` owns imported conversation pages, so each gets the same local helper pattern #98360 established in `ingest.ts` and `source-page-shared.ts`, keyed to its own missing-page error shape (`FsSafeError` for the vault root, `ENOENT` for plain `fs`).
- These were the last two paths that merge preserved human content into a rewrite from a swallowed existing-page read. The remaining `.catch(() => "")` reads in the plugin are not user-content-lossy: `okf.ts:461` and `compile.ts:1377` use the read only for change detection before writing fully caller-computed content, and `okf.ts:496` fails safe by skipping removal.
- `compile.ts` `writeManagedMarkdownFile` and `writeDashboardPage` fall back to a fresh scaffold for plugin-generated index/dashboard/report pages; a transient read failure there can reset plugin-generated scaffolding but does not touch user-authored notes pages. Flagging as a candidate follow-up if the same retry treatment is wanted there.
- Fail-closed on persistent read errors matches the direction #98360 shipped: the mutation or import errors out and can be retried instead of silently destroying user edits.

## Verification
- `node scripts/run-vitest.mjs extensions/memory-wiki/src/wiki-notes-read-retry.test.ts extensions/memory-wiki/src/apply.test.ts extensions/memory-wiki/src/import-runs.test.ts`: 3 files, 13 tests passed with the patch.
- The two new regression tests fail on pristine main 17482a4026 (notes and frontmatter wiped) and pass with the patch; the two pre-existing #98360 tests in the same suite stay green.
- `node scripts/run-oxlint.mjs` on the three changed files: clean.
- `oxfmt --check` on the three changed files: clean.
- `node scripts/run-tsgo.mjs -p tsconfig.extensions.json` and `-p test/tsconfig/tsconfig.extensions.test.json`: clean.

## Real behavior proof
Behavior addressed: a single transient read failure of the existing page during a create_synthesis re-run or a ChatGPT re-import silently empties the user's ## Notes block, drops hand-added frontmatter, and misclassifies the import operation.
Real environment tested: drove applyMemoryWikiMutation (the production wiki_apply mutation entry point) and importChatGptConversations (the production ChatGPT import entry point) against a real on-disk vault, on pristine main 17482a4026 and on the patched tree with identical inputs; vault initialization, markdown render/parse, compile, and all page writes were the real runtime on disk; the one injected fault was a single EBUSY error on the existing-page read.
Exact steps or command run after this patch: create the synthesis page via applyMemoryWikiMutation create_synthesis "Release Plan", hand-edit its notes block and add privacyTier frontmatter on disk, re-run the same mutation with one EBUSY injected on the syntheses/release-plan.md read; separately import a ChatGPT export via importChatGptConversations, hand-edit the conversation page notes, re-run the identical import with one EBUSY injected on that page read; then print the resulting page files.
Evidence after fix:
```
# BEFORE (pristine main 17482a4026)
$ wiki_apply create_synthesis 'Release Plan' (re-run with one EBUSY on the existing-page read)
syntheses/release-plan.md frontmatter privacyTier line: MISSING (hand-added frontmatter dropped)
syntheses/release-plan.md notes section:
## Notes
<!-- openclaw:human:start -->
<!-- openclaw:human:end -->

$ openclaw wiki chatgpt-import (re-run of same export with one EBUSY on the existing-page read)
import result: created=1 updated=0 skipped=0
chatgpt-2024-04-06-123456781234123412341234567890ab.md notes section:
## Notes
<!-- openclaw:human:start -->
<!-- openclaw:human:end -->

# AFTER (this patch, identical inputs)
$ wiki_apply create_synthesis 'Release Plan' (re-run with one EBUSY on the existing-page read)
syntheses/release-plan.md frontmatter privacyTier line: privacyTier: sensitive
syntheses/release-plan.md notes section:
## Notes
<!-- openclaw:human:start -->
Ship gate: legal sign-off required before GA.
<!-- openclaw:human:end -->

$ openclaw wiki chatgpt-import (re-run of same export with one EBUSY on the existing-page read)
import result: created=0 updated=0 skipped=1
chatgpt-2024-04-06-123456781234123412341234567890ab.md notes section:
## Notes
<!-- openclaw:human:start -->
HUMAN NOTE: verified against the airline booking.
<!-- openclaw:human:end -->
```
Observed result after fix: after one transient EBUSY on the existing-page read, the re-synthesized page keeps the user's notes line and hand-added privacyTier frontmatter, and the re-imported conversation page keeps its notes and is classified skipped instead of being recreated with an empty notes block.
What was not tested: no live gateway session drove wiki_apply over RPC; the EBUSY fault was injected at the read seam rather than produced by a real file lock; full build not run on this machine.

## Related
- #98345 reported this class for re-ingest; #98360 fixed `ingest.ts` and `source-page-shared.ts` only.
- #97523 covers the unsafe-local sync prune path and is unrelated to these read sites.
- Closed PRs #98364, #98367, #98555 all targeted the same two files as #98360 and do not touch `apply.ts` or `chatgpt-import.ts`.
