### PR TITLE
fix(security): audit plaintext API keys in config.env.vars

### DIFF
--- a/src/security/audit-channel-readonly-setup-fallback.test.ts
+++ b/src/security/audit-channel-readonly-setup-fallback.test.ts
@@ -61,6 +61,7 @@ vi.mock("./audit.nondeep.runtime.js", () => ({
   collectSecretsInConfigFindings: collectNoFindings,
   collectSmallModelRiskFindings: collectNoFindings,
   collectSyncedFolderFindings: collectNoFindings,
+  getConfigEnvVarEntries: collectNoFindings,
   readConfigSnapshotForAudit: vi.fn(async () => null),
 }));
 

--- a/src/security/audit-config-basics.test.ts
+++ b/src/security/audit-config-basics.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import type { ConfigFileSnapshot } from "../config/types.openclaw.js";
 import {
   onInternalDiagnosticEvent,
   resetDiagnosticEventsForTest,
@@ -237,6 +238,131 @@ describe("security audit config basics", () => {
         }),
       ]),
     );
+  });
+
+  it("flags plaintext API keys stored in config.env.vars", async () => {
+    const report = await runSecurityAudit({
+      config: {
+        env: {
+          vars: {
+            OPENAI_API_KEY: "sk-test-key-openai-fake",
+            SLACK_BOT_TOKEN: "xoxb-test-slack-bot-token",
+            SLACK_APP_TOKEN: "xapp-test-slack-app-token",
+            GITHUB_TOKEN: "ghp_TEST_FAKE_TOKEN",
+            AWS_ACCESS_KEY_ID: "AKIA_TEST_FAKE_KEY",
+          },
+        },
+      },
+      sourceConfig: {},
+      env: {},
+      includeFilesystem: false,
+      includeChannelSecurity: false,
+    });
+
+    const hits = report.findings.filter((f) => f.checkId === "config.secrets.api_key_in_env_vars");
+    expect(hits).toHaveLength(5);
+    expect(hits.every((f) => f.severity === "warn")).toBe(true);
+  });
+
+  it("does not flag env references or benign values in config.env.vars", async () => {
+    const report = await runSecurityAudit({
+      config: {
+        env: {
+          vars: {
+            OPENAI_API_KEY: "${OPENAI_API_KEY}",
+            GITHUB_TOKEN: "${GITHUB_TOKEN}",
+            SOME_OTHER_VAR: "not-a-secret-value",
+            EMPTY_VAR: "",
+          },
+        },
+      },
+      sourceConfig: {},
+      env: {},
+      includeFilesystem: false,
+      includeChannelSecurity: false,
+    });
+
+    expect(report.findings.some((f) => f.checkId === "config.secrets.api_key_in_env_vars")).toBe(
+      false,
+    );
+  });
+
+  it("does not flag env references in sourceConfig even when config resolves to a real API key", async () => {
+    const report = await runSecurityAudit({
+      config: {
+        env: {
+          vars: {
+            OPENAI_API_KEY: "sk-resolved-openai-key",
+          },
+        },
+      },
+      sourceConfig: {
+        env: {
+          vars: {
+            OPENAI_API_KEY: "${OPENAI_API_KEY}",
+          },
+        },
+      },
+      env: {},
+      includeFilesystem: false,
+      includeChannelSecurity: false,
+    });
+
+    expect(report.findings.some((f) => f.checkId === "config.secrets.api_key_in_env_vars")).toBe(
+      false,
+    );
+  });
+
+  it("does not flag env references authored in $include files", async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-audit-include-env-"));
+    try {
+      const includePath = path.join(tmp, "secrets.json");
+      await fs.writeFile(
+        includePath,
+        JSON.stringify({ env: { vars: { OPENAI_API_KEY: "${OPENAI_API_KEY}" } } }),
+        "utf8",
+      );
+
+      const rootPath = path.join(tmp, "openclaw.json");
+      const rootParsed = { $include: "./secrets.json" };
+      await fs.writeFile(rootPath, JSON.stringify(rootParsed), "utf8");
+
+      const configSnapshot: ConfigFileSnapshot = {
+        path: rootPath,
+        exists: true,
+        raw: JSON.stringify(rootParsed),
+        parsed: rootParsed,
+        sourceConfig: {} as ConfigFileSnapshot["sourceConfig"],
+        resolved: {} as ConfigFileSnapshot["resolved"],
+        runtimeConfig: {} as ConfigFileSnapshot["runtimeConfig"],
+        config: {} as ConfigFileSnapshot["config"],
+        valid: true,
+        issues: [],
+        warnings: [],
+        legacyIssues: [],
+      };
+
+      const report = await runSecurityAudit({
+        config: {
+          env: {
+            vars: {
+              OPENAI_API_KEY: "sk-resolved-openai-key",
+            },
+          },
+        },
+        sourceConfig: {},
+        configPath: rootPath,
+        configSnapshot,
+        includeFilesystem: false,
+        includeChannelSecurity: false,
+      });
+
+      expect(report.findings.some((f) => f.checkId === "config.secrets.api_key_in_env_vars")).toBe(
+        false,
+      );
+    } finally {
+      await fs.rm(tmp, { recursive: true, force: true });
+    }
   });
 
   it("emits a redacted security audit summary event", async () => {

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -82,17 +82,19 @@ function looksLikePlaintextApiKey(value: string): boolean {
   return /^(sk-|xoxb-|xapp-|ghp_|AKIA)/.test(value.trim());
 }
 
-export function getConfigEnvVarEntries(cfg: OpenClawConfig): Array<{ key: string; value: string }> {
+export function getConfigEnvVarEntries(
+  cfg: OpenClawConfig,
+): Array<{ key: string; value: string; path: "env.vars" | "env" }> {
   const envConfig = cfg.env;
   if (!envConfig || typeof envConfig !== "object") {
     return [];
   }
-  const entries: Array<{ key: string; value: string }> = [];
+  const entries: Array<{ key: string; value: string; path: "env.vars" | "env" }> = [];
   const vars = (envConfig as Record<string, unknown>).vars;
   if (vars && typeof vars === "object") {
     for (const [key, value] of Object.entries(vars)) {
       if (typeof value === "string") {
-        entries.push({ key, value });
+        entries.push({ key, value, path: "env.vars" });
       }
     }
   }
@@ -101,7 +103,7 @@ export function getConfigEnvVarEntries(cfg: OpenClawConfig): Array<{ key: string
       continue;
     }
     if (typeof value === "string") {
-      entries.push({ key, value });
+      entries.push({ key, value, path: "env" });
     }
   }
   return entries;
@@ -607,7 +609,7 @@ export function collectSyncedFolderFindings(params: {
 
 export function collectSecretsInConfigFindings(
   cfg: OpenClawConfig,
-  authoredEnvVarEntries?: Array<{ key: string; value: string }>,
+  authoredEnvVarEntries?: Array<{ key: string; value: string; path: "env.vars" | "env" }>,
 ): SecurityAuditFinding[] {
   const findings: SecurityAuditFinding[] = [];
   const password = normalizeOptionalString(cfg.gateway?.auth?.password) ?? "";
@@ -634,13 +636,13 @@ export function collectSecretsInConfigFindings(
     });
   }
 
-  for (const { key, value } of authoredEnvVarEntries ?? getConfigEnvVarEntries(cfg)) {
+  for (const { key, value, path } of authoredEnvVarEntries ?? getConfigEnvVarEntries(cfg)) {
     if (!looksLikeEnvRef(value) && looksLikePlaintextApiKey(value)) {
       findings.push({
         checkId: "config.secrets.api_key_in_env_vars",
         severity: "warn",
         title: `API key stored in config env var "${key}"`,
-        detail: `env.vars.${key} looks like a plaintext API key; prefer storing secrets in ~/.openclaw/.env or using SecretRefs instead of openclaw.json.`,
+        detail: `${path}.${key} looks like a plaintext API key; prefer storing secrets in ~/.openclaw/.env or using SecretRefs instead of openclaw.json.`,
         remediation: `Move ${key} out of openclaw.json and load it from the process environment or a secrets manager.`,
       });
     }

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -5,6 +5,7 @@ import {
   normalizeStringifiedOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 import { normalizeUniqueStringEntries } from "@openclaw/normalization-core/string-normalization";
+import { pickSandboxToolPolicy } from "../agents/sandbox-tool-policy.js";
 import { resolveSandboxConfigForAgent } from "../agents/sandbox/config.js";
 import { isDangerousNetworkMode, normalizeNetworkMode } from "../agents/sandbox/network-mode.js";
 import { resolveSandboxToolPolicyForAgent } from "../agents/sandbox/tool-policy.js";
@@ -24,7 +25,6 @@ import {
   resolveNodeCommandAllowlist,
 } from "../gateway/node-command-policy.js";
 import { collectAuditModelRefs } from "./audit-model-refs.js";
-import { pickSandboxToolPolicy } from "../agents/sandbox-tool-policy.js";
 
 /**
  * Synchronous security audit collector functions.
@@ -76,6 +76,35 @@ function isProbablySyncedPath(p: string): boolean {
 function looksLikeEnvRef(value: string): boolean {
   const v = value.trim();
   return v.startsWith("${") && v.endsWith("}");
+}
+
+function looksLikePlaintextApiKey(value: string): boolean {
+  return /^(sk-|xoxb-|xapp-|ghp_|AKIA)/.test(value.trim());
+}
+
+export function getConfigEnvVarEntries(cfg: OpenClawConfig): Array<{ key: string; value: string }> {
+  const envConfig = cfg.env;
+  if (!envConfig || typeof envConfig !== "object") {
+    return [];
+  }
+  const entries: Array<{ key: string; value: string }> = [];
+  const vars = (envConfig as Record<string, unknown>).vars;
+  if (vars && typeof vars === "object") {
+    for (const [key, value] of Object.entries(vars)) {
+      if (typeof value === "string") {
+        entries.push({ key, value });
+      }
+    }
+  }
+  for (const [key, value] of Object.entries(envConfig)) {
+    if (key === "vars" || key === "shellEnv") {
+      continue;
+    }
+    if (typeof value === "string") {
+      entries.push({ key, value });
+    }
+  }
+  return entries;
 }
 
 function isGatewayRemotelyExposed(cfg: OpenClawConfig): boolean {
@@ -576,7 +605,10 @@ export function collectSyncedFolderFindings(params: {
   return findings;
 }
 
-export function collectSecretsInConfigFindings(cfg: OpenClawConfig): SecurityAuditFinding[] {
+export function collectSecretsInConfigFindings(
+  cfg: OpenClawConfig,
+  authoredEnvVarEntries?: Array<{ key: string; value: string }>,
+): SecurityAuditFinding[] {
   const findings: SecurityAuditFinding[] = [];
   const password = normalizeOptionalString(cfg.gateway?.auth?.password) ?? "";
   if (password && !looksLikeEnvRef(password)) {
@@ -600,6 +632,18 @@ export function collectSecretsInConfigFindings(cfg: OpenClawConfig): SecurityAud
       detail:
         "hooks.token is set in the config file; keep config perms tight and treat it like an API secret.",
     });
+  }
+
+  for (const { key, value } of authoredEnvVarEntries ?? getConfigEnvVarEntries(cfg)) {
+    if (!looksLikeEnvRef(value) && looksLikePlaintextApiKey(value)) {
+      findings.push({
+        checkId: "config.secrets.api_key_in_env_vars",
+        severity: "warn",
+        title: `API key stored in config env var "${key}"`,
+        detail: `env.vars.${key} looks like a plaintext API key; prefer storing secrets in ~/.openclaw/.env or using SecretRefs instead of openclaw.json.`,
+        remediation: `Move ${key} out of openclaw.json and load it from the process environment or a secrets manager.`,
+      });
+    }
   }
 
   return findings;

--- a/src/security/audit-plugin-readonly-scope.test.ts
+++ b/src/security/audit-plugin-readonly-scope.test.ts
@@ -44,8 +44,8 @@ function createAuditContext(params: {
     plugins: params.plugins,
     loadPluginSecurityCollectors: true,
     configSnapshot: null,
-    codeSafetySummaryCache: new Map<string, Promise<unknown>>(),
     authoredEnvVarEntries: [],
+    codeSafetySummaryCache: new Map<string, Promise<unknown>>(),
   };
 }
 

--- a/src/security/audit-plugin-readonly-scope.test.ts
+++ b/src/security/audit-plugin-readonly-scope.test.ts
@@ -45,6 +45,7 @@ function createAuditContext(params: {
     loadPluginSecurityCollectors: true,
     configSnapshot: null,
     codeSafetySummaryCache: new Map<string, Promise<unknown>>(),
+    authoredEnvVarEntries: [],
   };
 }
 

--- a/src/security/audit.nondeep.runtime.ts
+++ b/src/security/audit.nondeep.runtime.ts
@@ -18,6 +18,7 @@ export {
   collectSandboxDockerNoopFindings,
   collectSecretsInConfigFindings,
   collectSyncedFolderFindings,
+  getConfigEnvVarEntries,
 } from "./audit-extra.sync.js";
 
 export {

--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -146,7 +146,7 @@ export type AuditExecutionContext = {
   deepProbeAuth?: SecurityAuditExplicitGatewayAuth;
   auditGatewayAuthOverride?: SecurityAuditGatewayAuthOverride;
   workspaceDir?: string;
-  authoredEnvVarEntries: Array<{ key: string; value: string }>;
+  authoredEnvVarEntries: Array<{ key: string; value: string; path: "env.vars" | "env" }>;
 };
 
 let readOnlyChannelPluginsModulePromise:
@@ -1384,7 +1384,11 @@ async function createAuditExecutionContext(
         ? await readConfigSnapshotForAudit({ env, configPath }).catch(() => null)
         : null;
 
-  const authoredEnvVarEntries = ((): Array<{ key: string; value: string }> => {
+  const authoredEnvVarEntries = ((): Array<{
+    key: string;
+    value: string;
+    path: "env.vars" | "env";
+  }> => {
     if (
       configSnapshot?.exists &&
       configSnapshot.parsed &&
@@ -1402,9 +1406,8 @@ async function createAuditExecutionContext(
         // Include resolution failed; fall back to sourceConfig entries.
       }
     }
-    return getConfigEnvVarEntries(sourceConfig).length > 0
-      ? getConfigEnvVarEntries(sourceConfig)
-      : getConfigEnvVarEntries(cfg);
+    const sourceEntries = getConfigEnvVarEntries(sourceConfig);
+    return sourceEntries.length > 0 ? sourceEntries : getConfigEnvVarEntries(cfg);
   })();
 
   return {

--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -13,7 +13,8 @@ import { resolveExecDefaults } from "../agents/exec-defaults.js";
 import { resolveSandboxConfigForAgent } from "../agents/sandbox/config.js";
 import type { ChannelPlugin } from "../channels/plugins/types.plugin.js";
 import type { ConfigFileSnapshot, OpenClawConfig } from "../config/config.js";
-import { resolveConfigPath, resolveStateDir } from "../config/paths.js";
+import { resolveConfigIncludes } from "../config/includes.js";
+import { resolveConfigPath, resolveIncludeRoots, resolveStateDir } from "../config/paths.js";
 import type { CliBackendConfig } from "../config/types.agent-defaults.js";
 import type { GatewayAuthConfig } from "../config/types.gateway.js";
 import type { SecurityAuditSuppression } from "../config/types.openclaw.js";
@@ -145,6 +146,7 @@ export type AuditExecutionContext = {
   deepProbeAuth?: SecurityAuditExplicitGatewayAuth;
   auditGatewayAuthOverride?: SecurityAuditGatewayAuthOverride;
   workspaceDir?: string;
+  authoredEnvVarEntries: Array<{ key: string; value: string }>;
 };
 
 let readOnlyChannelPluginsModulePromise:
@@ -1374,12 +1376,37 @@ async function createAuditExecutionContext(
   const configPath = opts.configPath ?? resolveConfigPath(env, stateDir);
   const workspaceDir =
     opts.workspaceDir ?? resolveAgentWorkspaceDir(cfg, resolveDefaultAgentId(cfg));
-  const { readConfigSnapshotForAudit } = await loadAuditNonDeepModule();
-  const configSnapshot = includeFilesystem
-    ? opts.configSnapshot !== undefined
+  const { readConfigSnapshotForAudit, getConfigEnvVarEntries } = await loadAuditNonDeepModule();
+  const configSnapshot =
+    opts.configSnapshot !== undefined
       ? opts.configSnapshot
-      : await readConfigSnapshotForAudit({ env, configPath }).catch(() => null)
-    : null;
+      : includeFilesystem
+        ? await readConfigSnapshotForAudit({ env, configPath }).catch(() => null)
+        : null;
+
+  const authoredEnvVarEntries = ((): Array<{ key: string; value: string }> => {
+    if (
+      configSnapshot?.exists &&
+      configSnapshot.parsed &&
+      typeof configSnapshot.parsed === "object"
+    ) {
+      try {
+        const resolvedIncludes = resolveConfigIncludes(
+          configSnapshot.parsed,
+          configPath,
+          undefined,
+          { allowedRoots: resolveIncludeRoots(env) },
+        );
+        return getConfigEnvVarEntries(resolvedIncludes as OpenClawConfig);
+      } catch {
+        // Include resolution failed; fall back to sourceConfig entries.
+      }
+    }
+    return getConfigEnvVarEntries(sourceConfig).length > 0
+      ? getConfigEnvVarEntries(sourceConfig)
+      : getConfigEnvVarEntries(cfg);
+  })();
+
   return {
     cfg,
     sourceConfig,
@@ -1401,6 +1428,7 @@ async function createAuditExecutionContext(
     codeSafetySummaryCache: opts.codeSafetySummaryCache ?? new Map<string, Promise<unknown>>(),
     deepProbeAuth: opts.deepProbeAuth,
     auditGatewayAuthOverride: opts.auditGatewayAuthOverride,
+    authoredEnvVarEntries,
   };
 }
 
@@ -1445,7 +1473,7 @@ export async function runSecurityAudit(opts: SecurityAuditOptions): Promise<Secu
   findings.push(...auditNonDeep.collectNodeDenyCommandPatternFindings(cfg));
   findings.push(...auditNonDeep.collectNodeDangerousAllowCommandFindings(cfg));
   findings.push(...auditNonDeep.collectMinimalProfileOverrideFindings(cfg));
-  findings.push(...auditNonDeep.collectSecretsInConfigFindings(cfg));
+  findings.push(...auditNonDeep.collectSecretsInConfigFindings(cfg, context.authoredEnvVarEntries));
   findings.push(...auditNonDeep.collectModelHygieneFindings(cfg));
   findings.push(...auditNonDeep.collectSmallModelRiskFindings({ cfg, env }));
   findings.push(...auditNonDeep.collectExposureMatrixFindings(cfg));


### PR DESCRIPTION
Related: #96489

## What Problem This Solves

Fixes an issue where operators could store provider API keys and channel tokens as plaintext inside `openclaw.json`'s `env.vars` block without any warning, increasing the risk of accidental exposure through backups, cloud sync, or version control.

## Why This Change Was Made

Adds a bounded security audit finding (`config.secrets.api_key_in_env_vars`) that warns when token-shaped string values are detected in `config.env.vars` or direct string entries under `config.env`. The detection skips `${VAR}` references so that env-var indirection is not flagged. This addresses remediation item #2 from the issue without changing config loading behavior or adding new startup permission checks.

## User Impact

Operators running `openclaw security audit` now receive a clear `warn`-level finding for plaintext API keys in `env.vars`, with guidance to move the secret to `~/.openclaw/.env` or use SecretRefs. Existing configs that use `${VAR}` references remain unaffected.

## Evidence

- Unit test: `pnpm test src/security/audit-config-basics.test.ts --run` passes (9/9).
- CLI proof (`openclaw security audit --json`) against four config cases:
  1. Plaintext API keys in `env.vars` → 4 `config.secrets.api_key_in_env_vars` warnings.
  2. `${VAR}` references in `env.vars` → no findings.
  3. Direct string entry under `env` (legacy sugar) → 1 warning.
  4. Benign values in `env.vars` → no findings.