### PR TITLE
fix(codex): honor timeoutSeconds for dynamic tool calls

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tool-execution.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-execution.test.ts
@@ -40,6 +40,48 @@ describe("dynamic tool execution helpers", () => {
     ).toBe(timeoutMs);
   });
 
+  it("uses per-call timeoutSeconds when timeoutMs is absent", () => {
+    expect(
+      resolveDynamicToolCallTimeoutMs({
+        call: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          callId: "call-timeout-seconds",
+          namespace: null,
+          tool: "sessions_send",
+          arguments: { timeoutSeconds: 12 },
+        },
+        config: undefined,
+      }),
+    ).toBe(12_000);
+    expect(
+      resolveDynamicToolCallTimeoutMs({
+        call: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          callId: "call-timeout-ms-wins",
+          namespace: null,
+          tool: "sessions_send",
+          arguments: { timeoutMs: 1234, timeoutSeconds: 12 },
+        },
+        config: undefined,
+      }),
+    ).toBe(1234);
+    expect(
+      resolveDynamicToolCallTimeoutMs({
+        call: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          callId: "call-invalid-timeout-seconds",
+          namespace: null,
+          tool: "sessions_send",
+          arguments: { timeoutSeconds: 0 },
+        },
+        config: undefined,
+      }),
+    ).toBe(CODEX_DYNAMIC_TOOL_TIMEOUT_MS);
+  });
+
   it("ignores partial dynamic tool timeout strings", () => {
     expect(
       resolveDynamicToolCallTimeoutMs({

--- a/extensions/codex/src/app-server/dynamic-tool-execution.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-execution.test.ts
@@ -5,6 +5,7 @@ import {
   CODEX_DYNAMIC_IMAGE_TOOL_TIMEOUT_MS,
   CODEX_DYNAMIC_MESSAGE_TOOL_TIMEOUT_MS,
   CODEX_DYNAMIC_TOOL_MAX_TIMEOUT_MS,
+  CODEX_DYNAMIC_TOOL_SECONDS_GRACE_MS,
   CODEX_DYNAMIC_TOOL_TIMEOUT_MS,
   handleDynamicToolCallWithTimeout,
   resolveDynamicToolCallTimeoutMs,
@@ -40,7 +41,7 @@ describe("dynamic tool execution helpers", () => {
     ).toBe(timeoutMs);
   });
 
-  it("uses per-call timeoutSeconds when timeoutMs is absent", () => {
+  it("uses per-call timeoutSeconds plus grace when timeoutMs is absent", () => {
     expect(
       resolveDynamicToolCallTimeoutMs({
         call: {
@@ -53,7 +54,7 @@ describe("dynamic tool execution helpers", () => {
         },
         config: undefined,
       }),
-    ).toBe(12_000);
+    ).toBe(12_000 + CODEX_DYNAMIC_TOOL_SECONDS_GRACE_MS);
     expect(
       resolveDynamicToolCallTimeoutMs({
         call: {
@@ -76,6 +77,21 @@ describe("dynamic tool execution helpers", () => {
           namespace: null,
           tool: "sessions_send",
           arguments: { timeoutSeconds: 0 },
+        },
+        config: undefined,
+      }),
+    ).toBe(CODEX_DYNAMIC_TOOL_TIMEOUT_MS);
+    // Fractional sub-second budgets must fall back to the default instead of
+    // flooring to a 0ms value the clamp would turn into an instant 1ms kill.
+    expect(
+      resolveDynamicToolCallTimeoutMs({
+        call: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          callId: "call-fractional-timeout-seconds",
+          namespace: null,
+          tool: "sessions_send",
+          arguments: { timeoutSeconds: 0.5 },
         },
         config: undefined,
       }),

--- a/extensions/codex/src/app-server/dynamic-tool-execution.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-execution.ts
@@ -10,7 +10,11 @@ import {
   hasPendingInternalDiagnosticEvent,
   type DiagnosticEventPayload,
 } from "openclaw/plugin-sdk/diagnostic-runtime";
-import { parseStrictNonNegativeInteger } from "openclaw/plugin-sdk/number-runtime";
+import {
+  addTimerTimeoutGraceMs,
+  finiteSecondsToTimerSafeMilliseconds,
+  parseStrictNonNegativeInteger,
+} from "openclaw/plugin-sdk/number-runtime";
 import type { CodexDynamicToolBridge } from "./dynamic-tools.js";
 import {
   isJsonObject,
@@ -28,6 +32,10 @@ const CODEX_DYNAMIC_IMAGE_GENERATION_TOOL_TIMEOUT_MS = 120_000;
 export const CODEX_DYNAMIC_IMAGE_TOOL_TIMEOUT_MS = 60_000;
 /** Timeout for message-delivery dynamic tool calls. */
 export const CODEX_DYNAMIC_MESSAGE_TOOL_TIMEOUT_MS = 120_000;
+// Per-call timeoutSeconds is the tool's inner wait budget (e.g. sessions_send
+// waits that long after gateway pre-work); without headroom the watchdog fires
+// first and replaces the tool's graceful timeout result with a hard kill.
+export const CODEX_DYNAMIC_TOOL_SECONDS_GRACE_MS = 30_000;
 const LOG_FIELD_MAX_LENGTH = 160;
 
 type DynamicToolTimeoutDetails = {
@@ -439,14 +447,19 @@ export function resolveDynamicToolCallTimeoutMs(params: {
   );
 }
 
-function readDynamicToolCallTimeoutMs(value: JsonValue | undefined): number | undefined {
+export function readDynamicToolCallTimeoutMs(value: JsonValue | undefined): number | undefined {
   if (!isJsonObject(value)) {
     return undefined;
   }
-  // Tool schemas expose seconds-form budgets to models; mirror that as the
-  // outer app-server watchdog when no millisecond override is supplied.
+  // timeoutMs stays an exact watchdog override. timeoutSeconds is the seconds
+  // budget tool schemas expose to models; grace lets the tool's own timer
+  // (same seconds value) win the race and return its structured result.
   return (
-    readPositiveFiniteTimeoutMs(value.timeoutMs) ?? readTimeoutSecondsAsMs(value.timeoutSeconds)
+    readPositiveFiniteTimeoutMs(value.timeoutMs) ??
+    addTimerTimeoutGraceMs(
+      readTimeoutSecondsAsMs(value.timeoutSeconds),
+      CODEX_DYNAMIC_TOOL_SECONDS_GRACE_MS,
+    )
   );
 }
 
@@ -479,12 +492,13 @@ function readConfiguredDynamicToolTimeoutMs(
   return undefined;
 }
 
-function readTimeoutSecondsAsMs(value: unknown): number | undefined {
-  const seconds = readPositiveFiniteTimeoutMs(value);
-  return seconds === undefined ? undefined : seconds * 1000;
+export function readTimeoutSecondsAsMs(value: unknown): number | undefined {
+  // floorSeconds matches sessions_send's own conversion, so watchdog and tool
+  // agree on what counts as a usable budget (fractional sub-second is not one).
+  return finiteSecondsToTimerSafeMilliseconds(value, { floorSeconds: true });
 }
 
-function readPositiveFiniteTimeoutMs(value: unknown): number | undefined {
+export function readPositiveFiniteTimeoutMs(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value) && value > 0
     ? Math.floor(value)
     : undefined;

--- a/extensions/codex/src/app-server/dynamic-tool-execution.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-execution.ts
@@ -443,7 +443,11 @@ function readDynamicToolCallTimeoutMs(value: JsonValue | undefined): number | un
   if (!isJsonObject(value)) {
     return undefined;
   }
-  return readPositiveFiniteTimeoutMs(value.timeoutMs);
+  // Tool schemas expose seconds-form budgets to models; mirror that as the
+  // outer app-server watchdog when no millisecond override is supplied.
+  return (
+    readPositiveFiniteTimeoutMs(value.timeoutMs) ?? readTimeoutSecondsAsMs(value.timeoutSeconds)
+  );
 }
 
 function readConfiguredDynamicToolTimeoutMs(

--- a/extensions/codex/src/app-server/side-question.test.ts
+++ b/extensions/codex/src/app-server/side-question.test.ts
@@ -1857,6 +1857,21 @@ describe("runCodexAppServerSideQuestion", () => {
     expect(timeoutMs).toBe(123_456);
   });
 
+  it("uses per-call timeoutSeconds for side-thread dynamic tool calls", () => {
+    const timeoutMs = testing.resolveSideDynamicToolCallTimeoutMs({
+      call: {
+        threadId: "side-thread",
+        turnId: "turn-1",
+        callId: "tool-1",
+        tool: "sessions_send",
+        arguments: { timeoutSeconds: 12 },
+      },
+      config: {} as never,
+    });
+
+    expect(timeoutMs).toBe(12_000);
+  });
+
   it("uses a 120 second default for side-thread image_generate calls", () => {
     const timeoutMs = testing.resolveSideDynamicToolCallTimeoutMs({
       call: {

--- a/extensions/codex/src/app-server/side-question.test.ts
+++ b/extensions/codex/src/app-server/side-question.test.ts
@@ -11,6 +11,7 @@ import {
 } from "openclaw/plugin-sdk/hook-runtime";
 import { createMockPluginRegistry } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CODEX_DYNAMIC_TOOL_SECONDS_GRACE_MS } from "./dynamic-tool-execution.js";
 import type { CodexServerNotification, JsonObject, RpcRequest } from "./protocol.js";
 
 const readCodexAppServerBindingMock = vi.fn();
@@ -1857,7 +1858,7 @@ describe("runCodexAppServerSideQuestion", () => {
     expect(timeoutMs).toBe(123_456);
   });
 
-  it("uses per-call timeoutSeconds for side-thread dynamic tool calls", () => {
+  it("uses per-call timeoutSeconds plus grace for side-thread dynamic tool calls", () => {
     const timeoutMs = testing.resolveSideDynamicToolCallTimeoutMs({
       call: {
         threadId: "side-thread",
@@ -1869,7 +1870,7 @@ describe("runCodexAppServerSideQuestion", () => {
       config: {} as never,
     });
 
-    expect(timeoutMs).toBe(12_000);
+    expect(timeoutMs).toBe(12_000 + CODEX_DYNAMIC_TOOL_SECONDS_GRACE_MS);
   });
 
   it("uses a 120 second default for side-thread image_generate calls", () => {

--- a/extensions/codex/src/app-server/side-question.ts
+++ b/extensions/codex/src/app-server/side-question.ts
@@ -898,7 +898,12 @@ function readSideDynamicToolCallTimeoutMs(value: JsonValue | undefined): number 
   if (!isJsonObject(value)) {
     return undefined;
   }
-  return readSidePositiveFiniteTimeoutMs(value.timeoutMs);
+  // Tool schemas expose seconds-form budgets to models; mirror that as the
+  // outer app-server watchdog when no millisecond override is supplied.
+  return (
+    readSidePositiveFiniteTimeoutMs(value.timeoutMs) ??
+    readSideTimeoutSecondsAsMs(value.timeoutSeconds)
+  );
 }
 
 function readSideImageGenerationModelTimeoutMs(

--- a/extensions/codex/src/app-server/side-question.ts
+++ b/extensions/codex/src/app-server/side-question.ts
@@ -42,6 +42,11 @@ import {
   emitDynamicToolTerminalDiagnostic,
 } from "./dynamic-tool-diagnostics.js";
 import {
+  readDynamicToolCallTimeoutMs,
+  readPositiveFiniteTimeoutMs,
+  readTimeoutSecondsAsMs,
+} from "./dynamic-tool-execution.js";
+import {
   filterCodexDynamicTools,
   resolveCodexDynamicToolsLoading,
 } from "./dynamic-tool-profile.js";
@@ -882,28 +887,16 @@ function resolveSideDynamicToolCallTimeoutMs(params: {
   config: AgentHarnessSideQuestionParams["cfg"];
 }): number {
   const configured =
-    readSideDynamicToolCallTimeoutMs(params.call.arguments) ??
+    readDynamicToolCallTimeoutMs(params.call.arguments) ??
     (params.call.tool === "image_generate"
       ? (readSideImageGenerationModelTimeoutMs(params.config) ??
         CODEX_SIDE_DYNAMIC_IMAGE_GENERATION_TOOL_TIMEOUT_MS)
       : undefined) ??
     (params.call.tool === "image"
-      ? (readSideTimeoutSecondsAsMs(params.config?.tools?.media?.image?.timeoutSeconds) ??
+      ? (readTimeoutSecondsAsMs(params.config?.tools?.media?.image?.timeoutSeconds) ??
         CODEX_SIDE_DYNAMIC_IMAGE_TOOL_TIMEOUT_MS)
       : undefined);
   return clampSideDynamicToolTimeoutMs(configured ?? CODEX_SIDE_DYNAMIC_TOOL_TIMEOUT_MS);
-}
-
-function readSideDynamicToolCallTimeoutMs(value: JsonValue | undefined): number | undefined {
-  if (!isJsonObject(value)) {
-    return undefined;
-  }
-  // Tool schemas expose seconds-form budgets to models; mirror that as the
-  // outer app-server watchdog when no millisecond override is supplied.
-  return (
-    readSidePositiveFiniteTimeoutMs(value.timeoutMs) ??
-    readSideTimeoutSecondsAsMs(value.timeoutSeconds)
-  );
 }
 
 function readSideImageGenerationModelTimeoutMs(
@@ -913,18 +906,7 @@ function readSideImageGenerationModelTimeoutMs(
   if (!imageGenerationModel || typeof imageGenerationModel !== "object") {
     return undefined;
   }
-  return readSidePositiveFiniteTimeoutMs(imageGenerationModel.timeoutMs);
-}
-
-function readSideTimeoutSecondsAsMs(value: unknown): number | undefined {
-  const seconds = readSidePositiveFiniteTimeoutMs(value);
-  return seconds === undefined ? undefined : seconds * 1000;
-}
-
-function readSidePositiveFiniteTimeoutMs(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isFinite(value) && value > 0
-    ? Math.floor(value)
-    : undefined;
+  return readPositiveFiniteTimeoutMs(imageGenerationModel.timeoutMs);
 }
 
 function clampSideDynamicToolTimeoutMs(timeoutMs: number): number {


### PR DESCRIPTION
Closes #98864

## What Problem This Solves

Codex dynamic tool calls such as `sessions_send` can pass `timeoutSeconds` without `timeoutMs`. The app-server watchdog only read `timeoutMs`, so a call with a seconds-form budget fell back to the default 90-second dynamic-tool guard and long-running bounded helpers were killed early.

## Why This Change Was Made

The dynamic-tool timeout readers now fall back to `timeoutSeconds` when `timeoutMs` is absent, with two deliberate properties beyond a verbatim mapping:

- **Shared, validated seconds conversion.** The conversion goes through `finiteSecondsToTimerSafeMilliseconds({ floorSeconds: true })` from `openclaw/plugin-sdk/number-runtime` — the same helper `sessions_send` uses for the same field (`src/agents/tools/sessions-send-tool.ts`) — so the watchdog and the tool agree on what counts as a usable budget. A naive floor-then-multiply reading maps a fractional value like `0.5` to `0`, which survives the `??` fallback chain and gets clamped up to a 1 ms watchdog (instant kill of the call). The shared helper rejects it and the reader falls back to the existing default. `DynamicToolCallParams.arguments` is raw `JsonValue` in the Codex app-server protocol (`codex-rs/app-server-protocol/src/protocol/v2/item.rs`, `DynamicToolCallParams`), so unvalidated values do reach this reader.
- **Grace headroom over the budget.** `timeoutSeconds` is the tool's *inner* wait budget: `sessions_send` does gateway pre-work (session resolve, baseline snapshot, `startAgentRun`) before waiting that long, then returns a structured `{status: "timeout", runId, sentBeforeError}` result. A watchdog armed with exactly the same value deterministically fires first and replaces that structured result with a generic hard-timeout error, losing the `runId`. The watchdog is now the seconds budget plus `CODEX_DYNAMIC_TOOL_SECONDS_GRACE_MS` (30 s) via the shared `addTimerTimeoutGraceMs`, so the tool's own timer wins the race. `timeoutMs` keeps exact-override precedence and the existing 600 s hard cap is unchanged.

The side-thread path previously duplicated the whole timeout-reader stack; the byte-identical `readSide*` leaf readers are deleted and `side-question.ts` now imports the shared readers from `dynamic-tool-execution.ts`, so the main-thread and side-thread watchdogs cannot silently diverge (net-negative production LOC).

AI-assisted: yes (initial implementation by Codex; multi-agent review and this revision by Claude). No agent transcript is included because sanitized transcript insertion was not approved in this automated run.

## User Impact

Seconds-form dynamic-tool budgets are honored instead of being capped by the default 90-second guard. Unlike a verbatim mapping, a `sessions_send` whose target run outlasts its budget still returns its structured timeout result (with `runId` and delivery status) instead of a generic watchdog error, and a malformed fractional budget can no longer produce an instant ~1 ms kill.

## Evidence

Proof harness driving the real `dynamic-tool-execution.ts` code (`resolveDynamicToolCallTimeoutMs` + `handleDynamicToolCallWithTimeout`) with the tool bridge mocked as a `sessions_send`-shaped waiter (pre-work, inner budget wait, structured timeout result). Harness kept out of the repo per contribution guidelines.

On `origin/main` (6e79ca3cbc) — the reported bug, `timeoutSeconds` ignored:

```
Scenario 1: sessions_send {timeoutSeconds: 2}, target run outlasts budget
  resolved watchdog: 90000ms (inner tool budget: 2000ms)
  [FAIL] watchdog is derived from the 2s budget (bounded, not the unrelated 90s default) — 90000ms
  ...
1 FAILED (5 checks)
```

On the previous head of this branch (4806bd5db5) — why the verbatim mapping was not enough:

```
Scenario 1: sessions_send {timeoutSeconds: 2}, target run outlasts budget
  resolved watchdog: 2000ms (inner tool budget: 2000ms)
  [PASS] watchdog is derived from the 2s budget (bounded, not the unrelated 90s default) — 2000ms
  [FAIL] watchdog has grace headroom over the 2000ms inner budget — 2000ms
  [FAIL] tool's graceful timeout result (with runId) beats the watchdog — {"contentItems":[{"type":"inputText","text":"OpenClaw dynamic tool call timed out after 2000ms while running tool sessions_send."}],"success

Scenario 2: {timeoutSeconds: 0.5} from unvalidated model JSON
  resolved watchdog: 1ms
  [FAIL] falls back to the 90s default instead of a ~1ms watchdog — 1ms
  [FAIL] a 300ms tool call survives instead of being killed instantly — {"contentItems":[{"type":"inputText","text":"OpenClaw dynamic tool call timed out after 1ms while running tool sessions_

4 FAILED (5 checks)
```

On this branch — fixed:

```
Scenario 1: sessions_send {timeoutSeconds: 2}, target run outlasts budget
  resolved watchdog: 32000ms (inner tool budget: 2000ms)
  [PASS] watchdog is derived from the 2s budget (bounded, not the unrelated 90s default) — 32000ms
  [PASS] watchdog has grace headroom over the 2000ms inner budget — 32000ms
  [PASS] tool's graceful timeout result (with runId) beats the watchdog — {"contentItems":[{"type":"inputText","text":"{\"status\":\"timeout\",\"runId\":\"run-123\"}"}],"success":true}

Scenario 2: {timeoutSeconds: 0.5} from unvalidated model JSON
  resolved watchdog: 90000ms
  [PASS] falls back to the 90s default instead of a ~1ms watchdog — 90000ms
  [PASS] a 300ms tool call survives instead of being killed instantly — {"contentItems":[{"type":"inputText","text":"ok"}],"success":true}

ALL PASS (5 checks)
```

- `node scripts/run-vitest.mjs extensions/codex/src/app-server/dynamic-tool-execution.test.ts extensions/codex/src/app-server/side-question.test.ts` — 2 files, 55 tests passed, including a new fractional-seconds regression case
- `git diff --check` clean; `oxfmt --check` clean; oxlint clean on the four changed files
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean ("patch is correct", no actionable findings); an earlier autoreview run on the previous head independently flagged the zero-grace race fixed here

What was not tested: live end-to-end gateway + real Codex model traffic. Behavior above the pre-existing 600 s watchdog cap is unchanged (a larger budget is still capped; that cap predates this PR and applies equally to `timeoutMs`).
