### PR TITLE
fix(telegram): sends and actions without an account id ignore the configured defaultAccount

### DIFF
--- a/extensions/telegram/src/account-inspect.test.ts
+++ b/extensions/telegram/src/account-inspect.test.ts
@@ -107,6 +107,27 @@ describe("inspectTelegramAccount SecretRef resolution", () => {
     expect(account.config.reactionLevel).toBe("ack");
   });
 
+  it("routes omitted-account inspection through the configured defaultAccount (#61012)", () => {
+    withEnv({ TELEGRAM_BOT_TOKEN: "123:env" }, () => {
+      const cfg: OpenClawConfig = {
+        channels: {
+          telegram: {
+            botToken: "123:channel",
+            defaultAccount: "ops",
+            accounts: {
+              ops: { botToken: "123:ops" },
+            },
+          },
+        },
+      };
+
+      const account = inspectTelegramAccount({ cfg });
+      expect(account.accountId).toBe("ops");
+      expect(account.tokenSource).toBe("config");
+      expect(account.token).toBe("123:ops");
+    });
+  });
+
   it("blocks channel-token fallback for unknown scoped accounts in multi-account config", () => {
     const cfg: OpenClawConfig = {
       channels: {

--- a/extensions/telegram/src/account-inspect.ts
+++ b/extensions/telegram/src/account-inspect.ts
@@ -252,8 +252,9 @@ export function inspectTelegramAccount(params: {
   accountId?: string | null;
   envToken?: string | null;
 }): InspectedTelegramAccount {
+  const resolvedAccountId = params.accountId ?? resolveDefaultTelegramAccountId(params.cfg);
   return resolveAccountWithDefaultFallback({
-    accountId: params.accountId,
+    accountId: resolvedAccountId,
     normalizeAccountId,
     resolvePrimary: (accountId) =>
       inspectTelegramAccountPrimary({

--- a/extensions/telegram/src/accounts.test.ts
+++ b/extensions/telegram/src/accounts.test.ts
@@ -173,6 +173,49 @@ describe("resolveTelegramAccount", () => {
     expect(accounts[0]?.token).toBe("tok-default");
     expect(accounts[0]?.tokenSource).toBe("config");
   });
+
+  it("routes omitted-account resolution through the configured defaultAccount (#61012)", () => {
+    const account = resolveAccountWithEnv(
+      { TELEGRAM_BOT_TOKEN: "tok-env" },
+      {
+        channels: {
+          telegram: {
+            botToken: "tok-top-level",
+            defaultAccount: "secondary",
+            accounts: {
+              primary: { botToken: "tok-primary" },
+              secondary: { botToken: "tok-secondary" },
+            },
+          },
+        },
+      },
+    );
+    expect(account.accountId).toBe("secondary");
+    expect(account.token).toBe("tok-secondary");
+    expect(account.tokenSource).toBe("config");
+  });
+
+  it("keeps explicit accountId ahead of the configured defaultAccount (#61012)", () => {
+    const account = resolveAccountWithEnv(
+      { TELEGRAM_BOT_TOKEN: "tok-env" },
+      {
+        channels: {
+          telegram: {
+            botToken: "tok-top-level",
+            defaultAccount: "secondary",
+            accounts: {
+              primary: { botToken: "tok-primary" },
+              secondary: { botToken: "tok-secondary" },
+            },
+          },
+        },
+      },
+      "primary",
+    );
+    expect(account.accountId).toBe("primary");
+    expect(account.token).toBe("tok-primary");
+    expect(account.tokenSource).toBe("config");
+  });
 });
 
 describe("resolveDefaultTelegramAccountId", () => {

--- a/extensions/telegram/src/accounts.ts
+++ b/extensions/telegram/src/accounts.ts
@@ -168,11 +168,9 @@ export function resolveTelegramAccount(params: {
     } satisfies ResolvedTelegramAccount;
   };
 
-  // If accountId is omitted, prefer a configured account token over failing on
-  // the implicit "default" account. This keeps env-based setups working while
-  // making config-only tokens work for things like heartbeats.
+  const resolvedAccountId = params.accountId ?? resolveDefaultTelegramAccountId(params.cfg);
   return resolveAccountWithDefaultFallback({
-    accountId: params.accountId,
+    accountId: resolvedAccountId,
     normalizeAccountId,
     resolvePrimary: resolve,
     hasCredential: (account) => account.tokenSource !== "none",

--- a/extensions/telegram/src/action-runtime.test.ts
+++ b/extensions/telegram/src/action-runtime.test.ts
@@ -342,6 +342,24 @@ describe("handleTelegramAction", () => {
     await expectReactionAdded("minimal");
   });
 
+  it("routes omitted-account action tokens through the configured defaultAccount (#61012)", async () => {
+    const cfg = {
+      channels: {
+        telegram: {
+          reactionLevel: "minimal",
+          defaultAccount: "kitt",
+          accounts: {
+            kitt: { botToken: "tok-kitt" },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    await handleTelegramAction(defaultReactionAction, cfg);
+    const call = mockCall(reactMessageTelegram, 0, "reaction add");
+    const options = requireRecord(call[3], "reaction add options");
+    expect(options.token).toBe("tok-kitt");
+  });
+
   it("surfaces non-fatal reaction warnings", async () => {
     reactMessageTelegram.mockResolvedValueOnce({
       ok: false,

--- a/extensions/telegram/src/reaction-level.test.ts
+++ b/extensions/telegram/src/reaction-level.test.ts
@@ -122,6 +122,24 @@ describe("resolveTelegramReactionLevel", () => {
     expectExtensiveFlags(result);
   });
 
+  it("resolves omitted-account reaction level from the configured defaultAccount (#61012)", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        telegram: {
+          botToken: "tok-default",
+          reactionLevel: "off",
+          defaultAccount: "work",
+          accounts: {
+            work: { botToken: "tok-work", reactionLevel: "extensive" },
+          },
+        },
+      },
+    };
+
+    const result = resolveTelegramReactionLevel({ cfg });
+    expectExtensiveFlags(result);
+  });
+
   it("falls back to global level when account has no reactionLevel", () => {
     const cfg: OpenClawConfig = {
       channels: {

--- a/extensions/telegram/src/token.test.ts
+++ b/extensions/telegram/src/token.test.ts
@@ -91,6 +91,37 @@ describe("resolveTelegramToken", () => {
     expect(res).toEqual(expected);
   });
 
+  it("resolves the configured defaultAccount token when accountId is omitted (#61012)", () => {
+    vi.stubEnv("TELEGRAM_BOT_TOKEN", "env-token");
+    const cfg = {
+      channels: {
+        telegram: {
+          defaultAccount: "kitt",
+          accounts: {
+            kitt: { botToken: "kitt-token" },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const res = resolveTelegramToken(cfg);
+    expect(res).toEqual({ token: "kitt-token", source: "config" });
+  });
+
+  it("keeps the env token for omitted accountId when no defaultAccount is configured", () => {
+    vi.stubEnv("TELEGRAM_BOT_TOKEN", "env-token");
+    const cfg = {
+      channels: {
+        telegram: {
+          accounts: {
+            kitt: { botToken: "kitt-token" },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const res = resolveTelegramToken(cfg);
+    expect(res).toEqual({ token: "env-token", source: "env" });
+  });
+
   it.runIf(process.platform !== "win32")("rejects symlinked tokenFile paths", () => {
     vi.stubEnv("TELEGRAM_BOT_TOKEN", "");
     const dir = createTempDir();

--- a/extensions/telegram/src/token.ts
+++ b/extensions/telegram/src/token.ts
@@ -5,11 +5,16 @@ import { tryReadSecretFileSync } from "openclaw/plugin-sdk/channel-core";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { TelegramAccountConfig } from "openclaw/plugin-sdk/config-contracts";
 import { resolveDefaultSecretProviderAlias } from "openclaw/plugin-sdk/provider-auth";
-import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/routing";
+import {
+  DEFAULT_ACCOUNT_ID,
+  normalizeAccountId,
+  normalizeOptionalAccountId,
+} from "openclaw/plugin-sdk/routing";
 import {
   normalizeSecretInputString,
   resolveSecretInputString,
 } from "openclaw/plugin-sdk/secret-input";
+import { resolveDefaultTelegramAccountId } from "./account-selection.js";
 
 type TelegramTokenSource = "env" | "tokenFile" | "config" | "none";
 
@@ -104,7 +109,9 @@ export function resolveTelegramToken(
   cfg?: OpenClawConfig,
   opts: ResolveTelegramTokenOpts = {},
 ): TelegramTokenResolution {
-  const accountId = normalizeAccountId(opts.accountId);
+  const requestedAccountId = normalizeOptionalAccountId(opts.accountId);
+  const accountId =
+    requestedAccountId ?? (cfg ? resolveDefaultTelegramAccountId(cfg) : DEFAULT_ACCOUNT_ID);
   const telegramCfg = cfg?.channels?.telegram;
 
   // Account IDs are normalized for routing (e.g. lowercased). Config keys may not


### PR DESCRIPTION
Related: #80804
Related: #61012
Related: #91156

## What Problem This Solves

Fixes an issue where Telegram sends and message actions that omit an account id ignored the configured `channels.telegram.defaultAccount` (and the default-agent binding) whenever the implicit `default` account still had any credential, such as a leftover `TELEGRAM_BOT_TOKEN` environment variable or a top-level `channels.telegram.botToken` from an earlier single-bot setup.

The result is the failure mode reported in #61012 and suspected in #80804: gateway sends, heartbeats, cron announces, and `openclaw message send` without `--account` go out through the wrong (stale) bot. In groups that stale bot never joined, Telegram answers `400: Bad Request: chat not found` even though the configured default bot is an admin and a direct Bot API call with its token succeeds. DMs keep working when the user once started the stale bot, which makes the misrouting look like a Telegram-side permissions problem.

A second facet hits the message-action runtime (`reactions`, `sendMessage`, polls, stickers, deletes, edits, forum topics, pairing notifications, thread bindings): those paths call `resolveTelegramToken` directly with the omitted account id, so they either used the same wrong stale token or failed with `Telegram bot token missing` even though the configured default account has a valid token.

## Why This Change Was Made

Both optional-account entry points resolved the literal `default` account first and only consulted the configured default when the implicit account had no credential, which is exactly the case where the bug does not bite:

- `resolveTelegramAccount` (extensions/telegram/src/accounts.ts) passed the raw omitted `accountId` into `resolveAccountWithDefaultFallback`, which normalizes `undefined` to `default` and returns it as soon as it is credentialed.
- `resolveTelegramToken` (extensions/telegram/src/token.ts) normalized the omitted `accountId` straight to `default`, so every raw caller (the action-runtime token gates, pairing notify at extensions/telegram/src/channel.ts:1174, thread bindings at extensions/telegram/src/thread-bindings.ts:746) never looked at `defaultAccount` at all.

The fix resolves the configured default account id up front in both entry points when the caller omits the account, which is the convention this plugin and its sibling already use: `createTelegramActionGate` (accounts.ts) and the nextcloud-talk resolver (extensions/nextcloud-talk/src/accounts.ts) both pre-resolve `accountId ?? resolveDefault...AccountId(cfg)`. Explicit account ids are untouched, `TELEGRAM_BOT_TOKEN` remains scoped to the `default` account id (the #53876 precedent), and setups without `defaultAccount` or bindings resolve exactly as before because `resolveListedDefaultAccountId` prefers the implicit `default` when it is listed.

This is intentionally fail-explicit: when the operator names a default account that has no token, sends now fail with a missing-token error for that account instead of silently going out under a different bot identity, since that silent substitution is the defect this class of reports describes.

Relationship to open PR #91156 by @sumitaich1998: that PR contains the same two-line pre-resolve for `resolveTelegramAccount` and this change credits it. Its review flagged that the message-action runtime still gates on `resolveTelegramToken(cfg, { accountId })` before durable delivery, so the resolver-only change leaves CLI and agent message actions broken. Fixing `resolveTelegramToken` itself covers those raw callers without touching the eight call sites, which keeps one canonical resolution path.

## User Impact

Multi-bot operators can rely on `channels.telegram.defaultAccount` and default-agent bindings: sends, heartbeats, cron announces, message actions, pairing notifications, and topic creation that omit an account id now use the configured default bot token. Group deliveries stop failing with `chat not found` under a stale environment token, and message actions stop failing with `bot token missing` when only the named default account has a token. Setups without a configured default keep their current behavior, including `TELEGRAM_BOT_TOKEN`-only configurations.

## Evidence

Live gateway before/after on identical inputs. Setup: real gateway (`node scripts/run-node.mjs gateway run`) plus real CLI send, config with `defaultAccount: "kitt"` (`accounts.kitt.botToken = 2222222222:KITT-NEW-BOT`) and a stale `TELEGRAM_BOT_TOKEN=1111111111:STALE-OLD-BOT` in the gateway environment. The only fake seam is a local HTTP server standing in for `api.telegram.org` via `channels.telegram.apiRoot`; it answers `400 chat not found` for the stale bot (which is what Telegram returns when that bot is not in the group) and `ok` for the kitt bot. Everything else (config loading, account resolution, gateway RPC, durable delivery, Telegram client) is the real runtime.

Command, both runs:

```
node scripts/run-node.mjs message send --channel telegram --target -1003757652981 --message "heartbeat check" --json
```

Before (pristine main 17482a4026):

```
GatewayClientRequestError: OutboundDeliveryError: Telegram send failed: chat not found (chat_id=-1003757652981). Likely: bot not started in DM, bot removed from group/channel, group migrated (new -100… id), or wrong bot token. Input was: "telegram:-1003757652981".
```

```
[telegram-api] sendMessage via STALE-ENV-BOT
```

After (this patch, identical inputs):

```
{
  "action": "send",
  "channel": "telegram",
  "dryRun": false,
  "handledBy": "plugin",
  "messageId": "8743",
  "payload": {
    "ok": true,
    "messageId": "8743"
  }
}
```

```
[telegram-api] sendMessage via KITT-DEFAULT-BOT
```

Regression tests (colocated): `node scripts/run-vitest.mjs extensions/telegram/src/token.test.ts extensions/telegram/src/accounts.test.ts extensions/telegram/src/action-runtime.test.ts`

- Pristine main: `Tests 3 failed | 139 passed (142)`; the three failures are exactly the new omitted-account defaultAccount tests (resolver, token, action-runtime reaction token).
- With this patch: `Tests 142 passed (142)`, including the untouched omitted-account compat tests (`uses TELEGRAM_BOT_TOKEN when default account config is missing`, `falls back to the first configured account when accountId is omitted`, the #53876 binding fallthrough, and the #82780 implicit-default listing).

Gates on the changed files: `scripts/run-oxlint.mjs` clean, `oxfmt --check` clean, `tsgo` clean for `tsconfig.core.json`, `test/tsconfig/tsconfig.core.test.json`, and `tsconfig.extensions.json`. `test/tsconfig/tsconfig.extensions.test.json` reports one pre-existing error in `extensions/qa-lab/src/suite.test.ts` (CRABLINE_SERVER_CHANNELS export) that reproduces on pristine main.

Not tested: no request against the real `api.telegram.org` (fake HTTP seam described above); full `pnpm build` not run (no module-boundary changes); a local `codex review --base origin/main` run was cut off by a usage limit before producing findings.


## Real behavior proof
Behavior addressed: Telegram sends and message actions that omit an account id ignored the configured channels.telegram.defaultAccount whenever the implicit default account still had a credential (stale TELEGRAM_BOT_TOKEN or top-level botToken), so group deliveries went out through the wrong bot and failed with 400 chat not found.
Real environment tested: real gateway process (node scripts/run-node.mjs gateway run) plus the real CLI send path over the gateway RPC, on pristine main 17482a4026 and on PR head 529dae1ca73be4734c135ee0b59f787b20448e5c; config loading, account and token resolution, durable delivery, and the Telegram client all real; the one faked seam is a local HTTP server standing in for api.telegram.org via channels.telegram.apiRoot, answering 400 chat not found for the stale bot token and ok for the configured default bot token, with the gateway environment carrying the stale TELEGRAM_BOT_TOKEN and the config carrying defaultAccount kitt.
Exact steps or command run after this patch: node scripts/run-node.mjs message send --channel telegram --target -1003757652981 --message "heartbeat check" --json
Evidence after fix:
```
# BEFORE (pristine main 17482a4026)
GatewayClientRequestError: OutboundDeliveryError: Telegram send failed: chat not found (chat_id=-1003757652981). Likely: bot not started in DM, bot removed from group/channel, group migrated (new -100… id), or wrong bot token. Input was: "telegram:-1003757652981".
[telegram-api] sendMessage via STALE-ENV-BOT
# AFTER (this patch, identical inputs, head 529dae1ca73be4734c135ee0b59f787b20448e5c)
{
  "action": "send",
  "channel": "telegram",
  "dryRun": false,
  "handledBy": "plugin",
  "messageId": "8743",
  "payload": {
    "ok": true,
    "messageId": "8743"
  }
}
[telegram-api] sendMessage via KITT-DEFAULT-BOT
```
Observed result after fix: the same no-account send that previously went out under the stale env bot and failed with chat not found now goes out under the configured default bot and is delivered, with the wire log flipping from STALE-ENV-BOT to KITT-DEFAULT-BOT on identical inputs.
What was not tested: no request against the real api.telegram.org (local HTTP stand-in described above); full build not run; local codex review was cut off by a usage limit before producing findings.
