### PR TITLE
fix(i18n): restore native source inventory validation

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -4835,7 +4835,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 97,
+      "line": 96,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawSurfaces.kt",
       "source": "Needs attention",
       "surface": "android",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where native-app i18n validation failed after Android release maintenance shifted a source string's line position without regenerating the checked-in native source inventory.

## Why This Change Was Made

Regenerates the canonical native i18n inventory with `pnpm native:i18n:sync`. The resulting change is limited to the approved generated line metadata correction from 97 to 96 for the unchanged `Needs attention` Android entry.

Provenance and credit: the drift was made visible by `341231831b706df0024d2d9e2096438e3581b5af` (`chore(android): prepare 2026.6.11 Play release`), authored and committed by @joshavant. The Android release change itself is retained; this PR only restores its generated inventory output. This repair was prepared with Codex under @steipete's maintainer direction.

## User Impact

No runtime or user-visible behavior changes. Native i18n inventory validation returns to green, allowing the existing Android release change to pass CI.

## Evidence

- Pinned base: `17482a402680c5489db4acde5b338b4a641920e4`, verified by [main CI](https://github.com/openclaw/openclaw/actions/runs/28554927717) with 100 successful jobs, 10 intentional skips, and zero failures.
- Before generation on Node 24.13.0: `pnpm native:i18n:check` reproduced `native app i18n inventory drift detected`.
- `pnpm native:i18n:sync`: 2,358 entries, `changed=true`; a second run reported `changed=false` with identical SHA-256 output.
- `pnpm native:i18n:check`: passed with 2,358 entries and `changed=false`.
- `node scripts/run-vitest.mjs test/scripts/native-app-i18n.test.ts`: 4/4 tests passed.
- `git diff --check`: passed.
- Fresh Codex autoreview: genuine `gpt-5.6-sol`, `xhigh`, no actionable findings, patch correct at 0.99 confidence.
- Scope: `apps/.i18n/native-source.json` only, +1/-1; no runtime, behavior, config, test, CI, coverage, or worker changes.
