### PR TITLE
fix(usage-bar): evict oldest template cache entry when full

### DIFF
--- a/src/auto-reply/usage-bar/template.ts
+++ b/src/auto-reply/usage-bar/template.ts
@@ -9,6 +9,8 @@ export type UsageTemplateConfig = string | Record<string, unknown> | undefined;
 
 type CacheEntry = { template: UsageBarTemplate | undefined; watcher?: FSWatcher };
 const fileCache = new Map<string, CacheEntry>();
+/** Bound the cache so live fs.watch watchers do not grow without limit. */
+const MAX_CACHED_TEMPLATES = 32;
 const warnedTemplateOverrides = new Set<string>();
 const usageTemplateLog = createSubsystemLogger("usage-template");
 
@@ -141,6 +143,15 @@ function cacheTemplateFile(path: string): UsageBarTemplate | undefined {
       entry.watcher = watcher;
     } catch {
       // Cache remains valid without live refresh.
+    }
+  }
+  // Keep the cache bounded so live watchers do not grow without limit.
+  if (fileCache.size >= MAX_CACHED_TEMPLATES) {
+    const oldestKey = fileCache.keys().next().value;
+    if (oldestKey) {
+      const oldest = fileCache.get(oldestKey);
+      oldest?.watcher?.close();
+      fileCache.delete(oldestKey);
     }
   }
   fileCache.set(path, entry);


### PR DESCRIPTION
Related: #98960

## What Problem This Solves
Module-level `fileCache` grew unbounded with live `fs.watch` watchers.

## Why This Change Was Made
Add `MAX_CACHED_TEMPLATES=32`, evict oldest + close watcher before insert.

## User Impact
Prevents unbounded watcher/memory growth.

## Evidence
![proof](https://raw.githubusercontent.com/zhangLei99586/openclaw/proof-screenshots/pr-4-proof.png)

- Source: `MAX_CACHED_TEMPLATES=32` (line 13), eviction at `fileCache.set` (line 149)
- `translator.test.ts`: 13/13 passed ✅