### PR TITLE
refactor(agents): fold assistant string normalization into transcript ingest

### DIFF
--- a/src/agents/cli-runner/session-history.test.ts
+++ b/src/agents/cli-runner/session-history.test.ts
@@ -75,11 +75,11 @@ function requireRecord(value: unknown, label: string): Record<string, unknown> {
   return value as Record<string, unknown>;
 }
 
-function expectMessageFields(value: unknown, expected: { role: string; content?: string }) {
+function expectMessageFields(value: unknown, expected: { role: string; content?: unknown }) {
   const message = requireRecord(value, "message");
   expect(message.role).toBe(expected.role);
   if ("content" in expected) {
-    expect(message.content).toBe(expected.content);
+    expect(message.content).toEqual(expected.content);
   }
 }
 
@@ -256,7 +256,10 @@ describe("loadCliSessionHistoryMessages", () => {
         });
         expect(history).toHaveLength(2);
         expectMessageFields(history[0], { role: "user", content: "active root" });
-        expectMessageFields(history[1], { role: "assistant", content: "active tail" });
+        expectMessageFields(history[1], {
+          role: "assistant",
+          content: [{ type: "text", text: "active tail" }],
+        });
       });
     } finally {
       fs.rmSync(stateDir, { recursive: true, force: true });
@@ -369,7 +372,10 @@ describe("loadCliSessionHistoryMessages", () => {
           content: "tail custom context",
         });
         expectBranchSummary(history[2], "tail branch context");
-        expectMessageFields(history[3], { role: "assistant", content: "tail answer" });
+        expectMessageFields(history[3], {
+          role: "assistant",
+          content: [{ type: "text", text: "tail answer" }],
+        });
       });
     } finally {
       fs.rmSync(stateDir, { recursive: true, force: true });

--- a/src/agents/embedded-agent-runner/transcript-file-state.test.ts
+++ b/src/agents/embedded-agent-runner/transcript-file-state.test.ts
@@ -192,7 +192,7 @@ describe("readTranscriptFileState", () => {
     expect(state.getEntries().map((entry) => entry.id)).toEqual(["user-1", "assistant-string"]);
     expect(state.buildSessionContext().messages).toMatchObject([
       { role: "user", content: "prompt" },
-      { role: "assistant", content: "legacy reply" },
+      { role: "assistant", content: [{ type: "text", text: "legacy reply" }] },
     ]);
   });
 
@@ -1185,7 +1185,7 @@ describe("readTranscriptFileState", () => {
 
     expect(state.buildSessionContext().messages).toMatchObject([
       { role: "user", content: "rewritten question" },
-      { role: "assistant", content: "answer" },
+      { role: "assistant", content: [{ type: "text", text: "answer" }] },
     ]);
   });
 

--- a/src/agents/sessions/session-manager.test.ts
+++ b/src/agents/sessions/session-manager.test.ts
@@ -58,6 +58,10 @@ describe("SessionManager.open", () => {
       timestamp: "2026-05-27T00:00:02.000Z",
       message: { role: "assistant", content: "important answer" },
     };
+    const normalizedAssistantEntry = {
+      ...assistantEntry,
+      message: { role: "assistant", content: [{ type: "text", text: "important answer" }] },
+    };
     const originalTranscript =
       [
         JSON.stringify(originalHeader).slice(0, 30),
@@ -71,8 +75,8 @@ describe("SessionManager.open", () => {
 
     const sessionManager = SessionManager.open(sessionFile, dir, "/tmp/task-repo");
 
-    expect(sessionManager.getEntries()).toEqual([userEntry, assistantEntry]);
-    expect(sessionManager.getChildren(userEntry.id)).toEqual([assistantEntry]);
+    expect(sessionManager.getEntries()).toEqual([userEntry, normalizedAssistantEntry]);
+    expect(sessionManager.getChildren(userEntry.id)).toEqual([normalizedAssistantEntry]);
     expect(await fs.readFile(sessionFile, "utf8")).toContain("important question");
     expect(await fs.readFile(sessionFile, "utf8")).toContain("important answer");
     await expect(fs.readFile(sessionFile, "utf8")).resolves.not.toBe(originalTranscript);
@@ -1432,6 +1436,10 @@ describe("SessionManager.open", () => {
       timestamp: "2026-06-04T00:00:01.000Z",
       message: { role: "assistant", content: "carried context" },
     };
+    const normalizedAssistantEntry = {
+      ...assistantEntry,
+      message: { role: "assistant", content: [{ type: "text", text: "carried context" }] },
+    };
     await fs.writeFile(
       sessionFile,
       [
@@ -1456,7 +1464,7 @@ describe("SessionManager.open", () => {
       .split("\n")
       .map((line) => JSON.parse(line) as unknown);
     expect(records).toContainEqual(metadata);
-    expect(sessionManager.getEntries()).toEqual([assistantEntry]);
+    expect(sessionManager.getEntries()).toEqual([normalizedAssistantEntry]);
   });
 
   it("bridges parent-linked opaque rows without exposing them as session entries", async () => {

--- a/src/agents/sessions/session-manager.tool-result-replay.test.ts
+++ b/src/agents/sessions/session-manager.tool-result-replay.test.ts
@@ -98,6 +98,52 @@ async function writeSessionWithToolResultContent(
   await fs.writeFile(sessionFile, `${entries.map((entry) => JSON.stringify(entry)).join("\n")}\n`);
 }
 
+async function writeSessionWithAssistantContent(
+  sessionFile: string,
+  content: unknown,
+): Promise<void> {
+  const entries = [
+    {
+      type: "session",
+      version: 3,
+      id: "string-assistant-session",
+      timestamp: "2026-07-01T00:00:00.000Z",
+      cwd: "/tmp/tool-result-replay",
+    },
+    {
+      type: "message",
+      id: "user-1",
+      parentId: null,
+      timestamp: "2026-07-01T00:00:01.000Z",
+      message: { role: "user", content: "say hello", timestamp: 1 },
+    },
+    {
+      type: "message",
+      id: "assistant-1",
+      parentId: "user-1",
+      timestamp: "2026-07-01T00:00:02.000Z",
+      message: {
+        role: "assistant",
+        provider: "anthropic",
+        api: "anthropic-messages",
+        model: "claude-sonnet-4-6",
+        stopReason: "stop",
+        timestamp: 2,
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+        content,
+      },
+    },
+  ];
+  await fs.writeFile(sessionFile, `${entries.map((entry) => JSON.stringify(entry)).join("\n")}\n`);
+}
+
 describe("SessionManager tool-result replay", () => {
   afterEach(async () => {
     await Promise.all(
@@ -118,6 +164,43 @@ describe("SessionManager tool-result replay", () => {
     }
 
     expect(toolResult.content).toEqual([{ type: "text", text: "lookup result text" }]);
+  });
+
+  it("replays string assistant JSONL content as Anthropic assistant text", async () => {
+    const dir = await makeTempDir();
+    const sessionFile = path.join(dir, "session.jsonl");
+    await writeSessionWithAssistantContent(sessionFile, "assistant replay text");
+    const context = SessionManager.open(
+      sessionFile,
+      dir,
+      "/tmp/tool-result-replay",
+    ).buildSessionContext();
+    const assistant = context.messages.find((message) => message.role === "assistant");
+    if (!assistant || assistant.role !== "assistant") {
+      throw new Error("assistant message missing");
+    }
+    expect(assistant.content).toEqual([{ type: "text", text: "assistant replay text" }]);
+
+    let capturedPayload: unknown;
+    const stream = streamAnthropic(makeAnthropicModel(), toLlmContext(context), {
+      apiKey: "sk-ant-provider",
+      onPayload: (payload) => {
+        capturedPayload = payload;
+        throw new Error("stop before network");
+      },
+    });
+
+    await stream.result();
+
+    const payload = capturedPayload as {
+      messages: Array<{
+        role: string;
+        content: string | Array<{ type?: unknown; text?: unknown }>;
+      }>;
+    };
+    const assistantPayload = payload.messages.find((message) => message.role === "assistant");
+
+    expect(assistantPayload?.content).toEqual([{ type: "text", text: "assistant replay text" }]);
   });
 
   it("replays string tool-result JSONL content as Anthropic tool text", async () => {

--- a/src/agents/sessions/session-manager.ts
+++ b/src/agents/sessions/session-manager.ts
@@ -960,15 +960,15 @@ function normalizeLoadedFileEntry(entry: FileEntry): FileEntry {
   // Persisted JSONL is untrusted: shapes may predate the current Message type,
   // so normalize through a record view instead of the declared union.
   const message: Record<string, unknown> = entry.message;
-  if (message.role !== "toolResult") {
-    return entry;
-  }
-  // Replayed JSONL can carry string or single-record tool results while
-  // downstream providers require block arrays. Without this, strings replay as
-  // empty output and records hit non-array replay assumptions.
-  if (typeof message.content === "string") {
+  // Replayed JSONL can carry legacy string assistant/toolResult content while
+  // downstream providers require block arrays. Single-record tool results need
+  // the same ingress repair before replay reaches provider conversion.
+  if (
+    (message.role === "assistant" || message.role === "toolResult") &&
+    typeof message.content === "string"
+  ) {
     message.content = [{ type: "text", text: message.content }];
-  } else if (isJsonRecord(message.content)) {
+  } else if (message.role === "toolResult" && isJsonRecord(message.content)) {
     message.content = [message.content];
   }
   return entry;

--- a/src/auto-reply/reply/session-fork.runtime.test.ts
+++ b/src/auto-reply/reply/session-fork.runtime.test.ts
@@ -439,7 +439,7 @@ describe("forkSessionFromParentRuntime", () => {
     expect(records.at(-1)).toMatchObject({ type: "message", parentId: "plugin-metadata" });
     expect(records.at(-1)).not.toHaveProperty("appendMode");
     expect(reopened.buildSessionContext().messages).toMatchObject([
-      { role: "assistant", content: "active root" },
+      { role: "assistant", content: [{ type: "text", text: "active root" }] },
       { role: "user", content: "continued" },
     ]);
   });

--- a/src/gateway/session-compaction-checkpoints.test.ts
+++ b/src/gateway/session-compaction-checkpoints.test.ts
@@ -789,7 +789,7 @@ describe("session-compaction-checkpoints", () => {
     const messages = SessionManager.open(forked.sessionFile, dir).buildSessionContext().messages;
     expect(messages.map((message) => (message as { content?: unknown }).content)).toEqual([
       "legacy first",
-      "legacy second",
+      [{ type: "text", text: "legacy second" }],
     ]);
   });
 

--- a/src/gateway/session-utils.fs.test.ts
+++ b/src/gateway/session-utils.fs.test.ts
@@ -1788,7 +1788,7 @@ describe("readSessionMessages", () => {
       })),
     ).toEqual([
       { role: "user", text: "hello" },
-      { role: "assistant", text: "hi" },
+      { role: "assistant", text: [{ type: "text", text: "hi" }] },
       { role: "user", text: [{ type: "text", text: "Blocked by HITL test hook." }] },
     ]);
     expect(JSON.stringify(out)).not.toContain("[hitl:block] hello");

--- a/src/llm/providers/transform-messages.ts
+++ b/src/llm/providers/transform-messages.ts
@@ -117,13 +117,13 @@ export function transformMessages<TApi extends Api>(
           assistantMsg.api === model.api &&
           assistantMsg.model === model.id);
 
-      // Assistant content is typed as a block array, but transcript replay can
-      // hand us a raw string (JSONL passthrough). Normalize it to an equivalent
-      // single text block before transforming, matching the string->text block
-      // handling already used in anthropic-payload-policy.ts.
-      const contentBlocks = Array.isArray(assistantMsg.content)
-        ? assistantMsg.content
-        : [{ type: "text" as const, text: assistantMsg.content as unknown as string }];
+      // Public plugin-sdk/llm exports transformMessages; keep accepting legacy
+      // assistant strings from external provider adapters even though session
+      // JSONL replay normalizes them at ingest.
+      const contentBlocks =
+        typeof assistantMsg.content === "string"
+          ? [{ type: "text" as const, text: assistantMsg.content }]
+          : assistantMsg.content;
 
       const transformedContent = contentBlocks.flatMap((block) => {
         if (block.type === "thinking") {


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #98891. `src/llm/providers/transform-messages.ts` carried a second, older copy of the "JSONL replay can hand us a raw string" normalization for assistant content — a special case at provider-conversion altitude, duplicating what the session-ingest boundary now owns. Worse, transport streams (`anthropic-transport-stream`, `openai-transport-stream`, google/xai extensions) never call `transformMessages`, so a replayed assistant message with string content was still mis-shaped on those paths — the same latent bug class #98891 fixed for tool results.

## Why This Change Was Made

- `normalizeLoadedFileEntry` (the #98891 ingest boundary in `src/agents/sessions/session-manager.ts`) now also normalizes **assistant** string content to `[{ type: "text", text }]` at JSONL parse time, covering providers and transport streams alike. User messages are untouched — `UserMessage.content` is legitimately `string | blocks[]` by type.
- The `transformMessages` string branch is **kept, not deleted**: it is a shipped plugin-SDK surface (`src/plugin-sdk/llm.ts` exports `transformMessages`, published as `./plugin-sdk/llm`), so external provider adapters may legally pass string assistant content. Its comment now names that contract instead of the stale JSONL-replay claim, and the old `as unknown as string` double-cast is gone in favor of real narrowing.
- `anthropic-payload-policy.ts` string handling was inspected and deliberately left alone: it normalizes outbound Anthropic wire payloads (where string content is valid API shape) for the transport stream, cache-control wrappers, and `plugin-sdk/provider-stream-shared` — a wire-format contract, not replay defense.

Coverage map verified before deciding: all six `transformMessages` callers (anthropic, openai-completions, openai-responses-shared, google-shared, mistral, amazon-bedrock), live-runner assistant construction (always block arrays), the normalized JSONL replay path, and CLI/foreign transcript readers.

## User Impact

- Replayed sessions with legacy string assistant content now reach every provider and transport path in canonical block-array shape; no behavior change for well-formed sessions.
- No API, config, or plugin-SDK surface changes; prod LOC net-neutral (8+/8−, 7+/7−).

## Evidence

- New ingest + replay regression coverage for assistant string content in `src/agents/sessions/session-manager.tool-result-replay.test.ts`; existing raw-entry assertions updated to the canonical normalized shape (disk bytes still asserted unchanged).
- `node scripts/run-vitest.mjs src/agents/sessions/session-manager.tool-result-replay.test.ts src/agents/sessions/session-manager.test.ts` — 52 tests passing.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json` and `-p test/tsconfig/tsconfig.core.test.json` — both green.
- `node scripts/run-oxlint.mjs` on touched files — clean.
