### PR TITLE
fix(gateway): dedupe MCP schema conflict warnings

### DIFF
--- a/src/gateway/mcp-http.schema.ts
+++ b/src/gateway/mcp-http.schema.ts
@@ -100,9 +100,7 @@ function flattenUnionSchema(raw: Record<string, unknown>): Record<string, unknow
         }
         if (!isRecord(existing) || !isRecord(incoming)) {
           if (existing !== incoming) {
-            logWarn(
-              `mcp loopback: conflicting schema definitions for "${key}", keeping the first variant`,
-            );
+            warnSchemaConflictOnce(key);
           }
           continue;
         }
@@ -122,9 +120,7 @@ function flattenUnionSchema(raw: Record<string, unknown>): Record<string, unknow
           mergedProps[key] = merged;
           continue;
         }
-        logWarn(
-          `mcp loopback: conflicting schema definitions for "${key}", keeping the first variant`,
-        );
+        warnSchemaConflictOnce(key);
       }
     }
     requiredSets.push(
@@ -143,6 +139,22 @@ function flattenUnionSchema(raw: Record<string, unknown>): Record<string, unknow
 
 function isPropertySchema(value: unknown): value is boolean | Record<string, unknown> {
   return typeof value === "boolean" || isRecord(value);
+}
+
+// Schema conflict warnings name field-level precedence, not request context.
+// Keep one warning per field so repeated loopback cache misses do not flood logs.
+const emittedConflictWarnings = new Set<string>();
+
+function warnSchemaConflictOnce(key: string) {
+  if (emittedConflictWarnings.has(key)) {
+    return;
+  }
+  emittedConflictWarnings.add(key);
+  logWarn(`mcp loopback: conflicting schema definitions for "${key}", keeping the first variant`);
+}
+
+export function clearMcpToolSchemaWarningsForTest() {
+  emittedConflictWarnings.clear();
 }
 
 /** Builds MCP-compatible tool schemas for loopback-visible gateway tools. */

--- a/src/gateway/mcp-http.schema.ts
+++ b/src/gateway/mcp-http.schema.ts
@@ -57,7 +57,10 @@ function readLoopbackToolParameters(tool: McpLoopbackTool): Record<string, unkno
   }
 }
 
-function flattenUnionSchema(raw: Record<string, unknown>): Record<string, unknown> {
+function flattenUnionSchema(
+  raw: Record<string, unknown>,
+  toolName: string,
+): Record<string, unknown> {
   // MCP clients vary in union-schema support. Merge only safe object variants
   // and keep common required fields so generated forms remain usable.
   const variants = (raw.anyOf ?? raw.oneOf) as unknown[] | undefined;
@@ -78,7 +81,9 @@ function flattenUnionSchema(raw: Record<string, unknown>): Record<string, unknow
     if (props) {
       for (const [key, schema] of Object.entries(props)) {
         if (!isPropertySchema(schema)) {
-          logWarn(`mcp loopback: malformed schema definition for "${key}", ignoring that variant`);
+          warnSchemaOnce(
+            `mcp loopback: malformed schema definition for "${toolName}.${key}", ignoring that variant`,
+          );
           continue;
         }
         if (!(key in mergedProps)) {
@@ -100,7 +105,9 @@ function flattenUnionSchema(raw: Record<string, unknown>): Record<string, unknow
         }
         if (!isRecord(existing) || !isRecord(incoming)) {
           if (existing !== incoming) {
-            warnSchemaConflictOnce(key);
+            warnSchemaOnce(
+              `mcp loopback: conflicting schema definitions for "${toolName}.${key}", keeping the first variant`,
+            );
           }
           continue;
         }
@@ -120,7 +127,9 @@ function flattenUnionSchema(raw: Record<string, unknown>): Record<string, unknow
           mergedProps[key] = merged;
           continue;
         }
-        warnSchemaConflictOnce(key);
+        warnSchemaOnce(
+          `mcp loopback: conflicting schema definitions for "${toolName}.${key}", keeping the first variant`,
+        );
       }
     }
     requiredSets.push(
@@ -141,20 +150,25 @@ function isPropertySchema(value: unknown): value is boolean | Record<string, unk
   return typeof value === "boolean" || isRecord(value);
 }
 
-// Schema conflict warnings name field-level precedence, not request context.
-// Keep one warning per field so repeated loopback cache misses do not flood logs.
-const emittedConflictWarnings = new Set<string>();
+// Loopback schemas are rebuilt on every cache miss (per session/owner context and
+// after TTL expiry), so raw logWarn would repeat the same field warning endlessly.
+// Dedupe on the full message: distinct (tool, field, reason) still each warn once,
+// but rebuilds collapse to one line. Named per tool.field so a conflict in one tool
+// no longer suppresses a genuinely different conflict on the same field name in
+// another tool. Bounded by the process-stable universe of loopback tool + field
+// names (gateway tool metadata does not change without restart or explicit reload).
+const emittedSchemaWarnings = new Set<string>();
 
-function warnSchemaConflictOnce(key: string) {
-  if (emittedConflictWarnings.has(key)) {
+function warnSchemaOnce(message: string) {
+  if (emittedSchemaWarnings.has(message)) {
     return;
   }
-  emittedConflictWarnings.add(key);
-  logWarn(`mcp loopback: conflicting schema definitions for "${key}", keeping the first variant`);
+  emittedSchemaWarnings.add(message);
+  logWarn(message);
 }
 
 export function clearMcpToolSchemaWarningsForTest() {
-  emittedConflictWarnings.clear();
+  emittedSchemaWarnings.clear();
 }
 
 /** Builds MCP-compatible tool schemas for loopback-visible gateway tools. */
@@ -169,7 +183,7 @@ export function buildMcpToolSchema(tools: McpLoopbackTool[]): McpToolSchemaEntry
       return [];
     }
     if (raw.anyOf || raw.oneOf) {
-      raw = flattenUnionSchema(raw);
+      raw = flattenUnionSchema(raw, name);
     }
     if (raw.type !== "object") {
       raw.type = "object";

--- a/src/gateway/mcp-http.test.ts
+++ b/src/gateway/mcp-http.test.ts
@@ -3,7 +3,7 @@
 import { request } from "node:http";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getFreePortBlockWithPermissionFallback } from "../test-utils/ports.js";
-import { buildMcpToolSchema } from "./mcp-http.schema.js";
+import { buildMcpToolSchema, clearMcpToolSchemaWarningsForTest } from "./mcp-http.schema.js";
 
 type MockGatewayTool = {
   name: string;
@@ -84,9 +84,19 @@ const resolveGatewayScopedToolsMock = vi.hoisted(() =>
   })),
 );
 
+const logWarnMock = vi.hoisted(() => vi.fn<(message: string) => void>());
+
 vi.mock("../config/io.js", () => ({
   getRuntimeConfig: () => ({ session: { mainKey: "main" } }),
 }));
+
+vi.mock("../logger.js", async () => {
+  const actual = await vi.importActual<typeof import("../logger.js")>("../logger.js");
+  return {
+    ...actual,
+    logWarn: (message: string) => logWarnMock(message),
+  };
+});
 
 vi.mock("../config/sessions.js", () => ({
   resolveMainSessionKey: () => "agent:main:main",
@@ -568,6 +578,8 @@ function buildMockMcpToolSchema(tools: MockGatewayTool[]) {
 }
 
 beforeEach(() => {
+  clearMcpToolSchemaWarningsForTest();
+  logWarnMock.mockClear();
   clearMcpLoopbackToolCallCapturesForTest();
   resolveGatewayScopedToolsMock.mockClear();
   runBeforeToolCallHookMock.mockClear();
@@ -672,6 +684,45 @@ describe("buildMcpToolSchema", () => {
         ])[0]?.inputSchema,
       ).toEqual(testCase.expected);
     }
+  });
+
+  it("warns once for repeated union schema conflicts across loopback schema rebuilds", () => {
+    const tool = makeMockTool({
+      name: "mcp_message_send",
+      parameters: {
+        anyOf: [
+          {
+            type: "object",
+            properties: {
+              action: { type: "string", description: "message action" },
+              callId: { type: "string", description: "voice call id" },
+            },
+          },
+          {
+            type: "object",
+            properties: {
+              action: { type: "number", description: "different server action" },
+              callId: { type: "number", description: "different call id" },
+            },
+          },
+        ],
+      },
+    });
+
+    for (let index = 0; index < 3; index += 1) {
+      expect(buildMockMcpToolSchema([tool])[0]?.inputSchema).toMatchObject({
+        type: "object",
+        properties: {
+          action: { type: "string", description: "message action" },
+          callId: { type: "string", description: "voice call id" },
+        },
+      });
+    }
+
+    expect(logWarnMock.mock.calls.map(([message]) => message)).toEqual([
+      'mcp loopback: conflicting schema definitions for "action", keeping the first variant',
+      'mcp loopback: conflicting schema definitions for "callId", keeping the first variant',
+    ]);
   });
 });
 

--- a/src/gateway/mcp-http.test.ts
+++ b/src/gateway/mcp-http.test.ts
@@ -720,8 +720,53 @@ describe("buildMcpToolSchema", () => {
     }
 
     expect(logWarnMock.mock.calls.map(([message]) => message)).toEqual([
-      'mcp loopback: conflicting schema definitions for "action", keeping the first variant',
-      'mcp loopback: conflicting schema definitions for "callId", keeping the first variant',
+      'mcp loopback: conflicting schema definitions for "mcp_message_send.action", keeping the first variant',
+      'mcp loopback: conflicting schema definitions for "mcp_message_send.callId", keeping the first variant',
+    ]);
+  });
+
+  it("warns per tool for the same conflicting field name across different tools", () => {
+    const conflictingUnion = (label: string) => ({
+      anyOf: [
+        { type: "object", properties: { action: { type: "string", description: `${label} a` } } },
+        { type: "object", properties: { action: { type: "number", description: `${label} b` } } },
+      ],
+    });
+    const messageTool = makeMockTool({
+      name: "mcp_message_send",
+      parameters: conflictingUnion("message"),
+    });
+    const calendarTool = makeMockTool({
+      name: "mcp_calendar_create",
+      parameters: conflictingUnion("calendar"),
+    });
+
+    buildMockMcpToolSchema([messageTool, calendarTool]);
+    // Rebuild to prove per-(tool, field) dedupe survives repeated schema builds.
+    buildMockMcpToolSchema([messageTool, calendarTool]);
+
+    expect(logWarnMock.mock.calls.map(([message]) => message)).toEqual([
+      'mcp loopback: conflicting schema definitions for "mcp_message_send.action", keeping the first variant',
+      'mcp loopback: conflicting schema definitions for "mcp_calendar_create.action", keeping the first variant',
+    ]);
+  });
+
+  it("warns once per tool for repeated malformed variant schemas across rebuilds", () => {
+    const tool = makeMockTool({
+      name: "mcp_message_send",
+      parameters: {
+        anyOf: [
+          { type: "object", properties: { action: { type: "string" } } },
+          { type: "object", properties: { action: 123 } },
+        ],
+      },
+    });
+
+    buildMockMcpToolSchema([tool]);
+    buildMockMcpToolSchema([tool]);
+
+    expect(logWarnMock.mock.calls.map(([message]) => message)).toEqual([
+      'mcp loopback: malformed schema definition for "mcp_message_send.action", ignoring that variant',
     ]);
   });
 });


### PR DESCRIPTION
Related: #98437

## What Problem This Solves

Operators see repeated MCP loopback `conflicting schema definitions` warnings every time loopback tool schemas are rebuilt for a different request/session context (`buildMcpToolSchema` runs on every cache miss in `src/gateway/mcp-http.runtime.ts`, and again after the 30s TTL expires). The same field-level first-shape fallback is logged over and over, burying more useful Gateway diagnostics during restart or session churn.

Two further problems in the same code path:

- The warning named only the **field** (`"action"`), not the tool, so it could not be attributed and — worse — deduping on the bare field name meant a genuine, *distinct* conflict on a common field (`action`/`id`/`type`) in a **second, different tool** was silently suppressed by the first tool's warning.
- The structurally identical `malformed schema definition` warning in the same function was left un-deduped and still flooded on every rebuild.

AI-assisted: this PR was prepared with Codex and Claude. I understand the change: it preserves the existing schema-flattening/first-variant behavior and only narrows and attributes duplicate warning emission.

## Why This Change Was Made

The Gateway MCP schema projection already keeps the first schema variant when union object fields conflict. This change keeps that diagnostic signal, but:

- Emits each warning **once per process for a given `(tool, field, reason)`** instead of once per schema rebuild/cache miss.
- Names the tool in the message (`"<tool>.<field>"`) so the warning is attributable and a conflict in one tool no longer suppresses a genuinely different conflict on the same field name in another tool.
- Routes the `malformed schema definition` warning through the same one-per-message helper, fixing the remaining flood.

The dedupe set is keyed on the full message and bounded by the process-stable universe of loopback tool + field names (gateway tool metadata does not change without a restart or explicit reload). The fix stays in the Gateway schema projection layer and does not rename tool fields, change MCP input schemas, or add config.

## User Impact

Operators see far less repeated MCP loopback warning noise while retaining one attributable warning per conflicting/malformed field per tool. Distinct conflicts across different tools are no longer masked. MCP clients continue to receive the same flattened object schema and first-variant precedence as before.

## Evidence

Focused proof run (`src/gateway/mcp-http.test.ts` drives the real `buildMcpToolSchema` path across repeated rebuilds and multiple tools):

```text
node scripts/run-vitest.mjs src/gateway/mcp-http.test.ts

Test Files  4 passed (4)
      Tests  232 passed (232)
```

New regression tests:

- `warns per tool for the same conflicting field name across different tools` — two tools each conflict on `action`; asserts both `mcp_message_send.action` and `mcp_calendar_create.action` warn (fails under the old bare-field-name dedupe, which suppressed the second), and rebuilding twice proves per-`(tool, field)` dedupe survives.
- `warns once per tool for repeated malformed variant schemas across rebuilds` — proves the malformed warning now dedupes instead of flooding.

Additional local checks:

```text
oxfmt --check                 # clean
scripts/run-oxlint.mjs        # clean
tsgo:core + tsgo:core:test    # clean (exit 0)
git diff --check              # clean
```

### Real-runtime live gateway proof (no cloud creds)

Beyond the unit path above, I booted the **real** MCP loopback HTTP server
(`startMcpLoopbackServer`, owner-token auth) and sent `tools/list` over
`http://127.0.0.1:<port>/mcp` **4x**, each with a distinct `x-openclaw-session-id`
to force 4 genuine `McpLoopbackToolCache` misses -> 4 real `buildMcpToolSchema`
rebuilds (`resolveCallCount === 4`). Tools are injected through the real
`resolveGatewayScopedTools` seam (the same seam plugins feed); the cache, schema
flatten, `warnSchemaOnce`, `logWarn`, and the HTTP handler are all production code.
Captured both log sinks — `logWarn` fan-writes to the terminal `console.log` sink
**and** `getLogger().warn` (the string `"mcp loopback:"` has a space, so it does not
match the subsystem-prefix regex), directly covering the logger double-write concern.

```text
real schema rebuilds forced (cache-miss resolves): 4
tools/list HTTP requests sent: 4

captured warn lines (identical on terminal + structured sinks):
  mcp loopback: conflicting schema definitions for "mcp_message_send.action", keeping the first variant
  mcp loopback: conflicting schema definitions for "mcp_message_send.callId", keeping the first variant
  mcp loopback: conflicting schema definitions for "mcp_calendar_create.action", keeping the first variant
  mcp loopback: malformed schema definition for "mcp_task_run.action", ignoring that variant

(a) mcp_message_send.action conflict    : 1 record/sink across 4 rebuilds (deduped, not 4x)
(b) mcp_task_run.action malformed       : 1 record/sink (no per-rebuild flood)
(c) mcp_calendar_create.action conflict : its own record (per-tool attribution — not
    suppressed by the same-named field in mcp_message_send)
(d) TOTAL: 8 warn records (4 unique x 2 sinks). Without dedupe: 4 warns x 4 rebuilds x 2 sinks = 32.
```

Real loopback server + real HTTP requests; tools injected via the production scoped-tools
seam; both log sinks captured. No cloud creds.

Autoreview: no accepted/actionable findings.
