### PR TITLE
fix(config/sessions): narrow reply-session initialization revision to identity fields

### DIFF
--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -72,13 +72,13 @@ import { parseSoftResetCommand } from "./commands-reset-mode.js";
 import { resolveConversationBindingContextFromMessage } from "./conversation-binding-input.js";
 import { normalizeInboundTextNewlines } from "./inbound-text.js";
 import { stripMentions, stripStructuralPrefixes } from "./mentions.js";
+import { replyRunRegistry } from "./reply-run-registry.js";
 import { isResetAuthorizedForContext } from "./reset-authorization.js";
 import {
   maybeRetireLegacyMainDeliveryRoute,
   resolveLastChannelRaw,
   resolveLastToRaw,
 } from "./session-delivery.js";
-import { replyRunRegistry } from "./reply-run-registry.js";
 import {
   createReplySessionEntryHandle,
   type ReplySessionEntryHandle,
@@ -927,6 +927,7 @@ async function initSessionStateAttemptLocked(
     retiredEntry: retiredLegacyMainDelivery,
     sessionEntry,
     sessionKey,
+    snapshotEntry: initializationSnapshot.currentEntry,
     storePath,
   });
   if (!committed.ok) {

--- a/src/config/sessions/session-accessor.reply-init-concurrency.test.ts
+++ b/src/config/sessions/session-accessor.reply-init-concurrency.test.ts
@@ -1,0 +1,226 @@
+import { spawn } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { pathToFileURL } from "node:url";
+import { describe, expect, it, vi } from "vitest";
+import { loadSessionEntry, updateSessionEntry, upsertSessionEntry } from "./session-accessor.js";
+
+vi.mock("../config.js", async () => ({
+  ...(await vi.importActual<typeof import("../config.js")>("../config.js")),
+  getRuntimeConfig: vi.fn().mockReturnValue({}),
+}));
+
+type ChildResult =
+  | {
+      ok: true;
+      sessionEntry: {
+        sessionFile?: string;
+        sessionId?: string;
+        updatedAt?: number;
+      };
+    }
+  | {
+      currentEntry?: {
+        sessionId?: string;
+        updatedAt?: number;
+      };
+      ok: false;
+      reason: string;
+      revision: string;
+    };
+
+const POLL_MS = 20;
+const WAIT_TIMEOUT_MS = 10_000;
+const SESSION_KEY = "agent:main:main";
+const AGENT_ID = "main";
+
+async function waitForFile(filePath: string): Promise<void> {
+  const deadline = Date.now() + WAIT_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    try {
+      await fs.access(filePath);
+      return;
+    } catch {
+      await new Promise((resolve) => {
+        setTimeout(resolve, POLL_MS);
+      });
+    }
+  }
+  throw new Error(`timeout waiting for ${filePath}`);
+}
+
+async function readJsonFile<T>(filePath: string): Promise<T> {
+  return JSON.parse(await fs.readFile(filePath, "utf8")) as T;
+}
+
+function createReplyInitChildScript(sessionAccessorUrl: string): string {
+  return `
+const fs = await import("node:fs/promises");
+const {
+  commitReplySessionInitialization,
+  loadReplySessionInitializationSnapshot,
+} = await import(${JSON.stringify(sessionAccessorUrl)});
+
+const POLL_MS = ${POLL_MS};
+const WAIT_TIMEOUT_MS = ${WAIT_TIMEOUT_MS};
+const SESSION_KEY = ${JSON.stringify(SESSION_KEY)};
+const AGENT_ID = ${JSON.stringify(AGENT_ID)};
+
+async function waitForFile(filePath) {
+  const deadline = Date.now() + WAIT_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    try {
+      await fs.access(filePath);
+      return;
+    } catch {
+      await new Promise((resolve) => {
+        setTimeout(resolve, POLL_MS);
+      });
+    }
+  }
+  throw new Error(\`timeout waiting for \${filePath}\`);
+}
+
+async function writeJsonFile(filePath, value) {
+  await fs.writeFile(filePath, \`\${JSON.stringify(value, null, 2)}\\n\`, "utf8");
+}
+
+const storePath = process.env.REPLY_INIT_STORE_PATH;
+const readyPath = process.env.REPLY_INIT_READY_PATH;
+const proceedPath = process.env.REPLY_INIT_PROCEED_PATH;
+const resultPath = process.env.REPLY_INIT_RESULT_PATH;
+const preparedUpdatedAt = process.env.REPLY_INIT_PREPARED_UPDATED_AT;
+if (!storePath || !readyPath || !proceedPath || !resultPath || !preparedUpdatedAt) {
+  throw new Error("reply initialization child env is incomplete");
+}
+
+const snapshot = loadReplySessionInitializationSnapshot({
+  sessionKey: SESSION_KEY,
+  storePath,
+});
+await writeJsonFile(readyPath, {
+  currentEntry: snapshot.currentEntry,
+  revision: snapshot.revision,
+});
+
+await waitForFile(proceedPath);
+
+const committed = await commitReplySessionInitialization({
+  activeSessionKey: SESSION_KEY,
+  agentId: AGENT_ID,
+  expectedRevision: snapshot.revision,
+  sessionEntry: {
+    sessionId: "existing-session",
+    updatedAt: Number(preparedUpdatedAt),
+  },
+  sessionKey: SESSION_KEY,
+  snapshotEntry: snapshot.currentEntry,
+  storePath,
+});
+await writeJsonFile(resultPath, committed);
+`;
+}
+
+async function waitForChild(child: ReturnType<typeof spawn>): Promise<void> {
+  let childStdout = "";
+  let childStderr = "";
+  child.stdout?.setEncoding("utf8");
+  child.stderr?.setEncoding("utf8");
+  child.stdout?.on("data", (chunk) => {
+    childStdout += String(chunk);
+  });
+  child.stderr?.on("data", (chunk) => {
+    childStderr += String(chunk);
+  });
+
+  const childExit = await new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
+    (resolve, reject) => {
+      child.once("error", reject);
+      child.once("exit", (code, signal) => resolve({ code, signal }));
+    },
+  );
+  if (childExit.code !== 0) {
+    throw new Error(
+      `reply initialization child failed code=${String(childExit.code)} signal=${String(childExit.signal)}\nstdout:\n${childStdout}\nstderr:\n${childStderr}`,
+    );
+  }
+}
+
+describe("reply session initialization concurrency", () => {
+  it("commits after same-session activity from another process", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-reply-init-"));
+    const sessionAccessorUrl = pathToFileURL(
+      path.resolve("src/config/sessions/session-accessor.ts"),
+    ).href;
+    const storePath = path.join(tempDir, "sessions.json");
+    const readyPath = path.join(tempDir, "snapshot-ready.json");
+    const proceedPath = path.join(tempDir, "proceed");
+    const resultPath = path.join(tempDir, "result.json");
+    const baseTime = Date.now();
+    const activeTurnUpdatedAt = baseTime + 20;
+    const preparedUpdatedAt = baseTime + 30;
+
+    try {
+      await upsertSessionEntry(
+        { sessionKey: SESSION_KEY, storePath },
+        {
+          sessionId: "existing-session",
+          updatedAt: baseTime,
+        },
+      );
+
+      const child = spawn(
+        process.execPath,
+        [
+          "--import",
+          "tsx",
+          "--input-type=module",
+          "--eval",
+          createReplyInitChildScript(sessionAccessorUrl),
+        ],
+        {
+          env: {
+            ...process.env,
+            REPLY_INIT_PREPARED_UPDATED_AT: String(preparedUpdatedAt),
+            REPLY_INIT_PROCEED_PATH: proceedPath,
+            REPLY_INIT_READY_PATH: readyPath,
+            REPLY_INIT_RESULT_PATH: resultPath,
+            REPLY_INIT_STORE_PATH: storePath,
+          },
+          stdio: ["ignore", "pipe", "pipe"],
+        },
+      );
+
+      await waitForFile(readyPath);
+      const snapshot = await readJsonFile<{ currentEntry?: unknown; revision: string }>(readyPath);
+      expect(snapshot.revision).toBe(JSON.stringify({ sessionId: "existing-session" }));
+
+      await updateSessionEntry(
+        { sessionKey: SESSION_KEY, storePath },
+        () => ({ updatedAt: activeTurnUpdatedAt }),
+        { skipMaintenance: true },
+      );
+      await fs.writeFile(proceedPath, "go\n", "utf8");
+      await waitForChild(child);
+
+      const result = await readJsonFile<ChildResult>(resultPath);
+      expect(result).toMatchObject({
+        ok: true,
+        sessionEntry: {
+          sessionId: "existing-session",
+          updatedAt: preparedUpdatedAt,
+        },
+      });
+      expect(
+        loadSessionEntry({ readConsistency: "latest", sessionKey: SESSION_KEY, storePath }),
+      ).toMatchObject({
+        sessionId: "existing-session",
+        updatedAt: preparedUpdatedAt,
+      });
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  }, 15_000);
+});

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -534,6 +534,53 @@ describe("session accessor file-backed seam", () => {
     });
   });
 
+  it("commits reply session initialization despite non-identity metadata changes", async () => {
+    const sessionKey = "agent:main:main";
+    await upsertSessionEntry(
+      { sessionKey, storePath },
+      {
+        sessionId: "existing-session",
+        updatedAt: 10,
+        lastHeartbeatSentAt: 100,
+        contextBudgetStatus: "ok",
+      },
+    );
+
+    const snapshot = loadReplySessionInitializationSnapshot({ sessionKey, storePath });
+
+    // Background activity (heartbeat runner, delivery retry, etc.) can touch
+    // metadata fields without rotating the session. The initialization guard
+    // should only care about session identity, so this must not conflict.
+    await upsertSessionEntry(
+      { sessionKey, storePath },
+      {
+        sessionId: "existing-session",
+        updatedAt: 20,
+        lastHeartbeatSentAt: 200,
+        contextBudgetStatus: "warning",
+      },
+    );
+
+    const committed = await commitReplySessionInitialization({
+      activeSessionKey: sessionKey,
+      agentId: "main",
+      expectedRevision: snapshot.revision,
+      previousEntry: snapshot.currentEntry,
+      sessionEntry: {
+        sessionId: "existing-session",
+        updatedAt: 30,
+      },
+      sessionKey,
+      storePath,
+    });
+
+    expect(committed.ok).toBe(true);
+    if (!committed.ok) {
+      throw new Error("expected reply session initialization to commit");
+    }
+    expect(committed.sessionEntry.sessionId).toBe("existing-session");
+  });
+
   it("commits reply session initialization despite runtime-only skill snapshot cache", async () => {
     const sessionKey = "agent:main:main";
     await upsertSessionEntry(

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -542,7 +542,7 @@ describe("session accessor file-backed seam", () => {
         sessionId: "existing-session",
         updatedAt: 10,
         lastHeartbeatSentAt: 100,
-        contextBudgetStatus: "ok",
+        lastHeartbeatText: "heartbeat-1",
       },
     );
 
@@ -557,7 +557,7 @@ describe("session accessor file-backed seam", () => {
         sessionId: "existing-session",
         updatedAt: 20,
         lastHeartbeatSentAt: 200,
-        contextBudgetStatus: "warning",
+        lastHeartbeatText: "heartbeat-2",
       },
     );
 
@@ -579,6 +579,15 @@ describe("session accessor file-backed seam", () => {
       throw new Error("expected reply session initialization to commit");
     }
     expect(committed.sessionEntry.sessionId).toBe("existing-session");
+    // The accepted commit must not roll back the metadata drift that happened
+    // while the initialization was in flight.
+    expect(committed.sessionEntry.lastHeartbeatSentAt).toBe(200);
+    expect(committed.sessionEntry.lastHeartbeatText).toBe("heartbeat-2");
+    expect(loadSessionEntry({ sessionKey, storePath })).toMatchObject({
+      sessionId: "existing-session",
+      lastHeartbeatSentAt: 200,
+      lastHeartbeatText: "heartbeat-2",
+    });
   });
 
   it("commits reply session initialization despite runtime-only skill snapshot cache", async () => {

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -534,7 +534,7 @@ describe("session accessor file-backed seam", () => {
     });
   });
 
-  it("rejects stale reply session initialization when decision metadata changes", async () => {
+  it("commits reply session initialization despite active-turn metadata changes", async () => {
     const sessionKey = "agent:main:main";
     await upsertSessionEntry(
       { sessionKey, storePath },
@@ -544,16 +544,16 @@ describe("session accessor file-backed seam", () => {
       },
     );
     const snapshot = loadReplySessionInitializationSnapshot({ sessionKey, storePath });
-    let concurrentUpdatedAt = 0;
     await sessionStore.updateSessionStore(storePath, (store) => {
       const current = store[sessionKey];
       if (!current) {
         throw new Error("expected existing session entry");
       }
-      concurrentUpdatedAt = current.updatedAt + 1;
       store[sessionKey] = {
         ...current,
-        updatedAt: concurrentUpdatedAt,
+        compactionCount: 1,
+        totalTokensFresh: false,
+        updatedAt: current.updatedAt + 1,
       };
     });
 
@@ -570,13 +570,21 @@ describe("session accessor file-backed seam", () => {
       storePath,
     });
 
-    expect(committed).toMatchObject({
-      ok: false,
-      reason: "stale-snapshot",
+    expect(committed.ok).toBe(true);
+    if (!committed.ok) {
+      throw new Error("expected reply session initialization to commit");
+    }
+    expect(committed.sessionEntry).toMatchObject({
+      compactionCount: 1,
+      sessionId: "existing-session",
+      totalTokensFresh: false,
+      updatedAt: 30,
     });
     expect(loadSessionEntry({ sessionKey, storePath })).toMatchObject({
+      compactionCount: 1,
       sessionId: "existing-session",
-      updatedAt: concurrentUpdatedAt,
+      totalTokensFresh: false,
+      updatedAt: 30,
     });
   });
 
@@ -640,6 +648,63 @@ describe("session accessor file-backed seam", () => {
       sessionId: "existing-session",
       lastHeartbeatSentAt: 200,
       lastHeartbeatText: "heartbeat-2",
+    });
+  });
+
+  it("preserves concurrent optional additions when prepared fields are undefined", async () => {
+    const sessionKey = "agent:main:main";
+    await upsertSessionEntry(
+      { sessionKey, storePath },
+      {
+        sessionId: "existing-session",
+        updatedAt: 10,
+      },
+    );
+
+    const snapshot = loadReplySessionInitializationSnapshot({ sessionKey, storePath });
+
+    await sessionStore.updateSessionStore(storePath, (store) => {
+      const current = store[sessionKey];
+      if (!current) {
+        throw new Error("expected existing session entry");
+      }
+      store[sessionKey] = {
+        ...current,
+        modelOverride: "channel-model",
+        modelOverrideSource: "user",
+      };
+    });
+
+    const committed = await commitReplySessionInitialization({
+      activeSessionKey: sessionKey,
+      agentId: "main",
+      expectedRevision: snapshot.revision,
+      sessionEntry: {
+        sessionId: "existing-session",
+        updatedAt: 30,
+        modelOverride: undefined,
+        modelOverrideSource: undefined,
+      },
+      sessionKey,
+      snapshotEntry: snapshot.currentEntry,
+      storePath,
+    });
+
+    expect(committed.ok).toBe(true);
+    if (!committed.ok) {
+      throw new Error("expected reply session initialization to commit");
+    }
+    expect(committed.sessionEntry).toMatchObject({
+      modelOverride: "channel-model",
+      modelOverrideSource: "user",
+      sessionId: "existing-session",
+      updatedAt: 30,
+    });
+    expect(loadSessionEntry({ sessionKey, storePath })).toMatchObject({
+      modelOverride: "channel-model",
+      modelOverrideSource: "user",
+      sessionId: "existing-session",
+      updatedAt: 30,
     });
   });
 

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -534,6 +534,52 @@ describe("session accessor file-backed seam", () => {
     });
   });
 
+  it("rejects stale reply session initialization when decision metadata changes", async () => {
+    const sessionKey = "agent:main:main";
+    await upsertSessionEntry(
+      { sessionKey, storePath },
+      {
+        sessionId: "existing-session",
+        updatedAt: 10,
+      },
+    );
+    const snapshot = loadReplySessionInitializationSnapshot({ sessionKey, storePath });
+    let concurrentUpdatedAt = 0;
+    await sessionStore.updateSessionStore(storePath, (store) => {
+      const current = store[sessionKey];
+      if (!current) {
+        throw new Error("expected existing session entry");
+      }
+      concurrentUpdatedAt = current.updatedAt + 1;
+      store[sessionKey] = {
+        ...current,
+        updatedAt: concurrentUpdatedAt,
+      };
+    });
+
+    const committed = await commitReplySessionInitialization({
+      activeSessionKey: sessionKey,
+      agentId: "main",
+      expectedRevision: snapshot.revision,
+      sessionEntry: {
+        sessionId: "existing-session",
+        updatedAt: 30,
+      },
+      sessionKey,
+      snapshotEntry: snapshot.currentEntry,
+      storePath,
+    });
+
+    expect(committed).toMatchObject({
+      ok: false,
+      reason: "stale-snapshot",
+    });
+    expect(loadSessionEntry({ sessionKey, storePath })).toMatchObject({
+      sessionId: "existing-session",
+      updatedAt: concurrentUpdatedAt,
+    });
+  });
+
   it("commits reply session initialization despite non-identity metadata changes", async () => {
     const sessionKey = "agent:main:main";
     await upsertSessionEntry(
@@ -551,21 +597,22 @@ describe("session accessor file-backed seam", () => {
     // Background activity (heartbeat runner, delivery retry, etc.) can touch
     // metadata fields without rotating the session. The initialization guard
     // should only care about session identity, so this must not conflict.
-    await upsertSessionEntry(
-      { sessionKey, storePath },
-      {
-        sessionId: "existing-session",
-        updatedAt: 20,
+    await sessionStore.updateSessionStore(storePath, (store) => {
+      const current = store[sessionKey];
+      if (!current) {
+        throw new Error("expected existing session entry");
+      }
+      store[sessionKey] = {
+        ...current,
         lastHeartbeatSentAt: 200,
         lastHeartbeatText: "heartbeat-2",
-      },
-    );
+      };
+    });
 
     const committed = await commitReplySessionInitialization({
       activeSessionKey: sessionKey,
       agentId: "main",
       expectedRevision: snapshot.revision,
-      previousEntry: snapshot.currentEntry,
       // The real caller builds the prepared entry from the snapshot, so it
       // inherits the pre-drift heartbeat values. The commit must still notice
       // the concurrent metadata change and preserve the newer values.
@@ -576,6 +623,7 @@ describe("session accessor file-backed seam", () => {
         lastHeartbeatText: "heartbeat-1",
       },
       sessionKey,
+      snapshotEntry: snapshot.currentEntry,
       storePath,
     });
 
@@ -593,6 +641,144 @@ describe("session accessor file-backed seam", () => {
       lastHeartbeatSentAt: 200,
       lastHeartbeatText: "heartbeat-2",
     });
+  });
+
+  it("does not restore pending final delivery metadata cleared after the snapshot", async () => {
+    const sessionKey = "agent:main:main";
+    await upsertSessionEntry(
+      { sessionKey, storePath },
+      {
+        sessionId: "existing-session",
+        updatedAt: 10,
+        pendingFinalDelivery: true,
+        pendingFinalDeliveryText: "durable reply",
+        pendingFinalDeliveryCreatedAt: 11,
+        pendingFinalDeliveryLastAttemptAt: 12,
+        pendingFinalDeliveryAttemptCount: 2,
+        pendingFinalDeliveryLastError: "previous failure",
+        pendingFinalDeliveryContext: { channel: "discord", to: "channel-1" },
+        pendingFinalDeliveryIntentId: "intent-1",
+      },
+    );
+
+    const snapshot = loadReplySessionInitializationSnapshot({ sessionKey, storePath });
+    if (!snapshot.currentEntry) {
+      throw new Error("expected reply session initialization snapshot");
+    }
+
+    await sessionStore.updateSessionStore(storePath, (store) => {
+      const current = store[sessionKey];
+      if (!current) {
+        throw new Error("expected existing session entry");
+      }
+      store[sessionKey] = {
+        ...current,
+        pendingFinalDelivery: undefined,
+        pendingFinalDeliveryText: undefined,
+        pendingFinalDeliveryCreatedAt: undefined,
+        pendingFinalDeliveryLastAttemptAt: undefined,
+        pendingFinalDeliveryAttemptCount: undefined,
+        pendingFinalDeliveryLastError: undefined,
+        pendingFinalDeliveryContext: undefined,
+        pendingFinalDeliveryIntentId: undefined,
+      };
+    });
+
+    const committed = await commitReplySessionInitialization({
+      activeSessionKey: sessionKey,
+      agentId: "main",
+      expectedRevision: snapshot.revision,
+      sessionEntry: {
+        ...snapshot.currentEntry,
+        updatedAt: 30,
+      },
+      sessionKey,
+      snapshotEntry: snapshot.currentEntry,
+      storePath,
+    });
+
+    expect(committed.ok).toBe(true);
+    if (!committed.ok) {
+      throw new Error("expected reply session initialization to commit");
+    }
+    expect(committed.sessionEntry.pendingFinalDelivery).toBeUndefined();
+    expect(committed.sessionEntry.pendingFinalDeliveryText).toBeUndefined();
+    expect(committed.sessionEntry.pendingFinalDeliveryCreatedAt).toBeUndefined();
+    expect(committed.sessionEntry.pendingFinalDeliveryLastAttemptAt).toBeUndefined();
+    expect(committed.sessionEntry.pendingFinalDeliveryAttemptCount).toBeUndefined();
+    expect(committed.sessionEntry.pendingFinalDeliveryLastError).toBeUndefined();
+    expect(committed.sessionEntry.pendingFinalDeliveryContext).toBeUndefined();
+    expect(committed.sessionEntry.pendingFinalDeliveryIntentId).toBeUndefined();
+
+    const persisted = loadSessionEntry({ sessionKey, storePath });
+    expect(persisted?.pendingFinalDelivery).toBeUndefined();
+    expect(persisted?.pendingFinalDeliveryText).toBeUndefined();
+    expect(persisted?.pendingFinalDeliveryCreatedAt).toBeUndefined();
+    expect(persisted?.pendingFinalDeliveryLastAttemptAt).toBeUndefined();
+    expect(persisted?.pendingFinalDeliveryAttemptCount).toBeUndefined();
+    expect(persisted?.pendingFinalDeliveryLastError).toBeUndefined();
+    expect(persisted?.pendingFinalDeliveryContext).toBeUndefined();
+    expect(persisted?.pendingFinalDeliveryIntentId).toBeUndefined();
+  });
+
+  it("does not merge old-session delivery metadata into a rotated session", async () => {
+    const sessionKey = "agent:main:main";
+    await upsertSessionEntry(
+      { sessionKey, storePath },
+      {
+        sessionId: "old-session",
+        updatedAt: 10,
+      },
+    );
+
+    const snapshot = loadReplySessionInitializationSnapshot({ sessionKey, storePath });
+
+    await sessionStore.updateSessionStore(storePath, (store) => {
+      const current = store[sessionKey];
+      if (!current) {
+        throw new Error("expected existing session entry");
+      }
+      store[sessionKey] = {
+        ...current,
+        pendingFinalDelivery: true,
+        pendingFinalDeliveryText: "old reply",
+        pendingFinalDeliveryCreatedAt: 21,
+        pendingFinalDeliveryContext: { channel: "discord", to: "channel-1" },
+        pendingFinalDeliveryIntentId: "intent-old",
+      };
+    });
+
+    const committed = await commitReplySessionInitialization({
+      activeSessionKey: sessionKey,
+      agentId: "main",
+      expectedRevision: snapshot.revision,
+      sessionEntry: {
+        sessionId: "new-session",
+        updatedAt: 30,
+      },
+      sessionKey,
+      snapshotEntry: snapshot.currentEntry,
+      storePath,
+    });
+
+    expect(committed.ok).toBe(true);
+    if (!committed.ok) {
+      throw new Error("expected reply session initialization to commit");
+    }
+    expect(committed.sessionEntry.sessionId).toBe("new-session");
+    expect(committed.sessionEntry.pendingFinalDelivery).toBeUndefined();
+    expect(committed.sessionEntry.pendingFinalDeliveryText).toBeUndefined();
+    expect(committed.sessionEntry.pendingFinalDeliveryCreatedAt).toBeUndefined();
+    expect(committed.sessionEntry.pendingFinalDeliveryContext).toBeUndefined();
+    expect(committed.sessionEntry.pendingFinalDeliveryIntentId).toBeUndefined();
+
+    const persisted = loadSessionEntry({ sessionKey, storePath });
+    expect(persisted?.sessionId).toBe("new-session");
+    expect(persisted?.pendingFinalDelivery).toBeUndefined();
+    expect(persisted?.pendingFinalDeliveryText).toBeUndefined();
+    expect(persisted?.pendingFinalDeliveryCreatedAt).toBeUndefined();
+    expect(persisted?.pendingFinalDeliveryContext).toBeUndefined();
+    expect(persisted?.pendingFinalDeliveryIntentId).toBeUndefined();
   });
 
   it("commits reply session initialization despite runtime-only skill snapshot cache", async () => {

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -566,9 +566,14 @@ describe("session accessor file-backed seam", () => {
       agentId: "main",
       expectedRevision: snapshot.revision,
       previousEntry: snapshot.currentEntry,
+      // The real caller builds the prepared entry from the snapshot, so it
+      // inherits the pre-drift heartbeat values. The commit must still notice
+      // the concurrent metadata change and preserve the newer values.
       sessionEntry: {
         sessionId: "existing-session",
         updatedAt: 30,
+        lastHeartbeatSentAt: 100,
+        lastHeartbeatText: "heartbeat-1",
       },
       sessionKey,
       storePath,

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -99,7 +99,7 @@ import {
   resolveOwnedSessionTranscriptWriteLockRunner,
   withOwnedSessionTranscriptWrites,
 } from "./transcript-write-context.js";
-import { mergeSessionEntry, type SessionCompactionCheckpoint, type SessionEntry } from "./types.js";
+import type { SessionCompactionCheckpoint, SessionEntry } from "./types.js";
 
 /**
  * Session access API for callers that need entries or transcripts without
@@ -1155,6 +1155,32 @@ function cloneSessionEntries(store: Record<string, SessionEntry>): Record<string
   );
 }
 
+// Background activity can mutate non-identity fields after the initialization
+// snapshot. Carry forward only those changes; the prepared entry still wins for
+// any field it explicitly modified relative to the snapshot. This preserves
+// heartbeat/delivery/context metadata without resurrecting fields that a reset
+// intentionally cleared (e.g. provider/model overrides on /new).
+function mergeConcurrentReplySessionMetadata(params: {
+  currentEntry: SessionEntry;
+  preparedEntry: SessionEntry;
+  snapshotEntry?: SessionEntry;
+}): SessionEntry {
+  const { currentEntry, preparedEntry, snapshotEntry } = params;
+  if (!snapshotEntry) {
+    return preparedEntry;
+  }
+  const merged = { ...preparedEntry } as Record<string, unknown>;
+  for (const key of Object.keys(currentEntry)) {
+    const currentValue = (currentEntry as Record<string, unknown>)[key];
+    const snapshotValue = (snapshotEntry as Record<string, unknown>)[key];
+    const preparedValue = merged[key];
+    if (currentValue !== snapshotValue && preparedValue === snapshotValue) {
+      merged[key] = currentValue;
+    }
+  }
+  return merged as SessionEntry;
+}
+
 function createReplySessionInitializationRevision(params: {
   entry: SessionEntry | undefined;
   storePath: string;
@@ -1788,12 +1814,16 @@ export async function commitReplySessionInitialization(params: {
         storePath: params.storePath,
       });
       // The identity-only guard allows commits when background activity touched
-      // non-identity metadata after the snapshot. Merge the current row so that
-      // heartbeat, delivery, context-budget, and route fields are not rolled
-      // back by the prepared turn entry; the prepared entry still wins for any
-      // fields it explicitly carries.
+      // non-identity metadata after the snapshot. Merge only the fields that
+      // actually changed since the snapshot so heartbeat/delivery/context
+      // metadata is not rolled back, while reset-cleared fields (e.g. provider
+      // or model overrides on /new) stay cleared.
       store[resolved.normalizedKey] = currentEntry
-        ? mergeSessionEntry(currentEntry, sessionEntry)
+        ? mergeConcurrentReplySessionMetadata({
+            currentEntry,
+            preparedEntry: sessionEntry,
+            snapshotEntry: params.previousEntry,
+          })
         : sessionEntry;
       if (params.retiredEntry) {
         store[params.retiredEntry.key] = params.retiredEntry.entry;

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -1174,20 +1174,28 @@ function sessionEntryFieldEqual(
   return Object.is(left, right) || isDeepStrictEqual(left, right);
 }
 
-const replySessionInitializationSafeMetadataKeys = [
-  "lastHeartbeatText",
-  "lastHeartbeatSentAt",
-  "pendingFinalDelivery",
-  "pendingFinalDeliveryCreatedAt",
-  "pendingFinalDeliveryLastAttemptAt",
-  "pendingFinalDeliveryAttemptCount",
-  "pendingFinalDeliveryLastError",
-  "pendingFinalDeliveryText",
-  "pendingFinalDeliveryContext",
-  "pendingFinalDeliveryIntentId",
-  "restartRecoveryDeliveryContext",
-  "restartRecoveryDeliveryRunId",
-] satisfies Array<keyof SessionEntry>;
+function sessionEntryFieldUnset(
+  hasValue: boolean,
+  value: SessionEntry[keyof SessionEntry],
+): boolean {
+  return !hasValue || value === undefined;
+}
+
+function sessionEntryFieldUnchanged(params: {
+  leftHasValue: boolean;
+  leftValue: SessionEntry[keyof SessionEntry];
+  rightHasValue: boolean;
+  rightValue: SessionEntry[keyof SessionEntry];
+}): boolean {
+  const { leftHasValue, leftValue, rightHasValue, rightValue } = params;
+  if (
+    sessionEntryFieldUnset(leftHasValue, leftValue) &&
+    sessionEntryFieldUnset(rightHasValue, rightValue)
+  ) {
+    return true;
+  }
+  return leftHasValue === rightHasValue && sessionEntryFieldEqual(leftValue, rightValue);
+}
 
 // Background activity can mutate non-identity fields after the initialization
 // snapshot. Carry forward only same-session changes; the prepared entry still
@@ -1214,10 +1222,18 @@ function mergeConcurrentReplySessionMetadata(params: {
     const currentValue = currentEntry[key];
     const snapshotValue = snapshotEntry[key];
     const preparedValue = preparedEntry[key];
-    const currentChanged =
-      currentHasValue !== snapshotHasValue || !sessionEntryFieldEqual(currentValue, snapshotValue);
-    const preparedKeptSnapshot =
-      preparedHasValue === snapshotHasValue && sessionEntryFieldEqual(preparedValue, snapshotValue);
+    const currentChanged = !sessionEntryFieldUnchanged({
+      leftHasValue: currentHasValue,
+      leftValue: currentValue,
+      rightHasValue: snapshotHasValue,
+      rightValue: snapshotValue,
+    });
+    const preparedKeptSnapshot = sessionEntryFieldUnchanged({
+      leftHasValue: preparedHasValue,
+      leftValue: preparedValue,
+      rightHasValue: snapshotHasValue,
+      rightValue: snapshotValue,
+    });
     if (currentChanged && preparedKeptSnapshot) {
       if (currentHasValue) {
         mergedFields[key] = currentValue;
@@ -1237,12 +1253,15 @@ function createReplySessionInitializationRevision(params: {
   if (!entry) {
     return JSON.stringify(null);
   }
-  // Compare decision-affecting persisted fields, while ignoring background
-  // delivery/heartbeat bookkeeping that the commit merge carries forward.
+  // The guard only rejects a true session-identity rebind. Same-session
+  // activity/context writes are merged below; comparing them here would reject
+  // before the merge can preserve the concurrent metadata.
   const projected = projectSessionEntryForPersistenceRevision({ storePath, entry });
-  const revisionEntry: SessionEntry = { ...projected };
-  for (const key of replySessionInitializationSafeMetadataKeys) {
-    delete revisionEntry[key];
+  const revisionEntry: Pick<SessionEntry, "sessionFile" | "sessionId"> = {
+    sessionId: projected.sessionId,
+  };
+  if (projected.sessionFile !== undefined) {
+    revisionEntry.sessionFile = projected.sessionFile;
   }
   return JSON.stringify(revisionEntry);
 }

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -99,7 +99,7 @@ import {
   resolveOwnedSessionTranscriptWriteLockRunner,
   withOwnedSessionTranscriptWrites,
 } from "./transcript-write-context.js";
-import type { SessionCompactionCheckpoint, SessionEntry } from "./types.js";
+import { mergeSessionEntry, type SessionCompactionCheckpoint, type SessionEntry } from "./types.js";
 
 /**
  * Session access API for callers that need entries or transcripts without
@@ -1787,7 +1787,14 @@ export async function commitReplySessionInitialization(params: {
         sessionEntry: preparedSessionEntry,
         storePath: params.storePath,
       });
-      store[resolved.normalizedKey] = sessionEntry;
+      // The identity-only guard allows commits when background activity touched
+      // non-identity metadata after the snapshot. Merge the current row so that
+      // heartbeat, delivery, context-budget, and route fields are not rolled
+      // back by the prepared turn entry; the prepared entry still wins for any
+      // fields it explicitly carries.
+      store[resolved.normalizedKey] = currentEntry
+        ? mergeSessionEntry(currentEntry, sessionEntry)
+        : sessionEntry;
       if (params.retiredEntry) {
         store[params.retiredEntry.key] = params.retiredEntry.entry;
       }

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { isDeepStrictEqual } from "node:util";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import {
   acquireSessionWriteLock,
@@ -52,6 +53,7 @@ import {
   patchSessionEntry as patchFileSessionEntry,
   patchSessionEntryWithKey as patchFileSessionEntryWithKey,
   purgeDeletedAgentSessionEntries as purgeFileDeletedAgentSessionEntries,
+  projectSessionEntryForPersistenceRevision,
   readSessionUpdatedAt as readFileSessionUpdatedAt,
   resolveSessionStoreEntry,
   resetSessionEntryLifecycle as resetFileSessionEntryLifecycle,
@@ -1155,45 +1157,94 @@ function cloneSessionEntries(store: Record<string, SessionEntry>): Record<string
   );
 }
 
+function collectSessionEntryKeys(...entries: SessionEntry[]): Array<keyof SessionEntry> {
+  const keys = new Set<keyof SessionEntry>();
+  for (const entry of entries) {
+    for (const key of Object.keys(entry) as Array<keyof SessionEntry>) {
+      keys.add(key);
+    }
+  }
+  return [...keys];
+}
+
+function sessionEntryFieldEqual(
+  left: SessionEntry[keyof SessionEntry],
+  right: SessionEntry[keyof SessionEntry],
+): boolean {
+  return Object.is(left, right) || isDeepStrictEqual(left, right);
+}
+
+const replySessionInitializationSafeMetadataKeys = [
+  "lastHeartbeatText",
+  "lastHeartbeatSentAt",
+  "pendingFinalDelivery",
+  "pendingFinalDeliveryCreatedAt",
+  "pendingFinalDeliveryLastAttemptAt",
+  "pendingFinalDeliveryAttemptCount",
+  "pendingFinalDeliveryLastError",
+  "pendingFinalDeliveryText",
+  "pendingFinalDeliveryContext",
+  "pendingFinalDeliveryIntentId",
+  "restartRecoveryDeliveryContext",
+  "restartRecoveryDeliveryRunId",
+] satisfies Array<keyof SessionEntry>;
+
 // Background activity can mutate non-identity fields after the initialization
-// snapshot. Carry forward only those changes; the prepared entry still wins for
-// any field it explicitly modified relative to the snapshot. This preserves
-// heartbeat/delivery/context metadata without resurrecting fields that a reset
-// intentionally cleared (e.g. provider/model overrides on /new).
+// snapshot. Carry forward only same-session changes; the prepared entry still
+// wins for any field it explicitly modified relative to the snapshot. This
+// preserves heartbeat/delivery/context metadata without resurrecting fields that
+// a reset intentionally cleared or carrying old-session metadata into /new.
 function mergeConcurrentReplySessionMetadata(params: {
   currentEntry: SessionEntry;
   preparedEntry: SessionEntry;
   snapshotEntry?: SessionEntry;
 }): SessionEntry {
   const { currentEntry, preparedEntry, snapshotEntry } = params;
-  if (!snapshotEntry) {
+  if (!snapshotEntry || preparedEntry.sessionId !== snapshotEntry.sessionId) {
     return preparedEntry;
   }
-  const merged = { ...preparedEntry } as Record<string, unknown>;
-  for (const key of Object.keys(currentEntry)) {
-    const currentValue = (currentEntry as Record<string, unknown>)[key];
-    const snapshotValue = (snapshotEntry as Record<string, unknown>)[key];
-    const preparedValue = merged[key];
-    if (currentValue !== snapshotValue && preparedValue === snapshotValue) {
-      merged[key] = currentValue;
+  const merged: SessionEntry = { ...preparedEntry };
+  const mergedFields = merged as Partial<
+    Record<keyof SessionEntry, SessionEntry[keyof SessionEntry]>
+  >;
+  for (const key of collectSessionEntryKeys(currentEntry, preparedEntry, snapshotEntry)) {
+    const currentHasValue = Object.hasOwn(currentEntry, key);
+    const snapshotHasValue = Object.hasOwn(snapshotEntry, key);
+    const preparedHasValue = Object.hasOwn(preparedEntry, key);
+    const currentValue = currentEntry[key];
+    const snapshotValue = snapshotEntry[key];
+    const preparedValue = preparedEntry[key];
+    const currentChanged =
+      currentHasValue !== snapshotHasValue || !sessionEntryFieldEqual(currentValue, snapshotValue);
+    const preparedKeptSnapshot =
+      preparedHasValue === snapshotHasValue && sessionEntryFieldEqual(preparedValue, snapshotValue);
+    if (currentChanged && preparedKeptSnapshot) {
+      if (currentHasValue) {
+        mergedFields[key] = currentValue;
+      } else {
+        delete mergedFields[key];
+      }
     }
   }
-  return merged as SessionEntry;
+  return merged;
 }
 
 function createReplySessionInitializationRevision(params: {
   entry: SessionEntry | undefined;
   storePath: string;
 }): string {
-  void params.storePath;
-  const { entry } = params;
-  // Only session identity matters for the initialization guard. Other persisted
-  // fields (updatedAt, heartbeat/delivery metadata, context budgets, etc.) can
-  // change due to background activity without rotating the session, so comparing
-  // the full entry caused false-positive stale-snapshot conflicts.
-  return JSON.stringify(
-    entry ? { sessionId: entry.sessionId, sessionFile: entry.sessionFile } : null,
-  );
+  const { entry, storePath } = params;
+  if (!entry) {
+    return JSON.stringify(null);
+  }
+  // Compare decision-affecting persisted fields, while ignoring background
+  // delivery/heartbeat bookkeeping that the commit merge carries forward.
+  const projected = projectSessionEntryForPersistenceRevision({ storePath, entry });
+  const revisionEntry: SessionEntry = { ...projected };
+  for (const key of replySessionInitializationSafeMetadataKeys) {
+    delete revisionEntry[key];
+  }
+  return JSON.stringify(revisionEntry);
 }
 
 function resolveInitializedReplySessionEntry(params: {
@@ -1775,6 +1826,7 @@ export async function commitReplySessionInitialization(params: {
   retiredEntry?: SessionEntryRetirement;
   sessionEntry: SessionEntry;
   sessionKey: string;
+  snapshotEntry?: SessionEntry;
   storePath: string;
 }): Promise<ReplySessionInitializationCommitResult> {
   const committed = await updateSessionStore(
@@ -1822,7 +1874,7 @@ export async function commitReplySessionInitialization(params: {
         ? mergeConcurrentReplySessionMetadata({
             currentEntry,
             preparedEntry: sessionEntry,
-            snapshotEntry: params.previousEntry,
+            snapshotEntry: params.snapshotEntry ?? params.previousEntry,
           })
         : sessionEntry;
       if (params.retiredEntry) {

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -52,7 +52,6 @@ import {
   patchSessionEntry as patchFileSessionEntry,
   patchSessionEntryWithKey as patchFileSessionEntryWithKey,
   purgeDeletedAgentSessionEntries as purgeFileDeletedAgentSessionEntries,
-  projectSessionEntryForPersistenceRevision,
   readSessionUpdatedAt as readFileSessionUpdatedAt,
   resolveSessionStoreEntry,
   resetSessionEntryLifecycle as resetFileSessionEntryLifecycle,
@@ -1160,12 +1159,14 @@ function createReplySessionInitializationRevision(params: {
   entry: SessionEntry | undefined;
   storePath: string;
 }): string {
-  const { entry, storePath } = params;
-  // Snapshot reads may see promptRef-only disk entries while commit reads can
-  // see hydrated prompt text and runtime-only resolvedSkills cache entries.
-  // Compare the canonical persisted shape so cache hydration is not a conflict.
+  void params.storePath;
+  const { entry } = params;
+  // Only session identity matters for the initialization guard. Other persisted
+  // fields (updatedAt, heartbeat/delivery metadata, context budgets, etc.) can
+  // change due to background activity without rotating the session, so comparing
+  // the full entry caused false-positive stale-snapshot conflicts.
   return JSON.stringify(
-    entry ? projectSessionEntryForPersistenceRevision({ storePath, entry }) : null,
+    entry ? { sessionId: entry.sessionId, sessionFile: entry.sessionFile } : null,
   );
 }
 

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -52,6 +52,7 @@ import {
   normalizeSessionStore,
   readSessionEntries,
   readSessionEntry,
+  stripPersistedSkillsCache,
 } from "./store-load.js";
 import {
   applyFileBackedSessionStoreMaintenance,
@@ -340,6 +341,18 @@ export type DeletedAgentSessionEntryPurgeParams = {
 
 function cloneSessionEntry(entry: SessionEntry): SessionEntry {
   return cloneSessionStoreRecord({ entry }).entry;
+}
+
+export function projectSessionEntryForPersistenceRevision(params: {
+  storePath: string;
+  entry: SessionEntry;
+}): SessionEntry {
+  const stripped = stripPersistedSkillsCache(params.entry);
+  const projected = projectSessionStoreForPersistence({
+    storePath: params.storePath,
+    store: { entry: stripped },
+  });
+  return projected.store.entry ?? stripped;
 }
 
 export function getSessionEntry(

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -52,7 +52,6 @@ import {
   normalizeSessionStore,
   readSessionEntries,
   readSessionEntry,
-  stripPersistedSkillsCache,
 } from "./store-load.js";
 import {
   applyFileBackedSessionStoreMaintenance,
@@ -341,18 +340,6 @@ export type DeletedAgentSessionEntryPurgeParams = {
 
 function cloneSessionEntry(entry: SessionEntry): SessionEntry {
   return cloneSessionStoreRecord({ entry }).entry;
-}
-
-export function projectSessionEntryForPersistenceRevision(params: {
-  storePath: string;
-  entry: SessionEntry;
-}): SessionEntry {
-  const stripped = stripPersistedSkillsCache(params.entry);
-  const projected = projectSessionStoreForPersistence({
-    storePath: params.storePath,
-    store: { entry: stripped },
-  });
-  return projected.store.entry ?? stripped;
 }
 
 export function getSessionEntry(


### PR DESCRIPTION
## What Problem This Solves

Fixes #98672. Users observed `reply session initialization conflicted for agent:main:main` errors that broke ongoing sessions until the gateway was restarted. The error came from the guarded reply-session initialization path comparing the full persisted session entry between snapshot and commit.

## Why This Change Was Made

The initialization guard only needs to detect whether another initializer rotated the session, meaning `sessionId` or `sessionFile` changed. Comparing the entire entry included volatile fields such as `updatedAt`, heartbeat metadata, pending-delivery metadata, and other fields that can legitimately change while a reply-session initialization is in flight.

The guard is narrowed to the identity fields `sessionId` and `sessionFile`. When that identity-only guard passes, the commit path carries forward metadata that changed since the snapshot via `mergeConcurrentReplySessionMetadata`. Fields the prepared turn entry explicitly modified relative to the snapshot still win, so `/new` and `/reset` continue to clear recovered auto-fallback provider/model overrides, runtime model caches, and context-budget state as before.

The merge also treats an absent field and an own `undefined` field as equivalent when deciding whether the prepared entry left the snapshot unchanged. That prevents incidental optional `undefined` properties from overwriting concurrent same-session additions.

## User Impact

- Sessions no longer fail with `reply session initialization conflicted` when same-session background activity touches metadata during reply initialization.
- Real session rotations are still detected and retried as before.
- Concurrent heartbeat, delivery, context, and optional metadata written after the snapshot is no longer overwritten by the initialization commit.
- Explicit reset clearing behavior (`/new`, `/reset`) is preserved.

## Evidence

### Behavior proof: same-session concurrent metadata write

This branch adds `src/config/sessions/session-accessor.reply-init-concurrency.test.ts`, a deterministic two-process behavior proof for the affected race window:

1. The parent process seeds `agent:main:main` in a real temporary `sessions.json` store.
2. A child Node process loads the real `loadReplySessionInitializationSnapshot` and waits with that snapshot held.
3. The parent process performs a production `updateSessionEntry` write that changes same-session metadata after the snapshot.
4. The child process calls the real `commitReplySessionInitialization` with the held revision and snapshot.
5. The expected fixed behavior is `ok: true`; a `stale-snapshot` result would reproduce the user-visible conflict class.

This is a deterministic multi-process proof at the production session-store/accessor boundary where the conflict is created and resolved.

```text
$ node scripts/run-vitest.mjs src/config/sessions/session-accessor.reply-init-concurrency.test.ts --reporter=verbose

[test] starting test/vitest/vitest.runtime-config.config.ts

 RUN  v4.1.8 /Users/phaedrus/Projects/openclaw/.worktrees/pr-98835-thermonuclear

 ✓ |runtime-config| src/config/sessions/session-accessor.reply-init-concurrency.test.ts > reply session initialization concurrency > commits after same-session activity from another process 1114ms

 Test Files  1 passed (1)
      Tests  1 passed (1)
```

### Local real-gateway proof, not committed

I also verified the same race through an actual spawned OpenClaw gateway process. This was an exploratory local proof only; the temporary test hook and e2e harness were removed and are not part of this PR.

Methodology:

1. Added a temporary VITEST-only pause seam immediately after `loadReplySessionInitializationSnapshot()` in `src/auto-reply/reply/session.ts`.
2. Added a temporary e2e test that starts a real gateway child process with `createOpenClawTestInstance`.
3. Connected to that gateway with the real Gateway WebSocket client.
4. Sent `chat.send` for `agent:main:main`.
5. Paused the gateway child after it loaded the reply-session initialization snapshot.
6. Mutated the same gateway-owned temporary `sessions.json` from the parent process with production `updateSessionEntry`, changing heartbeat metadata after the snapshot.
7. Resumed the gateway and asserted the `chat.send` ACK started successfully, the final session entry preserved the concurrent heartbeat metadata, and gateway logs did not contain `reply session initialization conflicted`.

Proof commands and results:

```text
$ node scripts/run-vitest.mjs test/gateway.reply-session-init.e2e.test.ts

 Test Files  1 passed (1)
      Tests  1 passed (1)
[test] passed 1 Vitest shard in 16.94s

$ node scripts/run-vitest.mjs src/config/sessions/session-accessor.reply-init-concurrency.test.ts src/config/sessions/session-accessor.test.ts test/gateway.reply-session-init.e2e.test.ts

Session accessor shard:
 Test Files  2 passed (2)
      Tests  65 passed (65)

Gateway e2e shard:
 Test Files  1 passed (1)
      Tests  1 passed (1)

[test] passed 2 Vitest shards in 32.12s

$ node scripts/run-oxlint.mjs src/auto-reply/reply/session.ts test/gateway.reply-session-init.e2e.test.ts
Passed.

$ git diff --check
Passed.
```

### Focused regression coverage

```text
$ node scripts/run-vitest.mjs src/config/sessions/session-accessor.test.ts -t 'commits reply session initialization despite active-turn metadata changes|commits reply session initialization despite non-identity metadata changes|preserves concurrent optional additions when prepared fields are undefined|does not restore pending final delivery metadata cleared after the snapshot|does not merge old-session delivery metadata into a rotated session|rejects stale reply session initialization snapshots without writing' --reporter=verbose

 ✓ rejects stale reply session initialization snapshots without writing
 ✓ commits reply session initialization despite active-turn metadata changes
 ✓ commits reply session initialization despite non-identity metadata changes
 ✓ preserves concurrent optional additions when prepared fields are undefined
 ✓ does not restore pending final delivery metadata cleared after the snapshot
 ✓ does not merge old-session delivery metadata into a rotated session

 Test Files  1 passed (1)
      Tests  6 passed | 58 skipped (64)
```

### Local quality gates

```text
$ node_modules/.bin/oxfmt --check src/config/sessions/session-accessor.ts src/config/sessions/session-accessor.test.ts src/config/sessions/session-accessor.reply-init-concurrency.test.ts
Checking formatting...
All matched files use the correct format.

$ node scripts/run-oxlint.mjs src/config/sessions/session-accessor.ts src/config/sessions/session-accessor.test.ts src/config/sessions/session-accessor.reply-init-concurrency.test.ts
Passed.

$ git diff --check
Passed.
```

### Autoreview

Structured autoreview was run against the current branch diff after the optional-`undefined` merge fix:

```text
$ .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main

autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.79)
```

### CI

Current head: `455615bd04a01fbaccc806581139805a91dcb7af`.

`gh pr checks 98835` is green for the active check set. Relevant passing checks include:

- `Real behavior proof`
- `check-session-accessor-boundary`
- `check-test-types`
- `check-lint`
- `check-prod-types`
- `check-dependencies`
- `check-shrinkwrap`
- `QA Smoke CI`
- `build-artifacts`
- `OpenGrep OSS`
- `Security High (core-auth-secrets)`
- `Security High (channel-runtime-boundary)`
- `Security High (network-ssrf-boundary)`
- `Security High (mcp-process-tool-boundary)`
- `Security High (process-exec-boundary)`
- `Security High (plugin-trust-boundary)`
- `Security High (actions)`

PR merge state is `CLEAN` at the current head.
