### PR TITLE
fix(ci): recover incomplete Swift build caches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1732,12 +1732,25 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: apps/macos/.build
-          key: ${{ runner.os }}-swift-build-v2-${{ steps.swift-toolchain.outputs.key }}-${{ hashFiles('apps/macos/Package.swift', 'apps/macos/Package.resolved', 'apps/macos/Sources/**', 'apps/macos/Tests/**', 'apps/shared/OpenClawKit/Package.swift', 'apps/shared/OpenClawKit/Sources/**', 'apps/swabble/Package.swift', 'apps/swabble/Sources/**') }}
+          key: ${{ runner.os }}-swift-build-v3-${{ steps.swift-toolchain.outputs.key }}-${{ hashFiles('apps/macos/Package.swift', 'apps/macos/Package.resolved', 'apps/macos/Sources/**', 'apps/macos/Tests/**', 'apps/shared/OpenClawKit/Package.swift', 'apps/shared/OpenClawKit/Sources/**', 'apps/swabble/Package.swift', 'apps/swabble/Sources/**') }}
           restore-keys: |
-            ${{ runner.os }}-swift-build-v2-${{ steps.swift-toolchain.outputs.key }}-
+            ${{ runner.os }}-swift-build-v3-${{ steps.swift-toolchain.outputs.key }}-
+
+      - name: Validate Swift build cache
+        id: validate-swift-build-cache
+        run: |
+          set -euo pipefail
+          cache_valid=true
+          sparkle_info="apps/macos/.build/artifacts/sparkle/Sparkle/Sparkle.xcframework/Info.plist"
+          if [[ -d apps/macos/.build && ! -f "$sparkle_info" ]]; then
+            echo "::warning::Swift build cache is missing Sparkle; resetting the local SwiftPM build directory."
+            swift package --package-path apps/macos reset
+            cache_valid=false
+          fi
+          echo "cache-valid=$cache_valid" >> "$GITHUB_OUTPUT"
 
       - name: Preserve Swift build cache hit
-        if: steps.swift-build-cache.outputs.cache-hit == 'true'
+        if: steps.swift-build-cache.outputs.cache-hit == 'true' && steps.validate-swift-build-cache.outputs.cache-valid == 'true'
         run: |
           set -euo pipefail
           # Exact source-hash cache hits already match these inputs; checkout


### PR DESCRIPTION
## What Problem This Solves

The macOS Swift CI lane can restore an exact build cache whose Sparkle XCFramework is incomplete. The subsequent build fails before compilation because `Sparkle.xcframework/Info.plist` is missing, and each built-in retry reuses the same broken local build directory.

## Why This Change Was Made

- Rotates the Swift build cache namespace from `v2` to `v3`, preventing reuse of the known-bad cache generation.
- Validates a restored SwiftPM build directory before the macOS build starts.
- Uses `swift package reset` when the required Sparkle artifact is absent, then allows SwiftPM to rebuild normally.
- Skips the cache-hit timestamp optimization after a reset.

## User Impact

No product behavior changes. macOS CI repairs an incomplete restored SwiftPM cache instead of failing all three build attempts.

## Evidence

- Exact-head macOS CI failed twice with the same missing `Sparkle.xcframework/Info.plist` error after restoring the same cache key.
- `actionlint .github/workflows/ci.yml`
- `pnpm test test/scripts/ci-workflow-guards.test.ts` — 32 passed
- `git diff --check`
- Fresh Codex autoreview — clean, 0.94 confidence

AI-assisted: implementation and review used Codex. No transcript attached; the PR contains the complete durable rationale and validation evidence.
