### PR TITLE
fix(huggingface): bound model discovery JSON response read to prevent OOM

### DIFF
--- a/extensions/huggingface/models.test.ts
+++ b/extensions/huggingface/models.test.ts
@@ -91,6 +91,38 @@ describe("huggingface models", () => {
     expect(timeoutSpy).toHaveBeenCalledWith(25_000);
   });
 
+  it("rejects oversized model discovery responses, cancels the stream, and falls back to static catalog", async () => {
+    process.env.VITEST = "false";
+    process.env.NODE_ENV = "development";
+    stubAbortSignalTimeout();
+    let canceled = false;
+    const ONE_MIB = 1024 * 1024;
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (let i = 0; i < 18; i++) controller.enqueue(new Uint8Array(ONE_MIB));
+        controller.close();
+      },
+      cancel() {
+        canceled = true;
+      },
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(body, {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+      ),
+    );
+
+    const models = await discoverHuggingfaceModels("hf_test_token");
+
+    expect(canceled).toBe(true);
+    expect(models).toHaveLength(HUGGINGFACE_MODEL_CATALOG.length);
+  });
+
   it("caps oversized live discovery timeout overrides", async () => {
     process.env.VITEST = "false";
     process.env.NODE_ENV = "development";

--- a/extensions/huggingface/models.ts
+++ b/extensions/huggingface/models.ts
@@ -1,5 +1,6 @@
 // Huggingface plugin module implements models behavior.
 import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-types";
 import {
   fetchWithSsrFGuard,
@@ -165,7 +166,10 @@ export async function discoverHuggingfaceModels(
         return HUGGINGFACE_MODEL_CATALOG.map(buildHuggingfaceModelDefinition);
       }
 
-      const body = (await response.json()) as OpenAIListModelsResponse;
+      const body = await readProviderJsonResponse<OpenAIListModelsResponse>(
+        response,
+        "huggingface.modelDiscovery",
+      );
       const data = body?.data;
       if (!Array.isArray(data) || data.length === 0) {
         return HUGGINGFACE_MODEL_CATALOG.map(buildHuggingfaceModelDefinition);


### PR DESCRIPTION
## What Problem This Solves

`discoverHuggingfaceModels` uses unbounded `response.json()` when fetching from `router.huggingface.co/v1/models`. A large or malicious response could cause OOM.

## Fix

Replace with `readProviderJsonResponse` (16 MiB cap). Oversized responses are stream-cancelled and fall back to the built-in static catalog.

## Test Evidence

```
extensions/huggingface/models.test.ts — 10 passed
Includes oversized response test: 18 MiB stream triggers cap, verifies cancel, falls back to static catalog.
```

## Files
| File | Change |
|------|--------|
| extensions/huggingface/models.ts | readProviderJsonResponse (16 MiB) |
| extensions/huggingface/models.test.ts | Oversized response rejection test |

🤖 Generated with [Claude Code](https://claude.com/claude-code)