### PR TITLE
fix(msteams): proactive sends fail after conversation migration

### DIFF
--- a/extensions/msteams/doctor-contract-api.test.ts
+++ b/extensions/msteams/doctor-contract-api.test.ts
@@ -9,6 +9,7 @@ import {
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import type {
   OpenKeyedStoreOptions,
+  PluginStateKeyedStore,
   PluginDoctorStateMigrationContext,
 } from "openclaw/plugin-sdk/runtime-doctor";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -42,6 +43,32 @@ function createDoctorContext(env: NodeJS.ProcessEnv): PluginDoctorStateMigration
         ...options,
         env: options.env ?? env,
       });
+    },
+  };
+}
+
+function createUnpersistedConversationContext(): PluginDoctorStateMigrationContext {
+  return {
+    openPluginStateKeyedStore<T>(): PluginStateKeyedStore<T> {
+      return {
+        async register() {},
+        async registerIfAbsent() {
+          return false;
+        },
+        async lookup() {
+          return undefined;
+        },
+        async consume() {
+          return undefined;
+        },
+        async delete() {
+          return false;
+        },
+        async entries() {
+          return [];
+        },
+        async clear() {},
+      };
     },
   };
 }
@@ -133,6 +160,88 @@ describe("msteams doctor state migration", () => {
       conversation: { id: "19:conv@thread.tacv2" },
       user: { id: "user-1" },
     });
+  });
+
+  it("preserves legacy conversations when retained rows are not visible in plugin state", async () => {
+    const filePath = path.join(stateDir, "msteams-conversations.json");
+    const ref: StoredConversationReference = {
+      conversation: { id: "19:lost@thread.tacv2" },
+      channelId: "msteams",
+      serviceUrl: "https://service.example.com",
+      user: { id: "user-lost" },
+    };
+    await fs.writeFile(
+      filePath,
+      `${JSON.stringify({
+        version: 1,
+        conversations: {
+          "19:lost@thread.tacv2": ref,
+        },
+      } satisfies MSTeamsLegacyConversationStoreData)}\n`,
+    );
+
+    const migration = migrationById("msteams-conversations-json-to-plugin-state");
+    const result = await migration.migrateLegacyState({
+      config: {},
+      env,
+      stateDir,
+      oauthDir: path.join(stateDir, "oauth"),
+      context: createUnpersistedConversationContext(),
+    });
+
+    expect(result.changes).toEqual([
+      expect.stringContaining("Migrated 0 Microsoft Teams conversation entries"),
+    ]);
+    expect(result.warnings).toEqual([
+      expect.stringContaining(
+        "Left Microsoft Teams conversation legacy source in place because 1 retained entry was not visible in plugin state after migration",
+      ),
+    ]);
+    await expect(fs.access(filePath)).resolves.toBeUndefined();
+    await expect(fs.access(`${filePath}.migrated`)).rejects.toThrow();
+  });
+
+  it("archives legacy conversations when zero imports are already present in plugin state", async () => {
+    const filePath = path.join(stateDir, "msteams-conversations.json");
+    const ref: StoredConversationReference = {
+      conversation: { id: "19:existing@thread.tacv2" },
+      channelId: "msteams",
+      serviceUrl: "https://service.example.com",
+      user: { id: "user-existing" },
+    };
+    await fs.writeFile(
+      filePath,
+      `${JSON.stringify({
+        version: 1,
+        conversations: {
+          "19:existing@thread.tacv2": ref,
+        },
+      } satisfies MSTeamsLegacyConversationStoreData)}\n`,
+    );
+
+    const migration = migrationById("msteams-conversations-json-to-plugin-state");
+    const context = createDoctorContext(env);
+    const store = context.openPluginStateKeyedStore<StoredConversationReference>({
+      namespace: MSTEAMS_CONVERSATIONS_NAMESPACE,
+      maxEntries: 2000,
+    });
+    await store.register(buildMSTeamsConversationStateKey("19:existing@thread.tacv2"), ref);
+
+    const result = await migration.migrateLegacyState({
+      config: {},
+      env,
+      stateDir,
+      oauthDir: path.join(stateDir, "oauth"),
+      context,
+    });
+
+    expect(result.warnings).toEqual([]);
+    expect(result.changes).toEqual([
+      expect.stringContaining("Migrated 0 Microsoft Teams conversation entries"),
+      expect.stringContaining("Archived Microsoft Teams conversation legacy source"),
+    ]);
+    await expect(fs.access(filePath)).rejects.toThrow();
+    await expect(fs.access(`${filePath}.migrated`)).resolves.toBeUndefined();
   });
 
   it("imports legacy polls and vote buckets into plugin state", async () => {

--- a/extensions/msteams/doctor-contract-api.ts
+++ b/extensions/msteams/doctor-contract-api.ts
@@ -300,25 +300,37 @@ export const stateMigrations: PluginDoctorStateMigration[] = [
         namespace: MSTEAMS_CONVERSATIONS_NAMESPACE,
         maxEntries: MSTEAMS_SQLITE_MAX_CONVERSATION_ROWS,
       });
+      let attempted = 0;
       let imported = 0;
-      for (const [rawConversationId, reference] of selectRetainedMSTeamsConversations(
-        state.conversations,
-      )) {
+      let present = 0;
+      const retainedConversations = selectRetainedMSTeamsConversations(state.conversations);
+      for (const [rawConversationId, reference] of retainedConversations) {
         const conversationId = normalizeStoredConversationId(rawConversationId);
         if (!conversationId) {
           continue;
         }
+        attempted++;
+        const key = buildMSTeamsConversationStateKey(conversationId);
         const didImport = await store.registerIfAbsent(
-          buildMSTeamsConversationStateKey(conversationId),
+          key,
           prepareMSTeamsConversationReferenceForStorage(conversationId, reference),
         );
         if (didImport) {
           imported++;
         }
+        if (await store.lookup(key)) {
+          present++;
+        }
       }
       changes.push(
         `Migrated ${imported} ${MSTEAMS_PLUGIN_ID} conversation ${imported === 1 ? "entry" : "entries"} -> plugin state`,
       );
+      if (attempted > 0 && imported === 0 && present === 0) {
+        warnings.push(
+          `Left ${MSTEAMS_PLUGIN_ID} conversation legacy source in place because ${attempted} retained ${attempted === 1 ? "entry was" : "entries were"} not visible in plugin state after migration`,
+        );
+        return { changes, warnings };
+      }
       await archiveLegacyStateSource({
         filePath,
         label: `${MSTEAMS_PLUGIN_ID} conversation`,


### PR DESCRIPTION
Closes #94939.

## What Problem This Solves

Fixes an issue where Microsoft Teams users could lose proactive Bot Framework sends after 6.x state migration when a non-empty legacy `msteams-conversations.json` source produced no conversation references visible in shared plugin state.

When that happens, archiving the legacy source silently removes recoverable Teams conversation data. The bot then cannot send proactively to those conversations until it receives a new message.

## Why This Change Was Made

The migration now treats a non-empty legacy Teams conversation source with zero visible migrated rows as unsafe to archive. It leaves the legacy source in place and reports a warning/change result instead of silently discarding recoverable conversation references.

The change is intentionally narrow: empty legacy sources and successfully verified migrations keep the existing archive behavior. This does not attempt to reinterpret every possible legacy migration failure.

## User Impact

Teams users and operators keep a recoverable legacy conversation reference source when migration cannot verify that references landed in shared plugin state. That reduces the risk of proactive Teams sends breaking after state migration and gives operators a clear warning instead of silent data loss.

## Evidence

Regression/source validation:

- `node scripts/run-vitest.mjs extensions/msteams/doctor-contract-api.test.ts`
- `node scripts/run-vitest.mjs extensions/msteams`
- `pnpm lint --threads=8`
- `pnpm run lint:extensions:bundled`
- `pnpm run lint:extensions:channels`
- `git diff --check`

Redacted local gateway validation:

```json
{
  "installedBundle": {
    "migrationGuardPresentInPatchedBundle": true,
    "migrationGuardPresentInBaselineBundle": false,
    "patchedDoctorContractSha256": "bb75fa0ebca072a1393c359968124e36e8895c0126538d51ad44698e4d4ad629",
    "baselineDoctorContractSha256": "43b77bdaf0da989857df4190b653318e5cdb8d42006a7ef1560f4804c11192ae"
  },
  "runtime": {
    "gatewayProcess": "running",
    "msteamsListener": "listening"
  },
  "stateCounters": {
    "msteamsConversationReferences": 20,
    "msteamsSentMessageRecordsBeforeProactiveSend": 6,
    "msteamsSentMessageRecordsAfterProactiveSend": 7
  },
  "teamsSmoke": {
    "inboundDmReceived": true,
    "botReplyObserved": true,
    "proactiveSendDryRun": false,
    "sentMessageRecordsIncreasedAfterProactiveSend": true,
    "latestPersonalConversationTimestampUpdatedAfterProactiveSend": true,
    "latestPersonalConversationUpdatedAt": "2026-07-02T02:30:21.367Z"
  },
  "privacy": {
    "conversationIds": "redacted",
    "tenantAndUserIds": "redacted",
    "messageBodiesFromLogs": "not included",
    "localHostnamesAndUsernames": "not included"
  }
}
```