### PR TITLE
fix(reply): persist cliSessionBinding updates on heartbeat turns (#98895)

### DIFF
--- a/src/auto-reply/reply/session-usage.ts
+++ b/src/auto-reply/reply/session-usage.ts
@@ -234,7 +234,11 @@ export async function persistSessionUsageUpdate(params: {
           ) {
             patch.totalTokensFresh = false;
           }
-          return preserveSessionModelState
+          // Internal handoff and runtime-model-preserving runs skip CLI binding
+          // writes by returning the patch directly.  Heartbeat runs must still
+          // apply binding updates so forwarded cliSessionBinding /
+          // clearCliSessionBinding metadata is persisted (#98895).
+          return preserveUserFacingRunState || params.preserveRuntimeModel
             ? patch
             : applyCliSessionIdToSessionPatch(params, entry, patch);
         },
@@ -285,7 +289,9 @@ export async function persistSessionUsageUpdate(params: {
             // zero persisted for the previously empty session.
             patch.totalTokensFresh = false;
           }
-          return preserveSessionModelState
+          // Internal handoff and runtime-model-preserving runs skip CLI
+          // binding writes.  Heartbeat runs must persist them (#98895).
+          return preserveUserFacingRunState || params.preserveRuntimeModel
             ? patch
             : applyCliSessionIdToSessionPatch(params, entry, patch);
         },

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -30,10 +30,10 @@ import {
 } from "../../test-utils/channel-plugins.js";
 import { withEnvAsync } from "../../test-utils/env.js";
 import { createSessionConversationTestRegistry } from "../../test-utils/session-conversation-registry.js";
+import { replyRunRegistry } from "./reply-run-registry.js";
 import { drainFormattedSystemEvents } from "./session-updates.js";
 import { persistSessionUsageUpdate } from "./session-usage.js";
 import { initSessionState } from "./session.js";
-import { replyRunRegistry } from "./reply-run-registry.js";
 
 const sessionForkMocks = vi.hoisted(() => ({
   forkSessionFromParent: vi.fn(),
@@ -4363,6 +4363,53 @@ describe("persistSessionUsageUpdate", () => {
         "claude-cli": "existing-cli-session",
       },
       claudeCliSessionId: "existing-cli-session",
+    });
+  });
+
+  it("persists cliSessionBinding on heartbeat runs while preserving display model fields (#98895)", async () => {
+    const storePath = await createStorePath("openclaw-usage-heartbeat-");
+    const sessionKey = "main";
+    await seedSessionStore({
+      storePath,
+      sessionKey,
+      entry: {
+        sessionId: "s1",
+        updatedAt: 1,
+        modelProvider: "anthropic",
+        model: "claude-opus-4-8",
+        contextTokens: 500_000,
+        cliSessionBindings: {
+          "claude-cli": { sessionId: "pre-heartbeat-binding" },
+        },
+        cliSessionIds: {
+          "claude-cli": "pre-heartbeat-binding",
+        },
+        claudeCliSessionId: "pre-heartbeat-binding",
+      },
+    });
+
+    await persistSessionUsageUpdate({
+      storePath,
+      sessionKey,
+      isHeartbeat: true,
+      providerUsed: "claude-cli",
+      modelUsed: "claude-sonnet-4-6",
+      usage: { input: 200, output: 100, total: 300 },
+      lastCallUsage: { input: 180, output: 100, total: 280 },
+      contextTokensUsed: 480_000,
+      cliSessionBinding: { sessionId: "heartbeat-binding" },
+    });
+
+    const stored = JSON.parse(await fs.readFile(storePath, "utf-8"));
+    expect(stored[sessionKey]).toMatchObject({
+      // Display model fields preserved (heartbeat keeps user-facing state)
+      modelProvider: "anthropic",
+      model: "claude-opus-4-8",
+      // CLI binding updated (heartbeat persisted the new binding)
+      claudeCliSessionId: "heartbeat-binding",
+      cliSessionIds: {
+        "claude-cli": "heartbeat-binding",
+      },
     });
   });
 


### PR DESCRIPTION
Fixes #98895.

## What Problem This Solves

Heartbeat turns silently discard `cliSessionBinding` and `clearCliSessionBinding` updates because `persistSessionUsageUpdate` returns the patch before calling `applyCliSessionIdToSessionPatch` when `preserveSessionModelState` is true — which covers heartbeat, `preserveRuntimeModel`, and internal handoff runs. CLI-side session bindings are lost after each heartbeat, causing CLI context drift in multi-turn agent workflows.

## Why This Change Was Made

Narrowed the CLI binding skip gate from `preserveSessionModelState` to `preserveUserFacingRunState || preserveRuntimeModel` at both persist call sites. Heartbeat runs now flow through `applyCliSessionIdToSessionPatch` while runtime-model-preserving and internal handoff runs keep their existing behavior.

## User Impact

Claude CLI-backed agents retain their CLI session context across heartbeat turns. Multi-turn workflows no longer silently lose conversation state. Model display fields remain preserved during heartbeat (unchanged).

## Evidence

**Behavior addressed**: Heartbeat turns skip `applyCliSessionIdToSessionPatch`, dropping `cliSessionBinding`/`clearCliSessionBinding` metadata.

**Real environment tested**: Node 22.19+, local OpenClaw checkout. Real `persistSessionUsageUpdate` function with real JSONL session store.

**Exact steps or command run after this patch**:

```
node --import tsx /tmp/proof-98895.mjs
```

**Evidence after fix**:

```
=== #98895: heartbeat cliSessionBinding persistence ===

Model display fields (heartbeat preserves):
  modelProvider: anthropic ✅
  model:         claude-opus-4-8 ✅

CLI binding (AFTER fix, heartbeat PERSISTS):
  cliSessionBindings: {"claude-cli":{"sessionId":"existing-binding"},"anthropic":{"sessionId":"heartbeat-binding"}}
  heartbeat binding applied: ✅ YES — BEFORE fix: heartbeat skipped applyCliSessionIdToSessionPatch

✅ PROOF PASSED
```

Before fix: heartbeat's `preserveSessionModelState=true` returned `patch` directly, bypassing `applyCliSessionIdToSessionPatch`. The new CLI binding was silently discarded.

After fix: the narrowed gate (`preserveUserFacingRunState || preserveRuntimeModel`) lets heartbeat through to `applyCliSessionIdToSessionPatch`, persisting both the display model fields AND the CLI binding updates.

```
node scripts/run-vitest.mjs src/auto-reply/reply/session.test.ts --run
 Test Files  1 passed (1) / Tests  124 passed (124)

node scripts/run-oxlint.mjs src/auto-reply/reply/session-usage.ts
 (passed, exit 0)
```

**Observed result after fix**: Heartbeat runs correctly persist CLI session bindings while preserving user-facing model display fields. Runtime-model-preserving and internal handoff runs keep their existing behavior of skipping both binding writes and model updates.

**What was not tested**: Live E2E with a real Claude CLI heartbeat turn. Verified through the `persistSessionUsageUpdate` production function with real JSONL session store — the exact drop point identified by ClawSweeper.

## Regression Test Plan

- `node scripts/run-vitest.mjs src/auto-reply/reply/session.test.ts --run` — 124 passed
- `node scripts/run-oxlint.mjs src/auto-reply/reply/session-usage.ts` — exit 0

## Root Cause

Commit `0314819f918a` widened the CLI binding skip gate from `preserveUserFacingRunState` to `preserveSessionModelState` (which additionally covers `isHeartbeat` and `preserveRuntimeModel`). The regression is that heartbeats which should carry forward CLI session context began silently dropping binding updates. The fix restores the pre-regression behavior for heartbeat while keeping `preserveRuntimeModel` runs unchanged.

## AI Assistance

- **AI-assisted**: Yes
- **Model used**: Claude Opus 4.8 (1M context)
- **Co-Authored-By**: Already in commit message
