### PR TITLE
fix(openai): bound OAuth token JSON responses to prevent unbounded reads

### DIFF
--- a/extensions/openai/openai-chatgpt-oauth-flow.runtime.ts
+++ b/extensions/openai/openai-chatgpt-oauth-flow.runtime.ts
@@ -10,6 +10,7 @@ import {
   resolveOAuthTokenExpiresAt,
   resolveOAuthTokenLifetimeMs,
 } from "openclaw/plugin-sdk/provider-oauth-runtime";
+import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { resolveCodexAuthIdentity } from "./openai-chatgpt-auth-identity.js";
 import {
@@ -38,6 +39,7 @@ const REDIRECT_URI = resolveRedirectUri(CALLBACK_HOST);
 const MANUAL_PROMPT_FALLBACK_MS = 15_000;
 const TOKEN_REQUEST_TIMEOUT_MS = 30_000;
 const SCOPE = "openid profile email offline_access";
+const OPENAI_OAUTH_TOKEN_JSON_MAX_BYTES = 256 * 1024; // 256 KiB — OAuth token responses are tiny
 
 type TokenSuccess = { type: "success"; access: string; refresh: string; expires: number };
 type TokenFailure = { type: "failed"; message: string; status?: number };
@@ -224,7 +226,19 @@ async function exchangeAuthorizationCode(
     };
   }
 
-  const json = (await response.json()) as TokenResponseJson;
+  let json: TokenResponseJson;
+  try {
+    const bytes = await readResponseWithLimit(response, OPENAI_OAUTH_TOKEN_JSON_MAX_BYTES, {
+      onOverflow: ({ size, maxBytes }) =>
+        new Error(`OpenAI Codex token exchange response exceeds ${maxBytes} bytes (got ${size})`),
+    });
+    json = JSON.parse(new TextDecoder().decode(bytes)) as TokenResponseJson;
+  } catch (cause) {
+    return {
+      type: "failed",
+      message: `OpenAI Codex token exchange failed: ${cause instanceof Error ? cause.message : "malformed response"}`,
+    };
+  }
 
   const expires = resolveOAuthTokenExpiresAt(json.expires_in);
   if (!json.access_token || !json.refresh_token || expires === undefined) {
@@ -266,7 +280,11 @@ async function refreshAccessToken(
       };
     }
 
-    const json = (await response.json()) as TokenResponseJson;
+    const bytes = await readResponseWithLimit(response, OPENAI_OAUTH_TOKEN_JSON_MAX_BYTES, {
+      onOverflow: ({ size, maxBytes }) =>
+        new Error(`OpenAI Codex token refresh response exceeds ${maxBytes} bytes (got ${size})`),
+    });
+    const json = JSON.parse(new TextDecoder().decode(bytes)) as TokenResponseJson;
 
     const expires = resolveOAuthTokenExpiresAt(json.expires_in);
     if (!json.access_token || !json.refresh_token || expires === undefined) {


### PR DESCRIPTION
## What Problem This Solves

Fixes two unbounded `response.json()` calls in the OpenAI Codex OAuth token exchange and refresh paths (`exchangeAuthorizationCode` and `refreshAccessToken`). The OpenAI OAuth token endpoint returns a tiny JSON response (under 1 KiB), but a misconfigured proxy or compromised endpoint could stream an arbitrarily large body and exhaust gateway memory.

## Why This Change Was Made

Read both token responses through the shared `readResponseWithLimit` helper (`openclaw/plugin-sdk/response-limit-runtime`) under a 256 KiB cap. Both call sites use the existing discriminated-union error channel — overflow is converted to `{type: "failed"}` rather than throwing, matching the established pattern for non-ok responses and missing fields.

**Non-goal:** no change to the OAuth flow, PKCE challenge, token validation, or public API.

## Evidence

```
node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-provider-openai.config.ts extensions/openai/openai-chatgpt-oauth-flow.runtime.test.ts

 Test Files  1 passed (1)
      Tests  10 passed (10)
```

`oxlint --quiet` is clean. All 10 existing tests pass unchanged.

## Design

- **exchangeAuthorizationCode** (line 229): bounded read wrapped in try/catch → overflow returns `{type: "failed"}`
- **refreshAccessToken** (line 295): bounded read inside existing outer try/catch → overflow naturally caught → returns `{type: "failed"}`
- 256 KiB cap is ~250× larger than any legitimate OAuth token response

---

AI-assisted (Claude Code).