### PR TITLE
fix: keep macOS onboarding controls visible on short screens

### DIFF
--- a/apps/macos/Sources/OpenClaw/Onboarding.swift
+++ b/apps/macos/Sources/OpenClaw/Onboarding.swift
@@ -47,7 +47,7 @@ final class OnboardingController {
         window.titlebarAppearsTransparent = true
         window.titleVisibility = .hidden
         window.isMovableByWindowBackground = true
-        window.center()
+        window.setFrame(WindowPlacement.centeredFrame(size: window.frame.size), display: false)
         DockIconManager.shared.temporarilyShowDock()
         window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
@@ -96,9 +96,11 @@ struct OnboardingView: View {
 
     static let windowWidth: CGFloat = 630
     static let windowHeight: CGFloat = 752 // ~+10% to fit full onboarding content
+    static let minimumWindowHeight: CGFloat = 465
 
     let pageWidth: CGFloat = Self.windowWidth
     let contentHeight: CGFloat = 460
+    let minimumContentHeight: CGFloat = 260
     let connectionPageIndex = 1
     let wizardPageIndex = 3
     let onboardingChatPageIndex = 8

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Layout.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Layout.swift
@@ -8,7 +8,8 @@ extension OnboardingView {
                 .offset(y: 10)
                 .frame(height: 145)
 
-            GeometryReader { _ in
+            GeometryReader { geometry in
+                let contentHeight = max(self.minimumContentHeight, geometry.size.height)
                 HStack(spacing: 0) {
                     ForEach(self.pageOrder, id: \.self) { pageIndex in
                         self.pageView(for: pageIndex)
@@ -19,15 +20,15 @@ extension OnboardingView {
                 .animation(
                     .interactiveSpring(response: 0.5, dampingFraction: 0.86, blendDuration: 0.25),
                     value: self.currentPage)
-                .frame(height: self.contentHeight, alignment: .top)
+                .frame(height: contentHeight, alignment: .top)
                 .clipped()
             }
-            .frame(height: self.contentHeight)
+            .frame(minHeight: self.minimumContentHeight)
 
             Spacer(minLength: 0)
             self.navigationBar
         }
-        .frame(width: self.pageWidth, height: Self.windowHeight)
+        .frame(width: self.pageWidth, minHeight: Self.minimumWindowHeight, maxHeight: Self.windowHeight)
         .background(Color(NSColor.windowBackgroundColor))
         .onAppear {
             self.currentPage = 0

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
@@ -780,26 +780,29 @@ extension OnboardingView {
     }
 
     func onboardingChatPage() -> some View {
-        VStack(spacing: 16) {
-            Text("Meet your agent")
-                .font(.largeTitle.weight(.semibold))
-            Text(
-                "This is a dedicated onboarding chat. Your agent will introduce itself, " +
-                    "learn who you are, and help you connect WhatsApp or Telegram if you want.")
-                .font(.body)
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
-                .frame(maxWidth: 520)
-                .fixedSize(horizontal: false, vertical: true)
+        ScrollView {
+            VStack(spacing: 16) {
+                Text("Meet your agent")
+                    .font(.largeTitle.weight(.semibold))
+                Text(
+                    "This is a dedicated onboarding chat. Your agent will introduce itself, " +
+                        "learn who you are, and help you connect WhatsApp or Telegram if you want.")
+                    .font(.body)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: 520)
+                    .fixedSize(horizontal: false, vertical: true)
 
-            self.onboardingGlassCard(padding: 8) {
-                OpenClawChatView(viewModel: self.onboardingChatModel, style: .onboarding)
-                    .frame(maxHeight: .infinity)
+                self.onboardingGlassCard(padding: 8) {
+                    OpenClawChatView(viewModel: self.onboardingChatModel, style: .onboarding)
+                        .frame(minHeight: 260)
+                }
             }
-            .frame(maxHeight: .infinity)
+            .frame(maxWidth: .infinity, alignment: .top)
+            .padding(.bottom, 8)
         }
         .padding(.horizontal, 28)
-        .frame(width: self.pageWidth, height: self.contentHeight, alignment: .top)
+        .frame(width: self.pageWidth, maxHeight: .infinity, alignment: .top)
     }
 
     func readyPage() -> some View {

--- a/apps/macos/Tests/OpenClawIPCTests/WindowPlacementTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/WindowPlacementTests.swift
@@ -22,6 +22,18 @@ struct WindowPlacementTests {
     }
 
     @Test
+    func `centered frame clamps onboarding height to visible bounds`() {
+        let bounds = NSRect(x: 0, y: 24, width: 1093, height: 690)
+        let frame = WindowPlacement.centeredFrame(
+            size: NSSize(width: OnboardingView.windowWidth, height: OnboardingView.windowHeight),
+            in: bounds)
+        #expect(frame.size.width == OnboardingView.windowWidth)
+        #expect(frame.size.height == bounds.height)
+        #expect(frame.minX == round(bounds.minX + (bounds.width - OnboardingView.windowWidth) / 2))
+        #expect(frame.minY == bounds.minY)
+    }
+
+    @Test
     func `top right frame zero bounds falls back to origin`() {
         let frame = WindowPlacement.topRightFrame(
             size: NSSize(width: 120, height: 80),


### PR DESCRIPTION
Closes #98674

## What Problem This Solves

Fixes an issue where users opening the macOS first-run onboarding window on a short visible desktop could have the bottom setup action clipped offscreen, making the onboarding/install flow impossible to complete.

## Why This Change Was Made

The onboarding window now uses the existing `WindowPlacement.centeredFrame` helper instead of raw `window.center()`, so the requested frame is clamped to the active screen visible frame before display.

The onboarding layout also adapts to constrained height: the page body can shrink within the window, and the onboarding chat page becomes scrollable when available height is short. This keeps the bottom navigation reachable without changing the normal 630x752 onboarding size on larger displays.

## User Impact

Users on short macOS displays can complete onboarding because the `Next` / `Finish` action remains inside the visible screen area. Larger displays keep the existing full-height onboarding presentation.

## Evidence

Focused verification passed:

- `git diff --check`
- `xcrun swiftc -parse apps/macos/Sources/OpenClaw/Onboarding.swift`
- `xcrun swiftc -parse apps/macos/Sources/OpenClaw/OnboardingView+Layout.swift`
- `xcrun swiftc -parse apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift`
- `xcrun swiftc -parse apps/macos/Tests/OpenClawIPCTests/WindowPlacementTests.swift`
- Standalone AppKit proof compiled the patched production `WindowPlacement.swift` and confirmed a 630x752 onboarding request clamps to 630x690 in a 1093x690 visible frame.

Real behavior proof:

![macOS onboarding after placement fix](https://litter.catbox.moe/9evyn8.png)

- Behavior addressed: macOS onboarding no longer places the bottom `Next` / `Finish` action below the visible desktop on short screens.
- Environment: macOS local checkout on `codex/fix-macos-onboarding-window-fit`; proof viewport matches the reporter screenshot size, 1093x690.
- Current-main contrast: current main creates a fixed 630x752 onboarding window and calls `window.center()` directly, with no visible-frame clamp.
- Exact steps or command run after this patch: generated the proof image from the patched branch by compiling a standalone AppKit proof that imports production `apps/macos/Sources/OpenClaw/WindowPlacement.swift`, requests a 630x752 onboarding frame, and applies it to a 1093x690 visible frame.
- Evidence after fix: computed frame is 630x690, so the onboarding window fits the visible frame and the bottom action remains reachable.
- Evidence artifact links: screenshot embedded above: https://litter.catbox.moe/9evyn8.png
- Control check: the reporter's before screenshot in #98674 is 1093x690 and shows the onboarding window clipped below the visible area.
- Observed result after fix: the patched placement clamps the window height to the visible frame, while the onboarding body can shrink and the onboarding chat page scrolls when height is constrained.
- What was not tested: a full `OpenClaw.app` screenshot was not captured locally. `swift test --package-path apps/macos --filter WindowPlacementTests` was blocked before touched tests by an existing SwiftUI `#Preview` macro plugin error under Command Line Tools; retrying with full Xcode was blocked by an unaccepted Xcode license on this machine.

Autoreview:

- `.agents/skills/autoreview/scripts/autoreview --mode local`
- Final run reported no accepted/actionable findings.

AI assistance note: This PR was authored with AI assistance. The proof above was run against the local branch after the patch.
