### PR TITLE
[AI-assisted] feat(android): add chat command controls

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -123,7 +123,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 101,
+      "line": 102,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Searching…",
       "surface": "android",
@@ -131,7 +131,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 188,
+      "line": 189,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Mic off",
       "surface": "android",
@@ -139,7 +139,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 198,
+      "line": 199,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Off",
       "surface": "android",
@@ -179,7 +179,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 499,
+      "line": 500,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Offline",
       "surface": "android",
@@ -187,7 +187,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2007,
+      "line": 2009,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: this host requires wss:// or Tailscale Serve. No TLS endpoint detected.",
       "surface": "android",
@@ -195,7 +195,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2009,
+      "line": 2011,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: secure endpoint reached, but TLS fingerprint verification timed out. Check Tailscale Serve or gateway TLS and retry.",
       "surface": "android",
@@ -203,7 +203,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2011,
+      "line": 2013,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "surface": "android",
@@ -4987,7 +4987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 141,
+      "line": 172,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatComposer.kt",
       "source": "Type a message…",
       "surface": "android",
@@ -4995,7 +4995,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 151,
+      "line": 182,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatComposer.kt",
       "source": "Gateway is offline. Open Settings to reconnect.",
       "surface": "android",
@@ -5003,7 +5003,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 180,
+      "line": 211,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatComposer.kt",
       "source": "Select thinking level",
       "surface": "android",
@@ -5011,7 +5011,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 204,
+      "line": 235,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatComposer.kt",
       "source": "Attach",
       "surface": "android",
@@ -5019,7 +5019,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 212,
+      "line": 243,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatComposer.kt",
       "source": "Refresh",
       "surface": "android",
@@ -5027,7 +5027,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 220,
+      "line": 251,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatComposer.kt",
       "source": "Abort",
       "surface": "android",
@@ -5035,11 +5035,19 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 255,
+      "line": 289,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatComposer.kt",
       "source": "Send",
       "surface": "android",
       "id": "native.android.02b1552edc8d59da"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 315,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatComposer.kt",
+      "source": "No commands found",
+      "surface": "android",
+      "id": "native.android.ff4e568bce360d5f"
     },
     {
       "kind": "ui-named-argument",
@@ -5139,7 +5147,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 201,
+      "line": 224,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat needs attention",
       "surface": "android",
@@ -5147,7 +5155,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 326,
+      "line": 350,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "All",
       "surface": "android",
@@ -5155,7 +5163,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 377,
+      "line": 409,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw",
       "surface": "android",
@@ -5163,7 +5171,15 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 398,
+      "line": 430,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "New chat",
+      "surface": "android",
+      "id": "native.android.4437f3cbdb3c8cbe"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 431,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Refresh chat",
       "surface": "android",
@@ -5171,7 +5187,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 401,
+      "line": 434,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat",
       "surface": "android",
@@ -5179,7 +5195,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 525,
+      "line": 561,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Loading session",
       "surface": "android",
@@ -5187,7 +5203,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 552,
+      "line": 588,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Jump to latest",
       "surface": "android",
@@ -5195,7 +5211,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 572,
+      "line": 608,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Ready when you are",
       "surface": "android",
@@ -5203,7 +5219,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 603,
+      "line": 639,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Fix connection",
       "surface": "android",
@@ -5211,7 +5227,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 604,
+      "line": 640,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Copy diagnostics",
       "surface": "android",
@@ -5219,7 +5235,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 741,
+      "line": 777,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Tools running",
       "surface": "android",
@@ -5227,7 +5243,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 746,
+      "line": 782,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "+${toolCalls.size - 4} more",
       "surface": "android",
@@ -5235,7 +5251,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 756,
+      "line": 792,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Thinking",
       "surface": "android",
@@ -5243,7 +5259,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 757,
+      "line": 793,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw is preparing a response.",
       "surface": "android",
@@ -5251,7 +5267,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 850,
+      "line": 905,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Stop",
       "surface": "android",
@@ -5259,7 +5275,15 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 867,
+      "line": 922,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "No commands found",
+      "surface": "android",
+      "id": "native.android.5953c956ff208e6e"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 984,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Gateway offline",
       "surface": "android",
@@ -5267,7 +5291,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 957,
+      "line": 1074,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Attach image",
       "surface": "android",
@@ -5275,7 +5299,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 972,
+      "line": 1089,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Message OpenClaw",
       "surface": "android",
@@ -5283,7 +5307,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 987,
+      "line": 1104,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Voice",
       "surface": "android",
@@ -5291,7 +5315,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1025,
+      "line": 1142,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Remove attachment",
       "surface": "android",
@@ -5299,15 +5323,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1037,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "New chat",
-      "surface": "android",
-      "id": "native.android.326caa6b92aa9bdf"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 1046,
+      "line": 1163,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Main",
       "surface": "android",
@@ -5315,7 +5331,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1102,
+      "line": 1219,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Send",
       "surface": "android",
@@ -5323,7 +5339,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1141,
+      "line": 1258,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$contextLabel · ${contextMeterThinkingLabel(thinkingLevel)}",
       "surface": "android",
@@ -5331,7 +5347,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 268,
+      "line": 272,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatSheetContent.kt",
       "source": "CHAT ERROR",
       "surface": "android",

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
@@ -1,5 +1,6 @@
 package ai.openclaw.app
 
+import ai.openclaw.app.chat.ChatCommandEntry
 import ai.openclaw.app.chat.ChatMessage
 import ai.openclaw.app.chat.ChatPendingToolCall
 import ai.openclaw.app.chat.ChatSessionEntry
@@ -210,6 +211,7 @@ class MainViewModel(
   val chatPendingToolCalls: StateFlow<List<ChatPendingToolCall>> = runtimeState(initial = emptyList()) { it.chatPendingToolCalls }
   val chatSessions: StateFlow<List<ChatSessionEntry>> = runtimeState(initial = emptyList()) { it.chatSessions }
   val pendingRunCount: StateFlow<Int> = runtimeState(initial = 0) { it.pendingRunCount }
+  val chatCommands: StateFlow<List<ChatCommandEntry>> = runtimeState(initial = emptyList<ChatCommandEntry>()) { it.chatCommands }
   val execApprovals: StateFlow<List<GatewayExecApprovalSummary>> = runtimeState(initial = emptyList()) { it.execApprovals }
   val execApprovalsRefreshing: StateFlow<Boolean> = runtimeState(initial = false) { it.execApprovalsRefreshing }
   val execApprovalsErrorText: StateFlow<String?> = runtimeState(initial = null) { it.execApprovalsErrorText }
@@ -598,6 +600,14 @@ class MainViewModel(
 
   fun abortChat() {
     ensureRuntime().abortChat()
+  }
+
+  fun startNewChat() {
+    ensureRuntime().startNewChat()
+  }
+
+  fun refreshChatCommands() {
+    ensureRuntime().refreshChatCommands()
   }
 
   fun sendChat(

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -1,6 +1,7 @@
 package ai.openclaw.app
 
 import ai.openclaw.app.chat.ChatController
+import ai.openclaw.app.chat.ChatCommandEntry
 import ai.openclaw.app.chat.ChatMessage
 import ai.openclaw.app.chat.ChatPendingToolCall
 import ai.openclaw.app.chat.ChatSessionEntry
@@ -1260,6 +1261,7 @@ class NodeRuntime(
   val chatPendingToolCalls: StateFlow<List<ChatPendingToolCall>> = chat.pendingToolCalls
   val chatSessions: StateFlow<List<ChatSessionEntry>> = chat.sessions
   val pendingRunCount: StateFlow<Int> = chat.pendingRunCount
+  val chatCommands: StateFlow<List<ChatCommandEntry>> = chat.commands
 
   init {
     if (prefs.voiceWakeMode.value != VoiceWakeMode.Off) {
@@ -2193,6 +2195,10 @@ class NodeRuntime(
     chat.abort()
   }
 
+  fun startNewChat() {
+    chat.startNewChat()
+  }
+
   fun sendChat(
     message: String,
     thinking: String,
@@ -2206,6 +2212,10 @@ class NodeRuntime(
     thinking: String,
     attachments: List<OutgoingAttachment>,
   ): Boolean = chat.sendMessageAwaitAcceptance(message = message, thinkingLevel = thinking, attachments = attachments)
+
+  fun refreshChatCommands() {
+    chat.refreshCommands()
+  }
 
   private fun handleGatewayEvent(
     event: String,

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -1,5 +1,6 @@
 package ai.openclaw.app.chat
 
+import ai.openclaw.app.resolveAgentIdFromMainSessionKey
 import ai.openclaw.app.gateway.GatewaySession
 import ai.openclaw.app.gateway.parseChatSendAck
 import kotlinx.coroutines.CoroutineScope
@@ -18,6 +19,7 @@ import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
 
 class ChatController internal constructor(
@@ -70,6 +72,9 @@ class ChatController internal constructor(
   private val _sessions = MutableStateFlow<List<ChatSessionEntry>>(emptyList())
   val sessions: StateFlow<List<ChatSessionEntry>> = _sessions.asStateFlow()
 
+  private val _commands = MutableStateFlow<List<ChatCommandEntry>>(emptyList())
+  val commands: StateFlow<List<ChatCommandEntry>> = _commands.asStateFlow()
+
   private val pendingRuns = mutableSetOf<String>()
   private val pendingRunTimeoutJobs = ConcurrentHashMap<String, Job>()
 
@@ -79,13 +84,17 @@ class ChatController internal constructor(
 
   // Drops stale history responses after session switches or refresh races.
   private val historyLoadGeneration = AtomicLong(0)
+  private val newChatCreateInFlight = AtomicBoolean(false)
 
   private var lastHealthPollAtMs: Long? = null
+  private var commandsAgentId: String? = null
 
   /** Clears transient chat state when the operator gateway session disconnects. */
   fun onDisconnected(message: String) {
     _healthOk.value = false
     _errorText.value = null
+    _commands.value = emptyList()
+    commandsAgentId = null
     clearPendingRuns()
     pendingToolCallsById.clear()
     publishPendingToolCalls()
@@ -139,6 +148,59 @@ class ChatController internal constructor(
     scope.launch { fetchSessions(limit = limit) }
   }
 
+  /** Starts a fresh chat for the active gateway session key. */
+  fun startNewChat() {
+    scope.launch { startNewChatAwait() }
+  }
+
+  /** Starts a fresh chat and returns whether the gateway created the session. */
+  suspend fun startNewChatAwait(): Boolean {
+    val parentKey = normalizeRequestedSessionKey(_sessionKey.value)
+    if (parentKey.isEmpty()) return false
+    if (_pendingRunCount.value > 0) {
+      _errorText.value = "Wait for the current response to finish before starting a new chat."
+      return false
+    }
+    if (!newChatCreateInFlight.compareAndSet(false, true)) {
+      return false
+    }
+    val requestGeneration = historyLoadGeneration.get()
+    _errorText.value = null
+    _historyLoading.value = true
+    return try {
+      val label = nextNewChatSessionLabel(_sessions.value)
+      val hasLoadedParentSession = !_sessionId.value.isNullOrBlank()
+      val params =
+        buildJsonObject {
+          put("agentId", JsonPrimitive(resolveAgentIdForSessionKey(parentKey)))
+          if (hasLoadedParentSession) {
+            put("parentSessionKey", JsonPrimitive(parentKey))
+            put("emitCommandHooks", JsonPrimitive(true))
+          }
+          put("label", JsonPrimitive(label))
+        }
+      val res = requestGateway("sessions.create", params.toString())
+      if (!isCurrentHistoryLoad(parentKey, _sessionKey.value, requestGeneration, historyLoadGeneration.get())) {
+        return false
+      }
+      val createdKey = parseCreatedSessionKey(json, res) ?: parentKey
+      val generation = beginHistoryLoad(createdKey, clearMessages = true)
+      bootstrap(sessionKey = createdKey, generation = generation, forceHealth = true, refreshSessions = true)
+      true
+    } catch (err: Throwable) {
+      _errorText.value = err.message
+      _historyLoading.value = false
+      false
+    } finally {
+      newChatCreateInFlight.set(false)
+    }
+  }
+
+  /** Refreshes the available text slash commands for the current gateway. */
+  fun refreshCommands() {
+    scope.launch { fetchCommands() }
+  }
+
   /** Persists the normalized thinking level used for subsequent chat sends. */
   fun setThinkingLevel(thinkingLevel: String) {
     val normalized = normalizeThinking(thinkingLevel)
@@ -163,6 +225,11 @@ class ChatController internal constructor(
   ): Long {
     val generation = historyLoadGeneration.incrementAndGet()
     _sessionKey.value = key
+    val nextAgentId = resolveAgentIdForSessionKey(key)
+    if (commandsAgentId != nextAgentId) {
+      _commands.value = emptyList()
+      commandsAgentId = null
+    }
     _errorText.value = null
     _healthOk.value = false
     clearPendingRuns()
@@ -183,6 +250,9 @@ class ChatController internal constructor(
     if (key == "main" && appliedMainSessionKey != "main") return appliedMainSessionKey
     return key
   }
+
+  private fun resolveAgentIdForSessionKey(parentKey: String): String =
+    resolveAgentIdFromMainSessionKey(parentKey) ?: "main"
 
   /** Queues a chat send without waiting for gateway acceptance. */
   fun sendMessage(
@@ -350,6 +420,7 @@ class ChatController internal constructor(
       }
       "health" -> {
         _healthOk.value = true
+        refreshCommandsAfterReconnect()
       }
       "seqGap" -> {
         _errorText.value = "Event stream interrupted; try refreshing."
@@ -427,6 +498,28 @@ class ChatController internal constructor(
     }
   }
 
+  private suspend fun fetchCommands() {
+    val agentId = resolveAgentIdForSessionKey(_sessionKey.value)
+    try {
+      val params =
+        buildJsonObject {
+          put("agentId", JsonPrimitive(agentId))
+          put("scope", JsonPrimitive("text"))
+          put("includeArgs", JsonPrimitive(true))
+        }
+      val res = requestGateway("commands.list", params.toString())
+      if (agentId == resolveAgentIdForSessionKey(_sessionKey.value)) {
+        _commands.value = parseChatCommands(json, res)
+        commandsAgentId = agentId
+      }
+    } catch (_: Throwable) {
+      if (agentId == resolveAgentIdForSessionKey(_sessionKey.value)) {
+        _commands.value = emptyList()
+        commandsAgentId = null
+      }
+    }
+  }
+
   private fun refreshSessionsForCurrentWindow() {
     scope.launch { fetchSessions(limit = _sessions.value.size.takeIf { it > 0 } ?: 100) }
   }
@@ -439,9 +532,17 @@ class ChatController internal constructor(
     try {
       requestGateway("health", null)
       _healthOk.value = true
+      if (_commands.value.isEmpty() || commandsAgentId != resolveAgentIdForSessionKey(_sessionKey.value)) {
+        fetchCommands()
+      }
     } catch (_: Throwable) {
       _healthOk.value = false
     }
+  }
+
+  private fun refreshCommandsAfterReconnect() {
+    if (_commands.value.isNotEmpty() && commandsAgentId == resolveAgentIdForSessionKey(_sessionKey.value)) return
+    scope.launch { fetchCommands() }
   }
 
   private fun handleChatEvent(payloadJson: String) {
@@ -811,6 +912,25 @@ class ChatController internal constructor(
     }
 }
 
+private const val NEW_CHAT_SESSION_LABEL = "New chat"
+
+internal fun nextNewChatSessionLabel(sessions: List<ChatSessionEntry>): String {
+  val baseLabel = NEW_CHAT_SESSION_LABEL
+  val existingLabels =
+    sessions
+      .mapNotNull { session -> session.displayName?.trim()?.takeIf { it.isNotEmpty() } }
+      .toSet()
+  if (baseLabel !in existingLabels) return baseLabel
+
+  var suffix = 2
+  while (newChatSessionLabelWithSuffix(suffix) in existingLabels) {
+    suffix += 1
+  }
+  return newChatSessionLabelWithSuffix(suffix)
+}
+
+private fun newChatSessionLabelWithSuffix(suffix: Int): String = NEW_CHAT_SESSION_LABEL + ' ' + suffix
+
 internal fun isCurrentHistoryLoad(
   requestedSessionKey: String,
   currentSessionKey: String,
@@ -853,6 +973,50 @@ internal fun parseChatMessageContents(obj: JsonObject): List<ChatMessageContent>
     return listOf(ChatMessageContent(type = "text", text = text))
   }
   return emptyList()
+}
+
+private fun parseCreatedSessionKey(json: Json, sessionJson: String): String? {
+  val root = runCatching { json.parseToJsonElement(sessionJson).asObjectOrNull() }.getOrNull() ?: return null
+  fun clean(value: String?): String? = value?.trim()?.takeIf { it.isNotEmpty() }
+  return clean(root["key"].asStringOrNull())
+    ?: clean(root["sessionKey"].asStringOrNull())
+    ?: root["session"].asObjectOrNull()?.let { session ->
+      clean(session["key"].asStringOrNull()) ?: clean(session["sessionKey"].asStringOrNull())
+    }
+}
+
+internal fun parseChatCommands(
+  json: Json,
+  commandsJson: String,
+): List<ChatCommandEntry> {
+  val root = json.parseToJsonElement(commandsJson).asObjectOrNull() ?: return emptyList()
+  val commands = root["commands"].asArrayOrNull() ?: return emptyList()
+  return commands.mapNotNull { item -> parseChatCommandEntry(item.asObjectOrNull()) }
+}
+
+private fun parseChatCommandEntry(obj: JsonObject?): ChatCommandEntry? {
+  if (obj == null) return null
+  val aliases =
+    obj["textAliases"]
+      .asArrayOrNull()
+      ?.mapNotNull { alias -> alias.asStringOrNull()?.trim()?.takeIf { it.startsWith("/") && it.length > 1 } }
+      ?.distinct()
+      .orEmpty()
+  val name =
+    obj["name"]
+      .asStringOrNull()
+      ?.trim()
+      ?.removePrefix("/")
+      ?.takeIf { it.isNotEmpty() }
+      ?: aliases.firstOrNull()?.removePrefix("/")
+      ?: return null
+  return ChatCommandEntry(
+    name = name,
+    description = obj["description"].asStringOrNull()?.trim().orEmpty(),
+    category = obj["category"].asStringOrNull()?.trim()?.takeIf { it.isNotEmpty() },
+    textAliases = aliases,
+    acceptsArgs = obj["acceptsArgs"].asBooleanOrNull() ?: false,
+  )
 }
 
 internal data class MainSessionState(

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatModels.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatModels.kt
@@ -47,6 +47,18 @@ data class ChatSessionEntry(
 )
 
 /**
+ * Slash command metadata exposed by the gateway for text-surface chat clients.
+ */
+data class ChatCommandEntry(
+  val name: String,
+  val description: String,
+  val category: String? = null,
+  val textAliases: List<String> = emptyList(),
+  val acceptsArgs: Boolean = false,
+)
+
+
+/**
  * Snapshot of one chat session, including optional thinking level selected on the gateway.
  */
 data class ChatHistory(

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatCommandControls.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatCommandControls.kt
@@ -1,0 +1,61 @@
+package ai.openclaw.app.ui.chat
+
+import ai.openclaw.app.chat.ChatCommandEntry
+import java.util.Locale
+
+internal fun slashCommandQuery(input: String): String? {
+  val trimmed = input.trimStart()
+  if (!trimmed.startsWith("/")) return null
+  val token = trimmed.drop(1).takeWhile { !it.isWhitespace() }
+  return token.lowercase(Locale.US)
+}
+
+internal fun shouldShowSlashCommandMenu(input: String): Boolean = slashCommandQuery(input) != null
+
+internal fun matchingSlashCommands(
+  input: String,
+  commands: List<ChatCommandEntry>,
+  limit: Int = 6,
+): List<ChatCommandEntry> {
+  val query = slashCommandQuery(input) ?: return emptyList()
+  val uniqueCommands = commands.map { command -> command.withMatchedSlashAliasFirst(query) }.distinctBy { slashCommandText(it) }
+  val matches =
+    if (query.isEmpty()) {
+      uniqueCommands
+    } else {
+      uniqueCommands.filter { command ->
+        slashCommandPrefixes(command).any { prefix -> prefix.startsWith(query) }
+      }
+    }
+  return matches.take(limit)
+}
+
+internal fun slashCommandText(command: ChatCommandEntry): String {
+  command.textAliases
+    .firstOrNull { alias -> alias.startsWith("/") && alias.length > 1 }
+    ?.let { return it }
+  val name = command.name.trim().removePrefix("/").takeIf { it.isNotEmpty() } ?: "help"
+  return "/$name"
+}
+
+internal fun slashCommandCompletion(command: ChatCommandEntry): String {
+  val text = slashCommandText(command)
+  return if (command.acceptsArgs) "$text " else text
+}
+
+private fun slashCommandPrefixes(command: ChatCommandEntry): List<String> =
+  buildList {
+    add(normalizedSlashCommandName(command.name))
+    command.textAliases.forEach { alias ->
+      add(normalizedSlashCommandName(alias))
+    }
+  }.filter { it.isNotEmpty() }
+
+private fun ChatCommandEntry.withMatchedSlashAliasFirst(query: String): ChatCommandEntry {
+  if (query.isEmpty()) return this
+  val match = textAliases.firstOrNull { alias -> normalizedSlashCommandName(alias).startsWith(query) } ?: return this
+  if (textAliases.firstOrNull() == match) return this
+  return copy(textAliases = listOf(match) + textAliases.filterNot { it == match })
+}
+
+private fun normalizedSlashCommandName(value: String): String = value.trim().removePrefix("/").lowercase(Locale.US)

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatComposer.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatComposer.kt
@@ -1,5 +1,6 @@
 package ai.openclaw.app.ui.chat
 
+import ai.openclaw.app.chat.ChatCommandEntry
 import ai.openclaw.app.ui.mobileAccent
 import ai.openclaw.app.ui.mobileAccentBorderStrong
 import ai.openclaw.app.ui.mobileAccentSoft
@@ -67,6 +68,20 @@ internal data class DraftApplication(
   val consumed: Boolean,
 )
 
+internal data class SheetSlashCommandSelection(
+  val input: String,
+)
+
+internal data class SheetComposerSendAction(
+  val sendMessage: Boolean,
+)
+
+internal fun resolveSheetSlashCommandSelection(command: ChatCommandEntry): SheetSlashCommandSelection =
+  SheetSlashCommandSelection(input = slashCommandCompletion(command))
+
+internal fun resolveSheetComposerSendAction(input: String): SheetComposerSendAction =
+  SheetComposerSendAction(sendMessage = input.trim().isNotEmpty())
+
 /** Applies a draft exactly once so restored prompts do not overwrite user edits. */
 internal fun applyDraftText(
   draftText: String?,
@@ -100,6 +115,7 @@ fun ChatComposer(
   healthOk: Boolean,
   thinkingLevel: String,
   pendingRunCount: Int,
+  commands: List<ChatCommandEntry>,
   attachments: List<PendingImageAttachment>,
   onDraftApplied: () -> Unit,
   onPickImages: () -> Unit,
@@ -112,6 +128,10 @@ fun ChatComposer(
   var input by rememberSaveable { mutableStateOf("") }
   var lastAppliedDraft by rememberSaveable { mutableStateOf<String?>(null) }
   var showThinkingMenu by remember { mutableStateOf(false) }
+  val slashCommands =
+    remember(input, commands) {
+      matchingSlashCommands(input = input, commands = commands)
+    }
 
   LaunchedEffect(draftText) {
     val next = applyDraftText(draftText = draftText, currentInput = input, lastAppliedDraft = lastAppliedDraft)
@@ -126,12 +146,23 @@ fun ChatComposer(
 
   // One in-flight run owns the composer actions; attachments alone are enough
   // to send when the gateway is healthy.
-  val canSend = pendingRunCount == 0 && (input.trim().isNotEmpty() || attachments.isNotEmpty()) && healthOk
+  val canSend =
+    pendingRunCount == 0 && (input.trim().isNotEmpty() || attachments.isNotEmpty()) && healthOk
   val sendBusy = pendingRunCount > 0
 
   Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(8.dp)) {
     if (attachments.isNotEmpty()) {
       AttachmentsStrip(attachments = attachments, onRemoveAttachment = onRemoveAttachment)
+    }
+
+    if (shouldShowSlashCommandMenu(input)) {
+      SheetSlashCommandPanel(
+        commands = slashCommands,
+        onSelect = { command ->
+          val selection = resolveSheetSlashCommandSelection(command = command)
+          input = selection.input
+        },
+      )
     }
 
     OutlinedTextField(
@@ -228,9 +259,12 @@ fun ChatComposer(
 
       Button(
         onClick = {
-          val text = input
-          input = ""
-          onSend(text)
+          val message = input.trim()
+          val action = resolveSheetComposerSendAction(input = message)
+          if (action.sendMessage || attachments.isNotEmpty()) {
+            input = ""
+            onSend(message)
+          }
         },
         enabled = canSend,
         modifier = Modifier.height(44.dp),
@@ -257,6 +291,64 @@ fun ChatComposer(
           maxLines = 1,
           overflow = TextOverflow.Ellipsis,
         )
+      }
+    }
+  }
+}
+
+@Composable
+private fun SheetSlashCommandPanel(
+  commands: List<ChatCommandEntry>,
+  onSelect: (ChatCommandEntry) -> Unit,
+) {
+  Surface(
+    modifier = Modifier.fillMaxWidth(),
+    color = mobileCardSurface,
+    shape = RoundedCornerShape(14.dp),
+    border = BorderStroke(1.dp, mobileBorderStrong),
+    tonalElevation = 0.dp,
+    shadowElevation = 0.dp,
+  ) {
+    Column(modifier = Modifier.padding(8.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+      if (commands.isEmpty()) {
+        Text(
+          text = "No commands found",
+          style = mobileCaption1,
+          color = mobileTextTertiary,
+        )
+      } else {
+        for (command in commands) {
+          Surface(
+            onClick = { onSelect(command) },
+            shape = RoundedCornerShape(10.dp),
+            color = Color.Transparent,
+            contentColor = mobileText,
+          ) {
+            Row(
+              modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp, vertical = 7.dp),
+              verticalAlignment = Alignment.CenterVertically,
+              horizontalArrangement = Arrangement.spacedBy(10.dp),
+            ) {
+              Text(
+                text = slashCommandText(command),
+                style = mobileCaption1.copy(fontWeight = FontWeight.Bold),
+                color = mobileText,
+                modifier = Modifier.width(76.dp),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+              )
+              Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(1.dp)) {
+                Text(
+                  text = command.description.ifBlank { command.category ?: "Command" },
+                  style = mobileCaption1,
+                  color = mobileTextSecondary,
+                  maxLines = 1,
+                  overflow = TextOverflow.Ellipsis,
+                )
+              }
+            }
+          }
+        }
       }
     }
   }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
@@ -2,6 +2,7 @@ package ai.openclaw.app.ui.chat
 
 import ai.openclaw.app.MainViewModel
 import ai.openclaw.app.R
+import ai.openclaw.app.chat.ChatCommandEntry
 import ai.openclaw.app.chat.ChatMessage
 import ai.openclaw.app.chat.ChatMessageContent
 import ai.openclaw.app.chat.ChatPendingToolCall
@@ -44,6 +45,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.AttachFile
 import androidx.compose.material.icons.filled.Close
@@ -105,6 +107,7 @@ fun ChatScreen(
   val streamingAssistantText by viewModel.chatStreamingAssistantText.collectAsState()
   val pendingToolCalls by viewModel.chatPendingToolCalls.collectAsState()
   val sessions by viewModel.chatSessions.collectAsState()
+  val chatCommands by viewModel.chatCommands.collectAsState()
   val chatDraft by viewModel.chatDraft.collectAsState()
   val pendingAssistantAutoSend by viewModel.pendingAssistantAutoSend.collectAsState()
   val remoteAddress by viewModel.remoteAddress.collectAsState()
@@ -144,6 +147,7 @@ fun ChatScreen(
       viewModel.loadChat(loadSessionKey)
     }
     viewModel.refreshChatSessions(limit = 100)
+    viewModel.refreshChatCommands()
   }
 
   LaunchedEffect(pendingAssistantAutoSend, healthOk, pendingRunCount, thinkingLevel) {
@@ -168,6 +172,21 @@ fun ChatScreen(
     viewModel.clearChatDraft()
   }
 
+  val newChatEnabled =
+    canStartNewChat(
+      pendingRunCount = pendingRunCount,
+      hasQueuedMessage = pendingAssistantAutoSend != null,
+      gatewayReady = healthOk && !gatewayOffline,
+    )
+
+  val startNewChat = {
+    if (newChatEnabled) {
+      viewModel.startNewChat()
+      viewModel.refreshChatSessions(limit = 100)
+      viewModel.refreshChatCommands()
+    }
+  }
+
   Column(
     modifier =
       Modifier
@@ -179,6 +198,10 @@ fun ChatScreen(
       sessionTitle = currentSessionTitle(sessionKey = sessionKey, sessions = sessions),
       healthOk = healthOk,
       pendingRunCount = pendingRunCount,
+      newChatEnabled = newChatEnabled,
+      onNewChat = {
+        startNewChat()
+      },
       onMore = {
         viewModel.refreshChat()
         viewModel.refreshChatSessions(limit = 100)
@@ -226,6 +249,7 @@ fun ChatScreen(
       gatewayOffline = gatewayOffline,
       offlineStatus = offlineStatus,
       pendingRunCount = pendingRunCount,
+      commands = chatCommands,
       onThinkingLevelChange = viewModel::setChatThinkingLevel,
       onPickImages = { pickImages.launch("image/*") },
       onRemoveAttachment = { id -> attachments.removeAll { it.id == id } },
@@ -354,11 +378,19 @@ private fun ChatSessionChip(
   }
 }
 
+internal fun canStartNewChat(
+  pendingRunCount: Int,
+  hasQueuedMessage: Boolean,
+  gatewayReady: Boolean,
+): Boolean = gatewayReady && pendingRunCount == 0 && !hasQueuedMessage
+
 @Composable
 private fun ChatHeader(
   sessionTitle: String,
   healthOk: Boolean,
   pendingRunCount: Int,
+  newChatEnabled: Boolean,
+  onNewChat: () -> Unit,
   onMore: () -> Unit,
 ) {
   Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
@@ -395,6 +427,7 @@ private fun ChatHeader(
             else -> ClawStatus.Danger
           },
       )
+      HeaderIcon(icon = Icons.Default.Add, contentDescription = "New chat", enabled = newChatEnabled, onClick = onNewChat)
       HeaderIcon(icon = Icons.Default.Refresh, contentDescription = "Refresh chat", onClick = onMore)
     }
     Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
@@ -446,14 +479,17 @@ private fun ModelPill(
 private fun HeaderIcon(
   icon: androidx.compose.ui.graphics.vector.ImageVector,
   contentDescription: String,
+  enabled: Boolean = true,
   onClick: () -> Unit,
 ) {
+  val contentColor = if (enabled) ClawTheme.colors.text else ClawTheme.colors.textMuted
   Surface(
     onClick = onClick,
+    enabled = enabled,
     modifier = Modifier.size(ClawTheme.spacing.touchTarget),
     shape = CircleShape,
     color = Color.Transparent,
-    contentColor = ClawTheme.colors.text,
+    contentColor = contentColor,
   ) {
     Box(contentAlignment = Alignment.Center) {
       Icon(imageVector = icon, contentDescription = contentDescription, modifier = Modifier.size(20.dp))
@@ -796,6 +832,7 @@ private fun ChatComposer(
   gatewayOffline: Boolean,
   offlineStatus: String,
   pendingRunCount: Int,
+  commands: List<ChatCommandEntry>,
   onThinkingLevelChange: (String) -> Unit,
   onPickImages: () -> Unit,
   onRemoveAttachment: (String) -> Unit,
@@ -805,6 +842,11 @@ private fun ChatComposer(
   onAbort: () -> Unit,
   onSend: () -> Unit,
 ) {
+  val slashCommands =
+    remember(value, commands) {
+      matchingSlashCommands(input = value, commands = commands)
+    }
+
   Column(modifier = Modifier.fillMaxWidth().imePadding(), verticalArrangement = Arrangement.spacedBy(4.dp)) {
     if (attachments.isNotEmpty()) {
       AttachmentStrip(attachments = attachments, onRemoveAttachment = onRemoveAttachment)
@@ -816,8 +858,21 @@ private fun ChatComposer(
       onClick = { onThinkingLevelChange(nextThinkingValue(thinkingLevel)) },
     )
 
+    if (shouldShowSlashCommandMenu(value)) {
+      SlashCommandPanel(
+        commands = slashCommands,
+        onSelect = { command -> onValueChange(slashCommandCompletion(command)) },
+      )
+    }
+
     Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
-      ChatInputPill(value = value, onValueChange = onValueChange, onPickImages = onPickImages, onVoice = onVoice, modifier = Modifier.weight(1f))
+      ChatInputPill(
+        value = value,
+        onValueChange = onValueChange,
+        onPickImages = onPickImages,
+        onVoice = onVoice,
+        modifier = Modifier.weight(1f),
+      )
       SendButton(
         enabled = healthOk && pendingRunCount == 0 && (value.trim().isNotEmpty() || attachments.isNotEmpty()),
         onClick = onSend,
@@ -850,6 +905,68 @@ private fun ChatComposer(
             Text(text = "Stop", style = ClawTheme.type.label)
           }
         }
+      }
+    }
+  }
+}
+
+@Composable
+private fun SlashCommandPanel(
+  commands: List<ChatCommandEntry>,
+  onSelect: (ChatCommandEntry) -> Unit,
+) {
+  ClawPanel(contentPadding = PaddingValues(horizontal = 0.dp, vertical = 0.dp)) {
+    Column {
+      if (commands.isEmpty()) {
+        Text(
+          text = "No commands found",
+          style = ClawTheme.type.caption,
+          color = ClawTheme.colors.textMuted,
+          modifier = Modifier.padding(horizontal = 11.dp, vertical = 9.dp),
+        )
+      } else {
+        commands.forEachIndexed { index, command ->
+          SlashCommandRow(command = command, onClick = { onSelect(command) })
+          if (index != commands.lastIndex) {
+            HorizontalDivider(color = ClawTheme.colors.border, thickness = 1.dp)
+          }
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun SlashCommandRow(
+  command: ChatCommandEntry,
+  onClick: () -> Unit,
+) {
+  Surface(onClick = onClick, color = Color.Transparent, contentColor = ClawTheme.colors.text) {
+    Row(
+      modifier =
+        Modifier
+          .fillMaxWidth()
+          .heightIn(min = 48.dp)
+          .padding(horizontal = 10.dp, vertical = 6.dp),
+      verticalAlignment = Alignment.CenterVertically,
+      horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+      Text(
+        text = slashCommandText(command),
+        style = ClawTheme.type.label,
+        color = ClawTheme.colors.text,
+        modifier = Modifier.width(82.dp),
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+      )
+      Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(1.dp)) {
+        Text(
+          text = command.description.ifBlank { command.category ?: "Command" },
+          style = ClawTheme.type.caption,
+          color = ClawTheme.colors.textMuted,
+          maxLines = 1,
+          overflow = TextOverflow.Ellipsis,
+        )
       }
     }
   }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatSheetContent.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatSheetContent.kt
@@ -98,6 +98,7 @@ fun ChatSheetContent(viewModel: MainViewModel) {
   val streamingAssistantText by viewModel.chatStreamingAssistantText.collectAsState()
   val pendingToolCalls by viewModel.chatPendingToolCalls.collectAsState()
   val sessions by viewModel.chatSessions.collectAsState()
+  val chatCommands by viewModel.chatCommands.collectAsState()
   val chatDraft by viewModel.chatDraft.collectAsState()
   val pendingAssistantAutoSend by viewModel.pendingAssistantAutoSend.collectAsState()
 
@@ -106,6 +107,7 @@ fun ChatSheetContent(viewModel: MainViewModel) {
     if (loadSessionKey != null) {
       viewModel.loadChat(loadSessionKey)
     }
+    viewModel.refreshChatCommands()
   }
 
   LaunchedEffect(pendingAssistantAutoSend, healthOk, pendingRunCount, thinkingLevel) {
@@ -188,6 +190,7 @@ fun ChatSheetContent(viewModel: MainViewModel) {
         healthOk = healthOk,
         thinkingLevel = thinkingLevel,
         pendingRunCount = pendingRunCount,
+        commands = chatCommands,
         attachments = attachments,
         onDraftApplied = viewModel::clearChatDraft,
         onPickImages = { pickImages.launch("image/*") },
@@ -196,6 +199,7 @@ fun ChatSheetContent(viewModel: MainViewModel) {
         onRefresh = {
           viewModel.refreshChat()
           viewModel.refreshChatSessions(limit = 200)
+          viewModel.refreshChatCommands()
         },
         onAbort = { viewModel.abortChat() },
         onSend = { text ->

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerCommandControlsTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerCommandControlsTest.kt
@@ -1,0 +1,419 @@
+package ai.openclaw.app.chat
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChatControllerCommandControlsTest {
+  private val json = Json { ignoreUnknownKeys = true }
+
+  @Test
+  fun parseChatCommandsKeepsTextAliasesAndArgumentFlag() {
+    val commands =
+      parseChatCommands(
+        json,
+        """
+        {
+          "commands": [
+            {
+              "name": "new",
+              "description": "Start a fresh chat",
+              "category": "session",
+              "textAliases": ["/new", "/reset"],
+              "acceptsArgs": false
+            },
+            {
+              "name": "/model",
+              "description": "Switch models",
+              "category": "options",
+              "textAliases": ["model", "/model"],
+              "acceptsArgs": true
+            }
+          ]
+        }
+        """.trimIndent(),
+      )
+
+    assertEquals(2, commands.size)
+    assertEquals("new", commands[0].name)
+    assertEquals(listOf("/new", "/reset"), commands[0].textAliases)
+    assertEquals(false, commands[0].acceptsArgs)
+    assertEquals("model", commands[1].name)
+    assertEquals(listOf("/model"), commands[1].textAliases)
+    assertEquals(true, commands[1].acceptsArgs)
+  }
+
+  @OptIn(ExperimentalCoroutinesApi::class)
+  @Test
+  fun healthEventRefreshesCommandsAfterReconnect() =
+    runTest {
+      val requests = mutableListOf<Pair<String, String?>>()
+      val controller =
+        ChatController(
+          scope = this,
+          json = json,
+          requestGateway = { method, paramsJson ->
+            requests += method to paramsJson
+            when (method) {
+              "commands.list" ->
+                """
+                {
+                  "commands": [
+                    {
+                      "name": "model",
+                      "description": "Switch models",
+                      "textAliases": ["/model"],
+                      "acceptsArgs": true
+                    }
+                  ]
+                }
+                """.trimIndent()
+              else -> "{}"
+            }
+          },
+        )
+
+      controller.handleGatewayEvent("health", null)
+      advanceUntilIdle()
+      assertEquals(listOf("/model"), controller.commands.value.single().textAliases)
+
+      controller.onDisconnected("gateway closed")
+      assertEquals(emptyList<ChatCommandEntry>(), controller.commands.value)
+
+      controller.handleGatewayEvent("health", null)
+      advanceUntilIdle()
+      assertEquals(listOf("/model"), controller.commands.value.single().textAliases)
+      assertEquals(2, requests.count { it.first == "commands.list" })
+    }
+
+  @OptIn(ExperimentalCoroutinesApi::class)
+  @Test
+  fun commandListScopesToActiveAgentAndRefreshesAfterAgentSwitch() =
+    runTest {
+      val requests = mutableListOf<Pair<String, String?>>()
+      val controller =
+        ChatController(
+          scope = this,
+          json = json,
+          requestGateway = { method, paramsJson ->
+            requests += method to paramsJson
+            when (method) {
+              "commands.list" ->
+                if (paramsJson.orEmpty().contains("\"agentId\":\"ops\"")) {
+                  """
+                  {
+                    "commands": [
+                      {
+                        "name": "ops",
+                        "description": "Ops command",
+                        "textAliases": ["/ops"],
+                        "acceptsArgs": false
+                      }
+                    ]
+                  }
+                  """.trimIndent()
+                } else {
+                  """
+                  {
+                    "commands": [
+                      {
+                        "name": "main",
+                        "description": "Main command",
+                        "textAliases": ["/main"],
+                        "acceptsArgs": false
+                      }
+                    ]
+                  }
+                  """.trimIndent()
+                }
+              "chat.history" -> """{"sessionId":"loaded-session","messages":[]}"""
+              "health" -> "{}"
+              else -> "{}"
+            }
+          },
+        )
+
+      controller.handleGatewayEvent("health", null)
+      advanceUntilIdle()
+      assertEquals(listOf("/main"), controller.commands.value.single().textAliases)
+
+      controller.switchSession("agent:ops:dashboard:parent")
+      advanceUntilIdle()
+      assertEquals(listOf("/ops"), controller.commands.value.single().textAliases)
+
+      val commandRequests = requests.filter { it.first == "commands.list" }
+      assertTrue(commandRequests.any { it.second.orEmpty().contains("\"agentId\":\"main\"") })
+      assertTrue(commandRequests.any { it.second.orEmpty().contains("\"agentId\":\"ops\"") })
+    }
+
+  @OptIn(ExperimentalCoroutinesApi::class)
+  @Test
+  fun startNewChatCreatesWriteScopedSessionAndReloadsHistory() =
+    runTest {
+      val requests = mutableListOf<Pair<String, String?>>()
+      val controller =
+        ChatController(
+          scope = this,
+          json = json,
+          requestGateway = { method, paramsJson ->
+            requests += method to paramsJson
+            when (method) {
+              "sessions.create" -> """{"ok":true,"key":"agent:main:dashboard:fresh"}"""
+              "chat.history" -> """{"sessionId":"fresh-session","messages":[]}"""
+              "health" -> "{}"
+              "sessions.list" -> """{"sessions":[]}"""
+              else -> "{}"
+            }
+          },
+        )
+      controller.handleGatewayEvent("health", null)
+      controller.load("main")
+      advanceUntilIdle()
+
+      assertTrue(controller.startNewChatAwait())
+
+      val create = requests.first { it.first == "sessions.create" }
+      assertTrue(create.second.orEmpty().contains("\"agentId\":\"main\""))
+      assertTrue(create.second.orEmpty().contains("\"parentSessionKey\":\"main\""))
+      assertTrue(create.second.orEmpty().contains("\"emitCommandHooks\":true"))
+      assertTrue(create.second.orEmpty().contains("\"label\":\"New chat\""))
+      assertEquals("agent:main:dashboard:fresh", controller.sessionKey.value)
+      assertEquals("fresh-session", controller.sessionId.value)
+      assertTrue(requests.any { it.first == "chat.history" })
+      assertTrue(requests.any { it.first == "sessions.list" })
+    }
+
+  @Test
+  fun startNewChatWithoutLoadedParentCreatesFirstSession() =
+    runTest {
+      val requests = mutableListOf<Pair<String, String?>>()
+      val controller =
+        ChatController(
+          scope = this,
+          json = json,
+          requestGateway = { method, paramsJson ->
+            requests += method to paramsJson
+            when (method) {
+              "sessions.create" -> """{"ok":true,"key":"agent:main:dashboard:first"}"""
+              "chat.history" -> """{"sessionId":"first-session","messages":[]}"""
+              "health" -> "{}"
+              "sessions.list" -> """{"sessions":[]}"""
+              else -> "{}"
+            }
+          },
+        )
+      controller.handleGatewayEvent("health", null)
+
+      assertTrue(controller.startNewChatAwait())
+
+      val create = requests.first { it.first == "sessions.create" }
+      assertTrue(create.second.orEmpty().contains("\"agentId\":\"main\""))
+      assertEquals(false, create.second.orEmpty().contains("\"parentSessionKey\""))
+      assertEquals(false, create.second.orEmpty().contains("\"emitCommandHooks\""))
+      assertEquals("agent:main:dashboard:first", controller.sessionKey.value)
+    }
+
+  @OptIn(ExperimentalCoroutinesApi::class)
+  @Test
+  fun startNewChatUsesNextAvailableNewChatLabel() =
+    runTest {
+      val requests = mutableListOf<Pair<String, String?>>()
+      val controller =
+        ChatController(
+          scope = this,
+          json = json,
+          requestGateway = { method, paramsJson ->
+            requests += method to paramsJson
+            when (method) {
+              "sessions.create" -> """{"ok":true,"key":"agent:main:dashboard:fresh-3"}"""
+              "chat.history" -> """{"sessionId":"fresh-session-3","messages":[]}"""
+              "health" -> "{}"
+              "sessions.list" ->
+                """
+                {
+                  "sessions": [
+                    {"key":"agent:main:dashboard:fresh","displayName":"New chat"},
+                    {"key":"agent:main:dashboard:fresh-2","displayName":"New chat 2"}
+                  ]
+                }
+                """.trimIndent()
+              else -> "{}"
+            }
+          },
+        )
+      controller.handleGatewayEvent("health", null)
+      controller.refreshSessions()
+      advanceUntilIdle()
+
+      assertTrue(controller.startNewChatAwait())
+
+      val create = requests.first { it.first == "sessions.create" }
+      assertTrue(create.second.orEmpty().contains("\"label\":\"New chat 3\""))
+      assertEquals("agent:main:dashboard:fresh-3", controller.sessionKey.value)
+    }
+
+  @OptIn(ExperimentalCoroutinesApi::class)
+  @Test
+  fun startNewChatScopesCreateToActiveAgentSession() =
+    runTest {
+      val requests = mutableListOf<Pair<String, String?>>()
+      val controller =
+        ChatController(
+          scope = this,
+          json = json,
+          requestGateway = { method, paramsJson ->
+            requests += method to paramsJson
+            when (method) {
+              "sessions.create" -> """{"ok":true,"key":"agent:ops:dashboard:fresh"}"""
+              "chat.history" -> """{"sessionId":"ops-session","messages":[]}"""
+              "health" -> "{}"
+              "sessions.list" -> """{"sessions":[]}"""
+              else -> "{}"
+            }
+          },
+        )
+
+      controller.switchSession("agent:ops:dashboard:parent")
+      advanceUntilIdle()
+
+      assertTrue(controller.startNewChatAwait())
+
+      val create = requests.first { it.first == "sessions.create" }
+      assertTrue(create.second.orEmpty().contains("\"agentId\":\"ops\""))
+      assertTrue(create.second.orEmpty().contains("\"parentSessionKey\":\"agent:ops:dashboard:parent\""))
+      assertEquals("agent:ops:dashboard:fresh", controller.sessionKey.value)
+    }
+
+  @Test
+  fun bareNewSlashCommandUsesGatewayChatCommandPath() =
+    runTest {
+      val requests = mutableListOf<Pair<String, String?>>()
+      val controller =
+        ChatController(
+          scope = this,
+          json = json,
+          requestGateway = { method, paramsJson ->
+            requests += method to paramsJson
+            when (method) {
+              "chat.send" -> """{"runId":"run-new"}"""
+              "health" -> "{}"
+              else -> "{}"
+            }
+          },
+        )
+      controller.handleGatewayEvent("health", null)
+
+      assertTrue(controller.sendMessageAwaitAcceptance("/new", "off", emptyList()))
+
+      val send = requests.single { it.first == "chat.send" }
+      assertTrue(send.second.orEmpty().contains("\"message\":\"/new\""))
+      assertTrue(requests.none { it.first == "sessions.create" })
+    }
+
+  @Test
+  fun startNewChatRejectsWhileRunPending() =
+    runTest {
+      val requests = mutableListOf<Pair<String, String?>>()
+      val controller =
+        ChatController(
+          scope = this,
+          json = json,
+          requestGateway = { method, paramsJson ->
+            requests += method to paramsJson
+            when (method) {
+              "chat.send" -> """{"runId":"run-1"}"""
+              "health" -> "{}"
+              else -> "{}"
+            }
+          },
+        )
+      controller.handleGatewayEvent("health", null)
+
+      assertTrue(controller.sendMessageAwaitAcceptance("hello", "off", emptyList()))
+      assertEquals(1, controller.pendingRunCount.value)
+      assertEquals(false, controller.startNewChatAwait())
+      assertTrue(requests.none { it.first == "sessions.create" })
+    }
+
+  @OptIn(ExperimentalCoroutinesApi::class)
+  @Test
+  fun startNewChatRejectsDuplicateCreateWhileFirstRequestIsPending() =
+    runTest {
+      val requests = mutableListOf<Pair<String, String?>>()
+      val createEntered = CompletableDeferred<Unit>()
+      val releaseCreate = CompletableDeferred<Unit>()
+      var createCount = 0
+      val controller =
+        ChatController(
+          scope = this,
+          json = json,
+          requestGateway = { method, paramsJson ->
+            requests += method to paramsJson
+            when (method) {
+              "sessions.create" -> {
+                createCount += 1
+                createEntered.complete(Unit)
+                releaseCreate.await()
+                """{"ok":true,"key":"agent:main:dashboard:fresh"}"""
+              }
+              "chat.history" -> """{"sessionId":"fresh-session","messages":[]}"""
+              "health" -> "{}"
+              "sessions.list" -> """{"sessions":[]}"""
+              else -> "{}"
+            }
+          },
+        )
+      controller.handleGatewayEvent("health", null)
+
+      val first = async { controller.startNewChatAwait() }
+      createEntered.await()
+
+      val second = async { controller.startNewChatAwait() }
+      advanceUntilIdle()
+      releaseCreate.complete(Unit)
+
+      assertTrue(first.await())
+      assertEquals(false, second.await())
+      assertEquals(1, createCount)
+      assertEquals(1, requests.count { it.first == "sessions.create" })
+    }
+
+  @OptIn(ExperimentalCoroutinesApi::class)
+  @Test
+  fun startNewChatIgnoresStaleCreateResponseAfterSessionSwitch() =
+    runTest {
+      val requests = mutableListOf<Pair<String, String?>>()
+      lateinit var controller: ChatController
+      controller =
+        ChatController(
+          scope = this,
+          json = json,
+          requestGateway = { method, paramsJson ->
+            requests += method to paramsJson
+            when (method) {
+              "sessions.create" -> {
+                controller.switchSession("agent:main:dashboard:other")
+                """{"ok":true,"key":"agent:main:dashboard:fresh"}"""
+              }
+              "chat.history" -> """{"sessionId":"other-session","messages":[]}"""
+              "health" -> "{}"
+              "sessions.list" -> """{"sessions":[]}"""
+              else -> "{}"
+            }
+          },
+        )
+      controller.handleGatewayEvent("health", null)
+
+      assertEquals(false, controller.startNewChatAwait())
+      advanceUntilIdle()
+      assertEquals("agent:main:dashboard:other", controller.sessionKey.value)
+      assertEquals("other-session", controller.sessionId.value)
+      assertTrue(requests.any { it.first == "sessions.create" })
+    }
+}

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerTerminalAckTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerTerminalAckTest.kt
@@ -105,7 +105,10 @@ class ChatControllerTerminalAckTest {
       advanceUntilIdle()
 
       assertTrue(accepted)
-      assertEquals(listOf("chat.send", "chat.history"), requestedMethods)
+      assertEquals(
+        listOf("chat.send", "chat.history"),
+        requestedMethods.filter { method -> method == "chat.send" || method == "chat.history" },
+      )
       assertEquals(0, controller.pendingRunCount.value)
       assertNull(controller.errorText.value)
       assertFalse(controller.messages.value.hasUserText("message that already completed"))

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt
@@ -199,13 +199,14 @@ class GatewaySessionInvokeTest {
       val secondEventHandled = CompletableDeferred<Unit>()
       val events = CopyOnWriteArrayList<String>()
       val lastDisconnect = AtomicReference("")
+      val serverWebSocket = AtomicReference<WebSocket?>(null)
       val server =
         startGatewayServer(json) { webSocket, id, method, _ ->
+          serverWebSocket.set(webSocket)
           if (method == "connect") {
             webSocket.send(connectResponseFrame(id))
             webSocket.send("""{"type":"event","event":"voice.first","payload":{}}""")
             webSocket.send("""{"type":"event","event":"voice.second","payload":{}}""")
-            webSocket.close(1000, "done")
           }
         }
 
@@ -237,6 +238,8 @@ class GatewaySessionInvokeTest {
         assertEquals(listOf("voice.first", "voice.second"), events.toList())
       } finally {
         releaseFirstEvent.complete(Unit)
+        runCatching { serverWebSocket.get()?.close(1000, "done") }
+        delay(100)
         shutdownHarness(harness, server)
       }
     }

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatCommandControlsTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatCommandControlsTest.kt
@@ -1,0 +1,209 @@
+package ai.openclaw.app.ui.chat
+
+import ai.openclaw.app.chat.ChatCommandEntry
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ChatCommandControlsTest {
+  @Test
+  fun matchingSlashCommandsFiltersByNameAndAliasPrefixes() {
+    val commands =
+      listOf(
+        ChatCommandEntry(
+          name = "new",
+          description = "Start fresh",
+          category = "session",
+          textAliases = listOf("/new"),
+        ),
+        ChatCommandEntry(
+          name = "model",
+          description = "Switch models",
+          category = "model",
+          textAliases = listOf("/model"),
+          acceptsArgs = true,
+        ),
+        ChatCommandEntry(
+          name = "agent",
+          description = "Pick runtime",
+          category = "agent",
+          textAliases = listOf("/agent", "/delegate"),
+          acceptsArgs = true,
+        ),
+      )
+
+    assertEquals(
+      listOf("/new", "/model", "/agent"),
+      matchingSlashCommands(input = "/", commands = commands).map(::slashCommandText),
+    )
+    assertEquals(
+      listOf("/new"),
+      matchingSlashCommands(input = "/n", commands = commands).map(::slashCommandText),
+    )
+    assertEquals(
+      listOf("/model"),
+      matchingSlashCommands(input = "/mo", commands = commands).map(::slashCommandText),
+    )
+    assertEquals(
+      listOf("/delegate"),
+      matchingSlashCommands(input = "/de", commands = commands).map(::slashCommandText),
+    )
+    assertEquals(emptyList<ChatCommandEntry>(), matchingSlashCommands(input = "/runtime", commands = commands))
+    assertEquals(emptyList<ChatCommandEntry>(), matchingSlashCommands(input = "/session", commands = commands))
+    assertEquals(emptyList<ChatCommandEntry>(), matchingSlashCommands(input = "hello", commands = commands))
+  }
+
+  @Test
+  fun matchingSlashCommandsKeepsGatewayAdvertisedAliases() {
+    val commands =
+      listOf(
+        ChatCommandEntry(
+          name = "new",
+          description = "Start fresh",
+          category = "session",
+          textAliases = listOf("/new", "/reset"),
+        ),
+        ChatCommandEntry(
+          name = "reset",
+          description = "Reset session",
+          category = "session",
+          textAliases = listOf("/reset"),
+        ),
+      )
+
+    assertEquals(
+      listOf("/new", "/reset"),
+      matchingSlashCommands(input = "/", commands = commands).map(::slashCommandText),
+    )
+    assertEquals(listOf("/reset"), matchingSlashCommands(input = "/reset", commands = commands).map(::slashCommandText))
+  }
+
+  @Test
+  fun selectedNewSlashCommandCompletesGatewayCommandText() {
+    assertEquals(
+      "/new",
+      slashCommandCompletion(
+        ChatCommandEntry(
+          name = "new",
+          description = "Start fresh",
+          textAliases = listOf("/new", "/reset"),
+        ),
+      ),
+    )
+    assertEquals(
+      "/model ",
+      slashCommandCompletion(
+        ChatCommandEntry(
+          name = "model",
+          description = "Switch model",
+          textAliases = listOf("/model"),
+          acceptsArgs = true,
+        ),
+      ),
+    )
+  }
+
+  @Test
+  fun matchingSlashCommandsKeepsGatewayAdvertisedNewCommandVisible() {
+    val commands =
+      listOf(
+        ChatCommandEntry(
+          name = "new",
+          description = "Start fresh",
+          textAliases = listOf("/new"),
+        ),
+        ChatCommandEntry(
+          name = "model",
+          description = "Switch model",
+          textAliases = listOf("/model"),
+        ),
+      )
+
+    assertEquals(
+      listOf("/new", "/model"),
+      matchingSlashCommands(input = "/", commands = commands).map(::slashCommandText),
+    )
+  }
+
+  @Test
+  fun sheetSelectedNewSlashCommandCompletesGatewayCommandText() {
+    val newCommand =
+      ChatCommandEntry(
+        name = "new",
+        description = "Start fresh",
+        textAliases = listOf("/new"),
+      )
+    val modelCommand =
+      ChatCommandEntry(
+        name = "model",
+        description = "Switch model",
+        textAliases = listOf("/model"),
+        acceptsArgs = true,
+      )
+
+    assertEquals(
+      SheetSlashCommandSelection(input = "/new"),
+      resolveSheetSlashCommandSelection(newCommand),
+    )
+    assertEquals(
+      SheetSlashCommandSelection(input = "/model "),
+      resolveSheetSlashCommandSelection(modelCommand),
+    )
+  }
+
+  @Test
+  fun sheetTypedNewSlashCommandSendsThroughGateway() {
+    assertEquals(
+      SheetComposerSendAction(sendMessage = true),
+      resolveSheetComposerSendAction("/new"),
+    )
+    assertEquals(
+      SheetComposerSendAction(sendMessage = true),
+      resolveSheetComposerSendAction("  /new"),
+    )
+    assertEquals(
+      SheetComposerSendAction(sendMessage = true),
+      resolveSheetComposerSendAction("/new gpt-5.5 continue"),
+    )
+    assertEquals(
+      SheetComposerSendAction(sendMessage = true),
+      resolveSheetComposerSendAction("hello"),
+    )
+    assertEquals(
+      SheetComposerSendAction(sendMessage = false),
+      resolveSheetComposerSendAction("   "),
+    )
+  }
+
+  @Test
+  fun canStartNewChatRequiresIdleRunAndQueue() {
+    assertEquals(true, canStartNewChat(pendingRunCount = 0, hasQueuedMessage = false, gatewayReady = true))
+    assertEquals(false, canStartNewChat(pendingRunCount = 1, hasQueuedMessage = false, gatewayReady = true))
+    assertEquals(false, canStartNewChat(pendingRunCount = 0, hasQueuedMessage = true, gatewayReady = true))
+    assertEquals(false, canStartNewChat(pendingRunCount = 0, hasQueuedMessage = false, gatewayReady = false))
+  }
+
+  @Test
+  fun slashCommandCompletionKeepsArgumentCommandsOpen() {
+    assertEquals(
+      "/model ",
+      slashCommandCompletion(
+        ChatCommandEntry(
+          name = "model",
+          description = "Switch models",
+          textAliases = listOf("/model"),
+          acceptsArgs = true,
+        ),
+      ),
+    )
+    assertEquals(
+      "/new",
+      slashCommandCompletion(
+        ChatCommandEntry(
+          name = "new",
+          description = "Start fresh",
+          textAliases = listOf("/new"),
+        ),
+      ),
+    )
+  }
+}


### PR DESCRIPTION
## What Problem This Solves

Android chat users need a visible New Chat control and a slash-command picker without Android becoming a second command-policy source.

The PR also addresses the review-blocking command-routing, generated-inventory, and command-picker cleanup follow-ups:

- Android must preserve `/new <model/text>` command tails instead of locally consuming argument-bearing `/new` inputs.
- The native i18n generated source inventory must stay in sync after merging current `main`.
- Slash-command rows should not repeat the smaller command category label underneath each command description.

## Why This Change Was Made

This keeps the Android UI controls while preserving Gateway-owned command and session semantics:

- Gateway `commands.list` remains the source for slash-command suggestions.
- Empty or failed command discovery does not fall back to an Android-local command catalog.
- Slash selection fills command text in the composer instead of executing commands locally.
- The header New Chat action and bare `/new` route use `sessions.create` with the selected parent session and `emitCommandHooks=true`.
- Argument-bearing `/new ...` input stays on the normal Gateway chat command path.
- Slash-command rows now show the command title and description without rendering `command.category` as a smaller secondary label under each row.
- Native i18n inventory was refreshed from the current generated source set after the line-number changes.

This PR does not change provider/model routing, command execution semantics, permissions grants, dependencies, or lockfiles.

## User Impact

Android users get first-class chat controls:

- The chat header exposes a New Chat action.
- The composer exposes slash-command suggestions from Gateway metadata.
- `/`, `/n`, `/mo`, and alias prefixes such as `/de` filter by command name or alias.
- Description/category text does not create unrelated slash matches.
- Android no longer shows commands the connected Gateway did not advertise.
- Bare `/new` can start a new chat locally, while `/new <model/text>` remains available to the Gateway command path.
- Slash-command suggestions are cleaner because the smaller category caption is no longer repeated under each command description.
- Command title, description, click behavior, routing, accessibility semantics, and `/new` argument preservation remain unchanged.
- The branch no longer carries native i18n generated-inventory drift for this PR head refresh.

## Evidence

Focused Android behavior and visual proof already attached to this PR:

- `ChatControllerCommandControlsTest` covers Gateway command metadata parsing, unique New Chat labels, parent-linked `sessions.create`, and `emitCommandHooks=true`.
- `ChatCommandControlsTest` covers slash prefix filtering and preserves `/new gpt-5.5 continue` by not routing argument-bearing `/new` locally.
- Public Android emulator recordings show the header New Chat button, bare `/new`, `/reset` slash-command interaction, and slash-command filtering:

Header `+` creates a unique new chat session:

https://github.com/user-attachments/assets/7a5dd45f-36bd-4253-90a2-82dbea994bb9

`/new` starts a new session:

https://github.com/user-attachments/assets/542a4a0a-3d5b-40bd-b8cc-ef7dd319ba6c

`/reset` slash-command interaction:

https://github.com/user-attachments/assets/53bd33c1-276c-48d5-84e3-b6978844cc64

Slash command filtering:

https://github.com/user-attachments/assets/1e05e549-0097-4488-a3c3-6c1ba8b29fa5

Latest local proof for the command category-label cleanup and native i18n inventory refresh:

```text
git diff --check
PASS

pnpm native:i18n:check
native-app-i18n: entries=2366 changed=false
PASS

cd apps/android && ./gradlew --no-daemon :app:testPlayDebugUnitTest --tests ai.openclaw.app.ui.chat.ChatCommandControlsTest --console=plain --stacktrace
BUILD SUCCESSFUL in 3m 22s
PASS
```

Relevant source assertions for the latest cleanup:

```text
ChatScreen.kt:
- SlashCommandRow no longer renders command.category as a smaller secondary label under each command description.
- The command title and description remain rendered.
- Click behavior and accessibility semantics remain on the row.

apps/.i18n/native-source.json:
- Generated inventory changed only because ChatScreen.kt line numbers shifted after removing the category-label block.
```

Relevant source assertions for the P1 command-tail repair:

```text
ChatCommandControlsTest:
- shouldRouteInputToNewChat("/new") == true
- shouldRouteInputToNewChat("/new gpt-5.5 continue") == false
- resolveSheetComposerSendAction("/new gpt-5.5 continue", true) keeps send enabled

ChatControllerCommandControlsTest:
- parent-linked sessions.create payload contains "emitCommandHooks":true
```

What was not re-run in this final command category-label cleanup phase:

```text
No new emulator recording was captured for the category-label removal; the latest change is a narrow row rendering cleanup backed by source diff, native i18n check, and the focused ChatCommandControlsTest.
ChatControllerCommandControlsTest was not re-run in this narrow pass because the latest patch does not touch controller session creation or Gateway routing.
```
