### PR TITLE
fix(config): preserve provider models during merge

### DIFF
--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -963,6 +963,79 @@ describe("config cli", () => {
       ]);
     });
 
+    it("merges provider objects without replacing existing model arrays", async () => {
+      const resolved = {
+        models: {
+          providers: {
+            ollama: {
+              api: "ollama",
+              apiKey: "keep-me",
+              models: [
+                { id: "llama3.2", name: "Llama 3.2", contextWindow: 131072 },
+                { id: "qwen3", name: "Qwen 3" },
+              ],
+            },
+          },
+        },
+      } as unknown as OpenClawConfig;
+      setSnapshot(resolved, resolved);
+
+      await runConfigCommand([
+        "config",
+        "set",
+        "models.providers.ollama",
+        '{"models":[{"id":"llama3.2","name":"Llama 3.2 latest"},{"id":"gemma4","name":"Gemma 4"}]}',
+        "--strict-json",
+        "--merge",
+      ]);
+
+      expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
+      const written = firstWrittenConfig();
+      expect(written.models?.providers?.ollama).toEqual({
+        api: "ollama",
+        apiKey: "keep-me",
+        models: [
+          { id: "llama3.2", name: "Llama 3.2 latest", contextWindow: 131072 },
+          { id: "qwen3", name: "Qwen 3" },
+          { id: "gemma4", name: "Gemma 4" },
+        ],
+      });
+    });
+
+    it("merges provider object models by normalized catalog id", async () => {
+      const resolved = {
+        models: {
+          providers: {
+            openrouter: {
+              api: "openai-completions",
+              models: [
+                { id: "openrouter/foo", name: "Foo", contextWindow: 32000 },
+                { id: "openrouter/bar", name: "Bar" },
+              ],
+            },
+          },
+        },
+      } as unknown as OpenClawConfig;
+      setSnapshot(resolved, resolved);
+
+      await runConfigCommand([
+        "config",
+        "set",
+        "models.providers.openrouter",
+        '{"models":[{"id":"foo","name":"Foo latest"},{"id":"baz","name":"Baz"}]}',
+        "--strict-json",
+        "--merge",
+      ]);
+
+      expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
+      const written = firstWrittenConfig();
+      expect(written.models?.providers?.openrouter?.models).toEqual([
+        { id: "openrouter/foo", name: "Foo latest", contextWindow: 32000 },
+        { id: "openrouter/bar", name: "Bar" },
+        { id: "openrouter/baz", name: "Baz" },
+      ]);
+    });
+
     it("drops gateway.auth.password when switching mode to token", async () => {
       const resolved: OpenClawConfig = {
         gateway: {

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -745,20 +745,29 @@ function modelArrayIds(value: unknown): Set<string> | null {
   return ids;
 }
 
-function mergeModelArrays(existing: unknown[], patch: unknown[]): unknown[] {
+function modelArrayMergeId(entry: unknown, provider?: string): string | null {
+  if (!isPlainRecord(entry) || typeof entry.id !== "string" || !entry.id.trim()) {
+    return null;
+  }
+  const id = entry.id.trim();
+  return provider ? normalizeConfiguredProviderCatalogModelId(provider, id) : id;
+}
+
+function mergeModelArrays(existing: unknown[], patch: unknown[], provider?: string): unknown[] {
   const merged = [...existing];
   const indexById = new Map<string, number>();
   for (const [index, entry] of merged.entries()) {
-    if (isPlainRecord(entry) && typeof entry.id === "string" && entry.id.trim()) {
-      indexById.set(entry.id.trim(), index);
+    const id = modelArrayMergeId(entry, provider);
+    if (id) {
+      indexById.set(id, index);
     }
   }
   for (const entry of patch) {
-    if (!isPlainRecord(entry) || typeof entry.id !== "string" || !entry.id.trim()) {
+    const id = modelArrayMergeId(entry, provider);
+    if (!id) {
       merged.push(entry);
       continue;
     }
-    const id = entry.id.trim();
     const existingIndex = indexById.get(id);
     if (existingIndex === undefined) {
       indexById.set(id, merged.length);
@@ -766,22 +775,43 @@ function mergeModelArrays(existing: unknown[], patch: unknown[]): unknown[] {
       continue;
     }
     const existingEntry = merged[existingIndex];
-    merged[existingIndex] = isPlainRecord(existingEntry) ? { ...existingEntry, ...entry } : entry;
+    merged[existingIndex] =
+      isPlainRecord(existingEntry) && isPlainRecord(entry) ? { ...existingEntry, ...entry } : entry;
   }
   return merged;
 }
 
 function mergeConfigValue(existing: unknown, patch: unknown, path: PathSegment[]): unknown {
   if (isProviderModelListPath(path) && Array.isArray(existing) && Array.isArray(patch)) {
-    return mergeModelArrays(existing, patch);
+    return mergeModelArrays(existing, patch, path[2]);
   }
   if (isPlainRecord(existing) && isPlainRecord(patch)) {
     const next: Record<string, unknown> = { ...existing };
     for (const [key, value] of Object.entries(patch)) {
-      next[key] =
-        hasOwnPathKey(next, key) && isPlainRecord(next[key]) && isPlainRecord(value)
-          ? mergeConfigValue(next[key], value, [...path, key])
-          : value;
+      const childPath = [...path, key];
+      if (!hasOwnPathKey(next, key)) {
+        next[key] = value;
+        continue;
+      }
+      const existingValue = next[key];
+      if (isPlainRecord(existingValue) && isPlainRecord(value)) {
+        next[key] = mergeConfigValue(existingValue, value, childPath);
+        continue;
+      }
+      if (
+        isProviderModelListPath(childPath) &&
+        Array.isArray(existingValue) &&
+        Array.isArray(value)
+      ) {
+        next[key] = mergeModelArrays(existingValue, value, childPath[2]);
+        continue;
+      }
+      assertNonDestructiveReplacementValue({
+        path: childPath,
+        existingValue,
+        value,
+      });
+      next[key] = value;
     }
     return next;
   }
@@ -851,13 +881,25 @@ function assertNonDestructiveReplacement(params: {
   if (!existing.found) {
     return;
   }
+  assertNonDestructiveReplacementValue({
+    path: params.path,
+    existingValue: existing.value,
+    value: params.value,
+  });
+}
+
+function assertNonDestructiveReplacementValue(params: {
+  path: PathSegment[];
+  existingValue: unknown;
+  value: unknown;
+}): void {
   const pathLabel = toDotPath(params.path);
-  if (isProtectedMapReplacementPath(params.path) && isPlainRecord(existing.value)) {
+  if (isProtectedMapReplacementPath(params.path) && isPlainRecord(params.existingValue)) {
     if (!isPlainRecord(params.value)) {
       return;
     }
     const nextKeys = new Set(Object.keys(params.value));
-    const removed = Object.keys(existing.value).filter((key) => !nextKeys.has(key));
+    const removed = Object.keys(params.existingValue).filter((key) => !nextKeys.has(key));
     if (removed.length > 0) {
       throw new Error(
         `Refusing to replace ${pathLabel}; it would remove existing entries: ${formatRemovedEntries(removed)}. Use --merge to merge object values or --replace to replace intentionally.`,
@@ -865,7 +907,7 @@ function assertNonDestructiveReplacement(params: {
     }
   }
   if (isProtectedArrayReplacementPath(params.path)) {
-    const existingIds = modelArrayIds(existing.value);
+    const existingIds = modelArrayIds(params.existingValue);
     const nextIds = modelArrayIds(params.value);
     if (!existingIds || !nextIds) {
       return;


### PR DESCRIPTION
## What Problem This Solves
`openclaw config set models.providers.<id> '<json>' --merge` was documented as an additive update path, but applying it at the provider object path replaced the provider model catalog array and silently dropped existing model rows omitted from the patch.

## Summary
`openclaw config set models.providers.<id> '<json>' --merge` now preserves existing provider model catalog rows when the patch is applied at the provider object path. Existing sibling provider fields still merge normally, existing model rows are updated by id, and new model rows are appended.

## Root cause
`src/cli/config-cli.ts` only used the model-array merge path when the requested path was exactly `models.providers.<id>.models`.

```before
if (isProviderModelListPath(path) && Array.isArray(existing) && Array.isArray(patch)) {
  return mergeModelArrays(existing, patch);
}
```

When the documented additive command targeted `models.providers.<id>`, recursive object merge only descended into plain records. The `models` child is an array, so the old branch assigned the patch array over the existing catalog and silently dropped omitted model ids.

## Fix
Provider model arrays are now merged by id when recursion reaches the protected `models.providers.<id>.models` child path, and protected child replacements reuse the same non-destructive guard as direct replacement.

```after
if (
  isProviderModelListPath(childPath) &&
  Array.isArray(existingValue) &&
  Array.isArray(value)
) {
  next[key] = mergeModelArrays(existingValue, value, childPath[2]);
  continue;
}
```

The merge key uses provider catalog normalization, so provider rows such as `openrouter/foo` and patch rows such as `foo` update the same model instead of creating duplicates after write-time normalization.

## Why this is the right boundary
`mergeConfigValue` owns `config set --merge` semantics, so the fix stays at the config mutation boundary before the write path normalizes model ids. Direct `models.providers.<id>.models --merge` behavior is preserved, provider-object `--merge` now reaches the same model-list path, and unrelated arrays still replace unless a protected-path guard rejects destructive removal.

## Verification
- `PATH=/opt/node/bin:$PATH node scripts/run-vitest.mjs src/cli/config-cli.test.ts` passed: 1 file, 130 tests.
- `OPENCLAW_OXLINT_SKIP_PREPARE=1 PATH=/opt/node/bin:$PATH node scripts/run-oxlint.mjs src/cli/config-cli.ts src/cli/config-cli.test.ts` passed. The normal wrapper preparation step was separately attempted and blocked in extension package-boundary artifact preparation; this diff does not touch extension package-boundary files.
- `PATH=/opt/node/bin:$PATH ./node_modules/.bin/oxfmt --check src/cli/config-cli.ts src/cli/config-cli.test.ts` passed.
- `PATH=/opt/node/bin:$PATH node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo` passed.
- `PATH=/opt/node/bin:$PATH node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo` passed.
- Local review found one normalized-id merge issue; the branch now merges by normalized catalog id and the final review had no actionable findings.

## Evidence
The focused config CLI regression covers provider-object `--merge`, sibling scalar preservation, model-id preservation, and normalized provider catalog ids. The real behavior proof below drives the production config mutation path against on-disk config before and after the patch.

## Real behavior proof
Behavior addressed: provider-object additive config updates no longer drop existing provider model catalog rows.
Real environment tested: real `runConfigSet` production mutation path with on-disk config writes on pristine main 6e79ca3cbc and on patched head 6d699dd2009aa841c8649dd87100375422b08362; no external service boundary was needed.
Exact steps or command run after this patch: invoke `runConfigSet` for `models.providers.ollama` with strict JSON merge against the same temporary config contents, then read the written file.
Evidence after fix:
```
# BEFORE (pristine main 6e79ca3cbc)
Updated models.providers.ollama. Change will apply without restarting the gateway.
ollama.apiKey after: "keep-me"
ollama.models after: [{"id":"llama3.2","name":"Llama 3.2 latest"},{"id":"gemma4","name":"Gemma 4"}]
# AFTER (this patch, identical input)
Updated models.providers.ollama. Change will apply without restarting the gateway.
ollama.apiKey after: "keep-me"
ollama.models after: [{"id":"llama3.2","name":"Llama 3.2 latest","contextWindow":131072},{"id":"qwen3","name":"Qwen 3"},{"id":"gemma4","name":"Gemma 4"}]
```
Observed result after fix: the provider sibling scalar remains and the existing `qwen3` row plus `llama3.2.contextWindow` remain after the additive provider update.
What was not tested: no live provider request was made because the defect is limited to local config mutation and file persistence.

## Novelty
Searches for `mergeConfigValue models providers models --merge`, `config set models.providers --merge`, and `model catalog merge provider models` did not find an open same-path fix. #98799 is an installer script issue that omits `--merge` for channels. #95722 is about provider-key normalization in the models catalog planner. #69169, #69213, #69175, and #70435 are closed onboarding or provider-login fixes for `agents.defaults.models`, not `config set --merge` at `models.providers.<id>`.
