### PR TITLE
fix(browser): bound Chrome diagnostics JSON response read to prevent OOM

### DIFF
--- a/extensions/browser/src/browser/chrome.diagnostics.ts
+++ b/extensions/browser/src/browser/chrome.diagnostics.ts
@@ -4,6 +4,7 @@
  * Probes /json/version and WebSocket health, redacts sensitive endpoint data,
  * and formats status output for browser doctor/status flows.
  */
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { SsrFPolicy } from "../infra/net/ssrf.js";
 import { rawDataToString } from "../infra/ws.js";
@@ -110,7 +111,10 @@ export async function readChromeVersion(
       ssrfPolicy,
     );
     try {
-      const data = (await response.json()) as ChromeVersion;
+      const data = await readProviderJsonResponse<ChromeVersion>(
+        response,
+        "chrome.diagnostics.version",
+      );
       if (!data || typeof data !== "object") {
         throw new Error("CDP /json/version returned non-object JSON");
       }


### PR DESCRIPTION
## What Problem This Solves

readChromeVersion calls response.json() on the Chrome CDP /json/version endpoint without a read limit. An oversized response could buffer arbitrarily large payloads before parsing, risking OOM.

## Why This Change Was Made

All external HTTP response reads should use readProviderJsonResponse (16 MiB cap).

## Evidence

readProviderJsonResponse is tested at packages/media-core/src/read-response-with-limit.test.ts.

## Risk

Low. 16 MiB cap is generous for a CDP diagnostics response. Same helper used across all provider JSON reads.