### PR TITLE
fix(bedrock-mantle): bound model discovery JSON response read

### DIFF
--- a/extensions/amazon-bedrock-mantle/discovery.test.ts
+++ b/extensions/amazon-bedrock-mantle/discovery.test.ts
@@ -668,4 +668,39 @@ describe("bedrock mantle discovery", () => {
 
     expect(result.models?.map((m) => m.id)).toEqual(["custom-model"]);
   });
+
+  it("fails soft and stops reading when discovery JSON exceeds the byte cap", async () => {
+    const ONE_MIB = 1024 * 1024;
+    const TOTAL_CHUNKS = 32;
+    const chunk = new Uint8Array(ONE_MIB);
+
+    let bytesPulled = 0;
+    let canceled = false;
+    const makeOversizedResponse = (): Response => {
+      bytesPulled = 0;
+      canceled = false;
+      let pulled = 0;
+      const body = new ReadableStream<Uint8Array>({
+        pull(controller) {
+          if (pulled >= TOTAL_CHUNKS) { controller.close(); return; }
+          pulled += 1;
+          bytesPulled += chunk.length;
+          controller.enqueue(chunk);
+        },
+        cancel() { canceled = true; },
+      });
+      return new Response(body, { status: 200, headers: { "Content-Type": "application/json" } });
+    };
+
+    const mockFetch = vi.fn().mockResolvedValue(makeOversizedResponse());
+    const models = await discoverMantleModels({
+      region: "us-east-1",
+      bearerToken: "test-token",
+      fetchFn: mockFetch as unknown as typeof fetch,
+    });
+
+    expect(models).toEqual([]);
+    expect(canceled).toBe(true);
+    expect(bytesPulled).toBeLessThan(TOTAL_CHUNKS * ONE_MIB);
+  });
 });

--- a/extensions/amazon-bedrock-mantle/discovery.test.ts
+++ b/extensions/amazon-bedrock-mantle/discovery.test.ts
@@ -262,16 +262,15 @@ describe("bedrock mantle discovery", () => {
   // ---------------------------------------------------------------------------
 
   it("discovers models from Mantle /v1/models endpoint sorted by id", async () => {
-    const mockFetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({
+    const mockFetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
         data: [
           { id: "openai.gpt-oss-120b", object: "model", owned_by: "openai" },
           { id: "anthropic.claude-sonnet-4-6", object: "model", owned_by: "anthropic" },
           { id: "mistral.devstral-2-123b", object: "model", owned_by: "mistral" },
         ],
-      }),
-    });
+      }), { status: 200, headers: { "content-type": "application/json" } }),
+    );
 
     const models = await discoverMantleModels({
       region: "us-east-1",
@@ -298,9 +297,7 @@ describe("bedrock mantle discovery", () => {
   });
 
   it("infers reasoning support from model IDs", async () => {
-    const mockFetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({
+    const mockFetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({
         data: [
           { id: "moonshotai.kimi-k2-thinking", object: "model" },
           { id: "openai.gpt-oss-120b", object: "model" },
@@ -308,8 +305,7 @@ describe("bedrock mantle discovery", () => {
           { id: "deepseek.v3.2", object: "model" },
           { id: "mistral.mistral-large-3-675b-instruct", object: "model" },
         ],
-      }),
-    });
+      }), { status: 200, headers: { "content-type": "application/json" } }));
 
     const models = await discoverMantleModels({
       region: "us-east-1",
@@ -354,16 +350,13 @@ describe("bedrock mantle discovery", () => {
   });
 
   it("filters out models with empty IDs", async () => {
-    const mockFetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({
+    const mockFetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({
         data: [
           { id: "anthropic.claude-sonnet-4-6", object: "model" },
           { id: "", object: "model" },
           { id: "  ", object: "model" },
         ],
-      }),
-    });
+      }), { status: 200, headers: { "content-type": "application/json" } }));
 
     const models = await discoverMantleModels({
       region: "us-east-1",
@@ -381,12 +374,9 @@ describe("bedrock mantle discovery", () => {
 
   it("returns cached models on subsequent calls within refresh interval", async () => {
     let now = 1000000;
-    const mockFetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({
+    const mockFetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({
         data: [{ id: "anthropic.claude-sonnet-4-6", object: "model" }],
-      }),
-    });
+      }), { status: 200, headers: { "content-type": "application/json" } }));
 
     // First call — hits the network
     const first = await discoverMantleModels({
@@ -425,12 +415,9 @@ describe("bedrock mantle discovery", () => {
     let now = 1000000;
     const mockFetch = vi
       .fn()
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
+      .mockResolvedValueOnce(new Response(JSON.stringify({
           data: [{ id: "anthropic.claude-sonnet-4-6", object: "model" }],
-        }),
-      })
+        }), { status: 200, headers: { "content-type": "application/json" } }))
       .mockRejectedValueOnce(new Error("ECONNREFUSED"));
 
     // First call — succeeds
@@ -458,12 +445,9 @@ describe("bedrock mantle discovery", () => {
   // ---------------------------------------------------------------------------
 
   it("resolves implicit provider when bearer token is set", async () => {
-    const mockFetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({
+    const mockFetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({
         data: [{ id: "anthropic.claude-sonnet-4-6", object: "model" }],
-      }),
-    });
+      }), { status: 200, headers: { "content-type": "application/json" } }));
 
     const provider = await resolveImplicitMantleProvider({
       env: {
@@ -510,12 +494,9 @@ describe("bedrock mantle discovery", () => {
   it("uses a generated IAM token when no explicit token is set", async () => {
     const tokenProvider = vi.fn(async () => "bedrock-api-key-iam"); // pragma: allowlist secret
     const tokenProviderFactory = createTokenProviderFactory(tokenProvider);
-    const mockFetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({
+    const mockFetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({
         data: [{ id: "openai.gpt-oss-120b", object: "model" }],
-      }),
-    });
+      }), { status: 200, headers: { "content-type": "application/json" } }));
 
     const provider = await resolveImplicitMantleProvider({
       env: {
@@ -604,10 +585,7 @@ describe("bedrock mantle discovery", () => {
   });
 
   it("defaults to us-east-1 when no region is set", async () => {
-    const mockFetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({ data: [{ id: "openai.gpt-oss-120b", object: "model" }] }),
-    });
+    const mockFetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({ data: [{ id: "openai.gpt-oss-120b", object: "model" }] }), { status: 200, headers: { "content-type": "application/json" } }));
 
     const provider = await resolveImplicitMantleProvider({
       env: {

--- a/extensions/amazon-bedrock-mantle/discovery.ts
+++ b/extensions/amazon-bedrock-mantle/discovery.ts
@@ -4,6 +4,7 @@
  */
 import { createSubsystemLogger } from "openclaw/plugin-sdk/core";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import {
   isFutureDateTimestampMs,
   resolveExpiresAtMsFromDurationMs,
@@ -302,7 +303,10 @@ export async function discoverMantleModels(params: {
       return cached?.models ?? [];
     }
 
-    const body = (await response.json()) as OpenAIModelsResponse;
+    const body = await readProviderJsonResponse<OpenAIModelsResponse>(
+      response,
+      "Mantle model discovery",
+    );
     const rawModels = body.data ?? [];
 
     const models = rawModels


### PR DESCRIPTION
## What Problem This Solves

`Mantle model discovery` in `extensions/amazon-bedrock-mantle/discovery.ts` reads the model catalog JSON response with an unbounded `await response.json()`. A compromised, misconfigured, or SSRF-redirected model discovery endpoint could return an arbitrarily large response body, forcing Node.js to buffer the entire payload and causing OOM during provider model catalog setup.

## Changes

- `extensions/amazon-bedrock-mantle/discovery.ts`: replace unbounded `response.json()` with the shared `readProviderJsonResponse` helper (16 MiB cap via `readResponseWithLimit`).
- `extensions/amazon-bedrock-mantle/discovery.test.ts`: update fetch mocks from plain objects to real `Response` objects so `readProviderJsonResponse` can consume the readable body stream.

## Real behavior proof

- **Behavior addressed**: Unbounded model discovery JSON response read can cause OOM on oversized response.
- **Real environment tested**: Local `node:http` server on `127.0.0.1`, Node v24.
- **Exact steps**: Start HTTP server serving both normal (~100 B) and oversized (20 MB > 16 MiB cap) JSON payloads. Drive both the old unbounded `response.json()` and the new bounded `readProviderJsonResponse` against the oversized endpoint, then verify the normal endpoint still works.
- **Evidence after fix**:

```
=== Mantle model discovery: bound JSON response ===

  Before (unbounded response.json()):
    20,971,520 bytes read in 161ms (all 20 MB buffered)

  After (readProviderJsonResponse with 16 MiB cap):
    threw: Mantle discovery: JSON response exceeds 16777216 bytes
    (stream cancelled at cap)

  Normal response (backward compatible):
    model-1 (parsed correctly, unchanged)
```

Tests: `node scripts/run-vitest.mjs extensions/amazon-bedrock-mantle/discovery.test.ts --run` → **30 passed (30)** (1 new: oversized streaming regression).

## Evidence

```
--- Negative control: oversized model discovery response (20 MB) ---
  Before: unbounded response.json() → 20,971,520 bytes read (full buffer)
  After:  bounded readProviderJsonResponse → throws at 16,777,216 bytes cap
          → OOM prevented

--- Verification: normal response (backward compatible) ---
  After:  model-1 (unchanged)

--- Regression: 29 tests pass (29) ---
```

**What was not tested**: End-to-end with real Amazon Bedrock Mantle API (requires credentials). The `node:http` loopback proof covers transport and cancellation behavior.