### PR TITLE
test(tools): add unit tests for toToolProtocolDescriptor and toToolProtocolDescriptors

### DIFF
--- a/src/tools/protocol.test.ts
+++ b/src/tools/protocol.test.ts
@@ -1,0 +1,45 @@
+// Protocol tests cover tool descriptor conversion for model runtimes.
+import { describe, expect, it } from "vitest";
+import { toToolProtocolDescriptor, toToolProtocolDescriptors } from "./protocol.js";
+import type { ToolPlanEntry } from "./types.js";
+
+function makeEntry(
+  name: string,
+  description = "",
+  inputSchema: Record<string, unknown> = {},
+): ToolPlanEntry {
+  return {
+    descriptor: { name, description, inputSchema },
+  } as ToolPlanEntry;
+}
+
+describe("toToolProtocolDescriptor", () => {
+  it("extracts name, description, and inputSchema from a plan entry", () => {
+    const entry = makeEntry("read_file", "Reads a file", {
+      type: "object",
+      properties: { path: { type: "string" } },
+    });
+    const result = toToolProtocolDescriptor(entry);
+    expect(result).toEqual({
+      name: "read_file",
+      description: "Reads a file",
+      inputSchema: {
+        type: "object",
+        properties: { path: { type: "string" } },
+      },
+    });
+  });
+});
+
+describe("toToolProtocolDescriptors", () => {
+  it("converts a list of entries preserving order", () => {
+    const entries = [makeEntry("a"), makeEntry("b"), makeEntry("c")];
+    const result = toToolProtocolDescriptors(entries);
+    expect(result).toHaveLength(3);
+    expect(result.map((r) => r.name)).toEqual(["a", "b", "c"]);
+  });
+
+  it("returns an empty array for empty input", () => {
+    expect(toToolProtocolDescriptors([])).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

`toToolProtocolDescriptor` and `toToolProtocolDescriptors` in `src/tools/protocol.ts` convert planned tool entries into protocol payloads for model runtimes. Despite being part of the tool descriptor pipeline, they had no unit tests.

## Why This Change Was Made

Add 3 tests covering:
- Extracting name, description, and inputSchema from a plan entry
- Converting a list of entries preserving order
- Returning empty array for empty input

## User Impact

No user-visible changes. The tool protocol descriptor conversion contract is now tested.

## Evidence

Reproducibility: not applicable.

Direct behavior probe (no mocks):

```text
$ node --import tsx -e "import('./src/tools/protocol.js').then((m)=>{
  const e={descriptor:{name:'test',description:'d',inputSchema:{}}};
  const r=[];
  r.push({single:m.toToolProtocolDescriptor(e)});
  r.push({multi_len:m.toToolProtocolDescriptors([e,e]).length});
  r.push({empty_len:m.toToolProtocolDescriptors([]).length});
  console.log(JSON.stringify(r,null,2));
})"
[
  {"single":{"name":"test","description":"d","inputSchema":{}}},
  {"multi_len":2},
  {"empty_len":0}
]
```

Targeted test:

```text
$ node scripts/run-vitest.mjs run src/tools/protocol.test.ts
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

Formatting:

```text
$ npx oxfmt --check src/tools/protocol.ts src/tools/protocol.test.ts
All matched files use the correct format.
```

Whitespace:

```text
$ git diff --check
```