### PR TITLE
fix(msteams): page channel thread replies

### DIFF
--- a/extensions/msteams/src/graph-thread.test.ts
+++ b/extensions/msteams/src/graph-thread.test.ts
@@ -8,9 +8,10 @@ import {
   resolveTeamGroupId,
   stripHtmlFromTeamsMessage,
 } from "./graph-thread.js";
-import { fetchGraphJson } from "./graph.js";
+import { fetchAllGraphPages, fetchGraphJson } from "./graph.js";
 
 vi.mock("./graph.js", () => ({
+  fetchAllGraphPages: vi.fn(),
   fetchGraphJson: vi.fn(),
 }));
 
@@ -18,6 +19,14 @@ const firstGraphPath = () => {
   const [call] = vi.mocked(fetchGraphJson).mock.calls;
   if (!call) {
     throw new Error("expected Graph fetch call");
+  }
+  return call[0].path;
+};
+
+const firstFetchAllGraphPagesPath = () => {
+  const [call] = vi.mocked(fetchAllGraphPages).mock.calls;
+  if (!call) {
+    throw new Error("expected paginated Graph fetch call");
   }
   return call[0].path;
 };
@@ -163,44 +172,86 @@ describe("fetchChannelMessage", () => {
 
 describe("fetchThreadReplies", () => {
   beforeEach(() => {
+    vi.mocked(fetchAllGraphPages).mockReset();
     vi.mocked(fetchGraphJson).mockReset();
   });
 
   it("fetches replies with correct path and default limit", async () => {
-    vi.mocked(fetchGraphJson).mockResolvedValueOnce({
-      value: [{ id: "reply-1" }, { id: "reply-2" }],
+    vi.mocked(fetchAllGraphPages).mockResolvedValueOnce({
+      items: [{ id: "reply-1" }, { id: "reply-2" }],
+      truncated: false,
     } as never);
 
     const result = await fetchThreadReplies("tok", "group-1", "channel-1", "msg-1");
 
     expect(result).toHaveLength(2);
-    expect(fetchGraphJson).toHaveBeenCalledWith({
+    expect(fetchAllGraphPages).toHaveBeenCalledWith({
       token: "tok",
       path: "/teams/group-1/channels/channel-1/messages/msg-1/replies?$top=50&$select=id,from,body,createdDateTime",
+      maxPages: 50,
     });
   });
 
   it("clamps limit to 50 maximum", async () => {
-    vi.mocked(fetchGraphJson).mockResolvedValueOnce({ value: [] } as never);
+    vi.mocked(fetchAllGraphPages).mockResolvedValueOnce({
+      items: Array.from({ length: 52 }, (_, index) => ({ id: `reply-${index + 1}` })),
+      truncated: false,
+    } as never);
 
-    await fetchThreadReplies("tok", "g", "c", "m", 200);
+    const result = await fetchThreadReplies("tok", "g", "c", "m", 200);
 
-    expect(firstGraphPath()).toContain("$top=50");
+    expect(firstFetchAllGraphPagesPath()).toContain("$top=50");
+    expect(result).toHaveLength(50);
+    expect(result[0]?.id).toBe("reply-3");
+    expect(result.at(-1)?.id).toBe("reply-52");
   });
 
-  it("clamps limit to 1 minimum", async () => {
-    vi.mocked(fetchGraphJson).mockResolvedValueOnce({ value: [] } as never);
+  it("clamps limit to 1 minimum and keeps the newest reply", async () => {
+    vi.mocked(fetchAllGraphPages).mockResolvedValueOnce({
+      items: [{ id: "oldest" }, { id: "newest" }],
+      truncated: false,
+    } as never);
 
-    await fetchThreadReplies("tok", "g", "c", "m", 0);
+    const result = await fetchThreadReplies("tok", "g", "c", "m", 0);
 
-    expect(firstGraphPath()).toContain("$top=1");
+    expect(firstFetchAllGraphPagesPath()).toContain("$top=50");
+    expect(result).toEqual([{ id: "newest" }]);
   });
 
   it("returns empty array when value is missing", async () => {
-    vi.mocked(fetchGraphJson).mockResolvedValueOnce({} as never);
+    vi.mocked(fetchAllGraphPages).mockResolvedValueOnce({ items: [], truncated: false } as never);
 
     const result = await fetchThreadReplies("tok", "g", "c", "m");
     expect(result).toStrictEqual([]);
+  });
+
+  it("returns newest limited replies from paginated results", async () => {
+    vi.mocked(fetchAllGraphPages).mockResolvedValueOnce({
+      items: [{ id: "reply-1" }, { id: "reply-2" }, { id: "reply-3" }, { id: "reply-4" }],
+      truncated: false,
+    } as never);
+
+    const result = await fetchThreadReplies("tok", "g", "c", "m", 3);
+
+    expect(result).toEqual([{ id: "reply-2" }, { id: "reply-3" }, { id: "reply-4" }]);
+  });
+
+  it("sets a page cap to avoid unbounded pagination", async () => {
+    vi.mocked(fetchAllGraphPages).mockResolvedValueOnce({
+      items: Array.from({ length: 50 }, (_, index) => ({ id: `reply-${index + 1}` })),
+      truncated: true,
+    } as never);
+
+    const result = await fetchThreadReplies("tok", "g", "c", "m");
+
+    expect(fetchAllGraphPages).toHaveBeenCalledWith({
+      token: "tok",
+      path: "/teams/g/channels/c/messages/m/replies?$top=50&$select=id,from,body,createdDateTime",
+      maxPages: 50,
+    });
+    expect(result).toHaveLength(50);
+    expect(result[0]?.id).toBe("reply-1");
+    expect(result.at(-1)?.id).toBe("reply-50");
   });
 });
 

--- a/extensions/msteams/src/graph-thread.test.ts
+++ b/extensions/msteams/src/graph-thread.test.ts
@@ -15,14 +15,6 @@ vi.mock("./graph.js", () => ({
   fetchGraphJson: vi.fn(),
 }));
 
-const firstGraphPath = () => {
-  const [call] = vi.mocked(fetchGraphJson).mock.calls;
-  if (!call) {
-    throw new Error("expected Graph fetch call");
-  }
-  return call[0].path;
-};
-
 const firstFetchAllGraphPagesPath = () => {
   const [call] = vi.mocked(fetchAllGraphPages).mock.calls;
   if (!call) {

--- a/extensions/msteams/src/graph-thread.test.ts
+++ b/extensions/msteams/src/graph-thread.test.ts
@@ -194,7 +194,10 @@ describe("fetchThreadReplies", () => {
 
   it("clamps limit to 50 maximum", async () => {
     vi.mocked(fetchAllGraphPages).mockResolvedValueOnce({
-      items: Array.from({ length: 52 }, (_, index) => ({ id: `reply-${index + 1}` })),
+      items: Array.from({ length: 52 }, (_, index) => ({
+        id: `reply-${index + 1}`,
+        createdDateTime: new Date(Date.UTC(2026, 0, 1, 0, index)).toISOString(),
+      })),
       truncated: false,
     } as never);
 
@@ -208,14 +211,17 @@ describe("fetchThreadReplies", () => {
 
   it("clamps limit to 1 minimum and keeps the newest reply", async () => {
     vi.mocked(fetchAllGraphPages).mockResolvedValueOnce({
-      items: [{ id: "oldest" }, { id: "newest" }],
+      items: [
+        { id: "oldest", createdDateTime: "2026-01-01T00:00:00Z" },
+        { id: "newest", createdDateTime: "2026-01-01T00:01:00Z" },
+      ],
       truncated: false,
     } as never);
 
     const result = await fetchThreadReplies("tok", "g", "c", "m", 0);
 
     expect(firstFetchAllGraphPagesPath()).toContain("$top=50");
-    expect(result).toEqual([{ id: "newest" }]);
+    expect(result.map((reply) => reply.id)).toEqual(["newest"]);
   });
 
   it("returns empty array when value is missing", async () => {
@@ -227,13 +233,49 @@ describe("fetchThreadReplies", () => {
 
   it("returns newest limited replies from paginated results", async () => {
     vi.mocked(fetchAllGraphPages).mockResolvedValueOnce({
-      items: [{ id: "reply-1" }, { id: "reply-2" }, { id: "reply-3" }, { id: "reply-4" }],
+      items: [
+        { id: "reply-1", createdDateTime: "2026-01-01T00:00:00Z" },
+        { id: "reply-2", createdDateTime: "2026-01-01T00:01:00Z" },
+        { id: "reply-3", createdDateTime: "2026-01-01T00:02:00Z" },
+        { id: "reply-4", createdDateTime: "2026-01-01T00:03:00Z" },
+      ],
       truncated: false,
     } as never);
 
     const result = await fetchThreadReplies("tok", "g", "c", "m", 3);
 
-    expect(result).toEqual([{ id: "reply-2" }, { id: "reply-3" }, { id: "reply-4" }]);
+    expect(result.map((reply) => reply.id)).toEqual(["reply-2", "reply-3", "reply-4"]);
+  });
+
+  it("returns newest limited replies when Graph pages arrive newest-first", async () => {
+    vi.mocked(fetchAllGraphPages).mockResolvedValueOnce({
+      items: [
+        { id: "reply-4", createdDateTime: "2026-01-01T00:03:00Z" },
+        { id: "reply-3", createdDateTime: "2026-01-01T00:02:00Z" },
+        { id: "reply-2", createdDateTime: "2026-01-01T00:01:00Z" },
+        { id: "reply-1", createdDateTime: "2026-01-01T00:00:00Z" },
+      ],
+      truncated: false,
+    } as never);
+
+    const result = await fetchThreadReplies("tok", "g", "c", "m", 3);
+
+    expect(result.map((reply) => reply.id)).toEqual(["reply-2", "reply-3", "reply-4"]);
+  });
+
+  it("preserves arrival order for replies without parseable dates", async () => {
+    vi.mocked(fetchAllGraphPages).mockResolvedValueOnce({
+      items: [
+        { id: "reply-1" },
+        { id: "reply-2", createdDateTime: "not-a-date" },
+        { id: "reply-3" },
+      ],
+      truncated: false,
+    } as never);
+
+    const result = await fetchThreadReplies("tok", "g", "c", "m", 2);
+
+    expect(result.map((reply) => reply.id)).toEqual(["reply-2", "reply-3"]);
   });
 
   it("sets a page cap to avoid unbounded pagination", async () => {

--- a/extensions/msteams/src/graph-thread.ts
+++ b/extensions/msteams/src/graph-thread.ts
@@ -3,7 +3,7 @@ import {
   asDateTimestampMs,
   resolveExpiresAtMsFromDurationMs,
 } from "openclaw/plugin-sdk/number-runtime";
-import { fetchGraphJson, type GraphResponse } from "./graph.js";
+import { fetchAllGraphPages, fetchGraphJson } from "./graph.js";
 
 export type GraphThreadMessage = {
   id?: string;
@@ -18,6 +18,8 @@ export type GraphThreadMessage = {
 // TTL cache for team ID -> group GUID mapping.
 const teamGroupIdCache = new Map<string, { groupId: string; expiresAt: number }>();
 const CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+const THREAD_REPLIES_PAGE_SIZE = 50;
+const THREAD_REPLIES_MAX_PAGES = 50;
 
 function resolveTeamGroupIdCacheExpiresAt(nowRaw = Date.now()): number | undefined {
   const now = asDateTimestampMs(nowRaw);
@@ -115,12 +117,8 @@ export async function fetchChannelMessage(
 /**
  * Fetch thread replies for a channel message, ordered chronologically.
  *
- * **Limitation:** The Graph API replies endpoint (`/messages/{id}/replies`) does not
- * support `$orderby`, so results are always returned in ascending (oldest-first) order.
- * Combined with the `$top` cap of 50, this means only the **oldest 50 replies** are
- * returned for long threads — newer replies are silently omitted. There is currently no
- * Graph API workaround for this; pagination via `@odata.nextLink` can retrieve more
- * replies but still in ascending order only.
+ * The Graph replies endpoint does not support `$orderby`, so pages arrive
+ * oldest-first. Follow pagination and retain the newest replies for context.
  */
 export async function fetchThreadReplies(
   token: string,
@@ -129,13 +127,17 @@ export async function fetchThreadReplies(
   messageId: string,
   limit = 50,
 ): Promise<GraphThreadMessage[]> {
-  const top = Math.min(Math.max(limit, 1), 50);
+  const rawLimit = Number.isFinite(limit) ? Math.floor(limit) : THREAD_REPLIES_PAGE_SIZE;
+  const replyLimit = Math.min(Math.max(rawLimit, 1), THREAD_REPLIES_PAGE_SIZE);
   // NOTE: Graph replies endpoint returns oldest-first and does not support $orderby.
-  // For threads with >50 replies, only the oldest 50 are returned. The most recent
-  // replies (often the most relevant context) may be truncated.
-  const path = `/teams/${encodeURIComponent(groupId)}/channels/${encodeURIComponent(channelId)}/messages/${encodeURIComponent(messageId)}/replies?$top=${top}&$select=id,from,body,createdDateTime`;
-  const res = await fetchGraphJson<GraphResponse<GraphThreadMessage>>({ token, path });
-  return res.value ?? [];
+  // Keep the newest replies as pages arrive so long threads preserve recent context.
+  const path = `/teams/${encodeURIComponent(groupId)}/channels/${encodeURIComponent(channelId)}/messages/${encodeURIComponent(messageId)}/replies?$top=${THREAD_REPLIES_PAGE_SIZE}&$select=id,from,body,createdDateTime`;
+  const { items } = await fetchAllGraphPages<GraphThreadMessage>({
+    token,
+    path,
+    maxPages: THREAD_REPLIES_MAX_PAGES,
+  });
+  return items.slice(-replyLimit);
 }
 
 /**

--- a/extensions/msteams/src/graph-thread.ts
+++ b/extensions/msteams/src/graph-thread.ts
@@ -21,6 +21,31 @@ const CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
 const THREAD_REPLIES_PAGE_SIZE = 50;
 const THREAD_REPLIES_MAX_PAGES = 50;
 
+function createdDateTimeMs(message: GraphThreadMessage): number | undefined {
+  return asDateTimestampMs(Date.parse(message.createdDateTime ?? ""));
+}
+
+function newestThreadReplies(
+  items: GraphThreadMessage[],
+  replyLimit: number,
+): GraphThreadMessage[] {
+  const sortableItems: Array<{ item: GraphThreadMessage; index: number; createdAtMs: number }> = [];
+  for (const [index, item] of items.entries()) {
+    const createdAtMs = createdDateTimeMs(item);
+    if (createdAtMs === undefined) {
+      return items.slice(-replyLimit);
+    }
+    sortableItems.push({ item, index, createdAtMs });
+  }
+  const orderedItems = sortableItems
+    .toSorted((a, b) => {
+      const dateOrder = a.createdAtMs - b.createdAtMs;
+      return dateOrder === 0 ? a.index - b.index : dateOrder;
+    })
+    .map(({ item }) => item);
+  return orderedItems.slice(-replyLimit);
+}
+
 function resolveTeamGroupIdCacheExpiresAt(nowRaw = Date.now()): number | undefined {
   const now = asDateTimestampMs(nowRaw);
   return now === undefined
@@ -117,8 +142,8 @@ export async function fetchChannelMessage(
 /**
  * Fetch thread replies for a channel message, ordered chronologically.
  *
- * The Graph replies endpoint does not support `$orderby`, so pages arrive
- * oldest-first. Follow pagination and retain the newest replies for context.
+ * The Graph replies endpoint does not support `$orderby`, so sort paginated
+ * results before retaining the newest replies for context.
  */
 export async function fetchThreadReplies(
   token: string,
@@ -129,15 +154,13 @@ export async function fetchThreadReplies(
 ): Promise<GraphThreadMessage[]> {
   const rawLimit = Number.isFinite(limit) ? Math.floor(limit) : THREAD_REPLIES_PAGE_SIZE;
   const replyLimit = Math.min(Math.max(rawLimit, 1), THREAD_REPLIES_PAGE_SIZE);
-  // NOTE: Graph replies endpoint returns oldest-first and does not support $orderby.
-  // Keep the newest replies as pages arrive so long threads preserve recent context.
   const path = `/teams/${encodeURIComponent(groupId)}/channels/${encodeURIComponent(channelId)}/messages/${encodeURIComponent(messageId)}/replies?$top=${THREAD_REPLIES_PAGE_SIZE}&$select=id,from,body,createdDateTime`;
   const { items } = await fetchAllGraphPages<GraphThreadMessage>({
     token,
     path,
     maxPages: THREAD_REPLIES_MAX_PAGES,
   });
-  return items.slice(-replyLimit);
+  return newestThreadReplies(items, replyLimit);
 }
 
 /**


### PR DESCRIPTION
Closes #98870

## What Problem This Solves

Fixes an issue where Microsoft Teams channel users in long thread conversations would lose the newest replies from agent context once the thread had more than 50 replies.

## Why This Change Was Made

Teams Graph exposes additional channel-message replies through `@odata.nextLink`, while the list-replies endpoint supports `$top` but not `$orderby`. This change uses the existing bounded Graph pagination helper for thread replies, sorts replies by `createdDateTime` before limiting when timestamps are parseable, and falls back to arrival-order slicing when Graph omits or returns an unparseable timestamp.

## User Impact

Agents responding in long Teams channel threads can now see the most recent relevant replies instead of being limited to the oldest first page of replies. The newest-window selection no longer depends on whether Graph returns reply pages oldest-first or newest-first.

## Evidence

- Claim proved: `fetchThreadReplies` now requests replies through bounded Graph pagination and returns the newest limited reply window without relying on Graph response order.
- Commands / artifacts:
  - `pnpm install --frozen-lockfile` completed successfully after the worktree initially lacked `node_modules`.
  - `node scripts/run-vitest.mjs extensions/msteams/src/graph-thread.test.ts` passed before follow-up: 1 test file, 28 tests.
  - After the ordering follow-up, `node scripts/run-vitest.mjs extensions/msteams/src/graph-thread.test.ts` passed: 1 test file, 30 tests.
  - After the lint follow-up, `node scripts/run-vitest.mjs extensions/msteams/src/graph-thread.test.ts` passed: 1 test file, 30 tests.
  - After the proof refresh on current head `6efb75654c039efa10e2814434620aa6ba9e1006`, `node scripts/run-vitest.mjs extensions/msteams/src/graph-thread.test.ts extensions/msteams/src/graph.test.ts` passed: 2 test files, 49 tests.
  - `git diff --check` passed after the lint follow-up and again on current head `6efb75654c039efa10e2814434620aa6ba9e1006`.
  - `pnpm exec oxlint extensions/msteams/src/graph-thread.test.ts extensions/msteams/src/graph-thread.ts` passed after the lint follow-up.
  - `PYTHONUTF8=1 python .agents\skills\autoreview\scripts\autoreview --mode local` passed after the ordering follow-up with `autoreview clean: no accepted/actionable findings reported`.
- Observed result: focused `graph-thread` tests cover the paginated helper call, newest-reply limit behavior, minimum/maximum limit handling, empty results, the explicit 50-page cap, newest-window selection when Graph pages arrive oldest-first, newest-window selection when Graph pages arrive newest-first, and arrival-order fallback when `createdDateTime` is missing or unparseable.
- Real helper boundary proof: the refreshed `graph.test.ts` run exercises the shared `fetchAllGraphPages` helper that `fetchThreadReplies` now calls, including multi-page `@odata.nextLink` chains, Graph root stripping for `v1.0`/`beta` next links, `maxPages` truncation, and early `findOne` behavior. This proves the PR is wired through the existing Graph pagination helper rather than only a standalone reply-order mock.
- Dependency contract checked: Microsoft Graph list channel-message replies documents `$top` with a maximum of 50 and says other OData query parameters are not supported; Graph paging docs direct callers to follow `@odata.nextLink` until it is absent.
- Not tested / proof gaps: no live Microsoft Teams tenant / Graph API integration proof was run. This environment has no usable `MSTEAMS_*`, `MICROSOFT_*`, `AZURE_*`, or `GRAPH_*` credentials and no `channels.msteams` credentials in the local user config, so I could not safely query a real tenant. Remaining maintainer/live proof needed: run against a real channel thread with more than 50 replies, capture redacted Graph output showing `@odata.nextLink` pages and newest replies included in the final context window, and record latency/throttling behavior for the bounded 50-page cap.