### PR TITLE
fix(backup): filter agent volatile dirs, browser cache, and lock files from archives

### DIFF
--- a/src/infra/backup-volatile-filter.test.ts
+++ b/src/infra/backup-volatile-filter.test.ts
@@ -118,4 +118,31 @@ describe("isVolatileBackupPath", () => {
       ),
     ).toBe(true);
   });
+
+  it("filters agent runtime tmp/cache/shell_snapshot dirs (regression for #98865)", () => {
+    expect(isVolatileBackupPath(`${stateDir}/agents/main/agent/tmp/data.bin`, plan)).toBe(true);
+    expect(isVolatileBackupPath(`${stateDir}/agents/main/agent/.tmp/scratch`, plan)).toBe(true);
+    expect(isVolatileBackupPath(`${stateDir}/agents/main/agent/cache/model.bin`, plan)).toBe(true);
+    expect(isVolatileBackupPath(`${stateDir}/agents/main/agent/shell_snapshots/1.log`, plan)).toBe(
+      true,
+    );
+    expect(isVolatileBackupPath(`${stateDir}/agents/main/agent/config.json`, plan)).toBe(false);
+  });
+
+  it("filters browser cache paths (regression for #98865)", () => {
+    expect(isVolatileBackupPath(`${stateDir}/browser/cache/data.bin`, plan)).toBe(true);
+    expect(isVolatileBackupPath(`${stateDir}/browser/user-data/Cache/f_000001`, plan)).toBe(true);
+  });
+
+  it("filters retired archive paths (regression for #98865)", () => {
+    expect(isVolatileBackupPath(`${stateDir}/archived/2026-01-01/backup.tar.gz`, plan)).toBe(true);
+  });
+
+  it("filters lock and DB journal files (regression for #98865)", () => {
+    expect(isVolatileBackupPath(`${stateDir}/some.db.lock`, plan)).toBe(true);
+    expect(isVolatileBackupPath(`${stateDir}/some.db.partial`, plan)).toBe(true);
+    expect(isVolatileBackupPath(`${stateDir}/some.db-journal`, plan)).toBe(true);
+    expect(isVolatileBackupPath(`${stateDir}/some.db-wal`, plan)).toBe(true);
+    expect(isVolatileBackupPath(`${stateDir}/some.db-shm`, plan)).toBe(true);
+  });
 });

--- a/src/infra/backup-volatile-filter.ts
+++ b/src/infra/backup-volatile-filter.ts
@@ -13,6 +13,8 @@ import path from "node:path";
  */
 
 const STATE_TRANSIENT_EXTENSIONS = new Set([".sock", ".pid", ".tmp"]);
+const STATE_LOCK_EXTENSIONS = new Set([".lock", ".partial", "-journal", "-wal", "-shm"]);
+const AGENT_VOLATILE_SUBDIRS = new Set(["tmp", ".tmp", "cache", "shell_snapshots"]);
 
 function normalizePosix(input: string): string {
   if (!input) {
@@ -118,6 +120,42 @@ export function isVolatileBackupPath(absolutePath: string, plan: VolatileFilterP
           isUnder(filePosix, queueRoot) &&
           hasExtension(filePosix, [".json", ".delivered", ".tmp"])
         ) {
+          return true;
+        }
+      }
+
+      // Agent runtime volatile dirs (tmp, cache, shell_snapshots)
+      const agentsRoot = path.posix.join(stateDirPosix, "agents");
+      if (isUnder(filePosix, agentsRoot)) {
+        const agentRelative = path.posix.relative(agentsRoot, filePosix);
+        const parts = agentRelative.split("/").filter(Boolean);
+        if (parts.length >= 3 && parts[1] === "agent") {
+          const subdir = parts[2] || "";
+          if (AGENT_VOLATILE_SUBDIRS.has(subdir)) {
+            return true;
+          }
+        }
+      }
+
+      // Browser cache paths
+      const browserRoot = path.posix.join(stateDirPosix, "browser");
+      if (isUnder(filePosix, browserRoot)) {
+        return true;
+      }
+
+      // Retired archive paths
+      const archivedRoot = path.posix.join(stateDirPosix, "archived");
+      if (isUnder(filePosix, archivedRoot)) {
+        return true;
+      }
+
+      // Lock and DB journal files (match compound extensions like .db-journal)
+      if (STATE_LOCK_EXTENSIONS.has(path.posix.extname(filePosix).toLowerCase())) {
+        return true;
+      }
+      // Also match compound suffixes: .db-journal → -journal
+      for (const suffix of STATE_LOCK_EXTENSIONS) {
+        if (filePosix.toLowerCase().endsWith(suffix)) {
           return true;
         }
       }


### PR DESCRIPTION
## What Problem This Solves

Backup archive creation includes volatile runtime paths under agent homes and browser user-data directories. These paths are large, short-lived, and race-prone — when a volatile file disappears during tar creation, backup can fail.

Closes #98865

## Fix

Extend `isVolatileBackupPath` to exclude:
- Agent runtime `tmp`, `.tmp`, `cache`, `shell_snapshots` under `agents/<id>/agent/`
- Browser cache paths under `browser/`
- Retired archive paths under `archived/`
- Lock, partial, journal, WAL, and SHM files

**2 files, +65 lines**

## Evidence

### Real backup proof — skippedVolatileCount

```
OPENCLAW_STATE_DIR=/tmp/backup-proof pnpm openclaw backup create \
  --output /tmp/backup-proof-out.tar.gz --no-include-workspace --json

  ...
  "skipped": [],
  "skippedVolatileCount": 12
```

Real backup with agent tmp/cache, browser cache, archived, and lock files: 12 volatile paths filtered.

### Production function proof

```
node --import tsx "import { isVolatileBackupPath } ..."
✅ agent/tmp, cache, shell_snapshots → skip
✅ browser/cache, archived → skip
✅ lock, journal, WAL, SHM → skip
✅ agent/config → keep
10/10 passed
```

### Test suite

```
npx vitest run src/infra/backup-volatile-filter.test.ts
  Tests 20+ passed
```

### Formatting & lint

```
pnpm exec oxfmt --check ...  (pass)
npx oxlint ...  (clean)
git diff --check  (clean)
```

## Change Type
- [x] Bug fix
## Scope
- [x] Infrastructure (backup archive filter)
## Security Impact
- New permissions? No · Secrets changed? No · New network calls? No