### PR TITLE
fix(codex): honor timeoutSeconds when timeoutMs is absent in dynamic tool calls (fixes #98864)

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tool-execution.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-execution.test.ts
@@ -179,6 +179,54 @@ describe("dynamic tool execution helpers", () => {
     ).toBe(90_000);
   });
 
+  it("honors timeoutSeconds when timeoutMs is absent in dynamic tool arguments", () => {
+    expect(
+      resolveDynamicToolCallTimeoutMs({
+        call: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          callId: "call-timeout-seconds",
+          namespace: null,
+          tool: "session_send",
+          arguments: { sessionKey: "abc", timeoutSeconds: 120 },
+        },
+        config: undefined,
+      }),
+    ).toBe(120_000);
+  });
+
+  it("prefers timeoutMs over timeoutSeconds when both are present", () => {
+    expect(
+      resolveDynamicToolCallTimeoutMs({
+        call: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          callId: "call-both-timeouts",
+          namespace: null,
+          tool: "session_send",
+          arguments: { sessionKey: "abc", timeoutMs: 45_000, timeoutSeconds: 120 },
+        },
+        config: undefined,
+      }),
+    ).toBe(45_000);
+  });
+
+  it("ignores non-positive timeoutSeconds in dynamic tool arguments", () => {
+    expect(
+      resolveDynamicToolCallTimeoutMs({
+        call: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          callId: "call-negative-timeout-seconds",
+          namespace: null,
+          tool: "session_send",
+          arguments: { sessionKey: "abc", timeoutSeconds: -10 },
+        },
+        config: undefined,
+      }),
+    ).toBe(90_000);
+  });
+
   it("returns a failed dynamic tool response when an app-server tool call exceeds the deadline", async () => {
     vi.useFakeTimers();
     let capturedSignal: AbortSignal | undefined;

--- a/extensions/codex/src/app-server/dynamic-tool-execution.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-execution.ts
@@ -443,7 +443,9 @@ function readDynamicToolCallTimeoutMs(value: JsonValue | undefined): number | un
   if (!isJsonObject(value)) {
     return undefined;
   }
-  return readPositiveFiniteTimeoutMs(value.timeoutMs);
+  return (
+    readPositiveFiniteTimeoutMs(value.timeoutMs) ?? readTimeoutSecondsAsMs(value.timeoutSeconds)
+  );
 }
 
 function readConfiguredDynamicToolTimeoutMs(

--- a/extensions/codex/src/app-server/side-question.ts
+++ b/extensions/codex/src/app-server/side-question.ts
@@ -898,7 +898,10 @@ function readSideDynamicToolCallTimeoutMs(value: JsonValue | undefined): number 
   if (!isJsonObject(value)) {
     return undefined;
   }
-  return readSidePositiveFiniteTimeoutMs(value.timeoutMs);
+  return (
+    readSidePositiveFiniteTimeoutMs(value.timeoutMs) ??
+    readSideTimeoutSecondsAsMs(value.timeoutSeconds)
+  );
 }
 
 function readSideImageGenerationModelTimeoutMs(


### PR DESCRIPTION
## What Problem This Solves

Dynamic tool calls can carry a `timeoutSeconds` field while omitting `timeoutMs`. The hard-call timeout reader (`readDynamicToolCallTimeoutMs`) only looked at `timeoutMs`, so a tool configured with a timeout in seconds would fall back to the default 90-second hard guard instead of honoring the configured value. This affects long-running or bounded tools such as session send helpers, where the caller expects `timeoutSeconds` to cap the tool call.

## Why This Change Was Made

The `readDynamicToolCallTimeoutMs` function in `extensions/codex/src/app-server/dynamic-tool-execution.ts` only read `value.timeoutMs` and ignored `value.timeoutSeconds`. The `readTimeoutSecondsAsMs` helper already existed in the same file for other timeout resolution paths (e.g., `readConfiguredDynamicToolTimeoutMs` for the `image` tool). The fix adds `readTimeoutSecondsAsMs(value.timeoutSeconds)` as a fallback when `timeoutMs` is absent, consistent with how other timeout resolution paths in the codebase handle seconds-vs-milliseconds duality (e.g., `web-guarded-fetch.ts`).

## User Impact

- A dynamic tool call with `timeoutMs` keeps existing behavior (no change).
- A dynamic tool call with only `timeoutSeconds` now uses that value as the hard timeout instead of the 90-second default.
- Invalid or non-positive `timeoutSeconds` values are ignored the same way invalid `timeoutMs` values are ignored.
- The existing failed-tool-response shape is returned on timeout; no behavioral change to the timeout error path.

## Evidence

- **Behavior addressed:** Dynamic tool hard timeout ignores `timeoutSeconds` when `timeoutMs` is absent.
- **Environment tested:** macOS, Node 22.22.3, OpenClaw 2026.6.11 (8e95e56).
- **Steps run after the patch:** Built the project (`pnpm build`), verified the compiled dist output, ran the codex extension test suite.
- **Evidence after fix:** The compiled `readDynamicToolCallTimeoutMs` in `dist/run-attempt-*.js` now reads:

```js
function readDynamicToolCallTimeoutMs(value) {
	if (!isJsonObject(value)) return;
	return readPositiveFiniteTimeoutMs(value.timeoutMs) ?? readTimeoutSecondsAsMs(value.timeoutSeconds);
}
```

- **Observed result after fix:** All 16 dynamic-tool-execution tests pass, including 3 new tests covering `timeoutSeconds` fallback, `timeoutMs` priority over `timeoutSeconds`, and non-positive `timeoutSeconds` rejection.
- **What was not tested:** Live end-to-end dynamic tool call with a real MCP server setting `timeoutSeconds`. The fix is a single-expression fallback addition with existing helper reuse; the test suite covers the resolution logic exhaustively.

## Real behavior proof

- **Behavior addressed:** Dynamic tool hard timeout ignores `timeoutSeconds` when `timeoutMs` is absent.
- **Environment tested:** macOS, Node 22.22.3, OpenClaw 2026.6.11 (8e95e56).
- **Steps run after the patch:** `pnpm build` → verified compiled dist → `node scripts/run-vitest.mjs run extensions/codex/src/app-server/dynamic-tool-execution.test.ts`.
- **Evidence after fix:** Compiled dist function:

```js
return readPositiveFiniteTimeoutMs(value.timeoutMs) ?? readTimeoutSecondsAsMs(value.timeoutSeconds);
```

Previously: `return readPositiveFiniteTimeoutMs(value.timeoutMs);` (no `timeoutSeconds` fallback).

- **Observed result after fix:** 16/16 tests pass. New tests confirm `timeoutSeconds: 120` → resolved to `120_000ms`; `timeoutMs: 45_000` takes priority over `timeoutSeconds: 120`; `timeoutSeconds: -10` falls back to default `90_000ms`.
- **What was not tested:** Live MCP server interaction. The fix reuses the existing `readTimeoutSecondsAsMs` helper already proven in other timeout resolution paths.

- [x] AI-assisted (Hermes Agent)
