### PR TITLE
fix(codex): preserve plugin app approvals in side conversations

### DIFF
--- a/extensions/codex/src/app-server/side-question.test.ts
+++ b/extensions/codex/src/app-server/side-question.test.ts
@@ -585,6 +585,110 @@ describe("runCodexAppServerSideQuestion", () => {
     expect(toolOptions).toHaveProperty("requireExplicitMessageTarget", true);
   });
 
+  it("replays app-scoped reviewer policy into side-thread forks", async () => {
+    const client = createFakeClient();
+    getSharedCodexAppServerClientMock.mockResolvedValue(client);
+    readCodexAppServerBindingMock.mockResolvedValue({
+      schemaVersion: 2,
+      threadId: "parent-thread",
+      sessionFile: "/tmp/session-1.jsonl",
+      cwd: "/tmp/workspace",
+      authProfileId: "openai:work",
+      model: "gpt-5.5",
+      approvalPolicy: "on-request",
+      sandbox: "workspace-write",
+      pluginAppPolicyContext: {
+        fingerprint: "mixed-plugin-policy",
+        apps: {
+          "ask-app": {
+            configKey: "ask",
+            marketplaceName: "openai",
+            pluginName: "ask",
+            allowDestructiveActions: true,
+            destructiveApprovalMode: "ask",
+            mcpServerNames: ["ask"],
+          },
+          "true-app": {
+            configKey: "true",
+            marketplaceName: "openai",
+            pluginName: "true",
+            allowDestructiveActions: true,
+            destructiveApprovalMode: "allow",
+            mcpServerNames: ["true"],
+          },
+          "false-app": {
+            configKey: "false",
+            marketplaceName: "openai",
+            pluginName: "false",
+            allowDestructiveActions: false,
+            destructiveApprovalMode: "deny",
+            mcpServerNames: ["false"],
+          },
+          "auto-app": {
+            configKey: "auto",
+            marketplaceName: "openai",
+            pluginName: "auto",
+            allowDestructiveActions: true,
+            destructiveApprovalMode: "auto",
+            mcpServerNames: ["auto"],
+          },
+        },
+        pluginAppIds: {
+          ask: ["ask-app"],
+          true: ["true-app"],
+          false: ["false-app"],
+          auto: ["auto-app"],
+        },
+      },
+      createdAt: new Date(0).toISOString(),
+      updatedAt: new Date(0).toISOString(),
+    });
+
+    await expect(
+      runCodexAppServerSideQuestion(sideParams(), {
+        pluginConfig: { appServer: { mode: "guardian" } },
+      }),
+    ).resolves.toEqual({ text: "Side answer." });
+
+    const forkParams = mockCall(client.request)[1] as Record<string, unknown> | undefined;
+    expect(forkParams?.approvalsReviewer).toBe("auto_review");
+    const config = forkParams?.config as Record<string, unknown> | undefined;
+    expect(config).not.toHaveProperty("approvals_reviewer");
+    expect(config?.["features.code_mode"]).toBe(true);
+    expect(config?.apps).toEqual({
+      _default: {
+        enabled: false,
+        destructive_enabled: false,
+        open_world_enabled: false,
+      },
+      "ask-app": {
+        enabled: true,
+        approvals_reviewer: "user",
+        destructive_enabled: true,
+        open_world_enabled: true,
+        default_tools_approval_mode: "auto",
+      },
+      "auto-app": {
+        enabled: true,
+        destructive_enabled: true,
+        open_world_enabled: true,
+        default_tools_approval_mode: "auto",
+      },
+      "false-app": {
+        enabled: true,
+        destructive_enabled: false,
+        open_world_enabled: true,
+        default_tools_approval_mode: "auto",
+      },
+      "true-app": {
+        enabled: true,
+        destructive_enabled: true,
+        open_world_enabled: true,
+        default_tools_approval_mode: "auto",
+      },
+    });
+  });
+
   it("disables hosted search when side-question sender policy removes managed web_search", async () => {
     createOpenClawCodingToolsMock.mockImplementation((options: { senderId?: string }) =>
       options.senderId === "restricted-sender"

--- a/extensions/codex/src/app-server/side-question.ts
+++ b/extensions/codex/src/app-server/side-question.ts
@@ -56,7 +56,10 @@ import {
   readCodexNotificationThreadId,
   readCodexNotificationTurnId,
 } from "./notification-correlation.js";
-import { mergeCodexThreadConfigs } from "./plugin-thread-config.js";
+import {
+  buildCodexPluginAppsConfigPatchFromPolicyContext,
+  mergeCodexThreadConfigs,
+} from "./plugin-thread-config.js";
 import {
   assertCodexThreadForkResponse,
   assertCodexTurnStartResponse,
@@ -420,10 +423,16 @@ export async function runCodexAppServerSideQuestion(
       nativeCodeModeEnabled: nativeToolSurfaceEnabled,
       nativeCodeModeOnlyEnabled: appServer.codeModeOnly,
     });
+    // Codex reloads config for thread/fork, so replay the persisted app policy or
+    // app-scoped reviewers disappear while sibling apps inherit the thread reviewer.
+    const pluginAppsConfigPatch = binding.pluginAppPolicyContext
+      ? buildCodexPluginAppsConfigPatchFromPolicyContext(binding.pluginAppPolicyContext)
+      : undefined;
     const threadConfig =
       mergeCodexThreadConfigs(
         nativeHookRelayConfig,
         runtimeThreadConfig,
+        pluginAppsConfigPatch,
         modelScopedAppServer.networkProxy?.configPatch,
       ) ?? runtimeThreadConfig;
     const forkResponse = assertCodexThreadForkResponse(


### PR DESCRIPTION
Related: #98501
Related: #97327
Related: #98499

## What Problem This Solves

Codex side conversations created with `/btw` fork from a fresh request config. That fork path did not replay the persisted plugin app policy context, so an app configured with `allow_destructive_actions: "ask"` could lose its app-scoped `approvals_reviewer: "user"` boundary in the side conversation. Reusing the thread-level reviewer would not be equivalent: it could either miss the ask app or broaden approval routing for sibling apps.

## Why This Change Was Made

The side-question owner now merges `buildCodexPluginAppsConfigPatchFromPolicyContext(binding.pluginAppPolicyContext)` into the fork config, alongside the existing native-hook, runtime, network-proxy, sandbox, and base-reviewer fields. This uses the same canonical persisted-policy replay already used by thread start/resume, keeps the `"ask"` hard-cut naming from #98501, and does not introduce a compatibility path.

Focused regression coverage proves that an ask-mode app keeps app-scoped user review after the fork while sibling `true`, `false`, and `"auto"` apps retain their own policy and the top-level reviewer remains unchanged.

Contributor provenance: Kevin Lin (@kevinslin) authored the app-scoped approval design in #97327 and the `"ask"` hard cut in #98501. This follow-up preserves that boundary at the previously omitted side-fork owner.

AI-assisted: yes. Codex implemented the repair and completed a clean gpt-5.6-sol xhigh autoreview against the exact synced commit.

## User Impact

When a user opens a Codex side conversation from a thread containing an ask-mode plugin app, that app's destructive actions still route to the user for approval. Mixed-policy sibling apps remain unchanged, and unrelated thread-level approvals are not broadened.

## Evidence

- Exact base: `3e50f41dd6ea3446b5c98a2f19ec70982ac908e6`; its substantive main run [28555775438](https://github.com/openclaw/openclaw/actions/runs/28555775438) completed with 111 successes, one intentional skip, and zero failures.
- Exact candidate: `f11fec224f1ce283a13402f610b96931831d99e3`; parent is the exact base above; tree is `c105a1a74cfe02e86be1766595fcdb9bd58944eb`.
- The synced candidate has the same stable patch id (`f5343a7972cd568dfb3891e60958b2a22fb62702`) as the approved candidate and remains limited to `extensions/codex/src/app-server/side-question.ts` and `extensions/codex/src/app-server/side-question.test.ts` (+114/-1).
- Focused tests passed: 69/69 across `side-question.test.ts` and `plugin-thread-config.test.ts`.
- Blacksmith Testbox `tbx_01kwg2ym3gm44kb6rp1c5end72` (`jade-shrimp`) passed the changed gate in [run 28556494609](https://github.com/openclaw/openclaw/actions/runs/28556494609): extension production/test typechecks, lint, repository guards, DB/sidecar guards, and import-cycle checks. The same Testbox passed the full `corepack pnpm build`, including SDK declarations/exports and UI build.
- Fresh genuine autoreview used workspace Codex 0.142.4 with `gpt-5.6-sol` and `xhigh` reasoning against the exact pinned base: no accepted/actionable findings, 0.99 confidence.
- Direct dependency inspection used the pinned sibling Codex `rust-v0.142.4` source: `codex-rs/app-server/src/request_processors/thread_processor.rs:3280` and `:3371` confirm fork config reload; `codex-rs/app-server-protocol/src/protocol/v2/thread.rs:484` and `:531` define the fork request/config override; `codex-rs/config/src/types.rs:451` and `:456` define app-scoped `approvals_reviewer`; `codex-rs/core/src/connectors.rs:548` confirms app -> `_default` -> global precedence; `codex-rs/core/src/session/mcp.rs:508` routes `codex_apps` elicitation through it; `codex-rs/core/src/connectors_tests.rs:314` covers precedence.
- `git diff --check` passed.

Commands:

```text
OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-codex-side-fork-synced-cache node scripts/run-vitest.mjs extensions/codex/src/app-server/side-question.test.ts extensions/codex/src/app-server/plugin-thread-config.test.ts

node scripts/crabbox-wrapper.mjs run --id tbx_01kwg2ym3gm44kb6rp1c5end72 --provider blacksmith --env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 --env OPENCLAW_CHANGED_LANES_RAW_SYNC=1 -- corepack pnpm check:changed

node scripts/crabbox-wrapper.mjs run --reclaim --id tbx_01kwg2ym3gm44kb6rp1c5end72 --provider blacksmith -- corepack pnpm build

.agents/skills/autoreview/scripts/autoreview --mode branch --base 3e50f41dd6ea3446b5c98a2f19ec70982ac908e6 --engine codex --codex-bin node_modules/.bin/codex --model gpt-5.6-sol --thinking xhigh --prompt '<side-fork approval-boundary review>' --stream-engine-output
```

Known proof gap: no external live `/btw` plugin-app mutation was performed. The direct Codex contract check, focused fork regression, changed gate, full build, and clean model review cover the repaired boundary without creating a live destructive action.
