### PR TITLE
fix(telegram): webhook updates survive crashes and restarts via durable spooling

### DIFF
--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -3,11 +3,7 @@ import { type RunOptions, run } from "@grammyjs/runner";
 import type { ChannelAccountSnapshot } from "openclaw/plugin-sdk/channel-contract";
 import type { TelegramNetworkConfig } from "openclaw/plugin-sdk/config-contracts";
 import { drainPendingDeliveries } from "openclaw/plugin-sdk/delivery-queue-runtime";
-import {
-  collectErrorGraphCandidates,
-  formatErrorMessage,
-  readErrorName,
-} from "openclaw/plugin-sdk/error-runtime";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import {
   clampPositiveTimerTimeoutMs,
   resolvePositiveTimerTimeoutMs,
@@ -26,13 +22,20 @@ import {
 } from "./bot-processing-outcome.js";
 import { createTelegramBot } from "./bot.js";
 import type { TelegramTransport } from "./fetch.js";
-import { isTelegramMessageDispatchReplayForgetError } from "./message-dispatch-dedupe.js";
 import { isRecoverableTelegramNetworkError } from "./network-errors.js";
 import { TelegramPollingLivenessTracker } from "./polling-liveness.js";
 import { createTelegramPollingStatusPublisher } from "./polling-status.js";
 import { TelegramPollingTransportState } from "./polling-transport-state.js";
 import { TELEGRAM_GET_UPDATES_REQUEST_TIMEOUT_MS } from "./request-timeouts.js";
 import { getTelegramSequentialKey } from "./sequential-key.js";
+import {
+  resolveNonRetryableSpooledUpdateFailure,
+  resolveSpooledUpdateAttemptNumber,
+  resolveSpooledUpdateRetryDelayMs,
+  shouldDeadLetterRetryableSpooledUpdate,
+  TELEGRAM_SPOOLED_RETRY_DEAD_LETTER_MIN_AGE_MS,
+  TELEGRAM_SPOOLED_RETRY_MAX_ATTEMPTS,
+} from "./spooled-update-retry-policy.js";
 import {
   claimNextTelegramSpooledUpdate,
   completeTelegramSpooledUpdate,
@@ -135,74 +138,12 @@ const TELEGRAM_SPOOLED_DRAIN_START_LIMIT = 100;
 const TELEGRAM_SPOOLED_DRAIN_SCAN_LIMIT = TELEGRAM_SPOOLED_DRAIN_START_LIMIT * 10;
 const TELEGRAM_SPOOLED_CLAIM_REFRESH_INTERVAL_MS = 5 * 60 * 1000;
 const TELEGRAM_SPOOLED_CLAIM_HEALTH_GRACE_MS = 2 * TELEGRAM_SPOOLED_CLAIM_REFRESH_INTERVAL_MS;
-const TELEGRAM_SPOOLED_RETRY_MAX_ATTEMPTS = 8;
-const TELEGRAM_SPOOLED_RETRY_BASE_MS = 1_000;
-const TELEGRAM_SPOOLED_RETRY_MAX_MS = 3 * 60_000;
-const TELEGRAM_SPOOLED_RETRY_DEAD_LETTER_MIN_AGE_MS = 24 * 60 * 60 * 1000;
 const TELEGRAM_POLLING_CLIENT_TIMEOUT_FLOOR_SECONDS = Math.ceil(
   TELEGRAM_GET_UPDATES_REQUEST_TIMEOUT_MS / 1000,
 );
-const MISSING_AGENT_HARNESS_ERROR_NAME = "MissingAgentHarnessError";
-const MISSING_AGENT_HARNESS_MESSAGE_RE = /Requested agent harness "[^"]+" is not registered\./u;
 
 function normalizeTelegramAccountId(accountId?: string | null): string {
   return accountId?.trim() || "default";
-}
-
-type NonRetryableSpooledUpdateFailure = {
-  reason: "missing-agent-harness" | "dispatch-dedupe-rollback-failed";
-  message: string;
-};
-
-function resolveNonRetryableSpooledUpdateFailure(
-  err: unknown,
-): NonRetryableSpooledUpdateFailure | null {
-  for (const candidate of collectErrorGraphCandidates(err, (current) => [
-    current.cause,
-    current.error,
-  ])) {
-    const message = formatErrorMessage(candidate);
-    if (isTelegramMessageDispatchReplayForgetError(candidate)) {
-      // A committed dispatch key that cannot be rolled back makes retry unsafe:
-      // the next replay can be duplicate-suppressed and then deleted.
-      return { reason: "dispatch-dedupe-rollback-failed", message };
-    }
-    if (
-      readErrorName(candidate) === MISSING_AGENT_HARNESS_ERROR_NAME ||
-      MISSING_AGENT_HARNESS_MESSAGE_RE.test(message)
-    ) {
-      return { reason: "missing-agent-harness", message };
-    }
-  }
-  return null;
-}
-
-function resolveSpooledUpdateRetryDelayMs(update: TelegramSpooledUpdate, now = Date.now()): number {
-  const attempts = update.attempts ?? 0;
-  if (!update.lastError || update.lastAttemptAt === undefined || attempts <= 0) {
-    return 0;
-  }
-  const exponent = Math.min(attempts - 1, 8);
-  const delayMs = Math.min(
-    TELEGRAM_SPOOLED_RETRY_MAX_MS,
-    TELEGRAM_SPOOLED_RETRY_BASE_MS * 2 ** exponent,
-  );
-  return Math.max(0, update.lastAttemptAt + delayMs - now);
-}
-
-function resolveSpooledUpdateAttemptNumber(update: TelegramSpooledUpdate): number {
-  return (update.attempts ?? 0) + 1;
-}
-
-function shouldDeadLetterRetryableSpooledUpdate(
-  update: TelegramSpooledUpdate,
-  attempt: number,
-  now = Date.now(),
-): boolean {
-  return (
-    attempt >= TELEGRAM_SPOOLED_RETRY_MAX_ATTEMPTS &&
-    now - update.receivedAt >= TELEGRAM_SPOOLED_RETRY_DEAD_LETTER_MIN_AGE_MS
-  );
 }
 
 type TelegramBot = ReturnType<typeof createTelegramBot>;

--- a/extensions/telegram/src/probe.test.ts
+++ b/extensions/telegram/src/probe.test.ts
@@ -313,6 +313,39 @@ describe("probeTelegram retry logic", () => {
     expect(resolveTelegramTransport).toHaveBeenCalledTimes(2);
   });
 
+  it("closes evicted cached probe transports", async () => {
+    const fetchMock = installFetchMock();
+    const closeSpies: Array<ReturnType<typeof vi.fn>> = [];
+    resolveTelegramTransport.mockImplementation((proxyFetch?: typeof fetch) => {
+      const close = vi.fn(async () => undefined);
+      closeSpies.push(close);
+      return {
+        fetch: proxyFetch ?? fetch,
+        sourceFetch: proxyFetch ?? fetch,
+        forceFallback: forceFallbackMock,
+        close,
+      };
+    });
+    vi.stubEnv("VITEST", "");
+    vi.stubEnv("NODE_ENV", "production");
+
+    for (let i = 0; i < 65; i += 1) {
+      mockGetMeSuccess(fetchMock);
+      mockGetWebhookInfoSuccess(fetchMock);
+      await probeTelegram(`${token}-cache-${i}`, timeoutMs, {
+        accountId: `account-${i}`,
+        network: {
+          autoSelectFamily: true,
+          dnsResultOrder: "ipv4first",
+        },
+      });
+    }
+
+    expect(resolveTelegramTransport).toHaveBeenCalledTimes(65);
+    expect(closeSpies[0]).toHaveBeenCalledTimes(1);
+    expect(closeSpies.slice(1).every((close) => close.mock.calls.length === 0)).toBe(true);
+  });
+
   it("reuses probe fetcher cache across token rotation when accountId is stable", async () => {
     const fetchMock = installFetchMock();
     vi.stubEnv("VITEST", "");

--- a/extensions/telegram/src/probe.ts
+++ b/extensions/telegram/src/probe.ts
@@ -87,7 +87,9 @@ function setCachedProbeTransport(
   if (probeTransportCache.size > MAX_PROBE_TRANSPORT_CACHE_SIZE) {
     const oldestKey = probeTransportCache.keys().next().value;
     if (oldestKey !== undefined) {
+      const oldestTransport = probeTransportCache.get(oldestKey);
       probeTransportCache.delete(oldestKey);
+      void oldestTransport?.close();
     }
   }
   return transport;

--- a/extensions/telegram/src/spooled-update-retry-policy.ts
+++ b/extensions/telegram/src/spooled-update-retry-policy.ts
@@ -1,0 +1,75 @@
+// Telegram plugin module shares spooled update retry policy.
+import {
+  collectErrorGraphCandidates,
+  formatErrorMessage,
+  readErrorName,
+} from "openclaw/plugin-sdk/error-runtime";
+import { isTelegramMessageDispatchReplayForgetError } from "./message-dispatch-dedupe.js";
+import type { TelegramSpooledUpdate } from "./telegram-ingress-spool.js";
+
+export const TELEGRAM_SPOOLED_RETRY_MAX_ATTEMPTS = 8;
+export const TELEGRAM_SPOOLED_RETRY_DEAD_LETTER_MIN_AGE_MS = 24 * 60 * 60 * 1000;
+const TELEGRAM_SPOOLED_RETRY_BASE_MS = 1_000;
+const TELEGRAM_SPOOLED_RETRY_MAX_MS = 3 * 60_000;
+
+const MISSING_AGENT_HARNESS_ERROR_NAME = "MissingAgentHarnessError";
+const MISSING_AGENT_HARNESS_MESSAGE_RE = /Requested agent harness "[^"]+" is not registered\./u;
+
+type NonRetryableSpooledUpdateFailure = {
+  reason: "missing-agent-harness" | "dispatch-dedupe-rollback-failed";
+  message: string;
+};
+
+export function resolveNonRetryableSpooledUpdateFailure(
+  err: unknown,
+): NonRetryableSpooledUpdateFailure | null {
+  for (const candidate of collectErrorGraphCandidates(err, (current) => [
+    current.cause,
+    current.error,
+  ])) {
+    const message = formatErrorMessage(candidate);
+    if (isTelegramMessageDispatchReplayForgetError(candidate)) {
+      // A committed dispatch key that cannot be rolled back makes retry unsafe:
+      // the next replay can be duplicate-suppressed and then deleted.
+      return { reason: "dispatch-dedupe-rollback-failed", message };
+    }
+    if (
+      readErrorName(candidate) === MISSING_AGENT_HARNESS_ERROR_NAME ||
+      MISSING_AGENT_HARNESS_MESSAGE_RE.test(message)
+    ) {
+      return { reason: "missing-agent-harness", message };
+    }
+  }
+  return null;
+}
+
+export function resolveSpooledUpdateRetryDelayMs(
+  update: TelegramSpooledUpdate,
+  now = Date.now(),
+): number {
+  const attempts = update.attempts ?? 0;
+  if (!update.lastError || update.lastAttemptAt === undefined || attempts <= 0) {
+    return 0;
+  }
+  const exponent = Math.min(attempts - 1, 8);
+  const delayMs = Math.min(
+    TELEGRAM_SPOOLED_RETRY_MAX_MS,
+    TELEGRAM_SPOOLED_RETRY_BASE_MS * 2 ** exponent,
+  );
+  return Math.max(0, update.lastAttemptAt + delayMs - now);
+}
+
+export function resolveSpooledUpdateAttemptNumber(update: TelegramSpooledUpdate): number {
+  return (update.attempts ?? 0) + 1;
+}
+
+export function shouldDeadLetterRetryableSpooledUpdate(
+  update: TelegramSpooledUpdate,
+  attempt: number,
+  now = Date.now(),
+): boolean {
+  return (
+    attempt >= TELEGRAM_SPOOLED_RETRY_MAX_ATTEMPTS &&
+    now - update.receivedAt >= TELEGRAM_SPOOLED_RETRY_DEAD_LETTER_MIN_AGE_MS
+  );
+}

--- a/extensions/telegram/src/webhook.test.ts
+++ b/extensions/telegram/src/webhook.test.ts
@@ -825,6 +825,55 @@ describe("startTelegramWebhook", () => {
     );
   });
 
+  it("keeps a timed-out webhook lane guarded until replay settles", async () => {
+    vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+    try {
+      let finishFirstUpdate: (() => void) | undefined;
+      const seenUpdateIds: number[] = [];
+      const firstUpdate = { update_id: 40, message: { chat: { id: 123 }, text: "slow" } };
+      const secondUpdate = { update_id: 41, message: { chat: { id: 123 }, text: "blocked" } };
+      await writeTelegramSpooledUpdate({
+        spoolDir: requireWebhookSpoolDir(),
+        update: firstUpdate,
+      });
+      await writeTelegramSpooledUpdate({
+        spoolDir: requireWebhookSpoolDir(),
+        update: secondUpdate,
+      });
+      handleUpdateSpy.mockImplementation(async (update: unknown) => {
+        const updateId = (update as { update_id: number }).update_id;
+        seenUpdateIds.push(updateId);
+        if (updateId === 40) {
+          await new Promise<void>((resolve) => {
+            finishFirstUpdate = resolve;
+          });
+        }
+      });
+
+      const started = await startTelegramWebhook({
+        token: TELEGRAM_TOKEN,
+        port: 0,
+        secret: TELEGRAM_SECRET,
+        path: TELEGRAM_WEBHOOK_PATH,
+        spoolDir: requireWebhookSpoolDir(),
+        runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      });
+      try {
+        await vi.waitFor(() => expect(seenUpdateIds).toEqual([40]));
+        await vi.advanceTimersByTimeAsync(25 * 60_000 + 10_000);
+        await yieldWebhookTask();
+        expect(seenUpdateIds).toEqual([40]);
+
+        finishFirstUpdate?.();
+        await vi.waitFor(() => expect(seenUpdateIds).toEqual([40, 41]));
+      } finally {
+        await started.stop();
+      }
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("drains spooled webhook updates left by a previous process on startup", async () => {
     const update = { update_id: 30, message: { text: "leftover" } };
     await writeTelegramSpooledUpdate({
@@ -917,7 +966,10 @@ describe("startTelegramWebhook", () => {
             [],
           ),
         );
-        expectMockMessageContains(runtimeLog, "reached retry limit after 8 attempts; dead-lettered");
+        expectMockMessageContains(
+          runtimeLog,
+          "reached retry limit after 8 attempts; dead-lettered",
+        );
       } finally {
         await started.stop();
       }

--- a/extensions/telegram/src/webhook.test.ts
+++ b/extensions/telegram/src/webhook.test.ts
@@ -1,10 +1,24 @@
 // Telegram tests cover webhook plugin behavior.
 import { createHash } from "node:crypto";
 import { once } from "node:events";
+import fs from "node:fs/promises";
 import { request, type IncomingMessage } from "node:http";
+import os from "node:os";
+import nodePath from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
+import {
+  closeOpenClawStateDatabaseForTest,
+  createChannelIngressQueueForTests as createChannelIngressQueue,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { WEBHOOK_RATE_LIMIT_DEFAULTS } from "openclaw/plugin-sdk/webhook-ingress";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { clearTelegramRuntime, setTelegramRuntime } from "./runtime.js";
+import type { TelegramRuntime } from "./runtime.types.js";
+import { TELEGRAM_SPOOLED_RETRY_DEAD_LETTER_MIN_AGE_MS } from "./spooled-update-retry-policy.js";
+import {
+  listTelegramSpooledUpdates,
+  writeTelegramSpooledUpdate,
+} from "./telegram-ingress-spool.js";
 
 const handleUpdateSpy = vi.hoisted(() => vi.fn((..._args: unknown[]): unknown => undefined));
 const setWebhookSpy = vi.hoisted(() => vi.fn());
@@ -104,6 +118,26 @@ vi.mock("./bot.js", () => ({
 }));
 
 let startTelegramWebhook: typeof import("./webhook.js").startTelegramWebhook;
+let webhookStateDir: string | undefined;
+let webhookSpoolDir: string | undefined;
+
+function installTelegramIngressQueueRuntime(resolveStateDir: () => string): void {
+  setTelegramRuntime({
+    state: {
+      resolveStateDir,
+      openChannelIngressQueue: (
+        options?: Omit<Parameters<typeof createChannelIngressQueue>[0], "channelId">,
+      ) => createChannelIngressQueue({ ...options, channelId: "telegram" }),
+    },
+  } as TelegramRuntime);
+}
+
+function requireWebhookSpoolDir(): string {
+  if (!webhookSpoolDir) {
+    throw new Error("webhook spool dir not initialized");
+  }
+  return webhookSpoolDir;
+}
 
 function resetTelegramWebhookMocks(): void {
   handleUpdateSpy.mockReset();
@@ -169,8 +203,23 @@ beforeAll(async () => {
   ({ startTelegramWebhook } = await import("./webhook.js"));
 });
 
-beforeEach(() => {
+beforeEach(async () => {
   resetTelegramWebhookMocks();
+  webhookStateDir = await fs.mkdtemp(nodePath.join(os.tmpdir(), "openclaw-telegram-webhook-"));
+  webhookSpoolDir = nodePath.join(webhookStateDir, "telegram", "ingress-spool-test");
+  await fs.mkdir(webhookSpoolDir, { recursive: true });
+  installTelegramIngressQueueRuntime(() => webhookStateDir ?? os.tmpdir());
+});
+
+afterEach(async () => {
+  clearTelegramRuntime();
+  closeOpenClawStateDatabaseForTest();
+  const stateDir = webhookStateDir;
+  webhookStateDir = undefined;
+  webhookSpoolDir = undefined;
+  if (stateDir) {
+    await fs.rm(stateDir, { recursive: true, force: true });
+  }
 });
 
 async function fetchWithTimeout(
@@ -401,6 +450,7 @@ async function withStartedWebhook<T>(
     token: TELEGRAM_TOKEN,
     port: 0,
     abortSignal: abort.signal,
+    spoolDir: options.spoolDir ?? requireWebhookSpoolDir(),
     ...options,
   });
   try {
@@ -659,9 +709,16 @@ describe("startTelegramWebhook", () => {
     );
   });
 
-  it("logs update processing failures after acknowledging Telegram", async () => {
+  it("durably retries a webhook update after acknowledging Telegram", async () => {
     const runtimeLog = vi.fn();
-    handleUpdateSpy.mockRejectedValueOnce(new Error("agent turn failed"));
+    const seenUpdates: unknown[] = [];
+    handleUpdateSpy.mockImplementation(async (update: unknown) => {
+      seenUpdates.push(update);
+      if (seenUpdates.length === 1) {
+        throw new Error("agent turn failed");
+      }
+    });
+    const payload = JSON.stringify({ update_id: 3, message: { text: "boom" } });
 
     await withStartedWebhook(
       {
@@ -672,18 +729,149 @@ describe("startTelegramWebhook", () => {
       async ({ port }) => {
         const response = await postWebhookJson({
           url: webhookUrl(port, TELEGRAM_WEBHOOK_PATH),
-          payload: JSON.stringify({ update_id: 3, message: { text: "boom" } }),
+          payload,
           secret: TELEGRAM_SECRET,
         });
 
         expect(response.status).toBe(200);
         expect(await response.text()).toBe("");
+        await vi.waitFor(() => expect(seenUpdates).toEqual([JSON.parse(payload)]));
+        await vi.waitFor(async () =>
+          expect(
+            (await listTelegramSpooledUpdates({ spoolDir: requireWebhookSpoolDir() })).length,
+          ).toBe(1),
+        );
+        expectMockMessageContains(runtimeLog, "webhook spooled update 3 failed; keeping for retry");
+        await sleep(1_100);
         await vi.waitFor(() =>
-          expectMockMessageContains(
-            runtimeLog,
-            "webhook update processing failed after ack: agent turn failed",
+          expect(seenUpdates).toEqual([JSON.parse(payload), JSON.parse(payload)]),
+        );
+        await vi.waitFor(async () =>
+          expect(await listTelegramSpooledUpdates({ spoolDir: requireWebhookSpoolDir() })).toEqual(
+            [],
           ),
         );
+      },
+    );
+  });
+
+  it("drains spooled webhook updates left by a previous process on startup", async () => {
+    const update = { update_id: 30, message: { text: "leftover" } };
+    await writeTelegramSpooledUpdate({
+      spoolDir: requireWebhookSpoolDir(),
+      update,
+    });
+
+    await withStartedWebhook(
+      {
+        secret: TELEGRAM_SECRET,
+        path: TELEGRAM_WEBHOOK_PATH,
+      },
+      async () => {
+        await vi.waitFor(() => expect(handleUpdateSpy).toHaveBeenCalledWith(update));
+        await vi.waitFor(async () =>
+          expect(await listTelegramSpooledUpdates({ spoolDir: requireWebhookSpoolDir() })).toEqual(
+            [],
+          ),
+        );
+      },
+    );
+  });
+
+  it("keeps retry-limit webhook updates pending until they are old enough to dead-letter", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(10_000_000);
+      const runtimeLog = vi.fn();
+      const update = { update_id: 31, message: { text: "young poison" } };
+      await writeTelegramSpooledUpdate({
+        spoolDir: requireWebhookSpoolDir(),
+        update,
+        now: Date.now(),
+      });
+      handleUpdateSpy.mockRejectedValue(new Error("deterministic handler failure"));
+
+      const started = await startTelegramWebhook({
+        token: TELEGRAM_TOKEN,
+        port: 0,
+        secret: TELEGRAM_SECRET,
+        path: TELEGRAM_WEBHOOK_PATH,
+        spoolDir: requireWebhookSpoolDir(),
+        runtime: { log: runtimeLog, error: vi.fn(), exit: vi.fn() },
+      });
+      try {
+        await vi.waitFor(() => expect(handleUpdateSpy).toHaveBeenCalled());
+        await vi.advanceTimersByTimeAsync(130_000);
+        await vi.waitFor(async () =>
+          expect(
+            (await listTelegramSpooledUpdates({ spoolDir: requireWebhookSpoolDir() })).map(
+              (spooled) => spooled.updateId,
+            ),
+          ).toEqual([31]),
+        );
+        expect(mockMessages(runtimeLog).join("\n")).not.toContain("dead-lettered");
+      } finally {
+        await started.stop();
+      }
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("dead-letters retry-limit webhook updates after the minimum age", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(10_000_000);
+      const runtimeLog = vi.fn();
+      const update = { update_id: 32, message: { text: "old poison" } };
+      await writeTelegramSpooledUpdate({
+        spoolDir: requireWebhookSpoolDir(),
+        update,
+        now: Date.now() - TELEGRAM_SPOOLED_RETRY_DEAD_LETTER_MIN_AGE_MS,
+      });
+      handleUpdateSpy.mockRejectedValue(new Error("deterministic handler failure"));
+
+      const started = await startTelegramWebhook({
+        token: TELEGRAM_TOKEN,
+        port: 0,
+        secret: TELEGRAM_SECRET,
+        path: TELEGRAM_WEBHOOK_PATH,
+        spoolDir: requireWebhookSpoolDir(),
+        runtime: { log: runtimeLog, error: vi.fn(), exit: vi.fn() },
+      });
+      try {
+        await vi.waitFor(() => expect(handleUpdateSpy).toHaveBeenCalled());
+        await vi.advanceTimersByTimeAsync(130_000);
+        await vi.waitFor(async () =>
+          expect(await listTelegramSpooledUpdates({ spoolDir: requireWebhookSpoolDir() })).toEqual(
+            [],
+          ),
+        );
+        expectMockMessageContains(runtimeLog, "reached retry limit after 8 attempts; dead-lettered");
+      } finally {
+        await started.stop();
+      }
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("returns non-200 when the webhook update cannot be spooled durably", async () => {
+    handleUpdateSpy.mockClear();
+    await withStartedWebhook(
+      {
+        secret: TELEGRAM_SECRET,
+        path: TELEGRAM_WEBHOOK_PATH,
+      },
+      async ({ port }) => {
+        const response = await postWebhookJson({
+          url: webhookUrl(port, TELEGRAM_WEBHOOK_PATH),
+          payload: JSON.stringify({ message: { text: "missing update id" } }),
+          secret: TELEGRAM_SECRET,
+        });
+
+        expect(response.status).toBe(500);
+        expect(handleUpdateSpy).not.toHaveBeenCalled();
       },
     );
   });
@@ -814,6 +1002,7 @@ describe("startTelegramWebhook", () => {
       abortSignal: firstAbort.signal,
       secret: TELEGRAM_SECRET,
       path: TELEGRAM_WEBHOOK_PATH,
+      spoolDir: requireWebhookSpoolDir(),
     });
     const second = await startTelegramWebhook({
       token: TELEGRAM_TOKEN,
@@ -821,6 +1010,7 @@ describe("startTelegramWebhook", () => {
       abortSignal: secondAbort.signal,
       secret: TELEGRAM_SECRET,
       path: TELEGRAM_WEBHOOK_PATH,
+      spoolDir: nodePath.join(requireWebhookSpoolDir(), "second"),
     });
 
     try {
@@ -1052,6 +1242,7 @@ describe("startTelegramWebhook", () => {
       port: 0,
       abortSignal: abort.signal,
       path: TELEGRAM_WEBHOOK_PATH,
+      spoolDir: requireWebhookSpoolDir(),
     });
 
     abort.abort();

--- a/extensions/telegram/src/webhook.test.ts
+++ b/extensions/telegram/src/webhook.test.ts
@@ -33,6 +33,18 @@ const createTelegramBotSpy = vi.hoisted(() =>
     stop: stopSpy,
   })),
 );
+const transportCloseSpies = vi.hoisted(() => [] as Array<ReturnType<typeof vi.fn>>);
+const resolveTelegramTransportSpy = vi.hoisted(() =>
+  vi.fn(() => {
+    const close = vi.fn(async () => undefined);
+    transportCloseSpies.push(close);
+    return {
+      fetch: globalThis.fetch,
+      sourceFetch: globalThis.fetch,
+      close,
+    };
+  }),
+);
 
 const WEBHOOK_POST_TIMEOUT_MS = process.platform === "win32" ? 20_000 : 8_000;
 const TELEGRAM_TOKEN = "tok";
@@ -117,6 +129,10 @@ vi.mock("./bot.js", () => ({
   createTelegramBot: createTelegramBotSpy,
 }));
 
+vi.mock("./fetch.js", () => ({
+  resolveTelegramTransport: resolveTelegramTransportSpy,
+}));
+
 let startTelegramWebhook: typeof import("./webhook.js").startTelegramWebhook;
 let webhookStateDir: string | undefined;
 let webhookSpoolDir: string | undefined;
@@ -149,6 +165,8 @@ function resetTelegramWebhookMocks(): void {
   initSpy.mockReset();
   initSpy.mockImplementation(async () => undefined);
   stopSpy.mockReset();
+  resolveTelegramTransportSpy.mockClear();
+  transportCloseSpies.length = 0;
   createTelegramBotSpy.mockReset();
   createTelegramBotSpy.mockImplementation(() => ({
     init: initSpy,
@@ -456,6 +474,7 @@ async function withStartedWebhook<T>(
   try {
     return await run({ server: started.server, port: getServerPort(started.server) });
   } finally {
+    await started.stop();
     abort.abort();
   }
 }
@@ -528,6 +547,7 @@ describe("startTelegramWebhook", () => {
         );
         expect(botParams.accountId).toBe("opie");
         expect(requireRecord(botParams.config, "telegram config").bindings).toEqual([]);
+        expect(botParams.telegramTransport).toBeDefined();
         const health = await fetch(`http://127.0.0.1:${port}/healthz`);
         expect(health.status).toBe(200);
         expect(initSpy).toHaveBeenCalledTimes(1);
@@ -608,6 +628,7 @@ describe("startTelegramWebhook", () => {
     ).rejects.toThrow("unauthorized");
 
     expect(stopSpy).toHaveBeenCalledTimes(1);
+    expect(transportCloseSpies[0]).toHaveBeenCalledTimes(1);
     expectMockMessageContains(runtimeError, "telegram setWebhook failed: unauthorized");
   });
 
@@ -655,7 +676,8 @@ describe("startTelegramWebhook", () => {
     ).rejects.toThrow("unauthorized");
 
     expect(setWebhookSpy).not.toHaveBeenCalled();
-    expect(stopSpy).not.toHaveBeenCalled();
+    expect(stopSpy).toHaveBeenCalledTimes(1);
+    expect(transportCloseSpies[0]).toHaveBeenCalledTimes(1);
     expectMockMessageContains(runtimeError, "telegram getMe failed: unauthorized");
   });
 
@@ -1085,6 +1107,8 @@ describe("startTelegramWebhook", () => {
       expect(secondResponse.status).toBe(200);
       await vi.waitFor(() => expect(handleUpdateSpy).toHaveBeenCalledTimes(1));
     } finally {
+      await first.stop();
+      await second.stop();
       firstAbort.abort();
       secondAbort.abort();
     }
@@ -1284,7 +1308,7 @@ describe("startTelegramWebhook", () => {
   it("does not de-register webhook when shutting down", async () => {
     deleteWebhookSpy.mockClear();
     const abort = new AbortController();
-    await startTelegramWebhook({
+    const started = await startTelegramWebhook({
       token: TELEGRAM_TOKEN,
       secret: TELEGRAM_SECRET,
       port: 0,
@@ -1293,7 +1317,23 @@ describe("startTelegramWebhook", () => {
       spoolDir: requireWebhookSpoolDir(),
     });
 
+    await started.stop();
     abort.abort();
     expect(deleteWebhookSpy).toHaveBeenCalledTimes(0);
+  });
+
+  it("closes the owned transport exactly once on shutdown", async () => {
+    const started = await startTelegramWebhook({
+      token: TELEGRAM_TOKEN,
+      secret: TELEGRAM_SECRET,
+      port: 0,
+      path: TELEGRAM_WEBHOOK_PATH,
+      spoolDir: requireWebhookSpoolDir(),
+    });
+
+    await started.stop();
+    await started.stop();
+
+    expect(transportCloseSpies[0]).toHaveBeenCalledTimes(1);
   });
 });

--- a/extensions/telegram/src/webhook.test.ts
+++ b/extensions/telegram/src/webhook.test.ts
@@ -611,6 +611,54 @@ describe("startTelegramWebhook", () => {
     expectMockMessageContains(runtimeError, "telegram setWebhook failed: unauthorized");
   });
 
+  it("retries transient getMe startup init failures before starting the account", async () => {
+    const runtimeLog = vi.fn();
+    initSpy.mockRejectedValueOnce(new TypeError("fetch failed")).mockResolvedValueOnce(undefined);
+
+    await withStartedWebhook(
+      {
+        secret: TELEGRAM_SECRET,
+        path: TELEGRAM_WEBHOOK_PATH,
+        runtime: { log: runtimeLog, error: vi.fn(), exit: vi.fn() },
+        webhookRegistrationRetryPolicy: {
+          initialMs: 0,
+          maxMs: 0,
+          factor: 1,
+          jitter: 0,
+        },
+      },
+      async ({ port }) => {
+        const health = await fetch(`http://127.0.0.1:${port}/healthz`);
+        expect(health.status).toBe(200);
+      },
+    );
+
+    expect(initSpy).toHaveBeenCalledTimes(2);
+    expect(runtimeLog).toHaveBeenCalledWith("telegram getMe retry 1 scheduled in 0ms");
+    expect(setWebhookSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails startup on non-recoverable getMe errors", async () => {
+    const runtimeError = vi.fn();
+    const error = Object.assign(new Error("unauthorized"), { error_code: 401 });
+    initSpy.mockRejectedValueOnce(error);
+
+    await expect(
+      startTelegramWebhook({
+        token: TELEGRAM_TOKEN,
+        port: 0,
+        secret: TELEGRAM_SECRET,
+        path: TELEGRAM_WEBHOOK_PATH,
+        spoolDir: requireWebhookSpoolDir(),
+        runtime: { log: vi.fn(), error: runtimeError, exit: vi.fn() },
+      }),
+    ).rejects.toThrow("unauthorized");
+
+    expect(setWebhookSpy).not.toHaveBeenCalled();
+    expect(stopSpy).not.toHaveBeenCalled();
+    expectMockMessageContains(runtimeError, "telegram getMe failed: unauthorized");
+  });
+
   it("registers webhook with certificate when webhookCertPath is provided", async () => {
     setWebhookSpy.mockClear();
     await withStartedWebhook(

--- a/extensions/telegram/src/webhook.test.ts
+++ b/extensions/telegram/src/webhook.test.ts
@@ -968,7 +968,7 @@ describe("startTelegramWebhook", () => {
     );
   });
 
-  it("rate limits repeated invalid secret guesses before authentication succeeds", async () => {
+  it("rate limits repeated invalid secret guesses without throttling authenticated delivery", async () => {
     handleUpdateSpy.mockClear();
     await withStartedWebhook(
       {
@@ -1002,9 +1002,30 @@ describe("startTelegramWebhook", () => {
           payload: JSON.stringify({ update_id: 999, message: { text: "hello" } }),
           secret: TELEGRAM_SECRET,
         });
-        expect(validResponse.status).toBe(429);
-        expect(await validResponse.text()).toBe("Too Many Requests");
-        expect(handleUpdateSpy).not.toHaveBeenCalled();
+        expect(validResponse.status).toBe(200);
+        expect(await validResponse.text()).toBe("");
+        await vi.waitFor(() => expect(handleUpdateSpy).toHaveBeenCalledTimes(1));
+      },
+    );
+  });
+
+  it("does not rate limit authenticated webhook request storms", async () => {
+    handleUpdateSpy.mockClear();
+    await withStartedWebhook(
+      {
+        secret: TELEGRAM_SECRET,
+        path: TELEGRAM_WEBHOOK_PATH,
+      },
+      async ({ port }) => {
+        for (let i = 0; i < TELEGRAM_WEBHOOK_RATE_LIMIT_BURST; i += 1) {
+          const response = await postWebhookJson({
+            url: webhookUrl(port, TELEGRAM_WEBHOOK_PATH),
+            payload: JSON.stringify({ update_id: 10_000 + i, message: { text: `valid ${i}` } }),
+            secret: TELEGRAM_SECRET,
+          });
+          expect(response.status).toBe(200);
+        }
+        await vi.waitFor(() => expect(handleUpdateSpy).toHaveBeenCalled());
       },
     );
   });

--- a/extensions/telegram/src/webhook.ts
+++ b/extensions/telegram/src/webhook.ts
@@ -84,7 +84,11 @@ const TELEGRAM_WEBHOOK_REGISTRATION_RETRY_POLICY: BackoffPolicy = {
   factor: 2,
   jitter: 0.2,
 };
-const activeWebhookSpooledHandlersByLane = new Set<string>();
+type ActiveWebhookSpooledHandler = {
+  laneKey: string;
+};
+
+const activeWebhookSpooledHandlersByLane = new Map<string, ActiveWebhookSpooledHandler>();
 
 function buildWebhookSpooledHandlerKey(params: { laneKey: string; spoolDir: string }): string {
   return `${params.spoolDir}\0${params.laneKey}`;
@@ -93,9 +97,9 @@ function buildWebhookSpooledHandlerKey(params: { laneKey: string; spoolDir: stri
 function resolveActiveWebhookSpooledLaneKeys(spoolDir: string): Set<string> {
   const laneKeys = new Set<string>();
   const prefix = `${spoolDir}\0`;
-  for (const handlerKey of activeWebhookSpooledHandlersByLane) {
+  for (const [handlerKey, handler] of activeWebhookSpooledHandlersByLane) {
     if (handlerKey.startsWith(prefix)) {
-      laneKeys.add(handlerKey.slice(prefix.length));
+      laneKeys.add(handler.laneKey);
     }
   }
   return laneKeys;
@@ -454,17 +458,21 @@ async function waitForTimedOutWebhookReplayGrace(params: {
   log: (line: string) => void;
   replayTask: Promise<{ deferredWork?: TelegramSpooledReplayDeferredParticipant }>;
   updateId: number;
-}): Promise<void> {
+}): Promise<boolean> {
   let timer: ReturnType<typeof setTimeout> | undefined;
   try {
-    await Promise.race([
-      params.replayTask.catch((replayErr: unknown) => {
-        params.log(
-          `[telegram][diag] timed out webhook spooled update ${params.updateId} replay later failed: ${formatErrorMessage(replayErr)}`,
-        );
-      }),
-      new Promise<void>((resolve) => {
-        timer = setTimeout(resolve, TELEGRAM_WEBHOOK_SPOOLED_HANDLER_ABORT_GRACE_MS);
+    return await Promise.race([
+      params.replayTask.then(
+        () => true,
+        (replayErr: unknown) => {
+          params.log(
+            `[telegram][diag] timed out webhook spooled update ${params.updateId} replay later failed: ${formatErrorMessage(replayErr)}`,
+          );
+          return true;
+        },
+      ),
+      new Promise<boolean>((resolve) => {
+        timer = setTimeout(() => resolve(false), TELEGRAM_WEBHOOK_SPOOLED_HANDLER_ABORT_GRACE_MS);
         timer.unref?.();
       }),
     ]);
@@ -474,6 +482,10 @@ async function waitForTimedOutWebhookReplayGrace(params: {
     }
   }
 }
+
+type WebhookSpooledUpdateHandlerResult = {
+  retainLaneGuardTask?: Promise<unknown>;
+};
 
 async function runWebhookSpooledReplayWithTimeout(params: {
   bot: ReturnType<typeof createTelegramBot>;
@@ -549,7 +561,7 @@ async function handleWebhookSpooledUpdate(params: {
   bot: ReturnType<typeof createTelegramBot>;
   log: (line: string) => void;
   update: ClaimedTelegramSpooledUpdate;
-}): Promise<void> {
+}): Promise<WebhookSpooledUpdateHandlerResult> {
   let replay: { deferredWork?: TelegramSpooledReplayDeferredParticipant };
   try {
     const rawUpdate = params.update.update;
@@ -583,19 +595,28 @@ async function handleWebhookSpooledUpdate(params: {
         message: err.message,
         update: params.update,
       });
-      await waitForTimedOutWebhookReplayGrace({
+      const replaySettled = await waitForTimedOutWebhookReplayGrace({
         log: params.log,
         replayTask: err.replayTask,
         updateId: params.update.updateId,
       });
-      return;
+      if (replaySettled) {
+        return {};
+      }
+      return {
+        retainLaneGuardTask: err.replayTask.catch((replayErr: unknown) => {
+          params.log(
+            `[telegram][diag] timed out webhook spooled update ${params.update.updateId} replay later failed: ${formatErrorMessage(replayErr)}`,
+          );
+        }),
+      };
     }
     await releaseFailedWebhookSpooledUpdate({
       err,
       log: params.log,
       update: params.update,
     });
-    return;
+    return {};
   }
   if (replay.deferredWork) {
     const result = await waitForWebhookSpooledDeferredWork({
@@ -611,14 +632,14 @@ async function handleWebhookSpooledUpdate(params: {
           message: formatErrorMessage(result.error),
           update: params.update,
         });
-        return;
+        return {};
       }
       await releaseFailedWebhookSpooledUpdate({
         err: result.error,
         log: params.log,
         update: params.update,
       });
-      return;
+      return {};
     }
   }
   try {
@@ -628,6 +649,7 @@ async function handleWebhookSpooledUpdate(params: {
       `[telegram][diag] webhook spooled update ${params.update.updateId} completed but processing marker cleanup failed: ${formatErrorMessage(err)}`,
     );
   }
+  return {};
 }
 
 export async function startTelegramWebhook(opts: {
@@ -769,7 +791,8 @@ export async function startTelegramWebhook(opts: {
         const handlerKey = buildWebhookSpooledHandlerKey({ spoolDir, laneKey });
         // Webhook HTTP requests and same-process restarts can overlap; keep
         // one process-global active claim per spool lane to preserve ordering.
-        activeWebhookSpooledHandlersByLane.add(handlerKey);
+        const handlerState: ActiveWebhookSpooledHandler = { laneKey };
+        activeWebhookSpooledHandlersByLane.set(handlerKey, handlerState);
         blockedLaneKeys.add(laneKey);
         // Claim ownership has a finite lease; refresh while the handler runs so
         // another process cannot recover and replay this update concurrently.
@@ -777,12 +800,24 @@ export async function startTelegramWebhook(opts: {
           log,
           update: claimedUpdate,
         });
+        let retainLaneGuardTask: Promise<unknown> | undefined;
         void handleWebhookSpooledUpdate({
           accountId: opts.accountId ?? "default",
           bot,
           log,
           update: claimedUpdate,
         })
+          .then((result) => {
+            retainLaneGuardTask = result.retainLaneGuardTask;
+            if (retainLaneGuardTask) {
+              void retainLaneGuardTask.finally(() => {
+                if (activeWebhookSpooledHandlersByLane.get(handlerKey) === handlerState) {
+                  activeWebhookSpooledHandlersByLane.delete(handlerKey);
+                }
+                void Promise.resolve().then(drainWebhookSpool);
+              });
+            }
+          })
           .catch((err: unknown) => {
             runtime.log?.(
               `[telegram][diag] webhook spooled update ${claimedUpdate.updateId} handler failed after claim: ${formatErrorMessage(err)}`,
@@ -790,7 +825,12 @@ export async function startTelegramWebhook(opts: {
           })
           .finally(() => {
             stopClaimRefresh();
-            activeWebhookSpooledHandlersByLane.delete(handlerKey);
+            if (
+              !retainLaneGuardTask &&
+              activeWebhookSpooledHandlersByLane.get(handlerKey) === handlerState
+            ) {
+              activeWebhookSpooledHandlersByLane.delete(handlerKey);
+            }
             void Promise.resolve().then(drainWebhookSpool);
           });
         started += 1;

--- a/extensions/telegram/src/webhook.ts
+++ b/extensions/telegram/src/webhook.ts
@@ -32,18 +32,73 @@ import {
 import { readJsonBodyWithLimit } from "openclaw/plugin-sdk/webhook-request-guards";
 import { resolveTelegramAllowedUpdates } from "./allowed-updates.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
+import {
+  runWithTelegramSpooledReplayUpdate,
+  type TelegramMessageProcessingResult,
+  type TelegramSpooledReplayDeferredParticipant,
+} from "./bot-processing-outcome.js";
 import { createTelegramBot } from "./bot.js";
 import { isRetryableTelegramApiError } from "./network-errors.js";
+import { getTelegramSequentialKey } from "./sequential-key.js";
+import {
+  resolveNonRetryableSpooledUpdateFailure,
+  resolveSpooledUpdateAttemptNumber,
+  resolveSpooledUpdateRetryDelayMs,
+  shouldDeadLetterRetryableSpooledUpdate,
+  TELEGRAM_SPOOLED_RETRY_MAX_ATTEMPTS,
+} from "./spooled-update-retry-policy.js";
+import {
+  claimNextTelegramSpooledUpdate,
+  completeTelegramSpooledUpdate,
+  failTelegramSpooledUpdateClaim,
+  isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess,
+  listTelegramSpooledUpdateClaims,
+  listTelegramSpooledUpdates,
+  recoverStaleTelegramSpooledUpdateClaims,
+  refreshTelegramSpooledUpdateClaim,
+  releaseTelegramSpooledUpdateClaim,
+  resolveTelegramIngressSpoolDir,
+  TELEGRAM_SPOOLED_UPDATE_CLAIM_LEASE_MS,
+  writeTelegramSpooledUpdate,
+  type ClaimedTelegramSpooledUpdate,
+} from "./telegram-ingress-spool.js";
+import {
+  buildTelegramReplyFenceLaneKey,
+  supersedeTelegramReplyFenceLane,
+} from "./telegram-reply-fence.js";
 import { createTelegramWebhookStatusPublisher } from "./webhook-status.js";
 
 const TELEGRAM_WEBHOOK_MAX_BODY_BYTES = 1024 * 1024;
 const TELEGRAM_WEBHOOK_BODY_TIMEOUT_MS = 30_000;
+const TELEGRAM_WEBHOOK_SPOOLED_DRAIN_INTERVAL_MS = 500;
+const TELEGRAM_WEBHOOK_SPOOLED_CLAIM_REFRESH_INTERVAL_MS = 5 * 60 * 1000;
+const TELEGRAM_WEBHOOK_SPOOLED_HANDLER_TIMEOUT_MS = 25 * 60_000;
+const TELEGRAM_WEBHOOK_SPOOLED_HANDLER_ABORT_GRACE_MS = 5_000;
+const TELEGRAM_WEBHOOK_SPOOLED_DRAIN_START_LIMIT = 100;
+const TELEGRAM_WEBHOOK_SPOOLED_DRAIN_SCAN_LIMIT = TELEGRAM_WEBHOOK_SPOOLED_DRAIN_START_LIMIT * 10;
 const TELEGRAM_WEBHOOK_REGISTRATION_RETRY_POLICY: BackoffPolicy = {
   initialMs: 5_000,
   maxMs: 60_000,
   factor: 2,
   jitter: 0.2,
 };
+const activeWebhookSpooledHandlersByLane = new Set<string>();
+
+function buildWebhookSpooledHandlerKey(params: { laneKey: string; spoolDir: string }): string {
+  return `${params.spoolDir}\0${params.laneKey}`;
+}
+
+function resolveActiveWebhookSpooledLaneKeys(spoolDir: string): Set<string> {
+  const laneKeys = new Set<string>();
+  const prefix = `${spoolDir}\0`;
+  for (const handlerKey of activeWebhookSpooledHandlersByLane) {
+    if (handlerKey.startsWith(prefix)) {
+      laneKeys.add(handlerKey.slice(prefix.length));
+    }
+  }
+  return laneKeys;
+}
+
 async function listenHttpServer(params: {
   server: ReturnType<typeof createServer>;
   port: number;
@@ -230,6 +285,317 @@ function resolveTelegramWebhookRateLimitKey(
   return `${path}:${resolveTelegramWebhookClientIp(req, config)}`;
 }
 
+function resolveWebhookSpooledUpdateLaneKey(update: unknown): string {
+  return getTelegramSequentialKey({
+    update: update as Parameters<typeof getTelegramSequentialKey>[0]["update"],
+  });
+}
+
+async function releaseFailedWebhookSpooledUpdate(params: {
+  err: unknown;
+  log: (line: string) => void;
+  update: ClaimedTelegramSpooledUpdate;
+}): Promise<void> {
+  const laneKey = resolveWebhookSpooledUpdateLaneKey(params.update.update);
+  const nonRetryable = resolveNonRetryableSpooledUpdateFailure(params.err);
+  if (nonRetryable) {
+    const failed = await failTelegramSpooledUpdateClaim({
+      update: params.update,
+      reason: nonRetryable.reason,
+      message: nonRetryable.message,
+    });
+    if (failed) {
+      params.log(
+        `[telegram][diag] webhook spooled update ${params.update.updateId} failed with non-retryable ${nonRetryable.reason}; dead-lettered: ${nonRetryable.message}`,
+      );
+    }
+    return;
+  }
+
+  const attempt = resolveSpooledUpdateAttemptNumber(params.update);
+  if (shouldDeadLetterRetryableSpooledUpdate(params.update, attempt)) {
+    const message = formatErrorMessage(params.err);
+    const failed = await failTelegramSpooledUpdateClaim({
+      update: params.update,
+      reason: "retry-limit-exceeded",
+      message,
+    });
+    if (failed) {
+      // Retryable poison updates must eventually become tombstones, but not
+      // during ordinary transient provider or state-store outages.
+      params.log(
+        `[telegram][warn] webhook spooled update ${params.update.updateId} on lane ${laneKey} reached retry limit after ${attempt} attempts; dead-lettered: ${message}`,
+      );
+    }
+    return;
+  }
+
+  await releaseTelegramSpooledUpdateClaim(params.update, {
+    lastError: formatErrorMessage(params.err),
+  });
+  params.log(
+    `[telegram][diag] webhook spooled update ${params.update.updateId} failed; keeping for retry attempt ${attempt + 1}/${TELEGRAM_SPOOLED_RETRY_MAX_ATTEMPTS}: ${formatErrorMessage(params.err)}`,
+  );
+}
+
+function startWebhookSpooledUpdateClaimRefresh(params: {
+  log: (line: string) => void;
+  update: ClaimedTelegramSpooledUpdate;
+}): () => void {
+  let stopped = false;
+  let refreshing = false;
+  const refresh = async (): Promise<void> => {
+    if (stopped || refreshing) {
+      return;
+    }
+    refreshing = true;
+    try {
+      const refreshed = await refreshTelegramSpooledUpdateClaim(params.update);
+      if (!refreshed && !stopped) {
+        params.log(
+          `[telegram][diag] webhook spooled update ${params.update.updateId} claim refresh lost ownership`,
+        );
+      }
+    } catch (err) {
+      params.log(
+        `[telegram][diag] webhook spooled update ${params.update.updateId} claim refresh failed: ${formatErrorMessage(err)}`,
+      );
+    } finally {
+      refreshing = false;
+    }
+  };
+  const timer = setInterval(() => {
+    void refresh();
+  }, TELEGRAM_WEBHOOK_SPOOLED_CLAIM_REFRESH_INTERVAL_MS);
+  timer.unref?.();
+  return () => {
+    if (stopped) {
+      return;
+    }
+    stopped = true;
+    clearInterval(timer);
+  };
+}
+
+type WebhookSpooledDeferredWorkResult = TelegramMessageProcessingResult & {
+  timedOut?: boolean;
+};
+
+class WebhookSpooledHandlerTimeoutError extends Error {
+  constructor(
+    message: string,
+    readonly replayTask: Promise<{ deferredWork?: TelegramSpooledReplayDeferredParticipant }>,
+  ) {
+    super(message);
+    this.name = "WebhookSpooledHandlerTimeoutError";
+  }
+}
+
+function formatWebhookSpooledHandlerTimeoutMessage(params: {
+  laneKey: string;
+  updateId: number;
+}): string {
+  const age = formatDurationPrecise(TELEGRAM_WEBHOOK_SPOOLED_HANDLER_TIMEOUT_MS);
+  return `Telegram webhook spool processing timed out behind update ${params.updateId} on lane ${params.laneKey} after ${age}; marking the update failed.`;
+}
+
+async function failTimedOutWebhookSpooledUpdate(params: {
+  log: (line: string) => void;
+  message: string;
+  update: ClaimedTelegramSpooledUpdate;
+}): Promise<void> {
+  const failed = await failTelegramSpooledUpdateClaim({
+    update: params.update,
+    reason: "handler-timeout",
+    message: params.message,
+  });
+  if (!failed) {
+    params.log(
+      `[telegram][diag] timed out webhook spooled update ${params.update.updateId} no longer had a processing marker to fail.`,
+    );
+  }
+}
+
+async function waitForTimedOutWebhookReplayGrace(params: {
+  log: (line: string) => void;
+  replayTask: Promise<{ deferredWork?: TelegramSpooledReplayDeferredParticipant }>;
+  updateId: number;
+}): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      params.replayTask.catch((replayErr: unknown) => {
+        params.log(
+          `[telegram][diag] timed out webhook spooled update ${params.updateId} replay later failed: ${formatErrorMessage(replayErr)}`,
+        );
+      }),
+      new Promise<void>((resolve) => {
+        timer = setTimeout(resolve, TELEGRAM_WEBHOOK_SPOOLED_HANDLER_ABORT_GRACE_MS);
+        timer.unref?.();
+      }),
+    ]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+}
+
+async function runWebhookSpooledReplayWithTimeout(params: {
+  bot: ReturnType<typeof createTelegramBot>;
+  laneKey: string;
+  rawUpdate: object;
+  update: Parameters<ReturnType<typeof createTelegramBot>["handleUpdate"]>[0];
+  updateId: number;
+}): Promise<{ deferredWork?: TelegramSpooledReplayDeferredParticipant }> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const replayTask = runWithTelegramSpooledReplayUpdate(params.rawUpdate, async () => {
+    await params.bot.handleUpdate(params.update);
+  });
+  replayTask.catch(() => undefined);
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => {
+      reject(
+        new WebhookSpooledHandlerTimeoutError(
+          formatWebhookSpooledHandlerTimeoutMessage({
+            laneKey: params.laneKey,
+            updateId: params.updateId,
+          }),
+          replayTask,
+        ),
+      );
+    }, TELEGRAM_WEBHOOK_SPOOLED_HANDLER_TIMEOUT_MS);
+    timer.unref?.();
+  });
+  try {
+    return await Promise.race([replayTask, timeout]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+}
+
+async function waitForWebhookSpooledDeferredWork(params: {
+  deferredWork: TelegramSpooledReplayDeferredParticipant;
+  laneKey: string;
+  log: (line: string) => void;
+  update: ClaimedTelegramSpooledUpdate;
+}): Promise<WebhookSpooledDeferredWorkResult> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<WebhookSpooledDeferredWorkResult>((resolve) => {
+    timer = setTimeout(() => {
+      const age = formatDurationPrecise(TELEGRAM_WEBHOOK_SPOOLED_HANDLER_TIMEOUT_MS);
+      const message = `Telegram webhook spool buffered processing timed out behind update ${params.update.updateId} on lane ${params.laneKey} after ${age}; marking the update failed.`;
+      params.log(`[telegram] ${message}`);
+      params.deferredWork.settle({
+        kind: "failed-retryable",
+        error: new Error(message),
+      });
+      resolve({ kind: "failed-retryable", error: new Error(message), timedOut: true });
+    }, TELEGRAM_WEBHOOK_SPOOLED_HANDLER_TIMEOUT_MS);
+    timer.unref?.();
+  });
+  try {
+    return await Promise.race([
+      params.deferredWork.task.catch((err: unknown): TelegramMessageProcessingResult => {
+        return { kind: "failed-retryable", error: err };
+      }),
+      timeout,
+    ]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+}
+
+async function handleWebhookSpooledUpdate(params: {
+  accountId: string;
+  bot: ReturnType<typeof createTelegramBot>;
+  log: (line: string) => void;
+  update: ClaimedTelegramSpooledUpdate;
+}): Promise<void> {
+  let replay: { deferredWork?: TelegramSpooledReplayDeferredParticipant };
+  try {
+    const rawUpdate = params.update.update;
+    if (!rawUpdate || typeof rawUpdate !== "object") {
+      throw new Error("Telegram spooled webhook update payload was invalid.");
+    }
+    const laneKey = resolveWebhookSpooledUpdateLaneKey(rawUpdate);
+    const update = rawUpdate as Parameters<typeof params.bot.handleUpdate>[0];
+    replay = await runWebhookSpooledReplayWithTimeout({
+      bot: params.bot,
+      laneKey,
+      rawUpdate,
+      update,
+      updateId: params.update.updateId,
+    });
+  } catch (err) {
+    if (err instanceof WebhookSpooledHandlerTimeoutError) {
+      params.log(`[telegram] ${err.message}`);
+      const scopedReplyFenceLaneKey = buildTelegramReplyFenceLaneKey({
+        accountId: params.accountId,
+        sequentialKey: resolveWebhookSpooledUpdateLaneKey(params.update.update),
+      });
+      const abortedReplyWork = supersedeTelegramReplyFenceLane(scopedReplyFenceLaneKey);
+      if (!abortedReplyWork) {
+        params.log(
+          `[telegram][diag] timed out webhook spooled update ${params.update.updateId} had no active reply fence on lane ${scopedReplyFenceLaneKey}.`,
+        );
+      }
+      await failTimedOutWebhookSpooledUpdate({
+        log: params.log,
+        message: err.message,
+        update: params.update,
+      });
+      await waitForTimedOutWebhookReplayGrace({
+        log: params.log,
+        replayTask: err.replayTask,
+        updateId: params.update.updateId,
+      });
+      return;
+    }
+    await releaseFailedWebhookSpooledUpdate({
+      err,
+      log: params.log,
+      update: params.update,
+    });
+    return;
+  }
+  if (replay.deferredWork) {
+    const result = await waitForWebhookSpooledDeferredWork({
+      deferredWork: replay.deferredWork,
+      laneKey: resolveWebhookSpooledUpdateLaneKey(params.update.update),
+      log: params.log,
+      update: params.update,
+    });
+    if (result.kind === "failed-retryable") {
+      if (result.timedOut) {
+        await failTimedOutWebhookSpooledUpdate({
+          log: params.log,
+          message: formatErrorMessage(result.error),
+          update: params.update,
+        });
+        return;
+      }
+      await releaseFailedWebhookSpooledUpdate({
+        err: result.error,
+        log: params.log,
+        update: params.update,
+      });
+      return;
+    }
+  }
+  try {
+    await completeTelegramSpooledUpdate(params.update);
+  } catch (err) {
+    params.log(
+      `[telegram][diag] webhook spooled update ${params.update.updateId} completed but processing marker cleanup failed: ${formatErrorMessage(err)}`,
+    );
+  }
+}
+
 export async function startTelegramWebhook(opts: {
   token: string;
   accountId?: string;
@@ -245,6 +611,7 @@ export async function startTelegramWebhook(opts: {
   publicUrl?: string;
   webhookCertPath?: string;
   webhookRegistrationRetryPolicy?: BackoffPolicy;
+  spoolDir?: string;
   setStatus?: (patch: Omit<ChannelAccountSnapshot, "accountId">) => void;
 }) {
   const path = opts.path ?? "/telegram-webhook";
@@ -264,6 +631,8 @@ export async function startTelegramWebhook(opts: {
   const webhookRegistrationRetryPolicy =
     opts.webhookRegistrationRetryPolicy ?? TELEGRAM_WEBHOOK_REGISTRATION_RETRY_POLICY;
   const diagnosticsEnabled = isDiagnosticsEnabled(opts.config);
+  const spoolDir = opts.spoolDir ?? resolveTelegramIngressSpoolDir({ accountId: opts.accountId });
+  let shutDown = false;
   const bot = createTelegramBot({
     token: opts.token,
     runtime,
@@ -284,6 +653,116 @@ export async function startTelegramWebhook(opts: {
   if (diagnosticsEnabled) {
     startDiagnosticHeartbeat(opts.config);
   }
+
+  const log = (line: string) => runtime.log?.(line);
+  let drainActive = false;
+  let drainRequested = false;
+  const drainWebhookSpool = async (): Promise<void> => {
+    if (shutDown || opts.abortSignal?.aborted) {
+      return;
+    }
+    if (drainActive) {
+      drainRequested = true;
+      return;
+    }
+    drainActive = true;
+    drainRequested = false;
+    try {
+      const activeWebhookSpooledLaneKeys = resolveActiveWebhookSpooledLaneKeys(spoolDir);
+      await recoverStaleTelegramSpooledUpdateClaims({
+        spoolDir,
+        staleMs: 0,
+        shouldRecover: (claim) =>
+          !activeWebhookSpooledLaneKeys.has(resolveWebhookSpooledUpdateLaneKey(claim.update)) &&
+          !isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess(claim, {
+            maxAgeMs: TELEGRAM_SPOOLED_UPDATE_CLAIM_LEASE_MS,
+          }),
+      });
+      const claimedLaneKeys = new Set(
+        (
+          await listTelegramSpooledUpdateClaims({
+            spoolDir,
+          })
+        ).map((claim) => resolveWebhookSpooledUpdateLaneKey(claim.update)),
+      );
+      const updates = await listTelegramSpooledUpdates({
+        spoolDir,
+        limit: TELEGRAM_WEBHOOK_SPOOLED_DRAIN_SCAN_LIMIT,
+      });
+      const candidateUpdateIds = updates.map((update) => update.updateId);
+      const blockedLaneKeys = new Set([...activeWebhookSpooledLaneKeys, ...claimedLaneKeys]);
+      for (const update of updates) {
+        // Release stamps lastAttemptAt; block the lane until backoff expires so
+        // webhook replay cannot hot-loop a retryable poison update.
+        if (resolveSpooledUpdateRetryDelayMs(update) > 0) {
+          blockedLaneKeys.add(resolveWebhookSpooledUpdateLaneKey(update.update));
+        }
+      }
+      let started = 0;
+      while (started < TELEGRAM_WEBHOOK_SPOOLED_DRAIN_START_LIMIT) {
+        if (shutDown || opts.abortSignal?.aborted) {
+          break;
+        }
+        const claimedUpdate = await claimNextTelegramSpooledUpdate({
+          spoolDir,
+          blockedLaneKeys,
+          candidateUpdateIds,
+          scanLimit: TELEGRAM_WEBHOOK_SPOOLED_DRAIN_SCAN_LIMIT,
+        });
+        if (!claimedUpdate) {
+          break;
+        }
+        const laneKey = resolveWebhookSpooledUpdateLaneKey(claimedUpdate.update);
+        const handlerKey = buildWebhookSpooledHandlerKey({ spoolDir, laneKey });
+        // Webhook HTTP requests and same-process restarts can overlap; keep
+        // one process-global active claim per spool lane to preserve ordering.
+        activeWebhookSpooledHandlersByLane.add(handlerKey);
+        blockedLaneKeys.add(laneKey);
+        // Claim ownership has a finite lease; refresh while the handler runs so
+        // another process cannot recover and replay this update concurrently.
+        const stopClaimRefresh = startWebhookSpooledUpdateClaimRefresh({
+          log,
+          update: claimedUpdate,
+        });
+        void handleWebhookSpooledUpdate({
+          accountId: opts.accountId ?? "default",
+          bot,
+          log,
+          update: claimedUpdate,
+        })
+          .catch((err: unknown) => {
+            runtime.log?.(
+              `[telegram][diag] webhook spooled update ${claimedUpdate.updateId} handler failed after claim: ${formatErrorMessage(err)}`,
+            );
+          })
+          .finally(() => {
+            stopClaimRefresh();
+            activeWebhookSpooledHandlersByLane.delete(handlerKey);
+            void Promise.resolve().then(drainWebhookSpool);
+          });
+        started += 1;
+      }
+    } catch (err) {
+      runtime.log?.(`[telegram][diag] webhook spool drain failed: ${formatErrorMessage(err)}`);
+    } finally {
+      drainActive = false;
+      if (drainRequested && !shutDown && !opts.abortSignal?.aborted) {
+        void Promise.resolve().then(drainWebhookSpool);
+      }
+    }
+  };
+  const requestWebhookSpoolDrain = () => {
+    void drainWebhookSpool();
+  };
+  let drainTimer: ReturnType<typeof setInterval> | undefined;
+  const startWebhookSpoolDrain = () => {
+    if (drainTimer) {
+      return;
+    }
+    requestWebhookSpoolDrain();
+    drainTimer = setInterval(requestWebhookSpoolDrain, TELEGRAM_WEBHOOK_SPOOLED_DRAIN_INTERVAL_MS);
+    drainTimer.unref?.();
+  };
 
   const server = createServer((req, res) => {
     const respondText = (statusCode: number, text = "") => {
@@ -350,30 +829,25 @@ export async function startTelegramWebhook(opts: {
         return;
       }
 
+      // Telegram sees 200 only after the update is durable. If SQLite rejects
+      // the enqueue, this path returns non-200 so Telegram redelivers.
+      await writeTelegramSpooledUpdate({
+        spoolDir,
+        update: body.value,
+        laneKey: resolveWebhookSpooledUpdateLaneKey(body.value),
+      });
+      // Enqueue duplicate detection makes Telegram webhook retries idempotent:
+      // re-posted update_ids map to the same spool row and still ack fast.
       respondText(200);
       status.noteWebhookUpdateReceived();
-
-      void (async () => {
-        await bot.handleUpdate(body.value as Parameters<typeof bot.handleUpdate>[0]);
-
-        if (diagnosticsEnabled) {
-          logWebhookProcessed({
-            channel: "telegram",
-            updateType: "telegram-post",
-            durationMs: Date.now() - startTime,
-          });
-        }
-      })().catch((err: unknown) => {
-        const errMsg = formatErrorMessage(err);
-        if (diagnosticsEnabled) {
-          logWebhookError({
-            channel: "telegram",
-            updateType: "telegram-post",
-            error: errMsg,
-          });
-        }
-        runtime.log?.(`webhook update processing failed after ack: ${errMsg}`);
-      });
+      requestWebhookSpoolDrain();
+      if (diagnosticsEnabled) {
+        logWebhookProcessed({
+          channel: "telegram",
+          updateType: "telegram-post",
+          durationMs: Date.now() - startTime,
+        });
+      }
     })().catch((err: unknown) => {
       const errMsg = formatErrorMessage(err);
       if (diagnosticsEnabled) {
@@ -404,13 +878,15 @@ export async function startTelegramWebhook(opts: {
     port,
   });
 
-  let shutDown = false;
   let webhookAdvertised = false;
   const shutdown = () => {
     if (shutDown) {
       return;
     }
     shutDown = true;
+    if (drainTimer) {
+      clearInterval(drainTimer);
+    }
     server.close();
     void bot.stop();
     status.noteWebhookStop();
@@ -486,6 +962,9 @@ export async function startTelegramWebhook(opts: {
   };
   const closeAfterStartupFailure = () => {
     shutDown = true;
+    if (drainTimer) {
+      clearInterval(drainTimer);
+    }
     server.close();
     void bot.stop();
     status.noteWebhookStop();
@@ -506,6 +985,11 @@ export async function startTelegramWebhook(opts: {
       }
       void retryWebhookRegistration(1);
     }
+  }
+  // Drain only after registration succeeds or after the retrying startup path
+  // is ready to return a stop handle; failed startup must not claim durable work.
+  if (!shutDown) {
+    startWebhookSpoolDrain();
   }
 
   return { server, bot, stop: shutdown };

--- a/extensions/telegram/src/webhook.ts
+++ b/extensions/telegram/src/webhook.ts
@@ -30,6 +30,7 @@ import {
   WEBHOOK_RATE_LIMIT_DEFAULTS,
 } from "openclaw/plugin-sdk/webhook-ingress";
 import { readJsonBodyWithLimit } from "openclaw/plugin-sdk/webhook-request-guards";
+import { mergeTelegramAccountConfig } from "./account-config.js";
 import { resolveTelegramAllowedUpdates } from "./allowed-updates.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import {
@@ -38,6 +39,7 @@ import {
   type TelegramSpooledReplayDeferredParticipant,
 } from "./bot-processing-outcome.js";
 import { createTelegramBot } from "./bot.js";
+import { resolveTelegramTransport } from "./fetch.js";
 import { isRetryableTelegramApiError } from "./network-errors.js";
 import { getTelegramSequentialKey } from "./sequential-key.js";
 import {
@@ -665,19 +667,37 @@ export async function startTelegramWebhook(opts: {
   const diagnosticsEnabled = isDiagnosticsEnabled(opts.config);
   const spoolDir = opts.spoolDir ?? resolveTelegramIngressSpoolDir({ accountId: opts.accountId });
   let shutDown = false;
+  const telegramAccountConfig = opts.config
+    ? mergeTelegramAccountConfig(opts.config, opts.accountId ?? "default")
+    : undefined;
+  const telegramTransport = resolveTelegramTransport(opts.fetch, {
+    network: telegramAccountConfig?.network,
+  });
+  let closeTransportPromise: Promise<void> | undefined;
+  const closeTransportOnce = (): Promise<void> => {
+    closeTransportPromise ??= telegramTransport.close();
+    return closeTransportPromise;
+  };
   const bot = createTelegramBot({
     token: opts.token,
     runtime,
     proxyFetch: opts.fetch,
     config: opts.config,
     accountId: opts.accountId,
+    telegramTransport,
   });
-  await initializeTelegramWebhookBot({
-    bot,
-    runtime,
-    abortSignal: opts.abortSignal,
-    retryPolicy: webhookRegistrationRetryPolicy,
-  });
+  try {
+    await initializeTelegramWebhookBot({
+      bot,
+      runtime,
+      abortSignal: opts.abortSignal,
+      retryPolicy: webhookRegistrationRetryPolicy,
+    });
+  } catch (err) {
+    await bot.stop();
+    await closeTransportOnce();
+    throw err;
+  }
   const telegramWebhookRateLimiter = createFixedWindowRateLimiter({
     windowMs: WEBHOOK_RATE_LIMIT_DEFAULTS.windowMs,
     maxRequests: WEBHOOK_RATE_LIMIT_DEFAULTS.maxRequests,
@@ -912,7 +932,7 @@ export async function startTelegramWebhook(opts: {
   });
 
   let webhookAdvertised = false;
-  const shutdown = () => {
+  const shutdown = async () => {
     if (shutDown) {
       return;
     }
@@ -921,16 +941,19 @@ export async function startTelegramWebhook(opts: {
       clearInterval(drainTimer);
     }
     server.close();
-    void bot.stop();
+    await bot.stop();
+    // The webhook owns this transport because it resolved and injected it into
+    // createTelegramBot; close once so abort/startup-failure paths cannot leak sockets.
+    await closeTransportOnce();
     status.noteWebhookStop();
     if (diagnosticsEnabled) {
       stopDiagnosticHeartbeat();
     }
   };
   if (opts.abortSignal?.aborted) {
-    shutdown();
+    void shutdown();
   } else if (opts.abortSignal) {
-    opts.abortSignal.addEventListener("abort", shutdown, { once: true });
+    opts.abortSignal.addEventListener("abort", () => void shutdown(), { once: true });
   }
 
   const advertiseWebhook = async (): Promise<void> => {
@@ -993,13 +1016,14 @@ export async function startTelegramWebhook(opts: {
       attempt += 1;
     }
   };
-  const closeAfterStartupFailure = () => {
+  const closeAfterStartupFailure = async () => {
     shutDown = true;
     if (drainTimer) {
       clearInterval(drainTimer);
     }
     server.close();
-    void bot.stop();
+    await bot.stop();
+    await closeTransportOnce();
     status.noteWebhookStop();
     if (diagnosticsEnabled) {
       stopDiagnosticHeartbeat();
@@ -1013,7 +1037,7 @@ export async function startTelegramWebhook(opts: {
       await advertiseWebhook();
     } catch (err) {
       if (!shouldRetryWebhookRegistration(err)) {
-        closeAfterStartupFailure();
+        await closeAfterStartupFailure();
         throw err;
       }
       void retryWebhookRegistration(1);

--- a/extensions/telegram/src/webhook.ts
+++ b/extensions/telegram/src/webhook.ts
@@ -139,7 +139,7 @@ function resolveWebhookPublicUrl(params: {
   return `http://${fallbackHost}:${params.port}${params.path}`;
 }
 
-async function initializeTelegramWebhookBot(params: {
+async function initializeTelegramWebhookBotOnce(params: {
   bot: ReturnType<typeof createTelegramBot>;
   runtime: RuntimeEnv;
   abortSignal?: AbortSignal;
@@ -150,6 +150,38 @@ async function initializeTelegramWebhookBot(params: {
     runtime: params.runtime,
     fn: () => params.bot.init(initSignal),
   });
+}
+
+async function initializeTelegramWebhookBot(params: {
+  abortSignal?: AbortSignal;
+  bot: ReturnType<typeof createTelegramBot>;
+  retryPolicy: BackoffPolicy;
+  runtime: RuntimeEnv;
+}) {
+  let attempt = 0;
+  while (true) {
+    try {
+      await initializeTelegramWebhookBotOnce({
+        bot: params.bot,
+        runtime: params.runtime,
+        abortSignal: params.abortSignal,
+      });
+      return;
+    } catch (err) {
+      if (
+        !isRetryableTelegramApiError(err, { context: "webhook" }) ||
+        params.abortSignal?.aborted
+      ) {
+        throw err;
+      }
+      attempt += 1;
+      const delayMs = computeBackoff(params.retryPolicy, attempt);
+      params.runtime.log?.(
+        `telegram getMe retry ${attempt} scheduled in ${formatDurationPrecise(delayMs)}`,
+      );
+      await sleepWithAbort(delayMs, params.abortSignal);
+    }
+  }
 }
 
 function resolveSingleHeaderValue(header: string | string[] | undefined): string | undefined {
@@ -644,6 +676,7 @@ export async function startTelegramWebhook(opts: {
     bot,
     runtime,
     abortSignal: opts.abortSignal,
+    retryPolicy: webhookRegistrationRetryPolicy,
   });
   const telegramWebhookRateLimiter = createFixedWindowRateLimiter({
     windowMs: WEBHOOK_RATE_LIMIT_DEFAULTS.windowMs,

--- a/extensions/telegram/src/webhook.ts
+++ b/extensions/telegram/src/webhook.ts
@@ -836,24 +836,24 @@ export async function startTelegramWebhook(opts: {
       res.end();
       return;
     }
-    // Apply the per-source limit before auth so invalid secret guesses consume budget
-    // in the same window as any later request from that source.
-    if (
-      !applyBasicWebhookRequestGuards({
-        req,
-        res,
-        rateLimiter: telegramWebhookRateLimiter,
-        rateLimitKey: resolveTelegramWebhookRateLimitKey(req, path, opts.config),
-      })
-    ) {
-      return;
-    }
     const startTime = Date.now();
     if (diagnosticsEnabled) {
       logWebhookReceived({ channel: "telegram", updateType: "telegram-post" });
     }
     const secretHeader = resolveSingleHeaderValue(req.headers["x-telegram-bot-api-secret-token"]);
     if (!hasValidTelegramWebhookSecret(secretHeader, secret)) {
+      // Authenticated Telegram delivery must not consume the abuse budget. Only
+      // failed secret guesses are rate-limited, before the body is read.
+      if (
+        !applyBasicWebhookRequestGuards({
+          req,
+          res,
+          rateLimiter: telegramWebhookRateLimiter,
+          rateLimitKey: resolveTelegramWebhookRateLimitKey(req, path, opts.config),
+        })
+      ) {
+        return;
+      }
       res.shouldKeepAlive = false;
       res.setHeader("Connection", "close");
       respondText(401, "unauthorized");


### PR DESCRIPTION
Closes #98777

## What Problem This Solves

Fixes an issue where Telegram webhook mode silently and permanently lost updates: the handler acked 200 to Telegram before any persistence, so a gateway crash, restart, deploy, or even a transient processing failure (DB lock, provider error) during an in-flight update dropped it forever — Telegram saw the 200 and never redelivers. Three sibling webhook-mode gaps are fixed with it: a single transient network blip during startup `getMe` failed the whole account start (burning the supervisor's cumulative restart budget), the webhook bot's HTTP transport was never closed (leaking keep-alive sockets on every restart — the same class as #68128, fixed for polling only), and the generic 120 req/min pre-auth rate limit throttled Telegram's own authenticated delivery on busy bots, growing `pending_update_count` until Telegram dropped old updates.

## Why This Change Was Made

Webhook mode now uses the same durability model as polling: the parsed update is written to the SQLite ingress spool **before** the 200 ack (a spool write failure returns non-200 so Telegram redelivers — that is the contract), and a webhook drain replays spooled updates through the bot with per-lane ordering, claim refresh, capped exponential backoff, and age-gated dead-lettering, including recovery of leftover updates on startup. Enqueue-time duplicate detection makes Telegram's own webhook retries idempotent. Rather than duplicating polling's retry policy, it is extracted into a shared `spooled-update-retry-policy.ts` consumed by both drains — including the age-gate semantics from 55d31beeef0 (over-limit updates keep retrying at the 3-minute cap and only tombstone once 24h old), now applied to webhook too. Startup `bot.init()` retries transient errors with the existing webhook retry classifier (401 stays fatal); the webhook owns its transport and closes it exactly once on shutdown and on startup failure (evicted probe-cache transports are closed as well); and the request path validates the Telegram secret first, so only failed secret guesses consume the abuse rate-limit budget — the pinned security contracts (constant-time compare, single-header enforcement, connection close on 401, body-size limits) are unchanged.

## User Impact

Webhook-mode Telegram accounts no longer lose messages across restarts, deploys, or transient failures — updates survive durably and replay, matching polling-mode reliability. Accounts come up cleanly after reboots instead of dying on the first network blip, long-running gateways stop leaking sockets on webhook restarts, and busy bots no longer have their own traffic rate-limited into growing delivery backlogs.

## Evidence

- New regression tests (`webhook.test.ts`, +313 lines): update spooled before ack and redelivered after a transient processing failure; non-200 when the spool write fails; leftover spooled updates drained on startup; young over-limit updates stay pending while >24h-old ones dead-letter (age-gate parity); transient `getMe` then success starts the account while 401 stays fatal; transport closed exactly once on shutdown and startup failure (plus `probe.test.ts` for evicted transports); authenticated request storm passes while unauthenticated storm still 429s.
- Extraction proof: `extensions/telegram/src/polling-session.test.ts` is **unchanged from `main`** and passes against the shared policy module — polling behavior is identical by its own tests, including the age-gate tests from 55d31beeef0.
- Validation on this branch rebased onto current `main`: `pnpm tsgo:extensions` pass; `node scripts/run-vitest.mjs` on `webhook.test.ts`, `probe.test.ts`, `polling-session.test.ts` — 114 tests pass; `node scripts/run-oxlint.mjs` on touched files clean; repo autoreview (branch mode vs `origin/main`) clean.
