### PR TITLE
fix(plugins): trust official npm-only ClawHub installs

### DIFF
--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { collectChannelSchemaMetadata } from "../config/channel-config-metadata.js";
+import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { collectBundledChannelConfigs } from "./bundled-channel-config-metadata.js";
 import type { PluginCandidate } from "./discovery.js";
 import {
@@ -99,6 +100,21 @@ function createPluginCandidate(params: {
     bundledManifest: params.bundledManifest,
     bundledManifestPath: params.bundledManifestPath,
   };
+}
+
+function createMsteamsClawHubInstallRecord(
+  installPath: string,
+  overrides: Partial<PluginInstallRecord> = {},
+): PluginInstallRecord {
+  const record: PluginInstallRecord = {
+    source: "clawhub",
+    spec: "clawhub:@openclaw/msteams",
+    installPath,
+    clawhubUrl: "https://clawhub.ai",
+    clawhubPackage: "@openclaw/msteams",
+    clawhubChannel: "official",
+  };
+  return { ...record, ...overrides };
 }
 
 function loadRegistry(candidates: PluginCandidate[]) {
@@ -719,6 +735,72 @@ describe("loadPluginManifestRegistry", () => {
     expect(registry.plugins[0]?.trustedOfficialInstall).toBe(true);
   });
 
+  it("marks official npm-only ClawHub channel installs as trusted official installs", () => {
+    const dir = makeTempDir();
+    writeManifest(dir, { id: "msteams", configSchema: { type: "object" } });
+
+    const registry = loadPluginManifestRegistry({
+      installRecords: {
+        msteams: createMsteamsClawHubInstallRecord(dir, { clawhubPackage: undefined }),
+      },
+      candidates: [
+        createPluginCandidate({
+          idHint: "msteams",
+          rootDir: dir,
+          packageName: "@openclaw/msteams",
+          origin: "global",
+        }),
+      ],
+    });
+
+    expect(registry.plugins[0]?.trustedOfficialInstall).toBe(true);
+  });
+
+  it.each([
+    {
+      name: "community ClawHub channel",
+      record: (dir: string) =>
+        createMsteamsClawHubInstallRecord(dir, { clawhubChannel: "community" }),
+    },
+    {
+      name: "private ClawHub channel",
+      record: (dir: string) =>
+        createMsteamsClawHubInstallRecord(dir, { clawhubChannel: "private" }),
+    },
+    {
+      name: "custom ClawHub URL",
+      record: (dir: string) =>
+        createMsteamsClawHubInstallRecord(dir, { clawhubUrl: "https://example.invalid" }),
+    },
+    {
+      name: "mismatched ClawHub package",
+      record: (dir: string) =>
+        createMsteamsClawHubInstallRecord(dir, {
+          spec: "clawhub:@openclaw/line",
+          clawhubPackage: "@openclaw/line",
+        }),
+    },
+  ])("does not trust npm-only official ClawHub installs from $name", ({ record }) => {
+    const dir = makeTempDir();
+    writeManifest(dir, { id: "msteams", configSchema: { type: "object" } });
+
+    const registry = loadPluginManifestRegistry({
+      installRecords: {
+        msteams: record(dir),
+      },
+      candidates: [
+        createPluginCandidate({
+          idHint: "msteams",
+          rootDir: dir,
+          packageName: "@openclaw/msteams",
+          origin: "global",
+        }),
+      ],
+    });
+
+    expect(registry.plugins[0]?.trustedOfficialInstall).toBeUndefined();
+  });
+
   it("marks official diagnostics-otel config paths trusted when the install record matches", () => {
     const dir = makeTempDir();
     writeManifest(dir, { id: "diagnostics-otel", configSchema: { type: "object" } });
@@ -798,6 +880,25 @@ describe("loadPluginManifestRegistry", () => {
           idHint: "diagnostics-prometheus",
           rootDir: dir,
           packageName: "@openclaw/diagnostics-prometheus",
+          origin: "global",
+        }),
+      ],
+    });
+
+    expect(registry.plugins[0]?.trustedOfficialInstall).toBeUndefined();
+  });
+
+  it("does not trust unrecorded npm-only official ClawHub channel globals", () => {
+    const dir = makeTempDir();
+    writeManifest(dir, { id: "msteams", configSchema: { type: "object" } });
+
+    const registry = loadPluginManifestRegistry({
+      installRecords: {},
+      candidates: [
+        createPluginCandidate({
+          idHint: "msteams",
+          rootDir: dir,
+          packageName: "@openclaw/msteams",
           origin: "global",
         }),
       ],

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -56,6 +56,7 @@ import {
   normalizeManifestChannelCommandDefaults,
 } from "./manifest.js";
 import { checkMinHostVersion } from "./min-host-version.js";
+import { resolveTrustedSourceLinkedOfficialClawHubInstall } from "./official-external-install-records.js";
 import {
   getOfficialExternalPluginCatalogEntryForPackage,
   getOfficialExternalPluginCatalogManifest,
@@ -820,6 +821,13 @@ function isTrustedOfficialPluginInstall(params: {
   if (!installRecord) {
     return false;
   }
+  const officialClawHubInstall =
+    installRecord.source === "clawhub"
+      ? resolveTrustedSourceLinkedOfficialClawHubInstall({
+          pluginId: params.pluginId,
+          record: installRecord,
+        })
+      : undefined;
   if (
     installRecord.source === "npm" &&
     officialInstall?.npmSpec === packageName &&
@@ -834,11 +842,13 @@ function isTrustedOfficialPluginInstall(params: {
   }
   if (
     installRecord.source === "clawhub" &&
-    officialInstall?.clawhubSpec &&
     installRecord.clawhubChannel === "official" &&
+    officialClawHubInstall &&
     (installRecord.clawhubPackage === packageName ||
-      installRecord.spec === officialInstall.clawhubSpec ||
-      installRecord.resolvedSpec === officialInstall.clawhubSpec)
+      officialClawHubInstall.npmSpec === packageName ||
+      (officialClawHubInstall.clawhubSpec &&
+        (installRecord.spec === officialClawHubInstall.clawhubSpec ||
+          installRecord.resolvedSpec === officialClawHubInstall.clawhubSpec)))
   ) {
     return true;
   }

--- a/test/scripts/ui.test.ts
+++ b/test/scripts/ui.test.ts
@@ -244,8 +244,10 @@ describe("scripts/ui windows spawn behavior", () => {
       });
 
       try {
-        await waitFor(() => fs.existsSync(readyFile), "UI runner readiness");
-        expect(fs.readFileSync(readyFile, "utf8")).toBe("install");
+        const readReadyFile = () =>
+          fs.existsSync(readyFile) ? fs.readFileSync(readyFile, "utf8") : "";
+        await waitFor(() => readReadyFile() === "install", "UI runner readiness");
+        expect(readReadyFile()).toBe("install");
         wrapper.kill(signal);
 
         const exit = await waitForExit(wrapper);


### PR DESCRIPTION
Closes #92452

## What Problem This Solves

Fixes an issue where users who install the official Microsoft Teams channel through ClawHub would have the channel crash-loop when it starts, because the official ClawHub install could not pass the 6.x keyed-store trusted-plugin gate.

The reported install path is:

```bash
openclaw plugins install clawhub:@openclaw/msteams
```

On current published OpenClaw, that install records official ClawHub provenance, but `msteams` remains an untrusted global plugin. When the channel opens keyed state during startup, the runtime rejects it with:

```text
[msteams] [default] channel exited: openKeyedStore is only available for trusted plugins in this release.
```

## Why This Change Was Made

The trust predicate now recognizes official ClawHub installs whose official external catalog entry is npmSpec-only, reusing the existing official install-record/catalog matching helper instead of adding a Teams-specific bypass.

The trusted path still requires the install record to match an official ClawHub source/channel/URL and the official catalog package identity for the plugin id. Community, private, custom-URL, mismatched-package, and unrecorded global installs remain untrusted.

This intentionally does not solve broader self-hosted or arbitrary local plugin trust. Those remain separate from this narrow official ClawHub provenance fix.

## User Impact

Users can install the official Microsoft Teams channel from ClawHub and have the channel start normally instead of crash-looping at the keyed-state gate.

Official npmSpec-only ClawHub channel installs, including the same catalog shape used by Discord, can now satisfy `trustedOfficialInstall` when their install record and catalog identity match. Untrusted install sources still cannot access trusted keyed-state APIs.

## Evidence

Focused regression tests:

```text
$ node scripts/run-vitest.mjs src/plugins/manifest-registry.test.ts src/plugin-state/plugin-state-store.runtime.test.ts
[test] passed 2 Vitest shards in 5.90s
Test Files 2 passed
Tests 82 passed
```

Formatting and changed-file checks:

```text
$ corepack pnpm exec oxfmt --check --threads=1 src/plugins/manifest-registry.ts src/plugins/manifest-registry.test.ts
All matched files use the correct format.

$ git diff --check upstream/main..HEAD
passed

$ OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed -- src/plugins/manifest-registry.ts src/plugins/manifest-registry.test.ts
passed
```

Build:

```text
$ corepack pnpm build
passed
```

Dale before/after proof, using the reported official ClawHub install path with a temporary upstream-compatible single-agent config and redacted output.

Before, published `openclaw@2026.6.11`:

```json
{
  "version": "2026.6.11",
  "plugin": {
    "id": "msteams",
    "origin": "global",
    "status": "loaded",
    "trustedOfficialInstall": null
  },
  "install": {
    "source": "clawhub",
    "spec": "clawhub:@openclaw/msteams",
    "clawhubUrl": "https://clawhub.ai",
    "clawhubPackage": "@openclaw/msteams",
    "clawhubChannel": "official",
    "installPath": "<proof-state>/extensions/msteams"
  }
}
```

Before runtime log:

```text
2026-07-01T23:13:51.153-04:00 [msteams] starting provider (port 3978)
2026-07-01T23:13:51.161-04:00 [msteams] [default] channel exited: openKeyedStore is only available for trusted plugins in this release.
2026-07-01T23:13:51.162-04:00 [msteams] [default] auto-restart attempt 1/10 in 5s
```

After, candidate core commit `eedf704b096b0fe1b00d576bb654d0d14ef46e6d` with the same ClawHub install record:

```json
{
  "version": "candidate eedf704b096b0fe1b00d576bb654d0d14ef46e6d",
  "plugin": {
    "id": "msteams",
    "origin": "global",
    "status": "loaded",
    "trustedOfficialInstall": true
  },
  "install": {
    "source": "clawhub",
    "spec": "clawhub:@openclaw/msteams",
    "clawhubUrl": "https://clawhub.ai",
    "clawhubPackage": "@openclaw/msteams",
    "clawhubChannel": "official",
    "installPath": "<proof-state>/extensions/msteams"
  }
}
```

After runtime log and local webhook probe:

```text
2026-07-01T23:16:49.347-04:00 [msteams] starting provider (port 3978)
after_local_3978_status=401
```

No `openKeyedStore` trust error, `channel exited`, or Teams auto-restart line appeared in the after-proof gateway log.

Dale was restored after proof:

```text
OpenClaw 2026.6.10 (b1c0ea2)
msteams origin: bundled
port 3978 listening under the managed launchd gateway process
```

