### PR TITLE
Add macOS Node TCC install preflight

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1619,6 +1619,85 @@ print_active_node_paths() {
     return 0
 }
 
+resolve_active_node_runtime_path() {
+    if ! command -v node &> /dev/null; then
+        return 1
+    fi
+
+    local node_path=""
+    node_path="$(node -p 'require("node:fs").realpathSync(process.execPath)' 2>/dev/null || true)"
+    if [[ -n "$node_path" && -x "$node_path" ]]; then
+        printf '%s\n' "$node_path"
+        return 0
+    fi
+
+    node_path="$(command -v node 2>/dev/null || true)"
+    if [[ -z "$node_path" ]]; then
+        return 1
+    fi
+    if command -v realpath >/dev/null 2>&1; then
+        realpath "$node_path" 2>/dev/null && return 0
+    fi
+    printf '%s\n' "$node_path"
+}
+
+maybe_open_macos_privacy_pane() {
+    local pane="$1"
+    if ! is_promptable; then
+        return 0
+    fi
+    if [[ "${OPENCLAW_OPEN_MACOS_TCC_PREFLIGHT:-1}" != "1" ]]; then
+        return 0
+    fi
+    if ! command -v open >/dev/null 2>&1; then
+        return 0
+    fi
+    open "x-apple.systempreferences:com.apple.preference.security?${pane}" >/dev/null 2>&1 || true
+}
+
+run_macos_node_tcc_preflight() {
+    if [[ "$OS" != "macos" ]]; then
+        return 0
+    fi
+    if [[ "${OPENCLAW_MACOS_NODE_TCC_PREFLIGHT:-1}" != "1" ]]; then
+        return 0
+    fi
+
+    local node_path node_shim runtime_dir node_record
+    node_path="$(resolve_active_node_runtime_path || true)"
+    if [[ -z "$node_path" ]]; then
+        return 0
+    fi
+    node_shim="$(command -v node 2>/dev/null || true)"
+    runtime_dir="$(resolve_openclaw_effective_home)/.openclaw/runtime"
+    node_record="${runtime_dir}/node-path"
+    mkdir -p "$runtime_dir" 2>/dev/null || true
+    printf '%s\n' "$node_path" > "$node_record" 2>/dev/null || true
+
+    ui_section "macOS Node permissions"
+    ui_info "OpenClaw Node runtime: ${node_path}"
+    ui_info "Saved runtime hint: ${node_record}"
+    if [[ "$node_shim" == *"/fnm_multishells/"* ]]; then
+        ui_warn "Current node command is an fnm multishell shim; TCC grants should target the resolved runtime above"
+    fi
+    if [[ "$node_path" == *"/.local/share/fnm/"* || "$node_path" == *"/.fnm/"* ]]; then
+        ui_warn "fnm-managed Node permissions stay stable only while this exact Node version remains selected"
+        echo "  Keep the install pinned, for example: fnm default ${NODE_DEFAULT_MAJOR}"
+    fi
+
+    echo "  Grant this exact node binary if generated scripts need broad local access:"
+    echo "    ${node_path}"
+    echo "  Recommended macOS privacy panes: Full Disk Access, Accessibility, and Screen Recording."
+    echo "  macOS will still require a user approval click unless the Mac is managed with a PPPC profile."
+
+    if is_promptable && command -v open >/dev/null 2>&1 && [[ "${OPENCLAW_OPEN_MACOS_TCC_PREFLIGHT:-1}" == "1" ]]; then
+        open -R "$node_path" >/dev/null 2>&1 || true
+        maybe_open_macos_privacy_pane "Privacy_AllFiles"
+        maybe_open_macos_privacy_pane "Privacy_Accessibility"
+        maybe_open_macos_privacy_pane "Privacy_ScreenCapture"
+    fi
+}
+
 ensure_macos_default_node_active() {
     if [[ "$OS" != "macos" ]]; then
         return 0
@@ -3172,6 +3251,8 @@ main() {
             warn_shell_path_missing_dir "$HOME/.local/bin" "user-local bin dir (~/.local/bin)"
         fi
     fi
+
+    run_macos_node_tcc_preflight
 
     refresh_gateway_service_if_loaded
 

--- a/test/scripts/install-sh.test.ts
+++ b/test/scripts/install-sh.test.ts
@@ -1358,10 +1358,7 @@ describe("install.sh", () => {
     mkdirSync(bin, { recursive: true });
     mkdirSync(outer, { recursive: true });
     mkdirSync(repo, { recursive: true });
-    writeFileSync(
-      join(outer, "package.json"),
-      '{\n  "packageManager": "yarn@4.5.0"\n}\n',
-    );
+    writeFileSync(join(outer, "package.json"), '{\n  "packageManager": "yarn@4.5.0"\n}\n');
     writeFileSync(
       join(repo, "package.json"),
       '{\n  "packageManager": "pnpm@11.2.2+sha512.test"\n}\n',
@@ -1550,6 +1547,78 @@ describe("install.sh macOS Homebrew Node behavior", () => {
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+
+  it("records resolved Node path and opens macOS TCC panes during interactive preflight", () => {
+    const result = runInstallShell(`
+      set -euo pipefail
+      source "${SCRIPT_PATH}"
+      OS=macos
+      NODE_REALPATH="$HOME/.local/share/fnm/node-versions/v24.15.0/installation/bin/node"
+      mkdir -p "$(dirname "$NODE_REALPATH")"
+      : > "$NODE_REALPATH"
+      chmod +x "$NODE_REALPATH"
+      fake_bin="$(mktemp -d)"
+      OPEN_LOG="$HOME/open.log"
+      export OPEN_LOG
+      cat > "$fake_bin/open" <<'EOS'
+#!/usr/bin/env bash
+printf 'open:%s\n' "$*" >> "$OPEN_LOG"
+EOS
+      chmod +x "$fake_bin/open"
+      export PATH="$fake_bin:$PATH"
+      is_promptable() { return 0; }
+      command() {
+        if [[ "$1" == "-v" && "$2" == "node" ]]; then
+          printf '%s\\n' "$HOME/.local/state/fnm_multishells/123/bin/node"
+          return 0
+        fi
+        builtin command "$@"
+      }
+      node() {
+        if [[ "$1" == "-p" ]]; then
+          printf '%s\\n' "$NODE_REALPATH"
+          return 0
+        fi
+        return 0
+      }
+      ui_section() { printf 'section:%s\\n' "$*"; }
+      ui_info() { printf 'info:%s\\n' "$*"; }
+      ui_warn() { printf 'warn:%s\\n' "$*"; }
+      run_macos_node_tcc_preflight
+      printf 'record=%s\\n' "$(cat "$HOME/.openclaw/runtime/node-path")"
+      cat "$OPEN_LOG"
+    `);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("section:macOS Node permissions");
+    expect(result.stdout).toContain("info:OpenClaw Node runtime: ");
+    expect(result.stdout).toContain(
+      "/.local/share/fnm/node-versions/v24.15.0/installation/bin/node",
+    );
+    expect(result.stdout).toContain("warn:Current node command is an fnm multishell shim");
+    expect(result.stdout).toContain("warn:fnm-managed Node permissions stay stable");
+    expect(result.stdout).toContain("open:-R ");
+    expect(result.stdout).toContain("Privacy_AllFiles");
+    expect(result.stdout).toContain("Privacy_Accessibility");
+    expect(result.stdout).toContain("Privacy_ScreenCapture");
+    expect(result.stdout).toContain("record=");
+  });
+
+  it("skips macOS Node TCC preflight outside macOS", () => {
+    const result = runInstallShell(`
+      set -euo pipefail
+      source "${SCRIPT_PATH}"
+      OS=linux
+      node() { echo "node-called"; }
+      ui_section() { echo "section-called"; }
+      run_macos_node_tcc_preflight
+      test ! -e "$HOME/.openclaw/runtime/node-path"
+    `);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).not.toContain("node-called");
+    expect(result.stdout).not.toContain("section-called");
   });
 });
 


### PR DESCRIPTION
## Summary
- add a macOS installer preflight that resolves the active Node runtime via process.execPath and records it at ~/.openclaw/runtime/node-path
- warn when Node is fnm-managed or launched through an fnm multishell shim so users grant TCC to the stable resolved binary
- open Finder plus Full Disk Access, Accessibility, and Screen Recording panes during interactive macOS installs

## Verification
- pnpm vitest run test/scripts/install-sh.test.ts
- bash -n scripts/install.sh
- git diff --check