### PR TITLE
fix(llm): preserve non-array tool result replay text

### DIFF
--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -16,6 +16,7 @@ import {
   createEmptyTransportUsage,
   createWritableTransportEventStream,
   describeToolResultMediaPlaceholder,
+  extractToolResultImageBlocks,
   extractToolResultText,
   failTransportStream,
   finalizeTransportStream,
@@ -651,10 +652,7 @@ function convertGoogleMessages(model: GoogleTransportModel, context: Context) {
     if (msg.role === "toolResult") {
       const textResult = extractToolResultText(msg.content);
       const imageContent = model.input.includes("image")
-        ? msg.content.filter(
-            (item): item is Extract<(typeof msg.content)[number], { type: "image" }> =>
-              item.type === "image",
-          )
+        ? extractToolResultImageBlocks(msg.content)
         : [];
       const mediaPlaceholder = describeToolResultMediaPlaceholder(msg.content);
       const responseValue = textResult

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -16,7 +16,6 @@ import {
   createEmptyTransportUsage,
   createWritableTransportEventStream,
   describeToolResultMediaPlaceholder,
-  extractToolResultImageBlocks,
   extractToolResultText,
   failTransportStream,
   finalizeTransportStream,
@@ -83,6 +82,37 @@ type GoogleGenerateContentRequest = {
   tools?: Array<Record<string, unknown>>;
   toolConfig?: Record<string, unknown>;
 };
+
+type GoogleToolResultImageBlock = {
+  type: "image";
+  mimeType: string;
+  data: string;
+};
+
+function normalizeGoogleToolResultBlocks(blocks: unknown): readonly unknown[] {
+  if (Array.isArray(blocks)) {
+    return blocks;
+  }
+  if (blocks === null || blocks === undefined) {
+    return [];
+  }
+  return [blocks];
+}
+
+function isGoogleToolResultImageBlock(block: unknown): block is GoogleToolResultImageBlock {
+  return (
+    block !== null &&
+    typeof block === "object" &&
+    !Array.isArray(block) &&
+    (block as Record<string, unknown>).type === "image" &&
+    typeof (block as Record<string, unknown>).mimeType === "string" &&
+    typeof (block as Record<string, unknown>).data === "string"
+  );
+}
+
+function extractGoogleToolResultImageBlocks(blocks: unknown): GoogleToolResultImageBlock[] {
+  return normalizeGoogleToolResultBlocks(blocks).filter(isGoogleToolResultImageBlock);
+}
 
 const GOOGLE_GEMINI3_FIRST_RESPONSE_RETRY_DEFAULT_MS = 45_000;
 const GOOGLE_GEMINI3_FIRST_RESPONSE_RETRY_ENV = "OPENCLAW_GOOGLE_GEMINI_FIRST_RESPONSE_RETRY_MS";
@@ -652,7 +682,7 @@ function convertGoogleMessages(model: GoogleTransportModel, context: Context) {
     if (msg.role === "toolResult") {
       const textResult = extractToolResultText(msg.content);
       const imageContent = model.input.includes("image")
-        ? extractToolResultImageBlocks(msg.content)
+        ? extractGoogleToolResultImageBlocks(msg.content)
         : [];
       const mediaPlaceholder = describeToolResultMediaPlaceholder(msg.content);
       const responseValue = textResult

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -16,7 +16,9 @@ import type { AnthropicOptions, AnthropicThinkingDisplay } from "../llm/provider
 import {
   describeToolResultMediaPlaceholder,
   extractToolResultBlockText,
+  isToolResultImageBlock,
   extractToolResultText,
+  normalizeToolResultBlocks,
 } from "../llm/providers/tool-result-text.js";
 import type {
   AssistantMessageDiagnostic,
@@ -301,15 +303,11 @@ function toClaudeCodeName(name: string): string {
   return CLAUDE_CODE_TOOL_LOOKUP.get(normalizeLowercaseStringOrEmpty(name)) ?? name;
 }
 
-function convertContentBlocks(content: readonly unknown[]) {
+function convertContentBlocks(content: unknown) {
   const text = extractToolResultText(content);
   const mediaPlaceholder = describeToolResultMediaPlaceholder(content);
-  const hasImages =
-    Array.isArray(content) &&
-    content.some(
-      (item) =>
-        item && typeof item === "object" && (item as Record<string, unknown>).type === "image",
-    );
+  const contentBlocks = normalizeToolResultBlocks(content);
+  const hasImages = contentBlocks.some(isToolResultImageBlock);
   if (!hasImages) {
     return sanitizeNonEmptyTransportPayloadText(text, mediaPlaceholder ?? "(no output)");
   }
@@ -321,25 +319,24 @@ function convertContentBlocks(content: readonly unknown[]) {
       }
   > = [];
   let hasTextBlock = false;
-  for (const block of Array.isArray(content) ? content : []) {
+  for (const block of contentBlocks) {
     if (!block || typeof block !== "object") {
       continue;
     }
-    const record = block as Record<string, unknown>;
     const blockText = extractToolResultBlockText(block);
     if (blockText) {
       blocks.push({ type: "text", text: sanitizeTransportPayloadText(blockText) });
       hasTextBlock = true;
     }
-    if (record.type !== "image") {
+    if (!isToolResultImageBlock(block)) {
       continue;
     }
     blocks.push({
       type: "image" as const,
       source: {
         type: "base64",
-        media_type: typeof record.mimeType === "string" ? record.mimeType : "image/png",
-        data: typeof record.data === "string" ? record.data : "",
+        media_type: block.mimeType,
+        data: block.data,
       },
     });
   }

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -29,6 +29,7 @@ import { clampOpenAIPromptCacheKey } from "../llm/providers/openai-prompt-cache.
 import { mapOpenAIStopReason } from "../llm/providers/openai-stop-reason.js";
 import {
   describeToolResultMediaPlaceholder,
+  extractToolResultImageBlocks,
   extractToolResultText,
 } from "../llm/providers/tool-result-text.js";
 import type { Api, Context, Model } from "../llm/types.js";
@@ -1290,7 +1291,8 @@ function convertResponsesMessages(
       const sanitizedTextResult = sanitizeTransportPayloadText(textResult);
       const hasText = sanitizedTextResult.trim().length > 0;
       const mediaPlaceholder = describeToolResultMediaPlaceholder(msg.content);
-      const hasImages = msg.content.some((item) => item.type === "image");
+      const imageBlocks = extractToolResultImageBlocks(msg.content);
+      const hasImages = imageBlocks.length > 0;
       const [callId] = msg.toolCallId.split("|");
       messages.push({
         type: "function_call_output",
@@ -1303,13 +1305,11 @@ function convertResponsesMessages(
                   : mediaPlaceholder === "(see attached media)"
                     ? [{ type: "input_text", text: mediaPlaceholder }]
                     : []),
-                ...msg.content
-                  .filter((item) => item.type === "image")
-                  .map((item) => ({
-                    type: "input_image",
-                    detail: "auto",
-                    image_url: `data:${item.mimeType};base64,${item.data}`,
-                  })),
+                ...imageBlocks.map((item) => ({
+                  type: "input_image",
+                  detail: "auto",
+                  image_url: `data:${item.mimeType};base64,${item.data}`,
+                })),
               ] as ResponseFunctionCallOutputItemList)
             : sanitizeNonEmptyTransportPayloadText(textResult, mediaPlaceholder ?? "(no output)"),
       });

--- a/src/llm/providers/anthropic.ts
+++ b/src/llm/providers/anthropic.ts
@@ -71,7 +71,9 @@ import { adjustMaxTokensForThinking, buildBaseOptions } from "./simple-options.j
 import {
   describeToolResultMediaPlaceholder,
   extractToolResultBlockText,
+  isToolResultImageBlock,
   extractToolResultText,
+  normalizeToolResultBlocks,
 } from "./tool-result-text.js";
 import { transformMessages } from "./transform-messages.js";
 
@@ -127,7 +129,7 @@ const toClaudeCodeName = (name: string) => ccToolLookup.get(name.toLowerCase()) 
 /**
  * Convert content blocks to Anthropic API format
  */
-function convertContentBlocks(content: readonly unknown[]):
+function convertContentBlocks(content: unknown):
   | string
   | Array<
       | { type: "text"; text: string }
@@ -142,12 +144,8 @@ function convertContentBlocks(content: readonly unknown[]):
     > {
   const text = extractToolResultText(content);
   const mediaPlaceholder = describeToolResultMediaPlaceholder(content);
-  const hasImages =
-    Array.isArray(content) &&
-    content.some(
-      (item) =>
-        item && typeof item === "object" && (item as Record<string, unknown>).type === "image",
-    );
+  const contentBlocks = normalizeToolResultBlocks(content);
+  const hasImages = contentBlocks.some(isToolResultImageBlock);
 
   if (!hasImages) {
     const sanitized = sanitizeSurrogates(text);
@@ -167,29 +165,24 @@ function convertContentBlocks(content: readonly unknown[]):
   > = [];
   let hasTextBlock = false;
 
-  for (const block of Array.isArray(content) ? content : []) {
+  for (const block of contentBlocks) {
     if (!block || typeof block !== "object") {
       continue;
     }
-    const record = block as Record<string, unknown>;
     const blockText = extractToolResultBlockText(block);
     if (blockText) {
       blocks.push({ type: "text" as const, text: sanitizeSurrogates(blockText) });
       hasTextBlock = true;
     }
-    if (record.type !== "image") {
+    if (!isToolResultImageBlock(block)) {
       continue;
     }
     blocks.push({
       type: "image" as const,
       source: {
         type: "base64" as const,
-        media_type: (typeof record.mimeType === "string" ? record.mimeType : "image/jpeg") as
-          | "image/jpeg"
-          | "image/png"
-          | "image/gif"
-          | "image/webp",
-        data: typeof record.data === "string" ? record.data : "",
+        media_type: block.mimeType as "image/jpeg" | "image/png" | "image/gif" | "image/webp",
+        data: block.data,
       },
     });
   }

--- a/src/llm/providers/github-copilot-headers.ts
+++ b/src/llm/providers/github-copilot-headers.ts
@@ -1,5 +1,6 @@
 // GitHub Copilot header helpers build request headers for Copilot-backed providers.
 import type { Message } from "../types.js";
+import { extractToolResultImageBlocks } from "./tool-result-text.js";
 
 // Copilot expects X-Initiator to indicate whether the request is user-initiated
 // or agent-initiated (e.g. follow-up after assistant/tool messages).
@@ -14,8 +15,8 @@ export function hasCopilotVisionInput(messages: Message[]): boolean {
     if (msg.role === "user" && Array.isArray(msg.content)) {
       return msg.content.some((c) => c.type === "image");
     }
-    if (msg.role === "toolResult" && Array.isArray(msg.content)) {
-      return msg.content.some((c) => c.type === "image");
+    if (msg.role === "toolResult") {
+      return extractToolResultImageBlocks(msg.content).length > 0;
     }
     return false;
   });

--- a/src/llm/providers/google-shared.ts
+++ b/src/llm/providers/google-shared.ts
@@ -32,7 +32,11 @@ import type {
 } from "../types.js";
 import type { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
-import { describeToolResultMediaPlaceholder, extractToolResultText } from "./tool-result-text.js";
+import {
+  describeToolResultMediaPlaceholder,
+  extractToolResultImageBlocks,
+  extractToolResultText,
+} from "./tool-result-text.js";
 import { transformMessages } from "./transform-messages.js";
 
 export type GoogleApiType = "google-generative-ai" | "google-vertex";
@@ -281,7 +285,7 @@ export function convertMessages<T extends GoogleApiType>(
       // Extract text and image content
       const textResult = extractToolResultText(msg.content);
       const imageContent = model.input.includes("image")
-        ? msg.content.filter((c): c is ImageContent => c.type === "image")
+        ? extractToolResultImageBlocks(msg.content)
         : [];
 
       const hasText = textResult.length > 0;

--- a/src/llm/providers/mistral.ts
+++ b/src/llm/providers/mistral.ts
@@ -30,7 +30,11 @@ import { shortHash } from "../utils/hash.js";
 import { parseStreamingJson } from "../utils/json-parse.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import { buildBaseOptions } from "./simple-options.js";
-import { describeToolResultMediaPlaceholder, extractToolResultText } from "./tool-result-text.js";
+import {
+  describeToolResultMediaPlaceholder,
+  extractToolResultImageBlocks,
+  extractToolResultText,
+} from "./tool-result-text.js";
 import { transformMessages } from "./transform-messages.js";
 
 const MISTRAL_TOOL_CALL_ID_LENGTH = 9;
@@ -694,7 +698,8 @@ function toChatMessages(
     const toolContent: ContentChunk[] = [];
     const textResult = extractToolResultText(msg.content);
     const mediaPlaceholder = describeToolResultMediaPlaceholder(msg.content);
-    const hasImages = msg.content.some((part) => part.type === "image");
+    const imageBlocks = extractToolResultImageBlocks(msg.content);
+    const hasImages = imageBlocks.length > 0;
     const toolText = buildToolResultText(
       textResult,
       mediaPlaceholder,
@@ -703,11 +708,8 @@ function toChatMessages(
       msg.isError,
     );
     toolContent.push({ type: "text", text: toolText });
-    for (const part of msg.content) {
+    for (const part of imageBlocks) {
       if (!supportsImages) {
-        continue;
-      }
-      if (part.type !== "image") {
         continue;
       }
       toolContent.push({

--- a/src/llm/providers/openai-completions.test.ts
+++ b/src/llm/providers/openai-completions.test.ts
@@ -484,6 +484,69 @@ describe("OpenAI-compatible completions params", () => {
     });
   });
 
+  it("preserves single-object image tool results with image placeholders and attachments", async () => {
+    let capturedMessages:
+      | Array<{ role?: string; content?: unknown; tool_call_id?: string }>
+      | undefined;
+    const stream = streamOpenAICompletions(
+      { ...model, input: ["text", "image"] },
+      {
+        messages: [
+          {
+            role: "assistant",
+            api: model.api,
+            provider: model.provider,
+            model: model.id,
+            usage: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 0,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            stopReason: "toolUse",
+            content: [
+              { type: "toolCall", id: "call_single_shot", name: "screenshot", arguments: {} },
+            ],
+            timestamp: 1,
+          },
+          {
+            role: "toolResult",
+            toolCallId: "call_single_shot",
+            toolName: "screenshot",
+            content: { type: "image", mimeType: "image/png", data: "c2luZ2xlLWltZw==" },
+            isError: false,
+            timestamp: 2,
+          },
+        ],
+      } as never,
+      {
+        apiKey: "sk-test",
+        onPayload(payload) {
+          capturedMessages = (payload as { messages?: typeof capturedMessages }).messages;
+          throw new Error("stop before network");
+        },
+      },
+    );
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    expect(capturedMessages?.find((message) => message.role === "tool")).toMatchObject({
+      role: "tool",
+      content: "(see attached image)",
+      tool_call_id: "call_single_shot",
+    });
+    expect(capturedMessages?.find((message) => Array.isArray(message.content))).toMatchObject({
+      role: "user",
+      content: [
+        { type: "text", text: "Attached image(s) from tool result:" },
+        { type: "image_url", image_url: { url: "data:image/png;base64,c2luZ2xlLWltZw==" } },
+      ],
+    });
+  });
+
   it("does not reread an unreadable tool inventory length", async () => {
     let capturedPayload: Record<string, unknown> | undefined;
     const tools = new Proxy([], {

--- a/src/llm/providers/openai-completions.ts
+++ b/src/llm/providers/openai-completions.ts
@@ -35,7 +35,6 @@ import type {
   AssistantMessage,
   CacheRetention,
   Context,
-  ImageContent,
   Message,
   Model,
   OpenAICompletionsCompat,
@@ -58,7 +57,11 @@ import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copi
 import { clampOpenAIPromptCacheKey } from "./openai-prompt-cache.js";
 import { mapOpenAIStopReason } from "./openai-stop-reason.js";
 import { buildBaseOptions } from "./simple-options.js";
-import { describeToolResultMediaPlaceholder, extractToolResultText } from "./tool-result-text.js";
+import {
+  describeToolResultMediaPlaceholder,
+  extractToolResultImageBlocks,
+  extractToolResultText,
+} from "./tool-result-text.js";
 import { transformMessages } from "./transform-messages.js";
 
 /**
@@ -92,10 +95,6 @@ function isThinkingContentBlock(block: { type: string }): block is ThinkingConte
 
 function isToolCallBlock(block: { type: string }): block is ToolCall {
   return block.type === "toolCall";
-}
-
-function isImageContentBlock(block: { type: string }): block is ImageContent {
-  return block.type === "image";
 }
 
 const EMPTY_TOOL_RESULT_TEXT = "(no output)";
@@ -1161,7 +1160,8 @@ export function convertMessages(
         // Extract text and image content
         const textResult = extractToolResultText(toolMsg.content);
         const mediaPlaceholder = describeToolResultMediaPlaceholder(toolMsg.content);
-        const hasImages = toolMsg.content.some((c) => c.type === "image");
+        const imageContentBlocks = extractToolResultImageBlocks(toolMsg.content);
+        const hasImages = imageContentBlocks.length > 0;
 
         // Always send tool result with text (or placeholder if only images)
         const content = sanitizeToolResultText(
@@ -1180,15 +1180,13 @@ export function convertMessages(
         params.push(toolResultMsg);
 
         if (hasImages && model.input.includes("image")) {
-          for (const block of toolMsg.content) {
-            if (isImageContentBlock(block)) {
-              imageBlocks.push({
-                type: "image_url",
-                image_url: {
-                  url: `data:${block.mimeType};base64,${block.data}`,
-                },
-              });
-            }
+          for (const block of imageContentBlocks) {
+            imageBlocks.push({
+              type: "image_url",
+              image_url: {
+                url: `data:${block.mimeType};base64,${block.data}`,
+              },
+            });
           }
         }
       }

--- a/src/llm/providers/openai-responses-shared.ts
+++ b/src/llm/providers/openai-responses-shared.ts
@@ -56,7 +56,11 @@ import { headersToRecord } from "../utils/headers.js";
 import { parseStreamingJson } from "../utils/json-parse.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import { convertResponsesToolPayload, convertResponsesTools } from "./openai-responses-tools.js";
-import { describeToolResultMediaPlaceholder, extractToolResultText } from "./tool-result-text.js";
+import {
+  describeToolResultMediaPlaceholder,
+  extractToolResultImageBlocks,
+  extractToolResultText,
+} from "./tool-result-text.js";
 import { transformMessages } from "./transform-messages.js";
 
 // =============================================================================
@@ -414,7 +418,8 @@ export function convertResponsesMessages<TApi extends Api>(
     } else if (msg.role === "toolResult") {
       const textResult = extractToolResultText(msg.content);
       const sanitizedTextResult = sanitizeSurrogates(textResult);
-      const hasImages = msg.content.some((c): c is ImageContent => c.type === "image");
+      const imageBlocks = extractToolResultImageBlocks(msg.content);
+      const hasImages = imageBlocks.length > 0;
       const mediaPlaceholder = describeToolResultMediaPlaceholder(msg.content);
       const hasText = sanitizedTextResult.trim().length > 0;
       const [callId] = msg.toolCallId.split("|");
@@ -435,14 +440,12 @@ export function convertResponsesMessages<TApi extends Api>(
           });
         }
 
-        for (const block of msg.content) {
-          if (block.type === "image") {
-            contentParts.push({
-              type: "input_image",
-              detail: "auto",
-              image_url: `data:${block.mimeType};base64,${block.data}`,
-            });
-          }
+        for (const block of imageBlocks) {
+          contentParts.push({
+            type: "input_image",
+            detail: "auto",
+            image_url: `data:${block.mimeType};base64,${block.data}`,
+          });
         }
 
         output = contentParts;

--- a/src/llm/providers/tool-result-text.test.ts
+++ b/src/llm/providers/tool-result-text.test.ts
@@ -157,6 +157,23 @@ describe("extractToolResultText", () => {
     expect(text).toContain("…(truncated)…");
     expect(text).not.toContain(tail);
   });
+
+  it("preserves plain string tool-result content", () => {
+    expect(extractToolResultText("plain status output")).toBe("plain status output");
+  });
+
+  it("serializes a single structured tool-result object", () => {
+    const text = extractToolResultText({ type: "json", payload: { ok: true, count: 2 } });
+
+    expect(text).toContain('"type":"json"');
+    expect(text).toContain('"ok":true');
+    expect(text).toContain('"count":2');
+  });
+
+  it("uses text-like fields from non-standard object tool results", () => {
+    expect(extractToolResultText({ output: "status card text" })).toBe("status card text");
+    expect(extractToolResultText({ content: "config text" })).toBe("config text");
+  });
 });
 
 describe("describeToolResultMediaPlaceholder", () => {

--- a/src/llm/providers/tool-result-text.test.ts
+++ b/src/llm/providers/tool-result-text.test.ts
@@ -174,6 +174,22 @@ describe("extractToolResultText", () => {
     expect(extractToolResultText({ output: "status card text" })).toBe("status card text");
     expect(extractToolResultText({ content: "config text" })).toBe("config text");
   });
+
+  it("redacts and truncates text-like fields from non-standard object tool results", () => {
+    const redactedText = extractToolResultText({
+      output:
+        '{"apiToken":"api-token-value-1234567890","safe":"ok","preview":"data:image/png;base64,abcdef"}',
+    });
+
+    expect(redactedText).toContain('"safe":"ok"');
+    expect(redactedText).toContain("[inline data URI:");
+    expect(redactedText).not.toContain("api-token-value-1234567890");
+    expect(redactedText).not.toContain("abcdef");
+
+    const truncatedText = extractToolResultText({ output: `${"x".repeat(8_200)}tail-marker` });
+    expect(truncatedText).toContain("…(truncated)…");
+    expect(truncatedText).not.toContain("tail-marker");
+  });
 });
 
 describe("describeToolResultMediaPlaceholder", () => {
@@ -198,5 +214,11 @@ describe("describeToolResultMediaPlaceholder", () => {
         { type: "audio", mimeType: "audio/mpeg", data: "audio" },
       ]),
     ).toBe("(see attached media)");
+  });
+
+  it("describes single-object image tool result media", () => {
+    expect(
+      describeToolResultMediaPlaceholder({ type: "image", mimeType: "image/png", data: "img" }),
+    ).toBe("(see attached image)");
   });
 });

--- a/src/llm/providers/tool-result-text.ts
+++ b/src/llm/providers/tool-result-text.ts
@@ -1,5 +1,6 @@
 import { redactSecrets, redactToolPayloadText } from "../../logging/redact.js";
 import { truncateUtf16Safe } from "../../shared/utf16-slice.js";
+import type { ImageContent } from "../types.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 
 const PROVIDER_TOOL_RESULT_MAX_CHARS = 8000;
@@ -28,7 +29,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
-function normalizeToolResultBlocks(blocks: unknown): readonly unknown[] {
+export function normalizeToolResultBlocks(blocks: unknown): readonly unknown[] {
   if (Array.isArray(blocks)) {
     return blocks;
   }
@@ -46,6 +47,19 @@ function primitiveToolResultText(value: unknown): string | undefined {
     return String(value);
   }
   return undefined;
+}
+
+export function isToolResultImageBlock(block: unknown): block is ImageContent {
+  return (
+    isRecord(block) &&
+    block.type === "image" &&
+    typeof block.mimeType === "string" &&
+    typeof block.data === "string"
+  );
+}
+
+export function extractToolResultImageBlocks(blocks: unknown): ImageContent[] {
+  return normalizeToolResultBlocks(blocks).filter(isToolResultImageBlock);
 }
 
 function readMimeType(value: unknown): string | undefined {
@@ -90,6 +104,12 @@ function redactStructuredTextValue(value: string): string {
   } catch {
     return redacted;
   }
+}
+
+function redactTextLikeStructuredField(value: string): string | undefined {
+  const redacted = redactInlineDataUris(redactStructuredTextValue(value));
+  const truncated = truncateProviderToolText(redacted);
+  return truncated ? sanitizeSurrogates(truncated) : undefined;
 }
 
 function stringifyStructuredBlock(block: Record<string, unknown>): string | undefined {
@@ -202,7 +222,7 @@ export function extractToolResultBlockText(block: unknown): string | undefined {
     for (const key of TEXT_FIELD_CANDIDATES) {
       const text = primitiveToolResultText(record[key]);
       if (text) {
-        return sanitizeSurrogates(text);
+        return redactTextLikeStructuredField(text);
       }
     }
   }

--- a/src/llm/providers/tool-result-text.ts
+++ b/src/llm/providers/tool-result-text.ts
@@ -22,9 +22,30 @@ const MIME_KEY_CANDIDATES = [
 const TEXTUAL_MIME_PATTERN =
   /^(?:text\/|application\/(?:json|ld\+json|x-ndjson|xml|javascript|x-www-form-urlencoded)|[^/]+\/[^+]+\+(?:json|xml)$)/i;
 const OPAQUE_OR_BINARY_FIELD_RE = /^(?:blob|buffer|bytes|encrypted_content|encrypted_stdout)$/i;
+const TEXT_FIELD_CANDIDATES = ["text", "output", "content"];
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function normalizeToolResultBlocks(blocks: unknown): readonly unknown[] {
+  if (Array.isArray(blocks)) {
+    return blocks;
+  }
+  if (blocks === null || blocks === undefined) {
+    return [];
+  }
+  return [blocks];
+}
+
+function primitiveToolResultText(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+    return String(value);
+  }
+  return undefined;
 }
 
 function readMimeType(value: unknown): string | undefined {
@@ -123,11 +144,11 @@ function truncateProviderToolText(text: string): string {
   return `${truncateUtf16Safe(text, PROVIDER_TOOL_RESULT_MAX_CHARS)}\n…(truncated)…`;
 }
 
-export function describeToolResultMediaPlaceholder(blocks: readonly unknown[]): string | undefined {
+export function describeToolResultMediaPlaceholder(blocks: unknown): string | undefined {
   let hasImage = false;
   let hasAudio = false;
 
-  for (const block of blocks) {
+  for (const block of normalizeToolResultBlocks(blocks)) {
     if (!block || typeof block !== "object") {
       continue;
     }
@@ -162,6 +183,10 @@ export function describeToolResultMediaPlaceholder(blocks: readonly unknown[]): 
 }
 
 export function extractToolResultBlockText(block: unknown): string | undefined {
+  const primitiveText = primitiveToolResultText(block);
+  if (primitiveText !== undefined) {
+    return primitiveText ? sanitizeSurrogates(primitiveText) : undefined;
+  }
   if (!block || typeof block !== "object") {
     return undefined;
   }
@@ -170,17 +195,25 @@ export function extractToolResultBlockText(block: unknown): string | undefined {
     return undefined;
   }
   if (record.type === "text") {
-    const text = typeof record.text === "string" ? record.text : "";
+    const text = primitiveToolResultText(record.text) ?? "";
     return text ? sanitizeSurrogates(text) : undefined;
+  }
+  if (typeof record.type !== "string") {
+    for (const key of TEXT_FIELD_CANDIDATES) {
+      const text = primitiveToolResultText(record[key]);
+      if (text) {
+        return sanitizeSurrogates(text);
+      }
+    }
   }
   const structured = stringifyStructuredBlock(record);
   return structured ? sanitizeSurrogates(truncateProviderToolText(structured)) : undefined;
 }
 
-export function extractToolResultText(blocks: readonly unknown[]): string {
+export function extractToolResultText(blocks: unknown): string {
   const explicitTexts: string[] = [];
   const structuredTexts: string[] = [];
-  for (const block of blocks) {
+  for (const block of normalizeToolResultBlocks(blocks)) {
     const text = extractToolResultBlockText(block);
     if (!text) {
       continue;

--- a/src/plugin-sdk/provider-transport-runtime.ts
+++ b/src/plugin-sdk/provider-transport-runtime.ts
@@ -7,7 +7,10 @@ export { stripSystemPromptCacheBoundary } from "../agents/system-prompt-cache-bo
 export { transformTransportMessages } from "../agents/transport-message-transform.js";
 export {
   describeToolResultMediaPlaceholder,
+  extractToolResultImageBlocks,
   extractToolResultText,
+  isToolResultImageBlock,
+  normalizeToolResultBlocks,
 } from "../llm/providers/tool-result-text.js";
 export {
   coerceTransportToolCallArguments,

--- a/src/plugin-sdk/provider-transport-runtime.ts
+++ b/src/plugin-sdk/provider-transport-runtime.ts
@@ -7,10 +7,7 @@ export { stripSystemPromptCacheBoundary } from "../agents/system-prompt-cache-bo
 export { transformTransportMessages } from "../agents/transport-message-transform.js";
 export {
   describeToolResultMediaPlaceholder,
-  extractToolResultImageBlocks,
   extractToolResultText,
-  isToolResultImageBlock,
-  normalizeToolResultBlocks,
 } from "../llm/providers/tool-result-text.js";
 export {
   coerceTransportToolCallArguments,


### PR DESCRIPTION
## Summary

Preserve useful provider replay text when tool-result content reaches the shared replay boundary as a plain string, primitive value, single structured object, or text-like object instead of the canonical content-block array.

## What Problem This Solves

After #97742 introduced shared structured tool-result replay extraction, non-canonical or legacy tool-result content can still reach provider replay as a non-array value. The previous draft normalized only inside `extractToolResultText()`, but several provider callers still inspected the original `msg.content` with `.some()`, `.filter()`, or direct iteration for image/media handling. That meant the stated string or single-object replay path could still throw or suppress useful output before provider payload creation finished.

## Review Context Addressed

- Normalized non-array content before provider media/image checks instead of only inside text extraction.
- Routed non-standard `text` / `output` / `content` object fields through the existing redaction, inline-data omission, and provider truncation safeguards before replay.
- Extended the same normalized image-block handling to OpenAI Responses, OpenAI Chat Completions, Mistral, Google, Anthropic, OpenAI/Anthropic transport replay, Google transport extension, and Copilot vision header detection.

## Implementation

- Export a shared `normalizeToolResultBlocks()` helper for provider replay boundaries.
- Add shared image-block helpers so caller media handling works for arrays, single image objects, and non-array text/object content without unsafe direct `.some()` / `.filter()` calls on the original value.
- Keep primitive string/number/boolean/bigint content as explicit replay text.
- Preserve text-like object fields while applying the same redaction/truncation safeguards used by structured fallback text.
- Keep existing canonical array behavior intact for text, image, audio, structured fallback, binary omission, inline-data omission, and truncation.

## Validation

- GitHub Actions is the authoritative validation source for this branch.
- Current-head cloud checks should be re-evaluated after the latest patch commit updates provider caller normalization and the PR evidence sections.
- Local pre-check only: formatter and `git diff --check` were attempted in a local OpenClaw checkout. The local session is affected by the tool-result replay output-loss symptom being fixed here, so local terminal output is not used as merge proof.

## Evidence

- Source-level proof: the patch removes direct non-array-unsafe media checks from the provider replay paths listed above and routes image extraction through the shared normalized helper.
- Regression coverage: focused tests now cover plain string content, single structured object content, text-like object redaction/truncation, and single-object image media placeholders.
- Review linkage: addresses the ClawSweeper findings on `src/llm/providers/tool-result-text.ts` for redacted text-like object handling and normalized caller media checks.
- Cloud proof: GitHub Actions checks for the latest PR head are expected to provide the authoritative current-head result after this body update and branch push.

## Risk

Low to moderate. The change broadens defensive handling for non-canonical replay content at provider boundaries, but it preserves canonical array behavior and keeps media payload handling restricted to validated image blocks with string MIME/data fields. The security-sensitive part is text-like object replay; that path now applies redaction, inline-data omission, and truncation before provider-bound text is produced.

## Rollback

Revert this PR to restore the previous strict array-shaped replay behavior. No data migration or configuration rollback is required.

## Docs Updated

No user-facing docs were changed. This is a defensive runtime compatibility fix with regression coverage.

## Related Issue / PR

- Fixes #98825.
- Follow-up to #97742.

## Not Tested / Limitations

- Local command output from the investigation session was not reliable enough to serve as proof because it intermittently exhibited the replay output-loss behavior under investigation.
- Full merge confidence should use the latest GitHub Actions checks and any maintainer-required proof artifacts for the current PR head.