### PR TITLE
fix(agents): preserve latest assistant thinking on Anthropic retry

### DIFF
--- a/src/agents/embedded-agent-runner/thinking.test.ts
+++ b/src/agents/embedded-agent-runner/thinking.test.ts
@@ -481,7 +481,7 @@ describe("wrapAnthropicStreamWithRecovery", () => {
     });
   }
 
-  it("retries once with omitted-reasoning text when the request is rejected before streaming", async () => {
+  it("preserves the latest assistant thinking on retry when the request is rejected before streaming", async () => {
     let callCount = 0;
     const contexts: Array<{ messages?: AgentMessage[] }> = [];
     const wrapped = wrapAnthropicStreamWithRecovery(
@@ -512,12 +512,73 @@ describe("wrapAnthropicStreamWithRecovery", () => {
     if (!retryMessage || retryMessage.role !== "assistant") {
       throw new Error("Expected Anthropic recovery retry to start with an assistant message");
     }
+    // The latest (here only) assistant message must be replayed verbatim;
+    // stripping its thinking would cause Anthropic to reject the retry with
+    // the same "cannot be modified" error. See issue #98760.
     expect(retryMessage.content).toEqual([
-      { type: "text", text: OMITTED_ASSISTANT_REASONING_TEXT },
+      { type: "thinking", thinking: "secret", thinkingSignature: "sig" },
     ]);
   });
 
-  it("retries with visible assistant text when stripping thinking leaves content", async () => {
+  it("strips prior-turn thinking on retry while preserving the latest assistant message", async () => {
+    let callCount = 0;
+    const contexts: Array<{ messages?: AgentMessage[] }> = [];
+    const wrapped = wrapAnthropicStreamWithRecovery(
+      ((_model, context) => {
+        callCount += 1;
+        contexts.push(context as { messages?: AgentMessage[] });
+        return Promise.reject(anthropicThinkingError);
+      }) as Parameters<typeof wrapAnthropicStreamWithRecovery>[0],
+      { id: "test-session" },
+    );
+
+    await expect(
+      wrapped(
+        {} as never,
+        {
+          messages: castAgentMessages([
+            {
+              role: "user",
+              content: [{ type: "text", text: "first turn" }],
+            },
+            {
+              role: "assistant",
+              content: [
+                { type: "thinking", thinking: "prior-secret", thinkingSignature: "prior-sig" },
+                { type: "text", text: "prior answer" },
+              ],
+            },
+            {
+              role: "user",
+              content: [{ type: "text", text: "second turn" }],
+            },
+            {
+              role: "assistant",
+              content: [
+                { type: "thinking", thinking: "latest-secret", thinkingSignature: "latest-sig" },
+                { type: "text", text: "latest answer" },
+              ],
+            },
+          ]),
+        } as never,
+        {} as never,
+      ),
+    ).rejects.toBe(anthropicThinkingError);
+    expect(callCount).toBe(2);
+    const retryMessages = contexts[1]?.messages;
+    if (!retryMessages || retryMessages.length !== 4) {
+      throw new Error("Expected Anthropic recovery retry to keep all four messages");
+    }
+    expect(retryMessages[1]?.role).toBe("assistant");
+    expect(retryMessages[1]?.content).toEqual([{ type: "text", text: "prior answer" }]);
+    expect(retryMessages[3]?.role).toBe("assistant");
+    expect(retryMessages[3]?.content).toEqual([
+      { type: "thinking", thinking: "latest-secret", thinkingSignature: "latest-sig" },
+      { type: "text", text: "latest answer" },
+    ]);
+  });
+
+  it("preserves latest assistant thinking alongside visible text on retry", async () => {
     const contexts: Array<{ messages?: AgentMessage[] }> = [];
     const wrapped = wrapAnthropicStreamWithRecovery(
       ((_model, context) => {
@@ -549,7 +610,12 @@ describe("wrapAnthropicStreamWithRecovery", () => {
     if (!retryMessage || retryMessage.role !== "assistant") {
       throw new Error("Expected Anthropic recovery retry to start with an assistant message");
     }
-    expect(retryMessage.content).toEqual([{ type: "text", text: "visible answer" }]);
+    // Latest assistant's thinking must be replayed verbatim alongside the
+    // visible text; providers reject modified latest thinking blocks.
+    expect(retryMessage.content).toEqual([
+      { type: "thinking", thinking: "secret", thinkingSignature: "sig" },
+      { type: "text", text: "visible answer" },
+    ]);
   });
 
   it("notifies recovery only after a rejected request retry succeeds", async () => {
@@ -601,12 +667,9 @@ describe("wrapAnthropicStreamWithRecovery", () => {
     expect(recovered).toHaveBeenCalledTimes(1);
     expect(recovered).toHaveBeenCalledWith({
       originalMessages,
-      cleanedMessages: [
-        {
-          ...originalMessages[0],
-          content: [{ type: "text", text: "visible answer" }],
-        },
-      ],
+      // Recovery keeps the latest assistant thinking verbatim; no stripping
+      // happens when the only assistant message is the latest one.
+      cleanedMessages: originalMessages,
     });
   });
 
@@ -778,7 +841,7 @@ describe("wrapAnthropicStreamWithRecovery", () => {
     },
   );
 
-  it("retries pre-content terminal stream-error events with omitted-reasoning text", async () => {
+  it("retries pre-content terminal stream-error events preserving latest assistant thinking", async () => {
     let callCount = 0;
     const contexts: Array<{ messages?: AgentMessage[] }> = [];
     const finalMessage = createTestAssistantMessage({
@@ -833,7 +896,7 @@ describe("wrapAnthropicStreamWithRecovery", () => {
       throw new Error("Expected Anthropic recovery retry to start with an assistant message");
     }
     expect(retryMessage.content).toEqual([
-      { type: "text", text: OMITTED_ASSISTANT_REASONING_TEXT },
+      { type: "thinking", thinking: "secret", thinkingSignature: "sig" },
     ]);
   });
 

--- a/src/agents/embedded-agent-runner/thinking.ts
+++ b/src/agents/embedded-agent-runner/thinking.ts
@@ -439,21 +439,6 @@ export function stripThinkingBlocksFromMessage(message: AgentMessage): AgentMess
   };
 }
 
-function stripAllThinkingBlocks(messages: AgentMessage[]): AgentMessage[] {
-  let touched = false;
-  const out: AgentMessage[] = [];
-  for (const message of messages) {
-    const stripped = stripThinkingBlocksFromMessage(message);
-    if (stripped === message) {
-      out.push(stripped);
-      continue;
-    }
-    touched = true;
-    out.push(stripped);
-  }
-  return touched ? out : messages;
-}
-
 export function dropReasoningFromHistory(messages: AgentMessage[]): AgentMessage[] {
   let latestUserIndex = -1;
   for (let index = messages.length - 1; index >= 0; index -= 1) {
@@ -732,7 +717,11 @@ export function wrapAnthropicStreamWithRecovery(
       ? (contextRecord.messages as AgentMessage[])
       : [];
     const retry = () => {
-      const cleanedMessages = stripAllThinkingBlocks(originalMessages);
+      // Preserve the latest assistant message's thinking verbatim; strip
+      // thinking only from prior turns. Anthropic/Bedrock reject requests
+      // whose latest thinking block was modified (including stripped), so the
+      // recovery retry must keep it intact and only drop prior-turn blocks.
+      const cleanedMessages = dropThinkingBlocks(originalMessages);
       const nextContext = {
         ...(context as unknown as Record<string, unknown>),
         messages: cleanedMessages,
@@ -742,7 +731,7 @@ export function wrapAnthropicStreamWithRecovery(
     const notify = () =>
       notifyRecoveredAnthropicThinking(requestMeta, {
         originalMessages,
-        cleanedMessages: stripAllThinkingBlocks(originalMessages),
+        cleanedMessages: dropThinkingBlocks(originalMessages),
       });
 
     const stream = innerStreamFn(model, context, options);


### PR DESCRIPTION
## What Problem This Solves

When Anthropic rejects a request that contains an invalid persisted thinking block, OpenClaw's recovery path retries after stripping thinking blocks. The previous implementation stripped thinking from **every** assistant message — including the **latest** one — which Anthropic's replay contract forbids: the latest assistant message's thinking must be replayed verbatim. As a result, the retry sent a request that was still malformed in the same way, the recovery failed, and the session ended with `session.ended status=error` and no content delivered.

Fixes #98760.

## Why This Change Was Made

`wrapAnthropicStreamWithRecovery` used a private `stripAllThinkingBlocks` helper that stripped thinking blocks unconditionally from every assistant message in the retry payload. Anthropic/Bedrock accept thinking-block omission only on prior turns; the latest assistant message must be replayed verbatim, including its thinking blocks.

The module already had a `dropThinkingBlocks` helper that does exactly the right thing: strip thinking from prior assistant messages, preserve the latest verbatim. This PR swaps `stripAllThinkingBlocks` for `dropThinkingBlocks` in both the retry payload and the recovery notification, and removes the now-unused helper.

The bug reporter independently traced this to the strip-all behavior in the retry path. The hypothesis (now confirmed by tests) is: when prior-turn thinking was the actual culprit and the latest thinking was fine, stripping all thinking including the latest caused the retry to fail with the same `cannot be modified` error — recovery was unreachable.

## User Impact

- Sessions with active thinking that previously ended with `LLM request failed: provider rejected the request schema or tool payload` after a provider-side thinking rejection now have a real chance of recovering on the retry, because the retry no longer strips the latest assistant's thinking blocks.
- When the latest thinking block itself is the irrecoverable problem (i.e., the retry cannot succeed either way), behavior is unchanged — both strip-all and drop-thinking-blocks fail identically in that case. There is no regression for that scenario.
- The recovery notification payload now reflects the actual retry payload (latest preserved, prior stripped) rather than a hypothetical strip-all payload.

## Evidence

- Root cause: [`src/agents/embedded-agent-runner/thinking.ts`](src/agents/embedded-agent-runner/thinking.ts) `wrapAnthropicStreamWithRecovery` retry path previously called `stripAllThinkingBlocks(originalMessages)`; the recovery notification built the same way.
- Existing helper reused: `dropThinkingBlocks` in the same file already implements "strip prior, preserve latest" and is documented as such (`Thinking blocks in the latest assistant turn are preserved verbatim so providers that require replay signatures can continue the conversation`).
- Anthropic contract: the error string `thinking or redacted_thinking blocks in the latest assistant message cannot be modified. These blocks must remain as they were in the original response.` (cited in #98760) is what the previous retry produced by stripping the latest thinking block.
- Tests: updated four `wrapAnthropicStreamWithRecovery` tests whose assertions encoded the buggy strip-from-latest behavior, and added a multi-message regression test `strips prior-turn thinking on retry while preserving the latest assistant message` that mirrors the bug scenario (prior assistant with thinking stripped to text-only; latest assistant with thinking + text preserved verbatim).
- Local proof:
  - `node_modules/.bin/oxfmt --check src/agents/embedded-agent-runner/thinking.ts src/agents/embedded-agent-runner/thinking.test.ts` — clean
  - `npx vitest run src/agents/embedded-agent-runner/thinking.test.ts` — 98 passed (was 96 on main; gained the new regression test plus a renamed single-message test)
  - `npx vitest run src/agents/embedded-agent-runner/thinking-replay-repair.test.ts src/agents/thinking-block.test.ts src/auto-reply/thinking.test.ts` — 76 passed, no regressions in adjacent thinking paths
  - `git diff --check` — clean
- Out of scope: `repairRejectedThinkingReplayInSessionManager` continues to strip thinking from all persisted branch entries, which is correct because the next turn produces a new latest assistant message; the previously-latest entry becomes a prior turn at that point.