### PR TITLE
fix(ios): back from settings details returns to the originating screen

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -7803,7 +7803,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 127,
+      "line": 129,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Overview",
       "surface": "apple",
@@ -7811,7 +7811,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 149,
+      "line": 151,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Instances",
       "surface": "apple",
@@ -7819,7 +7819,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 158,
+      "line": 160,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Dreaming",
       "surface": "apple",
@@ -7827,7 +7827,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 163,
+      "line": 165,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Usage",
       "surface": "apple",
@@ -7835,7 +7835,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 168,
+      "line": 170,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Cron Jobs",
       "surface": "apple",
@@ -7843,7 +7843,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 217,
+      "line": 225,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Online",
       "surface": "apple",
@@ -7851,7 +7851,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 218,
+      "line": 226,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Connecting",
       "surface": "apple",
@@ -7859,7 +7859,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 219,
+      "line": 227,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Attention",
       "surface": "apple",
@@ -7867,7 +7867,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 220,
+      "line": 228,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Offline",
       "surface": "apple",
@@ -8115,7 +8115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 290,
+      "line": 292,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Enable OpenClaw Hosted Push Relay?",
       "surface": "apple",
@@ -8123,7 +8123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 303,
+      "line": 305,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Continue",
       "surface": "apple",
@@ -8131,7 +8131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 306,
+      "line": 308,
       "path": "apps/ios/Sources/Design/SettingsProTab.swift",
       "source": "Not Now",
       "surface": "apple",
@@ -10779,7 +10779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 162,
+      "line": 169,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Talk",
       "surface": "apple",
@@ -10787,7 +10787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 172,
+      "line": 179,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Control",
       "surface": "apple",
@@ -10795,7 +10795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 181,
+      "line": 188,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Agent",
       "surface": "apple",
@@ -10803,7 +10803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 188,
+      "line": 195,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Settings",
       "surface": "apple",
@@ -10811,7 +10811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 287,
+      "line": 294,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "OpenClaw",
       "surface": "apple",
@@ -10819,7 +10819,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 316,
+      "line": 323,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "OpenClaw \\(self.sidebarGatewayStatusTitle)",
       "surface": "apple",
@@ -10827,7 +10827,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 321,
+      "line": 328,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Online",
       "surface": "apple",
@@ -10835,7 +10835,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 323,
+      "line": 330,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Connecting",
       "surface": "apple",
@@ -10843,7 +10843,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 325,
+      "line": 332,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Needs attention",
       "surface": "apple",
@@ -10851,7 +10851,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 327,
+      "line": 334,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Offline",
       "surface": "apple",
@@ -10859,7 +10859,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 405,
+      "line": 412,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Chat",
       "surface": "apple",
@@ -10867,7 +10867,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 418,
+      "line": 425,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Overview",
       "surface": "apple",
@@ -10875,7 +10875,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 442,
+      "line": 449,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Agents",
       "surface": "apple",
@@ -10883,7 +10883,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 449,
+      "line": 456,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Instances",
       "surface": "apple",
@@ -10891,7 +10891,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 460,
+      "line": 467,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Dreaming",
       "surface": "apple",
@@ -10899,7 +10899,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 467,
+      "line": 474,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Usage",
       "surface": "apple",
@@ -10907,7 +10907,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 474,
+      "line": 481,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Cron Jobs",
       "surface": "apple",
@@ -10915,7 +10915,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 579,
+      "line": 586,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Hide Sidebar",
       "surface": "apple",
@@ -10923,7 +10923,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 651,
+      "line": 658,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Close canvas",
       "surface": "apple",
@@ -10931,7 +10931,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 891,
+      "line": 898,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Gateway needs attention",
       "surface": "apple",
@@ -10939,7 +10939,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 891,
+      "line": 898,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "OpenClaw iOS",
       "surface": "apple",
@@ -10947,7 +10947,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 927,
+      "line": 934,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Available",
       "surface": "apple",
@@ -10955,7 +10955,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 927,
+      "line": 934,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Gateway default",
       "surface": "apple",

--- a/apps/ios/Sources/Design/RootTabsPhoneControlHub.swift
+++ b/apps/ios/Sources/Design/RootTabsPhoneControlHub.swift
@@ -15,7 +15,7 @@ struct RootTabsPhoneControlHub: View {
             List {
                 Section {
                     Button {
-                        self.openPhoneRootDestination(.gateway)
+                        self.openGatewayDetail()
                     } label: {
                         self.gatewayRow
                     }
@@ -118,8 +118,10 @@ struct RootTabsPhoneControlHub: View {
     @ViewBuilder
     private func detail(for destination: RootTabs.SidebarDestination) -> some View {
         switch destination {
-        case .chat, .talk, .agents, .gateway:
+        case .chat, .talk, .agents:
             EmptyView()
+        case .gateway:
+            SettingsProTab(directRoute: .gateway)
         case .overview:
             CommandCenterTab(
                 ownsNavigationStack: false,
@@ -127,27 +129,27 @@ struct RootTabsPhoneControlHub: View {
                 headerTitle: "Overview",
                 showsHeaderMark: false,
                 openChat: { self.openPhoneRootDestination(.chat) },
-                openSettings: { self.openPhoneRootDestination(.gateway) },
+                openSettings: { self.openGatewayDetail() },
                 openSessions: { self.navigationPath.append(.sessions) })
         case .activity:
             IPadActivityScreen(
                 usesNativeNavigationChrome: true,
                 openChat: { self.openPhoneRootDestination(.chat) },
-                openSettings: { self.openPhoneRootDestination(.gateway) })
+                openSettings: { self.openGatewayDetail() })
         case .workboard:
             IPadWorkboardScreen(
                 usesNativeNavigationChrome: true,
                 openChat: { self.openPhoneRootDestination(.chat) },
-                openSettings: { self.openPhoneRootDestination(.gateway) })
+                openSettings: { self.openGatewayDetail() })
         case .skillWorkshop:
             IPadSkillWorkshopScreen(
                 usesNativeNavigationChrome: true,
-                openSettings: { self.openPhoneRootDestination(.gateway) })
+                openSettings: { self.openGatewayDetail() })
         case .instances:
             AgentProTab(
                 directRoute: .instances,
                 headerTitle: "Instances",
-                openSettings: { self.openPhoneRootDestination(.gateway) })
+                openSettings: { self.openGatewayDetail() })
         case .sessions:
             CommandSessionsScreen(
                 usesNativeNavigationChrome: true,
@@ -156,24 +158,30 @@ struct RootTabsPhoneControlHub: View {
             AgentProTab(
                 directRoute: .dreaming,
                 headerTitle: "Dreaming",
-                openSettings: { self.openPhoneRootDestination(.gateway) })
+                openSettings: { self.openGatewayDetail() })
         case .usage:
             AgentProTab(
                 directRoute: .usage,
                 headerTitle: "Usage",
-                openSettings: { self.openPhoneRootDestination(.gateway) })
+                openSettings: { self.openGatewayDetail() })
         case .cron:
             AgentProTab(
                 directRoute: .cron,
                 headerTitle: "Cron Jobs",
-                openSettings: { self.openPhoneRootDestination(.gateway) })
+                openSettings: { self.openGatewayDetail() })
         case .docs:
             OpenClawDocsScreen(
                 usesNativeNavigationChrome: true,
-                gatewayAction: { self.openPhoneRootDestination(.gateway) })
+                gatewayAction: { self.openGatewayDetail() })
         case .settings:
             EmptyView()
         }
+    }
+
+    /// Gateway settings open as a pushed detail on this stack so Back returns
+    /// to the hub screen the user came from, not the canonical Settings tab.
+    private func openGatewayDetail() {
+        self.navigationPath.append(.gateway)
     }
 
     private func openPhoneRootDestination(_ destination: RootTabs.SidebarDestination) {

--- a/apps/ios/Sources/Design/SettingsProTab.swift
+++ b/apps/ios/Sources/Design/SettingsProTab.swift
@@ -256,7 +256,9 @@ struct SettingsProTab: View {
             navigateToRoute(.notifications)
             return
         }
-        self.navigationPath = [.notifications]
+        // Push, don't replace: Back from Notifications must return to the
+        // Approvals screen the user came from, not reset to the Settings root.
+        self.navigationPath.append(.notifications)
     }
 
     private func applyInitialRouteIfNeeded() {

--- a/apps/ios/Sources/RootTabs.swift
+++ b/apps/ios/Sources/RootTabs.swift
@@ -151,19 +151,26 @@ struct RootTabs: View {
 
     private var phoneTabContent: some View {
         TabView(selection: self.$selectedTab) {
-            ChatProTab(openSettings: { self.selectSidebarDestination(.gateway) })
-                .tabItem { Label("Chat", systemImage: "bubble.left.fill") }
-                .tag(AppTab.chat)
+            PhoneTabSettingsHost { openSettingsRoute in
+                ChatProTab(
+                    ownsNavigationStack: false,
+                    openSettings: { openSettingsRoute(.gateway) })
+            }
+            .tabItem { Label("Chat", systemImage: "bubble.left.fill") }
+            .tag(AppTab.chat)
 
-            TalkProTab(
-                openSettings: { self.selectSidebarDestination(.gateway) },
-                openVoiceSettings: { self.selectSettingsRoute(.voice) })
-                .tabItem {
-                    Label(
-                        "Talk",
-                        systemImage: self.appModel.talkMode.isEnabled ? "waveform.circle.fill" : "waveform.circle")
-                }
-                .tag(AppTab.talk)
+            PhoneTabSettingsHost { openSettingsRoute in
+                TalkProTab(
+                    ownsNavigationStack: false,
+                    openSettings: { openSettingsRoute(.gateway) },
+                    openVoiceSettings: { openSettingsRoute(.voice) })
+            }
+            .tabItem {
+                Label(
+                    "Talk",
+                    systemImage: self.appModel.talkMode.isEnabled ? "waveform.circle.fill" : "waveform.circle")
+            }
+            .tag(AppTab.talk)
 
             RootTabsPhoneControlHub(
                 groups: Self.phoneControlGroups,
@@ -173,10 +180,10 @@ struct RootTabs: View {
                 .badge(self.appModel.pendingExecApprovalPrompt == nil ? 0 : 1)
                 .tag(AppTab.control)
 
-            NavigationStack {
+            PhoneTabSettingsHost { openSettingsRoute in
                 AgentProTab(
                     directRoute: .agents,
-                    openSettings: { self.selectSidebarDestination(.gateway) })
+                    openSettings: { openSettingsRoute(.gateway) })
             }
             .tabItem { Label("Agent", systemImage: "person.2.fill") }
             .tag(AppTab.agent)
@@ -972,7 +979,9 @@ extension RootTabs {
     }
 
     private func pushSidebarSettingsRoute(_ route: SettingsRoute) {
-        self.sidebarNavigationPath = [route]
+        // Push, don't replace: Back must return to the settings screen the
+        // user came from (e.g. Approvals -> Notifications -> back -> Approvals).
+        self.sidebarNavigationPath.append(route)
         self.handleSettingsRouteChange(route)
     }
 
@@ -1164,6 +1173,29 @@ extension RootTabs {
             discoveredGatewayCount: self.gatewayController.gateways.count)
         guard shouldPresent else { return }
         self.presentedSheet = .quickSetup
+    }
+}
+
+/// Phone tabs push Settings routes (gateway, voice) onto their own stack so
+/// Back returns to the tab content the user navigated from; only global flows
+/// (deep links, onboarding, problem banner) jump to the canonical Settings tab.
+private struct PhoneTabSettingsHost<Content: View>: View {
+    @State private var settingsPath: [SettingsRoute] = []
+    private let content: (_ openSettingsRoute: @escaping (SettingsRoute) -> Void) -> Content
+
+    init(@ViewBuilder content: @escaping (_ openSettingsRoute: @escaping (SettingsRoute) -> Void) -> Content) {
+        self.content = content
+    }
+
+    var body: some View {
+        NavigationStack(path: self.$settingsPath) {
+            self.content { route in
+                self.settingsPath.append(route)
+            }
+            .navigationDestination(for: SettingsRoute.self) { route in
+                SettingsProTab(directRoute: route)
+            }
+        }
     }
 }
 

--- a/apps/ios/Tests/RootTabsSourceGuardTests.swift
+++ b/apps/ios/Tests/RootTabsSourceGuardTests.swift
@@ -74,7 +74,7 @@ struct RootTabsSourceGuardTests {
             from: "private var phoneTabContent: some View",
             to: "private var sidebarSplitContent: some View")
 
-        let chatRange = try #require(phoneTabContent.range(of: "ChatProTab(openSettings:"))
+        let chatRange = try #require(phoneTabContent.range(of: "ChatProTab("))
         let talkRange = try #require(phoneTabContent.range(of: "TalkProTab("))
         let controlRange = try #require(phoneTabContent.range(of: "RootTabsPhoneControlHub("))
         let agentRange = try #require(phoneTabContent.range(of: "AgentProTab("))
@@ -300,7 +300,7 @@ struct RootTabsSourceGuardTests {
 
         #expect(source.contains("case .docs:"))
         #expect(source.contains("OpenClawDocsScreen("))
-        #expect(source.contains("gatewayAction: { self.openPhoneRootDestination(.gateway) }"))
+        #expect(source.contains("gatewayAction: { self.openGatewayDetail() }"))
         #expect(!source.contains("phoneDetailBackAction"))
         #expect(!source.contains("Label(\"Docs\", systemImage: \"book\")"))
         #expect(!source.contains("https://docs.openclaw.ai"))
@@ -350,12 +350,12 @@ struct RootTabsSourceGuardTests {
         #expect(source.contains(".accessibilityLabel(\"Gateway \\(self.gatewayStateText),"))
         #expect(!source.contains("ProValuePill(value: self.gatewayStateText"))
         #expect(!source.contains("destination.subtitle"))
-        #expect(source.contains("self.openPhoneRootDestination(.gateway)"))
+        #expect(source.contains("self.openGatewayDetail()"))
+        #expect(!source.contains("self.openPhoneRootDestination(.gateway)"))
         #expect(source.contains("group.destinations.filter { !self.opensRootTab($0) }"))
         #expect(!source.contains("phoneDetailBackAction"))
         #expect(!source.contains(".navigationBarBackButtonHidden(true)"))
         #expect(!source.contains(".toolbar(.hidden, for: .navigationBar)"))
-        #expect(!source.contains("headerLeadingAction: self.phoneDetailBackAction"))
         #expect(source.matches(of: /usesNativeNavigationChrome: true/).count == 6)
         #expect(!source.contains("directRoute: .agents"))
         #expect(!source.contains("Image(systemName: \"gearshape\")"))
@@ -374,7 +374,7 @@ struct RootTabsSourceGuardTests {
 
         #expect(source.contains("NavigationStack(path: self.$navigationPath)"))
         #expect(!source.contains("self.openRootDestination(.gateway)"))
-        #expect(source.contains("self.openPhoneRootDestination(.gateway)"))
+        #expect(source.contains("self.navigationPath.append(.gateway)"))
         #expect(clearRange.lowerBound < openRange.lowerBound)
     }
 
@@ -679,8 +679,13 @@ struct RootTabsSourceGuardTests {
         #expect(rootSource.contains("onRouteChange: self.handleSettingsRouteChange"))
         #expect(rootSource.contains("navigateToRoute: self.pushSidebarSettingsRoute"))
         #expect(rootSource.contains("private func pushSidebarSettingsRoute(_ route: SettingsRoute)"))
+        #expect(rootSource.contains("self.sidebarNavigationPath.append(route)"))
         #expect(settingsTabSource.contains("let navigateToRoute: ((SettingsRoute) -> Void)?"))
         #expect(settingsTabSource.contains("navigateToRoute(.notifications)"))
+        // Cross-route settings shortcuts push so Back returns to the origin
+        // screen; replacing the path resets Back to the Settings root.
+        #expect(settingsTabSource.contains("self.navigationPath.append(.notifications)"))
+        #expect(!settingsTabSource.contains("self.navigationPath = [.notifications]"))
         #expect(rootSource.contains("private func handleSettingsRouteChange(_ route: SettingsRoute?)"))
         #expect(settingsTabSource.contains("let onRouteChange: ((SettingsRoute?) -> Void)?"))
         #expect(settingsTabSource.contains("self.onRouteChange?(self.navigationPath.last)"))

--- a/apps/ios/Tests/RootTabsSourceGuardTests.swift
+++ b/apps/ios/Tests/RootTabsSourceGuardTests.swift
@@ -84,6 +84,7 @@ struct RootTabsSourceGuardTests {
         #expect(talkRange.lowerBound < controlRange.lowerBound)
         #expect(controlRange.lowerBound < agentRange.lowerBound)
         #expect(agentRange.lowerBound < settingsRange.lowerBound)
+        #expect(phoneTabContent.matches(of: /PhoneTabSettingsHost \{/).count == 3)
     }
 
     @Test func `sidebar keeps navigation model destination only`() throws {
@@ -629,7 +630,8 @@ struct RootTabsSourceGuardTests {
             encoding: .utf8)
 
         #expect(rootSource.matches(of: /openSettings: \{ self\.selectSidebarDestination\(\.gateway\) \}/).count >= 2)
-        #expect(rootSource.matches(of: /openVoiceSettings: \{ self\.selectSettingsRoute\(\.voice\) \}/).count == 2)
+        #expect(rootSource.matches(of: /openVoiceSettings: \{ openSettingsRoute\(\.voice\) \}/).count == 1)
+        #expect(rootSource.matches(of: /openVoiceSettings: \{ self\.selectSettingsRoute\(\.voice\) \}/).count == 1)
         #expect(rootSource.matches(of: /gatewayAction: \{ self\.selectSidebarDestination\(\.gateway\) \}/).count == 1)
         #expect(!rootSource.contains("showGatewayActions"))
         #expect(!rootSource.contains("gatewayActionsDialog"))

--- a/apps/ios/UITests/OpenClawSnapshotUITests.swift
+++ b/apps/ios/UITests/OpenClawSnapshotUITests.swift
@@ -54,6 +54,44 @@ final class OpenClawSnapshotUITests: XCTestCase {
         XCTAssertEqual(self.app?.state, .runningForeground)
     }
 
+    func testSettingsBackReturnsToOriginatingPhoneTab() throws {
+        try XCTSkipIf(UIDevice.current.userInterfaceIdiom != .phone, "Phone settings navigation only")
+
+        self.launchApp(for: ScreenshotTarget(
+            initialTab: "chat",
+            initialDestination: "chat",
+            name: "chat-settings-back"))
+
+        let gatewaySettings = try XCTUnwrap(self.app?.buttons["chat-gateway-settings-control"])
+        XCTAssertTrue(gatewaySettings.waitForExistence(timeout: 8))
+        gatewaySettings.tap()
+        let gatewayNavigationBar = try XCTUnwrap(self.app?.navigationBars["Gateway"])
+        XCTAssertTrue(gatewayNavigationBar.waitForExistence(timeout: 5))
+        XCTAssertTrue(self.app?.tabBars.buttons["Chat"].isSelected == true)
+        self.attachScreenshot(named: "chat-gateway-origin-stack")
+
+        gatewayNavigationBar.buttons["BackButton"].tap()
+        XCTAssertTrue(gatewaySettings.waitForExistence(timeout: 5))
+        XCTAssertTrue(self.app?.tabBars.buttons["Chat"].isSelected == true)
+        self.attachScreenshot(named: "chat-after-settings-back")
+
+        self.launchApp(for: ScreenshotTarget(
+            initialTab: "talk",
+            initialDestination: "talk",
+            name: "talk-settings-back"))
+
+        let voiceSettings = try XCTUnwrap(self.app?.buttons["talk-voice-settings-control"])
+        XCTAssertTrue(voiceSettings.waitForExistence(timeout: 8))
+        voiceSettings.tap()
+        let voiceNavigationBar = try XCTUnwrap(self.app?.navigationBars["Voice & Talk"])
+        XCTAssertTrue(voiceNavigationBar.waitForExistence(timeout: 5))
+        XCTAssertTrue(self.app?.tabBars.buttons["Talk"].isSelected == true)
+
+        voiceNavigationBar.buttons["BackButton"].tap()
+        XCTAssertTrue(voiceSettings.waitForExistence(timeout: 5))
+        XCTAssertTrue(self.app?.tabBars.buttons["Talk"].isSelected == true)
+    }
+
     func testChatComposerStartsCompactAndGrowsWithDraft() throws {
         try XCTSkipIf(UIDevice.current.userInterfaceIdiom != .phone, "Phone composer proof only")
         self.launchApp(for: ScreenshotTarget(

--- a/apps/ios/UITests/OpenClawSnapshotUITests.swift
+++ b/apps/ios/UITests/OpenClawSnapshotUITests.swift
@@ -62,7 +62,7 @@ final class OpenClawSnapshotUITests: XCTestCase {
             initialDestination: "chat",
             name: "chat-settings-back"))
 
-        let gatewaySettings = try XCTUnwrap(self.app?.buttons["chat-gateway-settings-control"])
+        let gatewaySettings = try XCTUnwrap(self.app?.buttons["chat-gateway-status"])
         XCTAssertTrue(gatewaySettings.waitForExistence(timeout: 8))
         gatewaySettings.tap()
         let gatewayNavigationBar = try XCTUnwrap(self.app?.navigationBars["Gateway"])


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening a settings detail view from another screen would be returned to the wrong place when pressing Back. For example, tapping the connection status pill on the Chat tab opens the Gateway detail, but Back landed on the Settings tab root instead of returning to Chat. The same canonical-back behavior affected every gateway entrance (Talk, Agent, all Control hub screens, Docs), the voice-settings entrances on the Talk tab, and the Approvals screen's "Open Notifications" shortcut (which reset Back to the Settings root on both iPhone and iPad).

## Why This Change Was Made

On the iPhone, settings detail entrances previously navigated by switching the whole app to the Settings tab with the route pre-pushed, so the back stack always unwound inside Settings. Each phone tab (Chat, Talk, Agent) now owns a `NavigationStack` (`PhoneTabSettingsHost`) that pushes `SettingsRoute` details locally, and the Control hub pushes the gateway detail onto its own stack (`openGatewayDetail`), so Back pops to the exact screen the user came from — including nested cases like Control > Usage > Gateway. Cross-route settings shortcuts now append to the path instead of replacing it. Deliberately unchanged: global flows (deep links, onboarding auto-open, the gateway problem banner, the exec-approval notification dialog) still jump to the canonical Settings tab, and the iPad sidebar keeps its selection model (no Back button is involved there).

## User Impact

Pressing Back from the Gateway, Voice, or Notifications settings details now returns users to the screen they navigated from — Chat stays Chat, Talk stays Talk, and Control hub screens keep their place — instead of dumping them on the Settings tab. Tab-bar behavior, iPad layout, and deep-link/onboarding flows are unchanged.

## Evidence

- Full app build green including the SwiftFormat (lint) and SwiftLint build phases: `IOS_DEST="generic/platform=iOS Simulator" pnpm ios:build` → `** BUILD SUCCEEDED **`.
- Audited every navigation entrance in `apps/ios/Sources` (all `openSettings`/`openChat`/`openSessions`/`gatewayAction`/`navigateToRoute` closures, `NavigationLink`/`navigationDestination` registrations, and path mutations); the four multi-entrance detail views (gateway, voice, notifications, sessions) are the complete set — sessions already pushed locally and is untouched.
- Updated `RootTabsSourceGuardTests` pin the new wiring: gateway is never opened as a root-tab handoff from the hub, cross-route shortcuts append rather than replace, and phone tab order is preserved; all string assertions were mechanically re-checked against the final sources.
- Multi-agent review of the diff (8 finder angles + adversarial verification) surfaced no confirmed defects; verifiers refuted each candidate with documented SwiftUI semantics or pre-existing identical usage (e.g. view-destination `NavigationLink`s inside pushed `SettingsProTab(directRoute:)` work unchanged, as they already did on the iPad sidebar stack).
- Made sure i18n is synced.
- Please ask Mantis to walk through each of the flows for visual validation.