### PR TITLE
fix(proxy-capture): make path-based session cleanup atomic

### DIFF
--- a/src/proxy-capture/store.sqlite.test.ts
+++ b/src/proxy-capture/store.sqlite.test.ts
@@ -1,6 +1,7 @@
 // Proxy capture SQLite store tests cover persisted capture reads and writes.
 import fs from "node:fs";
 import path from "node:path";
+import { constants } from "node:sqlite";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 import { resolveSqliteDatabaseFilePaths } from "../infra/sqlite-files.js";
@@ -160,6 +161,66 @@ describe("DebugProxyCaptureStore", () => {
     lease.release();
     expect(lease.store.isClosed).toBe(true);
   });
+
+  it.each(["deleteSessions", "purgeAll"] as const)(
+    "rolls back path-based %s when session deletion fails",
+    (operation) => {
+      const root = makeTempDir(cleanupDirs, "openclaw-proxy-capture-rollback-");
+      const dbPath = path.join(root, "capture.sqlite");
+      const blobDir = path.join(root, "blobs");
+      const lease = acquireDebugProxyCaptureStore(dbPath, blobDir);
+      const sessionId = "path-based-rollback-session";
+
+      try {
+        lease.store.upsertSession({
+          id: sessionId,
+          startedAt: 1,
+          mode: "sdk",
+          sourceScope: "openclaw",
+          sourceProcess: "plugin",
+          dbPath,
+          blobDir,
+        });
+        const blob = lease.store.persistPayload(Buffer.from("rollback payload"), "text/plain");
+        lease.store.recordEvent({
+          sessionId,
+          ts: 2,
+          sourceScope: "openclaw",
+          sourceProcess: "plugin",
+          protocol: "https",
+          direction: "outbound",
+          kind: "request",
+          flowId: "path-based-rollback-flow",
+          dataBlobId: blob.blobId,
+          dataSha256: blob.sha256,
+        });
+
+        const cleanup = () =>
+          operation === "deleteSessions"
+            ? lease.store.deleteSessions([sessionId])
+            : lease.store.purgeAll();
+        lease.store.db.setAuthorizer((action, table) =>
+          action === constants.SQLITE_DELETE && table === "capture_sessions"
+            ? constants.SQLITE_DENY
+            : constants.SQLITE_OK,
+        );
+
+        expect(cleanup).toThrow(/not authorized/u);
+        lease.store.db.setAuthorizer(null);
+        expect(lease.store.listSessions()).toHaveLength(1);
+        expect(lease.store.getSessionEvents(sessionId)).toHaveLength(1);
+        expect(fs.existsSync(blob.path)).toBe(true);
+
+        expect(cleanup()).toEqual({ sessions: 1, events: 1, blobs: 1 });
+        expect(lease.store.listSessions()).toEqual([]);
+        expect(lease.store.getSessionEvents(sessionId)).toEqual([]);
+        expect(fs.existsSync(blob.path)).toBe(false);
+      } finally {
+        lease.store.db.setAuthorizer(null);
+        lease.release();
+      }
+    },
+  );
 
   it("uses rollback journaling for captures on NFS-backed volumes", () => {
     vi.spyOn(fs, "statfsSync").mockReturnValue({

--- a/src/proxy-capture/store.sqlite.ts
+++ b/src/proxy-capture/store.sqlite.ts
@@ -616,7 +616,9 @@ class DebugProxyCaptureStoreImpl {
       const eventCount =
         (this.db.prepare(`SELECT COUNT(*) AS count FROM capture_events`).get() as { count: number })
           .count ?? 0;
-      this.db.exec(`DELETE FROM capture_events; DELETE FROM capture_sessions;`);
+      runSqliteImmediateTransactionSync(this.db, () => {
+        this.db.exec(`DELETE FROM capture_events; DELETE FROM capture_sessions;`);
+      });
       let blobs = 0;
       if (fs.existsSync(this.pathBased.blobDir)) {
         for (const entry of fs.readdirSync(this.pathBased.blobDir)) {
@@ -764,12 +766,14 @@ class DebugProxyCaptureStoreImpl {
           )
           .get(...sessionIds) as { count: number }
       ).count ?? 0;
-    this.db
-      .prepare(`DELETE FROM capture_events WHERE session_id IN (${placeholders})`)
-      .run(...sessionIds);
-    this.db
-      .prepare(`DELETE FROM capture_sessions WHERE id IN (${placeholders})`)
-      .run(...sessionIds);
+    runSqliteImmediateTransactionSync(this.db, () => {
+      this.db
+        .prepare(`DELETE FROM capture_events WHERE session_id IN (${placeholders})`)
+        .run(...sessionIds);
+      this.db
+        .prepare(`DELETE FROM capture_sessions WHERE id IN (${placeholders})`)
+        .run(...sessionIds);
+    });
     const candidateBlobIds = blobRows
       .map((row) => row.blobId?.trim())
       .filter((blobId): blobId is string => Boolean(blobId));


### PR DESCRIPTION
Fixes #98959

Original contributor and issue reporter: @zhangLei99586. The original human Git author, email, and first authored timestamp are preserved.

## What Problem This Solves

The shipped path-based Plugin SDK proxy-capture store deleted capture events and capture sessions in separate SQLite auto-commit operations. A real failure on the second delete permanently removed the events while leaving the session behind; retrying `deleteSessions` could also strand the real payload blob. The sibling path-based `purgeAll` had the same atomicity defect.

## Why This Change Was Made

Use the already-existing synchronous `runSqliteImmediateTransactionSync` owner around only the SQL deletes in both path-based `deleteSessions` and `purgeAll`. All blob filesystem inspection and deletion remains outside and after the committed SQLite transaction. The non-path-based/shared-state implementations already own equivalent transactional behavior.

The original contributor branch predated a major store rewrite and no longer merged. This takeover reapplies the same original architectural fix onto current main, covers the sibling with the identical violated invariant, and adds actual fault-injection regression coverage. Production delta is four net lines; there is no schema migration, schema-version bump, configuration, dependency, or public API change.

## User Impact

Interrupted or failed path-based diagnostic cleanup can no longer silently corrupt session/event relationships or orphan capture payloads. Successful cleanup retains its existing counts and behavior.

## Evidence

Real production `acquireDebugProxyCaptureStore`, actual file-backed Node SQLite, actual on-disk payload blobs, and real `DatabaseSync.setAuthorizer(SQLITE_DELETE => SQLITE_DENY)` fault injection on the second SQL delete, with the same failure-then-retry execution order for both cleanup operations:

Before, current main:

```json
{"node":"v26.5.0","dependency":"node:sqlite DatabaseSync.setAuthorizer SQLITE_DELETE/SQLITE_DENY","results":[{"operation":"deleteSessions","afterFailure":{"error":"not authorized","sessions":1,"events":0,"blobExists":true,"transactionActive":false},"afterRetry":{"result":{"sessions":1,"events":0,"blobs":0},"sessions":0,"events":0,"blobExists":true,"schemaVersion":1}},{"operation":"purgeAll","afterFailure":{"error":"not authorized","sessions":1,"events":0,"blobExists":true,"transactionActive":false},"afterRetry":{"result":{"sessions":1,"events":0,"blobs":1},"sessions":0,"events":0,"blobExists":false,"schemaVersion":1}}]}
```

After, exact refreshed contributor head `b13ba9423a39540e012f61f0a4ecfe07e0fbf3bf`:

```json
{"node":"v26.5.0","dependency":"node:sqlite DatabaseSync.setAuthorizer SQLITE_DELETE/SQLITE_DENY","results":[{"operation":"deleteSessions","afterFailure":{"error":"not authorized","sessions":1,"events":1,"blobExists":true,"transactionActive":false},"afterRetry":{"result":{"sessions":1,"events":1,"blobs":1},"sessions":0,"events":0,"blobExists":false,"schemaVersion":1}},{"operation":"purgeAll","afterFailure":{"error":"not authorized","sessions":1,"events":1,"blobExists":true,"transactionActive":false},"afterRetry":{"result":{"sessions":1,"events":1,"blobs":1},"sessions":0,"events":0,"blobExists":false,"schemaVersion":1}}]}
```

Before, both operations persist `sessions=1, events=0` after the injected failure, and a retry of `deleteSessions` also leaves its payload blob orphaned. After, both operations roll back to `sessions=1, events=1, blobExists=true`, leave no active transaction, and a safe retry deletes one session, one event, and one blob. `PRAGMA user_version` remains exactly `1`.

```bash
OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/private/tmp/openclaw-vitest-s02-98852-b13ba942 node scripts/run-vitest.mjs src/proxy-capture/store.sqlite.test.ts
```

Focused owner suite passes, including both new real SQLite authorizer regressions; independent repeated proof reports 13 passing tests. Targeted oxfmt and `git diff --check` pass. Fresh Codex Sol xhigh autoreview reports no accepted or actionable findings.

Both ClawSweeper rank-up moves are complete: the conflict is resolved on current main, only synchronous SQL statements are inside the transaction, blob filesystem work remains outside it, and the focused path-based owner suite passes.

The exact unchanged two-file owner patch was rebased over the already-landed main fix `a14ada134f91c92f76d2bc886ae75b7c7dc0cc0d` after an unrelated CI tooling baseline failure. Both formerly failing oxlint shard-routing owner expectations now pass (2/2); the focused proxy-capture owner suite passes 13/13 again; fresh Codex Sol xhigh commit review is clean.