### PR TITLE
fix(agents): bound tools-manager GitHub release response read to prevent OOM

### DIFF
--- a/src/agents/utils/tools-manager.test.ts
+++ b/src/agents/utils/tools-manager.test.ts
@@ -183,3 +183,35 @@ describe("getToolPath exit-status handling", () => {
     expect(getToolPath("fd")).toBe("fd");
   });
 });
+
+describe("ensureTool GitHub release response bounding", () => {
+  it("rejects oversized GitHub release API responses and returns undefined", async () => {
+    const ONE_MIB = 1024 * 1024;
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        // 1 MiB exceeds the 512 KiB cap
+        controller.enqueue(new Uint8Array(ONE_MIB));
+        controller.close();
+      },
+    });
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: new Response(body, {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+      release: vi.fn(),
+    });
+    // Make commandExists fail so getToolPath returns null, forcing the download path
+    spawnSyncMock.mockReturnValue({
+      error: new Error("not found"),
+      status: 1,
+      stderr: Buffer.alloc(0),
+      stdout: Buffer.alloc(0),
+    });
+
+    const { ensureTool } = await import("./tools-manager.js");
+    // ensureTool catches errors gracefully and returns undefined
+    const result = await ensureTool("fd");
+    expect(result).toBeUndefined();
+  });
+});

--- a/src/agents/utils/tools-manager.ts
+++ b/src/agents/utils/tools-manager.ts
@@ -19,6 +19,7 @@ import { join } from "node:path";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import type { ReadableStream as NodeReadableStream } from "node:stream/web";
+import { readResponseWithLimit } from "@openclaw/media-core/read-response-with-limit";
 import chalk from "chalk";
 import { fetchWithSsrFGuard } from "../../infra/net/fetch-guard.js";
 import {
@@ -30,6 +31,7 @@ import { APP_NAME, getBinDir } from "../config.js";
 const TOOLS_DIR = getBinDir();
 const NETWORK_TIMEOUT_MS = 10_000;
 const DOWNLOAD_TIMEOUT_MS = 120_000;
+const TOOLS_MANAGER_RESPONSE_MAX_BYTES = 512 * 1024;
 
 async function cancelUnreadResponseBody(response: Response): Promise<void> {
   if (!response.bodyUsed) {
@@ -154,7 +156,11 @@ async function getLatestVersion(repo: string): Promise<string> {
       throw new Error(`GitHub API error: ${response.status}`);
     }
 
-    const data = (await response.json()) as { tag_name: string };
+    const bytes = await readResponseWithLimit(response, TOOLS_MANAGER_RESPONSE_MAX_BYTES, {
+      onOverflow: ({ maxBytes }) =>
+        new Error(`tools-manager GitHub release response exceeds ${maxBytes} bytes`),
+    });
+    const data = JSON.parse(new TextDecoder().decode(bytes)) as { tag_name: string };
     return data.tag_name.replace(/^v/, "");
   } finally {
     await guarded.release();


### PR DESCRIPTION
## What Problem This Solves

getLatestVersion in tools-manager.ts calls await response.json() on the GitHub releases API response without a read limit. An oversized response could buffer arbitrarily large payloads before parsing, risking OOM.

Same pattern as #98188 (docs search).

## Why This Change Was Made

All external HTTP response reads should use readResponseWithLimit. The function already uses fetchWithSsrFGuard for SSRF protection — this adds memory bounding.

## Evidence

### Committed test proves oversized response rejection

```
pnpm test src/agents/utils/tools-manager.test.ts
 Test Files  1 passed (1)
      Tests  6 passed (6)
```

Test output confirms bounded read:
```
fd not found. Downloading...
Failed to download fd: tools-manager GitHub release response exceeds 524288 bytes
```

## Risk

Low. 512 KiB cap is generous for a GitHub API version response. ensureTool already catches errors gracefully (returns undefined).