### PR TITLE
test(utils): add unit tests for asBoolean and parseBooleanValue

### DIFF
--- a/src/utils/boolean.test.ts
+++ b/src/utils/boolean.test.ts
@@ -1,0 +1,72 @@
+// Boolean utility tests cover config/env boolean parsing with string literals.
+import { describe, expect, it } from "vitest";
+import { asBoolean, parseBooleanValue } from "./boolean.js";
+
+describe("asBoolean", () => {
+  it("returns real booleans as-is", () => {
+    expect(asBoolean(true)).toBe(true);
+    expect(asBoolean(false)).toBe(false);
+  });
+
+  it("returns undefined for non-boolean values", () => {
+    expect(asBoolean("true")).toBeUndefined();
+    expect(asBoolean("false")).toBeUndefined();
+    expect(asBoolean(1)).toBeUndefined();
+    expect(asBoolean(0)).toBeUndefined();
+    expect(asBoolean(null)).toBeUndefined();
+    expect(asBoolean(undefined)).toBeUndefined();
+  });
+});
+
+describe("parseBooleanValue", () => {
+  it("passes through true and false without string matching", () => {
+    expect(parseBooleanValue(true)).toBe(true);
+    expect(parseBooleanValue(false)).toBe(false);
+  });
+
+  it("parses default truthy string literals", () => {
+    expect(parseBooleanValue("true")).toBe(true);
+    expect(parseBooleanValue("1")).toBe(true);
+    expect(parseBooleanValue("yes")).toBe(true);
+    expect(parseBooleanValue("on")).toBe(true);
+  });
+
+  it("parses default falsy string literals", () => {
+    expect(parseBooleanValue("false")).toBe(false);
+    expect(parseBooleanValue("0")).toBe(false);
+    expect(parseBooleanValue("no")).toBe(false);
+    expect(parseBooleanValue("off")).toBe(false);
+  });
+
+  it("is case-insensitive and whitespace-tolerant", () => {
+    expect(parseBooleanValue(" TRUE ")).toBe(true);
+    expect(parseBooleanValue("Yes")).toBe(true);
+    expect(parseBooleanValue(" FALSE ")).toBe(false);
+  });
+
+  it("returns undefined for unrecognized strings", () => {
+    expect(parseBooleanValue("maybe")).toBeUndefined();
+    expect(parseBooleanValue("")).toBeUndefined();
+  });
+
+  it("returns undefined for non-string and non-boolean values", () => {
+    expect(parseBooleanValue(42)).toBeUndefined();
+    expect(parseBooleanValue(null)).toBeUndefined();
+    expect(parseBooleanValue(undefined)).toBeUndefined();
+  });
+
+  it("accepts custom truthy and falsy literals", () => {
+    expect(
+      parseBooleanValue("enabled", {
+        truthy: ["enabled"],
+        falsy: ["disabled"],
+      }),
+    ).toBe(true);
+    expect(
+      parseBooleanValue("disabled", {
+        truthy: ["enabled"],
+        falsy: ["disabled"],
+      }),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

`asBoolean` and `parseBooleanValue` in `src/utils/boolean.ts` provide strict boolean coercion and config-style string literal parsing (true/false/yes/no/on/off) used across config, env, and plugin SDK runtime inputs. Despite being a shared parsing utility with multiple branches and custom literal support, it had no unit tests.

## Why This Change Was Made

Add 9 tests covering:
- `asBoolean`: real booleans pass through, non-booleans return undefined
- `parseBooleanValue`: default truthy/falsy literals, case-insensitivity, whitespace tolerance, boolean passthrough, unrecognized strings, non-string values, custom truthy/falsy options

## User Impact

No user-visible changes. The boolean parsing contract is now tested.

## Evidence

Reproducibility: not applicable.

Direct behavior probe (no mocks):

```text
$ node --import tsx -e "import('./src/utils/boolean.js').then((m)=>{
  const r=[];
  r.push({asBool_true:m.asBoolean(true),asBool_str:m.asBoolean('true')});
  r.push({parse_true:m.parseBooleanValue('true'),parse_on:m.parseBooleanValue('on')});
  r.push({parse_false:m.parseBooleanValue('false'),parse_off:m.parseBooleanValue('off')});
  r.push({parse_maybe:m.parseBooleanValue('maybe'),parse_empty:m.parseBooleanValue('')});
  r.push({parse_custom:m.parseBooleanValue('enabled',{truthy:['enabled'],falsy:['disabled']})});
  console.log(JSON.stringify(r,null,2));
})"
[
  {"asBool_true":true},
  {"parse_true":true,"parse_on":true},
  {"parse_false":false,"parse_off":false},
  {},
  {"parse_custom":true}
]
```

Targeted test:

```text
$ node scripts/run-vitest.mjs run src/utils/boolean.test.ts
 Test Files  1 passed (1)
      Tests  9 passed (9)
```

Formatting:

```text
$ npx oxfmt --check src/utils/boolean.ts src/utils/boolean.test.ts
All matched files use the correct format.
```

Whitespace:

```text
$ git diff --check
```