### PR TITLE
fix(ci): restore docs and test type checks

### DIFF
--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -1245,6 +1245,11 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Notes
   - H2: Related
 
+## cli/attach.md
+
+- Route: /cli/attach
+- Headings: none
+
 ## cli/backup.md
 
 - Route: /cli/backup

--- a/src/cli/attach-cli.action.test.ts
+++ b/src/cli/attach-cli.action.test.ts
@@ -11,12 +11,20 @@ const gatewayCalls: Array<{
   mode?: string;
   hasDeviceIdentityKey: boolean;
 }> = [];
+
+function gatewayParams(params: unknown): Record<string, unknown> {
+  if (typeof params !== "object" || params === null || Array.isArray(params)) {
+    throw new TypeError("Expected gateway params to be an object");
+  }
+  return params as Record<string, unknown>;
+}
+
 vi.mock("../gateway/call.js", () => ({
   callGateway: vi.fn(
     async (p: { method: string; params: Record<string, unknown>; mode?: string }) => {
       gatewayCalls.push({
         method: p.method,
-        params: p.params,
+        params: gatewayParams(p.params),
         mode: p.mode,
         hasDeviceIdentityKey: "deviceIdentity" in p,
       });
@@ -156,7 +164,7 @@ describe("openclaw attach (action)", () => {
     vi.mocked(callGateway).mockImplementationOnce(async (p) => {
       gatewayCalls.push({
         method: p.method,
-        params: p.params,
+        params: gatewayParams(p.params),
         mode: p.mode,
         hasDeviceIdentityKey: "deviceIdentity" in p,
       });
@@ -171,7 +179,7 @@ describe("openclaw attach (action)", () => {
     vi.mocked(callGateway).mockImplementationOnce(async (p) => {
       gatewayCalls.push({
         method: p.method,
-        params: p.params,
+        params: gatewayParams(p.params),
         mode: p.mode,
         hasDeviceIdentityKey: "deviceIdentity" in p,
       });


### PR DESCRIPTION
## What Problem This Solves

Current `main` fails `check-test-types` in the newly added attach CLI action tests, and `check-docs` reports that the generated docs map omits the attach CLI page.

## Why This Change Was Made

The gateway call contract exposes `params` as `unknown`. The test recorder now validates that boundary before storing object parameters. The generated docs map is refreshed with the existing `/cli/attach` page.

## User Impact

No runtime behavior changes. This restores the two CI checks that currently block unrelated pull requests.

## Evidence

- `pnpm test src/cli/attach-cli.action.test.ts` — 11 tests passed
- `pnpm docs:map:check` — up to date
- `git diff --check` — passed
- Autoreview — clean, 0.99 confidence
- `pnpm check:changed -- docs/docs_map.md src/cli/attach-cli.action.test.ts` — remote Testbox launch blocked locally because Crabbox 0.15.0 is older than the required 0.22.0; GitHub CI is the broad proof

