### PR TITLE
fix(llm): preserve non-array tool result replay

### DIFF
--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -16,6 +16,7 @@ import {
   createEmptyTransportUsage,
   createWritableTransportEventStream,
   describeToolResultMediaPlaceholder,
+  extractToolResultImageBlocks,
   extractToolResultText,
   failTransportStream,
   finalizeTransportStream,
@@ -651,10 +652,7 @@ function convertGoogleMessages(model: GoogleTransportModel, context: Context) {
     if (msg.role === "toolResult") {
       const textResult = extractToolResultText(msg.content);
       const imageContent = model.input.includes("image")
-        ? msg.content.filter(
-            (item): item is Extract<(typeof msg.content)[number], { type: "image" }> =>
-              item.type === "image",
-          )
+        ? extractToolResultImageBlocks(msg.content)
         : [];
       const mediaPlaceholder = describeToolResultMediaPlaceholder(msg.content);
       const responseValue = textResult

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -15,8 +15,10 @@ import {
 import type { AnthropicOptions, AnthropicThinkingDisplay } from "../llm/providers/anthropic.js";
 import {
   describeToolResultMediaPlaceholder,
+  extractToolResultImageBlocks,
   extractToolResultBlockText,
   extractToolResultText,
+  normalizeToolResultBlocks,
 } from "../llm/providers/tool-result-text.js";
 import type {
   AssistantMessageDiagnostic,
@@ -301,15 +303,11 @@ function toClaudeCodeName(name: string): string {
   return CLAUDE_CODE_TOOL_LOOKUP.get(normalizeLowercaseStringOrEmpty(name)) ?? name;
 }
 
-function convertContentBlocks(content: readonly unknown[]) {
+function convertContentBlocks(content: unknown) {
   const text = extractToolResultText(content);
   const mediaPlaceholder = describeToolResultMediaPlaceholder(content);
-  const hasImages =
-    Array.isArray(content) &&
-    content.some(
-      (item) =>
-        item && typeof item === "object" && (item as Record<string, unknown>).type === "image",
-    );
+  const imageBlocks = extractToolResultImageBlocks(content);
+  const hasImages = imageBlocks.length > 0;
   if (!hasImages) {
     return sanitizeNonEmptyTransportPayloadText(text, mediaPlaceholder ?? "(no output)");
   }
@@ -321,7 +319,7 @@ function convertContentBlocks(content: readonly unknown[]) {
       }
   > = [];
   let hasTextBlock = false;
-  for (const block of Array.isArray(content) ? content : []) {
+  for (const block of normalizeToolResultBlocks(content)) {
     if (!block || typeof block !== "object") {
       continue;
     }

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -29,6 +29,7 @@ import { clampOpenAIPromptCacheKey } from "../llm/providers/openai-prompt-cache.
 import { mapOpenAIStopReason } from "../llm/providers/openai-stop-reason.js";
 import {
   describeToolResultMediaPlaceholder,
+  extractToolResultImageBlocks,
   extractToolResultText,
 } from "../llm/providers/tool-result-text.js";
 import type { Api, Context, Model } from "../llm/types.js";
@@ -1290,7 +1291,8 @@ function convertResponsesMessages(
       const sanitizedTextResult = sanitizeTransportPayloadText(textResult);
       const hasText = sanitizedTextResult.trim().length > 0;
       const mediaPlaceholder = describeToolResultMediaPlaceholder(msg.content);
-      const hasImages = msg.content.some((item) => item.type === "image");
+      const imageBlocks = extractToolResultImageBlocks(msg.content);
+      const hasImages = imageBlocks.length > 0;
       const [callId] = msg.toolCallId.split("|");
       messages.push({
         type: "function_call_output",
@@ -1303,13 +1305,11 @@ function convertResponsesMessages(
                   : mediaPlaceholder === "(see attached media)"
                     ? [{ type: "input_text", text: mediaPlaceholder }]
                     : []),
-                ...msg.content
-                  .filter((item) => item.type === "image")
-                  .map((item) => ({
-                    type: "input_image",
-                    detail: "auto",
-                    image_url: `data:${item.mimeType};base64,${item.data}`,
-                  })),
+                ...imageBlocks.map((item) => ({
+                  type: "input_image",
+                  detail: "auto",
+                  image_url: `data:${item.mimeType};base64,${item.data}`,
+                })),
               ] as ResponseFunctionCallOutputItemList)
             : sanitizeNonEmptyTransportPayloadText(textResult, mediaPlaceholder ?? "(no output)"),
       });

--- a/src/llm/providers/anthropic.ts
+++ b/src/llm/providers/anthropic.ts
@@ -70,6 +70,8 @@ import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copi
 import { adjustMaxTokensForThinking, buildBaseOptions } from "./simple-options.js";
 import {
   describeToolResultMediaPlaceholder,
+  extractToolResultImageBlocks,
+  normalizeToolResultBlocks,
   extractToolResultBlockText,
   extractToolResultText,
 } from "./tool-result-text.js";
@@ -127,7 +129,7 @@ const toClaudeCodeName = (name: string) => ccToolLookup.get(name.toLowerCase()) 
 /**
  * Convert content blocks to Anthropic API format
  */
-function convertContentBlocks(content: readonly unknown[]):
+function convertContentBlocks(content: unknown):
   | string
   | Array<
       | { type: "text"; text: string }
@@ -142,12 +144,8 @@ function convertContentBlocks(content: readonly unknown[]):
     > {
   const text = extractToolResultText(content);
   const mediaPlaceholder = describeToolResultMediaPlaceholder(content);
-  const hasImages =
-    Array.isArray(content) &&
-    content.some(
-      (item) =>
-        item && typeof item === "object" && (item as Record<string, unknown>).type === "image",
-    );
+  const imageBlocks = extractToolResultImageBlocks(content);
+  const hasImages = imageBlocks.length > 0;
 
   if (!hasImages) {
     const sanitized = sanitizeSurrogates(text);
@@ -167,7 +165,7 @@ function convertContentBlocks(content: readonly unknown[]):
   > = [];
   let hasTextBlock = false;
 
-  for (const block of Array.isArray(content) ? content : []) {
+  for (const block of normalizeToolResultBlocks(content)) {
     if (!block || typeof block !== "object") {
       continue;
     }

--- a/src/llm/providers/github-copilot-headers.ts
+++ b/src/llm/providers/github-copilot-headers.ts
@@ -1,5 +1,6 @@
 // GitHub Copilot header helpers build request headers for Copilot-backed providers.
 import type { Message } from "../types.js";
+import { extractToolResultImageBlocks } from "./tool-result-text.js";
 
 // Copilot expects X-Initiator to indicate whether the request is user-initiated
 // or agent-initiated (e.g. follow-up after assistant/tool messages).
@@ -14,8 +15,8 @@ export function hasCopilotVisionInput(messages: Message[]): boolean {
     if (msg.role === "user" && Array.isArray(msg.content)) {
       return msg.content.some((c) => c.type === "image");
     }
-    if (msg.role === "toolResult" && Array.isArray(msg.content)) {
-      return msg.content.some((c) => c.type === "image");
+    if (msg.role === "toolResult") {
+      return extractToolResultImageBlocks(msg.content).length > 0;
     }
     return false;
   });

--- a/src/llm/providers/google-shared.ts
+++ b/src/llm/providers/google-shared.ts
@@ -18,7 +18,6 @@ import type {
   Api,
   AssistantMessage,
   Context,
-  ImageContent,
   Model,
   SimpleStreamOptions,
   StopReason,
@@ -32,7 +31,11 @@ import type {
 } from "../types.js";
 import type { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
-import { describeToolResultMediaPlaceholder, extractToolResultText } from "./tool-result-text.js";
+import {
+  describeToolResultMediaPlaceholder,
+  extractToolResultImageBlocks,
+  extractToolResultText,
+} from "./tool-result-text.js";
 import { transformMessages } from "./transform-messages.js";
 
 export type GoogleApiType = "google-generative-ai" | "google-vertex";
@@ -281,7 +284,7 @@ export function convertMessages<T extends GoogleApiType>(
       // Extract text and image content
       const textResult = extractToolResultText(msg.content);
       const imageContent = model.input.includes("image")
-        ? msg.content.filter((c): c is ImageContent => c.type === "image")
+        ? extractToolResultImageBlocks(msg.content)
         : [];
 
       const hasText = textResult.length > 0;

--- a/src/llm/providers/mistral.ts
+++ b/src/llm/providers/mistral.ts
@@ -30,7 +30,11 @@ import { shortHash } from "../utils/hash.js";
 import { parseStreamingJson } from "../utils/json-parse.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import { buildBaseOptions } from "./simple-options.js";
-import { describeToolResultMediaPlaceholder, extractToolResultText } from "./tool-result-text.js";
+import {
+  describeToolResultMediaPlaceholder,
+  extractToolResultImageBlocks,
+  extractToolResultText,
+} from "./tool-result-text.js";
 import { transformMessages } from "./transform-messages.js";
 
 const MISTRAL_TOOL_CALL_ID_LENGTH = 9;
@@ -694,7 +698,8 @@ function toChatMessages(
     const toolContent: ContentChunk[] = [];
     const textResult = extractToolResultText(msg.content);
     const mediaPlaceholder = describeToolResultMediaPlaceholder(msg.content);
-    const hasImages = msg.content.some((part) => part.type === "image");
+    const imageBlocks = extractToolResultImageBlocks(msg.content);
+    const hasImages = imageBlocks.length > 0;
     const toolText = buildToolResultText(
       textResult,
       mediaPlaceholder,
@@ -703,11 +708,8 @@ function toChatMessages(
       msg.isError,
     );
     toolContent.push({ type: "text", text: toolText });
-    for (const part of msg.content) {
+    for (const part of imageBlocks) {
       if (!supportsImages) {
-        continue;
-      }
-      if (part.type !== "image") {
         continue;
       }
       toolContent.push({

--- a/src/llm/providers/openai-completions.test.ts
+++ b/src/llm/providers/openai-completions.test.ts
@@ -1333,4 +1333,43 @@ describe("openai-completions stop-reason tool-call guard", () => {
       ]),
     );
   });
+
+  it("replays plain string tool-result content through provider payload construction", async () => {
+    let capturedPayload: Record<string, unknown> | undefined;
+    const stream = streamOpenAICompletions(
+      model,
+      {
+        messages: [
+          {
+            role: "toolResult",
+            toolCallId: "call_1",
+            toolName: "session_status",
+            content: "plain status output",
+            isError: false,
+            timestamp: 0,
+          },
+        ],
+      } as unknown as Context,
+      {
+        apiKey: "sk-test",
+        onPayload(payload) {
+          capturedPayload = payload as Record<string, unknown>;
+          throw new Error("stop before network");
+        },
+      },
+    );
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    expect(capturedPayload?.messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          role: "tool",
+          tool_call_id: "call_1",
+          content: "plain status output",
+        }),
+      ]),
+    );
+  });
 });

--- a/src/llm/providers/openai-completions.ts
+++ b/src/llm/providers/openai-completions.ts
@@ -35,7 +35,6 @@ import type {
   AssistantMessage,
   CacheRetention,
   Context,
-  ImageContent,
   Message,
   Model,
   OpenAICompletionsCompat,
@@ -58,7 +57,11 @@ import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copi
 import { clampOpenAIPromptCacheKey } from "./openai-prompt-cache.js";
 import { mapOpenAIStopReason } from "./openai-stop-reason.js";
 import { buildBaseOptions } from "./simple-options.js";
-import { describeToolResultMediaPlaceholder, extractToolResultText } from "./tool-result-text.js";
+import {
+  describeToolResultMediaPlaceholder,
+  extractToolResultImageBlocks,
+  extractToolResultText,
+} from "./tool-result-text.js";
 import { transformMessages } from "./transform-messages.js";
 
 /**
@@ -92,10 +95,6 @@ function isThinkingContentBlock(block: { type: string }): block is ThinkingConte
 
 function isToolCallBlock(block: { type: string }): block is ToolCall {
   return block.type === "toolCall";
-}
-
-function isImageContentBlock(block: { type: string }): block is ImageContent {
-  return block.type === "image";
 }
 
 const EMPTY_TOOL_RESULT_TEXT = "(no output)";
@@ -1161,7 +1160,8 @@ export function convertMessages(
         // Extract text and image content
         const textResult = extractToolResultText(toolMsg.content);
         const mediaPlaceholder = describeToolResultMediaPlaceholder(toolMsg.content);
-        const hasImages = toolMsg.content.some((c) => c.type === "image");
+        const toolImageBlocks = extractToolResultImageBlocks(toolMsg.content);
+        const hasImages = toolImageBlocks.length > 0;
 
         // Always send tool result with text (or placeholder if only images)
         const content = sanitizeToolResultText(
@@ -1180,15 +1180,13 @@ export function convertMessages(
         params.push(toolResultMsg);
 
         if (hasImages && model.input.includes("image")) {
-          for (const block of toolMsg.content) {
-            if (isImageContentBlock(block)) {
-              imageBlocks.push({
-                type: "image_url",
-                image_url: {
-                  url: `data:${block.mimeType};base64,${block.data}`,
-                },
-              });
-            }
+          for (const block of toolImageBlocks) {
+            imageBlocks.push({
+              type: "image_url",
+              image_url: {
+                url: `data:${block.mimeType};base64,${block.data}`,
+              },
+            });
           }
         }
       }

--- a/src/llm/providers/openai-responses-shared.ts
+++ b/src/llm/providers/openai-responses-shared.ts
@@ -39,7 +39,6 @@ import type {
   Api,
   AssistantMessage,
   Context,
-  ImageContent,
   Model,
   SimpleStreamOptions,
   StopReason,
@@ -56,7 +55,11 @@ import { headersToRecord } from "../utils/headers.js";
 import { parseStreamingJson } from "../utils/json-parse.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import { convertResponsesToolPayload, convertResponsesTools } from "./openai-responses-tools.js";
-import { describeToolResultMediaPlaceholder, extractToolResultText } from "./tool-result-text.js";
+import {
+  describeToolResultMediaPlaceholder,
+  extractToolResultImageBlocks,
+  extractToolResultText,
+} from "./tool-result-text.js";
 import { transformMessages } from "./transform-messages.js";
 
 // =============================================================================
@@ -414,7 +417,8 @@ export function convertResponsesMessages<TApi extends Api>(
     } else if (msg.role === "toolResult") {
       const textResult = extractToolResultText(msg.content);
       const sanitizedTextResult = sanitizeSurrogates(textResult);
-      const hasImages = msg.content.some((c): c is ImageContent => c.type === "image");
+      const imageBlocks = extractToolResultImageBlocks(msg.content);
+      const hasImages = imageBlocks.length > 0;
       const mediaPlaceholder = describeToolResultMediaPlaceholder(msg.content);
       const hasText = sanitizedTextResult.trim().length > 0;
       const [callId] = msg.toolCallId.split("|");
@@ -435,14 +439,12 @@ export function convertResponsesMessages<TApi extends Api>(
           });
         }
 
-        for (const block of msg.content) {
-          if (block.type === "image") {
-            contentParts.push({
-              type: "input_image",
-              detail: "auto",
-              image_url: `data:${block.mimeType};base64,${block.data}`,
-            });
-          }
+        for (const block of imageBlocks) {
+          contentParts.push({
+            type: "input_image",
+            detail: "auto",
+            image_url: `data:${block.mimeType};base64,${block.data}`,
+          });
         }
 
         output = contentParts;

--- a/src/llm/providers/tool-result-text.test.ts
+++ b/src/llm/providers/tool-result-text.test.ts
@@ -1,7 +1,33 @@
 import { describe, expect, it } from "vitest";
-import { describeToolResultMediaPlaceholder, extractToolResultText } from "./tool-result-text.js";
+import {
+  describeToolResultMediaPlaceholder,
+  extractToolResultImageBlocks,
+  extractToolResultText,
+} from "./tool-result-text.js";
 
 describe("extractToolResultText", () => {
+  it("preserves plain string content without iterating characters as blocks", () => {
+    expect(extractToolResultText("plain status output")).toBe("plain status output");
+  });
+
+  it("serializes single structured object content through the redacted fallback", () => {
+    const text = extractToolResultText({
+      type: "json",
+      payload: { ok: true },
+      apiToken: "api-token-value-1234567890",
+    });
+
+    expect(text).toContain('"type":"json"');
+    expect(text).toContain('"ok":true');
+    expect(text).not.toContain("api-token-value-1234567890");
+  });
+
+  it("keeps text-like fields on single object content visible via structured replay", () => {
+    const text = extractToolResultText({ output: "status card text" });
+
+    expect(text).toContain("status card text");
+  });
+
   it("redacts structured secret fields with the shared tool-payload contract", () => {
     const text = extractToolResultText([
       {
@@ -160,6 +186,12 @@ describe("extractToolResultText", () => {
 });
 
 describe("describeToolResultMediaPlaceholder", () => {
+  it("describes single-object image content", () => {
+    expect(
+      describeToolResultMediaPlaceholder({ type: "image", mimeType: "image/png", data: "img" }),
+    ).toBe("(see attached image)");
+  });
+
   it("describes image-only tool result media", () => {
     expect(
       describeToolResultMediaPlaceholder([{ type: "image", mimeType: "image/png", data: "img" }]),
@@ -181,5 +213,19 @@ describe("describeToolResultMediaPlaceholder", () => {
         { type: "audio", mimeType: "audio/mpeg", data: "audio" },
       ]),
     ).toBe("(see attached media)");
+  });
+});
+
+describe("extractToolResultImageBlocks", () => {
+  it("returns validated image blocks from single-object content", () => {
+    expect(
+      extractToolResultImageBlocks({ type: "image", mimeType: "image/png", data: "img" }),
+    ).toStrictEqual([{ type: "image", mimeType: "image/png", data: "img" }]);
+  });
+
+  it("drops malformed image objects before provider payload construction", () => {
+    expect(
+      extractToolResultImageBlocks({ type: "image", mimeType: "image/png", data: 123 }),
+    ).toStrictEqual([]);
   });
 });

--- a/src/llm/providers/tool-result-text.ts
+++ b/src/llm/providers/tool-result-text.ts
@@ -27,6 +27,41 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
+export interface ToolResultImageBlock {
+  type: "image";
+  data: string;
+  mimeType: string;
+}
+
+export function normalizeToolResultBlocks(content: unknown): readonly unknown[] {
+  if (Array.isArray(content)) {
+    return content;
+  }
+  if (content === null || content === undefined) {
+    return [];
+  }
+  if (typeof content === "string") {
+    return [{ type: "text", text: content }];
+  }
+  if (typeof content === "number" || typeof content === "boolean" || typeof content === "bigint") {
+    return [{ type: "text", text: String(content) }];
+  }
+  if (isRecord(content)) {
+    return [content];
+  }
+  return [];
+}
+
+export function extractToolResultImageBlocks(content: unknown): ToolResultImageBlock[] {
+  const blocks = normalizeToolResultBlocks(content);
+  return blocks.filter((block): block is ToolResultImageBlock => {
+    if (!isRecord(block) || block.type !== "image") {
+      return false;
+    }
+    return typeof block.data === "string" && typeof block.mimeType === "string";
+  });
+}
+
 function readMimeType(value: unknown): string | undefined {
   if (!isRecord(value)) {
     return undefined;
@@ -123,11 +158,11 @@ function truncateProviderToolText(text: string): string {
   return `${truncateUtf16Safe(text, PROVIDER_TOOL_RESULT_MAX_CHARS)}\n…(truncated)…`;
 }
 
-export function describeToolResultMediaPlaceholder(blocks: readonly unknown[]): string | undefined {
+export function describeToolResultMediaPlaceholder(content: unknown): string | undefined {
   let hasImage = false;
   let hasAudio = false;
 
-  for (const block of blocks) {
+  for (const block of normalizeToolResultBlocks(content)) {
     if (!block || typeof block !== "object") {
       continue;
     }
@@ -177,10 +212,10 @@ export function extractToolResultBlockText(block: unknown): string | undefined {
   return structured ? sanitizeSurrogates(truncateProviderToolText(structured)) : undefined;
 }
 
-export function extractToolResultText(blocks: readonly unknown[]): string {
+export function extractToolResultText(content: unknown): string {
   const explicitTexts: string[] = [];
   const structuredTexts: string[] = [];
-  for (const block of blocks) {
+  for (const block of normalizeToolResultBlocks(content)) {
     const text = extractToolResultBlockText(block);
     if (!text) {
       continue;

--- a/src/llm/providers/transform-messages.ts
+++ b/src/llm/providers/transform-messages.ts
@@ -10,6 +10,7 @@ import type {
   ToolCall,
   ToolResultMessage,
 } from "../types.js";
+import { normalizeToolResultBlocks } from "./tool-result-text.js";
 
 const NON_VISION_USER_IMAGE_PLACEHOLDER = "(image omitted: model does not support images)";
 const NON_VISION_TOOL_IMAGE_PLACEHOLDER = "(tool image omitted: model does not support images)";
@@ -37,6 +38,33 @@ function replaceImagesWithPlaceholder(
   return result;
 }
 
+function replaceToolResultImagesWithPlaceholder(
+  content: unknown,
+  placeholder: string,
+): ToolResultMessage["content"] {
+  const result: unknown[] = [];
+  let previousWasPlaceholder = false;
+
+  for (const block of normalizeToolResultBlocks(content)) {
+    if (!block || typeof block !== "object") {
+      continue;
+    }
+    const record = block as Record<string, unknown>;
+    if (record.type === "image") {
+      if (!previousWasPlaceholder) {
+        result.push({ type: "text", text: placeholder });
+      }
+      previousWasPlaceholder = true;
+      continue;
+    }
+
+    result.push(block);
+    previousWasPlaceholder = record.type === "text" && record.text === placeholder;
+  }
+
+  return result as ToolResultMessage["content"];
+}
+
 function downgradeUnsupportedImages<TApi extends Api>(
   messages: Message[],
   model: Model<TApi>,
@@ -56,7 +84,10 @@ function downgradeUnsupportedImages<TApi extends Api>(
     if (msg.role === "toolResult") {
       return {
         ...msg,
-        content: replaceImagesWithPlaceholder(msg.content, NON_VISION_TOOL_IMAGE_PLACEHOLDER),
+        content: replaceToolResultImagesWithPlaceholder(
+          msg.content,
+          NON_VISION_TOOL_IMAGE_PLACEHOLDER,
+        ),
       };
     }
 

--- a/src/plugin-sdk/provider-transport-runtime.ts
+++ b/src/plugin-sdk/provider-transport-runtime.ts
@@ -7,6 +7,7 @@ export { stripSystemPromptCacheBoundary } from "../agents/system-prompt-cache-bo
 export { transformTransportMessages } from "../agents/transport-message-transform.js";
 export {
   describeToolResultMediaPlaceholder,
+  extractToolResultImageBlocks,
   extractToolResultText,
 } from "../llm/providers/tool-result-text.js";
 export {


### PR DESCRIPTION
Closes #98825.

## What Problem This Solves

Fixes an issue where users could lose successful tool output on the next model turn when stored tool-result content reached provider replay as a plain string or single object instead of the canonical content-block array.

This is the same canonical bug targeted by #98838 and #98826, but this PR also covers the provider and transport replay callers that continue doing media/image checks after text extraction.

## Why This Change Was Made

Tool-result replay now normalizes non-array content at the shared replay boundary and reuses that normalized view for text extraction, media placeholders, validated image blocks, non-vision image downgrade, provider payload construction, transport payload construction, and Copilot vision-header detection.

The fix keeps structured single-object content on the existing redacted/truncated structured fallback path instead of special-casing text-like fields in a way that could bypass existing replay safeguards.

## User Impact

Tool results that were successfully produced as plain text, structured objects, or single image objects are preserved during provider replay instead of becoming `(no output)` or failing when callers attempt `.some()` / `.filter()` on non-array content.

## Evidence

- `node scripts/run-vitest.mjs src/llm/providers/tool-result-text.test.ts src/llm/providers/openai-completions.test.ts`
  - Passed: 2 files, 54 tests.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`
  - Passed.
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo`
  - Passed.
- `node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo`
  - Passed.
- `node scripts/run-oxlint.mjs extensions/google/transport-stream.ts src/agents/anthropic-transport-stream.ts src/agents/openai-transport-stream.ts src/llm/providers/anthropic.ts src/llm/providers/github-copilot-headers.ts src/llm/providers/google-shared.ts src/llm/providers/mistral.ts src/llm/providers/openai-completions.test.ts src/llm/providers/openai-completions.ts src/llm/providers/openai-responses-shared.ts src/llm/providers/tool-result-text.test.ts src/llm/providers/tool-result-text.ts src/llm/providers/transform-messages.ts src/plugin-sdk/provider-transport-runtime.ts`
  - Passed.
- `node scripts/check-plugin-sdk-subpath-exports.mjs`
  - Passed.
- `git diff --check`
  - Passed.

Runtime payload proof:

```json
[
  {
    "role": "tool",
    "content": "plain status output",
    "tool_call_id": "call_1"
  }
]
```

That payload was produced locally by calling the real OpenAI Completions `convertMessages()` path with a `toolResult` whose `content` was the plain string `"plain status output"`.
