### PR TITLE
fix(telegram): distinguish and render streamed reasoning/commentary progress lanes

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -3358,10 +3358,113 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(createTelegramDraftStream).toHaveBeenCalledTimes(1);
     expect(draftStream.updatePreview).toHaveBeenCalledWith(
       telegramProgressPreview(
-        "Shelling\n\n🛠️ Exec\n• Checking files",
-        "<b>Shelling</b>\n<b>🛠️ Exec</b>\n<i>Checking files</i>",
+        "Shelling\n\n🛠️ Exec\n🧠 Checking files",
+        "<b>Shelling</b>\n<b>🛠️ Exec</b>\n🧠 <i>Checking files</i>",
       ),
     );
+  });
+
+  it("renders model markdown in streamed reasoning and commentary lanes", async () => {
+    const draftStream = createSequencedDraftStream(2001);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+      await replyOptions?.onReplyStart?.();
+      await replyOptions?.onAssistantMessageStart?.();
+      await replyOptions?.onReasoningStream?.({ text: "<think>Running `sleep 4`</think>" });
+      await replyOptions?.onItemEvent?.({
+        kind: "preamble",
+        itemId: "c1",
+        progressText: "**Reading AGENTS.md**",
+      });
+      return { queuedFinal: false };
+    });
+
+    await dispatchWithContext({
+      context: createReasoningStreamContext(),
+      streamMode: "progress",
+      telegramCfg: {
+        streaming: { mode: "progress", progress: { label: "Shelling", commentary: true } },
+      },
+    });
+
+    const lastPreview = draftStream.updatePreview.mock.calls.at(-1)?.[0];
+    expect(lastPreview?.parseMode).toBe("HTML");
+    // Reasoning stays 🧠 italic with inline code rendered (not a raw backtick).
+    expect(lastPreview?.text).toContain("🧠 <i>Running <code>sleep 4</code></i>");
+    // Commentary renders the model's bold (not raw `**`), distinct from reasoning.
+    expect(lastPreview?.text).toContain("💬 <b>Reading <code>AGENTS.md</code></b>");
+    expect(lastPreview?.text).not.toContain("**");
+    expect(lastPreview?.text).not.toContain("`sleep");
+  });
+
+  it("keeps clipped long reasoning lines italic behind the 🧠 marker", async () => {
+    const draftStream = createSequencedDraftStream(2001);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    // Real reasoning routinely exceeds the progress clip limit; truncation must
+    // clip inside the `_…_` wrapper, not chop the closing underscore (which
+    // silently degrades the lane to plain text with a leaked underscore).
+    const longThought = "The user wants me to think carefully and run several steps. ".repeat(8);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+      await replyOptions?.onReplyStart?.();
+      await replyOptions?.onAssistantMessageStart?.();
+      await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+      await replyOptions?.onReasoningStream?.({ text: `<think>${longThought}</think>` });
+      return { queuedFinal: false };
+    });
+
+    await dispatchWithContext({
+      context: createReasoningStreamContext(),
+      streamMode: "progress",
+      telegramCfg: {
+        streaming: { mode: "progress", progress: { label: "Shelling", maxLineChars: 300 } },
+      },
+    });
+
+    const lastPreview = draftStream.updatePreview.mock.calls.at(-1)?.[0];
+    expect(lastPreview?.parseMode).toBe("HTML");
+    expect(lastPreview?.text).toContain("🧠 <i>The user wants me to think carefully");
+    expect(lastPreview?.text).toMatch(/…<\/i>/u);
+    expect(lastPreview?.text).not.toContain("_");
+  });
+
+  it("keeps multi-line commentary markdown parse_mode-safe in progress drafts", async () => {
+    const draftStream = createSequencedDraftStream(2001);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    // Models separate narration blocks with `\n\n---\n\n`; as block markdown that
+    // turns the paragraph above into a setext <h2> heading, which Telegram's
+    // parse_mode=HTML rejects — dropping the ENTIRE preview (all lanes) to
+    // unformatted plain text. Lane lines must render inline-safe HTML only.
+    const commentary =
+      "Planning: three sequential steps with a file read in between.\n\n---\n\n**Step 1:** Run `sleep 6 && date`";
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+      await replyOptions?.onReplyStart?.();
+      await replyOptions?.onAssistantMessageStart?.();
+      await replyOptions?.onReasoningStream?.({ text: "<think>Planning the steps</think>" });
+      await replyOptions?.onItemEvent?.({
+        kind: "preamble",
+        itemId: "c1",
+        progressText: commentary,
+      });
+      return { queuedFinal: false };
+    });
+
+    await dispatchWithContext({
+      context: createReasoningStreamContext(),
+      streamMode: "progress",
+      telegramCfg: {
+        streaming: { mode: "progress", progress: { label: "Shelling", commentary: true } },
+      },
+    });
+
+    const lastPreview = draftStream.updatePreview.mock.calls.at(-1)?.[0];
+    expect(lastPreview?.parseMode).toBe("HTML");
+    // Reasoning lane still italic, commentary collapsed to one inline-safe line.
+    expect(lastPreview?.text).toContain("🧠 <i>Planning the steps</i>");
+    expect(lastPreview?.text).toContain(
+      "💬 Planning: three sequential steps with a file read in between. --- <b>Step 1:</b> Run <code>sleep 6 &amp;&amp; date</code>",
+    );
+    // No rich-only block HTML that Telegram's parse_mode=HTML would reject.
+    expect(lastPreview?.text).not.toMatch(/<(h[1-6]|hr|ul|ol|li|p|div)\b/u);
   });
 
   it("renders configured Telegram commentary progress from preamble item events", async () => {
@@ -3390,8 +3493,8 @@ describe("dispatchTelegramMessage draft streaming", () => {
 
     expect(draftStream.updatePreview).toHaveBeenCalledWith(
       telegramProgressPreview(
-        "Shelling\n\nChecking recent context",
-        "<b>Shelling</b>\n<i>Checking recent context</i>",
+        "Shelling\n\n💬 Checking recent context",
+        "<b>Shelling</b>\n💬 Checking recent context",
       ),
     );
   });
@@ -3478,8 +3581,8 @@ describe("dispatchTelegramMessage draft streaming", () => {
 
     expect(draftStream.updatePreview).toHaveBeenCalledWith(
       telegramProgressPreview(
-        "Shelling\n\n• Checking files",
-        "<b>Shelling</b>\n<i>Checking files</i>",
+        "Shelling\n\n🧠 Checking files",
+        "<b>Shelling</b>\n🧠 <i>Checking files</i>",
       ),
     );
   });

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -2746,8 +2746,16 @@ describe("dispatchTelegramMessage draft streaming", () => {
       expect.objectContaining({ text: expect.stringMatching(/🛠️ Exec<\/b>$/) }),
     );
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(3, "Final answer");
-    expect(answerDraftStream.clear).toHaveBeenCalledTimes(1);
-    expect(answerDraftStream.forceNewMessage).toHaveBeenCalledTimes(2);
+    // The tool-progress window repositions before the final (deferred delete),
+    // never an immediate clear/delete.
+    expect(answerDraftStream.rotateToNewMessageDeferringDelete).toHaveBeenCalledTimes(1);
+    // The reposition rewinds the stream BEFORE any deliverer cleanup clear(),
+    // so that clear finds no live message id and never deletes the window.
+    if (answerDraftStream.clear.mock.invocationCallOrder.length > 0) {
+      expect(
+        answerDraftStream.rotateToNewMessageDeferringDelete.mock.invocationCallOrder[0],
+      ).toBeLessThan(answerDraftStream.clear.mock.invocationCallOrder[0]);
+    }
     const progressResetOrder = answerDraftStream.forceNewMessage.mock.invocationCallOrder[0];
     const progressUpdateOrder = answerDraftStream.updatePreview.mock.invocationCallOrder[0];
     expect(progressResetOrder).toBeLessThan(progressUpdateOrder);
@@ -2774,8 +2782,16 @@ describe("dispatchTelegramMessage draft streaming", () => {
     );
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(2, "Site B shows Y.");
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(3, "Final answer");
-    expect(answerDraftStream.forceNewMessage).toHaveBeenCalledTimes(2);
-    expect(answerDraftStream.clear).toHaveBeenCalledTimes(1);
+    // The tool-progress window repositions (deferred delete) rather than an
+    // immediate clear when the following text block takes over the lane.
+    expect(answerDraftStream.rotateToNewMessageDeferringDelete).toHaveBeenCalledTimes(1);
+    // The reposition rewinds the stream BEFORE any deliverer cleanup clear(),
+    // so that clear finds no live message id and never deletes the window.
+    if (answerDraftStream.clear.mock.invocationCallOrder.length > 0) {
+      expect(
+        answerDraftStream.rotateToNewMessageDeferringDelete.mock.invocationCallOrder[0],
+      ).toBeLessThan(answerDraftStream.clear.mock.invocationCallOrder[0]);
+    }
     expect(deliverReplies).not.toHaveBeenCalled();
   });
 
@@ -2815,12 +2831,20 @@ describe("dispatchTelegramMessage draft streaming", () => {
       expect.objectContaining({ text: expect.stringMatching(/🛠️ Exec<\/b>$/) }),
     );
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(1, "Branch is up to date");
-    expect(answerDraftStream.forceNewMessage).toHaveBeenCalledTimes(1);
-    expect(answerDraftStream.clear).toHaveBeenCalledTimes(1);
-    const clearOrder = answerDraftStream.clear.mock.invocationCallOrder[0];
-    const rotationOrder = answerDraftStream.forceNewMessage.mock.invocationCallOrder[0];
+    // Reposition, not delete-then-repost: the tool-progress window is rewound
+    // for a new message and its delete deferred until after the replacement
+    // lands. clear() (immediate delete) must NOT run — that scroll-jumps.
+    expect(answerDraftStream.rotateToNewMessageDeferringDelete).toHaveBeenCalledTimes(1);
+    // The reposition rewinds the stream BEFORE any deliverer cleanup clear(),
+    // so that clear finds no live message id and never deletes the window.
+    if (answerDraftStream.clear.mock.invocationCallOrder.length > 0) {
+      expect(
+        answerDraftStream.rotateToNewMessageDeferringDelete.mock.invocationCallOrder[0],
+      ).toBeLessThan(answerDraftStream.clear.mock.invocationCallOrder[0]);
+    }
+    const rotationOrder =
+      answerDraftStream.rotateToNewMessageDeferringDelete.mock.invocationCallOrder[0];
     const finalUpdateOrder = answerDraftStream.update.mock.invocationCallOrder[0];
-    expect(clearOrder).toBeLessThan(rotationOrder);
     expect(rotationOrder).toBeLessThan(finalUpdateOrder);
   });
 
@@ -2841,12 +2865,19 @@ describe("dispatchTelegramMessage draft streaming", () => {
       expect.objectContaining({ text: expect.stringMatching(/🛠️ Exec<\/b>$/) }),
     );
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(1, "Branch is up to date");
-    expect(answerDraftStream.forceNewMessage).toHaveBeenCalledTimes(1);
-    expect(answerDraftStream.clear).toHaveBeenCalledTimes(1);
-    const clearOrder = answerDraftStream.clear.mock.invocationCallOrder[0];
-    const rotationOrder = answerDraftStream.forceNewMessage.mock.invocationCallOrder[0];
+    // Across an assistant boundary the tool-progress window still repositions
+    // (new message first, deferred delete) rather than deleting immediately.
+    expect(answerDraftStream.rotateToNewMessageDeferringDelete).toHaveBeenCalledTimes(1);
+    // The reposition rewinds the stream BEFORE any deliverer cleanup clear(),
+    // so that clear finds no live message id and never deletes the window.
+    if (answerDraftStream.clear.mock.invocationCallOrder.length > 0) {
+      expect(
+        answerDraftStream.rotateToNewMessageDeferringDelete.mock.invocationCallOrder[0],
+      ).toBeLessThan(answerDraftStream.clear.mock.invocationCallOrder[0]);
+    }
+    const rotationOrder =
+      answerDraftStream.rotateToNewMessageDeferringDelete.mock.invocationCallOrder[0];
     const finalUpdateOrder = answerDraftStream.update.mock.invocationCallOrder[0];
-    expect(clearOrder).toBeLessThan(rotationOrder);
     expect(rotationOrder).toBeLessThan(finalUpdateOrder);
   });
 
@@ -2862,12 +2893,19 @@ describe("dispatchTelegramMessage draft streaming", () => {
 
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(1, "🛠️ Exec: pnpm test");
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(2, "Tests passed");
-    expect(answerDraftStream.forceNewMessage).toHaveBeenCalledTimes(1);
-    expect(answerDraftStream.clear).toHaveBeenCalledTimes(1);
-    const clearOrder = answerDraftStream.clear.mock.invocationCallOrder[0];
-    const rotationOrder = answerDraftStream.forceNewMessage.mock.invocationCallOrder[0];
+    // Verbose tool result window repositions before the final: new message
+    // first, superseded delete deferred (no immediate clear/delete).
+    expect(answerDraftStream.rotateToNewMessageDeferringDelete).toHaveBeenCalledTimes(1);
+    // The reposition rewinds the stream BEFORE any deliverer cleanup clear(),
+    // so that clear finds no live message id and never deletes the window.
+    if (answerDraftStream.clear.mock.invocationCallOrder.length > 0) {
+      expect(
+        answerDraftStream.rotateToNewMessageDeferringDelete.mock.invocationCallOrder[0],
+      ).toBeLessThan(answerDraftStream.clear.mock.invocationCallOrder[0]);
+    }
+    const rotationOrder =
+      answerDraftStream.rotateToNewMessageDeferringDelete.mock.invocationCallOrder[0];
     const finalUpdateOrder = answerDraftStream.update.mock.invocationCallOrder[1];
-    expect(clearOrder).toBeLessThan(rotationOrder);
     expect(rotationOrder).toBeLessThan(finalUpdateOrder);
   });
 
@@ -3056,6 +3094,42 @@ describe("dispatchTelegramMessage draft streaming", () => {
     const texts = allDeliveredReplyTexts();
     expect(texts.filter((text) => text.includes("⏱️"))).toHaveLength(0); // bar is the in-place edit
     expect(texts).toContain("Done");
+  });
+
+  it("repositions the tool-progress window (deferred delete) when text follows durable reasoning", async () => {
+    // on-off mid-stream jump: a durable 🧠 posts BELOW the tool-progress window;
+    // when answer text then takes over the lane, the window must reposition
+    // (send-new-first, delete-old-deferred) rather than delete-then-repost,
+    // which scroll-jumps the Telegram client.
+    loadSessionStore.mockReturnValue({ s1: { reasoningLevel: "on" } });
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+        await dispatcherOptions.deliver(
+          { text: "<think>hidden</think>", isReasoning: true },
+          { kind: "block" },
+        );
+        // Answer text mid-turn takes the lane over from the tool-progress window.
+        await dispatcherOptions.deliver({ text: "Here is the answer" }, { kind: "block" });
+        await dispatcherOptions.deliver({ text: "Here is the answer." }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+
+    await dispatchWithContext({
+      context: createContext({
+        ctxPayload: { SessionKey: "s1" } as unknown as TelegramMessageContext["ctxPayload"],
+      }),
+      streamMode: "progress",
+      telegramCfg: { streaming: { mode: "progress" } },
+    });
+
+    // The tool-progress window was repositioned via the deferred-delete path,
+    // never an immediate clear() (which deletes the window above the durable 🧠
+    // and reposts below — the focus-jump).
+    expect(answerDraftStream.rotateToNewMessageDeferringDelete).toHaveBeenCalled();
+    expect(answerDraftStream.clear).not.toHaveBeenCalled();
   });
 
   it("posts the collapse bar durably with no delete when the window has no live message", async () => {
@@ -3968,9 +4042,13 @@ describe("dispatchTelegramMessage draft streaming", () => {
         "<b>Shelling</b>\n<b>🔎 Web Search</b> <code>docs lookup</code>\n<b>Update</b> <code>tests passed</code>",
       ),
     );
-    expect(draftStream.forceNewMessage).toHaveBeenCalledTimes(1);
     expect(draftStream.materialize).not.toHaveBeenCalled();
-    expect(draftStream.clear).toHaveBeenCalledTimes(1);
+    // A tool-progress-only window with nothing to summarize is torn down via the
+    // deferred-delete reposition (new content first, delete later), not a bare
+    // immediate clear/delete or forceNewMessage.
+    expect(draftStream.rotateToNewMessageDeferringDelete).toHaveBeenCalledTimes(1);
+    expect(draftStream.forceNewMessage).not.toHaveBeenCalled();
+    expect(draftStream.clear).not.toHaveBeenCalled();
     expectDeliveredReply(0, { text: "Final after tool" });
     expect(editMessageTelegram).not.toHaveBeenCalled();
   });

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -2889,8 +2889,89 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(answerDraftStream.update).not.toHaveBeenCalledWith("Branch is up to date");
     expect(answerDraftStream.forceNewMessage).toHaveBeenCalledTimes(1);
     expect(answerDraftStream.clear).toHaveBeenCalledTimes(1);
-    expectDeliveredReply(0, { text: "Branch is up to date" });
+    // The progress window collapses to a one-line activity summary (Discord
+    // parity) before the final answer posts fresh below it.
+    expectDeliveredReply(0, { text: "🛠️ 1 tool call · ⏱️ 1s" });
+    expectDeliveredReply(0, { text: "Branch is up to date" }, 1);
     expect(editMessageTelegram).not.toHaveBeenCalled();
+  });
+
+  function allDeliveredReplyTexts(): string[] {
+    return deliverReplies.mock.calls.flatMap((call: unknown[]) =>
+      ((call[0] as { replies?: Array<{ text?: string }> }).replies ?? []).map(
+        (reply) => reply.text ?? "",
+      ),
+    );
+  }
+
+  it("tallies reasoning bursts and tool calls into the collapse summary", async () => {
+    setupDraftStreams({ answerMessageId: 2001 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        // burst 1 → tool → burst 2 → tool, then a trailing burst flushed at the
+        // summary: 3 thoughts, 2 tool calls.
+        await replyOptions?.onReasoningStream?.({ text: "thinking a" });
+        await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+        await replyOptions?.onReasoningStream?.({ text: "thinking b" });
+        await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+        await replyOptions?.onReasoningStream?.({ text: "thinking c" });
+        await dispatcherOptions.deliver({ text: "Done" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+
+    await dispatchWithContext({
+      // Reasoning must resolve to "stream" so thoughts route into the progress
+      // window — only window-streamed reasoning feeds the collapse summary.
+      context: createReasoningStreamContext(),
+      streamMode: "progress",
+      telegramCfg: { streaming: { mode: "progress" } },
+    });
+
+    expectDeliveredReply(0, { text: "🧠 3 thoughts · 🛠️ 2 tool calls · ⏱️ 1s" });
+    expectDeliveredReply(0, { text: "Done" }, 1);
+  });
+
+  it("does not post a collapse summary when no progress draft started", async () => {
+    setupDraftStreams({ answerMessageId: 2001 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      // No tools, thoughts, or notes — nothing collapses; just a final answer.
+      await dispatcherOptions.deliver({ text: "Just an answer" }, { kind: "final" });
+      return { queuedFinal: true };
+    });
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "progress",
+      telegramCfg: { streaming: { mode: "progress" } },
+    });
+
+    const texts = allDeliveredReplyTexts();
+    expect(texts.some((text) => text.includes("⏱️"))).toBe(false);
+    expect(texts).toContain("Just an answer");
+  });
+
+  it("does not post a collapse summary before an error final", async () => {
+    setupDraftStreams({ answerMessageId: 2001 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+        await dispatcherOptions.deliver(
+          { text: "Something went wrong", isError: true },
+          { kind: "final" },
+        );
+        return { queuedFinal: true };
+      },
+    );
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "progress",
+      telegramCfg: { streaming: { mode: "progress" } },
+    });
+
+    const texts = allDeliveredReplyTexts();
+    expect(texts.some((text) => text.includes("tool call · ⏱️"))).toBe(false);
   });
 
   it("replaces Telegram command progress items with matching command output", async () => {
@@ -2956,7 +3037,9 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(answerDraftStream.forceNewMessage.mock.invocationCallOrder[1]).toBeLessThan(
       answerDraftStream.update.mock.invocationCallOrder[0],
     );
-    expectDeliveredReply(0, { text: "Branch is up to date" });
+    // Collapse summary posts first, then the final answer below it.
+    expectDeliveredReply(0, { text: "🛠️ 1 tool call · ⏱️ 1s" });
+    expectDeliveredReply(0, { text: "Branch is up to date" }, 1);
   });
 
   it("does not stream text-only tool results into progress drafts", async () => {
@@ -3039,7 +3122,8 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
       telegramProgressPreview("Shelling\n\n🛠️ Exec", "<b>Shelling</b>\n<b>🛠️ Exec</b>"),
     );
-    expectDeliveredReply(0, { text: "Branch is up to date" });
+    expectDeliveredReply(0, { text: "🛠️ 1 tool call · ⏱️ 1s" });
+    expectDeliveredReply(0, { text: "Branch is up to date" }, 1);
   });
 
   it("does not restart progress drafts for command output after final answer delivery", async () => {
@@ -3069,7 +3153,8 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
       telegramProgressPreview("Shelling\n\n🛠️ Exec", "<b>Shelling</b>\n<b>🛠️ Exec</b>"),
     );
-    expectDeliveredReply(0, { text: "Branch is up to date" });
+    expectDeliveredReply(0, { text: "🛠️ 1 tool call · ⏱️ 1s" });
+    expectDeliveredReply(0, { text: "Branch is up to date" }, 1);
   });
 
   it("does not restart progress drafts for command output while final answer delivery is pending", async () => {
@@ -3103,7 +3188,8 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
       telegramProgressPreview("Shelling\n\n🛠️ Exec", "<b>Shelling</b>\n<b>🛠️ Exec</b>"),
     );
-    expectDeliveredReply(0, { text: "Branch is up to date" });
+    expectDeliveredReply(0, { text: "🛠️ 1 tool call · ⏱️ 1s" });
+    expectDeliveredReply(0, { text: "Branch is up to date" }, 1);
   });
 
   it("uses the transcript final when progress-mode final text is truncated", async () => {
@@ -3133,7 +3219,8 @@ describe("dispatchTelegramMessage draft streaming", () => {
       telegramCfg: { streaming: { mode: "progress" } },
     });
 
-    expectDeliveredReply(0, { text: fullAnswer });
+    expectDeliveredReply(0, { text: "🛠️ 1 tool call · ⏱️ 1s" });
+    expectDeliveredReply(0, { text: fullAnswer }, 1);
   });
 
   it("streams the first long final chunk and sends follow-up chunks", async () => {
@@ -3458,10 +3545,12 @@ describe("dispatchTelegramMessage draft streaming", () => {
 
     const lastPreview = draftStream.updatePreview.mock.calls.at(-1)?.[0];
     expect(lastPreview?.parseMode).toBe("HTML");
-    // Reasoning lane still italic, commentary collapsed to one inline-safe line.
+    // Reasoning lane still italic; commentary keeps its line structure (each
+    // line converted separately, so the `---` renders as a divider line instead
+    // of turning the paragraph above it into a setext <h2>).
     expect(lastPreview?.text).toContain("🧠 <i>Planning the steps</i>");
     expect(lastPreview?.text).toContain(
-      "💬 Planning: three sequential steps with a file read in between. --- <b>Step 1:</b> Run <code>sleep 6 &amp;&amp; date</code>",
+      "💬 Planning: three sequential steps with a file read in between.<br>───<br><b>Step 1:</b> Run <code>sleep 6 &amp;&amp; date</code>",
     );
     // No rich-only block HTML that Telegram's parse_mode=HTML would reject.
     expect(lastPreview?.text).not.toMatch(/<(h[1-6]|hr|ul|ol|li|p|div)\b/u);

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -3394,7 +3394,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
 
     // The interim block text never reached the window (neither update nor preview).
     const windowTexts = [
-      ...answerDraftStream.update.mock.calls.map((call) => call[0] as string),
+      ...answerDraftStream.update.mock.calls.map((call) => call[0]),
       ...answerDraftStream.updatePreview.mock.calls.map(
         (call) => (call[0] as { text?: string }).text ?? "",
       ),
@@ -3441,7 +3441,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
       async ({ dispatcherOptions, replyOptions }) => {
-        replyOptions?.onVerboseProgressVisibility?.(true);
+        replyOptions?.onVerboseProgressVisibility?.(() => true);
         await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
         await dispatcherOptions.deliver({ text: "Done" }, { kind: "final" });
         return { queuedFinal: true };

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -3017,6 +3017,76 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expectDeliveredReply(0, { text: "Done" });
   });
 
+  it("collapses a tool-progress-only window without deleting when reasoning is durable and the lane rotated mid-turn (on-off)", async () => {
+    // on-off cell: /reasoning on (durable), /verbose off. The window streams
+    // tool progress only; a mid-turn assistant boundary/rotation must not leave
+    // the collapse to a delete + repost. Every non-error collapse edits in place
+    // (or posts the bar durably) — NEVER a bare clear()/deleteMessage — so there
+    // is exactly one bar and no Telegram focus-jump.
+    loadSessionStore.mockReturnValue({ s1: { reasoningLevel: "on" } });
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+        // Durable reasoning + an assistant boundary land between tool progress
+        // and the final — the mid-turn churn that dropped the live window id.
+        await dispatcherOptions.deliver(
+          { text: "<think>hidden</think>", isReasoning: true },
+          { kind: "block" },
+        );
+        await replyOptions?.onAssistantMessageStart?.();
+        await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+        await dispatcherOptions.deliver({ text: "Done" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+
+    await dispatchWithContext({
+      context: createContext({
+        ctxPayload: { SessionKey: "s1" } as unknown as TelegramMessageContext["ctxPayload"],
+      }),
+      streamMode: "progress",
+      telegramCfg: { streaming: { mode: "progress" } },
+    });
+
+    // Collapse edited the window in place into the bar; the window was NOT
+    // deleted (no focus-jump), and exactly one bar exists.
+    expectWindowCollapsedTo(answerDraftStream, "🛠️ 2 tool calls · ⏱️ 1s");
+    expect(answerDraftStream.clear).not.toHaveBeenCalled();
+    const texts = allDeliveredReplyTexts();
+    expect(texts.filter((text) => text.includes("⏱️"))).toHaveLength(0); // bar is the in-place edit
+    expect(texts).toContain("Done");
+  });
+
+  it("posts the collapse bar durably with no delete when the window has no live message", async () => {
+    // When finalizeToPreview cannot edit in place (no live window message id),
+    // the bar is still surfaced — as a durable post — and the window is NOT
+    // cleared/deleted (nothing to delete; never a bare clear when a bar exists).
+    const answerDraftStream = createTestDraftStream({}); // no messageId -> edit fails
+    const reasoningDraftStream = createTestDraftStream({});
+    createTelegramDraftStream
+      .mockImplementationOnce(() => answerDraftStream)
+      .mockImplementationOnce(() => reasoningDraftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+        await dispatcherOptions.deliver({ text: "Done" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "progress",
+      telegramCfg: { streaming: { mode: "progress" } },
+    });
+
+    const texts = allDeliveredReplyTexts();
+    expect(texts.filter((text) => text.includes("⏱️"))).toEqual(["🛠️ 1 tool call · ⏱️ 1s"]);
+    expect(texts).toContain("Done");
+    expect(answerDraftStream.clear).not.toHaveBeenCalled();
+  });
+
   it("does not duplicate tool lines into the window under verbose", async () => {
     // Invariant D2 (persistent XOR window): when the durable verbose lane owns
     // tool messages, the window must render no tool line and must not count it.

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -3085,6 +3085,136 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(texts.some((text) => text.includes("tool call · ⏱️"))).toBe(false);
   });
 
+  it("delivers the collapse bar as a real message but never mirrors it into the transcript", async () => {
+    // Red-team F1: the bar is a cosmetic activity digest. It must be a durable
+    // Telegram message but must NOT enter the session transcript, or the model
+    // reads "🛠️ 1 tool call · ⏱️ Ns" back as its own prior turn. The real final
+    // still mirrors (Discord parity: its summary bar has no mirror seam either).
+    setupDraftStreams(); // no window message id → the bar posts durably (not an in-place edit)
+    const context = createContext();
+    context.ctxPayload.SessionKey = "agent:default:telegram:direct:123";
+    mockDefaultSessionEntry();
+    deliverReplies.mockImplementation(
+      async (params: {
+        replies?: Array<{ text?: string }>;
+        transcriptMirror?: (payload: { text?: string; mediaUrls?: string[] }) => Promise<void>;
+      }) => {
+        const text = params.replies
+          ?.map((reply) => reply.text)
+          .filter(Boolean)
+          .join("\n\n");
+        await params.transcriptMirror?.({ text });
+        return { delivered: true };
+      },
+    );
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+        await dispatcherOptions.deliver({ text: "Done" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+
+    await dispatchWithContext({
+      context,
+      streamMode: "progress",
+      telegramCfg: { streaming: { mode: "progress" } },
+    });
+
+    // The final is sent first (call 0, mirrored), then the bar (call 1, not).
+    expect(deliverReplies).toHaveBeenCalledTimes(2);
+    expectDeliveredReply(0, { text: "Done" });
+    expect(typeof mockCallArg(deliverReplies, 0).transcriptMirror).toBe("function");
+    const barParams = mockCallArg(deliverReplies, 1) as {
+      replies?: Array<{ text?: string }>;
+      transcriptMirror?: unknown;
+    };
+    expect(barParams.replies?.[0]?.text).toContain("🛠️ 1 tool call");
+    expect(barParams.transcriptMirror).toBeUndefined();
+    // Only the final reached the transcript; the bar line never did.
+    expect(appendAssistantMirrorMessageByIdentity).toHaveBeenCalledTimes(1);
+    expectRecordFields(mockCallArg(appendAssistantMirrorMessageByIdentity), { text: "Done" });
+  });
+
+  it("does not count a start-phase message tool toward the collapse bar", async () => {
+    // Red-team F4: progressSummary.noteToolCall() fired for ANY start-phase tool,
+    // but the window renders only work tools (isChannelProgressDraftWorkToolName
+    // rejects message/reply/react/…). A codex message_tool_only turn thus showed
+    // "🛠️ 1 tool call" with no tool line. The count must match the window: one
+    // work tool → 1, the message tool → 0.
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+        await replyOptions?.onToolStart?.({ name: "message", phase: "start" });
+        await dispatcherOptions.deliver({ text: "Done" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "progress",
+      telegramCfg: { streaming: { mode: "progress" } },
+    });
+
+    expectWindowCollapsedTo(answerDraftStream, "🛠️ 1 tool call · ⏱️ 1s");
+  });
+
+  it("does not count a work tool toward the collapse bar when toolProgress is off", async () => {
+    // Red-team F4: with streaming.progress.toolProgress=false the window renders
+    // no tool line, so a work tool must not feed the tally either — only the
+    // reasoning that streamed to the window counts.
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onReasoningStream?.({ text: "thinking" });
+        await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+        await dispatcherOptions.deliver({ text: "Done" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+
+    await dispatchWithContext({
+      context: createReasoningStreamContext(),
+      streamMode: "progress",
+      telegramCfg: { streaming: { mode: "progress", progress: { toolProgress: false } } },
+    });
+
+    expectWindowCollapsedTo(answerDraftStream, "🧠 1 thought · ⏱️ 1s");
+  });
+
+  it("keeps the turn alive when the cleanup-time collapse bar send throws", async () => {
+    // Red-team F3: the cosmetic bar posts from the cleanup fallback AFTER the
+    // real (out-of-band) final is already delivered. A flood-wait/network throw
+    // from that send must be swallowed, never propagated out of dispatch.
+    setupDraftStreams({ answerMessageId: 2001 });
+    deliverReplies.mockRejectedValue(new Error("Too Many Requests: retry after 5"));
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+      await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+      return {
+        queuedFinal: true,
+        counts: { block: 0, final: 1, tool: 1 },
+        sourceReplyDeliveryMode: "message_tool_only",
+      };
+    });
+
+    let thrown: unknown;
+    try {
+      await dispatchWithContext({
+        context: createContext(),
+        streamMode: "progress",
+        telegramCfg: { streaming: { mode: "progress" } },
+      });
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeUndefined();
+    // The bar send was attempted (and swallowed) rather than skipped.
+    expect(deliverReplies).toHaveBeenCalled();
+  });
+
   it("keeps the progress window alive under /reasoning on so commentary and tools still stream", async () => {
     // /reasoning on removes only the 🧠 lane from the window; commentary, tool
     // lines, and the collapse bar must still stream (Discord parity). A prior

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -3241,6 +3241,41 @@ describe("dispatchTelegramMessage draft streaming", () => {
     );
   });
 
+  it("never streams an interim answer block into the progress window (Discord parity)", async () => {
+    // Progress mode: the window is a pure activity log. An intermediate assistant
+    // answer block (info.kind === "block", before the final) must NOT render into
+    // the window; it is buffered and only the final answer is delivered below.
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+        // Intermediate assistant answer prose mid-turn.
+        await dispatcherOptions.deliver({ text: "Interim answer prose" }, { kind: "block" });
+        await dispatcherOptions.deliver({ text: "The real final answer." }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "progress",
+      telegramCfg: { streaming: { mode: "progress" } },
+    });
+
+    // The interim block text never reached the window (neither update nor preview).
+    const windowTexts = [
+      ...answerDraftStream.update.mock.calls.map((call) => call[0] as string),
+      ...answerDraftStream.updatePreview.mock.calls.map(
+        (call) => (call[0] as { text?: string }).text ?? "",
+      ),
+    ];
+    expect(windowTexts.some((text) => text.includes("Interim answer prose"))).toBe(false);
+    // The final answer is delivered below the collapsed window.
+    const delivered = allDeliveredReplyTexts();
+    expect(delivered).toContain("The real final answer.");
+    expect(delivered.some((text) => text.includes("Interim answer prose"))).toBe(false);
+  });
+
   it("posts the collapse bar durably with no delete when the window has no live message", async () => {
     // When finalizeToPreview cannot edit in place (no live window message id),
     // the bar is still surfaced — as a durable post — and the window is NOT

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -3435,6 +3435,51 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(answerDraftStream.clear).not.toHaveBeenCalled();
   });
 
+  it("keeps the turn alive when the no-live-message fallback bar send throws", async () => {
+    // Sibling of the F3 cleanup-throw guard: applyProgressCollapseSummary posts
+    // the bar durably when finalizeToPreview cannot edit in place. That fallback
+    // send is cosmetic and runs AFTER the in-band final, so a flood-wait/network
+    // throw must be swallowed (postCosmeticSummaryBar), never failing the turn.
+    const answerDraftStream = createTestDraftStream({}); // no messageId -> edit fails -> durable post
+    const reasoningDraftStream = createTestDraftStream({});
+    createTelegramDraftStream
+      .mockImplementationOnce(() => answerDraftStream)
+      .mockImplementationOnce(() => reasoningDraftStream);
+    // Only the cosmetic bar send throws; the real final "Done" still delivers.
+    deliverReplies.mockImplementation(
+      async (params: { replies?: Array<{ text?: string }> }) => {
+        if (params.replies?.some((reply) => reply.text?.includes("⏱️"))) {
+          throw new Error("Too Many Requests: retry after 5");
+        }
+        return { delivered: true };
+      },
+    );
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+        await dispatcherOptions.deliver({ text: "Done" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+
+    let thrown: unknown;
+    try {
+      await dispatchWithContext({
+        context: createContext(),
+        streamMode: "progress",
+        telegramCfg: { streaming: { mode: "progress" } },
+      });
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeUndefined();
+    // The bar fallback send was attempted (and swallowed); the final survived.
+    const texts = allDeliveredReplyTexts();
+    expect(texts.some((text) => text.includes("⏱️"))).toBe(true);
+    expect(texts).toContain("Done");
+  });
+
   it("does not duplicate tool lines into the window under verbose", async () => {
     // Invariant D2 (persistent XOR window): when the durable verbose lane owns
     // tool messages, the window must render no tool line and must not count it.

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -2942,8 +2942,13 @@ describe("dispatchTelegramMessage draft streaming", () => {
     // not delete + repost — Discord parity), so clear() is never called on it.
     expect(answerDraftStream.clear).not.toHaveBeenCalled();
     expectWindowCollapsedTo(answerDraftStream, "🛠️ 1 tool call · ⏱️ 1s");
-    // The final answer then posts fresh below the collapsed bar.
     expectDeliveredReply(0, { text: "Branch is up to date" });
+    // The final answer is SENT before the window collapses into the bar: sending
+    // first keeps the final at the bottom of the anchored viewport, so shrinking
+    // the tall window above it never drops the final off screen.
+    expect(deliverReplies.mock.invocationCallOrder[0]).toBeLessThan(
+      answerDraftStream.finalizeToPreview.mock.invocationCallOrder[0],
+    );
     expect(editMessageTelegram).not.toHaveBeenCalled();
   });
 
@@ -2954,6 +2959,61 @@ describe("dispatchTelegramMessage draft streaming", () => {
       ),
     );
   }
+
+  it("sends the final answer before collapsing the window into the bar", async () => {
+    // Edit-shrink anchor loss: shrinking the tall window to a one-line bar BEFORE
+    // the final is sent breaks the client's at-bottom follow and drops the final
+    // off screen. The final must be sent FIRST, then the window edited down.
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+        await dispatcherOptions.deliver({ text: "All done" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "progress",
+      telegramCfg: { streaming: { mode: "progress" } },
+    });
+
+    // Final delivered, then the window edited into the bar — final send precedes
+    // the collapse edit.
+    expectDeliveredReply(0, { text: "All done" });
+    expectWindowCollapsedTo(answerDraftStream, "🛠️ 1 tool call · ⏱️ 1s");
+    expect(deliverReplies.mock.invocationCallOrder[0]).toBeLessThan(
+      answerDraftStream.finalizeToPreview.mock.invocationCallOrder[0],
+    );
+    // The bar counters are snapshotted before the final send, so the count is
+    // stable (one tool call — the final's own delivery does not perturb it).
+    expect(answerDraftStream.finalizeToPreview).toHaveBeenCalledTimes(1);
+    expect(answerDraftStream.clear).not.toHaveBeenCalled();
+  });
+
+  it("still collapses the window when the final answer send is skipped", async () => {
+    // Failure path: if the final send skips/fails, the window must not be left
+    // stale — it still collapses to the bar (once-guard already consumed).
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    deliverReplies.mockResolvedValue({ delivered: false });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+        await dispatcherOptions.deliver({ text: "Answer that fails to send" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "progress",
+      telegramCfg: { streaming: { mode: "progress" } },
+    });
+
+    // The bar still edits the window in place even though the final send failed.
+    expectWindowCollapsedTo(answerDraftStream, "🛠️ 1 tool call · ⏱️ 1s");
+  });
 
   it("tallies reasoning bursts and tool calls into the collapse summary", async () => {
     const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -3156,11 +3156,12 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(texts).toContain("Done");
   });
 
-  it("repositions the tool-progress window (deferred delete) when text follows durable reasoning", async () => {
-    // on-off mid-stream jump: a durable 🧠 posts BELOW the tool-progress window;
-    // when answer text then takes over the lane, the window must reposition
-    // (send-new-first, delete-old-deferred) rather than delete-then-repost,
-    // which scroll-jumps the Telegram client.
+  it("keeps a single stationary window when text follows durable reasoning (no mid-turn rotation)", async () => {
+    // Single-message model (Discord parity): in progress mode the window is ONE
+    // message edited through every lane handover — durable 🧠, interim answer
+    // text — and edited into the bar only at collapse. It must NOT reposition or
+    // rotate mid-turn (no new bubble, no delete), which is what caused the churn
+    // and the on-off jump. Interim answer text does not render into the window.
     loadSessionStore.mockReturnValue({ s1: { reasoningLevel: "on" } });
     const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
@@ -3170,7 +3171,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
           { text: "<think>hidden</think>", isReasoning: true },
           { kind: "block" },
         );
-        // Answer text mid-turn takes the lane over from the tool-progress window.
+        // Interim answer text mid-turn: must not spawn a new window bubble.
         await dispatcherOptions.deliver({ text: "Here is the answer" }, { kind: "block" });
         await dispatcherOptions.deliver({ text: "Here is the answer." }, { kind: "final" });
         return { queuedFinal: true };
@@ -3185,11 +3186,59 @@ describe("dispatchTelegramMessage draft streaming", () => {
       telegramCfg: { streaming: { mode: "progress" } },
     });
 
-    // The tool-progress window was repositioned via the deferred-delete path,
-    // never an immediate clear() (which deletes the window above the durable 🧠
-    // and reposts below — the focus-jump).
-    expect(answerDraftStream.rotateToNewMessageDeferringDelete).toHaveBeenCalled();
+    // The one window message stays put through the whole turn: no mid-turn
+    // reposition and no delete — only the collapse edit into the bar at the end.
+    // (forceNewMessage fires once at collapse to rewind the stream after the bar
+    // edit; that is end-of-turn, not mid-turn churn.)
+    expect(answerDraftStream.rotateToNewMessageDeferringDelete).not.toHaveBeenCalled();
     expect(answerDraftStream.clear).not.toHaveBeenCalled();
+    expectWindowCollapsedTo(answerDraftStream, "🛠️ 1 tool call · ⏱️ 1s");
+    // The bar edit is the only send/edit that finalizes the window (one message).
+    expect(answerDraftStream.finalizeToPreview).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses one stationary window message across a multi-boundary turn (commentary→tool→commentary→tool→final)", async () => {
+    // Single-message model (Discord parity): ONE window message id is created
+    // once and edited through every lane handover; it collapses into the bar in
+    // place at the end. Zero deletes in the happy path; the final is posted
+    // before the bar edit (task-9 order).
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onItemEvent?.({ kind: "preamble", itemId: "c1", progressText: "Look" });
+        await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+        await replyOptions?.onItemEvent?.({ kind: "preamble", itemId: "c2", progressText: "Now" });
+        await replyOptions?.onToolStart?.({ name: "read", phase: "start" });
+        await dispatcherOptions.deliver({ text: "Final answer" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "progress",
+      telegramCfg: { streaming: { mode: "progress" } },
+    });
+
+    // The SAME window message id is used the whole turn — no new bubble.
+    const windowMessageIds = new Set(
+      answerDraftStream.updatePreview.mock.calls
+        .map(() => answerDraftStream.messageId())
+        .filter((id) => id != null),
+    );
+    expect(windowMessageIds).toEqual(new Set([2001]));
+    // The window was EDITED many times (once per lane change) ...
+    expect(answerDraftStream.updatePreview.mock.calls.length).toBeGreaterThan(1);
+    // ... and NEVER rotated/repositioned/deleted mid-turn.
+    expect(answerDraftStream.rotateToNewMessageDeferringDelete).not.toHaveBeenCalled();
+    expect(answerDraftStream.clear).not.toHaveBeenCalled();
+    // The bar edit is the single finalize, and it happens AFTER the final send.
+    expect(answerDraftStream.finalizeToPreview).toHaveBeenCalledTimes(1);
+    expectWindowCollapsedTo(answerDraftStream, "💬 2 notes · 🛠️ 2 tool calls · ⏱️ 1s");
+    expectDeliveredReply(0, { text: "Final answer" });
+    expect(deliverReplies.mock.invocationCallOrder[0]).toBeLessThan(
+      answerDraftStream.finalizeToPreview.mock.invocationCallOrder[0],
+    );
   });
 
   it("posts the collapse bar durably with no delete when the window has no live message", async () => {

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -411,6 +411,18 @@ describe("dispatchTelegramMessage draft streaming", () => {
     return expectRecordFields(mockCallArg(dispatchReplyWithBufferedBlockDispatcher), expected);
   }
 
+  // The collapse bar edits the live window message in place (finalizeToPreview)
+  // instead of deleting it and reposting the bar as a new message.
+  function expectWindowCollapsedTo(
+    stream: { finalizeToPreview: { mock: { calls: unknown[][] } } },
+    barText: string,
+  ) {
+    const calls = stream.finalizeToPreview.mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    const preview = calls[calls.length - 1][0] as { text?: string };
+    expect(preview.text).toBe(barText);
+  }
+
   function createContext(overrides?: Partial<TelegramMessageContext>): TelegramMessageContext {
     const base = {
       ctxPayload: {},
@@ -2888,11 +2900,12 @@ describe("dispatchTelegramMessage draft streaming", () => {
     );
     expect(answerDraftStream.update).not.toHaveBeenCalledWith("Branch is up to date");
     expect(answerDraftStream.forceNewMessage).toHaveBeenCalledTimes(1);
-    expect(answerDraftStream.clear).toHaveBeenCalledTimes(1);
-    // The progress window collapses to a one-line activity summary (Discord
-    // parity) before the final answer posts fresh below it.
-    expectDeliveredReply(0, { text: "🛠️ 1 tool call · ⏱️ 1s" });
-    expectDeliveredReply(0, { text: "Branch is up to date" }, 1);
+    // The window collapses IN PLACE into the one-line activity summary (edit,
+    // not delete + repost — Discord parity), so clear() is never called on it.
+    expect(answerDraftStream.clear).not.toHaveBeenCalled();
+    expectWindowCollapsedTo(answerDraftStream, "🛠️ 1 tool call · ⏱️ 1s");
+    // The final answer then posts fresh below the collapsed bar.
+    expectDeliveredReply(0, { text: "Branch is up to date" });
     expect(editMessageTelegram).not.toHaveBeenCalled();
   });
 
@@ -2905,7 +2918,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
   }
 
   it("tallies reasoning bursts and tool calls into the collapse summary", async () => {
-    setupDraftStreams({ answerMessageId: 2001 });
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
       async ({ dispatcherOptions, replyOptions }) => {
         // burst 1 → tool → burst 2 → tool, then a trailing burst flushed at the
@@ -2928,8 +2941,8 @@ describe("dispatchTelegramMessage draft streaming", () => {
       telegramCfg: { streaming: { mode: "progress" } },
     });
 
-    expectDeliveredReply(0, { text: "🧠 3 thoughts · 🛠️ 2 tool calls · ⏱️ 1s" });
-    expectDeliveredReply(0, { text: "Done" }, 1);
+    expectWindowCollapsedTo(answerDraftStream, "🧠 3 thoughts · 🛠️ 2 tool calls · ⏱️ 1s");
+    expectDeliveredReply(0, { text: "Done" });
   });
 
   it("does not post a collapse summary when no progress draft started", async () => {
@@ -2972,6 +2985,88 @@ describe("dispatchTelegramMessage draft streaming", () => {
 
     const texts = allDeliveredReplyTexts();
     expect(texts.some((text) => text.includes("tool call · ⏱️"))).toBe(false);
+  });
+
+  it("keeps the progress window alive under /reasoning on so commentary and tools still stream", async () => {
+    // /reasoning on removes only the 🧠 lane from the window; commentary, tool
+    // lines, and the collapse bar must still stream (Discord parity). A prior
+    // regression forced block streaming in progress mode, killing the window.
+    loadSessionStore.mockReturnValue({ s1: { reasoningLevel: "on" } });
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onItemEvent?.({ kind: "preamble", itemId: "c1", progressText: "Note" });
+        await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+        await dispatcherOptions.deliver({ text: "Done" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+
+    await dispatchWithContext({
+      context: createContext({
+        ctxPayload: { SessionKey: "s1" } as unknown as TelegramMessageContext["ctxPayload"],
+      }),
+      streamMode: "progress",
+      telegramCfg: { streaming: { mode: "progress" } },
+    });
+
+    // The window streamed (a preview was rendered) and collapsed into a bar
+    // counting the note + tool — proof the window was not killed.
+    expect(answerDraftStream.updatePreview).toHaveBeenCalled();
+    expectWindowCollapsedTo(answerDraftStream, "💬 1 note · 🛠️ 1 tool call · ⏱️ 1s");
+    expectDeliveredReply(0, { text: "Done" });
+  });
+
+  it("does not duplicate tool lines into the window under verbose", async () => {
+    // Invariant D2 (persistent XOR window): when the durable verbose lane owns
+    // tool messages, the window must render no tool line and must not count it.
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        replyOptions?.onVerboseProgressVisibility?.(true);
+        await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+        await dispatcherOptions.deliver({ text: "Done" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "progress",
+      telegramCfg: { streaming: { mode: "progress" } },
+    });
+
+    // No tool line ever rendered to the window (verbose owns it durably), so the
+    // window never streamed and there is no collapse bar to count it.
+    expect(answerDraftStream.updatePreview).not.toHaveBeenCalled();
+    expect(answerDraftStream.finalizeToPreview).not.toHaveBeenCalled();
+    const texts = allDeliveredReplyTexts();
+    expect(texts.some((text) => text.includes("tool call"))).toBe(false);
+  });
+
+  it("posts a collapse summary for a message_tool_only final that bypasses the answer path", async () => {
+    // Codex-runtime turns deliver the final out-of-band (queuedFinal), so the
+    // in-band collapse path never runs. The window still started, so the
+    // cleanup-time fallback must emit the bar (Discord parity).
+    setupDraftStreams({ answerMessageId: 2001 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+      await replyOptions?.onItemEvent?.({ kind: "preamble", itemId: "c1", progressText: "Note" });
+      await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+      return {
+        queuedFinal: true,
+        counts: { block: 0, final: 1, tool: 1 },
+        sourceReplyDeliveryMode: "message_tool_only",
+      };
+    });
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "progress",
+      telegramCfg: { streaming: { mode: "progress" } },
+    });
+
+    const texts = allDeliveredReplyTexts();
+    expect(texts).toContain("💬 1 note · 🛠️ 1 tool call · ⏱️ 1s");
   });
 
   it("replaces Telegram command progress items with matching command output", async () => {
@@ -3037,9 +3132,10 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(answerDraftStream.forceNewMessage.mock.invocationCallOrder[1]).toBeLessThan(
       answerDraftStream.update.mock.invocationCallOrder[0],
     );
-    // Collapse summary posts first, then the final answer below it.
-    expectDeliveredReply(0, { text: "🛠️ 1 tool call · ⏱️ 1s" });
-    expectDeliveredReply(0, { text: "Branch is up to date" }, 1);
+    // Window collapses in place into the summary bar; the final answer posts
+    // fresh below it.
+    expectWindowCollapsedTo(answerDraftStream, "🛠️ 1 tool call · ⏱️ 1s");
+    expectDeliveredReply(0, { text: "Branch is up to date" });
   });
 
   it("does not stream text-only tool results into progress drafts", async () => {
@@ -3122,8 +3218,8 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
       telegramProgressPreview("Shelling\n\n🛠️ Exec", "<b>Shelling</b>\n<b>🛠️ Exec</b>"),
     );
-    expectDeliveredReply(0, { text: "🛠️ 1 tool call · ⏱️ 1s" });
-    expectDeliveredReply(0, { text: "Branch is up to date" }, 1);
+    expectWindowCollapsedTo(answerDraftStream, "🛠️ 1 tool call · ⏱️ 1s");
+    expectDeliveredReply(0, { text: "Branch is up to date" });
   });
 
   it("does not restart progress drafts for command output after final answer delivery", async () => {
@@ -3153,8 +3249,8 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
       telegramProgressPreview("Shelling\n\n🛠️ Exec", "<b>Shelling</b>\n<b>🛠️ Exec</b>"),
     );
-    expectDeliveredReply(0, { text: "🛠️ 1 tool call · ⏱️ 1s" });
-    expectDeliveredReply(0, { text: "Branch is up to date" }, 1);
+    expectWindowCollapsedTo(answerDraftStream, "🛠️ 1 tool call · ⏱️ 1s");
+    expectDeliveredReply(0, { text: "Branch is up to date" });
   });
 
   it("does not restart progress drafts for command output while final answer delivery is pending", async () => {
@@ -3188,12 +3284,12 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(answerDraftStream.updatePreview).toHaveBeenCalledWith(
       telegramProgressPreview("Shelling\n\n🛠️ Exec", "<b>Shelling</b>\n<b>🛠️ Exec</b>"),
     );
-    expectDeliveredReply(0, { text: "🛠️ 1 tool call · ⏱️ 1s" });
-    expectDeliveredReply(0, { text: "Branch is up to date" }, 1);
+    expectWindowCollapsedTo(answerDraftStream, "🛠️ 1 tool call · ⏱️ 1s");
+    expectDeliveredReply(0, { text: "Branch is up to date" });
   });
 
   it("uses the transcript final when progress-mode final text is truncated", async () => {
-    setupDraftStreams({ answerMessageId: 2001 });
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
     const fullAnswer =
       "Ja. Hier nochmal sauber Schritt fuer Schritt. Einen API Key kopiert man aus der Google Cloud Console. Danach pruefst du die Projekt- und API-Einstellungen.";
     const truncatedFinal =
@@ -3219,8 +3315,8 @@ describe("dispatchTelegramMessage draft streaming", () => {
       telegramCfg: { streaming: { mode: "progress" } },
     });
 
-    expectDeliveredReply(0, { text: "🛠️ 1 tool call · ⏱️ 1s" });
-    expectDeliveredReply(0, { text: fullAnswer }, 1);
+    expectWindowCollapsedTo(answerDraftStream, "🛠️ 1 tool call · ⏱️ 1s");
+    expectDeliveredReply(0, { text: fullAnswer });
   });
 
   it("streams the first long final chunk and sends follow-up chunks", async () => {
@@ -3949,7 +4045,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
 
     await dispatchWithContext({ context: createReasoningStreamContext() });
 
-    expect(reasoningDraftStream.update).toHaveBeenCalledWith("Thinking\n\n_Thinking_");
+    expect(reasoningDraftStream.update).toHaveBeenCalledWith("🧠 _Thinking_");
     expect(answerDraftStream.update).toHaveBeenCalledWith("Answer");
     expect(deliverReplies).not.toHaveBeenCalled();
   });
@@ -3969,7 +4065,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
 
     await dispatchWithContext({ context: createReasoningForumTopicContext() });
 
-    expect(reasoningDraftStream.update).toHaveBeenCalledWith("Thinking\n\n_Thinking_");
+    expect(reasoningDraftStream.update).toHaveBeenCalledWith("🧠 _Thinking_");
     expect(answerDraftStream.update).toHaveBeenCalledWith("Answer");
     expect(answerDraftStream.stop).toHaveBeenCalled();
     expect(deliverReplies).not.toHaveBeenCalled();
@@ -4018,7 +4114,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     await dispatchWithContext({ context: createReasoningStreamContext() });
 
     expect(reasoningDraftStream.update).toHaveBeenLastCalledWith(
-      "Thinking\n\n_Reading_\n\n_Checking_",
+      "🧠 _Reading_\n\n_Checking_",
     );
     const updates = reasoningDraftStream.update.mock.calls.map((call) => call[0]);
     expect(updates.join("\n")).not.toContain("CheckingReading");
@@ -4047,7 +4143,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
       },
     });
 
-    expect(reasoningDraftStream.update).toHaveBeenCalledWith("Thinking\n\n_Thinking_");
+    expect(reasoningDraftStream.update).toHaveBeenCalledWith("🧠 _Thinking_");
     expect(answerDraftStream.update).toHaveBeenCalledWith("Answer");
   });
 
@@ -4068,10 +4164,12 @@ describe("dispatchTelegramMessage draft streaming", () => {
     const run = dispatchWithContext({ context: createReasoningStreamContext() });
 
     await vi.waitFor(() =>
-      expect(reasoningDraftStream.update).toHaveBeenCalledWith("Thinking\n\n_Thinking_"),
+      expect(reasoningDraftStream.update).toHaveBeenCalledWith("🧠 _Thinking_"),
     );
+    // Durable thoughts render behind the 🧠 marker; the literal "Thinking"
+    // header (and its streaming dot-variants) must never leak back into a lane.
+    expect(reasoningDraftStream.update).not.toHaveBeenCalledWith("Thinking\n\n_Thinking_");
     expect(reasoningDraftStream.update).not.toHaveBeenCalledWith("Thinking.\n\n_Thinking_");
-    expect(reasoningDraftStream.update).not.toHaveBeenCalledWith("Thinking..\n\n_Thinking_");
     expect(reasoningDraftStream.update).not.toHaveBeenCalledWith("Thinking...\n\n_Thinking_");
     finishRun?.();
     await run;
@@ -4158,7 +4256,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
 
     await dispatchWithContext({ context: createReasoningStreamContext() });
 
-    expect(reasoningDraftStream.update).toHaveBeenCalledWith("Thinking\n\n_hidden_");
+    expect(reasoningDraftStream.update).toHaveBeenCalledWith("🧠 _hidden_");
     expect(deliverReplies).not.toHaveBeenCalled();
   });
 
@@ -4180,7 +4278,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
       }),
     });
 
-    const delivered = expectDeliveredReply(0, { text: "Thinking\n\n_hidden_" });
+    const delivered = expectDeliveredReply(0, { text: "🧠 _hidden_" });
     expect(delivered).not.toHaveProperty("isReasoning");
   });
 

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -107,6 +107,10 @@ import {
   retainTelegramGroupHistoryPromptContext,
   selectTelegramGroupHistoryAfterLastSelf,
 } from "./group-history-window.js";
+import {
+  createTelegramProgressSummaryTracker,
+  formatTelegramProgressSummaryLine,
+} from "./progress-summary.js";
 import { beginTelegramInboundEventDeliveryCorrelation } from "./inbound-event-delivery.js";
 import {
   createLaneDeliveryStateTracker,
@@ -402,11 +406,10 @@ function renderTelegramProgressStringLine(text: string): string {
   // through renderTelegramHtmlText — the parse_mode=HTML-safe converter — NOT
   // markdownToTelegramRichHtml, whose rich-only block output (<h2> from a
   // setext heading, <hr>, lists) makes Telegram reject the edit and drops the
-  // whole preview to unformatted plain text.
-  // Collapse to one line first: progress lines are single-line by contract, and
-  // multi-line commentary otherwise forms block markdown (`\n\n---\n\n` turns
-  // the paragraph above it into a setext heading).
-  const trimmed = text.replace(/\s+/gu, " ").trim();
+  // whole preview to unformatted plain text. Callers convert ONE line at a
+  // time, which also keeps block markdown from forming (`---` under a
+  // paragraph is a setext heading only when they share a document).
+  const trimmed = text.trim();
   // Clip INSIDE a whole-line `_…_` wrapper (the reasoning-lane contract, marker
   // optional): clipping the assembled line chops the closing underscore, which
   // silently degrades every long reasoning line from italic to plain text.
@@ -424,8 +427,14 @@ function renderTelegramProgressLine(line: ChannelProgressDraftCompositorLine): s
   if (!line.icon && line.label === "Commentary") {
     // Commentary is model prose behind a 💬 marker: render its markdown (plain
     // unless the model emphasized) via the shared converter — distinct from the
-    // 🧠 italic reasoning lane, mirroring Discord.
-    return renderTelegramProgressStringLine(line.text);
+    // 🧠 italic reasoning lane, mirroring Discord. Multi-line notes keep their
+    // line structure (Discord parity); converting per line also prevents block
+    // markdown (setext headings) from forming across lines.
+    return line.text
+      .split(/\r?\n/u)
+      .map(renderTelegramProgressStringLine)
+      .filter(Boolean)
+      .join("<br>");
   }
   const label = [line.icon, line.label].filter(Boolean).join(" ");
   const parts = [`<b>${escapeTelegramProgressHtml(label)}</b>`];
@@ -1035,6 +1044,16 @@ export const dispatchTelegramMessage = async ({
     }
     activeAnswerDraftIsToolProgressOnly = true;
   }
+  // Tracks whether the ephemeral progress window ever actually rendered this
+  // turn (rv mode delivers everything durably and the window stays empty). The
+  // collapse summary must reflect what ACTUALLY streamed, so it is gated on
+  // this flag, not on the compositor gate having started (Bug 6).
+  let progressDraftEverRendered = false;
+  // Turn-activity tally for the post-turn collapse summary (Discord parity).
+  // Counters feed a one-line digest posted when the progress window collapses.
+  const progressSummaryStartedAt = Date.now();
+  const progressSummary = createTelegramProgressSummaryTracker();
+  let progressSummaryDelivered = false;
   const progressDraft = createChannelProgressDraftCompositor({
     entry: telegramCfg,
     mode: streamMode,
@@ -1049,6 +1068,7 @@ export const dispatchTelegramMessage = async ({
     commentaryLinePrefix: "💬 ",
     commentaryItalics: false,
     update: async (streamText, options) => {
+      progressDraftEverRendered = true;
       await prepareAnswerLaneForToolProgress();
       answerLane.lastPartialText = streamText;
       answerLane.hasStreamedMessage = true;
@@ -1091,6 +1111,15 @@ export const dispatchTelegramMessage = async ({
     text?: string;
     isReasoningSnapshot?: boolean;
   }) => {
+    // Opens (or keeps open) the current window reasoning burst for the collapse
+    // summary whenever window-destined reasoning text arrives — independent of
+    // whether this particular push renders, so a short burst between renders is
+    // still counted at the summary flush (mirrors Discord's windowReasoningOpen).
+    // Gated on the window lane: durable reasoning (/reasoning on) must not feed
+    // the bar (Bug 6: the bar counts only what streamed to the window).
+    if (streamReasoningInProgressDraft && payload.text) {
+      progressSummary.noteReasoningActivity();
+    }
     return await progressDraft.pushReasoningProgress(payload.text, {
       snapshot: payload.isReasoningSnapshot === true,
     });
@@ -1872,6 +1901,29 @@ export const dispatchTelegramMessage = async ({
       await emitPreviewFinalizedHook(result);
       return result.kind !== "skipped";
     };
+    // Post-turn collapse summary (Discord parity): when the progress window
+    // collapses at end-of-turn, post a one-line activity digest as a durable
+    // standalone message, then the final answer posts below it so the timeline
+    // reads thoughts/tools → summary → answer. Emitted at most once per turn,
+    // only for a non-error final, and only when the window actually rendered
+    // (rv mode delivers everything durably and the window stays empty — no bar).
+    const deliverProgressCollapseSummary = async () => {
+      if (progressSummaryDelivered) {
+        return;
+      }
+      progressSummaryDelivered = true;
+      if (!progressDraftEverRendered) {
+        return;
+      }
+      const line = formatTelegramProgressSummaryLine(
+        progressSummary.counts(),
+        Date.now() - progressSummaryStartedAt,
+      );
+      if (!line) {
+        return;
+      }
+      await sendPayload({ text: line }, { durable: true });
+    };
     const deliverProgressModeFinalAnswer = async (
       payload: ReplyPayload,
       text: string,
@@ -1881,6 +1933,12 @@ export const dispatchTelegramMessage = async ({
       } else {
         await answerLane.stream?.clear();
         resetDraftLaneState(answerLane);
+      }
+      if (payload.isError === true) {
+        // Error finals get no collapse summary (Discord parity); mark it handled.
+        progressSummaryDelivered = true;
+      } else {
+        await deliverProgressCollapseSummary();
       }
       const delivered = await sendPayload(applyTextToPayload(payload, text), { durable: true });
       if (!delivered) {
@@ -2430,10 +2488,17 @@ export const dispatchTelegramMessage = async ({
                   onReasoningEnd: reasoningLane.stream
                     ? () =>
                         enqueueDraftLaneEvent(async () => {
+                          progressSummary.closeReasoningBurst();
                           splitReasoningOnNextStream = reasoningLane.hasStreamedMessage;
                           resetProgressDraftState();
                         })
-                    : undefined,
+                    : () => {
+                        // Window-reasoning turns have no separate reasoning lane;
+                        // reasoning-end is still a burst boundary for the collapse
+                        // summary (some models never fire it — the tracker also
+                        // closes at the next tool call or the summary flush).
+                        progressSummary.closeReasoningBurst();
+                      },
                   suppressDefaultToolProgressMessages:
                     !streamDeliveryEnabled || Boolean(answerLane.stream),
                   forceToolResultProgress: streamMode === "progress" && streamToolProgressEnabled,
@@ -2447,6 +2512,22 @@ export const dispatchTelegramMessage = async ({
                   reasoningPayloadsEnabled: durableReasoningPayloadsEnabled,
                   onToolStart: async (payload) => {
                     const toolName = payload.name?.trim();
+                    // Only the "start" phase is a boundary (later phases of the same
+                    // call must not inflate the tally). The tool closes the preceding
+                    // reasoning AND commentary bursts, counting each per-burst — so a
+                    // turn's notes sharing the turn-local id "commentary-0" tally as
+                    // N, not 1 (D3). The tool itself is counted only when it renders
+                    // to the window: under verbose, tool summaries persist as their
+                    // own durable messages and must NOT also feed the bar (invariant:
+                    // persistent message XOR bar count — D2).
+                    if (payload.phase === "start") {
+                      if (verboseProgressActive() || !canPushStreamToolProgress()) {
+                        progressSummary.closeReasoningBurst();
+                        progressSummary.closeCommentaryBurst();
+                      } else {
+                        progressSummary.noteToolCall();
+                      }
+                    }
                     const progressPromise = pushStreamToolProgress(
                       buildChannelProgressDraftLineForEntry(
                         telegramCfg,
@@ -2470,8 +2551,13 @@ export const dispatchTelegramMessage = async ({
                   onItemEvent: async (payload) => {
                     if (payload.kind === "preamble") {
                       if (verboseProgressActive()) {
+                        // Durable verbose lane owns commentary; not counted toward
+                        // the collapse summary — it did not stream to the window.
                         return;
                       }
+                      // Window path: the note renders to the progress window, so
+                      // tally it for the collapse bar (counted per-burst, D3).
+                      progressSummary.noteCommentary(payload.itemId, payload.progressText);
                       await progressDraft.pushCommentaryProgress(payload.progressText, {
                         itemId: payload.itemId,
                       });

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -397,12 +397,24 @@ function escapeTelegramProgressHtml(text: string): string {
 }
 
 function renderTelegramProgressStringLine(text: string): string {
-  const clipped = clipTelegramProgressText(text.trim());
-  const italic = clipped.match(/^_(.*)_$/u);
-  if (italic) {
-    return `<i>${escapeTelegramProgressHtml(italic[1] ?? "")}</i>`;
-  }
-  return `<code>${escapeTelegramProgressHtml(clipped)}</code>`;
+  // Reasoning/commentary lanes carry model-authored markdown (e.g. `**bold**`,
+  // inline `` `code` ``, `_italic_` reasoning behind a 🧠/💬 marker). Render it
+  // through renderTelegramHtmlText — the parse_mode=HTML-safe converter — NOT
+  // markdownToTelegramRichHtml, whose rich-only block output (<h2> from a
+  // setext heading, <hr>, lists) makes Telegram reject the edit and drops the
+  // whole preview to unformatted plain text.
+  // Collapse to one line first: progress lines are single-line by contract, and
+  // multi-line commentary otherwise forms block markdown (`\n\n---\n\n` turns
+  // the paragraph above it into a setext heading).
+  const trimmed = text.replace(/\s+/gu, " ").trim();
+  // Clip INSIDE a whole-line `_…_` wrapper (the reasoning-lane contract, marker
+  // optional): clipping the assembled line chops the closing underscore, which
+  // silently degrades every long reasoning line from italic to plain text.
+  const italic = trimmed.match(/^(\S+ )?_(.*)_$/u);
+  const clipped = italic
+    ? `${italic[1] ?? ""}_${clipTelegramProgressText(italic[2] ?? "")}_`
+    : clipTelegramProgressText(trimmed);
+  return renderTelegramHtmlText(clipped);
 }
 
 function renderTelegramProgressLine(line: ChannelProgressDraftCompositorLine): string {
@@ -410,6 +422,9 @@ function renderTelegramProgressLine(line: ChannelProgressDraftCompositorLine): s
     return line.split(/\r?\n/u).map(renderTelegramProgressStringLine).filter(Boolean).join("<br>");
   }
   if (!line.icon && line.label === "Commentary") {
+    // Commentary is model prose behind a 💬 marker: render its markdown (plain
+    // unless the model emphasized) via the shared converter — distinct from the
+    // 🧠 italic reasoning lane, mirroring Discord.
     return renderTelegramProgressStringLine(line.text);
   }
   const label = [line.icon, line.label].filter(Boolean).join(" ");
@@ -420,7 +435,10 @@ function renderTelegramProgressLine(line: ChannelProgressDraftCompositorLine): s
   } else {
     const text = line.text.trim();
     if (text && text !== label) {
-      parts.push(renderTelegramProgressStringLine(text));
+      // Generic item payload (e.g. an "Update" line) keeps the monospace payload
+      // styling shared with tool details; only the reasoning/commentary lanes
+      // carry model markdown that needs converting.
+      parts.push(`<code>${escapeTelegramProgressHtml(clipTelegramProgressText(text))}</code>`);
     }
   }
   if (line.status && line.status !== "completed" && line.status !== line.detail) {
@@ -1024,6 +1042,12 @@ export const dispatchTelegramMessage = async ({
     seed: progressSeed,
     formatLine: formatTelegramProgressLine,
     reasoningGate: streamReasoningInProgressDraft,
+    // Distinguish the streamed lanes in the window the way Discord does: 🧠
+    // reasoning (italic, default) vs 💬 commentary (plain). Without these the
+    // two lanes render identically and are indistinguishable.
+    reasoningLinePrefix: "🧠 ",
+    commentaryLinePrefix: "💬 ",
+    commentaryItalics: false,
     update: async (streamText, options) => {
       await prepareAnswerLaneForToolProgress();
       answerLane.lastPartialText = streamText;

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -1237,8 +1237,15 @@ export const dispatchTelegramMessage = async ({
     if (!activeAnswerDraftIsToolProgressOnly) {
       return false;
     }
-    await answerLane.stream?.clear();
-    answerLane.stream?.forceNewMessage();
+    // Reposition, don't delete-then-repost: rewind so the replacement message
+    // sends below, and defer the tool-progress window's delete until after it
+    // lands. Deleting first (clear) scroll-jumps the client when a durable 🧠
+    // was posted between the window and the replacement (the on-off jump).
+    if (answerLane.stream?.rotateToNewMessageDeferringDelete) {
+      answerLane.stream.rotateToNewMessageDeferringDelete();
+    } else {
+      answerLane.stream?.forceNewMessage();
+    }
     resetDraftLaneState(answerLane);
     suppressProgressDraftState();
     rotateAnswerLaneWhenQueuedBlocksSettle = false;

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -1944,54 +1944,73 @@ export const dispatchTelegramMessage = async ({
       }
       await sendPayload({ text: line }, { durable: true });
     };
-    // Collapse the live window IN PLACE into the summary bar: edit the existing
-    // window message so its content becomes the bar line, keeping it on screen.
-    // Mirrors Discord — deleting the window and reposting the bar scroll-jumps
-    // the Telegram client and flashes the window away. Returns true when the
-    // window was collapsed in place; false when there is no bar (nothing
-    // streamed) or no live window message, so the caller tears the window down.
-    const collapseProgressWindowIntoSummary = async (): Promise<boolean> => {
+    // Collapse the progress window into the summary bar. ONE deterministic path
+    // for every mode (off-off, stream-off, on-off tool-progress-only): edit the
+    // live window message IN PLACE into the bar (no delete — deleting scroll-
+    // jumps the Telegram client). Only when there is genuinely no live window
+    // message (rv mode never rendered a message) is the bar posted durably, and
+    // even then NOTHING is deleted. Returns "edited" | "posted" | "none" so the
+    // caller resets lane state without ever falling back to a bare clear() when
+    // a bar exists. finalizeToPreview settles pending previews first, so a
+    // still-pending tool-progress window is materialized and edited rather than
+    // missed (the on-off inconsistency).
+    const collapseProgressWindowIntoSummary = async (): Promise<"edited" | "posted" | "none"> => {
       const line = resolveProgressCollapseSummaryLine();
       if (!line) {
-        return false;
+        return "none";
       }
       const messageId = await answerLane.stream?.finalizeToPreview(renderStreamText(line));
       if (typeof messageId === "number") {
-        return true;
+        return "edited";
       }
-      // No live window to edit (rv mode, never rendered): keep the bar as a
-      // fresh durable post so the timeline still shows the collapse summary.
+      // No live window message existed to edit; still surface the bar, but never
+      // delete (there is nothing on screen to remove).
       await sendPayload({ text: line }, { durable: true });
-      return false;
+      return "posted";
+    };
+    // Reset answer-lane bookkeeping after a bar was edited/posted in place,
+    // WITHOUT clear() — the window message stays (as the bar) and must not be
+    // deleted (no focus-jump). forceNewMessage only rewinds the stream so the
+    // next send starts a new message.
+    const resetAnswerLaneAfterCollapse = () => {
+      if (activeAnswerDraftIsToolProgressOnly) {
+        resetAnswerToolProgressDraft();
+        suppressProgressDraftState();
+        rotateAnswerLaneWhenQueuedBlocksSettle = false;
+      }
+      answerLane.stream?.forceNewMessage();
+      resetDraftLaneState(answerLane);
+    };
+    // Tear the window down (delete) — only when there is NO bar to keep it on
+    // screen for (error final, or a turn with nothing to summarize). A bar
+    // collapse never reaches here, so clear()/delete never runs when a bar
+    // exists (the on-off focus-jump).
+    const teardownProgressWindow = async () => {
+      if (activeAnswerDraftIsToolProgressOnly) {
+        await rotateAnswerLaneAfterToolProgress();
+      } else {
+        await answerLane.stream?.clear();
+        resetDraftLaneState(answerLane);
+      }
     };
     const deliverProgressModeFinalAnswer = async (
       payload: ReplyPayload,
       text: string,
     ): Promise<LaneDeliveryResult> => {
-      // Collapse the window into the bar in place BEFORE resetting lane state
-      // (which drops the stream's message id). Error finals get no summary
-      // (Discord parity). When nothing collapsed in place, tear the window down
-      // so a stale progress box does not linger above the final answer.
-      const collapsedInPlace =
-        payload.isError === true ? false : await collapseProgressWindowIntoSummary();
       if (payload.isError === true) {
+        // Error finals get no collapse summary (Discord parity); tear down.
         progressSummaryDelivered = true;
-      }
-      if (!collapsedInPlace) {
-        if (activeAnswerDraftIsToolProgressOnly) {
-          await rotateAnswerLaneAfterToolProgress();
-        } else {
-          await answerLane.stream?.clear();
-          resetDraftLaneState(answerLane);
-        }
+        await teardownProgressWindow();
       } else {
-        if (activeAnswerDraftIsToolProgressOnly) {
-          resetAnswerToolProgressDraft();
-          suppressProgressDraftState();
-          rotateAnswerLaneWhenQueuedBlocksSettle = false;
+        // Collapse BEFORE resetting lane state (which drops the stream's message
+        // id). "edited"/"posted" keep a bar on screen — reset without delete;
+        // "none" (nothing to summarize) tears the stale window down.
+        const outcome = await collapseProgressWindowIntoSummary();
+        if (outcome === "none") {
+          await teardownProgressWindow();
+        } else {
+          resetAnswerLaneAfterCollapse();
         }
-        answerLane.stream?.forceNewMessage();
-        resetDraftLaneState(answerLane);
       }
       const delivered = await sendPayload(applyTextToPayload(payload, text), { durable: true });
       if (!delivered) {

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -22,6 +22,7 @@ import {
   type ChannelProgressDraftLine,
   type ChannelProgressDraftCompositorLine,
   createChannelProgressDraftCompositor,
+  isChannelProgressDraftWorkToolName,
   resolveChannelStreamingBlockEnabled,
   resolveChannelStreamingPreviewToolProgress,
   resolveTranscriptBackedChannelFinalText,
@@ -1699,7 +1700,7 @@ export const dispatchTelegramMessage = async ({
     };
     const sendPayload = async (
       payload: ReplyPayload,
-      options?: { durable?: boolean; silent?: boolean },
+      options?: { durable?: boolean; silent?: boolean; mirrorTranscript?: boolean },
     ) => {
       if (isDispatchSuperseded()) {
         return false;
@@ -1757,7 +1758,15 @@ export const dispatchTelegramMessage = async ({
       }
       const result = await (telegramDeps.deliverReplies ?? deliverReplies)({
         ...deliveryBaseOptions,
-        transcriptMirror: options?.durable ? deliveryBaseOptions.transcriptMirror : undefined,
+        // The collapse bar is a cosmetic activity digest, not an assistant
+        // message: pass mirrorTranscript:false so it never enters the session
+        // transcript (the model must not read it back as its own prior turn).
+        // Discord parity: its summary bar (reply-delivery.ts deliverDiscordReply)
+        // has no transcript-mirror seam either. Real finals keep the default.
+        transcriptMirror:
+          options?.durable && options?.mirrorTranscript !== false
+            ? deliveryBaseOptions.transcriptMirror
+            : undefined,
         replies: [effectivePayload],
         onVoiceRecording: sendRecordVoice,
         silent,
@@ -1963,7 +1972,15 @@ export const dispatchTelegramMessage = async ({
       if (!line) {
         return;
       }
-      await sendPayload({ text: line }, { durable: true });
+      // Cosmetic bar, posted from the cleanup fallback AFTER the real final is
+      // already delivered (message_tool_only/codex turns). A flood-wait/network
+      // throw here must never fail the turn — swallow and log. The once-guard
+      // already fired in resolveProgressCollapseSummaryLine, so no retry storm.
+      try {
+        await sendPayload({ text: line }, { durable: true, mirrorTranscript: false });
+      } catch (err) {
+        logVerbose(`telegram: collapse summary bar send failed: ${formatErrorMessage(err)}`);
+      }
     };
     // Apply a pre-resolved bar line to the window: edit the live window message
     // IN PLACE into the bar (no delete — deleting scroll-jumps the client), or
@@ -1981,7 +1998,7 @@ export const dispatchTelegramMessage = async ({
       if (typeof messageId === "number") {
         return "edited";
       }
-      await sendPayload({ text: line }, { durable: true });
+      await sendPayload({ text: line }, { durable: true, mirrorTranscript: false });
       return "posted";
     };
     // Reset answer-lane bookkeeping after a bar was edited/posted in place,
@@ -2647,14 +2664,25 @@ export const dispatchTelegramMessage = async ({
                     // own durable messages and must NOT also feed the bar (invariant:
                     // persistent message XOR bar count — D2).
                     if (payload.phase === "start") {
-                      // canPushStreamToolProgress() is false under verbose, so this
-                      // also closes bursts (never counting the tool) when the durable
-                      // lane owns the tool message (invariant: persistent XOR window).
-                      if (!canPushStreamToolProgress()) {
+                      // Count a tool only when the WINDOW actually renders it, so the
+                      // bar's 🛠️ tally matches what streamed. The compositor renders
+                      // a tool line only for work tools (isChannelProgressDraftWorkToolName
+                      // rejects message/reply/react/typing/etc.) and only when
+                      // toolProgress is on; a start-phase message tool (codex/
+                      // message_tool_only) otherwise inflated the count with no tool
+                      // line. canPushStreamToolProgress() is false under verbose (the
+                      // durable lane owns the tool message: persistent XOR window). In
+                      // every non-counting case the tool start is still a burst
+                      // boundary, so close reasoning/commentary without counting it.
+                      const windowRendersTool =
+                        canPushStreamToolProgress() &&
+                        streamToolProgressEnabled &&
+                        isChannelProgressDraftWorkToolName(toolName);
+                      if (windowRendersTool) {
+                        progressSummary.noteToolCall();
+                      } else {
                         progressSummary.closeReasoningBurst();
                         progressSummary.closeCommentaryBurst();
-                      } else {
-                        progressSummary.noteToolCall();
                       }
                     }
                     const progressPromise = pushStreamToolProgress(

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -1963,6 +1963,19 @@ export const dispatchTelegramMessage = async ({
       );
       return line || undefined;
     };
+    // The collapse summary bar is cosmetic and always reaches the user AFTER the
+    // real final answer (edited in place, or posted below it). A flood-wait /
+    // network throw from its durable send must never fail an otherwise-complete
+    // turn. Shared by BOTH bar-post fallbacks (the cleanup path and the
+    // finalizeToPreview-miss path) so neither can propagate a cosmetic failure
+    // into turn delivery; sendPayload throws durable.error on delivery failure.
+    const postCosmeticSummaryBar = async (line: string) => {
+      try {
+        await sendPayload({ text: line }, { durable: true, mirrorTranscript: false });
+      } catch (err) {
+        logVerbose(`telegram: collapse summary bar send failed: ${formatErrorMessage(err)}`);
+      }
+    };
     // Post-turn collapse summary (Discord parity) as a durable standalone
     // message. Used when there is no live window to collapse in place — the
     // final answer posts below so the timeline reads thoughts/tools → summary →
@@ -1972,15 +1985,9 @@ export const dispatchTelegramMessage = async ({
       if (!line) {
         return;
       }
-      // Cosmetic bar, posted from the cleanup fallback AFTER the real final is
-      // already delivered (message_tool_only/codex turns). A flood-wait/network
-      // throw here must never fail the turn — swallow and log. The once-guard
+      // Cleanup fallback bar (message_tool_only/codex turns): the once-guard
       // already fired in resolveProgressCollapseSummaryLine, so no retry storm.
-      try {
-        await sendPayload({ text: line }, { durable: true, mirrorTranscript: false });
-      } catch (err) {
-        logVerbose(`telegram: collapse summary bar send failed: ${formatErrorMessage(err)}`);
-      }
+      await postCosmeticSummaryBar(line);
     };
     // Apply a pre-resolved bar line to the window: edit the live window message
     // IN PLACE into the bar (no delete — deleting scroll-jumps the client), or
@@ -1998,7 +2005,11 @@ export const dispatchTelegramMessage = async ({
       if (typeof messageId === "number") {
         return "edited";
       }
-      await sendPayload({ text: line }, { durable: true, mirrorTranscript: false });
+      // finalizeToPreview could not edit in place (no live window id, or a
+      // flood-wait/terminal edit): post the bar durably instead. This send is
+      // cosmetic and runs after the final answer, so a throw must not fail the
+      // turn — the shared guarded helper swallows and logs.
+      await postCosmeticSummaryBar(line);
       return "posted";
     };
     // Reset answer-lane bookkeeping after a bar was edited/posted in place,

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -900,7 +900,14 @@ export const dispatchTelegramMessage = async ({
     agentId: route.agentId,
     loadFreshSessionEntry,
   });
-  const forceBlockStreamingForReasoning = resolvedReasoningLevel === "on";
+  // Progress mode's ephemeral working-lane window IS the streaming mechanism and
+  // is independent of reasoning persistence (Discord keeps its window alive
+  // regardless of /reasoning). Only non-progress modes upgrade reasoning-on to
+  // block streaming. Forcing block streaming in progress mode killed the whole
+  // window (no commentary/tool lanes, no collapse bar) and suppressed all
+  // streamed output for message_tool_only providers.
+  const forceBlockStreamingForReasoning =
+    resolvedReasoningLevel === "on" && streamMode !== "progress";
   const streamReasoningDraft = resolvedReasoningLevel === "stream";
   const streamDeliveryEnabled = !isRoomEvent && streamMode !== "off";
   const rawReplyQuoteText =
@@ -1087,13 +1094,15 @@ export const dispatchTelegramMessage = async ({
   });
   let finalAnswerDeliveryStarted = false;
   let finalAnswerDelivered = false;
-  // While the durable verbose lane is active, the ephemeral draft yields its
-  // commentary lines so they render once. Tool/plan status lines keep the
-  // draft: they have no durable counterpart in streamed runs.
+  // While the durable verbose lane is active it owns EVERY progress surface
+  // (commentary, tool, plan, command output, patch summaries), posting each as
+  // its own persistent message. The ephemeral window must therefore render none
+  // of them, or each renders twice (invariant: persistent message XOR window).
   let verboseProgressActive: () => boolean = () => false;
   const canPushStreamToolProgress = () =>
     Boolean(
       answerLane.stream &&
+      !verboseProgressActive() &&
       !answerLane.finalized &&
       !finalAnswerDeliveryStarted &&
       !finalAnswerDelivered,
@@ -1130,6 +1139,7 @@ export const dispatchTelegramMessage = async ({
   };
   const markProgressFinalDelivered = () => {
     finalAnswerDelivered = true;
+    sawProgressFinal = true;
     progressDraft.markFinalReplyDelivered();
   };
   const resetProgressDraftState = () => {
@@ -1561,6 +1571,11 @@ export const dispatchTelegramMessage = async ({
   const silentErrorReplies = telegramCfg.silentErrorReplies === true;
   const isDmTopic = !isGroup && threadSpec.scope === "dm" && threadSpec.id != null;
   let queuedFinal = false;
+  // A final answer was produced this turn (in-band or out-of-band). Out-of-band
+  // finals (message_tool_only / codex) never flow through
+  // deliverProgressModeFinalAnswer, so the collapse bar must be posted from the
+  // cleanup fallback instead — see the finally block.
+  let sawProgressFinal = false;
   let skippedDuplicateAnswerBlockDraftDelivery = false;
   let suppressSilentReplyFallback = false;
   let hadErrorReplyFailureOrSkip = false;
@@ -1901,44 +1916,82 @@ export const dispatchTelegramMessage = async ({
       await emitPreviewFinalizedHook(result);
       return result.kind !== "skipped";
     };
-    // Post-turn collapse summary (Discord parity): when the progress window
-    // collapses at end-of-turn, post a one-line activity digest as a durable
-    // standalone message, then the final answer posts below it so the timeline
-    // reads thoughts/tools → summary → answer. Emitted at most once per turn,
-    // only for a non-error final, and only when the window actually rendered
-    // (rv mode delivers everything durably and the window stays empty — no bar).
-    const deliverProgressCollapseSummary = async () => {
+    // The one-line activity digest for the collapse bar, or undefined when the
+    // window never rendered (rv mode delivers everything durably — no bar) or
+    // the summary was already emitted this turn.
+    const resolveProgressCollapseSummaryLine = (): string | undefined => {
       if (progressSummaryDelivered) {
-        return;
+        return undefined;
       }
       progressSummaryDelivered = true;
       if (!progressDraftEverRendered) {
-        return;
+        return undefined;
       }
       const line = formatTelegramProgressSummaryLine(
         progressSummary.counts(),
         Date.now() - progressSummaryStartedAt,
       );
+      return line || undefined;
+    };
+    // Post-turn collapse summary (Discord parity) as a durable standalone
+    // message. Used when there is no live window to collapse in place — the
+    // final answer posts below so the timeline reads thoughts/tools → summary →
+    // answer. Emitted at most once per turn.
+    const deliverProgressCollapseSummary = async () => {
+      const line = resolveProgressCollapseSummaryLine();
       if (!line) {
         return;
       }
       await sendPayload({ text: line }, { durable: true });
     };
+    // Collapse the live window IN PLACE into the summary bar: edit the existing
+    // window message so its content becomes the bar line, keeping it on screen.
+    // Mirrors Discord — deleting the window and reposting the bar scroll-jumps
+    // the Telegram client and flashes the window away. Returns true when the
+    // window was collapsed in place; false when there is no bar (nothing
+    // streamed) or no live window message, so the caller tears the window down.
+    const collapseProgressWindowIntoSummary = async (): Promise<boolean> => {
+      const line = resolveProgressCollapseSummaryLine();
+      if (!line) {
+        return false;
+      }
+      const messageId = await answerLane.stream?.finalizeToPreview(renderStreamText(line));
+      if (typeof messageId === "number") {
+        return true;
+      }
+      // No live window to edit (rv mode, never rendered): keep the bar as a
+      // fresh durable post so the timeline still shows the collapse summary.
+      await sendPayload({ text: line }, { durable: true });
+      return false;
+    };
     const deliverProgressModeFinalAnswer = async (
       payload: ReplyPayload,
       text: string,
     ): Promise<LaneDeliveryResult> => {
-      if (activeAnswerDraftIsToolProgressOnly) {
-        await rotateAnswerLaneAfterToolProgress();
-      } else {
-        await answerLane.stream?.clear();
-        resetDraftLaneState(answerLane);
-      }
+      // Collapse the window into the bar in place BEFORE resetting lane state
+      // (which drops the stream's message id). Error finals get no summary
+      // (Discord parity). When nothing collapsed in place, tear the window down
+      // so a stale progress box does not linger above the final answer.
+      const collapsedInPlace =
+        payload.isError === true ? false : await collapseProgressWindowIntoSummary();
       if (payload.isError === true) {
-        // Error finals get no collapse summary (Discord parity); mark it handled.
         progressSummaryDelivered = true;
+      }
+      if (!collapsedInPlace) {
+        if (activeAnswerDraftIsToolProgressOnly) {
+          await rotateAnswerLaneAfterToolProgress();
+        } else {
+          await answerLane.stream?.clear();
+          resetDraftLaneState(answerLane);
+        }
       } else {
-        await deliverProgressCollapseSummary();
+        if (activeAnswerDraftIsToolProgressOnly) {
+          resetAnswerToolProgressDraft();
+          suppressProgressDraftState();
+          rotateAnswerLaneWhenQueuedBlocksSettle = false;
+        }
+        answerLane.stream?.forceNewMessage();
+        resetDraftLaneState(answerLane);
       }
       const delivered = await sendPayload(applyTextToPayload(payload, text), { durable: true });
       if (!delivered) {
@@ -2521,7 +2574,10 @@ export const dispatchTelegramMessage = async ({
                     // own durable messages and must NOT also feed the bar (invariant:
                     // persistent message XOR bar count — D2).
                     if (payload.phase === "start") {
-                      if (verboseProgressActive() || !canPushStreamToolProgress()) {
+                      // canPushStreamToolProgress() is false under verbose, so this
+                      // also closes bursts (never counting the tool) when the durable
+                      // lane owns the tool message (invariant: persistent XOR window).
+                      if (!canPushStreamToolProgress()) {
                         progressSummary.closeReasoningBurst();
                         progressSummary.closeCommentaryBurst();
                       } else {
@@ -2682,6 +2738,12 @@ export const dispatchTelegramMessage = async ({
         return { kind: "completed" };
       }
       ({ queuedFinal } = turnResult.dispatchResult);
+      // Out-of-band finals (message_tool_only) never run the in-band final-delivery
+      // path, so record the final from the dispatch counts for the cleanup-time
+      // collapse-bar fallback.
+      if ((turnResult.dispatchResult.counts?.final ?? 0) > 0) {
+        sawProgressFinal = true;
+      }
       suppressSilentReplyFallback =
         turnResult.dispatchResult.sourceReplyDeliveryMode === "message_tool_only";
     } catch (err) {
@@ -2709,6 +2771,20 @@ export const dispatchTelegramMessage = async ({
         } else {
           await stream.clear();
         }
+      }
+      // Fallback collapse summary (Discord parity): finals that bypass
+      // deliverProgressModeFinalAnswer — notably message_tool_only/codex turns
+      // whose final is delivered out-of-band — still collapse here. The internal
+      // once-guard and progressDraftEverRendered check keep this from
+      // double-posting or firing when the window never rendered.
+      if (
+        streamMode === "progress" &&
+        sawProgressFinal &&
+        !dispatchError &&
+        !hadErrorReplyFailureOrSkip &&
+        !isDispatchSuperseded()
+      ) {
+        await deliverProgressCollapseSummary();
       }
     }
   } finally {

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -1046,7 +1046,12 @@ export const dispatchTelegramMessage = async ({
     if (activeAnswerDraftIsToolProgressOnly) {
       return;
     }
-    if (answerLane.hasStreamedMessage) {
+    // Progress mode keeps ONE stationary window: interim answer text never
+    // streams into it (updateDraftFromPartial returns early), so hasStreamedMessage
+    // is only ever set by tool progress on this same message — never rotate here.
+    // The rotate exists for block/partial, where answer text streams first and a
+    // following tool run needs its own message.
+    if (streamMode !== "progress" && answerLane.hasStreamedMessage) {
       await rotateAnswerLaneForNewMessage();
     }
     activeAnswerDraftIsToolProgressOnly = true;
@@ -1263,6 +1268,15 @@ export const dispatchTelegramMessage = async ({
     return true;
   };
   const prepareAnswerLaneForText = async (): Promise<boolean> => {
+    // Single stationary window in progress mode: interim answer text never
+    // renders into the window (updateDraftFromPartial returns early for the
+    // answer lane), so it must NOT rotate/reposition the tool-progress window
+    // either. The one window message stays put through every lane handover and
+    // is edited into the summary bar at collapse (deliverProgressModeFinalAnswer);
+    // rotating here spawned a fresh bubble per interim answer chunk (churn).
+    if (streamMode === "progress") {
+      return false;
+    }
     if (await rotateAnswerLaneAfterToolProgress()) {
       return true;
     }
@@ -2350,7 +2364,15 @@ export const dispatchTelegramMessage = async ({
                           lanePayload,
                           info.assistantMessageIndex,
                         );
-                        if (shouldRotateQueuedBlock && !preparedAnswerLane) {
+                        // Single stationary window in progress mode: interim answer
+                        // blocks never render into the window, so don't rotate it to
+                        // a fresh bubble for them — the one message stays put until
+                        // collapse. Non-progress modes keep the block rotation.
+                        if (
+                          streamMode !== "progress" &&
+                          shouldRotateQueuedBlock &&
+                          !preparedAnswerLane
+                        ) {
                           await rotateAnswerLaneForNewMessage();
                           rotateAnswerLaneWhenQueuedBlocksSettle = false;
                         }

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -2346,7 +2346,21 @@ export const dispatchTelegramMessage = async ({
                         !ownedByQueuedAnswerBlockRotation &&
                         segment.update.text.trimEnd() === answerLane.lastPartialText.trimEnd();
 
-                      if (skipTextOnlyBlock) {
+                      // Progress mode: the window is a pure activity log — interim
+                      // answer blocks (intermediate assistant messages before the
+                      // final) never render into it (Discord parity). Buffer the
+                      // block so it still feeds the final/collapse, and skip the
+                      // draft stream. Media/approval/button blocks fall through to
+                      // normal delivery (they are not plain interim prose).
+                      const suppressProgressAnswerBlock =
+                        streamMode === "progress" &&
+                        info.kind === "block" &&
+                        segment.lane === "answer" &&
+                        !reply.hasMedia &&
+                        !hasExecApprovalPayload(effectivePayload) &&
+                        telegramButtons === undefined;
+
+                      if (skipTextOnlyBlock || suppressProgressAnswerBlock) {
                         // Keep duplicate blocks available for later rotation/finalization.
                         skippedDuplicateAnswerBlockDraftDelivery = true;
                         lastAnswerBlockPayload = effectivePayload;
@@ -2364,10 +2378,10 @@ export const dispatchTelegramMessage = async ({
                           lanePayload,
                           info.assistantMessageIndex,
                         );
-                        // Single stationary window in progress mode: interim answer
-                        // blocks never render into the window, so don't rotate it to
-                        // a fresh bubble for them — the one message stays put until
-                        // collapse. Non-progress modes keep the block rotation.
+                        // Single stationary window in progress mode: plain interim
+                        // answer blocks are already suppressed above, so only
+                        // media/approval/button blocks reach here in progress — they
+                        // still must not rotate the window to a fresh bubble.
                         if (
                           streamMode !== "progress" &&
                           shouldRotateQueuedBlock &&

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -1951,27 +1951,22 @@ export const dispatchTelegramMessage = async ({
       }
       await sendPayload({ text: line }, { durable: true });
     };
-    // Collapse the progress window into the summary bar. ONE deterministic path
-    // for every mode (off-off, stream-off, on-off tool-progress-only): edit the
-    // live window message IN PLACE into the bar (no delete — deleting scroll-
-    // jumps the Telegram client). Only when there is genuinely no live window
-    // message (rv mode never rendered a message) is the bar posted durably, and
-    // even then NOTHING is deleted. Returns "edited" | "posted" | "none" so the
-    // caller resets lane state without ever falling back to a bare clear() when
-    // a bar exists. finalizeToPreview settles pending previews first, so a
-    // still-pending tool-progress window is materialized and edited rather than
-    // missed (the on-off inconsistency).
-    const collapseProgressWindowIntoSummary = async (): Promise<"edited" | "posted" | "none"> => {
-      const line = resolveProgressCollapseSummaryLine();
-      if (!line) {
-        return "none";
-      }
+    // Apply a pre-resolved bar line to the window: edit the live window message
+    // IN PLACE into the bar (no delete — deleting scroll-jumps the client), or
+    // post it durably when there is no live window message to edit. NOTHING is
+    // deleted. Returns "edited" | "posted". The line is snapshotted by the
+    // caller BEFORE the final answer is sent, so the final's own delivery cannot
+    // perturb the counts; the EDIT itself runs AFTER the final so shrinking the
+    // tall window bubble down to one line happens above the anchored viewport
+    // (the final already sits at the bottom) and never drops the final off
+    // screen (the edit-shrink anchor loss). finalizeToPreview settles pending
+    // previews so a still-pending tool-progress window is materialized and
+    // edited rather than missed.
+    const applyProgressCollapseSummary = async (line: string): Promise<"edited" | "posted"> => {
       const messageId = await answerLane.stream?.finalizeToPreview(renderStreamText(line));
       if (typeof messageId === "number") {
         return "edited";
       }
-      // No live window message existed to edit; still surface the bar, but never
-      // delete (there is nothing on screen to remove).
       await sendPayload({ text: line }, { durable: true });
       return "posted";
     };
@@ -2005,21 +2000,37 @@ export const dispatchTelegramMessage = async ({
       text: string,
     ): Promise<LaneDeliveryResult> => {
       if (payload.isError === true) {
-        // Error finals get no collapse summary (Discord parity); tear down.
+        // Error finals get no collapse summary (Discord parity); tear down, then
+        // deliver the error below.
         progressSummaryDelivered = true;
         await teardownProgressWindow();
-      } else {
-        // Collapse BEFORE resetting lane state (which drops the stream's message
-        // id). "edited"/"posted" keep a bar on screen — reset without delete;
-        // "none" (nothing to summarize) tears the stale window down.
-        const outcome = await collapseProgressWindowIntoSummary();
-        if (outcome === "none") {
-          await teardownProgressWindow();
-        } else {
-          resetAnswerLaneAfterCollapse();
+        const delivered = await sendPayload(applyTextToPayload(payload, text), { durable: true });
+        if (!delivered) {
+          return { kind: "skipped" };
         }
+        answerLane.finalized = true;
+        markProgressFinalDelivered();
+        return { kind: "sent" };
       }
+      // Snapshot the bar line BEFORE the final send so the final's own delivery
+      // cannot perturb the counts/timer (and the once-guard fires exactly once).
+      const barLine = resolveProgressCollapseSummaryLine();
+      // Send the final FIRST so it lands at the bottom of the anchored viewport;
+      // THEN collapse the window above it. Editing the tall window down to a
+      // one-line bar after the final is delivered keeps the shrink above the
+      // anchor, so the final never scrolls off screen (edit-shrink anchor loss).
       const delivered = await sendPayload(applyTextToPayload(payload, text), { durable: true });
+      // Collapse AFTER the final either way — don't leave a stale window even
+      // when the final skipped/failed. resetAnswerLaneAfterCollapse resets lane
+      // state (clearing `finalized`), so mark the final delivered LAST.
+      if (barLine) {
+        await applyProgressCollapseSummary(barLine);
+        resetAnswerLaneAfterCollapse();
+      } else {
+        // Nothing to summarize (window never rendered / empty counts): tear the
+        // stale window down rather than leaving it above the final.
+        await teardownProgressWindow();
+      }
       if (!delivered) {
         return { kind: "skipped" };
       }

--- a/extensions/telegram/src/channel-message-flows.qa.e2e.test.ts
+++ b/extensions/telegram/src/channel-message-flows.qa.e2e.test.ts
@@ -21,6 +21,8 @@ describe("channel message flows QA e2e", () => {
       stop: vi.fn(async () => {}),
       messageId: vi.fn(() => 17),
       forceNewMessage: vi.fn(),
+      finalizeToPreview: vi.fn(async () => undefined),
+      rotateToNewMessageDeferringDelete: vi.fn(() => undefined),
     };
   }
 
@@ -40,6 +42,8 @@ describe("channel message flows QA e2e", () => {
       stop: vi.fn(async () => {}),
       messageId: vi.fn(() => 17),
       forceNewMessage: vi.fn(),
+      finalizeToPreview: vi.fn(async () => undefined),
+      rotateToNewMessageDeferringDelete: vi.fn(() => undefined),
     };
     const sendFinal = vi.fn(async () => {
       events.push("final");
@@ -88,6 +92,8 @@ describe("channel message flows QA e2e", () => {
       stop: vi.fn(async () => {}),
       messageId: vi.fn(() => 17),
       forceNewMessage: vi.fn(),
+      finalizeToPreview: vi.fn(async () => undefined),
+      rotateToNewMessageDeferringDelete: vi.fn(() => undefined),
     };
     const sendFinal = vi.fn(async () => ({ messageId: "99", chatId: "123" }));
 
@@ -120,6 +126,8 @@ describe("channel message flows QA e2e", () => {
       stop: vi.fn(async () => {}),
       messageId: vi.fn(() => 17),
       forceNewMessage: vi.fn(),
+      finalizeToPreview: vi.fn(async () => undefined),
+      rotateToNewMessageDeferringDelete: vi.fn(() => undefined),
     };
 
     await expect(

--- a/extensions/telegram/src/draft-stream.test-helpers.ts
+++ b/extensions/telegram/src/draft-stream.test-helpers.ts
@@ -18,6 +18,7 @@ type TestDraftStream = {
     typeof vi.fn<(preview: TelegramDraftPreview) => Promise<number | undefined>>
   >;
   forceNewMessage: ReturnType<typeof vi.fn<() => void>>;
+  rotateToNewMessageDeferringDelete: ReturnType<typeof vi.fn<() => number | undefined>>;
   sendMayHaveLanded: ReturnType<typeof vi.fn<() => boolean>>;
   setMessageId: (value: number | undefined) => void;
 };
@@ -85,6 +86,18 @@ export function createTestDraftStream(params?: {
       }
       visibleSinceMs = undefined;
     }),
+    rotateToNewMessageDeferringDelete: vi.fn().mockImplementation(() => {
+      // Mirror forceNewMessage's message-id handling (a sequenced harness swaps
+      // ids on the next send; the fixed harness keeps its id unless configured
+      // otherwise) so the rewind semantics match; return the superseded id.
+      const superseded = messageId;
+      stopped = false;
+      if (params?.clearMessageIdOnForceNew) {
+        messageId = undefined;
+      }
+      visibleSinceMs = undefined;
+      return superseded;
+    }),
     sendMayHaveLanded: vi.fn().mockReturnValue(false),
     setMessageId: (value: number | undefined) => {
       messageId = value;
@@ -136,6 +149,12 @@ export function createSequencedTestDraftStream(startMessageId = 1001): TestDraft
     forceNewMessage: vi.fn().mockImplementation(() => {
       activeMessageId = undefined;
       visibleSinceMs = undefined;
+    }),
+    rotateToNewMessageDeferringDelete: vi.fn().mockImplementation(() => {
+      const superseded = activeMessageId;
+      activeMessageId = undefined;
+      visibleSinceMs = undefined;
+      return superseded;
     }),
     sendMayHaveLanded: vi.fn().mockReturnValue(false),
     setMessageId: (value: number | undefined) => {

--- a/extensions/telegram/src/draft-stream.test-helpers.ts
+++ b/extensions/telegram/src/draft-stream.test-helpers.ts
@@ -14,6 +14,9 @@ type TestDraftStream = {
   stop: ReturnType<typeof vi.fn<() => Promise<void>>>;
   discard: ReturnType<typeof vi.fn<() => Promise<void>>>;
   materialize: ReturnType<typeof vi.fn<() => Promise<number | undefined>>>;
+  finalizeToPreview: ReturnType<
+    typeof vi.fn<(preview: TelegramDraftPreview) => Promise<number | undefined>>
+  >;
   forceNewMessage: ReturnType<typeof vi.fn<() => void>>;
   sendMayHaveLanded: ReturnType<typeof vi.fn<() => boolean>>;
   setMessageId: (value: number | undefined) => void;
@@ -66,6 +69,15 @@ export function createTestDraftStream(params?: {
       await params?.onDiscard?.();
     }),
     materialize: vi.fn().mockImplementation(async () => messageId),
+    finalizeToPreview: vi.fn().mockImplementation(async (preview: TelegramDraftPreview) => {
+      if (messageId == null) {
+        return undefined;
+      }
+      previewRevision += 1;
+      lastDeliveredText = preview.text.trimEnd();
+      stopped = true;
+      return messageId;
+    }),
     forceNewMessage: vi.fn().mockImplementation(() => {
       stopped = false;
       if (params?.clearMessageIdOnForceNew) {
@@ -113,6 +125,14 @@ export function createSequencedTestDraftStream(startMessageId = 1001): TestDraft
     stop: vi.fn().mockResolvedValue(undefined),
     discard: vi.fn().mockResolvedValue(undefined),
     materialize: vi.fn().mockImplementation(async () => activeMessageId),
+    finalizeToPreview: vi.fn().mockImplementation(async (preview: TelegramDraftPreview) => {
+      if (activeMessageId == null) {
+        return undefined;
+      }
+      previewRevision += 1;
+      lastDeliveredText = preview.text.trimEnd();
+      return activeMessageId;
+    }),
     forceNewMessage: vi.fn().mockImplementation(() => {
       activeMessageId = undefined;
       visibleSinceMs = undefined;

--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -380,6 +380,48 @@ describe("createTelegramDraftStream", () => {
     }
   });
 
+  it("rotateToNewMessageDeferringDelete posts the new message before deleting the old", async () => {
+    vi.useFakeTimers();
+    try {
+      const api = createMockDraftApi();
+      api.sendMessage
+        .mockResolvedValueOnce({ message_id: 17 })
+        .mockResolvedValueOnce({ message_id: 42 });
+      const stream = createThreadedDraftStream(api, { id: 42, scope: "dm" });
+
+      stream.update("🛠️ Exec");
+      await stream.flush();
+      // Reposition: rewind for a new message; the old one's delete is deferred.
+      const superseded = stream.rotateToNewMessageDeferringDelete();
+      expect(superseded).toBe(17);
+
+      // The NEW message is sent first...
+      stream.update("Answer below");
+      await stream.flush();
+      expect(api.sendMessage).toHaveBeenNthCalledWith(2, 123, "Answer below", {
+        message_thread_id: 42,
+      });
+      // ...and the superseded message is NOT deleted immediately (deferred so
+      // the new message lands first — no scroll-jump).
+      expect(api.deleteMessage).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(4_000);
+      expect(api.deleteMessage).toHaveBeenCalledWith(123, 17);
+      // Only the superseded (old) message is deleted; the new one stays.
+      expect(api.deleteMessage).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("rotateToNewMessageDeferringDelete is a no-op with no live message", () => {
+    const api = createMockDraftApi();
+    const stream = createThreadedDraftStream(api, { id: 42, scope: "dm" });
+
+    expect(stream.rotateToNewMessageDeferringDelete()).toBeUndefined();
+    expect(api.deleteMessage).not.toHaveBeenCalled();
+  });
+
   it("creates new message after forceNewMessage is called", async () => {
     const { api, stream } = createForceNewMessageHarness();
 

--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -277,6 +277,26 @@ describe("createTelegramDraftStream", () => {
     expect(api.raw.sendRichMessage).not.toHaveBeenCalled();
   });
 
+  it("converts <br> joins to newlines before parse_mode=HTML transport", async () => {
+    const api = createMockDraftApi();
+    const stream = createDraftStream(api, {
+      // Progress drafts join rendered lines with <br>; Bot API parse_mode=HTML
+      // has no <br> tag, so sending it verbatim 400s every multi-line edit and
+      // drops the preview to the unformatted plain fallback.
+      renderText: (text) => ({
+        text: `<b>Shelling</b><br>🧠 <i>${text}</i>`,
+        parseMode: "HTML",
+      }),
+    });
+
+    stream.update("Thinking");
+    await stream.flush();
+
+    expect(api.sendMessage).toHaveBeenCalledWith(123, "<b>Shelling</b>\n🧠 <i>Thinking</i>", {
+      parse_mode: "HTML",
+    });
+  });
+
   it("returns existing preview id when materializing message transport", async () => {
     const api = createMockDraftApi();
     const stream = createDraftStream(api, {

--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -312,6 +312,50 @@ describe("createTelegramDraftStream", () => {
     expect(api.raw.sendRichMessage).not.toHaveBeenCalled();
   });
 
+  it("finalizeToPreview edits the live window message in place without deleting", async () => {
+    const api = createMockDraftApi();
+    const stream = createDraftStream(api, { thread: { id: 42, scope: "dm" } });
+
+    stream.update("🛠️ Exec: pnpm test");
+    await stream.flush();
+    const messageId = await stream.finalizeToPreview({ text: "🛠️ 1 tool call · ⏱️ 1s" });
+
+    expect(messageId).toBe(17);
+    // The window message is EDITED into the bar, never deleted (no focus-jump).
+    expect(api.editMessageText).toHaveBeenCalledWith(123, 17, "🛠️ 1 tool call · ⏱️ 1s");
+    expect(api.deleteMessage).not.toHaveBeenCalled();
+  });
+
+  it("finalizeToPreview materializes a still-pending window before editing", async () => {
+    // A throttled preview may not have been sent yet when the collapse runs;
+    // finalizeToPreview must send it first so there is a message to edit into
+    // the bar, rather than returning undefined and forcing a delete + repost.
+    const api = createMockDraftApi();
+    const stream = createDraftStream(api, {
+      thread: { id: 42, scope: "dm" },
+      throttleMs: 10_000,
+    });
+
+    stream.update("🛠️ Exec: pnpm test");
+    const messageId = await stream.finalizeToPreview({ text: "🛠️ 1 tool call · ⏱️ 1s" });
+
+    expect(messageId).toBe(17);
+    expect(api.sendMessage).toHaveBeenCalledTimes(1);
+    expect(api.deleteMessage).not.toHaveBeenCalled();
+  });
+
+  it("finalizeToPreview returns undefined when no window ever rendered", async () => {
+    const api = createMockDraftApi();
+    const stream = createDraftStream(api, { thread: { id: 42, scope: "dm" } });
+
+    const messageId = await stream.finalizeToPreview({ text: "🛠️ 1 tool call · ⏱️ 1s" });
+
+    expect(messageId).toBeUndefined();
+    expect(api.sendMessage).not.toHaveBeenCalled();
+    expect(api.editMessageText).not.toHaveBeenCalled();
+    expect(api.deleteMessage).not.toHaveBeenCalled();
+  });
+
   it("deletes message preview on clear after finalization", async () => {
     vi.useFakeTimers();
     try {

--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -356,6 +356,31 @@ describe("createTelegramDraftStream", () => {
     expect(api.deleteMessage).not.toHaveBeenCalled();
   });
 
+  it("finalizeToPreview returns undefined when the in-place collapse edit does not apply", async () => {
+    // Red-team F2: a flood-wait (429) on the collapse edit makes the underlying
+    // send return false without applying. finalizeToPreview must report that as
+    // "not collapsed in place" (undefined) so the dispatch falls back to posting
+    // a durable bar — otherwise it assumes success, clears state, posts no bar,
+    // and the tall window is left on screen.
+    const api = createMockDraftApi();
+    api.editMessageText.mockRejectedValueOnce(
+      Object.assign(
+        new Error("Call to 'editMessageText' failed! (429: Too Many Requests: retry after 5)"),
+        { error_code: 429, parameters: { retry_after: 5 } },
+      ),
+    );
+    const stream = createDraftStream(api, { thread: { id: 42, scope: "dm" } });
+
+    stream.update("🛠️ Exec: pnpm test");
+    await stream.flush();
+    const messageId = await stream.finalizeToPreview({ text: "🛠️ 1 tool call · ⏱️ 1s" });
+
+    expect(messageId).toBeUndefined();
+    expect(api.editMessageText).toHaveBeenCalledTimes(1);
+    // The live window is NOT deleted (the caller posts the bar below it instead).
+    expect(api.deleteMessage).not.toHaveBeenCalled();
+  });
+
   it("deletes message preview on clear after finalization", async () => {
     vi.useFakeTimers();
     try {
@@ -420,6 +445,48 @@ describe("createTelegramDraftStream", () => {
 
     expect(stream.rotateToNewMessageDeferringDelete()).toBeUndefined();
     expect(api.deleteMessage).not.toHaveBeenCalled();
+  });
+
+  it("deletes a reposition-superseded first send instead of retaining an orphaned bubble", async () => {
+    // Red-team F5: rotateToNewMessageDeferringDelete rewinds while a FIRST send is
+    // still in flight (no message id yet). The late-landing message is a stale
+    // preview to delete — NOT a durable content chunk to retain (that is
+    // forceNewMessage's contract). Previously it fired onSupersededPreview
+    // {retain:true}, which the dispatch handler kept, leaving a ghost bubble.
+    vi.useFakeTimers();
+    try {
+      let resolveFirstSend: ((value: { message_id: number }) => void) | undefined;
+      const firstSend = new Promise<{ message_id: number }>((resolve) => {
+        resolveFirstSend = resolve;
+      });
+      const api = createMockDraftApi();
+      api.sendMessage.mockReturnValueOnce(firstSend).mockResolvedValueOnce({ message_id: 42 });
+      const onSupersededPreview = vi.fn();
+      const stream = createDraftStream(api, { onSupersededPreview });
+
+      stream.update("Message A partial");
+      await vi.advanceTimersByTimeAsync(0);
+      expect(api.sendMessage).toHaveBeenCalledTimes(1);
+
+      // Reposition while the first send is still in flight, then stream on.
+      stream.rotateToNewMessageDeferringDelete();
+      stream.update("Message B partial");
+
+      resolveFirstSend?.({ message_id: 17 });
+      await vi.advanceTimersByTimeAsync(0);
+      await stream.flush();
+
+      // The raced first send is NOT retained as a durable chunk...
+      expect(onSupersededPreview).not.toHaveBeenCalled();
+      expect(api.deleteMessage).not.toHaveBeenCalled();
+      // ...it is deleted deferred, so no orphaned stale bubble is left behind.
+      await vi.advanceTimersByTimeAsync(4_000);
+      expect(api.deleteMessage).toHaveBeenCalledWith(123, 17);
+      // The replacement message still streams normally.
+      expectNthPreviewSend(api, 2, "Message B partial");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("creates new message after forceNewMessage is called", async () => {

--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -313,18 +313,27 @@ describe("createTelegramDraftStream", () => {
   });
 
   it("deletes message preview on clear after finalization", async () => {
-    const api = createMockDraftApi();
-    const stream = createThreadedDraftStream(api, { id: 42, scope: "dm" });
+    vi.useFakeTimers();
+    try {
+      const api = createMockDraftApi();
+      const stream = createThreadedDraftStream(api, { id: 42, scope: "dm" });
 
-    stream.update("Hello");
-    await stream.flush();
-    stream.update("Hello again");
-    await stream.stop();
-    await stream.clear();
+      stream.update("Hello");
+      await stream.flush();
+      stream.update("Hello again");
+      await stream.stop();
+      await stream.clear();
 
-    expectPreviewSend(api, "Hello", { message_thread_id: 42 });
-    expectPreviewEdit(api, "Hello again");
-    expect(api.deleteMessage).toHaveBeenCalledWith(123, 17);
+      expectPreviewSend(api, "Hello", { message_thread_id: 42 });
+      expectPreviewEdit(api, "Hello again");
+      // The delete is deferred until the preview has been on screen for the
+      // dwell window; advance past it to trigger the detached cleanup.
+      expect(api.deleteMessage).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(4_000);
+      expect(api.deleteMessage).toHaveBeenCalledWith(123, 17);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("creates new message after forceNewMessage is called", async () => {
@@ -351,20 +360,50 @@ describe("createTelegramDraftStream", () => {
   });
 
   it("creates new message after cleanup and forceNewMessage", async () => {
-    const { api, stream } = createForceNewMessageHarness();
+    vi.useFakeTimers();
+    try {
+      const { api, stream } = createForceNewMessageHarness();
 
-    stream.update("Stale preview");
-    await stream.flush();
+      stream.update("Stale preview");
+      await stream.flush();
 
-    await stream.clear();
-    expect(api.deleteMessage).toHaveBeenCalledWith(123, 17);
+      await stream.clear();
+      // Delete is deferred past the dwell window; advance to trigger it.
+      await vi.advanceTimersByTimeAsync(4_000);
+      expect(api.deleteMessage).toHaveBeenCalledWith(123, 17);
 
-    stream.forceNewMessage();
-    stream.update("Next preview");
-    await stream.flush();
+      stream.forceNewMessage();
+      stream.update("Next preview");
+      await stream.flush();
 
-    expect(api.sendMessage).toHaveBeenCalledTimes(2);
-    expectNthPreviewSend(api, 2, "Next preview");
+      expect(api.sendMessage).toHaveBeenCalledTimes(2);
+      expectNthPreviewSend(api, 2, "Next preview");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps the streaming preview on screen for the dwell window before deleting", async () => {
+    vi.useFakeTimers();
+    try {
+      const api = createMockDraftApi();
+      const stream = createDraftStream(api);
+
+      stream.update("Working");
+      await stream.flush();
+      // Fast turn: the preview has only been visible ~1s when the turn tears down.
+      await vi.advanceTimersByTimeAsync(1_000);
+      await stream.clear();
+
+      // Delete is deferred, not synchronous, and does not fire before the 4s dwell.
+      await vi.advanceTimersByTimeAsync(2_000);
+      expect(api.deleteMessage).not.toHaveBeenCalled();
+      // At the dwell boundary (~4s after first appearing) the detached delete runs.
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(api.deleteMessage).toHaveBeenCalledWith(123, 17);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("sends first update immediately after forceNewMessage within throttle window", async () => {

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -112,7 +112,10 @@ function normalizeTelegramDraftTransportPreview(
   }
   if (preview.parseMode === "HTML") {
     return {
-      text: preview.text,
+      // Bot API parse_mode=HTML has no <br>; line breaks must be literal
+      // newlines. Sending <br> verbatim 400s every multi-line preview edit,
+      // dropping the whole progress draft to the unformatted plain fallback.
+      text: telegramRichHtmlToParseModeHtml(preview.text),
       parseMode: "HTML",
       plainText: telegramHtmlToPlainTextFallback(preview.text),
     };

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -68,6 +68,13 @@ export type TelegramDraftStream = {
   finalizeToPreview: (preview: TelegramDraftPreview) => Promise<number | undefined>;
   /** Reset internal state so the next update creates a new message instead of editing. */
   forceNewMessage: () => void;
+  /**
+   * Reposition the window: rewind so the next update creates a new message,
+   * and schedule the superseded message's delete for AFTER the new one lands
+   * (post-new-then-delete-old, never delete-then-repost — avoids the client
+   * scroll-jump). Returns the superseded message id, if any.
+   */
+  rotateToNewMessageDeferringDelete: () => number | undefined;
   /** True when a preview sendMessage was attempted but the response was lost. */
   sendMayHaveLanded?: () => boolean;
 };
@@ -546,6 +553,37 @@ export function createTelegramDraftStream(params: {
     loop.resetThrottleWindow();
   };
 
+  // Delete a superseded preview message DETACHED (scheduled, never awaited) so
+  // teardown is never stalled. The delay is at least the remaining on-screen
+  // dwell (so a preview is never flashed), and at least `minDelayMs` — a
+  // reposition passes a small floor so the NEW message has landed below before
+  // the old one disappears, keeping the viewport anchored instead of jumping.
+  const scheduleDetachedDelete = (
+    messageId: number,
+    visibleSince: number | undefined,
+    minDelayMs = 0,
+  ) => {
+    const runDelete = async () => {
+      try {
+        await params.api.deleteMessage(chatId, messageId);
+        params.log?.(`telegram stream preview deleted (chat=${chatId}, message=${messageId})`);
+      } catch (err) {
+        params.warn?.(`telegram stream preview cleanup failed: ${formatErrorMessage(err)}`);
+      }
+    };
+    const elapsedMs =
+      typeof visibleSince === "number" ? Date.now() - visibleSince : MIN_PREVIEW_DWELL_MS;
+    const remainingDwellMs = Math.max(0, MIN_PREVIEW_DWELL_MS - elapsedMs);
+    const delayMs = Math.max(remainingDwellMs, minDelayMs);
+    if (delayMs <= 0) {
+      void runDelete();
+    } else {
+      setTimeout(() => {
+        void runDelete();
+      }, delayMs);
+    }
+  };
+
   const clear = async () => {
     // Capture before the stop; takeMessageIdAfterStop resets streamVisibleSinceMs.
     const visibleSince = streamVisibleSinceMs;
@@ -557,28 +595,28 @@ export function createTelegramDraftStream(params: {
       },
     });
     if (typeof messageId === "number" && Number.isFinite(messageId)) {
-      const runDelete = async () => {
-        try {
-          await params.api.deleteMessage(chatId, messageId);
-          params.log?.(`telegram stream preview deleted (chat=${chatId}, message=${messageId})`);
-        } catch (err) {
-          params.warn?.(`telegram stream preview cleanup failed: ${formatErrorMessage(err)}`);
-        }
-      };
       // Keep the preview on screen for at least MIN_PREVIEW_DWELL_MS from when it
-      // first appeared, then delete DETACHED (scheduled, not awaited) so teardown
-      // is never stalled waiting for the dwell.
-      const elapsedMs =
-        typeof visibleSince === "number" ? Date.now() - visibleSince : MIN_PREVIEW_DWELL_MS;
-      const remainingMs = Math.max(0, MIN_PREVIEW_DWELL_MS - elapsedMs);
-      if (remainingMs <= 0) {
-        void runDelete();
-      } else {
-        setTimeout(() => {
-          void runDelete();
-        }, remainingMs);
-      }
+      // first appeared, then delete.
+      scheduleDetachedDelete(messageId, visibleSince);
     }
+  };
+
+  // Reposition the window: rewind so the NEXT update creates a fresh message
+  // (below anything posted since), then delete the superseded one AFTER a short
+  // delay so the new message lands first. Post-new-then-delete-old — never
+  // delete-then-repost, which scroll-jumps the Telegram client (the on-off
+  // durable-🧠 jump). Returns the superseded message id (for tests).
+  const REPOSITION_DELETE_DELAY_MS = 1_500;
+  const rotateToNewMessageDeferringDelete = (): number | undefined => {
+    const supersededMessageId = streamMessageId;
+    const supersededVisibleSince = streamVisibleSinceMs;
+    // Rewind WITHOUT deleting; the old id is captured above.
+    resetStreamToNewMessage();
+    if (typeof supersededMessageId === "number" && Number.isFinite(supersededMessageId)) {
+      scheduleDetachedDelete(supersededMessageId, supersededVisibleSince, REPOSITION_DELETE_DELAY_MS);
+      return supersededMessageId;
+    }
+    return undefined;
   };
 
   const discard = async () => {
@@ -646,6 +684,7 @@ export function createTelegramDraftStream(params: {
     materialize,
     finalizeToPreview,
     forceNewMessage,
+    rotateToNewMessageDeferringDelete,
     sendMayHaveLanded: () => messageSendAttempted && typeof streamMessageId !== "number",
   };
 }

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -597,13 +597,27 @@ export function createTelegramDraftStream(params: {
   const finalizeToPreview = async (
     preview: TelegramDraftPreview,
   ): Promise<number | undefined> => {
+    const text = preview.text.trimEnd();
+    if (!text) {
+      return undefined;
+    }
     // Settle pending updates so we edit the real, current window message.
     streamState.final = true;
     await loop.flush();
-    const text = preview.text.trimEnd();
-    // No live window message to edit (never rendered, or already torn down):
-    // nothing to collapse in place — caller falls back to a fresh bar post.
-    if (typeof streamMessageId !== "number" || !text) {
+    // A throttled preview can still be pending (the last tool-progress line was
+    // coalesced and never sent), leaving no message id even though the window
+    // "rendered". Materialize it as a final flush would, so the window message
+    // exists and can be edited in place — otherwise on-off collapses missed it
+    // and fell back to a delete + repost.
+    if (typeof streamMessageId !== "number" && !streamState.stopped) {
+      const pending = lastRequestedText.trimEnd();
+      if (pending && pending !== lastDeliveredText.trimEnd()) {
+        await sendOrEditStreamMessage(pending);
+      }
+    }
+    // Genuinely no live window message (rv mode never rendered): caller posts a
+    // fresh durable bar instead — but it must NOT delete anything.
+    if (typeof streamMessageId !== "number") {
       return undefined;
     }
     // Replace the whole message with the bar line: edits diff from a zero

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -37,6 +37,13 @@ const MAX_CONSECUTIVE_PREVIEW_FAILURES = 3;
 // Flood waits beyond this freeze the preview longer than it is useful; clamp so
 // a large retry_after cannot park the suspension past the run's lifetime.
 const MAX_PREVIEW_FLOOD_SUSPEND_MS = 60_000;
+// Minimum time the streaming preview ("gerund" box) stays on screen before it
+// is deleted at teardown, measured from when it first became visible. On fast
+// turns the box otherwise flashed and vanished before it could be read, and the
+// immediate delete could race a just-persisted message (intermittently dropping
+// the first verbose commentary). The delete is scheduled DETACHED so the turn is
+// never stalled waiting on the dwell.
+const MIN_PREVIEW_DWELL_MS = 4_000;
 
 export type TelegramDraftStream = {
   update: (text: string) => void;
@@ -533,6 +540,8 @@ export function createTelegramDraftStream(params: {
   };
 
   const clear = async () => {
+    // Capture before the stop; takeMessageIdAfterStop resets streamVisibleSinceMs.
+    const visibleSince = streamVisibleSinceMs;
     const messageId = await takeMessageIdAfterStop({
       stopForClear,
       readMessageId: () => streamMessageId,
@@ -541,11 +550,26 @@ export function createTelegramDraftStream(params: {
       },
     });
     if (typeof messageId === "number" && Number.isFinite(messageId)) {
-      try {
-        await params.api.deleteMessage(chatId, messageId);
-        params.log?.(`telegram stream preview deleted (chat=${chatId}, message=${messageId})`);
-      } catch (err) {
-        params.warn?.(`telegram stream preview cleanup failed: ${formatErrorMessage(err)}`);
+      const runDelete = async () => {
+        try {
+          await params.api.deleteMessage(chatId, messageId);
+          params.log?.(`telegram stream preview deleted (chat=${chatId}, message=${messageId})`);
+        } catch (err) {
+          params.warn?.(`telegram stream preview cleanup failed: ${formatErrorMessage(err)}`);
+        }
+      };
+      // Keep the preview on screen for at least MIN_PREVIEW_DWELL_MS from when it
+      // first appeared, then delete DETACHED (scheduled, not awaited) so teardown
+      // is never stalled waiting for the dwell.
+      const elapsedMs =
+        typeof visibleSince === "number" ? Date.now() - visibleSince : MIN_PREVIEW_DWELL_MS;
+      const remainingMs = Math.max(0, MIN_PREVIEW_DWELL_MS - elapsedMs);
+      if (remainingMs <= 0) {
+        void runDelete();
+      } else {
+        setTimeout(() => {
+          void runDelete();
+        }, remainingMs);
       }
     }
   };

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -256,6 +256,11 @@ export function createTelegramDraftStream(params: {
   let previewRevision = 0;
   let generation = 0;
   let deliveredTextOffset = 0;
+  // Generations whose in-flight FIRST send was superseded by a reposition
+  // (rotateToNewMessageDeferringDelete). Their late-landing message is a stale
+  // ephemeral preview to delete, NOT a durable content chunk to retain — that
+  // distinguishes a reposition from forceNewMessage's continuation-chunk race.
+  const repositionedSendGenerations = new Set<number>();
   type PreviewSendParams = {
     preview: TelegramDraftPreview;
     sendGeneration: number;
@@ -336,6 +341,13 @@ export function createTelegramDraftStream(params: {
     const normalizedMessageId = Math.trunc(sentMessageId);
     const visibleSinceMs = Date.now();
     if (sendGeneration !== generation) {
+      if (repositionedSendGenerations.delete(sendGeneration)) {
+        // A reposition rotated past this send while it was in flight: the landed
+        // message is a stale preview, so delete it deferred (same as the
+        // reposition's own old message) instead of leaking an orphaned bubble.
+        scheduleDetachedDelete(normalizedMessageId, visibleSinceMs, REPOSITION_DELETE_DELAY_MS);
+        return true;
+      }
       params.onSupersededPreview?.({
         messageId: normalizedMessageId,
         textSnapshot: preview.text,
@@ -610,6 +622,13 @@ export function createTelegramDraftStream(params: {
   const rotateToNewMessageDeferringDelete = (): number | undefined => {
     const supersededMessageId = streamMessageId;
     const supersededVisibleSince = streamVisibleSinceMs;
+    // A FIRST send may still be in flight (no id yet): mark its generation so the
+    // late-landing message is deleted as a reposition, not retained as a durable
+    // chunk (forceNewMessage's contract). resetStreamToNewMessage bumps
+    // generation, so capture the current one before rewinding.
+    if (messageSendAttempted && streamMessageId === undefined) {
+      repositionedSendGenerations.add(generation);
+    }
     // Rewind WITHOUT deleting; the old id is captured above.
     resetStreamToNewMessage();
     if (typeof supersededMessageId === "number" && Number.isFinite(supersededMessageId)) {
@@ -664,7 +683,13 @@ export function createTelegramDraftStream(params: {
     lastSentPreviewKey = "";
     lastRequestedText = text;
     lastRequestedPreview = { ...preview, text };
-    await sendOrEditStreamMessage(text);
+    // The edit can fail to apply (flood-wait 429 or a terminal error both return
+    // false). Report that as "not collapsed in place" so the caller falls back to
+    // posting a durable bar instead of assuming the tall window became the bar.
+    const edited = await sendOrEditStreamMessage(text);
+    if (!edited) {
+      return undefined;
+    }
     return streamMessageId;
   };
 

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -59,6 +59,13 @@ export type TelegramDraftStream = {
   discard?: () => Promise<void>;
   /** Return the current preview message id after pending updates settle. */
   materialize?: () => Promise<number | undefined>;
+  /**
+   * Collapse the preview in place: edit the existing window message so its
+   * content becomes `preview`, then stop without deleting. Used at end-of-turn
+   * so the streaming window becomes the summary bar (no delete + repost, which
+   * scroll-jumps the client). Returns the message id if the edit landed.
+   */
+  finalizeToPreview: (preview: TelegramDraftPreview) => Promise<number | undefined>;
   /** Reset internal state so the next update creates a new message instead of editing. */
   forceNewMessage: () => void;
   /** True when a preview sendMessage was attempted but the response was lost. */
@@ -587,6 +594,28 @@ export function createTelegramDraftStream(params: {
     return streamMessageId;
   };
 
+  const finalizeToPreview = async (
+    preview: TelegramDraftPreview,
+  ): Promise<number | undefined> => {
+    // Settle pending updates so we edit the real, current window message.
+    streamState.final = true;
+    await loop.flush();
+    const text = preview.text.trimEnd();
+    // No live window message to edit (never rendered, or already torn down):
+    // nothing to collapse in place — caller falls back to a fresh bar post.
+    if (typeof streamMessageId !== "number" || !text) {
+      return undefined;
+    }
+    // Replace the whole message with the bar line: edits diff from a zero
+    // offset, not from the streamed prefix.
+    deliveredTextOffset = 0;
+    lastSentPreviewKey = "";
+    lastRequestedText = text;
+    lastRequestedPreview = { ...preview, text };
+    await sendOrEditStreamMessage(text);
+    return streamMessageId;
+  };
+
   params.log?.(`telegram stream preview ready (maxChars=${maxChars}, throttleMs=${throttleMs})`);
 
   return {
@@ -601,6 +630,7 @@ export function createTelegramDraftStream(params: {
     stop,
     discard,
     materialize,
+    finalizeToPreview,
     forceNewMessage,
     sendMayHaveLanded: () => messageSendAttempted && typeof streamMessageId !== "number",
   };

--- a/extensions/telegram/src/progress-summary.test.ts
+++ b/extensions/telegram/src/progress-summary.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import {
+  createTelegramProgressSummaryTracker,
+  formatTelegramProgressSummaryLine,
+} from "./progress-summary.js";
+
+describe("formatTelegramProgressSummaryLine", () => {
+  it("renders all three lanes plus elapsed, mirroring Discord content", () => {
+    expect(
+      formatTelegramProgressSummaryLine(
+        { reasoningSteps: 3, commentaryNotes: 2, toolCalls: 4 },
+        21_000,
+      ),
+    ).toBe("🧠 3 thoughts · 💬 2 notes · 🛠️ 4 tool calls · ⏱️ 21s");
+  });
+
+  it("uses singular nouns for a count of one", () => {
+    expect(
+      formatTelegramProgressSummaryLine(
+        { reasoningSteps: 1, commentaryNotes: 1, toolCalls: 1 },
+        1_000,
+      ),
+    ).toBe("🧠 1 thought · 💬 1 note · 🛠️ 1 tool call · ⏱️ 1s");
+  });
+
+  it("omits lanes with a zero count", () => {
+    expect(
+      formatTelegramProgressSummaryLine(
+        { reasoningSteps: 0, commentaryNotes: 0, toolCalls: 2 },
+        5_400,
+      ),
+    ).toBe("🛠️ 2 tool calls · ⏱️ 5s");
+  });
+
+  it("returns undefined when there is nothing to summarize (no degenerate elapsed-only line)", () => {
+    expect(
+      formatTelegramProgressSummaryLine(
+        { reasoningSteps: 0, commentaryNotes: 0, toolCalls: 0 },
+        9_000,
+      ),
+    ).toBeUndefined();
+  });
+
+  it("floors elapsed at 1 second", () => {
+    expect(
+      formatTelegramProgressSummaryLine({ reasoningSteps: 0, commentaryNotes: 0, toolCalls: 1 }, 0),
+    ).toBe("🛠️ 1 tool call · ⏱️ 1s");
+  });
+
+  it("rounds elapsed to the nearest second", () => {
+    expect(
+      formatTelegramProgressSummaryLine(
+        { reasoningSteps: 0, commentaryNotes: 0, toolCalls: 1 },
+        21_600,
+      ),
+    ).toBe("🛠️ 1 tool call · ⏱️ 22s");
+  });
+});
+
+describe("createTelegramProgressSummaryTracker", () => {
+  it("counts a window reasoning burst once when closed by a tool call", () => {
+    const t = createTelegramProgressSummaryTracker();
+    t.noteReasoningActivity();
+    t.noteReasoningActivity(); // same burst, deltas
+    t.noteToolCall();
+    expect(t.counts()).toEqual({ reasoningSteps: 1, commentaryNotes: 0, toolCalls: 1 });
+  });
+
+  it("counts a trailing open burst at the summary flush (counts())", () => {
+    const t = createTelegramProgressSummaryTracker();
+    t.noteReasoningActivity();
+    t.noteToolCall();
+    t.noteReasoningActivity(); // trailing burst, no end event
+    expect(t.counts()).toEqual({ reasoningSteps: 2, commentaryNotes: 0, toolCalls: 1 });
+  });
+
+  it("closes a burst on an explicit reasoning-end event", () => {
+    const t = createTelegramProgressSummaryTracker();
+    t.noteReasoningActivity();
+    t.closeReasoningBurst();
+    t.closeReasoningBurst(); // idempotent, no double count
+    expect(t.counts()).toEqual({ reasoningSteps: 1, commentaryNotes: 0, toolCalls: 0 });
+  });
+
+  it("keeps one burst open across re-fires of the same note id", () => {
+    const t = createTelegramProgressSummaryTracker();
+    t.noteCommentary("a", "first");
+    t.noteCommentary("a", "first (delta)");
+    t.noteCommentary("b", "second");
+    expect(t.counts()).toEqual({ reasoningSteps: 0, commentaryNotes: 2, toolCalls: 0 });
+  });
+
+  it("counts same-id commentary notes separated by tool boundaries as N, not 1 (D3)", () => {
+    const t = createTelegramProgressSummaryTracker();
+    // The anthropic core re-uses the turn-local id "commentary-0" for EVERY note
+    // in a turn; a tool follows each note, so each note's burst closes at its tool
+    // before the next opens. An id-Set dedup collapsed these to 1 — the D3 bug.
+    t.noteCommentary("commentary-0", "about to run date");
+    t.noteToolCall();
+    t.noteCommentary("commentary-0", "about to list files");
+    t.noteToolCall();
+    t.noteCommentary("commentary-0", "about to run uptime");
+    t.noteToolCall();
+    expect(t.counts()).toEqual({ reasoningSteps: 0, commentaryNotes: 3, toolCalls: 3 });
+  });
+
+  it("a tool call closes an open commentary burst (counts it once)", () => {
+    const t = createTelegramProgressSummaryTracker();
+    t.noteCommentary("commentary-0", "narration");
+    t.noteToolCall();
+    expect(t.counts()).toEqual({ reasoningSteps: 0, commentaryNotes: 1, toolCalls: 1 });
+  });
+
+  it("dedupes id-less commentary by repeated text but counts new text", () => {
+    const t = createTelegramProgressSummaryTracker();
+    t.noteCommentary(undefined, "note");
+    t.noteCommentary(undefined, "note");
+    t.noteCommentary(undefined, "another");
+    expect(t.counts()).toEqual({ reasoningSteps: 0, commentaryNotes: 2, toolCalls: 0 });
+  });
+
+  it("ignores empty/whitespace id-less commentary", () => {
+    const t = createTelegramProgressSummaryTracker();
+    t.noteCommentary(undefined, "   ");
+    t.noteCommentary();
+    expect(t.hasActivity()).toBe(false);
+    expect(t.counts()).toEqual({ reasoningSteps: 0, commentaryNotes: 0, toolCalls: 0 });
+  });
+
+  it("hasActivity reflects an open burst before it is counted", () => {
+    const t = createTelegramProgressSummaryTracker();
+    expect(t.hasActivity()).toBe(false);
+    t.noteReasoningActivity();
+    expect(t.hasActivity()).toBe(true);
+  });
+
+  it("produces a faithful end-to-end deepseek-style summary (2 bursts closed by tools + trailing)", () => {
+    const t = createTelegramProgressSummaryTracker();
+    // burst 1 → tool → burst 2 → tool → trailing burst flushed at summary
+    t.noteReasoningActivity();
+    t.noteToolCall();
+    t.noteReasoningActivity();
+    t.noteToolCall();
+    t.noteReasoningActivity();
+    const line = formatTelegramProgressSummaryLine(t.counts(), 21_000);
+    expect(line).toBe("🧠 3 thoughts · 🛠️ 2 tool calls · ⏱️ 21s");
+  });
+});

--- a/extensions/telegram/src/progress-summary.ts
+++ b/extensions/telegram/src/progress-summary.ts
@@ -1,0 +1,168 @@
+// Post-turn collapse summary for the Telegram progress window.
+//
+// Mirrors Discord's collapse-summary line (extensions/discord/src/monitor/
+// message-handler.process.ts `buildProgressSummaryLine`): when the ephemeral
+// progress draft collapses at end-of-turn, Discord posts a one-line activity
+// digest like `🧠 3 thoughts · 💬 2 notes · 🛠️ 4 tool calls · ⏱️ 21s`.
+//
+// Telegram had no equivalent (conformance discrepancy #4). This tracks the same
+// turn-activity counters channel-side (Discord also tallies these in its handler,
+// not in core) and formats the same content. The only divergence is the line
+// prefix: Discord wraps the line in its `-#` small-text syntax, which Telegram
+// markdown has no analog for, so the Telegram line is emitted plain.
+
+export type TelegramProgressSummaryCounters = {
+  reasoningSteps: number;
+  commentaryNotes: number;
+  toolCalls: number;
+};
+
+// Tracks turn activity for the collapse summary. The summary reflects ONLY what
+// actually streamed to the progress window — never durable-delivered items
+// (per the user's spec: "only summarize messages that ACTUALLY streamed").
+// So there is deliberately no durable-reasoning counter: in rv (/reasoning on)
+// thoughts persist as standalone messages and must NOT feed the bar, or the bar
+// would show even though nothing streamed to the window. A reasoning "burst" is
+// counted once at whichever boundary arrives first — the reasoning-end event,
+// the next tool call, or the summary flush — because some models (e.g. deepseek)
+// do not emit a reliable thinking_end per burst, so counting on the end event
+// alone undercounts.
+export type TelegramProgressSummaryTracker = {
+  /** A reasoning delta arrived; opens (or keeps open) the current burst. */
+  noteReasoningActivity(): void;
+  /** Reasoning-end fired; close and count the current burst if one is open. */
+  closeReasoningBurst(): void;
+  /**
+   * A window-rendered tool call started: it is the boundary for any open
+   * reasoning/commentary burst, so close+count those first, then count one tool.
+   * Callers count the tool only when it is suppressed (window-rendered); under
+   * verbose the tool persists durably and they close the bursts directly instead
+   * (closeReasoningBurst/closeCommentaryBurst) without calling this.
+   */
+  noteToolCall(): void;
+  /**
+   * A commentary/preamble note arrived for the window. Opens (or keeps open) a
+   * commentary burst — it is NOT counted here. The burst is counted once when it
+   * closes at the next boundary (tool start, reasoning-end, a different note, or
+   * the summary flush). Counting per-burst rather than per-id is deliberate: the
+   * anthropic core tags every note in a turn with the SAME turn-local id
+   * ("commentary-0"), so an id-Set dedup collapsed a multi-tool turn's notes to
+   * one (D3). A tool follows each note in a tool-using turn, closing its burst
+   * before the next note opens => N notes.
+   */
+  noteCommentary(itemId?: string, text?: string): void;
+  /** Close and count the current commentary burst if one is open. */
+  closeCommentaryBurst(): void;
+  /** Snapshot of the current counters (closes any open bursts into the tally). */
+  counts(): TelegramProgressSummaryCounters;
+  /** True when there is at least one thought, note, or tool call to summarize. */
+  hasActivity(): boolean;
+};
+
+export function createTelegramProgressSummaryTracker(): TelegramProgressSummaryTracker {
+  let reasoningSteps = 0;
+  let commentaryNotes = 0;
+  let toolCalls = 0;
+  let reasoningBurstOpen = false;
+  // One open commentary burst at a time (mirrors Discord's windowCommentaryOpen /
+  // closePendingWindowCommentary). A re-fire of the SAME note (same id, or prefix
+  // growth of the same id-less streamed text) keeps the burst open; a different
+  // note with no intervening boundary closes the previous burst before opening
+  // the new one.
+  let commentaryBurstOpen = false;
+  let openCommentaryItemId: string | undefined;
+  let openCommentaryText = "";
+
+  const closeReasoningBurst = () => {
+    if (reasoningBurstOpen) {
+      reasoningBurstOpen = false;
+      reasoningSteps += 1;
+    }
+  };
+
+  const closeCommentaryBurst = () => {
+    if (commentaryBurstOpen) {
+      commentaryBurstOpen = false;
+      openCommentaryItemId = undefined;
+      openCommentaryText = "";
+      commentaryNotes += 1;
+    }
+  };
+
+  return {
+    noteReasoningActivity() {
+      reasoningBurstOpen = true;
+    },
+    closeReasoningBurst,
+    noteToolCall() {
+      closeReasoningBurst();
+      closeCommentaryBurst();
+      toolCalls += 1;
+    },
+    noteCommentary(itemId?: string, text?: string) {
+      const trimmed = text?.trim();
+      if (!trimmed) {
+        return;
+      }
+      const id = itemId?.trim() || undefined;
+      if (commentaryBurstOpen) {
+        const sameNote = openCommentaryItemId
+          ? id === openCommentaryItemId
+          : !id &&
+            (trimmed === openCommentaryText ||
+              trimmed.startsWith(openCommentaryText) ||
+              openCommentaryText.startsWith(trimmed));
+        if (sameNote) {
+          openCommentaryText = trimmed;
+          return;
+        }
+        // A different note arrived with no intervening boundary: close the
+        // previous burst before opening the new one.
+        closeCommentaryBurst();
+      }
+      commentaryBurstOpen = true;
+      openCommentaryItemId = id;
+      openCommentaryText = trimmed;
+    },
+    closeCommentaryBurst,
+    counts() {
+      closeReasoningBurst();
+      closeCommentaryBurst();
+      return { reasoningSteps, commentaryNotes, toolCalls };
+    },
+    hasActivity() {
+      return (
+        reasoningBurstOpen ||
+        commentaryBurstOpen ||
+        reasoningSteps > 0 ||
+        commentaryNotes > 0 ||
+        toolCalls > 0
+      );
+    },
+  };
+}
+
+// Formats the collapse-summary line. Returns undefined when there is nothing to
+// summarize (no thoughts, notes, or tool calls) so a degenerate "⏱️ Ns"-only
+// line is never emitted. Content and ordering mirror Discord exactly.
+export function formatTelegramProgressSummaryLine(
+  counters: TelegramProgressSummaryCounters,
+  elapsedMs: number,
+): string | undefined {
+  const { reasoningSteps, commentaryNotes, toolCalls } = counters;
+  if (reasoningSteps <= 0 && commentaryNotes <= 0 && toolCalls <= 0) {
+    return undefined;
+  }
+  const seconds = Math.max(1, Math.round(elapsedMs / 1000));
+  const parts = [
+    ...(reasoningSteps > 0
+      ? [`🧠 ${reasoningSteps} thought${reasoningSteps === 1 ? "" : "s"}`]
+      : []),
+    ...(commentaryNotes > 0
+      ? [`💬 ${commentaryNotes} note${commentaryNotes === 1 ? "" : "s"}`]
+      : []),
+    ...(toolCalls > 0 ? [`🛠️ ${toolCalls} tool call${toolCalls === 1 ? "" : "s"}`] : []),
+    `⏱️ ${seconds}s`,
+  ];
+  return parts.join(" · ");
+}

--- a/extensions/telegram/src/reasoning-lane-coordinator.ts
+++ b/extensions/telegram/src/reasoning-lane-coordinator.ts
@@ -5,8 +5,23 @@ import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coer
 import { findCodeRegions, isInsideCode } from "openclaw/plugin-sdk/text-chunking";
 import { stripReasoningTagsFromText } from "openclaw/plugin-sdk/text-chunking";
 
-const REASONING_MESSAGE_RE = /^Thinking\.{0,3}\s*_/u;
+// A durable reasoning message already marked channel-side: 🧠 + italic body
+// (see markReasoningMessage). Detect it so a re-split passes it through
+// unchanged instead of re-marking.
+const REASONING_MESSAGE_RE = /^🧠\s+_/u;
+// Core's formatReasoningMessage prefixes the italic body with a literal
+// "Thinking" header. Telegram renders durable thoughts with the 🧠 marker
+// (Discord parity), so this header must be rewritten channel-side.
+const CORE_THINKING_HEADER_RE = /^Thinking\.{0,3}\s*\n+/u;
 const LEGACY_REASONING_MESSAGE_PREFIX = "Reasoning:\n";
+
+// Rewrite core's "Thinking\n\n_body_" into "🧠 _body_": strip the header word
+// and prefix the first italic line with 🧠. Keeps the italic body intact so
+// Telegram HTML renders it as before.
+function markReasoningMessage(formatted: string): string {
+  const withoutHeader = formatted.replace(CORE_THINKING_HEADER_RE, "");
+  return withoutHeader.replace(/^_/u, "🧠 _");
+}
 const REASONING_TAG_PREFIXES = [
   "<think",
   "<thinking",
@@ -84,6 +99,11 @@ export function splitTelegramReasoningText(
   if (REASONING_MESSAGE_RE.test(trimmed)) {
     return { reasoningText: trimmed };
   }
+  // Durable reasoning payloads arrive pre-formatted by core with the "Thinking"
+  // header; rewrite that to the 🧠 marker rather than passing it through.
+  if (CORE_THINKING_HEADER_RE.test(trimmed)) {
+    return { reasoningText: markReasoningMessage(trimmed) };
+  }
   if (
     trimmed.startsWith(LEGACY_REASONING_MESSAGE_PREFIX) &&
     trimmed.length > LEGACY_REASONING_MESSAGE_PREFIX.length
@@ -94,7 +114,11 @@ export function splitTelegramReasoningText(
   const taggedReasoning = extractThinkingFromTaggedStreamOutsideCode(text);
   const strippedAnswer = stripReasoningTagsFromText(text, { mode: "strict", trim: "both" });
 
-  return { reasoningText: formatReasoningMessage(taggedReasoning || strippedAnswer || text) };
+  return {
+    reasoningText: markReasoningMessage(
+      formatReasoningMessage(taggedReasoning || strippedAnswer || text),
+    ),
+  };
 }
 
 type BufferedFinalAnswer = {


### PR DESCRIPTION
## What Problem This Solves

On Telegram, the streamed progress window (the live "thinking" preview shown while a reply is generated) was broken in several visible ways compared to Discord:

1. **Reasoning and commentary were indistinguishable.** Both lanes rendered plain, with no `🧠`/`💬` markers — a user watching a streamed turn could not tell the model's *reasoning* from its *commentary*. Discord renders reasoning italic under `🧠` and commentary upright under `💬`.
2. **Model Markdown leaked or was stripped.** `**bold**`, backticks, and `_…_` in lane text either surfaced as literal characters or were silently flattened to plain text.
3. **`<br>` broke every multi-line preview at the transport.** Progress drafts join rendered lines with `<br>`, but Bot API `parse_mode=HTML` has no `<br>` tag. Telegram rejected every multi-line preview edit with *"can't parse entities"*, and the parse-error fallback silently downgraded the whole draft to unformatted plain text — so streamed progress formatting effectively **never rendered** on non-rich accounts.
4. **No collapse summary.** When the window tore down, it left nothing behind — the streamed activity vanished with no digest of what happened.
5. **Window churn / scroll-jump.** The window was deleted and reposted on lane handovers, and on `/reasoning on` it repositioned below the durable reasoning block, yanking the client's scroll position up by pages and sometimes posting the final answer off-screen.
6. **Interim answer blocks streamed into the window.** Partial answer content leaked into the progress preview (Discord suppresses this).

## Why This Change Was Made

Channel-side only (`extensions/telegram/**`); no core `src/**` changes. One focused commit per concern:

1. **Lane identity + rendering** — pass the `🧠`/`💬` lane prefixes and `commentaryItalics:false` to the shared progress-draft compositor (mirroring the Discord channel), and render lane bodies through `renderTelegramHtmlText` (the `parse_mode=HTML`-safe converter). Lane lines collapse to one line first (multi-line commentary otherwise forms block markdown — a `\n\n---\n\n` separator turns the paragraph above into a setext `<h2>`, which Telegram rejects). Long lines clip **inside** the whole-line `_…_` wrapper so truncation cannot chop the closing underscore and degrade italic to plain.
2. **Transport** — convert `<br>` joins to literal newlines in the `parse_mode=HTML` transport branch, matching what the rich-message branch already does.
3. **Preview lifetime** — keep the streaming preview on screen ≥4s from first appearance before a teardown delete, scheduled detached (never awaited) so turn teardown is not stalled.
4. **Collapse summary bar** — on teardown, collapse the window **in place** (edit, not delete) into a one-line activity digest: `🧠 N thoughts · 💬 N notes · 🛠️ N tool calls · ⏱️ Ns`. Counts reflect **only streamed** content (durable `/verbose on` messages own their own delivery and are excluded — persistent-message XOR window-count invariant).
5. **Single stationary window** — one Telegram message per turn, edited through every lane handover; zero happy-path deletes. The final answer is delivered **before** the bar edit so the window never repositions below durable content (kills the scroll-jump). Rare repositions post-new-then-delete-old (deferred delete) instead of delete-then-repost.
6. **Interim answer-block suppression** — suppress partial answer blocks from the progress window (Discord parity).

Non-goals: final-answer rendering and the durable (`/verbose on`) lanes are untouched — this is only the streamed progress window.

## User Impact

Telegram users watching a streamed reply now see a formatted, stable progress window: reasoning (`🧠`, *italic*) clearly distinct from commentary (`💬`, plain), the model's Markdown rendered (bold step names, monospace commands) instead of leaking or being stripped, a stationary box that no longer deletes/reposts or jumps the scroll, and a persistent one-line activity digest left behind on collapse. Biggest improvement for deepseek, which narrates progress almost entirely through its markdown-heavy reasoning lane.

## Maintainer-ready classification

- **Fix classification:** channel-local bug fix + small feature (collapse bar). Bounded to `extensions/telegram/**`; no core, no plugin-SDK, no config/default surface added, no new env var.
- **Root cause:** the Telegram progress path never passed the compositor's per-channel lane markers, hand-escaped lane bodies instead of using the `parse_mode`-safe renderer, and emitted `<br>` into a `parse_mode=HTML` transport that has no such tag. The scroll-jump was a window-lifecycle defect (delete-then-repost across lane handovers).
- **Architecture / source-of-truth check:** lane semantics come from the shared `createChannelProgressDraftCompositor` (`src/channels/progress-draft-compositor.ts`) — the same source Discord consumes; this change makes Telegram a consumer of that contract rather than diverging. The tool-count gate reuses the compositor's own public predicate `isChannelProgressDraftWorkToolName` (via `openclaw/plugin-sdk/channel-outbound`), so the bar's `🛠️` tally cannot drift from what the compositor actually renders.
- **Sibling-surface check:** Discord is the mirror. Its summary bar (`deliverDiscordReply` → `sendDurableMessageBatch`) has **no transcript-mirror seam**, so the Telegram bar was hardened to match (see F1 below) — the invariant now holds identically on both channels.
- **Patch quality:** `git diff --numstat` net prod LOC is small and localized; new files are `progress-summary.ts` (tracker + formatter) and its test. No new fallback readers, no config compat.
- **Related-PR scan:** rebased onto current `main` (post-2026.7.1) including `b07fd6f1b4 fix(telegram): keep group history always on`; the only overlap was an import block (dropped the now-deleted `group-history-context` import, kept upstream's `selectTelegramGroupHistoryAfterLastSelf`). No open PR touches the progress-window path.

## Real behavior proof (required for external PRs)

- **Behavior addressed:** streamed progress-window lane rendering, `<br>` transport, collapse summary bar, stationary-window (no scroll-jump), interim-answer suppression.
- **Real environment tested:** dev gateway built from this exact branch head, Telegram Desktop, fresh session per turn (`/new`).
- **Exact steps:** `/reasoning stream` + markdown-heavy prompt for the lane render; `/reasoning on` + `/verbose off` for the collapse-bar + stationary-window turn.
- **Evidence (runtime capture):**

  **Summary bar + lane gating** (`/reasoning on`, `/verbose off`, gpt-5.5) — a single frame shows the collapse bar `💬 2 notes · 🛠️ 2 tool calls · ⏱️ 61s`, the durable 🧠 reasoning block rendered italic with bold/monospace preserved, and the correct gating: durable (`/reasoning on`) reasoning renders in full but is **not** counted in the bar, while streamed notes/tool calls **are** — matching the persistent-message XOR window-count invariant.

  ![summary bar + lane gating](https://raw.githubusercontent.com/Marvinthebored/openclaw/proof-assets-telegram-progress-lanes/telegram-streamed-progress-lanes/pr-proof-6-summary-bar-collapse.png)

  **Lane rendering close-ups** (`/reasoning stream`, markdown-heavy prompt) — reasoning `🧠` italic with `**bold**` rendered bold-italic and backtick commands monospace, all inside the italic wrapper; commentary `💬` upright with bold step names and monospace commands (visual contrast with the italic reasoning):

  [🧠 reasoning zoom](https://raw.githubusercontent.com/Marvinthebored/openclaw/proof-assets-telegram-progress-lanes/telegram-streamed-progress-lanes/pr-proof-2b-reasoning-zoom.png) · [💬 commentary zoom](https://raw.githubusercontent.com/Marvinthebored/openclaw/proof-assets-telegram-progress-lanes/telegram-streamed-progress-lanes/pr-proof-3b-commentary-zoom.png) · full-stage: [prompt](https://raw.githubusercontent.com/Marvinthebored/openclaw/proof-assets-telegram-progress-lanes/telegram-streamed-progress-lanes/pr-proof-1-prompt.png) · [🧠 reasoning](https://raw.githubusercontent.com/Marvinthebored/openclaw/proof-assets-telegram-progress-lanes/telegram-streamed-progress-lanes/pr-proof-2-reasoning-italic.png) · [💬 commentary](https://raw.githubusercontent.com/Marvinthebored/openclaw/proof-assets-telegram-progress-lanes/telegram-streamed-progress-lanes/pr-proof-3-commentary.png) · [💬 step 3](https://raw.githubusercontent.com/Marvinthebored/openclaw/proof-assets-telegram-progress-lanes/telegram-streamed-progress-lanes/pr-proof-4-commentary2.png)

- **Observed result:** `🧠` reasoning renders italic with bold/monospace preserved inside the wrapper; `💬` commentary renders upright; the window stays a single stationary message and collapses in place into `🧠 N thoughts · 💬 N notes · 🛠️ N tool calls · ⏱️ Ns`; the final answer arrives before the bar with no scroll-jump.
- **4s dwell / cleanup — terminal proof (this head):** the streaming preview is kept on screen for `MIN_PREVIEW_DWELL_MS = 4000` from first appearance before a *detached* cleanup delete (never before the dwell, never blocking teardown), asserted directly on the current head by `extensions/telegram/src/draft-stream.test.ts`:
  ```
  ✓ extensions/telegram/src/draft-stream.test.ts > createTelegramDraftStream >
    keeps the streaming preview on screen for the dwell window before deleting
  Test Files  1 passed (1)
  ```
  Complemented by CI's Mantis native Telegram Desktop before/after capture on this same head (`Overall: true`), which exercises the live preview → cleanup flow.
- **What was not tested:** streamed reasoning-lane italics were exercised on a reasoning-bearing provider in an earlier build and by unit tests; the latest sanity turn used a model that emitted empty reasoning, so its *streamed-🧠 italic* frame is covered by the unit suite + the earlier live capture rather than the final sanity capture. Group DM / forum-topic progress windows were not separately re-captured (unaffected by this change).
- **Proof limitations:** captures are from a dev gateway on a developer Telegram account (names/emails redacted), not a production deployment.

## Red-team hardening (this branch)

An adversarial pass produced 5 findings, all fixed in `fix(telegram): red-team hardening for the progress collapse bar`:

- **F1 (HIGH) — transcript pollution.** The bar was mirrored into the model's session transcript (`durable:true` → `transcriptMirror`), so the model could read its own cosmetic activity digest back as a prior turn. Discord's bar has no such seam. Fix: `mirrorTranscript:false` on the two bar sends; real finals keep mirroring.
- **F4 — tool overcount.** The bar's `🛠️` counter incremented on non-work tools (`message`/`reply`/etc.) before the compositor's work-tool gate. Fix: gate the count with `isChannelProgressDraftWorkToolName` + `toolProgress` so the tally matches what the window renders.
- **F2 — silent collapse drop.** `finalizeToPreview` ignored a failed edit (flood-wait 429). Fix: return `undefined` so the caller falls back to a durable bar post.
- **F3 — unguarded cosmetic send.** A throw in the cleanup-fallback bar send could fail the turn. Fix: try/catch + `logVerbose`.
- **F5 (LOW) — ghost-preview race.** A first send racing a reposition could orphan a bubble. Fix: `repositionedSendGenerations` guard deletes the late-landing send deferred.

Follow-up (ClawSweeper review finding): F3 originally guarded only the *cleanup* fallback bar send. The *normal* path (`applyProgressCollapseSummary`) awaited an unguarded durable send when `finalizeToPreview` could not edit in place, and `sendPayload` throws on delivery failure — so a cosmetic bar flood-wait could fail an otherwise-complete turn (`merge-risk: message-delivery`). Both cosmetic-bar sends now route through one shared guarded helper `postCosmeticSummaryBar` (swallow + `logVerbose`); added the regression for the no-live-message fallback send throwing while the final answer still delivers.

## Tests and validation

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-telegram.config.ts extensions/telegram/src/{bot-message-dispatch,draft-stream,progress-summary}.test.ts` → **239 passed** (3 files). New coverage: lane markdown rendering in both lanes, clipped-long-reasoning stays italic, multi-line commentary stays `parse_mode`-safe (the setext-`<h2>` trap), `<br>`→newline transport, ≥4s dwell timing, collapse-bar counts/format, stationary-window reposition + deferred-delete, one test per red-team finding (F1 mirror-absent, F4 counts, F2 failed-edit fallback, F3 throw-swallow, F5 reposition-race), and both cosmetic-bar fallback sends throwing without failing the turn (cleanup + no-live-message paths).
- Rebased clean onto current `main` (post-2026.7.1); telegram suites green on the rebased head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
