### PR TITLE
fix(tools-manager): bound GitHub release API JSON response read to prevent OOM

### DIFF
--- a/src/agents/utils/tools-manager.test.ts
+++ b/src/agents/utils/tools-manager.test.ts
@@ -183,3 +183,32 @@ describe("getToolPath exit-status handling", () => {
     expect(getToolPath("fd")).toBe("fd");
   });
 });
+
+describe("ensureTool GitHub release response bounding", () => {
+  it("rejects oversized GitHub release API responses and returns undefined", async () => {
+    const ONE_MIB = 1024 * 1024;
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array(ONE_MIB));
+        controller.close();
+      },
+    });
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: new Response(body, {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+      release: vi.fn(),
+    });
+    spawnSyncMock.mockReturnValue({
+      error: new Error("not found"),
+      status: 1,
+      stderr: Buffer.alloc(0),
+      stdout: Buffer.alloc(0),
+    });
+
+    const { ensureTool } = await import("./tools-manager.js");
+    const result = await ensureTool("fd");
+    expect(result).toBeUndefined();
+  });
+});

--- a/src/agents/utils/tools-manager.ts
+++ b/src/agents/utils/tools-manager.ts
@@ -19,6 +19,7 @@ import { join } from "node:path";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import type { ReadableStream as NodeReadableStream } from "node:stream/web";
+import { readResponseWithLimit } from "@openclaw/media-core/read-response-with-limit";
 import chalk from "chalk";
 import { fetchWithSsrFGuard } from "../../infra/net/fetch-guard.js";
 import {
@@ -30,6 +31,7 @@ import { APP_NAME, getBinDir } from "../config.js";
 const TOOLS_DIR = getBinDir();
 const NETWORK_TIMEOUT_MS = 10_000;
 const DOWNLOAD_TIMEOUT_MS = 120_000;
+const TOOLS_MANAGER_RESPONSE_MAX_BYTES = 512 * 1024;
 
 async function cancelUnreadResponseBody(response: Response): Promise<void> {
   if (!response.bodyUsed) {
@@ -154,7 +156,11 @@ async function getLatestVersion(repo: string): Promise<string> {
       throw new Error(`GitHub API error: ${response.status}`);
     }
 
-    const data = (await response.json()) as { tag_name: string };
+    const bytes = await readResponseWithLimit(response, TOOLS_MANAGER_RESPONSE_MAX_BYTES, {
+      onOverflow: ({ maxBytes }) =>
+        new Error(`tools-manager GitHub release response exceeds ${maxBytes} bytes`),
+    });
+    const data = JSON.parse(new TextDecoder().decode(bytes)) as { tag_name: string };
     return data.tag_name.replace(/^v/, "");
   } finally {
     await guarded.release();


### PR DESCRIPTION
## What Problem This Solves

`getLatestVersion` in tools-manager uses unbounded `response.json()` for GitHub releases API responses, creating OOM risk.

## Fix

Replace with `readResponseWithLimit` (512 KiB cap). Oversized responses return undefined gracefully.

## Test Evidence

```
src/agents/utils/tools-manager.test.ts — 6 passed
Includes oversized response test: 1 MiB stream triggers cap, returns undefined.
```

## Files
| File | Change |
|------|--------|
| src/agents/utils/tools-manager.ts | readResponseWithLimit (512 KiB) |
| src/agents/utils/tools-manager.test.ts | Oversized response rejection test |

🤖 Generated with [Claude Code](https://claude.com/claude-code)