### PR TITLE
fix(discord): skip malformed legacy thread-bindings store in doctor

### DIFF
--- a/extensions/discord/src/monitor/model-picker-preferences-migrations.test.ts
+++ b/extensions/discord/src/monitor/model-picker-preferences-migrations.test.ts
@@ -281,7 +281,7 @@ describe("Discord model picker preference migration", () => {
     if (plan?.kind !== "plugin-state-import") {
       throw new Error("expected plugin-state import plan");
     }
-    expect(plan.cleanupWhenEmpty).toBe(true);
+    expect(plan.cleanupWhenEmpty).toBeFalsy();
     expect(plan.readEntries()).toEqual([]);
   });
 

--- a/extensions/discord/src/monitor/model-picker-preferences-migrations.test.ts
+++ b/extensions/discord/src/monitor/model-picker-preferences-migrations.test.ts
@@ -149,6 +149,27 @@ describe("Discord model picker preference migration", () => {
     ).toEqual(["+275760-09-13T00:00:00.000Z", "+275760-09-12T23:59:59.999Z"]);
   });
 
+  it("skips a malformed legacy thread bindings store instead of crashing doctor", async () => {
+    const stateDir = await makeStateDir();
+    const sourcePath = path.join(stateDir, "discord", "thread-bindings.json");
+    await fs.mkdir(path.dirname(sourcePath), { recursive: true });
+    // Partial write / editor save with a syntax error -> not valid JSON.
+    await fs.writeFile(sourcePath, '{ "version": 1, "bindings": { , }');
+
+    const plans = await Promise.resolve(
+      detectDiscordLegacyStateMigrations({
+        cfg: {},
+        env: {},
+        oauthDir: path.join(stateDir, "credentials"),
+        stateDir,
+      }),
+    );
+    // readEntries is what doctor runs at fix time. Before the guard it threw a
+    // raw SyntaxError that killed the whole bundled migration loop.
+    const entries = plans?.[0]?.readEntries?.() ?? [];
+    expect(entries).toEqual([]);
+  });
+
   it("plans legacy thread bindings JSON import into plugin state", async () => {
     const stateDir = await makeStateDir();
     const sourcePath = path.join(stateDir, "discord", "thread-bindings.json");

--- a/extensions/discord/src/monitor/model-picker-preferences-migrations.ts
+++ b/extensions/discord/src/monitor/model-picker-preferences-migrations.ts
@@ -50,10 +50,18 @@ function readLegacyStore(filePath: string): LegacyModelPickerPreferencesStore | 
   }
 }
 
-function readLegacyThreadBindingsStore(filePath: string): LegacyThreadBindingsStore {
-  const parsed = JSON.parse(fs.readFileSync(filePath, "utf8")) as unknown;
+function readLegacyThreadBindingsStore(filePath: string): LegacyThreadBindingsStore | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fs.readFileSync(filePath, "utf8"));
+  } catch {
+    // Malformed legacy store (partial write, editor save with a syntax error,
+    // or truncation). Skip this plan instead of killing `openclaw doctor --fix`
+    // with a raw SyntaxError; matches the sibling readLegacyStore guard above.
+    return null;
+  }
   if (!parsed || typeof parsed !== "object") {
-    throw new Error("legacy Discord thread bindings store must be an object");
+    return null;
   }
   return parsed as LegacyThreadBindingsStore;
 }
@@ -186,7 +194,11 @@ export const detectDiscordLegacyStateMigrations: BundledChannelLegacyStateMigrat
       cleanupWhenEmpty: true,
       readEntries: () => {
         const store = readLegacyThreadBindingsStore(threadBindingsSourcePath);
-        if (store?.version !== 1 || !store.bindings || typeof store.bindings !== "object") {
+        if (!store) {
+          // Malformed or shape-incompatible legacy store; skip rather than block doctor.
+          return [];
+        }
+        if (store.version !== 1 || !store.bindings || typeof store.bindings !== "object") {
           throw new Error("legacy Discord thread bindings store must have version 1 bindings");
         }
         const out: Array<{ key: string; value: unknown }> = [];

--- a/extensions/discord/src/monitor/model-picker-preferences-migrations.ts
+++ b/extensions/discord/src/monitor/model-picker-preferences-migrations.ts
@@ -191,11 +191,12 @@ export const detectDiscordLegacyStateMigrations: BundledChannelLegacyStateMigrat
       maxEntries: THREAD_BINDINGS_MAX_ENTRIES,
       scopeKey: "",
       cleanupSource: "rename",
-      cleanupWhenEmpty: true,
       readEntries: () => {
         const store = readLegacyThreadBindingsStore(threadBindingsSourcePath);
         if (!store) {
-          // Malformed or shape-incompatible legacy store; skip rather than block doctor.
+          // Malformed or shape-incompatible legacy store; skip rather than block
+          // doctor. cleanupWhenEmpty is false so the source file is left in place
+          // instead of being renamed away with no data migrated.
           return [];
         }
         if (store.version !== 1 || !store.bindings || typeof store.bindings !== "object") {


### PR DESCRIPTION
## What Problem This Solves

`readLegacyThreadBindingsStore` parsed `state/discord/thread-bindings.json` with an unguarded `JSON.parse`. A partially-written or syntax-broken file threw a raw `SyntaxError` out of the plan's `readEntries`, which runs during `openclaw doctor --fix` via the bundled-channel state-migration loop, killing the whole migration pass. The sibling `readLegacyStore` in the same file already has the same guard (try/catch -> null); `readLegacyThreadBindingsStore` was the inconsistent outlier.

## Why This Change Was Made

Mirror the `readLegacyStore` guard. Also, the plan had `cleanupWhenEmpty: true`, which meant the source file was renamed away even when the store was malformed and no data was migrated. Set `cleanupWhenEmpty` to false so a malformed or shape-incompatible store is left in place (the user can inspect and repair it instead of having it silently renamed).

## User Impact

A corrupted legacy `thread-bindings.json` no longer kills `openclaw doctor --fix` with an opaque `SyntaxError`, and the source file is left in place instead of being renamed away with no data migrated.

## Real behavior proof

- **Behavior addressed:** A malformed `thread-bindings.json` threw a raw `SyntaxError` out of `readEntries`, killing the doctor migration pass. The source file was also renamed away (cleanupWhenEmpty=true) even with no data migrated.
- **Real environment tested:** Linux x86_64, Node v24.14.0, commit `ef1a965ef4` on branch `fix/discord-doctor-thread-bindings-jsonparse`.
- **Exact steps or command run after this patch:** `node --import tsx verify-discord-doctor-cleanup.mjs` — imports the real `detectDiscordLegacyStateMigrations`, writes a real malformed `thread-bindings.json`, runs the real detector, and calls the plan's real `readEntries`. No mocks: real fs, real detector, real readEntries.
- **Evidence after fix:** Terminal capture of `node` runtime verification (live stdout, copied verbatim):

  ```text
  $ node --import tsx verify-discord-doctor-cleanup.mjs
  raw JSON.parse -> SyntaxError (what doctor used to crash on)

  detector returned plan: kind=plugin-state-import label=Discord thread bindings
  readEntries: returned 0 entries
  source file still in place: true

  Verdict: doctor survives malformed thread-bindings.json; readEntries returns []; source file left in place (no cleanup)
  ```

- **Observed result after fix:** `readEntries` returns `[]` instead of throwing `SyntaxError`; the source file (malformed `thread-bindings.json`) is left in place, not renamed, because `cleanupWhenEmpty` is now false. A raw `JSON.parse` of the malformed body still throws `SyntaxError` (shown for contrast: that is what doctor used to crash on).
- **What was not tested:** A live `openclaw doctor --fix` on a production upgrade (the temp state dir + real detector + real readEntries is the faithful unit).

## Tests and validation

```text
$ pnpm test extensions/discord/src/monitor/model-picker-preferences-migrations.test.ts
 Test Files  1 passed (1)
      Tests  8 passed (8)
```

Added `skips a malformed legacy thread bindings store instead of crashing doctor`: writes a malformed `thread-bindings.json`, runs the real detector, asserts the plan's `readEntries` returns `[]` instead of throwing.

## Risk checklist

- User-visible behavior: Yes (intended) — corrupt legacy `thread-bindings.json` is now skipped (returns []) and left in place instead of crashing doctor or being renamed away. Well-formed stores and the happy path unchanged.
- Config/env/migration behavior: No.
- Security/auth/secrets/network/tool execution: No — only error handling around an existing JSON.parse of a local legacy file.
- Plugins/providers/channels/SDK: Yes (bounded) — internal to the Discord plugin doctor migration.
- Highest-risk area: a well-formed store with no data (empty bindings object) previously had its source cleaned up (cleanupWhenEmpty=true); now it is left in place. This is safer (user can delete manually) and matches the malformed case.
- Mitigation: 8 migration tests (incl. malformed-store case) + node runtime verification showing readEntries returns [] and the source file is preserved.

Closes: N/A (no existing issue)
