### PR TITLE
fix(llm): preserve non-array tool result text replay

### DIFF
--- a/src/llm/providers/tool-result-text.test.ts
+++ b/src/llm/providers/tool-result-text.test.ts
@@ -2,6 +2,21 @@ import { describe, expect, it } from "vitest";
 import { describeToolResultMediaPlaceholder, extractToolResultText } from "./tool-result-text.js";
 
 describe("extractToolResultText", () => {
+  it("replays plain string content without dropping it character-by-character", () => {
+    expect(extractToolResultText("plain status output" as never)).toBe("plain status output");
+  });
+
+  it("replays a single structured object as readable fallback text", () => {
+    const textFromOutputField = extractToolResultText({ output: "status card text" } as never);
+    const textFromPayloadObject = extractToolResultText({
+      type: "json",
+      payload: { ok: true },
+    } as never);
+
+    expect(textFromOutputField).toContain("status card text");
+    expect(textFromPayloadObject).toContain('"ok":true');
+  });
+
   it("redacts structured secret fields with the shared tool-payload contract", () => {
     const text = extractToolResultText([
       {

--- a/src/llm/providers/tool-result-text.ts
+++ b/src/llm/providers/tool-result-text.ts
@@ -123,11 +123,23 @@ function truncateProviderToolText(text: string): string {
   return `${truncateUtf16Safe(text, PROVIDER_TOOL_RESULT_MAX_CHARS)}\n…(truncated)…`;
 }
 
-export function describeToolResultMediaPlaceholder(blocks: readonly unknown[]): string | undefined {
+function normalizeToolResultBlocks(blocks: unknown): readonly unknown[] {
+  if (Array.isArray(blocks)) {
+    return blocks;
+  }
+  if (blocks === null || blocks === undefined) {
+    return [];
+  }
+  return [blocks];
+}
+
+export function describeToolResultMediaPlaceholder(
+  blocks: readonly unknown[] | unknown,
+): string | undefined {
   let hasImage = false;
   let hasAudio = false;
 
-  for (const block of blocks) {
+  for (const block of normalizeToolResultBlocks(blocks)) {
     if (!block || typeof block !== "object") {
       continue;
     }
@@ -177,10 +189,14 @@ export function extractToolResultBlockText(block: unknown): string | undefined {
   return structured ? sanitizeSurrogates(truncateProviderToolText(structured)) : undefined;
 }
 
-export function extractToolResultText(blocks: readonly unknown[]): string {
+export function extractToolResultText(blocks: readonly unknown[] | unknown): string {
+  if (typeof blocks === "string") {
+    return sanitizeSurrogates(blocks);
+  }
+
   const explicitTexts: string[] = [];
   const structuredTexts: string[] = [];
-  for (const block of blocks) {
+  for (const block of normalizeToolResultBlocks(blocks)) {
     const text = extractToolResultBlockText(block);
     if (!text) {
       continue;


### PR DESCRIPTION
## Summary
- normalize tool-result inputs before extracting text so replay can handle single objects and other non-array payloads
- preserve plain string tool results instead of iterating them character-by-character and falling back to media placeholders
- add regression coverage for plain-string and single-object tool result replay

Fixes #98825.

## Testing
- npm test -- src/llm/providers/tool-result-text.test.ts
