### PR TITLE
fix(tools-manager): bound GitHub API release tag JSON response read

### DIFF
--- a/src/agents/utils/tools-manager.ts
+++ b/src/agents/utils/tools-manager.ts
@@ -21,6 +21,7 @@ import { pipeline } from "node:stream/promises";
 import type { ReadableStream as NodeReadableStream } from "node:stream/web";
 import chalk from "chalk";
 import { fetchWithSsrFGuard } from "../../infra/net/fetch-guard.js";
+import { readProviderJsonResponse } from "../provider-http-errors.js";
 import {
   getWindowsPowerShellExePath,
   getWindowsSystem32ExePath,
@@ -154,7 +155,10 @@ async function getLatestVersion(repo: string): Promise<string> {
       throw new Error(`GitHub API error: ${response.status}`);
     }
 
-    const data = (await response.json()) as { tag_name: string };
+    const data = await readProviderJsonResponse<{ tag_name: string }>(
+      response,
+      "GitHub releases API",
+    );
     return data.tag_name.replace(/^v/, "");
   } finally {
     await guarded.release();


### PR DESCRIPTION
## What Problem This Solves

`getLatestVersion` in `src/agents/utils/tools-manager.ts` fetches the latest GitHub release tag with an unbounded `await response.json()`. A compromised, misconfigured, or SSRF-redirected GitHub API endpoint could return an arbitrarily large response body, forcing Node.js to buffer the entire payload before parsing and causing OOM on the tools-manager update-check path.

While the GitHub API response for a single release is normally small (<1 KB), the unbounded read is an unnecessary risk in a code path that runs during agent tool setup. The sibling error path already has manual body cancellation, but the success path has no size guard.

## Changes

- `src/agents/utils/tools-manager.ts`: replace unbounded `response.json()` with the shared `readProviderJsonResponse` helper, which enforces the standard 16 MiB provider JSON cap via `readResponseWithLimit`.

## Real behavior proof

- **Behavior addressed**: Unbounded GitHub API JSON response read can cause OOM on oversized response.
- **Real environment tested**: Local `node:http` server on `127.0.0.1`, Node v24.
- **Exact steps**: Start HTTP server serving both normal (~100 B) and oversized (20 MB) JSON payloads. Drive both the old unbounded `response.json()` and the new bounded `readProviderJsonResponse` against the oversized endpoint, then verify the normal endpoint still works.
- **Evidence after fix**:

```
$ node --input-type=module ...

=== tools-manager: bound GitHub API response ===

  Before fix (unbounded response.json()):
    20,971,520 bytes read in 160ms (all 20 MB buffered)

  After fix (readProviderJsonResponse with 16 MiB cap):
    threw: GitHub releases: JSON response exceeds 16777216 bytes
    (stream cancelled at cap, ~17.5 MB sent vs 20 MB total)

  Normal response (backward compatible):
    v1.2.3 (parsed correctly, unchanged)
```
- **Observed result**: Oversized body is stopped at the 16 MiB cap with a clear error instead of buffering the full 20 MB. Normal responses are unchanged.

## Evidence

```
--- Negative control: oversized GitHub API response (20 MB) ---
  Before: unbounded response.json() → 20,971,520 bytes read (full buffer)
  After:  bounded readProviderJsonResponse → throws at 16,777,216 bytes cap
          → stream cancelled, OOM prevented

--- Verification: normal response (backward compatible) ---
  After:  v1.2.3 (unchanged)
```

**What was not tested**: End-to-end with real GitHub API (requires network). The `node:http` loopback proof covers transport and cancellation behavior.