### PR TITLE
fix(terminal): preserve sibling home-prefix paths

### DIFF
--- a/packages/terminal-core/src/display-string.test.ts
+++ b/packages/terminal-core/src/display-string.test.ts
@@ -1,0 +1,47 @@
+// Terminal Core tests cover display-safe path shortening.
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { displayString } from "./display-string.js";
+
+function stubHome(home: string, openclawHome = ""): void {
+  vi.stubEnv("HOME", home);
+  vi.stubEnv("USERPROFILE", "");
+  vi.stubEnv("OPENCLAW_HOME", openclawHome);
+}
+
+describe("displayString", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("shortens whole-value homes and child paths without clipping sibling prefixes", () => {
+    const home = path.resolve("test-home", "alice");
+    stubHome(home);
+
+    expect(displayString(home)).toBe("~");
+    expect(displayString(`${home}/project`)).toBe("~/project");
+    expect(displayString(`${home}\\project`)).toBe("~\\project");
+    expect(displayString(`Workspace: ${home}/project`)).toBe("Workspace: ~/project");
+    expect(displayString(`${home}/one ${home}/two`)).toBe("~/one ~/two");
+    expect(displayString(`Home: ${home},`)).toBe("Home: ~,");
+    expect(displayString(`(${home})`)).toBe("(~)");
+    expect(displayString(`${home}.`)).toBe("~.");
+
+    expect(displayString(`${home}2/project`)).toBe(`${home}2/project`);
+    expect(displayString(`${home},backup`)).toBe(`${home},backup`);
+    expect(displayString(`${home} backup/project`)).toBe(`${home} backup/project`);
+    expect(displayString(`${home}../project`)).toBe(`${home}../project`);
+    expect(displayString(`prefix${home}/project`)).toBe(`prefix${home}/project`);
+    expect(displayString(`/tmp${home}/project`)).toBe(`/tmp${home}/project`);
+  });
+
+  it("uses OPENCLAW_HOME as the display prefix", () => {
+    const home = path.resolve("test-home", "alice");
+    const openclawHome = path.resolve("test-openclaw-home");
+    stubHome(home, openclawHome);
+
+    expect(displayString(openclawHome)).toBe("$OPENCLAW_HOME");
+    expect(displayString(`${openclawHome}/state`)).toBe("$OPENCLAW_HOME/state");
+    expect(displayString(`${openclawHome}2/state`)).toBe(`${openclawHome}2/state`);
+  });
+});

--- a/packages/terminal-core/src/display-string.ts
+++ b/packages/terminal-core/src/display-string.ts
@@ -73,16 +73,10 @@ function resolveHomeDisplayPrefix(): { home: string; prefix: string } | undefine
   return explicitHome ? { home, prefix: "$OPENCLAW_HOME" } : { home, prefix: "~" };
 }
 
-/** Replace only exact home matches or paths contained by that home directory. */
+/** Replace a whole-value home or child path without clipping sibling path prefixes. */
 function replaceHomePath(input: string, display: { home: string; prefix: string }): string {
   let output = "";
   let cursor = 0;
-  const isBeforeBoundary = (value: string | undefined) =>
-    value === undefined || value === "/" || value === "\\" || /[\s("'`:=[{,]/u.test(value);
-  const isTrailingDelimiter = (value: string | undefined) =>
-    value === undefined || /\s/u.test(value) || /[)"'`:,;\]}]/u.test(value);
-  const isAfterBoundary = (value: string | undefined) =>
-    value === undefined || value === "/" || value === "\\";
 
   while (cursor < input.length) {
     const index = input.indexOf(display.home, cursor);
@@ -91,12 +85,19 @@ function replaceHomePath(input: string, display: { home: string; prefix: string 
     }
 
     const before = input[index - 1];
-    const after = input[index + display.home.length];
-    const afterNext = input[index + display.home.length + 1];
-    if (
-      isBeforeBoundary(before) &&
-      (isAfterBoundary(after) || (isTrailingDelimiter(after) && isTrailingDelimiter(afterNext)))
-    ) {
+    const homeEnd = index + display.home.length;
+    const after = input[homeEnd];
+    const startsToken = before === undefined || /[\s("'`:=[{,]/u.test(before);
+    let punctuationEnd = homeEnd;
+    while (punctuationEnd < input.length && /[)"'`:,;.\]}]/u.test(input[punctuationEnd])) {
+      punctuationEnd += 1;
+    }
+    const punctuationEndsToken =
+      punctuationEnd > homeEnd &&
+      (punctuationEnd === input.length || /\s/u.test(input[punctuationEnd]));
+    const endsTokenOrContinuesPath =
+      after === undefined || after === "/" || after === "\\" || punctuationEndsToken;
+    if (startsToken && endsTokenOrContinuesPath) {
       output += `${input.slice(cursor, index)}${display.prefix}`;
     } else {
       output += input.slice(cursor, index + display.home.length);

--- a/packages/terminal-core/src/display-string.ts
+++ b/packages/terminal-core/src/display-string.ts
@@ -73,11 +73,34 @@ function resolveHomeDisplayPrefix(): { home: string; prefix: string } | undefine
   return explicitHome ? { home, prefix: "$OPENCLAW_HOME" } : { home, prefix: "~" };
 }
 
+/** Replace only exact home matches or paths contained by that home directory. */
+function replaceHomePath(input: string, display: { home: string; prefix: string }): string {
+  let output = "";
+  let cursor = 0;
+
+  while (cursor < input.length) {
+    const index = input.indexOf(display.home, cursor);
+    if (index < 0) {
+      return `${output}${input.slice(cursor)}`;
+    }
+
+    const after = input[index + display.home.length];
+    if (after === undefined || after === "/" || after === "\\") {
+      output += `${input.slice(cursor, index)}${display.prefix}`;
+    } else {
+      output += input.slice(cursor, index + display.home.length);
+    }
+    cursor = index + display.home.length;
+  }
+
+  return output;
+}
+
 /** Replace the effective home path with "~" or "$OPENCLAW_HOME" for terminal display. */
 export function displayString(input: string): string {
   if (!input) {
     return input;
   }
   const display = resolveHomeDisplayPrefix();
-  return display ? input.split(display.home).join(display.prefix) : input;
+  return display ? replaceHomePath(input, display) : input;
 }

--- a/packages/terminal-core/src/display-string.ts
+++ b/packages/terminal-core/src/display-string.ts
@@ -77,6 +77,10 @@ function resolveHomeDisplayPrefix(): { home: string; prefix: string } | undefine
 function replaceHomePath(input: string, display: { home: string; prefix: string }): string {
   let output = "";
   let cursor = 0;
+  const isBeforeBoundary = (value: string | undefined) =>
+    value === undefined || value === "/" || value === "\\" || /[\s("'`:=\[{,]/u.test(value);
+  const isAfterBoundary = (value: string | undefined) =>
+    value === undefined || value === "/" || value === "\\";
 
   while (cursor < input.length) {
     const index = input.indexOf(display.home, cursor);
@@ -84,8 +88,9 @@ function replaceHomePath(input: string, display: { home: string; prefix: string 
       return `${output}${input.slice(cursor)}`;
     }
 
+    const before = input[index - 1];
     const after = input[index + display.home.length];
-    if (after === undefined || after === "/" || after === "\\") {
+    if (isBeforeBoundary(before) && isAfterBoundary(after)) {
       output += `${input.slice(cursor, index)}${display.prefix}`;
     } else {
       output += input.slice(cursor, index + display.home.length);

--- a/packages/terminal-core/src/display-string.ts
+++ b/packages/terminal-core/src/display-string.ts
@@ -78,7 +78,9 @@ function replaceHomePath(input: string, display: { home: string; prefix: string 
   let output = "";
   let cursor = 0;
   const isBeforeBoundary = (value: string | undefined) =>
-    value === undefined || value === "/" || value === "\\" || /[\s("'`:=\[{,]/u.test(value);
+    value === undefined || value === "/" || value === "\\" || /[\s("'`:=[{,]/u.test(value);
+  const isTrailingDelimiter = (value: string | undefined) =>
+    value === undefined || /\s/u.test(value) || /[)"'`:,;\]}]/u.test(value);
   const isAfterBoundary = (value: string | undefined) =>
     value === undefined || value === "/" || value === "\\";
 
@@ -90,7 +92,11 @@ function replaceHomePath(input: string, display: { home: string; prefix: string 
 
     const before = input[index - 1];
     const after = input[index + display.home.length];
-    if (isBeforeBoundary(before) && isAfterBoundary(after)) {
+    const afterNext = input[index + display.home.length + 1];
+    if (
+      isBeforeBoundary(before) &&
+      (isAfterBoundary(after) || (isTrailingDelimiter(after) && isTrailingDelimiter(afterNext)))
+    ) {
       output += `${input.slice(cursor, index)}${display.prefix}`;
     } else {
       output += input.slice(cursor, index + display.home.length);

--- a/packages/terminal-core/src/table.test.ts
+++ b/packages/terminal-core/src/table.test.ts
@@ -1,6 +1,6 @@
-import { note as clackNote } from "@clack/prompts";
 // Terminal Core tests cover table behavior.
 import path from "node:path";
+import { note as clackNote } from "@clack/prompts";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { visibleWidth } from "./ansi.js";
 import { resolveNoteColumns, resolveNoteOutputColumns, wrapNoteMessage } from "./note.js";
@@ -192,14 +192,22 @@ describe("renderTable", () => {
         { Path: `${home}/project` },
         { Path: `${home}\\project` },
         { Path: `${home}2/project` },
+        { Path: `prefix${home}/project` },
+        { Path: `Workspace: ${home}/project` },
+        { Path: `path=${home}/project` },
       ],
     });
 
+    const embedded = `prefix${home}/project`;
     expect(out).toContain("~\n");
     expect(out).toContain("~/project");
     expect(out).toContain("~\\project");
     expect(out).toContain(`${home}2/project`);
+    expect(out).toContain(embedded);
+    expect(out).toContain("Workspace: ~/project");
+    expect(out).toContain("path=~/project");
     expect(out).not.toContain("~2/project");
+    expect(out).not.toContain("prefix~/project");
   });
 
   it("keeps OPENCLAW_HOME as the display prefix for exact and child paths", () => {

--- a/packages/terminal-core/src/table.test.ts
+++ b/packages/terminal-core/src/table.test.ts
@@ -195,6 +195,10 @@ describe("renderTable", () => {
         { Path: `prefix${home}/project` },
         { Path: `Workspace: ${home}/project` },
         { Path: `path=${home}/project` },
+        { Path: `Home: ${home},` },
+        { Path: `(${home})` },
+        { Path: `${home},backup` },
+        { Path: `${home} backup\\file` },
       ],
     });
 
@@ -206,7 +210,13 @@ describe("renderTable", () => {
     expect(out).toContain(embedded);
     expect(out).toContain("Workspace: ~/project");
     expect(out).toContain("path=~/project");
+    expect(out).toContain("Home: ~,");
+    expect(out).toContain("(~)");
+    expect(out).toContain(`${home},backup`);
+    expect(out).toContain(`${home} backup\\file`);
     expect(out).not.toContain("~2/project");
+    expect(out).not.toContain("~,backup");
+    expect(out).not.toContain("~ backup\\file");
     expect(out).not.toContain("prefix~/project");
   });
 

--- a/packages/terminal-core/src/table.test.ts
+++ b/packages/terminal-core/src/table.test.ts
@@ -190,57 +190,16 @@ describe("renderTable", () => {
       rows: [
         { Path: home },
         { Path: `${home}/project` },
-        { Path: `${home}\\project` },
         { Path: `${home}2/project` },
-        { Path: `prefix${home}/project` },
         { Path: `Workspace: ${home}/project` },
-        { Path: `path=${home}/project` },
-        { Path: `Home: ${home},` },
-        { Path: `(${home})` },
-        { Path: `${home},backup` },
-        { Path: `${home} backup\\file` },
       ],
     });
 
-    const embedded = `prefix${home}/project`;
     expect(out).toContain("~\n");
     expect(out).toContain("~/project");
-    expect(out).toContain("~\\project");
     expect(out).toContain(`${home}2/project`);
-    expect(out).toContain(embedded);
     expect(out).toContain("Workspace: ~/project");
-    expect(out).toContain("path=~/project");
-    expect(out).toContain("Home: ~,");
-    expect(out).toContain("(~)");
-    expect(out).toContain(`${home},backup`);
-    expect(out).toContain(`${home} backup\\file`);
     expect(out).not.toContain("~2/project");
-    expect(out).not.toContain("~,backup");
-    expect(out).not.toContain("~ backup\\file");
-    expect(out).not.toContain("prefix~/project");
-  });
-
-  it("keeps OPENCLAW_HOME as the display prefix for exact and child paths", () => {
-    const home = path.resolve("test-home", "alice");
-    const openclawHome = path.resolve("test-openclaw-home");
-    vi.stubEnv("HOME", home);
-    vi.stubEnv("USERPROFILE", "");
-    vi.stubEnv("OPENCLAW_HOME", openclawHome);
-
-    const out = renderTable({
-      border: "none",
-      columns: [{ key: "Path", header: "Path" }],
-      rows: [
-        { Path: openclawHome },
-        { Path: `${openclawHome}/state` },
-        { Path: `${openclawHome}2/state` },
-      ],
-    });
-
-    expect(out).toContain("$OPENCLAW_HOME\n");
-    expect(out).toContain("$OPENCLAW_HOME/state");
-    expect(out).toContain(`${openclawHome}2/state`);
-    expect(out).not.toContain("$OPENCLAW_HOME2/state");
   });
 
   it("keeps table borders aligned when cells contain wide emoji graphemes", () => {

--- a/packages/terminal-core/src/table.test.ts
+++ b/packages/terminal-core/src/table.test.ts
@@ -1,5 +1,6 @@
 import { note as clackNote } from "@clack/prompts";
 // Terminal Core tests cover table behavior.
+import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { visibleWidth } from "./ansi.js";
 import { resolveNoteColumns, resolveNoteOutputColumns, wrapNoteMessage } from "./note.js";
@@ -175,6 +176,53 @@ describe("renderTable", () => {
     const line2Index = lines.findIndex((line) => line.includes("line2"));
     expect(line1Index).toBeGreaterThan(-1);
     expect(line2Index).toBe(line1Index + 1);
+  });
+
+  it("shortens only exact home paths and child paths in table cells", () => {
+    const home = path.resolve("test-home", "alice");
+    vi.stubEnv("HOME", home);
+    vi.stubEnv("USERPROFILE", "");
+    vi.stubEnv("OPENCLAW_HOME", "");
+
+    const out = renderTable({
+      border: "none",
+      columns: [{ key: "Path", header: "Path" }],
+      rows: [
+        { Path: home },
+        { Path: `${home}/project` },
+        { Path: `${home}\\project` },
+        { Path: `${home}2/project` },
+      ],
+    });
+
+    expect(out).toContain("~\n");
+    expect(out).toContain("~/project");
+    expect(out).toContain("~\\project");
+    expect(out).toContain(`${home}2/project`);
+    expect(out).not.toContain("~2/project");
+  });
+
+  it("keeps OPENCLAW_HOME as the display prefix for exact and child paths", () => {
+    const home = path.resolve("test-home", "alice");
+    const openclawHome = path.resolve("test-openclaw-home");
+    vi.stubEnv("HOME", home);
+    vi.stubEnv("USERPROFILE", "");
+    vi.stubEnv("OPENCLAW_HOME", openclawHome);
+
+    const out = renderTable({
+      border: "none",
+      columns: [{ key: "Path", header: "Path" }],
+      rows: [
+        { Path: openclawHome },
+        { Path: `${openclawHome}/state` },
+        { Path: `${openclawHome}2/state` },
+      ],
+    });
+
+    expect(out).toContain("$OPENCLAW_HOME\n");
+    expect(out).toContain("$OPENCLAW_HOME/state");
+    expect(out).toContain(`${openclawHome}2/state`);
+    expect(out).not.toContain("$OPENCLAW_HOME2/state");
   });
 
   it("keeps table borders aligned when cells contain wide emoji graphemes", () => {


### PR DESCRIPTION
Closes #98872

## What Problem This Solves

Terminal table rendering globally replaced the effective home string, so sibling or embedded paths that merely shared that prefix could be corrupted. For example, `/home/alice2/project` could display as `~2/project` when the effective home was `/home/alice`.

## Why This Change Was Made

`displayString` now scans home occurrences and replaces only values with a real left token boundary plus one of these right boundaries:

- end of the value
- a `/` or `\\` child-path separator
- a terminal punctuation run followed by whitespace or end of input

This preserves whole-home and child-path shortening, including labeled table values, while rejecting sibling prefixes, embedded longer paths, space-suffixed siblings, comma-suffixed siblings, and punctuation runs that continue into a path. The detailed cases live beside `displayString`; `renderTable` keeps one integration test.

## User Impact

Terminal tables no longer show misleading paths such as `~2/project` or `/tmp~/project`. Exact home paths, child paths, and complete home tokens before terminal punctuation still use `~` or `$OPENCLAW_HOME`.

## Evidence

- Exact repaired head: `de0ff5fdf7f538594197830b1647895cf3c65064`
- `node scripts/run-vitest.mjs packages/terminal-core/src/display-string.test.ts packages/terminal-core/src/table.test.ts`: 27/27 tests passed
- `./node_modules/.bin/oxfmt --check ...` and `./node_modules/.bin/oxlint ...`: passed for all three changed files
- Fresh autoreview after accepted boundary fixes: no findings, confidence 0.91
- Blacksmith Testbox `tbx_01kwgwkdma74r1frdw64pn1ark`, Actions run `28573967242`: remote `check:changed` passed the `core` and `coreTests` lanes with exit 0
- Exact-head GitHub CI: 61 passing checks, 0 pending, 0 failing; two initial workflow-sanity checkout failures were rerun successfully after GitHub returned HTTP 429
- Known scope boundary: `src/utils.ts` has a broader public/plugin-SDK helper with similar prefix behavior; it is intentionally excluded from this narrow terminal-core fix and needs a separate clean follow-up