### PR TITLE
fix(find): call stopChild in error handler for symmetric cleanup

### DIFF
--- a/src/agents/sessions/tools/find.ts
+++ b/src/agents/sessions/tools/find.ts
@@ -296,6 +296,7 @@ export function createFindToolDefinition(
 
             child.on("error", (error) => {
               cleanup();
+              stopChild?.();
               settle(() => reject(new Error(`Failed to run fd: ${error.message}`)));
             });
 


### PR DESCRIPTION
Related: #98961

## What Problem This Solves
`child.on('error')` called `cleanup()` but missed `stopChild?.()` — asymmetric.

## Why This Change Was Made
Add `stopChild?.()` in error handler for symmetric cleanup with close handler.

## User Impact
No user-visible change. Both handlers clean up symmetrically.

## Evidence
![proof](https://raw.githubusercontent.com/zhangLei99586/openclaw/proof-screenshots/pr-4-proof.png)

- Source: `stopChild?.()` present in `child.on("error")` handler
- Matches symmetric `cleanup() + stopChild?.()` in `child.on("close")` handler