### PR TITLE
test(utils): add unit tests for safeParseWithSchema and safeParseJsonWithSchema

### DIFF
--- a/src/utils/zod-parse.test.ts
+++ b/src/utils/zod-parse.test.ts
@@ -1,0 +1,40 @@
+// Zod parse tests cover null-returning schema validation helpers.
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { safeParseJsonWithSchema, safeParseWithSchema } from "./zod-parse.js";
+
+const NameSchema = z.object({ name: z.string() });
+
+describe("safeParseWithSchema", () => {
+  it("returns parsed data when validation succeeds", () => {
+    expect(safeParseWithSchema(z.string(), "hello")).toBe("hello");
+    expect(safeParseWithSchema(NameSchema, { name: "test" })).toEqual({
+      name: "test",
+    });
+  });
+
+  it("returns null when validation fails", () => {
+    expect(safeParseWithSchema(z.string(), 123)).toBeNull();
+    expect(safeParseWithSchema(NameSchema, { name: 42 })).toBeNull();
+    expect(safeParseWithSchema(NameSchema, {})).toBeNull();
+  });
+});
+
+describe("safeParseJsonWithSchema", () => {
+  it("parses valid JSON and validates against schema", () => {
+    expect(safeParseJsonWithSchema(NameSchema, '{"name":"test"}')).toEqual({
+      name: "test",
+    });
+    expect(safeParseJsonWithSchema(z.array(z.number()), "[1,2,3]")).toEqual([1, 2, 3]);
+  });
+
+  it("returns null for malformed JSON", () => {
+    expect(safeParseJsonWithSchema(NameSchema, "{bad")).toBeNull();
+    expect(safeParseJsonWithSchema(NameSchema, "")).toBeNull();
+  });
+
+  it("returns null when JSON is valid but schema rejects", () => {
+    expect(safeParseJsonWithSchema(NameSchema, "{}")).toBeNull();
+    expect(safeParseJsonWithSchema(NameSchema, '{"name":42}')).toBeNull();
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

`safeParseWithSchema` and `safeParseJsonWithSchema` in `src/utils/zod-parse.ts` are null-returning Zod validation wrappers used at plugin and runtime boundaries where invalid external payloads should be silently ignored. Despite being a core validation primitive, they had no unit tests.

## Why This Change Was Made

Add 5 tests covering:
- `safeParseWithSchema`: successful validation returns data, validation failure returns null
- `safeParseJsonWithSchema`: valid JSON with valid schema returns data, malformed JSON returns null, valid JSON rejected by schema returns null

## User Impact

No user-visible changes. The Zod parse wrapper contract is now tested.

## Evidence

Reproducibility: not applicable.

Direct behavior probe (no mocks):

```text
$ node --import tsx -e "import('./src/utils/zod-parse.js').then((m)=>{
  const {z}=require('zod'); const S=z.object({name:z.string()});
  const r=[];
  r.push({valid:m.safeParseWithSchema(S,{name:'test'})});
  r.push({invalid:m.safeParseWithSchema(S,{name:42})});
  r.push({json_valid:m.safeParseJsonWithSchema(S,'{\"name\":\"x\"}')});
  r.push({json_bad:m.safeParseJsonWithSchema(S,'{bad')});
  r.push({json_schema_reject:m.safeParseJsonWithSchema(S,'{}')});
  console.log(JSON.stringify(r,null,2));
})"
[
  {"valid":{"name":"test"}},
  {"invalid":null},
  {"json_valid":{"name":"x"}},
  {"json_bad":null},
  {"json_schema_reject":null}
]
```

Targeted test:

```text
$ node scripts/run-vitest.mjs run src/utils/zod-parse.test.ts
 Test Files  1 passed (1)
      Tests  5 passed (5)
```

Formatting:

```text
$ npx oxfmt --check src/utils/zod-parse.ts src/utils/zod-parse.test.ts
All matched files use the correct format.
```

Whitespace:

```text
$ git diff --check
```