### PR TITLE
fix: copy workspace paths via clipboard helper

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -29,6 +29,7 @@ import {
 } from "./app-render.helpers.ts";
 import { hasOperatorAdminAccess, hasOperatorWriteAccess, warnQueryToken } from "./app-settings.ts";
 import type { AppViewState } from "./app-view-state.ts";
+import { copyToClipboard } from "./chat/clipboard.ts";
 import { reconcileChatRunLifecycle } from "./chat/run-lifecycle.ts";
 import {
   renderChatSessionSelect,
@@ -2247,7 +2248,7 @@ export function renderApp(state: AppViewState) {
     }, 160);
   };
   const copyChatWorkspacePath = (filePath: string) => {
-    void globalThis.navigator?.clipboard?.writeText?.(filePath);
+    void copyToClipboard(filePath);
   };
   function loadChatWorkspaceFiles(opts?: { force?: boolean }) {
     if (!state.client || !state.connected) {

--- a/ui/src/ui/e2e/chat-flow.e2e.test.ts
+++ b/ui/src/ui/e2e/chat-flow.e2e.test.ts
@@ -117,6 +117,25 @@ async function closeOpenBrowserContexts(): Promise<void> {
   await Promise.all([...openBrowserContexts].map((context) => closeBrowserContext(context)));
 }
 
+async function installExecCommandClipboardFallback(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    Object.defineProperty(navigator, "clipboard", { configurable: true, value: undefined });
+    (globalThis as unknown as { copiedViaExec: string[] }).copiedViaExec = [];
+    document.execCommand = ((command: string) => {
+      if (command !== "copy") {
+        return false;
+      }
+      // execCommand("copy") copies the active selection; the fallback selects
+      // its off-screen scratch textarea, so the focused element holds the text.
+      const active = document.activeElement as HTMLTextAreaElement | null;
+      (globalThis as unknown as { copiedViaExec: string[] }).copiedViaExec.push(
+        active?.value ?? "",
+      );
+      return true;
+    }) as typeof document.execCommand;
+  });
+}
+
 async function visibleChatBubbleTexts(page: Page): Promise<string[]> {
   return page.locator(".chat-thread").evaluate((element) => {
     const thread = element as HTMLElement;
@@ -376,22 +395,7 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
     // Simulate a plain-HTTP (non-secure) deployment: navigator.clipboard is
     // undefined there, so the Clipboard API path throws. Capture the legacy
     // execCommand copy the fallback should use instead.
-    await page.addInitScript(() => {
-      Object.defineProperty(navigator, "clipboard", { configurable: true, value: undefined });
-      (globalThis as unknown as { copiedViaExec: string[] }).copiedViaExec = [];
-      document.execCommand = ((command: string) => {
-        if (command !== "copy") {
-          return false;
-        }
-        // execCommand("copy") copies the active selection; the fallback selects
-        // its off-screen scratch textarea, so the focused element holds the text.
-        const active = document.activeElement as HTMLTextAreaElement | null;
-        (globalThis as unknown as { copiedViaExec: string[] }).copiedViaExec.push(
-          active?.value ?? "",
-        );
-        return true;
-      }) as typeof document.execCommand;
-    });
+    await installExecCommandClipboardFallback(page);
     const code = "const hello = 1;";
     const gateway = await installMockGateway(page, {
       historyMessages: [
@@ -431,6 +435,7 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
       viewport: { height: 900, width: 1280 },
     });
     const page = await context.newPage();
+    await installExecCommandClipboardFallback(page);
     const gateway = await installMockGateway(page, {
       methodResponses: {
         "artifacts.list": {
@@ -499,6 +504,15 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
       });
       expect(await gateway.getRequests("sessions.files.list")).toHaveLength(1);
       expect(await gateway.getRequests("artifacts.list")).toHaveLength(1);
+
+      await page
+        .locator(".chat-workspace-rail__file", { hasText: "AGENTS.md" })
+        .getByRole("button", { name: "Copy path" })
+        .click();
+      const copied = await page.evaluate(
+        () => (globalThis as unknown as { copiedViaExec: string[] }).copiedViaExec,
+      );
+      expect(copied).toContain("/workspace/AGENTS.md");
 
       await page.getByRole("button", { name: "Collapse session workspace" }).click();
       await page.getByRole("button", { name: "Expand session workspace" }).waitFor({


### PR DESCRIPTION
## What Problem This Solves

The Session Workspace "Copy path" button in the Chat view silently no-ops in plain-HTTP / non-secure contexts because `copyChatWorkspacePath` called `navigator.clipboard.writeText` directly instead of the shared Control UI clipboard helper.

## Why This Change Was Made

This patch routes the workspace-path copy affordance through `copyToClipboard`, which already handles both the secure-context Clipboard API and the `execCommand('copy')` fallback. That keeps the workspace action aligned with the rest of Control UI clipboard behavior and makes it work when `navigator.clipboard` is unavailable.

## User Impact

Users can copy workspace file paths from the Chat sidebar in both secure and non-secure browser contexts. On HTTP deployments, clicking Copy path now copies the full path instead of doing nothing.

## Evidence

### Real behavior proof

Behavior addressed:
- The workspace files panel Copy path button copies the selected file path even when `navigator.clipboard` is unavailable.

Environment:
- Local macOS checkout
- Chromium via Playwright
- UI e2e config: `test/vitest/vitest.ui-e2e.config.ts`

Current-main contrast:
- `git show origin/main:ui/src/ui/app-render.ts | nl -ba | sed -n '2246,2252p'`
- Result: current main still has `void globalThis.navigator?.clipboard?.writeText?.(filePath);` in `copyChatWorkspacePath`, so the button can silently no-op in non-secure contexts.

Exact steps or command run after this patch:
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/ui/e2e/chat-flow.e2e.test.ts -t "starts the workspace files panel collapsed and toggles it open"`

Evidence after fix:
- The test passed.
- The e2e installs a fallback that removes `navigator.clipboard`, opens Chat, expands the workspace rail, clicks `Copy path` on `AGENTS.md`, and asserts the captured `execCommand("copy")` payload contains `/workspace/AGENTS.md`.

Evidence artifact links:
- `/tmp/openclaw-98759-real-behavior-proof-20260702T003749Z.log`

Control check:
- `node scripts/run-vitest.mjs ui/src/ui/chat/clipboard.test.ts ui/src/ui/views/chat.test.ts`
- Result: `Test Files  2 passed (2)`
- Result: `Tests  138 passed (138)`

Observed result after fix:
- The workspace path copy action now routes through the shared clipboard helper and the fallback path copies `/workspace/AGENTS.md` under a simulated plain-HTTP environment.

What was not tested:
- A full repository-wide `pnpm check` / `pnpm test` sweep.
- The separate open PR `#98780` path was not used; this branch was verified independently.

Fixes #98759

AI disclosure: This patch was prepared with Codex assistance.
