### PR TITLE
fix(agents): normalize non-array tool-result content at transcript ingest

### DIFF
--- a/src/agents/sessions/session-manager.tool-result-replay.test.ts
+++ b/src/agents/sessions/session-manager.tool-result-replay.test.ts
@@ -1,0 +1,197 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { streamAnthropic } from "../../llm/providers/anthropic.js";
+import type { Context, Message, Model } from "../../llm/types.js";
+import type { AgentMessage } from "../runtime/index.js";
+import { SessionManager } from "./session-manager.js";
+
+const tempPaths: string[] = [];
+
+async function makeTempDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-tool-result-replay-"));
+  tempPaths.push(dir);
+  return dir;
+}
+
+function toLlmContext(context: { messages: AgentMessage[] }): Context {
+  const messages = context.messages.filter(
+    (message): message is Message =>
+      message.role === "user" || message.role === "assistant" || message.role === "toolResult",
+  );
+  return { messages };
+}
+
+function makeAnthropicModel(): Model<"anthropic-messages"> {
+  return {
+    id: "claude-sonnet-4-6",
+    name: "Claude Sonnet 4.6",
+    provider: "anthropic",
+    api: "anthropic-messages",
+    baseUrl: "https://api.anthropic.com",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 200_000,
+    maxTokens: 4096,
+  };
+}
+
+async function writeSessionWithToolResultContent(
+  sessionFile: string,
+  content: unknown,
+): Promise<void> {
+  const entries = [
+    {
+      type: "session",
+      version: 3,
+      id: "string-tool-result-session",
+      timestamp: "2026-07-01T00:00:00.000Z",
+      cwd: "/tmp/tool-result-replay",
+    },
+    {
+      type: "message",
+      id: "user-1",
+      parentId: null,
+      timestamp: "2026-07-01T00:00:01.000Z",
+      message: { role: "user", content: "run lookup", timestamp: 1 },
+    },
+    {
+      type: "message",
+      id: "assistant-1",
+      parentId: "user-1",
+      timestamp: "2026-07-01T00:00:02.000Z",
+      message: {
+        role: "assistant",
+        provider: "anthropic",
+        api: "anthropic-messages",
+        model: "claude-sonnet-4-6",
+        stopReason: "toolUse",
+        timestamp: 2,
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+        content: [{ type: "toolCall", id: "call_1", name: "lookup", arguments: {} }],
+      },
+    },
+    {
+      type: "message",
+      id: "tool-result-1",
+      parentId: "assistant-1",
+      timestamp: "2026-07-01T00:00:03.000Z",
+      message: {
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "lookup",
+        content,
+        isError: false,
+        timestamp: 3,
+      },
+    },
+  ];
+  await fs.writeFile(sessionFile, `${entries.map((entry) => JSON.stringify(entry)).join("\n")}\n`);
+}
+
+describe("SessionManager tool-result replay", () => {
+  afterEach(async () => {
+    await Promise.all(
+      tempPaths.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })),
+    );
+  });
+
+  it("normalizes string tool-result content loaded from JSONL", async () => {
+    const dir = await makeTempDir();
+    const sessionFile = path.join(dir, "session.jsonl");
+    await writeSessionWithToolResultContent(sessionFile, "lookup result text");
+
+    const sessionManager = SessionManager.open(sessionFile, dir, "/tmp/tool-result-replay");
+    const context = sessionManager.buildSessionContext();
+    const toolResult = context.messages.find((message) => message.role === "toolResult");
+    if (!toolResult || toolResult.role !== "toolResult") {
+      throw new Error("tool result message missing");
+    }
+
+    expect(toolResult.content).toEqual([{ type: "text", text: "lookup result text" }]);
+  });
+
+  it("replays string tool-result JSONL content as Anthropic tool text", async () => {
+    const dir = await makeTempDir();
+    const sessionFile = path.join(dir, "session.jsonl");
+    await writeSessionWithToolResultContent(sessionFile, "lookup result text");
+    const context = SessionManager.open(
+      sessionFile,
+      dir,
+      "/tmp/tool-result-replay",
+    ).buildSessionContext();
+
+    let capturedPayload: unknown;
+    const stream = streamAnthropic(makeAnthropicModel(), toLlmContext(context), {
+      apiKey: "sk-ant-provider",
+      onPayload: (payload) => {
+        capturedPayload = payload;
+        throw new Error("stop before network");
+      },
+    });
+
+    await stream.result();
+
+    const payload = capturedPayload as {
+      messages: Array<{
+        role: string;
+        content: Array<{ type?: unknown; content?: unknown }>;
+      }>;
+    };
+    const toolResultBlock = payload.messages
+      .flatMap((message) => message.content)
+      .find((block) => block.type === "tool_result");
+
+    expect(toolResultBlock?.content).toBe("lookup result text");
+  });
+
+  it("replays object tool-result JSONL content as structured Anthropic tool text", async () => {
+    const dir = await makeTempDir();
+    const sessionFile = path.join(dir, "session.jsonl");
+    const content = { output: "status card text" };
+    await writeSessionWithToolResultContent(sessionFile, content);
+
+    const context = SessionManager.open(
+      sessionFile,
+      dir,
+      "/tmp/tool-result-replay",
+    ).buildSessionContext();
+    const toolResult = context.messages.find((message) => message.role === "toolResult");
+    if (!toolResult || toolResult.role !== "toolResult") {
+      throw new Error("tool result message missing");
+    }
+    expect(toolResult.content).toEqual([content]);
+
+    let capturedPayload: unknown;
+    const stream = streamAnthropic(makeAnthropicModel(), toLlmContext(context), {
+      apiKey: "sk-ant-provider",
+      onPayload: (payload) => {
+        capturedPayload = payload;
+        throw new Error("stop before network");
+      },
+    });
+
+    await stream.result();
+
+    const payload = capturedPayload as {
+      messages: Array<{
+        role: string;
+        content: Array<{ type?: unknown; content?: unknown }>;
+      }>;
+    };
+    const toolResultBlock = payload.messages
+      .flatMap((message) => message.content)
+      .find((block) => block.type === "tool_result");
+
+    expect(String(toolResultBlock?.content)).toContain("status card text");
+  });
+});

--- a/src/agents/sessions/session-manager.ts
+++ b/src/agents/sessions/session-manager.ts
@@ -348,22 +348,7 @@ export function migrateSessionEntries(entries: FileEntry[]): void {
 
 /** Exported for compaction.test.ts */
 export function parseSessionEntries(content: string): FileEntry[] {
-  const entries: FileEntry[] = [];
-  const lines = content.trim().split("\n");
-
-  for (const line of lines) {
-    if (!line.trim()) {
-      continue;
-    }
-    try {
-      const entry = JSON.parse(line) as FileEntry;
-      entries.push(entry);
-    } catch {
-      // Skip malformed lines
-    }
-  }
-
-  return entries;
+  return parseJsonlEntries(content);
 }
 
 export function getLatestCompactionEntry(entries: SessionEntry[]): CompactionEntry | null {
@@ -740,7 +725,7 @@ function rememberAppendedSessionEntry(
   const persistedEntry = JSON.parse(
     serializedAppend.startsWith("\n") ? serializedAppend.slice(1) : serializedAppend,
   ) as FileEntry;
-  cached.entries.push(freezeFileEntry(persistedEntry));
+  cached.entries.push(freezeFileEntry(normalizeLoadedFileEntry(persistedEntry)));
   cached.snapshot = snapshot;
   cached.endsWithNewline = true;
   sessionEntriesCache.delete(resolvedPath);
@@ -959,13 +944,34 @@ function parseJsonlEntries(content: string): FileEntry[] {
     }
     try {
       const entry = JSON.parse(line) as FileEntry;
-      entries.push(entry);
+      entries.push(normalizeLoadedFileEntry(entry));
     } catch {
       // Skip malformed lines
     }
   }
 
   return entries;
+}
+
+function normalizeLoadedFileEntry(entry: FileEntry): FileEntry {
+  if (!isJsonRecord(entry) || entry.type !== "message" || !isJsonRecord(entry.message)) {
+    return entry;
+  }
+  // Persisted JSONL is untrusted: shapes may predate the current Message type,
+  // so normalize through a record view instead of the declared union.
+  const message: Record<string, unknown> = entry.message;
+  if (message.role !== "toolResult") {
+    return entry;
+  }
+  // Replayed JSONL can carry string or single-record tool results while
+  // downstream providers require block arrays. Without this, strings replay as
+  // empty output and records hit non-array replay assumptions.
+  if (typeof message.content === "string") {
+    message.content = [{ type: "text", text: message.content }];
+  } else if (isJsonRecord(message.content)) {
+    message.content = [message.content];
+  }
+  return entry;
 }
 
 function hasReadableSessionHeader(entries: FileEntry[]): boolean {


### PR DESCRIPTION
## What Problem This Solves

Fixes #98825 — after #97742, a tool result whose persisted `content` is a plain string (JSONL transcript passthrough) replays as **empty** tool output. `extractToolResultText()` iterates its input; a string iterates character-by-character, every 1-char primitive fails the object-block check, and the extracted replay text is `""`. The tool run succeeds, but the model's next turn sees nothing (`src/llm/providers/tool-result-text.ts`, consumed by all provider converters and transport streams).

The same type lie also crashes the paths that call `msg.content.some(...)` / `.filter(...)` (`openai-completions`, `openai-responses-shared`, `mistral`, `openai-transport-stream`, vision-model Google paths).

## Why This Change Was Made

`ToolResultMessage.content` is typed `(TextContent | ImageContent)[]` (`packages/llm-core/src/types.ts`), but session JSONL load passed whatever the file contained straight through. The repo already normalizes the identical case for assistant content (`src/llm/providers/transform-messages.ts` — "JSONL passthrough") — tool results never got the same treatment, and `transformMessages` wouldn't be enough anyway since transport streams don't call it.

This PR fixes the lie **once at the ingest boundary** instead of teaching every consumer to tolerate it: when a session entry is parsed from JSONL, toolResult string `content` becomes `[{ type: "text", text }]` and a single non-array object becomes `[object]`. Every downstream consumer — provider converters, transport streams, the `.some()`/`.filter()` sites, and the shared helpers — keeps receiving the canonical typed array with no signature changes.

Alternative approach considered: #98826 / #98838 / #98863 widen the shared helpers to accept `unknown` and normalize inside them. That keeps `ToolResultMessage.content` dishonest, spreads tolerance across consumers (plus a new `extractToolResultImageBlocks` helper for the `.some()` sites), and needs `as never` casts in tests to exercise states the type system says can't exist. Normalizing at ingest deletes the problem instead; helper signatures stay `readonly unknown[]`.

Also dedups `parseSessionEntries` into `parseJsonlEntries` (their bodies were identical), so all session-file readers (`SessionManager.open`, transcript file state, btw transcripts, CLI session history) share the one normalizing parser. Net prod diff is ±0 LOC.

## User Impact

- Replayed sessions with string tool-result content show the actual tool output to the model again instead of silently empty text / `(no output)` — the "tool ran fine but the model went blank" bug from #98825.
- Single-object tool-result content replays as redacted structured JSON text (same expected behavior list as the issue).
- No provider/transport behavior change for well-formed sessions; no config or API surface changes.

Thanks @snowzlmbot for the report and analysis in #98825.

## Evidence

- Boundary regression test: JSONL toolResult with string content loads as one text block; with `{ output: ... }` object content loads as a one-element array (`src/agents/sessions/session-manager.tool-result-replay.test.ts`).
- Symptom regression test (fails without the fix): a session file with string tool-result content replayed through `streamAnthropic` produces the string as `tool_result` content — red-checked on the pre-fix tree, where the Anthropic payload carried an empty string.
- `node scripts/run-vitest.mjs src/agents/sessions/session-manager.tool-result-replay.test.ts src/agents/sessions/session-manager.test.ts src/agents/embedded-agent-runner/transcript-file-state.test.ts` — 76 tests passing.
- Caller-side proof for the `parseSessionEntries` dedup: `node scripts/run-vitest.mjs src/agents/compaction.test.ts src/agents/cli-runner/session-history.test.ts` — 38 tests passing.
