### PR TITLE
test(shared): add unit tests for modelKey

### DIFF
--- a/src/shared/model-key.test.ts
+++ b/src/shared/model-key.test.ts
@@ -1,0 +1,28 @@
+// Model key tests cover canonical provider/model key construction.
+import { describe, expect, it } from "vitest";
+import { modelKey } from "./model-key.js";
+
+describe("modelKey", () => {
+  it("joins provider and model into a canonical key", () => {
+    expect(modelKey("openai", "gpt-5")).toBe("openai/gpt-5");
+    expect(modelKey("anthropic", "claude-opus-4-8")).toBe("anthropic/claude-opus-4-8");
+  });
+
+  it("returns the model alone when provider is empty", () => {
+    expect(modelKey("", "gpt-5")).toBe("gpt-5");
+    expect(modelKey("   ", "gpt-5")).toBe("gpt-5");
+  });
+
+  it("returns the provider alone when model is empty", () => {
+    expect(modelKey("openai", "")).toBe("openai");
+    expect(modelKey("openai", "   ")).toBe("openai");
+  });
+
+  it("avoids double prefix when model already contains provider prefix", () => {
+    expect(modelKey("openai", "openai/gpt-5")).toBe("openai/gpt-5");
+  });
+
+  it("trims whitespace from both arguments", () => {
+    expect(modelKey(" openai ", " gpt-5 ")).toBe("openai/gpt-5");
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

`modelKey` in `src/shared/model-key.ts` constructs canonical provider/model keys (e.g., `openai/gpt-5`) with whitespace trimming, empty-argument fallback, and double-prefix avoidance. Despite being used across the model catalog, it had no unit tests.

## Why This Change Was Made

Add 5 tests covering:
- Joining provider and model into a canonical key
- Returning model alone when provider is empty/whitespace
- Returning provider alone when model is empty/whitespace
- Avoiding double prefix when model already contains provider prefix
- Trimming whitespace from both arguments

## User Impact

No user-visible changes. The model key construction contract is now tested.

## Evidence

Reproducibility: not applicable.

Direct behavior probe (no mocks):

```text
$ node --import tsx -e "import('./src/shared/model-key.js').then((m)=>{
  const r=[];
  r.push({join:m.modelKey('openai','gpt-5')});
  r.push({empty_provider:m.modelKey('','gpt-5')});
  r.push({empty_model:m.modelKey('openai','')});
  r.push({no_double_prefix:m.modelKey('openai','openai/gpt-5')});
  r.push({trim:m.modelKey(' openai ',' gpt-5 ')});
  console.log(JSON.stringify(r,null,2));
})"
[
  {"join":"openai/gpt-5"},
  {"empty_provider":"gpt-5"},
  {"empty_model":"openai"},
  {"no_double_prefix":"openai/gpt-5"},
  {"trim":"openai/gpt-5"}
]
```

Targeted test:

```text
$ node scripts/run-vitest.mjs run src/shared/model-key.test.ts
 Test Files  1 passed (1)
      Tests  5 passed (5)
```

Formatting:

```text
$ npx oxfmt --check src/shared/model-key.ts src/shared/model-key.test.ts
All matched files use the correct format.
```

Whitespace:

```text
$ git diff --check
```