### PR TITLE
fix(sandbox): support configurable containerWorkdir for OpenShell media paths

### DIFF
--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -358,6 +358,7 @@ export function createOpenClawTools(
         hasRepliedRef: options?.hasRepliedRef,
         sameChannelThreadRequired: options?.sameChannelThreadRequired,
         sandboxRoot: options?.sandboxRoot,
+        sandboxContainerWorkdir: options?.sandboxContainerWorkdir,
         requireExplicitTarget: options?.requireExplicitMessageTarget,
         sourceReplyDeliveryMode: options?.sourceReplyDeliveryMode,
         inboundEventKind: options?.inboundEventKind,

--- a/src/agents/sandbox-paths.test.ts
+++ b/src/agents/sandbox-paths.test.ts
@@ -201,46 +201,72 @@ describe("resolveSandboxedMediaSource", () => {
     });
   });
 
-  it("maps container paths using custom containerWorkdir into sandbox root", async () => {
+  it.each([
+    {
+      name: "/sandbox absolute path",
+      media: "/sandbox/output/image.png",
+      containerWorkdir: "/sandbox",
+    },
+    {
+      name: "/sandbox/ absolute path with trailing slash",
+      media: "/sandbox/output/image.png",
+      containerWorkdir: "/sandbox/",
+    },
+    {
+      name: "file:///sandbox URL",
+      media: "file:///sandbox/output/image.png",
+      containerWorkdir: "/sandbox",
+    },
+    {
+      name: "file:///sandbox/ URL with trailing slash",
+      media: "file:///sandbox/output/image.png",
+      containerWorkdir: "/sandbox/",
+    },
+  ])("maps $name into sandbox root", async ({ media, containerWorkdir }) => {
     await withSandboxRoot(async (sandboxDir) => {
       const result = await resolveSandboxedMediaSource({
-        media: "/sandbox/output/image.png",
+        media,
         sandboxRoot: sandboxDir,
-        containerWorkdir: "/sandbox",
+        containerWorkdir,
       });
       expect(result).toBe(path.join(sandboxDir, "output", "image.png"));
     });
   });
 
-  it("maps file:// URLs under custom containerWorkdir into sandbox root", async () => {
+  it.each([
+    { name: "/sandbox root", media: "/sandbox", containerWorkdir: "/sandbox" },
+    {
+      name: "/sandbox/ root with trailing slash",
+      media: "/sandbox",
+      containerWorkdir: "/sandbox/",
+    },
+  ])("maps $name to sandbox root", async ({ media, containerWorkdir }) => {
     await withSandboxRoot(async (sandboxDir) => {
       const result = await resolveSandboxedMediaSource({
-        media: "file:///sandbox/output/image.png",
+        media,
         sandboxRoot: sandboxDir,
-        containerWorkdir: "/sandbox",
-      });
-      expect(result).toBe(path.join(sandboxDir, "output", "image.png"));
-    });
-  });
-
-  it("maps container root path with custom containerWorkdir", async () => {
-    await withSandboxRoot(async (sandboxDir) => {
-      const result = await resolveSandboxedMediaSource({
-        media: "/sandbox",
-        sandboxRoot: sandboxDir,
-        containerWorkdir: "/sandbox",
+        containerWorkdir,
       });
       expect(result).toBe(sandboxDir);
     });
   });
 
-  it("does not map paths under similarly named custom containerWorkdir roots", async () => {
+  it.each([
+    {
+      name: "/sandboxer prefix",
+      containerWorkdir: "/sandbox",
+    },
+    {
+      name: "/sandboxer prefix with trailing-slash workdir",
+      containerWorkdir: "/sandbox/",
+    },
+  ])("rejects $name as outside sandbox", async ({ containerWorkdir }) => {
     await withSandboxRoot(async (sandboxDir) => {
       await expect(
         resolveSandboxedMediaSource({
           media: "/sandboxer/secret",
           sandboxRoot: sandboxDir,
-          containerWorkdir: "/sandbox",
+          containerWorkdir,
         }),
       ).rejects.toThrow(/sandbox/i);
     });

--- a/src/agents/sandbox-paths.test.ts
+++ b/src/agents/sandbox-paths.test.ts
@@ -201,6 +201,51 @@ describe("resolveSandboxedMediaSource", () => {
     });
   });
 
+  it("maps container paths using custom containerWorkdir into sandbox root", async () => {
+    await withSandboxRoot(async (sandboxDir) => {
+      const result = await resolveSandboxedMediaSource({
+        media: "/sandbox/output/image.png",
+        sandboxRoot: sandboxDir,
+        containerWorkdir: "/sandbox",
+      });
+      expect(result).toBe(path.join(sandboxDir, "output", "image.png"));
+    });
+  });
+
+  it("maps file:// URLs under custom containerWorkdir into sandbox root", async () => {
+    await withSandboxRoot(async (sandboxDir) => {
+      const result = await resolveSandboxedMediaSource({
+        media: "file:///sandbox/output/image.png",
+        sandboxRoot: sandboxDir,
+        containerWorkdir: "/sandbox",
+      });
+      expect(result).toBe(path.join(sandboxDir, "output", "image.png"));
+    });
+  });
+
+  it("maps container root path with custom containerWorkdir", async () => {
+    await withSandboxRoot(async (sandboxDir) => {
+      const result = await resolveSandboxedMediaSource({
+        media: "/sandbox",
+        sandboxRoot: sandboxDir,
+        containerWorkdir: "/sandbox",
+      });
+      expect(result).toBe(sandboxDir);
+    });
+  });
+
+  it("does not map paths under similarly named custom containerWorkdir roots", async () => {
+    await withSandboxRoot(async (sandboxDir) => {
+      await expect(
+        resolveSandboxedMediaSource({
+          media: "/sandboxer/secret",
+          sandboxRoot: sandboxDir,
+          containerWorkdir: "/sandbox",
+        }),
+      ).rejects.toThrow(/sandbox/i);
+    });
+  });
+
   it("preserves remote mxc:// media sources", async () => {
     await withSandboxRoot(async (sandboxDir) => {
       const result = await resolveSandboxedMediaSource({

--- a/src/agents/sandbox-paths.ts
+++ b/src/agents/sandbox-paths.ts
@@ -162,11 +162,13 @@ export async function resolveSandboxedMediaSource(params: {
     return raw;
   }
   let candidate = raw;
+  const containerWorkdir =
+    (params.containerWorkdir ?? SANDBOX_CONTAINER_WORKDIR).replace(/\/+$/, "") || "/";
   if (/^file:\/\//i.test(candidate)) {
     const workspaceMappedFromUrl = mapContainerWorkspaceFileUrl({
       fileUrl: candidate,
       sandboxRoot: params.sandboxRoot,
-      containerWorkdir: params.containerWorkdir,
+      containerWorkdir,
     });
     if (workspaceMappedFromUrl) {
       candidate = workspaceMappedFromUrl;
@@ -183,7 +185,7 @@ export async function resolveSandboxedMediaSource(params: {
   const containerWorkspaceMapped = mapContainerWorkspacePath({
     candidate,
     sandboxRoot: params.sandboxRoot,
-    containerWorkdir: params.containerWorkdir,
+    containerWorkdir,
   });
   if (containerWorkspaceMapped) {
     candidate = containerWorkspaceMapped;
@@ -220,14 +222,14 @@ async function assertNoManagedMediaAliasEscape(params: {
 }
 
 function isContainerWorkspacePath(normalizedPath: string, containerWorkdir?: string): boolean {
-  const workdir = containerWorkdir ?? SANDBOX_CONTAINER_WORKDIR;
+  const workdir = (containerWorkdir ?? SANDBOX_CONTAINER_WORKDIR).replace(/\/+$/, "") || "/";
   return normalizedPath === workdir || normalizedPath.startsWith(`${workdir}/`);
 }
 
 function mapContainerWorkspaceFileUrl(params: {
   fileUrl: string;
   sandboxRoot: string;
-  containerWorkdir?: string;
+  containerWorkdir: string;
 }): string | undefined {
   let parsed: URL;
   try {
@@ -266,10 +268,10 @@ function mapContainerWorkspaceFileUrl(params: {
 function mapContainerWorkspacePath(params: {
   candidate: string;
   sandboxRoot: string;
-  containerWorkdir?: string;
+  containerWorkdir: string;
 }): string | undefined {
   const normalized = params.candidate.replace(/\\/g, "/");
-  const workdir = params.containerWorkdir ?? SANDBOX_CONTAINER_WORKDIR;
+  const workdir = params.containerWorkdir;
   if (normalized === workdir) {
     return path.resolve(params.sandboxRoot);
   }

--- a/src/agents/sandbox-paths.ts
+++ b/src/agents/sandbox-paths.ts
@@ -151,6 +151,8 @@ export async function resolveAllowedManagedMediaPath(
 export async function resolveSandboxedMediaSource(params: {
   media: string;
   sandboxRoot: string;
+  /** Container-side workspace dir (e.g. "/workspace" for Docker, "/sandbox" for OpenShell). */
+  containerWorkdir?: string;
 }): Promise<string> {
   const raw = params.media.trim();
   if (!raw) {
@@ -164,6 +166,7 @@ export async function resolveSandboxedMediaSource(params: {
     const workspaceMappedFromUrl = mapContainerWorkspaceFileUrl({
       fileUrl: candidate,
       sandboxRoot: params.sandboxRoot,
+      containerWorkdir: params.containerWorkdir,
     });
     if (workspaceMappedFromUrl) {
       candidate = workspaceMappedFromUrl;
@@ -180,6 +183,7 @@ export async function resolveSandboxedMediaSource(params: {
   const containerWorkspaceMapped = mapContainerWorkspacePath({
     candidate,
     sandboxRoot: params.sandboxRoot,
+    containerWorkdir: params.containerWorkdir,
   });
   if (containerWorkspaceMapped) {
     candidate = containerWorkspaceMapped;
@@ -215,9 +219,15 @@ async function assertNoManagedMediaAliasEscape(params: {
   });
 }
 
+function isContainerWorkspacePath(normalizedPath: string, containerWorkdir?: string): boolean {
+  const workdir = containerWorkdir ?? SANDBOX_CONTAINER_WORKDIR;
+  return normalizedPath === workdir || normalizedPath.startsWith(`${workdir}/`);
+}
+
 function mapContainerWorkspaceFileUrl(params: {
   fileUrl: string;
   sandboxRoot: string;
+  containerWorkdir?: string;
 }): string | undefined {
   let parsed: URL;
   try {
@@ -235,35 +245,35 @@ function mapContainerWorkspaceFileUrl(params: {
   if (hasEncodedFileUrlSeparator(parsed.pathname)) {
     return undefined;
   }
-  // Sandbox paths are Linux-style (/workspace/*). Parse the URL path directly so
-  // Windows hosts can still accept file:///workspace/... media references.
+  // Sandbox paths are Linux-style (/workspace/*, /sandbox/*, etc.). Parse the URL
+  // path directly so Windows hosts can still accept container file:// URLs.
   let normalizedPathname: string;
   try {
     normalizedPathname = decodeURIComponent(parsed.pathname).replace(/\\/g, "/");
   } catch {
     return undefined;
   }
-  if (
-    normalizedPathname !== SANDBOX_CONTAINER_WORKDIR &&
-    !normalizedPathname.startsWith(`${SANDBOX_CONTAINER_WORKDIR}/`)
-  ) {
+  if (!isContainerWorkspacePath(normalizedPathname, params.containerWorkdir)) {
     return undefined;
   }
   return mapContainerWorkspacePath({
     candidate: normalizedPathname,
     sandboxRoot: params.sandboxRoot,
+    containerWorkdir: params.containerWorkdir,
   });
 }
 
 function mapContainerWorkspacePath(params: {
   candidate: string;
   sandboxRoot: string;
+  containerWorkdir?: string;
 }): string | undefined {
   const normalized = params.candidate.replace(/\\/g, "/");
-  if (normalized === SANDBOX_CONTAINER_WORKDIR) {
+  const workdir = params.containerWorkdir ?? SANDBOX_CONTAINER_WORKDIR;
+  if (normalized === workdir) {
     return path.resolve(params.sandboxRoot);
   }
-  const prefix = `${SANDBOX_CONTAINER_WORKDIR}/`;
+  const prefix = `${workdir}/`;
   if (!normalized.startsWith(prefix)) {
     return undefined;
   }

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -888,6 +888,7 @@ type MessageToolOptions = {
   hasRepliedRef?: { value: boolean };
   sameChannelThreadRequired?: boolean;
   sandboxRoot?: string;
+  sandboxContainerWorkdir?: string;
   requireExplicitTarget?: boolean;
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
   inboundEventKind?: InboundEventKind;
@@ -1497,6 +1498,7 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
           sessionId: options?.sessionId,
           agentId: resolvedAgentId,
           sandboxRoot: options?.sandboxRoot,
+          sandboxContainerWorkdir: options?.sandboxContainerWorkdir,
           sourceReplyDeliveryMode: sourceReplySinkDeliveryMode,
           inboundEventKind: options?.inboundEventKind,
           inboundAudio: options?.currentInboundAudio,

--- a/src/auto-reply/reply/reply-media-paths.test.ts
+++ b/src/auto-reply/reply/reply-media-paths.test.ts
@@ -179,6 +179,37 @@ describe("createReplyMediaPathNormalizer", () => {
     );
   });
 
+  it("maps OpenShell /sandbox container paths using configured containerWorkdir", async () => {
+    ensureSandboxWorkspaceForSession.mockResolvedValue({
+      workspaceDir: "/tmp/sandboxes/session-1",
+      containerWorkdir: "/sandbox",
+    });
+    const normalize = createReplyMediaPathNormalizer({
+      cfg: {},
+      sessionKey: "session-key",
+      workspaceDir: "/tmp/agent-workspace",
+    });
+
+    const result = await normalize({
+      mediaUrls: ["file:///sandbox/output/photo.png", "/sandbox/output/video.png"],
+    });
+
+    expectMedia(result, "/tmp/outbound-media/photo.png", [
+      "/tmp/outbound-media/photo.png",
+      "/tmp/outbound-media/video.png",
+    ]);
+    expectOutboundAttachmentCall(
+      0,
+      path.join("/tmp/sandboxes/session-1", "output", "photo.png"),
+      5 * 1024 * 1024,
+    );
+    expectOutboundAttachmentCall(
+      1,
+      path.join("/tmp/sandboxes/session-1", "output", "video.png"),
+      5 * 1024 * 1024,
+    );
+  });
+
   it("drops sandbox-mapped media when staging fails instead of retrying the workspace fallback", async () => {
     ensureSandboxWorkspaceForSession.mockResolvedValue({
       workspaceDir: "/tmp/sandboxes/session-1",

--- a/src/auto-reply/reply/reply-media-paths.ts
+++ b/src/auto-reply/reply/reply-media-paths.ts
@@ -82,18 +82,27 @@ export function createReplyMediaPathNormalizer(params: {
     channel: params.messageProvider,
     accountId: params.accountId,
   });
-  let sandboxRootPromise: Promise<string | undefined> | undefined;
+  let sandboxInfoPromise:
+    | Promise<{ workspaceDir?: string; containerWorkdir?: string } | null>
+    | undefined;
   const persistedMediaBySource = new Map<string, Promise<string>>();
 
-  const resolveSandboxRoot = async (): Promise<string | undefined> => {
-    if (!sandboxRootPromise) {
-      sandboxRootPromise = ensureSandboxWorkspaceForSession({
+  const resolveSandboxInfo = async (): Promise<{
+    workspaceDir?: string;
+    containerWorkdir?: string;
+  } | null> => {
+    if (!sandboxInfoPromise) {
+      sandboxInfoPromise = ensureSandboxWorkspaceForSession({
         config: params.cfg,
         sessionKey: params.sessionKey,
         workspaceDir: params.workspaceDir,
-      }).then((sandbox) => sandbox?.workspaceDir);
+      }).then((sandbox) =>
+        sandbox
+          ? { workspaceDir: sandbox.workspaceDir, containerWorkdir: sandbox.containerWorkdir }
+          : null,
+      );
     }
-    return await sandboxRootPromise;
+    return await sandboxInfoPromise;
   };
 
   const resolveMediaAccessForSource = (media: string) =>
@@ -175,13 +184,14 @@ export function createReplyMediaPathNormalizer(params: {
       !media.startsWith("~") &&
       !path.isAbsolute(media) &&
       !WINDOWS_DRIVE_RE.test(media);
-    const sandboxRoot = await resolveSandboxRoot();
-    if (sandboxRoot) {
+    const sandboxInfo = await resolveSandboxInfo();
+    if (sandboxInfo?.workspaceDir) {
       let sandboxResolvedMedia: string;
       try {
         sandboxResolvedMedia = await resolveSandboxedMediaSource({
           media,
-          sandboxRoot,
+          sandboxRoot: sandboxInfo.workspaceDir,
+          containerWorkdir: sandboxInfo.containerWorkdir,
         });
       } catch (err) {
         if (FILE_URL_RE.test(media)) {

--- a/src/infra/outbound/message-action-params.test.ts
+++ b/src/infra/outbound/message-action-params.test.ts
@@ -4,6 +4,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanupTempDirs, makeTempDir } from "../../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { MEDIA_MAX_BYTES } from "../../media/store.js";
 
@@ -201,8 +202,9 @@ describe("message action media helpers", () => {
   maybeIt(
     "normalizes OpenShell /sandbox media params using configured containerWorkdir",
     async () => {
-      const sandboxRoot = await fs.mkdtemp(path.join(os.tmpdir(), "msg-params-openshell-"));
+      const tempDirs: string[] = [];
       try {
+        const sandboxRoot = makeTempDir(tempDirs, "msg-params-openshell-");
         const args: Record<string, unknown> = {
           mediaUrl: " file:///sandbox/output/photo.png ",
           fileUrl: "/sandbox/output/report.pdf",
@@ -220,7 +222,7 @@ describe("message action media helpers", () => {
         expect(args.mediaUrl).toBe(path.join(sandboxRoot, "output", "photo.png"));
         expect(args.fileUrl).toBe(path.join(sandboxRoot, "output", "report.pdf"));
       } finally {
-        await fs.rm(sandboxRoot, { recursive: true, force: true });
+        cleanupTempDirs(tempDirs);
       }
     },
   );

--- a/src/infra/outbound/message-action-params.test.ts
+++ b/src/infra/outbound/message-action-params.test.ts
@@ -135,6 +135,19 @@ describe("message action media helpers", () => {
     });
   });
 
+  it("carries containerWorkdir through sandbox media policy", () => {
+    expect(
+      resolveAttachmentMediaPolicy({
+        sandboxRoot: "/tmp/workspace",
+        containerWorkdir: "/sandbox",
+      }),
+    ).toEqual({
+      mode: "sandbox",
+      sandboxRoot: "/tmp/workspace",
+      containerWorkdir: "/sandbox",
+    });
+  });
+
   maybeIt("normalizes sandbox media lists and dedupes resolved workspace paths", async () => {
     const sandboxRoot = await fs.mkdtemp(path.join(os.tmpdir(), "msg-params-list-"));
     try {
@@ -184,6 +197,33 @@ describe("message action media helpers", () => {
       await fs.rm(sandboxRoot, { recursive: true, force: true });
     }
   });
+
+  maybeIt(
+    "normalizes OpenShell /sandbox media params using configured containerWorkdir",
+    async () => {
+      const sandboxRoot = await fs.mkdtemp(path.join(os.tmpdir(), "msg-params-openshell-"));
+      try {
+        const args: Record<string, unknown> = {
+          mediaUrl: " file:///sandbox/output/photo.png ",
+          fileUrl: "/sandbox/output/report.pdf",
+        };
+
+        await normalizeSandboxMediaParams({
+          args,
+          mediaPolicy: {
+            mode: "sandbox",
+            sandboxRoot: ` ${sandboxRoot} `,
+            containerWorkdir: "/sandbox",
+          },
+        });
+
+        expect(args.mediaUrl).toBe(path.join(sandboxRoot, "output", "photo.png"));
+        expect(args.fileUrl).toBe(path.join(sandboxRoot, "output", "report.pdf"));
+      } finally {
+        await fs.rm(sandboxRoot, { recursive: true, force: true });
+      }
+    },
+  );
 
   maybeIt("normalizes extension event image sandbox media params", async () => {
     const sandboxRoot = await fs.mkdtemp(path.join(os.tmpdir(), "msg-params-image-"));

--- a/src/infra/outbound/message-action-params.ts
+++ b/src/infra/outbound/message-action-params.ts
@@ -403,6 +403,7 @@ export type AttachmentMediaPolicy =
   | {
       mode: "sandbox";
       sandboxRoot: string;
+      containerWorkdir?: string;
     }
   | {
       mode: "host";
@@ -414,6 +415,7 @@ export type AttachmentMediaPolicy =
 /** Chooses sandbox or host media loading policy for attachment hydration. */
 export function resolveAttachmentMediaPolicy(params: {
   sandboxRoot?: string;
+  containerWorkdir?: string;
   mediaAccess?: OutboundMediaAccess;
   mediaLocalRoots?: readonly string[] | "any";
   mediaReadFile?: OutboundMediaReadFile;
@@ -423,6 +425,7 @@ export function resolveAttachmentMediaPolicy(params: {
     return {
       mode: "sandbox",
       sandboxRoot,
+      ...(params.containerWorkdir ? { containerWorkdir: params.containerWorkdir } : {}),
     };
   }
   const explicitLocalRoots = resolveOutboundMediaLocalRoots(params.mediaLocalRoots);
@@ -552,6 +555,8 @@ export async function normalizeSandboxMediaParams(params: {
 }): Promise<void> {
   const sandboxRoot =
     params.mediaPolicy.mode === "sandbox" ? params.mediaPolicy.sandboxRoot.trim() : undefined;
+  const containerWorkdir =
+    params.mediaPolicy.mode === "sandbox" ? params.mediaPolicy.containerWorkdir : undefined;
   for (const key of buildActionMediaSourceParamKeys(params.extraParamKeys)) {
     const entry = resolveMediaParamEntry(params.args, key);
     if (!entry) {
@@ -561,7 +566,11 @@ export async function normalizeSandboxMediaParams(params: {
     if (!sandboxRoot) {
       continue;
     }
-    const normalized = await resolveSandboxedMediaSource({ media: entry.value, sandboxRoot });
+    const normalized = await resolveSandboxedMediaSource({
+      media: entry.value,
+      sandboxRoot,
+      containerWorkdir,
+    });
     if (normalized !== entry.value) {
       params.args[entry.key] = normalized;
     }
@@ -583,6 +592,7 @@ export async function normalizeSandboxMediaParams(params: {
     const normalized = await resolveSandboxedMediaSource({
       media: attachmentSource.value,
       sandboxRoot,
+      containerWorkdir,
     });
     if (normalized !== attachmentSource.value) {
       attachmentSource.attachment[attachmentSource.key] = normalized;
@@ -594,8 +604,10 @@ export async function normalizeSandboxMediaParams(params: {
 export async function normalizeSandboxMediaList(params: {
   values: string[];
   sandboxRoot?: string;
+  containerWorkdir?: string;
 }): Promise<string[]> {
   const sandboxRoot = params.sandboxRoot?.trim();
+  const containerWorkdir = params.containerWorkdir;
   const normalized: string[] = [];
   const seen = new Set<string>();
   for (const value of params.values) {
@@ -605,7 +617,7 @@ export async function normalizeSandboxMediaList(params: {
     }
     assertMediaNotDataUrl(raw);
     const resolved = sandboxRoot
-      ? await resolveSandboxedMediaSource({ media: raw, sandboxRoot })
+      ? await resolveSandboxedMediaSource({ media: raw, sandboxRoot, containerWorkdir })
       : raw;
     if (seen.has(resolved)) {
       continue;

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -133,6 +133,7 @@ export type RunMessageActionParams = {
   sessionKey?: string;
   agentId?: string;
   sandboxRoot?: string;
+  sandboxContainerWorkdir?: string;
   dryRun?: boolean;
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
   inboundEventKind?: InboundEventKind;
@@ -957,6 +958,7 @@ async function buildSendPayloadParts(params: {
   const normalizedMediaUrls = await normalizeSandboxMediaList({
     values: mergedMediaUrls,
     sandboxRoot: input.sandboxRoot,
+    containerWorkdir: input.sandboxContainerWorkdir,
   });
   mergedMediaUrls.length = 0;
   mergedMediaUrls.push(...normalizedMediaUrls);
@@ -1503,6 +1505,7 @@ export async function runMessageAction(
   const dryRun = Boolean(input.dryRun ?? readBooleanParam(params, "dryRun"));
   const normalizationPolicy = resolveAttachmentMediaPolicy({
     sandboxRoot: input.sandboxRoot,
+    containerWorkdir: input.sandboxContainerWorkdir,
     mediaLocalRoots: getAgentScopedMediaLocalRoots(cfg, resolvedAgentId),
   });
   const extraActionMediaSourceParamKeys = resolveExtraActionMediaSourceParamKeys({
@@ -1542,6 +1545,7 @@ export async function runMessageAction(
   });
   const mediaPolicy = resolveAttachmentMediaPolicy({
     sandboxRoot: input.sandboxRoot,
+    containerWorkdir: input.sandboxContainerWorkdir,
     mediaAccess,
   });
   const gateway = resolveGateway(input);

--- a/src/scripts/test-projects.test.ts
+++ b/src/scripts/test-projects.test.ts
@@ -942,6 +942,12 @@ describe("test-projects args", () => {
         watchMode: false,
       },
       {
+        config: "test/vitest/vitest.infra.config.ts",
+        forwardedArgs: [],
+        includePatterns: ["src/infra/outbound/message-action-params.test.ts"],
+        watchMode: false,
+      },
+      {
         config: "test/vitest/vitest.runtime-config.config.ts",
         forwardedArgs: [],
         includePatterns: ["src/config/sessions/entry-freshness.test.ts"],


### PR DESCRIPTION
## What Problem This Solves

Closes #98446

OpenShell sandboxes use `/sandbox` as the container-side workspace root, but OpenClaw's sandbox media path normalization in `src/agents/sandbox-paths.ts` hardcodes `/workspace`. When an agent running in an OpenShell sandbox generates media under `/sandbox/output/photo.png` and tries to send it out, the path is rejected as escaping the sandbox root because the normalization layer only recognizes `/workspace` paths.

This change threads the sandbox backend's actual `containerWorkdir` (e.g. `/workspace` for Docker, `/sandbox` for OpenShell) through the media normalization chain so container paths are mapped to the host sandbox root correctly.

## Why This Change Was Made

The fix is a minimal parameterization of the existing path mapping helpers:

- `resolveSandboxedMediaSource`, `mapContainerWorkspaceFileUrl`, and `mapContainerWorkspacePath` now accept an optional `containerWorkdir` parameter, defaulting to `/workspace` to preserve existing behavior.
- `containerWorkdir` is normalized once (trailing slashes stripped, `/` preserved) before prefix checks, so OpenShell configs that spell the workdir as `/sandbox/` work the same as `/sandbox`.
- `AttachmentMediaPolicy` carries `containerWorkdir` so the message action and reply media paths can pass the configured workdir down.
- `reply-media-paths.ts` reads `containerWorkdir` from `ensureSandboxWorkspaceForSession`, which already exposes it via the sandbox backend's `workdir`.
- The message tool path (`openclaw-tools.ts` → `message-tool.ts` → `message-action-runner.ts`) forwards the existing `sandboxContainerWorkdir` option that `agent-tools.ts` already supplies.

No OpenShell plugin validation is changed; the plugin's requirement that `remoteWorkspaceDir` stay under `/sandbox` or `/agent` remains intact.

## User Impact

- OpenShell users can now send media files generated inside `/sandbox` workspaces.
- Docker sandbox users see no behavior change; the default container workdir remains `/workspace`.
- Security boundaries are preserved: paths outside the configured container workdir and similarly-named prefixes (e.g. `/sandboxer/secret`) are still rejected.

## Evidence

Unit tests:

```bash
node scripts/run-vitest.mjs src/agents/sandbox-paths.test.ts --run
node scripts/run-vitest.mjs src/infra/outbound/message-action-params.test.ts --run
node scripts/run-vitest.mjs src/auto-reply/reply/reply-media-paths.test.ts --run
node scripts/run-vitest.mjs src/agents/tools/message-tool.test.ts --run
node scripts/run-vitest.mjs src/scripts/test-projects.test.ts --run
```

Results:

- `src/agents/sandbox-paths.test.ts`: 41 passed
- `src/infra/outbound/message-action-params.test.ts`: 34 passed
- `src/auto-reply/reply/reply-media-paths.test.ts`: 23 passed
- `src/agents/tools/message-tool.test.ts`: 113 passed
- `src/scripts/test-projects.test.ts`: 83 passed

Lint: `node scripts/run-oxlint.mjs src/agents/sandbox-paths.ts src/agents/sandbox-paths.test.ts src/infra/outbound/message-action-params.ts src/infra/outbound/message-action-params.test.ts src/infra/outbound/message-action-runner.ts src/agents/tools/message-tool.ts src/agents/openclaw-tools.ts src/auto-reply/reply/reply-media-paths.ts src/auto-reply/reply/reply-media-paths.test.ts src/scripts/test-projects.test.ts` → exit 0.

Typecheck:

- `pnpm tsgo:core` → exit 0
- `pnpm tsgo:core:test` → exit 0

Build: `pnpm build` → exit 0.

## Real behavior proof

**Reproduction of the bug on current `main` source** (no fix applied), driving the real exported `resolveSandboxedMediaSource` against real on-disk state:

```text
sandboxRoot: /tmp/openclaw-proof-98446-XXXXXX/sandbox-root
host photo path: /tmp/openclaw-proof-98446-XXXXXX/sandbox-root/output/photo.png

✅ Docker /workspace file URL
    result: /tmp/.../sandbox-root/output/photo.png

❌ OpenShell /sandbox file URL
    media: file:///sandbox/output/photo.png
    error: Path escapes sandbox root (...): /sandbox/output/photo.png

✅ Absolute /workspace path
    result: /tmp/.../sandbox-root/output/photo.png

❌ Absolute /sandbox path
    media: /sandbox/output/photo.png
    error: Path escapes sandbox root (...): /sandbox/output/photo.png
```

**After this patch** (same standalone script, now passing `containerWorkdir: "/sandbox"` for OpenShell cases):

```text
sandboxRoot: /tmp/openclaw-proof-98446-XXXXXX/sandbox-root
host photo path: /tmp/openclaw-proof-98446-XXXXXX/sandbox-root/output/photo.png

✅ Docker default (/workspace file URL)
    containerWorkdir: <default /workspace>
    result: /tmp/.../sandbox-root/output/photo.png

✅ Docker default (/workspace absolute path)
    containerWorkdir: <default /workspace>
    result: /tmp/.../sandbox-root/output/photo.png

✅ OpenShell (/sandbox file URL with containerWorkdir)
    containerWorkdir: /sandbox
    result: /tmp/.../sandbox-root/output/photo.png

✅ OpenShell (/sandbox/ file URL with trailing-slash containerWorkdir)
    containerWorkdir: /sandbox/
    result: /tmp/.../sandbox-root/output/photo.png

✅ OpenShell (/sandbox absolute path with containerWorkdir)
    containerWorkdir: /sandbox
    result: /tmp/.../sandbox-root/output/photo.png

✅ OpenShell (/sandbox/ absolute path with trailing-slash containerWorkdir)
    containerWorkdir: /sandbox/
    result: /tmp/.../sandbox-root/output/photo.png

✅ Negative control (/sandboxer/secret with containerWorkdir)
    media: /sandboxer/secret
    rejected as expected: Path escapes sandbox root (...): /sandboxer/secret
```

- **Behavior addressed**: sandbox media path normalization now recognizes the configured container workdir (`/sandbox` for OpenShell) instead of only `/workspace`, including the trailing-slash spelling OpenShell preserves.
- **Real environment tested**: Linux, Node v22.19+, local source checkout, real temp directories and files.
- **Exact steps or command run after this patch**:
  - `node --import tsx /tmp/proof-98446.mts`
  - `node scripts/run-vitest.mjs src/agents/sandbox-paths.test.ts --run`
  - `node scripts/run-vitest.mjs src/infra/outbound/message-action-params.test.ts --run`
  - `node scripts/run-vitest.mjs src/auto-reply/reply/reply-media-paths.test.ts --run`
  - `node scripts/run-vitest.mjs src/agents/tools/message-tool.test.ts --run`
  - `node scripts/run-vitest.mjs src/scripts/test-projects.test.ts --run`
- **Evidence after fix**: all repro assertions pass; 211 unit tests pass; lint/typecheck/build pass.
- **Observed result after fix**: `/sandbox/...` media paths from OpenShell sandboxes map to the host sandbox root; `/workspace/...` Docker paths remain unchanged; similarly-named prefix attacks still fail; trailing-slash workdir configs are normalized correctly.
- **What was not tested**: live Kubernetes-deployed OpenShell pod; full Gateway e2e send flow. The proof exercises the same production helper and reply normalizer used by that flow.

## Related issues

- #98446

## AI-assisted

Implemented and proof-tested with AI assistance; reviewed by a human before submission.
