### PR TITLE
test(shared): add unit tests for normalizeNodePresenceAliveReason

### DIFF
--- a/src/shared/node-presence.test.ts
+++ b/src/shared/node-presence.test.ts
@@ -14,6 +14,8 @@ describe("normalizeNodePresenceAliveReason", () => {
     expect(normalizeNodePresenceAliveReason("silent_push")).toBe("silent_push");
     expect(normalizeNodePresenceAliveReason("manual")).toBe("manual");
     expect(normalizeNodePresenceAliveReason("connect")).toBe("connect");
+    expect(normalizeNodePresenceAliveReason("bg_app_refresh")).toBe("bg_app_refresh");
+    expect(normalizeNodePresenceAliveReason("significant_location")).toBe("significant_location");
   });
 
   it("is case-insensitive", () => {

--- a/src/shared/node-presence.test.ts
+++ b/src/shared/node-presence.test.ts
@@ -1,0 +1,38 @@
+// Node presence tests cover alive reason normalization for heartbeat metadata.
+import { describe, expect, it } from "vitest";
+import { NODE_PRESENCE_ALIVE_EVENT, normalizeNodePresenceAliveReason } from "./node-presence.js";
+
+describe("NODE_PRESENCE_ALIVE_EVENT", () => {
+  it("is the expected gateway event name", () => {
+    expect(NODE_PRESENCE_ALIVE_EVENT).toBe("node.presence.alive");
+  });
+});
+
+describe("normalizeNodePresenceAliveReason", () => {
+  it("passes through known canonical reasons", () => {
+    expect(normalizeNodePresenceAliveReason("background")).toBe("background");
+    expect(normalizeNodePresenceAliveReason("silent_push")).toBe("silent_push");
+    expect(normalizeNodePresenceAliveReason("manual")).toBe("manual");
+    expect(normalizeNodePresenceAliveReason("connect")).toBe("connect");
+  });
+
+  it("is case-insensitive", () => {
+    expect(normalizeNodePresenceAliveReason("MANUAL")).toBe("manual");
+    expect(normalizeNodePresenceAliveReason("Background")).toBe("background");
+  });
+
+  it("trims whitespace from input", () => {
+    expect(normalizeNodePresenceAliveReason("  manual  ")).toBe("manual");
+  });
+
+  it("defaults to background for unknown values", () => {
+    expect(normalizeNodePresenceAliveReason("unknown")).toBe("background");
+    expect(normalizeNodePresenceAliveReason("")).toBe("background");
+  });
+
+  it("defaults to background for non-string values", () => {
+    expect(normalizeNodePresenceAliveReason(undefined)).toBe("background");
+    expect(normalizeNodePresenceAliveReason(null)).toBe("background");
+    expect(normalizeNodePresenceAliveReason(123)).toBe("background");
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

`normalizeNodePresenceAliveReason` in `src/shared/node-presence.ts` normalizes untrusted node presence trigger values into canonical reasons (background, silent_push, manual, connect, etc.), defaulting unknown input to `background`. Despite being used in gateway heartbeat metadata, it had no dedicated unit tests.

## Why This Change Was Made

Add 6 tests covering:
- All known canonical reasons pass through unchanged
- Case-insensitive matching
- Whitespace trimming
- Unknown values default to `"background"`
- Non-string values (null, undefined, numbers) default to `"background"`
- `NODE_PRESENCE_ALIVE_EVENT` constant value

## User Impact

No user-visible changes. The node presence normalization contract is now tested.

## Evidence

Reproducibility: not applicable.

Direct behavior probe (no mocks):

```text
$ node --import tsx -e "import('./src/shared/node-presence.js').then((m)=>{
  const r=[];
  r.push({background:m.normalizeNodePresenceAliveReason('background')});
  r.push({manual:m.normalizeNodePresenceAliveReason('manual')});
  r.push({case_insensitive:m.normalizeNodePresenceAliveReason('MANUAL')});
  r.push({trim:m.normalizeNodePresenceAliveReason('  manual  ')});
  r.push({unknown:m.normalizeNodePresenceAliveReason('unknown')});
  r.push({null_default:m.normalizeNodePresenceAliveReason(null)});
  console.log(JSON.stringify(r,null,2));
})"
[
  {"background":"background"},
  {"manual":"manual"},
  {"case_insensitive":"manual"},
  {"trim":"manual"},
  {"unknown":"background"},
  {"null_default":"background"}
]
```

Targeted test:

```text
$ node scripts/run-vitest.mjs run src/shared/node-presence.test.ts
 Test Files  1 passed (1)
      Tests  6 passed (6)
```

Formatting:

```text
$ npx oxfmt --check src/shared/node-presence.ts src/shared/node-presence.test.ts
All matched files use the correct format.
```

Whitespace:

```text
$ git diff --check
```